### PR TITLE
fix: tool_calls leaks to non-assistant messages in saved prompt history

### DIFF
--- a/api/core/prompt/utils/prompt_message_util.py
+++ b/api/core/prompt/utils/prompt_message_util.py
@@ -24,8 +24,8 @@ class PromptMessageUtil:
         """
         prompts = []
         if model_mode == ModelMode.CHAT:
-            tool_calls = []
             for prompt_message in prompt_messages:
+                tool_calls: list[dict[str, Any]] = []
                 if prompt_message.role == PromptMessageRole.USER:
                     role = "user"
                 elif prompt_message.role == PromptMessageRole.ASSISTANT:


### PR DESCRIPTION
## Summary

Fixes a bug where `tool_calls` from an assistant message leaks onto subsequent tool/user/system messages in the saved prompt history (`CHAT` mode).

## Root Cause

In `PromptMessageUtil.prompt_messages_to_prompt_for_saving`, the `tool_calls` variable was initialized once **outside** the per-message loop and only reassigned inside the assistant branch. The check `if tool_calls:` runs for every message, so after an assistant message that sets `tool_calls`, the next message (tool result, user, system) incorrectly inherits the stale value.

## Fix

Move `tool_calls = []` inside the loop so it's reset to empty for each message iteration. Now `tool_calls` is only populated for assistant messages that actually contain tool calls.

## Test plan

- [x] Assistant message with tool_calls: `tool_calls` correctly added to prompt
- [x] Subsequent tool message: `tool_calls` is empty, not leaked
- [x] Subsequent user message: `tool_calls` is empty, not leaked
- [x] Assistant message without tool_calls: `tool_calls` is empty

Fixes #37095