### PR TITLE
fix: add bounded timeout to Jina auth credential validation

### DIFF
--- a/api/services/auth/jina/jina.py
+++ b/api/services/auth/jina/jina.py
@@ -6,6 +6,8 @@ import httpx
 from core.helper.http_client_pooling import get_pooled_http_client
 from services.auth.api_key_auth_base import ApiKeyAuthBase, AuthCredentials
 
+_CREDENTIAL_VALIDATION_TIMEOUT = httpx.Timeout(10.0, connect=3.0)
+
 _http_client: httpx.Client = get_pooled_http_client(
     "auth:jina",
     lambda: httpx.Client(limits=httpx.Limits(max_keepalive_connections=50, max_connections=100)),
@@ -39,7 +41,7 @@ class JinaAuth(ApiKeyAuthBase):
         return {"Content-Type": "application/json", "Authorization": f"Bearer {self.api_key}"}
 
     def _post_request(self, url, data, headers):
-        return _http_client.post(url, headers=headers, json=data)
+        return _http_client.post(url, headers=headers, json=data, timeout=_CREDENTIAL_VALIDATION_TIMEOUT)
 
     def _handle_error(self, response):
         if response.status_code in {402, 409, 500}:

--- a/api/tests/unit_tests/services/auth/test_jina_auth.py
+++ b/api/tests/unit_tests/services/auth/test_jina_auth.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from services.auth.jina.jina import JinaAuth
+from services.auth.jina.jina import JinaAuth, _CREDENTIAL_VALIDATION_TIMEOUT
 
 
 class TestJinaAuth:
@@ -51,6 +51,7 @@ class TestJinaAuth:
             "https://r.jina.ai",
             headers={"Content-Type": "application/json", "Authorization": "Bearer test_api_key_123"},
             json={"url": "https://example.com"},
+            timeout=_CREDENTIAL_VALIDATION_TIMEOUT,
         )
 
     @patch("services.auth.jina.jina._http_client.post", autospec=True)
@@ -185,3 +186,21 @@ class TestJinaAuth:
         with pytest.raises(ValueError) as exc_info:
             JinaAuth({"auth_type": "basic", "config": {"api_key": "super_secret_key_12345"}})
         assert "super_secret_key_12345" not in str(exc_info.value)
+
+    @patch("services.auth.jina.jina._http_client.post", autospec=True)
+    def test_should_pass_bounded_timeout_to_credential_validation(self, mock_post):
+        """Credential validation must not use the default unbounded timeout."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        credentials = {"auth_type": "bearer", "config": {"api_key": "test_api_key_123"}}
+        auth = JinaAuth(credentials)
+        auth.validate_credentials()
+
+        call_kwargs = mock_post.call_args
+        assert "timeout" in call_kwargs.kwargs, "timeout keyword is missing from _post_request"
+        timeout = call_kwargs.kwargs["timeout"]
+        assert isinstance(timeout, httpx.Timeout)
+        assert timeout.connect == _CREDENTIAL_VALIDATION_TIMEOUT.connect
+        assert timeout.read == _CREDENTIAL_VALIDATION_TIMEOUT.read


### PR DESCRIPTION
## Summary

- `JinaAuth._post_request` used the default unbounded timeout from the pooled `httpx.Client`, meaning credential validation could hang indefinitely on network issues
- Add `httpx.Timeout(10.0, connect=3.0)` constant (matching the pattern used across Dify) and pass it to the POST request
- Update existing test assertions and add a new test verifying the bounded timeout is passed

Closes #37524

## Test plan

- [x] Updated `test_should_validate_valid_credentials_successfully` to assert the timeout parameter
- [x] Added `test_should_pass_bounded_timeout_to_credential_validation` test
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)