### PR TITLE
fix(jina): handle non-json auth errors

### DIFF
--- a/api/services/auth/jina.py
+++ b/api/services/auth/jina.py
@@ -43,13 +43,16 @@ class JinaAuth(ApiKeyAuthBase):
 
     def _handle_error(self, response):
         if response.status_code in {402, 409, 500}:
-            error_message = response.json().get("error", "Unknown error occurred")
+            try:
+                error_message = response.json().get("error", "Unknown error occurred")
+            except ValueError:
+                error_message = response.text or "Unknown error occurred"
             raise Exception(f"Failed to authorize. Status code: {response.status_code}. Error: {error_message}")
         else:
             if response.text:
                 try:
                     error_message = json.loads(response.text).get("error", "Unknown error occurred")
-                except json.JSONDecodeError:
+                except ValueError:
                     error_message = response.text
                 raise Exception(f"Failed to authorize. Status code: {response.status_code}. Error: {error_message}")
             raise Exception(f"Unexpected error occurred while trying to authorize. Status code: {response.status_code}")

--- a/api/services/auth/jina.py
+++ b/api/services/auth/jina.py
@@ -47,6 +47,9 @@ class JinaAuth(ApiKeyAuthBase):
             raise Exception(f"Failed to authorize. Status code: {response.status_code}. Error: {error_message}")
         else:
             if response.text:
-                error_message = json.loads(response.text).get("error", "Unknown error occurred")
+                try:
+                    error_message = json.loads(response.text).get("error", "Unknown error occurred")
+                except json.JSONDecodeError:
+                    error_message = response.text
                 raise Exception(f"Failed to authorize. Status code: {response.status_code}. Error: {error_message}")
             raise Exception(f"Unexpected error occurred while trying to authorize. Status code: {response.status_code}")

--- a/api/services/auth/jina/jina.py
+++ b/api/services/auth/jina/jina.py
@@ -43,13 +43,16 @@ class JinaAuth(ApiKeyAuthBase):
 
     def _handle_error(self, response):
         if response.status_code in {402, 409, 500}:
-            error_message = response.json().get("error", "Unknown error occurred")
+            try:
+                error_message = response.json().get("error", "Unknown error occurred")
+            except ValueError:
+                error_message = response.text or "Unknown error occurred"
             raise Exception(f"Failed to authorize. Status code: {response.status_code}. Error: {error_message}")
         else:
             if response.text:
                 try:
                     error_message = json.loads(response.text).get("error", "Unknown error occurred")
-                except json.JSONDecodeError:
+                except ValueError:
                     error_message = response.text
                 raise Exception(f"Failed to authorize. Status code: {response.status_code}. Error: {error_message}")
             raise Exception(f"Unexpected error occurred while trying to authorize. Status code: {response.status_code}")

--- a/api/services/auth/jina/jina.py
+++ b/api/services/auth/jina/jina.py
@@ -47,6 +47,9 @@ class JinaAuth(ApiKeyAuthBase):
             raise Exception(f"Failed to authorize. Status code: {response.status_code}. Error: {error_message}")
         else:
             if response.text:
-                error_message = json.loads(response.text).get("error", "Unknown error occurred")
+                try:
+                    error_message = json.loads(response.text).get("error", "Unknown error occurred")
+                except json.JSONDecodeError:
+                    error_message = response.text
                 raise Exception(f"Failed to authorize. Status code: {response.status_code}. Error: {error_message}")
             raise Exception(f"Unexpected error occurred while trying to authorize. Status code: {response.status_code}")

--- a/api/tests/unit_tests/services/auth/test_jina_auth.py
+++ b/api/tests/unit_tests/services/auth/test_jina_auth.py
@@ -115,6 +115,22 @@ class TestJinaAuth:
         assert str(exc_info.value) == "Failed to authorize. Status code: 403. Error: Forbidden"
 
     @patch("services.auth.jina.jina._http_client.post", autospec=True)
+    def test_should_handle_unexpected_error_with_non_json_text_response(self, mock_post):
+        """Test handling of unexpected errors with non-JSON text response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.text = "Forbidden"
+        mock_response.json.side_effect = Exception("Not JSON")
+        mock_post.return_value = mock_response
+
+        credentials = {"auth_type": "bearer", "config": {"api_key": "test_api_key_123"}}
+        auth = JinaAuth(credentials)
+
+        with pytest.raises(Exception) as exc_info:
+            auth.validate_credentials()
+        assert str(exc_info.value) == "Failed to authorize. Status code: 403. Error: Forbidden"
+
+    @patch("services.auth.jina.jina._http_client.post", autospec=True)
     def test_should_handle_unexpected_error_without_text(self, mock_post):
         """Test handling of unexpected errors without text response"""
         mock_response = MagicMock()

--- a/api/tests/unit_tests/services/auth/test_jina_auth.py
+++ b/api/tests/unit_tests/services/auth/test_jina_auth.py
@@ -69,6 +69,22 @@ class TestJinaAuth:
         assert str(exc_info.value) == "Failed to authorize. Status code: 402. Error: Payment required"
 
     @patch("services.auth.jina.jina._http_client.post", autospec=True)
+    def test_should_handle_http_error_with_non_json_text_response(self, mock_post):
+        """Test handling of known HTTP errors with non-JSON text response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 402
+        mock_response.text = "Payment required"
+        mock_response.json.side_effect = ValueError("Not JSON")
+        mock_post.return_value = mock_response
+
+        credentials = {"auth_type": "bearer", "config": {"api_key": "test_api_key_123"}}
+        auth = JinaAuth(credentials)
+
+        with pytest.raises(Exception) as exc_info:
+            auth.validate_credentials()
+        assert str(exc_info.value) == "Failed to authorize. Status code: 402. Error: Payment required"
+
+    @patch("services.auth.jina.jina._http_client.post", autospec=True)
     def test_should_handle_http_409_error(self, mock_post):
         """Test handling of 409 Conflict error"""
         mock_response = MagicMock()

--- a/api/tests/unit_tests/services/auth/test_jina_auth_standalone_module.py
+++ b/api/tests/unit_tests/services/auth/test_jina_auth_standalone_module.py
@@ -128,6 +128,16 @@ def test_handle_error_with_text_json_body(jina_module: ModuleType) -> None:
         auth._handle_error(response)
 
 
+def test_handle_error_with_non_json_text_body(jina_module: ModuleType) -> None:
+    auth = jina_module.JinaAuth(_credentials(api_key="k"))
+    response = MagicMock()
+    response.status_code = 403
+    response.text = "Forbidden"
+
+    with pytest.raises(Exception, match="Status code: 403.*Forbidden"):
+        auth._handle_error(response)
+
+
 def test_handle_error_with_text_json_body_missing_error(jina_module: ModuleType) -> None:
     auth = jina_module.JinaAuth(_credentials(api_key="k"))
     response = MagicMock()

--- a/api/tests/unit_tests/services/auth/test_jina_auth_standalone_module.py
+++ b/api/tests/unit_tests/services/auth/test_jina_auth_standalone_module.py
@@ -118,6 +118,17 @@ def test_handle_error_statuses_default_unknown_error(jina_module: ModuleType) ->
         auth._handle_error(response)
 
 
+def test_handle_error_statuses_fall_back_to_text_body(jina_module: ModuleType) -> None:
+    auth = jina_module.JinaAuth(_credentials(api_key="k"))
+    response = MagicMock()
+    response.status_code = 402
+    response.text = "Payment required"
+    response.json.side_effect = ValueError("Not JSON")
+
+    with pytest.raises(Exception, match="Status code: 402.*Payment required"):
+        auth._handle_error(response)
+
+
 def test_handle_error_with_text_json_body(jina_module: ModuleType) -> None:
     auth = jina_module.JinaAuth(_credentials(api_key="k"))
     response = MagicMock()


### PR DESCRIPTION
## Summary

Fixes #37501.

`JinaAuth._handle_error()` attempted to parse non-empty error bodies as JSON. When Jina Reader or an upstream proxy returned a plain-text error body, credential validation leaked a raw JSON parsing exception instead of reporting the HTTP status and response message.

This change catches JSON parsing failures in both auth error branches and falls back to the response text. The same fix is applied to both the active package implementation and the standalone module copy so the behavior stays consistent.

## Screenshots

N/A. Backend credential validation error handling change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This does not apply to typos.)
- [x] I have added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I have updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Validation run:

```bash
UV_CACHE_DIR=/Volumes/Luochen/.cache/uv uv run --project api --group dev pytest api/tests/unit_tests/services/auth/test_jina_auth.py api/tests/unit_tests/services/auth/test_jina_auth_standalone_module.py -q
```

Result: 32 passed.

```bash
git diff --check
```

Result: no output.
