### PR TITLE
fix: re-vectorize child chunks on content update (#37063)

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -3843,6 +3843,7 @@ class SegmentService:
                     if child_chunk.content != child_chunk_update_args.content:
                         child_chunk.content = child_chunk_update_args.content
                         child_chunk.word_count = len(child_chunk.content)
+                        child_chunk.index_node_hash = helper.generate_text_hash(child_chunk.content)
                         child_chunk.updated_by = current_user.id
                         child_chunk.updated_at = naive_utc_now()
                         child_chunk.type = SegmentType.CUSTOMIZED
@@ -3903,6 +3904,7 @@ class SegmentService:
         try:
             child_chunk.content = content
             child_chunk.word_count = len(content)
+            child_chunk.index_node_hash = helper.generate_text_hash(content)
             child_chunk.updated_by = current_user.id
             child_chunk.updated_at = naive_utc_now()
             child_chunk.type = SegmentType.CUSTOMIZED

--- a/api/services/vector_service.py
+++ b/api/services/vector_service.py
@@ -244,7 +244,8 @@ class VectorService:
             # update vector index
             vector = Vector(dataset=dataset)
             if delete_node_ids:
-                vector.delete_by_ids(delete_node_ids)
+                for node_id in delete_node_ids:
+                    vector.delete_by_metadata_field("doc_id", node_id)
             if documents:
                 vector.add_texts(documents, duplicate_check=True)
 
@@ -252,7 +253,7 @@ class VectorService:
     def delete_child_chunk_vector(cls, child_chunk: ChildChunk, dataset: Dataset):
         vector = Vector(dataset=dataset)
         assert child_chunk.index_node_id
-        vector.delete_by_ids([child_chunk.index_node_id])
+        vector.delete_by_metadata_field("doc_id", child_chunk.index_node_id)
 
     @classmethod
     def update_multimodel_vector(cls, segment: DocumentSegment, attachment_ids: list[str], dataset: Dataset):

--- a/api/tests/unit_tests/services/test_dataset_service_segment.py
+++ b/api/tests/unit_tests/services/test_dataset_service_segment.py
@@ -177,7 +177,9 @@ class TestSegmentServiceChildChunks:
             patch("services.dataset_service.db") as mock_db,
             patch("services.dataset_service.naive_utc_now", return_value="now"),
             patch("services.dataset_service.VectorService") as vector_service,
+            patch("services.dataset_service.helper") as mock_helper,
         ):
+            mock_helper.generate_text_hash.return_value = "new-hash"
             result = SegmentService.update_child_chunk(
                 "new content", child_chunk, _make_segment(), _make_document(), dataset
             )
@@ -185,6 +187,7 @@ class TestSegmentServiceChildChunks:
         assert result is child_chunk
         assert child_chunk.content == "new content"
         assert child_chunk.word_count == len("new content")
+        assert child_chunk.index_node_hash == "new-hash"
         assert child_chunk.updated_by == "user-1"
         assert child_chunk.updated_at == "now"
         mock_db.session.add.assert_called_once_with(child_chunk)

--- a/api/tests/unit_tests/services/test_vector_service.py
+++ b/api/tests/unit_tests/services/test_vector_service.py
@@ -516,7 +516,11 @@ def test_update_child_chunk_vector_high_quality_updates_vector(monkeypatch: pyte
 
     VectorService.update_child_chunk_vector([new_chunk], [upd_chunk], [del_chunk], dataset)
 
-    vector_instance.delete_by_ids.assert_called_once_with(["uid", "did"])
+    # Should use delete_by_metadata_field instead of delete_by_ids to handle
+    # VDB backends like Weaviate that use content-based UUIDs (UUID5) internally
+    assert vector_instance.delete_by_metadata_field.call_count == 2
+    vector_instance.delete_by_metadata_field.assert_any_call("doc_id", "uid")
+    vector_instance.delete_by_metadata_field.assert_any_call("doc_id", "did")
     vector_instance.add_texts.assert_called_once()
     docs = vector_instance.add_texts.call_args.args[0]
     assert len(docs) == 2
@@ -539,7 +543,7 @@ def test_delete_child_chunk_vector_deletes_by_id(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(vector_service_module, "Vector", MagicMock(return_value=vector_instance))
 
     VectorService.delete_child_chunk_vector(child_chunk, dataset)
-    vector_instance.delete_by_ids.assert_called_once_with(["cid"])
+    vector_instance.delete_by_metadata_field.assert_called_once_with("doc_id", "cid")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this PR does

Fixes child chunk content updates via API not being re-vectorized, making modified content un-retrievable. Affects all VDB backends, most notably Weaviate.

### Root Cause

Three interrelated issues:

1. **UUID mismatch in delete**: `update_child_chunk_vector` called `vector.delete_by_ids([index_node_id])` where `index_node_id` is a UUID4. However, Weaviate stores objects using content-based UUID5 (`_get_uuids`), so the delete silently failed (404 swallowed). The old vector record remained in Weaviate.

2. **Duplicate check blocked insertion**: After the failed deletion, `add_texts(documents, duplicate_check=True)` checked `text_exists(doc_id)` which found the old record still present, filtering out the new content as a "duplicate".

3. **Hash not regenerated**: `update_child_chunk` and `update_child_chunks` in `dataset_service.py` did not regenerate `index_node_hash` when content changed.

### Changes

**`api/services/vector_service.py`:**
- `update_child_chunk_vector`: Replace `vector.delete_by_ids(delete_node_ids)` with `vector.delete_by_metadata_field("doc_id", node_id)` for each node_id. This queries by the `doc_id` metadata property instead of internal UUID, working correctly across all VDB backends.
- `delete_child_chunk_vector`: Same fix — use `delete_by_metadata_field` instead of `delete_by_ids`.

**`api/services/dataset_service.py`:**
- `update_child_chunk`: Add `child_chunk.index_node_hash = helper.generate_text_hash(content)` when content changes.
- `update_child_chunks`: Same — regenerate `index_node_hash` on content change.

**Tests updated:**
- `test_vector_service.py`: Updated assertions to verify `delete_by_metadata_field` calls instead of `delete_by_ids`.
- `test_dataset_service_segment.py`: Added `helper` mock and assertion for `index_node_hash` regeneration.

### How to verify

1. Create a knowledge base with hierarchical indexing using Weaviate
2. Upload a document and wait for indexing
3. Update a child chunk's content via the Service API
4. Search for the new content — it should now be retrievable

Fixes #37063