### PR TITLE
fix(api): deprecate create_by_file alias

### DIFF
--- a/api/controllers/service_api/dataset/document.py
+++ b/api/controllers/service_api/dataset/document.py
@@ -507,8 +507,7 @@ def _create_document_by_file(tenant_id: str, dataset_id: UUID) -> tuple[Mapping[
     except ProviderTokenNotInitError as ex:
         raise ProviderNotInitializeError(ex.description)
     document = documents[0]
-    documents_and_batch_fields = {"document": marshal(document, document_fields), "batch": batch}
-    return documents_and_batch_fields, 200
+    return dump_response(DocumentAndBatchResponse, {"document": document, "batch": batch}), 200
 
 
 @service_api_ns.route("/datasets/<uuid:dataset_id>/document/create-by-file")

--- a/api/controllers/service_api/dataset/document.py
+++ b/api/controllers/service_api/dataset/document.py
@@ -419,12 +419,101 @@ class DeprecatedDocumentUpdateByTextApi(DatasetApiResource):
         return _update_document_by_text(tenant_id=tenant_id, dataset_id=dataset_id, document_id=document_id)
 
 
-@service_api_ns.route(
-    "/datasets/<uuid:dataset_id>/document/create_by_file",
-    "/datasets/<uuid:dataset_id>/document/create-by-file",
-)
+def _create_document_by_file(tenant_id: str, dataset_id: UUID) -> tuple[Mapping[str, object], int]:
+    """Create a document from an uploaded file for canonical and deprecated routes."""
+    dataset = db.session.scalar(
+        select(Dataset).where(Dataset.tenant_id == tenant_id, Dataset.id == dataset_id).limit(1)
+    )
+
+    if not dataset:
+        raise ValueError("Dataset does not exist.")
+
+    if dataset.provider == "external":
+        raise ValueError("External datasets are not supported.")
+
+    args = {}
+    if "data" in request.form:
+        args = json.loads(request.form["data"])
+    if "doc_form" not in args:
+        args["doc_form"] = dataset.chunk_structure or "text_model"
+    if "doc_language" not in args:
+        args["doc_language"] = "English"
+
+    # get dataset info
+    tenant_id = str(tenant_id)
+
+    indexing_technique = args.get("indexing_technique") or dataset.indexing_technique
+    if not indexing_technique:
+        raise ValueError("indexing_technique is required.")
+    args["indexing_technique"] = indexing_technique
+
+    if "embedding_model_provider" in args:
+        DatasetService.check_embedding_model_setting(
+            tenant_id, args["embedding_model_provider"], args["embedding_model"]
+        )
+    if (
+        "retrieval_model" in args
+        and args["retrieval_model"].get("reranking_model")
+        and args["retrieval_model"].get("reranking_model").get("reranking_provider_name")
+    ):
+        DatasetService.check_reranking_model_setting(
+            tenant_id,
+            args["retrieval_model"].get("reranking_model").get("reranking_provider_name"),
+            args["retrieval_model"].get("reranking_model").get("reranking_model_name"),
+        )
+
+    # check file
+    if "file" not in request.files:
+        raise NoFileUploadedError()
+
+    if len(request.files) > 1:
+        raise TooManyFilesError()
+
+    # save file info
+    file = request.files["file"]
+    if not file.filename:
+        raise FilenameNotExistsError
+
+    if not current_user:
+        raise ValueError("current_user is required")
+    upload_file = FileService(db.engine).upload_file(
+        filename=file.filename,
+        content=file.stream.read(),
+        mimetype=file.mimetype,
+        user=current_user,
+        source="datasets",
+    )
+    data_source = {
+        "type": "upload_file",
+        "info_list": {"data_source_type": "upload_file", "file_info_list": {"file_ids": [upload_file.id]}},
+    }
+    args["data_source"] = data_source
+    # validate args
+    knowledge_config = KnowledgeConfig.model_validate(args)
+    DocumentService.document_create_args_validate(knowledge_config)
+
+    dataset_process_rule = dataset.latest_process_rule if "process_rule" not in args else None
+    if not knowledge_config.original_document_id and not dataset_process_rule and not knowledge_config.process_rule:
+        raise ValueError("process_rule is required.")
+
+    try:
+        documents, batch = DocumentService.save_document_with_dataset_id(
+            dataset=dataset,
+            knowledge_config=knowledge_config,
+            account=dataset.created_by_account,
+            dataset_process_rule=dataset_process_rule,
+            created_from="api",
+        )
+    except ProviderTokenNotInitError as ex:
+        raise ProviderNotInitializeError(ex.description)
+    document = documents[0]
+    documents_and_batch_fields = {"document": marshal(document, document_fields), "batch": batch}
+    return documents_and_batch_fields, 200
+
+
+@service_api_ns.route("/datasets/<uuid:dataset_id>/document/create-by-file")
 class DocumentAddByFileApi(DatasetApiResource):
-    """Resource for documents."""
+    """Resource for the canonical document file creation route."""
 
     @service_api_ns.doc("create_document_by_file")
     @service_api_ns.doc(description="Create a new document by uploading a file")
@@ -442,95 +531,37 @@ class DocumentAddByFileApi(DatasetApiResource):
     @cloud_edition_billing_resource_check("vector_space", "dataset")
     @cloud_edition_billing_resource_check("documents", "dataset")
     @cloud_edition_billing_rate_limit_check("knowledge", "dataset")
-    def post(self, tenant_id, dataset_id: UUID):
+    def post(self, tenant_id: str, dataset_id: UUID):
         """Create document by upload file."""
-        dataset = db.session.scalar(
-            select(Dataset).where(Dataset.tenant_id == tenant_id, Dataset.id == dataset_id).limit(1)
+        return _create_document_by_file(tenant_id=tenant_id, dataset_id=dataset_id)
+
+
+@service_api_ns.route("/datasets/<uuid:dataset_id>/document/create_by_file")
+class DeprecatedDocumentAddByFileApi(DatasetApiResource):
+    """Deprecated resource alias for document file creation."""
+
+    @service_api_ns.doc("create_document_by_file_deprecated")
+    @service_api_ns.doc(deprecated=True)
+    @service_api_ns.doc(
+        description=(
+            "Deprecated legacy alias for creating a new document by uploading a file. "
+            "Use /datasets/{dataset_id}/document/create-by-file instead."
         )
-
-        if not dataset:
-            raise ValueError("Dataset does not exist.")
-
-        if dataset.provider == "external":
-            raise ValueError("External datasets are not supported.")
-
-        args = {}
-        if "data" in request.form:
-            args = json.loads(request.form["data"])
-        if "doc_form" not in args:
-            args["doc_form"] = dataset.chunk_structure or "text_model"
-        if "doc_language" not in args:
-            args["doc_language"] = "English"
-
-        # get dataset info
-        tenant_id = str(tenant_id)
-
-        indexing_technique = args.get("indexing_technique") or dataset.indexing_technique
-        if not indexing_technique:
-            raise ValueError("indexing_technique is required.")
-        args["indexing_technique"] = indexing_technique
-
-        if "embedding_model_provider" in args:
-            DatasetService.check_embedding_model_setting(
-                tenant_id, args["embedding_model_provider"], args["embedding_model"]
-            )
-        if (
-            "retrieval_model" in args
-            and args["retrieval_model"].get("reranking_model")
-            and args["retrieval_model"].get("reranking_model").get("reranking_provider_name")
-        ):
-            DatasetService.check_reranking_model_setting(
-                tenant_id,
-                args["retrieval_model"].get("reranking_model").get("reranking_provider_name"),
-                args["retrieval_model"].get("reranking_model").get("reranking_model_name"),
-            )
-
-        # check file
-        if "file" not in request.files:
-            raise NoFileUploadedError()
-
-        if len(request.files) > 1:
-            raise TooManyFilesError()
-
-        # save file info
-        file = request.files["file"]
-        if not file.filename:
-            raise FilenameNotExistsError
-
-        if not current_user:
-            raise ValueError("current_user is required")
-        upload_file = FileService(db.engine).upload_file(
-            filename=file.filename,
-            content=file.stream.read(),
-            mimetype=file.mimetype,
-            user=current_user,
-            source="datasets",
-        )
-        data_source = {
-            "type": "upload_file",
-            "info_list": {"data_source_type": "upload_file", "file_info_list": {"file_ids": [upload_file.id]}},
+    )
+    @service_api_ns.doc(params={"dataset_id": "Dataset ID"})
+    @service_api_ns.doc(
+        responses={
+            200: "Document created successfully",
+            401: "Unauthorized - invalid API token",
+            400: "Bad request - invalid file or parameters",
         }
-        args["data_source"] = data_source
-        # validate args
-        knowledge_config = KnowledgeConfig.model_validate(args)
-        DocumentService.document_create_args_validate(knowledge_config)
-
-        dataset_process_rule = dataset.latest_process_rule if "process_rule" not in args else None
-        if not knowledge_config.original_document_id and not dataset_process_rule and not knowledge_config.process_rule:
-            raise ValueError("process_rule is required.")
-
-        try:
-            documents, batch = DocumentService.save_document_with_dataset_id(
-                dataset=dataset,
-                knowledge_config=knowledge_config,
-                account=dataset.created_by_account,
-                dataset_process_rule=dataset_process_rule,
-                created_from="api",
-            )
-        except ProviderTokenNotInitError as ex:
-            raise ProviderNotInitializeError(ex.description)
-        document = documents[0]
-        return dump_response(DocumentAndBatchResponse, {"document": document, "batch": batch}), 200
+    )
+    @cloud_edition_billing_resource_check("vector_space", "dataset")
+    @cloud_edition_billing_resource_check("documents", "dataset")
+    @cloud_edition_billing_rate_limit_check("knowledge", "dataset")
+    def post(self, tenant_id: str, dataset_id: UUID):
+        """Create document by upload file through the deprecated underscore alias."""
+        return _create_document_by_file(tenant_id=tenant_id, dataset_id=dataset_id)
 
 
 def _update_document_by_file(tenant_id: str, dataset_id: UUID, document_id: UUID) -> tuple[Mapping[str, object], int]:

--- a/api/openapi/markdown/service-swagger.md
+++ b/api/openapi/markdown/service-swagger.md
@@ -799,17 +799,15 @@ Deprecated legacy alias for creating a new document by uploading a file. Use /da
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| data | formData | Optional JSON string with document creation settings. | No | string |
-| file | formData | Document file to upload. | Yes | file |
 | dataset_id | path | Dataset ID | Yes | string |
 
 ##### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Document created successfully | [DocumentAndBatchResponse](#documentandbatchresponse) |
-| 400 | Bad request - invalid file or parameters |  |
-| 401 | Unauthorized - invalid API token |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Document created successfully |
+| 400 | Bad request - invalid file or parameters |
+| 401 | Unauthorized - invalid API token |
 
 ### /datasets/{dataset_id}/document/create_by_text
 

--- a/api/openapi/markdown/service-swagger.md
+++ b/api/openapi/markdown/service-swagger.md
@@ -790,9 +790,10 @@ Create a new document by providing text content
 ### /datasets/{dataset_id}/document/create_by_file
 
 #### POST
+***DEPRECATED***
 ##### Description
 
-Create a new document by uploading a file
+Deprecated legacy alias for creating a new document by uploading a file. Use /datasets/{dataset_id}/document/create-by-file instead.
 
 ##### Parameters
 

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_document.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_document.py
@@ -23,6 +23,7 @@ from flask import Flask
 from werkzeug.exceptions import Forbidden, NotFound
 
 from controllers.service_api.dataset.document import (
+    DeprecatedDocumentAddByFileApi,
     DeprecatedDocumentAddByTextApi,
     DeprecatedDocumentUpdateByFileApi,
     DeprecatedDocumentUpdateByTextApi,
@@ -1169,6 +1170,11 @@ class TestDocumentRouteDeprecation:
         """Ensure only the legacy create-by-text alias is marked deprecated."""
         assert DeprecatedDocumentAddByTextApi.post.__apidoc__["deprecated"] is True
         assert DocumentAddByTextApi.post.__apidoc__.get("deprecated") is not True
+
+    def test_create_by_file_legacy_alias_is_deprecated(self):
+        """Ensure only the legacy create-by-file alias is marked deprecated."""
+        assert DeprecatedDocumentAddByFileApi.post.__apidoc__["deprecated"] is True
+        assert DocumentAddByFileApi.post.__apidoc__.get("deprecated") is not True
 
     def test_update_by_text_legacy_alias_is_deprecated(self):
         """Ensure only the legacy update-by-text alias is marked deprecated."""

--- a/packages/contracts/generated/api/service/orpc.gen.ts
+++ b/packages/contracts/generated/api/service/orpc.gen.ts
@@ -878,11 +878,17 @@ export const post13 = oc
   .output(zPostDatasetsByDatasetIdDocumentCreateByFileResponse)
 
 /**
- * Create a new document by uploading a file
+ * Deprecated legacy alias for creating a new document by uploading a file. Use /datasets/{dataset_id}/document/create-by-file instead.
+ *
+ * Generated contract types may be inaccurate because backend OpenAPI annotations are incomplete. Do not migrate callers until the generated contract is accurate.
+ *
+ * @deprecated
  */
 export const post14 = oc
   .route({
-    description: 'Create a new document by uploading a file',
+    deprecated: true,
+    description:
+      'Deprecated legacy alias for creating a new document by uploading a file. Use /datasets/{dataset_id}/document/create-by-file instead.\n\nGenerated contract types may be inaccurate because backend OpenAPI annotations are incomplete. Do not migrate callers until the generated contract is accurate.',
     inputStructure: 'detailed',
     method: 'POST',
     operationId: 'postDatasetsByDatasetIdDocumentCreateByFile',

--- a/packages/contracts/generated/api/service/orpc.gen.ts
+++ b/packages/contracts/generated/api/service/orpc.gen.ts
@@ -121,7 +121,6 @@ import {
   zPostConversationsByCIdNamePath,
   zPostConversationsByCIdNameResponse,
   zPostDatasetsBody,
-  zPostDatasetsByDatasetIdDocumentCreateByFile2Body,
   zPostDatasetsByDatasetIdDocumentCreateByFile2Path,
   zPostDatasetsByDatasetIdDocumentCreateByFile2Response,
   zPostDatasetsByDatasetIdDocumentCreateByFileBody,
@@ -895,12 +894,7 @@ export const post14 = oc
     path: '/datasets/{dataset_id}/document/create_by_file',
     tags: ['service_api'],
   })
-  .input(
-    z.object({
-      body: zPostDatasetsByDatasetIdDocumentCreateByFile2Body,
-      params: zPostDatasetsByDatasetIdDocumentCreateByFile2Path,
-    }),
-  )
+  .input(z.object({ params: zPostDatasetsByDatasetIdDocumentCreateByFile2Path }))
   .output(zPostDatasetsByDatasetIdDocumentCreateByFile2Response)
 
 export const createByFile = {

--- a/packages/contracts/generated/api/service/types.gen.ts
+++ b/packages/contracts/generated/api/service/types.gen.ts
@@ -1944,10 +1944,7 @@ export type PostDatasetsByDatasetIdDocumentCreateByTextResponse
   = PostDatasetsByDatasetIdDocumentCreateByTextResponses[keyof PostDatasetsByDatasetIdDocumentCreateByTextResponses]
 
 export type PostDatasetsByDatasetIdDocumentCreateByFile2Data = {
-  body: {
-    data?: string
-    file: Blob | File
-  }
+  body?: never
   path: {
     dataset_id: string
   }
@@ -1968,7 +1965,9 @@ export type PostDatasetsByDatasetIdDocumentCreateByFile2Error
   = PostDatasetsByDatasetIdDocumentCreateByFile2Errors[keyof PostDatasetsByDatasetIdDocumentCreateByFile2Errors]
 
 export type PostDatasetsByDatasetIdDocumentCreateByFile2Responses = {
-  200: DocumentAndBatchResponse
+  200: {
+    [key: string]: unknown
+  }
 }
 
 export type PostDatasetsByDatasetIdDocumentCreateByFile2Response

--- a/packages/contracts/generated/api/service/zod.gen.ts
+++ b/packages/contracts/generated/api/service/zod.gen.ts
@@ -1682,11 +1682,6 @@ export const zPostDatasetsByDatasetIdDocumentCreateByTextPath = z.object({
  */
 export const zPostDatasetsByDatasetIdDocumentCreateByTextResponse = zDocumentAndBatchResponse
 
-export const zPostDatasetsByDatasetIdDocumentCreateByFile2Body = z.object({
-  data: z.string().optional(),
-  file: z.custom<Blob | File>(),
-})
-
 export const zPostDatasetsByDatasetIdDocumentCreateByFile2Path = z.object({
   dataset_id: z.string(),
 })
@@ -1694,7 +1689,10 @@ export const zPostDatasetsByDatasetIdDocumentCreateByFile2Path = z.object({
 /**
  * Document created successfully
  */
-export const zPostDatasetsByDatasetIdDocumentCreateByFile2Response = zDocumentAndBatchResponse
+export const zPostDatasetsByDatasetIdDocumentCreateByFile2Response = z.record(
+  z.string(),
+  z.unknown(),
+)
 
 export const zPostDatasetsByDatasetIdDocumentCreateByText2Body = zDocumentTextCreatePayload
 


### PR DESCRIPTION
## Summary
- split the legacy `create_by_file` Service API route into its own deprecated resource class
- keep the canonical `create-by-file` route on the non-deprecated resource
- share the existing file-upload implementation between both routes and add a focused deprecation assertion

## Tests
- `python3 -m py_compile api/controllers/service_api/dataset/document.py`
- `python3 -m py_compile api/tests/unit_tests/controllers/service_api/dataset/test_document.py`
- `python3 -m pytest api/tests/unit_tests/controllers/service_api/dataset/test_document.py::TestDocumentRouteDeprecation -q` *(fails locally: missing `werkzeug` in this environment)*
