### PR TITLE
fix: handle non-JSON error responses in WaterCrawl exceptions

### DIFF
--- a/api/core/rag/extractor/watercrawl/exceptions.py
+++ b/api/core/rag/extractor/watercrawl/exceptions.py
@@ -10,8 +10,11 @@ class WaterCrawlBadRequestError(WaterCrawlError):
     def __init__(self, response):
         self.status_code = response.status_code
         self.response = response
-        data = response.json()
-        self.message = data.get("message", "Unknown error occurred")
+        try:
+            data = response.json()
+        except ValueError:
+            data = {}
+        self.message = data.get("message", response.text or "Unknown error occurred")
         self.errors = data.get("errors", {})
         super().__init__(self.message)
 

--- a/api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py
+++ b/api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py
@@ -57,6 +57,32 @@ class TestWaterCrawlExceptions:
         assert "exceeding your WaterCrawl API limits" in str(permission)
         assert "API key is invalid or expired" in str(authentication)
 
+    def test_bad_request_error_with_non_json_response(self):
+        """Verify that non-JSON error bodies don't raise JSONDecodeError."""
+        response = MagicMock()
+        response.status_code = 401
+        response.json.side_effect = ValueError("Expecting value")
+        response.text = "<html>Unauthorized</html>"
+
+        err = WaterCrawlAuthenticationError(response)
+
+        assert err.status_code == 401
+        assert err.message == "<html>Unauthorized</html>"
+        assert err.errors == {}
+
+    def test_bad_request_error_with_empty_non_json_response(self):
+        """Verify fallback message when response.text is also empty."""
+        response = MagicMock()
+        response.status_code = 403
+        response.json.side_effect = ValueError("Expecting value")
+        response.text = ""
+
+        err = WaterCrawlPermissionError(response)
+
+        assert err.status_code == 403
+        assert err.message == "Unknown error occurred"
+        assert err.errors == {}
+
 
 class TestBaseAPIClient:
     def test_init_session_builds_expected_headers(self, monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Summary

When WaterCrawl API or an intermediate proxy returns a non-JSON error body (e.g. HTML) for 401/403/4xx responses, the exception constructors in `WaterCrawlBadRequestError.__init__` would raise `JSONDecodeError` instead of the intended domain-specific exception (`WaterCrawlAuthenticationError`, `WaterCrawlPermissionError`, or `WaterCrawlBadRequestError`).

This fix catches `ValueError` (the parent of `JSONDecodeError`) during JSON parsing and falls back to `response.text` as the error message.

## Changes

- **`api/core/rag/extractor/watercrawl/exceptions.py`**: Wrap `response.json()` in try/except, use `response.text` as fallback message
- **`api/tests/unit_tests/core/rag/extractor/watercrawl/test_watercrawl.py`**: Add tests for non-JSON error responses

## Test plan

- [x] Run existing WaterCrawl tests (all pass)
- [x] Added test for non-JSON 401 response (HTML body)
- [x] Added test for empty non-JSON response (fallback to "Unknown error occurred")

Fixes #37513