### PR TITLE
fix(web): allow enabling disabled edited segments

### DIFF
--- a/web/app/components/datasets/documents/detail/completed/segment-card/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/documents/detail/completed/segment-card/__tests__/index.spec.tsx
@@ -4,7 +4,7 @@ import type { Attachment, ChildChunkDetail, ParentMode, SegmentDetailModel } fro
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import * as React from 'react'
 import { ChunkingMode } from '@/models/datasets'
-import SegmentCard from '../index'
+import SegmentCard, { canToggleSegmentStatus } from '../index'
 
 // Context Mocks - need to control test scenarios
 
@@ -780,7 +780,7 @@ describe('SegmentCard', () => {
       expect(() => fireEvent.click(card)).not.toThrow()
     })
 
-    it('should handle switch being disabled when status is not completed', () => {
+    it('should handle switch being disabled when an enabled segment status is not completed', () => {
       const detail = createMockSegmentDetail({ status: 'indexing' })
 
       render(
@@ -794,6 +794,30 @@ describe('SegmentCard', () => {
 
       const switchElement = screen.getByRole('switch')
       expect(switchElement).toHaveAttribute('aria-disabled', 'true')
+    })
+
+    it('should allow enabling a disabled segment when status is not completed', async () => {
+      const onChangeSwitch = vi.fn().mockResolvedValue(undefined)
+      const detail = createMockSegmentDetail({ id: 'test-segment-id', enabled: false, status: 'indexing' })
+
+      render(
+        <SegmentCard
+          loading={false}
+          detail={detail}
+          onChangeSwitch={onChangeSwitch}
+          embeddingAvailable={true}
+          focused={defaultFocused}
+        />,
+      )
+
+      const switchElement = screen.getByRole('switch')
+      expect(switchElement).not.toHaveAttribute('aria-disabled', 'true')
+
+      fireEvent.click(switchElement)
+
+      await waitFor(() => {
+        expect(onChangeSwitch).toHaveBeenCalledWith(true, 'test-segment-id')
+      })
     })
 
     it('should handle zero word count', () => {
@@ -909,6 +933,23 @@ describe('SegmentCard', () => {
       render(<SegmentCard loading={false} detail={detail} focused={defaultFocused} />)
 
       expect(screen.getByText(/Chunk-12/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('canToggleSegmentStatus', () => {
+    it('should allow disabled segments to be toggled on from non-completed states', () => {
+      expect(canToggleSegmentStatus({ enabled: false, status: 'indexing' })).toBe(true)
+      expect(canToggleSegmentStatus({ enabled: false, status: 'waiting' })).toBe(true)
+      expect(canToggleSegmentStatus({ enabled: false, status: 'error' })).toBe(true)
+    })
+
+    it('should keep enabled non-completed segments locked while indexing', () => {
+      expect(canToggleSegmentStatus({ enabled: true, status: 'indexing' })).toBe(false)
+      expect(canToggleSegmentStatus({ enabled: true, status: 'completed' })).toBe(true)
+    })
+
+    it('should not allow archived segments to be toggled', () => {
+      expect(canToggleSegmentStatus({ archived: true, enabled: false, status: 'completed' })).toBe(false)
     })
   })
 

--- a/web/app/components/datasets/documents/detail/completed/segment-card/index.tsx
+++ b/web/app/components/datasets/documents/detail/completed/segment-card/index.tsx
@@ -50,6 +50,21 @@ type ISegmentCardProps = {
   }
 }
 
+export const canToggleSegmentStatus = ({
+  archived,
+  enabled,
+  status,
+}: {
+  archived?: boolean
+  enabled?: boolean
+  status?: string
+}) => {
+  if (archived)
+    return false
+
+  return !enabled || status === 'completed'
+}
+
 const SegmentCard: FC<ISegmentCardProps> = ({
   detail = { status: '' },
   onClick,
@@ -228,7 +243,7 @@ const SegmentCard: FC<ISegmentCardProps> = ({
                       >
                         <Switch
                           size="md"
-                          disabled={archived || detail?.status !== 'completed'}
+                          disabled={!canToggleSegmentStatus({ archived, enabled, status: detail?.status })}
                           checked={enabled}
                           onCheckedChange={async (val) => {
                             await onChangeSwitch?.(val, id)


### PR DESCRIPTION
## Summary

This PR fixes a knowledge-base document chunk toggle regression reported in #35815.

When a user edits a disabled document chunk, the chunk can enter a non-`completed` segment index status such as `waiting`, `indexing`, or `error`. The backend already supports enabling disabled chunks through the segment status endpoint and then queues the index update. However, the SegmentCard UI disabled the enable switch whenever `detail.status !== 'completed'`, regardless of whether the chunk was currently enabled or disabled.

That meant a disabled chunk could become stuck from the UI after editing: the user would see the chunk as disabled, but the switch would not accept the enable action, so the backend enable flow was never called.

## Root Cause

The switch disabled condition in `SegmentCard` was too broad:

```tsx
disabled={archived || detail?.status !== 'completed'}
```

This protected chunks that were actively indexing, but it also blocked the legitimate recovery path for disabled chunks. For disabled chunks, enabling the switch is exactly the action that should be allowed so the backend can mark the segment enabled and enqueue indexing.

## Changes

- Added `canToggleSegmentStatus` to make the toggle rules explicit.
- Disabled archived chunks as before.
- Kept already-enabled chunks locked when their segment index status is not `completed`, preserving the existing protection while indexing is in progress.
- Allowed disabled chunks to be toggled back on even when their segment index status is `waiting`, `indexing`, or `error`.
- Added SegmentCard regression coverage for the enable-after-edit path.
- Added direct tests for the toggle guard so future changes do not reintroduce the stuck-disabled behavior.

## Behavior After This Change

- Disabled + non-`completed` segment: switch remains interactive, so the user can enable it.
- Enabled + non-`completed` segment: switch remains disabled, avoiding changes while indexing is in progress.
- Archived segment: switch remains disabled.
- Completed segment: switch behavior remains unchanged.

## Why This Matches Backend Behavior

The backend `update_segments_status` enable path already filters for disabled segments, marks them enabled, clears disabled metadata, commits the change, and dispatches `enable_segments_to_index_task`. This PR removes the frontend-only blocker that prevented that backend flow from being triggered.

Fixes #35815

## Tests

- `git diff --check`
- Not run: `pnpm -C web test -- app/components/datasets/documents/detail/completed/segment-card/__tests__/index.spec.tsx` because the local Node runtime is `v22.17.0`, while this repository requires `^22.22.1`; pnpm rejects the environment before installing dependencies or starting Vitest.