### PR TITLE
chore(api): convert AppContext from ABC to Protocol

### DIFF
--- a/api/context/execution_context.py
+++ b/api/context/execution_context.py
@@ -7,7 +7,6 @@ consumes injected context managers when it needs to preserve thread-local state.
 
 import contextvars
 import threading
-from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator
 from contextlib import AbstractContextManager, contextmanager
 from typing import Any, Protocol, final, override, runtime_checkable
@@ -15,28 +14,25 @@ from typing import Any, Protocol, final, override, runtime_checkable
 from pydantic import BaseModel
 
 
-class AppContext(ABC):
+class AppContext(Protocol):
     """
-    Abstract application context interface.
+    Application context interface.
 
     Application adapters can implement this to restore framework-specific state
     such as Flask app context around worker execution.
     """
 
-    @abstractmethod
     def get_config(self, key: str, default: Any = None) -> Any:
         """Get configuration value by key."""
-        raise NotImplementedError
+        ...
 
-    @abstractmethod
     def get_extension(self, name: str) -> Any:
         """Get application extension by name."""
-        raise NotImplementedError
+        ...
 
-    @abstractmethod
     def enter(self) -> AbstractContextManager[None]:
         """Enter the application context."""
-        raise NotImplementedError
+        ...
 
 
 @runtime_checkable

--- a/api/tests/unit_tests/core/workflow/context/test_execution_context.py
+++ b/api/tests/unit_tests/core/workflow/context/test_execution_context.py
@@ -20,15 +20,6 @@ from context.execution_context import (
 )
 
 
-class TestAppContext:
-    """Test AppContext abstract base class."""
-
-    def test_app_context_is_abstract(self):
-        """Test that AppContext cannot be instantiated directly."""
-        with pytest.raises(TypeError):
-            AppContext()  # type: ignore
-
-
 class TestNullAppContext:
     """Test NullAppContext implementation."""
 


### PR DESCRIPTION
## Summary

Follow-up to #37158, continuing the ABC→`typing.Protocol` cleanup one focused class per PR (after #37171, #37182, #37199, #37200, and #37201). This converts **`AppContext`** in `api/context/execution_context.py` — the last of the convertible candidates.

- `class AppContext(ABC)` → `class AppContext(Protocol)`, dropping the `@abstractmethod` decorators and `raise NotImplementedError` bodies in favor of `...`.
- `NullAppContext` and `FlaskAppContext` keep explicit inheritance and their `@override` markers.
- Consumers (`ExecutionContext`, `ExecutionContextBuilder`) reference `AppContext` only as a type annotation — no `isinstance` against the base — so `@runtime_checkable` is not needed. (Note: the sibling `IExecutionContext` Protocol in the same module is already `@runtime_checkable`; `AppContext` has no such runtime usage.)

## Tests

Removed the now-meaningless ABC-instantiation test (`TestAppContext.test_app_context_is_abstract`), which asserted that the base cannot be instantiated — mechanics that no longer apply under `Protocol`. Behavior coverage on `NullAppContext` and the thread-safety `TrackingAppContext` implementation (which still inherits `AppContext`) is retained.

- `pytest tests/unit_tests/core/workflow/context/` → 40 passed
- `pyrefly check context/execution_context.py context/flask_app_context.py` → 0 errors
- `ruff check` / `ruff format` → clean

## Note on BaseStorage

`BaseStorage` is intentionally left as an ABC and not part of this series — it carries a concrete default `scan()` plus many backend subclasses, making the conversion high-churn for little gain. With this PR, the remaining ABC→Protocol candidates from #37158 that are clean to convert are done.

Part of #37158