### PR TITLE
refactor: convert isinstance chains to match/case (part 5)

### DIFF
--- a/api/core/agent/cot_completion_agent_runner.py
+++ b/api/core/agent/cot_completion_agent_runner.py
@@ -38,16 +38,18 @@ class CotCompletionAgentRunner(CotAgentRunner):
         historic_prompt = ""
 
         for message in historic_prompt_messages:
-            if isinstance(message, UserPromptMessage):
-                historic_prompt += f"Question: {message.content}\n\n"
-            elif isinstance(message, AssistantPromptMessage):
-                if isinstance(message.content, str):
-                    historic_prompt += message.content + "\n\n"
-                elif isinstance(message.content, list):
-                    for content in message.content:
-                        if not isinstance(content, TextPromptMessageContent):
-                            continue
-                        historic_prompt += content.data
+            match message:
+                case UserPromptMessage():
+                    historic_prompt += f"Question: {message.content}\n\n"
+                case AssistantPromptMessage():
+                    match message.content:
+                        case str():
+                            historic_prompt += message.content + "\n\n"
+                        case list():
+                            for content in message.content:
+                                if not isinstance(content, TextPromptMessageContent):
+                                    continue
+                                historic_prompt += content.data
 
         return historic_prompt
 

--- a/api/core/app/apps/completion/generate_response_converter.py
+++ b/api/core/app/apps/completion/generate_response_converter.py
@@ -105,17 +105,18 @@ class CompletionAppGenerateResponseConverter(AppGenerateResponseConverter[Comple
                 "created_at": chunk.created_at,
             }
 
-            if isinstance(sub_stream_response, MessageEndStreamResponse):
-                sub_stream_response_dict = sub_stream_response.model_dump(mode="json")
-                metadata = sub_stream_response_dict.get("metadata", {})
-                if not isinstance(metadata, dict):
-                    metadata = {}
-                sub_stream_response_dict["metadata"] = cls._get_simple_metadata(metadata)
-                response_chunk.update(sub_stream_response_dict)
-            elif isinstance(sub_stream_response, ErrorStreamResponse):
-                data = cls._error_to_stream_response(sub_stream_response.err)
-                response_chunk.update(data)
-            else:
-                response_chunk.update(sub_stream_response.model_dump(mode="json"))
+            match sub_stream_response:
+                case MessageEndStreamResponse():
+                    sub_stream_response_dict = sub_stream_response.model_dump(mode="json")
+                    metadata = sub_stream_response_dict.get("metadata", {})
+                    if not isinstance(metadata, dict):
+                        metadata = {}
+                    sub_stream_response_dict["metadata"] = cls._get_simple_metadata(metadata)
+                    response_chunk.update(sub_stream_response_dict)
+                case ErrorStreamResponse():
+                    data = cls._error_to_stream_response(sub_stream_response.err)
+                    response_chunk.update(data)
+                case _:
+                    response_chunk.update(sub_stream_response.model_dump(mode="json"))
 
             yield response_chunk

--- a/api/core/logging/filters.py
+++ b/api/core/logging/filters.py
@@ -80,15 +80,16 @@ class IdentityContextFilter(logging.Filter):
 
             identity: IdentityDict = {}
 
-            if isinstance(user, Account):
-                if user.current_tenant_id:
-                    identity["tenant_id"] = user.current_tenant_id
-                identity["user_id"] = user.id
-                identity["user_type"] = "account"
-            elif isinstance(user, EndUser):
-                identity["tenant_id"] = user.tenant_id
-                identity["user_id"] = user.id
-                identity["user_type"] = user.type or "end_user"
+            match user:
+                case Account():
+                    if user.current_tenant_id:
+                        identity["tenant_id"] = user.current_tenant_id
+                    identity["user_id"] = user.id
+                    identity["user_type"] = "account"
+                case EndUser():
+                    identity["tenant_id"] = user.tenant_id
+                    identity["user_id"] = user.id
+                    identity["user_type"] = user.type or "end_user"
 
             return identity
         except Exception:

--- a/api/core/ops/entities/trace_entity.py
+++ b/api/core/ops/entities/trace_entity.py
@@ -62,15 +62,16 @@ class BaseTraceInfo(BaseModel):
             parent_span_id_source is the outer node_execution_id.
         """
         parent_ctx = self.metadata.get("parent_trace_context")
-        if isinstance(parent_ctx, ParentTraceContext):
-            context = parent_ctx
-        elif isinstance(parent_ctx, Mapping):
-            try:
-                context = ParentTraceContext.model_validate(parent_ctx)
-            except ValueError:
+        match parent_ctx:
+            case ParentTraceContext():
+                context = parent_ctx
+            case Mapping():
+                try:
+                    context = ParentTraceContext.model_validate(parent_ctx)
+                except ValueError:
+                    return None, None
+            case _:
                 return None, None
-        else:
-            return None, None
         return (
             context.parent_workflow_run_id,
             context.parent_node_execution_id,

--- a/api/core/ops/utils.py
+++ b/api/core/ops/utils.py
@@ -38,18 +38,19 @@ def measure_time():
 
 
 def replace_text_with_content(data):
-    if isinstance(data, dict):
-        new_data = {}
-        for key, value in data.items():
-            if key == "text":
-                new_data["content"] = value
-            else:
-                new_data[key] = replace_text_with_content(value)
-        return new_data
-    elif isinstance(data, list):
-        return [replace_text_with_content(item) for item in data]
-    else:
-        return data
+    match data:
+        case dict():
+            new_data = {}
+            for key, value in data.items():
+                if key == "text":
+                    new_data["content"] = value
+                else:
+                    new_data[key] = replace_text_with_content(value)
+            return new_data
+        case list():
+            return [replace_text_with_content(item) for item in data]
+        case _:
+            return data
 
 
 def generate_dotted_order(run_id: str, start_time: Union[str, datetime], parent_dotted_order: str | None = None) -> str:

--- a/api/core/plugin/utils/converter.py
+++ b/api/core/plugin/utils/converter.py
@@ -6,16 +6,13 @@ from graphon.file import File
 
 def convert_parameters_to_plugin_format(parameters: dict[str, Any]) -> dict[str, Any]:
     for parameter_name, parameter in parameters.items():
-        if isinstance(parameter, File):
-            parameters[parameter_name] = parameter.to_plugin_parameter()
-        elif isinstance(parameter, list) and all(isinstance(p, File) for p in parameter):
-            parameters[parameter_name] = []
-            for p in parameter:
-                parameters[parameter_name].append(p.to_plugin_parameter())
-        elif isinstance(parameter, ToolSelector):
-            parameters[parameter_name] = parameter.to_plugin_parameter()
-        elif isinstance(parameter, list) and all(isinstance(p, ToolSelector) for p in parameter):
-            parameters[parameter_name] = []
-            for p in parameter:
-                parameters[parameter_name].append(p.to_plugin_parameter())
+        match parameter:
+            case File():
+                parameters[parameter_name] = parameter.to_plugin_parameter()
+            case list() if all(isinstance(p, File) for p in parameter):
+                parameters[parameter_name] = [p.to_plugin_parameter() for p in parameter]
+            case ToolSelector():
+                parameters[parameter_name] = parameter.to_plugin_parameter()
+            case list() if all(isinstance(p, ToolSelector) for p in parameter):
+                parameters[parameter_name] = [p.to_plugin_parameter() for p in parameter]
     return parameters

--- a/api/core/tools/__base/tool.py
+++ b/api/core/tools/__base/tool.py
@@ -66,20 +66,21 @@ class Tool(ABC):
             message_id=message_id,
         )
 
-        if isinstance(result, ToolInvokeMessage):
+        match result:
+            case ToolInvokeMessage():
 
-            def single_generator() -> Generator[ToolInvokeMessage, None, None]:
-                yield result
+                def single_generator() -> Generator[ToolInvokeMessage, None, None]:
+                    yield result
 
-            return single_generator()
-        elif isinstance(result, list):
+                return single_generator()
+            case list():
 
-            def generator() -> Generator[ToolInvokeMessage, None, None]:
-                yield from result
+                def generator() -> Generator[ToolInvokeMessage, None, None]:
+                    yield from result
 
-            return generator()
-        else:
-            return result
+                return generator()
+            case _:
+                return result
 
     def _transform_tool_parameters_type(self, tool_parameters: dict[str, Any]) -> dict[str, Any]:
         """

--- a/api/core/tools/mcp_tool/tool.py
+++ b/api/core/tools/mcp_tool/tool.py
@@ -111,13 +111,14 @@ class MCPTool(Tool):
 
     def _process_json_content(self, content_json: Any) -> Generator[ToolInvokeMessage, None, None]:
         """Process JSON content based on its type."""
-        if isinstance(content_json, dict):
-            yield self.create_json_message(content_json)
-        elif isinstance(content_json, list):
-            yield from self._process_json_list(content_json)
-        else:
-            # For primitive types (str, int, bool, etc.), convert to string
-            yield self.create_text_message(str(content_json))
+        match content_json:
+            case dict():
+                yield self.create_json_message(content_json)
+            case list():
+                yield from self._process_json_list(content_json)
+            case _:
+                # For primitive types (str, int, bool, etc.), convert to string
+                yield self.create_text_message(str(content_json))
 
     def _process_json_list(self, json_list: list) -> Generator[ToolInvokeMessage, None, None]:
         """Process a list of JSON items."""


### PR DESCRIPTION
## Summary

Continue the isinstance → match/case refactoring from #35902.

Converted **8 if/elif isinstance chains** across **8 files** to Python 3.10+ match/case statements.

### Files Changed

| File | Description |
|------|-------------|
| `api/core/plugin/utils/converter.py` | File/ToolSelector type dispatch (4 branches) |
| `api/core/ops/utils.py` | Recursive dict/list content replacement |
| `api/core/ops/entities/trace_entity.py` | ParentTraceContext/Mapping resolution |
| `api/core/tools/__base/tool.py` | ToolInvokeMessage/list result handling |
| `api/core/tools/mcp_tool/tool.py` | JSON content type dispatch |
| `api/core/logging/filters.py` | Account/EndUser identity extraction |
| `api/core/agent/cot_completion_agent_runner.py` | Prompt message type dispatch |
| `api/core/app/apps/completion/generate_response_converter.py` | Stream response type dispatch |

### Edge Cases Handled
- Guard conditions preserved: `case list() if all(isinstance(p, File) for p in parameter):`
- Nested match/case: message type → content type dispatch in cot_completion_agent_runner
- All standalone isinstance checks (not part of a chain) preserved as-is

### Verification
- `ruff check` passes on all modified files
- `ruff format --check` confirms formatting compliance

Continues work from: #35897, #35922, #36153, #36035, #36222, #36242, #36274