### PR TITLE
fix(web): explicitly resume AudioContext and play audio on first TTS load

### DIFF
--- a/web/app/components/base/audio-btn/audio.ts
+++ b/web/app/components/base/audio-btn/audio.ts
@@ -136,6 +136,10 @@ export default class AudioPlayer {
     }
     else {
       this.isLoadData = true
+      this.audioContext.resume().then((_) => {
+        this.audio.play()
+        this.callback?.('play')
+      })
       this.loadAudio()
     }
   }


### PR DESCRIPTION
AudioPlayer.playAudio() on first call went directly to loadAudio() without calling audio.play(), relying solely on autoplay=true. When audio is routed through AudioContext via createMediaElementSource, autoplay is unreliable and the AudioContext may be suspended, producing no sound despite a valid API response.

Mirror the SSE path (playAudioWithAudio) by explicitly resuming the AudioContext and calling audio.play() before streaming begins.

Fixes #35880

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
