### PR TITLE
fix(api): eliminate invalid savepoint release paths

### DIFF
--- a/api/extensions/ext_database.py
+++ b/api/extensions/ext_database.py
@@ -1,6 +1,5 @@
 import logging
 
-import gevent
 from sqlalchemy import event
 from sqlalchemy.pool import Pool
 
@@ -37,15 +36,9 @@ def _setup_gevent_compatibility():
         if reset_state.terminate_only:
             return
 
-        # Safe rollback for connection
-        try:
-            hub = gevent.get_hub()
-            if hasattr(hub, "loop") and getattr(hub.loop, "in_callback", False):
-                gevent.spawn_later(0, lambda: _safe_rollback(dbapi_connection))
-            else:
-                _safe_rollback(dbapi_connection)
-        except (AttributeError, ImportError):
-            _safe_rollback(dbapi_connection)
+        # Reset must complete before the connection can be reused; a delayed
+        # rollback can race with a new transaction and invalidate its savepoints.
+        _safe_rollback(dbapi_connection)
 
     _gevent_compatibility_setup = True
 

--- a/api/repositories/api_workflow_run_repository.py
+++ b/api/repositories/api_workflow_run_repository.py
@@ -343,10 +343,14 @@ class APIWorkflowRunRepository(WorkflowExecutionRepository, Protocol):
         runs: Sequence[WorkflowRun],
         delete_node_executions: Callable[[Session, Sequence[WorkflowRun]], tuple[int, int]] | None = None,
         delete_trigger_logs: Callable[[Session, Sequence[str]], int] | None = None,
+        session: Session | None = None,
     ) -> RunsWithRelatedCountsDict:
         """
         Delete workflow runs and their related records (node executions, offloads, app logs,
         trigger logs, pauses, pause reasons).
+
+        When ``session`` is provided, the caller owns the transaction boundary and
+        this method must not commit independently.
         """
         ...
 

--- a/api/repositories/sqlalchemy_api_workflow_run_repository.py
+++ b/api/repositories/sqlalchemy_api_workflow_run_repository.py
@@ -464,6 +464,7 @@ class DifyAPISQLAlchemyWorkflowRunRepository(APIWorkflowRunRepository):
         runs: Sequence[WorkflowRun],
         delete_node_executions: Callable[[Session, Sequence[WorkflowRun]], tuple[int, int]] | None = None,
         delete_trigger_logs: Callable[[Session, Sequence[str]], int] | None = None,
+        session: Session | None = None,
     ) -> RunsWithRelatedCountsDict:
         if not runs:
             return {
@@ -476,45 +477,74 @@ class DifyAPISQLAlchemyWorkflowRunRepository(APIWorkflowRunRepository):
                 "pause_reasons": 0,
             }
 
-        with self._session_maker() as session:
-            run_ids = [run.id for run in runs]
-            if delete_node_executions:
-                node_executions_deleted, offloads_deleted = delete_node_executions(session, runs)
-            else:
-                node_executions_deleted, offloads_deleted = 0, 0
+        if session is not None:
+            return self._delete_runs_with_related_in_session(
+                session=session,
+                runs=runs,
+                delete_node_executions=delete_node_executions,
+                delete_trigger_logs=delete_trigger_logs,
+                commit=False,
+            )
 
-            app_logs_result = session.execute(delete(WorkflowAppLog).where(WorkflowAppLog.workflow_run_id.in_(run_ids)))
-            app_logs_deleted = cast(CursorResult, app_logs_result).rowcount or 0
+        with self._session_maker() as managed_session:
+            return self._delete_runs_with_related_in_session(
+                session=managed_session,
+                runs=runs,
+                delete_node_executions=delete_node_executions,
+                delete_trigger_logs=delete_trigger_logs,
+                commit=True,
+            )
 
-            pause_stmt = select(WorkflowPause.id).where(WorkflowPause.workflow_run_id.in_(run_ids))
-            pause_ids = session.scalars(pause_stmt).all()
-            pause_reasons_deleted = 0
-            pauses_deleted = 0
+    def _delete_runs_with_related_in_session(
+        self,
+        session: Session,
+        runs: Sequence[WorkflowRun],
+        delete_node_executions: Callable[[Session, Sequence[WorkflowRun]], tuple[int, int]] | None,
+        delete_trigger_logs: Callable[[Session, Sequence[str]], int] | None,
+        *,
+        commit: bool,
+    ) -> RunsWithRelatedCountsDict:
+        run_ids = [run.id for run in runs]
+        if delete_node_executions:
+            node_executions_deleted, offloads_deleted = delete_node_executions(session, runs)
+        else:
+            node_executions_deleted, offloads_deleted = 0, 0
 
