### PR TITLE
refactor(web): migrate app-detail-collapse-or-expand and dify-isShowManageMetadata localStorage to hooks (#36898)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -109,9 +109,6 @@
     }
   },
   "web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx": {
-    "no-restricted-globals": {
-      "count": 1
-    },
     "react/set-state-in-effect": {
       "count": 2
     },
@@ -249,7 +246,7 @@
   },
   "web/app/components/app-sidebar/index.tsx": {
     "no-restricted-globals": {
-      "count": 2
+      "count": 1
     },
     "ts/no-explicit-any": {
       "count": 1
@@ -2294,11 +2291,6 @@
   },
   "web/app/components/datasets/metadata/metadata-dataset/dataset-metadata-drawer.tsx": {
     "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "web/app/components/datasets/metadata/metadata-document/info-group.tsx": {
-    "no-restricted-globals": {
       "count": 1
     }
   },

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx
@@ -26,6 +26,7 @@ import Loading from '@/app/components/base/loading'
 import { useAppContext } from '@/context/app-context'
 import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
 import useDocumentTitle from '@/hooks/use-document-title'
+import { useLocalStorage } from '@/hooks/use-local-storage'
 import { usePathname, useRouter } from '@/next/navigation'
 import { fetchAppDetailDirect } from '@/service/apps'
 import { AppModeEnum } from '@/types/app'
@@ -54,6 +55,7 @@ const AppDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
     setAppSidebarExpand: state.setAppSidebarExpand,
   })))
   const [isLoadingAppDetail, setIsLoadingAppDetail] = useState(false)
+  const [storedSidebarMode] = useLocalStorage<string>('app-detail-collapse-or-expand', 'expand', { raw: true })
   const [appDetailRes, setAppDetailRes] = useState<App | null>(null)
   const [navigation, setNavigation] = useState<Array<{
     name: string
@@ -104,14 +106,14 @@ const AppDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
 
   useEffect(() => {
     if (appDetail) {
-      const localeMode = localStorage.getItem('app-detail-collapse-or-expand') || 'expand'
+      const localeMode = storedSidebarMode || 'expand'
       const mode = isMobile ? 'collapse' : 'expand'
       setAppSidebarExpand(isMobile ? mode : localeMode)
       // TODO: consider screen size and mode
       // if ((appDetail.mode === AppModeEnum.ADVANCED_CHAT || appDetail.mode === 'workflow') && (pathname).endsWith('workflow'))
       //   setAppSidebarExpand('collapse')
     }
-  }, [appDetail, isMobile])
+  }, [appDetail, isMobile, storedSidebarMode])
 
   useEffect(() => {
     setAppDetail()

--- a/web/app/components/app-sidebar/index.tsx
+++ b/web/app/components/app-sidebar/index.tsx
@@ -9,6 +9,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useStore as useAppStore } from '@/app/components/app/store'
 import { useEventEmitterContextContext } from '@/context/event-emitter'
 import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
+import { useSetLocalStorage } from '@/hooks/use-local-storage'
 import { usePathname } from '@/next/navigation'
 import Divider from '../base/divider'
 import AppInfo, { AppInfoView } from './app-info'
@@ -49,6 +50,7 @@ const AppDetailNav = ({
   const media = useBreakpoints()
   const isMobile = media === MediaType.mobile
   const expand = appSidebarExpand === 'expand'
+  const setStoredSidebarMode = useSetLocalStorage('app-detail-collapse-or-expand', { raw: true })
 
   const handleToggle = useCallback(() => {
     setAppSidebarExpand(appSidebarExpand === 'expand' ? 'collapse' : 'expand')
@@ -71,10 +73,10 @@ const AppDetailNav = ({
 
   useEffect(() => {
     if (appSidebarExpand) {
-      localStorage.setItem('app-detail-collapse-or-expand', appSidebarExpand)
+      setStoredSidebarMode(appSidebarExpand)
       setAppSidebarExpand(appSidebarExpand)
     }
-  }, [appSidebarExpand, setAppSidebarExpand])
+  }, [appSidebarExpand, setAppSidebarExpand, setStoredSidebarMode])
 
   useHotkey('Mod+B', (e) => {
     e.preventDefault()

--- a/web/app/components/datasets/metadata/metadata-document/info-group.tsx
+++ b/web/app/components/datasets/metadata/metadata-document/info-group.tsx
@@ -11,7 +11,8 @@ import useTimestamp from '@/hooks/use-timestamp'
 import { useRouter } from '@/next/navigation'
 import InputCombined from '../edit-metadata-batch/input-combined'
 import { DatasetMetadataPicker } from '../metadata-dataset/dataset-metadata-picker'
-import { DataType, isShowManageMetadataLocalStorageKey } from '../types'
+import { useSetLocalStorage } from '@/hooks/use-local-storage'
+import { DataType } from '../types'
 import Field from './field'
 
 type Props = {
@@ -50,9 +51,10 @@ const InfoGroup: FC<Props> = ({
   const router = useRouter()
   const { t } = useTranslation()
   const { formatTime: formatTimestamp } = useTimestamp()
+  const setIsShowManageMetadata = useSetLocalStorage('dify-isShowManageMetadata', { raw: true })
 
   const handleMangeMetadata = () => {
-    localStorage.setItem(isShowManageMetadataLocalStorageKey, 'true')
+    setIsShowManageMetadata('true')
     router.push(`/datasets/${dataSetId}/documents`)
   }
 


### PR DESCRIPTION
## Summary

Migrate direct `localStorage` access to `@/hooks/use-local-storage` hooks for two keys, as part of #36898.

### Changes

**`dify-isShowManageMetadata` (setter only):**
- `metadata-document/info-group.tsx` — replaced `localStorage.setItem` with `useSetLocalStorage`
- Reader side in `use-edit-dataset-metadata.ts` kept as direct localStorage (consume-once pattern: read then immediately remove in useEffect)

**`app-detail-collapse-or-expand` (reader + setter):**
- `app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx` — replaced `localStorage.getItem` with `useLocalStorage` hook
- `app/components/app-sidebar/index.tsx` — replaced `localStorage.setItem` with `useSetLocalStorage` hook

### Notes
- Reader side uses `useLocalStorage<string>(..., { raw: true })` since the value is a plain string
- Setter side uses `useSetLocalStorage` since only write is needed
- `isShowManageMetadataLocalStorageKey` export kept in `types.ts` since it's still used by the consume-once reader in `use-edit-dataset-metadata.ts`