### PR TITLE
test(e2e): add expand beginner app types step to workflow app creation

### DIFF
--- a/e2e/features/apps/create-workflow-app.feature
+++ b/e2e/features/apps/create-workflow-app.feature
@@ -4,6 +4,7 @@ Feature: Create Workflow app
     Given I am signed in as the default E2E admin
     When I open the apps console
     And I start creating a blank app
+    And I expand the beginner app types
     And I select the "Workflow" app type
     And I enter a unique E2E app name
     And I confirm app creation


### PR DESCRIPTION
Fixes #34278

Add missing 'I expand the beginner app types' step to the Workflow app creation feature file to match the pattern used by other app type tests.