### PR TITLE
feat(api): forward user_type for MCP identity forwarding (webapp end-users)

### DIFF
--- a/api/core/app/apps/base_app_queue_manager.py
+++ b/api/core/app/apps/base_app_queue_manager.py
@@ -41,7 +41,7 @@ class AppQueueManager(ABC):
         self._invoke_from = invoke_from
         self.invoke_from = invoke_from  # Public accessor for invoke_from
 
-        user_prefix = "account" if self._invoke_from in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER} else "end-user"
+        user_prefix = "account" if self._invoke_from.runs_as_account() else "end-user"
         self._task_belong_cache_key = AppQueueManager._generate_task_belong_cache_key(self._task_id)
         redis_client.setex(self._task_belong_cache_key, 1800, f"{user_prefix}-{self._user_id}")
 

--- a/api/core/app/apps/base_app_runner.py
+++ b/api/core/app/apps/base_app_runner.py
@@ -431,9 +431,7 @@ class AppRunner:
             url=f"/files/tools/{tool_file.id}",
             upload_file_id=tool_file.id,
             created_by_role=(
-                CreatorUserRole.ACCOUNT
-                if queue_manager.invoke_from in {InvokeFrom.DEBUGGER, InvokeFrom.EXPLORE}
-                else CreatorUserRole.END_USER
+                CreatorUserRole.ACCOUNT if queue_manager.invoke_from.runs_as_account() else CreatorUserRole.END_USER
             ),
             created_by=user_id,
         )

--- a/api/core/app/apps/workflow_app_runner.py
+++ b/api/core/app/apps/workflow_app_runner.py
@@ -104,7 +104,7 @@ class WorkflowBasedAppRunner:
 
     @staticmethod
     def _resolve_user_from(invoke_from: InvokeFrom) -> UserFrom:
-        if invoke_from in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER}:
+        if invoke_from.runs_as_account():
             return UserFrom.ACCOUNT
         return UserFrom.END_USER
 

--- a/api/core/app/entities/app_invoke_entities.py
+++ b/api/core/app/entities/app_invoke_entities.py
@@ -47,6 +47,14 @@ class InvokeFrom(StrEnum):
         }
         return source_mapping.get(self, "dev")
 
+    def runs_as_account(self) -> bool:
+        """Whether a run from this entry point is attributed to a workspace
+        Account rather than an end user. Console contexts (debugger/explore)
+        run as the signed-in Account; webapp/service-api/trigger run as an
+        EndUser. Single source of truth for the created-by-role / user-type
+        split shared by the app runners and MCP identity forwarding."""
+        return self in (InvokeFrom.DEBUGGER, InvokeFrom.EXPLORE)
+
 
 class DifyRunContext(BaseModel):
     tenant_id: str

--- a/api/core/tools/mcp_tool/tool.py
+++ b/api/core/tools/mcp_tool/tool.py
@@ -7,6 +7,7 @@ from collections.abc import Generator, Mapping
 from typing import Any, cast, override
 
 from configs import dify_config
+from core.app.entities.app_invoke_entities import InvokeFrom
 from core.entities.mcp_provider import IdentityMode
 from core.mcp.auth_client import MCPClientWithAuthRetry
 from core.mcp.error import MCPConnectionError
@@ -31,6 +32,11 @@ logger = logging.getLogger(__name__)
 # stomping on the workspace-scoped Authorization header (provider OAuth /
 # user-supplied custom credentials), which would silently break those flows.
 FORWARDED_IDENTITY_HEADER = "X-Dify-SSO-Token"
+
+# invoke_from values where the caller is a console Account rather than a webapp/
+# API end-user. Mirrors core/app/apps/base_app_runner.py and
+# workflow_app_runner._resolve_user_from.
+_ACCOUNT_INVOKE_FROMS = frozenset({InvokeFrom.DEBUGGER, InvokeFrom.EXPLORE})
 
 
 class MCPTool(Tool):
@@ -358,7 +364,16 @@ class MCPTool(Tool):
                 tenant_id=self.tenant_id,
                 app_id=app_id,
                 audience=audience,
+                user_type=self._resolve_user_type(),
             )
         except MCPTokenError as e:
             raise ToolInvokeError(f"Failed to obtain forwarded identity token: {e}") from e
         headers[FORWARDED_IDENTITY_HEADER] = token
