### PR TITLE
fix(workflow): report truncated=True when _truncate_array drops or shortens array elements

### DIFF
--- a/api/services/variable_truncator.py
+++ b/api/services/variable_truncator.py
@@ -295,6 +295,7 @@ class VariableTruncator(BaseTruncator):
                 used_size += 1  # Account for comma
 
             if used_size > target_size:
+                truncated = True
                 break
 
             remaining_budget = target_size - used_size
@@ -304,7 +305,7 @@ class VariableTruncator(BaseTruncator):
                 raise UnknownTypeError(f"got unknown type {type(item)} in array truncation")
             truncated_value.append(part_result.value)
             used_size += part_result.value_size
-            truncated = part_result.truncated
+            truncated = truncated or part_result.truncated
         return _PartResult(truncated_value, used_size, truncated)
 
     @classmethod

--- a/api/tests/unit_tests/services/test_variable_truncator.py
+++ b/api/tests/unit_tests/services/test_variable_truncator.py
@@ -224,6 +224,34 @@ class TestArrayTruncation:
             assert isinstance(item, str)
         assert VariableTruncator.calculate_json_size(result.value) <= 50
 
+    def test_array_budget_break_sets_truncated_flag(self):
+        """Budget break drops trailing elements, so it must report truncated=True.
+
+        Regression for a defect where ``_truncate_array`` ``break``ed on the size
+        budget without flagging truncation, unlike the length-based path.
+        """
+        truncator = VariableTruncator(array_element_limit=20, max_size_bytes=1000)
+        # Each int fits individually, but the running total exceeds target_size=12,
+        # so the loop breaks at the 5th element and discards it.
+        result = truncator._truncate_array([10, 20, 30, 40, 50], 12)
+        assert result.value == [10, 20, 30, 40]  # trailing 50 was dropped
+        assert result.truncated is True
+
+    def test_array_truncated_flag_not_reset_by_later_untruncated_element(self):
+        """A later element that fits must not reset the flag set by an earlier one.
+
+        Regression for a defect where the per-element ``truncated`` flag was
+        overwritten instead of accumulated.
+        """
+        truncator = VariableTruncator(array_element_limit=20, max_size_bytes=1000, string_length_limit=10)
+        # Element 0 (long string) gets truncated; element 1 (short string) fits and
+        # must not flip the flag back to False. Both elements share one type, as
+        # real array variables are homogeneously typed.
+        result = truncator._truncate_array(["x" * 60, "a"], 60)
+        assert result.value[0] == "xxxxxxxxxx..."  # long string was truncated
+        assert result.value[1] == "a"  # short string kept intact
+        assert result.truncated is True
+
     def test_array_with_nested_objects(self, small_truncator):
         """Test array truncation with nested objects."""
         nested_array = [


### PR DESCRIPTION
Fixes #37192

## Summary

`VariableTruncator._truncate_array` could return `truncated=False` even though array data was actually dropped or shortened, in two cases:

1. **Size-limit break drops elements without flagging it** — when the running size exceeds the budget the loop `break`s and discards the remaining elements, but `truncated` was left unset. The element-count-limit branch a few lines above already returns `True` in the same situation.
2. **The per-element flag was overwritten instead of accumulated** — so an element that fit after a truncated one reset an earlier `True` back to `False`.

The fix mirrors the existing correct pattern in the sibling methods `truncate_variable_mapping` and `_truncate_object`, which accumulate the flag.

The flag funnels into `inputs_truncated`/`outputs_truncated` on the streaming node events, so a false negative reports truncated node values as untruncated. Impact is minor/cosmetic — the final `workflow_finished` output is not truncated and no data is lost.

## Screenshots

Same input (`{"result": [10, 20, 30, 40, 50]}`, small `WORKFLOW_VARIABLE_TRUNCATION_MAX_SIZE`), `node_finished` event:

| Before | After |
|--------|-------|
| `"outputs":{"result":[10]}, "outputs_truncated":false` | `"outputs":{"result":[10]}, "outputs_truncated":true` |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods