### PR TITLE
refactor: replace str | None = None with str = "" in OAuth functions

### DIFF
--- a/api/libs/oauth.py
+++ b/api/libs/oauth.py
@@ -69,9 +69,9 @@ class OAuthUserInfo:
 
 
 def encode_oauth_state(
-    invite_token: str | None = None,
-    timezone: str | None = None,
-    language: str | None = None,
+    invite_token: str = "",
+    timezone: str = "",
+    language: str = "",
 ) -> str | None:
     state: OAuthState = {}
     if invite_token:
@@ -119,9 +119,9 @@ class OAuth:
 
     def get_authorization_url(
         self,
-        invite_token: str | None = None,
-        timezone: str | None = None,
-        language: str | None = None,
+        invite_token: str = "",
+        timezone: str = "",
+        language: str = "",
     ) -> str:
         raise NotImplementedError()
 
@@ -147,9 +147,9 @@ class GitHubOAuth(OAuth):
 
     def get_authorization_url(
         self,
-        invite_token: str | None = None,
-        timezone: str | None = None,
-        language: str | None = None,
+        invite_token: str = "",
+        timezone: str = "",
+        language: str = "",
     ) -> str:
         params = {
             "client_id": self.client_id,
@@ -240,9 +240,9 @@ class GoogleOAuth(OAuth):
 
     def get_authorization_url(
         self,
-        invite_token: str | None = None,
-        timezone: str | None = None,
-        language: str | None = None,
+        invite_token: str = "",
+        timezone: str = "",
+        language: str = "",
     ) -> str:
         params = {
             "client_id": self.client_id,


### PR DESCRIPTION
## Summary

Fixes #35557

In `api/libs/oauth.py`, the `invite_token`, `timezone`, and `language` parameters used `str | None = None` as defaults, but the code only checks truthiness (`if invite_token:`). Since empty string is also falsy, we can use `str = ""` as the default instead.

This simplifies the type signature and removes unnecessary None handling. No behavior change — callers that pass None will now get an empty string, which has the same effect in the truthiness checks.

## Changes

- `api/libs/oauth.py`: Replace `str | None = None` with `str = ""` in:
  - `encode_oauth_state()` function
  - `OAuth.get_authorization_url()` base class method
  - `GoogleOAuth.get_authorization_url()` method
  - `GitHubOAuth.get_authorization_url()` method