### PR TITLE
test: stabilize modal context pricing test

### DIFF
--- a/web/context/modal-context.test.tsx
+++ b/web/context/modal-context.test.tsx
@@ -18,6 +18,10 @@ vi.mock('@/next/navigation', () => ({
   useSearchParams: vi.fn(() => new URLSearchParams()),
 }))
 
+vi.mock('@/app/components/billing/pricing', () => ({
+  default: () => <div>billing.plansCommon.mostPopular</div>,
+}))
+
 const mockUseProviderContext = vi.fn()
 vi.mock('@/context/provider-context', () => ({
   useProviderContext: () => mockUseProviderContext(),


### PR DESCRIPTION
## Summary

Fixes #36523

Mock the lazy-loaded billing `Pricing` component in `modal-context.test.tsx` so the provider test verifies the modal transition without racing the full pricing page dynamic import.

Validation:

- `pnpm -C web test context/modal-context.test.tsx --run`
- `pnpm -C web exec eslint context/modal-context.test.tsx --quiet`

## Screenshots

N/A

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
