### PR TITLE
fix(watercrawl): accept content type parameters

### DIFF
--- a/api/core/rag/extractor/watercrawl/client.py
+++ b/api/core/rag/extractor/watercrawl/client.py
@@ -118,16 +118,18 @@ class WaterCrawlAPIClient(BaseAPIClient):
         response.raise_for_status()
         if response.status_code == 204:
             return None
-        if response.headers.get("Content-Type") == "application/json":
+        content_type = response.headers.get("Content-Type", "")
+        media_type = content_type.split(";", 1)[0].strip().lower()
+        if media_type == "application/json":
             return response.json() or {}
 
-        if response.headers.get("Content-Type") == "application/octet-stream":
+        if media_type == "application/octet-stream":
             return response.content
 
-        if response.headers.get("Content-Type") == "text/event-stream":
+        if media_type == "text/event-stream":
             return self.process_eventstream(response)
 
-        raise Exception(f"Unknown response type: {response.headers.get('Content-Type')}")
+        raise Exception(f"Unknown response type: {content_type}")
 
     def get_crawl_requests_list(self, page: int | None = None, page_size: int | None = None):
         query_params = {"page": page or 1, "page_size": page_size or 10}

--- a/api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py
+++ b/api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py
@@ -168,6 +168,13 @@ class TestWaterCrawlAPIClient:
         assert client.process_response(_response(200, {"ok": True})) == {"ok": True}
         assert client.process_response(_response(200, None)) == {}
 
+    def test_process_response_accepts_json_content_type_parameters(self):
+        client = WaterCrawlAPIClient(api_key="k")
+
+        response = _response(200, {"ok": True}, content_type="application/json; charset=utf-8")
+
+        assert client.process_response(response) == {"ok": True}
+
     def test_process_response_octet_stream_returns_bytes(self):
         client = WaterCrawlAPIClient(api_key="k")
         assert (


### PR DESCRIPTION
## Summary

Fixes #37499.

`WaterCrawlAPIClient.process_response()` compared the full `Content-Type` header by exact string equality. Valid JSON responses such as `application/json; charset=utf-8` therefore fell through to `Unknown response type`.

This change parses the media type portion of the header, normalizes it, and keeps the existing JSON, octet-stream, and event-stream branches unchanged for unparameterized content types.

## Screenshots

N/A. Backend response parsing change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This does not apply to typos.)
- [x] I have added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I have updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Validation run:

```bash
uv run --project api --group dev pytest api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py -q
```

Result: 28 passed.
