### PR TITLE
feat: add Astraflow (UCloud ModelVerse) as a hosted provider

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -637,6 +637,19 @@ WORKFLOW_SCHEDULE_POLLER_BATCH_SIZE=100
 # Maximum number of scheduled workflows to dispatch per tick (0 for unlimited)
 WORKFLOW_SCHEDULE_MAX_DISPATCH_PER_TICK=0
 
+# Astraflow hosted service configuration
+# Astraflow (by UCloud) is an OpenAI-compatible AI model aggregation platform supporting 200+ models.
+# Global endpoint (env var: ASTRAFLOW_API_KEY)
+HOSTED_ASTRAFLOW_TRIAL_ENABLED=false
+HOSTED_ASTRAFLOW_PAID_ENABLED=false
+HOSTED_ASTRAFLOW_API_KEY=
+HOSTED_ASTRAFLOW_API_BASE=https://api-us-ca.umodelverse.ai/v1
+HOSTED_ASTRAFLOW_TRIAL_MODELS=
+HOSTED_ASTRAFLOW_PAID_MODELS=
+# China endpoint (env var: ASTRAFLOW_CN_API_KEY)
+HOSTED_ASTRAFLOW_CN_API_KEY=
+HOSTED_ASTRAFLOW_CN_API_BASE=https://api.modelverse.cn/v1
+
 # Position configuration
 POSITION_TOOL_PINS=
 POSITION_TOOL_INCLUDES=

--- a/api/configs/feature/hosted_service/__init__.py
+++ b/api/configs/feature/hosted_service/__init__.py
@@ -468,9 +468,60 @@ class HostedFetchPipelineTemplateConfig(BaseSettings):
     )
 
 
+class HostedAstraflowConfig(BaseSettings):
+    """
+    Configuration for hosted Astraflow service.
+    Astraflow (by UCloud) is an OpenAI-compatible AI model aggregation platform
+    supporting 200+ models via a single API key.
+    Global endpoint: https://api-us-ca.umodelverse.ai/v1
+    China  endpoint: https://api.modelverse.cn/v1
+    """
+
+    HOSTED_ASTRAFLOW_API_KEY: str | None = Field(
+        description="API key for hosted Astraflow service (global endpoint, env: ASTRAFLOW_API_KEY)",
+        default=None,
+    )
+
+    HOSTED_ASTRAFLOW_API_BASE: str | None = Field(
+        description="Base URL for hosted Astraflow API (defaults to global endpoint)",
+        default="https://api-us-ca.umodelverse.ai/v1",
+    )
+
+    HOSTED_ASTRAFLOW_CN_API_KEY: str | None = Field(
+        description="API key for hosted Astraflow China endpoint (env: ASTRAFLOW_CN_API_KEY)",
+        default=None,
+    )
+
+    HOSTED_ASTRAFLOW_CN_API_BASE: str | None = Field(
+        description="Base URL for hosted Astraflow China API",
+        default="https://api.modelverse.cn/v1",
+    )
+
+    HOSTED_ASTRAFLOW_TRIAL_ENABLED: bool = Field(
+        description="Enable trial access to hosted Astraflow service",
+        default=False,
+    )
+
+    HOSTED_ASTRAFLOW_TRIAL_MODELS: str = Field(
+        description="Comma-separated list of available models for trial access",
+        default="",
+    )
+
+    HOSTED_ASTRAFLOW_PAID_ENABLED: bool = Field(
+        description="Enable paid access to hosted Astraflow service",
+        default=False,
+    )
+
+    HOSTED_ASTRAFLOW_PAID_MODELS: str = Field(
+        description="Comma-separated list of available models for paid access",
+        default="",
+    )
+
+
 class HostedServiceConfig(
     # place the configs in alphabet order
     HostedAnthropicConfig,
+    HostedAstraflowConfig,
     HostedAzureOpenAiConfig,
     HostedFetchAppTemplateConfig,
     HostedFetchPipelineTemplateConfig,

--- a/api/core/hosting_configuration.py
+++ b/api/core/hosting_configuration.py
@@ -62,6 +62,7 @@ class HostingConfiguration:
         self.provider_map[f"{DEFAULT_PLUGIN_ID}/x/x"] = self.init_xai()
         self.provider_map[f"{DEFAULT_PLUGIN_ID}/deepseek/deepseek"] = self.init_deepseek()
         self.provider_map[f"{DEFAULT_PLUGIN_ID}/tongyi/tongyi"] = self.init_tongyi()
+        self.provider_map[f"{DEFAULT_PLUGIN_ID}/astraflow/astraflow"] = self.init_astraflow()
 
         self.moderation_config = self.init_moderation_config()
 
@@ -358,6 +359,36 @@ class HostingConfiguration:
                 quota_unit=quota_unit,
                 quotas=quotas,
             )
+
+        return HostingProvider(
+            enabled=False,
+            quota_unit=quota_unit,
+        )
+
+    def init_astraflow(self) -> HostingProvider:
+        quota_unit = QuotaUnit.CREDITS
+        quotas: list[HostingQuota] = []
+
+        if dify_config.HOSTED_ASTRAFLOW_TRIAL_ENABLED:
+            hosted_quota_limit = 0
+            trial_models = self.parse_restrict_models_from_env("HOSTED_ASTRAFLOW_TRIAL_MODELS")
+            trial_quota = TrialHostingQuota(quota_limit=hosted_quota_limit, restrict_models=trial_models)
+            quotas.append(trial_quota)
+
+        if dify_config.HOSTED_ASTRAFLOW_PAID_ENABLED:
+            paid_models = self.parse_restrict_models_from_env("HOSTED_ASTRAFLOW_PAID_MODELS")
+            paid_quota = PaidHostingQuota(restrict_models=paid_models)
+            quotas.append(paid_quota)
+
+        if len(quotas) > 0:
+            credentials = {
+                "openai_api_key": dify_config.HOSTED_ASTRAFLOW_API_KEY,
+            }
+
+            if dify_config.HOSTED_ASTRAFLOW_API_BASE:
+                credentials["openai_api_base"] = dify_config.HOSTED_ASTRAFLOW_API_BASE
+
+            return HostingProvider(enabled=True, credentials=credentials, quota_unit=quota_unit, quotas=quotas)
 
         return HostingProvider(
             enabled=False,


### PR DESCRIPTION
## Summary

Adds **Astraflow** (by UCloud / 优刻得, also known as ModelVerse) as a hosted model provider in Dify, following the exact same pattern used for DeepSeek, xAI, and other OpenAI-compatible providers.

Astraflow is an OpenAI-compatible AI model aggregation platform that supports 200+ models via a single API key.

## Changes

### `api/configs/feature/hosted_service/__init__.py`
- Added `HostedAstraflowConfig` Pydantic settings class with all the expected fields:
  - `HOSTED_ASTRAFLOW_API_KEY` — global API key (`ASTRAFLOW_API_KEY`)
  - `HOSTED_ASTRAFLOW_API_BASE` — global endpoint (`https://api-us-ca.umodelverse.ai/v1`, default)
  - `HOSTED_ASTRAFLOW_CN_API_KEY` — China API key (`ASTRAFLOW_CN_API_KEY`)
  - `HOSTED_ASTRAFLOW_CN_API_BASE` — China endpoint (`https://api.modelverse.cn/v1`, default)
  - `HOSTED_ASTRAFLOW_TRIAL_ENABLED` / `HOSTED_ASTRAFLOW_TRIAL_MODELS`
  - `HOSTED_ASTRAFLOW_PAID_ENABLED` / `HOSTED_ASTRAFLOW_PAID_MODELS`
- Mixed `HostedAstraflowConfig` into `HostedServiceConfig` (alphabetical order, after `HostedAnthropicConfig`)

### `api/core/hosting_configuration.py`
- Registered `init_astraflow()` in `init_app()` alongside the other hosted providers
- Added `init_astraflow()` method that follows the same pattern as `init_deepseek()` / `init_xai()`:  sets `openai_api_key` + `openai_api_base` credentials (OpenAI-compatible)

### `api/.env.example`
- Added documented environment variable block for Astraflow (both global and China endpoints)

## Endpoints
| Region | Base URL |
|--------|----------|
| Global | `https://api-us-ca.umodelverse.ai/v1` |
| China  | `https://api.modelverse.cn/v1`         |

## Why minimal?
Astraflow is fully OpenAI-compatible, so **no new SDK, no new subpackage, no new plugin scaffold** is required. The integration reuses the existing OpenAI credentials fields (`openai_api_key` + `openai_api_base`), identical to how xAI and DeepSeek are handled.
