### PR TITLE
refactor(web): migrate chat sidebar collapse storage

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -817,9 +817,6 @@
     }
   },
   "web/app/components/base/chat/chat-with-history/hooks.tsx": {
-    "react/set-state-in-effect": {
-      "count": 4
-    },
     "ts/no-explicit-any": {
       "count": 18
     }

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -817,9 +817,6 @@
     }
   },
   "web/app/components/base/chat/chat-with-history/hooks.tsx": {
-    "no-restricted-globals": {
-      "count": 2
-    },
     "react/set-state-in-effect": {
       "count": 4
     },

--- a/web/app/components/base/chat/chat-with-history/hooks.tsx
+++ b/web/app/components/base/chat/chat-with-history/hooks.tsx
@@ -125,9 +125,6 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
     rawStorageOptions,
   )
   const [sidebarCollapseState, setSidebarCollapseState] = useState<boolean>(storedSidebarCollapseState === 'collapsed')
-  useEffect(() => {
-    setSidebarCollapseState(storedSidebarCollapseState === 'collapsed')
-  }, [storedSidebarCollapseState])
   const handleSidebarCollapse = useCallback((state: boolean) => {
     if (appId) {
       setSidebarCollapseState(state)
@@ -202,6 +199,7 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
   const [initUserVariables, setInitUserVariables] = useState<Record<string, any>>({})
   const handleNewConversationInputsChange = useCallback((newInputs: Record<string, any>) => {
     newConversationInputsRef.current = newInputs
+    // eslint-disable-next-line react/set-state-in-effect -- This handler intentionally syncs derived input defaults when called from the reset effect below.
     setNewConversationInputs(newInputs)
   }, [])
   const inputsForms = useMemo(() => {
@@ -298,6 +296,7 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
   const [originConversationList, setOriginConversationList] = useState<ConversationItem[]>([])
   useEffect(() => {
     if (appConversationData?.data && !appConversationDataLoading)
+      // eslint-disable-next-line react/set-state-in-effect -- Conversation query results intentionally replace the local editable list.
       setOriginConversationList(appConversationData?.data)
   }, [appConversationData, appConversationDataLoading])
   const conversationList = useMemo(() => {
@@ -314,6 +313,7 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
   }, [originConversationList, showNewConversationItemInList, t])
   useEffect(() => {
     if (newConversation) {
+      // eslint-disable-next-line react/set-state-in-effect -- Newly resolved conversation names intentionally patch the local list cache.
       setOriginConversationList(produce((draft) => {
         const index = draft.findIndex(item => item.id === newConversation.id)
         if (index > -1)
@@ -337,6 +337,7 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
   const [currentConversationInputs, setCurrentConversationInputs] = useState<Record<string, any>>(currentConversationLatestInputs || {})
   useEffect(() => {
     if (currentConversationItem)
+      // eslint-disable-next-line react/set-state-in-effect -- Selected conversation changes intentionally resync the editable input snapshot.
       setCurrentConversationInputs(currentConversationLatestInputs || {})
   }, [currentConversationItem, currentConversationLatestInputs])
   const checkInputsRequired = useCallback((silent?: boolean) => {

--- a/web/app/components/base/chat/chat-with-history/hooks.tsx
+++ b/web/app/components/base/chat/chat-with-history/hooks.tsx
@@ -21,6 +21,9 @@ import { addFileInfos, sortAgentSorts } from '../../../tools/utils'
 import { CONVERSATION_ID_INFO } from '../constants'
 import { buildChatItemTree, getProcessedSystemVariablesFromUrlParams, getRawInputsFromUrlParams, getRawUserVariablesFromUrlParams } from '../utils'
 
+const WEBAPP_SIDEBAR_COLLAPSE_STORAGE_KEY = 'webappSidebarCollapse'
+const rawStorageOptions = { raw: true } as const
+
 function getFormattedChatList(messages: any[]) {
   const newChatList: ChatItem[] = []
   messages.forEach((item) => {
@@ -116,31 +119,21 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
     }
     setLocaleFromProps()
   }, [appData])
-  const [sidebarCollapseState, setSidebarCollapseState] = useState<boolean>(() => {
-    if (typeof window !== 'undefined') {
-      try {
-        const localState = localStorage.getItem('webappSidebarCollapse')
-        return localState === 'collapsed'
-      }
-      catch {
-        // localStorage may be disabled in private browsing mode or by security settings
-        // fallback to default value
-        return false
-      }
-    }
-    return false
-  })
+  const [storedSidebarCollapseState, setStoredSidebarCollapseState] = useLocalStorage<string>(
+    WEBAPP_SIDEBAR_COLLAPSE_STORAGE_KEY,
+    undefined,
+    rawStorageOptions,
+  )
+  const [sidebarCollapseState, setSidebarCollapseState] = useState<boolean>(storedSidebarCollapseState === 'collapsed')
+  useEffect(() => {
+    setSidebarCollapseState(storedSidebarCollapseState === 'collapsed')
+  }, [storedSidebarCollapseState])
   const handleSidebarCollapse = useCallback((state: boolean) => {
     if (appId) {
       setSidebarCollapseState(state)
-      try {
-        localStorage.setItem('webappSidebarCollapse', state ? 'collapsed' : 'expanded')
-      }
-      catch {
-        // localStorage may be disabled, continue without persisting state
-      }
+      setStoredSidebarCollapseState(state ? 'collapsed' : 'expanded')
     }
-  }, [appId, setSidebarCollapseState])
+  }, [appId, setSidebarCollapseState, setStoredSidebarCollapseState])
   const [conversationIdInfo, setConversationIdInfo] = useLocalStorage<Record<string, Record<string, string>>>(CONVERSATION_ID_INFO, {})
   const currentConversationId = useMemo(() => conversationIdInfo?.[appId || '']?.[userId || 'DEFAULT'] || '', [appId, conversationIdInfo, userId])
   const handleConversationIdInfoChange = useCallback((changeConversationId: string) => {

--- a/web/app/components/base/chat/chat-with-history/hooks.tsx
+++ b/web/app/components/base/chat/chat-with-history/hooks.tsx
@@ -124,13 +124,11 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
     undefined,
     rawStorageOptions,
   )
-  const [sidebarCollapseState, setSidebarCollapseState] = useState<boolean>(storedSidebarCollapseState === 'collapsed')
+  const sidebarCollapseState = storedSidebarCollapseState === 'collapsed'
   const handleSidebarCollapse = useCallback((state: boolean) => {
-    if (appId) {
-      setSidebarCollapseState(state)
+    if (appId)
       setStoredSidebarCollapseState(state ? 'collapsed' : 'expanded')
-    }
-  }, [appId, setSidebarCollapseState, setStoredSidebarCollapseState])
+  }, [appId, setStoredSidebarCollapseState])
   const [conversationIdInfo, setConversationIdInfo] = useLocalStorage<Record<string, Record<string, string>>>(CONVERSATION_ID_INFO, {})
   const currentConversationId = useMemo(() => conversationIdInfo?.[appId || '']?.[userId || 'DEFAULT'] || '', [appId, conversationIdInfo, userId])
   const handleConversationIdInfoChange = useCallback((changeConversationId: string) => {


### PR DESCRIPTION
## Summary

Part of #36898. Migrates the web app chat history sidebar collapse preference from direct `localStorage` access to `useLocalStorage`.

## Reproduction

The web app chat history hook reads and writes `webappSidebarCollapse` when the sidebar is collapsed or expanded. That storage key was still accessed through direct `localStorage.getItem` / `setItem` calls.

## Root cause

This path kept its own defensive localStorage access instead of using the shared `@/hooks/use-local-storage` abstraction requested in #36898.

## Changes

- Add a dedicated storage key constant for `webappSidebarCollapse`.
- Use `useLocalStorage<string>(..., undefined, { raw: true })` so the existing raw string values (`collapsed` / `expanded`) are preserved.
- Use the stored localStorage value as the single sidebar collapse state source.

## Tests

- `git diff --check`
- Parsed `web/app/components/base/chat/chat-with-history/hooks.tsx` with `@babel/parser` (`typescript` + `jsx` plugins).

Targeted test command was attempted but blocked locally before the test runner executed:

```
pnpm --dir web test app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx
Error: Cannot find matching keyid ...
```

Earlier targeted test attempts in this checkout were also blocked by the repository pnpm trust policy before execution:

```
pnpm --dir web test app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx
[ERR_PNPM_TRUST_DOWNGRADE] 15 lockfile entries failed verification due missing metadata time fields
```

## Screenshots/Logs

N/A: storage hook refactor only.
