### PR TITLE
refactor(web): migrate NEED_REFRESH_APP_LIST_KEY setItem in create-from-dsl + switch-app

### DIFF
--- a/web/app/components/app/create-from-dsl-modal/index.tsx
+++ b/web/app/components/app/create-from-dsl-modal/index.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/service/apps'
 import { getRedirection } from '@/utils/app-redirection'
 import { trackCreateApp } from '@/utils/create-app-tracking'
+import { setLocalStorageItem } from '@/utils/local-storage'
 import Uploader from './uploader'
 
 type CreateFromDSLModalProps = {
@@ -124,7 +125,7 @@ const CreateFromDSLModal = ({ show, onSuccess, onClose, activeTab = CreateFromDS
             ? t('newApp.appCreateDSLWarning', { ns: 'app' })
             : undefined,
         })
-        localStorage.setItem(NEED_REFRESH_APP_LIST_KEY, '1')
+        setLocalStorageItem(NEED_REFRESH_APP_LIST_KEY, '1')
         if (app_id)
           await handleCheckPluginDependencies(app_id)
         getRedirection(isCurrentWorkspaceEditor, { id: app_id!, mode: app_mode }, push)
@@ -178,7 +179,7 @@ const CreateFromDSLModal = ({ show, onSuccess, onClose, activeTab = CreateFromDS
         toast.success(t('newApp.appCreated', { ns: 'app' }))
         if (app_id)
           await handleCheckPluginDependencies(app_id)
-        localStorage.setItem(NEED_REFRESH_APP_LIST_KEY, '1')
+        setLocalStorageItem(NEED_REFRESH_APP_LIST_KEY, '1')
         getRedirection(isCurrentWorkspaceEditor, { id: app_id!, mode: app_mode }, push)
       }
       else if (status === DSLImportStatus.FAILED) {

--- a/web/app/components/app/switch-app-modal/index.tsx
+++ b/web/app/components/app/switch-app-modal/index.tsx
@@ -30,6 +30,7 @@ import { useRouter } from '@/next/navigation'
 import { deleteApp, switchApp } from '@/service/apps'
 import { AppModeEnum } from '@/types/app'
 import { getRedirection } from '@/utils/app-redirection'
+import { setLocalStorageItem } from '@/utils/local-storage'
 import AppIconPicker from '../../base/app-icon-picker'
 
 type SwitchAppModalProps = {
@@ -78,7 +79,7 @@ const SwitchAppModal = ({ show, appDetail, inAppDetail = false, onSuccess, onClo
         setAppDetail()
       if (removeOriginal)
         await deleteApp(appDetail.id)
-      localStorage.setItem(NEED_REFRESH_APP_LIST_KEY, '1')
+      setLocalStorageItem(NEED_REFRESH_APP_LIST_KEY, '1')
       getRedirection(
         isCurrentWorkspaceEditor,
         {


### PR DESCRIPTION
## Summary
Migrate remaining `localStorage.setItem(NEED_REFRESH_APP_LIST_KEY, '1')` calls to `setLocalStorageItem`.

Files:
- `web/app/components/app/create-from-dsl-modal/index.tsx` (2 occurrences: `onCreate` + `onDSLConfirm`)
- `web/app/components/app/switch-app-modal/index.tsx` (1 occurrence: `goStart`)