### PR TITLE
chore(codeowners): add Riskey for service API docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -166,6 +166,7 @@
 
 # Frontend - App - API Documentation
 /web/app/components/develop/ @JzoNgKVO @iamjoel
+/web/app/components/develop/template/*.mdx @JzoNgKVO @iamjoel @RiskeyL
 
 # Frontend - App - Logs and Annotations
 /web/app/components/app/workflow-log/ @JzoNgKVO @iamjoel


### PR DESCRIPTION
## Summary

- Adds @RiskeyL as a code owner for service API documentation MDX templates.
- Keeps existing API documentation owners on those files.

## Screenshots

N/A