### PR TITLE
fix(web): use generated current workspace query

### DIFF
--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -29,7 +29,7 @@ from controllers.console.wraps import (
 from enums.cloud_plan import CloudPlan
 from extensions.ext_database import db
 from fields.base import ResponseModel
-from libs.helper import TimestampField, to_timestamp
+from libs.helper import TimestampField, dump_response, to_timestamp
 from libs.login import current_account_with_tenant, login_required
 from models.account import Tenant, TenantCustomConfigDict, TenantStatus
 from services.account_service import TenantService
@@ -56,6 +56,11 @@ class WorkspaceCustomConfigPayload(BaseModel):
     replace_webapp_logo: str | None = None
 
 
+class WorkspaceCustomConfigResponse(ResponseModel):
+    remove_webapp_brand: bool | None = None
+    replace_webapp_logo: str | None = None
+
+
 class WorkspaceInfoPayload(BaseModel):
     name: str
 
@@ -69,7 +74,7 @@ class TenantInfoResponse(ResponseModel):
     role: str | None = None
     in_trial: bool | None = None
     trial_end_reason: str | None = None
-    custom_config: dict | None = None
+    custom_config: WorkspaceCustomConfigResponse | None = None
     trial_credits: int | None = None
     trial_credits_used: int | None = None
     next_credit_reset_date: int | None = None
@@ -101,9 +106,13 @@ register_schema_models(
     SwitchWorkspacePayload,
     WorkspaceCustomConfigPayload,
     WorkspaceInfoPayload,
-    TenantInfoResponse,
 )
-register_response_schema_models(console_ns, WorkspacePermissionResponse)
+register_response_schema_models(
+    console_ns,
+    TenantInfoResponse,
+    WorkspaceCustomConfigResponse,
+    WorkspacePermissionResponse,
+)
 
 provider_fields = {
     "provider_name": fields.String,
@@ -238,13 +247,7 @@ class TenantApi(Resource):
             else:
                 raise Unauthorized("workspace is archived")
 
-        return (
-            TenantInfoResponse.model_validate(
-                WorkspaceService.get_tenant_info(tenant),
-                from_attributes=True,
-            ).model_dump(mode="json"),
-            200,
-        )
+        return dump_response(TenantInfoResponse, WorkspaceService.get_tenant_info(tenant)), 200
 
 
 @console_ns.route("/workspaces/switch")

--- a/api/openapi/markdown/console-swagger.md
+++ b/api/openapi/markdown/console-swagger.md
@@ -15207,7 +15207,7 @@ Tag type
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | created_at | integer |  | No |
-| custom_config | object |  | No |
+| custom_config | [WorkspaceCustomConfigResponse](#workspacecustomconfigresponse) |  | No |
 | id | string |  | Yes |
 | in_trial | boolean |  | No |
 | name | string |  | No |
@@ -16324,6 +16324,13 @@ Workflow tool configuration
 | marked_name | string |  | No |
 
 #### WorkspaceCustomConfigPayload
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| remove_webapp_brand | boolean |  | No |
+| replace_webapp_logo | string |  | No |
+
+#### WorkspaceCustomConfigResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |

--- a/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
@@ -435,6 +435,23 @@ class TestTenantInfoResponse:
         assert payload["plan"] == "team"
         assert payload["created_at"] == int(created_at.timestamp())
 
+    def test_tenant_info_response_has_typed_custom_config(self):
+        payload = TenantInfoResponse.model_validate(
+            {
+                "id": "t1",
+                "custom_config": {
+                    "remove_webapp_brand": True,
+                    "replace_webapp_logo": "logo-file-id",
+                    "ignored": "value",
+                },
+            }
+        ).model_dump(mode="json")
+
+        assert payload["custom_config"] == {
+            "remove_webapp_brand": True,
+            "replace_webapp_logo": "logo-file-id",
+        }
+
 
 class TestSwitchWorkspaceApi:
     def test_switch_success(self, app: Flask):

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -4904,11 +4904,6 @@
       "count": 1
     }
   },
-  "web/app/device/page.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/education-apply/hooks.ts": {
     "react/set-state-in-effect": {
       "count": 5

--- a/packages/contracts/generated/api/console/info/orpc.gen.ts
+++ b/packages/contracts/generated/api/console/info/orpc.gen.ts
@@ -4,16 +4,8 @@ import { oc } from '@orpc/contract'
 
 import { zPostInfoResponse } from './zod.gen'
 
-/**
- * Generated contract types may be inaccurate because backend OpenAPI annotations are incomplete. Do not migrate callers until the generated contract is accurate.
- *
- * @deprecated
- */
 export const post = oc
   .route({
-    deprecated: true,
-    description:
-      'Generated contract types may be inaccurate because backend OpenAPI annotations are incomplete. Do not migrate callers until the generated contract is accurate.',
     inputStructure: 'detailed',
     method: 'POST',
     operationId: 'postInfo',

--- a/packages/contracts/generated/api/console/info/types.gen.ts
+++ b/packages/contracts/generated/api/console/info/types.gen.ts
@@ -6,9 +6,7 @@ export type ClientOptions = {
 
 export type TenantInfoResponse = {
   created_at?: number | null
-  custom_config?: {
-    [key: string]: unknown
-  } | null
+  custom_config?: WorkspaceCustomConfigResponse
   id: string
   in_trial?: boolean | null
   name?: string | null
@@ -19,6 +17,11 @@ export type TenantInfoResponse = {
   trial_credits?: number | null
   trial_credits_used?: number | null
   trial_end_reason?: string | null
+}
+
+export type WorkspaceCustomConfigResponse = {
+  remove_webapp_brand?: boolean | null
+  replace_webapp_logo?: string | null
 }
 
 export type PostInfoData = {

--- a/packages/contracts/generated/api/console/info/zod.gen.ts
+++ b/packages/contracts/generated/api/console/info/zod.gen.ts
@@ -3,11 +3,19 @@
 import * as z from 'zod'
 
 /**
+ * WorkspaceCustomConfigResponse
+ */
+export const zWorkspaceCustomConfigResponse = z.object({
+  remove_webapp_brand: z.boolean().nullish(),
+  replace_webapp_logo: z.string().nullish(),
+})
+
+/**
  * TenantInfoResponse
  */
 export const zTenantInfoResponse = z.object({
   created_at: z.int().nullish(),
-  custom_config: z.record(z.string(), z.unknown()).nullish(),
+  custom_config: zWorkspaceCustomConfigResponse.optional(),
   id: z.string(),
   in_trial: z.boolean().nullish(),
   name: z.string().nullish(),

--- a/packages/contracts/generated/api/console/workspaces/orpc.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/orpc.gen.ts
@@ -3682,16 +3682,8 @@ export const triggers = {
   get: get58,
 }
 
-/**
- * Generated contract types may be inaccurate because backend OpenAPI annotations are incomplete. Do not migrate callers until the generated contract is accurate.
- *
- * @deprecated
- */
 export const post63 = oc
   .route({
-    deprecated: true,
-    description:
-      'Generated contract types may be inaccurate because backend OpenAPI annotations are incomplete. Do not migrate callers until the generated contract is accurate.',
     inputStructure: 'detailed',
     method: 'POST',
     operationId: 'postWorkspacesCurrent',

--- a/packages/contracts/generated/api/console/workspaces/types.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/types.gen.ts
@@ -6,9 +6,7 @@ export type ClientOptions = {
 
 export type TenantInfoResponse = {
   created_at?: number | null
-  custom_config?: {
-    [key: string]: unknown
-  } | null
+  custom_config?: WorkspaceCustomConfigResponse
   id: string
   in_trial?: boolean | null
   name?: string | null
@@ -498,6 +496,11 @@ export type WorkspaceInfoPayload = {
 
 export type SwitchWorkspacePayload = {
   tenant_id: string
+}
+
+export type WorkspaceCustomConfigResponse = {
+  remove_webapp_brand?: boolean | null
+  replace_webapp_logo?: string | null
 }
 
 export type AccountWithRole = {

--- a/packages/contracts/generated/api/console/workspaces/zod.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/zod.gen.ts
@@ -3,24 +3,6 @@
 import * as z from 'zod'
 
 /**
- * TenantInfoResponse
- */
-export const zTenantInfoResponse = z.object({
-  created_at: z.int().nullish(),
-  custom_config: z.record(z.string(), z.unknown()).nullish(),
-  id: z.string(),
-  in_trial: z.boolean().nullish(),
-  name: z.string().nullish(),
-  next_credit_reset_date: z.int().nullish(),
-  plan: z.string().nullish(),
-  role: z.string().nullish(),
-  status: z.string().nullish(),
-  trial_credits: z.int().nullish(),
-  trial_credits_used: z.int().nullish(),
-  trial_end_reason: z.string().nullish(),
-})
-
-/**
  * SimpleResultResponse
  */
 export const zSimpleResultResponse = z.object({
@@ -453,6 +435,32 @@ export const zWorkspaceInfoPayload = z.object({
  */
 export const zSwitchWorkspacePayload = z.object({
   tenant_id: z.string(),
+})
+
+/**
+ * WorkspaceCustomConfigResponse
+ */
+export const zWorkspaceCustomConfigResponse = z.object({
+  remove_webapp_brand: z.boolean().nullish(),
+  replace_webapp_logo: z.string().nullish(),
+})
+
+/**
+ * TenantInfoResponse
+ */
+export const zTenantInfoResponse = z.object({
+  created_at: z.int().nullish(),
+  custom_config: zWorkspaceCustomConfigResponse.optional(),
+  id: z.string(),
+  in_trial: z.boolean().nullish(),
+  name: z.string().nullish(),
+  next_credit_reset_date: z.int().nullish(),
+  plan: z.string().nullish(),
+  role: z.string().nullish(),
+  status: z.string().nullish(),
+  trial_credits: z.int().nullish(),
+  trial_credits_used: z.int().nullish(),
+  trial_end_reason: z.string().nullish(),
 })
 
 /**

--- a/web/app/components/datasets/settings/form/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/settings/form/__tests__/index.spec.tsx
@@ -131,14 +131,6 @@ vi.mock('@/service/use-common', () => ({
       ],
     },
   }),
-  useCurrentWorkspace: () => ({
-    data: {
-      trial_credits: 1000,
-      trial_credits_used: 100,
-      next_credit_reset_date: undefined,
-    },
-    isPending: false,
-  }),
 }))
 
 vi.mock('@/app/components/header/account-setting/model-provider-page/hooks', () => ({

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/__tests__/quota-panel.spec.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/__tests__/quota-panel.spec.tsx
@@ -7,11 +7,11 @@ import QuotaPanel from '../quota-panel'
 let mockWorkspaceData: {
   trial_credits: number
   trial_credits_used: number
-  next_credit_reset_date: string
+  next_credit_reset_date: number
 } | undefined = {
   trial_credits: 100,
   trial_credits_used: 30,
-  next_credit_reset_date: '2024-12-31',
+  next_credit_reset_date: 1735603200,
 }
 let mockWorkspaceIsPending = false
 let mockTrialModels: string[] | undefined = ['langgenius/openai/openai']
@@ -32,11 +32,18 @@ vi.mock('@/app/components/base/icons/src/public/llm', () => {
   }
 })
 
-vi.mock('@/service/use-common', () => ({
-  useCurrentWorkspace: () => ({
-    data: mockWorkspaceData,
-    isPending: mockWorkspaceIsPending,
-  }),
+vi.mock('../use-trial-credits', () => ({
+  useTrialCredits: () => {
+    const totalCredits = mockWorkspaceData?.trial_credits ?? 0
+    const credits = Math.max(totalCredits - (mockWorkspaceData?.trial_credits_used ?? 0), 0)
+    return {
+      credits,
+      totalCredits,
+      isExhausted: credits <= 0,
+      isLoading: mockWorkspaceIsPending && !mockWorkspaceData,
+      nextCreditResetDate: mockWorkspaceData?.next_credit_reset_date,
+    }
+  },
 }))
 
 const renderQuotaPanel = (ui: ReactElement) => renderWithSystemFeatures(ui, {
@@ -78,7 +85,7 @@ describe('QuotaPanel', () => {
     mockWorkspaceData = {
       trial_credits: 100,
       trial_credits_used: 30,
-      next_credit_reset_date: '2024-12-31',
+      next_credit_reset_date: 1735603200,
     }
     mockWorkspaceIsPending = false
     mockTrialModels = ['langgenius/openai/openai']
@@ -118,7 +125,7 @@ describe('QuotaPanel', () => {
     mockWorkspaceData = {
       trial_credits: 10,
       trial_credits_used: 999,
-      next_credit_reset_date: '',
+      next_credit_reset_date: 0,
     }
 
     renderQuotaPanel(<QuotaPanel providers={mockProviders} />)

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/__tests__/use-trial-credits.spec.ts
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/__tests__/use-trial-credits.spec.ts
@@ -1,20 +1,34 @@
 import { renderHook } from '@testing-library/react'
 import { useTrialCredits } from '../use-trial-credits'
 
-const mockUseCurrentWorkspace = vi.fn()
+const { mockUseQuery } = vi.hoisted(() => ({
+  mockUseQuery: vi.fn(),
+}))
 
-vi.mock('@/service/use-common', () => ({
-  useCurrentWorkspace: () => mockUseCurrentWorkspace(),
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => mockUseQuery(),
+}))
+
+vi.mock('@/service/client', () => ({
+  consoleQuery: {
+    workspaces: {
+      current: {
+        post: {
+          queryOptions: () => ({ queryKey: ['console', 'workspaces', 'current', 'post'] }),
+        },
+      },
+    },
+  },
 }))
 
 describe('useTrialCredits', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockUseCurrentWorkspace.mockReturnValue({
+    mockUseQuery.mockReturnValue({
       data: {
         trial_credits: 100,
         trial_credits_used: 40,
-        next_credit_reset_date: '2026-04-01',
+        next_credit_reset_date: 1775001600,
       },
       isPending: false,
     })
@@ -29,16 +43,16 @@ describe('useTrialCredits', () => {
         totalCredits: 100,
         isExhausted: false,
         isLoading: false,
-        nextCreditResetDate: '2026-04-01',
+        nextCreditResetDate: 1775001600,
       })
     })
 
     it('should keep the hook out of loading state during a background refetch', () => {
-      mockUseCurrentWorkspace.mockReturnValue({
+      mockUseQuery.mockReturnValue({
         data: {
           trial_credits: 80,
           trial_credits_used: 20,
-          next_credit_reset_date: '2026-05-01',
+          next_credit_reset_date: 1777593600,
         },
         isPending: true,
       })
@@ -53,7 +67,7 @@ describe('useTrialCredits', () => {
 
   describe('when workspace data is missing or exhausted', () => {
     it('should report loading while the first workspace request is pending', () => {
-      mockUseCurrentWorkspace.mockReturnValue({
+      mockUseQuery.mockReturnValue({
         data: undefined,
         isPending: true,
       })
@@ -70,7 +84,7 @@ describe('useTrialCredits', () => {
     })
 
     it('should clamp negative remaining credits to zero', () => {
-      mockUseCurrentWorkspace.mockReturnValue({
+      mockUseQuery.mockReturnValue({
         data: {
           trial_credits: 10,
           trial_credits_used: 99,

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/model-auth-dropdown/credits-exhausted-alert.stories.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/model-auth-dropdown/credits-exhausted-alert.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import type { ICurrentWorkspace } from '@/models/common'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { consoleQuery } from '@/service/client'
 import CreditsExhaustedAlert from './credits-exhausted-alert'
 
 const baseWorkspace: ICurrentWorkspace = {
@@ -20,7 +21,7 @@ function createSeededQueryClient(overrides?: Partial<ICurrentWorkspace>) {
   const qc = new QueryClient({
     defaultOptions: { queries: { refetchOnWindowFocus: false, retry: false } },
   })
-  qc.setQueryData(['common', 'current-workspace'], { ...baseWorkspace, ...overrides })
+  qc.setQueryData(consoleQuery.workspaces.current.post.queryKey(), { ...baseWorkspace, ...overrides })
   return qc
 }
 

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/use-trial-credits.ts
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/use-trial-credits.ts
@@ -1,7 +1,8 @@
-import { useCurrentWorkspace } from '@/service/use-common'
+import { useQuery } from '@tanstack/react-query'
+import { consoleQuery } from '@/service/client'
 
 export const useTrialCredits = () => {
-  const { data: currentWorkspace, isPending } = useCurrentWorkspace()
+  const { data: currentWorkspace, isPending } = useQuery(consoleQuery.workspaces.current.post.queryOptions())
   const totalCredits = currentWorkspace?.trial_credits ?? 0
   const credits = Math.max(totalCredits - (currentWorkspace?.trial_credits_used ?? 0), 0)
 

--- a/web/app/device/page.tsx
+++ b/web/app/device/page.tsx
@@ -1,16 +1,14 @@
 'use client'
 
-import type { ICurrentWorkspace } from '@/models/common'
 import { Button } from '@langgenius/dify-ui/button'
 import { useQuery } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
 import Divider from '@/app/components/base/divider'
 import { userProfileQueryOptions } from '@/features/account-profile/client'
 import { usePathname, useRouter, useSearchParams } from '@/next/navigation'
-import { post } from '@/service/base'
+import { consoleQuery } from '@/service/client'
 import { deviceLookup } from '@/service/device-flow'
 import { systemFeaturesQueryOptions } from '@/service/system-features'
-import { commonQueryKeys } from '@/service/use-common'
 import AuthorizeAccount from './components/authorize-account'
 import AuthorizeSSO from './components/authorize-sso'
 import Chooser from './components/chooser'
@@ -52,9 +50,8 @@ export default function DevicePage() {
     refetchOnMount: false,
   })
   const account = userResp?.profile
-  const { data: currentWorkspace } = useQuery<ICurrentWorkspace>({
-    queryKey: commonQueryKeys.currentWorkspace,
-    queryFn: () => post<ICurrentWorkspace>('/workspaces/current'),
+  const { data: currentWorkspace } = useQuery({
+    ...consoleQuery.workspaces.current.post.queryOptions(),
     enabled: !!account && !profileErr,
     retry: false,
     refetchOnWindowFocus: false,
@@ -174,7 +171,7 @@ export default function DevicePage() {
           accountEmail={account?.email}
           accountName={account?.name}
           accountAvatarUrl={account?.avatar_url ?? null}
-          defaultWorkspace={currentWorkspace?.name}
+          defaultWorkspace={currentWorkspace?.name ?? undefined}
           onApproved={() => setView({ kind: 'success' })}
           onDenied={() => setView({ kind: 'error_expired' })}
           onError={e => setErrMsg(e)}

--- a/web/app/education-apply/education-apply-page.tsx
+++ b/web/app/education-apply/education-apply-page.tsx
@@ -23,7 +23,7 @@ import {
   useRouter,
   useSearchParams,
 } from '@/next/navigation'
-import { consoleClient } from '@/service/client'
+import { consoleClient, consoleQuery } from '@/service/client'
 import { switchWorkspace } from '@/service/common'
 import { commonQueryKeys } from '@/service/use-common'
 import {
@@ -129,7 +129,7 @@ const EducationApplyAgeContent = () => {
     try {
       await switchWorkspace({ url: '/workspaces/switch', body: { tenant_id: tenantId } })
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: commonQueryKeys.currentWorkspace }),
+        queryClient.invalidateQueries({ queryKey: consoleQuery.workspaces.current.post.key() }),
         queryClient.invalidateQueries({ queryKey: commonQueryKeys.workspaces }),
       ])
       onPlanInfoChanged()

--- a/web/context/app-context-provider.tsx
+++ b/web/context/app-context-provider.tsx
@@ -1,8 +1,9 @@
 'use client'
 
+import type { PostWorkspacesCurrentResponse } from '@dify/contracts/api/console/workspaces/types.gen'
 import type { FC, ReactNode } from 'react'
 import type { ICurrentWorkspace, LangGeniusVersionResponse, UserProfileResponse } from '@/models/common'
-import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
 import { useCallback, useEffect, useMemo } from 'react'
 import { setUserId, setUserProperties } from '@/app/components/base/amplitude'
 import { setZendeskConversationFields } from '@/app/components/base/zendesk/utils'
@@ -17,9 +18,9 @@ import {
 } from '@/context/app-context'
 import { env } from '@/env'
 import { userProfileQueryOptions } from '@/features/account-profile/client'
+import { consoleQuery } from '@/service/client'
 import { systemFeaturesQueryOptions } from '@/service/system-features'
 import {
-  useCurrentWorkspace,
   useLangGeniusVersion,
 } from '@/service/use-common'
 
@@ -27,18 +28,52 @@ type AppContextProviderProps = {
   children: ReactNode
 }
 
+const workspaceRoles = new Set<ICurrentWorkspace['role']>(['owner', 'admin', 'editor', 'dataset_operator', 'normal'])
+
+const resolveWorkspaceRole = (role: PostWorkspacesCurrentResponse['role']): ICurrentWorkspace['role'] => {
+  if (role && workspaceRoles.has(role as ICurrentWorkspace['role']))
+    return role as ICurrentWorkspace['role']
+
+  return initialWorkspaceInfo.role
+}
+
+const normalizeCurrentWorkspace = (workspace?: PostWorkspacesCurrentResponse): ICurrentWorkspace => {
+  if (!workspace)
+    return initialWorkspaceInfo
+
+  return {
+    id: workspace.id,
+    name: workspace.name ?? initialWorkspaceInfo.name,
+    plan: workspace.plan ?? initialWorkspaceInfo.plan,
+    status: workspace.status ?? initialWorkspaceInfo.status,
+    created_at: workspace.created_at ?? initialWorkspaceInfo.created_at,
+    role: resolveWorkspaceRole(workspace.role),
+    providers: initialWorkspaceInfo.providers,
+    trial_credits: workspace.trial_credits ?? initialWorkspaceInfo.trial_credits,
+    trial_credits_used: workspace.trial_credits_used ?? initialWorkspaceInfo.trial_credits_used,
+    next_credit_reset_date: workspace.next_credit_reset_date ?? initialWorkspaceInfo.next_credit_reset_date,
+    trial_end_reason: workspace.trial_end_reason ?? undefined,
+    custom_config: workspace.custom_config
+      ? {
+          remove_webapp_brand: workspace.custom_config.remove_webapp_brand ?? undefined,
+          replace_webapp_logo: workspace.custom_config.replace_webapp_logo ?? undefined,
+        }
+      : undefined,
+  }
+}
+
 export const AppContextProvider: FC<AppContextProviderProps> = ({ children }) => {
   const queryClient = useQueryClient()
   const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
   const { data: userProfileResp } = useSuspenseQuery(userProfileQueryOptions())
-  const { data: currentWorkspaceResp, isPending: isLoadingCurrentWorkspace, isFetching: isValidatingCurrentWorkspace } = useCurrentWorkspace()
+  const { data: currentWorkspaceResp, isPending: isLoadingCurrentWorkspace, isFetching: isValidatingCurrentWorkspace } = useQuery(consoleQuery.workspaces.current.post.queryOptions())
   const langGeniusVersionQuery = useLangGeniusVersion(
     userProfileResp?.meta.currentVersion,
     !systemFeatures.branding.enabled,
   )
 
   const userProfile = useMemo<UserProfileResponse>(() => userProfileResp?.profile || userProfilePlaceholder, [userProfileResp?.profile])
-  const currentWorkspace = useMemo<ICurrentWorkspace>(() => currentWorkspaceResp || initialWorkspaceInfo, [currentWorkspaceResp])
+  const currentWorkspace = useMemo<ICurrentWorkspace>(() => normalizeCurrentWorkspace(currentWorkspaceResp), [currentWorkspaceResp])
   const langGeniusVersionInfo = useMemo<LangGeniusVersionResponse>(() => {
     if (!userProfileResp?.meta?.currentVersion || !langGeniusVersionQuery.data)
       return initialLangGeniusVersionInfo
@@ -64,7 +99,7 @@ export const AppContextProvider: FC<AppContextProviderProps> = ({ children }) =>
   }, [queryClient])
 
   const mutateCurrentWorkspace = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: ['common', 'current-workspace'] })
+    queryClient.invalidateQueries({ queryKey: consoleQuery.workspaces.current.post.key() })
   }, [queryClient])
 
   // #region Zendesk conversation fields

--- a/web/service/use-common.ts
+++ b/web/service/use-common.ts
@@ -10,7 +10,6 @@ import type {
   CodeBasedExtension,
   CommonResponse,
   FileUploadConfigResponse,
-  ICurrentWorkspace,
   IWorkspace,
   LangGeniusVersionResponse,
   Member,
@@ -26,7 +25,6 @@ const NAME_SPACE = 'common'
 
 export const commonQueryKeys = {
   fileUploadConfig: [NAME_SPACE, 'file-upload-config'] as const,
-  currentWorkspace: [NAME_SPACE, 'current-workspace'] as const,
   workspaces: [NAME_SPACE, 'workspaces'] as const,
   members: [NAME_SPACE, 'members'] as const,
   filePreview: (fileID: string) => [NAME_SPACE, 'file-preview', fileID] as const,
@@ -65,13 +63,6 @@ export const useLangGeniusVersion = (currentVersion?: string | null, enabled?: b
     queryKey: commonQueryKeys.langGeniusVersion(currentVersion || undefined),
     queryFn: () => get<LangGeniusVersionResponse>('/version', { params: { current_version: currentVersion } }),
     enabled: !!currentVersion && (enabled ?? true),
-  })
-}
-
-export const useCurrentWorkspace = () => {
-  return useQuery<ICurrentWorkspace>({
-    queryKey: commonQueryKeys.currentWorkspace,
-    queryFn: () => post<ICurrentWorkspace>('/workspaces/current'),
   })
 }
 


### PR DESCRIPTION
## Summary
- type `/workspaces/current` custom_config in the backend response schema and regenerate console contracts
- remove the `useCurrentWorkspace` thin wrapper and old `commonQueryKeys.currentWorkspace` cache key
- migrate AppContext, trial credits, device flow, and education workspace invalidation to `consoleQuery.workspaces.current.post`

## Tests
- CI=true pnpm --dir web type-check
- CI=true pnpm --dir web test app/components/header/account-setting/model-provider-page/provider-added-card/__tests__/use-trial-credits.spec.ts app/components/header/account-setting/model-provider-page/provider-added-card/__tests__/quota-panel.spec.tsx app/components/datasets/settings/form/__tests__/index.spec.tsx
- uv run --project api pytest api/tests/unit_tests/controllers/console/workspace/test_workspace.py