### PR TITLE
refactor: use match case for draft variable serialization

### DIFF
--- a/api/controllers/console/app/workflow_draft_variable.py
+++ b/api/controllers/console/app/workflow_draft_variable.py
@@ -83,15 +83,15 @@ def _serialize_var_value(variable: WorkflowDraftVariable):
     # create a copy of the value to avoid affecting the model cache.
     value = value.model_copy(deep=True)
     # Refresh the url signature before returning it to client.
-    if isinstance(value, FileSegment):
-        file = value.value
-        file.remote_url = file.generate_url()
-    elif isinstance(value, ArrayFileSegment):
-        files = value.value
-        for file in files:
+    match value:
+        case FileSegment():
+            file = value.value
             file.remote_url = file.generate_url()
+        case ArrayFileSegment():
+            files = value.value
+            for file in files:
+                file.remote_url = file.generate_url()
     return _convert_values_to_json_serializable_object(value)
-
 
 def _serialize_variable_type(workflow_draft_var: WorkflowDraftVariable) -> str:
     value_type = workflow_draft_var.value_type

--- a/api/controllers/console/app/workflow_draft_variable.py
+++ b/api/controllers/console/app/workflow_draft_variable.py
@@ -93,6 +93,7 @@ def _serialize_var_value(variable: WorkflowDraftVariable):
                 file.remote_url = file.generate_url()
     return _convert_values_to_json_serializable_object(value)
 
+
 def _serialize_variable_type(workflow_draft_var: WorkflowDraftVariable) -> str:
     value_type = workflow_draft_var.value_type
     return str(value_type.exposed_type())


### PR DESCRIPTION
## Summary

- replace `if isinstance` / `elif isinstance` with `match` / `case` in draft variable serialization
- keep behavior unchanged while aligning with the existing pattern matching style in the same module

## Test

- `python -m compileall -q api/controllers/console/app/workflow_draft_variable.py`

Related to #35902