### PR TITLE
refactor(web): migrate app-collapse and debug-model localStorage to useLocalStorage

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -109,9 +109,6 @@
     }
   },
   "web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx": {
-    "no-restricted-globals": {
-      "count": 1
-    },
     "react/set-state-in-effect": {
       "count": 2
     },
@@ -249,7 +246,7 @@
   },
   "web/app/components/app-sidebar/index.tsx": {
     "no-restricted-globals": {
-      "count": 2
+      "count": 1
     },
     "ts/no-explicit-any": {
       "count": 1
@@ -510,9 +507,6 @@
     }
   },
   "web/app/components/app/configuration/debug/hooks.tsx": {
-    "no-restricted-globals": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 3
     }

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx
@@ -26,6 +26,7 @@ import Loading from '@/app/components/base/loading'
 import { useAppContext } from '@/context/app-context'
 import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
 import useDocumentTitle from '@/hooks/use-document-title'
+import { useLocalStorage } from '@/hooks/use-local-storage'
 import { usePathname, useRouter } from '@/next/navigation'
 import { fetchAppDetailDirect } from '@/service/apps'
 import { AppModeEnum } from '@/types/app'
@@ -61,6 +62,8 @@ const AppDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
     icon: NavIcon
     selectedIcon: NavIcon
   }>>([])
