### PR TITLE
fix(agent-v2): include workflow references in agent list

### DIFF
--- a/api/controllers/console/agent/roster.py
+++ b/api/controllers/console/agent/roster.py
@@ -64,10 +64,17 @@ class AgentAppUpdatePayload(UpdateAppPayload):
     role: str | None = Field(default=None, description="Agent role", max_length=255)
 
 
+class AgentAppPublishedReferenceResponse(BaseModel):
+    app_id: str
+    app_name: str
+    app_icon_type: str | None = None
+    app_icon: str | None = None
+    app_icon_background: str | None = None
+
+
 class AgentAppPartial(AppPartial):
     published_reference_count: int = 0
-    published_node_reference_count: int = 0
-    published_references: list[AgentPublishedReferenceResponse] = Field(default_factory=list)
+    published_references: list[AgentAppPublishedReferenceResponse] = Field(default_factory=list)
 
 
 class AgentAppPagination(AppPagination):
@@ -88,6 +95,7 @@ register_response_schema_models(
     console_ns,
     AppDetailWithSite,
     AgentAppPagination,
+    AgentAppPublishedReferenceResponse,
     AgentConfigSnapshotDetailResponse,
     AgentConfigSnapshotListResponse,
     AgentInviteOptionsResponse,
@@ -149,10 +157,16 @@ def _serialize_agent_app_pagination(app_pagination, *, tenant_id: str) -> dict:
             item["active_config_is_published"] = active_config_is_published_by_agent_id.get(agent.id, False)
             published_references = published_references_by_agent_id.get(agent.id, [])
             item["published_reference_count"] = len(published_references)
-            item["published_node_reference_count"] = sum(
-                len(reference["node_ids"]) for reference in published_references
-            )
-            item["published_references"] = published_references
+            item["published_references"] = [
+                {
+                    "app_id": reference["app_id"],
+                    "app_name": reference["app_name"],
+                    "app_icon_type": reference["app_icon_type"],
+                    "app_icon": reference["app_icon"],
+                    "app_icon_background": reference["app_icon_background"],
+                }
+                for reference in published_references
+            ]
     return AgentAppPagination.model_validate(payload).model_dump(
         mode="json",
         exclude={"data": {"__all__": {"bound_agent_id"}}},

--- a/api/controllers/console/agent/roster.py
+++ b/api/controllers/console/agent/roster.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 from flask import request
 from flask_restx import Resource
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field
 
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from controllers.console import console_ns
@@ -10,6 +10,7 @@ from controllers.console.app.app import (
     AppDetailWithSite,
     AppListQuery,
     AppPagination,
+    AppPartial,
     UpdateAppPayload,
     _normalize_app_list_query_args,
 )
@@ -63,6 +64,16 @@ class AgentAppUpdatePayload(UpdateAppPayload):
     role: str | None = Field(default=None, description="Agent role", max_length=255)
 
 
+class AgentAppPartial(AppPartial):
+    published_reference_count: int = 0
+    published_node_reference_count: int = 0
+    published_references: list[AgentPublishedReferenceResponse] = Field(default_factory=list)
+
+
+class AgentAppPagination(AppPagination):
+    data: list[AgentAppPartial] = Field(validation_alias=AliasChoices("items", "data"))
+
+
 register_schema_models(
     console_ns,
     AgentAppCreatePayload,
@@ -76,7 +87,7 @@ register_schema_models(
 register_response_schema_models(
     console_ns,
     AppDetailWithSite,
-    AppPagination,
+    AgentAppPagination,
     AgentConfigSnapshotDetailResponse,
     AgentConfigSnapshotListResponse,
     AgentInviteOptionsResponse,
@@ -122,6 +133,10 @@ def _serialize_agent_app_pagination(app_pagination, *, tenant_id: str) -> dict:
         tenant_id=tenant_id,
         agents=list(agents_by_app_id.values()),
     )
+    published_references_by_agent_id = roster_service.load_published_references_by_agent_id(
+        tenant_id=tenant_id,
+        agent_ids=[agent.id for agent in agents_by_app_id.values()],
+    )
     payload = AppPagination.model_validate(app_pagination, from_attributes=True).model_dump(mode="json")
     for item in payload["data"]:
         app_id = item["id"]
@@ -132,7 +147,16 @@ def _serialize_agent_app_pagination(app_pagination, *, tenant_id: str) -> dict:
             item["id"] = agent.id
             item["role"] = agent.role or ""
             item["active_config_is_published"] = active_config_is_published_by_agent_id.get(agent.id, False)
-    return payload
+            published_references = published_references_by_agent_id.get(agent.id, [])
+            item["published_reference_count"] = len(published_references)
+            item["published_node_reference_count"] = sum(
+                len(reference["node_ids"]) for reference in published_references
+            )
+            item["published_references"] = published_references
+    return AgentAppPagination.model_validate(payload).model_dump(
+        mode="json",
+        exclude={"data": {"__all__": {"bound_agent_id"}}},
+    )
 
 
 def _resolve_agent_app_model(*, tenant_id: str, agent_id: UUID):
@@ -142,7 +166,7 @@ def _resolve_agent_app_model(*, tenant_id: str, agent_id: UUID):
 @console_ns.route("/agent")
 class AgentAppListApi(Resource):
     @console_ns.doc(params=query_params_from_model(AppListQuery))
-    @console_ns.response(200, "Agent app list", console_ns.models[AppPagination.__name__])
+    @console_ns.response(200, "Agent app list", console_ns.models[AgentAppPagination.__name__])
     @setup_required
     @login_required
     @account_initialization_required
@@ -163,7 +187,7 @@ class AgentAppListApi(Resource):
 
         app_pagination = AppService().get_paginate_apps(current_user.id, current_tenant_id, params)
         if app_pagination is None:
-            empty = AppPagination(page=args.page, limit=args.limit, total=0, has_more=False, data=[])
+            empty = AgentAppPagination(page=args.page, limit=args.limit, total=0, has_more=False, data=[])
             return empty.model_dump(mode="json")
 
         return _serialize_agent_app_pagination(app_pagination, tenant_id=current_tenant_id)

--- a/api/controllers/console/agent/roster.py
+++ b/api/controllers/console/agent/roster.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 from flask import request
 from flask_restx import Resource
-from pydantic import AliasChoices, BaseModel, Field
+from pydantic import BaseModel, Field
 
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from controllers.console import console_ns
@@ -77,8 +77,12 @@ class AgentAppPartial(AppPartial):
     published_references: list[AgentAppPublishedReferenceResponse] = Field(default_factory=list)
 
 
-class AgentAppPagination(AppPagination):
-    data: list[AgentAppPartial] = Field(validation_alias=AliasChoices("items", "data"))
+class AgentAppPagination(BaseModel):
+    page: int
+    limit: int
+    total: int
+    has_more: bool
+    data: list[AgentAppPartial]
 
 
 register_schema_models(

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -311,7 +311,7 @@ Check if activation token is valid
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Agent app list | **application/json**: [AppPagination](#apppagination)<br> |
+| 200 | Agent app list | **application/json**: [AgentAppPagination](#agentapppagination)<br> |
 
 ### [POST] /agent
 #### Request Body
@@ -11305,6 +11305,50 @@ default (the config form sends the full desired feature state on save).
 | suggested_questions_after_answer | [AgentSuggestedQuestionsAfterAnswerFeatureConfig](#agentsuggestedquestionsafteranswerfeatureconfig) | Follow-up suggestions config, e.g. {'enabled': true} | No |
 | text_to_speech | [AgentTextToSpeechFeatureConfig](#agenttexttospeechfeatureconfig) | Text-to-speech config | No |
 
+#### AgentAppPagination
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| data | [ [AgentAppPartial](#agentapppartial) ] |  | Yes |
+| has_more | boolean |  | Yes |
+| limit | integer |  | Yes |
+| page | integer |  | Yes |
+| total | integer |  | Yes |
+
+#### AgentAppPartial
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| access_mode | string |  | No |
+| active_config_is_published | boolean |  | No |
+| app_id | string |  | No |
+| author_name | string |  | No |
+| bound_agent_id | string |  | No |
+| create_user_name | string |  | No |
+| created_at | integer |  | No |
+| created_by | string |  | No |
+| description | string |  | No |
+| has_draft_trigger | boolean |  | No |
+| icon | string |  | No |
+| icon_background | string |  | No |
+| icon_type | string |  | No |
+| icon_url | string |  | Yes |
+| id | string |  | Yes |
+| is_starred | boolean |  | No |
+| max_active_requests | integer |  | No |
+| mode | string |  | Yes |
+| model_config | [ModelConfigPartial](#modelconfigpartial) |  | No |
+| name | string |  | Yes |
+| published_node_reference_count | integer |  | No |
+| published_reference_count | integer |  | No |
+| published_references | [ [AgentPublishedReferenceResponse](#agentpublishedreferenceresponse) ] |  | No |
+| role | string |  | No |
+| tags | [ [Tag](#tag) ] |  | No |
+| updated_at | integer |  | No |
+| updated_by | string |  | No |
+| use_icon_as_answer_icon | boolean |  | No |
+| workflow | [WorkflowPartial](#workflowpartial) |  | No |
+
 #### AgentAppUpdatePayload
 
 | Name | Type | Description | Required |
@@ -12631,10 +12675,10 @@ AppMCPServer Status Enum
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| data | [ [AppPartial](#apppartial) ] |  | Yes |
-| has_more | boolean |  | Yes |
-| limit | integer |  | Yes |
+| has_next | boolean |  | Yes |
+| items | [ [AppPartial](#apppartial) ] |  | Yes |
 | page | integer |  | Yes |
+| per_page | integer |  | Yes |
 | total | integer |  | Yes |
 
 #### AppPartial
@@ -12644,22 +12688,21 @@ AppMCPServer Status Enum
 | access_mode | string |  | No |
 | active_config_is_published | boolean |  | No |
 | app_id | string |  | No |
+| app_model_config | [ModelConfigPartial](#modelconfigpartial) |  | No |
 | author_name | string |  | No |
 | bound_agent_id | string |  | No |
 | create_user_name | string |  | No |
 | created_at | integer |  | No |
 | created_by | string |  | No |
-| description | string |  | No |
+| desc_or_prompt | string |  | No |
 | has_draft_trigger | boolean |  | No |
 | icon | string |  | No |
 | icon_background | string |  | No |
 | icon_type | string |  | No |
-| icon_url | string |  | Yes |
 | id | string |  | Yes |
 | is_starred | boolean |  | No |
 | max_active_requests | integer |  | No |
-| mode | string |  | Yes |
-| model_config | [ModelConfigPartial](#modelconfigpartial) |  | No |
+| mode_compatible_with_agent | string |  | Yes |
 | name | string |  | Yes |
 | role | string |  | No |
 | tags | [ [Tag](#tag) ] |  | No |

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -11339,15 +11339,24 @@ default (the config form sends the full desired feature state on save).
 | mode | string |  | Yes |
 | model_config | [ModelConfigPartial](#modelconfigpartial) |  | No |
 | name | string |  | Yes |
-| published_node_reference_count | integer |  | No |
 | published_reference_count | integer |  | No |
-| published_references | [ [AgentPublishedReferenceResponse](#agentpublishedreferenceresponse) ] |  | No |
+| published_references | [ [AgentAppPublishedReferenceResponse](#agentapppublishedreferenceresponse) ] |  | No |
 | role | string |  | No |
 | tags | [ [Tag](#tag) ] |  | No |
 | updated_at | integer |  | No |
 | updated_by | string |  | No |
 | use_icon_as_answer_icon | boolean |  | No |
 | workflow | [WorkflowPartial](#workflowpartial) |  | No |
+
+#### AgentAppPublishedReferenceResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| app_icon | string |  | No |
+| app_icon_background | string |  | No |
+| app_icon_type | string |  | No |
+| app_id | string |  | Yes |
+| app_name | string |  | Yes |
 
 #### AgentAppUpdatePayload
 

--- a/api/services/agent/roster_service.py
+++ b/api/services/agent/roster_service.py
@@ -432,6 +432,12 @@ class AgentRosterService:
 
         return self._load_published_references_by_agent_id(tenant_id=tenant_id, agent_ids=[agent.id]).get(agent.id, [])
 
+    def load_published_references_by_agent_id(
+        self, *, tenant_id: str, agent_ids: list[str]
+    ) -> dict[str, list[AgentReferencingWorkflow]]:
+        """Return published workflow references grouped by roster Agent id."""
+        return self._load_published_references_by_agent_id(tenant_id=tenant_id, agent_ids=agent_ids)
+
     def get_roster_agent_detail(self, *, tenant_id: str, agent_id: str) -> dict[str, Any]:
         agent = self._get_agent(tenant_id=tenant_id, agent_id=agent_id, roster_only=True)
         active_version = self._get_version(

--- a/api/tests/test_containers_integration_tests/repositories/test_sqlalchemy_workflow_run_cleanup_repository.py
+++ b/api/tests/test_containers_integration_tests/repositories/test_sqlalchemy_workflow_run_cleanup_repository.py
@@ -87,7 +87,7 @@ def _add_app_log(session: Session, scope: _TestScope, workflow_run: WorkflowRun)
     session.commit()
 
 
-def _add_pause_with_reason(session: Session, scope: _TestScope, workflow_run: WorkflowRun) -> WorkflowPause:
+def _add_pause_with_reason(session: Session, workflow_run: WorkflowRun) -> WorkflowPause:
     pause = WorkflowPause(
         workflow_id=workflow_run.workflow_id,
         workflow_run_id=workflow_run.id,
@@ -185,7 +185,7 @@ class TestCountRunsWithRelatedByIds:
         )
         missing_run_id = str(uuid4())
         _add_app_log(db_session_with_containers, scope, workflow_run)
-        _add_pause_with_reason(db_session_with_containers, scope, workflow_run)
+        _add_pause_with_reason(db_session_with_containers, workflow_run)
         counted_node_run_ids: list[str] = []
         counted_trigger_run_ids: list[str] = []
 
@@ -239,7 +239,7 @@ class TestDeleteRunsWithRelatedByIds:
             created_at=datetime(2024, 1, 1, 12, 0, 0),
         )
         _add_app_log(db_session_with_containers, scope, workflow_run)
-        pause = _add_pause_with_reason(db_session_with_containers, scope, workflow_run)
+        pause = _add_pause_with_reason(db_session_with_containers, workflow_run)
         pause_id = pause.id
         deleted_node_run_ids: list[str] = []
         deleted_trigger_run_ids: list[str] = []

--- a/api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
+++ b/api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
@@ -211,6 +211,26 @@ def test_agent_app_list_and_create_use_agent_route(
         ),
     )
     monkeypatch.setattr(
+        roster_controller.AgentRosterService,
+        "load_published_references_by_agent_id",
+        lambda _self, **kwargs: {
+            "agent-list": [
+                {
+                    "app_id": "workflow-app-id",
+                    "app_name": "RFP Review Flow",
+                    "app_icon_type": "emoji",
+                    "app_icon": "A",
+                    "app_icon_background": "#fff",
+                    "app_mode": "workflow",
+                    "app_updated_at": 1781660000,
+                    "workflow_id": "workflow-1",
+                    "workflow_version": "v1",
+                    "node_ids": ["node-1", "node-2"],
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
         roster_controller.FeatureService,
         "get_system_features",
         lambda: SimpleNamespace(webapp_auth=SimpleNamespace(enabled=False)),
@@ -226,6 +246,10 @@ def test_agent_app_list_and_create_use_agent_route(
     assert listed["data"][0]["app_id"] == "app-list"
     assert listed["data"][0]["role"] == "List role"
     assert listed["data"][0]["active_config_is_published"] is False
+    assert listed["data"][0]["published_reference_count"] == 1
+    assert listed["data"][0]["published_node_reference_count"] == 2
+    assert listed["data"][0]["published_references"][0]["app_id"] == "workflow-app-id"
+    assert listed["data"][0]["published_references"][0]["node_ids"] == ["node-1", "node-2"]
     assert "bound_agent_id" not in listed["data"][0]
     list_call = cast(dict[str, object], captured["list"])
     list_params = cast(Any, list_call["params"])

--- a/api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
+++ b/api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
@@ -247,9 +247,15 @@ def test_agent_app_list_and_create_use_agent_route(
     assert listed["data"][0]["role"] == "List role"
     assert listed["data"][0]["active_config_is_published"] is False
     assert listed["data"][0]["published_reference_count"] == 1
-    assert listed["data"][0]["published_node_reference_count"] == 2
-    assert listed["data"][0]["published_references"][0]["app_id"] == "workflow-app-id"
-    assert listed["data"][0]["published_references"][0]["node_ids"] == ["node-1", "node-2"]
+    assert listed["data"][0]["published_references"] == [
+        {
+            "app_id": "workflow-app-id",
+            "app_name": "RFP Review Flow",
+            "app_icon_type": "emoji",
+            "app_icon": "A",
+            "app_icon_background": "#fff",
+        }
+    ]
     assert "bound_agent_id" not in listed["data"][0]
     list_call = cast(dict[str, object], captured["list"])
     list_params = cast(Any, list_call["params"])

--- a/packages/contracts/generated/api/console/agent/types.gen.ts
+++ b/packages/contracts/generated/api/console/agent/types.gen.ts
@@ -279,9 +279,8 @@ export type AgentAppPartial = {
   mode: string
   model_config?: ModelConfigPartial | null
   name: string
-  published_node_reference_count?: number
   published_reference_count?: number
-  published_references?: Array<AgentPublishedReferenceResponse>
+  published_references?: Array<AgentAppPublishedReferenceResponse>
   role?: string | null
   tags?: Array<Tag>
   updated_at?: number | null
@@ -668,6 +667,20 @@ export type ModelConfigPartial = {
   updated_by?: string | null
 }
 
+export type AgentAppPublishedReferenceResponse = {
+  app_icon?: string | null
+  app_icon_background?: string | null
+  app_icon_type?: string | null
+  app_id: string
+  app_name: string
+}
+
+export type LlmMode = 'chat' | 'completion'
+
+export type AgentKind = 'dify_agent'
+
+export type AgentIconType = 'emoji' | 'image' | 'link'
+
 export type AgentPublishedReferenceResponse = {
   app_icon?: string | null
   app_icon_background?: string | null
@@ -680,12 +693,6 @@ export type AgentPublishedReferenceResponse = {
   workflow_id: string
   workflow_version: string
 }
-
-export type LlmMode = 'chat' | 'completion'
-
-export type AgentKind = 'dify_agent'
-
-export type AgentIconType = 'emoji' | 'image' | 'link'
 
 export type AgentScope = 'roster' | 'workflow_only'
 
@@ -1319,9 +1326,8 @@ export type AgentAppPartialWritable = {
   mode: string
   model_config?: ModelConfigPartial | null
   name: string
-  published_node_reference_count?: number
   published_reference_count?: number
-  published_references?: Array<AgentPublishedReferenceResponse>
+  published_references?: Array<AgentAppPublishedReferenceResponse>
   role?: string | null
   tags?: Array<Tag>
   updated_at?: number | null

--- a/packages/contracts/generated/api/console/agent/types.gen.ts
+++ b/packages/contracts/generated/api/console/agent/types.gen.ts
@@ -4,8 +4,8 @@ export type ClientOptions = {
   baseUrl: `${string}://${string}/console/api` | (string & {})
 }
 
-export type AppPagination = {
-  data: Array<AppPartial>
+export type AgentAppPagination = {
+  data: Array<AgentAppPartial>
   has_more: boolean
   limit: number
   page: number
@@ -258,7 +258,7 @@ export type AgentConfigSnapshotDetailResponse = {
   version_note?: string | null
 }
 
-export type AppPartial = {
+export type AgentAppPartial = {
   access_mode?: string | null
   active_config_is_published?: boolean
   app_id?: string | null
@@ -279,6 +279,9 @@ export type AppPartial = {
   mode: string
   model_config?: ModelConfigPartial | null
   name: string
+  published_node_reference_count?: number
+  published_reference_count?: number
+  published_references?: Array<AgentPublishedReferenceResponse>
   role?: string | null
   tags?: Array<Tag>
   updated_at?: number | null
@@ -665,12 +668,6 @@ export type ModelConfigPartial = {
   updated_by?: string | null
 }
 
-export type LlmMode = 'chat' | 'completion'
-
-export type AgentKind = 'dify_agent'
-
-export type AgentIconType = 'emoji' | 'image' | 'link'
-
 export type AgentPublishedReferenceResponse = {
   app_icon?: string | null
   app_icon_background?: string | null
@@ -683,6 +680,12 @@ export type AgentPublishedReferenceResponse = {
   workflow_id: string
   workflow_version: string
 }
+
+export type LlmMode = 'chat' | 'completion'
+
+export type AgentKind = 'dify_agent'
+
+export type AgentIconType = 'emoji' | 'image' | 'link'
 
 export type AgentScope = 'roster' | 'workflow_only'
 
@@ -1258,8 +1261,8 @@ export type FileTransferMethod = 'datasource_file' | 'local_file' | 'remote_url'
 
 export type ValueSourceType = 'constant' | 'variable'
 
-export type AppPaginationWritable = {
-  data: Array<AppPartialWritable>
+export type AgentAppPaginationWritable = {
+  data: Array<AgentAppPartialWritable>
   has_more: boolean
   limit: number
   page: number
@@ -1296,7 +1299,7 @@ export type AppDetailWithSiteWritable = {
   workflow?: WorkflowPartial | null
 }
 
-export type AppPartialWritable = {
+export type AgentAppPartialWritable = {
   access_mode?: string | null
   active_config_is_published?: boolean
   app_id?: string | null
@@ -1316,6 +1319,9 @@ export type AppPartialWritable = {
   mode: string
   model_config?: ModelConfigPartial | null
   name: string
+  published_node_reference_count?: number
+  published_reference_count?: number
+  published_references?: Array<AgentPublishedReferenceResponse>
   role?: string | null
   tags?: Array<Tag>
   updated_at?: number | null
@@ -1365,7 +1371,7 @@ export type GetAgentData = {
 }
 
 export type GetAgentResponses = {
-  200: AppPagination
+  200: AgentAppPagination
 }
 
 export type GetAgentResponse = GetAgentResponses[keyof GetAgentResponses]

--- a/packages/contracts/generated/api/console/agent/zod.gen.ts
+++ b/packages/contracts/generated/api/console/agent/zod.gen.ts
@@ -471,9 +471,25 @@ export const zModelConfigPartial = z.object({
 })
 
 /**
- * AppPartial
+ * AgentPublishedReferenceResponse
  */
-export const zAppPartial = z.object({
+export const zAgentPublishedReferenceResponse = z.object({
+  app_icon: z.string().nullish(),
+  app_icon_background: z.string().nullish(),
+  app_icon_type: z.string().nullish(),
+  app_id: z.string(),
+  app_mode: z.string(),
+  app_name: z.string(),
+  app_updated_at: z.int().nullish(),
+  node_ids: z.array(z.string()).optional(),
+  workflow_id: z.string(),
+  workflow_version: z.string(),
+})
+
+/**
+ * AgentAppPartial
+ */
+export const zAgentAppPartial = z.object({
   access_mode: z.string().nullish(),
   active_config_is_published: z.boolean().optional().default(false),
   app_id: z.string().nullish(),
@@ -494,6 +510,9 @@ export const zAppPartial = z.object({
   mode: z.string(),
   model_config: zModelConfigPartial.nullish(),
   name: z.string(),
+  published_node_reference_count: z.int().optional().default(0),
+  published_reference_count: z.int().optional().default(0),
+  published_references: z.array(zAgentPublishedReferenceResponse).optional(),
   role: z.string().nullish(),
   tags: z.array(zTag).optional(),
   updated_at: z.int().nullish(),
@@ -503,10 +522,10 @@ export const zAppPartial = z.object({
 })
 
 /**
- * AppPagination
+ * AgentAppPagination
  */
-export const zAppPagination = z.object({
-  data: z.array(zAppPartial),
+export const zAgentAppPagination = z.object({
+  data: z.array(zAgentAppPartial),
   has_more: z.boolean(),
   limit: z.int(),
   page: z.int(),
@@ -580,22 +599,6 @@ export const zAgentKind = z.enum(['dify_agent'])
  * Supported icon storage formats for Agent roster entries.
  */
 export const zAgentIconType = z.enum(['emoji', 'image', 'link'])
-
-/**
- * AgentPublishedReferenceResponse
- */
-export const zAgentPublishedReferenceResponse = z.object({
-  app_icon: z.string().nullish(),
-  app_icon_background: z.string().nullish(),
-  app_icon_type: z.string().nullish(),
-  app_id: z.string(),
-  app_mode: z.string(),
-  app_name: z.string(),
-  app_updated_at: z.int().nullish(),
-  node_ids: z.array(z.string()).optional(),
-  workflow_id: z.string(),
-  workflow_version: z.string(),
-})
 
 /**
  * AgentScope
@@ -1773,9 +1776,9 @@ export const zMessageInfiniteScrollPaginationResponse = z.object({
 })
 
 /**
- * AppPartial
+ * AgentAppPartial
  */
-export const zAppPartialWritable = z.object({
+export const zAgentAppPartialWritable = z.object({
   access_mode: z.string().nullish(),
   active_config_is_published: z.boolean().optional().default(false),
   app_id: z.string().nullish(),
@@ -1795,6 +1798,9 @@ export const zAppPartialWritable = z.object({
   mode: z.string(),
   model_config: zModelConfigPartial.nullish(),
   name: z.string(),
+  published_node_reference_count: z.int().optional().default(0),
+  published_reference_count: z.int().optional().default(0),
+  published_references: z.array(zAgentPublishedReferenceResponse).optional(),
   role: z.string().nullish(),
   tags: z.array(zTag).optional(),
   updated_at: z.int().nullish(),
@@ -1804,10 +1810,10 @@ export const zAppPartialWritable = z.object({
 })
 
 /**
- * AppPagination
+ * AgentAppPagination
  */
-export const zAppPaginationWritable = z.object({
-  data: z.array(zAppPartialWritable),
+export const zAgentAppPaginationWritable = z.object({
+  data: z.array(zAgentAppPartialWritable),
   has_more: z.boolean(),
   limit: z.int(),
   page: z.int(),
@@ -1895,7 +1901,7 @@ export const zGetAgentQuery = z.object({
 /**
  * Agent app list
  */
-export const zGetAgentResponse = zAppPagination
+export const zGetAgentResponse = zAgentAppPagination
 
 export const zPostAgentBody = zAgentAppCreatePayload
 

--- a/packages/contracts/generated/api/console/agent/zod.gen.ts
+++ b/packages/contracts/generated/api/console/agent/zod.gen.ts
@@ -471,19 +471,14 @@ export const zModelConfigPartial = z.object({
 })
 
 /**
- * AgentPublishedReferenceResponse
+ * AgentAppPublishedReferenceResponse
  */
-export const zAgentPublishedReferenceResponse = z.object({
+export const zAgentAppPublishedReferenceResponse = z.object({
   app_icon: z.string().nullish(),
   app_icon_background: z.string().nullish(),
   app_icon_type: z.string().nullish(),
   app_id: z.string(),
-  app_mode: z.string(),
   app_name: z.string(),
-  app_updated_at: z.int().nullish(),
-  node_ids: z.array(z.string()).optional(),
-  workflow_id: z.string(),
-  workflow_version: z.string(),
 })
 
 /**
@@ -510,9 +505,8 @@ export const zAgentAppPartial = z.object({
   mode: z.string(),
   model_config: zModelConfigPartial.nullish(),
   name: z.string(),
-  published_node_reference_count: z.int().optional().default(0),
   published_reference_count: z.int().optional().default(0),
-  published_references: z.array(zAgentPublishedReferenceResponse).optional(),
+  published_references: z.array(zAgentAppPublishedReferenceResponse).optional(),
   role: z.string().nullish(),
   tags: z.array(zTag).optional(),
   updated_at: z.int().nullish(),
@@ -599,6 +593,22 @@ export const zAgentKind = z.enum(['dify_agent'])
  * Supported icon storage formats for Agent roster entries.
  */
 export const zAgentIconType = z.enum(['emoji', 'image', 'link'])
+
+/**
+ * AgentPublishedReferenceResponse
+ */
+export const zAgentPublishedReferenceResponse = z.object({
+  app_icon: z.string().nullish(),
+  app_icon_background: z.string().nullish(),
+  app_icon_type: z.string().nullish(),
+  app_id: z.string(),
+  app_mode: z.string(),
+  app_name: z.string(),
+  app_updated_at: z.int().nullish(),
+  node_ids: z.array(z.string()).optional(),
+  workflow_id: z.string(),
+  workflow_version: z.string(),
+})
 
 /**
  * AgentScope
@@ -1798,9 +1808,8 @@ export const zAgentAppPartialWritable = z.object({
   mode: z.string(),
   model_config: zModelConfigPartial.nullish(),
   name: z.string(),
-  published_node_reference_count: z.int().optional().default(0),
   published_reference_count: z.int().optional().default(0),
-  published_references: z.array(zAgentPublishedReferenceResponse).optional(),
+  published_references: z.array(zAgentAppPublishedReferenceResponse).optional(),
   role: z.string().nullish(),
   tags: z.array(zTag).optional(),
   updated_at: z.int().nullish(),

--- a/packages/contracts/generated/api/console/apps/types.gen.ts
+++ b/packages/contracts/generated/api/console/apps/types.gen.ts
@@ -5,10 +5,10 @@ export type ClientOptions = {
 }
 
 export type AppPagination = {
-  data: Array<AppPartial>
-  has_more: boolean
-  limit: number
+  has_next: boolean
+  items: Array<AppPartial>
   page: number
+  per_page: number
   total: number
 }
 
@@ -1158,22 +1158,21 @@ export type AppPartial = {
   access_mode?: string | null
   active_config_is_published?: boolean
   app_id?: string | null
+  app_model_config?: ModelConfigPartial | null
   author_name?: string | null
   bound_agent_id?: string | null
   create_user_name?: string | null
   created_at?: number | null
   created_by?: string | null
-  description?: string | null
+  desc_or_prompt?: string | null
   has_draft_trigger?: boolean | null
   icon?: string | null
   icon_background?: string | null
   icon_type?: string | null
-  readonly icon_url: string | null
   id: string
   is_starred?: boolean
   max_active_requests?: number | null
-  mode: string
-  model_config?: ModelConfigPartial | null
+  mode_compatible_with_agent: string
   name: string
   role?: string | null
   tags?: Array<Tag>
@@ -2576,14 +2575,6 @@ export type AgentModerationIoConfig = {
 
 export type ValueSourceType = 'constant' | 'variable'
 
-export type AppPaginationWritable = {
-  data: Array<AppPartialWritable>
-  has_more: boolean
-  limit: number
-  page: number
-  total: number
-}
-
 export type AppDetailWithSiteWritable = {
   access_mode?: string | null
   active_config_is_published?: boolean
@@ -2635,34 +2626,6 @@ export type WorkflowCommentDetailWritable = {
   resolved_by?: string | null
   resolved_by_account?: WorkflowCommentAccountWritable | null
   updated_at?: number | null
-}
-
-export type AppPartialWritable = {
-  access_mode?: string | null
-  active_config_is_published?: boolean
-  app_id?: string | null
-  author_name?: string | null
-  bound_agent_id?: string | null
-  create_user_name?: string | null
-  created_at?: number | null
-  created_by?: string | null
-  description?: string | null
-  has_draft_trigger?: boolean | null
-  icon?: string | null
-  icon_background?: string | null
-  icon_type?: string | null
-  id: string
-  is_starred?: boolean
-  max_active_requests?: number | null
-  mode: string
-  model_config?: ModelConfigPartial | null
-  name: string
-  role?: string | null
-  tags?: Array<Tag>
-  updated_at?: number | null
-  updated_by?: string | null
-  use_icon_as_answer_icon?: boolean | null
-  workflow?: WorkflowPartial | null
 }
 
 export type SiteWritable = {

--- a/packages/contracts/generated/api/console/apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/apps/zod.gen.ts
@@ -1948,22 +1948,21 @@ export const zAppPartial = z.object({
   access_mode: z.string().nullish(),
   active_config_is_published: z.boolean().optional().default(false),
   app_id: z.string().nullish(),
+  app_model_config: zModelConfigPartial.nullish(),
   author_name: z.string().nullish(),
   bound_agent_id: z.string().nullish(),
   create_user_name: z.string().nullish(),
   created_at: z.int().nullish(),
   created_by: z.string().nullish(),
-  description: z.string().nullish(),
+  desc_or_prompt: z.string().nullish(),
   has_draft_trigger: z.boolean().nullish(),
   icon: z.string().nullish(),
   icon_background: z.string().nullish(),
   icon_type: z.string().nullish(),
-  icon_url: z.string().nullable(),
   id: z.string(),
   is_starred: z.boolean().optional().default(false),
   max_active_requests: z.int().nullish(),
-  mode: z.string(),
-  model_config: zModelConfigPartial.nullish(),
+  mode_compatible_with_agent: z.string(),
   name: z.string(),
   role: z.string().nullish(),
   tags: z.array(zTag).optional(),
@@ -1977,10 +1976,10 @@ export const zAppPartial = z.object({
  * AppPagination
  */
 export const zAppPagination = z.object({
-  data: z.array(zAppPartial),
-  has_more: z.boolean(),
-  limit: z.int(),
+  has_next: z.boolean(),
+  items: z.array(zAppPartial),
   page: z.int(),
+  per_page: z.int(),
   total: z.int(),
 })
 
@@ -3472,48 +3471,6 @@ export const zMessageInfiniteScrollPaginationResponse = z.object({
  * GeneratedAppResponse
  */
 export const zGeneratedAppResponseWritable = zJsonValue
-
-/**
- * AppPartial
- */
-export const zAppPartialWritable = z.object({
-  access_mode: z.string().nullish(),
-  active_config_is_published: z.boolean().optional().default(false),
-  app_id: z.string().nullish(),
-  author_name: z.string().nullish(),
-  bound_agent_id: z.string().nullish(),
-  create_user_name: z.string().nullish(),
-  created_at: z.int().nullish(),
-  created_by: z.string().nullish(),
-  description: z.string().nullish(),
-  has_draft_trigger: z.boolean().nullish(),
-  icon: z.string().nullish(),
-  icon_background: z.string().nullish(),
-  icon_type: z.string().nullish(),
-  id: z.string(),
-  is_starred: z.boolean().optional().default(false),
-  max_active_requests: z.int().nullish(),
-  mode: z.string(),
-  model_config: zModelConfigPartial.nullish(),
-  name: z.string(),
-  role: z.string().nullish(),
-  tags: z.array(zTag).optional(),
-  updated_at: z.int().nullish(),
-  updated_by: z.string().nullish(),
-  use_icon_as_answer_icon: z.boolean().nullish(),
-  workflow: zWorkflowPartial.nullish(),
-})
-
-/**
- * AppPagination
- */
-export const zAppPaginationWritable = z.object({
-  data: z.array(zAppPartialWritable),
-  has_more: z.boolean(),
-  limit: z.int(),
-  page: z.int(),
-  total: z.int(),
-})
 
 /**
  * Site


### PR DESCRIPTION
## Summary
- add Agent App list response fields for published workflow reference count and references
- reuse AgentRosterService published-reference loading so the roster list and Access reference data share the same source
- regenerate the console agent contract for the updated /agent response

## Why
The Agent V2 roster card needs to show whether an agent is used by published workflows. The existing /agent list response only returned app-backed agent metadata, so the frontend would fall back to 0 even when /agent/{agent_id}/referencing-workflows had data.

## Validation
- uv run --project api pytest api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py -q
- uv run --project api ruff check api/controllers/console/agent/roster.py api/services/agent/roster_service.py api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
- pnpm -C packages/contracts type-check