### PR TITLE
fix: don't blanket-override Content-Type to octet-stream for file-preview

### DIFF
--- a/api/controllers/files/image_preview.py
+++ b/api/controllers/files/image_preview.py
@@ -132,7 +132,7 @@ class FilePreviewApi(Resource):
         if args.as_attachment:
             encoded_filename = quote(upload_file.name)
             response.headers["Content-Disposition"] = f"attachment; filename*=UTF-8''{encoded_filename}"
-        response.headers["Content-Type"] = "application/octet-stream"
+            response.headers["Content-Type"] = "application/octet-stream"
 
         enforce_download_for_html(
             response,

--- a/api/tests/unit_tests/controllers/files/test_image_preview.py
+++ b/api/tests/unit_tests/controllers/files/test_image_preview.py
@@ -107,7 +107,8 @@ class TestFilePreviewApi:
 
         response = get_fn("file-id")
 
-        assert response.mimetype == "application/octet-stream"
+        # Non-attachment download should keep original content type, not blanket override to octet-stream
+        assert response.mimetype == "text/plain"
         assert response.headers["Content-Length"] == "100"
         assert "Accept-Ranges" not in response.headers
         mock_enforce.assert_called_once()


### PR DESCRIPTION
﻿## Summary

Fixes #37198

The /files/{id}/file-preview endpoint unconditionally set Content-Type: application/octet-stream after the Response constructor had already used upload_file.mime_type, causing browsers to force-download all files instead of previewing them inline.

## Root Cause

In controllers/files/image_preview.py, line 137:
  response.headers["Content-Type"] = "application/octet-stream"
was outside the if args.as_attachment block, overriding the correct mimetype for ALL requests.

## Fix

Move the octet-stream override inside the as_attachment conditional, so it only applies when the caller explicitly requests download-as-attachment.

## Before/After

| Scenario | Before | After |
|----------|--------|-------|
| Inline preview (image/png) | octet-stream -> download | image/png -> browser inline |
| Inline preview (pdf) | octet-stream -> download | application/pdf -> inline |
| Attachment download | octet-stream | octet-stream (unchanged) |

## Changes

1 line moved - Content-Type override from unconditional to conditional (under as_attachment branch).