-            if pause_ids:
-                pause_reasons_result = session.execute(
-                    delete(WorkflowPauseReason).where(WorkflowPauseReason.pause_id.in_(pause_ids))
-                )
-                pause_reasons_deleted = cast(CursorResult, pause_reasons_result).rowcount or 0
-                pauses_result = session.execute(delete(WorkflowPause).where(WorkflowPause.id.in_(pause_ids)))
-                pauses_deleted = cast(CursorResult, pauses_result).rowcount or 0
+        app_logs_result = session.execute(delete(WorkflowAppLog).where(WorkflowAppLog.workflow_run_id.in_(run_ids)))
+        app_logs_deleted = cast(CursorResult, app_logs_result).rowcount or 0
 
-            trigger_logs_deleted = delete_trigger_logs(session, run_ids) if delete_trigger_logs else 0
+        pause_stmt = select(WorkflowPause.id).where(WorkflowPause.workflow_run_id.in_(run_ids))
+        pause_ids = session.scalars(pause_stmt).all()
+        pause_reasons_deleted = 0
+        pauses_deleted = 0
 
-            runs_result = session.execute(delete(WorkflowRun).where(WorkflowRun.id.in_(run_ids)))
-            runs_deleted = cast(CursorResult, runs_result).rowcount or 0
+        if pause_ids:
+            pause_reasons_result = session.execute(
+                delete(WorkflowPauseReason).where(WorkflowPauseReason.pause_id.in_(pause_ids))
+            )
+            pause_reasons_deleted = cast(CursorResult, pause_reasons_result).rowcount or 0
+            pauses_result = session.execute(delete(WorkflowPause).where(WorkflowPause.id.in_(pause_ids)))
+            pauses_deleted = cast(CursorResult, pauses_result).rowcount or 0
 
+        trigger_logs_deleted = delete_trigger_logs(session, run_ids) if delete_trigger_logs else 0
+
+        runs_result = session.execute(delete(WorkflowRun).where(WorkflowRun.id.in_(run_ids)))
+        runs_deleted = cast(CursorResult, runs_result).rowcount or 0
+
+        if commit:
             session.commit()
+        else:
+            session.flush()
 
-            return {
-                "runs": runs_deleted,
-                "node_executions": node_executions_deleted,
-                "offloads": offloads_deleted,
-                "app_logs": app_logs_deleted,
-                "trigger_logs": trigger_logs_deleted,
-                "pauses": pauses_deleted,
-                "pause_reasons": pause_reasons_deleted,
-            }
+        return {
+            "runs": runs_deleted,
+            "node_executions": node_executions_deleted,
+            "offloads": offloads_deleted,
+            "app_logs": app_logs_deleted,
+            "trigger_logs": trigger_logs_deleted,
+            "pauses": pauses_deleted,
+            "pause_reasons": pause_reasons_deleted,
+        }
 
     def get_app_logs_by_run_id(
         self,

--- a/api/schedule/clean_workflow_runlogs_precise.py
+++ b/api/schedule/clean_workflow_runlogs_precise.py
@@ -4,7 +4,6 @@ import time
 from collections.abc import Sequence
 
 import click
-from sqlalchemy import delete, select
 from sqlalchemy.orm import Session, sessionmaker
 
 import app
@@ -75,8 +74,13 @@ def clean_workflow_runlogs_precise() -> None:
 
             last_seen = (run_rows[-1].created_at, run_rows[-1].id)
             batch_count += 1
-            with session_factory.begin() as session:
-                success = _delete_batch(session, workflow_run_repo, run_rows, failed_batches)
+            try:
+                with session_factory.begin() as session:
+                    _delete_batch(session, workflow_run_repo, run_rows)
+                success = True
+            except Exception:
+                logger.exception("Batch deletion failed (attempt %s)", failed_batches + 1)
+                success = False
 
             if success:
                 total_deleted += len(run_rows)
@@ -108,61 +112,53 @@ def _delete_batch(
     session: Session,
     workflow_run_repo,
     workflow_runs: Sequence[WorkflowRun],
-    attempt_count: int,
-) -> bool:
-    """Delete a single batch of workflow runs and all related data within a nested transaction."""
-    try:
-        with session.begin_nested():
-            workflow_run_ids = [run.id for run in workflow_runs]
-            message_data = session.execute(
-                select(Message.id, Message.conversation_id).where(Message.workflow_run_id.in_(workflow_run_ids))
-            ).all()
-            message_id_list = [msg.id for msg in message_data]
-            conversation_id_list = list({msg.conversation_id for msg in message_data if msg.conversation_id})
-            if message_id_list:
-                message_related_models = [
-                    AppAnnotationHitHistory,
-                    DatasetRetrieverResource,
-                    MessageAgentThought,
-                    MessageChain,
-                    MessageFile,
-                    MessageAnnotation,
-                    MessageFeedback,
-                    SavedMessage,
-                ]
-                for model in message_related_models:
-                    session.execute(delete(model).where(model.message_id.in_(message_id_list)))  # type: ignore
-                    # error: "DeclarativeAttributeIntercept" has no attribute "message_id". But this type is only in lib
-                    # and these 6 types all have the message_id field.
+) -> None:
+    """Delete a single batch of workflow runs inside the caller-owned transaction."""
+    workflow_run_ids = [run.id for run in workflow_runs]
+    message_data = (
+        session.query(Message.id, Message.conversation_id).where(Message.workflow_run_id.in_(workflow_run_ids)).all()
+    )
+    message_id_list = [msg.id for msg in message_data]
+    conversation_id_list = list({msg.conversation_id for msg in message_data if msg.conversation_id})
+    if message_id_list:
+        message_related_models = [
+            AppAnnotationHitHistory,
+            DatasetRetrieverResource,
+            MessageAgentThought,
+            MessageChain,
+            MessageFile,
+            MessageAnnotation,
+            MessageFeedback,
+            SavedMessage,
+        ]
+        for model in message_related_models:
+            session.query(model).where(model.message_id.in_(message_id_list)).delete(synchronize_session=False)  # type: ignore
+            # error: "DeclarativeAttributeIntercept" has no attribute "message_id". But this type is only in lib
+            # and these 6 types all have the message_id field.
 
