### PR TITLE
refactor: migrate direct localStorage usage to useLocalStorage hook

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -243,9 +243,6 @@
     }
   },
   "web/app/components/app-sidebar/index.tsx": {
-    "no-restricted-globals": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 1
     }
@@ -658,9 +655,6 @@
     }
   },
   "web/app/components/apps/list.tsx": {
-    "no-restricted-globals": {
-      "count": 2
-    },
     "no-restricted-imports": {
       "count": 1
     }
@@ -3152,11 +3146,6 @@
       "count": 2
     }
   },
-  "web/app/components/signin/countdown.tsx": {
-    "no-restricted-globals": {
-      "count": 4
-    }
-  },
   "web/app/components/tools/edit-custom-collection-modal/get-schema.tsx": {
     "no-restricted-imports": {
       "count": 1
@@ -3461,11 +3450,6 @@
   },
   "web/app/components/workflow/hooks/use-serial-async-callback.ts": {
     "ts/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "web/app/components/workflow/hooks/use-workflow-canvas-maximize.ts": {
-    "no-restricted-globals": {
       "count": 1
     }
   },

--- a/web/app/components/app-sidebar/index.tsx
+++ b/web/app/components/app-sidebar/index.tsx
@@ -9,6 +9,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useStore as useAppStore } from '@/app/components/app/store'
 import { useEventEmitterContextContext } from '@/context/event-emitter'
 import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
+import { useLocalStorage } from '@/hooks/use-local-storage'
 import { usePathname } from '@/next/navigation'
 import Divider from '../base/divider'
 import AppInfo, { AppInfoView } from './app-info'
