### PR TITLE
fix(watercrawl): handle non-json error responses

### DIFF
--- a/api/core/rag/extractor/watercrawl/client.py
+++ b/api/core/rag/extractor/watercrawl/client.py
@@ -121,7 +121,10 @@ class WaterCrawlAPIClient(BaseAPIClient):
         content_type = response.headers.get("Content-Type", "")
         media_type = content_type.split(";", 1)[0].strip().lower()
         if media_type == "application/json":
-            return response.json() or {}
+            try:
+                return response.json() or {}
+            except ValueError as exc:
+                raise ValueError("Invalid JSON response from WaterCrawl") from exc
 
         if media_type == "application/octet-stream":
             return response.content

--- a/api/core/rag/extractor/watercrawl/exceptions.py
+++ b/api/core/rag/extractor/watercrawl/exceptions.py
@@ -1,3 +1,11 @@
+"""WaterCrawl domain exceptions.
+
+These exceptions are constructed from upstream HTTP responses, which may be
+JSON API errors or plain text/HTML proxy errors. Keep the exception type stable
+even when the body is not JSON so callers can handle WaterCrawl failures by
+domain type instead of low-level parser errors.
+"""
+
 import json
 from typing import override
 
@@ -10,8 +18,13 @@ class WaterCrawlBadRequestError(WaterCrawlError):
     def __init__(self, response):
         self.status_code = response.status_code
         self.response = response
-        data = response.json()
-        self.message = data.get("message", "Unknown error occurred")
+        try:
+            data = response.json()
+        except ValueError:
+            data = {}
+        if not isinstance(data, dict):
+            data = {}
+        self.message = data.get("message") or response.text or "Unknown error occurred"
         self.errors = data.get("errors", {})
         super().__init__(self.message)
 

--- a/api/core/rag/extractor/watercrawl/exceptions.py
+++ b/api/core/rag/extractor/watercrawl/exceptions.py
@@ -7,7 +7,9 @@ domain type instead of low-level parser errors.
 """
 
 import json
-from typing import override
+from typing import Any, override
+
+from httpx import Response
 
 
 class WaterCrawlError(Exception):
@@ -15,11 +17,11 @@ class WaterCrawlError(Exception):
 
 
 class WaterCrawlBadRequestError(WaterCrawlError):
-    def __init__(self, response):
+    def __init__(self, response: Response):
         self.status_code = response.status_code
         self.response = response
         try:
-            data = response.json()
+            data: Any = response.json()
         except ValueError:
             data = {}
         if not isinstance(data, dict):

--- a/api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py
+++ b/api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py
@@ -184,6 +184,14 @@ class TestWaterCrawlAPIClient:
         assert client.process_response(_response(200, {"ok": True})) == {"ok": True}
         assert client.process_response(_response(200, None)) == {}
 
+    def test_process_response_json_payload_with_invalid_body_raises_clear_error(self):
+        client = WaterCrawlAPIClient(api_key="k")
+        response = _response(200, text="<html>upstream error</html>")
+        response.json.side_effect = json.JSONDecodeError("Expecting value", response.text, 0)
+
+        with pytest.raises(ValueError, match="Invalid JSON response from WaterCrawl"):
+            client.process_response(response)
+
     def test_process_response_accepts_json_content_type_parameters(self):
         client = WaterCrawlAPIClient(api_key="k")
 

--- a/api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py
+++ b/api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py
@@ -159,6 +159,22 @@ class TestWaterCrawlAPIClient:
         with pytest.raises(expected_exception):
             client.process_response(_response(status, {"message": "bad", "errors": {"url": ["x"]}}))
 
+    @pytest.mark.parametrize(
+        ("status", "expected_exception"),
+        [
+            (401, WaterCrawlAuthenticationError),
+            (403, WaterCrawlPermissionError),
+            (422, WaterCrawlBadRequestError),
+        ],
+    )
+    def test_process_response_error_statuses_with_non_json_body(self, status: int, expected_exception: type[Exception]):
+        client = WaterCrawlAPIClient(api_key="k")
+        response = _response(status, text="<html>upstream error</html>")
+        response.json.side_effect = json.JSONDecodeError("Expecting value", response.text, 0)
+
+        with pytest.raises(expected_exception):
+            client.process_response(response)
+
     def test_process_response_204_returns_none(self):
         client = WaterCrawlAPIClient(api_key="k")
         assert client.process_response(_response(204, None)) is None


### PR DESCRIPTION
## Summary

- keep WaterCrawl domain exceptions stable when upstream 4xx responses are not JSON
- fall back to response text and empty errors for non-JSON error bodies
- raise a clear `Invalid JSON response from WaterCrawl` error when a JSON content-type response has an invalid body
- add coverage for 401, 403, 4xx non-JSON responses and invalid JSON success responses

Closes #37513

## Tests

- `uv run --project api pytest -o addopts='' api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py -q`
- `uv run --project api --with ruff ruff check api/core/rag/extractor/watercrawl/client.py api/core/rag/extractor/watercrawl/exceptions.py api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py`
- `uv run --project api --with ruff ruff format --check api/core/rag/extractor/watercrawl/client.py api/core/rag/extractor/watercrawl/exceptions.py api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py`