### PR TITLE
fix: handle null plugin badges

### DIFF
--- a/web/app/components/plugins/card/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/card/__tests__/index.spec.tsx
@@ -465,6 +465,14 @@ describe('Card', () => {
 
       expect(screen.queryByTestId('partner-badge')).not.toBeInTheDocument()
     })
+
+    it('should handle null badges from the marketplace API', () => {
+      const plugin = createMockPlugin({ badges: null })
+
+      render(<Card payload={plugin} />)
+
+      expect(screen.queryByTestId('partner-badge')).not.toBeInTheDocument()
+    })
   })
 
   // ================================

--- a/web/app/components/plugins/card/index.tsx
+++ b/web/app/components/plugins/card/index.tsx
@@ -53,7 +53,8 @@ const Card = ({
   const { t } = useTranslation()
   const { categoriesMap } = useCategories(true)
   const currentWorkspaceId = useSelector(s => s.currentWorkspace.id)
-  const { category, type, name, org, label, brief, icon, icon_dark, verified, badges = [], from } = payload
+  const { category, type, name, org, label, brief, icon, icon_dark, verified, from } = payload
+  const badges = payload.badges ?? []
   const { theme } = useTheme()
   const iconSrc = getPluginCardIconUrl(
     { from, name, org, type },

--- a/web/app/components/plugins/types.ts
+++ b/web/app/components/plugins/types.ts
@@ -190,7 +190,7 @@ export type PluginManifestInMarket = {
   introduction: string
   verified: boolean
   install_count: number
-  badges: string[]
+  badges: string[] | null
   verification: {
     authorized_category: 'langgenius' | 'partner' | 'community'
   }
@@ -255,7 +255,7 @@ export type Plugin = {
     settings: CredentialFormSchemaBase[]
   }
   tags: { name: string }[]
-  badges: string[]
+  badges: string[] | null
   verification: {
     authorized_category: 'langgenius' | 'partner' | 'community'
   }


### PR DESCRIPTION
## Summary

Handle marketplace plugin payloads where `badges` is returned as `null` instead of an array.

## Root Cause

The plugin card used a destructuring default (`badges = []`), which only covers `undefined`. When the API returns `badges: null`, the component still calls `.includes()` on `null` and can crash rendering.

## Changes

- Normalize `payload.badges ?? []` before checking for the partner badge.
- Update marketplace plugin types to allow nullable `badges` fields.
- Add a regression test for `badges: null`.

## Validation

- `pnpm exec vp test app/components/plugins/card/__tests__/index.spec.tsx -t "null badges"`
- `pnpm exec vp test app/components/plugins/card/__tests__/index.spec.tsx`
- `pnpm exec tsc --noEmit --pretty false --incremental false`

Note: root-level `pnpm exec vp test ...` failed with `Cannot find binary path for command 'node'`; rerunning from `/Users/banana/Work/dify/web` passed. Targeted ESLint on the touched files reports pre-existing lint debt unrelated to this patch.