### PR TITLE
refactor(apps): simplify query state and debounce URL writes

### DIFF
--- a/.agents/skills/how-to-write-component/SKILL.md
+++ b/.agents/skills/how-to-write-component/SKILL.md
@@ -23,17 +23,6 @@ Use this as the decision guide for React/TypeScript component structure. Existin
 - Keep callbacks in a parent only for workflow coordination such as form submission, shared selection, batch behavior, or navigation. Otherwise let the child or row own its action.
 - Prefer uncontrolled DOM state and CSS variables before adding controlled props.
 
-## State And URL State
-
-- Keep one source of truth for each user-editable value. If URL state, form state, Jotai, TanStack Query, or another owner already controls a value, do not mirror it into `useState` just to make an input responsive.
-- Use derived values for delayed consumers. For search inputs backed by URL state, bind the input to the URL state directly, then debounce the value consumed by TanStack Query or expensive rendering with `useDebounce`/`useDeferredValue` instead of maintaining a second submitted state.
-- Do not use `useEffect` to copy one state variable into another state variable that represents the same concept. An effect whose main job is `setLocal(external)` usually means the ownership model is wrong.
-- For `nuqs`, define a parser map at the feature hook boundary, use `inferParserType`, prefer `.withDefault(...)` to remove nullable cleanup code, and put parser-specific options on the parser when they always apply to that key.
-- Treat `nuqs` `limitUrlUpdates` as URL/history rate limiting only. The hook state still updates immediately; debounce client-side fetching separately when TanStack Query consumes the value.
-- Let search/text input URL updates use the default `replace` history unless the product explicitly wants each keystroke to create history entries. Use `history: 'push'` only for discrete navigation-like changes such as tabs or committed filters.
-- Avoid hook-level `history: 'push'` when the same `useQueryStates` parser map includes high-frequency search keys. Put `push` on the specific setter call that needs it.
-- Expose feature-specific URL state actions such as `setKeywords`, `setTagIDs`, or `setSort`, not a generic `setQuery`, unless callers truly need arbitrary atomic multi-key updates.
-
 ## Components, Props, And Types
 
 - Type component signatures directly; do not use `FC` or `React.FC`.
@@ -66,10 +55,17 @@ Use this as the decision guide for React/TypeScript component structure. Existin
 - Avoid unnecessary DOM hierarchy. Do not add wrapper elements unless they provide layout, semantics, accessibility, state ownership, or integration with a library API; prefer fragments or styling an existing element when possible.
 - Avoid shallow wrappers and prop renaming unless the wrapper adds validation, orchestration, error handling, state ownership, or a real semantic boundary.
 
-## Navigation, Effects, And Performance
+## You Might Not Need An Effect
+
+- Use Effects only to synchronize with external systems such as browser APIs, non-React widgets, subscriptions, timers, analytics that must run because the component was shown, or imperative DOM integration.
+- Do not use Effects to transform props or state for rendering. Calculate derived values during render, and use `useMemo` only when the calculation is actually expensive.
+- Do not use Effects to handle user actions. Put action-specific logic in the event handler where the cause is known.
+- Do not use Effects to copy one state value into another state value representing the same concept. Pick one source of truth and derive the rest during render.
+- Do not reset or adjust state from props with an Effect. Prefer a `key` reset, storing a stable ID and deriving the selected object, or guarded same-component render-time adjustment when truly necessary.
+- Prefer framework data APIs or TanStack Query for data fetching instead of writing request Effects in components.
+- If an Effect still seems necessary, first name the external system it synchronizes with. If there is no external system, remove the Effect and restructure the state or event flow.
+
+## Navigation And Performance
 
 - Prefer `Link` for normal navigation. Use router APIs only for command-flow side effects such as mutation success, guarded redirects, or form submission.
-- Treat `useEffect` as a last resort. First try deriving values during render, moving event-driven work into handlers, or using existing hooks/APIs for persistence, subscriptions, media queries, timers, and DOM sync.
-- Before adding an effect to synchronize state, identify the source of truth and check whether the consumer can read that state directly or read a derived value during render.
-- Do not use `useEffect` directly in components. If unavoidable, encapsulate it in a purpose-built hook so the component consumes a declarative API.
 - Avoid `memo`, `useMemo`, and `useCallback` unless there is a clear performance reason.

--- a/.agents/skills/how-to-write-component/SKILL.md
+++ b/.agents/skills/how-to-write-component/SKILL.md
@@ -23,6 +23,17 @@ Use this as the decision guide for React/TypeScript component structure. Existin
 - Keep callbacks in a parent only for workflow coordination such as form submission, shared selection, batch behavior, or navigation. Otherwise let the child or row own its action.
 - Prefer uncontrolled DOM state and CSS variables before adding controlled props.
 
+## State And URL State
+
+- Keep one source of truth for each user-editable value. If URL state, form state, Jotai, TanStack Query, or another owner already controls a value, do not mirror it into `useState` just to make an input responsive.
+- Use derived values for delayed consumers. For search inputs backed by URL state, bind the input to the URL state directly, then debounce the value consumed by TanStack Query or expensive rendering with `useDebounce`/`useDeferredValue` instead of maintaining a second submitted state.
+- Do not use `useEffect` to copy one state variable into another state variable that represents the same concept. An effect whose main job is `setLocal(external)` usually means the ownership model is wrong.
+- For `nuqs`, define a parser map at the feature hook boundary, use `inferParserType`, prefer `.withDefault(...)` to remove nullable cleanup code, and put parser-specific options on the parser when they always apply to that key.
+- Treat `nuqs` `limitUrlUpdates` as URL/history rate limiting only. The hook state still updates immediately; debounce client-side fetching separately when TanStack Query consumes the value.
+- Let search/text input URL updates use the default `replace` history unless the product explicitly wants each keystroke to create history entries. Use `history: 'push'` only for discrete navigation-like changes such as tabs or committed filters.
+- Avoid hook-level `history: 'push'` when the same `useQueryStates` parser map includes high-frequency search keys. Put `push` on the specific setter call that needs it.
+- Expose feature-specific URL state actions such as `setKeywords`, `setTagIDs`, or `setSort`, not a generic `setQuery`, unless callers truly need arbitrary atomic multi-key updates.
+
 ## Components, Props, And Types
 
 - Type component signatures directly; do not use `FC` or `React.FC`.
