### PR TITLE
refactor(web): migrate automatic generator model storage

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -407,9 +407,6 @@
     }
   },
   "web/app/components/app/configuration/config/automatic/get-automatic-res.tsx": {
-    "no-restricted-globals": {
-      "count": 6
-    },
     "react/set-state-in-effect": {
       "count": 4
     },

--- a/web/app/components/app/configuration/config/automatic/__tests__/get-automatic-res.spec.tsx
+++ b/web/app/components/app/configuration/config/automatic/__tests__/get-automatic-res.spec.tsx
@@ -46,13 +46,19 @@ vi.mock('@/service/debug', () => ({
 
 vi.mock('@/app/components/header/account-setting/model-provider-page/model-parameter-modal', () => ({
   default: ({
+    modelId,
+    provider,
     setModel,
     onCompletionParamsChange,
   }: {
+    modelId: string
+    provider: string
     setModel: (value: { modelId: string, provider: string, mode?: string, features?: string[] }) => void
     onCompletionParamsChange: (value: Record<string, unknown>) => void
   }) => (
     <div>
+      <div data-testid="selected-model">{modelId}</div>
+      <div data-testid="selected-provider">{provider}</div>
       <button onClick={() => setModel({ modelId: 'gpt-4o-mini', provider: 'openai', mode: 'chat' })}>change-model</button>
       <button onClick={() => onCompletionParamsChange({ temperature: 0.3 })}>change-params</button>
     </div>
@@ -169,6 +175,33 @@ describe('GetAutomaticRes', () => {
 
     fireEvent.click(screen.getByText('change-params'))
     expect(localStorage.getItem('auto-gen-model')).toContain('"temperature":0.3')
+  })
+
+  it('should initialize model selection from local storage', async () => {
+    localStorage.setItem('auto-gen-model', JSON.stringify({
+      name: 'stored-model',
+      provider: 'stored-provider',
+      mode: 'chat',
+      completion_params: {
+        temperature: 0.5,
+      },
+    }))
+
+    render(
+      <GetAutomaticRes
+        mode={AppModeEnum.CHAT}
+        isShow
+        onClose={mockOnClose}
+        onFinished={mockOnFinished}
+        flowId="flow-1"
+        isBasicMode
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-model')).toHaveTextContent('stored-model')
+      expect(screen.getByTestId('selected-provider')).toHaveTextContent('stored-provider')
+    })
   })
 
   it('should block generation when instruction is empty', () => {

--- a/web/app/components/app/configuration/config/automatic/get-automatic-res.tsx
+++ b/web/app/components/app/configuration/config/automatic/get-automatic-res.tsx
@@ -37,6 +37,7 @@ import Loading from '@/app/components/base/loading'
 import { ModelTypeEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import { useModelListAndDefaultModelAndCurrentProviderAndModel } from '@/app/components/header/account-setting/model-provider-page/hooks'
 import ModelParameterModal from '@/app/components/header/account-setting/model-provider-page/model-parameter-modal'
+import { useLocalStorage } from '@/hooks/use-local-storage'
 import { generateBasicAppFirstTimeRule, generateRule } from '@/service/debug'
 import { useGenerateRuleTemplate } from '@/service/use-apps'
 import IdeaOutput from './idea-output'
@@ -49,6 +50,7 @@ import { GeneratorType } from './types'
 import useGenData from './use-gen-data'
 
 const i18nPrefix = 'generate'
+const AUTO_GEN_MODEL_STORAGE_KEY = 'auto-gen-model'
 
 type IGetAutomaticResProps = {
   mode: AppModeEnum
@@ -90,10 +92,8 @@ const GetAutomaticRes: FC<IGetAutomaticResProps> = ({
   onFinished,
 }) => {
   const { t } = useTranslation()
-  const localModel = localStorage.getItem('auto-gen-model')
-    ? JSON.parse(localStorage.getItem('auto-gen-model') as string) as Model
-    : null
-  const [model, setModel] = React.useState<Model>(localModel || {
+  const [storedModel, setStoredModel] = useLocalStorage<Model>(AUTO_GEN_MODEL_STORAGE_KEY)
+  const [model, setModel] = React.useState<Model>(storedModel || {
     name: '',
     provider: '',
     mode: mode as unknown as ModelModeType,
@@ -182,11 +182,8 @@ const GetAutomaticRes: FC<IGetAutomaticResProps> = ({
 
   useEffect(() => {
     if (defaultModel) {
-      const localModel = localStorage.getItem('auto-gen-model')
-        ? JSON.parse(localStorage.getItem('auto-gen-model') || '')
-        : null
-      if (localModel) {
-        setModel(localModel)
+      if (storedModel) {
+        setModel(storedModel)
       }
       else {
         setModel(prev => ({
@@ -196,7 +193,7 @@ const GetAutomaticRes: FC<IGetAutomaticResProps> = ({
         }))
       }
     }
-  }, [defaultModel])
+  }, [defaultModel, storedModel])
 
   const renderLoading = (
     <div className="flex h-full w-0 grow flex-col items-center justify-center space-y-3">
@@ -213,8 +210,8 @@ const GetAutomaticRes: FC<IGetAutomaticResProps> = ({
       mode: newValue.mode as ModelModeType,
     }
     setModel(newModel)
-    localStorage.setItem('auto-gen-model', JSON.stringify(newModel))
-  }, [model, setModel])
+    setStoredModel(newModel)
+  }, [model, setModel, setStoredModel])
 
   const handleCompletionParamsChange = useCallback((newParams: FormValue) => {
     const newModel = {
@@ -222,8 +219,8 @@ const GetAutomaticRes: FC<IGetAutomaticResProps> = ({
       completion_params: newParams as CompletionParams,
     }
     setModel(newModel)
-    localStorage.setItem('auto-gen-model', JSON.stringify(newModel))
-  }, [model, setModel])
+    setStoredModel(newModel)
+  }, [model, setModel, setStoredModel])
 
   const onGenerate = async () => {
     if (!isValid())


### PR DESCRIPTION
## Summary

Part of #36898.

Migrates the automatic prompt generator's `auto-gen-model` persistence from direct `localStorage` calls to the shared `useLocalStorage` hook boundary.

## Reproduction

The component previously read and wrote `auto-gen-model` directly in `web/app/components/app/configuration/config/automatic/get-automatic-res.tsx` when initializing the selected model and when changing model parameters.

## Root cause

`GetAutomaticRes` still parsed and wrote `localStorage` inline instead of using `@/hooks/use-local-storage`, leaving this storage path outside the SSR-safe/reactive storage abstraction requested in #36898.

## Changes

- Added `useLocalStorage<Model>` for `auto-gen-model` in `get-automatic-res.tsx`.
- Reused the hook setter for model and completion parameter updates while preserving the existing JSON storage format.
- Added a regression test that initializes the model selector from an existing `auto-gen-model` value.
- Pruned the now-unused `no-restricted-globals` suppression for this file.

## Tests

- `PATH=/Users/liumin/.nvm/versions/node/v22.13.0/bin:$PATH npx --yes --force pnpm@11.5.0 -C web test app/components/app/configuration/config/automatic/__tests__/get-automatic-res.spec.tsx`
- `PATH=/Users/liumin/.nvm/versions/node/v22.13.0/bin:$PATH npx --yes --force pnpm@11.5.0 exec vp exec eslint --quiet --prune-suppressions web/app/components/app/configuration/config/automatic/get-automatic-res.tsx web/app/components/app/configuration/config/automatic/__tests__/get-automatic-res.spec.tsx`
- `PATH=/Users/liumin/.nvm/versions/node/v22.13.0/bin:$PATH npx --yes --force pnpm@11.5.0 -C web type-check`
- `PATH=/Users/liumin/.nvm/versions/node/v22.13.0/bin:$PATH npx --yes --force pnpm@11.5.0 exec vp staged`
- `git diff --check`

## Screenshots/Logs

N/A. This is a storage-boundary refactor with unit coverage.

Note: the local commands emitted the existing devEngines warning because this machine has Node v22.13.0 while the repo expects `^22.22.1`; the commands completed successfully.