+
+    def _resolve_user_type(self) -> str:
+        """Return "account" for console-authenticated callers (debugger/explore),
+        "end_user" for webapp / service-api / trigger callers — so the enterprise
+        side routes to the console store vs the published-webapp store."""
+        if self.runtime.invoke_from in _ACCOUNT_INVOKE_FROMS:
+            return "account"
+        return "end_user"

--- a/api/core/tools/mcp_tool/tool.py
+++ b/api/core/tools/mcp_tool/tool.py
@@ -7,7 +7,6 @@ from collections.abc import Generator, Mapping
 from typing import Any, cast, override
 
 from configs import dify_config
-from core.app.entities.app_invoke_entities import InvokeFrom
 from core.entities.mcp_provider import IdentityMode
 from core.mcp.auth_client import MCPClientWithAuthRetry
 from core.mcp.error import MCPConnectionError
@@ -32,11 +31,6 @@ logger = logging.getLogger(__name__)
 # stomping on the workspace-scoped Authorization header (provider OAuth /
 # user-supplied custom credentials), which would silently break those flows.
 FORWARDED_IDENTITY_HEADER = "X-Dify-SSO-Token"
-
-# invoke_from values where the caller is a console Account rather than a webapp/
-# API end-user. Mirrors core/app/apps/base_app_runner.py and
-# workflow_app_runner._resolve_user_from.
-_ACCOUNT_INVOKE_FROMS = frozenset({InvokeFrom.DEBUGGER, InvokeFrom.EXPLORE})
 
 
 class MCPTool(Tool):
@@ -374,6 +368,7 @@ class MCPTool(Tool):
         """Return "account" for console-authenticated callers (debugger/explore),
         "end_user" for webapp / service-api / trigger callers — so the enterprise
         side routes to the console store vs the published-webapp store."""
-        if self.runtime.invoke_from in _ACCOUNT_INVOKE_FROMS:
+        invoke_from = self.runtime.invoke_from
+        if invoke_from is not None and invoke_from.runs_as_account():
             return "account"
         return "end_user"

--- a/api/services/enterprise/enterprise_service.py
+++ b/api/services/enterprise/enterprise_service.py
@@ -136,6 +136,7 @@ class EnterpriseService:
         tenant_id: str,
         app_id: str | None,
         audience: str,
