### PR TITLE
refactor: use short-lived db sessions during app generation

### DIFF
--- a/api/core/app/apps/message_based_app_generator.py
+++ b/api/core/app/apps/message_based_app_generator.py
@@ -80,6 +80,8 @@ class MessageBasedAppGenerator(BaseAppGenerator):
             stream=stream,
         )
 
+        db.session.remove()
+
         try:
             return generate_task_pipeline.process()
         except ValueError as e:

--- a/api/core/app/task_pipeline/message_cycle_manager.py
+++ b/api/core/app/task_pipeline/message_cycle_manager.py
@@ -137,9 +137,7 @@ class MessageCycleManager:
                     name = cached_name.decode("utf-8")
                 else:
                     try:
-                        name = LLMGenerator.generate_conversation_name(
-                            tenant_id, query, conversation_id, app_id
-                        )
+                        name = LLMGenerator.generate_conversation_name(tenant_id, query, conversation_id, app_id)
                         redis_client.setex(cache_key, 3600, name)
                     except Exception:
                         if dify_config.DEBUG:

--- a/api/core/app/task_pipeline/message_cycle_manager.py
+++ b/api/core/app/task_pipeline/message_cycle_manager.py
@@ -4,7 +4,7 @@ from threading import Thread, Timer
 from typing import Union
 
 from flask import Flask, current_app
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
 from configs import dify_config
@@ -34,9 +34,9 @@ from core.llm_generator.llm_generator import LLMGenerator
 from core.tools.signature import sign_tool_file
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
+from models.account import Account
 from models.enums import MessageFileBelongsTo
-from models.model import AppMode, Conversation, MessageAnnotation, MessageFile
-from services.annotation_service import AppAnnotationService
+from models.model import App, AppMode, Conversation, MessageAnnotation, MessageFile
 
 logger = logging.getLogger(__name__)
 
@@ -115,18 +115,19 @@ class MessageCycleManager:
 
     def _generate_conversation_name_worker(self, flask_app: Flask, conversation_id: str, query: str):
         with flask_app.app_context():
-            # get conversation and message
-            stmt = select(Conversation).where(Conversation.id == conversation_id)
-            conversation = db.session.scalar(stmt)
+            with session_factory.create_session() as session:
+                conversation_info = session.execute(
+                    select(Conversation.mode, Conversation.app_id, App.tenant_id)
+                    .join(App, App.id == Conversation.app_id)
+                    .where(Conversation.id == conversation_id)
+                ).one_or_none()
 
-            if not conversation:
+            if not conversation_info:
                 return
 
-            if conversation.mode != AppMode.COMPLETION:
-                app_model = conversation.app
-                if not app_model:
-                    return
+            conversation_mode, app_id, tenant_id = conversation_info
 
+            if conversation_mode != AppMode.COMPLETION:
                 # generate conversation name
                 query_hash = hashlib.md5(query.encode()).hexdigest()[:16]
                 cache_key = f"conv_name:{conversation_id}:{query_hash}"
@@ -137,16 +138,20 @@ class MessageCycleManager:
                 else:
                     try:
                         name = LLMGenerator.generate_conversation_name(
-                            app_model.tenant_id, query, conversation_id, conversation.app_id
+                            tenant_id, query, conversation_id, app_id
                         )
                         redis_client.setex(cache_key, 3600, name)
                     except Exception:
                         if dify_config.DEBUG:
                             logger.exception("generate conversation name failed, conversation_id: %s", conversation_id)
                         name = query[:47] + "..." if len(query) > 50 else query
-                conversation.name = name
-                db.session.commit()
-                db.session.close()
+
+                with session_factory.create_session() as session, session.begin():
+                    session.execute(
+                        update(Conversation)
+                        .where(Conversation.id == conversation_id, Conversation.app_id == app_id)
+                        .values(name=name)
+                    )
 
     def handle_annotation_reply(self, event: QueueAnnotationReplyEvent) -> MessageAnnotation | None:
         """
@@ -154,14 +159,20 @@ class MessageCycleManager:
         :param event: event
         :return:
         """
