### PR TITLE
fix: make score_threshold optional in external retrieval model response

### DIFF
--- a/api/fields/dataset_fields.py
+++ b/api/fields/dataset_fields.py
@@ -200,7 +200,7 @@ class DatasetExternalKnowledgeInfoResponse(ResponseModel):
 
 class DatasetExternalRetrievalModelResponse(ResponseModel):
     top_k: int
-    score_threshold: float
+    score_threshold: float | None = None
     score_threshold_enabled: bool | None = None
 
 

--- a/api/openapi/markdown/console-swagger.md
+++ b/api/openapi/markdown/console-swagger.md
@@ -11799,7 +11799,7 @@ Condition detail
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| score_threshold | number |  | Yes |
+| score_threshold | number |  | No |
 | score_threshold_enabled | boolean |  | No |
 | top_k | integer |  | Yes |
 

--- a/api/openapi/markdown/service-swagger.md
+++ b/api/openapi/markdown/service-swagger.md
@@ -2421,7 +2421,7 @@ Condition detail
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| score_threshold | number |  | Yes |
+| score_threshold | number |  | No |
 | score_threshold_enabled | boolean |  | No |
 | top_k | integer |  | Yes |
 

--- a/packages/contracts/generated/api/console/datasets/types.gen.ts
+++ b/packages/contracts/generated/api/console/datasets/types.gen.ts
@@ -504,7 +504,7 @@ export type DatasetExternalKnowledgeInfoResponse = {
 }
 
 export type DatasetExternalRetrievalModelResponse = {
-  score_threshold: number
+  score_threshold?: number | null
   score_threshold_enabled?: boolean | null
   top_k: number
 }

--- a/packages/contracts/generated/api/console/datasets/zod.gen.ts
+++ b/packages/contracts/generated/api/console/datasets/zod.gen.ts
@@ -317,7 +317,7 @@ export const zDatasetExternalKnowledgeInfoResponse = z.object({
  * DatasetExternalRetrievalModelResponse
  */
 export const zDatasetExternalRetrievalModelResponse = z.object({
-  score_threshold: z.number(),
+  score_threshold: z.number().nullish(),
   score_threshold_enabled: z.boolean().nullish(),
   top_k: z.int(),
 })

--- a/packages/contracts/generated/api/service/types.gen.ts
+++ b/packages/contracts/generated/api/service/types.gen.ts
@@ -258,7 +258,7 @@ export type DatasetExternalKnowledgeInfoResponse = {
 }
 
 export type DatasetExternalRetrievalModelResponse = {
-  score_threshold: number
+  score_threshold?: number | null
   score_threshold_enabled?: boolean | null
   top_k: number
 }

--- a/packages/contracts/generated/api/service/zod.gen.ts
+++ b/packages/contracts/generated/api/service/zod.gen.ts
@@ -227,7 +227,7 @@ export const zDatasetExternalKnowledgeInfoResponse = z.object({
  * DatasetExternalRetrievalModelResponse
  */
 export const zDatasetExternalRetrievalModelResponse = z.object({
-  score_threshold: z.number(),
+  score_threshold: z.number().nullish(),
   score_threshold_enabled: z.boolean().nullish(),
   top_k: z.int(),
 })

--- a/web/app/components/header/dataset-nav/index.tsx
+++ b/web/app/components/header/dataset-nav/index.tsx
@@ -36,10 +36,10 @@ const DatasetNav = () => {
     return {
       id: currentDataset.id,
       name: currentDataset.name,
-      icon: currentDataset.icon_info.icon,
-      icon_type: currentDataset.icon_info.icon_type,
-      icon_background: currentDataset.icon_info.icon_background,
-      icon_url: currentDataset.icon_info.icon_url,
+      icon: currentDataset.icon_info?.icon ?? '',
+      icon_type: currentDataset.icon_info?.icon_type ?? 'emoji',
+      icon_background: currentDataset.icon_info?.icon_background ?? '',
+      icon_url: currentDataset.icon_info?.icon_url ?? '',
     } as Omit<NavItem, 'link'>
   }, [currentDataset?.id, currentDataset?.name, currentDataset?.icon_info])
 
@@ -60,10 +60,10 @@ const DatasetNav = () => {
         id: dataset.id,
         name: dataset.name,
         link,
-        icon: dataset.icon_info.icon,
-        icon_type: dataset.icon_info.icon_type,
-        icon_background: dataset.icon_info.icon_background,
-        icon_url: dataset.icon_info.icon_url,
+        icon: dataset.icon_info?.icon ?? '',
+        icon_type: dataset.icon_info?.icon_type ?? 'emoji',
+        icon_background: dataset.icon_info?.icon_background ?? '',
+        icon_url: dataset.icon_info?.icon_url ?? '',
       }
     }) as NavItem[]
   }, [datasetItems, getDatasetLink])

--- a/web/models/datasets.ts
+++ b/web/models/datasets.ts
@@ -53,7 +53,7 @@ export type DataSet = {
   id: string
   name: string
   indexing_status: DocumentIndexingStatus
-  icon_info: IconInfo
+  icon_info: IconInfo | null
   description: string
   permission: DatasetPermission
   data_source_type: DataSourceType


### PR DESCRIPTION
## Problem

`DatasetExternalRetrievalModelResponse` defines `score_threshold` as a required `float`, but external knowledge datasets may not provide a numeric score threshold. This causes Pydantic validation errors when the API serializes responses for external retrieval datasets.

Note the inconsistency: `score_threshold_enabled` (line 204) is already optional (`bool | None = None`), but `score_threshold` itself is not. The non-external counterpart `DatasetRetrievalModelResponse` already correctly makes `score_threshold` optional.

## Fix

Change `score_threshold: float` to `score_threshold: float | None = None` in `DatasetExternalRetrievalModelResponse`, matching the pattern used by `DatasetRetrievalModelResponse`.

Fixes #36575