### PR TITLE
refactor: remove unnecessary # type: ignore for yaml imports (#24494)

### DIFF
--- a/api/services/snippet_dsl_service.py
+++ b/api/services/snippet_dsl_service.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from urllib.parse import urlparse
 
-import yaml  # type: ignore
+import yaml
 from packaging import version
 from pydantic import BaseModel, Field
 from sqlalchemy import select
@@ -498,7 +498,7 @@ class SnippetDslService:
             export_data=export_data, snippet=snippet, workflow=workflow, include_secret=include_secret
         )
 
-        return yaml.dump(export_data, allow_unicode=True)  # type: ignore
+        return yaml.dump(export_data, allow_unicode=True)
 
     def _append_workflow_export_data(
         self, *, export_data: dict, snippet: CustomizedSnippet, workflow: Workflow, include_secret: bool


### PR DESCRIPTION
Fixes #24494

Remove unnecessary `# type: ignore` comments for `yaml` imports since `types-pyyaml` is installed and provides type stubs.

## Changes

- `api/services/snippet_dsl_service.py`:
  - Remove `# type: ignore` from `import yaml` (line 9)
  - Remove `# type: ignore` from `yaml.dump(...)` call (line 501)