### PR TITLE
fix(web): prevent workspace trigger focus ring clipping

### DIFF
--- a/web/app/components/main-nav/components/workspace-card.tsx
+++ b/web/app/components/main-nav/components/workspace-card.tsx
@@ -118,6 +118,7 @@ function WorkspaceCardTrigger({
         title={name}
         className={cn(
           'flex w-full items-center gap-1.5 py-1.5 pr-3 pl-1.5 text-left transition-colors focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden focus-visible:ring-inset',
+          showCloudBilling ? 'rounded-t-xl' : 'rounded-xl',
           open && 'bg-linear-to-b from-background-section-burn to-background-section',
         )}
       >


### PR DESCRIPTION
## Summary
- Add matching border radius to the workspace card popover trigger so its inset focus ring follows the visible card shape.
- Preserve the existing card layout, hover state, and trigger-level focus ownership.

## Why
The workspace switcher trigger already used an inset focus ring, but the parent card clips overflow with `rounded-xl`. Since the focused trigger itself had square corners, the ring could appear clipped at the card corners. Matching the trigger radius to its visible region keeps the focus indicator complete without z-index changes.

## Validation
- `pnpm exec eslint --cache --concurrency=auto web/app/components/main-nav/components/workspace-card.tsx`