### PR TITLE
fix(web): prune stale knowledge retrieval datasets

### DIFF
--- a/web/app/components/app/configuration/configuration-view.tsx
+++ b/web/app/components/app/configuration/configuration-view.tsx
@@ -69,6 +69,7 @@ const ConfigurationView: FC<ConfigurationViewModel> = ({
   onSelectDataSets,
   promptVariables,
   selectedIds,
+  selectedDatasets,
   showAppConfigureFeaturesModal,
   showLoading,
   showUseGPT4Confirm,
@@ -188,6 +189,7 @@ const ConfigurationView: FC<ConfigurationViewModel> = ({
             isShow={isShowSelectDataSet}
             onClose={onCloseSelectDataSet}
             selectedIds={selectedIds}
+            selectedDatasets={selectedDatasets}
             onSelect={onSelectDataSets}
           />
 

--- a/web/app/components/app/configuration/dataset-config/select-dataset/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/dataset-config/select-dataset/__tests__/index.spec.tsx
@@ -193,6 +193,98 @@ describe('SelectDataSet', () => {
     expect(onSelect).toHaveBeenCalledWith([datasetOne])
   })
 
+  it('preserves selectedDatasets outside the loaded page and prunes missing selected IDs', async () => {
+    const datasetOne = makeDataset({
+      id: 'set-1',
+      name: 'Dataset One',
+    })
+    const offPageDataset = makeDataset({
+      id: 'off-page-set',
+      name: 'Off Page Dataset',
+    })
+    mockUseInfiniteDatasets.mockReturnValue({
+      data: { pages: [{ data: [datasetOne] }] },
+      isLoading: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+    })
+
+    const onSelect = vi.fn()
+    await act(async () => {
+      render(
+        <SelectDataSet
+          {...baseProps}
+          onSelect={onSelect}
+          selectedIds={['off-page-set', 'missing-set']}
+          selectedDatasets={[offPageDataset]}
+        />,
+      )
+    })
+
+    expect(screen.getByText('1 appDebug.feature.dataSet.selected')).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Dataset One'))
+    })
+    expect(screen.getByText('2 appDebug.feature.dataSet.selected')).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'common.operation.add' }))
+    })
+
+    expect(onSelect).toHaveBeenCalledWith([offPageDataset, datasetOne])
+  })
+
+  it('uses the latest selectedDatasets when opened after props change', async () => {
+    const datasetOne = makeDataset({
+      id: 'set-1',
+      name: 'Dataset One',
+    })
+    const offPageDataset = makeDataset({
+      id: 'off-page-set',
+      name: 'Off Page Dataset',
+    })
+    mockUseInfiniteDatasets.mockReturnValue({
+      data: { pages: [{ data: [datasetOne] }] },
+      isLoading: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+    })
+
+    const onSelect = vi.fn()
+    const { rerender } = render(
+      <SelectDataSet
+        {...baseProps}
+        isShow={false}
+        onSelect={onSelect}
+        selectedIds={[]}
+        selectedDatasets={[]}
+      />,
+    )
+
+    await act(async () => {
+      rerender(
+        <SelectDataSet
+          {...baseProps}
+          isShow
+          onSelect={onSelect}
+          selectedIds={['off-page-set']}
+          selectedDatasets={[offPageDataset]}
+        />,
+      )
+    })
+
+    expect(screen.getByText('1 appDebug.feature.dataSet.selected')).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'common.operation.add' }))
+    })
+
+    expect(onSelect).toHaveBeenCalledWith([offPageDataset])
+  })
+
   it('should deselect existing selections and ignore unavailable dataset clicks', async () => {
     const datasetOne = makeDataset({
       id: 'set-1',

--- a/web/app/components/app/configuration/dataset-config/select-dataset/index.tsx
+++ b/web/app/components/app/configuration/dataset-config/select-dataset/index.tsx
@@ -24,6 +24,7 @@ type ISelectDataSetProps = {
   modal?: boolean
   onClose: () => void
   selectedIds: string[]
+  selectedDatasets?: DataSet[]
   onSelect: (dataSet: DataSet[]) => void
 }
 
@@ -32,10 +33,15 @@ const SelectDataSet: FC<ISelectDataSetProps> = ({
   modal,
   onClose,
   selectedIds,
+  selectedDatasets,
   onSelect,
 }) => {
   const { t } = useTranslation()
-  const [selectedIdsInModal, setSelectedIdsInModal] = useState(() => selectedIds)
+  const initialSelectedIds = useMemo(() => {
+    return selectedDatasets?.length ? selectedDatasets.map(dataset => dataset.id) : selectedIds
+  }, [selectedDatasets, selectedIds])
+  const [selectedIdsInModalState, setSelectedIdsInModalState] = useState<string[]>()
+  const selectedIdsInModal = selectedIdsInModalState ?? initialSelectedIds
   const canSelectMulti = true
   const { formatIndexingTechniqueAndMethod } = useKnowledge()
   const workspacePermissionKeys = useAppContextSelector(state => state.workspacePermissionKeys)
@@ -49,9 +55,17 @@ const SelectDataSet: FC<ISelectDataSetProps> = ({
     return pages.flatMap(page => page.data.filter(item => item.indexing_technique || item.provider === 'external'))
   }, [data])
   const datasetMap = useMemo(() => new Map(datasets.map(item => [item.id, item])), [datasets])
+  const selectedDatasetMap = useMemo(() => {
+    return new Map((selectedDatasets || []).map(item => [item.id, item]))
+  }, [selectedDatasets])
   const selected = useMemo(() => {
-    return selectedIdsInModal.map(id => datasetMap.get(id) || ({ id } as DataSet))
-  }, [datasetMap, selectedIdsInModal])
+    return selectedIdsInModal.reduce<DataSet[]>((acc, id) => {
+      const dataset = datasetMap.get(id) || selectedDatasetMap.get(id)
+      if (dataset)
+        acc.push(dataset)
+      return acc
+    }, [])
+  }, [datasetMap, selectedDatasetMap, selectedIdsInModal])
   const hasNoData = !isLoading && datasets.length === 0
 
   const listRef = useRef<HTMLDivElement>(null)
@@ -72,23 +86,25 @@ const SelectDataSet: FC<ISelectDataSetProps> = ({
   )
 
   const toggleSelect = (dataSet: DataSet) => {
-    setSelectedIdsInModal((prev) => {
-      const isSelected = prev.includes(dataSet.id)
+    setSelectedIdsInModalState((prev) => {
+      const currentSelectedIds = prev ?? initialSelectedIds
+      const isSelected = currentSelectedIds.includes(dataSet.id)
       if (isSelected)
-        return prev.filter(id => id !== dataSet.id)
+        return currentSelectedIds.filter(id => id !== dataSet.id)
 
-      return canSelectMulti ? [...prev, dataSet.id] : [dataSet.id]
+      return canSelectMulti ? [...currentSelectedIds, dataSet.id] : [dataSet.id]
     })
   }
 
   const handleSelect = () => {
     onSelect(selected)
+    setSelectedIdsInModalState(undefined)
   }
 
   const handleClose = useCallback(() => {
-    setSelectedIdsInModal(selectedIds)
+    setSelectedIdsInModalState(undefined)
     onClose()
-  }, [onClose, selectedIds])
+  }, [onClose])
 
   const handleOpenChange = useCallback((open: boolean) => {
     if (!open)

--- a/web/app/components/app/configuration/hooks/use-configuration.ts
+++ b/web/app/components/app/configuration/hooks/use-configuration.ts
@@ -102,6 +102,7 @@ export type ConfigurationViewModel = {
   onSelectDataSets: (data: DataSet[]) => void
   promptVariables: PromptVariable[]
   selectedIds: string[]
+  selectedDatasets?: DataSet[]
   showAppConfigureFeaturesModal: boolean
   showLoading: boolean
   showUseGPT4Confirm: boolean
@@ -701,6 +702,7 @@ export const useConfiguration = (): ConfigurationViewModel => {
     onSelectDataSets: handleSelect,
     promptVariables: modelConfig.configs.prompt_variables,
     selectedIds,
+    selectedDatasets: dataSets,
     showAppConfigureFeaturesModal,
     showLoading: !hasFetchedDetail || isLoadingCurrentWorkspace || !currentWorkspace?.id,
     showUseGPT4Confirm,

--- a/web/app/components/workflow/datasets-detail-store/__tests__/provider.spec.tsx
+++ b/web/app/components/workflow/datasets-detail-store/__tests__/provider.spec.tsx
@@ -1,6 +1,7 @@
 import type { Node } from '../../types'
 import type { DataSet } from '@/models/datasets'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { useEffect } from 'react'
 import { BlockEnum } from '../../types'
 import DatasetsDetailProvider from '../provider'
 import { useDatasetsDetailStore } from '../store'
@@ -14,6 +15,20 @@ vi.mock('@/service/datasets', () => ({
 const Consumer = () => {
   const datasetCount = useDatasetsDetailStore(state => Object.keys(state.datasetsDetail).length)
   return <div>{`dataset-count:${datasetCount}`}</div>
+}
+
+const SeededConsumer = ({
+  datasets,
+}: {
+  datasets: DataSet[]
+}) => {
+  const updateDatasetsDetail = useDatasetsDetailStore(state => state.updateDatasetsDetail)
+
+  useEffect(() => {
+    updateDatasetsDetail(datasets)
+  }, [datasets, updateDatasetsDetail])
+
+  return <Consumer />
 }
 
 const createWorkflowNode = (datasetIds: string[] = []): Node => ({
@@ -86,6 +101,43 @@ describe('datasets-detail-store provider', () => {
         },
       })
       expect(screen.getByText('dataset-count:2')).toBeInTheDocument()
+    })
+  })
+
+  it('should prune stale requested dataset details when the API returns an empty list', async () => {
+    let resolveFetch: ((value: { data: DataSet[] }) => void) | undefined
+    mockFetchDatasets.mockImplementation(() => new Promise<{ data: DataSet[] }>((resolve) => {
+      resolveFetch = resolve
+    }))
+    const seededDatasets = [createDataset('dataset-1')]
+
+    render(
+      <DatasetsDetailProvider nodes={[
+        createWorkflowNode(['dataset-1']),
+      ]}
+      >
+        <SeededConsumer datasets={seededDatasets} />
+      </DatasetsDetailProvider>,
+    )
+
+    await waitFor(() => {
+      expect(mockFetchDatasets).toHaveBeenCalledWith({
+        url: '/datasets',
+        params: {
+          page: 1,
+          ids: ['dataset-1'],
+        },
+      })
+      expect(screen.getByText('dataset-count:1')).toBeInTheDocument()
+    })
+    expect(resolveFetch).toBeDefined()
+
+    await act(async () => {
+      resolveFetch!({ data: [] })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('dataset-count:0')).toBeInTheDocument()
     })
   })
 })

--- a/web/app/components/workflow/datasets-detail-store/__tests__/store.spec.tsx
+++ b/web/app/components/workflow/datasets-detail-store/__tests__/store.spec.tsx
@@ -66,6 +66,34 @@ describe('datasets-detail-store store', () => {
     })
   })
 
+  it('prunes requested dataset ids that are missing from the returned details', () => {
+    const store = createDatasetsDetailStore()
+
+    store.getState().updateDatasetsDetail([
+      createDataset('dataset-1', 'Dataset One'),
+      createDataset('dataset-2', 'Dataset Two'),
+      createDataset('dataset-3', 'Dataset Three'),
+    ])
+    store.getState().updateDatasetsDetail([
+      createDataset('dataset-2', 'Dataset Two Updated'),
+    ], ['dataset-1', 'dataset-2'])
+
+    expect(store.getState().datasetsDetail).toMatchObject({
+      'dataset-2': { name: 'Dataset Two Updated' },
+      'dataset-3': { name: 'Dataset Three' },
+    })
+    expect(store.getState().datasetsDetail['dataset-1']).toBeUndefined()
+  })
+
+  it('prunes requested dataset ids when the returned details are empty', () => {
+    const store = createDatasetsDetailStore()
+
+    store.getState().updateDatasetsDetail([createDataset('dataset-1', 'Dataset One')])
+    store.getState().updateDatasetsDetail([], ['dataset-1'])
+
+    expect(store.getState().datasetsDetail).toEqual({})
+  })
+
   it('reads state from the datasets detail context', () => {
     const store = createDatasetsDetailStore()
     store.getState().updateDatasetsDetail([createDataset('dataset-3')])

--- a/web/app/components/workflow/datasets-detail-store/provider.tsx
+++ b/web/app/components/workflow/datasets-detail-store/provider.tsx
@@ -28,8 +28,7 @@ const DatasetsDetailProvider: FC<DatasetsDetailProviderProps> = ({
 
   const updateDatasetsDetail = useCallback(async (datasetIds: string[]) => {
     const { data: datasetsDetail } = await fetchDatasets({ url: '/datasets', params: { page: 1, ids: datasetIds } })
-    if (datasetsDetail && datasetsDetail.length > 0)
-      storeRef.current!.getState().updateDatasetsDetail(datasetsDetail)
+    storeRef.current!.getState().updateDatasetsDetail(datasetsDetail || [], datasetIds)
   }, [])
 
   useEffect(() => {

--- a/web/app/components/workflow/datasets-detail-store/store.ts
+++ b/web/app/components/workflow/datasets-detail-store/store.ts
@@ -6,20 +6,23 @@ import { DatasetsDetailContext } from './provider'
 
 type DatasetsDetailStore = {
   datasetsDetail: Record<string, DataSet>
-  updateDatasetsDetail: (datasetsDetail: DataSet[]) => void
+  updateDatasetsDetail: (datasetsDetail: DataSet[], requestedIds?: string[]) => void
 }
 
 export const createDatasetsDetailStore = () => {
   return createStore<DatasetsDetailStore>((set, get) => ({
     datasetsDetail: {},
-    updateDatasetsDetail: (datasets: DataSet[]) => {
+    updateDatasetsDetail: (datasets: DataSet[], requestedIds?: string[]) => {
       const oldDatasetsDetail = get().datasetsDetail
       const datasetsDetail = datasets.reduce<Record<string, DataSet>>((acc, dataset) => {
         acc[dataset.id] = dataset
         return acc
       }, {})
-      // Merge new datasets detail into old one
       const newDatasetsDetail = produce(oldDatasetsDetail, (draft) => {
+        requestedIds?.forEach((id) => {
+          if (!datasetsDetail[id])
+            delete draft[id]
+        })
         Object.entries(datasetsDetail).forEach(([key, value]) => {
           draft[key] = value
         })

--- a/web/app/components/workflow/nodes/knowledge-retrieval/__tests__/panel.spec.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/__tests__/panel.spec.tsx
@@ -145,7 +145,7 @@ vi.mock('../components/dataset-list', () => ({
 
 vi.mock('../components/add-dataset', () => ({
   __esModule: true,
-  default: (props: { selectedIds: string[], onChange: (datasets: DataSet[]) => void }) => {
+  default: (props: { selectedDatasets: DataSet[], onChange: (datasets: DataSet[]) => void }) => {
     mockAddKnowledge(props)
     return (
       <button
@@ -318,6 +318,12 @@ describe('knowledge-retrieval/panel', () => {
 
     expect(screen.getByText('result:Array[Object]')).toBeInTheDocument()
     expect(screen.getByText('shared')).toBeInTheDocument()
+    expect(mockAddKnowledge).toHaveBeenCalledWith(expect.objectContaining({
+      selectedDatasets: [
+        expect.objectContaining({ id: 'dataset-1' }),
+        expect.objectContaining({ id: 'dataset-2' }),
+      ],
+    }))
 
     await user.click(screen.getAllByRole('button', { name: 'var-reference-picker' })[0]!)
     await user.click(screen.getAllByRole('button', { name: 'var-reference-picker' })[1]!)

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/add-dataset.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/add-dataset.tsx
@@ -3,19 +3,21 @@ import type { FC } from 'react'
 import type { DataSet } from '@/models/datasets'
 import { useBoolean } from 'ahooks'
 import * as React from 'react'
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import SelectDataset from '@/app/components/app/configuration/dataset-config/select-dataset'
 
 type Props = Readonly<{
   selectedIds: string[]
   modal?: boolean
+  selectedDatasets?: DataSet[]
   onChange: (dataSets: DataSet[]) => void
 }>
 
 const AddDataset: FC<Props> = ({
   selectedIds,
   modal,
+  selectedDatasets,
   onChange,
 }) => {
   const { t } = useTranslation()
@@ -28,6 +30,11 @@ const AddDataset: FC<Props> = ({
     onChange(datasets)
     hideModal()
   }, [onChange, hideModal])
+
+  const currentSelectedIds = useMemo(() => {
+    return selectedDatasets?.length ? selectedDatasets.map(dataset => dataset.id) : selectedIds
+  }, [selectedDatasets, selectedIds])
+
   return (
     <div>
       <button
@@ -42,7 +49,8 @@ const AddDataset: FC<Props> = ({
         isShow={isShowModal}
         modal={modal}
         onClose={hideModal}
-        selectedIds={selectedIds}
+        selectedIds={currentSelectedIds}
+        selectedDatasets={selectedDatasets}
         onSelect={handleSelect}
       />
     </div>

--- a/web/app/components/workflow/nodes/knowledge-retrieval/hooks/__tests__/use-knowledge-dataset-selection.spec.ts
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/hooks/__tests__/use-knowledge-dataset-selection.spec.ts
@@ -168,6 +168,53 @@ describe('use-knowledge-dataset-selection', () => {
     expect(result.current.showImageQueryVarSelector).toBe(true)
   })
 
+  it('prunes stale dataset ids when fetched details omit deleted datasets', async () => {
+    const existingDataset = createDataset({
+      id: 'dataset-1',
+      name: 'Knowledge Base',
+    })
+    mockFetchDatasets.mockResolvedValueOnce({
+      data: [existingDataset],
+      page: 1,
+      limit: 20,
+      total: 1,
+      has_more: false,
+    })
+    const { inputRef, setInputs } = createState(createPayload({
+      dataset_ids: ['dataset-1', 'deleted-id'],
+    }))
+
+    const { result } = renderHook(() => useKnowledgeDatasetSelection({
+      inputs: inputRef.current,
+      inputRef,
+      setInputs,
+      payloadRetrievalMode: RETRIEVE_TYPE.multiWay,
+      updateDatasetsDetail,
+      fallbackRerankModel: {
+        provider: 'rerank-provider',
+        model: 'rerank-model',
+      },
+    }))
+
+    await waitFor(() => {
+      expect(result.current.selectedDatasetsLoaded).toBe(true)
+    })
+
+    expect(mockFetchDatasets).toHaveBeenCalledWith({
+      url: '/datasets',
+      params: {
+        page: 1,
+        ids: ['dataset-1', 'deleted-id'],
+      },
+    })
+    expect(result.current.selectedDatasets).toEqual([existingDataset])
+    expect(inputRef.current.dataset_ids).toEqual(['dataset-1'])
+    expect(setInputs).toHaveBeenCalledWith(expect.objectContaining({
+      dataset_ids: ['dataset-1'],
+    }))
+    expect(updateDatasetsDetail).toHaveBeenCalledWith([existingDataset], ['dataset-1', 'deleted-id'])
+  })
+
   it('updates dataset ids, retrieval config, attachment selector, and rerank modal state', async () => {
     const { inputRef, setInputs } = createState(createPayload({
       dataset_ids: [],

--- a/web/app/components/workflow/nodes/knowledge-retrieval/hooks/use-knowledge-dataset-selection.ts
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/hooks/use-knowledge-dataset-selection.ts
@@ -24,7 +24,7 @@ type Params = {
   inputRef: MutableRefObject<KnowledgeRetrievalNodeType>
   setInputs: (inputs: KnowledgeRetrievalNodeType) => void
   payloadRetrievalMode: RETRIEVE_TYPE
-  updateDatasetsDetail: (datasets: DataSet[]) => void
+  updateDatasetsDetail: (datasets: DataSet[], requestedIds?: string[]) => void
   fallbackRerankModel: ModelIdentity
 }
 
@@ -44,6 +44,7 @@ const useKnowledgeDatasetSelection = ({
     void (async () => {
       const currentInputs = inputRef.current
       const datasetIds = currentInputs.dataset_ids
+      let loadedDatasets: DataSet[] = []
       if (datasetIds.length > 0) {
         const { data: dataSetsWithDetail } = await fetchDatasets({
           url: '/datasets',
@@ -52,16 +53,25 @@ const useKnowledgeDatasetSelection = ({
             ids: datasetIds,
           },
         })
-        setSelectedDatasets(dataSetsWithDetail)
+        const datasetsById = new Map(dataSetsWithDetail.map(dataset => [dataset.id, dataset] as const))
+        loadedDatasets = datasetIds.reduce<DataSet[]>((acc, id) => {
+          const dataset = datasetsById.get(id)
+          if (dataset)
+            acc.push(dataset)
+
+          return acc
+        }, [])
+        updateDatasetsDetail(loadedDatasets, datasetIds)
+        setSelectedDatasets(loadedDatasets)
       }
 
-      const nextInputs = produce(currentInputs, (draft) => {
-        draft.dataset_ids = datasetIds
+      const nextInputs = produce(inputRef.current, (draft) => {
+        draft.dataset_ids = loadedDatasets.map(dataset => dataset.id)
       })
       setInputs(nextInputs)
       setSelectedDatasetsLoaded(true)
     })()
-  }, [inputRef, setInputs])
+  }, [inputRef, setInputs, updateDatasetsDetail])
 
   const handleOnDatasetsChange = useCallback((newDatasets: DataSet[]) => {
     const {

--- a/web/app/components/workflow/nodes/knowledge-retrieval/panel.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/panel.tsx
@@ -115,6 +115,7 @@ const Panel: FC<NodePanelProps<KnowledgeRetrievalNodeType>> = ({
               {!readOnly && (
                 <AddKnowledge
                   selectedIds={inputs.dataset_ids}
+                  selectedDatasets={selectedDatasets}
                   onChange={handleOnDatasetsChange}
                 />
               )}


### PR DESCRIPTION
## Summary
- prune deleted/stale dataset ids from Knowledge Retrieval node inputs after `/datasets` returns only valid dataset details
- prune requested ids missing from the shared workflow dataset detail cache, including empty API responses
- avoid emitting `{ id }` placeholder datasets from `SelectDataSet` while preserving valid selected datasets outside the current page
- pass valid selected dataset details through Knowledge Retrieval and app configuration selector flows

Fixes #36919

## Test Plan
- `pnpm --dir web test app/components/workflow/nodes/knowledge-retrieval/hooks/__tests__/use-knowledge-dataset-selection.spec.ts app/components/workflow/datasets-detail-store/__tests__/store.spec.tsx app/components/workflow/datasets-detail-store/__tests__/provider.spec.tsx app/components/app/configuration/dataset-config/select-dataset/__tests__/index.spec.tsx app/components/workflow/nodes/knowledge-retrieval/__tests__/panel.spec.tsx app/components/workflow/nodes/knowledge-retrieval/__tests__/node.spec.tsx`
- `pnpm --dir web test app/components/app/configuration/dataset-config/select-dataset/__tests__/index.spec.tsx app/components/app/configuration/__tests__/configuration-view.spec.tsx app/components/workflow/nodes/knowledge-retrieval/__tests__/panel.spec.tsx app/components/workflow/nodes/knowledge-retrieval/__tests__/node.spec.tsx`
- `pnpm --dir web type-check`
- `pnpm lint -- web/app/components/workflow web/app/components/app/configuration/dataset-config/select-dataset`
