### PR TITLE
fix: align explore installed app site icon

### DIFF
--- a/api/controllers/console/explore/installed_app.py
+++ b/api/controllers/console/explore/installed_app.py
@@ -8,7 +8,13 @@ from pydantic import BaseModel, Field, computed_field, field_validator
 from sqlalchemy import and_, select
 from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
-from controllers.common.fields import SimpleMessageResponse, SimpleResultMessageResponse
+from controllers.common.fields import (
+    SimpleMessageResponse,
+    SimpleResultMessageResponse,
+)
+from controllers.common.fields import (
+    Site as SiteResponse,
+)
 from controllers.common.schema import register_response_schema_models, register_schema_models
 from controllers.console import console_ns
 from controllers.console.explore.wraps import InstalledAppResource
@@ -56,6 +62,13 @@ def _safe_primitive(value: Any) -> Any:
     return None
 
 
+def _get_app_site(value: Any) -> Any | None:
+    site = getattr(value, "site", None)
+    if _safe_primitive(getattr(site, "title", None)) is None:
+        return None
+    return site
+
+
 class InstalledAppInfoResponse(ResponseModel):
     id: str
     name: str | None = None
@@ -83,6 +96,7 @@ class InstalledAppInfoResponse(ResponseModel):
 class InstalledAppResponse(ResponseModel):
     id: str
     app: InstalledAppInfoResponse
+    site: SiteResponse | None = None
     app_owner_tenant_id: str
     is_pinned: bool
     last_used_at: int | None = None
