### PR TITLE
chore: update frontend code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,10 @@
 # Agents
 /.agents/skills/ @hyoban
 
+# Packages
+/packages/ @lyzno1
+/packages/contracts/ @crazywoola @laipz8200
+
 # Docs
 /docs/ @crazywoola
 
@@ -143,6 +147,14 @@
 # Frontend
 /web/ @iamjoel
 
+# Frontend - Platform and Features
+/web/config/ @lyzno1
+/web/contract/ @lyzno1
+/web/env.ts @lyzno1
+/web/features/ @lyzno1
+/web/hooks/ @lyzno1
+/web/scripts/gen-icons.mjs @lyzno1
+
 # Frontend - Web Tests
 /.github/workflows/web-tests.yml @iamjoel
 
@@ -253,7 +265,6 @@
 /web/utils/time.ts @iamjoel @zxhlyh
 /web/utils/format.ts @iamjoel @zxhlyh
 /web/utils/clipboard.ts @iamjoel @zxhlyh
-/web/hooks/use-document-title.ts @iamjoel @zxhlyh
 
 # Frontend - Billing and Education
 /web/app/components/billing/ @iamjoel @zxhlyh


### PR DESCRIPTION
## Summary
- add @lyzno1 as the sole owner for frontend platform and feature CODEOWNERS scopes
- add @lyzno1 as the package default owner while excluding generated contracts
- remove the narrower web hooks owner rule so /web/hooks/ is owned consistently

## Testing
- git diff --check
- GitHub CODEOWNERS errors endpoint checked; remaining errors are pre-existing backend owner access issues, not the new entries

Fixes #37110