### PR TITLE
fix(mcp): start OAuth when initialize succeeds without tokens

### DIFF
--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -1149,6 +1149,17 @@ class ToolMCPAuthApi(Resource):
                 timeout=provider_entity.timeout,
                 sse_read_timeout=provider_entity.sse_read_timeout,
             ):
+                # Some OAuth-protected MCP servers may return 200 OK on initialize even without tokens.
+                # In that case, we still need to kick off OAuth instead of marking the provider as authed.
+                if (
+                    provider_entity.retrieve_tokens() is None
+                    and "client_information" in provider_entity.decrypt_credentials()
+                ):
+                    auth_result = auth(provider_entity)
+                    with sessionmaker(db.engine).begin() as session:
+                        service = MCPToolManageService(session=session)
+                        response = service.execute_auth_actions(auth_result)
+                        return response
                 # Update credentials in new transaction
                 with sessionmaker(db.engine).begin() as session:
                     service = MCPToolManageService(session=session)

--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -1529,6 +1529,17 @@ class ToolMCPAuthApi(Resource):
                 timeout=provider_entity.timeout,
                 sse_read_timeout=provider_entity.sse_read_timeout,
             ):
+                # Some OAuth-protected MCP servers may return 200 OK on initialize even without tokens.
+                # In that case, we still need to kick off OAuth instead of marking the provider as authed.
+                if (
+                    provider_entity.retrieve_tokens() is None
+                    and "client_information" in provider_entity.decrypt_credentials()
+                ):
+                    auth_result = auth(provider_entity)
+                    with sessionmaker(db.engine).begin() as session:
+                        service = MCPToolManageService(session=session)
+                        response = service.execute_auth_actions(auth_result)
+                        return response
                 # Update credentials in new transaction
                 with sessionmaker(db.engine).begin() as session:
                     service = MCPToolManageService(session=session)

