### PR TITLE
fix: _truncate_array under-reports truncated flag after dropping/shortening elements

### DIFF
--- a/api/services/variable_truncator.py
+++ b/api/services/variable_truncator.py
@@ -292,6 +292,7 @@ class VariableTruncator(BaseTruncator):
                 used_size += 1  # Account for comma
 
             if used_size > target_size:
+                truncated = True
                 break
 
             remaining_budget = target_size - used_size
@@ -301,7 +302,7 @@ class VariableTruncator(BaseTruncator):
                 raise UnknownTypeError(f"got unknown type {type(item)} in array truncation")
             truncated_value.append(part_result.value)
             used_size += part_result.value_size
-            truncated = part_result.truncated
+            truncated = truncated or part_result.truncated
         return _PartResult(truncated_value, used_size, truncated)
 
     @classmethod


### PR DESCRIPTION
## Summary

Fixes #37192

\_truncate_array\ has two bugs causing the \	runcated\ flag to be under-reported:

1. **Size-limit break doesn't set flag**: When \used_size > target_size\, the loop breaks but \	runcated\ stays \False\, so dropped tail elements go unreported.
2. **Flag gets overwritten instead of accumulated**: \	runcated = part_result.truncated\ replaces the flag, so a later element that fits resets the flag from an earlier truncated one.

## Changes

- Set \	runcated = True\ before the size-limit \reak\
- Use \	runcated = truncated or part_result.truncated\ to accumulate

## Testing

Verified with the reproduction cases from #37192:

\\\python
t = VariableTruncator(array_element_limit=20, max_size_bytes=1000)
r = t._truncate_array([10, 20, 30, 40, 50], 12)
# Before: r.truncated == False, r.value == [10, 20, 30, 40]
# After:  r.truncated == True  ✅

t2 = VariableTruncator(array_element_limit=20, max_size_bytes=1000, string_length_limit=10)
r2 = t2._truncate_array(['x'*60, 'a'], 60)
# Before: r2.truncated == False
# After:  r2.truncated == True  ✅
\\\

Also verified element-count-limit path and no-truncation path are unaffected.