### PR TITLE
refactor(web): mark Props of workflow/variable-inspect components as read-only (#25219)

### DIFF
--- a/web/app/components/workflow/variable-inspect/group.tsx
+++ b/web/app/components/workflow/variable-inspect/group.tsx
@@ -18,7 +18,7 @@ import { VariableIconWithColor } from '@/app/components/workflow/nodes/_base/com
 import { VarInInspectType } from '@/types/workflow'
 import { useToolIcon } from '../hooks'
 
-type Props = {
+type Props = Readonly<{
   nodeData?: NodeWithVar
   currentVar?: currentVarType
   varType: VarInInspectType
@@ -26,7 +26,7 @@ type Props = {
   handleSelect: (state: any) => void
   handleView?: () => void
   handleClear?: () => void
-}
+}>
 
 const Group = ({
   nodeData,

--- a/web/app/components/workflow/variable-inspect/large-data-alert.tsx
+++ b/web/app/components/workflow/variable-inspect/large-data-alert.tsx
@@ -5,11 +5,11 @@ import { RiInformation2Fill } from '@remixicon/react'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 
-type Props = {
+type Props = Readonly<{
   textHasNoExport?: boolean
   downloadUrl?: string
   className?: string
-}
+}>
 
 const LargeDataAlert: FC<Props> = ({
   textHasNoExport,

--- a/web/app/components/workflow/variable-inspect/left.tsx
+++ b/web/app/components/workflow/variable-inspect/left.tsx
@@ -11,10 +11,10 @@ import { useNodesInteractions } from '../hooks/use-nodes-interactions'
 import { useStore } from '../store'
 import Group from './group'
 
-type Props = {
+type Props = Readonly<{
   currentNodeVar?: currentVarType
   handleVarSelect: (state: any) => void
-}
+}>
 
 const Left = ({
   currentNodeVar,

--- a/web/app/components/workflow/variable-inspect/right.tsx
+++ b/web/app/components/workflow/variable-inspect/right.tsx
@@ -36,12 +36,12 @@ import { BlockEnum } from '../types'
 import Empty from './empty'
 import ValueContent from './value-content'
 
-type Props = {
+type Props = Readonly<{
   nodeId: string
   currentNodeVar?: currentVarType
   handleOpenMenu: () => void
   isValueFetching?: boolean
-}
+}>
 
 const Right = ({
   nodeId,

--- a/web/app/components/workflow/variable-inspect/value-content.tsx
+++ b/web/app/components/workflow/variable-inspect/value-content.tsx
@@ -20,11 +20,11 @@ import {
   validateInspectJsonValue,
 } from './value-content.helpers'
 
-type Props = {
+type Props = Readonly<{
   currentVar: VarInInspect
   handleValueChange: (varId: string, value: any) => void
   isTruncated: boolean
-}
+}>
 
 const ValueContent = ({
   currentVar,


### PR DESCRIPTION
## Summary

Mark component Props as `Readonly<>` in `app/components/workflow/variable-inspect/` (5 files) as part of #25219.

### Changes

- `large-data-alert.tsx` — `type Props = Readonly<{ ... }>`
- `left.tsx` — `type Props = Readonly<{ ... }>`
- `value-content.tsx` — `type Props = Readonly<{ ... }>`
- `group.tsx` — `type Props = Readonly<{ ... }>`
- `right.tsx` — `type Props = Readonly<{ ... }>`

Each change wraps the existing Props type with `Readonly<>` to enforce immutability at the type level, consistent with React best practices.