### PR TITLE
fix: allow end-users to access account-owned upload files in published workflows

### DIFF
--- a/api/core/app/file_access/controller.py
+++ b/api/core/app/file_access/controller.py
@@ -51,16 +51,18 @@ class DatabaseFileAccessController(FileAccessControllerProtocol):
         if not resolved_scope.requires_user_ownership:
             return scoped_stmt
 
+        account_owned_filter = UploadFile.created_by_role == CreatorUserRole.ACCOUNT
         user_owned_filter = and_(
             UploadFile.created_by_role == CreatorUserRole.END_USER,
             UploadFile.created_by == resolved_scope.user_id,
         )
         if not resolved_scope.granted_upload_file_ids:
-            return scoped_stmt.where(user_owned_filter)
+            return scoped_stmt.where(or_(user_owned_filter, account_owned_filter))
 
         return scoped_stmt.where(
             or_(
                 user_owned_filter,
+                account_owned_filter,
                 UploadFile.id.in_(resolved_scope.granted_upload_file_ids),
             )
         )


### PR DESCRIPTION
## Summary

Since v1.14.0, the `FileAccessScope` introduced in `DatabaseFileAccessController` strictly requires end-users to own upload files (`created_by_role == END_USER && created_by == user_id`). This breaks a valid use case:

**Account users pre-load files as default values in the Start node of a workflow/advanced-chat app.** When the app is published and accessed by end-users, the file lookup fails because the account-owned file does not pass the end-user ownership check.

## Bug

When an account user adds a file variable with a default file in the workflow Start node and publishes the app, end-users get:

```
ValueError: Invalid upload file
```

This happens because `apply_upload_file_filters()` only allows files where `created_by_role == END_USER` and `created_by == resolved_scope.user_id`. Files uploaded by account users are rejected.

The preview/debug mode works because it runs with account-level context where `requires_user_ownership = False`.

## Fix

Allow end-users to access upload files created by accounts (`created_by_role == ACCOUNT`) within the same tenant. Tenant isolation is preserved via the existing `tenant_id` filter.

## Related Issues

- Fixes #36287
- Fixes #36218
- Related #33822

## Testing

- Verified on self-hosted Dify v1.14.2: account-owned files are now accessible in published advanced-chat apps
- End-user owned files continue to work as before
- Tenant isolation is preserved (tenant_id check remains mandatory)

<details>
<summary>Diff</summary>

```diff
+        account_owned_filter = UploadFile.created_by_role == CreatorUserRole.ACCOUNT
         user_owned_filter = and_(
             UploadFile.created_by_role == CreatorUserRole.END_USER,
             UploadFile.created_by == resolved_scope.user_id,
         )
         if not resolved_scope.granted_upload_file_ids:
-            return scoped_stmt.where(user_owned_filter)
+            return scoped_stmt.where(or_(user_owned_filter, account_owned_filter))
 
         return scoped_stmt.where(
             or_(
                 user_owned_filter,
+                account_owned_filter,
                 UploadFile.id.in_(resolved_scope.granted_upload_file_ids),
             )
         )
```
</details>