### PR TITLE
fix: Weaviate BM25 search drops results due to missing score extraction

### DIFF
--- a/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
@@ -480,6 +480,7 @@ class WeaviateVector(BaseVector):
                 query_properties=[Field.TEXT_KEY.value],
                 limit=top_k,
                 return_properties=props,
+                return_metadata=MetadataQuery(score=True),
                 include_vector=True,
                 filters=where,
             )
@@ -490,6 +491,7 @@ class WeaviateVector(BaseVector):
                 query_properties=[Field.TEXT_KEY.value],
                 limit=top_k,
                 return_properties=props,
+                return_metadata=MetadataQuery(score=True),
                 include_vector=True,
                 filters=where,
             )
@@ -502,6 +504,9 @@ class WeaviateVector(BaseVector):
             vec = obj.vector
             if isinstance(vec, dict):
                 vec = vec.get("default") or next(iter(vec.values()), None)
+
+            if obj.metadata and obj.metadata.score is not None:
+                properties["score"] = obj.metadata.score
 
             docs.append(Document(page_content=text, vector=vec, metadata=properties))
         return docs


### PR DESCRIPTION
## Summary

Fixes #37045 — Weaviate BM25 full-text search silently drops all results.

## Root Cause

\search_by_full_text\ in \weaviate_vector.py\ omitted \eturn_metadata=MetadataQuery(score=True)\ from both \col.query.bm25(...)\ calls. Since Weaviate only returns metadata fields that are explicitly requested, \obj.metadata.score\ was always \None\, and the score defaulted to \