### PR TITLE
fix: prevent global loading screen when switching tabs

### DIFF
--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx
@@ -124,7 +124,7 @@ const AppDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
     }).finally(() => {
       setIsLoadingAppDetail(false)
     })
-  }, [appId, pathname])
+  }, [appId])
 
   useEffect(() => {
     if (!appDetailRes || !currentWorkspace.id || isLoadingCurrentWorkspace || isLoadingAppDetail)


### PR DESCRIPTION
## Description

Fix the issue where switching tabs in an app causes the entire page to show a loading screen.

### Problem:
When switching between tabs (e.g., from Configuration to Logs), the `useEffect` that fetches app details was running again because `pathname` was in its dependency array. This caused `setAppDetail()` to be called, clearing the app detail and showing a full-page loading screen.

### Solution:
Remove `pathname` from the `useEffect` dependency array. The app details should only be re-fetched when the `appId` changes, not when navigating between tabs within the same app.

### Before:
```typescript
useEffect(() => {
  setAppDetail()
  setIsLoadingAppDetail(true)
  fetchAppDetailDirect({ url: '/apps', id: appId }).then((res: App) => {
    setAppDetailRes(res)
  }).catch((e: any) => {
    if (e.status === 404)
      router.replace('/apps')
  }).finally(() => {
    setIsLoadingAppDetail(false)
  })
}, [appId, pathname])  // pathname causes re-fetch on tab switch
```

### After:
```typescript
useEffect(() => {
  setAppDetail()
  setIsLoadingAppDetail(true)
  fetchAppDetailDirect({ url: '/apps', id: appId }).then((res: App) => {
    setAppDetailRes(res)
  }).catch((e: any) => {
    if (e.status === 404)
      router.replace('/apps')
  }).finally(() => {
    setIsLoadingAppDetail(false)
  })
}, [appId])  // Only re-fetch when appId changes
```

Fixes #31171