### PR TITLE
refactor(web): simplify workflow block selector filtering

### DIFF
--- a/web/app/components/workflow/block-selector/__tests__/blocks.spec.tsx
+++ b/web/app/components/workflow/block-selector/__tests__/blocks.spec.tsx
@@ -17,10 +17,15 @@ vi.mock('reactflow', () => ({
   }),
 }))
 
-const createBlock = (type: BlockEnum, title: string, classification = BlockClassificationEnum.Default): NodeDefault => ({
+const createBlock = (
+  type: BlockEnum,
+  title: string,
+  classification = BlockClassificationEnum.Default,
+  sort = 0,
+): NodeDefault => ({
   metaData: {
     classification,
-    sort: 0,
+    sort,
     type,
     title,
     author: 'Dify',
@@ -75,5 +80,24 @@ describe('Blocks', () => {
     )
 
     expect(screen.getByText('workflow.tabs.noResult')).toBeInTheDocument()
+  })
+
+  it('sorts matching blocks without mutating the provided block list', () => {
+    const blocks = [
+      createBlock(BlockEnum.Code, 'Code', BlockClassificationEnum.Transform, 2),
+      createBlock(BlockEnum.TemplateTransform, 'Template', BlockClassificationEnum.Transform, 1),
+    ]
+
+    render(
+      <Blocks
+        searchText=""
+        onSelect={vi.fn()}
+        availableBlocksTypes={[BlockEnum.Code, BlockEnum.TemplateTransform]}
+        blocks={blocks}
+      />,
+    )
+
+    expect(screen.getByText('Template').compareDocumentPosition(screen.getByText('Code')) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(blocks.map(block => block.metaData.type)).toEqual([BlockEnum.Code, BlockEnum.TemplateTransform])
   })
 })

--- a/web/app/components/workflow/block-selector/all-tools.tsx
+++ b/web/app/components/workflow/block-selector/all-tools.tsx
@@ -87,8 +87,8 @@ const AllTools = ({
   const hasSearchText = trimmedSearchText.length > 0
   const hasTags = tags.length > 0
   const hasFilter = hasSearchText || hasTags
-  const isMatchingKeywords = (text: string, keywords: string) => {
-    return text.toLowerCase().includes(keywords.toLowerCase())
+  const isMatchingKeywords = (text: string, normalizedKeywords: string) => {
+    return text.toLowerCase().includes(normalizedKeywords)
   }
   const allProviders = useMemo(() => [...buildInTools, ...customTools, ...workflowTools, ...mcpTools], [buildInTools, customTools, workflowTools, mcpTools])
   const providerMap = useMemo(() => {

--- a/web/app/components/workflow/block-selector/blocks.tsx
+++ b/web/app/components/workflow/block-selector/blocks.tsx
@@ -6,7 +6,6 @@ import {
   PreviewCardContent,
   PreviewCardTrigger,
 } from '@langgenius/dify-ui/preview-card'
-import { groupBy } from 'es-toolkit/compat'
 import {
   memo,
   useCallback,
@@ -29,6 +28,37 @@ type BlocksProps = {
 type BlockPreviewPayload = {
   block: NodeDefault
 }
+
+type RenderedBlockClassification = typeof BLOCK_CLASSIFICATIONS[number]
+type BlockGroups = Record<RenderedBlockClassification, NodeDefault[]>
+
+const [
+  DEFAULT_BLOCK_CLASSIFICATION,
+  QUESTION_UNDERSTAND_BLOCK_CLASSIFICATION,
+  LOGIC_BLOCK_CLASSIFICATION,
+  TRANSFORM_BLOCK_CLASSIFICATION,
+  UTILITIES_BLOCK_CLASSIFICATION,
+] = BLOCK_CLASSIFICATIONS
+
+const HIDDEN_BLOCK_TYPES: ReadonlySet<BlockEnum> = new Set([
+  BlockEnum.TriggerWebhook,
+  BlockEnum.TriggerSchedule,
+  BlockEnum.TriggerPlugin,
+])
+
+const BLOCK_CLASSIFICATION_SET: ReadonlySet<BlockClassificationEnum> = new Set<BlockClassificationEnum>(BLOCK_CLASSIFICATIONS)
+
+const isRenderedBlockClassification = (classification: BlockClassificationEnum): classification is RenderedBlockClassification => {
+  return BLOCK_CLASSIFICATION_SET.has(classification)
+}
+
+const createEmptyBlockGroups = (): BlockGroups => ({
+  [DEFAULT_BLOCK_CLASSIFICATION]: [],
+  [QUESTION_UNDERSTAND_BLOCK_CLASSIFICATION]: [],
+  [LOGIC_BLOCK_CLASSIFICATION]: [],
+  [TRANSFORM_BLOCK_CLASSIFICATION]: [],
+  [UTILITIES_BLOCK_CLASSIFICATION]: [],
+})
 
 const Blocks = ({
   searchText,
@@ -56,38 +86,44 @@ const Blocks = ({
     checkValid: () => ({ isValid: true }),
   }) as NodeDefault)
 
+  const hasKnowledgeBaseNode = store.getState().getNodes().some(node => node.data.type === BlockEnum.KnowledgeBase)
+
   const groups = useMemo(() => {
-    return BLOCK_CLASSIFICATIONS.reduce((acc, classification) => {
-      const grouped = groupBy(blocks, 'metaData.classification')
-      const list = (grouped[classification] || []).filter((block) => {
-        // Filter out trigger types from Blocks tab
-        if (block.metaData.type === BlockEnum.TriggerWebhook
-          || block.metaData.type === BlockEnum.TriggerSchedule
-          || block.metaData.type === BlockEnum.TriggerPlugin) {
-          return false
-        }
+    const normalizedSearchText = searchText.toLowerCase()
+    const availableBlockTypes = new Set(availableBlocksTypes)
+    const nextGroups = createEmptyBlockGroups()
 
-        return block.metaData.title.toLowerCase().includes(searchText.toLowerCase()) && availableBlocksTypes.includes(block.metaData.type)
-      })
+    blocks.forEach((block) => {
+      const { classification, title, type } = block.metaData
 
-      return {
-        ...acc,
-        [classification]: list,
-      }
-    }, {} as Record<string, typeof blocks>)
-  }, [blocks, searchText, availableBlocksTypes])
+      if (!isRenderedBlockClassification(classification))
+        return
+
+      if (HIDDEN_BLOCK_TYPES.has(type))
+        return
+
+      if (hasKnowledgeBaseNode && type === BlockEnum.KnowledgeBase)
+        return
+
+      if (!availableBlockTypes.has(type))
+        return
+
+      if (!title.toLowerCase().includes(normalizedSearchText))
+        return
+
+      nextGroups[classification].push(block)
+    })
+
+    BLOCK_CLASSIFICATIONS.forEach((classification) => {
+      nextGroups[classification].sort((a, b) => (a.metaData.sort || 0) - (b.metaData.sort || 0))
+    })
+
+    return nextGroups
+  }, [blocks, searchText, availableBlocksTypes, hasKnowledgeBaseNode])
   const isEmpty = Object.values(groups).every(list => !list.length)
 
-  const renderGroup = useCallback((classification: BlockClassificationEnum) => {
-    const list = groups[classification]!.sort((a, b) => (a.metaData.sort || 0) - (b.metaData.sort || 0))
-    const { getNodes } = store.getState()
-    const nodes = getNodes()
-    const hasKnowledgeBaseNode = nodes.some(node => node.data.type === BlockEnum.KnowledgeBase)
-    const filteredList = list.filter((block) => {
-      if (hasKnowledgeBaseNode)
-        return block.metaData.type !== BlockEnum.KnowledgeBase
-      return true
-    })
+  const renderGroup = useCallback((classification: RenderedBlockClassification) => {
+    const list = groups[classification]
 
     return (
       <div
@@ -95,7 +131,7 @@ const Blocks = ({
         className="mb-1 last-of-type:mb-0"
       >
         {
-          classification !== '-' && !!filteredList.length && (
+          classification !== DEFAULT_BLOCK_CLASSIFICATION && !!list.length && (
             <div className="flex h-[22px] items-start px-3 text-xs font-medium text-text-tertiary">
               {t(`tabs.${classification}`, { ns: 'workflow' })}
             </div>
@@ -106,7 +142,7 @@ const Blocks = ({
           // from the node that gets added on click (inspector + canvas), so
           // hover/focus-only activation is a11y-safe. See
           // packages/dify-ui/AGENTS.md → Overlay Primitive Selection.
-          filteredList.map(block => (
+          list.map(block => (
             <PreviewCardTrigger
               key={block.metaData.type}
               delay={150}
@@ -138,7 +174,7 @@ const Blocks = ({
         }
       </div>
     )
-  }, [groups, onSelect, previewCardHandle, t, store])
+  }, [groups, onSelect, previewCardHandle, t])
 
   return (
     <div className="max-h-[480px] max-w-[500px] overflow-y-auto p-1">


### PR DESCRIPTION
## Summary
- simplify workflow block selector grouping/filtering to avoid repeated grouping, repeated membership scans, and render-time sorting
- model block groups with an explicit typed Record tied to rendered classifications instead of a reducer assertion
- reuse normalized tool search text instead of lowercasing the query for every comparison
- cover block sort order without mutating the provided block list

## Tests
- pnpm --dir web test app/components/workflow/block-selector/__tests__/blocks.spec.tsx app/components/workflow/block-selector/__tests__/all-tools.spec.tsx
- pnpm --dir web type-check
- pnpm lint web/app/components/workflow/block-selector/blocks.tsx web/app/components/workflow/block-selector/all-tools.tsx web/app/components/workflow/block-selector/__tests__/blocks.spec.tsx (passes with existing icon migration warnings in all-tools.tsx)