### PR TITLE
chore(web): support separate public API target for dev proxy

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -23,6 +23,8 @@ NEXT_PUBLIC_SOCKET_URL=ws://localhost:5001
 # Dev proxy routes are configured in web/dev-proxy.config.ts.
 # pnpm -C web run dev:proxy loads web/.env.local before evaluating that config file.
 DEV_PROXY_TARGET=https://cloud.dify.ai
+# Defaults to DEV_PROXY_TARGET when omitted. Set this when Web App public APIs use a different origin.
+DEV_PROXY_PUBLIC_TARGET=https://udify.app
 DEV_PROXY_HOST=127.0.0.1
 DEV_PROXY_PORT=5001
 

--- a/web/dev-proxy.config.ts
+++ b/web/dev-proxy.config.ts
@@ -3,6 +3,7 @@ import type { CookieRewriteOptions, DevProxyConfig } from '@langgenius/dev-proxy
 const DIFY_CLOUD_TARGET = 'https://cloud.dify.ai'
 const DEV_PROXY_TARGET = process.env.DEV_PROXY_TARGET || DIFY_CLOUD_TARGET
 const DEV_PROXY_ENTERPRISE_TARGET = process.env.DEV_PROXY_ENTERPRISE_TARGET || DEV_PROXY_TARGET
+const DEV_PROXY_PUBLIC_TARGET = process.env.DEV_PROXY_PUBLIC_TARGET || DEV_PROXY_TARGET
 const DEV_PROXY_HOST = process.env.DEV_PROXY_HOST || '127.0.0.1'
 const DEV_PROXY_PORT = Number(process.env.DEV_PROXY_PORT || 5001)
 
@@ -46,9 +47,15 @@ export default {
     {
       paths: [
         '/console/api',
-        '/api',
       ],
       target: DEV_PROXY_TARGET,
+      cookieRewrite: difyCookieRewrite,
+    },
+    {
+      paths: [
+        '/api',
+      ],
+      target: DEV_PROXY_PUBLIC_TARGET,
       cookieRewrite: difyCookieRewrite,
     },
   ],


### PR DESCRIPTION
## Summary

Add `DEV_PROXY_PUBLIC_TARGET` to configure the dev proxy public API upstream separately

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
