### PR TITLE
docs(api): fix typo in vector migration docstrings

### DIFF
--- a/api/commands/vector.py
+++ b/api/commands/vector.py
@@ -30,7 +30,7 @@ def vdb_migrate(scope: str):
 
 def migrate_annotation_vector_database():
     """
-    Migrate annotation datas to target vector database .
+    Migrate annotation data to target vector database.
     """
     click.echo(click.style("Starting annotation data migration.", fg="green"))
     create_count = 0
@@ -140,7 +140,7 @@ def migrate_annotation_vector_database():
 
 def migrate_knowledge_vector_database():
     """
-    Migrate vector database datas to target vector database .
+    Migrate vector database data to target vector database.
     """
     click.echo(click.style("Starting vector database migration.", fg="green"))
     create_count = 0


### PR DESCRIPTION
  > [!IMPORTANT]
  >
  > 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
  > 1. Ensure there is an associated issue and you have been assigned to it
  > 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

  ## Summary

  Minor docstring cleanup in `api/commands/vector.py`:

  - `migrate_annotation_vector_database`: `Migrate annotation datas to target vector database .` → `Migrate annotation data
  to target vector database.`
  - `migrate_knowledge_vector_database`: `Migrate vector database datas to target vector database .` → `Migrate vector
  database data to target vector database.`
  
  "data" is uncountable in English, and the stray space before the trailing period is removed. No behavior change.

  Per CONTRIBUTING.md, typo fixes are exempt from the "issue first" rule.
  
  ## Screenshots
  
  N/A — docstring-only change.
  
  ## Checklist

  - [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
  - [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to
  typos!)
  - [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic
  change.
  - [ ] I've updated the documentation accordingly.
  - [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint
  gods
