### PR TITLE
fix: request /api/datasets raise exception

### DIFF
--- a/api/fields/dataset_fields.py
+++ b/api/fields/dataset_fields.py
@@ -162,9 +162,9 @@ class DatasetVectorSettingResponse(ResponseModel):
 
 
 class DatasetWeightedScoreResponse(ResponseModel):
-    weight_type: str | None
-    keyword_setting: DatasetKeywordSettingResponse | None
-    vector_setting: DatasetVectorSettingResponse | None
+    weight_type: str | None = None
+    keyword_setting: DatasetKeywordSettingResponse | None = None
+    vector_setting: DatasetVectorSettingResponse | None = None
 
 
 class DatasetRetrievalModelResponse(ResponseModel):

--- a/api/openapi/markdown/console-swagger.md
+++ b/api/openapi/markdown/console-swagger.md
@@ -12085,9 +12085,9 @@ Condition detail
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| keyword_setting | [DatasetKeywordSettingResponse](#datasetkeywordsettingresponse) |  | Yes |
-| vector_setting | [DatasetVectorSettingResponse](#datasetvectorsettingresponse) |  | Yes |
-| weight_type | string |  | Yes |
+| keyword_setting | [DatasetKeywordSettingResponse](#datasetkeywordsettingresponse) |  | No |
+| vector_setting | [DatasetVectorSettingResponse](#datasetvectorsettingresponse) |  | No |
+| weight_type | string |  | No |
 
 #### DatasourceCredentialDeletePayload
 

--- a/api/openapi/markdown/service-swagger.md
+++ b/api/openapi/markdown/service-swagger.md
@@ -2574,9 +2574,9 @@ Condition detail
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| keyword_setting | [DatasetKeywordSettingResponse](#datasetkeywordsettingresponse) |  | Yes |
-| vector_setting | [DatasetVectorSettingResponse](#datasetvectorsettingresponse) |  | Yes |
-| weight_type | string |  | Yes |
+| keyword_setting | [DatasetKeywordSettingResponse](#datasetkeywordsettingresponse) |  | No |
+| vector_setting | [DatasetVectorSettingResponse](#datasetvectorsettingresponse) |  | No |
+| weight_type | string |  | No |
 
 #### DatasourceNodeRunPayload
 

--- a/api/tests/unit_tests/controllers/console/datasets/test_datasets.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_datasets.py
@@ -245,6 +245,55 @@ class TestDatasetList:
 
         assert status == 200
 
+    def test_get_allows_legacy_weighted_score_without_weight_type(self, app: Flask):
+        api = DatasetListApi()
+        method = unwrap(api.get)
+
+        current_user = self._mock_user()
+        datasets = [
+            make_dataset(
+                retrieval_model={
+                    "search_method": "hybrid_search",
+                    "reranking_enable": True,
+                    "reranking_mode": "weighted_score",
+                    "reranking_model": None,
+                    "weights": {
+                        "vector_setting": {
+                            "vector_weight": 0.7,
+                            "embedding_model_name": "text-embedding",
+                            "embedding_provider_name": "openai",
+                        },
+                        "keyword_setting": {"keyword_weight": 0.3},
+                    },
+                    "top_k": 3,
+                    "score_threshold_enabled": False,
+                    "score_threshold": 0.0,
+                }
+            )
+        ]
+
+        with app.test_request_context("/datasets"):
+            with (
+                patch(
+                    "controllers.console.datasets.datasets.current_account_with_tenant",
+                    return_value=(current_user, "tenant-1"),
+                ),
+                patch.object(
+                    DatasetService,
+                    "get_datasets",
+                    return_value=(datasets, 1),
+                ),
+                patch.object(
+                    ProviderManager,
+                    "get_configurations",
+                    return_value=MagicMock(get_models=lambda **_: []),
+                ),
+            ):
+                resp, status = method(api)
+
+        assert status == 200
+        assert resp["data"][0]["retrieval_model_dict"]["weights"]["weight_type"] is None
+
     def test_embedding_available_false(self, app: Flask):
         api = DatasetListApi()
         method = unwrap(api.get)

--- a/packages/contracts/generated/api/console/datasets/types.gen.ts
+++ b/packages/contracts/generated/api/console/datasets/types.gen.ts
@@ -709,9 +709,9 @@ export type DatasetRerankingModelResponse = {
 }
 
 export type DatasetWeightedScoreResponse = {
-  keyword_setting: DatasetKeywordSettingResponse
-  vector_setting: DatasetVectorSettingResponse
-  weight_type: string | null
+  keyword_setting?: DatasetKeywordSettingResponse
+  vector_setting?: DatasetVectorSettingResponse
+  weight_type?: string | null
 }
 
 export type DatasetRerankingModel = {

--- a/packages/contracts/generated/api/console/datasets/zod.gen.ts
+++ b/packages/contracts/generated/api/console/datasets/zod.gen.ts
@@ -670,9 +670,9 @@ export const zDatasetVectorSettingResponse = z.object({
  * DatasetWeightedScoreResponse
  */
 export const zDatasetWeightedScoreResponse = z.object({
-  keyword_setting: zDatasetKeywordSettingResponse,
-  vector_setting: zDatasetVectorSettingResponse,
-  weight_type: z.string().nullable(),
+  keyword_setting: zDatasetKeywordSettingResponse.optional(),
+  vector_setting: zDatasetVectorSettingResponse.optional(),
+  weight_type: z.string().nullish(),
 })
 
 /**

--- a/packages/contracts/generated/api/service/types.gen.ts
+++ b/packages/contracts/generated/api/service/types.gen.ts
@@ -377,9 +377,9 @@ export type DatasetVectorSettingResponse = {
 }
 
 export type DatasetWeightedScoreResponse = {
-  keyword_setting: DatasetKeywordSettingResponse
-  vector_setting: DatasetVectorSettingResponse
-  weight_type: string | null
+  keyword_setting?: DatasetKeywordSettingResponse
+  vector_setting?: DatasetVectorSettingResponse
+  weight_type?: string | null
 }
 
 export type DatasourceNodeRunPayload = {

--- a/packages/contracts/generated/api/service/zod.gen.ts
+++ b/packages/contracts/generated/api/service/zod.gen.ts
@@ -354,9 +354,9 @@ export const zDatasetVectorSettingResponse = z.object({
  * DatasetWeightedScoreResponse
  */
 export const zDatasetWeightedScoreResponse = z.object({
-  keyword_setting: zDatasetKeywordSettingResponse,
-  vector_setting: zDatasetVectorSettingResponse,
-  weight_type: z.string().nullable(),
+  keyword_setting: zDatasetKeywordSettingResponse.optional(),
+  vector_setting: zDatasetVectorSettingResponse.optional(),
+  weight_type: z.string().nullish(),
 })
 
 /**


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->
fix https://github.com/langgenius/dify/issues/36590

Root cause:
The dataset list/detail APIs were migrated from Flask-RESTX marshaling to Pydantic response models in #36480. In Pydantic, a field typed as `str | None` is still required unless it has a default value. Some existing dataset retrieval models have `retrieval_model.weights` with `vector_setting` and `keyword_setting`, but without `weight_type`. Flask-RESTX previously tolerated the missing field and serialized it as null, while the new Pydantic response validation rejected it with `Field required`.

Fix:
Make the weighted score response fields default to `None` so legacy retrieval model payloads remain response-compatible with the previous API behavior. Added a regression test covering dataset list serialization when `weights.weight_type` is missing.


## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
