### PR TITLE
fix(variables): parse json_schema string to dict before validation

### DIFF
--- a/api/core/app/app_config/workflow_ui_based_app/variables/manager.py
+++ b/api/core/app/app_config/workflow_ui_based_app/variables/manager.py
@@ -1,3 +1,4 @@
+import json
 import re
 
 from core.app.app_config.entities import RagPipelineVariableEntity
@@ -22,8 +23,6 @@ class WorkflowVariablesConfigManager:
         for variable in user_input_form:
             # Parse json_schema from string to dict if needed
             if variable.get("type") == "json_object" and isinstance(variable.get("json_schema"), str):
-                import json
-
                 try:
                     variable["json_schema"] = json.loads(variable["json_schema"])
                 except (json.JSONDecodeError, TypeError):

--- a/api/core/app/app_config/workflow_ui_based_app/variables/manager.py
+++ b/api/core/app/app_config/workflow_ui_based_app/variables/manager.py
@@ -20,6 +20,13 @@ class WorkflowVariablesConfigManager:
 
         # variables
         for variable in user_input_form:
+            # Parse json_schema from string to dict if needed
+            if variable.get("type") == "json_object" and isinstance(variable.get("json_schema"), str):
+                import json
+                try:
+                    variable["json_schema"] = json.loads(variable["json_schema"])
+                except (json.JSONDecodeError, TypeError):
+                    variable["json_schema"] = None
             variables.append(VariableEntity.model_validate(variable))
 
         return variables

--- a/api/core/app/app_config/workflow_ui_based_app/variables/manager.py
+++ b/api/core/app/app_config/workflow_ui_based_app/variables/manager.py
@@ -23,6 +23,7 @@ class WorkflowVariablesConfigManager:
             # Parse json_schema from string to dict if needed
             if variable.get("type") == "json_object" and isinstance(variable.get("json_schema"), str):
                 import json
+
                 try:
                     variable["json_schema"] = json.loads(variable["json_schema"])
                 except (json.JSONDecodeError, TypeError):


### PR DESCRIPTION
Fixes #36766

Workflow start variables with type json_object may have json_schema stored as a JSON string rather than a dict. This causes pydantic validation to fail with 'Input should be a valid dictionary'.

Add pre-validation parsing in WorkflowVariablesConfigManager.convert to detect string json_schema values and parse them before model_validate.