### PR TITLE
fix: get recommend_app categories should not re-order it

### DIFF
--- a/api/services/recommend_app/remote/remote_retrieval.py
+++ b/api/services/recommend_app/remote/remote_retrieval.py
@@ -13,7 +13,10 @@ logger = logging.getLogger(__name__)
 
 class RemoteRecommendAppRetrieval(RecommendAppRetrievalBase):
     """
-    Retrieval recommended app from dify official
+    Retrieval recommended app from dify official.
+
+    The remote `/apps` payload is already curated for display, including category order.
+    Keep the response order intact so Explore matches the template service.
     """
 
     def get_recommend_app_detail(self, app_id: str):
@@ -64,8 +67,4 @@ class RemoteRecommendAppRetrieval(RecommendAppRetrievalBase):
             raise ValueError(f"fetch recommended apps failed, status code: {response.status_code}")
 
         result: dict[str, Any] = response.json()
-
-        if "categories" in result:
-            result["categories"] = sorted(result["categories"])
-
         return result

--- a/api/tests/unit_tests/services/recommend_app/test_remote_retrieval.py
+++ b/api/tests/unit_tests/services/recommend_app/test_remote_retrieval.py
@@ -85,7 +85,7 @@ class TestFetchFromDifyOfficial:
 
     @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
-    def test_apps_returns_sorted_categories_on_200(self, mock_get, mock_config):
+    def test_apps_preserves_remote_categories_order_on_200(self, mock_get, mock_config):
         mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {
@@ -96,7 +96,7 @@ class TestFetchFromDifyOfficial:
 
         result = RemoteRecommendAppRetrieval.fetch_recommended_apps_from_dify_official("en-US")
 
-        assert result["categories"] == ["agent", "chat", "writing"]
+        assert result["categories"] == ["writing", "agent", "chat"]
 
     @patch("services.recommend_app.remote.remote_retrieval.dify_config")
     @patch("services.recommend_app.remote.remote_retrieval.httpx.get")


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
