### PR TITLE
test: add dataset CRUD e2e tests

### DIFF
--- a/e2e/features/datasets/create-dataset.feature
+++ b/e2e/features/datasets/create-dataset.feature
@@ -1,0 +1,10 @@
+@datasets @authenticated
+Feature: Create dataset
+  Scenario: Create a new empty dataset from the datasets page
+    Given I am signed in as the default E2E admin
+    When I open the datasets page
+    And I click the create knowledge link
+    And I click the empty knowledge creation option
+    And I enter a unique E2E dataset name
+    And I confirm empty dataset creation
+    Then I should land on the dataset documents page

--- a/e2e/features/datasets/delete-dataset.feature
+++ b/e2e/features/datasets/delete-dataset.feature
@@ -1,0 +1,10 @@
+@datasets @authenticated
+Feature: Delete dataset
+  Scenario: Delete an existing dataset from the datasets page
+    Given I am signed in as the default E2E admin
+    And there is an existing E2E dataset available for testing
+    When I open the datasets page
+    And I open the operations menu for the last created E2E dataset
+    And I click "Delete" in the dataset operations menu
+    And I confirm the dataset deletion
+    Then the dataset should no longer appear on the datasets page

--- a/e2e/features/datasets/list-datasets.feature
+++ b/e2e/features/datasets/list-datasets.feature
@@ -1,0 +1,8 @@
+@datasets @authenticated
+Feature: List datasets
+  Scenario: View datasets list on the datasets page
+    Given I am signed in as the default E2E admin
+    And there is an existing E2E dataset available for testing
+    When I open the datasets page
+    Then I should see the dataset in the list
+    And the dataset count should be at least 1

--- a/e2e/features/datasets/update-dataset.feature
+++ b/e2e/features/datasets/update-dataset.feature
@@ -1,0 +1,11 @@
+@datasets @authenticated
+Feature: Update dataset
+  Scenario: Rename an existing dataset from the datasets page
+    Given I am signed in as the default E2E admin
+    And there is an existing E2E dataset available for testing
+    When I open the datasets page
+    And I open the operations menu for the last created E2E dataset
+    And I click "Rename" in the dataset operations menu
+    And I enter a new dataset name
+    And I confirm the dataset rename
+    Then the dataset should display the new name on the datasets page

--- a/e2e/features/step-definitions/datasets/datasets.steps.ts
+++ b/e2e/features/step-definitions/datasets/datasets.steps.ts
@@ -74,3 +74,47 @@ Then('the dataset should no longer appear on the datasets page', async function 
     timeout: 10_000,
   })
 })
+
+When('I enter a new dataset name', async function (this: DifyWorld) {
+  const newName = `E2E Dataset Renamed ${Date.now()}`
+  this.lastCreatedDatasetName = newName
+  const dialog = this.getPage().getByRole('dialog')
+  await expect(dialog).toBeVisible()
+  await dialog.getByRole('textbox').fill(newName)
+})
+
+When('I confirm the dataset rename', async function (this: DifyWorld) {
+  const dialog = this.getPage().getByRole('dialog')
+  await dialog.getByRole('button', { name: 'Save' }).click()
+})
+
+Then('the dataset should display the new name on the datasets page', async function (this: DifyWorld) {
+  const datasetName = this.lastCreatedDatasetName
+  if (!datasetName) {
+    throw new Error(
+      'No dataset name stored. Run "I enter a new dataset name" first.',
+    )
+  }
+
+  await expect(this.getPage().getByTitle(datasetName)).toBeVisible({
+    timeout: 10_000,
+  })
+})
+
+Then('I should see the dataset in the list', async function (this: DifyWorld) {
+  const datasetName = this.lastCreatedDatasetName
+  if (!datasetName) {
+    throw new Error(
+      'No dataset name stored. Run "there is an existing E2E dataset available for testing" first.',
+    )
+  }
+
+  await expect(this.getPage().getByTitle(datasetName)).toBeVisible({
+    timeout: 10_000,
+  })
+})
+
+Then('the dataset count should be at least {int}', async function (this: DifyWorld, minCount: number) {
+  const datasetCards = this.getPage().locator('div[title^="E2E Dataset"]')
+  await expect(datasetCards).toHaveCount(minCount, { timeout: 10_000 })
+})

