### PR TITLE
fix: credit pool access outside flask context

### DIFF
--- a/api/services/credit_pool_service.py
+++ b/api/services/credit_pool_service.py
@@ -1,9 +1,10 @@
 import logging
 
 from sqlalchemy import select
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import Session
 
 from configs import dify_config
+from core.db.session_factory import session_factory
 from core.errors.error import QuotaExceededError
 from extensions.ext_database import db
 from models import TenantCreditPool
@@ -41,7 +42,7 @@ class CreditPoolService:
     @classmethod
     def get_pool(cls, tenant_id: str, pool_type: str = "trial") -> TenantCreditPool | None:
         """get tenant credit pool"""
-        with sessionmaker(db.engine, expire_on_commit=False).begin() as session:
+        with session_factory.get_session_maker().begin() as session:
             return session.scalar(
                 select(TenantCreditPool)
                 .where(
@@ -76,7 +77,7 @@ class CreditPoolService:
             return 0
 
         try:
-            with sessionmaker(db.engine, expire_on_commit=False).begin() as session:
+            with session_factory.get_session_maker().begin() as session:
                 pool = cls._get_locked_pool(session=session, tenant_id=tenant_id, pool_type=pool_type)
                 if not pool:
                     raise QuotaExceededError("Credit pool not found")
@@ -108,7 +109,7 @@ class CreditPoolService:
             return 0
 
         try:
-            with sessionmaker(db.engine, expire_on_commit=False).begin() as session:
+            with session_factory.get_session_maker().begin() as session:
                 pool = cls._get_locked_pool(session=session, tenant_id=tenant_id, pool_type=pool_type)
                 if not pool:
                     logger.warning("Credit pool not found, tenant_id=%s, pool_type=%s", tenant_id, pool_type)

--- a/api/tests/unit_tests/core/app/test_llm_quota.py
+++ b/api/tests/unit_tests/core/app/test_llm_quota.py
@@ -1,8 +1,12 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from sqlalchemy import create_engine, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import sessionmaker
 
 from configs import dify_config
 from core.app.llm.quota import (
@@ -19,6 +23,13 @@ from graphon.model_runtime.entities.model_entities import ModelType
 from models import TenantCreditPool
 from models.enums import ProviderQuotaType as ModelProviderQuotaType
 from models.provider import Provider, ProviderType
+
+
+@contextmanager
+def _patched_credit_pool_session_factory(engine: Engine) -> Iterator[None]:
+    session_maker = sessionmaker(bind=engine, expire_on_commit=False)
+    with patch("services.credit_pool_service.session_factory.get_session_maker", return_value=session_maker):
+        yield
 
 
 def test_ensure_llm_quota_available_for_model_raises_when_system_model_is_exhausted() -> None:
@@ -148,7 +159,7 @@ def test_deduct_llm_quota_for_model_caps_trial_pool_when_usage_exceeds_remaining
 
     with (
         patch("core.app.llm.quota.create_plugin_provider_manager", return_value=provider_manager),
-        patch("services.credit_pool_service.db", SimpleNamespace(engine=engine)),
+        _patched_credit_pool_session_factory(engine),
     ):
         deduct_llm_quota_for_model(
             tenant_id="tenant-id",

--- a/api/tests/unit_tests/events/test_update_provider_when_message_created.py
+++ b/api/tests/unit_tests/events/test_update_provider_when_message_created.py
@@ -1,14 +1,25 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import patch
 from uuid import uuid4
 
 from sqlalchemy import create_engine, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import sessionmaker
 
 from core.app.entities.app_invoke_entities import ChatAppGenerateEntity
 from core.entities.provider_entities import ProviderQuotaType, QuotaUnit
 from events.event_handlers import update_provider_when_message_created
 from models import TenantCreditPool
 from models.provider import ProviderType
+
+
+@contextmanager
+def _patched_credit_pool_session_factory(engine: Engine) -> Iterator[None]:
+    session_maker = sessionmaker(bind=engine, expire_on_commit=False)
+    with patch("services.credit_pool_service.session_factory.get_session_maker", return_value=session_maker):
+        yield
 
 
 def test_message_created_trial_credit_accounting_does_not_raise_when_balance_is_insufficient() -> None:
@@ -54,7 +65,7 @@ def test_message_created_trial_credit_accounting_does_not_raise_when_balance_is_
     message = SimpleNamespace(message_tokens=2, answer_tokens=1)
 
     with (
-        patch("services.credit_pool_service.db", SimpleNamespace(engine=engine)),
+        _patched_credit_pool_session_factory(engine),
         patch.object(update_provider_when_message_created, "_execute_provider_updates"),
     ):
         update_provider_when_message_created.handle(

--- a/api/tests/unit_tests/services/test_credit_pool_service.py
+++ b/api/tests/unit_tests/services/test_credit_pool_service.py
@@ -1,10 +1,12 @@
-from types import SimpleNamespace
+from collections.abc import Iterator
+from contextlib import contextmanager
 from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
 from sqlalchemy import create_engine, select
 from sqlalchemy.engine import Engine
+from sqlalchemy.orm import sessionmaker
 
 from core.errors.error import QuotaExceededError
 from models import TenantCreditPool
@@ -31,15 +33,33 @@ def _create_engine_with_pool(*, quota_limit: int, quota_used: int) -> tuple[Engi
     return engine, tenant_id, pool_id
 
 
+@contextmanager
+def _patched_session_factory(engine: Engine) -> Iterator[None]:
+    session_maker = sessionmaker(bind=engine, expire_on_commit=False)
+    with patch("services.credit_pool_service.session_factory.get_session_maker", return_value=session_maker):
+        yield
+
+
 def _get_quota_used(*, engine: Engine, pool_id: str) -> int | None:
     with engine.connect() as connection:
         return connection.scalar(select(TenantCreditPool.quota_used).where(TenantCreditPool.id == pool_id))
 
 
+def test_get_pool_uses_configured_session_factory_without_flask_app_context() -> None:
+    engine, tenant_id, _ = _create_engine_with_pool(quota_limit=10, quota_used=2)
+
+    with _patched_session_factory(engine):
+        pool = CreditPoolService.get_pool(tenant_id=tenant_id, pool_type=ProviderQuotaType.TRIAL)
+
+    assert pool is not None
+    assert pool.tenant_id == tenant_id
+    assert pool.quota_used == 2
+
+
 def test_check_and_deduct_credits_deducts_exact_amount_when_sufficient() -> None:
     engine, tenant_id, pool_id = _create_engine_with_pool(quota_limit=10, quota_used=2)
 
-    with patch("services.credit_pool_service.db", SimpleNamespace(engine=engine)):
+    with _patched_session_factory(engine):
         deducted_credits = CreditPoolService.check_and_deduct_credits(tenant_id=tenant_id, credits_required=3)
 
     assert deducted_credits == 3
@@ -55,7 +75,7 @@ def test_check_and_deduct_credits_raises_when_pool_is_missing() -> None:
     TenantCreditPool.__table__.create(engine)
 
     with (
-        patch("services.credit_pool_service.db", SimpleNamespace(engine=engine)),
+        _patched_session_factory(engine),
         pytest.raises(QuotaExceededError, match="Credit pool not found"),
     ):
         CreditPoolService.check_and_deduct_credits(tenant_id=str(uuid4()), credits_required=1)
@@ -65,7 +85,7 @@ def test_check_and_deduct_credits_raises_when_pool_is_empty() -> None:
     engine, tenant_id, pool_id = _create_engine_with_pool(quota_limit=10, quota_used=10)
 
     with (
-        patch("services.credit_pool_service.db", SimpleNamespace(engine=engine)),
+        _patched_session_factory(engine),
         pytest.raises(QuotaExceededError, match="No credits remaining"),
     ):
         CreditPoolService.check_and_deduct_credits(tenant_id=tenant_id, credits_required=1)
@@ -77,7 +97,7 @@ def test_check_and_deduct_credits_raises_without_partial_deduction_when_insuffic
     engine, tenant_id, pool_id = _create_engine_with_pool(quota_limit=10, quota_used=9)
 
     with (
-        patch("services.credit_pool_service.db", SimpleNamespace(engine=engine)),
+        _patched_session_factory(engine),
         pytest.raises(QuotaExceededError, match="Insufficient credits remaining"),
     ):
         CreditPoolService.check_and_deduct_credits(tenant_id=tenant_id, credits_required=3)
@@ -89,7 +109,7 @@ def test_check_and_deduct_credits_wraps_unexpected_deduction_errors() -> None:
     engine, tenant_id, pool_id = _create_engine_with_pool(quota_limit=10, quota_used=2)
 
     with (
-        patch("services.credit_pool_service.db", SimpleNamespace(engine=engine)),
+        _patched_session_factory(engine),
         patch.object(CreditPoolService, "_get_locked_pool", side_effect=RuntimeError("database unavailable")),
         pytest.raises(QuotaExceededError, match="Failed to deduct credits"),
     ):
@@ -106,7 +126,7 @@ def test_deduct_credits_capped_returns_zero_when_pool_is_missing() -> None:
     engine = create_engine("sqlite:///:memory:")
     TenantCreditPool.__table__.create(engine)
 
-    with patch("services.credit_pool_service.db", SimpleNamespace(engine=engine)):
+    with _patched_session_factory(engine):
         deducted_credits = CreditPoolService.deduct_credits_capped(tenant_id=str(uuid4()), credits_required=1)
 
     assert deducted_credits == 0
@@ -115,7 +135,7 @@ def test_deduct_credits_capped_returns_zero_when_pool_is_missing() -> None:
 def test_deduct_credits_capped_returns_zero_when_pool_is_empty() -> None:
     engine, tenant_id, pool_id = _create_engine_with_pool(quota_limit=10, quota_used=10)
 
-    with patch("services.credit_pool_service.db", SimpleNamespace(engine=engine)):
+    with _patched_session_factory(engine):
         deducted_credits = CreditPoolService.deduct_credits_capped(tenant_id=tenant_id, credits_required=1)
 
     assert deducted_credits == 0
@@ -125,7 +145,7 @@ def test_deduct_credits_capped_returns_zero_when_pool_is_empty() -> None:
 def test_deduct_credits_capped_deducts_only_remaining_balance_when_insufficient() -> None:
     engine, tenant_id, pool_id = _create_engine_with_pool(quota_limit=10, quota_used=9)
 
-    with patch("services.credit_pool_service.db", SimpleNamespace(engine=engine)):
+    with _patched_session_factory(engine):
         deducted_credits = CreditPoolService.deduct_credits_capped(tenant_id=tenant_id, credits_required=3)
 
     assert deducted_credits == 1
@@ -136,7 +156,7 @@ def test_deduct_credits_capped_wraps_unexpected_deduction_errors() -> None:
     engine, tenant_id, pool_id = _create_engine_with_pool(quota_limit=10, quota_used=2)
 
     with (
-        patch("services.credit_pool_service.db", SimpleNamespace(engine=engine)),
+        _patched_session_factory(engine),
         patch.object(CreditPoolService, "_get_locked_pool", side_effect=RuntimeError("database unavailable")),
         pytest.raises(QuotaExceededError, match="Failed to deduct credits"),
     ):
@@ -149,7 +169,7 @@ def test_deduct_credits_capped_reraises_quota_exceeded_errors() -> None:
     engine, tenant_id, pool_id = _create_engine_with_pool(quota_limit=10, quota_used=2)
 
     with (
-        patch("services.credit_pool_service.db", SimpleNamespace(engine=engine)),
+        _patched_session_factory(engine),
         patch.object(CreditPoolService, "_get_locked_pool", side_effect=QuotaExceededError("quota unavailable")),
         pytest.raises(QuotaExceededError, match="quota unavailable"),
     ):


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->
fix https://github.com/langgenius/dify/issues/36132

error logs:
```
Traceback (most recent call last):\n  File \"/app/api/.venv/lib/python3.12/site-packages/graphon/graph/graph.py\", line 161, in _create_node_instances\n    node_instance = node_factory.create_node(node_config)\n                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/api/core/workflow/node_factory.py\", line 443, in create_node\n    node_init_kwargs = node_init_kwargs_factories.get(node_type, lambda: {})()\n                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/api/core/workflow/node_factory.py\", line 398, in <lambda>\n    BuiltinNodeTypes.LLM: lambda: self._build_llm_compatible_node_init_kwargs(\n                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/api/core/workflow/node_factory.py\", line 480, in _build_llm_compatible_node_init_kwargs\n    model_instance = self._build_model_instance_for_llm_node(validated_node_data)\n                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/api/core/workflow/node_factory.py\", line 508, in _build_model_instance_for_llm_node\n    model_instance, _ = fetch_model_config(\n                        ^^^^^^^^^^^^^^^^^^^\n  File \"/app/api/core/app/llm/model_access.py\", line 141, in fetch_model_config\n    credentials = credentials_provider.fetch(node_data_model.provider, node_data_model.name)\n                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/api/core/app/llm/model_access.py\", line 53, in fetch\n    provider_configurations = self.provider_manager.get_configurations(self.tenant_id)\n                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/api/core/provider_manager.py\", line 230, in get_configurations\n    system_configuration = self._to_system_configuration(tenant_id, provider_entity, provider_records)\n                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/api/core/provider_manager.py\", line 958, in _to_system_configuration\n    trail_pool = CreditPoolService.get_pool(\n                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/api/services/credit_pool_service.py\", line 44, in get_pool\n    with sessionmaker(db.engine, expire_on_commit=False).begin() as session:\n                      ^^^^^^^^^\n  File \"/app/api/.venv/lib/python3.12/site-packages/flask_sqlalchemy/extension.py\", line 709, in engine\n    return self.engines[None]\n           ^^^^^^^^^^^^\n  File \"/app/api/.venv/lib/python3.12/site-packages/flask_sqlalchemy/extension.py\", line 687, in engines\n    app = current_app._get_current_object()  # type: ignore[attr-defined]\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/api/.venv/lib/python3.12/site-packages/werkzeug/local.py\", line 519, in _get_current_object\n    raise RuntimeError(unbound_message) from None\nRuntimeError: Working outside of application context.\n\nThis typically means that you attempted to use functionality that needed\nthe current application. To solve this, set up an application context\nwith app.app_context(). See the documentation for more information.\n
```

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