--- a/api/tests/unit_tests/controllers/console/workspace/test_tool_providers.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_tool_providers.py
@@ -430,3 +430,108 @@ def test_resolve_identity_mode_off_is_passthrough_when_not_enterprise(
     monkeypatch.setattr(controller_module.dify_config, "ENTERPRISE_ENABLED", False)
 
     assert controller_module._resolve_identity_mode(None, current=identity_mode.OFF) == identity_mode.OFF
+
+
+class _DummyBegin:
+    def __init__(self, session: object | None = None) -> None:
+        self._session = session or MagicMock()
+
+    def __enter__(self):
+        return self._session
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_mcp_auth_starts_oauth_when_initialize_succeeds_but_no_tokens(
+    app: Flask, controller_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+):
+    user = _mock_account()
+    _set_current_account(monkeypatch, controller_module, user, "tenant-mcp")
+    monkeypatch.setattr(controller_module, "db", SimpleNamespace(engine=MagicMock()))
+
+    provider_entity = MagicMock()
+    provider_entity.decrypt_server_url.return_value = "https://example.com/mcp"
+    provider_entity.decrypt_authentication.return_value = {}
+    provider_entity.decrypt_credentials.return_value = {"client_information": {"client_id": "cid"}}
+    provider_entity.retrieve_tokens.return_value = None
+    provider_entity.timeout = 1
+    provider_entity.sse_read_timeout = 1
+
+    db_provider = MagicMock()
+    db_provider.to_entity.return_value = provider_entity
+
+    service_mock = MagicMock()
+    service_mock.get_provider.return_value = db_provider
+    service_mock.execute_auth_actions.return_value = {"authorization_url": "https://auth.example.com"}
+
+    monkeypatch.setattr(controller_module, "MCPToolManageService", MagicMock(return_value=service_mock))
+
+    session_factory = MagicMock()
+    session_factory.begin.return_value = _DummyBegin()
+    monkeypatch.setattr(controller_module, "sessionmaker", MagicMock(return_value=session_factory))
+
+    mcp_client = MagicMock()
+    mcp_client.__enter__.return_value = mcp_client
+    mcp_client.__exit__.return_value = None
+    monkeypatch.setattr(controller_module, "MCPClient", MagicMock(return_value=mcp_client))
+
+    auth_result = MagicMock()
+    auth_mock = MagicMock(return_value=auth_result)
+    monkeypatch.setattr(controller_module, "auth", auth_mock)
+
+    with app.test_request_context(
+        "/workspaces/current/tool-provider/mcp/auth", method="POST", json={"provider_id": "p1"}
+    ):
+        resp = controller_module.ToolMCPAuthApi().post()
+
+    assert resp == {"authorization_url": "https://auth.example.com"}
+    auth_mock.assert_called_once_with(provider_entity)
+    service_mock.execute_auth_actions.assert_called_once_with(auth_result)
+    service_mock.update_provider_credentials.assert_not_called()
+
+
+def test_mcp_auth_marks_authed_when_tokens_already_present(
+    app: Flask, controller_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+):
+    user = _mock_account()
+    _set_current_account(monkeypatch, controller_module, user, "tenant-mcp")
+    monkeypatch.setattr(controller_module, "db", SimpleNamespace(engine=MagicMock()))
+
+    provider_entity = MagicMock()
+    provider_entity.decrypt_server_url.return_value = "https://example.com/mcp"
+    provider_entity.decrypt_authentication.return_value = {"Authorization": "Bearer token"}
+    provider_entity.decrypt_credentials.return_value = {"client_information": {"client_id": "cid"}, "access_token": "t"}
+    provider_entity.retrieve_tokens.return_value = MagicMock()
+    provider_entity.credentials = {"client_information": {"client_id": "cid"}}
+    provider_entity.timeout = 1
+    provider_entity.sse_read_timeout = 1
+
+    db_provider = MagicMock()
+    db_provider.to_entity.return_value = provider_entity
+
+    service_mock = MagicMock()
+    service_mock.get_provider.return_value = db_provider
+
+    monkeypatch.setattr(controller_module, "MCPToolManageService", MagicMock(return_value=service_mock))
+
+    session_factory = MagicMock()
+    session_factory.begin.return_value = _DummyBegin()
+    monkeypatch.setattr(controller_module, "sessionmaker", MagicMock(return_value=session_factory))
+
+    mcp_client = MagicMock()
+    mcp_client.__enter__.return_value = mcp_client
+    mcp_client.__exit__.return_value = None
+    monkeypatch.setattr(controller_module, "MCPClient", MagicMock(return_value=mcp_client))
+
+    auth_mock = MagicMock()
+    monkeypatch.setattr(controller_module, "auth", auth_mock)
+
+    with app.test_request_context(
+        "/workspaces/current/tool-provider/mcp/auth", method="POST", json={"provider_id": "p1"}
+    ):
+        resp = controller_module.ToolMCPAuthApi().post()
+
+    assert resp == {"result": "success"}
+    auth_mock.assert_not_called()
+    service_mock.update_provider_credentials.assert_called_once()

--- a/api/tests/unit_tests/controllers/console/workspace/test_tool_providers.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_tool_providers.py
@@ -6,7 +6,7 @@ import builtins
 import importlib
 from contextlib import ExitStack, contextmanager
 from inspect import unwrap
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 from uuid import NAMESPACE_URL, uuid5
 
@@ -948,3 +948,108 @@ def test_tool_oauth_callback_unknown_stored_visibility_falls_back_to_only_me(
 
     _, kwargs = add_provider.call_args
     assert kwargs["visibility"] == "only_me"
+
+
+class _DummyBegin:
+    def __init__(self, session: object | None = None) -> None:
+        self._session = session or MagicMock()
+
+    def __enter__(self):
+        return self._session
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_mcp_auth_starts_oauth_when_initialize_succeeds_but_no_tokens(
+    app: Flask, controller_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+):
+    user = _mock_account()
+    _set_current_account(monkeypatch, controller_module, user, "tenant-mcp")
+    monkeypatch.setattr(controller_module, "db", SimpleNamespace(engine=MagicMock()))
+
+    provider_entity = MagicMock()
+    provider_entity.decrypt_server_url.return_value = "https://example.com/mcp"
+    provider_entity.decrypt_authentication.return_value = {}
+    provider_entity.decrypt_credentials.return_value = {"client_information": {"client_id": "cid"}}
+    provider_entity.retrieve_tokens.return_value = None
+    provider_entity.timeout = 1
+    provider_entity.sse_read_timeout = 1
+
+    db_provider = MagicMock()
+    db_provider.to_entity.return_value = provider_entity
+
+    service_mock = MagicMock()
+    service_mock.get_provider.return_value = db_provider
+    service_mock.execute_auth_actions.return_value = {"authorization_url": "https://auth.example.com"}
+
+    monkeypatch.setattr(controller_module, "MCPToolManageService", MagicMock(return_value=service_mock))
+
+    session_factory = MagicMock()
+    session_factory.begin.return_value = _DummyBegin()
+    monkeypatch.setattr(controller_module, "sessionmaker", MagicMock(return_value=session_factory))
+
+    mcp_client = MagicMock()
+    mcp_client.__enter__.return_value = mcp_client
+    mcp_client.__exit__.return_value = None
+    monkeypatch.setattr(controller_module, "MCPClient", MagicMock(return_value=mcp_client))
+
+    auth_result = MagicMock()
+    auth_mock = MagicMock(return_value=auth_result)
+    monkeypatch.setattr(controller_module, "auth", auth_mock)
+
+    with app.test_request_context(
+        "/workspaces/current/tool-provider/mcp/auth", method="POST", json={"provider_id": "p1"}
+    ):
+        resp = controller_module.ToolMCPAuthApi().post()
+
+    assert resp == {"authorization_url": "https://auth.example.com"}
+    auth_mock.assert_called_once_with(provider_entity)
+    service_mock.execute_auth_actions.assert_called_once_with(auth_result)
+    service_mock.update_provider_credentials.assert_not_called()
+
+
+def test_mcp_auth_marks_authed_when_tokens_already_present(
+    app: Flask, controller_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+):
+    user = _mock_account()
+    _set_current_account(monkeypatch, controller_module, user, "tenant-mcp")
+    monkeypatch.setattr(controller_module, "db", SimpleNamespace(engine=MagicMock()))
+
+    provider_entity = MagicMock()
+    provider_entity.decrypt_server_url.return_value = "https://example.com/mcp"
+    provider_entity.decrypt_authentication.return_value = {"Authorization": "Bearer token"}
+    provider_entity.decrypt_credentials.return_value = {"client_information": {"client_id": "cid"}, "access_token": "t"}
+    provider_entity.retrieve_tokens.return_value = MagicMock()
+    provider_entity.credentials = {"client_information": {"client_id": "cid"}}
+    provider_entity.timeout = 1
+    provider_entity.sse_read_timeout = 1
+
+    db_provider = MagicMock()
+    db_provider.to_entity.return_value = provider_entity
+
+    service_mock = MagicMock()
+    service_mock.get_provider.return_value = db_provider
+
+    monkeypatch.setattr(controller_module, "MCPToolManageService", MagicMock(return_value=service_mock))
+
+    session_factory = MagicMock()
+    session_factory.begin.return_value = _DummyBegin()
+    monkeypatch.setattr(controller_module, "sessionmaker", MagicMock(return_value=session_factory))
+
+    mcp_client = MagicMock()
+    mcp_client.__enter__.return_value = mcp_client
+    mcp_client.__exit__.return_value = None
+    monkeypatch.setattr(controller_module, "MCPClient", MagicMock(return_value=mcp_client))
+
+    auth_mock = MagicMock()
+    monkeypatch.setattr(controller_module, "auth", auth_mock)
+
+    with app.test_request_context(
+        "/workspaces/current/tool-provider/mcp/auth", method="POST", json={"provider_id": "p1"}
+    ):
+        resp = controller_module.ToolMCPAuthApi().post()
+
+    assert resp == {"authorization_url": None, "result": "success"}
+    auth_mock.assert_not_called()
+    service_mock.update_provider_credentials.assert_called_once()


### PR DESCRIPTION
﻿### What
Fix MCP OAuth authorization flow for servers that return `200 OK` on `initialize` even when no tokens are present.

Today `ToolMCPAuthApi` marks the provider as `authed=true` as soon as it can connect, which breaks OAuth-protected servers like Google Drive MCP: `initialize` succeeds, but later tool calls fail because no access token was ever obtained.

### How
After a successful connect, if the provider has `client_information` configured but still has no tokens, start the OAuth flow via `core.mcp.auth.auth_flow.auth()` and return the `authorization_url` response instead of saving `authed=true`.

### Tests
- `uv run --project api pytest -q api/tests/unit_tests/controllers/console/workspace/test_tool_providers.py -k mcp_auth`
- `uv run --project api ruff check api/controllers/console/workspace/tool_providers.py api/tests/unit_tests/controllers/console/workspace/test_tool_providers.py`

Fixes #36230
