### PR TITLE
fix(web): use default profile query cache

### DIFF
--- a/web/features/account-profile/client.ts
+++ b/web/features/account-profile/client.ts
@@ -35,7 +35,5 @@ export const userProfileQueryOptions = () =>
         },
       }
     },
-    staleTime: 0,
-    gcTime: 0,
     retry: (failureCount, error) => !isLegacyBase401(error) && failureCount < 3,
   })

--- a/web/features/account-profile/server.ts
+++ b/web/features/account-profile/server.ts
@@ -75,7 +75,5 @@ export const serverUserProfileQueryOptions = () =>
         },
       }
     },
-    staleTime: 0,
-    gcTime: 0,
     retry: false,
   })


### PR DESCRIPTION
## Summary
- remove per-query staleTime/gcTime overrides from account profile query options
- let hydrated profile data use the global 5-minute query freshness default
- avoid immediate client refetch after server hydration

## Verification
- vpr lint --quiet --fix
- pnpm -C web type-check

Note: `vpr type-check --filter dify-web` was attempted first, but this passes `--filter` through to `tsgo` and fails with an unknown compiler option; `pnpm -C web type-check` was used for the web check.