### PR TITLE
chore(web): use 'use' instead of 'useContext' (Fixes #25193)

### DIFF
--- a/web/__mocks__/base-ui-dropdown-menu.tsx
+++ b/web/__mocks__/base-ui-dropdown-menu.tsx
@@ -54,7 +54,7 @@ export const DropdownMenuTrigger = ({
   onClick,
   ...props
 }: DropdownMenuTriggerProps) => {
-  const { open, onOpenChange } = React.useContext(DropdownMenuContext)
+  const { open, onOpenChange } = React.use(DropdownMenuContext)
   const node = render ?? children
   const isNativeButton = React.isValidElement(node) && node.type === 'button'
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
@@ -97,7 +97,7 @@ export const DropdownMenuContent = ({
   alignOffset,
   ...props
 }: DropdownMenuContentProps) => {
-  const { open } = React.useContext(DropdownMenuContext)
+  const { open } = React.use(DropdownMenuContext)
   if (!open)
     return null
 

--- a/web/__mocks__/base-ui-popover.tsx
+++ b/web/__mocks__/base-ui-popover.tsx
@@ -86,7 +86,7 @@ export const PopoverTrigger = ({
   onClick,
   ...props
 }: PopoverTriggerProps) => {
-  const { open, onOpenChange } = React.useContext(PopoverContext)
+  const { open, onOpenChange } = React.use(PopoverContext)
   const node = render ?? children
 
   if (React.isValidElement(node)) {
@@ -139,7 +139,7 @@ export const PopoverContent = ({
   popupProps,
   ...props
 }: PopoverContentProps) => {
-  const { open } = React.useContext(PopoverContext)
+  const { open } = React.use(PopoverContext)
 
   if (!open)
     return null

--- a/web/__mocks__/base-ui-select.tsx
+++ b/web/__mocks__/base-ui-select.tsx
@@ -49,7 +49,7 @@ export const SelectItem = ({
   onClick,
   ...props
 }: React.HTMLAttributes<HTMLDivElement> & { children?: ReactNode, value?: unknown }) => {
-  const select = React.useContext(SelectContext)
+  const select = React.use(SelectContext)
   return (
     <div
       role="option"

--- a/web/__mocks__/base-ui-tooltip.tsx
+++ b/web/__mocks__/base-ui-tooltip.tsx
@@ -33,7 +33,7 @@ export const TooltipTrigger = ({
   nativeButton: _nativeButton,
   ...props
 }: React.HTMLAttributes<HTMLElement> & { children?: ReactNode, render?: React.ReactElement, nativeButton?: boolean }) => {
-  const { open, onOpenChange } = React.useContext(TooltipContext)
+  const { open, onOpenChange } = React.use(TooltipContext)
   const node = render ?? children
 
   if (React.isValidElement(node)) {
@@ -86,7 +86,7 @@ export const TooltipContent = ({
   children,
   ...props
 }: React.HTMLAttributes<HTMLDivElement> & { children?: ReactNode }) => {
-  const { open } = React.useContext(TooltipContext)
+  const { open } = React.use(TooltipContext)
   if (!open)
     return null
   return <div {...props}>{children}</div>

--- a/web/__tests__/datasets/hit-testing-flow.test.tsx
+++ b/web/__tests__/datasets/hit-testing-flow.test.tsx
@@ -25,7 +25,7 @@ vi.mock('@/context/dataset-detail', () => ({
 }))
 
 vi.mock('use-context-selector', () => ({
-  useContext: vi.fn(() => ({})),
+  use: vi.fn(() => ({})),
   useContextSelector: vi.fn(() => false),
   createContext: vi.fn(() => ({})),
 }))

--- a/web/app/components/app/configuration/config-prompt/advanced-prompt-input.tsx
+++ b/web/app/components/app/configuration/config-prompt/advanced-prompt-input.tsx
@@ -14,7 +14,7 @@ import copy from 'copy-to-clipboard'
 import { produce } from 'immer'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { useContext } from 'use-context-selector'
+import { use } from 'use-context-selector'
 import { ADD_EXTERNAL_DATA_TOOL } from '@/app/components/app/configuration/config-var'
 import {
   Copy,
@@ -73,7 +73,7 @@ const AdvancedPromptInput: FC<Props> = ({
     dataSets,
     showSelectDataSet,
     externalDataToolsConfig,
-  } = useContext(ConfigContext)
+  } = use(ConfigContext)
   const { setShowExternalDataToolModal } = useModalContext()
   const handleOpenExternalDataToolModal = () => {
     setShowExternalDataToolModal({

--- a/web/app/components/app/configuration/config-prompt/index.tsx
+++ b/web/app/components/app/configuration/config-prompt/index.tsx
@@ -9,7 +9,7 @@ import {
 import { produce } from 'immer'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { useContext } from 'use-context-selector'
+import { use } from 'use-context-selector'
 import AdvancedMessageInput from '@/app/components/app/configuration/config-prompt/advanced-prompt-input'
 import { MAX_PROMPT_MESSAGE_LENGTH } from '@/config'
 import ConfigContext from '@/context/debug-configuration'
@@ -49,7 +49,7 @@ const Prompt: FC<IPromptProps> = ({
     modelModeType,
     dataSets,
     hasSetBlockStatus,
-  } = useContext(ConfigContext)
+  } = use(ConfigContext)
 
   const handleMessageTypeChange = (index: number, role: PromptRole) => {
     const newPrompt = produce(currentAdvancedPrompt as PromptItem[], (draft) => {

--- a/web/app/components/app/configuration/config-prompt/simple-prompt-input.tsx
+++ b/web/app/components/app/configuration/config-prompt/simple-prompt-input.tsx
@@ -11,7 +11,7 @@ import { produce } from 'immer'
 import * as React from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useContext } from 'use-context-selector'
+import { use } from 'use-context-selector'
 import { ADD_EXTERNAL_DATA_TOOL } from '@/app/components/app/configuration/config-var'
 import AutomaticBtn from '@/app/components/app/configuration/config/automatic/automatic-btn'
 import GetAutomaticResModal from '@/app/components/app/configuration/config/automatic/get-automatic-res'
@@ -71,7 +71,7 @@ const Prompt: FC<ISimplePromptInput> = ({
     hasSetBlockStatus,
     showSelectDataSet,
     externalDataToolsConfig,
-  } = useContext(ConfigContext)
+  } = use(ConfigContext)
   const { setShowExternalDataToolModal } = useModalContext()
   const handleOpenExternalDataToolModal = () => {
     setShowExternalDataToolModal({

--- a/web/app/components/app/configuration/config-var/config-modal/index.tsx
+++ b/web/app/components/app/configuration/config-var/config-modal/index.tsx
@@ -7,7 +7,7 @@ import { toast } from '@langgenius/dify-ui/toast'
 import * as React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useContext } from 'use-context-selector'
+import { use } from 'use-context-selector'
 import { useStore as useAppStore } from '@/app/components/app/store'
 import ConfigContext from '@/context/debug-configuration'
 import { AppModeEnum } from '@/types/app'
@@ -45,7 +45,7 @@ const ConfigModal: FC<IConfigModalProps> = ({
   showHiddenField,
   supportFile,
 }) => {
-  const { modelConfig } = useContext(ConfigContext)
+  const { modelConfig } = use(ConfigContext)
   const { t } = useTranslation()
   const [tempPayload, setTempPayload] = useState<InputVar>(() => normalizeSelectDefaultValue(payload || getNewVarInWorkflow('') as any))
   const { type, options, max_length } = tempPayload

--- a/web/app/components/app/configuration/config-var/index.tsx
+++ b/web/app/components/app/configuration/config-var/index.tsx
@@ -21,7 +21,7 @@ import * as React from 'react'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ReactSortable } from 'react-sortablejs'
-import { useContext } from 'use-context-selector'
+import { use } from 'use-context-selector'
 import { Infotip } from '@/app/components/base/infotip'
 import { InputVarType } from '@/app/components/workflow/types'
 import ConfigContext from '@/context/debug-configuration'
@@ -99,7 +99,7 @@ const ConfigVar: FC<IConfigVarProps> = ({ promptVariables, readonly, onPromptVar
   const {
     mode,
     dataSets,
-  } = useContext(ConfigContext)
+  } = use(ConfigContext)
   const { eventEmitter } = useEventEmitterContextContext()
 
   const hasVar = promptVariables.length > 0

--- a/web/app/components/app/configuration/config-vision/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/config-vision/__tests__/index.spec.tsx
@@ -16,7 +16,7 @@ vi.mock('use-context-selector', async (importOriginal) => {
   const actual = await importOriginal<typeof import('use-context-selector')>()
   return {
     ...actual,
-    useContext: (context: unknown) => mockUseContext(context),
+    use: (context: unknown) => mockUseContext(context),
   }
 })
 

--- a/web/app/components/app/configuration/config-vision/index.tsx
+++ b/web/app/components/app/configuration/config-vision/index.tsx
@@ -7,7 +7,7 @@ import { produce } from 'immer'
 import * as React from 'react'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useContext } from 'use-context-selector'
+import { use } from 'use-context-selector'
 // import { Resolution } from '@/types/app'
 import { useFeatures, useFeaturesStore } from '@/app/components/base/features/hooks'
 import { Vision } from '@/app/components/base/icons/src/vender/features'
@@ -21,7 +21,7 @@ import ParamConfig from './param-config'
 
 const ConfigVision: FC = () => {
   const { t } = useTranslation()
-  const { isShowVisionConfig, isAllowVideoUpload, readonly } = useContext(ConfigContext)
+  const { isShowVisionConfig, isAllowVideoUpload, readonly } = use(ConfigContext)
   const file = useFeatures(s => s.features.file)
   const featuresStore = useFeaturesStore()
 

--- a/web/app/components/app/configuration/config/__tests__/config-audio.spec.tsx
+++ b/web/app/components/app/configuration/config/__tests__/config-audio.spec.tsx
@@ -11,7 +11,7 @@ vi.mock('use-context-selector', async (importOriginal) => {
   const actual = await importOriginal<typeof import('use-context-selector')>()
   return {
     ...actual,
-    useContext: (context: unknown) => mockUseContext(context),
+    use: (context: unknown) => mockUseContext(context),
   }
 })
 

--- a/web/app/components/app/configuration/config/__tests__/config-document.spec.tsx
+++ b/web/app/components/app/configuration/config/__tests__/config-document.spec.tsx
@@ -11,7 +11,7 @@ vi.mock('use-context-selector', async (importOriginal) => {
   const actual = await importOriginal<typeof import('use-context-selector')>()
   return {
     ...actual,
-    useContext: (context: unknown) => mockUseContext(context),
+    use: (context: unknown) => mockUseContext(context),
   }
 })
 

--- a/web/app/components/app/configuration/config/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/config/__tests__/index.spec.tsx
@@ -11,7 +11,7 @@ vi.mock('use-context-selector', async (importOriginal) => {
   const actual = await importOriginal<typeof import('use-context-selector')>()
   return {
     ...actual,
-    useContext: vi.fn(),
+    use: vi.fn(),
   }
 })
 
@@ -142,7 +142,7 @@ const createContextValue = (overrides: Partial<MockContext> = {}): MockContext =
   ...overrides,
 })
 
-const mockUseContext = vi.mocked(useContextSelector.useContext)
+const mockUseContext = vi.mocked(useContextSelector.use)
 
 const renderConfig = (contextOverrides: Partial<MockContext> = {}) => {
   const contextValue = createContextValue(contextOverrides)

--- a/web/app/components/app/configuration/config/agent/agent-tools/index.tsx
+++ b/web/app/components/app/configuration/config/agent/agent-tools/index.tsx
@@ -18,7 +18,7 @@ import { produce } from 'immer'
 import * as React from 'react'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useContext } from 'use-context-selector'
+import { use } from 'use-context-selector'
 import Panel from '@/app/components/app/configuration/base/feature-panel'
 import OperationBtn from '@/app/components/app/configuration/base/operation-btn'
 import AppIcon from '@/app/components/base/app-icon'
@@ -41,7 +41,7 @@ type AgentToolWithMoreInfo = AgentTool & { icon: any, collection?: Collection } 
 const AgentTools: FC = () => {
   const { t } = useTranslation()
   const [isShowChooseTool, setIsShowChooseTool] = useState(false)
-  const { readonly, modelConfig, setModelConfig } = useContext(ConfigContext)
+  const { readonly, modelConfig, setModelConfig } = use(ConfigContext)
   const { data: buildInTools } = useAllBuiltInTools()
   const { data: customTools } = useAllCustomTools()
   const { data: workflowTools } = useAllWorkflowTools()

--- a/web/app/components/app/configuration/config/config-audio.tsx
+++ b/web/app/components/app/configuration/config/config-audio.tsx
@@ -6,7 +6,7 @@ import * as React from 'react'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { useContext } from 'use-context-selector'
+import { use } from 'use-context-selector'
 import { useFeatures, useFeaturesStore } from '@/app/components/base/features/hooks'
 import { Microphone01 } from '@/app/components/base/icons/src/vender/features'
 import { Infotip } from '@/app/components/base/infotip'
@@ -17,7 +17,7 @@ const ConfigAudio: FC = () => {
   const { t } = useTranslation()
   const file = useFeatures(s => s.features.file)
   const featuresStore = useFeaturesStore()
-  const { isShowAudioConfig, readonly } = useContext(ConfigContext)
+  const { isShowAudioConfig, readonly } = use(ConfigContext)
 
   const isAudioEnabled = file?.allowed_file_types?.includes(SupportUploadFileTypes.audio) ?? false
 

--- a/web/app/components/app/configuration/config/config-document.tsx
+++ b/web/app/components/app/configuration/config/config-document.tsx
@@ -6,7 +6,7 @@ import * as React from 'react'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { useContext } from 'use-context-selector'
+import { use } from 'use-context-selector'
 import { useFeatures, useFeaturesStore } from '@/app/components/base/features/hooks'
 import { Document } from '@/app/components/base/icons/src/vender/features'
 import { Infotip } from '@/app/components/base/infotip'
@@ -17,7 +17,7 @@ const ConfigDocument: FC = () => {
   const { t } = useTranslation()
   const file = useFeatures(s => s.features.file)
   const featuresStore = useFeaturesStore()
-  const { isShowDocumentConfig, readonly } = useContext(ConfigContext)
+  const { isShowDocumentConfig, readonly } = use(ConfigContext)
 
   const isDocumentEnabled = file?.allowed_file_types?.includes(SupportUploadFileTypes.document) ?? false
 

--- a/web/app/components/app/configuration/config/index.tsx
+++ b/web/app/components/app/configuration/config/index.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'react'
 import type { ModelConfig, PromptVariable } from '@/models/debug'
 import { produce } from 'immer'
 import * as React from 'react'
-import { useContext } from 'use-context-selector'
+import { use } from 'use-context-selector'
 import ConfigPrompt from '@/app/components/app/configuration/config-prompt'
 import ConfigVar from '@/app/components/app/configuration/config-var'
 import ConfigContext from '@/context/debug-configuration'
@@ -29,7 +29,7 @@ const Config: FC = () => {
     setModelConfig,
     setPrevPromptConfig,
     dataSets,
-  } = useContext(ConfigContext)
+  } = use(ConfigContext)
   const isChatApp = [AppModeEnum.ADVANCED_CHAT, AppModeEnum.AGENT_CHAT, AppModeEnum.CHAT].includes(mode)
   const formattingChangedDispatcher = useFormattingChangedDispatcher()
 

--- a/web/app/components/app/configuration/dataset-config/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/dataset-config/__tests__/index.spec.tsx
@@ -3,7 +3,7 @@ import type { DataSet } from '@/models/datasets'
 import type { DatasetConfigs } from '@/models/debug'
 import { fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { useContext } from 'use-context-selector'
+import { use } from 'use-context-selector'
 import { ComparisonOperator, LogicalOperator } from '@/app/components/workflow/nodes/knowledge-retrieval/types'
 import { getSelectedDatasetsMode } from '@/app/components/workflow/nodes/knowledge-retrieval/utils'
 import { DatasetPermission, DataSourceType } from '@/models/datasets'
@@ -233,7 +233,7 @@ vi.mock('@/context/debug-configuration', () => ({
 }))
 
 vi.mock('use-context-selector', () => ({
-  useContext: vi.fn(() => mockConfigContext),
+  use: vi.fn(() => mockConfigContext),
 }))
 
 const createMockDataset = (overrides: Partial<DataSet> = {}): DataSet => {
@@ -318,7 +318,7 @@ const createMockDataset = (overrides: Partial<DataSet> = {}): DataSet => {
 
 const renderDatasetConfig = (contextOverrides: Partial<typeof mockConfigContext> = {}) => {
   const mergedContext = { ...mockConfigContext, ...contextOverrides }
-  vi.mocked(useContext).mockReturnValue(mergedContext)
+  vi.mocked(use).mockReturnValue(mergedContext)
 
   return render(<DatasetConfig />)
 }
@@ -824,7 +824,7 @@ describe('DatasetConfig', () => {
     })
 
     it('should handle missing userProfile', () => {
-      vi.mocked(useContext).mockReturnValue({
+      vi.mocked(use).mockReturnValue({
         ...mockConfigContext,
         userProfile: null,
       })

--- a/web/app/components/app/configuration/dataset-config/context-var/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/dataset-config/context-var/__tests__/index.spec.tsx
@@ -43,7 +43,7 @@ vi.mock('@langgenius/dify-ui/popover', async () => {
   }
 
   const PopoverTrigger = ({ render }: { render: React.ReactNode }) => {
-    const { open, setOpen } = React.useContext(PopoverContext)
+    const { open, setOpen } = React.use(PopoverContext)
     return (
       <div
         data-testid="popover-trigger"
@@ -58,7 +58,7 @@ vi.mock('@langgenius/dify-ui/popover', async () => {
     children,
     ...props
   }: React.HTMLAttributes<HTMLDivElement> & { children?: React.ReactNode }) => {
-    const { open } = React.useContext(PopoverContext)
+    const { open } = React.use(PopoverContext)
     if (!open)
       return null
 

--- a/web/app/components/app/configuration/dataset-config/context-var/__tests__/var-picker.spec.tsx
+++ b/web/app/components/app/configuration/dataset-config/context-var/__tests__/var-picker.spec.tsx
@@ -33,7 +33,7 @@ vi.mock('@langgenius/dify-ui/popover', () => {
   }
 
   const PopoverContent = ({ children, ...props }: PopoverContentProps) => {
-    const { open } = React.useContext(PopoverContext)
+    const { open } = React.use(PopoverContext)
     if (!open)
       return null
     return (
@@ -44,7 +44,7 @@ vi.mock('@langgenius/dify-ui/popover', () => {
   }
 
   const PopoverTrigger = ({ children, asChild, render, ...props }: PopoverTriggerProps & { render?: React.ReactNode }) => {
-    const { open, onOpenChange } = React.useContext(PopoverContext)
+    const { open, onOpenChange } = React.use(PopoverContext)
     const content = render ?? children
     const handleClick = (e: React.MouseEvent<HTMLElement>) => {
       props.onClick?.(e)

--- a/web/app/components/app/configuration/dataset-config/index.tsx
+++ b/web/app/components/app/configuration/dataset-config/index.tsx
@@ -14,7 +14,7 @@ import { produce } from 'immer'
 import * as React from 'react'
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useContext } from 'use-context-selector'
+import { use } from 'use-context-selector'
 import { v4 as uuid4 } from 'uuid'
 import { ModelTypeEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import { useModelListAndDefaultModelAndCurrentProviderAndModel } from '@/app/components/header/account-setting/model-provider-page/hooks'
@@ -59,7 +59,7 @@ const DatasetConfig: FC<Props> = ({ readonly, hideMetadataFilter }) => {
     datasetConfigsRef,
     setDatasetConfigs,
     setRerankSettingModalOpen,
-  } = useContext(ConfigContext)
+  } = use(ConfigContext)
   const formattingChangedDispatcher = useFormattingChangedDispatcher()
 
   const hasData = dataSet.length > 0

--- a/web/app/components/app/configuration/dataset-config/params-config/index.tsx
+++ b/web/app/components/app/configuration/dataset-config/params-config/index.tsx
@@ -8,7 +8,7 @@ import { toast } from '@langgenius/dify-ui/toast'
 import { RiEqualizer2Line } from '@remixicon/react'
 import { memo, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useContext } from 'use-context-selector'
+import { use } from 'use-context-selector'
 import { ModelTypeEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import { useCurrentProviderAndModel, useModelListAndDefaultModelAndCurrentProviderAndModel } from '@/app/components/header/account-setting/model-provider-page/hooks'
 import {
@@ -33,7 +33,7 @@ const ParamsConfig = ({
     setDatasetConfigs,
     rerankSettingModalOpen,
     setRerankSettingModalOpen,
-  } = useContext(ConfigContext)
+  } = use(ConfigContext)
   const [tempDataSetConfigs, setTempDataSetConfigs] = useState(datasetConfigs)
 
   useEffect(() => {

--- a/web/app/components/app/configuration/debug/__tests__/chat-user-input.spec.tsx
+++ b/web/app/components/app/configuration/debug/__tests__/chat-user-input.spec.tsx
@@ -13,7 +13,7 @@ vi.mock('react-i18next', () => ({
 }))
 
 vi.mock('use-context-selector', () => ({
-  useContext: () => mockUseContext(),
+  use: () => mockUseContext(),
   createContext: vi.fn(() => ({})),
 }))
 
@@ -58,7 +58,7 @@ vi.mock('@langgenius/dify-ui/select', async () => {
       </SelectContext.Provider>
     ),
     SelectTrigger: ({ children, className }: { children: React.ReactNode, className?: string }) => {
-      const context = React.useContext(SelectContext)
+      const context = React.use(SelectContext)
       return (
         <div>
           <button data-testid="select-input" type="button" disabled={context.disabled} className={className}>
@@ -72,7 +72,7 @@ vi.mock('@langgenius/dify-ui/select', async () => {
     },
     SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     SelectItem: ({ children, value }: { children: React.ReactNode, value: string }) => {
-      const context = React.useContext(SelectContext)
+      const context = React.use(SelectContext)
       return (
         <button data-testid={`select-${value}`} type="button" role="option" onClick={() => context.onValueChange?.(value)}>
           {children}

--- a/web/app/components/app/configuration/debug/chat-user-input.tsx
+++ b/web/app/components/app/configuration/debug/chat-user-input.tsx
@@ -5,7 +5,7 @@ import { Textarea } from '@langgenius/dify-ui/textarea'
 import * as React from 'react'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useContext } from 'use-context-selector'
+import { use } from 'use-context-selector'
 import Input from '@/app/components/base/input'
 import BoolInput from '@/app/components/workflow/nodes/_base/components/before-run-form/bool-input'
 import ConfigContext from '@/context/debug-configuration'
@@ -18,7 +18,7 @@ const ChatUserInput = ({
   inputs,
 }: Props) => {
   const { t } = useTranslation()
-  const { modelConfig, setInputs, canTestAndRun = false } = useContext(ConfigContext)
+  const { modelConfig, setInputs, canTestAndRun = false } = use(ConfigContext)
   const debugInputReadonly = !canTestAndRun
 
   const promptVariables = modelConfig.configs.prompt_variables.filter(({ key, name }) => {

--- a/web/app/components/app/configuration/debug/debug-with-multiple-model/context.ts
+++ b/web/app/components/app/configuration/debug/debug-with-multiple-model/context.ts
@@ -2,7 +2,7 @@
 
 import type { ModelAndParameter } from '../types'
 import { noop } from 'es-toolkit/function'
-import { createContext, useContext } from 'use-context-selector'
+import { createContext, use } from 'use-context-selector'
 
 export type DebugWithMultipleModelContextType = {
   multipleModelConfigs: ModelAndParameter[]
@@ -17,4 +17,4 @@ export const DebugWithMultipleModelContext = createContext<DebugWithMultipleMode
   onDebugWithMultipleModelChange: noop,
 })
 
-export const useDebugWithMultipleModelContext = () => useContext(DebugWithMultipleModelContext)
+export const useDebugWithMultipleModelContext = () => use(DebugWithMultipleModelContext)

--- a/web/app/components/app/configuration/debug/index.tsx
+++ b/web/app/components/app/configuration/debug/index.tsx
@@ -24,7 +24,7 @@ import { produce, setAutoFreeze } from 'immer'
 import * as React from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useContext } from 'use-context-selector'
+import { use } from 'use-context-selector'
 import { useShallow } from 'zustand/react/shallow'
 import ChatUserInput from '@/app/components/app/configuration/debug/chat-user-input'
 import PromptValuePanel from '@/app/components/app/configuration/prompt-value-panel'
@@ -99,7 +99,7 @@ const Debug: FC<IDebug> = ({
     hasSetContextVar,
     datasetConfigs,
     externalDataToolsConfig,
-  } = useContext(ConfigContext)
+  } = use(ConfigContext)
   const { eventEmitter } = useEventEmitterContextContext()
   const { data: text2speechDefaultModel } = useDefaultModel(ModelTypeEnum.textEmbedding)
   useEffect(() => {

--- a/web/app/components/app/configuration/prompt-value-panel/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/prompt-value-panel/__tests__/index.spec.tsx
@@ -68,7 +68,7 @@ vi.mock('@langgenius/dify-ui/select', async () => {
       </SelectContext.Provider>
     ),
     SelectTrigger: ({ children }: { children: React.ReactNode }) => {
-      const context = React.useContext(SelectContext)
+      const context = React.use(SelectContext)
       return (
         <div>
           <button type="button">{children}</button>
@@ -80,7 +80,7 @@ vi.mock('@langgenius/dify-ui/select', async () => {
     },
     SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     SelectItem: ({ children, value }: { children: React.ReactNode, value: string }) => {
-      const context = React.useContext(SelectContext)
+      const context = React.use(SelectContext)
       return (
         <button type="button" onClick={() => context.onValueChange?.(value)}>
           {children}

--- a/web/app/components/app/configuration/prompt-value-panel/index.tsx
+++ b/web/app/components/app/configuration/prompt-value-panel/index.tsx
@@ -15,7 +15,7 @@ import {
 import * as React from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useContext } from 'use-context-selector'
+import { use } from 'use-context-selector'
 import { useStore as useAppStore } from '@/app/components/app/store'
 import FeatureBar from '@/app/components/base/features/new-feature-panel/feature-bar'
 import TextGenerationImageUploader from '@/app/components/base/image-uploader/text-generation-image-uploader'
@@ -40,7 +40,7 @@ const PromptValuePanel: FC<IPromptValuePanelProps> = ({
   onVisionFilesChange,
 }) => {
   const { t } = useTranslation()
-  const { readonly, canTestAndRun = false, modelModeType, modelConfig, setInputs, mode, isAdvancedMode, completionPromptConfig, chatPromptConfig } = useContext(ConfigContext)
+  const { readonly, canTestAndRun = false, modelModeType, modelConfig, setInputs, mode, isAdvancedMode, completionPromptConfig, chatPromptConfig } = use(ConfigContext)
   const debugInputReadonly = !canTestAndRun
   const [userInputFieldCollapse, setUserInputFieldCollapse] = useState(false)
   const promptVariables = modelConfig.configs.prompt_variables.filter(({ key, name }) => {

--- a/web/app/components/app/log/__tests__/model-info.spec.tsx
+++ b/web/app/components/app/log/__tests__/model-info.spec.tsx
@@ -47,7 +47,7 @@ vi.mock('@langgenius/dify-ui/popover', async () => {
       </PopoverContext.Provider>
     ),
     PopoverTrigger: ({ children, render }: { children?: React.ReactNode, render?: React.ReactNode }) => {
-      const context = React.useContext(PopoverContext)
+      const context = React.use(PopoverContext)
       const content = render ?? children
       const handleClick = () => {
         context?.onOpenChange?.(!context.open)
@@ -61,7 +61,7 @@ vi.mock('@langgenius/dify-ui/popover', async () => {
       return <button type="button" data-testid="popover-trigger" onClick={handleClick}>{content}</button>
     },
     PopoverContent: ({ children }: { children: React.ReactNode }) => {
-      const context = React.useContext(PopoverContext)
+      const context = React.use(PopoverContext)
       if (!context?.open)
         return null
 

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -30,7 +30,7 @@ import { parseAsString, useQueryState } from 'nuqs'
 import * as React from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { createContext, useContext } from 'use-context-selector'
+import { createContext, use } from 'use-context-selector'
 import { useShallow } from 'zustand/react/shallow'
 import ModelInfo from '@/app/components/app/log/model-info'
 import { useStore as useAppStore } from '@/app/components/app/store'
@@ -164,7 +164,7 @@ function DetailPanel({ detail, onFeedback }: IDetailPanel) {
     select: data => data.profile.timezone ?? undefined,
   })
   const { formatTime } = useTimestamp()
-  const { onClose, appDetail } = useContext(DrawerContext)
+  const { onClose, appDetail } = use(DrawerContext)
   const { currentLogItem, setCurrentLogItem, showMessageLogModal, setShowMessageLogModal, showPromptLogModal, setShowPromptLogModal, currentLogModalActiveTab } = useAppStore(useShallow((state: AppStoreState) => ({
     currentLogItem: state.currentLogItem,
     setCurrentLogItem: state.setCurrentLogItem,

--- a/web/app/components/apps/__tests__/app-card.spec.tsx
+++ b/web/app/components/apps/__tests__/app-card.spec.tsx
@@ -56,7 +56,7 @@ vi.mock('@langgenius/dify-ui/toast', () => ({
 // Include createContext for components that use it (like Toast)
 vi.mock('use-context-selector', () => ({
   createContext: <T,>(defaultValue: T) => React.createContext(defaultValue),
-  useContext: () => ({
+  use: () => ({
     notify: toastMocks.api,
   }),
   useContextSelector: (_context: unknown, selector: (state: Record<string, unknown>) => unknown) => selector({

--- a/web/app/components/base/carousel/index.tsx
+++ b/web/app/components/base/carousel/index.tsx
@@ -30,7 +30,7 @@ type CarouselContextValue = {
 const CarouselContext = React.createContext<CarouselContextValue | null>(null)
 
 function useCarousel() {
-  const context = React.useContext(CarouselContext)
+  const context = React.use(CarouselContext)
 
   if (!context)
     throw new Error('useCarousel must be used within a <Carousel />')

--- a/web/app/components/base/chat/chat-with-history/context.ts
+++ b/web/app/components/base/chat/chat-with-history/context.ts
@@ -15,7 +15,7 @@ import type {
   ConversationItem,
 } from '@/models/share'
 import { noop } from 'es-toolkit/function'
-import { createContext, useContext } from 'use-context-selector'
+import { createContext, use } from 'use-context-selector'
 
 export type ChatWithHistoryContextValue = {
   appMeta?: AppMeta | null
@@ -96,4 +96,4 @@ export const ChatWithHistoryContext = createContext<ChatWithHistoryContextValue>
   allInputsHidden: false,
   initUserVariables: {},
 })
-export const useChatWithHistoryContext = () => useContext(ChatWithHistoryContext)
+export const useChatWithHistoryContext = () => use(ChatWithHistoryContext)

--- a/web/app/components/base/chat/chat-with-history/inputs-form/__tests__/content.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/inputs-form/__tests__/content.spec.tsx
@@ -91,7 +91,7 @@ const createMockContext = (overrides: Partial<ChatWithHistoryContextValue> = {})
 const MockContext = React.createContext<ChatWithHistoryContextValue>(createMockContext())
 
 vi.mock('../../context', () => ({
-  useChatWithHistoryContext: () => React.useContext(MockContext),
+  useChatWithHistoryContext: () => React.use(MockContext),
 }))
 
 const MockContextProvider = ({ children, value }: { children: React.ReactNode, value: ChatWithHistoryContextValue }) => {

--- a/web/app/components/base/chat/chat/context.ts
+++ b/web/app/components/base/chat/chat/context.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import type { ChatProps } from './index'
-import { createContext, useContext } from 'use-context-selector'
+import { createContext, use } from 'use-context-selector'
 
 export type ChatContextValue = Pick<ChatProps, 'config'
   | 'isResponding'
@@ -25,4 +25,4 @@ export const ChatContext = createContext<ChatContextValue>({
   readonly: false,
 })
 
-export const useChatContext = () => useContext(ChatContext)
+export const useChatContext = () => use(ChatContext)

--- a/web/app/components/base/chat/embedded-chatbot/context.ts
+++ b/web/app/components/base/chat/embedded-chatbot/context.ts
@@ -14,7 +14,7 @@ import type {
   ConversationItem,
 } from '@/models/share'
 import { noop } from 'es-toolkit/function'
-import { createContext, useContext } from 'use-context-selector'
+import { createContext, use } from 'use-context-selector'
 import { AppSourceType } from '@/service/share'
 
 export type EmbeddedChatbotContextValue = {
@@ -91,4 +91,4 @@ export const EmbeddedChatbotContext = createContext<EmbeddedChatbotContextValue>
   allInputsHidden: false,
   initUserVariables: {},
 })
-export const useEmbeddedChatbotContext = () => useContext(EmbeddedChatbotContext)
+export const useEmbeddedChatbotContext = () => use(EmbeddedChatbotContext)

--- a/web/app/components/base/chat/embedded-chatbot/theme/theme-context.ts
+++ b/web/app/components/base/chat/embedded-chatbot/theme/theme-context.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'use-context-selector'
+import { createContext, use } from 'use-context-selector'
 import { hexToRGBA } from './utils'
 
 export class Theme {
@@ -70,4 +70,4 @@ export class ThemeBuilder {
 }
 
 const ThemeContext = createContext<ThemeBuilder>(new ThemeBuilder())
-export const useThemeContext = () => useContext(ThemeContext)
+export const useThemeContext = () => use(ThemeContext)

--- a/web/app/components/datasets/create-from-pipeline/create-options/create-from-dsl-modal/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/create-from-pipeline/create-options/create-from-dsl-modal/__tests__/index.spec.tsx
@@ -60,7 +60,7 @@ vi.mock('use-context-selector', async () => {
   const actual = await vi.importActual<typeof import('use-context-selector')>('use-context-selector')
   return {
     ...actual,
-    useContext: vi.fn(() => ({ notify: toastMocks.api })),
+    use: vi.fn(() => ({ notify: toastMocks.api })),
   }
 })
 

--- a/web/app/components/datasets/create-from-pipeline/create-options/create-from-dsl-modal/hooks/__tests__/use-dsl-import.spec.tsx
+++ b/web/app/components/datasets/create-from-pipeline/create-options/create-from-dsl-modal/hooks/__tests__/use-dsl-import.spec.tsx
@@ -57,7 +57,7 @@ vi.mock('use-context-selector', async () => {
   const actual = await vi.importActual<typeof import('use-context-selector')>('use-context-selector')
   return {
     ...actual,
-    useContext: vi.fn(() => ({ notify: toastMocks.api })),
+    use: vi.fn(() => ({ notify: toastMocks.api })),
   }
 })
 

--- a/web/app/components/datasets/create/file-uploader/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/create/file-uploader/__tests__/index.spec.tsx
@@ -9,7 +9,7 @@ vi.mock('use-context-selector', async () => {
   const actual = await vi.importActual<typeof import('use-context-selector')>('use-context-selector')
   return {
     ...actual,
-    useContext: vi.fn(() => ({ notify: mockNotify })),
+    use: vi.fn(() => ({ notify: mockNotify })),
   }
 })
 

--- a/web/app/components/datasets/documents/detail/batch-modal/__tests__/csv-uploader.spec.tsx
+++ b/web/app/components/datasets/documents/detail/batch-modal/__tests__/csv-uploader.spec.tsx
@@ -47,7 +47,7 @@ vi.mock('use-context-selector', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
   return {
     ...actual,
-    useContext: () => ({
+    use: () => ({
       toast: toastMocks.api,
     }),
   }

--- a/web/app/components/datasets/documents/detail/metadata/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/documents/detail/metadata/__tests__/index.spec.tsx
@@ -30,7 +30,7 @@ vi.mock('use-context-selector', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
   return {
     ...actual,
-    useContext: () => ({ notify: toastMocks.api }),
+    use: () => ({ notify: toastMocks.api }),
   }
 })
 

--- a/web/app/components/datasets/documents/detail/settings/__tests__/document-settings.spec.tsx
+++ b/web/app/components/datasets/documents/detail/settings/__tests__/document-settings.spec.tsx
@@ -18,7 +18,7 @@ vi.mock('use-context-selector', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
   return {
     ...actual,
-    useContext: () => ({
+    use: () => ({
       indexingTechnique: 'qualified',
       dataset: { id: 'dataset-1' },
     }),

--- a/web/app/components/datasets/documents/detail/settings/document-settings.tsx
+++ b/web/app/components/datasets/documents/detail/settings/document-settings.tsx
@@ -12,7 +12,7 @@ import type {
 } from '@/models/datasets'
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useContext } from 'use-context-selector'
+import { use } from 'use-context-selector'
 import AppUnavailable from '@/app/components/base/app-unavailable'
 import Loading from '@/app/components/base/loading'
 import StepTwo from '@/app/components/datasets/create/step-two'
@@ -33,7 +33,7 @@ const DocumentSettings = ({ datasetId, documentId }: DocumentSettingsProps) => {
   const { t } = useTranslation()
   const router = useRouter()
   const openIntegrationsSetting = useIntegrationsSetting()
-  const { indexingTechnique, dataset } = useContext(DatasetDetailContext)
+  const { indexingTechnique, dataset } = use(DatasetDetailContext)
   const { data: embeddingsDefaultModel } = useDefaultModel(ModelTypeEnum.textEmbedding)
   const handleOpenAccountSetting = useCallback(() => {
     openIntegrationsSetting({ payload: ACCOUNT_SETTING_TAB.PROVIDER })

--- a/web/app/components/datasets/documents/status-item/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/documents/status-item/__tests__/index.spec.tsx
@@ -21,7 +21,7 @@ const toastMocks = vi.hoisted(() => {
 })
 vi.mock('use-context-selector', () => ({
   createContext: (defaultValue: unknown) => React.createContext(defaultValue),
-  useContext: () => ({
+  use: () => ({
     notify: toastMocks.api,
   }),
   useContextSelector: (context: unknown, selector: (state: unknown) => unknown) => selector({}),

--- a/web/app/components/datasets/extra-info/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/extra-info/__tests__/index.spec.tsx
@@ -40,7 +40,7 @@ const mockDataset: Partial<DataSet> = {
 
 // Mock use-context-selector
 vi.mock('use-context-selector', () => ({
-  useContext: vi.fn(() => ({ dataset: mockDataset })),
+  use: vi.fn(() => ({ dataset: mockDataset })),
   useContextSelector: vi.fn((_, selector) => selector({ dataset: mockDataset })),
   createContext: vi.fn(() => ({})),
 }))

--- a/web/app/components/datasets/hit-testing/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/hit-testing/__tests__/index.spec.tsx
@@ -65,7 +65,7 @@ let mockAppContextState = {
 }
 
 vi.mock('use-context-selector', () => ({
-  useContext: vi.fn(() => ({ dataset: mockDataset })),
+  use: vi.fn(() => ({ dataset: mockDataset })),
   useContextSelector: vi.fn((_, selector) => selector({ dataset: mockDataset })),
   createContext: vi.fn(() => ({})),
 }))

--- a/web/app/components/datasets/hit-testing/index.tsx
+++ b/web/app/components/datasets/hit-testing/index.tsx
@@ -23,7 +23,7 @@ import { useBoolean } from 'ahooks'
 import * as React from 'react'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useContext } from 'use-context-selector'
+import { use } from 'use-context-selector'
 import FloatRightContainer from '@/app/components/base/float-right-container'
 import Loading from '@/app/components/base/loading'
 import docStyle from '@/app/components/datasets/documents/detail/completed/style.module.css'
@@ -62,7 +62,7 @@ const HitTestingPage: FC<Props> = ({ datasetId }: Props) => {
   const [queryInputKey, setQueryInputKey] = useState(Date.now())
 
   const [currPage, setCurrPage] = useState<number>(0)
-  const { dataset: currentDataset } = useContext(DatasetDetailContext)
+  const { dataset: currentDataset } = use(DatasetDetailContext)
   const currentUserId = useAppContextWithSelector(state => state.userProfile?.id)
   const workspacePermissionKeys = useAppContextWithSelector(state => state.workspacePermissionKeys)
   const canRunRetrievalRecall = React.useMemo(() => getDatasetACLCapabilities(currentDataset?.permission_keys, {
@@ -74,6 +74,7 @@ const HitTestingPage: FC<Props> = ({ datasetId }: Props) => {
 
   const total = recordsRes?.total || 0
   const totalPages = total ? Math.max(Math.ceil(total / limit), 1) : 1
+
 
   const isExternal = currentDataset?.provider === 'external'
 

--- a/web/app/components/header/account-setting/language-page/__tests__/index.spec.tsx
+++ b/web/app/components/header/account-setting/language-page/__tests__/index.spec.tsx
@@ -35,7 +35,7 @@ vi.mock('@langgenius/dify-ui/select', async () => {
       )
     },
     SelectTrigger: ({ children }: { children: React.ReactNode }) => {
-      const context = React.useContext(SelectContext)
+      const context = React.use(SelectContext)
       return (
         <div>
           <button type="button" disabled={context.disabled}>
@@ -52,7 +52,7 @@ vi.mock('@langgenius/dify-ui/select', async () => {
     },
     SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     SelectItem: ({ children, value }: { children: React.ReactNode, value: string }) => {
-      const context = React.useContext(SelectContext)
+      const context = React.use(SelectContext)
       return (
         <button type="button" role="option" onClick={() => context.onValueChange?.(value)}>
           {children}

--- a/web/app/components/plugins/install-plugin/install-from-github/steps/__tests__/selectPackage.spec.tsx
+++ b/web/app/components/plugins/install-plugin/install-from-github/steps/__tests__/selectPackage.spec.tsx
@@ -40,7 +40,7 @@ vi.mock('@langgenius/dify-ui/select', async () => {
     ),
     SelectLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     SelectTrigger: ({ children }: { children: React.ReactNode }) => {
-      const context = React.useContext(SelectContext)
+      const context = React.use(SelectContext)
       return (
         <div>
           <div data-testid="select-trigger" className={context.readOnly ? 'cursor-not-allowed' : 'cursor-pointer'}>
@@ -57,7 +57,7 @@ vi.mock('@langgenius/dify-ui/select', async () => {
     },
     SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     SelectItem: ({ children, value }: { children: React.ReactNode, value: string }) => {
-      const context = React.useContext(SelectContext)
+      const context = React.use(SelectContext)
       return (
         <button type="button" onClick={() => context.onValueChange?.(value)}>
           {children}

--- a/web/app/components/plugins/plugin-detail-panel/app-selector/__tests__/app-inputs-form.spec.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/app-selector/__tests__/app-inputs-form.spec.tsx
@@ -39,7 +39,7 @@ vi.mock('@langgenius/dify-ui/select', async () => {
       </SelectContext.Provider>
     ),
     SelectTrigger: ({ children }: { children: React.ReactNode }) => {
-      const context = React.useContext(SelectContext)
+      const context = React.use(SelectContext)
 
       return (
         <div>
@@ -52,7 +52,7 @@ vi.mock('@langgenius/dify-ui/select', async () => {
     },
     SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     SelectItem: ({ children, value }: { children: React.ReactNode, value: string }) => {
-      const context = React.useContext(SelectContext)
+      const context = React.use(SelectContext)
       return (
         <button key={value} data-testid={`select-${value}`} type="button" onClick={() => context.onValueChange?.(value)}>
           {children}

--- a/web/app/components/plugins/plugin-detail-panel/model-selector/__tests__/tts-params-panel.spec.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/model-selector/__tests__/tts-params-panel.spec.tsx
@@ -58,7 +58,7 @@ vi.mock('@langgenius/dify-ui/select', async (importOriginal) => {
       </button>
     ),
     SelectValue: () => {
-      const { value } = React.useContext(MockSelectContext)
+      const { value } = React.use(MockSelectContext)
       return <span data-testid="selected-value">{value}</span>
     },
     SelectContent: ({
@@ -79,7 +79,7 @@ vi.mock('@langgenius/dify-ui/select', async (importOriginal) => {
       children: React.ReactNode
       value: string
     }) => {
-      const { onValueChange } = React.useContext(MockSelectContext)
+      const { onValueChange } = React.use(MockSelectContext)
       return (
         <button
           data-testid={`select-item-${value}`}

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/__tests__/selector-entry.spec.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/__tests__/selector-entry.spec.tsx
@@ -37,7 +37,7 @@ vi.mock('@langgenius/dify-ui/popover', async () => {
   }
 
   const PopoverTrigger = ({ render }: { render: React.ReactNode }) => {
-    const { open, setOpen } = React.useContext(PopoverContext)
+    const { open, setOpen } = React.use(PopoverContext)
     return (
       <div onClick={() => setOpen(!open)}>
         {render}
@@ -46,7 +46,7 @@ vi.mock('@langgenius/dify-ui/popover', async () => {
   }
 
   const PopoverContent = ({ children }: { children: React.ReactNode }) => {
-    const { open } = React.useContext(PopoverContext)
+    const { open } = React.use(PopoverContext)
     return open ? <div data-testid="popover-content">{children}</div> : null
   }
 

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/create/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/create/__tests__/index.spec.tsx
@@ -172,7 +172,7 @@ vi.mock('@langgenius/dify-ui/select', async () => {
       )
     },
     SelectTrigger: ({ children, className }: { children: React.ReactNode, render?: React.ReactNode, className?: string }) => {
-      const context = React.useContext(SelectContext)
+      const context = React.use(SelectContext)
       return (
         <div
           data-testid="custom-trigger"
@@ -187,7 +187,7 @@ vi.mock('@langgenius/dify-ui/select', async () => {
       <div data-testid="options-container">{children}</div>
     ),
     SelectItem: ({ children, value }: { children: React.ReactNode, value: string }) => {
-      const context = React.useContext(SelectContext)
+      const context = React.use(SelectContext)
       return (
         <div
           data-testid={`option-${value}`}

--- a/web/app/components/plugins/plugin-detail-panel/tool-selector/components/__tests__/reasoning-config-form.spec.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/tool-selector/components/__tests__/reasoning-config-form.spec.tsx
@@ -34,7 +34,7 @@ vi.mock('@langgenius/dify-ui/select', async () => {
     ),
     SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     SelectItem: ({ children, value }: { children: React.ReactNode, value: string }) => {
-      const context = React.useContext(SelectContext)
+      const context = React.use(SelectContext)
       return (
         <button key={value} data-testid={`select-${value}`} type="button" onClick={() => context.onValueChange?.(value)}>
           {children}

--- a/web/app/components/plugins/plugin-page/filter-management/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/plugin-page/filter-management/__tests__/index.spec.tsx
@@ -1,7 +1,7 @@
 import type { Category, Tag } from '../constant'
 import type { FilterState } from '../index'
 import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react'
-import { createContext, useContext } from 'react'
+import { createContext, use } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // ==================== Imports (after mocks) ====================
@@ -93,7 +93,7 @@ vi.mock('@langgenius/dify-ui/popover', () => ({
     render?: React.ReactNode
     className?: string
   }) => {
-    const { open, onOpenChange } = useContext(MockPopoverContext)
+    const { open, onOpenChange } = use(MockPopoverContext)
     return (
       <div
         data-testid="portal-trigger"
@@ -108,7 +108,7 @@ vi.mock('@langgenius/dify-ui/popover', () => ({
     children: React.ReactNode
     className?: string
   }) => {
-    const { open } = useContext(MockPopoverContext)
+    const { open } = use(MockPopoverContext)
     if (!open)
       return null
     return <div data-testid="portal-content" className={className}>{children}</div>

--- a/web/app/components/plugins/reference-setting-modal/auto-update-setting/__tests__/tool-picker.spec.tsx
+++ b/web/app/components/plugins/reference-setting-modal/auto-update-setting/__tests__/tool-picker.spec.tsx
@@ -41,7 +41,7 @@ vi.mock('@langgenius/dify-ui/popover', async () => {
   )
 
   const PopoverTrigger = ({ render }: { render: React.ReactNode }) => {
-    const { open, setOpen } = React.useContext(PopoverContext)
+    const { open, setOpen } = React.use(PopoverContext)
     return (
       <div onClick={() => setOpen(!open)}>
         {render}
@@ -56,7 +56,7 @@ vi.mock('@langgenius/dify-ui/popover', async () => {
     children: React.ReactNode
     className?: string
   }) => {
-    const { open } = React.useContext(PopoverContext)
+    const { open } = React.use(PopoverContext)
     return open ? <div data-testid="popover-content" className={className}>{children}</div> : null
   }
 

--- a/web/app/components/tools/labels/__tests__/selector.spec.tsx
+++ b/web/app/components/tools/labels/__tests__/selector.spec.tsx
@@ -43,7 +43,7 @@ vi.mock('@langgenius/dify-ui/popover', async () => {
     className?: string
     render?: React.ReactNode
   }) => {
-    const { open, setOpen } = React.useContext(PopoverContext)
+    const { open, setOpen } = React.use(PopoverContext)
     if (render) {
       return (
         <div onClick={() => setOpen(!open)}>
@@ -63,7 +63,7 @@ vi.mock('@langgenius/dify-ui/popover', async () => {
     children,
     ...props
   }: React.HTMLAttributes<HTMLDivElement> & { children?: React.ReactNode }) => {
-    const { open } = React.useContext(PopoverContext)
+    const { open } = React.use(PopoverContext)
     if (!open)
       return null
 

--- a/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/__tests__/json-importer.spec.tsx
+++ b/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/__tests__/json-importer.spec.tsx
@@ -62,7 +62,7 @@ vi.mock('@langgenius/dify-ui/popover', async () => {
 
   const PopoverTrigger = ReactModule.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
     ({ children, onClick, ...props }, ref) => {
-      const context = ReactModule.useContext(PopoverContext)
+      const context = ReactModule.use(PopoverContext)
 
       return (
         <button
@@ -98,7 +98,7 @@ vi.mock('@langgenius/dify-ui/popover', async () => {
     ),
     PopoverTrigger,
     PopoverContent: ({ children }: { children: React.ReactNode }) => {
-      const context = ReactModule.useContext(PopoverContext)
+      const context = ReactModule.use(PopoverContext)
       if (!context?.open)
         return null
 

--- a/web/app/components/workflow/nodes/trigger-webhook/__tests__/panel.spec.tsx
+++ b/web/app/components/workflow/nodes/trigger-webhook/__tests__/panel.spec.tsx
@@ -50,7 +50,7 @@ vi.mock('@langgenius/dify-ui/select', async () => {
     ),
     SelectLabel: () => null,
     SelectTrigger: ({ children, className }: { children: React.ReactNode, className?: string }) => {
-      const context = React.useContext(SelectContext)
+      const context = React.use(SelectContext)
       return (
         <div>
           <button data-testid="select-trigger" type="button" disabled={context.disabled} className={className}>
@@ -64,7 +64,7 @@ vi.mock('@langgenius/dify-ui/select', async () => {
     },
     SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     SelectItem: ({ children, value }: { children: React.ReactNode, value: string }) => {
-      const context = React.useContext(SelectContext)
+      const context = React.use(SelectContext)
       return (
         <button data-testid={`select-${value}`} type="button" onClick={() => context.onValueChange?.(value)}>
           {children}

--- a/web/context/app-context.ts
+++ b/web/context/app-context.ts
@@ -3,7 +3,7 @@
 import type { GetAccountProfileResponse } from '@dify/contracts/api/console/account/types.gen'
 import type { ICurrentWorkspace, LangGeniusVersionResponse } from '@/models/common'
 import { noop } from 'es-toolkit/function'
-import { createContext, useContext, useContextSelector } from 'use-context-selector'
+import { createContext, use, useContextSelector } from 'use-context-selector'
 
 export type AppContextValue = {
   userProfile: GetAccountProfileResponse
@@ -75,4 +75,4 @@ export function useSelector<T>(selector: (value: AppContextValue) => T): T {
   return useContextSelector(AppContext, selector)
 }
 
-export const useAppContext = () => useContext(AppContext)
+export const useAppContext = () => use(AppContext)

--- a/web/context/dataset-detail.ts
+++ b/web/context/dataset-detail.ts
@@ -1,7 +1,7 @@
 import type { QueryObserverResult, RefetchOptions } from '@tanstack/react-query'
 import type { IndexingType } from '@/app/components/datasets/create/step-two'
 import type { DataSet } from '@/models/datasets'
-import { createContext, useContext, useContextSelector } from 'use-context-selector'
+import { createContext, use, useContextSelector } from 'use-context-selector'
 
 type DatasetDetailContextValue = {
   indexingTechnique?: IndexingType
@@ -10,7 +10,7 @@ type DatasetDetailContextValue = {
 }
 const DatasetDetailContext = createContext<DatasetDetailContextValue>({})
 
-export const useDatasetDetailContext = () => useContext(DatasetDetailContext)
+export const useDatasetDetailContext = () => use(DatasetDetailContext)
 
 export const useDatasetDetailContextWithSelector = <T>(selector: (value: DatasetDetailContextValue) => T): T => {
   return useContextSelector(DatasetDetailContext, selector)

--- a/web/context/debug-configuration.ts
+++ b/web/context/debug-configuration.ts
@@ -23,7 +23,7 @@ import type {
 } from '@/models/debug'
 import type { VisionSettings } from '@/types/app'
 import { noop } from 'es-toolkit/function'
-import { createContext, useContext } from 'use-context-selector'
+import { createContext, use } from 'use-context-selector'
 import { ANNOTATION_DEFAULT, DEFAULT_AGENT_SETTING, DEFAULT_CHAT_PROMPT_CONFIG, DEFAULT_COMPLETION_PROMPT_CONFIG } from '@/config'
 import { PromptMode } from '@/models/debug'
 import { AppModeEnum, ModelModeType, Resolution, RETRIEVE_TYPE, TransferMethod } from '@/types/app'
@@ -274,6 +274,6 @@ const DebugConfigurationContext = createContext<IDebugConfiguration>({
   setRerankSettingModalOpen: noop,
 })
 
-export const useDebugConfigurationContext = () => useContext(DebugConfigurationContext)
+export const useDebugConfigurationContext = () => use(DebugConfigurationContext)
 
 export default DebugConfigurationContext

--- a/web/context/event-emitter.ts
+++ b/web/context/event-emitter.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import type { EventEmitter } from 'ahooks/lib/useEventEmitter'
-import { createContext, useContext } from 'use-context-selector'
+import { createContext, use } from 'use-context-selector'
 
 /**
  * Typed event object emitted via the shared EventEmitter.
@@ -19,4 +19,4 @@ export const EventEmitterContext = createContext<{ eventEmitter: EventEmitter<Ev
   eventEmitter: null,
 })
 
-export const useEventEmitterContextContext = () => useContext(EventEmitterContext)
+export const useEventEmitterContextContext = () => use(EventEmitterContext)

--- a/web/context/modal-context.ts
+++ b/web/context/modal-context.ts
@@ -22,7 +22,7 @@ import type {
 } from '@/models/common'
 import type { ModerationConfig, PromptVariable } from '@/models/debug'
 import { noop } from 'es-toolkit/function'
-import { createContext, useContext, useContextSelector } from 'use-context-selector'
+import { createContext, use, useContextSelector } from 'use-context-selector'
 
 export type ModalState<T> = {
   payload: T
@@ -80,7 +80,7 @@ export const ModalContext = createContext<ModalContextState>({
   setShowTriggerEventsLimitModal: noop,
 })
 
-export const useModalContext = () => useContext(ModalContext)
+export const useModalContext = () => use(ModalContext)
 
 // Adding a dangling comma to avoid the generic parsing issue in tsx, see:
 // https://github.com/microsoft/TypeScript/issues/15713

--- a/web/context/provider-context.ts
+++ b/web/context/provider-context.ts
@@ -4,7 +4,7 @@ import type { Plan, UsagePlanInfo, UsageResetInfo } from '@/app/components/billi
 import type { Model, ModelProvider } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import type { RETRIEVE_METHOD } from '@/types/app'
 import { noop } from 'es-toolkit/function'
-import { createContext, useContext, useContextSelector } from 'use-context-selector'
+import { createContext, use, useContextSelector } from 'use-context-selector'
 import { defaultPlan } from '@/app/components/billing/config'
 
 export type ProviderContextState = {
@@ -84,7 +84,7 @@ export const baseProviderContextValue: ProviderContextState = {
 
 export const ProviderContext = createContext<ProviderContextState>(baseProviderContextValue)
 
-export const useProviderContext = () => useContext(ProviderContext)
+export const useProviderContext = () => use(ProviderContext)
 
 // Adding a dangling comma to avoid the generic parsing issue in tsx, see:
 // https://github.com/microsoft/TypeScript/issues/15713

--- a/web/features/tag-management/__tests__/tag-item-editor.spec.tsx
+++ b/web/features/tag-management/__tests__/tag-item-editor.spec.tsx
@@ -67,7 +67,7 @@ vi.mock('ahooks', async (importOriginal) => {
 
 vi.mock('use-context-selector', () => ({
   createContext: <T,>(defaultValue: T) => React.createContext(defaultValue),
-  useContext: () => ({
+  use: () => ({
     notify: tagMocks.api,
   }),
 }))

--- a/web/scripts/refactor-component.js
+++ b/web/scripts/refactor-component.js
@@ -31,7 +31,7 @@ class RefactorAnalyzer extends ComponentAnalyzer {
     const memoCount = (code.match(/useMemo\s*\(/g) || []).length
     const conditionalBlocks = this.countConditionalBlocks(code)
     const nestedTernaries = this.countNestedTernaries(code)
-    const hasContext = code.includes('useContext') || code.includes('createContext')
+    const hasContext = code.includes('use') || code.includes('createContext')
     const hasReducer = code.includes('useReducer')
     const hasModals = this.countModals(code)
 
@@ -118,7 +118,7 @@ Usage:               ${analysis.usageCount} reference${analysis.usageCount !== 1
   ${analysis.hasEffects ? '✓' : '✗'} Side effects (useEffect)
   ${analysis.hasCallbacks ? '✓' : '✗'} Callbacks (useCallback)
   ${analysis.hasMemo ? '✓' : '✗'} Memoization (useMemo)
-  ${analysis.hasContext ? '✓' : '✗'} Context (useContext/createContext)
+  ${analysis.hasContext ? '✓' : '✗'} Context (use/createContext)
   ${analysis.hasEvents ? '✓' : '✗'} Event handlers
   ${analysis.hasRouter ? '✓' : '✗'} Next.js routing
   ${analysis.hasAPI ? '✓' : '✗'} API calls

--- a/web/utils/context.ts
+++ b/web/utils/context.ts
@@ -44,6 +44,6 @@ type CreateCtxReturn<T> = [Provider<T>, () => T, Context<T>] & {
 export const createCtx = createCreateCtxFunction(use, createContext)
 
 export const createSelectorCtx = createCreateCtxFunction(
-  selector.useContext as UseContextImpl,
+  selector.use as UseContextImpl,
   selector.createContext as typeof createContext,
 )


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
