### PR TITLE
fix(api): raise BadRequest when retrieving parameters for disabled webapp

### DIFF
--- a/api/controllers/web/app.py
+++ b/api/controllers/web/app.py
@@ -4,7 +4,7 @@ from typing import Any, cast
 from flask import request
 from flask_restx import Resource
 from pydantic import BaseModel, ConfigDict, Field
-from werkzeug.exceptions import Unauthorized
+from werkzeug.exceptions import BadRequest, Unauthorized
 
 from constants import HEADER_NAME_APP_CODE
 from controllers.common import fields
@@ -58,6 +58,9 @@ class AppParameterApi(WebApiResource):
     )
     def get(self, app_model: App, end_user: EndUser):
         """Retrieve app parameters."""
+        if not app_model.enable_site:
+            raise BadRequest("Site is disabled.")
+
         if app_model.mode in {AppMode.ADVANCED_CHAT, AppMode.WORKFLOW}:
             workflow = app_model.workflow
             if workflow is None:

--- a/api/tests/unit_tests/controllers/web/test_app.py
+++ b/api/tests/unit_tests/controllers/web/test_app.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
+from werkzeug.exceptions import BadRequest
 
 from controllers.web.app import AppAccessMode, AppMeta, AppParameterApi, AppWebAuthPermission
 from controllers.web.error import AppUnavailableError
@@ -16,13 +17,20 @@ from controllers.web.error import AppUnavailableError
 # AppParameterApi
 # ---------------------------------------------------------------------------
 class TestAppParameterApi:
+    def test_disabled_web_app_raises(self, app: Flask) -> None:
+        app_model = SimpleNamespace(mode="chat", enable_site=False)
+
+        with app.test_request_context("/parameters"):
+            with pytest.raises(BadRequest, match="Site is disabled"):
+                AppParameterApi().get(app_model, SimpleNamespace())
+
     def test_advanced_chat_mode_uses_workflow(self, app: Flask) -> None:
         features_dict = {"opening_statement": "Hello"}
         workflow = SimpleNamespace(
             features_dict=features_dict,
             user_input_form=lambda to_old_structure=False: [],
         )
-        app_model = SimpleNamespace(mode="advanced-chat", workflow=workflow)
+        app_model = SimpleNamespace(mode="advanced-chat", workflow=workflow, enable_site=True)
 
         with (
             app.test_request_context("/parameters"),
@@ -41,7 +49,7 @@ class TestAppParameterApi:
             features_dict=features_dict,
             user_input_form=lambda to_old_structure=False: [{"var": "x"}],
         )
-        app_model = SimpleNamespace(mode="workflow", workflow=workflow)
+        app_model = SimpleNamespace(mode="workflow", workflow=workflow, enable_site=True)
 
         with (
             app.test_request_context("/parameters"),
@@ -54,14 +62,14 @@ class TestAppParameterApi:
         mock_params.assert_called_once_with(features_dict=features_dict, user_input_form=[{"var": "x"}])
 
     def test_advanced_chat_mode_no_workflow_raises(self, app: Flask) -> None:
-        app_model = SimpleNamespace(mode="advanced-chat", workflow=None)
+        app_model = SimpleNamespace(mode="advanced-chat", workflow=None, enable_site=True)
         with app.test_request_context("/parameters"):
             with pytest.raises(AppUnavailableError):
                 AppParameterApi().get(app_model, SimpleNamespace())
 
     def test_standard_mode_uses_app_model_config(self, app: Flask) -> None:
         config = SimpleNamespace(to_dict=lambda: {"user_input_form": [{"var": "y"}], "key": "val"})
-        app_model = SimpleNamespace(mode="chat", app_model_config=config)
+        app_model = SimpleNamespace(mode="chat", app_model_config=config, enable_site=True)
 
         with (
             app.test_request_context("/parameters"),
@@ -75,7 +83,7 @@ class TestAppParameterApi:
         assert call_kwargs.kwargs["user_input_form"] == [{"var": "y"}]
 
     def test_standard_mode_no_config_raises(self, app: Flask) -> None:
-        app_model = SimpleNamespace(mode="chat", app_model_config=None)
+        app_model = SimpleNamespace(mode="chat", app_model_config=None, enable_site=True)
         with app.test_request_context("/parameters"):
             with pytest.raises(AppUnavailableError):
                 AppParameterApi().get(app_model, SimpleNamespace())


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
