### PR TITLE
fix: center align slider thumb

### DIFF
--- a/packages/dify-ui/src/slider/index.tsx
+++ b/packages/dify-ui/src/slider/index.tsx
@@ -149,7 +149,7 @@ export function Slider({
       step={step}
       disabled={disabled}
       name={name}
-      thumbAlignment="edge-client-only"
+      thumbAlignment="center"
       className={cn(sliderRootClassName, className)}
     >
       <SliderControl className={slotClassNames?.control}>


### PR DESCRIPTION
## Summary
- set the Dify UI slider thumb alignment to explicit center alignment

## Tests
- pnpm -C packages/dify-ui test src/slider/__tests__/index.spec.tsx
- pnpm -C packages/dify-ui type-check
- pnpm eslint --cache --fix packages/dify-ui/src/slider/index.tsx packages/dify-ui/src/slider/__tests__/index.spec.tsx
- pnpm -C packages/dify-ui test