### PR TITLE
fix: handle missing unstructured[image] gracefully in EML extraction

### DIFF
--- a/api/core/rag/extractor/unstructured/unstructured_eml_extractor.py
+++ b/api/core/rag/extractor/unstructured/unstructured_eml_extractor.py
@@ -13,6 +13,11 @@ logger = logging.getLogger(__name__)
 
 class UnstructuredEmailExtractor(BaseExtractor):
     """Load eml files.
+
+    Requires the ``unstructured[image]`` extra for emails with embedded images.
+    Without it, ``partition_email`` raises an error when it encounters image
+    attachments that need ``partition_image``.
+
     Args:
         file_path: Path to the file to load.
     """
@@ -31,7 +36,18 @@ class UnstructuredEmailExtractor(BaseExtractor):
         else:
             from unstructured.partition.email import partition_email
 
-            elements = partition_email(filename=self._file_path)
+            try:
+                elements = partition_email(filename=self._file_path)
+            except ImportError as e:
+                if "partition_image" in str(e) or "unstructured[image]" in str(e):
+                    logger.warning(
+                        "Failed to process EML with image attachments due to missing "
+                        "unstructured[image] dependencies; retrying without attachment processing. "
+                        "Install unstructured[image] to enable embedded image extraction."
+                    )
+                    elements = partition_email(filename=self._file_path, process_attachments=False)
+                else:
+                    raise
 
         # noinspection PyBroadException
         with contextlib.suppress(Exception):


### PR DESCRIPTION
## Problem

When processing EML files with embedded images, the `partition_email` function internally calls `partition_image()` which requires `unstructured[image]`. If this extra is not installed, extraction fails with `ImportError`.

## Fix

Catch the `ImportError` and retry extraction with `process_attachments=False`, allowing email body text to still be extracted while gracefully degrading when image processing dependencies are missing.

Fixes #36212