### PR TITLE
refactor(web): migrate question classifier label hint storage

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -4432,11 +4432,6 @@
       "count": 9
     }
   },
-  "web/app/components/workflow/nodes/question-classifier/components/class-list.tsx": {
-    "no-restricted-properties": {
-      "count": 2
-    }
-  },
   "web/app/components/workflow/nodes/question-classifier/use-single-run-form-params.ts": {
     "ts/no-explicit-any": {
       "count": 8

--- a/web/app/components/workflow/nodes/question-classifier/components/class-list.tsx
+++ b/web/app/components/workflow/nodes/question-classifier/components/class-list.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ReactSortable } from 'react-sortablejs'
 import { ArrowDownRoundFill } from '@/app/components/base/icons/src/vender/solid/general'
+import { useLocalStorage } from '@/hooks/use-local-storage'
 import { useEdgesInteractions } from '../../../hooks'
 import AddButton from '../../_base/components/add-button'
 import Item from './class-item'
@@ -42,17 +43,7 @@ const ClassList: FC<Props> = ({
   const [shouldScrollToEnd, setShouldScrollToEnd] = useState(false)
   const prevListLength = useRef(list.length)
   const [collapsed, setCollapsed] = useState(false)
-  const [isRenameHintDismissed, setIsRenameHintDismissed] = useState(() => {
-    if (typeof window === 'undefined')
-      return true
-
-    try {
-      return window.localStorage.getItem(INLINE_LABEL_HINT_STORAGE_KEY) === 'true'
-    }
-    catch {
-      return false
-    }
-  })
+  const [isRenameHintDismissed, setIsRenameHintDismissed] = useLocalStorage<boolean>(INLINE_LABEL_HINT_STORAGE_KEY, false)
 
   const handleClassChange = useCallback((index: number) => {
     return (value: Topic) => {
@@ -104,12 +95,7 @@ const ClassList: FC<Props> = ({
       return
 
     setIsRenameHintDismissed(true)
-    try {
-      window.localStorage.setItem(INLINE_LABEL_HINT_STORAGE_KEY, 'true')
-    }
-    catch {
-    }
-  }, [isRenameHintDismissed])
+  }, [isRenameHintDismissed, setIsRenameHintDismissed])
 
   const shouldShowRenameHint = !readonly && !isRenameHintDismissed && list.some((item, index) => {
     return isDefaultClassLabel(item.label, index + 1, t)

--- a/web/app/components/workflow/nodes/question-classifier/components/class-list.tsx
+++ b/web/app/components/workflow/nodes/question-classifier/components/class-list.tsx
@@ -43,7 +43,8 @@ const ClassList: FC<Props> = ({
   const [shouldScrollToEnd, setShouldScrollToEnd] = useState(false)
   const prevListLength = useRef(list.length)
   const [collapsed, setCollapsed] = useState(false)
-  const [isRenameHintDismissed, setIsRenameHintDismissed] = useLocalStorage<boolean>(INLINE_LABEL_HINT_STORAGE_KEY, false)
+  const [storedRenameHintDismissed, setIsRenameHintDismissed] = useLocalStorage<boolean>(INLINE_LABEL_HINT_STORAGE_KEY)
+  const isRenameHintDismissed = storedRenameHintDismissed ?? false
 
   const handleClassChange = useCallback((index: number) => {
     return (value: Topic) => {


### PR DESCRIPTION
Summary
- Part of #36898.
- Migrates the question classifier inline label hint dismissal flag to the shared useLocalStorage hook.

Reproduction
- The question classifier class list reads question-classifier-inline-label-hint-dismissed to decide whether to show the inline label rename hint.
- Dismissing the hint writes the same key to localStorage.

Root cause
- This component still used direct window.localStorage.getItem/setItem calls instead of @/hooks/use-local-storage.

Changes
- Added useLocalStorage in the question classifier class list.
- Replaced the hand-written localStorage initializer with useLocalStorage<boolean>(..., false).
- Replaced the manual localStorage.setItem call with the hook setter.

Tests
- git diff --check
- Parsed web/app/components/workflow/nodes/question-classifier/components/class-list.tsx with @babel/parser using TypeScript + JSX plugins.
- Attempted pnpm install --frozen-lockfile --ignore-scripts with Node 22.22.1 and pnpm 11.5.0; install was blocked by the repository trustPolicy/no-downgrade lockfile verification for existing lockfile entries, so full type-check could not be run locally.

Screenshots/Logs
- Not applicable; this is a storage refactor with no intended UI change.