### PR TITLE
refactor(api): Default null summary index setting to disabled

### DIFF
--- a/api/fields/dataset_fields.py
+++ b/api/fields/dataset_fields.py
@@ -189,7 +189,7 @@ class DatasetRetrievalModelResponse(ResponseModel):
 
 
 class DatasetSummaryIndexSettingResponse(ResponseModel):
-    enable: bool | None = None
+    enable: bool = False
     model_name: str | None = None
     model_provider_name: str | None = None
     summary_prompt: str | None = None

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -164,6 +164,15 @@ _SummaryIndexSetting = Annotated[
 ]
 
 
+def _normalize_optional_summary_index_setting(v: Any) -> Any:
+    """Treat legacy empty summary index payloads as disabled for estimate requests."""
+    if v is None:
+        return None
+    if isinstance(v, dict) and v.get("enable") is None:
+        return None
+    return v
+
+
 class _AutomaticProcessRule(BaseModel):
     model_config = ConfigDict(extra="allow")
 
@@ -173,12 +182,7 @@ class _AutomaticProcessRule(BaseModel):
     @field_validator("summary_index_setting", mode="before")
     @classmethod
     def _normalize_summary_index_setting(cls, v: Any) -> Any:
-        """Treat dicts with enable=None (or missing enable) as None (#36602)."""
-        if v is None:
-            return None
-        if isinstance(v, dict) and v.get("enable") is None:
-            return None
-        return v
+        return _normalize_optional_summary_index_setting(v)
 
 
 class _CustomProcessRule(BaseModel):
@@ -191,12 +195,7 @@ class _CustomProcessRule(BaseModel):
     @field_validator("summary_index_setting", mode="before")
     @classmethod
     def _normalize_summary_index_setting(cls, v: Any) -> Any:
-        """Treat dicts with enable=None (or missing enable) as None (#36602)."""
-        if v is None:
-            return None
-        if isinstance(v, dict) and v.get("enable") is None:
-            return None
-        return v
+        return _normalize_optional_summary_index_setting(v)
 
 
 class _HierarchicalProcessRule(BaseModel):
@@ -209,12 +208,7 @@ class _HierarchicalProcessRule(BaseModel):
     @field_validator("summary_index_setting", mode="before")
     @classmethod
     def _normalize_summary_index_setting(cls, v: Any) -> Any:
-        """Treat dicts with enable=None (or missing enable) as None (#36602)."""
-        if v is None:
-            return None
-        if isinstance(v, dict) and v.get("enable") is None:
-            return None
-        return v
+        return _normalize_optional_summary_index_setting(v)
 
 
 _EstimateProcessRule = Annotated[

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -164,25 +164,11 @@ _SummaryIndexSetting = Annotated[
 ]
 
 
-def _normalize_optional_summary_index_setting(v: Any) -> Any:
-    """Treat legacy empty summary index payloads as disabled for estimate requests."""
-    if v is None:
-        return None
-    if isinstance(v, dict) and v.get("enable") is None:
-        return None
-    return v
-
-
 class _AutomaticProcessRule(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     mode: Literal[ProcessRuleMode.AUTOMATIC]
     summary_index_setting: _SummaryIndexSetting | None = None
-
-    @field_validator("summary_index_setting", mode="before")
-    @classmethod
-    def _normalize_summary_index_setting(cls, v: Any) -> Any:
-        return _normalize_optional_summary_index_setting(v)
 
 
 class _CustomProcessRule(BaseModel):
@@ -192,11 +178,6 @@ class _CustomProcessRule(BaseModel):
     rules: _EstimateRules
     summary_index_setting: _SummaryIndexSetting | None = None
 
-    @field_validator("summary_index_setting", mode="before")
-    @classmethod
-    def _normalize_summary_index_setting(cls, v: Any) -> Any:
-        return _normalize_optional_summary_index_setting(v)
-
 
 class _HierarchicalProcessRule(BaseModel):
     model_config = ConfigDict(extra="allow")
@@ -204,11 +185,6 @@ class _HierarchicalProcessRule(BaseModel):
     mode: Literal[ProcessRuleMode.HIERARCHICAL]
     rules: _EstimateRules
     summary_index_setting: _SummaryIndexSetting | None = None
-
-    @field_validator("summary_index_setting", mode="before")
-    @classmethod
-    def _normalize_summary_index_setting(cls, v: Any) -> Any:
-        return _normalize_optional_summary_index_setting(v)
 
 
 _EstimateProcessRule = Annotated[

--- a/api/tests/unit_tests/controllers/console/datasets/test_datasets.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_datasets.py
@@ -1221,6 +1221,21 @@ class TestDatasetIndexingEstimateApi:
             "dataset_id": None,
         }
 
+    def _base_process_rule(self):
+        return {
+            "mode": "custom",
+            "rules": {
+                "pre_processing_rules": [
+                    {"id": "remove_extra_spaces", "enabled": True},
+                    {"id": "remove_urls_emails", "enabled": False},
+                ],
+                "segmentation": {
+                    "separator": "\n\n",
+                    "max_tokens": 1024,
+                },
+            },
+        }
+
     def test_post_success_upload_file(self, app: Flask):
         api = DatasetIndexingEstimateApi()
         method = unwrap(api.post)
@@ -1261,6 +1276,77 @@ class TestDatasetIndexingEstimateApi:
 
         assert status == 200
         assert response == {"tokens": 100}
+
+    def test_dataset_detail_summary_index_setting_round_trips_into_indexing_estimate(self, app: Flask):
+        dataset_id = "123e4567-e89b-12d3-a456-426614174000"
+        dataset = make_dataset(id=dataset_id, summary_index_setting=None)
+
+        dataset_api = DatasetApi()
+        dataset_get = unwrap(dataset_api.get)
+
+        with (
+            app.test_request_context(f"/datasets/{dataset_id}"),
+            patch(
+                "controllers.console.datasets.datasets.current_account_with_tenant",
+                return_value=(MagicMock(), "tenant-1"),
+            ),
+            patch.object(
+                DatasetService,
+                "get_dataset",
+                return_value=dataset,
+            ),
+            patch.object(
+                DatasetService,
+                "check_dataset_permission",
+                return_value=None,
+            ),
+            patch("controllers.console.datasets.datasets.create_plugin_provider_manager") as provider_manager_mock,
+        ):
+            provider_manager_mock.return_value.get_configurations.return_value.get_models.return_value = []
+            dataset_detail, status = dataset_get(dataset_api, dataset_id)
+
+        assert status == 200
+        assert dataset_detail["summary_index_setting"]["enable"] is False
+
+        payload = self._base_payload()
+        payload["process_rule"] = {
+            **self._base_process_rule(),
+            "summary_index_setting": dataset_detail["summary_index_setting"],
+        }
+
+        mock_file = self._upload_file()
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {"tokens": 100}
+
+        estimate_api = DatasetIndexingEstimateApi()
+        estimate_post = unwrap(estimate_api.post)
+
+        with (
+            app.test_request_context("/datasets/indexing-estimate"),
+            patch(
+                "controllers.console.datasets.datasets.current_account_with_tenant",
+                return_value=(MagicMock(), "tenant-1"),
+            ),
+            patch.object(
+                type(console_ns),
+                "payload",
+                new_callable=PropertyMock,
+                return_value=payload,
+            ),
+            patch(
+                "controllers.console.datasets.datasets.db.session.scalars",
+                return_value=MagicMock(all=lambda: [mock_file]),
+            ),
+            patch(
+                "controllers.console.datasets.datasets.IndexingRunner.indexing_estimate",
+                return_value=mock_response,
+            ) as indexing_estimate,
+        ):
+            response, status = estimate_post(estimate_api)
+
+        assert status == 200
+        assert response == {"tokens": 100}
+        assert indexing_estimate.call_args.args[2]["summary_index_setting"] == {"enable": False}
 
     def test_post_file_not_found(self, app: Flask):
         api = DatasetIndexingEstimateApi()

--- a/api/tests/unit_tests/controllers/console/datasets/test_datasets.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_datasets.py
@@ -1221,6 +1221,21 @@ class TestDatasetIndexingEstimateApi:
             "dataset_id": None,
         }
 
+    def _base_process_rule(self):
+        return {
+            "mode": "custom",
+            "rules": {
+                "pre_processing_rules": [
+                    {"id": "remove_extra_spaces", "enabled": True},
+                    {"id": "remove_urls_emails", "enabled": False},
+                ],
+                "segmentation": {
+                    "separator": "\n\n",
+                    "max_tokens": 1024,
+                },
+            },
+        }
+
     def test_post_success_upload_file(self, app: Flask):
         api = DatasetIndexingEstimateApi()
         method = unwrap(api.post)
@@ -1261,6 +1276,52 @@ class TestDatasetIndexingEstimateApi:
 
         assert status == 200
         assert response == {"tokens": 100}
+
+    def test_post_accepts_legacy_null_summary_index_setting(self, app: Flask):
+        api = DatasetIndexingEstimateApi()
+        method = unwrap(api.post)
+
+        payload = self._base_payload()
+        payload["process_rule"] = {
+            **self._base_process_rule(),
+            "summary_index_setting": {
+                "enable": None,
+                "model_name": None,
+                "model_provider_name": None,
+                "summary_prompt": None,
+            },
+        }
+
+        mock_file = self._upload_file()
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {"tokens": 100}
+
+        with (
+            app.test_request_context("/"),
+            patch(
+                "controllers.console.datasets.datasets.current_account_with_tenant",
+                return_value=(MagicMock(), "tenant-1"),
+            ),
+            patch.object(
+                type(console_ns),
+                "payload",
+                new_callable=PropertyMock,
+                return_value=payload,
+            ),
+            patch(
+                "controllers.console.datasets.datasets.db.session.scalars",
+                return_value=MagicMock(all=lambda: [mock_file]),
+            ),
+            patch(
+                "controllers.console.datasets.datasets.IndexingRunner.indexing_estimate",
+                return_value=mock_response,
+            ) as indexing_estimate,
+        ):
+            response, status = method(api)
+
+        assert status == 200
+        assert response == {"tokens": 100}
+        assert "summary_index_setting" not in indexing_estimate.call_args.args[2]
 
     def test_post_file_not_found(self, app: Flask):
         api = DatasetIndexingEstimateApi()

--- a/api/tests/unit_tests/controllers/console/datasets/test_datasets.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_datasets.py
@@ -1221,21 +1221,6 @@ class TestDatasetIndexingEstimateApi:
             "dataset_id": None,
         }
 
-    def _base_process_rule(self):
-        return {
-            "mode": "custom",
-            "rules": {
-                "pre_processing_rules": [
-                    {"id": "remove_extra_spaces", "enabled": True},
-                    {"id": "remove_urls_emails", "enabled": False},
-                ],
-                "segmentation": {
-                    "separator": "\n\n",
-                    "max_tokens": 1024,
-                },
-            },
-        }
-
     def test_post_success_upload_file(self, app: Flask):
         api = DatasetIndexingEstimateApi()
         method = unwrap(api.post)
@@ -1276,52 +1261,6 @@ class TestDatasetIndexingEstimateApi:
 
         assert status == 200
         assert response == {"tokens": 100}
-
-    def test_post_accepts_legacy_null_summary_index_setting(self, app: Flask):
-        api = DatasetIndexingEstimateApi()
-        method = unwrap(api.post)
-
-        payload = self._base_payload()
-        payload["process_rule"] = {
-            **self._base_process_rule(),
-            "summary_index_setting": {
-                "enable": None,
-                "model_name": None,
-                "model_provider_name": None,
-                "summary_prompt": None,
-            },
-        }
-
-        mock_file = self._upload_file()
-        mock_response = MagicMock()
-        mock_response.model_dump.return_value = {"tokens": 100}
-
-        with (
-            app.test_request_context("/"),
-            patch(
-                "controllers.console.datasets.datasets.current_account_with_tenant",
-                return_value=(MagicMock(), "tenant-1"),
-            ),
-            patch.object(
-                type(console_ns),
-                "payload",
-                new_callable=PropertyMock,
-                return_value=payload,
-            ),
-            patch(
-                "controllers.console.datasets.datasets.db.session.scalars",
-                return_value=MagicMock(all=lambda: [mock_file]),
-            ),
-            patch(
-                "controllers.console.datasets.datasets.IndexingRunner.indexing_estimate",
-                return_value=mock_response,
-            ) as indexing_estimate,
-        ):
-            response, status = method(api)
-
-        assert status == 200
-        assert response == {"tokens": 100}
-        assert "summary_index_setting" not in indexing_estimate.call_args.args[2]
 
     def test_post_file_not_found(self, app: Flask):
         api = DatasetIndexingEstimateApi()

