### PR TITLE
fix: mismatched button label in prefilled WebApp launch description

### DIFF
--- a/web/i18n/ja-JP/app-overview.json
+++ b/web/i18n/ja-JP/app-overview.json
@@ -106,7 +106,7 @@
   "overview.appInfo.settings.workflow.subTitle": "ワークフローの詳細",
   "overview.appInfo.settings.workflow.title": "ワークフローステップ",
   "overview.appInfo.title": "Web App",
-  "overview.appInfo.workflowLaunchHiddenInputs.description": "非表示フィールドに値を入力後、<bold>起動</bold>をクリックすると、事前入力された値が適用された WebApp が開きます。",
+  "overview.appInfo.workflowLaunchHiddenInputs.description": "非表示フィールドに値を入力後、<bold>公開</bold>をクリックすると、事前入力された値が適用された WebApp が開きます。",
   "overview.appInfo.workflowLaunchHiddenInputs.title": "非表示フィールドを事前入力",
   "overview.disableTooltip.triggerMode": "トリガーノードモードでは{{feature}}機能を使用できません。",
   "overview.status.disable": "無効",


### PR DESCRIPTION
## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
