### PR TITLE
Feature/dynamic credential overrides

### DIFF
--- a/api/controllers/common/controller_schemas.py
+++ b/api/controllers/common/controller_schemas.py
@@ -63,6 +63,10 @@ class WorkflowListQuery(BaseModel):
 class WorkflowRunPayload(BaseModel):
     inputs: dict[str, Any]
     files: list[dict[str, Any]] | None = None
+    credential_overrides: dict[str, str] | None = Field(
+        default=None,
+        description="Optional mapping of provider name to credential ID for overriding default credentials per provider.",
+    )
 
 
 class WorkflowUpdatePayload(BaseModel):

--- a/api/controllers/console/app/completion.py
+++ b/api/controllers/console/app/completion.py
@@ -68,6 +68,7 @@ class BaseMessagePayload(BaseModel):
     files: list[Any] | None = Field(default=None, description="Uploaded files")
     response_mode: Literal["blocking", "streaming"] = Field(default="blocking", description="Response mode")
     retriever_from: str = Field(default="dev", description="Retriever source")
+    credential_overrides: dict[str, str] | None = Field(default=None, description="Dynamic credential overrides")
 
 
 class CompletionMessagePayload(BaseMessagePayload):

--- a/api/controllers/console/explore/completion.py
+++ b/api/controllers/console/explore/completion.py
@@ -48,6 +48,7 @@ class CompletionMessageExplorePayload(BaseModel):
     files: list[dict[str, Any]] | None = None
     response_mode: Literal["blocking", "streaming"] | None = None
     retriever_from: str = Field(default="explore_app")
+    credential_overrides: dict[str, str] | None = Field(default=None, description="Dynamic credential overrides")
 
 
 class ChatMessagePayload(BaseModel):
@@ -57,6 +58,7 @@ class ChatMessagePayload(BaseModel):
     conversation_id: str | None = None
     parent_message_id: str | None = None
     retriever_from: str = Field(default="explore_app")
+    credential_overrides: dict[str, str] | None = Field(default=None, description="Dynamic credential overrides")
 
     @field_validator("conversation_id", "parent_message_id", mode="before")
     @classmethod

--- a/api/controllers/openapi/_models.py
+++ b/api/controllers/openapi/_models.py
@@ -297,6 +297,7 @@ class AppRunRequest(BaseModel):
     auto_generate_name: bool = True
     workflow_id: str | None = None
     workspace_id: UUIDStrOrEmpty | None = None
+    credential_overrides: dict[str, str] | None = Field(default=None, description="Dynamic credential overrides")
 
     @field_validator("conversation_id", mode="before")
     @classmethod

--- a/api/controllers/service_api/app/completion.py
+++ b/api/controllers/service_api/app/completion.py
@@ -57,6 +57,7 @@ class CompletionRequestPayload(BaseModel):
     response_mode: Literal["blocking", "streaming"] | None = None
     retriever_from: str = Field(default="dev")
     trace_session_id: str | None = Field(default=None, description="Trace session ID for observability grouping")
+    credential_overrides: dict[str, str] | None = Field(default=None, description="Dynamic credential overrides")
 
 
 class ChatRequestPayload(BaseModel):
@@ -69,6 +70,7 @@ class ChatRequestPayload(BaseModel):
     auto_generate_name: bool = Field(default=True, description="Auto generate conversation name")
     workflow_id: str | None = Field(default=None, description="Workflow ID for advanced chat")
     trace_session_id: str | None = Field(default=None, description="Trace session ID for observability grouping")
+    credential_overrides: dict[str, str] | None = Field(default=None, description="Dynamic credential overrides")
 
     @field_validator("conversation_id", mode="before")
     @classmethod

--- a/api/controllers/web/completion.py
+++ b/api/controllers/web/completion.py
@@ -54,6 +54,7 @@ class CompletionMessagePayload(BaseModel):
         default=None, description="Response mode: blocking or streaming"
     )
     retriever_from: str = Field(default="web_app", description="Source of retriever")
+    credential_overrides: dict[str, str] | None = Field(default=None, description="Dynamic credential overrides")
 
 
 class ChatMessagePayload(BaseModel):
