### PR TITLE
fix: normalize disabled summary_index_setting to prevent validation error

### DIFF
--- a/api/core/workflow/nodes/knowledge_index/entities.py
+++ b/api/core/workflow/nodes/knowledge_index/entities.py
@@ -105,10 +105,20 @@ class KnowledgeIndexNodeData(BaseNodeData):
     @field_validator("summary_index_setting", mode="before")
     @classmethod
     def normalize_summary_index_setting(cls, v: Any) -> Any:
-        """Treat dicts with enable=None (or missing enable) as None (#36233)."""
+        """Normalize summary_index_setting: treat disabled/None entries as None.
+
+        When the "Summary Generation Auto" switch is turned off, the frontend
+        may send ``{"enable": null, ...}`` or ``{"enable": false, "model_name": null, ...}``.
+        Both forms should collapse to ``None`` because the downstream
+        ``SummaryIndexSettingDict`` TypedDict rejects ``None`` values for its
+        string fields even when ``enable=False``.
+
+        Refs #36233, #37209.
+        """
         if v is None:
             return None
         if isinstance(v, dict):
-            if v.get("enable") is None:
+            enable = v.get("enable")
+            if enable is None or enable is False:
                 return None
         return v

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -178,11 +178,21 @@ class _AutomaticProcessRule(BaseModel):
     @field_validator("summary_index_setting", mode="before")
     @classmethod
     def _normalize_summary_index_setting(cls, v: Any) -> Any:
-        """Treat dicts with enable=None (or missing enable) as None (#36602)."""
+        """Treat dicts with enable=None/False (or missing enable) as None.
+
+        When the "Summary Generation Auto" switch is off the frontend may send
+        ``{"enable": null, ...}`` or ``{"enable": false, "model_name": null, ...}``.
+        Collapsing to ``None`` prevents storing nullable string fields that
+        downstream ``SummaryIndexSettingDict`` TypedDict validation rejects.
+
+        Refs #36602, #37209.
+        """
         if v is None:
             return None
-        if isinstance(v, dict) and v.get("enable") is None:
-            return None
+        if isinstance(v, dict):
+            enable = v.get("enable")
+            if enable is None or enable is False:
+                return None
         return v
 
 
@@ -196,11 +206,13 @@ class _CustomProcessRule(BaseModel):
     @field_validator("summary_index_setting", mode="before")
     @classmethod
     def _normalize_summary_index_setting(cls, v: Any) -> Any:
-        """Treat dicts with enable=None (or missing enable) as None (#36602)."""
+        """Treat dicts with enable=None/False (or missing enable) as None."""
         if v is None:
             return None
-        if isinstance(v, dict) and v.get("enable") is None:
-            return None
+        if isinstance(v, dict):
+            enable = v.get("enable")
+            if enable is None or enable is False:
+                return None
         return v
 
 
@@ -214,11 +226,13 @@ class _HierarchicalProcessRule(BaseModel):
     @field_validator("summary_index_setting", mode="before")
     @classmethod
     def _normalize_summary_index_setting(cls, v: Any) -> Any:
-        """Treat dicts with enable=None (or missing enable) as None (#36602)."""
+        """Treat dicts with enable=None/False (or missing enable) as None."""
         if v is None:
             return None
-        if isinstance(v, dict) and v.get("enable") is None:
-            return None
+        if isinstance(v, dict):
+            enable = v.get("enable")
+            if enable is None or enable is False:
+                return None
         return v
 
 
