### PR TITLE
fix(api): restore agent roster mutations

### DIFF
--- a/api/controllers/console/agent/roster.py
+++ b/api/controllers/console/agent/roster.py
@@ -8,8 +8,10 @@ from controllers.common.schema import query_params_from_model, register_response
 from controllers.console import console_ns
 from controllers.console.wraps import (
     account_initialization_required,
+    edit_permission_required,
     setup_required,
     with_current_tenant_id,
+    with_current_user_id,
 )
 from extensions.ext_database import db
 from fields.agent_fields import (
@@ -23,7 +25,11 @@ from fields.agent_fields import (
 from libs.helper import dump_response
 from libs.login import login_required
 from services.agent.roster_service import AgentRosterService
-from services.entities.agent_entities import RosterListQuery
+from services.entities.agent_entities import (
+    RosterAgentCreatePayload,
+    RosterAgentUpdatePayload,
+    RosterListQuery,
+)
 
 
 class AgentInviteOptionsQuery(RosterListQuery):
@@ -38,6 +44,8 @@ register_schema_models(
     console_ns,
     AgentInviteOptionsQuery,
     AgentIdPath,
+    RosterAgentCreatePayload,
+    RosterAgentUpdatePayload,
     RosterListQuery,
 )
 register_response_schema_models(
@@ -70,6 +78,26 @@ class AgentRosterListApi(Resource):
             _agent_roster_service().list_roster_agents(
                 tenant_id=tenant_id, page=query.page, limit=query.limit, keyword=query.keyword
             ),
+        )
+
+    @console_ns.expect(console_ns.models[RosterAgentCreatePayload.__name__])
+    @console_ns.response(201, "Agent created", console_ns.models[AgentRosterResponse.__name__])
+    @setup_required
+    @login_required
+    @account_initialization_required
+    @edit_permission_required
+    @with_current_user_id
+    @with_current_tenant_id
+    def post(self, tenant_id: str, account_id: str):
+        payload = RosterAgentCreatePayload.model_validate(console_ns.payload or {})
+        service = _agent_roster_service()
+        agent = service.create_roster_agent(tenant_id=tenant_id, account_id=account_id, payload=payload)
+        return (
+            dump_response(
+                AgentRosterResponse,
+                service.get_roster_agent_detail(tenant_id=tenant_id, agent_id=agent.id),
+            ),
+            201,
         )
 
 
@@ -107,6 +135,41 @@ class AgentRosterDetailApi(Resource):
             AgentRosterResponse,
             _agent_roster_service().get_roster_agent_detail(tenant_id=tenant_id, agent_id=str(agent_id)),
         )
+
+    @console_ns.expect(console_ns.models[RosterAgentUpdatePayload.__name__])
+    @console_ns.response(200, "Agent updated", console_ns.models[AgentRosterResponse.__name__])
+    @setup_required
+    @login_required
+    @account_initialization_required
+    @edit_permission_required
+    @with_current_user_id
+    @with_current_tenant_id
+    def patch(self, tenant_id: str, account_id: str, agent_id: UUID):
+        payload = RosterAgentUpdatePayload.model_validate(console_ns.payload or {})
+        return dump_response(
+            AgentRosterResponse,
+            _agent_roster_service().update_roster_agent(
+                tenant_id=tenant_id,
+                agent_id=str(agent_id),
+                account_id=account_id,
+                payload=payload,
+            ),
+        )
+
+    @console_ns.response(204, "Agent archived")
+    @setup_required
+    @login_required
+    @account_initialization_required
+    @edit_permission_required
+    @with_current_user_id
+    @with_current_tenant_id
+    def delete(self, tenant_id: str, account_id: str, agent_id: UUID):
+        _agent_roster_service().archive_roster_agent(
+            tenant_id=tenant_id,
+            agent_id=str(agent_id),
+            account_id=account_id,
+        )
+        return "", 204
 
 
 @console_ns.route("/agents/<uuid:agent_id>/versions")

--- a/api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
+++ b/api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
@@ -149,10 +149,77 @@ def test_roster_list_get_parses_query_and_calls_service(app: Flask, monkeypatch:
     assert captured == {"tenant_id": "tenant-1", "page": 2, "limit": 5, "keyword": "analyst"}
 
 
-def test_roster_direct_mutation_endpoints_are_not_exposed() -> None:
-    assert not hasattr(AgentRosterListApi, "post")
-    assert not hasattr(AgentRosterDetailApi, "patch")
-    assert not hasattr(AgentRosterDetailApi, "delete")
+def test_roster_create_validates_payload_and_calls_service(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+    agent = SimpleNamespace(id="agent-1")
+
+    def create_roster_agent(_self: object, **kwargs: object) -> object:
+        captured.update(kwargs)
+        return agent
+
+    monkeypatch.setattr(roster_controller.AgentRosterService, "create_roster_agent", create_roster_agent)
+    monkeypatch.setattr(
+        roster_controller.AgentRosterService,
+        "get_roster_agent_detail",
+        lambda _self, **kwargs: _agent_response(cast(str, kwargs["agent_id"])),
+    )
+
+    payload = {
+        "name": "Analyst",
+        "description": "Research markets",
+        "role": "Researcher",
+        "icon_type": "emoji",
+        "icon": "🧸",
+        "icon_background": "#F5F3FF",
+    }
+    with app.test_request_context(json=payload):
+        response, status = unwrap(AgentRosterListApi.post)(AgentRosterListApi(), "tenant-1", "account-1")
+
+    assert status == 201
+    assert response["id"] == "agent-1"
+    assert captured["tenant_id"] == "tenant-1"
+    assert captured["account_id"] == "account-1"
+    assert captured["payload"].name == "Analyst"
+    assert captured["payload"].role == "Researcher"
+
+
+def test_roster_update_validates_payload_and_calls_service(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+    agent_id = "00000000-0000-0000-0000-000000000001"
+
+    def update_roster_agent(_self: object, **kwargs: object) -> dict:
+        captured.update(kwargs)
+        return _agent_response(cast(str, kwargs["agent_id"]))
+
+    monkeypatch.setattr(roster_controller.AgentRosterService, "update_roster_agent", update_roster_agent)
+
+    with app.test_request_context(json={"name": "Updated Analyst", "role": "Planner"}):
+        response = unwrap(AgentRosterDetailApi.patch)(AgentRosterDetailApi(), "tenant-1", "account-1", agent_id)
+
+    assert response["id"] == agent_id
+    assert captured["tenant_id"] == "tenant-1"
+    assert captured["account_id"] == "account-1"
+    assert captured["agent_id"] == agent_id
+    assert captured["payload"].name == "Updated Analyst"
+    assert captured["payload"].role == "Planner"
+
+
+def test_roster_delete_archives_agent(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+    agent_id = "00000000-0000-0000-0000-000000000001"
+
+    def archive_roster_agent(_self: object, **kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(roster_controller.AgentRosterService, "archive_roster_agent", archive_roster_agent)
+
+    with app.test_request_context():
+        response, status = unwrap(AgentRosterDetailApi.delete)(
+            AgentRosterDetailApi(), "tenant-1", "account-1", agent_id
+        )
+
+    assert (response, status) == ("", 204)
+    assert captured == {"tenant_id": "tenant-1", "agent_id": agent_id, "account_id": "account-1"}
 
 
 def test_invite_options_get_parses_app_id(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/contracts/generated/api/console/agents/orpc.gen.ts
+++ b/packages/contracts/generated/api/console/agents/orpc.gen.ts
@@ -4,6 +4,8 @@ import { oc } from '@orpc/contract'
 import * as z from 'zod'
 
 import {
+  zDeleteAgentsByAgentIdPath,
+  zDeleteAgentsByAgentIdResponse,
   zGetAgentsByAgentIdPath,
   zGetAgentsByAgentIdResponse,
   zGetAgentsByAgentIdVersionsByVersionIdPath,
@@ -14,6 +16,11 @@ import {
   zGetAgentsInviteOptionsResponse,
   zGetAgentsQuery,
   zGetAgentsResponse,
+  zPatchAgentsByAgentIdBody,
+  zPatchAgentsByAgentIdPath,
+  zPatchAgentsByAgentIdResponse,
+  zPostAgentsBody,
+  zPostAgentsResponse,
 } from './zod.gen'
 
 export const get = oc
@@ -62,6 +69,18 @@ export const versions = {
   byVersionId,
 }
 
+export const delete_ = oc
+  .route({
+    inputStructure: 'detailed',
+    method: 'DELETE',
+    operationId: 'deleteAgentsByAgentId',
+    path: '/agents/{agent_id}',
+    successStatus: 204,
+    tags: ['console'],
+  })
+  .input(z.object({ params: zDeleteAgentsByAgentIdPath }))
+  .output(zDeleteAgentsByAgentIdResponse)
+
 export const get4 = oc
   .route({
     inputStructure: 'detailed',
@@ -73,8 +92,21 @@ export const get4 = oc
   .input(z.object({ params: zGetAgentsByAgentIdPath }))
   .output(zGetAgentsByAgentIdResponse)
 
+export const patch = oc
+  .route({
+    inputStructure: 'detailed',
+    method: 'PATCH',
+    operationId: 'patchAgentsByAgentId',
+    path: '/agents/{agent_id}',
+    tags: ['console'],
+  })
+  .input(z.object({ body: zPatchAgentsByAgentIdBody, params: zPatchAgentsByAgentIdPath }))
+  .output(zPatchAgentsByAgentIdResponse)
+
 export const byAgentId = {
+  delete: delete_,
   get: get4,
+  patch,
   versions,
 }
 
@@ -89,8 +121,21 @@ export const get5 = oc
   .input(z.object({ query: zGetAgentsQuery.optional() }))
   .output(zGetAgentsResponse)
 
+export const post = oc
+  .route({
+    inputStructure: 'detailed',
+    method: 'POST',
+    operationId: 'postAgents',
+    path: '/agents',
+    successStatus: 201,
+    tags: ['console'],
+  })
+  .input(z.object({ body: zPostAgentsBody }))
+  .output(zPostAgentsResponse)
+
 export const agents = {
   get: get5,
+  post,
   inviteOptions,
   byAgentId,
 }

--- a/packages/contracts/generated/api/console/agents/types.gen.ts
+++ b/packages/contracts/generated/api/console/agents/types.gen.ts
@@ -12,12 +12,16 @@ export type AgentRosterListResponse = {
   total: number
 }
 
-export type AgentInviteOptionsResponse = {
-  data: Array<AgentInviteOptionResponse>
-  has_more: boolean
-  limit: number
-  page: number
-  total: number
+export type RosterAgentCreatePayload = {
+  agent_soul?: AgentSoulConfig
+  description?: string
+  icon?: string | null
+  icon_background?: string | null
+  icon_type?: AgentIconType | null
+  mode?: 'agent'
+  name: string
+  role?: string
+  version_note?: string | null
 }
 
 export type AgentRosterResponse = {
@@ -48,6 +52,23 @@ export type AgentRosterResponse = {
   workflow_node_id?: string | null
 }
 
+export type AgentInviteOptionsResponse = {
+  data: Array<AgentInviteOptionResponse>
+  has_more: boolean
+  limit: number
+  page: number
+  total: number
+}
+
+export type RosterAgentUpdatePayload = {
+  description?: string | null
+  icon?: string | null
+  icon_background?: string | null
+  icon_type?: AgentIconType | null
+  name?: string | null
+  role?: string | null
+}
+
 export type AgentConfigSnapshotListResponse = {
   data: Array<AgentConfigSnapshotSummaryResponse>
 }
@@ -63,6 +84,51 @@ export type AgentConfigSnapshotDetailResponse = {
   version: number
   version_note?: string | null
 }
+
+export type AgentSoulConfig = {
+  app_features?: AgentSoulAppFeaturesConfig
+  app_variables?: Array<AppVariableConfig>
+  env?: AgentSoulEnvConfig
+  human?: AgentSoulHumanConfig
+  knowledge?: AgentSoulKnowledgeConfig
+  memory?: AgentSoulMemoryConfig
+  misc_legacy?: AgentSoulAppFeaturesConfig
+  model?: AgentSoulModelConfig | null
+  prompt?: AgentSoulPromptConfig
+  sandbox?: AgentSoulSandboxConfig
+  schema_version?: number
+  skills_files?: AgentSoulSkillsFilesConfig
+  tools?: AgentSoulToolsConfig
+}
+
+export type AgentIconType = 'emoji' | 'image' | 'link'
+
+export type AgentConfigSnapshotSummaryResponse = {
+  agent_id?: string | null
+  created_at?: number | null
+  created_by?: string | null
+  id: string
+  summary?: string | null
+  version: number
+  version_note?: string | null
+}
+
+export type AgentKind = 'dify_agent'
+
+export type AgentPublishedReferenceResponse = {
+  app_id: string
+  app_mode: string
+  app_name: string
+  node_ids?: Array<string>
+  workflow_id: string
+  workflow_version: string
+}
+
+export type AgentScope = 'roster' | 'workflow_only'
+
+export type AgentSource = 'agent_app' | 'imported' | 'roster' | 'system' | 'workflow'
+
+export type AgentStatus = 'active' | 'archived'
 
 export type AgentInviteOptionResponse = {
   active_config_snapshot?: AgentConfigSnapshotSummaryResponse | null
@@ -93,51 +159,6 @@ export type AgentInviteOptionResponse = {
   updated_by?: string | null
   workflow_id?: string | null
   workflow_node_id?: string | null
-}
-
-export type AgentConfigSnapshotSummaryResponse = {
-  agent_id?: string | null
-  created_at?: number | null
-  created_by?: string | null
-  id: string
-  summary?: string | null
-  version: number
-  version_note?: string | null
-}
-
-export type AgentKind = 'dify_agent'
-
-export type AgentIconType = 'emoji' | 'image' | 'link'
-
-export type AgentPublishedReferenceResponse = {
-  app_id: string
-  app_mode: string
-  app_name: string
-  node_ids?: Array<string>
-  workflow_id: string
-  workflow_version: string
-}
-
-export type AgentScope = 'roster' | 'workflow_only'
-
-export type AgentSource = 'agent_app' | 'imported' | 'roster' | 'system' | 'workflow'
-
-export type AgentStatus = 'active' | 'archived'
-
-export type AgentSoulConfig = {
-  app_features?: AgentSoulAppFeaturesConfig
-  app_variables?: Array<AppVariableConfig>
-  env?: AgentSoulEnvConfig
-  human?: AgentSoulHumanConfig
-  knowledge?: AgentSoulKnowledgeConfig
-  memory?: AgentSoulMemoryConfig
-  misc_legacy?: AgentSoulAppFeaturesConfig
-  model?: AgentSoulModelConfig | null
-  prompt?: AgentSoulPromptConfig
-  sandbox?: AgentSoulSandboxConfig
-  schema_version?: number
-  skills_files?: AgentSoulSkillsFilesConfig
-  tools?: AgentSoulToolsConfig
 }
 
 export type AgentConfigRevisionResponse = {
@@ -518,6 +539,19 @@ export type GetAgentsResponses = {
 
 export type GetAgentsResponse = GetAgentsResponses[keyof GetAgentsResponses]
 
+export type PostAgentsData = {
+  body: RosterAgentCreatePayload
+  path?: never
+  query?: never
+  url: '/agents'
+}
+
+export type PostAgentsResponses = {
+  201: AgentRosterResponse
+}
+
+export type PostAgentsResponse = PostAgentsResponses[keyof PostAgentsResponses]
+
 export type GetAgentsInviteOptionsData = {
   body?: never
   path?: never
@@ -537,6 +571,22 @@ export type GetAgentsInviteOptionsResponses = {
 export type GetAgentsInviteOptionsResponse
   = GetAgentsInviteOptionsResponses[keyof GetAgentsInviteOptionsResponses]
 
+export type DeleteAgentsByAgentIdData = {
+  body?: never
+  path: {
+    agent_id: string
+  }
+  query?: never
+  url: '/agents/{agent_id}'
+}
+
+export type DeleteAgentsByAgentIdResponses = {
+  204: void
+}
+
+export type DeleteAgentsByAgentIdResponse
+  = DeleteAgentsByAgentIdResponses[keyof DeleteAgentsByAgentIdResponses]
+
 export type GetAgentsByAgentIdData = {
   body?: never
   path: {
@@ -552,6 +602,22 @@ export type GetAgentsByAgentIdResponses = {
 
 export type GetAgentsByAgentIdResponse
   = GetAgentsByAgentIdResponses[keyof GetAgentsByAgentIdResponses]
+
+export type PatchAgentsByAgentIdData = {
+  body: RosterAgentUpdatePayload
+  path: {
+    agent_id: string
+  }
+  query?: never
+  url: '/agents/{agent_id}'
+}
+
+export type PatchAgentsByAgentIdResponses = {
+  200: AgentRosterResponse
+}
+
+export type PatchAgentsByAgentIdResponse
+  = PatchAgentsByAgentIdResponses[keyof PatchAgentsByAgentIdResponses]
 
 export type GetAgentsByAgentIdVersionsData = {
   body?: never

--- a/packages/contracts/generated/api/console/agents/zod.gen.ts
+++ b/packages/contracts/generated/api/console/agents/zod.gen.ts
@@ -3,6 +3,25 @@
 import * as z from 'zod'
 
 /**
+ * AgentIconType
+ *
+ * Supported icon storage formats for Agent roster entries.
+ */
+export const zAgentIconType = z.enum(['emoji', 'image', 'link'])
+
+/**
+ * RosterAgentUpdatePayload
+ */
+export const zRosterAgentUpdatePayload = z.object({
+  description: z.string().nullish(),
+  icon: z.string().max(255).nullish(),
+  icon_background: z.string().max(255).nullish(),
+  icon_type: zAgentIconType.nullish(),
+  name: z.string().min(1).max(255).nullish(),
+  role: z.string().max(255).nullish(),
+})
+
+/**
  * AgentConfigSnapshotSummaryResponse
  */
 export const zAgentConfigSnapshotSummaryResponse = z.object({
@@ -31,13 +50,6 @@ export const zAgentConfigSnapshotListResponse = z.object({
  * the current roster/workflow APIs scoped to Dify Agent.
  */
 export const zAgentKind = z.enum(['dify_agent'])
-
-/**
- * AgentIconType
- *
- * Supported icon storage formats for Agent roster entries.
- */
-export const zAgentIconType = z.enum(['emoji', 'image', 'link'])
 
 /**
  * AgentPublishedReferenceResponse
@@ -677,6 +689,21 @@ export const zAgentSoulConfig = z.object({
 })
 
 /**
+ * RosterAgentCreatePayload
+ */
+export const zRosterAgentCreatePayload = z.object({
+  agent_soul: zAgentSoulConfig.optional(),
+  description: z.string().optional().default(''),
+  icon: z.string().max(255).nullish(),
+  icon_background: z.string().max(255).nullish(),
+  icon_type: zAgentIconType.nullish(),
+  mode: z.literal('agent').optional().default('agent'),
+  name: z.string().min(1).max(255),
+  role: z.string().max(255).optional().default(''),
+  version_note: z.string().nullish(),
+})
+
+/**
  * AgentConfigSnapshotDetailResponse
  */
 export const zAgentConfigSnapshotDetailResponse = z.object({
@@ -702,6 +729,13 @@ export const zGetAgentsQuery = z.object({
  */
 export const zGetAgentsResponse = zAgentRosterListResponse
 
+export const zPostAgentsBody = zRosterAgentCreatePayload
+
+/**
+ * Agent created
+ */
+export const zPostAgentsResponse = zAgentRosterResponse
+
 export const zGetAgentsInviteOptionsQuery = z.object({
   app_id: z.string().optional(),
   keyword: z.string().optional(),
@@ -714,6 +748,15 @@ export const zGetAgentsInviteOptionsQuery = z.object({
  */
 export const zGetAgentsInviteOptionsResponse = zAgentInviteOptionsResponse
 
+export const zDeleteAgentsByAgentIdPath = z.object({
+  agent_id: z.string(),
+})
+
+/**
+ * Agent archived
+ */
+export const zDeleteAgentsByAgentIdResponse = z.void()
+
 export const zGetAgentsByAgentIdPath = z.object({
   agent_id: z.string(),
 })
@@ -722,6 +765,17 @@ export const zGetAgentsByAgentIdPath = z.object({
  * Agent detail
  */
 export const zGetAgentsByAgentIdResponse = zAgentRosterResponse
+
+export const zPatchAgentsByAgentIdBody = zRosterAgentUpdatePayload
+
+export const zPatchAgentsByAgentIdPath = z.object({
+  agent_id: z.string(),
+})
+
+/**
+ * Agent updated
+ */
+export const zPatchAgentsByAgentIdResponse = zAgentRosterResponse
 
 export const zGetAgentsByAgentIdVersionsPath = z.object({
   agent_id: z.string(),


### PR DESCRIPTION
## Summary
- Restore Agent roster direct mutation endpoints for create, update, and archive flows.
- Register generated request payload schemas so `consoleQuery.agents.post`, `patch`, and `delete` are available again for Agent v2 roster UI.
- Update controller tests to cover the restored mutation calls through the existing `AgentRosterService` boundary.

## Context
The Agent v2 roster UI already uses generated contracts for direct roster mutations. A previous backend change removed those endpoints from OpenAPI/generated contracts, which broke `web` type-check even though the service-layer roster mutation methods still exist. `POST /apps` is not an equivalent replacement for the roster create/edit/delete dialogs because it creates an Agent App and backing roster agent, not a direct roster entry with the same role/edit/delete semantics.

## Verification
- `uv run --project api pytest api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py`
- `pnpm -C packages/contracts gen-api-contract`
- `pnpm -C web type-check`
- `uv run --project api pytest api/tests/unit_tests/controllers/common/test_schema.py api/tests/unit_tests/commands/test_generate_swagger_specs.py api/tests/unit_tests/controllers/test_swagger.py`
- `uv run --project api ruff check api/controllers/console/agent/roster.py api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py`
- `git diff --check`
