### PR TITLE
refactor: add missing @override decorator to AppQueueManager subclasses

### DIFF
--- a/api/core/app/apps/message_based_app_queue_manager.py
+++ b/api/core/app/apps/message_based_app_queue_manager.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from core.app.apps.base_app_queue_manager import AppQueueManager, PublishFrom
 from core.app.apps.exc import GenerateTaskStoppedError
 from core.app.entities.app_invoke_entities import InvokeFrom
@@ -21,6 +23,7 @@ class MessageBasedAppQueueManager(AppQueueManager):
         self._app_mode = app_mode
         self._message_id = str(message_id)
 
+    @override
     def _publish(self, event: AppQueueEvent, pub_from: PublishFrom):
         """
         Publish event to queue

--- a/api/core/app/apps/pipeline/pipeline_queue_manager.py
+++ b/api/core/app/apps/pipeline/pipeline_queue_manager.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from core.app.apps.base_app_queue_manager import AppQueueManager, PublishFrom
 from core.app.apps.exc import GenerateTaskStoppedError
 from core.app.entities.app_invoke_entities import InvokeFrom
@@ -19,6 +21,7 @@ class PipelineQueueManager(AppQueueManager):
 
         self._app_mode = app_mode
 
+    @override
     def _publish(self, event: AppQueueEvent, pub_from: PublishFrom) -> None:
         """
         Publish event to queue

--- a/api/core/app/apps/workflow/app_queue_manager.py
+++ b/api/core/app/apps/workflow/app_queue_manager.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from core.app.apps.base_app_queue_manager import AppQueueManager, PublishFrom
 from core.app.apps.exc import GenerateTaskStoppedError
 from core.app.entities.app_invoke_entities import InvokeFrom
@@ -19,6 +21,7 @@ class WorkflowAppQueueManager(AppQueueManager):
 
         self._app_mode = app_mode
 
+    @override
     def _publish(self, event: AppQueueEvent, pub_from: PublishFrom):
         """
         Publish event to queue


### PR DESCRIPTION
Relates to #36406.

Adds `@override` (PEP 698, `from typing import override`) to the `_publish` method in the three `AppQueueManager` subclasses:
- `MessageBasedAppQueueManager` (`api/core/app/apps/message_based_app_queue_manager.py`)
- `WorkflowAppQueueManager` (`api/core/app/apps/workflow/app_queue_manager.py`)
- `PipelineQueueManager` (`api/core/app/apps/pipeline/pipeline_queue_manager.py`)

The base class `AppQueueManager` declares `_publish` as `@abstractmethod`. Pattern follows the merged example in #36425 and the first slice in #36486.