### PR TITLE
test(e2e): add dataset creation e2e test

### DIFF
--- a/e2e/features/datasets/create-dataset.feature
+++ b/e2e/features/datasets/create-dataset.feature
@@ -4,7 +4,7 @@ Feature: Create dataset
     Given I am signed in as the default E2E admin
     When I open the datasets page
     And I start creating a new dataset
-    And I select "Create an empty dataset"
+    And I select "Create an empty Knowledge"
     And I enter a unique E2E dataset name
     And I confirm dataset creation
     Then I should land on the dataset document page

--- a/e2e/features/datasets/create-dataset.feature
+++ b/e2e/features/datasets/create-dataset.feature
@@ -1,0 +1,10 @@
+@datasets @authenticated @core
+Feature: Create dataset
+  Scenario: Create a new empty dataset
+    Given I am signed in as the default E2E admin
+    When I open the datasets page
+    And I start creating a new dataset
+    And I select "Create an empty dataset"
+    And I enter a unique E2E dataset name
+    And I confirm dataset creation
+    Then I should land on the dataset document page

--- a/e2e/features/step-definitions/datasets/create-dataset.steps.ts
+++ b/e2e/features/step-definitions/datasets/create-dataset.steps.ts
@@ -8,8 +8,8 @@ When('I open the datasets page', async function (this: DifyWorld) {
 
 When('I start creating a new dataset', async function (this: DifyWorld) {
   const page = this.getPage()
-  await expect(page.getByRole('button', { name: 'Create Dataset' })).toBeVisible()
-  await page.getByRole('button', { name: 'Create Dataset' }).click()
+  await expect(page.getByText('Create Knowledge')).toBeVisible()
+  await page.getByText('Create Knowledge').click()
 })
 
 When('I select {string}', async function (this: DifyWorld, option: string) {
@@ -21,7 +21,7 @@ When('I select {string}', async function (this: DifyWorld, option: string) {
 When('I enter a unique E2E dataset name', async function (this: DifyWorld) {
   const datasetName = `E2E Dataset ${Date.now()}`
   this.lastCreatedDatasetName = datasetName
-  await this.getPage().getByPlaceholder('Dataset name').fill(datasetName)
+  await this.getPage().getByPlaceholder('Please input').fill(datasetName)
 })
 
 When('I confirm dataset creation', async function (this: DifyWorld) {

--- a/e2e/features/step-definitions/datasets/create-dataset.steps.ts
+++ b/e2e/features/step-definitions/datasets/create-dataset.steps.ts
@@ -1,0 +1,36 @@
+import type { DifyWorld } from '../../support/world'
+import { Then, When } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+
+When('I open the datasets page', async function (this: DifyWorld) {
+  await this.getPage().goto('/datasets')
+})
+
+When('I start creating a new dataset', async function (this: DifyWorld) {
+  const page = this.getPage()
+  await expect(page.getByRole('button', { name: 'Create Dataset' })).toBeVisible()
+  await page.getByRole('button', { name: 'Create Dataset' }).click()
+})
+
+When('I select {string}', async function (this: DifyWorld, option: string) {
+  const page = this.getPage()
+  await expect(page.getByText(option)).toBeVisible()
+  await page.getByText(option).click()
+})
+
+When('I enter a unique E2E dataset name', async function (this: DifyWorld) {
+  const datasetName = `E2E Dataset ${Date.now()}`
+  this.lastCreatedDatasetName = datasetName
+  await this.getPage().getByPlaceholder('Dataset name').fill(datasetName)
+})
+
+When('I confirm dataset creation', async function (this: DifyWorld) {
+  const page = this.getPage()
+  const createButton = page.getByRole('button', { name: 'Create' }).last()
+  await expect(createButton).toBeEnabled()
+  await createButton.click()
+})
+
+Then('I should land on the dataset document page', async function (this: DifyWorld) {
+  await expect(this.getPage()).toHaveURL(/\/datasets\/[^/]+\/documents(?:\?.*)?$/)
+})

--- a/e2e/features/support/world.ts
+++ b/e2e/features/support/world.ts
@@ -13,6 +13,7 @@ export class DifyWorld extends World {
   scenarioStartedAt: number | undefined
   session: AuthSessionMetadata | undefined
   lastCreatedAppName: string | undefined
+  lastCreatedDatasetName: string | undefined
   createdAppIds: string[] = []
   capturedDownloads: Download[] = []
   shareURL: string | undefined
@@ -26,6 +27,7 @@ export class DifyWorld extends World {
     this.consoleErrors = []
     this.pageErrors = []
     this.lastCreatedAppName = undefined
+    this.lastCreatedDatasetName = undefined
     this.createdAppIds = []
     this.capturedDownloads = []
     this.shareURL = undefined


### PR DESCRIPTION
## Summary

Add a new e2e test scenario for creating an empty dataset, following the existing Cucumber BDD + Playwright pattern.

Fixes #34278

## Changes

- Added `e2e/features/datasets/create-dataset.feature` with Cucumber scenario
- Added `e2e/features/step-definitions/datasets/create-dataset.steps.ts` with step definitions
- Updated `e2e/features/support/world.ts` to track created dataset names

## Test scenario

```gherkin
@datasets @authenticated @core
Feature: Create dataset
  Scenario: Create a new empty dataset
    Given I am signed in as the default E2E admin
    When I open the datasets page
    And I start creating a new dataset
    And I select "Create an empty dataset"
    And I enter a unique E2E dataset name
    And I confirm dataset creation
    Then I should land on the dataset document page
```

## Checklist

- [x] Title explains the problem clearly
- [x] Tests added/updated (if applicable)
- [x] Documentation updated (if applicable)
- [x] No breaking changes
