### PR TITLE
[codex] Fix provider last-used throttling race

### DIFF
--- a/api/events/event_handlers/update_provider_when_message_created.py
+++ b/api/events/event_handlers/update_provider_when_message_created.py
@@ -23,8 +23,6 @@ logger = logging.getLogger(__name__)
 
 # Redis cache key prefix for provider last used timestamps
 _PROVIDER_LAST_USED_CACHE_PREFIX = "provider:last_used"
-# Default TTL for cache entries (10 minutes)
-_CACHE_TTL_SECONDS = 600
 LAST_USED_UPDATE_WINDOW_SECONDS = 60 * 5
 
 
@@ -33,19 +31,27 @@ def _get_provider_cache_key(tenant_id: str, provider_name: str) -> str:
     return f"{_PROVIDER_LAST_USED_CACHE_PREFIX}:{tenant_id}:{provider_name}"
 
 
-@redis_fallback(default_return=None)
-def _get_last_update_timestamp(cache_key: str) -> datetime | None:
-    """Get last update timestamp from Redis cache."""
-    timestamp_str = redis_client.get(cache_key)
-    if timestamp_str:
-        return datetime.fromtimestamp(float(timestamp_str.decode("utf-8")))
-    return None
+@redis_fallback(default_return=True)
+def _claim_last_used_update_window(cache_key: str, timestamp: datetime) -> bool:
+    """Atomically claim the provider last-used update window.
+
+    Redis failures fail open so provider usage still reaches the database; the
+    cache only throttles best-effort timestamp writes.
+    """
+    return bool(
+        redis_client.set(
+            cache_key,
+            str(timestamp.timestamp()),
+            ex=LAST_USED_UPDATE_WINDOW_SECONDS,
+            nx=True,
+        )
+    )
 
 
 @redis_fallback()
-def _set_last_update_timestamp(cache_key: str, timestamp: datetime):
-    """Set last update timestamp in Redis cache with TTL."""
-    redis_client.setex(cache_key, _CACHE_TTL_SECONDS, str(timestamp.timestamp()))
+def _release_last_used_update_window(cache_key: str) -> None:
+    """Release a claimed last-used throttle token after a failed DB transaction."""
+    redis_client.delete(cache_key)
 
 
 class _ProviderUpdateFilters(BaseModel):
