### PR TITLE
fix: reset tool_calls per message when saving CHAT prompt history

### DIFF
--- a/api/core/prompt/utils/prompt_message_util.py
+++ b/api/core/prompt/utils/prompt_message_util.py
@@ -24,8 +24,10 @@ class PromptMessageUtil:
         """
         prompts = []
         if model_mode == ModelMode.CHAT:
-            tool_calls = []
             for prompt_message in prompt_messages:
+                # Reset per message: tool_calls belong only to the assistant message that
+                # produced them, so they must not leak onto the following message.
+                tool_calls = []
                 if prompt_message.role == PromptMessageRole.USER:
                     role = "user"
                 elif prompt_message.role == PromptMessageRole.ASSISTANT:

--- a/api/tests/unit_tests/core/prompt/test_prompt_message.py
+++ b/api/tests/unit_tests/core/prompt/test_prompt_message.py
@@ -79,6 +79,36 @@ def test_prompt_messages_to_prompt_for_saving_chat_mode():
     assert prompts[2]["role"] == "tool"
 
 
+def test_prompt_messages_to_prompt_for_saving_does_not_leak_tool_calls_to_following_messages():
+    """tool_calls belong only to the assistant message that produced them.
+
+    tool_calls was initialized once outside the per-message loop and only reassigned in the
+    assistant branch, so a message following an assistant message with tool_calls inherited
+    the stale list.
+    """
+    chat_messages = [
+        AssistantPromptMessage(
+            content="assistant-text",
+            tool_calls=[
+                {
+                    "id": "tool-1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": '{"q":"python"}'},
+                }
+            ],
+        ),
+        UserPromptMessage(content="follow-up question"),
+    ]
+
+    prompts = PromptMessageUtil.prompt_messages_to_prompt_for_saving(ModelMode.CHAT, chat_messages)
+
+    assert prompts[0]["role"] == "assistant"
+    assert prompts[0]["tool_calls"][0]["function"]["name"] == "search"
+    assert prompts[1]["role"] == "user"
+    # The following user message must not inherit the assistant's tool_calls.
+    assert "tool_calls" not in prompts[1]
+
+
 def test_prompt_messages_to_prompt_for_saving_completion_mode_with_and_without_files():
     completion_message_with_files = UserPromptMessage(
         content=[


### PR DESCRIPTION
Fixes #37095

## Summary

In `PromptMessageUtil.prompt_messages_to_prompt_for_saving` (`api/core/prompt/utils/prompt_message_util.py`), CHAT mode initializes `tool_calls = []` **once, outside** the per-message loop, and only reassigns it inside the assistant branch — but `if tool_calls: prompt["tool_calls"] = tool_calls` runs for **every** message:

```python
tool_calls = []
for prompt_message in prompt_messages:
    ...
    elif prompt_message.role == PromptMessageRole.ASSISTANT:
        ...
        tool_calls = [ ... ]   # only set here
    ...
    if tool_calls:             # but read for every role
        prompt["tool_calls"] = tool_calls
```

So after an assistant message that carries `tool_calls`, the **next** message (the tool-result message, and any later non-assistant message until the next assistant turn) reuses the stale list and is wrongly tagged with the previous assistant's tool calls.

## Fix

Reset `tool_calls` at the top of each loop iteration so they belong only to the assistant message that produced them.

## Verification

Added `test_prompt_messages_to_prompt_for_saving_does_not_leak_tool_calls_to_following_messages`, which builds `[assistant(with tool_calls), user]` and asserts the following user message has no `tool_calls`. Verified it fails before the fix (the user message inherits the tool_calls) and passes after. Full `test_prompt_message.py` suite green; ruff check + format clean.

## Screenshots

| Before | After |
|--------|-------|
| N/A (backend logic fix) | N/A |

## Checklist

- [ ] This change requires a documentation update
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran the linter and the relevant backend unit tests locally.