### PR TITLE
fix(api): avoid dify-agent path lookup during Docker build

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
     "readabilipy>=0.3.0,<1.0.0",
     "resend>=2.27.0,<3.0.0",
     # Emerging: newer and fast-moving, use compatible pins
-    "dify-agent",
     "fastopenapi[flask]~=0.7.0",
     "graphon~=0.3.1",
     "httpx-sse~=0.4.0",
@@ -115,6 +114,7 @@ override-dependencies = [
 ############################################################
 dev = [
     "coverage>=7.13.4",
+    "dify-agent",
     "dotenv-linter>=0.7.0",
     "faker>=40.15.0",
     "lxml-stubs>=0.5.1",


### PR DESCRIPTION
Move dify-agent from production dependencies to dev dependency group because it is not used by the API runtime.

The dify-agent package is sourced from a local path (../dify-agent) which is outside the api/ build context. This causes Docker build failures when uv tries to resolve the path.

With this change, using 'uv sync --frozen --no-dev' in the Docker packages stage will exclude dify-agent and avoid the path lookup.

Fixes #36187

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

 Fixes #36186 (reported in #36187)
- Moves `dify-agent` from API production dependencies to the dev dependency group because it is not currently used by the API runtime.
- The Docker `packages` stage already uses `uv sync --frozen --no-dev`, so this change ensures `dify-agent` (sourced from `../dify-agent`, outside the `api/` build context) is not looked up during Docker build.

### Motivation and Context

The `dify-agent` package is listed in main dependencies with a path source `../dify-agent`. During Docker build, only the `api/` directory is copied to the build context, so `../dify-agent` doesn't exist. This causes build failures.

By moving `dify-agent` to dev dependencies and using `--no-dev` in Docker build, we avoid this path lookup issue.

### Verification

- [x] `uv lock --project api --check` passes
- [ ] `docker build --target packages -t dify-api-packages:test ./api` (Docker build verification)

### Checklist

- [x] This change follows the contribution guidelines
- [x] Code review completed
- [ ] Tests added/updated (N/A - dependency config change)
- [ ] Documentation updated (N/A)
