### PR TITLE
feat(web): support search input autofocus

### DIFF
--- a/web/app/components/base/search-input/__tests__/index.spec.tsx
+++ b/web/app/components/base/search-input/__tests__/index.spec.tsx
@@ -23,6 +23,11 @@ describe('SearchInput', () => {
       expect(screen.getByRole('searchbox', { name: 'Search providers' })).toBeInTheDocument()
     })
 
+    it('focuses the searchbox when autoFocus is enabled', () => {
+      render(<SearchInput value="" onValueChange={() => {}} autoFocus />)
+      expect(screen.getByRole('searchbox', { name: 'common.operation.search' })).toHaveFocus()
+    })
+
     it('shows clear button when value is present', () => {
       const onValueChange = vi.fn()
       render(<SearchInput value="has value" onValueChange={onValueChange} />)

--- a/web/app/components/base/search-input/index.tsx
+++ b/web/app/components/base/search-input/index.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps } from 'react'
+import type { InputProps } from '@langgenius/dify-ui/input'
 import { cn } from '@langgenius/dify-ui/cn'
 import { Input } from '@langgenius/dify-ui/input'
 import { useRef, useState } from 'react'
@@ -9,13 +9,14 @@ type SearchInputProps = {
   onValueChange: (value: string) => void
   placeholder?: string
   className?: string
-} & Pick<ComponentProps<'input'>, 'aria-label'>
+} & Pick<InputProps, 'aria-label' | 'autoFocus'>
 
 export function SearchInput({
   placeholder,
   className,
   value,
   onValueChange,
+  autoFocus,
   'aria-label': ariaLabel,
 }: SearchInputProps) {
   const { t } = useTranslation()
@@ -83,6 +84,7 @@ export function SearchInput({
           onValueChange(e.currentTarget.value)
         }}
         autoComplete="off"
+        autoFocus={autoFocus}
         enterKeyHint="search"
       />
       {!!inputValue && (


### PR DESCRIPTION
## Summary
- expose a narrow `autoFocus` prop on the shared `SearchInput` wrapper
- source the prop type from dify-ui `InputProps` while keeping the SearchInput API intentionally allowlisted
- cover autofocus behavior with a focused component test

## Tests
- `pnpm -C web test app/components/base/search-input/__tests__/index.spec.tsx`
- `pnpm eslint web/app/components/base/search-input/index.tsx web/app/components/base/search-input/__tests__/index.spec.tsx`
- `pnpm -C web type-check`