### PR TITLE
fix: validate app metadata on create and update

### DIFF
--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -44,6 +44,12 @@ from fields.base import ResponseModel
 from graphon.enums import WorkflowExecutionStatus
 from libs.helper import build_icon_url, dump_response, to_timestamp
 from libs.login import login_required
+from libs.validators import (
+    MAX_APP_DESCRIPTION_LENGTH,
+    MAX_APP_ICON_LENGTH,
+    MAX_APP_NAME_LENGTH,
+    validate_app_name,
+)
 from models import Account, App, DatasetPermissionEnum, Workflow
 from models.model import IconType
 from services.app_dsl_service import AppDslService
@@ -161,30 +167,61 @@ def _normalize_app_list_query_args(query_args: MultiDict[str, str]) -> dict[str,
 
 
 class CreateAppPayload(BaseModel):
-    name: str = Field(..., min_length=1, description="App name")
-    description: str | None = Field(default=None, description="App description (max 400 chars)", max_length=400)
-    mode: Literal["chat", "agent-chat", "advanced-chat", "workflow", "completion"] = Field(..., description="App mode")
+    name: str = Field(..., min_length=1, max_length=MAX_APP_NAME_LENGTH, description="App name")
+    description: str | None = Field(
+        default=None, description="App description (max 400 chars)", max_length=MAX_APP_DESCRIPTION_LENGTH
+    )
+    mode: Literal["chat", "agent-chat", "advanced-chat", "workflow", "completion"] = Field(
+        ..., description="App mode"
+    )
     icon_type: IconType | None = Field(default=None, description="Icon type")
-    icon: str | None = Field(default=None, description="Icon")
-    icon_background: str | None = Field(default=None, description="Icon background color")
+    icon: str | None = Field(default=None, max_length=MAX_APP_ICON_LENGTH, description="Icon")
+    icon_background: str | None = Field(
+        default=None, max_length=MAX_APP_ICON_LENGTH, description="Icon background color"
+    )
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        return validate_app_name(value)
 
 
 class UpdateAppPayload(BaseModel):
-    name: str = Field(..., min_length=1, description="App name")
-    description: str | None = Field(default=None, description="App description (max 400 chars)", max_length=400)
+    name: str = Field(..., min_length=1, max_length=MAX_APP_NAME_LENGTH, description="App name")
+    description: str | None = Field(
+        default=None, description="App description (max 400 chars)", max_length=MAX_APP_DESCRIPTION_LENGTH
+    )
     icon_type: IconType | None = Field(default=None, description="Icon type")
-    icon: str | None = Field(default=None, description="Icon")
-    icon_background: str | None = Field(default=None, description="Icon background color")
+    icon: str | None = Field(default=None, max_length=MAX_APP_ICON_LENGTH, description="Icon")
+    icon_background: str | None = Field(
+        default=None, max_length=MAX_APP_ICON_LENGTH, description="Icon background color"
+    )
     use_icon_as_answer_icon: bool | None = Field(default=None, description="Use icon as answer icon")
     max_active_requests: int | None = Field(default=None, description="Maximum active requests")
 
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        return validate_app_name(value)
+
 
 class CopyAppPayload(BaseModel):
-    name: str | None = Field(default=None, description="Name for the copied app")
-    description: str | None = Field(default=None, description="Description for the copied app", max_length=400)
+    name: str | None = Field(default=None, max_length=MAX_APP_NAME_LENGTH, description="Name for the copied app")
+    description: str | None = Field(
+        default=None, description="Description for the copied app", max_length=MAX_APP_DESCRIPTION_LENGTH
+    )
     icon_type: IconType | None = Field(default=None, description="Icon type")
-    icon: str | None = Field(default=None, description="Icon")
-    icon_background: str | None = Field(default=None, description="Icon background color")
+    icon: str | None = Field(default=None, max_length=MAX_APP_ICON_LENGTH, description="Icon")
+    icon_background: str | None = Field(
+        default=None, max_length=MAX_APP_ICON_LENGTH, description="Icon background color"
+    )
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        return validate_app_name(value)
 
 
 class AppExportQuery(BaseModel):
@@ -193,13 +230,20 @@ class AppExportQuery(BaseModel):
 
 
 class AppNamePayload(BaseModel):
-    name: str = Field(..., min_length=1, description="Name to check")
+    name: str = Field(..., min_length=1, max_length=MAX_APP_NAME_LENGTH, description="Name to check")
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        return validate_app_name(value)
 
 
 class AppIconPayload(BaseModel):
-    icon: str | None = Field(default=None, description="Icon data")
+    icon: str | None = Field(default=None, max_length=MAX_APP_ICON_LENGTH, description="Icon data")
     icon_type: IconType | None = Field(default=None, description="Icon type")
-    icon_background: str | None = Field(default=None, description="Icon background color")
+    icon_background: str | None = Field(
+        default=None, max_length=MAX_APP_ICON_LENGTH, description="Icon background color"
+    )
 
 
 class AppSiteStatusPayload(BaseModel):
@@ -421,6 +465,7 @@ class AppDetail(ResponseModel):
     name: str
     description: str | None = None
     mode: str = Field(validation_alias="mode_compatible_with_agent")
+    icon_type: str | None = None
     icon: str | None = None
     icon_background: str | None = None
     enable_site: bool
@@ -440,6 +485,11 @@ class AppDetail(ResponseModel):
     access_mode: str | None = None
     tags: list[Tag] = Field(default_factory=list)
 
+    @computed_field(return_type=str | None)  # type: ignore
+    @property
+    def icon_url(self) -> str | None:
+        return build_icon_url(self.icon_type, self.icon)
+
     @field_validator("created_at", "updated_at", mode="before")
     @classmethod
     def _normalize_timestamp(cls, value: datetime | int | None) -> int | None:
@@ -447,7 +497,6 @@ class AppDetail(ResponseModel):
 
 
 class AppDetailWithSite(AppDetail):
-    icon_type: str | None = None
     api_base_url: str | None = None
     max_active_requests: int | None = None
     deleted_tools: list[DeletedTool] = Field(default_factory=list)
@@ -457,11 +506,6 @@ class AppDetailWithSite(AppDetail):
     # For Agent App responses exposed through /agent.
     app_id: str | None = None
     role: str | None = None
-
-    @computed_field(return_type=str | None)  # type: ignore
-    @property
-    def icon_url(self) -> str | None:
-        return build_icon_url(self.icon_type, self.icon)
 
 
 class AppPagination(ResponseModel):

--- a/api/libs/validators.py
+++ b/api/libs/validators.py
@@ -1,5 +1,19 @@
+MAX_APP_NAME_LENGTH = 255
+MAX_APP_DESCRIPTION_LENGTH = 400
+MAX_APP_ICON_LENGTH = 255
+
+
+def validate_app_name(name: str) -> str:
+    """Validate app name length and visible content."""
+    if not name.strip():
+        raise ValueError("App name is required.")
+    if len(name) > MAX_APP_NAME_LENGTH:
+        raise ValueError(f"App name cannot exceed {MAX_APP_NAME_LENGTH} characters.")
+    return name
+
+
 def validate_description_length(description: str | None) -> str | None:
     """Validate description length."""
-    if description and len(description) > 400:
-        raise ValueError("Description cannot exceed 400 characters.")
+    if description and len(description) > MAX_APP_DESCRIPTION_LENGTH:
+        raise ValueError(f"Description cannot exceed {MAX_APP_DESCRIPTION_LENGTH} characters.")
     return description

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -12500,6 +12500,7 @@ Enum class for api provider schema type.
 | enable_site | boolean |  | Yes |
 | icon | string |  | No |
 | icon_background | string |  | No |
+| icon_type | string |  | No |
 | id | string |  | Yes |
 | mode_compatible_with_agent | string |  | Yes |
 | name | string |  | Yes |

--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -6,7 +6,7 @@ from typing import Any, Literal, NotRequired, TypedDict, cast, override
 
 import sqlalchemy as sa
 from flask_sqlalchemy.pagination import Pagination
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import select
 from sqlalchemy.orm import Session, scoped_session
 
@@ -23,6 +23,7 @@ from graphon.model_runtime.entities.model_entities import ModelPropertyKey, Mode
 from graphon.model_runtime.model_providers.base.large_language_model import LargeLanguageModel
 from libs.datetime_utils import naive_utc_now
 from libs.login import current_user
+from libs.validators import MAX_APP_NAME_LENGTH, validate_app_name
 from models import Account, AppStar
 from models.agent import Agent, AgentIconType, AgentScope, AgentSource, AgentStatus
 from models.model import App, AppMode, AppModelConfig, IconType, Site
@@ -60,7 +61,7 @@ class StarredAppListParams(AppListBaseParams):
 
 
 class CreateAppParams(BaseModel):
-    name: str = Field(min_length=1)
+    name: str = Field(min_length=1, max_length=MAX_APP_NAME_LENGTH)
     description: str | None = None
     mode: Literal["chat", "agent-chat", "agent", "advanced-chat", "workflow", "completion"]
     agent_role: str = Field(default="", max_length=255)
@@ -70,6 +71,11 @@ class CreateAppParams(BaseModel):
     api_rph: int = 0
     api_rpm: int = 0
     max_active_requests: int | None = None
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        return validate_app_name(value)
 
 
 class AppService:
@@ -362,7 +368,7 @@ class AppService:
             default_model_config["model"] = json.dumps(default_model_dict)
 
         app = App(**app_template["app"])
-        app.name = params.name
+        app.name = validate_app_name(params.name)
         app.description = params.description or ""
         app.mode = app_mode
         app.icon_type = IconType(params.icon_type) if params.icon_type else IconType.EMOJI
@@ -580,7 +586,7 @@ class AppService:
         :return: App instance
         """
         assert current_user is not None
-        app.name = args["name"]
+        app.name = validate_app_name(args["name"])
         app.description = args["description"]
         icon_type = args.get("icon_type")
         if icon_type is None:
@@ -620,7 +626,7 @@ class AppService:
         :return: App instance
         """
         assert current_user is not None
-        app.name = name
+        app.name = validate_app_name(name)
         app.updated_by = current_user.id
         app.updated_at = naive_utc_now()
         self._sync_backing_agent_identity(

--- a/api/tests/unit_tests/controllers/console/app/test_create_app_payload.py
+++ b/api/tests/unit_tests/controllers/console/app/test_create_app_payload.py
@@ -1,9 +1,13 @@
 """Regression tests for CreateAppPayload mode validation."""
 
+import importlib
+from types import SimpleNamespace
+
 import pytest
 from pydantic import ValidationError
 
-from controllers.console.app.app import CreateAppPayload
+from controllers.console.app.app import AppDetail, CopyAppPayload, CreateAppPayload, UpdateAppPayload
+from libs.validators import MAX_APP_NAME_LENGTH
 
 
 class TestCreateAppPayloadMode:
@@ -22,3 +26,64 @@ class TestCreateAppPayloadMode:
     def test_rejects_unknown_mode(self):
         with pytest.raises(ValidationError):
             CreateAppPayload.model_validate({"name": "X", "mode": "not-a-mode"})
+
+
+class TestAppPayloadNameValidation:
+    @pytest.mark.parametrize(
+        ("payload_cls", "payload"),
+        [
+            (CreateAppPayload, {"mode": "chat"}),
+            (UpdateAppPayload, {}),
+            (CopyAppPayload, {}),
+        ],
+    )
+    def test_accepts_name_at_database_limit(self, payload_cls, payload):
+        name = "x" * MAX_APP_NAME_LENGTH
+        model = payload_cls.model_validate({"name": name, **payload})
+        assert model.name == name
+
+    @pytest.mark.parametrize(
+        ("payload_cls", "payload"),
+        [
+            (CreateAppPayload, {"mode": "chat"}),
+            (UpdateAppPayload, {}),
+            (CopyAppPayload, {}),
+        ],
+    )
+    def test_rejects_name_over_database_limit(self, payload_cls, payload):
+        with pytest.raises(ValidationError):
+            payload_cls.model_validate({"name": "x" * (MAX_APP_NAME_LENGTH + 1), **payload})
+
+    @pytest.mark.parametrize(
+        ("payload_cls", "payload"),
+        [
+            (CreateAppPayload, {"mode": "chat"}),
+            (UpdateAppPayload, {}),
+            (CopyAppPayload, {}),
+        ],
+    )
+    def test_rejects_blank_name(self, payload_cls, payload):
+        with pytest.raises(ValidationError):
+            payload_cls.model_validate({"name": "   ", **payload})
+
+
+def test_app_detail_includes_icon_url_for_image_icons(monkeypatch):
+    app_module = importlib.import_module("controllers.console.app.app")
+    monkeypatch.setattr(app_module, "build_icon_url", lambda icon_type, icon: f"/files/{icon_type}/{icon}")
+
+    app = SimpleNamespace(
+        id="app-1",
+        name="Image App",
+        description="",
+        mode_compatible_with_agent="chat",
+        icon_type="image",
+        icon="file-1",
+        icon_background=None,
+        enable_site=True,
+        enable_api=True,
+    )
+
+    payload = AppDetail.model_validate(app, from_attributes=True).model_dump(mode="json")
+
+    assert payload["icon_type"] == "image"
+    assert payload["icon_url"] == "/files/image/file-1"

--- a/packages/contracts/generated/api/console/apps/types.gen.ts
+++ b/packages/contracts/generated/api/console/apps/types.gen.ts
@@ -317,6 +317,7 @@ export type AppDetail = {
   enable_site: boolean
   icon?: string | null
   icon_background?: string | null
+  icon_type?: string | null
   id: string
   mode_compatible_with_agent: string
   name: string

--- a/packages/contracts/generated/api/console/apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/apps/zod.gen.ts
@@ -315,7 +315,7 @@ export const zModelConfigRequest = z.object({
  * AppNamePayload
  */
 export const zAppNamePayload = z.object({
-  name: z.string().min(1),
+  name: z.string().min(1).max(255),
 })
 
 /**
@@ -786,11 +786,11 @@ export const zIconType = z.enum(['emoji', 'image', 'link'])
  */
 export const zCreateAppPayload = z.object({
   description: z.string().max(400).nullish(),
-  icon: z.string().nullish(),
-  icon_background: z.string().nullish(),
+  icon: z.string().max(255).nullish(),
+  icon_background: z.string().max(255).nullish(),
   icon_type: zIconType.nullish(),
   mode: z.enum(['advanced-chat', 'agent-chat', 'chat', 'completion', 'workflow']),
-  name: z.string().min(1),
+  name: z.string().min(1).max(255),
 })
 
 /**
@@ -798,11 +798,11 @@ export const zCreateAppPayload = z.object({
  */
 export const zUpdateAppPayload = z.object({
   description: z.string().max(400).nullish(),
-  icon: z.string().nullish(),
-  icon_background: z.string().nullish(),
+  icon: z.string().max(255).nullish(),
+  icon_background: z.string().max(255).nullish(),
   icon_type: zIconType.nullish(),
   max_active_requests: z.int().nullish(),
-  name: z.string().min(1),
+  name: z.string().min(1).max(255),
   use_icon_as_answer_icon: z.boolean().nullish(),
 })
 
@@ -811,18 +811,18 @@ export const zUpdateAppPayload = z.object({
  */
 export const zCopyAppPayload = z.object({
   description: z.string().max(400).nullish(),
-  icon: z.string().nullish(),
-  icon_background: z.string().nullish(),
+  icon: z.string().max(255).nullish(),
+  icon_background: z.string().max(255).nullish(),
   icon_type: zIconType.nullish(),
-  name: z.string().nullish(),
+  name: z.string().max(255).nullish(),
 })
 
 /**
  * AppIconPayload
  */
 export const zAppIconPayload = z.object({
-  icon: z.string().nullish(),
-  icon_background: z.string().nullish(),
+  icon: z.string().max(255).nullish(),
+  icon_background: z.string().max(255).nullish(),
   icon_type: zIconType.nullish(),
 })
 
@@ -2046,6 +2046,7 @@ export const zAppDetail = z.object({
   enable_site: z.boolean(),
   icon: z.string().nullish(),
   icon_background: z.string().nullish(),
+  icon_type: z.string().nullish(),
   id: z.string(),
   mode_compatible_with_agent: z.string(),
   name: z.string(),

--- a/web/app/components/apps/__tests__/app-card.spec.tsx
+++ b/web/app/components/apps/__tests__/app-card.spec.tsx
@@ -3,6 +3,7 @@ import type { App } from '@/types/app'
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import * as React from 'react'
 import { renderWithSystemFeatures } from '@/__tests__/utils/mock-system-features'
+import { MAX_APP_NAME_LENGTH } from '@/app/components/explore/create-app-modal/constants'
 import { AccessMode } from '@/models/access-control'
 import * as appsService from '@/service/apps'
 import * as exploreService from '@/service/explore'
@@ -770,6 +771,18 @@ describe('AppCard', () => {
       await waitFor(() => {
         expect(mockDeleteAppMutation).toHaveBeenCalled()
       })
+    })
+
+    it('should allow the delete confirmation input to hold the full app name', async () => {
+      const longName = 'x'.repeat(MAX_APP_NAME_LENGTH + 12)
+      render(<AppCard app={{ ...mockApp, name: longName }} />)
+
+      fireEvent.click(screen.getByTestId('dropdown-menu-trigger'))
+      fireEvent.click(await screen.findByRole('menuitem', { name: 'common.operation.delete' }))
+      expect(await screen.findByRole('alertdialog')).toBeInTheDocument()
+
+      const deleteInput = screen.getByRole('textbox')
+      expect(deleteInput).toHaveAttribute('maxlength', String(longName.length))
     })
 
     it('should not call onRefresh after successful delete', async () => {

--- a/web/app/components/apps/app-card.tsx
+++ b/web/app/components/apps/app-card.tsx
@@ -38,6 +38,7 @@ import { AppTypeIcon } from '@/app/components/app/type-selector'
 import AppIcon from '@/app/components/base/app-icon'
 import StarIcon from '@/app/components/base/icons/src/vender/Star'
 import { UserAvatarList } from '@/app/components/base/user-avatar-list'
+import { MAX_APP_NAME_LENGTH } from '@/app/components/explore/create-app-modal/constants'
 import { buildInstalledAppPath } from '@/app/components/explore/installed-app/routes'
 import { NEED_REFRESH_APP_LIST_KEY } from '@/config'
 import { useAppContext } from '@/context/app-context'
@@ -607,7 +608,7 @@ export const AppCardActionBar: React.FC<AppCardActionBarProps> = ({ app, onRefre
                     ns="app"
                     values={{ appName: app.name }}
                     components={{
-                      appName: <span className="system-sm-semibold text-text-primary" translate="no" />,
+                      appName: <span className="system-sm-semibold break-all text-text-primary" translate="no" />,
                     }}
                   />
                 </FieldLabel>
@@ -615,6 +616,7 @@ export const AppCardActionBar: React.FC<AppCardActionBarProps> = ({ app, onRefre
                   type="text"
                   autoComplete="off"
                   spellCheck={false}
+                  maxLength={Math.max(app.name.length, MAX_APP_NAME_LENGTH)}
                   placeholder={t('deleteAppConfirmInputPlaceholder', { ns: 'app' })}
                   value={confirmDeleteInput}
                   onValueChange={setConfirmDeleteInput}
@@ -1111,7 +1113,7 @@ const AppCard = ({ app, onlineUsers = [], onRefresh, onOpenTagManagement = () =>
                     ns="app"
                     values={{ appName: app.name }}
                     components={{
-                      appName: <span className="system-sm-semibold text-text-primary" translate="no" />,
+                      appName: <span className="system-sm-semibold break-all text-text-primary" translate="no" />,
                     }}
                   />
                 </FieldLabel>
@@ -1120,6 +1122,7 @@ const AppCard = ({ app, onlineUsers = [], onRefresh, onOpenTagManagement = () =>
                     type="text"
                     autoComplete="off"
                     spellCheck={false}
+                    maxLength={Math.max(app.name.length, MAX_APP_NAME_LENGTH)}
                     placeholder={t('deleteAppConfirmInputPlaceholder', { ns: 'app' })}
                     value={confirmDeleteInput}
                     onValueChange={setConfirmDeleteInput}

--- a/web/app/components/explore/create-app-modal/__tests__/index.spec.tsx
+++ b/web/app/components/explore/create-app-modal/__tests__/index.spec.tsx
@@ -5,6 +5,7 @@ import * as React from 'react'
 import { createMockPlan, createMockPlanTotal, createMockPlanUsage } from '@/__mocks__/provider-context'
 import { Plan } from '@/app/components/billing/type'
 import { AppModeEnum } from '@/types/app'
+import { MAX_APP_DESCRIPTION_LENGTH, MAX_APP_NAME_LENGTH } from '../constants'
 import CreateAppModal from '../index'
 
 const hotkeyMocks = vi.hoisted(() => ({
@@ -185,6 +186,13 @@ describe('CreateAppModal', () => {
       await setup({ appName: '   ' })
 
       expect(screen.getByRole('button', { name: /common\.operation\.create/ }))!.toBeDisabled()
+    })
+
+    it('should limit app name and description input lengths', async () => {
+      await setup()
+
+      expect(screen.getByPlaceholderText('app.newApp.appNamePlaceholder')).toHaveAttribute('maxlength', String(MAX_APP_NAME_LENGTH))
+      expect(screen.getByPlaceholderText('app.newApp.appDescriptionPlaceholder')).toHaveAttribute('maxlength', String(MAX_APP_DESCRIPTION_LENGTH))
     })
   })
 
@@ -454,6 +462,24 @@ describe('CreateAppModal', () => {
 
       expect(onConfirm).toHaveBeenCalledTimes(1)
       expect(onConfirm.mock.calls[0]![0]).toMatchObject({ description: 'Updated description' })
+    })
+
+    it('should truncate overlong name and description before submitting', async () => {
+      const { onConfirm } = await setup({ appName: 'Short', appDescription: '' })
+      const longName = 'n'.repeat(MAX_APP_NAME_LENGTH + 10)
+      const longDescription = 'd'.repeat(MAX_APP_DESCRIPTION_LENGTH + 10)
+
+      fireEvent.change(screen.getByPlaceholderText('app.newApp.appNamePlaceholder'), { target: { value: longName } })
+      fireEvent.change(screen.getByPlaceholderText('app.newApp.appDescriptionPlaceholder'), { target: { value: longDescription } })
+
+      fireEvent.click(screen.getByRole('button', { name: /common\.operation\.create/ }))
+      await act(async () => {
+        vi.advanceTimersByTime(300)
+      })
+
+      const payload = onConfirm.mock.calls[0]![0]
+      expect(payload.name).toHaveLength(MAX_APP_NAME_LENGTH)
+      expect(payload.description).toHaveLength(MAX_APP_DESCRIPTION_LENGTH)
     })
 
     it('should omit icon_background when submitting with image icon', async () => {

--- a/web/app/components/explore/create-app-modal/constants.ts
+++ b/web/app/components/explore/create-app-modal/constants.ts
@@ -1,0 +1,2 @@
+export const MAX_APP_NAME_LENGTH = 255
+export const MAX_APP_DESCRIPTION_LENGTH = 400

--- a/web/app/components/explore/create-app-modal/index.tsx
+++ b/web/app/components/explore/create-app-modal/index.tsx
@@ -17,6 +17,7 @@ import AppsFull from '@/app/components/billing/apps-full-in-dialog'
 import { useProviderContext } from '@/context/provider-context'
 import { AppModeEnum } from '@/types/app'
 import AppIconPicker from '../../base/app-icon-picker'
+import { MAX_APP_DESCRIPTION_LENGTH, MAX_APP_NAME_LENGTH } from './constants'
 
 export type CreateAppModalProps = {
   show: boolean
@@ -63,14 +64,14 @@ const CreateAppModal = ({
 }: CreateAppModalProps) => {
   const { t } = useTranslation()
 
-  const [name, setName] = React.useState(appName)
+  const [name, setName] = React.useState(() => appName.slice(0, MAX_APP_NAME_LENGTH))
   const [appIcon, setAppIcon] = useState(
     () => appIconType === 'image'
       ? { type: 'image' as const, fileId: _appIcon, url: appIconUrl }
       : { type: 'emoji' as const, icon: _appIcon, background: appIconBackground },
   )
   const [showAppIconPicker, setShowAppIconPicker] = useState(false)
-  const [description, setDescription] = useState(appDescription || '')
+  const [description, setDescription] = useState(() => (appDescription || '').slice(0, MAX_APP_DESCRIPTION_LENGTH))
   const [useIconAsAnswerIcon, setUseIconAsAnswerIcon] = useState(appUseIconAsAnswerIcon || false)
 
   const [maxActiveRequestsInput, setMaxActiveRequestsInput] = useState(
@@ -138,7 +139,8 @@ const CreateAppModal = ({
                 />
                 <Input
                   value={name}
-                  onChange={e => setName(e.target.value)}
+                  maxLength={MAX_APP_NAME_LENGTH}
+                  onChange={e => setName(e.target.value.slice(0, MAX_APP_NAME_LENGTH))}
                   placeholder={t('newApp.appNamePlaceholder', { ns: 'app' }) || ''}
                   className="h-10 grow"
                 />
@@ -152,7 +154,8 @@ const CreateAppModal = ({
                 className="resize-none"
                 placeholder={t('newApp.appDescriptionPlaceholder', { ns: 'app' }) || ''}
                 value={description}
-                onValueChange={value => setDescription(value)}
+                maxLength={MAX_APP_DESCRIPTION_LENGTH}
+                onValueChange={value => setDescription(value.slice(0, MAX_APP_DESCRIPTION_LENGTH))}
               />
             </div>
             {/* answer icon */}


### PR DESCRIPTION
## Summary

- Limit app name, description, and icon metadata to backend/database-safe lengths
- Add backend validation for create/update/copy/name app payloads and service methods
- Include `icon_type` and `icon_url` in app detail responses so uploaded image icons render after creation
- Limit frontend create/edit inputs and keep delete confirmation usable for long app names

## Tests

- `uv run pytest -o addopts='' tests/unit_tests/controllers/console/app/test_create_app_payload.py tests/unit_tests/controllers/console/app/test_description_validation.py`
- `pnpm --filter dify-web test -- app/components/explore/create-app-modal/__tests__/index.spec.tsx app/components/apps/__tests__/app-card.spec.tsx`
- `python3 -m py_compile api/libs/validators.py api/services/app_service.py api/controllers/console/app/app.py api/tests/unit_tests/controllers/console/app/test_create_app_payload.py`