### PR TITLE
Fix/marketplace collection templates limit

### DIFF
--- a/web/app/components/plugins/marketplace/utils.ts
+++ b/web/app/components/plugins/marketplace/utils.ts
@@ -205,7 +205,7 @@ export const getMarketplaceTemplateCollectionsAndTemplates = async (
       try {
         const templatesRes = await marketplaceClient.templateCollections.getTemplates({
           params: { collectionName: collection.name },
-          body: { limit: 20 },
+          body: { limit: 100 },
         }, { signal: options?.signal })
         const templatesData = templatesRes.data?.templates || []
         templateCollectionTemplatesMap[collection.name] = templatesData.map(mapTemplateDetailToTemplate)


### PR DESCRIPTION
## Summary
Bump the per-collection template fetch limit from 20 to 100 in the marketplace home's curated-collections layout.

## Background
On the marketplace home page, each template collection (e.g. `featured`) is fetched with `getMarketplaceTemplateCollectionsAndTemplates`. That function hardcodes `body: { limit: 20 }` when calling `POST /template-collections/{name}/templates`. The returned 20 items are then post-filtered on the client by the user's system locale via `useTemplateCollectionsMapFilteredBySystemLanguage` (en / zh / ja / other bucket).

These two caps compound: if a collection has 32 templates on the backend and the user's locale is `en-US`, only the first 20 are fetched, and only the English ones in that slice survive the locale filter — so collections that legitimately have 30+ templates ended up rendering as few as ~10 visible cards even though plenty more matched the user's language on the server.

## Change
- `web/app/components/plugins/marketplace/utils.ts` — change `limit: 20` → `limit: 100` in `getMarketplaceTemplateCollectionsAndTemplates`.

Pagination semantics elsewhere (search results, the templates listing query, the carousel page size) are untouched. The locale post-filter still does its job; it just now has a representative slice to filter over.

## Why 100 (not "remove the cap")
Curated collections aren't paginated on the home page — they render inside a carousel. Keeping a bounded request guards against pathological collection sizes degrading the home load. 100 is large enough that the locale post-filter rarely empties a collection and small enough to keep the response cheap.

## Test plan
- [ ] Load the marketplace home with system locale `en-US`; confirm collections with 30+ templates show their full English subset (previously truncated).
- [ ] Switch system locale to `zh-Hans` / `ja-JP`; confirm the visible set updates and is not silently empty.
- [ ] Search mode and the `/[creationType]/[category]` pages still paginate as before (no regression — those paths don't go through this function).
- [ ] Network tab: each `/template-collections/{name}/templates` POST sends `{ "limit": 100 }`.
