### PR TITLE
fix: stop auth header prefix accumulating on repeated Custom Tool calls

### DIFF
--- a/api/core/tools/custom_tool/tool.py
+++ b/api/core/tools/custom_tool/tool.py
@@ -100,16 +100,17 @@ class ApiTool(Tool):
             elif not isinstance(credentials["api_key_value"], str):
                 raise ToolProviderCredentialValidationError("api_key_value must be a string")
 
+            api_key_value = credentials["api_key_value"]
             if "api_key_header_prefix" in credentials:
                 api_key_header_prefix = credentials["api_key_header_prefix"]
-                if api_key_header_prefix == "basic" and credentials["api_key_value"]:
-                    credentials["api_key_value"] = f"Basic {credentials['api_key_value']}"
-                elif api_key_header_prefix == "bearer" and credentials["api_key_value"]:
-                    credentials["api_key_value"] = f"Bearer {credentials['api_key_value']}"
+                if api_key_header_prefix == "basic" and api_key_value:
+                    api_key_value = f"Basic {api_key_value}"
+                elif api_key_header_prefix == "bearer" and api_key_value:
+                    api_key_value = f"Bearer {api_key_value}"
                 elif api_key_header_prefix == "custom":
                     pass
 
-            headers[api_key_header] = credentials["api_key_value"]
+            headers[api_key_header] = api_key_value
 
         elif credentials["auth_type"] == "api_key_query":
             # For query parameter authentication, we don't add anything to headers

--- a/api/tests/unit_tests/core/tools/test_custom_tool.py
+++ b/api/tests/unit_tests/core/tools/test_custom_tool.py
@@ -91,6 +91,33 @@ def test_assembling_request_auth_header_assembly():
     assert tool.assembling_request(parameters={}) == {}
 
 
+def test_assembling_request_auth_header_prefix_no_accumulation():
+    """Regression test for #35974: calling assembling_request multiple times
+    must not accumulate Bearer/Basic prefixes on the stored credential."""
+    tool = _build_tool()
+    tool.runtime.credentials = {
+        "auth_type": "api_key_header",
+        "api_key_header_prefix": "bearer",
+        "api_key_value": "my-token",
+    }
+
+    # Call 3 times — header must always be "Bearer my-token", never accumulate
+    for _ in range(3):
+        headers = tool.assembling_request(parameters={})
+        assert headers["Authorization"] == "Bearer my-token"
+
+    # Verify the stored credential was NOT mutated
+    assert tool.runtime.credentials["api_key_value"] == "my-token"
+
+    # Same for "basic" prefix
+    tool.runtime.credentials["api_key_header_prefix"] = "basic"
+    tool.runtime.credentials["api_key_value"] = "abc"
+    for _ in range(3):
+        headers = tool.assembling_request(parameters={})
+        assert headers["Authorization"] == "Basic abc"
+    assert tool.runtime.credentials["api_key_value"] == "abc"
+
+
 def test_assembling_request_runtime_auth_errors():
     tool = _build_tool()
 


### PR DESCRIPTION
Fixes #35974

## Problem

When a Custom Tool uses API Key authentication with a Bearer or Basic prefix, `assembling_request` mutates `runtime.credentials` in-place, prepending the prefix to `api_key_value` on every call.

Subsequent invocations read the already-prefixed value and prefix it again:

| Call | Stored `api_key_value` | Sent header |
|------|----------------------|-------------|
| 1 | `Bearer my-token` | `Bearer my-token` |
| 2 | `Bearer Bearer my-token` | `Bearer Bearer my-token` |
| 3 | `Bearer Bearer Bearer my-token` | `Bearer Bearer Bearer my-token` |

This causes 401/403 on any repeated tool invocation (agents, workflow loops, retries, parallel branches).

## Fix

Use a local variable `api_key_value` instead of writing back to `credentials["api_key_value"]`, so the stored credential is never mutated.

```python
# before
credentials["api_key_value"] = f"Bearer {credentials['api_key_value']}"
headers[api_key_header] = credentials["api_key_value"]

# after
api_key_value = credentials["api_key_value"]
api_key_value = f"Bearer {api_key_value}"
headers[api_key_header] = api_key_value
```

## Testing

Added `test_assembling_request_auth_header_prefix_no_accumulation` which:
- Calls `assembling_request` 3 times with bearer prefix, asserts header is always `Bearer my-token`
- Verifies stored `credentials["api_key_value"]` is not mutated
- Repeats for `basic` prefix

All 10 tests pass.