### PR TITLE
fix: align app and knowledge detail shell styles

### DIFF
--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/layout-main.tsx
@@ -13,7 +13,6 @@ import useDocumentTitle from '@/hooks/use-document-title'
 import { usePathname, useRouter } from '@/next/navigation'
 import { fetchAppDetailDirect } from '@/service/apps'
 import { AppModeEnum } from '@/types/app'
-import s from './style.module.css'
 
 type IAppDetailLayoutProps = {
   children: React.ReactNode
@@ -116,9 +115,19 @@ const AppDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
     )
   }
 
+  const isWorkflowPage = pathname.endsWith('/workflow')
+
   return (
-    <div className={cn(s.app, 'relative ml-1 flex', 'overflow-hidden')}>
-      <div className="grow overflow-hidden bg-components-panel-bg">
+    <div className={cn(
+      'relative flex h-0 grow overflow-hidden',
+      !isWorkflowPage && 'pt-1 pr-1 pb-1',
+    )}
+    >
+      <div className={cn(
+        'grow overflow-hidden bg-components-panel-bg',
+        !isWorkflowPage && 'rounded-lg shadow-xs shadow-shadow-shadow-3',
+      )}
+      >
         {children}
       </div>
     </div>

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/chart-view.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/chart-view.tsx
@@ -10,6 +10,7 @@ import { TIME_PERIOD_MAPPING as LONG_TIME_PERIOD_MAPPING } from '@/app/component
 import { AvgResponseTime, AvgSessionInteractions, AvgUserInteractions, ConversationsChart, CostChart, EndUsersChart, MessagesChart, TokenPerSecond, UserSatisfactionRate, WorkflowCostChart, WorkflowDailyTerminalsChart, WorkflowMessagesChart } from '@/app/components/app/overview/app-chart'
 import { useStore as useAppStore } from '@/app/components/app/store'
 import { IS_CLOUD_EDITION } from '@/config'
+import { useDocLink } from '@/context/i18n'
 import LongTimeRangePicker from './long-time-range-picker'
 import TimeRangePicker from './time-range-picker'
 
@@ -34,6 +35,7 @@ type IChartViewProps = {
 
 export default function ChartView({ appId, headerRight }: IChartViewProps) {
   const { t } = useTranslation()
+  const docLink = useDocLink()
   const appDetail = useAppStore(state => state.appDetail)
   const isChatApp = appDetail?.mode !== 'completion' && appDetail?.mode !== 'workflow'
   const isWorkflow = appDetail?.mode === 'workflow'
@@ -46,10 +48,26 @@ export default function ChartView({ appId, headerRight }: IChartViewProps) {
     return null
 
   return (
-    <div>
-      <div className="mb-4">
-        <div className="mb-2 system-xl-semibold text-text-primary">{t('appMenus.overview', { ns: 'common' })}</div>
-        <div className="flex items-center justify-between">
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="h-[106px] shrink-0">
+        <div className="px-6 pt-3">
+          <div className="flex h-6 items-center">
+            <h1 className="title-2xl-semi-bold text-text-primary">{t('appMenus.overview', { ns: 'common' })}</h1>
+          </div>
+          <div className="mt-0.5 flex h-4 min-w-0 items-start gap-0.5 system-xs-regular text-text-tertiary">
+            <p className="min-w-0 truncate">{t('monitoring.description', { ns: 'appLog' })}</p>
+            <a
+              href={docLink('/use-dify/monitor/analysis')}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex shrink-0 items-center text-text-accent hover:underline"
+            >
+              <span>{t('operation.learnMore', { ns: 'common' })}</span>
+              <span className="i-ri-external-link-line size-3" aria-hidden="true" />
+            </a>
+          </div>
+        </div>
+        <div className="mt-1 flex h-10 items-center justify-between pr-10 pl-6">
           {IS_CLOUD_EDITION
             ? (
                 <TimeRangePicker
@@ -69,47 +87,35 @@ export default function ChartView({ appId, headerRight }: IChartViewProps) {
           {headerRight}
         </div>
       </div>
-      {!isWorkflow && (
-        <div className="mb-6 grid w-full grid-cols-1 gap-6 xl:grid-cols-2">
-          <ConversationsChart period={period} id={appId} />
-          <EndUsersChart period={period} id={appId} />
+      <div className="min-h-0 flex-1 overflow-y-auto px-6 pt-2 pb-6">
+        <div className="grid w-full grid-cols-1 gap-3 xl:grid-cols-2">
+          {!isWorkflow && (
+            <>
+              <ConversationsChart period={period} id={appId} />
+              <EndUsersChart period={period} id={appId} />
+              {isChatApp
+                ? (
+                    <AvgSessionInteractions period={period} id={appId} />
+                  )
+                : (
+                    <AvgResponseTime period={period} id={appId} />
+                  )}
+              <TokenPerSecond period={period} id={appId} />
+              <UserSatisfactionRate period={period} id={appId} />
+              <CostChart period={period} id={appId} />
+              {isChatApp && <MessagesChart period={period} id={appId} />}
+            </>
+          )}
+          {isWorkflow && (
+            <>
+              <WorkflowMessagesChart period={period} id={appId} />
+              <WorkflowDailyTerminalsChart period={period} id={appId} />
+              <WorkflowCostChart period={period} id={appId} />
+              <AvgUserInteractions period={period} id={appId} />
+            </>
+          )}
         </div>
-      )}
-      {!isWorkflow && (
-        <div className="mb-6 grid w-full grid-cols-1 gap-6 xl:grid-cols-2">
-          {isChatApp
-            ? (
-                <AvgSessionInteractions period={period} id={appId} />
-              )
-            : (
-                <AvgResponseTime period={period} id={appId} />
-              )}
-          <TokenPerSecond period={period} id={appId} />
-        </div>
-      )}
-      {!isWorkflow && (
-        <div className="mb-6 grid w-full grid-cols-1 gap-6 xl:grid-cols-2">
-          <UserSatisfactionRate period={period} id={appId} />
-          <CostChart period={period} id={appId} />
-        </div>
-      )}
-      {!isWorkflow && isChatApp && (
-        <div className="mb-6 grid w-full grid-cols-1 gap-6 xl:grid-cols-2">
-          <MessagesChart period={period} id={appId} />
-        </div>
-      )}
-      {isWorkflow && (
-        <div className="mb-6 grid w-full grid-cols-1 gap-6 xl:grid-cols-2">
-          <WorkflowMessagesChart period={period} id={appId} />
-          <WorkflowDailyTerminalsChart period={period} id={appId} />
-        </div>
-      )}
-      {isWorkflow && (
-        <div className="mb-6 grid w-full grid-cols-1 gap-6 xl:grid-cols-2">
-          <WorkflowCostChart period={period} id={appId} />
-          <AvgUserInteractions period={period} id={appId} />
-        </div>
-      )}
+      </div>
     </div>
   )
 }

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/page.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/page.tsx
@@ -15,12 +15,14 @@ const Overview = async (props: IDevelopProps) => {
   } = params
 
   return (
-    <div className="h-full overflow-y-auto bg-chatbot-bg px-4 py-6 sm:px-12">
+    <div className="flex h-full min-h-0 flex-col">
       <ApikeyInfoPanel />
-      <ChartView
-        appId={appId}
-        headerRight={<TracingPanel />}
-      />
+      <div className="min-h-0 flex-1">
+        <ChartView
+          appId={appId}
+          headerRight={<TracingPanel />}
+        />
+      </div>
     </div>
   )
 }

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/panel.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/panel.tsx
@@ -247,7 +247,7 @@ const Panel: FC = () => {
         >
           <div
             className={cn(
-              'flex cursor-pointer items-center rounded-xl border-t border-l-[0.5px] border-effects-highlight bg-background-default-dodge p-2 shadow-xs select-none hover:border-effects-highlight-lightmode-off hover:bg-background-default-lighter',
+              'flex cursor-pointer items-center rounded-xl border-[0.5px] border-components-panel-border bg-background-default-dodge p-2 shadow-xs select-none hover:bg-background-default-lighter',
             )}
           >
             <TracingIcon size="md" />
@@ -286,7 +286,7 @@ const Panel: FC = () => {
         >
           <div
             className={cn(
-              'flex cursor-pointer items-center rounded-xl border-t border-l-[0.5px] border-effects-highlight bg-background-default-dodge p-2 shadow-xs select-none hover:border-effects-highlight-lightmode-off hover:bg-background-default-lighter',
+              'flex cursor-pointer items-center rounded-xl border-[0.5px] border-components-panel-border bg-background-default-dodge p-2 shadow-xs select-none hover:bg-background-default-lighter',
             )}
           >
             <div className="mr-1 ml-4 flex items-center">

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/style.module.css
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/style.module.css
@@ -1,6 +1,0 @@
-.app {
-    flex-grow: 1;
-    height: 0;
-    border-radius: 16px 16px 0px 0px;
-    box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.05), 0px 0px 2px -1px rgba(0, 0, 0, 0.03);
-}

--- a/web/app/(commonLayout)/datasets/(datasetDetailLayout)/[datasetId]/__tests__/layout-main.spec.tsx
+++ b/web/app/(commonLayout)/datasets/(datasetDetailLayout)/[datasetId]/__tests__/layout-main.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
-import { useRouter } from '@/next/navigation'
+import { usePathname, useRouter } from '@/next/navigation'
 import { useDatasetDetail } from '@/service/knowledge/use-dataset'
 import DatasetDetailLayout from '../layout-main'
 
@@ -31,11 +31,13 @@ vi.mock('@/hooks/use-document-title', () => ({
 }))
 
 const mockUseRouter = vi.mocked(useRouter)
+const mockUsePathname = vi.mocked(usePathname)
 const mockUseDatasetDetail = vi.mocked(useDatasetDetail)
 
 describe('DatasetDetailLayout', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUsePathname.mockReturnValue('/datasets/dataset-1/documents')
     mockUseRouter.mockReturnValue({
       back: vi.fn(),
       forward: vi.fn(),
@@ -117,6 +119,83 @@ describe('DatasetDetailLayout', () => {
       // Assert
       expect(screen.getByText('Pipeline content')).toBeInTheDocument()
       expect(mockReplace).not.toHaveBeenCalled()
+    })
+
+    it('should apply the dataset surface outside pipeline pages', () => {
+      // Arrange
+      mockUseDatasetDetail.mockReturnValue({
+        data: {
+          id: 'dataset-1',
+          name: 'Dataset 1',
+          provider: 'vendor',
+          runtime_mode: 'rag_pipeline',
+          is_published: true,
+        },
+        error: null,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof useDatasetDetail>)
+
+      // Act
+      render(
+        <DatasetDetailLayout datasetId="dataset-1">
+          <div>Documents content</div>
+        </DatasetDetailLayout>,
+      )
+
+      // Assert
+      expect(screen.getByText('Documents content').parentElement).toHaveClass('rounded-lg')
+    })
+
+    it('should keep pipeline pages unframed', () => {
+      // Arrange
+      mockUsePathname.mockReturnValue('/datasets/dataset-1/pipeline')
+      mockUseDatasetDetail.mockReturnValue({
+        data: {
+          id: 'dataset-1',
+          name: 'Dataset 1',
+          provider: 'vendor',
+          runtime_mode: 'rag_pipeline',
+          is_published: false,
+        },
+        error: null,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof useDatasetDetail>)
+
+      // Act
+      render(
+        <DatasetDetailLayout datasetId="dataset-1">
+          <div>Pipeline content</div>
+        </DatasetDetailLayout>,
+      )
+
+      // Assert
+      expect(screen.getByText('Pipeline content').parentElement).not.toHaveClass('rounded-lg')
+    })
+
+    it('should keep create-from-pipeline pages unframed', () => {
+      // Arrange
+      mockUsePathname.mockReturnValue('/datasets/dataset-1/documents/create-from-pipeline')
+      mockUseDatasetDetail.mockReturnValue({
+        data: {
+          id: 'dataset-1',
+          name: 'Dataset 1',
+          provider: 'vendor',
+          runtime_mode: 'rag_pipeline',
+          is_published: false,
+        },
+        error: null,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof useDatasetDetail>)
+
+      // Act
+      render(
+        <DatasetDetailLayout datasetId="dataset-1">
+          <div>Create from pipeline content</div>
+        </DatasetDetailLayout>,
+      )
+
+      // Assert
+      expect(screen.getByText('Create from pipeline content').parentElement).not.toHaveClass('rounded-lg')
     })
   })
 })

--- a/web/app/(commonLayout)/datasets/(datasetDetailLayout)/[datasetId]/layout-main.tsx
+++ b/web/app/(commonLayout)/datasets/(datasetDetailLayout)/[datasetId]/layout-main.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next'
 import Loading from '@/app/components/base/loading'
 import DatasetDetailContext from '@/context/dataset-detail'
 import useDocumentTitle from '@/hooks/use-document-title'
-import { useRouter } from '@/next/navigation'
+import { usePathname, useRouter } from '@/next/navigation'
 import { useDatasetDetail } from '@/service/knowledge/use-dataset'
 
 type IAppDetailLayoutProps = {
@@ -35,6 +35,7 @@ const DatasetDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
   } = props
   const { t } = useTranslation()
   const router = useRouter()
+  const pathname = usePathname()
 
   const { data: datasetRes, error, refetch: mutateDatasetRes } = useDatasetDetail(datasetId)
   const shouldRedirect = shouldRedirectToDatasetList(error)
@@ -52,11 +53,13 @@ const DatasetDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
   if (shouldRedirect)
     return <Loading type="app" />
 
+  const isPipelinePage = pathname.endsWith('/pipeline') || pathname.includes('/create-from-pipeline')
+
   return (
     <div
       className={cn(
-        'flex grow overflow-hidden',
-        'rounded-t-2xl',
+        'relative flex h-0 grow overflow-hidden',
+        !isPipelinePage && 'pt-1 pr-1 pb-1',
       )}
     >
       <DatasetDetailContext.Provider value={{
@@ -65,7 +68,13 @@ const DatasetDetailLayout: FC<IAppDetailLayoutProps> = (props) => {
         mutateDatasetRes,
       }}
       >
-        <div className="grow overflow-hidden bg-background-default-subtle">{children}</div>
+        <div className={cn(
+          'grow overflow-hidden bg-components-panel-bg',
+          !isPipelinePage && 'rounded-lg shadow-xs shadow-shadow-shadow-3',
+        )}
+        >
+          {children}
+        </div>
       </DatasetDetailContext.Provider>
     </div>
   )

--- a/web/app/components/app-sidebar/app-detail-section.tsx
+++ b/web/app/components/app-sidebar/app-detail-section.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { ComponentProps } from 'react'
 import type { NavIcon } from './nav-link'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
@@ -30,6 +31,15 @@ type AppDetailNavItem = {
   icon: NavIcon
   selectedIcon: NavIcon
 }
+
+const AnnotationNavIcon = ({ className, ...props }: ComponentProps<typeof Annotations>) => (
+  <Annotations
+    {...props}
+    className={cn(className, 'size-4')}
+  />
+)
+
+AnnotationNavIcon.displayName = 'Annotations'
 
 const isLogsNavItem = (item: AppDetailNavItem) => item.href.endsWith('/logs')
 const isAnnotationsNavItem = (item: AppDetailNavItem) => item.href.endsWith('/annotations')
@@ -98,8 +108,8 @@ const AppDetailSection = ({
             ? [{
                 name: t('appMenus.annotations', { ns: 'common' }),
                 href: `/app/${appId}/annotations`,
-                icon: Annotations,
-                selectedIcon: Annotations,
+                icon: AnnotationNavIcon,
+                selectedIcon: AnnotationNavIcon,
               }]
             : [])]
         : []

--- a/web/app/components/app/overview/app-chart.tsx
+++ b/web/app/components/app/overview/app-chart.tsx
@@ -95,11 +95,11 @@ const Chart: React.FC<IChartProps> = ({
   const tokenSummary = getTokenSummary(statistics)
 
   return (
-    <div className={`flex w-full flex-col rounded-xl bg-components-chart-bg px-6 py-4 shadow-xs ${className ?? ''}`}>
-      <div className="mb-3">
+    <div className={`flex h-[316px] w-full flex-col overflow-hidden rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-on-panel-item-bg ${className ?? ''}`}>
+      <div className="flex h-11 shrink-0 items-center px-6 pt-6 pb-1">
         <Basic name={title} type={timePeriod} hoverTip={explanation} />
       </div>
-      <div className="mb-4 flex-1">
+      <div className="flex h-8 shrink-0 items-start px-6 py-1">
         <Basic
           isExtraInLine={CHART_TYPE_CONFIG[chartType].showTokens}
           name={summaryValue}
@@ -123,7 +123,7 @@ const Chart: React.FC<IChartProps> = ({
           textStyle={{ main: `text-3xl! font-normal! ${summaryValue === '0' || summaryValue === '0 ms' ? 'text-text-quaternary!' : ''}` }}
         />
       </div>
-      <ReactECharts option={options} style={{ height: 160 }} />
+      <ReactECharts option={options} style={{ height: 240, width: '100%' }} />
     </div>
   )
 }

--- a/web/app/components/app/workflow-log/index.tsx
+++ b/web/app/components/app/workflow-log/index.tsx
@@ -16,6 +16,7 @@ import Loading from '@/app/components/base/loading'
 import { APP_PAGE_LIMIT } from '@/config'
 import { userProfileQueryOptions } from '@/features/account-profile/client'
 import { useWorkflowLogs } from '@/service/use-log'
+import PageTitle from '../log-annotation/page-title'
 import Filter, { TIME_PERIOD_MAPPING } from './filter'
 import List from './list'
 
@@ -67,8 +68,10 @@ const Logs: FC<ILogsProps> = ({ appDetail }) => {
 
   return (
     <div className="flex h-full flex-col">
-      <h1 className="system-xl-semibold text-text-primary">{t('workflowTitle', { ns: 'appLog' })}</h1>
-      <p className="system-sm-regular text-text-tertiary">{t('workflowSubtitle', { ns: 'appLog' })}</p>
+      <PageTitle
+        title={t('workflowTitle', { ns: 'appLog' })}
+        description={t('workflowSubtitle', { ns: 'appLog' })}
+      />
       <div className="flex max-h-[calc(100%-16px)] flex-1 flex-col py-4">
         <Filter queryParams={queryParams} setQueryParams={setQueryParams} />
         {/* workflow log */}

--- a/web/i18n/ar-TN/app-log.json
+++ b/web/i18n/ar-TN/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "اليوم",
   "filter.period.yearToDate": "السنة حتى الآن",
   "filter.sortBy": "رتب حسب:",
+  "monitoring.description": "يسجل الرصد حالة تشغيل التطبيق، بما في ذلك الأداء ونشاط المستخدمين والتكاليف.",
   "promptLog": "سجل المطالبة",
   "runDetail.fileListDetail": "تفاصيل",
   "runDetail.fileListLabel": "تفاصيل الملف",

--- a/web/i18n/de-DE/app-log.json
+++ b/web/i18n/de-DE/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "Heute",
   "filter.period.yearToDate": "Jahr bis heute",
   "filter.sortBy": "Sortieren nach:",
+  "monitoring.description": "Das Monitoring zeichnet den Betriebsstatus der Anwendung auf, einschließlich Leistung, Nutzeraktivität und Kosten.",
   "promptLog": "Prompt-Protokoll",
   "runDetail.fileListDetail": "Detail",
   "runDetail.fileListLabel": "Details zur Datei",

--- a/web/i18n/en-US/app-log.json
+++ b/web/i18n/en-US/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "Today",
   "filter.period.yearToDate": "Year to date",
   "filter.sortBy": "Sort by:",
+  "monitoring.description": "Monitoring records the running status of the application, including performance, user activity, and costs.",
   "promptLog": "Prompt Log",
   "runDetail.fileListDetail": "Detail",
   "runDetail.fileListLabel": "File Details",

--- a/web/i18n/es-ES/app-log.json
+++ b/web/i18n/es-ES/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "Hoy",
   "filter.period.yearToDate": "Año hasta la fecha",
   "filter.sortBy": "Ordenar por:",
+  "monitoring.description": "La monitorización registra el estado de ejecución de la aplicación, incluyendo rendimiento, actividad de los usuarios y costes.",
   "promptLog": "Registro de Indicación",
   "runDetail.fileListDetail": "Detalle",
   "runDetail.fileListLabel": "Detalles del archivo",

--- a/web/i18n/fa-IR/app-log.json
+++ b/web/i18n/fa-IR/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "امروز",
   "filter.period.yearToDate": "از ابتدای سال تاکنون",
   "filter.sortBy": "مرتب‌سازی بر اساس:",
+  "monitoring.description": "مانیتورینگ وضعیت اجرای برنامه را ثبت می‌کند، از جمله عملکرد، فعالیت کاربران و هزینه‌ها.",
   "promptLog": "لاگ درخواست",
   "runDetail.fileListDetail": "جزئیات",
   "runDetail.fileListLabel": "جزئیات فایل",

--- a/web/i18n/fr-FR/app-log.json
+++ b/web/i18n/fr-FR/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "Aujourd'hui",
   "filter.period.yearToDate": "Année à ce jour",
   "filter.sortBy": "Trier par :",
+  "monitoring.description": "Le monitoring enregistre l’état de fonctionnement de l’application, notamment les performances, l’activité des utilisateurs et les coûts.",
   "promptLog": "Journal de consigne",
   "runDetail.fileListDetail": "Détail",
   "runDetail.fileListLabel": "Détails du fichier",

--- a/web/i18n/hi-IN/app-log.json
+++ b/web/i18n/hi-IN/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "आज",
   "filter.period.yearToDate": "वर्ष तक तिथि",
   "filter.sortBy": "इसके अनुसार क्रमबद्ध करें:",
+  "monitoring.description": "मॉनिटरिंग एप्लिकेशन की रनिंग स्थिति रिकॉर्ड करती है, जिसमें प्रदर्शन, उपयोगकर्ता गतिविधि और लागतें शामिल हैं।",
   "promptLog": "प्रॉम्प्ट लॉग",
   "runDetail.fileListDetail": "विस्तार",
   "runDetail.fileListLabel": "फ़ाइल विवरण",

--- a/web/i18n/id-ID/app-log.json
+++ b/web/i18n/id-ID/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "Hari Ini",
   "filter.period.yearToDate": "Tahun hingga saat ini",
   "filter.sortBy": "Urutkan berdasarkan",
+  "monitoring.description": "Monitoring mencatat status berjalan aplikasi, termasuk performa, aktivitas pengguna, dan biaya.",
   "promptLog": "Prompt Log",
   "runDetail.fileListDetail": "Detail",
   "runDetail.fileListLabel": "Rincian File",

--- a/web/i18n/it-IT/app-log.json
+++ b/web/i18n/it-IT/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "Oggi",
   "filter.period.yearToDate": "Anno corrente",
   "filter.sortBy": "Ordina per:",
+  "monitoring.description": "Il monitoraggio registra lo stato di esecuzione dell’applicazione, inclusi prestazioni, attività degli utenti e costi.",
   "promptLog": "Registro Prompt",
   "runDetail.fileListDetail": "Dettaglio",
   "runDetail.fileListLabel": "Dettagli del file",

--- a/web/i18n/ja-JP/app-log.json
+++ b/web/i18n/ja-JP/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "今日",
   "filter.period.yearToDate": "年初から今日まで",
   "filter.sortBy": "並べ替え",
+  "monitoring.description": "モニタリングは、パフォーマンス、ユーザー活動、コストを含むアプリケーションの実行状況を記録します。",
   "promptLog": "プロンプトログ",
   "runDetail.fileListDetail": "詳細",
   "runDetail.fileListLabel": "ファイルの詳細",

--- a/web/i18n/ko-KR/app-log.json
+++ b/web/i18n/ko-KR/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "오늘",
   "filter.period.yearToDate": "연 초부터 오늘까지",
   "filter.sortBy": "정렬 기준:",
+  "monitoring.description": "모니터링은 성능, 사용자 활동, 비용을 포함한 애플리케이션 실행 상태를 기록합니다.",
   "promptLog": "프롬프트 로그",
   "runDetail.fileListDetail": "세부",
   "runDetail.fileListLabel": "파일 세부 정보",

--- a/web/i18n/nl-NL/app-log.json
+++ b/web/i18n/nl-NL/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "Today",
   "filter.period.yearToDate": "Year to date",
   "filter.sortBy": "Sort by:",
+  "monitoring.description": "Monitoring records the running status of the application, including performance, user activity, and costs.",
   "promptLog": "Prompt Log",
   "runDetail.fileListDetail": "Detail",
   "runDetail.fileListLabel": "File Details",

--- a/web/i18n/pl-PL/app-log.json
+++ b/web/i18n/pl-PL/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "Dzisiaj",
   "filter.period.yearToDate": "Od początku roku",
   "filter.sortBy": "Sortuj według:",
+  "monitoring.description": "Monitoring rejestruje stan działania aplikacji, w tym wydajność, aktywność użytkowników i koszty.",
   "promptLog": "Dziennik monitów",
   "runDetail.fileListDetail": "Detal",
   "runDetail.fileListLabel": "Szczegóły pliku",

--- a/web/i18n/pt-BR/app-log.json
+++ b/web/i18n/pt-BR/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "Hoje",
   "filter.period.yearToDate": "Ano até hoje",
   "filter.sortBy": "Ordenar por:",
+  "monitoring.description": "O monitoramento registra o status de execução do aplicativo, incluindo desempenho, atividade dos usuários e custos.",
   "promptLog": "Registro de Prompt",
   "runDetail.fileListDetail": "Detalhe",
   "runDetail.fileListLabel": "Detalhes do arquivo",

--- a/web/i18n/ro-RO/app-log.json
+++ b/web/i18n/ro-RO/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "Astăzi",
   "filter.period.yearToDate": "Anul curent",
   "filter.sortBy": "Sortează după:",
+  "monitoring.description": "Monitorizarea înregistrează starea de funcționare a aplicației, inclusiv performanța, activitatea utilizatorilor și costurile.",
   "promptLog": "Jurnal prompt",
   "runDetail.fileListDetail": "Amănunt",
   "runDetail.fileListLabel": "Detalii fișier",

--- a/web/i18n/ru-RU/app-log.json
+++ b/web/i18n/ru-RU/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "Сегодня",
   "filter.period.yearToDate": "С начала года",
   "filter.sortBy": "Сортировать по:",
+  "monitoring.description": "Мониторинг записывает состояние работы приложения, включая производительность, активность пользователей и затраты.",
   "promptLog": "Журнал подсказок",
   "runDetail.fileListDetail": "Подробность",
   "runDetail.fileListLabel": "Сведения о файле",

--- a/web/i18n/sl-SI/app-log.json
+++ b/web/i18n/sl-SI/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "Danes",
   "filter.period.yearToDate": "Leto do danes",
   "filter.sortBy": "Razvrsti po:",
+  "monitoring.description": "Spremljanje beleži stanje delovanja aplikacije, vključno z zmogljivostjo, dejavnostjo uporabnikov in stroški.",
   "promptLog": "Dnevnik PROMPT-ov",
   "runDetail.fileListDetail": "Podrobnosti",
   "runDetail.fileListLabel": "Podrobnosti o datoteki",

--- a/web/i18n/th-TH/app-log.json
+++ b/web/i18n/th-TH/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "วันนี้",
   "filter.period.yearToDate": "ปีจนถึงปัจจุบัน",
   "filter.sortBy": "เมืองสีดํา:",
+  "monitoring.description": "การมอนิเตอร์บันทึกสถานะการทำงานของแอปพลิเคชัน รวมถึงประสิทธิภาพ กิจกรรมผู้ใช้ และค่าใช้จ่าย",
   "promptLog": "บันทึกพร้อมท์",
   "runDetail.fileListDetail": "รายละเอียด",
   "runDetail.fileListLabel": "รายละเอียดไฟล์",

--- a/web/i18n/tr-TR/app-log.json
+++ b/web/i18n/tr-TR/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "Bugün",
   "filter.period.yearToDate": "Yıl Başlangıcından İtibaren",
   "filter.sortBy": "Sıralama ölçütü:",
+  "monitoring.description": "İzleme, performans, kullanıcı etkinliği ve maliyetler dahil olmak üzere uygulamanın çalışma durumunu kaydeder.",
   "promptLog": "Prompt Günlüğü",
   "runDetail.fileListDetail": "Ayrıntı",
   "runDetail.fileListLabel": "Dosya Detayları",

--- a/web/i18n/uk-UA/app-log.json
+++ b/web/i18n/uk-UA/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "Сьогодні",
   "filter.period.yearToDate": "Рік до сьогодні",
   "filter.sortBy": "Сортувати за:",
+  "monitoring.description": "Моніторинг фіксує робочий стан застосунку, зокрема продуктивність, активність користувачів і витрати.",
   "promptLog": "Журнал Запитань",
   "runDetail.fileListDetail": "Деталь",
   "runDetail.fileListLabel": "Подробиці файлу",

--- a/web/i18n/vi-VN/app-log.json
+++ b/web/i18n/vi-VN/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "Hôm nay",
   "filter.period.yearToDate": "Năm hiện tại",
   "filter.sortBy": "Sắp xếp theo:",
+  "monitoring.description": "Giám sát ghi lại trạng thái hoạt động của ứng dụng, bao gồm hiệu suất, hoạt động người dùng và chi phí.",
   "promptLog": "Nhật ký lời nhắc",
   "runDetail.fileListDetail": "Chi tiết",
   "runDetail.fileListLabel": "Chi tiết tệp",

--- a/web/i18n/zh-Hans/app-log.json
+++ b/web/i18n/zh-Hans/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "今天",
   "filter.period.yearToDate": "本年至今",
   "filter.sortBy": "排序：",
+  "monitoring.description": "监控记录应用的运行情况，包括性能、用户活动和成本。",
   "promptLog": "Prompt 日志",
   "runDetail.fileListDetail": "详情",
   "runDetail.fileListLabel": "文件详情",

--- a/web/i18n/zh-Hant/app-log.json
+++ b/web/i18n/zh-Hant/app-log.json
@@ -42,6 +42,7 @@
   "filter.period.today": "今天",
   "filter.period.yearToDate": "本年至今",
   "filter.sortBy": "排序：",
+  "monitoring.description": "監控記錄應用的執行情況，包括效能、使用者活動和成本。",
   "promptLog": "Prompt 日誌",
   "runDetail.fileListDetail": "細節",
   "runDetail.fileListLabel": "檔詳細資訊",


### PR DESCRIPTION
## Summary

- Align app and knowledge detail shell surfaces with the updated nav shell design, while keeping workflow and pipeline canvas pages unframed.
- Align the monitoring overview header, chart cards, tracing panel border, and monitoring description/link copy.
- Align app detail navigation icon sizing and reuse the logs page title component for workflow logs.

## Screenshots

| Knowledge detail zh-Hans | Knowledge detail en-US |
|--------------------------|-------------------------|
| <img width="400" alt="Knowledge detail zh-Hans" src="https://github.com/user-attachments/assets/6ceba1f4-4464-4e2b-8364-dd5ddc5058f8" /> | <img width="400" alt="Knowledge detail en-US" src="https://github.com/user-attachments/assets/95285348-7233-49f9-87f6-a7ac8e092c5f" /> |

## Testing

- [x] `pnpm -C web test 'app/(commonLayout)/datasets/(datasetDetailLayout)/[datasetId]/__tests__/layout-main.spec.tsx'`
- [x] `pnpm -C web test 'app/components/app-sidebar/__tests__/app-detail-section.spec.tsx'`
- [x] `pnpm -C web type-check`
- [x] `git diff --check HEAD~3..HEAD`

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Codex