### PR TITLE
refactor(api): remove redundant typing.cast calls

### DIFF
--- a/api/core/workflow/generator/runner.py
+++ b/api/core/workflow/generator/runner.py
@@ -434,7 +434,7 @@ class WorkflowGenerator:
             if isinstance(parsed, dict):
                 if attempt > 0:
                     logger.info("Workflow generator: %s JSON parse recovered on retry", stage)
-                return cast(dict[str, Any], parsed)
+                return parsed
             last_detail = f"Non-object JSON: {type(parsed).__name__}"
             logger.info("Workflow generator: %s non-object JSON on attempt %s", stage, attempt + 1)
         raise _StageJSONError(stage, last_detail or "JSON parse failed")

--- a/api/core/workflow/nodes/agent_v2/plugin_tools_builder.py
+++ b/api/core/workflow/nodes/agent_v2/plugin_tools_builder.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, Protocol, cast
+from typing import Any, Protocol
 
 from dify_agent.layers.dify_plugin import (
     DifyPluginCredentialValue,
@@ -197,7 +197,7 @@ class WorkflowAgentPluginToolsBuilder:
             credentials=self._normalize_credentials(runtime.credentials, tool_name=tool_config.tool_name),
             runtime_parameters=runtime_parameters,
             parameters=parameters,
-            parameters_json_schema=cast(dict[str, Any], tool_runtime.get_llm_parameters_json_schema()),
+            parameters_json_schema=tool_runtime.get_llm_parameters_json_schema(),
         )
 
     @staticmethod

--- a/api/enterprise/telemetry/enterprise_trace.py
+++ b/api/enterprise/telemetry/enterprise_trace.py
@@ -720,7 +720,7 @@ class EnterpriseOtelTrace:
 
         docs: list[dict[str, Any]] = []
         documents_any: Any = info.documents
-        documents_list: list[Any] = cast(list[Any], documents_any) if isinstance(documents_any, list) else []
+        documents_list: list[Any] = documents_any if isinstance(documents_any, list) else []
         for entry in documents_list:
             if isinstance(entry, dict):
                 entry_dict: dict[str, Any] = cast(dict[str, Any], entry)

--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -1226,7 +1226,7 @@ class DatasetKeywordTable(TypeBase):
                         items = cast(dict[str, Any], dct).items()
                         for keyword, node_idxs in items:
                             if isinstance(node_idxs, list):
-                                result[keyword] = set(cast(list[Any], node_idxs))
+                                result[keyword] = set(node_idxs)
                             else:
                                 result[keyword] = node_idxs
                         return result

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -1153,7 +1153,7 @@ class Conversation(Base):
                     tenant_resolver=tenant_resolver,
                 )
             elif isinstance(value, list):
-                value_list = cast(list[Any], value)
+                value_list = value
                 if all(
                     isinstance(item, dict)
                     and cast(dict[str, Any], item).get("dify_model_identity") == FILE_MODEL_IDENTITY
@@ -1181,7 +1181,7 @@ class Conversation(Base):
             if isinstance(v, File):
                 inputs[k] = v.model_dump()
             elif isinstance(v, list):
-                v_list = cast(list[Any], v)
+                v_list = v
                 if all(isinstance(item, File) for item in v_list):
                     inputs[k] = [item.model_dump() for item in v_list if isinstance(item, File)]
         self._inputs = inputs
@@ -1495,7 +1495,7 @@ class Message(Base):
                     tenant_resolver=tenant_resolver,
                 )
             elif isinstance(value, list):
-                value_list = cast(list[Any], value)
+                value_list = value
                 if all(
                     isinstance(item, dict)
                     and cast(dict[str, Any], item).get("dify_model_identity") == FILE_MODEL_IDENTITY
@@ -1522,7 +1522,7 @@ class Message(Base):
             if isinstance(v, File):
                 inputs[k] = v.model_dump()
             elif isinstance(v, list):
-                v_list = cast(list[Any], v)
+                v_list = v
                 if all(isinstance(item, File) for item in v_list):
                     inputs[k] = [item.model_dump() for item in v_list if isinstance(item, File)]
         self._inputs = inputs

--- a/api/models/workflow.py
+++ b/api/models/workflow.py
@@ -1688,7 +1688,7 @@ class WorkflowDraftVariable(Base):
                     tenant_id=tenant_id,
                 )
             case list() if value:
-                value_list = cast(list[Any], value)
+                value_list = value
                 first: Any = value_list[0]
                 if not maybe_file_object(first):
                     return cast(Any, value)
@@ -1742,7 +1742,7 @@ class WorkflowDraftVariable(Base):
                 normalized_file.pop("tenant_id", None)
                 return build_file_from_mapping_without_lookup(file_mapping=normalized_file)
             case list() if value:
-                value_list = cast(list[Any], value)
+                value_list = value
                 first: Any = value_list[0]
                 if not maybe_file_object(first):
                     return cast(Any, value)


### PR DESCRIPTION
 #24645

## Summary

Remove 10 redundant `typing.cast()` calls across 6 files in the `api/` directory. All casts were flagged by `pyrefly check` as `redundant-cast` because the inner expression already has the same type as the cast target.

## Changes

| File | Line | Removed cast | Reason |
|------|------|-------------|--------|
| `core/workflow/generator/runner.py` | 437 | `cast(dict[str, Any], parsed)` | `parsed` already typed as `dict[str, Any]` |
| `core/workflow/nodes/agent_v2/plugin_tools_builder.py` | 200 | `cast(dict[str, Any], ...)` | Return type already `dict[str, Any]` |
| `enterprise/telemetry/enterprise_trace.py` | 723 | `cast(list[Any], documents_any)` | After `isinstance` check, already `list[Any]` |
| `models/dataset.py` | 1229 | `cast(list[Any], node_idxs)` | After `isinstance` check, already `list[Any]` |
| `models/model.py` | 1156, 1184, 1498, 1525 | 4x `cast(list[Any], ...)` | After `isinstance` check, already `list[Any]` |
| `models/workflow.py` | 1691, 1745 | 2x `cast(list[Any], ...)` | After `isinstance` check, already `list[Any]` |

**Total: 6 files, 10 cast removals**

## Verification

- All 6 files pass `uv run --project api ruff check` with no new errors
- Removed unused `cast` import from `plugin_tools_builder.py`; other files retain imports for remaining legitimate uses