### PR TITLE
refactor: use explicit sessions in workspace controllers

### DIFF
--- a/api/controllers/console/workspace/members.py
+++ b/api/controllers/console/workspace/members.py
@@ -4,13 +4,15 @@ from uuid import UUID
 from flask import abort, request
 from flask_restx import Resource
 from pydantic import BaseModel, Field, TypeAdapter
-from sqlalchemy import func, select
+from sqlalchemy import event, func, select
+from sqlalchemy.orm import Session
 
 import services
 from configs import dify_config
 from controllers.common.fields import SimpleResultDataResponse, VerificationTokenResponse
 from controllers.common.schema import register_enum_models, register_response_schema_models, register_schema_models
 from controllers.console import console_ns
+from controllers.console.app.wraps import with_session
 from controllers.console.auth.error import (
     CannotTransferOwnerToSelfError,
     EmailCodeError,
@@ -27,7 +29,6 @@ from controllers.console.wraps import (
     setup_required,
     with_current_user,
 )
-from extensions.ext_database import db
 from extensions.ext_redis import redis_client
 from fields.member_fields import AccountWithRole, AccountWithRoleList
 from libs.helper import extract_remote_ip
@@ -85,15 +86,15 @@ def _normalize_invitee_emails(emails: list[str]) -> list[str]:
     return list(dict.fromkeys(email.lower() for email in emails))
 
 
-def _count_new_member_invites(tenant_id: str, emails: list[str]) -> int:
+def _count_new_member_invites(session: Session, tenant_id: str, emails: list[str]) -> int:
     new_member_count = 0
     for email in emails:
-        account = AccountService.get_account_by_email_with_case_fallback(email)
+        account = AccountService.get_account_by_email_with_case_fallback(email, session=session)
         if not account:
             new_member_count += 1
             continue
 
-        exists = db.session.scalar(
+        exists = session.scalar(
             select(TenantAccountJoin.id)
             .where(TenantAccountJoin.tenant_id == tenant_id, TenantAccountJoin.account_id == account.id)
             .limit(1)
@@ -104,13 +105,11 @@ def _count_new_member_invites(tenant_id: str, emails: list[str]) -> int:
     return new_member_count
 
 
-def _count_current_members(tenant_id: str) -> int:
-    return (
-        db.session.scalar(select(func.count(TenantAccountJoin.id)).where(TenantAccountJoin.tenant_id == tenant_id)) or 0
-    )
+def _count_current_members(session: Session, tenant_id: str) -> int:
+    return session.scalar(select(func.count(TenantAccountJoin.id)).where(TenantAccountJoin.tenant_id == tenant_id)) or 0
 
 
-def _check_member_invite_limits(tenant_id: str, new_member_count: int) -> None:
+def _check_member_invite_limits(session: Session, tenant_id: str, new_member_count: int) -> None:
     if new_member_count <= 0:
         return
 
@@ -124,7 +123,7 @@ def _check_member_invite_limits(tenant_id: str, new_member_count: int) -> None:
 
     if dify_config.BILLING_ENABLED and features.billing.enabled is True:
         members = features.members
-        current_member_count = _count_current_members(tenant_id)
+        current_member_count = _count_current_members(session, tenant_id)
         if 0 < members.limit < current_member_count + new_member_count:
             raise WorkspaceMembersLimitExceeded()
 
@@ -138,10 +137,11 @@ class MemberListApi(Resource):
     @account_initialization_required
     @console_ns.response(200, "Success", console_ns.models[AccountWithRoleList.__name__])
     @with_current_user
-    def get(self, current_user: Account):
+    @with_session(write=False)
+    def get(self, session: Session, current_user: Account):
         if not current_user.current_tenant:
             raise ValueError("No current tenant")
-        members = TenantService.get_tenant_members(current_user.current_tenant)
+        members = TenantService.get_tenant_members(current_user.current_tenant, session=session)
         member_models = TypeAdapter(list[AccountWithRole]).validate_python(members, from_attributes=True)
         response = AccountWithRoleList(accounts=member_models)
         return response.model_dump(mode="json"), 200
@@ -156,7 +156,8 @@ class MemberInviteEmailApi(Resource):
     @login_required
     @account_initialization_required
     @with_current_user
-    def post(self, current_user: Account):
+    @with_session(write=False)
+    def post(self, session: Session, current_user: Account):
         payload = console_ns.payload or {}
         args = MemberInvitePayload.model_validate(payload)
 
@@ -181,8 +182,8 @@ class MemberInviteEmailApi(Resource):
 
         tenant_id = inviter.current_tenant.id
         with redis_client.lock(f"workspace_member_invite:{tenant_id}", timeout=60):
-            new_member_count = _count_new_member_invites(tenant_id, invitee_emails)
-            _check_member_invite_limits(tenant_id, new_member_count)
+            new_member_count = _count_new_member_invites(session, tenant_id, invitee_emails)
+            _check_member_invite_limits(session, tenant_id, new_member_count)
 
             for invitee_email in invitee_emails:
                 try:
@@ -225,15 +226,18 @@ class MemberCancelInviteApi(Resource):
     @login_required
     @account_initialization_required
     @with_current_user
-    def delete(self, current_user: Account, member_id: UUID):
+    @with_session
+    def delete(self, session: Session, current_user: Account, member_id: UUID):
         if not current_user.current_tenant:
             raise ValueError("No current tenant")
-        member = db.session.get(Account, str(member_id))
+        member = session.get(Account, str(member_id))
         if member is None:
             abort(404)
         else:
             try:
-                TenantService.remove_member_from_tenant(current_user.current_tenant, member, current_user)
+                TenantService.remove_member_from_tenant(
+                    current_user.current_tenant, member, current_user, session=session
+                )
             except services.errors.account.CannotOperateSelfError as e:
                 return {"code": "cannot-operate-self", "message": str(e)}, 400
             except services.errors.account.NoPermissionError as e:
@@ -258,7 +262,8 @@ class MemberUpdateRoleApi(Resource):
     @login_required
     @account_initialization_required
     @with_current_user
-    def put(self, current_user: Account, member_id: UUID):
+    @with_session
+    def put(self, session: Session, current_user: Account, member_id: UUID):
         payload = console_ns.payload or {}
         args = MemberRoleUpdatePayload.model_validate(payload)
         new_role = args.role
@@ -269,13 +274,19 @@ class MemberUpdateRoleApi(Resource):
             raise ValueError("No current tenant")
         if not _is_role_enabled(new_role, current_user.current_tenant.id):
             return {"code": "invalid-role", "message": "Invalid role"}, 400
-        member = db.session.get(Account, str(member_id))
+        member = session.get(Account, str(member_id))
         if not member:
             abort(404)
 
         try:
             assert member is not None, "Member not found"
-            TenantService.update_member_role(current_user.current_tenant, member, new_role, current_user)
+            TenantService.update_member_role(
+                current_user.current_tenant,
+                member,
+                new_role,
+                current_user,
+                session=session,
+            )
         except services.errors.account.CannotOperateSelfError as e:
             return {"code": "cannot-operate-self", "message": str(e)}, 400
         except services.errors.account.NoPermissionError as e:
@@ -299,10 +310,11 @@ class DatasetOperatorMemberListApi(Resource):
     @account_initialization_required
     @console_ns.response(200, "Success", console_ns.models[AccountWithRoleList.__name__])
     @with_current_user
-    def get(self, current_user: Account):
+    @with_session(write=False)
+    def get(self, session: Session, current_user: Account):
         if not current_user.current_tenant:
             raise ValueError("No current tenant")
-        members = TenantService.get_dataset_operator_members(current_user.current_tenant)
+        members = TenantService.get_dataset_operator_members(current_user.current_tenant, session=session)
         member_models = TypeAdapter(list[AccountWithRole]).validate_python(members, from_attributes=True)
         response = AccountWithRoleList(accounts=member_models)
         return response.model_dump(mode="json"), 200
@@ -319,7 +331,8 @@ class SendOwnerTransferEmailApi(Resource):
     @account_initialization_required
     @is_allow_transfer_owner
     @with_current_user
-    def post(self, current_user: Account):
+    @with_session(write=False)
+    def post(self, session: Session, current_user: Account):
         payload = console_ns.payload or {}
         args = OwnerTransferEmailPayload.model_validate(payload)
         ip_address = extract_remote_ip(request)
@@ -328,7 +341,7 @@ class SendOwnerTransferEmailApi(Resource):
         # check if the current user is the owner of the workspace
         if not current_user.current_tenant:
             raise ValueError("No current tenant")
-        if not TenantService.is_owner(current_user, current_user.current_tenant):
+        if not TenantService.is_owner(current_user, current_user.current_tenant, session=session):
             raise NotOwnerError()
 
         if args.language is not None and args.language == "zh-Hans":
@@ -357,13 +370,14 @@ class OwnerTransferCheckApi(Resource):
     @account_initialization_required
     @is_allow_transfer_owner
     @with_current_user
-    def post(self, current_user: Account):
+    @with_session(write=False)
+    def post(self, session: Session, current_user: Account):
         payload = console_ns.payload or {}
         args = OwnerTransferCheckPayload.model_validate(payload)
         # check if the current user is the owner of the workspace
         if not current_user.current_tenant:
             raise ValueError("No current tenant")
-        if not TenantService.is_owner(current_user, current_user.current_tenant):
+        if not TenantService.is_owner(current_user, current_user.current_tenant, session=session):
             raise NotOwnerError()
 
         user_email = current_user.email
@@ -401,14 +415,15 @@ class OwnerTransfer(Resource):
     @account_initialization_required
     @is_allow_transfer_owner
     @with_current_user
-    def post(self, current_user: Account, member_id: UUID):
+    @with_session
+    def post(self, session: Session, current_user: Account, member_id: UUID):
         payload = console_ns.payload or {}
         args = OwnerTransferPayload.model_validate(payload)
 
         # check if the current user is the owner of the workspace
         if not current_user.current_tenant:
             raise ValueError("No current tenant")
-        if not TenantService.is_owner(current_user, current_user.current_tenant):
+        if not TenantService.is_owner(current_user, current_user.current_tenant, session=session):
             raise NotOwnerError()
 
         if current_user.id == str(member_id):
@@ -423,32 +438,43 @@ class OwnerTransfer(Resource):
 
         AccountService.revoke_owner_transfer_token(args.token)
 
-        member = db.session.get(Account, str(member_id))
+        member = session.get(Account, str(member_id))
         if not member:
             abort(404)
             return  # Never reached, but helps type checker
 
         if not current_user.current_tenant:
             raise ValueError("No current tenant")
-        if not TenantService.is_member(member, current_user.current_tenant):
+        if not TenantService.is_member(member, current_user.current_tenant, session=session):
             raise MemberNotInTenantError()
 
         try:
             assert member is not None, "Member not found"
-            TenantService.update_member_role(current_user.current_tenant, member, "owner", current_user)
-
-            AccountService.send_new_owner_transfer_notify_email(
-                account=member,
-                email=member.email,
-                workspace_name=current_user.current_tenant.name if current_user.current_tenant else "",
+            TenantService.update_member_role(
+                current_user.current_tenant,
+                member,
+                "owner",
+                current_user,
+                session=session,
             )
 
-            AccountService.send_old_owner_transfer_notify_email(
-                account=current_user,
-                email=current_user.email,
-                workspace_name=current_user.current_tenant.name if current_user.current_tenant else "",
-                new_owner_email=member.email,
-            )
+            new_owner_email = member.email
+            old_owner_email = current_user.email
+            workspace_name = current_user.current_tenant.name if current_user.current_tenant else ""
+
+            def after_commit(_session: Session):
+                AccountService.send_new_owner_transfer_notify_email(
+                    email=new_owner_email,
+                    workspace_name=workspace_name,
+                )
+
+                AccountService.send_old_owner_transfer_notify_email(
+                    email=old_owner_email,
+                    workspace_name=workspace_name,
+                    new_owner_email=new_owner_email,
+                )
+
+            event.listen(session, "after_commit", after_commit, once=True)
 
         except Exception as e:
             raise ValueError(str(e))

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -5,7 +5,8 @@ from flask import request
 from flask_restx import Resource, fields, marshal
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import select
-from werkzeug.exceptions import Unauthorized
+from sqlalchemy.orm import Session
+from werkzeug.exceptions import NotFound, Unauthorized
 
 import services
 from configs import dify_config
@@ -19,6 +20,7 @@ from controllers.common.errors import (
 from controllers.common.schema import register_response_schema_models, register_schema_models
 from controllers.console import console_ns
 from controllers.console.admin import admin_required
+from controllers.console.app.wraps import with_session
 from controllers.console.error import AccountNotLinkTenantError
 from controllers.console.wraps import (
     account_initialization_required,
@@ -256,18 +258,19 @@ class SwitchWorkspaceApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
-    def post(self):
+    @with_session
+    def post(self, session: Session):
         current_user, _ = current_account_with_tenant()
         payload = console_ns.payload or {}
         args = SwitchWorkspacePayload.model_validate(payload)
 
         # check if tenant_id is valid, 403 if not
         try:
-            TenantService.switch_tenant(current_user, args.tenant_id)
+            TenantService.switch_tenant(current_user, args.tenant_id, session=session)
         except Exception:
             raise AccountNotLinkTenantError("Account not link tenant")
 
-        new_tenant = db.session.get(Tenant, args.tenant_id)  # Get new tenant
+        new_tenant = session.get(Tenant, args.tenant_id)  # Get new tenant
         if new_tenant is None:
             raise ValueError("Tenant not found")
 
@@ -281,11 +284,14 @@ class CustomConfigWorkspaceApi(Resource):
     @login_required
     @account_initialization_required
     @cloud_edition_billing_resource_check("workspace_custom")
-    def post(self):
+    @with_session
+    def post(self, session: Session):
         _, current_tenant_id = current_account_with_tenant()
         payload = console_ns.payload or {}
         args = WorkspaceCustomConfigPayload.model_validate(payload)
-        tenant = db.get_or_404(Tenant, current_tenant_id)
+        tenant = session.get(Tenant, current_tenant_id)
+        if tenant is None:
+            raise NotFound()
 
         custom_config_dict: TenantCustomConfigDict = {
             "remove_webapp_brand": args.remove_webapp_brand
@@ -297,7 +303,6 @@ class CustomConfigWorkspaceApi(Resource):
         }
 
         tenant.custom_config_dict = custom_config_dict
-        db.session.commit()
 
         return {"result": "success", "tenant": marshal(WorkspaceService.get_tenant_info(tenant), tenant_fields)}
 
@@ -349,16 +354,18 @@ class WorkspaceInfoApi(Resource):
     @login_required
     @account_initialization_required
     # Change workspace name
-    def post(self):
+    @with_session
+    def post(self, session: Session):
         _, current_tenant_id = current_account_with_tenant()
         payload = console_ns.payload or {}
         args = WorkspaceInfoPayload.model_validate(payload)
 
         if not current_tenant_id:
             raise ValueError("No current tenant")
-        tenant = db.get_or_404(Tenant, current_tenant_id)
+        tenant = session.get(Tenant, current_tenant_id)
+        if tenant is None:
+            raise NotFound()
         tenant.name = args.name
-        db.session.commit()
 
         return {"result": "success", "tenant": marshal(WorkspaceService.get_tenant_info(tenant), tenant_fields)}
 

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -8,7 +8,7 @@ from hashlib import sha256
 from typing import Any, TypedDict, cast
 
 from pydantic import BaseModel, TypeAdapter, ValidationError
-from sqlalchemy import Row, delete, func, select, update
+from sqlalchemy import Row, delete, event, func, select, update
 from sqlalchemy.orm import Session, scoped_session
 
 from core.db.session_factory import session_factory
@@ -915,13 +915,22 @@ class AccountService:
         return token
 
     @staticmethod
-    def get_account_by_email_with_case_fallback(email: str) -> Account | None:
+    def get_account_by_email_with_case_fallback(
+        email: str, *, session: Session | scoped_session | None = None
+    ) -> Account | None:
         """
         Retrieve an account by email and fall back to the lowercase email if the original lookup fails.
 
         This keeps backward compatibility for older records that stored uppercase emails while the
         rest of the system gradually normalizes new inputs.
         """
+        if session is not None:
+            account = session.execute(select(Account).where(Account.email == email)).scalar_one_or_none()
+            if account or email == email.lower():
+                return account
+
+            return session.execute(select(Account).where(Account.email == email.lower())).scalar_one_or_none()
+
         with session_factory.create_session() as session:
             account = session.execute(select(Account).where(Account.email == email)).scalar_one_or_none()
             if account or email == email.lower():
@@ -1420,14 +1429,19 @@ class TenantService:
         return tenant
 
     @staticmethod
-    def switch_tenant(account: Account, tenant_id: str | None = None):
+    def switch_tenant(
+        account: Account, tenant_id: str | None = None, *, session: Session | scoped_session | None = None
+    ):
         """Switch the current workspace for the account"""
 
         # Ensure tenant_id is provided
         if tenant_id is None:
             raise ValueError("Tenant ID must be provided.")
 
-        tenant_account_join = db.session.scalar(
+        should_commit = session is None
+        session = session or db.session
+
+        tenant_account_join = session.scalar(
             select(TenantAccountJoin)
             .join(Tenant, TenantAccountJoin.tenant_id == Tenant.id)
             .where(
@@ -1441,7 +1455,7 @@ class TenantService:
         if not tenant_account_join:
             raise AccountNotLinkTenantError("Tenant not found or account is not a member of the tenant.")
         else:
-            db.session.execute(
+            session.execute(
                 update(TenantAccountJoin)
                 .where(TenantAccountJoin.account_id == account.id, TenantAccountJoin.tenant_id != tenant_id)
                 .values(current=False)
@@ -1449,10 +1463,11 @@ class TenantService:
             tenant_account_join.current = True
             # Set the current tenant for the account
             account.set_tenant_id(tenant_account_join.tenant_id)
-            db.session.commit()
+            if should_commit:
+                session.commit()
 
     @staticmethod
-    def get_tenant_members(tenant: Tenant) -> list[Account]:
+    def get_tenant_members(tenant: Tenant, *, session: Session | scoped_session | None = None) -> list[Account]:
         """Get tenant members"""
         stmt = (
             select(Account, TenantAccountJoin.role)
@@ -1461,17 +1476,20 @@ class TenantService:
             .where(TenantAccountJoin.tenant_id == tenant.id)
         )
 
+        session = session or db.session
         # Initialize an empty list to store the updated accounts
         updated_accounts = []
 
-        for account, role in db.session.execute(stmt):
+        for account, role in session.execute(stmt):
             account.role = role
             updated_accounts.append(account)
 
         return updated_accounts
 
     @staticmethod
-    def get_dataset_operator_members(tenant: Tenant) -> list[Account]:
+    def get_dataset_operator_members(
+        tenant: Tenant, *, session: Session | scoped_session | None = None
+    ) -> list[Account]:
         """Get dataset admin members"""
         stmt = (
             select(Account, TenantAccountJoin.role)
@@ -1481,10 +1499,11 @@ class TenantService:
             .where(TenantAccountJoin.role == "dataset_operator")
         )
 
+        session = session or db.session
         # Initialize an empty list to store the updated accounts
         updated_accounts = []
 
-        for account, role in db.session.execute(stmt):
+        for account, role in session.execute(stmt):
             account.role = role
             updated_accounts.append(account)
 
@@ -1509,9 +1528,12 @@ class TenantService:
         )
 
     @staticmethod
-    def get_user_role(account: Account, tenant: Tenant) -> TenantAccountRole | None:
+    def get_user_role(
+        account: Account, tenant: Tenant, *, session: Session | scoped_session | None = None
+    ) -> TenantAccountRole | None:
         """Get the role of the current account for a given tenant"""
-        join = db.session.scalar(
+        session = session or db.session
+        join = session.scalar(
             select(TenantAccountJoin)
             .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.account_id == account.id)
             .limit(1)
@@ -1524,7 +1546,14 @@ class TenantService:
         return cast(int, db.session.scalar(select(func.count(Tenant.id))))
 
     @staticmethod
-    def check_member_permission(tenant: Tenant, operator: Account, member: Account | None, action: str):
+    def check_member_permission(
+        tenant: Tenant,
+        operator: Account,
+        member: Account | None,
+        action: str,
+        *,
+        session: Session | scoped_session | None = None,
+    ):
         """Check member permission"""
         perms = {
             "add": [TenantAccountRole.OWNER, TenantAccountRole.ADMIN],
@@ -1538,7 +1567,8 @@ class TenantService:
             if operator.id == member.id:
                 raise CannotOperateSelfError("Cannot operate self.")
 
-        ta_operator = db.session.scalar(
+        session = session or db.session
+        ta_operator = session.scalar(
             select(TenantAccountJoin)
             .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.account_id == operator.id)
             .limit(1)
@@ -1548,7 +1578,7 @@ class TenantService:
             raise NoPermissionError(f"No permission to {action} member.")
 
         if action == "remove" and ta_operator.role == TenantAccountRole.ADMIN and member:
-            ta_member = db.session.scalar(
+            ta_member = session.scalar(
                 select(TenantAccountJoin)
                 .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.account_id == member.id)
                 .limit(1)
@@ -1557,7 +1587,9 @@ class TenantService:
                 raise NoPermissionError(f"No permission to {action} member.")
 
     @staticmethod
-    def remove_member_from_tenant(tenant: Tenant, account: Account, operator: Account):
+    def remove_member_from_tenant(
+        tenant: Tenant, account: Account, operator: Account, *, session: Session | scoped_session | None = None
+    ):
         """Remove member from tenant.
 
         If the removed member has ``AccountStatus.PENDING`` (invited but never
@@ -1567,9 +1599,12 @@ class TenantService:
         if operator.id == account.id:
             raise CannotOperateSelfError("Cannot operate self.")
 
-        TenantService.check_member_permission(tenant, operator, account, "remove")
+        should_commit = session is None
+        session = session or db.session
 
-        ta = db.session.scalar(
+        TenantService.check_member_permission(tenant, operator, account, "remove", session=session)
+
+        ta = session.scalar(
             select(TenantAccountJoin)
             .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.account_id == account.id)
             .limit(1)
@@ -1579,57 +1614,73 @@ class TenantService:
 
         # Capture identifiers before any deletions; attribute access on the ORM
         # object may fail after commit() expires the instance.
+        tenant_id = tenant.id
         account_id = account.id
         account_email = account.email
 
-        db.session.delete(ta)
+        session.delete(ta)
 
         # Clean up orphaned pending accounts (invited but never activated)
         should_delete_account = False
         if account.status == AccountStatus.PENDING:
             # autoflush flushes ta deletion before this query, so 0 means no remaining joins
             remaining_joins = (
-                db.session.scalar(
+                session.scalar(
                     select(func.count(TenantAccountJoin.id)).where(TenantAccountJoin.account_id == account_id)
                 )
                 or 0
             )
             if remaining_joins == 0:
-                db.session.delete(account)
+                session.delete(account)
                 should_delete_account = True
 
-        db.session.commit()
+        def after_commit():
+            if should_delete_account:
+                logger.info(
+                    "Deleted orphaned pending account: account_id=%s, email=%s",
+                    account_id,
+                    account_email,
+                )
 
-        if should_delete_account:
-            logger.info(
-                "Deleted orphaned pending account: account_id=%s, email=%s",
-                account_id,
-                account_email,
+            if dify_config.BILLING_ENABLED:
+                BillingService.clean_billing_info_cache(tenant_id)
+
+            # Queue account deletion sync task for enterprise backend to reassign resources (enterprise only)
+            from services.enterprise.account_deletion_sync import sync_workspace_member_removal
+
+            sync_success = sync_workspace_member_removal(
+                workspace_id=tenant_id, member_id=account_id, source="workspace_member_removed"
             )
+            if not sync_success:
+                logger.warning(
+                    "Enterprise workspace member removal sync failed: workspace_id=%s, member_id=%s",
+                    tenant_id,
+                    account_id,
+                )
 
-        if dify_config.BILLING_ENABLED:
-            BillingService.clean_billing_info_cache(tenant.id)
-
-        # Queue account deletion sync task for enterprise backend to reassign resources (enterprise only)
-        from services.enterprise.account_deletion_sync import sync_workspace_member_removal
-
-        sync_success = sync_workspace_member_removal(
-            workspace_id=tenant.id, member_id=account_id, source="workspace_member_removed"
-        )
-        if not sync_success:
-            logger.warning(
-                "Enterprise workspace member removal sync failed: workspace_id=%s, member_id=%s",
-                tenant.id,
-                account_id,
-            )
+        if should_commit:
+            session.commit()
+            after_commit()
+        else:
+            event.listen(session, "after_commit", lambda _: after_commit(), once=True)
 
     @staticmethod
-    def update_member_role(tenant: Tenant, member: Account, new_role: str, operator: Account):
+    def update_member_role(
+        tenant: Tenant,
+        member: Account,
+        new_role: str,
+        operator: Account,
+        *,
+        session: Session | scoped_session | None = None,
+    ):
         """Update member role"""
-        TenantService.check_member_permission(tenant, operator, member, "update")
+        should_commit = session is None
+        session = session or db.session
+
+        TenantService.check_member_permission(tenant, operator, member, "update", session=session)
         new_tenant_role = TenantAccountRole(new_role)
 
-        target_member_join = db.session.scalar(
+        target_member_join = session.scalar(
             select(TenantAccountJoin)
             .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.account_id == member.id)
             .limit(1)
@@ -1638,7 +1689,7 @@ class TenantService:
         if not target_member_join:
             raise MemberNotInTenantError("Member not in tenant.")
 
-        operator_role = TenantService.get_user_role(operator, tenant)
+        operator_role = TenantService.get_user_role(operator, tenant, session=session)
         target_role = TenantAccountRole(target_member_join.role)
         if operator_role == TenantAccountRole.ADMIN and (TenantAccountRole.OWNER in {target_role, new_tenant_role}):
             raise NoPermissionError("No permission to update member.")
@@ -1648,7 +1699,7 @@ class TenantService:
 
         if new_role == "owner":
             # Find the current owner and change their role to 'admin'
-            current_owner_join = db.session.scalar(
+            current_owner_join = session.scalar(
                 select(TenantAccountJoin)
                 .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.role == "owner")
                 .limit(1)
@@ -1658,7 +1709,8 @@ class TenantService:
 
         # Update the role of the target member
         target_member_join.role = new_tenant_role
-        db.session.commit()
+        if should_commit:
+            session.commit()
 
     @staticmethod
     def get_custom_config(tenant_id: str):
@@ -1667,13 +1719,13 @@ class TenantService:
         return tenant.custom_config_dict
 
     @staticmethod
-    def is_owner(account: Account, tenant: Tenant) -> bool:
-        return TenantService.get_user_role(account, tenant) == TenantAccountRole.OWNER
+    def is_owner(account: Account, tenant: Tenant, *, session: Session | scoped_session | None = None) -> bool:
+        return TenantService.get_user_role(account, tenant, session=session) == TenantAccountRole.OWNER
 
     @staticmethod
-    def is_member(account: Account, tenant: Tenant) -> bool:
+    def is_member(account: Account, tenant: Tenant, *, session: Session | scoped_session | None = None) -> bool:
         """Check if the account is a member of the tenant"""
-        return TenantService.get_user_role(account, tenant) is not None
+        return TenantService.get_user_role(account, tenant, session=session) is not None
 
 
 class RegisterService:

--- a/api/tests/test_containers_integration_tests/controllers/console/workspace/test_members.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/workspace/test_members.py
@@ -128,7 +128,7 @@ class TestMemberCancelInviteApiWithContainers:
             flask_app_with_containers.test_request_context("/"),
             patch.object(members_module.TenantService, "remove_member_from_tenant") as mock_remove_member,
         ):
-            result, status = method(api, current_user, member.id)
+            result, status = method(api, db_session_with_containers, current_user, member.id)
 
         assert status == 200
         assert result["result"] == "success"
@@ -137,6 +137,7 @@ class TestMemberCancelInviteApiWithContainers:
         assert called_tenant.id == tenant.id
         assert called_member.id == member.id
         assert called_current_user.id == current_user.id
+        assert mock_remove_member.call_args.kwargs["session"] is db_session_with_containers
 
     def test_cancel_not_found(self, flask_app_with_containers: Flask, db_session_with_containers: Session) -> None:
         api = MemberCancelInviteApi()
@@ -146,7 +147,7 @@ class TestMemberCancelInviteApiWithContainers:
 
         with flask_app_with_containers.test_request_context("/"):
             with pytest.raises(HTTPException):
-                method(api, current_user, str(uuid4()))
+                method(api, db_session_with_containers, current_user, str(uuid4()))
 
     def test_cancel_cannot_operate_self(
         self, flask_app_with_containers: Flask, db_session_with_containers: Session
@@ -165,7 +166,7 @@ class TestMemberCancelInviteApiWithContainers:
                 side_effect=services.errors.account.CannotOperateSelfError("x"),
             ),
         ):
-            result, status = method(api, current_user, member.id)
+            result, status = method(api, db_session_with_containers, current_user, member.id)
 
         assert status == 400
         assert result["code"] == "cannot-operate-self"
@@ -185,7 +186,7 @@ class TestMemberCancelInviteApiWithContainers:
                 side_effect=services.errors.account.NoPermissionError("x"),
             ),
         ):
-            result, status = method(api, current_user, member.id)
+            result, status = method(api, db_session_with_containers, current_user, member.id)
 
         assert status == 403
         assert result["code"] == "forbidden"
@@ -207,7 +208,7 @@ class TestMemberCancelInviteApiWithContainers:
                 side_effect=services.errors.account.MemberNotInTenantError(),
             ),
         ):
-            result, status = method(api, current_user, member.id)
+            result, status = method(api, db_session_with_containers, current_user, member.id)
 
         assert status == 404
         assert result["code"] == "member-not-found"
@@ -227,7 +228,9 @@ class TestMemberUpdateRoleApiWithContainers:
         )
 
         with flask_app_with_containers.test_request_context("/", json={"role": "normal"}):
-            result = method(api, current_user, member.id)
+            result = method(api, db_session_with_containers, current_user, member.id)
+
+        db_session_with_containers.commit()
 
         if isinstance(result, tuple):
             result = result[0]
@@ -247,7 +250,7 @@ class TestMemberUpdateRoleApiWithContainers:
 
         with flask_app_with_containers.test_request_context("/", json={"role": "normal"}):
             with pytest.raises(HTTPException):
-                method(api, current_user, str(uuid4()))
+                method(api, db_session_with_containers, current_user, str(uuid4()))
 
 
 class TestOwnerTransferApiWithContainers:
@@ -261,7 +264,7 @@ class TestOwnerTransferApiWithContainers:
 
         with flask_app_with_containers.test_request_context("/", json={"token": token}):
             with pytest.raises(MemberNotInTenantError):
-                method(api, current_user, member.id)
+                method(api, db_session_with_containers, current_user, member.id)
 
     def test_member_not_found(self, flask_app_with_containers: Flask, db_session_with_containers: Session) -> None:
         api = OwnerTransfer()
@@ -272,7 +275,7 @@ class TestOwnerTransferApiWithContainers:
 
         with flask_app_with_containers.test_request_context("/", json={"token": token}):
             with pytest.raises(HTTPException):
-                method(api, current_user, str(uuid4()))
+                method(api, db_session_with_containers, current_user, str(uuid4()))
 
     def test_transfer_success(self, flask_app_with_containers: Flask, db_session_with_containers: Session) -> None:
         api = OwnerTransfer()
@@ -292,7 +295,8 @@ class TestOwnerTransferApiWithContainers:
             patch.object(members_module.AccountService, "send_new_owner_transfer_notify_email") as mock_new_owner_email,
             patch.object(members_module.AccountService, "send_old_owner_transfer_notify_email") as mock_old_owner_email,
         ):
-            result = method(api, current_user, member.id)
+            result = method(api, db_session_with_containers, current_user, member.id)
+            db_session_with_containers.commit()
 
         assert result["result"] == "success"
         assert (

--- a/api/tests/unit_tests/controllers/console/test_workspace_members.py
+++ b/api/tests/unit_tests/controllers/console/test_workspace_members.py
@@ -1,6 +1,6 @@
 from contextlib import nullcontext
 from types import SimpleNamespace
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from flask import Flask, g
@@ -46,13 +46,17 @@ class TestMemberInviteEmailApi:
         mock_invite_member.return_value = "token-abc"
 
         tenant = SimpleNamespace(id="tenant-1", name="Test Tenant")
-        inviter = SimpleNamespace(email="Owner@Example.com", current_tenant=tenant, status="active")
+        mock_session = MagicMock()
+        mock_session_context = MagicMock()
+        mock_session_context.__enter__.return_value = mock_session
+        mock_session_context.__exit__.return_value = False
 
         with (
             patch("controllers.console.workspace.members.dify_config.CONSOLE_WEB_URL", "https://console.example.com"),
             patch("controllers.console.workspace.members._count_new_member_invites", return_value=1),
             patch("controllers.console.workspace.members.dify_config.ENTERPRISE_ENABLED", False),
             patch("controllers.console.workspace.members.dify_config.BILLING_ENABLED", False),
+            patch("controllers.console.app.wraps.session_factory.create_session", return_value=mock_session_context),
         ):
             with app.test_request_context(
                 "/workspaces/current/members/invite-email",

--- a/api/tests/unit_tests/controllers/console/workspace/test_members.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_members.py
@@ -46,12 +46,13 @@ class TestMemberListApi:
         member.role = "admin"
         member.status = "active"
         members = [member]
+        session = MagicMock()
 
         with (
             app.test_request_context("/"),
             patch("controllers.console.workspace.members.TenantService.get_tenant_members", return_value=members),
         ):
-            result, status = method(api, user)
+            result, status = method(api, session, user)
 
         assert status == 200
         assert len(result["accounts"]) == 1
@@ -61,12 +62,13 @@ class TestMemberListApi:
         method = unwrap(api.get)
 
         user = MagicMock(current_tenant=None)
+        session = MagicMock()
 
         with (
             app.test_request_context("/"),
         ):
             with pytest.raises(ValueError):
-                method(api, user)
+                method(api, session, user)
 
 
 class TestMemberInviteEmailApi:
@@ -85,6 +87,7 @@ class TestMemberInviteEmailApi:
         features.billing.enabled = False
         features.workspace_members.enabled = False
         features.workspace_members.is_available.return_value = True
+        session = MagicMock()
 
         payload = {
             "emails": ["a@test.com"],
@@ -101,7 +104,7 @@ class TestMemberInviteEmailApi:
             patch("controllers.console.workspace.members.dify_config.ENTERPRISE_ENABLED", False),
             patch("controllers.console.workspace.members.dify_config.BILLING_ENABLED", False),
         ):
-            result, status = method(api, user)
+            result, status = method(api, session, user)
 
         assert status == 201
         assert result["result"] == "success"
@@ -116,6 +119,7 @@ class TestMemberInviteEmailApi:
         features.billing.enabled = False
         features.workspace_members.enabled = True
         features.workspace_members.is_available.return_value = False
+        session = MagicMock()
 
         payload = {
             "emails": ["a@test.com"],
@@ -130,7 +134,7 @@ class TestMemberInviteEmailApi:
             patch("controllers.console.workspace.members.dify_config.BILLING_ENABLED", False),
         ):
             with pytest.raises(WorkspaceMembersLimitExceeded):
-                method(api, user)
+                method(api, session, user)
 
     def test_invite_billing_limit_exceeded(self, app: Flask):
         api = MemberInviteEmailApi()
@@ -143,6 +147,7 @@ class TestMemberInviteEmailApi:
         features.members.size = 9
         features.members.limit = 10
         features.workspace_members.enabled = False
+        session = MagicMock()
 
         payload = {
             "emails": ["a@test.com", "b@test.com"],
@@ -158,7 +163,7 @@ class TestMemberInviteEmailApi:
             patch("controllers.console.workspace.members.dify_config.BILLING_ENABLED", True),
         ):
             with pytest.raises(WorkspaceMembersLimitExceeded):
-                method(api, user)
+                method(api, session, user)
 
     def test_invite_already_member(self, app: Flask):
         api = MemberInviteEmailApi()
@@ -170,6 +175,7 @@ class TestMemberInviteEmailApi:
         features.billing.enabled = False
         features.workspace_members.enabled = False
         features.workspace_members.is_available.return_value = True
+        session = MagicMock()
 
         payload = {
             "emails": ["a@test.com"],
@@ -188,7 +194,7 @@ class TestMemberInviteEmailApi:
             patch("controllers.console.workspace.members.dify_config.ENTERPRISE_ENABLED", False),
             patch("controllers.console.workspace.members.dify_config.BILLING_ENABLED", False),
         ):
-            result, status = method(api, user)
+            result, status = method(api, session, user)
 
         assert result["invitation_results"][0]["status"] == "success"
 
@@ -200,9 +206,10 @@ class TestMemberInviteEmailApi:
             "emails": ["a@test.com"],
             "role": "owner",
         }
+        session = MagicMock()
 
         with app.test_request_context("/", json=payload):
-            result, status = method(api, MagicMock())
+            result, status = method(api, session, MagicMock())
 
         assert status == 400
         assert result["code"] == "invalid-role"
@@ -217,6 +224,7 @@ class TestMemberInviteEmailApi:
         features.billing.enabled = False
         features.workspace_members.enabled = False
         features.workspace_members.is_available.return_value = True
+        session = MagicMock()
 
         payload = {
             "emails": ["a@test.com"],
@@ -235,7 +243,7 @@ class TestMemberInviteEmailApi:
             patch("controllers.console.workspace.members.dify_config.ENTERPRISE_ENABLED", False),
             patch("controllers.console.workspace.members.dify_config.BILLING_ENABLED", False),
         ):
-            result, _ = method(api, user)
+            result, _ = method(api, session, user)
 
         assert result["invitation_results"][0]["status"] == "failed"
 
@@ -246,9 +254,10 @@ class TestMemberUpdateRoleApi:
         method = unwrap(api.put)
 
         payload = {"role": "invalid-role"}
+        session = MagicMock()
 
         with app.test_request_context("/", json=payload):
-            result, status = method(api, MagicMock(), "id")
+            result, status = method(api, session, MagicMock(), "id")
 
         assert status == 400
 
@@ -268,6 +277,7 @@ class TestDatasetOperatorMemberListApi:
         member.role = "operator"
         member.status = "active"
         members = [member]
+        session = MagicMock()
 
         with (
             app.test_request_context("/"),
@@ -275,7 +285,7 @@ class TestDatasetOperatorMemberListApi:
                 "controllers.console.workspace.members.TenantService.get_dataset_operator_members", return_value=members
             ),
         ):
-            result, status = method(api, user)
+            result, status = method(api, session, user)
 
         assert status == 200
         assert len(result["accounts"]) == 1
@@ -285,12 +295,13 @@ class TestDatasetOperatorMemberListApi:
         method = unwrap(api.get)
 
         user = MagicMock(current_tenant=None)
+        session = MagicMock()
 
         with (
             app.test_request_context("/"),
         ):
             with pytest.raises(ValueError):
-                method(api, user)
+                method(api, session, user)
 
 
 class TestSendOwnerTransferEmailApi:
@@ -300,6 +311,7 @@ class TestSendOwnerTransferEmailApi:
 
         tenant = MagicMock(name="ws")
         user = MagicMock(email="a@test.com", current_tenant=tenant)
+        session = MagicMock()
 
         payload = {}
 
@@ -312,7 +324,7 @@ class TestSendOwnerTransferEmailApi:
                 "controllers.console.workspace.members.AccountService.send_owner_transfer_email", return_value="token"
             ),
         ):
-            result = method(api, user)
+            result = method(api, session, user)
 
         assert result["result"] == "success"
 
@@ -321,6 +333,7 @@ class TestSendOwnerTransferEmailApi:
         method = unwrap(api.post)
 
         payload = {}
+        session = MagicMock()
 
         with (
             app.test_request_context("/", json=payload),
@@ -328,7 +341,7 @@ class TestSendOwnerTransferEmailApi:
             patch("controllers.console.workspace.members.AccountService.is_email_send_ip_limit", return_value=True),
         ):
             with pytest.raises(EmailSendIpLimitError):
-                method(api, MagicMock())
+                method(api, session, MagicMock())
 
     def test_send_not_owner(self, app: Flask):
         api = SendOwnerTransferEmailApi()
@@ -336,6 +349,7 @@ class TestSendOwnerTransferEmailApi:
 
         tenant = MagicMock()
         user = MagicMock(current_tenant=tenant)
+        session = MagicMock()
 
         with (
             app.test_request_context("/", json={}),
@@ -344,7 +358,7 @@ class TestSendOwnerTransferEmailApi:
             patch("controllers.console.workspace.members.TenantService.is_owner", return_value=False),
         ):
             with pytest.raises(NotOwnerError):
-                method(api, user)
+                method(api, session, user)
 
 
 class TestOwnerTransferCheckApi:
@@ -354,6 +368,7 @@ class TestOwnerTransferCheckApi:
 
         tenant = MagicMock()
         user = MagicMock(email="a@test.com", current_tenant=tenant)
+        session = MagicMock()
 
         payload = {"code": "x", "token": "t"}
 
@@ -370,7 +385,7 @@ class TestOwnerTransferCheckApi:
             ),
         ):
             with pytest.raises(EmailCodeError):
-                method(api, user)
+                method(api, session, user)
 
     def test_rate_limited(self, app: Flask):
         api = OwnerTransferCheckApi()
@@ -378,6 +393,7 @@ class TestOwnerTransferCheckApi:
 
         tenant = MagicMock()
         user = MagicMock(email="a@test.com", current_tenant=tenant)
+        session = MagicMock()
 
         payload = {"code": "x", "token": "t"}
 
@@ -390,7 +406,7 @@ class TestOwnerTransferCheckApi:
             ),
         ):
             with pytest.raises(OwnerTransferLimitError):
-                method(api, user)
+                method(api, session, user)
 
     def test_invalid_token(self, app: Flask):
         api = OwnerTransferCheckApi()
@@ -398,6 +414,7 @@ class TestOwnerTransferCheckApi:
 
         tenant = MagicMock()
         user = MagicMock(email="a@test.com", current_tenant=tenant)
+        session = MagicMock()
 
         payload = {"code": "x", "token": "t"}
 
@@ -411,7 +428,7 @@ class TestOwnerTransferCheckApi:
             patch("controllers.console.workspace.members.AccountService.get_owner_transfer_data", return_value=None),
         ):
             with pytest.raises(InvalidTokenError):
-                method(api, user)
+                method(api, session, user)
 
     def test_invalid_email(self, app: Flask):
         api = OwnerTransferCheckApi()
@@ -419,6 +436,7 @@ class TestOwnerTransferCheckApi:
 
         tenant = MagicMock()
         user = MagicMock(email="a@test.com", current_tenant=tenant)
+        session = MagicMock()
 
         payload = {"code": "x", "token": "t"}
 
@@ -435,7 +453,7 @@ class TestOwnerTransferCheckApi:
             ),
         ):
             with pytest.raises(InvalidEmailError):
-                method(api, user)
+                method(api, session, user)
 
 
 class TestOwnerTransferApi:
@@ -445,6 +463,7 @@ class TestOwnerTransferApi:
 
         tenant = MagicMock()
         user = MagicMock(id="1", email="a@test.com", current_tenant=tenant)
+        session = MagicMock()
 
         payload = {"token": "t"}
 
@@ -453,7 +472,7 @@ class TestOwnerTransferApi:
             patch("controllers.console.workspace.members.TenantService.is_owner", return_value=True),
         ):
             with pytest.raises(CannotTransferOwnerToSelfError):
-                method(api, user, "1")
+                method(api, session, user, "1")
 
     def test_invalid_token(self, app: Flask):
         api = OwnerTransfer()
@@ -461,6 +480,7 @@ class TestOwnerTransferApi:
 
         tenant = MagicMock()
         user = MagicMock(id="1", email="a@test.com", current_tenant=tenant)
+        session = MagicMock()
 
         payload = {"token": "t"}
 
@@ -470,4 +490,52 @@ class TestOwnerTransferApi:
             patch("controllers.console.workspace.members.AccountService.get_owner_transfer_data", return_value=None),
         ):
             with pytest.raises(InvalidTokenError):
-                method(api, user, "2")
+                method(api, session, user, "2")
+
+    def test_transfer_success_sends_notifications_after_commit(self, app: Flask):
+        api = OwnerTransfer()
+        method = unwrap(api.post)
+
+        tenant = MagicMock()
+        tenant.name = "ws"
+        user = MagicMock(id="1", email="old@test.com", current_tenant=tenant)
+        member = MagicMock(email="new@test.com")
+        session = MagicMock()
+        session.get.return_value = member
+
+        payload = {"token": "t"}
+
+        with (
+            app.test_request_context("/", json=payload),
+            patch("controllers.console.workspace.members.TenantService.is_owner", return_value=True),
+            patch(
+                "controllers.console.workspace.members.AccountService.get_owner_transfer_data",
+                return_value={"email": "old@test.com"},
+            ),
+            patch("controllers.console.workspace.members.AccountService.revoke_owner_transfer_token"),
+            patch("controllers.console.workspace.members.TenantService.is_member", return_value=True),
+            patch("controllers.console.workspace.members.TenantService.update_member_role"),
+            patch("controllers.console.workspace.members.event.listen") as listen_mock,
+            patch(
+                "controllers.console.workspace.members.AccountService.send_new_owner_transfer_notify_email"
+            ) as send_new,
+            patch(
+                "controllers.console.workspace.members.AccountService.send_old_owner_transfer_notify_email"
+            ) as send_old,
+        ):
+            result = method(api, session, user, "2")
+
+            assert result["result"] == "success"
+            send_new.assert_not_called()
+            send_old.assert_not_called()
+            listen_mock.assert_called_once()
+
+            after_commit = listen_mock.call_args.args[2]
+            after_commit(session)
+
+            send_new.assert_called_once_with(email="new@test.com", workspace_name="ws")
+            send_old.assert_called_once_with(
+                email="old@test.com",
+                workspace_name="ws",
+                new_owner_email="new@test.com",
+            )

--- a/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from flask import Flask
@@ -460,28 +460,31 @@ class TestSwitchWorkspaceApi:
 
         payload = {"tenant_id": "t2"}
         tenant = MagicMock(id="t2")
+        session = MagicMock()
+        session.get.return_value = tenant
 
         with (
             app.test_request_context("/workspaces/switch", json=payload),
             patch(
                 "controllers.console.workspace.workspace.current_account_with_tenant", return_value=(MagicMock(), "t1")
             ),
-            patch("controllers.console.workspace.workspace.TenantService.switch_tenant"),
-            patch("controllers.console.workspace.workspace.db.session.get") as get_mock,
+            patch("controllers.console.workspace.workspace.TenantService.switch_tenant") as switch_tenant_mock,
             patch(
                 "controllers.console.workspace.workspace.WorkspaceService.get_tenant_info", return_value={"id": "t2"}
             ),
         ):
-            get_mock.return_value = tenant
-            result = method(api)
+            result = method(api, session)
 
         assert result["result"] == "success"
+        switch_tenant_mock.assert_called_once_with(ANY, "t2", session=session)
+        session.get.assert_called_once_with(ANY, "t2")
 
     def test_switch_not_linked(self, app: Flask):
         api = SwitchWorkspaceApi()
         method = unwrap(api.post)
 
         payload = {"tenant_id": "bad"}
+        session = MagicMock()
 
         with (
             app.test_request_context("/workspaces/switch", json=payload),
@@ -491,13 +494,15 @@ class TestSwitchWorkspaceApi:
             patch("controllers.console.workspace.workspace.TenantService.switch_tenant", side_effect=Exception),
         ):
             with pytest.raises(AccountNotLinkTenantError):
-                method(api)
+                method(api, session)
 
     def test_switch_tenant_not_found(self, app: Flask):
         api = SwitchWorkspaceApi()
         method = unwrap(api.post)
 
         payload = {"tenant_id": "missing"}
+        session = MagicMock()
+        session.get.return_value = None
 
         with (
             app.test_request_context("/workspaces/switch", json=payload),
@@ -506,12 +511,9 @@ class TestSwitchWorkspaceApi:
                 return_value=(MagicMock(), "t1"),
             ),
             patch("controllers.console.workspace.workspace.TenantService.switch_tenant"),
-            patch("controllers.console.workspace.workspace.db.session.get") as get_mock,
         ):
-            get_mock.return_value = None
-
             with pytest.raises(ValueError):
-                method(api)
+                method(api, session)
 
 
 class TestCustomConfigWorkspaceApi:
@@ -520,6 +522,8 @@ class TestCustomConfigWorkspaceApi:
         method = unwrap(api.post)
 
         tenant = MagicMock(custom_config_dict={})
+        session = MagicMock()
+        session.get.return_value = tenant
 
         payload = {"remove_webapp_brand": True}
 
@@ -528,21 +532,22 @@ class TestCustomConfigWorkspaceApi:
             patch(
                 "controllers.console.workspace.workspace.current_account_with_tenant", return_value=(MagicMock(), "t1")
             ),
-            patch("controllers.console.workspace.workspace.db.get_or_404", return_value=tenant),
-            patch("controllers.console.workspace.workspace.db.session.commit"),
             patch(
                 "controllers.console.workspace.workspace.WorkspaceService.get_tenant_info", return_value={"id": "t1"}
             ),
         ):
-            result = method(api)
+            result = method(api, session)
 
         assert result["result"] == "success"
+        session.get.assert_called_once_with(ANY, "t1")
 
     def test_logo_fallback(self, app: Flask):
         api = CustomConfigWorkspaceApi()
         method = unwrap(api.post)
 
         tenant = MagicMock(custom_config_dict={"replace_webapp_logo": "old-logo"})
+        session = MagicMock()
+        session.get.return_value = tenant
 
         payload = {"remove_webapp_brand": False}
 
@@ -553,16 +558,11 @@ class TestCustomConfigWorkspaceApi:
                 return_value=(MagicMock(), "t1"),
             ),
             patch(
-                "controllers.console.workspace.workspace.db.get_or_404",
-                return_value=tenant,
-            ),
-            patch("controllers.console.workspace.workspace.db.session.commit"),
-            patch(
                 "controllers.console.workspace.workspace.WorkspaceService.get_tenant_info",
                 return_value={"id": "t1"},
             ),
         ):
-            result = method(api)
+            result = method(api, session)
 
         assert tenant.custom_config_dict["replace_webapp_logo"] == "old-logo"
         assert result["result"] == "success"
@@ -737,6 +737,8 @@ class TestWorkspaceInfoApi:
         method = unwrap(api.post)
 
         tenant = MagicMock()
+        session = MagicMock()
+        session.get.return_value = tenant
 
         payload = {"name": "New Name"}
 
@@ -745,16 +747,15 @@ class TestWorkspaceInfoApi:
             patch(
                 "controllers.console.workspace.workspace.current_account_with_tenant", return_value=(MagicMock(), "t1")
             ),
-            patch("controllers.console.workspace.workspace.db.get_or_404", return_value=tenant),
-            patch("controllers.console.workspace.workspace.db.session.commit"),
             patch(
                 "controllers.console.workspace.workspace.WorkspaceService.get_tenant_info",
                 return_value={"name": "New Name"},
             ),
         ):
-            result = method(api)
+            result = method(api, session)
 
         assert result["result"] == "success"
+        session.get.assert_called_once_with(ANY, "t1")
 
     def test_no_current_tenant(self, app: Flask):
         api = WorkspaceInfoApi()
@@ -770,7 +771,7 @@ class TestWorkspaceInfoApi:
             ),
         ):
             with pytest.raises(ValueError):
-                method(api)
+                method(api, MagicMock())
 
 
 class TestWorkspacePermissionApi:

--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -907,6 +907,44 @@ class TestTenantService:
             # Assert: only the join record should be deleted
             mock_db.session.delete.assert_called_once_with(mock_ta)
 
+    def test_remove_member_from_tenant_uses_injected_session(self):
+        """Test member removal can reuse an injected session without committing it."""
+        mock_tenant = MagicMock()
+        mock_tenant.id = "tenant-456"
+        mock_operator = TestAccountAssociatedDataFactory.create_account_mock(account_id="operator-123", role="owner")
+        mock_active_member = TestAccountAssociatedDataFactory.create_account_mock(
+            account_id="active-user-789", email="active@example.com", status=AccountStatus.ACTIVE
+        )
+        mock_operator_join = TestAccountAssociatedDataFactory.create_tenant_join_mock(
+            tenant_id="tenant-456", account_id="operator-123", role="owner"
+        )
+        mock_ta = TestAccountAssociatedDataFactory.create_tenant_join_mock(
+            tenant_id="tenant-456", account_id="active-user-789", role="normal"
+        )
+        session = MagicMock()
+        session.scalar.side_effect = [mock_operator_join, mock_ta]
+
+        with (
+            patch("services.account_service.event.listen") as listen_mock,
+            patch(
+                "services.enterprise.account_deletion_sync.sync_workspace_member_removal", return_value=True
+            ) as sync_mock,
+        ):
+            TenantService.remove_member_from_tenant(mock_tenant, mock_active_member, mock_operator, session=session)
+
+            session.delete.assert_called_once_with(mock_ta)
+            session.commit.assert_not_called()
+            sync_mock.assert_not_called()
+            listen_mock.assert_called_once()
+
+            after_commit = listen_mock.call_args.args[2]
+            after_commit(session)
+            sync_mock.assert_called_once_with(
+                workspace_id="tenant-456",
+                member_id="active-user-789",
+                source="workspace_member_removed",
+            )
+
     # ==================== Tenant Switching Tests ====================
 
     def test_switch_tenant_success(self):
@@ -928,6 +966,22 @@ class TestTenantService:
             # Verify tenant was switched
             assert mock_tenant_join.current is True
             self._assert_database_operations_called(mock_db)
+
+    def test_switch_tenant_uses_injected_session(self):
+        """Test tenant switching can reuse an injected session without committing it."""
+        mock_account = TestAccountAssociatedDataFactory.create_account_mock()
+        mock_tenant_join = TestAccountAssociatedDataFactory.create_tenant_join_mock(
+            tenant_id="tenant-456", account_id="user-123", current=False
+        )
+        session = MagicMock()
+        session.scalar.return_value = mock_tenant_join
+
+        TenantService.switch_tenant(mock_account, "tenant-456", session=session)
+
+        assert mock_tenant_join.current is True
+        mock_account.set_tenant_id.assert_called_once_with("tenant-456")
+        session.execute.assert_called_once()
+        session.commit.assert_not_called()
 
     def test_switch_tenant_no_tenant_id(self):
         """Test tenant switching without providing tenant ID."""
@@ -964,6 +1018,26 @@ class TestTenantService:
             # Verify role was updated
             assert mock_target_join.role == "admin"
             self._assert_database_operations_called(mock_db)
+
+    def test_update_member_role_uses_injected_session(self):
+        """Test role updates can reuse an injected session without committing it."""
+        mock_tenant = MagicMock()
+        mock_tenant.id = "tenant-456"
+        mock_member = TestAccountAssociatedDataFactory.create_account_mock(account_id="member-789")
+        mock_operator = TestAccountAssociatedDataFactory.create_account_mock(account_id="operator-123")
+        mock_target_join = TestAccountAssociatedDataFactory.create_tenant_join_mock(
+            tenant_id="tenant-456", account_id="member-789", role="normal"
+        )
+        mock_operator_join = TestAccountAssociatedDataFactory.create_tenant_join_mock(
+            tenant_id="tenant-456", account_id="operator-123", role="owner"
+        )
+        session = MagicMock()
+        session.scalar.side_effect = [mock_operator_join, mock_target_join, mock_operator_join]
+
+        TenantService.update_member_role(mock_tenant, mock_member, "admin", mock_operator, session=session)
+
+        assert mock_target_join.role == "admin"
+        session.commit.assert_not_called()
 
     def test_admin_can_update_admin_member_role(self):
         """Test admin can update another non-owner member, including an admin."""

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1300,6 +1300,7 @@ requires-dist = [
     { name = "pydantic-ai-slim", extras = ["anthropic", "google", "openai"], marker = "extra == 'server'", specifier = ">=1.85.1,<2.0.0" },
     { name = "pydantic-settings", marker = "extra == 'server'", specifier = ">=2.12.0,<3.0.0" },
     { name = "redis", marker = "extra == 'server'", specifier = ">=7.4.0,<8.0.0" },
+    { name = "shell-session-manager", marker = "extra == 'server'", specifier = "==2.1.1" },
     { name = "typing-extensions", specifier = ">=4.12.2,<5.0.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = "==0.46.0" },
 ]

--- a/dify-agent/src/dify_agent/layers/shell/layer.py
+++ b/dify-agent/src/dify_agent/layers/shell/layer.py
@@ -256,9 +256,7 @@ class DifyShellRuntimeState(BaseModel):
                 raise ValueError("workspace_cwd requires a matching session_id.")
             expected_workspace = _workspace_cwd(self.session_id)
             if self.workspace_cwd != expected_workspace:
-                raise ValueError(
-                    f"workspace_cwd must equal {expected_workspace!r} for session_id {self.session_id!r}."
-                )
+                raise ValueError(f"workspace_cwd must equal {expected_workspace!r} for session_id {self.session_id!r}.")
         unknown_offset_job_ids = set(self.job_offsets) - set(self.job_ids)
         if unknown_offset_job_ids:
             names = ", ".join(sorted(unknown_offset_job_ids))
@@ -694,12 +692,12 @@ def _workspace_mkdir_script(*, session_id: str) -> str:
     of silently reusing another session's workspace.
     """
     safe_session_id = _validated_session_id(session_id)
-    workspace_dir = f'$HOME/workspace/{safe_session_id}'
+    workspace_dir = f"$HOME/workspace/{safe_session_id}"
     return (
         'mkdir -p "$HOME/workspace"; '
         f'if mkdir "{workspace_dir}"; then exit 0; fi; '
         f'if [ -e "{workspace_dir}" ]; then exit {_WORKSPACE_COLLISION_EXIT_CODE}; fi; '
-        'exit 1'
+        "exit 1"
     )
 
 

--- a/dify-agent/tests/local/dify_agent/layers/shell/test_layer.py
+++ b/dify-agent/tests/local/dify_agent/layers/shell/test_layer.py
@@ -277,6 +277,7 @@ def test_shell_layer_suspend_and_resume_reuse_state_with_fresh_clients() -> None
         return next(clients)
 
     compositor = Compositor([LayerNode("shell", _shell_provider(client_factory=factory))])
+
     async def scenario() -> None:
         async with compositor.enter(configs={"shell": DifyShellLayerConfig()}) as run:
             shell_layer = run.get_layer("shell", DifyShellLayer)
@@ -342,7 +343,10 @@ def test_shell_layer_delete_removes_workspace_then_force_deletes_tracked_jobs_an
 
     assert client.events[:2] == [("run", 'rm -rf -- "$HOME/workspace/abc12ff"'), ("wait", "cleanup-job")]
     assert {call.job_id for call in client.delete_calls} == {"user-job", "mkdir-job", "cleanup-job"}
-    assert all(client.events.index(("delete", call.job_id)) > client.events.index(("wait", "cleanup-job")) for call in client.delete_calls)
+    assert all(
+        client.events.index(("delete", call.job_id)) > client.events.index(("wait", "cleanup-job"))
+        for call in client.delete_calls
+    )
     assert all(call.force is True for call in client.delete_calls)
     assert layer.runtime_state.job_ids == []
     assert layer.runtime_state.job_offsets == {}

--- a/dify-agent/tests/local/dify_agent/runtime/test_compositor_factory.py
+++ b/dify-agent/tests/local/dify_agent/runtime/test_compositor_factory.py
@@ -27,7 +27,9 @@ def test_default_layer_providers_register_shell_layer_with_configured_token_fact
 
         return factory
 
-    monkeypatch.setattr(compositor_factory_module, "create_shellctl_client_factory", fake_create_shellctl_client_factory)
+    monkeypatch.setattr(
+        compositor_factory_module, "create_shellctl_client_factory", fake_create_shellctl_client_factory
+    )
 
     providers = create_default_layer_providers(
         shellctl_entrypoint="http://shellctl.example",
@@ -56,7 +58,9 @@ def test_default_layer_providers_keep_empty_shellctl_token_by_default(
 
         return factory
 
-    monkeypatch.setattr(compositor_factory_module, "create_shellctl_client_factory", fake_create_shellctl_client_factory)
+    monkeypatch.setattr(
+        compositor_factory_module, "create_shellctl_client_factory", fake_create_shellctl_client_factory
+    )
 
     providers = create_default_layer_providers(shellctl_entrypoint="http://shellctl.example")
     shell_provider = next(provider for provider in providers if provider.type_id == DIFY_SHELL_LAYER_TYPE_ID)

--- a/dify-agent/tests/local/dify_agent/runtime/test_runner.py
+++ b/dify-agent/tests/local/dify_agent/runtime/test_runner.py
@@ -684,7 +684,8 @@ def test_runner_rejects_duplicate_tool_names_between_shell_and_other_layers(
         ),
     )
     layer_providers = tuple(
-        provider for provider in create_default_layer_providers(shellctl_entrypoint="http://unused")
+        provider
+        for provider in create_default_layer_providers(shellctl_entrypoint="http://unused")
         if provider.type_id != DIFY_SHELL_LAYER_TYPE_ID
     ) + (shell_provider,)
 


### PR DESCRIPTION
## Summary

- migrate workspace switch, custom config, workspace info, and membership controller paths to explicit injected SQLAlchemy sessions
- let related AccountService/TenantService helpers reuse an injected session while preserving scoped-session fallback behavior
- defer member-removal sync/cache cleanup and owner-transfer notifications until after injected transactions commit

Refs #36544

## Screenshots

N/A, backend refactor.

## Tests

- `uv run --project api --dev pytest api/tests/unit_tests/controllers/console/workspace/test_workspace.py api/tests/unit_tests/controllers/console/workspace/test_members.py api/tests/unit_tests/controllers/console/test_workspace_members.py api/tests/unit_tests/services/test_account_service.py`
- `uv run --project api --dev ruff check api/controllers/console/workspace/workspace.py api/controllers/console/workspace/members.py api/services/account_service.py api/tests/unit_tests/controllers/console/workspace/test_workspace.py api/tests/unit_tests/controllers/console/workspace/test_members.py api/tests/unit_tests/controllers/console/test_workspace_members.py api/tests/unit_tests/services/test_account_service.py`

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods