### PR TITLE
fix: preserve external retrieval settings in hit testing

### DIFF
--- a/web/app/components/datasets/hit-testing/components/query-input/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/hit-testing/components/query-input/__tests__/index.spec.tsx
@@ -382,7 +382,18 @@ describe('QueryInput', () => {
         return response
       })
 
-      render(<QueryInput {...defaultProps} isExternal={true} externalKnowledgeBaseHitTestingMutation={mockExternalMutation} />)
+      render(
+        <QueryInput
+          {...defaultProps}
+          isExternal={true}
+          externalKnowledgeBaseHitTestingMutation={mockExternalMutation}
+          externalRetrievalModel={{
+            top_k: 7,
+            score_threshold: 0.85,
+            score_threshold_enabled: true,
+          }}
+        />,
+      )
 
       fireEvent.click(screen.getByRole('button', { name: /input\.testing/ }))
 
@@ -391,9 +402,9 @@ describe('QueryInput', () => {
           expect.objectContaining({
             query: 'test query',
             external_retrieval_model: expect.objectContaining({
-              top_k: 4,
-              score_threshold: 0.5,
-              score_threshold_enabled: false,
+              top_k: 7,
+              score_threshold: 0.85,
+              score_threshold_enabled: true,
             }),
           }),
           expect.objectContaining({ onSuccess: expect.any(Function) }),

--- a/web/app/components/datasets/hit-testing/components/query-input/index.tsx
+++ b/web/app/components/datasets/hit-testing/components/query-input/index.tsx
@@ -3,6 +3,7 @@ import type { ChangeEvent } from 'react'
 import type { FileEntity } from '@/app/components/datasets/common/image-uploader/types'
 import type {
   Attachment,
+  DataSet,
   ExternalKnowledgeBaseHitTestingRequest,
   ExternalKnowledgeBaseHitTestingResponse,
   HitTestingRequest,
@@ -17,7 +18,7 @@ import {
   RiPlayCircleLine,
 } from '@remixicon/react'
 import * as React from 'react'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { v4 as uuid4 } from 'uuid'
 import ImageUploaderInRetrievalTesting from '@/app/components/datasets/common/image-uploader/image-uploader-in-retrieval-testing'
@@ -37,6 +38,7 @@ type QueryInputProps = {
   isExternal?: boolean
   onClickRetrievalMethod: () => void
   retrievalConfig: RetrievalConfig
+  externalRetrievalModel?: DataSet['external_retrieval_model']
   isEconomy: boolean
   onSubmit?: () => void
   hitTestingMutation: UseMutateAsyncFunction<HitTestingResponse, Error, HitTestingRequest, unknown>
@@ -58,6 +60,7 @@ const QueryInput = ({
   isExternal = false,
   onClickRetrievalMethod,
   retrievalConfig,
+  externalRetrievalModel,
   isEconomy,
   onSubmit: _onSubmit,
   hitTestingMutation,
@@ -67,10 +70,21 @@ const QueryInput = ({
   const isMultimodal = useDatasetDetailContextWithSelector(s => !!s.dataset?.is_multimodal)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
   const [externalRetrievalSettings, setExternalRetrievalSettings] = useState({
-    top_k: 4,
-    score_threshold: 0.5,
-    score_threshold_enabled: false,
+    top_k: externalRetrievalModel?.top_k ?? 4,
+    score_threshold: externalRetrievalModel?.score_threshold ?? 0.5,
+    score_threshold_enabled: externalRetrievalModel?.score_threshold_enabled ?? false,
   })
+
+  useEffect(() => {
+    if (!externalRetrievalModel)
+      return
+
+    setExternalRetrievalSettings({
+      top_k: externalRetrievalModel.top_k,
+      score_threshold: externalRetrievalModel.score_threshold,
+      score_threshold_enabled: externalRetrievalModel.score_threshold_enabled,
+    })
+  }, [externalRetrievalModel])
 
   const text = useMemo(() => {
     return queries.find(query => query.content_type === 'text_query')?.content ?? ''

--- a/web/app/components/datasets/hit-testing/index.tsx
+++ b/web/app/components/datasets/hit-testing/index.tsx
@@ -140,6 +140,7 @@ const HitTestingPage: FC<Props> = ({ datasetId }: Props) => {
           onClickRetrievalMethod={() => setIsShowModifyRetrievalModal(true)}
           retrievalConfig={retrievalConfig}
           isEconomy={currentDataset?.indexing_technique === 'economy'}
+          externalRetrievalModel={currentDataset?.external_retrieval_model}
           hitTestingMutation={hitTestingMutation}
           externalKnowledgeBaseHitTestingMutation={externalKnowledgeBaseHitTestingMutation}
         />

--- a/web/app/components/datasets/settings/form/hooks/__tests__/use-form-state.spec.ts
+++ b/web/app/components/datasets/settings/form/hooks/__tests__/use-form-state.spec.ts
@@ -753,5 +753,33 @@ describe('useFormState', () => {
         }),
       })
     })
+
+    it('should save external settings without internal retrieval config', async () => {
+      mockDataset = {
+        ...mockDataset,
+        retrieval_model: undefined as DataSet['retrieval_model'],
+        retrieval_model_dict: undefined as DataSet['retrieval_model_dict'],
+      }
+      const { updateDatasetSetting } = await import('@/service/datasets')
+      const { result } = renderHook(() => useFormState())
+
+      await act(async () => {
+        await result.current.handleSave()
+      })
+
+      expect(result.current.showMultiModalTip).toBe(false)
+      expect(updateDatasetSetting).toHaveBeenCalledWith({
+        datasetId: 'dataset-1',
+        body: expect.objectContaining({
+          external_knowledge_id: 'ext-123',
+          external_knowledge_api_id: 'api-456',
+          external_retrieval_model: {
+            top_k: 5,
+            score_threshold: 0.8,
+            score_threshold_enabled: true,
+          },
+        }),
+      })
+    })
   })
 })

--- a/web/app/components/datasets/settings/form/hooks/use-form-state.ts
+++ b/web/app/components/datasets/settings/form/hooks/use-form-state.ts
@@ -2,7 +2,7 @@
 import type { AppIconSelection } from '@/app/components/base/app-icon-picker'
 import type { DefaultModel } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import type { Member } from '@/models/common'
-import type { IconInfo, SummaryIndexSetting as SummaryIndexSettingType } from '@/models/datasets'
+import type { DataSet, IconInfo, SummaryIndexSetting as SummaryIndexSettingType } from '@/models/datasets'
 import type { RetrievalConfig } from '@/types/app'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useCallback, useMemo, useRef, useState } from 'react'
@@ -25,11 +25,20 @@ const DEFAULT_APP_ICON: IconInfo = {
   icon_url: '',
 }
 
+type DatasetSettingsUpdateBody = Parameters<typeof updateDatasetSetting>[0]['body'] & {
+  keyword_number?: number
+  summary_index_setting?: SummaryIndexSettingType
+  external_knowledge_id?: string
+  external_knowledge_api_id?: string
+  external_retrieval_model?: DataSet['external_retrieval_model']
+}
+
 export const useFormState = () => {
   const { t } = useTranslation()
   const isCurrentWorkspaceDatasetOperator = useAppContextWithSelector(state => state.isCurrentWorkspaceDatasetOperator)
   const currentDataset = useDatasetDetailContextWithSelector(state => state.dataset)
   const mutateDatasets = useDatasetDetailContextWithSelector(state => state.mutateDatasetRes)
+  const isExternalProvider = currentDataset?.provider === 'external'
 
   // Basic form state
   const [loading, setLoading] = useState(false)
@@ -46,9 +55,9 @@ export const useFormState = () => {
   const [selectedMemberIDs, setSelectedMemberIDs] = useState<string[]>(currentDataset?.partial_member_list || [])
 
   // External retrieval state
-  const [topK, setTopK] = useState(currentDataset?.external_retrieval_model.top_k ?? 2)
-  const [scoreThreshold, setScoreThreshold] = useState(currentDataset?.external_retrieval_model.score_threshold ?? 0.5)
-  const [scoreThresholdEnabled, setScoreThresholdEnabled] = useState(currentDataset?.external_retrieval_model.score_threshold_enabled ?? false)
+  const [topK, setTopK] = useState(currentDataset?.external_retrieval_model?.top_k ?? 2)
+  const [scoreThreshold, setScoreThreshold] = useState(currentDataset?.external_retrieval_model?.score_threshold ?? 0.5)
+  const [scoreThresholdEnabled, setScoreThresholdEnabled] = useState(currentDataset?.external_retrieval_model?.score_threshold_enabled ?? false)
 
   // Indexing and retrieval state
   const [indexMethod, setIndexMethod] = useState(currentDataset?.indexing_technique)
@@ -127,36 +136,39 @@ export const useFormState = () => {
       return
     }
 
-    if (!isReRankModelSelected({ rerankModelList, retrievalConfig, indexMethod })) {
+    if (!isExternalProvider && !isReRankModelSelected({ rerankModelList, retrievalConfig, indexMethod })) {
       toast.error(t('datasetConfig.rerankModelRequired', { ns: 'appDebug' }))
       return
     }
 
-    if (retrievalConfig.weights) {
+    if (retrievalConfig?.weights) {
       retrievalConfig.weights.vector_setting.embedding_provider_name = embeddingModel.provider || ''
       retrievalConfig.weights.vector_setting.embedding_model_name = embeddingModel.model || ''
     }
 
     try {
       setLoading(true)
-      const body: Record<string, unknown> = {
+      const body: DatasetSettingsUpdateBody = {
         name,
         icon_info: iconInfo,
         doc_form: currentDataset?.doc_form,
         description,
         permission,
-        indexing_technique: indexMethod,
-        retrieval_model: {
-          ...retrievalConfig,
-          score_threshold: retrievalConfig.score_threshold_enabled ? retrievalConfig.score_threshold : 0,
-        },
-        embedding_model: embeddingModel.model,
-        embedding_model_provider: embeddingModel.provider,
-        keyword_number: keywordNumber,
         summary_index_setting: summaryIndexSetting,
       }
 
-      if (currentDataset!.provider === 'external') {
+      if (!isExternalProvider) {
+        body.indexing_technique = indexMethod
+        body.retrieval_model = {
+          ...retrievalConfig,
+          score_threshold: retrievalConfig.score_threshold_enabled ? retrievalConfig.score_threshold : 0,
+        }
+        body.embedding_model = embeddingModel.model
+        body.embedding_model_provider = embeddingModel.provider
+        body.keyword_number = keywordNumber
+      }
+
+      if (isExternalProvider) {
         body.external_knowledge_id = currentDataset!.external_knowledge_info.external_knowledge_id
         body.external_knowledge_api_id = currentDataset!.external_knowledge_info.external_knowledge_api_id
         body.external_retrieval_model = {
@@ -193,6 +205,9 @@ export const useFormState = () => {
 
   // Computed values
   const showMultiModalTip = useMemo(() => {
+    if (isExternalProvider || !retrievalConfig?.reranking_model)
+      return false
+
     return checkShowMultiModalTip({
       embeddingModel,
       rerankingEnable: retrievalConfig.reranking_enable,
@@ -204,7 +219,7 @@ export const useFormState = () => {
       embeddingModelList,
       rerankModelList,
     })
-  }, [embeddingModel, rerankModelList, retrievalConfig.reranking_enable, retrievalConfig.reranking_model, embeddingModelList, indexMethod])
+  }, [embeddingModel, rerankModelList, retrievalConfig?.reranking_enable, retrievalConfig?.reranking_model, embeddingModelList, indexMethod, isExternalProvider])
 
   return {
     // Context values


### PR DESCRIPTION
Fixes #35912

## Summary

This PR preserves external knowledge retrieval settings during hit testing.

- Passes the dataset external retrieval model into the hit-testing query input.
- Initializes and syncs external hit-testing settings from saved dataset settings.
- Avoids internal rerank/retrieval validation for external datasets.
- Adds tests for external retrieval settings in hit testing and settings save behavior.

## Screenshots

No visual UI changes.

## Testing

- Ran `git diff --check`
- Could not run frontend tests locally because the repo requires Node `^22.22.1`, but local Node is `22.20.0`.