### PR TITLE
chore(web): remove redundant body select-auto

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -55,7 +55,7 @@ const LocaleLayout = async ({
         <ReactScanLoader />
       </head>
       <body
-        className="h-full select-auto"
+        className="h-full"
         {...datasetMap}
       >
         <div className="isolate h-full">


### PR DESCRIPTION
## Summary
- Remove the redundant `select-auto` class from the root `body` element.
- Keep `h-full` intact for the root height chain.

Fixes #36552