### PR TITLE
refactor(web): use non-suspense system features queries in public routes

### DIFF
--- a/web/app/(shareLayout)/webapp-reset-password/layout.tsx
+++ b/web/app/(shareLayout)/webapp-reset-password/layout.tsx
@@ -2,11 +2,20 @@
 import { cn } from '@langgenius/dify-ui/cn'
 import { useQuery } from '@tanstack/react-query'
 
+import Loading from '@/app/components/base/loading'
 import Header from '@/app/signin/_header'
 import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 
 export default function SignInLayout({ children }: any) {
-  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder, isPlaceholderData } = useQuery(systemFeaturesQueryOptions())
+  if (isPlaceholderData) {
+    return (
+      <div className="flex min-h-screen w-full justify-center bg-background-default-burn">
+        <Loading />
+      </div>
+    )
+  }
+
   return (
     <>
       <div className={cn('flex min-h-screen w-full justify-center bg-background-default-burn p-6')}>

--- a/web/app/(shareLayout)/webapp-reset-password/layout.tsx
+++ b/web/app/(shareLayout)/webapp-reset-password/layout.tsx
@@ -1,12 +1,12 @@
 'use client'
 import { cn } from '@langgenius/dify-ui/cn'
+import { useQuery } from '@tanstack/react-query'
 
-import { useSuspenseQuery } from '@tanstack/react-query'
 import Header from '@/app/signin/_header'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 
 export default function SignInLayout({ children }: any) {
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
   return (
     <>
       <div className={cn('flex min-h-screen w-full justify-center bg-background-default-burn p-6')}>

--- a/web/app/(shareLayout)/webapp-signin/components/external-member-sso-auth.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/external-member-sso-auth.tsx
@@ -1,17 +1,17 @@
 'use client'
 import { toast } from '@langgenius/dify-ui/toast'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import * as React from 'react'
 import { useCallback, useEffect } from 'react'
 import AppUnavailable from '@/app/components/base/app-unavailable'
 import Loading from '@/app/components/base/loading'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { SSOProtocol } from '@/features/system-features/constants'
 import { useRouter, useSearchParams } from '@/next/navigation'
 import { fetchWebOAuth2SSOUrl, fetchWebOIDCSSOUrl, fetchWebSAMLSSOUrl } from '@/service/share'
 
 const ExternalMemberSSOAuth = () => {
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder, isPlaceholderData: isSystemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
   const searchParams = useSearchParams()
   const router = useRouter()
 
@@ -63,8 +63,19 @@ const ExternalMemberSSOAuth = () => {
   }, [getAppCodeFromRedirectUrl, redirectUrl, router, systemFeatures.webapp_auth.sso_config.protocol])
 
   useEffect(() => {
+    if (isSystemFeaturesPlaceholder)
+      return
+
     handleSSOLogin()
-  }, [handleSSOLogin])
+  }, [handleSSOLogin, isSystemFeaturesPlaceholder])
+
+  if (isSystemFeaturesPlaceholder) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loading />
+      </div>
+    )
+  }
 
   if (!systemFeatures.webapp_auth.sso_config.protocol) {
     return (

--- a/web/app/(shareLayout)/webapp-signin/layout.tsx
+++ b/web/app/(shareLayout)/webapp-signin/layout.tsx
@@ -1,15 +1,15 @@
 'use client'
-
 import type { PropsWithChildren } from 'react'
+
 import { cn } from '@langgenius/dify-ui/cn'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import useDocumentTitle from '@/hooks/use-document-title'
 
 export default function SignInLayout({ children }: PropsWithChildren) {
   const { t } = useTranslation()
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
   useDocumentTitle(t('webapp.login', { ns: 'login' }))
   return (
     <>

--- a/web/app/(shareLayout)/webapp-signin/layout.tsx
+++ b/web/app/(shareLayout)/webapp-signin/layout.tsx
@@ -4,13 +4,22 @@ import type { PropsWithChildren } from 'react'
 import { cn } from '@langgenius/dify-ui/cn'
 import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
+import Loading from '@/app/components/base/loading'
 import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import useDocumentTitle from '@/hooks/use-document-title'
 
 export default function SignInLayout({ children }: PropsWithChildren) {
   const { t } = useTranslation()
-  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder, isPlaceholderData } = useQuery(systemFeaturesQueryOptions())
   useDocumentTitle(t('webapp.login', { ns: 'login' }))
+  if (isPlaceholderData) {
+    return (
+      <div className="flex min-h-screen w-full justify-center bg-background-default-burn">
+        <Loading />
+      </div>
+    )
+  }
+
   return (
     <>
       <div className={cn('flex min-h-screen w-full justify-center bg-background-default-burn p-6')}>

--- a/web/app/(shareLayout)/webapp-signin/normalForm.tsx
+++ b/web/app/(shareLayout)/webapp-signin/normalForm.tsx
@@ -1,44 +1,41 @@
 'use client'
 import { cn } from '@langgenius/dify-ui/cn'
 import { RiContractLine, RiDoorLockLine, RiErrorWarningFill } from '@remixicon/react'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import * as React from 'react'
-import { useCallback, useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Loading from '@/app/components/base/loading'
 import { IS_CE_EDITION } from '@/config'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { LicenseStatus } from '@/features/system-features/constants'
 import Link from '@/next/link'
 import MailAndCodeAuth from './components/mail-and-code-auth'
 import MailAndPasswordAuth from './components/mail-and-password-auth'
 import SSOAuth from './components/sso-auth'
 
+type AuthType = 'code' | 'password'
+
 const NormalForm = () => {
   const { t } = useTranslation()
 
-  const [isLoading, setIsLoading] = useState(true)
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
-  const [authType, updateAuthType] = useState<'code' | 'password'>('password')
-  const [showORLine, setShowORLine] = useState(false)
-  const [allMethodsAreDisabled, setAllMethodsAreDisabled] = useState(false)
+  const { data: systemFeatures = systemFeaturesPlaceholder, isPlaceholderData: isSystemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
+  const [selectedAuthType, setSelectedAuthType] = useState<AuthType | null>(null)
 
-  const init = useCallback(async () => {
-    try {
-      setAllMethodsAreDisabled(!systemFeatures.enable_social_oauth_login && !systemFeatures.enable_email_code_login && !systemFeatures.enable_email_password_login && !systemFeatures.sso_enforced_for_signin)
-      setShowORLine((systemFeatures.enable_social_oauth_login || systemFeatures.sso_enforced_for_signin) && (systemFeatures.enable_email_code_login || systemFeatures.enable_email_password_login))
-      updateAuthType(systemFeatures.enable_email_password_login ? 'password' : 'code')
-    }
-    catch (error) {
-      console.error(error)
-      setAllMethodsAreDisabled(true)
-    }
-    finally { setIsLoading(false) }
-  }, [systemFeatures])
-  useEffect(() => {
-    init()
-  }, [init])
-  if (isLoading) {
+  const hasSsoLogin = Boolean(systemFeatures.sso_enforced_for_signin)
+  const hasEmailCodeLogin = systemFeatures.enable_email_code_login
+  const hasEmailPasswordLogin = systemFeatures.enable_email_password_login
+  const hasEmailLogin = hasEmailCodeLogin || hasEmailPasswordLogin
+  const defaultAuthType: AuthType = hasEmailPasswordLogin ? 'password' : 'code'
+  const authType = selectedAuthType === 'password' && hasEmailPasswordLogin
+    ? 'password'
+    : selectedAuthType === 'code' && hasEmailCodeLogin
+      ? 'code'
+      : defaultAuthType
+  const showORLine = hasSsoLogin && hasEmailLogin
+  const allMethodsAreDisabled = !hasEmailCodeLogin && !hasEmailPasswordLogin && !hasSsoLogin
+
+  if (isSystemFeaturesPlaceholder) {
     return (
       <div className={
         cn(
@@ -110,7 +107,7 @@ const NormalForm = () => {
         </div>
         <div className="relative">
           <div className="mt-6 flex flex-col gap-3">
-            {systemFeatures.sso_enforced_for_signin && (
+            {hasSsoLogin && (
               <div className="w-full">
                 <SSOAuth protocol={systemFeatures.sso_enforced_for_signin_protocol} />
               </div>
@@ -128,23 +125,23 @@ const NormalForm = () => {
             </div>
           )}
           {
-            (systemFeatures.enable_email_code_login || systemFeatures.enable_email_password_login) && (
+            hasEmailLogin && (
               <>
-                {systemFeatures.enable_email_code_login && authType === 'code' && (
+                {hasEmailCodeLogin && authType === 'code' && (
                   <>
                     <MailAndCodeAuth />
-                    {systemFeatures.enable_email_password_login && (
-                      <div className="cursor-pointer py-1 text-center" onClick={() => { updateAuthType('password') }}>
+                    {hasEmailPasswordLogin && (
+                      <div className="cursor-pointer py-1 text-center" onClick={() => { setSelectedAuthType('password') }}>
                         <span className="system-xs-medium text-components-button-secondary-accent-text">{t('usePassword', { ns: 'login' })}</span>
                       </div>
                     )}
                   </>
                 )}
-                {systemFeatures.enable_email_password_login && authType === 'password' && (
+                {hasEmailPasswordLogin && authType === 'password' && (
                   <>
                     <MailAndPasswordAuth isEmailSetup={systemFeatures.is_email_setup} />
-                    {systemFeatures.enable_email_code_login && (
-                      <div className="cursor-pointer py-1 text-center" onClick={() => { updateAuthType('code') }}>
+                    {hasEmailCodeLogin && (
+                      <div className="cursor-pointer py-1 text-center" onClick={() => { setSelectedAuthType('code') }}>
                         <span className="system-xs-medium text-components-button-secondary-accent-text">{t('useVerificationCode', { ns: 'login' })}</span>
                       </div>
                     )}

--- a/web/app/(shareLayout)/webapp-signin/page.tsx
+++ b/web/app/(shareLayout)/webapp-signin/page.tsx
@@ -1,12 +1,13 @@
 'use client'
 import type { FC } from 'react'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import * as React from 'react'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import AppUnavailable from '@/app/components/base/app-unavailable'
+import Loading from '@/app/components/base/loading'
 import { useWebAppStore } from '@/context/web-app-context'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { AccessMode } from '@/models/access-control'
 import { useRouter, useSearchParams } from '@/next/navigation'
 import { webAppLogout } from '@/service/webapp-auth'
@@ -15,7 +16,7 @@ import NormalForm from './normalForm'
 
 const WebSSOForm: FC = () => {
   const { t } = useTranslation()
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder, isPlaceholderData: isSystemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
   const webAppAccessMode = useWebAppStore(s => s.webAppAccessMode)
   const searchParams = useSearchParams()
   const router = useRouter()
@@ -39,6 +40,14 @@ const WebSSOForm: FC = () => {
     return (
       <div className="flex h-full items-center justify-center">
         <AppUnavailable code={t('common.appUnavailable', { ns: 'share' })} unknownReason="redirect url is invalid." />
+      </div>
+    )
+  }
+
+  if (isSystemFeaturesPlaceholder) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loading />
       </div>
     )
   }

--- a/web/app/account/oauth/authorize/layout.tsx
+++ b/web/app/account/oauth/authorize/layout.tsx
@@ -1,27 +1,25 @@
 'use client'
 import { cn } from '@langgenius/dify-ui/cn'
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 import Loading from '@/app/components/base/loading'
 import Header from '@/app/signin/_header'
-import { AppContextProvider } from '@/context/app-context-provider'
 import { isLegacyBase401, userProfileQueryOptions } from '@/features/account-profile/client'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import useDocumentTitle from '@/hooks/use-document-title'
 
 export default function SignInLayout({ children }: any) {
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder, isPlaceholderData: isSystemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
   useDocumentTitle('')
   // Probe login state. 401 stays as `error` (not thrown) so this layout can render
   // the signin/oauth UI for unauthenticated users; other errors bubble to error.tsx.
   // (When unauthenticated, service/base.ts's auto-redirect to /signin still fires.)
-  const { isPending, data: userResp, error } = useQuery({
+  const { isPending } = useQuery({
     ...userProfileQueryOptions(),
     throwOnError: err => !isLegacyBase401(err),
   })
-  const isLoggedIn = !!userResp && !error
 
-  if (isPending) {
+  if (isPending || isSystemFeaturesPlaceholder) {
     return (
       <div className="flex min-h-screen w-full justify-center bg-background-default-burn">
         <Loading />
@@ -35,13 +33,7 @@ export default function SignInLayout({ children }: any) {
           <Header />
           <div className={cn('flex w-full grow flex-col items-center justify-center px-6 md:px-[108px]')}>
             <div className="flex flex-col md:w-[400px]">
-              {isLoggedIn
-                ? (
-                    <AppContextProvider>
-                      {children}
-                    </AppContextProvider>
-                  )
-                : children}
+              {children}
             </div>
           </div>
           {systemFeatures.branding.enabled === false && (

--- a/web/app/activate/page.tsx
+++ b/web/app/activate/page.tsx
@@ -2,12 +2,21 @@
 import { cn } from '@langgenius/dify-ui/cn'
 import { useQuery } from '@tanstack/react-query'
 import * as React from 'react'
+import Loading from '@/app/components/base/loading'
 import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import Header from '../signin/_header'
 import ActivateForm from './activateForm'
 
 const Activate = () => {
-  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder, isPlaceholderData } = useQuery(systemFeaturesQueryOptions())
+  if (isPlaceholderData) {
+    return (
+      <div className="flex min-h-screen w-full justify-center bg-background-default-burn">
+        <Loading />
+      </div>
+    )
+  }
+
   return (
     <div className={cn('flex min-h-screen w-full justify-center bg-background-default-burn p-6')}>
       <div className={cn('flex w-full shrink-0 flex-col rounded-2xl border border-effects-highlight bg-background-default-subtle')}>

--- a/web/app/activate/page.tsx
+++ b/web/app/activate/page.tsx
@@ -1,13 +1,13 @@
 'use client'
 import { cn } from '@langgenius/dify-ui/cn'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import * as React from 'react'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import Header from '../signin/_header'
 import ActivateForm from './activateForm'
 
 const Activate = () => {
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
   return (
     <div className={cn('flex min-h-screen w-full justify-center bg-background-default-burn p-6')}>
       <div className={cn('flex w-full shrink-0 flex-col rounded-2xl border border-effects-highlight bg-background-default-subtle')}>

--- a/web/app/components/base/chat/chat-with-history/sidebar/index.tsx
+++ b/web/app/components/base/chat/chat-with-history/sidebar/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@langgenius/dify-ui/alert-dialog'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import {
   useCallback,
   useState,
@@ -22,7 +22,7 @@ import List from '@/app/components/base/chat/chat-with-history/sidebar/list'
 import RenameModal from '@/app/components/base/chat/chat-with-history/sidebar/rename-modal'
 import DifyLogo from '@/app/components/base/logo/dify-logo'
 import MenuDropdown from '@/app/components/share/text-generation/menu-dropdown'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { useChatWithHistoryContext } from '../context'
 
 type Props = {
@@ -51,7 +51,7 @@ const Sidebar = ({ isPanel }: Props) => {
     isResponding,
   } = useChatWithHistoryContext()
   const isSidebarCollapsed = sidebarCollapseState
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
   const [showConfirm, setShowConfirm] = useState<ConversationItem | null>(null)
   const [showRename, setShowRename] = useState<ConversationItem | null>(null)
 

--- a/web/app/components/base/chat/embedded-chatbot/header/index.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/header/index.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react'
 import type { Theme } from '../theme/theme-context'
 import { cn } from '@langgenius/dify-ui/cn'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/tooltip'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import * as React from 'react'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -10,7 +10,7 @@ import ActionButton from '@/app/components/base/action-button'
 import ViewFormDropdown from '@/app/components/base/chat/embedded-chatbot/inputs-form/view-form-dropdown'
 import Divider from '@/app/components/base/divider'
 import DifyLogo from '@/app/components/base/logo/dify-logo'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { isClient } from '@/utils/client'
 import {
   useEmbeddedChatbotContext,
@@ -45,7 +45,7 @@ const Header: FC<IHeaderProps> = ({
   const [parentOrigin, setParentOrigin] = useState('')
   const [showToggleExpandButton, setShowToggleExpandButton] = useState(false)
   const [expanded, setExpanded] = useState(false)
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
 
   const handleMessageReceived = useCallback((event: MessageEvent) => {
     let currentParentOrigin = parentOrigin

--- a/web/app/components/base/chat/embedded-chatbot/index.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 import type { AppData } from '@/models/share'
 import { cn } from '@langgenius/dify-ui/cn'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import {
   useEffect,
 } from 'react'
@@ -11,7 +11,7 @@ import Header from '@/app/components/base/chat/embedded-chatbot/header'
 import Loading from '@/app/components/base/loading'
 import DifyLogo from '@/app/components/base/logo/dify-logo'
 import LogoHeader from '@/app/components/base/logo/logo-embedded-chat-header'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
 import useDocumentTitle from '@/hooks/use-document-title'
 import { AppSourceType } from '@/service/share'
@@ -35,7 +35,7 @@ const Chatbot = () => {
     themeBuilder,
   } = useEmbeddedChatbotContext()
   const { t } = useTranslation()
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
 
   const customConfig = appData?.custom_config
   const site = appData?.site

--- a/web/app/components/share/text-generation/hooks/use-text-generation-app-state.ts
+++ b/web/app/components/share/text-generation/hooks/use-text-generation-app-state.ts
@@ -3,12 +3,12 @@ import type { MoreLikeThisConfig, PromptConfig, SavedMessage, TextToSpeechConfig
 import type { SiteInfo } from '@/models/share'
 import type { VisionSettings } from '@/types/app'
 import { toast } from '@langgenius/dify-ui/toast'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getRawInputsFromUrlParams } from '@/app/components/base/chat/utils'
 import { useWebAppStore } from '@/context/web-app-context'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { useAppFavicon } from '@/hooks/use-app-favicon'
 import useDocumentTitle from '@/hooks/use-document-title'
 import { changeLanguage } from '@/i18n-config/client'
@@ -73,7 +73,7 @@ const coerceWorkflowUrlDefault = (
 export const useTextGenerationAppState = ({ isInstalledApp, isWorkflow }: UseTextGenerationAppStateOptions) => {
   const { t } = useTranslation()
   const appSourceType = isInstalledApp ? AppSourceType.installedApp : AppSourceType.webApp
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
   const appData = useWebAppStore(s => s.appInfo)
   const appParams = useWebAppStore(s => s.appParams)
   const accessMode = useWebAppStore(s => s.webAppAccessMode)

--- a/web/app/device/_header.tsx
+++ b/web/app/device/_header.tsx
@@ -19,19 +19,21 @@ const ThemeSelector = dynamic(() => import('@/app/components/base/theme-selector
 
 const Header = () => {
   const locale = useLocale()
-  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder, isPlaceholderData } = useQuery(systemFeaturesQueryOptions())
 
   return (
     <div className="flex w-full items-center justify-between p-6">
-      {systemFeatures.branding.enabled && systemFeatures.branding.login_page_logo
-        ? (
-            <img
-              src={systemFeatures.branding.login_page_logo}
-              className="block h-7 w-auto object-contain"
-              alt="logo"
-            />
-          )
-        : <DifyLogo size="large" />}
+      {isPlaceholderData
+        ? <div className="h-7 w-16 bg-transparent" />
+        : systemFeatures.branding.enabled && systemFeatures.branding.login_page_logo
+          ? (
+              <img
+                src={systemFeatures.branding.login_page_logo}
+                className="block h-7 w-auto object-contain"
+                alt="logo"
+              />
+            )
+          : <DifyLogo size="large" />}
       <div className="flex items-center gap-1">
         <LocaleMenu
           value={locale}

--- a/web/app/device/_header.tsx
+++ b/web/app/device/_header.tsx
@@ -1,9 +1,9 @@
 'use client'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import Divider from '@/app/components/base/divider'
 import LocaleMenu from '@/app/signin/_locale-menu'
 import { useLocale } from '@/context/i18n'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { setLocaleOnClient } from '@/i18n-config'
 import { languages } from '@/i18n-config/language'
 import dynamic from '@/next/dynamic'
@@ -19,7 +19,7 @@ const ThemeSelector = dynamic(() => import('@/app/components/base/theme-selector
 
 const Header = () => {
   const locale = useLocale()
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
 
   return (
     <div className="flex w-full items-center justify-between p-6">

--- a/web/app/device/layout.tsx
+++ b/web/app/device/layout.tsx
@@ -1,12 +1,12 @@
 'use client'
 import { cn } from '@langgenius/dify-ui/cn'
-import { useSuspenseQuery } from '@tanstack/react-query'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { useQuery } from '@tanstack/react-query'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import useDocumentTitle from '@/hooks/use-document-title'
 import Header from './_header'
 
 export default function DeviceLayout({ children }: { children: React.ReactNode }) {
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
   useDocumentTitle('')
   return (
     <div className={cn('flex min-h-screen w-full justify-center bg-background-default-burn p-6')}>

--- a/web/app/device/layout.tsx
+++ b/web/app/device/layout.tsx
@@ -1,13 +1,22 @@
 'use client'
 import { cn } from '@langgenius/dify-ui/cn'
 import { useQuery } from '@tanstack/react-query'
+import Loading from '@/app/components/base/loading'
 import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import useDocumentTitle from '@/hooks/use-document-title'
 import Header from './_header'
 
 export default function DeviceLayout({ children }: { children: React.ReactNode }) {
-  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder, isPlaceholderData } = useQuery(systemFeaturesQueryOptions())
   useDocumentTitle('')
+  if (isPlaceholderData) {
+    return (
+      <div className="flex min-h-screen w-full justify-center bg-background-default-burn">
+        <Loading />
+      </div>
+    )
+  }
+
   return (
     <div className={cn('flex min-h-screen w-full justify-center bg-background-default-burn p-6')}>
       <div className={cn('flex w-full shrink-0 flex-col items-center rounded-2xl border border-effects-highlight bg-background-default-subtle')}>

--- a/web/app/forgot-password/page.tsx
+++ b/web/app/forgot-password/page.tsx
@@ -2,6 +2,7 @@
 import { cn } from '@langgenius/dify-ui/cn'
 import { useQuery } from '@tanstack/react-query'
 import * as React from 'react'
+import Loading from '@/app/components/base/loading'
 import ChangePasswordForm from '@/app/forgot-password/ChangePasswordForm'
 import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import useDocumentTitle from '@/hooks/use-document-title'
@@ -13,7 +14,14 @@ const ForgotPassword = () => {
   useDocumentTitle('')
   const searchParams = useSearchParams()
   const token = searchParams.get('token')
-  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder, isPlaceholderData } = useQuery(systemFeaturesQueryOptions())
+  if (isPlaceholderData) {
+    return (
+      <div className="flex min-h-screen w-full justify-center bg-background-default-burn">
+        <Loading />
+      </div>
+    )
+  }
 
   return (
     <div className={cn('flex min-h-screen w-full justify-center bg-background-default-burn p-6')}>

--- a/web/app/forgot-password/page.tsx
+++ b/web/app/forgot-password/page.tsx
@@ -1,9 +1,9 @@
 'use client'
 import { cn } from '@langgenius/dify-ui/cn'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import * as React from 'react'
 import ChangePasswordForm from '@/app/forgot-password/ChangePasswordForm'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import useDocumentTitle from '@/hooks/use-document-title'
 import { useSearchParams } from '@/next/navigation'
 import Header from '../signin/_header'
@@ -13,7 +13,7 @@ const ForgotPassword = () => {
   useDocumentTitle('')
   const searchParams = useSearchParams()
   const token = searchParams.get('token')
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
 
   return (
     <div className={cn('flex min-h-screen w-full justify-center bg-background-default-burn p-6')}>

--- a/web/app/install/page.tsx
+++ b/web/app/install/page.tsx
@@ -1,13 +1,13 @@
 'use client'
 import { cn } from '@langgenius/dify-ui/cn'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import * as React from 'react'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import Header from '../signin/_header'
 import InstallForm from './installForm'
 
 const Install = () => {
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
   return (
     <div className={cn('flex min-h-screen w-full justify-center bg-background-default-burn p-6')}>
       <div className={cn('flex w-full shrink-0 flex-col rounded-2xl border border-effects-highlight bg-background-default-subtle')}>

--- a/web/app/install/page.tsx
+++ b/web/app/install/page.tsx
@@ -2,12 +2,21 @@
 import { cn } from '@langgenius/dify-ui/cn'
 import { useQuery } from '@tanstack/react-query'
 import * as React from 'react'
+import Loading from '@/app/components/base/loading'
 import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import Header from '../signin/_header'
 import InstallForm from './installForm'
 
 const Install = () => {
-  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder, isPlaceholderData } = useQuery(systemFeaturesQueryOptions())
+  if (isPlaceholderData) {
+    return (
+      <div className="flex min-h-screen w-full justify-center bg-background-default-burn">
+        <Loading />
+      </div>
+    )
+  }
+
   return (
     <div className={cn('flex min-h-screen w-full justify-center bg-background-default-burn p-6')}>
       <div className={cn('flex w-full shrink-0 flex-col rounded-2xl border border-effects-highlight bg-background-default-subtle')}>

--- a/web/app/reset-password/layout.tsx
+++ b/web/app/reset-password/layout.tsx
@@ -2,11 +2,20 @@
 import { cn } from '@langgenius/dify-ui/cn'
 import { useQuery } from '@tanstack/react-query'
 
+import Loading from '@/app/components/base/loading'
 import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import Header from '../signin/_header'
 
 export default function SignInLayout({ children }: any) {
-  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder, isPlaceholderData } = useQuery(systemFeaturesQueryOptions())
+  if (isPlaceholderData) {
+    return (
+      <div className="flex min-h-screen w-full justify-center bg-background-default-burn">
+        <Loading />
+      </div>
+    )
+  }
+
   return (
     <>
       <div className={cn('flex min-h-screen w-full justify-center bg-background-default-burn p-6')}>

--- a/web/app/reset-password/layout.tsx
+++ b/web/app/reset-password/layout.tsx
@@ -1,12 +1,12 @@
 'use client'
 import { cn } from '@langgenius/dify-ui/cn'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import Header from '../signin/_header'
 
 export default function SignInLayout({ children }: any) {
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
   return (
     <>
       <div className={cn('flex min-h-screen w-full justify-center bg-background-default-burn p-6')}>

--- a/web/app/signin/__tests__/_header.spec.tsx
+++ b/web/app/signin/__tests__/_header.spec.tsx
@@ -1,11 +1,15 @@
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { setLocaleOnClient } from '@/i18n-config'
 import Header from '../_header'
 
-vi.mock('@tanstack/react-query', () => ({
-  useSuspenseQuery: vi.fn(),
-}))
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query')
+  return {
+    ...actual,
+    useQuery: vi.fn(),
+  }
+})
 
 vi.mock('@/context/i18n', () => ({
   useLocale: () => 'en-US',
@@ -19,10 +23,6 @@ vi.mock('@/next/dynamic', () => ({
   default: () => () => null,
 }))
 
-vi.mock('@/features/system-features/client', () => ({
-  systemFeaturesQueryOptions: () => ({}),
-}))
-
 vi.mock('../_locale-menu', () => ({
   default: ({ onChange }: { onChange?: (value: string) => void }) => (
     <button type="button" onClick={() => onChange?.('ja-JP')}>
@@ -31,20 +31,20 @@ vi.mock('../_locale-menu', () => ({
   ),
 }))
 
-const mockUseSuspenseQuery = vi.mocked(useSuspenseQuery)
+const mockUseQuery = vi.mocked(useQuery)
 const mockSetLocaleOnClient = vi.mocked(setLocaleOnClient)
 
 describe('Signin Header', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockUseSuspenseQuery.mockReturnValue({
+    mockUseQuery.mockReturnValue({
       data: {
         branding: {
           enabled: false,
           login_page_logo: '',
         },
       },
-    } as ReturnType<typeof useSuspenseQuery>)
+    } as ReturnType<typeof useQuery>)
   })
 
   it('should switch locale without forcing a full page reload', () => {

--- a/web/app/signin/_header.tsx
+++ b/web/app/signin/_header.tsx
@@ -20,19 +20,21 @@ const ThemeSelector = dynamic(() => import('@/app/components/base/theme-selector
 
 const Header = () => {
   const locale = useLocale()
-  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder, isPlaceholderData } = useQuery(systemFeaturesQueryOptions())
 
   return (
     <div className="flex w-full items-center justify-between p-6">
-      {systemFeatures.branding.enabled && systemFeatures.branding.login_page_logo
-        ? (
-            <img
-              src={systemFeatures.branding.login_page_logo}
-              className="block h-7 w-auto object-contain"
-              alt="logo"
-            />
-          )
-        : <DifyLogo size="large" />}
+      {isPlaceholderData
+        ? <div className="h-7 w-16 bg-transparent" />
+        : systemFeatures.branding.enabled && systemFeatures.branding.login_page_logo
+          ? (
+              <img
+                src={systemFeatures.branding.login_page_logo}
+                className="block h-7 w-auto object-contain"
+                alt="logo"
+              />
+            )
+          : <DifyLogo size="large" />}
       <div className="flex items-center gap-1">
         <LocaleMenu
           value={locale}

--- a/web/app/signin/_header.tsx
+++ b/web/app/signin/_header.tsx
@@ -1,8 +1,8 @@
 'use client'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import Divider from '@/app/components/base/divider'
 import { useLocale } from '@/context/i18n'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { setLocaleOnClient } from '@/i18n-config'
 import { languages } from '@/i18n-config/language'
 import dynamic from '@/next/dynamic'
@@ -20,7 +20,7 @@ const ThemeSelector = dynamic(() => import('@/app/components/base/theme-selector
 
 const Header = () => {
   const locale = useLocale()
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
 
   return (
     <div className="flex w-full items-center justify-between p-6">

--- a/web/app/signin/invite-settings/__tests__/page.spec.tsx
+++ b/web/app/signin/invite-settings/__tests__/page.spec.tsx
@@ -1,4 +1,5 @@
 import type { MockedFunction } from 'vitest'
+import { useQuery } from '@tanstack/react-query'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useLocale } from '@/context/i18n'
@@ -15,13 +16,7 @@ vi.mock('@tanstack/react-query', async () => {
     useQueryClient: vi.fn(() => ({
       resetQueries: vi.fn(),
     })),
-    useSuspenseQuery: vi.fn(() => ({
-      data: {
-        branding: {
-          enabled: true,
-        },
-      },
-    })),
+    useQuery: vi.fn(),
   }
 })
 
@@ -67,6 +62,7 @@ const mockRefetch = vi.fn()
 const mockUseLocale = useLocale as unknown as MockedFunction<typeof useLocale>
 const mockUseRouter = useRouter as unknown as MockedFunction<typeof useRouter>
 const mockUseSearchParams = useSearchParams as unknown as MockedFunction<typeof useSearchParams>
+const mockUseQuery = useQuery as unknown as MockedFunction<typeof useQuery>
 const mockActivateMember = activateMember as unknown as MockedFunction<typeof activateMember>
 const mockUseInvitationCheck = useInvitationCheck as unknown as MockedFunction<typeof useInvitationCheck>
 const mockGetBrowserTimezone = getBrowserTimezone as unknown as MockedFunction<typeof getBrowserTimezone>
@@ -79,6 +75,13 @@ describe('InviteSettingsPage', () => {
     mockUseSearchParams.mockReturnValue(
       new URLSearchParams('invite_token=invite-token') as unknown as ReturnType<typeof useSearchParams>,
     )
+    mockUseQuery.mockReturnValue({
+      data: {
+        branding: {
+          enabled: true,
+        },
+      },
+    } as ReturnType<typeof useQuery>)
     mockUseInvitationCheck.mockReturnValue({
       data: {
         is_valid: true,

--- a/web/app/signin/invite-settings/page.tsx
+++ b/web/app/signin/invite-settings/page.tsx
@@ -4,7 +4,7 @@ import { Button } from '@langgenius/dify-ui/button'
 import { Select, SelectContent, SelectItem, SelectItemIndicator, SelectItemText, SelectTrigger } from '@langgenius/dify-ui/select'
 import { toast } from '@langgenius/dify-ui/toast'
 import { RiAccountCircleLine } from '@remixicon/react'
-import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { noop } from 'es-toolkit/function'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -12,7 +12,7 @@ import Input from '@/app/components/base/input'
 import Loading from '@/app/components/base/loading'
 import { LICENSE_LINK } from '@/constants/link'
 import { useLocale } from '@/context/i18n'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { i18n, setLocaleOnClient } from '@/i18n-config'
 import { languages } from '@/i18n-config/language'
 import Link from '@/next/link'
@@ -54,7 +54,7 @@ const getInitialLanguage = (locale: Locale): Locale => {
 
 export default function InviteSettingsPage() {
   const { t } = useTranslation()
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
   const router = useRouter()
   const queryClient = useQueryClient()
   const searchParams = useSearchParams()

--- a/web/app/signin/layout.tsx
+++ b/web/app/signin/layout.tsx
@@ -1,13 +1,13 @@
 'use client'
 import { cn } from '@langgenius/dify-ui/cn'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import useDocumentTitle from '@/hooks/use-document-title'
 import Header from './_header'
 
 export default function SignInLayout({ children }: any) {
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
   useDocumentTitle('')
   return (
     <>

--- a/web/app/signin/layout.tsx
+++ b/web/app/signin/layout.tsx
@@ -2,13 +2,22 @@
 import { cn } from '@langgenius/dify-ui/cn'
 import { useQuery } from '@tanstack/react-query'
 
+import Loading from '@/app/components/base/loading'
 import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import useDocumentTitle from '@/hooks/use-document-title'
 import Header from './_header'
 
 export default function SignInLayout({ children }: any) {
-  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder, isPlaceholderData } = useQuery(systemFeaturesQueryOptions())
   useDocumentTitle('')
+  if (isPlaceholderData) {
+    return (
+      <div className="flex min-h-screen w-full justify-center bg-background-default-burn">
+        <Loading />
+      </div>
+    )
+  }
+
   return (
     <>
       <div className={cn('flex min-h-screen w-full justify-center bg-background-default-burn p-6')}>

--- a/web/app/signin/normal-form.tsx
+++ b/web/app/signin/normal-form.tsx
@@ -1,13 +1,12 @@
 import { cn } from '@langgenius/dify-ui/cn'
 import { toast } from '@langgenius/dify-ui/toast'
 import { RiContractLine, RiDoorLockLine, RiErrorWarningFill } from '@remixicon/react'
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
-import * as React from 'react'
-import { useCallback, useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { IS_CE_EDITION } from '@/config'
 import { isLegacyBase401, userProfileQueryOptions } from '@/features/account-profile/client'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { LicenseStatus } from '@/features/system-features/constants'
 import Link from '@/next/link'
 import { useRouter, useSearchParams } from '@/next/navigation'
@@ -20,7 +19,9 @@ import SSOAuth from './components/sso-auth'
 import Split from './split'
 import { resolvePostLoginRedirect } from './utils/post-login-redirect'
 
-const NormalForm = () => {
+type AuthType = 'code' | 'password'
+
+function NormalForm() {
   const { t } = useTranslation()
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -30,55 +31,58 @@ const NormalForm = () => {
   const { isPending: isCheckLoading, data: userResp, error: probeError } = useQuery({
     ...userProfileQueryOptions(),
     throwOnError: err => !isLegacyBase401(err),
+    refetchOnWindowFocus: false,
   })
   const isLoggedIn = !!userResp && !probeError
   const message = decodeURIComponent(searchParams.get('message') || '')
-  const invite_token = decodeURIComponent(searchParams.get('invite_token') || '')
-  const [isInitCheckLoading, setInitCheckLoading] = useState(true)
-  const [isRedirecting, setIsRedirecting] = useState(false)
-  const isLoading = isCheckLoading || isInitCheckLoading || isRedirecting
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
-  const [authType, updateAuthType] = useState<'code' | 'password'>('password')
-  const [showORLine, setShowORLine] = useState(false)
-  const [allMethodsAreDisabled, setAllMethodsAreDisabled] = useState(false)
-  const [workspaceName, setWorkSpaceName] = useState('')
+  const inviteToken = decodeURIComponent(searchParams.get('invite_token') || '')
+  const { data: systemFeatures = systemFeaturesPlaceholder, isPlaceholderData: isSystemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
+  const [selectedAuthType, setSelectedAuthType] = useState<AuthType | null>(null)
 
-  const isInviteLink = Boolean(invite_token && invite_token !== 'null')
+  const isInviteLink = Boolean(inviteToken && inviteToken !== 'null')
+  const { data: invitationCheckResp, isPending: isInviteCheckLoading, isError: isInviteCheckError } = useQuery({
+    queryKey: ['signin', 'invite-check', inviteToken],
+    queryFn: () => invitationCheck({
+      url: '/activate/check',
+      params: {
+        token: inviteToken,
+      },
+    }),
+    enabled: isInviteLink,
+    retry: false,
+    refetchOnWindowFocus: false,
+  })
 
-  const init = useCallback(async () => {
-    try {
-      if (isLoggedIn) {
-        setIsRedirecting(true)
-        const redirectUrl = resolvePostLoginRedirect(searchParams)
-        router.replace(redirectUrl || '/')
-        return
-      }
+  const workspaceName = invitationCheckResp?.data?.workspace_name || ''
+  const hasSocialLogin = systemFeatures.enable_social_oauth_login
+  const hasSsoLogin = Boolean(systemFeatures.sso_enforced_for_signin)
+  const hasEmailCodeLogin = systemFeatures.enable_email_code_login
+  const hasEmailPasswordLogin = systemFeatures.enable_email_password_login
+  const hasEmailLogin = hasEmailCodeLogin || hasEmailPasswordLogin
+  const defaultAuthType: AuthType = hasEmailPasswordLogin ? 'password' : 'code'
+  const authType = selectedAuthType === 'password' && hasEmailPasswordLogin
+    ? 'password'
+    : selectedAuthType === 'code' && hasEmailCodeLogin
+      ? 'code'
+      : defaultAuthType
+  const showORLine = (hasSocialLogin || hasSsoLogin) && hasEmailLogin
+  const noLoginMethodsConfigured = !hasSocialLogin && !hasEmailCodeLogin && !hasEmailPasswordLogin && !hasSsoLogin
+  const allMethodsAreDisabled = noLoginMethodsConfigured || isInviteCheckError
+  const isLoading = isCheckLoading || isLoggedIn || isSystemFeaturesPlaceholder || (isInviteLink && isInviteCheckLoading)
 
-      if (message) {
-        toast.error(message)
-      }
-      setAllMethodsAreDisabled(!systemFeatures.enable_social_oauth_login && !systemFeatures.enable_email_code_login && !systemFeatures.enable_email_password_login && !systemFeatures.sso_enforced_for_signin)
-      setShowORLine((systemFeatures.enable_social_oauth_login || systemFeatures.sso_enforced_for_signin) && (systemFeatures.enable_email_code_login || systemFeatures.enable_email_password_login))
-      updateAuthType(systemFeatures.enable_email_password_login ? 'password' : 'code')
-      if (isInviteLink) {
-        const checkRes = await invitationCheck({
-          url: '/activate/check',
-          params: {
-            token: invite_token,
-          },
-        })
-        setWorkSpaceName(checkRes?.data?.workspace_name || '')
-      }
-    }
-    catch (error) {
-      console.error(error)
-      setAllMethodsAreDisabled(true)
-    }
-    finally { setInitCheckLoading(false) }
-  }, [isLoggedIn, message, router, searchParams, invite_token, isInviteLink, systemFeatures])
   useEffect(() => {
-    init()
-  }, [init])
+    if (!isLoggedIn)
+      return
+
+    const redirectUrl = resolvePostLoginRedirect(searchParams)
+    router.replace(redirectUrl || '/')
+  }, [isLoggedIn, router, searchParams])
+
+  useEffect(() => {
+    if (message)
+      toast.error(message)
+  }, [message])
+
   if (isLoading) {
     return (
       <div className={
@@ -169,8 +173,8 @@ const NormalForm = () => {
             )}
         <div className="relative">
           <div className="mt-6 flex flex-col gap-3">
-            {systemFeatures.enable_social_oauth_login && <SocialAuth />}
-            {systemFeatures.sso_enforced_for_signin && (
+            {hasSocialLogin && <SocialAuth />}
+            {hasSsoLogin && (
               <div className="w-full">
                 <SSOAuth protocol={systemFeatures.sso_enforced_for_signin_protocol} />
               </div>
@@ -187,23 +191,23 @@ const NormalForm = () => {
             </div>
           )}
           {
-            (systemFeatures.enable_email_code_login || systemFeatures.enable_email_password_login) && (
+            hasEmailLogin && (
               <>
-                {systemFeatures.enable_email_code_login && authType === 'code' && (
+                {hasEmailCodeLogin && authType === 'code' && (
                   <>
                     <MailAndCodeAuth isInvite={isInviteLink} />
-                    {systemFeatures.enable_email_password_login && (
-                      <div className="cursor-pointer py-1 text-center" onClick={() => { updateAuthType('password') }}>
+                    {hasEmailPasswordLogin && (
+                      <div className="cursor-pointer py-1 text-center" onClick={() => { setSelectedAuthType('password') }}>
                         <span className="system-xs-medium text-components-button-secondary-accent-text">{t('usePassword', { ns: 'login' })}</span>
                       </div>
                     )}
                   </>
                 )}
-                {systemFeatures.enable_email_password_login && authType === 'password' && (
+                {hasEmailPasswordLogin && authType === 'password' && (
                   <>
                     <MailAndPasswordAuth isInvite={isInviteLink} isEmailSetup={systemFeatures.is_email_setup} allowRegistration={systemFeatures.is_allow_register} />
-                    {systemFeatures.enable_email_code_login && (
-                      <div className="cursor-pointer py-1 text-center" onClick={() => { updateAuthType('code') }}>
+                    {hasEmailCodeLogin && (
+                      <div className="cursor-pointer py-1 text-center" onClick={() => { setSelectedAuthType('code') }}>
                         <span className="system-xs-medium text-components-button-secondary-accent-text">{t('useVerificationCode', { ns: 'login' })}</span>
                       </div>
                     )}

--- a/web/app/signup/components/input-mail.tsx
+++ b/web/app/signup/components/input-mail.tsx
@@ -2,14 +2,14 @@
 import type { MailSendResponse } from '@/service/use-common'
 import { Button } from '@langgenius/dify-ui/button'
 import { toast } from '@langgenius/dify-ui/toast'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Input from '@/app/components/base/input'
 import Split from '@/app/signin/split'
 import { emailRegex } from '@/config'
 import { useLocale } from '@/context/i18n'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import Link from '@/next/link'
 import { useSendMail } from '@/service/use-common'
 
@@ -22,7 +22,7 @@ export default function Form({
   const { t } = useTranslation()
   const [email, setEmail] = useState('')
   const locale = useLocale()
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
 
   const { mutateAsync: submitMail, isPending } = useSendMail()
 

--- a/web/app/signup/layout.tsx
+++ b/web/app/signup/layout.tsx
@@ -2,13 +2,22 @@
 import { cn } from '@langgenius/dify-ui/cn'
 import { useQuery } from '@tanstack/react-query'
 
+import Loading from '@/app/components/base/loading'
 import Header from '@/app/signin/_header'
 import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import useDocumentTitle from '@/hooks/use-document-title'
 
 export default function RegisterLayout({ children }: any) {
-  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder, isPlaceholderData } = useQuery(systemFeaturesQueryOptions())
   useDocumentTitle('')
+  if (isPlaceholderData) {
+    return (
+      <div className="flex min-h-screen w-full justify-center bg-background-default-burn">
+        <Loading />
+      </div>
+    )
+  }
+
   return (
     <>
       <div className={cn('flex min-h-screen w-full justify-center bg-background-default-burn p-6')}>

--- a/web/app/signup/layout.tsx
+++ b/web/app/signup/layout.tsx
@@ -1,13 +1,13 @@
 'use client'
 import { cn } from '@langgenius/dify-ui/cn'
+import { useQuery } from '@tanstack/react-query'
 
-import { useSuspenseQuery } from '@tanstack/react-query'
 import Header from '@/app/signin/_header'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { systemFeaturesPlaceholder, systemFeaturesQueryOptions } from '@/features/system-features/client'
 import useDocumentTitle from '@/hooks/use-document-title'
 
 export default function RegisterLayout({ children }: any) {
-  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const { data: systemFeatures = systemFeaturesPlaceholder } = useQuery(systemFeaturesQueryOptions())
   useDocumentTitle('')
   return (
     <>

--- a/web/features/system-features/client.ts
+++ b/web/features/system-features/client.ts
@@ -4,6 +4,10 @@ import { IS_CLOUD_EDITION } from '@/config'
 import { consoleClient, consoleQuery } from '@/service/client'
 import { cloudSystemFeatures, defaultSystemFeatures } from './config'
 
+export const systemFeaturesPlaceholder = IS_CLOUD_EDITION
+  ? cloudSystemFeatures
+  : defaultSystemFeatures
+
 /**
  * Soft-fallback to defaults so the dashboard stays usable when /system-features fails.
  *
@@ -25,12 +29,14 @@ export const systemFeaturesQueryOptions = () => {
     return queryOptions<GetSystemFeaturesResponse>({
       queryKey,
       queryFn: async () => cloudSystemFeatures,
+      placeholderData: systemFeaturesPlaceholder,
       staleTime: 'static',
     })
   }
 
   return queryOptions<GetSystemFeaturesResponse>({
     queryKey,
+    placeholderData: systemFeaturesPlaceholder,
     queryFn: async () => {
       try {
         return await consoleClient.systemFeatures.get()

--- a/web/hooks/use-document-title.ts
+++ b/web/hooks/use-document-title.ts
@@ -7,12 +7,12 @@ import { defaultSystemFeatures } from '@/features/system-features/config'
 import { basePath } from '@/utils/var'
 
 export default function useDocumentTitle(title: string) {
-  const { data, isPending } = useQuery(systemFeaturesQueryOptions())
+  const { data, isPending, isPlaceholderData } = useQuery(systemFeaturesQueryOptions())
   const systemFeatures = data ?? defaultSystemFeatures
   const prefix = title ? `${title} - ` : ''
   let titleStr = ''
   let favicon = ''
-  if (isPending === false) {
+  if (isPending === false && isPlaceholderData === false) {
     if (systemFeatures.branding.enabled) {
       titleStr = `${prefix}${systemFeatures.branding.application_title}`
       favicon = systemFeatures.branding.favicon


### PR DESCRIPTION
## Summary
- consolidate system features placeholder defaults into the single `systemFeaturesQueryOptions` contract
- switch public/auth/share route consumers from `useSuspenseQuery` to explicit `useQuery(systemFeaturesQueryOptions())`
- keep common-layout/product consumers on Suspense and restore signin normal form behavior from `fix/normal-form`

## Verification
- `pnpm -C web type-check`