### PR TITLE
fix: use FloatVariable for number-type variables with integer values

### DIFF
--- a/api/factories/variable_factory.py
+++ b/api/factories/variable_factory.py
@@ -82,10 +82,19 @@ def _build_variable_from_mapping(*, mapping: Mapping[str, Any], selector: Sequen
             result = StringVariable.model_validate(mapping)
         case SegmentType.SECRET:
             result = SecretVariable.model_validate(mapping)
-        case SegmentType.NUMBER | SegmentType.INTEGER if isinstance(value, int):
-            mapping = dict(mapping)
-            mapping["value_type"] = SegmentType.INTEGER
-            result = IntegerVariable.model_validate(mapping)
+        case SegmentType.NUMBER | SegmentType.INTEGER if isinstance(value, int) and not isinstance(value, bool):
+            if value_type == SegmentType.NUMBER:
+                # When value_type is "number", always use float to avoid
+                # narrowing the type to "integer" which breaks subsequent
+                # turns when a code node outputs a float value (#36346)
+                mapping = dict(mapping)
+                mapping["value_type"] = SegmentType.FLOAT
+                mapping["value"] = float(value)
+                result = FloatVariable.model_validate(mapping)
+            else:
+                mapping = dict(mapping)
+                mapping["value_type"] = SegmentType.INTEGER
+                result = IntegerVariable.model_validate(mapping)
         case SegmentType.NUMBER | SegmentType.FLOAT if isinstance(value, float):
             mapping = dict(mapping)
             mapping["value_type"] = SegmentType.FLOAT

--- a/api/tests/unit_tests/factories/test_variable_factory.py
+++ b/api/tests/unit_tests/factories/test_variable_factory.py
@@ -45,7 +45,7 @@ def test_string_variable():
 
 
 def test_integer_variable():
-    test_data = {"value_type": "number", "name": "test_int", "value": 42}
+    test_data = {"value_type": "integer", "name": "test_int", "value": 42}
     result = variable_factory.build_conversation_variable_from_mapping(test_data)
     assert isinstance(result, IntegerVariable)
 
@@ -54,6 +54,23 @@ def test_float_variable():
     test_data = {"value_type": "number", "name": "test_float", "value": 3.14}
     result = variable_factory.build_conversation_variable_from_mapping(test_data)
     assert isinstance(result, FloatVariable)
+
+
+def test_number_variable_with_int_value():
+    """When value_type is 'number' and value is int, should create FloatVariable to avoid
+    narrowing the type to 'integer' which breaks subsequent turns (#36346)."""
+    test_data = {"value_type": "number", "name": "test_number_int", "value": 42}
+    result = variable_factory.build_conversation_variable_from_mapping(test_data)
+    assert isinstance(result, FloatVariable)
+    assert result.value == 42.0
+
+
+def test_number_variable_with_zero():
+    """value_type='number' with value=0 should not fail and should create FloatVariable (#36346)."""
+    test_data = {"value_type": "number", "name": "test_zero", "value": 0}
+    result = variable_factory.build_conversation_variable_from_mapping(test_data)
+    assert isinstance(result, FloatVariable)
+    assert result.value == 0.0
 
 
 def test_secret_variable():


### PR DESCRIPTION
## Problem

When `value_type` is `"number"` and the value is an integer (e.g. `0`), the `_build_variable_from_mapping` function creates an `IntegerVariable` and changes `value_type` to `"integer"`. This causes subsequent conversation turns to fail with:

```
not supported value type integer
```

when a code node outputs a float value for the same conversation variable.

## Steps to Reproduce

1. Create a conversation variable in ChatFlow with `value: 0.0` (stored as `value: 0`, `value_type: number`)
2. Use a Code node to output a Number variable with a float value
3. First conversation turn works
4. Second turn fails because the variable type was narrowed from `number` to `integer`

## Fix

When `value_type` is `"number"` and the value is an integer, always create a `FloatVariable` (converting the int value to float). This ensures the variable type stays as `float` across conversation turns, which is compatible with both integer and float values from code nodes.

Also added `not isinstance(value, bool)` guard since `bool` is a subclass of `int` in Python.

Fixes #36346