### PR TITLE
refactor(web): replace useContext with use() (React 19) (Issue #25193)

### DIFF
--- a/web/app/components/base/features/hooks.ts
+++ b/web/app/components/base/features/hooks.ts
@@ -1,10 +1,10 @@
 import type { FeatureStoreState } from './store'
-import { useContext } from 'react'
+import { use } from 'react'
 import { useStore } from 'zustand'
 import { FeaturesContext } from './context'
 
 export function useFeatures<T>(selector: (state: FeatureStoreState) => T): T {
-  const store = useContext(FeaturesContext)
+  const store = use(FeaturesContext)
   if (!store)
     throw new Error('Missing FeaturesContext.Provider in the tree')
 

--- a/web/app/components/base/features/hooks.ts
+++ b/web/app/components/base/features/hooks.ts
@@ -12,5 +12,5 @@ export function useFeatures<T>(selector: (state: FeatureStoreState) => T): T {
 }
 
 export function useFeaturesStore() {
-  return useContext(FeaturesContext)
+  return use(FeaturesContext)
 }


### PR DESCRIPTION
- Replace useContext() with React 19's use() API
- Keep createContext() unchanged
- Use use() to read context values

 #25193

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Description

React 19 introduced the `use()` API which can read context (and other resources like promises). This PR replaces `useContext()` with `use()` where appropriate.

## Changes

- Replace `useContext(MyContext)` with `use(MyContext)` in:
  - `web/app/components/base/features/hooks.ts`

## Related Issues

Closes #25193

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Other

## Testing

1. Verified the app still works correctly
2. Verified context values are read correctly with `use()`

## Additional Notes

- `use()` is only for reading context (not for `createContext`)
- Kept `createContext()` unchanged
- React 19's `use()` can also read promises, but this PR only replaces `useContext`

---

**PR Link**: https://github.com/langgenius/dify/compare/main...guangyang1206:dify:fix/replace-useContext-with-use-25193

