### PR TITLE
test: stabilize trigger subscription name uniqueness setup

### DIFF
--- a/api/tests/test_containers_integration_tests/services/test_trigger_provider_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_trigger_provider_service.py
@@ -92,6 +92,7 @@ class TestTriggerProviderService:
         credential_type,
         credentials,
         mock_external_service_dependencies,
+        name: str | None = None,
     ):
         """
         Helper method to create a test trigger subscription.
@@ -104,6 +105,7 @@ class TestTriggerProviderService:
             credential_type: Credential type
             credentials: Credentials dict
             mock_external_service_dependencies: Mock dependencies
+            name: Optional subscription name. Pass a deterministic value when a test depends on name uniqueness.
 
         Returns:
             TriggerSubscription: Created subscription instance
@@ -123,7 +125,7 @@ class TestTriggerProviderService:
         )
 
         subscription = TriggerSubscription(
-            name=fake.word(),
+            name=name or fake.word(),
             tenant_id=tenant_id,
             user_id=user_id,
             provider_id=str(provider_id),
@@ -527,6 +529,7 @@ class TestTriggerProviderService:
             credential_type,
             {"api_key": "key1"},
             mock_external_service_dependencies,
+            name="subscription-1",
         )
 
         # Create second subscription with different name
@@ -538,6 +541,7 @@ class TestTriggerProviderService:
             credential_type,
             {"api_key": "key2"},
             mock_external_service_dependencies,
+            name="subscription-2",
         )
 
         new_subscription_entity = TriggerSubscriptionEntity(


### PR DESCRIPTION
## Summary
- allow trigger subscription test setup to pass explicit subscription names
- use deterministic distinct names in the rebuild uniqueness test

## Motivation
Fixes the merge-queue failure observed on PR #36310: https://github.com/langgenius/dify/pull/36310#event-25648247780

That merge-queue run failed in `test_rebuild_trigger_subscription_name_uniqueness_check` with a database `UniqueViolation` before the test reached the rebuild behavior it intends to verify. The setup created two subscriptions with `fake.word()`, but Faker random values are not guaranteed to be unique. When both setup calls generate the same word, they collide with the unique `(tenant_id, provider_id, name)` constraint.

The duplicate setup value is reproducible with Faker seeding:

```python
from faker import Faker

Faker.seed(1095)
fake = Faker()

print(fake.word())
print(fake.word())

# Output:
# different
# different
```

This PR keeps the helper default behavior unchanged for other tests, but lets this test pass explicit setup names so the uniqueness scenario is deterministic.

## Validation
- Local targeted pytest passed: `DEBUG=false uv run --project api pytest api/tests/test_containers_integration_tests/services/test_trigger_provider_service.py::TestTriggerProviderService::test_rebuild_trigger_subscription_name_uniqueness_check`
