### PR TITLE
Fix child chunk vector refresh on update

### DIFF
--- a/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
@@ -288,6 +288,11 @@ class WeaviateVector(BaseVector):
 
         uuids = []
         for doc in documents:
+            doc_id = doc.metadata.get("doc_id") if doc.metadata else None
+            if isinstance(doc_id, str) and self._is_uuid(doc_id):
+                uuids.append(doc_id)
+                continue
+
             uuid_val = _uuid.uuid5(URL_NAMESPACE, doc.page_content)
             uuids.append(str(uuid_val))
 

--- a/api/providers/vdb/vdb-weaviate/tests/integration_tests/test_weaviate.py
+++ b/api/providers/vdb/vdb-weaviate/tests/integration_tests/test_weaviate.py
@@ -1,8 +1,11 @@
+import uuid
+
 from dify_vdb_weaviate.weaviate_vector import WeaviateConfig, WeaviateVector
 
 from core.rag.datasource.vdb.vector_integration_test_support import (
     AbstractVectorTest,
 )
+from core.rag.models.document import Document
 
 
 class WeaviateVectorTest(AbstractVectorTest):
@@ -21,3 +24,101 @@ class WeaviateVectorTest(AbstractVectorTest):
 
 def test_weaviate_vector(setup_mock_redis):
     WeaviateVectorTest().run_all_tests()
+
+
+def test_weaviate_delete_by_metadata_field_refreshes_same_doc_id(setup_mock_redis):
+    vector_test = WeaviateVectorTest()
+    doc_id = str(uuid.uuid4())
+    old_document = Document(
+        page_content="stale child chunk content",
+        metadata={
+            "doc_id": doc_id,
+            "doc_hash": "old-hash",
+            "document_id": "document-1",
+            "dataset_id": vector_test.dataset_id,
+        },
+    )
+    updated_document = Document(
+        page_content="fresh child chunk content",
+        metadata={
+            "doc_id": doc_id,
+            "doc_hash": "new-hash",
+            "document_id": "document-1",
+            "dataset_id": vector_test.dataset_id,
+        },
+    )
+
+    try:
+        vector_test.vector.create(texts=[old_document], embeddings=[vector_test.example_embedding])
+        assert vector_test.vector.text_exists(doc_id)
+
+        vector_test.vector.delete_by_metadata_field("doc_id", doc_id)
+        assert not vector_test.vector.text_exists(doc_id)
+
+        vector_test.vector.add_texts(documents=[updated_document], embeddings=[vector_test.example_embedding])
+        hits = vector_test.vector.search_by_full_text(query="fresh child chunk content")
+
+        matching_hits = [hit for hit in hits if hit.metadata["doc_id"] == doc_id]
+        assert matching_hits
+        assert matching_hits[0].page_content == "fresh child chunk content"
+        assert matching_hits[0].metadata["doc_hash"] == "new-hash"
+    finally:
+        vector_test.delete_vector()
+
+
+def test_weaviate_child_chunk_refresh_preserves_other_doc_with_same_content(setup_mock_redis):
+    vector_test = WeaviateVectorTest()
+    target_doc_id = str(uuid.uuid4())
+    other_doc_id = str(uuid.uuid4())
+    shared_content = "shared updated child chunk content"
+    old_document = Document(
+        page_content="stale child chunk content before refresh",
+        metadata={
+            "doc_id": target_doc_id,
+            "doc_hash": "old-target-hash",
+            "document_id": "document-1",
+            "dataset_id": vector_test.dataset_id,
+        },
+    )
+    other_document = Document(
+        page_content=shared_content,
+        metadata={
+            "doc_id": other_doc_id,
+            "doc_hash": "other-hash",
+            "document_id": "document-2",
+            "dataset_id": vector_test.dataset_id,
+        },
+    )
+    updated_document = Document(
+        page_content=shared_content,
+        metadata={
+            "doc_id": target_doc_id,
+            "doc_hash": "new-target-hash",
+            "document_id": "document-1",
+            "dataset_id": vector_test.dataset_id,
+        },
+    )
+
+    try:
+        vector_test.vector.create(
+            texts=[old_document, other_document],
+            embeddings=[vector_test.example_embedding, vector_test.example_embedding],
+        )
+        assert vector_test.vector.text_exists(target_doc_id)
+        assert vector_test.vector.text_exists(other_doc_id)
+
+        vector_test.vector.delete_by_metadata_field("doc_id", target_doc_id)
+        assert not vector_test.vector.text_exists(target_doc_id)
+        assert vector_test.vector.text_exists(other_doc_id)
+
+        vector_test.vector.add_texts(documents=[updated_document], embeddings=[vector_test.example_embedding])
+
+        assert vector_test.vector.text_exists(target_doc_id)
+        assert vector_test.vector.text_exists(other_doc_id)
+        hits_by_doc_id = {
+            hit.metadata["doc_id"]: hit for hit in vector_test.vector.search_by_full_text(query=shared_content)
+        }
+        assert hits_by_doc_id[target_doc_id].metadata["doc_hash"] == "new-target-hash"
+        assert hits_by_doc_id[other_doc_id].metadata["doc_hash"] == "other-hash"
+    finally:
+        vector_test.delete_vector()

