### PR TITLE
refactor: use explicit sessions in workspace handlers

### DIFF
--- a/api/controllers/console/app/wraps.py
+++ b/api/controllers/console/app/wraps.py
@@ -2,10 +2,11 @@
 
 `with_session` opens one SQLAlchemy session for a request handler and injects it
 as the first argument after `self`. Handlers use a transaction by default so
-migrated write paths keep commit/rollback handling; pure read handlers may opt
-out with `write=False`. App-loading decorators prefer that injected session when
-present, while still supporting existing handlers that have not been migrated
-yet and still rely on Flask-SQLAlchemy's scoped `db.session`.
+migrated write paths keep commit/rollback handling; read handlers and
+service-owned commit paths may opt out with `write=False`. App-loading
+decorators prefer that injected session when present, while still supporting
+existing handlers that have not been migrated yet and still rely on
+Flask-SQLAlchemy's scoped `db.session`.
 """
 
 from collections.abc import Callable
@@ -68,7 +69,12 @@ def with_session[T, **P, R](
 ) -> (
     Callable[Concatenate[T, P], R] | Callable[[Callable[Concatenate[T, Session, P], R]], Callable[Concatenate[T, P], R]]
 ):
-    """Inject a request-scoped session, using a transaction only for write handlers."""
+    """Inject a request-scoped session.
+
+    ``write=False`` still injects a session, but leaves transaction ownership to
+    the caller/service so legacy commit ordering can be preserved during
+    incremental migrations.
+    """
 
     def decorator(view: Callable[Concatenate[T, Session, P], R]) -> Callable[Concatenate[T, P], R]:
         @wraps(view)

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -295,6 +295,8 @@ class WorkspaceListApi(Resource):
         args = WorkspaceListQuery.model_validate(payload)
 
         stmt = select(Tenant).order_by(Tenant.created_at.desc())
+        # TODO(#36544): migrate this once the explicit-session path has a
+        # replacement for Flask-SQLAlchemy's paginate helper.
         tenants = db.paginate(select=stmt, page=args.page, per_page=args.limit, error_out=False)
         has_more = False
 
@@ -347,7 +349,7 @@ class SwitchWorkspaceApi(Resource):
     @login_required
     @account_initialization_required
     @with_current_user
-    @with_session
+    @with_session(write=False)
     def post(self, session: Session, current_user: Account):
         payload = console_ns.payload or {}
         args = SwitchWorkspacePayload.model_validate(payload)
@@ -374,7 +376,7 @@ class CustomConfigWorkspaceApi(Resource):
     @account_initialization_required
     @cloud_edition_billing_resource_check("workspace_custom")
     @with_current_tenant_id
-    @with_session
+    @with_session(write=False)
     def post(self, session: Session, current_tenant_id: str):
         payload = console_ns.payload or {}
         args = WorkspaceCustomConfigPayload.model_validate(payload)
@@ -392,6 +394,7 @@ class CustomConfigWorkspaceApi(Resource):
         }
 
         tenant.custom_config_dict = custom_config_dict
+        session.commit()
 
         return {"result": "success", "tenant": marshal(WorkspaceService.get_tenant_info(tenant), tenant_fields)}
 
@@ -422,6 +425,9 @@ class WebappLogoWorkspaceApi(Resource):
             raise UnsupportedFileTypeError()
 
         try:
+            # TODO(#36544): FileService currently owns its DB access through
+            # an engine-backed session, so keep this path on the legacy session
+            # boundary until that service can accept an injected session.
             upload_file = FileService(db.engine).upload_file(
                 filename=file.filename,
                 content=file.stream.read(),
@@ -446,7 +452,7 @@ class WorkspaceInfoApi(Resource):
     @account_initialization_required
     # Change workspace name
     @with_current_tenant_id
-    @with_session
+    @with_session(write=False)
     def post(self, session: Session, current_tenant_id: str):
         payload = console_ns.payload or {}
         args = WorkspaceInfoPayload.model_validate(payload)
@@ -457,6 +463,7 @@ class WorkspaceInfoApi(Resource):
         if tenant is None:
             abort(404)
         tenant.name = args.name
+        session.commit()
 
         return {"result": "success", "tenant": marshal(WorkspaceService.get_tenant_info(tenant), tenant_fields)}
 

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -1,10 +1,11 @@
 import logging
 from datetime import datetime
 
-from flask import request
+from flask import abort, request
 from flask_restx import Resource, fields, marshal
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import select
+from sqlalchemy.orm import Session
 from werkzeug.exceptions import Unauthorized
 
 import services
@@ -19,6 +20,7 @@ from controllers.common.errors import (
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from controllers.console import console_ns
 from controllers.console.admin import admin_required
+from controllers.console.app.wraps import with_session
 from controllers.console.error import AccountNotLinkTenantError
 from controllers.console.wraps import (
     account_initialization_required,
@@ -345,17 +347,18 @@ class SwitchWorkspaceApi(Resource):
     @login_required
     @account_initialization_required
     @with_current_user
-    def post(self, current_user: Account):
+    @with_session
+    def post(self, session: Session, current_user: Account):
         payload = console_ns.payload or {}
         args = SwitchWorkspacePayload.model_validate(payload)
 
         # check if tenant_id is valid, 403 if not
         try:
-            TenantService.switch_tenant(current_user, args.tenant_id)
+            TenantService.switch_tenant(current_user, args.tenant_id, session=session)
         except Exception:
             raise AccountNotLinkTenantError("Account not link tenant")
 
-        new_tenant = db.session.get(Tenant, args.tenant_id)  # Get new tenant
+        new_tenant = session.get(Tenant, args.tenant_id)  # Get new tenant
         if new_tenant is None:
             raise ValueError("Tenant not found")
 
@@ -371,10 +374,13 @@ class CustomConfigWorkspaceApi(Resource):
     @account_initialization_required
     @cloud_edition_billing_resource_check("workspace_custom")
     @with_current_tenant_id
-    def post(self, current_tenant_id: str):
+    @with_session
+    def post(self, session: Session, current_tenant_id: str):
         payload = console_ns.payload or {}
         args = WorkspaceCustomConfigPayload.model_validate(payload)
-        tenant = db.get_or_404(Tenant, current_tenant_id)
+        tenant = session.get(Tenant, current_tenant_id)
+        if tenant is None:
+            abort(404)
 
         custom_config_dict: TenantCustomConfigDict = {
             "remove_webapp_brand": args.remove_webapp_brand
@@ -386,7 +392,6 @@ class CustomConfigWorkspaceApi(Resource):
         }
 
         tenant.custom_config_dict = custom_config_dict
-        db.session.commit()
 
         return {"result": "success", "tenant": marshal(WorkspaceService.get_tenant_info(tenant), tenant_fields)}
 
@@ -441,15 +446,17 @@ class WorkspaceInfoApi(Resource):
     @account_initialization_required
     # Change workspace name
     @with_current_tenant_id
-    def post(self, current_tenant_id: str):
+    @with_session
+    def post(self, session: Session, current_tenant_id: str):
         payload = console_ns.payload or {}
         args = WorkspaceInfoPayload.model_validate(payload)
 
         if not current_tenant_id:
             raise ValueError("No current tenant")
-        tenant = db.get_or_404(Tenant, current_tenant_id)
+        tenant = session.get(Tenant, current_tenant_id)
+        if tenant is None:
+            abort(404)
         tenant.name = args.name
-        db.session.commit()
 
         return {"result": "success", "tenant": marshal(WorkspaceService.get_tenant_info(tenant), tenant_fields)}
 

--- a/api/controllers/openapi/workspaces.py
+++ b/api/controllers/openapi/workspaces.py
@@ -126,7 +126,7 @@ class WorkspaceSwitchApi(Resource):
     """
 
     @auth_router.guard_workspace(scope=Scope.WORKSPACE_READ, allowed_token_types=frozenset({TokenType.OAUTH_ACCOUNT}))
-    @with_session
+    @with_session(write=False)
     @returns(200, WorkspaceDetailResponse, description="Workspace detail")
     def post(self, session: Session, workspace_id: str, *, auth_data: AuthData):
         account = _load_account(session, auth_data.account_id)
@@ -174,7 +174,7 @@ class WorkspaceMembersApi(Resource):
         allowed_token_types=frozenset({TokenType.OAUTH_ACCOUNT}),
         allowed_roles=frozenset({TenantAccountRole.OWNER, TenantAccountRole.ADMIN}),
     )
-    @with_session
+    @with_session(write=False)
     @returns(201, MemberInviteResponse, description="Member invited")
     @accepts(body=MemberInvitePayload)
     def post(self, session: Session, workspace_id: str, *, auth_data: AuthData, body: MemberInvitePayload):
@@ -230,7 +230,7 @@ class WorkspaceMemberApi(Resource):
         allowed_token_types=frozenset({TokenType.OAUTH_ACCOUNT}),
         allowed_roles=frozenset({TenantAccountRole.OWNER, TenantAccountRole.ADMIN}),
     )
-    @with_session
+    @with_session(write=False)
     @returns(200, MemberActionResponse, description="Member removed")
     def delete(self, session: Session, workspace_id: str, member_id: str, *, auth_data: AuthData):
         operator = _load_account(session, auth_data.account_id)
@@ -264,7 +264,7 @@ class WorkspaceMemberRoleApi(Resource):
         allowed_token_types=frozenset({TokenType.OAUTH_ACCOUNT}),
         allowed_roles=frozenset({TenantAccountRole.OWNER, TenantAccountRole.ADMIN}),
     )
-    @with_session
+    @with_session(write=False)
     @returns(200, MemberActionResponse, description="Role updated")
     @accepts(body=MemberRoleUpdatePayload)
     def put(

--- a/api/controllers/openapi/workspaces.py
+++ b/api/controllers/openapi/workspaces.py
@@ -37,7 +37,6 @@ from controllers.openapi._models import (
 )
 from controllers.openapi.auth.composition import auth_router
 from controllers.openapi.auth.data import AuthData
-from extensions.ext_database import db
 from libs.oauth_bearer import Scope, TokenType
 from models import Account, Tenant, TenantAccountJoin
 from models.account import TenantAccountRole, TenantStatus
@@ -65,8 +64,8 @@ def _member_response(account: Account) -> MemberResponse:
     )
 
 
-def _load_tenant(workspace_id: str) -> Tenant:
-    tenant = TenantService.get_tenant_by_id(db.session, workspace_id)
+def _load_tenant(session: Session | scoped_session, workspace_id: str) -> Tenant:
+    tenant = TenantService.get_tenant_by_id(session, workspace_id)
     if tenant is None or tenant.status != TenantStatus.NORMAL:
         raise NotFound("workspace not found")
     return tenant
@@ -94,9 +93,10 @@ def _check_member_invite_quota(tenant_id: str) -> None:
 @openapi_ns.route("/workspaces")
 class WorkspacesApi(Resource):
     @auth_router.guard(scope=Scope.WORKSPACE_READ, allowed_token_types=frozenset({TokenType.OAUTH_ACCOUNT}))
+    @with_session(write=False)
     @returns(200, WorkspaceListResponse, description="Workspace list")
-    def get(self, *, auth_data: AuthData):
-        rows = TenantService.get_workspaces_for_account(db.session, str(auth_data.account_id))
+    def get(self, session: Session, *, auth_data: AuthData):
+        rows = TenantService.get_workspaces_for_account(session, str(auth_data.account_id))
 
         return WorkspaceListResponse(workspaces=list(starmap(_workspace_summary, rows)))
 
@@ -104,9 +104,10 @@ class WorkspacesApi(Resource):
 @openapi_ns.route("/workspaces/<string:workspace_id>")
 class WorkspaceByIdApi(Resource):
     @auth_router.guard(scope=Scope.WORKSPACE_READ, allowed_token_types=frozenset({TokenType.OAUTH_ACCOUNT}))
+    @with_session(write=False)
     @returns(200, WorkspaceDetailResponse, description="Workspace detail")
-    def get(self, workspace_id: str, *, auth_data: AuthData):
-        row = TenantService.find_workspace_for_account(db.session, str(auth_data.account_id), workspace_id)
+    def get(self, session: Session, workspace_id: str, *, auth_data: AuthData):
+        row = TenantService.find_workspace_for_account(session, str(auth_data.account_id), workspace_id)
         # 404 (not 403) on non-member so workspace IDs don't leak across tenants.
         if row is None:
             raise NotFound("workspace not found")
