### PR TITLE
fix: fix plugin miss version and checksum

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -4699,9 +4699,6 @@
     },
     "ts/no-explicit-any": {
       "count": 3
-    },
-    "ts/no-non-null-asserted-optional-chain": {
-      "count": 1
     }
   },
   "web/service/use-tools.ts": {

--- a/web/service/use-plugins.ts
+++ b/web/service/use-plugins.ts
@@ -336,7 +336,7 @@ export const useInstallOrUpdate = ({
           }
           if (item.type === 'marketplace') {
             const data = item as GitHubItemAndMarketPlaceDependency
-            uniqueIdentifier = data.value.marketplace_plugin_unique_identifier! || plugin[i]?.plugin_id!
+            uniqueIdentifier = data.value.marketplace_plugin_unique_identifier! || (plugin[i]?.latest_package_identifier ?? '') || (plugin[i]?.plugin_id ?? '')
             if (uniqueIdentifier === installedPayload?.uniqueIdentifier) {
               return {
                 status: TaskStatus.success,


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #36081

when call https://marketplace.dify.ai/api/v1/plugins/download?unique_identifier=langgenius/deepseek

it need unique_identifier it author/plugin:version@checksum format, but currently it miss version@checksum, so it will fail {"code":-1,"data":null,"msg":"plugin unique identifier is invalid"}

and call 

```
2026-05-12 11:39:46,89 ERROR [base.py:242] 787f6b0685 Failed to request plugin daemon, status: 400, url: plugin/f067162a-a141-4128-9836-ee2ad3623e94/management/fetch/manifest
Traceback (most recent call last):
  File "/Users/fatelei/dify/dify/api/core/plugin/impl/base.py", line 240, in _request_with_plugin_daemon_response
    response.raise_for_status()
  File "/Users/fatelei/dify/dify/api/.venv/lib/python3.12/site-packages/httpx/_models.py", line 829, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Client error '400 Bad Request' for url 'http://127.0.0.1:10000/plugin/f067162a-a141-4128-9836-ee2ad3623e94/management/fetch/manifest?plugin_unique_identifier=langgenius%2Fdeepseek'
```

latest_package_identifier is the right format

<img width="867" height="250" alt="image" src="https://github.com/user-attachments/assets/0b4f0879-1593-4d05-90be-5758bb57f4f5" />


## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
