### PR TITLE
chore: remove unused pyrefly ignore comments in dataset.py

### DIFF
--- a/api/controllers/service_api/dataset/dataset.py
+++ b/api/controllers/service_api/dataset/dataset.py
@@ -177,13 +177,8 @@ class DatasetListApi(DatasetApiResource):
 
         data = marshal(datasets, dataset_detail_fields)
         for item in data:
-            if (
-                item["indexing_technique"] == IndexTechniqueType.HIGH_QUALITY
-                and item["embedding_model_provider"]
-            ):
-                item["embedding_model_provider"] = str(
-                    ModelProviderID(item["embedding_model_provider"])
-                )
+            if item["indexing_technique"] == IndexTechniqueType.HIGH_QUALITY and item["embedding_model_provider"]:
+                item["embedding_model_provider"] = str(ModelProviderID(item["embedding_model_provider"]))
                 item_model = f"{item['embedding_model']}:{item['embedding_model_provider']}"
                 if item_model in model_names:
                     item["embedding_available"] = True  # type: ignore

--- a/api/controllers/service_api/dataset/dataset.py
+++ b/api/controllers/service_api/dataset/dataset.py
@@ -178,13 +178,13 @@ class DatasetListApi(DatasetApiResource):
         data = marshal(datasets, dataset_detail_fields)
         for item in data:
             if (
-                item["indexing_technique"] == IndexTechniqueType.HIGH_QUALITY  # pyrefly: ignore[bad-index]
-                and item["embedding_model_provider"]  # pyrefly: ignore[bad-index]
+                item["indexing_technique"] == IndexTechniqueType.HIGH_QUALITY
+                and item["embedding_model_provider"]
             ):
-                item["embedding_model_provider"] = str(  # pyrefly: ignore[unsupported-operation]
-                    ModelProviderID(item["embedding_model_provider"])  # pyrefly: ignore[bad-index]
+                item["embedding_model_provider"] = str(
+                    ModelProviderID(item["embedding_model_provider"])
                 )
-                item_model = f"{item['embedding_model']}:{item['embedding_model_provider']}"  # pyrefly: ignore[bad-index]
+                item_model = f"{item['embedding_model']}:{item['embedding_model_provider']}"
                 if item_model in model_names:
                     item["embedding_available"] = True  # type: ignore
                 else:


### PR DESCRIPTION
## Description

Removed 5 unused `# pyrefly: ignore` comments that are no longer needed in `api/controllers/service_api/dataset/dataset.py`.

## Changes
- Removed `bad-index` ignores on lines 181, 182, 185, 187
- Removed `unsupported-operation` ignore on line 184

These comments were flagged as unused by pyrefly linter and are no longer necessary.

## Related Issue
Fixes #36408

## Type of Change
- [x] Chore (code cleanup, no functional changes)