@@ -125,8 +126,8 @@ class WorkspaceSwitchApi(Resource):
     """
 
     @auth_router.guard_workspace(scope=Scope.WORKSPACE_READ, allowed_token_types=frozenset({TokenType.OAUTH_ACCOUNT}))
-    @returns(200, WorkspaceDetailResponse, description="Workspace detail")
     @with_session
+    @returns(200, WorkspaceDetailResponse, description="Workspace detail")
     def post(self, session: Session, workspace_id: str, *, auth_data: AuthData):
         account = _load_account(session, auth_data.account_id)
 
@@ -151,11 +152,12 @@ class WorkspaceMembersApi(Resource):
     """
 
     @auth_router.guard_workspace(scope=Scope.WORKSPACE_READ, allowed_token_types=frozenset({TokenType.OAUTH_ACCOUNT}))
+    @with_session(write=False)
     @returns(200, MemberListResponse, description="Member list")
     @accepts(query=MemberListQuery)
-    def get(self, workspace_id: str, *, auth_data: AuthData, query: MemberListQuery):
-        tenant = _load_tenant(workspace_id)
-        members = TenantService.get_tenant_members(tenant)
+    def get(self, session: Session, workspace_id: str, *, auth_data: AuthData, query: MemberListQuery):
+        tenant = _load_tenant(session, workspace_id)
+        members = TenantService.get_tenant_members(tenant, session=session)
         total = len(members)
         start = (query.page - 1) * query.limit
         page_items = members[start : start + query.limit]
@@ -172,11 +174,12 @@ class WorkspaceMembersApi(Resource):
         allowed_token_types=frozenset({TokenType.OAUTH_ACCOUNT}),
         allowed_roles=frozenset({TenantAccountRole.OWNER, TenantAccountRole.ADMIN}),
     )
+    @with_session
     @returns(201, MemberInviteResponse, description="Member invited")
     @accepts(body=MemberInvitePayload)
-    def post(self, workspace_id: str, *, auth_data: AuthData, body: MemberInvitePayload):
-        inviter = _load_account(db.session, auth_data.account_id)
-        tenant = _load_tenant(workspace_id)
+    def post(self, session: Session, workspace_id: str, *, auth_data: AuthData, body: MemberInvitePayload):
+        inviter = _load_account(session, auth_data.account_id)
+        tenant = _load_tenant(session, workspace_id)
 
         _check_member_invite_quota(str(tenant.id))
 
@@ -187,6 +190,7 @@ class WorkspaceMembersApi(Resource):
                 language=None,
                 role=body.role,
                 inviter=inviter,
+                session=session,
             )
         except AccountAlreadyInTenantError as exc:
             raise BadRequest(str(exc))
@@ -196,7 +200,7 @@ class WorkspaceMembersApi(Resource):
             raise BadRequest(str(exc))
 
         normalized_email = body.email.lower()
-        member = AccountService.get_account_by_email_with_case_fallback(normalized_email)
+        member = AccountService.get_account_by_email_with_case_fallback(normalized_email, session=session)
         if member is None:
             # invite_new_member just created or fetched this account.
             raise RuntimeError("invited member missing from DB after invite")
@@ -226,16 +230,17 @@ class WorkspaceMemberApi(Resource):
         allowed_token_types=frozenset({TokenType.OAUTH_ACCOUNT}),
         allowed_roles=frozenset({TenantAccountRole.OWNER, TenantAccountRole.ADMIN}),
     )
+    @with_session
     @returns(200, MemberActionResponse, description="Member removed")
-    def delete(self, workspace_id: str, member_id: str, *, auth_data: AuthData):
-        operator = _load_account(db.session, auth_data.account_id)
-        tenant = _load_tenant(workspace_id)
-        member = AccountService.get_account_by_id(db.session, member_id)
+    def delete(self, session: Session, workspace_id: str, member_id: str, *, auth_data: AuthData):
+        operator = _load_account(session, auth_data.account_id)
+        tenant = _load_tenant(session, workspace_id)
+        member = AccountService.get_account_by_id(session, member_id)
         if member is None:
             raise NotFound("member not found")
 
         try:
-            TenantService.remove_member_from_tenant(tenant, member, operator)
+            TenantService.remove_member_from_tenant(tenant, member, operator, session=session)
         except CannotOperateSelfError as exc:
             raise BadRequest(str(exc))
         except NoPermissionError as exc:
@@ -259,17 +264,26 @@ class WorkspaceMemberRoleApi(Resource):
         allowed_token_types=frozenset({TokenType.OAUTH_ACCOUNT}),
         allowed_roles=frozenset({TenantAccountRole.OWNER, TenantAccountRole.ADMIN}),
     )
+    @with_session
     @returns(200, MemberActionResponse, description="Role updated")
     @accepts(body=MemberRoleUpdatePayload)
-    def put(self, workspace_id: str, member_id: str, *, auth_data: AuthData, body: MemberRoleUpdatePayload):
-        operator = _load_account(db.session, auth_data.account_id)
-        tenant = _load_tenant(workspace_id)
-        member = AccountService.get_account_by_id(db.session, member_id)
+    def put(
+        self,
+        session: Session,
+        workspace_id: str,
+        member_id: str,
+        *,
+        auth_data: AuthData,
+        body: MemberRoleUpdatePayload,
+    ):
+        operator = _load_account(session, auth_data.account_id)
+        tenant = _load_tenant(session, workspace_id)
+        member = AccountService.get_account_by_id(session, member_id)
         if member is None:
             raise NotFound("member not found")
 
         try:
-            TenantService.update_member_role(tenant, member, body.role, operator)
+            TenantService.update_member_role(tenant, member, body.role, operator, session=session)
         except CannotOperateSelfError as exc:
             raise BadRequest(str(exc))
         except NoPermissionError as exc:

--- a/api/controllers/openapi/workspaces.py
+++ b/api/controllers/openapi/workspaces.py
@@ -15,9 +15,11 @@ from itertools import starmap
 from urllib import parse
 
 from flask_restx import Resource
+from sqlalchemy.orm import Session, scoped_session
 from werkzeug.exceptions import BadRequest, NotFound
 
 from configs import dify_config
+from controllers.console.app.wraps import with_session
 from controllers.openapi import openapi_ns
 from controllers.openapi._contract import accepts, returns
 from controllers.openapi._errors import MemberLicenseExceeded, MemberLimitExceeded
@@ -70,8 +72,8 @@ def _load_tenant(workspace_id: str) -> Tenant:
     return tenant
 
 
-def _load_account(account_id: object) -> Account:
-    account = AccountService.get_account_by_id(db.session, str(account_id)) if account_id else None
+def _load_account(session: Session | scoped_session, account_id: object) -> Account:
+    account = AccountService.get_account_by_id(session, str(account_id)) if account_id else None
     if account is None:
         raise RuntimeError("authenticated account_id has no Account row")
     return account
@@ -124,15 +126,16 @@ class WorkspaceSwitchApi(Resource):
 
     @auth_router.guard_workspace(scope=Scope.WORKSPACE_READ, allowed_token_types=frozenset({TokenType.OAUTH_ACCOUNT}))
     @returns(200, WorkspaceDetailResponse, description="Workspace detail")
-    def post(self, workspace_id: str, *, auth_data: AuthData):
-        account = _load_account(auth_data.account_id)
+    @with_session
+    def post(self, session: Session, workspace_id: str, *, auth_data: AuthData):
+        account = _load_account(session, auth_data.account_id)
 
         try:
-            TenantService.switch_tenant(account, workspace_id)
+            TenantService.switch_tenant(account, workspace_id, session=session)
         except AccountNotLinkTenantError:
             raise NotFound("workspace not found")
 
-        row = TenantService.find_workspace_for_account(db.session, str(auth_data.account_id), workspace_id)
+        row = TenantService.find_workspace_for_account(session, str(auth_data.account_id), workspace_id)
         if row is None:
             raise NotFound("workspace not found")
         tenant, membership = row
@@ -172,7 +175,7 @@ class WorkspaceMembersApi(Resource):
     @returns(201, MemberInviteResponse, description="Member invited")
     @accepts(body=MemberInvitePayload)
     def post(self, workspace_id: str, *, auth_data: AuthData, body: MemberInvitePayload):
-        inviter = _load_account(auth_data.account_id)
+        inviter = _load_account(db.session, auth_data.account_id)
         tenant = _load_tenant(workspace_id)
 
         _check_member_invite_quota(str(tenant.id))
@@ -225,7 +228,7 @@ class WorkspaceMemberApi(Resource):
     )
     @returns(200, MemberActionResponse, description="Member removed")
     def delete(self, workspace_id: str, member_id: str, *, auth_data: AuthData):
-        operator = _load_account(auth_data.account_id)
+        operator = _load_account(db.session, auth_data.account_id)
         tenant = _load_tenant(workspace_id)
         member = AccountService.get_account_by_id(db.session, member_id)
         if member is None:
@@ -259,7 +262,7 @@ class WorkspaceMemberRoleApi(Resource):
     @returns(200, MemberActionResponse, description="Role updated")
     @accepts(body=MemberRoleUpdatePayload)
     def put(self, workspace_id: str, member_id: str, *, auth_data: AuthData, body: MemberRoleUpdatePayload):
-        operator = _load_account(auth_data.account_id)
+        operator = _load_account(db.session, auth_data.account_id)
         tenant = _load_tenant(workspace_id)
         member = AccountService.get_account_by_id(db.session, member_id)
         if member is None:

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -981,13 +981,23 @@ class AccountService:
         return token
 
     @staticmethod
-    def get_account_by_email_with_case_fallback(email: str) -> Account | None:
+    def get_account_by_email_with_case_fallback(
+        email: str,
+        session: Session | scoped_session | None = None,
+    ) -> Account | None:
         """
         Retrieve an account by email and fall back to the lowercase email if the original lookup fails.
 
         This keeps backward compatibility for older records that stored uppercase emails while the
         rest of the system gradually normalizes new inputs.
         """
+        if session is not None:
+            account = session.execute(select(Account).where(Account.email == email)).scalar_one_or_none()
+            if account or email == email.lower():
+                return account
+
+            return session.execute(select(Account).where(Account.email == email.lower())).scalar_one_or_none()
+
         with session_factory.create_session() as session:
             account = session.execute(select(Account).where(Account.email == email)).scalar_one_or_none()
             if account or email == email.lower():
@@ -1295,15 +1305,20 @@ class TenantService:
 
     @staticmethod
     def create_tenant_member(
-        tenant: Tenant, account: Account, session: scoped_session, role: str = "normal"
+        tenant: Tenant,
+        account: Account,
+        session: Session | scoped_session | None = None,
+        role: str = "normal",
     ) -> TenantAccountJoin:
         """Create tenant member"""
+        active_session = session if session is not None else db.session
+
         if role == TenantAccountRole.OWNER:
-            if TenantService.has_roles(tenant, [TenantAccountRole.OWNER]):
+            if TenantService.has_roles(tenant, [TenantAccountRole.OWNER], session=active_session):
                 logger.error("Tenant %s has already an owner.", tenant.id)
                 raise Exception("Tenant already has an owner.")
 
