### PR TITLE
refactor: remove unused Flask-RESTX field dicts from end_user and conversation_variable fields (#28015)

### DIFF
--- a/api/fields/conversation_variable_fields.py
+++ b/api/fields/conversation_variable_fields.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from flask_restx import Namespace, fields
+from flask_restx import fields
 from pydantic import field_validator
 
 from fields.base import ResponseModel
@@ -20,20 +20,6 @@ conversation_variable_fields = {
     "description": fields.String,
     "created_at": TimestampField,
     "updated_at": TimestampField,
-}
-
-paginated_conversation_variable_fields = {
-    "page": fields.Integer,
-    "limit": fields.Integer,
-    "total": fields.Integer,
-    "has_more": fields.Boolean,
-    "data": fields.List(fields.Nested(conversation_variable_fields), attribute="data"),
-}
-
-conversation_variable_infinite_scroll_pagination_fields = {
-    "limit": fields.Integer,
-    "has_more": fields.Boolean,
-    "data": fields.List(fields.Nested(conversation_variable_fields)),
 }
 
 
@@ -97,19 +83,3 @@ class ConversationVariableInfiniteScrollPaginationResponse(ResponseModel):
     limit: int
     has_more: bool
     data: list[ConversationVariableResponse]
-
-
-def build_conversation_variable_model(api_or_ns: Namespace):
-    """Build the conversation variable model for the API or Namespace."""
-    return api_or_ns.model("ConversationVariable", conversation_variable_fields)
-
-
-def build_conversation_variable_infinite_scroll_pagination_model(api_or_ns: Namespace):
-    """Build the conversation variable infinite scroll pagination model for the API or Namespace."""
-    # Build the nested variable model first
-    conversation_variable_model = build_conversation_variable_model(api_or_ns)
-
-    copied_fields = conversation_variable_infinite_scroll_pagination_fields.copy()
-    copied_fields["data"] = fields.List(fields.Nested(conversation_variable_model))
-
-    return api_or_ns.model("ConversationVariableInfiniteScrollPagination", copied_fields)

--- a/api/fields/end_user_fields.py
+++ b/api/fields/end_user_fields.py
@@ -2,30 +2,9 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from flask_restx import fields
 from pydantic import Field
 
 from fields.base import ResponseModel
-
-simple_end_user_fields = {
-    "id": fields.String,
-    "type": fields.String,
-    "is_anonymous": fields.Boolean,
-    "session_id": fields.String,
-}
-
-end_user_detail_fields = {
-    "id": fields.String,
-    "tenant_id": fields.String,
-    "app_id": fields.String,
-    "type": fields.String,
-    "external_user_id": fields.String,
-    "name": fields.String,
-    "is_anonymous": fields.Boolean,
-    "session_id": fields.String,
-    "created_at": fields.DateTime,
-    "updated_at": fields.DateTime,
-}
 
 
 class SimpleEndUser(ResponseModel):


### PR DESCRIPTION
## Summary

Removes legacy Flask-RESTX field dictionaries that have been fully replaced by Pydantic `BaseModel` equivalents.

Related to #28015

## Changes

### `api/fields/end_user_fields.py` (-21 lines)
- Remove `simple_end_user_fields` dict (no external references)
- Remove `end_user_detail_fields` dict (no external references)
- Remove `flask_restx` import (no longer needed)

### `api/fields/conversation_variable_fields.py` (-31 lines)
- Remove `paginated_conversation_variable_fields` dict (no external references)
- Remove `conversation_variable_infinite_scroll_pagination_fields` dict (no external references)
- Remove `build_conversation_variable_model()` function (no external references)
- Remove `build_conversation_variable_infinite_scroll_pagination_model()` function (no external references)
- Remove `Namespace` import (only used by removed builder functions)

**Kept**: `conversation_variable_fields` dict — still imported by `workflow_fields.py` and `trial.py`.

## Verification

- `uv run python -c "from fields.end_user_fields import SimpleEndUser, EndUserDetail"` ✓
- `uv run python -c "from fields.conversation_variable_fields import ConversationVariableResponse"` ✓
- `uv run python -c "from fields.workflow_fields import conversation_variable_fields"` ✓
- Ruff lint passed ✓
- lint-staged passed on commit ✓