### PR TITLE
refactor(web): replace useContext with use() in workflow components (#25193)

### DIFF
--- a/web/app/components/workflow/datasets-detail-store/store.ts
+++ b/web/app/components/workflow/datasets-detail-store/store.ts
@@ -1,6 +1,6 @@
 import type { DataSet } from '@/models/datasets'
 import { produce } from 'immer'
-import { useContext } from 'react'
+import { use } from 'react'
 import { createStore, useStore } from 'zustand'
 import { DatasetsDetailContext } from './provider'
 
@@ -30,7 +30,7 @@ export const createDatasetsDetailStore = () => {
 }
 
 export const useDatasetsDetailStore = <T>(selector: (state: DatasetsDetailStore) => T): T => {
-  const store = useContext(DatasetsDetailContext)
+  const store = use(DatasetsDetailContext)
   if (!store)
     throw new Error('Missing DatasetsDetailContext.Provider in the tree')
 

--- a/web/app/components/workflow/hooks-store/store.ts
+++ b/web/app/components/workflow/hooks-store/store.ts
@@ -11,7 +11,7 @@ import type { SchemaTypeDefinition } from '@/service/use-common'
 import type { FlowType } from '@/types/common'
 import type { VarInInspect } from '@/types/workflow'
 import { noop } from 'es-toolkit/function'
-import { useContext } from 'react'
+import { use } from 'react'
 import {
   useStore as useZustandStore,
 } from 'zustand'
@@ -159,7 +159,7 @@ export const createHooksStore = ({
 }
 
 export function useHooksStore<T>(selector: (state: Shape) => T): T {
-  const store = useContext(HooksStoreContext)
+  const store = use(HooksStoreContext)
   if (!store)
     throw new Error('Missing HooksStoreContext.Provider in the tree')
 

--- a/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/context.tsx
+++ b/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/context.tsx
@@ -1,7 +1,7 @@
 import { noop } from 'es-toolkit/function'
 import {
   createContext,
-  useContext,
+  use,
   useRef,
 } from 'react'
 import { useMitt } from '@/hooks/use-mitt'
@@ -46,5 +46,5 @@ export const MittProvider = ({ children }: { children: React.ReactNode }) => {
 }
 
 export const useMittContext = () => {
-  return useContext(MittContext)
+  return use(MittContext)
 }

--- a/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/store.ts
+++ b/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/store.ts
@@ -1,5 +1,5 @@
 import type { SchemaRoot } from '../../../types'
-import { useContext } from 'react'
+import { use } from 'react'
 import { createStore, useStore } from 'zustand'
 import { VisualEditorContext } from './context'
 
@@ -26,7 +26,7 @@ export const createVisualEditorStore = () => createStore<VisualEditorStore>(set 
 }))
 
 export const useVisualEditorStore = <T>(selector: (state: VisualEditorStore) => T): T => {
-  const store = useContext(VisualEditorContext)
+  const store = use(VisualEditorContext)
   if (!store)
     throw new Error('Missing VisualEditorContext.Provider in the tree')
 

--- a/web/app/components/workflow/note-node/note-editor/store.ts
+++ b/web/app/components/workflow/note-node/note-editor/store.ts
@@ -1,4 +1,4 @@
-import { useContext } from 'react'
+import { use } from 'react'
 import {
   useStore as useZustandStore,
 } from 'zustand'
@@ -65,7 +65,7 @@ export const createNoteEditorStore = () => {
 }
 
 export function useStore<T>(selector: (state: Shape) => T): T {
-  const store = useContext(NoteEditorContext)
+  const store = use(NoteEditorContext)
   if (!store)
     throw new Error('Missing NoteEditorContext.Provider in the tree')
 
@@ -73,5 +73,5 @@ export function useStore<T>(selector: (state: Shape) => T): T {
 }
 
 export const useNoteEditorStore = () => {
-  return useContext(NoteEditorContext)!
+  return use(NoteEditorContext)!
 }


### PR DESCRIPTION
part of #25193

## Summary

Continues #25193. Replaces React's `useContext(X)` with the `use(X)` API in the
workflow store/context modules.


Files changed:

- `workflow/datasets-detail-store/store.ts`
- `workflow/hooks-store/store.ts`
- `workflow/note-node/note-editor/store.ts`
- `workflow/nodes/llm/components/json-schema-config-modal/visual-editor/store.ts`
- `workflow/nodes/llm/components/json-schema-config-modal/visual-editor/context.tsx`

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I tried as much as possible to make a single atomic change (behavior-neutral; no tests applicable).
- [ ] I've updated the documentation accordingly.
- [x] I ran the frontend checks: `cd web && pnpm eslint <changed files>` and `pnpm type-check` both pass.