### PR TITLE
chore(codeowners): assign trigger scheduler ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -92,28 +92,28 @@
 /api/tasks/process_tenant_plugin_autoupgrade_check_task.py @WH-2099
 
 # Backend - Trigger/Schedule/Webhook
-/api/controllers/trigger/ @Mairuis
-/api/controllers/console/app/workflow_trigger.py @Mairuis
-/api/controllers/console/workspace/trigger_providers.py @Mairuis
-/api/core/trigger/ @Mairuis
-/api/core/app/layers/trigger_post_layer.py @Mairuis
-/api/services/trigger/ @Mairuis
-/api/models/trigger.py @Mairuis
-/api/fields/workflow_trigger_fields.py @Mairuis
-/api/repositories/workflow_trigger_log_repository.py @Mairuis
-/api/repositories/sqlalchemy_workflow_trigger_log_repository.py @Mairuis
-/api/libs/schedule_utils.py @Mairuis
-/api/services/workflow/scheduler.py @Mairuis
-/api/schedule/trigger_provider_refresh_task.py @Mairuis
-/api/schedule/workflow_schedule_task.py @Mairuis
-/api/tasks/trigger_processing_tasks.py @Mairuis
-/api/tasks/trigger_subscription_refresh_tasks.py @Mairuis
-/api/tasks/workflow_schedule_tasks.py @Mairuis
-/api/tasks/workflow_cfs_scheduler/ @Mairuis
-/api/events/event_handlers/sync_plugin_trigger_when_app_created.py @Mairuis
-/api/events/event_handlers/update_app_triggers_when_app_published_workflow_updated.py @Mairuis
-/api/events/event_handlers/sync_workflow_schedule_when_app_published.py @Mairuis
-/api/events/event_handlers/sync_webhook_when_app_created.py @Mairuis
+/api/controllers/trigger/ @CourTeous33
+/api/controllers/console/app/workflow_trigger.py @CourTeous33
+/api/controllers/console/workspace/trigger_providers.py @CourTeous33
+/api/core/trigger/ @CourTeous33
+/api/core/app/layers/trigger_post_layer.py @CourTeous33
+/api/services/trigger/ @CourTeous33
+/api/models/trigger.py @CourTeous33
+/api/fields/workflow_trigger_fields.py @CourTeous33
+/api/repositories/workflow_trigger_log_repository.py @CourTeous33
+/api/repositories/sqlalchemy_workflow_trigger_log_repository.py @CourTeous33
+/api/libs/schedule_utils.py @CourTeous33
+/api/services/workflow/scheduler.py @CourTeous33
+/api/schedule/trigger_provider_refresh_task.py @CourTeous33
+/api/schedule/workflow_schedule_task.py @CourTeous33
+/api/tasks/trigger_processing_tasks.py @CourTeous33
+/api/tasks/trigger_subscription_refresh_tasks.py @CourTeous33
+/api/tasks/workflow_schedule_tasks.py @CourTeous33
+/api/tasks/workflow_cfs_scheduler/ @CourTeous33
+/api/events/event_handlers/sync_plugin_trigger_when_app_created.py @CourTeous33
+/api/events/event_handlers/update_app_triggers_when_app_published_workflow_updated.py @CourTeous33
+/api/events/event_handlers/sync_workflow_schedule_when_app_published.py @CourTeous33
+/api/events/event_handlers/sync_webhook_when_app_created.py @CourTeous33
 
 # Backend - Async Workflow
 /api/services/async_workflow_service.py @Mairuis


### PR DESCRIPTION
## Summary

Assigns backend trigger, schedule, and webhook CODEOWNERS entries to `@CourTeous33` (Charles Yao), covering the existing trigger controller, service, model, scheduler, task, and event-handler paths.

This updates reviewer routing for backend trigger and scheduler ownership.

No associated issue was provided for this draft PR.

## Screenshots

N/A. CODEOWNERS-only change.