### PR TITLE
fix: use members SSO endpoints in external-member-sso-auth

### DIFF
--- a/web/app/(shareLayout)/webapp-signin/components/external-member-sso-auth.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/external-member-sso-auth.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect } from 'react'
 import AppUnavailable from '@/app/components/base/app-unavailable'
 import Loading from '@/app/components/base/loading'
 import { useRouter, useSearchParams } from '@/next/navigation'
-import { fetchWebOAuth2SSOUrl, fetchWebOIDCSSOUrl, fetchWebSAMLSSOUrl } from '@/service/share'
+import { fetchMembersOAuth2SSOUrl, fetchMembersOIDCSSOUrl, fetchMembersSAMLSSOUrl } from '@/service/share'
 import { systemFeaturesQueryOptions } from '@/service/system-features'
 import { SSOProtocol } from '@/types/feature'
 
@@ -41,17 +41,17 @@ const ExternalMemberSSOAuth = () => {
 
     switch (systemFeatures.webapp_auth.sso_config.protocol) {
       case SSOProtocol.SAML: {
-        const samlRes = await fetchWebSAMLSSOUrl(appCode, redirectUrl)
+        const samlRes = await fetchMembersSAMLSSOUrl(appCode, redirectUrl)
         router.push(samlRes.url)
         break
       }
       case SSOProtocol.OIDC: {
-        const oidcRes = await fetchWebOIDCSSOUrl(appCode, redirectUrl)
+        const oidcRes = await fetchMembersOIDCSSOUrl(appCode, redirectUrl)
         router.push(oidcRes.url)
         break
       }
       case SSOProtocol.OAuth2: {
-        const oauth2Res = await fetchWebOAuth2SSOUrl(appCode, redirectUrl)
+        const oauth2Res = await fetchMembersOAuth2SSOUrl(appCode, redirectUrl)
         router.push(oauth2Res.url)
         break
       }


### PR DESCRIPTION
## Summary

Fixes #36307

This PR fixes the SSO endpoint inconsistency in `external-member-sso-auth.tsx` that was causing CORS errors and incorrect redirects when SSO is initiated from the WebApp domain.

## Problem

When users clicked SSO login from the published WebApp on the app domain, the component was calling console-oriented SSO endpoints (`/enterprise/sso/saml/login`, etc.) instead of the members endpoints. This caused:
1. Cross-origin requests from app domain to console domain
2. CORS errors unless the reverse proxy was customized
3. Redirects back to the console domain instead of the WebApp domain after authentication

## Solution

Updated `external-member-sso-auth.tsx` to use the members SSO endpoints, matching the behavior of `sso-auth.tsx`:

- Changed `fetchWebSAMLSSOUrl` → `fetchMembersSAMLSSOUrl`
- Changed `fetchWebOIDCSSOUrl` → `fetchMembersOIDCSSOUrl`
- Changed `fetchWebOAuth2SSOUrl` → `fetchMembersOAuth2SSOUrl`

These members endpoints (`/enterprise/sso/members/saml/login`, etc.) are designed for WebApp authentication and keep the SSO flow within the app domain.

## Changes

- Modified `web/app/(shareLayout)/webapp-signin/components/external-member-sso-auth.tsx`
  - Updated imports (line 9)
  - Updated function calls (lines 44, 49, 54)

## Testing

The fix ensures:
- SSO initiated from the WebApp uses the correct members endpoints
- No CORS errors occur during the SSO flow
- Users are redirected back to the WebApp domain after successful authentication
- Behavior is consistent with `sso-auth.tsx`

## Related

As confirmed by @dosubot, both sets of functions are defined in `web/service/share.ts`, making this a straightforward import and function call update.