### PR TITLE
refactor(web): mark Props of datasets/hit-testing components as read-only

### DIFF
--- a/web/app/components/datasets/hit-testing/components/child-chunks-item.tsx
+++ b/web/app/components/datasets/hit-testing/components/child-chunks-item.tsx
@@ -6,8 +6,8 @@ import { SliceContent } from '../../formatted-text/flavours/shared'
 import Score from './score'
 
 type Props = {
-  payload: HitTestingChildChunk
-  isShowAll: boolean
+  readonly payload: HitTestingChildChunk
+  readonly isShowAll: boolean
 }
 
 const ChildChunks: FC<Props> = ({

--- a/web/app/components/datasets/hit-testing/components/result-item-external.tsx
+++ b/web/app/components/datasets/hit-testing/components/result-item-external.tsx
@@ -12,8 +12,8 @@ import ResultItemMeta from './result-item-meta'
 
 const i18nPrefix = ''
 type Props = {
-  payload: ExternalKnowledgeBaseHitTesting
-  positionId: number
+  readonly payload: ExternalKnowledgeBaseHitTesting
+  readonly positionId: number
 }
 
 const ResultItemExternal: FC<Props> = ({ payload, positionId }) => {

--- a/web/app/components/datasets/hit-testing/components/result-item-footer.tsx
+++ b/web/app/components/datasets/hit-testing/components/result-item-footer.tsx
@@ -7,9 +7,9 @@ import { useTranslation } from 'react-i18next'
 import FileIcon from '@/app/components/base/file-uploader/file-type-icon'
 
 type Props = {
-  docType: FileAppearanceTypeEnum
-  docTitle: string
-  showDetailModal: () => void
+  readonly docType: FileAppearanceTypeEnum
+  readonly docTitle: string
+  readonly showDetailModal: () => void
 }
 const i18nPrefix = ''
 

--- a/web/app/components/datasets/hit-testing/components/result-item-meta.tsx
+++ b/web/app/components/datasets/hit-testing/components/result-item-meta.tsx
@@ -8,11 +8,11 @@ import { SegmentIndexTag } from '../../documents/detail/completed/common/segment
 import Score from './score'
 
 type Props = {
-  labelPrefix: string
-  positionId: number
-  wordCount: number
-  score: number
-  className?: string
+  readonly labelPrefix: string
+  readonly positionId: number
+  readonly wordCount: number
+  readonly score: number
+  readonly className?: string
 }
 
 const ResultItemMeta: FC<Props> = ({

--- a/web/app/components/datasets/hit-testing/components/score.tsx
+++ b/web/app/components/datasets/hit-testing/components/score.tsx
@@ -4,8 +4,8 @@ import { cn } from '@langgenius/dify-ui/cn'
 import * as React from 'react'
 
 type Props = {
-  value: number | null
-  besideChunkName?: boolean
+  readonly value: number | null
+  readonly besideChunkName?: boolean
 }
 
 const Score: FC<Props> = ({


### PR DESCRIPTION
part of #25219

## Summary

Adds the `readonly` modifier to each property of the `Props` types in five `datasets/hit-testing` leaf components, per [`@eslint-react/prefer-read-only-props`](https://eslint-react.xyz/docs/rules/prefer-read-only-props):

- `score.tsx`
- `child-chunks-item.tsx`
- `result-item-footer.tsx`
- `result-item-meta.tsx`
- `result-item-external.tsx`

Pattern matches the merged example PR #25220. This is a type-annotation-only change (props are never mutated), so there is no behavior change and no tests or docs are required.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I tried as much as possible to make a single atomic change (type-only; no tests applicable).
- [ ] I've updated the documentation accordingly.
- [x] I ran the frontend lint (`cd web && pnpm exec eslint` on the changed files; the pre-commit hook's `eslint --fix` also passed). Backend lint/type-check not applicable (frontend-only change).

From Claude Code