--- a/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
@@ -12,6 +12,7 @@ Focuses on verifying that doc_type is properly handled in:
 import datetime
 import json
 import unittest
+import uuid
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -750,6 +751,17 @@ class TestWeaviateVector(unittest.TestCase):
         assert call_kwargs.kwargs["uuid"] == "fallback-uuid"
         assert call_kwargs.kwargs["vector"] is None
         assert call_kwargs.kwargs["properties"]["created_at"] == created_at.isoformat()
+
+    def test_get_uuids_prefers_valid_doc_id_metadata(self):
+        first_doc_id = str(uuid.uuid4())
+        second_doc_id = str(uuid.uuid4())
+        wv = WeaviateVector.__new__(WeaviateVector)
+        documents = [
+            Document(page_content="same child content", metadata={"doc_id": first_doc_id}),
+            Document(page_content="same child content", metadata={"doc_id": second_doc_id}),
+        ]
+
+        assert wv._get_uuids(documents) == [first_doc_id, second_doc_id]
 
     def test_is_uuid_handles_invalid_values(self):
         wv = WeaviateVector.__new__(WeaviateVector)

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -3843,6 +3843,7 @@ class SegmentService:
                 if child_chunk:
                     if child_chunk.content != child_chunk_update_args.content:
                         child_chunk.content = child_chunk_update_args.content
+                        child_chunk.index_node_hash = helper.generate_text_hash(child_chunk.content)
                         child_chunk.word_count = len(child_chunk.content)
                         child_chunk.updated_by = current_user.id
                         child_chunk.updated_at = naive_utc_now()
@@ -3902,6 +3903,8 @@ class SegmentService:
         assert current_user is not None
 
         try:
+            if child_chunk.content != content:
+                child_chunk.index_node_hash = helper.generate_text_hash(content)
             child_chunk.content = content
             child_chunk.word_count = len(content)
             child_chunk.updated_by = current_user.id

--- a/api/services/vector_service.py
+++ b/api/services/vector_service.py
@@ -211,7 +211,8 @@ class VectorService:
         delete_child_chunks: list[ChildChunk],
         dataset: Dataset,
     ):
-        documents = []
+        new_documents = []
+        updated_documents = []
         delete_node_ids = []
         for new_child_chunk in new_child_chunks:
             new_child_document = Document(
@@ -223,7 +224,7 @@ class VectorService:
                     "dataset_id": new_child_chunk.dataset_id,
                 },
             )
-            documents.append(new_child_document)
+            new_documents.append(new_child_document)
         for update_child_chunk in update_child_chunks:
             assert update_child_chunk.index_node_id
             child_document = Document(
@@ -235,7 +236,7 @@ class VectorService:
                     "dataset_id": update_child_chunk.dataset_id,
                 },
             )
-            documents.append(child_document)
+            updated_documents.append(child_document)
             delete_node_ids.append(update_child_chunk.index_node_id)
         for delete_child_chunk in delete_child_chunks:
             assert delete_child_chunk.index_node_id
@@ -243,16 +244,19 @@ class VectorService:
         if dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY:
             # update vector index
             vector = Vector(dataset=dataset)
