### PR TITLE
chore(docker): upgrade plugin daemon to 0.6.1

### DIFF
--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -518,7 +518,7 @@ services:
 
   # plugin daemon
   plugin_daemon:
-    image: langgenius/dify-plugin-daemon:0.6.0-local
+    image: langgenius/dify-plugin-daemon:0.6.1-local
     restart: always
     env_file:
       - path: ./envs/core-services/shared.env

--- a/docker/docker-compose.middleware.yaml
+++ b/docker/docker-compose.middleware.yaml
@@ -129,7 +129,7 @@ services:
 
   # plugin daemon
   plugin_daemon:
-    image: langgenius/dify-plugin-daemon:0.6.0-local
+    image: langgenius/dify-plugin-daemon:0.6.1-local
     restart: always
     env_file:
       - ./middleware.env

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -524,7 +524,7 @@ services:
 
   # plugin daemon
   plugin_daemon:
-    image: langgenius/dify-plugin-daemon:0.6.0-local
+    image: langgenius/dify-plugin-daemon:0.6.1-local
     restart: always
     env_file:
       - path: ./envs/core-services/shared.env


### PR DESCRIPTION
## Summary

Fixes #36309

Updates Docker compose plugin daemon image references to `langgenius/dify-plugin-daemon:0.6.1-local` while preserving the `-local` suffix across the main, template, and middleware Docker deployments.

## Screenshots

N/A - Docker configuration only.