### PR TITLE
refactor(api): migrate app dataset join event sessions

### DIFF
--- a/api/events/event_handlers/update_app_dataset_join_when_app_model_config_updated.py
+++ b/api/events/event_handlers/update_app_dataset_join_when_app_model_config_updated.py
@@ -1,6 +1,7 @@
 from typing import Any, cast
 
 from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
 
 from events.app_event import app_model_config_was_updated
 from extensions.ext_database import db
@@ -17,30 +18,33 @@ def handle(sender, **kwargs):
 
     dataset_ids = get_dataset_ids_from_model_config(app_model_config)
 
-    app_dataset_joins = db.session.scalars(select(AppDatasetJoin).where(AppDatasetJoin.app_id == app.id)).all()
+    with Session(db.engine, expire_on_commit=False) as session:
+        app_dataset_joins = session.scalars(select(AppDatasetJoin).where(AppDatasetJoin.app_id == app.id)).all()
 
-    removed_dataset_ids: set[str] = set()
-    if not app_dataset_joins:
-        added_dataset_ids = dataset_ids
-    else:
-        old_dataset_ids: set[str] = set()
-        old_dataset_ids.update(app_dataset_join.dataset_id for app_dataset_join in app_dataset_joins)
+        removed_dataset_ids: set[str] = set()
+        if not app_dataset_joins:
+            added_dataset_ids = dataset_ids
+        else:
+            old_dataset_ids: set[str] = set()
+            old_dataset_ids.update(app_dataset_join.dataset_id for app_dataset_join in app_dataset_joins)
 
-        added_dataset_ids = dataset_ids - old_dataset_ids
-        removed_dataset_ids = old_dataset_ids - dataset_ids
+            added_dataset_ids = dataset_ids - old_dataset_ids
+            removed_dataset_ids = old_dataset_ids - dataset_ids
 
-    if removed_dataset_ids:
-        for dataset_id in removed_dataset_ids:
-            db.session.execute(
-                delete(AppDatasetJoin).where(AppDatasetJoin.app_id == app.id, AppDatasetJoin.dataset_id == dataset_id)
-            )
+        if removed_dataset_ids:
+            for dataset_id in removed_dataset_ids:
+                session.execute(
+                    delete(AppDatasetJoin).where(
+                        AppDatasetJoin.app_id == app.id, AppDatasetJoin.dataset_id == dataset_id
+                    )
+                )
 
-    if added_dataset_ids:
-        for dataset_id in added_dataset_ids:
-            app_dataset_join = AppDatasetJoin(app_id=app.id, dataset_id=dataset_id)
-            db.session.add(app_dataset_join)
+        if added_dataset_ids:
+            for dataset_id in added_dataset_ids:
+                app_dataset_join = AppDatasetJoin(app_id=app.id, dataset_id=dataset_id)
+                session.add(app_dataset_join)
 
-    db.session.commit()
+        session.commit()
 
 
 def get_dataset_ids_from_model_config(app_model_config: AppModelConfig) -> set[str]:

--- a/api/events/event_handlers/update_app_dataset_join_when_app_published_workflow_updated.py
+++ b/api/events/event_handlers/update_app_dataset_join_when_app_published_workflow_updated.py
@@ -1,6 +1,7 @@
 from typing import cast
 
 from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
 
 from core.workflow.nodes.knowledge_retrieval.entities import KnowledgeRetrievalNodeData
 from events.app_event import app_published_workflow_was_updated
@@ -17,30 +18,33 @@ def handle(sender, **kwargs):
     published_workflow = cast(Workflow, published_workflow)
 
     dataset_ids = get_dataset_ids_from_workflow(published_workflow)
-    app_dataset_joins = db.session.scalars(select(AppDatasetJoin).where(AppDatasetJoin.app_id == app.id)).all()
+    with Session(db.engine, expire_on_commit=False) as session:
+        app_dataset_joins = session.scalars(select(AppDatasetJoin).where(AppDatasetJoin.app_id == app.id)).all()
 
-    removed_dataset_ids: set[str] = set()
-    if not app_dataset_joins:
-        added_dataset_ids = dataset_ids
-    else:
-        old_dataset_ids: set[str] = set()
-        old_dataset_ids.update(app_dataset_join.dataset_id for app_dataset_join in app_dataset_joins)
+        removed_dataset_ids: set[str] = set()
+        if not app_dataset_joins:
+            added_dataset_ids = dataset_ids
+        else:
+            old_dataset_ids: set[str] = set()
+            old_dataset_ids.update(app_dataset_join.dataset_id for app_dataset_join in app_dataset_joins)
 