-                session.execute(delete(Message).where(Message.workflow_run_id.in_(workflow_run_ids)))
+        session.query(Message).where(Message.workflow_run_id.in_(workflow_run_ids)).delete(synchronize_session=False)
 
-            if conversation_id_list:
-                session.execute(
-                    delete(ConversationVariable).where(ConversationVariable.conversation_id.in_(conversation_id_list))
-                )
+    if conversation_id_list:
+        session.query(ConversationVariable).where(
+            ConversationVariable.conversation_id.in_(conversation_id_list)
+        ).delete(synchronize_session=False)
 
-                session.execute(delete(Conversation).where(Conversation.id.in_(conversation_id_list)))
+        session.query(Conversation).where(Conversation.id.in_(conversation_id_list)).delete(synchronize_session=False)
 
-            def _delete_node_executions(active_session: Session, runs: Sequence[WorkflowRun]) -> tuple[int, int]:
-                run_ids = [run.id for run in runs]
-                repo = DifyAPIRepositoryFactory.create_api_workflow_node_execution_repository(
-                    session_maker=sessionmaker(bind=active_session.get_bind(), expire_on_commit=False)
-                )
-                return repo.delete_by_runs(active_session, run_ids)
+    def _delete_node_executions(active_session: Session, runs: Sequence[WorkflowRun]) -> tuple[int, int]:
+        run_ids = [run.id for run in runs]
+        repo = DifyAPIRepositoryFactory.create_api_workflow_node_execution_repository(
+            session_maker=sessionmaker(bind=active_session.get_bind(), expire_on_commit=False)
+        )
+        return repo.delete_by_runs(active_session, run_ids)
 
-            def _delete_trigger_logs(active_session: Session, run_ids: Sequence[str]) -> int:
-                trigger_repo = SQLAlchemyWorkflowTriggerLogRepository(active_session)
-                return trigger_repo.delete_by_run_ids(run_ids)
+    def _delete_trigger_logs(active_session: Session, run_ids: Sequence[str]) -> int:
+        trigger_repo = SQLAlchemyWorkflowTriggerLogRepository(active_session)
+        return trigger_repo.delete_by_run_ids(run_ids)
 
