### PR TITLE
fix: mcp page results shows non mcp tools

### DIFF
--- a/web/app/components/tools/mcp/index.tsx
+++ b/web/app/components/tools/mcp/index.tsx
@@ -40,10 +40,15 @@ const MCPList = ({
 
   const filteredList = useMemo(() => {
     return list.filter((collection) => {
-      if (searchText)
-        return Object.values(collection.name).some(value => (value as string).toLowerCase().includes(searchText.toLowerCase()))
-      return collection.type === 'mcp'
-    }) as ToolWithProvider[]
+      const isMcpType = collection.type === 'mcp'
+      if (searchText) {
+        const matchesSearch = Object.values(collection.name).some(value =>
+          (value as string).toLowerCase().includes(searchText.toLowerCase()),
+        )
+        return isMcpType && matchesSearch
+      }
+      return isMcpType
+    })
   }, [list, searchText])
 
   const [currentProviderID, setCurrentProviderID] = useState<string>()


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #36647 `.

## Summary

Fixes #36647. The MCP page's filter logic in `web/app/components/tools/mcp/index.tsx` had a bug where the `collection.type === 'mcp'` check was only applied when `searchText` was empty. When a search term was entered, the filter returned any tool whose name matched, regardless of type — causing non-MCP tools (e.g., built-in tools) to appear in the MCP results. This fix extracts `isMcpType` into a shared variable so the type constraint is always enforced, even during search.

## Screenshots
| Before | After |
|--------|-------|
| Searching shows non-MCP tools mixed in results | Only MCP-type tools match when searching |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
