### PR TITLE
fix(web): z-index issue of variable picker in prompt editor

### DIFF
--- a/web/app/components/base/prompt-editor/plugins/component-picker-block/__tests__/index.spec.tsx
+++ b/web/app/components/base/prompt-editor/plugins/component-picker-block/__tests__/index.spec.tsx
@@ -704,6 +704,7 @@ describe('ComponentPicker (component-picker-block/index.tsx)', () => {
     await setEditorText(editor, '{', true)
     const typeaheadMenu = document.getElementById('typeahead-menu')
     expect(typeaheadMenu).not.toBeNull()
+    expect(typeaheadMenu).toHaveClass('z-50')
 
     const ce = screen.getByTestId(CONTENT_EDITABLE_TEST_ID)
     const fiber = getReactFiberFromDom(ce)

--- a/web/app/components/base/prompt-editor/plugins/component-picker-block/index.tsx
+++ b/web/app/components/base/prompt-editor/plugins/component-picker-block/index.tsx
@@ -318,7 +318,7 @@ const ComponentPicker = ({
       //
       // We no need the position function of the `LexicalTypeaheadMenuPlugin`,
       // so the reference anchor should be positioned based on the range of the trigger string, and the menu will be positioned by the floating ui.
-      anchorClassName="z-999999 translate-y-[calc(-100%-3px)]"
+      anchorClassName="z-50 translate-y-[calc(-100%-3px)]"
       menuRenderFn={renderMenu}
       triggerFn={checkForTriggerMatch}
     />


### PR DESCRIPTION
## Summary

Fix z-index issue of variable picker in prompt editor

## Screenshots

| Before | After |
|--------|-------|
| <img width="1244" height="932" alt="img_v3_0212f_99621c7c-c456-4c55-96df-daefcfbb901g" src="https://github.com/user-attachments/assets/f3bab02b-f453-474f-86cb-f32c9ea38fc1" /> | <img width="1302" height="884" alt="img_v3_0212f_28462ae8-0c6d-409a-8ebe-7c3ce7025d7g" src="https://github.com/user-attachments/assets/a4ff0045-9bd7-4891-94c4-9aaa396457c1" /> |

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
