### PR TITLE
fix: enforce file upload limit for clipboard paste and drag-drop

### DIFF
--- a/web/app/components/base/file-uploader/hooks.ts
+++ b/web/app/components/base/file-uploader/hooks.ts
@@ -301,9 +301,14 @@ export const useFile = (fileConfig: FileUpload, noNeedToCheckEnable = true) => {
     const text = e.clipboardData?.getData('text/plain')
     if (file && !text) {
       e.preventDefault()
+      const currentFiles = fileStore.getState().files
+      if (fileConfig.number_limits && currentFiles.length >= fileConfig.number_limits) {
+        toast.error(t('fileUploader.numberLimitExceeded', { ns: 'common', limit: fileConfig.number_limits }))
+        return
+      }
       handleLocalFileUpload(file)
     }
-  }, [handleLocalFileUpload])
+  }, [handleLocalFileUpload, fileStore, fileConfig.number_limits, t])
 
   const [isDragActive, setIsDragActive] = useState(false)
   const handleDragFileEnter = useCallback((e: React.DragEvent<HTMLElement>) => {
@@ -330,9 +335,15 @@ export const useFile = (fileConfig: FileUpload, noNeedToCheckEnable = true) => {
 
     const file = e.dataTransfer.files[0]
 
-    if (file)
+    if (file) {
+      const currentFiles = fileStore.getState().files
+      if (fileConfig.number_limits && currentFiles.length >= fileConfig.number_limits) {
+        toast.error(t('fileUploader.numberLimitExceeded', { ns: 'common', limit: fileConfig.number_limits }))
+        return
+      }
       handleLocalFileUpload(file)
-  }, [handleLocalFileUpload])
+    }
+  }, [handleLocalFileUpload, fileStore, fileConfig.number_limits, t])
 
   return {
     handleAddFile,

--- a/web/i18n/en-US/common.json
+++ b/web/i18n/en-US/common.json
@@ -191,6 +191,7 @@
   "fileUploader.uploadFromComputerLimit": "Upload {{type}} cannot exceed {{size}}",
   "fileUploader.uploadFromComputerReadError": "File reading failed, please try again.",
   "fileUploader.uploadFromComputerUploadError": "File upload failed, please upload again.",
+  "fileUploader.numberLimitExceeded": "Cannot upload more than {{limit}} files",
   "imageInput.browse": "browse",
   "imageInput.dropImageHere": "Drop your image here, or",
   "imageInput.supportedFormats": "Supports PNG, JPG, JPEG, WEBP and GIF",

--- a/web/i18n/zh-Hans/common.json
+++ b/web/i18n/zh-Hans/common.json
@@ -191,6 +191,7 @@
   "fileUploader.uploadFromComputerLimit": "上传 {{type}} 不能超过 {{size}}",
   "fileUploader.uploadFromComputerReadError": "文件读取失败，请重新选择。",
   "fileUploader.uploadFromComputerUploadError": "文件上传失败，请重新上传。",
+  "fileUploader.numberLimitExceeded": "无法上传超过 {{limit}} 个文件",
   "imageInput.browse": "浏览",
   "imageInput.dropImageHere": "将图片拖放到此处，或",
   "imageInput.supportedFormats": "支持 PNG、JPG、JPEG、WEBP 和 GIF 格式",


### PR DESCRIPTION
## Description

Fixes #36219

This PR enforces the file upload count limit (`number_limits`) for all file input methods, not just the upload button.

## Problem

Previously, the file upload count limit was only checked when using the upload button. Users could bypass this limit by:
- Pasting files with `Ctrl+V` / `Cmd+V`
- Dragging and dropping files

This could lead to:
- Exceeding configured limits
- Unexpected behavior when sending messages with too many files
- Potential backend errors

## Solution

Added `number_limits` validation in both `handleClipboardPasteFile` and `handleDropFile` functions before calling `handleLocalFileUpload`.

When the limit is exceeded:
- The file is not uploaded
- A clear error toast is shown to the user
- The error message is localized (en-US and zh-Hans)

## Changes

- ✅ Add number_limits check in `handleClipboardPasteFile`
- ✅ Add number_limits check in `handleDropFile`
- ✅ Show error toast when limit is exceeded
- ✅ Add i18n keys: `fileUploader.numberLimitExceeded`

## Testing

**Manual test steps:**
1. Create a chatflow/chat app
2. Enable File Upload with `number_limits` set to 3
3. Try to paste 4+ files with Ctrl+V → ❌ Error toast shown
4. Try to drag-drop 4+ files → ❌ Error toast shown
5. Try to upload 4+ files via button → ❌ Already blocked

All file input methods now respect the configured limit.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security fix (addresses a validation bypass)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added i18n translations for new user-facing text
- [x] My changes follow the project's coding style
- [x] I have commented my code where necessary