### PR TITLE
chore(api): convert PipelineTemplateRetrievalBase from ABC to Protocol

### DIFF
--- a/api/services/rag_pipeline/pipeline_template/pipeline_template_base.py
+++ b/api/services/rag_pipeline/pipeline_template/pipeline_template_base.py
@@ -1,18 +1,11 @@
-from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Protocol
 
 
-class PipelineTemplateRetrievalBase(ABC):
+class PipelineTemplateRetrievalBase(Protocol):
     """Interface for pipeline template retrieval."""
 
-    @abstractmethod
-    def get_pipeline_templates(self, language: str) -> dict[str, Any]:
-        raise NotImplementedError
+    def get_pipeline_templates(self, language: str) -> dict[str, Any]: ...
 
-    @abstractmethod
-    def get_pipeline_template_detail(self, template_id: str) -> dict[str, Any] | None:
-        raise NotImplementedError
+    def get_pipeline_template_detail(self, template_id: str) -> dict[str, Any] | None: ...
 
-    @abstractmethod
-    def get_type(self) -> str:
-        raise NotImplementedError
+    def get_type(self) -> str: ...

--- a/api/tests/unit_tests/services/rag_pipeline/pipeline_template/test_pipeline_template_base.py
+++ b/api/tests/unit_tests/services/rag_pipeline/pipeline_template/test_pipeline_template_base.py
@@ -1,5 +1,3 @@
-import pytest
-
 from services.rag_pipeline.pipeline_template.pipeline_template_base import PipelineTemplateRetrievalBase
 
 
@@ -14,30 +12,9 @@ class DummyRetrieval(PipelineTemplateRetrievalBase):
         return "dummy"
 
 
-class MissingTypeRetrieval(PipelineTemplateRetrievalBase):
-    def get_pipeline_templates(self, language: str) -> dict:
-        return {"language": language}
-
-    def get_pipeline_template_detail(self, template_id: str) -> dict | None:
-        return {"id": template_id}
-
-
 def test_pipeline_template_retrieval_base_concrete_implementation() -> None:
     retrieval = DummyRetrieval()
 
     assert retrieval.get_pipeline_templates("en-US") == {"language": "en-US"}
     assert retrieval.get_pipeline_template_detail("tpl-1") == {"id": "tpl-1"}
     assert retrieval.get_type() == "dummy"
-
-
-def test_pipeline_template_retrieval_base_requires_abstract_methods() -> None:
-    assert "get_type" in MissingTypeRetrieval.__abstractmethods__
-
-
-def test_pipeline_template_retrieval_base_default_methods_raise() -> None:
-    with pytest.raises(NotImplementedError):
-        PipelineTemplateRetrievalBase.get_pipeline_templates(DummyRetrieval(), "en-US")
-    with pytest.raises(NotImplementedError):
-        PipelineTemplateRetrievalBase.get_pipeline_template_detail(DummyRetrieval(), "tpl-1")
-    with pytest.raises(NotImplementedError):
-        PipelineTemplateRetrievalBase.get_type(DummyRetrieval())


### PR DESCRIPTION
## Summary

Follow-up to #37158, continuing the ABC→`typing.Protocol` cleanup one focused class per PR (after #37171 `MessagesCleanPolicy`, #37182 `RecommendAppRetrievalBase`, #37199 `BaseTruncator`, and #37200 `BaseQueueDispatcher`).

This PR converts **`PipelineTemplateRetrievalBase`** in `api/services/rag_pipeline/pipeline_template/pipeline_template_base.py`:

- `class PipelineTemplateRetrievalBase(ABC)` → `class PipelineTemplateRetrievalBase(Protocol)`, dropping the `@abstractmethod` decorators and the `raise NotImplementedError` bodies in favor of `...`.
- The four concrete retrievals (`built_in`, `customized`, `database`, `remote`) keep explicit inheritance and their `@override` markers.
- `PipelineTemplateRetrievalFactory` only returns subclasses behind a `type[PipelineTemplateRetrievalBase]` annotation — no `isinstance` against the base — so `@runtime_checkable` is not needed.

## Tests

Removed the two ABC-mechanics tests (`__abstractmethods__` assertion and the `NotImplementedError` default-method test) plus the `MissingTypeRetrieval` helper that only existed to exercise them. These asserted ABC internals that no longer apply under `Protocol`.

The retrieval contract stays covered by:
- the concrete-implementation behavior test in `test_pipeline_template_base.py`, and
- the existing factory-selection tests in `test_pipeline_template_factory.py` (all four modes + invalid mode + built-in).

- `pytest tests/unit_tests/services/rag_pipeline/pipeline_template/` → 30 passed
- `pyrefly check` (base + factory + 4 concrete retrievals) → 0 errors
- `ruff check` / `ruff format` → clean

Part of #37158