### PR TITLE
fix: avoid duplicating lines when merging text for summarization

### DIFF
--- a/api/core/plugin/backwards_invocation/model.py
+++ b/api/core/plugin/backwards_invocation/model.py
@@ -392,7 +392,7 @@ Here is the extra instruction you need to follow:
             else:
                 if len(messages[-1]) + len(line) < max_tokens * 0.5:
                     messages[-1] += line
-                if get_prompt_tokens(messages[-1] + line) > max_tokens * 0.7:
+                elif get_prompt_tokens(messages[-1] + line) > max_tokens * 0.7:
                     messages.append(line)
                 else:
                     messages[-1] += line

--- a/api/core/tools/builtin_tool/tool.py
+++ b/api/core/tools/builtin_tool/tool.py
@@ -135,7 +135,7 @@ class BuiltinTool(Tool):
             else:
                 if len(messages[-1]) + len(j) < max_tokens * 0.5:
                     messages[-1] += j
-                if get_prompt_tokens(messages[-1] + j) > max_tokens * 0.7:
+                elif get_prompt_tokens(messages[-1] + j) > max_tokens * 0.7:
                     messages.append(j)
                 else:
                     messages[-1] += j

--- a/api/tests/unit_tests/core/tools/test_builtin_tool_base.py
+++ b/api/tests/unit_tests/core/tools/test_builtin_tool_base.py
@@ -129,3 +129,34 @@ def test_builtin_tool_summary_short_and_long_content_paths():
 
     assert result
     assert "S" in result
+
+
+def test_builtin_tool_summary_does_not_duplicate_lines_when_merging_chunks():
+    """Each line must be placed into exactly one summarization chunk.
+
+    The chunk-merge loop used two adjacent, non-mutually-exclusive ``if`` blocks, so a
+    line that fit the character budget was concatenated onto the current chunk AND then
+    appended a second time. That duplicated content in the text sent to the model.
+    """
+    tool = _build_tool()
+
+    captured_chunks: list[str] = []
+
+    def _record_invoke(user_id, prompt_messages, stop):
+        captured_chunks.append(prompt_messages[-1].content)
+        return SimpleNamespace(message=SimpleNamespace(content="S"))
+
+    content = "\n".join(["a" * 20, "b" * 20, "c" * 20])
+
+    with patch.object(_BuiltinDummyTool, "get_max_tokens", return_value=100):
+        with patch.object(
+            _BuiltinDummyTool,
+            "get_prompt_tokens",
+            side_effect=lambda prompt_messages: len(prompt_messages[-1].content),
+        ):
+            with patch.object(_BuiltinDummyTool, "invoke_model", side_effect=_record_invoke):
+                tool.summary(user_id="u1", content=content)
+
+    combined = "".join(captured_chunks)
+    for line in ("a" * 20, "b" * 20, "c" * 20):
+        assert combined.count(line) == 1, f"line was sent to the model {combined.count(line)} times, expected 1"


### PR DESCRIPTION
Fixes #37092

## Summary

`BuiltinTool.summary()` (`api/core/tools/builtin_tool/tool.py`) splits long content into lines and merges them into token-bounded chunks before summarizing each chunk with the LLM. The merge loop used **two adjacent, non-mutually-exclusive `if` blocks**, so a line that fit the character budget was concatenated onto the current chunk **and then placed a second time**:

```python
if len(messages[-1]) + len(j) < max_tokens * 0.5:
    messages[-1] += j          # (A) line placed into current chunk
if get_prompt_tokens(messages[-1] + j) > max_tokens * 0.7:   # ran regardless of (A)
    messages.append(j)         # (B) line placed AGAIN
else:
    messages[-1] += j          # (C) line placed AGAIN
```

When (A) fires, `j` is merged into the current chunk; then the separate `if`/`else` runs unconditionally and places `j` again. The token check at (B) is also evaluated on `messages[-1] + j` *after* `j` was already merged, double-counting it.

**Impact:** every line that fits the budget is duplicated in the text sent to the summarization model — wasted tokens and a degraded summary. This is a live path: the builtin **web scraper** tool calls `summary()` to condense scraped pages.

The identical loop is copy-pasted into `api/core/plugin/backwards_invocation/model.py`, so this PR fixes both sites.

## Fix

Make the two branches mutually exclusive (`if` → `elif`) so each line is placed into exactly one chunk — merged into the current chunk if it fits, otherwise starting a new one. Two-character change per site, no behavior change beyond removing the duplication.

Added a regression test (`test_builtin_tool_summary_does_not_duplicate_lines_when_merging_chunks`) that captures the chunks actually sent to the model and asserts no line is sent more than once. Verified it fails before the fix (a line is sent twice) and passes after.

## Screenshots

| Before | After |
|--------|-------|
| N/A (backend logic fix) | N/A |

## Checklist

- [ ] This change requires a documentation update
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran the linter and the relevant backend unit tests locally.