### PR TITLE
fix: add tenant isolation to file preview signing and access

### DIFF
--- a/api/controllers/files/image_preview.py
+++ b/api/controllers/files/image_preview.py
@@ -20,6 +20,7 @@ class FileSignatureQuery(BaseModel):
     timestamp: str = Field(..., description="Unix timestamp used in the signature")
     nonce: str = Field(..., description="Random string for signature")
     sign: str = Field(..., description="HMAC signature")
+    tenant_id: str | None = Field(default=None, description="Tenant ID for cross-tenant isolation")
 
 
 class FilePreviewQuery(FileSignatureQuery):
@@ -57,6 +58,7 @@ class ImagePreviewApi(Resource):
         timestamp = args.timestamp
         nonce = args.nonce
         sign = args.sign
+        tenant_id = args.tenant_id
 
         try:
             generator, mimetype = FileService(db.engine).get_image_preview(
@@ -64,6 +66,7 @@ class ImagePreviewApi(Resource):
                 timestamp=timestamp,
                 nonce=nonce,
                 sign=sign,
+                tenant_id=tenant_id,
             )
         except services.errors.file.UnsupportedFileTypeError:
             raise UnsupportedFileTypeError()
@@ -103,6 +106,7 @@ class FilePreviewApi(Resource):
                 timestamp=args.timestamp,
                 nonce=args.nonce,
                 sign=args.sign,
+                tenant_id=args.tenant_id,
             )
         except services.errors.file.UnsupportedFileTypeError:
             raise UnsupportedFileTypeError()

--- a/api/core/app/workflow/file_runtime.py
+++ b/api/core/app/workflow/file_runtime.py
@@ -102,7 +102,14 @@ class DifyWorkflowFileRuntime(WorkflowFileRuntimeProtocol):
         self._assert_upload_file_access(upload_file_id=upload_file_id)
         base_url = self._base_url(for_external=for_external)
         url = f"{base_url}/files/{upload_file_id}/file-preview"
-        query = self._sign_query(payload=f"file-preview|{upload_file_id}")
+        # Include tenant_id in the signature when an access scope is active,
+        # so the signed URL is bound to the current tenant and cannot be
+        # replayed across tenants.
+        tenant_id: str | None = None
+        scope = self._file_access_controller.current_scope()
+        if scope is not None:
+            tenant_id = scope.tenant_id
+        query = self._sign_query(payload=f"file-preview|{upload_file_id}", tenant_id=tenant_id)
         if as_attachment:
             query["as_attachment"] = "true"
         return f"{url}?{urllib.parse.urlencode(query)}"
@@ -121,7 +128,22 @@ class DifyWorkflowFileRuntime(WorkflowFileRuntimeProtocol):
         timestamp: str,
         nonce: str,
         sign: str,
+        tenant_id: str | None = None,
     ) -> bool:
+        """Verify the HMAC signature for a file preview URL.
+
+        Supports two payload formats for backward compatibility:
+        - New format (with tenant binding): ``{kind}-preview|{file_id}|{tenant_id}|{timestamp}|{nonce}``
+        - Legacy format (no tenant binding): ``{kind}-preview|{file_id}|{timestamp}|{nonce}``
+        """
+        # Try new tenant-bound format first when tenant_id is provided
+        if tenant_id:
+            payload = f"{preview_kind}-preview|{file_id}|{tenant_id}|{timestamp}|{nonce}"
+            recalculated = hmac.new(self._secret_key(), payload.encode(), hashlib.sha256).digest()
+            if sign == base64.urlsafe_b64encode(recalculated).decode():
+                return int(time.time()) - int(timestamp) <= dify_config.FILES_ACCESS_TIMEOUT
+
+        # Fall back to legacy format without tenant binding
         payload = f"{preview_kind}-preview|{file_id}|{timestamp}|{nonce}"
         recalculated = hmac.new(self._secret_key(), payload.encode(), hashlib.sha256).digest()
         if sign != base64.urlsafe_b64encode(recalculated).decode():
