### PR TITLE
fix(docker): update middleware env setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ DOCKER_REGISTRY=langgenius
 WEB_IMAGE=$(DOCKER_REGISTRY)/dify-web
 API_IMAGE=$(DOCKER_REGISTRY)/dify-api
 VERSION=latest
+DOCKER_DIR=docker
+DOCKER_MIDDLEWARE_ENV=$(DOCKER_DIR)/middleware.env
+DOCKER_MIDDLEWARE_ENV_EXAMPLE=$(DOCKER_DIR)/envs/middleware.env.example
+DOCKER_MIDDLEWARE_PROJECT=dify-middlewares-dev
 
 # Default target - show help
 .DEFAULT_GOAL := help
@@ -17,8 +21,13 @@ dev-setup: prepare-docker prepare-web prepare-api
 # Step 1: Prepare Docker middleware
 prepare-docker:
 	@echo "🐳 Setting up Docker middleware..."
-	@cp -n docker/middleware.env.example docker/middleware.env 2>/dev/null || echo "Docker middleware.env already exists"
-	@cd docker && docker compose -f docker-compose.middleware.yaml --env-file middleware.env -p dify-middlewares-dev up -d
+	@if [ ! -f "$(DOCKER_MIDDLEWARE_ENV)" ]; then \
+		cp "$(DOCKER_MIDDLEWARE_ENV_EXAMPLE)" "$(DOCKER_MIDDLEWARE_ENV)"; \
+		echo "Docker middleware.env created"; \
+	else \
+		echo "Docker middleware.env already exists"; \
+	fi
+	@cd $(DOCKER_DIR) && docker compose -f docker-compose.middleware.yaml --env-file middleware.env -p $(DOCKER_MIDDLEWARE_PROJECT) up -d
 	@echo "✅ Docker middleware started"
 
 # Step 2: Prepare web environment
@@ -39,12 +48,18 @@ prepare-api:
 # Clean dev environment
 dev-clean:
 	@echo "⚠️  Stopping Docker containers..."
-	@cd docker && docker compose -f docker-compose.middleware.yaml --env-file middleware.env -p dify-middlewares-dev down
+	@if [ -f "$(DOCKER_MIDDLEWARE_ENV)" ]; then \
+		cd $(DOCKER_DIR) && docker compose -f docker-compose.middleware.yaml --env-file middleware.env -p $(DOCKER_MIDDLEWARE_PROJECT) down; \
+	else \
+		echo "Docker middleware.env does not exist, skipping compose down"; \
+	fi
 	@echo "🗑️  Removing volumes..."
 	@rm -rf docker/volumes/db
+	@rm -rf docker/volumes/mysql
 	@rm -rf docker/volumes/redis
 	@rm -rf docker/volumes/plugin_daemon
 	@rm -rf docker/volumes/weaviate
+	@rm -rf docker/volumes/sandbox/dependencies
 	@rm -rf api/storage
 	@echo "✅ Cleanup complete"
 
@@ -132,7 +147,7 @@ help:
 	@echo "  make prepare-docker - Set up Docker middleware"
 	@echo "  make prepare-web    - Set up web environment"
 	@echo "  make prepare-api    - Set up API environment"
-	@echo "  make dev-clean      - Stop Docker middleware containers"
+	@echo "  make dev-clean      - Stop Docker middleware containers and remove dev data"
 	@echo ""
 	@echo "Backend Code Quality:"
 	@echo "  make format         - Format code with ruff"

--- a/dev/pytest/pytest_full.sh
+++ b/dev/pytest/pytest_full.sh
@@ -15,7 +15,7 @@ mkdir -p "${OPENDAL_FS_ROOT}"
 
 # Prepare env files like CI
 cp -n docker/.env.example docker/.env || true
-cp -n docker/middleware.env.example docker/middleware.env || true
+cp -n docker/envs/middleware.env.example docker/middleware.env || true
 cp -n api/tests/integration_tests/.env.example api/tests/integration_tests/.env || true
 
 # Expose service ports (same as CI) without leaving the repo dirty

--- a/dev/setup
+++ b/dev/setup
@@ -8,7 +8,7 @@ API_ENV_EXAMPLE="$ROOT/api/.env.example"
 API_ENV="$ROOT/api/.env"
 WEB_ENV_EXAMPLE="$ROOT/web/.env.example"
 WEB_ENV="$ROOT/web/.env.local"
-MIDDLEWARE_ENV_EXAMPLE="$ROOT/docker/middleware.env.example"
+MIDDLEWARE_ENV_EXAMPLE="$ROOT/docker/envs/middleware.env.example"
 MIDDLEWARE_ENV="$ROOT/docker/middleware.env"
 
 # 1) Copy api/.env.example -> api/.env
@@ -17,7 +17,7 @@ cp "$API_ENV_EXAMPLE" "$API_ENV"
 # 2) Copy web/.env.example -> web/.env.local
 cp "$WEB_ENV_EXAMPLE" "$WEB_ENV"
 
-# 3) Copy docker/middleware.env.example -> docker/middleware.env
+# 3) Copy docker/envs/middleware.env.example -> docker/middleware.env
 cp "$MIDDLEWARE_ENV_EXAMPLE" "$MIDDLEWARE_ENV"
 
 # 4) Install deps


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. I have read the contribution guidelines.
> 1. Associated issue: Fixes #35945.

## Summary

Fixes #35945

This updates local setup and cleanup flows after the Docker env file split:

- Create `docker/middleware.env` from `docker/envs/middleware.env.example` in `make prepare-docker`.
- Make `make dev-clean` safe when the generated middleware env file is absent.
- Remove current middleware data directories for MySQL and sandbox dependencies during dev cleanup.
- Align `dev/setup` and `dev/pytest/pytest_full.sh` with the new middleware env template location.

## Screenshots

N/A