### PR TITLE
chore: remove unnecessary | None type annotations

### DIFF
--- a/api/core/agent/base_agent_runner.py
+++ b/api/core/agent/base_agent_runner.py
@@ -118,7 +118,7 @@ class BaseAgentRunner(AppRunner):
         features = model_schema.features if model_schema and model_schema.features else []
         self.stream_tool_call = ModelFeature.STREAM_TOOL_CALL in features
         self.files = application_generate_entity.files if ModelFeature.VISION in features else []
-        self.query: str | None = ""
+        self.query: str = ""
         self._current_thoughts: list[PromptMessage] = []
 
     def _repack_app_generate_entity(

--- a/api/core/app/app_config/entities.py
+++ b/api/core/app/app_config/entities.py
@@ -149,12 +149,12 @@ class DatasetRetrieveConfigEntity(BaseModel):
 
     retrieve_strategy: RetrieveStrategy
     top_k: int | None = None
-    score_threshold: float | None = 0.0
-    rerank_mode: str | None = "reranking_model"
+    score_threshold: float = 0.0
+    rerank_mode: str = "reranking_model"
     reranking_model: RerankingModelDict | None = None
     weights: WeightsDict | None = None
-    reranking_enabled: bool | None = True
-    metadata_filtering_mode: Literal["disabled", "automatic", "manual"] | None = "disabled"
+    reranking_enabled: bool = True
+    metadata_filtering_mode: Literal["disabled", "automatic", "manual"] = "disabled"
     metadata_model_config: ModelConfig | None = None
     metadata_filtering_conditions: MetadataFilteringCondition | None = None
 

--- a/api/core/app/entities/task_entities.py
+++ b/api/core/app/entities/task_entities.py
@@ -241,8 +241,8 @@ class WorkflowFinishStreamResponse(StreamResponse):
         created_by: Mapping[str, object] = Field(default_factory=dict)
         created_at: int
         finished_at: int | None
-        exceptions_count: int | None = 0
-        files: Sequence[Mapping[str, Any]] | None = []
+        exceptions_count: int = 0
+        files: Sequence[Mapping[str, Any]] = []
 
     event: StreamEvent = StreamEvent.WORKFLOW_FINISHED
     workflow_run_id: str
@@ -439,7 +439,7 @@ class NodeFinishStreamResponse(StreamResponse):
         execution_metadata: Mapping[WorkflowNodeExecutionMetadataKey, Any] | None = None
         created_at: int
         finished_at: int
-        files: Sequence[Mapping[str, Any]] | None = []
+        files: Sequence[Mapping[str, Any]] = []
         iteration_id: str | None = None
         loop_id: str | None = None
 
@@ -503,7 +503,7 @@ class NodeRetryStreamResponse(StreamResponse):
         execution_metadata: Mapping[WorkflowNodeExecutionMetadataKey, Any] | None = None
         created_at: int
         finished_at: int
-        files: Sequence[Mapping[str, Any]] | None = []
+        files: Sequence[Mapping[str, Any]] = []
         iteration_id: str | None = None
         loop_id: str | None = None
         retry_index: int = 0

--- a/api/core/callback_handler/agent_tool_callback_handler.py
+++ b/api/core/callback_handler/agent_tool_callback_handler.py
@@ -34,7 +34,7 @@ def print_text(text: str, color: str | None = None, end: str = "", file: TextIO 
 class DifyAgentCallbackHandler(BaseModel):
     """Callback Handler that prints to std out."""
 
-    color: str | None = ""
+    color: str = ""
     current_loop: int = 1
 
     def __init__(self, color: str | None = None):

--- a/api/core/datasource/entities/datasource_entities.py
+++ b/api/core/datasource/entities/datasource_entities.py
@@ -317,7 +317,7 @@ class WebSiteInfo(BaseModel):
     """
 
     status: str | None = Field(..., description="crawl job status")
-    web_info_list: list[WebSiteInfoDetail] | None = []
+    web_info_list: list[WebSiteInfoDetail] = []
     total: int | None = Field(default=0, description="The total number of websites")
     completed: int | None = Field(default=0, description="The number of completed websites")
 

--- a/api/core/rag/extractor/entity/extract_setting.py
+++ b/api/core/rag/extractor/entity/extract_setting.py
@@ -10,7 +10,7 @@ class NotionInfo(BaseModel):
     """
 
     credential_id: str | None = None
-    notion_workspace_id: str | None = ""
+    notion_workspace_id: str = ""
     notion_obj_id: str
     notion_page_type: str
     document: Document | None = None

--- a/api/core/workflow/nodes/knowledge_index/entities.py
+++ b/api/core/workflow/nodes/knowledge_index/entities.py
@@ -17,7 +17,7 @@ class RetrievalSetting(BaseModel):
 
     search_method: RetrievalMethod
     top_k: int
-    score_threshold: float | None = 0.5
+    score_threshold: float = 0.5
     score_threshold_enabled: bool = False
     reranking_mode: str = "reranking_model"
     reranking_enable: bool = True

--- a/api/core/workflow/nodes/knowledge_retrieval/entities.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/entities.py
@@ -43,7 +43,7 @@ class KnowledgeRetrievalNodeData(BaseNodeData):
     retrieval_mode: Literal["single", "multiple"]
     multiple_retrieval_config: MultipleRetrievalConfig | None = None
     single_retrieval_config: SingleRetrievalConfig | None = None
-    metadata_filtering_mode: Literal["disabled", "automatic", "manual"] | None = "disabled"
+    metadata_filtering_mode: Literal["disabled", "automatic", "manual"] = "disabled"
     metadata_model_config: ModelConfig | None = None
     metadata_filtering_conditions: MetadataFilteringCondition | None = None
     vision: VisionConfig = Field(default_factory=VisionConfig)


### PR DESCRIPTION
Remove redundant | None from type annotations where the variable always has a non-None default value.

Refs #35557