### PR TITLE
feat(MessageLogModal): enhance modal behavior with floating support and accessibility improvements

### DIFF
--- a/web/app/components/base/message-log-modal/__tests__/index.spec.tsx
+++ b/web/app/components/base/message-log-modal/__tests__/index.spec.tsx
@@ -76,14 +76,19 @@ describe('MessageLogModal', () => {
 
     it('sets fixed style when fixedWidth is false (floating)', () => {
       const { container } = render(<MessageLogModal width={1000} onCancel={onCancel} currentLogItem={mockLog} fixedWidth={false} />)
-      const modal = container.firstChild as HTMLElement
-      expect(modal.style.position).toBe('fixed')
+      const modal = screen.getByRole('dialog')
+      expect(container).not.toContainElement(modal)
+      expect(document.body).toContainElement(modal)
+      expect(modal).toHaveClass('fixed', 'z-50')
       expect(modal.style.width).toBe('480px')
+      expect(modal.style.left).toBe('528px')
     })
 
     it('sets fixed width when fixedWidth is true', () => {
       const { container } = render(<MessageLogModal width={1000} onCancel={onCancel} currentLogItem={mockLog} fixedWidth={true} />)
-      const modal = container.firstChild as HTMLElement
+      const modal = screen.getByRole('dialog')
+      expect(container).toContainElement(modal)
+      expect(modal).toHaveClass('relative', 'z-10')
       expect(modal.style.width).toBe('1000px')
     })
   })

--- a/web/app/components/base/message-log-modal/index.tsx
+++ b/web/app/components/base/message-log-modal/index.tsx
@@ -3,7 +3,8 @@ import type { IChatItem } from '@/app/components/base/chat/chat/type'
 import { cn } from '@langgenius/dify-ui/cn'
 import { RiCloseLine } from '@remixicon/react'
 import { useClickAway } from 'ahooks'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useStore } from '@/app/components/app/store'
 import Run from '@/app/components/workflow/run'
@@ -23,6 +24,7 @@ const MessageLogModal: FC<MessageLogModalProps> = ({
   onCancel,
 }) => {
   const { t } = useTranslation()
+  const titleId = useId()
   const ref = useRef(null)
   const [mounted, setMounted] = useState(false)
   const appDetail = useStore(state => state.appDetail)
@@ -39,17 +41,23 @@ const MessageLogModal: FC<MessageLogModalProps> = ({
   if (!currentLogItem || !currentLogItem.workflow_run_id)
     return null
 
-  return (
+  const floatingWidth = 480
+  const content = (
     <div
-      className={cn('relative z-10 flex flex-col rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg pt-3 shadow-xl')}
+      role="dialog"
+      aria-labelledby={titleId}
+      className={cn(
+        fixedWidth ? 'relative z-10' : 'fixed z-50',
+        'flex flex-col rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg pt-3 shadow-xl',
+      )}
       style={{
-        width: fixedWidth ? width : 480,
+        width: fixedWidth ? width : floatingWidth,
         ...(!fixedWidth
           ? {
-              position: 'fixed',
               top: 56 + 8,
-              left: 8 + (width - 480),
+              left: Math.max(8, 8 + (width - floatingWidth)),
               bottom: 16,
+              maxWidth: 'calc(100vw - 16px)',
             }
           : {
               marginRight: 8,
@@ -57,7 +65,7 @@ const MessageLogModal: FC<MessageLogModalProps> = ({
       }}
       ref={ref}
     >
-      <h1 className="shrink-0 px-4 py-1 system-xl-semibold text-text-primary">{t('runDetail.title', { ns: 'appLog' })}</h1>
+      <h1 id={titleId} className="shrink-0 px-4 py-1 system-xl-semibold text-text-primary">{t('runDetail.title', { ns: 'appLog' })}</h1>
       <button
         type="button"
         aria-label={t('operation.close', { ns: 'common' })}
@@ -74,6 +82,11 @@ const MessageLogModal: FC<MessageLogModalProps> = ({
       />
     </div>
   )
+
+  if (!fixedWidth && typeof document !== 'undefined')
+    return createPortal(content, document.body)
+
+  return content
 }
 
 export default MessageLogModal


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Added support for floating modal positioning when fixedWidth is false, utilizing createPortal for rendering.
- Introduced useId for unique title ID to improve accessibility.
- Updated tests to verify modal rendering behavior based on fixedWidth prop.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
