### PR TITLE
feat: add workspace-level MCP Server for multiple workflow exposure

### DIFF
--- a/api/controllers/mcp/__init__.py
+++ b/api/controllers/mcp/__init__.py
@@ -13,14 +13,19 @@ api = ExternalApi(
 )
 
 mcp_ns = Namespace("mcp", description="MCP operations", path="/")
+workspace_mcp_ns = Namespace("workspace-mcp", description="Workspace-level MCP operations", path="/")
 
 from . import mcp
+from . import workspace_mcp
 
 api.add_namespace(mcp_ns)
+api.add_namespace(workspace_mcp_ns)
 
 __all__ = [
     "api",
     "bp",
     "mcp",
     "mcp_ns",
+    "workspace_mcp",
+    "workspace_mcp_ns",
 ]

--- a/api/controllers/mcp/workspace_mcp.py
+++ b/api/controllers/mcp/workspace_mcp.py
@@ -1,0 +1,191 @@
+"""
+Workspace-level MCP controller.
+
+Provides an HTTP JSON-RPC endpoint that exposes all MCP-enabled apps
+in a workspace as individual MCP tools.
+
+Endpoint: POST /mcp/workspace/<workspace_id>/mcp
+Auth: Bearer <api-token> (Authorization header)
+"""
+
+from typing import Any
+
+from flask import Response, request
+from flask_restx import Resource
+from pydantic import BaseModel, Field, ValidationError
+from sqlalchemy import select
+from werkzeug.exceptions import Forbidden, NotFound, Unauthorized
+
+from controllers.common.schema import register_schema_model
+from controllers.mcp import workspace_mcp_ns
+from core.mcp import types as mcp_types
+from core.mcp.server.workspace_mcp_server import handle_workspace_mcp_request
+from extensions.ext_database import db
+from libs import helper
+from models.model import ApiToken, EndUser, Tenant, TenantStatus
+
+
+class MCPWorkspaceRequestError(Exception):
+    """Custom exception for workspace MCP request processing errors."""
+
+    def __init__(self, error_code: int, message: str):
+        self.error_code = error_code
+        self.message = message
+        super().__init__(message)
+
+
+class MCPWorkspaceRequestPayload(BaseModel):
+    jsonrpc: str = Field(description="JSON-RPC version (should be '2.0')")
+    method: str = Field(description="The method to invoke")
+    params: dict[str, Any] | None = Field(default=None, description="Parameters for the method")
+    id: int | str | None = Field(default=None, description="Request ID for tracking responses")
+
+
+register_schema_model(workspace_mcp_ns, MCPWorkspaceRequestPayload)
+
+
+def _validate_bearer_token() -> ApiToken:
+    """Extract and validate Bearer token from Authorization header."""
+    auth_header = request.headers.get("Authorization")
+    if not auth_header or " " not in auth_header:
+        raise Unauthorized("Authorization header must be provided and start with 'Bearer'")
+
+    auth_scheme, auth_token = auth_header.split(None, 1)
+    if auth_scheme.lower() != "bearer":
+        raise Unauthorized("Authorization scheme must be 'Bearer'")
+
+    api_token = db.session.scalar(
+        select(ApiToken).where(ApiToken.token == auth_token).limit(1)
+    )
+    if not api_token:
+        raise Unauthorized("Invalid API token")
+
+    return api_token
+
+
+def _validate_workspace_access(api_token: ApiToken, workspace_id: str) -> Tenant:
+    """Validate that the API token has access to the specified workspace."""
+    if api_token.tenant_id and api_token.tenant_id == workspace_id:
+        tenant = db.session.get(Tenant, workspace_id)
+    else:
+        raise Forbidden("API token does not have access to this workspace")
+
+    if not tenant:
+        raise NotFound("Workspace not found")
+    if tenant.status == TenantStatus.ARCHIVE:
+        raise Forbidden("The workspace's status is archived")
+
+    return tenant
+
+
+def _create_or_get_end_user(tenant_id: str, app_id: str) -> EndUser:
+    """Create or retrieve an MCP end user for the given tenant/app."""
+    end_user = db.session.scalar(
+        select(EndUser)
+        .where(EndUser.tenant_id == tenant_id)
+        .where(EndUser.session_id == tenant_id)
+        .where(EndUser.type == "mcp")
+        .limit(1)
+    )
+    if not end_user:
+        end_user = EndUser(
+            tenant_id=tenant_id,
+            app_id=app_id,
+            type="mcp",
+            name="mcp-workspace-client",
+            session_id=tenant_id,
+        )
+        db.session.add(end_user)
+        db.session.flush()
+        db.session.refresh(end_user)
+    return end_user
+
+
+@workspace_mcp_ns.route("/workspace/<string:workspace_id>/mcp")
+class MCPWorkspaceApi(Resource):
+    @workspace_mcp_ns.expect(workspace_mcp_ns.models[MCPWorkspaceRequestPayload.__name__])
+    @workspace_mcp_ns.doc("handle_workspace_mcp_request")
+    @workspace_mcp_ns.doc(description="Handle MCP requests at the workspace level")
+    @workspace_mcp_ns.doc(params={"workspace_id": "Workspace (tenant) ID"})
+    @workspace_mcp_ns.doc(
+        responses={
+            200: "MCP response successfully processed",
+            400: "Invalid MCP request or parameters",
+            401: "Invalid or missing API token",
+            403: "API token does not have workspace access",
+            404: "Workspace not found",
+        }
+    )
+    def post(self, workspace_id: str):
+        """
+        Handle MCP JSON-RPC requests at the workspace level.
+
+        Exposes all MCP-enabled apps in a workspace as individual MCP tools,
+        allowing MCP clients to discover and call multiple workflows from
+        a single endpoint.
+
+        Auth: Requires a valid Dify API token in the Authorization header
+              as a Bearer token.
+        """
+        # 1. Validate auth
+        api_token = _validate_bearer_token()
+
+        # 2. Validate workspace access
+        tenant = _validate_workspace_access(api_token, workspace_id)
+
+        # 3. Parse the JSON-RPC payload
+        try:
+            payload = MCPWorkspaceRequestPayload.model_validate(workspace_mcp_ns.payload or {})
+        except ValidationError:
+            raise MCPWorkspaceRequestError(
+                mcp_types.INVALID_REQUEST,
+                "Invalid MCP request format",
+            )
+
+        request_id = payload.id
+        args = payload.model_dump(exclude_none=True)
+
+        # 4. Parse into MCP types
+        try:
+            mcp_request = mcp_types.ClientRequest.model_validate(args)
+        except ValidationError:
+            try:
+                mcp_notification = mcp_types.ClientNotification.model_validate(args)
+                if mcp_notification.root.method != "notifications/initialized":
+                    raise MCPWorkspaceRequestError(
+                        mcp_types.INVALID_REQUEST,
+                        "Invalid notification method",
+                    )
+                return Response("", status=202, content_type="application/json")
+            except ValidationError as e:
+                raise MCPWorkspaceRequestError(
+                    mcp_types.INVALID_PARAMS,
+                    f"Invalid MCP request: {e}",
+                )
+
+        if request_id is None:
+            raise MCPWorkspaceRequestError(
+                mcp_types.INVALID_REQUEST,
+                "Request ID is required",
+            )
+
+        # 5. Get or create end user for the workspace
+        end_user = _create_or_get_end_user(tenant.id, tenant.id)
+
+        # 6. Handle the MCP request
+        result = handle_workspace_mcp_request(
+            workspace_id=workspace_id,
+            request=mcp_request,
+            end_user=end_user,
+            request_id=request_id,
+        )
+
+        if result is None:
+            raise MCPWorkspaceRequestError(
+                mcp_types.INTERNAL_ERROR,
+                "No response generated for request",
+            )
+
+        return helper.compact_generate_response(
+            result.model_dump(by_alias=True, mode="json", exclude_none=True)
+        )

