### PR TITLE
fix: Image rendering in the knowledge base failed.

### DIFF
--- a/api/core/rag/extractor/pdf_extractor.py
+++ b/api/core/rag/extractor/pdf_extractor.py
@@ -115,7 +115,7 @@ class PdfExtractor(BaseExtractor):
         """
         image_content = []
         upload_files = []
-        base_url = dify_config.INTERNAL_FILES_URL or dify_config.FILES_URL
+        base_url = dify_config.FILES_URL
 
         try:
             image_objects = page.get_objects(filter=(pdfium_c.FPDF_PAGEOBJ_IMAGE,))

--- a/api/core/rag/extractor/word_extractor.py
+++ b/api/core/rag/extractor/word_extractor.py
@@ -88,7 +88,7 @@ class WordExtractor(BaseExtractor):
     def _extract_images_from_docx(self, doc):
         image_count = 0
         image_map = {}
-        base_url = dify_config.INTERNAL_FILES_URL or dify_config.FILES_URL
+        base_url = dify_config.FILES_URL
 
         for r_id, rel in doc.part.rels.items():
             if "image" in rel.target_ref:

--- a/api/core/tools/signature.py
+++ b/api/core/tools/signature.py
@@ -25,12 +25,12 @@ def sign_tool_file(tool_file_id: str, extension: str, for_external: bool = True)
     return f"{file_preview_url}?timestamp={timestamp}&nonce={nonce}&sign={encoded_sign}"
 
 
-def sign_upload_file(upload_file_id: str, extension: str) -> str:
+def sign_upload_file(upload_file_id: str, extension: str, for_external: bool = True) -> str:
     """
     sign file to get a temporary url for plugin access
     """
     # Use internal URL for plugin/tool file access in Docker environments
-    base_url = dify_config.INTERNAL_FILES_URL or dify_config.FILES_URL
+    base_url = dify_config.FILES_URL if for_external else (dify_config.INTERNAL_FILES_URL or dify_config.FILES_URL)
     file_preview_url = f"{base_url}/files/{upload_file_id}/image-preview"
 
     timestamp = str(int(time.time()))

--- a/api/core/tools/signature.py
+++ b/api/core/tools/signature.py
@@ -27,9 +27,12 @@ def sign_tool_file(tool_file_id: str, extension: str, for_external: bool = True)
 
 def sign_upload_file(upload_file_id: str, extension: str, for_external: bool = True) -> str:
     """
-    sign file to get a temporary url for plugin access
+    Sign an upload file to get a temporary image preview URL.
+
+    External URLs are the default because uploaded-file previews are returned to
+    user-facing retrieval responses. Internal URLs remain available for callers
+    that need to access files inside the deployment network.
     """
-    # Use internal URL for plugin/tool file access in Docker environments
     base_url = dify_config.FILES_URL if for_external else (dify_config.INTERNAL_FILES_URL or dify_config.FILES_URL)
     file_preview_url = f"{base_url}/files/{upload_file_id}/image-preview"
 

--- a/api/tests/unit_tests/core/tools/test_signature.py
+++ b/api/tests/unit_tests/core/tools/test_signature.py
@@ -83,7 +83,7 @@ def test_verify_tool_file_signature_rejects_expired_signature(monkeypatch: pytes
     assert verify_tool_file_signature("tool-file-id", timestamp, nonce, sign) is False
 
 
-def test_sign_upload_file_prefers_internal_url(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sign_upload_file_for_external_uses_files_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("core.tools.signature.time.time", lambda: 1700000000)
     monkeypatch.setattr("core.tools.signature.os.urandom", lambda _: b"\x03" * 16)
     monkeypatch.setattr("core.tools.signature.dify_config.SECRET_KEY", "unit-secret")
@@ -91,6 +91,24 @@ def test_sign_upload_file_prefers_internal_url(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr("core.tools.signature.dify_config.INTERNAL_FILES_URL", "https://internal.example.com")
 
     url = sign_upload_file("upload-id", ".png")
+    parsed = urlparse(url)
+    query = parse_qs(parsed.query)
+
+    assert parsed.netloc == "files.example.com"
+    assert parsed.path == "/files/upload-id/image-preview"
+    assert query["timestamp"][0]
+    assert query["nonce"][0]
+    assert query["sign"][0]
+
+
+def test_sign_upload_file_for_internal_prefers_internal_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("core.tools.signature.time.time", lambda: 1700000000)
+    monkeypatch.setattr("core.tools.signature.os.urandom", lambda _: b"\x08" * 16)
+    monkeypatch.setattr("core.tools.signature.dify_config.SECRET_KEY", "unit-secret")
+    monkeypatch.setattr("core.tools.signature.dify_config.FILES_URL", "https://files.example.com")
+    monkeypatch.setattr("core.tools.signature.dify_config.INTERNAL_FILES_URL", "https://internal.example.com")
+
+    url = sign_upload_file("upload-id", ".png", for_external=False)
     parsed = urlparse(url)
     query = parse_qs(parsed.query)
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

fixes https://github.com/langgenius/dify/issues/35910

In the environment variable configuration INTERNAL_FILES_URL, the value is the API service address in the container, such as http://dify-api-svc:5001/.
Upload images for retrieval during the knowledge base retrieval test.
Then the browser will not request the image asset.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
