### PR TITLE
fix: confirm app deletion with Enter key

### DIFF
--- a/web/app/components/apps/__tests__/app-card.spec.tsx
+++ b/web/app/components/apps/__tests__/app-card.spec.tsx
@@ -725,6 +725,22 @@ describe('AppCard', () => {
       })
     })
 
+    it('should call deleteApp API when pressing Enter in the delete confirmation input', async () => {
+      render(<AppCard app={mockApp} onRefresh={mockOnRefresh} />)
+
+      fireEvent.click(screen.getByTestId('dropdown-menu-trigger'))
+      fireEvent.click(await screen.findByRole('menuitem', { name: 'common.operation.delete' }))
+      expect(await screen.findByRole('alertdialog')).toBeInTheDocument()
+
+      const deleteInput = screen.getByRole('textbox')
+      fireEvent.change(deleteInput, { target: { value: mockApp.name } })
+      fireEvent.keyDown(deleteInput, { key: 'Enter', code: 'Enter' })
+
+      await waitFor(() => {
+        expect(mockDeleteAppMutation).toHaveBeenCalled()
+      })
+    })
+
     it('should not call onRefresh after successful delete', async () => {
       render(<AppCard app={mockApp} onRefresh={mockOnRefresh} />)
 

--- a/web/app/components/apps/app-card.tsx
+++ b/web/app/components/apps/app-card.tsx
@@ -250,13 +250,25 @@ const AppCard = ({ app, onlineUsers = [], onRefresh, onOpenTagManagement = () =>
 
   const isDeleteConfirmDisabled = isDeleting || confirmDeleteInput !== app.name
 
-  const onDeleteDialogSubmit: React.FormEventHandler<HTMLFormElement> = useCallback((e) => {
-    e.preventDefault()
+  const submitDeleteConfirmation = useCallback(() => {
     if (isDeleteConfirmDisabled)
       return
 
     void onConfirmDelete()
   }, [isDeleteConfirmDisabled, onConfirmDelete])
+
+  const onDeleteDialogSubmit: React.FormEventHandler<HTMLFormElement> = useCallback((e) => {
+    e.preventDefault()
+    submitDeleteConfirmation()
+  }, [submitDeleteConfirmation])
+
+  const onDeleteConfirmInputKeyDown: React.KeyboardEventHandler<HTMLInputElement> = useCallback((e) => {
+    if (e.key !== 'Enter' || e.nativeEvent.isComposing)
+      return
+
+    e.preventDefault()
+    submitDeleteConfirmation()
+  }, [submitDeleteConfirmation])
 
   const handleShowEditModal = useCallback(() => {
     setIsOperationsMenuOpen(false)
@@ -652,6 +664,7 @@ const AppCard = ({ app, onlineUsers = [], onRefresh, onOpenTagManagement = () =>
                   placeholder={t('deleteAppConfirmInputPlaceholder', { ns: 'app' })}
                   value={confirmDeleteInput}
                   onChange={e => setConfirmDeleteInput(e.target.value)}
+                  onKeyDown={onDeleteConfirmInputKeyDown}
                   className="border-components-input-border-hover bg-components-input-bg-normal focus:border-components-input-border-active focus:bg-components-input-bg-active"
                 />
               </div>


### PR DESCRIPTION
## Summary

- Allows users to confirm app deletion from the app card modal by pressing Enter in the confirmation input after typing the exact app name.
- Routes Enter through the same confirmation guard used by the submit button, preserving the existing disabled and deleting protections.
- No visual changes.

Fixes #35921

## Screenshots

| Before | After |
|--------|-------|
| No visual change | No visual change |