@@ -59,5 +70,6 @@ Use this as the decision guide for React/TypeScript component structure. Existin
 
 - Prefer `Link` for normal navigation. Use router APIs only for command-flow side effects such as mutation success, guarded redirects, or form submission.
 - Treat `useEffect` as a last resort. First try deriving values during render, moving event-driven work into handlers, or using existing hooks/APIs for persistence, subscriptions, media queries, timers, and DOM sync.
+- Before adding an effect to synchronize state, identify the source of truth and check whether the consumer can read that state directly or read a derived value during render.
 - Do not use `useEffect` directly in components. If unavoidable, encapsulate it in a purpose-built hook so the component consumes a declarative API.
 - Avoid `memo`, `useMemo`, and `useCallback` unless there is a clear performance reason.

--- a/web/app/components/apps/__tests__/list.spec.tsx
+++ b/web/app/components/apps/__tests__/list.spec.tsx
@@ -51,14 +51,18 @@ vi.mock('@/context/app-context', () => ({
 const mockSetKeywords = vi.fn()
 const mockSetTagIDs = vi.fn()
 const mockSetIsCreatedByMe = vi.fn()
+const mockSetCategory = vi.fn()
 const mockQueryState = {
+  category: 'all',
   tagIDs: [] as string[],
   keywords: '',
   isCreatedByMe: false,
 }
 vi.mock('../hooks/use-apps-query-state', () => ({
+  isAppListCategory: (value: string) => value === 'all' || Object.values(AppModeEnum).includes(value as AppModeEnum),
   useAppsQueryState: () => ({
     query: mockQueryState,
+    setCategory: mockSetCategory,
     setKeywords: mockSetKeywords,
     setTagIDs: mockSetTagIDs,
     setIsCreatedByMe: mockSetIsCreatedByMe,
@@ -248,6 +252,7 @@ describe('List', () => {
     mockServiceState.hasNextPage = false
     mockServiceState.isLoading = false
     mockServiceState.isFetchingNextPage = false
+    mockQueryState.category = 'all'
     mockQueryState.tagIDs = []
     mockQueryState.keywords = ''
     mockQueryState.isCreatedByMe = false
@@ -321,25 +326,21 @@ describe('List', () => {
   })
 
   describe('Tab Navigation', () => {
-    it('should update URL when workflow tab is clicked', async () => {
-      const { onUrlUpdate } = renderList()
+    it('should update category when workflow tab is clicked', () => {
+      renderList()
 
       fireEvent.click(screen.getByText('app.types.workflow'))
 
-      await vi.waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
-      const lastCall = onUrlUpdate.mock.calls[onUrlUpdate.mock.calls.length - 1]![0]
-      expect(lastCall.searchParams.get('category')).toBe(AppModeEnum.WORKFLOW)
+      expect(mockSetCategory).toHaveBeenCalledWith(AppModeEnum.WORKFLOW)
     })
 
-    it('should update URL when all tab is clicked', async () => {
-      const { onUrlUpdate } = renderList('?category=workflow')
+    it('should update category when all tab is clicked', () => {
+      mockQueryState.category = AppModeEnum.WORKFLOW
+      renderList()
 
       fireEvent.click(screen.getByText('app.types.all'))
 
-      await vi.waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
-      const lastCall = onUrlUpdate.mock.calls[onUrlUpdate.mock.calls.length - 1]![0]
-      // nuqs removes the default value ('all') from URL params
-      expect(lastCall.searchParams.has('category')).toBe(false)
+      expect(mockSetCategory).toHaveBeenCalledWith('all')
     })
   })
 
@@ -377,8 +378,9 @@ describe('List', () => {
       mockQueryState.tagIDs = ['tag-1']
       mockQueryState.keywords = 'sales'
       mockQueryState.isCreatedByMe = true
+      mockQueryState.category = AppModeEnum.WORKFLOW
 
-      renderList('?category=workflow')
+      renderList()
 
       const options = mockAppListInfiniteOptions.mock.calls.at(-1)?.[0] as AppListInfiniteOptions
 
@@ -510,8 +512,8 @@ describe('List', () => {
       expect(screen.getByText('app.types.completion'))!.toBeInTheDocument()
     })
 
-    it('should update URL for each app type tab click', async () => {
-      const { onUrlUpdate } = renderList()
+    it('should update category for each app type tab click', () => {
+      renderList()
 
       const appTypeTexts = [
         { mode: AppModeEnum.WORKFLOW, text: 'app.types.workflow' },
@@ -522,11 +524,9 @@ describe('List', () => {
       ]
 
       for (const { mode, text } of appTypeTexts) {
-        onUrlUpdate.mockClear()
+        mockSetCategory.mockClear()
         fireEvent.click(screen.getByText(text))
-        await vi.waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
-        const lastCall = onUrlUpdate.mock.calls[onUrlUpdate.mock.calls.length - 1]![0]
-        expect(lastCall.searchParams.get('category')).toBe(mode)
+        expect(mockSetCategory).toHaveBeenCalledWith(mode)
       }
     })
   })

--- a/web/app/components/apps/__tests__/list.spec.tsx
+++ b/web/app/components/apps/__tests__/list.spec.tsx
@@ -48,16 +48,20 @@ vi.mock('@/context/app-context', () => ({
   }),
 }))
 
-const mockSetQuery = vi.fn()
+const mockSetKeywords = vi.fn()
+const mockSetTagIDs = vi.fn()
+const mockSetIsCreatedByMe = vi.fn()
 const mockQueryState = {
   tagIDs: [] as string[],
   keywords: '',
   isCreatedByMe: false,
 }
 vi.mock('../hooks/use-apps-query-state', () => ({
-  default: () => ({
+  useAppsQueryState: () => ({
     query: mockQueryState,
-    setQuery: mockSetQuery,
+    setKeywords: mockSetKeywords,
+    setTagIDs: mockSetTagIDs,
+    setIsCreatedByMe: mockSetIsCreatedByMe,
   }),
 }))
 
@@ -351,7 +355,7 @@ describe('List', () => {
       const input = screen.getByRole('textbox')
       fireEvent.change(input, { target: { value: 'test search' } })
 
-      expect(mockSetQuery).toHaveBeenCalled()
+      expect(mockSetKeywords).toHaveBeenCalledWith('test search')
     })
 
     it('should handle search clear button click', () => {
@@ -364,7 +368,7 @@ describe('List', () => {
       if (clearButton)
         fireEvent.click(clearButton)
 
-      expect(mockSetQuery).toHaveBeenCalled()
+      expect(mockSetKeywords).toHaveBeenCalledWith('')
     })
   })
 
@@ -412,7 +416,7 @@ describe('List', () => {
       const checkbox = screen.getByTestId('checkbox-undefined')
       fireEvent.click(checkbox)
 
-      expect(mockSetQuery).toHaveBeenCalled()
+      expect(mockSetIsCreatedByMe).toHaveBeenCalledWith(true)
     })
   })
 

--- a/web/app/components/apps/constants.ts
+++ b/web/app/components/apps/constants.ts
@@ -1,0 +1,1 @@
+export const APP_LIST_SEARCH_DEBOUNCE_MS = 500

--- a/web/app/components/apps/hooks/__tests__/use-apps-query-state.spec.tsx
+++ b/web/app/components/apps/hooks/__tests__/use-apps-query-state.spec.tsx
@@ -1,5 +1,6 @@
 import { act, waitFor } from '@testing-library/react'
 import { renderHookWithNuqs } from '@/test/nuqs-testing'
+import { AppModeEnum } from '@/types/app'
 import { APP_LIST_SEARCH_DEBOUNCE_MS } from '../../constants'
 import { useAppsQueryState } from '../use-apps-query-state'
 
@@ -16,10 +17,12 @@ describe('useAppsQueryState', () => {
     const { result } = renderWithAdapter()
 
     expect(result.current.query).toEqual({
+      category: 'all',
       tagIDs: [],
       keywords: '',
       isCreatedByMe: false,
     })
+    expect(typeof result.current.setCategory).toBe('function')
     expect(typeof result.current.setKeywords).toBe('function')
     expect(typeof result.current.setTagIDs).toBe('function')
     expect(typeof result.current.setIsCreatedByMe).toBe('function')
@@ -27,14 +30,42 @@ describe('useAppsQueryState', () => {
 
   it('should parse app list filters from URL', () => {
     const { result } = renderWithAdapter(
-      '?tagIDs=tag1;tag2&keywords=search+term&isCreatedByMe=true',
+      '?category=workflow&tagIDs=tag1;tag2&keywords=search+term&isCreatedByMe=true',
     )
 
     expect(result.current.query).toEqual({
+      category: AppModeEnum.WORKFLOW,
       tagIDs: ['tag1', 'tag2'],
       keywords: 'search term',
       isCreatedByMe: true,
     })
+  })
+
+  it('should update category URL state', async () => {
+    const { result, onUrlUpdate } = renderWithAdapter()
+
+    act(() => {
+      result.current.setCategory(AppModeEnum.WORKFLOW)
+    })
+
+    await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
+    const update = onUrlUpdate.mock.calls.at(-1)![0]
+    expect(result.current.query.category).toBe(AppModeEnum.WORKFLOW)
+    expect(update.searchParams.get('category')).toBe(AppModeEnum.WORKFLOW)
+    expect(update.options.history).toBe('push')
+  })
+
+  it('should remove category from URL when set to all', async () => {
+    const { result, onUrlUpdate } = renderWithAdapter('?category=workflow')
+
+    act(() => {
+      result.current.setCategory('all')
+    })
+
+    await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
+    const update = onUrlUpdate.mock.calls.at(-1)![0]
+    expect(result.current.query.category).toBe('all')
+    expect(update.searchParams.has('category')).toBe(false)
   })
 
   it('should update keywords state immediately while debouncing URL writes', async () => {
@@ -56,8 +87,6 @@ describe('useAppsQueryState', () => {
       expect(onUrlUpdate).toHaveBeenCalled()
       const update = onUrlUpdate.mock.calls.at(-1)![0]
       expect(update.searchParams.get('keywords')).toBe('search')
-      expect(update.options.history).toBe('replace')
-      expect(update.options.shallow).toBe(false)
     }
     finally {
       vi.useRealTimers()

--- a/web/app/components/apps/hooks/__tests__/use-apps-query-state.spec.tsx
+++ b/web/app/components/apps/hooks/__tests__/use-apps-query-state.spec.tsx
@@ -1,6 +1,7 @@
 import { act, waitFor } from '@testing-library/react'
 import { renderHookWithNuqs } from '@/test/nuqs-testing'
-import useAppsQueryState from '../use-apps-query-state'
+import { APP_LIST_SEARCH_DEBOUNCE_MS } from '../../constants'
+import { useAppsQueryState } from '../use-apps-query-state'
 
 const renderWithAdapter = (searchParams = '') => {
   return renderHookWithNuqs(() => useAppsQueryState(), { searchParams })
@@ -11,214 +12,133 @@ describe('useAppsQueryState', () => {
     vi.clearAllMocks()
   })
 
-  describe('Initialization', () => {
-    it('should expose query and setQuery when initialized', () => {
-      const { result } = renderWithAdapter()
+  it('should expose app list query state actions', () => {
+    const { result } = renderWithAdapter()
 
-      expect(result.current.query).toBeDefined()
-      expect(typeof result.current.setQuery).toBe('function')
+    expect(result.current.query).toEqual({
+      tagIDs: [],
+      keywords: '',
+      isCreatedByMe: false,
     })
+    expect(typeof result.current.setKeywords).toBe('function')
+    expect(typeof result.current.setTagIDs).toBe('function')
+    expect(typeof result.current.setIsCreatedByMe).toBe('function')
+  })
 
-    it('should default to empty filters when search params are missing', () => {
-      const { result } = renderWithAdapter()
+  it('should parse app list filters from URL', () => {
+    const { result } = renderWithAdapter(
+      '?tagIDs=tag1;tag2&keywords=search+term&isCreatedByMe=true',
+    )
 
-      expect(result.current.query.tagIDs).toBeUndefined()
-      expect(result.current.query.keywords).toBeUndefined()
-      expect(result.current.query.isCreatedByMe).toBe(false)
+    expect(result.current.query).toEqual({
+      tagIDs: ['tag1', 'tag2'],
+      keywords: 'search term',
+      isCreatedByMe: true,
     })
   })
 
-  describe('Parsing search params', () => {
-    it('should parse tagIDs when URL includes tagIDs', () => {
-      const { result } = renderWithAdapter('?tagIDs=tag1;tag2;tag3')
-
-      expect(result.current.query.tagIDs).toEqual(['tag1', 'tag2', 'tag3'])
-    })
-
-    it('should parse keywords when URL includes keywords', () => {
-      const { result } = renderWithAdapter('?keywords=search+term')
-
-      expect(result.current.query.keywords).toBe('search term')
-    })
-
-    it('should parse isCreatedByMe when URL includes true value', () => {
-      const { result } = renderWithAdapter('?isCreatedByMe=true')
-
-      expect(result.current.query.isCreatedByMe).toBe(true)
-    })
-
-    it('should parse all params when URL includes multiple filters', () => {
-      const { result } = renderWithAdapter(
-        '?tagIDs=tag1;tag2&keywords=test&isCreatedByMe=true',
-      )
-
-      expect(result.current.query.tagIDs).toEqual(['tag1', 'tag2'])
-      expect(result.current.query.keywords).toBe('test')
-      expect(result.current.query.isCreatedByMe).toBe(true)
-    })
-  })
-
-  describe('Updating query state', () => {
-    it('should update keywords when setQuery receives keywords', () => {
-      const { result } = renderWithAdapter()
-
-      act(() => {
-        result.current.setQuery({ keywords: 'new search' })
-      })
-
-      expect(result.current.query.keywords).toBe('new search')
-    })
-
-    it('should update tagIDs when setQuery receives tagIDs', () => {
-      const { result } = renderWithAdapter()
-
-      act(() => {
-        result.current.setQuery({ tagIDs: ['tag1', 'tag2'] })
-      })
-
-      expect(result.current.query.tagIDs).toEqual(['tag1', 'tag2'])
-    })
-
-    it('should update isCreatedByMe when setQuery receives true', () => {
-      const { result } = renderWithAdapter()
-
-      act(() => {
-        result.current.setQuery({ isCreatedByMe: true })
-      })
-
-      expect(result.current.query.isCreatedByMe).toBe(true)
-    })
-
-    it('should support partial updates when setQuery uses callback', () => {
-      const { result } = renderWithAdapter()
-
-      act(() => {
-        result.current.setQuery({ keywords: 'initial' })
-      })
-
-      act(() => {
-        result.current.setQuery(prev => ({ ...prev, isCreatedByMe: true }))
-      })
-
-      expect(result.current.query.keywords).toBe('initial')
-      expect(result.current.query.isCreatedByMe).toBe(true)
-    })
-  })
-
-  describe('URL synchronization', () => {
-    it('should sync keywords to URL when keywords change', async () => {
+  it('should update keywords state immediately while debouncing URL writes', async () => {
+    vi.useFakeTimers()
+    try {
       const { result, onUrlUpdate } = renderWithAdapter()
 
       act(() => {
-        result.current.setQuery({ keywords: 'search' })
+        result.current.setKeywords('search')
       })
 
-      await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
-      const update = onUrlUpdate.mock.calls[onUrlUpdate.mock.calls.length - 1]![0]
+      expect(result.current.query.keywords).toBe('search')
+      expect(onUrlUpdate).not.toHaveBeenCalled()
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(APP_LIST_SEARCH_DEBOUNCE_MS + 100)
+      })
+
+      expect(onUrlUpdate).toHaveBeenCalled()
+      const update = onUrlUpdate.mock.calls.at(-1)![0]
       expect(update.searchParams.get('keywords')).toBe('search')
-      expect(update.options.history).toBe('push')
-    })
+      expect(update.options.history).toBe('replace')
+      expect(update.options.shallow).toBe(false)
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
 
-    it('should sync tagIDs to URL when tagIDs change', async () => {
-      const { result, onUrlUpdate } = renderWithAdapter()
-
-      act(() => {
-        result.current.setQuery({ tagIDs: ['tag1', 'tag2'] })
-      })
-
-      await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
-      const update = onUrlUpdate.mock.calls[onUrlUpdate.mock.calls.length - 1]![0]
-      expect(update.searchParams.get('tagIDs')).toBe('tag1;tag2')
-    })
-
-    it('should sync isCreatedByMe to URL when enabled', async () => {
-      const { result, onUrlUpdate } = renderWithAdapter()
-
-      act(() => {
-        result.current.setQuery({ isCreatedByMe: true })
-      })
-
-      await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
-      const update = onUrlUpdate.mock.calls[onUrlUpdate.mock.calls.length - 1]![0]
-      expect(update.searchParams.get('isCreatedByMe')).toBe('true')
-    })
-
-    it('should remove keywords from URL when keywords are cleared', async () => {
+  it('should remove keywords from URL when cleared', async () => {
+    vi.useFakeTimers()
+    try {
       const { result, onUrlUpdate } = renderWithAdapter('?keywords=existing')
 
       act(() => {
-        result.current.setQuery({ keywords: '' })
+        result.current.setKeywords('')
       })
 
-      await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
-      const update = onUrlUpdate.mock.calls[onUrlUpdate.mock.calls.length - 1]![0]
+      expect(result.current.query.keywords).toBe('')
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(APP_LIST_SEARCH_DEBOUNCE_MS + 100)
+      })
+
+      expect(onUrlUpdate).toHaveBeenCalled()
+      const update = onUrlUpdate.mock.calls.at(-1)![0]
       expect(update.searchParams.has('keywords')).toBe(false)
-    })
-
-    it('should remove tagIDs from URL when tagIDs are empty', async () => {
-      const { result, onUrlUpdate } = renderWithAdapter('?tagIDs=tag1;tag2')
-
-      act(() => {
-        result.current.setQuery({ tagIDs: [] })
-      })
-
-      await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
-      const update = onUrlUpdate.mock.calls[onUrlUpdate.mock.calls.length - 1]![0]
-      expect(update.searchParams.has('tagIDs')).toBe(false)
-    })
-
-    it('should remove isCreatedByMe from URL when disabled', async () => {
-      const { result, onUrlUpdate } = renderWithAdapter('?isCreatedByMe=true')
-
-      act(() => {
-        result.current.setQuery({ isCreatedByMe: false })
-      })
-
-      await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
-      const update = onUrlUpdate.mock.calls[onUrlUpdate.mock.calls.length - 1]![0]
-      expect(update.searchParams.has('isCreatedByMe')).toBe(false)
-    })
+    }
+    finally {
+      vi.useRealTimers()
+    }
   })
 
-  describe('Edge cases', () => {
-    it('should treat empty tagIDs as empty list when URL param is empty', () => {
-      const { result } = renderWithAdapter('?tagIDs=')
+  it('should update tag filter URL state', async () => {
+    const { result, onUrlUpdate } = renderWithAdapter()
 
-      expect(result.current.query.tagIDs).toEqual([])
+    act(() => {
+      result.current.setTagIDs(['tag1', 'tag2'])
     })
 
-    it('should treat empty keywords as undefined when URL param is empty', () => {
-      const { result } = renderWithAdapter('?keywords=')
-
-      expect(result.current.query.keywords).toBeUndefined()
-    })
-
-    it('should decode keywords with spaces when URL contains encoded spaces', () => {
-      const { result } = renderWithAdapter('?keywords=test+with+spaces')
-
-      expect(result.current.query.keywords).toBe('test with spaces')
-    })
+    await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
+    const update = onUrlUpdate.mock.calls.at(-1)![0]
+    expect(result.current.query.tagIDs).toEqual(['tag1', 'tag2'])
+    expect(update.searchParams.get('tagIDs')).toBe('tag1;tag2')
+    expect(update.options.history).toBe('push')
   })
 
-  describe('Integration scenarios', () => {
-    it('should keep accumulated filters when updates are sequential', () => {
-      const { result } = renderWithAdapter()
+  it('should remove tagIDs from URL when empty', async () => {
+    const { result, onUrlUpdate } = renderWithAdapter('?tagIDs=tag1;tag2')
 
-      act(() => {
-        result.current.setQuery({ keywords: 'first' })
-      })
-
-      act(() => {
-        result.current.setQuery(prev => ({ ...prev, tagIDs: ['tag1'] }))
-      })
-
-      act(() => {
-        result.current.setQuery(prev => ({ ...prev, isCreatedByMe: true }))
-      })
-
-      expect(result.current.query.keywords).toBe('first')
-      expect(result.current.query.tagIDs).toEqual(['tag1'])
-      expect(result.current.query.isCreatedByMe).toBe(true)
+    act(() => {
+      result.current.setTagIDs([])
     })
+
+    await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
+    const update = onUrlUpdate.mock.calls.at(-1)![0]
+    expect(result.current.query.tagIDs).toEqual([])
+    expect(update.searchParams.has('tagIDs')).toBe(false)
+  })
+
+  it('should update created-by-me URL state', async () => {
+    const { result, onUrlUpdate } = renderWithAdapter()
+
+    act(() => {
+      result.current.setIsCreatedByMe(true)
+    })
+
+    await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
+    const update = onUrlUpdate.mock.calls.at(-1)![0]
+    expect(result.current.query.isCreatedByMe).toBe(true)
+    expect(update.searchParams.get('isCreatedByMe')).toBe('true')
+    expect(update.options.history).toBe('push')
+  })
+
+  it('should remove isCreatedByMe from URL when disabled', async () => {
+    const { result, onUrlUpdate } = renderWithAdapter('?isCreatedByMe=true')
+
+    act(() => {
+      result.current.setIsCreatedByMe(false)
+    })
+
+    await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
+    const update = onUrlUpdate.mock.calls.at(-1)![0]
+    expect(result.current.query.isCreatedByMe).toBe(false)
+    expect(update.searchParams.has('isCreatedByMe')).toBe(false)
   })
 })

--- a/web/app/components/apps/hooks/use-apps-query-state.ts
+++ b/web/app/components/apps/hooks/use-apps-query-state.ts
@@ -1,57 +1,38 @@
-import { parseAsArrayOf, parseAsBoolean, parseAsString, useQueryStates } from 'nuqs'
+import type { inferParserType } from 'nuqs'
+import { debounce, parseAsArrayOf, parseAsBoolean, parseAsString, useQueryStates } from 'nuqs'
 import { useCallback, useMemo } from 'react'
+import { APP_LIST_SEARCH_DEBOUNCE_MS } from '../constants'
 
-type AppsQuery = {
-  tagIDs?: string[]
-  keywords?: string
-  isCreatedByMe?: boolean
+const appListQueryParsers = {
+  tagIDs: parseAsArrayOf(parseAsString, ';').withDefault([]),
+  keywords: parseAsString.withDefault('').withOptions({
+    shallow: false,
+    limitUrlUpdates: debounce(APP_LIST_SEARCH_DEBOUNCE_MS),
+  }),
+  isCreatedByMe: parseAsBoolean.withDefault(false),
 }
 
-const normalizeKeywords = (value: string | null) => value || undefined
+export type AppsQuery = inferParserType<typeof appListQueryParsers>
 
-function useAppsQueryState() {
-  const [urlQuery, setUrlQuery] = useQueryStates(
-    {
-      tagIDs: parseAsArrayOf(parseAsString, ';'),
-      keywords: parseAsString,
-      isCreatedByMe: parseAsBoolean,
-    },
-    {
-      history: 'push',
-    },
-  )
+export function useAppsQueryState() {
+  const [query, setQuery] = useQueryStates(appListQueryParsers)
 
-  const query = useMemo<AppsQuery>(() => ({
-    tagIDs: urlQuery.tagIDs ?? undefined,
-    keywords: normalizeKeywords(urlQuery.keywords),
-    isCreatedByMe: urlQuery.isCreatedByMe ?? false,
-  }), [urlQuery.isCreatedByMe, urlQuery.keywords, urlQuery.tagIDs])
+  const setKeywords = useCallback((keywords: string) => {
+    setQuery({ keywords })
+  }, [setQuery])
 
-  const setQuery = useCallback((next: AppsQuery | ((prev: AppsQuery) => AppsQuery)) => {
-    const buildPatch = (patch: AppsQuery) => {
-      const result: Partial<typeof urlQuery> = {}
-      if ('tagIDs' in patch)
-        result.tagIDs = patch.tagIDs && patch.tagIDs.length > 0 ? patch.tagIDs : null
-      if ('keywords' in patch)
-        result.keywords = patch.keywords ? patch.keywords : null
-      if ('isCreatedByMe' in patch)
-        result.isCreatedByMe = patch.isCreatedByMe ? true : null
-      return result
-    }
+  const setTagIDs = useCallback((tagIDs: string[]) => {
+    setQuery({ tagIDs }, { history: 'push' })
+  }, [setQuery])
 
-    if (typeof next === 'function') {
-      setUrlQuery(prev => buildPatch(next({
-        tagIDs: prev.tagIDs ?? undefined,
-        keywords: normalizeKeywords(prev.keywords),
-        isCreatedByMe: prev.isCreatedByMe ?? false,
-      })))
-      return
-    }
+  const setIsCreatedByMe = useCallback((isCreatedByMe: boolean) => {
+    setQuery({ isCreatedByMe }, { history: 'push' })
+  }, [setQuery])
 
-    setUrlQuery(buildPatch(next))
-  }, [setUrlQuery])
-
-  return useMemo(() => ({ query, setQuery }), [query, setQuery])
+  return useMemo(() => ({
+    query,
+    setKeywords,
+    setTagIDs,
+    setIsCreatedByMe,
+  }), [query, setKeywords, setTagIDs, setIsCreatedByMe])
 }
-
-export default useAppsQueryState

--- a/web/app/components/apps/hooks/use-apps-query-state.ts
+++ b/web/app/components/apps/hooks/use-apps-query-state.ts
@@ -1,35 +1,56 @@
-import { debounce, parseAsArrayOf, parseAsBoolean, parseAsString, useQueryStates } from 'nuqs'
+import { debounce, parseAsArrayOf, parseAsBoolean, parseAsString, parseAsStringLiteral, useQueryStates } from 'nuqs'
 import { useCallback, useMemo } from 'react'
+import { AppModes } from '@/types/app'
 import { APP_LIST_SEARCH_DEBOUNCE_MS } from '../constants'
 
+const APP_LIST_CATEGORY_VALUES = ['all', ...AppModes] as const
+export type AppListCategory = typeof APP_LIST_CATEGORY_VALUES[number]
+
+const appListCategorySet = new Set<string>(APP_LIST_CATEGORY_VALUES)
+
+export const isAppListCategory = (value: string): value is AppListCategory => {
+  return appListCategorySet.has(value)
+}
+
 const appListQueryParsers = {
-  tagIDs: parseAsArrayOf(parseAsString, ';').withDefault([]),
+  category: parseAsStringLiteral(APP_LIST_CATEGORY_VALUES)
+    .withDefault('all')
+    .withOptions({ history: 'push' }),
+  tagIDs: parseAsArrayOf(parseAsString, ';')
+    .withDefault([])
+    .withOptions({ history: 'push' }),
   keywords: parseAsString.withDefault('').withOptions({
-    shallow: false,
     limitUrlUpdates: debounce(APP_LIST_SEARCH_DEBOUNCE_MS),
   }),
-  isCreatedByMe: parseAsBoolean.withDefault(false),
+  isCreatedByMe: parseAsBoolean
+    .withDefault(false)
+    .withOptions({ history: 'push' }),
 }
 
 export function useAppsQueryState() {
   const [query, setQuery] = useQueryStates(appListQueryParsers)
+
+  const setCategory = useCallback((category: AppListCategory) => {
+    setQuery({ category })
+  }, [setQuery])
 
   const setKeywords = useCallback((keywords: string) => {
     setQuery({ keywords })
   }, [setQuery])
 
   const setTagIDs = useCallback((tagIDs: string[]) => {
-    setQuery({ tagIDs }, { history: 'push' })
+    setQuery({ tagIDs })
   }, [setQuery])
 
   const setIsCreatedByMe = useCallback((isCreatedByMe: boolean) => {
-    setQuery({ isCreatedByMe }, { history: 'push' })
+    setQuery({ isCreatedByMe })
   }, [setQuery])
 
   return useMemo(() => ({
     query,
+    setCategory,
     setKeywords,
     setTagIDs,
     setIsCreatedByMe,
-  }), [query, setKeywords, setTagIDs, setIsCreatedByMe])
+  }), [query, setCategory, setKeywords, setTagIDs, setIsCreatedByMe])
 }

--- a/web/app/components/apps/hooks/use-apps-query-state.ts
+++ b/web/app/components/apps/hooks/use-apps-query-state.ts
@@ -1,4 +1,3 @@
-import type { inferParserType } from 'nuqs'
 import { debounce, parseAsArrayOf, parseAsBoolean, parseAsString, useQueryStates } from 'nuqs'
 import { useCallback, useMemo } from 'react'
 import { APP_LIST_SEARCH_DEBOUNCE_MS } from '../constants'
@@ -11,8 +10,6 @@ const appListQueryParsers = {
   }),
   isCreatedByMe: parseAsBoolean.withDefault(false),
 }
-
-export type AppsQuery = inferParserType<typeof appListQueryParsers>
 
 export function useAppsQueryState() {
   const [query, setQuery] = useQueryStates(appListQueryParsers)

--- a/web/app/components/apps/list.tsx
+++ b/web/app/components/apps/list.tsx
@@ -5,7 +5,6 @@ import type { AppListQuery } from '@/contract/console/apps'
 import { cn } from '@langgenius/dify-ui/cn'
 import { keepPreviousData, useInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query'
 import { useDebounce } from 'ahooks'
-import { parseAsStringLiteral, useQueryState } from 'nuqs'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Checkbox from '@/app/components/base/checkbox'
@@ -18,13 +17,13 @@ import { CheckModal } from '@/hooks/use-pay'
 import dynamic from '@/next/dynamic'
 import { consoleQuery } from '@/service/client'
 import { systemFeaturesQueryOptions } from '@/service/system-features'
-import { AppModeEnum, AppModes } from '@/types/app'
+import { AppModeEnum } from '@/types/app'
 import AppCard from './app-card'
 import { AppCardSkeleton } from './app-card-skeleton'
 import { APP_LIST_SEARCH_DEBOUNCE_MS } from './constants'
 import Empty from './empty'
 import Footer from './footer'
-import { useAppsQueryState } from './hooks/use-apps-query-state'
+import { isAppListCategory, useAppsQueryState } from './hooks/use-apps-query-state'
 import { useDSLDragDrop } from './hooks/use-dsl-drag-drop'
 import { useWorkflowOnlineUsers } from './hooks/use-workflow-online-users'
 import NewAppCard from './new-app-card'
@@ -36,18 +35,6 @@ const CreateFromDSLModal = dynamic(() => import('@/app/components/app/create-fro
   ssr: false,
 })
 
-const APP_LIST_CATEGORY_VALUES = ['all', ...AppModes] as const
-type AppListCategory = typeof APP_LIST_CATEGORY_VALUES[number]
-const appListCategorySet = new Set<string>(APP_LIST_CATEGORY_VALUES)
-
-const isAppListCategory = (value: string): value is AppListCategory => {
-  return appListCategorySet.has(value)
-}
-
-const parseAsAppListCategory = parseAsStringLiteral(APP_LIST_CATEGORY_VALUES)
-  .withDefault('all')
-  .withOptions({ history: 'push' })
-
 type Props = {
   controlRefreshList?: number
 }
@@ -57,14 +44,11 @@ const List: FC<Props> = ({
   const { t } = useTranslation()
   const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
   const { isCurrentWorkspaceEditor, isCurrentWorkspaceDatasetOperator, isLoadingCurrentWorkspace } = useAppContext()
-  const [activeTab, setActiveTab] = useQueryState(
-    'category',
-    parseAsAppListCategory,
-  )
 
   // eslint-disable-next-line react/use-state -- custom URL query hook, not React.useState
   const {
-    query: { tagIDs, keywords, isCreatedByMe },
+    query: { category, tagIDs, keywords, isCreatedByMe },
+    setCategory,
     setKeywords,
     setTagIDs,
     setIsCreatedByMe,
@@ -93,8 +77,8 @@ const List: FC<Props> = ({
     name: debouncedKeywords,
     ...(tagIDs.length ? { tag_ids: tagIDs } : {}),
     ...(isCreatedByMe ? { is_created_by_me: isCreatedByMe } : {}),
-    ...(activeTab !== 'all' ? { mode: activeTab } : {}),
-  }), [activeTab, debouncedKeywords, isCreatedByMe, tagIDs])
+    ...(category !== 'all' ? { mode: category } : {}),
+  }), [category, debouncedKeywords, isCreatedByMe, tagIDs])
 
   const {
     data,
@@ -211,10 +195,10 @@ const List: FC<Props> = ({
 
         <div className="sticky top-0 z-10 flex flex-wrap items-center justify-between gap-y-2 bg-background-body px-12 pt-7 pb-5">
           <TabSliderNew
-            value={activeTab}
+            value={category}
             onChange={(nextValue) => {
               if (isAppListCategory(nextValue))
-                setActiveTab(nextValue)
+                setCategory(nextValue)
             }}
             options={options}
           />
@@ -246,7 +230,7 @@ const List: FC<Props> = ({
               ref={newAppCardRef}
               isLoading={isLoadingCurrentWorkspace}
               onSuccess={refetch}
-              selectedAppType={activeTab}
+              selectedAppType={category}
               className={cn(!hasAnyApp && 'z-10')}
             />
           )}

--- a/web/app/components/apps/list.tsx
+++ b/web/app/components/apps/list.tsx
@@ -4,7 +4,7 @@ import type { FC } from 'react'
 import type { AppListQuery } from '@/contract/console/apps'
 import { cn } from '@langgenius/dify-ui/cn'
 import { keepPreviousData, useInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query'
-import { useDebounceFn } from 'ahooks'
+import { useDebounce } from 'ahooks'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -21,9 +21,10 @@ import { systemFeaturesQueryOptions } from '@/service/system-features'
 import { AppModeEnum, AppModes } from '@/types/app'
 import AppCard from './app-card'
 import { AppCardSkeleton } from './app-card-skeleton'
+import { APP_LIST_SEARCH_DEBOUNCE_MS } from './constants'
 import Empty from './empty'
 import Footer from './footer'
-import useAppsQueryStateHook from './hooks/use-apps-query-state'
+import { useAppsQueryState } from './hooks/use-apps-query-state'
 import { useDSLDragDrop } from './hooks/use-dsl-drag-drop'
 import { useWorkflowOnlineUsers } from './hooks/use-workflow-online-users'
 import NewAppCard from './new-app-card'
@@ -62,22 +63,18 @@ const List: FC<Props> = ({
   )
 
   // eslint-disable-next-line react/use-state -- custom URL query hook, not React.useState
-  const appsQuery = useAppsQueryStateHook()
-  const { query: { tagIDs = [], keywords = '', isCreatedByMe: queryIsCreatedByMe = false }, setQuery } = appsQuery
-  const [isCreatedByMe, setIsCreatedByMe] = useState(queryIsCreatedByMe)
-  const [tagFilterValue, setTagFilterValue] = useState<string[]>(tagIDs)
-  const [searchKeywords, setSearchKeywords] = useState(keywords)
+  const {
+    query: { tagIDs, keywords, isCreatedByMe },
+    setKeywords,
+    setTagIDs,
+    setIsCreatedByMe,
+  } = useAppsQueryState()
+  const debouncedKeywords = useDebounce(keywords, { wait: APP_LIST_SEARCH_DEBOUNCE_MS })
   const newAppCardRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const [showTagManagementModal, setShowTagManagementModal] = useState(false)
   const [showCreateFromDSLModal, setShowCreateFromDSLModal] = useState(false)
   const [droppedDSLFile, setDroppedDSLFile] = useState<File | undefined>()
-  const setKeywords = useCallback((keywords: string) => {
-    setQuery(prev => ({ ...prev, keywords }))
-  }, [setQuery])
-  const setTagIDs = useCallback((tagIDs: string[]) => {
-    setQuery(prev => ({ ...prev, tagIDs }))
-  }, [setQuery])
 
   const handleDSLFileDropped = useCallback((file: File) => {
     setDroppedDSLFile(file)
@@ -93,11 +90,11 @@ const List: FC<Props> = ({
   const appListQuery = useMemo<AppListQuery>(() => ({
     page: 1,
     limit: 30,
-    name: searchKeywords,
+    name: debouncedKeywords,
     ...(tagIDs.length ? { tag_ids: tagIDs } : {}),
     ...(isCreatedByMe ? { is_created_by_me: isCreatedByMe } : {}),
     ...(activeTab !== 'all' ? { mode: activeTab } : {}),
-  }), [activeTab, isCreatedByMe, searchKeywords, tagIDs])
+  }), [activeTab, debouncedKeywords, isCreatedByMe, tagIDs])
 
   const {
     data,
@@ -177,27 +174,9 @@ const List: FC<Props> = ({
     return () => observer?.disconnect()
   }, [isLoading, isFetchingNextPage, fetchNextPage, error, hasNextPage, isCurrentWorkspaceDatasetOperator])
 
-  const { run: handleSearch } = useDebounceFn(() => {
-    setSearchKeywords(keywords)
-  }, { wait: 500 })
-  const handleKeywordsChange = (value: string) => {
-    setKeywords(value)
-    handleSearch()
-  }
-
-  const { run: handleTagsUpdate } = useDebounceFn(() => {
-    setTagIDs(tagFilterValue)
-  }, { wait: 500 })
-  const handleTagsChange = (value: string[]) => {
-    setTagFilterValue(value)
-    handleTagsUpdate()
-  }
-
   const handleCreatedByMeChange = useCallback(() => {
-    const newValue = !isCreatedByMe
-    setIsCreatedByMe(newValue)
-    setQuery(prev => ({ ...prev, isCreatedByMe: newValue }))
-  }, [isCreatedByMe, setQuery])
+    setIsCreatedByMe(!isCreatedByMe)
+  }, [isCreatedByMe, setIsCreatedByMe])
 
   const pages = useMemo(() => data?.pages ?? [], [data?.pages])
   const apps = useMemo(() => pages.flatMap(({ data: pageApps }) => pageApps), [pages])
@@ -246,14 +225,14 @@ const List: FC<Props> = ({
                 {t('showMyCreatedAppsOnly', { ns: 'app' })}
               </div>
             </label>
-            <TagFilter type="app" value={tagFilterValue} onChange={handleTagsChange} onOpenTagManagement={() => setShowTagManagementModal(true)} />
+            <TagFilter type="app" value={tagIDs} onChange={setTagIDs} onOpenTagManagement={() => setShowTagManagementModal(true)} />
             <Input
               showLeftIcon
               showClearIcon
               wrapperClassName="w-[200px]"
               value={keywords}
-              onChange={e => handleKeywordsChange(e.target.value)}
-              onClear={() => handleKeywordsChange('')}
+              onChange={e => setKeywords(e.target.value)}
+              onClear={() => setKeywords('')}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Reworked `useAppsQueryState` into a named, domain-specific hook API with `query`, `setKeywords`, `setTagIDs`, and `setIsCreatedByMe`.
- Switched the apps search flow to nuqs parser-level debouncing for URL writes and ahooks `useDebounce` for TanStack Query input.
- Removed the extra mirrored search state from the `/apps` list and kept the debounce constant in a local feature constant.
- Updated list and hook tests to cover the new API and debounce behavior.

## Testing
- `pnpm --dir web test app/components/apps/__tests__/list.spec.tsx app/components/apps/hooks/__tests__/use-apps-query-state.spec.tsx`
- `web/node_modules/.bin/tsgo --project web/tsconfig.json --pretty false`