### PR TITLE
chore: install dify-agent as editable

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -59,7 +59,7 @@ members = ["providers/vdb/*", "providers/trace/*"]
 exclude = ["providers/vdb/__pycache__", "providers/trace/__pycache__"]
 
 [tool.uv.sources]
-dify-agent = { path = "../dify-agent" }
+dify-agent = { path = "../dify-agent", editable = true }
 dify-vdb-alibabacloud-mysql = { workspace = true }
 dify-vdb-analyticdb = { workspace = true }
 dify-vdb-baidu = { workspace = true }

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1281,7 +1281,7 @@ wheels = [
 [[package]]
 name = "dify-agent"
 version = "0.1.0"
-source = { directory = "../dify-agent" }
+source = { editable = "../dify-agent" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
@@ -1615,7 +1615,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.43.14,<2.0.0" },
     { name = "celery", specifier = ">=5.6.3,<6.0.0" },
     { name = "croniter", specifier = ">=6.2.2,<7.0.0" },
-    { name = "dify-agent", directory = "../dify-agent" },
+    { name = "dify-agent", editable = "../dify-agent" },
     { name = "fastopenapi", extras = ["flask"], specifier = "==0.7.0" },
     { name = "flask", specifier = ">=3.1.3,<4.0.0" },
     { name = "flask-compress", specifier = ">=1.24,<2.0.0" },


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Marks the local `dify-agent` uv path dependency as editable.
- Updates `api/uv.lock` so `dify-agent` resolves from the source tree during local API development.
- Prevents stale local `api/.venv` imports when `dify-agent/src` changes.

Fixes #36734

## Screenshots

N/A

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Validation:

- `uv lock --project api`
- `uv sync --project api --dev`
- `uv run --project api python -c "import dify_agent, pathlib; print(pathlib.Path(dify_agent.__file__).as_posix())"` prints a path under `dify-agent/src`
- `uv run --project api python -c "from dify_agent.layers.dify_plugin import DIFY_PLUGIN_TOOLS_LAYER_TYPE_ID; print(DIFY_PLUGIN_TOOLS_LAYER_TYPE_ID)"` prints `dify.plugin.tools`
- `git diff --check`
