### PR TITLE
fix: drop overbudget memory history

### DIFF
--- a/api/core/memory/token_buffer_memory.py
+++ b/api/core/memory/token_buffer_memory.py
@@ -199,10 +199,11 @@ class TokenBufferMemory:
         # prune the chat message if it exceeds the max token limit
         curr_message_tokens = self.model_instance.get_llm_num_tokens(prompt_messages)
 
-        if curr_message_tokens > max_token_limit:
-            while curr_message_tokens > max_token_limit and len(prompt_messages) > 1:
-                prompt_messages.pop(0)
-                curr_message_tokens = self.model_instance.get_llm_num_tokens(prompt_messages)
+        while curr_message_tokens > max_token_limit and prompt_messages:
+            prompt_messages.pop(0)
+            if not prompt_messages:
+                break
+            curr_message_tokens = self.model_instance.get_llm_num_tokens(prompt_messages)
 
         return prompt_messages
 

--- a/api/tests/unit_tests/core/memory/test_token_buffer_memory.py
+++ b/api/tests/unit_tests/core/memory/test_token_buffer_memory.py
@@ -757,8 +757,8 @@ class TestGetHistoryPromptMessages:
         # After pruning, we should have fewer than the 2 initial messages
         assert len(result) <= 1
 
-    def test_token_pruning_stops_at_single_message(self):
-        """Pruning stops when only 1 message remains (to prevent empty list)."""
+    def test_token_pruning_drops_last_message_when_it_still_exceeds_limit(self):
+        """History should be empty when even the newest message cannot fit the token budget."""
         conv = _make_conversation()
         conv.app = MagicMock()
 
@@ -796,8 +796,7 @@ class TestGetHistoryPromptMessages:
             mock_db.session.scalars.side_effect = scalars_side_effect
             result = mem.get_history_prompt_messages(max_token_limit=1)
 
-        # At least 1 message should remain
-        assert len(result) >= 1
+        assert result == []
 
     def test_no_pruning_when_within_limit(self):
         """When tokens ≤ limit, no pruning occurs."""


### PR DESCRIPTION
 ## Summary

  Drop conversation memory history when the newest remaining history message still exceeds the available token budget.

  When a previous answer is very long, the memory token budget can be exhausted for later LLM/Agent nodes. The old pruning logic always kept one history message, even when that message still exceeded max_token_limit, so the oversized history could continue to be passed into the next prompt.

  This updates TokenBufferMemory to return an empty history when no history message can fit within the available budget.

  Fixes #36717 

  ## Checklist

  - [ ] This change requires a documentation update, included: Dify Document (https://github.com/langgenius/dify-docs)
  - [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
  - [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
  - [ ] I've updated the documentation accordingly.
  - [ ] I ran make lint && make type-check (backend) and cd web && pnpm exec vp staged (frontend) to appease the lint gods

## Validation:

```bash
uv run --project api python -m pytest api/tests/unit_tests/core/memory/test_token_buffer_memory.py
uv run --project api ruff check api/core/memory/token_buffer_memory.py api/tests/unit_tests/core/memory/test_token_buffer_memory.py
```