### PR TITLE
fix(marketplace): prevent search tab switches from polluting browser history

### DIFF
--- a/web/app/components/plugins/marketplace/atoms.ts
+++ b/web/app/components/plugins/marketplace/atoms.ts
@@ -104,8 +104,12 @@ export function useSearchTab() {
   const handleChange = useCallback(
     (newTab: string) => {
       const location = new URL(window.location.href)
+      const isAlreadyOnSearch = location.pathname.startsWith('/search/')
       location.pathname = `/search/${newTab}`
-      router.push(location.href)
+      if (isAlreadyOnSearch)
+        router.replace(location.href)
+      else
+        router.push(location.href)
     },
     [router],
   )


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

On the marketplace, pressing the browser back button from **All Templates** (`/search/templates`) landed users on **All Plugins** (`/search/plugins`) instead of returning to the page that opened search (e.g. `/templates`).

Root cause: `useSearchTab().handleChange` in `web/app/components/plugins/marketplace/atoms.ts` always called `router.push` when switching the search tab. Because `/search/plugins`, `/search/templates`, etc. are distinct paths, every in-page tab switch added a new history entry — so back had to traverse those entries before leaving the search context.

Fix: distinguish entry from in-page navigation.

- When already on `/search/*`, switch tabs with `router.replace` — no extra history entry.
- When entering search from elsewhere (e.g. clicking "View More" on `/templates`), keep `router.push` — the prior page stays in history so back works.

After this change:
- `/templates` → search input → `/search/all` → click Templates tab → `/search/templates` → **Back goes directly to `/templates`** (previously required two back clicks).
- Existing flows that enter search from outside (View More, search submit) are unaffected.

## Screenshots

| Before | After |
|--------|-------|
| Back from `/search/templates` lands on `/search/plugins` | Back from `/search/templates` returns to `/templates` |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