-            workflow_run_repo.delete_runs_with_related(
-                workflow_runs,
-                delete_node_executions=_delete_node_executions,
-                delete_trigger_logs=_delete_trigger_logs,
-            )
-
-            return True
-
-    except Exception:
-        logger.exception("Batch deletion failed (attempt %s)", attempt_count + 1)
-        return False
+    workflow_run_repo.delete_runs_with_related(
+        workflow_runs,
+        delete_node_executions=_delete_node_executions,
+        delete_trigger_logs=_delete_trigger_logs,
+        session=session,
+    )

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -271,8 +271,14 @@ class AccountService:
         password: str | None = None,
         interface_theme: str = "light",
         is_setup: bool | None = False,
+        *,
+        commit: bool = True,
     ) -> Account:
-        """create account"""
+        """Create an account.
+
+        When ``commit`` is ``False``, the new row is flushed so the caller can
+        keep a larger workflow inside a single transaction.
+        """
         if not FeatureService.get_system_features().is_allow_register and not is_setup:
             from controllers.console.error import AccountNotFound
 
@@ -313,7 +319,10 @@ class AccountService:
         )
 
         db.session.add(account)
-        db.session.commit()
+        if commit:
+            db.session.commit()
+        else:
+            db.session.flush()
         return account
 
     @staticmethod
@@ -386,8 +395,8 @@ class AccountService:
         delete_account_task.delay(account.id)
 
     @staticmethod
-    def link_account_integrate(provider: str, open_id: str, account: Account):
-        """Link account integrate"""
+    def link_account_integrate(provider: str, open_id: str, account: Account, *, commit: bool = True):
+        """Link an external identity to an account."""
         try:
             # Query whether there is an existing binding record for the same provider
             account_integrate: AccountIntegrate | None = db.session.scalar(
@@ -408,7 +417,10 @@ class AccountService:
                 )
                 db.session.add(account_integrate)
 
-            db.session.commit()
+            if commit:
+                db.session.commit()
+            else:
+                db.session.flush()
             logger.info("Account %s linked %s account %s.", account.id, provider, open_id)
         except Exception as e:
             logger.exception("Failed to link %s account %s to Account %s", provider, open_id, account.id)
@@ -1053,8 +1065,18 @@ class AccountService:
 
 class TenantService:
     @staticmethod
