### PR TITLE
Fix retry_document_indexing_task exiting early on single document failure

### DIFF
--- a/api/tasks/retry_document_indexing_task.py
+++ b/api/tasks/retry_document_indexing_task.py
@@ -59,16 +59,20 @@ def retry_document_indexing_task(dataset_id: str, document_ids: list[str], user_
                                 "your subscription."
                             )
                 except Exception as e:
-                    document = session.scalar(
-                        select(Document).where(Document.id == document_id, Document.dataset_id == dataset_id).limit(1)
-                    )
-                    if document:
-                        document.indexing_status = IndexingStatus.ERROR
-                        document.error = str(e)
-                        document.stopped_at = naive_utc_now()
-                        session.add(document)
-                        session.commit()
-                    redis_client.delete(retry_indexing_cache_key)
+                    remaining_ids = document_ids[document_ids.index(document_id):]
+                    for remaining_id in remaining_ids:
+                        remaining_doc = session.scalar(
+                            select(Document).where(
+                                Document.id == remaining_id, Document.dataset_id == dataset_id
+                            ).limit(1)
+                        )
+                        if remaining_doc:
+                            remaining_doc.indexing_status = IndexingStatus.ERROR
+                            remaining_doc.error = str(e)
+                            remaining_doc.stopped_at = naive_utc_now()
+                            session.add(remaining_doc)
+                        redis_client.delete(f"document_{remaining_id}_is_retried")
+                    session.commit()
                     return
 
                 logger.info(click.style(f"Start retry document: {document_id}", fg="green"))
@@ -77,7 +81,7 @@ def retry_document_indexing_task(dataset_id: str, document_ids: list[str], user_
                 )
                 if not document:
                     logger.info(click.style(f"Document not found: {document_id}", fg="yellow"))
-                    return
+                    continue
                 try:
                     # clean old data
                     index_processor = IndexProcessorFactory(document.doc_form).init_index_processor()

--- a/api/tasks/retry_document_indexing_task.py
+++ b/api/tasks/retry_document_indexing_task.py
@@ -59,12 +59,12 @@ def retry_document_indexing_task(dataset_id: str, document_ids: list[str], user_
                                 "your subscription."
                             )
                 except Exception as e:
-                    remaining_ids = document_ids[document_ids.index(document_id):]
+                    remaining_ids = document_ids[document_ids.index(document_id) :]
                     for remaining_id in remaining_ids:
                         remaining_doc = session.scalar(
-                            select(Document).where(
-                                Document.id == remaining_id, Document.dataset_id == dataset_id
-                            ).limit(1)
+                            select(Document)
+                            .where(Document.id == remaining_id, Document.dataset_id == dataset_id)
+                            .limit(1)
                         )
                         if remaining_doc:
                             remaining_doc.indexing_status = IndexingStatus.ERROR


### PR DESCRIPTION
## Summary
- Changed `return` to `continue` when a document is not found, so remaining documents in the batch are still processed
- When billing limit is exceeded, mark ALL remaining documents as ERROR and clean up their Redis cache keys instead of only handling the current one

## Bug Details

### Bug 1: `return` instead of `continue`
In the `for document_id in document_ids` loop, when `session.scalar(...)` returns `None` (document not found), the code used `return` which exits the entire task function. This silently skips all subsequent documents that may be perfectly valid.

### Bug 2: Incomplete cleanup on billing limit
When the billing limit check raises, only the current document was marked as `IndexingStatus.ERROR` and had its `document_{id}_is_retried` Redis key deleted. All remaining documents in the list:
- Were NOT marked as ERROR (they remain in their original retry state)
- Had their Redis cache keys left behind (potentially blocking future retry attempts since the key existence is often checked before allowing a retry)

Since all documents belong to the same tenant and the billing limit applies to the tenant, no remaining document can succeed either. They should all be marked as ERROR and have their cache keys cleaned up.

## Test plan
- [ ] Verify that when one document ID in a batch is not found, the remaining documents are still processed
- [ ] Verify that when billing limit is exceeded, all remaining documents in the batch are marked as ERROR and their Redis cache keys are cleaned up

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)