### PR TITLE
refactor(api): remove safe type ignores

### DIFF
--- a/api/core/rag/datasource/vdb/vector_backend_registry.py
+++ b/api/core/rag/datasource/vdb/vector_backend_registry.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import importlib
 import logging
 from importlib.metadata import entry_points
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from core.rag.datasource.vdb.vector_factory import AbstractVectorFactory
@@ -49,7 +49,7 @@ def _load_plugin_factory(vector_type: str) -> type[AbstractVectorFactory] | None
         except Exception:
             logger.exception("Failed to load vector backend entry point %s", ep.name)
             raise
-        return loaded  # type: ignore[return-value]
+        return cast("type[AbstractVectorFactory]", loaded)
     return None
 
 
@@ -69,7 +69,7 @@ def _load_builtin_factory(vector_type: str) -> type[AbstractVectorFactory]:
         raise _unsupported(vector_type)
     module_path, _, attr = target.partition(":")
     module = importlib.import_module(module_path)
-    return getattr(module, attr)  # type: ignore[no-any-return]
+    return cast("type[AbstractVectorFactory]", getattr(module, attr))
 
 
 def get_vector_factory_class(vector_type: str) -> type[AbstractVectorFactory]:

--- a/api/services/workflow/queue_dispatcher.py
+++ b/api/services/workflow/queue_dispatcher.py
@@ -68,7 +68,7 @@ class QueueDispatcherManager:
     """Factory for creating appropriate dispatcher based on tenant subscription"""
 
     # Mapping of billing plans to dispatchers
-    PLAN_DISPATCHER_MAP = {
+    PLAN_DISPATCHER_MAP: dict[str, type[BaseQueueDispatcher]] = {
         "professional": ProfessionalQueueDispatcher,
         "team": TeamQueueDispatcher,
         "sandbox": SandboxQueueDispatcher,
@@ -103,4 +103,4 @@ class QueueDispatcherManager:
             SandboxQueueDispatcher,  # Default to sandbox for unknown plans
         )
 
-        return dispatcher_class()  # type: ignore
+        return dispatcher_class()


### PR DESCRIPTION
## Summary
- add an explicit dispatcher class map type so `QueueDispatcherManager.get_dispatcher()` no longer needs a type ignore
- replace vector backend registry return-value ignores with targeted `typing.cast()` calls for dynamically loaded factories

Part of #24494. This does not close the whole issue.

## Verification
- `uv run --directory api --dev pyrefly check services/workflow/queue_dispatcher.py core/rag/datasource/vdb/vector_backend_registry.py`
- `uv run --directory api --dev ruff check services/workflow/queue_dispatcher.py core/rag/datasource/vdb/vector_backend_registry.py`
- `uv run --directory api --dev pytest -o addopts='' tests/unit_tests/services/workflow/test_queue_dispatcher.py tests/unit_tests/core/rag/datasource/vdb/test_vector_factory.py`
- `git diff --check`