### PR TITLE
refactor(web): migrate workflow-canvas-maximize to useSetLocalStorage

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3464,11 +3464,6 @@
       "count": 1
     }
   },
-  "web/app/components/workflow/hooks/use-workflow-canvas-maximize.ts": {
-    "no-restricted-globals": {
-      "count": 1
-    }
-  },
   "web/app/components/workflow/hooks/use-workflow-interactions.ts": {
     "no-barrel-files/no-barrel-files": {
       "count": 5

--- a/web/app/components/workflow/hooks/use-workflow-canvas-maximize.ts
+++ b/web/app/components/workflow/hooks/use-workflow-canvas-maximize.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import { useEventEmitterContextContext } from '@/context/event-emitter'
+import { useSetLocalStorage } from '@/hooks/use-local-storage'
 import { useStore } from '../store'
 import { useNodesReadOnly } from './use-workflow'
 
@@ -8,6 +9,7 @@ export const useWorkflowCanvasMaximize = () => {
   const maximizeCanvas = useStore(s => s.maximizeCanvas)
   const setMaximizeCanvas = useStore(s => s.setMaximizeCanvas)
   const { getNodesReadOnly } = useNodesReadOnly()
+  const setLocalStorageMaximize = useSetLocalStorage<string>('workflow-canvas-maximize', { raw: true })
 
   const handleToggleMaximizeCanvas = useCallback(() => {
     if (getNodesReadOnly())
@@ -15,12 +17,12 @@ export const useWorkflowCanvasMaximize = () => {
 
     const nextValue = !maximizeCanvas
     setMaximizeCanvas(nextValue)
-    localStorage.setItem('workflow-canvas-maximize', String(nextValue))
+    setLocalStorageMaximize(String(nextValue))
     eventEmitter?.emit({
       type: 'workflow-canvas-maximize',
       payload: nextValue,
     } as never)
-  }, [eventEmitter, getNodesReadOnly, maximizeCanvas, setMaximizeCanvas])
+  }, [eventEmitter, getNodesReadOnly, maximizeCanvas, setMaximizeCanvas, setLocalStorageMaximize])
 
   return {
     handleToggleMaximizeCanvas,


### PR DESCRIPTION
## What

Replace direct `localStorage.setItem` call with `useSetLocalStorage` hook from `@/hooks/use-local-storage` for the `workflow-canvas-maximize` key.

Part of #36898

## Changes

- `web/app/components/workflow/hooks/use-workflow-canvas-maximize.ts`:
  - Import `useSetLocalStorage` from `@/hooks/use-local-storage`
  - Replace `localStorage.setItem('workflow-canvas-maximize', String(nextValue))` with `setLocalStorageMaximize(String(nextValue))`
  - Add `setLocalStorageMaximize` to the `useCallback` dependency array

## Testing

- All existing tests pass (`pnpm test -- --run app/components/workflow/hooks/__tests__/use-workflow-canvas-maximize.spec.ts`)
- The behavior is preserved: toggling maximize state still persists to localStorage and emits the canvas event

## Notes

- The `layout-slice.ts` file still uses `getStoredMaximizeCanvas()` to read the initial value from localStorage, as zustand stores cannot use React hooks directly. This is consistent with the hook boundary pattern described in AGENTS.md.