### PR TITLE
fix: stream LLM text chunks as message event regardless of file state (#36990)

### DIFF
--- a/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
+++ b/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
@@ -346,15 +346,9 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline):
 
                     match event:
                         case QueueLLMChunkEvent():
-                            # Determine the event type once, on first LLM chunk, and reuse for subsequent chunks
-                            if not hasattr(self, "_precomputed_event_type") or self._precomputed_event_type is None:
-                                self._precomputed_event_type = self._message_cycle_manager.get_message_event_type(
-                                    message_id=self._message_id
-                                )
                             yield self._message_cycle_manager.message_to_stream_response(
                                 answer=cast(str, delta_text),
                                 message_id=self._message_id,
-                                event_type=self._precomputed_event_type,
                             )
                         case _:
                             yield self._agent_message_to_stream_response(

--- a/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_based_generate_task_pipeline.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_based_generate_task_pipeline.py
@@ -133,10 +133,10 @@ class TestEasyUIBasedGenerateTaskPipelineProcessStreamResponse:
             pipeline._task_state = mock_task_state
             return pipeline
 
-    def test_get_message_event_type_called_once_when_first_llm_chunk_arrives(
+    def test_llm_chunk_always_streams_as_message_event(
         self, pipeline, mock_message_cycle_manager
     ):
-        """Expect get_message_event_type to be called when processing the first LLM chunk event."""
+        """LLM text chunks should always be streamed as MESSAGE, regardless of file state."""
         # Setup a minimal LLM chunk event
         chunk = Mock()
         chunk.delta.message.content = "hi"
@@ -150,8 +150,12 @@ class TestEasyUIBasedGenerateTaskPipelineProcessStreamResponse:
         # Execute
         list(pipeline._process_stream_response(publisher=None, trace_manager=None))
 
-        # Assert
-        mock_message_cycle_manager.get_message_event_type.assert_called_once_with(message_id="test-message-id")
+        # Assert: get_message_event_type should NOT be called for LLM chunks
+        mock_message_cycle_manager.get_message_event_type.assert_not_called()
+        # Assert: message_to_stream_response should be called WITHOUT explicit event_type (defaults to MESSAGE)
+        mock_message_cycle_manager.message_to_stream_response.assert_called_once_with(
+            answer="hi", message_id="test-message-id"
+        )
 
     def test_llm_chunk_event_with_text_content(self, pipeline, mock_message_cycle_manager, mock_task_state):
         """Test handling of LLM chunk events with text content."""
@@ -167,15 +171,13 @@ class TestEasyUIBasedGenerateTaskPipelineProcessStreamResponse:
         mock_queue_message.event = llm_chunk_event
         pipeline.queue_manager.listen.return_value = [mock_queue_message]
 
-        mock_message_cycle_manager.get_message_event_type.return_value = StreamEvent.MESSAGE
-
         # Execute
         responses = list(pipeline._process_stream_response(publisher=None, trace_manager=None))
 
         # Assert
         assert len(responses) == 1
         mock_message_cycle_manager.message_to_stream_response.assert_called_once_with(
-            answer="Hello, world!", message_id="test-message-id", event_type=StreamEvent.MESSAGE
+            answer="Hello, world!", message_id="test-message-id"
         )
         assert mock_task_state.llm_result.message.content == "Hello, world!"
 
@@ -196,15 +198,13 @@ class TestEasyUIBasedGenerateTaskPipelineProcessStreamResponse:
         mock_queue_message.event = llm_chunk_event
         pipeline.queue_manager.listen.return_value = [mock_queue_message]
 
-        mock_message_cycle_manager.get_message_event_type.return_value = StreamEvent.MESSAGE
-
         # Execute
         responses = list(pipeline._process_stream_response(publisher=None, trace_manager=None))
 
         # Assert
         assert len(responses) == 1
         mock_message_cycle_manager.message_to_stream_response.assert_called_once_with(
-            answer="Hello world!", message_id="test-message-id", event_type=StreamEvent.MESSAGE
+            answer="Hello world!", message_id="test-message-id"
         )
         assert mock_task_state.llm_result.message.content == "Hello world!"
 
@@ -400,7 +400,6 @@ class TestEasyUIBasedGenerateTaskPipelineProcessStreamResponse:
         ]
         pipeline.queue_manager.listen.return_value = mock_queue_messages
 
-        mock_message_cycle_manager.get_message_event_type.return_value = StreamEvent.MESSAGE
         pipeline.ping_stream_response = Mock(return_value=Mock(spec=PingStreamResponse))
 
         # Execute
@@ -413,8 +412,8 @@ class TestEasyUIBasedGenerateTaskPipelineProcessStreamResponse:
         # Verify calls to message_to_stream_response
         assert mock_message_cycle_manager.message_to_stream_response.call_count == 2
         mock_message_cycle_manager.message_to_stream_response.assert_any_call(
-            answer="Hello", message_id="test-message-id", event_type=StreamEvent.MESSAGE
+            answer="Hello", message_id="test-message-id"
         )
         mock_message_cycle_manager.message_to_stream_response.assert_any_call(
-            answer=" world!", message_id="test-message-id", event_type=StreamEvent.MESSAGE
+            answer=" world!", message_id="test-message-id"
         )

--- a/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_based_generate_task_pipeline.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_based_generate_task_pipeline.py
@@ -133,9 +133,7 @@ class TestEasyUIBasedGenerateTaskPipelineProcessStreamResponse:
             pipeline._task_state = mock_task_state
             return pipeline
 
-    def test_llm_chunk_always_streams_as_message_event(
-        self, pipeline, mock_message_cycle_manager
-    ):
+    def test_llm_chunk_always_streams_as_message_event(self, pipeline, mock_message_cycle_manager):
         """LLM text chunks should always be streamed as MESSAGE, regardless of file state."""
         # Setup a minimal LLM chunk event
         chunk = Mock()


### PR DESCRIPTION
## Summary

Fixes #36990: `QueueLLMChunkEvent` text chunks should always be streamed as `event: message`, regardless of whether the same assistant message also has files.

### Root cause

In `_process_stream_response`, when processing an LLM chunk event, the code called `get_message_event_type()` which returns `MESSAGE_FILE` if the message had previously emitted a file event. The LLM text chunk was then wrapped in a `message_file` event, causing the frontend to drop the text content.

### Fix

Remove the `get_message_event_type()` call from the LLM chunk path. `message_to_stream_response()` already defaults to `StreamEvent.MESSAGE` when no `event_type` is passed, so the fix simply stops overriding it.

### Changes

- `easy_ui_based_generate_task_pipeline.py`: stop calling `get_message_event_type()` for `QueueLLMChunkEvent`, let `message_to_stream_response()` use its default `MESSAGE` event type
- Updated 4 tests to reflect the new behavior + verify that LLM chunks always stream as `MESSAGE`

### Test plan

- [x] All 37 tests in `test_easy_ui_based_generate_task_pipeline.py` pass
- [x] All 34 tests in `test_easy_ui_based_generate_task_pipeline_core.py` pass
- [x] All 7 tests in `test_message_cycle_manager_optimization.py` pass
- [x] Ruff linting passes