### PR TITLE
refactor: type remaining bare dict annotations

### DIFF
--- a/api/core/app/apps/chat/app_config_manager.py
+++ b/api/core/app/apps/chat/app_config_manager.py
@@ -81,7 +81,7 @@ class ChatAppConfigManager(BaseAppConfigManager):
         return app_config
 
     @classmethod
-    def config_validate(cls, tenant_id: str, config: dict) -> AppModelConfigDict:
+    def config_validate(cls, tenant_id: str, config: dict[str, Any]) -> AppModelConfigDict:
         """
         Validate for chat app model config
 

--- a/api/core/app/apps/completion/app_config_manager.py
+++ b/api/core/app/apps/completion/app_config_manager.py
@@ -68,7 +68,7 @@ class CompletionAppConfigManager(BaseAppConfigManager):
         return app_config
 
     @classmethod
-    def config_validate(cls, tenant_id: str, config: dict) -> AppModelConfigDict:
+    def config_validate(cls, tenant_id: str, config: dict[str, Any]) -> AppModelConfigDict:
         """
         Validate for completion app model config
 

--- a/api/providers/vdb/vdb-tidb-on-qdrant/src/dify_vdb_tidb_on_qdrant/tidb_service.py
+++ b/api/providers/vdb/vdb-tidb-on-qdrant/src/dify_vdb_tidb_on_qdrant/tidb_service.py
@@ -1,7 +1,8 @@
 import logging
 import time
 import uuid
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 import httpx
 from httpx import DigestAuth
@@ -24,7 +25,7 @@ _tidb_http_client: httpx.Client = get_pooled_http_client(
 
 class TidbService:
     @staticmethod
-    def extract_qdrant_endpoint(cluster_response: dict) -> str | None:
+    def extract_qdrant_endpoint(cluster_response: Mapping[str, Any]) -> str | None:
         """Extract the qdrant endpoint URL from a Get Cluster API response.
 
         Reads ``endpoints.public.host`` (e.g. ``gateway01.xx.tidbcloud.com``),


### PR DESCRIPTION
## Summary

 #22651

- Replace the remaining production bare `dict` annotations called out in the issue with explicit types.
- Use `dict[str, Any]` for app config validators because the validation pipeline mutates the config mapping.
- Use `Mapping[str, Any]` for the TiDB cluster response helper because it only reads from the response.

## Screenshots

N/A. Backend typing-only cleanup.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Validation:

- `/tmp/dify-ruff-venv/bin/ruff format --check api/core/app/apps/chat/app_config_manager.py api/core/app/apps/completion/app_config_manager.py api/providers/vdb/vdb-tidb-on-qdrant/src/dify_vdb_tidb_on_qdrant/tidb_service.py`
- `/tmp/dify-ruff-venv/bin/ruff check api/core/app/apps/chat/app_config_manager.py api/core/app/apps/completion/app_config_manager.py api/providers/vdb/vdb-tidb-on-qdrant/src/dify_vdb_tidb_on_qdrant/tidb_service.py`
- `python3 -m py_compile api/core/app/apps/chat/app_config_manager.py api/core/app/apps/completion/app_config_manager.py api/providers/vdb/vdb-tidb-on-qdrant/src/dify_vdb_tidb_on_qdrant/tidb_service.py`
- `git diff --check`

From Codex
