### PR TITLE
fix: remove unnecessary # type: ignore comments (#24494)

### DIFF
--- a/api/core/workflow/nodes/knowledge_index/knowledge_index_node.py
+++ b/api/core/workflow/nodes/knowledge_index/knowledge_index_node.py
@@ -46,7 +46,7 @@ class KnowledgeIndexNode(Node[KnowledgeIndexNodeData]):
         self.index_processor = IndexProcessor()
         self.summary_index_service = SummaryIndex()
 
-    def _run(self) -> NodeRunResult:  # type: ignore
+    def _run(self) -> NodeRunResult:
         node_data = self.node_data
         variable_pool = self.graph_runtime_state.variable_pool
 

--- a/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
+++ b/api/core/workflow/nodes/knowledge_retrieval/knowledge_retrieval_node.py
@@ -134,7 +134,7 @@ class KnowledgeRetrievalNode(LLMUsageTrackingMixin, Node[KnowledgeRetrievalNodeD
                 status=WorkflowNodeExecutionStatus.SUCCEEDED,
                 inputs=variables,
                 process_data={"usage": jsonable_encoder(usage)},
-                outputs=outputs,  # type: ignore
+                outputs=outputs,
                 metadata={
                     WorkflowNodeExecutionMetadataKey.TOTAL_TOKENS: usage.total_tokens,
                     WorkflowNodeExecutionMetadataKey.TOTAL_PRICE: usage.total_price,


### PR DESCRIPTION
## What

Remove 2 unnecessary `# type: ignore` comments from `api/core/workflow/`.

 #24494

## Changes

### `knowledge_retrieval_node.py:137`
- Removed `# type: ignore` from `outputs=outputs`
- Reason: `dict[str, ArrayObjectSegment]` is fully compatible with the `Mapping[str, Any]` parameter type — no type error

### `knowledge_index_node.py:49`
- Removed `# type: ignore` from `def _run(self) -> NodeRunResult`
- Reason: Return type narrowing from `NodeRunResult | Generator[...]` to `NodeRunResult` is valid per Liskov substitution (covariant return types)

## Not changed (22 legitimate type: ignore)

- `runtime_support.py:57` — real type mismatch (`Union[list[str], ...]` vs `Sequence[str]`)
- `model.py:16,27` — untyped third-party imports (flask_login, libs.helper)
- `model.py:1209` — TypedDict unknown key
- All 18 `api/core/app` comments — Flask proxy typing, untyped imports, method assignment (all legitimate)