### PR TITLE
test(e2e): assert created workflow app name

### DIFF
--- a/e2e/features/apps/create-workflow-app.feature
+++ b/e2e/features/apps/create-workflow-app.feature
@@ -8,3 +8,4 @@ Feature: Create Workflow app
     And I enter a unique E2E app name
     And I confirm app creation
     Then I should land on the workflow editor
+    And I should see the created app name in the editor

--- a/e2e/features/step-definitions/apps/create-app.steps.ts
+++ b/e2e/features/step-definitions/apps/create-app.steps.ts
@@ -53,6 +53,15 @@ Then('I should land on the workflow editor', async function (this: DifyWorld) {
   await expect(this.getPage()).toHaveURL(/\/app\/[^/]+\/workflow(?:\?.*)?$/)
 })
 
+Then('I should see the created app name in the editor', async function (this: DifyWorld) {
+  const appName = this.lastCreatedAppName
+
+  if (!appName)
+    throw new Error('No created app name found. Run "I enter a unique E2E app name" first.')
+
+  await expect(this.getPage().getByText(appName, { exact: true })).toBeVisible()
+})
+
 Then('I should land on the app configuration page', async function (this: DifyWorld) {
   await expect(this.getPage()).toHaveURL(/\/app\/[^/]+\/configuration(?:\?.*)?$/)
 })


### PR DESCRIPTION
## Summary
- Adds an assertion to the workflow app creation E2E scenario that the generated app name is visible after landing in the workflow editor.
- Reuses the existing `lastCreatedAppName` scenario state and an exact text locator for a small non-overlapping coverage improvement.

## Related Issue
- Part of #34278

## Verification
- `PNPM_CONFIG_ENGINE_STRICT=false npx -y pnpm@11.1.1 -C e2e type-check`
- `PNPM_CONFIG_ENGINE_STRICT=false npx -y pnpm@11.1.1 exec eslint e2e/features/step-definitions/apps/create-app.steps.ts`