### PR TITLE
refactor: add missing @override decorator to Moderation subclasses

### DIFF
--- a/api/core/moderation/api/api.py
+++ b/api/core/moderation/api/api.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, override
 
 from pydantic import BaseModel, Field
 from sqlalchemy import select
@@ -25,6 +25,7 @@ class ApiModeration(Moderation):
     name: str = "api"
 
     @classmethod
+    @override
     def validate_config(cls, tenant_id: str, config: dict[str, Any]):
         """
         Validate the incoming form config data.
@@ -43,6 +44,7 @@ class ApiModeration(Moderation):
         if not extension:
             raise ValueError("API-based Extension not found. Please check it again.")
 
+    @override
     def moderation_for_inputs(self, inputs: dict[str, Any], query: str = "") -> ModerationInputsResult:
         flagged = False
         preset_response = ""
@@ -59,6 +61,7 @@ class ApiModeration(Moderation):
             flagged=flagged, action=ModerationAction.DIRECT_OUTPUT, preset_response=preset_response
         )
 
+    @override
     def moderation_for_outputs(self, text: str) -> ModerationOutputsResult:
         flagged = False
         preset_response = ""

--- a/api/core/moderation/keywords/keywords.py
+++ b/api/core/moderation/keywords/keywords.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, override
 
 from core.moderation.base import Moderation, ModerationAction, ModerationInputsResult, ModerationOutputsResult
 
@@ -8,6 +8,7 @@ class KeywordsModeration(Moderation):
     name: str = "keywords"
 
     @classmethod
+    @override
     def validate_config(cls, tenant_id: str, config: dict[str, Any]):
         """
         Validate the incoming form config data.
@@ -28,6 +29,7 @@ class KeywordsModeration(Moderation):
         if len(keywords_row_len) > 100:
             raise ValueError("the number of rows for the keywords must be less than 100")
 
+    @override
     def moderation_for_inputs(self, inputs: dict[str, Any], query: str = "") -> ModerationInputsResult:
         flagged = False
         preset_response = ""
@@ -49,6 +51,7 @@ class KeywordsModeration(Moderation):
             flagged=flagged, action=ModerationAction.DIRECT_OUTPUT, preset_response=preset_response
         )
 
+    @override
     def moderation_for_outputs(self, text: str) -> ModerationOutputsResult:
         flagged = False
         preset_response = ""

--- a/api/core/moderation/openai_moderation/openai_moderation.py
+++ b/api/core/moderation/openai_moderation/openai_moderation.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, override
 
 from core.model_manager import ModelManager
 from core.moderation.base import Moderation, ModerationAction, ModerationInputsResult, ModerationOutputsResult
@@ -9,6 +9,7 @@ class OpenAIModeration(Moderation):
     name: str = "openai_moderation"
 
     @classmethod
+    @override
     def validate_config(cls, tenant_id: str, config: dict[str, Any]):
         """
         Validate the incoming form config data.
@@ -19,6 +20,7 @@ class OpenAIModeration(Moderation):
         """
         cls._validate_inputs_and_outputs_config(config, True)
 
+    @override
     def moderation_for_inputs(self, inputs: dict[str, Any], query: str = "") -> ModerationInputsResult:
         flagged = False
         preset_response = ""
@@ -36,6 +38,7 @@ class OpenAIModeration(Moderation):
             flagged=flagged, action=ModerationAction.DIRECT_OUTPUT, preset_response=preset_response
         )
 
+    @override
     def moderation_for_outputs(self, text: str) -> ModerationOutputsResult:
         flagged = False
         preset_response = ""


### PR DESCRIPTION
Relates to #36406.

Adds `@override` (PEP 698, `from typing import override`) to the three abstract methods (`validate_config`, `moderation_for_inputs`, `moderation_for_outputs`) in the three `Moderation` subclasses (9 decorators total):

- `ApiModeration` (`api/core/moderation/api/api.py`)
- `KeywordsModeration` (`api/core/moderation/keywords/keywords.py`)
- `OpenAIModeration` (`api/core/moderation/openai_moderation/openai_moderation.py`)

Pattern follows the merged example in #36425 and the previous slices in #36486, #36490, #36491.