### PR TITLE
feat: add answer regeneration branches

### DIFF
--- a/api/controllers/service_api/app/completion.py
+++ b/api/controllers/service_api/app/completion.py
@@ -37,6 +37,8 @@ from services.app_generate_service import AppGenerateService
 from services.app_task_service import AppTaskService
 from services.errors.app import IsDraftWorkflowError, WorkflowIdFormatError, WorkflowNotFoundError
 from services.errors.llm import InvokeRateLimitError
+from services.errors.message import MessageBranchMismatchError, MessageNotExistsError
+from services.message_service import MessageService
 
 logger = logging.getLogger(__name__)
 
@@ -215,6 +217,91 @@ class ChatApi(Resource):
             )
 
             return helper.compact_generate_response(response)
+        except WorkflowNotFoundError as ex:
+            raise NotFound(str(ex))
+        except IsDraftWorkflowError as ex:
+            raise BadRequest(str(ex))
+        except WorkflowIdFormatError as ex:
+            raise BadRequest(str(ex))
+        except services.errors.conversation.ConversationNotExistsError:
+            raise NotFound("Conversation Not Exists.")
+        except services.errors.conversation.ConversationCompletedError:
+            raise ConversationCompletedError()
+        except services.errors.app_model_config.AppModelConfigBrokenError:
+            logger.exception("App model config broken.")
+            raise AppUnavailableError()
+        except ProviderTokenNotInitError as ex:
+            raise ProviderNotInitializeError(ex.description)
+        except QuotaExceededError:
+            raise ProviderQuotaExceededError()
+        except ModelCurrentlyNotSupportError:
+            raise ProviderModelCurrentlyNotSupportError()
+        except InvokeRateLimitError as ex:
+            raise InvokeRateLimitHttpError(ex.description)
+        except InvokeError as e:
+            raise CompletionRequestError(e.description)
+        except ValueError as e:
+            raise e
+        except Exception:
+            logger.exception("internal server error.")
+            raise InternalServerError()
+
+
+@service_api_ns.route("/chat-messages/<uuid:message_id>/regenerate")
+class ChatRegenerateApi(Resource):
+    @service_api_ns.expect(service_api_ns.models[ChatRequestPayload.__name__])
+    @service_api_ns.doc("regenerate_chat_message")
+    @service_api_ns.doc(description="Regenerate an answer variant for the latest active chat message")
+    @service_api_ns.doc(params={"message_id": "Latest active answer message ID to regenerate from"})
+    @service_api_ns.doc(
+        responses={
+            200: "Message regenerated successfully",
+            400: "Bad request - invalid parameters, workflow issues, or inactive message branch",
+            401: "Unauthorized - invalid API token",
+            404: "Message, conversation, or workflow not found",
+            429: "Rate limit exceeded",
+            500: "Internal server error",
+        }
+    )
+    @validate_app_token(fetch_user_arg=FetchUserArg(fetch_from=WhereisUserArg.JSON, required=True))
+    def post(self, app_model: App, end_user: EndUser, message_id: UUID):
+        """Regenerate the latest active answer variant for chat, agent chat, and advanced chat applications."""
+        app_mode = AppMode.value_of(app_model.mode)
+        if app_mode not in {AppMode.CHAT, AppMode.AGENT_CHAT, AppMode.ADVANCED_CHAT}:
+            raise NotChatAppError()
+
+        payload = ChatRequestPayload.model_validate(service_api_ns.payload or {})
+
+        external_trace_id = get_external_trace_id(request)
+        args = payload.model_dump(exclude_none=True)
+        if external_trace_id:
+            args["external_trace_id"] = external_trace_id
+
+        streaming = payload.response_mode == "streaming"
+
+        try:
+            source_message = MessageService.get_regenerate_source_message(
+                app_model=app_model,
+                user=end_user,
+                message_id=str(message_id),
+                conversation_id=payload.conversation_id,
+            )
+            args["conversation_id"] = source_message.conversation_id
+            args["_regenerate_parent_message_id"] = source_message.parent_message_id
+
+            response = AppGenerateService.generate(
+                app_model=app_model,
+                user=end_user,
+                args=args,
+                invoke_from=InvokeFrom.SERVICE_API,
+                streaming=streaming,
+            )
+
+            return helper.compact_generate_response(response)
+        except MessageNotExistsError:
+            raise NotFound("Message Not Exists.")
+        except MessageBranchMismatchError:
+            raise BadRequest("Message branch mismatch.")
         except WorkflowNotFoundError as ex:
             raise NotFound(str(ex))
         except IsDraftWorkflowError as ex:

--- a/api/controllers/service_api/app/message.py
+++ b/api/controllers/service_api/app/message.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from flask import request
 from flask_restx import Resource
-from pydantic import BaseModel, Field, TypeAdapter
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
 
 import services
@@ -14,12 +14,14 @@ from controllers.service_api import service_api_ns
 from controllers.service_api.app.error import NotChatAppError
 from controllers.service_api.wraps import FetchUserArg, WhereisUserArg, validate_app_token
 from core.app.entities.app_invoke_entities import InvokeFrom
+from fields.base import ResponseModel
 from fields.conversation_fields import ResultResponse
 from fields.message_fields import MessageInfiniteScrollPagination, MessageListItem
 from models.enums import FeedbackRating
 from models.model import App, AppMode, EndUser
 from services.errors.message import (
     FirstMessageNotExistsError,
+    MessageBranchMismatchError,
     MessageNotExistsError,
     SuggestedQuestionsAfterAnswerDisabledError,
 )
@@ -33,8 +35,27 @@ class FeedbackListQuery(BaseModel):
     limit: int = Field(default=20, ge=1, le=101, description="Number of feedbacks per page")
 
 
-register_schema_models(service_api_ns, MessageListQuery, MessageFeedbackPayload, FeedbackListQuery)
-register_response_schema_models(service_api_ns, ResultResponse, SimpleResultStringListResponse)
+class MessageSwitchPayload(BaseModel):
+    target_message_id: UUID = Field(description="Target answer message ID")
+    user: str = Field(description="End-user identifier")
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class MessageSwitchResponse(ResponseModel):
+    result: str = "success"
+    active_message_id: str
+
+
+register_schema_models(
+    service_api_ns, MessageListQuery, MessageFeedbackPayload, FeedbackListQuery, MessageSwitchPayload
+)
+register_response_schema_models(
+    service_api_ns,
+    ResultResponse,
+    SimpleResultStringListResponse,
+    MessageSwitchResponse,
+)
 
 
 @service_api_ns.route("/messages")
@@ -116,6 +137,49 @@ class MessageFeedbackApi(Resource):
             raise NotFound("Message Not Exists.")
 
         return ResultResponse(result="success").model_dump(mode="json")
+
+
+@service_api_ns.route("/chat-messages/<uuid:message_id>/switch")
+class MessageSwitchApi(Resource):
+    @service_api_ns.expect(service_api_ns.models[MessageSwitchPayload.__name__])
+    @service_api_ns.response(
+        200,
+        "Active answer switched successfully",
+        service_api_ns.models[MessageSwitchResponse.__name__],
+    )
+    @service_api_ns.doc("switch_chat_message_answer")
+    @service_api_ns.doc(description="Switch the active answer variant for a chat message")
+    @service_api_ns.doc(params={"message_id": "Current answer message ID"})
+    @service_api_ns.doc(
+        responses={
+            200: "Active answer switched successfully",
+            400: "Target answer is not in the current active answer branch",
+            401: "Unauthorized - invalid API token",
+            404: "Message not found",
+        }
+    )
+    @validate_app_token(fetch_user_arg=FetchUserArg(fetch_from=WhereisUserArg.JSON, required=True))
+    def post(self, app_model: App, end_user: EndUser, message_id: UUID):
+        """Switch the latest active answer variant used by future chat turns."""
+        app_mode = AppMode.value_of(app_model.mode)
+        if app_mode not in {AppMode.CHAT, AppMode.AGENT_CHAT, AppMode.ADVANCED_CHAT}:
+            raise NotChatAppError()
+
+        payload = MessageSwitchPayload.model_validate(service_api_ns.payload or {})
+
+        try:
+            target_message = MessageService.switch_active_message(
+                app_model=app_model,
+                user=end_user,
+                message_id=str(message_id),
+                target_message_id=str(payload.target_message_id),
+            )
+        except MessageNotExistsError:
+            raise NotFound("Message Not Exists.")
+        except MessageBranchMismatchError:
+            raise BadRequest("Message branch mismatch.")
+
+        return MessageSwitchResponse(active_message_id=target_message.id).model_dump(mode="json")
 
 
 @service_api_ns.route("/app/feedbacks")

--- a/api/core/app/apps/advanced_chat/app_generator.py
+++ b/api/core/app/apps/advanced_chat/app_generator.py
@@ -182,6 +182,11 @@ class AdvancedChatAppGenerator(MessageBasedAppGenerator):
             trace_manager = TraceQueueManager(
                 app_id=app_model.id, user_id=user.id if isinstance(user, Account) else user.session_id
             )
+            use_internal_parent_message_id, internal_parent_message_id = self._get_internal_parent_message_id(
+                args=args,
+                invoke_from=invoke_from,
+                conversation=conversation,
+            )
 
             if invoke_from == InvokeFrom.DEBUGGER:
                 # always enable retriever resource in debugger mode
@@ -203,6 +208,8 @@ class AdvancedChatAppGenerator(MessageBasedAppGenerator):
                     if invoke_from not in {InvokeFrom.SERVICE_API, InvokeFrom.OPENAPI}
                     else UUID_NIL
                 ),
+                internal_parent_message_id=internal_parent_message_id,
+                use_internal_parent_message_id=use_internal_parent_message_id,
                 user_id=user.id,
                 stream=streaming,
                 invoke_from=invoke_from,
@@ -512,7 +519,10 @@ class AdvancedChatAppGenerator(MessageBasedAppGenerator):
             # get conversation dialogue count
             # NOTE: dialogue_count should not start from 0,
             # because during the first conversation, dialogue_count should be 1.
