### PR TITLE
refactor(web): migrate anthropic quota notice storage

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -5164,9 +5164,6 @@
     }
   },
   "web/context/provider-context-provider.tsx": {
-    "no-restricted-globals": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 1
     }

--- a/web/context/provider-context-provider.tsx
+++ b/web/context/provider-context-provider.tsx
@@ -15,6 +15,7 @@ import {
   ModelTypeEnum,
 } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import { ZENDESK_FIELD_IDS } from '@/config'
+import { useLocalStorage } from '@/hooks/use-local-storage'
 import { fetchCurrentPlanInfo } from '@/service/billing'
 import {
   useModelListByType,
@@ -37,6 +38,8 @@ const unlimitedMemberInviteLimit: MemberInviteLimit = {
   size: 0,
   limit: 0,
 }
+
+const ANTHROPIC_QUOTA_NOTICE_STORAGE_KEY = 'anthropic_quota_notice'
 
 const resolveMemberInviteLimit = (data: Awaited<ReturnType<typeof fetchCurrentPlanInfo>>): MemberInviteLimit => {
   if (!data)
@@ -154,8 +157,14 @@ export const ProviderContextProvider = ({
   // #endregion Zendesk conversation fields
 
   const { t } = useTranslation()
+  const [anthropicQuotaNotice, setAnthropicQuotaNotice] = useLocalStorage<string>(
+    ANTHROPIC_QUOTA_NOTICE_STORAGE_KEY,
+    'false',
+    { raw: true },
+  )
+
   useEffect(() => {
-    if (localStorage.getItem('anthropic_quota_notice') === 'true')
+    if (anthropicQuotaNotice === 'true')
       return
 
     if (dayjs().isAfter(dayjs('2025-03-17')))
@@ -166,14 +175,14 @@ export const ProviderContextProvider = ({
       if (anthropic && anthropic.system_configuration.current_quota_type === CurrentSystemQuotaTypeEnum.trial) {
         const quota = anthropic.system_configuration.quota_configurations.find(item => item.quota_type === anthropic.system_configuration.current_quota_type)
         if (quota && quota.is_valid && quota.quota_used < quota.quota_limit) {
-          localStorage.setItem('anthropic_quota_notice', 'true')
+          setAnthropicQuotaNotice('true')
           toast.info(t('provider.anthropicHosted.trialQuotaTip', { ns: 'common' }), {
             timeout: 60000,
           })
         }
       }
     }
-  }, [providersData, t])
+  }, [anthropicQuotaNotice, providersData, setAnthropicQuotaNotice, t])
 
   return (
     <ProviderContext.Provider value={{


### PR DESCRIPTION
Summary
- Part of #36898.
- Migrates the Anthropic trial quota notice storage flag from direct localStorage access to the shared useLocalStorage hook.

Reproduction
- The provider context reads the anthropic_quota_notice key to avoid showing the trial quota toast more than once.
- When the toast is shown, the same key is written to localStorage.

Root cause
- This component still used direct localStorage.getItem/setItem calls instead of the shared @/hooks/use-local-storage abstraction requested in #36898.

Changes
- Added a dedicated ANTHROPIC_QUOTA_NOTICE_STORAGE_KEY constant.
- Replaced direct reads with useLocalStorage<string>(..., { raw: true }).
- Replaced direct writes with the hook setter while preserving the existing raw string value semantics.

Tests
- git diff --check
- Parsed web/context/provider-context-provider.tsx with @babel/parser using TypeScript + JSX plugins.
- Attempted pnpm install --frozen-lockfile --ignore-scripts with Node 22.22.1 and pnpm 11.5.0; install was blocked by the repository trustPolicy/no-downgrade lockfile verification for existing lockfile entries, so full type-check could not be run locally.

Screenshots/Logs
- Not applicable; this is a small storage refactor with no intended UI change.