### PR TITLE
chore(codeowners): update CLI ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,8 +23,8 @@
 /docs/ @crazywoola
 
 # CLI
-/cli/ @langgenius/maintainers
-/.github/workflows/cli-tests.yml @langgenius/maintainers
+/cli/ @GareArc
+/.github/workflows/cli-tests.yml @GareArc
 
 # Backend (default owner, more specific rules below will override)
 /api/ @QuantumGhost


### PR DESCRIPTION
## Summary

Updates CODEOWNERS so CLI files and the CLI tests workflow are owned by `@GareArc` instead of `@langgenius/maintainers`.

Issue: N/A - ownership metadata update.

## Screenshots

N/A - CODEOWNERS metadata update.