### PR TITLE
fix(auth): preserve `phase` field in `_TokenData` so reset-password / change-email phase-bound checks don't 400 (#36116)

### DIFF
--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -39,6 +39,7 @@ class _TokenData(TypedDict, total=False):
     token_type: str
     code: str
     old_email: str
+    phase: str
 
 
 _token_data_adapter: TypeAdapter[_TokenData] = TypeAdapter(_TokenData)

--- a/api/tests/unit_tests/libs/test_token_manager.py
+++ b/api/tests/unit_tests/libs/test_token_manager.py
@@ -1,0 +1,58 @@
+"""
+Regression tests for the `_TokenData` TypedDict used by
+`libs.helper.TokenManager`.
+
+These tests guard the contract that every field a caller writes via
+`generate_token` survives the TypedDict-validated round-trip performed
+by `get_token_data`. Specifically, the `phase` field that the console
+and web `forgot-password` + `change-email` controllers depend on for
+the security check introduced in PR #35425 (GHSA-4q3w-q5mc-45rq) must
+be preserved — otherwise downstream `if data.get("phase", "") != "reset"`
+checks always fail with `InvalidTokenError`.
+"""
+
+import json
+
+# pyright: reportPrivateUsage=false
+from libs.helper import _token_data_adapter
+
+
+def test_token_data_adapter_preserves_phase_field() -> None:
+    """`phase` written by callers like generate_reset_password_token must
+    survive the TypedDict-validated round-trip in get_token_data.
+
+    Regression: PR #34380 introduced `_TokenData` but did not list
+    `phase`, so the TypeAdapter silently dropped it and the security
+    gate from PR #35425 (GHSA-4q3w-q5mc-45rq) always failed.
+    """
+    payload = {
+        "account_id": None,
+        "email": "user@example.com",
+        "token_type": "reset_password",
+        "code": "123456",
+        "phase": "reset",
+    }
+    data = dict(_token_data_adapter.validate_json(json.dumps(payload)))
+
+    assert data.get("phase") == "reset", (
+        "phase field was stripped by the _TokenData TypedDict adapter; "
+        "the forgot-password phase-bound check (PR #35425) will always fail."
+    )
+
+
+def test_token_data_adapter_preserves_change_email_payload() -> None:
+    """Sanity round-trip for the change-email flow: every field set by
+    `generate_change_email_token` must come back, including the phase
+    string the controller branches on."""
+    payload = {
+        "account_id": "acc-1",
+        "email": "new@example.com",
+        "token_type": "change_email",
+        "code": "654321",
+        "old_email": "old@example.com",
+        "phase": "verify_old_email",
+    }
+    data = dict(_token_data_adapter.validate_json(json.dumps(payload)))
+
+    assert data.get("old_email") == "old@example.com"
+    assert data.get("phase") == "verify_old_email"


### PR DESCRIPTION
Fixes #36116

## Summary

`POST /console/api/forgot-password/resets` (and equivalent change-email flows) always return `400 invalid_or_expired_token` on `1.14.0`, `1.14.1`, and current `main` — even with a fresh, valid token that's still in redis. Two PRs that shipped together in `1.14.0` interact badly:

- **#35425** (`fix(auth): enforce phase-bound change-email token flow`, GHSA-4q3w-q5mc-45rq) added a `phase` field to reset / change-email tokens and a `if data.get("phase", "") != "reset"` gate in `controllers/console/auth/forgot_password.py:174`.
- **#34380** (`refactor(api): replace json.loads with Pydantic validation in security and tools layers`) replaced `json.loads(...)` in `TokenManager.get_token_data` (`libs/helper.py:473`) with `dict(_token_data_adapter.validate_json(...))`. The `_TokenData` TypedDict on `libs/helper.py:36` lists `account_id, email, token_type, code, old_email` — but **not** `phase`, so the TypeAdapter silently strips it.

Net effect: the gate from #35425 always sees `phase == ""` and the reset flow is 100% broken. Issue #36116 has the full repro.

This PR adds `phase: str` to `_TokenData`. Since the TypedDict is declared `total=False`, every field is already optional — no callers need to change.

I also added `api/tests/unit_tests/libs/test_token_manager.py` which round-trips both the `reset_password` and `change_email` payloads through the `_token_data_adapter`. Without the one-line fix, both tests fail with the same `KeyError`/`None` symptom seen in production; with the fix, both pass.

Verified end-to-end on a `1.14.0` deployment after hot-patching the same line: `/forgot-password/resets` returns `200 {"result":"success"}` and the password is updated.

## Screenshots

N/A — backend-only change. The user-visible symptom is the 400 alert on the password-reset form; after this fix the form succeeds and routes to the sign-in page as before `1.14.0`.

## Checklist

- [x] This change requires a documentation update — N/A, internal contract.
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. Issue #36116 was filed first; this PR links to it.
- [x] I've added a test for each change that was introduced (`api/tests/unit_tests/libs/test_token_manager.py`) and tried to keep it a single atomic change.
- [x] I've updated the documentation accordingly. (No docs touched the field list.)
- [x] I ran `ruff check` + `ruff format --check` on the changed files locally (using `ruff 0.15.12`, matching `api/pyproject.toml`'s pin); both clean.

From Claude Code