### PR TITLE
fix: close SQLAlchemy sessions in datasource_provider_service

### DIFF
--- a/api/services/datasource_provider_service.py
+++ b/api/services/datasource_provider_service.py
@@ -433,7 +433,7 @@ class DatasourceProviderService:
         """
         check if system oauth params exist
         """
-        with Session(db.engine).no_autoflush as session:
+        with Session(db.engine) as session:
             return (
                 session.scalar(
                     select(DatasourceOauthParamConfig)
@@ -510,7 +510,7 @@ class DatasourceProviderService:
         """
         provider = datasource_provider_id.provider_name
         plugin_id = datasource_provider_id.plugin_id
-        with Session(db.engine).no_autoflush as session:
+        with Session(db.engine) as session:
             # get tenant oauth client params
             tenant_oauth_client_params = session.scalar(
                 select(DatasourceOauthTenantParamConfig)


### PR DESCRIPTION
## Summary

The pattern `with Session(db.engine).no_autoflush as session:` creates a Session that is **never closed**. The `no_autoflush` context manager only manages the autoflush flag — it does NOT close the session when the `with` block exits. This leaks database connections from the connection pool.

Two methods in `DatasourceProviderService` used this pattern:
- `is_system_oauth_params_exist()` (line 436) — read-only SELECT query
- `get_oauth_client()` (line 513) — read-only SELECT query

Neither function needs `no_autoflush` since they only perform SELECT queries and never call `session.add()` or `session.commit()` that would trigger autoflush.

## Fix

Replaced `with Session(db.engine).no_autoflush as session:` with the standard `with Session(db.engine) as session:` pattern used elsewhere in the codebase (e.g., `plugin_parameter_service.py`, `plugin_migration.py`, `workflow_comment_service.py`), which properly closes the session on context manager exit.

## How the bug works

```python
session = Session(db.engine)      # Creates a session, acquires a connection
with session.no_autoflush as s:   # Only temporarily disables autoflush
    pass                          # Exit: autoflush is restored, BUT session is NOT closed!
# Session still holds the DB connection — never returned to pool
```

vs. the correct pattern:

```python
with Session(db.engine) as session:  # Session created AND managed
    pass                              # Exit: session.close() is called, connection returned to pool
```

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)