### PR TITLE
fix(api): preserve parallel iteration outputs

### DIFF
--- a/api/core/workflow/node_factory.py
+++ b/api/core/workflow/node_factory.py
@@ -41,6 +41,7 @@ from core.workflow.nodes.agent_v2 import DifyAgentNode
 from core.workflow.nodes.agent_v2.binding_resolver import WorkflowAgentBindingResolver
 from core.workflow.nodes.agent_v2.output_adapter import WorkflowAgentOutputAdapter
 from core.workflow.nodes.agent_v2.runtime_request_builder import WorkflowAgentRuntimeRequestBuilder
+from core.workflow.nodes.iteration import DifyIterationNode
 from core.workflow.system_variables import SystemVariableKey, get_system_text, system_variable_selector
 from core.workflow.template_rendering import CodeExecutorJinja2TemplateRenderer
 from graphon.entities.base_node_data import BaseNodeData
@@ -126,6 +127,9 @@ def get_node_type_classes_mapping() -> Mapping[NodeType, Mapping[str, type[Node]
 
 def resolve_workflow_node_class(*, node_type: NodeType, node_version: str) -> type[Node]:
     """Resolve the production node class for the requested type/version."""
+    if node_type == BuiltinNodeTypes.ITERATION and node_version in (DifyIterationNode.version(), LATEST_VERSION):
+        return DifyIterationNode
+
     node_mapping = get_node_type_classes_mapping().get(node_type)
     if not node_mapping:
         raise ValueError(f"No class mapping found for node type: {node_type}")

--- a/api/core/workflow/nodes/iteration/__init__.py
+++ b/api/core/workflow/nodes/iteration/__init__.py
@@ -1,0 +1,3 @@
+from .node import DifyIterationNode
+
+__all__ = ["DifyIterationNode"]

--- a/api/core/workflow/nodes/iteration/node.py
+++ b/api/core/workflow/nodes/iteration/node.py
@@ -11,6 +11,10 @@ from graphon.runtime import VariablePool
 class DifyIterationNode(IterationNode):
     """Dify compatibility layer for Graphon's iteration node."""
 
+    @classmethod
+    def version(cls) -> str:
+        return IterationNode.version()
+
     @override
     def _execute_parallel_iteration_with_graph_engine(
         self,

--- a/api/core/workflow/nodes/iteration/node.py
+++ b/api/core/workflow/nodes/iteration/node.py
@@ -1,0 +1,91 @@
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any, override
+
+from graphon.graph_events import GraphNodeEventBase, GraphRunPartialSucceededEvent, GraphRunSucceededEvent
+from graphon.model_runtime.entities.llm_entities import LLMUsage
+from graphon.nodes.iteration.iteration_node import IterationNode
+from graphon.runtime import VariablePool
+
+
+class DifyIterationNode(IterationNode):
+    """Dify compatibility layer for Graphon's iteration node."""
+
+    @override
+    def _execute_parallel_iteration_with_graph_engine(
+        self,
+        *,
+        graph_engine: Any,
+    ) -> tuple[float, list[GraphNodeEventBase], object | None, LLMUsage]:
+        iter_start_at = datetime.now(UTC).replace(tzinfo=None)
+        outputs_temp: list[object] = []
+        events: list[GraphNodeEventBase] = []
+        variable_pool = graph_engine.graph_runtime_state.variable_pool
+        current_index = self._get_current_iteration_index(variable_pool)
+
+        for event in graph_engine.run():
+            if isinstance(event, GraphRunSucceededEvent | GraphRunPartialSucceededEvent):
+                outputs_temp.append(self._get_parallel_iteration_output(variable_pool=variable_pool, events=events))
+                break
+
+            event_to_yield, stop_iteration = self._process_single_iteration_event(
+                event=event,
+                current_index=current_index,
+                variable_pool=variable_pool,
+                outputs=outputs_temp,
+            )
+            if event_to_yield is not None:
+                events.append(event_to_yield)
+            if stop_iteration:
+                break
+
+        output_value = outputs_temp[0] if outputs_temp else None
+        iteration_duration = (datetime.now(UTC).replace(tzinfo=None) - iter_start_at).total_seconds()
+
+        return (
+            iteration_duration,
+            events,
+            output_value,
+            graph_engine.graph_runtime_state.llm_usage,
+        )
+
+    def _get_parallel_iteration_output(
+        self,
+        *,
+        variable_pool: VariablePool,
+        events: list[GraphNodeEventBase],
+    ) -> object | None:
+        result = variable_pool.get(self.node_data.output_selector)
+        if result is not None:
+            return result.to_object()
+
+        return self._get_output_from_child_events(events=events)
+
+    def _get_output_from_child_events(self, *, events: list[GraphNodeEventBase]) -> object | None:
+        output_selector = self.node_data.output_selector
+        if len(output_selector) < 2:
+            return None
+
+        selected_node_id = output_selector[0]
+        selected_output_name = output_selector[1]
+        nested_selector = output_selector[2:]
+
+        for event in reversed(events):
+            if event.node_id != selected_node_id:
+                continue
+
+            value = event.node_run_result.outputs.get(selected_output_name)
+            if nested_selector:
+                return self._get_nested_output(value=value, selector=nested_selector)
+            return value
+
+        return None
+
+    @staticmethod
+    def _get_nested_output(*, value: object, selector: list[str]) -> object | None:
+        current = value
+        for key in selector:
+            if not isinstance(current, Mapping):
+                return None
+            current = current.get(key)
+        return current

--- a/api/tests/unit_tests/core/workflow/nodes/iteration/test_iteration_parallel_outputs.py
+++ b/api/tests/unit_tests/core/workflow/nodes/iteration/test_iteration_parallel_outputs.py
@@ -1,0 +1,84 @@
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from core.workflow.node_factory import resolve_workflow_node_class
+from core.workflow.nodes.iteration import DifyIterationNode
+from core.workflow.system_variables import default_system_variables
+from graphon.enums import BuiltinNodeTypes, WorkflowNodeExecutionStatus
+from graphon.graph_events import GraphRunSucceededEvent, NodeRunIterationSucceededEvent, NodeRunSucceededEvent
+from graphon.model_runtime.entities.llm_entities import LLMUsage
+from graphon.node_events import NodeRunResult
+from graphon.nodes.iteration.entities import IterationNodeData
+from graphon.runtime import GraphRuntimeState, VariablePool
+from tests.workflow_test_utils import build_test_graph_init_params
+
+
+class _ChildEngine:
+    def __init__(self, *, index: int, output: object) -> None:
+        variable_pool = VariablePool.from_bootstrap(system_variables=default_system_variables(), user_inputs={})
+        variable_pool.add(["iteration-node", "index"], index)
+        variable_pool.add(["iteration-node", "item"], f"item-{index}")
+        self.graph_runtime_state = SimpleNamespace(
+            variable_pool=variable_pool,
+            llm_usage=LLMUsage.empty_usage(),
+        )
+        self._output = output
+
+    def run(self):
+        started_at = datetime.now(UTC).replace(tzinfo=None)
+        yield NodeRunSucceededEvent(
+            id=f"child-run-{self._output}",
+            node_id="child-node",
+            node_type=BuiltinNodeTypes.CODE,
+            start_at=started_at,
+            finished_at=started_at,
+            node_run_result=NodeRunResult(
+                status=WorkflowNodeExecutionStatus.SUCCEEDED,
+                outputs={"result": self._output},
+            ),
+        )
+        yield GraphRunSucceededEvent(outputs={"result": self._output})
+
+
+def _build_iteration_node(*, outputs: list[object]) -> DifyIterationNode:
+    variable_pool = VariablePool.from_bootstrap(system_variables=default_system_variables(), user_inputs={})
+    variable_pool.add(["source-node", "items"], ["item-0", "item-1"])
+    runtime_state = GraphRuntimeState(variable_pool=variable_pool, start_at=0.0)
+
+    node = DifyIterationNode(
+        node_id="iteration-node",
+        data=IterationNodeData(
+            title="Iteration",
+            iterator_selector=["source-node", "items"],
+            output_selector=["child-node", "result"],
+            start_node_id="iteration-start",
+            is_parallel=True,
+            parallel_nums=2,
+        ),
+        graph_init_params=build_test_graph_init_params(),
+        graph_runtime_state=runtime_state,
+    )
+
+    child_engines = [_ChildEngine(index=index, output=output) for index, output in enumerate(outputs)]
+    node._create_graph_engine = lambda index, item: child_engines[index]  # type: ignore[method-assign]
+    return node
+
+
+def test_parallel_iteration_collects_child_event_output_when_variable_pool_lacks_selector() -> None:
+    node = _build_iteration_node(outputs=["first", "second"])
+
+    events = list(node.run())
+
+    iteration_success = next(event for event in events if isinstance(event, NodeRunIterationSucceededEvent))
+    completed = next(
+        event
+        for event in events
+        if isinstance(event, NodeRunSucceededEvent) and event.node_id == "iteration-node"
+    )
+
+    assert iteration_success.outputs == {"output": ["first", "second"]}
+    assert completed.node_run_result.outputs == {"output": ["first", "second"]}
+
+
+def test_dify_node_factory_uses_iteration_compatibility_wrapper() -> None:
+    assert resolve_workflow_node_class(node_type=BuiltinNodeTypes.ITERATION, node_version="1") is DifyIterationNode

--- a/api/tests/unit_tests/core/workflow/nodes/iteration/test_iteration_parallel_outputs.py
+++ b/api/tests/unit_tests/core/workflow/nodes/iteration/test_iteration_parallel_outputs.py
@@ -71,9 +71,7 @@ def test_parallel_iteration_collects_child_event_output_when_variable_pool_lacks
 
     iteration_success = next(event for event in events if isinstance(event, NodeRunIterationSucceededEvent))
     completed = next(
-        event
-        for event in events
-        if isinstance(event, NodeRunSucceededEvent) and event.node_id == "iteration-node"
+        event for event in events if isinstance(event, NodeRunSucceededEvent) and event.node_id == "iteration-node"
     )
 
     assert iteration_success.outputs == {"output": ["first", "second"]}


### PR DESCRIPTION
## Summary

This PR fixes a regression where an Iteration node could return `[null]` after enabling Parallel Mode, even when the child nodes completed successfully and produced outputs.

The issue happens in the parallel execution path. Each iteration runs in its own child graph, and the parent iteration node collects the selected output after that child graph finishes. In some cases, the selected output is available in the emitted child node success event, but it is not yet readable from the child graph's variable pool when the parallel collector checks it. That causes the collector to store `None`, so the final iteration output becomes `[null]`.

To fix this, this PR adds a Dify compatibility wrapper around Graphon's Iteration node. The wrapper keeps the existing Graphon implementation, but improves parallel output collection by falling back to the selected child node's emitted outputs when the child variable pool does not expose the selected output yet.

This keeps sequential iteration behavior unchanged and only affects the parallel iteration output collection path.

## Changes

- Add `DifyIterationNode`, a Dify workflow-layer wrapper for Graphon's `IterationNode`
- Route iteration node creation through `DifyIterationNode`
- Preserve normal variable-pool output lookup as the first choice
- Fall back to the selected child node's emitted `NodeRunSucceededEvent` output when the variable pool lookup returns `None`
- Support nested output selectors when reading from emitted child node outputs
- Add regression coverage for parallel iterations returning actual child output instead of `[null]`

## Tests

- `python -m py_compile api/core/workflow/nodes/iteration/__init__.py api/core/workflow/nodes/iteration/node.py api/core/workflow/node_factory.py api/tests/unit_tests/core/workflow/nodes/iteration/test_iteration_parallel_outputs.py`
- `git diff --check`
- `.\.venv\Scripts\pytest.exe -o addopts='' tests/unit_tests/core/workflow/nodes/iteration/test_iteration_parallel_outputs.py tests/unit_tests/core/workflow/nodes/iteration/test_iteration_child_engine_errors.py`
- `.\.venv\Scripts\pytest.exe -o addopts='' tests/unit_tests/core/workflow/test_node_factory.py tests/unit_tests/core/workflow/test_node_mapping_bootstrap.py`

Fixes #36158