### PR TITLE
fix: correctly propagate truncated flag in VariableTruncator._truncate_array

### DIFF
--- a/api/services/variable_truncator.py
+++ b/api/services/variable_truncator.py
@@ -292,6 +292,7 @@ class VariableTruncator(BaseTruncator):
                 used_size += 1  # Account for comma
 
             if used_size > target_size:
+                truncated = True
                 break
 
             remaining_budget = target_size - used_size
@@ -301,7 +302,7 @@ class VariableTruncator(BaseTruncator):
                 raise UnknownTypeError(f"got unknown type {type(item)} in array truncation")
             truncated_value.append(part_result.value)
             used_size += part_result.value_size
-            truncated = part_result.truncated
+            truncated = truncated or part_result.truncated
         return _PartResult(truncated_value, used_size, truncated)
 
     @classmethod

--- a/api/tests/unit_tests/services/test_variable_truncator.py
+++ b/api/tests/unit_tests/services/test_variable_truncator.py
@@ -238,6 +238,31 @@ class TestArrayTruncation:
         for item in result.value:
             assert isinstance(item, dict)
 
+    def test_size_limit_break_sets_truncated_flag(self):
+        """
+        Regression test for GH #37192 (case 1):
+        When the size budget is exhausted mid-array, the break should set truncated=True.
+        Previously the flag was left False because the break did not update it.
+        """
+        # Each integer takes ~2 bytes; target_size=12 fits [10,20,30,40] but not 50
+        t = VariableTruncator(array_element_limit=20, max_size_bytes=1000)
+        result = t._truncate_array([10, 20, 30, 40, 50], 12)
+        assert result.truncated is True
+        assert 50 not in result.value
+
+    def test_later_element_does_not_reset_truncated_flag(self):
+        """
+        Regression test for GH #37192 (case 2):
+        A later element that fits should not reset the truncated flag set by an
+        earlier truncated element.  Previously `truncated = part_result.truncated`
+        (assignment) was used instead of `truncated = truncated or part_result.truncated`
+        (accumulation).
+        """
+        t = VariableTruncator(array_element_limit=20, max_size_bytes=1000, string_length_limit=10)
+        # First element is 60 chars → truncated; second element "a" fits → should NOT reset flag
+        result = t._truncate_array(["x" * 60, "a"], 60)
+        assert result.truncated is True
+
 
 class TestObjectTruncation:
     """Test object truncation functionality."""


### PR DESCRIPTION
## Summary

Fixes two bugs in `VariableTruncator._truncate_array` that caused the `truncated` flag to be silently under-reported, so `outputs_truncated` on streaming node events stayed `false` even when elements were actually dropped or shortened.

Fixes #37192

## Root Cause

**Bug 1 — `break` without setting the flag (size-limit path)**

When the accumulated size exceeded the budget mid-array, `break` exited the loop but left `truncated = False`. Elements dropped from the tail went unreported.

**Bug 2 — assignment overwrites accumulation (inner truncation path)**

`truncated = part_result.truncated` (assignment) meant a later element that fit the budget would reset the flag to `False`, hiding truncation from an earlier element.

## Changes

`api/services/variable_truncator.py` — 2-line fix:
- Set `truncated = True` before `break` (Bug 1)
- Change `truncated = part_result.truncated` to `truncated = truncated or part_result.truncated` (Bug 2)

Matches the correct accumulation pattern already used by sibling methods `truncate_variable_mapping` and `_truncate_object`.

`api/tests/unit_tests/services/test_variable_truncator.py` — 2 regression tests added:
- `test_size_limit_break_sets_truncated_flag`
- `test_later_element_does_not_reset_truncated_flag`

## Test plan

- [x] Both new regression tests pass
- [x] All 49 existing tests pass (0 regressions)
- [x] `ruff check` passes on modified files