### PR TITLE
fix: handle agent_message and message events in MCP streaming response

### DIFF
--- a/api/core/mcp/server/streamable_http.py
+++ b/api/core/mcp/server/streamable_http.py
@@ -304,16 +304,22 @@ def extract_answer_from_response(app: App, response: Any) -> str:
 def process_streaming_response(response: RateLimitGenerator) -> str:
     """Process streaming response for agent chat mode"""
     answer = ""
+    last_thought = ""
     for item in response.generator:
         if isinstance(item, str) and item.startswith("data: "):
             try:
                 json_str = item[6:].strip()
                 parsed_data = json.loads(json_str)
-                if parsed_data.get("event") == "agent_thought":
-                    answer += parsed_data.get("thought", "")
+                event = parsed_data.get("event")
+                if event in ("message", "agent_message"):
+                    answer += parsed_data.get("answer", "")
+                elif event == "agent_thought":
+                    thought = parsed_data.get("thought", "")
+                    if thought:
+                        last_thought = thought
             except json.JSONDecodeError:
                 continue
-    return answer
+    return answer or last_thought
 
 
 def process_mapping_response(app: App, response: Mapping) -> str:

--- a/api/core/mcp/server/streamable_http.py
+++ b/api/core/mcp/server/streamable_http.py
@@ -46,6 +46,11 @@ def negotiate_protocol_version(header_value: str | None, is_initialize: bool) ->
     return header_value
 
 
+_EVENT_MESSAGE = "message"
+_EVENT_AGENT_MESSAGE = "agent_message"
+_EVENT_AGENT_THOUGHT = "agent_thought"
+
+
 class ToolParameterSchemaDict(TypedDict):
     type: str
     properties: dict[str, Any]
@@ -311,9 +316,9 @@ def process_streaming_response(response: RateLimitGenerator) -> str:
                 json_str = item[6:].strip()
                 parsed_data = json.loads(json_str)
                 event = parsed_data.get("event")
-                if event in ("message", "agent_message"):
+                if event in (_EVENT_MESSAGE, _EVENT_AGENT_MESSAGE):
                     answer += parsed_data.get("answer", "")
-                elif event == "agent_thought":
+                elif event == _EVENT_AGENT_THOUGHT:
                     thought = parsed_data.get("thought", "")
                     if thought:
                         last_thought = thought

--- a/api/core/mcp/server/streamable_http.py
+++ b/api/core/mcp/server/streamable_http.py
@@ -18,6 +18,10 @@ logger = logging.getLogger(__name__)
 # Structured tool output (outputSchema + structuredContent) was introduced in MCP 2025-06-18.
 STRUCTURED_OUTPUT_MIN_VERSION = "2025-06-18"
 
