### PR TITLE
fix: close SSE stream on early execution failure to prevent 300 s hang (#36996)

### DIFF
--- a/api/tasks/app_generate/workflow_execute_task.py
+++ b/api/tasks/app_generate/workflow_execute_task.py
@@ -250,6 +250,10 @@ def _publish_error_event(exc: Exception, workflow_run_id: str, app_mode: AppMode
     topic = MessageBasedAppGenerator.get_response_topic(app_mode, workflow_run_id)
     payload = json.dumps({"event": "error", "message": str(exc), "status": 500})
     topic.publish(payload.encode())
+    # Publish a terminal event to close the SSE stream immediately.
+    # Without this, stream_topic_events keeps waiting until idle_timeout (300 s),
+    # leaving the UI stuck in "Running" with no feedback to the user.
+    topic.publish(json.dumps({"event": "workflow_finished", "data": {}}).encode())
 
 
 def _publish_streaming_response(


### PR DESCRIPTION
## Summary

Fixes #36996.

Close the SSE stream when workflow generation fails before `queue_manager` is initialized. Without a terminal event, `stream_topic_events` keeps waiting until the 300 s idle timeout and the UI can remain stuck in the running state.

## Root Cause

When `WorkflowAppGenerator.generate()` raises early, `_AppRunner.run()` catches the exception and calls `_publish_error_event()`. That helper publishes an `error` event to the Redis topic, but the SSE stream only exits on terminal workflow events such as `workflow_finished` or `workflow_paused`.

## Fix

After publishing the error event, `_publish_error_event()` now publishes a minimal `workflow_finished` event so the SSE stream closes immediately.

## Validation

- `python -m py_compile` syntax check passed
- GitHub Actions checks are passing on the latest commit