### PR TITLE
fix(workflow): ignore placeholder file mappings to prevent invalid up…

### DIFF
--- a/api/factories/file_factory/builders.py
+++ b/api/factories/file_factory/builders.py
@@ -324,9 +324,25 @@ def _is_valid_mapping(mapping: Mapping[str, Any]) -> bool:
     if not mapping or not mapping.get("transfer_method"):
         return False
 
-    if mapping.get("transfer_method") == FileTransferMethod.REMOTE_URL:
+    try:
+        transfer_method = FileTransferMethod.value_of(mapping.get("transfer_method"))
+    except ValueError:
+        return False
+
+    if transfer_method == FileTransferMethod.LOCAL_FILE:
+        return bool(resolve_mapping_file_id(mapping, "upload_file_id"))
+
+    if transfer_method == FileTransferMethod.TOOL_FILE:
+        return bool(resolve_mapping_file_id(mapping, "tool_file_id"))
+
+    if transfer_method == FileTransferMethod.DATASOURCE_FILE:
+        return bool(resolve_mapping_file_id(mapping, "datasource_file_id"))
+
+    if transfer_method == FileTransferMethod.REMOTE_URL:
+        # Remote files are valid when either a persisted upload row exists or a direct URL is provided.
+        if resolve_mapping_file_id(mapping, "upload_file_id"):
+            return True
         url = mapping.get("url") or mapping.get("remote_url")
-        if not url:
-            return False
+        return bool(url)
 
     return True

--- a/api/tests/unit_tests/factories/test_build_from_mapping.py
+++ b/api/tests/unit_tests/factories/test_build_from_mapping.py
@@ -8,6 +8,7 @@ from core.app.entities.app_invoke_entities import InvokeFrom, UserFrom
 from core.app.file_access import DatabaseFileAccessController, FileAccessScope, bind_file_access_scope
 from core.workflow.file_reference import build_file_reference, parse_file_reference, resolve_file_record_id
 from factories.file_factory.builders import build_from_mapping as _build_from_mapping
+from factories.file_factory.builders import build_from_mappings as _build_from_mappings
 from graphon.file import File, FileTransferMethod, FileType, FileUploadConfig
 from models import ToolFile, UploadFile
 
@@ -45,6 +46,16 @@ TEST_CONFIG = FileUploadConfig(
 def build_from_mapping(*, mapping, tenant_id, config=None, strict_type_validation=False):
     return _build_from_mapping(
         mapping=mapping,
+        tenant_id=tenant_id,
+        config=config,
+        strict_type_validation=strict_type_validation,
+        access_controller=TEST_ACCESS_CONTROLLER,
+    )
+
+
+def build_from_mappings(*, mappings, tenant_id, config=None, strict_type_validation=False):
+    return _build_from_mappings(
+        mappings=mappings,
         tenant_id=tenant_id,
         config=config,
         strict_type_validation=strict_type_validation,
@@ -421,3 +432,32 @@ def test_disallowed_extensions(mock_upload_file):
 
     with pytest.raises(ValueError, match="File validation failed"):
         build_from_mapping(mapping=mapping, tenant_id=TEST_TENANT_ID, config=restricted_config)
+
+
+def test_build_from_mappings_ignores_placeholder_local_file_mapping():
+    mappings = [
+        {
+            "transfer_method": "local_file",
+            "type": "image",
+            "upload_file_id": "",
+        }
+    ]
+
+    files = build_from_mappings(mappings=mappings, tenant_id=TEST_TENANT_ID)
+
+    assert files == []
+
+
+def test_build_from_mappings_ignores_placeholder_remote_file_mapping():
+    mappings = [
+        {
+            "transfer_method": "remote_url",
+            "type": "image",
+            "upload_file_id": "",
+            "url": "",
+        }
+    ]
+
+    files = build_from_mappings(mappings=mappings, tenant_id=TEST_TENANT_ID)
+
+    assert files == []


### PR DESCRIPTION
## Summary
Fixes [#36218](https://github.com/langgenius/dify/issues/36218), where text-only API chat requests could intermittently fail with:

`Node llm failed with ABORT strategy: Invalid upload file`

The root cause was that placeholder/incomplete file mappings (for example, empty `upload_file_id` / empty `url`) were still treated as valid file inputs and later failed during file resolution.

## What Changed
- Hardened file mapping validation in `api/factories/file_factory/builders.py`:
  - `_is_valid_mapping` now validates `transfer_method` safely.
  - `local_file` requires a resolvable `upload_file_id`.
  - `tool_file` requires a resolvable `tool_file_id`.
  - `datasource_file` requires a resolvable `datasource_file_id`.
  - `remote_url` requires either:
    - a resolvable `upload_file_id`, or
    - a non-empty direct URL (`url` / `remote_url`).
- Invalid/incomplete mappings are filtered out in `build_from_mappings(...)` instead of causing downstream runtime errors.

## Tests
Added regression tests in `api/tests/unit_tests/factories/test_build_from_mapping.py`:
- `test_build_from_mappings_ignores_placeholder_local_file_mapping`
- `test_build_from_mappings_ignores_placeholder_remote_file_mapping`

Local verification:
- `DEBUG=false uv run --project api pytest -q -o addopts='' api/tests/unit_tests/factories/test_build_from_mapping.py`
- Result: `26 passed`

## Impact
- Prevents false-positive file validation failures in text-only chat/completion API calls.
- Preserves existing behavior for valid file mappings and real file uploads.