### PR TITLE
fix: auto-detect configured tracing provider when enabling toggle

### DIFF
--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/panel.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/panel.tsx
@@ -46,13 +46,6 @@ const Panel: FC = () => {
       toast(t('api.success', { ns: 'common' }), { type: 'success' })
     }
   }
-
-  const handleTracingEnabledChange = (enabled: boolean) => {
-    handleTracingStatusChange({
-      tracing_provider: tracingStatus?.tracing_provider || null,
-      enabled,
-    })
-  }
   const handleChooseProvider = (provider: TracingProvider) => {
     handleTracingStatusChange({
       tracing_provider: provider,
@@ -86,6 +79,36 @@ const Panel: FC = () => {
   const [databricksConfig, setDatabricksConfig] = useState<DatabricksConfig | null>(null)
   const [tencentConfig, setTencentConfig] = useState<TencentConfig | null>(null)
   const hasConfiguredTracing = !!(langSmithConfig || langFuseConfig || opikConfig || weaveConfig || arizeConfig || phoenixConfig || aliyunConfig || mlflowConfig || databricksConfig || tencentConfig)
+  const configuredProvider: TracingProvider | null
+    = langFuseConfig
+      ? TracingProvider.langfuse
+      : langSmithConfig
+        ? TracingProvider.langSmith
+        : opikConfig
+          ? TracingProvider.opik
+          : arizeConfig
+            ? TracingProvider.arize
+            : phoenixConfig
+              ? TracingProvider.phoenix
+              : weaveConfig
+                ? TracingProvider.weave
+                : aliyunConfig
+                  ? TracingProvider.aliyun
+                  : mlflowConfig
+                    ? TracingProvider.mlflow
+                    : databricksConfig
+                      ? TracingProvider.databricks
+                      : tencentConfig
+                        ? TracingProvider.tencent
+                        : null
+
+  const handleTracingEnabledChange = (enabled: boolean) => {
+    handleTracingStatusChange({
+      tracing_provider: tracingStatus?.tracing_provider
+        || (enabled ? configuredProvider : null),
+      enabled,
+    })
+  }
 
   const fetchTracingConfig = async () => {
     const getArizeConfig = async () => {


### PR DESCRIPTION
## Summary

Fixes #37174

When a tracing provider (e.g. Langfuse) has been configured but tracing is disabled, clicking the global enable toggle sends `enabled=true` without `tracing_provider`. The backend rejects this with `"tracing_provider is required when enabled is True"`.

## Root Cause

`handleTracingEnabledChange` relied on `tracingStatus?.tracing_provider` which may be `null` even when a provider is configured (the tracing config and status are stored via separate APIs).

## Fix

Added a `configuredProvider` helper that detects the first configured provider from local state. When enabling tracing and `tracingStatus.tracing_provider` is null, it falls back to the configured provider automatically.

### Changes
- `web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/panel.tsx`: Added `configuredProvider` computed value from provider config states, used in `handleTracingEnabledChange` when enabling and no provider is set

## Testing
- Local ESLint: 0 errors (only pre-existing warnings)