### PR TITLE
refactor(openapi): unify request validation behind @accepts/@returns decorators

### DIFF
--- a/api/controllers/openapi/_contract.py
+++ b/api/controllers/openapi/_contract.py
@@ -1,0 +1,88 @@
+"""Request/response contract decorators for the openapi controllers.
+
+Each openapi handler used to declare its request/response shape twice against
+the same Pydantic model — once for Swagger (``@openapi_ns.doc(params=...)`` /
+``@openapi_ns.response(...)`` / ``@openapi_ns.expect(...)``) and once for runtime
+behaviour (inline ``model_validate`` / ``.model_dump``). The two could drift, and
+the inline copies disagreed on the failure status (422 vs 400).
+
+``@accepts`` and ``@returns`` each own one slice of the contract from a single
+model reference: they emit the Swagger schema AND perform the runtime
+validation/serialisation, so doc and behaviour can no longer diverge. Validation
+failures map to a single shape — 422 with ``ValidationError.json()``.
+
+These decorators must sit BELOW ``@auth_router.guard`` (guard stays outermost) so
+that auth runs before validation, and so the unit-test ``view.__wrapped__`` seam
+keeps unwrapping exactly the guard layer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import wraps
+from typing import Any
+
+from flask import request
+from pydantic import BaseModel, ValidationError
+from werkzeug.exceptions import UnprocessableEntity
+
+from controllers.common.schema import query_params_from_model, query_params_from_request
+from controllers.openapi import openapi_ns
+
+
+def accepts(*, query: type[BaseModel] | None = None, body: type[BaseModel] | None = None) -> Callable:
+    """Validate the request against ``query``/``body`` models and inject them as typed kwargs.
+
+    Emits the matching Swagger param/body schema from the same models, so the
+    advertised contract and the enforced contract stay in lockstep. Injects the
+    validated models under the keyword arguments ``query`` and ``body``; the
+    handler declares them as keyword-only parameters.
+    """
+
+    def decorator(view: Callable) -> Callable:
+        @wraps(view)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                if query is not None:
+                    kwargs["query"] = query_params_from_request(query)
+                if body is not None:
+                    kwargs["body"] = body.model_validate(request.get_json(silent=True) or {})
+            except ValidationError as exc:
+                raise UnprocessableEntity(exc.json())
+            return view(*args, **kwargs)
+
+        if query is not None:
+            openapi_ns.doc(params=query_params_from_model(query))(wrapper)
+        if body is not None:
+            openapi_ns.expect(openapi_ns.models[body.__name__])(wrapper)
+        return wrapper
+
+    return decorator
+
+
+def returns(code: int, model: type[BaseModel], description: str | None = None) -> Callable:
+    """Serialise the handler's returned Pydantic model and emit the response schema.
+
+    The handler returns a ``BaseModel`` (serialised with ``code``) or a
+    ``(payload, status)`` tuple (the model in ``payload`` is serialised, the
+    status is honoured). Anything else — a dict, a ``flask.Response`` (e.g. an SSE
+    stream) — is passed through untouched.
+    """
+
+    def decorator(view: Callable) -> Callable:
+        @wraps(view)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            result = view(*args, **kwargs)
+            if isinstance(result, tuple):
+                payload, status = result
+                if isinstance(payload, BaseModel):
+                    payload = payload.model_dump(mode="json")
+                return payload, status
+            if isinstance(result, BaseModel):
+                return result.model_dump(mode="json"), code
+            return result
+
+        openapi_ns.response(code, description or model.__name__, openapi_ns.models[model.__name__])(wrapper)
+        return wrapper
+
+    return decorator

--- a/api/controllers/openapi/account.py
+++ b/api/controllers/openapi/account.py
@@ -2,17 +2,14 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from flask import request
 from flask_restx import Resource
-from pydantic import ValidationError
-from werkzeug.exceptions import NotFound, UnprocessableEntity
+from werkzeug.exceptions import NotFound
 
-from controllers.common.schema import query_params_from_model
 from controllers.openapi import openapi_ns
+from controllers.openapi._contract import accepts, returns
 from controllers.openapi._models import (
     AccountPayload,
     AccountResponse,
-    PaginationEnvelope,
     RevokeResponse,
     SessionListQuery,
     SessionListResponse,
@@ -72,17 +69,13 @@ class AccountSessionsSelfApi(Resource):
 
 @openapi_ns.route("/account/sessions")
 class AccountSessionsApi(Resource):
-    @openapi_ns.doc(params=query_params_from_model(SessionListQuery))
-    @openapi_ns.response(200, "Session list", openapi_ns.models[SessionListResponse.__name__])
     @auth_router.guard(scope=Scope.FULL, allowed_token_types=frozenset({TokenType.OAUTH_ACCOUNT}))
-    def get(self, *, auth_data: AuthData):
-        # Validate page/limit through the same model the contract advertises (extra='forbid',
-        # page>=1, 1<=limit<=MAX_PAGE_LIMIT) so the server actually enforces those bounds rather
-        # than silently coercing (e.g. page=0 -> empty slice). Mirrors AppDescribeQuery.
-        try:
-            query = SessionListQuery.model_validate(request.args.to_dict(flat=True))
-        except ValidationError as exc:
-            raise UnprocessableEntity(exc.json())
+    @returns(200, SessionListResponse, description="Session list")
+    @accepts(query=SessionListQuery)
+    def get(self, *, auth_data: AuthData, query: SessionListQuery):
+        # SessionListQuery enforces the advertised bounds (extra='forbid', page>=1,
+        # 1<=limit<=MAX_PAGE_LIMIT) so the server rejects out-of-range paging rather
+        # than silently coercing (e.g. page=0 -> empty slice).
         ctx = get_auth_ctx()
         now = datetime.now(UTC)
         page = query.page
@@ -106,9 +99,12 @@ class AccountSessionsApi(Resource):
             for r in sliced
         ]
 
-        return (
-            PaginationEnvelope.build(page=page, limit=limit, total=total, items=items).model_dump(mode="json"),
-            200,
+        return SessionListResponse(
+            page=page,
+            limit=limit,
+            total=total,
+            has_more=page * limit < total,
+            data=items,
         )
 
 

--- a/api/controllers/openapi/app_run.py
+++ b/api/controllers/openapi/app_run.py
@@ -7,14 +7,13 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from typing import Any
 
-from flask import request
 from flask_restx import Resource
-from pydantic import ValidationError
 from werkzeug.exceptions import BadRequest, HTTPException, InternalServerError, NotFound, UnprocessableEntity
 
 import services
 from controllers.openapi import openapi_ns
 from controllers.openapi._audit import emit_app_run
+from controllers.openapi._contract import accepts
 from controllers.openapi._models import AppRunRequest, TaskStopResponse
 from controllers.openapi.auth.composition import auth_router
 from controllers.openapi.auth.data import AuthData
@@ -123,23 +122,18 @@ _DISPATCH: dict[AppMode, Callable[[App, Any, AppRunRequest], Any]] = {
 
 @openapi_ns.route("/apps/<string:app_id>/run")
 class AppRunApi(Resource):
-    @openapi_ns.expect(openapi_ns.models[AppRunRequest.__name__])
-    @openapi_ns.response(200, "Run result (SSE stream)")
     @auth_router.guard(scope=Scope.APPS_RUN)
-    def post(self, app_id: str, *, auth_data: AuthData):
+    @openapi_ns.response(200, "Run result (SSE stream)")
+    @accepts(body=AppRunRequest)
+    def post(self, app_id: str, *, auth_data: AuthData, body: AppRunRequest):
         app_model, caller, caller_kind = auth_data.require_app_context()
-        body = request.get_json(silent=True) or {}
-        try:
-            payload = AppRunRequest.model_validate(body)
-        except ValidationError as exc:
-            raise UnprocessableEntity(exc.json())
 
         handler = _DISPATCH.get(app_model.mode)
         if handler is None:
             raise UnprocessableEntity("mode_not_runnable")
 
         try:
-            stream_obj = handler(app_model, caller, payload)
+            stream_obj = handler(app_model, caller, body)
         except HTTPException:
             raise
         except Exception:

--- a/api/controllers/openapi/apps.py
+++ b/api/controllers/openapi/apps.py
@@ -5,14 +5,12 @@ from __future__ import annotations
 import uuid as _uuid
 from typing import Any, cast
 
-from flask import request
 from flask_restx import Resource
-from pydantic import ValidationError
 from werkzeug.exceptions import Conflict, NotFound, UnprocessableEntity
 
 from controllers.common.fields import Parameters
-from controllers.common.schema import query_params_from_model
 from controllers.openapi import openapi_ns
+from controllers.openapi._contract import accepts, returns
 from controllers.openapi._input_schema import EMPTY_INPUT_SCHEMA, build_input_schema, resolve_app_config
 from controllers.openapi._models import (
     AppDescribeInfo,
@@ -88,15 +86,10 @@ def parameters_payload(app: App) -> dict:
 
 @openapi_ns.route("/apps/<string:app_id>/describe")
 class AppDescribeApi(AppReadResource):
-    @openapi_ns.doc(params=query_params_from_model(AppDescribeQuery))
-    @openapi_ns.response(200, "App description", openapi_ns.models[AppDescribeResponse.__name__])
     @auth_router.guard(scope=Scope.APPS_READ, allowed_token_types=frozenset({TokenType.OAUTH_ACCOUNT}))
-    def get(self, app_id: str, *, auth_data: AuthData):
-        try:
-            query = AppDescribeQuery.model_validate(request.args.to_dict(flat=True))
-        except ValidationError as exc:
-            raise UnprocessableEntity(exc.json())
-
+    @returns(200, AppDescribeResponse, description="App description")
+    @accepts(query=AppDescribeQuery)
+    def get(self, app_id: str, *, auth_data: AuthData, query: AppDescribeQuery):
         app = self._load(app_id, workspace_id=query.workspace_id)
 
         requested = query.fields
@@ -133,35 +126,22 @@ class AppDescribeApi(AppReadResource):
             except AppUnavailableError:
                 input_schema = dict(EMPTY_INPUT_SCHEMA)
 
-        return (
-            AppDescribeResponse(
-                info=info,
-                parameters=parameters,
-                input_schema=input_schema,
-            ).model_dump(mode="json", exclude_none=False),
-            200,
+        return AppDescribeResponse(
+            info=info,
+            parameters=parameters,
+            input_schema=input_schema,
         )
 
 
 @openapi_ns.route("/apps")
 class AppListApi(Resource):
-    @openapi_ns.doc(params=query_params_from_model(AppListQuery))
-    @openapi_ns.response(200, "App list", openapi_ns.models[AppListResponse.__name__])
     @auth_router.guard_workspace(scope=Scope.APPS_READ, allowed_token_types=frozenset({TokenType.OAUTH_ACCOUNT}))
-    def get(self, *, auth_data: AuthData):
-        try:
-            query: AppListQuery = AppListQuery.model_validate(request.args.to_dict(flat=True))
-        except ValidationError as exc:
-            raise UnprocessableEntity(exc.json())
-
+    @returns(200, AppListResponse, description="App list")
+    @accepts(query=AppListQuery)
+    def get(self, *, auth_data: AuthData, query: AppListQuery):
         workspace_id = query.workspace_id
 
-        empty = (
-            AppListResponse(page=query.page, limit=query.limit, total=0, has_more=False, data=[]).model_dump(
-                mode="json"
-            ),
-            200,
-        )
+        empty = AppListResponse(page=query.page, limit=query.limit, total=0, has_more=False, data=[])
 
         if query.name:
             try:
@@ -189,7 +169,7 @@ class AppListApi(Resource):
                 workspace_name=tenant_name,
             )
             env = AppListResponse(page=1, limit=1, total=1, has_more=False, data=[item])
-            return env.model_dump(mode="json"), 200
+            return env
 
         tag_ids: list[str] | None = None
         if query.tag:
@@ -240,4 +220,4 @@ class AppListApi(Resource):
             has_more=query.page * query.limit < cast(int, pagination.total),
             data=items,
         )
-        return env.model_dump(mode="json"), 200
+        return env

--- a/api/controllers/openapi/apps_permitted_external.py
+++ b/api/controllers/openapi/apps_permitted_external.py
@@ -7,12 +7,10 @@ EE blueprint chain so this module is unreachable there.
 
 from __future__ import annotations
 
-from flask import request
 from flask_restx import Resource
-from pydantic import ValidationError
-from werkzeug.exceptions import UnprocessableEntity
 
 from controllers.openapi import openapi_ns
+from controllers.openapi._contract import accepts, returns
 from controllers.openapi._models import (
     AppListRow,
     PermittedExternalAppsListQuery,
@@ -30,20 +28,14 @@ from services.enterprise.app_permitted_service import list_permitted_apps
 
 @openapi_ns.route("/permitted-external-apps")
 class PermittedExternalAppsListApi(Resource):
-    @openapi_ns.response(
-        200, "Permitted external apps list", openapi_ns.models[PermittedExternalAppsListResponse.__name__]
-    )
     @auth_router.guard(
         scope=Scope.APPS_READ_PERMITTED_EXTERNAL,
         allowed_token_types=frozenset({TokenType.OAUTH_EXTERNAL_SSO}),
         edition=frozenset({Edition.EE}),
     )
-    def get(self, *, auth_data: AuthData):
-        try:
-            query = PermittedExternalAppsListQuery.model_validate(request.args.to_dict(flat=True))
-        except ValidationError as exc:
-            raise UnprocessableEntity(exc.json())
-
+    @returns(200, PermittedExternalAppsListResponse, description="Permitted external apps list")
+    @accepts(query=PermittedExternalAppsListQuery)
+    def get(self, *, auth_data: AuthData, query: PermittedExternalAppsListQuery):
         page_result = list_permitted_apps(
             page=query.page,
             limit=query.limit,
@@ -55,7 +47,7 @@ class PermittedExternalAppsListApi(Resource):
             env = PermittedExternalAppsListResponse(
                 page=query.page, limit=query.limit, total=page_result.total, has_more=False, data=[]
             )
-            return env.model_dump(mode="json"), 200
+            return env
 
         apps_by_id: dict[str, App] = {
             str(a.id): a for a in AppService.find_visible_apps_by_ids(db.session, page_result.app_ids)
@@ -89,4 +81,4 @@ class PermittedExternalAppsListApi(Resource):
             has_more=query.page * query.limit < page_result.total,
             data=items,
         )
-        return env.model_dump(mode="json"), 200
+        return env

--- a/api/controllers/openapi/workspaces.py
+++ b/api/controllers/openapi/workspaces.py
@@ -20,8 +20,8 @@ from pydantic import BaseModel, ValidationError
 from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
 from configs import dify_config
-from controllers.common.schema import query_params_from_model
 from controllers.openapi import openapi_ns
+from controllers.openapi._contract import accepts, returns
 from controllers.openapi._models import (
     MemberActionResponse,
     MemberInvitePayload,
@@ -174,15 +174,10 @@ class WorkspaceMembersApi(Resource):
     assigned through invite (ownership transfer is console-only).
     """
 
