### PR TITLE
fix: reject malformed pagination params with 400 instead of silent fallback

### DIFF
--- a/api/controllers/service_api/dataset/segment.py
+++ b/api/controllers/service_api/dataset/segment.py
@@ -232,7 +232,6 @@ class SegmentApi(DatasetApiResource):
         args = query_params_from_request(
             SegmentListQuery,
             list_fields=("status",),
-            use_defaults_for_malformed_ints=True,
         )
         page = args.page
         limit = args.limit
@@ -550,7 +549,7 @@ class ChildChunkApi(DatasetApiResource):
         if not segment:
             raise NotFound("Segment not found.")
 
-        args = query_params_from_request(ChildChunkListQuery, use_defaults_for_malformed_ints=True)
+        args = query_params_from_request(ChildChunkListQuery)
 
         page = args.page
         limit = min(args.limit, 100)


### PR DESCRIPTION
## Summary

Remove `use_defaults_for_malformed_ints=True` from segment list and child chunk list endpoints. This ensures Pydantic validation catches malformed integer query params (e.g. `page=bad`, `limit=abc`) and returns `400 Bad Request` instead of silently falling back to defaults.

## Changes

- `api/controllers/service_api/dataset/segment.py`: Remove `use_defaults_for_malformed_ints=True` from `SegmentListQuery` and `ChildChunkListQuery` parsing

## Before

```
GET /v1/datasets/{id}/documents/{id}/segments?page=bad&limit=abc
→ 200 OK (defaults: page=1, limit=20)
```

## After

```
GET /v1/datasets/{id}/documents/{id}/segments?page=bad&limit=abc
→ 400 Bad Request (validation error)
```

Fixes: #36519