### PR TITLE
fix(workflow): filter structured output picker search

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/variable/object-child-tree-panel/picker/__tests__/index.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/object-child-tree-panel/picker/__tests__/index.spec.tsx
@@ -1,0 +1,50 @@
+import type { StructuredOutput } from '../../../../../../llm/types'
+import { render, screen } from '@testing-library/react'
+import { Type } from '../../../../../../llm/types'
+import { PickerPanelMain } from '../index'
+
+vi.mock('ahooks', () => ({
+  useHover: vi.fn(),
+}))
+
+describe('PickerPanelMain', () => {
+  const payload: StructuredOutput = {
+    schema: {
+      type: Type.object,
+      additionalProperties: false,
+      properties: {
+        customer: {
+          type: Type.object,
+          properties: {
+            displayName: { type: Type.string },
+            metadata: {
+              type: Type.object,
+              properties: {
+                orderId: { type: Type.string },
+                irrelevantFlag: { type: Type.boolean },
+              },
+            },
+          },
+        },
+        unrelatedRoot: { type: Type.string },
+      },
+    },
+  }
+
+  it('filters structured fields to the subtree matched by the search text', () => {
+    render(
+      <PickerPanelMain
+        root={{ nodeId: 'node-a', nodeName: 'Node A', attrName: 'payload', attrAlias: 'object' }}
+        payload={payload}
+        searchText="order"
+      />,
+    )
+
+    expect(screen.getByText('customer')).toBeInTheDocument()
+    expect(screen.getByText('metadata')).toBeInTheDocument()
+    expect(screen.getByText('orderId')).toBeInTheDocument()
+    expect(screen.queryByText('displayName')).not.toBeInTheDocument()
+    expect(screen.queryByText('irrelevantFlag')).not.toBeInTheDocument()
+    expect(screen.queryByText('unrelatedRoot')).not.toBeInTheDocument()
+  })
+})

--- a/web/app/components/workflow/nodes/_base/components/variable/object-child-tree-panel/picker/index.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/object-child-tree-panel/picker/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 import type { FC } from 'react'
-import type { StructuredOutput } from '../../../../../llm/types'
+import type { Field as FieldType, StructuredOutput } from '../../../../../llm/types'
 import type { ValueSelector } from '@/app/components/workflow/types'
 import { cn } from '@langgenius/dify-ui/cn'
 import { useHover } from 'ahooks'
@@ -15,6 +15,46 @@ type Props = {
   readonly?: boolean
   onSelect?: (valueSelector: ValueSelector) => void
   onHovering?: (value: boolean) => void
+  searchText?: string
+}
+
+const includesSearchText = (value: string | undefined, searchText: string) => {
+  if (!value)
+    return false
+
+  return value.toLowerCase().includes(searchText)
+}
+
+const getFieldTypeText = (field: FieldType) => {
+  if (typeof field.type === 'string')
+    return field.type
+
+  return undefined
+}
+
+const filterFieldBySearchText = (name: string, field: FieldType, searchText: string): FieldType | undefined => {
+  if (!searchText)
+    return field
+
+  if (includesSearchText(name, searchText) || includesSearchText(getFieldTypeText(field), searchText))
+    return field
+
+  if (!field.properties)
+    return undefined
+
+  const filteredProperties = Object.fromEntries(
+    Object.entries(field.properties)
+      .map(([childName, childField]): [string, FieldType | undefined] => [childName, filterFieldBySearchText(childName, childField, searchText)])
+      .filter((entry): entry is [string, FieldType] => !!entry[1]),
+  )
+
+  if (Object.keys(filteredProperties).length === 0)
+    return undefined
+
+  return {
+    ...field,
+    properties: filteredProperties,
+  }
 }
 
 export const PickerPanelMain: FC<Props> = ({
@@ -24,6 +64,7 @@ export const PickerPanelMain: FC<Props> = ({
   readonly,
   onHovering,
   onSelect,
+  searchText = '',
 }) => {
   const ref = useRef<HTMLDivElement>(null)
   useHover(ref, {
@@ -39,7 +80,14 @@ export const PickerPanelMain: FC<Props> = ({
     },
   })
   const schema = payload.schema
-  const fieldNames = Object.keys(schema.properties)
+  const normalizedSearchText = searchText.trim().toLowerCase()
+  const allFields = Object.entries(schema.properties)
+  const filteredFields = normalizedSearchText
+    ? allFields
+      .map(([name, field]): [string, FieldType | undefined] => [name, filterFieldBySearchText(name, field, normalizedSearchText)])
+      .filter((entry): entry is [string, FieldType] => !!entry[1])
+    : allFields
+  const visibleFields = filteredFields.length > 0 ? filteredFields : allFields
   return (
     <div className={cn(className)} ref={ref}>
       {/* Root info */}
@@ -55,11 +103,11 @@ export const PickerPanelMain: FC<Props> = ({
         </div>
         <div className="ml-2 truncate system-xs-regular text-text-tertiary" title={root.attrAlias || 'object'}>{root.attrAlias || 'object'}</div>
       </div>
-      {fieldNames.map(name => (
+      {visibleFields.map(([name, field]) => (
         <Field
           key={name}
           name={name}
-          payload={schema.properties[name]!}
+          payload={field}
           readonly={readonly}
           valueSelector={[root.nodeId!, root.attrName]}
           onSelect={onSelect}

--- a/web/app/components/workflow/nodes/_base/components/variable/var-reference-vars.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/var-reference-vars.tsx
@@ -80,6 +80,7 @@ type ItemProps = {
   isInCodeGeneratorInstructionEditor?: boolean
   className?: string
   preferSchemaType?: boolean
+  searchText?: string
   isSelected?: boolean
   onActivate?: () => void
 }
@@ -98,6 +99,7 @@ const Item: FC<ItemProps> = ({
   isInCodeGeneratorInstructionEditor,
   className,
   preferSchemaType,
+  searchText = '',
   isSelected,
   onActivate,
 }) => {
@@ -269,6 +271,7 @@ const Item: FC<ItemProps> = ({
             root={{ nodeId, nodeName: title, attrName: itemData.variable, attrAlias: itemData.schemaType }}
             payload={structuredOutput!}
             onHovering={setIsChildrenHovering}
+            searchText={searchText}
             onSelect={(valueSelector) => {
               onChange(valueSelector, itemData)
             }}
@@ -482,6 +485,7 @@ const VarReferenceVars: FC<Props> = ({
                         isFlat={item.isFlat}
                         isInCodeGeneratorInstructionEditor={isInCodeGeneratorInstructionEditor}
                         preferSchemaType={preferSchemaType}
+                        searchText={searchValue}
                         isSelected={effectiveSelectedIndex === optionIndex}
                         onActivate={() => setSelectedIndex(optionIndex)}
                       />


### PR DESCRIPTION
## Summary

- Pass the active variable search text into the structured output picker.
- Recursively filter structured output fields so a nested match keeps only the matched subtree instead of showing unrelated sibling fields.
- Add a regression test for a nested `orderId` match that hides unrelated structured fields.

From Codex

## Screenshots

| Before | After |
|--------|-------|
| Structured output search could keep the parent row while the child picker still showed unrelated sibling fields. | The child picker is pruned to the matched nested subtree. |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Validation performed locally:

- `git diff --check`

Not run locally:

- `cd web && pnpm test app/components/workflow/nodes/_base/components/variable/object-child-tree-panel/picker/__tests__/index.spec.tsx` could not start because this checkout has no `node_modules`, and Corepack could not fetch `pnpm@11.0.8` in this environment.
