### PR TITLE
fix: remove unused datasource_parameters from Notion pre-import query

### DIFF
--- a/api/controllers/console/datasets/data_source.py
+++ b/api/controllers/console/datasets/data_source.py
@@ -48,7 +48,6 @@ class NotionEstimatePayload(BaseModel):
 class DataSourceNotionListQuery(BaseModel):
     dataset_id: str | None = Field(default=None, description="Dataset ID")
     credential_id: str = Field(..., description="Credential ID", min_length=1)
-    datasource_parameters: dict[str, Any] | None = Field(default=None, description="Datasource parameters JSON string")
 
 
 class DataSourceNotionPreviewQuery(BaseModel):
@@ -205,9 +204,6 @@ class DataSourceNotionListApi(Resource):
 
         query = DataSourceNotionListQuery.model_validate(request.args.to_dict())
 
-        # Get datasource_parameters from query string (optional, for GitHub and other datasources)
-        datasource_parameters = query.datasource_parameters or {}
-
         datasource_provider_service = DatasourceProviderService()
         credential = datasource_provider_service.get_datasource_credentials(
             tenant_id=current_tenant_id,
@@ -255,7 +251,7 @@ class DataSourceNotionListApi(Resource):
             online_document_result: Generator[OnlineDocumentPagesMessage, None, None] = (
                 datasource_runtime.get_online_document_pages(
                     user_id=current_user.id,
-                    datasource_parameters=datasource_parameters,
+                    datasource_parameters={},
                     provider_type=datasource_runtime.datasource_provider_type(),
                 )
             )


### PR DESCRIPTION
## Problem

`DataSourceNotionListQuery` has a `datasource_parameters: dict[str, Any] | None` field that is:

1. **Type-incorrect**: Query params arrive as strings, so Pydantic fails to parse a string as `dict[str, Any]`
2. **Never populated by frontend**: No frontend code sends this parameter ([`web/service/knowledge/use-import.ts`](https://github.com/langgenius/dify/blob/main/web/service/knowledge/use-import.ts) only sends `dataset_id` and `credential_id`)
3. **Dead code**: Always evaluates to `{}` via the `or {}` fallback on line 209

Fixes #36622

## Fix

Remove `datasource_parameters` from `DataSourceNotionListQuery` and pass `{}` directly to `get_online_document_pages()`. The downstream `datasource_parameters` parameter is still used correctly via POST body in the RAG pipeline.

## Changes

- `api/controllers/console/datasets/data_source.py`: Remove field from query model, remove extraction code, pass `{}` directly