### PR TITLE
fix: prevent apps page crash when dataset icon_info is null (#36574)

### DIFF
--- a/web/app/components/header/dataset-nav/index.tsx
+++ b/web/app/components/header/dataset-nav/index.tsx
@@ -36,10 +36,10 @@ const DatasetNav = () => {
     return {
       id: currentDataset.id,
       name: currentDataset.name,
-      icon: currentDataset.icon_info.icon,
-      icon_type: currentDataset.icon_info.icon_type,
-      icon_background: currentDataset.icon_info.icon_background,
-      icon_url: currentDataset.icon_info.icon_url,
+      icon: currentDataset.icon_info?.icon,
+      icon_type: currentDataset.icon_info?.icon_type,
+      icon_background: currentDataset.icon_info?.icon_background,
+      icon_url: currentDataset.icon_info?.icon_url,
     } as Omit<NavItem, 'link'>
   }, [currentDataset?.id, currentDataset?.name, currentDataset?.icon_info])
 
@@ -60,10 +60,10 @@ const DatasetNav = () => {
         id: dataset.id,
         name: dataset.name,
         link,
-        icon: dataset.icon_info.icon,
-        icon_type: dataset.icon_info.icon_type,
-        icon_background: dataset.icon_info.icon_background,
-        icon_url: dataset.icon_info.icon_url,
+        icon: dataset.icon_info?.icon,
+        icon_type: dataset.icon_info?.icon_type,
+        icon_background: dataset.icon_info?.icon_background,
+        icon_url: dataset.icon_info?.icon_url,
       }
     }) as NavItem[]
   }, [datasetItems, getDatasetLink])


### PR DESCRIPTION
## Problem

The apps page crashes with:
```
TypeError: Cannot read properties of null (reading 'icon')
```

When a dataset has `icon_info` set to `null` or missing icon fields, the dataset navigation component directly accesses `icon_info.icon`, `icon_info.icon_type`, etc. without null guards.

## Fix

Added optional chaining (`?.`) on all `icon_info` property accesses in `web/app/components/header/dataset-nav/index.tsx`:

```ts
// Before (crashes on null)
icon: currentDataset.icon_info.icon,
icon_type: currentDataset.icon_info.icon_type,

// After (graceful null handling)
icon: currentDataset.icon_info?.icon,
icon_type: currentDataset.icon_info?.icon_type,
```

Applied to both `currentNavItem` (line 39-42) and `navigationItems` (line 63-66).

## Testing

1. Create a dataset with `icon_info` set to `null` in the database
2. Navigate to `/apps`
3. Page should render without crashing
4. Datasets with missing icon metadata should use defaults

Fixes #36574
