### PR TITLE
refactor(web): mark Props of tools/ components as read-only (#25219)

### DIFF
--- a/web/app/components/tools/edit-custom-collection-modal/config-credentials.tsx
+++ b/web/app/components/tools/edit-custom-collection-modal/config-credentials.tsx
@@ -23,12 +23,12 @@ import { useTranslation } from 'react-i18next'
 import { Infotip } from '@/app/components/base/infotip'
 import { AuthHeaderPrefix, AuthType } from '@/app/components/tools/types'
 
-type Props = {
+type Props = Readonly<{
   positionCenter?: boolean
   credential: Credential
   onChange: (credential: Credential) => void
   onHide: () => void
-}
+}>
 
 type ItemProps = {
   text: string

--- a/web/app/components/tools/edit-custom-collection-modal/get-schema.tsx
+++ b/web/app/components/tools/edit-custom-collection-modal/get-schema.tsx
@@ -15,9 +15,9 @@ import Input from '@/app/components/base/input'
 import { importSchemaFromURL } from '@/service/tools'
 import examples from './examples'
 
-type Props = {
+type Props = Readonly<{
   onChange: (value: string) => void
-}
+}>
 
 const GetSchema: FC<Props> = ({
   onChange,

--- a/web/app/components/tools/edit-custom-collection-modal/index.tsx
+++ b/web/app/components/tools/edit-custom-collection-modal/index.tsx
@@ -33,7 +33,7 @@ import ConfigCredentials from './config-credentials'
 import GetSchema from './get-schema'
 import TestApi from './test-api'
 
-type Props = {
+type Props = Readonly<{
   positionLeft?: boolean
   dialogClassName?: string
   payload: any
@@ -41,7 +41,7 @@ type Props = {
   onAdd?: (payload: CustomCollectionBackend) => void
   onRemove?: () => void
   onEdit?: (payload: CustomCollectionBackend) => void
-}
+}>
 // Add and Edit
 const EditCustomCollectionModal: FC<Props> = ({
   positionLeft,

--- a/web/app/components/tools/edit-custom-collection-modal/test-api.tsx
+++ b/web/app/components/tools/edit-custom-collection-modal/test-api.tsx
@@ -24,12 +24,12 @@ import { getLanguage } from '@/i18n-config/language'
 import { testAPIAvailable } from '@/service/tools'
 import ConfigCredentials from './config-credentials'
 
-type Props = {
+type Props = Readonly<{
   positionCenter?: boolean
   customCollection: CustomCollectionBackend
   tool: CustomParamSchema
   onHide: () => void
-}
+}>
 
 const TestApi: FC<Props> = ({
   positionCenter,

--- a/web/app/components/tools/provider/custom-create-card.tsx
+++ b/web/app/components/tools/provider/custom-create-card.tsx
@@ -10,9 +10,9 @@ import EditCustomToolModal from '@/app/components/tools/edit-custom-collection-m
 import { useAppContext } from '@/context/app-context'
 import { createCustomCollection } from '@/service/tools'
 
-type Props = {
+type Props = Readonly<{
   onRefreshData: () => void
-}
+}>
 
 const Contribute = ({ onRefreshData }: Props) => {
   const { t } = useTranslation()

--- a/web/app/components/tools/provider/detail.tsx
+++ b/web/app/components/tools/provider/detail.tsx
@@ -63,11 +63,11 @@ import { basePath } from '@/utils/var'
 import { AuthHeaderPrefix, AuthType, CollectionType } from '../types'
 import ToolItem from './tool-item'
 
-type Props = {
+type Props = Readonly<{
   collection: Collection
   onHide: () => void
   onRefreshData: () => void
-}
+}>
 
 const ProviderDetail = ({
   collection,

--- a/web/app/components/tools/provider/empty.tsx
+++ b/web/app/components/tools/provider/empty.tsx
@@ -7,10 +7,10 @@ import Link from '@/next/link'
 import { NoToolPlaceholder } from '../../base/icons/src/vender/other'
 import { ToolTypeEnum } from '../../workflow/block-selector/types'
 
-type Props = {
+type Props = Readonly<{
   type?: ToolTypeEnum
   isAgent?: boolean
-}
+}>
 
 const getLink = (type?: ToolTypeEnum) => {
   switch (type) {

--- a/web/app/components/tools/provider/tool-item.tsx
+++ b/web/app/components/tools/provider/tool-item.tsx
@@ -7,13 +7,13 @@ import SettingBuiltInTool from '@/app/components/app/configuration/config/agent/
 import { useLocale } from '@/context/i18n'
 import { getLanguage } from '@/i18n-config/language'
 
-type Props = {
+type Props = Readonly<{
   disabled?: boolean
   collection: Collection
   tool: Tool
   isBuiltIn: boolean
   isModel: boolean
-}
+}>
 
 const ToolItem = ({
   disabled,

--- a/web/app/components/tools/setting/build-in/config-credentials.tsx
+++ b/web/app/components/tools/setting/build-in/config-credentials.tsx
@@ -26,14 +26,14 @@ import Form from '@/app/components/header/account-setting/model-provider-page/mo
 import { fetchBuiltInToolCredential, fetchBuiltInToolCredentialSchema } from '@/service/tools'
 import { addDefaultValue, toolCredentialToFormSchemas } from '../../utils/to-form-schema'
 
-type Props = {
+type Props = Readonly<{
   collection: Collection
   onCancel: () => void
   onSaved: (value: Record<string, any>) => void
   isHideRemoveBtn?: boolean
   onRemove?: () => void
   isSaving?: boolean
-}
+}>
 
 const ConfigCredential: FC<Props> = ({
   collection,

--- a/web/app/components/tools/workflow-tool/configure-button.tsx
+++ b/web/app/components/tools/workflow-tool/configure-button.tsx
@@ -7,7 +7,7 @@ import Loading from '@/app/components/base/loading'
 import { useRouter } from '@/next/navigation'
 import Divider from '../../base/divider'
 
-type Props = {
+type Props = Readonly<{
   disabled: boolean
   published: boolean
   isLoading: boolean
@@ -15,7 +15,7 @@ type Props = {
   isCurrentWorkspaceManager: boolean
   onConfigure: () => void
   disabledReason?: string
-}
+}>
 
 const WorkflowToolConfigureButton = ({
   disabled,


### PR DESCRIPTION
part of #25219

## Summary

Continues #25219. Covers the rest of the `tools/` directory — the non-MCP files
(`tools/mcp` was handled separately in #37251).

Each component's local `type Props = { ... }` is wrapped in `Readonly<{ ... }>` to
mark the props immutable. Type-only change, no runtime behavior change.

Files changed:

- `tools/edit-custom-collection-modal/config-credentials.tsx`
- `tools/edit-custom-collection-modal/get-schema.tsx`
- `tools/edit-custom-collection-modal/index.tsx`
- `tools/edit-custom-collection-modal/test-api.tsx`
- `tools/provider/custom-create-card.tsx`
- `tools/provider/detail.tsx`
- `tools/provider/empty.tsx`
- `tools/provider/tool-item.tsx`
- `tools/setting/build-in/config-credentials.tsx`
- `tools/workflow-tool/configure-button.tsx`

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I tried as much as possible to make a single atomic change (type-only; no tests applicable).
- [ ] I've updated the documentation accordingly.
- [x] I ran the frontend checks: `cd web && pnpm eslint app/components/tools` and `pnpm type-check` both pass.