### PR TITLE
fix(device): redirect external-SSO completion to web-origin /device (WTA-438)

### DIFF
--- a/api/controllers/openapi/oauth_device_sso.py
+++ b/api/controllers/openapi/oauth_device_sso.py
@@ -83,14 +83,8 @@ def _trusted_origin() -> str:
 
 
 def _device_url(query: str) -> str:
-    """Absolute web-origin URL for the /device SPA page.
-
-    sso-complete runs on the API origin (CONSOLE_API_URL); /device is served
-    by the web frontend (CONSOLE_WEB_URL). A bare relative redirect resolves
-    against the API origin and dead-ends in split-origin deployments, so the
-    target must be built from CONSOLE_WEB_URL (assumed always set).
-    `query` includes the leading "?".
-    """
+    # /device is served by the web frontend, not this API origin — a relative
+    # redirect would dead-end on the API host in split-origin deployments.
     base = dify_config.CONSOLE_WEB_URL.rstrip("/")
     return f"{base}/device{query}"
 
@@ -183,7 +177,7 @@ def sso_complete():
             _RejectedClaims(subject_email=claims.email, subject_issuer=claims.issuer),
             reason="email_belongs_to_dify_account",
         )
-        return redirect("/device?sso_error=email_belongs_to_dify_account", code=302)
+        return redirect(_device_url("?sso_error=email_belongs_to_dify_account"), code=302)
 
     iss = _trusted_origin()
     cookie_value, _ = mint_approval_grant(
@@ -194,7 +188,7 @@ def sso_complete():
         user_code=user_code,
     )
 
-    resp = redirect("/device?sso_verified=1", code=302)
+    resp = redirect(_device_url("?sso_verified=1"), code=302)
     resp.set_cookie(**approval_grant_cookie_kwargs(cookie_value))
     return resp
 

--- a/api/controllers/openapi/oauth_device_sso.py
+++ b/api/controllers/openapi/oauth_device_sso.py
@@ -82,6 +82,19 @@ def _trusted_origin() -> str:
     return base
 
 
+def _device_url(query: str) -> str:
+    """Absolute web-origin URL for the /device SPA page.
+
+    sso-complete runs on the API origin (CONSOLE_API_URL); /device is served
+    by the web frontend (CONSOLE_WEB_URL). A bare relative redirect resolves
+    against the API origin and dead-ends in split-origin deployments, so the
+    target must be built from CONSOLE_WEB_URL (assumed always set).
+    `query` includes the leading "?".
+    """
+    base = dify_config.CONSOLE_WEB_URL.rstrip("/")
+    return f"{base}/device{query}"
+
+
 @bp.route("/oauth/device/sso-initiate", methods=["GET"])
 @enterprise_only
 @rate_limit(LIMIT_SSO_INITIATE_PER_IP)

--- a/api/tests/unit_tests/controllers/openapi/test_device_sso.py
+++ b/api/tests/unit_tests/controllers/openapi/test_device_sso.py
@@ -77,3 +77,28 @@ def test_sso_complete_idp_callback_url_uses_canonical_path():
     from controllers.openapi import oauth_device_sso
 
     assert oauth_device_sso._SSO_COMPLETE_PATH == "/openapi/v1/oauth/device/sso-complete"
+
+
+def test_device_url_uses_console_web_url_when_set(monkeypatch):
+    """Redirect target must be absolute on the web origin so split-origin
+    deployments (web :3000 / api :5001) land on the SPA, not the API host.
+    """
+    from configs import dify_config
+    from controllers.openapi import oauth_device_sso
+
+    monkeypatch.setattr(dify_config, "CONSOLE_WEB_URL", "https://web.example.com")
+    assert (
+        oauth_device_sso._device_url("?sso_verified=1")
+        == "https://web.example.com/device?sso_verified=1"
+    )
+
+
+def test_device_url_strips_trailing_slash(monkeypatch):
+    from configs import dify_config
+    from controllers.openapi import oauth_device_sso
+
+    monkeypatch.setattr(dify_config, "CONSOLE_WEB_URL", "https://web.example.com/")
+    assert (
+        oauth_device_sso._device_url("?sso_error=x")
+        == "https://web.example.com/device?sso_error=x"
+    )

--- a/api/tests/unit_tests/controllers/openapi/test_device_sso.py
+++ b/api/tests/unit_tests/controllers/openapi/test_device_sso.py
@@ -80,17 +80,11 @@ def test_sso_complete_idp_callback_url_uses_canonical_path():
 
 
 def test_device_url_uses_console_web_url_when_set(monkeypatch):
-    """Redirect target must be absolute on the web origin so split-origin
-    deployments (web :3000 / api :5001) land on the SPA, not the API host.
-    """
     from configs import dify_config
     from controllers.openapi import oauth_device_sso
 
     monkeypatch.setattr(dify_config, "CONSOLE_WEB_URL", "https://web.example.com")
-    assert (
-        oauth_device_sso._device_url("?sso_verified=1")
-        == "https://web.example.com/device?sso_verified=1"
-    )
+    assert oauth_device_sso._device_url("?sso_verified=1") == "https://web.example.com/device?sso_verified=1"
 
 
 def test_device_url_strips_trailing_slash(monkeypatch):
@@ -98,7 +92,4 @@ def test_device_url_strips_trailing_slash(monkeypatch):
     from controllers.openapi import oauth_device_sso
 
     monkeypatch.setattr(dify_config, "CONSOLE_WEB_URL", "https://web.example.com/")
-    assert (
-        oauth_device_sso._device_url("?sso_error=x")
-        == "https://web.example.com/device?sso_error=x"
-    )
+    assert oauth_device_sso._device_url("?sso_error=x") == "https://web.example.com/device?sso_error=x"


### PR DESCRIPTION
## Problem

External-SSO device-flow login (`difyctl auth login`) bounced the user back to the 8-digit code prompt a second time. `sso_complete` redirected to a bare relative `/device?...`. That handler runs on the **API** origin (`CONSOLE_API_URL`), but `/device` is a page served by the **web** frontend (`CONSOLE_WEB_URL`). In split-origin deployments (local dev: web `:3000` / api `:5001`, or any prod with separate api/web hosts) the browser resolves the relative `Location` against the API origin and dead-ends, so the post-SSO landing never reaches the SPA.

## Fix

Build the redirect target from `CONSOLE_WEB_URL` via a small `_device_url` helper, matching every other web-facing redirect in the codebase (e.g. `controllers/console/auth/oauth.py`). Applied to both the `sso_verified` and `sso_error` redirects in `sso_complete`.

## Test

Added unit tests for `_device_url` (absolute web-origin URL, trailing-slash tolerance). Full `tests/unit_tests/controllers/openapi/` suite passes.

Linear: WTA-438
