### PR TITLE
fix(contracts): include account avatar url in profile schema

### DIFF
--- a/api/controllers/console/workspace/account.py
+++ b/api/controllers/console/workspace/account.py
@@ -173,7 +173,6 @@ class CheckEmailUniquePayload(BaseModel):
 
 register_schema_models(
     console_ns,
-    AccountResponse,
     AccountInitPayload,
     AccountNamePayload,
     AccountAvatarPayload,
@@ -245,6 +244,7 @@ register_schema_models(
 )
 register_response_schema_models(
     console_ns,
+    AccountResponse,
     AvatarUrlResponse,
     SimpleResultDataResponse,
     SimpleResultResponse,

--- a/api/openapi/markdown/console-swagger.md
+++ b/api/openapi/markdown/console-swagger.md
@@ -10519,6 +10519,7 @@ Get banner list
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | avatar | string |  | No |
+| avatar_url | string |  | Yes |
 | created_at | integer |  | No |
 | email | string |  | Yes |
 | id | string |  | Yes |

--- a/packages/contracts/generated/api/console/account/types.gen.ts
+++ b/packages/contracts/generated/api/console/account/types.gen.ts
@@ -14,6 +14,7 @@ export type AccountAvatarPayload = {
 
 export type Account = {
   avatar?: string | null
+  readonly avatar_url: string | null
   created_at?: number | null
   email: string
   id: string
@@ -133,6 +134,20 @@ export type AccountIntegrateResponse = {
   is_bound: boolean
   link?: string | null
   provider: string
+}
+
+export type AccountWritable = {
+  avatar?: string | null
+  created_at?: number | null
+  email: string
+  id: string
+  interface_language?: string | null
+  interface_theme?: string | null
+  is_password_set: boolean
+  last_login_at?: number | null
+  last_login_ip?: string | null
+  name: string
+  timezone?: string | null
 }
 
 export type GetAccountAvatarData = {

--- a/packages/contracts/generated/api/console/account/zod.gen.ts
+++ b/packages/contracts/generated/api/console/account/zod.gen.ts
@@ -21,6 +21,7 @@ export const zAccountAvatarPayload = z.object({
  */
 export const zAccount = z.object({
   avatar: z.string().nullish(),
+  avatar_url: z.string().readonly().nullable(),
   created_at: z.int().nullish(),
   email: z.string(),
   id: z.string(),
@@ -203,6 +204,23 @@ export const zAccountIntegrateResponse = z.object({
  */
 export const zAccountIntegrateListResponse = z.object({
   data: z.array(zAccountIntegrateResponse),
+})
+
+/**
+ * Account
+ */
+export const zAccountWritable = z.object({
+  avatar: z.string().nullish(),
+  created_at: z.int().nullish(),
+  email: z.string(),
+  id: z.string(),
+  interface_language: z.string().nullish(),
+  interface_theme: z.string().nullish(),
+  is_password_set: z.boolean(),
+  last_login_at: z.int().nullish(),
+  last_login_ip: z.string().nullish(),
+  name: z.string(),
+  timezone: z.string().nullish(),
 })
 
 export const zGetAccountAvatarQuery = z.object({


### PR DESCRIPTION
## Summary
- register the account profile response model with response schema mode so serialized computed fields are included in OpenAPI
- regenerate the console account contract so Account includes avatar_url

## Tests
- uv run --project api pytest api/tests/unit_tests/controllers/common/test_schema.py api/tests/unit_tests/commands/test_generate_swagger_specs.py api/tests/unit_tests/controllers/test_swagger.py
- uv run --project api pytest api/tests/unit_tests/controllers/console/workspace/test_accounts.py
- pnpm --dir packages/contracts type-check
- pnpm -C web type-check