+        user_type: str = "account",
     ) -> tuple[str, int]:
         """Mint a short-lived SSO id_token (or OAuth2 access_token) representing
         the calling Dify user, audience-scoped to the given MCP server identifier.
@@ -163,6 +164,7 @@ class EnterpriseService:
                     "tenant_id": tenant_id,
                     "app_id": app_id or "",
                     "audience": audience,
+                    "user_type": user_type,
                 },
             )
         except EnterpriseServiceError as e:

--- a/api/tests/unit_tests/core/app/test_invoke_from.py
+++ b/api/tests/unit_tests/core/app/test_invoke_from.py
@@ -7,3 +7,19 @@ def test_openapi_variant_present():
 
 def test_openapi_distinct_from_service_api():
     assert InvokeFrom.OPENAPI != InvokeFrom.SERVICE_API
+
+
+def test_runs_as_account_only_for_console_contexts():
+    # Console contexts (studio debugger / explore) run as the signed-in Account.
+    assert InvokeFrom.DEBUGGER.runs_as_account() is True
+    assert InvokeFrom.EXPLORE.runs_as_account() is True
+    # Everything else is attributed to an end user.
+    for invoke_from in (
+        InvokeFrom.WEB_APP,
+        InvokeFrom.SERVICE_API,
+        InvokeFrom.OPENAPI,
+        InvokeFrom.TRIGGER,
+        InvokeFrom.PUBLISHED_PIPELINE,
+        InvokeFrom.VALIDATION,
+    ):
+        assert invoke_from.runs_as_account() is False

--- a/api/tests/unit_tests/core/tools/test_mcp_tool.py
+++ b/api/tests/unit_tests/core/tools/test_mcp_tool.py
@@ -230,7 +230,9 @@ def test_inject_forwarded_identity_sends_end_user_type_for_webapp():
         "services.enterprise.enterprise_service.EnterpriseService.issue_mcp_token",
         return_value=("forwarded.jwt", 1900000000),
     ) as issue:
-        tool._inject_forwarded_identity(headers, user_id="eu-1", app_id="app-1", audience="https://mcp.example.com/mcp/")
+        tool._inject_forwarded_identity(
+            headers, user_id="eu-1", app_id="app-1", audience="https://mcp.example.com/mcp/"
+        )
 
     assert issue.call_args.kwargs["user_type"] == "end_user"
 

--- a/api/tests/unit_tests/core/tools/test_mcp_tool.py
+++ b/api/tests/unit_tests/core/tools/test_mcp_tool.py
@@ -219,6 +219,36 @@ def test_inject_forwarded_identity_translates_token_error_to_invoke_error():
     assert "Authorization" not in headers
 
 
+def test_inject_forwarded_identity_sends_end_user_type_for_webapp():
+    """A WEB_APP run forwards user_type=end_user so enterprise routes to the
+    published-webapp token store."""
+    tool = _build_forwarding_tool()
+    tool.runtime = ToolRuntime(tenant_id="tenant-1", invoke_from=InvokeFrom.WEB_APP)
+    headers: dict[str, str] = {}
+
+    with patch(
+        "services.enterprise.enterprise_service.EnterpriseService.issue_mcp_token",
+        return_value=("forwarded.jwt", 1900000000),
+    ) as issue:
+        tool._inject_forwarded_identity(headers, user_id="eu-1", app_id="app-1", audience="https://mcp.example.com/mcp/")
+
+    assert issue.call_args.kwargs["user_type"] == "end_user"
+
+
+def test_inject_forwarded_identity_sends_account_type_for_debugger():
+    """A DEBUGGER/console run forwards user_type=account (the existing behaviour)."""
+    tool = _build_forwarding_tool()  # built with InvokeFrom.DEBUGGER
+    headers: dict[str, str] = {}
+
+    with patch(
+        "services.enterprise.enterprise_service.EnterpriseService.issue_mcp_token",
+        return_value=("forwarded.jwt", 1900000000),
+    ) as issue:
+        tool._inject_forwarded_identity(headers, user_id="acc-1", app_id=None, audience="https://mcp.example.com/mcp/")
+
+    assert issue.call_args.kwargs["user_type"] == "account"
+
+
 def test_invoke_remote_mcp_tool_fails_closed_when_user_id_missing():
     """When forwarding is enabled AND the deployment is enterprise, missing
     user_id must raise — never silently invoke as the static identity."""

--- a/api/tests/unit_tests/services/enterprise/test_enterprise_service.py
+++ b/api/tests/unit_tests/services/enterprise/test_enterprise_service.py
@@ -500,8 +500,23 @@ class TestIssueMCPToken:
                 "tenant_id": "tenant-uuid",
                 "app_id": "app-uuid",
                 "audience": "https://mcp.example.com/mcp/",
+                "user_type": "account",
             },
         )
+
+    def test_end_user_type_is_forwarded(self):
+        with patch(f"{MODULE}.EnterpriseRequest") as req:
+            req.send_request.return_value = {"token": "t", "expires_at": 1900000000}
+            EnterpriseService.issue_mcp_token(
+                user_id="end-user-uuid",
+                tenant_id="tenant-uuid",
+                app_id="app-uuid",
+                audience="https://mcp.example.com/mcp/",
+                user_type="end_user",
+            )
+        body = req.send_request.call_args.kwargs["json"]
+        assert body["user_type"] == "end_user"
+        assert body["app_id"] == "app-uuid"
 
     def test_401_maps_to_identity_refresh_error(self):
         from services.enterprise.base import MCPIdentityRefreshError


### PR DESCRIPTION
## Summary
Adds a **`user_type`** field to `EnterpriseService.issue_mcp_token` so the enterprise side can route MCP identity-forwarding to the right token store:

- `user_type` is derived from `invoke_from` using the codebase's existing rule — `{DEBUGGER, EXPLORE}` → `"account"` (console), everything else (`WEB_APP`/`SERVICE_API`/…) → `"end_user"` — mirroring `core/app/apps/base_app_runner.py`.
- Defaults to `"account"`, so existing console forwarding is unchanged.

This is the dify-api half of **MCP identity forwarding for published-webapp users**. The enterprise side consumes `user_type` to forward a webapp end-user's identity (`EndUser.id` + `app_id`) instead of only console Account users.

## Companion PR
Enterprise side: **langgenius/dify-enterprise#597** (webapp token store, `IssueForWebappUser`, `/mcp/issue-token` routing).

## Test plan
- [x] `pytest api/tests/unit_tests/core/tools/test_mcp_tool.py api/tests/unit_tests/services/enterprise/test_enterprise_service.py` — 67 pass (asserts `user_type` is sent; `WEB_APP`→`end_user`, `DEBUGGER`→`account`).
- [x] `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)