### PR TITLE
refactor(web): mark Props of share/ components as read-only (#25219)

### DIFF
--- a/web/app/components/share/text-generation/info-modal.tsx
+++ b/web/app/components/share/text-generation/info-modal.tsx
@@ -5,11 +5,11 @@ import * as React from 'react'
 import AppIcon from '@/app/components/base/app-icon'
 import { appDefaultIconBackground } from '@/config'
 
-type Props = {
+type Props = Readonly<{
   data?: SiteInfo
   isShow: boolean
   onClose: () => void
-}
+}>
 
 const InfoModal = ({
   isShow,

--- a/web/app/components/share/text-generation/menu-dropdown.tsx
+++ b/web/app/components/share/text-generation/menu-dropdown.tsx
@@ -21,11 +21,11 @@ import { usePathname, useRouter } from '@/next/navigation'
 import { webAppLogout } from '@/service/webapp-auth'
 import InfoModal from './info-modal'
 
-type Props = {
+type Props = Readonly<{
   data?: SiteInfo
   placement?: Placement
   hideLogout?: boolean
-}
+}>
 
 const MenuDropdown: FC<Props> = ({
   data,

--- a/web/app/components/share/text-generation/run-batch/csv-reader/index.tsx
+++ b/web/app/components/share/text-generation/run-batch/csv-reader/index.tsx
@@ -9,9 +9,9 @@ import {
 } from 'react-papaparse'
 import { Csv as CSVIcon } from '@/app/components/base/icons/src/public/files'
 
-type Props = {
+type Props = Readonly<{
   onParsed: (data: string[][]) => void
-}
+}>
 
 const CSVReader: FC<Props> = ({
   onParsed,


### PR DESCRIPTION
### Summary

Marks the `Props` types of `share/` components as read-only using `Readonly<{ ... }>`, part of #25219.

This is a type-only change with no runtime behavior impact.

Files changed:
- `web/app/components/share/text-generation/info-modal.tsx`
- `web/app/components/share/text-generation/menu-dropdown.tsx`
- `web/app/components/share/text-generation/run-batch/csv-reader/index.tsx`

### Checklist

- [x] This change is backed by tests; if not feasible, the PR description explains the manual verification steps. (Type-only change; `pnpm type-check` and `pnpm eslint` pass, no tests applicable.)
- [x] I confirm that the PR is aligned with the issue and the implementation approach.
- [ ] Documentation has been updated where relevant (README, docs, inline comments).
- [x] No secrets, credentials, or sensitive information are included in this change.
