### PR TITLE
refactor(api): remove unnecessary type: ignore in summary_index_service (#24494)

### DIFF
--- a/api/services/summary_index_service.py
+++ b/api/services/summary_index_service.py
@@ -123,7 +123,7 @@ class SummaryIndexService:
                 # Update existing record
                 existing_summary.summary_content = summary_content
                 existing_summary.status = status
-                existing_summary.error = None  # type: ignore[assignment]  # Clear any previous errors
+                existing_summary.error = None  # Clear any previous errors
                 # Re-enable if it was disabled
                 if not existing_summary.enabled:
                     existing_summary.enabled = True
@@ -583,7 +583,7 @@ class SummaryIndexService:
                 if existing_summary:
                     # Update existing record
                     existing_summary.status = status
-                    existing_summary.error = None  # type: ignore[assignment]  # Clear any previous errors
+                    existing_summary.error = None  # Clear any previous errors
                     if not existing_summary.enabled:
                         existing_summary.enabled = True
                         existing_summary.disabled_at = None
@@ -685,7 +685,7 @@ class SummaryIndexService:
 
                 # Update status to "generating"
                 summary_record_in_session.status = SummaryStatus.GENERATING
-                summary_record_in_session.error = None  # type: ignore[assignment]
+                summary_record_in_session.error = None
                 session.add(summary_record_in_session)
                 # Don't flush here - wait until after vectorization succeeds
 
@@ -1127,7 +1127,7 @@ class SummaryIndexService:
                     # Update summary content
                     summary_record.summary_content = summary_content
                     summary_record.status = SummaryStatus.GENERATING
-                    summary_record.error = None  # type: ignore[assignment]  # Clear any previous errors
+                    summary_record.error = None  # Clear any previous errors
                     session.add(summary_record)
                     # Flush to ensure summary_content is saved before vectorize_summary queries it
                     session.flush()


### PR DESCRIPTION
## Summary

Part of #24494 (clean unnecessary `# type: ignore`).

`api/services/summary_index_service.py` carried four `# type: ignore[assignment]` comments on `summary.error = None` assignments. The `error` field is `Optional`, so assigning `None` already type-checks and the suppressions are unnecessary; keeping them hides real future type errors on those lines. `mypy --warn-unused-ignores` reports all four as unused, and both `pyrefly` and `mypy` stay clean after removal. The intent comments (`# Clear any previous errors`) are preserved.

This is a comment-only change with no runtime or behavioral effect.

## Checklist

- [ ] This change requires a documentation update
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
