### PR TITLE
fix(device): surface SSO errors on /device and fix CLI null-account crash on external-SSO login

### DIFF
--- a/cli/src/api/oauth-device.ts
+++ b/cli/src/api/oauth-device.ts
@@ -40,7 +40,7 @@ export type PollSuccess = {
   subject_type?: string
   subject_email?: string
   subject_issuer?: string
-  account?: PollAccount
+  account?: PollAccount | null
   workspaces?: readonly PollWorkspace[]
   default_workspace_id?: string
   token_id?: string

--- a/cli/src/commands/auth/login/login.test.ts
+++ b/cli/src/commands/auth/login/login.test.ts
@@ -106,6 +106,8 @@ describe('runLogin', () => {
     expect(bundle.account).toBeUndefined()
     expect(bundle.external_subject?.email).toBe('sso@dify.ai')
     expect(bundle.external_subject?.issuer).toBe('https://issuer.example')
+    const stored = await store.get(bundle.current_host, 'sso@dify.ai')
+    expect(stored).toBe('dfoe_test')
     expect(io.outBuf()).toContain('external SSO')
     expect(io.outBuf()).toContain('sso@dify.ai')
   })

--- a/cli/src/commands/auth/login/login.ts
+++ b/cli/src/commands/auth/login/login.ts
@@ -100,9 +100,8 @@ function renderCodePrompt(w: NodeJS.WritableStream, cs: ReturnType<typeof colorS
 
 function renderLoggedIn(w: NodeJS.WritableStream, cs: ReturnType<typeof colorScheme>, host: string, s: PollSuccess): void {
   const display = bareHost(host)
-  const account = s.account ?? undefined
-  if (account !== undefined && account.email !== '') {
-    w.write(`${cs.successIcon()} Logged in to ${display} as ${cs.bold(account.email)} (${account.name})\n`)
+  if (s.account && s.account.email !== '') {
+    w.write(`${cs.successIcon()} Logged in to ${display} as ${cs.bold(s.account.email)} (${s.account.name})\n`)
     const ws = findDefaultWorkspace(s)
     if (ws !== undefined)
       w.write(`  Workspace: ${ws.name}\n`)
@@ -141,12 +140,11 @@ function bundleFromSuccess(host: string, s: PollSuccess, mode: StorageMode): Hos
     token_id: s.token_id,
     tokens: { bearer: s.token },
   }
-  const account = s.account ?? undefined
-  if (account !== undefined) {
-    bundle.account = { id: account.id, email: account.email, name: account.name }
+  if (s.account) {
+    bundle.account = { id: s.account.id, email: s.account.email, name: s.account.name }
   }
   if (s.subject_email !== undefined && s.subject_email !== ''
-    && (account === undefined || account.id === '')) {
+    && (!s.account || s.account.id === '')) {
     bundle.external_subject = {
       email: s.subject_email,
       issuer: s.subject_issuer ?? '',

--- a/cli/src/commands/auth/login/login.ts
+++ b/cli/src/commands/auth/login/login.ts
@@ -100,8 +100,9 @@ function renderCodePrompt(w: NodeJS.WritableStream, cs: ReturnType<typeof colorS
 
 function renderLoggedIn(w: NodeJS.WritableStream, cs: ReturnType<typeof colorScheme>, host: string, s: PollSuccess): void {
   const display = bareHost(host)
-  if (s.account !== undefined && s.account.email !== '') {
-    w.write(`${cs.successIcon()} Logged in to ${display} as ${cs.bold(s.account.email)} (${s.account.name})\n`)
+  const account = s.account ?? undefined
+  if (account !== undefined && account.email !== '') {
+    w.write(`${cs.successIcon()} Logged in to ${display} as ${cs.bold(account.email)} (${account.name})\n`)
     const ws = findDefaultWorkspace(s)
     if (ws !== undefined)
       w.write(`  Workspace: ${ws.name}\n`)
@@ -140,11 +141,12 @@ function bundleFromSuccess(host: string, s: PollSuccess, mode: StorageMode): Hos
     token_id: s.token_id,
     tokens: { bearer: s.token },
   }
-  if (s.account !== undefined) {
-    bundle.account = { id: s.account.id, email: s.account.email, name: s.account.name }
+  const account = s.account ?? undefined
+  if (account !== undefined) {
+    bundle.account = { id: account.id, email: account.email, name: account.name }
   }
   if (s.subject_email !== undefined && s.subject_email !== ''
-    && (s.account === undefined || s.account.id === '')) {
+    && (account === undefined || account.id === '')) {
     bundle.external_subject = {
       email: s.subject_email,
       issuer: s.subject_issuer ?? '',

--- a/cli/test/fixtures/dify-mock/server.ts
+++ b/cli/test/fixtures/dify-mock/server.ts
@@ -356,6 +356,9 @@ export function buildApp(getScenario: () => Scenario, state?: MockState): Hono {
         subject_type: 'external_sso',
         subject_email: 'sso@dify.ai',
         subject_issuer: 'https://issuer.example',
+        account: null,
+        workspaces: [],
+        default_workspace_id: null,
         token_id: 'tok-sso-1',
       })
     }

--- a/web/app/device/__tests__/page-terminal.spec.tsx
+++ b/web/app/device/__tests__/page-terminal.spec.tsx
@@ -118,42 +118,40 @@ describe('error_lookup_failed terminal state', () => {
   })
 })
 
-describe('error_sso terminal state from sso_error param', () => {
-  it('shows "Single sign-on failed" heading when sso_error is present', async () => {
+describe('sso_error inline banner on the code-entry page', () => {
+  const SSO_BANNER_COPY = /identity is linked to a Dify account/i
+
+  it('shows the error banner with friendly copy when sso_error is present', async () => {
     mockSearchParams = { sso_error: 'email_belongs_to_dify_account' }
     render(<DevicePage />)
-    await screen.findByText('Single sign-on failed')
+    expect(await screen.findByText(SSO_BANNER_COPY)).toBeInTheDocument()
   })
 
-  it('maps the error code to friendly copy', async () => {
+  it('keeps the code-entry screen visible (error on main page, not a separate view)', async () => {
     mockSearchParams = { sso_error: 'email_belongs_to_dify_account' }
     render(<DevicePage />)
-    await screen.findByText('Single sign-on failed')
-    expect(screen.getByText(/Dify account/i)).toBeInTheDocument()
+    await screen.findByText(SSO_BANNER_COPY)
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Continue/i })).toBeInTheDocument()
+  })
+
+  it('does not surface the raw backend error code', async () => {
+    mockSearchParams = { sso_error: 'email_belongs_to_dify_account' }
+    render(<DevicePage />)
+    await screen.findByText(SSO_BANNER_COPY)
     expect(screen.queryByText('email_belongs_to_dify_account')).not.toBeInTheDocument()
-  })
-
-  it('does not silently bounce to the code-entry screen', async () => {
-    mockSearchParams = { sso_error: 'email_belongs_to_dify_account' }
-    render(<DevicePage />)
-    await screen.findByText('Single sign-on failed')
-    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
   })
 
   it('does not scrub the param on mount (regression: error was wiped by router.replace)', async () => {
     mockSearchParams = { sso_error: 'email_belongs_to_dify_account' }
     render(<DevicePage />)
-    await screen.findByText('Single sign-on failed')
+    await screen.findByText(SSO_BANNER_COPY)
     expect(mockReplace).not.toHaveBeenCalled()
   })
 
-  it('ghost button resets to code_entry and clears the URL', async () => {
-    mockSearchParams = { sso_error: 'email_belongs_to_dify_account' }
+  it('shows no banner when sso_error is absent', () => {
     render(<DevicePage />)
-    await screen.findByText('Single sign-on failed')
-    fireEvent.click(screen.getByRole('button', { name: /Try a different code/i }))
     expect(screen.getByRole('textbox')).toBeInTheDocument()
-    expect(screen.queryByText('Single sign-on failed')).not.toBeInTheDocument()
-    expect(mockReplace).toHaveBeenCalledWith('/device')
+    expect(screen.queryByText(SSO_BANNER_COPY)).not.toBeInTheDocument()
   })
 })

--- a/web/app/device/__tests__/page-terminal.spec.tsx
+++ b/web/app/device/__tests__/page-terminal.spec.tsx
@@ -6,9 +6,10 @@ import DevicePage from '../page'
 const mockPush = vi.fn()
 const mockReplace = vi.fn()
 const mockDeviceLookup = vi.fn()
+let mockSearchParams: Record<string, string | null> = {}
 
 vi.mock('@/next/navigation', () => ({
-  useSearchParams: () => ({ get: () => null }),
+  useSearchParams: () => ({ get: (key: string) => mockSearchParams[key] ?? null }),
   useRouter: () => ({ push: mockPush, replace: mockReplace }),
   usePathname: () => '/device',
 }))
@@ -53,6 +54,12 @@ let MockDeviceFlowError: MockDeviceFlowErrorCtor
 
 beforeEach(async () => {
   vi.clearAllMocks()
+  mockSearchParams = {}
+  // router.replace(pathname) in the real app drops the query string; mirror
+  // that so useSearchParams reflects the cleared URL on the next render.
+  mockReplace.mockImplementation(() => {
+    mockSearchParams = {}
+  })
   mockUseQuery.mockReturnValue({ data: undefined, isError: false } as ReturnType<typeof useQuery>)
   const mod = await import('@/service/device-flow') as { DeviceFlowError: MockDeviceFlowErrorCtor }
   MockDeviceFlowError = mod.DeviceFlowError
@@ -108,5 +115,45 @@ describe('error_lookup_failed terminal state', () => {
     fireEvent.click(screen.getByRole('button', { name: /Try again/i }))
     expect(screen.getByRole('textbox')).toBeInTheDocument()
     expect(screen.queryByText('Could not verify the code')).not.toBeInTheDocument()
+  })
+})
+
+describe('error_sso terminal state from sso_error param', () => {
+  it('shows "Single sign-on failed" heading when sso_error is present', async () => {
+    mockSearchParams = { sso_error: 'email_belongs_to_dify_account' }
+    render(<DevicePage />)
+    await screen.findByText('Single sign-on failed')
+  })
+
+  it('maps the error code to friendly copy', async () => {
+    mockSearchParams = { sso_error: 'email_belongs_to_dify_account' }
+    render(<DevicePage />)
+    await screen.findByText('Single sign-on failed')
+    expect(screen.getByText(/Dify account/i)).toBeInTheDocument()
+    expect(screen.queryByText('email_belongs_to_dify_account')).not.toBeInTheDocument()
+  })
+
+  it('does not silently bounce to the code-entry screen', async () => {
+    mockSearchParams = { sso_error: 'email_belongs_to_dify_account' }
+    render(<DevicePage />)
+    await screen.findByText('Single sign-on failed')
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+  })
+
+  it('does not scrub the param on mount (regression: error was wiped by router.replace)', async () => {
+    mockSearchParams = { sso_error: 'email_belongs_to_dify_account' }
+    render(<DevicePage />)
+    await screen.findByText('Single sign-on failed')
+    expect(mockReplace).not.toHaveBeenCalled()
+  })
+
+  it('ghost button resets to code_entry and clears the URL', async () => {
+    mockSearchParams = { sso_error: 'email_belongs_to_dify_account' }
+    render(<DevicePage />)
+    await screen.findByText('Single sign-on failed')
+    fireEvent.click(screen.getByRole('button', { name: /Try a different code/i }))
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+    expect(screen.queryByText('Single sign-on failed')).not.toBeInTheDocument()
+    expect(mockReplace).toHaveBeenCalledWith('/device')
   })
 })

--- a/web/app/device/page.tsx
+++ b/web/app/device/page.tsx
@@ -26,7 +26,6 @@ type View
     | { kind: 'error_expired' }
     | { kind: 'error_rate_limited' }
     | { kind: 'error_lookup_failed' }
-    | { kind: 'error_sso', code: string }
 
 export default function DevicePage() {
   const searchParams = useSearchParams()
@@ -82,14 +81,6 @@ export default function DevicePage() {
       setView({ kind: 'authorize_account', userCode: view.userCode }) // eslint-disable-line react/set-state-in-effect
       return
     }
-    // sso_error is a non-sensitive backend error code. Drive a stable terminal
-    // view from it and leave it in the URL — scrubbing it here (router.replace)
-    // remounts the page in the same tick and wipes the just-set state, so the
-    // error never renders. The top guard stops re-runs from clobbering it.
-    if (ssoError) {
-      setView({ kind: 'error_sso', code: ssoError }) // eslint-disable-line react/set-state-in-effect
-      return
-    }
     let consumed = false
     if (ssoVerified) {
       setView({ kind: 'authorize_sso' }) // eslint-disable-line react/set-state-in-effect
@@ -104,7 +95,7 @@ export default function DevicePage() {
     }
     if (consumed && (urlUserCode || ssoVerified))
       router.replace(pathname)
-  }, [urlUserCode, ssoVerified, ssoError, account, view, router, pathname])
+  }, [urlUserCode, ssoVerified, account, view, router, pathname])
 
   const onContinue = async () => {
     if (!isValidUserCode(typed))
@@ -135,6 +126,12 @@ export default function DevicePage() {
     <>
       {view.kind === 'code_entry' && (
         <div className="flex flex-col gap-5">
+          {ssoError && (
+            <div className="flex items-start gap-2 rounded-lg bg-state-destructive-hover p-3">
+              <span className="mt-0.5 i-ri-close-circle-line h-4 w-4 shrink-0 text-util-colors-red-red-600" />
+              <p className="text-sm text-text-destructive">{ssoErrorCopy(ssoError)}</p>
+            </div>
+          )}
           <div>
             <h1 className="text-2xl font-semibold text-text-primary">Authorize Dify CLI</h1>
             <p className="mt-2 text-sm text-text-secondary">
@@ -271,28 +268,6 @@ export default function DevicePage() {
             }}
           >
             ← Try again
-          </Button>
-        </div>
-      )}
-
-      {view.kind === 'error_sso' && (
-        <div className="flex flex-col gap-1">
-          <div className="mb-2.5 flex h-[38px] w-[38px] items-center justify-center rounded-full bg-state-destructive-hover">
-            <span className="i-ri-close-circle-line h-[18px] w-[18px] text-util-colors-red-red-600" />
-          </div>
-          <h1 className="text-xl font-semibold text-text-primary">Single sign-on failed</h1>
-          <p className="text-sm text-text-secondary">{ssoErrorCopy(view.code)}</p>
-          <Divider className="my-3" />
-          <Button
-            variant="ghost"
-            className="w-full"
-            onClick={() => {
-              router.replace(pathname)
-              setView({ kind: 'code_entry' })
-              setErrMsg(null)
-            }}
-          >
-            ← Try a different code
           </Button>
         </div>
       )}

--- a/web/app/device/page.tsx
+++ b/web/app/device/page.tsx
@@ -33,6 +33,7 @@ export default function DevicePage() {
   const pathname = usePathname()
   const urlUserCode = (searchParams.get('user_code') || '').trim().toUpperCase()
   const ssoVerified = searchParams.get('sso_verified') === '1'
+  const ssoError = searchParams.get('sso_error') || ''
 
   const [typed, setTyped] = useState('')
   const [view, setView] = useState<View>({ kind: 'code_entry' })
@@ -81,7 +82,11 @@ export default function DevicePage() {
       return
     }
     let consumed = false
-    if (ssoVerified) {
+    if (ssoError) {
+      setErrMsg(ssoError) // eslint-disable-line react/set-state-in-effect
+      consumed = true
+    }
+    else if (ssoVerified) {
       setView({ kind: 'authorize_sso' }) // eslint-disable-line react/set-state-in-effect
       consumed = true
     }
@@ -92,9 +97,9 @@ export default function DevicePage() {
         setView({ kind: 'chooser', userCode: urlUserCode }) // eslint-disable-line react/set-state-in-effect
       consumed = true
     }
-    if (consumed && (urlUserCode || ssoVerified))
+    if (consumed && (urlUserCode || ssoVerified || ssoError))
       router.replace(pathname)
-  }, [urlUserCode, ssoVerified, account, view, router, pathname])
+  }, [urlUserCode, ssoVerified, ssoError, account, view, router, pathname])
 
   const onContinue = async () => {
     if (!isValidUserCode(typed))

--- a/web/app/device/page.tsx
+++ b/web/app/device/page.tsx
@@ -14,7 +14,7 @@ import AuthorizeAccount from './components/authorize-account'
 import AuthorizeSSO from './components/authorize-sso'
 import Chooser from './components/chooser'
 import CodeInput from './components/code-input'
-import { classifyLookupError } from './utils/error-copy'
+import { classifyLookupError, ssoErrorCopy } from './utils/error-copy'
 import { isValidUserCode } from './utils/user-code'
 
 type View
@@ -26,6 +26,7 @@ type View
     | { kind: 'error_expired' }
     | { kind: 'error_rate_limited' }
     | { kind: 'error_lookup_failed' }
+    | { kind: 'error_sso', code: string }
 
 export default function DevicePage() {
   const searchParams = useSearchParams()
@@ -81,12 +82,16 @@ export default function DevicePage() {
       setView({ kind: 'authorize_account', userCode: view.userCode }) // eslint-disable-line react/set-state-in-effect
       return
     }
-    let consumed = false
+    // sso_error is a non-sensitive backend error code. Drive a stable terminal
+    // view from it and leave it in the URL — scrubbing it here (router.replace)
+    // remounts the page in the same tick and wipes the just-set state, so the
+    // error never renders. The top guard stops re-runs from clobbering it.
     if (ssoError) {
-      setErrMsg(ssoError) // eslint-disable-line react/set-state-in-effect
-      consumed = true
+      setView({ kind: 'error_sso', code: ssoError }) // eslint-disable-line react/set-state-in-effect
+      return
     }
-    else if (ssoVerified) {
+    let consumed = false
+    if (ssoVerified) {
       setView({ kind: 'authorize_sso' }) // eslint-disable-line react/set-state-in-effect
       consumed = true
     }
@@ -97,7 +102,7 @@ export default function DevicePage() {
         setView({ kind: 'chooser', userCode: urlUserCode }) // eslint-disable-line react/set-state-in-effect
       consumed = true
     }
-    if (consumed && (urlUserCode || ssoVerified || ssoError))
+    if (consumed && (urlUserCode || ssoVerified))
       router.replace(pathname)
   }, [urlUserCode, ssoVerified, ssoError, account, view, router, pathname])
 
@@ -266,6 +271,28 @@ export default function DevicePage() {
             }}
           >
             ← Try again
+          </Button>
+        </div>
+      )}
+
+      {view.kind === 'error_sso' && (
+        <div className="flex flex-col gap-1">
+          <div className="mb-2.5 flex h-[38px] w-[38px] items-center justify-center rounded-full bg-state-destructive-hover">
+            <span className="i-ri-close-circle-line h-[18px] w-[18px] text-util-colors-red-red-600" />
+          </div>
+          <h1 className="text-xl font-semibold text-text-primary">Single sign-on failed</h1>
+          <p className="text-sm text-text-secondary">{ssoErrorCopy(view.code)}</p>
+          <Divider className="my-3" />
+          <Button
+            variant="ghost"
+            className="w-full"
+            onClick={() => {
+              router.replace(pathname)
+              setView({ kind: 'code_entry' })
+              setErrMsg(null)
+            }}
+          >
+            ← Try a different code
           </Button>
         </div>
       )}

--- a/web/app/device/utils/error-copy.ts
+++ b/web/app/device/utils/error-copy.ts
@@ -30,6 +30,18 @@ export function approveErrorCopy(err: unknown): string {
   return DEFAULT_MESSAGE
 }
 
+// SSO-branch failures arrive as a `sso_error` query param set by the backend
+// (oauth_device_sso sso-complete) when it redirects back to /device.
+const SSO_ERROR_COPY: Record<string, string> = {
+  email_belongs_to_dify_account: 'This identity is linked to a Dify account. Use “Sign in with Dify account” instead.',
+}
+
+const DEFAULT_SSO_ERROR_MESSAGE = 'Single sign-on could not be completed. Try again.'
+
+export function ssoErrorCopy(code: string): string {
+  return SSO_ERROR_COPY[code] ?? DEFAULT_SSO_ERROR_MESSAGE
+}
+
 export type LookupOutcome = 'expired' | 'rate_limited' | 'failed'
 
 export function classifyLookupError(err: unknown): LookupOutcome {


### PR DESCRIPTION
## Summary

Two related fixes for the device-authorization (RFC 8628) SSO path.

### Web — surface SSO errors on `/device`

When the SSO callback (SAML ACS / OIDC / OAuth2) rejects a login, the enterprise backend redirects the browser to `/device?sso_error=<code>`. The `/device` page read `sso_verified` from the URL but not `sso_error`, so the failure was silent — the user landed back on a blank code-entry form with no feedback.

The page now maps the `sso_error` code to friendly copy (`ssoErrorCopy()` dispatch table) and shows it as an **inline banner on the code-entry page**. The banner is derived directly from the URL param (no effect, no extra state), so it survives re-render/remount and shows the error on the main page rather than a separate full-screen view. The param is intentionally **not** scrubbed (non-sensitive error code; keeps the banner stable instead of being wiped by `router.replace`).

### CLI — fix crash on external-SSO device login

The poll-success contract sends `account: null` for the `external_sso` subject type (external SSO has no console account). `difyctl auth login` guarded only `!== undefined` and then read `.id` on the result, crashing the SSO login with `null is not an object (evaluating 'account.id')`. Normalized `null`/`undefined` to a single path so the `external_subject` branch is taken, and widened the `PollSuccess.account` type to `PollAccount | null` to match the contract. Updated the device-flow mock's SSO scenario to send `account: null` so the test reproduces the real server response (the gap that hid the bug).

## Tests

- **web** `page-terminal.spec.tsx` — banner shows with friendly copy, code-entry stays visible, raw backend code not surfaced, no scrub-on-mount regression. 11/11 pass.
- **cli** `login.test.ts` — SSO case reproduces the crash pre-fix, passes post-fix; `whoami`/`status` already cover both subject types. Full CLI suite 817/817 pass.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