-    def create_tenant(name: str, is_setup: bool | None = False, is_from_dashboard: bool | None = False) -> Tenant:
-        """Create tenant"""
+    def create_tenant(
+        name: str,
+        is_setup: bool | None = False,
+        is_from_dashboard: bool | None = False,
+        *,
+        commit: bool = True,
+    ) -> Tenant:
+        """Create a tenant.
+
+        When ``commit`` is ``False``, the caller owns the surrounding
+        transaction and this method only flushes intermediate rows.
+        """
         if (
             not FeatureService.get_system_features().is_allow_create_workspace
             and not is_setup
@@ -1066,7 +1088,7 @@ class TenantService:
         tenant = Tenant(name=name)
 
         db.session.add(tenant)
-        db.session.commit()
+        db.session.flush()
 
         plugin_upgrade_strategy = TenantPluginAutoUpgradeStrategy(
             tenant_id=tenant.id,
@@ -1077,20 +1099,29 @@ class TenantService:
             include_plugins=[],
         )
         db.session.add(plugin_upgrade_strategy)
-        db.session.commit()
 
         tenant.encrypt_public_key = generate_key_pair(tenant.id)
-        db.session.commit()
 
         from services.credit_pool_service import CreditPoolService
 
-        CreditPoolService.create_default_pool(tenant.id)
+        CreditPoolService.create_default_pool(tenant.id, commit=False)
+
+        if commit:
+            db.session.commit()
+        else:
+            db.session.flush()
 
         return tenant
 
     @staticmethod
-    def create_owner_tenant_if_not_exist(account: Account, name: str | None = None, is_setup: bool | None = False):
-        """Check if user have a workspace or not"""
+    def create_owner_tenant_if_not_exist(
+        account: Account,
+        name: str | None = None,
+        is_setup: bool | None = False,
+        *,
+        commit: bool = True,
+    ):
+        """Create an owner workspace when the account does not have one."""
         available_ta = db.session.scalar(
             select(TenantAccountJoin)
             .where(TenantAccountJoin.account_id == account.id)
@@ -1110,17 +1141,26 @@ class TenantService:
             raise WorkspacesLimitExceededError()
 
         if name:
-            tenant = TenantService.create_tenant(name=name, is_setup=is_setup)
+            tenant = TenantService.create_tenant(name=name, is_setup=is_setup, commit=False)
         else:
-            tenant = TenantService.create_tenant(name=f"{account.name}'s Workspace", is_setup=is_setup)
-        TenantService.create_tenant_member(tenant, account, role="owner")
+            tenant = TenantService.create_tenant(name=f"{account.name}'s Workspace", is_setup=is_setup, commit=False)
+        TenantService.create_tenant_member(tenant, account, role="owner", commit=False)
         account.current_tenant = tenant
-        db.session.commit()
-        tenant_was_created.send(tenant)
+        if commit:
+            db.session.commit()
+            tenant_was_created.send(tenant)
+        else:
+            db.session.flush()
 
     @staticmethod
-    def create_tenant_member(tenant: Tenant, account: Account, role: str = "normal") -> TenantAccountJoin:
-        """Create tenant member"""
+    def create_tenant_member(
+        tenant: Tenant,
+        account: Account,
+        role: str = "normal",
+        *,
+        commit: bool = True,
+    ) -> TenantAccountJoin:
+        """Create a tenant membership for the account."""
         if role == TenantAccountRole.OWNER:
             if TenantService.has_roles(tenant, [TenantAccountRole.OWNER]):
                 logger.error("Tenant %s has already an owner.", tenant.id)
@@ -1137,7 +1177,10 @@ class TenantService:
             ta = TenantAccountJoin(tenant_id=tenant.id, account_id=account.id, role=TenantAccountRole(role))
             db.session.add(ta)
 
-        db.session.commit()
+        if commit:
+            db.session.commit()
+        else:
+            db.session.flush()
         if dify_config.BILLING_ENABLED:
             BillingService.clean_billing_info_cache(tenant.id)
         return ta
@@ -1469,8 +1512,8 @@ class RegisterService:
         is_setup: bool | None = False,
         create_workspace_required: bool | None = True,
     ) -> Account:
-        db.session.begin_nested()
-        """Register account"""
+        """Register an account with transaction boundaries owned by this method."""
+        tenant: Tenant | None = None
         try:
             account = AccountService.create_account(
                 email=email,
@@ -1478,12 +1521,15 @@ class RegisterService:
                 interface_language=get_valid_language(language),
                 password=password,
                 is_setup=is_setup,
+                commit=False,
             )
             account.status = status or AccountStatus.ACTIVE
             account.initialized_at = naive_utc_now()
+            db.session.commit()
 
             if open_id is not None and provider is not None:
-                AccountService.link_account_integrate(provider, open_id, account)
+                AccountService.link_account_integrate(provider, open_id, account, commit=False)
+                db.session.commit()
 
             if (
                 FeatureService.get_system_features().is_allow_create_workspace
@@ -1491,15 +1537,14 @@ class RegisterService:
                 and FeatureService.get_system_features().license.workspaces.is_available()
             ):
                 try:
-                    tenant = TenantService.create_tenant(f"{account.name}'s Workspace")
-                    TenantService.create_tenant_member(tenant, account, role="owner")
+                    tenant = TenantService.create_tenant(f"{account.name}'s Workspace", commit=False)
+                    TenantService.create_tenant_member(tenant, account, role="owner", commit=False)
                     account.current_tenant = tenant
                     tenant_was_created.send(tenant)
+                    db.session.commit()
                 except Exception:
                     _try_join_enterprise_default_workspace(str(account.id))
                     raise
-
-            db.session.commit()
 
             _try_join_enterprise_default_workspace(str(account.id))
         except WorkSpaceNotAllowedCreateError:

--- a/api/services/credit_pool_service.py
+++ b/api/services/credit_pool_service.py
@@ -26,8 +26,12 @@ class CreditPoolService:
         )
 
     @classmethod
-    def create_default_pool(cls, tenant_id: str) -> TenantCreditPool:
-        """create default credit pool for new tenant"""
+    def create_default_pool(cls, tenant_id: str, *, commit: bool = True) -> TenantCreditPool:
+        """Create the default credit pool for a new tenant.
+
+        When ``commit`` is ``False``, the new pool is flushed into the caller-owned
+        transaction so outer workflows can keep a single transaction owner.
+        """
         credit_pool = TenantCreditPool(
             tenant_id=tenant_id,
             quota_limit=dify_config.HOSTED_POOL_CREDITS,
@@ -35,7 +39,10 @@ class CreditPoolService:
             pool_type=ProviderQuotaType.TRIAL,
         )
         db.session.add(credit_pool)
-        db.session.commit()
+        if commit:
+            db.session.commit()
+        else:
+            db.session.flush()
         return credit_pool
 
     @classmethod

