### PR TITLE
fix: #36183 add auto-generate workflow/chatflow functionality

### DIFF
--- a/api/controllers/console/app/generator.py
+++ b/api/controllers/console/app/generator.py
@@ -17,7 +17,12 @@ from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotIni
 from core.helper.code_executor.code_node_provider import CodeNodeProvider
 from core.helper.code_executor.javascript.javascript_code_provider import JavascriptCodeProvider
 from core.helper.code_executor.python3.python3_code_provider import Python3CodeProvider
-from core.llm_generator.entities import RuleCodeGeneratePayload, RuleGeneratePayload, RuleStructuredOutputPayload
+from core.llm_generator.entities import (
+    RuleCodeGeneratePayload,
+    RuleGeneratePayload,
+    RuleStructuredOutputPayload,
+    WorkflowGeneratePayload,
+)
 from core.llm_generator.llm_generator import LLMGenerator
 from extensions.ext_database import db
 from graphon.model_runtime.entities.llm_entities import LLMMode
@@ -47,6 +52,7 @@ register_schema_models(
     RuleGeneratePayload,
     RuleCodeGeneratePayload,
     RuleStructuredOutputPayload,
+    WorkflowGeneratePayload,
     InstructionGeneratePayload,
     InstructionTemplatePayload,
     ModelConfig,
@@ -263,3 +269,35 @@ class InstructionGenerationTemplateApi(Resource):
                 return {"data": INSTRUCTION_GENERATE_TEMPLATE_CODE}
             case _:
                 raise ValueError(f"Invalid type: {args.type}")
+
+
+@console_ns.route("/workflow-generate")
+class WorkflowGenerateApi(Resource):
+    @console_ns.doc("generate_workflow")
+    @console_ns.doc(description="Auto-generate a workflow or chatflow graph from a natural language description")
+    @console_ns.expect(console_ns.models[WorkflowGeneratePayload.__name__])
+    @console_ns.response(200, "Workflow graph generated successfully")
+    @console_ns.response(400, "Invalid request parameters")
+    @console_ns.response(402, "Provider quota exceeded")
+    @setup_required
+    @login_required
+    @account_initialization_required
+    @with_current_tenant_id
+    def post(self, current_tenant_id: str):
+        args = WorkflowGeneratePayload.model_validate(console_ns.payload)
+
+        try:
+            result = LLMGenerator.generate_workflow(
+                tenant_id=current_tenant_id,
+                args=args,
+            )
+        except ProviderTokenNotInitError as ex:
+            raise ProviderNotInitializeError(ex.description)
+        except QuotaExceededError:
+            raise ProviderQuotaExceededError()
+        except ModelCurrentlyNotSupportError:
+            raise ProviderModelCurrentlyNotSupportError()
+        except InvokeError as e:
+            raise CompletionRequestError(e.description)
+
+        return result

--- a/api/core/llm_generator/entities.py
+++ b/api/core/llm_generator/entities.py
@@ -18,3 +18,9 @@ class RuleCodeGeneratePayload(RuleGeneratePayload):
 class RuleStructuredOutputPayload(BaseModel):
     instruction: str = Field(..., description="Structured output generation instruction")
     model_config_data: ModelConfig = Field(..., alias="model_config", description="Model configuration")
+
+
+class WorkflowGeneratePayload(BaseModel):
+    description: str = Field(..., description="Natural language description of the desired workflow")
+    app_mode: str = Field(default="advanced-chat", description="App mode: 'advanced-chat' (chatflow) or 'workflow'")
+    model_config_data: ModelConfig = Field(..., alias="model_config", description="Model configuration")

--- a/api/core/llm_generator/llm_generator.py
+++ b/api/core/llm_generator/llm_generator.py
@@ -8,7 +8,12 @@ import json_repair
 from sqlalchemy import select
 
 from core.app.app_config.entities import ModelConfig
-from core.llm_generator.entities import RuleCodeGeneratePayload, RuleGeneratePayload, RuleStructuredOutputPayload
+from core.llm_generator.entities import (
+    RuleCodeGeneratePayload,
+    RuleGeneratePayload,
+    RuleStructuredOutputPayload,
+    WorkflowGeneratePayload,
+)
 from core.llm_generator.output_parser.rule_config_generator import RuleConfigGeneratorOutputParser
 from core.llm_generator.output_parser.suggested_questions_after_answer import SuggestedQuestionsAfterAnswerOutputParser
 from core.llm_generator.prompts import (
@@ -19,6 +24,8 @@ from core.llm_generator.prompts import (
     LLM_MODIFY_PROMPT_SYSTEM,
     PYTHON_CODE_GENERATOR_PROMPT_TEMPLATE,
     SYSTEM_STRUCTURED_OUTPUT_GENERATE,
+    WORKFLOW_GENERATE_PROMPT_SYSTEM,
+    WORKFLOW_GENERATE_PROMPT_USER,
     WORKFLOW_RULE_CONFIG_PROMPT_GENERATE_TEMPLATE,
 )
 from core.model_manager import ModelManager
@@ -485,6 +492,82 @@ class LLMGenerator:
         except Exception as e:
             logger.exception("Failed to invoke LLM model, model: %s", args.model_config_data.name)
             return {"output": "", "error": f"An unexpected error occurred: {str(e)}"}
+
+    @classmethod
+    def generate_workflow(
+        cls,
+        tenant_id: str,
+        args: WorkflowGeneratePayload,
+    ) -> dict[str, Any]:
+        """Generate a workflow graph from a natural language description.
+
+        Returns a dict with keys ``graph`` (the generated workflow graph) and ``error``.
+        """
+        prompt_template = PromptTemplateParser(WORKFLOW_GENERATE_PROMPT_USER)
+        app_mode_label = "chatflow (advanced-chat)" if args.app_mode == "advanced-chat" else "workflow"
+        prompt = prompt_template.format(
+            inputs={
+                "APP_MODE": app_mode_label,
+                "DESCRIPTION": args.description,
+            },
+            remove_template_variables=False,
+        )
+
+        model_manager = ModelManager.for_tenant(tenant_id=tenant_id)
+        model_instance = model_manager.get_model_instance(
+            tenant_id=tenant_id,
+            model_type=ModelType.LLM,
+            provider=args.model_config_data.provider,
+            model=args.model_config_data.name,
+        )
+
+        prompt_messages: list[PromptMessage] = [
+            SystemPromptMessage(content=WORKFLOW_GENERATE_PROMPT_SYSTEM),
+            UserPromptMessage(content=prompt),
+        ]
+        model_parameters = {
+            **(args.model_config_data.completion_params or {}),
+            "temperature": 0.2,
+            "max_tokens": 4096,
+        }
+
+        try:
+            response: LLMResult = model_instance.invoke_llm(
+                prompt_messages=prompt_messages, model_parameters=model_parameters, stream=False
+            )
+
+            raw_content = response.message.get_text_content()
+
+            # Strip markdown code fences if present
+            cleaned = raw_content.strip()
+            if cleaned.startswith("```"):
+                # Remove opening fence (```json or ```)
+                first_newline = cleaned.index("\n")
+                cleaned = cleaned[first_newline + 1 :]
+            if cleaned.endswith("```"):
+                cleaned = cleaned[: -len("```")]
+            cleaned = cleaned.strip()
+
+            try:
+                graph = json.loads(cleaned)
+            except json.JSONDecodeError:
+                graph = json_repair.loads(cleaned)
+
+            if not isinstance(graph, dict):
+                return {"graph": {}, "error": "LLM did not return a valid workflow graph object."}
+
+            # Basic validation
+            if "nodes" not in graph or "edges" not in graph:
+                return {"graph": {}, "error": "Generated graph is missing 'nodes' or 'edges'."}
+
+            return {"graph": graph, "error": ""}
+
+        except InvokeError as e:
+            error = str(e)
+            return {"graph": {}, "error": f"Failed to generate workflow. Error: {error}"}
+        except Exception as e:
+            logger.exception("Failed to generate workflow, model: %s", args.model_config_data.name)
+            return {"graph": {}, "error": f"An unexpected error occurred: {str(e)}"}
 
     @staticmethod
     def instruction_modify_legacy(

--- a/api/core/llm_generator/prompts.py
+++ b/api/core/llm_generator/prompts.py
@@ -425,6 +425,131 @@ You should edit the prompt according to the IDEAL OUTPUT."""
 
 INSTRUCTION_GENERATE_TEMPLATE_CODE = """Please fix the errors in the {{#error_message#}}."""
 
+WORKFLOW_GENERATE_PROMPT_SYSTEM = """You are an expert workflow designer for the Dify platform. Your task is to generate a workflow graph (as JSON) based on the user's natural language description.
+
+## Available Node Types
+- "start": The entry point of the workflow. Always required. Has a `variables` array for user input fields.
+- "llm": A Large Language Model node for text generation, summarization, classification, etc.
+- "code": A code execution node (Python or JavaScript) for data transformation.
+- "http-request": Makes HTTP requests to external APIs.
+- "knowledge-retrieval": Retrieves relevant context from a knowledge base.
+- "question-classifier": Classifies user input into categories and routes to different branches.
+- "if-else": Conditional branching based on variable values.
+- "template-transform": Jinja2 template for text formatting.
+- "answer": Terminal node for chatflow (advanced-chat) mode that outputs the response to the user.
+- "end": Terminal node for workflow mode that outputs the final result.
+
+## Graph Structure
+The output must be a valid JSON object with:
+- "nodes": array of node objects
+- "edges": array of edge objects connecting nodes
+
+### Node Object
+```json
+{
+  "id": "<unique_string_id>",
+  "position": {"x": <number>, "y": <number>},
+  "data": {
+    "type": "<node_type>",
+    "title": "<human_readable_title>",
+    ...node-type-specific fields
+  }
+}
+```
+
+### Edge Object
+```json
+{
+  "id": "<source_id>-<target_id>",
+  "source": "<source_node_id>",
+  "sourceHandle": "source",
+  "target": "<target_node_id>",
+  "targetHandle": "target"
+}
+```
+
+## Node-Specific Data Fields
+
+### start node
+- `variables`: array of input variable definitions, e.g. `[{"type": "text-input", "variable": "query", "label": "Query", "required": true}]`
+  - Supported variable types: "text-input", "paragraph", "number", "select", "file", "file-list"
+
+### llm node
+- `model`: {"provider": "", "name": "", "mode": "chat", "completion_params": {"temperature": 0.7, "max_tokens": 512}}
+- `prompt_template`: array of messages, e.g. `[{"role": "system", "text": "You are a helpful assistant."}, {"role": "user", "text": "{{#start.query#}}"}]`
+- `memory`: null or {"window": {"enabled": false, "size": 10}, "query_prompt_template": "{{#sys.query#}}"}
+- `context`: {"enabled": false, "variable_selector": []} or reference a knowledge-retrieval node output
+
+### code node
+- `code_language`: "python3" or "javascript"
+- `code`: the code string (must define a `main` function returning a dict)
+- `variables`: array of `{"variable": "<name>", "value_selector": ["<node_id>", "<output_key>"]}`
+- `outputs`: object mapping output names to types, e.g. `{"result": {"type": "string"}}`
+
+### http-request node
+- `method`: "get", "post", "put", "delete"
+- `url`: the URL string
+- `headers`: string of headers (key: value per line)
+- `params`: string of query params
+- `body`: {"type": "json", "data": "<json_string>"} or {"type": "none"}
+- `authorization`: {"type": "no-auth"} or {"type": "api-key", "config": {"type": "bearer", "api_key": ""}}
+
+### knowledge-retrieval node
+- `query_variable_selector`: e.g. ["start", "query"] or ["sys", "query"]
+- `dataset_ids`: [] (empty, user will configure)
+- `retrieval_mode`: "single" or "multiple"
+
+### question-classifier node
+- `query_variable_selector`: e.g. ["start", "query"] or ["sys", "query"]
+- `model`: same as llm node model field
+- `classes`: array of `{"id": "<unique_id>", "name": "<class_name>"}`
+- Note: edges from this node use `sourceHandle` = class id
+
+### if-else node
+- `conditions`: array of condition objects
+- `logical_operator`: "and" or "or"
+- Note: edges use `sourceHandle` = "true" or "false"
+
+### template-transform node
+- `template`: Jinja2 template string
+- `variables`: array of `{"variable": "<name>", "value_selector": ["<node_id>", "<output_key>"]}`
+
+### answer node (for chatflow/advanced-chat mode)
+- `answer`: the answer template string, e.g. "{{#llm.text#}}"
+
+### end node (for workflow mode)
+- `outputs`: array of `{"variable": "<name>", "value_selector": ["<node_id>", "<output_key>"]}`
+
+## Variable References
+Use the format `{{#<node_id>.<variable_name>#}}` in text templates to reference outputs from other nodes.
+Use `["<node_id>", "<variable_name>"]` in `value_selector` arrays.
+For system variables in chatflow mode, use `sys.query` for the user's message.
+
+## Layout Rules
+- Position nodes left-to-right with x increments of 300.
+- Start node at position (80, 282).
+- Parallel branches should be offset vertically by 200.
+
+## Important Rules
+1. Always include exactly one "start" node.
+2. For chatflow mode (when user says "chatflow" or "chat"): end with "answer" node(s).
+3. For workflow mode (when user says "workflow"): end with "end" node(s).
+4. If the mode is unclear, default to chatflow with "answer" node.
+5. Every node must be connected via edges. No orphan nodes.
+6. The `model` field in llm/question-classifier nodes should have empty provider and name (the system will fill defaults).
+7. Generate meaningful node titles.
+8. Keep the workflow practical and minimal - don't add unnecessary nodes.
+9. Output ONLY the JSON object, no markdown formatting, no explanation.
+"""
+
+WORKFLOW_GENERATE_PROMPT_USER = """Generate a workflow graph for the following description:
+
+App mode: {{APP_MODE}}
+
+Description: {{DESCRIPTION}}
+
+Output only the JSON object with "nodes" and "edges" arrays. No markdown, no explanation."""
+
 DEFAULT_GENERATOR_SUMMARY_PROMPT = (
     """Summarize the following content. Extract only the key information and main points. """
     """Remove redundant details.

--- a/api/tests/unit_tests/core/llm_generator/test_llm_generator.py
+++ b/api/tests/unit_tests/core/llm_generator/test_llm_generator.py
@@ -683,3 +683,109 @@ class TestLLMGenerator:
                 "tenant_id", "flow_id", "current", "instruction", model_config_entity, "ideal"
             )
             assert "An unexpected error occurred" in result["error"]
+
+    def test_generate_workflow_success(self, mock_model_instance, model_config_entity):
+        from core.llm_generator.entities import WorkflowGeneratePayload
+
+        graph_json = json.dumps({
+            "nodes": [
+                {"id": "start", "position": {"x": 80, "y": 282}, "data": {"type": "start", "title": "START", "variables": []}},
+                {"id": "llm", "position": {"x": 380, "y": 282}, "data": {"type": "llm", "title": "LLM", "model": {"provider": "", "name": "", "mode": "chat", "completion_params": {}}, "prompt_template": [{"role": "user", "text": "{{#start.query#}}"}]}},
+                {"id": "answer", "position": {"x": 680, "y": 282}, "data": {"type": "answer", "title": "Answer", "answer": "{{#llm.text#}}"}},
+            ],
+            "edges": [
+                {"id": "start-llm", "source": "start", "sourceHandle": "source", "target": "llm", "targetHandle": "target"},
+                {"id": "llm-answer", "source": "llm", "sourceHandle": "source", "target": "answer", "targetHandle": "target"},
+            ],
+        })
+
+        mock_response = MagicMock()
+        mock_response.message.get_text_content.return_value = graph_json
+        mock_model_instance.invoke_llm.return_value = mock_response
+
+        args = WorkflowGeneratePayload(
+            description="A simple chatbot that answers questions",
+            app_mode="advanced-chat",
+            model_config=model_config_entity,
+        )
+        result = LLMGenerator.generate_workflow(tenant_id="tenant_id", args=args)
+
+        assert result["error"] == ""
+        assert "nodes" in result["graph"]
+        assert "edges" in result["graph"]
+        assert len(result["graph"]["nodes"]) == 3
+        assert len(result["graph"]["edges"]) == 2
+
+    def test_generate_workflow_with_markdown_fences(self, mock_model_instance, model_config_entity):
+        from core.llm_generator.entities import WorkflowGeneratePayload
+
+        graph = {
+            "nodes": [
+                {"id": "start", "position": {"x": 80, "y": 282}, "data": {"type": "start", "title": "START", "variables": []}},
+            ],
+            "edges": [],
+        }
+        # Wrap in markdown code fences
+        raw_response = f"```json\n{json.dumps(graph)}\n```"
+
+        mock_response = MagicMock()
+        mock_response.message.get_text_content.return_value = raw_response
+        mock_model_instance.invoke_llm.return_value = mock_response
+
+        args = WorkflowGeneratePayload(
+            description="A simple workflow",
+            app_mode="workflow",
+            model_config=model_config_entity,
+        )
+        result = LLMGenerator.generate_workflow(tenant_id="tenant_id", args=args)
+
+        assert result["error"] == ""
+        assert result["graph"]["nodes"][0]["id"] == "start"
+
+    def test_generate_workflow_invoke_error(self, mock_model_instance, model_config_entity):
+        from core.llm_generator.entities import WorkflowGeneratePayload
+
+        mock_model_instance.invoke_llm.side_effect = InvokeError("Model unavailable")
+
+        args = WorkflowGeneratePayload(
+            description="A chatbot",
+            app_mode="advanced-chat",
+            model_config=model_config_entity,
+        )
+        result = LLMGenerator.generate_workflow(tenant_id="tenant_id", args=args)
+
+        assert result["graph"] == {}
+        assert "Failed to generate workflow" in result["error"]
+
+    def test_generate_workflow_invalid_json(self, mock_model_instance, model_config_entity):
+        from core.llm_generator.entities import WorkflowGeneratePayload
+
+        mock_response = MagicMock()
+        mock_response.message.get_text_content.return_value = "This is not JSON at all and cannot be repaired"
+        mock_model_instance.invoke_llm.return_value = mock_response
+
+        args = WorkflowGeneratePayload(
+            description="A chatbot",
+            app_mode="advanced-chat",
+            model_config=model_config_entity,
+        )
+        result = LLMGenerator.generate_workflow(tenant_id="tenant_id", args=args)
+
+        # json_repair may return something unexpected, but we handle it
+        assert result["error"] != "" or result["graph"] == {}
+
+    def test_generate_workflow_missing_nodes_or_edges(self, mock_model_instance, model_config_entity):
+        from core.llm_generator.entities import WorkflowGeneratePayload
+
+        mock_response = MagicMock()
+        mock_response.message.get_text_content.return_value = json.dumps({"nodes": []})
+        mock_model_instance.invoke_llm.return_value = mock_response
+
+        args = WorkflowGeneratePayload(
+            description="A chatbot",
+            app_mode="advanced-chat",
+            model_config=model_config_entity,
+        )
+        result = LLMGenerator.generate_workflow(tenant_id="tenant_id", args=args)
+
+        assert "missing" in result["error"].lower() or result["graph"] == {}

--- a/web/service/debug.ts
+++ b/web/service/debug.ts
@@ -68,6 +68,20 @@ export const generateRule = (body: Record<string, any>) => {
   })
 }
 
+export type WorkflowGenerateRes = {
+  graph: {
+    nodes: any[]
+    edges: any[]
+  }
+  error?: string
+}
+
+export const generateWorkflow = (body: Record<string, any>) => {
+  return post<WorkflowGenerateRes>('/workflow-generate', {
+    body,
+  })
+}
+
 export const fetchPromptTemplate = ({
   appMode,
   mode,


### PR DESCRIPTION
Fixes #36183

## Summary

Adds the ability to automatically generate chatflows or workflows from a natural language description using an LLM.

## Changes

- **Backend API endpoint**: `POST /workflow-generate` that accepts a description and app mode, then uses an LLM to generate a complete workflow graph (nodes + edges)
- **LLM prompt**: A detailed system prompt that instructs the LLM on available node types, graph structure, and layout rules
- **Frontend service**: `generateWorkflow()` function to call the new endpoint
- **Tests**: Unit tests covering success, markdown fence stripping, error handling, and invalid JSON cases

## How it works

1. User provides a natural language description of the desired workflow (e.g., "A chatbot that retrieves knowledge from a database and answers questions")
2. The system sends this to the configured LLM with a structured prompt describing all available node types and their schemas
3. The LLM returns a valid workflow graph JSON
4. The frontend can use this graph to populate the workflow canvas

## What was tested

- Python syntax validation of all modified files
- Unit tests for the generate_workflow method (success, markdown fences, invoke errors, invalid JSON, missing fields)