### PR TITLE
refactor: add Mapped[] type annotations to unmapped ORM columns (#22652)

### DIFF
--- a/api/models/agent.py
+++ b/api/models/agent.py
@@ -199,7 +199,7 @@ class AgentConfigSnapshot(DefaultFieldsMixin, Base):
     tenant_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     agent_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     version: Mapped[int] = mapped_column(sa.Integer, nullable=False)
-    config_snapshot: Mapped[Any] = mapped_column(JSONModelColumn(AgentSoulConfig), nullable=False)
+    config_snapshot: Mapped[AgentSoulConfig] = mapped_column(JSONModelColumn(AgentSoulConfig), nullable=False)
     summary: Mapped[str | None] = mapped_column(LongText, nullable=True)
     version_note: Mapped[str | None] = mapped_column(LongText, nullable=True)
     created_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
@@ -301,7 +301,7 @@ class WorkflowAgentNodeBinding(DefaultFieldsMixin, Base):
     )
     agent_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     current_snapshot_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
-    node_job_config: Mapped[Any] = mapped_column(JSONModelColumn(WorkflowNodeJobConfig), nullable=False)
+    node_job_config: Mapped[WorkflowNodeJobConfig] = mapped_column(JSONModelColumn(WorkflowNodeJobConfig), nullable=False)
     created_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     updated_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
 

--- a/api/models/agent.py
+++ b/api/models/agent.py
@@ -301,7 +301,9 @@ class WorkflowAgentNodeBinding(DefaultFieldsMixin, Base):
     )
     agent_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     current_snapshot_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
-    node_job_config: Mapped[WorkflowNodeJobConfig] = mapped_column(JSONModelColumn(WorkflowNodeJobConfig), nullable=False)
+    node_job_config: Mapped[WorkflowNodeJobConfig] = mapped_column(
+        JSONModelColumn(WorkflowNodeJobConfig), nullable=False
+    )
     created_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     updated_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
 

--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -9,7 +9,7 @@ import re
 import time
 from datetime import datetime
 from json import JSONDecodeError
-from typing import Any, ClassVar, Optional, TypedDict, cast, override
+from typing import Any, ClassVar, TypedDict, cast, override
 from uuid import uuid4
 
 import sqlalchemy as sa
@@ -177,37 +177,39 @@ class Dataset(Base):
     id: Mapped[str] = mapped_column(StringUUID, default=lambda: str(uuid4()))
     tenant_id: Mapped[str] = mapped_column(StringUUID)
     name: Mapped[str] = mapped_column(String(255))
-    description: Mapped[Optional[str]] = mapped_column(LongText, nullable=True)
+    description: Mapped[str | None] = mapped_column(LongText, nullable=True)
     provider: Mapped[str] = mapped_column(String(255), server_default=sa.text("'vendor'"))
     permission: Mapped[DatasetPermissionEnum] = mapped_column(
         EnumText(DatasetPermissionEnum, length=255),
         server_default=sa.text("'only_me'"),
         default=DatasetPermissionEnum.ONLY_ME,
     )
-    data_source_type: Mapped[Optional[str]] = mapped_column(EnumText(DataSourceType, length=255))
+    data_source_type: Mapped[str | None] = mapped_column(EnumText(DataSourceType, length=255))
     indexing_technique: Mapped[IndexTechniqueType | None] = mapped_column(EnumText(IndexTechniqueType, length=255))
-    index_struct: Mapped[Optional[str]] = mapped_column(LongText, nullable=True)
+    index_struct: Mapped[str | None] = mapped_column(LongText, nullable=True)
     created_by: Mapped[str] = mapped_column(StringUUID, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.current_timestamp())
-    updated_by: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    updated_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     updated_at: Mapped[datetime] = mapped_column(
         sa.DateTime, nullable=False, server_default=func.current_timestamp(), onupdate=func.current_timestamp()
     )
-    embedding_model: Mapped[Optional[str]] = mapped_column(sa.String(255), nullable=True)
-    embedding_model_provider: Mapped[Optional[str]] = mapped_column(sa.String(255), nullable=True)
-    keyword_number: Mapped[Optional[int]] = mapped_column(sa.Integer, nullable=True, server_default=sa.text("10"))
-    collection_binding_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
-    retrieval_model: Mapped[Optional[dict]] = mapped_column(AdjustedJSON, nullable=True)
-    summary_index_setting: Mapped[Optional[dict]] = mapped_column(AdjustedJSON, nullable=True)
+    embedding_model: Mapped[str | None] = mapped_column(sa.String(255), nullable=True)
+    embedding_model_provider: Mapped[str | None] = mapped_column(sa.String(255), nullable=True)
+    keyword_number: Mapped[int | None] = mapped_column(sa.Integer, nullable=True, server_default=sa.text("10"))
+    collection_binding_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
+    retrieval_model: Mapped[dict | None] = mapped_column(AdjustedJSON, nullable=True)
+    summary_index_setting: Mapped[dict | None] = mapped_column(AdjustedJSON, nullable=True)
     built_in_field_enabled: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
-    icon_info: Mapped[Optional[dict]] = mapped_column(AdjustedJSON, nullable=True)
-    runtime_mode: Mapped[Optional[str]] = mapped_column(
+    icon_info: Mapped[dict | None] = mapped_column(AdjustedJSON, nullable=True)
+    runtime_mode: Mapped[str | None] = mapped_column(
         EnumText(DatasetRuntimeMode, length=255), nullable=True, server_default=sa.text("'general'")
     )
-    pipeline_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
-    chunk_structure: Mapped[Optional[str]] = mapped_column(sa.String(255), nullable=True)
+    pipeline_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
+    chunk_structure: Mapped[str | None] = mapped_column(sa.String(255), nullable=True)
     enable_api: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("true"))
-    is_multimodal: Mapped[bool] = mapped_column(sa.Boolean, default=False, nullable=False, server_default=db.text("false"))
+    is_multimodal: Mapped[bool] = mapped_column(
+        sa.Boolean, default=False, nullable=False, server_default=db.text("false")
+    )
 
     @property
     def total_documents(self):
@@ -508,20 +510,20 @@ class Document(Base):
     dataset_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     position: Mapped[int] = mapped_column(sa.Integer, nullable=False)
     data_source_type: Mapped[str] = mapped_column(EnumText(DataSourceType, length=255), nullable=False)
-    data_source_info: Mapped[Optional[str]] = mapped_column(LongText, nullable=True)
-    dataset_process_rule_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    data_source_info: Mapped[str | None] = mapped_column(LongText, nullable=True)
+    dataset_process_rule_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     batch: Mapped[str] = mapped_column(String(255), nullable=False)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     created_from: Mapped[str] = mapped_column(EnumText(DocumentCreatedFrom, length=255), nullable=False)
     created_by: Mapped[str] = mapped_column(StringUUID, nullable=False)
-    created_api_request_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    created_api_request_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.current_timestamp())
 
     # start processing
     processing_started_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     # parsing
-    file_id: Mapped[Optional[str]] = mapped_column(LongText, nullable=True)
+    file_id: Mapped[str | None] = mapped_column(LongText, nullable=True)
     word_count: Mapped[int | None] = mapped_column(sa.Integer, nullable=True)  # TODO: make this not nullable
     parsing_completed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
@@ -538,11 +540,11 @@ class Document(Base):
 
     # pause
     is_paused: Mapped[bool | None] = mapped_column(sa.Boolean, nullable=True, server_default=sa.text("false"))
-    paused_by: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    paused_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     paused_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     # error
-    error: Mapped[Optional[str]] = mapped_column(LongText, nullable=True)
+    error: Mapped[str | None] = mapped_column(LongText, nullable=True)
     stopped_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     # basic fields
@@ -551,20 +553,20 @@ class Document(Base):
     )
     enabled: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("true"))
     disabled_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
-    disabled_by: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    disabled_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     archived: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
-    archived_reason: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
-    archived_by: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    archived_reason: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    archived_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     archived_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.current_timestamp(), onupdate=func.current_timestamp()
     )
-    doc_type: Mapped[Optional[str]] = mapped_column(EnumText(DocumentDocType, length=40), nullable=True)
-    doc_metadata: Mapped[Optional[dict]] = mapped_column(AdjustedJSON, nullable=True)
+    doc_type: Mapped[str | None] = mapped_column(EnumText(DocumentDocType, length=40), nullable=True)
+    doc_metadata: Mapped[dict | None] = mapped_column(AdjustedJSON, nullable=True)
     doc_form: Mapped[IndexStructureType] = mapped_column(
         EnumText(IndexStructureType, length=255), nullable=False, server_default=sa.text("'text_model'")
     )
-    doc_language: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    doc_language: Mapped[str | None] = mapped_column(String(255), nullable=True)
     need_summary: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
 
     DATA_SOURCES = ["upload_file", "notion_import", "website_crawl"]

--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -869,7 +869,7 @@ class DocumentSegment(TypeBase):
     index_node_hash: Mapped[str | None] = mapped_column(String(255), nullable=True, default=None)
     enabled: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("true"), default=True)
     answer: Mapped[str | None] = mapped_column(LongText, nullable=True, default=None)
-    keywords: Mapped[Any] = mapped_column(sa.JSON, nullable=True, default=None)
+    keywords: Mapped[Optional[list]] = mapped_column(sa.JSON, nullable=True, default=None)
     disabled_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True, default=None)
     disabled_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True, default=None)
     status: Mapped[SegmentStatus] = mapped_column(

--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -869,7 +869,7 @@ class DocumentSegment(TypeBase):
     index_node_hash: Mapped[str | None] = mapped_column(String(255), nullable=True, default=None)
     enabled: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("true"), default=True)
     answer: Mapped[str | None] = mapped_column(LongText, nullable=True, default=None)
