### PR TITLE
fix(webapp): restore settings dialog scroll behavior

### DIFF
--- a/web/app/components/app/overview/settings/index.tsx
+++ b/web/app/components/app/overview/settings/index.tsx
@@ -251,7 +251,7 @@ const SettingsModal: FC<ISettingsModalProps> = ({
   return (
     <>
       <Dialog open={isShow} onOpenChange={open => !open && onHide()}>
-        <DialogContent className="max-h-[calc(100dvh-2rem)] w-[520px] overflow-visible p-0">
+        <DialogContent className="flex max-h-[calc(100dvh-2rem)] w-[520px] flex-col overflow-hidden p-0">
           {/* header */}
           <div className="pt-5 pr-5 pb-3 pl-6">
             <div className="flex items-center gap-1">
@@ -263,7 +263,7 @@ const SettingsModal: FC<ISettingsModalProps> = ({
             </div>
           </div>
           {/* form body */}
-          <div className="space-y-5 px-6 py-3">
+          <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-6 py-3">
             {/* name & icon */}
             <div className="flex gap-4">
               <div className="grow">


### PR DESCRIPTION
### Motivation
- The Modal → Dialog migration introduced `overflow-visible` on the settings dialog which regressed scrolling behavior, causing the entire dialog to scroll instead of only the content area.

### Description
- Replace `DialogContent` classes from `max-h-[calc(100dvh-2rem)] w-[520px] overflow-visible p-0` to `flex max-h-[calc(100dvh-2rem)] w-[520px] flex-col overflow-hidden p-0` in `web/app/components/app/overview/settings/index.tsx` so header/footer remain fixed.
- Make the form body the scroll container by changing its wrapper to `min-h-0 flex-1 space-y-5 overflow-y-auto px-6 py-3` so long content scrolls only inside the dialog body.

### Testing
- Attempted to run ESLint on the modified file with `pnpm -C web exec eslint app/components/app/overview/settings/index.tsx`, but the command failed due to a Node engine mismatch in the environment (repo expects `^22.22.1`, current is `v24.15.0`), so linting could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06c9aafba8833186acad3d6bf6c461)