### PR TITLE
feat: enter the app name that need to be deleted by one click

### DIFF
--- a/web/app/components/app-sidebar/app-info/app-info-modals.tsx
+++ b/web/app/components/app-sidebar/app-info/app-info-modals.tsx
@@ -179,7 +179,7 @@ const AppInfoModals = ({
                   <button
                     type="button"
                     onClick={() => setConfirmDeleteInput(appDetail.name)}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-black/[0.06] px-2.5 py-1 system-xs-medium text-text-secondary hover:bg-black/[0.1]"
+                    className="absolute top-1/2 right-2 -translate-y-1/2 rounded-full bg-black/[0.06] px-2.5 py-1 system-xs-medium text-text-secondary hover:bg-black/[0.1]"
                   >
                     {t('operation.fill', { ns: 'common' })}
                   </button>

--- a/web/app/components/app-sidebar/app-info/app-info-modals.tsx
+++ b/web/app/components/app-sidebar/app-info/app-info-modals.tsx
@@ -166,14 +166,24 @@ const AppInfoModals = ({
                     }}
                   />
                 </label>
-                <Input
-                  type="text"
-                  autoComplete="off"
-                  spellCheck={false}
-                  placeholder={t('deleteAppConfirmInputPlaceholder', { ns: 'app' })}
-                  value={confirmDeleteInput}
-                  onChange={e => setConfirmDeleteInput(e.target.value)}
-                />
+                <div className="relative">
+                  <Input
+                    type="text"
+                    autoComplete="off"
+                    spellCheck={false}
+                    placeholder={t('deleteAppConfirmInputPlaceholder', { ns: 'app' })}
+                    value={confirmDeleteInput}
+                    onChange={e => setConfirmDeleteInput(e.target.value)}
+                    className="pr-20"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setConfirmDeleteInput(appDetail.name)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-black/[0.06] px-2.5 py-1 system-xs-medium text-text-secondary hover:bg-black/[0.1]"
+                  >
+                    {t('operation.fill', { ns: 'common' })}
+                  </button>
+                </div>
               </div>
             </div>
             <AlertDialogActions>

--- a/web/app/components/apps/app-card.tsx
+++ b/web/app/components/apps/app-card.tsx
@@ -643,15 +643,24 @@ const AppCard = ({ app, onlineUsers = [], onRefresh, onOpenTagManagement = () =>
                     }}
                   />
                 </FieldLabel>
-                <FieldControl
-                  type="text"
-                  autoComplete="off"
-                  spellCheck={false}
-                  placeholder={t('deleteAppConfirmInputPlaceholder', { ns: 'app' })}
-                  value={confirmDeleteInput}
-                  onValueChange={setConfirmDeleteInput}
-                  className="border-components-input-border-hover bg-components-input-bg-normal focus:border-components-input-border-active focus:bg-components-input-bg-active"
-                />
+                <div className="relative">
+                  <FieldControl
+                    type="text"
+                    autoComplete="off"
+                    spellCheck={false}
+                    placeholder={t('deleteAppConfirmInputPlaceholder', { ns: 'app' })}
+                    value={confirmDeleteInput}
+                    onValueChange={setConfirmDeleteInput}
+                    className="border-components-input-border-hover bg-components-input-bg-normal pr-20 focus:border-components-input-border-active focus:bg-components-input-bg-active"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setConfirmDeleteInput(app.name)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-black/[0.06] px-2.5 py-1 system-xs-medium text-text-secondary hover:bg-black/[0.1]"
+                  >
+                    {t('operation.fill', { ns: 'common' })}
+                  </button>
+                </div>
               </FieldRoot>
             </div>
             <AlertDialogActions>

--- a/web/app/components/apps/app-card.tsx
+++ b/web/app/components/apps/app-card.tsx
@@ -656,7 +656,7 @@ const AppCard = ({ app, onlineUsers = [], onRefresh, onOpenTagManagement = () =>
                   <button
                     type="button"
                     onClick={() => setConfirmDeleteInput(app.name)}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-black/[0.06] px-2.5 py-1 system-xs-medium text-text-secondary hover:bg-black/[0.1]"
+                    className="absolute top-1/2 right-2 -translate-y-1/2 rounded-full bg-black/[0.06] px-2.5 py-1 system-xs-medium text-text-secondary hover:bg-black/[0.1]"
                   >
                     {t('operation.fill', { ns: 'common' })}
                   </button>

--- a/web/i18n/ar-TN/common.json
+++ b/web/i18n/ar-TN/common.json
@@ -497,6 +497,7 @@
   "operation.duplicate": "تكرار",
   "operation.edit": "تعديل",
   "operation.exporting": "جارٍ التصدير",
+  "operation.fill": "ملء تلقائي",
   "operation.format": "تنسيق",
   "operation.getForFree": "احصل عليه مجانا",
   "operation.imageCopied": "تم نسخ الصورة",

--- a/web/i18n/de-DE/common.json
+++ b/web/i18n/de-DE/common.json
@@ -498,7 +498,6 @@
   "operation.edit": "Bearbeiten",
   "operation.exporting": "Exportiere",
   "operation.fill": "Automatisch ausfüllen",
-  "operation.fill": "Automatisch ausfüllen",
   "operation.format": "Format",
   "operation.getForFree": "Kostenlos erhalten",
   "operation.imageCopied": "Kopiertes Bild",

--- a/web/i18n/de-DE/common.json
+++ b/web/i18n/de-DE/common.json
@@ -497,6 +497,8 @@
   "operation.duplicate": "Duplikat",
   "operation.edit": "Bearbeiten",
   "operation.exporting": "Exportiere",
+  "operation.fill": "Automatisch ausfüllen",
+  "operation.fill": "Automatisch ausfüllen",
   "operation.format": "Format",
   "operation.getForFree": "Kostenlos erhalten",
   "operation.imageCopied": "Kopiertes Bild",

--- a/web/i18n/en-US/common.json
+++ b/web/i18n/en-US/common.json
@@ -497,6 +497,7 @@
   "operation.duplicate": "Duplicate",
   "operation.edit": "Edit",
   "operation.exporting": "Exporting",
+  "operation.fill": "Autofill",
   "operation.format": "Format",
   "operation.getForFree": "Get for free",
   "operation.imageCopied": "Image copied",

--- a/web/i18n/es-ES/common.json
+++ b/web/i18n/es-ES/common.json
@@ -497,6 +497,7 @@
   "operation.duplicate": "Duplicar",
   "operation.edit": "Editar",
   "operation.exporting": "Exportando",
+  "operation.fill": "Autocompletar",
   "operation.format": "Formato",
   "operation.getForFree": "Obtener gratis",
   "operation.imageCopied": "Imagen copiada",

--- a/web/i18n/fa-IR/common.json
+++ b/web/i18n/fa-IR/common.json
@@ -497,6 +497,7 @@
   "operation.duplicate": "تکرار",
   "operation.edit": "ویرایش",
   "operation.exporting": "در حال خروجی گرفتن",
+  "operation.fill": "پر کردن خودکار",
   "operation.format": "قالب",
   "operation.getForFree": "دریافت رایگان",
   "operation.imageCopied": "تصویر کپی شده",

--- a/web/i18n/fr-FR/common.json
+++ b/web/i18n/fr-FR/common.json
@@ -498,7 +498,6 @@
   "operation.edit": "Modifier",
   "operation.exporting": "Exportation",
   "operation.fill": "Remplissage auto",
-  "operation.fill": "Remplissage auto",
   "operation.format": "Format",
   "operation.getForFree": "Obtenez gratuitement",
   "operation.imageCopied": "Image copied",

--- a/web/i18n/fr-FR/common.json
+++ b/web/i18n/fr-FR/common.json
@@ -497,6 +497,8 @@
   "operation.duplicate": "Dupliquer",
   "operation.edit": "Modifier",
   "operation.exporting": "Exportation",
+  "operation.fill": "Remplissage auto",
+  "operation.fill": "Remplissage auto",
   "operation.format": "Format",
   "operation.getForFree": "Obtenez gratuitement",
   "operation.imageCopied": "Image copied",

--- a/web/i18n/hi-IN/common.json
+++ b/web/i18n/hi-IN/common.json
@@ -497,6 +497,7 @@
   "operation.duplicate": "डुप्लिकेट",
   "operation.edit": "संपादित करें",
   "operation.exporting": "निर्यात हो रहा है",
+  "operation.fill": "ऑटोफिल",
   "operation.format": "फॉर्मेट",
   "operation.getForFree": "मुफ्त में प्राप्त करें",
   "operation.imageCopied": "कॉपी की गई छवि",

--- a/web/i18n/id-ID/common.json
+++ b/web/i18n/id-ID/common.json
@@ -497,6 +497,8 @@
   "operation.duplicate": "Duplikat",
   "operation.edit": "Mengedit",
   "operation.exporting": "Mengekspor",
+  "operation.fill": "Isi otomatis",
+  "operation.fill": "Isi otomatis",
   "operation.format": "Format",
   "operation.getForFree": "Dapatkan gratis",
   "operation.imageCopied": "Gambar yang disalin",

--- a/web/i18n/id-ID/common.json
+++ b/web/i18n/id-ID/common.json
@@ -498,7 +498,6 @@
   "operation.edit": "Mengedit",
   "operation.exporting": "Mengekspor",
   "operation.fill": "Isi otomatis",
-  "operation.fill": "Isi otomatis",
   "operation.format": "Format",
   "operation.getForFree": "Dapatkan gratis",
   "operation.imageCopied": "Gambar yang disalin",

--- a/web/i18n/it-IT/common.json
+++ b/web/i18n/it-IT/common.json
@@ -497,6 +497,7 @@
   "operation.duplicate": "Duplica",
   "operation.edit": "Modifica",
   "operation.exporting": "Esportazione in corso",
+  "operation.fill": "Compilazione automatica",
   "operation.format": "Formato",
   "operation.getForFree": "Ottieni gratuitamente",
   "operation.imageCopied": "Immagine copiata",

--- a/web/i18n/ja-JP/common.json
+++ b/web/i18n/ja-JP/common.json
@@ -497,6 +497,7 @@
   "operation.duplicate": "複製",
   "operation.edit": "編集",
   "operation.exporting": "エクスポート中",
+  "operation.fill": "自動入力",
   "operation.format": "フォーマット",
   "operation.getForFree": "無料で入手",
   "operation.imageCopied": "コピーした画像",

--- a/web/i18n/ko-KR/common.json
+++ b/web/i18n/ko-KR/common.json
@@ -497,6 +497,7 @@
   "operation.duplicate": "중복",
   "operation.edit": "편집",
   "operation.exporting": "내보내는 중",
+  "operation.fill": "자동 입력",
   "operation.format": "형식",
   "operation.getForFree": "무료로 받기",
   "operation.imageCopied": "복사된 이미지",

--- a/web/i18n/nl-NL/common.json
+++ b/web/i18n/nl-NL/common.json
@@ -498,7 +498,6 @@
   "operation.edit": "Edit",
   "operation.exporting": "Exporteren",
   "operation.fill": "Automatisch invullen",
-  "operation.fill": "Automatisch invullen",
   "operation.format": "Format",
   "operation.getForFree": "Get for free",
   "operation.imageCopied": "Image copied",

--- a/web/i18n/nl-NL/common.json
+++ b/web/i18n/nl-NL/common.json
@@ -497,6 +497,8 @@
   "operation.duplicate": "Duplicate",
   "operation.edit": "Edit",
   "operation.exporting": "Exporteren",
+  "operation.fill": "Automatisch invullen",
+  "operation.fill": "Automatisch invullen",
   "operation.format": "Format",
   "operation.getForFree": "Get for free",
   "operation.imageCopied": "Image copied",

--- a/web/i18n/pl-PL/common.json
+++ b/web/i18n/pl-PL/common.json
@@ -497,6 +497,8 @@
   "operation.duplicate": "Duplikuj",
   "operation.edit": "Edytuj",
   "operation.exporting": "Eksportowanie",
+  "operation.fill": "Autouzupełnianie",
+  "operation.fill": "Autouzupełnianie",
   "operation.format": "Format",
   "operation.getForFree": "Zdobądź za darmo",
   "operation.imageCopied": "Skopiowany obraz",

--- a/web/i18n/pl-PL/common.json
+++ b/web/i18n/pl-PL/common.json
@@ -498,7 +498,6 @@
   "operation.edit": "Edytuj",
   "operation.exporting": "Eksportowanie",
   "operation.fill": "Autouzupełnianie",
-  "operation.fill": "Autouzupełnianie",
   "operation.format": "Format",
   "operation.getForFree": "Zdobądź za darmo",
   "operation.imageCopied": "Skopiowany obraz",

--- a/web/i18n/pt-BR/common.json
+++ b/web/i18n/pt-BR/common.json
@@ -497,6 +497,7 @@
   "operation.duplicate": "Duplicada",
   "operation.edit": "Editar",
   "operation.exporting": "Exportando",
+  "operation.fill": "Preenchimento automático",
   "operation.format": "Formato",
   "operation.getForFree": "Obter gratuitamente",
   "operation.imageCopied": "Imagem copiada",

--- a/web/i18n/ro-RO/common.json
+++ b/web/i18n/ro-RO/common.json
@@ -497,6 +497,8 @@
   "operation.duplicate": "Duplică",
   "operation.edit": "Editează",
   "operation.exporting": "Se exportă",
+  "operation.fill": "Completare automată",
+  "operation.fill": "Completare automată",
   "operation.format": "Format",
   "operation.getForFree": "Obține gratuit",
   "operation.imageCopied": "Imagine copiată",

--- a/web/i18n/ro-RO/common.json
+++ b/web/i18n/ro-RO/common.json
@@ -498,7 +498,6 @@
   "operation.edit": "Editează",
   "operation.exporting": "Se exportă",
   "operation.fill": "Completare automată",
-  "operation.fill": "Completare automată",
   "operation.format": "Format",
   "operation.getForFree": "Obține gratuit",
   "operation.imageCopied": "Imagine copiată",

--- a/web/i18n/ru-RU/common.json
+++ b/web/i18n/ru-RU/common.json
@@ -497,6 +497,7 @@
   "operation.duplicate": "Дублировать",
   "operation.edit": "Редактировать",
   "operation.exporting": "Экспорт",
+  "operation.fill": "Автозаполнение",
   "operation.format": "Формат",
   "operation.getForFree": "Получить бесплатно",
   "operation.imageCopied": "Скопированное изображение",

--- a/web/i18n/sl-SI/common.json
+++ b/web/i18n/sl-SI/common.json
@@ -497,6 +497,8 @@
   "operation.duplicate": "Podvoji",
   "operation.edit": "Uredi",
   "operation.exporting": "Izvažanje",
+  "operation.fill": "Samodejno izpolni",
+  "operation.fill": "Samodejno izpolni",
   "operation.format": "Format",
   "operation.getForFree": "Dobite brezplačno",
   "operation.imageCopied": "Kopirana slika",

--- a/web/i18n/sl-SI/common.json
+++ b/web/i18n/sl-SI/common.json
@@ -498,7 +498,6 @@
   "operation.edit": "Uredi",
   "operation.exporting": "Izvažanje",
   "operation.fill": "Samodejno izpolni",
-  "operation.fill": "Samodejno izpolni",
   "operation.format": "Format",
   "operation.getForFree": "Dobite brezplačno",
   "operation.imageCopied": "Kopirana slika",

--- a/web/i18n/th-TH/common.json
+++ b/web/i18n/th-TH/common.json
@@ -497,6 +497,7 @@
   "operation.duplicate": "สำเนา",
   "operation.edit": "แก้ไข",
   "operation.exporting": "กำลังส่งออก",
+  "operation.fill": "กรอกอัตโนมัติ",
   "operation.format": "รูปแบบ",
   "operation.getForFree": "รับฟรี",
   "operation.imageCopied": "ภาพที่คัดลอก",

--- a/web/i18n/tr-TR/common.json
+++ b/web/i18n/tr-TR/common.json
@@ -498,7 +498,6 @@
   "operation.edit": "Düzenle",
   "operation.exporting": "Dışa aktarılıyor",
   "operation.fill": "Otomatik doldur",
-  "operation.fill": "Otomatik doldur",
   "operation.format": "Format",
   "operation.getForFree": "Ücretsiz edinin",
   "operation.imageCopied": "Kopyalanan görüntü",

--- a/web/i18n/tr-TR/common.json
+++ b/web/i18n/tr-TR/common.json
@@ -497,6 +497,8 @@
   "operation.duplicate": "Çoğalt",
   "operation.edit": "Düzenle",
   "operation.exporting": "Dışa aktarılıyor",
+  "operation.fill": "Otomatik doldur",
+  "operation.fill": "Otomatik doldur",
   "operation.format": "Format",
   "operation.getForFree": "Ücretsiz edinin",
   "operation.imageCopied": "Kopyalanan görüntü",

--- a/web/i18n/uk-UA/common.json
+++ b/web/i18n/uk-UA/common.json
@@ -497,6 +497,7 @@
   "operation.duplicate": "дублікат",
   "operation.edit": "Редагувати",
   "operation.exporting": "Експорт",
+  "operation.fill": "Автозаповнення",
   "operation.format": "Формат",
   "operation.getForFree": "Отримати безкоштовно",
   "operation.imageCopied": "Скопійоване зображення",

--- a/web/i18n/vi-VN/common.json
+++ b/web/i18n/vi-VN/common.json
@@ -497,6 +497,7 @@
   "operation.duplicate": "Nhân bản",
   "operation.edit": "Chỉnh sửa",
   "operation.exporting": "Đang xuất",
+  "operation.fill": "Tự động điền",
   "operation.format": "Định dạng",
   "operation.getForFree": "Nhận miễn phí",
   "operation.imageCopied": "Hình ảnh sao chép",

--- a/web/i18n/zh-Hans/common.json
+++ b/web/i18n/zh-Hans/common.json
@@ -497,6 +497,7 @@
   "operation.duplicate": "复制",
   "operation.edit": "编辑",
   "operation.exporting": "导出中",
+  "operation.fill": "一键填入",
   "operation.format": "格式化",
   "operation.getForFree": "免费获取",
   "operation.imageCopied": "图片已复制",

--- a/web/i18n/zh-Hant/common.json
+++ b/web/i18n/zh-Hant/common.json
@@ -497,6 +497,7 @@
   "operation.duplicate": "複製",
   "operation.edit": "編輯",
   "operation.exporting": "匯出中",
+  "operation.fill": "一鍵填入",
   "operation.format": "格式",
   "operation.getForFree": "免費獲取",
   "operation.imageCopied": "複製的圖片",


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Adds a one-click autofill button next to the app name confirmation input in the app deletion dialog. Users can now click "Autofill" to automatically populate the input field with the app's name, making the deletion confirmation flow more convenient.

The button is added in two places:
- `web/app/components/apps/app-card.tsx` — app card delete confirmation dialog
- `web/app/components/app-sidebar/app-info/app-info-modals.tsx` — app info sidebar delete confirmation dialog

A new i18n key `operation.fill` has been added across all supported locales.

## Screenshots

| Before | After |
|--------|-------|
| Input field only | Input field with an "Autofill" button on the right that fills in the app name on click |

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods