### PR TITLE
fix: Weaviate BM25 full-text search drops results due to missing score extraction

### DIFF
--- a/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
@@ -480,6 +480,7 @@ class WeaviateVector(BaseVector):
                 query_properties=[Field.TEXT_KEY.value],
                 limit=top_k,
                 return_properties=props,
+                return_metadata=MetadataQuery(score=True),
                 include_vector=True,
                 filters=where,
             )
@@ -490,6 +491,7 @@ class WeaviateVector(BaseVector):
                 query_properties=[Field.TEXT_KEY.value],
                 limit=top_k,
                 return_properties=props,
+                return_metadata=MetadataQuery(score=True),
                 include_vector=True,
                 filters=where,
             )
@@ -502,6 +504,9 @@ class WeaviateVector(BaseVector):
             vec = obj.vector
             if isinstance(vec, dict):
                 vec = vec.get("default") or next(iter(vec.values()), None)
+
+            if obj.metadata and obj.metadata.score is not None:
+                properties["score"] = obj.metadata.score
 
             docs.append(Document(page_content=text, vector=vec, metadata=properties))
         return docs


### PR DESCRIPTION
## Summary

Fixes a bug where Weaviate BM25 full-text search always drops results because scores are not requested from Weaviate and not extracted from response metadata, causing all matches to get a default score of `0.0`.

The fix mirrors the existing pattern used in `search_by_vector` (Dense Retrieval) which already calls `MetadataQuery(distance=True)`.

## Root Cause

In `search_by_full_text`:
1. `col.query.bm25()` was called without `return_metadata=MetadataQuery(score=True)`, so Weaviate didn't return scores
2. Even when scores were available, they weren't extracted from `obj.metadata.score`

## Changes

Three additions to `api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py`:

1. Added `return_metadata=MetadataQuery(score=True)` to the first `col.query.bm25()` call
2. Added `return_metadata=MetadataQuery(score=True)` to the fallback `col.query.bm25()` call
3. Added score extraction: `properties["score"] = obj.metadata.score` when available

## Test plan

- [x] BM25 scores are now requested from Weaviate via `MetadataQuery(score=True)`
- [x] Scores are extracted from `obj.metadata.score` and propagated to `Document.metadata`
- [x] The `search_by_vector` method already uses this pattern (`MetadataQuery(distance=True)`) — this fix aligns `search_by_full_text` with the existing convention

Fixes #37045