### PR TITLE
fix(web): defer react-scan loader

### DIFF
--- a/web/app/components/devtools/react-scan/loader.tsx
+++ b/web/app/components/devtools/react-scan/loader.tsx
@@ -9,7 +9,9 @@ export function ReactScanLoader() {
     <Script
       src="//unpkg.com/react-scan/dist/auto.global.js"
       crossOrigin="anonymous"
-      strategy="beforeInteractive"
+      // React Scan recommends beforeInteractive to catch initial renders, but it
+      // can mismatch with Dify's inline attribution bootstrap during dev hydration.
+      strategy="afterInteractive"
     />
   )
 }


### PR DESCRIPTION
### Summary
- defer the dev-only react-scan script until after hydration
- document that react-scan recommends beforeInteractive, but it can conflict with Dify's inline attribution bootstrap during dev hydration

### Tests
- Not run (per request).
