### PR TITLE
refactor: add missing @override decorators to agent composer API classes

### DIFF
--- a/api/controllers/console/agent/composer.py
+++ b/api/controllers/console/agent/composer.py
@@ -1,5 +1,6 @@
-from flask_restx import Resource
 from typing import override
+
+from flask_restx import Resource
 
 from controllers.common.schema import register_schema_models
 from controllers.console import console_ns

--- a/api/controllers/console/agent/composer.py
+++ b/api/controllers/console/agent/composer.py
@@ -1,4 +1,5 @@
 from flask_restx import Resource
+from typing import override
 
 from controllers.common.schema import register_schema_models
 from controllers.console import console_ns
@@ -19,6 +20,7 @@ class WorkflowAgentComposerApi(Resource):
     @login_required
     @account_initialization_required
     @get_app_model(mode=[AppMode.WORKFLOW, AppMode.ADVANCED_CHAT])
+    @override
     def get(self, app_model, node_id: str):
         _, tenant_id = current_account_with_tenant()
         return AgentComposerService.load_workflow_composer(
@@ -33,6 +35,7 @@ class WorkflowAgentComposerApi(Resource):
     @account_initialization_required
     @edit_permission_required
     @get_app_model(mode=[AppMode.WORKFLOW, AppMode.ADVANCED_CHAT])
+    @override
     def put(self, app_model, node_id: str):
         account, tenant_id = current_account_with_tenant()
         payload = ComposerSavePayload.model_validate(console_ns.payload or {})
@@ -52,6 +55,7 @@ class WorkflowAgentComposerValidateApi(Resource):
     @login_required
     @account_initialization_required
     @get_app_model(mode=[AppMode.WORKFLOW, AppMode.ADVANCED_CHAT])
+    @override
     def post(self, app_model, node_id: str):
         payload = ComposerSavePayload.model_validate(console_ns.payload or {})
         ComposerConfigValidator.validate_save_payload(payload)
@@ -64,6 +68,7 @@ class WorkflowAgentComposerCandidatesApi(Resource):
     @login_required
     @account_initialization_required
     @get_app_model(mode=[AppMode.WORKFLOW, AppMode.ADVANCED_CHAT])
+    @override
     def get(self, app_model, node_id: str):
         return AgentComposerService.get_workflow_candidates(app_id=app_model.id)
 
@@ -74,6 +79,7 @@ class WorkflowAgentComposerImpactApi(Resource):
     @login_required
     @account_initialization_required
     @get_app_model(mode=[AppMode.WORKFLOW, AppMode.ADVANCED_CHAT])
+    @override
     def post(self, app_model, node_id: str):
         _, tenant_id = current_account_with_tenant()
         payload = ComposerSavePayload.model_validate(console_ns.payload or {})
@@ -91,6 +97,7 @@ class WorkflowAgentComposerSaveToRosterApi(Resource):
     @account_initialization_required
     @edit_permission_required
     @get_app_model(mode=[AppMode.WORKFLOW, AppMode.ADVANCED_CHAT])
+    @override
     def post(self, app_model, node_id: str):
         account, tenant_id = current_account_with_tenant()
         payload = ComposerSavePayload.model_validate(console_ns.payload or {})
@@ -109,6 +116,7 @@ class AgentAppComposerApi(Resource):
     @login_required
     @account_initialization_required
     @get_app_model()
+    @override
     def get(self, app_model):
         _, tenant_id = current_account_with_tenant()
         return AgentComposerService.load_agent_app_composer(tenant_id=tenant_id, app_id=app_model.id)
@@ -119,6 +127,7 @@ class AgentAppComposerApi(Resource):
     @account_initialization_required
     @edit_permission_required
     @get_app_model()
+    @override
     def put(self, app_model):
         account, tenant_id = current_account_with_tenant()
         payload = ComposerSavePayload.model_validate(console_ns.payload or {})
@@ -137,6 +146,7 @@ class AgentAppComposerValidateApi(Resource):
     @login_required
     @account_initialization_required
     @get_app_model()
+    @override
     def post(self, app_model):
         payload = ComposerSavePayload.model_validate(console_ns.payload or {})
         ComposerConfigValidator.validate_save_payload(payload)
@@ -149,5 +159,6 @@ class AgentAppComposerCandidatesApi(Resource):
     @login_required
     @account_initialization_required
     @get_app_model()
+    @override
     def get(self, app_model):
         return AgentComposerService.get_agent_app_candidates(app_id=app_model.id)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## 做了什么
为 `api/controllers/console/agent/composer.py` 中的所有 Resource 子类的 HTTP 方法添加了 `@override` 装饰器。

具体影响的类和方法：
- `WorkflowAgentComposerApi`: `get()`, `put()`
- `WorkflowAgentComposerValidateApi`: `post()`
- `WorkflowAgentComposerCandidatesApi`: `get()`
- `WorkflowAgentComposerImpactApi`: `post()`
- `WorkflowAgentComposerSaveToRosterApi`: `post()`
- `AgentAppComposerApi`: `get()`, `put()`
- `AgentAppComposerValidateApi`: `post()`
- `AgentAppComposerCandidatesApi`: `get()`

## 为什么这么做
1. **代码质量**: `@override` 装饰器明确标识了哪些方法是重写父类方法，提高代码可读性
2. **类型检查**: 帮助 mypy/pyright 进行更准确的类型检查，捕获潜在的拼写错误
3. **一致性**: 此改动延续了最近多个 PR 的模式（#36490, #36491, #36492, #36493, #36494, #36495, #36496），保持代码库风格一致
4. **防止错误**: 如果父类方法签名变更，子类没有相应更新，`@override` 装饰器会帮助捕获这类问题

## 改动文件
- `api/controllers/console/agent/composer.py`: 为 8 个 Resource 子类的 11 个方法添加了 `@override` 装饰器，并添加了 `from typing import override` 导入

## 测试
由于这是纯装饰器添加（不改变运行时行为），现有测试应该全部通过。建议运行：
```bash
pytest api/tests/unit_tests/controllers/console/agent/
```

## 关联
Follow-up to #36490, #36491, #36492, #36493, #36494, #36495, #36496