### PR TITLE
fix(api): set default allowed roles for PipelineRouter

### DIFF
--- a/api/controllers/openapi/auth/pipeline.py
+++ b/api/controllers/openapi/auth/pipeline.py
@@ -144,7 +144,9 @@ class PipelineRouter:
         scope: Scope | None = None,
         allowed_token_types: frozenset[TokenType] | None = None,
         edition: frozenset[Edition] | None = None,
-        allowed_roles: frozenset[TenantAccountRole] | None = None,
+        allowed_roles: frozenset[TenantAccountRole] | None = frozenset(
+            [TenantAccountRole.ADMIN, TenantAccountRole.EDITOR]
+        ),
     ) -> Callable:
         return self._make_decorator(
             scope=scope,

--- a/api/controllers/openapi/auth/pipeline.py
+++ b/api/controllers/openapi/auth/pipeline.py
@@ -145,7 +145,7 @@ class PipelineRouter:
         allowed_token_types: frozenset[TokenType] | None = None,
         edition: frozenset[Edition] | None = None,
         allowed_roles: frozenset[TenantAccountRole] | None = frozenset(
-            [TenantAccountRole.ADMIN, TenantAccountRole.EDITOR]
+            [TenantAccountRole.OWNER, TenantAccountRole.ADMIN, TenantAccountRole.EDITOR]
         ),
     ) -> Callable:
         return self._make_decorator(

--- a/api/tests/unit_tests/controllers/openapi/auth/test_pipeline.py
+++ b/api/tests/unit_tests/controllers/openapi/auth/test_pipeline.py
@@ -279,6 +279,8 @@ def test_guard_workspace_sets_membership_and_roles(app):
 
 
 def test_guard_workspace_without_roles(app):
+    from models.account import TenantAccountRole
+
     router = _make_router()
     received = {}
 
@@ -298,7 +300,9 @@ def test_guard_workspace_without_roles(app):
             view()
 
     assert isinstance(received["data"], AuthData)
-    assert received["data"].allowed_roles is None
+    assert received["data"].allowed_roles == frozenset(
+        {TenantAccountRole.OWNER, TenantAccountRole.ADMIN, TenantAccountRole.EDITOR}
+    )
 
 
 def test_guard_no_external_identity_when_subject_email_absent(app):


### PR DESCRIPTION

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Add default role constraint for `guard_workspace()`. Default to OWNER, EDITOR and ADMIN.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
