### PR TITLE
feat(webapp): display app description on chat and text-generation app screens

### DIFF
--- a/api/controllers/console/explore/installed_app.py
+++ b/api/controllers/console/explore/installed_app.py
@@ -85,6 +85,7 @@ def _published_app_filter():
 class InstalledAppInfoResponse(ResponseModel):
     id: str
     name: str | None = None
+    description: str | None = None
     mode: str | None = None
     icon_type: str | None = None
     icon: str | None = None
@@ -123,6 +124,7 @@ class InstalledAppResponse(ResponseModel):
         return {
             "id": _safe_primitive(getattr(value, "id", "")) or "",
             "name": _safe_primitive(getattr(value, "name", None)),
+            "description": _safe_primitive(getattr(value, "description", None)),
             "mode": _safe_primitive(getattr(value, "mode", None)),
             "icon_type": _safe_primitive(getattr(value, "icon_type", None)),
             "icon": _safe_primitive(getattr(value, "icon", None)),

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -16427,6 +16427,7 @@ Input field definition for snippet parameters.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
+| description | string |  | No |
 | icon | string |  | No |
 | icon_background | string |  | No |
 | icon_type | string |  | No |

--- a/packages/contracts/generated/api/console/installed-apps/types.gen.ts
+++ b/packages/contracts/generated/api/console/installed-apps/types.gen.ts
@@ -231,6 +231,7 @@ export type SavedMessageItem = {
 }
 
 export type InstalledAppInfoResponse = {
+  description?: string | null
   icon?: string | null
   icon_background?: string | null
   icon_type?: string | null

--- a/packages/contracts/generated/api/console/installed-apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/installed-apps/zod.gen.ts
@@ -229,6 +229,7 @@ export const zParameters = z.object({
  * InstalledAppInfoResponse
  */
 export const zInstalledAppInfoResponse = z.object({
+  description: z.string().nullish(),
   icon: z.string().nullish(),
   icon_background: z.string().nullish(),
   icon_type: z.string().nullish(),

--- a/web/app/components/base/chat/chat-with-history/chat-wrapper.tsx
+++ b/web/app/components/base/chat/chat-with-history/chat-wrapper.tsx
@@ -177,6 +177,14 @@ const ChatWrapper = () => {
     }
   }, [])
 
+  const [hasSent, setHasSent] = useState(false)
+  const [prevConversationId, setPrevConversationId] = useState(currentConversationId)
+  if (prevConversationId !== currentConversationId) {
+    setPrevConversationId(currentConversationId)
+    if (!currentConversationId)
+      setHasSent(false)
+  }
+
   const doSend: OnSend = useCallback((message, files, isRegenerate = false, parentAnswer: ChatItem | null = null) => {
     if (!currentConversationId)
       setHasSent(true)
@@ -229,12 +237,6 @@ const ChatWrapper = () => {
 
   const [collapsed, setCollapsed] = useState(!!currentConversationId)
   const [descExpanded, setDescExpanded] = useState(false)
-  const [hasSent, setHasSent] = useState(false)
-
-  useEffect(() => {
-    if (!currentConversationId)
-      setHasSent(false)
-  }, [currentConversationId])
 
   const description = appData?.site.description
   const showDescToggle = !!description && (description.includes('\n') || description.length > 100)
@@ -247,10 +249,11 @@ const ChatWrapper = () => {
         <div className="w-full max-w-[672px] rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-md">
           <div className={cn('p-6', isMobile && 'p-4')}>
             <div className={cn(
-              'relative system-xs-regular text-text-tertiary whitespace-pre-wrap break-words',
+              'relative system-xs-regular break-words whitespace-pre-wrap text-text-tertiary',
               !descExpanded && 'line-clamp-2',
               descExpanded && 'max-h-32 overflow-y-auto',
-            )}>
+            )}
+            >
               {description}
               {!descExpanded && showDescToggle && (
                 <div className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-linear-to-b from-components-panel-bg-transparent to-components-panel-bg" />
@@ -263,9 +266,18 @@ const ChatWrapper = () => {
                 onClick={() => setDescExpanded(v => !v)}
               >
                 {descExpanded
-                  ? <><RiArrowUpSLine className="size-3" />{t('chat.collapse', { ns: 'share' })}</>
-                  : <><RiArrowDownSLine className="size-3" />{t('chat.expand', { ns: 'share' })}</>
-                }
+                  ? (
+                      <>
+                        <RiArrowUpSLine className="size-3" />
+                        {t('chat.collapse', { ns: 'share' })}
+                      </>
+                    )
+                  : (
+                      <>
+                        <RiArrowDownSLine className="size-3" />
+                        {t('chat.expand', { ns: 'share' })}
+                      </>
+                    )}
               </button>
             )}
           </div>

--- a/web/app/components/base/chat/chat-with-history/chat-wrapper.tsx
+++ b/web/app/components/base/chat/chat-with-history/chat-wrapper.tsx
@@ -7,7 +7,9 @@ import type {
 } from '../types'
 import { Avatar } from '@langgenius/dify-ui/avatar'
 import { cn } from '@langgenius/dify-ui/cn'
+import { RiArrowDownSLine, RiArrowUpSLine } from '@remixicon/react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import AnswerIcon from '@/app/components/base/answer-icon'
 import AppIcon from '@/app/components/base/app-icon'
 import InputsForm from '@/app/components/base/chat/chat-with-history/inputs-form'
@@ -30,6 +32,7 @@ import { getLastAnswer, isValidGeneratedAnswer } from '../utils'
 import { useChatWithHistoryContext } from './context'
 
 const ChatWrapper = () => {
+  const { t } = useTranslation()
   const {
     appParams,
     appPrevChatTree,
@@ -175,6 +178,8 @@ const ChatWrapper = () => {
   }, [])
 
   const doSend: OnSend = useCallback((message, files, isRegenerate = false, parentAnswer: ChatItem | null = null) => {
+    if (!currentConversationId)
+      setHasSent(true)
     const data: any = {
       query: message,
       files,
@@ -223,6 +228,51 @@ const ChatWrapper = () => {
   }, [isInstalledApp])
 
   const [collapsed, setCollapsed] = useState(!!currentConversationId)
+  const [descExpanded, setDescExpanded] = useState(false)
+  const [hasSent, setHasSent] = useState(false)
+
+  useEffect(() => {
+    if (!currentConversationId)
+      setHasSent(false)
+  }, [currentConversationId])
+
+  const description = appData?.site.description
+  const showDescToggle = !!description && (description.includes('\n') || description.length > 100)
+
+  const descriptionNode = useMemo(() => {
+    if (!description || currentConversationId || hasSent)
+      return null
+    return (
+      <div className={cn('flex flex-col items-center px-4 pt-6', isMobile && 'pt-4')}>
+        <div className="w-full max-w-[672px] rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-md">
+          <div className={cn('p-6', isMobile && 'p-4')}>
+            <div className={cn(
+              'relative system-xs-regular text-text-tertiary whitespace-pre-wrap break-words',
+              !descExpanded && 'line-clamp-2',
+              descExpanded && 'max-h-32 overflow-y-auto',
+            )}>
+              {description}
+              {!descExpanded && showDescToggle && (
+                <div className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-linear-to-b from-components-panel-bg-transparent to-components-panel-bg" />
+              )}
+            </div>
+            {showDescToggle && (
+              <button
+                type="button"
+                className="mt-0.5 flex items-center gap-0.5 system-xs-regular text-text-accent hover:opacity-80"
+                onClick={() => setDescExpanded(v => !v)}
+              >
+                {descExpanded
+                  ? <><RiArrowUpSLine className="size-3" />{t('chat.collapse', { ns: 'share' })}</>
+                  : <><RiArrowDownSLine className="size-3" />{t('chat.expand', { ns: 'share' })}</>
+                }
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    )
+  }, [description, isMobile, currentConversationId, hasSent, descExpanded, showDescToggle, t])
 
   const chatNode = useMemo(() => {
     if (allInputsHidden || !inputsForms.length)
@@ -332,6 +382,7 @@ const ChatWrapper = () => {
         onHumanInputFormSubmit={handleSubmitHumanInputForm}
         chatNode={(
           <>
+            {descriptionNode}
             {chatNode}
             {welcome}
           </>

--- a/web/app/components/base/chat/chat-with-history/chat-wrapper.tsx
+++ b/web/app/components/base/chat/chat-with-history/chat-wrapper.tsx
@@ -239,7 +239,10 @@ const ChatWrapper = () => {
   const [descExpanded, setDescExpanded] = useState(false)
 
   const description = appData?.site.description
-  const showDescToggle = !!description && (description.includes('\n') || description.length > 100)
+  const [showDescToggle, setShowDescToggle] = useState(false)
+  const handleDescRef = useCallback((node: HTMLDivElement | null) => {
+    setShowDescToggle(!!node && node.scrollHeight > node.clientHeight)
+  }, [])
 
   const descriptionNode = useMemo(() => {
     if (!description || currentConversationId || hasSent)
@@ -248,11 +251,13 @@ const ChatWrapper = () => {
       <div className={cn('flex flex-col items-center px-4 pt-6', isMobile && 'pt-4')}>
         <div className="w-full max-w-[672px] rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-md">
           <div className={cn('p-6', isMobile && 'p-4')}>
-            <div className={cn(
-              'relative system-xs-regular break-words whitespace-pre-wrap text-text-tertiary',
-              !descExpanded && 'line-clamp-2',
-              descExpanded && 'max-h-32 overflow-y-auto',
-            )}
+            <div
+              ref={handleDescRef}
+              className={cn(
+                'relative system-xs-regular break-words whitespace-pre-wrap text-text-tertiary',
+                !descExpanded && 'line-clamp-3',
+                descExpanded && 'max-h-32 overflow-y-auto',
+              )}
             >
               {description}
               {!descExpanded && showDescToggle && (

--- a/web/app/components/base/chat/chat-with-history/hooks.tsx
+++ b/web/app/components/base/chat/chat-with-history/hooks.tsx
@@ -96,6 +96,7 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
         app_id: id,
         site: {
           title: app.name,
+          description: app.description,
           icon_type: app.icon_type,
           icon: app.icon,
           icon_background: app.icon_background,

--- a/web/app/components/base/chat/embedded-chatbot/chat-wrapper.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/chat-wrapper.tsx
@@ -8,7 +8,9 @@ import type {
 } from '../types'
 import { Avatar } from '@langgenius/dify-ui/avatar'
 import { cn } from '@langgenius/dify-ui/cn'
+import { RiArrowDownSLine, RiArrowUpSLine } from '@remixicon/react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import AnswerIcon from '@/app/components/base/answer-icon'
 import AppIcon from '@/app/components/base/app-icon'
 import SuggestedQuestions from '@/app/components/base/chat/chat/answer/suggested-questions'
@@ -32,6 +34,7 @@ import { useEmbeddedChatbotContext } from './context'
 import { isDify } from './utils'
 
 const ChatWrapper = () => {
+  const { t } = useTranslation()
   const {
     appData,
     appParams,
@@ -178,6 +181,8 @@ const ChatWrapper = () => {
   }, [])
 
   const doSend: OnSend = useCallback((message, files, isRegenerate = false, parentAnswer: ChatItem | null = null) => {
+    if (!currentConversationId)
+      setHasSent(true)
     const data: any = {
       query: message,
       files,
@@ -219,6 +224,51 @@ const ChatWrapper = () => {
 
   const isTryApp = appSourceType === AppSourceType.tryApp
   const [collapsed, setCollapsed] = useState(!!currentConversationId && !isTryApp) // try app always use the new chat
+  const [descExpanded, setDescExpanded] = useState(false)
+  const [hasSent, setHasSent] = useState(false)
+
+  useEffect(() => {
+    if (!currentConversationId)
+      setHasSent(false)
+  }, [currentConversationId])
+
+  const description = appData?.site.description
+  const showDescToggle = !!description && (description.includes('\n') || description.length > 100)
+
+  const descriptionNode = useMemo(() => {
+    if (!description || currentConversationId || hasSent)
+      return null
+    return (
+      <div className={cn('flex flex-col items-center px-4 pt-6', isMobile && 'pt-4')}>
+        <div className="w-full max-w-[672px] rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-md">
+          <div className={cn('p-6', isMobile && 'p-4')}>
+            <div className={cn(
+              'relative system-xs-regular text-text-tertiary whitespace-pre-wrap break-words',
+              !descExpanded && 'line-clamp-2',
+              descExpanded && 'max-h-32 overflow-y-auto',
+            )}>
+              {description}
+              {!descExpanded && showDescToggle && (
+                <div className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-linear-to-b from-components-panel-bg-transparent to-components-panel-bg" />
+              )}
+            </div>
+            {showDescToggle && (
+              <button
+                type="button"
+                className="mt-0.5 flex items-center gap-0.5 system-xs-regular text-text-accent hover:opacity-80"
+                onClick={() => setDescExpanded(v => !v)}
+              >
+                {descExpanded
+                  ? <><RiArrowUpSLine className="size-3" />{t('chat.collapse', { ns: 'share' })}</>
+                  : <><RiArrowDownSLine className="size-3" />{t('chat.expand', { ns: 'share' })}</>
+                }
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    )
+  }, [description, isMobile, currentConversationId, hasSent, descExpanded, showDescToggle, t])
 
   const chatNode = useMemo(() => {
     if (allInputsHidden || !inputsForms.length)
@@ -317,11 +367,12 @@ const ChatWrapper = () => {
       onStopResponding={handleStop}
       onHumanInputFormSubmit={handleSubmitHumanInputForm}
       chatNode={(
-        <>
-          {chatNode}
-          {welcome}
-        </>
-      )}
+          <>
+            {descriptionNode}
+            {chatNode}
+            {welcome}
+          </>
+        )}
       allToolIcons={appMeta?.tool_icons || {}}
       disableFeedback={disableFeedback}
       onFeedback={handleFeedback}

--- a/web/app/components/base/chat/embedded-chatbot/chat-wrapper.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/chat-wrapper.tsx
@@ -235,7 +235,10 @@ const ChatWrapper = () => {
   const [descExpanded, setDescExpanded] = useState(false)
 
   const description = appData?.site.description
-  const showDescToggle = !!description && (description.includes('\n') || description.length > 100)
+  const [showDescToggle, setShowDescToggle] = useState(false)
+  const handleDescRef = useCallback((node: HTMLDivElement | null) => {
+    setShowDescToggle(!!node && node.scrollHeight > node.clientHeight)
+  }, [])
 
   const descriptionNode = useMemo(() => {
     if (!description || currentConversationId || hasSent)
@@ -244,11 +247,13 @@ const ChatWrapper = () => {
       <div className={cn('flex flex-col items-center px-4 pt-6', isMobile && 'pt-4')}>
         <div className="w-full max-w-[672px] rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-md">
           <div className={cn('p-6', isMobile && 'p-4')}>
-            <div className={cn(
-              'relative system-xs-regular break-words whitespace-pre-wrap text-text-tertiary',
-              !descExpanded && 'line-clamp-2',
-              descExpanded && 'max-h-32 overflow-y-auto',
-            )}
+            <div
+              ref={handleDescRef}
+              className={cn(
+                'relative system-xs-regular break-words whitespace-pre-wrap text-text-tertiary',
+                !descExpanded && 'line-clamp-3',
+                descExpanded && 'max-h-32 overflow-y-auto',
+              )}
             >
               {description}
               {!descExpanded && showDescToggle && (

--- a/web/app/components/base/chat/embedded-chatbot/chat-wrapper.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/chat-wrapper.tsx
@@ -180,6 +180,14 @@ const ChatWrapper = () => {
     }
   }, [])
 
+  const [hasSent, setHasSent] = useState(false)
+  const [prevConversationId, setPrevConversationId] = useState(currentConversationId)
+  if (prevConversationId !== currentConversationId) {
+    setPrevConversationId(currentConversationId)
+    if (!currentConversationId)
+      setHasSent(false)
+  }
+
   const doSend: OnSend = useCallback((message, files, isRegenerate = false, parentAnswer: ChatItem | null = null) => {
     if (!currentConversationId)
       setHasSent(true)
@@ -225,12 +233,6 @@ const ChatWrapper = () => {
   const isTryApp = appSourceType === AppSourceType.tryApp
   const [collapsed, setCollapsed] = useState(!!currentConversationId && !isTryApp) // try app always use the new chat
   const [descExpanded, setDescExpanded] = useState(false)
-  const [hasSent, setHasSent] = useState(false)
-
-  useEffect(() => {
-    if (!currentConversationId)
-      setHasSent(false)
-  }, [currentConversationId])
 
   const description = appData?.site.description
   const showDescToggle = !!description && (description.includes('\n') || description.length > 100)
@@ -243,10 +245,11 @@ const ChatWrapper = () => {
         <div className="w-full max-w-[672px] rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-md">
           <div className={cn('p-6', isMobile && 'p-4')}>
             <div className={cn(
-              'relative system-xs-regular text-text-tertiary whitespace-pre-wrap break-words',
+              'relative system-xs-regular break-words whitespace-pre-wrap text-text-tertiary',
               !descExpanded && 'line-clamp-2',
               descExpanded && 'max-h-32 overflow-y-auto',
-            )}>
+            )}
+            >
               {description}
               {!descExpanded && showDescToggle && (
                 <div className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-linear-to-b from-components-panel-bg-transparent to-components-panel-bg" />
@@ -259,9 +262,18 @@ const ChatWrapper = () => {
                 onClick={() => setDescExpanded(v => !v)}
               >
                 {descExpanded
-                  ? <><RiArrowUpSLine className="size-3" />{t('chat.collapse', { ns: 'share' })}</>
-                  : <><RiArrowDownSLine className="size-3" />{t('chat.expand', { ns: 'share' })}</>
-                }
+                  ? (
+                      <>
+                        <RiArrowUpSLine className="size-3" />
+                        {t('chat.collapse', { ns: 'share' })}
+                      </>
+                    )
+                  : (
+                      <>
+                        <RiArrowDownSLine className="size-3" />
+                        {t('chat.expand', { ns: 'share' })}
+                      </>
+                    )}
               </button>
             )}
           </div>
@@ -367,12 +379,12 @@ const ChatWrapper = () => {
       onStopResponding={handleStop}
       onHumanInputFormSubmit={handleSubmitHumanInputForm}
       chatNode={(
-          <>
-            {descriptionNode}
-            {chatNode}
-            {welcome}
-          </>
-        )}
+        <>
+          {descriptionNode}
+          {chatNode}
+          {welcome}
+        </>
+      )}
       allToolIcons={appMeta?.tool_icons || {}}
       disableFeedback={disableFeedback}
       onFeedback={handleFeedback}

--- a/web/app/components/base/chat/embedded-chatbot/chat-wrapper.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/chat-wrapper.tsx
@@ -9,7 +9,7 @@ import type {
 import { Avatar } from '@langgenius/dify-ui/avatar'
 import { cn } from '@langgenius/dify-ui/cn'
 import { RiArrowDownSLine, RiArrowUpSLine } from '@remixicon/react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import AnswerIcon from '@/app/components/base/answer-icon'
 import AppIcon from '@/app/components/base/app-icon'
@@ -236,9 +236,24 @@ const ChatWrapper = () => {
 
   const description = appData?.site.description
   const [showDescToggle, setShowDescToggle] = useState(false)
-  const handleDescRef = useCallback((node: HTMLDivElement | null) => {
-    setShowDescToggle(!!node && node.scrollHeight > node.clientHeight)
-  }, [])
+  const descRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const el = descRef.current
+    if (!el)
+      return
+    if (el.offsetWidth > 0) {
+      setShowDescToggle(el.scrollHeight > el.clientHeight)
+      return
+    }
+    const observer = new ResizeObserver((entries) => {
+      if (!entries[0] || entries[0].contentRect.width === 0)
+        return
+      setShowDescToggle(el.scrollHeight > el.clientHeight)
+      observer.disconnect()
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [description])
 
   const descriptionNode = useMemo(() => {
     if (!description || currentConversationId || hasSent)
@@ -248,7 +263,7 @@ const ChatWrapper = () => {
         <div className="w-full max-w-[672px] rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-md">
           <div className={cn('p-6', isMobile && 'p-4')}>
             <div
-              ref={handleDescRef}
+              ref={descRef}
               className={cn(
                 'relative system-xs-regular break-words whitespace-pre-wrap text-text-tertiary',
                 !descExpanded && 'line-clamp-3',

--- a/web/app/components/explore/installed-app/index.tsx
+++ b/web/app/components/explore/installed-app/index.tsx
@@ -55,6 +55,7 @@ const InstalledApp = ({
         app_id: id,
         site: {
           title: app.name,
+          description: app.description,
           icon_type: app.icon_type,
           icon: app.icon,
           icon_background: app.icon_background,

--- a/web/app/components/explore/try-app/app/text-generation.tsx
+++ b/web/app/components/explore/try-app/app/text-generation.tsx
@@ -40,6 +40,10 @@ const TextGeneration: FC<Props> = ({
 }) => {
   const { t } = useTranslation()
   const [descExpanded, setDescExpanded] = useState(false)
+  const [showDescToggle, setShowDescToggle] = useState(false)
+  const handleDescRef = useCallback((node: HTMLDivElement | null) => {
+    setShowDescToggle(!!node && node.scrollHeight > node.clientHeight)
+  }, [])
   const media = useBreakpoints()
   const isPC = media === MediaType.pc
 
@@ -184,8 +188,6 @@ const TextGeneration: FC<Props> = ({
     )
   }
 
-  const showDescToggle = !!siteInfo.description && (siteInfo.description.includes('\n') || siteInfo.description.length > 100)
-
   return (
     <div className={cn(
       'rounded-2xl border border-components-panel-border bg-background-section-burn',
@@ -216,11 +218,13 @@ const TextGeneration: FC<Props> = ({
           </div>
           {siteInfo.description && (
             <div>
-              <div className={cn(
-                'relative system-xs-regular break-words whitespace-pre-wrap text-text-tertiary',
-                !descExpanded && 'line-clamp-2',
-                descExpanded && 'max-h-32 overflow-y-auto',
-              )}
+              <div
+                ref={handleDescRef}
+                className={cn(
+                  'relative system-xs-regular break-words whitespace-pre-wrap text-text-tertiary',
+                  !descExpanded && 'line-clamp-3',
+                  descExpanded && 'max-h-32 overflow-y-auto',
+                )}
               >
                 {siteInfo.description}
                 {!descExpanded && showDescToggle && (

--- a/web/app/components/explore/try-app/app/text-generation.tsx
+++ b/web/app/components/explore/try-app/app/text-generation.tsx
@@ -5,6 +5,7 @@ import type { MoreLikeThisConfig, PromptConfig, TextToSpeechConfig } from '@/mod
 import type { AppData, CustomConfigValueType, SiteInfo } from '@/models/share'
 import type { VisionFile, VisionSettings } from '@/types/app'
 import { cn } from '@langgenius/dify-ui/cn'
+import { RiArrowDownSLine, RiArrowUpSLine } from '@remixicon/react'
 import { useBoolean } from 'ahooks'
 import { noop } from 'es-toolkit/function'
 import * as React from 'react'
@@ -38,6 +39,7 @@ const TextGeneration: FC<Props> = ({
   appData,
 }) => {
   const { t } = useTranslation()
+  const [descExpanded, setDescExpanded] = useState(false)
   const media = useBreakpoints()
   const isPC = media === MediaType.pc
 
@@ -210,9 +212,35 @@ const TextGeneration: FC<Props> = ({
             />
             <div className="grow truncate system-md-semibold text-text-secondary">{siteInfo.title}</div>
           </div>
-          {siteInfo.description && (
-            <div className="system-xs-regular text-text-tertiary">{siteInfo.description}</div>
-          )}
+          {siteInfo.description && (() => {
+            const showDescToggle = siteInfo.description.includes('\n') || siteInfo.description.length > 100
+            return (
+              <div>
+                <div className={cn(
+                  'relative system-xs-regular text-text-tertiary whitespace-pre-wrap break-words',
+                  !descExpanded && 'line-clamp-2',
+                  descExpanded && 'max-h-32 overflow-y-auto',
+                )}>
+                  {siteInfo.description}
+                  {!descExpanded && showDescToggle && (
+                    <div className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-linear-to-b from-components-panel-bg-transparent to-components-panel-bg" />
+                  )}
+                </div>
+                {showDescToggle && (
+                  <button
+                    type="button"
+                    className="mt-0.5 flex items-center gap-0.5 system-xs-regular text-text-accent hover:opacity-80"
+                    onClick={() => setDescExpanded(v => !v)}
+                  >
+                    {descExpanded
+                      ? <><RiArrowUpSLine className="size-3" />{t('chat.collapse', { ns: 'share' })}</>
+                      : <><RiArrowDownSLine className="size-3" />{t('chat.expand', { ns: 'share' })}</>
+                    }
+                  </button>
+                )}
+              </div>
+            )
+          })()}
         </div>
         {/* form */}
         <div className={cn(

--- a/web/app/components/explore/try-app/app/text-generation.tsx
+++ b/web/app/components/explore/try-app/app/text-generation.tsx
@@ -184,6 +184,8 @@ const TextGeneration: FC<Props> = ({
     )
   }
 
+  const showDescToggle = !!siteInfo.description && (siteInfo.description.includes('\n') || siteInfo.description.length > 100)
+
   return (
     <div className={cn(
       'rounded-2xl border border-components-panel-border bg-background-section-burn',
@@ -212,35 +214,42 @@ const TextGeneration: FC<Props> = ({
             />
             <div className="grow truncate system-md-semibold text-text-secondary">{siteInfo.title}</div>
           </div>
-          {siteInfo.description && (() => {
-            const showDescToggle = siteInfo.description.includes('\n') || siteInfo.description.length > 100
-            return (
-              <div>
-                <div className={cn(
-                  'relative system-xs-regular text-text-tertiary whitespace-pre-wrap break-words',
-                  !descExpanded && 'line-clamp-2',
-                  descExpanded && 'max-h-32 overflow-y-auto',
-                )}>
-                  {siteInfo.description}
-                  {!descExpanded && showDescToggle && (
-                    <div className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-linear-to-b from-components-panel-bg-transparent to-components-panel-bg" />
-                  )}
-                </div>
-                {showDescToggle && (
-                  <button
-                    type="button"
-                    className="mt-0.5 flex items-center gap-0.5 system-xs-regular text-text-accent hover:opacity-80"
-                    onClick={() => setDescExpanded(v => !v)}
-                  >
-                    {descExpanded
-                      ? <><RiArrowUpSLine className="size-3" />{t('chat.collapse', { ns: 'share' })}</>
-                      : <><RiArrowDownSLine className="size-3" />{t('chat.expand', { ns: 'share' })}</>
-                    }
-                  </button>
+          {siteInfo.description && (
+            <div>
+              <div className={cn(
+                'relative system-xs-regular break-words whitespace-pre-wrap text-text-tertiary',
+                !descExpanded && 'line-clamp-2',
+                descExpanded && 'max-h-32 overflow-y-auto',
+              )}
+              >
+                {siteInfo.description}
+                {!descExpanded && showDescToggle && (
+                  <div className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-linear-to-b from-components-panel-bg-transparent to-components-panel-bg" />
                 )}
               </div>
-            )
-          })()}
+              {showDescToggle && (
+                <button
+                  type="button"
+                  className="mt-0.5 flex items-center gap-0.5 system-xs-regular text-text-accent hover:opacity-80"
+                  onClick={() => setDescExpanded(v => !v)}
+                >
+                  {descExpanded
+                    ? (
+                        <>
+                          <RiArrowUpSLine className="size-3" />
+                          {t('chat.collapse', { ns: 'share' })}
+                        </>
+                      )
+                    : (
+                        <>
+                          <RiArrowDownSLine className="size-3" />
+                          {t('chat.expand', { ns: 'share' })}
+                        </>
+                      )}
+                </button>
+              )}
+            </div>
+          )}
         </div>
         {/* form */}
         <div className={cn(

--- a/web/app/components/share/text-generation/text-generation-sidebar.tsx
+++ b/web/app/components/share/text-generation/text-generation-sidebar.tsx
@@ -7,7 +7,7 @@ import type { VisionFile, VisionSettings } from '@/types/app'
 import { cn } from '@langgenius/dify-ui/cn'
 import { Tabs, TabsList, TabsPanel, TabsTab } from '@langgenius/dify-ui/tabs'
 import { RiArrowDownSLine, RiArrowUpSLine } from '@remixicon/react'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import SavedItems from '@/app/components/app/text-generate/saved-items'
 import AppIcon from '@/app/components/base/app-icon'
@@ -72,7 +72,10 @@ const TextGenerationSidebar: FC<TextGenerationSidebarProps> = ({
 }) => {
   const { t } = useTranslation()
   const [descExpanded, setDescExpanded] = useState(false)
-  const showDescToggle = !!siteInfo.description && (siteInfo.description.includes('\n') || siteInfo.description.length > 100)
+  const [showDescToggle, setShowDescToggle] = useState(false)
+  const handleDescRef = useCallback((node: HTMLDivElement | null) => {
+    setShowDescToggle(!!node && node.scrollHeight > node.clientHeight)
+  }, [])
 
   return (
     <Tabs
@@ -98,11 +101,13 @@ const TextGenerationSidebar: FC<TextGenerationSidebarProps> = ({
         </div>
         {siteInfo.description && (
           <div>
-            <div className={cn(
-              'relative system-xs-regular break-words whitespace-pre-wrap text-text-tertiary',
-              !descExpanded && 'line-clamp-2',
-              descExpanded && 'max-h-32 overflow-y-auto',
-            )}
+            <div
+              ref={handleDescRef}
+              className={cn(
+                'relative system-xs-regular break-words whitespace-pre-wrap text-text-tertiary',
+                !descExpanded && 'line-clamp-3',
+                descExpanded && 'max-h-32 overflow-y-auto',
+              )}
             >
               {siteInfo.description}
               {!descExpanded && showDescToggle && (

--- a/web/app/components/share/text-generation/text-generation-sidebar.tsx
+++ b/web/app/components/share/text-generation/text-generation-sidebar.tsx
@@ -1,6 +1,5 @@
 import type { GetSystemFeaturesResponse } from '@dify/contracts/api/console/system-features/types.gen'
 import type { FC, RefObject } from 'react'
-import { useState } from 'react'
 import type { InputValueTypes, TextGenerationCustomConfig, TextGenerationRunControl } from './types'
 import type { PromptConfig, SavedMessage, TextToSpeechConfig } from '@/models/debug'
 import type { SiteInfo } from '@/models/share'
@@ -8,6 +7,7 @@ import type { VisionFile, VisionSettings } from '@/types/app'
 import { cn } from '@langgenius/dify-ui/cn'
 import { Tabs, TabsList, TabsPanel, TabsTab } from '@langgenius/dify-ui/tabs'
 import { RiArrowDownSLine, RiArrowUpSLine } from '@remixicon/react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import SavedItems from '@/app/components/app/text-generate/saved-items'
 import AppIcon from '@/app/components/base/app-icon'
@@ -99,10 +99,11 @@ const TextGenerationSidebar: FC<TextGenerationSidebarProps> = ({
         {siteInfo.description && (
           <div>
             <div className={cn(
-              'relative system-xs-regular text-text-tertiary whitespace-pre-wrap break-words',
+              'relative system-xs-regular break-words whitespace-pre-wrap text-text-tertiary',
               !descExpanded && 'line-clamp-2',
               descExpanded && 'max-h-32 overflow-y-auto',
-            )}>
+            )}
+            >
               {siteInfo.description}
               {!descExpanded && showDescToggle && (
                 <div className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-linear-to-b from-components-panel-bg-transparent to-components-panel-bg" />
@@ -115,9 +116,18 @@ const TextGenerationSidebar: FC<TextGenerationSidebarProps> = ({
                 onClick={() => setDescExpanded(v => !v)}
               >
                 {descExpanded
-                  ? <><RiArrowUpSLine className="size-3" />{t('chat.collapse', { ns: 'share' })}</>
-                  : <><RiArrowDownSLine className="size-3" />{t('chat.expand', { ns: 'share' })}</>
-                }
+                  ? (
+                      <>
+                        <RiArrowUpSLine className="size-3" />
+                        {t('chat.collapse', { ns: 'share' })}
+                      </>
+                    )
+                  : (
+                      <>
+                        <RiArrowDownSLine className="size-3" />
+                        {t('chat.expand', { ns: 'share' })}
+                      </>
+                    )}
               </button>
             )}
           </div>

--- a/web/app/components/share/text-generation/text-generation-sidebar.tsx
+++ b/web/app/components/share/text-generation/text-generation-sidebar.tsx
@@ -1,11 +1,13 @@
 import type { GetSystemFeaturesResponse } from '@dify/contracts/api/console/system-features/types.gen'
 import type { FC, RefObject } from 'react'
+import { useState } from 'react'
 import type { InputValueTypes, TextGenerationCustomConfig, TextGenerationRunControl } from './types'
 import type { PromptConfig, SavedMessage, TextToSpeechConfig } from '@/models/debug'
 import type { SiteInfo } from '@/models/share'
 import type { VisionFile, VisionSettings } from '@/types/app'
 import { cn } from '@langgenius/dify-ui/cn'
 import { Tabs, TabsList, TabsPanel, TabsTab } from '@langgenius/dify-ui/tabs'
+import { RiArrowDownSLine, RiArrowUpSLine } from '@remixicon/react'
 import { useTranslation } from 'react-i18next'
 import SavedItems from '@/app/components/app/text-generate/saved-items'
 import AppIcon from '@/app/components/base/app-icon'
@@ -69,6 +71,8 @@ const TextGenerationSidebar: FC<TextGenerationSidebarProps> = ({
   visionConfig,
 }) => {
   const { t } = useTranslation()
+  const [descExpanded, setDescExpanded] = useState(false)
+  const showDescToggle = !!siteInfo.description && (siteInfo.description.includes('\n') || siteInfo.description.length > 100)
 
   return (
     <Tabs
@@ -93,7 +97,30 @@ const TextGenerationSidebar: FC<TextGenerationSidebarProps> = ({
           <MenuDropdown hideLogout={isInstalledApp || accessMode === AccessMode.PUBLIC} data={siteInfo} />
         </div>
         {siteInfo.description && (
-          <div className="system-xs-regular text-text-tertiary">{siteInfo.description}</div>
+          <div>
+            <div className={cn(
+              'relative system-xs-regular text-text-tertiary whitespace-pre-wrap break-words',
+              !descExpanded && 'line-clamp-2',
+              descExpanded && 'max-h-32 overflow-y-auto',
+            )}>
+              {siteInfo.description}
+              {!descExpanded && showDescToggle && (
+                <div className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-linear-to-b from-components-panel-bg-transparent to-components-panel-bg" />
+              )}
+            </div>
+            {showDescToggle && (
+              <button
+                type="button"
+                className="mt-0.5 flex items-center gap-0.5 system-xs-regular text-text-accent hover:opacity-80"
+                onClick={() => setDescExpanded(v => !v)}
+              >
+                {descExpanded
+                  ? <><RiArrowUpSLine className="size-3" />{t('chat.collapse', { ns: 'share' })}</>
+                  : <><RiArrowDownSLine className="size-3" />{t('chat.expand', { ns: 'share' })}</>
+                }
+              </button>
+            )}
+          </div>
         )}
         <TabsList className="w-full">
           <TabsTab value="create">


### PR DESCRIPTION
## Summary

This PR surfaces the description field across all app execution views, with a collapsible/expandable behavior to avoid pushing the input form off screen.

Changes:

- **Text-generation apps**
  - Web App: The existing description field is now collapsible. It defaults to 2 lines with a fade overlay; clicking Expand shows the full text in a height-capped, scrollable area.
  - Installed App (Explore): Same collapsible description field added. Note: this shows the App Description (not the Web App Description), sourced from the installed app metadata.
- **Chat apps**
  - Web App: A description card is shown on the new-conversation screen, styled to match the "New chat setup" input form panel. It disappears the moment the user sends their first message and reappears when a new conversation is started.
  - Installed App (Explore): Same behavior as Web App.
  - Embedded App: Same behavior as Web App.
- **API**
  - `GET /console/api/installed-apps` now includes the `description` field in the app object of each response item.

Checklist:
- [x] Text-generation - Web App - PC
- [x] Text-generation - Web App - Mobile
- [x] Text-generation - Installed App - PC
- [x] Text-generation - Installed App - Mobile
- [x] Chat - Web App - No input form - PC
- [x] Chat - Web App - No input form - Mobile
- [x] Chat - Web App - With input form - PC
- [x] Chat - Web App - With input form - Mobile
- [x] Chat - Installed App - No input form - PC
- [x] Chat - Installed App - No input form - Mobile
- [x] Chat - Installed App - With input form - PC
- [x] Chat - Installed App - With input form - Mobile
- [x] Chat - Embedded App - No input form - PC
- [x] Chat - Embedded App - No input form - Mobile
- [x] Chat - Embedded App - With input form - PC
- [x] Chat - Embedded App - With input form - Mobile

Closes #37344 

## Screenshots

### Before

Chat: The app description is not shown anywhere.

<img width="1372" height="907" alt="image" src="https://github.com/user-attachments/assets/d8dd503e-5d9a-4be0-92d2-af3e1b27e2c3" />

Workflow: The app description is displayed, but line breaks are not preserved, and since there is no height limit, the layout is prone to breaking.

<img width="1708" height="905" alt="image" src="https://github.com/user-attachments/assets/f798110e-c3f8-4f00-8583-841358073359" />


### After

#### Chat

At the start of a conversation, a collapsible description field is shown in the center. Its height is limited and it is scrollable. Once the chat starts, it is hidden.

<img width="1326" height="733" alt="image" src="https://github.com/user-attachments/assets/97c45e51-2ac6-4a4a-a3b0-b96b38acfc3c" />
<img width="1328" height="735" alt="image" src="https://github.com/user-attachments/assets/e97b64e6-7598-4277-86ec-3a374f538103" />
<img width="1326" height="737" alt="image" src="https://github.com/user-attachments/assets/3316dacb-4fc5-4c2c-a3fc-23ea4c08af8e" />

If there is an input field, they are displayed side by side.

<img width="1326" height="729" alt="image" src="https://github.com/user-attachments/assets/e6ea6b97-b3a7-45ae-a51d-72afd79917f3" />

This also works with conversation openers.

<img width="1327" height="736" alt="image" src="https://github.com/user-attachments/assets/a1d94be3-5bb7-40ba-a334-50f21dd8b140" />
<img width="1327" height="737" alt="image" src="https://github.com/user-attachments/assets/376f09b9-b1bc-46be-b61e-e71fd7c06ff4" />

The same display is used in mobile browsers.

<img width="438" height="916" alt="image" src="https://github.com/user-attachments/assets/479298e2-1db3-4da0-8d1a-01cabcc195b4" />

It works in embedded apps as well.

<img width="367" height="643" alt="image" src="https://github.com/user-attachments/assets/f146141a-94cc-4f43-a477-e39fc2726273" />

#### Workflow

There is no change to the display position, but but line breaks are preserved, and the field can be expanded and scrolled.

<img width="1376" height="874" alt="image" src="https://github.com/user-attachments/assets/6197ec55-4eb1-4f7c-9505-cd2099be5bdc" />
<img width="1376" height="868" alt="image" src="https://github.com/user-attachments/assets/41267e7b-d35a-4bcc-8e8e-6417b4a3d02f" />

The same display is used in mobile browsers.

<img width="432" height="919" alt="image" src="https://github.com/user-attachments/assets/b53c2332-3e05-4886-b87a-7e263d348aa1" />

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