-        annotation = AppAnnotationService.get_annotation_by_id(event.message_annotation_id)
-        if annotation:
-            account = annotation.account
+        with session_factory.create_session() as session:
+            row = session.execute(
+                select(MessageAnnotation, Account.name)
+                .outerjoin(Account, Account.id == MessageAnnotation.account_id)
+                .where(MessageAnnotation.id == event.message_annotation_id)
+            ).one_or_none()
+
+        if row:
+            annotation, account_name = row
             self._task_state.metadata.annotation_reply = AnnotationReply(
                 id=annotation.id,
                 account=AnnotationReplyAccount(
                     id=annotation.account_id,
-                    name=account.name if account else "Dify user",
+                    name=account_name or "Dify user",
                 ),
             )
 

--- a/api/tests/unit_tests/core/app/apps/test_message_based_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/test_message_based_app_generator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -13,10 +14,12 @@ from core.app.app_config.entities import (
     PromptTemplateEntity,
 )
 from core.app.apps import message_based_app_generator
+from core.app.apps.base_app_queue_manager import AppQueueManager
 from core.app.apps.exc import GenerateTaskStoppedError
 from core.app.apps.message_based_app_generator import MessageBasedAppGenerator
-from core.app.entities.app_invoke_entities import ChatAppGenerateEntity, InvokeFrom
-from models.model import AppMode, Conversation, Message
+from core.app.entities.app_invoke_entities import ChatAppGenerateEntity, CompletionAppGenerateEntity, InvokeFrom
+from models.account import Account
+from models.model import App, AppMode, Conversation, Message
 from services.errors.app_model_config import AppModelConfigBrokenError
 
 
@@ -90,9 +93,9 @@ def _mock_db_session(monkeypatch: pytest.MonkeyPatch):
 
     def refresh_side_effect(obj):
         if isinstance(obj, Conversation) and obj.id is None:
-            obj.id = "generated-conversation-id"
+            object.__setattr__(obj, "id", "generated-conversation-id")
         if isinstance(obj, Message) and obj.id is None:
-            obj.id = "generated-message-id"
+            object.__setattr__(obj, "id", "generated-message-id")
 
     session.refresh.side_effect = refresh_side_effect
     session.add.return_value = None
@@ -108,7 +111,9 @@ def test_init_generate_records_skips_conversation_fields_for_non_conversation_en
 
     generator = MessageBasedAppGenerator()
 
-    conversation, message = generator._init_generate_records(entity, conversation=None)
+    conversation, message = generator._init_generate_records(
+        cast(CompletionAppGenerateEntity, entity), conversation=None
+    )
 
     assert conversation.id == "generated-conversation-id"
     assert message.id == "generated-message-id"
@@ -148,22 +153,28 @@ class TestMessageBasedAppGeneratorExtras:
         with pytest.raises(GenerateTaskStoppedError):
             generator._handle_response(
                 application_generate_entity=_make_chat_generate_entity(_make_app_config(AppMode.CHAT)),
-                queue_manager=SimpleNamespace(),
-                conversation=SimpleNamespace(id="conv"),
-                message=SimpleNamespace(id="msg"),
-                user=SimpleNamespace(),
+                queue_manager=cast(AppQueueManager, SimpleNamespace()),
+                conversation=cast(Conversation, SimpleNamespace(id="conv")),
+                message=cast(Message, SimpleNamespace(id="msg")),
+                user=cast(Account, SimpleNamespace()),
                 stream=False,
             )
 
     def test_handle_response_removes_scoped_session_before_processing(self, monkeypatch: pytest.MonkeyPatch):
         generator = MessageBasedAppGenerator()
+        remove_mock = MagicMock()
+        monkeypatch.setattr(
+            message_based_app_generator,
+            "db",
+            SimpleNamespace(session=SimpleNamespace(remove=remove_mock)),
+        )
 
         class _Pipeline:
             def __init__(self, **kwargs) -> None:
                 _ = kwargs
 
             def process(self):
-                assert message_based_app_generator.db.session.remove.called
+                assert remove_mock.called
                 return SimpleNamespace()
 
         monkeypatch.setattr(
@@ -173,32 +184,33 @@ class TestMessageBasedAppGeneratorExtras:
 
         generator._handle_response(
             application_generate_entity=_make_chat_generate_entity(_make_app_config(AppMode.CHAT)),
-            queue_manager=SimpleNamespace(),
-            conversation=SimpleNamespace(id="conv"),
-            message=SimpleNamespace(id="msg", created_at=SimpleNamespace(timestamp=lambda: 0)),
-            user=SimpleNamespace(),
+            queue_manager=cast(AppQueueManager, SimpleNamespace()),
+            conversation=cast(Conversation, SimpleNamespace(id="conv")),
+            message=cast(Message, SimpleNamespace(id="msg", created_at=SimpleNamespace(timestamp=lambda: 0))),
+            user=cast(Account, SimpleNamespace()),
             stream=False,
         )
 
-        message_based_app_generator.db.session.remove.assert_called_once()
+        remove_mock.assert_called_once()
 
     def test_get_app_model_config_requires_valid_config(self, monkeypatch: pytest.MonkeyPatch):
         generator = MessageBasedAppGenerator()
-        app_model = SimpleNamespace(id="app", app_model_config_id=None, app_model_config=None)
+        app_model = cast(App, SimpleNamespace(id="app", app_model_config_id=None, app_model_config=None))
 
         with pytest.raises(AppModelConfigBrokenError):
             generator._get_app_model_config(app_model, conversation=None)
 
-        conversation = SimpleNamespace(app_model_config_id="missing-id")
+        conversation = cast(Conversation, SimpleNamespace(app_model_config_id="missing-id"))
         monkeypatch.setattr(
             message_based_app_generator, "db", SimpleNamespace(session=SimpleNamespace(scalar=lambda _: None))
         )
 
         with pytest.raises(AppModelConfigBrokenError):
-            generator._get_app_model_config(app_model=SimpleNamespace(id="app"), conversation=conversation)
+            generator._get_app_model_config(app_model=cast(App, SimpleNamespace(id="app")), conversation=conversation)
 
     def test_get_conversation_introduction_handles_missing_inputs(self):
         app_config = _make_app_config(AppMode.CHAT)
+        assert app_config.additional_features is not None
         app_config.additional_features.opening_statement = "Hello {{name}}"
         entity = _make_chat_generate_entity(app_config)
         entity.inputs = {}

--- a/api/tests/unit_tests/core/app/apps/test_message_based_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/test_message_based_app_generator.py
@@ -155,6 +155,33 @@ class TestMessageBasedAppGeneratorExtras:
                 stream=False,
             )
 
+    def test_handle_response_removes_scoped_session_before_processing(self, monkeypatch: pytest.MonkeyPatch):
+        generator = MessageBasedAppGenerator()
+
+        class _Pipeline:
+            def __init__(self, **kwargs) -> None:
+                _ = kwargs
+
+            def process(self):
+                assert message_based_app_generator.db.session.remove.called
+                return SimpleNamespace()
+
+        monkeypatch.setattr(
+            "core.app.apps.message_based_app_generator.EasyUIBasedGenerateTaskPipeline",
+            _Pipeline,
+        )
+
+        generator._handle_response(
+            application_generate_entity=_make_chat_generate_entity(_make_app_config(AppMode.CHAT)),
+            queue_manager=SimpleNamespace(),
+            conversation=SimpleNamespace(id="conv"),
+            message=SimpleNamespace(id="msg", created_at=SimpleNamespace(timestamp=lambda: 0)),
+            user=SimpleNamespace(),
+            stream=False,
+        )
+
+        message_based_app_generator.db.session.remove.assert_called_once()
+
     def test_get_app_model_config_requires_valid_config(self, monkeypatch: pytest.MonkeyPatch):
         generator = MessageBasedAppGenerator()
         app_model = SimpleNamespace(id="app", app_model_config_id=None, app_model_config=None)

--- a/api/tests/unit_tests/core/app/task_pipeline/test_message_cycle_manager_optimization.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_message_cycle_manager_optimization.py
@@ -226,11 +226,17 @@ class TestMessageCycleManagerOptimization:
         flask_app = object()
 
         class DummyTimer:
-            def __init__(self, interval, function, args=None, kwargs=None):
+            def __init__(
+                self,
+                interval: int,
+                function: object,
+                args: list[object] | None = None,
+                kwargs: dict[str, object] | None = None,
+            ):
                 self.interval = interval
                 self.function = function
                 self.args = args or []
-                self.kwargs = kwargs
+                self.kwargs = kwargs or {}
                 self.daemon = False
                 self.started = False
 
@@ -254,7 +260,7 @@ class TestMessageCycleManagerOptimization:
         assert thread.kwargs["flask_app"] is flask_app
         assert thread.kwargs["conversation_id"] == "conv-1"
         assert thread.kwargs["query"] == "hello"
-        assert message_cycle_manager._application_generate_entity.is_new_conversation is False
+        assert vars(message_cycle_manager._application_generate_entity)["is_new_conversation"] is False
 
     def test_generate_conversation_name_skips_thread_when_auto_generate_disabled(self, message_cycle_manager):
         """Skip thread creation when auto naming is disabled but still mark conversation as not new."""
@@ -266,7 +272,7 @@ class TestMessageCycleManagerOptimization:
 
         assert result is None
         mock_timer.assert_not_called()
-        assert message_cycle_manager._application_generate_entity.is_new_conversation is False
+        assert vars(message_cycle_manager._application_generate_entity)["is_new_conversation"] is False
 
     def test_generate_conversation_name_worker_releases_db_before_llm_call(self, message_cycle_manager):
         """Keep DB sessions bounded around reads and writes, not around LLM generation."""

--- a/api/tests/unit_tests/core/app/task_pipeline/test_message_cycle_manager_optimization.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_message_cycle_manager_optimization.py
@@ -1,7 +1,7 @@
 """Unit tests for the message cycle manager optimization."""
 
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from flask import Flask, current_app
@@ -11,6 +11,13 @@ from core.app.entities.task_entities import MessageStreamResponse, StreamEvent, 
 from core.app.task_pipeline.message_cycle_manager import MessageCycleManager
 from core.rag.entities import RetrievalSourceMetadata
 from models.model import AppMode
+
+
+def _mock_session_context(session: Mock | None = None) -> tuple[MagicMock, Mock]:
+    context = MagicMock()
+    session = session or Mock()
+    context.__enter__.return_value = session
+    return context, session
 
 
 class TestMessageCycleManagerOptimization:
@@ -258,122 +265,161 @@ class TestMessageCycleManagerOptimization:
             result = message_cycle_manager.generate_conversation_name(conversation_id="conv-2", query="hello")
 
         assert result is None
-        assert message_cycle_manager._application_generate_entity.is_new_conversation is False
         mock_timer.assert_not_called()
+        assert message_cycle_manager._application_generate_entity.is_new_conversation is False
+
+    def test_generate_conversation_name_worker_releases_db_before_llm_call(self, message_cycle_manager):
+        """Keep DB sessions bounded around reads and writes, not around LLM generation."""
+        flask_app = Flask(__name__)
+        sessions = []
+
+        class _Session:
+            def __init__(self, scalar_result=None):
+                self.scalar_result = scalar_result
+                self.closed = False
+                self.executed = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self.closed = True
+
+            def begin(self):
+                return self
+
+            def execute(self, stmt):
+                self.executed.append(stmt)
+                return self
+
+            def one_or_none(self):
+                return self.scalar_result
+
+        read_session = _Session(scalar_result=(AppMode.CHAT, "app-id", "tenant-id"))
+        write_session = _Session()
+        sessions.extend([read_session, write_session])
+
+        def create_session():
+            return sessions.pop(0)
+
+        def generate_name(tenant_id, query, conversation_id, app_id):
+            assert read_session.closed is True
+            assert write_session.closed is False
+            assert tenant_id == "tenant-id"
+            assert query == "hello"
+            assert conversation_id == "conv-3"
+            assert app_id == "app-id"
+            return "Generated name"
+
+        with (
+            patch(
+                "core.app.task_pipeline.message_cycle_manager.session_factory.create_session",
+                side_effect=create_session,
+            ),
+            patch(
+                "core.app.task_pipeline.message_cycle_manager.LLMGenerator.generate_conversation_name",
+                side_effect=generate_name,
+            ) as mock_generate,
+        ):
+            message_cycle_manager._generate_conversation_name_worker(flask_app, conversation_id="conv-3", query="hello")
+
+        mock_generate.assert_called_once()
+        assert read_session.closed is True
+        assert write_session.closed is True
+        assert len(write_session.executed) == 1
 
     def test_generate_conversation_name_worker_returns_when_conversation_missing(self, message_cycle_manager):
         """Return early when the conversation cannot be found."""
         flask_app = Flask(__name__)
-        db_session = Mock()
-        db_session.scalar.return_value = None
+        read_context, read_session = _mock_session_context()
+        read_session.execute.return_value.one_or_none.return_value = None
 
