### PR TITLE
fix(watercrawl): bound result download timeout

### DIFF
--- a/api/core/rag/extractor/watercrawl/client.py
+++ b/api/core/rag/extractor/watercrawl/client.py
@@ -217,7 +217,7 @@ class WaterCrawlAPIClient(BaseAPIClient):
                 return event_data["data"]
 
     def download_result(self, result_object: dict[str, Any]):
-        response = httpx.get(result_object["result"], timeout=None)
+        response = httpx.get(result_object["result"], timeout=30)
         try:
             response.raise_for_status()
             result_object["result"] = response.json()

--- a/api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py
+++ b/api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py
@@ -242,11 +242,18 @@ class TestWaterCrawlAPIClient:
         client = WaterCrawlAPIClient(api_key="k")
 
         response = _response(200, {"markdown": "body"})
-        monkeypatch.setattr(client_module.httpx, "get", lambda *args, **kwargs: response)
+        captured = {}
+
+        def fake_get(*args, **kwargs):
+            captured.update(kwargs)
+            return response
+
+        monkeypatch.setattr(client_module.httpx, "get", fake_get)
 
         result = client.download_result({"result": "https://example.com/result.json"})
 
         assert result["result"] == {"markdown": "body"}
+        assert captured["timeout"] is not None
         response.close.assert_called_once()
 
 


### PR DESCRIPTION
## Summary

Fixes #37494.

WaterCrawl result event handling downloads each result payload via `download_result()`. That request used `timeout=None`, which disables HTTPX timeouts for a single result JSON download.

This change keeps the long-running crawl status stream behavior untouched, but gives result payload downloads a bounded 30-second timeout. The unit test now asserts that `download_result()` does not pass `timeout=None`.

## Screenshots

N/A. Backend extractor reliability change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This does not apply to typos.)
- [x] I have added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I have updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Validation run:

```bash
uv run --project api --group dev pytest api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py -q
```

Result: 27 passed.
