### PR TITLE
refactor(web): use localStorage helpers in app sidebar

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -248,9 +248,6 @@
     }
   },
   "web/app/components/app-sidebar/index.tsx": {
-    "no-restricted-globals": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 1
     }

--- a/web/app/components/app-sidebar/index.tsx
+++ b/web/app/components/app-sidebar/index.tsx
@@ -9,6 +9,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useStore as useAppStore } from '@/app/components/app/store'
 import { useEventEmitterContextContext } from '@/context/event-emitter'
 import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
+import { useLocalStorage, useSetLocalStorage } from '@/hooks/use-local-storage'
 import { usePathname } from '@/next/navigation'
 import Divider from '../base/divider'
 import AppInfo, { AppInfoView } from './app-info'
@@ -60,7 +61,8 @@ const AppDetailNav = ({
   const pathname = usePathname()
   const inWorkflowCanvas = pathname.endsWith('/workflow')
   const isPipelineCanvas = pathname.endsWith('/pipeline')
-  const workflowCanvasMaximize = localStorage.getItem('workflow-canvas-maximize') === 'true'
+  const [workflowCanvasMaximize] = useLocalStorage<boolean>('workflow-canvas-maximize', false)
+  const setAppSidebarExpandStorage = useSetLocalStorage<string>('app-detail-collapse-or-expand', { raw: true })
   const [hideHeader, setHideHeader] = useState(workflowCanvasMaximize)
   const { eventEmitter } = useEventEmitterContextContext()
 
@@ -71,10 +73,10 @@ const AppDetailNav = ({
 
   useEffect(() => {
     if (appSidebarExpand) {
-      localStorage.setItem('app-detail-collapse-or-expand', appSidebarExpand)
+      setAppSidebarExpandStorage(appSidebarExpand)
       setAppSidebarExpand(appSidebarExpand)
     }
-  }, [appSidebarExpand, setAppSidebarExpand])
+  }, [appSidebarExpand, setAppSidebarExpand, setAppSidebarExpandStorage])
 
   useHotkey('Mod+B', (e) => {
     e.preventDefault()


### PR DESCRIPTION
## Summary

Migrate the remaining direct localStorage calls in `web/app/components/app-sidebar/index.tsx` to the shared local storage hook helpers:

- `localStorage.getItem('workflow-canvas-maximize') === 'true'` -> `useLocalStorage<boolean>('workflow-canvas-maximize', false)`
- `localStorage.setItem('app-detail-collapse-or-expand', appSidebarExpand)` -> `useSetLocalStorage<string>('app-detail-collapse-or-expand', { raw: true })`

The previous `app-info` and `apps/list` refresh-list calls are no longer changed here because upstream `main` now handles them with `useSetLocalStorage` / `useLocalStorage`.

## Verification

- `eslint --pass-on-unpruned-suppressions web/app/components/app-sidebar/index.tsx`
- GitHub Actions checks are passing on the latest commit.