-    keywords: Mapped[Optional[list]] = mapped_column(sa.JSON, nullable=True, default=None)
+    keywords: Mapped[list | None] = mapped_column(sa.JSON, nullable=True, default=None)
     disabled_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True, default=None)
     disabled_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True, default=None)
     status: Mapped[SegmentStatus] = mapped_column(

--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -9,7 +9,7 @@ import re
 import time
 from datetime import datetime
 from json import JSONDecodeError
-from typing import Any, ClassVar, TypedDict, cast, override
+from typing import Any, ClassVar, Optional, TypedDict, cast, override
 from uuid import uuid4
 
 import sqlalchemy as sa
@@ -177,37 +177,37 @@ class Dataset(Base):
     id: Mapped[str] = mapped_column(StringUUID, default=lambda: str(uuid4()))
     tenant_id: Mapped[str] = mapped_column(StringUUID)
     name: Mapped[str] = mapped_column(String(255))
-    description = mapped_column(LongText, nullable=True)
+    description: Mapped[Optional[str]] = mapped_column(LongText, nullable=True)
     provider: Mapped[str] = mapped_column(String(255), server_default=sa.text("'vendor'"))
     permission: Mapped[DatasetPermissionEnum] = mapped_column(
         EnumText(DatasetPermissionEnum, length=255),
         server_default=sa.text("'only_me'"),
         default=DatasetPermissionEnum.ONLY_ME,
     )
-    data_source_type = mapped_column(EnumText(DataSourceType, length=255))
+    data_source_type: Mapped[Optional[str]] = mapped_column(EnumText(DataSourceType, length=255))
     indexing_technique: Mapped[IndexTechniqueType | None] = mapped_column(EnumText(IndexTechniqueType, length=255))
-    index_struct = mapped_column(LongText, nullable=True)
-    created_by = mapped_column(StringUUID, nullable=False)
+    index_struct: Mapped[Optional[str]] = mapped_column(LongText, nullable=True)
+    created_by: Mapped[str] = mapped_column(StringUUID, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.current_timestamp())
-    updated_by = mapped_column(StringUUID, nullable=True)
-    updated_at = mapped_column(
+    updated_by: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(
         sa.DateTime, nullable=False, server_default=func.current_timestamp(), onupdate=func.current_timestamp()
     )
-    embedding_model = mapped_column(sa.String(255), nullable=True)
-    embedding_model_provider = mapped_column(sa.String(255), nullable=True)
-    keyword_number = mapped_column(sa.Integer, nullable=True, server_default=sa.text("10"))
-    collection_binding_id = mapped_column(StringUUID, nullable=True)
-    retrieval_model = mapped_column(AdjustedJSON, nullable=True)
-    summary_index_setting = mapped_column(AdjustedJSON, nullable=True)
-    built_in_field_enabled = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
-    icon_info = mapped_column(AdjustedJSON, nullable=True)
-    runtime_mode = mapped_column(
+    embedding_model: Mapped[Optional[str]] = mapped_column(sa.String(255), nullable=True)
+    embedding_model_provider: Mapped[Optional[str]] = mapped_column(sa.String(255), nullable=True)
+    keyword_number: Mapped[Optional[int]] = mapped_column(sa.Integer, nullable=True, server_default=sa.text("10"))
+    collection_binding_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    retrieval_model: Mapped[Optional[dict]] = mapped_column(AdjustedJSON, nullable=True)
+    summary_index_setting: Mapped[Optional[dict]] = mapped_column(AdjustedJSON, nullable=True)
+    built_in_field_enabled: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
+    icon_info: Mapped[Optional[dict]] = mapped_column(AdjustedJSON, nullable=True)
+    runtime_mode: Mapped[Optional[str]] = mapped_column(
         EnumText(DatasetRuntimeMode, length=255), nullable=True, server_default=sa.text("'general'")
     )
-    pipeline_id = mapped_column(StringUUID, nullable=True)
-    chunk_structure = mapped_column(sa.String(255), nullable=True)
-    enable_api = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("true"))
-    is_multimodal = mapped_column(sa.Boolean, default=False, nullable=False, server_default=db.text("false"))
+    pipeline_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    chunk_structure: Mapped[Optional[str]] = mapped_column(sa.String(255), nullable=True)
+    enable_api: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("true"))
+    is_multimodal: Mapped[bool] = mapped_column(sa.Boolean, default=False, nullable=False, server_default=db.text("false"))
 
     @property
     def total_documents(self):
@@ -503,25 +503,25 @@ class Document(Base):
     )
 
     # initial fields
-    id = mapped_column(StringUUID, nullable=False, default=lambda: str(uuid4()))
-    tenant_id = mapped_column(StringUUID, nullable=False)
-    dataset_id = mapped_column(StringUUID, nullable=False)
+    id: Mapped[str] = mapped_column(StringUUID, nullable=False, default=lambda: str(uuid4()))
+    tenant_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
+    dataset_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     position: Mapped[int] = mapped_column(sa.Integer, nullable=False)
     data_source_type: Mapped[str] = mapped_column(EnumText(DataSourceType, length=255), nullable=False)
-    data_source_info = mapped_column(LongText, nullable=True)
-    dataset_process_rule_id = mapped_column(StringUUID, nullable=True)
+    data_source_info: Mapped[Optional[str]] = mapped_column(LongText, nullable=True)
+    dataset_process_rule_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
     batch: Mapped[str] = mapped_column(String(255), nullable=False)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     created_from: Mapped[str] = mapped_column(EnumText(DocumentCreatedFrom, length=255), nullable=False)
-    created_by = mapped_column(StringUUID, nullable=False)
-    created_api_request_id = mapped_column(StringUUID, nullable=True)
+    created_by: Mapped[str] = mapped_column(StringUUID, nullable=False)
+    created_api_request_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.current_timestamp())
 
     # start processing
     processing_started_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     # parsing
-    file_id = mapped_column(LongText, nullable=True)
+    file_id: Mapped[Optional[str]] = mapped_column(LongText, nullable=True)
     word_count: Mapped[int | None] = mapped_column(sa.Integer, nullable=True)  # TODO: make this not nullable
     parsing_completed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
@@ -538,33 +538,33 @@ class Document(Base):
 
     # pause
     is_paused: Mapped[bool | None] = mapped_column(sa.Boolean, nullable=True, server_default=sa.text("false"))
-    paused_by = mapped_column(StringUUID, nullable=True)
+    paused_by: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
     paused_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     # error
-    error = mapped_column(LongText, nullable=True)
+    error: Mapped[Optional[str]] = mapped_column(LongText, nullable=True)
     stopped_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     # basic fields
-    indexing_status = mapped_column(
+    indexing_status: Mapped[str] = mapped_column(
         EnumText(IndexingStatus, length=255), nullable=False, server_default=sa.text("'waiting'")
     )
     enabled: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("true"))
     disabled_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
-    disabled_by = mapped_column(StringUUID, nullable=True)
+    disabled_by: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
     archived: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
-    archived_reason = mapped_column(String(255), nullable=True)
-    archived_by = mapped_column(StringUUID, nullable=True)
+    archived_reason: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    archived_by: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
     archived_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.current_timestamp(), onupdate=func.current_timestamp()
     )
-    doc_type = mapped_column(EnumText(DocumentDocType, length=40), nullable=True)
-    doc_metadata = mapped_column(AdjustedJSON, nullable=True)
+    doc_type: Mapped[Optional[str]] = mapped_column(EnumText(DocumentDocType, length=40), nullable=True)
+    doc_metadata: Mapped[Optional[dict]] = mapped_column(AdjustedJSON, nullable=True)
     doc_form: Mapped[IndexStructureType] = mapped_column(
         EnumText(IndexStructureType, length=255), nullable=False, server_default=sa.text("'text_model'")
     )
-    doc_language = mapped_column(String(255), nullable=True)
+    doc_language: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     need_summary: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
 
     DATA_SOURCES = ["upload_file", "notion_import", "website_crawl"]

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from decimal import Decimal
 from enum import StrEnum, auto
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict, cast, override
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, Optional, TypedDict, cast, override
 from uuid import uuid4
 
 import sqlalchemy as sa
@@ -403,10 +403,10 @@ class App(Base):
     description: Mapped[str] = mapped_column(LongText, default=sa.text("''"))
     mode: Mapped[AppMode] = mapped_column(EnumText(AppMode, length=255))
     icon_type: Mapped[IconType | None] = mapped_column(EnumText(IconType, length=255))
-    icon = mapped_column(String(255))
+    icon: Mapped[Optional[str]] = mapped_column(String(255))
     icon_background: Mapped[str | None] = mapped_column(String(255))
-    app_model_config_id = mapped_column(StringUUID, nullable=True)
-    workflow_id = mapped_column(StringUUID, nullable=True)
+    app_model_config_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    workflow_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
     status: Mapped[AppStatus] = mapped_column(
         EnumText(AppStatus, length=255), server_default=sa.text("'normal'"), default=AppStatus.NORMAL
     )
@@ -417,11 +417,11 @@ class App(Base):
     is_demo: Mapped[bool] = mapped_column(sa.Boolean, server_default=sa.text("false"))
     is_public: Mapped[bool] = mapped_column(sa.Boolean, server_default=sa.text("false"))
     is_universal: Mapped[bool] = mapped_column(sa.Boolean, server_default=sa.text("false"))
-    tracing = mapped_column(LongText, nullable=True)
+    tracing: Mapped[Optional[str]] = mapped_column(LongText, nullable=True)
     max_active_requests: Mapped[int | None]
-    created_by = mapped_column(StringUUID, nullable=True)
-    created_at = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())
-    updated_by = mapped_column(StringUUID, nullable=True)
+    created_by: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())
+    updated_by: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
     updated_at: Mapped[datetime] = mapped_column(
         sa.DateTime, nullable=False, server_default=func.current_timestamp(), onupdate=func.current_timestamp()
     )
@@ -1086,17 +1086,17 @@ class Conversation(Base):
     )
 
     id: Mapped[str] = mapped_column(StringUUID, default=lambda: str(uuid4()))
-    app_id = mapped_column(StringUUID, nullable=False)
-    app_model_config_id = mapped_column(StringUUID, nullable=True)
-    model_provider = mapped_column(String(255), nullable=True)
-    override_model_configs = mapped_column(LongText)
-    model_id = mapped_column(String(255), nullable=True)
+    app_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
+    app_model_config_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    model_provider: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    override_model_configs: Mapped[Optional[str]] = mapped_column(LongText)
+    model_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     mode: Mapped[AppMode] = mapped_column(EnumText(AppMode, length=255))
     name: Mapped[str] = mapped_column(String(255), nullable=False)
-    summary = mapped_column(LongText)
+    summary: Mapped[Optional[str]] = mapped_column(LongText)
     _inputs: Mapped[dict[str, Any]] = mapped_column("inputs", sa.JSON)
-    introduction = mapped_column(LongText)
-    system_instruction = mapped_column(LongText)
+    introduction: Mapped[Optional[str]] = mapped_column(LongText)
+    system_instruction: Mapped[Optional[str]] = mapped_column(LongText)
     system_instruction_tokens: Mapped[int] = mapped_column(sa.Integer, nullable=False, server_default=sa.text("0"))
     status: Mapped[ConversationStatus] = mapped_column(
         EnumText(ConversationStatus, length=255), nullable=False, default=ConversationStatus.NORMAL
@@ -1112,13 +1112,13 @@ class Conversation(Base):
     from_source: Mapped[ConversationFromSource] = mapped_column(
         EnumText(ConversationFromSource, length=255), nullable=False
     )
-    from_end_user_id = mapped_column(StringUUID)
-    from_account_id = mapped_column(StringUUID)
-    read_at = mapped_column(sa.DateTime)
-    read_account_id = mapped_column(StringUUID)
+    from_end_user_id: Mapped[Optional[str]] = mapped_column(StringUUID)
+    from_account_id: Mapped[Optional[str]] = mapped_column(StringUUID)
+    read_at: Mapped[Optional[datetime]] = mapped_column(sa.DateTime)
+    read_account_id: Mapped[Optional[str]] = mapped_column(StringUUID)
     dialogue_count: Mapped[int] = mapped_column(default=0)
-    created_at = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())
-    updated_at = mapped_column(
+    created_at: Mapped[datetime] = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())
+    updated_at: Mapped[datetime] = mapped_column(
         sa.DateTime, nullable=False, server_default=func.current_timestamp(), onupdate=func.current_timestamp()
     )
 
@@ -2049,10 +2049,10 @@ class EndUser(Base, UserMixin):
 
     id: Mapped[str] = mapped_column(StringUUID, default=lambda: str(uuid4()))
     tenant_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
-    app_id = mapped_column(StringUUID, nullable=True)
+    app_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
     type: Mapped[str] = mapped_column(String(255), nullable=False)
-    external_user_id = mapped_column(String(255), nullable=True)
-    name = mapped_column(String(255))
+    external_user_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    name: Mapped[Optional[str]] = mapped_column(String(255))
     _is_anonymous: Mapped[bool] = mapped_column(
         "is_anonymous", sa.Boolean, nullable=False, server_default=sa.text("true")
     )
@@ -2068,8 +2068,8 @@ class EndUser(Base, UserMixin):
         self._is_anonymous = value
 
     session_id: Mapped[str] = mapped_column(String(255), nullable=False)
-    created_at = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())
-    updated_at = mapped_column(
+    created_at: Mapped[datetime] = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())
+    updated_at: Mapped[datetime] = mapped_column(
         sa.DateTime, nullable=False, server_default=func.current_timestamp(), onupdate=func.current_timestamp()
     )
 
@@ -2129,22 +2129,22 @@ class Site(Base):
         sa.Index("site_code_idx", "code", "status"),
     )
 
-    id = mapped_column(StringUUID, default=lambda: str(uuid4()))
-    app_id = mapped_column(StringUUID, nullable=False)
+    id: Mapped[Optional[str]] = mapped_column(StringUUID, default=lambda: str(uuid4()))
+    app_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     icon_type: Mapped[IconType | None] = mapped_column(EnumText(IconType, length=255), nullable=True)
-    icon = mapped_column(String(255))
-    icon_background = mapped_column(String(255))
-    description = mapped_column(LongText)
+    icon: Mapped[Optional[str]] = mapped_column(String(255))
+    icon_background: Mapped[Optional[str]] = mapped_column(String(255))
+    description: Mapped[Optional[str]] = mapped_column(LongText)
     default_language: Mapped[str] = mapped_column(String(255), nullable=False)
-    chat_color_theme = mapped_column(String(255))
+    chat_color_theme: Mapped[Optional[str]] = mapped_column(String(255))
     chat_color_theme_inverted: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
-    copyright = mapped_column(String(255))
-    privacy_policy = mapped_column(String(255))
+    copyright: Mapped[Optional[str]] = mapped_column(String(255))
+    privacy_policy: Mapped[Optional[str]] = mapped_column(String(255))
     show_workflow_steps: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("true"))
     use_icon_as_answer_icon: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
     _custom_disclaimer: Mapped[str] = mapped_column("custom_disclaimer", LongText, default="")
-    customize_domain = mapped_column(String(255))
+    customize_domain: Mapped[Optional[str]] = mapped_column(String(255))
     customize_token_strategy: Mapped[CustomizeTokenStrategy] = mapped_column(
         EnumText(CustomizeTokenStrategy, length=255), nullable=False
     )
@@ -2152,13 +2152,13 @@ class Site(Base):
     status: Mapped[AppStatus] = mapped_column(
         EnumText(AppStatus, length=255), nullable=False, server_default=sa.text("'normal'"), default=AppStatus.NORMAL
     )
-    created_by = mapped_column(StringUUID, nullable=True)
-    created_at = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())
-    updated_by = mapped_column(StringUUID, nullable=True)
-    updated_at = mapped_column(
+    created_by: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())
+    updated_by: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(
         sa.DateTime, nullable=False, server_default=func.current_timestamp(), onupdate=func.current_timestamp()
     )
-    code = mapped_column(String(255))
+    code: Mapped[Optional[str]] = mapped_column(String(255))
 
     @property
     def custom_disclaimer(self):
@@ -2193,13 +2193,13 @@ class ApiToken(Base):  # bug: this uses setattr so idk the field.
         sa.Index("api_token_tenant_idx", "tenant_id", "type"),
     )
 
-    id = mapped_column(StringUUID, default=lambda: str(uuid4()))
-    app_id = mapped_column(StringUUID, nullable=True)
-    tenant_id = mapped_column(StringUUID, nullable=True)
+    id: Mapped[Optional[str]] = mapped_column(StringUUID, default=lambda: str(uuid4()))
+    app_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    tenant_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
     type: Mapped[ApiTokenType] = mapped_column(EnumText(ApiTokenType, length=16), nullable=False)
     token: Mapped[str] = mapped_column(String(255), nullable=False)
-    last_used_at = mapped_column(sa.DateTime, nullable=True)
-    created_at = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())
+    last_used_at: Mapped[Optional[datetime]] = mapped_column(sa.DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())
 
     @staticmethod
     def generate_api_key(prefix: str, n: int) -> str:

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -899,7 +899,7 @@ class RecommendedApp(TypeBase):
         init=False,
     )
     app_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
-    description: Mapped[Any] = mapped_column(sa.JSON, nullable=False)
+    description: Mapped[dict] = mapped_column(sa.JSON, nullable=False)
     copyright: Mapped[str] = mapped_column(String(255), nullable=False)
     privacy_policy: Mapped[str] = mapped_column(String(255), nullable=False)
     category: Mapped[str] = mapped_column(String(255), nullable=False)

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from decimal import Decimal
 from enum import StrEnum, auto
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Literal, NotRequired, Optional, TypedDict, cast, override
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict, cast, override
 from uuid import uuid4
 
 import sqlalchemy as sa
@@ -403,10 +403,10 @@ class App(Base):
     description: Mapped[str] = mapped_column(LongText, default=sa.text("''"))
     mode: Mapped[AppMode] = mapped_column(EnumText(AppMode, length=255))
     icon_type: Mapped[IconType | None] = mapped_column(EnumText(IconType, length=255))
-    icon: Mapped[Optional[str]] = mapped_column(String(255))
+    icon: Mapped[str | None] = mapped_column(String(255))
     icon_background: Mapped[str | None] = mapped_column(String(255))
-    app_model_config_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
-    workflow_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    app_model_config_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
+    workflow_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     status: Mapped[AppStatus] = mapped_column(
         EnumText(AppStatus, length=255), server_default=sa.text("'normal'"), default=AppStatus.NORMAL
     )
@@ -417,11 +417,11 @@ class App(Base):
     is_demo: Mapped[bool] = mapped_column(sa.Boolean, server_default=sa.text("false"))
     is_public: Mapped[bool] = mapped_column(sa.Boolean, server_default=sa.text("false"))
     is_universal: Mapped[bool] = mapped_column(sa.Boolean, server_default=sa.text("false"))
-    tracing: Mapped[Optional[str]] = mapped_column(LongText, nullable=True)
+    tracing: Mapped[str | None] = mapped_column(LongText, nullable=True)
     max_active_requests: Mapped[int | None]
-    created_by: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    created_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     created_at: Mapped[datetime] = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())
-    updated_by: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    updated_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     updated_at: Mapped[datetime] = mapped_column(
         sa.DateTime, nullable=False, server_default=func.current_timestamp(), onupdate=func.current_timestamp()
     )
@@ -1087,16 +1087,16 @@ class Conversation(Base):
 
     id: Mapped[str] = mapped_column(StringUUID, default=lambda: str(uuid4()))
     app_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
-    app_model_config_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
-    model_provider: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
-    override_model_configs: Mapped[Optional[str]] = mapped_column(LongText)
-    model_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    app_model_config_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
+    model_provider: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    override_model_configs: Mapped[str | None] = mapped_column(LongText)
+    model_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     mode: Mapped[AppMode] = mapped_column(EnumText(AppMode, length=255))
     name: Mapped[str] = mapped_column(String(255), nullable=False)
-    summary: Mapped[Optional[str]] = mapped_column(LongText)
+    summary: Mapped[str | None] = mapped_column(LongText)
     _inputs: Mapped[dict[str, Any]] = mapped_column("inputs", sa.JSON)
-    introduction: Mapped[Optional[str]] = mapped_column(LongText)
-    system_instruction: Mapped[Optional[str]] = mapped_column(LongText)
+    introduction: Mapped[str | None] = mapped_column(LongText)
+    system_instruction: Mapped[str | None] = mapped_column(LongText)
     system_instruction_tokens: Mapped[int] = mapped_column(sa.Integer, nullable=False, server_default=sa.text("0"))
     status: Mapped[ConversationStatus] = mapped_column(
         EnumText(ConversationStatus, length=255), nullable=False, default=ConversationStatus.NORMAL
@@ -1112,10 +1112,10 @@ class Conversation(Base):
     from_source: Mapped[ConversationFromSource] = mapped_column(
         EnumText(ConversationFromSource, length=255), nullable=False
     )
-    from_end_user_id: Mapped[Optional[str]] = mapped_column(StringUUID)
-    from_account_id: Mapped[Optional[str]] = mapped_column(StringUUID)
-    read_at: Mapped[Optional[datetime]] = mapped_column(sa.DateTime)
-    read_account_id: Mapped[Optional[str]] = mapped_column(StringUUID)
+    from_end_user_id: Mapped[str | None] = mapped_column(StringUUID)
+    from_account_id: Mapped[str | None] = mapped_column(StringUUID)
+    read_at: Mapped[datetime | None] = mapped_column(sa.DateTime)
+    read_account_id: Mapped[str | None] = mapped_column(StringUUID)
     dialogue_count: Mapped[int] = mapped_column(default=0)
     created_at: Mapped[datetime] = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())
     updated_at: Mapped[datetime] = mapped_column(
@@ -2049,10 +2049,10 @@ class EndUser(Base, UserMixin):
 
     id: Mapped[str] = mapped_column(StringUUID, default=lambda: str(uuid4()))
     tenant_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
-    app_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    app_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     type: Mapped[str] = mapped_column(String(255), nullable=False)
-    external_user_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
-    name: Mapped[Optional[str]] = mapped_column(String(255))
+    external_user_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    name: Mapped[str | None] = mapped_column(String(255))
     _is_anonymous: Mapped[bool] = mapped_column(
         "is_anonymous", sa.Boolean, nullable=False, server_default=sa.text("true")
     )
@@ -2129,22 +2129,22 @@ class Site(Base):
         sa.Index("site_code_idx", "code", "status"),
     )
 
-    id: Mapped[Optional[str]] = mapped_column(StringUUID, default=lambda: str(uuid4()))
+    id: Mapped[str | None] = mapped_column(StringUUID, default=lambda: str(uuid4()))
     app_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     icon_type: Mapped[IconType | None] = mapped_column(EnumText(IconType, length=255), nullable=True)
-    icon: Mapped[Optional[str]] = mapped_column(String(255))
-    icon_background: Mapped[Optional[str]] = mapped_column(String(255))
-    description: Mapped[Optional[str]] = mapped_column(LongText)
+    icon: Mapped[str | None] = mapped_column(String(255))
+    icon_background: Mapped[str | None] = mapped_column(String(255))
+    description: Mapped[str | None] = mapped_column(LongText)
     default_language: Mapped[str] = mapped_column(String(255), nullable=False)
-    chat_color_theme: Mapped[Optional[str]] = mapped_column(String(255))
+    chat_color_theme: Mapped[str | None] = mapped_column(String(255))
     chat_color_theme_inverted: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
