### PR TITLE
ci: add deploy-agent workflow triggered on deploy/agent branch

### DIFF
--- a/.github/workflows/deploy-agent.yml
+++ b/.github/workflows/deploy-agent.yml
@@ -1,0 +1,28 @@
+name: Deploy Agent
+
+permissions:
+  contents: read
+
+on:
+  workflow_run:
+    workflows: ["Build and Push API & Web"]
+    branches:
+      - "deploy/agent"
+    types:
+      - completed
+
+jobs:
+  deploy:
+    runs-on: depot-ubuntu-24.04
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'deploy/agent'
+    steps:
+      - name: Deploy to server
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.AGENT_SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            ${{ vars.SSH_SCRIPT_AGENT || secrets.SSH_SCRIPT_AGENT }}


### PR DESCRIPTION
## Background

Add a dedicated deploy workflow for the Agent environment. The `workflow_run` trigger requires the workflow file to exist on the default branch (main) before GitHub recognizes and activates it, so this PR introduces only `deploy-agent.yml`.

## Changes

- Add `.github/workflows/deploy-agent.yml`
- Listens for `Build and Push API & Web` completing successfully on the `deploy/agent` branch, then SSHes into the Agent server to run the deploy script
- Mirrors the existing `deploy-saas.yml` / `deploy-hitl.yml`

## Trigger flow

```
push to deploy/agent branch
  → build-push.yml builds images (deploy/** already matches, no change needed)
    → deploy-agent.yml auto SSH deploy
```

## Required repository Secrets / Variables

| Type | Name | Description |
|------|------|-------------|
| Secret | `AGENT_SSH_HOST` | Agent server address |
| Secret | `SSH_USER` | SSH username (shared with other deploys) |
| Secret | `SSH_PRIVATE_KEY` | SSH private key (shared with other deploys) |
| Variable or Secret | `SSH_SCRIPT_AGENT` | Deploy script |