### PR TITLE
fix(docker/ssrf): allow FreeCAD API access via host.docker.internal:5056

### DIFF
--- a/docker/ssrf_proxy/squid.conf.template
+++ b/docker/ssrf_proxy/squid.conf.template
@@ -20,6 +20,9 @@ acl Safe_ports port 591		# filemaker
 acl Safe_ports port 777		# multiling http
 acl CONNECT method CONNECT
 acl allowed_domains dstdomain .marketplace.dify.ai
+acl freecad_api dstdomain host.docker.internal
+acl freecad_api_port port 5056
+http_access allow freecad_api freecad_api_port
 http_access allow allowed_domains
 http_access deny !Safe_ports
 http_access deny CONNECT !SSL_ports
@@ -103,4 +106,3 @@ access_log daemon:/var/log/squid/access.log dify_log
 
 # Access log to track concurrent requests and timeouts
 logfile_rotate 10
-


### PR DESCRIPTION
## Summary

- Add SSRF proxy ACL rules to allow outbound connections to `host.docker.internal` on port `5056`
- This enables Dify API/worker containers to call a locally running FreeCAD MCP server via the SSRF proxy
- Without this rule, requests to the Docker host are blocked by the default squid deny-all policy

## Motivation

When running FreeCAD MCP alongside Dify on the same machine (e.g. for local AI-assisted CAD workflows), Dify containers need to reach `host.docker.internal:5056`. The existing squid config has no rule for this, causing all such requests to be denied.

## Changes

`docker/ssrf_proxy/squid.conf.template`:
- Added `acl freecad_api dstdomain host.docker.internal`
- Added `acl freecad_api_port port 5056`
- Added `http_access allow freecad_api freecad_api_port`

## Test plan

- [ ] Start Dify stack with `docker compose up -d`
- [ ] Verify FreeCAD MCP server is reachable from `docker-api-1` via `curl http://host.docker.internal:5056`
- [ ] Confirm other SSRF protections remain intact (blocked IPs, disallowed ports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)