-            self._dialogue_count = get_thread_messages_length(conversation.id) + 1
+            self._dialogue_count = get_thread_messages_length(
+                conversation.id,
+                active_message_id=conversation.active_message_id,
+            ) + 1
 
             # init queue manager
             queue_manager = MessageBasedAppQueueManager(

--- a/api/core/app/apps/agent_chat/app_generator.py
+++ b/api/core/app/apps/agent_chat/app_generator.py
@@ -154,6 +154,11 @@ class AgentChatAppGenerator(MessageBasedAppGenerator):
 
             # get tracing instance
             trace_manager = TraceQueueManager(app_model.id, user.id if isinstance(user, Account) else user.session_id)
+            use_internal_parent_message_id, internal_parent_message_id = self._get_internal_parent_message_id(
+                args=args,
+                invoke_from=invoke_from,
+                conversation=conversation,
+            )
 
             # init application generate entity
             application_generate_entity = AgentChatAppGenerateEntity(
@@ -172,6 +177,8 @@ class AgentChatAppGenerator(MessageBasedAppGenerator):
                     if invoke_from not in {InvokeFrom.SERVICE_API, InvokeFrom.OPENAPI}
                     else UUID_NIL
                 ),
+                internal_parent_message_id=internal_parent_message_id,
+                use_internal_parent_message_id=use_internal_parent_message_id,
                 user_id=user.id,
                 stream=streaming,
                 invoke_from=invoke_from,

--- a/api/core/app/apps/chat/app_generator.py
+++ b/api/core/app/apps/chat/app_generator.py
@@ -148,6 +148,11 @@ class ChatAppGenerator(MessageBasedAppGenerator):
             trace_manager = TraceQueueManager(
                 app_id=app_model.id, user_id=user.id if isinstance(user, Account) else user.session_id
             )
+            use_internal_parent_message_id, internal_parent_message_id = self._get_internal_parent_message_id(
+                args=args,
+                invoke_from=invoke_from,
+                conversation=conversation,
+            )
 
             # init application generate entity
             application_generate_entity = ChatAppGenerateEntity(
@@ -166,6 +171,8 @@ class ChatAppGenerator(MessageBasedAppGenerator):
                     if invoke_from not in {InvokeFrom.SERVICE_API, InvokeFrom.OPENAPI}
                     else UUID_NIL
                 ),
+                internal_parent_message_id=internal_parent_message_id,
+                use_internal_parent_message_id=use_internal_parent_message_id,
                 user_id=user.id,
                 invoke_from=invoke_from,
                 extras=extras,

--- a/api/core/app/apps/message_based_app_generator.py
+++ b/api/core/app/apps/message_based_app_generator.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from collections.abc import Callable, Generator, Mapping
-from typing import Union, cast
+from typing import Any, Union, cast
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -44,6 +44,22 @@ logger = logging.getLogger(__name__)
 
 
 class MessageBasedAppGenerator(BaseAppGenerator):
+    def _get_internal_parent_message_id(
+        self,
+        args: Mapping[str, Any],
+        invoke_from: InvokeFrom,
+        conversation: Conversation | None,
+    ) -> tuple[bool, str | None]:
+        if "_regenerate_parent_message_id" in args:
+            return True, cast(str | None, args["_regenerate_parent_message_id"])
+
+        if invoke_from in {InvokeFrom.SERVICE_API, InvokeFrom.OPENAPI} and conversation is not None:
+            active_message_id = getattr(conversation, "active_message_id", None)
+            if active_message_id:
+                return True, active_message_id
+
+        return False, None
+
     def _handle_response(
         self,
         application_generate_entity: Union[
@@ -189,6 +205,13 @@ class MessageBasedAppGenerator(BaseAppGenerator):
             else:
                 conversation.updated_at = naive_utc_now()
 
+            parent_message_id = getattr(application_generate_entity, "parent_message_id", None)
+            if (
+                isinstance(application_generate_entity, ConversationAppGenerateEntity)
+                and application_generate_entity.use_internal_parent_message_id
+            ):
+                parent_message_id = application_generate_entity.internal_parent_message_id
+
             message = Message(
                 app_id=app_config.app_id,
                 model_provider=model_provider,
@@ -205,7 +228,7 @@ class MessageBasedAppGenerator(BaseAppGenerator):
                 answer_tokens=0,
                 answer_unit_price=0,
                 answer_price_unit=0,
-                parent_message_id=getattr(application_generate_entity, "parent_message_id", None),
+                parent_message_id=parent_message_id,
                 provider_response_latency=0,
                 total_price=0,
                 currency="USD",
@@ -219,6 +242,8 @@ class MessageBasedAppGenerator(BaseAppGenerator):
             db.session.add(message)
             db.session.flush()
             db.session.refresh(message)
+            if isinstance(application_generate_entity, ConversationAppGenerateEntity):
+                conversation.active_message_id = message.id
 
             message_files = []
             for file in application_generate_entity.files:

--- a/api/core/app/entities/app_invoke_entities.py
+++ b/api/core/app/entities/app_invoke_entities.py
@@ -167,6 +167,16 @@ class ConversationAppGenerateEntity(AppGenerateEntity):
             "It needs to be set to UUID_NIL so that the subsequent processing will treat it as legacy messages."
         ),
     )
+    internal_parent_message_id: str | None = Field(
+        default=None,
+        exclude=True,
+        description="Internal branch parent used by service/openapi generation without exposing parent_message_id.",
+    )
+    use_internal_parent_message_id: bool = Field(
+        default=False,
+        exclude=True,
+        description="Whether internal_parent_message_id was explicitly resolved and should override parent_message_id.",
+    )
 
     @field_validator("parent_message_id")
     @classmethod

--- a/api/core/memory/token_buffer_memory.py
+++ b/api/core/memory/token_buffer_memory.py
@@ -145,7 +145,10 @@ class TokenBufferMemory:
 
         # instead of all messages from the conversation, we only need to extract messages
         # that belong to the thread of last message
-        thread_messages = extract_thread_messages(messages)
+        active_message_id = getattr(self.conversation, "active_message_id", None)
+        if not isinstance(active_message_id, str):
+            active_message_id = None
+        thread_messages = extract_thread_messages(messages, active_message_id=active_message_id)
 
         # for newly created message, its answer is temporarily empty, we don't need to add it to memory
         if thread_messages and not thread_messages[0].answer and thread_messages[0].answer_tokens == 0:

--- a/api/core/prompt/utils/extract_thread_messages.py
+++ b/api/core/prompt/utils/extract_thread_messages.py
@@ -4,11 +4,23 @@ from constants import UUID_NIL
 from models import Message
 
 
-def extract_thread_messages(messages: Sequence[Message]):
+def extract_thread_messages(messages: Sequence[Message], active_message_id: str | None = None):
+    """
+    Extract the visible message thread from newest-to-oldest messages.
+
+    When active_message_id is provided, branch traversal starts from that message so regenerated sibling answers newer
+    than the active answer do not leak into memory.
+    """
     thread_messages: list[Message] = []
     next_message = None
+    active_message_found = active_message_id is None
 
     for message in messages:
+        if not active_message_found:
+            if message.id != active_message_id:
+                continue
+            active_message_found = True
+
         if not message.parent_message_id:
             # If the message is regenerated and does not have a parent message, it is the start of a new thread
             thread_messages.append(message)
@@ -16,10 +28,17 @@ def extract_thread_messages(messages: Sequence[Message]):
 
         if not next_message:
             thread_messages.append(message)
+            if active_message_id and message.parent_message_id == UUID_NIL:
+                break
             next_message = message.parent_message_id
         else:
-            if next_message in {message.id, UUID_NIL}:
+            if message.id == next_message or (not active_message_id and next_message == UUID_NIL):
                 thread_messages.append(message)
+                if active_message_id and message.parent_message_id == UUID_NIL:
+                    break
                 next_message = message.parent_message_id
+
+    if active_message_id and not thread_messages:
+        return extract_thread_messages(messages)
 
     return thread_messages

--- a/api/core/prompt/utils/get_thread_messages_length.py
+++ b/api/core/prompt/utils/get_thread_messages_length.py
@@ -5,7 +5,7 @@ from extensions.ext_database import db
 from models.model import Message
 
 
-def get_thread_messages_length(conversation_id: str) -> int:
+def get_thread_messages_length(conversation_id: str, active_message_id: str | None = None) -> int:
     """
     Get the number of thread messages based on the parent message id.
     """
@@ -15,7 +15,7 @@ def get_thread_messages_length(conversation_id: str) -> int:
     messages = db.session.scalars(stmt).all()
 
     # Extract thread messages
-    thread_messages = extract_thread_messages(messages)
+    thread_messages = extract_thread_messages(messages, active_message_id=active_message_id)
 
     # Exclude the newly created message with an empty answer
     if thread_messages and not thread_messages[0].answer:

--- a/api/fields/message_fields.py
+++ b/api/fields/message_fields.py
@@ -47,6 +47,10 @@ class MessageListItem(ResponseModel):
     id: str
     conversation_id: str
     parent_message_id: str | None = None
+    is_active: bool = False
+    is_in_active_thread: bool = False
+    can_switch: bool = False
+    can_regenerate: bool = False
     inputs: dict[str, JSONValueType]
     query: str
     answer: str = Field(validation_alias="re_sign_file_url_answer")

--- a/api/migrations/versions/2026_05_26_1200-3b8f4d2a9c61_add_active_message_id_to_conversations.py
+++ b/api/migrations/versions/2026_05_26_1200-3b8f4d2a9c61_add_active_message_id_to_conversations.py
@@ -1,0 +1,30 @@
+"""add active_message_id to conversations
+
+Revision ID: 3b8f4d2a9c61
+Revises: d4a5e1f3c9b7
+Create Date: 2026-05-26 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+import models
+
+# revision identifiers, used by Alembic.
+revision = "3b8f4d2a9c61"
+down_revision = "d4a5e1f3c9b7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("conversations", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("active_message_id", models.types.StringUUID(), nullable=True))
+        batch_op.create_index("conversation_active_message_idx", ["active_message_id"], unique=False)
+
+
+def downgrade():
+    with op.batch_alter_table("conversations", schema=None) as batch_op:
+        batch_op.drop_index("conversation_active_message_idx")
+        batch_op.drop_column("active_message_id")

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -260,6 +260,7 @@ class ConversationDict(TypedDict):
     id: str
     app_id: str
     app_model_config_id: str | None
+    active_message_id: str | None
     model_provider: str | None
     override_model_configs: str | None
     model_id: str | None
@@ -1058,11 +1059,13 @@ class Conversation(Base):
             sa.text("updated_at DESC"),
             postgresql_where=sa.text("is_deleted IS false"),
         ),
+        sa.Index("conversation_active_message_idx", "active_message_id"),
     )
 
     id: Mapped[str] = mapped_column(StringUUID, default=lambda: str(uuid4()))
     app_id = mapped_column(StringUUID, nullable=False)
     app_model_config_id = mapped_column(StringUUID, nullable=True)
+    active_message_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     model_provider = mapped_column(String(255), nullable=True)
     override_model_configs = mapped_column(LongText)
     model_id = mapped_column(String(255), nullable=True)
@@ -1367,6 +1370,7 @@ class Conversation(Base):
             "id": self.id,
             "app_id": self.app_id,
             "app_model_config_id": self.app_model_config_id,
+            "active_message_id": self.active_message_id,
             "model_provider": self.model_provider,
             "override_model_configs": self.override_model_configs,
             "model_id": self.model_id,

--- a/api/openapi/markdown/service-swagger.md
+++ b/api/openapi/markdown/service-swagger.md
@@ -245,6 +245,65 @@ Supports conversation management and both blocking and streaming response modes.
 | 429 | Rate limit exceeded |
 | 500 | Internal server error |
 
+### /chat-messages/{message_id}/regenerate
+
+#### POST
+##### Summary
+
+Regenerate an answer variant for the latest active chat message
+
+##### Description
+
+Regenerate an answer variant for the latest active chat message.
+Only the latest active answer returned by `/messages` with `can_regenerate=true` can be regenerated. The request payload contains the input for this regeneration and does not include the previous answer output. The regenerated answer becomes the active answer for future chat turns.
+
+##### Parameters
+
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ------ |
+| payload | body |  | Yes | [ChatRequestPayload](#chatrequestpayload) |
+| message_id | path | Latest active answer message ID to regenerate from | Yes | string |
+
+##### Responses
+
+| Code | Description |
+| ---- | ----------- |
+| 200 | Message regenerated successfully |
+| 400 | Bad request - invalid parameters, workflow issues, or inactive message branch |
+| 401 | Unauthorized - invalid API token |
+| 404 | Message, conversation, or workflow not found |
+| 429 | Rate limit exceeded |
+| 500 | Internal server error |
+
+### /chat-messages/{message_id}/switch
+
+#### POST
+##### Summary
+
+Switch the active answer variant for a chat message
+
+##### Description
+
+Switch the active answer variant for the latest answer group. `message_id` is the current latest active answer ID, and `target_message_id` is another candidate answer ID in the same latest answer group. After switching, future chat turns continue from the returned `active_message_id`.
+
+Only the latest answer group can be switched. Once the user sends the next chat turn, previous answer groups are locked and can no longer be switched.
+
+##### Parameters
+
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ------ |
+| payload | body |  | Yes | [MessageSwitchPayload](#messageswitchpayload) |
+| message_id | path | Current answer message ID | Yes | string |
+
+##### Responses
+
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Active answer switched successfully | [MessageSwitchResponse](#messageswitchresponse) |
+| 400 | Target answer is not in the current active answer branch |  |
+| 401 | Unauthorized - invalid API token |  |
+| 404 | Message not found |  |
+
 ### /chat-messages/{task_id}/stop
 
 #### POST
@@ -1797,6 +1856,7 @@ List messages in a conversation
 
 List messages in a conversation
 Retrieves messages with pagination support using first_id.
+Message items include answer branch metadata: `is_active` marks the active answer used by future chat turns, `is_in_active_thread` marks whether the message is in the current backend context branch, `can_switch` marks candidates in the latest switchable answer group, and `can_regenerate` marks the latest active answer that can be regenerated.
 
 ##### Parameters
 
@@ -2750,6 +2810,20 @@ Note: The SQLAlchemy model defines an `is_anonymous` property for Flask-Login se
 | conversation_id | string | Conversation UUID | Yes |
 | first_id | string | First message ID for pagination | No |
 | limit | integer | Number of messages to return (1-100) | No |
+
+#### MessageSwitchPayload
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| target_message_id | string | Target answer message ID | Yes |
+| user | string | End-user identifier | Yes |
+
+#### MessageSwitchResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| active_message_id | string | Active answer message ID after switching | Yes |
+| result | string |  | Yes |
 
 #### MetadataArgs
 

--- a/api/services/errors/message.py
+++ b/api/services/errors/message.py
@@ -13,5 +13,9 @@ class MessageNotExistsError(BaseServiceError):
     pass
 
 
+class MessageBranchMismatchError(BaseServiceError):
+    pass
+
+
 class SuggestedQuestionsAfterAnswerDisabledError(BaseServiceError):
     pass

--- a/api/services/message_service.py
+++ b/api/services/message_service.py
@@ -35,6 +35,7 @@ from services.conversation_service import ConversationService
 from services.errors.message import (
     FirstMessageNotExistsError,
     LastMessageNotExistsError,
+    MessageBranchMismatchError,
     MessageNotExistsError,
     SuggestedQuestionsAfterAnswerDisabledError,
 )
@@ -61,6 +62,37 @@ def attach_message_extra_contents(messages: Sequence[Message]) -> None:
 
 
 class MessageService:
+    @staticmethod
+    def _apply_message_activity_flags(messages: Sequence[Message], active_message_id: str | None) -> None:
+        active_id = active_message_id if isinstance(active_message_id, str) else None
+        message_by_id = {message.id: message for message in messages}
+        active_message = message_by_id.get(active_id) if active_id else None
+
+        active_thread_ids: set[str] = set()
+        current_message = active_message
+        while current_message and current_message.id not in active_thread_ids:
+            active_thread_ids.add(current_message.id)
+            parent_message_id = current_message.parent_message_id
+            if not parent_message_id:
+                break
+            current_message = message_by_id.get(parent_message_id)
+
+        active_parent_message_id = active_message.parent_message_id if active_message else None
+        active_group_size = sum(
+            1
+            for message in messages
+            if active_message is not None and message.parent_message_id == active_parent_message_id
+        )
+        for message in messages:
+            message.is_active = active_id == message.id
+            message.is_in_active_thread = message.id in active_thread_ids
+            message.can_switch = (
+                active_message is not None
+                and active_group_size > 1
+                and message.parent_message_id == active_parent_message_id
+            )
+            message.can_regenerate = active_id == message.id
+
     @classmethod
     def pagination_by_first_id(
         cls,
@@ -118,6 +150,7 @@ class MessageService:
             history_messages = list(reversed(history_messages))
 
         attach_message_extra_contents(history_messages)
+        cls._apply_message_activity_flags(history_messages, getattr(conversation, "active_message_id", None))
 
         return InfiniteScrollPagination(data=history_messages, limit=limit, has_more=has_more)
 
@@ -244,6 +277,66 @@ class MessageService:
 
         if not message:
             raise MessageNotExistsError()
+
+        return message
+
+    @classmethod
+    def switch_active_message(
+        cls,
+        *,
+        app_model: App,
+        user: Account | EndUser | None,
+        message_id: str,
+        target_message_id: str,
+    ) -> Message:
+        if not user:
+            raise ValueError("user cannot be None")
+
+        source_message = cls.get_message(app_model=app_model, user=user, message_id=message_id)
+        target_message = cls.get_message(app_model=app_model, user=user, message_id=target_message_id)
+
+        if (
+            source_message.conversation_id != target_message.conversation_id
+            or source_message.parent_message_id != target_message.parent_message_id
+        ):
+            raise MessageBranchMismatchError()
+
+        conversation = ConversationService.get_conversation(
+            app_model=app_model,
+            user=user,
+            conversation_id=source_message.conversation_id,
+        )
+        if getattr(conversation, "active_message_id", None) != source_message.id:
+            raise MessageBranchMismatchError()
+
+        conversation.active_message_id = target_message.id
+        db.session.commit()
+
+        return target_message
+
+    @classmethod
+    def get_regenerate_source_message(
+        cls,
+        *,
+        app_model: App,
+        user: Account | EndUser | None,
+        message_id: str,
+        conversation_id: str | None,
+    ) -> Message:
+        if not user:
+            raise ValueError("user cannot be None")
+
+        message = cls.get_message(app_model=app_model, user=user, message_id=message_id)
+        if conversation_id is not None and message.conversation_id != conversation_id:
+            raise MessageBranchMismatchError()
+
+        conversation = ConversationService.get_conversation(
+            app_model=app_model,
+            user=user,
+            conversation_id=message.conversation_id,
+        )
+        if getattr(conversation, "active_message_id", None) != message.id:
+            raise MessageBranchMismatchError()
 
         return message
 

--- a/api/tests/unit_tests/controllers/service_api/app/test_completion.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_completion.py
@@ -11,6 +11,7 @@ Focus on:
 - Error types and their mappings
 """
 
+import sys
 import uuid
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -23,6 +24,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 import services
 from controllers.service_api.app.completion import (
     ChatApi,
+    ChatRegenerateApi,
     ChatRequestPayload,
     ChatStopApi,
     CompletionApi,
@@ -34,6 +36,7 @@ from controllers.service_api.app.error import (
     ConversationCompletedError,
     NotChatAppError,
 )
+from core.app.entities.app_invoke_entities import InvokeFrom
 from core.errors.error import QuotaExceededError
 from graphon.model_runtime.errors.invoke import InvokeError
 from models.model import App, AppMode, EndUser
@@ -42,6 +45,8 @@ from services.app_task_service import AppTaskService
 from services.errors.app import IsDraftWorkflowError, WorkflowIdFormatError, WorkflowNotFoundError
 from services.errors.conversation import ConversationNotExistsError
 from services.errors.llm import InvokeRateLimitError
+from services.errors.message import MessageBranchMismatchError, MessageNotExistsError
+from services.message_service import MessageService
 
 
 def _unwrap(func):
@@ -511,6 +516,124 @@ class TestChatApiController:
         with app.test_request_context("/chat-messages", method="POST", json={"inputs": {}, "query": "hi"}):
             with pytest.raises(BadRequest):
                 handler(api, app_model=app_model, end_user=end_user)
+
+
+class TestChatRegenerateApiController:
+    def test_wrong_mode(self, app: Flask) -> None:
+        api = ChatRegenerateApi()
+        handler = _unwrap(api.post)
+        app_model = SimpleNamespace(mode=AppMode.COMPLETION.value)
+        end_user = SimpleNamespace()
+
+        with app.test_request_context(
+            "/chat-messages/m1/regenerate", method="POST", json={"inputs": {}, "query": "hi"}
+        ):
+            with pytest.raises(NotChatAppError):
+                handler(api, app_model=app_model, end_user=end_user, message_id=uuid.uuid4())
+
+    def test_success_uses_source_parent_as_internal_regenerate_parent(
+        self, app: Flask, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        message_id = str(uuid.uuid4())
+        conversation_id = str(uuid.uuid4())
+        parent_message_id = str(uuid.uuid4())
+        source_message = SimpleNamespace(conversation_id=conversation_id, parent_message_id=parent_message_id)
+        generate_calls = []
+
+        monkeypatch.setattr(MessageService, "get_regenerate_source_message", lambda **_kwargs: source_message)
+
+        def fake_generate(**kwargs):
+            generate_calls.append(kwargs)
+            return {"answer": "new answer"}
+
+        monkeypatch.setattr(AppGenerateService, "generate", fake_generate)
+        completion_module = sys.modules[ChatRegenerateApi.__module__]
+        monkeypatch.setattr(
+            completion_module.helper,
+            "compact_generate_response",
+            lambda response: {"compacted": response["answer"]},
+        )
+
+        api = ChatRegenerateApi()
+        handler = _unwrap(api.post)
+        app_model = SimpleNamespace(mode=AppMode.CHAT.value)
+        end_user = SimpleNamespace()
+
+        with app.test_request_context(
+            f"/chat-messages/{message_id}/regenerate",
+            method="POST",
+            json={"inputs": {"topic": "x"}, "query": "retry", "response_mode": "blocking"},
+        ):
+            response = handler(api, app_model=app_model, end_user=end_user, message_id=uuid.UUID(message_id))
+
+        assert response == {"compacted": "new answer"}
+        assert generate_calls == [
+            {
+                "app_model": app_model,
+                "user": end_user,
+                "args": {
+                    "inputs": {"topic": "x"},
+                    "query": "retry",
+                    "response_mode": "blocking",
+                    "retriever_from": "dev",
+                    "auto_generate_name": True,
+                    "conversation_id": conversation_id,
+                    "_regenerate_parent_message_id": parent_message_id,
+                },
+                "invoke_from": InvokeFrom.SERVICE_API,
+                "streaming": False,
+            }
+        ]
+
+    def test_not_found(self, app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            MessageService,
+            "get_regenerate_source_message",
+            lambda **_kwargs: (_ for _ in ()).throw(MessageNotExistsError()),
+        )
+
+        api = ChatRegenerateApi()
+        handler = _unwrap(api.post)
+        app_model = SimpleNamespace(mode=AppMode.CHAT.value)
+        end_user = SimpleNamespace()
+
+        with app.test_request_context(
+            "/chat-messages/00000000-0000-0000-0000-000000000001/regenerate",
+            method="POST",
+            json={"inputs": {}, "query": "hi"},
+        ):
+            with pytest.raises(NotFound):
+                handler(
+                    api,
+                    app_model=app_model,
+                    end_user=end_user,
+                    message_id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+                )
+
+    def test_conversation_mismatch(self, app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            MessageService,
+            "get_regenerate_source_message",
+            lambda **_kwargs: (_ for _ in ()).throw(MessageBranchMismatchError()),
+        )
+
+        api = ChatRegenerateApi()
+        handler = _unwrap(api.post)
+        app_model = SimpleNamespace(mode=AppMode.CHAT.value)
+        end_user = SimpleNamespace()
+
+        with app.test_request_context(
+            "/chat-messages/00000000-0000-0000-0000-000000000001/regenerate",
+            method="POST",
+            json={"inputs": {}, "query": "hi", "conversation_id": "00000000-0000-0000-0000-000000000002"},
+        ):
+            with pytest.raises(BadRequest):
+                handler(
+                    api,
+                    app_model=app_model,
+                    end_user=end_user,
+                    message_id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+                )
 
 
 class TestChatStopApiController:

--- a/api/tests/unit_tests/controllers/service_api/app/test_message.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_message.py
@@ -31,12 +31,15 @@ from controllers.service_api.app.message import (
     MessageListApi,
     MessageListQuery,
     MessageSuggestedApi,
+    MessageSwitchApi,
+    MessageSwitchPayload,
 )
 from models.enums import FeedbackRating
 from models.model import App, AppMode, EndUser
 from services.errors.conversation import ConversationNotExistsError
 from services.errors.message import (
     FirstMessageNotExistsError,
+    MessageBranchMismatchError,
     MessageNotExistsError,
     SuggestedQuestionsAfterAnswerDisabledError,
 )
@@ -429,6 +432,40 @@ class TestMessageListApi:
             with pytest.raises(NotFound):
                 handler(api, app_model=app_model, end_user=end_user)
 
+    def test_success_includes_active_marker(self, app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+        message = SimpleNamespace(
+            id="00000000-0000-0000-0000-000000000002",
+            conversation_id="00000000-0000-0000-0000-000000000001",
+            parent_message_id=None,
+            inputs={},
+            query="hello",
+            re_sign_file_url_answer="answer",
+            user_feedback=None,
+            retriever_resources=[],
+            created_at=None,
+            agent_thoughts=[],
+            message_files=[],
+            status="normal",
+            error=None,
+            extra_contents=[],
+            is_active=True,
+        )
+        pagination = SimpleNamespace(data=[message], limit=20, has_more=False)
+        monkeypatch.setattr(MessageService, "pagination_by_first_id", lambda *_args, **_kwargs: pagination)
+
+        api = MessageListApi()
+        handler = _unwrap(api.get)
+        app_model = SimpleNamespace(mode=AppMode.CHAT.value)
+        end_user = SimpleNamespace()
+
+        with app.test_request_context(
+            "/messages?conversation_id=00000000-0000-0000-0000-000000000001",
+            method="GET",
+        ):
+            response = handler(api, app_model=app_model, end_user=end_user)
+
+        assert response["data"][0]["is_active"] is True
+
 
 class TestMessageFeedbackApi:
     def test_not_found(self, app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -450,6 +487,122 @@ class TestMessageFeedbackApi:
         ):
             with pytest.raises(NotFound):
                 handler(api, app_model=app_model, end_user=end_user, message_id="m1")
+
+
+class TestMessageSwitchPayload:
+    def test_payload_accepts_target_message_id(self) -> None:
+        target_message_id = str(uuid.uuid4())
+
+        payload = MessageSwitchPayload(target_message_id=target_message_id, user="end-user-1")
+
+        assert str(payload.target_message_id) == target_message_id
+
+    def test_payload_accepts_user_for_service_api_context(self) -> None:
+        target_message_id = str(uuid.uuid4())
+
+        payload = MessageSwitchPayload(target_message_id=target_message_id, user="end-user-1")
+
+        assert str(payload.target_message_id) == target_message_id
+        assert payload.user == "end-user-1"
+
+
+class TestMessageSwitchApi:
+    def test_not_chat_app(self, app: Flask) -> None:
+        api = MessageSwitchApi()
+        handler = _unwrap(api.post)
+        app_model = SimpleNamespace(mode=AppMode.COMPLETION.value)
+        end_user = SimpleNamespace()
+
+        with app.test_request_context(
+            "/chat-messages/m1/switch",
+            method="POST",
+            json={"target_message_id": "m2", "user": "end-user-1"},
+        ):
+            with pytest.raises(NotChatAppError):
+                handler(api, app_model=app_model, end_user=end_user, message_id=uuid.uuid4())
+
+    def test_success(self, app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+        message_id = str(uuid.uuid4())
+        target_message_id = str(uuid.uuid4())
+        calls = []
+
+        def fake_switch_active_message(**kwargs):
+            calls.append(kwargs)
+            return SimpleNamespace(id=target_message_id)
+
+        monkeypatch.setattr(MessageService, "switch_active_message", fake_switch_active_message)
+
+        api = MessageSwitchApi()
+        handler = _unwrap(api.post)
+        app_model = SimpleNamespace(mode=AppMode.CHAT.value)
+        end_user = SimpleNamespace()
+
+        with app.test_request_context(
+            f"/chat-messages/{message_id}/switch",
+            method="POST",
+            json={"target_message_id": target_message_id, "user": "end-user-1"},
+        ):
+            response = handler(api, app_model=app_model, end_user=end_user, message_id=uuid.UUID(message_id))
+
+        assert response == {"result": "success", "active_message_id": target_message_id}
+        assert calls == [
+            {
+                "app_model": app_model,
+                "user": end_user,
+                "message_id": message_id,
+                "target_message_id": target_message_id,
+            }
+        ]
+
+    def test_not_found(self, app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            MessageService,
+            "switch_active_message",
+            lambda **_kwargs: (_ for _ in ()).throw(MessageNotExistsError()),
+        )
+
+        api = MessageSwitchApi()
+        handler = _unwrap(api.post)
+        app_model = SimpleNamespace(mode=AppMode.CHAT.value)
+        end_user = SimpleNamespace()
+
+        with app.test_request_context(
+            "/chat-messages/00000000-0000-0000-0000-000000000001/switch",
+            method="POST",
+            json={"target_message_id": "00000000-0000-0000-0000-000000000002", "user": "end-user-1"},
+        ):
+            with pytest.raises(NotFound):
+                handler(
+                    api,
+                    app_model=app_model,
+                    end_user=end_user,
+                    message_id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+                )
+
+    def test_branch_mismatch(self, app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            MessageService,
+            "switch_active_message",
+            lambda **_kwargs: (_ for _ in ()).throw(MessageBranchMismatchError()),
+        )
+
+        api = MessageSwitchApi()
+        handler = _unwrap(api.post)
+        app_model = SimpleNamespace(mode=AppMode.CHAT.value)
+        end_user = SimpleNamespace()
+
+        with app.test_request_context(
+            "/chat-messages/00000000-0000-0000-0000-000000000001/switch",
+            method="POST",
+            json={"target_message_id": "00000000-0000-0000-0000-000000000002", "user": "end-user-1"},
+        ):
+            with pytest.raises(BadRequest):
+                handler(
+                    api,
+                    app_model=app_model,
+                    end_user=end_user,
+                    message_id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+                )
 
 
 class TestAppGetFeedbacksApi:

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_generator.py
@@ -377,7 +377,12 @@ class TestAdvancedChatAppGeneratorInternals:
         )
 
         workflow = SimpleNamespace(id="wf-1", tenant_id="tenant", features={"feature": True}, features_dict={})
-        conversation = SimpleNamespace(id="conv-1", mode=AppMode.ADVANCED_CHAT, override_model_configs=None)
+        conversation = SimpleNamespace(
+            id="conv-1",
+            mode=AppMode.ADVANCED_CHAT,
+            override_model_configs=None,
+            active_message_id="active-message-id",
+        )
         message = SimpleNamespace(
             id="msg-1",
             query="hello",
@@ -388,9 +393,17 @@ class TestAdvancedChatAppGeneratorInternals:
         db_session = SimpleNamespace(commit=MagicMock(), refresh=MagicMock(), close=MagicMock())
         captured: dict[str, object] = {}
         thread_data: dict[str, object] = {}
+        thread_length_calls: list[tuple[str, str | None]] = []
+
+        def _get_thread_messages_length(conversation_id: str, active_message_id: str | None = None) -> int:
+            thread_length_calls.append((conversation_id, active_message_id))
+            return 2
 
         monkeypatch.setattr(generator, "_init_generate_records", lambda *args: (conversation, message))
-        monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.get_thread_messages_length", lambda _: 2)
+        monkeypatch.setattr(
+            "core.app.apps.advanced_chat.app_generator.get_thread_messages_length",
+            _get_thread_messages_length,
+        )
         monkeypatch.setattr(
             "core.app.apps.advanced_chat.app_generator.MessageBasedAppQueueManager",
             lambda **kwargs: SimpleNamespace(**kwargs),
@@ -447,6 +460,7 @@ class TestAdvancedChatAppGeneratorInternals:
         assert thread_data["started"] is True
         assert "pause-layer" in thread_data["kwargs"]["graph_engine_layers"]
         assert generator._dialogue_count == 3
+        assert thread_length_calls == [("conv-1", "active-message-id")]
         db_session.commit.assert_called_once()
         db_session.refresh.assert_called_once_with(conversation)
         db_session.close.assert_called_once()
@@ -475,7 +489,12 @@ class TestAdvancedChatAppGeneratorInternals:
         )
 
         workflow = SimpleNamespace(id="wf-2", tenant_id="tenant", features={}, features_dict={})
-        conversation = SimpleNamespace(id="conv-2", mode=AppMode.ADVANCED_CHAT, override_model_configs=None)
+        conversation = SimpleNamespace(
+            id="conv-2",
+            mode=AppMode.ADVANCED_CHAT,
+            override_model_configs=None,
+            active_message_id="existing-active-message-id",
+        )
         message = SimpleNamespace(
             id="msg-2",
             query="hello",
@@ -486,9 +505,17 @@ class TestAdvancedChatAppGeneratorInternals:
         db_session = SimpleNamespace(close=MagicMock(), commit=MagicMock(), refresh=MagicMock())
         init_records = MagicMock()
         thread_data: dict[str, object] = {}
+        thread_length_calls: list[tuple[str, str | None]] = []
+
+        def _get_thread_messages_length(conversation_id: str, active_message_id: str | None = None) -> int:
+            thread_length_calls.append((conversation_id, active_message_id))
+            return 0
 
         monkeypatch.setattr(generator, "_init_generate_records", init_records)
-        monkeypatch.setattr("core.app.apps.advanced_chat.app_generator.get_thread_messages_length", lambda _: 0)
+        monkeypatch.setattr(
+            "core.app.apps.advanced_chat.app_generator.get_thread_messages_length",
+            _get_thread_messages_length,
+        )
         monkeypatch.setattr(
             "core.app.apps.advanced_chat.app_generator.MessageBasedAppQueueManager",
             lambda **kwargs: SimpleNamespace(**kwargs),
@@ -537,6 +564,7 @@ class TestAdvancedChatAppGeneratorInternals:
         assert response == {"raw": True}
         init_records.assert_not_called()
         assert thread_data["started"] is True
+        assert thread_length_calls == [("conv-2", "existing-active-message-id")]
         db_session.commit.assert_not_called()
         db_session.refresh.assert_not_called()
         db_session.close.assert_called_once()
@@ -1223,6 +1251,12 @@ class TestAdvancedChatAppGeneratorInternals:
             lambda **kwargs: SimpleNamespace(),
         )
 
+        active_conversation = SimpleNamespace(id="conversation-id", active_message_id="active-message-id")
+        monkeypatch.setattr(
+            "core.app.apps.advanced_chat.app_generator.ConversationService.get_conversation",
+            lambda **kwargs: active_conversation,
+        )
+
         captured = {}
 
         def _fake_generate(**kwargs):
@@ -1242,13 +1276,21 @@ class TestAdvancedChatAppGeneratorInternals:
             app_model=app_model,
             workflow=workflow,
             user=user,
-            args={"query": "hello", "inputs": {}, "parent_message_id": "p1"},
+            args={
+                "query": "hello",
+                "inputs": {},
+                "conversation_id": "conversation-id",
+                "parent_message_id": "p1",
+            },
             invoke_from=InvokeFrom.SERVICE_API,
             workflow_run_id="run-id",
             streaming=False,
         )
 
-        assert captured["application_generate_entity"].parent_message_id == UUID_NIL
+        application_generate_entity = captured["application_generate_entity"]
+        assert application_generate_entity.parent_message_id == UUID_NIL
+        assert application_generate_entity.internal_parent_message_id == "active-message-id"
+        assert application_generate_entity.use_internal_parent_message_id is True
 
 
 class TestAdvancedChatAppGeneratorResume:

--- a/api/tests/unit_tests/core/app/apps/agent_chat/test_agent_chat_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/agent_chat/test_agent_chat_app_generator.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
+from constants import UUID_NIL
 from core.app.apps.agent_chat.app_generator import AgentChatAppGenerator
 from core.app.apps.exc import GenerateTaskStoppedError
 from core.app.entities.app_invoke_entities import InvokeFrom
@@ -210,6 +211,85 @@ class TestAgentChatAppGeneratorGenerate:
         )
 
         assert result == {"result": "ok"}
+
+    def test_generate_service_api_uses_active_message_as_internal_parent(self, generator, mocker: MockerFixture):
+        app_model = mocker.MagicMock(id="app1", tenant_id="tenant", mode="agent-chat")
+        app_model_config = mocker.MagicMock(id="cfg1")
+        app_model_config.to_dict.return_value = {"model": {"provider": "p"}}
+
+        user = DummyAccount("user")
+        active_conversation = mocker.MagicMock(id="conv", active_message_id="active-message-id")
+
+        generator._get_app_model_config = mocker.MagicMock(return_value=app_model_config)
+        generator._prepare_user_inputs = mocker.MagicMock(return_value={"x": 1})
+        generator._init_generate_records = mocker.MagicMock(
+            return_value=(mocker.MagicMock(id="conv", mode="agent-chat"), mocker.MagicMock(id="msg"))
+        )
+        generator._handle_response = mocker.MagicMock(return_value="response")
+
+        app_config = mocker.MagicMock(variables={}, prompt_template=mocker.MagicMock(), external_data_variables=[])
+        mocker.patch(
+            "core.app.apps.agent_chat.app_generator.AgentChatAppConfigManager.get_app_config",
+            return_value=app_config,
+        )
+        mocker.patch(
+            "core.app.apps.agent_chat.app_generator.ModelConfigConverter.convert",
+            return_value=mocker.MagicMock(),
+        )
+        mocker.patch(
+            "core.app.apps.agent_chat.app_generator.FileUploadConfigManager.convert",
+            return_value=None,
+        )
+        mocker.patch(
+            "core.app.apps.agent_chat.app_generator.ConversationService.get_conversation",
+            return_value=active_conversation,
+        )
+        mocker.patch(
+            "core.app.apps.agent_chat.app_generator.TraceQueueManager",
+            return_value=mocker.MagicMock(),
+        )
+        mocker.patch(
+            "core.app.apps.agent_chat.app_generator.MessageBasedAppQueueManager",
+            return_value=mocker.MagicMock(),
+        )
+        mocker.patch(
+            "core.app.apps.agent_chat.app_generator.threading.Thread",
+            return_value=mocker.MagicMock(),
+        )
+        mocker.patch(
+            "core.app.apps.agent_chat.app_generator.AgentChatAppGenerateResponseConverter.convert",
+            return_value={"result": "ok"},
+        )
+
+        captured = {}
+
+        def _build_entity(**kwargs):
+            entity = mocker.MagicMock(**kwargs)
+            for key, value in kwargs.items():
+                setattr(entity, key, value)
+            captured["entity"] = entity
+            return entity
+
+        mocker.patch("core.app.apps.agent_chat.app_generator.AgentChatAppGenerateEntity", side_effect=_build_entity)
+
+        result = generator.generate(
+            app_model=app_model,
+            user=user,
+            args={
+                "query": "hello",
+                "inputs": {"name": "world"},
+                "conversation_id": "conv",
+                "parent_message_id": "external-parent-id",
+            },
+            invoke_from=InvokeFrom.SERVICE_API,
+            streaming=True,
+        )
+
+        assert result == {"result": "ok"}
+        application_generate_entity = captured["entity"]
+        assert application_generate_entity.parent_message_id == UUID_NIL
+        assert application_generate_entity.internal_parent_message_id == "active-message-id"
+        assert application_generate_entity.use_internal_parent_message_id is True
 
 
 class TestAgentChatAppGeneratorWorker:

--- a/api/tests/unit_tests/core/app/apps/chat/test_app_generator_and_runner.py
+++ b/api/tests/unit_tests/core/app/apps/chat/test_app_generator_and_runner.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from constants import UUID_NIL
 from core.app.apps.chat.app_generator import ChatAppGenerator
 from core.app.apps.chat.app_runner import ChatAppRunner
 from core.app.apps.exc import GenerateTaskStoppedError
@@ -91,6 +92,66 @@ class TestChatAppGenerator:
             result = generator.generate(app_model, user, args, InvokeFrom.DEBUGGER, streaming=False)
 
         assert result == {"ok": True}
+
+    @pytest.mark.parametrize(
+        ("extra_args", "expected_internal_parent"),
+        [
+            ({}, "active-message-id"),
+            ({"_regenerate_parent_message_id": None}, None),
+        ],
+    )
+    def test_generate_service_api_sets_internal_parent(
+        self, extra_args: dict[str, object], expected_internal_parent: str | None
+    ):
+        generator = ChatAppGenerator()
+        app_model = SimpleNamespace(id="app-1", tenant_id="tenant-1")
+        user = SimpleNamespace(id="user-1", session_id="session-1")
+        active_conversation = SimpleNamespace(id="conversation-id", active_message_id="active-message-id")
+        args = {
+            "query": "hi",
+            "inputs": {},
+            "conversation_id": "conversation-id",
+            "parent_message_id": "external-parent-id",
+            **extra_args,
+        }
+        init_generate_records = Mock(
+            return_value=(SimpleNamespace(id="conversation-id", mode="chat"), SimpleNamespace(id="message-id"))
+        )
+
+        with (
+            patch(
+                "core.app.apps.chat.app_generator.ConversationService.get_conversation",
+                return_value=active_conversation,
+            ),
+            patch(
+                "core.app.apps.chat.app_generator.ChatAppConfigManager.get_app_config",
+                return_value=SimpleNamespace(
+                    variables=[], external_data_variables=[], app_model_config_dict={}, app_mode=AppMode.CHAT
+                ),
+            ),
+            patch("core.app.apps.chat.app_generator.ModelConfigConverter.convert", return_value=SimpleNamespace()),
+            patch("core.app.apps.chat.app_generator.FileUploadConfigManager.convert", return_value=None),
+            patch("core.app.apps.chat.app_generator.ChatAppGenerateEntity", DummyGenerateEntity),
+            patch("core.app.apps.chat.app_generator.TraceQueueManager", return_value=SimpleNamespace()),
+            patch("core.app.apps.chat.app_generator.MessageBasedAppQueueManager", DummyQueueManager),
+            patch(
+                "core.app.apps.chat.app_generator.ChatAppGenerateResponseConverter.convert", return_value={"ok": True}
+            ),
+            patch.object(ChatAppGenerator, "_get_app_model_config", return_value=SimpleNamespace(to_dict=lambda: {})),
+            patch.object(ChatAppGenerator, "_prepare_user_inputs", return_value={}),
+            patch.object(ChatAppGenerator, "_init_generate_records", init_generate_records),
+            patch.object(ChatAppGenerator, "_handle_response", return_value={"response": True}),
+            patch("core.app.apps.chat.app_generator.copy_current_request_context", side_effect=lambda f: f),
+            patch("core.app.apps.chat.app_generator.threading.Thread") as mock_thread,
+        ):
+            mock_thread.return_value.start.return_value = None
+            result = generator.generate(app_model, user, args, InvokeFrom.SERVICE_API, streaming=False)
+
+        assert result == {"ok": True}
+        application_generate_entity = init_generate_records.call_args.args[0]
+        assert application_generate_entity.parent_message_id == UUID_NIL
+        assert application_generate_entity.internal_parent_message_id == expected_internal_parent
+        assert application_generate_entity.use_internal_parent_message_id is True
 
     def test_generate_rejects_model_config_override_for_non_debugger(self):
         generator = ChatAppGenerator()

--- a/api/tests/unit_tests/core/app/apps/test_message_based_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/test_message_based_app_generator.py
@@ -84,6 +84,15 @@ def _make_chat_generate_entity(app_config: EasyUIBasedAppConfig) -> ChatAppGener
     )
 
 
+def _make_internal_parent_chat_generate_entity(
+    app_config: EasyUIBasedAppConfig, internal_parent_message_id: str | None
+) -> ChatAppGenerateEntity:
+    entity = _make_chat_generate_entity(app_config)
+    object.__setattr__(entity, "internal_parent_message_id", internal_parent_message_id)
+    object.__setattr__(entity, "use_internal_parent_message_id", True)
+    return entity
+
+
 @pytest.fixture(autouse=True)
 def _mock_db_session(monkeypatch: pytest.MonkeyPatch):
     session = MagicMock()
@@ -127,6 +136,30 @@ def test_init_generate_records_sets_conversation_fields_for_chat_entity():
     assert entity.conversation_id == "generated-conversation-id"
     assert entity.is_new_conversation is True
     assert conversation.id == "generated-conversation-id"
+
+
+def test_init_generate_records_uses_internal_parent_message_id_and_marks_active_message():
+    app_config = _make_app_config(AppMode.CHAT)
+    entity = _make_internal_parent_chat_generate_entity(app_config, internal_parent_message_id="root-parent-id")
+
+    generator = MessageBasedAppGenerator()
+
+    conversation, message = generator._init_generate_records(entity, conversation=None)
+
+    assert message.parent_message_id == "root-parent-id"
+    assert conversation.active_message_id == "generated-message-id"
+
+
+def test_init_generate_records_preserves_explicit_internal_parent_none():
+    app_config = _make_app_config(AppMode.CHAT)
+    entity = _make_internal_parent_chat_generate_entity(app_config, internal_parent_message_id=None)
+    entity.parent_message_id = "ignored-parent-id"
+
+    generator = MessageBasedAppGenerator()
+
+    _, message = generator._init_generate_records(entity, conversation=None)
+
+    assert message.parent_message_id is None
 
 
 class TestMessageBasedAppGeneratorExtras:

--- a/api/tests/unit_tests/core/memory/test_token_buffer_memory.py
+++ b/api/tests/unit_tests/core/memory/test_token_buffer_memory.py
@@ -512,6 +512,22 @@ class TestGetHistoryPromptMessages:
             result = mem.get_history_prompt_messages()
         assert result == []
 
+    def test_uses_active_message_when_extracting_thread(self):
+        mem = self._make_memory()
+        active_message_id = str(uuid4())
+        mem.conversation.active_message_id = active_message_id
+
+        with (
+            patch("core.memory.token_buffer_memory.db") as mock_db,
+            patch("core.memory.token_buffer_memory.extract_thread_messages", return_value=[]) as mock_extract,
+        ):
+            mock_db.session.scalars.return_value.all.return_value = []
+
+            result = mem.get_history_prompt_messages()
+
+        assert result == []
+        mock_extract.assert_called_once_with([], active_message_id=active_message_id)
+
     def test_skips_first_message_without_answer(self):
         """The newest message (index 0 after extraction) without answer and tokens==0 is skipped."""
         mem = self._make_memory()

--- a/api/tests/unit_tests/core/prompt/test_extract_thread_messages.py
+++ b/api/tests/unit_tests/core/prompt/test_extract_thread_messages.py
@@ -51,6 +51,35 @@ def test_extract_thread_messages_branched_thread():
     assert [msg["id"] for msg in result] == [id4, id2, id1]
 
 
+def test_extract_thread_messages_starts_from_active_message():
+    id1, id2, id3, id4 = str(uuid4()), str(uuid4()), str(uuid4()), str(uuid4())
+    messages = [
+        MockMessage(id4, id2),
+        MockMessage(id3, id2),
+        MockMessage(id2, id1),
+        MockMessage(id1, UUID_NIL),
+    ]
+
+    result = extract_thread_messages(messages, active_message_id=id3)
+
+    assert len(result) == 3
+    assert [msg["id"] for msg in result] == [id3, id2, id1]
+
+
+def test_extract_thread_messages_active_root_variant_excludes_sibling_roots():
+    original_id, regenerated_id, followup_id = str(uuid4()), str(uuid4()), str(uuid4())
+    messages = [
+        MockMessage(followup_id, regenerated_id),
+        MockMessage(regenerated_id, UUID_NIL),
+        MockMessage(original_id, UUID_NIL),
+    ]
+
+    result = extract_thread_messages(messages, active_message_id=followup_id)
+
+    assert len(result) == 2
+    assert [msg["id"] for msg in result] == [followup_id, regenerated_id]
+
+
 def test_extract_thread_messages_empty_list():
     messages = []
     result = extract_thread_messages(messages)
@@ -134,3 +163,20 @@ def test_get_thread_messages_length_keeps_non_empty_latest_answer(mocker: Mocker
     length = get_thread_messages_length("conversation-2")
 
     assert length == 2
+
+
+def test_get_thread_messages_length_uses_active_message(mocker: MockerFixture):
+    id1, id2, id3, id4 = str(uuid4()), str(uuid4()), str(uuid4()), str(uuid4())
+    messages = [
+        MockMessage(id4, id2),
+        MockMessage(id3, id2),
+        MockMessage(id2, id1),
+        MockMessage(id1, UUID_NIL),
+    ]
+
+    mock_scalars = mocker.patch("core.prompt.utils.get_thread_messages_length.db.session.scalars")
+    mock_scalars.return_value.all.return_value = messages
+
+    length = get_thread_messages_length("conversation-3", active_message_id=id3)
+
+    assert length == 3

--- a/api/tests/unit_tests/services/test_message_service.py
+++ b/api/tests/unit_tests/services/test_message_service.py
@@ -11,6 +11,7 @@ from models.model import App, AppMode, EndUser, Message
 from services.errors.message import (
     FirstMessageNotExistsError,
     LastMessageNotExistsError,
+    MessageBranchMismatchError,
     MessageNotExistsError,
     SuggestedQuestionsAfterAnswerDisabledError,
 )
@@ -48,17 +49,20 @@ class TestMessageServiceFactory:
     def create_conversation_mock(
         conversation_id: str = "conv-001",
         app_id: str = "app-123",
+        active_message_id: str | None = None,
     ) -> MagicMock:
         """Create a mock Conversation object."""
         conversation = MagicMock()
         conversation.id = conversation_id
         conversation.app_id = app_id
+        conversation.active_message_id = active_message_id
         return conversation
 
     @staticmethod
     def create_message_mock(
         message_id: str = "msg-001",
         conversation_id: str = "conv-001",
+        parent_message_id: str | None = None,
         query: str = "What is AI?",
         answer: str = "AI stands for Artificial Intelligence.",
         created_at: datetime | None = None,
@@ -67,6 +71,7 @@ class TestMessageServiceFactory:
         message = MagicMock(spec=Message)
         message.id = message_id
         message.conversation_id = conversation_id
+        message.parent_message_id = parent_message_id
         message.query = query
         message.answer = answer
         message.created_at = created_at or datetime.now()
@@ -351,6 +356,108 @@ class TestMessageServicePaginationByFirstId:
         assert len(result.data) == 0
         assert result.has_more is False
         assert result.limit == 10
+
+    @patch("services.message_service._create_execution_extra_content_repository")
+    @patch("services.message_service.db")
+    @patch("services.message_service.ConversationService")
+    def test_pagination_by_first_id_marks_active_message(
+        self, mock_conversation_service, mock_db, mock_create_repo, factory
+    ):
+        """Test pagination marks the active answer in the returned candidates."""
+        # Arrange
+        app = factory.create_app_mock()
+        user = factory.create_end_user_mock()
+        conversation = factory.create_conversation_mock(active_message_id="msg-active")
+        mock_conversation_service.get_conversation.return_value = conversation
+        messages = [
+            factory.create_message_mock(message_id="msg-other"),
+            factory.create_message_mock(message_id="msg-active"),
+        ]
+        mock_db.session.scalars.return_value.all.return_value = messages
+
+        # Act
+        result = MessageService.pagination_by_first_id(
+            app_model=app,
+            user=user,
+            conversation_id="conv-001",
+            first_id=None,
+            limit=10,
+        )
+
+        # Assert
+        active_by_id = {message.id: getattr(message, "is_active", None) for message in result.data}
+        assert active_by_id == {"msg-other": False, "msg-active": True}
+
+    @patch("services.message_service._create_execution_extra_content_repository")
+    @patch("services.message_service.db")
+    @patch("services.message_service.ConversationService")
+    def test_pagination_by_first_id_marks_active_thread_and_last_round_actions(
+        self, mock_conversation_service, mock_db, mock_create_repo, factory
+    ):
+        """Test pagination marks the active branch and only exposes actions for the active leaf group."""
+        app = factory.create_app_mock()
+        user = factory.create_end_user_mock()
+        conversation = factory.create_conversation_mock(active_message_id="msg-b2")
+        mock_conversation_service.get_conversation.return_value = conversation
+        messages = [
+            factory.create_message_mock(message_id="msg-b2", parent_message_id="msg-a2"),
+            factory.create_message_mock(message_id="msg-b1", parent_message_id="msg-a2"),
+            factory.create_message_mock(message_id="msg-a2", parent_message_id="00000000-0000-0000-0000-000000000000"),
+            factory.create_message_mock(message_id="msg-a1", parent_message_id="00000000-0000-0000-0000-000000000000"),
+        ]
+        mock_db.session.scalars.return_value.all.return_value = messages
+
+        result = MessageService.pagination_by_first_id(
+            app_model=app,
+            user=user,
+            conversation_id="conv-001",
+            first_id=None,
+            limit=10,
+            order="desc",
+        )
+
+        flags_by_id = {
+            message.id: (
+                getattr(message, "is_in_active_thread", None),
+                getattr(message, "can_switch", None),
+                getattr(message, "can_regenerate", None),
+            )
+            for message in result.data
+        }
+        assert flags_by_id == {
+            "msg-a1": (False, False, False),
+            "msg-a2": (True, False, False),
+            "msg-b1": (False, True, False),
+            "msg-b2": (True, True, True),
+        }
+
+    @patch("services.message_service._create_execution_extra_content_repository")
+    @patch("services.message_service.db")
+    @patch("services.message_service.ConversationService")
+    def test_pagination_by_first_id_does_not_allow_switch_for_single_latest_answer(
+        self, mock_conversation_service, mock_db, mock_create_repo, factory
+    ):
+        """Test a latest answer with no returned alternatives is not marked switchable."""
+        app = factory.create_app_mock()
+        user = factory.create_end_user_mock()
+        conversation = factory.create_conversation_mock(active_message_id="msg-active")
+        mock_conversation_service.get_conversation.return_value = conversation
+        messages = [factory.create_message_mock(message_id="msg-active", parent_message_id="parent-1")]
+        mock_db.session.scalars.return_value.all.return_value = messages
+
+        result = MessageService.pagination_by_first_id(
+            app_model=app,
+            user=user,
+            conversation_id="conv-001",
+            first_id=None,
+            limit=10,
+        )
+
+        message = result.data[0]
+        assert message.is_active is True
+        assert message.is_in_active_thread is True
+        assert message.can_switch is False
+        assert message.can_regenerate is True
 
 
 class TestMessageServicePaginationByLastId:
@@ -707,6 +814,164 @@ class TestMessageServiceGetMessage:
         # Act & Assert
         with pytest.raises(MessageNotExistsError):
             MessageService.get_message(app_model=app, user=user, message_id="msg-123")
+
+
+class TestMessageServiceSwitchActiveMessage:
+    """Unit tests for MessageService.switch_active_message method."""
+
+    @pytest.fixture
+    def factory(self):
+        """Provide test data factory."""
+        return TestMessageServiceFactory()
+
+    @patch("services.message_service.db")
+    @patch("services.message_service.ConversationService")
+    @patch.object(MessageService, "get_message")
+    def test_switch_active_message_updates_conversation_pointer(
+        self, mock_get_message, mock_conversation_service, mock_db, factory
+    ):
+        """Test switching active answer updates the conversation pointer."""
+        app = factory.create_app_mock()
+        user = factory.create_end_user_mock()
+        source = factory.create_message_mock(message_id="msg-source", parent_message_id="parent-1")
+        target = factory.create_message_mock(message_id="msg-target", parent_message_id="parent-1")
+        conversation = factory.create_conversation_mock(active_message_id="msg-source")
+        mock_get_message.side_effect = [source, target]
+        mock_conversation_service.get_conversation.return_value = conversation
+
+        result = MessageService.switch_active_message(
+            app_model=app,
+            user=user,
+            message_id="msg-source",
+            target_message_id="msg-target",
+        )
+
+        assert result == target
+        assert conversation.active_message_id == "msg-target"
+        mock_db.session.commit.assert_called_once()
+
+    @patch("services.message_service.db")
+    @patch("services.message_service.ConversationService")
+    @patch.object(MessageService, "get_message")
+    def test_switch_active_message_rejects_different_parent_group(
+        self, mock_get_message, mock_conversation_service, mock_db, factory
+    ):
+        """Test switching to a non-sibling answer is rejected."""
+        app = factory.create_app_mock()
+        user = factory.create_end_user_mock()
+        source = factory.create_message_mock(message_id="msg-source", parent_message_id="parent-1")
+        target = factory.create_message_mock(message_id="msg-target", parent_message_id="parent-2")
+        mock_get_message.side_effect = [source, target]
+
+        with pytest.raises(MessageBranchMismatchError):
+            MessageService.switch_active_message(
+                app_model=app,
+                user=user,
+                message_id="msg-source",
+                target_message_id="msg-target",
+            )
+
+        mock_conversation_service.get_conversation.assert_not_called()
+        mock_db.session.commit.assert_not_called()
+
+    @patch("services.message_service.db")
+    @patch("services.message_service.ConversationService")
+    @patch.object(MessageService, "get_message")
+    def test_switch_active_message_rejects_locked_previous_round(
+        self, mock_get_message, mock_conversation_service, mock_db, factory
+    ):
+        """Test switching an older answer group is rejected after a later answer becomes active."""
+        app = factory.create_app_mock()
+        user = factory.create_end_user_mock()
+        source = factory.create_message_mock(
+            message_id="msg-a2",
+            parent_message_id="00000000-0000-0000-0000-000000000000",
+        )
+        target = factory.create_message_mock(
+            message_id="msg-a1",
+            parent_message_id="00000000-0000-0000-0000-000000000000",
+        )
+        conversation = factory.create_conversation_mock(active_message_id="msg-b1")
+        mock_get_message.side_effect = [source, target]
+        mock_conversation_service.get_conversation.return_value = conversation
+
+        with pytest.raises(MessageBranchMismatchError):
+            MessageService.switch_active_message(
+                app_model=app,
+                user=user,
+                message_id="msg-a2",
+                target_message_id="msg-a1",
+            )
+
+        mock_db.session.commit.assert_not_called()
+
+
+class TestMessageServiceGetRegenerateSourceMessage:
+    """Unit tests for MessageService.get_regenerate_source_message method."""
+
+    @pytest.fixture
+    def factory(self):
+        """Provide test data factory."""
+        return TestMessageServiceFactory()
+
+    @patch("services.message_service.ConversationService")
+    @patch.object(MessageService, "get_message")
+    def test_get_regenerate_source_message_returns_active_target_message(
+        self, mock_get_message, mock_conversation_service, factory
+    ):
+        """Test regenerate source lookup returns the active leaf answer message."""
+        app = factory.create_app_mock()
+        user = factory.create_end_user_mock()
+        message = factory.create_message_mock(message_id="msg-source", conversation_id="conv-001")
+        conversation = factory.create_conversation_mock(conversation_id="conv-001", active_message_id="msg-source")
+        mock_get_message.return_value = message
+        mock_conversation_service.get_conversation.return_value = conversation
+
+        result = MessageService.get_regenerate_source_message(
+            app_model=app,
+            user=user,
+            message_id="msg-source",
+            conversation_id="conv-001",
+        )
+
+        assert result == message
+
+    @patch.object(MessageService, "get_message")
+    def test_get_regenerate_source_message_rejects_different_conversation(self, mock_get_message, factory):
+        """Test regenerate source lookup rejects mismatched conversation IDs."""
+        app = factory.create_app_mock()
+        user = factory.create_end_user_mock()
+        message = factory.create_message_mock(message_id="msg-source", conversation_id="conv-001")
+        mock_get_message.return_value = message
+
+        with pytest.raises(MessageBranchMismatchError):
+            MessageService.get_regenerate_source_message(
+                app_model=app,
+                user=user,
+                message_id="msg-source",
+                conversation_id="conv-other",
+            )
+
+    @patch("services.message_service.ConversationService")
+    @patch.object(MessageService, "get_message")
+    def test_get_regenerate_source_message_rejects_locked_previous_round(
+        self, mock_get_message, mock_conversation_service, factory
+    ):
+        """Test regenerate source lookup rejects a non-active answer after later turns exist."""
+        app = factory.create_app_mock()
+        user = factory.create_end_user_mock()
+        message = factory.create_message_mock(message_id="msg-a2", conversation_id="conv-001")
+        conversation = factory.create_conversation_mock(conversation_id="conv-001", active_message_id="msg-b1")
+        mock_get_message.return_value = message
+        mock_conversation_service.get_conversation.return_value = conversation
+
+        with pytest.raises(MessageBranchMismatchError):
+            MessageService.get_regenerate_source_message(
+                app_model=app,
+                user=user,
+                message_id="msg-a2",
+                conversation_id="conv-001",
+            )
 
 
 class TestMessageServiceFeedback:

--- a/docker/README.md
+++ b/docker/README.md
@@ -32,6 +32,18 @@ Welcome to the new `docker` directory for deploying Dify using Docker Compose. T
    docker compose up -d
    ```
 
+   For a normal restart with the images that already exist locally, `docker compose up -d` is enough. If you changed backend or frontend source code, rebuild the affected images first; `docker compose up -d` alone does not rebuild them.
+
+   From the repository root, rebuild the local images used by this compose file and recreate the changed services:
+
+   ```bash
+   docker build -f api/Dockerfile -t dify-api:regenerate-answer .
+   docker build -f web/Dockerfile -t langgenius/dify-web:1.14.3 .
+   docker compose -f docker/docker-compose.yaml up -d --force-recreate api worker worker_beat web
+   ```
+
+   The API image is shared by the `api`, `api_websocket`, `worker`, and `worker_beat` services. If you use the collaboration profile, recreate `api_websocket` as well. Database migrations run during API startup when `MIGRATION_ENABLED=true`, which is the default in `.env.example`.
+
 4. **SSL Certificate Setup**:
    - Refer to `docker/certbot/README.md` to set up SSL certificates using Certbot.
 5. **OpenTelemetry Collector Setup**:

--- a/web/app/components/develop/template/template_advanced_chat.zh.mdx
+++ b/web/app/components/develop/template/template_advanced_chat.zh.mdx
@@ -843,6 +843,186 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
     </CodeGroup>
   </Col>
 </Row>
+
+---
+
+### 答案分支、重新生成与切换行为
+
+工作流编排对话型应用的 Service API 支持对当前答案重新生成，并在同一轮的首次答案、重新生成答案、第 n 次生成答案之间切换。
+
+- `POST /chat-messages/:message_id/regenerate`：基于当前最新生效答案重新生成一个新的答案分支。请求只需要传入本次重新生成使用的输入和会话信息，不需要传入原答案输出内容。
+- `POST /chat-messages/:message_id/switch`：切换当前最新答案组的生效答案。`message_id` 传当前最新生效答案 ID，`target_message_id` 传要切换到的同组候选答案 ID。
+- `GET /messages` 会返回 `is_active`、`is_in_active_thread`、`can_switch`、`can_regenerate`，用于前端判断当前展示、历史上下文分支和按钮状态。
+
+交互行为采用“仅最新一轮可操作”的设计：用户发送下一轮问题后，上一轮的首次答案和重新生成答案会被锁定，不再支持切换或重新生成。后续对话的历史上下文沿 `conversation.active_message_id` 指向的生效答案链路组织；前端可用 `is_in_active_thread` 判断哪些消息属于当前后端上下文分支，用 `can_switch` 展示答案切换按钮，用 `can_regenerate` 展示重新生成按钮。
+
+<Heading
+  url='/chat-messages/:message_id/regenerate'
+  method='POST'
+  title='重新生成答案'
+  name='#Regenerate-Chat-Message'
+/>
+<Row>
+  <Col>
+    基于当前最新生效答案消息重新生成一个新的答案分支。
+
+    该接口不会要求传入被重新生成的原输出内容；只需传入本次重新生成使用的输入，历史会话上下文会根据当前生效答案链路定位。新生成的答案会成为当前会话的生效答案，后续对话会从该答案继续。
+
+    仅 `GET /messages` 返回 `can_regenerate: true` 的消息可以调用该接口。用户发送下一轮问题后，上一轮的首次答案/重新生成答案会被锁定，不能再重新生成。
+
+    ### Path Params
+
+    <Properties>
+      <Property name='message_id' type='string' key='message_id'>
+        当前最新生效答案消息 ID，对应 `GET /messages` 返回 `can_regenerate: true` 的消息。
+      </Property>
+    </Properties>
+
+    ### Request Body
+
+    <Properties>
+      <Property name='query' type='string' key='query'>
+        本次重新生成使用的用户输入/提问内容。
+      </Property>
+      <Property name='inputs' type='object' key='inputs'>
+        允许传入 App 定义的各变量值，格式同发送对话消息接口。默认 `{}`。
+      </Property>
+      <Property name='response_mode' type='string' key='response_mode'>
+        - `streaming` 流式模式（推荐）。
+        - `blocking` 阻塞模式，等待执行完毕后返回结果。
+      </Property>
+      <Property name='user' type='string' key='user'>
+        用户标识，由开发者定义规则，需保证用户标识在应用内唯一。
+      </Property>
+      <Property name='conversation_id' type='string' key='conversation_id'>
+        （选填）会话 ID。传入时必须与 `message_id` 所属会话一致。
+      </Property>
+      <Property name='files' type='array[object]' key='files'>
+        文件列表，格式同发送对话消息接口。
+      </Property>
+      <Property name='auto_generate_name' type='bool' key='auto_generate_name'>
+        （选填）自动生成标题，默认 `true`。
+      </Property>
+      <Property name='workflow_id' type='string' key='workflow_id'>
+        （选填）工作流 ID，用于指定特定版本。如果不提供则使用默认的已发布版本。
+      </Property>
+    </Properties>
+
+    ### Response
+    返回内容同发送对话消息接口，`response_mode` 为 `blocking` 时返回 ChatCompletionResponse object，`response_mode` 为 `streaming` 时返回 ChunkChatCompletionResponse object 流式序列。
+
+    ### Errors
+    - 404，对话或消息不存在
+    - 400，`invalid_param`，传入参数异常
+    - 400，消息不是当前最新生效答案，或不属于当前会话分支
+    - 400，`completion_request_error`，文本生成失败
+    - 500，服务内部异常
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="POST"
+      label="/chat-messages/:message_id/regenerate"
+      targetCode={`curl -X POST '${props.appDetail.api_base_url}/chat-messages/{message_id}/regenerate' \\
+--header 'Authorization: Bearer {api_key}' \\
+--header 'Content-Type: application/json' \\
+--data-raw '{
+    "inputs": {},
+    "query": "请重新回答这个问题",
+    "response_mode": "blocking",
+    "conversation_id": "{conversation_id}",
+    "user": "abc-123"
+}'`}
+    />
+
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {
+        "event": "message",
+        "task_id": "c3800678-a077-43df-a102-53f23ed20b88",
+        "id": "9da23599-e713-473b-982c-4328d4f5c78a",
+        "message_id": "9da23599-e713-473b-982c-4328d4f5c78a",
+        "conversation_id": "45701982-8118-4bc5-8e9b-64562b4555f2",
+        "mode": "advanced-chat",
+        "answer": "这是重新生成后的答案。",
+        "metadata": {
+            "usage": null,
+            "retriever_resources": []
+        },
+        "created_at": 1705407629
+    }
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+<Heading
+  url='/chat-messages/:message_id/switch'
+  method='POST'
+  title='切换答案'
+  name='#Switch-Chat-Message'
+/>
+<Row>
+  <Col>
+    切换当前会话最新一轮的生效答案，用于在首次答案、重新生成答案、第 n 次生成答案之间切换。切换后，后续对话会从返回的 `active_message_id` 对应答案继续。
+
+    仅支持切换当前最新答案组。用户发送下一轮问题后，上一轮的答案组会被锁定，不再支持切换。前端应使用 `GET /messages` 返回的 `can_switch` 判断是否展示答案切换按钮；同一答案组至少存在两个候选答案时才会返回 `can_switch: true`。
+
+    ### Path Params
+
+    <Properties>
+      <Property name='message_id' type='string' key='message_id'>
+        当前最新生效答案消息 ID，对应 `GET /messages` 返回 `is_active: true` 的消息。
+      </Property>
+    </Properties>
+
+    ### Request Body
+
+    <Properties>
+      <Property name='target_message_id' type='string' key='target_message_id'>
+        要切换为生效答案的目标消息 ID。该消息必须与 `message_id` 属于同一会话、同一轮答案组；通常从 `GET /messages` 返回 `can_switch: true` 的候选答案中选择。
+      </Property>
+      <Property name='user' type='string' key='user'>
+        用户标识，由开发者定义规则，需保证用户标识在应用内唯一。
+      </Property>
+    </Properties>
+
+    ### Response
+    - `result` (string) 固定返回 `success`
+    - `active_message_id` (string) 切换后的生效答案消息 ID
+
+    ### Errors
+    - 404，对话或消息不存在
+    - 400，`invalid_param`，传入参数异常
+    - 400，目标答案不在当前最新答案组，或 `message_id` 不是当前最新生效答案
+    - 500，服务内部异常
+  </Col>
+  <Col sticky>
+    <CodeGroup
+      title="Request"
+      tag="POST"
+      label="/chat-messages/:message_id/switch"
+      targetCode={`curl -X POST '${props.appDetail.api_base_url}/chat-messages/{message_id}/switch' \\
+--header 'Authorization: Bearer {api_key}' \\
+--header 'Content-Type: application/json' \\
+--data-raw '{
+    "target_message_id": "{target_message_id}",
+    "user": "abc-123"
+}'`}
+    />
+
+    <CodeGroup title="Response">
+    ```json {{ title: 'Response' }}
+    {
+        "result": "success",
+        "active_message_id": "5ad4cb98-f0c7-4085-b384-88c403be6290"
+    }
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
 ---
 
 <Heading
@@ -1299,6 +1479,10 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
         - `url` (string) 文件预览地址，使用文件预览 API (`/files/{file_id}/preview`) 访问文件
         - `belongs_to` (string) 文件归属方，user 或 assistant
       - `answer` (string)  回答消息内容
+      - `is_active` (bool) 当前会话中是否为生效答案。重新生成或切换答案后，后续对话会从生效答案继续。
+      - `is_in_active_thread` (bool) 是否在当前后端历史会话分支中。后续对话的历史上下文会沿这条分支组织。
+      - `can_switch` (bool) 是否属于当前最新可切换答案组；同组至少存在两个候选答案时为 `true`。前端可据此展示答案切换按钮。
+      - `can_regenerate` (bool) 是否可作为重新生成源。仅当前最新生效答案为 `true`。
       - `created_at`  (timestamp) 创建时间
       - `feedback` (object) 反馈信息
         - `rating` (string) 点赞 like / 点踩 dislike
@@ -1331,6 +1515,10 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
             },
             "query": "iphone 13 pro",
             "answer": "The iPhone 13 Pro, released on September 24, 2021, features a 6.1-inch display with a resolution of 1170 x 2532. It is equipped with a Hexa-core (2x3.23 GHz Avalanche + 4x1.82 GHz Blizzard) processor, 6 GB of RAM, and offers storage options of 128 GB, 256 GB, 512 GB, and 1 TB. The camera is 12 MP, the battery capacity is 3095 mAh, and it runs on iOS 15.",
+            "is_active": true,
+            "is_in_active_thread": true,
+            "can_switch": false,
+            "can_regenerate": true,
             "message_files": [],
             "feedback": null,
             "retriever_resources": [
@@ -1365,6 +1553,10 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
             "inputs": {},
             "query": "draw a cat",
             "answer": "I have generated an image of a cat for you. Please check your messages to view the image.",
+            "is_active": true,
+            "is_in_active_thread": true,
+            "can_switch": false,
+            "can_regenerate": true,
             "message_files": [
                 {
                     "id": "976990d2-5294-47e6-8f14-7356ba9d2d76",


### PR DESCRIPTION
## Summary

  - Add Service API support for regenerating the latest active answer and switching answer variants in the latest answer group.
  - Track the active conversation branch with `conversation.active_message_id` so future chat turns follow the selected answer path.
  - Expose message branch metadata in `/messages`: `is_active`, `is_in_active_thread`, `can_switch`, and `can_regenerate`.
  - Add migration, unit coverage, OpenAPI markdown docs, console API docs, and Docker restart/rebuild notes.

  ## Behavior

  - Only the latest answer group can be switched or regenerated.
  - Once the user sends the next chat turn, previous answer groups are locked.
  - Future chat context follows the active message chain from `conversation.active_message_id`.

  ## Test Plan

  - [x] `git diff --check`
  - [x] `python -m py_compile ...` for changed backend Python files
  - [ ] `uv run --project api pytest ...`

  `pytest` did not execute locally because dependency installation failed while building `chroma-hnswlib==0.7.6`; the local Windows environment is missing Microsoft Visual C++ 14.0+ Build Tools. This is an
  environment/toolchain failure before test collection, not a test assertion failure.