### PR TITLE
fix: populate sign_content in hit-testing responses

### DIFF
--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -57,6 +57,14 @@ class HitTestingService:
     @classmethod
     def _dump_retrieval_records(cls, records: list[Any]) -> list[dict[str, Any]]:
         dumped_records = [record.model_dump() for record in records]
+        # Pydantic's model_dump() only introspects mapped DB columns and never
+        # evaluates @property decorators.  The Segment.sign_content property
+        # generates time-limited signed URLs for embedded file previews, so we
+        # must populate it explicitly after the dump.
+        for record, dumped in zip(records, dumped_records):
+            segment = dumped.get("segment")
+            if segment is not None and isinstance(segment, dict) and hasattr(record.segment, "sign_content"):
+                segment["sign_content"] = record.segment.sign_content
         document_ids = {
             segment.get("document_id")
             for record in dumped_records

--- a/api/tests/unit_tests/services/test_hit_testing_service_dump_records.py
+++ b/api/tests/unit_tests/services/test_hit_testing_service_dump_records.py
@@ -6,6 +6,9 @@ from services.hit_testing_service import HitTestingService
 def _retrieval_record(payload: dict):
     record = Mock()
     record.model_dump.return_value = payload
+    # Align the mock's .segment attribute with the dumped payload so that
+    # _dump_retrieval_records can safely inspect it for @property values.
+    record.segment = payload.get("segment")
     return record
 
 
@@ -86,3 +89,31 @@ class TestHitTestingServiceDumpRecords:
 
         assert result == []
         assert "Skipping hit-testing records with missing documents" in caplog.text
+
+    def test_dump_retrieval_records_populates_sign_content_from_property(self):
+        """sign_content is a @property on the Segment model that generates
+        signed URLs for embedded file previews.  Pydantic's model_dump() only
+        sees mapped columns, so _dump_retrieval_records must explicitly copy
+        the property value into the dumped dict."""
+        segment_mock = Mock()
+        segment_mock.sign_content = "signed preview content"
+        record = Mock()
+        record.segment = segment_mock
+        record.model_dump.return_value = {
+            "segment": {"id": "seg-1", "content": "![img](/files/abc/file-preview)", "sign_content": None},
+            "score": 0.9,
+        }
+
+        result = HitTestingService._dump_retrieval_records([record])
+
+        assert result[0]["segment"]["sign_content"] == "signed preview content"
+
+    def test_dump_retrieval_records_preserves_sign_content_when_no_segment(self):
+        """Records without a segment should pass through unchanged."""
+        record = Mock()
+        record.segment = None
+        record.model_dump.return_value = {"segment": None, "score": 0.8}
+
+        result = HitTestingService._dump_retrieval_records([record])
+
+        assert result == [{"segment": None, "score": 0.8}]


### PR DESCRIPTION
## Problem

Hit-testing responses return `segment.sign_content: null` while the segment list endpoint correctly returns signed URLs for embedded file previews.

**Root cause:** `_dump_retrieval_records()` uses Pydantic's `model_dump()` to serialize `RetrievalSegments` objects. Pydantic only introspects mapped DB columns and never evaluates `@property` decorators. The `Segment.sign_content` property generates time-limited signed URLs, so it silently becomes `null` after serialization.

## Fix

Explicitly copy the `sign_content` property value into the dumped dict after `model_dump()`, guarded by `hasattr()` to avoid breaking records where segment is already a plain dict (e.g., in tests or external retrieval).

## Testing

- Added `test_dump_retrieval_records_populates_sign_content_from_property` — verifies sign_content is populated from the @property
- Added `test_dump_retrieval_records_preserves_sign_content_when_no_segment` — verifies records without segments pass through unchanged
- All existing tests pass (25/25)

Fixes #36532