### PR TITLE
fix: normalize summary_index_setting None to fix preview error

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -170,6 +170,16 @@ class _AutomaticProcessRule(BaseModel):
     mode: Literal[ProcessRuleMode.AUTOMATIC]
     summary_index_setting: _SummaryIndexSetting | None = None
 
+    @field_validator("summary_index_setting", mode="before")
+    @classmethod
+    def _normalize_summary_index_setting(cls, v: Any) -> Any:
+        """Treat dicts with enable=None (or missing enable) as None (#36602)."""
+        if v is None:
+            return None
+        if isinstance(v, dict) and v.get("enable") is None:
+            return None
+        return v
+
 
 class _CustomProcessRule(BaseModel):
     model_config = ConfigDict(extra="allow")
@@ -178,6 +188,16 @@ class _CustomProcessRule(BaseModel):
     rules: _EstimateRules
     summary_index_setting: _SummaryIndexSetting | None = None
 
+    @field_validator("summary_index_setting", mode="before")
+    @classmethod
+    def _normalize_summary_index_setting(cls, v: Any) -> Any:
+        """Treat dicts with enable=None (or missing enable) as None (#36602)."""
+        if v is None:
+            return None
+        if isinstance(v, dict) and v.get("enable") is None:
+            return None
+        return v
+
 
 class _HierarchicalProcessRule(BaseModel):
     model_config = ConfigDict(extra="allow")
@@ -185,6 +205,16 @@ class _HierarchicalProcessRule(BaseModel):
     mode: Literal[ProcessRuleMode.HIERARCHICAL]
     rules: _EstimateRules
     summary_index_setting: _SummaryIndexSetting | None = None
+
+    @field_validator("summary_index_setting", mode="before")
+    @classmethod
+    def _normalize_summary_index_setting(cls, v: Any) -> Any:
+        """Treat dicts with enable=None (or missing enable) as None (#36602)."""
+        if v is None:
+            return None
+        if isinstance(v, dict) and v.get("enable") is None:
+            return None
+        return v
 
 
 _EstimateProcessRule = Annotated[


### PR DESCRIPTION
## Problem

When creating a new empty knowledge base and clicking preview after adding a file, the system throws:

```
Input tag 'None' found using 'enable' does not match any of the expected tags: False, True
```

This happens because the frontend sends `{"enable": null}` for `summary_index_setting` when the auto-generate summary toggle is off. Pydantic's discriminated union tries to match `None` against `Literal[True]` and `Literal[False]`, which fails.

Fixes #36602

## Fix

Add `@field_validator("summary_index_setting", mode="before")` to all three process rule models (`_AutomaticProcessRule`, `_CustomProcessRule`, `_HierarchicalProcessRule`) that normalizes dicts with `enable=None` to `None`.

This follows the exact same pattern as PR #36355 which fixed the identical issue in `KnowledgeIndexNodeData`.

## Changes

- `api/services/dataset_service.py`: Add `_normalize_summary_index_setting` field_validator to all three process rule models