### PR TITLE
fix(api): hide agent apps from installed apps

### DIFF
--- a/api/controllers/console/explore/installed_app.py
+++ b/api/controllers/console/explore/installed_app.py
@@ -73,9 +73,12 @@ def _published_app_filter():
     has_published_workflow = exists(select(Workflow.id).where(Workflow.id == App.workflow_id))
     has_published_model_config = exists(select(AppModelConfig.id).where(AppModelConfig.id == App.app_model_config_id))
 
-    return or_(
-        and_(App.mode.in_(workflow_app_modes), App.workflow_id.isnot(None), has_published_workflow),
-        and_(~App.mode.in_(workflow_app_modes), App.app_model_config_id.isnot(None), has_published_model_config),
+    return and_(
+        App.mode != AppMode.AGENT,
+        or_(
+            and_(App.mode.in_(workflow_app_modes), App.workflow_id.isnot(None), has_published_workflow),
+            and_(~App.mode.in_(workflow_app_modes), App.app_model_config_id.isnot(None), has_published_model_config),
+        ),
     )
 
 

--- a/api/tests/unit_tests/controllers/console/explore/test_installed_app.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_installed_app.py
@@ -64,6 +64,7 @@ class TestInstalledAppsListApi:
         assert "app_model_configs" in compiled_filter
         assert "workflow_id" in compiled_filter
         assert "app_model_config_id" in compiled_filter
+        assert "apps.mode != 'agent'" in compiled_filter
 
     def test_get_installed_apps(
         self, app: Flask, current_user: MagicMock, tenant_id: str, installed_app: MagicMock


### PR DESCRIPTION
## Summary
- Exclude Agent v2 app rows from /console/api/installed-apps published-app filtering
- Keep workflow/chat/agent-chat installed app behavior unchanged
- Add unit coverage for the agent-mode exclusion in the installed apps filter

## Validation
- uv run --project api --dev pytest api/tests/unit_tests/controllers/console/explore/test_installed_app.py -q
- uv run --project api --dev ruff check api/controllers/console/explore/installed_app.py api/tests/unit_tests/controllers/console/explore/test_installed_app.py
- uv run --project api --dev ruff format --check api/controllers/console/explore/installed_app.py api/tests/unit_tests/controllers/console/explore/test_installed_app.py
- Deployed the same fix to deploy/agent and verified on agent.dify.dev: a real installed agent app returns 0 items from /console/api/installed-apps?app_id=<agent_app_id>

Linear: DIFY-2503