### PR TITLE
refactor: replace isinstance chains with match-case (#24487)

### DIFF
--- a/api/core/plugin/utils/converter.py
+++ b/api/core/plugin/utils/converter.py
@@ -6,16 +6,13 @@ from graphon.file import File
 
 def convert_parameters_to_plugin_format(parameters: dict[str, Any]) -> dict[str, Any]:
     for parameter_name, parameter in parameters.items():
-        if isinstance(parameter, File):
-            parameters[parameter_name] = parameter.to_plugin_parameter()
-        elif isinstance(parameter, list) and all(isinstance(p, File) for p in parameter):
-            parameters[parameter_name] = []
-            for p in parameter:
-                parameters[parameter_name].append(p.to_plugin_parameter())
-        elif isinstance(parameter, ToolSelector):
-            parameters[parameter_name] = parameter.to_plugin_parameter()
-        elif isinstance(parameter, list) and all(isinstance(p, ToolSelector) for p in parameter):
-            parameters[parameter_name] = []
-            for p in parameter:
-                parameters[parameter_name].append(p.to_plugin_parameter())
+        match parameter:
+            case File():
+                parameters[parameter_name] = parameter.to_plugin_parameter()
+            case [*items] if all(isinstance(p, File) for p in items):
+                parameters[parameter_name] = [p.to_plugin_parameter() for p in items]
+            case ToolSelector():
+                parameters[parameter_name] = parameter.to_plugin_parameter()
+            case [*items] if all(isinstance(p, ToolSelector) for p in items):
+                parameters[parameter_name] = [p.to_plugin_parameter() for p in items]
     return parameters

--- a/api/core/tools/__base/tool.py
+++ b/api/core/tools/__base/tool.py
@@ -66,20 +66,21 @@ class Tool(ABC):
             message_id=message_id,
         )
 
-        if isinstance(result, ToolInvokeMessage):
+        match result:
+            case ToolInvokeMessage():
 
-            def single_generator() -> Generator[ToolInvokeMessage, None, None]:
-                yield result
+                def single_generator() -> Generator[ToolInvokeMessage, None, None]:
+                    yield result
 
-            return single_generator()
-        elif isinstance(result, list):
+                return single_generator()
+            case list():
 
-            def generator() -> Generator[ToolInvokeMessage, None, None]:
-                yield from result
+                def generator() -> Generator[ToolInvokeMessage, None, None]:
+                    yield from result
 
-            return generator()
-        else:
-            return result
+                return generator()
+            case _:
+                return result
 
     def _transform_tool_parameters_type(self, tool_parameters: dict[str, Any]) -> dict[str, Any]:
         """


### PR DESCRIPTION
Fixes #24487

Replace `if/elif isinstance` chains with structural pattern matching (`match-case`) for cleaner, more readable dispatch logic.

## Changes

- `api/core/plugin/utils/converter.py`: Replace 4-branch isinstance chain in `convert_parameters_to_plugin_format` with match-case using class patterns and guard clauses
- `api/core/tools/__base/tool.py`: Replace 3-branch isinstance chain in `invoke` method with match-case for result type dispatch

## Benefits

- More readable pattern matching syntax
- Exhaustive matching with `case _:` catch-all
- List unpacking patterns with guards replace verbose `isinstance(p, X) for p in items` checks