### PR TITLE
fix(web): tighten start block preview card spacing

### DIFF
--- a/web/app/components/workflow/block-selector/start-blocks.tsx
+++ b/web/app/components/workflow/block-selector/start-blocks.tsx
@@ -210,7 +210,7 @@ function StartBlockPreviewCard({
   ].includes(block.type)
 
   return (
-    <PreviewCardContent placement="right" popupClassName="w-[224px] px-3 pt-3 pb-4">
+    <PreviewCardContent placement="right" popupClassName="w-[224px] px-3 pt-3 pb-2.5">
       <div>
         <BlockIcon
           size="md"
@@ -224,7 +224,7 @@ function StartBlockPreviewCard({
           {description}
         </div>
         {showDifyTeamAuthor && (
-          <div className="my-1 system-xs-regular text-text-tertiary">
+          <div className="mt-1 system-xs-regular text-text-tertiary">
             {t('author', { ns: 'tools' })}
             {' '}
             {t('difyTeam', { ns: 'workflow' })}


### PR DESCRIPTION
## Summary

- Tighten the Start/User Input/trigger preview card bottom spacing in the workflow block selector.
- Keep the existing PreviewCard primitive, width, border, placement, and content structure unchanged.

| Before | After |
| --- | --- |
| <img width="466" height="298" alt="Before preview card spacing" src="https://github.com/user-attachments/assets/4d9e72f6-3e9b-4c02-8a11-008dc1750549" /> | <img width="468" height="282" alt="After preview card spacing" src="https://github.com/user-attachments/assets/6a45394b-ca2a-4259-a7e9-e82233f4e899" /> |

## Root Cause

The start block preview card used extra bottom padding plus vertical margin on the Dify Team author row, leaving noticeably more empty space below the author line than comparable workflow preview cards.

## Verification

- `pnpm eslint web/app/components/workflow/block-selector/start-blocks.tsx`
- `pnpm -C web test app/components/workflow/block-selector/__tests__/start-blocks.spec.tsx`