### PR TITLE
fix: #36162

### DIFF
--- a/api/core/entities/parameter_entities.py
+++ b/api/core/entities/parameter_entities.py
@@ -22,6 +22,9 @@ class CommonParameterType(StrEnum):
     # eg: Select a Slack channel from a Slack workspace
     DYNAMIC_SELECT = "dynamic-select"
 
+    # Date picker parameter
+    DATE = auto()
+
     # TOOL_SELECTOR = "tool-selector"
     # MCP object and array type parameters
     ARRAY = auto()

--- a/api/core/plugin/entities/parameters.py
+++ b/api/core/plugin/entities/parameters.py
@@ -43,6 +43,9 @@ class PluginParameterType(StrEnum):
     # deprecated, should not use.
     SYSTEM_FILES = CommonParameterType.SYSTEM_FILES
 
+    # Date picker parameter
+    DATE = CommonParameterType.DATE
+
     # MCP object and array type parameters
     ARRAY = CommonParameterType.ARRAY
     OBJECT = CommonParameterType.OBJECT
@@ -95,6 +98,7 @@ def as_normal_type(typ: StrEnum):
         PluginParameterType.SECRET_INPUT,
         PluginParameterType.SELECT,
         PluginParameterType.CHECKBOX,
+        PluginParameterType.DATE,
     }:
         return "string"
     return typ.value
@@ -109,6 +113,7 @@ def cast_parameter_value(typ: StrEnum, value: Any, /):
                 | PluginParameterType.SELECT
                 | PluginParameterType.CHECKBOX
                 | PluginParameterType.DYNAMIC_SELECT
+                | PluginParameterType.DATE
             ):
                 if value is None:
                     return ""

--- a/api/core/tools/entities/tool_entities.py
+++ b/api/core/tools/entities/tool_entities.py
@@ -314,6 +314,9 @@ class ToolParameter(PluginParameter):
         ANY = PluginParameterType.ANY
         DYNAMIC_SELECT = PluginParameterType.DYNAMIC_SELECT
 
+        # Date picker parameter
+        DATE = PluginParameterType.DATE
+
         # MCP object and array type parameters
         ARRAY = MCPServerParameterType.ARRAY
         OBJECT = MCPServerParameterType.OBJECT

--- a/web/app/components/header/account-setting/model-provider-page/declarations.ts
+++ b/web/app/components/header/account-setting/model-provider-page/declarations.ts
@@ -25,6 +25,7 @@ export enum FormTypeEnum {
   any = 'any',
   object = 'object',
   array = 'array',
+  date = 'date',
   dynamicSelect = 'dynamic-select',
 }
 

--- a/web/app/components/tools/utils/to-form-schema.ts
+++ b/web/app/components/tools/utils/to-form-schema.ts
@@ -73,6 +73,8 @@ export const toType = (type: string) => {
       return 'number-input'
     case 'boolean':
       return 'checkbox'
+    case 'date':
+      return 'date'
     default:
       return type
   }
@@ -178,6 +180,11 @@ const correctInitialData = (type: string, target: FormValueInput, defaultValue: 
       target.value = Number.parseFloat(defaultValue)
   }
 
+  if (type === 'date') {
+    if (typeof defaultValue === 'string')
+      target.value = defaultValue
+  }
+
   if (type === 'app-selector' || type === 'model-selector')
     target.value = defaultValue
 
