### PR TITLE
fix(api): skip uuidv7() creation when PostgreSQL 18 provides it natively

### DIFF
--- a/api/migrations/versions/2025_07_02_2332-1c9ba48be8e4_add_uuidv7_function_in_sql.py
+++ b/api/migrations/versions/2025_07_02_2332-1c9ba48be8e4_add_uuidv7_function_in_sql.py
@@ -45,10 +45,22 @@ def upgrade():
     # PostgreSQL 18's `uuidv7` function. This capability is rarely needed in practice, as IDs can be
     # generated and controlled within the application layer.
     conn = op.get_bind()
-    
+
     if _is_pg(conn):
-        # PostgreSQL: Create uuidv7 functions
-        op.execute(sa.text(r"""
+        # PostgreSQL 18 ships a native pg_catalog.uuidv7(), so only create our own
+        # when the server does not already provide one.  In Alembic offline mode
+        # conn.execute returns None, so we default to creating the function (which
+        # is the safe conservative choice for SQL output generation).
+        result = conn.execute(sa.text(
+            "SELECT 1 FROM pg_proc p "
+            "JOIN pg_namespace n ON p.pronamespace = n.oid "
+            "WHERE p.proname = 'uuidv7' AND n.nspname = 'pg_catalog'"
+        ))
+        has_native = result is not None and result.scalar() == 1
+
+        if not has_native:
+            # PostgreSQL: Create uuidv7 function
+            op.execute(sa.text(r"""
 /* Main function to generate a uuidv7 value with millisecond precision */
 CREATE FUNCTION uuidv7() RETURNS uuid
 AS
@@ -71,6 +83,8 @@ COMMENT ON FUNCTION uuidv7 IS
     'Generate a uuid-v7 value with a 48-bit timestamp (millisecond precision) and 74 bits of randomness';
 """))
 
+        # uuidv7_boundary(timestamptz) is not provided by PostgreSQL 18,
+        # so it is always created.
         op.execute(sa.text(r"""
 CREATE FUNCTION uuidv7_boundary(timestamptz) RETURNS uuid
 AS
@@ -93,9 +107,13 @@ COMMENT ON FUNCTION uuidv7_boundary(timestamptz) IS
 
 def downgrade():
     conn = op.get_bind()
-    
+
     if _is_pg(conn):
-        op.execute(sa.text("DROP FUNCTION uuidv7"))
-        op.execute(sa.text("DROP FUNCTION uuidv7_boundary"))
+        # IF EXISTS keeps the downgrade a no-op on PostgreSQL 18, where the
+        # native pg_catalog.uuidv7() was kept and no public.uuidv7() was
+        # created. Scoping the drop to the public schema avoids touching the
+        # built-in.
+        op.execute(sa.text("DROP FUNCTION IF EXISTS public.uuidv7()"))
+        op.execute(sa.text("DROP FUNCTION IF EXISTS public.uuidv7_boundary(timestamptz)"))
     else:
         pass

--- a/api/tests/unit_tests/migrations/test_uuidv7_pg18_migration.py
+++ b/api/tests/unit_tests/migrations/test_uuidv7_pg18_migration.py
@@ -1,0 +1,137 @@
+"""Tests for the uuidv7 SQL migration's PostgreSQL 18 compatibility guard.
+
+The migration file name is not a valid Python identifier (it starts with a date and
+contains hyphens), so it is loaded directly from its path. The ``models`` import at the
+top of the migration is stubbed because the migration never uses it during
+``upgrade()``/``downgrade()`` and pulling in the real package would require a full app
+context.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "migrations"
+    / "versions"
+    / "2025_07_02_2332-1c9ba48be8e4_add_uuidv7_function_in_sql.py"
+)
+
+
+def _load_migration():
+    # The migration does `import models as models` but never references it, so a stub is
+    # enough and keeps the test free of any database/app configuration.
+    sys.modules.setdefault("models", types.ModuleType("models"))
+    spec = importlib.util.spec_from_file_location("uuidv7_pg18_migration_under_test", MIGRATION_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_sentinel = object()
+
+
+def _make_bind(dialect_name, scalar_return=_sentinel, execute_return=_sentinel):
+    """Create a mock bind.
+
+    When ``execute_return`` is set, ``conn.execute()`` returns that value (e.g. None for
+    Alembic offline mode). When ``scalar_return`` is set and ``execute_return`` is left
+    at the sentinel, ``conn.execute()`` returns a mock whose ``.scalar()`` returns
+    ``scalar_return``.
+    """
+    bind = mock.MagicMock()
+    bind.dialect.name = dialect_name
+    if execute_return is not _sentinel:
+        bind.execute.return_value = execute_return
+    elif scalar_return is not _sentinel:
+        bind.execute.return_value.scalar.return_value = scalar_return
+    return bind
+
+
+def _executed_sql(fake_op):
+    return [str(call.args[0]) for call in fake_op.execute.call_args_list]
+
+
+@pytest.fixture
+def migration():
+    return _load_migration()
+
+
+def test_upgrade_creates_both_functions_when_native_uuidv7_absent(migration):
+    # PostgreSQL 13 to 17: no native pg_catalog.uuidv7(), so both functions are created.
+    bind = _make_bind("postgresql", scalar_return=None)
+    with mock.patch.object(migration, "op") as fake_op:
+        fake_op.get_bind.return_value = bind
+        migration.upgrade()
+
+    sql = _executed_sql(fake_op)
+    assert any("CREATE FUNCTION uuidv7()" in stmt for stmt in sql)
+    assert any("CREATE FUNCTION uuidv7_boundary(timestamptz)" in stmt for stmt in sql)
+
+
+def test_upgrade_skips_uuidv7_but_keeps_boundary_when_native_present(migration):
+    # PostgreSQL 18: native pg_catalog.uuidv7() exists, so we must not recreate it, but
+    # uuidv7_boundary is still missing and has to be created unconditionally.
+    bind = _make_bind("postgresql", scalar_return=1)
+    with mock.patch.object(migration, "op") as fake_op:
+        fake_op.get_bind.return_value = bind
+        migration.upgrade()
+
+    sql = _executed_sql(fake_op)
+    assert not any("CREATE FUNCTION uuidv7()" in stmt for stmt in sql)
+    assert any("CREATE FUNCTION uuidv7_boundary(timestamptz)" in stmt for stmt in sql)
+
+    # The presence check must look up uuidv7 in the pg_catalog schema.
+    probe_sql = str(bind.execute.call_args.args[0])
+    assert "pg_catalog" in probe_sql
+    assert "uuidv7" in probe_sql
+
+
+def test_upgrade_handles_offline_mode_where_execute_returns_none(migration):
+    # Alembic offline mode: conn.execute() may return None because there is no real
+    # database connection. The guard must not crash and should default to creating
+    # the function (safe for SQL output generation).
+    bind = _make_bind("postgresql", execute_return=None)
+    with mock.patch.object(migration, "op") as fake_op:
+        fake_op.get_bind.return_value = bind
+        migration.upgrade()
+
+    # In offline mode we conservatively create uuidv7() since we cannot probe.
+    sql = _executed_sql(fake_op)
+    assert any("CREATE FUNCTION uuidv7()" in stmt for stmt in sql)
+    assert any("CREATE FUNCTION uuidv7_boundary(timestamptz)" in stmt for stmt in sql)
+
+
+def test_upgrade_is_noop_on_non_postgres(migration):
+    bind = _make_bind("sqlite")
+    with mock.patch.object(migration, "op") as fake_op:
+        fake_op.get_bind.return_value = bind
+        migration.upgrade()
+
+    fake_op.execute.assert_not_called()
+    bind.execute.assert_not_called()
+
+
+def test_downgrade_uses_if_exists_and_public_schema(migration):
+    bind = _make_bind("postgresql")
+    with mock.patch.object(migration, "op") as fake_op:
+        fake_op.get_bind.return_value = bind
+        migration.downgrade()
+
+    sql = _executed_sql(fake_op)
+    assert "DROP FUNCTION IF EXISTS public.uuidv7()" in sql
+    assert "DROP FUNCTION IF EXISTS public.uuidv7_boundary(timestamptz)" in sql
+
+
+def test_downgrade_is_noop_on_non_postgres(migration):
+    bind = _make_bind("sqlite")
+    with mock.patch.object(migration, "op") as fake_op:
+        fake_op.get_bind.return_value = bind
+        migration.downgrade()
+
+    fake_op.execute.assert_not_called()


### PR DESCRIPTION
## Summary

On PostgreSQL 18 a fresh start fails during database migration. Revision `1c9ba48be8e4` runs `CREATE FUNCTION uuidv7()`, but PostgreSQL 18 already ships a native `pg_catalog.uuidv7()`. Our create collides with the built-in, and the unqualified `COMMENT ON FUNCTION uuidv7` that follows becomes ambiguous, so the migration aborts and the API container never finishes booting. Reported against PostgreSQL 18.3 in #36907.

This PR guards the create. In `upgrade()` we look up `pg_proc`/`pg_namespace` for a `uuidv7` function in the `pg_catalog` schema before creating our own. When the server already provides one (PostgreSQL 18), we skip both the `CREATE FUNCTION uuidv7()` and its `COMMENT`, and call sites that use `uuidv7()` then resolve to the native implementation, which has a compatible zero-argument signature.

The guard explicitly handles Alembic offline mode, where `conn.execute()` may return `None` instead of a `CursorResult`. In that case we conservatively default to creating the function, which is safe for SQL output generation.

The `uuidv7_boundary(timestamptz)` helper is still created unconditionally because PostgreSQL 18 does not provide it.

`downgrade()` now uses `DROP FUNCTION IF EXISTS public.uuidv7()` and `DROP FUNCTION IF EXISTS public.uuidv7_boundary(timestamptz)`. The `IF EXISTS` plus the explicit `public` schema make a rollback a no-op on PostgreSQL 18 (where the public copy was never created) and keep it from ever touching the built-in.

Behavior on PostgreSQL 13 to 17 is unchanged: there is no native `uuidv7`, so both functions are created exactly as before.

Fixes #36907

## Changes

- `api/migrations/versions/2025_07_02_2332-1c9ba48be8e4_add_uuidv7_function_in_sql.py`: Guard `uuidv7()` creation with a `pg_catalog` probe; handle offline mode where `conn.execute()` returns `None`; use `IF EXISTS` and `public.` qualifier in `downgrade()`.
- `api/tests/unit_tests/migrations/test_uuidv7_pg18_migration.py`: New test file covering all branches: native absent (PG<18), native present (PG18), offline mode, non-PostgreSQL dialects, downgrade with IF EXISTS.

## Test Plan

```shell
python -m pytest api/tests/unit_tests/migrations/test_uuidv7_pg18_migration.py -v --noconftest -c /dev/null
```

```
6 passed:
  test_upgrade_creates_both_functions_when_native_uuidv7_absent
  test_upgrade_skips_uuidv7_but_keeps_boundary_when_native_present
  test_upgrade_handles_offline_mode_where_execute_returns_none
  test_upgrade_is_noop_on_non_postgres
  test_downgrade_uses_if_exists_and_public_schema
  test_downgrade_is_noop_on_non_postgres
```

Also verified with a PostgreSQL 18.3 container that the migration runs without error (the original issue reporter confirmed the root cause and workaround).

## Risk

Low. The change is scoped to one migration file. PostgreSQL 13–17 behavior is unchanged. On PostgreSQL 18 the probe is a single lightweight catalog query. Offline mode falls back to the original behavior (create the function).

## Related Issue

Closes #36907