### PR TITLE
fix(api): reuse hierarchical process rule when API upload uses mode=automatic

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -1993,12 +1993,30 @@ class DocumentService:
                             if not dataset_process_rule:
                                 raise ValueError("No process rule found.")
                     elif process_rule.mode == ProcessRuleMode.AUTOMATIC:
-                        dataset_process_rule = DatasetProcessRule(
-                            dataset_id=dataset.id,
-                            mode=process_rule.mode,
-                            rules=json.dumps(DatasetProcessRule.AUTOMATIC_RULES),
-                            created_by=account.id,
-                        )
+                        # For hierarchical (parent-child) datasets, AUTOMATIC_RULES does not
+                        # contain the required `parent_mode` field.  Blindly creating a new
+                        # DatasetProcessRule from AUTOMATIC_RULES would leave the document with
+                        # 0 segments because ParentChildIndexProcessor.transform() falls
+                        # through all branch checks when parent_mode is None.
+                        # Instead, reuse the dataset's existing process rule (which carries the
+                        # correct hierarchical configuration), falling back to AUTOMATIC_RULES
+                        # only for non-hierarchical doc forms.  See issue #35858.
+                        if knowledge_config.doc_form == IndexStructureType.PARENT_CHILD_INDEX:
+                            dataset_process_rule = dataset.latest_process_rule
+                            if not dataset_process_rule:
+                                raise ValueError(
+                                    "process_rule with mode='automatic' cannot be used for a "
+                                    "hierarchical (parent-child) dataset that has no existing "
+                                    "process rule. Provide a process_rule with "
+                                    "mode='hierarchical' and explicit rules instead."
+                                )
+                        else:
+                            dataset_process_rule = DatasetProcessRule(
+                                dataset_id=dataset.id,
+                                mode=process_rule.mode,
+                                rules=json.dumps(DatasetProcessRule.AUTOMATIC_RULES),
+                                created_by=account.id,
+                            )
                     else:
                         logger.warning(
                             "Invalid process rule mode: %s, can not find dataset process rule",

--- a/api/tests/unit_tests/services/test_dataset_service_document.py
+++ b/api/tests/unit_tests/services/test_dataset_service_document.py
@@ -1629,3 +1629,90 @@ class TestDocumentServiceSaveDocumentAdditionalBranches:
                     account_context,
                     dataset_process_rule=SimpleNamespace(id="rule-1"),
                 )
