### PR TITLE
chore: Clean up unnecessary None defaults

### DIFF
--- a/api/controllers/console/auth/oauth.py
+++ b/api/controllers/console/auth/oauth.py
@@ -89,9 +89,9 @@ class OAuthLogin(Resource):
     @console_ns.response(302, "Redirect to OAuth authorization URL")
     @console_ns.response(400, "Invalid provider")
     def get(self, provider: str):
-        invite_token = request.args.get("invite_token") or None
-        timezone = _validated_timezone(request.args.get("timezone") or None)
-        language = _validated_language(request.args.get("language") or None)
+        invite_token = request.args.get("invite_token", "")
+        timezone = _validated_timezone(request.args.get("timezone"))
+        language = _validated_language(request.args.get("language"))
         OAUTH_PROVIDERS = get_oauth_providers()
         with current_app.app_context():
             oauth_provider = OAUTH_PROVIDERS.get(provider)
@@ -100,8 +100,8 @@ class OAuthLogin(Resource):
 
         auth_url = oauth_provider.get_authorization_url(
             invite_token=invite_token,
-            timezone=timezone,
-            language=language,
+            timezone=timezone or "",
+            language=language or "",
         )
         return redirect(auth_url)
 

--- a/api/dev/generate_swagger_specs.py
+++ b/api/dev/generate_swagger_specs.py
@@ -277,7 +277,7 @@ def drop_null_values(value: object) -> object:
     return value
 
 
-def sort_openapi_arrays(value: object, *, parent_key: str | None = None) -> object:
+def sort_openapi_arrays(value: object, *, parent_key: str = "") -> object:
     """Sort order-insensitive Swagger arrays so generated Markdown is stable."""
 
     if isinstance(value, dict):

--- a/api/libs/oauth.py
+++ b/api/libs/oauth.py
@@ -69,9 +69,9 @@ class OAuthUserInfo:
 
 
 def encode_oauth_state(
-    invite_token: str | None = None,
-    timezone: str | None = None,
-    language: str | None = None,
+    invite_token: str = "",
+    timezone: str = "",
+    language: str = "",
 ) -> str | None:
     state: OAuthState = {}
     if invite_token:
@@ -119,9 +119,9 @@ class OAuth:
 
     def get_authorization_url(
         self,
-        invite_token: str | None = None,
-        timezone: str | None = None,
-        language: str | None = None,
+        invite_token: str = "",
+        timezone: str = "",
+        language: str = "",
     ) -> str:
         raise NotImplementedError()
 