-            if delete_node_ids:
-                vector.delete_by_ids(delete_node_ids)
-            if documents:
-                vector.add_texts(documents, duplicate_check=True)
+            for node_id in delete_node_ids:
+                vector.delete_by_metadata_field("doc_id", node_id)
+            if new_documents:
+                vector.add_texts(new_documents, duplicate_check=True)
+            if updated_documents:
+                # Force delete-then-insert refreshes even if a stale vector still exists.
+                vector.add_texts(updated_documents, duplicate_check=False)
 
     @classmethod
     def delete_child_chunk_vector(cls, child_chunk: ChildChunk, dataset: Dataset):
         vector = Vector(dataset=dataset)
         assert child_chunk.index_node_id
-        vector.delete_by_ids([child_chunk.index_node_id])
+        vector.delete_by_metadata_field("doc_id", child_chunk.index_node_id)
 
     @classmethod
     def update_multimodel_vector(cls, segment: DocumentSegment, attachment_ids: list[str], dataset: Dataset):

--- a/api/tests/unit_tests/services/test_dataset_service_segment.py
+++ b/api/tests/unit_tests/services/test_dataset_service_segment.py
@@ -110,10 +110,11 @@ class TestSegmentServiceChildChunks:
         )
         existing_a.id = "child-a"
         existing_b.id = "child-b"
+        existing_a.index_node_hash = "old-hash"
         with (
             patch("services.dataset_service.db") as mock_db,
             patch("services.dataset_service.uuid.uuid4", return_value="node-new"),
-            patch("services.dataset_service.helper.generate_text_hash", return_value="hash-new"),
+            patch("services.dataset_service.helper.generate_text_hash", return_value="hash-new") as generate_text_hash,
             patch("services.dataset_service.naive_utc_now", return_value="now"),
             patch("services.dataset_service.VectorService") as vector_service,
         ):
@@ -131,6 +132,8 @@ class TestSegmentServiceChildChunks:
 
         assert [chunk.position for chunk in result] == [1, 3]
         assert existing_a.content == "updated content"
+        assert existing_a.index_node_hash == "hash-new"
+        generate_text_hash.assert_any_call("updated content")
         assert existing_a.updated_by == account_context.id
         assert existing_a.updated_at == "now"
         mock_db.session.bulk_save_objects.assert_called_once_with([existing_a])
@@ -176,6 +179,7 @@ class TestSegmentServiceChildChunks:
             patch("services.dataset_service.current_user", SimpleNamespace(id="user-1")),
             patch("services.dataset_service.db") as mock_db,
             patch("services.dataset_service.naive_utc_now", return_value="now"),
