### PR TITLE
feat(web): allow annotation reply score threshold below 0.8

### DIFF
--- a/web/app/components/base/features/new-feature-panel/annotation-reply/__tests__/config-param-modal.spec.tsx
+++ b/web/app/components/base/features/new-feature-panel/annotation-reply/__tests__/config-param-modal.spec.tsx
@@ -40,7 +40,7 @@ vi.mock('../score-slider', () => ({
     <input
       role="slider"
       type="range"
-      min={80}
+      min={0}
       max={100}
       value={value}
       onChange={e => onChange(Number((e.target as HTMLInputElement).value))}
@@ -272,7 +272,7 @@ describe('ConfigParamModal', () => {
     )
 
     const slider = screen.getByRole('slider')
-    expect(slider).toHaveAttribute('min', '80')
+    expect(slider).toHaveAttribute('min', '0')
     expect(slider).toHaveAttribute('max', '100')
     expect(slider).toHaveValue('90')
   })
@@ -375,7 +375,7 @@ describe('ConfigParamModal', () => {
   it('should use ANNOTATION_DEFAULT score_threshold when config has no score_threshold', () => {
     const configWithoutThreshold = {
       ...defaultAnnotationConfig,
-      score_threshold: 0,
+      score_threshold: undefined as unknown as number,
     }
     render(
       <ConfigParamModal
@@ -388,6 +388,35 @@ describe('ConfigParamModal', () => {
     )
 
     expect(screen.getByRole('slider')).toHaveValue('90')
+  })
+
+  it('should preserve zero score threshold instead of falling back to default', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    render(
+      <ConfigParamModal
+        appId="test-app"
+        isShow={true}
+        onHide={vi.fn()}
+        onSave={onSave}
+        annotationConfig={{
+          ...defaultAnnotationConfig,
+          score_threshold: 0,
+        }}
+      />,
+    )
+
+    expect(screen.getByRole('slider')).toHaveValue('0')
+
+    const buttons = screen.getAllByRole('button')
+    const saveBtn = buttons.find(b => b.textContent?.includes('initSetup'))
+    fireEvent.click(saveBtn!)
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({ embedding_provider_name: 'openai' }),
+        0,
+      )
+    })
   })
 
   it('should set loading state while saving', async () => {

--- a/web/app/components/base/features/new-feature-panel/annotation-reply/__tests__/index.spec.tsx
+++ b/web/app/components/base/features/new-feature-panel/annotation-reply/__tests__/index.spec.tsx
@@ -175,6 +175,22 @@ describe('AnnotationReply', () => {
     expect(screen.getByText('text-embedding-ada-002')).toBeInTheDocument()
   })
 
+  it('should show zero score threshold when enabled', () => {
+    renderWithProvider({}, {
+      annotationReply: {
+        enabled: true,
+        score_threshold: 0,
+        embedding_model: {
+          embedding_provider_name: 'openai',
+          embedding_model_name: 'text-embedding-ada-002',
+        },
+      },
+    })
+
+    expect(screen.getByText('0')).toBeInTheDocument()
+    expect(screen.getByText('text-embedding-ada-002')).toBeInTheDocument()
+  })
+
   it('should show dash when score threshold is not set', () => {
     renderWithProvider({}, {
       annotationReply: {

--- a/web/app/components/base/features/new-feature-panel/annotation-reply/__tests__/use-annotation-config.spec.ts
+++ b/web/app/components/base/features/new-feature-panel/annotation-reply/__tests__/use-annotation-config.spec.ts
@@ -1,6 +1,6 @@
 import type { AnnotationReplyConfig } from '@/models/debug'
 import { act, renderHook } from '@testing-library/react'
-import { queryAnnotationJobStatus } from '@/service/annotation'
+import { queryAnnotationJobStatus, updateAnnotationStatus } from '@/service/annotation'
 import { sleep } from '@/utils'
 import useAnnotationConfig from '../use-annotation-config'
 
@@ -160,6 +160,35 @@ describe('useAnnotationConfig', () => {
     expect(setAnnotationConfig).toHaveBeenCalled()
     const updatedConfig = setAnnotationConfig.mock.calls[0]![0]
     expect(updatedConfig.score_threshold).toBe(0.85)
+  })
+
+  it('should preserve zero score threshold when enabling annotation', async () => {
+    const zeroScoreConfig = { ...defaultConfig, score_threshold: 0 }
+    const setAnnotationConfig = vi.fn()
+    const { result } = renderHook(() => useAnnotationConfig({
+      appId: 'test-app',
+      annotationConfig: zeroScoreConfig,
+      setAnnotationConfig,
+    }))
+
+    await act(async () => {
+      await result.current.handleEnableAnnotation({
+        embedding_provider_name: 'openai',
+        embedding_model_name: 'text-embedding-3-small',
+      }, 0)
+    })
+
+    expect(updateAnnotationStatus).toHaveBeenCalledWith(
+      'test-app',
+      'enable',
+      {
+        embedding_provider_name: 'openai',
+        embedding_model_name: 'text-embedding-3-small',
+      },
+      0,
+    )
+    const updatedConfig = setAnnotationConfig.mock.calls[0]![0]
+    expect(updatedConfig.score_threshold).toBe(0)
   })
 
   it('should set score and embedding model together', () => {

--- a/web/app/components/base/features/new-feature-panel/annotation-reply/config-param-modal.tsx
+++ b/web/app/components/base/features/new-feature-panel/annotation-reply/config-param-modal.tsx
@@ -75,7 +75,7 @@ const ConfigParamModal: FC<Props> = ({ isShow, onHide: doHide, onSave, isInit, a
           <Item title={t('feature.annotation.scoreThreshold.title', { ns: 'appDebug' })} tooltip={t('feature.annotation.scoreThreshold.description', { ns: 'appDebug' })}>
             <ScoreSlider
               className="mt-1"
-              value={(annotationConfig.score_threshold || ANNOTATION_DEFAULT.score_threshold) * 100}
+              value={(annotationConfig.score_threshold ?? ANNOTATION_DEFAULT.score_threshold) * 100}
               onChange={(val) => {
                 setAnnotationConfig({
                   ...annotationConfig,

--- a/web/app/components/base/features/new-feature-panel/annotation-reply/index.tsx
+++ b/web/app/components/base/features/new-feature-panel/annotation-reply/index.tsx
@@ -100,7 +100,7 @@ const AnnotationReply = ({
                 <div className="flex items-center gap-4 pt-0.5">
                   <div className="">
                     <div className="mb-0.5 system-2xs-medium-uppercase text-text-tertiary">{t('feature.annotation.scoreThreshold.title', { ns: 'appDebug' })}</div>
-                    <div className="system-xs-regular text-text-secondary">{annotationReply.score_threshold || '-'}</div>
+                    <div className="system-xs-regular text-text-secondary">{annotationReply.score_threshold ?? '-'}</div>
                   </div>
                   <div className="h-[27px] w-px rotate-12 bg-divider-subtle"></div>
                   <div className="">

--- a/web/app/components/base/features/new-feature-panel/annotation-reply/score-slider/__tests__/index.spec.tsx
+++ b/web/app/components/base/features/new-feature-panel/annotation-reply/score-slider/__tests__/index.spec.tsx
@@ -17,7 +17,7 @@ describe('ScoreSlider', () => {
   it('should display easy match and accurate match labels', () => {
     render(<ScoreSlider value={90} onChange={vi.fn()} />)
 
-    expect(screen.getByText('0.8')).toBeInTheDocument()
+    expect(screen.getByText('0.0')).toBeInTheDocument()
     expect(screen.getByText('1.0')).toBeInTheDocument()
     expect(screen.getByText(/feature\.annotation\.scoreThreshold\.easyMatch/)).toBeInTheDocument()
     expect(screen.getByText(/feature\.annotation\.scoreThreshold\.accurateMatch/)).toBeInTheDocument()
@@ -35,5 +35,12 @@ describe('ScoreSlider', () => {
 
     expect(getSliderInput()).toHaveValue('95')
     expect(screen.getByText('0.95')).toBeInTheDocument()
+  })
+
+  it('should allow zero as the minimum score threshold', () => {
+    render(<ScoreSlider value={0} onChange={vi.fn()} />)
+
+    expect(getSliderInput()).toHaveValue('0')
+    expect(screen.getByText('0.00')).toBeInTheDocument()
   })
 })

--- a/web/app/components/base/features/new-feature-panel/annotation-reply/score-slider/index.tsx
+++ b/web/app/components/base/features/new-feature-panel/annotation-reply/score-slider/index.tsx
@@ -17,13 +17,16 @@ const clamp = (value: number, min: number, max: number) => {
   return Math.min(Math.max(value, min), max)
 }
 
+const SCORE_MIN = 0
+const SCORE_MAX = 100
+
 const ScoreSlider: FC<Props> = ({
   className,
   value,
   onChange,
 }) => {
   const { t } = useTranslation()
-  const safeValue = clamp(value, 80, 100)
+  const safeValue = clamp(value, SCORE_MIN, SCORE_MAX)
 
   return (
     <div className={className}>
@@ -31,8 +34,8 @@ const ScoreSlider: FC<Props> = ({
         <Slider
           className="w-full"
           value={safeValue}
-          min={80}
-          max={100}
+          min={SCORE_MIN}
+          max={SCORE_MAX}
           step={1}
           onValueChange={onChange}
           aria-label={t('feature.annotation.scoreThreshold.title', { ns: 'appDebug' })}
@@ -40,7 +43,7 @@ const ScoreSlider: FC<Props> = ({
         <div
           className="pointer-events-none absolute top-[-16px] system-sm-semibold text-text-primary"
           style={{
-            left: `calc(4px + ${(safeValue - 80) / 20} * (100% - 8px))`,
+            left: `calc(4px + ${safeValue / SCORE_MAX} * (100% - 8px))`,
             transform: 'translateX(-50%)',
           }}
         >
@@ -49,7 +52,7 @@ const ScoreSlider: FC<Props> = ({
       </div>
       <div className="mt-[10px] flex items-center justify-between system-xs-semibold-uppercase">
         <div className="flex space-x-1 text-util-colors-cyan-cyan-500">
-          <div>0.8</div>
+          <div>0.0</div>
           <div>·</div>
           <div>{t('feature.annotation.scoreThreshold.easyMatch', { ns: 'appDebug' })}</div>
         </div>

--- a/web/app/components/base/features/new-feature-panel/annotation-reply/use-annotation-config.ts
+++ b/web/app/components/base/features/new-feature-panel/annotation-reply/use-annotation-config.ts
@@ -53,7 +53,7 @@ const useAnnotationConfig = ({
     setAnnotationConfig(produce(annotationConfig, (draft: AnnotationReplyConfig) => {
       draft.enabled = true
       draft.embedding_model = embeddingModel
-      if (!draft.score_threshold)
+      if (draft.score_threshold === undefined || draft.score_threshold === null)
         draft.score_threshold = ANNOTATION_DEFAULT.score_threshold
     }))
   }

--- a/web/service/annotation.spec.ts
+++ b/web/service/annotation.spec.ts
@@ -1,0 +1,28 @@
+import { AnnotationEnableStatus } from '@/app/components/app/annotation/type'
+import { updateAnnotationStatus } from './annotation'
+import { post } from './base'
+
+vi.mock('./base', () => ({
+  post: vi.fn(),
+}))
+
+describe('annotation service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should preserve zero score threshold when updating annotation status', () => {
+    updateAnnotationStatus('app-1', AnnotationEnableStatus.enable, {
+      embedding_model_name: 'model',
+      embedding_provider_name: 'provider',
+    }, 0)
+
+    expect(post).toHaveBeenCalledWith('apps/app-1/annotation-reply/enable', {
+      body: {
+        embedding_model_name: 'model',
+        embedding_provider_name: 'provider',
+        score_threshold: 0,
+      },
+    })
+  })
+})

--- a/web/service/annotation.ts
+++ b/web/service/annotation.ts
@@ -7,7 +7,7 @@ export const fetchAnnotationConfig = (appId: string) => {
 }
 export const updateAnnotationStatus = (appId: string, action: AnnotationEnableStatus, embeddingModel?: EmbeddingModelConfig, score?: number) => {
   let body: any = {
-    score_threshold: score || ANNOTATION_DEFAULT.score_threshold,
+    score_threshold: score ?? ANNOTATION_DEFAULT.score_threshold,
   }
   if (embeddingModel) {
     body = {


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Removed the Annotation Reply score threshold UI lower bound of 0.8, allowing values from 0.00 to 1.00.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
