### PR TITLE
fix(agenton): use AsyncGenerator return annotation for asynccontextmanager

### DIFF
--- a/dify-agent/src/agenton/compositor/core.py
+++ b/dify-agent/src/agenton/compositor/core.py
@@ -14,7 +14,7 @@ hydrated deterministically.
 """
 
 from collections import OrderedDict
-from collections.abc import AsyncIterator, Mapping, Sequence
+from collections.abc import AsyncGenerator, Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any, Generic, cast
@@ -178,7 +178,7 @@ class Compositor(Generic[PromptT, ToolT, LayerPromptT, LayerToolT, UserPromptT, 
         *,
         configs: Mapping[str, LayerConfigInput] | None = None,
         session_snapshot: CompositorSessionSnapshotValue | None = None,
-    ) -> AsyncIterator[CompositorRun[PromptT, ToolT, LayerPromptT, LayerToolT, UserPromptT, LayerUserPromptT]]:
+    ) -> AsyncGenerator[CompositorRun[PromptT, ToolT, LayerPromptT, LayerToolT, UserPromptT, LayerUserPromptT]]:
         """Create a fresh run, enter layers in graph order, and yield it.
 
         Configs are keyed by layer node name and validated before factories run.


### PR DESCRIPTION
## Summary

Fixes #35433 (remaining instance)

The `@asynccontextmanager` decorator on `Compositor.enter()` still used `-> AsyncIterator[...]` as its return annotation. Python type checkers (basedpyright, pyright) now emit `reportDeprecated` for this pattern — `AsyncGenerator` is the correct annotation for async context managers.

The two sync instances (`flask_utils.py`, `file_service.py`) and the other async instance (`dify_agent/adapters/llm/model.py`) have already been updated. This was the last remaining occurrence.

## Root Cause

`dify-agent/src/agenton/compositor/core.py:181` defined:

```python
@asynccontextmanager
async def enter(self, ...) -> AsyncIterator[CompositorRun[...]]:
```

The `contextlib.asynccontextmanager` decorator wraps an `async def` that yields exactly once — the return type should be `AsyncGenerator[Y, None]`, not `AsyncIterator[Y]`. This follows the same deprecation that applies to sync `@contextmanager` with `Iterator` → `Generator`.

## Fix

- **Line 17**: Added `AsyncGenerator` to the `collections.abc` import (replacing `AsyncIterator` since it is no longer used elsewhere in the file)
- **Line 181**: Changed `AsyncIterator[...]` → `AsyncGenerator[...]` in the return annotation

This matches the pattern already applied in `dify-agent/src/dify_agent/adapters/llm/model.py` and the two sync files under `api/`.

## Changes

- `dify-agent/src/agenton/compositor/core.py`: 2 lines changed (`+2 -2`)

## Testing

- **Type checking**: `AsyncGenerator[CompositorRun[...], None, None]` is structurally compatible with `AsyncIterator[CompositorRun[...]]` — no runtime behavior change ✅
- **Existing callers**: `Compositor.enter()` is used via `async with` — the context manager protocol is unaffected by the annotation change ✅
- **Import validity**: `AsyncGenerator` is available in `collections.abc` since Python 3.9 ✅
