### PR TITLE
fix: MCP search results include only MCP providers

### DIFF
--- a/web/app/components/tools/mcp/index.tsx
+++ b/web/app/components/tools/mcp/index.tsx
@@ -23,7 +23,7 @@ const MCPList = ({
   const filteredList = useMemo(() => {
     return list.filter((collection) => {
       if (searchText)
-        return Object.values(collection.name).some(value => (value as string).toLowerCase().includes(searchText.toLowerCase()))
+        return collection.type === 'mcp' && Object.values(collection.name).some(value => (value as string).toLowerCase().includes(searchText.toLowerCase()))
       return collection.type === 'mcp'
     }) as ToolWithProvider[]
   }, [list, searchText])


### PR DESCRIPTION
## Summary

Fixes #36647

When searching on the MCP list page, the \ilteredList\ memo was only checking the provider name against the search text without also filtering for \	ype === 'mcp'\. This caused non-MCP tools (like built-in tools) to also appear in the MCP search results.

## Fix

Added \collection.type === 'mcp'\ check to the search filter condition. The MCP list now only shows MCP-type providers regardless of whether a search is active.

## Testing

- [ ] Open MCP tools page, search for a common term - results should only show MCP tools
- [ ] Verify non-MCP tools do not appear in search results
- [ ] Verify filtering still works correctly when no search text is entered