-        ta = session.scalar(
+        ta = active_session.scalar(
             select(TenantAccountJoin)
             .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.account_id == account.id)
             .limit(1)
@@ -1312,9 +1327,13 @@ class TenantService:
             ta.role = TenantAccountRole(role)
         else:
             ta = TenantAccountJoin(tenant_id=tenant.id, account_id=account.id, role=TenantAccountRole(role))
-            session.add(ta)
+            active_session.add(ta)
 
-        session.commit()
+        if session is None:
+            db.session.commit()
+        else:
+            active_session.flush()
+
         if dify_config.BILLING_ENABLED:
             BillingService.clean_billing_info_cache(tenant.id)
         return ta
@@ -1544,8 +1563,9 @@ class TenantService:
                 db.session.commit()
 
     @staticmethod
-    def get_tenant_members(tenant: Tenant) -> list[Account]:
+    def get_tenant_members(tenant: Tenant, session: Session | scoped_session | None = None) -> list[Account]:
         """Get tenant members"""
+        active_session = session if session is not None else db.session
         stmt = (
             select(Account, TenantAccountJoin.role)
             .select_from(Account)
@@ -1556,7 +1576,7 @@ class TenantService:
         # Initialize an empty list to store the updated accounts
         updated_accounts = []
 
-        for account, role in db.session.execute(stmt):
+        for account, role in active_session.execute(stmt):
             account.role = role
             updated_accounts.append(account)
 
@@ -1583,13 +1603,18 @@ class TenantService:
         return updated_accounts
 
     @staticmethod
-    def has_roles(tenant: Tenant, roles: list[TenantAccountRole]) -> bool:
+    def has_roles(
+        tenant: Tenant,
+        roles: list[TenantAccountRole],
+        session: Session | scoped_session | None = None,
+    ) -> bool:
         """Check if user has any of the given roles for a tenant"""
         if not all(isinstance(role, TenantAccountRole) for role in roles):
             raise ValueError("all roles must be TenantAccountRole")
 
+        active_session = session if session is not None else db.session
         return (
-            db.session.scalar(
+            active_session.scalar(
                 select(TenantAccountJoin)
                 .where(
                     TenantAccountJoin.tenant_id == tenant.id,
@@ -1601,9 +1626,14 @@ class TenantService:
         )
 
     @staticmethod
-    def get_user_role(account: Account, tenant: Tenant) -> TenantAccountRole | None:
+    def get_user_role(
+        account: Account,
+        tenant: Tenant,
+        session: Session | scoped_session | None = None,
+    ) -> TenantAccountRole | None:
         """Get the role of the current account for a given tenant"""
-        join = db.session.scalar(
+        active_session = session if session is not None else db.session
+        join = active_session.scalar(
             select(TenantAccountJoin)
             .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.account_id == account.id)
             .limit(1)
@@ -1616,8 +1646,15 @@ class TenantService:
         return cast(int, db.session.scalar(select(func.count(Tenant.id))))
 
     @staticmethod
-    def check_member_permission(tenant: Tenant, operator: Account, member: Account | None, action: str):
+    def check_member_permission(
+        tenant: Tenant,
+        operator: Account,
+        member: Account | None,
+        action: str,
+        session: Session | scoped_session | None = None,
+    ):
         """Check member permission"""
+        active_session = session if session is not None else db.session
         if action not in {"add", "remove", "update"}:
             raise InvalidActionError("Invalid action.")
 
@@ -1650,7 +1687,7 @@ class TenantService:
             "update": [TenantAccountRole.OWNER, TenantAccountRole.ADMIN],
         }
 
-        ta_operator = db.session.scalar(
+        ta_operator = active_session.scalar(
             select(TenantAccountJoin)
             .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.account_id == operator.id)
             .limit(1)
@@ -1660,7 +1697,7 @@ class TenantService:
             raise NoPermissionError(f"No permission to {action} member.")
 
         if action == "remove" and ta_operator.role == TenantAccountRole.ADMIN and member:
-            ta_member = db.session.scalar(
+            ta_member = active_session.scalar(
                 select(TenantAccountJoin)
                 .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.account_id == member.id)
                 .limit(1)
@@ -1669,7 +1706,12 @@ class TenantService:
                 raise NoPermissionError(f"No permission to {action} member.")
 
     @staticmethod
-    def remove_member_from_tenant(tenant: Tenant, account: Account, operator: Account):
+    def remove_member_from_tenant(
+        tenant: Tenant,
+        account: Account,
+        operator: Account,
+        session: Session | scoped_session | None = None,
+    ):
         """Remove member from tenant.
 
         Apps and datasets maintained by the removed member are reassigned to
@@ -1681,9 +1723,10 @@ class TenantService:
         if operator.id == account.id:
             raise CannotOperateSelfError("Cannot operate self.")
 
-        TenantService.check_member_permission(tenant, operator, account, "remove")
+        active_session = session if session is not None else db.session
+        TenantService.check_member_permission(tenant, operator, account, "remove", session=active_session)
 
-        ta = db.session.scalar(
+        ta = active_session.scalar(
             select(TenantAccountJoin)
             .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.account_id == account.id)
             .limit(1)
@@ -1700,7 +1743,7 @@ class TenantService:
         if dify_config.RBAC_ENABLED:
             owner_id = AccountService.get_rbac_workspace_owner_account_id(str(tenant.id), str(operator.id))
         else:
-            owner_id = db.session.scalar(
+            owner_id = active_session.scalar(
                 select(TenantAccountJoin.account_id)
                 .where(
                     TenantAccountJoin.tenant_id == tenant.id,
@@ -1711,7 +1754,7 @@ class TenantService:
         if owner_id is None:
             raise ValueError(f"Workspace owner not found for tenant {tenant.id}.")
 
-        db.session.execute(
+        active_session.execute(
             update(App)
             .where(
                 App.tenant_id == tenant.id,
@@ -1719,7 +1762,7 @@ class TenantService:
             )
             .values(maintainer=owner_id)
         )
-        db.session.execute(
+        active_session.execute(
             update(Dataset)
             .where(
                 Dataset.tenant_id == tenant.id,
@@ -1727,23 +1770,26 @@ class TenantService:
             )
             .values(maintainer=owner_id)
         )
-        db.session.delete(ta)
+        active_session.delete(ta)
 
         # Clean up orphaned pending accounts (invited but never activated)
         should_delete_account = False
         if account.status == AccountStatus.PENDING:
             # autoflush flushes ta deletion before this query, so 0 means no remaining joins
             remaining_joins = (
-                db.session.scalar(
+                active_session.scalar(
                     select(func.count(TenantAccountJoin.id)).where(TenantAccountJoin.account_id == account_id)
                 )
                 or 0
             )
             if remaining_joins == 0:
-                db.session.delete(account)
+                active_session.delete(account)
                 should_delete_account = True
 
-        db.session.commit()
+        if session is None:
+            db.session.commit()
+        else:
+            active_session.flush()
 
         if should_delete_account:
             logger.info(
@@ -1769,12 +1815,19 @@ class TenantService:
             )
 
     @staticmethod
-    def update_member_role(tenant: Tenant, member: Account, new_role: str, operator: Account):
+    def update_member_role(
+        tenant: Tenant,
+        member: Account,
+        new_role: str,
+        operator: Account,
+        session: Session | scoped_session | None = None,
+    ):
         """Update member role"""
-        TenantService.check_member_permission(tenant, operator, member, "update")
+        active_session = session if session is not None else db.session
+        TenantService.check_member_permission(tenant, operator, member, "update", session=active_session)
         new_tenant_role = TenantAccountRole(new_role)
 
-        target_member_join = db.session.scalar(
+        target_member_join = active_session.scalar(
             select(TenantAccountJoin)
             .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.account_id == member.id)
             .limit(1)
@@ -1783,7 +1836,7 @@ class TenantService:
         if not target_member_join:
             raise MemberNotInTenantError("Member not in tenant.")
 
-        operator_role = TenantService.get_user_role(operator, tenant)
+        operator_role = TenantService.get_user_role(operator, tenant, session=active_session)
         target_role = TenantAccountRole(target_member_join.role)
         if operator_role == TenantAccountRole.ADMIN and (TenantAccountRole.OWNER in {target_role, new_tenant_role}):
             raise NoPermissionError("No permission to update member.")
@@ -1793,7 +1846,7 @@ class TenantService:
 
         if new_role == "owner":
             # Find the current owner and change their role to 'admin'
-            current_owner_join = db.session.scalar(
+            current_owner_join = active_session.scalar(
                 select(TenantAccountJoin)
                 .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.role == "owner")
                 .limit(1)
@@ -1829,7 +1882,11 @@ class TenantService:
             )
         else:
             target_member_join.role = new_tenant_role
-        db.session.commit()
+
+        if session is None:
+            db.session.commit()
+        else:
+            active_session.flush()
 
     @staticmethod
     def get_custom_config(tenant_id: str):
@@ -1956,13 +2013,20 @@ class RegisterService:
 
     @classmethod
     def invite_new_member(
-        cls, tenant: Tenant, email: str, language: str | None, role: str = "normal", inviter: Account | None = None
+        cls,
+        tenant: Tenant,
+        email: str,
+        language: str | None,
+        role: str = "normal",
+        inviter: Account | None = None,
+        session: Session | scoped_session | None = None,
     ) -> str:
         if not inviter:
             raise ValueError("Inviter is required")
 
         normalized_email = email.lower()
         tenant_join_role = TenantAccountRole.NORMAL.value if dify_config.RBAC_ENABLED else role
+        active_session = session if session is not None else db.session
 
         """Invite new member"""
         # Check workspace permission for member invitations
@@ -1970,11 +2034,11 @@ class RegisterService:
 
         check_workspace_member_invite_permission(tenant.id)
 
-        account = AccountService.get_account_by_email_with_case_fallback(email)
+        account = AccountService.get_account_by_email_with_case_fallback(email, session=session)
 
         requires_setup = False
         if not account:
-            TenantService.check_member_permission(tenant, inviter, None, "add")
+            TenantService.check_member_permission(tenant, inviter, None, "add", session=session)
             name = normalized_email.split("@")[0]
 
             account = cls.register(
@@ -1984,12 +2048,12 @@ class RegisterService:
                 status=AccountStatus.PENDING,
                 is_setup=True,
             )
-            TenantService.create_tenant_member(tenant, account, db.session, tenant_join_role)
-            TenantService.switch_tenant(account, tenant.id)
+            TenantService.create_tenant_member(tenant, account, session=session, role=tenant_join_role)
+            TenantService.switch_tenant(account, tenant.id, session=session)
             requires_setup = True
         else:
-            TenantService.check_member_permission(tenant, inviter, account, "add")
-            ta = db.session.scalar(
+            TenantService.check_member_permission(tenant, inviter, account, "add", session=session)
+            ta = active_session.scalar(
                 select(TenantAccountJoin)
                 .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.account_id == account.id)
                 .limit(1)
@@ -1997,7 +2061,7 @@ class RegisterService:
             requires_setup = account.status == AccountStatus.PENDING
 
             if not ta and (account.status == AccountStatus.PENDING or dify_config.RBAC_ENABLED):
-                TenantService.create_tenant_member(tenant, account, db.session, tenant_join_role)
+                TenantService.create_tenant_member(tenant, account, session=session, role=tenant_join_role)
 
             # Support resend invitation email when the account is pending status
             if account.status != AccountStatus.PENDING:

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -1499,14 +1499,25 @@ class TenantService:
         return tenant
 
     @staticmethod
-    def switch_tenant(account: Account, tenant_id: str | None = None):
-        """Switch the current workspace for the account"""
+    def switch_tenant(
+        account: Account,
+        tenant_id: str | None = None,
+        session: Session | scoped_session | None = None,
+    ):
+        """Switch the current workspace for the account.
+
+        When a controller owns the request transaction, pass its session so the
+        membership update commits with the outer handler. Legacy callers keep
+        using the Flask-scoped session and commit here.
+        """
 
         # Ensure tenant_id is provided
         if tenant_id is None:
             raise ValueError("Tenant ID must be provided.")
 
-        tenant_account_join = db.session.scalar(
+        active_session = session if session is not None else db.session
+
+        tenant_account_join = active_session.scalar(
             select(TenantAccountJoin)
             .join(Tenant, TenantAccountJoin.tenant_id == Tenant.id)
             .where(
@@ -1520,7 +1531,7 @@ class TenantService:
         if not tenant_account_join:
             raise AccountNotLinkTenantError("Tenant not found or account is not a member of the tenant.")
         else:
-            db.session.execute(
+            active_session.execute(
                 update(TenantAccountJoin)
                 .where(TenantAccountJoin.account_id == account.id, TenantAccountJoin.tenant_id != tenant_id)
                 .values(current=False)
@@ -1529,7 +1540,8 @@ class TenantService:
             tenant_account_join.last_opened_at = naive_utc_now()
             # Set the current tenant for the account
             account.set_tenant_id(tenant_account_join.tenant_id)
-            db.session.commit()
+            if session is None:
+                db.session.commit()
 
     @staticmethod
     def get_tenant_members(tenant: Tenant) -> list[Account]:

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -991,19 +991,19 @@ class AccountService:
         This keeps backward compatibility for older records that stored uppercase emails while the
         rest of the system gradually normalizes new inputs.
         """
-        if session is not None:
-            account = session.execute(select(Account).where(Account.email == email)).scalar_one_or_none()
+
+        def get_account(active_session: Session | scoped_session) -> Account | None:
+            account = active_session.execute(select(Account).where(Account.email == email)).scalar_one_or_none()
             if account or email == email.lower():
                 return account
 
-            return session.execute(select(Account).where(Account.email == email.lower())).scalar_one_or_none()
+            return active_session.execute(select(Account).where(Account.email == email.lower())).scalar_one_or_none()
+
+        if session is not None:
+            return get_account(session)
 
         with session_factory.create_session() as session:
-            account = session.execute(select(Account).where(Account.email == email)).scalar_one_or_none()
-            if account or email == email.lower():
-                return account
-
-            return session.execute(select(Account).where(Account.email == email.lower())).scalar_one_or_none()
+            return get_account(session)
 
     @classmethod
     def get_email_code_login_data(cls, token: str) -> dict[str, Any] | None:
@@ -1329,10 +1329,7 @@ class TenantService:
             ta = TenantAccountJoin(tenant_id=tenant.id, account_id=account.id, role=TenantAccountRole(role))
             active_session.add(ta)
 
-        if session is None:
-            db.session.commit()
-        else:
-            active_session.flush()
+        active_session.commit()
 
         if dify_config.BILLING_ENABLED:
             BillingService.clean_billing_info_cache(tenant.id)
@@ -1525,9 +1522,8 @@ class TenantService:
     ):
         """Switch the current workspace for the account.
 
-        When a controller owns the request transaction, pass its session so the
-        membership update commits with the outer handler. Legacy callers keep
-        using the Flask-scoped session and commit here.
+        When a controller passes an explicit session, this service still owns
+        the commit so side effects keep their legacy ordering.
         """
 
         # Ensure tenant_id is provided
@@ -1559,8 +1555,7 @@ class TenantService:
             tenant_account_join.last_opened_at = naive_utc_now()
             # Set the current tenant for the account
             account.set_tenant_id(tenant_account_join.tenant_id)
-            if session is None:
-                db.session.commit()
+            active_session.commit()
 
     @staticmethod
     def get_tenant_members(tenant: Tenant, session: Session | scoped_session | None = None) -> list[Account]:
@@ -1786,10 +1781,7 @@ class TenantService:
                 active_session.delete(account)
                 should_delete_account = True
 
-        if session is None:
-            db.session.commit()
-        else:
-            active_session.flush()
+        active_session.commit()
 
         if should_delete_account:
             logger.info(
@@ -1883,10 +1875,7 @@ class TenantService:
         else:
             target_member_join.role = new_tenant_role
 
-        if session is None:
-            db.session.commit()
-        else:
-            active_session.flush()
+        active_session.commit()
 
     @staticmethod
     def get_custom_config(tenant_id: str):

--- a/api/tests/test_containers_integration_tests/controllers/openapi/test_workspaces.py
+++ b/api/tests/test_containers_integration_tests/controllers/openapi/test_workspaces.py
@@ -24,7 +24,7 @@ class TestWorkspacesList:
 
         api = WorkspacesApi()
         with app.test_request_context("/openapi/v1/workspaces"):
-            result = unwrap(api.get)(api, auth_data=auth_for(account))
+            result = unwrap(api.get)(api, db_session_with_containers, auth_data=auth_for(account))
 
         ids = {w.id for w in result.workspaces}
         assert ids == {owner_tenant.id}
@@ -45,7 +45,7 @@ class TestWorkspacesList:
 
         api = WorkspacesApi()
         with app.test_request_context("/openapi/v1/workspaces"):
-            result = unwrap(api.get)(api, auth_data=auth_for(account))
+            result = unwrap(api.get)(api, db_session_with_containers, auth_data=auth_for(account))
 
         assert {w.id for w in result.workspaces} == {owner_tenant.id, second.id}
 
@@ -60,7 +60,9 @@ class TestWorkspaceDetail:
 
         api = WorkspaceByIdApi()
         with app.test_request_context(f"/openapi/v1/workspaces/{tenant.id}"):
-            detail = unwrap(api.get)(api, workspace_id=tenant.id, auth_data=auth_for(account))
+            detail = unwrap(api.get)(
+                api, db_session_with_containers, workspace_id=tenant.id, auth_data=auth_for(account)
+            )
 
         assert detail.id == tenant.id
         assert detail.role == TenantAccountRole.OWNER.value
@@ -80,7 +82,12 @@ class TestWorkspaceDetail:
         api = WorkspaceByIdApi()
         with app.test_request_context(f"/openapi/v1/workspaces/{someone_elses_ws.id}"):
             with pytest.raises(NotFound):
-                unwrap(api.get)(api, workspace_id=someone_elses_ws.id, auth_data=auth_for(outsider))
+                unwrap(api.get)(
+                    api,
+                    db_session_with_containers,
+                    workspace_id=someone_elses_ws.id,
+                    auth_data=auth_for(outsider),
+                )
 
 
 class TestWorkspaceSwitch:
@@ -94,7 +101,9 @@ class TestWorkspaceSwitch:
 
         api = WorkspaceSwitchApi()
         with app.test_request_context(f"/openapi/v1/workspaces/{target.id}/switch", method="POST"):
-            detail = unwrap(api.post)(api, workspace_id=target.id, auth_data=auth_for(account))
+            detail = unwrap(api.post)(
+                api, db_session_with_containers, workspace_id=target.id, auth_data=auth_for(account)
+            )
 
         # Response reflects the post-switch state.
         assert detail.id == target.id
@@ -103,7 +112,8 @@ class TestWorkspaceSwitch:
         # And the switch persisted: the previously-current owner workspace is no
         # longer current (verified through the real read path).
         with app.test_request_context("/openapi/v1/workspaces"):
-            listing = unwrap(WorkspacesApi().get)(WorkspacesApi(), auth_data=auth_for(account))
+            listing_api = WorkspacesApi()
+            listing = unwrap(listing_api.get)(listing_api, db_session_with_containers, auth_data=auth_for(account))
         by_id = {w.id: w for w in listing.workspaces}
         assert by_id[target.id].current is True
         assert by_id[owner_tenant.id].current is False
@@ -118,4 +128,9 @@ class TestWorkspaceSwitch:
         api = WorkspaceSwitchApi()
         with app.test_request_context(f"/openapi/v1/workspaces/{outsider_ws.id}/switch", method="POST"):
             with pytest.raises(NotFound):
-                unwrap(api.post)(api, workspace_id=outsider_ws.id, auth_data=auth_for(account))
+                unwrap(api.post)(
+                    api,
+                    db_session_with_containers,
+                    workspace_id=outsider_ws.id,
+                    auth_data=auth_for(account),
+                )

--- a/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
@@ -428,19 +428,21 @@ class TestSwitchWorkspaceApi:
         payload = {"tenant_id": "t2"}
         tenant = make_tenant("t2")
         user = make_account()
+        session = MagicMock()
+        session.get.return_value = tenant
 
         with (
             app.test_request_context("/workspaces/switch", json=payload),
-            patch("controllers.console.workspace.workspace.TenantService.switch_tenant"),
-            patch("controllers.console.workspace.workspace.db.session.get") as get_mock,
+            patch("controllers.console.workspace.workspace.TenantService.switch_tenant") as switch_tenant_mock,
             patch(
                 "controllers.console.workspace.workspace.WorkspaceService.get_tenant_info", return_value={"id": "t2"}
             ),
         ):
-            get_mock.return_value = tenant
-            result = method(api, user)
+            result = method(api, session, user)
 
         assert result["result"] == "success"
+        switch_tenant_mock.assert_called_once_with(user, "t2", session=session)
+        session.get.assert_called_once()
 
     def test_switch_not_linked(self, app: Flask):
         api = SwitchWorkspaceApi()
@@ -448,13 +450,14 @@ class TestSwitchWorkspaceApi:
 
         payload = {"tenant_id": "bad"}
         user = make_account()
+        session = MagicMock()
 
         with (
             app.test_request_context("/workspaces/switch", json=payload),
             patch("controllers.console.workspace.workspace.TenantService.switch_tenant", side_effect=Exception),
         ):
             with pytest.raises(AccountNotLinkTenantError):
-                method(api, user)
+                method(api, session, user)
 
     def test_switch_tenant_not_found(self, app: Flask):
         api = SwitchWorkspaceApi()
@@ -462,16 +465,16 @@ class TestSwitchWorkspaceApi:
 
         payload = {"tenant_id": "missing"}
         user = make_account()
+        session = MagicMock()
+        session.get.return_value = None
 
         with (
             app.test_request_context("/workspaces/switch", json=payload),
             patch("controllers.console.workspace.workspace.TenantService.switch_tenant"),
-            patch("controllers.console.workspace.workspace.db.session.get") as get_mock,
         ):
-            get_mock.return_value = None
-
             with pytest.raises(ValueError):
-                method(api, user)
+                method(api, session, user)
+        session.get.assert_called_once()
 
 
 class TestCustomConfigWorkspaceApi:
@@ -480,42 +483,40 @@ class TestCustomConfigWorkspaceApi:
         method = inspect.unwrap(api.post)
 
         tenant = make_tenant(custom_config={})
+        session = MagicMock()
+        session.get.return_value = tenant
 
         payload = {"remove_webapp_brand": True}
 
         with (
             app.test_request_context("/workspaces/custom-config", json=payload),
-            patch("controllers.console.workspace.workspace.db.get_or_404", return_value=tenant),
-            patch("controllers.console.workspace.workspace.db.session.commit"),
             patch(
                 "controllers.console.workspace.workspace.WorkspaceService.get_tenant_info", return_value={"id": "t1"}
             ),
         ):
-            result = method(api, "t1")
+            result = method(api, session, "t1")
 
         assert result["result"] == "success"
+        session.get.assert_called_once()
 
     def test_logo_fallback(self, app: Flask):
         api = CustomConfigWorkspaceApi()
         method = inspect.unwrap(api.post)
 
         tenant = make_tenant(custom_config={"replace_webapp_logo": "old-logo"})
+        session = MagicMock()
+        session.get.return_value = tenant
 
         payload = {"remove_webapp_brand": False}
 
         with (
             app.test_request_context("/workspaces/custom-config", json=payload),
             patch(
-                "controllers.console.workspace.workspace.db.get_or_404",
-                return_value=tenant,
-            ),
-            patch("controllers.console.workspace.workspace.db.session.commit"),
-            patch(
                 "controllers.console.workspace.workspace.WorkspaceService.get_tenant_info",
                 return_value={"id": "t1"},
             ),
         ):
-            result = method(api, "t1")
+            result = method(api, session, "t1")
 
         assert tenant.custom_config_dict["replace_webapp_logo"] == "old-logo"
         assert result["result"] == "success"
@@ -664,33 +665,35 @@ class TestWorkspaceInfoApi:
         method = inspect.unwrap(api.post)
 
         tenant = make_tenant()
+        session = MagicMock()
+        session.get.return_value = tenant
 
         payload = {"name": "New Name"}
 
         with (
             app.test_request_context("/workspaces/info", json=payload),
-            patch("controllers.console.workspace.workspace.db.get_or_404", return_value=tenant),
-            patch("controllers.console.workspace.workspace.db.session.commit"),
             patch(
                 "controllers.console.workspace.workspace.WorkspaceService.get_tenant_info",
                 return_value={"name": "New Name"},
             ),
         ):
-            result = method(api, "t1")
+            result = method(api, session, "t1")
 
         assert result["result"] == "success"
+        session.get.assert_called_once()
 
     def test_no_current_tenant(self, app: Flask):
         api = WorkspaceInfoApi()
         method = inspect.unwrap(api.post)
 
         payload = {"name": "X"}
+        session = MagicMock()
 
         with (
             app.test_request_context("/workspaces/info", json=payload),
         ):
             with pytest.raises(ValueError):
-                method(api, None)
+                method(api, session, None)
 
 
 class TestWorkspacePermissionApi:

--- a/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
@@ -498,6 +498,7 @@ class TestCustomConfigWorkspaceApi:
 
         assert result["result"] == "success"
         session.get.assert_called_once()
+        session.commit.assert_called_once()
 
     def test_logo_fallback(self, app: Flask):
         api = CustomConfigWorkspaceApi()
@@ -520,6 +521,7 @@ class TestCustomConfigWorkspaceApi:
 
         assert tenant.custom_config_dict["replace_webapp_logo"] == "old-logo"
         assert result["result"] == "success"
+        session.commit.assert_called_once()
 
 
 class TestWebappLogoWorkspaceApi:
@@ -681,6 +683,7 @@ class TestWorkspaceInfoApi:
 
         assert result["result"] == "success"
         session.get.assert_called_once()
+        session.commit.assert_called_once()
 
     def test_no_current_tenant(self, app: Flask):
         api = WorkspaceInfoApi()

--- a/api/tests/unit_tests/controllers/openapi/test_workspaces.py
+++ b/api/tests/unit_tests/controllers/openapi/test_workspaces.py
@@ -4,13 +4,19 @@ list + member-gated detail. No legacy /v1/ equivalent — the cookie-authed
 """
 
 import builtins
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock
 
 import pytest
 from flask import Flask
 from flask.views import MethodView
 
 from controllers.openapi import bp as openapi_bp
+from controllers.openapi.auth.data import AuthData
 from controllers.openapi.workspaces import WorkspaceByIdApi, WorkspacesApi
+from libs.oauth_bearer import Scope, TokenType
 
 if not hasattr(builtins, "MethodView"):
     builtins.MethodView = MethodView  # type: ignore[attr-defined]
@@ -26,6 +32,29 @@ def openapi_app() -> Flask:
 
 def _rule(app: Flask, path: str):
     return next(r for r in app.url_map.iter_rules() if r.rule == path)
+
+
+def _auth_data(account_id: uuid.UUID) -> AuthData:
+    return AuthData(
+        token_type=TokenType.OAUTH_ACCOUNT,
+        account_id=account_id,
+        token_hash="testhash",
+        scopes=frozenset({Scope.FULL}),
+    )
+
+
+def _call_with_session(method, resource, session: MagicMock, /, *args, **kwargs):
+    """Bypass auth and `with_session`, while keeping contract wrappers."""
+    return method.__wrapped__.__wrapped__(resource, session, *args, **kwargs)
+
+
+def _tenant(tenant_id: str = "ws-1") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=tenant_id,
+        name="WS",
+        status="normal",
+        created_at=datetime(2026, 5, 18, tzinfo=UTC),
+    )
 
 
 def test_workspaces_list_route_registered(openapi_app: Flask):
@@ -56,3 +85,42 @@ def test_console_legacy_workspaces_route_not_remounted_on_openapi(openapi_app: F
     """
     rules = {r.rule for r in openapi_app.url_map.iter_rules()}
     assert "/console/api/workspaces" not in rules
+
+
+def test_workspaces_list_uses_injected_session(monkeypatch):
+    acct_id = uuid.uuid4()
+    api = WorkspacesApi()
+    session = MagicMock()
+    membership = SimpleNamespace(role="owner", current=True)
+    get_workspaces = Mock(return_value=[(_tenant("ws-1"), membership)])
+
+    monkeypatch.setattr(
+        "controllers.openapi.workspaces.TenantService",
+        SimpleNamespace(get_workspaces_for_account=get_workspaces),
+    )
+
+    body, status = _call_with_session(api.get, api, session, auth_data=_auth_data(acct_id))
+
+    assert status == 200
+    assert body["workspaces"][0]["id"] == "ws-1"
+    get_workspaces.assert_called_once_with(session, str(acct_id))
+
+
+def test_workspace_detail_uses_injected_session(monkeypatch):
+    acct_id = uuid.uuid4()
+    ws_id = str(uuid.uuid4())
+    api = WorkspaceByIdApi()
+    session = MagicMock()
+    membership = SimpleNamespace(role="admin", current=False)
+    find_workspace = Mock(return_value=(_tenant(ws_id), membership))
+
+    monkeypatch.setattr(
+        "controllers.openapi.workspaces.TenantService",
+        SimpleNamespace(find_workspace_for_account=find_workspace),
+    )
+
+    body, status = _call_with_session(api.get, api, session, workspace_id=ws_id, auth_data=_auth_data(acct_id))
+
+    assert status == 200
+    assert body["id"] == ws_id
+    find_workspace.assert_called_once_with(session, str(acct_id), ws_id)

--- a/api/tests/unit_tests/controllers/openapi/test_workspaces_members.py
+++ b/api/tests/unit_tests/controllers/openapi/test_workspaces_members.py
@@ -143,8 +143,8 @@ def _tenant_service(**overrides) -> SimpleNamespace:
 
     Read getters (`get_tenant_by_id`, `find_workspace_for_account`) delegate
     to the session they're handed, so tests keep driving entity loads through
-    ``mock_db.session.get`` / ``.execute`` and their existing side_effect
-    ordering — the SQL those methods run is covered in test_account_service.py.
+    ``session.get`` / ``.execute`` and their existing side_effect ordering —
+    the SQL those methods run is covered in test_account_service.py.
     Domain mutators default to no-op Mocks; override per test as needed.
     """
     methods: dict = {
@@ -169,17 +169,9 @@ def _account_service(**overrides) -> SimpleNamespace:
     return SimpleNamespace(**methods)
 
 
-def _patch_write_session(monkeypatch, session: MagicMock) -> MagicMock:
-    """Keep the auth decorator bypassed while preserving `with_session`."""
-    from controllers.console.app import wraps as wraps_module
-
-    session_context = MagicMock()
-    session_context.__enter__.return_value = session
-    session_context.__exit__.return_value = None
-    session_maker = MagicMock()
-    session_maker.begin.return_value = session_context
-    monkeypatch.setattr(wraps_module.session_factory, "get_session_maker", lambda: session_maker)
-    return session_maker
+def _call_with_session(method, resource, session: MagicMock, /, *args, **kwargs):
+    """Bypass auth and `with_session`, while keeping contract wrappers."""
+    return method.__wrapped__.__wrapped__(resource, session, *args, **kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -247,6 +239,7 @@ def test_invite_rejects_invalid_body_with_422(app: Flask, bypass_pipeline):
     ws_id = str(uuid.uuid4())
     acct_id = uuid.uuid4()
     api = WorkspaceMembersApi()
+    session = MagicMock()
 
     with app.test_request_context(
         f"/openapi/v1/workspaces/{ws_id}/members",
@@ -256,7 +249,7 @@ def test_invite_rejects_invalid_body_with_422(app: Flask, bypass_pipeline):
     ):
         _seed(_auth_ctx(account_id=acct_id))
         with pytest.raises(UnprocessableEntity):
-            api.post.__wrapped__(api, workspace_id=ws_id, auth_data=_auth_data(acct_id))
+            _call_with_session(api.post, api, session, workspace_id=ws_id, auth_data=_auth_data(acct_id))
 
 
 def test_update_role_rejects_invalid_body_with_422(app: Flask, bypass_pipeline):
@@ -264,6 +257,7 @@ def test_update_role_rejects_invalid_body_with_422(app: Flask, bypass_pipeline):
     ws_id, member_id = str(uuid.uuid4()), str(uuid.uuid4())
     acct_id = uuid.uuid4()
     api = WorkspaceMemberRoleApi()
+    session = MagicMock()
 
     with app.test_request_context(
         f"/openapi/v1/workspaces/{ws_id}/members/{member_id}/role",
@@ -273,7 +267,14 @@ def test_update_role_rejects_invalid_body_with_422(app: Flask, bypass_pipeline):
     ):
         _seed(_auth_ctx(account_id=acct_id))
         with pytest.raises(UnprocessableEntity):
-            api.put.__wrapped__(api, workspace_id=ws_id, member_id=member_id, auth_data=_auth_data(acct_id))
+            _call_with_session(
+                api.put,
+                api,
+                session,
+                workspace_id=ws_id,
+                member_id=member_id,
+                auth_data=_auth_data(acct_id),
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -293,7 +294,6 @@ def test_switch_returns_workspace_detail_with_current_true(
     api = WorkspaceSwitchApi()
 
     session = MagicMock()
-    session_maker = _patch_write_session(monkeypatch, session)
     account = _account(account_id=str(acct_id))
     session.get.return_value = account
     membership = SimpleNamespace(role=TenantAccountRole.OWNER, current=True)
@@ -308,12 +308,11 @@ def test_switch_returns_workspace_detail_with_current_true(
 
     with app.test_request_context(f"/openapi/v1/workspaces/{ws_id}/switch", method="POST"):
         _seed(_auth_ctx(account_id=acct_id))
-        body, status = api.post.__wrapped__(api, workspace_id=ws_id, auth_data=_auth_data(acct_id))
+        body, status = _call_with_session(api.post, api, session, workspace_id=ws_id, auth_data=_auth_data(acct_id))
 
     assert status == 200
     assert body["id"] == ws_id
     assert body["current"] is True
-    session_maker.begin.assert_called_once()
     switch_mock.assert_called_once_with(account, ws_id, session=session)
 
 
@@ -327,7 +326,6 @@ def test_switch_404s_when_service_raises_account_not_link_tenant(
     api = WorkspaceSwitchApi()
 
     session = MagicMock()
-    _patch_write_session(monkeypatch, session)
     session.get.return_value = _account(account_id=str(acct_id))
 
     monkeypatch.setattr(
@@ -339,7 +337,7 @@ def test_switch_404s_when_service_raises_account_not_link_tenant(
     with app.test_request_context(f"/openapi/v1/workspaces/{ws_id}/switch", method="POST"):
         _seed(_auth_ctx(account_id=acct_id))
         with pytest.raises(NotFound):
-            api.post.__wrapped__(api, workspace_id=ws_id, auth_data=_auth_data(acct_id))
+            _call_with_session(api.post, api, session, workspace_id=ws_id, auth_data=_auth_data(acct_id))
 
 
 # ---------------------------------------------------------------------------
@@ -361,19 +359,18 @@ def test_members_list_returns_normalized_rows(app: Flask, bypass_pipeline, monke
         role=TenantAccountRole.ADMIN,
     )
 
-    mock_db = MagicMock()
-    mock_db.session.get.return_value = _tenant(ws_id)
+    session = MagicMock()
+    session.get.return_value = _tenant(ws_id)
 
     monkeypatch.setattr(
         sys.modules["controllers.openapi.workspaces"],
         "TenantService",
         _tenant_service(get_tenant_members=Mock(return_value=[member])),
     )
-    monkeypatch.setattr(sys.modules["controllers.openapi.workspaces"], "db", mock_db)
 
     with app.test_request_context(f"/openapi/v1/workspaces/{ws_id}/members"):
         _seed(_auth_ctx(account_id=acct_id))
-        body, status = api.get.__wrapped__(api, workspace_id=ws_id, auth_data=_auth_data(acct_id))
+        body, status = _call_with_session(api.get, api, session, workspace_id=ws_id, auth_data=_auth_data(acct_id))
 
     assert status == 200
     assert body["page"] == 1
@@ -403,19 +400,18 @@ def test_members_list_paginates_with_query_params(app: Flask, bypass_pipeline, m
         for i in range(5)
     ]
 
-    mock_db = MagicMock()
-    mock_db.session.get.return_value = _tenant(ws_id)
+    session = MagicMock()
+    session.get.return_value = _tenant(ws_id)
 
     monkeypatch.setattr(
         sys.modules["controllers.openapi.workspaces"],
         "TenantService",
         _tenant_service(get_tenant_members=Mock(return_value=members)),
     )
-    monkeypatch.setattr(sys.modules["controllers.openapi.workspaces"], "db", mock_db)
 
     with app.test_request_context(f"/openapi/v1/workspaces/{ws_id}/members?page=2&limit=2"):
         _seed(_auth_ctx(account_id=acct_id))
-        body, status = api.get.__wrapped__(api, workspace_id=ws_id, auth_data=_auth_data(acct_id))
+        body, status = _call_with_session(api.get, api, session, workspace_id=ws_id, auth_data=_auth_data(acct_id))
 
     assert status == 200
     assert body["page"] == 2
@@ -430,15 +426,12 @@ def test_members_list_rejects_unknown_query_param(app: Flask, bypass_pipeline, m
     ws_id = str(uuid.uuid4())
     acct_id = uuid.uuid4()
     api = WorkspaceMembersApi()
-
-    mock_db = MagicMock()
-    mock_db.session.get.return_value = _tenant(ws_id)
-    monkeypatch.setattr(sys.modules["controllers.openapi.workspaces"], "db", mock_db)
+    session = MagicMock()
 
     with app.test_request_context(f"/openapi/v1/workspaces/{ws_id}/members?pg=2"):
         _seed(_auth_ctx(account_id=acct_id))
         with pytest.raises(UnprocessableEntity):
-            api.get.__wrapped__(api, workspace_id=ws_id, auth_data=_auth_data(acct_id))
+            _call_with_session(api.get, api, session, workspace_id=ws_id, auth_data=_auth_data(acct_id))
 
 
 # ---------------------------------------------------------------------------
@@ -455,21 +448,22 @@ def test_invite_happy_path_returns_invite_url_and_member_id(
 
     invited = _account(account_id="new-1", email="new@example.com")
 
-    mock_db = MagicMock()
+    session = MagicMock()
     # session.get is called twice: once for inviter Account, once for Tenant
-    mock_db.session.get.side_effect = [_account(account_id=str(acct_id)), _tenant(ws_id)]
+    session.get.side_effect = [_account(account_id=str(acct_id)), _tenant(ws_id)]
+    invite_mock = Mock(return_value="tok-123")
+    get_member_mock = Mock(return_value=invited)
 
     monkeypatch.setattr(
         sys.modules["controllers.openapi.workspaces"],
         "RegisterService",
-        SimpleNamespace(invite_new_member=Mock(return_value="tok-123")),
+        SimpleNamespace(invite_new_member=invite_mock),
     )
     monkeypatch.setattr(
         sys.modules["controllers.openapi.workspaces"],
         "AccountService",
-        _account_service(get_account_by_email_with_case_fallback=Mock(return_value=invited)),
+        _account_service(get_account_by_email_with_case_fallback=get_member_mock),
     )
-    monkeypatch.setattr(sys.modules["controllers.openapi.workspaces"], "db", mock_db)
 
     with app.test_request_context(
         f"/openapi/v1/workspaces/{ws_id}/members",
@@ -478,7 +472,7 @@ def test_invite_happy_path_returns_invite_url_and_member_id(
         content_type="application/json",
     ):
         _seed(_auth_ctx(account_id=acct_id))
-        body, status = api.post.__wrapped__(api, workspace_id=ws_id, auth_data=_auth_data(acct_id))
+        body, status = _call_with_session(api.post, api, session, workspace_id=ws_id, auth_data=_auth_data(acct_id))
 
     assert status == 201
     assert body["result"] == "success"
@@ -488,6 +482,9 @@ def test_invite_happy_path_returns_invite_url_and_member_id(
     assert "token=tok-123" in body["invite_url"]
     assert "email=new%40example.com" in body["invite_url"]
     assert body["tenant_id"] == ws_id
+    invite_mock.assert_called_once()
+    assert invite_mock.call_args.kwargs["session"] is session
+    get_member_mock.assert_called_once_with("new@example.com", session=session)
 
 
 def _features(
@@ -536,8 +533,8 @@ def test_invite_blocked_by_saas_members_cap(app: Flask, bypass_pipeline, monkeyp
     acct_id = uuid.uuid4()
     api = WorkspaceMembersApi()
 
-    mock_db = MagicMock()
-    mock_db.session.get.side_effect = [_account(account_id=str(acct_id)), _tenant(ws_id)]
+    session = MagicMock()
+    session.get.side_effect = [_account(account_id=str(acct_id)), _tenant(ws_id)]
 
     invite_mock = Mock()
     monkeypatch.setattr(
@@ -545,7 +542,6 @@ def test_invite_blocked_by_saas_members_cap(app: Flask, bypass_pipeline, monkeyp
         "RegisterService",
         SimpleNamespace(invite_new_member=invite_mock),
     )
-    monkeypatch.setattr(sys.modules["controllers.openapi.workspaces"], "db", mock_db)
     monkeypatch.setattr(
         sys.modules["controllers.openapi.workspaces"],
         "FeatureService",
@@ -559,7 +555,7 @@ def test_invite_blocked_by_saas_members_cap(app: Flask, bypass_pipeline, monkeyp
     with _invite_request(app, ws_id, acct_id):
         _seed(_auth_ctx(account_id=acct_id))
         with pytest.raises(MemberLimitExceeded):
-            api.post.__wrapped__(api, workspace_id=ws_id, auth_data=_auth_data(acct_id))
+            _call_with_session(api.post, api, session, workspace_id=ws_id, auth_data=_auth_data(acct_id))
 
     invite_mock.assert_not_called()
 
@@ -574,8 +570,8 @@ def test_invite_blocked_by_ee_workspace_members_license(app: Flask, bypass_pipel
     acct_id = uuid.uuid4()
     api = WorkspaceMembersApi()
 
-    mock_db = MagicMock()
-    mock_db.session.get.side_effect = [_account(account_id=str(acct_id)), _tenant(ws_id)]
+    session = MagicMock()
+    session.get.side_effect = [_account(account_id=str(acct_id)), _tenant(ws_id)]
 
     invite_mock = Mock()
     monkeypatch.setattr(
@@ -583,7 +579,6 @@ def test_invite_blocked_by_ee_workspace_members_license(app: Flask, bypass_pipel
         "RegisterService",
         SimpleNamespace(invite_new_member=invite_mock),
     )
-    monkeypatch.setattr(sys.modules["controllers.openapi.workspaces"], "db", mock_db)
     monkeypatch.setattr(
         sys.modules["controllers.openapi.workspaces"],
         "FeatureService",
@@ -601,7 +596,7 @@ def test_invite_blocked_by_ee_workspace_members_license(app: Flask, bypass_pipel
     with _invite_request(app, ws_id, acct_id):
         _seed(_auth_ctx(account_id=acct_id))
         with pytest.raises(MemberLicenseExceeded):
-            api.post.__wrapped__(api, workspace_id=ws_id, auth_data=_auth_data(acct_id))
+            _call_with_session(api.post, api, session, workspace_id=ws_id, auth_data=_auth_data(acct_id))
 
     invite_mock.assert_not_called()
 
@@ -614,20 +609,20 @@ def test_invite_ce_passes_when_both_caps_disabled(app: Flask, bypass_pipeline, m
     api = WorkspaceMembersApi()
 
     invited = _account(account_id="new-1", email="new@example.com")
-    mock_db = MagicMock()
-    mock_db.session.get.side_effect = [_account(account_id=str(acct_id)), _tenant(ws_id)]
+    session = MagicMock()
+    session.get.side_effect = [_account(account_id=str(acct_id)), _tenant(ws_id)]
+    invite_mock = Mock(return_value="tok-ce")
 
     monkeypatch.setattr(
         sys.modules["controllers.openapi.workspaces"],
         "RegisterService",
-        SimpleNamespace(invite_new_member=Mock(return_value="tok-ce")),
+        SimpleNamespace(invite_new_member=invite_mock),
     )
     monkeypatch.setattr(
         sys.modules["controllers.openapi.workspaces"],
         "AccountService",
         _account_service(get_account_by_email_with_case_fallback=Mock(return_value=invited)),
     )
-    monkeypatch.setattr(sys.modules["controllers.openapi.workspaces"], "db", mock_db)
     monkeypatch.setattr(
         sys.modules["controllers.openapi.workspaces"],
         "FeatureService",
@@ -636,10 +631,11 @@ def test_invite_ce_passes_when_both_caps_disabled(app: Flask, bypass_pipeline, m
 
     with _invite_request(app, ws_id, acct_id):
         _seed(_auth_ctx(account_id=acct_id))
-        body, status = api.post.__wrapped__(api, workspace_id=ws_id, auth_data=_auth_data(acct_id))
+        body, status = _call_with_session(api.post, api, session, workspace_id=ws_id, auth_data=_auth_data(acct_id))
 
     assert status == 201
     assert body["email"] == "new@example.com"
+    assert invite_mock.call_args.kwargs["session"] is session
 
 
 def test_invite_400_when_already_in_tenant(app: Flask, bypass_pipeline, monkeypatch: pytest.MonkeyPatch):
@@ -647,15 +643,14 @@ def test_invite_400_when_already_in_tenant(app: Flask, bypass_pipeline, monkeypa
     acct_id = uuid.uuid4()
     api = WorkspaceMembersApi()
 
-    mock_db = MagicMock()
-    mock_db.session.get.side_effect = [_account(account_id=str(acct_id)), _tenant(ws_id)]
+    session = MagicMock()
+    session.get.side_effect = [_account(account_id=str(acct_id)), _tenant(ws_id)]
 
     monkeypatch.setattr(
         sys.modules["controllers.openapi.workspaces"],
         "RegisterService",
         SimpleNamespace(invite_new_member=Mock(side_effect=AccountAlreadyInTenantError("already in tenant"))),
     )
-    monkeypatch.setattr(sys.modules["controllers.openapi.workspaces"], "db", mock_db)
 
     with app.test_request_context(
         f"/openapi/v1/workspaces/{ws_id}/members",
@@ -665,7 +660,7 @@ def test_invite_400_when_already_in_tenant(app: Flask, bypass_pipeline, monkeypa
     ):
         _seed(_auth_ctx(account_id=acct_id))
         with pytest.raises(BadRequest):
-            api.post.__wrapped__(api, workspace_id=ws_id, auth_data=_auth_data(acct_id))
+            _call_with_session(api.post, api, session, workspace_id=ws_id, auth_data=_auth_data(acct_id))
 
 
 # ---------------------------------------------------------------------------
@@ -678,8 +673,8 @@ def test_delete_member_happy_path(app: Flask, bypass_pipeline, monkeypatch: pyte
     acct_id = uuid.uuid4()
     api = WorkspaceMemberApi()
 
-    mock_db = MagicMock()
-    mock_db.session.get.side_effect = [
+    session = MagicMock()
+    session.get.side_effect = [
         _account(account_id=str(acct_id)),  # operator
         _tenant(ws_id),  # tenant
         _account(account_id=member_id),  # target member
@@ -691,20 +686,20 @@ def test_delete_member_happy_path(app: Flask, bypass_pipeline, monkeypatch: pyte
         "TenantService",
         _tenant_service(remove_member_from_tenant=remove_mock),
     )
-    monkeypatch.setattr(sys.modules["controllers.openapi.workspaces"], "db", mock_db)
 
     with app.test_request_context(
         f"/openapi/v1/workspaces/{ws_id}/members/{member_id}",
         method="DELETE",
     ):
         _seed(_auth_ctx(account_id=acct_id))
-        body, status = api.delete.__wrapped__(
-            api, workspace_id=ws_id, member_id=member_id, auth_data=_auth_data(acct_id)
+        body, status = _call_with_session(
+            api.delete, api, session, workspace_id=ws_id, member_id=member_id, auth_data=_auth_data(acct_id)
         )
 
     assert status == 200
     assert body == {"result": "success"}
-    assert remove_mock.called
+    remove_mock.assert_called_once()
+    assert remove_mock.call_args.kwargs["session"] is session
 
 
 @pytest.mark.parametrize(
@@ -720,8 +715,8 @@ def test_delete_member_exception_mapping(app: Flask, bypass_pipeline, monkeypatc
     acct_id = uuid.uuid4()
     api = WorkspaceMemberApi()
 
-    mock_db = MagicMock()
-    mock_db.session.get.side_effect = [
+    session = MagicMock()
+    session.get.side_effect = [
         _account(account_id=str(acct_id)),
         _tenant(ws_id),
         _account(account_id=member_id),
@@ -732,7 +727,6 @@ def test_delete_member_exception_mapping(app: Flask, bypass_pipeline, monkeypatc
         "TenantService",
         _tenant_service(remove_member_from_tenant=Mock(side_effect=exc)),
     )
-    monkeypatch.setattr(sys.modules["controllers.openapi.workspaces"], "db", mock_db)
 
     with app.test_request_context(
         f"/openapi/v1/workspaces/{ws_id}/members/{member_id}",
@@ -740,8 +734,10 @@ def test_delete_member_exception_mapping(app: Flask, bypass_pipeline, monkeypatc
     ):
         _seed(_auth_ctx(account_id=acct_id))
         with pytest.raises(expected):
-            api.delete.__wrapped__(
+            _call_with_session(
+                api.delete,
                 api,
+                session,
                 workspace_id=ws_id,
                 member_id=member_id,
                 auth_data=_auth_data(acct_id),
@@ -753,13 +749,12 @@ def test_delete_member_404_when_member_missing(app: Flask, bypass_pipeline, monk
     acct_id = uuid.uuid4()
     api = WorkspaceMemberApi()
 
-    mock_db = MagicMock()
-    mock_db.session.get.side_effect = [
+    session = MagicMock()
+    session.get.side_effect = [
         _account(account_id=str(acct_id)),
         _tenant(ws_id),
         None,  # member not found
     ]
-    monkeypatch.setattr(sys.modules["controllers.openapi.workspaces"], "db", mock_db)
 
     with app.test_request_context(
         f"/openapi/v1/workspaces/{ws_id}/members/{member_id}",
@@ -767,8 +762,10 @@ def test_delete_member_404_when_member_missing(app: Flask, bypass_pipeline, monk
     ):
         _seed(_auth_ctx(account_id=acct_id))
         with pytest.raises(NotFound):
-            api.delete.__wrapped__(
+            _call_with_session(
+                api.delete,
                 api,
+                session,
                 workspace_id=ws_id,
                 member_id=member_id,
                 auth_data=_auth_data(acct_id),
@@ -785,8 +782,8 @@ def test_update_role_happy_path(app: Flask, bypass_pipeline, monkeypatch: pytest
     acct_id = uuid.uuid4()
     api = WorkspaceMemberRoleApi()
 
-    mock_db = MagicMock()
-    mock_db.session.get.side_effect = [
+    session = MagicMock()
+    session.get.side_effect = [
         _account(account_id=str(acct_id)),
         _tenant(ws_id),
         _account(account_id=member_id),
@@ -798,7 +795,6 @@ def test_update_role_happy_path(app: Flask, bypass_pipeline, monkeypatch: pytest
         "TenantService",
         _tenant_service(update_member_role=update_mock),
     )
-    monkeypatch.setattr(sys.modules["controllers.openapi.workspaces"], "db", mock_db)
 
     with app.test_request_context(
         f"/openapi/v1/workspaces/{ws_id}/members/{member_id}/role",
@@ -807,12 +803,15 @@ def test_update_role_happy_path(app: Flask, bypass_pipeline, monkeypatch: pytest
         content_type="application/json",
     ):
         _seed(_auth_ctx(account_id=acct_id))
-        body, status = api.put.__wrapped__(api, workspace_id=ws_id, member_id=member_id, auth_data=_auth_data(acct_id))
+        body, status = _call_with_session(
+            api.put, api, session, workspace_id=ws_id, member_id=member_id, auth_data=_auth_data(acct_id)
+        )
 
     assert status == 200
     assert body == {"result": "success"}
     args = update_mock.call_args.args
     assert args[2] == "admin"
+    assert update_mock.call_args.kwargs["session"] is session
 
 
 @pytest.mark.parametrize(
@@ -829,8 +828,8 @@ def test_update_role_exception_mapping(app: Flask, bypass_pipeline, monkeypatch,
     acct_id = uuid.uuid4()
     api = WorkspaceMemberRoleApi()
 
-    mock_db = MagicMock()
-    mock_db.session.get.side_effect = [
+    session = MagicMock()
+    session.get.side_effect = [
         _account(account_id=str(acct_id)),
         _tenant(ws_id),
         _account(account_id=member_id),
@@ -841,7 +840,6 @@ def test_update_role_exception_mapping(app: Flask, bypass_pipeline, monkeypatch,
         "TenantService",
         _tenant_service(update_member_role=Mock(side_effect=exc)),
     )
-    monkeypatch.setattr(sys.modules["controllers.openapi.workspaces"], "db", mock_db)
 
     with app.test_request_context(
         f"/openapi/v1/workspaces/{ws_id}/members/{member_id}/role",
@@ -851,8 +849,10 @@ def test_update_role_exception_mapping(app: Flask, bypass_pipeline, monkeypatch,
     ):
         _seed(_auth_ctx(account_id=acct_id))
         with pytest.raises(expected):
-            api.put.__wrapped__(
+            _call_with_session(
+                api.put,
                 api,
+                session,
                 workspace_id=ws_id,
                 member_id=member_id,
                 auth_data=_auth_data(acct_id),
@@ -871,20 +871,19 @@ def test_load_tenant_rejects_archived_workspace(app: Flask, bypass_pipeline, mon
     api = WorkspaceMembersApi()
 
     archived = SimpleNamespace(id=ws_id, name="WS", status="archive", created_at=datetime(2026, 5, 18, tzinfo=UTC))
-    mock_db = MagicMock()
-    mock_db.session.get.return_value = archived
+    session = MagicMock()
+    session.get.return_value = archived
 
     monkeypatch.setattr(
         sys.modules["controllers.openapi.workspaces"],
         "TenantService",
         _tenant_service(),
     )
-    monkeypatch.setattr(sys.modules["controllers.openapi.workspaces"], "db", mock_db)
 
     with app.test_request_context(f"/openapi/v1/workspaces/{ws_id}/members"):
         _seed(_auth_ctx(account_id=acct_id))
         with pytest.raises(NotFound):
-            api.get.__wrapped__(api, workspace_id=ws_id, auth_data=_auth_data(acct_id))
+            _call_with_session(api.get, api, session, workspace_id=ws_id, auth_data=_auth_data(acct_id))
 
 
 # ---------------------------------------------------------------------------
@@ -898,8 +897,8 @@ def test_invite_400_when_register_error(app: Flask, bypass_pipeline, monkeypatch
     acct_id = uuid.uuid4()
     api = WorkspaceMembersApi()
 
-    mock_db = MagicMock()
-    mock_db.session.get.side_effect = [_account(account_id=str(acct_id)), _tenant(ws_id)]
+    session = MagicMock()
+    session.get.side_effect = [_account(account_id=str(acct_id)), _tenant(ws_id)]
 
     monkeypatch.setattr(
         sys.modules["controllers.openapi.workspaces"],
@@ -908,7 +907,6 @@ def test_invite_400_when_register_error(app: Flask, bypass_pipeline, monkeypatch
             invite_new_member=Mock(side_effect=AccountRegisterError("Workspace is not allowed to create.")),
         ),
     )
-    monkeypatch.setattr(sys.modules["controllers.openapi.workspaces"], "db", mock_db)
 
     with app.test_request_context(
         f"/openapi/v1/workspaces/{ws_id}/members",
@@ -918,4 +916,4 @@ def test_invite_400_when_register_error(app: Flask, bypass_pipeline, monkeypatch
     ):
         _seed(_auth_ctx(account_id=acct_id))
         with pytest.raises(BadRequest):
-            api.post.__wrapped__(api, workspace_id=ws_id, auth_data=_auth_data(acct_id))
+            _call_with_session(api.post, api, session, workspace_id=ws_id, auth_data=_auth_data(acct_id))

--- a/api/tests/unit_tests/controllers/openapi/test_workspaces_members.py
+++ b/api/tests/unit_tests/controllers/openapi/test_workspaces_members.py
@@ -169,6 +169,19 @@ def _account_service(**overrides) -> SimpleNamespace:
     return SimpleNamespace(**methods)
 
 
+def _patch_write_session(monkeypatch, session: MagicMock) -> MagicMock:
+    """Keep the auth decorator bypassed while preserving `with_session`."""
+    from controllers.console.app import wraps as wraps_module
+
+    session_context = MagicMock()
+    session_context.__enter__.return_value = session
+    session_context.__exit__.return_value = None
+    session_maker = MagicMock()
+    session_maker.begin.return_value = session_context
+    monkeypatch.setattr(wraps_module.session_factory, "get_session_maker", lambda: session_maker)
+    return session_maker
+
+
 # ---------------------------------------------------------------------------
 # Route registration
 # ---------------------------------------------------------------------------
@@ -272,16 +285,19 @@ def test_switch_returns_workspace_detail_with_current_true(
     app: Flask, bypass_pipeline, monkeypatch: pytest.MonkeyPatch
 ):
     """Happy path: switch service is called, then the workspace+membership
-    row is re-queried so the returned `current` reflects post-commit state.
+    row is re-queried with the injected request session so the returned
+    `current` reflects the switch within the same transaction.
     """
     ws_id = str(uuid.uuid4())
     acct_id = uuid.uuid4()
     api = WorkspaceSwitchApi()
 
-    mock_db = MagicMock()
-    mock_db.session.get.return_value = _account(account_id=str(acct_id))
+    session = MagicMock()
+    session_maker = _patch_write_session(monkeypatch, session)
+    account = _account(account_id=str(acct_id))
+    session.get.return_value = account
     membership = SimpleNamespace(role=TenantAccountRole.OWNER, current=True)
-    mock_db.session.execute.return_value.first.return_value = (_tenant(ws_id), membership)
+    session.execute.return_value.first.return_value = (_tenant(ws_id), membership)
 
     switch_mock = Mock()
     monkeypatch.setattr(
@@ -289,7 +305,6 @@ def test_switch_returns_workspace_detail_with_current_true(
         "TenantService",
         _tenant_service(switch_tenant=switch_mock),
     )
-    monkeypatch.setattr(sys.modules["controllers.openapi.workspaces"], "db", mock_db)
 
     with app.test_request_context(f"/openapi/v1/workspaces/{ws_id}/switch", method="POST"):
         _seed(_auth_ctx(account_id=acct_id))
@@ -298,7 +313,8 @@ def test_switch_returns_workspace_detail_with_current_true(
     assert status == 200
     assert body["id"] == ws_id
     assert body["current"] is True
-    assert switch_mock.called
+    session_maker.begin.assert_called_once()
+    switch_mock.assert_called_once_with(account, ws_id, session=session)
 
 
 def test_switch_404s_when_service_raises_account_not_link_tenant(
@@ -310,15 +326,15 @@ def test_switch_404s_when_service_raises_account_not_link_tenant(
     acct_id = uuid.uuid4()
     api = WorkspaceSwitchApi()
 
-    mock_db = MagicMock()
-    mock_db.session.get.return_value = _account(account_id=str(acct_id))
+    session = MagicMock()
+    _patch_write_session(monkeypatch, session)
+    session.get.return_value = _account(account_id=str(acct_id))
 
     monkeypatch.setattr(
         sys.modules["controllers.openapi.workspaces"],
         "TenantService",
         _tenant_service(switch_tenant=Mock(side_effect=AccountNotLinkTenantError("…"))),
     )
-    monkeypatch.setattr(sys.modules["controllers.openapi.workspaces"], "db", mock_db)
 
     with app.test_request_context(f"/openapi/v1/workspaces/{ws_id}/switch", method="POST"):
         _seed(_auth_ctx(account_id=acct_id))

--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -810,6 +810,21 @@ class TestTenantService:
 
         self._assert_database_operations_called(mock_db_dependencies["db"])
 
+    def test_create_tenant_member_uses_injected_session_without_commit(self):
+        """Injected request sessions should leave member creation commits to the caller."""
+        mock_tenant = MagicMock()
+        mock_tenant.id = "tenant-456"
+        mock_account = TestAccountAssociatedDataFactory.create_account_mock()
+        mock_session = MagicMock()
+        mock_session.scalar.return_value = None
+
+        result = TenantService.create_tenant_member(mock_tenant, mock_account, "normal", session=mock_session)
+
+        assert result is not None
+        mock_session.add.assert_called_once()
+        mock_session.flush.assert_called_once()
+        mock_session.commit.assert_not_called()
+
     # ==================== Member Removal Tests ====================
 
     def test_remove_pending_member_deletes_orphaned_account(self):
@@ -913,6 +928,30 @@ class TestTenantService:
 
             # Assert: only the join record should be deleted
             mock_db.session.delete.assert_called_once_with(mock_ta)
+
+    def test_remove_member_uses_injected_session_without_commit(self):
+        """Injected request sessions should leave member-removal commits to the caller."""
+        mock_tenant = MagicMock()
+        mock_tenant.id = "tenant-456"
+        mock_operator = TestAccountAssociatedDataFactory.create_account_mock(account_id="operator-123", role="owner")
+        mock_member = TestAccountAssociatedDataFactory.create_account_mock(account_id="member-789")
+        mock_operator_join = TestAccountAssociatedDataFactory.create_tenant_join_mock(
+            tenant_id="tenant-456", account_id="operator-123", role="owner"
+        )
+        mock_ta = TestAccountAssociatedDataFactory.create_tenant_join_mock(
+            tenant_id="tenant-456", account_id="member-789", role="normal"
+        )
+        mock_session = MagicMock()
+        mock_session.scalar.side_effect = [mock_operator_join, mock_ta]
+
+        with patch("services.enterprise.account_deletion_sync.sync_workspace_member_removal") as mock_sync:
+            mock_sync.return_value = True
+
+            TenantService.remove_member_from_tenant(mock_tenant, mock_member, mock_operator, session=mock_session)
+
+        mock_session.delete.assert_called_once_with(mock_ta)
+        mock_session.flush.assert_called_once()
+        mock_session.commit.assert_not_called()
 
     # ==================== Tenant Switching Tests ====================
 
@@ -1089,6 +1128,27 @@ class TestTenantService:
 
             with pytest.raises(NoPermissionError):
                 TenantService.update_member_role(mock_tenant, mock_member, "owner", mock_operator)
+
+    def test_update_member_role_uses_injected_session_without_commit(self):
+        """Injected request sessions should leave role-update commits to the caller."""
+        mock_tenant = MagicMock()
+        mock_tenant.id = "tenant-456"
+        mock_member = TestAccountAssociatedDataFactory.create_account_mock(account_id="member-789")
+        mock_operator = TestAccountAssociatedDataFactory.create_account_mock(account_id="operator-123")
+        mock_target_join = TestAccountAssociatedDataFactory.create_tenant_join_mock(
+            tenant_id="tenant-456", account_id="member-789", role="normal"
+        )
+        mock_operator_join = TestAccountAssociatedDataFactory.create_tenant_join_mock(
+            tenant_id="tenant-456", account_id="operator-123", role="owner"
+        )
+        mock_session = MagicMock()
+        mock_session.scalar.side_effect = [mock_operator_join, mock_target_join, mock_operator_join]
+
+        TenantService.update_member_role(mock_tenant, mock_member, "admin", mock_operator, session=mock_session)
+
+        assert mock_target_join.role == TenantAccountRole.ADMIN
+        mock_session.flush.assert_called_once()
+        mock_session.commit.assert_not_called()
 
     # ==================== Permission Check Tests ====================
 

--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -941,6 +941,23 @@ class TestTenantService:
             assert mock_tenant_join.last_opened_at == mock_now
             self._assert_database_operations_called(mock_db)
 
+    def test_switch_tenant_uses_injected_session_without_commit(self):
+        """Injected request sessions should leave commit ownership to the caller."""
+        mock_account = TestAccountAssociatedDataFactory.create_account_mock()
+        mock_tenant_join = TestAccountAssociatedDataFactory.create_tenant_join_mock(
+            tenant_id="tenant-456", account_id="user-123", current=False
+        )
+        mock_session = MagicMock()
+        mock_session.scalar.return_value = mock_tenant_join
+
+        TenantService.switch_tenant(mock_account, "tenant-456", session=mock_session)
+
+        assert mock_tenant_join.current is True
+        mock_session.scalar.assert_called_once()
+        mock_session.execute.assert_called_once()
+        mock_session.commit.assert_not_called()
+        mock_account.set_tenant_id.assert_called_once_with("tenant-456")
+
     def test_switch_tenant_no_tenant_id(self):
         """Test tenant switching without providing tenant ID."""
         # Setup test data

--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -810,20 +810,20 @@ class TestTenantService:
 
         self._assert_database_operations_called(mock_db_dependencies["db"])
 
-    def test_create_tenant_member_uses_injected_session_without_commit(self):
-        """Injected request sessions should leave member creation commits to the caller."""
+    def test_create_tenant_member_uses_injected_session_and_preserves_commit(self):
+        """Injected sessions still preserve the service-owned commit boundary."""
         mock_tenant = MagicMock()
         mock_tenant.id = "tenant-456"
         mock_account = TestAccountAssociatedDataFactory.create_account_mock()
         mock_session = MagicMock()
         mock_session.scalar.return_value = None
 
-        result = TenantService.create_tenant_member(mock_tenant, mock_account, "normal", session=mock_session)
+        result = TenantService.create_tenant_member(mock_tenant, mock_account, mock_session, role="normal")
 
         assert result is not None
         mock_session.add.assert_called_once()
-        mock_session.flush.assert_called_once()
-        mock_session.commit.assert_not_called()
+        mock_session.commit.assert_called_once()
+        mock_session.flush.assert_not_called()
 
     # ==================== Member Removal Tests ====================
 
@@ -929,8 +929,8 @@ class TestTenantService:
             # Assert: only the join record should be deleted
             mock_db.session.delete.assert_called_once_with(mock_ta)
 
-    def test_remove_member_uses_injected_session_without_commit(self):
-        """Injected request sessions should leave member-removal commits to the caller."""
+    def test_remove_member_uses_injected_session_and_preserves_commit(self):
+        """Injected sessions still commit before member-removal side effects."""
         mock_tenant = MagicMock()
         mock_tenant.id = "tenant-456"
         mock_operator = TestAccountAssociatedDataFactory.create_account_mock(account_id="operator-123", role="owner")
@@ -942,16 +942,21 @@ class TestTenantService:
             tenant_id="tenant-456", account_id="member-789", role="normal"
         )
         mock_session = MagicMock()
-        mock_session.scalar.side_effect = [mock_operator_join, mock_ta]
+        mock_session.scalar.side_effect = [mock_operator_join, mock_ta, "owner-123"]
+
+        events: list[str] = []
+        mock_session.commit.side_effect = lambda: events.append("commit")
 
         with patch("services.enterprise.account_deletion_sync.sync_workspace_member_removal") as mock_sync:
             mock_sync.return_value = True
+            mock_sync.side_effect = lambda **_: events.append("sync") or True
 
             TenantService.remove_member_from_tenant(mock_tenant, mock_member, mock_operator, session=mock_session)
 
         mock_session.delete.assert_called_once_with(mock_ta)
-        mock_session.flush.assert_called_once()
-        mock_session.commit.assert_not_called()
+        mock_session.commit.assert_called_once()
+        mock_session.flush.assert_not_called()
+        assert events == ["commit", "sync"]
 
     # ==================== Tenant Switching Tests ====================
 
@@ -980,8 +985,8 @@ class TestTenantService:
             assert mock_tenant_join.last_opened_at == mock_now
             self._assert_database_operations_called(mock_db)
 
-    def test_switch_tenant_uses_injected_session_without_commit(self):
-        """Injected request sessions should leave commit ownership to the caller."""
+    def test_switch_tenant_uses_injected_session_and_preserves_commit(self):
+        """Injected sessions still preserve the service-owned switch commit."""
         mock_account = TestAccountAssociatedDataFactory.create_account_mock()
         mock_tenant_join = TestAccountAssociatedDataFactory.create_tenant_join_mock(
             tenant_id="tenant-456", account_id="user-123", current=False
@@ -994,7 +999,7 @@ class TestTenantService:
         assert mock_tenant_join.current is True
         mock_session.scalar.assert_called_once()
         mock_session.execute.assert_called_once()
-        mock_session.commit.assert_not_called()
+        mock_session.commit.assert_called_once()
         mock_account.set_tenant_id.assert_called_once_with("tenant-456")
 
     def test_switch_tenant_no_tenant_id(self):
@@ -1129,8 +1134,8 @@ class TestTenantService:
             with pytest.raises(NoPermissionError):
                 TenantService.update_member_role(mock_tenant, mock_member, "owner", mock_operator)
 
-    def test_update_member_role_uses_injected_session_without_commit(self):
-        """Injected request sessions should leave role-update commits to the caller."""
+    def test_update_member_role_uses_injected_session_and_preserves_commit(self):
+        """Injected sessions still preserve the service-owned role-update commit."""
         mock_tenant = MagicMock()
         mock_tenant.id = "tenant-456"
         mock_member = TestAccountAssociatedDataFactory.create_account_mock(account_id="member-789")
@@ -1147,8 +1152,8 @@ class TestTenantService:
         TenantService.update_member_role(mock_tenant, mock_member, "admin", mock_operator, session=mock_session)
 
         assert mock_target_join.role == TenantAccountRole.ADMIN
-        mock_session.flush.assert_called_once()
-        mock_session.commit.assert_not_called()
+        mock_session.commit.assert_called_once()
+        mock_session.flush.assert_not_called()
 
     # ==================== Permission Check Tests ====================
 
@@ -1898,7 +1903,7 @@ class TestRegisterService:
                         status=AccountStatus.PENDING,
                         is_setup=True,
                     )
-                    mock_lookup.assert_called_once_with("newuser@example.com")
+                    mock_lookup.assert_called_once_with("newuser@example.com", session=None)
 
     def test_invite_new_member_normalizes_new_account_email(
         self, mock_db_dependencies, mock_redis_dependencies, mock_task_dependencies
@@ -1942,12 +1947,12 @@ class TestRegisterService:
                         status=AccountStatus.PENDING,
                         is_setup=True,
                     )
-                    mock_lookup.assert_called_once_with(mixed_email)
-                    mock_check_permission.assert_called_once_with(mock_tenant, mock_inviter, None, "add")
+                    mock_lookup.assert_called_once_with(mixed_email, session=None)
+                    mock_check_permission.assert_called_once_with(mock_tenant, mock_inviter, None, "add", session=None)
                     mock_create_member.assert_called_once_with(
-                        mock_tenant, mock_new_account, mock_db_dependencies["db"].session, "normal"
+                        mock_tenant, mock_new_account, session=None, role="normal"
                     )
-                    mock_switch_tenant.assert_called_once_with(mock_new_account, mock_tenant.id)
+                    mock_switch_tenant.assert_called_once_with(mock_new_account, mock_tenant.id, session=None)
                     mock_generate_token.assert_called_once_with(
                         mock_tenant, mock_new_account, "normal", requires_setup=True
                     )
@@ -1994,13 +1999,13 @@ class TestRegisterService:
                 # Verify results
                 assert result == "invite-token-123"
                 mock_create_member.assert_called_once_with(
-                    mock_tenant, mock_existing_account, mock_db_dependencies["db"].session, "normal"
+                    mock_tenant, mock_existing_account, session=None, role="normal"
                 )
                 mock_generate_token.assert_called_once_with(
                     mock_tenant, mock_existing_account, "normal", requires_setup=True
                 )
                 mock_task_dependencies.delay.assert_called_once()
-                mock_lookup.assert_called_once_with("existing@example.com")
+                mock_lookup.assert_called_once_with("existing@example.com", session=None)
 
     def test_invite_existing_active_account_requires_acceptance_before_joining(
         self, mock_db_dependencies, mock_redis_dependencies, mock_task_dependencies
@@ -2034,7 +2039,9 @@ class TestRegisterService:
                 )
 
                 assert result == "invite-token-123"
-                mock_check_permission.assert_called_once_with(mock_tenant, mock_inviter, mock_existing_account, "add")
+                mock_check_permission.assert_called_once_with(
+                    mock_tenant, mock_inviter, mock_existing_account, "add", session=None
+                )
                 mock_create_member.assert_not_called()
                 mock_generate_token.assert_called_once_with(
                     mock_tenant, mock_existing_account, "admin", requires_setup=False
@@ -2129,7 +2136,7 @@ class TestRegisterService:
 
                 assert result == "rbac-token"
                 mock_create_member.assert_called_once_with(
-                    mock_tenant, mock_new_account, mock_db_dependencies["db"].session, TenantAccountRole.NORMAL.value
+                    mock_tenant, mock_new_account, session=None, role=TenantAccountRole.NORMAL.value
                 )
                 mock_rbac_service.MemberRoles.replace.assert_called_once_with(
                     tenant_id=str(mock_tenant.id),
@@ -2176,8 +2183,8 @@ class TestRegisterService:
                 mock_create_member.assert_called_once_with(
                     mock_tenant,
                     mock_existing_account,
-                    mock_db_dependencies["db"].session,
-                    TenantAccountRole.NORMAL.value,
+                    session=None,
+                    role=TenantAccountRole.NORMAL.value,
                 )
                 mock_rbac_service.MemberRoles.replace.assert_called_once_with(
                     tenant_id=str(mock_tenant.id),
@@ -2223,8 +2230,8 @@ class TestRegisterService:
                 mock_create_member.assert_called_once_with(
                     mock_tenant,
                     mock_existing_account,
-                    mock_db_dependencies["db"].session,
-                    TenantAccountRole.NORMAL.value,
+                    session=None,
+                    role=TenantAccountRole.NORMAL.value,
                 )
                 mock_rbac_service.MemberRoles.replace.assert_called_once_with(
                     tenant_id=str(mock_tenant.id),
@@ -2271,9 +2278,7 @@ class TestRegisterService:
                 )
 
                 assert result == "legacy-token"
-                mock_create_member.assert_called_once_with(
-                    mock_tenant, mock_new_account, mock_db_dependencies["db"].session, "editor"
-                )
+                mock_create_member.assert_called_once_with(mock_tenant, mock_new_account, session=None, role="editor")
                 mock_rbac_service.MemberRoles.replace.assert_not_called()
 
     # ==================== Token Management Tests ====================


### PR DESCRIPTION
## Summary

Refs #36544

- migrate workspace switch, custom config, and workspace info update handlers to explicit SQLAlchemy sessions
- let `TenantService.switch_tenant` reuse an optional injected session while preserving the scoped-session fallback for existing callers
- update focused unit coverage for the migrated workspace controller paths and injected service-session behavior

This is a partial migration under #36544. It intentionally does not touch workspace member-management, service API, inner API, agent roster, explore/auth, or console app batches.

## Screenshots

N/A, backend-only refactor.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

## Validation

- `uv run --project api --dev pytest api/tests/unit_tests/controllers/console/workspace/test_workspace.py api/tests/unit_tests/services/test_account_service.py`
  - `120 passed, 3 warnings`
- `uv run --project api --dev ruff check api/controllers/console/workspace/workspace.py api/services/account_service.py api/tests/unit_tests/controllers/console/workspace/test_workspace.py api/tests/unit_tests/services/test_account_service.py`
  - `All checks passed!`
- `uv run --project api --dev ruff format --check api/controllers/console/workspace/workspace.py api/services/account_service.py api/tests/unit_tests/controllers/console/workspace/test_workspace.py api/tests/unit_tests/services/test_account_service.py`
  - `4 files already formatted`
- `uv lock --project api --check`
- `git diff --check`