### PR TITLE
fix(rag): rerank attachment-only hybrid retrieval as IMAGE_QUERY

### DIFF
--- a/api/core/rag/datasource/retrieval_service.py
+++ b/api/core/rag/datasource/retrieval_service.py
@@ -862,6 +862,10 @@ class RetrievalService:
                     str(dataset.tenant_id), reranking_mode, reranking_model, weights, False
                 )
 
+                # Derive the rerank query type from the original query: an attachment-only
+                # retrieval (no text query) must rerank as IMAGE_QUERY. This must be computed
+                # before `query` is overwritten with the attachment id below.
+                query_type = QueryType.TEXT_QUERY if query else QueryType.IMAGE_QUERY
                 query = query or attachment_id
                 if not query:
                     return
@@ -870,7 +874,7 @@ class RetrievalService:
                     documents=all_documents_item,
                     score_threshold=score_threshold,
                     top_n=top_k,
-                    query_type=QueryType.TEXT_QUERY if query else QueryType.IMAGE_QUERY,
+                    query_type=query_type,
                 )
                 if not data_post_processor.rerank_runner and score_threshold:
                     all_documents_item = self._filter_documents_by_vector_score_threshold(

--- a/api/tests/unit_tests/core/rag/datasource/test_retrieval_attachment_access.py
+++ b/api/tests/unit_tests/core/rag/datasource/test_retrieval_attachment_access.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import cast
 from uuid import uuid4
 
 from sqlalchemy import select
@@ -21,7 +22,7 @@ from core.rag.retrieval import dataset_retrieval as dataset_retrieval_module
 from core.rag.retrieval.dataset_retrieval import DatasetRetrieval
 from core.rag.retrieval.retrieval_methods import RetrievalMethod
 from core.workflow.nodes.knowledge_retrieval.retrieval import KnowledgeRetrievalRequest
-from models import UploadFile
+from models import Dataset, UploadFile
 
 
 class _ScalarResult:
@@ -192,7 +193,7 @@ def test_retrieve_hybrid_attachment_only_reranks_with_image_query_type(app, monk
     RetrievalService()._retrieve(
         flask_app=app,
         retrieval_method=RetrievalMethod.HYBRID_SEARCH,
-        dataset=dataset,
+        dataset=cast(Dataset, dataset),
         all_documents=[],
         exceptions=[],
         query=None,

--- a/api/tests/unit_tests/core/rag/datasource/test_retrieval_attachment_access.py
+++ b/api/tests/unit_tests/core/rag/datasource/test_retrieval_attachment_access.py
@@ -16,8 +16,10 @@ from core.app.file_access import (
     is_retriever_segment_access_granted,
 )
 from core.rag.datasource.retrieval_service import RetrievalService
+from core.rag.index_processor.constant.query_type import QueryType
 from core.rag.retrieval import dataset_retrieval as dataset_retrieval_module
 from core.rag.retrieval.dataset_retrieval import DatasetRetrieval
+from core.rag.retrieval.retrieval_methods import RetrievalMethod
 from core.workflow.nodes.knowledge_retrieval.retrieval import KnowledgeRetrievalRequest
 from models import UploadFile
 
@@ -162,3 +164,42 @@ def test_knowledge_retrieval_grants_returned_segments_to_current_scope(monkeypat
     assert results[0].metadata.segment_id == segment_id
     assert current_scope is not None
     assert segment_id in current_scope.granted_retriever_segment_ids
+
+
+def test_retrieve_hybrid_attachment_only_reranks_with_image_query_type(app, monkeypatch) -> None:
+    """Attachment-only hybrid retrieval must rerank as IMAGE_QUERY, not TEXT_QUERY.
+
+    ``query = query or attachment_id`` overwrote ``query`` before the rerank query_type was
+    derived from it, so the ``IMAGE_QUERY`` branch was unreachable: the upload-file id was
+    sent to the reranker as plain text instead of loading the actual image.
+    """
+    captured: dict[str, object] = {}
+
+    class _CapturingDataPostProcessor:
+        def __init__(self, *args, **kwargs) -> None:
+            self.rerank_runner = object()  # truthy: skip the score-threshold-only filter branch
+
+        def invoke(self, *, query, documents, score_threshold, top_n, query_type):
+            captured["query_type"] = query_type
+            return []
+
+    monkeypatch.setattr("core.rag.datasource.retrieval_service.DataPostProcessor", _CapturingDataPostProcessor)
+    # The attachment embedding search would hit the vector store / DB; stub it out.
+    monkeypatch.setattr(RetrievalService, "embedding_search", lambda *args, **kwargs: None)
+
+    dataset = SimpleNamespace(id=str(uuid4()), tenant_id=str(uuid4()))
+
+    RetrievalService()._retrieve(
+        flask_app=app,
+        retrieval_method=RetrievalMethod.HYBRID_SEARCH,
+        dataset=dataset,
+        all_documents=[],
+        exceptions=[],
+        query=None,
+        attachment_id="upload-file-1",
+        top_k=4,
+        score_threshold=0.0,
+        reranking_mode="reranking_model",
+    )
+
+    assert captured["query_type"] == QueryType.IMAGE_QUERY


### PR DESCRIPTION
Fixes #37116

## Summary

In `RetrievalService._retrieve` (`api/core/rag/datasource/retrieval_service.py`), the `HYBRID_SEARCH` branch derived the rerank `query_type` **after** `query` had already been overwritten:

```python
query = query or attachment_id
if not query:
    return
all_documents_item = data_post_processor.invoke(
    ...,
    query_type=QueryType.TEXT_QUERY if query else QueryType.IMAGE_QUERY,  # query is always truthy here
)
```

For an attachment-only retrieval (`query=None, attachment_id=<upload_file_id>`), `query` becomes the truthy upload-file id before the ternary (and the `if not query: return` guard guarantees it), so the `IMAGE_QUERY` branch is **unreachable** — attachment-only hybrid retrieval is always reranked as `TEXT_QUERY`.

This is load-bearing: `RerankModelRunner.fetch_multimodal_rerank` uses `IMAGE_QUERY` to load the upload file and base64-encode the image as the rerank query, while `TEXT_QUERY` passes the query string to the reranker literally. So the bug sends the **raw upload-file-id string** to a vision reranker as text instead of the image, producing wrong rerank ordering.

The non-hybrid embedding path in the same file already distinguishes the two correctly (`QueryType.TEXT_QUERY` for the text future, `QueryType.IMAGE_QUERY` for the attachment future).

## Fix

Compute `query_type` from the original `query` before it is overwritten with `attachment_id`.

## Verification

Added `test_retrieve_hybrid_attachment_only_reranks_with_image_query_type`, which drives `_retrieve` with `query=None, attachment_id=..., retrieval_method=HYBRID_SEARCH` (stubbing the embedding search and capturing the `query_type` forwarded to the rerank post-processor) and asserts it is `IMAGE_QUERY`. Verified it fails before the fix (captures `TEXT_QUERY`) and passes after. `test_retrieval_attachment_access.py` suite green; ruff check + format clean.

## Screenshots

| Before | After |
|--------|-------|
| N/A (backend logic fix) | N/A |

## Checklist

- [ ] This change requires a documentation update
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran the linter and the relevant backend unit tests locally.