### PR TITLE
refactor(web): mark Props of misc components as read-only (#25219)

### DIFF
--- a/web/app/components/app-sidebar/app-sidebar-dropdown.tsx
+++ b/web/app/components/app-sidebar/app-sidebar-dropdown.tsx
@@ -21,7 +21,7 @@ import AppInfo from './app-info'
 import { getAppModeLabel } from './app-info/app-mode-labels'
 import NavLink from './nav-link'
 
-type Props = {
+type Props = Readonly<{
   navigation: Array<{
     name: string
     href: string
@@ -29,7 +29,7 @@ type Props = {
     selectedIcon: NavIcon
   }>
   appInfoActions?: AppInfoActions
-}
+}>
 
 const AppSidebarDropdown = ({ navigation, appInfoActions }: Props) => {
   const { t } = useTranslation()

--- a/web/app/components/apps/list.tsx
+++ b/web/app/components/apps/list.tsx
@@ -37,9 +37,9 @@ const CreateFromDSLModal = dynamic(() => import('@/app/components/app/create-fro
   ssr: false,
 })
 
-type Props = {
+type Props = Readonly<{
   controlRefreshList?: number
-}
+}>
 function List({
   controlRefreshList = 0,
 }: Props) {

--- a/web/app/components/goto-anything/command-selector.tsx
+++ b/web/app/components/goto-anything/command-selector.tsx
@@ -6,14 +6,14 @@ import { useTranslation } from 'react-i18next'
 import { usePathname } from '@/next/navigation'
 import { slashCommandRegistry } from './actions/commands/registry'
 
-type Props = {
+type Props = Readonly<{
   actions: Record<string, ActionItem>
   onCommandSelect: (commandKey: string) => void
   searchFilter?: string
   commandValue?: string
   onCommandValueChange?: (value: string) => void
   originalQuery?: string
-}
+}>
 
 const CommandSelector: FC<Props> = ({ actions, onCommandSelect, searchFilter, commandValue, onCommandValueChange, originalQuery }) => {
   const { t } = useTranslation()

--- a/web/app/components/goto-anything/index.tsx
+++ b/web/app/components/goto-anything/index.tsx
@@ -18,9 +18,9 @@ import {
   useGotoAnythingSearch,
 } from './hooks'
 
-type Props = {
+type Props = Readonly<{
   onHide?: () => void
-}
+}>
 
 const GotoAnythingDialog: FC<Props> = ({
   onHide,

--- a/web/app/components/snippet-list/components/snippet-card.tsx
+++ b/web/app/components/snippet-list/components/snippet-card.tsx
@@ -30,12 +30,12 @@ import { useDeleteSnippetMutation, useExportSnippetMutation, useUpdateSnippetMut
 import { downloadBlob } from '@/utils/download'
 import { formatTime } from '@/utils/time'
 
-type Props = {
+type Props = Readonly<{
   snippet: SnippetListItem
   onOpenTagManagement?: () => void
   onRefresh?: () => void
   onTagsChange?: () => void
-}
+}>
 
 const SnippetCard = ({
   snippet,

--- a/web/context/app-list-context.ts
+++ b/web/context/app-list-context.ts
@@ -2,12 +2,12 @@ import type { SetTryAppPanel, TryAppSelection } from '@/types/try-app'
 import { noop } from 'es-toolkit/function'
 import { createContext } from 'use-context-selector'
 
-type Props = {
+type Props = Readonly<{
   currentApp?: TryAppSelection
   isShowTryAppPanel: boolean
   setShowTryAppPanel: SetTryAppPanel
   controlHideCreateFromTemplatePanel: number
-}
+}>
 
 const AppListContext = createContext<Props>({
   isShowTryAppPanel: false,


### PR DESCRIPTION
### Summary

Marks the `Props` types of remaining small top-level components as read-only using `Readonly<{ ... }>`, part of #25219.

This is a type-only change with no runtime behavior impact.

Files changed:
- `web/app/components/app-sidebar/app-sidebar-dropdown.tsx`
- `web/app/components/apps/list.tsx`
- `web/app/components/goto-anything/command-selector.tsx`
- `web/app/components/goto-anything/index.tsx`
- `web/app/components/snippet-list/components/snippet-card.tsx`
- `web/context/app-list-context.ts`

### Checklist

- [x] This change is backed by tests; if not feasible, the PR description explains the manual verification steps. (Type-only change; `pnpm type-check` and `pnpm eslint` pass, no tests applicable.)
- [x] I confirm that the PR is aligned with the issue and the implementation approach.
- [ ] Documentation has been updated where relevant (README, docs, inline comments).
- [x] No secrets, credentials, or sensitive information are included in this change.
