### PR TITLE
fix: avoid trial workflow schema model collision

### DIFF
--- a/api/controllers/console/explore/trial.py
+++ b/api/controllers/console/explore/trial.py
@@ -106,7 +106,7 @@ app_detail_fields_with_site_copy["tags"] = fields.List(fields.Nested(tag_model))
 app_detail_fields_with_site_copy["site"] = fields.Nested(site_model)
 app_detail_with_site_model = get_or_create_model("TrialAppDetailWithSite", app_detail_fields_with_site_copy)
 
-simple_account_model = get_or_create_model("SimpleAccount", simple_account_fields)
+simple_account_model = get_or_create_model("TrialSimpleAccount", simple_account_fields)
 conversation_variable_model = get_or_create_model("TrialConversationVariable", conversation_variable_fields)
 pipeline_variable_model = get_or_create_model("TrialPipelineVariable", pipeline_variable_fields)
 

--- a/api/openapi/markdown/console-swagger.md
+++ b/api/openapi/markdown/console-swagger.md
@@ -13786,6 +13786,14 @@ Tag type
 | unit | string |  | No |
 | variable | string |  | No |
 
+#### TrialSimpleAccount
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| email | string |  | No |
+| id | string |  | No |
+| name | string |  | No |
+
 #### TrialSite
 
 | Name | Type | Description | Required |
@@ -13829,7 +13837,7 @@ Tag type
 | ---- | ---- | ----------- | -------- |
 | conversation_variables | [ [TrialConversationVariable](#trialconversationvariable) ] |  | No |
 | created_at | object |  | No |
-| created_by | [SimpleAccount](#simpleaccount) |  | No |
+| created_by | [TrialSimpleAccount](#trialsimpleaccount) |  | No |
 | environment_variables | [ object ] |  | No |
 | features | object |  | No |
 | graph | object |  | No |
@@ -13840,7 +13848,7 @@ Tag type
 | rag_pipeline_variables | [ [TrialPipelineVariable](#trialpipelinevariable) ] |  | No |
 | tool_published | boolean |  | No |
 | updated_at | object |  | No |
-| updated_by | [SimpleAccount](#simpleaccount) |  | No |
+| updated_by | [TrialSimpleAccount](#trialsimpleaccount) |  | No |
 | version | string |  | No |
 
 #### TrialWorkflowPartial

--- a/api/tests/unit_tests/controllers/console/explore/test_trial.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_trial.py
@@ -88,6 +88,11 @@ def valid_parameters():
     }
 
 
+def test_trial_workflow_uses_trial_scoped_simple_account_model():
+    assert module.simple_account_model.name == "TrialSimpleAccount"
+    assert hasattr(module.simple_account_model, "items")
+
+
 class TestTrialAppWorkflowRunApi:
     def test_not_workflow_app(self, app: Flask):
         api = module.TrialAppWorkflowRunApi()


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix https://github.com/langgenius/dify/issues/36059

maybe caused by #35967 

`SimpleAccount` can be registered as a Swagger-only `SchemaModel` by Pydantic response schema registration. The trial workflow response then reused that global `SimpleAccount` name inside `fields.Nested(...)`, which made Flask-RESTX marshal fail with:

`AttributeError: 'SchemaModel' object has no attribute 'items'`

This change scopes the trial response model name to `TrialSimpleAccount`, matching the existing `Trial*` model naming pattern and avoiding the collision without changing the response payload shape.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
