### PR TITLE
refactor(web): mark workflow run props readonly

### DIFF
--- a/web/app/components/workflow/run/iteration-log/iteration-result-panel.tsx
+++ b/web/app/components/workflow/run/iteration-log/iteration-result-panel.tsx
@@ -18,9 +18,9 @@ import { NodeRunningStatus } from '@/app/components/workflow/types'
 const i18nPrefix = 'singleRun'
 
 type Props = {
-  list: NodeTracing[][]
-  onBack: () => void
-  iterDurationMap?: IterationDurationMap
+  readonly list: NodeTracing[][]
+  readonly onBack: () => void
+  readonly iterDurationMap?: IterationDurationMap
 }
 
 const IterationResultPanel: FC<Props> = ({

--- a/web/app/components/workflow/run/loop-log/loop-result-panel.tsx
+++ b/web/app/components/workflow/run/loop-log/loop-result-panel.tsx
@@ -32,10 +32,10 @@ const getLoopRunKey = (loop: NodeTracing[], fallbackIndex: number) => {
 }
 
 type Props = {
-  list: NodeTracing[][]
-  onBack: () => void
-  loopDurationMap?: LoopDurationMap
-  loopVariableMap?: LoopVariableMap
+  readonly list: NodeTracing[][]
+  readonly onBack: () => void
+  readonly loopDurationMap?: LoopDurationMap
+  readonly loopVariableMap?: LoopVariableMap
 }
 
 const LoopResultPanel: FC<Props> = ({

--- a/web/app/components/workflow/run/loop-result-panel.tsx
+++ b/web/app/components/workflow/run/loop-result-panel.tsx
@@ -16,10 +16,10 @@ import TracingPanel from './tracing-panel'
 const i18nPrefix = 'singleRun'
 
 type Props = {
-  list: NodeTracing[][]
-  onHide: () => void
-  onBack: () => void
-  noWrap?: boolean
+  readonly list: NodeTracing[][]
+  readonly onHide: () => void
+  readonly onBack: () => void
+  readonly noWrap?: boolean
 }
 
 const LoopResultPanel: FC<Props> = ({

--- a/web/app/components/workflow/run/meta.tsx
+++ b/web/app/components/workflow/run/meta.tsx
@@ -4,13 +4,13 @@ import { useTranslation } from 'react-i18next'
 import useTimestamp from '@/hooks/use-timestamp'
 
 type Props = {
-  status: string
-  executor?: string
-  startTime?: number
-  time?: number
-  tokens?: number
-  steps?: number
-  showSteps?: boolean
+  readonly status: string
+  readonly executor?: string
+  readonly startTime?: number
+  readonly time?: number
+  readonly tokens?: number
+  readonly steps?: number
+  readonly showSteps?: boolean
 }
 
 const MetaData: FC<Props> = ({

--- a/web/app/components/workflow/run/node.tsx
+++ b/web/app/components/workflow/run/node.tsx
@@ -34,18 +34,18 @@ import { LoopLogTrigger } from './loop-log'
 import { RetryLogTrigger } from './retry-log'
 
 type Props = {
-  className?: string
-  nodeInfo: NodeTracing
-  allExecutions?: NodeTracing[]
-  inMessage?: boolean
-  hideInfo?: boolean
-  hideProcessDetail?: boolean
-  onShowIterationDetail?: (detail: NodeTracing[][], iterDurationMap: IterationDurationMap) => void
-  onShowLoopDetail?: (detail: NodeTracing[][], loopDurationMap: LoopDurationMap, loopVariableMap: LoopVariableMap) => void
-  onShowRetryDetail?: (detail: NodeTracing[]) => void
-  onShowAgentOrToolLog?: (detail?: AgentLogItemWithChildren) => void
-  notShowIterationNav?: boolean
-  notShowLoopNav?: boolean
+  readonly className?: string
+  readonly nodeInfo: NodeTracing
+  readonly allExecutions?: NodeTracing[]
+  readonly inMessage?: boolean
+  readonly hideInfo?: boolean
+  readonly hideProcessDetail?: boolean
+  readonly onShowIterationDetail?: (detail: NodeTracing[][], iterDurationMap: IterationDurationMap) => void
+  readonly onShowLoopDetail?: (detail: NodeTracing[][], loopDurationMap: LoopDurationMap, loopVariableMap: LoopVariableMap) => void
+  readonly onShowRetryDetail?: (detail: NodeTracing[]) => void
+  readonly onShowAgentOrToolLog?: (detail?: AgentLogItemWithChildren) => void
+  readonly notShowIterationNav?: boolean
+  readonly notShowLoopNav?: boolean
 }
 
 const NodePanel: FC<Props> = ({

--- a/web/app/components/workflow/run/retry-log/retry-result-panel.tsx
+++ b/web/app/components/workflow/run/retry-log/retry-result-panel.tsx
@@ -10,8 +10,8 @@ import { useTranslation } from 'react-i18next'
 import TracingPanel from '../tracing-panel'
 
 type Props = {
-  list: NodeTracing[]
-  onBack: () => void
+  readonly list: NodeTracing[]
+  readonly onBack: () => void
 }
 
 const RetryResultPanel: FC<Props> = ({

--- a/web/app/components/workflow/run/status-container.tsx
+++ b/web/app/components/workflow/run/status-container.tsx
@@ -5,8 +5,8 @@ import useTheme from '@/hooks/use-theme'
 import { Theme } from '@/types/app'
 
 type Props = {
-  status: string
-  children?: React.ReactNode
+  readonly status: string
+  readonly children?: React.ReactNode
 }
 
 const StatusContainer: FC<Props> = ({


### PR DESCRIPTION
## Summary
- mark Props fields in workflow run components as readonly
- keep the change scoped to a small workflow/run slice

Relates to #25219. This is a partial pass and avoids overlapping with the header-only PR #36487.

## Tests
- git diff --check
- pnpm --dir web exec vp test run app/components/workflow/run/__tests__/meta.spec.tsx app/components/workflow/run/__tests__/node.spec.tsx app/components/workflow/run/__tests__/status-container.spec.tsx app/components/workflow/run/__tests__/loop-result-panel.spec.tsx app/components/workflow/run/iteration-log/__tests__/iteration-result-panel.spec.tsx app/components/workflow/run/loop-log/__tests__/loop-result-panel.spec.tsx app/components/workflow/run/retry-log/__tests__/retry-result-panel.spec.tsx
- pnpm --filter dify-web type-check
- pnpm exec eslint web/app/components/workflow/run/node.tsx web/app/components/workflow/run/meta.tsx web/app/components/workflow/run/status-container.tsx web/app/components/workflow/run/iteration-log/iteration-result-panel.tsx web/app/components/workflow/run/loop-log/loop-result-panel.tsx web/app/components/workflow/run/loop-result-panel.tsx web/app/components/workflow/run/retry-log/retry-result-panel.tsx (0 errors; existing warnings only)