--- a/api/tests/unit_tests/fields/test_dataset_fields.py
+++ b/api/tests/unit_tests/fields/test_dataset_fields.py
@@ -82,7 +82,7 @@ def _dump_dataset_detail(payload):
     return DatasetDetailResponse.model_validate(payload).model_dump(mode="json")
 
 
-def test_dataset_detail_expands_legacy_null_nested_fields():
+def test_dataset_detail_defaults_legacy_null_summary_index_setting_to_disabled():
     response = _dump_dataset_detail(
         _dataset_detail_payload(
             summary_index_setting=None,
@@ -92,7 +92,7 @@ def test_dataset_detail_expands_legacy_null_nested_fields():
     )
 
     assert response["summary_index_setting"] == {
-        "enable": None,
+        "enable": False,
         "model_name": None,
         "model_provider_name": None,
         "summary_prompt": None,

--- a/api/tests/unit_tests/services/test_dataset_service_document.py
+++ b/api/tests/unit_tests/services/test_dataset_service_document.py
@@ -1360,28 +1360,6 @@ class TestDocumentServiceEstimateValidation:
         with pytest.raises(ValueError, match="Field required"):
             DocumentService.estimate_args_validate(args)
 
-    def test_estimate_args_validate_ignores_legacy_null_summary_index_setting(self):
-        args = {
-            "info_list": {"data_source_type": "upload_file"},
-            "process_rule": {
-                "mode": "custom",
-                "rules": {
-                    "pre_processing_rules": [{"id": "remove_stopwords", "enabled": True}],
-                    "segmentation": {"separator": "\n", "max_tokens": 128},
-                },
-                "summary_index_setting": {
-                    "enable": None,
-                    "model_name": None,
-                    "model_provider_name": None,
-                    "summary_prompt": None,
-                },
-            },
-        }
-
-        DocumentService.estimate_args_validate(args)
-
-        assert "summary_index_setting" not in args["process_rule"]
-
 
 class TestDocumentServiceSaveDocumentAdditionalBranches:
     """Additional unit tests for dataset bootstrap and process-rule branches."""

--- a/api/tests/unit_tests/services/test_dataset_service_document.py
+++ b/api/tests/unit_tests/services/test_dataset_service_document.py
@@ -1360,6 +1360,28 @@ class TestDocumentServiceEstimateValidation:
         with pytest.raises(ValueError, match="Field required"):
             DocumentService.estimate_args_validate(args)
 
+    def test_estimate_args_validate_ignores_legacy_null_summary_index_setting(self):
+        args = {
+            "info_list": {"data_source_type": "upload_file"},
+            "process_rule": {
+                "mode": "custom",
+                "rules": {
+                    "pre_processing_rules": [{"id": "remove_stopwords", "enabled": True}],
+                    "segmentation": {"separator": "\n", "max_tokens": 128},
+                },
+                "summary_index_setting": {
+                    "enable": None,
+                    "model_name": None,
+                    "model_provider_name": None,
+                    "summary_prompt": None,
+                },
+            },
+        }
+
+        DocumentService.estimate_args_validate(args)
+
+        assert "summary_index_setting" not in args["process_rule"]
+
 
 class TestDocumentServiceSaveDocumentAdditionalBranches:
     """Additional unit tests for dataset bootstrap and process-rule branches."""

--- a/packages/contracts/generated/api/console/datasets/types.gen.ts
+++ b/packages/contracts/generated/api/console/datasets/types.gen.ts
@@ -528,7 +528,7 @@ export type DatasetRetrievalModelResponse = {
 }
 
 export type DatasetSummaryIndexSettingResponse = {
-  enable?: boolean | null
+  enable?: boolean
   model_name?: string | null
   model_provider_name?: string | null
   summary_prompt?: string | null

--- a/packages/contracts/generated/api/console/datasets/zod.gen.ts
+++ b/packages/contracts/generated/api/console/datasets/zod.gen.ts
@@ -336,7 +336,7 @@ export const zDatasetIconInfoResponse = z.object({
  * DatasetSummaryIndexSettingResponse
  */
 export const zDatasetSummaryIndexSettingResponse = z.object({
-  enable: z.boolean().nullish(),
+  enable: z.boolean().optional().default(false),
   model_name: z.string().nullish(),
   model_provider_name: z.string().nullish(),
   summary_prompt: z.string().nullish(),

--- a/packages/contracts/generated/api/service/types.gen.ts
+++ b/packages/contracts/generated/api/service/types.gen.ts
@@ -340,7 +340,7 @@ export type DatasetRetrievalModelResponse = {
 }
 
 export type DatasetSummaryIndexSettingResponse = {
-  enable?: boolean | null
+  enable?: boolean
   model_name?: string | null
   model_provider_name?: string | null
   summary_prompt?: string | null

--- a/packages/contracts/generated/api/service/zod.gen.ts
+++ b/packages/contracts/generated/api/service/zod.gen.ts
@@ -326,7 +326,7 @@ export const zDatasetRerankingModelResponse = z.object({
  * DatasetSummaryIndexSettingResponse
  */
 export const zDatasetSummaryIndexSettingResponse = z.object({
-  enable: z.boolean().nullish(),
+  enable: z.boolean().optional().default(false),
   model_name: z.string().nullish(),
   model_provider_name: z.string().nullish(),
   summary_prompt: z.string().nullish(),


### PR DESCRIPTION
**AI disclosure**: This PR was AI-assisted with Codex using GPT-5.5. I have reviewed the final diff, and I am responsible for the content.

## Summary

This PR fixes the Console dataset detail response for legacy datasets whose `summary_index_setting` is stored as `NULL`.

A `NULL` summary index setting means summary index generation is not configured and should behave as disabled. The response currently exposes that storage detail as `enable: null`, which gives Console clients an ambiguous boolean value and can be propagated into follow-up requests such as `/datasets/indexing-estimate`.

PR #36626 resolves the issue by introducing custom validation rules. However, this logic could be removed and simplified by changing the interpretation of `NULL` summary_index_setting.

Closes #36813

## Fix

- Default `DatasetSummaryIndexSettingResponse.enable` to `false`.
- Keep nullable storage semantics inside the backend persistence layer.
- Remove the estimate-request input workaround for `{ "enable": null }`, so the API output contract is responsible for producing a valid disabled setting.
- Update field serialization coverage for `summary_index_setting = NULL`.
- Add a controller round-trip regression test: read dataset detail, reuse the returned `summary_index_setting` in an indexing estimate request, and verify the estimate path accepts the normalized disabled setting.
