### PR TITLE
fix: publish error event on invalid conversation/message in chatflow SSE

### DIFF
--- a/api/core/app/apps/advanced_chat/app_generator.py
+++ b/api/core/app/apps/advanced_chat/app_generator.py
@@ -56,6 +56,7 @@ from models import Account, App, Conversation, EndUser, Message, Workflow, Workf
 from models.enums import WorkflowRunTriggeredFrom
 from services.conversation_service import ConversationService
 from services.errors.conversation import ConversationNotExistsError
+from services.errors.message import MessageNotExistsError
 from services.workflow_draft_variable_service import (
     DraftVarLoader,
     WorkflowDraftVariableService,
@@ -616,8 +617,12 @@ class AdvancedChatAppGenerator(MessageBasedAppGenerator):
 
         with preserve_flask_contexts(flask_app, context_vars=context):
             # get conversation and message
-            conversation = self._get_conversation(conversation_id)
-            message = self._get_message(message_id)
+            try:
+                conversation = self._get_conversation(conversation_id)
+                message = self._get_message(message_id)
+            except (ConversationNotExistsError, MessageNotExistsError) as e:
+                queue_manager.publish_error(e, PublishFrom.APPLICATION_MANAGER)
+                return
 
             with Session(db.engine, expire_on_commit=False) as session:
                 workflow = session.scalar(


### PR DESCRIPTION
﻿## Summary

Fixes #37197

When sending a chat-messages request with a non-existing conversation_id to a chatflow (advanced-chat) app, the SSE stream opens but only ping/keepalive events are received - the request never completes and no error is returned.

## Root Cause

In AdvancedChatAppGenerator._generate_worker, the conversation and message lookup (lines 619-620) was placed BEFORE the try/except block that catches errors and publishes them to the SSE queue:

`python
conversation = self._get_conversation(conversation_id)  # raises ConversationNotExistsError
message = self._get_message(message_id)
# ... later ...
try:
    runner.run()
except ...:
    queue_manager.publish_error(...)
`

When ConversationNotExistsError or MessageNotExistsError is raised, the worker thread crashes silently without publishing an error event. The main SSE stream loop continues waiting on the queue manager, sending only periodic pings.

## Fix

Wrap the conversation/message fetch in a try/except that publishes the error via queue_manager.publish_error(e, PublishFrom.APPLICATION_MANAGER). This is consistent with how chat/app_generator and agent_chat/app_generator already handle this - both have the _get_conversation call inside their try/except blocks.

`python
try:
    conversation = self._get_conversation(conversation_id)
    message = self._get_message(message_id)
except (ConversationNotExistsError, MessageNotExistsError) as e:
    queue_manager.publish_error(e, PublishFrom.APPLICATION_MANAGER)
    return
`

## Behavior After Fix

Invalid conversation_id -> SSE error event: {"event": "error", "message": "Conversation not exists", "status": 500}
