### PR TITLE
refactor: migrate dify-isShowManageMetadata localStorage to hooks (#36898)

### DIFF
--- a/web/app/components/datasets/metadata/hooks/use-edit-dataset-metadata.ts
+++ b/web/app/components/datasets/metadata/hooks/use-edit-dataset-metadata.ts
@@ -3,9 +3,10 @@ import type { DataSet } from '@/models/datasets'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useBoolean } from 'ahooks'
 import { useCallback, useEffect, useState } from 'react'
+import { useLocalStorage } from '@/hooks/use-local-storage'
 import { useTranslation } from 'react-i18next'
 import { useBuiltInMetaDataFields, useCreateMetaData, useDatasetMetaData, useDeleteMetaData, useRenameMeta, useUpdateBuiltInStatus } from '@/service/knowledge/use-metadata'
-import { isShowManageMetadataLocalStorageKey } from '../types'
+
 import useCheckMetadataName from './use-check-metadata-name'
 
 const useEditDatasetMetadata = ({ datasetId,
@@ -17,13 +18,13 @@ const useEditDatasetMetadata = ({ datasetId,
 }) => {
   const { t } = useTranslation()
   const [isShowEditModal, { setTrue: showEditModal, setFalse: hideEditModal }] = useBoolean(false)
+  const [isShowManageMetadata, setIsShowManageMetadata] = useLocalStorage<string>('dify-isShowManageMetadata', '', { raw: true })
   useEffect(() => {
-    const isShowManageMetadata = localStorage.getItem(isShowManageMetadataLocalStorageKey)
     if (isShowManageMetadata) {
       showEditModal()
-      localStorage.removeItem(isShowManageMetadataLocalStorageKey)
+      setIsShowManageMetadata('')
     }
-  }, [])
+  }, [isShowManageMetadata, setIsShowManageMetadata, showEditModal])
   const { data: datasetMetaData } = useDatasetMetaData(datasetId)
   const { mutate: doAddMetaData } = useCreateMetaData(datasetId)
   const { checkName } = useCheckMetadataName()

--- a/web/app/components/datasets/metadata/metadata-document/info-group.tsx
+++ b/web/app/components/datasets/metadata/metadata-document/info-group.tsx
@@ -12,6 +12,7 @@ import { useRouter } from '@/next/navigation'
 import InputCombined from '../edit-metadata-batch/input-combined'
 import { DatasetMetadataPicker } from '../metadata-dataset/dataset-metadata-picker'
 import { DataType, isShowManageMetadataLocalStorageKey } from '../types'
+import { useSetLocalStorage } from '@/hooks/use-local-storage'
 import Field from './field'
 
 type Props = {
@@ -50,9 +51,9 @@ const InfoGroup: FC<Props> = ({
   const router = useRouter()
   const { t } = useTranslation()
   const { formatTime: formatTimestamp } = useTimestamp()
-
+  const setIsShowManageMetadata = useSetLocalStorage<string>(isShowManageMetadataLocalStorageKey, { raw: true })
   const handleMangeMetadata = () => {
-    localStorage.setItem(isShowManageMetadataLocalStorageKey, 'true')
+    setIsShowManageMetadata('true')
     router.push(`/datasets/${dataSetId}/documents`)
   }
 


### PR DESCRIPTION
## Summary

Migrates direct `localStorage` usage for the `dify-isShowManageMetadata` signal flag to `@/hooks/use-local-storage` hooks.

This is a slice of #36898.

## Changes

**`info-group.tsx`** (setter):
- Replaced `localStorage.setItem(isShowManageMetadataLocalStorageKey, 'true')` with `useSetLocalStorage<string>(isShowManageMetadataLocalStorageKey, { raw: true })`

**`use-edit-dataset-metadata.ts`** (reader):
- Replaced `localStorage.getItem()` + `localStorage.removeItem()` with `useLocalStorage<string>()`
- The `useEffect` now depends on the hook value and clears it via the setter after reading

## Pattern

This is a cross-page signal flag pattern: `info-group.tsx` sets the flag before navigating, and `use-edit-dataset-metadata.ts` reads and clears it on mount. The migration preserves this behavior using the hook boundary.