### PR TITLE
fix: restore CJK/non-ASCII keyword search in workflow logs

### DIFF
--- a/api/services/workflow_app_service.py
+++ b/api/services/workflow_app_service.py
@@ -92,8 +92,11 @@ class WorkflowAppService:
         if keyword:
             from libs.helper import escape_like_pattern
 
-            # Escape special characters in keyword to prevent SQL injection via LIKE wildcards
-            escaped_keyword = escape_like_pattern(keyword[:30])
+            # json.dumps() stores non-ASCII text as \uXXXX escape sequences (ensure_ascii=True
+            # default). Convert the keyword to the same format before escaping LIKE wildcards so
+            # that CJK and other non-ASCII searches match the stored representation.
+            unicode_escaped_keyword = keyword[:30].encode("unicode_escape").decode("utf-8")
+            escaped_keyword = escape_like_pattern(unicode_escaped_keyword)
             keyword_like_val = f"%{escaped_keyword}%"
             keyword_conditions = [
                 WorkflowRun.inputs.ilike(keyword_like_val, escape="\\"),


### PR DESCRIPTION
## Summary

Workflow log keyword search returns empty results for Chinese/Japanese/Korean and other non-ASCII characters since v1.11.0.

**Root cause:** PR #30450 (merged 2026-01-06) refactored the LIKE pattern escaping to prevent SQL injection via wildcards. This was correct, but it dropped the `unicode_escape` encoding step that was essential for matching non-ASCII text.

Workflow run `inputs` and `outputs` are serialized with `json.dumps()`, which defaults to `ensure_ascii=True`. This means Chinese characters like `你好` are stored in the database as `你好` (literal backslash-u sequences). The LIKE pattern must use the same escaped form to find a match.

**Fix:** Convert the search keyword to Unicode escape format (matching the stored representation) before passing it to `escape_like_pattern`. ASCII keywords are unaffected—`"hello".encode("unicode_escape").decode("utf-8")` returns `"hello"` unchanged.

Fixes #37367

## Changes

- `api/services/workflow_app_service.py`: apply `encode("unicode_escape").decode("utf-8")` to the keyword before escaping LIKE wildcards, restoring the match between the search term and how non-ASCII text is stored in the database