### PR TITLE
refactor(web): mark Props of tools/mcp components as read-only (#25219)

### DIFF
--- a/web/app/components/tools/mcp/create-card.tsx
+++ b/web/app/components/tools/mcp/create-card.tsx
@@ -12,9 +12,9 @@ import { useDocLink } from '@/context/i18n'
 import { useCreateMCP } from '@/service/use-tools'
 import MCPModal from './modal'
 
-type Props = {
+type Props = Readonly<{
   handleCreate: (provider: ToolWithProvider) => void
-}
+}>
 
 const NewMCPCard = ({ handleCreate }: Props) => {
   const { t } = useTranslation()

--- a/web/app/components/tools/mcp/detail/content.tsx
+++ b/web/app/components/tools/mcp/detail/content.tsx
@@ -37,13 +37,13 @@ import ListLoading from './list-loading'
 import OperationDropdown from './operation-dropdown'
 import ToolItem from './tool-item'
 
-type Props = {
+type Props = Readonly<{
   detail: ToolWithProvider
   onUpdate: (isDelete?: boolean) => void
   onHide: () => void
   isTriggerAuthorize: boolean
   onFirstCreate: () => void
-}
+}>
 
 type MCPModalConfirmPayload = Parameters<ComponentProps<typeof MCPModal>['onConfirm']>[0]
 type MutationResult = {

--- a/web/app/components/tools/mcp/detail/operation-dropdown.tsx
+++ b/web/app/components/tools/mcp/detail/operation-dropdown.tsx
@@ -16,12 +16,12 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import ActionButton from '@/app/components/base/action-button'
 
-type Props = {
+type Props = Readonly<{
   inCard?: boolean
   onOpenChange?: (open: boolean) => void
   onEdit: () => void
   onRemove: () => void
-}
+}>
 
 const OperationDropdown: FC<Props> = ({
   inCard,

--- a/web/app/components/tools/mcp/detail/provider-detail.tsx
+++ b/web/app/components/tools/mcp/detail/provider-detail.tsx
@@ -13,13 +13,13 @@ import {
 import * as React from 'react'
 import MCPDetailContent from './content'
 
-type Props = {
+type Props = Readonly<{
   detail?: ToolWithProvider
   onUpdate: () => void
   onHide: () => void
   isTriggerAuthorize: boolean
   onFirstCreate: () => void
-}
+}>
 
 const MCPDetailPanel: FC<Props> = ({
   detail,

--- a/web/app/components/tools/mcp/detail/tool-item.tsx
+++ b/web/app/components/tools/mcp/detail/tool-item.tsx
@@ -7,9 +7,9 @@ import { useTranslation } from 'react-i18next'
 import { useLocale } from '@/context/i18n'
 import { getLanguage } from '@/i18n-config/language'
 
-type Props = {
+type Props = Readonly<{
   tool: Tool
-}
+}>
 
 const MCPToolItem = ({
   tool,

--- a/web/app/components/tools/mcp/headers-input.tsx
+++ b/web/app/components/tools/mcp/headers-input.tsx
@@ -14,12 +14,12 @@ export type HeaderItem = {
   value: string
 }
 
-type Props = {
+type Props = Readonly<{
   headersItems: HeaderItem[]
   onChange: (headerItems: HeaderItem[]) => void
   readonly?: boolean
   isMasked?: boolean
-}
+}>
 
 const HeadersInput = ({
   headersItems,

--- a/web/app/components/tools/mcp/index.tsx
+++ b/web/app/components/tools/mcp/index.tsx
@@ -10,9 +10,9 @@ import NewMCPCard from './create-card'
 import MCPDetailPanel from './detail/provider-detail'
 import MCPCard from './provider-card'
 
-type Props = {
+type Props = Readonly<{
   searchText: string
-}
+}>
 
 const MCPList = ({
   searchText,

--- a/web/app/components/tools/mcp/mcp-server-param-item.tsx
+++ b/web/app/components/tools/mcp/mcp-server-param-item.tsx
@@ -3,11 +3,11 @@ import { Textarea } from '@langgenius/dify-ui/textarea'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 
-type Props = {
+type Props = Readonly<{
   data?: any
   value: string
   onChange: (value: string) => void
-}
+}>
 
 const MCPServerParamItem = ({
   data,

--- a/web/app/components/tools/mcp/provider-card.tsx
+++ b/web/app/components/tools/mcp/provider-card.tsx
@@ -21,13 +21,13 @@ import { useDeleteMCP, useUpdateMCP } from '@/service/use-tools'
 import OperationDropdown from './detail/operation-dropdown'
 import MCPModal from './modal'
 
-type Props = {
+type Props = Readonly<{
   currentProvider?: ToolWithProvider
   data: ToolWithProvider
   handleSelect: (providerID: string) => void
   onUpdate: (providerID: string) => void
   onDeleted: () => void
-}
+}>
 
 const MCPCard = ({
   currentProvider,


### PR DESCRIPTION
part of #25219

## Summary

Files changed:

- `mcp/create-card.tsx`
- `mcp/index.tsx`
- `mcp/headers-input.tsx`
- `mcp/mcp-server-param-item.tsx`
- `mcp/provider-card.tsx`
- `mcp/detail/content.tsx`
- `mcp/detail/operation-dropdown.tsx`
- `mcp/detail/provider-detail.tsx`
- `mcp/detail/tool-item.tsx`

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I tried as much as possible to make a single atomic change (type-only; no tests applicable).
- [ ] I've updated the documentation accordingly.
- [x] I ran the frontend checks: `cd web && pnpm eslint app/components/tools/mcp` and `pnpm type-check` both pass.