### PR TITLE
refactor(web): mark Props of header/ components as read-only

### DIFF
--- a/web/app/components/header/account-about/index.tsx
+++ b/web/app/components/header/account-about/index.tsx
@@ -13,8 +13,8 @@ import Link from '@/next/link'
 import { systemFeaturesQueryOptions } from '@/service/system-features'
 
 type IAccountSettingProps = {
-  langGeniusVersionInfo: LangGeniusVersionResponse
-  onCancel: () => void
+  readonly langGeniusVersionInfo: LangGeniusVersionResponse
+  readonly onCancel: () => void
 }
 
 export default function AccountAbout({

--- a/web/app/components/header/app-back/index.tsx
+++ b/web/app/components/header/app-back/index.tsx
@@ -8,7 +8,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 type IAppBackProps = {
-  curApp: AppDetailResponse
+  readonly curApp: AppDetailResponse
 }
 export default function AppBack({ curApp }: IAppBackProps) {
   const { t } = useTranslation()

--- a/web/app/components/header/indicator/index.tsx
+++ b/web/app/components/header/indicator/index.tsx
@@ -3,8 +3,8 @@
 import { cn } from '@langgenius/dify-ui/cn'
 
 export type IndicatorProps = {
-  color?: 'green' | 'orange' | 'red' | 'blue' | 'yellow' | 'gray'
-  className?: string
+  readonly color?: 'green' | 'orange' | 'red' | 'blue' | 'yellow' | 'gray'
+  readonly className?: string
 }
 
 export type ColorMap = {

--- a/web/app/components/header/plan-badge/index.tsx
+++ b/web/app/components/header/plan-badge/index.tsx
@@ -9,10 +9,10 @@ import PremiumBadge, { PremiumBadgeButton } from '../../base/premium-badge'
 import { Plan } from '../../billing/type'
 
 type PlanBadgeProps = {
-  plan: Plan
-  allowHover?: boolean
-  sandboxAsUpgrade?: boolean
-  onClick?: () => void
+  readonly plan: Plan
+  readonly allowHover?: boolean
+  readonly sandboxAsUpgrade?: boolean
+  readonly onClick?: () => void
 }
 
 function PlanBadgeShell({
@@ -22,9 +22,9 @@ function PlanBadgeShell({
   onClick,
   children,
 }: Pick<PlanBadgeProps, 'allowHover' | 'onClick'> & {
-  size?: 's' | 'm'
-  color: 'blue' | 'indigo' | 'gray'
-  children: ReactNode
+  readonly size?: 's' | 'm'
+  readonly color: 'blue' | 'indigo' | 'gray'
+  readonly children: ReactNode
 }) {
   if (onClick) {
     return (


### PR DESCRIPTION
Relates to #25219.

Adds the `readonly` modifier to each property of the Props types in four header components:
- `app-back` (`IAppBackProps`)
- `indicator` (`IndicatorProps`)
- `plan-badge` (`PlanBadgeProps` + `PlanBadgeShell` inline props)
- `account-about` (`IAccountSettingProps`)

Pattern matches the merged example PR #25220 (`@eslint-react/prefer-read-only-props`).