@@ -56,7 +57,8 @@ const AppDetailNav = ({
   const pathname = usePathname()
   const inWorkflowCanvas = pathname.endsWith('/workflow')
   const isPipelineCanvas = pathname.endsWith('/pipeline')
-  const workflowCanvasMaximize = localStorage.getItem('workflow-canvas-maximize') === 'true'
+  const [workflowCanvasMaximizeValue] = useLocalStorage<string>('workflow-canvas-maximize', '0', { raw: true })
+  const workflowCanvasMaximize = workflowCanvasMaximizeValue === 'true'
   const [hideHeader, setHideHeader] = useState(workflowCanvasMaximize)
   const { eventEmitter } = useEventEmitterContextContext()
 
@@ -65,12 +67,14 @@ const AppDetailNav = ({
       setHideHeader(v.payload)
   })
 
+  const [, setAppSidebarExpandStorage] = useLocalStorage<string>('app-detail-collapse-or-expand', '', { raw: true })
+
   useEffect(() => {
     if (appSidebarExpand) {
-      localStorage.setItem('app-detail-collapse-or-expand', appSidebarExpand)
+      setAppSidebarExpandStorage(appSidebarExpand)
       setAppSidebarExpand(appSidebarExpand)
     }
-  }, [appSidebarExpand, setAppSidebarExpand])
+  }, [appSidebarExpand, setAppSidebarExpand, setAppSidebarExpandStorage])
 
   useHotkey('Mod+B', (e) => {
     e.preventDefault()

--- a/web/app/components/apps/list.tsx
+++ b/web/app/components/apps/list.tsx
@@ -15,6 +15,7 @@ import { useAppContext } from '@/context/app-context'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { TagFilter } from '@/features/tag-management/components/tag-filter'
 import { CheckModal } from '@/hooks/use-pay'
+import { useLocalStorage } from '@/hooks/use-local-storage'
 import dynamic from '@/next/dynamic'
 import { usePathname, useRouter, useSearchParams } from '@/next/navigation'
 import { consoleQuery } from '@/service/client'
@@ -135,12 +136,14 @@ const List: FC<Props> = ({
     { value: AppModeEnum.COMPLETION, text: t('types.completion', { ns: 'app' }), icon: <span className="mr-1 i-ri-file-4-line h-[14px] w-[14px]" /> },
   ]
 
+  const [needRefreshValue, setNeedRefreshValue] = useLocalStorage<string>(NEED_REFRESH_APP_LIST_KEY, '0', { raw: true })
+
   useEffect(() => {
-    if (localStorage.getItem(NEED_REFRESH_APP_LIST_KEY) === '1') {
-      localStorage.removeItem(NEED_REFRESH_APP_LIST_KEY)
+    if (needRefreshValue === '1') {
+      setNeedRefreshValue(null)
       refetch()
     }
-  }, [refetch])
+  }, [needRefreshValue, setNeedRefreshValue, refetch])
 
   useEffect(() => {
     if (isCurrentWorkspaceDatasetOperator)

--- a/web/app/components/signin/countdown.tsx
+++ b/web/app/components/signin/countdown.tsx
@@ -2,6 +2,7 @@
 import { useCountDown } from 'ahooks'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useLocalStorage } from '@/hooks/use-local-storage'
 
 export const COUNT_DOWN_TIME_MS = 59000
 export const COUNT_DOWN_KEY = 'leftTime'
@@ -12,24 +13,25 @@ type CountdownProps = {
 
 export default function Countdown({ onResend }: CountdownProps) {
   const { t } = useTranslation()
-  const [leftTime, setLeftTime] = useState(() => Number(localStorage.getItem(COUNT_DOWN_KEY) || COUNT_DOWN_TIME_MS))
+  const [leftTimeValue, setLeftTimeValue] = useLocalStorage<string>(COUNT_DOWN_KEY, `${COUNT_DOWN_TIME_MS}`, { raw: true })
+  const [leftTime, setLeftTime] = useState(() => Number(leftTimeValue || COUNT_DOWN_TIME_MS))
   const [time] = useCountDown({
     leftTime,
     onEnd: () => {
       setLeftTime(0)
-      localStorage.removeItem(COUNT_DOWN_KEY)
+      setLeftTimeValue(null)
     },
   })
 
   const resend = async function () {
     setLeftTime(COUNT_DOWN_TIME_MS)
-    localStorage.setItem(COUNT_DOWN_KEY, `${COUNT_DOWN_TIME_MS}`)
+    setLeftTimeValue(`${COUNT_DOWN_TIME_MS}`)
     onResend?.()
   }
 
   useEffect(() => {
-    localStorage.setItem(COUNT_DOWN_KEY, `${time}`)
-  }, [time])
+    setLeftTimeValue(`${time}`)
+  }, [time, setLeftTimeValue])
 
   return (
     <p className="system-xs-regular text-text-tertiary">

--- a/web/app/components/workflow/hooks/use-workflow-canvas-maximize.ts
+++ b/web/app/components/workflow/hooks/use-workflow-canvas-maximize.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import { useEventEmitterContextContext } from '@/context/event-emitter'
+import { useLocalStorage } from '@/hooks/use-local-storage'
 import { useStore } from '../store'
 import { useNodesReadOnly } from './use-workflow'
 
@@ -8,6 +9,7 @@ export const useWorkflowCanvasMaximize = () => {
   const maximizeCanvas = useStore(s => s.maximizeCanvas)
   const setMaximizeCanvas = useStore(s => s.setMaximizeCanvas)
   const { getNodesReadOnly } = useNodesReadOnly()
+  const [, setWorkflowCanvasMaximize] = useLocalStorage<string>('workflow-canvas-maximize', '0', { raw: true })
 
   const handleToggleMaximizeCanvas = useCallback(() => {
     if (getNodesReadOnly())
@@ -15,12 +17,12 @@ export const useWorkflowCanvasMaximize = () => {
 
     const nextValue = !maximizeCanvas
     setMaximizeCanvas(nextValue)
-    localStorage.setItem('workflow-canvas-maximize', String(nextValue))
+    setWorkflowCanvasMaximize(String(nextValue))
     eventEmitter?.emit({
       type: 'workflow-canvas-maximize',
       payload: nextValue,
     } as never)
-  }, [eventEmitter, getNodesReadOnly, maximizeCanvas, setMaximizeCanvas])
+  }, [eventEmitter, getNodesReadOnly, maximizeCanvas, setMaximizeCanvas, setWorkflowCanvasMaximize])
 
   return {
     handleToggleMaximizeCanvas,


### PR DESCRIPTION
## Description

Migrate direct `localStorage.getItem`/`setItem` calls to use the `useLocalStorage` hook from `@/hooks/use-local-storage`.

### Benefits:
- **Reactive state updates**: Components automatically re-render when localStorage values change
- **SSR safety**: Hook handles server-side rendering gracefully
- **Cross-tab synchronization**: Changes in one tab are reflected in others

## Files changed

- `web/app/components/app-sidebar/index.tsx`: Migrate `workflow-canvas-maximize` and `app-detail-collapse-or-expand`
- `web/app/components/apps/list.tsx`: Migrate `NEED_REFRESH_APP_LIST_KEY`
- `web/app/components/signin/countdown.tsx`: Migrate `leftTime` countdown timer
- `web/app/components/workflow/hooks/use-workflow-canvas-maximize.ts`: Migrate `workflow-canvas-maximize`

## Pattern

**Before:**
```typescript
const value = localStorage.getItem('key')
localStorage.setItem('key', newValue)
localStorage.removeItem('key')
```

**After:**
```typescript
const [value, setValue] = useLocalStorage<string>('key', 'default', { raw: true })
setValue(newValue)
setValue(null) // removes the key
```

Refs #36898