### PR TITLE
refactor(web): migrate NEED_REFRESH_APP_LIST_KEY to useLocalStorage hook (#36898)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -567,9 +567,6 @@
     }
   },
   "web/app/components/app/create-app-modal/index.tsx": {
-    "no-restricted-globals": {
-      "count": 1
-    },
     "no-restricted-imports": {
       "count": 1
     }
@@ -577,9 +574,6 @@
   "web/app/components/app/create-from-dsl-modal/index.tsx": {
     "erasable-syntax-only/enums": {
       "count": 1
-    },
-    "no-restricted-globals": {
-      "count": 2
     },
     "no-restricted-imports": {
       "count": 1
@@ -646,9 +640,6 @@
     }
   },
   "web/app/components/app/switch-app-modal/index.tsx": {
-    "no-restricted-globals": {
-      "count": 1
-    },
     "no-restricted-imports": {
       "count": 1
     },
@@ -684,15 +675,7 @@
       "count": 1
     }
   },
-  "web/app/components/apps/app-card.tsx": {
-    "no-restricted-globals": {
-      "count": 1
-    }
-  },
   "web/app/components/apps/list.tsx": {
-    "no-restricted-globals": {
-      "count": 2
-    },
     "no-restricted-imports": {
       "count": 1
     }

--- a/web/app/components/app/create-app-modal/index.tsx
+++ b/web/app/components/app/create-app-modal/index.tsx
@@ -17,9 +17,9 @@ import Divider from '@/app/components/base/divider'
 import { BubbleTextMod, ChatBot, ListSparkle, Logic } from '@/app/components/base/icons/src/vender/solid/communication'
 import Input from '@/app/components/base/input'
 import AppsFull from '@/app/components/billing/apps-full-in-dialog'
-import { NEED_REFRESH_APP_LIST_KEY } from '@/config'
 import { useAppContext } from '@/context/app-context'
 import { useProviderContext } from '@/context/provider-context'
+import { useSetLocalStorage } from '@/hooks/use-local-storage'
 import useTheme from '@/hooks/use-theme'
 import { useRouter } from '@/next/navigation'
 import { createApp } from '@/service/apps'
@@ -55,6 +55,7 @@ function CreateApp({ onClose, onSuccess, onCreateFromTemplate, defaultAppMode }:
   const { plan, enableBilling } = useProviderContext()
   const isAppsFull = (enableBilling && plan.usage.buildApps >= plan.total.buildApps)
   const { isCurrentWorkspaceEditor } = useAppContext()
+  const setNeedRefreshAppList = useSetLocalStorage<string>('NEED_REFRESH_APP_LIST_KEY', { raw: true })
 
   const isCreatingRef = useRef(false)
 
@@ -85,7 +86,7 @@ function CreateApp({ onClose, onSuccess, onCreateFromTemplate, defaultAppMode }:
       toast.success(t('newApp.appCreated', { ns: 'app' }))
       onSuccess()
       onClose()
-      localStorage.setItem(NEED_REFRESH_APP_LIST_KEY, '1')
+      setNeedRefreshAppList('1')
       getRedirection(isCurrentWorkspaceEditor, app, push)
     }
     catch (error) {

--- a/web/app/components/app/create-from-dsl-modal/index.tsx
+++ b/web/app/components/app/create-from-dsl-modal/index.tsx
@@ -13,9 +13,9 @@ import { useTranslation } from 'react-i18next'
 import Input from '@/app/components/base/input'
 import AppsFull from '@/app/components/billing/apps-full-in-dialog'
 import { usePluginDependencies } from '@/app/components/workflow/plugin-dependency/hooks'
-import { NEED_REFRESH_APP_LIST_KEY } from '@/config'
 import { useAppContext } from '@/context/app-context'
 import { useProviderContext } from '@/context/provider-context'
+import { useSetLocalStorage } from '@/hooks/use-local-storage'
 import {
   DSLImportMode,
   DSLImportStatus,
@@ -74,6 +74,7 @@ const CreateFromDSLModal = ({ show, onSuccess, onClose, activeTab = CreateFromDS
 
   const { isCurrentWorkspaceEditor } = useAppContext()
   const { plan, enableBilling } = useProviderContext()
+  const setNeedRefreshAppList = useSetLocalStorage<string>('NEED_REFRESH_APP_LIST_KEY', { raw: true })
   const isAppsFull = (enableBilling && plan.usage.buildApps >= plan.total.buildApps)
 
   const isCreatingRef = useRef(false)
@@ -124,7 +125,7 @@ const CreateFromDSLModal = ({ show, onSuccess, onClose, activeTab = CreateFromDS
             ? t('newApp.appCreateDSLWarning', { ns: 'app' })
             : undefined,
         })
-        localStorage.setItem(NEED_REFRESH_APP_LIST_KEY, '1')
+        setNeedRefreshAppList('1')
         if (app_id)
           await handleCheckPluginDependencies(app_id)
         getRedirection(isCurrentWorkspaceEditor, { id: app_id!, mode: app_mode }, push)
@@ -178,7 +179,7 @@ const CreateFromDSLModal = ({ show, onSuccess, onClose, activeTab = CreateFromDS
         toast.success(t('newApp.appCreated', { ns: 'app' }))
         if (app_id)
           await handleCheckPluginDependencies(app_id)
-        localStorage.setItem(NEED_REFRESH_APP_LIST_KEY, '1')
+        setNeedRefreshAppList('1')
         getRedirection(isCurrentWorkspaceEditor, { id: app_id!, mode: app_mode }, push)
       }
       else if (status === DSLImportStatus.FAILED) {

--- a/web/app/components/app/switch-app-modal/index.tsx
+++ b/web/app/components/app/switch-app-modal/index.tsx
@@ -23,9 +23,9 @@ import AppIcon from '@/app/components/base/app-icon'
 import { AlertTriangle } from '@/app/components/base/icons/src/vender/solid/alertsAndFeedback'
 import Input from '@/app/components/base/input'
 import AppsFull from '@/app/components/billing/apps-full-in-dialog'
-import { NEED_REFRESH_APP_LIST_KEY } from '@/config'
 import { useAppContext } from '@/context/app-context'
 import { useProviderContext } from '@/context/provider-context'
+import { useSetLocalStorage } from '@/hooks/use-local-storage'
 import { useRouter } from '@/next/navigation'
 import { deleteApp, switchApp } from '@/service/apps'
 import { AppModeEnum } from '@/types/app'
@@ -47,6 +47,7 @@ const SwitchAppModal = ({ show, appDetail, inAppDetail = false, onSuccess, onClo
 
   const { isCurrentWorkspaceEditor } = useAppContext()
   const { plan, enableBilling } = useProviderContext()
+  const setNeedRefreshAppList = useSetLocalStorage<string>('NEED_REFRESH_APP_LIST_KEY', { raw: true })
   const isAppsFull = (enableBilling && plan.usage.buildApps >= plan.total.buildApps)
 
   const [showAppIconPicker, setShowAppIconPicker] = useState(false)
@@ -78,7 +79,7 @@ const SwitchAppModal = ({ show, appDetail, inAppDetail = false, onSuccess, onClo
         setAppDetail()
       if (removeOriginal)
         await deleteApp(appDetail.id)
-      localStorage.setItem(NEED_REFRESH_APP_LIST_KEY, '1')
+      setNeedRefreshAppList('1')
       getRedirection(
         isCurrentWorkspaceEditor,
         {

--- a/web/app/components/apps/app-card.tsx
+++ b/web/app/components/apps/app-card.tsx
@@ -36,12 +36,12 @@ import { Trans, useTranslation } from 'react-i18next'
 import { AppTypeIcon } from '@/app/components/app/type-selector'
 import AppIcon from '@/app/components/base/app-icon'
 import { UserAvatarList } from '@/app/components/base/user-avatar-list'
-import { NEED_REFRESH_APP_LIST_KEY } from '@/config'
 import { useAppContext } from '@/context/app-context'
 import { useProviderContext } from '@/context/provider-context'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { AppCardTags } from '@/features/tag-management/components/app-card-tags'
 import { useAsyncWindowOpen } from '@/hooks/use-async-window-open'
+import { useSetLocalStorage } from '@/hooks/use-local-storage'
 import { AccessMode } from '@/models/access-control'
 import dynamic from '@/next/dynamic'
 import { useRouter } from '@/next/navigation'
@@ -213,6 +213,7 @@ const AppCard = ({ app, onlineUsers = [], onRefresh, onOpenTagManagement = () =>
   const { isCurrentWorkspaceEditor } = useAppContext()
   const { onPlanInfoChanged } = useProviderContext()
   const { push } = useRouter()
+  const setNeedRefreshAppList = useSetLocalStorage<string>('NEED_REFRESH_APP_LIST_KEY', { raw: true })
 
   const [showEditModal, setShowEditModal] = useState(false)
   const [showDuplicateModal, setShowDuplicateModal] = useState(false)
@@ -334,7 +335,7 @@ const AppCard = ({ app, onlineUsers = [], onRefresh, onOpenTagManagement = () =>
       })
       setShowDuplicateModal(false)
       toast.success(t('newApp.appCreated', { ns: 'app' }))
-      localStorage.setItem(NEED_REFRESH_APP_LIST_KEY, '1')
+      setNeedRefreshAppList('1')
       if (onRefresh)
         onRefresh()
       onPlanInfoChanged()

--- a/web/app/components/apps/list.tsx
+++ b/web/app/components/apps/list.tsx
@@ -10,10 +10,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Input from '@/app/components/base/input'
 import TabSliderNew from '@/app/components/base/tab-slider-new'
-import { NEED_REFRESH_APP_LIST_KEY } from '@/config'
 import { useAppContext } from '@/context/app-context'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { TagFilter } from '@/features/tag-management/components/tag-filter'
+import { useLocalStorage } from '@/hooks/use-local-storage'
 import { CheckModal } from '@/hooks/use-pay'
 import dynamic from '@/next/dynamic'
 import { usePathname, useRouter, useSearchParams } from '@/next/navigation'
@@ -56,6 +56,7 @@ const List: FC<Props> = ({
     setKeywords,
     setIsCreatedByMe,
   } = useAppsQueryState()
+  const [needRefreshAppList, setNeedRefreshAppList] = useLocalStorage<string>('NEED_REFRESH_APP_LIST_KEY', undefined, { raw: true })
   const [tagIDs, setTagIDs] = useState<string[]>([])
   const debouncedKeywords = useDebounce(keywords, { wait: APP_LIST_SEARCH_DEBOUNCE_MS })
   const newAppCardRef = useRef<HTMLDivElement>(null)
@@ -136,11 +137,11 @@ const List: FC<Props> = ({
   ]
 
   useEffect(() => {
-    if (localStorage.getItem(NEED_REFRESH_APP_LIST_KEY) === '1') {
-      localStorage.removeItem(NEED_REFRESH_APP_LIST_KEY)
+    if (needRefreshAppList === '1') {
+      setNeedRefreshAppList(null)
       refetch()
     }
-  }, [refetch])
+  }, [needRefreshAppList, refetch, setNeedRefreshAppList])
 
   useEffect(() => {
     if (isCurrentWorkspaceDatasetOperator)


### PR DESCRIPTION
## Summary

Migrates direct `localStorage` usage for `NEED_REFRESH_APP_LIST_KEY` to the `useLocalStorage`/`useSetLocalStorage` hooks from `@/hooks/use-local-storage`.

Closes #36898

## Changes

| File | Pattern | Call sites |
|------|---------|------------|
| `app-card.tsx` | `useSetLocalStorage` | 1 (duplicate app) |
| `list.tsx` | `useLocalStorage` | 1 (check+remove on mount) |
| `switch-app-modal/index.tsx` | `useSetLocalStorage` | 1 (switch app) |
| `create-app-modal/index.tsx` | `useSetLocalStorage` | 1 (create app) |
| `create-from-dsl-modal/index.tsx` | `useSetLocalStorage` | 2 (DSL import + confirm) |

**Total: 5 files, 6 call sites**

## Self-check

- [x] Code style follows existing patterns (see #36915 for reference)
- [x] `pnpm lint-staged` passed on commit
- [x] No behavioral change — same localStorage key, same read/write semantics
- [x] Kept PR scope small per maintainer guidance (3–5 call sites per PR)