### PR TITLE
ci: show web test shard failures

### DIFF
--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -39,7 +39,7 @@ jobs:
         uses: ./.github/actions/setup-web
 
       - name: Run tests
-        run: vp test run --reporter=blob --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --coverage
+        run: vp test run --reporter=blob --reporter=minimal --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --coverage
 
       - name: Upload blob report
         if: ${{ !cancelled() }}

--- a/web/app/components/signin/__tests__/countdown.spec.tsx
+++ b/web/app/components/signin/__tests__/countdown.spec.tsx
@@ -173,7 +173,7 @@ describe('Countdown', () => {
   // Exported Constants
   describe('Exported Constants', () => {
     it('should export COUNT_DOWN_TIME_MS as 59000', () => {
-      expect(COUNT_DOWN_TIME_MS).toBe(1)
+      expect(COUNT_DOWN_TIME_MS).toBe(59000)
     })
 
     it('should export COUNT_DOWN_KEY as leftTime', () => {

--- a/web/app/components/signin/__tests__/countdown.spec.tsx
+++ b/web/app/components/signin/__tests__/countdown.spec.tsx
@@ -173,7 +173,7 @@ describe('Countdown', () => {
   // Exported Constants
   describe('Exported Constants', () => {
     it('should export COUNT_DOWN_TIME_MS as 59000', () => {
-      expect(COUNT_DOWN_TIME_MS).toBe(59000)
+      expect(COUNT_DOWN_TIME_MS).toBe(1)
     })
 
     it('should export COUNT_DOWN_KEY as leftTime', () => {


### PR DESCRIPTION
## Summary

- add the minimal reporter to web test shard runs while keeping blob reports for merging

## Issue

Fixes #36435

## Verification

- `pnpm --dir web exec vp test run --help | rg -n "reporter <name>|minimal|blob|mergeReports|shard" -C 1`
- `git diff --check`

## Screenshot
<img width="3024" height="1814" alt="img_v3_0211s_428301c4-5702-4305-8519-032fdd8a08dg" src="https://github.com/user-attachments/assets/e55e16a0-ca72-4922-ad99-ca106ed2da73" />
