### PR TITLE
chore: bump restx. now deco has type

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -60,7 +60,7 @@ exclude = ["providers/vdb/__pycache__", "providers/trace/__pycache__"]
 
 [tool.uv.sources]
 dify-agent = { path = "../dify-agent", editable = true }
-flask-restx = { git = "https://github.com/asukaminato0721/flask-restx", rev = "27758e26f8f740d7525d5039c51a9e524b6e2b68" }
+flask-restx = { git = "https://github.com/asukaminato0721/flask-restx", rev = "e44a2861b854" }
 dify-vdb-alibabacloud-mysql = { workspace = true }
 dify-vdb-analyticdb = { workspace = true }
 dify-vdb-baidu = { workspace = true }

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1630,7 +1630,7 @@ requires-dist = [
     { name = "flask-login", specifier = "==0.6.3" },
     { name = "flask-migrate", specifier = ">=4.1.0,<5.0.0" },
     { name = "flask-orjson", specifier = ">=2.0.0,<3.0.0" },
-    { name = "flask-restx", git = "https://github.com/asukaminato0721/flask-restx?rev=27758e26f8f740d7525d5039c51a9e524b6e2b68" },
+    { name = "flask-restx", git = "https://github.com/asukaminato0721/flask-restx?rev=e44a2861b854" },
     { name = "gevent", specifier = ">=26.4.0,<26.5.0" },
     { name = "gevent-websocket", specifier = "==0.10.1" },
     { name = "gmpy2", specifier = ">=2.3.0,<3.0.0" },
@@ -2571,7 +2571,7 @@ wheels = [
 [[package]]
 name = "flask-restx"
 version = "1.3.3.dev0"
-source = { git = "https://github.com/asukaminato0721/flask-restx?rev=27758e26f8f740d7525d5039c51a9e524b6e2b68#27758e26f8f740d7525d5039c51a9e524b6e2b68" }
+source = { git = "https://github.com/asukaminato0721/flask-restx?rev=e44a2861b854#e44a2861b854e672625c196f79debb257d3c846d" }
 dependencies = [
     { name = "aniso8601" },
     { name = "flask" },


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

for #35871 

add type signature in the original lib so we can get type even in test.

<img width="1250" height="361" alt="image" src="https://github.com/user-attachments/assets/d16ab3cb-53fd-4b68-9471-fc95d74fb891" />

the auto inferred return type.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