--- a/e2e/features/step-definitions/datasets/datasets.steps.ts
+++ b/e2e/features/step-definitions/datasets/datasets.steps.ts
@@ -1,0 +1,76 @@
+import type { DifyWorld } from '../../support/world'
+import { Given, Then, When } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { createTestDataset } from '../../../support/api'
+
+Given('there is an existing E2E dataset available for testing', async function (this: DifyWorld) {
+  const dataset = await createTestDataset(`E2E Dataset ${Date.now()}`)
+  this.createdDatasetIds.push(dataset.id)
+  this.lastCreatedDatasetName = dataset.name
+})
+
+When('I open the datasets page', async function (this: DifyWorld) {
+  await this.getPage().goto('/datasets')
+})
+
+When('I click the create knowledge link', async function (this: DifyWorld) {
+  await this.getPage().getByText('Create Knowledge').click()
+})
+
+When('I click the empty knowledge creation option', async function (this: DifyWorld) {
+  await this.getPage().getByText('I want to create an empty Knowledge').click()
+})
+
+When('I enter a unique E2E dataset name', async function (this: DifyWorld) {
+  const datasetName = `E2E Dataset ${Date.now()}`
+  this.lastCreatedDatasetName = datasetName
+  const dialog = this.getPage().getByRole('dialog')
+  await expect(dialog).toBeVisible()
+  await dialog.getByRole('textbox').fill(datasetName)
+})
+
+When('I confirm empty dataset creation', async function (this: DifyWorld) {
+  const dialog = this.getPage().getByRole('dialog')
+  await dialog.getByRole('button', { name: 'Create' }).click()
+})
+
+When('I open the operations menu for the last created E2E dataset', async function (this: DifyWorld) {
+  const datasetName = this.lastCreatedDatasetName
+  if (!datasetName) {
+    throw new Error(
+      'No dataset name stored. Run "there is an existing E2E dataset available for testing" first.',
+    )
+  }
+
+  const page = this.getPage()
+  const datasetCard = page.locator(`div[title="${datasetName}"]`).locator('..').locator('..').locator('..')
+  await datasetCard.hover()
+  await datasetCard.getByRole('button', { name: 'Dataset operations' }).click()
+})
+
+When('I click {string} in the dataset operations menu', async function (this: DifyWorld, operation: string) {
+  await this.getPage().getByRole('menuitem', { name: operation }).click()
+})
+
+When('I confirm the dataset deletion', async function (this: DifyWorld) {
+  const dialog = this.getPage().getByRole('alertdialog')
+  await expect(dialog).toBeVisible()
+  await dialog.getByRole('button', { name: 'Confirm' }).click()
+})
+
+Then('I should land on the dataset documents page', async function (this: DifyWorld) {
+  await expect(this.getPage()).toHaveURL(/\/datasets\/[^/]+\/documents(?:\\?.*)?$/)
+})
+
+Then('the dataset should no longer appear on the datasets page', async function (this: DifyWorld) {
+  const datasetName = this.lastCreatedDatasetName
+  if (!datasetName) {
+    throw new Error(
+      'No dataset name stored. Run "there is an existing E2E dataset available for testing" first.',
+    )
+  }
+
+  await expect(this.getPage().getByTitle(datasetName)).not.toBeVisible({
+    timeout: 10_000,
+  })
+})

--- a/e2e/features/support/hooks.ts
+++ b/e2e/features/support/hooks.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url'
 import { After, AfterAll, Before, BeforeAll, setDefaultTimeout, Status } from '@cucumber/cucumber'
 import { chromium } from '@playwright/test'
 import { AUTH_BOOTSTRAP_TIMEOUT_MS, ensureAuthenticatedState } from '../../fixtures/auth'
-import { deleteTestApp } from '../../support/api'
+import { deleteTestApp, deleteTestDataset } from '../../support/api'
 import { baseURL, cucumberHeadless, cucumberSlowMo } from '../../test-env'
 
 const e2eRoot = fileURLToPath(new URL('../..', import.meta.url))
@@ -90,6 +90,7 @@ After(async function (this: DifyWorld, { pickle, result }) {
   )
 
   for (const id of this.createdAppIds) await deleteTestApp(id).catch(() => {})
+  for (const id of this.createdDatasetIds) await deleteTestDataset(id).catch(() => {})
 
   await this.closeSession()
 })

--- a/e2e/features/support/world.ts
+++ b/e2e/features/support/world.ts
@@ -16,6 +16,8 @@ export class DifyWorld extends World {
   createdAppIds: string[] = []
   capturedDownloads: Download[] = []
   shareURL: string | undefined
+  lastCreatedDatasetName: string | undefined
+  createdDatasetIds: string[] = []
 
   constructor(options: IWorldOptions) {
     super(options)
@@ -29,6 +31,8 @@ export class DifyWorld extends World {
     this.createdAppIds = []
     this.capturedDownloads = []
     this.shareURL = undefined
+    this.lastCreatedDatasetName = undefined
+    this.createdDatasetIds = []
   }
 
   async startSession(browser: Browser, authenticated: boolean) {

--- a/e2e/support/api.ts
+++ b/e2e/support/api.ts
@@ -160,3 +160,36 @@ export async function enableAppSiteAndGetURL(appId: string): Promise<string> {
     await ctx.dispose()
   }
 }
+
+export type DatasetSeed = {
+  id: string
+  name: string
+}
+
+export async function createTestDataset(name: string): Promise<DatasetSeed> {
+  const ctx = await createApiContext()
+  try {
+    const response = await ctx.post('/console/api/datasets', {
+      data: {
+        name,
+        indexing_technique: 'high_quality',
+        permission: 'all_team_members',
+      },
+    })
+    const body = (await response.json()) as DatasetSeed
+    return body
+  }
+  finally {
+    await ctx.dispose()
+  }
+}
+
+export async function deleteTestDataset(id: string): Promise<void> {
+  const ctx = await createApiContext()
+  try {
+    await ctx.delete(`/console/api/datasets/${id}`)
+  }
+  finally {
+    await ctx.dispose()
+  }
+}


### PR DESCRIPTION
Closes #34278

---

Add end-to-end tests for dataset (knowledge base) CRUD operations following existing Cucumber BDD + Playwright patterns.

## What this adds

**Create dataset** (`@datasets`):
- Navigate to datasets page
- Click "Create Knowledge" → "I want to create an empty Knowledge"
- Enter unique name and confirm
- Verify redirect to dataset documents page

**Delete dataset** (`@datasets`):
- Pre-seed a dataset via API
- Navigate to datasets page
- Open operations menu → click Delete → confirm
- Verify dataset no longer appears

## Files

- `e2e/features/datasets/create-dataset.feature` — create scenario
- `e2e/features/datasets/delete-dataset.feature` — delete scenario
- `e2e/features/step-definitions/datasets/datasets.steps.ts` — step definitions
- `e2e/support/api.ts` — added `createTestDataset` and `deleteTestDataset` helpers
- `e2e/features/support/world.ts` — added dataset tracking fields
- `e2e/features/support/hooks.ts` — added dataset cleanup in After hook

---
*AI-agent involvement: This contribution was assisted by an AI coding agent.*