### PR TITLE
feat: Enable GitHub output format for Pyrefly type checker

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -294,3 +294,4 @@ project-excludes = [".venv", "migrations/"]
 python-platform = "linux"
 python-version = "3.12.0"
 infer-with-first-use = false
+outputformat = "github"


### PR DESCRIPTION
## Description

This PR enables GitHub-formatted output for the Pyrefly type checker, which will show inline annotations in pull requests for type checking errors.

## Changes

- Added `outputformat = "github"` to `[tool.pyrefly]` configuration in `api/pyproject.toml`

## Benefits

- **Better DX**: Type errors will appear as inline comments in PR diffs
- **Faster feedback**: Developers can see type issues directly in the GitHub UI without checking CI logs
- **Consistent with best practices**: Follows Pyrefly's recommended configuration for GitHub Actions

## Reference

- Pyrefly documentation: https://pyrefly.org/en/docs/installation/#inline-pr-annotations

## Testing

The configuration change is minimal and follows Pyrefly's official documentation. The next PR with type checking will demonstrate the inline annotations.

Fixes #36189