### PR TITLE
refactor(web): use localStorage hooks for metadata flow

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2275,9 +2275,6 @@
     }
   },
   "web/app/components/datasets/metadata/hooks/use-edit-dataset-metadata.ts": {
-    "no-restricted-globals": {
-      "count": 2
-    },
     "react/set-state-in-effect": {
       "count": 1
     }
@@ -2297,11 +2294,6 @@
   },
   "web/app/components/datasets/metadata/metadata-dataset/dataset-metadata-drawer.tsx": {
     "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "web/app/components/datasets/metadata/metadata-document/info-group.tsx": {
-    "no-restricted-globals": {
       "count": 1
     }
   },

--- a/web/app/components/datasets/metadata/hooks/use-edit-dataset-metadata.ts
+++ b/web/app/components/datasets/metadata/hooks/use-edit-dataset-metadata.ts
@@ -4,6 +4,7 @@ import { toast } from '@langgenius/dify-ui/toast'
 import { useBoolean } from 'ahooks'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useLocalStorage } from '@/hooks/use-local-storage'
 import { useBuiltInMetaDataFields, useCreateMetaData, useDatasetMetaData, useDeleteMetaData, useRenameMeta, useUpdateBuiltInStatus } from '@/service/knowledge/use-metadata'
 import { isShowManageMetadataLocalStorageKey } from '../types'
 import useCheckMetadataName from './use-check-metadata-name'
@@ -17,13 +18,13 @@ const useEditDatasetMetadata = ({ datasetId,
 }) => {
   const { t } = useTranslation()
   const [isShowEditModal, { setTrue: showEditModal, setFalse: hideEditModal }] = useBoolean(false)
+  const [isShowManageMetadata, setIsShowManageMetadata] = useLocalStorage<string>(isShowManageMetadataLocalStorageKey, undefined, { raw: true })
   useEffect(() => {
-    const isShowManageMetadata = localStorage.getItem(isShowManageMetadataLocalStorageKey)
     if (isShowManageMetadata) {
       showEditModal()
-      localStorage.removeItem(isShowManageMetadataLocalStorageKey)
+      setIsShowManageMetadata(null)
     }
-  }, [])
+  }, [isShowManageMetadata, setIsShowManageMetadata, showEditModal])
   const { data: datasetMetaData } = useDatasetMetaData(datasetId)
   const { mutate: doAddMetaData } = useCreateMetaData(datasetId)
   const { checkName } = useCheckMetadataName()

--- a/web/app/components/datasets/metadata/metadata-document/info-group.tsx
+++ b/web/app/components/datasets/metadata/metadata-document/info-group.tsx
@@ -7,6 +7,7 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import Divider from '@/app/components/base/divider'
 import { Infotip } from '@/app/components/base/infotip'
+import { useSetLocalStorage } from '@/hooks/use-local-storage'
 import useTimestamp from '@/hooks/use-timestamp'
 import { useRouter } from '@/next/navigation'
 import InputCombined from '../edit-metadata-batch/input-combined'
@@ -50,9 +51,10 @@ const InfoGroup: FC<Props> = ({
   const router = useRouter()
   const { t } = useTranslation()
   const { formatTime: formatTimestamp } = useTimestamp()
+  const setIsShowManageMetadata = useSetLocalStorage<string>(isShowManageMetadataLocalStorageKey, { raw: true })
 
   const handleMangeMetadata = () => {
-    localStorage.setItem(isShowManageMetadataLocalStorageKey, 'true')
+    setIsShowManageMetadata('true')
     router.push(`/datasets/${dataSetId}/documents`)
   }
 


### PR DESCRIPTION
## Summary
- Replace direct metadata-management localStorage reads with the existing `useLocalStorage` hook.
- Replace the metadata-management flag write with `useSetLocalStorage`.
- Rebase on the latest `main` and keep the final diff scoped to the metadata flow.

## Tests
- `eslint --pass-on-unpruned-suppressions web/app/components/datasets/metadata/hooks/use-edit-dataset-metadata.ts web/app/components/datasets/metadata/metadata-document/info-group.tsx` (passes with an existing `RiDeleteBinLine` warning)
- `vp run dify-web#test -- app/components/datasets/metadata/hooks/__tests__/use-edit-dataset-metadata.spec.ts app/components/datasets/metadata/metadata-document/__tests__/info-group.spec.tsx`