@@ -153,6 +167,7 @@ class InstalledAppsListApi(Resource):
             {
                 "id": installed_app.id,
                 "app": installed_app.app,
+                "site": _get_app_site(installed_app.app),
                 "app_owner_tenant_id": installed_app.app_owner_tenant_id,
                 "is_pinned": installed_app.is_pinned,
                 "last_used_at": installed_app.last_used_at,

--- a/api/openapi/markdown/console-swagger.md
+++ b/api/openapi/markdown/console-swagger.md
@@ -13072,6 +13072,7 @@ Request payload for bulk downloading documents as a zip archive.
 | id | string |  | Yes |
 | is_pinned | boolean |  | Yes |
 | last_used_at | integer |  | No |
+| site | [Site](#site) |  | No |
 | uninstallable | boolean |  | Yes |
 
 #### InstalledAppUpdatePayload
@@ -14454,28 +14455,19 @@ Form input definition.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| app_base_url | string |  | No |
 | chat_color_theme | string |  | No |
-| chat_color_theme_inverted | boolean |  | No |
-| code | string |  | No |
+| chat_color_theme_inverted | boolean |  | Yes |
 | copyright | string |  | No |
-| created_at | integer |  | No |
-| created_by | string |  | No |
 | custom_disclaimer | string |  | No |
-| customize_domain | string |  | No |
-| customize_token_strategy | string |  | No |
-| default_language | string |  | No |
+| default_language | string |  | Yes |
 | description | string |  | No |
 | icon | string |  | No |
 | icon_background | string |  | No |
-| icon_type |  |  | No |
+| icon_type | string |  | No |
 | privacy_policy | string |  | No |
-| prompt_public | boolean |  | No |
-| show_workflow_steps | boolean |  | No |
-| title | string |  | No |
-| updated_at | integer |  | No |
-| updated_by | string |  | No |
-| use_icon_as_answer_icon | boolean |  | No |
+| show_workflow_steps | boolean |  | Yes |
+| title | string |  | Yes |
+| use_icon_as_answer_icon | boolean |  | Yes |
 
 #### StatisticTimeRangeQuery
 

--- a/api/tests/unit_tests/controllers/console/explore/test_installed_app.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_installed_app.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -32,6 +33,7 @@ def installed_app():
     app = MagicMock()
     app.id = "ia1"
     app.app = MagicMock(id="a1")
+    app.app.site = None
     app.app_owner_tenant_id = "t2"
     app.is_pinned = False
     app.last_used_at = datetime(2024, 1, 1)
@@ -75,6 +77,55 @@ class TestInstalledAppsListApi:
         assert "installed_apps" in result
         assert result["installed_apps"][0]["editable"] is True
         assert result["installed_apps"][0]["uninstallable"] is False
+
+    def test_get_installed_apps_includes_site_config(self, app: Flask, current_user, tenant_id, installed_app):
+        api = module.InstalledAppsListApi()
+        method = unwrap(api.get)
+
+        installed_app.app.id = "a1"
+        installed_app.app.name = "App Name"
+        installed_app.app.mode = "chat"
+        installed_app.app.icon_type = "emoji"
+        installed_app.app.icon = "🤖"
+        installed_app.app.icon_background = "#FFFFFF"
+        installed_app.app.use_icon_as_answer_icon = False
+        installed_app.app.site = SimpleNamespace(
+            title="Web App",
+            chat_color_theme=None,
+            chat_color_theme_inverted=False,
+            icon_type="emoji",
+            icon="🚀",
+            icon_background="#D5F5F6",
+            description=None,
+            copyright="",
+            privacy_policy=None,
+            custom_disclaimer="",
+            default_language="en-US",
+            show_workflow_steps=True,
+            use_icon_as_answer_icon=True,
+        )
+
+        session = MagicMock()
+        session.scalars.return_value.all.return_value = [installed_app]
+
+        with (
+            app.test_request_context("/"),
+            patch.object(module, "current_account_with_tenant", return_value=(current_user, tenant_id)),
+            patch.object(module.db, "session", session),
+            patch.object(module.TenantService, "get_user_role", return_value="owner"),
+            patch.object(
+                module.FeatureService,
+                "get_system_features",
+                return_value=MagicMock(webapp_auth=MagicMock(enabled=False)),
+            ),
+        ):
+            result = method(api)
+
+        installed_app_result = result["installed_apps"][0]
+        assert installed_app_result["app"]["icon"] == "🤖"
+        assert installed_app_result["app"]["use_icon_as_answer_icon"] is False
+        assert installed_app_result["site"]["icon"] == "🚀"
+        assert installed_app_result["site"]["use_icon_as_answer_icon"] is True
 
     def test_get_installed_apps_with_app_id_filter(self, app: Flask, current_user, tenant_id):
         api = module.InstalledAppsListApi()

--- a/packages/contracts/generated/api/console/apps/types.gen.ts
+++ b/packages/contracts/generated/api/console/apps/types.gen.ts
@@ -921,28 +921,19 @@ export type DeletedTool = {
 }
 
 export type Site = {
-  app_base_url?: string | null
   chat_color_theme?: string | null
-  chat_color_theme_inverted?: boolean | null
-  code?: string | null
+  chat_color_theme_inverted: boolean
   copyright?: string | null
-  created_at?: number | null
-  created_by?: string | null
   custom_disclaimer?: string | null
-  customize_domain?: string | null
-  customize_token_strategy?: string | null
-  default_language?: string | null
+  default_language: string
   description?: string | null
   icon?: string | null
   icon_background?: string | null
-  icon_type?: unknown
+  icon_type?: string | null
   privacy_policy?: string | null
-  prompt_public?: boolean | null
-  show_workflow_steps?: boolean | null
-  title?: string | null
-  updated_at?: number | null
-  updated_by?: string | null
-  use_icon_as_answer_icon?: boolean | null
+  show_workflow_steps: boolean
+  title: string
+  use_icon_as_answer_icon: boolean
 }
 
 export type AdvancedChatWorkflowRunForListResponse = {

--- a/packages/contracts/generated/api/console/apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/apps/zod.gen.ts
@@ -705,28 +705,19 @@ export const zDeletedTool = z.object({
  * Site
  */
 export const zSite = z.object({
-  app_base_url: z.string().nullish(),
   chat_color_theme: z.string().nullish(),
-  chat_color_theme_inverted: z.boolean().nullish(),
-  code: z.string().nullish(),
+  chat_color_theme_inverted: z.boolean(),
   copyright: z.string().nullish(),
-  created_at: z.int().nullish(),
-  created_by: z.string().nullish(),
   custom_disclaimer: z.string().nullish(),
-  customize_domain: z.string().nullish(),
-  customize_token_strategy: z.string().nullish(),
-  default_language: z.string().nullish(),
+  default_language: z.string(),
   description: z.string().nullish(),
   icon: z.string().nullish(),
   icon_background: z.string().nullish(),
-  icon_type: z.unknown().optional(),
+  icon_type: z.string().nullish(),
   privacy_policy: z.string().nullish(),
-  prompt_public: z.boolean().nullish(),
-  show_workflow_steps: z.boolean().nullish(),
-  title: z.string().nullish(),
-  updated_at: z.int().nullish(),
-  updated_by: z.string().nullish(),
-  use_icon_as_answer_icon: z.boolean().nullish(),
+  show_workflow_steps: z.boolean(),
+  title: z.string(),
+  use_icon_as_answer_icon: z.boolean(),
 })
 
 /**

--- a/packages/contracts/generated/api/console/installed-apps/types.gen.ts
+++ b/packages/contracts/generated/api/console/installed-apps/types.gen.ts
@@ -94,6 +94,7 @@ export type InstalledAppResponse = {
   id: string
   is_pinned: boolean
   last_used_at?: number | null
+  site?: Site
   uninstallable: boolean
 }
 
@@ -105,6 +106,22 @@ export type InstalledAppInfoResponse = {
   mode?: string | null
   name?: string | null
   use_icon_as_answer_icon?: boolean | null
+}
+
+export type Site = {
+  chat_color_theme?: string | null
+  chat_color_theme_inverted: boolean
+  copyright?: string | null
+  custom_disclaimer?: string | null
+  default_language: string
+  description?: string | null
+  icon?: string | null
+  icon_background?: string | null
+  icon_type?: string | null
+  privacy_policy?: string | null
+  show_workflow_steps: boolean
+  title: string
+  use_icon_as_answer_icon: boolean
 }
 
 export type GetInstalledAppsData = {

--- a/packages/contracts/generated/api/console/installed-apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/installed-apps/zod.gen.ts
@@ -119,6 +119,25 @@ export const zInstalledAppInfoResponse = z.object({
 })
 
 /**
+ * Site
+ */
+export const zSite = z.object({
+  chat_color_theme: z.string().nullish(),
+  chat_color_theme_inverted: z.boolean(),
+  copyright: z.string().nullish(),
+  custom_disclaimer: z.string().nullish(),
+  default_language: z.string(),
+  description: z.string().nullish(),
+  icon: z.string().nullish(),
+  icon_background: z.string().nullish(),
+  icon_type: z.string().nullish(),
+  privacy_policy: z.string().nullish(),
+  show_workflow_steps: z.boolean(),
+  title: z.string(),
+  use_icon_as_answer_icon: z.boolean(),
+})
+
+/**
  * InstalledAppResponse
  */
 export const zInstalledAppResponse = z.object({
@@ -128,6 +147,7 @@ export const zInstalledAppResponse = z.object({
   id: z.string(),
   is_pinned: z.boolean(),
   last_used_at: z.int().nullish(),
+  site: zSite.optional(),
   uninstallable: z.boolean(),
 })
 

--- a/web/app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx
@@ -989,6 +989,15 @@ describe('useChatWithHistory', () => {
           icon_url: '',
           use_icon_as_answer_icon: false,
         },
+        site: {
+          title: 'Installed Web App',
+          icon_type: 'emoji',
+          icon: '🚀',
+          icon_background: '#D5F5F6',
+          icon_url: '',
+          show_workflow_steps: true,
+          use_icon_as_answer_icon: true,
+        },
       } as unknown as InstalledApp
       mockFetchConversations.mockResolvedValue(createConversationData())
       mockFetchChatList.mockResolvedValue({ data: [] })
@@ -999,7 +1008,9 @@ describe('useChatWithHistory', () => {
       // Assert
       expect(result!.current.isInstalledApp).toBe(true)
       expect(result!.current.appId).toBe('installed-app-id')
-      expect(result!.current.appData?.site.title).toBe('Installed App')
+      expect(result!.current.appData?.site.title).toBe('Installed Web App')
+      expect(result!.current.appData?.site.icon).toBe('🚀')
+      expect(result!.current.appData?.site.use_icon_as_answer_icon).toBe(true)
     })
   })
 

--- a/web/app/components/base/chat/chat-with-history/hooks.tsx
+++ b/web/app/components/base/chat/chat-with-history/hooks.tsx
@@ -82,19 +82,19 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
   })
   const appData = useMemo(() => {
     if (isInstalledApp) {
-      const { id, app } = installedAppInfo!
+      const { id, app, site } = installedAppInfo!
       return {
         app_id: id,
         site: {
-          title: app.name,
-          icon_type: app.icon_type,
-          icon: app.icon,
-          icon_background: app.icon_background,
-          icon_url: app.icon_url,
+          title: site?.title ?? app.name,
+          icon_type: site?.icon_type ?? app.icon_type,
+          icon: site?.icon ?? app.icon,
+          icon_background: site?.icon_background ?? app.icon_background,
+          icon_url: site?.icon_url ?? app.icon_url,
           prompt_public: false,
-          copyright: '',
-          show_workflow_steps: true,
-          use_icon_as_answer_icon: app.use_icon_as_answer_icon,
+          copyright: site?.copyright ?? '',
+          show_workflow_steps: site?.show_workflow_steps ?? true,
+          use_icon_as_answer_icon: site?.use_icon_as_answer_icon ?? app.use_icon_as_answer_icon,
         },
         plan: 'basic',
         custom_config: null,

--- a/web/app/components/explore/installed-app/__tests__/index.spec.tsx
+++ b/web/app/components/explore/installed-app/__tests__/index.spec.tsx
@@ -386,6 +386,41 @@ describe('InstalledApp', () => {
       })
     })
 
+    it('should update app info from site config when installed app includes site', async () => {
+      const installedAppWithSite = {
+        ...mockInstalledApp,
+        site: {
+          title: 'Published Web App',
+          icon_type: 'emoji' as const,
+          icon: '✨',
+          icon_background: '#D5F5F6',
+          icon_url: '',
+          copyright: 'Copyright',
+          show_workflow_steps: false,
+          use_icon_as_answer_icon: true,
+        },
+      }
+      setupMocks([installedAppWithSite])
+
+      render(<InstalledApp id="installed-app-123" />)
+
+      await waitFor(() => {
+        expect(mockUpdateAppInfo).toHaveBeenCalledWith(
+          expect.objectContaining({
+            app_id: 'installed-app-123',
+            site: expect.objectContaining({
+              title: 'Published Web App',
+              icon: '✨',
+              icon_background: '#D5F5F6',
+              copyright: 'Copyright',
+              show_workflow_steps: false,
+              use_icon_as_answer_icon: true,
+            }),
+          }),
+        )
+      })
+    })
+
     it('should update app info to null when installedApp is not found', async () => {
       setupMocks([])
 

--- a/web/app/components/explore/installed-app/index.tsx
+++ b/web/app/components/explore/installed-app/index.tsx
@@ -34,19 +34,19 @@ const InstalledApp = ({
       updateAppInfo(null)
     }
     else {
-      const { id, app } = installedApp
+      const { id, app, site } = installedApp
       updateAppInfo({
         app_id: id,
         site: {
-          title: app.name,
-          icon_type: app.icon_type,
-          icon: app.icon,
-          icon_background: app.icon_background,
-          icon_url: app.icon_url,
+          title: site?.title ?? app.name,
+          icon_type: site?.icon_type ?? app.icon_type,
+          icon: site?.icon ?? app.icon,
+          icon_background: site?.icon_background ?? app.icon_background,
+          icon_url: site?.icon_url ?? app.icon_url,
           prompt_public: false,
-          copyright: '',
-          show_workflow_steps: true,
-          use_icon_as_answer_icon: app.use_icon_as_answer_icon,
+          copyright: site?.copyright ?? '',
+          show_workflow_steps: site?.show_workflow_steps ?? true,
+          use_icon_as_answer_icon: site?.use_icon_as_answer_icon ?? app.use_icon_as_answer_icon,
         },
         plan: 'basic',
         custom_config: null,

--- a/web/app/components/plugins/install-plugin/install-from-marketplace/index.tsx
+++ b/web/app/components/plugins/install-plugin/install-from-marketplace/index.tsx
@@ -77,7 +77,7 @@ const InstallFromMarketplace: React.FC<InstallFromMarketplaceProps> = ({
           foldAnimInto()
       }}
     >
-      <DialogContent className={cn('w-[560px] max-w-none! overflow-hidden! text-left align-middle', cn(modalClassName, 'shadows-shadow-xl flex max-h-[calc(100dvh-48px)] min-w-[560px] flex-col items-start rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-0'))}>
+      <DialogContent backdropProps={{ forceRender: true }} className={cn('w-[560px] max-w-none! overflow-hidden! text-left align-middle', cn(modalClassName, 'shadows-shadow-xl flex max-h-[calc(100dvh-48px)] min-w-[560px] flex-col items-start rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-0'))}>
         <DialogCloseButton />
 
         <div className="flex items-start gap-2 self-stretch pt-6 pr-14 pb-3 pl-6">

--- a/web/models/explore.ts
+++ b/web/models/explore.ts
@@ -1,3 +1,4 @@
+import type { SiteInfo } from './share'
 import type { AppIconType, AppModeEnum } from '@/types/app'
 
 type AppBasicInfo = {
@@ -33,6 +34,7 @@ export type App = {
 
 export type InstalledApp = {
   app: AppBasicInfo
+  site?: SiteInfo | null
   id: string
   uninstallable: boolean
   is_pinned: boolean


### PR DESCRIPTION
## Summary
- Return the web app site config from the Explore installed-apps API while keeping the app card icon data unchanged.
- Use the returned site config for Explore installed chatflow runtime appData so assistant answer icons follow the web app setting.
- Add backend and frontend regression coverage for site icon/use_icon_as_answer_icon propagation.

## Tests
- uv run --project api pytest api/tests/unit_tests/controllers/console/explore/test_installed_app.py
- pnpm -C web test app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx
- pnpm -C web test app/components/explore/installed-app/__tests__/index.spec.tsx
- pnpm -C web type-check
- uv run --project api ruff check api/controllers/console/explore/installed_app.py api/tests/unit_tests/controllers/console/explore/test_installed_app.py
- pnpm -C web exec eslint models/explore.ts app/components/explore/installed-app/index.tsx app/components/explore/installed-app/__tests__/index.spec.tsx