### PR TITLE
chore: add missing @override decorators to pipeline WorkflowAppGenerateResponseConverter

### DIFF
--- a/api/core/app/apps/pipeline/generate_response_converter.py
+++ b/api/core/app/apps/pipeline/generate_response_converter.py
@@ -1,5 +1,5 @@
 from collections.abc import Generator
-from typing import Any, cast
+from typing import Any, cast, override
 
 from core.app.apps.base_app_generate_response_converter import AppGenerateResponseConverter
 from core.app.entities.task_entities import (
@@ -15,6 +15,7 @@ from core.app.entities.task_entities import (
 
 class WorkflowAppGenerateResponseConverter(AppGenerateResponseConverter[WorkflowAppBlockingResponse]):
     @classmethod
+    @override
     def convert_blocking_full_response(cls, blocking_response: WorkflowAppBlockingResponse) -> dict[str, object]:
         """
         Convert blocking full response.
@@ -24,6 +25,7 @@ class WorkflowAppGenerateResponseConverter(AppGenerateResponseConverter[Workflow
         return dict(blocking_response.model_dump())
 
     @classmethod
+    @override
     def convert_blocking_simple_response(cls, blocking_response: WorkflowAppBlockingResponse) -> dict[str, object]:
         """
         Convert blocking simple response.
@@ -33,6 +35,7 @@ class WorkflowAppGenerateResponseConverter(AppGenerateResponseConverter[Workflow
         return cls.convert_blocking_full_response(blocking_response)
 
     @classmethod
+    @override
     def convert_stream_full_response(
         cls, stream_response: Generator[AppStreamResponse, None, None]
     ) -> Generator[dict[str, Any] | str, None, None]:
@@ -66,6 +69,7 @@ class WorkflowAppGenerateResponseConverter(AppGenerateResponseConverter[Workflow
             yield response_chunk
 
     @classmethod
+    @override
     def convert_stream_simple_response(
         cls, stream_response: Generator[AppStreamResponse, None, None]
     ) -> Generator[dict[str, Any] | str, None, None]:


### PR DESCRIPTION
## Description

Add missing `@override` decorators to `WorkflowAppGenerateResponseConverter` in the pipeline module.

This PR addresses part of #36406 by adding `@override` decorators to the following methods:
- `convert_blocking_full_response`
- `convert_blocking_simple_response`
- `convert_stream_full_response`
- `convert_stream_simple_response`

## Changes

- Added `from typing import override` to imports
- Added `@override` decorator to all 4 methods that override parent class methods

## Related Issues

Refs #36406