### PR TITLE
fix(watercrawl): bound client request timeouts

### DIFF
--- a/api/core/rag/extractor/watercrawl/client.py
+++ b/api/core/rag/extractor/watercrawl/client.py
@@ -12,7 +12,7 @@ from core.rag.extractor.watercrawl.exceptions import (
     WaterCrawlPermissionError,
 )
 
-WATERCRAWL_REQUEST_TIMEOUT = httpx.Timeout(30.0, connect=5.0)
+WATERCRAWL_REQUEST_TIMEOUT: httpx.Timeout = httpx.Timeout(30.0, connect=5.0)
 
 
 class SpiderOptions(TypedDict):

--- a/api/core/rag/extractor/watercrawl/client.py
+++ b/api/core/rag/extractor/watercrawl/client.py
@@ -12,6 +12,8 @@ from core.rag.extractor.watercrawl.exceptions import (
     WaterCrawlPermissionError,
 )
 
+WATERCRAWL_REQUEST_TIMEOUT = httpx.Timeout(30.0, connect=5.0)
+
 
 class SpiderOptions(TypedDict):
     max_depth: int
@@ -48,7 +50,7 @@ class BaseAPIClient:
             "User-Agent": "WaterCrawl-Plugin",
             "Accept-Language": "en-US",
         }
-        return httpx.Client(headers=headers, timeout=None)
+        return httpx.Client(headers=headers, timeout=WATERCRAWL_REQUEST_TIMEOUT)
 
     def _request(
         self,

--- a/api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py
+++ b/api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py
@@ -73,6 +73,9 @@ class TestBaseAPIClient:
         assert client.session == "session"
         assert captured["headers"]["X-API-Key"] == "k"
         assert captured["headers"]["User-Agent"] == "WaterCrawl-Plugin"
+        assert captured["timeout"] is not None
+        assert captured["timeout"].connect is not None
+        assert captured["timeout"].read is not None
 
     def test_request_stream_and_non_stream_paths(self, monkeypatch: pytest.MonkeyPatch):
         class FakeSession:


### PR DESCRIPTION
## Summary

- replace the WaterCrawl shared client `timeout=None` with an explicit bounded httpx timeout
- keep connect/read timeouts enabled for crawl request, status, and result paths
- add unit coverage to prevent the shared client from disabling timeouts again

Fixes #37512

## Tests

- `uv run --project api pytest -o addopts='' api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py -q`
- `uv run --project api --with ruff ruff check api/core/rag/extractor/watercrawl/client.py api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py`
- `uv run --project api --with ruff ruff format --check api/core/rag/extractor/watercrawl/client.py api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py`
