### PR TITLE
fix: pydantic_core._pydantic_core.ValidationError: 2 validation errors for DatasetDetailResponse

### DIFF
--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -323,6 +323,12 @@ class Dataset(Base):
 
     @property
     def retrieval_model_dict(self):
+        """Return a normalized retrieval model payload for API responses.
+
+        Older rows may only persist a partial retrieval model dict. Merge the
+        stored value over the current defaults so response validation still sees
+        the required baseline fields.
+        """
         default_retrieval_model = {
             "search_method": RetrievalMethod.SEMANTIC_SEARCH,
             "reranking_enable": False,
@@ -330,7 +336,10 @@ class Dataset(Base):
             "top_k": 2,
             "score_threshold_enabled": False,
         }
-        return self.retrieval_model or default_retrieval_model
+        if not self.retrieval_model:
+            return default_retrieval_model
+
+        return {**default_retrieval_model, **self.retrieval_model}
 
     @property
     def tags(self):

--- a/api/tests/unit_tests/controllers/console/datasets/test_datasets.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_datasets.py
@@ -294,6 +294,39 @@ class TestDatasetList:
         assert status == 200
         assert resp["data"][0]["retrieval_model_dict"]["weights"]["weight_type"] is None
 
+    def test_get_merges_partial_retrieval_model_defaults(self, app: Flask):
+        api = DatasetListApi()
+        method = unwrap(api.get)
+
+        current_user = self._mock_user()
+        datasets = [make_dataset(retrieval_model={"top_k": 4, "score_threshold_enabled": False})]
+
+        with app.test_request_context("/datasets"):
+            with (
+                patch(
+                    "controllers.console.datasets.datasets.current_account_with_tenant",
+                    return_value=(current_user, "tenant-1"),
+                ),
+                patch.object(
+                    DatasetService,
+                    "get_datasets",
+                    return_value=(datasets, 1),
+                ),
+                patch.object(
+                    ProviderManager,
+                    "get_configurations",
+                    return_value=MagicMock(get_models=lambda **_: []),
+                ),
+            ):
+                resp, status = method(api)
+
+        assert status == 200
+        retrieval_model = resp["data"][0]["retrieval_model_dict"]
+        assert retrieval_model["search_method"] == "semantic_search"
+        assert retrieval_model["reranking_enable"] is False
+        assert retrieval_model["top_k"] == 4
+        assert retrieval_model["score_threshold_enabled"] is False
+
     def test_embedding_available_false(self, app: Flask):
         api = DatasetListApi()
         method = unwrap(api.get)

--- a/api/tests/unit_tests/models/test_dataset_models.py
+++ b/api/tests/unit_tests/models/test_dataset_models.py
@@ -219,6 +219,31 @@ class TestDatasetModelValidation:
         assert result["reranking_enable"] is False
         assert result["score_threshold_enabled"] is False
 
+    def test_dataset_retrieval_model_dict_property_merges_partial_values(self):
+        """Test retrieval_model_dict property fills in missing legacy keys."""
+        # Arrange
+        dataset = Dataset(
+            tenant_id=str(uuid4()),
+            name="Test Dataset",
+            data_source_type=DataSourceType.UPLOAD_FILE,
+            created_by=str(uuid4()),
+            retrieval_model={
+                "top_k": 4,
+                "score_threshold_enabled": True,
+                "score_threshold": 0.42,
+            },
+        )
+
+        # Act
+        result = dataset.retrieval_model_dict
+
+        # Assert
+        assert result["search_method"] == "semantic_search"
+        assert result["reranking_enable"] is False
+        assert result["top_k"] == 4
+        assert result["score_threshold_enabled"] is True
+        assert result["score_threshold"] == 0.42
+
     def test_dataset_gen_collection_name_by_id(self):
         """Test static method for generating collection name."""
         # Arrange


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.
fixes https://github.com/langgenius/dify/issues/36722
## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
