### PR TITLE
refactor(web): migrate app-collapse and debug-model localStorage to useLocalStorage hook (#36898)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -109,9 +109,6 @@
     }
   },
   "web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx": {
-    "no-restricted-globals": {
-      "count": 1
-    },
     "react/set-state-in-effect": {
       "count": 2
     },
@@ -249,7 +246,7 @@
   },
   "web/app/components/app-sidebar/index.tsx": {
     "no-restricted-globals": {
-      "count": 2
+      "count": 1
     },
     "ts/no-explicit-any": {
       "count": 1
@@ -510,9 +507,6 @@
     }
   },
   "web/app/components/app/configuration/debug/hooks.tsx": {
-    "no-restricted-globals": {
-      "count": 2
-    },
     "ts/no-explicit-any": {
       "count": 3
     }

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx
@@ -26,6 +26,7 @@ import Loading from '@/app/components/base/loading'
 import { useAppContext } from '@/context/app-context'
 import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
 import useDocumentTitle from '@/hooks/use-document-title'
+import { useLocalStorage } from '@/hooks/use-local-storage'
 import { usePathname, useRouter } from '@/next/navigation'
 import { fetchAppDetailDirect } from '@/service/apps'
 import { AppModeEnum } from '@/types/app'
@@ -101,17 +102,17 @@ const AppDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
   }, [t])
 
   useDocumentTitle(appDetail?.name || t('menus.appDetail', { ns: 'common' }))
+  const [localeMode] = useLocalStorage<string>('app-detail-collapse-or-expand', 'expand', { raw: true })
 
   useEffect(() => {
     if (appDetail) {
-      const localeMode = localStorage.getItem('app-detail-collapse-or-expand') || 'expand'
       const mode = isMobile ? 'collapse' : 'expand'
       setAppSidebarExpand(isMobile ? mode : localeMode)
       // TODO: consider screen size and mode
       // if ((appDetail.mode === AppModeEnum.ADVANCED_CHAT || appDetail.mode === 'workflow') && (pathname).endsWith('workflow'))
       //   setAppSidebarExpand('collapse')
     }
-  }, [appDetail, isMobile])
+  }, [appDetail, isMobile, localeMode])
 
   useEffect(() => {
     setAppDetail()

--- a/web/app/components/app-sidebar/index.tsx
+++ b/web/app/components/app-sidebar/index.tsx
@@ -9,6 +9,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useStore as useAppStore } from '@/app/components/app/store'
 import { useEventEmitterContextContext } from '@/context/event-emitter'
 import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
+import { useSetLocalStorage } from '@/hooks/use-local-storage'
 import { usePathname } from '@/next/navigation'
 import Divider from '../base/divider'
 import AppInfo, { AppInfoView } from './app-info'
@@ -69,12 +70,14 @@ const AppDetailNav = ({
       setHideHeader(v.payload)
   })
 
+  const setLocalStorageExpand = useSetLocalStorage<string>('app-detail-collapse-or-expand', { raw: true })
+
   useEffect(() => {
     if (appSidebarExpand) {
-      localStorage.setItem('app-detail-collapse-or-expand', appSidebarExpand)
+      setLocalStorageExpand(appSidebarExpand)
       setAppSidebarExpand(appSidebarExpand)
     }
-  }, [appSidebarExpand, setAppSidebarExpand])
+  }, [appSidebarExpand, setAppSidebarExpand, setLocalStorageExpand])
 
   useHotkey('Mod+B', (e) => {
     e.preventDefault()

--- a/web/app/components/app/configuration/debug/hooks.tsx
+++ b/web/app/components/app/configuration/debug/hooks.tsx
@@ -9,13 +9,13 @@ import type {
 import { cloneDeep } from 'es-toolkit/object'
 import {
   useCallback,
-  useRef,
   useState,
 } from 'react'
 import { SupportUploadFileTypes } from '@/app/components/workflow/types'
 import { DEFAULT_CHAT_PROMPT_CONFIG, DEFAULT_COMPLETION_PROMPT_CONFIG } from '@/config'
 import { useDebugConfigurationContext } from '@/context/debug-configuration'
 import { useEventEmitterContextContext } from '@/context/event-emitter'
+import { useLocalStorage } from '@/hooks/use-local-storage'
 import {
   AgentStrategy,
 } from '@/types/app'
@@ -23,28 +23,17 @@ import { promptVariablesToUserInputsForm } from '@/utils/model-config'
 import { ORCHESTRATE_CHANGED } from './types'
 
 export const useDebugWithSingleOrMultipleModel = (appId: string) => {
-  const localeDebugWithSingleOrMultipleModelConfigs = localStorage.getItem('app-debug-with-single-or-multiple-models')
-
-  const debugWithSingleOrMultipleModelConfigs = useRef<DebugWithSingleOrMultipleModelConfigs>({})
-
-  if (localeDebugWithSingleOrMultipleModelConfigs) {
-    try {
-      debugWithSingleOrMultipleModelConfigs.current = JSON.parse(localeDebugWithSingleOrMultipleModelConfigs) || {}
-    }
-    catch (e) {
-      console.error(e)
-    }
-  }
+  const [storedConfigs, setStoredConfigs] = useLocalStorage<DebugWithSingleOrMultipleModelConfigs>('app-debug-with-single-or-multiple-models', {})
 
   const [
     debugWithMultipleModel,
     setDebugWithMultipleModel,
-  ] = useState(debugWithSingleOrMultipleModelConfigs.current[appId]?.multiple || false)
+  ] = useState(storedConfigs?.[appId]?.multiple || false)
 
   const [
     multipleModelConfigs,
     setMultipleModelConfigs,
-  ] = useState(debugWithSingleOrMultipleModelConfigs.current[appId]?.configs || [])
+  ] = useState(storedConfigs?.[appId]?.configs || [])
 
   const handleMultipleModelConfigsChange = useCallback((
     multiple: boolean,
@@ -54,11 +43,10 @@ export const useDebugWithSingleOrMultipleModel = (appId: string) => {
       multiple,
       configs: modelConfigs,
     }
-    debugWithSingleOrMultipleModelConfigs.current[appId] = value
-    localStorage.setItem('app-debug-with-single-or-multiple-models', JSON.stringify(debugWithSingleOrMultipleModelConfigs.current))
+    setStoredConfigs(prev => ({ ...(prev || {}), [appId]: value }))
     setDebugWithMultipleModel(value.multiple)
     setMultipleModelConfigs(value.configs)
-  }, [appId])
+  }, [appId, setStoredConfigs])
 
   return {
     debugWithMultipleModel,


### PR DESCRIPTION
## Summary

Migrate 2 remaining localStorage keys from direct `localStorage` calls to `useLocalStorage`/`useSetLocalStorage` hooks.

Closes #36898

## Changes

| Key | File | Pattern |
|-----|------|--------|
| `app-detail-collapse-or-expand` | `layout-main.tsx` | `localStorage.getItem` → `useLocalStorage<string>(..., { raw: true })` |
| `app-detail-collapse-or-expand` | `app-sidebar/index.tsx` | `localStorage.setItem` → `useSetLocalStorage<string>(..., { raw: true })` |
| `app-debug-with-single-or-multiple-models` | `debug/hooks.tsx` | `localStorage.getItem/setItem` + `useRef` → `useLocalStorage<DebugWithSingleOrMultipleModelConfigs>` |

**Total: 3 files, +14 / -22 lines**

## Self-check

- [x] `pnpm lint-staged` passed on commit
- [x] No behavioral change — same localStorage key, same read/write semantics
- [x] Kept PR small per maintainer guidance