### PR TITLE
fix(security): isolate Langfuse v3 SDK TracerProvider to prevent cros…

### DIFF
--- a/api/providers/trace/trace-langfuse/src/dify_trace_langfuse/langfuse_trace.py
+++ b/api/providers/trace/trace-langfuse/src/dify_trace_langfuse/langfuse_trace.py
@@ -13,6 +13,8 @@ from langfuse.api import (
     TraceBody,
 )
 from langfuse.api.commons.types.usage import Usage
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
 from sqlalchemy.orm import sessionmaker
 
 from core.ops.base_trace_instance import BaseTraceInstance
@@ -52,12 +54,39 @@ class LangFuseDataTrace(BaseTraceInstance):
         langfuse_config: LangfuseConfig,
     ):
         super().__init__(langfuse_config)
+        # Isolated TracerProvider prevents the langfuse v3 SDK from attaching its
+        # SpanProcessor to the global OpenTelemetry TracerProvider, which would
+        # otherwise siphon every Flask/Celery/SQLAlchemy span in the process into
+        # this tenant's Langfuse project. See langfuse upgrade guide v2 -> v3.
+        self._tracer_provider = TracerProvider(
+            resource=Resource.create({"service.name": "dify-langfuse-app-trace"}),
+        )
         self.langfuse_client = Langfuse(
             public_key=langfuse_config.public_key,
             secret_key=langfuse_config.secret_key,
             host=langfuse_config.host,
+            tracer_provider=self._tracer_provider,
         )
         self.file_base_url = os.getenv("FILES_URL", "http://127.0.0.1:5001")
+
+    def close(self) -> None:
+        """Flush and shut down the isolated TracerProvider.
+
+        Called explicitly when the trace instance is evicted from the cache, or
+        implicitly via ``__del__`` on garbage collection. Idempotent.
+        """
+        provider = getattr(self, "_tracer_provider", None)
+        if provider is None:
+            return
+        try:
+            provider.shutdown()
+        except Exception:
+            logger.debug("Failed to shut down Langfuse TracerProvider", exc_info=True)
+        finally:
+            self._tracer_provider = None
+
+    def __del__(self) -> None:
+        self.close()
 
     @staticmethod
     def _get_completion_start_time(

--- a/api/providers/trace/trace-langfuse/tests/unit_tests/langfuse_trace/test_langfuse_trace.py
+++ b/api/providers/trace/trace-langfuse/tests/unit_tests/langfuse_trace/test_langfuse_trace.py
@@ -50,18 +50,92 @@ def trace_instance(langfuse_config, monkeypatch: pytest.MonkeyPatch):
 
 
 def test_init(langfuse_config, monkeypatch: pytest.MonkeyPatch):
+    from opentelemetry.sdk.trace import TracerProvider
+
     mock_langfuse = MagicMock()
     monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.Langfuse", mock_langfuse)
     monkeypatch.setenv("FILES_URL", "http://test.url")
 
     instance = LangFuseDataTrace(langfuse_config)
 
-    mock_langfuse.assert_called_once_with(
-        public_key=langfuse_config.public_key,
-        secret_key=langfuse_config.secret_key,
-        host=langfuse_config.host,
-    )
+    mock_langfuse.assert_called_once()
+    kwargs = mock_langfuse.call_args.kwargs
+    assert kwargs["public_key"] == langfuse_config.public_key
+    assert kwargs["secret_key"] == langfuse_config.secret_key
+    assert kwargs["host"] == langfuse_config.host
+    assert isinstance(kwargs["tracer_provider"], TracerProvider)
+    assert kwargs["tracer_provider"] is instance._tracer_provider
     assert instance.file_base_url == "http://test.url"
+
+
+def test_init_passes_isolated_tracer_provider_to_langfuse(
+    langfuse_config, monkeypatch: pytest.MonkeyPatch
+):
+    """Regression test for langfuse v3 SDK side effect.
+
+    Without an explicit ``tracer_provider=`` kwarg, the Langfuse v3 SDK
+    attaches a ``LangfuseSpanProcessor`` to the *global* OpenTelemetry
+    TracerProvider — siphoning every Flask / Celery / SQLAlchemy span in the
+    process into the tenant's Langfuse project. See langfuse upgrade-path
+    docs (v2 -> v3) and GitHub discussion #9136.
+
+    The fix is to construct an isolated ``TracerProvider`` and pass it via
+    ``tracer_provider=`` so the SDK never touches the global one.
+    """
+    from opentelemetry import trace as otel_trace_api
+    from opentelemetry.sdk.trace import TracerProvider
+
+    captured: dict[str, object] = {}
+
+    def fake_langfuse(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.Langfuse", fake_langfuse)
+
+    instance = LangFuseDataTrace(langfuse_config)
+
+    # 1. tracer_provider kwarg must be supplied (drives the no-pollution branch
+    #    in langfuse.LangfuseResourceManager._init_tracer_provider).
+    assert "tracer_provider" in captured, (
+        "Langfuse() must receive an explicit tracer_provider=; without it the "
+        "v3 SDK attaches its SpanProcessor to the global OTEL TracerProvider."
+    )
+
+    passed_provider = captured["tracer_provider"]
+    assert isinstance(passed_provider, TracerProvider)
+    assert passed_provider is instance._tracer_provider
+
+    # 2. The instance's provider must not be the global one.
+    global_provider = otel_trace_api.get_tracer_provider()
+    assert passed_provider is not global_provider
+
+
+def test_close_shuts_down_tracer_provider(langfuse_config, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.Langfuse", lambda **kwargs: MagicMock())
+
+    instance = LangFuseDataTrace(langfuse_config)
+    provider = instance._tracer_provider
+    provider_shutdown = MagicMock()
+    monkeypatch.setattr(provider, "shutdown", provider_shutdown)
+
+    instance.close()
+
+    provider_shutdown.assert_called_once()
+    assert instance._tracer_provider is None
+
+
+def test_close_is_idempotent(langfuse_config, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("dify_trace_langfuse.langfuse_trace.Langfuse", lambda **kwargs: MagicMock())
+
+    instance = LangFuseDataTrace(langfuse_config)
+    provider_shutdown = MagicMock()
+    monkeypatch.setattr(instance._tracer_provider, "shutdown", provider_shutdown)
+
+    instance.close()
+    instance.close()
+
+    provider_shutdown.assert_called_once()
 
 
 def test_trace_dispatch(trace_instance, monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
…s-tenant trace leak

Langfuse Python SDK v3 (introduced in #34265) attaches its SpanProcessor to the *global* OpenTelemetry TracerProvider when no explicit tracer_provider is passed. With ext_otel.py already installing a global TracerProvider and FlaskInstrumentor active, every Flask / Celery / SQLAlchemy span emitted by the process — across all tenants — was being exported to the first tenant who configured a workflow-level Langfuse integration.

Fix:
- Construct an isolated TracerProvider per LangFuseDataTrace instance and pass it via the documented tracer_provider= kwarg so the SDK never touches the global provider.
- Add close() / __del__ to shut down the isolated provider when the trace instance is evicted from the LRU cache, avoiding background batch exporter thread leaks on config rotation.

Tests:
- Regression test asserting Langfuse() receives an isolated TracerProvider distinct from the global one.
- Tests for close() shutdown and idempotency.

Refs:
- langfuse upgrade guide v2 -> v3 (warns about cross-instrumentation capture)
- https://github.com/orgs/langfuse/discussions/9136

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
