### PR TITLE
Refactor: replace type ignores with typing.cast in factory patterns

### DIFF
--- a/api/core/external_data_tool/factory.py
+++ b/api/core/external_data_tool/factory.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping
 from typing import Any, cast
 
 from core.extension.extensible import ExtensionModule
+from core.external_data_tool.base import ExternalDataTool
 from extensions.ext_code_based_extension import code_based_extension
 
 
@@ -24,7 +25,7 @@ class ExternalDataToolFactory:
         """
         extension_class = code_based_extension.extension_class(ExtensionModule.EXTERNAL_DATA_TOOL, name)
         # FIXME mypy issue here, figure out how to fix it
-        extension_class.validate_config(tenant_id, config)  # type: ignore
+        cast(type[ExternalDataTool], extension_class).validate_config(tenant_id, config)
 
     def query(self, inputs: Mapping[str, Any], query: str | None = None) -> str:
         """

--- a/api/core/moderation/factory.py
+++ b/api/core/moderation/factory.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 
 from core.extension.extensible import ExtensionModule
 from core.moderation.base import Moderation, ModerationInputsResult, ModerationOutputsResult
@@ -24,7 +24,7 @@ class ModerationFactory:
         """
         extension_class = code_based_extension.extension_class(ExtensionModule.MODERATION, name)
         # FIXME: mypy error, try to fix it instead of using type: ignore
-        extension_class.validate_config(tenant_id, config)  # type: ignore
+        cast(type[Moderation], extension_class).validate_config(tenant_id, config)
 
     def moderation_for_inputs(self, inputs: dict[str, Any], query: str = "") -> ModerationInputsResult:
         """


### PR DESCRIPTION
Replaced `# type: ignore` with `typing.cast()` for dynamic imports in `api/core/external_data_tool/factory.py` and `api/core/moderation/factory.py` to improve static analysis capabilities.