### PR TITLE
refactor(web): migrate NOTE_SHOW_AUTHOR_STORAGE_KEY to useLocalStorage/useSetLocalStorage

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -4631,11 +4631,6 @@
       "count": 5
     }
   },
-  "web/app/components/workflow/note-node/hooks.ts": {
-    "no-restricted-globals": {
-      "count": 1
-    }
-  },
   "web/app/components/workflow/note-node/note-editor/index.tsx": {
     "no-barrel-files/no-barrel-files": {
       "count": 3
@@ -4663,9 +4658,6 @@
     }
   },
   "web/app/components/workflow/operator/hooks.ts": {
-    "no-restricted-globals": {
-      "count": 1
-    },
     "ts/no-explicit-any": {
       "count": 1
     }

--- a/web/app/components/workflow/note-node/hooks.ts
+++ b/web/app/components/workflow/note-node/hooks.ts
@@ -1,12 +1,14 @@
 import type { EditorState } from 'lexical'
 import type { NoteTheme } from './types'
 import { useCallback } from 'react'
+import { useSetLocalStorage } from '@/hooks/use-local-storage'
 import { useNodeDataUpdate, useWorkflowHistory, WorkflowHistoryEvent } from '../hooks'
 import { NOTE_SHOW_AUTHOR_STORAGE_KEY } from './constants'
 
 export const useNote = (id: string) => {
   const { handleNodeDataUpdateWithSyncDraft } = useNodeDataUpdate()
   const { saveStateToHistory } = useWorkflowHistory()
+  const setShowAuthorStorage = useSetLocalStorage<string>(NOTE_SHOW_AUTHOR_STORAGE_KEY, { raw: true })
 
   const handleThemeChange = useCallback((theme: NoteTheme) => {
     handleNodeDataUpdateWithSyncDraft({ id, data: { theme } })
@@ -21,10 +23,10 @@ export const useNote = (id: string) => {
   }, [handleNodeDataUpdateWithSyncDraft, id])
 
   const handleShowAuthorChange = useCallback((showAuthor: boolean) => {
-    localStorage.setItem(NOTE_SHOW_AUTHOR_STORAGE_KEY, String(showAuthor))
+    setShowAuthorStorage(String(showAuthor))
     handleNodeDataUpdateWithSyncDraft({ id, data: { showAuthor } })
     saveStateToHistory(WorkflowHistoryEvent.NoteChange, { nodeId: id })
-  }, [handleNodeDataUpdateWithSyncDraft, id, saveStateToHistory])
+  }, [handleNodeDataUpdateWithSyncDraft, id, saveStateToHistory, setShowAuthorStorage])
 
   return {
     handleThemeChange,

--- a/web/app/components/workflow/operator/hooks.ts
+++ b/web/app/components/workflow/operator/hooks.ts
@@ -1,6 +1,7 @@
 import type { NoteNodeType } from '../note-node/types'
 import { useCallback } from 'react'
 import { useAppContext } from '@/context/app-context'
+import { useLocalStorage } from '@/hooks/use-local-storage'
 import {
   CUSTOM_NOTE_NODE,
   NOTE_SHOW_AUTHOR_STORAGE_KEY,
@@ -12,6 +13,7 @@ import { generateNewNode } from '../utils'
 export const useOperator = () => {
   const workflowStore = useWorkflowStore()
   const { userProfile } = useAppContext()
+  const [showAuthorStorage] = useLocalStorage<string>(NOTE_SHOW_AUTHOR_STORAGE_KEY, '0', { raw: true })
 
   const handleAddNote = useCallback(() => {
     const { newNode } = generateNewNode({
@@ -23,7 +25,7 @@ export const useOperator = () => {
         text: '',
         theme: NoteTheme.blue,
         author: userProfile?.name || '',
-        showAuthor: localStorage.getItem(NOTE_SHOW_AUTHOR_STORAGE_KEY) !== 'false',
+        showAuthor: showAuthorStorage !== 'false',
         width: 240,
         height: 88,
         _isCandidate: true,
@@ -36,7 +38,7 @@ export const useOperator = () => {
     workflowStore.setState({
       candidateNode: newNode,
     })
-  }, [workflowStore, userProfile])
+  }, [workflowStore, userProfile, showAuthorStorage])
 
   return {
     handleAddNote,

--- a/web/app/components/workflow/operator/hooks.ts
+++ b/web/app/components/workflow/operator/hooks.ts
@@ -13,7 +13,7 @@ import { generateNewNode } from '../utils'
 export const useOperator = () => {
   const workflowStore = useWorkflowStore()
   const { userProfile } = useAppContext()
-  const [showAuthorStorage] = useLocalStorage<string>(NOTE_SHOW_AUTHOR_STORAGE_KEY, '0', { raw: true })
+  const [showAuthorStorage] = useLocalStorage<string>(NOTE_SHOW_AUTHOR_STORAGE_KEY, 'true', { raw: true })
 
   const handleAddNote = useCallback(() => {
     const { newNode } = generateNewNode({


### PR DESCRIPTION
## Summary

Migrates all direct `localStorage.getItem/setItem` calls for `NOTE_SHOW_AUTHOR_STORAGE_KEY` to `useLocalStorage` and `useSetLocalStorage` hooks from `@/hooks/use-local-storage`.

This is part of the broader refactor tracked in #36898 — one storage concern at a time.

## Changes

**2 source files** touched, both using `{ raw: true }` option for raw string storage:

### Setter-only (useSetLocalStorage)
- `web/app/components/workflow/note-node/hooks.ts` — replaced `localStorage.setItem` with `useSetLocalStorage<string>`

### Getter (useLocalStorage)
- `web/app/components/workflow/operator/hooks.ts` — replaced `localStorage.getItem` with `useLocalStorage<string>(key, '0', { raw: true })`, maintaining the existing `!== 'false'` check

## Checklist

- [x] TypeScript compiles with zero errors
- [x] All `localStorage.*NOTE_SHOW_AUTHOR_STORAGE_KEY` references in source files have been migrated

Closes #36898