### PR TITLE
fix(docker): pin web docker node version

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM node:22-alpine AS base
+FROM node:22.22.1-alpine AS base
 LABEL maintainer="takatost@gmail.com"
 
 # if you located in China, you can use aliyun mirror to speed up


### PR DESCRIPTION
## Summary

  Pin the web Docker base image to Node 22.22.1 so it matches the repository Node engine requirement.

  Fixes #36723

  ## Screenshots

<img width="1226" height="737" alt="image" src="https://github.com/user-attachments/assets/76606489-085a-494d-9581-9429c6cc6b5c" />


  ## Checklist

  - [ ] This change requires a documentation update, included: Dify Document (https://github.com/langgenius/dify-docs)
  - [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
  - [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
  - [ ] I've updated the documentation accordingly.
  - [ ] I ran make lint && make type-check (backend) and cd web && pnpm exec vp staged (frontend) to appease the lint gods

## Validation:

```bash
rg -n "FROM node:|\"node\": \"\^22\.22\.1\"" package.json web/Dockerfile
curl -fsSL https://registry.hub.docker.com/v2/repositories/library/node/tags/22.22.1-alpine
docker build -t dify-web:test -f web/Dockerfile .
```