### PR TITLE
fix: guard against null icon_info in dataset navigation

### DIFF
--- a/web/app/components/header/dataset-nav/index.tsx
+++ b/web/app/components/header/dataset-nav/index.tsx
@@ -36,10 +36,10 @@ const DatasetNav = () => {
     return {
       id: currentDataset.id,
       name: currentDataset.name,
-      icon: currentDataset.icon_info.icon,
-      icon_type: currentDataset.icon_info.icon_type,
-      icon_background: currentDataset.icon_info.icon_background,
-      icon_url: currentDataset.icon_info.icon_url,
+      icon: currentDataset.icon_info?.icon ?? '',
+      icon_type: currentDataset.icon_info?.icon_type ?? 'emoji',
+      icon_background: currentDataset.icon_info?.icon_background ?? '',
+      icon_url: currentDataset.icon_info?.icon_url ?? '',
     } as Omit<NavItem, 'link'>
   }, [currentDataset?.id, currentDataset?.name, currentDataset?.icon_info])
 
@@ -60,10 +60,10 @@ const DatasetNav = () => {
         id: dataset.id,
         name: dataset.name,
         link,
-        icon: dataset.icon_info.icon,
-        icon_type: dataset.icon_info.icon_type,
-        icon_background: dataset.icon_info.icon_background,
-        icon_url: dataset.icon_info.icon_url,
+        icon: dataset.icon_info?.icon ?? '',
+        icon_type: dataset.icon_info?.icon_type ?? 'emoji',
+        icon_background: dataset.icon_info?.icon_background ?? '',
+        icon_url: dataset.icon_info?.icon_url ?? '',
       }
     }) as NavItem[]
   }, [datasetItems, getDatasetLink])

--- a/web/models/datasets.ts
+++ b/web/models/datasets.ts
@@ -53,7 +53,7 @@ export type DataSet = {
   id: string
   name: string
   indexing_status: DocumentIndexingStatus
-  icon_info: IconInfo
+  icon_info: IconInfo | null
   description: string
   permission: DatasetPermission
   data_source_type: DataSourceType


### PR DESCRIPTION
## Problem

The `DatasetNav` component on the `/apps` page accesses `dataset.icon_info.icon` (and `.icon_type`, `.icon_background`, `.icon_url`) without null guards. When a dataset has `icon_info` set to `null` (which the API can return despite the TypeScript type declaring it non-optional), the page crashes with:

```
TypeError: Cannot read properties of null (reading 'icon')
```

## Fix

- Add optional chaining (`?.`) with sensible defaults at both access sites (`curNav` and `navigationItems` in `dataset-nav/index.tsx`)
- Update the `DataSet` type in `models/datasets.ts` to allow `null` for `icon_info`

This matches the pattern already used in `knowledge-retrieval/node.tsx` which correctly handles null `icon_info` with a fallback.

Fixes #36574