### PR TITLE
fix(ui): align infotip popover focus styles

### DIFF
--- a/packages/dify-ui/src/popover/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/popover/__tests__/index.spec.tsx
@@ -29,6 +29,11 @@ describe('PopoverContent', () => {
       await expect.element(screen.getByRole('group', { name: 'default positioner' })).toHaveAttribute('data-side', 'bottom')
       await expect.element(screen.getByRole('group', { name: 'default positioner' })).toHaveAttribute('data-align', 'center')
       await expect.element(screen.getByRole('dialog', { name: 'default popover' })).toHaveTextContent('Default content')
+      await expect.element(screen.getByRole('dialog', { name: 'default popover' })).toHaveClass(
+        'outline-hidden',
+        'focus:outline-hidden',
+        'focus-visible:outline-hidden',
+      )
     })
 
     it('should apply parsed custom placement and custom offsets when placement props are provided', async () => {

--- a/packages/dify-ui/src/popover/index.tsx
+++ b/packages/dify-ui/src/popover/index.tsx
@@ -57,6 +57,7 @@ export function PopoverContent({
         <BasePopover.Popup
           className={cn(
             'rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg',
+            'outline-hidden focus:outline-hidden focus-visible:outline-hidden',
             'origin-(--transform-origin) transition-[transform,scale,opacity] data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:scale-95 data-starting-style:opacity-0 motion-reduce:transition-none',
             popupClassName,
           )}

--- a/web/app/components/base/infotip/index.tsx
+++ b/web/app/components/base/infotip/index.tsx
@@ -71,7 +71,7 @@ export function Infotip({
         aria-label={ariaLabel}
         onClick={handleClick}
         className={cn(
-          'inline-flex size-4 shrink-0 cursor-pointer items-center justify-center border-0 bg-transparent p-0 focus-visible:ring-1 focus-visible:ring-components-input-border-hover focus-visible:outline-hidden',
+          'inline-flex size-4 shrink-0 cursor-pointer items-center justify-center border-0 bg-transparent p-0 focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden',
           className,
         )}
       >


### PR DESCRIPTION
## Summary

- Update `Infotip` trigger keyboard focus to use the Dify blue focus token with a stronger ring.
- Reset the focus outline on the shared `PopoverContent` popup container, matching Base UI's Popover examples while preserving Base UI focus management.
- Add a regression assertion so the outline reset stays attached to the actual popup element.

## Why

Keyboard focus should be visible on the real trigger users operate. When Base UI moves focus into a popover, the popup container can receive programmatic focus as a fallback, but it should not expose a browser-default outline as if the container were the interactive target.

This keeps the accessible focus flow intact while leaving focus indication to the trigger and any interactive controls inside the popup.