### PR TITLE
fix(docker): copy dify-agent source into production stage

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -27,7 +27,7 @@ COPY api/providers ./providers
 COPY dify-agent/pyproject.toml dify-agent/README.md /app/dify-agent/
 COPY dify-agent/src /app/dify-agent/src
 # Trust the checked-in lock during image builds; local path sources are copied from the repository context.
-RUN uv sync --frozen --no-dev
+RUN uv sync --frozen --no-dev --no-editable
 
 # production stage
 FROM base AS production


### PR DESCRIPTION
## Summary

#36735 switched `dify-agent` to an editable install, which writes a `.pth` file pointing to `/app/dify-agent/src` at build time. The `production` stage copied the venv (including the `.pth`) but not the source directory itself — making the path dead at runtime and raising `ModuleNotFoundError: No module named 'agenton'`.

## Fix

Add `--no-editable` to `uv sync` in the `packages` stage. This installs all editable deps as regular wheel installs, copying packages directly into site-packages. No source directory is needed at runtime, and future editable local packages will work automatically without additional `COPY` lines.

Local developer workflow is unaffected — editable behavior is preserved when running `uv sync` without this flag.

## Test plan

- [ ] Build the Docker image locally and verify `flask db upgrade` completes without `ModuleNotFoundError`
- [ ] Confirm `agenton` is importable inside the running container