### PR TITLE
fix: prevent crash when annotation error key is missing in Redis

### DIFF
--- a/api/controllers/console/app/annotation.py
+++ b/api/controllers/console/app/annotation.py
@@ -241,7 +241,8 @@ class AnnotationReplyActionStatusApi(Resource):
         error_msg = ""
         if job_status == "error":
             app_annotation_error_key = f"{action}_app_annotation_error_{job_id_str}"
-            error_msg = redis_client.get(app_annotation_error_key).decode()
+            error_msg = redis_client.get(app_annotation_error_key)
+            error_msg = error_msg.decode() if error_msg else ""
 
         return {"job_id": job_id_str, "job_status": job_status, "error_msg": error_msg}, 200
 
@@ -471,7 +472,8 @@ class AnnotationBatchImportStatusApi(Resource):
         error_msg = ""
         if job_status == "error":
             indexing_error_msg_key = f"app_annotation_batch_import_error_msg_{str(job_id)}"
-            error_msg = redis_client.get(indexing_error_msg_key).decode()
+            error_msg = redis_client.get(indexing_error_msg_key)
+            error_msg = error_msg.decode() if error_msg else ""
 
         return {"job_id": job_id, "job_status": job_status, "error_msg": error_msg}, 200
 

--- a/api/controllers/service_api/app/annotation.py
+++ b/api/controllers/service_api/app/annotation.py
@@ -120,7 +120,8 @@ class AnnotationReplyActionStatusApi(Resource):
         error_msg = ""
         if job_status == "error":
             app_annotation_error_key = f"{action}_app_annotation_error_{job_id_str}"
-            error_msg = redis_client.get(app_annotation_error_key).decode()
+            error_msg = redis_client.get(app_annotation_error_key)
+            error_msg = error_msg.decode() if error_msg else ""
 
         return {"job_id": job_id_str, "job_status": job_status, "error_msg": error_msg}, 200
 


### PR DESCRIPTION
## Summary

Three API endpoints for annotation job status crash with `AttributeError` when the job status is `"error"` but the error message key doesn't exist in Redis.

When an annotation job status is `"error"`, the endpoints fetch the error message from Redis using `redis_client.get(error_key).decode()`. However, the error key may not exist if:

1. The worker process crashed between setting the job status key (`"error"`) and setting the error message key — they are set in two separate `setex` calls
2. The error key expired before the status key (both have 600s TTL, but the error key is always set after the status key)

When the key is missing, `get()` returns `None` and calling `.decode()` raises:
```
AttributeError: 'NoneType' object has no attribute 'decode'
```

## Affected endpoints

- `api/controllers/service_api/app/annotation.py:123` — `AnnotationReplyActionStatusApi.get()`
- `api/controllers/console/app/annotation.py:244` — `AnnotationReplyActionStatusApi.get()`
- `api/controllers/console/app/annotation.py:474` — `AnnotationBatchImportStatusApi.get()`

## Fix

Check the return value of `redis_client.get()` before calling `.decode()`, falling back to an empty string if the key is missing.

## Test plan

- [x] Verified `redis_client.get(missing_key)` returns `None` (not `b""`) in Redis
- [x] Confirmed the error key and job status key are set in separate `setex` calls in the task files (`enable_annotation_reply_task.py`, `disable_annotation_reply_task.py`, `batch_import_annotations_task.py`), making the crash window possible

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)