### PR TITLE
refactor(web): use React use for context helper

### DIFF
--- a/web/utils/context.spec.ts
+++ b/web/utils/context.spec.ts
@@ -6,7 +6,7 @@ import { renderHook } from '@testing-library/react'
  * and automatic error handling when context is used outside of its provider.
  *
  * Two variants are provided:
- * - createCtx: Standard React context using useContext/createContext
+ * - createCtx: Standard React context using React's use/createContext
  * - createSelectorCtx: Context with selector support using use-context-selector library
  */
 import * as React from 'react'

--- a/web/utils/context.ts
+++ b/web/utils/context.ts
@@ -1,9 +1,11 @@
 import type { Context, Provider } from 'react'
-import { createContext, useContext } from 'react'
+import { createContext, use } from 'react'
 import * as selector from 'use-context-selector'
 
+type UseContextImpl = <T>(context: Context<T>) => T
+
 const createCreateCtxFunction = (
-  useContextImpl: typeof useContext,
+  useContextImpl: UseContextImpl,
   createContextImpl: typeof createContext,
 ) => {
   return function<T>({ name, defaultValue }: CreateCtxOptions<T> = {}): CreateCtxReturn<T> {
@@ -39,9 +41,9 @@ type CreateCtxReturn<T> = [Provider<T>, () => T, Context<T>] & {
 // example
 // const [AppProvider, useApp, AppContext] = createCtx<AppContextValue>()
 
-export const createCtx = createCreateCtxFunction(useContext, createContext)
+export const createCtx = createCreateCtxFunction(use, createContext)
 
 export const createSelectorCtx = createCreateCtxFunction(
-  selector.useContext,
+  selector.useContext as UseContextImpl,
   selector.createContext as typeof createContext,
 )


### PR DESCRIPTION
Refs #25193

## Summary
Migrate the default React context helper from native `useContext` to React 19 `use`, keeping the selector-based helper on `use-context-selector`.

## Reproduction
`web/utils/context.ts` still imported React native `useContext` and passed it into `createCreateCtxFunction` for the default `createCtx` helper.

## Root cause
The shared helper predates the project's React 19 migration guidance, so `createCtx` still consumed standard React contexts through `useContext` even though React `use` can read context values.

## Changes
- Replace the React native `useContext` import with `use` in `web/utils/context.ts`.
- Add a small `UseContextImpl` adapter type so `createCreateCtxFunction` can support both React `use` and `use-context-selector`'s `useContext`.
- Update the context utility test description to mention React `use`.

## Tests
- `git diff --check`
- `pnpm --dir web test utils/context.spec.ts --run`
- `pnpm --dir web exec eslint utils/context.ts utils/context.spec.ts`
- `pnpm --dir web type-check`

## Screenshots/Logs
N/A, refactor-only utility change with no UI surface.