+
+  const [storedAppSidebarMode] = useLocalStorage<string>('app-detail-collapse-or-expand', 'expand', { raw: true })
 
   const getNavigationConfig = useCallback((appId: string, isCurrentWorkspaceEditor: boolean, mode: AppModeEnum) => {
     const navConfig = [
@@ -104,14 +107,10 @@ const AppDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
 
   useEffect(() => {
     if (appDetail) {
-      const localeMode = localStorage.getItem('app-detail-collapse-or-expand') || 'expand'
       const mode = isMobile ? 'collapse' : 'expand'
-      setAppSidebarExpand(isMobile ? mode : localeMode)
-      // TODO: consider screen size and mode
-      // if ((appDetail.mode === AppModeEnum.ADVANCED_CHAT || appDetail.mode === 'workflow') && (pathname).endsWith('workflow'))
-      //   setAppSidebarExpand('collapse')
+      setAppSidebarExpand(isMobile ? mode : storedAppSidebarMode)
     }
-  }, [appDetail, isMobile])
+  }, [appDetail, isMobile, storedAppSidebarMode])
 
   useEffect(() => {
     setAppDetail()

--- a/web/app/components/app-sidebar/index.tsx
+++ b/web/app/components/app-sidebar/index.tsx
@@ -9,6 +9,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useStore as useAppStore } from '@/app/components/app/store'
 import { useEventEmitterContextContext } from '@/context/event-emitter'
 import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
+import { useSetLocalStorage } from '@/hooks/use-local-storage'
 import { usePathname } from '@/next/navigation'
 import Divider from '../base/divider'
 import AppInfo, { AppInfoView } from './app-info'
@@ -56,6 +57,8 @@ const AppDetailNav = ({
 
   const isHoveringSidebar = useHover(sidebarRef)
 
+  const setStoredAppSidebarMode = useSetLocalStorage<string>('app-detail-collapse-or-expand', { raw: true })
+
   // Check if the current path is a workflow canvas & fullscreen
   const pathname = usePathname()
   const inWorkflowCanvas = pathname.endsWith('/workflow')
@@ -71,10 +74,10 @@ const AppDetailNav = ({
 
   useEffect(() => {
     if (appSidebarExpand) {
-      localStorage.setItem('app-detail-collapse-or-expand', appSidebarExpand)
+      setStoredAppSidebarMode(appSidebarExpand)
       setAppSidebarExpand(appSidebarExpand)
     }
-  }, [appSidebarExpand, setAppSidebarExpand])
+  }, [appSidebarExpand, setAppSidebarExpand, setStoredAppSidebarMode])
 
   useHotkey('Mod+B', (e) => {
     e.preventDefault()

--- a/web/app/components/app/configuration/debug/hooks.tsx
+++ b/web/app/components/app/configuration/debug/hooks.tsx
@@ -9,13 +9,12 @@ import type {
 import { cloneDeep } from 'es-toolkit/object'
 import {
   useCallback,
-  useRef,
-  useState,
 } from 'react'
 import { SupportUploadFileTypes } from '@/app/components/workflow/types'
 import { DEFAULT_CHAT_PROMPT_CONFIG, DEFAULT_COMPLETION_PROMPT_CONFIG } from '@/config'
 import { useDebugConfigurationContext } from '@/context/debug-configuration'
 import { useEventEmitterContextContext } from '@/context/event-emitter'
+import { useLocalStorage } from '@/hooks/use-local-storage'
 import {
   AgentStrategy,
 } from '@/types/app'
@@ -23,42 +22,20 @@ import { promptVariablesToUserInputsForm } from '@/utils/model-config'
 import { ORCHESTRATE_CHANGED } from './types'
 
 export const useDebugWithSingleOrMultipleModel = (appId: string) => {
-  const localeDebugWithSingleOrMultipleModelConfigs = localStorage.getItem('app-debug-with-single-or-multiple-models')
+  const [debugWithSingleOrMultipleModelConfigs, setDebugWithSingleOrMultipleModelConfigs] = useLocalStorage<DebugWithSingleOrMultipleModelConfigs>('app-debug-with-single-or-multiple-models', {})
 
-  const debugWithSingleOrMultipleModelConfigs = useRef<DebugWithSingleOrMultipleModelConfigs>({})
-
-  if (localeDebugWithSingleOrMultipleModelConfigs) {
-    try {
-      debugWithSingleOrMultipleModelConfigs.current = JSON.parse(localeDebugWithSingleOrMultipleModelConfigs) || {}
-    }
-    catch (e) {
-      console.error(e)
-    }
-  }
-
-  const [
-    debugWithMultipleModel,
-    setDebugWithMultipleModel,
-  ] = useState(debugWithSingleOrMultipleModelConfigs.current[appId]?.multiple || false)
-
-  const [
-    multipleModelConfigs,
-    setMultipleModelConfigs,
-  ] = useState(debugWithSingleOrMultipleModelConfigs.current[appId]?.configs || [])
+  const debugWithMultipleModel = debugWithSingleOrMultipleModelConfigs?.[appId]?.multiple || false
+  const multipleModelConfigs = debugWithSingleOrMultipleModelConfigs?.[appId]?.configs || []
 
   const handleMultipleModelConfigsChange = useCallback((
     multiple: boolean,
     modelConfigs: ModelAndParameter[],
   ) => {
-    const value = {
-      multiple,
-      configs: modelConfigs,
-    }
-    debugWithSingleOrMultipleModelConfigs.current[appId] = value
-    localStorage.setItem('app-debug-with-single-or-multiple-models', JSON.stringify(debugWithSingleOrMultipleModelConfigs.current))
-    setDebugWithMultipleModel(value.multiple)
-    setMultipleModelConfigs(value.configs)
-  }, [appId])
+    setDebugWithSingleOrMultipleModelConfigs(prev => ({
+      ...(prev || {}),
+      [appId]: { multiple, configs: modelConfigs },
+    }))
+  }, [appId, setDebugWithSingleOrMultipleModelConfigs])
 
   return {
     debugWithMultipleModel,


### PR DESCRIPTION
Closes #36898

## Summary

Migrate two localStorage keys to use the `useLocalStorage`/`useSetLocalStorage` hooks from `@/hooks/use-local-storage`, replacing direct `localStorage.getItem`/`setItem` calls.

## Changes

### 1. `app-detail-collapse-or-expand` (2 files)

- **`layout-main.tsx`** (read-only): Replaced `localStorage.getItem('app-detail-collapse-or-expand')` with `useLocalStorage<string>('app-detail-collapse-or-expand', 'expand', { raw: true })`. Added `storedAppSidebarMode` to the `useEffect` dependency array for proper reactivity.

- **`app-sidebar/index.tsx`** (write-only): Replaced `localStorage.setItem('app-detail-collapse-or-expand', ...)` with `useSetLocalStorage<string>('app-detail-collapse-or-expand', { raw: true })`. Added the setter to the `useEffect` dependency array.

### 2. `app-debug-with-single-or-multiple-models` (1 file)

- **`debug/hooks.tsx`** (read+write, JSON): Replaced manual `localStorage.getItem` + `JSON.parse` + `useRef` + `useState` + `localStorage.setItem` + `JSON.stringify` pattern with a single `useLocalStorage<DebugWithSingleOrMultipleModelConfigs>('app-debug-with-single-or-multiple-models', {})` call. This handles JSON serialization/deserialization automatically and eliminates the need for `useRef`, `useState`, and manual error handling. The hook is now significantly simpler — values are derived directly from the hook state, and updates use the functional setter pattern.

## Call sites: 3
