### PR TITLE
fix: use members SSO endpoints for webapp auth

### DIFF
--- a/web/app/(shareLayout)/webapp-signin/components/__tests__/external-member-sso-auth.spec.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/__tests__/external-member-sso-auth.spec.tsx
@@ -1,0 +1,84 @@
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { render, waitFor } from '@testing-library/react'
+import {
+  fetchMembersOAuth2SSOUrl,
+  fetchMembersOIDCSSOUrl,
+  fetchMembersSAMLSSOUrl,
+  fetchWebOAuth2SSOUrl,
+  fetchWebOIDCSSOUrl,
+  fetchWebSAMLSSOUrl,
+} from '@/service/share'
+import { SSOProtocol } from '@/types/feature'
+import ExternalMemberSSOAuth from '../external-member-sso-auth'
+
+const mockPush = vi.fn()
+const mockUseSearchParams = vi.fn()
+
+vi.mock('@tanstack/react-query', () => ({
+  useSuspenseQuery: vi.fn(),
+}))
+
+vi.mock('@/app/components/base/app-unavailable', () => ({
+  default: () => <div data-testid="app-unavailable" />,
+}))
+
+vi.mock('@/app/components/base/loading', () => ({
+  default: () => <div data-testid="loading" />,
+}))
+
+vi.mock('@/next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => mockUseSearchParams(),
+}))
+
+vi.mock('@/service/share', () => ({
+  fetchMembersOAuth2SSOUrl: vi.fn(),
+  fetchMembersOIDCSSOUrl: vi.fn(),
+  fetchMembersSAMLSSOUrl: vi.fn(),
+  fetchWebOAuth2SSOUrl: vi.fn(),
+  fetchWebOIDCSSOUrl: vi.fn(),
+  fetchWebSAMLSSOUrl: vi.fn(),
+}))
+
+vi.mock('@/service/system-features', () => ({
+  systemFeaturesQueryOptions: () => ({}),
+}))
+
+const mockUseSuspenseQuery = vi.mocked(useSuspenseQuery)
+
+const setSSOProtocol = (protocol: SSOProtocol) => {
+  mockUseSuspenseQuery.mockReturnValue({
+    data: {
+      webapp_auth: {
+        sso_config: {
+          protocol,
+        },
+      },
+    },
+  } as ReturnType<typeof useSuspenseQuery>)
+}
+
+describe('ExternalMemberSSOAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseSearchParams.mockReturnValue(new URLSearchParams('redirect_url=%2Fchat%2Fapp-code'))
+  })
+
+  it.each([
+    [SSOProtocol.SAML, fetchMembersSAMLSSOUrl, fetchWebSAMLSSOUrl],
+    [SSOProtocol.OIDC, fetchMembersOIDCSSOUrl, fetchWebOIDCSSOUrl],
+    [SSOProtocol.OAuth2, fetchMembersOAuth2SSOUrl, fetchWebOAuth2SSOUrl],
+  ])('uses members SSO endpoint for external webapp %s auth', async (protocol, membersFetch, webFetch) => {
+    setSSOProtocol(protocol)
+    vi.mocked(membersFetch).mockResolvedValue({ url: `https://app.example/${protocol}` })
+    vi.mocked(webFetch).mockResolvedValue({ url: `https://console.example/${protocol}` })
+
+    render(<ExternalMemberSSOAuth />)
+
+    await waitFor(() => {
+      expect(membersFetch).toHaveBeenCalledWith('app-code', '/chat/app-code')
+    })
+    expect(webFetch).not.toHaveBeenCalled()
+    expect(mockPush).toHaveBeenCalledWith(`https://app.example/${protocol}`)
+  })
+})

--- a/web/app/(shareLayout)/webapp-signin/components/external-member-sso-auth.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/external-member-sso-auth.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect } from 'react'
 import AppUnavailable from '@/app/components/base/app-unavailable'
 import Loading from '@/app/components/base/loading'
 import { useRouter, useSearchParams } from '@/next/navigation'
-import { fetchWebOAuth2SSOUrl, fetchWebOIDCSSOUrl, fetchWebSAMLSSOUrl } from '@/service/share'
+import { fetchMembersOAuth2SSOUrl, fetchMembersOIDCSSOUrl, fetchMembersSAMLSSOUrl } from '@/service/share'
 import { systemFeaturesQueryOptions } from '@/service/system-features'
 import { SSOProtocol } from '@/types/feature'
 
@@ -41,17 +41,17 @@ const ExternalMemberSSOAuth = () => {
 
     switch (systemFeatures.webapp_auth.sso_config.protocol) {
       case SSOProtocol.SAML: {
-        const samlRes = await fetchWebSAMLSSOUrl(appCode, redirectUrl)
+        const samlRes = await fetchMembersSAMLSSOUrl(appCode, redirectUrl)
         router.push(samlRes.url)
         break
       }
       case SSOProtocol.OIDC: {
-        const oidcRes = await fetchWebOIDCSSOUrl(appCode, redirectUrl)
+        const oidcRes = await fetchMembersOIDCSSOUrl(appCode, redirectUrl)
         router.push(oidcRes.url)
         break
       }
       case SSOProtocol.OAuth2: {
-        const oauth2Res = await fetchWebOAuth2SSOUrl(appCode, redirectUrl)
+        const oauth2Res = await fetchMembersOAuth2SSOUrl(appCode, redirectUrl)
         router.push(oauth2Res.url)
         break
       }


### PR DESCRIPTION
## Summary

- Route external WebApp member SSO auto-login through the members SSO endpoints instead of console-oriented Web SSO endpoints.
- Add a regression test covering SAML, OIDC, and OAuth2 protocols for the external member WebApp SSO flow.

Fixes #36307

## Tests

- `PATH=/Users/cc/.cache/codex-runtimes/node22/node-v22.22.3-darwin-arm64/bin:$PATH pnpm --filter dify-web test "app/(shareLayout)/webapp-signin/components/__tests__/external-member-sso-auth.spec.tsx"`
- `PATH=/Users/cc/.cache/codex-runtimes/node22/node-v22.22.3-darwin-arm64/bin:$PATH pnpm exec eslint "web/app/(shareLayout)/webapp-signin/components/external-member-sso-auth.tsx" "web/app/(shareLayout)/webapp-signin/components/__tests__/external-member-sso-auth.spec.tsx"`
- `PATH=/Users/cc/.cache/codex-runtimes/node22/node-v22.22.3-darwin-arm64/bin:$PATH pnpm --filter dify-web type-check`
- `git diff --check HEAD~1..HEAD`