### PR TITLE
fix: prevent HTML form elements from rendering in user chat input

### DIFF
--- a/web/app/components/base/chat/chat/question.tsx
+++ b/web/app/components/base/chat/chat/question.tsx
@@ -206,7 +206,12 @@ const Question: FC<QuestionProps> = ({
             )
           }
           {!isEditing
-            ? <Markdown content={content} />
+            ? (
+                <Markdown
+                  content={content}
+                  customDisallowedElements={['button', 'form', 'input', 'textarea', 'label', 'select', 'option']}
+                />
+              )
             : (
                 <div className="flex flex-col gap-4">
                   <div className="max-h-[158px] overflow-x-hidden overflow-y-auto pr-1">


### PR DESCRIPTION
## Summary

- User input in the Question component was rendered through the full Markdown pipeline, which allows raw HTML tags including `<button>`, `<form>`, `<input>`, etc.
- These tags are intentionally permitted in LLM responses for human-input form rendering, but user-supplied messages should never produce interactive HTML elements
- Entering `<button class="primary-button">Confirm</button>` in the chat input would render as an actual clickable button
- Pass `customDisallowedElements` to the Markdown component in the Question component to strip `button`, `form`, `input`, `textarea`, `label`, `select`, and `option` elements from user messages

Closes #37414

## Test plan

- [x] Verified that `<button>Confirm</button>` in user input is stripped instead of rendered as an interactive element
- [x] Verified that LLM responses with human-input forms still render correctly (no changes to answer rendering)
- [x] Existing Question component tests continue to pass

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)