### PR TITLE
fix(notion): add bounded timeouts to Notion API requests

### DIFF
--- a/api/core/rag/extractor/notion_extractor.py
+++ b/api/core/rag/extractor/notion_extractor.py
@@ -21,6 +21,10 @@ SEARCH_URL = "https://api.notion.com/v1/search"
 
 RETRIEVE_PAGE_URL_TMPL = "https://api.notion.com/v1/pages/{page_id}"
 RETRIEVE_DATABASE_URL_TMPL = "https://api.notion.com/v1/databases/{database_id}"
+
+# Bound how long Notion API requests wait so a slow or unresponsive Notion
+# endpoint cannot stall document import or sync indefinitely.
+NOTION_REQUEST_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
 # if user want split by headings, use the corresponding splitter
 HEADING_SPLITTER = {
     "heading_1": "# ",
@@ -110,6 +114,7 @@ class NotionExtractor(BaseExtractor):
                     "Notion-Version": "2022-06-28",
                 },
                 json=current_query,
+                timeout=NOTION_REQUEST_TIMEOUT,
             )
 
             response_data = res.json()
@@ -179,6 +184,7 @@ class NotionExtractor(BaseExtractor):
                         "Notion-Version": "2022-06-28",
                     },
                     params=query_dict,
+                    timeout=NOTION_REQUEST_TIMEOUT,
                 )
                 if res.status_code != 200:
                     raise ValueError(f"Error fetching Notion block data: {res.text}")
@@ -241,6 +247,7 @@ class NotionExtractor(BaseExtractor):
                     "Notion-Version": "2022-06-28",
                 },
                 params=query_dict,
+                timeout=NOTION_REQUEST_TIMEOUT,
             )
             data = res.json()
             if "results" not in data or data["results"] is None:
@@ -301,6 +308,7 @@ class NotionExtractor(BaseExtractor):
                     "Notion-Version": "2022-06-28",
                 },
                 params=query_dict,
+                timeout=NOTION_REQUEST_TIMEOUT,
             )
             data = res.json()
             # get table headers text
@@ -375,6 +383,7 @@ class NotionExtractor(BaseExtractor):
                 "Notion-Version": "2022-06-28",
             },
             json=query_dict,
+            timeout=NOTION_REQUEST_TIMEOUT,
         )
 
         data = res.json()

--- a/api/tests/unit_tests/core/rag/extractor/test_notion_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_notion_extractor.py
@@ -522,3 +522,43 @@ class TestNotionMetadataAndCredentialMethods:
         monkeypatch.setattr(notion_extractor, "DatasourceProviderService", FakeProviderServiceFound)
 
         assert notion_extractor.NotionExtractor._get_access_token("tenant", "cred") == "token-from-credential"
+
+
+class TestNotionRequestTimeouts:
+    """Notion API calls must carry a bounded timeout so a slow or unresponsive
+    endpoint cannot hang document import/sync indefinitely."""
+
+    def _extractor(self, page_type: str = "page"):
+        return notion_extractor.NotionExtractor(
+            notion_workspace_id="ws",
+            notion_obj_id="obj",
+            notion_page_type=page_type,
+            tenant_id="tenant",
+            notion_access_token="token",
+        )
+
+    def test_database_query_passes_bounded_timeout(self, mocker: MockerFixture):
+        extractor = self._extractor(page_type="database")
+        mock_post = mocker.patch(
+            "httpx.post",
+            return_value=_mock_response({"results": [], "has_more": False, "next_cursor": None}),
+        )
+
+        extractor._get_notion_database_data("db-1")
+
+        timeout = mock_post.call_args.kwargs["timeout"]
+        assert timeout is notion_extractor.NOTION_REQUEST_TIMEOUT
+        assert isinstance(timeout, httpx.Timeout)
+
+    def test_last_edited_time_passes_bounded_timeout(self, mocker: MockerFixture):
+        extractor = self._extractor(page_type="page")
+        mock_request = mocker.patch(
+            "httpx.request",
+            return_value=_mock_response({"last_edited_time": "2024-01-01T00:00:00.000Z"}),
+        )
+
+        extractor.get_notion_last_edited_time()
+
+        timeout = mock_request.call_args.kwargs["timeout"]
+        assert timeout is notion_extractor.NOTION_REQUEST_TIMEOUT
+        assert isinstance(timeout, httpx.Timeout)


### PR DESCRIPTION
## What

`NotionExtractor` makes five calls to the Notion API — database query, block children, block read, table rows, and last-edited-time — all via `httpx` with no `timeout`. This adds a module-level `NOTION_REQUEST_TIMEOUT` (`httpx.Timeout(30.0, connect=10.0)`) and passes it to each call.

## Why

`httpx` has no default timeout, so a call with no `timeout=` waits forever. If Notion is slow or unresponsive, a document import or sync can hang indefinitely and tie up the worker handling it — there's no upper bound on how long these requests block.

This is the same failure mode the recently merged bounded-timeout fixes addressed for the Nacos remote-settings client (#37444) and the Marketplace client (#37424); the Notion extractor is another data-source path that was still unbounded.

## Test

Added `TestNotionRequestTimeouts` to `test_notion_extractor.py`, covering the `httpx.post` (database query) and `httpx.request` (last-edited-time) paths and asserting each call receives the bounded `NOTION_REQUEST_TIMEOUT`. The tests follow the existing `mocker.patch("httpx.post"/"httpx.request")` + `_mock_response` patterns already used in that file.

Note: I couldn't run the full backend test suite locally (it pulls in the complete workflow stack via `conftest.py`, which needs dependencies I don't have set up here), so I'm relying on CI for the test run. `ruff check`/`ruff format --check` pass on both changed files and the module compiles cleanly.

From Claude Code
