### PR TITLE
fix: terminate SSE stream when error event is received

### DIFF
--- a/api/core/app/apps/streaming_utils.py
+++ b/api/core/app/apps/streaming_utils.py
@@ -60,7 +60,7 @@ def stream_topic_events(
 
 def _normalize_terminal_events(terminal_events: Iterable[str | StreamEvent] | None) -> set[str]:
     if terminal_events is None:
-        return {StreamEvent.WORKFLOW_FINISHED.value, StreamEvent.WORKFLOW_PAUSED.value}
+        return {StreamEvent.WORKFLOW_FINISHED.value, StreamEvent.WORKFLOW_PAUSED.value, StreamEvent.ERROR.value}
     values: set[str] = set()
     for item in terminal_events:
         if isinstance(item, StreamEvent):

--- a/api/tests/unit_tests/core/app/apps/test_streaming_utils.py
+++ b/api/tests/unit_tests/core/app/apps/test_streaming_utils.py
@@ -85,6 +85,7 @@ def test_normalize_terminal_events_defaults():
     assert _normalize_terminal_events(None) == {
         StreamEvent.WORKFLOW_FINISHED.value,
         StreamEvent.WORKFLOW_PAUSED.value,
+        StreamEvent.ERROR.value,
     }
 
 


### PR DESCRIPTION
## Summary

When a Chatflow streaming request encounters a fatal error before execution begins (e.g. a `conversation_id` that no longer exists is passed via the Web API), `_publish_error_event()` publishes an `\"error\"` event to the SSE topic. However, `_normalize_terminal_events` did not include `\"error\"` in the default terminal-event set, so `stream_topic_events` continued waiting the full `idle_timeout` (300 s) before closing the connection — causing the client to hang with only `ping` events.

This change adds `StreamEvent.ERROR` to the default terminal events, so the SSE generator returns immediately after yielding the error event to the client.

Fixes #37197

## Changes

- `api/core/app/apps/streaming_utils.py`: add `StreamEvent.ERROR.value` to the default terminal-event set returned by `_normalize_terminal_events`