### PR TITLE
fix: preserve annotation reply metadata

### DIFF
--- a/api/core/app/apps/advanced_chat/generate_task_pipeline.py
+++ b/api/core/app/apps/advanced_chat/generate_task_pipeline.py
@@ -1078,9 +1078,6 @@ class AdvancedChatAppGenerateTaskPipeline(GraphRuntimeStateSupport):
         """
         extras = self._task_state.metadata.model_dump()
 
-        if self._task_state.metadata.annotation_reply:
-            del extras["annotation_reply"]
-
         return MessageEndStreamResponse(
             task_id=self._application_generate_entity.task_id,
             id=self._message_id,

--- a/api/core/app/apps/base_app_generate_response_converter.py
+++ b/api/core/app/apps/base_app_generate_response_converter.py
@@ -99,10 +99,6 @@ class AppGenerateResponseConverter[TBlockingResponse: AppBlockingResponse](ABC):
                 )
             metadata["retriever_resources"] = updated_resources
 
-        # show annotation reply
-        if "annotation_reply" in metadata:
-            del metadata["annotation_reply"]
-
         # show usage
         if "usage" in metadata:
             del metadata["usage"]

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py
@@ -264,7 +264,7 @@ class TestAdvancedChatGenerateTaskPipeline:
         assert "UPDATE messages" in stmt_str
         assert "WHERE messages.id" in stmt_str
 
-    def test_message_end_to_stream_response_strips_annotation_reply(self):
+    def test_message_end_to_stream_response_preserves_annotation_reply(self):
         pipeline = _make_pipeline()
         pipeline._task_state.metadata.annotation_reply = AnnotationReply(
             id="ann",
@@ -273,7 +273,10 @@ class TestAdvancedChatGenerateTaskPipeline:
 
         response = pipeline._message_end_to_stream_response()
 
-        assert "annotation_reply" not in response.metadata
+        assert response.metadata["annotation_reply"] == {
+            "id": "ann",
+            "account": {"id": "acc", "name": "acc"},
+        }
 
     def test_handle_output_moderation_chunk_publishes_stop(self):
         pipeline = _make_pipeline()

--- a/api/tests/unit_tests/core/app/apps/agent_chat/test_agent_chat_generate_response_converter.py
+++ b/api/tests/unit_tests/core/app/apps/agent_chat/test_agent_chat_generate_response_converter.py
@@ -71,7 +71,7 @@ class TestAgentChatAppGenerateResponseConverterBlocking:
 
         result = AgentChatAppGenerateResponseConverter.convert_blocking_simple_response(blocking)
 
-        assert "annotation_reply" not in result["metadata"]
+        assert result["metadata"]["annotation_reply"] == {"id": "a"}
         assert "usage" not in result["metadata"]
 
     def test_convert_blocking_simple_response_with_non_dict_metadata(self):
@@ -169,7 +169,7 @@ class TestAgentChatAppGenerateResponseConverterStream:
         assert items[2]["event"] == "message_end"
         assert "metadata" in items[2]
         metadata = items[2]["metadata"]
-        assert "annotation_reply" not in metadata
+        assert metadata["annotation_reply"] == {"id": "a"}
         assert "usage" not in metadata
         assert metadata["retriever_resources"] == [
             {

--- a/api/tests/unit_tests/core/app/apps/completion/test_completion_generate_response_converter.py
+++ b/api/tests/unit_tests/core/app/apps/completion/test_completion_generate_response_converter.py
@@ -75,7 +75,7 @@ class TestCompletionAppGenerateResponseConverter:
 
         result = CompletionAppGenerateResponseConverter.convert_blocking_simple_response(blocking)
 
-        assert "annotation_reply" not in result["metadata"]
+        assert result["metadata"]["annotation_reply"] == {"a": 1}
         assert "usage" not in result["metadata"]
         assert result["metadata"]["retriever_resources"][0]["dataset_id"] == "dataset-1"
         assert result["metadata"]["retriever_resources"][0]["document_id"] == "document-1"
@@ -164,6 +164,6 @@ class TestCompletionAppGenerateResponseConverter:
 
         assert result[0] == "ping"
         assert result[1]["event"] == "message_end"
-        assert "annotation_reply" not in result[1]["metadata"]
+        assert result[1]["metadata"]["annotation_reply"] == {"a": 1}
         assert "usage" not in result[1]["metadata"]
         assert result[2]["event"] == "error"


### PR DESCRIPTION
## Summary

Fixes #37000

This PR preserves `metadata.annotation_reply` in `message_end` responses so the frontend can detect annotation-hit replies correctly.

The metadata was previously stripped in two backend paths:

- `api/core/app/apps/base_app_generate_response_converter.py`
- `api/core/app/apps/advanced_chat/generate_task_pipeline.py`

For chatflow / advanced chat, annotation replies short-circuit workflow execution, so the frontend relies on `message_end.metadata.annotation_reply` to clear the responding state and show annotation metadata. Without this field, the stop-response button can remain visible after an annotation reply.

## Screenshots

The visual reproduction is documented in the linked issue. The affected UI shows an annotation reply already returned while the stop-response button remains visible.

## Tests

```bash
pytest -o addopts="" \
  tests/unit_tests/core/app/apps/agent_chat/test_agent_chat_generate_response_converter.py \
  tests/unit_tests/core/app/apps/completion/test_completion_generate_response_converter.py \
  tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py -q
```

Result:

```text
33 passed
```

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods