### PR TITLE
test(e2e): add app search scenario

### DIFF
--- a/e2e/features/apps/search-app.feature
+++ b/e2e/features/apps/search-app.feature
@@ -1,0 +1,8 @@
+@apps @authenticated @core
+Feature: Search app
+  Scenario: Search an existing app by name from the apps console
+    Given I am signed in as the default E2E admin
+    And there is an existing E2E app available for testing
+    When I open the apps console
+    And I search for the last created E2E app
+    Then I should see the last created E2E app in the apps console

--- a/e2e/features/step-definitions/apps/search-app.steps.ts
+++ b/e2e/features/step-definitions/apps/search-app.steps.ts
@@ -1,0 +1,36 @@
+import type { DifyWorld } from '../../support/world'
+import { Then, When } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+
+When('I search for the last created E2E app', async function (this: DifyWorld) {
+  const appName = this.lastCreatedAppName
+  if (!appName) {
+    throw new Error(
+      'No app name stored. Run "there is an existing E2E app available for testing" first.',
+    )
+  }
+
+  const page = this.getPage()
+
+  await expect(page.getByRole('button', { name: 'Create from Blank' })).toBeVisible()
+
+  const searchInput = page.getByRole('textbox').last()
+
+  await expect(searchInput).toBeVisible()
+  await searchInput.fill(appName)
+
+  await expect
+    .poll(() => new URL(page.url()).searchParams.get('keywords'))
+    .toBe(appName)
+})
+
+Then('I should see the last created E2E app in the apps console', async function (this: DifyWorld) {
+  const appName = this.lastCreatedAppName
+  if (!appName) {
+    throw new Error(
+      'No app name stored. Run "there is an existing E2E app available for testing" first.',
+    )
+  }
+
+  await expect(this.getPage().getByText(appName, { exact: true })).toBeVisible()
+})


### PR DESCRIPTION
## What

Adds an E2E scenario for searching an existing app by name from the apps console.

This PR adds:

- `e2e/features/apps/search-app.feature`
- `e2e/features/step-definitions/apps/search-app.steps.ts`

## Why

The apps E2E coverage already includes creation, duplication, deletion, export, publish, share, and mode-switching flows. This PR adds coverage for another common apps console path: filtering/searching an app by name.

This contributes to #34278.

## Implementation

The scenario:

1. Signs in as the default E2E admin.
2. Creates an existing E2E app via the existing test setup step.
3. Opens the apps console.
4. Searches for the last created E2E app by name.
5. Verifies the app is visible in the apps console.

The test reuses the existing app setup flow and keeps the scope limited to one apps-console search scenario.

## Validation

Local static check:

`git diff --cached --check`

Result: passed with no whitespace errors.

Full E2E suite was not run locally because this change was prepared from a sparse checkout focused on the `e2e/` directory.