+_EVENT_MESSAGE = "message"
+_EVENT_AGENT_MESSAGE = "agent_message"
+_EVENT_AGENT_THOUGHT = "agent_thought"
+
 
 def _supports_structured_output(protocol_version: str) -> bool:
     """Return True when the negotiated protocol version supports structured tool output.
@@ -311,9 +315,9 @@ def process_streaming_response(response: RateLimitGenerator) -> str:
                 json_str = item[6:].strip()
                 parsed_data = json.loads(json_str)
                 event = parsed_data.get("event")
-                if event in ("message", "agent_message"):
+                if event in (_EVENT_MESSAGE, _EVENT_AGENT_MESSAGE):
                     answer += parsed_data.get("answer", "")
-                elif event == "agent_thought":
+                elif event == _EVENT_AGENT_THOUGHT:
                     thought = parsed_data.get("thought", "")
                     if thought:
                         last_thought = thought

--- a/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
+++ b/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
@@ -595,6 +595,49 @@ class TestUtilityFunctions:
 
         assert extract_structured_output(app, {"answer": "hi"}, "hi") is None
 
+    def test_extract_answer_prefers_agent_message_over_thought(self):
+        """Test that agent_message and message events take priority over agent_thought fallback"""
+        app = Mock(spec=App)
+
+        mock_generator = Mock(spec=RateLimitGenerator)
+        mock_generator.generator = [
+            'data: {"event": "agent_thought", "thought": "internal thinking"}',
+            'data: {"event": "agent_message", "answer": "Hello "}',
+            'data: {"event": "agent_message", "answer": "world"}',
+        ]
+
+        result = extract_answer_from_response(app, mock_generator)
+
+        assert result == "Hello world"
+
+    def test_extract_answer_uses_message_event(self):
+        """Test that message events are collected into the answer"""
+        app = Mock(spec=App)
+
+        mock_generator = Mock(spec=RateLimitGenerator)
+        mock_generator.generator = [
+            'data: {"event": "message", "answer": "part1 "}',
+            'data: {"event": "message", "answer": "part2"}',
+        ]
+
+        result = extract_answer_from_response(app, mock_generator)
+
+        assert result == "part1 part2"
+
+    def test_extract_answer_falls_back_to_last_thought_when_no_answer(self):
+        """Test fallback to last agent_thought when no answer events are present"""
+        app = Mock(spec=App)
+
+        mock_generator = Mock(spec=RateLimitGenerator)
+        mock_generator.generator = [
+            'data: {"event": "agent_thought", "thought": "first thought"}',
+            'data: {"event": "agent_thought", "thought": "final thought"}',
+        ]
+
+        result = extract_answer_from_response(app, mock_generator)
+
+        assert result == "final thought"
+
     def test_process_mapping_response_invalid_mode(self):
         """Test processing mapping response with invalid app mode"""
         app = Mock(spec=App)

--- a/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
+++ b/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
@@ -534,7 +534,8 @@ class TestUtilityFunctions:
 
         result = extract_answer_from_response(app, mock_generator)
 
-        assert result == "thinking...more thinking"
+        # fallback returns the last agent_thought when no answer events are present
+        assert result == "more thinking"
 
     def test_extract_structured_output_workflow(self):
         """Workflow mode exposes the raw outputs mapping as structured content."""

--- a/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
+++ b/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
@@ -608,6 +608,49 @@ class TestUtilityFunctions:
 
         assert extract_structured_output(app, {"answer": "hi"}, "hi") is None
 
+    def test_extract_answer_prefers_agent_message_over_thought(self):
+        """Test that agent_message and message events take priority over agent_thought fallback"""
+        app = Mock(spec=App)
+
+        mock_generator = Mock(spec=RateLimitGenerator)
+        mock_generator.generator = [
+            'data: {"event": "agent_thought", "thought": "internal thinking"}',
+            'data: {"event": "agent_message", "answer": "Hello "}',
+            'data: {"event": "agent_message", "answer": "world"}',
+        ]
+
+        result = extract_answer_from_response(app, mock_generator)
+
+        assert result == "Hello world"
+
+    def test_extract_answer_uses_message_event(self):
+        """Test that message events are collected into the answer"""
+        app = Mock(spec=App)
+
+        mock_generator = Mock(spec=RateLimitGenerator)
+        mock_generator.generator = [
+            'data: {"event": "message", "answer": "part1 "}',
+            'data: {"event": "message", "answer": "part2"}',
+        ]
+
+        result = extract_answer_from_response(app, mock_generator)
+
+        assert result == "part1 part2"
+
+    def test_extract_answer_falls_back_to_last_thought_when_no_answer(self):
+        """Test fallback to last agent_thought when no answer events are present"""
+        app = Mock(spec=App)
+
+        mock_generator = Mock(spec=RateLimitGenerator)
+        mock_generator.generator = [
+            'data: {"event": "agent_thought", "thought": "first thought"}',
+            'data: {"event": "agent_thought", "thought": "final thought"}',
+        ]
+
+        result = extract_answer_from_response(app, mock_generator)
+
+        assert result == "final thought"
+
     def test_process_mapping_response_invalid_mode(self):
         """Test processing mapping response with invalid app mode"""
         app = App(

--- a/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
+++ b/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
@@ -539,7 +539,8 @@ class TestUtilityFunctions:
 
         result = extract_answer_from_response(app, mock_generator)
 
-        assert result == "thinking...more thinking"
+        # fallback returns the last agent_thought when no answer events are present
+        assert result == "more thinking"
 
     def test_extract_structured_output_workflow(self):
         """Workflow mode exposes the raw outputs mapping as structured content."""


### PR DESCRIPTION
Fixes #32526.

`process_streaming_response()` only collected `agent_thought` text, so agent-chat mode MCP responses always returned empty strings. The actual answer tokens stream as `agent_message` and `message` events, which were silently ignored.

Added handling for `message` and `agent_message` as the primary answer source, with `agent_thought` as fallback when no answer events are present. Extracted event names as module-level constants per the code review on the original PR #32541.

This is a rebased version of #32541 which was too far behind main to rebase cleanly.