### PR TITLE
fix: replace sessionmaker().begin() with Session() in RAG Pipeline controllers to prevent transaction conflicts

### DIFF
--- a/api/controllers/console/datasets/rag_pipeline/rag_pipeline_datasets.py
+++ b/api/controllers/console/datasets/rag_pipeline/rag_pipeline_datasets.py
@@ -1,6 +1,6 @@
 from flask_restx import Resource, marshal
 from pydantic import BaseModel
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session
 from werkzeug.exceptions import Forbidden
 
 import services
@@ -54,7 +54,7 @@ class CreateRagPipelineDatasetApi(Resource):
             yaml_content=payload.yaml_content,
         )
         try:
-            with sessionmaker(db.engine).begin() as session:
+            with Session(db.engine, expire_on_commit=False) as session:
                 rag_pipeline_dsl_service = RagPipelineDslService(session)
                 import_info = rag_pipeline_dsl_service.create_rag_pipeline_dataset(
                     tenant_id=current_tenant_id,

--- a/api/controllers/console/datasets/rag_pipeline/rag_pipeline_import.py
+++ b/api/controllers/console/datasets/rag_pipeline/rag_pipeline_import.py
@@ -1,7 +1,7 @@
 from flask import request
 from flask_restx import Resource, fields, marshal_with  # type: ignore
 from pydantic import BaseModel, Field
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session
 
 from controllers.common.schema import get_or_create_model, register_schema_models
 from controllers.console import console_ns
@@ -68,7 +68,7 @@ class RagPipelineImportApi(Resource):
         payload = RagPipelineImportPayload.model_validate(console_ns.payload or {})
 
         # Create service with session
-        with sessionmaker(db.engine).begin() as session:
+        with Session(db.engine, expire_on_commit=False) as session:
             import_service = RagPipelineDslService(session)
             # Import app
             account = current_user
@@ -103,7 +103,7 @@ class RagPipelineImportConfirmApi(Resource):
         current_user, _ = current_account_with_tenant()
 
         # Create service with session
-        with sessionmaker(db.engine).begin() as session:
+        with Session(db.engine, expire_on_commit=False) as session:
             import_service = RagPipelineDslService(session)
             # Confirm import
             account = current_user
@@ -124,7 +124,7 @@ class RagPipelineImportCheckDependenciesApi(Resource):
     @edit_permission_required
     @marshal_with(pipeline_import_check_dependencies_model)
     def get(self, pipeline: Pipeline):
-        with sessionmaker(db.engine).begin() as session:
+        with Session(db.engine, expire_on_commit=False) as session:
             import_service = RagPipelineDslService(session)
             result = import_service.check_dependencies(pipeline=pipeline)
 
@@ -142,7 +142,7 @@ class RagPipelineExportApi(Resource):
         # Add include_secret params
         query = IncludeSecretQuery.model_validate(request.args.to_dict())
 
-        with sessionmaker(db.engine).begin() as session:
+        with Session(db.engine, expire_on_commit=False) as session:
             export_service = RagPipelineDslService(session)
             result = export_service.export_rag_pipeline_dsl(
                 pipeline=pipeline, include_secret=query.include_secret == "true"

--- a/api/controllers/console/datasets/rag_pipeline/rag_pipeline_workflow.py
+++ b/api/controllers/console/datasets/rag_pipeline/rag_pipeline_workflow.py
@@ -5,7 +5,7 @@ from typing import Any, Literal, cast
 from flask import abort, request
 from flask_restx import Resource, marshal_with  # type: ignore
 from pydantic import BaseModel, Field, ValidationError
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session
 from werkzeug.exceptions import BadRequest, Forbidden, InternalServerError, NotFound
 
 import services
@@ -591,7 +591,7 @@ class PublishedAllRagPipelineApi(Resource):
                 raise Forbidden()
 
         rag_pipeline_service = RagPipelineService()
-        with sessionmaker(db.engine).begin() as session:
+        with Session(db.engine, expire_on_commit=False) as session:
             workflows, has_more = rag_pipeline_service.get_all_published_workflow(
                 session=session,
                 pipeline=pipeline,
@@ -663,7 +663,7 @@ class RagPipelineByIdApi(Resource):
         rag_pipeline_service = RagPipelineService()
 
         # Create a session and manage the transaction
-        with sessionmaker(db.engine, expire_on_commit=False).begin() as session:
+        with Session(db.engine, expire_on_commit=False) as session:
             workflow = rag_pipeline_service.update_workflow(
                 session=session,
                 workflow_id=workflow_id,
@@ -691,7 +691,7 @@ class RagPipelineByIdApi(Resource):
 
         workflow_service = WorkflowService()
 
-        with sessionmaker(db.engine).begin() as session:
+        with Session(db.engine, expire_on_commit=False) as session:
             try:
                 workflow_service.delete_workflow(
                     session=session,


### PR DESCRIPTION
…ntrollers

Fixes langgenius/dify#36062

Root cause: sessionmaker(db.engine).begin() auto-closes the transaction when the with block exits, conflicting with RagPipelineDslService internal commits (lines 328, 340, 465, 477, 588, 631).

Fix: Replace with Session(db.engine, expire_on_commit=False) pattern (as used in app_import.py and PR #34407).

Changes:
- rag_pipeline_datasets.py: import + usage
- rag_pipeline_import.py: import + 4 usages
- rag_pipeline_workflow.py: import + 2 usages

Note: rag_pipeline_workflow.py:666 already fixed by PR #34407

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

RAG Pipeline controllers use sessionmaker(db.engine).begin() as a context manager, which auto-closes the transaction when the with block exits normally. However, RagPipelineDslService internally calls self._session.commit() at multiple points (lines 328, 340, 465, 477, 588, 631). This causes sqlalchemy.exc.InvalidRequestError: Can't operate on closed transaction when the ORM lazy-loads attributes after an internal commit.

Related Issues:
- Primary: Fixes #36062
- Related: #34406, #34407 (PR #34407 partially fixed similar issue for workflow publish path)

Symptoms:
1. RAG Pipeline dataset creation (POST /console/api/datasets) → redirect to /datasets/null/pipeline, frontend 404 errors
2. Workflow draft sync (POST /console/api/rag/pipelines/{id}/workflows/draft) → HTTP 409 Conflict

Fix:
Replace sessionmaker(db.engine).begin() with Session(db.engine, expire_on_commit=False) — no auto-close, service controls commit.

Before (problematic):
with sessionmaker(db.engine).begin() as session:
    service = RagPipelineDslService(session)
    result = service.import_rag_pipeline(...)  # internal commit() at line 328
    return result.model_dump()  # lazy-load fails!

After (correct):
with Session(db.engine, expire_on_commit=False) as session:
    service = RagPipelineDslService(session)
    result = service.import_rag_pipeline(...)
    return result.model_dump()  # lazy-load succeeds

Changes:
- rag_pipeline_datasets.py: import + 1 usage
- rag_pipeline_import.py: import + 4 usages
- rag_pipeline_workflow.py: import + 2 usages

Note: rag_pipeline_workflow.py:666 already fixed by PR #34407, left unchanged.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
