### PR TITLE
fix(core): filter unsupported file content types in memory per model capability

### DIFF
--- a/api/core/memory/token_buffer_memory.py
+++ b/api/core/memory/token_buffer_memory.py
@@ -18,7 +18,7 @@ from graphon.model_runtime.entities import (
     TextPromptMessageContent,
     UserPromptMessage,
 )
-from graphon.model_runtime.entities.message_entities import PromptMessageContentUnionTypes
+from graphon.model_runtime.entities.message_entities import PromptMessageContentType, PromptMessageContentUnionTypes
 from models.model import AppMode, Conversation, Message, MessageFile
 from models.workflow import Workflow
 from repositories.api_workflow_run_repository import APIWorkflowRunRepository
@@ -153,16 +153,22 @@ class TokenBufferMemory:
 
         messages = list(reversed(thread_messages))
 
+        model_schema = self.model_instance.get_model_schema()
+        supports_vision = model_schema.supports_prompt_content_type(PromptMessageContentType.IMAGE)
+
         curr_message_tokens = 0
         prompt_messages: list[PromptMessage] = []
         for message in messages:
             # Process user message with files
-            user_files = db.session.scalars(
-                select(MessageFile).where(
-                    MessageFile.message_id == message.id,
-                    (MessageFile.belongs_to == "user") | (MessageFile.belongs_to.is_(None)),
-                )
-            ).all()
+            if supports_vision:
+                user_files = db.session.scalars(
+                    select(MessageFile).where(
+                        MessageFile.message_id == message.id,
+                        (MessageFile.belongs_to == "user") | (MessageFile.belongs_to.is_(None)),
+                    )
+                ).all()
+            else:
+                user_files = []
 
             if user_files:
                 user_prompt_message = self._build_prompt_message_with_files(
@@ -177,9 +183,12 @@ class TokenBufferMemory:
                 prompt_messages.append(UserPromptMessage(content=message.query))
 
             # Process assistant message with files
-            assistant_files = db.session.scalars(
-                select(MessageFile).where(MessageFile.message_id == message.id, MessageFile.belongs_to == "assistant")
-            ).all()
+            if supports_vision:
+                assistant_files = db.session.scalars(
+                    select(MessageFile).where(MessageFile.message_id == message.id, MessageFile.belongs_to == "assistant")
+                ).all()
+            else:
+                assistant_files = []
 
             if assistant_files:
                 assistant_prompt_message = self._build_prompt_message_with_files(

--- a/api/core/memory/token_buffer_memory.py
+++ b/api/core/memory/token_buffer_memory.py
@@ -114,6 +114,16 @@ class TokenBufferMemory:
                 prompt_message_contents.append(prompt_message)
             prompt_message_contents.append(TextPromptMessageContent(data=text_content))
 
+            # Filter out content types the current model doesn't support
+            # (e.g., skip image content when model is not a vision model)
+            model_schema = self.model_instance.get_model_schema()
+            prompt_message_contents = [
+                c
+                for c in prompt_message_contents
+                if c.type == PromptMessageContentType.TEXT
+                or model_schema.supports_prompt_content_type(c.type)
+            ]
+
             if is_user_message:
                 return UserPromptMessage(content=prompt_message_contents)
             else:
@@ -153,22 +163,16 @@ class TokenBufferMemory:
 
         messages = list(reversed(thread_messages))
 
-        model_schema = self.model_instance.get_model_schema()
-        supports_vision = model_schema.supports_prompt_content_type(PromptMessageContentType.IMAGE)
-
         curr_message_tokens = 0
         prompt_messages: list[PromptMessage] = []
         for message in messages:
             # Process user message with files
-            if supports_vision:
-                user_files = db.session.scalars(
-                    select(MessageFile).where(
-                        MessageFile.message_id == message.id,
-                        (MessageFile.belongs_to == "user") | (MessageFile.belongs_to.is_(None)),
-                    )
-                ).all()
-            else:
-                user_files = []
+            user_files = db.session.scalars(
+                select(MessageFile).where(
+                    MessageFile.message_id == message.id,
+                    (MessageFile.belongs_to == "user") | (MessageFile.belongs_to.is_(None)),
+                )
+            ).all()
 
             if user_files:
                 user_prompt_message = self._build_prompt_message_with_files(
@@ -183,12 +187,9 @@ class TokenBufferMemory:
                 prompt_messages.append(UserPromptMessage(content=message.query))
 
             # Process assistant message with files
-            if supports_vision:
-                assistant_files = db.session.scalars(
-                    select(MessageFile).where(MessageFile.message_id == message.id, MessageFile.belongs_to == "assistant")
-                ).all()
-            else:
-                assistant_files = []
+            assistant_files = db.session.scalars(
+                select(MessageFile).where(MessageFile.message_id == message.id, MessageFile.belongs_to == "assistant")
+            ).all()
 
             if assistant_files:
                 assistant_prompt_message = self._build_prompt_message_with_files(

--- a/api/tests/unit_tests/core/memory/test_token_buffer_memory.py
+++ b/api/tests/unit_tests/core/memory/test_token_buffer_memory.py
@@ -9,6 +9,7 @@ from core.memory.token_buffer_memory import TokenBufferMemory
 from graphon.model_runtime.entities import (
     AssistantPromptMessage,
     ImagePromptMessageContent,
+    PromptMessageContentType,
     PromptMessageRole,
     TextPromptMessageContent,
     UserPromptMessage,
@@ -873,6 +874,72 @@ class TestGetHistoryPromptMessages:
         assert user_msg.content == "My query"
         assert isinstance(ai_msg, AssistantPromptMessage)
         assert ai_msg.content == "My answer"
+
+    def test_non_vision_model_skips_file_queries(self):
+        """When model doesn't support vision, file queries are skipped entirely
+        and plain text messages are returned regardless of stored files."""
+        mem = self._make_memory()
+        msg = _make_message(answer="answer text")
+        msg.query = "query text"
+        msg.parent_message_id = None
+
+        mock_schema = MagicMock()
+        mock_schema.supports_prompt_content_type.return_value = False
+        mem.model_instance.get_model_schema = MagicMock(return_value=mock_schema)
+
+        with (
+            patch("core.memory.token_buffer_memory.db") as mock_db,
+            patch(
+                "core.memory.token_buffer_memory.extract_thread_messages",
+                return_value=[msg],
+            ),
+        ):
+            mock_db.session.scalars.return_value.all.return_value = [msg]
+            result = mem.get_history_prompt_messages()
+
+        assert len(result) == 2
+        user_msg, ai_msg = result
+        assert isinstance(user_msg, UserPromptMessage)
+        assert user_msg.content == "query text"
+        assert isinstance(ai_msg, AssistantPromptMessage)
+        assert ai_msg.content == "answer text"
+        mem.model_instance.get_model_schema.assert_called_once()
+        mock_schema.supports_prompt_content_type.assert_called_once_with(PromptMessageContentType.IMAGE)
+
+    def test_vision_model_queries_files(self):
+        """When model supports vision, file queries are executed for each message."""
+        mem = self._make_memory()
+        msg = _make_message(answer="answer text")
+        msg.query = "query text"
+        msg.parent_message_id = None
+
+        mock_schema = MagicMock()
+        mock_schema.supports_prompt_content_type.return_value = True
+        mem.model_instance.get_model_schema = MagicMock(return_value=mock_schema)
+
+        call_count = {"n": 0}
+
+        def scalars_side_effect(stmt):
+            r = MagicMock()
+            if call_count["n"] == 0:
+                r.all.return_value = [msg]  # messages query
+            else:
+                r.all.return_value = []  # file queries
+            call_count["n"] += 1
+            return r
+
+        with (
+            patch("core.memory.token_buffer_memory.db") as mock_db,
+            patch(
+                "core.memory.token_buffer_memory.extract_thread_messages",
+                return_value=[msg],
+            ),
+        ):
+            mock_db.session.scalars.side_effect = scalars_side_effect
+            result = mem.get_history_prompt_messages()
+
+        assert len(result) == 2
+        assert call_count["n"] == 3  # messages + user_files + assistant_files
 
 
 # ===========================================================================

--- a/api/tests/unit_tests/core/memory/test_token_buffer_memory.py
+++ b/api/tests/unit_tests/core/memory/test_token_buffer_memory.py
@@ -492,6 +492,56 @@ class TestBuildPromptMessageWithFiles:
                 is_user_message=True,
             )
 
+    def test_unsupported_content_type_filtered_out(self):
+        """When model doesn't support the file content type (e.g. vision),
+        non-text content is filtered out and only text remains."""
+        conv = _make_conversation(AppMode.CHAT)
+
+        mock_schema = MagicMock()
+        mock_schema.supports_prompt_content_type.return_value = False
+        mi = _make_model_instance()
+        mi.get_model_schema.return_value = mock_schema
+
+        mem = TokenBufferMemory(conversation=conv, model_instance=mi)
+
+        mock_file_extra_config = MagicMock()
+        mock_file_extra_config.image_config = None
+
+        mock_app_record = MagicMock()
+        mock_app_record.tenant_id = "tenant-1"
+
+        real_image_content = ImagePromptMessageContent(
+            url="http://example.com/img.png", format="png", mime_type="image/png"
+        )
+
+        with (
+            patch(
+                "core.memory.token_buffer_memory.FileUploadConfigManager.convert",
+                return_value=mock_file_extra_config,
+            ),
+            patch(
+                "core.memory.token_buffer_memory.file_factory.build_from_message_file",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "core.memory.token_buffer_memory.file_manager.to_prompt_message_content",
+                return_value=real_image_content,
+            ),
+        ):
+            result = mem._build_prompt_message_with_files(
+                message_files=[MagicMock()],
+                text_content="user text",
+                message=_make_message(),
+                app_record=mock_app_record,
+                is_user_message=True,
+            )
+
+        assert isinstance(result, UserPromptMessage)
+        assert isinstance(result.content, list)
+        assert len(result.content) == 1
+        assert isinstance(result.content[0], TextPromptMessageContent)
+        assert result.content[0].data == "user text"
+
 
 # ===========================================================================
 # Tests for get_history_prompt_messages
@@ -874,72 +924,6 @@ class TestGetHistoryPromptMessages:
         assert user_msg.content == "My query"
         assert isinstance(ai_msg, AssistantPromptMessage)
         assert ai_msg.content == "My answer"
-
-    def test_non_vision_model_skips_file_queries(self):
-        """When model doesn't support vision, file queries are skipped entirely
-        and plain text messages are returned regardless of stored files."""
-        mem = self._make_memory()
-        msg = _make_message(answer="answer text")
-        msg.query = "query text"
-        msg.parent_message_id = None
-
-        mock_schema = MagicMock()
-        mock_schema.supports_prompt_content_type.return_value = False
-        mem.model_instance.get_model_schema = MagicMock(return_value=mock_schema)
-
-        with (
-            patch("core.memory.token_buffer_memory.db") as mock_db,
-            patch(
-                "core.memory.token_buffer_memory.extract_thread_messages",
-                return_value=[msg],
-            ),
-        ):
-            mock_db.session.scalars.return_value.all.return_value = [msg]
-            result = mem.get_history_prompt_messages()
-
-        assert len(result) == 2
-        user_msg, ai_msg = result
-        assert isinstance(user_msg, UserPromptMessage)
-        assert user_msg.content == "query text"
-        assert isinstance(ai_msg, AssistantPromptMessage)
-        assert ai_msg.content == "answer text"
-        mem.model_instance.get_model_schema.assert_called_once()
-        mock_schema.supports_prompt_content_type.assert_called_once_with(PromptMessageContentType.IMAGE)
-
-    def test_vision_model_queries_files(self):
-        """When model supports vision, file queries are executed for each message."""
-        mem = self._make_memory()
-        msg = _make_message(answer="answer text")
-        msg.query = "query text"
-        msg.parent_message_id = None
-
-        mock_schema = MagicMock()
-        mock_schema.supports_prompt_content_type.return_value = True
-        mem.model_instance.get_model_schema = MagicMock(return_value=mock_schema)
-
-        call_count = {"n": 0}
-
-        def scalars_side_effect(stmt):
-            r = MagicMock()
-            if call_count["n"] == 0:
-                r.all.return_value = [msg]  # messages query
-            else:
-                r.all.return_value = []  # file queries
-            call_count["n"] += 1
-            return r
-
-        with (
-            patch("core.memory.token_buffer_memory.db") as mock_db,
-            patch(
-                "core.memory.token_buffer_memory.extract_thread_messages",
-                return_value=[msg],
-            ),
-        ):
-            mock_db.session.scalars.side_effect = scalars_side_effect
-            result = mem.get_history_prompt_messages()
-
-        assert len(result) == 2
-        assert call_count["n"] == 3  # messages + user_files + assistant_files
 
 
 # ===========================================================================


### PR DESCRIPTION
## Fixes #37042

## Summary
When a workflow LLM node switches to a model that doesn't support certain multimodal content types (e.g., switching from GPT-4o to GPT-4 for vision, or to a model without document support), `TokenBufferMemory` still includes all file content (`ImagePromptMessageContent`, `DocumentPromptMessageContent`, etc.) in history prompt messages. This passes invalid multimodal content to the LLM invocation.

This PR adds content-type-level filtering in `_build_prompt_message_with_files`: after converting files to prompt message contents, each non-text content type is checked against the model schema, and unsupported types are filtered out.

## Changes
- `api/core/memory/token_buffer_memory.py`:
  - In `_build_prompt_message_with_files`, filter `prompt_message_contents` by model capability via `model_schema.supports_prompt_content_type()`, keeping only `TEXT` and content types the current model supports.
  - Import `PromptMessageContentType` for content type checking.

## Test plan
1. Create a workflow with an LLM node using a vision model (e.g., GPT-4o), upload an image in a previous conversation turn — image context should still appear in history prompts.
2. Switch the LLM node to a non-vision model (e.g., GPT-4), repeat — image content should be filtered out, only text remains.
3. Verify no regression for Agent Chat / Completion / Chat app modes.
4. Run the added unit test `test_unsupported_content_type_filtered_out`.