### PR TITLE
refactor(web): migrate debug-and-preview-panel-width to useSetLocalStorage

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -4689,11 +4689,6 @@
       "count": 12
     }
   },
-  "web/app/components/workflow/panel/debug-and-preview/index.tsx": {
-    "no-restricted-globals": {
-      "count": 1
-    }
-  },
   "web/app/components/workflow/panel/env-panel/variable-modal.tsx": {
     "no-restricted-imports": {
       "count": 1

--- a/web/app/components/workflow/panel/debug-and-preview/index.tsx
+++ b/web/app/components/workflow/panel/debug-and-preview/index.tsx
@@ -19,6 +19,7 @@ import { RefreshCcw01 } from '@/app/components/base/icons/src/vender/line/arrows
 import { useEdgesInteractionsWithoutSync } from '@/app/components/workflow/hooks/use-edges-interactions-without-sync'
 import { useNodesInteractionsWithoutSync } from '@/app/components/workflow/hooks/use-nodes-interactions-without-sync'
 import { useStore } from '@/app/components/workflow/store'
+import { useSetLocalStorage } from '@/hooks/use-local-storage'
 import {
   useWorkflowInteractions,
 } from '../../hooks'
@@ -54,11 +55,12 @@ const DebugAndPreview = () => {
   const nodePanelWidth = useStore(s => s.nodePanelWidth)
   const panelWidth = useStore(s => s.previewPanelWidth)
   const setPanelWidth = useStore(s => s.setPreviewPanelWidth)
+  const setPanelWidthStorage = useSetLocalStorage<string>('debug-and-preview-panel-width', { raw: true })
   const handleResize = useCallback((width: number, source: 'user' | 'system' = 'user') => {
     if (source === 'user')
-      localStorage.setItem('debug-and-preview-panel-width', `${width}`)
+      setPanelWidthStorage(`${width}`)
     setPanelWidth(width)
-  }, [setPanelWidth])
+  }, [setPanelWidth, setPanelWidthStorage])
   const maxPanelWidth = useMemo(() => {
     if (!workflowCanvasWidth)
       return 720


### PR DESCRIPTION
## Summary

Migrate direct `localStorage.setItem('debug-and-preview-panel-width')` to `useSetLocalStorage` hook pattern.

Part of #36898

## Changes

- `workflow/panel/debug-and-preview/index.tsx`: replace `localStorage.setItem` with `useSetLocalStorage<string>(..., { raw: true })`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>