### PR TITLE
fix(api): return configured tracing provider fallback

### DIFF
--- a/api/core/ops/ops_trace_manager.py
+++ b/api/core/ops/ops_trace_manager.py
@@ -592,15 +592,31 @@ class OpsTraceManager:
         """
         Get app tracing config
         :param app_id: app id
-        :return:
+        :return: app tracing status with a configured provider fallback when the status has not selected one yet
         """
         app: App | None = session.get(App, app_id)
         if not app:
             raise ValueError("App not found")
+        tracing_provider = cls._get_active_tracing_provider(app_id, session)
         if not app.tracing:
-            return {"enabled": False, "tracing_provider": None}
+            return {"enabled": False, "tracing_provider": tracing_provider}
         app_trace_config = _app_tracing_config_adapter.validate_json(app.tracing)
+        if not app_trace_config.get("tracing_provider"):
+            app_trace_config["tracing_provider"] = tracing_provider
         return app_trace_config
+
+    @staticmethod
+    def _get_active_tracing_provider(app_id: str, session: Session) -> str | None:
+        return session.scalar(
+            select(TraceAppConfig.tracing_provider)
+            .where(
+                TraceAppConfig.app_id == app_id,
+                TraceAppConfig.is_active.is_(True),
+                TraceAppConfig.tracing_provider.is_not(None),
+            )
+            .order_by(TraceAppConfig.updated_at.desc())
+            .limit(1)
+        )
 
     @staticmethod
     def check_trace_config_is_effective(tracing_config: dict[str, Any], tracing_provider: str):

--- a/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
+++ b/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
@@ -412,7 +412,27 @@ def test_get_app_tracing_config_errors_when_missing(mock_db):
 
 def test_get_app_tracing_config_returns_defaults(mock_db):
     mock_db.get.return_value = SimpleNamespace(tracing=None)
+    mock_db.scalar.return_value = None
     assert OpsTraceManager.get_app_tracing_config("app-id", mock_db) == {"enabled": False, "tracing_provider": None}
+
+
+def test_get_app_tracing_config_falls_back_to_active_provider(mock_db):
+    mock_db.get.return_value = SimpleNamespace(tracing=None)
+    mock_db.scalar.return_value = "langfuse"
+    assert OpsTraceManager.get_app_tracing_config("app-id", mock_db) == {
+        "enabled": False,
+        "tracing_provider": "langfuse",
+    }
+
+
+def test_get_app_tracing_config_keeps_disabled_status_with_active_provider(mock_db):
+    payload = {"enabled": False, "tracing_provider": None}
+    mock_db.get.return_value = SimpleNamespace(tracing=json.dumps(payload))
+    mock_db.scalar.return_value = "langfuse"
+    assert OpsTraceManager.get_app_tracing_config("app-id", mock_db) == {
+        "enabled": False,
+        "tracing_provider": "langfuse",
+    }
 
 
 def test_get_app_tracing_config_returns_payload(mock_db):


### PR DESCRIPTION
## Summary

Fixes #37174.

When an app already has an active tracing provider configuration but its saved app tracing status does not include `tracing_provider`, the trace settings API should still return the active provider. This lets the UI send the provider when enabling tracing instead of failing validation.

## Reproduction

1. Configure Langfuse tracing for an app.
2. Load the trace settings endpoint for the app.
3. Observe that the app tracing response can return `enabled: false` with `tracing_provider: null`, while the active trace config exists for Langfuse.
4. Toggle tracing on from the UI.
5. The enable request sends `enabled: true` without `tracing_provider` and fails with `tracing_provider is required when enabled is True`.

## Root cause

`OpsTraceManager.get_app_tracing_config()` only read `tracing_provider` from `app.tracing`. If that saved app-level tracing status was missing the provider, the response returned `null` even when `TraceAppConfig` had an active provider configuration for the same app.

## Changes

- Look up the active `TraceAppConfig.tracing_provider` for the app as a fallback.
- Return the fallback provider when `app.tracing` is empty or lacks `tracing_provider`.
- Keep the saved `enabled` value unchanged.
- Add unit coverage for the fallback provider and disabled-state behavior.

## Tests

- `python3 -m py_compile api/core/ops/ops_trace_manager.py api/tests/unit_tests/core/ops/test_ops_trace_manager.py`
- `uv run --project api --no-sync pytest --confcutdir=api/tests/unit_tests/core/ops api/tests/unit_tests/core/ops/test_ops_trace_manager.py -q` (`35 passed`)
- `uv run --project api --no-sync ruff check api/core/ops/ops_trace_manager.py api/tests/unit_tests/core/ops/test_ops_trace_manager.py`
- `uv run --project api --no-sync ruff format --check api/core/ops/ops_trace_manager.py api/tests/unit_tests/core/ops/test_ops_trace_manager.py`
- `git diff --check`

## Screenshots/Logs

N/A. Backend API fallback and unit-test change only.

## Screenshots

N/A.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Codex