### PR TITLE
refactor(api): default OAuth state inputs to empty strings

### DIFF
--- a/api/controllers/console/auth/oauth.py
+++ b/api/controllers/console/auth/oauth.py
@@ -89,7 +89,7 @@ class OAuthLogin(Resource):
     @console_ns.response(302, "Redirect to OAuth authorization URL")
     @console_ns.response(400, "Invalid provider")
     def get(self, provider: str):
-        invite_token = request.args.get("invite_token") or None
+        invite_token = request.args.get("invite_token") or ""
         timezone = _validated_timezone(request.args.get("timezone") or None)
         language = _validated_language(request.args.get("language") or None)
         OAUTH_PROVIDERS = get_oauth_providers()
@@ -100,8 +100,8 @@ class OAuthLogin(Resource):
 
         auth_url = oauth_provider.get_authorization_url(
             invite_token=invite_token,
-            timezone=timezone,
-            language=language,
+            timezone=timezone or "",
+            language=language or "",
         )
         return redirect(auth_url)
 

--- a/api/libs/oauth.py
+++ b/api/libs/oauth.py
@@ -69,9 +69,9 @@ class OAuthUserInfo:
 
 
 def encode_oauth_state(
-    invite_token: str | None = None,
-    timezone: str | None = None,
-    language: str | None = None,
+    invite_token: str = "",
+    timezone: str = "",
+    language: str = "",
 ) -> str | None:
     state: OAuthState = {}
     if invite_token:
@@ -119,9 +119,9 @@ class OAuth:
 
     def get_authorization_url(
         self,
-        invite_token: str | None = None,
-        timezone: str | None = None,
-        language: str | None = None,
+        invite_token: str = "",
+        timezone: str = "",
+        language: str = "",
     ) -> str:
         raise NotImplementedError()
 
