### PR TITLE
fix: preserve float type for NUMBER variables when value is integer

### DIFF
--- a/api/factories/variable_factory.py
+++ b/api/factories/variable_factory.py
@@ -82,7 +82,15 @@ def _build_variable_from_mapping(*, mapping: Mapping[str, Any], selector: Sequen
             result = StringVariable.model_validate(mapping)
         case SegmentType.SECRET:
             result = SecretVariable.model_validate(mapping)
-        case SegmentType.NUMBER | SegmentType.INTEGER if isinstance(value, int):
+        case SegmentType.NUMBER if isinstance(value, int):
+            # Preserve float type for NUMBER variables even when the Python value is an int
+            # (e.g. 0 instead of 0.0). This prevents "not supported value type integer"
+            # errors on subsequent conversation turns when the variable was declared as NUMBER.
+            mapping = dict(mapping)
+            mapping["value"] = float(value)
+            mapping["value_type"] = SegmentType.FLOAT
+            result = FloatVariable.model_validate(mapping)
+        case SegmentType.INTEGER if isinstance(value, int):
             mapping = dict(mapping)
             mapping["value_type"] = SegmentType.INTEGER
             result = IntegerVariable.model_validate(mapping)


### PR DESCRIPTION
Closes #36346

## What this PR does

When a ChatFlow conversation variable is declared as NUMBER type with a float value (0.0), it gets stored correctly as FloatVariable. But when the value later becomes an integer (0), the match statement converted it to IntegerVariable, changing the type. On the next conversation turn, this caused 'not supported value type integer because cannot init a float var' error.

## Root cause

In `_build_variable_from_mapping`, the match case:
```python
case SegmentType.NUMBER | SegmentType.INTEGER if isinstance(value, int):
    mapping["value_type"] = SegmentType.INTEGER
    result = IntegerVariable.model_validate(mapping)
```

This incorrectly treated NUMBER and INTEGER the same when the Python value was int, overriding the declared value_type from NUMBER to INTEGER.

## Fix

Split the match case into two:
- When `value_type` is `SegmentType.NUMBER` and value is int: convert int to float and create `FloatVariable`, preserving the original declared type
- When `value_type` is `SegmentType.INTEGER` and value is int: create `IntegerVariable` as before