### PR TITLE
fix: extract BM25 score from Weaviate full-text search results (#37045)

### DIFF
--- a/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
@@ -470,6 +470,7 @@ class WeaviateVector(BaseVector):
                 query_properties=[Field.TEXT_KEY.value],
                 limit=top_k,
                 return_properties=props,
+                return_metadata=MetadataQuery(score=True),
                 include_vector=True,
                 filters=where,
             )
@@ -480,6 +481,7 @@ class WeaviateVector(BaseVector):
                 query_properties=[Field.TEXT_KEY.value],
                 limit=top_k,
                 return_properties=props,
+                return_metadata=MetadataQuery(score=True),
                 include_vector=True,
                 filters=where,
             )
@@ -492,6 +494,9 @@ class WeaviateVector(BaseVector):
             vec = obj.vector
             if isinstance(vec, dict):
                 vec = vec.get("default") or next(iter(vec.values()), None)
+
+            if obj.metadata and obj.metadata.score is not None:
+                properties["score"] = obj.metadata.score
 
             docs.append(Document(page_content=text, vector=vec, metadata=properties))
         return docs

--- a/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
@@ -555,6 +555,7 @@ class TestWeaviateVector(unittest.TestCase):
             "doc_type": "image",
         }
         mock_obj.vector = {"default": [0.1] * 128}
+        mock_obj.metadata.score = 10.5
 
         mock_result = MagicMock()
         mock_result.objects = [mock_obj]
@@ -578,6 +579,79 @@ class TestWeaviateVector(unittest.TestCase):
         assert len(docs) == 1
         assert docs[0].metadata.get("doc_type") == "image"
 
+        # Verify return_metadata includes score=True
+        assert call_kwargs.kwargs.get("return_metadata") is not None
+
+        # Verify BM25 score is extracted and stored in metadata
+        assert docs[0].metadata.get("score") == 10.5
+
+    @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
+    def test_search_by_full_text_extracts_bm25_score(self, mock_weaviate_module):
+        """Test that search_by_full_text extracts BM25 score from metadata and includes it in Document."""
+        mock_client = MagicMock()
+        mock_client.is_ready.return_value = True
+        mock_weaviate_module.connect_to_custom.return_value = mock_client
+        mock_client.collections.exists.return_value = True
+        mock_col = MagicMock()
+        mock_client.collections.use.return_value = mock_col
+
+        mock_obj = MagicMock()
+        mock_obj.properties = {"text": "Zabbix agent is not available", "doc_id": "segment-1"}
+        mock_obj.vector = [0.1, 0.2, 0.3]
+        mock_obj.metadata.score = 10.297276
+
+        mock_result = MagicMock()
+        mock_result.objects = [mock_obj]
+        mock_col.query.bm25.return_value = mock_result
+
+        wv = WeaviateVector(
+            collection_name=self.collection_name,
+            config=self.config,
+            attributes=self.attributes,
+        )
+        docs = wv.search_by_full_text(query="Zabbix agent is not available", top_k=1)
+
+        assert len(docs) == 1
+
+        # Verify return_metadata=MetadataQuery(score=True) is passed
+        call_kwargs = mock_col.query.bm25.call_args
+        return_metadata = call_kwargs.kwargs.get("return_metadata")
+        assert return_metadata is not None
+
+        # Verify BM25 score is in document metadata
+        assert docs[0].metadata.get("score") == pytest.approx(10.297276)
+        assert docs[0].page_content == "Zabbix agent is not available"
+
+    @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
+    def test_search_by_full_text_handles_none_score(self, mock_weaviate_module):
+        """Test that search_by_full_text handles None score gracefully."""
+        mock_client = MagicMock()
+        mock_client.is_ready.return_value = True
+        mock_weaviate_module.connect_to_custom.return_value = mock_client
+        mock_client.collections.exists.return_value = True
+        mock_col = MagicMock()
+        mock_client.collections.use.return_value = mock_col
+
+        mock_obj = MagicMock()
+        mock_obj.properties = {"text": "test content", "doc_id": "segment-1"}
+        mock_obj.vector = [0.1]
+        mock_obj.metadata.score = None
+
+        mock_result = MagicMock()
+        mock_result.objects = [mock_obj]
+        mock_col.query.bm25.return_value = mock_result
+
+        wv = WeaviateVector(
+            collection_name=self.collection_name,
+            config=self.config,
+            attributes=self.attributes,
+        )
+        docs = wv.search_by_full_text(query="test", top_k=1)
+
+        assert len(docs) == 1
+        # When score is None, it should not be added to metadata
+        assert "score" not in docs[0].metadata
+
     @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
     def test_search_by_full_text_uses_document_filter(self, mock_weaviate_module):
         mock_client = MagicMock()
@@ -590,6 +664,7 @@ class TestWeaviateVector(unittest.TestCase):
         mock_obj = MagicMock()
         mock_obj.properties = {"text": "bm25 result", "doc_id": "segment-1"}
         mock_obj.vector = [0.3, 0.4]
+        mock_obj.metadata.score = 8.5
 
         mock_result = MagicMock()
         mock_result.objects = [mock_obj]
@@ -638,6 +713,7 @@ class TestWeaviateVector(unittest.TestCase):
         mock_obj = MagicMock()
         mock_obj.properties = {"text": "retry bm25 result", "doc_id": "segment-1"}
         mock_obj.vector = {"default": [0.5, 0.6]}
+        mock_obj.metadata.score = 12.0
 
         mock_result = MagicMock()
         mock_result.objects = [mock_obj]


### PR DESCRIPTION
## What this PR does

Fixes Weaviate full-text (BM25) search silently dropping all results because the BM25 score was never requested or extracted from Weaviate.

### Root Cause

In `weaviate_vector.py`, the `search_by_full_text` method was missing `return_metadata=MetadataQuery(score=True)` when calling `col.query.bm25()`. Without this, Weaviate doesn't return the BM25 score, and `obj.metadata.score` is `None`. The documents were created without a `score` in metadata, defaulting to `0.0`, which caused Dify's `dataset_retrieval.py` to filter them out during hybrid/keyword retrieval.

### Changes

**`api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py`:**
- Added `return_metadata=MetadataQuery(score=True)` to both `col.query.bm25()` calls (initial + retry)
- Extract `obj.metadata.score` and store it in document properties when available

**`api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py`:**
- Added `test_search_by_full_text_extracts_bm25_score` — verifies score extraction with a realistic BM25 score value
- Added `test_search_by_full_text_handles_none_score` — verifies graceful handling when score is `None`
- Updated existing BM25 test mocks to set explicit `metadata.score` values

### How to verify

1. Configure Weaviate as the vector database
2. Upload a document with specific text content
3. Query using the "multiple" (hybrid/keyword) retrieval strategy
4. Verify that `retriever_resources` in the API response contains the matched documents with non-zero scores

Fixes #37045