### PR TITLE
refactor(api): migrate oauth token cleanup session

### DIFF
--- a/api/schedule/clean_oauth_access_tokens_task.py
+++ b/api/schedule/clean_oauth_access_tokens_task.py
@@ -10,13 +10,13 @@ import logging
 import time
 from datetime import UTC, datetime, timedelta
 
-import click
-from sqlalchemy import delete, or_, select
-
 import app
+import click
 from configs import dify_config
 from extensions.ext_database import db
 from models.oauth import OAuthAccessToken
+from sqlalchemy import delete, or_, select
+from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 
@@ -37,13 +37,14 @@ def clean_oauth_access_tokens_task():
     )
 
     total = 0
-    while True:
-        ids = db.session.scalars(select(OAuthAccessToken.id).where(candidates).limit(DELETE_BATCH_SIZE)).all()
-        if not ids:
-            break
-        db.session.execute(delete(OAuthAccessToken).where(OAuthAccessToken.id.in_(ids)))
-        db.session.commit()
-        total += len(ids)
+    with Session(db.engine, expire_on_commit=False) as session:
+        while True:
+            ids = session.scalars(select(OAuthAccessToken.id).where(candidates).limit(DELETE_BATCH_SIZE)).all()
+            if not ids:
+                break
+            session.execute(delete(OAuthAccessToken).where(OAuthAccessToken.id.in_(ids)))
+            session.commit()
+            total += len(ids)
 
     end_at = time.perf_counter()
     click.echo(

--- a/api/schedule/clean_oauth_access_tokens_task.py
+++ b/api/schedule/clean_oauth_access_tokens_task.py
@@ -10,13 +10,14 @@ import logging
 import time
 from datetime import UTC, datetime, timedelta
 
-import app
 import click
+from sqlalchemy import delete, or_, select
+from sqlalchemy.orm import Session
+
+import app
 from configs import dify_config
 from extensions.ext_database import db
 from models.oauth import OAuthAccessToken
-from sqlalchemy import delete, or_, select
-from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Part of #24115.

Migrate the OAuth access token retention cleanup task from the Flask-SQLAlchemy scoped `db.session` to an explicit SQLAlchemy `Session(db.engine, expire_on_commit=False)` context.

## Reproduction

N/A. This is a small refactor for the ongoing session migration.

## Root cause

`clean_oauth_access_tokens_task` still used `db.session` directly while #24115 tracks replacing these usages with explicit SQLAlchemy sessions.

## Changes

- Add a local SQLAlchemy `Session` context in `clean_oauth_access_tokens_task`.
- Replace `db.session.scalars`, `db.session.execute`, and `db.session.commit` with the local `session`.
- Keep the existing batched deletion behavior and retention criteria unchanged.

## Tests

- `git diff --check`
- `python3 -m py_compile api/schedule/clean_oauth_access_tokens_task.py`
- `/tmp/dify-ruff-verify/bin/ruff check api/schedule/clean_oauth_access_tokens_task.py --config api/.ruff.toml`
- `/tmp/dify-ruff-verify/bin/ruff format --check api/schedule/clean_oauth_access_tokens_task.py --config api/.ruff.toml`

## Screenshots/Logs

N/A.