### PR TITLE
fix(web): read pnpm config env in standalone start

### DIFF
--- a/web/scripts/copy-and-start.mjs
+++ b/web/scripts/copy-and-start.mjs
@@ -94,8 +94,8 @@ const main = async () => {
   await copyAllDirs(standaloneRoot)
 
   // Start server
-  const port = process.env.npm_config_port || process.env.PORT || '3000'
-  const host = process.env.npm_config_host || process.env.HOSTNAME || '0.0.0.0'
+  const port = process.env.pnpm_config_port || process.env.PORT || '3000'
+  const host = process.env.pnpm_config_host || process.env.HOSTNAME || '0.0.0.0'
 
   console.info(`Starting server on ${host}:${port}`)
   console.debug(`Server script path: ${serverScriptPath}`)


### PR DESCRIPTION
## Summary
- read pnpm v11 config env vars for standalone start port and host
- keep PORT/HOSTNAME fallbacks unchanged

## Test
- pnpm eslint web/scripts/copy-and-start.mjs