### PR TITLE
fix: Include dify-agent in API Docker build context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ build-web:
 
 build-api:
 	@echo "Building API Docker image: $(API_IMAGE):$(VERSION)..."
-	docker build -t $(API_IMAGE):$(VERSION) ./api
+	docker build -f api/Dockerfile -t $(API_IMAGE):$(VERSION) .
 	@echo "API Docker image built successfully: $(API_IMAGE):$(VERSION)"
 
 # Push Docker images

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -22,8 +22,9 @@ RUN apt-get update \
           libmpfr-dev libmpc-dev
 
 # Install Python dependencies (workspace members under providers/vdb/)
-COPY pyproject.toml uv.lock ./
-COPY providers ./providers
+COPY api/pyproject.toml api/uv.lock ./
+COPY api/providers ./providers
+COPY dify-agent ./dify-agent
 RUN uv sync --locked --no-dev
 
 # production stage
@@ -107,10 +108,10 @@ RUN python -c "import tiktoken; tiktoken.encoding_for_model('gpt2')" \
     && chown -R dify:dify ${TIKTOKEN_CACHE_DIR}
 
 # Copy source code
-COPY --chown=dify:dify . /app/api/
+COPY --chown=dify:dify api /app/api/
 
 # Prepare entrypoint script
-COPY --chown=dify:dify --chmod=755 docker/entrypoint.sh /entrypoint.sh
+COPY --chown=dify:dify --chmod=755 api/docker/entrypoint.sh /entrypoint.sh
 
 
 ARG COMMIT_SHA


### PR DESCRIPTION
## Description

Fixes the API Docker build failure introduced by PR #36087, which added `dify-agent` as a path dependency but did not update the Docker build context to include it.

## Root Cause

PR #36087 added `dify-agent` as a path dependency in `api/pyproject.toml`:

```toml
dify-agent = { path = "../dify-agent" }
```

However, the API Docker build was using `./api` as the build context, which cannot access `../dify-agent` outside the context. This caused the build to fail with:

```
error: Failed to generate package metadata for dify-agent==0.1.0 @ directory+../dify-agent
  Caused by: Distribution not found at: file:///app/dify-agent
```

## Solution

Following the same pattern as PR #34468 (which fixed a similar issue for web builds), this PR:

1. **Updates Makefile** - Changes `build-api` target to build from root directory (`.`) with `-f api/Dockerfile`, matching the web build pattern
2. **Updates api/Dockerfile** - Adjusts COPY paths to include `api/` prefix since build context is now root directory
3. **Adds dify-agent to build** - Copies `dify-agent/` directory in the packages stage before running `uv sync`

## Changes

- `Makefile`: Changed `docker build -t ... ./api` to `docker build -f api/Dockerfile -t ... .`
- `api/Dockerfile`: 
  - Updated `COPY pyproject.toml uv.lock` to `COPY api/pyproject.toml api/uv.lock`
  - Updated `COPY providers` to `COPY api/providers`
  - Added `COPY dify-agent ./dify-agent`
  - Updated source code copy paths to include `api/` prefix

## Testing

The fix can be verified by building the API Docker image:

```bash
make build-api
# or
docker build -f api/Dockerfile -t dify-api:test .
```

Fixes #36186