### PR TITLE
fix(api): add bounded timeouts to Marketplace POST requests

### DIFF
--- a/api/core/helper/marketplace.py
+++ b/api/core/helper/marketplace.py
@@ -29,7 +29,10 @@ def batch_fetch_plugin_manifests(plugin_ids: list[str]) -> Sequence[MarketplaceP
 
     url = str(marketplace_api_url / "api/v1/plugins/batch")
     response = httpx.post(
-        url, json={"plugin_ids": plugin_ids}, headers={"X-Dify-Version": dify_config.project.version}, timeout=MARKETPLACE_TIMEOUT
+        url,
+        json={"plugin_ids": plugin_ids},
+        headers={"X-Dify-Version": dify_config.project.version},
+        timeout=MARKETPLACE_TIMEOUT,
     )
     response.raise_for_status()
 
@@ -42,7 +45,10 @@ def batch_fetch_plugin_by_ids(plugin_ids: list[str]) -> list[dict]:
 
     url = str(marketplace_api_url / "api/v1/plugins/batch")
     response = httpx.post(
-        url, json={"plugin_ids": plugin_ids}, headers={"X-Dify-Version": dify_config.project.version}, timeout=MARKETPLACE_TIMEOUT
+        url,
+        json={"plugin_ids": plugin_ids},
+        headers={"X-Dify-Version": dify_config.project.version},
+        timeout=MARKETPLACE_TIMEOUT,
     )
     response.raise_for_status()
 

--- a/api/core/helper/marketplace.py
+++ b/api/core/helper/marketplace.py
@@ -12,6 +12,8 @@ from extensions.ext_redis import redis_client
 marketplace_api_url = URL(str(dify_config.MARKETPLACE_API_URL))
 logger = logging.getLogger(__name__)
 
+MARKETPLACE_TIMEOUT = 30
+
 
 def get_plugin_pkg_url(plugin_unique_identifier: str) -> str:
     return str((marketplace_api_url / "api/v1/plugins/download").with_query(unique_identifier=plugin_unique_identifier))
@@ -26,7 +28,9 @@ def batch_fetch_plugin_manifests(plugin_ids: list[str]) -> Sequence[MarketplaceP
         return []
 
     url = str(marketplace_api_url / "api/v1/plugins/batch")
-    response = httpx.post(url, json={"plugin_ids": plugin_ids}, headers={"X-Dify-Version": dify_config.project.version})
+    response = httpx.post(
+        url, json={"plugin_ids": plugin_ids}, headers={"X-Dify-Version": dify_config.project.version}, timeout=MARKETPLACE_TIMEOUT
+    )
     response.raise_for_status()
 
     return [MarketplacePluginDeclaration.model_validate(plugin) for plugin in response.json()["data"]["plugins"]]
@@ -37,7 +41,9 @@ def batch_fetch_plugin_by_ids(plugin_ids: list[str]) -> list[dict]:
         return []
 
     url = str(marketplace_api_url / "api/v1/plugins/batch")
-    response = httpx.post(url, json={"plugin_ids": plugin_ids}, headers={"X-Dify-Version": dify_config.project.version})
+    response = httpx.post(
+        url, json={"plugin_ids": plugin_ids}, headers={"X-Dify-Version": dify_config.project.version}, timeout=MARKETPLACE_TIMEOUT
+    )
     response.raise_for_status()
 
     data = response.json()
@@ -46,7 +52,7 @@ def batch_fetch_plugin_by_ids(plugin_ids: list[str]) -> list[dict]:
 
 def record_install_plugin_event(plugin_unique_identifier: str):
     url = str(marketplace_api_url / "api/v1/stats/plugins/install_count")
-    response = httpx.post(url, json={"unique_identifier": plugin_unique_identifier})
+    response = httpx.post(url, json={"unique_identifier": plugin_unique_identifier}, timeout=MARKETPLACE_TIMEOUT)
     response.raise_for_status()
 
 
@@ -64,7 +70,7 @@ def fetch_global_plugin_manifest(cache_key_prefix: str, cache_ttl: int) -> None:
         Exception: If any other error occurs during fetching or caching
     """
     url = str(marketplace_api_url / "api/v1/dist/plugins/manifest.json")
-    response = httpx.get(url, headers={"X-Dify-Version": dify_config.project.version}, timeout=30)
+    response = httpx.get(url, headers={"X-Dify-Version": dify_config.project.version}, timeout=MARKETPLACE_TIMEOUT)
     response.raise_for_status()
 
     raw_json = response.json()


### PR DESCRIPTION
## Summary

`batch_fetch_plugin_manifests`, `batch_fetch_plugin_by_ids`, and `record_install_plugin_event` called `httpx.post()` without an explicit timeout. In self-hosted deployments where the Marketplace API is slow, unreachable, or blocked, these calls would wait indefinitely — hanging plugin listing and install flows.

Introduces a `MARKETPLACE_TIMEOUT = 30` module-level constant and applies it to all four Marketplace HTTP calls, making the POST paths consistent with the existing `timeout=30` in `fetch_global_plugin_manifest`.

Fixes #37419

## Changes

- `api/core/helper/marketplace.py`:
  - Added `MARKETPLACE_TIMEOUT = 30` constant
  - Applied `timeout=MARKETPLACE_TIMEOUT` to `batch_fetch_plugin_manifests`, `batch_fetch_plugin_by_ids`, and `record_install_plugin_event`
  - Replaced inline `timeout=30` in `fetch_global_plugin_manifest` with the constant for consistency