### PR TITLE
fix: use correct Content-Type in file-preview endpoint for non-download requests

### DIFF
--- a/api/controllers/files/image_preview.py
+++ b/api/controllers/files/image_preview.py
@@ -132,7 +132,7 @@ class FilePreviewApi(Resource):
         if args.as_attachment:
             encoded_filename = quote(upload_file.name)
             response.headers["Content-Disposition"] = f"attachment; filename*=UTF-8''{encoded_filename}"
-        response.headers["Content-Type"] = "application/octet-stream"
+            response.headers["Content-Type"] = "application/octet-stream"
 
         enforce_download_for_html(
             response,

--- a/api/tests/unit_tests/controllers/files/test_image_preview.py
+++ b/api/tests/unit_tests/controllers/files/test_image_preview.py
@@ -107,7 +107,7 @@ class TestFilePreviewApi:
 
         response = get_fn("file-id")
 
-        assert response.mimetype == "application/octet-stream"
+        assert response.mimetype == "text/plain"
         assert response.headers["Content-Length"] == "100"
         assert "Accept-Ranges" not in response.headers
         mock_enforce.assert_called_once()


### PR DESCRIPTION
## Problem

The `/files/{file_id}/file-preview` endpoint was unconditionally overriding `Content-Type` to `application/octet-stream` on every response, regardless of whether the request was a preview or a download.

This meant that when users tried to preview images or PDFs inline in the browser, the browser received `Content-Type: application/octet-stream` and was forced to download the file instead of rendering it. This was a regression from v1.12.1 where the correct MIME type was returned.

## Root Cause

In `api/controllers/files/image_preview.py:135`, the line that sets `Content-Type` to `application/octet-stream` was outside the `if args.as_attachment:` guard, so it ran for every request — both preview and download.

## Fix

Moved the `Content-Type` override inside the `as_attachment` guard so it only applies when the client explicitly requests a download. For preview requests, the correct MIME type (set via the `mimetype` parameter when constructing the Flask `Response`) is preserved.

## Testing

Updated the existing unit test in `test_image_preview.py` to expect the correct MIME type (`text/plain`) for non-attachment preview requests, rather than the incorrect `application/octet-stream`.

Fixes #37198
