### PR TITLE
test: replace logger patch with caplog in version and rag pipeline tests

### DIFF
--- a/api/tests/unit_tests/controllers/console/test_version.py
+++ b/api/tests/unit_tests/controllers/console/test_version.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import MagicMock, patch
 
 import controllers.console.version as version_module
@@ -18,15 +19,15 @@ class TestHasNewVersion:
         )
         assert result is False
 
-    def test_has_new_version_invalid_version(self):
-        with patch.object(version_module.logger, "warning") as log_warning:
+    def test_has_new_version_invalid_version(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="controllers.console.version"):
             result = version_module._has_new_version(
                 latest_version="invalid",
                 current_version="1.0.0",
             )
 
         assert result is False
-        log_warning.assert_called_once()
+        assert "Invalid version format" in caplog.text
 
 
 class TestCheckVersionUpdate:

--- a/api/tests/unit_tests/services/test_rag_pipeline_task_proxy.py
+++ b/api/tests/unit_tests/services/test_rag_pipeline_task_proxy.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from unittest.mock import Mock, patch
 
 import pytest
@@ -468,16 +469,14 @@ class TestRagPipelineTaskProxy:
         # Assert
         proxy._dispatch.assert_called_once()
 
-    @patch("services.rag_pipeline.rag_pipeline_task_proxy.logger")
-    def test_delay_method_with_empty_entities(self, mock_logger):
+    def test_delay_method_with_empty_entities(self, caplog):
         """Test delay method with empty rag_pipeline_invoke_entities."""
         # Arrange
         proxy = RagPipelineTaskProxy("tenant-123", "user-456", [])
 
         # Act
-        proxy.delay()
+        with caplog.at_level(logging.WARNING, logger="services.rag_pipeline.rag_pipeline_task_proxy"):
+            proxy.delay()
 
         # Assert
-        mock_logger.warning.assert_called_once_with(
-            "Received empty rag pipeline invoke entities, no tasks delivered: %s %s", "tenant-123", "user-456"
-        )
+        assert "Received empty rag pipeline invoke entities, no tasks delivered: tenant-123 user-456" in caplog.text


### PR DESCRIPTION
## Summary

Part of #37468. Replaces `@patch(...logger...)` / `patch.object(logger, ...)` mocking with pytest's `caplog` fixture in two unit test files:
  - `tests/unit_tests/controllers/console/test_version.py`
  - `tests/unit_tests/services/test_rag_pipeline_task_proxy.py`
  
`caplog` captures the actual log output instead of asserting that a mocked logger method was called, which is less brittle (independent of logger names / import paths) and reduces boilerplate. This follows the existing pattern in `tests/unit_tests/libs/test_workspace_permission.py`.
  
Using `Refs` rather than `Fixes` because #37468 spans ~8 files and is being open for the remaining files.

Happy to follow up with the remaining files in separate PRs if this approach looks good.
  
## Checklist
  
  - [x] I understand that this PR may be closed in case there was no previous discussion or issues.
  - [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
  - [ ] This change requires a documentation update
  - [ ] I've updated the documentation accordingly.
  
Refs #37468