@@ -66,6 +67,7 @@ class ChatMessagePayload(BaseModel):
     conversation_id: str | None = Field(default=None, description="Conversation ID")
     parent_message_id: str | None = Field(default=None, description="Parent message ID")
     retriever_from: str = Field(default="web_app", description="Source of retriever")
+    credential_overrides: dict[str, str] | None = Field(default=None, description="Dynamic credential overrides")
 
     @field_validator("conversation_id", "parent_message_id")
     @classmethod

--- a/api/core/app/apps/workflow/app_generator.py
+++ b/api/core/app/apps/workflow/app_generator.py
@@ -222,6 +222,7 @@ class WorkflowAppGenerator(BaseAppGenerator):
                 trace_manager=trace_manager,
                 workflow_execution_id=workflow_run_id,
                 extras=extras,
+                credential_overrides=args.get("credential_overrides"),
             )
 
             contexts.plugin_tool_providers.set({})

--- a/api/core/app/apps/workflow/app_runner.py
+++ b/api/core/app/apps/workflow/app_runner.py
@@ -89,6 +89,7 @@ class WorkflowAppRunner(WorkflowBasedAppRunner):
                 invoke_from=invoke_from,
                 root_node_id=self._root_node_id,
                 trace_session_id=self.application_generate_entity.extras.get("trace_session_id"),
+                credential_overrides=self.application_generate_entity.credential_overrides,
             )
         elif self.application_generate_entity.single_iteration_run or self.application_generate_entity.single_loop_run:
             graph, variable_pool, graph_runtime_state = self._prepare_single_node_execution(
@@ -140,6 +141,7 @@ class WorkflowAppRunner(WorkflowBasedAppRunner):
                 invoke_from=invoke_from,
                 root_node_id=root_node_id,
                 trace_session_id=self.application_generate_entity.extras.get("trace_session_id"),
+                credential_overrides=self.application_generate_entity.credential_overrides,
             )
 
         # RUN WORKFLOW

--- a/api/core/app/apps/workflow_app_runner.py
+++ b/api/core/app/apps/workflow_app_runner.py
@@ -119,6 +119,7 @@ class WorkflowBasedAppRunner:
         user_id: str = "",
         root_node_id: str | None = None,
         trace_session_id: str | None = None,
+        credential_overrides: dict[str, str] | None = None,
     ) -> Graph:
         """
         Init graph
@@ -140,6 +141,7 @@ class WorkflowBasedAppRunner:
             user_from=user_from,
             invoke_from=invoke_from,
             trace_session_id=trace_session_id,
+            credential_overrides=credential_overrides,
         )
         graph_init_context = DifyGraphInitContext(
             workflow_id=workflow_id,

--- a/api/core/app/entities/app_invoke_entities.py
+++ b/api/core/app/entities/app_invoke_entities.py
@@ -55,6 +55,7 @@ class DifyRunContext(BaseModel):
     user_from: UserFrom
     invoke_from: InvokeFrom
     trace_session_id: str | None = None
+    credential_overrides: dict[str, str] | None = None
 
 
 def build_dify_run_context(
@@ -65,6 +66,7 @@ def build_dify_run_context(
     user_from: UserFrom,
     invoke_from: InvokeFrom,
     trace_session_id: str | None = None,
+    credential_overrides: dict[str, str] | None = None,
     extra_context: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """
@@ -81,6 +83,7 @@ def build_dify_run_context(
         user_from=user_from,
         invoke_from=invoke_from,
         trace_session_id=trace_session_id,
+        credential_overrides=credential_overrides,
     )
     return run_context
 
@@ -258,6 +261,7 @@ class WorkflowAppGenerateEntity(AppGenerateEntity):
     # app config
     app_config: WorkflowUIBasedAppConfig = None  # type: ignore
     workflow_execution_id: str