@@ -251,76 +257,77 @@ def _execute_provider_updates(updates_to_perform: list[_ProviderUpdateOperation]
         return
 
     updates_to_perform = sorted(updates_to_perform, key=lambda i: (i.filters.tenant_id, i.filters.provider_name))
+    claimed_last_used_cache_keys: list[str] = []
 
-    # Use SQLAlchemy's context manager for transaction management
-    # This automatically handles commit/rollback
-    with Session(db.engine) as session, session.begin():
-        # Use a single transaction for all updates
-        for update_operation in updates_to_perform:
-            filters = update_operation.filters
-            values = update_operation.values
-            additional_filters = update_operation.additional_filters
-            description = update_operation.description
+    try:
+        # Use SQLAlchemy's context manager for transaction management
+        # This automatically handles commit/rollback
+        with Session(db.engine) as session, session.begin():
+            # Use a single transaction for all updates
+            for update_operation in updates_to_perform:
+                filters = update_operation.filters
+                values = update_operation.values
+                additional_filters = update_operation.additional_filters
+                description = update_operation.description
 
-            # Build the where conditions
-            where_conditions = [
-                Provider.tenant_id == filters.tenant_id,
-                Provider.provider_name == filters.provider_name,
-            ]
+                # Build the where conditions
+                where_conditions = [
+                    Provider.tenant_id == filters.tenant_id,
+                    Provider.provider_name == filters.provider_name,
+                ]
 
-            # Add additional filters if specified
-            if filters.provider_type is not None:
-                where_conditions.append(Provider.provider_type == filters.provider_type)
-            if filters.quota_type is not None:
-                where_conditions.append(Provider.quota_type == filters.quota_type)
-            if additional_filters.quota_limit_check:
-                where_conditions.append(Provider.quota_limit > Provider.quota_used)
+                # Add additional filters if specified
+                if filters.provider_type is not None:
+                    where_conditions.append(Provider.provider_type == filters.provider_type)
+                if filters.quota_type is not None:
+                    where_conditions.append(Provider.quota_type == filters.quota_type)
+                if additional_filters.quota_limit_check:
+                    where_conditions.append(Provider.quota_limit > Provider.quota_used)
 
-            # Prepare values dict for SQLAlchemy update
-            update_values = {}
+                # Prepare values dict for SQLAlchemy update
+                update_values = {}
 
-            # NOTE: For frequently used providers under high load, this implementation may experience
-            # race conditions or update contention despite the time-window optimization:
-            # 1. Multiple concurrent requests might check the same cache key simultaneously
-            # 2. Redis cache operations are not atomic with database updates
-            # 3. Heavy providers could still face database lock contention during peak usage
-            # The current implementation is acceptable for most scenarios, but future optimization
-            # considerations could include: batched updates, or async processing.
-            if values.last_used is not None:
-                cache_key = _get_provider_cache_key(filters.tenant_id, filters.provider_name)
-                now = datetime_utils.naive_utc_now()
-                last_update = _get_last_update_timestamp(cache_key)
+                # Claim the throttle window atomically before writing last_used. This avoids
+                # the old get-then-set race where concurrent requests could all pass the
+                # window check and amplify writes against the same Provider row.
+                if values.last_used is not None:
+                    cache_key = _get_provider_cache_key(filters.tenant_id, filters.provider_name)
+                    now = datetime_utils.naive_utc_now()
 
-                if last_update is None or (now - last_update).total_seconds() > LAST_USED_UPDATE_WINDOW_SECONDS:  # type: ignore
-                    update_values["last_used"] = values.last_used
-                    _set_last_update_timestamp(cache_key, now)
+                    if _claim_last_used_update_window(cache_key, now):
+                        update_values["last_used"] = values.last_used
+                        claimed_last_used_cache_keys.append(cache_key)
 
-            if values.quota_used is not None:
-                update_values["quota_used"] = values.quota_used
-            # Skip the current update operation if no updates are required.
-            if not update_values:
-                continue
+                if values.quota_used is not None:
+                    update_values["quota_used"] = values.quota_used
+                # Skip the current update operation if no updates are required.
+                if not update_values:
+                    continue
 
-            # Build and execute the update statement
-            stmt = update(Provider).where(*where_conditions).values(**update_values)
-            result = cast(CursorResult, session.execute(stmt))
-            rows_affected = result.rowcount
+                # Build and execute the update statement
+                stmt = update(Provider).where(*where_conditions).values(**update_values)
+                result = cast(CursorResult, session.execute(stmt))
+                rows_affected = result.rowcount
 
-            logger.debug(
-                "Provider update (%s): %s rows affected. Filters: %s, Values: %s",
-                description,
-                rows_affected,
-                filters.model_dump(),
-                update_values,
-            )
-
-            # If no rows were affected for quota updates, log a warning
-            if rows_affected == 0 and description == "quota_deduction_update":
-                logger.warning(
-                    "No Provider rows updated for quota deduction. "
-                    "This may indicate quota limit exceeded or provider not found. "
-                    "Filters: %s",
+                logger.debug(
+                    "Provider update (%s): %s rows affected. Filters: %s, Values: %s",
+                    description,
+                    rows_affected,
                     filters.model_dump(),
+                    update_values,
                 )
 
-        logger.debug("Successfully processed %s Provider updates", len(updates_to_perform))
+                # If no rows were affected for quota updates, log a warning
+                if rows_affected == 0 and description == "quota_deduction_update":
+                    logger.warning(
+                        "No Provider rows updated for quota deduction. "
+                        "This may indicate quota limit exceeded or provider not found. "
+                        "Filters: %s",
+                        filters.model_dump(),
+                    )
+
+            logger.debug("Successfully processed %s Provider updates", len(updates_to_perform))
+    except Exception:
+        for cache_key in claimed_last_used_cache_keys:
+            _release_last_used_update_window(cache_key)
+        raise

--- a/api/tests/unit_tests/events/test_update_provider_when_message_created.py
+++ b/api/tests/unit_tests/events/test_update_provider_when_message_created.py
@@ -1,18 +1,22 @@
 from collections.abc import Generator
 from contextlib import contextmanager
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import patch
 from uuid import uuid4
 
+import pytest
+from redis import RedisError
 from sqlalchemy import create_engine, select
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import sessionmaker
 
 from core.app.entities.app_invoke_entities import ChatAppGenerateEntity
 from core.entities.provider_entities import ProviderQuotaType, QuotaUnit
 from events.event_handlers import update_provider_when_message_created
 from models import TenantCreditPool
-from models.provider import ProviderType
+from models.provider import Provider, ProviderType
 
 
 @contextmanager
@@ -139,3 +143,136 @@ def test_capped_credit_pool_accounting_skips_exhaustion_warning_when_full_amount
         pool_type="trial",
     )
     assert "Credit pool exhausted during message-created accounting" not in caplog.text
+
+
+def test_claim_last_used_update_window_uses_atomic_redis_set() -> None:
+    timestamp = datetime(2026, 5, 26, 12, 0, 0)
+
+    with patch.object(update_provider_when_message_created.redis_client, "set", return_value=True) as mock_set:
+        claimed = update_provider_when_message_created._claim_last_used_update_window("cache-key", timestamp)
+
+    assert claimed is True
+    mock_set.assert_called_once_with(
+        "cache-key",
+        str(timestamp.timestamp()),
+        ex=update_provider_when_message_created.LAST_USED_UPDATE_WINDOW_SECONDS,
+        nx=True,
+    )
+
+
+def test_claim_last_used_update_window_returns_false_when_window_exists() -> None:
+    timestamp = datetime(2026, 5, 26, 12, 0, 0)
+
+    with patch.object(update_provider_when_message_created.redis_client, "set", return_value=None):
+        claimed = update_provider_when_message_created._claim_last_used_update_window("cache-key", timestamp)
+
+    assert claimed is False
+
+
+def test_claim_last_used_update_window_fails_open_when_redis_is_unavailable() -> None:
+    timestamp = datetime(2026, 5, 26, 12, 0, 0)
+
+    with patch.object(update_provider_when_message_created.redis_client, "set", side_effect=RedisError("down")):
+        claimed = update_provider_when_message_created._claim_last_used_update_window("cache-key", timestamp)
+
+    assert claimed is True
+
+
+def test_execute_provider_updates_skips_last_used_when_throttle_window_is_already_claimed() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Provider.__table__.create(engine)
+    tenant_id = str(uuid4())
+    provider_id = str(uuid4())
+
+    with engine.begin() as connection:
+        connection.execute(
+            Provider.__table__.insert(),
+            {
+                "id": provider_id,
+                "tenant_id": tenant_id,
+                "provider_name": "openai",
+                "provider_type": ProviderType.CUSTOM,
+                "is_valid": True,
+            },
+        )
+
+    operation = update_provider_when_message_created._ProviderUpdateOperation(
+        filters=update_provider_when_message_created._ProviderUpdateFilters(
+            tenant_id=tenant_id,
+            provider_name="openai",
+        ),
+        values=update_provider_when_message_created._ProviderUpdateValues(last_used=datetime(2026, 5, 26, 12, 0, 0)),
+    )
+
+    with (
+        patch.object(update_provider_when_message_created, "db", SimpleNamespace(engine=engine)),
+        patch.object(update_provider_when_message_created, "_claim_last_used_update_window", return_value=False),
+    ):
+        update_provider_when_message_created._execute_provider_updates([operation])
+
+    with engine.connect() as connection:
+        last_used = connection.scalar(select(Provider.last_used).where(Provider.id == provider_id))
+
+    assert last_used is None
+
+
+def test_execute_provider_updates_writes_last_used_after_claiming_throttle_window() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Provider.__table__.create(engine)
+    tenant_id = str(uuid4())
+    provider_id = str(uuid4())
+    last_used_at = datetime(2026, 5, 26, 12, 0, 0)
+
+    with engine.begin() as connection:
+        connection.execute(
+            Provider.__table__.insert(),
+            {
+                "id": provider_id,
+                "tenant_id": tenant_id,
+                "provider_name": "openai",
+                "provider_type": ProviderType.CUSTOM,
+                "is_valid": True,
+            },
+        )
+
+    operation = update_provider_when_message_created._ProviderUpdateOperation(
+        filters=update_provider_when_message_created._ProviderUpdateFilters(
+            tenant_id=tenant_id,
+            provider_name="openai",
+        ),
+        values=update_provider_when_message_created._ProviderUpdateValues(last_used=last_used_at),
+    )
+
+    with (
+        patch.object(update_provider_when_message_created, "db", SimpleNamespace(engine=engine)),
+        patch.object(update_provider_when_message_created, "_claim_last_used_update_window", return_value=True),
+    ):
+        update_provider_when_message_created._execute_provider_updates([operation])
+
+    with engine.connect() as connection:
+        last_used = connection.scalar(select(Provider.last_used).where(Provider.id == provider_id))
+
+    assert last_used == last_used_at
+
+
+def test_execute_provider_updates_releases_claimed_window_after_transaction_failure() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    tenant_id = str(uuid4())
+    cache_key = update_provider_when_message_created._get_provider_cache_key(tenant_id, "openai")
+    operation = update_provider_when_message_created._ProviderUpdateOperation(
+        filters=update_provider_when_message_created._ProviderUpdateFilters(
+            tenant_id=tenant_id,
+            provider_name="openai",
+        ),
+        values=update_provider_when_message_created._ProviderUpdateValues(last_used=datetime(2026, 5, 26, 12, 0, 0)),
+    )
+
+    with (
+        patch.object(update_provider_when_message_created, "db", SimpleNamespace(engine=engine)),
+        patch.object(update_provider_when_message_created, "_claim_last_used_update_window", return_value=True),
+        patch.object(update_provider_when_message_created, "_release_last_used_update_window") as mock_release,
+        pytest.raises(SQLAlchemyError),
+    ):
+        update_provider_when_message_created._execute_provider_updates([operation])
+
+    mock_release.assert_called_once_with(cache_key)


### PR DESCRIPTION
## Summary
- replace provider last-used Redis get/set throttling with an atomic SET NX window claim
- fail open when Redis is unavailable so provider usage still reaches the database
- release claimed throttle tokens when the provider update transaction fails
- add unit coverage for atomic claim behavior, throttled skips, successful writes, Redis fallback, and transaction rollback cleanup

## Why
The previous timestamp check performed Redis GET followed by SETEX. Under concurrent message creation, multiple requests could observe the missing or stale key at the same time and all write last_used for the same Provider row, amplifying DB contention on hot providers.

## Validation
- DEBUG=false uv run --project api --group dev pytest api/tests/unit_tests/events/test_update_provider_when_message_created.py -q
- uv run --project api --group dev ruff check api/events/event_handlers/update_provider_when_message_created.py api/tests/unit_tests/events/test_update_provider_when_message_created.py

Issue: none opened; small concurrency/performance fix discovered during code scan.