### PR TITLE
fix(web): app icon in webapp

### DIFF
--- a/web/app/components/base/app-icon/__tests__/index.spec.tsx
+++ b/web/app/components/base/app-icon/__tests__/index.spec.tsx
@@ -26,9 +26,8 @@ describe('AppIcon', () => {
           super()
         }
 
-        // Mock basic functionality
         connectedCallback() {
-          this.innerHTML = '🤖'
+          this.innerHTML = this.getAttribute('id') || '🤖'
         }
       })
     }
@@ -49,6 +48,15 @@ describe('AppIcon', () => {
     const emojiElement = document.querySelector('em-emoji')
     expect(emojiElement).toBeInTheDocument()
     expect(emojiElement?.getAttribute('id')).toBe('smile')
+  })
+
+  it('updates the rendered emoji when icon changes', () => {
+    const { rerender } = render(<AppIcon icon="smile" />)
+    expect(document.querySelector('em-emoji')).toHaveTextContent('smile')
+
+    rerender(<AppIcon icon="robot" />)
+
+    expect(document.querySelector('em-emoji')).toHaveTextContent('robot')
   })
 
   it('renders image when iconType is image and imageUrl is provided', () => {

--- a/web/app/components/base/app-icon/index.tsx
+++ b/web/app/components/base/app-icon/index.tsx
@@ -104,7 +104,8 @@ const AppIcon: FC<AppIconProps> = ({
   showEditIcon = false,
 }) => {
   const isValidImageIcon = iconType === 'image' && imageUrl
-  const Icon = (icon && icon !== '') ? <em-emoji id={icon} /> : <em-emoji id="🤖" />
+  const emojiIcon = (icon && icon !== '') ? icon : '🤖'
+  const Icon = <em-emoji key={emojiIcon} id={emojiIcon} />
   const wrapperRef = useRef<HTMLSpanElement>(null)
   const isHovering = useHover(wrapperRef)
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes the web app icon emoji refresh behavior. `AppIcon` now derives a stable `emojiIcon` value and uses it as the React `key` for the `em-emoji` custom element, forcing the emoji element to remount when the icon changes. This ensures UI locations such as the chat header/sidebar update correctly when `appData.site.icon` changes.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
