### PR TITLE
fix: remove pagination current transition

### DIFF
--- a/packages/dify-ui/src/avatar/index.tsx
+++ b/packages/dify-ui/src/avatar/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import type { ImageLoadingStatus } from '@base-ui/react/avatar'
 import { Avatar as BaseAvatar } from '@base-ui/react/avatar'
 import { cn } from '../cn'

--- a/packages/dify-ui/src/button/index.tsx
+++ b/packages/dify-ui/src/button/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import type { Button as BaseButtonNS } from '@base-ui/react/button'
 import type { VariantProps } from 'class-variance-authority'
 import { Button as BaseButton } from '@base-ui/react/button'

--- a/packages/dify-ui/src/internals/use-iso-layout-effect.ts
+++ b/packages/dify-ui/src/internals/use-iso-layout-effect.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import * as React from 'react'
 
 const noop: typeof React.useLayoutEffect = () => {}

--- a/packages/dify-ui/src/pagination/index.tsx
+++ b/packages/dify-ui/src/pagination/index.tsx
@@ -483,9 +483,8 @@ export function PaginationPage({
       aria-current={current ? 'page' : undefined}
       aria-label={ariaLabel ?? (current ? `Page ${page}, current page` : `Go to page ${page}`)}
       className={cn(
-        'inline-flex h-8 min-w-8 touch-manipulation items-center justify-center rounded-lg px-1 py-2 system-sm-medium tabular-nums text-text-tertiary outline-hidden transition-colors hover:bg-components-button-ghost-bg-hover hover:text-text-secondary focus-visible:ring-2 focus-visible:ring-state-accent-solid',
+        'inline-flex h-8 min-w-8 touch-manipulation items-center justify-center rounded-lg px-1 py-2 system-sm-medium tabular-nums text-text-tertiary outline-hidden hover:bg-components-button-ghost-bg-hover hover:text-text-secondary focus-visible:ring-2 focus-visible:ring-state-accent-solid',
         current && 'bg-components-button-tertiary-bg text-components-button-tertiary-text hover:bg-components-button-ghost-bg-hover',
-        'motion-reduce:transition-none',
         className,
       )}
       onClick={(event) => {


### PR DESCRIPTION
## Summary
- remove color transitions from pagination page buttons
- keep current page state changes visually in sync with React renders when the page window shifts

## Root Cause
Stable page-number keys reuse the same button DOM nodes as the pagination window moves. The existing `transition-colors` animated the current-state class changes, making the previous active page appear to fade out after it moved.

## Validation
- `pnpm -C packages/dify-ui test src/pagination/__tests__/index.spec.tsx`
- `pnpm eslint packages/dify-ui/src/pagination/index.tsx`