-        with patch("core.app.task_pipeline.message_cycle_manager.db") as mock_db:
-            mock_db.session = db_session
+        with patch("core.app.task_pipeline.message_cycle_manager.session_factory.create_session") as create_session:
+            create_session.return_value = read_context
             message_cycle_manager._generate_conversation_name_worker(flask_app, "conv-missing", "hello")
 
-        db_session.commit.assert_not_called()
-        db_session.close.assert_not_called()
+        create_session.assert_called_once()
 
     def test_generate_conversation_name_worker_returns_when_app_missing(self, message_cycle_manager):
         """Return early when non-completion conversation has no app relation."""
         flask_app = Flask(__name__)
-        conversation = SimpleNamespace(mode=AppMode.CHAT, app=None, app_id="app-id")
-        db_session = Mock()
-        db_session.scalar.return_value = conversation
+        read_context, read_session = _mock_session_context()
+        read_session.execute.return_value.one_or_none.return_value = None
 
-        with patch("core.app.task_pipeline.message_cycle_manager.db") as mock_db:
-            mock_db.session = db_session
+        with patch("core.app.task_pipeline.message_cycle_manager.session_factory.create_session") as create_session:
+            create_session.return_value = read_context
             message_cycle_manager._generate_conversation_name_worker(flask_app, "conv-1", "hello")
 
-        db_session.commit.assert_not_called()
-        db_session.close.assert_not_called()
+        create_session.assert_called_once()
 
     def test_generate_conversation_name_worker_uses_cached_name(self, message_cycle_manager):
         """Use cached conversation name when present and avoid LLM call."""
         flask_app = Flask(__name__)
-        conversation = SimpleNamespace(
-            mode=AppMode.CHAT,
-            app=SimpleNamespace(tenant_id="tenant-1"),
-            app_id="app-id",
-            name="",
-        )
-        db_session = Mock()
-        db_session.scalar.return_value = conversation
+        read_context, read_session = _mock_session_context()
+        read_session.execute.return_value.one_or_none.return_value = (AppMode.CHAT, "app-id", "tenant-1")
+        write_context, write_session = _mock_session_context(MagicMock())
 
         with (
-            patch("core.app.task_pipeline.message_cycle_manager.db") as mock_db,
+            patch("core.app.task_pipeline.message_cycle_manager.session_factory.create_session") as create_session,
             patch("core.app.task_pipeline.message_cycle_manager.redis_client") as mock_redis,
             patch("core.app.task_pipeline.message_cycle_manager.LLMGenerator") as mock_llm_generator,
         ):
-            mock_db.session = db_session
+            create_session.side_effect = [read_context, write_context]
             mock_redis.get.return_value = b"cached-title"
 
             message_cycle_manager._generate_conversation_name_worker(flask_app, "conv-1", "hello")
 
-        assert conversation.name == "cached-title"
-        db_session.commit.assert_called_once()
-        db_session.close.assert_called_once()
+        assert create_session.call_count == 2
+        write_session.execute.assert_called_once()
         mock_llm_generator.generate_conversation_name.assert_not_called()
         mock_redis.setex.assert_not_called()
 
     def test_generate_conversation_name_worker_generates_and_caches_name(self, message_cycle_manager):
         """Generate conversation name and write it to redis cache on cache miss."""
         flask_app = Flask(__name__)
-        conversation = SimpleNamespace(
-            mode=AppMode.CHAT,
-            app=SimpleNamespace(tenant_id="tenant-1"),
-            app_id="app-id",
-            name="",
-        )
-        db_session = Mock()
-        db_session.scalar.return_value = conversation
+        read_context, read_session = _mock_session_context()
+        read_session.execute.return_value.one_or_none.return_value = (AppMode.CHAT, "app-id", "tenant-1")
+        write_context, write_session = _mock_session_context(MagicMock())
 
         with (
-            patch("core.app.task_pipeline.message_cycle_manager.db") as mock_db,
+            patch("core.app.task_pipeline.message_cycle_manager.session_factory.create_session") as create_session,
             patch("core.app.task_pipeline.message_cycle_manager.redis_client") as mock_redis,
             patch("core.app.task_pipeline.message_cycle_manager.LLMGenerator") as mock_llm_generator,
         ):
-            mock_db.session = db_session
+            create_session.side_effect = [read_context, write_context]
             mock_redis.get.return_value = None
             mock_llm_generator.generate_conversation_name.return_value = "generated-title"
 
             message_cycle_manager._generate_conversation_name_worker(flask_app, "conv-1", "hello")
 
