### PR TITLE
fix: clean unnecessary | None type annotations (#35557)

### DIFF
--- a/api/core/agent/base_agent_runner.py
+++ b/api/core/agent/base_agent_runner.py
@@ -118,7 +118,7 @@ class BaseAgentRunner(AppRunner):
         features = model_schema.features if model_schema and model_schema.features else []
         self.stream_tool_call = ModelFeature.STREAM_TOOL_CALL in features
         self.files = application_generate_entity.files if ModelFeature.VISION in features else []
-        self.query: str | None = ""
+        self.query: str = ""
         self._current_thoughts: list[PromptMessage] = []
 
     def _repack_app_generate_entity(

--- a/api/core/app/entities/task_entities.py
+++ b/api/core/app/entities/task_entities.py
@@ -241,7 +241,7 @@ class WorkflowFinishStreamResponse(StreamResponse):
         created_by: Mapping[str, object] = Field(default_factory=dict)
         created_at: int
         finished_at: int | None
-        exceptions_count: int | None = 0
+        exceptions_count: int = 0
         files: Sequence[Mapping[str, Any]] | None = []
 
     event: StreamEvent = StreamEvent.WORKFLOW_FINISHED

--- a/api/core/datasource/entities/datasource_entities.py
+++ b/api/core/datasource/entities/datasource_entities.py
@@ -317,9 +317,9 @@ class WebSiteInfo(BaseModel):
     """
 
     status: str | None = Field(..., description="crawl job status")
-    web_info_list: list[WebSiteInfoDetail] | None = []
-    total: int | None = Field(default=0, description="The total number of websites")
-    completed: int | None = Field(default=0, description="The number of completed websites")
+    web_info_list: list[WebSiteInfoDetail] = []
+    total: int = Field(default=0, description="The total number of websites")
+    completed: int = Field(default=0, description="The number of completed websites")
 
 
 class WebsiteCrawlMessage(BaseModel):

--- a/api/core/datasource/entities/datasource_entities.py
+++ b/api/core/datasource/entities/datasource_entities.py
@@ -317,7 +317,7 @@ class WebSiteInfo(BaseModel):
     """
 
     status: str | None = Field(..., description="crawl job status")
-    web_info_list: list[WebSiteInfoDetail] = []
+    web_info_list: list[WebSiteInfoDetail] = Field(default_factory=list)
     total: int = Field(default=0, description="The total number of websites")
     completed: int = Field(default=0, description="The number of completed websites")
 

--- a/api/core/datasource/entities/datasource_entities.py
+++ b/api/core/datasource/entities/datasource_entities.py
@@ -317,9 +317,9 @@ class WebSiteInfo(BaseModel):
     """
 
     status: str | None = Field(..., description="crawl job status")
-    web_info_list: list[WebSiteInfoDetail] = Field(default_factory=list)
-    total: int = Field(default=0, description="The total number of websites")
-    completed: int = Field(default=0, description="The number of completed websites")
+    web_info_list: list[WebSiteInfoDetail] | None = []
+    total: int | None = Field(default=0, description="The total number of websites")
+    completed: int | None = Field(default=0, description="The number of completed websites")
 
 
 class WebsiteCrawlMessage(BaseModel):

--- a/api/core/entities/provider_entities.py
+++ b/api/core/entities/provider_entities.py
@@ -113,7 +113,7 @@ class CustomModelConfiguration(BaseModel):
     current_credential_id: str | None = None
     current_credential_name: str | None = None
     available_model_credentials: list[CredentialConfiguration] = []
-    unadded_to_model_list: bool | None = False
+    unadded_to_model_list: bool = False
 
     # pydantic configs
     model_config = ConfigDict(protected_namespaces=())
@@ -209,7 +209,7 @@ class ProviderConfig(BasicProviderConfig):
     required: bool = False
     default: Union[int, str, float, bool] | None = None
     options: list[Option] | None = None
-    multiple: bool | None = False
+    multiple: bool = False
     label: I18nObject | None = None
     help: I18nObject | None = None
     url: str | None = None

--- a/api/core/plugin/entities/request.py
+++ b/api/core/plugin/entities/request.py
@@ -73,7 +73,7 @@ class RequestInvokeLLM(BaseRequestInvokeModel):
     prompt_messages: list[PromptMessage] = Field(default_factory=list)
     tools: list[PromptMessageTool] | None = Field(default_factory=list[PromptMessageTool])
     stop: list[str] | None = Field(default_factory=list[str])
-    stream: bool | None = False
+    stream: bool = False
 
     model_config = ConfigDict(protected_namespaces=())
 

--- a/api/core/trigger/entities/entities.py
+++ b/api/core/trigger/entities/entities.py
@@ -46,8 +46,8 @@ class EventParameter(BaseModel):
     )
     template: PluginParameterTemplate | None = Field(default=None, description="The template of the parameter")
     scope: str | None = None
-    required: bool | None = False
-    multiple: bool | None = Field(
+    required: bool = False
+    multiple: bool = Field(
         default=False,
         description="Whether the parameter is multiple select, only valid for select or dynamic-select type",
     )

--- a/packages/contracts/generated/api/console/workspaces/types.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/types.gen.ts
@@ -1238,7 +1238,7 @@ export type CustomModelConfiguration = {
   current_credential_name?: string | null
   model: string
   model_type: ModelType
-  unadded_to_model_list?: boolean | null
+  unadded_to_model_list?: boolean
 }
 
 export type CredentialFormSchema = {

--- a/packages/contracts/generated/api/console/workspaces/zod.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/zod.gen.ts
@@ -1531,7 +1531,7 @@ export const zCustomModelConfiguration = z.object({
   current_credential_name: z.string().nullish(),
   model: z.string(),
   model_type: zModelType,
-  unadded_to_model_list: z.boolean().nullish().default(false),
+  unadded_to_model_list: z.boolean().optional().default(false),
 })
 
 /**


### PR DESCRIPTION
## What

Remove `| None` from type annotations where the field has a non-None default value.

 #35557

## Changes

- `bool | None = False` -> `bool = False` (required, multiple, stream, unadded_to_model_list)
- `int | None = 0` -> `int = 0` (exceptions_count, total, completed)
- `str | None = ""` -> `str = ""` (query)
- `list[...] | None = []` -> `list[...] = []` (web_info_list)

6 files changed, 10 modifications total.