### PR TITLE
refactor: convert isinstance chains to match/case syntax

### DIFF
--- a/api/core/app/apps/base_app_queue_manager.py
+++ b/api/core/app/apps/base_app_queue_manager.py
@@ -209,14 +209,15 @@ class AppQueueManager(ABC):
 
     def _check_for_sqlalchemy_models(self, data: Any):
         # from entity to dict or list
-        if isinstance(data, dict):
-            for value in data.values():
-                self._check_for_sqlalchemy_models(value)
-        elif isinstance(data, list):
-            for item in data:
-                self._check_for_sqlalchemy_models(item)
-        else:
-            if isinstance(data, DeclarativeMeta) or hasattr(data, "_sa_instance_state"):
-                raise TypeError(
-                    "Critical Error: Passing SQLAlchemy Model instances that cause thread safety issues is not allowed."
-                )
+        match data:
+            case dict():
+                for value in data.values():
+                    self._check_for_sqlalchemy_models(value)
+            case list():
+                for item in data:
+                    self._check_for_sqlalchemy_models(item)
+            case _:
+                if isinstance(data, DeclarativeMeta) or hasattr(data, "_sa_instance_state"):
+                    raise TypeError(
+                        "Critical Error: Passing SQLAlchemy Model instances that cause thread safety issues is not allowed."
+                    )

--- a/api/core/app/apps/base_app_queue_manager.py
+++ b/api/core/app/apps/base_app_queue_manager.py
@@ -219,5 +219,6 @@ class AppQueueManager(ABC):
             case _:
                 if isinstance(data, DeclarativeMeta) or hasattr(data, "_sa_instance_state"):
                     raise TypeError(
-                        "Critical Error: Passing SQLAlchemy Model instances that cause thread safety issues is not allowed."
+                        "Critical Error: Passing SQLAlchemy Model instances that"
+                        " cause thread safety issues is not allowed."
                     )

--- a/api/core/app/apps/pipeline/generate_response_converter.py
+++ b/api/core/app/apps/pipeline/generate_response_converter.py
@@ -1,5 +1,5 @@
 from collections.abc import Generator
