### PR TITLE
fix(api): enforce document creation limits in pipeline generator

### DIFF
--- a/api/core/app/apps/pipeline/pipeline_generator.py
+++ b/api/core/app/apps/pipeline/pipeline_generator.py
@@ -138,6 +138,10 @@ class PipelineGenerator(BaseAppGenerator):
         documents: list[Document] = []
         if invoke_from == InvokeFrom.PUBLISHED_PIPELINE and not is_retry and not args.get("original_document_id"):
             from services.dataset_service import DocumentService
+            from services.feature_service import FeatureService
+
+            features = FeatureService.get_features(pipeline.tenant_id)
+            DocumentService.check_document_creation_limits(len(datasource_info_list), features)
 
             for datasource_info in datasource_info_list:
                 position = DocumentService.get_documents_position(dataset.id)

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -2032,14 +2032,7 @@ class DocumentService:
                         website_info = knowledge_config.data_source.info_list.website_info_list
                         assert website_info
                         count = len(website_info.urls)
-                    batch_upload_limit = int(dify_config.BATCH_UPLOAD_LIMIT)
-
-                    if features.billing.subscription.plan == CloudPlan.SANDBOX and count > 1:
-                        raise ValueError("Your current plan does not support batch upload, please upgrade your plan.")
-                    if count > batch_upload_limit:
-                        raise ValueError(f"You have reached the batch upload limit of {batch_upload_limit}.")
-
-                    DocumentService.check_documents_upload_quota(count, features)
+                    DocumentService.check_document_creation_limits(count, features)
 
         # if dataset is empty, update dataset data_source_type
         if not dataset.data_source_type and knowledge_config.data_source:
@@ -2604,6 +2597,21 @@ class DocumentService:
             )
 
     @staticmethod
+    def check_document_creation_limits(count: int, features: FeatureModel):
+        """Validate billing-backed document creation limits before document rows are created."""
+        if not features.billing.enabled:
+            return
+
+        if features.billing.subscription.plan == CloudPlan.SANDBOX and count > 1:
+            raise ValueError("Your current plan does not support batch upload, please upgrade your plan.")
+
+        batch_upload_limit = int(dify_config.BATCH_UPLOAD_LIMIT)
+        if count > batch_upload_limit:
+            raise ValueError(f"You have reached the batch upload limit of {batch_upload_limit}.")
+
+        DocumentService.check_documents_upload_quota(count, features)
+
+    @staticmethod
     def build_document(
         dataset: Dataset,
         process_rule_id: str | None,
@@ -2824,13 +2832,7 @@ class DocumentService:
                 website_info = knowledge_config.data_source.info_list.website_info_list
                 if website_info:
                     count = len(website_info.urls)
-            if features.billing.subscription.plan == CloudPlan.SANDBOX and count > 1:
-                raise ValueError("Your current plan does not support batch upload, please upgrade your plan.")
-            batch_upload_limit = int(dify_config.BATCH_UPLOAD_LIMIT)
-            if count > batch_upload_limit:
-                raise ValueError(f"You have reached the batch upload limit of {batch_upload_limit}.")
-
-            DocumentService.check_documents_upload_quota(count, features)
+            DocumentService.check_document_creation_limits(count, features)
 
         dataset_collection_binding_id = None
         retrieval_model = None

--- a/api/tests/unit_tests/core/app/apps/pipeline/test_pipeline_generator.py
+++ b/api/tests/unit_tests/core/app/apps/pipeline/test_pipeline_generator.py
@@ -233,9 +233,7 @@ def test_generate_published_pipeline_creates_documents_and_delay(generator, mock
     task_proxy.delay.assert_called_once()
 
 
-def test_generate_published_pipeline_rejects_when_document_creation_limits_exceeded(
-    generator, mocker: MockerFixture
-):
+def test_generate_published_pipeline_rejects_when_document_creation_limits_exceeded(generator, mocker: MockerFixture):
     pipeline = _build_pipeline()
     workflow = _build_workflow()
 

--- a/api/tests/unit_tests/core/app/apps/pipeline/test_pipeline_generator.py
+++ b/api/tests/unit_tests/core/app/apps/pipeline/test_pipeline_generator.py
@@ -173,6 +173,9 @@ def test_generate_published_pipeline_creates_documents_and_delay(generator, mock
     mocker.patch.object(generator, "_prepare_user_inputs", return_value={"k": "v"})
 
     mocker.patch("services.dataset_service.DocumentService.get_documents_position", return_value=1)
+    features = SimpleNamespace()
+    mocker.patch("services.feature_service.FeatureService.get_features", return_value=features)
+    check_limits = mocker.patch("services.dataset_service.DocumentService.check_document_creation_limits")
 
     document1 = SimpleNamespace(
         id="doc1",
@@ -226,7 +229,53 @@ def test_generate_published_pipeline_creates_documents_and_delay(generator, mock
 
     assert result["batch"]
     assert len(result["documents"]) == 2
+    check_limits.assert_called_once_with(len(datasource_info_list), features)
     task_proxy.delay.assert_called_once()
+
+
+def test_generate_published_pipeline_rejects_when_document_creation_limits_exceeded(
+    generator, mocker: MockerFixture
+):
+    pipeline = _build_pipeline()
+    workflow = _build_workflow()
+
+    session = DummySession()
+    _patch_session(mocker, session)
+
+    datasource_info_list = [{"name": "file1"}, {"name": "file2"}]
+    mocker.patch.object(
+        generator,
+        "_format_datasource_info_list",
+        return_value=datasource_info_list,
+    )
+    mocker.patch.object(
+        module.PipelineConfigManager,
+        "get_pipeline_config",
+        return_value=SimpleNamespace(app_id="pipe", rag_pipeline_variables=[]),
+    )
+
+    features = SimpleNamespace()
+    mocker.patch("services.feature_service.FeatureService.get_features", return_value=features)
+    check_limits = mocker.patch(
+        "services.dataset_service.DocumentService.check_document_creation_limits",
+        side_effect=ValueError("document limit exceeded"),
+    )
+
+    db_session = MagicMock()
+    mocker.patch.object(module.db, "session", db_session)
+
+    with pytest.raises(ValueError, match="document limit exceeded"):
+        generator.generate(
+            pipeline=pipeline,
+            workflow=workflow,
+            user=_build_user(),
+            args=_build_args(),
+            invoke_from=InvokeFrom.PUBLISHED_PIPELINE,
+            streaming=False,
+        )
+
+    check_limits.assert_called_once_with(len(datasource_info_list), features)
+    db_session.add.assert_not_called()
 
 
 def test_generate_is_retry_calls_generate(generator, mocker: MockerFixture):


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
