### PR TITLE
fix: prevent crashes in jieba text_exists and rate_limit flush_cache

### DIFF
--- a/api/core/app/features/rate_limiting/rate_limit.py
+++ b/api/core/app/features/rate_limiting/rate_limit.py
@@ -50,10 +50,11 @@ class RateLimit:
     def flush_cache(self, use_local_value=False):
         self.last_recalculate_time = time.time()
         # flush max active requests
-        if use_local_value or not redis_client.exists(self.max_active_requests_key):
+        cached = redis_client.get(self.max_active_requests_key)
+        if use_local_value or cached is None:
             redis_client.setex(self.max_active_requests_key, timedelta(days=1), self.max_active_requests)
         else:
-            self.max_active_requests = int(redis_client.get(self.max_active_requests_key).decode("utf-8"))
+            self.max_active_requests = int(cached.decode("utf-8"))
             redis_client.expire(self.max_active_requests_key, timedelta(days=1))
         if self.disabled():
             return

--- a/api/core/rag/datasource/keyword/jieba/jieba.py
+++ b/api/core/rag/datasource/keyword/jieba/jieba.py
@@ -77,7 +77,7 @@ class Jieba(BaseKeyword):
     @override
     def text_exists(self, id: str) -> bool:
         keyword_table = self._get_dataset_keyword_table()
-        if keyword_table is None:
+        if not keyword_table:
             return False
         return id in set.union(*keyword_table.values())
 

--- a/api/tests/unit_tests/core/app/features/rate_limiting/test_rate_limit.py
+++ b/api/tests/unit_tests/core/app/features/rate_limiting/test_rate_limit.py
@@ -140,7 +140,6 @@ class TestRateLimit:
         """Test max requests syncs from Redis when key exists."""
         redis_patch.configure_mock(
             **{
-                "exists.return_value": True,
                 "get.return_value": b"10",
                 "expire.return_value": True,
             }
@@ -150,6 +149,27 @@ class TestRateLimit:
         rate_limit.flush_cache()
 
         assert rate_limit.max_active_requests == 10
+
+    def test_should_use_local_value_when_redis_key_disappears_between_exists_and_get(self, redis_patch):
+        """Test that flush_cache doesn't crash when Redis key expires between exists() and get().
+
+        This is a TOCTOU race condition: the key can expire between the exists() check and the
+        get() call. Before the fix, this would cause `AttributeError: 'NoneType' object has no
+        attribute 'decode'` because get() returns None but .decode() is called on it.
+        """
+        redis_patch.configure_mock(
+            **{
+                "get.return_value": None,  # Key expired between check and get
+                "setex.return_value": True,
+            }
+        )
+
+        rate_limit = RateLimit("test_client", 5)
+
+        # Should not raise, and should fall back to using local value
+        rate_limit.flush_cache()
+        assert rate_limit.max_active_requests == 5
+        redis_patch.setex.assert_called()
 
     @patch("time.time")
     def test_should_clean_timeout_requests_from_active_list(self, mock_time, redis_patch):

--- a/api/tests/unit_tests/core/rag/datasource/keyword/jieba/test_jieba.py
+++ b/api/tests/unit_tests/core/rag/datasource/keyword/jieba/test_jieba.py
@@ -157,6 +157,9 @@ def test_text_exists_handles_missing_and_existing_keyword_table(monkeypatch: pyt
     monkeypatch.setattr(keyword, "_get_dataset_keyword_table", MagicMock(return_value=None))
     assert keyword.text_exists("node-1") is False
 
+    monkeypatch.setattr(keyword, "_get_dataset_keyword_table", MagicMock(return_value={}))
+    assert keyword.text_exists("node-1") is False
+
     monkeypatch.setattr(keyword, "_get_dataset_keyword_table", MagicMock(return_value={"k": {"node-1", "node-2"}}))
     assert keyword.text_exists("node-2") is True
     assert keyword.text_exists("node-x") is False


### PR DESCRIPTION
## Summary

- **Jieba keyword table crash**: `text_exists()` crashes with `TypeError` when `_get_dataset_keyword_table()` returns an empty dict `{}`, because `set.union(*{}.values())` requires at least one argument. The method only guarded against `None` but `_get_dataset_keyword_table` returns `{}` at line 184. Fixed by changing the guard from `keyword_table is None` to `not keyword_table`.
- **Rate limiting TOCTOU race**: `flush_cache()` had a race condition between `redis_client.exists()` and `redis_client.get()`. If the Redis key expires between the two calls, `get()` returns `None` and calling `.decode("utf-8")` on it raises `AttributeError`. Fixed by replacing the `exists()` + `get()` pattern with a single `get()` call and a `None` check.

## Reproduction

**Bug 1** — `set.union` on empty dict:
```python
>>> set.union(*{}.values())
TypeError: unbound method set.union() needs an argument
```
This is reachable when `_get_dataset_keyword_table()` returns `{}`, which happens at line 184 when no keyword table data exists.

**Bug 2** — Redis key expires between `exists()` and `get()`:
```python
# Key exists during exists() check, but expires before get()
cached = redis_client.get(key)  # Returns None
int(cached.decode("utf-8"))     # AttributeError: 'NoneType' object has no attribute 'decode'
```

## Test plan

- [x] Added test for `text_exists()` with empty dict `{}` — verifies it returns `False` instead of crashing
- [x] Added test for `flush_cache()` when Redis key disappears — verifies it falls back to local value instead of crashing
- [x] Updated existing `test_should_sync_max_requests_from_redis_on_subsequent_flush` to remove stale `exists.return_value` mock (no longer needed after fix)

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)