@@ -148,9 +148,9 @@ class GitHubOAuth(OAuth):
     @override
     def get_authorization_url(
         self,
-        invite_token: str | None = None,
-        timezone: str | None = None,
-        language: str | None = None,
+        invite_token: str = "",
+        timezone: str = "",
+        language: str = "",
     ) -> str:
         params = {
             "client_id": self.client_id,
@@ -234,7 +234,7 @@ class GitHubOAuth(OAuth):
             github_id = payload["id"]
             email = f"{github_id}@users.noreply.github.com"
             logger.info("GitHub user %s has no public email; using noreply address", payload["login"])
-        return OAuthUserInfo(id=str(payload["id"]), name=str(payload.get("name") or ""), email=email)
+        return OAuthUserInfo(id=str(payload["id"]), name=payload.get("name") or "", email=email)
 
 
 class GoogleOAuth(OAuth):
@@ -245,9 +245,9 @@ class GoogleOAuth(OAuth):
     @override
     def get_authorization_url(
         self,
-        invite_token: str | None = None,
-        timezone: str | None = None,
-        language: str | None = None,
+        invite_token: str = "",
+        timezone: str = "",
+        language: str = "",
     ) -> str:
         params = {
             "client_id": self.client_id,
@@ -290,4 +290,4 @@ class GoogleOAuth(OAuth):
     @override
     def _transform_user_info(self, raw_info: JsonObject) -> OAuthUserInfo:
         payload = GOOGLE_RAW_USER_INFO_ADAPTER.validate_python(raw_info)
-        return OAuthUserInfo(id=str(payload["sub"]), name="", email=payload["email"])
+        return OAuthUserInfo(id=payload["sub"], name="", email=payload["email"])

--- a/api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth.py
@@ -102,9 +102,9 @@ class TestOAuthLogin:
             resource.get("github")
 
         mock_oauth_provider.get_authorization_url.assert_called_once_with(
-            invite_token=expected_token,
-            timezone=None,
-            language=None,
+            invite_token=expected_token or "",
+            timezone="",
+            language="",
         )
         mock_redirect.assert_called_once_with("https://github.com/login/oauth/authorize?...")
 
@@ -124,9 +124,9 @@ class TestOAuthLogin:
             resource.get("github")
 
         mock_oauth_provider.get_authorization_url.assert_called_once_with(
-            invite_token=None,
+            invite_token="",
             timezone="Asia/Shanghai",
-            language=None,
+            language="",
         )
         mock_redirect.assert_called_once_with("https://github.com/login/oauth/authorize?...")
 
@@ -146,8 +146,8 @@ class TestOAuthLogin:
             resource.get("github")
 
         mock_oauth_provider.get_authorization_url.assert_called_once_with(
-            invite_token=None,
-            timezone=None,
+            invite_token="",
+            timezone="",
             language="zh-Hans",
         )
         mock_redirect.assert_called_once_with("https://github.com/login/oauth/authorize?...")

--- a/api/tests/unit_tests/controllers/console/auth/test_oauth_timezone.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_oauth_timezone.py
@@ -30,7 +30,7 @@ def test_oauth_login_passes_language_and_timezone_to_authorization_url(
         OAuthLogin().get("github")
 
     oauth_provider.get_authorization_url.assert_called_once_with(
-        invite_token=None,
+        invite_token="",
         timezone="Asia/Shanghai",
         language="zh-Hans",
     )

--- a/api/tests/unit_tests/libs/test_oauth_clients.py
+++ b/api/tests/unit_tests/libs/test_oauth_clients.py
@@ -39,11 +39,10 @@ class TestGitHubOAuth(BaseOAuthTest):
     @pytest.mark.parametrize(
         ("invite_token", "timezone", "language", "expected_state"),
         [
-            (None, None, None, None),
-            ("test_invite_token", None, None, {"invite_token": "test_invite_token"}),
-            ("", None, None, None),
-            (None, "Asia/Shanghai", None, {"timezone": "Asia/Shanghai"}),
-            (None, None, "zh-Hans", {"language": "zh-Hans"}),
+            ("", "", "", None),
+            ("test_invite_token", "", "", {"invite_token": "test_invite_token"}),
+            ("", "Asia/Shanghai", "", {"timezone": "Asia/Shanghai"}),
+            ("", "", "zh-Hans", {"language": "zh-Hans"}),
             (
                 "test_invite_token",
                 "Asia/Shanghai",
@@ -220,11 +219,10 @@ class TestGoogleOAuth(BaseOAuthTest):
     @pytest.mark.parametrize(
         ("invite_token", "timezone", "language", "expected_state"),
         [
-            (None, None, None, None),
-            ("test_invite_token", None, None, {"invite_token": "test_invite_token"}),
-            ("", None, None, None),
-            (None, "Asia/Shanghai", None, {"timezone": "Asia/Shanghai"}),
-            (None, None, "zh-Hans", {"language": "zh-Hans"}),
+            ("", "", "", None),
+            ("test_invite_token", "", "", {"invite_token": "test_invite_token"}),
+            ("", "Asia/Shanghai", "", {"timezone": "Asia/Shanghai"}),
+            ("", "", "zh-Hans", {"language": "zh-Hans"}),
             (
                 "test_invite_token",
                 "Asia/Shanghai",


### PR DESCRIPTION
## Summary

- default OAuth authorization state inputs to empty strings instead of optional `None` values
- normalize missing login query params before passing them to OAuth providers
- remove two unnecessary string conversions from OAuth user transforms

Refs #35557

## Tests

- `uv run --project api --dev pytest api/tests/unit_tests/libs/test_oauth_base.py api/tests/unit_tests/libs/test_oauth_clients.py api/tests/unit_tests/controllers/console/auth/test_oauth_timezone.py`
- `uv run --project api --dev ruff check api/libs/oauth.py api/controllers/console/auth/oauth.py api/tests/unit_tests/libs/test_oauth_clients.py api/tests/unit_tests/controllers/console/auth/test_oauth_timezone.py api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth.py`
- `uv run --project api --dev ruff format --check api/libs/oauth.py api/controllers/console/auth/oauth.py api/tests/unit_tests/libs/test_oauth_clients.py api/tests/unit_tests/controllers/console/auth/test_oauth_timezone.py api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth.py`
- `uv run --project api --dev pyrefly check api/libs/oauth.py api/controllers/console/auth/oauth.py`