### PR TITLE
fix: Default MCP OAuth grant to authorization code

### DIFF
--- a/api/core/mcp/auth/auth_flow.py
+++ b/api/core/mcp/auth/auth_flow.py
@@ -199,6 +199,18 @@ def get_effective_scope(
     return client_scope
 
 
+def _select_effective_grant_type(server_metadata: OAuthMetadata) -> str:
+    supported_grant_types = server_metadata.grant_types_supported
+    if supported_grant_types is None:
+        # OAuth authorization-server metadata defaults omitted grant types to authorization-code based flows.
+        return MCPSupportGrantType.AUTHORIZATION_CODE.value
+
+    supported_grant_types_lower = [grant_type.lower() for grant_type in supported_grant_types]
+    if MCPSupportGrantType.AUTHORIZATION_CODE.value in supported_grant_types_lower:
+        return MCPSupportGrantType.AUTHORIZATION_CODE.value
+    return MCPSupportGrantType.CLIENT_CREDENTIALS.value
+
+
 def _create_secure_redis_state(state_data: OAuthCallbackState) -> str:
     """Create a secure state parameter by storing state data in Redis and returning a random state key."""
     # Generate a secure random state key
@@ -577,17 +589,7 @@ def auth(
     if not server_metadata:
         raise ValueError("Failed to discover OAuth metadata from server")
 
-    supported_grant_types = server_metadata.grant_types_supported or []
-
-    # Convert to lowercase for comparison
-    supported_grant_types_lower = [gt.lower() for gt in supported_grant_types]
-
-    # Determine which grant type to use
-    effective_grant_type = None
-    if MCPSupportGrantType.AUTHORIZATION_CODE.value in supported_grant_types_lower:
-        effective_grant_type = MCPSupportGrantType.AUTHORIZATION_CODE.value
-    else:
-        effective_grant_type = MCPSupportGrantType.CLIENT_CREDENTIALS.value
+    effective_grant_type = _select_effective_grant_type(server_metadata)
 
     # Determine effective scope using priority-based strategy
     effective_scope = get_effective_scope(scope_from_www_auth, prm, server_metadata, credentials.get("scope"))

--- a/api/core/mcp/auth/auth_flow.py
+++ b/api/core/mcp/auth/auth_flow.py
@@ -199,6 +199,21 @@ def get_effective_scope(
     return client_scope
 
 
+def _select_effective_grant_type(server_metadata: OAuthMetadata) -> str:
+    """Select a supported OAuth flow, applying RFC 8414 defaults only when metadata omits the field."""
+    supported_grant_types = server_metadata.grant_types_supported
+    if supported_grant_types is None:
+        if "grant_types_supported" not in server_metadata.model_fields_set:
+            return MCPSupportGrantType.AUTHORIZATION_CODE.value
+        raise ValueError("Incompatible auth server: does not advertise a supported grant type")
+
+    if MCPSupportGrantType.AUTHORIZATION_CODE.value in supported_grant_types:
+        return MCPSupportGrantType.AUTHORIZATION_CODE.value
+    if MCPSupportGrantType.CLIENT_CREDENTIALS.value in supported_grant_types:
+        return MCPSupportGrantType.CLIENT_CREDENTIALS.value
+    raise ValueError("Incompatible auth server: does not advertise a supported grant type")
+
+
 def _create_secure_redis_state(state_data: OAuthCallbackState) -> str:
     """Create a secure state parameter by storing state data in Redis and returning a random state key."""
     # Generate a secure random state key
@@ -577,17 +592,7 @@ def auth(
     if not server_metadata:
         raise ValueError("Failed to discover OAuth metadata from server")
 
-    supported_grant_types = server_metadata.grant_types_supported or []
-
-    # Convert to lowercase for comparison
-    supported_grant_types_lower = [gt.lower() for gt in supported_grant_types]
-
-    # Determine which grant type to use
-    effective_grant_type = None
-    if MCPSupportGrantType.AUTHORIZATION_CODE.value in supported_grant_types_lower:
-        effective_grant_type = MCPSupportGrantType.AUTHORIZATION_CODE.value
-    else:
-        effective_grant_type = MCPSupportGrantType.CLIENT_CREDENTIALS.value
+    effective_grant_type = _select_effective_grant_type(server_metadata)
 
     # Determine effective scope using priority-based strategy
     effective_scope = get_effective_scope(scope_from_www_auth, prm, server_metadata, credentials.get("scope"))

--- a/api/tests/unit_tests/core/mcp/auth/test_auth_flow.py
+++ b/api/tests/unit_tests/core/mcp/auth/test_auth_flow.py
@@ -1318,6 +1318,39 @@ class TestAuthOrchestration:
                 auth(provider)
 
     @patch("core.mcp.auth.auth_flow.discover_oauth_metadata")
+    def test_auth_defaults_to_authorization_code_when_metadata_omits_grant_types(self, mock_discover):
+        provider = Mock(spec=MCPProviderEntity)
+        provider.decrypt_server_url.return_value = "https://api"
+        provider.id = "p1"
+        provider.tenant_id = "t1"
+        provider.redirect_url = "https://console/api/mcp/oauth/callback"
+        provider.retrieve_client_information.return_value = OAuthClientInformation(client_id="c1")
+        provider.retrieve_tokens.return_value = None
+        provider.decrypt_credentials.return_value = {"scope": "read"}
+
+        asm = OAuthMetadata(
+            authorization_endpoint="https://auth/auth",
+            token_endpoint="https://auth/token",
+            response_types_supported=["code"],
+            grant_types_supported=None,
+        )
+        mock_discover.return_value = (asm, None, None)
+
+        with (
+            patch("core.mcp.auth.auth_flow._create_secure_redis_state", return_value="state-key"),
+            patch("core.mcp.auth.auth_flow.generate_pkce_challenge", return_value=("verifier", "challenge")),
+            patch("core.mcp.auth.auth_flow.client_credentials_flow") as mock_client_credentials,
+        ):
+            result = auth(provider)
+
+        authorization_url = result.response["authorization_url"]
+        assert authorization_url.startswith("https://auth/auth?")
+        assert "client_id=c1" in authorization_url
+        assert "state=state-key" in authorization_url
+        assert result.actions[0].action_type == AuthActionType.SAVE_CODE_VERIFIER
+        mock_client_credentials.assert_not_called()
+
+    @patch("core.mcp.auth.auth_flow.discover_oauth_metadata")
     def test_auth_orchestration_authorization_code(self, mock_discover):
         provider = Mock(spec=MCPProviderEntity)
         provider.decrypt_server_url.return_value = "https://api"

--- a/api/tests/unit_tests/core/mcp/auth/test_auth_flow.py
+++ b/api/tests/unit_tests/core/mcp/auth/test_auth_flow.py
@@ -16,6 +16,7 @@ from core.mcp.auth.auth_flow import (
     _create_secure_redis_state,
     _parse_token_response,
     _retrieve_redis_state,
+    _select_effective_grant_type,
     auth,
     build_oauth_authorization_server_metadata_discovery_urls,
     build_protected_resource_metadata_discovery_urls,
@@ -596,11 +597,12 @@ class TestAuthOrchestration:
         """Test auth flow for new client registration."""
         # Setup
         mock_discover.return_value = (
-            OAuthMetadata(
-                authorization_endpoint="https://auth.example.com/authorize",
-                token_endpoint="https://auth.example.com/token",
-                response_types_supported=["code"],
-                grant_types_supported=["authorization_code"],
+            OAuthMetadata.model_validate(
+                {
+                    "authorization_endpoint": "https://auth.example.com/authorize",
+                    "token_endpoint": "https://auth.example.com/token",
+                    "response_types_supported": ["code"],
+                }
             ),
             None,
             None,
@@ -930,6 +932,51 @@ class TestAuthOrchestration:
         assert get_effective_scope(None, None, asm, "client") == "openid profile"
         # 4. Client configured
         assert get_effective_scope(None, None, None, "client") == "client"
+
+    def test_select_effective_grant_type_defaults_omitted_metadata_to_authorization_code(self) -> None:
+        metadata = OAuthMetadata.model_validate(
+            {
+                "authorization_endpoint": "https://auth.example.com/auth",
+                "token_endpoint": "https://auth.example.com/token",
+                "response_types_supported": ["code"],
+            }
+        )
+
+        assert _select_effective_grant_type(metadata) == "authorization_code"
+
+    @pytest.mark.parametrize(
+        ("grant_types_supported", "expected"),
+        [
+            (["authorization_code"], "authorization_code"),
+            (["client_credentials"], "client_credentials"),
+            (["client_credentials", "authorization_code"], "authorization_code"),
+        ],
+    )
+    def test_select_effective_grant_type_uses_explicit_supported_flow(
+        self, grant_types_supported: list[str], expected: str
+    ) -> None:
+        metadata = OAuthMetadata(
+            authorization_endpoint="https://auth.example.com/auth",
+            token_endpoint="https://auth.example.com/token",
+            response_types_supported=["code"],
+            grant_types_supported=grant_types_supported,
+        )
+
+        assert _select_effective_grant_type(metadata) == expected
+
+    @pytest.mark.parametrize("grant_types_supported", [list[str](), ["implicit"], ["Authorization_Code"], None])
+    def test_select_effective_grant_type_rejects_invalid_or_unsupported_explicit_metadata(
+        self, grant_types_supported: list[str] | None
+    ) -> None:
+        metadata = OAuthMetadata(
+            authorization_endpoint="https://auth.example.com/auth",
+            token_endpoint="https://auth.example.com/token",
+            response_types_supported=["code"],
+            grant_types_supported=grant_types_supported,
+        )
+
+        with pytest.raises(ValueError, match="does not advertise a supported grant type"):
+            _select_effective_grant_type(metadata)
 
     @patch("core.mcp.auth.auth_flow.redis_client")
     def test_redis_state_management(self, mock_redis):
@@ -1316,6 +1363,40 @@ class TestAuthOrchestration:
             mock_cc.side_effect = ValueError("CC Failed")
             with pytest.raises(ValueError, match="Client credentials flow failed"):
                 auth(provider)
+
+    @patch("core.mcp.auth.auth_flow.discover_oauth_metadata")
+    def test_auth_defaults_to_authorization_code_when_metadata_omits_grant_types(self, mock_discover: Mock) -> None:
+        provider = Mock(spec=MCPProviderEntity)
+        provider.decrypt_server_url.return_value = "https://api"
+        provider.id = "p1"
+        provider.tenant_id = "t1"
+        provider.redirect_url = "https://console/api/mcp/oauth/callback"
+        provider.retrieve_client_information.return_value = OAuthClientInformation(client_id="c1")
+        provider.retrieve_tokens.return_value = None
+        provider.decrypt_credentials.return_value = {"scope": "read"}
+
+        asm = OAuthMetadata.model_validate(
+            {
+                "authorization_endpoint": "https://auth/auth",
+                "token_endpoint": "https://auth/token",
+                "response_types_supported": ["code"],
+            }
+        )
+        mock_discover.return_value = (asm, None, None)
+
+        with (
+            patch("core.mcp.auth.auth_flow._create_secure_redis_state", return_value="state-key"),
+            patch("core.mcp.auth.auth_flow.generate_pkce_challenge", return_value=("verifier", "challenge")),
+            patch("core.mcp.auth.auth_flow.client_credentials_flow") as mock_client_credentials,
+        ):
+            result = auth(provider)
+
+        authorization_url = result.response["authorization_url"]
+        assert authorization_url.startswith("https://auth/auth?")
+        assert "client_id=c1" in authorization_url
+        assert "state=state-key" in authorization_url
+        assert result.actions[0].action_type == AuthActionType.SAVE_CODE_VERIFIER
+        mock_client_credentials.assert_not_called()
 
     @patch("core.mcp.auth.auth_flow.discover_oauth_metadata")
     def test_auth_orchestration_authorization_code(self, mock_discover):


### PR DESCRIPTION
## Summary

- default omitted MCP OAuth `grant_types_supported` metadata to authorization-code flow
- keep explicit `client_credentials` metadata on the existing client credentials path
- add regression coverage so omitted grant metadata returns an authorization URL instead of invoking client credentials

Fixes #37374

## Tests

- `api\.venv\Scripts\python.exe -m pytest -o addopts='' api\tests\unit_tests\core\mcp\auth\test_auth_flow.py -q`
- `api\.venv\Scripts\python.exe -m pytest -o addopts='' api\tests\unit_tests\core\entities\test_entities_mcp_provider.py -q`
- `api\.venv\Scripts\python.exe -m pytest -o addopts='' api\tests\unit_tests\core\mcp\test_mcp_client.py -q`
- `api\.venv\Scripts\python.exe -m pytest -o addopts='' api\tests\unit_tests\controllers\console\workspace\test_tool_providers.py -q`
- `api\.venv\Scripts\python.exe -m ruff check api\core\mcp\auth\auth_flow.py api\tests\unit_tests\core\mcp\auth\test_auth_flow.py`
- `git diff --check origin/main...HEAD`