### PR TITLE
refactor: clean unnecessary `| None` in services

### DIFF
--- a/api/controllers/console/app/message.py
+++ b/api/controllers/console/app/message.py
@@ -387,11 +387,11 @@ class MessageFeedbackExportApi(Resource):
         try:
             export_data = FeedbackService.export_feedbacks(
                 app_id=app_model.id,
-                from_source=args.from_source,
-                rating=args.rating,
+                from_source=args.from_source or "",
+                rating=args.rating or "",
                 has_comment=args.has_comment,
-                start_date=args.start_date,
-                end_date=args.end_date,
+                start_date=args.start_date or "",
+                end_date=args.end_date or "",
                 format_type=args.format,
             )
 

--- a/api/controllers/console/tag/tags.py
+++ b/api/controllers/console/tag/tags.py
@@ -44,7 +44,7 @@ class TagBindingRemovePayload(BaseModel):
 
 class TagListQueryParam(BaseModel):
     type: Literal["knowledge", "app", ""] = Field("", description="Tag type filter")
-    keyword: str | None = Field(None, description="Search keyword")
+    keyword: str = Field("", description="Search keyword")
 
 
 class TagResponse(ResponseModel):

--- a/api/services/feedback_service.py
+++ b/api/services/feedback_service.py
@@ -15,11 +15,11 @@ class FeedbackService:
     @staticmethod
     def export_feedbacks(
         app_id: str,
-        from_source: str | None = None,
-        rating: str | None = None,
+        from_source: str = "",
+        rating: str = "",
         has_comment: bool | None = None,
-        start_date: str | None = None,
-        end_date: str | None = None,
+        start_date: str = "",
+        end_date: str = "",
         format_type: str = "csv",
     ):
         """

--- a/api/services/tag_service.py
+++ b/api/services/tag_service.py
@@ -37,7 +37,7 @@ class TagBindingDeletePayload(BaseModel):
 
 class TagService:
     @staticmethod
-    def get_tags(tag_type: str, current_tenant_id: str, keyword: str | None = None):
+    def get_tags(tag_type: str, current_tenant_id: str, keyword: str = ""):
         stmt = (
             select(Tag.id, Tag.type, Tag.name, func.count(TagBinding.id).label("binding_count"))
             .outerjoin(TagBinding, Tag.id == TagBinding.tag_id)


### PR DESCRIPTION
## Summary

Remove unnecessary `| None` type annotations in service layer files where parameters are only checked with truthiness (`if param:`) and never with `is None`.

Relates to #35557

## Changes

- **api/services/tag_service.py**: `keyword: str | None = None` → `keyword: str = ""`
- **api/services/feedback_service.py**: `from_source`, `rating`, `start_date`, `end_date`: `str | None = None` → `str = ""`
- **api/controllers/console/tag/tags.py**: Updated `TagListQueryParam.keyword` field to `str = ""` to match
- **api/controllers/console/app/message.py**: Coalesce `None` to `""` at call site for `FeedbackService.export_feedbacks`

## Verification

- Each parameter was verified to only be used in truthiness checks (`if param:`), never `is None`
- No callers pass explicit `None` without coalescing
- All files pass `ruff check` and AST parsing
- `has_comment: bool | None = None` in feedback_service.py was intentionally preserved because it uses `is not None` check

## What was not changed

- `api/services/errors/enterprise.py`: The single `int | None = None` for `status_code` was preserved because `None` carries semantic meaning (no HTTP status code available) and there is no natural empty integer default
