### PR TITLE
refactor(web): migrate debug model config storage to useLocalStorage

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -505,9 +505,6 @@
     }
   },
   "web/app/components/app/configuration/debug/hooks.tsx": {
-    "no-restricted-globals": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 3
     }

--- a/web/app/components/app/configuration/debug/hooks.tsx
+++ b/web/app/components/app/configuration/debug/hooks.tsx
@@ -9,13 +9,13 @@ import type {
 import { cloneDeep } from 'es-toolkit/object'
 import {
   useCallback,
-  useRef,
   useState,
 } from 'react'
 import { SupportUploadFileTypes } from '@/app/components/workflow/types'
 import { DEFAULT_CHAT_PROMPT_CONFIG, DEFAULT_COMPLETION_PROMPT_CONFIG } from '@/config'
 import { useDebugConfigurationContext } from '@/context/debug-configuration'
 import { useEventEmitterContextContext } from '@/context/event-emitter'
+import { useLocalStorage } from '@/hooks/use-local-storage'
 import {
   AgentStrategy,
 } from '@/types/app'
@@ -23,28 +23,17 @@ import { promptVariablesToUserInputsForm } from '@/utils/model-config'
 import { ORCHESTRATE_CHANGED } from './types'
 
 export const useDebugWithSingleOrMultipleModel = (appId: string) => {
-  const localeDebugWithSingleOrMultipleModelConfigs = localStorage.getItem('app-debug-with-single-or-multiple-models')
-
-  const debugWithSingleOrMultipleModelConfigs = useRef<DebugWithSingleOrMultipleModelConfigs>({})
-
-  if (localeDebugWithSingleOrMultipleModelConfigs) {
-    try {
-      debugWithSingleOrMultipleModelConfigs.current = JSON.parse(localeDebugWithSingleOrMultipleModelConfigs) || {}
-    }
-    catch (e) {
-      console.error(e)
-    }
-  }
+  const [debugWithSingleOrMultipleModelConfigs, setDebugWithSingleOrMultipleModelConfigs] = useLocalStorage<DebugWithSingleOrMultipleModelConfigs>('app-debug-with-single-or-multiple-models', {})
 
   const [
     debugWithMultipleModel,
     setDebugWithMultipleModel,
-  ] = useState(debugWithSingleOrMultipleModelConfigs.current[appId]?.multiple || false)
+  ] = useState(debugWithSingleOrMultipleModelConfigs[appId]?.multiple || false)
 
   const [
     multipleModelConfigs,
     setMultipleModelConfigs,
-  ] = useState(debugWithSingleOrMultipleModelConfigs.current[appId]?.configs || [])
+  ] = useState(debugWithSingleOrMultipleModelConfigs[appId]?.configs || [])
 
   const handleMultipleModelConfigsChange = useCallback((
     multiple: boolean,
@@ -54,11 +43,13 @@ export const useDebugWithSingleOrMultipleModel = (appId: string) => {
       multiple,
       configs: modelConfigs,
     }
-    debugWithSingleOrMultipleModelConfigs.current[appId] = value
-    localStorage.setItem('app-debug-with-single-or-multiple-models', JSON.stringify(debugWithSingleOrMultipleModelConfigs.current))
+    setDebugWithSingleOrMultipleModelConfigs(prev => ({
+      ...prev,
+      [appId]: value,
+    }))
     setDebugWithMultipleModel(value.multiple)
     setMultipleModelConfigs(value.configs)
-  }, [appId])
+  }, [appId, setDebugWithSingleOrMultipleModelConfigs])
 
   return {
     debugWithMultipleModel,


### PR DESCRIPTION
## What

Replace direct `localStorage.getItem`/`setItem` calls with `useLocalStorage` hook for the `app-debug-with-single-or-multiple-models` key.

Part of #37028

## Changes

- `web/app/components/app/configuration/debug/hooks.tsx`:
  - Import `useLocalStorage` from `@/hooks/use-local-storage`
  - Replace `localStorage.getItem('app-debug-with-single-or-multiple-models')` and `JSON.parse` with `useLocalStorage<DebugWithSingleOrMultipleModelConfigs>`
  - Replace `localStorage.setItem` with `setDebugWithSingleOrMultipleModelConfigs` using functional update
  - Remove `useRef` for managing the config object
  - Remove manual JSON serialization/deserialization

## Testing

- All existing tests pass (`pnpm test -- --run app/components/app/configuration/debug/__tests__/hooks.spec.tsx`)
- The behavior is preserved: debug settings are still persisted to localStorage and retrieved on initialization

## Notes

- This migration uses `useLocalStorage` with a default value of `{}` (empty object)
- The hook handles JSON serialization/deserialization automatically
- The functional update pattern `setDebugWithSingleOrMultipleModelConfigs(prev => ({ ...prev, [appId]: value }))` ensures we don't lose other app configs when updating one app's settings