### PR TITLE
refactor(web): migrate metadata modal storage

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2275,9 +2275,6 @@
     }
   },
   "web/app/components/datasets/metadata/hooks/use-edit-dataset-metadata.ts": {
-    "no-restricted-globals": {
-      "count": 2
-    },
     "react/set-state-in-effect": {
       "count": 1
     }

--- a/web/app/components/datasets/metadata/hooks/__tests__/use-edit-dataset-metadata.spec.ts
+++ b/web/app/components/datasets/metadata/hooks/__tests__/use-edit-dataset-metadata.spec.ts
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
-import { DataType } from '../../types'
+import { DataType, isShowManageMetadataLocalStorageKey } from '../../types'
 import useEditDatasetMetadata from '../use-edit-dataset-metadata'
 
 const mockDoAddMetaData = vi.fn().mockResolvedValue({})
@@ -61,15 +61,6 @@ vi.mock('../use-check-metadata-name', () => ({
   }),
 }))
 
-// Mock localStorage
-const localStorageMock = {
-  getItem: vi.fn(),
-  setItem: vi.fn(),
-  removeItem: vi.fn(),
-  clear: vi.fn(),
-}
-Object.defineProperty(window, 'localStorage', { value: localStorageMock })
-
 describe('useEditDatasetMetadata', () => {
   const defaultProps = {
     datasetId: 'ds-1',
@@ -78,7 +69,7 @@ describe('useEditDatasetMetadata', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    localStorageMock.getItem.mockReturnValue(null)
+    window.localStorage.clear()
   })
 
   describe('Hook Initialization', () => {
@@ -173,6 +164,17 @@ describe('useEditDatasetMetadata', () => {
 
       act(() => result.current.showEditModal())
       expect(result.current.isShowEditModal).toBe(true)
+    })
+
+    it('should show modal and clear manage metadata flag when stored', async () => {
+      window.localStorage.setItem(isShowManageMetadataLocalStorageKey, 'true')
+
+      const { result } = renderHook(() => useEditDatasetMetadata(defaultProps))
+
+      await waitFor(() => {
+        expect(result.current.isShowEditModal).toBe(true)
+      })
+      expect(window.localStorage.getItem(isShowManageMetadataLocalStorageKey)).toBeNull()
     })
   })
 

--- a/web/app/components/datasets/metadata/hooks/use-edit-dataset-metadata.ts
+++ b/web/app/components/datasets/metadata/hooks/use-edit-dataset-metadata.ts
@@ -4,6 +4,7 @@ import { toast } from '@langgenius/dify-ui/toast'
 import { useBoolean } from 'ahooks'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useLocalStorage } from '@/hooks/use-local-storage'
 import { useBuiltInMetaDataFields, useCreateMetaData, useDatasetMetaData, useDeleteMetaData, useRenameMeta, useUpdateBuiltInStatus } from '@/service/knowledge/use-metadata'
 import { isShowManageMetadataLocalStorageKey } from '../types'
 import useCheckMetadataName from './use-check-metadata-name'
@@ -17,13 +18,17 @@ const useEditDatasetMetadata = ({ datasetId,
 }) => {
   const { t } = useTranslation()
   const [isShowEditModal, { setTrue: showEditModal, setFalse: hideEditModal }] = useBoolean(false)
+  const [isShowManageMetadata, setIsShowManageMetadata] = useLocalStorage<string>(
+    isShowManageMetadataLocalStorageKey,
+    undefined,
+    { raw: true },
+  )
   useEffect(() => {
-    const isShowManageMetadata = localStorage.getItem(isShowManageMetadataLocalStorageKey)
     if (isShowManageMetadata) {
       showEditModal()
-      localStorage.removeItem(isShowManageMetadataLocalStorageKey)
+      setIsShowManageMetadata(null)
     }
-  }, [])
+  }, [isShowManageMetadata, setIsShowManageMetadata, showEditModal])
   const { data: datasetMetaData } = useDatasetMetaData(datasetId)
   const { mutate: doAddMetaData } = useCreateMetaData(datasetId)
   const { checkName } = useCheckMetadataName()


### PR DESCRIPTION
## Summary

Part of #36898. Migrates the dataset metadata management modal flag reader/remover from direct `localStorage` calls to `@/hooks/use-local-storage`.

This is intentionally limited to one storage concern and two app-code call sites in `use-edit-dataset-metadata.ts`, avoiding overlap with #36948, which only touches the setter in `metadata-document/info-group.tsx`.

## Reproduction

Before this change, `useEditDatasetMetadata` read and removed `dify-isShowManageMetadata` directly:

```ts
localStorage.getItem(isShowManageMetadataLocalStorageKey)
localStorage.removeItem(isShowManageMetadataLocalStorageKey)
```

That bypassed the shared local storage hook boundary requested in #36898.

## Root cause

The metadata modal flow used an ad-hoc localStorage read/remove effect instead of the shared hook used for client-only persistent UI state.

## Changes

- Use `useLocalStorage<string>(..., undefined, { raw: true })` for the metadata management flag.
- Clear the flag with the hook setter by passing `null`, preserving the existing raw string storage format.
- Update the existing hook test to use jsdom `window.localStorage` and cover the stored-flag path.

## Tests

Ran with pnpm 11.5.0 and Node.js v22.13.0. The repo warns that devEngines prefers Node.js ^22.22.1, but commands completed successfully.

```bash
pnpm -C web test app/components/datasets/metadata/hooks/__tests__/use-edit-dataset-metadata.spec.ts --run
pnpm lint --no-warn-ignored --pass-on-unpruned-suppressions web/app/components/datasets/metadata/hooks/use-edit-dataset-metadata.ts web/app/components/datasets/metadata/hooks/__tests__/use-edit-dataset-metadata.spec.ts
pnpm -C packages/dev-proxy build
pnpm -C web type-check
git diff --check
```

## Screenshots/Logs

N/A. Hook-only storage migration; no visual UI change.