### PR TITLE
refactor(web): mark Props of explore/ components as read-only (#25219)

### DIFF
--- a/web/app/components/explore/try-app/app-info/index.tsx
+++ b/web/app/components/explore/try-app/app-info/index.tsx
@@ -9,13 +9,13 @@ import { AppTypeIcon } from '@/app/components/app/type-selector'
 import AppIcon from '@/app/components/base/app-icon'
 import useGetRequirements from './use-get-requirements'
 
-type Props = {
+type Props = Readonly<{
   appId: string
   appDetail: TryAppInfo
   categories?: string[]
   className?: string
   onCreate: () => void
-}
+}>
 
 const headerClassName = 'system-sm-semibold-uppercase text-text-secondary mb-3'
 const requirementIconSize = 20

--- a/web/app/components/explore/try-app/app/chat.tsx
+++ b/web/app/components/explore/try-app/app/chat.tsx
@@ -26,11 +26,11 @@ import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
 import { AppSourceType } from '@/service/share'
 import { useThemeContext } from '../../../base/chat/embedded-chatbot/theme/theme-context'
 
-type Props = {
+type Props = Readonly<{
   appId: string
   appDetail: TryAppInfo
   className: string
-}
+}>
 
 const TryApp: FC<Props> = ({
   appId,

--- a/web/app/components/explore/try-app/app/index.tsx
+++ b/web/app/components/explore/try-app/app/index.tsx
@@ -7,10 +7,10 @@ import useDocumentTitle from '@/hooks/use-document-title'
 import Chat from './chat'
 import TextGeneration from './text-generation'
 
-type Props = {
+type Props = Readonly<{
   appId: string
   appDetail: TryAppInfo
-}
+}>
 
 const TryApp: FC<Props> = ({
   appId,

--- a/web/app/components/explore/try-app/app/text-generation.tsx
+++ b/web/app/components/explore/try-app/app/text-generation.tsx
@@ -24,12 +24,12 @@ import { Resolution, TransferMethod } from '@/types/app'
 import { userInputsFormToPromptVariables } from '@/utils/model-config'
 import RunOnce from '../../../share/text-generation/run-once'
 
-type Props = {
+type Props = Readonly<{
   appId: string
   className?: string
   isWorkflow?: boolean
   appData: AppData | null
-}
+}>
 
 const TextGeneration: FC<Props> = ({
   appId,

--- a/web/app/components/explore/try-app/index.tsx
+++ b/web/app/components/explore/try-app/index.tsx
@@ -19,13 +19,13 @@ import AppInfo from './app-info'
 import Preview from './preview'
 import { TypeEnum } from './types'
 
-type Props = {
+type Props = Readonly<{
   appId: string
   app?: AppType
   categories?: string[]
   onClose: () => void
   onCreate: () => void
-}
+}>
 
 const TryApp: FC<Props> = ({
   appId,


### PR DESCRIPTION
### Summary

Marks the `Props` types of `explore/` components as read-only using `Readonly<{ ... }>`, part of #25219.

This is a type-only change with no runtime behavior impact.

Files changed:
- `web/app/components/explore/try-app/app-info/index.tsx`
- `web/app/components/explore/try-app/app/chat.tsx`
- `web/app/components/explore/try-app/app/index.tsx`
- `web/app/components/explore/try-app/app/text-generation.tsx`
- `web/app/components/explore/try-app/index.tsx`

The three `explore/try-app/preview/` components already use per-field `readonly` modifiers, so they are left as is.

### Checklist

- [x] This change is backed by tests; if not feasible, the PR description explains the manual verification steps. (Type-only change; `pnpm type-check` and `pnpm eslint` pass, no tests applicable.)
- [x] I confirm that the PR is aligned with the issue and the implementation approach.
- [ ] Documentation has been updated where relevant (README, docs, inline comments).
- [x] No secrets, credentials, or sensitive information are included in this change.
