### PR TITLE
chore(web): remove drawer overlay import restriction

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -14,7 +14,6 @@ import {
   GENERATED_IGNORES,
   HYOBAN_PREFER_TAILWIND_ICONS_OPTIONS,
   NEXT_PLATFORM_RESTRICTED_IMPORT_PATHS,
-  OVERLAY_RESTRICTED_IMPORT_PATTERNS,
   WEB_RESTRICTED_IMPORT_PATTERNS,
 } from './eslint.constants.mjs'
 import dify from './plugins/eslint/index.js'
@@ -168,23 +167,6 @@ export default antfu(
       'no-restricted-imports': ['error', {
         paths: NEXT_PLATFORM_RESTRICTED_IMPORT_PATHS,
         patterns: WEB_RESTRICTED_IMPORT_PATTERNS,
-      }],
-    },
-  },
-  {
-    name: 'dify/overlay-import-policy',
-    files: [GLOB_TS, GLOB_TSX],
-    ignores: [
-      'next/**',
-      ...GLOB_TESTS,
-    ],
-    rules: {
-      'no-restricted-imports': ['error', {
-        paths: NEXT_PLATFORM_RESTRICTED_IMPORT_PATHS,
-        patterns: [
-          ...WEB_RESTRICTED_IMPORT_PATTERNS,
-          ...OVERLAY_RESTRICTED_IMPORT_PATTERNS,
-        ],
       }],
     },
   },

--- a/web/eslint.constants.mjs
+++ b/web/eslint.constants.mjs
@@ -54,16 +54,6 @@ export const WEB_RESTRICTED_IMPORT_PATTERNS = [
   ...FLOATING_UI_RESTRICTED_IMPORT_PATTERNS,
 ]
 
-export const OVERLAY_RESTRICTED_IMPORT_PATTERNS = [
-  {
-    group: [
-      '**/base/drawer',
-      '**/base/drawer/index',
-    ],
-    message: 'Deprecated: use @langgenius/dify-ui/drawer instead. See issue #32767.',
-  },
-]
-
 export const HYOBAN_PREFER_TAILWIND_ICONS_OPTIONS = {
   prefix: 'i-',
   propMappings: {


### PR DESCRIPTION
## Summary
- remove the drawer-only overlay restricted import pattern from ESLint constants
- drop the now-redundant overlay import policy ESLint config block

## Testing
- pnpm --dir web exec eslint eslint.config.mjs eslint.constants.mjs