--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -1128,9 +1128,10 @@ class TestRegisterService:
                     interface_language="en-US",
                     password="password123",
                     is_setup=False,
+                    commit=False,
                 )
-                mock_create_tenant.assert_called_once_with("Test User's Workspace")
-                mock_create_member.assert_called_once_with(mock_tenant, mock_account, role="owner")
+                mock_create_tenant.assert_called_once_with("Test User's Workspace", commit=False)
+                mock_create_member.assert_called_once_with(mock_tenant, mock_account, role="owner", commit=False)
                 mock_event.send.assert_called_once_with(mock_tenant)
                 self._assert_database_operations_called(mock_db_dependencies["db"])
 
@@ -1230,7 +1231,7 @@ class TestRegisterService:
                 )
 
             mock_join_default_workspace.assert_called_once_with(str(mock_account.id))
-            mock_db_dependencies["db"].session.commit.assert_not_called()
+            mock_db_dependencies["db"].session.commit.assert_called_once()
 
     def test_register_still_calls_default_workspace_join_when_workspace_limit_exceeded(
         self, mock_db_dependencies, mock_external_service_dependencies, monkeypatch
@@ -1269,7 +1270,7 @@ class TestRegisterService:
                 )
 
             mock_join_default_workspace.assert_called_once_with(str(mock_account.id))
-            mock_db_dependencies["db"].session.commit.assert_not_called()
+            mock_db_dependencies["db"].session.commit.assert_called_once()
 
     def test_register_with_oauth(self, mock_db_dependencies, mock_external_service_dependencies):
         """Test account registration with OAuth integration."""
@@ -1312,7 +1313,7 @@ class TestRegisterService:
 
                 # Verify results
                 assert result == mock_account
-                mock_link_account.assert_called_once_with("google", "oauth123", mock_account)
+                mock_link_account.assert_called_once_with("google", "oauth123", mock_account, commit=False)
                 self._assert_database_operations_called(mock_db_dependencies["db"])
 
     def test_register_with_pending_status(self, mock_db_dependencies, mock_external_service_dependencies):


### PR DESCRIPTION

  ## Summary

  This PR fixes several transaction-boundary issues that can trigger MySQL:

  `sqlalchemy.exc.OperationalError: (1305, 'savepoint does not exist')`

  The main problem was that some API flows created savepoints or nested transaction scopes, then invalidated them by committing or rolling back in lower-level helpers or by asynchronously rolling back pooled
  connections.

  ## What Changed

  - Make SQLAlchemy pool reset rollback synchronous in `api/extensions/ext_database.py`
  - Remove invalid nested/savepoint transaction behavior from account registration flow
  - Let account, tenant, and credit-pool helpers participate in caller-owned transactions through optional `commit` control
  - Preserve the existing registration semantics where account creation can still succeed even if personal workspace creation fails later
  - Allow workflow-run deletion repository code to reuse a caller-provided `Session` instead of always opening and committing its own session
  - Simplify precise workflow cleanup batching so each batch uses a single caller-owned transaction boundary
  - Update account-service unit tests to reflect the new transaction behavior

  ## Why

  There were two concrete failure patterns:

  1. `RegisterService.register()` previously used a nested transaction/savepoint path while helper methods like `create_account()` and tenant-related methods also called `commit()` internally.
     This could cause SQLAlchemy to later execute `RELEASE SAVEPOINT sa_savepoint_1` after the savepoint had already been invalidated.

  2. The pool reset hook could defer `rollback()` with `gevent.spawn_later(...)`.
     That created a race where a connection could be reused by a new request before the delayed rollback executed, which could wipe out the new transaction/savepoint unexpectedly.

  This PR removes both classes of invalid transaction behavior.

  ## Validation

  Passed locally:

  - `uv run --project api ruff check api/extensions/ext_database.py api/repositories/api_workflow_run_repository.py api/repositories/sqlalchemy_api_workflow_run_repository.py api/schedule/
  clean_workflow_runlogs_precise.py api/services/account_service.py api/services/credit_pool_service.py api/tests/unit_tests/services/test_account_service.py`
  - `uv run --project api --group dev pytest tests/unit_tests/services/test_account_service.py tests/unit_tests/services/test_clear_free_plan_expired_workflow_run_logs.py -q`

  Result:

  - `76 passed`

  ## Scope

  This PR only includes the transaction/savepoint fix set under `api/`.
  It does not include unrelated local files such as `charts/`.