@@ -147,9 +147,9 @@ class GitHubOAuth(OAuth):
 
     def get_authorization_url(
         self,
-        invite_token: str | None = None,
-        timezone: str | None = None,
-        language: str | None = None,
+        invite_token: str = "",
+        timezone: str = "",
+        language: str = "",
     ) -> str:
         params = {
             "client_id": self.client_id,
@@ -240,9 +240,9 @@ class GoogleOAuth(OAuth):
 
     def get_authorization_url(
         self,
-        invite_token: str | None = None,
-        timezone: str | None = None,
-        language: str | None = None,
+        invite_token: str = "",
+        timezone: str = "",
+        language: str = "",
     ) -> str:
         params = {
             "client_id": self.client_id,

--- a/api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth.py
@@ -78,9 +78,9 @@ class TestOAuthLogin:
     @pytest.mark.parametrize(
         ("invite_token", "expected_token"),
         [
-            (None, None),
+            (None, ""),
             ("test_invite_token", "test_invite_token"),
-            ("", None),
+            ("", ""),
         ],
     )
     @patch("controllers.console.auth.oauth.get_oauth_providers")
@@ -103,8 +103,8 @@ class TestOAuthLogin:
 
         mock_oauth_provider.get_authorization_url.assert_called_once_with(
             invite_token=expected_token,
-            timezone=None,
-            language=None,
+            timezone="",
+            language="",
         )
         mock_redirect.assert_called_once_with("https://github.com/login/oauth/authorize?...")
 
@@ -124,9 +124,9 @@ class TestOAuthLogin:
             resource.get("github")
 
         mock_oauth_provider.get_authorization_url.assert_called_once_with(
-            invite_token=None,
+            invite_token="",
             timezone="Asia/Shanghai",
-            language=None,
+            language="",
         )
         mock_redirect.assert_called_once_with("https://github.com/login/oauth/authorize?...")
 
@@ -146,8 +146,8 @@ class TestOAuthLogin:
             resource.get("github")
 
         mock_oauth_provider.get_authorization_url.assert_called_once_with(
-            invite_token=None,
-            timezone=None,
+            invite_token="",
+            timezone="",
             language="zh-Hans",
         )
         mock_redirect.assert_called_once_with("https://github.com/login/oauth/authorize?...")

--- a/api/tests/unit_tests/controllers/console/auth/test_oauth_timezone.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_oauth_timezone.py
@@ -30,7 +30,7 @@ def test_oauth_login_passes_language_and_timezone_to_authorization_url(
         OAuthLogin().get("github")
 
     oauth_provider.get_authorization_url.assert_called_once_with(
-        invite_token=None,
+        invite_token="",
         timezone="Asia/Shanghai",
         language="zh-Hans",
     )

--- a/api/tests/unit_tests/libs/test_oauth_clients.py
+++ b/api/tests/unit_tests/libs/test_oauth_clients.py
@@ -39,11 +39,10 @@ class TestGitHubOAuth(BaseOAuthTest):
     @pytest.mark.parametrize(
         ("invite_token", "timezone", "language", "expected_state"),
         [
-            (None, None, None, None),
-            ("test_invite_token", None, None, {"invite_token": "test_invite_token"}),
-            ("", None, None, None),
-            (None, "Asia/Shanghai", None, {"timezone": "Asia/Shanghai"}),
-            (None, None, "zh-Hans", {"language": "zh-Hans"}),
+            ("", "", "", None),
+            ("test_invite_token", "", "", {"invite_token": "test_invite_token"}),
+            ("", "Asia/Shanghai", "", {"timezone": "Asia/Shanghai"}),
+            ("", "", "zh-Hans", {"language": "zh-Hans"}),
             (
                 "test_invite_token",
                 "Asia/Shanghai",
@@ -220,11 +219,10 @@ class TestGoogleOAuth(BaseOAuthTest):
     @pytest.mark.parametrize(
         ("invite_token", "timezone", "language", "expected_state"),
         [
-            (None, None, None, None),
-            ("test_invite_token", None, None, {"invite_token": "test_invite_token"}),
-            ("", None, None, None),
-            (None, "Asia/Shanghai", None, {"timezone": "Asia/Shanghai"}),
-            (None, None, "zh-Hans", {"language": "zh-Hans"}),
+            ("", "", "", None),
+            ("test_invite_token", "", "", {"invite_token": "test_invite_token"}),
+            ("", "Asia/Shanghai", "", {"timezone": "Asia/Shanghai"}),
+            ("", "", "zh-Hans", {"language": "zh-Hans"}),
             (
                 "test_invite_token",
                 "Asia/Shanghai",


### PR DESCRIPTION
## Summary
- replace optional OAuth state defaults with empty string defaults where absence is checked by truthiness
- normalize OAuth login query parameters before building provider authorization URLs
- use an empty string default for Swagger array sorting parent keys

#35557.

## Tests
- `python -m compileall -q libs\oauth.py controllers\console\auth\oauth.py dev\generate_swagger_specs.py tests\unit_tests\libs\test_oauth_clients.py tests\unit_tests\controllers\console\auth\test_oauth_timezone.py tests\test_containers_integration_tests\controllers\console\auth\test_oauth.py`
- `python -m ruff check libs\oauth.py controllers\console\auth\oauth.py dev\generate_swagger_specs.py tests\unit_tests\libs\test_oauth_clients.py tests\unit_tests\controllers\console\auth\test_oauth_timezone.py tests\test_containers_integration_tests\controllers\console\auth\test_oauth.py`
- direct OAuth authorization/state encoding check