### PR TITLE
fix: correct truncated flag accumulation in _truncate_array (#37192)

### DIFF
--- a/api/services/variable_truncator.py
+++ b/api/services/variable_truncator.py
@@ -292,6 +292,7 @@ class VariableTruncator(BaseTruncator):
                 used_size += 1  # Account for comma
 
             if used_size > target_size:
+                truncated = True
                 break
 
             remaining_budget = target_size - used_size
@@ -301,7 +302,7 @@ class VariableTruncator(BaseTruncator):
                 raise UnknownTypeError(f"got unknown type {type(item)} in array truncation")
             truncated_value.append(part_result.value)
             used_size += part_result.value_size
-            truncated = part_result.truncated
+            truncated = truncated or part_result.truncated
         return _PartResult(truncated_value, used_size, truncated)
 
     @classmethod


### PR DESCRIPTION
## Summary

Fixes the `truncated` flag not being correctly accumulated in `VariableTruncator._truncate_array()`.

The method had two bugs in how it tracked whether truncation occurred:

1. **Size-budget break without flag**: When `used_size > target_size` caused the loop to break early (dropping remaining elements), the `truncated` flag was never set to `True`. This meant `outputs_truncated` / `inputs_truncated` was reported as `false` on the node's streaming event even though array elements were dropped.

2. **Flag overwrite instead of accumulation**: `truncated = part_result.truncated` overwrites the flag on each iteration. If an early element was truncated but a later one wasn't, the flag was silently reset to `False`. The sibling methods `_truncate_object` and `truncate_variable_mapping` both use `or` accumulation correctly; only `_truncate_array` had this issue.

## Fix

- Add `truncated = True` before the `break` when the size budget is exceeded.
- Change `truncated = part_result.truncated` to `truncated = truncated or part_result.truncated` to accumulate the flag across iterations.

## Tests

Reproduced with the issue's unit-level example. After the fix:

```python
from services.variable_truncator import VariableTruncator

# Case 1: size-limit break drops the tail
t = VariableTruncator(array_element_limit=20, max_size_bytes=1000)
r = t._truncate_array([10, 20, 30, 40, 50], 12)
assert r.truncated is True  # was False before fix

# Case 2: later non-truncated element no longer resets the flag
t2 = VariableTruncator(array_element_limit=20, max_size_bytes=1000, string_length_limit=10)
r2 = t2._truncate_array(["x" * 60, "a"], 60)
assert r2.truncated is True  # was False before fix
```

Refs #37192