### PR TITLE
refactor(web): mark Props of explore/try-app/preview components as read-only (#25219)

### DIFF
--- a/web/app/components/explore/try-app/preview/basic-app-preview.tsx
+++ b/web/app/components/explore/try-app/preview/basic-app-preview.tsx
@@ -29,7 +29,7 @@ import { basePath } from '@/utils/var'
 import { useTextGenerationCurrentProviderAndModelAndModelList } from '../../../header/account-setting/model-provider-page/hooks'
 
 type Props = {
-  appId: string
+  readonly appId: string
 }
 
 const defaultModelConfig = {

--- a/web/app/components/explore/try-app/preview/flow-app-preview.tsx
+++ b/web/app/components/explore/try-app/preview/flow-app-preview.tsx
@@ -7,8 +7,8 @@ import WorkflowPreview from '@/app/components/workflow/workflow-preview'
 import { useGetTryAppFlowPreview } from '@/service/use-try-app'
 
 type Props = {
-  appId: string
-  className?: string
+  readonly appId: string
+  readonly className?: string
 }
 
 const FlowAppPreview: FC<Props> = ({

--- a/web/app/components/explore/try-app/preview/index.tsx
+++ b/web/app/components/explore/try-app/preview/index.tsx
@@ -6,8 +6,8 @@ import BasicAppPreview from './basic-app-preview'
 import FlowAppPreview from './flow-app-preview'
 
 type Props = {
-  appId: string
-  appDetail: TryAppInfo
+  readonly appId: string
+  readonly appDetail: TryAppInfo
 }
 
 const Preview: FC<Props> = ({


### PR DESCRIPTION
part of #25219

## Summary

Adds the `readonly` modifier to each property of the `Props` types in the three `explore/try-app/preview` components, per [`@eslint-react/prefer-read-only-props`](https://eslint-react.xyz/docs/rules/prefer-read-only-props):

- `index.tsx`
- `flow-app-preview.tsx`
- `basic-app-preview.tsx`

Same pattern as the merged #37118. This is a type-annotation-only change (props are never mutated), so there is no behavior change and no tests or docs are required.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I tried as much as possible to make a single atomic change (type-only; no tests applicable).
- [ ] I've updated the documentation accordingly.
- [x] I ran the frontend lint (the repo's pre-commit `eslint --fix` ran clean on the changed files).

From Claude Code
