### PR TITLE
refactor: add missing @override decorator to agent runners, tool caches, and logging extensions

### DIFF
--- a/api/core/agent/cot_chat_agent_runner.py
+++ b/api/core/agent/cot_chat_agent_runner.py
@@ -1,4 +1,5 @@
 import json
+from typing import override
 
 from core.agent.cot_agent_runner import CotAgentRunner
 from graphon.file import file_manager
@@ -66,6 +67,7 @@ class CotChatAgentRunner(CotAgentRunner):
 
         return prompt_messages
 
+    @override
     def _organize_prompt_messages(self) -> list[PromptMessage]:
         """
         Organize

--- a/api/core/agent/cot_completion_agent_runner.py
+++ b/api/core/agent/cot_completion_agent_runner.py
@@ -1,4 +1,5 @@
 import json
+from typing import override
 
 from core.agent.cot_agent_runner import CotAgentRunner
 from graphon.model_runtime.entities.message_entities import (
@@ -51,6 +52,7 @@ class CotCompletionAgentRunner(CotAgentRunner):
 
         return historic_prompt
 
+    @override
     def _organize_prompt_messages(self) -> list[PromptMessage]:
         """
         Organize prompt messages

--- a/api/core/agent/strategy/plugin.py
+++ b/api/core/agent/strategy/plugin.py
@@ -1,5 +1,5 @@
 from collections.abc import Generator, Sequence
-from typing import Any
+from typing import Any, override
 
 from core.agent.entities import AgentInvokeMessage
 from core.agent.plugin_entities import AgentStrategyEntity, AgentStrategyParameter
@@ -23,6 +23,7 @@ class PluginAgentStrategy(BaseAgentStrategy):
         self.declaration = declaration
         self.meta_version = meta_version
 
+    @override
     def get_parameters(self) -> Sequence[AgentStrategyParameter]:
         return self.declaration.parameters
 
@@ -34,6 +35,7 @@ class PluginAgentStrategy(BaseAgentStrategy):
             params[parameter.name] = parameter.init_frontend_parameter(params.get(parameter.name))
         return params
 
+    @override
     def _invoke(
         self,
         params: dict[str, Any],

--- a/api/core/helper/provider_cache.py
+++ b/api/core/helper/provider_cache.py
@@ -1,7 +1,7 @@
 import json
 from abc import ABC, abstractmethod
 from json import JSONDecodeError
-from typing import Any
+from typing import Any, override
 
 from extensions.ext_redis import redis_client
 
@@ -47,6 +47,7 @@ class SingletonProviderCredentialsCache(ProviderCredentialsCache):
             provider_identity=provider_identity,
         )
 
+    @override
     def _generate_cache_key(self, **kwargs) -> str:
         tenant_id = kwargs["tenant_id"]
         provider_type = kwargs["provider_type"]
@@ -61,6 +62,7 @@ class ToolProviderCredentialsCache(ProviderCredentialsCache):
     def __init__(self, tenant_id: str, provider: str, credential_id: str):
         super().__init__(tenant_id=tenant_id, provider=provider, credential_id=credential_id)
 
+    @override
     def _generate_cache_key(self, **kwargs) -> str:
         tenant_id = kwargs["tenant_id"]
         provider = kwargs["provider"]

--- a/api/core/logging/filters.py
+++ b/api/core/logging/filters.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import logging
+from typing import override
 
 import flask
 
@@ -15,6 +16,7 @@ class TraceContextFilter(logging.Filter):
     Integrates with OpenTelemetry when available, falls back to ContextVar-based trace_id.
     """
 
+    @override
     def filter(self, record: logging.LogRecord) -> bool:
         # Get trace context from OpenTelemetry
         trace_id, span_id = self._get_otel_context()
@@ -54,6 +56,7 @@ class IdentityContextFilter(logging.Filter):
     Extracts tenant_id, user_id, and user_type from Flask-Login current_user.
     """
 
+    @override
     def filter(self, record: logging.LogRecord) -> bool:
         identity = self._extract_identity()
         record.tenant_id = identity.get("tenant_id", "")

--- a/api/core/logging/structured_formatter.py
+++ b/api/core/logging/structured_formatter.py
@@ -3,7 +3,7 @@
 import logging
 import traceback
 from datetime import UTC, datetime
-from typing import Any, NotRequired, TypedDict
+from typing import Any, NotRequired, TypedDict, override
 
 import orjson
 
@@ -58,6 +58,7 @@ class StructuredJSONFormatter(logging.Formatter):
         super().__init__()
         self._service_name = service_name or dify_config.APPLICATION_NAME
 
+    @override
     def format(self, record: logging.LogRecord) -> str:
         log_dict = self._build_log_dict(record)
         try:


### PR DESCRIPTION
Relates to #36406.

Adds `@override` (PEP 698, `from typing import override`) to 9 method implementations across 6 files:

**Agent runners** (CotAgentRunner subclasses):
- `CotChatAgentRunner._organize_prompt_messages` (`api/core/agent/cot_chat_agent_runner.py`)
- `CotCompletionAgentRunner._organize_prompt_messages` (`api/core/agent/cot_completion_agent_runner.py`)

**Plugin agent strategy** (BaseAgentStrategy subclass):
- `PluginAgentStrategy.get_parameters`, `_invoke` (`api/core/agent/strategy/plugin.py`)

**Provider credential caches** (ProviderCredentialsCache subclasses):
- `SingletonProviderCredentialsCache._generate_cache_key` (`api/core/helper/provider_cache.py`)
- `ToolProviderCredentialsCache._generate_cache_key` (`api/core/helper/provider_cache.py`)

**Logging extensions** (stdlib `logging.Filter` / `logging.Formatter` subclasses):
- `TraceContextFilter.filter`, `IdentityContextFilter.filter` (`api/core/logging/filters.py`)
- `StructuredJSONFormatter.format` (`api/core/logging/structured_formatter.py`)

Pattern follows the merged example in #36425 and the previous merged slices (#36486, #36490, #36491, #36492, #36493, #36494, #36495, #36496).