### PR TITLE
fix: add null-safety for document in hit-testing result-item

### DIFF
--- a/web/app/components/datasets/hit-testing/components/result-item.tsx
+++ b/web/app/components/datasets/hit-testing/components/result-item.tsx
@@ -30,7 +30,7 @@ const ResultItem = ({
   const data = segment
   const { position, word_count, content, sign_content, keywords, document } = data
   const isParentChildRetrieval = !!(child_chunks && child_chunks.length > 0)
-  const extension = document.name.split('.').slice(-1)[0] as FileAppearanceTypeEnum
+  const extension = (document?.name?.split('.').slice(-1)[0] || 'txt') as FileAppearanceTypeEnum
   const fileType = extensionToFileType(extension)
   const [isFold, {
     toggle: toggleFold,
@@ -104,7 +104,7 @@ const ResultItem = ({
         )}
       </div>
       {/* Foot */}
-      <ResultItemFooter docType={fileType} docTitle={document.name} showDetailModal={showDetailModal} />
+      <ResultItemFooter docType={fileType} docTitle={document?.name ?? ''} showDetailModal={showDetailModal} />
 
       {
         isShowDetailModal && (


### PR DESCRIPTION
﻿## Summary

Fixes #37064

## Problem

The hit-testing result item component crashes when the backend returns null document metadata. This causes the frontend to show "internal server error" because `document.name` is accessed without null-safety checks.

## Root Cause

Two locations in `result-item.tsx` access `document.name` unprotected:

1. **Line 33**: `document.name.split('.')` — crashes when document is null
2. **Line 85**: `document.name` as `docTitle` prop — same crash

The backend PR #36106 fixed the enrichment logic, but edge cases (orphaned segments, stale vector metadata) can still produce null document fields.

## Fix

- Added optional chaining (`document?.name`) and fallback values (`'txt'` / `''`) in both locations
- 2 lines modified, no new imports

## Testing

- No behavioral change when document has valid data
- Prevents runtime crash when document is null/undefined
