### PR TITLE
fix(security): reject internal-address targets in MCP server_url validation (#35992)

### DIFF
--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -23,6 +23,7 @@ from controllers.console.wraps import (
 )
 from core.db.session_factory import session_factory
 from core.entities.mcp_provider import IdentityMode, MCPAuthentication, MCPConfiguration
+from core.helper.ssrf_proxy import is_safe_external_url
 from core.mcp.auth.auth_flow import auth, handle_callback
 from core.mcp.error import MCPAuthError, MCPError, MCPRefreshTokenError
 from core.mcp.mcp_client import MCPClient
@@ -50,14 +51,7 @@ logger = logging.getLogger(__name__)
 
 
 def is_valid_url(url: str) -> bool:
-    if not url:
-        return False
-
-    try:
-        parsed = urlparse(url)
-        return all([parsed.scheme, parsed.netloc]) and parsed.scheme in ["http", "https"]
-    except (ValueError, TypeError):
-        return False
+    return is_safe_external_url(url)
 
 
 class ToolProviderListQuery(BaseModel):

--- a/api/core/helper/ssrf_proxy.py
+++ b/api/core/helper/ssrf_proxy.py
@@ -333,20 +333,12 @@ def _is_disallowed_ip(raw: str) -> bool:
         ip = ipaddress.ip_address(raw)
     except ValueError:
         return True
-    return (
-        ip.is_private
-        or ip.is_loopback
-        or ip.is_link_local
-        or ip.is_multicast
-        or ip.is_reserved
-        or ip.is_unspecified
-    )
+    return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_reserved or ip.is_unspecified
 
 
 def _ssrf_proxy_configured() -> bool:
     return bool(
-        dify_config.SSRF_PROXY_ALL_URL
-        or (dify_config.SSRF_PROXY_HTTP_URL and dify_config.SSRF_PROXY_HTTPS_URL)
+        dify_config.SSRF_PROXY_ALL_URL or (dify_config.SSRF_PROXY_HTTP_URL and dify_config.SSRF_PROXY_HTTPS_URL)
     )
 
 

--- a/api/core/helper/ssrf_proxy.py
+++ b/api/core/helper/ssrf_proxy.py
@@ -10,9 +10,12 @@ file URLs can be resolved through DB + storage before falling back to this SSRF
 client.
 """
 
+import ipaddress
 import logging
+import socket
 import time
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 from pydantic import TypeAdapter, ValidationError
@@ -323,3 +326,75 @@ class GraphonSSRFProxy:
 
 ssrf_proxy = SSRFProxy()
 graphon_ssrf_proxy = GraphonSSRFProxy()
+
+
+def _is_disallowed_ip(raw: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(raw)
+    except ValueError:
+        return True
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _ssrf_proxy_configured() -> bool:
+    return bool(
+        dify_config.SSRF_PROXY_ALL_URL
+        or (dify_config.SSRF_PROXY_HTTP_URL and dify_config.SSRF_PROXY_HTTPS_URL)
+    )
+
+
+def is_safe_external_url(url: str) -> bool:
+    """Defense-in-depth URL validation for tenant-supplied outbound targets.
+
+    Beyond the usual http(s)-scheme + non-empty-host format check, this also
+    rejects URLs whose host points into a private, loopback, link-local,
+    multicast, reserved, or unspecified range — covering cloud instance
+    metadata (169.254.169.254), Docker bridge networks, and RFC1918 LANs.
+
+    When an SSRF egress proxy is configured (``SSRF_PROXY_*``), the proxy is
+    already the chokepoint for outbound traffic, so DNS resolution is skipped
+    for hostnames; only IP-literal hosts are still rejected. When no proxy
+    is configured (the default in ``.env.example``), hostnames are resolved
+    via ``getaddrinfo`` and every resolved address must be a public IP.
+
+    DNS rebinding is a residual risk: a hostname can resolve to a public IP
+    at validation time and a private IP at connection time. Callers that
+    need rebind-safe behavior should also resolve-and-pin at the client
+    layer.
+    """
+    if not url:
+        return False
+    try:
+        parsed = urlparse(url)
+    except (ValueError, TypeError):
+        return False
+    if parsed.scheme not in ("http", "https"):
+        return False
+    host = parsed.hostname
+    if not host:
+        return False
+
+    try:
+        ipaddress.ip_address(host)
+        is_ip_literal = True
+    except ValueError:
+        is_ip_literal = False
+
+    if is_ip_literal:
+        return not _is_disallowed_ip(host)
+
+    if _ssrf_proxy_configured():
+        return True
+
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except (socket.gaierror, UnicodeError, OSError):
+        return False
+    return all(not _is_disallowed_ip(info[4][0]) for info in infos)

--- a/api/core/helper/ssrf_proxy.py
+++ b/api/core/helper/ssrf_proxy.py
@@ -389,4 +389,6 @@ def is_safe_external_url(url: str) -> bool:
         infos = socket.getaddrinfo(host, None)
     except (socket.gaierror, UnicodeError, OSError):
         return False
-    return all(not _is_disallowed_ip(info[4][0]) for info in infos)
+    # sockaddr[0] is the address string for both AF_INET and AF_INET6;
+    # str() keeps the type checker happy about the int | str union.
+    return all(not _is_disallowed_ip(str(info[4][0])) for info in infos)

--- a/api/services/tools/mcp_tools_manage_service.py
+++ b/api/services/tools/mcp_tools_manage_service.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 from core.entities.mcp_provider import IdentityMode, MCPAuthentication, MCPConfiguration, MCPProviderEntity
 from core.helper import encrypter
 from core.helper.provider_cache import NoOpProviderCredentialCache
+from core.helper.ssrf_proxy import is_safe_external_url
 from core.mcp.auth.auth_flow import auth
 from core.mcp.auth_client import MCPClientWithAuthRetry
 from core.mcp.entities import AuthActionType, AuthResult
@@ -716,14 +717,13 @@ class MCPToolManageService:
         raise error
 
     def _is_valid_url(self, url: str) -> bool:
-        """Validate URL format."""
-        if not url:
-            return False
-        try:
-            parsed = urlparse(url)
-            return all([parsed.scheme, parsed.netloc]) and parsed.scheme in ["http", "https"]
-        except (ValueError, TypeError):
-            return False
+        """Validate URL format and that it does not target an internal address.
+
+        Defense-in-depth check before persisting the URL or issuing the
+        ``MCPClient`` handshake; see ``is_safe_external_url`` for the
+        scheme / IP-range rules and the SSRF-proxy interaction.
+        """
+        return is_safe_external_url(url)
 
     def _update_optional_fields(self, mcp_provider: MCPToolProvider, configuration: MCPConfiguration) -> None:
         """Update optional configuration fields using setattr for cleaner code."""

--- a/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
+++ b/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
@@ -10,6 +10,7 @@ from core.helper.ssrf_proxy import (
     _get_user_provided_host_header,
     _to_graphon_http_response,
     graphon_ssrf_proxy,
+    is_safe_external_url,
     make_request,
     max_retries_exceeded_error,
     request_error,
@@ -262,3 +263,148 @@ def test_graphon_ssrf_proxy_wraps_module_requests(method_name: str) -> None:
     assert wrapped.status_code == 200
     assert wrapped.url == "https://example.com/resource"
     assert wrapped.content == b"ok"
+
+
+# ---------------------------------------------------------------------------
+# is_safe_external_url — defense-in-depth checks for tenant-supplied URLs
+# (e.g. MCP tool ``server_url``).
+# ---------------------------------------------------------------------------
+
+
+def _no_proxy_config(monkeypatch):
+    monkeypatch.setattr("core.helper.ssrf_proxy.dify_config.SSRF_PROXY_ALL_URL", "")
+    monkeypatch.setattr("core.helper.ssrf_proxy.dify_config.SSRF_PROXY_HTTP_URL", "")
+    monkeypatch.setattr("core.helper.ssrf_proxy.dify_config.SSRF_PROXY_HTTPS_URL", "")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        None,
+        "not-a-url",
+        "ftp://example.com",
+        "file:///etc/passwd",
+        "javascript:alert(1)",
+        "http://",
+    ],
+)
+def test_is_safe_external_url_rejects_malformed_or_wrong_scheme(monkeypatch, url):
+    _no_proxy_config(monkeypatch)
+    assert is_safe_external_url(url) is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1/path",
+        "http://127.0.0.1:8080/",
+        "https://10.0.0.1/",
+        "https://10.255.255.255/",
+        "https://172.16.0.5/",
+        "https://172.31.255.255/",
+        "https://192.168.1.1/",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://0.0.0.0/",
+        "http://[::1]/",
+        "http://[fe80::1]/",
+        "http://[::ffff:127.0.0.1]/",
+    ],
+)
+def test_is_safe_external_url_rejects_internal_ip_literals(monkeypatch, url):
+    """169.254.169.254 (AWS/GCP metadata), loopback, RFC1918, link-local IPv6
+    and unspecified addresses must all be blocked before the HTTP client is
+    handed a tenant-supplied ``server_url``."""
+    _no_proxy_config(monkeypatch)
+    assert is_safe_external_url(url) is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://93.184.216.34/",
+        "https://93.184.216.34/path",
+        "http://[2606:2800:220:1:248:1893:25c8:1946]/",
+    ],
+)
+def test_is_safe_external_url_accepts_public_ip_literals(monkeypatch, url):
+    _no_proxy_config(monkeypatch)
+    assert is_safe_external_url(url) is True
+
+
+def test_is_safe_external_url_rejects_hostname_resolving_to_private(monkeypatch):
+    _no_proxy_config(monkeypatch)
+
+    def fake_getaddrinfo(host, *args, **kwargs):
+        return [(0, 0, 0, "", ("127.0.0.1", 0))]
+
+    monkeypatch.setattr("core.helper.ssrf_proxy.socket.getaddrinfo", fake_getaddrinfo)
+    assert is_safe_external_url("https://attacker.example/") is False
+
+
+def test_is_safe_external_url_rejects_hostname_with_any_private_record(monkeypatch):
+    """If a hostname round-robins between public and private addresses, the
+    private record must veto — DNS round-robin must not bypass the guard."""
+    _no_proxy_config(monkeypatch)
+
+    def fake_getaddrinfo(host, *args, **kwargs):
+        return [
+            (0, 0, 0, "", ("93.184.216.34", 0)),
+            (0, 0, 0, "", ("10.0.0.1", 0)),
+        ]
+
+    monkeypatch.setattr("core.helper.ssrf_proxy.socket.getaddrinfo", fake_getaddrinfo)
+    assert is_safe_external_url("https://mixed.example/") is False
+
+
+def test_is_safe_external_url_accepts_public_hostname(monkeypatch):
+    _no_proxy_config(monkeypatch)
+
+    def fake_getaddrinfo(host, *args, **kwargs):
+        return [(0, 0, 0, "", ("93.184.216.34", 0))]
+
+    monkeypatch.setattr("core.helper.ssrf_proxy.socket.getaddrinfo", fake_getaddrinfo)
+    assert is_safe_external_url("https://example.com/") is True
+
+
+def test_is_safe_external_url_skips_resolution_when_proxy_configured(monkeypatch):
+    """With an SSRF egress proxy in front of all outbound traffic, the proxy
+    is the chokepoint that enforces network policy. Skip the DNS round-trip
+    for hostnames so the validation path is fast and never reveals tenant
+    URLs to the public resolver."""
+    monkeypatch.setattr(
+        "core.helper.ssrf_proxy.dify_config.SSRF_PROXY_ALL_URL",
+        "http://squid:3128",
+    )
+
+    def fail_resolve(*args, **kwargs):
+        raise AssertionError("getaddrinfo must not run when proxy is configured")
+
+    monkeypatch.setattr("core.helper.ssrf_proxy.socket.getaddrinfo", fail_resolve)
+    assert is_safe_external_url("https://attacker.example/") is True
+
+
+def test_is_safe_external_url_still_rejects_ip_literals_when_proxy_configured(monkeypatch):
+    """Even with the SSRF proxy in front, a request whose URL already names
+    an internal IP literal should be rejected at the boundary — the proxy
+    would forward the literal as-is."""
+    monkeypatch.setattr(
+        "core.helper.ssrf_proxy.dify_config.SSRF_PROXY_ALL_URL",
+        "http://squid:3128",
+    )
+    assert is_safe_external_url("http://169.254.169.254/latest/meta-data/") is False
+    assert is_safe_external_url("http://127.0.0.1/") is False
+
+
+def test_is_safe_external_url_rejects_unresolvable_hostname(monkeypatch):
+    """``getaddrinfo`` failure is treated as fail-closed — a hostname we
+    cannot resolve cannot be proven safe."""
+    _no_proxy_config(monkeypatch)
+
+    def boom(*args, **kwargs):
+        import socket as _socket
+
+        raise _socket.gaierror("nodename nor servname provided, or not known")
+
+    monkeypatch.setattr("core.helper.ssrf_proxy.socket.getaddrinfo", boom)
+    assert is_safe_external_url("https://nonexistent.invalid/") is False


### PR DESCRIPTION
## Summary

Closes #35992 with a defense-in-depth URL validation pass at both MCP tool-provider entry points.

`_is_valid_url()` on the MCP tool-provider create / update flow accepts any `http(s)` URL with a non-empty netloc, including loopback, RFC1918, link-local, and cloud instance metadata addresses. Any authenticated workspace member can therefore coerce the backend into issuing the MCP handshake against `http://169.254.169.254/`, `http://127.0.0.1:<port>/`, internal Kubernetes services, etc. When `SSRF_PROXY_*` is not configured — the default in `api/.env.example` — the connection goes straight to the target.

This PR adds `is_safe_external_url()` in `core/helper/ssrf_proxy.py` and routes both validation entry points (`MCPToolManageService._is_valid_url` and the controller-level `is_valid_url`) through it. Behavior:

- Keeps the existing scheme + non-empty-host format check.
- Rejects URLs whose host is an **IP literal** in any private / loopback / link-local / multicast / reserved / unspecified range — IPv4 *and* IPv6 (incl. IPv4-mapped IPv6 like `::ffff:127.0.0.1`).
- For **hostnames**, resolves via `getaddrinfo` and rejects if *any* resolved address falls into a disallowed range, so DNS round-robin cannot smuggle a private IP past the check.
- **Skips hostname resolution when an outbound SSRF proxy is configured.** The proxy is already the egress chokepoint and we avoid leaking tenant-supplied hostnames to the public resolver. IP-literal hosts are still rejected at the boundary even with the proxy in place.
- Fails closed on resolution errors.

### Residual risk

DNS rebinding (validation-time vs. connection-time race) is not closed by this PR — narrowing it requires a resolve-and-pin at the `MCPClient` / httpx layer. Happy to follow up if maintainers want that done in the same patch series.

### Why not require `SSRF_PROXY_*`?

The issue body offered "make SSRF_PROXY_* required at startup" as an alternative. That would break every existing deploy that runs MCP without a Squid sidecar (the documented default in `.env.example`). Defense-in-depth at the validation layer keeps backward compatibility while closing the no-proxy gap.

## Test plan

```
$ pytest tests/unit_tests/core/helper/test_ssrf_proxy.py tests/unit_tests/services/tools/ -p no:warnings
134 passed
```

New `is_safe_external_url` coverage (28 cases including parametrization expansions):

- Malformed / wrong-scheme URLs (empty, `None`, `ftp://`, `file://`, `javascript:`, `http://` with no host)
- IPv4 internal literals: `127.0.0.1`, `10.x`, `172.16-31.x`, `192.168.x`, `169.254.169.254` (AWS/GCP metadata), `0.0.0.0`
- IPv6 internal literals: `[::1]`, `[fe80::1]`, `[::ffff:127.0.0.1]`
- Public IP literals (positive control): IPv4 + IPv6
- Hostname resolving to a private IP → rejected
- Hostname with **mixed** public + private records → rejected (DNS round-robin bypass attempt)
- Hostname resolving to public-only → accepted
- SSRF proxy configured → DNS resolution skipped for hostnames, IP literals still rejected
- `getaddrinfo` failure → fail-closed

No PoC included; following the responsible-disclosure pattern from the recent Huntr batch (#35699 / #35793 / #35797 / #35843).

cc @laipz8200 @zafido for continuity with the prior MCP / tenant-scoping batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)