### PR TITLE
refactor: convert isinstance chains to match/case in otel parser

### DIFF
--- a/api/extensions/otel/parser/base.py
+++ b/api/extensions/otel/parser/base.py
@@ -53,25 +53,27 @@ def safe_json_dumps(obj: Any, ensure_ascii: bool = False) -> str:
 
     def _convert_value(value: Any) -> Any:
         """Recursively convert non-serializable values."""
-        if value is None:
-            return None
-        if isinstance(value, (bool, int, float, str)):
-            return value
-        if isinstance(value, Segment):
-            # Convert Segment to its underlying value
-            return _convert_value(value.value)
-        if isinstance(value, File):
-            # Convert File to dict
-            return value.to_dict()
-        if isinstance(value, BaseModel):
-            # Convert Pydantic model to dict
-            return _convert_value(value.model_dump(mode="json"))
-        if isinstance(value, dict):
-            return {k: _convert_value(v) for k, v in value.items()}
-        if isinstance(value, (list, tuple)):
-            return [_convert_value(item) for item in value]
-        # Fallback to string representation for unknown types
-        return str(value)
+        match value:
+            case None:
+                return None
+            case bool() | int() | float() | str():
+                return value
+            case Segment():
+                # Convert Segment to its underlying value
+                return _convert_value(value.value)
+            case File():
+                # Convert File to dict
+                return value.to_dict()
+            case BaseModel():
+                # Convert Pydantic model to dict
+                return _convert_value(value.model_dump(mode="json"))
+            case dict():
+                return {k: _convert_value(v) for k, v in value.items()}
+            case list() | tuple():
+                return [_convert_value(item) for item in value]
+            case _:
+                # Fallback to string representation for unknown types
+                return str(value)
 
     try:
         converted = _convert_value(obj)
@@ -104,15 +106,15 @@ class DefaultNodeOTelParser:
 
         span.set_attribute(GenAIAttributes.FRAMEWORK, "dify")
 
-        node_type = node.node_type
-        if node_type == BuiltinNodeTypes.LLM:
-            span.set_attribute(GenAIAttributes.SPAN_KIND, "LLM")
-        elif node_type == BuiltinNodeTypes.KNOWLEDGE_RETRIEVAL:
-            span.set_attribute(GenAIAttributes.SPAN_KIND, "RETRIEVER")
-        elif node_type == BuiltinNodeTypes.TOOL:
-            span.set_attribute(GenAIAttributes.SPAN_KIND, "TOOL")
-        else:
-            span.set_attribute(GenAIAttributes.SPAN_KIND, "TASK")
+        match node.node_type:
+            case BuiltinNodeTypes.LLM:
+                span.set_attribute(GenAIAttributes.SPAN_KIND, "LLM")
+            case BuiltinNodeTypes.KNOWLEDGE_RETRIEVAL:
+                span.set_attribute(GenAIAttributes.SPAN_KIND, "RETRIEVER")
+            case BuiltinNodeTypes.TOOL:
+                span.set_attribute(GenAIAttributes.SPAN_KIND, "TOOL")
+            case _:
+                span.set_attribute(GenAIAttributes.SPAN_KIND, "TASK")
 
         # Extract inputs and outputs from result_event
         if result_event and result_event.node_run_result:


### PR DESCRIPTION
### Self Checks

- [x] I have read the [Contributing Guide](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md) and [Language Policy](https://github.com/langgenius/dify/issues/1542).
- [x] This is only for refactors or chores; if you would like to ask a question, please head to [Discussions](https://github.com/langgenius/dify/discussions/categories/general).
- [x] I have searched for existing issues [search for existing issues](https://github.com/langgenius/dify/issues), including closed ones.
- [x] I confirm that I am using English to submit this report, otherwise it will be closed.
- [x] 【中文用户 & Non English User】请使用英语提交，否则会被关闭 ：）
- [x] Please do not modify this template :) and fill in all the required fields.

### Description

This PR converts the remaining `isinstance` chains in `api/extensions/otel/parser/base.py` to `match/case` syntax, following the scope of #35902.

Changes:
1. `_convert_value()` in `safe_json_dumps()`: replaced 7 `if isinstance(...)` branches with a single `match/case` block
2. `DefaultNodeOTelParser.parse()`: replaced `if/elif` node_type equality checks with `match/case`

### Motivation

1. Prevents missing branches — `match/case` makes it clear when a type is unhandled
2. Better semantic meaning — pattern matching conveys intent more clearly than isinstance chains

This file was not covered by the previously merged PR #35922.