### PR TITLE
refactor(web): migrate account education notice storage

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2512,11 +2512,6 @@
       "count": 1
     }
   },
-  "web/app/components/header/account-dropdown/index.tsx": {
-    "no-restricted-globals": {
-      "count": 3
-    }
-  },
   "web/app/components/header/account-setting/data-source-page-new/card.tsx": {
     "ts/no-explicit-any": {
       "count": 2

--- a/web/app/components/header/account-dropdown/index.tsx
+++ b/web/app/components/header/account-dropdown/index.tsx
@@ -18,6 +18,7 @@ import { useModalContext } from '@/context/modal-context'
 import { useProviderContext } from '@/context/provider-context'
 import { env } from '@/env'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { useSetLocalStorage } from '@/hooks/use-local-storage'
 import Link from '@/next/link'
 import { useRouter } from '@/next/navigation'
 import { useLogout } from '@/service/use-common'
@@ -26,6 +27,10 @@ import GithubStar from '../github-star'
 import Compliance from './compliance'
 import { ExternalLinkIndicator, MenuItemContent } from './menu-item-content'
 import Support from './support'
+
+const EDUCATION_REVERIFY_PREV_EXPIRE_AT_KEY = 'education-reverify-prev-expire-at'
+const EDUCATION_REVERIFY_HAS_NOTICED_KEY = 'education-reverify-has-noticed'
+const EDUCATION_EXPIRED_HAS_NOTICED_KEY = 'education-expired-has-noticed'
 
 type AccountMenuRouteItemProps = {
   href: string
@@ -116,6 +121,9 @@ export default function AppSelector() {
   const { userProfile, langGeniusVersionInfo, isCurrentWorkspaceOwner } = useAppContext()
   const { isEducationAccount } = useProviderContext()
   const { setShowAccountSettingModal } = useModalContext()
+  const clearEducationReverifyPrevExpireAt = useSetLocalStorage<number>(EDUCATION_REVERIFY_PREV_EXPIRE_AT_KEY)
+  const clearEducationReverifyHasNoticed = useSetLocalStorage<boolean>(EDUCATION_REVERIFY_HAS_NOTICED_KEY)
+  const clearEducationExpiredHasNoticed = useSetLocalStorage<boolean>(EDUCATION_EXPIRED_HAS_NOTICED_KEY)
 
   const { mutateAsync: logout } = useLogout()
   const handleLogout = async () => {
@@ -124,9 +132,9 @@ export default function AppSelector() {
     // Tokens are now stored in cookies and cleared by backend
 
     // To avoid use other account's education notice info
-    localStorage.removeItem('education-reverify-prev-expire-at')
-    localStorage.removeItem('education-reverify-has-noticed')
-    localStorage.removeItem('education-expired-has-noticed')
+    clearEducationReverifyPrevExpireAt(null)
+    clearEducationReverifyHasNoticed(null)
+    clearEducationExpiredHasNoticed(null)
 
     router.push('/signin')
   }


### PR DESCRIPTION
## Summary

- Migrate account logout education notice storage cleanup to `useSetLocalStorage`.
- Remove direct `localStorage.removeItem` calls for the education reverify/expired notice keys.

Refs #36898

## Screenshots

Not applicable. This refactor preserves the existing UI behavior.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

## Validation

```bash
../node_modules/.bin/vp test __tests__/header/account-dropdown-flow.test.tsx
../node_modules/.bin/eslint --quiet app/components/header/account-dropdown/index.tsx
./node_modules/.bin/tsgo --noEmit --pretty false --project tsconfig.json
git diff --check