### PR TITLE
chore(api): convert BaseQueueDispatcher from ABC to Protocol

### DIFF
--- a/api/services/workflow/queue_dispatcher.py
+++ b/api/services/workflow/queue_dispatcher.py
@@ -1,13 +1,12 @@
-from typing import override
+from typing import Protocol, override
 
 """
 Queue dispatcher system for async workflow execution.
 
-Implements an ABC-based pattern for handling different subscription tiers
+Implements a Protocol-based pattern for handling different subscription tiers
 with appropriate queue routing and priority assignment.
 """
 
-from abc import ABC, abstractmethod
 from enum import StrEnum
 
 from configs import dify_config
@@ -22,18 +21,16 @@ class QueuePriority(StrEnum):
     SANDBOX = "workflow_sandbox"  # Free tier
 
 
-class BaseQueueDispatcher(ABC):
-    """Abstract base class for queue dispatchers"""
+class BaseQueueDispatcher(Protocol):
+    """Protocol for queue dispatchers"""
 
-    @abstractmethod
     def get_queue_name(self) -> str:
         """Get the queue name for this dispatcher"""
-        pass
+        ...
 
-    @abstractmethod
     def get_priority(self) -> int:
         """Get task priority level"""
-        pass
+        ...
 
 
 class ProfessionalQueueDispatcher(BaseQueueDispatcher):

--- a/api/tests/unit_tests/services/workflow/test_queue_dispatcher.py
+++ b/api/tests/unit_tests/services/workflow/test_queue_dispatcher.py
@@ -1,9 +1,6 @@
 from unittest.mock import patch
 
-import pytest
-
 from services.workflow.queue_dispatcher import (
-    BaseQueueDispatcher,
     ProfessionalQueueDispatcher,
     QueueDispatcherManager,
     QueuePriority,
@@ -34,10 +31,6 @@ class TestDispatchers:
         d = SandboxQueueDispatcher()
         assert d.get_queue_name() == QueuePriority.SANDBOX
         assert d.get_priority() == 10
-
-    def test_base_dispatcher_is_abstract(self):
-        with pytest.raises(TypeError):
-            BaseQueueDispatcher()
 
 
 class TestQueueDispatcherManager:


### PR DESCRIPTION
## Summary

Follow-up to #37158, continuing the ABC→`typing.Protocol` cleanup one focused class per PR (after #37171 `MessagesCleanPolicy`, #37182 `RecommendAppRetrievalBase`, and #37199 `BaseTruncator`).

This PR converts **`BaseQueueDispatcher`** in `api/services/workflow/queue_dispatcher.py`:

- `class BaseQueueDispatcher(ABC)` → `class BaseQueueDispatcher(Protocol)`, dropping the `@abstractmethod` decorators in favor of `...` method bodies.
- Concrete dispatchers (`ProfessionalQueueDispatcher`, `TeamQueueDispatcher`, `SandboxQueueDispatcher`) keep explicit inheritance and their `@override` markers.
- `QueueDispatcherManager.get_dispatcher` only hands out instances behind a `BaseQueueDispatcher` return annotation — no `isinstance` against the base — so `@runtime_checkable` is not needed.

## Tests

Removed the ABC-instantiation test (`test_base_dispatcher_is_abstract`), which asserted that the base cannot be instantiated — mechanics that no longer apply under `Protocol`. The dispatcher behavior tests and the `QueueDispatcherManager` factory-selection tests are retained.

- `pytest tests/unit_tests/services/workflow/test_queue_dispatcher.py` → 11 passed
- `pyrefly check services/workflow/queue_dispatcher.py` → 0 errors
- `ruff check` / `ruff format` → clean

Part of #37158