@@ -243,7 +250,7 @@ export const getConfiguredValue = (value: Record<string, unknown>, formSchemas: 
 const getVarKindType = (type: FormTypeEnum) => {
   if (type === FormTypeEnum.file || type === FormTypeEnum.files)
     return VarKindType.variable
-  if (type === FormTypeEnum.select || type === FormTypeEnum.checkbox || type === FormTypeEnum.textNumber)
+  if (type === FormTypeEnum.select || type === FormTypeEnum.checkbox || type === FormTypeEnum.textNumber || type === FormTypeEnum.date)
     return VarKindType.constant
   if (type === FormTypeEnum.textInput || type === FormTypeEnum.secretInput)
     return VarKindType.mixed

--- a/web/app/components/workflow/nodes/_base/components/form-input-item.helpers.ts
+++ b/web/app/components/workflow/nodes/_base/components/form-input-item.helpers.ts
@@ -48,6 +48,7 @@ type FormInputState = {
   isBoolean: boolean
   isCheckbox: boolean
   isConstant: boolean
+  isDate: boolean
   isDynamicSelect: boolean
   isFile: boolean
   isFiles: boolean
@@ -106,6 +107,7 @@ export const getFormInputState = (
   const isDynamicSelect = type === FormTypeEnum.dynamicSelect
   const isAppSelector = type === FormTypeEnum.appSelector
   const isModelSelector = type === FormTypeEnum.modelSelector
+  const isDate = type === FormTypeEnum.date
   const showTypeSwitch = isNumber || isBoolean || isObject || isArray || isSelect
   const isConstant = varInput?.type === VarKindType.constant || !varInput?.type
   const showVariableSelector = isFile || varInput?.type === VarKindType.variable
@@ -118,6 +120,7 @@ export const getFormInputState = (
     isBoolean,
     isCheckbox,
     isConstant,
+    isDate,
     isDynamicSelect,
     isFile,
     isFiles,
@@ -152,6 +155,8 @@ export const getTargetVarType = (state: FormInputState) => {
     return VarType.object
   if (state.isArray)
     return VarType.arrayObject
+  if (state.isDate)
+    return VarType.string
   return VarType.string
 }
 
@@ -174,7 +179,7 @@ export const getFilterVar = (state: FormInputState) => {
 export const getVarKindType = (state: FormInputState) => {
   if (state.isFile)
     return VarKindType.variable
-  if (state.isSelect || state.isDynamicSelect || state.isBoolean || state.isNumber || state.isArray || state.isObject)
+  if (state.isSelect || state.isDynamicSelect || state.isBoolean || state.isNumber || state.isArray || state.isObject || state.isDate)
     return VarKindType.constant
   if (state.isString)
     return VarKindType.mixed

--- a/web/app/components/workflow/nodes/_base/components/form-input-item.tsx
+++ b/web/app/components/workflow/nodes/_base/components/form-input-item.tsx
@@ -7,8 +7,10 @@ import type { TriggerWithProvider } from '@/app/components/workflow/block-select
 import type { ToolWithProvider, ValueSelector, Var } from '@/app/components/workflow/types'
 import { cn } from '@langgenius/dify-ui/cn'
 import { Select, SelectContent, SelectItem, SelectItemIndicator, SelectItemText, SelectTrigger } from '@langgenius/dify-ui/select'
+import dayjs from 'dayjs'
 import { useEffect, useMemo, useState } from 'react'
 import { CheckboxList } from '@/app/components/base/checkbox-list'
+import DatePicker from '@/app/components/base/date-and-time-picker/date-picker'
 import Input from '@/app/components/base/input'
 import { useLanguage } from '@/app/components/header/account-setting/model-provider-page/hooks'
 import { AppSelector } from '@/app/components/plugins/plugin-detail-panel/app-selector'
@@ -90,6 +92,7 @@ const FormInputItem: FC<Props> = ({
     isBoolean,
     isCheckbox,
     isConstant,
+    isDate,
     isDynamicSelect,
     isModelSelector,
     isMultipleSelect,
@@ -390,6 +393,17 @@ const FormInputItem: FC<Props> = ({
           value={(varInput?.value as string) || ''}
           onChange={handleValueChange}
           placeholder={<div className="whitespace-pre">{placeholder?.[language] || placeholder?.en_US}</div>}
+        />
+      )}
+      {isDate && isConstant && (
+        <DatePicker
+          value={varInput?.value ? dayjs(varInput.value as string) : undefined}
+          onChange={(date) => {
+            handleValueChange(date ? date.format('YYYY-MM-DD') : '')
+          }}
+          onClear={() => handleValueChange('')}
+          placeholder={placeholder?.[language] || placeholder?.en_US}
+          needTimePicker={false}
         />
       )}
       {isAppSelector && (


### PR DESCRIPTION
Fixes #36162

## Summary
Adds Fri May 29 08:02:02 PM UTC 2026 parameter type support for tool plugins, enabling plugin developers to use a date picker input in tool parameter forms.

## Changes

### Backend (API)
- Added  to  enum
- Added  to  enum
- Added  to  enum
- Updated  to map DATE to "string" (dates are stored as ISO date strings)
- Updated  to handle DATE type (cast to string, same as other string-like types)

### Frontend (Web)
- Added `date = 'date'` to `FormTypeEnum`
- Updated `toType()` to pass through `'date'` type
- Added `isDate` state to form input helpers
- Added `DatePicker` component rendering in `form-input-item.tsx` for date parameters
- Updated `getVarKindType` and `correctInitialData` to handle date type

## Testing
- DATE type correctly resolves to "string" normal type
- DATE values are cast as strings (ISO format YYYY-MM-DD)
- Frontend renders the existing DatePicker component for date-type parameters