### PR TITLE
fix: preserve correct Content-Type for inline file preview

### DIFF
--- a/api/controllers/files/image_preview.py
+++ b/api/controllers/files/image_preview.py
@@ -132,7 +132,7 @@ class FilePreviewApi(Resource):
         if args.as_attachment:
             encoded_filename = quote(upload_file.name)
             response.headers["Content-Disposition"] = f"attachment; filename*=UTF-8''{encoded_filename}"
-        response.headers["Content-Type"] = "application/octet-stream"
+            response.headers["Content-Type"] = "application/octet-stream"
 
         enforce_download_for_html(
             response,


### PR DESCRIPTION
## Summary
- The `/file-preview` endpoint unconditionally sets `Content-Type: application/octet-stream`, overriding the correct MIME type (`upload_file.mime_type`) even for inline previews where `as_attachment=False`
- This causes browsers to download files instead of displaying them inline (e.g., PDFs, images, audio/video)
- Moved the `Content-Type` override inside the `if args.as_attachment:` block so it only applies for downloads, matching the pattern already used in the service API endpoint (`controllers/service_api/app/file_preview.py`)

## Test plan
- [ ] Verify that a file preview request (without `as_attachment`) returns the correct `Content-Type` matching the file's MIME type
- [ ] Verify that a file download request (with `as_attachment=True`) still returns `Content-Type: application/octet-stream`
- [ ] Verify that `enforce_download_for_html` still forces `application/octet-stream` for HTML content (security measure preserved)

Closes #37198

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)