### PR TITLE
fix: preserve hierarchical indexing estimate rules

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -138,6 +138,8 @@ class _EstimateSegmentation(BaseModel):
 class _EstimateRules(BaseModel):
     pre_processing_rules: list[_EstimatePreProcessingRule]
     segmentation: _EstimateSegmentation
+    parent_mode: Literal["full-doc", "paragraph"] | None = None
+    subchunk_segmentation: _EstimateSegmentation | None = None
 
     @field_validator("pre_processing_rules")
     @classmethod

--- a/api/tests/unit_tests/services/test_dataset_service_document.py
+++ b/api/tests/unit_tests/services/test_dataset_service_document.py
@@ -1687,3 +1687,30 @@ class TestDocumentServiceSaveDocumentAdditionalBranches:
                     account_context,
                     dataset_process_rule=SimpleNamespace(id="rule-1"),
                 )
+
+
+class TestDocumentServiceEstimateArgsValidation:
+    """Unit tests for indexing estimate argument validation."""
+
+    def test_estimate_args_validate_preserves_hierarchical_chunking_rules(self):
+        args = {
+            "info_list": {"data_source_type": "upload_file", "file_info_list": {"file_ids": ["file-1"]}},
+            "process_rule": {
+                "mode": "hierarchical",
+                "rules": {
+                    "pre_processing_rules": [
+                        {"id": "remove_extra_spaces", "enabled": False},
+                        {"id": "remove_urls_emails", "enabled": False},
+                    ],
+                    "segmentation": {"separator": "\\n\\n", "max_tokens": 1024},
+                    "parent_mode": "paragraph",
+                    "subchunk_segmentation": {"separator": "\\n", "max_tokens": 512},
+                },
+            },
+        }
+
+        DocumentService.estimate_args_validate(args)
+
+        rules = args["process_rule"]["rules"]
+        assert rules["parent_mode"] == "paragraph"
+        assert rules["subchunk_segmentation"] == {"separator": "\\n", "max_tokens": 512}


### PR DESCRIPTION
## Summary
- Preserve parent-child indexing estimate fields during request validation
- Keep `parent_mode` and `subchunk_segmentation` when normalizing process rules
- Add a regression test for hierarchical indexing estimate validation

## Problem
When creating a knowledge base with parent-child chunking, the preview endpoint can return zero chunks even though the uploaded document is parsed correctly. The request payload includes `parent_mode` and `subchunk_segmentation`, but `DocumentService.estimate_args_validate` rebuilds `process_rule` from `_EstimateRules`, which previously only allowed `pre_processing_rules` and `segmentation`. As a result, parent-child specific fields are dropped before indexing estimation.

## Test
- `python -m pytest -o addopts='' tests/unit_tests/services/test_dataset_service_document.py -k estimate_args_validate_preserves_hierarchical_chunking_rules -q`
