### PR TITLE
fix: External retrieval model response rejects empty score threshold bug

### DIFF
--- a/api/fields/dataset_fields.py
+++ b/api/fields/dataset_fields.py
@@ -200,7 +200,7 @@ class DatasetExternalKnowledgeInfoResponse(ResponseModel):
 
 class DatasetExternalRetrievalModelResponse(ResponseModel):
     top_k: int
-    score_threshold: float
+    score_threshold: float | None = None
     score_threshold_enabled: bool | None = None
 
 

--- a/api/openapi/markdown/console-swagger.md
+++ b/api/openapi/markdown/console-swagger.md
@@ -11799,7 +11799,7 @@ Condition detail
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| score_threshold | number |  | Yes |
+| score_threshold | number |  | No |
 | score_threshold_enabled | boolean |  | No |
 | top_k | integer |  | Yes |
 

--- a/api/openapi/markdown/service-swagger.md
+++ b/api/openapi/markdown/service-swagger.md
@@ -2421,7 +2421,7 @@ Condition detail
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| score_threshold | number |  | Yes |
+| score_threshold | number |  | No |
 | score_threshold_enabled | boolean |  | No |
 | top_k | integer |  | Yes |
 

--- a/packages/contracts/generated/api/console/datasets/types.gen.ts
+++ b/packages/contracts/generated/api/console/datasets/types.gen.ts
@@ -504,7 +504,7 @@ export type DatasetExternalKnowledgeInfoResponse = {
 }
 
 export type DatasetExternalRetrievalModelResponse = {
-  score_threshold: number
+  score_threshold?: number | null
   score_threshold_enabled?: boolean | null
   top_k: number
 }

--- a/packages/contracts/generated/api/console/datasets/zod.gen.ts
+++ b/packages/contracts/generated/api/console/datasets/zod.gen.ts
@@ -317,7 +317,7 @@ export const zDatasetExternalKnowledgeInfoResponse = z.object({
  * DatasetExternalRetrievalModelResponse
  */
 export const zDatasetExternalRetrievalModelResponse = z.object({
-  score_threshold: z.number(),
+  score_threshold: z.number().nullish(),
   score_threshold_enabled: z.boolean().nullish(),
   top_k: z.int(),
 })

--- a/packages/contracts/generated/api/service/types.gen.ts
+++ b/packages/contracts/generated/api/service/types.gen.ts
@@ -258,7 +258,7 @@ export type DatasetExternalKnowledgeInfoResponse = {
 }
 
 export type DatasetExternalRetrievalModelResponse = {
-  score_threshold: number
+  score_threshold?: number | null
   score_threshold_enabled?: boolean | null
   top_k: number
 }

--- a/packages/contracts/generated/api/service/zod.gen.ts
+++ b/packages/contracts/generated/api/service/zod.gen.ts
@@ -227,7 +227,7 @@ export const zDatasetExternalKnowledgeInfoResponse = z.object({
  * DatasetExternalRetrievalModelResponse
  */
 export const zDatasetExternalRetrievalModelResponse = z.object({
-  score_threshold: z.number(),
+  score_threshold: z.number().nullish(),
   score_threshold_enabled: z.boolean().nullish(),
   top_k: z.int(),
 })


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

close #36575 

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
