### PR TITLE
test(api): isolate container DB between tests

### DIFF
--- a/api/tests/test_containers_integration_tests/conftest.py
+++ b/api/tests/test_containers_integration_tests/conftest.py
@@ -496,6 +496,51 @@ def db_session_with_containers(flask_app_with_containers: Flask) -> Generator[Se
             logger.debug("Database session closed")
 
 
+def _truncate_container_database(app: Flask) -> None:
+    """
+    Reset application tables after a container integration test.
+
+    Tests in this package share one PostgreSQL container for performance, while
+    application code may commit through db.session, Session(db.engine), or
+    session_factory-created sessions. Truncating after each test gives the suite
+    a central DB isolation contract that does not depend on which session a test used.
+    This only covers SQLAlchemy application tables in db.metadata for now;
+    Redis, object storage, and custom ad hoc metadata still need their own cleanup.
+    """
+    with app.app_context():
+        db.session.remove()
+
+        tables = db.metadata.sorted_tables
+        if not tables:
+            return
+
+        preparer = db.engine.dialect.identifier_preparer
+        table_names = ", ".join(preparer.format_table(table) for table in tables)
+
+        with db.engine.begin() as conn:
+            conn.execute(text("SET LOCAL lock_timeout = '5s'"))
+            conn.execute(text(f"TRUNCATE TABLE {table_names} RESTART IDENTITY CASCADE"))
+
+        db.session.remove()
+
+
+@pytest.fixture(autouse=True)
+def isolate_container_database(request: pytest.FixtureRequest) -> Generator[None, None, None]:
+    """
+    Clean DB state after tests that use the containerized Flask app.
+
+    This fixture intentionally does not depend on flask_app_with_containers so
+    non-DB tests under this package do not start the full app/container stack.
+    """
+    yield
+
+    if "flask_app_with_containers" not in request.fixturenames:
+        return
+
+    app = request.getfixturevalue("flask_app_with_containers")
+    _truncate_container_database(app)
+
+
 @pytest.fixture(scope="package", autouse=True)
 def mock_ssrf_proxy_requests():
     """


### PR DESCRIPTION
## Summary

Part of https://github.com/langgenius/dify/issues/32454#issuecomment-4417553947.

This is a diagnostic draft PR. It is expected to expose existing DB session leaks before the service fixes are applied.

The code change is the intended test infrastructure direction: after each container integration test that used the containerized Flask app, reset SQLAlchemy application tables with `TRUNCATE ... RESTART IDENTITY CASCADE`.

The cleanup also sets `SET LOCAL lock_timeout = '5s'` for the cleanup transaction. That is test-only behavior in `conftest.py`: if another session is holding a conflicting lock, CI should fail loudly instead of hanging for a long time.

## Why this exists

Container integration tests currently share one PostgreSQL container and many tests/services commit through different sessions. Without a central cleanup contract, DB state can leak between tests unless each test adds its own local cleanup workaround.

This draft PR records what happens when central DB isolation is enabled before fixing the existing session leaks. The follow-up service PR should close the leaked private sessions, and the final DB isolation PR should build on that.

## Validation

- `uv run --project api ruff check api/tests/test_containers_integration_tests/conftest.py`
