### PR TITLE
fix(auth): use validity-returned token in ChangePasswordForm reset submit

### DIFF
--- a/web/app/forgot-password/ChangePasswordForm.spec.tsx
+++ b/web/app/forgot-password/ChangePasswordForm.spec.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { changePasswordWithToken } from '@/service/common'
+import { useVerifyForgotPasswordToken } from '@/service/use-common'
+import ChangePasswordForm from './ChangePasswordForm'
+
+const mockReplace = vi.fn()
+vi.mock('@/next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams('token=url-token-t1'),
+  useRouter: () => ({ replace: mockReplace }),
+}))
+
+vi.mock('@/service/use-common', () => ({
+  useVerifyForgotPasswordToken: vi.fn(),
+}))
+
+vi.mock('@/service/common', () => ({
+  changePasswordWithToken: vi.fn(),
+}))
+
+vi.mock('@/utils/var', () => ({ basePath: '' }))
+
+type UseVerifyResult = ReturnType<typeof useVerifyForgotPasswordToken>
+const mockUseVerify = vi.mocked(useVerifyForgotPasswordToken)
+const mockChangePassword = vi.mocked(changePasswordWithToken)
+
+const VALID_PASSWORD = 'ValidPass123!'
+
+describe('ChangePasswordForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('when token is valid', () => {
+    const T2 = 'verified-token-t2'
+
+    beforeEach(() => {
+      mockUseVerify.mockReturnValue({
+        data: { result: 'success', is_valid: true, email: 'user@example.com', token: T2 },
+        refetch: vi.fn(),
+      } as unknown as UseVerifyResult)
+    })
+
+    it('renders the password form', () => {
+      render(<ChangePasswordForm />)
+      expect(screen.getByText('login.changePassword')).toBeInTheDocument()
+    })
+
+    it('submits with T2 (from validity response), NOT T1 (from URL)', async () => {
+      mockChangePassword.mockResolvedValue({ result: 'success' })
+
+      render(<ChangePasswordForm />)
+
+      const inputs = Array.from(document.querySelectorAll<HTMLInputElement>('input[type="password"]')) as [HTMLInputElement, HTMLInputElement]
+      fireEvent.change(inputs[0], { target: { value: VALID_PASSWORD } })
+      fireEvent.change(inputs[1], { target: { value: VALID_PASSWORD } })
+
+      fireEvent.click(screen.getByRole('button', { name: /common\.operation\.reset/ }))
+
+      await waitFor(() => {
+        expect(mockChangePassword).toHaveBeenCalledWith({
+          url: '/forgot-password/resets',
+          body: {
+            token: T2,
+            new_password: VALID_PASSWORD,
+            password_confirm: VALID_PASSWORD,
+          },
+        })
+      })
+    })
+  })
+
+  describe('when token is invalid', () => {
+    beforeEach(() => {
+      mockUseVerify.mockReturnValue({
+        data: { result: 'success', is_valid: false, email: '', token: '' },
+        refetch: vi.fn(),
+      } as unknown as UseVerifyResult)
+    })
+
+    it('shows invalid token state and no form', () => {
+      render(<ChangePasswordForm />)
+      expect(screen.getByText('login.invalid')).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /common\.operation\.reset/ })).not.toBeInTheDocument()
+    })
+  })
+})

--- a/web/app/forgot-password/ChangePasswordForm.tsx
+++ b/web/app/forgot-password/ChangePasswordForm.tsx
@@ -49,7 +49,7 @@ const ChangePasswordForm = () => {
   }, [password, confirmPassword, showErrorMessage, t])
 
   const handleChangePassword = useCallback(async () => {
-    const token = searchParams.get('token') || ''
+    const resetToken = verifyTokenRes?.token ?? ''
 
     if (!valid())
       return
@@ -57,7 +57,7 @@ const ChangePasswordForm = () => {
       await changePasswordWithToken({
         url: '/forgot-password/resets',
         body: {
-          token,
+          token: resetToken,
           new_password: password,
           password_confirm: confirmPassword,
         },
@@ -67,7 +67,7 @@ const ChangePasswordForm = () => {
     catch {
       await revalidateToken()
     }
-  }, [confirmPassword, password, revalidateToken, searchParams, valid])
+  }, [confirmPassword, password, revalidateToken, verifyTokenRes?.token, valid])
 
   return (
     <div className={

--- a/web/service/use-common.ts
+++ b/web/service/use-common.ts
@@ -250,7 +250,7 @@ export const useLogout = () => {
   })
 }
 
-type ForgotPasswordValidity = CommonResponse & { is_valid: boolean, email: string }
+type ForgotPasswordValidity = CommonResponse & { is_valid: boolean, email: string, token: string }
 export const useVerifyForgotPasswordToken = (token?: string | null) => {
   return useQuery<ForgotPasswordValidity>({
     queryKey: commonQueryKeys.forgotPasswordValidity(token),


### PR DESCRIPTION
## Summary

- `ForgotPasswordValidity` type was missing `token` field, causing the verified token (T2) returned by `/forgot-password/validity` to be discarded
- `ChangePasswordForm.handleChangePassword` was re-reading the original URL token (T1) from `searchParams` and sending it to `/forgot-password/resets`
- Backend rejects T1 with `invalid_or_expired_token` because T1 lacks `phase: "reset"` (added in the security hardening that introduced the two-phase reset flow)

## Root cause

Security fix in #18363 added a two-phase token flow: `/validity` consumes T1 and returns T2 with `phase: "reset"`. The backend `/resets` endpoint requires T2. The frontend was never updated to use T2.

Broken since #18363 (April 2025). Only affects the link-based reset flow (`/forgot-password?token=...`) used by admin-triggered password resets in EE.

Fixes ENG-423

## Changes

- `web/service/use-common.ts` — add `token: string` to `ForgotPasswordValidity` type
- `web/app/forgot-password/ChangePasswordForm.tsx` — use `verifyTokenRes.token` (T2) in `handleChangePassword` instead of `searchParams.get('token')` (T1)
- `web/app/forgot-password/ChangePasswordForm.spec.tsx` — new tests verifying T2 is submitted, not T1

## Test plan

- [ ] Tests pass: `cd web && pnpm test app/forgot-password/`
- [ ] Trigger admin password reset in EE environment, verify reset completes without `invalid_or_expired_token`