### PR TITLE
feat(api): expose workflow_id in Service API /info endpoint

### DIFF
--- a/api/controllers/service_api/app/app.py
+++ b/api/controllers/service_api/app/app.py
@@ -19,6 +19,7 @@ class AppInfoResponse(ResponseModel):
     tags: list[str]
     mode: str
     author_name: str | None
+    workflow_id: str | None
 
 
 register_response_schema_models(service_api_ns, AppInfoResponse)
@@ -112,4 +113,5 @@ class AppInfoApi(Resource):
             "tags": tags,
             "mode": app_model.mode,
             "author_name": app_model.author_name,
+            "workflow_id": app_model.workflow_id,
         }

--- a/api/controllers/service_api/app/app.py
+++ b/api/controllers/service_api/app/app.py
@@ -113,5 +113,5 @@ class AppInfoApi(Resource):
             "tags": tags,
             "mode": app_model.mode,
             "author_name": app_model.author_name,
-            "workflow_id": app_model.workflow_id,
+            "workflow_id": app_model.workflow_id if app_model.mode in [AppMode.WORKFLOW.value, AppMode.ADVANCED_CHAT.value] else None,
         }

--- a/api/openapi/markdown/service-swagger.md
+++ b/api/openapi/markdown/service-swagger.md
@@ -2221,6 +2221,7 @@ Returns a list of available models for the specified model type.
 | mode | string |  | Yes |
 | name | string |  | Yes |
 | tags | [ string ] |  | Yes |
+| workflow_id | string | Nullable. Published workflow ID for workflow/advanced-chat apps; null otherwise. | Yes |
 
 #### ChatRequestPayload
 

--- a/packages/contracts/generated/api/service/types.gen.ts
+++ b/packages/contracts/generated/api/service/types.gen.ts
@@ -43,6 +43,7 @@ export type AppInfoResponse = {
   mode: string
   name: string
   tags: Array<string>
+  workflow_id: string | null
 }
 
 export type ChatRequestPayload = {

--- a/packages/contracts/generated/api/service/zod.gen.ts
+++ b/packages/contracts/generated/api/service/zod.gen.ts
@@ -59,6 +59,7 @@ export const zAppInfoResponse = z.object({
   mode: z.string(),
   name: z.string(),
   tags: z.array(z.string()),
+  workflow_id: z.string().nullable(),
 })
 
 /**


### PR DESCRIPTION
Add the currently published workflow_id to the /v1/info response so API consumers can programmatically discover which workflow version is active without executing the workflow first.

- Add workflow_id (str | None) to AppInfoResponse model
- Return app_model.workflow_id in AppInfoApi.get() response

The field is null for non-workflow app modes (chat, completion, agent-chat) and populated for workflow/advanced-chat apps that have a published workflow. This is a backward-compatible additive change with no migration or model changes required — the App model already stores workflow_id as a nullable UUID column.

Closes #35444

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

<img width="715" height="347" alt="image" src="https://github.com/user-attachments/assets/84a5c54b-a8bd-45f7-8af7-0267a6597484" />
## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
