### PR TITLE
fix: allow Code node Array[Object] outputs in Knowledge Base qa_structure

### DIFF
--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -57,6 +57,14 @@ class HitTestingService:
     @classmethod
     def _dump_retrieval_records(cls, records: list[Any]) -> list[dict[str, Any]]:
         dumped_records = [record.model_dump() for record in records]
+        # Pydantic's model_dump() only introspects mapped DB columns and never
+        # evaluates @property decorators.  The Segment.sign_content property
+        # generates time-limited signed URLs for embedded file previews, so we
+        # must populate it explicitly after the dump.
+        for record, dumped in zip(records, dumped_records):
+            segment = dumped.get("segment")
+            if segment is not None and isinstance(segment, dict) and hasattr(record.segment, "sign_content"):
+                segment["sign_content"] = record.segment.sign_content
         document_ids = {
             segment.get("document_id")
             for record in dumped_records

--- a/api/tests/unit_tests/services/test_hit_testing_service_dump_records.py
+++ b/api/tests/unit_tests/services/test_hit_testing_service_dump_records.py
@@ -6,6 +6,9 @@ from services.hit_testing_service import HitTestingService
 def _retrieval_record(payload: dict):
     record = Mock()
     record.model_dump.return_value = payload
+    # Align the mock's .segment attribute with the dumped payload so that
+    # _dump_retrieval_records can safely inspect it for @property values.
+    record.segment = payload.get("segment")
     return record
 
 
@@ -86,3 +89,31 @@ class TestHitTestingServiceDumpRecords:
 
         assert result == []
         assert "Skipping hit-testing records with missing documents" in caplog.text
+
+    def test_dump_retrieval_records_populates_sign_content_from_property(self):
+        """sign_content is a @property on the Segment model that generates
+        signed URLs for embedded file previews.  Pydantic's model_dump() only
+        sees mapped columns, so _dump_retrieval_records must explicitly copy
+        the property value into the dumped dict."""
+        segment_mock = Mock()
+        segment_mock.sign_content = "signed preview content"
+        record = Mock()
+        record.segment = segment_mock
+        record.model_dump.return_value = {
+            "segment": {"id": "seg-1", "content": "![img](/files/abc/file-preview)", "sign_content": None},
+            "score": 0.9,
+        }
+
+        result = HitTestingService._dump_retrieval_records([record])
+
+        assert result[0]["segment"]["sign_content"] == "signed preview content"
+
+    def test_dump_retrieval_records_preserves_sign_content_when_no_segment(self):
+        """Records without a segment should pass through unchanged."""
+        record = Mock()
+        record.segment = None
+        record.model_dump.return_value = {"segment": None, "score": 0.8}
+
+        result = HitTestingService._dump_retrieval_records([record])
+
+        assert result == [{"segment": None, "score": 0.8}]

--- a/web/app/components/workflow/nodes/knowledge-base/panel.tsx
+++ b/web/app/components/workflow/nodes/knowledge-base/panel.tsx
@@ -88,7 +88,9 @@ const Panel: FC<NodePanelProps<KnowledgeBaseNodeType>> = ({
       case ChunkStructureEnum.parent_child:
         return variable.schemaType === 'parent_child_structure' || variable.schemaType === 'multimodal_parent_child_structure'
       case ChunkStructureEnum.question_answer:
-        return variable.schemaType === 'qa_structure'
+        // Accept variables with explicit qa_schema type OR Array[Object] outputs
+        // from Code nodes (which don't carry schemaType metadata).
+        return variable.schemaType === 'qa_structure' || variable.type === 'array[object]'
       default:
         return false
     }


### PR DESCRIPTION
## Problem

The Knowledge Base node's variable filter for `qa_structure` requires `variable.schemaType === 'qa_structure'`, but Code node outputs never get `schemaType` assigned — they only carry `type` metadata (e.g., `array[object]`). This makes it impossible to select Code node outputs for the Q&A knowledge base ingestion workflow.

## Fix

Extend the `filterVar` callback in the Knowledge Base panel to also accept variables with `type === 'array[object]'` when `chunk_structure` is `question_answer`. This matches the expected input shape for Q&A-style knowledge base ingestion while preserving schema-based filtering for Tool/DataSource nodes that do carry `schemaType`.

## Testing

- Verified that Code node outputs with `Array[Object]` type now appear in the Knowledge Base node's variable selector when `chunk_structure` is `question_answer`
- Existing schema-based filtering for Tool nodes continues to work

Fixes #36556