+    credential_overrides: dict[str, str] | None = None
 
     class SingleIterationRunEntity(BaseModel):
         """

--- a/api/core/app/llm/model_access.py
+++ b/api/core/app/llm/model_access.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import json
+import logging
 from copy import deepcopy
 from typing import Any
 
+from sqlalchemy import select
+
 from core.app.entities.app_invoke_entities import DifyRunContext, ModelConfigWithCredentialsEntity
+from core.db.session_factory import session_factory
 from core.errors.error import ProviderTokenNotInitError
+from core.helper import encrypter
 from core.model_manager import ModelInstance, ModelManager
 from core.plugin.impl.model_runtime_factory import create_plugin_provider_manager
 from core.provider_manager import ProviderManager
@@ -12,6 +18,9 @@ from graphon.model_runtime.entities.model_entities import ModelType
 from graphon.nodes.llm.entities import ModelConfig
 from graphon.nodes.llm.exc import LLMModeRequiredError, ModelNotExistError
 from graphon.nodes.llm.protocols import CredentialsProvider
+from models.provider import ProviderCredential
+
+logger = logging.getLogger(__name__)
 
 
 class DifyCredentialsProvider:
@@ -36,8 +45,10 @@ class DifyCredentialsProvider:
         *,
         run_context: DifyRunContext,
         provider_manager: ProviderManager | None = None,
+        credential_overrides: dict[str, str] | None = None,
     ) -> None:
         self.tenant_id = run_context.tenant_id
+        self.credential_overrides = credential_overrides or {}
         if provider_manager is None:
             provider_manager = create_plugin_provider_manager(
                 tenant_id=run_context.tenant_id,
@@ -47,6 +58,21 @@ class DifyCredentialsProvider:
         self.credentials_cache = {}
 
     def fetch(self, provider_name: str, model_name: str) -> dict[str, Any]:
+        # Check for per-run credential override for this provider
+        override_credential_id = self.credential_overrides.get(provider_name)
+        if override_credential_id:
+            cache_key_override = (f"__override__{provider_name}", override_credential_id)
+            if cache_key_override in self.credentials_cache:
+                return deepcopy(self.credentials_cache[cache_key_override])
+
+            credentials = self._fetch_by_credential_id(
+                credential_id=override_credential_id,
+                provider_name=provider_name,
+            )
+            self.credentials_cache[cache_key_override] = deepcopy(credentials)
+            return credentials
+
+        # Default resolution logic
         if (provider_name, model_name) in self.credentials_cache:
             return deepcopy(self.credentials_cache[(provider_name, model_name)])
 
@@ -65,6 +91,52 @@ class DifyCredentialsProvider:
             raise ProviderTokenNotInitError(f"Model {model_name} credentials is not initialized.")
 
         self.credentials_cache[(provider_name, model_name)] = deepcopy(credentials)
+        return credentials
+
+    def _fetch_by_credential_id(
+        self,
+        credential_id: str,
+        provider_name: str,
+    ) -> dict[str, Any]:
+        """Resolve and decrypt credentials from a specific ProviderCredential record.
+
+        Security: The credential must belong to the same tenant as the current run.
+        """
+        with session_factory.create_session() as session:
+            stmt = select(ProviderCredential).where(
+                ProviderCredential.id == credential_id,
+                ProviderCredential.tenant_id == self.tenant_id,
+            )
+            credential_record = session.scalar(stmt)
+
+        if credential_record is None:
+            raise ProviderTokenNotInitError(
+                f"Credential '{credential_id}' not found or does not belong to this workspace."
+            )
+
+        if credential_record.provider_name != provider_name:
+            raise ValueError(
+                f"Credential '{credential_id}' belongs to provider '{credential_record.provider_name}', "
+                f"but was requested for provider '{provider_name}'."
+            )
+
+        # Decrypt the encrypted_config JSON blob
+        try:
+            credentials: dict[str, Any] = json.loads(credential_record.encrypted_config)
+        except (json.JSONDecodeError, TypeError) as e:
+            raise ProviderTokenNotInitError(
+                f"Failed to parse credentials for credential '{credential_id}': {e}"
+            )
+
+        # Decrypt secret fields using tenant RSA key
+        for key, value in credentials.items():
+            if isinstance(value, str) and value:
+                try:
+                    credentials[key] = encrypter.decrypt_token(tenant_id=self.tenant_id, token=value)
+                except Exception:
+                    # Not an encrypted value or not valid base64, keep as-is
+                    pass
+
         return credentials
 
 
@@ -98,7 +170,11 @@ class DifyModelFactory:
         )
 
 
-def build_dify_model_access(run_context: DifyRunContext) -> tuple[CredentialsProvider, DifyModelFactory]:
+def build_dify_model_access(
+    run_context: DifyRunContext,
+    *,
+    credential_overrides: dict[str, str] | None = None,
+) -> tuple[CredentialsProvider, DifyModelFactory]:
     """Create LLM access adapters that share the same tenant-bound manager graph."""
     provider_manager = create_plugin_provider_manager(
         tenant_id=run_context.tenant_id,
@@ -107,7 +183,11 @@ def build_dify_model_access(run_context: DifyRunContext) -> tuple[CredentialsPro
     model_manager = ModelManager(provider_manager=provider_manager, enable_credentials_cache=True)
 
     return (
-        DifyCredentialsProvider(run_context=run_context, provider_manager=provider_manager),
+        DifyCredentialsProvider(
+            run_context=run_context,
+            provider_manager=provider_manager,
+            credential_overrides=credential_overrides,
+        ),
         DifyModelFactory(run_context=run_context, model_manager=model_manager),
     )
 

--- a/api/core/app/llm/model_access.py
+++ b/api/core/app/llm/model_access.py
@@ -58,8 +58,12 @@ class DifyCredentialsProvider:
         self.credentials_cache = {}
 
     def fetch(self, provider_name: str, model_name: str) -> dict[str, Any]:
-        # Check for per-run credential override for this provider
-        override_credential_id = self.credential_overrides.get(provider_name)
+        # Check for per-run credential override for this provider (accept provider aliases)
+        override_credential_id = None
+        for provider_alias in ProviderManager._get_provider_names(provider_name):
+            override_credential_id = self.credential_overrides.get(provider_alias)
+            if override_credential_id:
+                break
         if override_credential_id:
             cache_key_override = (f"__override__{provider_name}", override_credential_id)
             if cache_key_override in self.credentials_cache:
@@ -114,7 +118,7 @@ class DifyCredentialsProvider:
                 f"Credential '{credential_id}' not found or does not belong to this workspace."
             )
 
-        if credential_record.provider_name != provider_name:
+        if credential_record.provider_name not in ProviderManager._get_provider_names(provider_name):
             raise ValueError(
                 f"Credential '{credential_id}' belongs to provider '{credential_record.provider_name}', "
                 f"but was requested for provider '{provider_name}'."

--- a/api/core/workflow/node_factory.py
+++ b/api/core/workflow/node_factory.py
@@ -351,7 +351,10 @@ class DifyNodeFactory(NodeFactory):
             ssrf_default_max_retries=dify_config.SSRF_DEFAULT_MAX_RETRIES,
         )
 
-        self._llm_credentials_provider, self._llm_model_factory = build_dify_model_access(self._dify_context)
+        self._llm_credentials_provider, self._llm_model_factory = build_dify_model_access(
+            self._dify_context,
+            credential_overrides=self._dify_context.credential_overrides,
+        )
         self._agent_strategy_resolver = PluginAgentStrategyResolver()
         self._agent_strategy_presentation_provider = PluginAgentStrategyPresentationProvider()
         self._agent_runtime_support = AgentRuntimeSupport()

--- a/api/tests/unit_tests/core/app/llm/test_credential_overrides.py
+++ b/api/tests/unit_tests/core/app/llm/test_credential_overrides.py
@@ -1,0 +1,309 @@
+"""Unit tests for DifyCredentialsProvider credential_overrides behaviour.
+
+Covers:
+- Override path: alias resolution, provider mismatch, tenant scoping
+- Caching of overridden credentials
+- Decryption of encrypted fields with pass-through for plaintext values
+- Fallback to default resolution when no override is present
+"""
+
+import json
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from core.app.entities.app_invoke_entities import DifyRunContext, InvokeFrom, UserFrom
+from core.app.llm.model_access import DifyCredentialsProvider
+from core.errors.error import ProviderTokenNotInitError
+
+
+def _build_run_context(tenant_id: str = "tenant-1") -> DifyRunContext:
+    return DifyRunContext(
+        tenant_id=tenant_id,
+        app_id="app-1",
+        user_id="user-1",
+        user_from=UserFrom.ACCOUNT,
+        invoke_from=InvokeFrom.SERVICE_API,
+    )
+
+
+def _build_credential_record(
+    *,
+    credential_id: str = "cred-1",
+    tenant_id: str = "tenant-1",
+    provider_name: str = "langgenius/groq/groq",
+    encrypted_config: str | None = None,
+) -> SimpleNamespace:
+    """Build a lightweight stand-in for a ProviderCredential row."""
+    if encrypted_config is None:
+        encrypted_config = json.dumps({"api_key": "encrypted-api-key", "endpoint_url": "https://api.groq.com"})
+    return SimpleNamespace(
+        id=credential_id,
+        tenant_id=tenant_id,
+        provider_name=provider_name,
+        encrypted_config=encrypted_config,
+    )
+
+
+def _patch_session(credential_record):
+    """Return a context manager that patches session_factory to return the given record."""
+    mock_session = mock.MagicMock()
+    mock_session.__enter__ = mock.MagicMock(return_value=mock_session)
+    mock_session.__exit__ = mock.MagicMock(return_value=False)
+    mock_session.scalar.return_value = credential_record
+    return mock.patch(
+        "core.app.llm.model_access.session_factory.create_session",
+        return_value=mock_session,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Override resolves credential by ID and decrypts
+# ---------------------------------------------------------------------------
+class TestCredentialOverrideResolution:
+    def test_override_fetches_and_decrypts_credential(self):
+        """When a valid override is provided, fetch() should look up the credential
+        by ID, decrypt encrypted fields, and return the result."""
+        record = _build_credential_record()
+
+        with (
+            _patch_session(record),
+            mock.patch(
+                "core.app.llm.model_access.encrypter.decrypt_token",
+                side_effect=lambda tenant_id, token: f"decrypted:{token}",
+            ),
+        ):
+            provider = DifyCredentialsProvider(
+                run_context=_build_run_context(),
+                provider_manager=mock.MagicMock(),
+                credential_overrides={"langgenius/groq/groq": "cred-1"},
+            )
+            result = provider.fetch("langgenius/groq/groq", "llama-3.3-70b-versatile")
+
+        assert result["api_key"] == "decrypted:encrypted-api-key"
+        # endpoint_url should also attempt decrypt; our mock decrypts everything
+        assert result["endpoint_url"] == "decrypted:https://api.groq.com"
+
+    def test_override_passthrough_for_undecryptable_fields(self):
+        """Fields that fail decryption (e.g. plain URLs) should be kept as-is."""
+        record = _build_credential_record()
+
+        def selective_decrypt(tenant_id: str, token: str) -> str:
+            if token == "encrypted-api-key":
+                return "real-api-key"
+            raise ValueError("Not encrypted")
+
+        with (
+            _patch_session(record),
+            mock.patch(
+                "core.app.llm.model_access.encrypter.decrypt_token",
+                side_effect=selective_decrypt,
+            ),
+        ):
+            provider = DifyCredentialsProvider(
+                run_context=_build_run_context(),
+                provider_manager=mock.MagicMock(),
+                credential_overrides={"langgenius/groq/groq": "cred-1"},
+            )
+            result = provider.fetch("langgenius/groq/groq", "llama-3.3-70b-versatile")
+
+        assert result["api_key"] == "real-api-key"
+        assert result["endpoint_url"] == "https://api.groq.com"
+
+
+# ---------------------------------------------------------------------------
+# 2. Provider alias resolution
+# ---------------------------------------------------------------------------
+class TestProviderAliasResolution:
+    def test_override_under_short_name_matches_full_provider_name(self):
+        """Override keyed as 'groq' should match when fetch() is called with
+        'langgenius/groq/groq'."""
+        record = _build_credential_record(provider_name="groq")
+
+        with (
+            _patch_session(record),
+            mock.patch(
+                "core.app.llm.model_access.encrypter.decrypt_token",
+                side_effect=lambda tenant_id, token: token,
+            ),
+        ):
+            provider = DifyCredentialsProvider(
+                run_context=_build_run_context(),
+                provider_manager=mock.MagicMock(),
+                credential_overrides={"groq": "cred-1"},
+            )
+            result = provider.fetch("langgenius/groq/groq", "llama-3.3-70b-versatile")
+
+        assert result["api_key"] == "encrypted-api-key"
+
+    def test_override_under_full_name_matches_short_provider_name(self):
+        """Override keyed as 'langgenius/openai/openai' should match when fetch()
+        is called with 'openai'."""
+        record = _build_credential_record(provider_name="langgenius/openai/openai")
+
+        with (
+            _patch_session(record),
+            mock.patch(
+                "core.app.llm.model_access.encrypter.decrypt_token",
+                side_effect=lambda tenant_id, token: token,
+            ),
+        ):
+            provider = DifyCredentialsProvider(
+                run_context=_build_run_context(),
+                provider_manager=mock.MagicMock(),
+                credential_overrides={"langgenius/openai/openai": "cred-1"},
+            )
+            result = provider.fetch("openai", "gpt-4")
+
+        assert result["api_key"] == "encrypted-api-key"
+
+    def test_credential_record_provider_alias_accepted_in_validation(self):
+        """A credential stored under 'openai' should not be rejected when the
+        runtime requests 'langgenius/openai/openai' (alias match)."""
+        record = _build_credential_record(provider_name="openai")
+
+        with (
+            _patch_session(record),
+            mock.patch(
+                "core.app.llm.model_access.encrypter.decrypt_token",
+                side_effect=lambda tenant_id, token: token,
+            ),
+        ):
+            provider = DifyCredentialsProvider(
+                run_context=_build_run_context(),
+                provider_manager=mock.MagicMock(),
+                credential_overrides={"langgenius/openai/openai": "cred-1"},
+            )
+            # Should NOT raise ValueError about provider mismatch
+            result = provider.fetch("langgenius/openai/openai", "gpt-4")
+
+        assert "api_key" in result
+
+
+# ---------------------------------------------------------------------------
+# 3. Provider mismatch rejection
+# ---------------------------------------------------------------------------
+class TestProviderMismatchHandling:
+    def test_credential_for_wrong_provider_raises_value_error(self):
+        """If a credential belongs to 'anthropic' but the override maps it to
+        'openai', a ValueError must be raised."""
+        record = _build_credential_record(provider_name="anthropic")
+
+        with (
+            _patch_session(record),
+            mock.patch("core.app.llm.model_access.encrypter.decrypt_token"),
+        ):
+            provider = DifyCredentialsProvider(
+                run_context=_build_run_context(),
+                provider_manager=mock.MagicMock(),
+                credential_overrides={"openai": "cred-1"},
+            )
+            with pytest.raises(ValueError, match="belongs to provider 'anthropic'"):
+                provider.fetch("openai", "gpt-4")
+
+
+# ---------------------------------------------------------------------------
+# 4. Tenant scoping
+# ---------------------------------------------------------------------------
+class TestTenantScoping:
+    def test_credential_not_found_raises_provider_token_error(self):
+        """If the credential ID does not exist (or belongs to another tenant),
+        ProviderTokenNotInitError must be raised."""
+        with _patch_session(None):  # No record found
+            provider = DifyCredentialsProvider(
+                run_context=_build_run_context(),
+                provider_manager=mock.MagicMock(),
+                credential_overrides={"openai": "nonexistent-cred"},
+            )
+            with pytest.raises(ProviderTokenNotInitError, match="not found or does not belong"):
+                provider.fetch("openai", "gpt-4")
+
+
+# ---------------------------------------------------------------------------
+# 5. Caching
+# ---------------------------------------------------------------------------
+class TestOverrideCaching:
+    def test_second_fetch_uses_cache(self):
+        """After the first fetch with an override, the second call should return
+        a cached copy without hitting the DB again."""
+        record = _build_credential_record()
+
+        mock_session_obj = mock.MagicMock()
+        mock_session_obj.__enter__ = mock.MagicMock(return_value=mock_session_obj)
+        mock_session_obj.__exit__ = mock.MagicMock(return_value=False)
+        mock_session_obj.scalar.return_value = record
+
+        with (
+            mock.patch(
+                "core.app.llm.model_access.session_factory.create_session",
+                return_value=mock_session_obj,
+            ) as mock_create_session,
+            mock.patch(
+                "core.app.llm.model_access.encrypter.decrypt_token",
+                side_effect=lambda tenant_id, token: token,
+            ),
+        ):
+            provider = DifyCredentialsProvider(
+                run_context=_build_run_context(),
+                provider_manager=mock.MagicMock(),
+                credential_overrides={"langgenius/groq/groq": "cred-1"},
+            )
+            first = provider.fetch("langgenius/groq/groq", "llama-3.3-70b-versatile")
+            second = provider.fetch("langgenius/groq/groq", "llama-3.3-70b-versatile")
+
+        # DB session should only have been created once
+        assert mock_create_session.call_count == 1
+        # Results should be equal but not the same object (deepcopy)
+        assert first == second
+        assert first is not second
+
+
+# ---------------------------------------------------------------------------
+# 6. Fallback to default when no override is present
+# ---------------------------------------------------------------------------
+class TestFallbackToDefault:
+    def test_no_override_uses_default_resolution(self):
+        """When no credential_overrides are provided for a provider, the default
+        provider_manager resolution path should be used."""
+        mock_provider_manager = mock.MagicMock()
+        mock_configurations = mock.MagicMock()
+        mock_provider_configuration = mock.MagicMock()
+        mock_provider_model = mock.MagicMock()
+
+        mock_configurations.get.return_value = mock_provider_configuration
+        mock_provider_configuration.get_provider_model.return_value = mock_provider_model
+        mock_provider_configuration.get_current_credentials.return_value = {"api_key": "default-key"}
+        mock_provider_manager.get_configurations.return_value = mock_configurations
+
+        provider = DifyCredentialsProvider(
+            run_context=_build_run_context(),
+            provider_manager=mock_provider_manager,
+            credential_overrides={},  # No overrides
+        )
+        result = provider.fetch("openai", "gpt-4")
+
+        assert result == {"api_key": "default-key"}
+        mock_provider_manager.get_configurations.assert_called_once_with("tenant-1")
+
+    def test_override_for_different_provider_does_not_interfere(self):
+        """An override for 'groq' should not affect a fetch for 'openai'."""
+        mock_provider_manager = mock.MagicMock()
+        mock_configurations = mock.MagicMock()
+        mock_provider_configuration = mock.MagicMock()
+        mock_provider_model = mock.MagicMock()
+
+        mock_configurations.get.return_value = mock_provider_configuration
+        mock_provider_configuration.get_provider_model.return_value = mock_provider_model
+        mock_provider_configuration.get_current_credentials.return_value = {"api_key": "default-openai-key"}
+        mock_provider_manager.get_configurations.return_value = mock_configurations
+
+        provider = DifyCredentialsProvider(
+            run_context=_build_run_context(),
+            provider_manager=mock_provider_manager,
+            credential_overrides={"langgenius/groq/groq": "cred-1"},  # Only Groq overridden
+        )
+        result = provider.fetch("openai", "gpt-4")
+
+        assert result == {"api_key": "default-openai-key"}
+        mock_provider_manager.get_configurations.assert_called_once()


### PR DESCRIPTION
> [!IMPORTANT]
>
Fixes #35440 

## Summary

Added support for dynamic, per-request LLM credential overrides across all major API endpoints. This feature allows API consumers to pass custom credential IDs at runtime, which temporarily override the workspace's default LLM credentials (like API keys) for the duration of that specific workflow or chat execution.

## Motivation and Context
Previously, all workflow and chat executions in Dify were rigidly bound to the default LLM credentials configured at the workspace level. This caused a significant limitation for developers building multi-tenant SaaS applications on top of Dify, as they were forced to absorb all LLM billing costs centrally.

By allowing credential_overrides in the API payload, applications can now dynamically inject their own end-users' API keys into the Dify execution context. This enables Bring-Your-Own-Key (BYOK) architectures and direct usage billing, vastly improving Dify's flexibility as an orchestration backend without requiring architectural changes to the frontend apps.

## Screenshots

<img width="702" height="240" alt="image" src="https://github.com/user-attachments/assets/da57d198-11f6-45a8-b831-668074e1b5e9" />
<img width="695" height="260" alt="image" src="https://github.com/user-attachments/assets/603fb509-33da-431b-9d8b-14d39448a58e" />
<img width="686" height="229" alt="image" src="https://github.com/user-attachments/assets/231d49bd-58fe-4956-a9e0-684fe8578062" />
<img width="670" height="267" alt="image" src="https://github.com/user-attachments/assets/fec3faf4-e086-4ecf-90bc-02aa4d974ee3" />
<img width="689" height="242" alt="image" src="https://github.com/user-attachments/assets/25ca35cc-bc4a-4506-ba8d-3a5c36441113" />

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
