### PR TITLE
fix(api): fix incorrect docker build context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ build-web:
 
 build-api:
 	@echo "Building API Docker image: $(API_IMAGE):$(VERSION)..."
-	docker build -t $(API_IMAGE):$(VERSION) ./api
+	docker build -t $(API_IMAGE):$(VERSION) -f api/Dockerfile .
 	@echo "API Docker image built successfully: $(API_IMAGE):$(VERSION)"
 
 # Push Docker images

--- a/api/Dockerfile.dockerignore
+++ b/api/Dockerfile.dockerignore
@@ -8,18 +8,30 @@
 !dify-agent/src/
 !dify-agent/src/**
 
-api/.venv
-api/.venv/**
-api/.env
-api/*.env.*
-api/.idea
-api/.mypy_cache
-api/.ruff_cache
-api/storage/generate_files/*
-api/storage/privkeys/*
-api/storage/tools/*
-api/storage/upload_files/*
-api/logs
-api/*.log*
+# Environment configuration and example
+.env
+*.env.*
+
+# Python related files
 **/__pycache__
 **/*.pyc
+**/.venv/
+**/.mypy_cache/
+**/.ruff_cache/
+**/.import_linter_cache/
+**/.pytest_cache/
+**/.hypothesis/
+
+
+# Upload files and logs
+api/storage/**
+api/logs/
+api/*.log*
+
+# Tests
+api/tests
+
+
+# Editor configuration
+**/.vscode/
+**/.idea/


### PR DESCRIPTION
## Summary

- Changed the Docker build context for `build-api` to point to the repository root.
- Optimized Docker ignore configurations specifically for the API module.

Ideally, the same build script should be used for both CI and local development, so that any issues in the development build process can be caught early before impacting developers. However, the CI configuration is currently quite complex, and modifying it falls outside the scope of this PR.

Closes #37430.

## Screenshots

| Before | After |
|--------|-------|
| <img width="1512" height="849" alt="image" src="https://github.com/user-attachments/assets/652c2d6a-8a2f-435f-8ed6-90a3114e2a66" /> | <img width="1510" height="590" alt="image" src="https://github.com/user-attachments/assets/ed004550-e782-4fbe-9dc8-15070fe15582" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
