### PR TITLE
refactor(web): use storage hook for workflow canvas maximize

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3497,11 +3497,6 @@
       "count": 1
     }
   },
-  "web/app/components/workflow/hooks/use-workflow-canvas-maximize.ts": {
-    "no-restricted-globals": {
-      "count": 1
-    }
-  },
   "web/app/components/workflow/hooks/use-workflow-interactions.ts": {
     "no-barrel-files/no-barrel-files": {
       "count": 5

--- a/web/app/components/workflow/hooks/use-workflow-canvas-maximize.ts
+++ b/web/app/components/workflow/hooks/use-workflow-canvas-maximize.ts
@@ -1,13 +1,17 @@
 import { useCallback } from 'react'
 import { useEventEmitterContextContext } from '@/context/event-emitter'
+import { useSetLocalStorage } from '@/hooks/use-local-storage'
 import { useStore } from '../store'
 import { useNodesReadOnly } from './use-workflow'
+
+const WORKFLOW_CANVAS_MAXIMIZE_STORAGE_KEY = 'workflow-canvas-maximize'
 
 export const useWorkflowCanvasMaximize = () => {
   const { eventEmitter } = useEventEmitterContextContext()
   const maximizeCanvas = useStore(s => s.maximizeCanvas)
   const setMaximizeCanvas = useStore(s => s.setMaximizeCanvas)
   const { getNodesReadOnly } = useNodesReadOnly()
+  const setStoredMaximizeCanvas = useSetLocalStorage<boolean>(WORKFLOW_CANVAS_MAXIMIZE_STORAGE_KEY)
 
   const handleToggleMaximizeCanvas = useCallback(() => {
     if (getNodesReadOnly())
@@ -15,12 +19,12 @@ export const useWorkflowCanvasMaximize = () => {
 
     const nextValue = !maximizeCanvas
     setMaximizeCanvas(nextValue)
-    localStorage.setItem('workflow-canvas-maximize', String(nextValue))
+    setStoredMaximizeCanvas(nextValue)
     eventEmitter?.emit({
       type: 'workflow-canvas-maximize',
       payload: nextValue,
     } as never)
-  }, [eventEmitter, getNodesReadOnly, maximizeCanvas, setMaximizeCanvas])
+  }, [eventEmitter, getNodesReadOnly, maximizeCanvas, setMaximizeCanvas, setStoredMaximizeCanvas])
 
   return {
     handleToggleMaximizeCanvas,


### PR DESCRIPTION
## Summary
Part of #36898.

Migrates the workflow canvas maximize storage write from direct `localStorage.setItem` to the existing `useSetLocalStorage` helper.

## Reproduction
`useWorkflowCanvasMaximize` directly wrote the `workflow-canvas-maximize` key when toggling canvas maximize mode.

## Root cause
This hook still had a one-off direct localStorage write while other consumers of the same key already read it through `useLocalStorage`.

## Changes
- Added a local storage key constant for `workflow-canvas-maximize`.
- Replaced direct `localStorage.setItem` with `useSetLocalStorage<boolean>`.
- Kept the existing Zustand state update and event emitter notification behavior unchanged.
- Removed the now-obsolete `no-restricted-globals` suppression for this file via autofix.ci.

## Tests
- `git diff --check`
- Parsed `web/app/components/workflow/hooks/use-workflow-canvas-maximize.ts` with `@babel/parser` using TypeScript/JSX plugins
- GitHub Actions passed: style checks, Web Tests, Web Full-Stack E2E, API/CLI/VDB/DB tests, Semantic PR title, labeler, autofix
- `pnpm --dir web type-check` (blocked locally by Corepack keyid verification error under Node.js v22.2.0 before CI ran)
- `pnpm --dir web test app/components/workflow/hooks/use-workflow-canvas-maximize.ts` (blocked locally by the same Corepack keyid verification error before CI ran)

## Screenshots/Logs
N/A. Storage hook refactor only.
