### PR TITLE
chore(api): adjust migration timestamp metadata for a1b2c3d4e5f6

### DIFF
--- a/api/migrations/versions/2026_06_01_0610-a1b2c3d4e5f6_add_credential_visibility.py
+++ b/api/migrations/versions/2026_06_01_0610-a1b2c3d4e5f6_add_credential_visibility.py
@@ -2,7 +2,7 @@
 
 Revision ID: a1b2c3d4e5f6
 Revises: 7885bd53f9a9
-Create Date: 2026-04-11 14:00:00.000000
+Create Date: 2026-06-01 06:10:00.000000
 
 """
 


### PR DESCRIPTION
**AI disclosure**: This PR was primarily drafted with Codex using GPT-5.4. I have reviewed and edited the final diff, and I am responsible for the content.

Closes #36909.

## Summary
- rename migration `a1b2c3d4e5f6` to use the UTC timestamp prefix `2026_06_01_0610`
- update the Alembic header `Create Date` to `2026-06-01 06:10:00.000000`

## Why
The revision is chained after `7885bd53f9a9` (`2026-05-27 09:53 UTC`), but its filename and header still used an earlier timestamp from `2026-04-11`. That made the migration history inconsistent with the actual merge time and harder to inspect chronologically.

The source PR was merged at `2026-06-01 14:10 +08:00`, which is `2026-06-01 06:10 UTC`, so the migration metadata should use that UTC time.

## Impact
This is a metadata-only fix. It does not change the revision id, `down_revision`, or schema behavior.
