### PR TITLE
fix(web): preserve hidden file defaults in shared workflow

### DIFF
--- a/web/app/components/share/text-generation/result/__tests__/result-request.spec.ts
+++ b/web/app/components/share/text-generation/result/__tests__/result-request.spec.ts
@@ -179,6 +179,27 @@ describe('result-request', () => {
     })
   })
 
+  it('should reject pending local prompt file inputs outside batch mode', () => {
+    const result = validateResultRequest({
+      completionFiles: [],
+      inputs: {
+        name: 'Alice',
+        file: createFileEntity({ uploadedId: undefined }),
+      },
+      isCallBatchAPI: false,
+      promptConfig,
+      t: createTranslator(),
+    })
+
+    expect(result).toEqual({
+      canSend: false,
+      notification: {
+        type: 'info',
+        message: 'errorMessage.waitForFileUpload',
+      },
+    })
+  })
+
   it('should handle missing prompt metadata with and without pending uploads', () => {
     const t = createTranslator()
 
@@ -284,6 +305,53 @@ describe('result-request', () => {
             transfer_method: TransferMethod.local_file,
             upload_file_id: 'uploaded-2',
             url: 'https://example.com/second.txt',
+          },
+        ],
+        name: 'Alice',
+      },
+    })
+  })
+
+  it('should preserve hidden default file inputs that are already in server format', () => {
+    const hiddenDefaultFile = {
+      type: 'document',
+      transfer_method: TransferMethod.local_file,
+      upload_file_id: 'upload-hidden',
+      url: '',
+    }
+    const hiddenDefaultListFile = {
+      type: 'document',
+      transfer_method: TransferMethod.remote_url,
+      related_id: 'remote-related',
+      remote_url: 'https://example.com/default.docx',
+    }
+
+    const result = buildResultRequestData({
+      completionFiles: [],
+      inputs: {
+        name: 'Alice',
+        file: hiddenDefaultFile,
+        files: [hiddenDefaultListFile],
+      },
+      promptConfig,
+      visionConfig: { ...visionConfig, enabled: false },
+    })
+
+    expect(result).toEqual({
+      inputs: {
+        enabled: false,
+        file: {
+          type: 'document',
+          transfer_method: TransferMethod.local_file,
+          upload_file_id: 'upload-hidden',
+          url: '',
+        },
+        files: [
+          {
+            type: 'document',
+            transfer_method: TransferMethod.remote_url,
+            upload_file_id: 'remote-related',
+            url: 'https://example.com/default.docx',
           },
         ],
         name: 'Alice',

--- a/web/app/components/share/text-generation/result/result-request.ts
+++ b/web/app/components/share/text-generation/result/result-request.ts
@@ -60,6 +60,52 @@ const hasPendingLocalFiles = (completionFiles: VisionFile[]) => {
   return completionFiles.some(item => item.transfer_method === TransferMethod.local_file && !item.upload_file_id)
 }
 
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+const isProcessedFileInput = (value: unknown): value is Record<string, unknown> => {
+  return isRecord(value) && 'transfer_method' in value
+}
+
+const processInputFileFromServer = (fileItem: Record<string, unknown>) => {
+  return {
+    type: fileItem.type,
+    transfer_method: fileItem.transfer_method,
+    url: fileItem.url || fileItem.remote_url || '',
+    upload_file_id: fileItem.upload_file_id || fileItem.related_id || '',
+  }
+}
+
+const hasPendingPromptFile = (value: ResultInputValue) => {
+  if (!value)
+    return false
+
+  const files = Array.isArray(value) ? value : [value]
+
+  return files.some((file) => {
+    if (!isRecord(file))
+      return false
+
+    if ('transfer_method' in file)
+      return file.transfer_method === TransferMethod.local_file && !file.upload_file_id && !file.related_id
+
+    return file.transferMethod === TransferMethod.local_file && !file.uploadedId
+  })
+}
+
+const hasPendingPromptFiles = (
+  promptVariables: PromptConfig['prompt_variables'] | undefined,
+  inputs: Record<string, ResultInputValue>,
+) => {
+  return promptVariables?.some((variable) => {
+    if (variable.type !== 'file' && variable.type !== 'file-list')
+      return false
+
+    return hasPendingPromptFile(inputs[variable.key])
+  })
+}
+
 export const validateResultRequest = ({
   completionFiles,
   inputs,
@@ -106,7 +152,7 @@ export const validateResultRequest = ({
     }
   }
 
-  if (hasPendingLocalFiles(completionFiles)) {
+  if (hasPendingLocalFiles(completionFiles) || hasPendingPromptFiles(promptVariables, inputs)) {
     return {
       canSend: false,
       notification: {
@@ -132,12 +178,20 @@ export const buildResultRequestData = ({
   promptConfig?.prompt_variables.forEach((variable) => {
     const value = processedInputs[variable.key]
     if (variable.type === 'file' && value && typeof value === 'object' && !Array.isArray(value)) {
-      processedInputs[variable.key] = getProcessedFiles([value as FileEntity])[0]!
+      processedInputs[variable.key] = isProcessedFileInput(value)
+        ? processInputFileFromServer(value)
+        : getProcessedFiles([value as FileEntity])[0]!
       return
     }
 
-    if (variable.type === 'file-list' && Array.isArray(value) && value.length > 0)
-      processedInputs[variable.key] = getProcessedFiles(value as FileEntity[])
+    if (variable.type === 'file-list' && Array.isArray(value) && value.length > 0) {
+      processedInputs[variable.key] = value.map((file) => {
+        if (isProcessedFileInput(file))
+          return processInputFileFromServer(file)
+
+        return getProcessedFiles([file as FileEntity])[0]!
+      })
+    }
   })
 
   return {

--- a/web/app/components/share/text-generation/run-once/__tests__/index.spec.tsx
+++ b/web/app/components/share/text-generation/run-once/__tests__/index.spec.tsx
@@ -296,6 +296,36 @@ describe('RunOnce', () => {
       expect(screen.getByText('File Input'))!.toBeInTheDocument()
     })
 
+    it('should initialize hidden single file input with its default file', async () => {
+      const defaultFile = {
+        type: 'document',
+        transfer_method: TransferMethod.local_file,
+        upload_file_id: 'upload-1',
+        url: '',
+      }
+      const promptConfig: PromptConfig = {
+        prompt_template: 'template',
+        prompt_variables: [
+          createPromptVariable({
+            key: 'fileInput',
+            name: 'File Input',
+            type: 'file',
+            hide: true,
+            default: defaultFile,
+          }),
+        ],
+      }
+
+      const { onInputsChange } = setup({ promptConfig, visionConfig: { ...baseVisionConfig, enabled: false } })
+
+      await waitFor(() => {
+        expect(onInputsChange).toHaveBeenCalledWith({
+          fileInput: defaultFile,
+        })
+      })
+      expect(screen.queryByText('File Input'))!.not.toBeInTheDocument()
+    })
+
     it('should render file uploader for file-list input', async () => {
       const promptConfig: PromptConfig = {
         prompt_template: 'template',
@@ -314,6 +344,38 @@ describe('RunOnce', () => {
         })
       })
       expect(screen.getByText('File List Input'))!.toBeInTheDocument()
+    })
+
+    it('should initialize hidden file-list input with its default files', async () => {
+      const defaultFiles = [
+        {
+          type: 'document',
+          transfer_method: TransferMethod.local_file,
+          upload_file_id: 'upload-1',
+          url: '',
+        },
+      ]
+      const promptConfig: PromptConfig = {
+        prompt_template: 'template',
+        prompt_variables: [
+          createPromptVariable({
+            key: 'fileListInput',
+            name: 'File List Input',
+            type: 'file-list',
+            hide: true,
+            default: defaultFiles,
+          }),
+        ],
+      }
+
+      const { onInputsChange } = setup({ promptConfig, visionConfig: { ...baseVisionConfig, enabled: false } })
+
+      await waitFor(() => {
+        expect(onInputsChange).toHaveBeenCalledWith({
+          fileListInput: defaultFiles,
+        })
+      })
+      expect(screen.queryByText('File List Input'))!.not.toBeInTheDocument()
     })
   })
 

--- a/web/app/components/share/text-generation/run-once/index.tsx
+++ b/web/app/components/share/text-generation/run-once/index.tsx
@@ -24,6 +24,23 @@ import CodeEditor from '@/app/components/workflow/nodes/_base/components/editor/
 import { CodeLanguage } from '@/app/components/workflow/nodes/code/types'
 import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
 
+const getDefaultFileInputValue = (defaultValue: unknown) => {
+  if (defaultValue && typeof defaultValue === 'object' && !Array.isArray(defaultValue))
+    return defaultValue
+
+  return undefined
+}
+
+const getDefaultFileListInputValue = (defaultValue: unknown) => {
+  if (Array.isArray(defaultValue))
+    return defaultValue
+
+  if (defaultValue && typeof defaultValue === 'object')
+    return [defaultValue]
+
+  return []
+}
+
 type IRunOnceProps = {
   siteInfo: SiteInfo
   promptConfig: PromptConfig
@@ -100,9 +117,9 @@ const RunOnce: FC<IRunOnceProps> = ({
       else if (item.type === 'checkbox')
         newInputs[item.key] = item.default || false
       else if (item.type === 'file')
-        newInputs[item.key] = undefined
+        newInputs[item.key] = getDefaultFileInputValue(item.default)
       else if (item.type === 'file-list')
-        newInputs[item.key] = []
+        newInputs[item.key] = getDefaultFileListInputValue(item.default)
       else
         newInputs[item.key] = undefined
     })

--- a/web/models/debug.ts
+++ b/web/models/debug.ts
@@ -52,7 +52,7 @@ export type PromptVariable = {
   key: string
   name: string
   type: string // "string" | "number" | "select",
-  default?: string | number | boolean
+  default?: string | number | boolean | Record<string, unknown> | Record<string, unknown>[]
   required?: boolean
   options?: string[]
   max_length?: number


### PR DESCRIPTION
## Summary

This PR fixes the standalone workflow run hang reported in #35935.

In the shared `/workflow/[token]` run page, hidden start-node variables are initialized even though they are not rendered in the form. Scalar hidden defaults were preserved, but file variables were always initialized as empty values:

```tsx
file      -> undefined
file-list -> []
```

So when a workflow had a hidden optional single-file variable with an uploaded default file, the standalone run page silently dropped that default before sending the workflow run request. Studio preview could still work because it uses a different input panel path that keeps start-node defaults.

## Root Cause

The standalone `RunOnce` form treated file defaults differently from all other variable defaults. File defaults from the start node can already be present in server/API format, for example with `transfer_method`, `upload_file_id`, `related_id`, or `remote_url`. The run request builder then only knew how to serialize freshly uploaded frontend `FileEntity` values, so server-shaped default files could be lost or malformed.

## Changes

- Preserve default values for hidden and visible `file` variables during standalone form initialization.
- Preserve default values for `file-list` variables during standalone form initialization.
- Accept file defaults that are already in server/API format when building the run request payload.
- Continue supporting newly uploaded frontend `FileEntity` values.
- Block runs while prompt file inputs still contain unfinished local uploads, matching the existing wait-for-upload behavior used for vision uploads.
- Widen the `PromptVariable.default` type so file default objects are represented correctly.
- Add regression tests for hidden single-file and file-list defaults.
- Add request serialization tests for server-shaped default file inputs.

## Behavior After This Change

- A hidden single-file start variable with an uploaded default file is included in the standalone workflow run request.
- A hidden file-list variable with default files is included as well.
- File defaults already shaped like backend file payloads are preserved instead of being reprocessed as empty frontend files.
- Incomplete local prompt-file uploads are not sent; the user gets the existing wait-for-upload notification.

Fixes #35935

## Tests

- `git diff --check`
- Not run: `pnpm -C web test -- app/components/share/text-generation/run-once/__tests__/index.spec.tsx app/components/share/text-generation/result/__tests__/result-request.spec.ts` because the local Node runtime is `v22.17.0`, while this repository requires `^22.22.1`; pnpm rejects the environment before installing dependencies or starting Vitest.