+
+    # -------------------------------------------------------------------------
+    # Regression tests for issue #35858:
+    # API upload with doc_form=hierarchical_model + process_rule mode=automatic
+    # must not produce 0 segments.
+    # -------------------------------------------------------------------------
+
+    def test_save_document_with_dataset_id_hierarchical_automatic_reuses_latest_process_rule(
+        self, account_context
+    ):
+        """Regression: automatic process rule on a hierarchical dataset must fall back to
+        the dataset's existing process rule, not create a rule with AUTOMATIC_RULES (which
+        lacks the required `parent_mode` field and causes 0 segments)."""
+        existing_process_rule = SimpleNamespace(id="rule-hierarchical")
+        dataset = _make_dataset(latest_process_rule=existing_process_rule)
+        created_document = _make_document(document_id="doc-created", name="file.txt")
+        knowledge_config = KnowledgeConfig(
+            indexing_technique="economy",
+            data_source=DataSource(
+                info_list=InfoList(
+                    data_source_type="upload_file",
+                    file_info_list=FileInfo(file_ids=["file-1"]),
+                )
+            ),
+            process_rule=ProcessRule(mode="automatic"),
+            doc_form=IndexStructureType.PARENT_CHILD_INDEX,
+            doc_language="English",
+        )
+
+        with (
+            patch("services.dataset_service.FeatureService.get_features", return_value=_make_features(enabled=False)),
+            patch("services.dataset_service.redis_client") as mock_redis,
+            patch("services.dataset_service.db") as mock_db,
+            patch("services.dataset_service.DatasetProcessRule") as process_rule_cls,
+            patch.object(DocumentService, "get_documents_position", return_value=1),
+            patch.object(DocumentService, "build_document", return_value=created_document),
+            patch("services.dataset_service.DocumentIndexingTaskProxy"),
+            patch("services.dataset_service.time.strftime", return_value="20260101010101"),
+            patch("services.dataset_service.secrets.randbelow", return_value=23),
+        ):
+            mock_redis.lock.return_value = _make_lock_context()
+            process_rule_cls.AUTOMATIC_RULES = DatasetProcessRule.AUTOMATIC_RULES
+            mock_db.session.scalars.return_value.all.side_effect = [
+                [SimpleNamespace(id="file-1", name="file.txt")],
+                [],
+            ]
+
+            documents, batch = DocumentService.save_document_with_dataset_id(
+                dataset, knowledge_config, account_context
+            )
+
+        assert documents == [created_document]
+        # The DatasetProcessRule constructor must NOT have been called with AUTOMATIC_RULES,
+        # because doing so would omit parent_mode and produce 0 segments.
+        for call in process_rule_cls.call_args_list:
+            called_rules = (call.kwargs or {}).get("rules") or (call.args[2] if len(call.args) > 2 else None)
+            if called_rules is not None:
+                import json as _json
+
+                parsed = _json.loads(called_rules) if isinstance(called_rules, str) else called_rules
+                assert "parent_mode" in parsed or parsed != DatasetProcessRule.AUTOMATIC_RULES, (
+                    "AUTOMATIC_RULES (without parent_mode) must not be used for hierarchical datasets"
+                )
+
+    def test_save_document_with_dataset_id_hierarchical_automatic_raises_when_no_existing_rule(
+        self, account_context
+    ):
+        """Regression: if no existing process rule exists for a hierarchical dataset and
+        the API request uses mode=automatic, raise a clear ValueError rather than silently
+        producing 0 segments with a broken AUTOMATIC_RULES rule."""
+        dataset = _make_dataset(latest_process_rule=None)
+        knowledge_config = KnowledgeConfig(
+            indexing_technique="economy",
+            data_source=DataSource(
+                info_list=InfoList(
+                    data_source_type="upload_file",
+                    file_info_list=FileInfo(file_ids=["file-1"]),
+                )
+            ),
+            process_rule=ProcessRule(mode="automatic"),
+            doc_form=IndexStructureType.PARENT_CHILD_INDEX,
+            doc_language="English",
+        )
+
+        with patch("services.dataset_service.FeatureService.get_features", return_value=_make_features(enabled=False)):
+            with pytest.raises(ValueError, match="hierarchical"):
+                DocumentService.save_document_with_dataset_id(dataset, knowledge_config, account_context)

--- a/api/tests/unit_tests/services/test_dataset_service_document.py
+++ b/api/tests/unit_tests/services/test_dataset_service_document.py
@@ -1636,9 +1636,7 @@ class TestDocumentServiceSaveDocumentAdditionalBranches:
     # must not produce 0 segments.
     # -------------------------------------------------------------------------
 
-    def test_save_document_with_dataset_id_hierarchical_automatic_reuses_latest_process_rule(
-        self, account_context
-    ):
+    def test_save_document_with_dataset_id_hierarchical_automatic_reuses_latest_process_rule(self, account_context):
         """Regression: automatic process rule on a hierarchical dataset must fall back to
         the dataset's existing process rule, not create a rule with AUTOMATIC_RULES (which
         lacks the required `parent_mode` field and causes 0 segments)."""
@@ -1676,9 +1674,7 @@ class TestDocumentServiceSaveDocumentAdditionalBranches:
                 [],
             ]
 
-            documents, batch = DocumentService.save_document_with_dataset_id(
-                dataset, knowledge_config, account_context
-            )
+            documents, batch = DocumentService.save_document_with_dataset_id(dataset, knowledge_config, account_context)
 
         assert documents == [created_document]
         # The DatasetProcessRule constructor must NOT have been called with AUTOMATIC_RULES,
@@ -1693,9 +1689,7 @@ class TestDocumentServiceSaveDocumentAdditionalBranches:
                     "AUTOMATIC_RULES (without parent_mode) must not be used for hierarchical datasets"
                 )
 
-    def test_save_document_with_dataset_id_hierarchical_automatic_raises_when_no_existing_rule(
-        self, account_context
-    ):
+    def test_save_document_with_dataset_id_hierarchical_automatic_raises_when_no_existing_rule(self, account_context):
         """Regression: if no existing process rule exists for a hierarchical dataset and
         the API request uses mode=automatic, raise a clear ValueError rather than silently
         producing 0 segments with a broken AUTOMATIC_RULES rule."""


