### PR TITLE
fix: fall back to existing tracing provider when toggle sends enabled without provider

### DIFF
--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -1020,8 +1020,16 @@ class AppTraceApi(Resource):
     @edit_permission_required
     @get_app_model
     def post(self, app_model: App):
-        # add app trace
-        args = AppTracePayload.model_validate(console_ns.payload)
+        payload = console_ns.payload
+        # When the UI toggles tracing on without specifying a provider,
+        # fall back to the currently configured provider so the toggle
+        # works after initial provider setup.
+        if payload.get("enabled") and not payload.get("tracing_provider"):
+            existing = OpsTraceManager.get_app_tracing_config(app_model.id, db.session)
+            if existing.get("tracing_provider"):
+                payload["tracing_provider"] = existing["tracing_provider"]
+
+        args = AppTracePayload.model_validate(payload)
 
         OpsTraceManager.update_app_tracing_config(
             app_id=app_model.id,

--- a/api/tests/unit_tests/controllers/console/app/test_app_response_models.py
+++ b/api/tests/unit_tests/controllers/console/app/test_app_response_models.py
@@ -457,6 +457,61 @@ def test_app_pagination_aliases_per_page_and_has_next(app_models):
     assert serialized["data"][1]["icon_url"] is None
 
 
+def test_trace_toggle_falls_back_to_existing_provider(app_module, monkeypatch):
+    """When the UI sends enabled=True without tracing_provider, the endpoint
+    should fall back to the currently configured provider instead of
+    raising a validation error (issue #37174)."""
+    payload = {"enabled": True}
+    app_model = SimpleNamespace(id="app-1")
+
+    # Stub OpsTraceManager to return an existing provider config
+    trace_manager = MagicMock()
+    trace_manager.get_app_tracing_config.return_value = {
+        "enabled": False,
+        "tracing_provider": "langfuse",
+    }
+    trace_manager.update_app_tracing_config.return_value = None
+    monkeypatch.setattr(app_module, "OpsTraceManager", trace_manager)
+
+    # Stub db.session used by the fallback lookup
+    monkeypatch.setattr(app_module, "db", SimpleNamespace(session=MagicMock()))
+
+    app_module.console_ns.payload = payload
+    try:
+        _unwrap(app_module.AppTraceApi().post)(app_model)
+    finally:
+        app_module.console_ns.payload = None
+
+    # The update should be called with the existing provider, not None
+    trace_manager.update_app_tracing_config.assert_called_once_with(
+        app_id="app-1",
+        enabled=True,
+        tracing_provider="langfuse",
+    )
+
+
+def test_trace_toggle_without_existing_provider_still_validates(app_module, monkeypatch):
+    """When enabled=True and no existing provider is configured, the
+    validation error should still be raised (no silent misconfiguration)."""
+    payload = {"enabled": True}
+    app_model = SimpleNamespace(id="app-2")
+
+    trace_manager = MagicMock()
+    trace_manager.get_app_tracing_config.return_value = {
+        "enabled": False,
+        "tracing_provider": None,
+    }
+    monkeypatch.setattr(app_module, "OpsTraceManager", trace_manager)
+    monkeypatch.setattr(app_module, "db", SimpleNamespace(session=MagicMock()))
+
+    app_module.console_ns.payload = payload
+    try:
+        with pytest.raises(ValidationError):
+            _unwrap(app_module.AppTraceApi().post)(app_model)
+    finally:
+        app_module.console_ns.payload = None
+
+
 def test_app_list_uses_injected_session_for_draft_workflows(
     app: Flask, app_module: ModuleType, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- The tracing enable toggle in the UI sends `{"enabled": true}` without including `tracing_provider`
- The `AppTracePayload` validator rejects this with `"tracing_provider is required when enabled is True"`, even when a provider like Langfuse is already configured
- The endpoint now looks up the current `tracing_provider` from the app's existing config before validation, so the toggle works after initial provider setup
- If no provider is configured yet, the validation error still correctly fires

## Test plan
- [ ] Configure a tracing provider (e.g., Langfuse) in an app's monitoring settings
- [ ] Toggle the tracing enable switch on — should succeed without validation error
- [ ] Toggle the tracing enable switch off — should succeed
- [ ] Try enabling tracing on an app with no provider configured — should still get the validation error
- [ ] Verify unit tests pass

Closes #37174

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)