### PR TITLE
fix(plugin): use clipboard fallback for plugin url and key copy

### DIFF
--- a/web/app/components/plugins/base/__tests__/key-value-item.spec.tsx
+++ b/web/app/components/plugins/base/__tests__/key-value-item.spec.tsx
@@ -16,15 +16,16 @@ vi.mock('@/app/components/base/action-button', () => ({
   ),
 }))
 
-const mockCopy = vi.fn()
-vi.mock('copy-to-clipboard', () => ({
-  default: (...args: unknown[]) => mockCopy(...args),
+const mockWriteTextToClipboard = vi.fn()
+vi.mock('@/utils/clipboard', () => ({
+  writeTextToClipboard: (...args: unknown[]) => mockWriteTextToClipboard(...args),
 }))
 
 describe('KeyValueItem', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.useFakeTimers()
+    mockWriteTextToClipboard.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -44,10 +45,10 @@ describe('KeyValueItem', () => {
     expect(screen.queryByText('sk-secret')).not.toBeInTheDocument()
   })
 
-  it('copies actual value (not masked) when copy button is clicked', () => {
+  it('copies actual value (not masked) when copy button is clicked', async () => {
     render(<KeyValueItem label="Key" value="sk-secret" maskedValue="sk-***" />)
     fireEvent.click(screen.getByTestId('action-button'))
-    expect(mockCopy).toHaveBeenCalledWith('sk-secret')
+    expect(mockWriteTextToClipboard).toHaveBeenCalledWith('sk-secret')
   })
 
   it('renders copy tooltip', () => {

--- a/web/app/components/plugins/base/key-value-item.tsx
+++ b/web/app/components/plugins/base/key-value-item.tsx
@@ -2,11 +2,11 @@
 import type { FC } from 'react'
 import { cn } from '@langgenius/dify-ui/cn'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/tooltip'
-import copy from 'copy-to-clipboard'
 import * as React from 'react'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import ActionButton from '@/app/components/base/action-button'
+import { writeTextToClipboard } from '@/utils/clipboard'
 import { CopyCheck } from '../../base/icons/src/vender/line/files'
 
 type Props = {
@@ -27,8 +27,9 @@ const KeyValueItem: FC<Props> = ({
   const { t } = useTranslation()
   const [isCopied, setIsCopied] = useState(false)
   const handleCopy = useCallback(() => {
-    copy(value)
-    setIsCopied(true)
+    void writeTextToClipboard(value).then(() => {
+      setIsCopied(true)
+    })
   }, [value])
 
   useEffect(() => {

--- a/web/app/components/plugins/plugin-detail-panel/__tests__/endpoint-card.spec.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/__tests__/endpoint-card.spec.tsx
@@ -9,6 +9,7 @@ const mockDisableEndpoint = vi.fn()
 const mockDeleteEndpoint = vi.fn()
 const mockUpdateEndpoint = vi.fn()
 const mockToastNotify = vi.fn()
+const mockWriteTextToClipboard = vi.fn()
 
 vi.mock('@langgenius/dify-ui/toast', () => ({
   toast: Object.assign(
@@ -70,6 +71,10 @@ vi.mock('@/service/use-endpoints', () => ({
         onSuccess()
     },
   }),
+}))
+
+vi.mock('@/utils/clipboard', () => ({
+  writeTextToClipboard: (...args: unknown[]) => mockWriteTextToClipboard(...args),
 }))
 
 vi.mock('@/app/components/header/indicator', () => ({
@@ -136,6 +141,7 @@ const mockPluginDetail: PluginDetail = {
 describe('EndpointCard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockWriteTextToClipboard.mockResolvedValue(undefined)
     // Reset failure flags
     failureFlags.enable = false
     failureFlags.disable = false
@@ -233,6 +239,14 @@ describe('EndpointCard', () => {
       fireEvent.click(allButtons[0]!)
 
       expect(screen.getByTestId('endpoint-modal'))!.toBeInTheDocument()
+    })
+
+    it('should copy endpoint url when copy action is clicked', () => {
+      render(<EndpointCard pluginDetail={mockPluginDetail} data={mockEndpointData} handleChange={mockHandleChange} />)
+
+      fireEvent.click(screen.getByRole('button', { name: 'common.operation.copy' }))
+
+      expect(mockWriteTextToClipboard).toHaveBeenCalledWith('https://api.example.com/api/test')
     })
 
     it('should call updateEndpoint when save in modal', () => {

--- a/web/app/components/plugins/plugin-detail-panel/endpoint-card.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/endpoint-card.tsx
@@ -12,7 +12,6 @@ import { Switch } from '@langgenius/dify-ui/switch'
 import { toast } from '@langgenius/dify-ui/toast'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/tooltip'
 import { useBoolean } from 'ahooks'
-import copy from 'copy-to-clipboard'
 import * as React from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -26,6 +25,7 @@ import {
   useEnableEndpoint,
   useUpdateEndpoint,
 } from '@/service/use-endpoints'
+import { writeTextToClipboard } from '@/utils/clipboard'
 import EndpointModal from './endpoint-modal'
 import { NAME_FIELD } from './utils'
 
@@ -127,8 +127,9 @@ const EndpointCard = ({
 
   const [isCopied, setIsCopied] = useState(false)
   const handleCopy = (value: string) => {
-    copy(value)
-    setIsCopied(true)
+    void writeTextToClipboard(value).then(() => {
+      setIsCopied(true)
+    })
   }
 
   const handleDisableConfirmOpenChange = (open: boolean) => {


### PR DESCRIPTION
## Summary
- route plugin endpoint URL copy actions through the shared `writeTextToClipboard` fallback
- route plugin key/value copy actions through the same utility instead of direct `copy-to-clipboard` calls
- add targeted tests for both copy surfaces

Closes #35926

## Testing
- `cd /Users/odeili/Projects/dify && mise exec node@22 -- pnpm -C web exec vp test app/components/plugins/base/__tests__/key-value-item.spec.tsx app/components/plugins/plugin-detail-panel/__tests__/endpoint-card.spec.tsx`
- `cd /Users/odeili/Projects/dify && mise exec node@22 -- pnpm -C web exec eslint app/components/plugins/base/key-value-item.tsx app/components/plugins/plugin-detail-panel/endpoint-card.tsx app/components/plugins/base/__tests__/key-value-item.spec.tsx app/components/plugins/plugin-detail-panel/__tests__/endpoint-card.spec.tsx`