### PR TITLE
refactor: add missing @override decorator to file access controller and workflow file runtime

### DIFF
--- a/api/core/app/file_access/controller.py
+++ b/api/core/app/file_access/controller.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import override
 
 from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import Session
@@ -31,9 +32,11 @@ class DatabaseFileAccessController(FileAccessControllerProtocol):
     ) -> None:
         self._scope_getter = scope_getter
 
+    @override
     def current_scope(self) -> FileAccessScope | None:
         return self._scope_getter()
 
+    @override
     def apply_upload_file_filters(
         self,
         stmt: Select[tuple[UploadFile]],
@@ -62,6 +65,7 @@ class DatabaseFileAccessController(FileAccessControllerProtocol):
             )
         )
 
+    @override
     def apply_tool_file_filters(
         self,
         stmt: Select[tuple[ToolFile]],
@@ -78,6 +82,7 @@ class DatabaseFileAccessController(FileAccessControllerProtocol):
 
         return scoped_stmt.where(ToolFile.user_id == resolved_scope.user_id)
 
+    @override
     def get_upload_file(
         self,
         *,
@@ -95,6 +100,7 @@ class DatabaseFileAccessController(FileAccessControllerProtocol):
         )
         return session.scalar(stmt)
 
+    @override
     def get_tool_file(
         self,
         *,

--- a/api/core/app/workflow/file_runtime.py
+++ b/api/core/app/workflow/file_runtime.py
@@ -7,7 +7,7 @@ import os
 import time
 import urllib.parse
 from collections.abc import Generator
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, override
 
 from configs import dify_config
 from core.app.file_access import DatabaseFileAccessController, FileAccessControllerProtocol
@@ -40,15 +40,19 @@ class DifyWorkflowFileRuntime(WorkflowFileRuntimeProtocol):
         self._file_access_controller = file_access_controller
 
     @property
+    @override
     def multimodal_send_format(self) -> str:
         return dify_config.MULTIMODAL_SEND_FORMAT
 
+    @override
     def http_get(self, url: str, *, follow_redirects: bool = True) -> HttpResponseProtocol:
         return graphon_ssrf_proxy.get(url, follow_redirects=follow_redirects)
 
+    @override
     def storage_load(self, path: str, *, stream: bool = False) -> bytes | Generator:
         return storage.load(path, stream=stream)
 
+    @override
     def load_file_bytes(self, *, file: File) -> bytes:
         storage_key = self._resolve_storage_key(file=file)
         data = storage.load(storage_key, stream=False)
@@ -56,6 +60,7 @@ class DifyWorkflowFileRuntime(WorkflowFileRuntimeProtocol):
             raise ValueError(f"file {storage_key} is not a bytes object")
         return data
 
+    @override
     def resolve_file_url(self, *, file: File, for_external: bool = True) -> str | None:
         if file.transfer_method == FileTransferMethod.REMOTE_URL:
             return file.remote_url
@@ -86,6 +91,7 @@ class DifyWorkflowFileRuntime(WorkflowFileRuntimeProtocol):
             )
         return None
 
+    @override
     def resolve_upload_file_url(
         self,
         *,
@@ -101,10 +107,12 @@ class DifyWorkflowFileRuntime(WorkflowFileRuntimeProtocol):
             query["as_attachment"] = "true"
         return f"{url}?{urllib.parse.urlencode(query)}"
 
+    @override
     def resolve_tool_file_url(self, *, tool_file_id: str, extension: str, for_external: bool = True) -> str:
         self._assert_tool_file_access(tool_file_id=tool_file_id)
         return sign_tool_file(tool_file_id=tool_file_id, extension=extension, for_external=for_external)
 
+    @override
     def verify_preview_signature(
         self,
         *,


### PR DESCRIPTION
Relates to #36406.

Adds `@override` (PEP 698, `from typing import override`) to 13 protocol method implementations across two files:

**`api/core/app/file_access/controller.py`** — `DatabaseFileAccessController` (implements `FileAccessControllerProtocol`):
- `current_scope`
- `apply_upload_file_filters`
- `apply_tool_file_filters`
- `get_upload_file`
- `get_tool_file`

**`api/core/app/workflow/file_runtime.py`** — `DifyWorkflowFileRuntime` (implements `WorkflowFileRuntimeProtocol`):
- `multimodal_send_format` (property)
- `http_get`
- `storage_load`
- `load_file_bytes`
- `resolve_file_url`
- `resolve_upload_file_url`
- `resolve_tool_file_url`
- `verify_preview_signature`

`@override` is placed below `@property` for `multimodal_send_format`, per the PEP 698 convention for decorator stacking.

Pattern follows the merged example in #36425 and previous slices #36486, #36490, #36491, #36492, #36493, #36494.