### PR TITLE
fix: align knowledge retrieval node output description with backend Source model

### DIFF
--- a/web/app/components/workflow/nodes/knowledge-retrieval/panel.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/panel.tsx
@@ -162,21 +162,15 @@ const Panel: FC<NodePanelProps<KnowledgeRetrievalNodeType>> = ({
                   type: 'string',
                   description: t(`${i18nPrefix}.outputVars.content`, { ns: 'workflow' }),
                 },
-                // url, title, link like bing search reference result: link, link page title, link page icon
                 {
                   name: 'title',
                   type: 'string',
                   description: t(`${i18nPrefix}.outputVars.title`, { ns: 'workflow' }),
                 },
                 {
-                  name: 'url',
+                  name: 'summary',
                   type: 'string',
-                  description: t(`${i18nPrefix}.outputVars.url`, { ns: 'workflow' }),
-                },
-                {
-                  name: 'icon',
-                  type: 'string',
-                  description: t(`${i18nPrefix}.outputVars.icon`, { ns: 'workflow' }),
+                  description: t(`${i18nPrefix}.outputVars.summary`, { ns: 'workflow' }),
                 },
                 {
                   name: 'metadata',

--- a/web/i18n/en-US/workflow.json
+++ b/web/i18n/en-US/workflow.json
@@ -757,11 +757,9 @@
   "nodes.knowledgeRetrieval.metadata.title": "Metadata Filtering",
   "nodes.knowledgeRetrieval.outputVars.content": "Segmented content",
   "nodes.knowledgeRetrieval.outputVars.files": "Retrieved files",
-  "nodes.knowledgeRetrieval.outputVars.icon": "Segmented icon",
   "nodes.knowledgeRetrieval.outputVars.metadata": "Other metadata",
   "nodes.knowledgeRetrieval.outputVars.output": "Retrieval segmented data",
   "nodes.knowledgeRetrieval.outputVars.title": "Segmented title",
-  "nodes.knowledgeRetrieval.outputVars.url": "Segmented URL",
   "nodes.knowledgeRetrieval.queryAttachment": "Query Images",
   "nodes.knowledgeRetrieval.queryText": "Query Text",
   "nodes.knowledgeRetrieval.queryVariable": "Query Variable",
@@ -1221,5 +1219,6 @@
   "versionHistory.nameThisVersion": "Name this version",
   "versionHistory.releaseNotesPlaceholder": "Describe what changed",
   "versionHistory.restorationTip": "After version restoration, the current draft will be overwritten.",
-  "versionHistory.title": "Versions"
+  "versionHistory.title": "Versions",
+  "nodes.knowledgeRetrieval.outputVars.summary": "Content summary if available"
 }

--- a/web/i18n/zh-Hans/workflow.json
+++ b/web/i18n/zh-Hans/workflow.json
@@ -757,11 +757,9 @@
   "nodes.knowledgeRetrieval.metadata.title": "元数据过滤",
   "nodes.knowledgeRetrieval.outputVars.content": "分段内容",
   "nodes.knowledgeRetrieval.outputVars.files": "召回的文件",
-  "nodes.knowledgeRetrieval.outputVars.icon": "分段图标",
   "nodes.knowledgeRetrieval.outputVars.metadata": "其他元数据",
   "nodes.knowledgeRetrieval.outputVars.output": "召回的分段",
   "nodes.knowledgeRetrieval.outputVars.title": "分段标题",
-  "nodes.knowledgeRetrieval.outputVars.url": "分段链接",
   "nodes.knowledgeRetrieval.queryAttachment": "查询图片",
   "nodes.knowledgeRetrieval.queryText": "查询文本",
   "nodes.knowledgeRetrieval.queryVariable": "查询变量",
@@ -1221,5 +1219,6 @@
   "versionHistory.nameThisVersion": "命名",
   "versionHistory.releaseNotesPlaceholder": "请描述变更",
   "versionHistory.restorationTip": "版本回滚后，当前草稿将被覆盖。",
-  "versionHistory.title": "版本"
+  "versionHistory.title": "版本",
+  "nodes.knowledgeRetrieval.outputVars.summary": "内容摘要（如有）"
 }


### PR DESCRIPTION
## What
Fixes #36764

The frontend output variable description for the Knowledge Retrieval node listed `url` and `icon` fields that do **not** exist in the backend `Source` model, and was missing the `summary` field that the backend actually returns.

## Changes
- **Removed** `url` and `icon` from output variable definitions (not present in backend `Source` model)
- **Added** `summary` output variable (matches `Source.summary`)
- **Updated** en-US and zh-Hans i18n translations

## Backend `Source` model reference
```python
class Source(BaseModel):
    metadata: SourceMetadata
    title: str
    files: list[Any] | None
    content: str | None
    summary: str | None
```

## Frontend before vs after
| Before | After |
|---|---|
| content, title, url, icon, metadata, files | content, title, summary, metadata, files |