### PR TITLE
fix: render marketplace template icons with AppIcon

### DIFF
--- a/web/app/components/apps/__tests__/import-from-marketplace-template-modal.spec.tsx
+++ b/web/app/components/apps/__tests__/import-from-marketplace-template-modal.spec.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react'
+import ImportFromMarketplaceTemplateModal from '../import-from-marketplace-template-modal'
+
+const mockUseMarketplaceTemplateDetail = vi.fn()
+const mockFetchMarketplaceTemplateDSL = vi.fn()
+
+vi.mock('@/service/marketplace-templates', () => ({
+  useMarketplaceTemplateDetail: (...args: unknown[]) => mockUseMarketplaceTemplateDetail(...args),
+  fetchMarketplaceTemplateDSL: (...args: unknown[]) => mockFetchMarketplaceTemplateDSL(...args),
+}))
+
+describe('ImportFromMarketplaceTemplateModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseMarketplaceTemplateDetail.mockReturnValue({
+      data: {
+        data: {
+          id: 'human-input-writing',
+          template_name: 'Human Input: Writing Assistant',
+          overview: 'Send your creative brief, get a high-quality draft, and review before publishing.',
+          icon: 'technologist',
+          icon_background: '#D1FAE5',
+          icon_file_key: '',
+          publisher_unique_handle: 'langgenius',
+          usage_count: 261,
+          categories: ['operations'],
+        },
+      },
+      isLoading: false,
+      isError: false,
+    })
+  })
+
+  it('renders marketplace emoji icons without exposing the emoji id as text', () => {
+    render(
+      <ImportFromMarketplaceTemplateModal
+        templateId="human-input-writing"
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Human Input: Writing Assistant')).toBeInTheDocument()
+    expect(screen.queryByText('technologist')).not.toBeInTheDocument()
+  })
+})

--- a/web/app/components/apps/import-from-marketplace-template-modal.tsx
+++ b/web/app/components/apps/import-from-marketplace-template-modal.tsx
@@ -6,6 +6,7 @@ import { toast } from '@langgenius/dify-ui/toast'
 import { RiCloseLine } from '@remixicon/react'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import AppIcon from '@/app/components/base/app-icon'
 import { MARKETPLACE_API_PREFIX } from '@/config'
 import {
   fetchMarketplaceTemplateDSL,
@@ -100,22 +101,13 @@ const ImportFromMarketplaceTemplateModal = ({
           {template && (
             <div className="flex flex-col gap-4">
               <div className="flex items-center gap-3">
-                {template.icon_file_key
-                  ? (
-                      <img
-                        src={`${MARKETPLACE_API_PREFIX}/templates/${template.id}/icon`}
-                        alt={template.template_name}
-                        className="size-10 rounded-lg object-cover"
-                      />
-                    )
-                  : (
-                      <div
-                        className="flex size-10 items-center justify-center rounded-lg text-xl"
-                        style={{ background: template.icon_background || '#F3F4F6' }}
-                      >
-                        {template.icon || '📄'}
-                      </div>
-                    )}
+                <AppIcon
+                  size="large"
+                  iconType={template.icon_file_key ? 'image' : 'emoji'}
+                  icon={template.icon || 'page_facing_up'}
+                  background={template.icon_file_key ? undefined : template.icon_background}
+                  imageUrl={template.icon_file_key ? `${MARKETPLACE_API_PREFIX}/templates/${template.id}/icon` : undefined}
+                />
                 <div className="flex flex-col">
                   <div className="system-md-semibold text-text-primary">{template.template_name}</div>
                   <div className="flex items-center gap-1 system-xs-regular text-text-tertiary">


### PR DESCRIPTION
## Summary

Fixes FPRD-104

This PR fixes the Marketplace template import confirmation modal so template emoji icon identifiers, such as `technologist`, are rendered through the shared `AppIcon` component instead of being displayed as raw text.

It also adds a focused regression test for the `Human Input: Writing Assistant` template case.

From Codex

## Screenshots

| Before | After |
|--------|-------|
| Marketplace import modal showed raw `technologist` text across the template row. | Marketplace import modal renders the template icon through `AppIcon` without exposing the emoji id as text. |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods