### PR TITLE
fix: parse JSON schema strings in workflow variables

### DIFF
--- a/api/core/app/app_config/workflow_ui_based_app/variables/manager.py
+++ b/api/core/app/app_config/workflow_ui_based_app/variables/manager.py
@@ -1,4 +1,6 @@
+import json
 import re
+from typing import Any
 
 from core.app.app_config.entities import RagPipelineVariableEntity
 from graphon.variables.input_entities import VariableEntity
@@ -6,6 +8,24 @@ from models.workflow import Workflow
 
 
 class WorkflowVariablesConfigManager:
+    @staticmethod
+    def _normalize_variable(variable: Any) -> Any:
+        if not isinstance(variable, dict):
+            return variable
+
+        json_schema = variable.get("json_schema")
+        if not isinstance(json_schema, str):
+            return variable
+
+        stripped = json_schema.strip()
+        normalized = dict(variable)
+        if not stripped:
+            normalized["json_schema"] = None
+            return normalized
+
+        normalized["json_schema"] = json.loads(stripped)
+        return normalized
+
     @classmethod
     def convert(cls, workflow: Workflow) -> list[VariableEntity]:
         """
@@ -20,7 +40,7 @@ class WorkflowVariablesConfigManager:
 
         # variables
         for variable in user_input_form:
-            variables.append(VariableEntity.model_validate(variable))
+            variables.append(VariableEntity.model_validate(cls._normalize_variable(variable)))
 
         return variables
 

--- a/api/tests/unit_tests/core/app/app_config/workflow_ui_based_app/test_workflow_ui_based_app_manager.py
+++ b/api/tests/unit_tests/core/app/app_config/workflow_ui_based_app/test_workflow_ui_based_app_manager.py
@@ -4,6 +4,7 @@ from pytest_mock import MockerFixture
 from core.app.app_config.workflow_ui_based_app.variables.manager import (
     WorkflowVariablesConfigManager,
 )
+from graphon.variables.input_entities import VariableEntityType
 
 # =============================
 # Fixtures
@@ -69,6 +70,38 @@ class TestWorkflowVariablesConfigManagerConvert:
         # Arrange
         mock_workflow.user_input_form.return_value = [{"invalid": "data"}]
         mock_variable_entity.model_validate.side_effect = ValueError("validation error")
+
+        # Act & Assert
+        with pytest.raises(ValueError):
+            WorkflowVariablesConfigManager.convert(mock_workflow)
+
+    def test_convert_parses_json_schema_string(self, mock_workflow):
+        # Arrange
+        mock_workflow.user_input_form.return_value = [
+            {
+                "variable": "profile",
+                "label": "Profile",
+                "type": VariableEntityType.JSON_OBJECT,
+                "json_schema": '{"type":"object","properties":{"age":{"type":"number"}}}',
+            }
+        ]
+
+        # Act
+        result = WorkflowVariablesConfigManager.convert(mock_workflow)
+
+        # Assert
+        assert result[0].json_schema == {"type": "object", "properties": {"age": {"type": "number"}}}
+
+    def test_convert_rejects_invalid_json_schema_string(self, mock_workflow):
+        # Arrange
+        mock_workflow.user_input_form.return_value = [
+            {
+                "variable": "profile",
+                "label": "Profile",
+                "type": VariableEntityType.JSON_OBJECT,
+                "json_schema": "{invalid-json-schema",
+            }
+        ]
 
         # Act & Assert
         with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- parse JSON schema strings before validating workflow input variables
- keep empty schema strings as unset values
- add regression coverage for valid and invalid string schemas

## To verify
- uv run --group dev pytest tests\unit_tests\core\app\app_config\workflow_ui_based_app\test_workflow_ui_based_app_manager.py -q
- uv run ruff check core\app\app_config\workflow_ui_based_app\variables\manager.py tests\unit_tests\core\app\app_config\workflow_ui_based_app\test_workflow_ui_based_app_manager.py
- git diff --check

Fixes #36766