### PR TITLE
fix external knowledge base retrieval settings save and hit testing

### DIFF
--- a/web/app/components/datasets/hit-testing/components/query-input/index.tsx
+++ b/web/app/components/datasets/hit-testing/components/query-input/index.tsx
@@ -17,7 +17,7 @@ import {
   RiPlayCircleLine,
 } from '@remixicon/react'
 import * as React from 'react'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { v4 as uuid4 } from 'uuid'
 import ImageUploaderInRetrievalTesting from '@/app/components/datasets/common/image-uploader/image-uploader-in-retrieval-testing'
@@ -65,12 +65,30 @@ const QueryInput = ({
 }: QueryInputProps) => {
   const { t } = useTranslation()
   const isMultimodal = useDatasetDetailContextWithSelector(s => !!s.dataset?.is_multimodal)
+  const datasetExternalRetrievalModel = useDatasetDetailContextWithSelector(s => s.dataset?.external_retrieval_model)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
   const [externalRetrievalSettings, setExternalRetrievalSettings] = useState({
     top_k: 4,
     score_threshold: 0.5,
     score_threshold_enabled: false,
   })
+
+  // dataset 是异步加载的，首次挂载时 external_retrieval_model 为 undefined，
+  // useState 的初始值会被固化为上面的默认值。此处在 dataset 第一次就绪后
+  // 一次性同步到本地 state，后续用户通过「设置」弹窗修改的值不会被覆盖。
+  const hasSyncedExternalRetrievalSettingsRef = useRef(false)
+  useEffect(() => {
+    if (hasSyncedExternalRetrievalSettingsRef.current)
+      return
+    if (!datasetExternalRetrievalModel)
+      return
+    setExternalRetrievalSettings({
+      top_k: datasetExternalRetrievalModel.top_k ?? 4,
+      score_threshold: datasetExternalRetrievalModel.score_threshold ?? 0.5,
+      score_threshold_enabled: datasetExternalRetrievalModel.score_threshold_enabled ?? false,
+    })
+    hasSyncedExternalRetrievalSettingsRef.current = true
+  }, [datasetExternalRetrievalModel])
 
   const text = useMemo(() => {
     return queries.find(query => query.content_type === 'text_query')?.content ?? ''

--- a/web/app/components/datasets/settings/form/hooks/use-form-state.ts
+++ b/web/app/components/datasets/settings/form/hooks/use-form-state.ts
@@ -132,7 +132,7 @@ export const useFormState = () => {
       return
     }
 
-    if (retrievalConfig.weights) {
+    if (retrievalConfig?.weights) {
       retrievalConfig.weights.vector_setting.embedding_provider_name = embeddingModel.provider || ''
       retrievalConfig.weights.vector_setting.embedding_model_name = embeddingModel.model || ''
     }
@@ -191,20 +191,19 @@ export const useFormState = () => {
     }
   }
 
-  // Computed values
   const showMultiModalTip = useMemo(() => {
     return checkShowMultiModalTip({
       embeddingModel,
-      rerankingEnable: retrievalConfig.reranking_enable,
+      rerankingEnable: retrievalConfig?.reranking_enable,
       rerankModel: {
-        rerankingProviderName: retrievalConfig.reranking_model.reranking_provider_name,
-        rerankingModelName: retrievalConfig.reranking_model.reranking_model_name,
+        rerankingProviderName: retrievalConfig?.reranking_model?.reranking_provider_name ?? '',
+        rerankingModelName: retrievalConfig?.reranking_model?.reranking_model_name ?? '',
       },
       indexMethod,
       embeddingModelList,
       rerankModelList,
     })
-  }, [embeddingModel, rerankModelList, retrievalConfig.reranking_enable, retrievalConfig.reranking_model, embeddingModelList, indexMethod])
+  }, [embeddingModel, rerankModelList, retrievalConfig?.reranking_enable, retrievalConfig?.reranking_model, embeddingModelList, indexMethod])
 
   return {
     // Context values


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #<35912>

Fix external knowledge base retrieval settings (top_k / score_threshold / score_threshold_enabled) not taking effect on the Dataset Settings page and the Hit Testing page.

### Problem

For datasets with `provider === 'external'`:

1. **Hit Testing page**: The request body `external_retrieval_model` was always sent with hardcoded defaults `{top_k: 4, score_threshold: 0.5, score_threshold_enabled: false}`, ignoring what users had saved in the dataset's retrieval settings.
2. **Dataset Settings page**: After saving the retrieval settings once, clicking "Save" again produced no effect — no `PATCH /console/api/datasets/{id}` request was fired.

### Root Causes

1. **Hit Testing page (`query-input/index.tsx`)**  
   `useState` initial value is only evaluated on the first mount. The dataset detail is loaded asynchronously, so `dataset.external_retrieval_model` was `undefined` at mount time, causing state to be permanently frozen at hardcoded defaults.

2. **Settings page (`use-form-state.ts`)**  
   Backend `_update_external_dataset` persists the flat object `{top_k, score_threshold, score_threshold_enabled}` directly into `dataset.retrieval_model`, so `retrieval_model_dict` returned a flat object **without** `reranking_model` / `weights` fields.  
   The `showMultiModalTip` `useMemo` unconditionally accessed `retrievalConfig.reranking_model.reranking_provider_name`, throwing `TypeError: Cannot read properties of undefined` on every render. The hook crashed before the save handler could fire the PATCH request.

### Fix

- **`web/app/components/datasets/hit-testing/components/query-input/index.tsx`**
  - Read `dataset?.external_retrieval_model` from `useDatasetDetailContextWithSelector`.
  - Add a `useEffect + useRef` guard to sync the saved `external_retrieval_model` into local state exactly once when the dataset finishes loading, so subsequent manual edits in the settings modal are not overwritten.

- **`web/app/components/datasets/settings/form/hooks/use-form-state.ts`**
  - Apply optional chaining to all `retrievalConfig.reranking_model.*` / `retrievalConfig.weights` accesses in `handleSave` and the `showMultiModalTip` `useMemo` (including its dependency array) to prevent runtime crashes on external datasets where the retrieval config is a flat object.
  - Add a short comment documenting why the defensive access is required.

### Impact

- External knowledge base retrieval settings now persist correctly and are reflected in Hit Testing requests.
- The Settings page no longer silently crashes on external datasets; "Save" reliably triggers the PATCH request.
- Non-external datasets are unaffected (optional chaining is a no-op when the full nested config exists).

## Screenshots

| Before | After |
|--------|-------|
| Hit Testing sends `external_retrieval_model: {top_k:4, score_threshold:0.5, score_threshold_enabled:false}` regardless of saved settings; Save button on Settings page produces no network request. | Hit Testing request uses the dataset's saved `external_retrieval_model`; Save button on Settings page fires `PATCH /console/api/datasets/{id}` as expected. |
<img width="3428" height="1830" alt="img_v3_0211g_3ebf8acb-793b-4ccf-b211-b53f2df8a9ag" src="https://github.com/user-attachments/assets/b3037dd9-87b9-4510-bc5f-52c8cc8c808b" />
<img width="3420" height="1828" alt="img_v3_0211g_8458372b-7232-41f0-aa3f-541b7a922ebg" src="https://github.com/user-attachments/assets/af3022f9-dff3-4203-9b04-2fb0fe3128f2" />



## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs) — **N/A**, pure bug fix, no user-facing doc changes.
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly. — **N/A**
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods