### PR TITLE
fix: persist partially generated message when user stops generation

### DIFF
--- a/api/core/app/apps/base_app_runner.py
+++ b/api/core/app/apps/base_app_runner.py
@@ -337,6 +337,24 @@ class AppRunner:
         except GenerateTaskStoppedError:
             # Explicitly close provider stream to stop in-flight token generation ASAP.
             invoke_result.close()
+            # Persist partially generated content so it is not lost when the user stops.
+            if text and message_id:
+                try:
+                    from sqlalchemy import select
+
+                    from extensions.ext_database import db
+                    from libs.datetime_utils import naive_utc_now
+                    from models.model import Message
+
+                    stmt = select(Message).where(Message.id == message_id)
+                    message = db.session.scalar(stmt)
+                    if message and not message.answer:
+                        message.answer = text
+                        message.updated_at = naive_utc_now()
+                        db.session.commit()
+                except Exception:
+                    db.session.rollback()
+                    _logger.exception("Failed to persist partial answer for message %s", message_id)
             raise
 
         if usage is None:


### PR DESCRIPTION
## What
Fixes #36779

When a user clicks "Stop generating" during streaming chat, the backend catches `GenerateTaskStoppedError` and aborts, but the already-generated content is lost because `QueueMessageEndEvent` is never published.

## Changes
In `base_app_runner.py` `_handle_invoke_result()`, when `GenerateTaskStoppedError` is caught:

- Persist the partial `text` (accumulated LLM output) to the `Message.answer` field in the database
- Only save if there is actual partial content and the message doesn't already have an answer
- Wrapped in try/except to avoid masking the original stop error

## Why
This aligns Dify behavior with industry standards (ChatGPT, Gemini) where stopped generations preserve the partial response in conversation history. Currently, the partial content is completely lost and users cannot see what was already generated.

## Implementation
```python
except GenerateTaskStoppedError:
    invoke_result.close()
    # Persist partially generated content so it is not lost when the user stops.
    if text and message_id:
        try:
            # Save partial answer to message record
            message = db.session.scalar(select(Message).where(Message.id == message_id))
            if message and not message.answer:
                message.answer = text
                message.updated_at = naive_utc_now()
                db.session.commit()
        except Exception:
            db.session.rollback()
    raise
```