+            patch("services.dataset_service.helper.generate_text_hash", return_value="new-hash") as generate_text_hash,
             patch("services.dataset_service.VectorService") as vector_service,
         ):
             result = SegmentService.update_child_chunk(
@@ -184,6 +188,8 @@ class TestSegmentServiceChildChunks:
 
         assert result is child_chunk
         assert child_chunk.content == "new content"
+        assert child_chunk.index_node_hash == "new-hash"
+        generate_text_hash.assert_called_once_with("new content")
         assert child_chunk.word_count == len("new content")
         assert child_chunk.updated_by == "user-1"
         assert child_chunk.updated_at == "now"

--- a/api/tests/unit_tests/services/test_vector_service.py
+++ b/api/tests/unit_tests/services/test_vector_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
@@ -473,6 +473,7 @@ def test_create_child_chunk_vector_high_quality_adds_texts(monkeypatch: pytest.M
 
     VectorService.create_child_chunk_vector(child_chunk, dataset)
     vector_instance.add_texts.assert_called_once()
+    assert vector_instance.add_texts.call_args.kwargs["duplicate_check"] is True
 
 
 def test_create_child_chunk_vector_economy_noop(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -516,10 +517,25 @@ def test_update_child_chunk_vector_high_quality_updates_vector(monkeypatch: pyte
 
     VectorService.update_child_chunk_vector([new_chunk], [upd_chunk], [del_chunk], dataset)
 
-    vector_instance.delete_by_ids.assert_called_once_with(["uid", "did"])
-    vector_instance.add_texts.assert_called_once()
-    docs = vector_instance.add_texts.call_args.args[0]
-    assert len(docs) == 2
+    vector_instance.delete_by_ids.assert_not_called()
+    assert vector_instance.delete_by_metadata_field.call_args_list == [
+        call("doc_id", "uid"),
+        call("doc_id", "did"),
+    ]
+    assert vector_instance.add_texts.call_count == 2
+
+    new_docs_call, updated_docs_call = vector_instance.add_texts.call_args_list
+    new_docs = new_docs_call.args[0]
+    assert new_docs_call.kwargs == {"duplicate_check": True}
+    assert len(new_docs) == 1
+    assert new_docs[0].page_content == "n"
+    assert new_docs[0].metadata["doc_id"] == "nid"
+
+    updated_docs = updated_docs_call.args[0]
+    assert updated_docs_call.kwargs == {"duplicate_check": False}
+    assert len(updated_docs) == 1
+    assert updated_docs[0].page_content == "u"
+    assert updated_docs[0].metadata["doc_id"] == "uid"
 
 
 def test_update_child_chunk_vector_economy_noop(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -530,7 +546,7 @@ def test_update_child_chunk_vector_economy_noop(monkeypatch: pytest.MonkeyPatch)
     vector_cls.assert_not_called()
 
 
-def test_delete_child_chunk_vector_deletes_by_id(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_delete_child_chunk_vector_deletes_by_doc_id_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
     dataset = _make_dataset()
     child_chunk = MagicMock()
     child_chunk.index_node_id = "cid"
@@ -539,7 +555,8 @@ def test_delete_child_chunk_vector_deletes_by_id(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(vector_service_module, "Vector", MagicMock(return_value=vector_instance))
 
     VectorService.delete_child_chunk_vector(child_chunk, dataset)
-    vector_instance.delete_by_ids.assert_called_once_with(["cid"])
+    vector_instance.delete_by_ids.assert_not_called()
+    vector_instance.delete_by_metadata_field.assert_called_once_with("doc_id", "cid")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Recompute child chunk `index_node_hash` when child chunk content changes.
- Refresh updated/deleted child chunk vectors by deleting by `doc_id` metadata instead of backend object id.
- Reinsert updated child chunk vectors with `duplicate_check=False` and add unit plus Weaviate coverage for metadata-delete refresh behavior.

Fixes #37063

## Test Plan
- `python -m uv run --project api --no-sync python -m pytest -o addopts='' --confcutdir=api/tests/unit_tests/services api/tests/unit_tests/services/test_vector_service.py::test_update_child_chunk_vector_high_quality_updates_vector api/tests/unit_tests/services/test_vector_service.py::test_delete_child_chunk_vector_deletes_by_doc_id_metadata -q` — 2 passed
- `python -m uv run --project api --no-sync python -m pytest -o addopts='' --confcutdir=api/tests/unit_tests/services api/tests/unit_tests/services/test_dataset_service_segment.py::TestSegmentServiceChildChunks::test_update_child_chunks_updates_deletes_and_creates_records api/tests/unit_tests/services/test_dataset_service_segment.py::TestSegmentServiceChildChunks::test_update_child_chunk_updates_vector_and_commits -q` — 2 passed
- `python -m uv run --project api --no-sync python -m pytest -o addopts='' --confcutdir=api/providers/vdb/vdb-weaviate/tests api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py::TestWeaviateVector::test_delete_by_metadata_field_returns_when_collection_is_missing api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py::TestWeaviateVector::test_delete_by_metadata_field_deletes_matching_objects -q` — 2 passed
- `api\.venv\Scripts\ruff.exe check api/services/vector_service.py api/services/dataset_service.py api/tests/unit_tests/services/test_vector_service.py api/tests/unit_tests/services/test_dataset_service_segment.py api/providers/vdb/vdb-weaviate/tests/integration_tests/test_weaviate.py` — passed
- `git diff --check origin/main..HEAD` — passed

Note: I added Weaviate integration coverage, but could not run the Docker-backed `--start-vdb` suite locally because this Windows environment does not have the `docker` command available.