### PR TITLE
fix(weaviate): return BM25 score metadata

### DIFF
--- a/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
@@ -449,7 +449,7 @@ class WeaviateVector(BaseVector):
         """
         Performs BM25 full-text search on document content.
 
-        Filters by document IDs if provided and returns matching documents with vectors.
+        Filters by document IDs if provided and returns matching documents with vectors and BM25 scores.
         """
         if not self._client.collections.exists(self._collection_name):
             return []
@@ -470,6 +470,7 @@ class WeaviateVector(BaseVector):
                 query_properties=[Field.TEXT_KEY.value],
                 limit=top_k,
                 return_properties=props,
+                return_metadata=MetadataQuery(score=True),
                 include_vector=True,
                 filters=where,
             )
@@ -480,6 +481,7 @@ class WeaviateVector(BaseVector):
                 query_properties=[Field.TEXT_KEY.value],
                 limit=top_k,
                 return_properties=props,
+                return_metadata=MetadataQuery(score=True),
                 include_vector=True,
                 filters=where,
             )
@@ -492,6 +494,10 @@ class WeaviateVector(BaseVector):
             vec = obj.vector
             if isinstance(vec, dict):
                 vec = vec.get("default") or next(iter(vec.values()), None)
+
+            score = getattr(getattr(obj, "metadata", None), "score", None)
+            if isinstance(score, (int, float, str)):
+                properties["score"] = float(score)
 
             docs.append(Document(page_content=text, vector=vec, metadata=properties))
         return docs

--- a/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
@@ -579,6 +579,36 @@ class TestWeaviateVector(unittest.TestCase):
         assert docs[0].metadata.get("doc_type") == "image"
 
     @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
+    def test_search_by_full_text_returns_bm25_score_metadata(self, mock_weaviate_module):
+        """Test that search_by_full_text propagates Weaviate BM25 scores."""
+        mock_client = MagicMock()
+        mock_client.is_ready.return_value = True
+        mock_weaviate_module.connect_to_custom.return_value = mock_client
+        mock_client.collections.exists.return_value = True
+        mock_col = MagicMock()
+        mock_client.collections.use.return_value = mock_col
+
+        mock_obj = MagicMock()
+        mock_obj.properties = {"text": "bm25 result", "doc_id": "segment-1"}
+        mock_obj.vector = {"default": [0.3, 0.4]}
+        mock_obj.metadata = SimpleNamespace(score=10.29)
+
+        mock_result = MagicMock()
+        mock_result.objects = [mock_obj]
+        mock_col.query.bm25.return_value = mock_result
+
+        wv = WeaviateVector(
+            collection_name=self.collection_name,
+            config=self.config,
+            attributes=self.attributes,
+        )
+        docs = wv.search_by_full_text(query="bm25", top_k=1)
+
+        assert mock_col.query.bm25.call_args.kwargs.get("return_metadata") is not None
+        assert len(docs) == 1
+        assert docs[0].metadata["score"] == pytest.approx(10.29)
+
+    @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
     def test_search_by_full_text_uses_document_filter(self, mock_weaviate_module):
         mock_client = MagicMock()
         mock_client.is_ready.return_value = True


### PR DESCRIPTION
Fixes #37045

## Summary

- request Weaviate BM25 score metadata for full-text searches
- propagate returned BM25 scores into `Document.metadata["score"]`
- add unit coverage for BM25 score metadata propagation

## Tests

- isolated provider regression harness: failed before the fix with `BM25 score metadata was not requested`; passed after the fix
- `uv run --no-default-groups --group dev --with-editable ./providers/vdb/vdb-weaviate --with pydantic-settings --with pycryptodome --with deprecated --with cachetools pytest providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py -k 'full_text' -q` (5 passed)
- `uv run --no-default-groups --group dev --with-editable ./providers/vdb/vdb-weaviate --with pydantic-settings --with pycryptodome --with deprecated --with cachetools pytest providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py -q` (40 passed)
- `uv run --no-default-groups --group dev ruff check providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py`
- `uv run --no-default-groups --group dev ruff format --check providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py`
- `git diff --check`

## AI assistance

AI-assisted: yes. I reviewed the changes and verified the behavior locally.
