### PR TITLE
ci: ensure pnpm is available in setup-web action

### DIFF
--- a/.github/actions/setup-web/action.yml
+++ b/.github/actions/setup-web/action.yml
@@ -1,8 +1,13 @@
 name: Setup Web Environment
+description: Set up Node.js, Vite+, pnpm, and web dependencies
 
 runs:
   using: composite
   steps:
+    - name: Setup pnpm
+      uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+      with:
+        run_install: false
     - name: Setup Vite+
       uses: voidzero-dev/setup-vp@4f5aa3e38c781f1b01e78fb9255527cee8a6efa6 # v1.8.0
       with:


### PR DESCRIPTION
## Summary
- add setup-web action metadata description
- install pnpm with the official pnpm/action-setup action before Vite+ setup
- let pnpm/action-setup read the repository packageManager field and avoid a duplicate install

close #36317

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/actions/setup-web/action.yml"); puts "yaml ok"'
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label ".*" is unknown'
- git diff --check
- pnpm --version