### PR TITLE
refactor(web): mark Props of header/account-setting components as read-only (#25219)

### DIFF
--- a/web/app/components/header/account-setting/members-page/operation/transfer-ownership.tsx
+++ b/web/app/components/header/account-setting/members-page/operation/transfer-ownership.tsx
@@ -16,9 +16,9 @@ import { useAppContext } from '@/context/app-context'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { useWorkspacePermissions } from '@/service/use-workspace'
 
-type Props = {
+type Props = Readonly<{
   onOperate: () => void
-}
+}>
 
 const TransferOwnership = ({ onOperate }: Props) => {
   const { t } = useTranslation()

--- a/web/app/components/header/account-setting/members-page/transfer-ownership-modal/index.tsx
+++ b/web/app/components/header/account-setting/members-page/transfer-ownership-modal/index.tsx
@@ -9,10 +9,10 @@ import { useAppContext } from '@/context/app-context'
 import { ownershipTransfer, sendOwnerEmail, verifyOwnerEmail } from '@/service/common'
 import MemberSelector from './member-selector'
 
-type Props = {
+type Props = Readonly<{
   show: boolean
   onClose: () => void
-}
+}>
 enum STEP {
   start = 'start',
   verify = 'verify',

--- a/web/app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx
+++ b/web/app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx
@@ -12,11 +12,11 @@ import { useTranslation } from 'react-i18next'
 import Input from '@/app/components/base/input'
 import { useMembers } from '@/service/use-common'
 
-type Props = {
+type Props = Readonly<{
   value?: string
   onSelect: (value: string) => void
   exclude?: string[]
-}
+}>
 
 const MemberSelector: FC<Props> = ({
   value,

--- a/web/app/components/header/account-setting/model-provider-page/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/index.tsx
@@ -27,9 +27,9 @@ import { providerToPluginId } from './utils'
 
 type SystemModelConfigStatus = 'no-provider' | 'none-configured' | 'partially-configured' | 'fully-configured'
 
-type Props = {
+type Props = Readonly<{
   searchText: string
-}
+}>
 
 const FixedModelProvider = ['langgenius/openai/openai', 'langgenius/anthropic/anthropic']
 

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/provider-card-actions.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/provider-card-actions.tsx
@@ -15,10 +15,10 @@ import { useLocale } from '@/context/i18n'
 import useTheme from '@/hooks/use-theme'
 import { getMarketplaceUrl } from '@/utils/var'
 
-type Props = {
+type Props = Readonly<{
   detail: PluginDetail
   onUpdate?: () => void
-}
+}>
 
 const ProviderCardActions: FC<Props> = ({ detail, onUpdate }) => {
   const { t } = useTranslation()


### PR DESCRIPTION
### Summary

Marks the `Props` types of `header/account-setting/` components as read-only using `Readonly<{ ... }>`, part of #25219.

This is a type-only change with no runtime behavior impact. It does not overlap with #36487, which covers other `header/` components.

Files changed:
- `web/app/components/header/account-setting/members-page/operation/transfer-ownership.tsx`
- `web/app/components/header/account-setting/members-page/transfer-ownership-modal/index.tsx`
- `web/app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx`
- `web/app/components/header/account-setting/model-provider-page/index.tsx`
- `web/app/components/header/account-setting/model-provider-page/provider-added-card/provider-card-actions.tsx`

### Checklist

- [x] This change is backed by tests; if not feasible, the PR description explains the manual verification steps. (Type-only change; `pnpm type-check` and `pnpm eslint` pass, no tests applicable.)
- [x] I confirm that the PR is aligned with the issue and the implementation approach.
- [ ] Documentation has been updated where relevant (README, docs, inline comments).
- [x] No secrets, credentials, or sensitive information are included in this change.
