### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in Dify, please report it privately through GitHub Security Advisories:
+
+https://github.com/langgenius/dify/security/advisories/new
+
+Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.
+
+When submitting a report, include as much relevant information as you can safely provide, such as:
+
+- A description of the vulnerability
+- Steps to reproduce, if safe to share privately
+- Affected components, versions, or configurations
+- Potential impact
+- Any suggested mitigation or fix, if available
+
+The maintainers will review reports submitted through GitHub Security Advisories and coordinate follow-up there.
+
+## Public Disclosure
+
+Please avoid publicly disclosing details of a vulnerability until it has been reviewed and, where appropriate, a fix or mitigation has been made available.
+
+## Security Updates
+
+Security fixes may be released through normal project releases or other appropriate channels. Users are encouraged to keep Dify deployments up to date.


### PR DESCRIPTION
## Summary
- add SECURITY.md with the existing private GitHub Security Advisory reporting path
- ask reporters not to disclose vulnerabilities in public issues, discussions, or PRs
- add concise guidance on what to include in private reports and how disclosure/security updates are handled

Closes #36692.

## Verification
- Confirmed SECURITY.md and .github/SECURITY.md were not present via GitHub Contents API
- Confirmed the repo already exposes the private advisory contact link
- Ran git diff --check

This is documentation only. No credentials, account access, private data, or vulnerability details are included.