-        assert conversation.name == "generated-title"
-        db_session.commit.assert_called_once()
-        db_session.close.assert_called_once()
+        assert create_session.call_count == 2
+        write_session.execute.assert_called_once()
         mock_redis.setex.assert_called_once()
 
     def test_generate_conversation_name_worker_falls_back_when_generation_fails(self, message_cycle_manager):
         """Fallback to truncated query when LLM generation fails."""
         flask_app = Flask(__name__)
-        conversation = SimpleNamespace(
-            mode=AppMode.CHAT,
-            app=SimpleNamespace(tenant_id="tenant-1"),
-            app_id="app-id",
-            name="",
-        )
-        db_session = Mock()
-        db_session.scalar.return_value = conversation
+        read_context, read_session = _mock_session_context()
+        read_session.execute.return_value.one_or_none.return_value = (AppMode.CHAT, "app-id", "tenant-1")
+        write_context, write_session = _mock_session_context(MagicMock())
         long_query = "q" * 60
 
         with (
-            patch("core.app.task_pipeline.message_cycle_manager.db") as mock_db,
+            patch("core.app.task_pipeline.message_cycle_manager.session_factory.create_session") as create_session,
             patch("core.app.task_pipeline.message_cycle_manager.redis_client") as mock_redis,
             patch("core.app.task_pipeline.message_cycle_manager.LLMGenerator") as mock_llm_generator,
             patch("core.app.task_pipeline.message_cycle_manager.dify_config") as mock_dify_config,
             patch("core.app.task_pipeline.message_cycle_manager.logger") as mock_logger,
         ):
-            mock_db.session = db_session
+            create_session.side_effect = [read_context, write_context]
             mock_redis.get.return_value = None
             mock_llm_generator.generate_conversation_name.side_effect = RuntimeError("generation failed")
             mock_dify_config.DEBUG = True
 
             message_cycle_manager._generate_conversation_name_worker(flask_app, "conv-1", long_query)
 
-        assert conversation.name == (long_query[:47] + "...")
-        db_session.commit.assert_called_once()
-        db_session.close.assert_called_once()
+        assert create_session.call_count == 2
+        write_session.execute.assert_called_once()
         mock_logger.exception.assert_called_once()
 
     def test_handle_annotation_reply_sets_metadata(self, message_cycle_manager):
@@ -391,9 +437,11 @@ class TestMessageCycleManagerOptimization:
             account=SimpleNamespace(name="Alice"),
         )
 
-        with patch("core.app.task_pipeline.message_cycle_manager.AppAnnotationService") as mock_service:
-            mock_service.get_annotation_by_id.return_value = annotation
+        read_context, read_session = _mock_session_context()
+        read_session.execute.return_value.one_or_none.return_value = (annotation, "Alice")
 
+        with patch("core.app.task_pipeline.message_cycle_manager.session_factory.create_session") as create_session:
+            create_session.return_value = read_context
             result = message_cycle_manager.handle_annotation_reply(
                 QueueAnnotationReplyEvent(message_annotation_id="ann-1")
             )
@@ -406,9 +454,11 @@ class TestMessageCycleManagerOptimization:
         """Return None and keep metadata unchanged when annotation is not found."""
         message_cycle_manager._task_state = SimpleNamespace(metadata=TaskStateMetadata())
 
-        with patch("core.app.task_pipeline.message_cycle_manager.AppAnnotationService") as mock_service:
-            mock_service.get_annotation_by_id.return_value = None
+        read_context, read_session = _mock_session_context()
+        read_session.execute.return_value.one_or_none.return_value = None
 
+        with patch("core.app.task_pipeline.message_cycle_manager.session_factory.create_session") as create_session:
+            create_session.return_value = read_context
             result = message_cycle_manager.handle_annotation_reply(
                 QueueAnnotationReplyEvent(message_annotation_id="missing")
             )


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #37311.

This PR reduces database connection pool pressure in long-running app generation flows by avoiding Flask scoped sessions across streaming and background work.

Changes:
- Release the request-scoped SQLAlchemy session after the easy-ui response pipeline snapshots the conversation/message fields it needs.
- Refactor conversation-name generation to use short-lived `session_factory` sessions so the LLM call runs without an open DB session.
- Refactor annotation reply metadata lookup to avoid `db.session` and lazy account loading inside the stream response loop.
- Add regression tests for scoped-session release and bounded session usage.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
