### PR TITLE
fix(watercrawl): handle non-json auth errors

### DIFF
--- a/api/services/auth/watercrawl/watercrawl.py
+++ b/api/services/auth/watercrawl/watercrawl.py
@@ -37,13 +37,16 @@ class WatercrawlAuth(ApiKeyAuthBase):
 
     def _handle_error(self, response):
         if response.status_code in {402, 409, 500}:
-            error_message = response.json().get("error", "Unknown error occurred")
+            try:
+                error_message = response.json().get("error", "Unknown error occurred")
+            except ValueError:
+                error_message = response.text or "Unknown error occurred"
             raise Exception(f"Failed to authorize. Status code: {response.status_code}. Error: {error_message}")
         else:
             if response.text:
                 try:
                     error_message = json.loads(response.text).get("error", "Unknown error occurred")
-                except json.JSONDecodeError:
+                except ValueError:
                     error_message = response.text
                 raise Exception(f"Failed to authorize. Status code: {response.status_code}. Error: {error_message}")
             raise Exception(f"Unexpected error occurred while trying to authorize. Status code: {response.status_code}")

--- a/api/services/auth/watercrawl/watercrawl.py
+++ b/api/services/auth/watercrawl/watercrawl.py
@@ -41,6 +41,9 @@ class WatercrawlAuth(ApiKeyAuthBase):
             raise Exception(f"Failed to authorize. Status code: {response.status_code}. Error: {error_message}")
         else:
             if response.text:
-                error_message = json.loads(response.text).get("error", "Unknown error occurred")
+                try:
+                    error_message = json.loads(response.text).get("error", "Unknown error occurred")
+                except json.JSONDecodeError:
+                    error_message = response.text
                 raise Exception(f"Failed to authorize. Status code: {response.status_code}. Error: {error_message}")
             raise Exception(f"Unexpected error occurred while trying to authorize. Status code: {response.status_code}")

--- a/api/tests/unit_tests/services/auth/test_watercrawl_auth.py
+++ b/api/tests/unit_tests/services/auth/test_watercrawl_auth.py
@@ -104,7 +104,7 @@ class TestWatercrawlAuth:
         [
             (403, '{"error": "Forbidden"}', True, "Failed to authorize. Status code: 403. Error: Forbidden"),
             (404, "", True, "Unexpected error occurred while trying to authorize. Status code: 404"),
-            (401, "Not JSON", True, "Expecting value"),  # JSON decode error
+            (401, "Not JSON", True, "Failed to authorize. Status code: 401. Error: Not JSON"),
         ],
     )
     @patch("services.auth.watercrawl.watercrawl.httpx.get", autospec=True)

--- a/api/tests/unit_tests/services/auth/test_watercrawl_auth.py
+++ b/api/tests/unit_tests/services/auth/test_watercrawl_auth.py
@@ -99,6 +99,19 @@ class TestWatercrawlAuth:
             auth_instance.validate_credentials()
         assert str(exc_info.value) == f"Failed to authorize. Status code: {status_code}. Error: {error_message}"
 
+    @patch("services.auth.watercrawl.watercrawl.httpx.get", autospec=True)
+    def test_should_handle_http_error_with_non_json_text_response(self, mock_get, auth_instance):
+        """Test handling of known HTTP errors with non-JSON text response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 402
+        mock_response.text = "Payment required"
+        mock_response.json.side_effect = ValueError("Not JSON")
+        mock_get.return_value = mock_response
+
+        with pytest.raises(Exception) as exc_info:
+            auth_instance.validate_credentials()
+        assert str(exc_info.value) == "Failed to authorize. Status code: 402. Error: Payment required"
+
     @pytest.mark.parametrize(
         ("status_code", "response_text", "has_json_error", "expected_error_contains"),
         [


### PR DESCRIPTION
## Summary

Fixes #37497.

`WatercrawlAuth._handle_error()` attempted to parse non-empty error bodies as JSON. When WaterCrawl or an upstream proxy returned a plain-text error body, credential validation leaked a raw JSON parsing exception instead of reporting the HTTP status and response message.

This change catches JSON parsing failures in both auth error branches and falls back to the response text, matching the graceful behavior used by the sibling Firecrawl auth provider.

## Screenshots

N/A. Backend credential validation error handling change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This does not apply to typos.)
- [x] I have added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I have updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Validation run:

```bash
uv run --project api --group dev pytest api/tests/unit_tests/services/auth/test_watercrawl_auth.py -q
```

Result: 27 passed.

```bash
git diff --check
```

Result: no output.
