### PR TITLE
fix(workflow): clamp file list upload limit

### DIFF
--- a/web/app/components/base/prompt-editor/plugins/hitl-input-block/__tests__/input-field.spec.tsx
+++ b/web/app/components/base/prompt-editor/plugins/hitl-input-block/__tests__/input-field.spec.tsx
@@ -1,7 +1,9 @@
 import type { FormInputItem, ParagraphFormInput } from '@/app/components/workflow/nodes/human-input/types'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useFileSizeLimit } from '@/app/components/base/file-uploader/hooks'
 import { InputVarType, SupportUploadFileTypes, VarType } from '@/app/components/workflow/types'
+import { useFileUploadConfig } from '@/service/use-common'
 import { TransferMethod } from '@/types/app'
 import InputField from '../input-field'
 
@@ -11,6 +13,15 @@ type VarReferencePickerProps = {
 }
 
 let lastVarReferencePickerProps: VarReferencePickerProps | undefined
+let fileUploadSettingMaxLength: number | undefined = 4
+
+vi.mock('@/service/use-common', () => ({
+  useFileUploadConfig: vi.fn(),
+}))
+
+vi.mock('@/app/components/base/file-uploader/hooks', () => ({
+  useFileSizeLimit: vi.fn(),
+}))
 
 vi.mock('@/app/components/workflow/nodes/_base/components/variable/var-reference-picker', () => ({
   default: (props: VarReferencePickerProps) => {
@@ -66,7 +77,7 @@ vi.mock('@/app/components/workflow/nodes/_base/components/file-upload-setting', 
         allowed_file_extensions: ['.pdf'],
         allowed_file_types: [SupportUploadFileTypes.document],
         allowed_file_upload_methods: [TransferMethod.local_file],
-        max_length: 4,
+        max_length: fileUploadSettingMaxLength,
       })}
     >
       file-upload-setting
@@ -89,6 +100,15 @@ describe('InputField', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     lastVarReferencePickerProps = undefined
+    fileUploadSettingMaxLength = 4
+    vi.mocked(useFileUploadConfig).mockReturnValue({ data: {} } as ReturnType<typeof useFileUploadConfig>)
+    vi.mocked(useFileSizeLimit).mockReturnValue({
+      imgSizeLimit: 10 * 1024 * 1024,
+      docSizeLimit: 20 * 1024 * 1024,
+      audioSizeLimit: 30 * 1024 * 1024,
+      videoSizeLimit: 40 * 1024 * 1024,
+      maxFileUploadLimit: 10,
+    } as ReturnType<typeof useFileSizeLimit>)
   })
 
   it('should keep the header and actions visible while the field content scrolls internally', () => {
@@ -625,6 +645,36 @@ describe('InputField', () => {
       allowed_file_upload_methods: ['local_file'],
       number_limits: 4,
     })
+  })
+
+  it.each([
+    { maxLength: 20, expectedNumberLimits: 10 },
+    { maxLength: 0, expectedNumberLimits: 1 },
+    { maxLength: Number.NaN, expectedNumberLimits: 1 },
+  ])('should normalize file-list upload limits on save', async ({ maxLength, expectedNumberLimits }) => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    fileUploadSettingMaxLength = maxLength
+
+    render(
+      <InputField
+        nodeId="node-14-normalize"
+        isEdit={false}
+        payload={createPayload()}
+        onChange={onChange}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'select-file-list' }))
+    await user.click(screen.getByRole('button', { name: 'file-upload-setting' }))
+    await user.click(screen.getByRole('button', { name: /workflow\.nodes\.humanInput\.insertInputField\.insert/i }))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange.mock.calls[0]![0]).toEqual(expect.objectContaining({
+      type: InputVarType.multiFiles,
+      number_limits: expectedNumberLimits,
+    }))
   })
 
   it('should clear paragraph default state when switching to file-list', async () => {

--- a/web/app/components/base/prompt-editor/plugins/hitl-input-block/__tests__/input-field.spec.tsx
+++ b/web/app/components/base/prompt-editor/plugins/hitl-input-block/__tests__/input-field.spec.tsx
@@ -1,9 +1,7 @@
 import type { FormInputItem, ParagraphFormInput } from '@/app/components/workflow/nodes/human-input/types'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { useFileSizeLimit } from '@/app/components/base/file-uploader/hooks'
 import { InputVarType, SupportUploadFileTypes, VarType } from '@/app/components/workflow/types'
-import { useFileUploadConfig } from '@/service/use-common'
 import { TransferMethod } from '@/types/app'
 import InputField from '../input-field'
 
@@ -14,14 +12,6 @@ type VarReferencePickerProps = {
 
 let lastVarReferencePickerProps: VarReferencePickerProps | undefined
 let fileUploadSettingMaxLength: number | undefined = 4
-
-vi.mock('@/service/use-common', () => ({
-  useFileUploadConfig: vi.fn(),
-}))
-
-vi.mock('@/app/components/base/file-uploader/hooks', () => ({
-  useFileSizeLimit: vi.fn(),
-}))
 
 vi.mock('@/app/components/workflow/nodes/_base/components/variable/var-reference-picker', () => ({
   default: (props: VarReferencePickerProps) => {
@@ -101,14 +91,6 @@ describe('InputField', () => {
     vi.clearAllMocks()
     lastVarReferencePickerProps = undefined
     fileUploadSettingMaxLength = 4
-    vi.mocked(useFileUploadConfig).mockReturnValue({ data: {} } as ReturnType<typeof useFileUploadConfig>)
-    vi.mocked(useFileSizeLimit).mockReturnValue({
-      imgSizeLimit: 10 * 1024 * 1024,
-      docSizeLimit: 20 * 1024 * 1024,
-      audioSizeLimit: 30 * 1024 * 1024,
-      videoSizeLimit: 40 * 1024 * 1024,
-      maxFileUploadLimit: 10,
-    } as ReturnType<typeof useFileSizeLimit>)
   })
 
   it('should keep the header and actions visible while the field content scrolls internally', () => {
@@ -647,14 +629,10 @@ describe('InputField', () => {
     })
   })
 
-  it.each([
-    { maxLength: 20, expectedNumberLimits: 10 },
-    { maxLength: 0, expectedNumberLimits: 1 },
-    { maxLength: Number.NaN, expectedNumberLimits: 1 },
-  ])('should normalize file-list upload limits on save', async ({ maxLength, expectedNumberLimits }) => {
+  it('should normalize empty file-list upload limit on save', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
-    fileUploadSettingMaxLength = maxLength
+    fileUploadSettingMaxLength = Number.NaN
 
     render(
       <InputField
@@ -673,7 +651,7 @@ describe('InputField', () => {
     expect(onChange).toHaveBeenCalledTimes(1)
     expect(onChange.mock.calls[0]![0]).toEqual(expect.objectContaining({
       type: InputVarType.multiFiles,
-      number_limits: expectedNumberLimits,
+      number_limits: 1,
     }))
   })
 

--- a/web/app/components/base/prompt-editor/plugins/hitl-input-block/input-field.tsx
+++ b/web/app/components/base/prompt-editor/plugins/hitl-input-block/input-field.tsx
@@ -12,7 +12,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import TypeSelector from '@/app/components/app/configuration/config-var/config-modal/type-select'
 import ConfigSelect from '@/app/components/app/configuration/config-var/config-select'
-import { useFileSizeLimit } from '@/app/components/base/file-uploader/hooks'
 import FileUploadSetting from '@/app/components/workflow/nodes/_base/components/file-upload-setting'
 import VarReferencePicker from '@/app/components/workflow/nodes/_base/components/variable/var-reference-picker'
 import {
@@ -24,7 +23,6 @@ import {
   isSelectFormInput,
 } from '@/app/components/workflow/nodes/human-input/types'
 import { InputVarType, VarType } from '@/app/components/workflow/types'
-import { useFileUploadConfig } from '@/service/use-common'
 import PrePopulate from './pre-populate'
 import TypeSwitch from './type-switch'
 
@@ -47,8 +45,6 @@ const InputField: React.FC<InputFieldProps> = ({
   onCancel,
 }) => {
   const { t } = useTranslation()
-  const { data: fileUploadConfigResponse } = useFileUploadConfig()
-  const { maxFileUploadLimit } = useFileSizeLimit(fileUploadConfigResponse)
   const [tempPayload, setTempPayload] = useState<FormInputItem>(() => payload || createDefaultParagraphFormInput())
   const fieldTypeItems = useMemo<TypeSelectItem[]>(() => {
     return [
@@ -103,16 +99,16 @@ const InputField: React.FC<InputFieldProps> = ({
       return
     if (isFileListFormInput(tempPayload)) {
       const value = tempPayload.number_limits ?? 5
-      const safeValue = Number.isFinite(value) ? value : 1
-      const numberLimits = Math.min(Math.max(safeValue, 1), maxFileUploadLimit)
-      onChange({
-        ...tempPayload,
-        number_limits: numberLimits,
-      })
-      return
+      if (!Number.isFinite(value)) {
+        onChange({
+          ...tempPayload,
+          number_limits: 1,
+        })
+        return
+      }
     }
     onChange(tempPayload)
-  }, [maxFileUploadLimit, nameValid, onChange, tempPayload])
+  }, [nameValid, onChange, tempPayload])
   const handleTypeChange = useCallback((item: TypeSelectItem) => {
     setTempPayload(prev => createDefaultFormInputByType(item.value as FormInputItem['type'], prev.output_variable_name))
   }, [])

--- a/web/app/components/base/prompt-editor/plugins/hitl-input-block/input-field.tsx
+++ b/web/app/components/base/prompt-editor/plugins/hitl-input-block/input-field.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import TypeSelector from '@/app/components/app/configuration/config-var/config-modal/type-select'
 import ConfigSelect from '@/app/components/app/configuration/config-var/config-select'
+import { useFileSizeLimit } from '@/app/components/base/file-uploader/hooks'
 import FileUploadSetting from '@/app/components/workflow/nodes/_base/components/file-upload-setting'
 import VarReferencePicker from '@/app/components/workflow/nodes/_base/components/variable/var-reference-picker'
 import {
@@ -23,6 +24,7 @@ import {
   isSelectFormInput,
 } from '@/app/components/workflow/nodes/human-input/types'
 import { InputVarType, VarType } from '@/app/components/workflow/types'
+import { useFileUploadConfig } from '@/service/use-common'
 import PrePopulate from './pre-populate'
 import TypeSwitch from './type-switch'
 
@@ -45,6 +47,8 @@ const InputField: React.FC<InputFieldProps> = ({
   onCancel,
 }) => {
   const { t } = useTranslation()
+  const { data: fileUploadConfigResponse } = useFileUploadConfig()
+  const { maxFileUploadLimit } = useFileSizeLimit(fileUploadConfigResponse)
   const [tempPayload, setTempPayload] = useState<FormInputItem>(() => payload || createDefaultParagraphFormInput())
   const fieldTypeItems = useMemo<TypeSelectItem[]>(() => {
     return [
@@ -97,8 +101,18 @@ const InputField: React.FC<InputFieldProps> = ({
   const handleSave = useCallback(() => {
     if (!nameValid)
       return
+    if (isFileListFormInput(tempPayload)) {
+      const value = tempPayload.number_limits ?? 5
+      const safeValue = Number.isFinite(value) ? value : 1
+      const numberLimits = Math.min(Math.max(safeValue, 1), maxFileUploadLimit)
+      onChange({
+        ...tempPayload,
+        number_limits: numberLimits,
+      })
+      return
+    }
     onChange(tempPayload)
-  }, [nameValid, onChange, tempPayload])
+  }, [maxFileUploadLimit, nameValid, onChange, tempPayload])
   const handleTypeChange = useCallback((item: TypeSelectItem) => {
     setTempPayload(prev => createDefaultFormInputByType(item.value as FormInputItem['type'], prev.output_variable_name))
   }, [])

--- a/web/app/components/workflow/nodes/_base/components/__tests__/file-support.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/components/__tests__/file-support.spec.tsx
@@ -1,6 +1,7 @@
 import type { UploadFileSetting } from '@/app/components/workflow/types'
 import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
 import { useFileSizeLimit } from '@/app/components/base/file-uploader/hooks'
 import { SupportUploadFileTypes } from '@/app/components/workflow/types'
 import { useFileUploadConfig } from '@/service/use-common'
@@ -118,6 +119,35 @@ describe('File upload support components', () => {
       expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
         max_length: 5,
       }))
+    })
+
+    it('should keep upload limits within the configured range', () => {
+      const StatefulFileUploadSetting = () => {
+        const [payload, setPayload] = useState(createPayload())
+
+        return (
+          <FileUploadSetting
+            payload={payload}
+            isMultiple
+            onChange={setPayload}
+          />
+        )
+      }
+
+      render(<StatefulFileUploadSetting />)
+
+      const input = screen.getByRole('spinbutton')
+
+      fireEvent.change(input, { target: { value: '20' } })
+      expect(input).toHaveValue(10)
+
+      fireEvent.change(input, { target: { value: '0' } })
+      expect(input).toHaveValue(1)
+
+      fireEvent.change(input, { target: { value: '' } })
+      expect(input).toHaveValue(null)
+      fireEvent.blur(input)
+      expect(input).toHaveValue(1)
     })
 
     it('should toggle built-in and custom file type selections', async () => {

--- a/web/app/components/workflow/nodes/_base/components/file-upload-setting.tsx
+++ b/web/app/components/workflow/nodes/_base/components/file-upload-setting.tsx
@@ -89,11 +89,14 @@ const FileUploadSetting: FC<Props> = ({
   }, [onChange, payload])
 
   const handleMaxUploadNumLimitChange = useCallback((value: number) => {
+    const normalizedValue = Number.isFinite(value)
+      ? Math.min(Math.max(value, 1), maxFileUploadLimit)
+      : value
     const newPayload = produce(payload, (draft) => {
-      draft.max_length = value
+      draft.max_length = normalizedValue
     })
     onChange(newPayload)
-  }, [onChange, payload])
+  }, [maxFileUploadLimit, onChange, payload])
 
   return (
     <div>
@@ -163,6 +166,7 @@ const FileUploadSetting: FC<Props> = ({
             <InputNumberWithSlider
               label={t('variableConfig.maxNumberOfUploads', { ns: 'appDebug' })!}
               value={max_length}
+              defaultValue={1}
               min={1}
               max={maxFileUploadLimit}
               onChange={handleMaxUploadNumLimitChange}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes the Human Input file-list upload limit editor so the numeric input cannot persist values outside the configured upload range.

The slider already caps the value at the workspace upload limit, but the number input could accept a larger value and allow users to save it. This caused the saved value and the reopened UI to disagree, because the control would display the configured maximum again.

This change:
- Normalizes finite number-input changes in `FileUploadSetting` to the configured `1..maxFileUploadLimit` range.
- Keeps temporary empty input editable, then restores it to `1` on blur via `defaultValue`.
- Adds a save-boundary guard for Human Input file-list fields so keyboard save paths such as `Mod + Enter` cannot persist `NaN` or out-of-range values.
- Adds focused tests for both the field editing behavior and the final save payload.

From Codex

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
