### PR TITLE
refactor(api): migrate clean embedding cache session

### DIFF
--- a/api/schedule/clean_embedding_cache_task.py
+++ b/api/schedule/clean_embedding_cache_task.py
@@ -4,6 +4,7 @@ import time
 import click
 from sqlalchemy import select, text
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
 
 import app
 from configs import dify_config
@@ -17,24 +18,25 @@ def clean_embedding_cache_task():
     clean_days = int(dify_config.PLAN_SANDBOX_CLEAN_DAY_SETTING)
     start_at = time.perf_counter()
     thirty_days_ago = datetime.datetime.now() - datetime.timedelta(days=clean_days)
-    while True:
-        try:
-            embedding_ids = db.session.scalars(
-                select(Embedding.id)
-                .where(Embedding.created_at < thirty_days_ago)
-                .order_by(Embedding.created_at.desc())
-                .limit(100)
-            ).all()
-        except SQLAlchemyError:
-            raise
-        if embedding_ids:
-            for embedding_id in embedding_ids:
-                db.session.execute(
-                    text("DELETE FROM embeddings WHERE id = :embedding_id"), {"embedding_id": embedding_id}
-                )
+    with Session(db.engine, expire_on_commit=False) as session:
+        while True:
+            try:
+                embedding_ids = session.scalars(
+                    select(Embedding.id)
+                    .where(Embedding.created_at < thirty_days_ago)
+                    .order_by(Embedding.created_at.desc())
+                    .limit(100)
+                ).all()
+            except SQLAlchemyError:
+                raise
+            if embedding_ids:
+                for embedding_id in embedding_ids:
+                    session.execute(
+                        text("DELETE FROM embeddings WHERE id = :embedding_id"), {"embedding_id": embedding_id}
+                    )
 
-            db.session.commit()
-        else:
-            break
+                session.commit()
+            else:
+                break
     end_at = time.perf_counter()
     click.echo(click.style(f"Cleaned embedding cache from db success latency: {end_at - start_at}", fg="green"))

--- a/api/tests/unit_tests/schedule/test_clean_embedding_cache_task.py
+++ b/api/tests/unit_tests/schedule/test_clean_embedding_cache_task.py
@@ -1,0 +1,78 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+class FakeCelery:
+    def task(self, **_kwargs):
+        return lambda func: func
+
+
+class FakeColumn:
+    def __lt__(self, _other):
+        return "older-than-cutoff"
+
+    def desc(self):
+        return "created-at-desc"
+
+
+def load_clean_embedding_cache_task_module(monkeypatch):
+    module_path = Path(__file__).parents[3] / "schedule" / "clean_embedding_cache_task.py"
+    module_name = "test_clean_embedding_cache_task_module"
+
+    monkeypatch.setitem(sys.modules, "app", SimpleNamespace(celery=FakeCelery()))
+    monkeypatch.setitem(
+        sys.modules,
+        "configs",
+        SimpleNamespace(dify_config=SimpleNamespace(PLAN_SANDBOX_CLEAN_DAY_SETTING="30")),
+    )
+    monkeypatch.setitem(sys.modules, "extensions.ext_database", SimpleNamespace(db=MagicMock()))
+    monkeypatch.setitem(
+        sys.modules,
+        "models.dataset",
+        SimpleNamespace(Embedding=SimpleNamespace(id=FakeColumn(), created_at=FakeColumn())),
+    )
+
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_clean_embedding_cache_task_uses_explicit_sqlalchemy_session(monkeypatch):
+    module = load_clean_embedding_cache_task_module(monkeypatch)
+
+    assert hasattr(module, "Session")
+
+    engine = object()
+    db = MagicMock()
+    db.engine = engine
+    monkeypatch.setattr(module, "db", db)
+    monkeypatch.setattr(module.dify_config, "PLAN_SANDBOX_CLEAN_DAY_SETTING", "30")
+
+    session = MagicMock()
+    session.scalars.return_value.all.side_effect = [["embedding-1", "embedding-2"], []]
+
+    session_context = MagicMock()
+    session_context.__enter__.return_value = session
+    session_context.__exit__.return_value = None
+
+    session_cls = MagicMock(return_value=session_context)
+    monkeypatch.setattr(module, "Session", session_cls)
+
+    query = MagicMock()
+    query.where.return_value = query
+    query.order_by.return_value = query
+    query.limit.return_value = query
+    monkeypatch.setattr(module, "select", MagicMock(return_value=query))
+    monkeypatch.setattr(module, "text", MagicMock(return_value="delete statement"))
+
+    module.clean_embedding_cache_task()
+
+    session_cls.assert_called_once_with(engine, expire_on_commit=False)
+    assert session.execute.call_count == 2
+    session.commit.assert_called_once()


### PR DESCRIPTION
## Summary

Part of #24115.

Migrate the clean embedding cache scheduled task from Flask-SQLAlchemy scoped db.session access to an explicit SQLAlchemy Session(db.engine, expire_on_commit=False) scope.

## Changes

- Replace db.session usage in clean_embedding_cache_task with a local SQLAlchemy Session.
- Keep the existing cleanup cutoff, batch size, raw delete statement, per-batch commit, and loop behavior unchanged.
- Add a focused unit test that isolates the task module and verifies it uses the explicit session while deleting and committing stale embedding rows.

## Tests

- uv run --project api pytest -o addopts='' api/tests/unit_tests/schedule/test_clean_embedding_cache_task.py -q
- uv run --project api ruff format --check api/schedule/clean_embedding_cache_task.py api/tests/unit_tests/schedule/test_clean_embedding_cache_task.py
- uv run --project api ruff check api/schedule/clean_embedding_cache_task.py api/tests/unit_tests/schedule/test_clean_embedding_cache_task.py
- uv run --project api python -m py_compile api/schedule/clean_embedding_cache_task.py api/tests/unit_tests/schedule/test_clean_embedding_cache_task.py
- git diff --check