### PR TITLE
fix: replace SimpleNamespace with MagicMock(spec=App) in _app_stub (#34636)

### DIFF
--- a/api/tests/test_containers_integration_tests/services/test_app_dsl_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_app_dsl_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 import json
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 

--- a/api/tests/test_containers_integration_tests/services/test_app_dsl_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_app_dsl_service.py
@@ -71,6 +71,7 @@ def _pending_yaml_content(version: str = "99.0.0") -> bytes:
 
 
 def _app_stub(**overrides: Any) -> App:
+    """Create a stub App object for testing without hitting the database."""
     defaults = {
         "id": str(uuid4()),
         "tenant_id": _DEFAULT_TENANT_ID,
@@ -83,7 +84,10 @@ def _app_stub(**overrides: Any) -> App:
         "use_icon_as_answer_icon": False,
         "app_model_config": None,
     }
-    return cast(App, SimpleNamespace(**(defaults | overrides)))
+    app = MagicMock(spec=App)
+    for key, value in (defaults | overrides).items():
+        object.__setattr__(app, key, value)
+    return app
 
 
 class TestAppDslService:


### PR DESCRIPTION
## Summary

Replaces `cast(App, SimpleNamespace(...))` with `MagicMock(spec=App)` in the `_app_stub` helper function to resolve Pyright type-checking errors.

Fixes #34636 (partial - addressing `_app_stub` root cause)

## Problem

The test helper `_app_stub()` uses `SimpleNamespace` to create lightweight App stand-ins. Pyright correctly flags these because `SimpleNamespace` is not assignable to parameters typed as `App`:

```
ERROR Argument `SimpleNamespace` is not assignable to parameter `app_model` with type `App`
```

## Solution

Replace `cast(App, SimpleNamespace(...))` with `MagicMock(spec=App)`:

- `MagicMock(spec=App)` makes the type checker accept the object as `App`
- `spec=App` restricts mock behavior to real `App` attributes
- Using `object.__setattr__` bypasses MagicMock internals for attribute assignment
- No database connection needed (unlike real `App` ORM instances)
- `app_model_config` (a read-only `@property`) can still be set on the mock

## Checklist

- [x] Only modifies `_app_stub()` function (root cause of all errors)
- [x] Does not remove `SimpleNamespace` import (still used elsewhere in file)
- [x] Syntax validated via `ast.parse`
- [x] Addresses the core pattern that causes 12+ type errors in this file