### PR TITLE
chore(web): remove select-auto in body

### DIFF
--- a/web/app/components/__tests__/create-app-attribution-bootstrap.spec.tsx
+++ b/web/app/components/__tests__/create-app-attribution-bootstrap.spec.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement, ReactNode } from 'react'
+import type { ReactElement } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { runCreateAppAttributionBootstrap } from '@/utils/create-app-tracking'
 
@@ -28,14 +28,7 @@ vi.mock('@/next/headers', () => ({
 
 const loadComponent = async () => {
   const mod = await import('../create-app-attribution-bootstrap')
-  const rawExport = mod.default as unknown
-  const renderer: (() => Promise<ReactNode>) | undefined
-    = typeof rawExport === 'function' ? rawExport as () => Promise<ReactNode> : (rawExport as { type?: () => Promise<ReactNode> }).type
-
-  if (!renderer)
-    throw new Error('CreateAppAttributionBootstrap component is not callable in tests')
-
-  return renderer
+  return mod.CreateAppAttributionBootstrap
 }
 
 const runBootstrapScript = () => {

--- a/web/app/components/create-app-attribution-bootstrap.tsx
+++ b/web/app/components/create-app-attribution-bootstrap.tsx
@@ -1,23 +1,17 @@
-import { memo } from 'react'
 import { IS_PROD } from '@/config'
 import { headers } from '@/next/headers'
 import Script from '@/next/script'
 import { buildCreateAppAttributionBootstrapScript } from '@/utils/create-app-tracking'
 
-const CreateAppAttributionBootstrap = async () => {
-  const nonce = IS_PROD ? (await headers()).get('x-nonce') ?? '' : ''
-  /* v8 ignore next -- `nonce` is always a string (`''` or header value), so nullish fallback is unreachable in runtime. @preserve */
-  const scriptNonce = nonce ?? undefined
-
+export async function CreateAppAttributionBootstrap() {
+  const nonce = IS_PROD ? (await headers()).get('x-nonce') ?? undefined : undefined
   return (
     <Script
       id="create-app-attribution-bootstrap"
       strategy="beforeInteractive"
-      nonce={scriptNonce}
+      nonce={nonce}
     >
       {buildCreateAppAttributionBootstrapScript()}
     </Script>
   )
 }
-
-export default memo(CreateAppAttributionBootstrap)

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -10,7 +10,7 @@ import { getDatasetMap } from '@/env'
 import { getLocaleOnServer } from '@/i18n-config/server'
 import { headers } from '@/next/headers'
 import PartnerStackCookieRecorder from './components/billing/partner-stack/cookie-recorder'
-import CreateAppAttributionBootstrap from './components/create-app-attribution-bootstrap'
+import { CreateAppAttributionBootstrap } from './components/create-app-attribution-bootstrap'
 import { AgentationLoader } from './components/devtools/agentation-loader'
 import { ReactScanLoader } from './components/devtools/react-scan/loader'
 import { I18nServerProvider } from './components/provider/i18n-server'
@@ -51,11 +51,10 @@ const LocaleLayout = async ({
         <meta name="msapplication-config" content="/browserconfig.xml" />
 
         <CreateAppAttributionBootstrap />
-        {/* <ReactGrabLoader /> */}
         <ReactScanLoader />
       </head>
       <body
-        className="h-full select-auto"
+        className="h-full"
         {...datasetMap}
       >
         <div className="isolate h-full">


### PR DESCRIPTION
## Summary
- Remove the redundant `select-auto` class from the root `body` element.
- Simplify the create app attribution bootstrap component export and nonce handling.

Fixes #36552