### PR TITLE
fix(api): preserve hierarchical estimate rules

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -148,6 +148,11 @@ class _EstimateRules(BaseModel):
         return list(seen.values())
 
 
+class _EstimateHierarchicalRules(_EstimateRules):
+    parent_mode: Literal["full-doc", "paragraph"] | None = None
+    subchunk_segmentation: _EstimateSegmentation | None = None
+
+
 class _SummaryIndexSettingDisabled(BaseModel):
     enable: Literal[False] = False
 
@@ -203,7 +208,7 @@ class _HierarchicalProcessRule(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     mode: Literal[ProcessRuleMode.HIERARCHICAL]
-    rules: _EstimateRules
+    rules: _EstimateHierarchicalRules
     summary_index_setting: _SummaryIndexSetting | None = None
 
     @field_validator("summary_index_setting", mode="before")
@@ -2971,6 +2976,10 @@ class DocumentService:
         process_rule_dict = validated.process_rule.model_dump(exclude_none=True)
         if validated.process_rule.mode == ProcessRuleMode.AUTOMATIC:
             process_rule_dict["rules"] = {}
+        elif validated.process_rule.mode == ProcessRuleMode.HIERARCHICAL:
+            rules = process_rule_dict.get("rules")
+            if isinstance(rules, dict) and not rules.get("parent_mode"):
+                rules["parent_mode"] = "paragraph"
         args["process_rule"] = process_rule_dict
 
     @staticmethod

--- a/api/tests/unit_tests/services/test_dataset_service_document.py
+++ b/api/tests/unit_tests/services/test_dataset_service_document.py
@@ -1344,6 +1344,27 @@ class TestDocumentServiceEstimateValidation:
 
         assert args["process_rule"]["rules"]["pre_processing_rules"] == [{"id": "remove_stopwords", "enabled": False}]
 
+    def test_estimate_args_validate_custom_mode_drops_hierarchical_fields(self):
+        args = {
+            "info_list": {"data_source_type": "upload_file"},
+            "process_rule": {
+                "mode": "custom",
+                "rules": {
+                    "pre_processing_rules": [{"id": "remove_stopwords", "enabled": True}],
+                    "segmentation": {"separator": "\n", "max_tokens": 128},
+                    "parent_mode": "full-doc",
+                    "subchunk_segmentation": {"separator": "###", "max_tokens": 64},
+                },
+            },
+        }
+
+        DocumentService.estimate_args_validate(args)
+
+        assert args["process_rule"]["rules"] == {
+            "pre_processing_rules": [{"id": "remove_stopwords", "enabled": True}],
+            "segmentation": {"separator": "\n", "max_tokens": 128},
+        }
+
     def test_estimate_args_validate_requires_summary_index_provider_name(self):
         args = {
             "info_list": {"data_source_type": "upload_file"},
@@ -1359,6 +1380,43 @@ class TestDocumentServiceEstimateValidation:
 
         with pytest.raises(ValueError, match="Field required"):
             DocumentService.estimate_args_validate(args)
+
+    def test_estimate_args_validate_preserves_hierarchical_fields(self):
+        args = {
+            "info_list": {"data_source_type": "upload_file"},
+            "process_rule": {
+                "mode": "hierarchical",
+                "rules": {
+                    "pre_processing_rules": [{"id": "remove_stopwords", "enabled": True}],
+                    "segmentation": {"separator": "\n", "max_tokens": 512},
+                    "parent_mode": "full-doc",
+                    "subchunk_segmentation": {"separator": "###", "max_tokens": 128},
+                },
+            },
+        }
+
+        DocumentService.estimate_args_validate(args)
+
+        assert args["process_rule"]["rules"]["parent_mode"] == "full-doc"
+        assert args["process_rule"]["rules"]["subchunk_segmentation"] == {"separator": "###", "max_tokens": 128}
+
+    def test_estimate_args_validate_hierarchical_defaults_parent_mode_to_paragraph(self):
+        args = {
+            "info_list": {"data_source_type": "upload_file"},
+            "process_rule": {
+                "mode": "hierarchical",
+                "rules": {
+                    "pre_processing_rules": [{"id": "remove_stopwords", "enabled": True}],
+                    "segmentation": {"separator": "\n", "max_tokens": 512},
+                    "subchunk_segmentation": {"separator": "###", "max_tokens": 128},
+                },
+            },
+        }
+
+        DocumentService.estimate_args_validate(args)
+
+        assert args["process_rule"]["rules"]["parent_mode"] == "paragraph"
+        assert args["process_rule"]["rules"]["subchunk_segmentation"] == {"separator": "###", "max_tokens": 128}
 
 
 class TestDocumentServiceSaveDocumentAdditionalBranches:


### PR DESCRIPTION
## Summary

Fixes #36795.

This fixes the knowledge-base indexing estimate validation for parent-child segmentation. The estimate path now preserves the hierarchical rule fields needed by parent-child preview:

- `parent_mode`
- `subchunk_segmentation`

When hierarchical rules omit `parent_mode`, the estimate path now defaults it to `paragraph`, matching the save path behavior. Custom-mode estimate validation keeps the previous ordinary rule shape and does not retain parent-child-only fields.

## Screenshots

| Before | After |
|--------|-------|
| Parent-child preview could produce `0 chunks` after validation dropped hierarchical fields. | Hierarchical estimate validation preserves the parent-child fields used by preview. |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Local checks run:

- `uv run --project api --no-sync pytest api/tests/unit_tests/services/test_dataset_service_document.py -k estimate_args_validate -q`
- `uv run --project api --no-sync pytest api/tests/unit_tests/services/test_dataset_service_document.py -q`
- `uv run --project api --no-sync python api/dev/lint_response_contracts.py --fail-on-mismatch`
- `uv lock --project api --check`
- `git diff --check -- api/services/dataset_service.py api/tests/unit_tests/services/test_dataset_service_document.py`
