### PR TITLE
fix(web): raise SelectContent z-index above Popover positioner in chat settings

### DIFF
--- a/web/app/components/base/chat/chat-with-history/inputs-form/content.tsx
+++ b/web/app/components/base/chat/chat-with-history/inputs-form/content.tsx
@@ -92,7 +92,7 @@ const InputsFormContent = ({ showTip }: Props) => {
               <SelectTrigger className="w-full">
                 {String(inputsFormValue?.[form.variable] ?? form.default ?? form.label)}
               </SelectTrigger>
-              <SelectContent popupClassName="z-[60] w-(--anchor-width)">
+              <SelectContent popupClassName="z-[1100] w-(--anchor-width)">
                 {form.options.map((option: string) => (
                   <SelectItem key={option} value={option}>
                     <SelectItemText>{option}</SelectItemText>

--- a/web/app/components/base/chat/embedded-chatbot/inputs-form/content.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/inputs-form/content.tsx
@@ -92,7 +92,7 @@ const InputsFormContent = ({ showTip }: Props) => {
               <SelectTrigger className="w-full">
                 {String(inputsFormValue?.[form.variable] ?? form.default ?? form.label)}
               </SelectTrigger>
-              <SelectContent popupClassName="z-[60] w-(--anchor-width)">
+              <SelectContent popupClassName="z-[1100] w-(--anchor-width)">
                 {form.options.map((option: string) => (
                   <SelectItem key={option} value={option}>
                     <SelectItemText>{option}</SelectItemText>


### PR DESCRIPTION
## Title `fix(web): raise SelectContent z-index above Popover positioner in chat settings`


The chat settings Popover positioner uses z-1002 (from PopoverContent in dify-ui). The SelectContent for 'select' type input variables was using z-[60], which is far below the positioner's z-1002, causing the dropdown options to render hidden behind the Popover panel.

Fix: bump SelectContent popupClassName from z-[60] to z-[1100] in both the chat-with-history and embedded-chatbot InputsFormContent components so that select option dropdowns float above the parent settings panel.

Fixes #27581

### Summary

Fixes **#27581** — "select" type user-input variables in the chat settings popover are obscured by the popover itself.

### Root Cause

`PopoverContent` in `packages/dify-ui/src/popover/index.tsx` renders its positioner with `className="z-1002 …"`, giving the entire settings panel a z-index of 1002.

`SelectContent` inside that panel was using `popupClassName="z-[60] …"` — far below 1002 — so the dropdown list rendered hidden behind the popover.

### Changes

| File | Change |
|------|--------|
| `web/app/components/base/chat/chat-with-history/inputs-form/content.tsx` | `z-[60]` → `z-[1100]` on `SelectContent` |
| `web/app/components/base/chat/embedded-chatbot/inputs-form/content.tsx` | `z-[60]` → `z-[1100]` on `SelectContent` |

### Why z-[1100]?

The positioner is at `z-1002`. We need a value above that to break out of the stacking context, but below `z-[9999]` (used for toasts/modals) to avoid interference. `z-[1100]` provides sufficient headroom (+98) over the positioner without over-escalating.

### Testing

1. Create/open a Dify app with at least one "select" type user variable.
2. Publish the app.
3. Start a long conversation so the chat area extends beyond the viewport.
4. Click the chat-settings (⚙️) icon in the upper-right of the chat header.
5. Click the "select" field — dropdown options should now appear **above** the settings panel.

### Self-checklist

- [x] I have read the Contributing Guide and Language Policy
- [x] No new dependencies introduced
- [x] Fix applies to both `chat-with-history` and `embedded-chatbot` variants
- [x] Change is purely a CSS z-index bump — no logic changes

Fixes #27581
