### PR TITLE
fix: preserve annotation reply metadata

### DIFF
--- a/api/core/app/apps/advanced_chat/generate_task_pipeline.py
+++ b/api/core/app/apps/advanced_chat/generate_task_pipeline.py
@@ -1078,9 +1078,6 @@ class AdvancedChatAppGenerateTaskPipeline(GraphRuntimeStateSupport):
         """
         extras = self._task_state.metadata.model_dump()
 
-        if self._task_state.metadata.annotation_reply:
-            del extras["annotation_reply"]
-
         return MessageEndStreamResponse(
             task_id=self._application_generate_entity.task_id,
             id=self._message_id,

--- a/api/core/app/apps/base_app_generate_response_converter.py
+++ b/api/core/app/apps/base_app_generate_response_converter.py
@@ -99,10 +99,6 @@ class AppGenerateResponseConverter[TBlockingResponse: AppBlockingResponse](ABC):
                 )
             metadata["retriever_resources"] = updated_resources
 
-        # show annotation reply
-        if "annotation_reply" in metadata:
-            del metadata["annotation_reply"]
-
         # show usage
         if "usage" in metadata:
             del metadata["usage"]

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py
@@ -264,7 +264,7 @@ class TestAdvancedChatGenerateTaskPipeline:
         assert "UPDATE messages" in stmt_str
         assert "WHERE messages.id" in stmt_str
 
-    def test_message_end_to_stream_response_strips_annotation_reply(self):
+    def test_message_end_to_stream_response_preserves_annotation_reply(self):
         pipeline = _make_pipeline()
         pipeline._task_state.metadata.annotation_reply = AnnotationReply(
             id="ann",
@@ -273,7 +273,13 @@ class TestAdvancedChatGenerateTaskPipeline:
 
         response = pipeline._message_end_to_stream_response()
 
-        assert "annotation_reply" not in response.metadata
+        # annotation_reply must be preserved so the frontend can detect annotation hits
+        # and clear the "stop responding" state on message_end. Stripping it here was the
+        # root cause of the chatflow stop-button-stuck-on-annotation-hit bug.
+        assert response.metadata["annotation_reply"] == {
+            "id": "ann",
+            "account": {"id": "acc", "name": "acc"},
+        }
 
     def test_handle_output_moderation_chunk_publishes_stop(self):
         pipeline = _make_pipeline()

--- a/api/tests/unit_tests/core/app/apps/agent_chat/test_agent_chat_generate_response_converter.py
+++ b/api/tests/unit_tests/core/app/apps/agent_chat/test_agent_chat_generate_response_converter.py
@@ -71,7 +71,9 @@ class TestAgentChatAppGenerateResponseConverterBlocking:
 
         result = AgentChatAppGenerateResponseConverter.convert_blocking_simple_response(blocking)
 
-        assert "annotation_reply" not in result["metadata"]
+        # annotation_reply must be preserved so the frontend can detect annotation hits
+        # and clear the "stop responding" state on message_end.
+        assert result["metadata"]["annotation_reply"] == {"id": "a"}
         assert "usage" not in result["metadata"]
 
     def test_convert_blocking_simple_response_with_non_dict_metadata(self):
@@ -169,7 +171,9 @@ class TestAgentChatAppGenerateResponseConverterStream:
         assert items[2]["event"] == "message_end"
         assert "metadata" in items[2]
         metadata = items[2]["metadata"]
-        assert "annotation_reply" not in metadata
+        # annotation_reply must be preserved so the frontend can detect annotation hits
+        # and clear the "stop responding" state on message_end.
+        assert metadata["annotation_reply"] == {"id": "a"}
         assert "usage" not in metadata
         assert metadata["retriever_resources"] == [
             {

--- a/api/tests/unit_tests/core/app/apps/completion/test_completion_generate_response_converter.py
+++ b/api/tests/unit_tests/core/app/apps/completion/test_completion_generate_response_converter.py
@@ -75,7 +75,9 @@ class TestCompletionAppGenerateResponseConverter:
 
         result = CompletionAppGenerateResponseConverter.convert_blocking_simple_response(blocking)
 
-        assert "annotation_reply" not in result["metadata"]
+        # annotation_reply must be preserved so the frontend can detect annotation hits
+        # and clear the "stop responding" state on message_end.
+        assert result["metadata"]["annotation_reply"] == {"a": 1}
         assert "usage" not in result["metadata"]
         assert result["metadata"]["retriever_resources"][0]["dataset_id"] == "dataset-1"
         assert result["metadata"]["retriever_resources"][0]["document_id"] == "document-1"
@@ -164,6 +166,8 @@ class TestCompletionAppGenerateResponseConverter:
 
         assert result[0] == "ping"
         assert result[1]["event"] == "message_end"
-        assert "annotation_reply" not in result[1]["metadata"]
+        # annotation_reply must be preserved so the frontend can detect annotation hits
+        # and clear the "stop responding" state on message_end.
+        assert result[1]["metadata"]["annotation_reply"] == {"a": 1}
         assert "usage" not in result[1]["metadata"]
         assert result[2]["event"] == "error"


### PR DESCRIPTION
## Summary

Preserve `metadata.annotation_reply` in simple app responses and advanced-chat `message_end` responses.

This lets the web client reliably detect annotation-reply hits, clear the responding state, and attach annotation metadata such as the annotation id and author name.

## Root Cause

For annotation replies in chatflow / advanced-chat, the backend publishes an annotation reply event and then stops without running the workflow. The frontend already has logic to handle `messageEnd.metadata.annotation_reply`, but the backend strips that field before the final `message_end` response reaches the client:

- `AppGenerateResponseConverter._get_simple_metadata` deletes `metadata["annotation_reply"]` for simple public/webapp responses.
- `AdvancedChatAppGenerateTaskPipeline._message_end_to_stream_response` deletes `extras["annotation_reply"]` before conversion.

As a result, the web client cannot enter its annotation-reply completion branch, which can leave the UI in a responding/stop-button state and also prevents annotation author metadata from being shown.

This is related to #33103. The existing frontend-side fix helps clear responding state, but preserving the backend metadata keeps the API response contract consistent and allows the existing annotation metadata UI path to work.

## Changes

- Stop stripping `annotation_reply` from simple response metadata.
- Stop stripping `annotation_reply` from advanced-chat `message_end` metadata.
- Update unit tests to assert that annotation metadata is preserved.

## Validation

Ran:

```bash
env UV_CACHE_DIR=.uv-cache uv run --project api pytest -o addopts='' \
  api/tests/unit_tests/core/app/apps/agent_chat/test_agent_chat_generate_response_converter.py \
  api/tests/unit_tests/core/app/apps/completion/test_completion_generate_response_converter.py \
  api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py
```

Result: `33 passed, 2 warnings`.

Note: `-o addopts=''` was used locally because the test environment did not have the coverage plugin required by the repository default pytest addopts.