### PR TITLE
fix: VariableTruncator._truncate_array under-reports truncated flag

### DIFF
--- a/api/services/variable_truncator.py
+++ b/api/services/variable_truncator.py
@@ -292,6 +292,7 @@ class VariableTruncator(BaseTruncator):
                 used_size += 1  # Account for comma
 
             if used_size > target_size:
+                truncated = True
                 break
 
             remaining_budget = target_size - used_size
@@ -301,7 +302,7 @@ class VariableTruncator(BaseTruncator):
                 raise UnknownTypeError(f"got unknown type {type(item)} in array truncation")
             truncated_value.append(part_result.value)
             used_size += part_result.value_size
-            truncated = part_result.truncated
+            truncated = truncated or part_result.truncated
         return _PartResult(truncated_value, used_size, truncated)
 
     @classmethod


### PR DESCRIPTION
## Summary

Fixes two bugs in `VariableTruncator._truncate_array` that caused the `truncated` flag to be under-reported:

1. **Size-limit break path**: When `used_size > target_size`, the loop `break`s without setting `truncated = True`, so dropped tail elements are not reflected in the flag.
2. **Overwrite instead of accumulation**: `truncated = part_result.truncated` overwrites the flag on each iteration. If an earlier element was truncated but a later element fits, the flag is incorrectly reset to `False`.

Both sibling methods (`truncate_variable_mapping` and `_truncate_object`) correctly accumulate the flag with `|=` or `or`.

## Changes

- Added `truncated = True` before the size-limit `break`
- Changed `truncated = part_result.truncated` to `truncated = truncated or part_result.truncated`

## Test plan

- [x] Case 1: size-limit break — `truncated=True` when tail elements are dropped
- [x] Case 2: flag accumulation — truncated flag preserved when later element fits
- [x] Case 3: no truncation — `truncated=False` unchanged
- [x] Case 4: element limit — `truncated=True` unchanged

Fixes #37192