### PR TITLE
fix(web): align tag filter dropdown icon

### DIFF
--- a/web/features/tag-management/components/tag-filter.tsx
+++ b/web/features/tag-management/components/tag-filter.tsx
@@ -78,11 +78,11 @@ export const TagFilter = ({
             !!value.length && 'pr-6 shadow-xs',
           )}
         >
-          <span className="flex min-w-0 items-center gap-1">
+          <span className="flex w-full min-w-0 items-center gap-1">
             <span className="p-px">
               <Tag01Icon className="h-3.5 w-3.5 text-text-tertiary" aria-hidden="true" />
             </span>
-            <span className="min-w-0 truncate text-[13px] leading-4.5 text-text-secondary">
+            <span className="min-w-0 grow truncate text-[13px] leading-4.5 text-text-secondary">
               {!value.length && t('tag.placeholder', { ns: 'common' })}
               {!!value.length && currentTagName}
             </span>


### PR DESCRIPTION
## Summary
- keep the tag filter trigger width stable while allowing the label area to fill available space
- align the dropdown icon to the right edge for the empty tag filter state

## Testing
- pnpm --dir web exec eslint --cache features/tag-management/components/tag-filter.tsx
- git diff --check