### PR TITLE
docs: add client state guidelines

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -13,6 +13,16 @@
 
 - When translating Figma designs to code, read `../packages/dify-ui/AGENTS.md` for the Figma `--radius/*` token to Tailwind `rounded-*` class mapping. The two scales are offset by one step.
 
+## Client State Management
+
+- Use local component state for state owned by one component.
+- Use feature-level Jotai atoms for simple client state shared across components in the same feature, especially when components need a shared source of truth, derived values, or shared actions.
+- Use existing feature stores for complex or high-frequency interaction state such as workflow canvas, drag, resize, and panel runtime state.
+- Use `@/hooks/use-local-storage` only for low-frequency, client-only persistence such as user preferences, dismissed notices, and UI defaults. Do not use localStorage as the live source of truth for app state.
+- For high-frequency interactions, update the feature state during interaction and persist storage only on commit or settled updates.
+- Do not access `localStorage`, `window.localStorage`, or `globalThis.localStorage` directly in app code; use the storage hook boundary and preserve existing raw/custom storage formats.
+- Do not add ad hoc global event listeners for shared state. Prefer atoms, existing stores, or a shared subscription hook so listeners are centralized and deduplicated.
+
 ## Automated Test Generation
 
 - Use `./docs/test.md` as the canonical instruction set for generating frontend automated tests.


### PR DESCRIPTION
## Summary
- Add frontend client state management guidance to web/AGENTS.md
- Clarify when to use local component state, feature-level Jotai atoms, feature stores, and the local storage hook
- Document that high-frequency interactions should persist storage only on commit/settled updates

## Tests
- Not run; documentation-only change