### PR TITLE
fix: check account exists before calling BillingService.delete_account

### DIFF
--- a/api/tasks/delete_account_task.py
+++ b/api/tasks/delete_account_task.py
@@ -16,6 +16,9 @@ logger = logging.getLogger(__name__)
 def delete_account_task(account_id):
     with session_factory.create_session() as session:
         account = session.scalar(select(Account).where(Account.id == account_id).limit(1))
+        if not account:
+            logger.error("Account %s not found.", account_id)
+            return
         try:
             if dify_config.BILLING_ENABLED:
                 BillingService.delete_account(account_id)
@@ -23,8 +26,5 @@ def delete_account_task(account_id):
             logger.exception("Failed to delete account %s from billing service.", account_id)
             raise
 
-        if not account:
-            logger.error("Account %s not found.", account_id)
-            return
         # send success email
         send_deletion_success_task.delay(account.email)

--- a/api/tests/test_containers_integration_tests/tasks/test_delete_account_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_delete_account_task.py
@@ -65,7 +65,7 @@ def test_billing_disabled_account_exists_sends_email_only(
     mail_task.delay.assert_called_once_with(account.email)
 
 
-def test_billing_enabled_account_not_found_calls_billing_no_email(
+def test_billing_enabled_account_not_found_skips_billing_and_email(
     mock_external_dependencies: tuple[MagicMock, MagicMock], mocker: MockerFixture, caplog: LogCaptureFixture
 ) -> None:
     billing_service, mail_task = mock_external_dependencies
@@ -74,7 +74,7 @@ def test_billing_enabled_account_not_found_calls_billing_no_email(
 
     delete_account_task(account_id)
 
-    billing_service.delete_account.assert_called_once_with(account_id)
+    billing_service.delete_account.assert_not_called()
     mail_task.delay.assert_not_called()
     assert any("not found" in record.getMessage().lower() for record in caplog.records)
 


### PR DESCRIPTION
## Summary

In `delete_account_task`, the account existence check was placed **after** the billing service deletion call. If the account doesn't exist, `BillingService.delete_account()` would have already been executed (which may make irreversible external changes) before the task discovers the account is missing and returns early.

## Before

```python
account = session.scalar(...)
try:
    if dify_config.BILLING_ENABLED:
        BillingService.delete_account(account_id)  # Runs even if account is None!
except Exception:
    raise

if not account:
    return  # Too late — billing deletion already happened
```

## After

```python
account = session.scalar(...)
if not account:
    return  # Bail out before making any external changes

try:
    if dify_config.BILLING_ENABLED:
        BillingService.delete_account(account_id)
except Exception:
    raise
```

## Test plan

- [x] Logic is straightforward — the check is simply moved above the billing call
- [ ] Verify that `BillingService.delete_account` with a non-existent account ID would have caused side effects (the current code path would have hit this in production for any stale Celery task retry)

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)