### PR TITLE
fix: restore published config callback

### DIFF
--- a/cli/src/store/store.ts
+++ b/cli/src/store/store.ts
@@ -44,7 +44,7 @@ abstract class FileBasedStore implements Store {
   flush(): void {
     fs.mkdirSync(dirname(this.filePath), { recursive: true, mode: DIR_PERM })
 
-    // we don't handle A-B-A scenario, 
+    // we don't handle A-B-A scenario,
     // which is not likely to happen in cli
     if (!this.dirty) {
       return

--- a/web/app/components/app/app-publisher/__tests__/features-wrapper.spec.tsx
+++ b/web/app/components/app/app-publisher/__tests__/features-wrapper.spec.tsx
@@ -85,7 +85,6 @@ describe('FeaturesWrappedAppPublisher', () => {
         allowed_file_upload_methods: ['remote_url'],
         number_limits: 5,
       },
-      resetAppConfig: vi.fn(),
     },
   }
 
@@ -110,9 +109,11 @@ describe('FeaturesWrappedAppPublisher', () => {
   })
 
   it('should restore published features after confirmation', async () => {
+    const resetAppConfig = vi.fn()
     render(
       <FeaturesWrappedAppPublisher
         publishedConfig={publishedConfig as any}
+        resetAppConfig={resetAppConfig}
       />,
     )
 
@@ -120,7 +121,7 @@ describe('FeaturesWrappedAppPublisher', () => {
     fireEvent.click(screen.getByRole('button', { name: 'operation.confirm' }))
 
     await waitFor(() => {
-      expect(publishedConfig.modelConfig.resetAppConfig).toHaveBeenCalledTimes(1)
+      expect(resetAppConfig).toHaveBeenCalledTimes(1)
       expect(mockSetFeatures).toHaveBeenCalledWith(expect.objectContaining({
         moreLikeThis: { enabled: true },
         opening: {
@@ -139,9 +140,11 @@ describe('FeaturesWrappedAppPublisher', () => {
   })
 
   it('should close restore confirmation without restoring when cancelled', async () => {
+    const resetAppConfig = vi.fn()
     render(
       <FeaturesWrappedAppPublisher
         publishedConfig={publishedConfig as any}
+        resetAppConfig={resetAppConfig}
       />,
     )
 
@@ -153,7 +156,7 @@ describe('FeaturesWrappedAppPublisher', () => {
     await waitFor(() => {
       expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
     })
-    expect(publishedConfig.modelConfig.resetAppConfig).not.toHaveBeenCalled()
+    expect(resetAppConfig).not.toHaveBeenCalled()
     expect(mockSetFeatures).not.toHaveBeenCalled()
   })
 })

--- a/web/app/components/app/app-publisher/features-wrapper.tsx
+++ b/web/app/components/app/app-publisher/features-wrapper.tsx
@@ -32,10 +32,10 @@ const FeaturesWrappedAppPublisher = (props: Props) => {
   const features = useFeatures(s => s.features)
   const featuresStore = useFeaturesStore()
   const [restoreConfirmOpen, setRestoreConfirmOpen] = useState(false)
-  const { more_like_this, opening_statement, suggested_questions, sensitive_word_avoidance, speech_to_text, text_to_speech, suggested_questions_after_answer, retriever_resource, annotation_reply, file_upload, resetAppConfig } = props.publishedConfig.modelConfig
+  const { more_like_this, opening_statement, suggested_questions, sensitive_word_avoidance, speech_to_text, text_to_speech, suggested_questions_after_answer, retriever_resource, annotation_reply, file_upload } = props.publishedConfig.modelConfig
 
   const handleConfirm = useCallback(() => {
-    resetAppConfig?.()
+    props.resetAppConfig?.()
     const {
       features,
       setFeatures,


### PR DESCRIPTION
## Summary

This PR fixes the restore published config action in `FeaturesWrappedAppPublisher`.

The restore callback is passed as a top-level prop (`props.resetAppConfig`), but the component currently reads `resetAppConfig` from `props.publishedConfig.modelConfig`. Since `modelConfig` does not contain this callback, confirming the restore dialog does not reset the main app configuration state.

This change restores the callback usage to `props.resetAppConfig?.()` and updates the unit test to pass `resetAppConfig` through the same top-level prop shape used in real usage.

From Codex

## Screenshots

| Before | After |
|--------|-------|
| Confirming restore does not reset the app configuration because `resetAppConfig` is undefined. | Confirming restore calls `props.resetAppConfig` and restores the published configuration state. |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Note: I could not run the frontend verification locally because the current Node.js version is v22.16.0 while this repository requires ^22.22.1.