### PR TITLE
fix(errors): clean unnecessary | None in error classes

### DIFF
--- a/api/services/errors/base.py
+++ b/api/services/errors/base.py
@@ -1,3 +1,3 @@
 class BaseServiceError(ValueError):
-    def __init__(self, description: str | None = None):
+    def __init__(self, description: str = ""):
         self.description = description

--- a/api/services/errors/enterprise.py
+++ b/api/services/errors/enterprise.py
@@ -6,7 +6,7 @@ from services.errors.base import BaseServiceError
 class EnterpriseServiceError(BaseServiceError):
     """Base exception for enterprise service errors."""
 
-    def __init__(self, description: str | None = None, status_code: int | None = None):
+    def __init__(self, description: str = "", status_code: int | None = None):
         super().__init__(description)
         self.status_code = status_code
 
@@ -20,26 +20,26 @@ class EnterpriseAPIError(EnterpriseServiceError):
 class EnterpriseAPINotFoundError(EnterpriseServiceError):
     """Enterprise API returned 404 Not Found."""
 
-    def __init__(self, description: str | None = None):
+    def __init__(self, description: str = ""):
         super().__init__(description, status_code=404)
 
 
 class EnterpriseAPIForbiddenError(EnterpriseServiceError):
     """Enterprise API returned 403 Forbidden."""
 
-    def __init__(self, description: str | None = None):
+    def __init__(self, description: str = ""):
         super().__init__(description, status_code=403)
 
 
 class EnterpriseAPIUnauthorizedError(EnterpriseServiceError):
     """Enterprise API returned 401 Unauthorized."""
 
-    def __init__(self, description: str | None = None):
+    def __init__(self, description: str = ""):
         super().__init__(description, status_code=401)
 
 
 class EnterpriseAPIBadRequestError(EnterpriseServiceError):
     """Enterprise API returned 400 Bad Request."""
 
-    def __init__(self, description: str | None = None):
+    def __init__(self, description: str = ""):
         super().__init__(description, status_code=400)

--- a/api/services/errors/llm.py
+++ b/api/services/errors/llm.py
@@ -1,9 +1,9 @@
 class InvokeError(Exception):
     """Base class for all LLM exceptions."""
 
-    description: str | None = None
+    description: str = ""
 
-    def __init__(self, description: str | None = None):
+    def __init__(self, description: str = ""):
         self.description = description
 
     def __str__(self):


### PR DESCRIPTION
## Summary

Replace `description: str | None = None` with `description: str = ""` in error classes where the description is always a string.

## Changes

- `api/services/errors/base.py`: `BaseServiceError.__init__` parameter
- `api/services/errors/llm.py`: `InvokeError` class attribute and `__init__` parameter
- `api/services/errors/enterprise.py`: All enterprise error classes

## Rationale

The `| None` annotation was unnecessary because:
1. All callers pass strings, not None
2. The `__str__` method uses `or` which works with empty strings
3. Empty string is a more appropriate default than None

#35557