@@ -231,6 +245,25 @@ _EstimateProcessRule = Annotated[
 class _EstimateArgs(BaseModel):
     info_list: dict[str, Any]
     process_rule: _EstimateProcessRule
+
+
+def _normalize_summary_index_setting_value(v: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Normalize a raw summary_index_setting value.
+
+    When the "Summary Generation Auto" switch is turned off, the DB may store
+    ``{"enable": false, "model_name": null, ...}`` or ``{"enable": null, ...}``.
+    Downstream ``SummaryIndexSettingDict`` TypedDict validation rejects ``None``
+    values for string fields, so we collapse disabled settings to ``None``.
+
+    Refs #37209.
+    """
+    if v is None:
+        return None
+    if isinstance(v, dict):
+        enable = v.get("enable")
+        if enable is None or enable is False:
+            return None
+    return v
 
 
 class DatasetService:
@@ -397,7 +430,7 @@ class DatasetService:
         dataset.permission = DatasetPermissionEnum(permission) if permission else DatasetPermissionEnum.ONLY_ME
         dataset.provider = provider
         if summary_index_setting is not None:
-            dataset.summary_index_setting = summary_index_setting
+            dataset.summary_index_setting = _normalize_summary_index_setting_value(summary_index_setting)
         db.session.add(dataset)
         db.session.flush()
 
@@ -626,6 +659,11 @@ class DatasetService:
         # Update summary index setting if provided
         summary_index_setting = data.get("summary_index_setting", None)
         if summary_index_setting is not None:
+            # Normalize: collapse disabled/enable=None settings to None (#37209)
+            if isinstance(summary_index_setting, dict):
+                enable = summary_index_setting.get("enable")
+                if enable is None or enable is False:
+                    summary_index_setting = None
             dataset.summary_index_setting = summary_index_setting
 
         # Update basic dataset properties
@@ -719,8 +757,15 @@ class DatasetService:
         if data.get("retrieval_model"):
             filtered_data["retrieval_model"] = data["retrieval_model"]
         # update summary index setting
-        if data.get("summary_index_setting"):
-            filtered_data["summary_index_setting"] = data.get("summary_index_setting")
+        summary_index_setting = data.get("summary_index_setting")
+        if summary_index_setting:
+            # Normalize: collapse disabled/enable=None settings to None (#37209)
+            if isinstance(summary_index_setting, dict):
+                enable = summary_index_setting.get("enable")
+                if enable is None or enable is False:
+                    summary_index_setting = None
+            if summary_index_setting is not None:
+                filtered_data["summary_index_setting"] = summary_index_setting
         # update icon info
         if data.get("icon_info"):
             filtered_data["icon_info"] = data.get("icon_info")
@@ -788,7 +833,9 @@ class DatasetService:
                             knowledge_index_node_data["chunk_structure"] = dataset.chunk_structure
                             knowledge_index_node_data["indexing_technique"] = dataset.indexing_technique
                             knowledge_index_node_data["keyword_number"] = dataset.keyword_number
-                            knowledge_index_node_data["summary_index_setting"] = dataset.summary_index_setting
+                            knowledge_index_node_data["summary_index_setting"] = _normalize_summary_index_setting_value(
+                                dataset.summary_index_setting
+                            )
                             node["data"] = knowledge_index_node_data
                             updated = True
                         except Exception:
@@ -1118,7 +1165,9 @@ class DatasetService:
             dataset.retrieval_model = knowledge_configuration.retrieval_model.model_dump()
             # Update summary_index_setting if provided
             if knowledge_configuration.summary_index_setting is not None:
-                dataset.summary_index_setting = knowledge_configuration.summary_index_setting
+                dataset.summary_index_setting = _normalize_summary_index_setting_value(
+                    knowledge_configuration.summary_index_setting
+                )
             session.add(dataset)
         else:
             if dataset.chunk_structure and dataset.chunk_structure != knowledge_configuration.chunk_structure:
@@ -1230,7 +1279,9 @@ class DatasetService:
             dataset.retrieval_model = knowledge_configuration.retrieval_model.model_dump()
             # Update summary_index_setting if provided
             if knowledge_configuration.summary_index_setting is not None:
-                dataset.summary_index_setting = knowledge_configuration.summary_index_setting
+                dataset.summary_index_setting = _normalize_summary_index_setting_value(
+                    knowledge_configuration.summary_index_setting
+                )
             session.add(dataset)
             session.commit()
             if action:

--- a/api/services/rag_pipeline/rag_pipeline_dsl_service.py
+++ b/api/services/rag_pipeline/rag_pipeline_dsl_service.py
@@ -317,7 +317,11 @@ class RagPipelineDslService:
                         dataset.keyword_number = knowledge_configuration.keyword_number
                     # Update summary_index_setting if provided
                     if knowledge_configuration.summary_index_setting is not None:
-                        dataset.summary_index_setting = knowledge_configuration.summary_index_setting
+                        from services.dataset_service import _normalize_summary_index_setting_value
+
+                        dataset.summary_index_setting = _normalize_summary_index_setting_value(
+                            knowledge_configuration.summary_index_setting
+                        )
                     dataset.pipeline_id = pipeline.id
                     self._session.add(dataset)
                     self._session.flush()
@@ -454,7 +458,11 @@ class RagPipelineDslService:
                         dataset.keyword_number = knowledge_configuration.keyword_number
                     # Update summary_index_setting if provided
                     if knowledge_configuration.summary_index_setting is not None:
-                        dataset.summary_index_setting = knowledge_configuration.summary_index_setting
+                        from services.dataset_service import _normalize_summary_index_setting_value
+
+                        dataset.summary_index_setting = _normalize_summary_index_setting_value(
+                            knowledge_configuration.summary_index_setting
+                        )
                     dataset.pipeline_id = pipeline.id
                     self._session.add(dataset)
                     self._session.flush()

--- a/api/services/rag_pipeline/rag_pipeline_transform_service.py
+++ b/api/services/rag_pipeline/rag_pipeline_transform_service.py
@@ -185,8 +185,12 @@ class RagPipelineTransformService:
             dataset.retrieval_model = knowledge_configuration.retrieval_model.model_dump()
 
         # Copy summary_index_setting from dataset to knowledge_index node configuration
+        # Normalize: collapse disabled/enable=None settings to None (#37209)
         if dataset.summary_index_setting:
-            knowledge_configuration.summary_index_setting = dataset.summary_index_setting
+            sis = dataset.summary_index_setting
+            enable = sis.get("enable") if isinstance(sis, dict) else None
+            if enable is not None and enable is not False:
+                knowledge_configuration.summary_index_setting = sis
 
         knowledge_configuration_dict.update(knowledge_configuration.model_dump())
         node["data"] = knowledge_configuration_dict

--- a/api/tests/unit_tests/core/workflow/nodes/knowledge_index/test_knowledge_index_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/knowledge_index/test_knowledge_index_node.py
@@ -618,6 +618,112 @@ class TestKnowledgeIndexNode:
         assert template.segments == []
 
 
+class TestSummaryIndexSettingNormalization:
+    """Tests for the normalize_summary_index_setting field validator."""
+
+    def test_none_stays_none(self):
+        data = KnowledgeIndexNodeData(
+            title="KI",
+            type="knowledge-index",
+            chunk_structure="general_structure",
+            index_chunk_variable_selector=["start", "chunks"],
+            summary_index_setting=None,
+        )
+        assert data.summary_index_setting is None
+
+    def test_enable_none_normalized_to_none(self):
+        """When enable is None, the whole setting should be None (#36233)."""
+        validated = KnowledgeIndexNodeData.model_validate(
+            {
+                "title": "KI",
+                "type": "knowledge-index",
+                "chunk_structure": "general_structure",
+                "index_chunk_variable_selector": ["start", "chunks"],
+                "summary_index_setting": {
+                    "enable": None,
+                    "model_name": None,
+                    "model_provider_name": None,
+                    "summary_prompt": None,
+                },
+            }
+        )
+        assert validated.summary_index_setting is None
+
+    def test_enable_false_normalized_to_none(self):
+        """When enable=False, setting should be None regardless of other fields (#37209).
+
+        The frontend sends ``{"enable": false, "model_name": null, ...}`` when
+        the user turns off the "Summary Generation Auto" switch.  The downstream
+        ``SummaryIndexSettingDict`` TypedDict rejects ``None`` for its string
+        fields, so we must collapse the whole value to ``None``.
+        """
+        validated = KnowledgeIndexNodeData.model_validate(
+            {
+                "title": "KI",
+                "type": "knowledge-index",
+                "chunk_structure": "general_structure",
+                "index_chunk_variable_selector": ["start", "chunks"],
+                "summary_index_setting": {
+                    "enable": False,
+                    "model_name": None,
+                    "model_provider_name": None,
+                    "summary_prompt": None,
+                },
+            }
+        )
+        assert validated.summary_index_setting is None
+
+    def test_enable_false_with_empty_strings_normalized_to_none(self):
+        """enable=False with empty-string values also yields None."""
+        validated = KnowledgeIndexNodeData.model_validate(
+            {
+                "title": "KI",
+                "type": "knowledge-index",
+                "chunk_structure": "general_structure",
+                "index_chunk_variable_selector": ["start", "chunks"],
+                "summary_index_setting": {
+                    "enable": False,
+                    "model_name": "",
+                    "model_provider_name": "",
+                },
+            }
+        )
+        assert validated.summary_index_setting is None
+
+    def test_enable_true_preserved(self):
+        """When enable=True, the setting should be preserved as-is."""
+        validated = KnowledgeIndexNodeData.model_validate(
+            {
+                "title": "KI",
+                "type": "knowledge-index",
+                "chunk_structure": "general_structure",
+                "index_chunk_variable_selector": ["start", "chunks"],
+                "summary_index_setting": {
+                    "enable": True,
+                    "model_name": "gpt-4o",
+                    "model_provider_name": "openai",
+                },
+            }
+        )
+        assert validated.summary_index_setting is not None
+        assert validated.summary_index_setting["enable"] is True
+
+    def test_missing_enable_key_normalized_to_none(self):
+        """When the enable key is missing, treat as None."""
+        validated = KnowledgeIndexNodeData.model_validate(
+            {
+                "title": "KI",
+                "type": "knowledge-index",
+                "chunk_structure": "general_structure",
+                "index_chunk_variable_selector": ["start", "chunks"],
+                "summary_index_setting": {
+                    "model_name": "gpt-4o",
+                },
+            }
+        )
+        assert validated.summary_index_setting is None
+
+
 class TestInvokeKnowledgeIndex:
     def test_invoke_with_summary_index_setting(
         self,


### PR DESCRIPTION
## Summary

- When the "Summary Generation Auto" switch is turned off, the frontend sends `{"enable": false, "model_name": null, ...}`, but the existing `normalize_summary_index_setting` validator only handled `enable=None`, not `enable=False`
- This caused `SummaryIndexSettingDict` TypedDict validation to reject `None` values for `NotRequired[str]` fields, resulting in a 4-field `ValidationError` when running knowledge pipeline workflows
- Extended all `normalize_summary_index_setting` validators to treat `enable=False` the same as `enable=None` (collapse to `None`)
- Added `_normalize_summary_index_setting_value()` helper and applied it at all DB write paths so disabled settings are never persisted with `None` string values

## Changes

1. **`entities.py`** — Extended `KnowledgeIndexNodeData.normalize_summary_index_setting` to also handle `enable=False`
2. **`dataset_service.py`** — Extended 3 Pydantic validators (`_AutomaticProcessRule`, `_CustomProcessRule`, `_HierarchicalProcessRule`); added `_normalize_summary_index_setting_value()` helper; normalized 5 DB write paths
3. **`rag_pipeline_dsl_service.py`** — Normalized 2 DB write paths using the helper
4. **`rag_pipeline_transform_service.py`** — Normalized workflow node copy path
5. **`test_knowledge_index_node.py`** — Added `TestSummaryIndexSettingNormalization` with 6 test cases

Fixes #37209
Refs #36233

## Test plan

- [ ] Create a dataset with "Summary Generation Auto" enabled, then disable it — verify no validation error
- [ ] Run a knowledge pipeline workflow with a dataset that has `summary_index_setting` stored as `{"enable": false, "model_name": null, ...}` — verify workflow runs without error
- [ ] Verify that `enable=True` settings are still preserved correctly
- [ ] Run the new unit tests: `pytest api/tests/unit_tests/core/workflow/nodes/knowledge_index/test_knowledge_index_node.py -k TestSummaryIndexSettingNormalization`

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)