### PR TITLE
fix: add bounded timeout to WaterCrawl auth credential validation

### DIFF
--- a/api/services/auth/watercrawl/watercrawl.py
+++ b/api/services/auth/watercrawl/watercrawl.py
@@ -6,6 +6,8 @@ import httpx
 
 from services.auth.api_key_auth_base import ApiKeyAuthBase, AuthCredentials
 
+_CREDENTIAL_VALIDATION_TIMEOUT = httpx.Timeout(10.0, connect=3.0)
+
 
 class WatercrawlAuth(ApiKeyAuthBase):
     def __init__(self, credentials: AuthCredentials):
@@ -33,7 +35,7 @@ class WatercrawlAuth(ApiKeyAuthBase):
         return {"Content-Type": "application/json", "X-API-KEY": self.api_key}
 
     def _get_request(self, url, headers):
-        return httpx.get(url, headers=headers)
+        return httpx.get(url, headers=headers, timeout=_CREDENTIAL_VALIDATION_TIMEOUT)
 
     def _handle_error(self, response):
         if response.status_code in {402, 409, 500}:

--- a/api/tests/unit_tests/services/auth/test_watercrawl_auth.py
+++ b/api/tests/unit_tests/services/auth/test_watercrawl_auth.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from services.auth.watercrawl.watercrawl import WatercrawlAuth
+from services.auth.watercrawl.watercrawl import WatercrawlAuth, _CREDENTIAL_VALIDATION_TIMEOUT
 
 
 class TestWatercrawlAuth:
@@ -77,6 +77,7 @@ class TestWatercrawlAuth:
         mock_get.assert_called_once_with(
             "https://app.watercrawl.dev/api/v1/core/crawl-requests/",
             headers={"Content-Type": "application/json", "X-API-KEY": "test_api_key_123"},
+            timeout=_CREDENTIAL_VALIDATION_TIMEOUT,
         )
 
     @pytest.mark.parametrize(
@@ -216,3 +217,19 @@ class TestWatercrawlAuth:
 
         # Verify the timeout exception is raised with original message
         assert "timed out" in str(exc_info.value)
+
+    @patch("services.auth.watercrawl.watercrawl.httpx.get", autospec=True)
+    def test_should_pass_bounded_timeout_to_credential_validation(self, mock_get, auth_instance):
+        """Credential validation must not use the default unbounded timeout."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        auth_instance.validate_credentials()
+
+        call_kwargs = mock_get.call_args
+        assert "timeout" in call_kwargs.kwargs, "timeout keyword is missing from _get_request"
+        timeout = call_kwargs.kwargs["timeout"]
+        assert isinstance(timeout, httpx.Timeout)
+        assert timeout.connect == _CREDENTIAL_VALIDATION_TIMEOUT.connect
+        assert timeout.read == _CREDENTIAL_VALIDATION_TIMEOUT.read

--- a/api/tests/unit_tests/services/auth/test_watercrawl_auth.py
+++ b/api/tests/unit_tests/services/auth/test_watercrawl_auth.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from services.auth.watercrawl.watercrawl import WatercrawlAuth, _CREDENTIAL_VALIDATION_TIMEOUT
+from services.auth.watercrawl.watercrawl import _CREDENTIAL_VALIDATION_TIMEOUT, WatercrawlAuth
 
 
 class TestWatercrawlAuth:


### PR DESCRIPTION
## Summary

- `WatercrawlAuth._get_request` used `httpx.get` without a timeout parameter, meaning credential validation could hang indefinitely on network issues
- Add `httpx.Timeout(10.0, connect=3.0)` constant (matching the pattern used across Dify) and pass it to the GET request
- Update existing test assertions and add a new test verifying the bounded timeout is passed

Same class of issue as #37524 (Jina auth validation timeout).

## Test plan

- [x] Updated `test_should_validate_valid_credentials_successfully` to assert the timeout parameter
- [x] Added `test_should_pass_bounded_timeout_to_credential_validation` test
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)