-    @openapi_ns.doc(params=query_params_from_model(MemberListQuery))
-    @openapi_ns.response(200, "Member list", openapi_ns.models[MemberListResponse.__name__])
     @auth_router.guard_workspace(scope=Scope.WORKSPACE_READ, allowed_token_types=frozenset({TokenType.OAUTH_ACCOUNT}))
-    def get(self, workspace_id: str, *, auth_data: AuthData):
-        try:
-            query = MemberListQuery.model_validate(request.args.to_dict(flat=True))
-        except ValidationError as exc:
-            raise BadRequest(str(exc))
-
+    @returns(200, MemberListResponse, description="Member list")
+    @accepts(query=MemberListQuery)
+    def get(self, workspace_id: str, *, auth_data: AuthData, query: MemberListQuery):
         tenant = _load_tenant(workspace_id)
         members = TenantService.get_tenant_members(tenant)
         total = len(members)
@@ -194,7 +189,7 @@ class WorkspaceMembersApi(Resource):
             total=total,
             has_more=query.page * query.limit < total,
             data=[_member_response(m) for m in page_items],
-        ).model_dump(mode="json"), 200
+        )
 
     @openapi_ns.expect(openapi_ns.models[MemberInvitePayload.__name__])
     @openapi_ns.response(201, "Member invited", openapi_ns.models[MemberInviteResponse.__name__])

