### PR TITLE
chore: drop unnecessary | None on LLMError and Mail.send

### DIFF
--- a/api/core/errors/error.py
+++ b/api/core/errors/error.py
@@ -1,9 +1,9 @@
 class LLMError(ValueError):
     """Base class for all LLM exceptions."""
 
-    description: str | None = None
+    description: str = ""
 
-    def __init__(self, description: str | None = None):
+    def __init__(self, description: str = ""):
         self.description = description
 
 

--- a/api/extensions/ext_mail.py
+++ b/api/extensions/ext_mail.py
@@ -67,7 +67,7 @@ class Mail:
             case _:
                 raise ValueError(f"Unsupported mail type {mail_type}")
 
-    def send(self, to: str, subject: str, html: str, from_: str | None = None):
+    def send(self, to: str, subject: str, html: str, from_: str = ""):
         if not self._client:
             raise ValueError("Mail client is not initialized")
 


### PR DESCRIPTION
## Summary

Refs #35557.

A couple of small spots where the `| None` annotation was carrying no
real information and the body never distinguished between `None` and a
plain empty string. Tighten them to `str` with a `""` default so the
types match actual usage.

This is a follow-on cleanup in the same spirit as #36135, but for
different files.

## Changes

- `api/core/errors/error.py`: `LLMError.description` and
  `LLMError.__init__(description=...)` — `str | None = None` → `str = ""`.
  No subclass or caller relies on `description is None`; the field is only
  set/read as a string.
- `api/extensions/ext_mail.py`: `Mail.send(from_=...)` —
  `str | None = None` → `str = ""`. The body uses `if not from_:` then falls
  back to `self._default_send_from`, so an empty string and `None` are
  already equivalent. The only non-test caller
  (`tasks/mail_human_input_delivery_task.py`) does not pass `from_`.

## Notes

- I deliberately kept the diff tiny. There are more candidates suggested
  in the issue thread, but several of them have call sites that pass
  `None` explicitly or rely on `is None` semantics, so they need more
  thought than a mechanical rewrite.
- No behavior change. No new tests required: existing email-send tests
  still cover the default-`from_` path, and `LLMError.description` has no
  test that checks the `None` case.
