### PR TITLE
fix: preserve inline image for chatflow messages (backport #37455 to lts/1.13.x)

### DIFF
--- a/api/core/app/apps/advanced_chat/generate_task_pipeline.py
+++ b/api/core/app/apps/advanced_chat/generate_task_pipeline.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import re
 import time
 from collections.abc import Callable, Generator, Mapping
 from contextlib import contextmanager
@@ -895,11 +894,7 @@ class AdvancedChatAppGenerateTaskPipeline(GraphRuntimeStateSupport):
         if message.status == MessageStatus.PAUSED:
             message.status = MessageStatus.NORMAL
 
-        # If there are assistant files, remove markdown image links from answer
         answer_text = self._task_state.answer
-        if self._recorded_files:
-            # Remove markdown image links since we're storing files separately
-            answer_text = re.sub(r"!\[.*?\]\(.*?\)", "", answer_text).strip()
 
         message.answer = answer_text
         message.updated_at = naive_utc_now()

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py
@@ -479,7 +479,7 @@ class TestAdvancedChatGenerateTaskPipeline:
         assert list(pipeline._handle_human_input_form_timeout_event(timeout_event)) == ["timeout"]
         assert persisted == ["saved"]
 
-    def test_save_message_strips_markdown_and_sets_usage(self):
+    def test_save_message_preserves_full_answer_and_sets_usage(self):
         pipeline = _make_pipeline()
         pipeline._recorded_files = [
             {
@@ -489,7 +489,8 @@ class TestAdvancedChatGenerateTaskPipeline:
                 "related_id": "file-id",
             }
         ]
-        pipeline._task_state.answer = "![img](url) hello"
+        # The answer is stored verbatim; markdown image links are never stripped.
+        pipeline._task_state.answer = "![img](http://example.com/file.png) hello ![inline](http://llm.com/img.jpg)"
         pipeline._task_state.is_streaming_response = True
         pipeline._task_state.first_token_time = pipeline._base_task_pipeline.start_at + 0.1
         pipeline._task_state.last_token_time = pipeline._base_task_pipeline.start_at + 0.2
@@ -529,7 +530,7 @@ class TestAdvancedChatGenerateTaskPipeline:
         pipeline._save_message(session=_Session(), graph_runtime_state=graph_runtime_state)
 
         assert message.status == MessageStatus.NORMAL
-        assert message.answer == "hello"
+        assert message.answer == "![img](http://example.com/file.png) hello ![inline](http://llm.com/img.jpg)"
         assert message.message_metadata
 
     def test_handle_stop_event_saves_message_for_moderation(self, monkeypatch):


### PR DESCRIPTION
Backport of #37455 to `lts/1.13.x`.

## Summary

Fixes #37450 caused by #24663.

The original fix in #24663 stripped **all** markdown image links from `message.answer` before saving to DB when `_recorded_files` is present. This caused LLM-generated inline image links (which have no corresponding `MessageFile` record) to be lost when conversation history is reloaded.

This fix removes the stripping entirely, storing `message.answer` verbatim. Files recorded as `MessageFile` rows are still rendered by the front-end via `message_files`; inline images generated by the LLM are now also preserved.

## Cherry-pick

```
cherry picked from commit 619cb85dd4c3ce1c04f840f0e46a1cb6bfdcf5ee
```