### PR TITLE
feat(docker): add missing OPENAPI_* env vars to shared.env.example

### DIFF
--- a/docker/envs/core-services/shared.env.example
+++ b/docker/envs/core-services/shared.env.example
@@ -222,6 +222,16 @@ QUEUE_MONITOR_INTERVAL=30
 SWAGGER_UI_ENABLED=false
 SWAGGER_UI_PATH=/swagger-ui.html
 OPENAPI_ENABLED=false
+# Comma-separated CORS origins for /openapi/v1/*. Empty = same-origin only.
+OPENAPI_CORS_ALLOW_ORIGINS=
+# Comma-separated client_id values accepted at POST /openapi/v1/oauth/device/code.
+# Unknown client_id returns 400 unsupported_client.
+OPENAPI_KNOWN_CLIENT_IDS=difyctl
+# Per-token rate limit on /openapi/v1/* (requests per minute).
+# Bucket keyed on sha256(token), shared across API replicas via Redis.
+OPENAPI_RATE_LIMIT_PER_TOKEN=60
+# Enable OAuth bearer middleware (device-flow tokens + Service API /v1/* bearer).
+ENABLE_OAUTH_BEARER=true
 DSL_EXPORT_ENCRYPT_DATASET_ID=true
 DATASET_MAX_SEGMENTS_PER_REQUEST=0
 ENABLE_CLEAN_EMBEDDING_CACHE_TASK=false

--- a/docker/envs/core-services/shared.env.example
+++ b/docker/envs/core-services/shared.env.example
@@ -222,16 +222,10 @@ QUEUE_MONITOR_INTERVAL=30
 SWAGGER_UI_ENABLED=false
 SWAGGER_UI_PATH=/swagger-ui.html
 OPENAPI_ENABLED=false
-# Comma-separated CORS origins for /openapi/v1/*. Empty = same-origin only.
 OPENAPI_CORS_ALLOW_ORIGINS=
-# Comma-separated client_id values accepted at POST /openapi/v1/oauth/device/code.
-# Unknown client_id returns 400 unsupported_client.
 OPENAPI_KNOWN_CLIENT_IDS=difyctl
-# Per-token rate limit on /openapi/v1/* (requests per minute).
-# Bucket keyed on sha256(token), shared across API replicas via Redis.
 OPENAPI_RATE_LIMIT_PER_TOKEN=60
-# Enable OAuth bearer middleware (device-flow tokens + Service API /v1/* bearer).
-ENABLE_OAUTH_BEARER=true
+ENABLE_OAUTH_BEARER=false
 DSL_EXPORT_ENCRYPT_DATASET_ID=true
 DATASET_MAX_SEGMENTS_PER_REQUEST=0
 ENABLE_CLEAN_EMBEDDING_CACHE_TASK=false


### PR DESCRIPTION
## Summary

`docker/envs/core-services/shared.env.example` already carried `OPENAPI_ENABLED=false` but was missing the four companion variables introduced alongside it. This PR adds them.

**Variables added:**

| Variable | Default | Purpose |
|---|---|---|
| `OPENAPI_CORS_ALLOW_ORIGINS` | *(empty)* | Comma-separated CORS allowlist for `/openapi/v1/*`. Empty = same-origin only. |
| `OPENAPI_KNOWN_CLIENT_IDS` | `difyctl` | Comma-separated `client_id` values accepted at the device-flow endpoint. Unknown IDs return `400 unsupported_client`. |
| `OPENAPI_RATE_LIMIT_PER_TOKEN` | `60` | Per-token request rate limit on `/openapi/v1/*` (requests per minute). Bucket keyed on `sha256(token)`, shared across replicas via Redis. |
| `ENABLE_OAUTH_BEARER` | `false` | Enable OAuth bearer middleware for device-flow tokens and Service API bearer auth. |

## Test plan

- [ ] Verify the four new variables appear in `docker/envs/core-services/shared.env.example` after `OPENAPI_ENABLED=false`
- [ ] Confirm defaults match the values defined in `api/configs/feature/__init__.py`