### PR TITLE
fix(tools): scope builtin tool default-credential clear to tenant

### DIFF
--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -875,10 +875,10 @@ class ToolBuiltinProviderSetDefaultApi(Resource):
     @login_required
     @account_initialization_required
     def post(self, provider):
-        current_user, current_tenant_id = current_account_with_tenant()
+        _, current_tenant_id = current_account_with_tenant()
         payload = BuiltinProviderDefaultCredentialPayload.model_validate(console_ns.payload or {})
         return BuiltinToolManageService.set_default_provider(
-            tenant_id=current_tenant_id, user_id=current_user.id, provider=provider, id=payload.id
+            tenant_id=current_tenant_id, provider=provider, id=payload.id
         )
 
 

--- a/api/services/tools/builtin_tools_manage_service.py
+++ b/api/services/tools/builtin_tools_manage_service.py
@@ -416,9 +416,9 @@ class BuiltinToolManageService:
             if target_provider is None:
                 raise ValueError("provider not found")
 
-            # clear default provider
+            # clear default provider (tenant-scoped: only one default per provider per workspace)
             session.query(BuiltinToolProvider).filter_by(
-                tenant_id=tenant_id, user_id=user_id, provider=provider, is_default=True
+                tenant_id=tenant_id, provider=provider, is_default=True
             ).update({"is_default": False})
 
             # set new default provider

--- a/api/services/tools/builtin_tools_manage_service.py
+++ b/api/services/tools/builtin_tools_manage_service.py
@@ -406,7 +406,7 @@ class BuiltinToolManageService:
         return {"result": "success"}
 
     @staticmethod
-    def set_default_provider(tenant_id: str, user_id: str, provider: str, id: str):
+    def set_default_provider(tenant_id: str, provider: str, id: str):
         """
         set default provider
         """

--- a/api/tests/unit_tests/services/tools/test_builtin_tools_manage_service.py
+++ b/api/tests/unit_tests/services/tools/test_builtin_tools_manage_service.py
@@ -189,6 +189,27 @@ class TestSetDefaultProvider:
         assert target.is_default is True
         session.commit.assert_called_once()
 
+    @patch(f"{MODULE}.Session")
+    @patch(f"{MODULE}.db")
+    def test_clear_default_is_tenant_scoped_not_user_scoped(self, mock_db, mock_session_cls):
+        # Regression: clearing prior defaults must NOT filter by user_id, otherwise
+        # two workspace members can each leave their own credential as default at
+        # the same time (the default flag is tenant-scoped, not per-user).
+        session = _mock_session(mock_session_cls)
+        session.query.return_value.filter_by.return_value.first.return_value = MagicMock()
+
+        BuiltinToolManageService.set_default_provider("tenant-1", "user-A", "google", "cred-id")
+
+        clear_calls = [
+            call
+            for call in session.query.return_value.filter_by.call_args_list
+            if call.kwargs.get("is_default") is True
+        ]
+        assert len(clear_calls) == 1
+        assert "user_id" not in clear_calls[0].kwargs
+        assert clear_calls[0].kwargs["tenant_id"] == "tenant-1"
+        assert clear_calls[0].kwargs["provider"] == "google"
+
 
 class TestUpdateBuiltinToolProvider:
     @patch(f"{MODULE}.Session")

--- a/api/tests/unit_tests/services/tools/test_builtin_tools_manage_service.py
+++ b/api/tests/unit_tests/services/tools/test_builtin_tools_manage_service.py
@@ -174,7 +174,7 @@ class TestSetDefaultProvider:
         session.query.return_value.filter_by.return_value.first.return_value = None
 
         with pytest.raises(ValueError, match="provider not found"):
-            BuiltinToolManageService.set_default_provider("t", "u", "p", "id")
+            BuiltinToolManageService.set_default_provider("t", "p", "id")
 
     @patch(f"{MODULE}.Session")
     @patch(f"{MODULE}.db")
@@ -183,7 +183,7 @@ class TestSetDefaultProvider:
         target = MagicMock()
         session.query.return_value.filter_by.return_value.first.return_value = target
 
-        result = BuiltinToolManageService.set_default_provider("t", "u", "p", "id")
+        result = BuiltinToolManageService.set_default_provider("t", "p", "id")
 
         assert result == {"result": "success"}
         assert target.is_default is True
@@ -198,7 +198,7 @@ class TestSetDefaultProvider:
         session = _mock_session(mock_session_cls)
         session.query.return_value.filter_by.return_value.first.return_value = MagicMock()
 
-        BuiltinToolManageService.set_default_provider("tenant-1", "user-A", "google", "cred-id")
+        BuiltinToolManageService.set_default_provider("tenant-1", "google", "cred-id")
 
         clear_calls = [
             call


### PR DESCRIPTION
## Summary

Backport of equivalent fix on `main` (langgenius/dify#35887) to `lts/1.13.x`.

Fixes a bug where two workspace members each setting their own credential as default for the same builtin tool provider left **both** rows with `is_default=True` for the same `(tenant_id, provider)`. The `clear-default` UPDATE in `BuiltinToolManageService.set_default_provider` was filtered by `user_id`, so it only reset the caller's own defaults. The consumer is tenant-scoped, so multiple defaults produce user-visible inconsistencies.

Drops `user_id` from the `filter_by` call, matching the tenant-scoped semantics of `DatasourceProviderService.set_default_datasource_provider`.

## Test plan

- [x] Unit test added: `TestSetDefaultProvider::test_clear_default_is_tenant_scoped_not_user_scoped` — asserts the clear `filter_by` call uses `tenant_id`/`provider` but not `user_id`. Verified failing on pre-fix code, passing on fixed code.
- [x] Existing `TestSetDefaultProvider` tests still pass.
- [x] Already merged into `origin/deploy/enterprise` for dev validation.

## Notes

- Pre-existing TOCTOU race between concurrent transactions remains; a partial unique index `UNIQUE (tenant_id, provider) WHERE is_default` would close it — out of scope, flagging for follow-up.
- Pre-existing IDOR on `target_provider` lookup (`filter_by(id=id).first()` without `tenant_id` check) is intentionally NOT included here to keep the fix minimal. PR #34436 fixed it on `main`; backport candidate for a separate PR if desired.