### PR TITLE
refactor(api): migrate embedding cache cleanup session

### DIFF
--- a/api/schedule/clean_embedding_cache_task.py
+++ b/api/schedule/clean_embedding_cache_task.py
@@ -1,14 +1,13 @@
 import datetime
 import time
 
-import click
-from sqlalchemy import select, text
-from sqlalchemy.exc import SQLAlchemyError
-
 import app
+import click
 from configs import dify_config
 from extensions.ext_database import db
 from models.dataset import Embedding
+from sqlalchemy import select, text
+from sqlalchemy.orm import Session
 
 
 @app.celery.task(queue="dataset")
@@ -17,24 +16,22 @@ def clean_embedding_cache_task():
     clean_days = int(dify_config.PLAN_SANDBOX_CLEAN_DAY_SETTING)
     start_at = time.perf_counter()
     thirty_days_ago = datetime.datetime.now() - datetime.timedelta(days=clean_days)
-    while True:
-        try:
-            embedding_ids = db.session.scalars(
+    with Session(db.engine, expire_on_commit=False) as session:
+        while True:
+            embedding_ids = session.scalars(
                 select(Embedding.id)
                 .where(Embedding.created_at < thirty_days_ago)
                 .order_by(Embedding.created_at.desc())
                 .limit(100)
             ).all()
-        except SQLAlchemyError:
-            raise
-        if embedding_ids:
-            for embedding_id in embedding_ids:
-                db.session.execute(
-                    text("DELETE FROM embeddings WHERE id = :embedding_id"), {"embedding_id": embedding_id}
-                )
+            if embedding_ids:
+                for embedding_id in embedding_ids:
+                    session.execute(
+                        text("DELETE FROM embeddings WHERE id = :embedding_id"), {"embedding_id": embedding_id}
+                    )
 
-            db.session.commit()
-        else:
-            break
+                session.commit()
+            else:
+                break
     end_at = time.perf_counter()
     click.echo(click.style(f"Cleaned embedding cache from db success latency: {end_at - start_at}", fg="green"))

--- a/api/schedule/clean_embedding_cache_task.py
+++ b/api/schedule/clean_embedding_cache_task.py
@@ -1,13 +1,14 @@
 import datetime
 import time
 
-import app
 import click
+from sqlalchemy import select, text
+from sqlalchemy.orm import Session
+
+import app
 from configs import dify_config
 from extensions.ext_database import db
 from models.dataset import Embedding
-from sqlalchemy import select, text
-from sqlalchemy.orm import Session
 
 
 @app.celery.task(queue="dataset")


### PR DESCRIPTION
## Summary

Part of #24115.

Migrate the embedding cache cleanup task from the Flask-SQLAlchemy scoped `db.session` to an explicit SQLAlchemy `Session(db.engine, expire_on_commit=False)` context.

## Reproduction

N/A. This is a small refactor for the ongoing session migration.

## Root cause

The task still used `db.session` directly while #24115 tracks replacing these usages with explicit SQLAlchemy sessions.

## Changes

- Add a local SQLAlchemy `Session` context in `clean_embedding_cache_task`.
- Replace `db.session.scalars`, `db.session.execute`, and `db.session.commit` with the local `session`.
- Remove the redundant `except SQLAlchemyError: raise` block.

## Tests

- `git diff --check`
- `python3 -m py_compile api/schedule/clean_embedding_cache_task.py`
- `/tmp/dify-ruff-verify/bin/ruff check api/schedule/clean_embedding_cache_task.py --config api/.ruff.toml`
- `/tmp/dify-ruff-verify/bin/ruff format --check api/schedule/clean_embedding_cache_task.py --config api/.ruff.toml`

## Screenshots/Logs

N/A.