### PR TITLE
fix(web): forward csp nonce to theme script

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -5,9 +5,11 @@ import { Provider as JotaiProvider } from 'jotai/react'
 import { ThemeProvider } from 'next-themes'
 import { NuqsAdapter } from 'nuqs/adapters/next/app'
 import AmplitudeProvider from '@/app/components/base/amplitude'
+import { IS_PROD } from '@/config'
 import { TanstackQueryInitializer } from '@/context/query-client'
 import { getDatasetMap } from '@/env'
 import { getLocaleOnServer } from '@/i18n-config/server'
+import { headers } from '@/next/headers'
 import PartnerStackCookieRecorder from './components/billing/partner-stack/cookie-recorder'
 import CreateAppAttributionBootstrap from './components/create-app-attribution-bootstrap'
 import { AgentationLoader } from './components/devtools/agentation-loader'
@@ -32,6 +34,7 @@ const LocaleLayout = async ({
 }) => {
   const locale = await getLocaleOnServer()
   const datasetMap = getDatasetMap()
+  const nonce = IS_PROD ? (await headers()).get('x-nonce') ?? undefined : undefined
 
   return (
     <html lang={locale ?? 'en'} className="h-full" suppressHydrationWarning>
@@ -64,6 +67,7 @@ const LocaleLayout = async ({
               defaultTheme="system"
               enableSystem
               disableTransitionOnChange
+              nonce={nonce}
             >
               <NuqsAdapter>
                 <TanstackQueryInitializer>

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -18,15 +18,16 @@ const wrapResponseWithXFrameOptions = (response: NextResponse, pathname: string)
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
   const requestHeaders = new Headers(request.headers)
-  const response = NextResponse.next({
-    request: {
-      headers: requestHeaders,
-    },
-  })
 
   const isWhiteListEnabled = !!env.NEXT_PUBLIC_CSP_WHITELIST && process.env.NODE_ENV === 'production'
-  if (!isWhiteListEnabled)
+  if (!isWhiteListEnabled) {
+    const response = NextResponse.next({
+      request: {
+        headers: requestHeaders,
+      },
+    })
     return wrapResponseWithXFrameOptions(response, pathname)
+  }
 
   const whiteList = `${env.NEXT_PUBLIC_CSP_WHITELIST} ${NECESSARY_DOMAIN}`
   const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
@@ -59,6 +60,12 @@ export function proxy(request: NextRequest) {
     'Content-Security-Policy',
     contentSecurityPolicyHeaderValue,
   )
+
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  })
 
   response.headers.set(
     'Content-Security-Policy',


### PR DESCRIPTION
Fixes #32185

## Summary
- pass the CSP nonce from root layout into next-themes ThemeProvider
- set forwarded request headers before creating NextResponse.next() so RSC can read x-nonce

## Testing
- pnpm --dir web exec eslint app/layout.tsx proxy.ts
- pre-commit eslint on staged files