--- a/api/tests/unit_tests/controllers/openapi/test_contract.py
+++ b/api/tests/unit_tests/controllers/openapi/test_contract.py
@@ -1,0 +1,131 @@
+"""Unit tests for the @accepts / @returns contract decorators.
+
+Exercises the decorators in isolation (not through a real controller): a plain
+view function decorated with @accepts/@returns, driven inside a request context.
+"""
+
+import pytest
+from pydantic import BaseModel, ConfigDict, Field
+from werkzeug.exceptions import UnprocessableEntity
+
+from controllers.common.schema import register_response_schema_model, register_schema_model
+from controllers.openapi import openapi_ns
+from controllers.openapi._contract import accepts, returns
+
+
+class ContractQuery(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    page: int = Field(1, ge=1)
+    limit: int = Field(20, ge=1, le=100)
+
+
+class ContractBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+
+
+class ContractResp(BaseModel):
+    value: int
+
+
+# @accepts(body=) and @returns emit Swagger via openapi_ns, which resolves models
+# by name — register the body/response models so those lookups succeed.
+register_schema_model(openapi_ns, ContractBody)
+register_response_schema_model(openapi_ns, ContractResp)
+
+
+def test_accepts_injects_validated_query(app):
+    @accepts(query=ContractQuery)
+    def view(*, query):
+        return query
+
+    with app.test_request_context("/?page=3&limit=5"):
+        result = view()
+
+    assert isinstance(result, ContractQuery)
+    assert result.page == 3
+    assert result.limit == 5
+
+
+def test_accepts_query_uses_defaults_when_absent(app):
+    @accepts(query=ContractQuery)
+    def view(*, query):
+        return query
+
+    with app.test_request_context("/"):
+        result = view()
+
+    assert result.page == 1
+    assert result.limit == 20
+
+
+@pytest.mark.parametrize("query_string", ["page=0", "limit=999", "page=abc", "unknown=1"])
+def test_accepts_rejects_invalid_query_with_422(app, query_string):
+    @accepts(query=ContractQuery)
+    def view(*, query):
+        return query
+
+    with app.test_request_context(f"/?{query_string}"):
+        with pytest.raises(UnprocessableEntity):
+            view()
+
+
+def test_accepts_injects_validated_body(app):
+    @accepts(body=ContractBody)
+    def view(*, body):
+        return body
+
+    with app.test_request_context("/", method="POST", json={"name": "x"}):
+        result = view()
+
+    assert isinstance(result, ContractBody)
+    assert result.name == "x"
+
+
+def test_accepts_rejects_invalid_body_with_422(app):
+    @accepts(body=ContractBody)
+    def view(*, body):
+        return body
+
+    with app.test_request_context("/", method="POST", json={"wrong": 1}):
+        with pytest.raises(UnprocessableEntity):
+            view()
+
+
+def test_returns_serializes_model_with_decorator_status(app):
+    @returns(200, ContractResp)
+    def view():
+        return ContractResp(value=7)
+
+    with app.test_request_context("/"):
+        body, status = view()
+
+    assert status == 200
+    assert body == {"value": 7}
+
+
+def test_returns_serializes_model_in_tuple_and_honors_status(app):
+    @returns(200, ContractResp)
+    def view():
+        return ContractResp(value=9), 201
+
+    with app.test_request_context("/"):
+        body, status = view()
+
+    assert status == 201
+    assert body == {"value": 9}
+
+
+def test_returns_passes_through_non_model(app):
+    sentinel = object()
+
+    @returns(200, ContractResp)
+    def view():
+        return sentinel
+
+    with app.test_request_context("/"):
+        result = view()
+
+    assert result is sentinel

--- a/api/tests/unit_tests/controllers/openapi/test_workspaces_members.py
+++ b/api/tests/unit_tests/controllers/openapi/test_workspaces_members.py
@@ -29,7 +29,7 @@ import pytest
 from flask import Flask
 from flask.views import MethodView
 from pydantic import ValidationError
-from werkzeug.exceptions import BadRequest, Forbidden, NotFound
+from werkzeug.exceptions import BadRequest, Forbidden, NotFound, UnprocessableEntity
 
 from controllers.openapi import bp as openapi_bp
 from controllers.openapi._models import MemberInvitePayload, MemberRoleUpdatePayload
@@ -384,7 +384,7 @@ def test_members_list_paginates_with_query_params(app, bypass_pipeline, monkeypa
 
 
 def test_members_list_rejects_unknown_query_param(app, bypass_pipeline, monkeypatch):
-    """Strict (`extra='forbid'`) — typos like `?pg=2` surface as 400."""
+    """Strict (`extra='forbid'`) — typos like `?pg=2` surface as 422 (unified via @accepts)."""
     ws_id = str(uuid.uuid4())
     acct_id = uuid.uuid4()
     api = WorkspaceMembersApi()
@@ -395,7 +395,7 @@ def test_members_list_rejects_unknown_query_param(app, bypass_pipeline, monkeypa
 
     with app.test_request_context(f"/openapi/v1/workspaces/{ws_id}/members?pg=2"):
         _seed(_auth_ctx(account_id=acct_id))
-        with pytest.raises(BadRequest):
+        with pytest.raises(UnprocessableEntity):
             api.get.__wrapped__(api, workspace_id=ws_id, auth_data=_auth_data(acct_id))
 
 


### PR DESCRIPTION
## Summary

Follow-up to #37090. Each openapi handler declared its request/response shape **twice** against the same Pydantic model — once for Swagger (`@openapi_ns.doc(params=...)` / `@openapi_ns.response(...)` / `@openapi_ns.expect(...)`) and once for runtime behavior (inline `model_validate` / `.model_dump`) — letting the advertised contract and the enforced contract drift. The inline copies also disagreed on the failure status (422 vs 400).

This adds two decorators in `controllers/openapi/_contract.py`, each owning one slice of the contract from a single model reference:

- **`@accepts(query=, body=)`** — validates the request, injects the validated model as a typed kwarg, and emits the Swagger param/body schema. Validation failures map to one shape: **422** with `ValidationError.json()`.
- **`@returns(status, model)`** — emits the response schema and serializes the handler's returned model; non-model returns (e.g. the app-run SSE stream) pass through.

Six handlers migrate onto them — apps describe/list, account sessions, permitted-external apps, workspace members, app run — so each model is referenced once and the two contracts can no longer diverge.

**Behavior change:** `GET /workspaces/<id>/members` now returns **422** (was 400) on an invalid query, unifying it with the other openapi validation failures.

Both decorators sit below `@auth_router.guard` so auth runs before validation. Scope is the `openapi/` surface only; OAuth device-flow controllers (RFC 8628 error bodies) are excluded. The app-run handler keeps its hand-written SSE response (no response model). Response-side serialization for non-trivial cases and the `@doc` prose split are left for follow-ups.

## Screenshots

N/A — backend-only change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Claude Code.