### PR TITLE
fix: tolerate missing dataset icon info

### DIFF
--- a/web/app/components/app/configuration/dataset-config/select-dataset/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/dataset-config/select-dataset/__tests__/index.spec.tsx
@@ -9,6 +9,12 @@ import { DatasetPermission } from '@/models/datasets'
 import { RETRIEVE_METHOD } from '@/types/app'
 import SelectDataSet from '../index'
 
+const mockAppIcon = vi.hoisted(() => vi.fn(() => null))
+
+vi.mock('@/app/components/base/app-icon', () => ({
+  default: mockAppIcon,
+}))
+
 vi.mock('@/i18n-config/i18next-config', () => ({
   default: {
     changeLanguage: vi.fn(),
@@ -119,6 +125,39 @@ describe('SelectDataSet', () => {
       fireEvent.click(addButton)
     })
     expect(onSelect).toHaveBeenCalledWith([datasetOne])
+  })
+
+  it('uses the default dataset icon when icon_info is missing', async () => {
+    const dataset = {
+      ...makeDataset({
+        id: 'set-null-icon',
+        name: 'Dataset Without Icon',
+      }),
+      icon_info: null,
+    } as unknown as DataSet
+    mockUseInfiniteDatasets.mockReturnValue({
+      data: { pages: [{ data: [dataset] }] },
+      isLoading: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+    })
+
+    await act(async () => {
+      render(<SelectDataSet {...baseProps} selectedIds={[]} />)
+    })
+
+    expect(screen.getByText('Dataset Without Icon')).toBeInTheDocument()
+    expect(mockAppIcon).toHaveBeenCalledWith(
+      expect.objectContaining({
+        size: 'tiny',
+        iconType: 'emoji',
+        icon: '📙',
+        background: '#FFF4ED',
+        imageUrl: undefined,
+      }),
+      undefined,
+    )
   })
 
   it('shows empty state when no datasets are available and disables add', async () => {

--- a/web/app/components/app/configuration/dataset-config/select-dataset/index.tsx
+++ b/web/app/components/app/configuration/dataset-config/select-dataset/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 import type { FC } from 'react'
-import type { DataSet } from '@/models/datasets'
+import type { DataSet, IconInfo } from '@/models/datasets'
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
 import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
@@ -16,6 +16,34 @@ import FeatureIcon from '@/app/components/header/account-setting/model-provider-
 import { useKnowledge } from '@/hooks/use-knowledge'
 import Link from '@/next/link'
 import { useInfiniteDatasets } from '@/service/knowledge/use-dataset'
+
+const DEFAULT_DATASET_ICON: IconInfo = {
+  icon_type: 'emoji',
+  icon: '📙',
+  icon_background: '#FFF4ED',
+  icon_url: '',
+}
+
+type NullableDatasetIconInfo = Partial<{
+  [Key in keyof IconInfo]: IconInfo[Key] | null
+}>
+
+const normalizeDatasetIconInfo = (iconInfo?: NullableDatasetIconInfo | null): IconInfo => ({
+  icon_type: iconInfo?.icon_type ?? DEFAULT_DATASET_ICON.icon_type,
+  icon: iconInfo?.icon ?? DEFAULT_DATASET_ICON.icon,
+  icon_background: iconInfo?.icon_background ?? DEFAULT_DATASET_ICON.icon_background,
+  icon_url: iconInfo?.icon_url ?? DEFAULT_DATASET_ICON.icon_url,
+})
+
+const getDatasetIconProps = (iconInfo?: NullableDatasetIconInfo | null) => {
+  const normalizedIconInfo = normalizeDatasetIconInfo(iconInfo)
+  return {
+    iconType: normalizedIconInfo.icon_type,
+    icon: normalizedIconInfo.icon,
+    background: normalizedIconInfo.icon_type === 'image' ? undefined : normalizedIconInfo.icon_background,
+    imageUrl: normalizedIconInfo.icon_type === 'image' ? normalizedIconInfo.icon_url : undefined,
+  }
+}
 
 type ISelectDataSetProps = {
   isShow: boolean
@@ -128,10 +156,7 @@ const SelectDataSet: FC<ISelectDataSetProps> = ({
                     <div className={cn('mr-2', !item.embedding_available && 'opacity-30')}>
                       <AppIcon
                         size="tiny"
-                        iconType={item.icon_info.icon_type}
-                        icon={item.icon_info.icon}
-                        background={item.icon_info.icon_type === 'image' ? undefined : item.icon_info.icon_background}
-                        imageUrl={item.icon_info.icon_type === 'image' ? item.icon_info.icon_url : undefined}
+                        {...getDatasetIconProps(item.icon_info)}
                       />
                     </div>
                     <div className={cn('max-w-50 truncate text-[13px] font-medium text-text-secondary', !item.embedding_available && 'max-w-30! opacity-30')}>{item.name}</div>


### PR DESCRIPTION
## Summary

- make the app dataset selector tolerate missing or null `icon_info`
- reuse the same default dataset icon shape used elsewhere in the web app
- add a regression test for datasets that render with `icon_info: null`

## Context

`DatasetNav` already normalizes missing dataset icon metadata on current `main`, but the app configuration dataset selector still reads `item.icon_info.icon_type` and related fields directly. A dataset row with null icon metadata can still crash that selector before the user can pick a dataset.

This follows the existing fallback convention instead of changing the API contract.

## Validation

- `git diff --check`
- secret scan on the changed files

## To verify

- `pnpm --filter dify-web test web/app/components/app/configuration/dataset-config/select-dataset/__tests__/index.spec.tsx`

I could not complete the targeted pnpm test locally because dependency installation repeatedly timed out while downloading packages from the npm registry. The lockfile policy check passed on retry, but tarball downloads kept aborting before a usable `node_modules` was created.