### PR DESCRIPTION
Fixes #35858.

## Summary

- API document uploads to a **hierarchical (parent-child)** dataset with `process_rule: {mode: "automatic"}` produced `segment_count=0` even though indexing reported success.
- GUI uploads to the same dataset worked correctly.

## Root cause (code walkthrough)

**Entry point** — `DocumentAddByFileApi.post()` in `api/controllers/service_api/dataset/document.py` (line 452):

```python
dataset_process_rule = dataset.latest_process_rule if "process_rule" not in args else None
```

When the API caller supplies `process_rule`, `dataset_process_rule` is forced to `None`, so `save_document_with_dataset_id` creates a new rule from the payload.

**Bug branch** — `save_document_with_dataset_id()` in `api/services/dataset_service.py` (old lines 1995–2001):

```python
elif process_rule.mode == ProcessRuleMode.AUTOMATIC:
    dataset_process_rule = DatasetProcessRule(
        dataset_id=dataset.id,
        mode=process_rule.mode,
        rules=json.dumps(DatasetProcessRule.AUTOMATIC_RULES),  # ← no parent_mode
        created_by=account.id,
    )
```

`AUTOMATIC_RULES` contains only `pre_processing_rules` and `segmentation`. It has **no `parent_mode` field**.

**Downstream failure** — `ParentChildIndexProcessor.transform()` in `api/core/rag/index_processor/processor/parent_child_index_processor.py`:

```python
rules = Rule.model_validate(process_rule.get("rules"))
# rules.parent_mode is None

if rules.parent_mode == ParentMode.PARAGRAPH:   # False
    ...
elif rules.parent_mode == ParentMode.FULL_DOC:  # False
    ...
# Falls through → all_documents stays []
```

Zero segments are saved. The document reaches `completed` status with `segment_count=0`.

**GUI path** works because the GUI always sends `mode=hierarchical` with explicit rules containing `parent_mode`, so the first branch in `save_document_with_dataset_id` (lines 1983–1994) is taken and the correct rule is built.

## Fix

In the `AUTOMATIC` branch of `save_document_with_dataset_id`, detect when `doc_form` is `hierarchical_model` and fall back to `dataset.latest_process_rule` (which carries the correct hierarchical config) instead of constructing a new AUTOMATIC_RULES-based rule. Raise a clear `ValueError` if no existing rule is present.

```python
elif process_rule.mode == ProcessRuleMode.AUTOMATIC:
    if knowledge_config.doc_form == IndexStructureType.PARENT_CHILD_INDEX:
        dataset_process_rule = dataset.latest_process_rule
        if not dataset_process_rule:
            raise ValueError(
                "process_rule with mode='automatic' cannot be used for a "
                "hierarchical (parent-child) dataset that has no existing "
                "process rule. Provide a process_rule with "
                "mode='hierarchical' and explicit rules instead."
            )
    else:
        dataset_process_rule = DatasetProcessRule(
            dataset_id=dataset.id,
            mode=process_rule.mode,
            rules=json.dumps(DatasetProcessRule.AUTOMATIC_RULES),
            created_by=account.id,
        )
```

## Tests

Two regression unit tests added to `TestDocumentServiceSaveDocumentAdditionalBranches` in `api/tests/unit_tests/services/test_dataset_service_document.py`:

1. `test_save_document_with_dataset_id_hierarchical_automatic_reuses_latest_process_rule` — verifies the existing rule is reused (not AUTOMATIC_RULES).
2. `test_save_document_with_dataset_id_hierarchical_automatic_raises_when_no_existing_rule` — verifies a clear `ValueError` is raised when no existing rule exists.

Both pass:

```
PASSED tests/...::TestDocumentServiceSaveDocumentAdditionalBranches::test_save_document_with_dataset_id_hierarchical_automatic_reuses_latest_process_rule
PASSED tests/...::TestDocumentServiceSaveDocumentAdditionalBranches::test_save_document_with_dataset_id_hierarchical_automatic_raises_when_no_existing_rule
```

## Checklist

- [x] I've added a test for each change that was introduced.
- [x] I ran the relevant unit tests (`10 passed`).
- [ ] Documentation update required: No — this is a bug fix that restores parity with GUI behavior.

From Claude Code