### PR TITLE
fix: preserve inline image for chatflow messages

### DIFF
--- a/api/core/app/apps/advanced_chat/generate_task_pipeline.py
+++ b/api/core/app/apps/advanced_chat/generate_task_pipeline.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import re
 import time
 from collections.abc import Callable, Generator, Mapping
 from contextlib import contextmanager
@@ -1010,11 +1009,7 @@ class AdvancedChatAppGenerateTaskPipeline(GraphRuntimeStateSupport):
         if message.status == MessageStatus.PAUSED:
             message.status = MessageStatus.NORMAL
 
-        # If there are assistant files, remove markdown image links from answer
         answer_text = self._task_state.answer
-        if self._recorded_files:
-            # Remove markdown image links since we're storing files separately
-            answer_text = re.sub(r"!\[.*?\]\(.*?\)", "", answer_text).strip()
 
         message.answer = answer_text
         message.updated_at = naive_utc_now()

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py
@@ -562,7 +562,7 @@ class TestAdvancedChatGenerateTaskPipeline:
         assert list(pipeline._handle_human_input_form_timeout_event(timeout_event)) == ["timeout"]
         assert persisted == ["saved"]
 
-    def test_save_message_strips_markdown_and_sets_usage(self):
+    def test_save_message_preserves_full_answer_and_sets_usage(self):
         pipeline = _make_pipeline()
         pipeline._recorded_files = [
             {
@@ -572,7 +572,8 @@ class TestAdvancedChatGenerateTaskPipeline:
                 "related_id": "file-id",
             }
         ]
-        pipeline._task_state.answer = "![img](url) hello"
+        # The answer is stored verbatim; markdown image links are never stripped.
+        pipeline._task_state.answer = "![img](http://example.com/file.png) hello ![inline](http://llm.com/img.jpg)"
         pipeline._task_state.is_streaming_response = True
         pipeline._task_state.first_token_time = pipeline._base_task_pipeline.start_at + 0.1
         pipeline._task_state.last_token_time = pipeline._base_task_pipeline.start_at + 0.2
@@ -614,7 +615,7 @@ class TestAdvancedChatGenerateTaskPipeline:
         pipeline._save_message(session=_Session(), graph_runtime_state=graph_runtime_state)
 
         assert message.status == MessageStatus.NORMAL
-        assert message.answer == "hello"
+        assert message.answer == "![img](http://example.com/file.png) hello ![inline](http://llm.com/img.jpg)"
         assert message.message_metadata
 
     def test_handle_stop_event_saves_message_for_moderation(self, monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #37450 caused by #24663

## Screenshots

| Before | After |
|--------|-------|
|<img width="729" height="247" alt="截屏2026-06-15 14 17 17" src="https://github.com/user-attachments/assets/ed395f87-52e7-4104-9221-754f8440129c" /> | <img width="700" height="470" alt="截屏2026-06-15 15 14 42" src="https://github.com/user-attachments/assets/3820e341-5bff-4a20-af3d-a768796ca010" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
