### PR TITLE
chore: add missing @override decorator to api/configs

### DIFF
--- a/api/configs/app_config.py
+++ b/api/configs/app_config.py
@@ -29,6 +29,7 @@ class RemoteSettingsSourceFactory(PydanticBaseSettingsSource):
     def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
         raise NotImplementedError
 
+    @override
     def __call__(self) -> dict[str, Any]:
         current_state = self.current_state
         remote_source_name = current_state.get("REMOTE_SETTINGS_SOURCE_NAME")


### PR DESCRIPTION
## Summary

  `RemoteSettingsSourceFactory.__call__` overrides
  `PydanticBaseSettingsSource.__call__`
  (abstract method) but was missing the `@override`
  decorator. The `typing.override`
  import was already in the file — `get_field_value` in the
  same class already uses it —
  so this is just the one missing annotation.

   #36406

  ## Checklist

  - [ ] This change requires a documentation update,
  included: [Dify 
  Document](https://github.com/langgenius/dify-docs)
  - [x] I understand that this PR may be closed in case there
  was no previous discussion or issues. (This doesn't apply
  to typos!)
  - [ ] I've added a test for each change that was
  introduced, and I tried as much as possible to make a
  single atomic change.
  - [ ] I've updated the documentation accordingly.
  - [x] I ran `make lint && make type-check` (backend) and
  `cd web && pnpm exec vp staged` (frontend) to appease the
  lint gods