### PR TITLE
refactor: replace str | None = None with str = "" in service layer

### DIFF
--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -506,7 +506,7 @@ class AccountService:
         db.session.commit()
 
     @staticmethod
-    def login(account: Account, *, ip_address: str | None = None) -> TokenPair:
+    def login(account: Account, *, ip_address: str = "") -> TokenPair:
         if ip_address:
             AccountService.update_login_info(account=account, ip_address=ip_address)
 
@@ -1154,7 +1154,7 @@ class TenantService:
         return tenant
 
     @staticmethod
-    def create_owner_tenant_if_not_exist(account: Account, name: str | None = None, is_setup: bool | None = False):
+    def create_owner_tenant_if_not_exist(account: Account, name: str = "", is_setup: bool | None = False):
         """Check if user have a workspace or not"""
         available_ta = db.session.scalar(
             select(TenantAccountJoin)

--- a/api/services/agent/roster_service.py
+++ b/api/services/agent/roster_service.py
@@ -71,7 +71,7 @@ class AgentRosterService:
         }
 
     def list_roster_agents(
-        self, *, tenant_id: str, page: int = 1, limit: int = 20, keyword: str | None = None
+        self, *, tenant_id: str, page: int = 1, limit: int = 20, keyword: str = ""
     ) -> dict[str, Any]:
         stmt = select(Agent).where(
             Agent.tenant_id == tenant_id,
@@ -107,7 +107,7 @@ class AgentRosterService:
         }
 
     def list_invite_options(
-        self, *, tenant_id: str, page: int = 1, limit: int = 20, keyword: str | None = None, app_id: str | None = None
+        self, *, tenant_id: str, page: int = 1, limit: int = 20, keyword: str = "", app_id: str | None = None
     ) -> dict[str, Any]:
         result = self.list_roster_agents(tenant_id=tenant_id, page=page, limit=limit, keyword=keyword)
         usage_by_agent_id: dict[str, list[str]] = {}

--- a/api/services/app_generate_service.py
+++ b/api/services/app_generate_service.py
@@ -383,7 +383,7 @@ class AppGenerateService:
         )
 
     @classmethod
-    def _get_workflow(cls, app_model: App, invoke_from: InvokeFrom, workflow_id: str | None = None) -> Workflow:
+    def _get_workflow(cls, app_model: App, invoke_from: InvokeFrom, workflow_id: str = "") -> Workflow:
         """
         Get workflow
         :param app_model: app model

--- a/api/services/async_workflow_service.py
+++ b/api/services/async_workflow_service.py
@@ -308,7 +308,7 @@ class AsyncWorkflowService:
     def _get_workflow(
         workflow_service: WorkflowService,
         app_model: App,
-        workflow_id: str | None = None,
+        workflow_id: str = "",
         session: Session | None = None,
     ) -> Workflow:
         """

--- a/api/services/billing_service.py
+++ b/api/services/billing_service.py
@@ -637,9 +637,9 @@ class BillingService:
         contents: list[LangContentDict],
         frequency: str = "once",
         status: str = "active",
-        notification_id: str | None = None,
-        start_time: str | None = None,
-        end_time: str | None = None,
+        notification_id: str = "",
+        start_time: str = "",
+        end_time: str = "",
     ) -> UpsertNotificationDict:
         """Create or update a notification.
 

--- a/api/services/conversation_service.py
+++ b/api/services/conversation_service.py
@@ -212,7 +212,7 @@ class ConversationService:
         user: Account | EndUser | None,
         limit: int,
         last_id: str | None,
-        variable_name: str | None = None,
+        variable_name: str = "",
     ) -> InfiniteScrollPagination:
         conversation = cls.get_conversation(app_model, conversation_id, user)
 

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -1521,7 +1521,7 @@ class DocumentService:
     }
 
     @staticmethod
-    def get_document(dataset_id: str, document_id: str | None = None) -> Document | None:
+    def get_document(dataset_id: str, document_id: str = "") -> Document | None:
         if document_id:
             document = db.session.scalar(
                 select(Document).where(Document.id == document_id, Document.dataset_id == dataset_id).limit(1)
@@ -3919,7 +3919,7 @@ class SegmentService:
 
     @classmethod
     def get_child_chunks(
-        cls, segment_id: str, document_id: str, dataset_id: str, page: int, limit: int, keyword: str | None = None
+        cls, segment_id: str, document_id: str, dataset_id: str, page: int, limit: int, keyword: str = ""
     ):
         assert isinstance(current_user, Account)
 
@@ -3952,7 +3952,7 @@ class SegmentService:
         document_id: str,
         tenant_id: str,
         status_list: list[str] | None = None,
-        keyword: str | None = None,
+        keyword: str = "",
         page: int = 1,
         limit: int = 20,
     ):

--- a/api/services/datasource_provider_service.py
+++ b/api/services/datasource_provider_service.py
@@ -193,7 +193,7 @@ class DatasourceProviderService:
         tenant_id: str,
         provider: str,
         plugin_id: str,
-        credential_id: str | None = None,
+        credential_id: str = "",
     ) -> dict[str, Any]:
         """
         Return decrypted datasource credentials.

--- a/api/services/model_load_balancing_service.py
+++ b/api/services/model_load_balancing_service.py
@@ -503,7 +503,7 @@ class ModelLoadBalancingService:
         model: str,
         model_type: str,
         credentials: dict[str, Any],
-        config_id: str | None = None,
+        config_id: str = "",
     ):
         """
         Validate load balancing credentials.

--- a/api/services/model_provider_service.py
+++ b/api/services/model_provider_service.py
@@ -53,7 +53,7 @@ class ModelProviderService:
 
         return provider_configuration
 
-    def get_provider_list(self, tenant_id: str, model_type: str | None = None) -> list[ProviderResponse]:
+    def get_provider_list(self, tenant_id: str, model_type: str = "") -> list[ProviderResponse]:
         """
         get provider list.
 

--- a/api/services/plugin/oauth_service.py
+++ b/api/services/plugin/oauth_service.py
@@ -18,7 +18,7 @@ class OAuthProxyService(BasePluginClient):
         plugin_id: str,
         provider: str,
         extra_data: dict[str, Any] = {},
-        credential_id: str | None = None,
+        credential_id: str = "",
     ):
         """
         Create a proxy context for an OAuth 2.0 authorization request.

--- a/api/services/tag_service.py
+++ b/api/services/tag_service.py
@@ -37,7 +37,7 @@ class TagBindingDeletePayload(BaseModel):
 
 class TagService:
     @staticmethod
-    def get_tags(tag_type: str, current_tenant_id: str, keyword: str | None = None):
+    def get_tags(tag_type: str, current_tenant_id: str, keyword: str = ""):
         stmt = (
             select(Tag.id, Tag.type, Tag.name, func.count(TagBinding.id).label("binding_count"))
             .outerjoin(TagBinding, Tag.id == TagBinding.tag_id)

--- a/api/services/trigger/trigger_provider_service.py
+++ b/api/services/trigger/trigger_provider_service.py
@@ -133,7 +133,7 @@ class TriggerProviderService:
         parameters: Mapping[str, Any],
         properties: Mapping[str, Any],
         credentials: Mapping[str, str],
-        subscription_id: str | None = None,
+        subscription_id: str = "",
         credential_expires_at: int = -1,
         expires_at: int = -1,
     ) -> Mapping[str, Any]:
@@ -331,7 +331,7 @@ class TriggerProviderService:
                 )
 
     @classmethod
-    def get_subscription_by_id(cls, tenant_id: str, subscription_id: str | None = None) -> TriggerSubscription | None:
+    def get_subscription_by_id(cls, tenant_id: str, subscription_id: str = "") -> TriggerSubscription | None:
         """
         Get a trigger subscription by the ID.
         """

--- a/api/services/webapp_auth_service.py
+++ b/api/services/webapp_auth_service.py
@@ -132,7 +132,7 @@ class WebAppAuthService:
 
     @classmethod
     def is_app_require_permission_check(
-        cls, app_code: str | None = None, app_id: str | None = None, access_mode: str | None = None
+        cls, app_code: str = "", app_id: str | None = None, access_mode: str = ""
     ) -> bool:
         """
         Check if the app requires permission check based on its access mode.
@@ -154,7 +154,7 @@ class WebAppAuthService:
         return False
 
     @classmethod
-    def get_app_auth_type(cls, app_code: str | None = None, access_mode: str | None = None) -> WebAppAuthType:
+    def get_app_auth_type(cls, app_code: str = "", access_mode: str = "") -> WebAppAuthType:
         """
         Get the authentication type for the app based on its access mode.
         """

--- a/api/services/workflow_service.py
+++ b/api/services/workflow_service.py
@@ -140,7 +140,7 @@ class WorkflowService:
         )
         return db.session.execute(stmt).scalar_one()
 
-    def get_draft_workflow(self, app_model: App, workflow_id: str | None = None) -> Workflow | None:
+    def get_draft_workflow(self, app_model: App, workflow_id: str = "") -> Workflow | None:
         """
         Get draft workflow
         """


### PR DESCRIPTION
## Summary

Replace unnecessary `str | None = None` defaults with `str = ""` in 15 service layer files where the parameter is checked with `if param:` and None has no distinct semantics from empty string.

## Changes

- Updated 15 service files in `api/services/`
- Each change replaces `param: str | None = None` with `param: str = ""`
- No behavioral change since all affected parameters use `if param:` checks

Closes #35557