@@ -138,15 +160,27 @@ class DifyWorkflowFileRuntime(WorkflowFileRuntimeProtocol):
     def _secret_key() -> bytes:
         return dify_config.SECRET_KEY.encode()
 
-    def _sign_query(self, *, payload: str) -> dict[str, str]:
+    def _sign_query(self, *, payload: str, tenant_id: str | None = None) -> dict[str, str]:
+        """Build signed query parameters for a file preview URL.
+
+        When *tenant_id* is provided it is included in both the HMAC payload
+        and the returned query dict so the verifier can enforce tenant isolation.
+        """
         timestamp = str(int(time.time()))
         nonce = os.urandom(16).hex()
-        sign = hmac.new(self._secret_key(), f"{payload}|{timestamp}|{nonce}".encode(), hashlib.sha256).digest()
-        return {
+        if tenant_id:
+            full_payload = f"{payload}|{tenant_id}|{timestamp}|{nonce}"
+        else:
+            full_payload = f"{payload}|{timestamp}|{nonce}"
+        sign = hmac.new(self._secret_key(), full_payload.encode(), hashlib.sha256).digest()
+        result: dict[str, str] = {
             "timestamp": timestamp,
             "nonce": nonce,
             "sign": base64.urlsafe_b64encode(sign).decode(),
         }
+        if tenant_id:
+            result["tenant_id"] = tenant_id
+        return result
 
     def _resolve_storage_key(self, *, file: File) -> str:
         parsed_reference = parse_file_reference(file.reference)

--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -948,12 +948,12 @@ class DocumentSegment(TypeBase):
             upload_file_id = match.group(1)
             nonce = os.urandom(16).hex()
             timestamp = str(int(time.time()))
-            data_to_sign = f"image-preview|{upload_file_id}|{timestamp}|{nonce}"
+            data_to_sign = f"image-preview|{upload_file_id}|{self.tenant_id}|{timestamp}|{nonce}"
             secret_key = dify_config.SECRET_KEY.encode()
             sign = hmac.new(secret_key, data_to_sign.encode(), hashlib.sha256).digest()
             encoded_sign = base64.urlsafe_b64encode(sign).decode()
 
-            params = f"timestamp={timestamp}&nonce={nonce}&sign={encoded_sign}"
+            params = f"timestamp={timestamp}&nonce={nonce}&tenant_id={self.tenant_id}&sign={encoded_sign}"
             base_url = f"/files/{upload_file_id}/image-preview"
             signed_url = f"{base_url}?{params}"
             signed_urls.append((match.start(), match.end(), signed_url))
@@ -965,31 +965,31 @@ class DocumentSegment(TypeBase):
             upload_file_id = match.group(1)
             nonce = os.urandom(16).hex()
             timestamp = str(int(time.time()))
-            data_to_sign = f"file-preview|{upload_file_id}|{timestamp}|{nonce}"
+            data_to_sign = f"file-preview|{upload_file_id}|{self.tenant_id}|{timestamp}|{nonce}"
             secret_key = dify_config.SECRET_KEY.encode()
             sign = hmac.new(secret_key, data_to_sign.encode(), hashlib.sha256).digest()
             encoded_sign = base64.urlsafe_b64encode(sign).decode()
 
-            params = f"timestamp={timestamp}&nonce={nonce}&sign={encoded_sign}"
+            params = f"timestamp={timestamp}&nonce={nonce}&tenant_id={self.tenant_id}&sign={encoded_sign}"
             base_url = f"/files/{upload_file_id}/file-preview"
             signed_url = f"{base_url}?{params}"
             signed_urls.append((match.start(), match.end(), signed_url))
 
         # For tools directory - direct file formats (e.g., .png, .jpg, etc.)
         # Match URL including any query parameters up to common URL boundaries (space, parenthesis, quotes)
-        pattern = r"/files/tools/([a-f0-9\-]+)\.([a-zA-Z0-9]+)(?:\?[^\s\)\"\']*)?"
+        pattern = r"/files/tools/([a-f0-9\-]+)\.([a-zA-Z0-9]+)(?:\?[^\s\)\"\'\`]*)?"
         matches = re.finditer(pattern, text)
         for match in matches:
             upload_file_id = match.group(1)
             file_extension = match.group(2)
             nonce = os.urandom(16).hex()
             timestamp = str(int(time.time()))
-            data_to_sign = f"file-preview|{upload_file_id}|{timestamp}|{nonce}"
+            data_to_sign = f"file-preview|{upload_file_id}|{self.tenant_id}|{timestamp}|{nonce}"
             secret_key = dify_config.SECRET_KEY.encode()
             sign = hmac.new(secret_key, data_to_sign.encode(), hashlib.sha256).digest()
             encoded_sign = base64.urlsafe_b64encode(sign).decode()
 
-            params = f"timestamp={timestamp}&nonce={nonce}&sign={encoded_sign}"
+            params = f"timestamp={timestamp}&nonce={nonce}&tenant_id={self.tenant_id}&sign={encoded_sign}"
             base_url = f"/files/tools/{upload_file_id}.{file_extension}"
             signed_url = f"{base_url}?{params}"
             signed_urls.append((match.start(), match.end(), signed_url))

--- a/api/services/file_service.py
+++ b/api/services/file_service.py
@@ -1,6 +1,8 @@
 import base64
 import hashlib
+import hmac
 import os
+import time
 import uuid
 from collections.abc import Generator, Sequence  # Changed Iterator to Generator
 from contextlib import contextmanager, suppress
@@ -45,6 +47,40 @@ class FileService:
             self._session_maker = session_factory
         else:
             raise AssertionError("must be a sessionmaker or an Engine.")
+
+    def _verify_preview_signature(
+        self,
+        *,
+        preview_kind: Literal["image", "file"],
+        file_id: str,
+        timestamp: str,
+        nonce: str,
+        sign: str,
+        tenant_id: str | None = None,
+    ) -> bool:
+        """Verify HMAC signature for a file preview, with optional tenant binding.
+
+        When *tenant_id* is provided the new payload format
+        ``{kind}-preview|{file_id}|{tenant_id}|{timestamp}|{nonce}`` is checked
+        first.  If that fails, or if *tenant_id* is ``None``, the legacy format
+        ``{kind}-preview|{file_id}|{timestamp}|{nonce}`` is tried so that
+        pre-existing URLs keep working during the migration window.
+        """
+        secret_key = dify_config.SECRET_KEY.encode()
+
+        # Try new tenant-bound format first
+        if tenant_id:
+            payload = f"{preview_kind}-preview|{file_id}|{tenant_id}|{timestamp}|{nonce}"
+            recalculated = hmac.new(secret_key, payload.encode(), hashlib.sha256).digest()
+            if sign == base64.urlsafe_b64encode(recalculated).decode():
+                return int(time.time()) - int(timestamp) <= dify_config.FILES_ACCESS_TIMEOUT
+
+        # Fall back to legacy format
+        payload = f"{preview_kind}-preview|{file_id}|{timestamp}|{nonce}"
+        recalculated = hmac.new(secret_key, payload.encode(), hashlib.sha256).digest()
+        if sign != base64.urlsafe_b64encode(recalculated).decode():
+            return False
+        return int(time.time()) - int(timestamp) <= dify_config.FILES_ACCESS_TIMEOUT
 
     def upload_file(
         self,
@@ -195,14 +231,29 @@ class FileService:
 
         return text
 
-    def get_image_preview(self, file_id: str, timestamp: str, nonce: str, sign: str):
-        result = file_helpers.verify_image_signature(
-            upload_file_id=file_id, timestamp=timestamp, nonce=nonce, sign=sign
-        )
-        if not result:
+    def get_image_preview(self, file_id: str, timestamp: str, nonce: str, sign: str, tenant_id: str | None = None):
+        """Retrieve a streaming image preview for *file_id*.
+
+        The HMAC signature is verified using the new tenant-bound format when
+        *tenant_id* is supplied, falling back to the legacy format for backward
+        compatibility.  The database lookup is always scoped to *tenant_id* when
+        provided, preventing cross-tenant file access even if a legacy signature
+        is accepted.
+        """
+        if not self._verify_preview_signature(
+            preview_kind="image",
+            file_id=file_id,
+            timestamp=timestamp,
+            nonce=nonce,
+            sign=sign,
+            tenant_id=tenant_id,
+        ):
             raise NotFound("File not found or signature is invalid")
         with self._session_maker(expire_on_commit=False) as session:
-            upload_file = session.scalar(select(UploadFile).where(UploadFile.id == file_id).limit(1))
+            stmt = select(UploadFile).where(UploadFile.id == file_id)
+            if tenant_id:
+                stmt = stmt.where(UploadFile.tenant_id == tenant_id)
+            upload_file = session.scalar(stmt.limit(1))
 
         if not upload_file:
             raise NotFound("File not found or signature is invalid")
@@ -216,13 +267,32 @@ class FileService:
 
         return generator, upload_file.mime_type
 
-    def get_file_generator_by_file_id(self, file_id: str, timestamp: str, nonce: str, sign: str):
-        result = file_helpers.verify_file_signature(upload_file_id=file_id, timestamp=timestamp, nonce=nonce, sign=sign)
-        if not result:
+    def get_file_generator_by_file_id(
+        self, file_id: str, timestamp: str, nonce: str, sign: str, tenant_id: str | None = None
+    ):
+        """Retrieve a streaming file generator for *file_id*.
+
+        The HMAC signature is verified using the new tenant-bound format when
+        *tenant_id* is supplied, falling back to the legacy format for backward
+        compatibility.  The database lookup is always scoped to *tenant_id* when
+        provided, preventing cross-tenant file access even if a legacy signature
+        is accepted.
+        """
+        if not self._verify_preview_signature(
+            preview_kind="file",
+            file_id=file_id,
+            timestamp=timestamp,
+            nonce=nonce,
+            sign=sign,
+            tenant_id=tenant_id,
+        ):
             raise NotFound("File not found or signature is invalid")
 
         with self._session_maker(expire_on_commit=False) as session:
-            upload_file = session.scalar(select(UploadFile).where(UploadFile.id == file_id).limit(1))
+            stmt = select(UploadFile).where(UploadFile.id == file_id)
+            if tenant_id:
+                stmt = stmt.where(UploadFile.tenant_id == tenant_id)
+            upload_file = session.scalar(stmt.limit(1))
 
         if not upload_file:
             raise NotFound("File not found or signature is invalid")


### PR DESCRIPTION
## Problem

`DocumentSegment.get_sign_content()` generates signed URLs for images embedded in segment content, but the signing and verification pipeline has **no tenant isolation**. This allows one tenant to access another tenant's files by:

1. Creating a segment whose content contains `/files/{other_tenant_file_id}/image-preview`
2. `get_sign_content()` blindly signs the file_id with the server's HMAC key
3. The signed URL is served and loads the other tenant's image

Fixes #36623

## Security Analysis

**Before**: HMAC payload = `"image-preview|{file_id}|{timestamp}|{nonce}"` — no tenant binding

**After**: HMAC payload = `"image-preview|{file_id}|{tenant_id}|{timestamp}|{nonce}"` — tenant-bound

### Defense in depth

1. **Signing layer** (`dataset.py`): `get_sign_content()` includes `self.tenant_id` in HMAC payload
2. **Verification layer** (`file_runtime.py`): `verify_preview_signature()` validates tenant_id in signature, with backward-compatible fallback for existing URLs
3. **Access layer** (`file_service.py`): DB queries filter `UploadFile.tenant_id == tenant_id`
4. **Controller layer** (`image_preview.py`): Passes `tenant_id` from URL params to service

## Changes

- `api/models/dataset.py`: Include `self.tenant_id` in HMAC signed payload and URL params
- `api/core/app/workflow/file_runtime.py`: Add `tenant_id` to signature verification and signing, with legacy fallback
- `api/services/file_service.py`: Add `tenant_id` parameter and DB filter to `get_image_preview()` and `get_file_generator_by_file_id()`
- `api/controllers/files/image_preview.py`: Pass `tenant_id` from query params to service methods