-from typing import Any, cast
+from typing import Any, cast, override
 
 from core.app.apps.base_app_generate_response_converter import AppGenerateResponseConverter
 from core.app.entities.task_entities import (
@@ -15,6 +15,7 @@ from core.app.entities.task_entities import (
 
 class WorkflowAppGenerateResponseConverter(AppGenerateResponseConverter[WorkflowAppBlockingResponse]):
     @classmethod
+    @override
     def convert_blocking_full_response(cls, blocking_response: WorkflowAppBlockingResponse) -> dict[str, object]:
         """
         Convert blocking full response.
@@ -24,6 +25,7 @@ class WorkflowAppGenerateResponseConverter(AppGenerateResponseConverter[Workflow
         return dict(blocking_response.model_dump())
 
     @classmethod
+    @override
     def convert_blocking_simple_response(cls, blocking_response: WorkflowAppBlockingResponse) -> dict[str, object]:
         """
         Convert blocking simple response.
@@ -33,6 +35,7 @@ class WorkflowAppGenerateResponseConverter(AppGenerateResponseConverter[Workflow
         return cls.convert_blocking_full_response(blocking_response)
 
     @classmethod
+    @override
     def convert_stream_full_response(
         cls, stream_response: Generator[AppStreamResponse, None, None]
     ) -> Generator[dict[str, Any] | str, None, None]:
@@ -66,6 +69,7 @@ class WorkflowAppGenerateResponseConverter(AppGenerateResponseConverter[Workflow
             yield response_chunk
 
     @classmethod
+    @override
     def convert_stream_simple_response(
         cls, stream_response: Generator[AppStreamResponse, None, None]
     ) -> Generator[dict[str, Any] | str, None, None]:

--- a/api/core/logging/filters.py
+++ b/api/core/logging/filters.py
@@ -83,15 +83,16 @@ class IdentityContextFilter(logging.Filter):
 
             identity: IdentityDict = {}
 
-            if isinstance(user, Account):
-                if user.current_tenant_id:
-                    identity["tenant_id"] = user.current_tenant_id
-                identity["user_id"] = user.id
-                identity["user_type"] = "account"
-            elif isinstance(user, EndUser):
-                identity["tenant_id"] = user.tenant_id
-                identity["user_id"] = user.id
-                identity["user_type"] = user.type or "end_user"
+            match user:
+                case Account():
+                    if user.current_tenant_id:
+                        identity["tenant_id"] = user.current_tenant_id
+                    identity["user_id"] = user.id
+                    identity["user_type"] = "account"
+                case EndUser():
+                    identity["tenant_id"] = user.tenant_id
+                    identity["user_id"] = user.id
+                    identity["user_type"] = user.type or "end_user"
 
             return identity
         except Exception:

--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -1525,16 +1525,18 @@ class DatasetRetrieval:
                 filters.append(json_field.like(f"%{escaped_value}", escape="\\"))
 
             case "is" | "=":
-                if isinstance(value, str):
-                    filters.append(json_field == value)
-                elif isinstance(value, (int, float)):
-                    filters.append(DatasetDocument.doc_metadata[metadata_name].as_float() == value)
+                match value:
+                    case str():
+                        filters.append(json_field == value)
+                    case int() | float():
+                        filters.append(DatasetDocument.doc_metadata[metadata_name].as_float() == value)
 
             case "is not" | "≠":
-                if isinstance(value, str):
-                    filters.append(json_field != value)
-                elif isinstance(value, (int, float)):
-                    filters.append(DatasetDocument.doc_metadata[metadata_name].as_float() != value)
+                match value:
+                    case str():
+                        filters.append(json_field != value)
+                    case int() | float():
+                        filters.append(DatasetDocument.doc_metadata[metadata_name].as_float() != value)
 
             case "empty":
                 filters.append(DatasetDocument.doc_metadata[metadata_name].is_(None))
@@ -1554,12 +1556,13 @@ class DatasetRetrieval:
             case "≥" | ">=":
                 filters.append(DatasetDocument.doc_metadata[metadata_name].as_float() >= value)
             case "in" | "not in":
-                if isinstance(value, str):
-                    value_list = [v.strip() for v in value.split(",") if v.strip()]
-                elif isinstance(value, (list, tuple)):
-                    value_list = [str(v) for v in value if v is not None]
-                else:
-                    value_list = [str(value)] if value is not None else []
+                match value:
+                    case str():
+                        value_list = [v.strip() for v in value.split(",") if v.strip()]
+                    case list() | tuple():
+                        value_list = [str(v) for v in value if v is not None]
+                    case _:
+                        value_list = [str(value)] if value is not None else []
 
                 if not value_list:
                     # `field in []` is False, `field not in []` is True
@@ -1706,12 +1709,13 @@ class DatasetRetrieval:
         usage = None
         for result in invoke_result:
             text = result.delta.message.content
-            if isinstance(text, str):
-                full_text += text
-            elif isinstance(text, list):
-                for i in text:
-                    if i.data:
-                        full_text += i.data
+            match text:
+                case str():
+                    full_text += text
+                case list():
+                    for i in text:
+                        if i.data:
+                            full_text += i.data
 
             if not model:
                 model = result.model


### PR DESCRIPTION
## Description

Convert `if isinstance`/`elif isinstance` chains to Python 3.10+ structural pattern matching (`match`/`case`) for better readability and exhaustive type checking.

## Changes

- **api/core/logging/filters.py**: Convert `Account`/`EndUser` type dispatch to `match/case`
- **api/core/app/apps/base_app_queue_manager.py**: Convert `dict`/`list`/`DeclarativeMeta` check to `match/case`
- **api/core/rag/retrieval/dataset_retrieval.py**: Convert `str`/`int`/`float`/`list`/`tuple` patterns to `match/case`

## Related Issues

Refs #35902