### PR TITLE
fix: stop start-api when migration fails

### DIFF
--- a/dev/start-api
+++ b/dev/start-api
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+set -ex
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 cd "$SCRIPT_DIR/../api"


### PR DESCRIPTION
## Summary

- make `dev/start-api` exit when `flask db upgrade` fails
- keep the existing trace output behavior

## Why

`dev/start-api` currently uses `set -x` only. If the database migration command fails, the script keeps going and starts the Flask dev server against a broken migration state. With `set -e`, the script stops at the failed migration instead of masking the startup failure.

Fixes #36992.

## To verify

```text
C:\Program Files\Git\bin\bash.exe -n dev/start-api
C:\Program Files\Git\bin\bash.exe -lc 'set -e; false; echo should-not-print'
git diff --check
```

The second command exits non-zero before printing `should-not-print`, which is the expected `set -e` behavior.