-    copyright: Mapped[Optional[str]] = mapped_column(String(255))
-    privacy_policy: Mapped[Optional[str]] = mapped_column(String(255))
+    copyright: Mapped[str | None] = mapped_column(String(255))
+    privacy_policy: Mapped[str | None] = mapped_column(String(255))
     show_workflow_steps: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("true"))
     use_icon_as_answer_icon: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
     _custom_disclaimer: Mapped[str] = mapped_column("custom_disclaimer", LongText, default="")
-    customize_domain: Mapped[Optional[str]] = mapped_column(String(255))
+    customize_domain: Mapped[str | None] = mapped_column(String(255))
     customize_token_strategy: Mapped[CustomizeTokenStrategy] = mapped_column(
         EnumText(CustomizeTokenStrategy, length=255), nullable=False
     )
@@ -2152,13 +2152,13 @@ class Site(Base):
     status: Mapped[AppStatus] = mapped_column(
         EnumText(AppStatus, length=255), nullable=False, server_default=sa.text("'normal'"), default=AppStatus.NORMAL
     )
-    created_by: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    created_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     created_at: Mapped[datetime] = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())
-    updated_by: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    updated_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     updated_at: Mapped[datetime] = mapped_column(
         sa.DateTime, nullable=False, server_default=func.current_timestamp(), onupdate=func.current_timestamp()
     )
-    code: Mapped[Optional[str]] = mapped_column(String(255))
+    code: Mapped[str | None] = mapped_column(String(255))
 
     @property
     def custom_disclaimer(self):
@@ -2193,12 +2193,12 @@ class ApiToken(Base):  # bug: this uses setattr so idk the field.
         sa.Index("api_token_tenant_idx", "tenant_id", "type"),
     )
 
-    id: Mapped[Optional[str]] = mapped_column(StringUUID, default=lambda: str(uuid4()))
-    app_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
-    tenant_id: Mapped[Optional[str]] = mapped_column(StringUUID, nullable=True)
+    id: Mapped[str | None] = mapped_column(StringUUID, default=lambda: str(uuid4()))
+    app_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
+    tenant_id: Mapped[str | None] = mapped_column(StringUUID, nullable=True)
     type: Mapped[ApiTokenType] = mapped_column(EnumText(ApiTokenType, length=16), nullable=False)
     token: Mapped[str] = mapped_column(String(255), nullable=False)
-    last_used_at: Mapped[Optional[datetime]] = mapped_column(sa.DateTime, nullable=True)
+    last_used_at: Mapped[datetime | None] = mapped_column(sa.DateTime, nullable=True)
     created_at: Mapped[datetime] = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())
 
     @staticmethod


### PR DESCRIPTION
## Summary

Part of #22652

Add explicit `Mapped[T]` type annotations to model fields that were using bare `mapped_column()` calls or `Mapped[Any]` without precise types. This improves type safety, IDE autocompletion, and consistency with the rest of the codebase.

### Changes

**Phase 1: Add `Mapped[]` annotations to unmapped fields (81 fields)**
- **models/model.py**: 45 fields annotated
- **models/dataset.py**: 36 fields annotated

**Phase 2: Replace `Mapped[Any]` with precise types (4 fields)**
- **models/agent.py**: `config_snapshot` → `Mapped[AgentSoulConfig]`
- **models/agent.py**: `node_job_config` → `Mapped[WorkflowNodeJobConfig]`
- **models/dataset.py**: `keywords` → `Mapped[Optional[list]]`
- **models/model.py**: `description` → `Mapped[dict]`

### Pattern applied

```python
# Before (no type annotation):
description = mapped_column(LongText, nullable=True)
created_at = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())

# After (with Mapped[] annotation):
description: Mapped[Optional[str]] = mapped_column(LongText, nullable=True)
created_at: Mapped[datetime] = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())

# Before (Any type):
config_snapshot: Mapped[Any] = mapped_column(JSONModelColumn(AgentSoulConfig), nullable=False)

# After (precise type):
config_snapshot: Mapped[AgentSoulConfig] = mapped_column(JSONModelColumn(AgentSoulConfig), nullable=False)
```

### Type mapping

| Column Type | Python Type | Nullable |
|---|---|---|
| StringUUID / String / LongText / Text | `str` | `Optional[str]` if nullable |
| DateTime | `datetime` | `Optional[datetime]` if nullable |
| Integer | `int` | `Optional[int]` if nullable |
| Boolean | `bool` | `Optional[bool]` if nullable |
| Numeric | `Decimal` | `Optional[Decimal]` if nullable |
| JSONB / AdjustedJSON | `dict` | `Optional[dict]` if nullable |
| EnumText | `str` | `Optional[str]` if nullable |
| JSONModelColumn(T) | `T` | `Optional[T]` if nullable |

### Verification

- `python3 -m py_compile models/model.py` ✅
- `python3 -m py_compile models/dataset.py` ✅
- `python3 -m py_compile models/agent.py` ✅
- `ruff check` — no new errors introduced
- Zero `Mapped[Any]` remaining in models/ directory
