### PR TITLE
chore: inject SQLAlchemy session in agent roster controllers

### DIFF
--- a/api/controllers/console/agent/roster.py
+++ b/api/controllers/console/agent/roster.py
@@ -3,11 +3,12 @@ from uuid import UUID
 from flask import request
 from flask_restx import Resource
 from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
 
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from controllers.console import console_ns
+from controllers.console.app.wraps import with_session
 from controllers.console.wraps import account_initialization_required, edit_permission_required, setup_required
-from extensions.ext_database import db
 from fields.agent_fields import (
     AgentConfigSnapshotDetailResponse,
     AgentConfigSnapshotListResponse,
@@ -47,8 +48,8 @@ register_response_schema_models(
 )
 
 
-def _agent_roster_service() -> AgentRosterService:
-    return AgentRosterService(db.session)
+def _agent_roster_service(session: Session) -> AgentRosterService:
+    return AgentRosterService(session)
 
 
 @console_ns.route("/agents")
@@ -58,12 +59,13 @@ class AgentRosterListApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
-    def get(self):
+    @with_session(write=False)
+    def get(self, session: Session):
         _, tenant_id = current_account_with_tenant()
         query = RosterListQuery.model_validate(request.args.to_dict(flat=True))
         return dump_response(
             AgentRosterListResponse,
-            _agent_roster_service().list_roster_agents(
+            _agent_roster_service(session).list_roster_agents(
                 tenant_id=tenant_id, page=query.page, limit=query.limit, keyword=query.keyword
             ),
         )
@@ -74,10 +76,11 @@ class AgentRosterListApi(Resource):
     @login_required
     @account_initialization_required
     @edit_permission_required
-    def post(self):
+    @with_session
+    def post(self, session: Session):
         account, tenant_id = current_account_with_tenant()
         payload = RosterAgentCreatePayload.model_validate(console_ns.payload or {})
-        service = _agent_roster_service()
+        service = _agent_roster_service(session)
         agent = service.create_roster_agent(tenant_id=tenant_id, account_id=account.id, payload=payload)
         return dump_response(
             AgentRosterResponse,
@@ -92,12 +95,13 @@ class AgentInviteOptionsApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
-    def get(self):
+    @with_session(write=False)
+    def get(self, session: Session):
         _, tenant_id = current_account_with_tenant()
         query = AgentInviteOptionsQuery.model_validate(request.args.to_dict(flat=True))
         return dump_response(
             AgentInviteOptionsResponse,
-            _agent_roster_service().list_invite_options(
+            _agent_roster_service(session).list_invite_options(
                 tenant_id=tenant_id,
                 page=query.page,
                 limit=query.limit,
@@ -113,11 +117,12 @@ class AgentRosterDetailApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
-    def get(self, agent_id: UUID):
+    @with_session(write=False)
+    def get(self, session: Session, agent_id: UUID):
         _, tenant_id = current_account_with_tenant()
         return dump_response(
             AgentRosterResponse,
-            _agent_roster_service().get_roster_agent_detail(tenant_id=tenant_id, agent_id=str(agent_id)),
+            _agent_roster_service(session).get_roster_agent_detail(tenant_id=tenant_id, agent_id=str(agent_id)),
         )
 
     @console_ns.expect(console_ns.models[RosterAgentUpdatePayload.__name__])
@@ -126,12 +131,13 @@ class AgentRosterDetailApi(Resource):
     @login_required
     @account_initialization_required
     @edit_permission_required
-    def patch(self, agent_id: UUID):
+    @with_session
+    def patch(self, session: Session, agent_id: UUID):
         account, tenant_id = current_account_with_tenant()
         payload = RosterAgentUpdatePayload.model_validate(console_ns.payload or {})
         return dump_response(
             AgentRosterResponse,
-            _agent_roster_service().update_roster_agent(
+            _agent_roster_service(session).update_roster_agent(
                 tenant_id=tenant_id, agent_id=str(agent_id), account_id=account.id, payload=payload
             ),
         )
@@ -141,9 +147,12 @@ class AgentRosterDetailApi(Resource):
     @login_required
     @account_initialization_required
     @edit_permission_required
-    def delete(self, agent_id: UUID):
+    @with_session
+    def delete(self, session: Session, agent_id: UUID):
         account, tenant_id = current_account_with_tenant()
-        _agent_roster_service().archive_roster_agent(tenant_id=tenant_id, agent_id=str(agent_id), account_id=account.id)
+        _agent_roster_service(session).archive_roster_agent(
+            tenant_id=tenant_id, agent_id=str(agent_id), account_id=account.id
+        )
         return "", 204
 
 
@@ -153,11 +162,12 @@ class AgentRosterVersionsApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
-    def get(self, agent_id: UUID):
+    @with_session(write=False)
+    def get(self, session: Session, agent_id: UUID):
         _, tenant_id = current_account_with_tenant()
         return dump_response(
             AgentConfigSnapshotListResponse,
-            {"data": _agent_roster_service().list_agent_versions(tenant_id=tenant_id, agent_id=str(agent_id))},
+            {"data": _agent_roster_service(session).list_agent_versions(tenant_id=tenant_id, agent_id=str(agent_id))},
         )
 
 
@@ -167,11 +177,12 @@ class AgentRosterVersionDetailApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
-    def get(self, agent_id: UUID, version_id: UUID):
+    @with_session(write=False)
+    def get(self, session: Session, agent_id: UUID, version_id: UUID):
         _, tenant_id = current_account_with_tenant()
         return dump_response(
             AgentConfigSnapshotDetailResponse,
-            _agent_roster_service().get_agent_version_detail(
+            _agent_roster_service(session).get_agent_version_detail(
                 tenant_id=tenant_id,
                 agent_id=str(agent_id),
                 version_id=str(version_id),

--- a/api/services/agent/roster_service.py
+++ b/api/services/agent/roster_service.py
@@ -170,7 +170,6 @@ class AgentRosterService:
         try:
             self._session.flush()
         except IntegrityError as exc:
-            self._session.rollback()
             raise AgentNameConflictError() from exc
 
         version = AgentConfigSnapshot(
@@ -197,9 +196,8 @@ class AgentRosterService:
         agent.active_config_snapshot_id = version.id
 
         try:
-            self._session.commit()
+            self._session.flush()
         except IntegrityError as exc:
-            self._session.rollback()
             raise AgentNameConflictError() from exc
         return agent
 
@@ -223,9 +221,8 @@ class AgentRosterService:
         agent.updated_by = account_id
 
         try:
-            self._session.commit()
+            self._session.flush()
         except IntegrityError as exc:
-            self._session.rollback()
             raise AgentNameConflictError() from exc
         return self.get_roster_agent_detail(tenant_id=tenant_id, agent_id=agent_id)
 
@@ -237,7 +234,7 @@ class AgentRosterService:
         agent.archived_by = account_id
         agent.archived_at = naive_utc_now()
         agent.updated_by = account_id
-        self._session.commit()
+        self._session.flush()
 
     def list_agent_versions(self, *, tenant_id: str, agent_id: str) -> list[dict[str, Any]]:
         self._get_agent(tenant_id=tenant_id, agent_id=agent_id, roster_only=True)

--- a/api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
+++ b/api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
@@ -30,6 +30,15 @@ def _unwrap(method):
     return method
 
 
+@pytest.fixture
+def roster_session() -> SimpleNamespace:
+    return SimpleNamespace()
+
+
+def _call_roster(method, api_instance, session, *args, **kwargs):
+    return _unwrap(method)(api_instance, session, *args, **kwargs)
+
+
 def _agent_response(agent_id: str = "agent-1") -> dict:
     return {
         "id": agent_id,
@@ -125,7 +134,7 @@ def patch_account_context(monkeypatch, account):
     monkeypatch.setattr(composer_controller, "current_account_with_tenant", lambda: (account, "tenant-1"))
 
 
-def test_roster_list_get_parses_query_and_calls_service(app, monkeypatch):
+def test_roster_list_get_parses_query_and_calls_service(app, monkeypatch, roster_session):
     captured = {}
 
     def list_roster_agents(_self, **kwargs):
@@ -135,13 +144,13 @@ def test_roster_list_get_parses_query_and_calls_service(app, monkeypatch):
     monkeypatch.setattr(roster_controller.AgentRosterService, "list_roster_agents", list_roster_agents)
 
     with app.test_request_context("/console/api/agents?page=2&limit=5&keyword=analyst"):
-        result = _unwrap(AgentRosterListApi.get)(AgentRosterListApi())
+        result = _call_roster(AgentRosterListApi.get, AgentRosterListApi(), roster_session)
 
     assert result["page"] == 2
     assert captured == {"tenant_id": "tenant-1", "page": 2, "limit": 5, "keyword": "analyst"}
 
 
-def test_roster_list_post_creates_agent_and_returns_detail(app, monkeypatch):
+def test_roster_list_post_creates_agent_and_returns_detail(app, monkeypatch, roster_session):
     created_agent = SimpleNamespace(id="agent-1")
     monkeypatch.setattr(
         roster_controller.AgentRosterService,
@@ -155,14 +164,14 @@ def test_roster_list_post_creates_agent_and_returns_detail(app, monkeypatch):
     )
 
     with app.test_request_context(json={"name": "Analyst", "agent_soul": {"prompt": {"system_prompt": "x"}}}):
-        result, status = _unwrap(AgentRosterListApi.post)(AgentRosterListApi())
+        result, status = _call_roster(AgentRosterListApi.post, AgentRosterListApi(), roster_session)
 
     assert status == 201
     assert result["id"] == "agent-1"
     assert result["agent_kind"] == "dify_agent"
 
 
-def test_invite_options_get_parses_app_id(app, monkeypatch):
+def test_invite_options_get_parses_app_id(app, monkeypatch, roster_session):
     captured = {}
 
     def list_invite_options(_self, **kwargs):
@@ -172,13 +181,13 @@ def test_invite_options_get_parses_app_id(app, monkeypatch):
     monkeypatch.setattr(roster_controller.AgentRosterService, "list_invite_options", list_invite_options)
 
     with app.test_request_context("/console/api/agents/invite-options?page=1&limit=10&app_id=app-1"):
-        result = _unwrap(AgentInviteOptionsApi.get)(AgentInviteOptionsApi())
+        result = _call_roster(AgentInviteOptionsApi.get, AgentInviteOptionsApi(), roster_session)
 
     assert result == {"data": [], "page": 1, "limit": 10, "total": 0, "has_more": False}
     assert captured == {"tenant_id": "tenant-1", "page": 1, "limit": 10, "keyword": None, "app_id": "app-1"}
 
 
-def test_roster_detail_patch_delete_and_versions_call_services(app, monkeypatch):
+def test_roster_detail_patch_delete_and_versions_call_services(app, monkeypatch, roster_session):
     agent_id = "00000000-0000-0000-0000-000000000001"
     version_id = "00000000-0000-0000-0000-000000000002"
     archived = {}
@@ -225,13 +234,23 @@ def test_roster_detail_patch_delete_and_versions_call_services(app, monkeypatch)
         },
     )
 
-    assert _unwrap(AgentRosterDetailApi.get)(AgentRosterDetailApi(), agent_id)["id"] == agent_id
+    api = AgentRosterDetailApi()
+    assert _call_roster(AgentRosterDetailApi.get, api, roster_session, agent_id)["id"] == agent_id
     with app.test_request_context(json={"description": "updated"}):
-        assert _unwrap(AgentRosterDetailApi.patch)(AgentRosterDetailApi(), agent_id)["description"] == "updated"
-    assert _unwrap(AgentRosterDetailApi.delete)(AgentRosterDetailApi(), agent_id) == ("", 204)
+        assert _call_roster(AgentRosterDetailApi.patch, api, roster_session, agent_id)["description"] == "updated"
+    assert _call_roster(AgentRosterDetailApi.delete, api, roster_session, agent_id) == ("", 204)
     assert archived["account_id"] == "account-1"
-    assert _unwrap(AgentRosterVersionsApi.get)(AgentRosterVersionsApi(), agent_id)["data"][0]["id"] == "version-1"
-    version_detail = _unwrap(AgentRosterVersionDetailApi.get)(AgentRosterVersionDetailApi(), agent_id, version_id)
+    versions_api = AgentRosterVersionsApi()
+    assert (
+        _call_roster(AgentRosterVersionsApi.get, versions_api, roster_session, agent_id)["data"][0]["id"] == "version-1"
+    )
+    version_detail = _call_roster(
+        AgentRosterVersionDetailApi.get,
+        AgentRosterVersionDetailApi(),
+        roster_session,
+        agent_id,
+        version_id,
+    )
     assert version_detail["id"] == version_id
     assert version_detail["agent_id"] == agent_id
 

--- a/api/tests/unit_tests/services/agent/test_agent_services.py
+++ b/api/tests/unit_tests/services/agent/test_agent_services.py
@@ -560,6 +560,8 @@ def test_roster_update_archive_versions_and_detail(monkeypatch):
     assert agent.status == AgentStatus.ARCHIVED
     assert versions[0]["id"] == "version-2"
     assert detail["config_snapshot"] == {"prompt": {}}
+    assert fake_session.commits == 0
+    assert fake_session.flushes == 2
 
 
 def test_roster_create_detail_and_lookup_helpers(monkeypatch):
@@ -598,6 +600,8 @@ def test_roster_create_detail_and_lookup_helpers(monkeypatch):
     assert found_agent.id == "agent-1"
     assert found_version.id == "version-1"
     assert loaded_versions["version-1"].agent_id == "agent-1"
+    assert fake_session.commits == 0
+    assert fake_session.flushes == 3
 
 
 def test_validator_dict_helpers_wrap_validation_errors():


### PR DESCRIPTION
Part of #36544

> [!IMPORTANT]
> - I have read [CONTRIBUTING.md](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md).
> - Associated issue: #36544 (session injection migration).
> - Issue has no formal assignee; I claimed the agent roster slice in a comment on the issue to avoid overlap with other batches.

## Summary

Migrates the **agent roster** console API to explicit SQLAlchemy session injection (`@with_session` from #36545 / `controllers/console/app/wraps.py`) and aligns `AgentRosterService` with the decorator’s transaction model.

### Controllers (`api/controllers/console/agent/roster.py`)

- Replaces `AgentRosterService(db.session)` with request-scoped `Session` injection
- **GET** handlers use `@with_session(write=False)`
- **POST / PATCH / DELETE** use `@with_session` (write; outer `begin()` commits on successful handler exit)
- Roster unit tests pass injected `session` into unwrapped handlers via `_call_roster` / `_unwrap`

### Service (`api/services/agent/roster_service.py`)

- Write paths use **`flush()`** instead of **`commit()`** / in-service **`rollback()`**
- The caller (`@with_session` on write handlers) owns the commit
- Fixes a transaction issue on write routes: service-level `commit()` inside `begin()` ended the transaction before follow-up queries (e.g. POST `create_roster_agent` → `get_roster_agent_detail`, PATCH `update_roster_agent` → detail load)
- Service unit tests assert write paths do not call `commit()`

**Scope:** Agent roster controller + service only — does not overlap with `console/app`, `service_api`, `inner_api`, or explore work on #36544. No `wraps.py` changes; composer flows still use `db.session`.

**Motivation:** Clear transaction boundaries, testability, and alignment with the ongoing Flask session injection effort (#36544), without changing HTTP API behavior.

**Dependencies:** None.

## Screenshots

| Before | After |
|--------|-------|
| N/A — backend-only, no UI change | N/A |

## Checklist

- [ ] This change requires a documentation update ([Dify Document](https://github.com/langgenius/dify-docs)) — **N/A**
- [x] There was prior discussion on the issue (slice claim comment).
- [x] Tests added/updated for this change.
- [x] Single atomic change (roster controller + roster service + unit tests)
- [ ] Documentation updated — **N/A**
- [x] I ran `make lint && make type-check` and targeted unit tests (backend). Frontend checks not applicable.

## Validation plan

```bash
uv run --project api --dev pytest api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py api/tests/unit_tests/services/agent/test_agent_services.py
# 28 passed, 3 warnings

uv run --project api --dev ruff check api/controllers/console/agent/roster.py api/services/agent/roster_service.py api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py api/tests/unit_tests/services/agent/test_agent_services.py
# All checks passed!
```

- [x] Roster controller + service unit tests
- [x] `make lint` / `make type-check`