### PR TITLE
refactor(api): migrate plugin upgrade check session

### DIFF
--- a/api/schedule/check_upgradable_plugin_task.py
+++ b/api/schedule/check_upgradable_plugin_task.py
@@ -2,13 +2,14 @@ import logging
 import math
 import time
 
-import app
 import click
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+import app
 from core.helper.marketplace import fetch_global_plugin_manifest
 from extensions.ext_database import db
 from models.account import TenantPluginAutoUpgradeStrategy
-from sqlalchemy import select
-from sqlalchemy.orm import Session
 from tasks import process_tenant_plugin_autoupgrade_check_task as check_task
 
 logger = logging.getLogger(__name__)

--- a/api/schedule/check_upgradable_plugin_task.py
+++ b/api/schedule/check_upgradable_plugin_task.py
@@ -2,13 +2,13 @@ import logging
 import math
 import time
 
-import click
-from sqlalchemy import select
-
 import app
+import click
 from core.helper.marketplace import fetch_global_plugin_manifest
 from extensions.ext_database import db
 from models.account import TenantPluginAutoUpgradeStrategy
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 from tasks import process_tenant_plugin_autoupgrade_check_task as check_task
 
 logger = logging.getLogger(__name__)
@@ -29,15 +29,16 @@ def check_upgradable_plugin_task():
     now_seconds_of_day = time.time() % 86400 - 30  # we assume the tz is UTC
     click.echo(click.style(f"Now seconds of day: {now_seconds_of_day}", fg="green"))
 
-    strategies = db.session.scalars(
-        select(TenantPluginAutoUpgradeStrategy).where(
-            TenantPluginAutoUpgradeStrategy.upgrade_time_of_day >= now_seconds_of_day,
-            TenantPluginAutoUpgradeStrategy.upgrade_time_of_day
-            < now_seconds_of_day + AUTO_UPGRADE_MINIMAL_CHECKING_INTERVAL,
-            TenantPluginAutoUpgradeStrategy.strategy_setting
-            != TenantPluginAutoUpgradeStrategy.StrategySetting.DISABLED,
-        )
-    ).all()
+    with Session(db.engine, expire_on_commit=False) as session:
+        strategies = session.scalars(
+            select(TenantPluginAutoUpgradeStrategy).where(
+                TenantPluginAutoUpgradeStrategy.upgrade_time_of_day >= now_seconds_of_day,
+                TenantPluginAutoUpgradeStrategy.upgrade_time_of_day
+                < now_seconds_of_day + AUTO_UPGRADE_MINIMAL_CHECKING_INTERVAL,
+                TenantPluginAutoUpgradeStrategy.strategy_setting
+                != TenantPluginAutoUpgradeStrategy.StrategySetting.DISABLED,
+            )
+        ).all()
 
     total_strategies = len(strategies)
     click.echo(click.style(f"Total strategies: {total_strategies}", fg="green"))


### PR DESCRIPTION
## Summary

Part of #24115.

Migrate the plugin auto-upgrade check task from the Flask-SQLAlchemy scoped `db.session` to an explicit SQLAlchemy `Session(db.engine, expire_on_commit=False)` context.

## Reproduction

N/A. This is a small refactor for the ongoing session migration.

## Root cause

`check_upgradable_plugin_task` still queried `TenantPluginAutoUpgradeStrategy` through `db.session`, while #24115 tracks replacing these usages with explicit SQLAlchemy sessions.

## Changes

- Add a local SQLAlchemy `Session` context in `check_upgradable_plugin_task`.
- Replace `db.session.scalars(...)` with `session.scalars(...)` for loading due tenant plugin auto-upgrade strategies.
- Keep the fetched strategy fields available after the session closes by using `expire_on_commit=False`.

## Tests

- `git diff --check`
- `python3 -m py_compile api/schedule/check_upgradable_plugin_task.py`
- `/tmp/dify-ruff-verify/bin/ruff check api/schedule/check_upgradable_plugin_task.py --config api/.ruff.toml`
- `/tmp/dify-ruff-verify/bin/ruff format --check api/schedule/check_upgradable_plugin_task.py --config api/.ruff.toml`

## Screenshots/Logs

N/A.