### PR TITLE
fix: VariableTruncator._truncate_array under-reports truncated flag

### DIFF
--- a/api/services/variable_truncator.py
+++ b/api/services/variable_truncator.py
@@ -292,6 +292,7 @@ class VariableTruncator(BaseTruncator):
                 used_size += 1  # Account for comma
 
             if used_size > target_size:
+                truncated = True
                 break
 
             remaining_budget = target_size - used_size
@@ -301,7 +302,7 @@ class VariableTruncator(BaseTruncator):
                 raise UnknownTypeError(f"got unknown type {type(item)} in array truncation")
             truncated_value.append(part_result.value)
             used_size += part_result.value_size
-            truncated = part_result.truncated
+            truncated = truncated or part_result.truncated
         return _PartResult(truncated_value, used_size, truncated)
 
     @classmethod

--- a/api/tests/unit_tests/services/test_variable_truncator.py
+++ b/api/tests/unit_tests/services/test_variable_truncator.py
@@ -224,6 +224,25 @@ class TestArrayTruncation:
             assert isinstance(item, str)
         assert VariableTruncator.calculate_json_size(result.value) <= 50
 
+    def test_array_size_limit_break_sets_truncated_flag(self):
+        """When _truncate_array breaks out of the loop due to used_size exceeding
+        target_size, the truncated flag must be True (elements were dropped)."""
+        t = VariableTruncator(array_element_limit=20, max_size_bytes=1000)
+        # target_size=12 is small enough that only a few integers fit (each is
+        # 2-3 bytes in JSON, plus commas).  The tail of the array gets dropped.
+        result = t._truncate_array([10, 20, 30, 40, 50], 12)
+        assert result.truncated is True
+        assert len(result.value) < 5  # at least one element was dropped
+
+    def test_array_truncated_flag_accumulates_across_elements(self):
+        """If an earlier element is truncated but a later element is not, the
+        accumulated truncated flag must still be True (no overwrite)."""
+        t = VariableTruncator(array_element_limit=20, max_size_bytes=1000, string_length_limit=10)
+        # The first string (60 chars) will be truncated to fit budget, the second
+        # ("a") fits without truncation.  The flag must still be True overall.
+        result = t._truncate_array(["x" * 60, "a"], 60)
+        assert result.truncated is True
+
     def test_array_with_nested_objects(self, small_truncator):
         """Test array truncation with nested objects."""
         nested_array = [


### PR DESCRIPTION
## Summary

- Fix `_truncate_array` size-limit `break` not setting `truncated = True` before exiting the loop, causing dropped tail elements to go unreported
- Fix `_truncate_array` overwriting the `truncated` flag on each iteration instead of accumulating it (`truncated = truncated or part_result.truncated`), so a later non-truncated element could erase an earlier truncation signal
- Add two targeted unit tests reproducing the exact scenarios from the issue

## Context

Closes #37192

The `_truncate_object` and `truncate_variable_mapping` sibling methods already accumulate the flag correctly. This PR brings `_truncate_array` in line with them.

**Bug 1 — size-limit break:** When `used_size > target_size`, the loop breaks but leaves `truncated = False`, so dropped array elements are not reported:
```python
t = VariableTruncator(array_element_limit=20, max_size_bytes=1000)
r = t._truncate_array([10, 20, 30, 40, 50], 12)
# Before fix: r.truncated == False (wrong — element 50 was dropped)
# After fix:  r.truncated == True
```

**Bug 2 — flag overwrite:** `truncated = part_result.truncated` replaces the flag on each iteration instead of OR-accumulating:
```python
t2 = VariableTruncator(array_element_limit=20, max_size_bytes=1000, string_length_limit=10)
r2 = t2._truncate_array(["x" * 60, "a"], 60)
# Before fix: r2.truncated == False (wrong — "x"*60 was truncated)
# After fix:  r2.truncated == True
```

## Test plan

- [x] New test `test_array_size_limit_break_sets_truncated_flag` verifies bug 1
- [x] New test `test_array_truncated_flag_accumulates_across_elements` verifies bug 2
- [x] Existing `TestArrayTruncation` tests continue to pass (no behavior change for non-buggy paths)

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)