--- a/api/core/mcp/server/workspace_mcp_server.py
+++ b/api/core/mcp/server/workspace_mcp_server.py
@@ -1,0 +1,374 @@
+"""
+Workspace-level MCP server that exposes multiple Dify workflows/tools
+as individual MCP tools from a single endpoint.
+
+This handler supports:
+- tools/list: Returns all published apps/workflows in the workspace as MCP tools
+- tools/call: Routes execution to the specific app identified by tool name
+- initialize: Returns workspace-level server capabilities
+- ping: Health check
+"""
+
+import json
+import logging
+from collections.abc import Mapping
+from typing import Any, cast
+
+from sqlalchemy import select
+
+from configs import dify_config
+from core.app.entities.app_invoke_entities import InvokeFrom
+from core.app.features.rate_limiting.rate_limit import RateLimitGenerator
+from core.mcp import types as mcp_types
+from extensions.ext_database import db
+from graphon.variables.input_entities import VariableEntity, VariableEntityType
+from models.enums import AppMCPServerStatus, AppMode
+from models.model import App, AppMCPServer, EndUser
+from services.app_generate_service import AppGenerateService
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def handle_workspace_mcp_request(
+    workspace_id: str,
+    request: mcp_types.ClientRequest,
+    end_user: EndUser | None = None,
+    request_id: int | str = 1,
+) -> mcp_types.JSONRPCResponse | mcp_types.JSONRPCError:
+    """
+    Handle an MCP JSON-RPC request at the workspace level.
+
+    Args:
+        workspace_id: The tenant/workspace ID.
+        request: The parsed JSON-RPC ClientRequest.
+        end_user: Optional end user for tool calls.
+        request_id: The JSON-RPC request ID.
+
+    Returns:
+        A JSONRPCResponse or JSONRPCError.
+    """
+
+    request_root = request.root
+
+    def _ok(result_data: mcp_types.Result) -> mcp_types.JSONRPCResponse:
+        return mcp_types.JSONRPCResponse(
+            jsonrpc="2.0",
+            id=request_id,
+            result=result_data.model_dump(by_alias=True, mode="json", exclude_none=True),
+        )
+
+    def _err(code: int, message: str) -> mcp_types.JSONRPCError:
+        from core.mcp.types import ErrorData
+
+        return mcp_types.JSONRPCError(
+            jsonrpc="2.0",
+            id=request_id,
+            error=ErrorData(code=code, message=message),
+        )
+
+    try:
+        match request_root:
+            case mcp_types.InitializeRequest():
+                return _ok(_handle_initialize())
+            case mcp_types.ListToolsRequest():
+                return _ok(_handle_list_tools(workspace_id))
+            case mcp_types.CallToolRequest():
+                return _ok(_handle_call_tool(workspace_id, request, end_user))
+            case mcp_types.PingRequest():
+                return _ok(mcp_types.EmptyResult())
+            case _:
+                return _err(
+                    mcp_types.METHOD_NOT_FOUND,
+                    f"Method not found: {type(request_root).__name__}",
+                )
+    except ValueError as e:
+        logger.exception("Invalid params in workspace MCP handler")
+        return _err(mcp_types.INVALID_PARAMS, str(e))
+    except Exception as e:
+        logger.exception("Internal error in workspace MCP handler")
+        return _err(mcp_types.INTERNAL_ERROR, f"Internal server error: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Initialize
+# ---------------------------------------------------------------------------
+
+
+def _handle_initialize() -> mcp_types.InitializeResult:
+    capabilities = mcp_types.ServerCapabilities(
+        tools=mcp_types.ToolsCapability(listChanged=False),
+    )
+    return mcp_types.InitializeResult(
+        protocolVersion=mcp_types.SERVER_LATEST_PROTOCOL_VERSION,
+        capabilities=capabilities,
+        serverInfo=mcp_types.Implementation(name="Dify Workspace", version=dify_config.project.version),
+        instructions="Workspace-level MCP server for Dify. Use tools/list to discover available workflows.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# tools/list — enumerate every active MCP-enabled app in the workspace
+# ---------------------------------------------------------------------------
+
+
+def _handle_list_tools(workspace_id: str) -> mcp_types.ListToolsResult:
+    """Return every active MCP server in the workspace as an individual tool."""
+    servers = (
+        db.session.execute(
+            select(AppMCPServer, App)
+            .join(App, App.id == AppMCPServer.app_id)
+            .where(
+                AppMCPServer.tenant_id == workspace_id,
+                AppMCPServer.status == AppMCPServerStatus.ACTIVE,
+                App.status == "normal",
+            )
+        )
+        .all()
+    )
+
+    tools: list[mcp_types.Tool] = []
+    for server, app in servers:
+        user_input_form = _get_app_user_input_form(app)
+        schema = _build_tool_schema(app, user_input_form, server.parameters_dict)
+        tool_name = _sanitize_tool_name(app.name)
+
+        tools.append(
+            mcp_types.Tool(
+                name=tool_name,
+                title=app.name,
+                description=server.description or app.description or "",
+                inputSchema=cast(dict[str, Any], schema),
+            )
+        )
+
+    return mcp_types.ListToolsResult(tools=tools)
+
+
+# ---------------------------------------------------------------------------
+# tools/call — route to the correct app
+# ---------------------------------------------------------------------------
+
+
+def _handle_call_tool(
+    workspace_id: str,
+    request: mcp_types.ClientRequest,
+    end_user: EndUser | None,
+) -> mcp_types.CallToolResult:
+    call_request = cast(mcp_types.CallToolRequest, request.root)
+    tool_name = call_request.params.name
+    arguments = call_request.params.arguments or {}
+
+    # Find the matching app in the workspace
+    app = _find_app_by_tool_name(workspace_id, tool_name)
+    if app is None:
+        raise ValueError(f"Tool not found: {tool_name}")
+
+    if not end_user:
+        raise ValueError("End user is required for tool execution")
+
+    # Prepare arguments based on app mode
+    args = _prepare_tool_arguments(app, arguments)
+
+    response = AppGenerateService.generate(
+        app,
+        end_user,
+        args,
+        InvokeFrom.SERVICE_API,
+        streaming=app.mode == AppMode.AGENT_CHAT,
+    )
+
+    answer = _extract_answer(app, response)
+    return mcp_types.CallToolResult(
+        content=[mcp_types.TextContent(text=answer, type="text")]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_app_by_tool_name(workspace_id: str, tool_name: str) -> App | None:
+    """
+    Find an app in the workspace whose sanitized name matches *tool_name*.
+    We also match by the raw app name for backward compatibility.
+    """
+    servers = (
+        db.session.execute(
+            select(AppMCPServer, App)
+            .join(App, App.id == AppMCPServer.app_id)
+            .where(
+                AppMCPServer.tenant_id == workspace_id,
+                AppMCPServer.status == AppMCPServerStatus.ACTIVE,
+                App.status == "normal",
+            )
+        )
+        .all()
+    )
+
+    for _server, app in servers:
+        if _sanitize_tool_name(app.name) == tool_name or app.name == tool_name:
+            return app
+    return None
+
+
+def _sanitize_tool_name(name: str) -> str:
+    """
+    Convert an app name to a valid MCP tool name.
+    MCP tool names should be lowercase, alphanumeric with underscores/hyphens.
+    """
+    sanitized = ""
+    for ch in name.strip().lower():
+        if ch.isalnum() or ch in ("_", "-"):
+            sanitized += ch
+        elif ch == " ":
+            sanitized += "_"
+        else:
+            sanitized += "_"
+    # Collapse repeated underscores
+    while "__" in sanitized:
+        sanitized = sanitized.replace("__", "_")
+    return sanitized.strip("_") or "unnamed_tool"
+
+
+def _get_app_user_input_form(app: App) -> list[VariableEntity]:
+    """Extract user input form variables from an app."""
+    if app.mode in {AppMode.ADVANCED_CHAT, AppMode.WORKFLOW}:
+        if not app.workflow:
+            return []
+        raw = app.workflow.user_input_form(to_old_structure=True)
+    else:
+        if not app.app_model_config:
+            return []
+        raw = app.app_model_config.to_dict().get("user_input_form", [])
+
+    entities: list[VariableEntity] = []
+    for item in raw:
+        variable_type_raw: str = item.get("type", "") or list(item.keys())[0]
+        try:
+            variable_type = VariableEntityType(variable_type_raw)
+        except ValueError:
+            continue
+        variable = item[variable_type_raw]
+        entities.append(
+            VariableEntity(
+                type=variable_type,
+                variable=variable.get("variable"),
+                description=variable.get("description") or "",
+                label=variable.get("label"),
+                required=variable.get("required", False),
+                max_length=variable.get("max_length"),
+                options=variable.get("options") or [],
+                json_schema=variable.get("json_schema"),
+            )
+        )
+    return entities
+
+
+def _build_tool_schema(
+    app: App,
+    user_input_form: list[VariableEntity],
+    parameters_dict: dict[str, str],
+) -> dict[str, Any]:
+    """Build JSON Schema for a tool's input parameters."""
+    properties: dict[str, dict[str, Any]] = {}
+    required: list[str] = []
+
+    for item in user_input_form:
+        if item.type in (
+            VariableEntityType.FILE,
+            VariableEntityType.FILE_LIST,
+            VariableEntityType.EXTERNAL_DATA_TOOL,
+        ):
+            continue
+
+        properties[item.variable] = {}
+        if item.required:
+            required.append(item.variable)
+
+        desc = parameters_dict.get(item.variable, item.description or "")
+        properties[item.variable]["description"] = desc
+
+        if item.type in (VariableEntityType.TEXT_INPUT, VariableEntityType.PARAGRAPH):
+            properties[item.variable]["type"] = "string"
+        elif item.type == VariableEntityType.SELECT:
+            properties[item.variable]["type"] = "string"
+            properties[item.variable]["enum"] = item.options
+        elif item.type == VariableEntityType.NUMBER:
+            properties[item.variable]["type"] = "number"
+        elif item.type == VariableEntityType.CHECKBOX:
+            properties[item.variable]["type"] = "boolean"
+        elif item.type == VariableEntityType.JSON_OBJECT:
+            properties[item.variable]["type"] = "object"
+            if item.json_schema:
+                for key in ("properties", "required", "additionalProperties"):
+                    if key in item.json_schema:
+                        properties[item.variable][key] = item.json_schema[key]
+
+    if app.mode in {AppMode.COMPLETION, AppMode.WORKFLOW}:
+        return {
+            "type": "object",
+            "properties": properties,
+            "required": required,
+        }
+    else:
+        return {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "User Input/Question content"},
+                **properties,
+            },
+            "required": ["query", *required],
+        }
+
+
+def _prepare_tool_arguments(app: App, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Prepare arguments for app generation based on app mode."""
+    mode = app.mode
+    if mode == AppMode.WORKFLOW:
+        return {"inputs": arguments}
+    elif mode == AppMode.COMPLETION:
+        return {"query": "", "inputs": arguments}
+    else:
+        args_copy = arguments.copy()
+        query = args_copy.pop("query", "")
+        return {"query": query, "inputs": args_copy}
+
+
+def _extract_answer(app: App, response: Any) -> str:
+    """Extract the answer text from an app generation response."""
+    if isinstance(response, RateLimitGenerator):
+        return _process_streaming(response)
+    elif isinstance(response, Mapping):
+        return _process_mapping(app, response)
+    else:
+        logger.warning("Unexpected response type: %s", type(response))
+        return ""
+
+
+def _process_streaming(response: RateLimitGenerator) -> str:
+    answer = ""
+    for item in response.generator:
+        if isinstance(item, str) and item.startswith("data: "):
+            try:
+                json_str = item[6:].strip()
+                parsed = json.loads(json_str)
+                if parsed.get("event") == "agent_thought":
+                    answer += parsed.get("thought", "")
+            except json.JSONDecodeError:
+                continue
+    return answer
+
+
+def _process_mapping(app: App, response: Mapping) -> str:
+    mode = app.mode
+    if mode in {AppMode.ADVANCED_CHAT, AppMode.COMPLETION, AppMode.CHAT, AppMode.AGENT_CHAT}:
+        return response.get("answer", "")
+    elif mode == AppMode.WORKFLOW:
+        return json.dumps(response["data"]["outputs"], ensure_ascii=False)
+    else:
+        raise ValueError(f"Invalid app mode: {mode}")

--- a/api/tests/unit_tests/controllers/mcp/__init__.py
+++ b/api/tests/unit_tests/controllers/mcp/__init__.py
@@ -1,0 +1,1 @@
+# Unit tests for MCP controllers

--- a/api/tests/unit_tests/controllers/mcp/test_workspace_mcp.py
+++ b/api/tests/unit_tests/controllers/mcp/test_workspace_mcp.py
@@ -1,0 +1,289 @@
+"""Unit tests for workspace-level MCP server."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from core.mcp import types as mcp_types
+
+TENANT_ID = str(uuid4())
+APP_ID = str(uuid4())
+
+
+class TestSanitizeToolName:
+    """Tests for the _sanitize_tool_name helper."""
+
+    def test_lowercase_and_underscore(self):
+        from core.mcp.server.workspace_mcp_server import _sanitize_tool_name
+
+        assert _sanitize_tool_name("Hello World") == "hello_world"
+
+    def test_special_characters(self):
+        from core.mcp.server.workspace_mcp_server import _sanitize_tool_name
+
+        assert _sanitize_tool_name("My App!@#") == "my_app"
+
+    def test_multiple_spaces(self):
+        from core.mcp.server.workspace_mcp_server import _sanitize_tool_name
+
+        assert _sanitize_tool_name("  My   App  ") == "my_app"
+
+    def test_empty_name(self):
+        from core.mcp.server.workspace_mcp_server import _sanitize_tool_name
+
+        assert _sanitize_tool_name("") == "unnamed_tool"
+
+    def test_only_special_chars(self):
+        from core.mcp.server.workspace_mcp_server import _sanitize_tool_name
+
+        assert _sanitize_tool_name("!@#$%") == "unnamed_tool"
+
+    def test_alphanumeric(self):
+        from core.mcp.server.workspace_mcp_server import _sanitize_tool_name
+
+        assert _sanitize_tool_name("myTool123") == "mytool123"
+
+    def test_collapse_double_underscores(self):
+        from core.mcp.server.workspace_mcp_server import _sanitize_tool_name
+
+        assert _sanitize_tool_name("a!@#b") == "a_b"
+
+
+class TestHandleInitialize:
+    """Tests for the workspace-level initialize handler."""
+
+    def test_returns_correct_protocol_version(self):
+        from core.mcp.server.workspace_mcp_server import _handle_initialize
+
+        result = _handle_initialize()
+        assert result.protocolVersion == mcp_types.SERVER_LATEST_PROTOCOL_VERSION
+        assert result.serverInfo.name == "Dify Workspace"
+        assert result.capabilities.tools is not None
+        assert result.capabilities.tools.listChanged is False
+
+
+class TestHandlePing:
+    """Tests for ping handling via the main entry point."""
+
+    def test_ping_returns_empty_result(self):
+        from core.mcp.server.workspace_mcp_server import handle_workspace_mcp_request
+
+        ping_request = mcp_types.ClientRequest(
+            root=mcp_types.PingRequest(method="ping", params=None)
+        )
+        result = handle_workspace_mcp_request(TENANT_ID, ping_request, request_id=1)
+        assert result.jsonrpc == "2.0"
+        assert result.id == 1
+        assert "result" in result.model_dump()
+
+
+class TestHandleListTools:
+    """Tests for workspace-level tools/list."""
+
+    @patch("core.mcp.server.workspace_mcp_server.db")
+    def test_returns_tools_for_active_servers(self, mock_db):
+        from core.mcp.server.workspace_mcp_server import _handle_list_tools
+        from models.enums import AppMCPServerStatus, AppMode
+
+        mock_server = MagicMock()
+        mock_server.tenant_id = TENANT_ID
+        mock_server.status = AppMCPServerStatus.ACTIVE
+        mock_server.description = "A test app"
+        mock_server.parameters = json.dumps({})
+        mock_server.parameters_dict = {}
+
+        mock_app = MagicMock()
+        mock_app.id = APP_ID
+        mock_app.name = "Test App"
+        mock_app.description = "A test description"
+        mock_app.mode = AppMode.WORKFLOW
+        mock_app.status = "normal"
+        mock_app.workflow = MagicMock()
+        mock_app.workflow.user_input_form.return_value = []
+
+        mock_result = MagicMock()
+        mock_result.all.return_value = [(mock_server, mock_app)]
+        mock_db.session.execute.return_value = mock_result
+
+        result = _handle_list_tools(TENANT_ID)
+        assert isinstance(result, mcp_types.ListToolsResult)
+        assert len(result.tools) == 1
+        assert result.tools[0].name == "test_app"
+        assert result.tools[0].description == "A test app"
+
+    @patch("core.mcp.server.workspace_mcp_server.db")
+    def test_returns_empty_when_no_servers(self, mock_db):
+        from core.mcp.server.workspace_mcp_server import _handle_list_tools
+
+        mock_result = MagicMock()
+        mock_result.all.return_value = []
+        mock_db.session.execute.return_value = mock_result
+
+        result = _handle_list_tools(TENANT_ID)
+        assert isinstance(result, mcp_types.ListToolsResult)
+        assert len(result.tools) == 0
+
+
+class TestHandleCallTool:
+    """Tests for workspace-level tools/call."""
+
+    @patch("core.mcp.server.workspace_mcp_server.AppGenerateService")
+    @patch("core.mcp.server.workspace_mcp_server.db")
+    @patch("core.mcp.server.workspace_mcp_server._find_app_by_tool_name")
+    def test_calls_correct_app(self, mock_find, mock_db, mock_gen_service):
+        from core.mcp.server.workspace_mcp_server import _handle_call_tool
+        from models.enums import AppMode
+
+        mock_app = MagicMock()
+        mock_app.id = APP_ID
+        mock_app.name = "Test App"
+        mock_app.mode = AppMode.WORKFLOW
+        mock_find.return_value = mock_app
+
+        mock_end_user = MagicMock()
+        mock_end_user.id = "end-user-1"
+
+        mock_gen_service.generate.return_value = {"data": {"outputs": {"result": "ok"}}}
+
+        call_request = mcp_types.ClientRequest(
+            root=mcp_types.CallToolRequest(
+                method="tools/call",
+                params=mcp_types.CallToolRequestParams(
+                    name="test_app",
+                    arguments={"input1": "value1"},
+                ),
+            )
+        )
+
+        result = _handle_call_tool(TENANT_ID, call_request, mock_end_user)
+
+        assert isinstance(result, mcp_types.CallToolResult)
+        assert len(result.content) > 0
+        assert result.content[0].type == "text"
+
+    @patch("core.mcp.server.workspace_mcp_server._find_app_by_tool_name")
+    def test_raises_when_tool_not_found(self, mock_find):
+        from core.mcp.server.workspace_mcp_server import _handle_call_tool
+
+        mock_find.return_value = None
+
+        call_request = mcp_types.ClientRequest(
+            root=mcp_types.CallToolRequest(
+                method="tools/call",
+                params=mcp_types.CallToolRequestParams(
+                    name="nonexistent",
+                    arguments={},
+                ),
+            )
+        )
+
+        with pytest.raises(ValueError, match="Tool not found"):
+            _handle_call_tool(TENANT_ID, call_request, None)
+
+    @patch("core.mcp.server.workspace_mcp_server._find_app_by_tool_name")
+    def test_raises_when_no_end_user(self, mock_find):
+        from core.mcp.server.workspace_mcp_server import _handle_call_tool
+
+        mock_app = MagicMock()
+        mock_find.return_value = mock_app
+
+        call_request = mcp_types.ClientRequest(
+            root=mcp_types.CallToolRequest(
+                method="tools/call",
+                params=mcp_types.CallToolRequestParams(
+                    name="test_app",
+                    arguments={},
+                ),
+            )
+        )
+
+        with pytest.raises(ValueError, match="End user is required"):
+            _handle_call_tool(TENANT_ID, call_request, None)
+
+
+class TestHandleUnknownMethod:
+    """Tests for unknown method handling."""
+
+    def test_returns_method_not_found_error(self):
+        from core.mcp.server.workspace_mcp_server import handle_workspace_mcp_request
+
+        unknown_request = mcp_types.JSONRPCRequest(
+            jsonrpc="2.0",
+            id=1,
+            method="unknown/method",
+            params={},
+        )
+        client_req = mcp_types.ClientRequest(root=unknown_request)
+
+        result = handle_workspace_mcp_request(TENANT_ID, client_req, request_id=1)
+        assert result.jsonrpc == "2.0"
+        assert result.id == 1
+        result_dict = result.model_dump()
+        assert "error" in result_dict
+        assert result_dict["error"]["code"] == mcp_types.METHOD_NOT_FOUND
+
+
+class TestBuildToolSchema:
+    """Tests for the tool schema builder."""
+
+    def test_builds_workflow_schema(self):
+        from core.mcp.server.workspace_mcp_server import _build_tool_schema
+        from models.enums import AppMode
+
+        mock_app = MagicMock()
+        mock_app.mode = AppMode.WORKFLOW
+
+        schema = _build_tool_schema(mock_app, [], {})
+        assert schema["type"] == "object"
+        assert "properties" in schema
+        assert "required" in schema
+
+    def test_builds_chat_schema_with_query(self):
+        from core.mcp.server.workspace_mcp_server import _build_tool_schema
+        from models.enums import AppMode
+
+        mock_app = MagicMock()
+        mock_app.mode = AppMode.CHAT
+
+        schema = _build_tool_schema(mock_app, [], {})
+        assert schema["type"] == "object"
+        assert "query" in schema["properties"]
+        assert "query" in schema["required"]
+
+
+class TestPrepareToolArguments:
+    """Tests for argument preparation."""
+
+    def test_workflow_mode(self):
+        from core.mcp.server.workspace_mcp_server import _prepare_tool_arguments
+        from models.enums import AppMode
+
+        mock_app = MagicMock()
+        mock_app.mode = AppMode.WORKFLOW
+
+        args = _prepare_tool_arguments(mock_app, {"key": "value"})
+        assert args == {"inputs": {"key": "value"}}
+
+    def test_chat_mode(self):
+        from core.mcp.server.workspace_mcp_server import _prepare_tool_arguments
+        from models.enums import AppMode
+
+        mock_app = MagicMock()
+        mock_app.mode = AppMode.CHAT
+
+        args = _prepare_tool_arguments(mock_app, {"query": "hello", "key": "value"})
+        assert args == {"query": "hello", "inputs": {"key": "value"}}
+
+    def test_completion_mode(self):
+        from core.mcp.server.workspace_mcp_server import _prepare_tool_arguments
+        from models.enums import AppMode
+
+        mock_app = MagicMock()
+        mock_app.mode = AppMode.COMPLETION
+
+        args = _prepare_tool_arguments(mock_app, {"key": "value"})
+        assert args == {"query": "", "inputs": {"key": "value"}}


### PR DESCRIPTION
## Summary

Implements the workspace-level Model Context Protocol (MCP) server endpoint for Dify, allowing all MCP-enabled apps/workflows in a workspace to be exposed as individual MCP tools from a single endpoint.

Closes #36967

## Changes

### New files
- **`api/core/mcp/server/workspace_mcp_server.py`** — Core MCP handler for workspace-level protocol operations
  - `tools/list`: Returns all active MCP-enabled apps in a workspace as individual MCP tools with auto-generated JSON schemas
  - `tools/call`: Routes tool calls to the correct Dify app/workflow based on tool name
  - `initialize`: Returns workspace-level server capabilities
  - `ping`: Health check
  
- **`api/controllers/mcp/workspace_mcp.py`** — Flask REST controller
  - Endpoint: `POST /mcp/workspace/<workspace_id>/mcp`
  - Authentication via Bearer token (existing Dify API tokens)
  - Workspace access validation
  - Automatic end user creation for MCP clients
  
- **`api/tests/unit_tests/controllers/mcp/test_workspace_mcp.py`** — Unit tests covering:
  - Tool name sanitization
  - Initialize handler
  - Ping handler
  - tools/list (with and without servers)
  - tools/call (success, tool-not-found, missing-end-user)
  - Unknown method handling
  - Tool schema building
  - Argument preparation for different app modes

### Modified files
- **`api/controllers/mcp/__init__.py`** — Registered the new workspace MCP namespace and imported the workspace_mcp module

## Architecture

This feature complements the existing per-app MCP server (`/mcp/server/<server_code>/mcp`) with a workspace-level endpoint. While the per-app server exposes a single workflow as one tool, the workspace-level server exposes ALL MCP-enabled apps in a workspace as individual tools, enabling MCP clients to discover and invoke multiple workflows from a single endpoint.

### MCP Protocol Flow
1. Client sends `initialize` → Server responds with capabilities and server info
2. Client sends `tools/list` → Server returns all active apps as MCP tools with JSON schemas derived from workflow input forms
3. Client sends `tools/call` with tool name and arguments → Server routes to the correct app, executes the workflow, and returns results

### Authentication
- Uses the existing Dify API token system
- Bearer token in Authorization header
- Validates workspace access
- Creates an MCP-type EndUser for tracking

## Testing

Unit tests are provided for all core functions. The code follows the same patterns and conventions as the existing per-app MCP server implementation.

