### PR TITLE
refactor(web): migrate workflow-variable-inpsect-panel-height to useSetLocalStorage

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -4909,11 +4909,6 @@
       "count": 2
     }
   },
-  "web/app/components/workflow/variable-inspect/index.tsx": {
-    "no-restricted-globals": {
-      "count": 1
-    }
-  },
   "web/app/components/workflow/variable-inspect/left.tsx": {
     "ts/no-explicit-any": {
       "count": 1

--- a/web/app/components/workflow/variable-inspect/index.tsx
+++ b/web/app/components/workflow/variable-inspect/index.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useMemo,
 } from 'react'
+import { useSetLocalStorage } from '@/hooks/use-local-storage'
 import { useResizePanel } from '../nodes/_base/hooks/use-resize-panel'
 import { useStore } from '../store'
 import Panel from './panel'
@@ -21,10 +22,12 @@ const VariableInspectPanel: FC = () => {
     return workflowCanvasHeight - 60
   }, [workflowCanvasHeight])
 
+  const setPanelHeightStorage = useSetLocalStorage<string>('workflow-variable-inpsect-panel-height', { raw: true })
+
   const handleResize = useCallback((width: number, height: number) => {
-    localStorage.setItem('workflow-variable-inpsect-panel-height', `${height}`)
+    setPanelHeightStorage(`${height}`)
     setVariableInspectPanelHeight(height)
-  }, [setVariableInspectPanelHeight])
+  }, [setVariableInspectPanelHeight, setPanelHeightStorage])
 
   const {
     triggerRef,


### PR DESCRIPTION
## Summary

Migrate direct `localStorage.setItem('workflow-variable-inpsect-panel-height')` to `useSetLocalStorage` hook pattern.

Part of #36898

## Changes

- `workflow/variable-inspect/index.tsx`: replace `localStorage.setItem` with `useSetLocalStorage<string>(..., { raw: true })`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>