### PR TITLE
fix(console): require admin/owner to set default builtin tool credential

### DIFF
--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -874,6 +874,7 @@ class ToolBuiltinProviderSetDefaultApi(Resource):
     @console_ns.expect(console_ns.models[BuiltinProviderDefaultCredentialPayload.__name__])
     @setup_required
     @login_required
+    @is_admin_or_owner_required
     @account_initialization_required
     def post(self, provider):
         _, current_tenant_id = current_account_with_tenant()


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

`ToolBuiltinProviderSetDefaultApi.post` was missing `@is_admin_or_owner_required`, while `ToolBuiltinProviderDeleteApi` and `ToolBuiltinProviderUpdateApi` already enforce admin/owner for the same builtin tool credential surface. Any authenticated workspace member could set the default credential.

This PR adds `@is_admin_or_owner_required` between `@login_required` and `@account_initialization_required` on `post`, matching sibling endpoints. No new imports (decorator already imported).

Draft issue: `BUG_ISSUE_BUILTIN_TOOL_SET_DEFAULT_MISSING_ACL.md`.

## Screenshots

| Before | After |
|--------|-------|
| Any workspace member could `POST .../default-credential` | Only admin/owner can set default credential |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

## Testing

```bash
cd dify/api && uv run pytest \
  tests/test_containers_integration_tests/controllers/console/workspace/test_tool_provider.py::TestToolBuiltinProviderApi::test_set_default_credential -v
```

Manual (optional): call `POST .../default-credential` as a non-admin workspace member; expect the same forbidden response as `.../update` or `.../delete`.

## Files changed

- `dify/api/controllers/console/workspace/tool_providers.py`

## Related issue

Fixes #36263 