-        added_dataset_ids = dataset_ids - old_dataset_ids
-        removed_dataset_ids = old_dataset_ids - dataset_ids
+            added_dataset_ids = dataset_ids - old_dataset_ids
+            removed_dataset_ids = old_dataset_ids - dataset_ids
 
-    if removed_dataset_ids:
-        for dataset_id in removed_dataset_ids:
-            db.session.execute(
-                delete(AppDatasetJoin).where(AppDatasetJoin.app_id == app.id, AppDatasetJoin.dataset_id == dataset_id)
-            )
+        if removed_dataset_ids:
+            for dataset_id in removed_dataset_ids:
+                session.execute(
+                    delete(AppDatasetJoin).where(
+                        AppDatasetJoin.app_id == app.id, AppDatasetJoin.dataset_id == dataset_id
+                    )
+                )
 
-    if added_dataset_ids:
-        for dataset_id in added_dataset_ids:
-            app_dataset_join = AppDatasetJoin(app_id=app.id, dataset_id=dataset_id)
-            db.session.add(app_dataset_join)
+        if added_dataset_ids:
+            for dataset_id in added_dataset_ids:
+                app_dataset_join = AppDatasetJoin(app_id=app.id, dataset_id=dataset_id)
+                session.add(app_dataset_join)
 
-    db.session.commit()
+        session.commit()
 
 
 def get_dataset_ids_from_workflow(published_workflow: Workflow) -> set[str]:

--- a/api/services/app_dsl_service.py
+++ b/api/services/app_dsl_service.py
@@ -505,6 +505,7 @@ class AppDslService:
                     app.app_model_config_id = app_model_config.id
 
                     self._session.add(app_model_config)
+                    self._session.flush()
                     app_model_config_was_updated.send(app, app_model_config=app_model_config)
             case _:
                 raise ValueError("Invalid app mode")


### PR DESCRIPTION
## Summary

Part of #24115.

Migrate the app dataset join update event handlers from the Flask-SQLAlchemy scoped `db.session` to explicit SQLAlchemy `Session(db.engine, expire_on_commit=False)` scopes.

## Reproduction

This is a refactor from the open migration issue rather than a user-visible bug. The affected handlers previously used `db.session` for AppDatasetJoin query/delete/add/commit work when app model config or published workflow dataset references change.

After the first version of this PR, CI surfaced a regression in `TestAppDslService::test_create_or_update_app_chat_creates_model_config_and_sends_event`: the old handler's `db.session.commit()` was implicitly flushing/committing the caller's AppDslService session, while the explicit handler session no longer does that.

## Root cause

`db.session` is the Flask-SQLAlchemy scoped session. The migration issue asks non-request/background/event-handler code to use explicit SQLAlchemy sessions so session ownership and lifetime are local to the handler.

The AppDslService path also relied on the old handler's scoped-session commit side effect to make a newly created `AppModelConfig` and `app.app_model_config_id` visible before the test expired the session. Once the handler owns a separate session, AppDslService needs to flush its own pending model-config changes before emitting the event.

## Changes

- Updated `update_app_dataset_join_when_app_model_config_updated.py` to use an explicit SQLAlchemy `Session` context.
- Updated `update_app_dataset_join_when_app_published_workflow_updated.py` to use an explicit SQLAlchemy `Session` context.
- Added an explicit `self._session.flush()` before `app_model_config_was_updated.send(...)` in AppDslService so the service owns its transaction boundary instead of relying on handler commit side effects.
- Preserved the existing dataset join diff logic and commit behavior.

## Tests

- `/tmp/dify-ruff-verify/bin/ruff check api/services/app_dsl_service.py api/events/event_handlers/update_app_dataset_join_when_app_model_config_updated.py api/events/event_handlers/update_app_dataset_join_when_app_published_workflow_updated.py`
- `/tmp/dify-ruff-verify/bin/ruff format --check api/services/app_dsl_service.py api/events/event_handlers/update_app_dataset_join_when_app_model_config_updated.py api/events/event_handlers/update_app_dataset_join_when_app_published_workflow_updated.py`
- `python3 -m py_compile api/services/app_dsl_service.py api/events/event_handlers/update_app_dataset_join_when_app_model_config_updated.py api/events/event_handlers/update_app_dataset_join_when_app_published_workflow_updated.py`
- `git diff --check`

I could not run the failing testcontainers integration test locally because Docker is not available in my environment (`docker not found`). The updated branch has been pushed so GitHub Actions can rerun the affected integration suite.

## Screenshots/Logs

Not applicable; backend-only refactor.
