### PR TITLE
test: use caplog for workspace permission logging

### DIFF
--- a/api/tests/unit_tests/libs/test_workspace_permission.py
+++ b/api/tests/unit_tests/libs/test_workspace_permission.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import Mock, patch
 
 import pytest
@@ -124,10 +125,9 @@ class TestWorkspacePermissionHelper:
 
         mock_enterprise_service.WorkspacePermissionService.get_permission.assert_called_once_with("test-workspace-id")
 
-    @patch("libs.workspace_permission.logger")
     @patch("libs.workspace_permission.EnterpriseService")
     @patch("libs.workspace_permission.dify_config")
-    def test_enterprise_service_error_fails_open(self, mock_config, mock_enterprise_service, mock_logger):
+    def test_enterprise_service_error_fails_open(self, mock_config, mock_enterprise_service, caplog):
         """On enterprise service error, should fail-open (allow) and log error."""
         mock_config.ENTERPRISE_ENABLED = True
 
@@ -135,8 +135,7 @@ class TestWorkspacePermissionHelper:
         mock_enterprise_service.WorkspacePermissionService.get_permission.side_effect = Exception("Service unavailable")
 
         # Should not raise (fail-open)
-        check_workspace_member_invite_permission("test-workspace-id")
+        with caplog.at_level(logging.ERROR, logger="libs.workspace_permission"):
+            check_workspace_member_invite_permission("test-workspace-id")
 
-        # Should log the error
-        mock_logger.exception.assert_called_once()
-        assert "Failed to check workspace invite permission" in str(mock_logger.exception.call_args)
+        assert "Failed to check workspace invite permission for test-workspace-id" in caplog.text


### PR DESCRIPTION
## Summary

Part of #37468.

This replaces one logger patch in `test_workspace_permission.py` with pytest's `caplog` fixture so the test captures the real log output from `libs.workspace_permission`.

## Reproduction

The issue notes that tests patch module loggers directly. In this case, `test_enterprise_service_error_fails_open` patched `libs.workspace_permission.logger` only to assert that the fail-open path logged an exception.

## Root cause

Patching the logger couples the test to the module-level logger object instead of the emitted log record. `caplog` can assert the same behavior through pytest's log capture without replacing the logger.

## Changes

- Remove the `@patch("libs.workspace_permission.logger")` decorator from the workspace permission test.
- Capture `ERROR` logs for `libs.workspace_permission` with `caplog`.
- Assert the emitted message contains the expected workspace ID context.

## Tests

- `python3 -m py_compile api/tests/unit_tests/libs/test_workspace_permission.py`
- `git diff --check`
- `.venv/bin/python -m ruff check api/tests/unit_tests/libs/test_workspace_permission.py`

I also attempted the targeted pytest run locally:

- `PYTHONPATH=api .venv/bin/python -m pytest -c api/pytest.ini api/tests/unit_tests/libs/test_workspace_permission.py -q`
- `PYTHONPATH=api .venv/bin/python -m pytest --confcutdir=api/tests/unit_tests/libs api/tests/unit_tests/libs/test_workspace_permission.py -q`

Those could not complete in this local environment because `uv` and Python 3.12 are not installed here, and the ad-hoc Python 3.14 environment stops during import on missing runtime dependencies from the wider API import chain, eventually reaching `gevent` via `extensions.ext_database`.

## Screenshots/Logs

Not applicable; test-only change.
