### PR TITLE
fix(workflow): open start selector after flag changes

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/__tests__/node-handle.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/components/__tests__/node-handle.spec.tsx
@@ -339,6 +339,29 @@ describe('node-handle', () => {
       expect(mockSetHasSelectedStartNode).toHaveBeenCalledWith(false)
     })
 
+    it('should open when the start selector flag changes after mount', () => {
+      const { rerender } = renderSourceHandle({ type: BlockEnum.Start })
+
+      expect(getAddNodeButton()).toHaveClass('opacity-0')
+
+      mockStoreState.shouldAutoOpenStartNodeSelector = true
+
+      rerender(
+        <NodeSourceHandle
+          id="source-node"
+          data={createNodeData({ type: BlockEnum.Start })}
+          handleId="source-handle"
+          nodeSelectorClassName="custom-selector"
+          handleClassName="custom-source-handle"
+        />,
+      )
+
+      expect(getAddNodeButton()).toHaveClass('opacity-100')
+      expect(getAddNodeButton()).toHaveClass('pointer-events-none')
+      expect(mockSetShouldAutoOpenStartNodeSelector).toHaveBeenCalledWith(false)
+      expect(mockSetHasSelectedStartNode).toHaveBeenCalledWith(false)
+    })
+
     it('should skip source auto-open in chat mode and only reset the start selector flag', () => {
       mockHooksState.isChatMode = true
       mockStoreState.shouldAutoOpenStartNodeSelector = true

--- a/web/app/components/workflow/nodes/_base/components/node-handle.tsx
+++ b/web/app/components/workflow/nodes/_base/components/node-handle.tsx
@@ -181,6 +181,8 @@ export const NodeSourceHandle = memo(({
     }
 
     if (canAutoOpenStartNodeSelector(data.type, false)) {
+      setOpen(true)
+
       if (setShouldAutoOpenStartNodeSelector)
         setShouldAutoOpenStartNodeSelector(false)
       else


### PR DESCRIPTION
## Summary

- Re-open the source-handle block selector when `shouldAutoOpenStartNodeSelector` changes to true after `NodeSourceHandle` has already mounted.
- Keep the existing flag-reset behavior after the selector is opened.
- Add a regression test for the false-to-true store flag transition.

From Codex

## Screenshots

| Before | After |
|--------|-------|
| If the auto-open flag changed after mount, the effect consumed the flag but the add-node selector stayed closed. | The selector opens before the flag is reset. |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Validation performed locally:

- `git diff --check`

Not run locally:

- `cd web && pnpm test app/components/workflow/nodes/_base/components/__tests__/node-handle.spec.tsx` could not start because this checkout has no `node_modules`, and Corepack could not fetch `pnpm@11.0.8` in this environment.
