### PR TITLE
chore: compatiable conversation is not exists (#33274)

### DIFF
--- a/api/core/app/apps/advanced_chat/app_generator.py
+++ b/api/core/app/apps/advanced_chat/app_generator.py
@@ -50,6 +50,7 @@ from models import Account, App, Conversation, EndUser, Message, Workflow, Workf
 from models.base import Base
 from models.enums import WorkflowRunTriggeredFrom
 from services.conversation_service import ConversationService
+from services.errors.conversation import ConversationNotExistsError
 from services.workflow_draft_variable_service import (
     DraftVarLoader,
     WorkflowDraftVariableService,
@@ -140,9 +141,15 @@ class AdvancedChatAppGenerator(MessageBasedAppGenerator):
         conversation = None
         conversation_id = args.get("conversation_id")
         if conversation_id:
-            conversation = ConversationService.get_conversation(
-                app_model=app_model, conversation_id=conversation_id, user=user
-            )
+            try:
+                conversation = ConversationService.get_conversation(
+                    app_model=app_model, conversation_id=conversation_id, user=user
+                )
+            except ConversationNotExistsError:
+                if invoke_from == InvokeFrom.SERVICE_API:
+                    conversation = None
+                else:
+                    raise
 
         # parse files
         # TODO(QuantumGhost): Move file parsing logic to the API controller layer

--- a/api/tests/unit_tests/core/app/apps/test_advanced_chat_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/test_advanced_chat_app_generator.py
@@ -11,8 +11,10 @@ from core.app.apps.advanced_chat.app_generator import AdvancedChatAppGenerator
 from core.app.entities.app_invoke_entities import AdvancedChatAppGenerateEntity, InvokeFrom
 from core.app.task_pipeline import message_cycle_manager
 from core.app.task_pipeline.message_cycle_manager import MessageCycleManager
+from core.ops.ops_trace_manager import TraceQueueManager
 from models.enums import ConversationFromSource
 from models.model import AppMode, Conversation, Message
+from services.errors.conversation import ConversationNotExistsError
 
 
 def _make_app_config() -> WorkflowUIBasedAppConfig:
@@ -106,6 +108,75 @@ def test_init_generate_records_marks_existing_conversation():
     assert entity.conversation_id == "existing-conversation-id"
     assert conversation is existing_conversation
     assert entity.is_new_conversation is False
+
+
+def test_generate_falls_back_to_new_conversation_when_conversation_missing(monkeypatch: pytest.MonkeyPatch):
+    app_config = _make_app_config()
+    workflow = SimpleNamespace(
+        features_dict={},
+        tenant_id="tenant-id",
+        app_id="app-id",
+        id="workflow-id",
+    )
+    app_model = SimpleNamespace(id="app-id", tenant_id="tenant-id")
+    user = SimpleNamespace(id="user-id", session_id="session-id")
+
+    def raise_conversation_not_exists(**_kwargs):
+        raise ConversationNotExistsError()
+
+    monkeypatch.setattr(
+        "core.app.apps.advanced_chat.app_generator.ConversationService.get_conversation",
+        raise_conversation_not_exists,
+    )
+    monkeypatch.setattr(
+        "core.app.apps.advanced_chat.app_generator.FileUploadConfigManager.convert",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "core.app.apps.advanced_chat.app_generator.AdvancedChatAppConfigManager.get_app_config",
+        lambda **_kwargs: app_config,
+    )
+    monkeypatch.setattr(
+        "core.app.apps.advanced_chat.app_generator.db",
+        SimpleNamespace(engine=object()),
+    )
+    trace_manager = object.__new__(TraceQueueManager)
+    monkeypatch.setattr(
+        "core.app.apps.advanced_chat.app_generator.TraceQueueManager",
+        lambda **_kwargs: trace_manager,
+    )
+    monkeypatch.setattr(
+        "core.app.apps.advanced_chat.app_generator.DifyCoreRepositoryFactory.create_workflow_execution_repository",
+        lambda **_kwargs: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        "core.app.apps.advanced_chat.app_generator.DifyCoreRepositoryFactory.create_workflow_node_execution_repository",
+        lambda **_kwargs: SimpleNamespace(),
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_generate(self, **kwargs):
+        captured.update(kwargs)
+        return {"status": "ok"}
+
+    monkeypatch.setattr(AdvancedChatAppGenerator, "_generate", fake_generate)
+
+    result = AdvancedChatAppGenerator().generate(
+        app_model=app_model,
+        workflow=workflow,
+        user=user,
+        args={"inputs": {}, "query": "hello", "conversation_id": "missing-conversation-id"},
+        invoke_from=InvokeFrom.SERVICE_API,
+        workflow_run_id="workflow-run-id",
+        streaming=False,
+    )
+
+    assert result == {"status": "ok"}
+    assert captured["conversation"] is None
+    application_generate_entity = captured["application_generate_entity"]
+    assert isinstance(application_generate_entity, AdvancedChatAppGenerateEntity)
+    assert application_generate_entity.conversation_id is None
 
 
 def test_message_cycle_manager_uses_new_conversation_flag(monkeypatch):


### PR DESCRIPTION
Backport of #33274 to `lts/1.13.x`.

## Summary

Cherry-picks `56d4d54c16f47f7efd6f03d5cc5a6a145c8a9ef9` (chore: compatiable conversation is not exists, #33274).

When an advanced-chat app is invoked via the Service API with a `conversation_id` that no longer exists, `ConversationService.get_conversation` raises `ConversationNotExistsError`. This change catches that error and falls back to creating a new conversation for `InvokeFrom.SERVICE_API` requests, while preserving the original behaviour (re-raise) for other invocation sources.

## Changes

- `api/core/app/apps/advanced_chat/app_generator.py`: wrap `get_conversation` in a try/except, falling back to `conversation = None` for Service API calls.
- `api/tests/unit_tests/core/app/apps/test_advanced_chat_app_generator.py`: add regression test `test_generate_falls_back_to_new_conversation_when_conversation_missing`.

## Cherry-pick notes

- Used `git cherry-pick -x` so the provenance line `(cherry picked from commit 56d4d54c16...)` is preserved.
- Minor conflict in the test file (an adjacent test signature differed on the LTS branch) was resolved by keeping the LTS-side signature and inserting the new test.

## Testing

`uv run --project api pytest tests/unit_tests/core/app/apps/test_advanced_chat_app_generator.py` — 4 passed.
