### PR TITLE
fix: improve Service API OpenAPI contracts

### DIFF
--- a/api/controllers/common/controller_schemas.py
+++ b/api/controllers/common/controller_schemas.py
@@ -1,7 +1,8 @@
+from copy import deepcopy
 from typing import Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, GetJsonSchemaHandler, model_validator
 
 from libs.helper import UUIDStrOrEmpty
 
@@ -11,6 +12,44 @@ from libs.helper import UUIDStrOrEmpty
 class ConversationRenamePayload(BaseModel):
     name: str | None = None
     auto_generate: bool = False
+
+    @classmethod
+    def __get_pydantic_json_schema__(cls, core_schema: Any, handler: GetJsonSchemaHandler) -> dict[str, Any]:
+        schema = handler.resolve_ref_schema(handler(core_schema))
+        properties = schema.get("properties")
+        if not isinstance(properties, dict):
+            return schema
+
+        auto_generate_schema = deepcopy(properties.get("auto_generate", {"type": "boolean"}))
+        name_schema = deepcopy(properties.get("name", {"type": "string"}))
+        non_blank_name_schema: dict[str, Any] = {"pattern": r".*\S.*", "type": "string"}
+        if isinstance(name_schema, dict) and isinstance(name_schema.get("title"), str):
+            non_blank_name_schema["title"] = name_schema["title"]
+
+        auto_generate_true_schema = {**auto_generate_schema, "enum": [True]}
+        auto_generate_true_schema.pop("default", None)
+
+        return {
+            **schema,
+            "anyOf": [
+                {
+                    "properties": {
+                        "auto_generate": auto_generate_true_schema,
+                        "name": name_schema,
+                    },
+                    "required": ["auto_generate"],
+                    "type": "object",
+                },
+                {
+                    "properties": {
+                        "auto_generate": {**auto_generate_schema, "enum": [False]},
+                        "name": non_blank_name_schema,
+                    },
+                    "required": ["name"],
+                    "type": "object",
+                },
+            ],
+        }
 
     @model_validator(mode="after")
     def validate_name_requirement(self):

--- a/api/controllers/common/controller_schemas.py
+++ b/api/controllers/common/controller_schemas.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any, Literal
+from typing import Any, Literal, override
 from uuid import UUID
 
 from pydantic import BaseModel, Field, GetJsonSchemaHandler, model_validator
@@ -14,6 +14,7 @@ class ConversationRenamePayload(BaseModel):
     auto_generate: bool = False
 
     @classmethod
+    @override
     def __get_pydantic_json_schema__(cls, core_schema: Any, handler: GetJsonSchemaHandler) -> dict[str, Any]:
         schema = handler.resolve_ref_schema(handler(core_schema))
         properties = schema.get("properties")

--- a/api/controllers/service_api/app/annotation.py
+++ b/api/controllers/service_api/app/annotation.py
@@ -45,6 +45,13 @@ class AnnotationJobStatusResponse(ResponseModel):
     error_msg: str | None = None
 
 
+ANNOTATION_REPLY_ACTION_PARAM = {
+    "description": "Action to perform: 'enable' or 'disable'",
+    "enum": ["enable", "disable"],
+    "type": "string",
+}
+
+
 register_schema_models(
     service_api_ns,
     AnnotationCreatePayload,
@@ -61,7 +68,7 @@ class AnnotationReplyActionApi(Resource):
     @service_api_ns.expect(service_api_ns.models[AnnotationReplyActionPayload.__name__])
     @service_api_ns.doc("annotation_reply_action")
     @service_api_ns.doc(description="Enable or disable annotation reply feature")
-    @service_api_ns.doc(params={"action": "Action to perform: 'enable' or 'disable'"})
+    @service_api_ns.doc(params={"action": ANNOTATION_REPLY_ACTION_PARAM})
     @service_api_ns.doc(
         responses={
             200: "Action completed successfully",

--- a/api/controllers/service_api/app/audio.py
+++ b/api/controllers/service_api/app/audio.py
@@ -20,6 +20,7 @@ from controllers.service_api.app.error import (
     ProviderQuotaExceededError,
     UnsupportedAudioTypeError,
 )
+from controllers.service_api.schema import binary_response, expect_with_user, multipart_file_params
 from controllers.service_api.wraps import FetchUserArg, WhereisUserArg, validate_app_token
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from graphon.model_runtime.errors.invoke import InvokeError
@@ -41,6 +42,7 @@ register_response_schema_models(service_api_ns, AudioBinaryResponse, AudioTransc
 class AudioApi(Resource):
     @service_api_ns.doc("audio_to_text")
     @service_api_ns.doc(description="Convert audio to text using speech-to-text")
+    @service_api_ns.doc(consumes=["multipart/form-data"], params=multipart_file_params(include_user=True))
     @service_api_ns.doc(
         responses={
             200: "Audio successfully transcribed",
@@ -99,7 +101,8 @@ register_schema_model(service_api_ns, TextToAudioPayload)
 
 @service_api_ns.route("/text-to-audio")
 class TextApi(Resource):
-    @service_api_ns.expect(service_api_ns.models[TextToAudioPayload.__name__])
+    @expect_with_user(service_api_ns, TextToAudioPayload)
+    @binary_response(service_api_ns, "audio/mpeg")
     @service_api_ns.doc("text_to_audio")
     @service_api_ns.doc(description="Convert text to audio using text-to-speech")
     @service_api_ns.doc(
@@ -110,11 +113,7 @@ class TextApi(Resource):
             500: "Internal server error",
         }
     )
-    @service_api_ns.response(
-        200,
-        "Text successfully converted to audio",
-        service_api_ns.models[AudioBinaryResponse.__name__],
-    )
+    @service_api_ns.response(200, "Text successfully converted to audio")
     @validate_app_token(fetch_user_arg=FetchUserArg(fetch_from=WhereisUserArg.JSON))
     def post(self, app_model: App, end_user: EndUser):
         """Convert text to audio using text-to-speech.

--- a/api/controllers/service_api/app/completion.py
+++ b/api/controllers/service_api/app/completion.py
@@ -20,6 +20,7 @@ from controllers.service_api.app.error import (
     ProviderNotInitializeError,
     ProviderQuotaExceededError,
 )
+from controllers.service_api.schema import expect_user_json, expect_with_user, json_or_event_stream_response
 from controllers.service_api.wraps import FetchUserArg, WhereisUserArg, validate_app_token
 from controllers.web.error import InvokeRateLimitError as InvokeRateLimitHttpError
 from core.app.entities.app_invoke_entities import InvokeFrom
@@ -92,7 +93,8 @@ register_response_schema_models(service_api_ns, GeneratedAppResponse, SimpleResu
 
 @service_api_ns.route("/completion-messages")
 class CompletionApi(Resource):
-    @service_api_ns.expect(service_api_ns.models[CompletionRequestPayload.__name__])
+    @expect_with_user(service_api_ns, CompletionRequestPayload)
+    @json_or_event_stream_response(service_api_ns)
     @service_api_ns.doc("create_completion")
     @service_api_ns.doc(description="Create a completion for the given prompt")
     @service_api_ns.doc(
@@ -168,6 +170,7 @@ class CompletionApi(Resource):
 
 @service_api_ns.route("/completion-messages/<string:task_id>/stop")
 class CompletionStopApi(Resource):
+    @expect_user_json(service_api_ns)
     @service_api_ns.doc("stop_completion")
     @service_api_ns.doc(description="Stop a running completion task")
     @service_api_ns.doc(params={"task_id": "The ID of the task to stop"})
@@ -197,7 +200,8 @@ class CompletionStopApi(Resource):
 
 @service_api_ns.route("/chat-messages")
 class ChatApi(Resource):
-    @service_api_ns.expect(service_api_ns.models[ChatRequestPayload.__name__])
+    @expect_with_user(service_api_ns, ChatRequestPayload)
+    @json_or_event_stream_response(service_api_ns)
     @service_api_ns.doc("create_chat_message")
     @service_api_ns.doc(description="Send a message in a chat conversation")
     @service_api_ns.doc(
@@ -276,6 +280,7 @@ class ChatApi(Resource):
 
 @service_api_ns.route("/chat-messages/<string:task_id>/stop")
 class ChatStopApi(Resource):
+    @expect_user_json(service_api_ns)
     @service_api_ns.doc("stop_chat_message")
     @service_api_ns.doc(description="Stop a running chat message generation")
     @service_api_ns.doc(params={"task_id": "The ID of the task to stop"})

--- a/api/controllers/service_api/app/conversation.py
+++ b/api/controllers/service_api/app/conversation.py
@@ -13,6 +13,7 @@ from controllers.common.controller_schemas import ConversationRenamePayload
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from controllers.service_api import service_api_ns
 from controllers.service_api.app.error import NotChatAppError
+from controllers.service_api.schema import expect_user_json, expect_with_user
 from controllers.service_api.wraps import FetchUserArg, WhereisUserArg, validate_app_token
 from core.app.entities.app_invoke_entities import InvokeFrom
 from extensions.ext_database import db
@@ -197,6 +198,7 @@ class ConversationApi(Resource):
 
 @service_api_ns.route("/conversations/<uuid:c_id>")
 class ConversationDetailApi(Resource):
+    @expect_user_json(service_api_ns)
     @service_api_ns.doc("delete_conversation")
     @service_api_ns.doc(description="Delete a specific conversation")
     @service_api_ns.doc(params={"c_id": "Conversation ID"})
@@ -225,7 +227,7 @@ class ConversationDetailApi(Resource):
 
 @service_api_ns.route("/conversations/<uuid:c_id>/name")
 class ConversationRenameApi(Resource):
-    @service_api_ns.expect(service_api_ns.models[ConversationRenamePayload.__name__])
+    @expect_with_user(service_api_ns, ConversationRenamePayload)
     @service_api_ns.doc("rename_conversation")
     @service_api_ns.doc(description="Rename a conversation or auto-generate a name")
     @service_api_ns.doc(params={"c_id": "Conversation ID"})
@@ -312,7 +314,7 @@ class ConversationVariablesApi(Resource):
 
 @service_api_ns.route("/conversations/<uuid:c_id>/variables/<uuid:variable_id>")
 class ConversationVariableDetailApi(Resource):
-    @service_api_ns.expect(service_api_ns.models[ConversationVariableUpdatePayload.__name__])
+    @expect_with_user(service_api_ns, ConversationVariableUpdatePayload)
     @service_api_ns.doc("update_conversation_variable")
     @service_api_ns.doc(description="Update a conversation variable's value")
     @service_api_ns.doc(params={"c_id": "Conversation ID", "variable_id": "Variable ID"})

--- a/api/controllers/service_api/app/file.py
+++ b/api/controllers/service_api/app/file.py
@@ -12,6 +12,7 @@ from controllers.common.errors import (
 )
 from controllers.common.schema import register_schema_models
 from controllers.service_api import service_api_ns
+from controllers.service_api.schema import multipart_file_params
 from controllers.service_api.wraps import FetchUserArg, WhereisUserArg, validate_app_token
 from extensions.ext_database import db
 from fields.file_fields import FileResponse
@@ -25,6 +26,7 @@ register_schema_models(service_api_ns, FileResponse)
 class FileApi(Resource):
     @service_api_ns.doc("upload_file")
     @service_api_ns.doc(description="Upload a file for use in conversations")
+    @service_api_ns.doc(consumes=["multipart/form-data"], params=multipart_file_params(include_user=True))
     @service_api_ns.doc(
         responses={
             201: "File uploaded successfully",

--- a/api/controllers/service_api/app/file_preview.py
+++ b/api/controllers/service_api/app/file_preview.py
@@ -15,6 +15,7 @@ from controllers.service_api.app.error import (
     FileAccessDeniedError,
     FileNotFoundError,
 )
+from controllers.service_api.schema import binary_response
 from controllers.service_api.wraps import FetchUserArg, WhereisUserArg, validate_app_token
 from extensions.ext_database import db
 from extensions.ext_storage import storage
@@ -41,6 +42,7 @@ class FilePreviewApi(Resource):
     """
 
     @service_api_ns.doc(params=query_params_from_model(FilePreviewQuery))
+    @binary_response(service_api_ns, "application/octet-stream")
     @service_api_ns.doc("preview_file")
     @service_api_ns.doc(description="Preview or download a file uploaded via Service API")
     @service_api_ns.doc(params={"file_id": "UUID of the file to preview"})
@@ -52,11 +54,7 @@ class FilePreviewApi(Resource):
             404: "File not found",
         }
     )
-    @service_api_ns.response(
-        200,
-        "File retrieved successfully",
-        service_api_ns.models[BinaryFileResponse.__name__],
-    )
+    @service_api_ns.response(200, "File retrieved successfully")
     @validate_app_token(fetch_user_arg=FetchUserArg(fetch_from=WhereisUserArg.QUERY))
     def get(self, app_model: App, end_user: EndUser, file_id: UUID):
         """

--- a/api/controllers/service_api/app/file_preview.py
+++ b/api/controllers/service_api/app/file_preview.py
@@ -31,6 +31,26 @@ class FilePreviewQuery(BaseModel):
 register_schema_model(service_api_ns, FilePreviewQuery)
 register_response_schema_model(service_api_ns, BinaryFileResponse)
 
+FILE_PREVIEW_RESPONSE_MEDIA_TYPES = [
+    "application/octet-stream",
+    "application/pdf",
+    "audio/aac",
+    "audio/flac",
+    "audio/mp4",
+    "audio/mpeg",
+    "audio/ogg",
+    "audio/wav",
+    "audio/x-m4a",
+    "image/gif",
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+    "text/plain",
+    "video/mp4",
+    "video/quicktime",
+    "video/webm",
+]
+
 
 @service_api_ns.route("/files/<uuid:file_id>/preview")
 class FilePreviewApi(Resource):
@@ -42,7 +62,7 @@ class FilePreviewApi(Resource):
     """
 
     @service_api_ns.doc(params=query_params_from_model(FilePreviewQuery))
-    @binary_response(service_api_ns, "application/octet-stream")
+    @binary_response(service_api_ns, FILE_PREVIEW_RESPONSE_MEDIA_TYPES)
     @service_api_ns.doc("preview_file")
     @service_api_ns.doc(description="Preview or download a file uploaded via Service API")
     @service_api_ns.doc(params={"file_id": "UUID of the file to preview"})

--- a/api/controllers/service_api/app/human_input_form.py
+++ b/api/controllers/service_api/app/human_input_form.py
@@ -18,6 +18,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 from controllers.common.human_input import HumanInputFormSubmitPayload, stringify_form_default_values
 from controllers.common.schema import register_response_schema_models, register_schema_models
 from controllers.service_api import service_api_ns
+from controllers.service_api.schema import expect_with_user
 from controllers.service_api.wraps import FetchUserArg, WhereisUserArg, validate_app_token
 from core.workflow.human_input_policy import HumanInputSurface, is_recipient_type_allowed_for_surface
 from extensions.ext_database import db
@@ -101,7 +102,7 @@ class WorkflowHumanInputFormApi(Resource):
         inputs = service.resolve_form_inputs(form)
         return _jsonify_form_definition(form, inputs=inputs)
 
-    @service_api_ns.expect(service_api_ns.models[HumanInputFormSubmitPayload.__name__])
+    @expect_with_user(service_api_ns, HumanInputFormSubmitPayload)
     @service_api_ns.doc("submit_human_input_form")
     @service_api_ns.doc(description="Submit a paused human input form by token")
     @service_api_ns.doc(params={"form_token": "Human input form token"})

--- a/api/controllers/service_api/app/message.py
+++ b/api/controllers/service_api/app/message.py
@@ -12,6 +12,7 @@ from controllers.common.fields import SimpleResultStringListResponse
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from controllers.service_api import service_api_ns
 from controllers.service_api.app.error import NotChatAppError
+from controllers.service_api.schema import expect_with_user
 from controllers.service_api.wraps import FetchUserArg, WhereisUserArg, validate_app_token
 from core.app.entities.app_invoke_entities import InvokeFrom
 from fields.base import ResponseModel
@@ -112,7 +113,7 @@ class MessageListApi(Resource):
 
 @service_api_ns.route("/messages/<uuid:message_id>/feedbacks")
 class MessageFeedbackApi(Resource):
-    @service_api_ns.expect(service_api_ns.models[MessageFeedbackPayload.__name__])
+    @expect_with_user(service_api_ns, MessageFeedbackPayload)
     @service_api_ns.response(200, "Feedback submitted successfully", service_api_ns.models[ResultResponse.__name__])
     @service_api_ns.doc("create_message_feedback")
     @service_api_ns.doc(description="Submit feedback for a message")

--- a/api/controllers/service_api/app/workflow.py
+++ b/api/controllers/service_api/app/workflow.py
@@ -21,6 +21,11 @@ from controllers.service_api.app.error import (
     ProviderNotInitializeError,
     ProviderQuotaExceededError,
 )
+from controllers.service_api.schema import (
+    expect_user_json,
+    expect_with_user,
+    json_or_event_stream_response,
+)
 from controllers.service_api.wraps import FetchUserArg, WhereisUserArg, validate_app_token
 from controllers.web.error import InvokeRateLimitError as InvokeRateLimitHttpError
 from core.app.apps.base_app_queue_manager import AppQueueManager
@@ -249,7 +254,8 @@ class WorkflowRunDetailApi(Resource):
 
 @service_api_ns.route("/workflows/run")
 class WorkflowRunApi(Resource):
-    @service_api_ns.expect(service_api_ns.models[WorkflowRunPayload.__name__])
+    @expect_with_user(service_api_ns, WorkflowRunPayload)
+    @json_or_event_stream_response(service_api_ns)
     @service_api_ns.doc("run_workflow")
     @service_api_ns.doc(description="Execute a workflow")
     @service_api_ns.doc(
@@ -313,7 +319,8 @@ class WorkflowRunApi(Resource):
 
 @service_api_ns.route("/workflows/<string:workflow_id>/run")
 class WorkflowRunByIdApi(Resource):
-    @service_api_ns.expect(service_api_ns.models[WorkflowRunPayload.__name__])
+    @expect_with_user(service_api_ns, WorkflowRunPayload)
+    @json_or_event_stream_response(service_api_ns)
     @service_api_ns.doc("run_workflow_by_id")
     @service_api_ns.doc(description="Execute a specific workflow by ID")
     @service_api_ns.doc(params={"workflow_id": "Workflow ID to execute"})
@@ -387,6 +394,7 @@ class WorkflowRunByIdApi(Resource):
 
 @service_api_ns.route("/workflows/tasks/<string:task_id>/stop")
 class WorkflowTaskStopApi(Resource):
+    @expect_user_json(service_api_ns)
     @service_api_ns.doc("stop_workflow_task")
     @service_api_ns.doc(description="Stop a running workflow task")
     @service_api_ns.doc(params={"task_id": "Task ID to stop"})

--- a/api/controllers/service_api/app/workflow_events.py
+++ b/api/controllers/service_api/app/workflow_events.py
@@ -15,6 +15,7 @@ from controllers.common.fields import EventStreamResponse
 from controllers.common.schema import query_params_from_model, register_response_schema_model, register_schema_models
 from controllers.service_api import service_api_ns
 from controllers.service_api.app.error import NotWorkflowAppError
+from controllers.service_api.schema import event_stream_response
 from controllers.service_api.wraps import FetchUserArg, WhereisUserArg, validate_app_token
 from core.app.apps.advanced_chat.app_generator import AdvancedChatAppGenerator
 from core.app.apps.base_app_generator import BaseAppGenerator
@@ -44,6 +45,7 @@ register_response_schema_model(service_api_ns, EventStreamResponse)
 class WorkflowEventsApi(Resource):
     """Service API for getting workflow execution events after resume."""
 
+    @event_stream_response(service_api_ns)
     @service_api_ns.doc("get_workflow_events")
     @service_api_ns.doc(description="Get workflow execution events stream after resume")
     @service_api_ns.doc(params={"task_id": "Workflow run ID"})

--- a/api/controllers/service_api/dataset/dataset.py
+++ b/api/controllers/service_api/dataset/dataset.py
@@ -2,7 +2,7 @@ from typing import Any, Literal
 from uuid import UUID
 
 from flask import request
-from pydantic import BaseModel, ConfigDict, Field, RootModel, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, GetJsonSchemaHandler, RootModel, field_validator, model_validator
 from werkzeug.exceptions import Forbidden, NotFound
 
 import services
@@ -113,6 +113,44 @@ class TagUnbindingPayload(BaseModel):
     tag_ids: list[str] = Field(default_factory=list)
     tag_id: str | None = None
     target_id: str
+
+    @classmethod
+    def __get_pydantic_json_schema__(cls, _core_schema: object, _handler: GetJsonSchemaHandler) -> dict[str, object]:
+        tag_id_property = {
+            "description": "Legacy single tag ID accepted by the Service API.",
+            "type": "string",
+        }
+        tag_ids_property = {
+            "description": "Tag IDs to unbind. Use this for new integrations.",
+            "items": {"type": "string"},
+            "minItems": 1,
+            "type": "array",
+        }
+        target_id_property = {"title": "Target Id", "type": "string"}
+        return {
+            "anyOf": [
+                {
+                    "properties": {
+                        "tag_id": tag_id_property,
+                        "tag_ids": tag_ids_property,
+                        "target_id": target_id_property,
+                    },
+                    "required": ["tag_id", "target_id"],
+                    "type": "object",
+                },
+                {
+                    "properties": {
+                        "tag_id": {**tag_id_property, "nullable": True},
+                        "tag_ids": tag_ids_property,
+                        "target_id": target_id_property,
+                    },
+                    "required": ["tag_ids", "target_id"],
+                    "type": "object",
+                },
+            ],
+            "description": "Accepts either the legacy tag_id payload or the normalized tag_ids payload.",
+            "title": cls.__name__,
+        }
 
     @model_validator(mode="before")
     @classmethod

--- a/api/controllers/service_api/dataset/dataset.py
+++ b/api/controllers/service_api/dataset/dataset.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Any, Literal, override
 from uuid import UUID
 
 from flask import request
@@ -122,6 +122,7 @@ class TagUnbindingPayload(BaseModel):
     target_id: str
 
     @classmethod
+    @override
     def __get_pydantic_json_schema__(cls, _core_schema: object, _handler: GetJsonSchemaHandler) -> dict[str, object]:
         tag_id_property = {
             "description": "Legacy single tag ID accepted by the Service API.",

--- a/api/controllers/service_api/dataset/dataset.py
+++ b/api/controllers/service_api/dataset/dataset.py
@@ -79,6 +79,13 @@ class DocumentStatusPayload(BaseModel):
     document_ids: list[str] = Field(default_factory=list, description="Document IDs to update")
 
 
+DOCUMENT_STATUS_ACTION_PARAM = {
+    "description": "Action to perform: 'enable', 'disable', 'archive', or 'un_archive'",
+    "enum": ["enable", "disable", "archive", "un_archive"],
+    "type": "string",
+}
+
+
 class TagNamePayload(BaseModel):
     name: str = Field(..., min_length=1, max_length=50)
 
@@ -567,7 +574,7 @@ class DocumentStatusApi(DatasetApiResource):
     @service_api_ns.doc(
         params={
             "dataset_id": "Dataset ID",
-            "action": "Action to perform: 'enable', 'disable', 'archive', or 'un_archive'",
+            "action": DOCUMENT_STATUS_ACTION_PARAM,
         }
     )
     @service_api_ns.doc(

--- a/api/controllers/service_api/dataset/document.py
+++ b/api/controllers/service_api/dataset/document.py
@@ -8,11 +8,12 @@ deprecated in generated API docs so clients migrate toward the canonical paths.
 import json
 from collections.abc import Mapping
 from contextlib import ExitStack
+from copy import deepcopy
 from typing import Any, Literal, Self
 from uuid import UUID
 
 from flask import request, send_file
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, GetJsonSchemaHandler, field_validator, model_validator
 from sqlalchemy import desc, func, select
 from werkzeug.exceptions import Forbidden, NotFound
 
@@ -105,11 +106,58 @@ class DocumentTextUpdate(BaseModel):
             raise ValueError("Invalid doc_form.")
         return value
 
+    @classmethod
+    def __get_pydantic_json_schema__(cls, core_schema: Any, handler: GetJsonSchemaHandler) -> dict[str, Any]:
+        schema = handler.resolve_ref_schema(handler(core_schema))
+        properties = schema.get("properties")
+        if not isinstance(properties, dict):
+            return schema
+
+        text_branch_properties = deepcopy(properties)
+        text_branch_properties["text"] = _non_null_property_schema(properties.get("text"))
+        text_branch_properties["name"] = _non_null_property_schema(properties.get("name"))
+
+        no_text_branch_properties = deepcopy(properties)
+        no_text_branch_properties["text"] = {"type": "null"}
+
+        return {
+            **schema,
+            "anyOf": [
+                {
+                    "properties": text_branch_properties,
+                    "required": ["name", "text"],
+                    "type": "object",
+                },
+                {
+                    "properties": no_text_branch_properties,
+                    "type": "object",
+                },
+            ],
+        }
+
     @model_validator(mode="after")
     def check_text_and_name(self) -> Self:
         if self.text is not None and self.name is None:
             raise ValueError("name is required when text is provided")
         return self
+
+
+def _non_null_property_schema(property_schema: object) -> dict[str, Any]:
+    if not isinstance(property_schema, dict):
+        return {}
+
+    any_of = property_schema.get("anyOf")
+    if isinstance(any_of, list):
+        non_null_candidates = [
+            candidate for candidate in any_of if isinstance(candidate, dict) and candidate.get("type") != "null"
+        ]
+        if len(non_null_candidates) == 1:
+            return {
+                **{key: value for key, value in property_schema.items() if key != "anyOf"},
+                **deepcopy(non_null_candidates[0]),
+            }
+
+    return deepcopy(property_schema)
 
 
 class DocumentListQuery(BaseModel):

--- a/api/controllers/service_api/dataset/document.py
+++ b/api/controllers/service_api/dataset/document.py
@@ -39,6 +39,7 @@ from controllers.service_api.dataset.error import (
     DocumentIndexingError,
     InvalidMetadataError,
 )
+from controllers.service_api.schema import binary_response
 from controllers.service_api.wraps import (
     DatasetApiResource,
     cloud_edition_billing_rate_limit_check,
@@ -463,8 +464,17 @@ class DeprecatedDocumentUpdateByTextApi(DatasetApiResource):
 
 @service_api_ns.route(
     "/datasets/<uuid:dataset_id>/document/create_by_file",
-    "/datasets/<uuid:dataset_id>/document/create-by-file",
+    doc={
+        "post": {
+            "deprecated": True,
+            "description": (
+                "Deprecated legacy alias for creating a new document by uploading a file. "
+                "Use /datasets/{dataset_id}/document/create-by-file instead."
+            ),
+        }
+    },
 )
+@service_api_ns.route("/datasets/<uuid:dataset_id>/document/create-by-file")
 class DocumentAddByFileApi(DatasetApiResource):
     """Resource for documents."""
 
@@ -746,6 +756,7 @@ class DocumentListApi(DatasetApiResource):
 class DocumentBatchDownloadZipApi(DatasetApiResource):
     """Download multiple uploaded-file documents as a single ZIP archive."""
 
+    @binary_response(service_api_ns, "application/zip")
     @service_api_ns.expect(service_api_ns.models[DocumentBatchDownloadZipPayload.__name__])
     @service_api_ns.doc("download_documents_as_zip")
     @service_api_ns.doc(description="Download selected uploaded documents as a single ZIP archive")
@@ -758,11 +769,7 @@ class DocumentBatchDownloadZipApi(DatasetApiResource):
             404: "Document or dataset not found",
         }
     )
-    @service_api_ns.response(
-        200,
-        "ZIP archive generated successfully",
-        service_api_ns.models[BinaryFileResponse.__name__],
-    )
+    @service_api_ns.response(200, "ZIP archive generated successfully")
     @cloud_edition_billing_rate_limit_check("knowledge", "dataset")
     def post(self, tenant_id, dataset_id: UUID):
         payload = DocumentBatchDownloadZipPayload.model_validate(service_api_ns.payload or {})

--- a/api/controllers/service_api/dataset/document.py
+++ b/api/controllers/service_api/dataset/document.py
@@ -9,7 +9,7 @@ import json
 from collections.abc import Mapping
 from contextlib import ExitStack
 from copy import deepcopy
-from typing import Any, Literal, Self
+from typing import Any, Literal, Self, override
 from uuid import UUID
 
 from flask import request, send_file
@@ -107,6 +107,7 @@ class DocumentTextUpdate(BaseModel):
         return value
 
     @classmethod
+    @override
     def __get_pydantic_json_schema__(cls, core_schema: Any, handler: GetJsonSchemaHandler) -> dict[str, Any]:
         schema = handler.resolve_ref_schema(handler(core_schema))
         properties = schema.get("properties")

--- a/api/controllers/service_api/dataset/metadata.py
+++ b/api/controllers/service_api/dataset/metadata.py
@@ -24,6 +24,12 @@ from services.entities.knowledge_entities.knowledge_entities import (
 )
 from services.metadata_service import MetadataService
 
+BUILT_IN_METADATA_ACTION_PARAM = {
+    "description": "Action to perform: 'enable' or 'disable'",
+    "enum": ["enable", "disable"],
+    "type": "string",
+}
+
 register_schema_model(service_api_ns, MetadataUpdatePayload)
 register_schema_models(
     service_api_ns,
@@ -175,7 +181,7 @@ class DatasetMetadataBuiltInFieldServiceApi(DatasetApiResource):
 class DatasetMetadataBuiltInFieldActionServiceApi(DatasetApiResource):
     @service_api_ns.doc("toggle_built_in_field")
     @service_api_ns.doc(description="Enable or disable built-in metadata field")
-    @service_api_ns.doc(params={"dataset_id": "Dataset ID", "action": "Action to perform: 'enable' or 'disable'"})
+    @service_api_ns.doc(params={"dataset_id": "Dataset ID", "action": BUILT_IN_METADATA_ACTION_PARAM})
     @service_api_ns.doc(
         responses={
             200: "Action completed successfully",

--- a/api/controllers/service_api/dataset/rag_pipeline/rag_pipeline_workflow.py
+++ b/api/controllers/service_api/dataset/rag_pipeline/rag_pipeline_workflow.py
@@ -19,6 +19,11 @@ from controllers.common.schema import (
 from controllers.service_api import service_api_ns
 from controllers.service_api.dataset.error import PipelineRunError
 from controllers.service_api.dataset.rag_pipeline.serializers import serialize_upload_file
+from controllers.service_api.schema import (
+    event_stream_response,
+    json_or_event_stream_response,
+    multipart_file_params,
+)
 from controllers.service_api.wraps import DatasetApiResource
 from core.app.apps.pipeline.pipeline_generator import PipelineGenerator
 from core.app.entities.app_invoke_entities import InvokeFrom
@@ -137,6 +142,7 @@ class DatasourcePluginsApi(DatasetApiResource):
 class DatasourceNodeRunApi(DatasetApiResource):
     """Resource for datasource node run."""
 
+    @event_stream_response(service_api_ns)
     @service_api_ns.doc(shortcut="pipeline_datasource_node_run")
     @service_api_ns.doc(description="Run a datasource node for a rag pipeline")
     @service_api_ns.doc(
@@ -195,6 +201,7 @@ class DatasourceNodeRunApi(DatasetApiResource):
 class PipelineRunApi(DatasetApiResource):
     """Resource for datasource node run."""
 
+    @json_or_event_stream_response(service_api_ns)
     @service_api_ns.doc(shortcut="pipeline_datasource_node_run")
     @service_api_ns.doc(description="Run a datasource node for a rag pipeline")
     @service_api_ns.doc(
@@ -250,6 +257,7 @@ class KnowledgebasePipelineFileUploadApi(DatasetApiResource):
 
     @service_api_ns.doc(shortcut="knowledgebase_pipeline_file_upload")
     @service_api_ns.doc(description="Upload a file to a knowledgebase pipeline")
+    @service_api_ns.doc(consumes=["multipart/form-data"], params=multipart_file_params(include_user=False))
     @service_api_ns.doc(
         responses={
             201: "File uploaded successfully",

--- a/api/controllers/service_api/schema.py
+++ b/api/controllers/service_api/schema.py
@@ -1,0 +1,96 @@
+"""Service API OpenAPI documentation helpers.
+
+These helpers keep documentation-only request shapes next to controller
+definitions without changing the Pydantic models used for runtime validation.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+from flask_restx import Namespace
+from pydantic import BaseModel
+
+USER_PROPERTY_SCHEMA = {"description": "End user identifier", "type": "string"}
+USER_QUERY_PARAM = {"description": "End user identifier", "in": "query", "type": "string"}
+USER_FORM_PARAM = {"description": "End user identifier", "in": "formData", "type": "string"}
+FILE_FORM_PARAM = {"in": "formData", "required": True, "type": "file"}
+USER_FETCH_FROM_ATTR = "_dify_service_api_user_fetch_from"
+USER_REQUIRED_ATTR = "_dify_service_api_user_required"
+JSON_USER_FETCH_FROM = "JSON"
+
+
+def expect_with_user(namespace: Namespace, model: type[BaseModel]):
+    """Document a JSON request body as ``model`` plus Service API ``user``."""
+
+    source_model = namespace.models[model.__name__]
+    model_name = f"{model.__name__}WithUser"
+
+    def decorator(view_func):
+        required = _json_user_required(view_func)
+        schema = deepcopy(source_model.__schema__)
+        _add_user_property(schema, required=required)
+        if model_name not in namespace.models:
+            namespace.schema_model(model_name, schema)
+        return namespace.expect(namespace.models[model_name], validate=False)(view_func)
+
+    return decorator
+
+
+def expect_user_json(namespace: Namespace):
+    """Document a JSON request body that only carries the Service API ``user``."""
+
+    def decorator(view_func):
+        required = _json_user_required(view_func)
+        schema = {"properties": {}, "title": "ServiceApiUserPayload", "type": "object"}
+        _add_user_property(schema, required=required)
+        model_name = "RequiredServiceApiUserPayload" if required else "OptionalServiceApiUserPayload"
+        if model_name not in namespace.models:
+            namespace.schema_model(model_name, schema)
+        return namespace.expect(namespace.models[model_name], validate=False)(view_func)
+
+    return decorator
+
+
+def multipart_file_params(*, include_user: bool) -> dict[str, dict[str, object]]:
+    params = {"file": FILE_FORM_PARAM}
+    if include_user:
+        params["user"] = USER_FORM_PARAM
+    return deepcopy(params)
+
+
+def json_or_event_stream_response(namespace: Namespace):
+    return namespace.doc(produces=["application/json", "text/event-stream"])
+
+
+def event_stream_response(namespace: Namespace):
+    return namespace.doc(produces=["text/event-stream"])
+
+
+def binary_response(namespace: Namespace, media_type: str):
+    return namespace.doc(produces=[media_type])
+
+
+def _json_user_required(view_func) -> bool:
+    fetch_from = getattr(view_func, USER_FETCH_FROM_ATTR, None)
+    if fetch_from != JSON_USER_FETCH_FROM:
+        raise ValueError("JSON user documentation must match validate_app_token(fetch_user_arg=WhereisUserArg.JSON)")
+
+    return bool(getattr(view_func, USER_REQUIRED_ATTR, False))
+
+
+def _add_user_property(schema: dict[str, object], *, required: bool) -> None:
+    properties = schema.setdefault("properties", {})
+    if isinstance(properties, dict):
+        properties["user"] = USER_PROPERTY_SCHEMA
+
+    if required:
+        required_fields = schema.setdefault("required", [])
+        if isinstance(required_fields, list) and "user" not in required_fields:
+            required_fields.append("user")
+    else:
+        required_fields = schema.get("required")
+        if isinstance(required_fields, list) and "user" in required_fields:
+            required_fields.remove("user")
+        if required_fields == []:
+            schema.pop("required", None)

--- a/api/controllers/service_api/schema.py
+++ b/api/controllers/service_api/schema.py
@@ -6,6 +6,7 @@ definitions without changing the Pydantic models used for runtime validation.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from copy import deepcopy
 
 from flask_restx import Namespace
@@ -67,8 +68,9 @@ def event_stream_response(namespace: Namespace):
     return namespace.doc(produces=["text/event-stream"])
 
 
-def binary_response(namespace: Namespace, media_type: str):
-    return namespace.doc(produces=[media_type])
+def binary_response(namespace: Namespace, media_type: str | Sequence[str]):
+    media_types = [media_type] if isinstance(media_type, str) else list(media_type)
+    return namespace.doc(produces=media_types)
 
 
 def _json_user_required(view_func) -> bool:
@@ -80,6 +82,20 @@ def _json_user_required(view_func) -> bool:
 
 
 def _add_user_property(schema: dict[str, object], *, required: bool) -> None:
+    variants: list[dict[str, object]] = []
+    for keyword in ("anyOf", "oneOf"):
+        candidates = schema.get(keyword)
+        if isinstance(candidates, list):
+            variants.extend(candidate for candidate in candidates if isinstance(candidate, dict))
+
+    if variants:
+        for variant in variants:
+            _add_user_property_to_object_schema(variant, required=required)
+
+    _add_user_property_to_object_schema(schema, required=required)
+
+
+def _add_user_property_to_object_schema(schema: dict[str, object], *, required: bool) -> None:
     properties = schema.setdefault("properties", {})
     if isinstance(properties, dict):
         properties["user"] = USER_PROPERTY_SCHEMA

--- a/api/controllers/service_api/schema.py
+++ b/api/controllers/service_api/schema.py
@@ -8,14 +8,15 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from copy import deepcopy
+from typing import cast
 
 from flask_restx import Namespace
 from pydantic import BaseModel
 
-USER_PROPERTY_SCHEMA = {"description": "End user identifier", "type": "string"}
-USER_QUERY_PARAM = {"description": "End user identifier", "in": "query", "type": "string"}
-USER_FORM_PARAM = {"description": "End user identifier", "in": "formData", "type": "string"}
-FILE_FORM_PARAM = {"in": "formData", "required": True, "type": "file"}
+USER_PROPERTY_SCHEMA: dict[str, object] = {"description": "End user identifier", "type": "string"}
+USER_QUERY_PARAM: dict[str, object] = {"description": "End user identifier", "in": "query", "type": "string"}
+USER_FORM_PARAM: dict[str, object] = {"description": "End user identifier", "in": "formData", "type": "string"}
+FILE_FORM_PARAM: dict[str, object] = {"in": "formData", "required": True, "type": "file"}
 USER_FETCH_FROM_ATTR = "_dify_service_api_user_fetch_from"
 USER_REQUIRED_ATTR = "_dify_service_api_user_required"
 JSON_USER_FETCH_FROM = "JSON"
@@ -29,7 +30,7 @@ def expect_with_user(namespace: Namespace, model: type[BaseModel]):
 
     def decorator(view_func):
         required = _json_user_required(view_func)
-        schema = deepcopy(source_model.__schema__)
+        schema = cast(dict[str, object], deepcopy(source_model.__schema__))
         _add_user_property(schema, required=required)
         if model_name not in namespace.models:
             namespace.schema_model(model_name, schema)
@@ -43,7 +44,7 @@ def expect_user_json(namespace: Namespace):
 
     def decorator(view_func):
         required = _json_user_required(view_func)
-        schema = {"properties": {}, "title": "ServiceApiUserPayload", "type": "object"}
+        schema: dict[str, object] = {"properties": {}, "title": "ServiceApiUserPayload", "type": "object"}
         _add_user_property(schema, required=required)
         model_name = "RequiredServiceApiUserPayload" if required else "OptionalServiceApiUserPayload"
         if model_name not in namespace.models:
@@ -54,7 +55,7 @@ def expect_user_json(namespace: Namespace):
 
 
 def multipart_file_params(*, include_user: bool) -> dict[str, dict[str, object]]:
-    params = {"file": FILE_FORM_PARAM}
+    params: dict[str, dict[str, object]] = {"file": FILE_FORM_PARAM}
     if include_user:
         params["user"] = USER_FORM_PARAM
     return deepcopy(params)
@@ -98,7 +99,7 @@ def _add_user_property(schema: dict[str, object], *, required: bool) -> None:
 def _add_user_property_to_object_schema(schema: dict[str, object], *, required: bool) -> None:
     properties = schema.setdefault("properties", {})
     if isinstance(properties, dict):
-        properties["user"] = USER_PROPERTY_SCHEMA
+        cast(dict[str, object], properties)["user"] = USER_PROPERTY_SCHEMA
 
     if required:
         required_fields = schema.setdefault("required", [])

--- a/api/controllers/service_api/wraps.py
+++ b/api/controllers/service_api/wraps.py
@@ -9,11 +9,18 @@ from typing import cast, overload
 from flask import current_app, request
 from flask_login import user_logged_in
 from flask_restx import Resource
+from flask_restx.utils import merge
 from pydantic import BaseModel
 from sqlalchemy import select
 from werkzeug.exceptions import Forbidden, NotFound, Unauthorized
 
 from configs import dify_config
+from controllers.service_api.schema import (
+    USER_FETCH_FROM_ATTR,
+    USER_FORM_PARAM,
+    USER_QUERY_PARAM,
+    USER_REQUIRED_ATTR,
+)
 from enums.cloud_plan import CloudPlan
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
@@ -41,6 +48,32 @@ class WhereisUserArg(StrEnum):
 class FetchUserArg(BaseModel):
     fetch_from: WhereisUserArg
     required: bool = False
+
+
+APP_TOKEN_FORBIDDEN_RESPONSE = {
+    403: "Forbidden - token scope, app, dataset, or workspace access denied",
+}
+
+DATASET_TOKEN_AUTH_RESPONSES = {
+    401: "Unauthorized - invalid API token",
+    403: "Forbidden - dataset API access or workspace access denied",
+}
+
+
+def _document_app_token_contract(view_func: Callable[..., object], fetch_user_arg: FetchUserArg | None) -> None:
+    doc: dict[str, object] = {"responses": APP_TOKEN_FORBIDDEN_RESPONSE}
+    if fetch_user_arg is not None:
+        setattr(view_func, USER_FETCH_FROM_ATTR, fetch_user_arg.fetch_from.name)
+        setattr(view_func, USER_REQUIRED_ATTR, fetch_user_arg.required)
+        match fetch_user_arg.fetch_from:
+            case WhereisUserArg.QUERY:
+                doc["params"] = {"user": {**USER_QUERY_PARAM, "required": fetch_user_arg.required}}
+            case WhereisUserArg.FORM:
+                doc["params"] = {"user": {**USER_FORM_PARAM, "required": fetch_user_arg.required}}
+            case WhereisUserArg.JSON:
+                pass
+
+    view_func.__apidoc__ = merge(getattr(view_func, "__apidoc__", {}), doc)
 
 
 @overload
@@ -126,6 +159,7 @@ def validate_app_token[**P, R](
 
             return view_func(*args, **kwargs)
 
+        _document_app_token_contract(decorated_view, fetch_user_arg)
         return decorated_view
 
     if view is None:
@@ -343,6 +377,8 @@ def validate_and_get_api_token(scope: str | None = None):
 
 
 class DatasetApiResource(Resource):
+    __apidoc__ = {"responses": DATASET_TOKEN_AUTH_RESPONSES}
+
     method_decorators = [validate_dataset_token]
 
     def get_dataset(self, dataset_id: str, tenant_id: str) -> Dataset:

--- a/api/controllers/service_api/wraps.py
+++ b/api/controllers/service_api/wraps.py
@@ -4,7 +4,7 @@ import time
 from collections.abc import Callable
 from enum import StrEnum, auto
 from functools import wraps
-from typing import cast, overload
+from typing import Protocol, cast, overload
 
 from flask import current_app, request
 from flask_login import user_logged_in
@@ -33,6 +33,12 @@ from services.end_user_service import EndUserService
 from services.feature_service import FeatureService
 
 logger = logging.getLogger(__name__)
+
+
+class _RestxDocumentedView(Protocol):
+    """Callable view object carrying Flask-RESTX documentation metadata."""
+
+    __apidoc__: dict[str, object]
 
 
 class WhereisUserArg(StrEnum):
@@ -73,7 +79,10 @@ def _document_app_token_contract(view_func: Callable[..., object], fetch_user_ar
             case WhereisUserArg.JSON:
                 pass
 
-    view_func.__apidoc__ = merge(getattr(view_func, "__apidoc__", {}), doc)
+    cast(_RestxDocumentedView, view_func).__apidoc__ = cast(
+        dict[str, object],
+        merge(getattr(view_func, "__apidoc__", {}), doc),
+    )
 
 
 @overload

--- a/api/dev/generate_swagger_markdown_docs.py
+++ b/api/dev/generate_swagger_markdown_docs.py
@@ -167,6 +167,12 @@ def _patch_union_schema_markdown(markdown: str, spec_path: Path) -> str:
     return markdown
 
 
+def _strip_trailing_line_whitespace(markdown: str) -> str:
+    """Remove converter-emitted trailing whitespace without changing line structure."""
+
+    return "\n".join(line.rstrip(" \t") for line in markdown.split("\n"))
+
+
 def _convert_spec_to_markdown(spec_path: Path, markdown_path: Path) -> None:
     markdown_path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix=f"{markdown_path.stem}-") as temp_dir:
@@ -201,6 +207,7 @@ def _convert_spec_to_markdown(spec_path: Path, markdown_path: Path) -> None:
             temp_markdown_path.read_text(encoding="utf-8"),
             spec_path,
         )
+        converted_markdown = _strip_trailing_line_whitespace(converted_markdown)
         if not converted_markdown.strip():
             raise RuntimeError(f"swagger-markdown wrote an empty document for {markdown_path}")
 

--- a/api/dev/generate_swagger_specs.py
+++ b/api/dev/generate_swagger_specs.py
@@ -154,9 +154,9 @@ def create_spec_app() -> Flask:
 
     apply_runtime_defaults()
 
-    from libs.flask_restx_compat import patch_swagger_for_inline_nested_dicts
+    from libs.flask_restx_compat import install_swagger_compatibility
 
-    patch_swagger_for_inline_nested_dicts()
+    install_swagger_compatibility()
 
     app = Flask(__name__)
 

--- a/api/dev/generate_swagger_specs.py
+++ b/api/dev/generate_swagger_specs.py
@@ -104,11 +104,14 @@ def _field_signature(field: object) -> object:
         "description",
         "example",
         "max",
+        "max_items",
         "min",
+        "min_items",
         "nullable",
         "readonly",
         "required",
         "title",
+        "unique",
     ):
         if hasattr(field_instance, attr_name):
             signature[attr_name] = _jsonable_schema_value(getattr(field_instance, attr_name))

--- a/api/libs/external_api.py
+++ b/api/libs/external_api.py
@@ -9,7 +9,7 @@ from werkzeug.http import HTTP_STATUS_CODES
 
 from configs import dify_config
 from core.errors.error import AppInvokeQuotaExceededError
-from libs.flask_restx_compat import patch_swagger_for_inline_nested_dicts
+from libs.flask_restx_compat import install_swagger_compatibility
 from libs.token import build_force_logout_cookie_headers
 
 
@@ -127,16 +127,22 @@ def register_external_error_handlers(api: Api, body_formatter: ErrorBodyFormatte
 class ExternalApi(Api):
     _authorizations = {
         "Bearer": {
-            "type": "apiKey",
-            "in": "header",
-            "name": "Authorization",
-            "description": "Type: Bearer {your-api-key}",
+            "bearerFormat": "API_KEY",
+            "description": "Use the Service API key as a Bearer token in the Authorization header.",
+            "scheme": "bearer",
+            "type": "http",
         }
     }
 
-    def __init__(self, app: Blueprint | Flask, *args, error_body_formatter: ErrorBodyFormatter | None = None, **kwargs):
+    def __init__(
+        self,
+        app: Blueprint | Flask,
+        *args,
+        error_body_formatter: ErrorBodyFormatter | None = None,
+        **kwargs,
+    ):
         self._error_body_formatter = error_body_formatter
-        patch_swagger_for_inline_nested_dicts()
+        install_swagger_compatibility()
         kwargs.setdefault("authorizations", self._authorizations)
         kwargs.setdefault("security", "Bearer")
         kwargs["add_specs"] = dify_config.SWAGGER_UI_ENABLED

--- a/api/libs/flask_restx_compat.py
+++ b/api/libs/flask_restx_compat.py
@@ -12,6 +12,7 @@ from typing import TypeGuard
 
 from flask import current_app
 from flask_restx import fields
+from flask_restx import swagger as restx_swagger
 from flask_restx.model import Model, OrderedModel, instance
 from flask_restx.swagger import Swagger
 
@@ -98,20 +99,25 @@ def _inline_model_name(nested_fields: dict[object, object]) -> str:
     return f"_AnonymousInlineModel_{digest}"
 
 
-def patch_swagger_for_inline_nested_dicts() -> None:
-    """Allow OpenAPI generation to handle legacy inline Flask-RESTX field dicts.
+def install_swagger_compatibility() -> None:
+    """Install Dify's Flask-RESTX OpenAPI compatibility hooks.
 
     Some existing controllers use raw field mappings in `fields.Nested({...})`
     or directly in `@namespace.response(...)`. Runtime marshalling accepts that,
     but Flask-RESTX registration expects a named model. Convert those
     anonymous mappings into temporary named models during docs generation.
+
+    Flask-RESTX also drops parameter descriptions from generated schemas and
+    does not expose the Werkzeug `uuid` route converter as `format: uuid`.
     """
 
-    if getattr(Swagger, "_dify_inline_nested_dict_patch", False):
+    if getattr(Swagger, "_dify_swagger_compatibility_installed", False):
         return
 
     original_register_model = Swagger.register_model
     original_register_field = Swagger.register_field
+    original_extract_path_params = restx_swagger.extract_path_params
+    original_schema_from_parameter = Swagger.schema_from_parameter
     original_as_dict = Swagger.as_dict
 
     def get_or_create_inline_model(self: Swagger, nested_fields: dict[object, object]) -> object:
@@ -134,6 +140,20 @@ def patch_swagger_for_inline_nested_dicts() -> None:
 
         original_register_field(self, field)
 
+    def schema_from_parameter_with_description(self: Swagger, param: dict[str, object]):
+        schema = original_schema_from_parameter(self, param)
+        description = param.get("description")
+        if isinstance(description, str):
+            schema["description"] = description
+        return schema
+
+    def extract_path_params_with_uuid_format(path: str):
+        params = original_extract_path_params(path)
+        for converter, _arguments, variable in restx_swagger.parse_rule(path):
+            if converter == "uuid" and variable in params:
+                params[variable]["format"] = "uuid"
+        return params
+
     def as_dict_with_inline_dict_support(self: Swagger):
         # Temporary set RESTX_INCLUDE_ALL_MODELS = false to prevent "length changed while iterating" error
         include_all_models = current_app.config.get("RESTX_INCLUDE_ALL_MODELS", False)
@@ -145,5 +165,7 @@ def patch_swagger_for_inline_nested_dicts() -> None:
 
     Swagger.register_model = register_model_with_inline_dict_support
     Swagger.register_field = register_field_with_inline_dict_support
+    restx_swagger.extract_path_params = extract_path_params_with_uuid_format
+    Swagger.schema_from_parameter = schema_from_parameter_with_description
     Swagger.as_dict = as_dict_with_inline_dict_support
-    Swagger._dify_inline_nested_dict_patch = True
+    Swagger._dify_swagger_compatibility_installed = True

--- a/api/libs/flask_restx_compat.py
+++ b/api/libs/flask_restx_compat.py
@@ -8,7 +8,7 @@ spec export fail or succeed in the same way.
 
 import hashlib
 import json
-from typing import TypeGuard
+from typing import TypeGuard, cast
 
 from flask import current_app
 from flask_restx import fields
@@ -140,8 +140,8 @@ def install_swagger_compatibility() -> None:
 
         original_register_field(self, field)
 
-    def schema_from_parameter_with_description(self: Swagger, param: dict[str, object]):
-        schema = original_schema_from_parameter(self, param)
+    def schema_from_parameter_with_description(self: Swagger, param: dict[str, object]) -> dict[str, object]:
+        schema = cast(dict[str, object], original_schema_from_parameter(self, param))
         description = param.get("description")
         if isinstance(description, str):
             schema["description"] = description

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -18285,7 +18285,7 @@ Payload for running a loop node in snippet draft workflow.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| data | [ [_AnonymousInlineModel_efd591151ea9](#_anonymousinlinemodel_efd591151ea9) ] |  | No |
+| data | [ [_AnonymousInlineModel_744ff9cc03e6](#_anonymousinlinemodel_744ff9cc03e6) ] |  | No |
 | has_more | boolean |  | No |
 | limit | integer |  | No |
 | page | integer |  | No |
@@ -20069,6 +20069,25 @@ Workflow tool configuration
 | allow_owner_transfer | boolean |  | Yes |
 | workspace_id | string |  | Yes |
 
+#### _AnonymousInlineModel_744ff9cc03e6
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| author_name | string |  | No |
+| created_at | long |  | No |
+| created_by | string |  | No |
+| description | string |  | No |
+| icon_info | object |  | No |
+| id | string |  | No |
+| is_published | boolean |  | No |
+| name | string |  | No |
+| tags | [ [_AnonymousInlineModel_7b8b49ca164e](#_anonymousinlinemodel_7b8b49ca164e) ] |  | No |
+| type | string |  | No |
+| updated_at | long |  | No |
+| updated_by | string |  | No |
+| use_count | integer |  | No |
+| version | integer |  | No |
+
 #### _AnonymousInlineModel_7b8b49ca164e
 
 | Name | Type | Description | Required |
@@ -20093,25 +20112,6 @@ Workflow tool configuration
 | model_name | string |  | No |
 | model_provider_name | string |  | No |
 | summary_prompt | string |  | No |
-
-#### _AnonymousInlineModel_efd591151ea9
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| author_name | string |  | No |
-| created_at | long |  | No |
-| created_by | string |  | No |
-| description | string |  | No |
-| icon_info | object |  | No |
-| id | string |  | No |
-| is_published | boolean |  | No |
-| name | string |  | No |
-| tags | [ [_AnonymousInlineModel_7b8b49ca164e](#_anonymousinlinemodel_7b8b49ca164e) ] |  | No |
-| type | string |  | No |
-| updated_at | long |  | No |
-| updated_by | string |  | No |
-| use_count | integer |  | No |
-| version | integer |  | No |
 
 #### core__tools__entities__common_entities__I18nObject
 

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -17996,7 +17996,7 @@ Model class for provider quota configuration.
 | ---- | ---- | ----------- | -------- |
 | chunk_overlap | integer |  | No |
 | max_tokens | integer |  | Yes |
-| separator | string, <br>**Default:** 
+| separator | string, <br>**Default:**
  |  | No |
 
 #### SelectInputConfig

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -4,10 +4,9 @@ Console management APIs for app configuration, monitoring, and administration
 ## Version: 1.0
 
 ### Available authorizations
-#### Bearer (API Key Authentication)
-Type: Bearer {your-api-key}  
-**Name:** Authorization  
-**In:** header  
+#### Bearer (HTTP, bearer)
+Use the Service API key as a Bearer token in the Authorization header.  
+Bearer format: API_KEY
 
 ---
 ## console
@@ -349,7 +348,7 @@ Check if activation token is valid
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path |  | Yes | string |
+| agent_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -363,7 +362,7 @@ Check if activation token is valid
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path |  | Yes | string |
+| agent_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -376,7 +375,7 @@ Check if activation token is valid
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path |  | Yes | string |
+| agent_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -399,7 +398,7 @@ Get Agent App chat messages for a conversation with pagination
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path | Agent ID | Yes | string |
+| agent_id | path | Agent ID | Yes | string (uuid) |
 | conversation_id | query | Conversation ID | Yes | string |
 | first_id | query | First message ID for pagination | No | string |
 | limit | query | Number of messages to return (1-100) | No | integer, <br>**Default:** 20 |
@@ -418,8 +417,8 @@ Get suggested questions for an Agent App message
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path | Agent ID | Yes | string |
-| message_id | path | Message ID | Yes | string |
+| agent_id | path | Agent ID | Yes | string (uuid) |
+| message_id | path | Message ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -435,7 +434,7 @@ Stop a running Agent App chat message generation
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path | Agent ID | Yes | string |
+| agent_id | path | Agent ID | Yes | string (uuid) |
 | task_id | path | Task ID to stop | Yes | string |
 
 #### Responses
@@ -449,7 +448,7 @@ Stop a running Agent App chat message generation
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path |  | Yes | string |
+| agent_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -462,7 +461,7 @@ Stop a running Agent App chat message generation
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path |  | Yes | string |
+| agent_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -481,7 +480,7 @@ Stop a running Agent App chat message generation
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path |  | Yes | string |
+| agent_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -494,7 +493,7 @@ Stop a running Agent App chat message generation
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path |  | Yes | string |
+| agent_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -513,7 +512,7 @@ Stop a running Agent App chat message generation
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path |  | Yes | string |
+| agent_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -536,7 +535,7 @@ List agent drive entries for an Agent App
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path | Agent ID | Yes | string |
+| agent_id | path | Agent ID | Yes | string (uuid) |
 | prefix | query | Key prefix filter: '<slug>/' for one skill, 'files/' for files | No | string |
 
 #### Responses
@@ -552,7 +551,7 @@ Time-limited external signed URL for one Agent App drive value
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path | Agent ID | Yes | string |
+| agent_id | path | Agent ID | Yes | string (uuid) |
 | key | query | Drive key, e.g. tender-analyzer/SKILL.md | Yes | string |
 
 #### Responses
@@ -568,7 +567,7 @@ Truncated text preview of one Agent App drive value
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path | Agent ID | Yes | string |
+| agent_id | path | Agent ID | Yes | string (uuid) |
 | key | query | Drive key, e.g. tender-analyzer/SKILL.md | Yes | string |
 
 #### Responses
@@ -584,7 +583,7 @@ Update an Agent App's presentation features (opener, follow-up, citations, ...)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path | Agent ID | Yes | string |
+| agent_id | path | Agent ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -607,7 +606,7 @@ Create or update Agent App message feedback
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path | Agent ID | Yes | string |
+| agent_id | path | Agent ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -629,7 +628,7 @@ Delete one Agent App drive file by key
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path | Agent ID | Yes | string |
+| agent_id | path | Agent ID | Yes | string (uuid) |
 | key | query | Drive key, e.g. files/sample.pdf | Yes | string |
 
 #### Responses
@@ -645,7 +644,7 @@ Commit an uploaded file into the Agent App drive under files/<name>
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path | Agent ID | Yes | string |
+| agent_id | path | Agent ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -671,7 +670,7 @@ Commit an uploaded file into the Agent App drive under files/<name>
 | source | query | Filter by all, console/explore, api/service-api, web-app, debugger, openapi, or trigger | No | string |
 | start | query | Start date (YYYY-MM-DD HH:MM) | No | string |
 | status | query | Filter by success, failed, or paused | No | string |
-| agent_id | path |  | Yes | string |
+| agent_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -686,8 +685,8 @@ Get Agent App message details by ID
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path | Agent ID | Yes | string |
-| message_id | path | Message ID | Yes | string |
+| agent_id | path | Agent ID | Yes | string (uuid) |
+| message_id | path | Message ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -703,7 +702,7 @@ List workflow apps that reference this Agent App's bound Agent (read-only)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path | Agent ID | Yes | string |
+| agent_id | path | Agent ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -719,7 +718,7 @@ List a directory in an Agent App conversation sandbox
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path | Agent ID | Yes | string |
+| agent_id | path | Agent ID | Yes | string (uuid) |
 | conversation_id | query | Agent App conversation ID | Yes | string |
 | path | query | Directory path relative to the sandbox workspace | No | string, <br>**Default:** . |
 
@@ -736,7 +735,7 @@ Read a text/binary preview file in an Agent App conversation sandbox
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path | Agent ID | Yes | string |
+| agent_id | path | Agent ID | Yes | string (uuid) |
 | conversation_id | query | Agent App conversation ID | Yes | string |
 | path | query | File path relative to the sandbox workspace | Yes | string |
 
@@ -753,7 +752,7 @@ Upload one Agent App sandbox file as a Dify ToolFile mapping
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path |  | Yes | string |
+| agent_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -774,7 +773,7 @@ Validate + standardize a Skill into an Agent App drive
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path | Agent ID | Yes | string |
+| agent_id | path | Agent ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -790,7 +789,7 @@ Upload + validate a Skill package for an Agent App
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path | Agent ID | Yes | string |
+| agent_id | path | Agent ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -806,7 +805,7 @@ Delete a standardized skill from an Agent App drive
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path | Agent ID | Yes | string |
+| agent_id | path | Agent ID | Yes | string (uuid) |
 | slug | path | Skill slug (single path segment) | Yes | string |
 
 #### Responses
@@ -822,7 +821,7 @@ Infer CLI tool + ENV suggestions from a standardized Agent App skill
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path | Agent ID | Yes | string |
+| agent_id | path | Agent ID | Yes | string (uuid) |
 | slug | path | Skill slug (single path segment) | Yes | string |
 
 #### Responses
@@ -839,7 +838,7 @@ Infer CLI tool + ENV suggestions from a standardized Agent App skill
 | end | query | End date (YYYY-MM-DD HH:MM) | No | string |
 | source | query | Filter by all, console/explore, api/service-api, web-app, debugger, openapi, or trigger | No | string |
 | start | query | Start date (YYYY-MM-DD HH:MM) | No | string |
-| agent_id | path |  | Yes | string |
+| agent_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -852,7 +851,7 @@ Infer CLI tool + ENV suggestions from a standardized Agent App skill
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path |  | Yes | string |
+| agent_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -865,8 +864,8 @@ Infer CLI tool + ENV suggestions from a standardized Agent App skill
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path |  | Yes | string |
-| version_id | path |  | Yes | string |
+| agent_id | path |  | Yes | string (uuid) |
+| version_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -919,7 +918,7 @@ Delete API-based extension
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| id | path | Extension ID | Yes | string |
+| id | path | Extension ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -934,7 +933,7 @@ Get API-based extension by ID
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| id | path | Extension ID | Yes | string |
+| id | path | Extension ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -949,7 +948,7 @@ Update API-based extension
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| id | path | Extension ID | Yes | string |
+| id | path | Extension ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -988,7 +987,7 @@ Update API-based extension
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| binding_id | path |  | Yes | string |
+| binding_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -1157,7 +1156,7 @@ Delete application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -1175,7 +1174,7 @@ Get application details
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -1192,7 +1191,7 @@ Update application details
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -1217,7 +1216,7 @@ Get advanced chat workflow run list
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | last_id | query | Last run ID for pagination | No | string |
 | limit | query | Number of items per page (1-100) | No | integer, <br>**Default:** 20 |
 | status | query | Workflow run status filter | No | string, <br>**Available values:** "failed", "partial-succeeded", "running", "stopped", "succeeded" |
@@ -1236,7 +1235,7 @@ Get advanced chat workflow run list
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | status | query | Workflow run status filter | No | string, <br>**Available values:** "failed", "partial-succeeded", "running", "stopped", "succeeded" |
 | time_range | query | Filter by time range (optional): e.g., 7d (7 days), 4h (4 hours), 30m (30 minutes), 30s (30 seconds). Filters by created_at field. | No | string |
 | triggered_from | query | Filter by trigger source: debugging or app-run. Default: debugging | No | string, <br>**Available values:** "app-run", "debugging" |
@@ -1256,7 +1255,7 @@ Get human input form preview for advanced chat workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | path | Node ID | Yes | string |
 
 #### Request Body
@@ -1280,7 +1279,7 @@ Submit human input form preview for advanced chat workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | path | Node ID | Yes | string |
 
 #### Request Body
@@ -1304,7 +1303,7 @@ Run draft workflow iteration node for advanced chat
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | path | Node ID | Yes | string |
 
 #### Request Body
@@ -1330,7 +1329,7 @@ Run draft workflow loop node for advanced chat
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | path | Node ID | Yes | string |
 
 #### Request Body
@@ -1356,7 +1355,7 @@ Run draft workflow for advanced chat application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -1379,7 +1378,7 @@ List agent drive entries (read-only inspector; one endpoint for both tabs)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | query | Workflow node ID (workflow composer variant) | No | string |
 | prefix | query | Key prefix filter: '<slug>/' for one skill, 'files/' for files | No | string |
 
@@ -1396,7 +1395,7 @@ Time-limited external signed URL for one drive value (no streaming proxy)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | key | query | Drive key, e.g. tender-analyzer/SKILL.md | Yes | string |
 | node_id | query | Workflow node ID (workflow composer variant) | No | string |
 
@@ -1413,7 +1412,7 @@ Truncated text preview of one drive value (binary-safe; SKILL.md is the main cas
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | key | query | Drive key, e.g. tender-analyzer/SKILL.md | Yes | string |
 | node_id | query | Workflow node ID (workflow composer variant) | No | string |
 
@@ -1430,7 +1429,7 @@ Delete one drive file by key; soul ref first, then the KV row (ENG-625 D5)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | key | query | Drive key, e.g. files/sample.pdf | Yes | string |
 | node_id | query | Workflow node ID (workflow composer variant) | No | string |
 
@@ -1449,7 +1448,7 @@ Commit an uploaded file into the agent drive under files/<name> (ENG-625 D3)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | query | Workflow node ID (workflow composer variant) | No | string |
 
 #### Request Body
@@ -1473,7 +1472,7 @@ Get agent execution logs for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | conversation_id | query | Conversation UUID | Yes | string |
 | message_id | query | Message UUID | Yes | string |
 
@@ -1493,7 +1492,7 @@ Validate + standardize a Skill into the agent drive (ENG-594)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | query | Workflow node ID (workflow composer variant) | No | string |
 
 #### Responses
@@ -1514,7 +1513,7 @@ plus its manifest. Standardizing into the agent drive is ENG-594.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -1530,7 +1529,7 @@ Delete a standardized skill: soul ref first, then the <slug>/ drive prefix (ENG-
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | slug | path | Skill slug (single path segment) | Yes | string |
 | node_id | query | Workflow node ID (workflow composer variant) | No | string |
 
@@ -1550,7 +1549,7 @@ Saving still goes through composer validation.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | slug | path | Skill slug (single path segment) | Yes | string |
 | node_id | query | Workflow node ID (workflow composer variant) | No | string |
 
@@ -1568,7 +1567,7 @@ Enable or disable annotation reply for an app
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | action | path | Action to perform (enable/disable) | Yes | string |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -1591,8 +1590,8 @@ Get status of annotation reply action job
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | action | path | Action type | Yes | string |
-| app_id | path | Application ID | Yes | string |
-| job_id | path | Job ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
+| job_id | path | Job ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -1608,7 +1607,7 @@ Get annotation settings for an app
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -1624,8 +1623,8 @@ Update annotation settings for an app
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| annotation_setting_id | path | Annotation setting ID | Yes | string |
-| app_id | path | Application ID | Yes | string |
+| annotation_setting_id | path | Annotation setting ID | Yes | string (uuid) |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -1645,7 +1644,7 @@ Update annotation settings for an app
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -1660,7 +1659,7 @@ Get annotations for an app with pagination
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | keyword | query | Search keyword | No | string |
 | limit | query | Page size | No | integer, <br>**Default:** 20 |
 | page | query | Page number | No | integer, <br>**Default:** 1 |
@@ -1679,7 +1678,7 @@ Create a new annotation for an app
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -1701,7 +1700,7 @@ Batch import annotations from CSV file with rate limiting and security checks
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -1720,8 +1719,8 @@ Get status of batch import job
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
-| job_id | path | Job ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
+| job_id | path | Job ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -1737,7 +1736,7 @@ Get count of message annotations for the app
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -1752,7 +1751,7 @@ Export all annotations for an app with CSV injection protection
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -1766,8 +1765,8 @@ Export all annotations for an app with CSV injection protection
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| annotation_id | path |  | Yes | string |
-| app_id | path |  | Yes | string |
+| annotation_id | path |  | Yes | string (uuid) |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -1782,8 +1781,8 @@ Update or delete an annotation
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| annotation_id | path | Annotation ID | Yes | string |
-| app_id | path | Application ID | Yes | string |
+| annotation_id | path | Annotation ID | Yes | string (uuid) |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -1806,8 +1805,8 @@ Get hit histories for an annotation
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| annotation_id | path | Annotation ID | Yes | string |
-| app_id | path | Application ID | Yes | string |
+| annotation_id | path | Annotation ID | Yes | string (uuid) |
+| app_id | path | Application ID | Yes | string (uuid) |
 | limit | query | Page size | No | integer, <br>**Default:** 20 |
 | page | query | Page number | No | integer, <br>**Default:** 1 |
 
@@ -1825,7 +1824,7 @@ Enable or disable app API
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -1847,7 +1846,7 @@ Transcript audio to text for chat messages
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | App ID | Yes | string |
+| app_id | path | App ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -1864,7 +1863,7 @@ Get chat conversations with pagination, filtering and summary
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | annotation_status | query | Annotation status filter | No | string, <br>**Available values:** "all", "annotated", "not_annotated", <br>**Default:** all |
 | end | query | End date (YYYY-MM-DD HH:MM) | No | string |
 | keyword | query | Search keyword | No | string |
@@ -1887,8 +1886,8 @@ Delete a chat conversation
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
-| conversation_id | path | Conversation ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
+| conversation_id | path | Conversation ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -1905,8 +1904,8 @@ Get chat conversation details
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
-| conversation_id | path | Conversation ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
+| conversation_id | path | Conversation ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -1923,7 +1922,7 @@ Get chat messages for a conversation with pagination
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | conversation_id | query | Conversation ID | Yes | string |
 | first_id | query | First message ID for pagination | No | string |
 | limit | query | Number of messages to return (1-100) | No | integer, <br>**Default:** 20 |
@@ -1942,8 +1941,8 @@ Get suggested questions for a message
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
-| message_id | path | Message ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
+| message_id | path | Message ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -1959,7 +1958,7 @@ Stop a running chat message generation
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | task_id | path | Task ID to stop | Yes | string |
 
 #### Responses
@@ -1975,7 +1974,7 @@ Get completion conversations with pagination and filtering
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | annotation_status | query | Annotation status filter | No | string, <br>**Available values:** "all", "annotated", "not_annotated", <br>**Default:** all |
 | end | query | End date (YYYY-MM-DD HH:MM) | No | string |
 | keyword | query | Search keyword | No | string |
@@ -1997,8 +1996,8 @@ Delete a completion conversation
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
-| conversation_id | path | Conversation ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
+| conversation_id | path | Conversation ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -2015,8 +2014,8 @@ Get completion conversation details with messages
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
-| conversation_id | path | Conversation ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
+| conversation_id | path | Conversation ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -2033,7 +2032,7 @@ Generate completion message for debugging
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -2056,7 +2055,7 @@ Stop a running completion message generation
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | task_id | path | Task ID to stop | Yes | string |
 
 #### Responses
@@ -2072,7 +2071,7 @@ Get conversation variables for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | conversation_id | query | Conversation ID to filter variables | Yes | string |
 
 #### Responses
@@ -2092,7 +2091,7 @@ Convert Completion App to Workflow App
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -2117,7 +2116,7 @@ Create a copy of an existing application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID to copy | Yes | string |
+| app_id | path | Application ID to copy | Yes | string (uuid) |
 
 #### Request Body
 
@@ -2141,7 +2140,7 @@ Export application configuration as DSL
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID to export | Yes | string |
+| app_id | path | Application ID to export | Yes | string (uuid) |
 | include_secret | query | Include secrets in export | No | boolean |
 | workflow_id | query | Specific workflow ID to export | No | string |
 
@@ -2159,7 +2158,7 @@ Create or update message feedback (like/dislike)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -2182,7 +2181,7 @@ Export user feedback data for Google Sheets
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | end_date | query | End date (YYYY-MM-DD) | No | string |
 | format | query | Export format | No | string, <br>**Available values:** "csv", "json", <br>**Default:** csv |
 | from_source | query | Filter by feedback source | No | string, <br>**Available values:** "admin", "user" |
@@ -2205,7 +2204,7 @@ Update application icon
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -2227,8 +2226,8 @@ Get message details by ID
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
-| message_id | path | Message ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
+| message_id | path | Message ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -2246,7 +2245,7 @@ Update application model configuration
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -2269,7 +2268,7 @@ Check if app name is available
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -2290,7 +2289,7 @@ Check if app name is available
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -2305,7 +2304,7 @@ Get MCP server configuration for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -2320,7 +2319,7 @@ Create MCP server configuration for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -2342,7 +2341,7 @@ Update MCP server configuration for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -2365,7 +2364,7 @@ Update application site configuration
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -2388,7 +2387,7 @@ Enable or disable app site
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -2410,7 +2409,7 @@ Reset access token for application site
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -2427,7 +2426,7 @@ Remove the current account's star from an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -2443,7 +2442,7 @@ Star an application for the current account
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -2459,7 +2458,7 @@ Get average response time statistics for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | end | query | End date (YYYY-MM-DD HH:MM) | No | string |
 | start | query | Start date (YYYY-MM-DD HH:MM) | No | string |
 
@@ -2476,7 +2475,7 @@ Get average session interaction statistics for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | end | query | End date (YYYY-MM-DD HH:MM) | No | string |
 | start | query | Start date (YYYY-MM-DD HH:MM) | No | string |
 
@@ -2493,7 +2492,7 @@ Get daily conversation statistics for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | end | query | End date (YYYY-MM-DD HH:MM) | No | string |
 | start | query | Start date (YYYY-MM-DD HH:MM) | No | string |
 
@@ -2510,7 +2509,7 @@ Get daily terminal/end-user statistics for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | end | query | End date (YYYY-MM-DD HH:MM) | No | string |
 | start | query | Start date (YYYY-MM-DD HH:MM) | No | string |
 
@@ -2527,7 +2526,7 @@ Get daily message statistics for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | end | query | End date (YYYY-MM-DD HH:MM) | No | string |
 | start | query | Start date (YYYY-MM-DD HH:MM) | No | string |
 
@@ -2544,7 +2543,7 @@ Get daily token cost statistics for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | end | query | End date (YYYY-MM-DD HH:MM) | No | string |
 | start | query | Start date (YYYY-MM-DD HH:MM) | No | string |
 
@@ -2561,7 +2560,7 @@ Get tokens per second statistics for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | end | query | End date (YYYY-MM-DD HH:MM) | No | string |
 | start | query | Start date (YYYY-MM-DD HH:MM) | No | string |
 
@@ -2578,7 +2577,7 @@ Get user satisfaction rate statistics for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | end | query | End date (YYYY-MM-DD HH:MM) | No | string |
 | start | query | Start date (YYYY-MM-DD HH:MM) | No | string |
 
@@ -2595,7 +2594,7 @@ Convert text to speech for chat messages
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | App ID | Yes | string |
+| app_id | path | App ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -2617,7 +2616,7 @@ Get available TTS voices for a specific language
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | App ID | Yes | string |
+| app_id | path | App ID | Yes | string (uuid) |
 | language | query | Language code | Yes | string |
 
 #### Responses
@@ -2636,7 +2635,7 @@ Get app tracing configuration
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -2651,7 +2650,7 @@ Update app tracing configuration
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -2675,7 +2674,7 @@ Delete an existing tracing configuration for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | tracing_provider | query | Tracing provider name | Yes | string |
 
 #### Responses
@@ -2692,7 +2691,7 @@ Get tracing configuration for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | tracing_provider | query | Tracing provider name | Yes | string |
 
 #### Responses
@@ -2711,7 +2710,7 @@ Update an existing tracing configuration for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -2735,7 +2734,7 @@ Create a new tracing configuration for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -2757,7 +2756,7 @@ Create a new tracing configuration for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -2778,7 +2777,7 @@ Create a new tracing configuration for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -2795,7 +2794,7 @@ Get workflow application execution logs
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | created_at__after | query | Filter logs created after this timestamp | No | dateTime |
 | created_at__before | query | Filter logs created before this timestamp | No | dateTime |
 | created_by_account | query | Filter by account | No | string |
@@ -2821,7 +2820,7 @@ Get workflow archived execution logs
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | created_at__after | query | Filter logs created after this timestamp | No | dateTime |
 | created_at__before | query | Filter logs created before this timestamp | No | dateTime |
 | created_by_account | query | Filter by account | No | string |
@@ -2845,7 +2844,7 @@ Get workflow archived execution logs
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | last_id | query | Last run ID for pagination | No | string |
 | limit | query | Number of items per page (1-100) | No | integer, <br>**Default:** 20 |
 | status | query | Workflow run status filter | No | string, <br>**Available values:** "failed", "partial-succeeded", "running", "stopped", "succeeded" |
@@ -2864,7 +2863,7 @@ Get workflow archived execution logs
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | status | query | Workflow run status filter | No | string, <br>**Available values:** "failed", "partial-succeeded", "running", "stopped", "succeeded" |
 | time_range | query | Filter by time range (optional): e.g., 7d (7 days), 4h (4 hours), 30m (30 minutes), 30s (30 seconds). Filters by created_at field. | No | string |
 | triggered_from | query | Filter by trigger source: debugging or app-run. Default: debugging | No | string, <br>**Available values:** "app-run", "debugging" |
@@ -2884,7 +2883,7 @@ Stop running workflow task
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | task_id | path | Task ID | Yes | string |
 
 #### Responses
@@ -2902,8 +2901,8 @@ Stop running workflow task
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
-| run_id | path | Workflow run ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
+| run_id | path | Workflow run ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -2919,8 +2918,8 @@ Generate a download URL for an archived workflow run.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
-| run_id | path | Workflow run ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
+| run_id | path | Workflow run ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -2935,8 +2934,8 @@ Generate a download URL for an archived workflow run.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
-| run_id | path | Workflow run ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
+| run_id | path | Workflow run ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -2952,9 +2951,9 @@ List a directory in a workflow Agent node sandbox
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | path | Workflow Agent node ID | Yes | string |
-| workflow_run_id | path | Workflow run ID | Yes | string |
+| workflow_run_id | path | Workflow run ID | Yes | string (uuid) |
 | node_execution_id | query | Optional workflow node execution ID. When omitted, the latest active session for the node is used. | No | string |
 | path | query | Directory path relative to the sandbox workspace | No | string, <br>**Default:** . |
 
@@ -2971,9 +2970,9 @@ Read a text/binary preview file in a workflow Agent node sandbox
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | path | Workflow Agent node ID | Yes | string |
-| workflow_run_id | path | Workflow run ID | Yes | string |
+| workflow_run_id | path | Workflow run ID | Yes | string (uuid) |
 | node_execution_id | query | Optional workflow node execution ID. When omitted, the latest active session for the node is used. | No | string |
 | path | query | File path relative to the sandbox workspace | Yes | string |
 
@@ -2990,9 +2989,9 @@ Upload one workflow Agent sandbox file as a Dify ToolFile mapping
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 | node_id | path |  | Yes | string |
-| workflow_run_id | path |  | Yes | string |
+| workflow_run_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -3013,7 +3012,7 @@ Upload one workflow Agent sandbox file as a Dify ToolFile mapping
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -3028,7 +3027,7 @@ Upload one workflow Agent sandbox file as a Dify ToolFile mapping
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -3049,7 +3048,7 @@ Upload one workflow Agent sandbox file as a Dify ToolFile mapping
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -3064,7 +3063,7 @@ Upload one workflow Agent sandbox file as a Dify ToolFile mapping
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | comment_id | path | Comment ID | Yes | string |
 
 #### Responses
@@ -3080,7 +3079,7 @@ Upload one workflow Agent sandbox file as a Dify ToolFile mapping
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | comment_id | path | Comment ID | Yes | string |
 
 #### Responses
@@ -3096,7 +3095,7 @@ Upload one workflow Agent sandbox file as a Dify ToolFile mapping
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | comment_id | path | Comment ID | Yes | string |
 
 #### Request Body
@@ -3118,7 +3117,7 @@ Upload one workflow Agent sandbox file as a Dify ToolFile mapping
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | comment_id | path | Comment ID | Yes | string |
 
 #### Request Body
@@ -3140,7 +3139,7 @@ Upload one workflow Agent sandbox file as a Dify ToolFile mapping
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | comment_id | path | Comment ID | Yes | string |
 | reply_id | path | Reply ID | Yes | string |
 
@@ -3157,7 +3156,7 @@ Upload one workflow Agent sandbox file as a Dify ToolFile mapping
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | comment_id | path | Comment ID | Yes | string |
 | reply_id | path | Reply ID | Yes | string |
 
@@ -3180,7 +3179,7 @@ Upload one workflow Agent sandbox file as a Dify ToolFile mapping
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | comment_id | path | Comment ID | Yes | string |
 
 #### Responses
@@ -3196,7 +3195,7 @@ Get workflow average app interaction statistics
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | end | query | End date and time (YYYY-MM-DD HH:MM) | No | string |
 | start | query | Start date and time (YYYY-MM-DD HH:MM) | No | string |
 
@@ -3213,7 +3212,7 @@ Get workflow daily runs statistics
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | end | query | End date and time (YYYY-MM-DD HH:MM) | No | string |
 | start | query | Start date and time (YYYY-MM-DD HH:MM) | No | string |
 
@@ -3230,7 +3229,7 @@ Get workflow daily terminals statistics
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | end | query | End date and time (YYYY-MM-DD HH:MM) | No | string |
 | start | query | Start date and time (YYYY-MM-DD HH:MM) | No | string |
 
@@ -3247,7 +3246,7 @@ Get workflow daily token cost statistics
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | end | query | End date and time (YYYY-MM-DD HH:MM) | No | string |
 | start | query | Start date and time (YYYY-MM-DD HH:MM) | No | string |
 
@@ -3266,7 +3265,7 @@ Get all published workflows for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | limit | query |  | No | integer, <br>**Default:** 10 |
 | named_only | query |  | No | boolean |
 | page | query |  | No | integer, <br>**Default:** 1 |
@@ -3287,7 +3286,7 @@ Get default block configurations for workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -3304,7 +3303,7 @@ Get default block configuration by type
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | block_type | path | Block type | Yes | string |
 | q | query |  | No | string |
 
@@ -3324,7 +3323,7 @@ Get draft workflow for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -3342,7 +3341,7 @@ Sync draft workflow configuration
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -3365,7 +3364,7 @@ Get conversation variables for workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -3381,7 +3380,7 @@ Update conversation variables for workflow draft
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -3404,7 +3403,7 @@ Get environment variables for workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -3420,7 +3419,7 @@ Update environment variables for workflow draft
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -3441,7 +3440,7 @@ Update draft workflow features
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -3464,7 +3463,7 @@ Test human input delivery for workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | path | Node ID | Yes | string |
 
 #### Request Body
@@ -3488,7 +3487,7 @@ Get human input form preview for workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | path | Node ID | Yes | string |
 
 #### Request Body
@@ -3512,7 +3511,7 @@ Submit human input form preview for workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | path | Node ID | Yes | string |
 
 #### Request Body
@@ -3534,7 +3533,7 @@ Submit human input form preview for workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | path | Node ID | Yes | string |
 
 #### Request Body
@@ -3558,7 +3557,7 @@ Submit human input form preview for workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | path | Node ID | Yes | string |
 
 #### Request Body
@@ -3580,7 +3579,7 @@ Submit human input form preview for workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 | node_id | path |  | Yes | string |
 
 #### Responses
@@ -3594,7 +3593,7 @@ Submit human input form preview for workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 | node_id | path |  | Yes | string |
 
 #### Request Body
@@ -3614,7 +3613,7 @@ Submit human input form preview for workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 | node_id | path |  | Yes | string |
 
 #### Responses
@@ -3628,7 +3627,7 @@ Submit human input form preview for workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 | node_id | path |  | Yes | string |
 
 #### Request Body
@@ -3648,7 +3647,7 @@ Submit human input form preview for workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 | node_id | path |  | Yes | string |
 
 #### Request Body
@@ -3668,7 +3667,7 @@ Submit human input form preview for workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 | node_id | path |  | Yes | string |
 
 #### Request Body
@@ -3690,7 +3689,7 @@ Get last run result for draft workflow node
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | path | Node ID | Yes | string |
 
 #### Responses
@@ -3708,7 +3707,7 @@ Get last run result for draft workflow node
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | path | Node ID | Yes | string |
 
 #### Request Body
@@ -3732,7 +3731,7 @@ Get last run result for draft workflow node
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | path | Node ID | Yes | string |
 
 #### Responses
@@ -3750,7 +3749,7 @@ Delete all variables for a specific node
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 | node_id | path |  | Yes | string |
 
 #### Responses
@@ -3766,7 +3765,7 @@ Get variables for a specific node
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | path | Node ID | Yes | string |
 
 #### Responses
@@ -3782,7 +3781,7 @@ Get variables for a specific node
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -3804,8 +3803,8 @@ Snapshot of every node's declared outputs for a draft workflow run.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
-| run_id | path | Workflow run ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
+| run_id | path | Workflow run ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -3821,8 +3820,8 @@ Server-Sent Events stream of inspector deltas for a draft workflow run.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
-| run_id | path | Workflow run ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
+| run_id | path | Workflow run ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -3838,9 +3837,9 @@ One node's declared outputs for a draft workflow run.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | path | Node ID inside the workflow graph | Yes | string |
-| run_id | path | Workflow run ID | Yes | string |
+| run_id | path | Workflow run ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -3856,10 +3855,10 @@ Full value for one declared output, including signed download URL for files.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | path | Node ID inside the workflow graph | Yes | string |
 | output_name | path | Declared output name as exposed by Composer | Yes | string |
-| run_id | path | Workflow run ID | Yes | string |
+| run_id | path | Workflow run ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -3875,7 +3874,7 @@ Get system variables for workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -3890,7 +3889,7 @@ Get system variables for workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -3913,7 +3912,7 @@ Get system variables for workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -3936,7 +3935,7 @@ Delete all draft workflow variables
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -3953,7 +3952,7 @@ Get draft workflow variables
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | limit | query | Items per page | No | integer, <br>**Default:** 20 |
 | page | query | Page number | No | integer, <br>**Default:** 1 |
 
@@ -3970,8 +3969,8 @@ Delete a workflow variable
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
-| variable_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
+| variable_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -3987,8 +3986,8 @@ Get a specific workflow variable
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
-| variable_id | path | Variable ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
+| variable_id | path | Variable ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -4004,8 +4003,8 @@ Update a workflow variable
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
-| variable_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
+| variable_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -4027,8 +4026,8 @@ Reset a workflow variable to its default value
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
-| variable_id | path | Variable ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
+| variable_id | path | Variable ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -4047,7 +4046,7 @@ Get published workflow for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -4062,7 +4061,7 @@ Get published workflow for an application
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -4083,8 +4082,8 @@ Snapshot of every node's declared outputs for a published workflow run.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
-| run_id | path | Workflow run ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
+| run_id | path | Workflow run ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -4100,8 +4099,8 @@ Server-Sent Events stream of inspector deltas for a published workflow run.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
-| run_id | path | Workflow run ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
+| run_id | path | Workflow run ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -4117,9 +4116,9 @@ One node's declared outputs for a published workflow run.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | path | Node ID inside the workflow graph | Yes | string |
-| run_id | path | Workflow run ID | Yes | string |
+| run_id | path | Workflow run ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -4135,10 +4134,10 @@ Full value for one declared output of a published run.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | node_id | path | Node ID inside the workflow graph | Yes | string |
 | output_name | path | Declared output name as exposed by Composer | Yes | string |
-| run_id | path | Workflow run ID | Yes | string |
+| run_id | path | Workflow run ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -4155,7 +4154,7 @@ Full value for one declared output of a published run.
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | query |  | Yes | string |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -4170,7 +4169,7 @@ Full value for one declared output of a published run.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 | workflow_id | path |  | Yes | string |
 
 #### Responses
@@ -4188,7 +4187,7 @@ Update workflow by ID
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | workflow_id | path | Workflow ID | Yes | string |
 
 #### Request Body
@@ -4212,7 +4211,7 @@ Restore a published workflow version into the draft workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path | Application ID | Yes | string |
+| app_id | path | Application ID | Yes | string (uuid) |
 | workflow_id | path | Published workflow ID | Yes | string |
 
 #### Responses
@@ -4230,7 +4229,7 @@ Restore a published workflow version into the draft workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| resource_id | path | App ID | Yes | string |
+| resource_id | path | App ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -4245,7 +4244,7 @@ Restore a published workflow version into the draft workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| resource_id | path | App ID | Yes | string |
+| resource_id | path | App ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -4261,8 +4260,8 @@ Restore a published workflow version into the draft workflow
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| api_key_id | path | API key ID | Yes | string |
-| resource_id | path | App ID | Yes | string |
+| api_key_id | path | API key ID | Yes | string (uuid) |
+| resource_id | path | App ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -4277,7 +4276,7 @@ Refresh MCP server configuration and regenerate server code
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| server_id | path | Server ID | Yes | string |
+| server_id | path | Server ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -4534,7 +4533,7 @@ Get compliance document download link
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | action | path |  | Yes | string |
-| binding_id | path |  | Yes | string |
+| binding_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -4548,7 +4547,7 @@ Get compliance document download link
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | action | path |  | Yes | string |
-| binding_id | path |  | Yes | string |
+| binding_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -4625,7 +4624,7 @@ Delete dataset API key
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| api_key_id | path | API key ID | Yes | string |
+| api_key_id | path | API key ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -4638,7 +4637,7 @@ Delete dataset API key
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| job_id | path |  | Yes | string |
+| job_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -4651,7 +4650,7 @@ Delete dataset API key
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| job_id | path |  | Yes | string |
+| job_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -4717,7 +4716,7 @@ Get external knowledge API templates
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| external_knowledge_api_id | path |  | Yes | string |
+| external_knowledge_api_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -4732,7 +4731,7 @@ Get external knowledge API template details
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| external_knowledge_api_id | path | External knowledge API ID | Yes | string |
+| external_knowledge_api_id | path | External knowledge API ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -4746,7 +4745,7 @@ Get external knowledge API template details
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| external_knowledge_api_id | path |  | Yes | string |
+| external_knowledge_api_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -4767,7 +4766,7 @@ Check if external knowledge API is being used
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| external_knowledge_api_id | path | External knowledge API ID | Yes | string |
+| external_knowledge_api_id | path | External knowledge API ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -4870,7 +4869,7 @@ Get mock dataset retrieval settings by vector type
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -4885,7 +4884,7 @@ Get dataset details
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -4902,7 +4901,7 @@ Update dataset details
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -4923,7 +4922,7 @@ Update dataset details
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 | status | path |  | Yes | string |
 
 #### Responses
@@ -4939,7 +4938,7 @@ Get dataset auto disable logs
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -4954,7 +4953,7 @@ Get dataset auto disable logs
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | batch | path |  | Yes | string |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -4968,7 +4967,7 @@ Get dataset auto disable logs
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | batch | path |  | Yes | string |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -4981,7 +4980,7 @@ Get dataset auto disable logs
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -4996,7 +4995,7 @@ Get documents in a dataset
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 | fetch | query | Fetch full details (default: false) | No | string |
 | keyword | query | Search keyword | No | string |
 | limit | query | Number of items per page (default: 20) | No | string |
@@ -5015,7 +5014,7 @@ Get documents in a dataset
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -5038,7 +5037,7 @@ Download selected dataset documents as a single ZIP archive (upload-file only)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -5064,7 +5063,7 @@ then asynchronously generates summary indexes for the provided documents.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -5086,7 +5085,7 @@ then asynchronously generates summary indexes for the provided documents.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -5106,7 +5105,7 @@ then asynchronously generates summary indexes for the provided documents.
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | action | path |  | Yes | string |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -5119,8 +5118,8 @@ then asynchronously generates summary indexes for the provided documents.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
-| document_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
+| document_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -5135,8 +5134,8 @@ Get document details
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 | metadata | query | Metadata inclusion (all/only/without) | No | string |
 
 #### Responses
@@ -5153,8 +5152,8 @@ Get a signed download URL for a dataset document's original uploaded file
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
-| document_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
+| document_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -5169,8 +5168,8 @@ Estimate document indexing cost
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -5187,8 +5186,8 @@ Get document indexing status
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -5204,8 +5203,8 @@ Update document metadata
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -5226,8 +5225,8 @@ Update document metadata
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
-| document_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
+| document_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -5240,8 +5239,8 @@ Update document metadata
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
-| document_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
+| document_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -5256,8 +5255,8 @@ Update document metadata
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
-| document_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
+| document_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -5272,8 +5271,8 @@ Update document metadata
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
-| document_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
+| document_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -5289,8 +5288,8 @@ Update document processing status (pause/resume)
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | action | path | Action to perform (pause/resume) | Yes | string |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -5305,8 +5304,8 @@ Update document processing status (pause/resume)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
-| document_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
+| document_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -5325,8 +5324,8 @@ Update document processing status (pause/resume)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -5346,8 +5345,8 @@ Update document processing status (pause/resume)
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | action | path | Action | Yes | string |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 | segment_id | query | Segment IDs | No | [ string ] |
 
 #### Responses
@@ -5361,8 +5360,8 @@ Update document processing status (pause/resume)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 | segment_id | query | Segment IDs | No | [ string ] |
 
 #### Responses
@@ -5376,8 +5375,8 @@ Update document processing status (pause/resume)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 | enabled | query |  | No | string, <br>**Default:** all |
 | hit_count_gte | query |  | No | integer |
 | keyword | query |  | No | string |
@@ -5396,8 +5395,8 @@ Update document processing status (pause/resume)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
-| document_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
+| document_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -5410,8 +5409,8 @@ Update document processing status (pause/resume)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
-| document_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
+| document_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -5430,9 +5429,9 @@ Update document processing status (pause/resume)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
-| segment_id | path | Segment ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
+| segment_id | path | Segment ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -5445,9 +5444,9 @@ Update document processing status (pause/resume)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
-| segment_id | path | Segment ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
+| segment_id | path | Segment ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -5466,9 +5465,9 @@ Update document processing status (pause/resume)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
-| segment_id | path | Parent segment ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
+| segment_id | path | Parent segment ID | Yes | string (uuid) |
 | keyword | query |  | No | string |
 | limit | query |  | No | integer, <br>**Default:** 20 |
 | page | query |  | No | integer, <br>**Default:** 1 |
@@ -5484,9 +5483,9 @@ Update document processing status (pause/resume)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
-| segment_id | path | Parent segment ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
+| segment_id | path | Parent segment ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -5505,9 +5504,9 @@ Update document processing status (pause/resume)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
-| segment_id | path | Parent segment ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
+| segment_id | path | Parent segment ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -5526,10 +5525,10 @@ Update document processing status (pause/resume)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| child_chunk_id | path | Child chunk ID | Yes | string |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
-| segment_id | path | Parent segment ID | Yes | string |
+| child_chunk_id | path | Child chunk ID | Yes | string (uuid) |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
+| segment_id | path | Parent segment ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -5542,10 +5541,10 @@ Update document processing status (pause/resume)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| child_chunk_id | path | Child chunk ID | Yes | string |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
-| segment_id | path | Parent segment ID | Yes | string |
+| child_chunk_id | path | Child chunk ID | Yes | string (uuid) |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
+| segment_id | path | Parent segment ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -5576,8 +5575,8 @@ Returns:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -5593,8 +5592,8 @@ Returns:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
-| document_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
+| document_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -5609,7 +5608,7 @@ Get dataset error documents
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -5625,7 +5624,7 @@ Test external knowledge retrieval for dataset
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -5648,7 +5647,7 @@ Test dataset knowledge retrieval
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -5671,7 +5670,7 @@ Get dataset indexing status
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -5684,7 +5683,7 @@ Get dataset indexing status
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -5697,7 +5696,7 @@ Get dataset indexing status
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -5717,7 +5716,7 @@ Get dataset indexing status
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | action | path |  | Yes | string |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -5730,8 +5729,8 @@ Get dataset indexing status
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
-| metadata_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
+| metadata_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -5744,8 +5743,8 @@ Get dataset indexing status
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
-| metadata_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
+| metadata_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -5764,7 +5763,7 @@ Get dataset indexing status
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -5779,7 +5778,7 @@ Get dataset permission user list
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -5796,7 +5795,7 @@ Get dataset query history
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -5811,7 +5810,7 @@ Get applications related to dataset
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -5826,7 +5825,7 @@ Get applications related to dataset
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -5847,7 +5846,7 @@ Check if dataset is in use
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -5862,7 +5861,7 @@ Check if dataset is in use
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| resource_id | path | Dataset ID | Yes | string |
+| resource_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -5877,7 +5876,7 @@ Check if dataset is in use
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| resource_id | path | Dataset ID | Yes | string |
+| resource_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -5893,8 +5892,8 @@ Check if dataset is in use
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| api_key_id | path | API key ID | Yes | string |
-| resource_id | path | Dataset ID | Yes | string |
+| api_key_id | path | API key ID | Yes | string (uuid) |
+| resource_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -5998,7 +5997,7 @@ Check if dataset is in use
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -6050,7 +6049,7 @@ Check if dataset is in use
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| file_id | path |  | Yes | string |
+| file_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -6192,7 +6191,7 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| installed_app_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -6205,7 +6204,7 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| installed_app_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -6224,7 +6223,7 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| installed_app_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -6237,7 +6236,7 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| installed_app_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -6256,7 +6255,7 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| installed_app_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
 | task_id | path |  | Yes | string |
 
 #### Responses
@@ -6270,7 +6269,7 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| installed_app_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -6289,7 +6288,7 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| installed_app_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
 | task_id | path |  | Yes | string |
 
 #### Responses
@@ -6306,7 +6305,7 @@ Request body:
 | last_id | query |  | No | string |
 | limit | query |  | No | integer, <br>**Default:** 20 |
 | pinned | query |  | No | boolean |
-| installed_app_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -6319,8 +6318,8 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| c_id | path |  | Yes | string |
-| installed_app_id | path |  | Yes | string |
+| c_id | path |  | Yes | string (uuid) |
+| installed_app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -6333,8 +6332,8 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| c_id | path |  | Yes | string |
-| installed_app_id | path |  | Yes | string |
+| c_id | path |  | Yes | string (uuid) |
+| installed_app_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -6353,8 +6352,8 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| c_id | path |  | Yes | string |
-| installed_app_id | path |  | Yes | string |
+| c_id | path |  | Yes | string (uuid) |
+| installed_app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -6367,8 +6366,8 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| c_id | path |  | Yes | string |
-| installed_app_id | path |  | Yes | string |
+| c_id | path |  | Yes | string (uuid) |
+| installed_app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -6384,7 +6383,7 @@ Request body:
 | conversation_id | query | Conversation UUID | Yes | string |
 | first_id | query | First message ID for pagination | No | string |
 | limit | query | Number of messages to return (1-100) | No | integer, <br>**Default:** 20 |
-| installed_app_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -6397,8 +6396,8 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| installed_app_id | path |  | Yes | string |
-| message_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
+| message_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -6418,8 +6417,8 @@ Request body:
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | response_mode | query |  | Yes | string, <br>**Available values:** "blocking", "streaming" |
-| installed_app_id | path |  | Yes | string |
-| message_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
+| message_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -6432,8 +6431,8 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| installed_app_id | path |  | Yes | string |
-| message_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
+| message_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -6448,7 +6447,7 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| installed_app_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -6463,7 +6462,7 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| installed_app_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -6478,7 +6477,7 @@ Request body:
 | ---- | ---------- | ----------- | -------- | ------ |
 | last_id | query |  | No | string |
 | limit | query |  | No | integer, <br>**Default:** 20 |
-| installed_app_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -6491,7 +6490,7 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| installed_app_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -6510,8 +6509,8 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| installed_app_id | path |  | Yes | string |
-| message_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
+| message_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -6524,7 +6523,7 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| installed_app_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -6545,7 +6544,7 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| installed_app_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -6566,7 +6565,7 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| installed_app_id | path |  | Yes | string |
+| installed_app_id | path |  | Yes | string (uuid) |
 | task_id | path |  | Yes | string |
 
 #### Responses
@@ -6676,7 +6675,7 @@ Mark a notification as dismissed for the current user.
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | credential_id | query | Credential ID | Yes | string |
-| page_id | path |  | Yes | string |
+| page_id | path |  | Yes | string (uuid) |
 | page_type | path |  | Yes | string |
 
 #### Responses
@@ -6776,7 +6775,7 @@ Sync data from OAuth data source
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| binding_id | path | Data source binding ID | Yes | string |
+| binding_id | path | Data source binding ID | Yes | string (uuid) |
 | provider | path | Data source provider name (notion) | Yes | string |
 
 #### Responses
@@ -7089,7 +7088,7 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7139,7 +7138,7 @@ Initiate OAuth login process
 | ---- | ---------- | ----------- | -------- | ------ |
 | last_id | query |  | No | string |
 | limit | query |  | No | integer, <br>**Default:** 20 |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7154,7 +7153,7 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 | task_id | path |  | Yes | string |
 
 #### Responses
@@ -7170,8 +7169,8 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
-| run_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
+| run_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7186,8 +7185,8 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
-| run_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
+| run_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7206,7 +7205,7 @@ Initiate OAuth login process
 | named_only | query |  | No | boolean |
 | page | query |  | No | integer, <br>**Default:** 1 |
 | user_id | query |  | No | string |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7222,7 +7221,7 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7239,7 +7238,7 @@ Initiate OAuth login process
 | ---- | ---------- | ----------- | -------- | ------ |
 | q | query |  | No | string |
 | block_type | path |  | Yes | string |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7254,7 +7253,7 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7270,7 +7269,7 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -7292,7 +7291,7 @@ Initiate OAuth login process
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | path |  | Yes | string |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -7313,7 +7312,7 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -7334,7 +7333,7 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7350,7 +7349,7 @@ Initiate OAuth login process
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | path |  | Yes | string |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -7372,7 +7371,7 @@ Initiate OAuth login process
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | path |  | Yes | string |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -7392,7 +7391,7 @@ Initiate OAuth login process
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | path |  | Yes | string |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7408,7 +7407,7 @@ Initiate OAuth login process
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | path |  | Yes | string |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -7428,7 +7427,7 @@ Initiate OAuth login process
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | path |  | Yes | string |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7442,7 +7441,7 @@ Initiate OAuth login process
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | path |  | Yes | string |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7458,7 +7457,7 @@ Initiate OAuth login process
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | query |  | Yes | string |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7474,7 +7473,7 @@ Initiate OAuth login process
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | query |  | Yes | string |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7489,7 +7488,7 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -7508,7 +7507,7 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7521,7 +7520,7 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7538,7 +7537,7 @@ Initiate OAuth login process
 | ---- | ---------- | ----------- | -------- | ------ |
 | limit | query |  | No | integer, <br>**Default:** 20 |
 | page | query |  | No | integer, <br>**Default:** 1 |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7551,8 +7550,8 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
-| variable_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
+| variable_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7565,8 +7564,8 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
-| variable_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
+| variable_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7579,8 +7578,8 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
-| variable_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
+| variable_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -7599,8 +7598,8 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
-| variable_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
+| variable_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7616,7 +7615,7 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7631,7 +7630,7 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7647,7 +7646,7 @@ Initiate OAuth login process
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | path |  | Yes | string |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -7669,7 +7668,7 @@ Initiate OAuth login process
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | path |  | Yes | string |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -7691,7 +7690,7 @@ Initiate OAuth login process
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | query |  | Yes | string |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7707,7 +7706,7 @@ Initiate OAuth login process
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | query |  | Yes | string |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7722,7 +7721,7 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -7743,7 +7742,7 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 | workflow_id | path |  | Yes | string |
 
 #### Responses
@@ -7759,7 +7758,7 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 | workflow_id | path |  | Yes | string |
 
 #### Request Body
@@ -7782,7 +7781,7 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| pipeline_id | path |  | Yes | string |
+| pipeline_id | path |  | Yes | string (uuid) |
 | workflow_id | path |  | Yes | string |
 
 #### Responses
@@ -7897,7 +7896,7 @@ Generate structured output rules using LLM
 | ---- | ---------- | ----------- | -------- | ------ |
 | last_id | query |  | No | string |
 | limit | query |  | No | integer, <br>**Default:** 20 |
-| snippet_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7915,7 +7914,7 @@ command channel for backward compatibility.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
 | task_id | path |  | Yes | string |
 
 #### Responses
@@ -7932,8 +7931,8 @@ command channel for backward compatibility.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| run_id | path |  | Yes | string |
-| snippet_id | path |  | Yes | string |
+| run_id | path |  | Yes | string (uuid) |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7949,8 +7948,8 @@ command channel for backward compatibility.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| run_id | path |  | Yes | string |
-| snippet_id | path |  | Yes | string |
+| run_id | path |  | Yes | string (uuid) |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7967,7 +7966,7 @@ Get all published workflows for a snippet
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path | Snippet ID | Yes | string |
+| snippet_id | path | Snippet ID | Yes | string (uuid) |
 | limit | query |  | No | integer, <br>**Default:** 10 |
 | page | query |  | No | integer, <br>**Default:** 1 |
 
@@ -7984,7 +7983,7 @@ Get all published workflows for a snippet
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -7999,7 +7998,7 @@ Get all published workflows for a snippet
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8015,7 +8014,7 @@ Get all published workflows for a snippet
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -8037,7 +8036,7 @@ Get all published workflows for a snippet
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8052,7 +8051,7 @@ Conversation variables are not used in snippet workflows; returns an empty list 
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8067,7 +8066,7 @@ Get environment variables from snippet draft workflow graph
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8088,7 +8087,7 @@ Returns an SSE event stream with iteration progress and results.
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | path | Node ID | Yes | string |
-| snippet_id | path | Snippet ID | Yes | string |
+| snippet_id | path | Snippet ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -8115,7 +8114,7 @@ Returns an SSE event stream with loop progress and results.
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | path | Node ID | Yes | string |
-| snippet_id | path | Snippet ID | Yes | string |
+| snippet_id | path | Snippet ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -8142,7 +8141,7 @@ including status, inputs, outputs, and timing information.
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | path | Node ID | Yes | string |
-| snippet_id | path | Snippet ID | Yes | string |
+| snippet_id | path | Snippet ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -8163,7 +8162,7 @@ Returns the node execution result including status, outputs, and timing.
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | path | Node ID | Yes | string |
-| snippet_id | path | Snippet ID | Yes | string |
+| snippet_id | path | Snippet ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -8186,7 +8185,7 @@ Delete all variables for a specific node (snippet draft workflow)
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | path |  | Yes | string |
-| snippet_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8202,7 +8201,7 @@ Get variables for a specific node (snippet draft workflow)
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | node_id | path |  | Yes | string |
-| snippet_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8220,7 +8219,7 @@ and returns an SSE event stream with execution progress and results.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -8242,7 +8241,7 @@ System variables are not used in snippet workflows; returns an empty list for AP
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8257,7 +8256,7 @@ Delete all draft workflow variables for the current user (snippet scope)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8274,7 +8273,7 @@ List draft workflow variables without values (paginated, snippet scope)
 | ---- | ---------- | ----------- | -------- | ------ |
 | limit | query | Items per page | No | integer, <br>**Default:** 20 |
 | page | query | Page number | No | integer, <br>**Default:** 1 |
-| snippet_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8289,8 +8288,8 @@ Delete a draft workflow variable (snippet scope)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path |  | Yes | string |
-| variable_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
+| variable_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8306,8 +8305,8 @@ Get a specific draft workflow variable (snippet scope)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path |  | Yes | string |
-| variable_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
+| variable_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8323,8 +8322,8 @@ Update a draft workflow variable (snippet scope)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path |  | Yes | string |
-| variable_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
+| variable_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -8346,8 +8345,8 @@ Reset a draft workflow variable to its default value (snippet scope)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path |  | Yes | string |
-| variable_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
+| variable_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8364,7 +8363,7 @@ Reset a draft workflow variable to its default value (snippet scope)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8380,7 +8379,7 @@ Reset a draft workflow variable to its default value (snippet scope)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -8402,7 +8401,7 @@ Reset a draft workflow variable to its default value (snippet scope)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path | Snippet ID | Yes | string |
+| snippet_id | path | Snippet ID | Yes | string (uuid) |
 | workflow_id | path | Published workflow ID | Yes | string |
 
 #### Responses
@@ -8501,7 +8500,7 @@ Remove one or more tag bindings from a target.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| tag_id | path |  | Yes | string |
+| tag_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8514,7 +8513,7 @@ Remove one or more tag bindings from a target.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| tag_id | path |  | Yes | string |
+| tag_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -8550,7 +8549,7 @@ Bedrock retrieval test (internal use only)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8563,7 +8562,7 @@ Bedrock retrieval test (internal use only)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8576,7 +8575,7 @@ Bedrock retrieval test (internal use only)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -8595,7 +8594,7 @@ Bedrock retrieval test (internal use only)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -8617,7 +8616,7 @@ Bedrock retrieval test (internal use only)
 | ids | query | Dataset IDs | No | [ string ] |
 | limit | query | Number of items per page | No | integer, <br>**Default:** 20 |
 | page | query | Page number | No | integer, <br>**Default:** 1 |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8630,8 +8629,8 @@ Bedrock retrieval test (internal use only)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
-| message_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
+| message_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8646,7 +8645,7 @@ Bedrock retrieval test (internal use only)
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8663,7 +8662,7 @@ Returns the site configuration for the application including theme, icons, and t
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8676,7 +8675,7 @@ Returns the site configuration for the application including theme, icons, and t
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -8697,7 +8696,7 @@ Returns the site configuration for the application including theme, icons, and t
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8712,7 +8711,7 @@ Returns the site configuration for the application including theme, icons, and t
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -8733,7 +8732,7 @@ Returns the site configuration for the application including theme, icons, and t
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| app_id | path |  | Yes | string |
+| app_id | path |  | Yes | string (uuid) |
 | task_id | path |  | Yes | string |
 
 #### Responses
@@ -8958,7 +8957,7 @@ Get list of available agent providers
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8974,7 +8973,7 @@ Get list of available agent providers
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -8990,7 +8989,7 @@ Get list of available agent providers
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path |  | Yes | string |
+| snippet_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -9013,7 +9012,7 @@ Get list of available agent providers
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path | Snippet ID | Yes | string |
+| snippet_id | path | Snippet ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -9031,7 +9030,7 @@ Export snippet configuration as DSL
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path | Snippet ID to export | Yes | string |
+| snippet_id | path | Snippet ID to export | Yes | string (uuid) |
 | include_secret | query | Whether to include secret variables | No | string, <br>**Default:** false |
 
 #### Responses
@@ -9050,7 +9049,7 @@ Increment snippet use count by 1
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| snippet_id | path | Snippet ID | Yes | string |
+| snippet_id | path | Snippet ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -9319,7 +9318,7 @@ Update a plugin endpoint
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| member_id | path |  | Yes | string |
+| member_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -9332,7 +9331,7 @@ Update a plugin endpoint
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| member_id | path |  | Yes | string |
+| member_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -9351,7 +9350,7 @@ Update a plugin endpoint
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| member_id | path |  | Yes | string |
+| member_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -5,7 +5,7 @@ Console management APIs for app configuration, monitoring, and administration
 
 ### Available authorizations
 #### Bearer (HTTP, bearer)
-Use the Service API key as a Bearer token in the Authorization header.  
+Use the Service API key as a Bearer token in the Authorization header.
 Bearer format: API_KEY
 
 ---

--- a/api/openapi/markdown/openapi-openapi.md
+++ b/api/openapi/markdown/openapi-openapi.md
@@ -4,10 +4,9 @@ User-scoped programmatic API (bearer auth)
 ## Version: 1.0
 
 ### Available authorizations
-#### Bearer (API Key Authentication)
-Type: Bearer {your-api-key}  
-**Name:** Authorization  
-**In:** header  
+#### Bearer (HTTP, bearer)
+Use the Service API key as a Bearer token in the Authorization header.  
+Bearer format: API_KEY
 
 ---
 ## openapi

--- a/api/openapi/markdown/openapi-openapi.md
+++ b/api/openapi/markdown/openapi-openapi.md
@@ -5,7 +5,7 @@ User-scoped programmatic API (bearer auth)
 
 ### Available authorizations
 #### Bearer (HTTP, bearer)
-Use the Service API key as a Bearer token in the Authorization header.  
+Use the Service API key as a Bearer token in the Authorization header.
 Bearer format: API_KEY
 
 ---

--- a/api/openapi/markdown/service-openapi.md
+++ b/api/openapi/markdown/service-openapi.md
@@ -47,7 +47,7 @@ Returns paginated list of all feedback submitted for messages in this app.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| action | path | Action to perform: 'enable' or 'disable' | Yes | string |
+| action | path | Action to perform: 'enable' or 'disable' | Yes | string, <br>**Available values:** "disable", "enable" |
 
 #### Request Body
 
@@ -838,7 +838,7 @@ Raises:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| action | path | Action to perform: 'enable', 'disable', 'archive', or 'un_archive' | Yes | string |
+| action | path | Action to perform: 'enable', 'disable', 'archive', or 'un_archive' | Yes | string, <br>**Available values:** "archive", "disable", "enable", "un_archive" |
 | dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Request Body
@@ -1375,7 +1375,7 @@ Tests retrieval performance for the specified dataset.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| action | path | Action to perform: 'enable' or 'disable' | Yes | string |
+| action | path | Action to perform: 'enable' or 'disable' | Yes | string, <br>**Available values:** "disable", "enable" |
 | dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Responses

--- a/api/openapi/markdown/service-openapi.md
+++ b/api/openapi/markdown/service-openapi.md
@@ -4,10 +4,9 @@ API for application services
 ## Version: 1.0
 
 ### Available authorizations
-#### Bearer (API Key Authentication)
-Type: Bearer {your-api-key}  
-**Name:** Authorization  
-**In:** header  
+#### Bearer (HTTP, bearer)
+Use the Service API key as a Bearer token in the Authorization header.  
+Bearer format: API_KEY
 
 ---
 ## service_api
@@ -39,6 +38,7 @@ Returns paginated list of all feedback submitted for messages in this app.
 | ---- | ----------- | ------ |
 | 200 | Feedbacks retrieved successfully | **application/json**: [AppFeedbackListResponse](#appfeedbacklistresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 
 ### [POST] /apps/annotation-reply/{action}
 **Enable or disable annotation reply feature**
@@ -61,6 +61,7 @@ Returns paginated list of all feedback submitted for messages in this app.
 | ---- | ----------- | ------ |
 | 200 | Action completed successfully | **application/json**: [AnnotationJobStatusResponse](#annotationjobstatusresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 
 ### [GET] /apps/annotation-reply/{action}/status/{job_id}
 **Get the status of an annotation reply action job**
@@ -70,7 +71,7 @@ Returns paginated list of all feedback submitted for messages in this app.
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | action | path | Action type | Yes | string |
-| job_id | path | Job ID | Yes | string |
+| job_id | path | Job ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -78,6 +79,7 @@ Returns paginated list of all feedback submitted for messages in this app.
 | ---- | ----------- | ------ |
 | 200 | Job status retrieved successfully | **application/json**: [AnnotationJobStatusResponse](#annotationjobstatusresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Job not found |  |
 
 ### [GET] /apps/annotations
@@ -97,6 +99,7 @@ Returns paginated list of all feedback submitted for messages in this app.
 | ---- | ----------- | ------ |
 | 200 | Annotations retrieved successfully | **application/json**: [AnnotationList](#annotationlist)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 
 ### [POST] /apps/annotations
 **Create a new annotation**
@@ -113,6 +116,7 @@ Returns paginated list of all feedback submitted for messages in this app.
 | ---- | ----------- | ------ |
 | 201 | Annotation created successfully | **application/json**: [Annotation](#annotation)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 
 ### [DELETE] /apps/annotations/{annotation_id}
 **Delete an annotation**
@@ -121,7 +125,7 @@ Returns paginated list of all feedback submitted for messages in this app.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| annotation_id | path | Annotation ID | Yes | string |
+| annotation_id | path | Annotation ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -139,7 +143,7 @@ Returns paginated list of all feedback submitted for messages in this app.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| annotation_id | path | Annotation ID | Yes | string |
+| annotation_id | path | Annotation ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -162,6 +166,12 @@ Returns paginated list of all feedback submitted for messages in this app.
 Convert audio to text using speech-to-text
 Accepts an audio file upload and returns the transcribed text.
 
+#### Request Body
+
+| Required | Schema |
+| -------- | ------ |
+|  Yes | **multipart/form-data**: { **"file"**: binary, **"user"**: string }<br> |
+
 #### Responses
 
 | Code | Description | Schema |
@@ -169,6 +179,7 @@ Accepts an audio file upload and returns the transcribed text.
 | 200 | Audio successfully transcribed | **application/json**: [AudioTranscriptResponse](#audiotranscriptresponse)<br> |
 | 400 | Bad request - no audio or invalid audio |  |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 413 | Audio file too large |  |
 | 415 | Unsupported audio type |  |
 | 500 | Internal server error |  |
@@ -184,15 +195,16 @@ Supports conversation management and both blocking and streaming response modes.
 
 | Required | Schema |
 | -------- | ------ |
-|  Yes | **application/json**: [ChatRequestPayload](#chatrequestpayload)<br> |
+|  Yes | **application/json**: [ChatRequestPayloadWithUser](#chatrequestpayloadwithuser)<br> |
 
 #### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Message sent successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 200 | Message sent successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br>**text/event-stream**: [GeneratedAppResponse](#generatedappresponse)<br> |
 | 400 | Bad request - invalid parameters or workflow issues |  |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Conversation or workflow not found |  |
 | 429 | Rate limit exceeded |  |
 | 500 | Internal server error |  |
@@ -206,12 +218,19 @@ Supports conversation management and both blocking and streaming response modes.
 | ---- | ---------- | ----------- | -------- | ------ |
 | task_id | path | The ID of the task to stop | Yes | string |
 
+#### Request Body
+
+| Required | Schema |
+| -------- | ------ |
+|  Yes | **application/json**: [RequiredServiceApiUserPayload](#requiredserviceapiuserpayload)<br> |
+
 #### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
 | 200 | Task stopped successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Task not found |  |
 
 ### [POST] /completion-messages
@@ -225,15 +244,16 @@ Supports both blocking and streaming response modes.
 
 | Required | Schema |
 | -------- | ------ |
-|  Yes | **application/json**: [CompletionRequestPayload](#completionrequestpayload)<br> |
+|  Yes | **application/json**: [CompletionRequestPayloadWithUser](#completionrequestpayloadwithuser)<br> |
 
 #### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Completion created successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 200 | Completion created successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br>**text/event-stream**: [GeneratedAppResponse](#generatedappresponse)<br> |
 | 400 | Bad request - invalid parameters |  |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Conversation not found |  |
 | 500 | Internal server error |  |
 
@@ -246,12 +266,19 @@ Supports both blocking and streaming response modes.
 | ---- | ---------- | ----------- | -------- | ------ |
 | task_id | path | The ID of the task to stop | Yes | string |
 
+#### Request Body
+
+| Required | Schema |
+| -------- | ------ |
+|  Yes | **application/json**: [RequiredServiceApiUserPayload](#requiredserviceapiuserpayload)<br> |
+
 #### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
 | 200 | Task stopped successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Task not found |  |
 
 ### [GET] /conversations
@@ -267,6 +294,7 @@ Supports pagination using last_id and limit parameters.
 | last_id | query | Last conversation ID for pagination | No | string |
 | limit | query | Number of conversations to return | No | integer, <br>**Default:** 20 |
 | sort_by | query | Sort order for conversations | No | string, <br>**Available values:** "-created_at", "-updated_at", "created_at", "updated_at", <br>**Default:** -updated_at |
+| user | query | End user identifier | No | string |
 
 #### Responses
 
@@ -274,6 +302,7 @@ Supports pagination using last_id and limit parameters.
 | ---- | ----------- | ------ |
 | 200 | Conversations retrieved successfully | **application/json**: [ConversationInfiniteScrollPagination](#conversationinfinitescrollpagination)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Last conversation not found |  |
 
 ### [DELETE] /conversations/{c_id}
@@ -283,7 +312,13 @@ Supports pagination using last_id and limit parameters.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| c_id | path | Conversation ID | Yes | string |
+| c_id | path | Conversation ID | Yes | string (uuid) |
+
+#### Request Body
+
+| Required | Schema |
+| -------- | ------ |
+|  Yes | **application/json**: [OptionalServiceApiUserPayload](#optionalserviceapiuserpayload)<br> |
 
 #### Responses
 
@@ -291,6 +326,7 @@ Supports pagination using last_id and limit parameters.
 | ---- | ----------- |
 | 204 | Conversation deleted successfully |
 | 401 | Unauthorized - invalid API token |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |
 | 404 | Conversation not found |
 
 ### [POST] /conversations/{c_id}/name
@@ -300,13 +336,13 @@ Supports pagination using last_id and limit parameters.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| c_id | path | Conversation ID | Yes | string |
+| c_id | path | Conversation ID | Yes | string (uuid) |
 
 #### Request Body
 
 | Required | Schema |
 | -------- | ------ |
-|  Yes | **application/json**: [ConversationRenamePayload](#conversationrenamepayload)<br> |
+|  Yes | **application/json**: [ConversationRenamePayloadWithUser](#conversationrenamepayloadwithuser)<br> |
 
 #### Responses
 
@@ -314,6 +350,7 @@ Supports pagination using last_id and limit parameters.
 | ---- | ----------- | ------ |
 | 200 | Conversation renamed successfully | **application/json**: [SimpleConversation](#simpleconversation)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Conversation not found |  |
 
 ### [GET] /conversations/{c_id}/variables
@@ -326,9 +363,10 @@ Conversational variables are only available for chat applications.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| c_id | path | Conversation ID | Yes | string |
+| c_id | path | Conversation ID | Yes | string (uuid) |
 | last_id | query | Last variable ID for pagination | No | string |
 | limit | query | Number of variables to return | No | integer, <br>**Default:** 20 |
+| user | query | End user identifier | No | string |
 | variable_name | query | Filter variables by name | No | string |
 
 #### Responses
@@ -337,6 +375,7 @@ Conversational variables are only available for chat applications.
 | ---- | ----------- | ------ |
 | 200 | Variables retrieved successfully | **application/json**: [ConversationVariableInfiniteScrollPaginationResponse](#conversationvariableinfinitescrollpaginationresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Conversation not found |  |
 
 ### [PUT] /conversations/{c_id}/variables/{variable_id}
@@ -350,14 +389,14 @@ The value must match the variable's expected type.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| c_id | path | Conversation ID | Yes | string |
-| variable_id | path | Variable ID | Yes | string |
+| c_id | path | Conversation ID | Yes | string (uuid) |
+| variable_id | path | Variable ID | Yes | string (uuid) |
 
 #### Request Body
 
 | Required | Schema |
 | -------- | ------ |
-|  Yes | **application/json**: [ConversationVariableUpdatePayload](#conversationvariableupdatepayload)<br> |
+|  Yes | **application/json**: [ConversationVariableUpdatePayloadWithUser](#conversationvariableupdatepayloadwithuser)<br> |
 
 #### Responses
 
@@ -366,6 +405,7 @@ The value must match the variable's expected type.
 | 200 | Variable updated successfully | **application/json**: [ConversationVariableResponse](#conversationvariableresponse)<br> |
 | 400 | Bad request - type mismatch |  |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Conversation or variable not found |  |
 
 ### [GET] /datasets
@@ -389,6 +429,7 @@ List all datasets
 | ---- | ----------- | ------ |
 | 200 | Datasets retrieved successfully | **application/json**: [DatasetListResponse](#datasetlistresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 
 ### [POST] /datasets
 **Resource for creating datasets**
@@ -408,12 +449,19 @@ Create a new dataset
 | 200 | Dataset created successfully | **application/json**: [DatasetDetailResponse](#datasetdetailresponse)<br> |
 | 400 | Bad request - invalid parameters |  |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 
 ### [POST] /datasets/pipeline/file-upload
 **Upload a file for use in conversations**
 
 Upload a file to a knowledgebase pipeline
 Accepts a single file upload via multipart/form-data.
+
+#### Request Body
+
+| Required | Schema |
+| -------- | ------ |
+|  Yes | **multipart/form-data**: { **"file"**: binary }<br> |
 
 #### Responses
 
@@ -422,6 +470,7 @@ Accepts a single file upload via multipart/form-data.
 | 201 | File uploaded successfully | **application/json**: [PipelineUploadFileResponse](#pipelineuploadfileresponse)<br> |
 | 400 | Bad request - no file or invalid file |  |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 413 | File too large |  |
 | 415 | Unsupported file type |  |
 
@@ -451,6 +500,7 @@ Accepts a single file upload via multipart/form-data.
 | ---- | ----------- | ------ |
 | 200 | Tags retrieved successfully | **application/json**: [KnowledgeTagListResponse](#knowledgetaglistresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 
 ### [PATCH] /datasets/tags
 Update a knowledge type tag
@@ -540,7 +590,7 @@ Raises:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -548,6 +598,7 @@ Raises:
 | ---- | ----------- |
 | 204 | Dataset deleted successfully |
 | 401 | Unauthorized - invalid API token |
+| 403 | Forbidden - dataset API access or workspace access denied |
 | 404 | Dataset not found |
 | 409 | Conflict - dataset is in use |
 
@@ -558,7 +609,7 @@ Get a specific dataset by ID
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -576,7 +627,7 @@ Update an existing dataset
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -600,7 +651,7 @@ Create a new document by uploading a file
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -615,6 +666,7 @@ Create a new document by uploading a file
 | 200 | Document created successfully | **application/json**: [DocumentAndBatchResponse](#documentandbatchresponse)<br> |
 | 400 | Bad request - invalid file or parameters |  |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 
 ### [POST] /datasets/{dataset_id}/document/create-by-text
 Create a new document by providing text content
@@ -623,7 +675,7 @@ Create a new document by providing text content
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -638,15 +690,19 @@ Create a new document by providing text content
 | 200 | Document created successfully | **application/json**: [DocumentAndBatchResponse](#documentandbatchresponse)<br> |
 | 400 | Bad request - invalid parameters |  |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 
-### [POST] /datasets/{dataset_id}/document/create_by_file
+### ~~[POST] /datasets/{dataset_id}/document/create_by_file~~
+
+***DEPRECATED***
+
 Create a new document by uploading a file
 
 #### Parameters
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -661,6 +717,7 @@ Create a new document by uploading a file
 | 200 | Document created successfully | **application/json**: [DocumentAndBatchResponse](#documentandbatchresponse)<br> |
 | 400 | Bad request - invalid file or parameters |  |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 
 ### ~~[POST] /datasets/{dataset_id}/document/create_by_text~~
 
@@ -672,7 +729,7 @@ Deprecated legacy alias for creating a new document by providing text content. U
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -687,6 +744,7 @@ Deprecated legacy alias for creating a new document by providing text content. U
 | 200 | Document created successfully | **application/json**: [DocumentAndBatchResponse](#documentandbatchresponse)<br> |
 | 400 | Bad request - invalid parameters |  |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 
 ### [GET] /datasets/{dataset_id}/documents
 List all documents in a dataset
@@ -695,7 +753,7 @@ List all documents in a dataset
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 | keyword | query | Search keyword | No | string |
 | limit | query | Number of items per page | No | integer, <br>**Default:** 20 |
 | page | query | Page number | No | integer, <br>**Default:** 1 |
@@ -707,6 +765,7 @@ List all documents in a dataset
 | ---- | ----------- | ------ |
 | 200 | Documents retrieved successfully | **application/json**: [DocumentListResponse](#documentlistresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Dataset not found |  |
 
 ### [POST] /datasets/{dataset_id}/documents/download-zip
@@ -716,7 +775,7 @@ Download selected uploaded documents as a single ZIP archive
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -726,12 +785,12 @@ Download selected uploaded documents as a single ZIP archive
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | ZIP archive generated successfully | **application/json**: [BinaryFileResponse](#binaryfileresponse)<br> |
-| 401 | Unauthorized - invalid API token |  |
-| 403 | Forbidden - insufficient permissions |  |
-| 404 | Document or dataset not found |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | ZIP archive generated successfully |
+| 401 | Unauthorized - invalid API token |
+| 403 | Forbidden - insufficient permissions |
+| 404 | Document or dataset not found |
 
 ### [POST] /datasets/{dataset_id}/documents/metadata
 **Update metadata for multiple documents**
@@ -740,7 +799,7 @@ Download selected uploaded documents as a single ZIP archive
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -754,6 +813,7 @@ Download selected uploaded documents as a single ZIP archive
 | ---- | ----------- | ------ |
 | 200 | Documents metadata updated successfully | **application/json**: [DatasetMetadataActionResponse](#datasetmetadataactionresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Dataset not found |  |
 
 ### [PATCH] /datasets/{dataset_id}/documents/status/{action}
@@ -779,7 +839,7 @@ Raises:
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | action | path | Action to perform: 'enable', 'disable', 'archive', or 'un_archive' | Yes | string |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -805,7 +865,7 @@ Get indexing status for documents in a batch
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | batch | path | Batch ID | Yes | string |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -813,6 +873,7 @@ Get indexing status for documents in a batch
 | ---- | ----------- | ------ |
 | 200 | Indexing status retrieved successfully | **application/json**: [DocumentStatusListResponse](#documentstatuslistresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Dataset or documents not found |  |
 
 ### [DELETE] /datasets/{dataset_id}/documents/{document_id}
@@ -824,8 +885,8 @@ Delete a document
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -843,8 +904,8 @@ Get a specific document by ID
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 | metadata | query | Metadata response mode | No | string, <br>**Available values:** "all", "only", "without", <br>**Default:** all |
 
 #### Responses
@@ -863,8 +924,8 @@ Update an existing document by uploading a file
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -878,6 +939,7 @@ Update an existing document by uploading a file
 | ---- | ----------- | ------ |
 | 200 | Document updated successfully | **application/json**: [DocumentAndBatchResponse](#documentandbatchresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Document not found |  |
 
 ### [GET] /datasets/{dataset_id}/documents/{document_id}/download
@@ -887,8 +949,8 @@ Get a signed download URL for a document's original uploaded file
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -906,8 +968,8 @@ List segments in a document
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 | keyword | query |  | No | string |
 | limit | query |  | No | integer, <br>**Default:** 20 |
 | page | query |  | No | integer, <br>**Default:** 1 |
@@ -919,6 +981,7 @@ List segments in a document
 | ---- | ----------- | ------ |
 | 200 | Segments retrieved successfully | **application/json**: [SegmentListResponse](#segmentlistresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Dataset or document not found |  |
 
 ### [POST] /datasets/{dataset_id}/documents/{document_id}/segments
@@ -928,8 +991,8 @@ Create segments in a document
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -944,6 +1007,7 @@ Create segments in a document
 | 200 | Segments created successfully | **application/json**: [SegmentCreateListResponse](#segmentcreatelistresponse)<br> |
 | 400 | Bad request - segments data is missing |  |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Dataset or document not found |  |
 
 ### [DELETE] /datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}
@@ -953,9 +1017,9 @@ Delete a specific segment
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
-| segment_id | path | Segment ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
+| segment_id | path | Segment ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -963,6 +1027,7 @@ Delete a specific segment
 | ---- | ----------- |
 | 204 | Segment deleted successfully |
 | 401 | Unauthorized - invalid API token |
+| 403 | Forbidden - dataset API access or workspace access denied |
 | 404 | Dataset, document, or segment not found |
 
 ### [GET] /datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}
@@ -972,9 +1037,9 @@ Get a specific segment by ID
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
-| segment_id | path | Segment ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
+| segment_id | path | Segment ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -982,6 +1047,7 @@ Get a specific segment by ID
 | ---- | ----------- | ------ |
 | 200 | Segment retrieved successfully | **application/json**: [SegmentDetailResponse](#segmentdetailresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Dataset, document, or segment not found |  |
 
 ### [POST] /datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}
@@ -991,9 +1057,9 @@ Update a specific segment
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
-| segment_id | path | Segment ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
+| segment_id | path | Segment ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -1007,6 +1073,7 @@ Update a specific segment
 | ---- | ----------- | ------ |
 | 200 | Segment updated successfully | **application/json**: [SegmentDetailResponse](#segmentdetailresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Dataset, document, or segment not found |  |
 
 ### [GET] /datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks
@@ -1016,9 +1083,9 @@ List child chunks for a segment
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
-| segment_id | path | Parent segment ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
+| segment_id | path | Parent segment ID | Yes | string (uuid) |
 | keyword | query |  | No | string |
 | limit | query |  | No | integer, <br>**Default:** 20 |
 | page | query |  | No | integer, <br>**Default:** 1 |
@@ -1029,6 +1096,7 @@ List child chunks for a segment
 | ---- | ----------- | ------ |
 | 200 | Child chunks retrieved successfully | **application/json**: [ChildChunkListResponse](#childchunklistresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Dataset, document, or segment not found |  |
 
 ### [POST] /datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks
@@ -1038,9 +1106,9 @@ Create a new child chunk for a segment
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
-| segment_id | path | Parent segment ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
+| segment_id | path | Parent segment ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -1054,6 +1122,7 @@ Create a new child chunk for a segment
 | ---- | ----------- | ------ |
 | 200 | Child chunk created successfully | **application/json**: [ChildChunkDetailResponse](#childchunkdetailresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Dataset, document, or segment not found |  |
 
 ### [DELETE] /datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks/{child_chunk_id}
@@ -1063,10 +1132,10 @@ Delete a specific child chunk
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| child_chunk_id | path | Child chunk ID | Yes | string |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
-| segment_id | path | Parent segment ID | Yes | string |
+| child_chunk_id | path | Child chunk ID | Yes | string (uuid) |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
+| segment_id | path | Parent segment ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -1074,6 +1143,7 @@ Delete a specific child chunk
 | ---- | ----------- |
 | 204 | Child chunk deleted successfully |
 | 401 | Unauthorized - invalid API token |
+| 403 | Forbidden - dataset API access or workspace access denied |
 | 404 | Dataset, document, segment, or child chunk not found |
 
 ### [PATCH] /datasets/{dataset_id}/documents/{document_id}/segments/{segment_id}/child_chunks/{child_chunk_id}
@@ -1083,10 +1153,10 @@ Update a specific child chunk
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| child_chunk_id | path | Child chunk ID | Yes | string |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
-| segment_id | path | Parent segment ID | Yes | string |
+| child_chunk_id | path | Child chunk ID | Yes | string (uuid) |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
+| segment_id | path | Parent segment ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -1100,6 +1170,7 @@ Update a specific child chunk
 | ---- | ----------- | ------ |
 | 200 | Child chunk updated successfully | **application/json**: [ChildChunkDetailResponse](#childchunkdetailresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Dataset, document, segment, or child chunk not found |  |
 
 ### ~~[POST] /datasets/{dataset_id}/documents/{document_id}/update-by-file~~
@@ -1112,8 +1183,8 @@ Deprecated legacy alias for updating an existing document by uploading a file. U
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -1127,6 +1198,7 @@ Deprecated legacy alias for updating an existing document by uploading a file. U
 | ---- | ----------- | ------ |
 | 200 | Document updated successfully | **application/json**: [DocumentAndBatchResponse](#documentandbatchresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Document not found |  |
 
 ### [POST] /datasets/{dataset_id}/documents/{document_id}/update-by-text
@@ -1136,8 +1208,8 @@ Update an existing document by providing text content
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -1151,6 +1223,7 @@ Update an existing document by providing text content
 | ---- | ----------- | ------ |
 | 200 | Document updated successfully | **application/json**: [DocumentAndBatchResponse](#documentandbatchresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Document not found |  |
 
 ### ~~[POST] /datasets/{dataset_id}/documents/{document_id}/update_by_file~~
@@ -1163,8 +1236,8 @@ Deprecated legacy alias for updating an existing document by uploading a file. U
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -1178,6 +1251,7 @@ Deprecated legacy alias for updating an existing document by uploading a file. U
 | ---- | ----------- | ------ |
 | 200 | Document updated successfully | **application/json**: [DocumentAndBatchResponse](#documentandbatchresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Document not found |  |
 
 ### ~~[POST] /datasets/{dataset_id}/documents/{document_id}/update_by_text~~
@@ -1190,8 +1264,8 @@ Deprecated legacy alias for updating an existing document by providing text cont
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| document_id | path | Document ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| document_id | path | Document ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -1205,6 +1279,7 @@ Deprecated legacy alias for updating an existing document by providing text cont
 | ---- | ----------- | ------ |
 | 200 | Document updated successfully | **application/json**: [DocumentAndBatchResponse](#documentandbatchresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Document not found |  |
 
 ### [POST] /datasets/{dataset_id}/hit-testing
@@ -1217,7 +1292,7 @@ Tests retrieval performance for the specified dataset.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -1231,6 +1306,7 @@ Tests retrieval performance for the specified dataset.
 | ---- | ----------- | ------ |
 | 200 | Hit testing results | **application/json**: [HitTestingResponse](#hittestingresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Dataset not found |  |
 
 ### [GET] /datasets/{dataset_id}/metadata
@@ -1240,7 +1316,7 @@ Tests retrieval performance for the specified dataset.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -1248,6 +1324,7 @@ Tests retrieval performance for the specified dataset.
 | ---- | ----------- | ------ |
 | 200 | Metadata retrieved successfully | **application/json**: [DatasetMetadataListResponse](#datasetmetadatalistresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Dataset not found |  |
 
 ### [POST] /datasets/{dataset_id}/metadata
@@ -1257,7 +1334,7 @@ Tests retrieval performance for the specified dataset.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -1271,6 +1348,7 @@ Tests retrieval performance for the specified dataset.
 | ---- | ----------- | ------ |
 | 201 | Metadata created successfully | **application/json**: [DatasetMetadataResponse](#datasetmetadataresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Dataset not found |  |
 
 ### [GET] /datasets/{dataset_id}/metadata/built-in
@@ -1280,7 +1358,7 @@ Tests retrieval performance for the specified dataset.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -1288,6 +1366,7 @@ Tests retrieval performance for the specified dataset.
 | ---- | ----------- | ------ |
 | 200 | Built-in fields retrieved successfully | **application/json**: [DatasetMetadataBuiltInFieldsResponse](#datasetmetadatabuiltinfieldsresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 
 ### [POST] /datasets/{dataset_id}/metadata/built-in/{action}
 **Enable or disable built-in metadata field**
@@ -1297,7 +1376,7 @@ Tests retrieval performance for the specified dataset.
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | action | path | Action to perform: 'enable' or 'disable' | Yes | string |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -1305,6 +1384,7 @@ Tests retrieval performance for the specified dataset.
 | ---- | ----------- | ------ |
 | 200 | Action completed successfully | **application/json**: [DatasetMetadataActionResponse](#datasetmetadataactionresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Dataset not found |  |
 
 ### [DELETE] /datasets/{dataset_id}/metadata/{metadata_id}
@@ -1314,8 +1394,8 @@ Tests retrieval performance for the specified dataset.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| metadata_id | path | Metadata ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| metadata_id | path | Metadata ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -1323,6 +1403,7 @@ Tests retrieval performance for the specified dataset.
 | ---- | ----------- |
 | 204 | Metadata deleted successfully |
 | 401 | Unauthorized - invalid API token |
+| 403 | Forbidden - dataset API access or workspace access denied |
 | 404 | Dataset or metadata not found |
 
 ### [PATCH] /datasets/{dataset_id}/metadata/{metadata_id}
@@ -1332,8 +1413,8 @@ Tests retrieval performance for the specified dataset.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
-| metadata_id | path | Metadata ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
+| metadata_id | path | Metadata ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -1347,6 +1428,7 @@ Tests retrieval performance for the specified dataset.
 | ---- | ----------- | ------ |
 | 200 | Metadata updated successfully | **application/json**: [DatasetMetadataResponse](#datasetmetadataresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Dataset or metadata not found |  |
 
 ### [GET] /datasets/{dataset_id}/pipeline/datasource-plugins
@@ -1359,7 +1441,7 @@ List all datasource plugins for a rag pipeline
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | is_published | query |  | No | boolean, <br>**Default:** true |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -1367,6 +1449,7 @@ List all datasource plugins for a rag pipeline
 | ---- | ----------- | ------ |
 | 200 | Datasource plugins retrieved successfully | **application/json**: [DatasourcePluginListResponse](#datasourcepluginlistresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 
 ### [POST] /datasets/{dataset_id}/pipeline/datasource/nodes/{node_id}/run
 **Resource for getting datasource plugins**
@@ -1377,7 +1460,7 @@ Run a datasource node for a rag pipeline
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 | node_id | path |  | Yes | string |
 
 #### Request Body
@@ -1390,8 +1473,9 @@ Run a datasource node for a rag pipeline
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Datasource node run successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 200 | Datasource node run successfully | **text/event-stream**: [GeneratedAppResponse](#generatedappresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 
 ### [POST] /datasets/{dataset_id}/pipeline/run
 **Resource for running a rag pipeline**
@@ -1402,7 +1486,7 @@ Run a datasource node for a rag pipeline
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path |  | Yes | string |
+| dataset_id | path |  | Yes | string (uuid) |
 
 #### Request Body
 
@@ -1414,8 +1498,9 @@ Run a datasource node for a rag pipeline
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Pipeline run successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 200 | Pipeline run successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br>**text/event-stream**: [GeneratedAppResponse](#generatedappresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 
 ### [POST] /datasets/{dataset_id}/retrieve
 **Perform hit testing on a dataset**
@@ -1427,7 +1512,7 @@ Tests retrieval performance for the specified dataset.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Request Body
 
@@ -1441,6 +1526,7 @@ Tests retrieval performance for the specified dataset.
 | ---- | ----------- | ------ |
 | 200 | Hit testing results | **application/json**: [HitTestingResponse](#hittestingresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 | 404 | Dataset not found |  |
 
 ### [GET] /datasets/{dataset_id}/tags
@@ -1452,7 +1538,7 @@ Get tags bound to a specific dataset
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| dataset_id | path | Dataset ID | Yes | string |
+| dataset_id | path | Dataset ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -1460,6 +1546,7 @@ Get tags bound to a specific dataset
 | ---- | ----------- | ------ |
 | 200 | Tags retrieved successfully | **application/json**: [DatasetBoundTagListResponse](#datasetboundtaglistresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - dataset API access or workspace access denied |  |
 
 ### [GET] /end-users/{end_user_id}
 **Get end user detail**
@@ -1472,7 +1559,7 @@ cross-tenant/app access when an end-user ID is known.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| end_user_id | path | End user ID | Yes | string |
+| end_user_id | path | End user ID | Yes | string (uuid) |
 
 #### Responses
 
@@ -1480,6 +1567,7 @@ cross-tenant/app access when an end-user ID is known.
 | ---- | ----------- | ------ |
 | 200 | End user retrieved successfully | **application/json**: [EndUserDetail](#enduserdetail)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | End user not found |  |
 
 ### [POST] /files/upload
@@ -1488,6 +1576,12 @@ cross-tenant/app access when an end-user ID is known.
 Upload a file for use in conversations
 Accepts a single file upload via multipart/form-data.
 
+#### Request Body
+
+| Required | Schema |
+| -------- | ------ |
+|  Yes | **multipart/form-data**: { **"file"**: binary, **"user"**: string }<br> |
+
 #### Responses
 
 | Code | Description | Schema |
@@ -1495,6 +1589,7 @@ Accepts a single file upload via multipart/form-data.
 | 201 | File uploaded successfully | **application/json**: [FileResponse](#fileresponse)<br> |
 | 400 | Bad request - no file or invalid file |  |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 413 | File too large |  |
 | 415 | Unsupported file type |  |
 
@@ -1509,17 +1604,18 @@ Files can only be accessed if they belong to messages within the requesting app'
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| file_id | path | UUID of the file to preview | Yes | string |
+| file_id | path | UUID of the file to preview | Yes | string (uuid) |
 | as_attachment | query | Download as attachment | No | boolean |
+| user | query | End user identifier | No | string |
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | File retrieved successfully | **application/json**: [BinaryFileResponse](#binaryfileresponse)<br> |
-| 401 | Unauthorized - invalid API token |  |
-| 403 | Forbidden - file access denied |  |
-| 404 | File not found |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | File retrieved successfully |
+| 401 | Unauthorized - invalid API token |
+| 403 | Forbidden - file access denied |
+| 404 | File not found |
 
 ### [GET] /form/human_input/{form_token}
 Get a paused human input form by token
@@ -1536,6 +1632,7 @@ Get a paused human input form by token
 | ---- | ----------- | ------ |
 | 200 | Form retrieved successfully | **application/json**: [HumanInputFormDefinitionResponse](#humaninputformdefinitionresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Form not found |  |
 | 412 | Form already submitted or expired |  |
 
@@ -1552,7 +1649,7 @@ Submit a paused human input form by token
 
 | Required | Schema |
 | -------- | ------ |
-|  Yes | **application/json**: [HumanInputFormSubmitPayload](#humaninputformsubmitpayload)<br> |
+|  Yes | **application/json**: [HumanInputFormSubmitPayloadWithUser](#humaninputformsubmitpayloadwithuser)<br> |
 
 #### Responses
 
@@ -1561,6 +1658,7 @@ Submit a paused human input form by token
 | 200 | Form submitted successfully | **application/json**: [HumanInputFormSubmitResponse](#humaninputformsubmitresponse)<br> |
 | 400 | Bad request - invalid submission data |  |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Form not found |  |
 | 412 | Form already submitted or expired |  |
 
@@ -1576,6 +1674,7 @@ Returns basic information about the application including name, description, tag
 | ---- | ----------- | ------ |
 | 200 | Application info retrieved successfully | **application/json**: [AppInfoResponse](#appinforesponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Application not found |  |
 
 ### [GET] /messages
@@ -1591,6 +1690,7 @@ Retrieves messages with pagination support using first_id.
 | conversation_id | query | Conversation UUID | Yes | string |
 | first_id | query | First message ID for pagination | No | string |
 | limit | query | Number of messages to return (1-100) | No | integer, <br>**Default:** 20 |
+| user | query | End user identifier | No | string |
 
 #### Responses
 
@@ -1598,6 +1698,7 @@ Retrieves messages with pagination support using first_id.
 | ---- | ----------- | ------ |
 | 200 | Messages retrieved successfully | **application/json**: [MessageInfiniteScrollPagination](#messageinfinitescrollpagination)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Conversation or first message not found |  |
 
 ### [POST] /messages/{message_id}/feedbacks
@@ -1610,13 +1711,13 @@ Allows users to rate messages as like/dislike and provide optional feedback cont
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| message_id | path | Message ID | Yes | string |
+| message_id | path | Message ID | Yes | string (uuid) |
 
 #### Request Body
 
 | Required | Schema |
 | -------- | ------ |
-|  Yes | **application/json**: [MessageFeedbackPayload](#messagefeedbackpayload)<br> |
+|  Yes | **application/json**: [MessageFeedbackPayloadWithUser](#messagefeedbackpayloadwithuser)<br> |
 
 #### Responses
 
@@ -1624,6 +1725,7 @@ Allows users to rate messages as like/dislike and provide optional feedback cont
 | ---- | ----------- | ------ |
 | 200 | Feedback submitted successfully | **application/json**: [ResultResponse](#resultresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Message not found |  |
 
 ### [GET] /messages/{message_id}/suggested
@@ -1636,7 +1738,8 @@ Returns AI-generated follow-up questions based on the message content.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| message_id | path | Message ID | Yes | string |
+| message_id | path | Message ID | Yes | string (uuid) |
+| user | query | End user identifier | Yes | string |
 
 #### Responses
 
@@ -1645,6 +1748,7 @@ Returns AI-generated follow-up questions based on the message content.
 | 200 | Suggested questions retrieved successfully | **application/json**: [SimpleResultStringListResponse](#simpleresultstringlistresponse)<br> |
 | 400 | Suggested questions feature is disabled |  |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Message not found |  |
 | 500 | Internal server error |  |
 
@@ -1660,6 +1764,7 @@ Returns metadata about the application including configuration and settings.
 | ---- | ----------- | ------ |
 | 200 | Metadata retrieved successfully | **application/json**: [AppMetaResponse](#appmetaresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Application not found |  |
 
 ### [GET] /parameters
@@ -1674,6 +1779,7 @@ Returns the input form parameters and configuration for the application.
 | ---- | ----------- | ------ |
 | 200 | Parameters retrieved successfully | **application/json**: [Parameters](#parameters)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Application not found |  |
 
 ### [GET] /site
@@ -1700,16 +1806,17 @@ Converts the provided text to audio using the specified voice.
 
 | Required | Schema |
 | -------- | ------ |
-|  Yes | **application/json**: [TextToAudioPayload](#texttoaudiopayload)<br> |
+|  Yes | **application/json**: [TextToAudioPayloadWithUser](#texttoaudiopayloadwithuser)<br> |
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Text successfully converted to audio | **application/json**: [AudioBinaryResponse](#audiobinaryresponse)<br> |
-| 400 | Bad request - invalid parameters |  |
-| 401 | Unauthorized - invalid API token |  |
-| 500 | Internal server error |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Text successfully converted to audio |
+| 400 | Bad request - invalid parameters |
+| 401 | Unauthorized - invalid API token |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |
+| 500 | Internal server error |
 
 ### [GET] /workflow/{task_id}/events
 Get workflow execution events stream after resume
@@ -1727,8 +1834,9 @@ Get workflow execution events stream after resume
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | SSE event stream | **application/json**: [EventStreamResponse](#eventstreamresponse)<br> |
+| 200 | SSE event stream | **text/event-stream**: [EventStreamResponse](#eventstreamresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Workflow run not found |  |
 
 ### [GET] /workflows/logs
@@ -1756,6 +1864,7 @@ Returns paginated workflow execution logs with filtering options.
 | ---- | ----------- | ------ |
 | 200 | Logs retrieved successfully | **application/json**: [WorkflowAppLogPaginationResponse](#workflowapplogpaginationresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 
 ### [POST] /workflows/run
 **Execute a workflow**
@@ -1768,15 +1877,16 @@ Supports both blocking and streaming response modes.
 
 | Required | Schema |
 | -------- | ------ |
-|  Yes | **application/json**: [WorkflowRunPayload](#workflowrunpayload)<br> |
+|  Yes | **application/json**: [WorkflowRunPayloadWithUser](#workflowrunpayloadwithuser)<br> |
 
 #### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow executed successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 200 | Workflow executed successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br>**text/event-stream**: [GeneratedAppResponse](#generatedappresponse)<br> |
 | 400 | Bad request - invalid parameters or workflow issues |  |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Workflow not found |  |
 | 429 | Rate limit exceeded |  |
 | 500 | Internal server error |  |
@@ -1799,6 +1909,7 @@ Returns detailed information about a specific workflow run.
 | ---- | ----------- | ------ |
 | 200 | Workflow run details retrieved successfully | **application/json**: [WorkflowRunResponse](#workflowrunresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Workflow run not found |  |
 
 ### [POST] /workflows/tasks/{task_id}/stop
@@ -1810,12 +1921,19 @@ Returns detailed information about a specific workflow run.
 | ---- | ---------- | ----------- | -------- | ------ |
 | task_id | path | Task ID to stop | Yes | string |
 
+#### Request Body
+
+| Required | Schema |
+| -------- | ------ |
+|  Yes | **application/json**: [RequiredServiceApiUserPayload](#requiredserviceapiuserpayload)<br> |
+
 #### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
 | 200 | Task stopped successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Task not found |  |
 
 ### [POST] /workflows/{workflow_id}/run
@@ -1834,15 +1952,16 @@ Executes a specific workflow version identified by its ID.
 
 | Required | Schema |
 | -------- | ------ |
-|  Yes | **application/json**: [WorkflowRunPayload](#workflowrunpayload)<br> |
+|  Yes | **application/json**: [WorkflowRunPayloadWithUser](#workflowrunpayloadwithuser)<br> |
 
 #### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow executed successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 200 | Workflow executed successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br>**text/event-stream**: [GeneratedAppResponse](#generatedappresponse)<br> |
 | 400 | Bad request - invalid parameters or workflow issues |  |
 | 401 | Unauthorized - invalid API token |  |
+| 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 404 | Workflow not found |  |
 | 429 | Rate limit exceeded |  |
 | 500 | Internal server error |  |
@@ -2014,6 +2133,21 @@ Button styles for user actions.
 | trace_session_id | string | Trace session ID for observability grouping | No |
 | workflow_id | string | Workflow ID for advanced chat | No |
 
+#### ChatRequestPayloadWithUser
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| auto_generate_name | boolean, <br>**Default:** true | Auto generate conversation name | No |
+| conversation_id | string | Conversation UUID | No |
+| files | [ object ] |  | No |
+| inputs | object |  | Yes |
+| query | string |  | Yes |
+| response_mode | string |  | No |
+| retriever_from | string, <br>**Default:** dev |  | No |
+| trace_session_id | string | Trace session ID for observability grouping | No |
+| user | string | End user identifier | Yes |
+| workflow_id | string | Workflow ID for advanced chat | No |
+
 #### ChildChunkCreatePayload
 
 | Name | Type | Description | Required |
@@ -2074,6 +2208,18 @@ Button styles for user actions.
 | retriever_from | string, <br>**Default:** dev |  | No |
 | trace_session_id | string | Trace session ID for observability grouping | No |
 
+#### CompletionRequestPayloadWithUser
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| files | [ object ] |  | No |
+| inputs | object |  | Yes |
+| query | string |  | No |
+| response_mode | string |  | No |
+| retriever_from | string, <br>**Default:** dev |  | No |
+| trace_session_id | string | Trace session ID for observability grouping | No |
+| user | string | End user identifier | Yes |
+
 #### Condition
 
 Condition detail
@@ -2107,6 +2253,14 @@ Condition detail
 | auto_generate | boolean |  | No |
 | name | string |  | No |
 
+#### ConversationRenamePayloadWithUser
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| auto_generate | boolean |  | No |
+| name | string |  | No |
+| user | string | End user identifier | No |
+
 #### ConversationVariableInfiniteScrollPaginationResponse
 
 | Name | Type | Description | Required |
@@ -2131,6 +2285,13 @@ Condition detail
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
+| value |  |  | Yes |
+
+#### ConversationVariableUpdatePayloadWithUser
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| user | string | End user identifier | No |
 | value |  |  | Yes |
 
 #### ConversationVariablesQuery
@@ -2914,6 +3075,14 @@ Enum class for fetch from.
 | action | string |  | Yes |
 | inputs | object | Submitted human input values keyed by output variable name. Use a string for paragraph or select input values, a file mapping for file inputs, and a list of file mappings for file-list inputs. Local file mappings use `transfer_method=local_file` with `upload_file_id`; remote file mappings use `transfer_method=remote_url` with `url` or `remote_url`. | Yes |
 
+#### HumanInputFormSubmitPayloadWithUser
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| action | string |  | Yes |
+| inputs | object | Submitted human input values keyed by output variable name. Use a string for paragraph or select input values, a file mapping for file inputs, and a list of file mappings for file-list inputs. Local file mappings use `transfer_method=local_file` with `upload_file_id`; remote file mappings use `transfer_method=remote_url` with `url` or `remote_url`. | Yes |
+| user | string | End user identifier | Yes |
+
 #### HumanInputFormSubmitResponse
 
 | Name | Type | Description | Required |
@@ -2981,6 +3150,14 @@ Model class for i18n object.
 | ---- | ---- | ----------- | -------- |
 | content | string |  | No |
 | rating | string |  | No |
+
+#### MessageFeedbackPayloadWithUser
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| content | string |  | No |
+| rating | string |  | No |
+| user | string | End user identifier | Yes |
 
 #### MessageFile
 
@@ -3101,6 +3278,12 @@ Enum class for model type.
 | ---- | ---- | ----------- | -------- |
 | ModelType | string | Enum class for model type. |  |
 
+#### OptionalServiceApiUserPayload
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| user | string | End user identifier | No |
+
 #### ParagraphInputConfig
 
 Form input definition.
@@ -3217,6 +3400,12 @@ Model class for provider with models response.
 | provider | string |  | Yes |
 | status | [CustomConfigurationStatus](#customconfigurationstatus) |  | Yes |
 | tenant_id | string |  | Yes |
+
+#### RequiredServiceApiUserPayload
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| user | string | End user identifier | Yes |
 
 #### RerankingModel
 
@@ -3525,13 +3714,11 @@ Default configuration for form inputs.
 
 #### TagUnbindingPayload
 
-Accept the legacy single-tag Service API payload while exposing a normalized tag_ids list internally.
+Accepts either the legacy tag_id payload or the normalized tag_ids payload.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| tag_id | string |  | No |
-| tag_ids | [ string ] |  | No |
-| target_id | string |  | Yes |
+| TagUnbindingPayload | object<br>object | Accepts either the legacy tag_id payload or the normalized tag_ids payload. |  |
 
 #### TagUpdatePayload
 
@@ -3547,6 +3734,16 @@ Accept the legacy single-tag Service API payload while exposing a normalized tag
 | message_id | string | Message ID | No |
 | streaming | boolean | Enable streaming response | No |
 | text | string | Text to convert to audio | No |
+| voice | string | Voice to use for TTS | No |
+
+#### TextToAudioPayloadWithUser
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| message_id | string | Message ID | No |
+| streaming | boolean | Enable streaming response | No |
+| text | string | Text to convert to audio | No |
+| user | string | End user identifier | No |
 | voice | string | Voice to use for TTS | No |
 
 #### UrlResponse
@@ -3664,6 +3861,16 @@ in form definiton, or a variable while the workflow is running.
 | inputs | object |  | Yes |
 | response_mode | string |  | No |
 | trace_session_id | string | Trace session ID for observability grouping | No |
+
+#### WorkflowRunPayloadWithUser
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| files | [ object ] |  | No |
+| inputs | object |  | Yes |
+| response_mode | string |  | No |
+| trace_session_id | string | Trace session ID for observability grouping | No |
+| user | string | End user identifier | Yes |
 
 #### WorkflowRunResponse
 

--- a/api/openapi/markdown/service-openapi.md
+++ b/api/openapi/markdown/service-openapi.md
@@ -5,7 +5,7 @@ API for application services
 
 ### Available authorizations
 #### Bearer (HTTP, bearer)
-Use the Service API key as a Bearer token in the Authorization header.  
+Use the Service API key as a Bearer token in the Authorization header.
 Bearer format: API_KEY
 
 ---

--- a/api/openapi/markdown/service-openapi.md
+++ b/api/openapi/markdown/service-openapi.md
@@ -3587,7 +3587,7 @@ Model class for provider with models response.
 | ---- | ---- | ----------- | -------- |
 | chunk_overlap | integer |  | No |
 | max_tokens | integer |  | Yes |
-| separator | string, <br>**Default:** 
+| separator | string, <br>**Default:**
  |  | No |
 
 #### SelectInputConfig

--- a/api/openapi/markdown/web-openapi.md
+++ b/api/openapi/markdown/web-openapi.md
@@ -4,10 +4,9 @@ Public APIs for web applications including file uploads, chat interactions, and 
 ## Version: 1.0
 
 ### Available authorizations
-#### Bearer (API Key Authentication)
-Type: Bearer {your-api-key}  
-**Name:** Authorization  
-**In:** header  
+#### Bearer (HTTP, bearer)
+Use the Service API key as a Bearer token in the Authorization header.  
+Bearer format: API_KEY
 
 ---
 ## web
@@ -140,7 +139,7 @@ Delete a specific conversation.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| c_id | path | Conversation UUID | Yes | string |
+| c_id | path | Conversation UUID | Yes | string (uuid) |
 
 #### Responses
 
@@ -160,7 +159,7 @@ Rename a specific conversation with a custom name or auto-generate one.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| c_id | path | Conversation UUID | Yes | string |
+| c_id | path | Conversation UUID | Yes | string (uuid) |
 | auto_generate | query | Auto-generate conversation name | No | boolean |
 | name | query | New conversation name | No | string |
 
@@ -188,7 +187,7 @@ Pin a specific conversation to keep it at the top of the list.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| c_id | path | Conversation UUID | Yes | string |
+| c_id | path | Conversation UUID | Yes | string (uuid) |
 
 #### Responses
 
@@ -208,7 +207,7 @@ Unpin a specific conversation to remove it from the top of the list.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| c_id | path | Conversation UUID | Yes | string |
+| c_id | path | Conversation UUID | Yes | string (uuid) |
 
 #### Responses
 
@@ -494,7 +493,7 @@ Submit feedback (like/dislike) for a specific message.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| message_id | path | Message UUID | Yes | string |
+| message_id | path | Message UUID | Yes | string (uuid) |
 | content | query | Feedback content | No | string |
 | rating | query | Feedback rating | No | string, <br>**Available values:** "dislike", "like" |
 
@@ -523,7 +522,7 @@ Generate a new completion similar to an existing message (completion apps only).
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
 | response_mode | query | Response mode | Yes | string, <br>**Available values:** "blocking", "streaming" |
-| message_id | path |  | Yes | string |
+| message_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -543,7 +542,7 @@ Get suggested follow-up questions after a message (chat apps only).
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| message_id | path | Message UUID | Yes | string |
+| message_id | path | Message UUID | Yes | string (uuid) |
 
 #### Responses
 
@@ -731,7 +730,7 @@ Remove a message from saved messages.
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| message_id | path | Message UUID to delete | Yes | string |
+| message_id | path | Message UUID to delete | Yes | string (uuid) |
 
 #### Responses
 

--- a/api/openapi/markdown/web-openapi.md
+++ b/api/openapi/markdown/web-openapi.md
@@ -5,7 +5,7 @@ Public APIs for web applications including file uploads, chat interactions, and 
 
 ### Available authorizations
 #### Bearer (HTTP, bearer)
-Use the Service API key as a Bearer token in the Authorization header.  
+Use the Service API key as a Bearer token in the Authorization header.
 Bearer format: API_KEY
 
 ---

--- a/api/tests/unit_tests/commands/test_generate_swagger_markdown_docs.py
+++ b/api/tests/unit_tests/commands/test_generate_swagger_markdown_docs.py
@@ -266,6 +266,7 @@ def test_patch_union_schema_markdown_ignores_unrenderable_shapes(tmp_path):
     assert module._schema_ref_name(None) is None
     assert module._schema_markdown_type(None) == ""
     assert module._schema_markdown_type({"anyOf": [{"type": "null"}]}) == ""
+    assert module._strip_trailing_line_whitespace("line  \ncell\t \n") == "line\ncell\n"
     assert module._replace_schema_table_type("unchanged", "Definition", "field", "") == "unchanged"
     assert (
         module._replace_schema_table_type(
@@ -319,7 +320,10 @@ def test_convert_spec_to_markdown_patches_generated_union_tables(tmp_path, monke
         assert kwargs["check"] is False
         markdown_path = Path(args[args.index("-o") + 1])
         markdown_path.write_text(
-            """#### FormInputConfig
+            "Intro line"
+            + "  \n"
+            + """
+#### FormInputConfig
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
@@ -340,5 +344,7 @@ def test_convert_spec_to_markdown_patches_generated_union_tables(tmp_path, monke
     module._convert_spec_to_markdown(spec_path, output_path)
 
     converted = output_path.read_text(encoding="utf-8")
+    assert "Intro line  \n" not in converted
+    assert "Intro line\n" in converted
     assert "| FormInputConfig | [ParagraphInputConfig](#paragraphinputconfig) |  |  |" in converted
     assert "| default | [StringSource](#stringsource) |  | No |" in converted

--- a/api/tests/unit_tests/commands/test_generate_swagger_specs.py
+++ b/api/tests/unit_tests/commands/test_generate_swagger_specs.py
@@ -106,6 +106,23 @@ def test_generate_specs_writes_get_operations_without_request_bodies(tmp_path):
         assert all("requestBody" not in operation for operation in _get_operations(payload))
 
 
+def test_standalone_inline_model_name_includes_list_constraints():
+    module = _load_generate_swagger_specs_module()
+
+    from flask_restx import fields
+
+    cases = (
+        ({"min_items": 1}, {"min_items": 2}),
+        ({"max_items": 1}, {"max_items": 2}),
+        ({"unique": True}, {"unique": False}),
+    )
+    for first_kwargs, second_kwargs in cases:
+        first_inline_model = {"items": fields.List(fields.String, **first_kwargs)}
+        second_inline_model = {"items": fields.List(fields.String, **second_kwargs)}
+
+        assert module._inline_model_name(first_inline_model) != module._inline_model_name(second_inline_model)
+
+
 def test_generate_specs_is_idempotent(tmp_path):
     module = _load_generate_swagger_specs_module()
 

--- a/api/tests/unit_tests/controllers/test_swagger.py
+++ b/api/tests/unit_tests/controllers/test_swagger.py
@@ -320,7 +320,25 @@ def test_service_openapi_documents_non_json_response_media_types(monkeypatch: py
     }
     assert _response_content_types(paths["/workflow/{task_id}/events"]["get"]) == {"text/event-stream"}
     assert _response_content_types(paths["/text-to-audio"]["post"]) == {"audio/mpeg"}
-    assert _response_content_types(paths["/files/{file_id}/preview"]["get"]) == {"application/octet-stream"}
+    assert _response_content_types(paths["/files/{file_id}/preview"]["get"]) == {
+        "application/octet-stream",
+        "application/pdf",
+        "audio/aac",
+        "audio/flac",
+        "audio/mp4",
+        "audio/mpeg",
+        "audio/ogg",
+        "audio/wav",
+        "audio/x-m4a",
+        "image/gif",
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+        "text/plain",
+        "video/mp4",
+        "video/quicktime",
+        "video/webm",
+    }
     assert _response_content_types(paths["/datasets/{dataset_id}/documents/download-zip"]["post"]) == {
         "application/zip"
     }
@@ -356,6 +374,62 @@ def test_service_openapi_documents_uuid_params_and_deprecated_routes(monkeypatch
 
     assert paths["/datasets/{dataset_id}/document/create_by_file"]["post"]["deprecated"] is True
     assert paths["/datasets/{dataset_id}/documents/{document_id}/update_by_text"]["post"]["deprecated"] is True
+
+
+def test_service_openapi_documents_path_action_enums(monkeypatch: pytest.MonkeyPatch):
+    from configs import dify_config
+    from controllers.service_api import bp as service_api_bp
+
+    monkeypatch.setattr(dify_config, "SWAGGER_UI_ENABLED", True)
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["RESTX_INCLUDE_ALL_MODELS"] = True
+    app.register_blueprint(service_api_bp)
+
+    payload = app.test_client().get("/v1/openapi.json").get_json()
+    paths = payload["paths"]
+
+    annotation_params = _parameters_by_name(paths["/apps/annotation-reply/{action}"]["post"])
+    assert annotation_params["action"]["schema"]["enum"] == ["enable", "disable"]
+
+    document_status_params = _parameters_by_name(paths["/datasets/{dataset_id}/documents/status/{action}"]["patch"])
+    assert document_status_params["action"]["schema"]["enum"] == ["enable", "disable", "archive", "un_archive"]
+
+    metadata_params = _parameters_by_name(paths["/datasets/{dataset_id}/metadata/built-in/{action}"]["post"])
+    assert metadata_params["action"]["schema"]["enum"] == ["enable", "disable"]
+
+
+def test_service_openapi_documents_conditional_payload_schemas(monkeypatch: pytest.MonkeyPatch):
+    from configs import dify_config
+    from controllers.service_api import bp as service_api_bp
+
+    monkeypatch.setattr(dify_config, "SWAGGER_UI_ENABLED", True)
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["RESTX_INCLUDE_ALL_MODELS"] = True
+    app.register_blueprint(service_api_bp)
+
+    payload = app.test_client().get("/v1/openapi.json").get_json()
+    paths = payload["paths"]
+
+    rename_schema = _json_body_schema(payload, paths["/conversations/{c_id}/name"]["post"])
+    auto_generate_branch, manual_name_branch = rename_schema["anyOf"]
+    assert auto_generate_branch["properties"]["auto_generate"]["enum"] == [True]
+    assert auto_generate_branch["required"] == ["auto_generate"]
+    assert manual_name_branch["properties"]["auto_generate"]["enum"] == [False]
+    assert manual_name_branch["properties"]["name"]["pattern"] == r".*\S.*"
+    assert manual_name_branch["required"] == ["name"]
+    for branch in rename_schema["anyOf"]:
+        assert branch["properties"]["user"] == {"description": "End user identifier", "type": "string"}
+
+    document_update_schema = payload["components"]["schemas"]["DocumentTextUpdate"]
+    with_text_branch, without_text_branch = document_update_schema["anyOf"]
+    assert with_text_branch["properties"]["text"]["type"] == "string"
+    assert with_text_branch["properties"]["name"]["type"] == "string"
+    assert with_text_branch["required"] == ["name", "text"]
+    assert without_text_branch["properties"]["text"]["type"] == "null"
 
 
 def test_service_openapi_does_not_encode_docs_coverage_boundaries(monkeypatch: pytest.MonkeyPatch):

--- a/api/tests/unit_tests/controllers/test_swagger.py
+++ b/api/tests/unit_tests/controllers/test_swagger.py
@@ -57,6 +57,36 @@ def _multipart_form_schema(operation: dict[str, object]) -> dict[str, object]:
     return schema
 
 
+def _json_body_schema(payload: dict[str, object], operation: dict[str, object]) -> dict[str, object]:
+    request_body = operation.get("requestBody")
+    assert isinstance(request_body, dict)
+    content = request_body.get("content")
+    assert isinstance(content, dict)
+    json_media = content.get("application/json")
+    assert isinstance(json_media, dict)
+    schema = json_media.get("schema")
+    assert isinstance(schema, dict)
+
+    ref = schema.get("$ref")
+    if isinstance(ref, str):
+        schema_name = ref.removeprefix("#/components/schemas/")
+        resolved = payload["components"]["schemas"][schema_name]
+        assert isinstance(resolved, dict)
+        return resolved
+
+    return schema
+
+
+def _response_content_types(operation: dict[str, object], status_code: str = "200") -> set[str]:
+    responses = operation.get("responses")
+    assert isinstance(responses, dict)
+    response = responses.get(status_code)
+    assert isinstance(response, dict)
+    content = response.get("content")
+    assert isinstance(content, dict)
+    return set(content)
+
+
 @pytest.mark.parametrize(
     ("first_kwargs", "second_kwargs"),
     [
@@ -77,6 +107,25 @@ def test_inline_model_name_includes_list_constraints(
     second_inline_model: dict[object, object] = {"items": fields.List(fields.String, **second_kwargs)}
 
     assert _inline_model_name(first_inline_model) != _inline_model_name(second_inline_model)
+
+
+def test_uuid_path_format_is_derived_from_route_converter():
+    from flask_restx import swagger as restx_swagger
+
+    from libs.flask_restx_compat import install_swagger_compatibility
+
+    app = Flask(__name__)
+    with app.app_context():
+        install_swagger_compatibility()
+        params = restx_swagger.extract_path_params("/resources/<uuid:custom_resource_uuid>")
+
+    assert params["custom_resource_uuid"] == {
+        "format": "uuid",
+        "in": "path",
+        "name": "custom_resource_uuid",
+        "required": True,
+        "type": "string",
+    }
 
 
 def test_openapi_json_endpoints_render(monkeypatch: pytest.MonkeyPatch):
@@ -132,7 +181,10 @@ def test_service_document_file_routes_document_multipart_form_data(monkeypatch: 
     create_properties = create_schema["properties"]
     assert isinstance(create_properties, dict)
     assert create_properties["file"] == {"type": "string", "format": "binary"}
-    assert create_properties["data"] == {"type": "string"}
+    assert create_properties["data"] == {
+        "description": "Optional JSON string with document creation settings.",
+        "type": "string",
+    }
     assert create_schema["required"] == ["file"]
     assert create_operation["requestBody"]["required"] is True
 
@@ -146,7 +198,10 @@ def test_service_document_file_routes_document_multipart_form_data(monkeypatch: 
         update_properties = update_schema["properties"]
         assert isinstance(update_properties, dict)
         assert update_properties["file"] == {"type": "string", "format": "binary"}
-        assert update_properties["data"] == {"type": "string"}
+        assert update_properties["data"] == {
+            "description": "Optional JSON string with document update settings.",
+            "type": "string",
+        }
         assert "required" not in update_schema
         assert update_operation["requestBody"]["required"] is False
 
@@ -168,6 +223,198 @@ def test_service_document_list_documents_query_params_render(monkeypatch: pytest
 
     for name in ("page", "limit", "keyword", "status"):
         assert params[name]["in"] == "query"
+
+
+def test_service_openapi_documents_decorator_user_contracts(monkeypatch: pytest.MonkeyPatch):
+    from configs import dify_config
+    from controllers.service_api import bp as service_api_bp
+
+    monkeypatch.setattr(dify_config, "SWAGGER_UI_ENABLED", True)
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["RESTX_INCLUDE_ALL_MODELS"] = True
+    app.register_blueprint(service_api_bp)
+
+    payload = app.test_client().get("/v1/openapi.json").get_json()
+    paths = payload["paths"]
+
+    required_json_user_operations = (
+        ("/completion-messages", "post"),
+        ("/completion-messages/{task_id}/stop", "post"),
+        ("/chat-messages", "post"),
+        ("/chat-messages/{task_id}/stop", "post"),
+        ("/messages/{message_id}/feedbacks", "post"),
+        ("/form/human_input/{form_token}", "post"),
+        ("/workflows/run", "post"),
+        ("/workflows/{workflow_id}/run", "post"),
+        ("/workflows/tasks/{task_id}/stop", "post"),
+    )
+    for path, method in required_json_user_operations:
+        schema = _json_body_schema(payload, paths[path][method])
+        assert schema["properties"]["user"] == {"description": "End user identifier", "type": "string"}
+        assert "user" in schema["required"]
+
+    optional_json_user_operations = (
+        ("/text-to-audio", "post"),
+        ("/conversations/{c_id}", "delete"),
+        ("/conversations/{c_id}/name", "post"),
+        ("/conversations/{c_id}/variables/{variable_id}", "put"),
+    )
+    for path, method in optional_json_user_operations:
+        schema = _json_body_schema(payload, paths[path][method])
+        assert schema["properties"]["user"] == {"description": "End user identifier", "type": "string"}
+        assert "user" not in schema.get("required", [])
+
+    messages_params = _parameters_by_name(paths["/messages"]["get"])
+    assert messages_params["user"]["in"] == "query"
+    assert messages_params["user"]["required"] is False
+
+    events_params = _parameters_by_name(paths["/workflow/{task_id}/events"]["get"])
+    assert events_params["user"]["in"] == "query"
+    assert events_params["user"]["required"] is True
+
+
+def test_service_openapi_documents_app_multipart_contracts(monkeypatch: pytest.MonkeyPatch):
+    from configs import dify_config
+    from controllers.service_api import bp as service_api_bp
+
+    monkeypatch.setattr(dify_config, "SWAGGER_UI_ENABLED", True)
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["RESTX_INCLUDE_ALL_MODELS"] = True
+    app.register_blueprint(service_api_bp)
+
+    payload = app.test_client().get("/v1/openapi.json").get_json()
+    paths = payload["paths"]
+
+    for path in ("/files/upload", "/audio-to-text"):
+        schema = _multipart_form_schema(paths[path]["post"])
+        assert schema["properties"]["file"] == {"format": "binary", "type": "string"}
+        assert schema["properties"]["user"] == {"description": "End user identifier", "type": "string"}
+        assert schema["required"] == ["file"]
+
+    pipeline_schema = _multipart_form_schema(paths["/datasets/pipeline/file-upload"]["post"])
+    assert pipeline_schema["properties"]["file"] == {"format": "binary", "type": "string"}
+    assert pipeline_schema["required"] == ["file"]
+
+
+def test_service_openapi_documents_non_json_response_media_types(monkeypatch: pytest.MonkeyPatch):
+    from configs import dify_config
+    from controllers.service_api import bp as service_api_bp
+
+    monkeypatch.setattr(dify_config, "SWAGGER_UI_ENABLED", True)
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["RESTX_INCLUDE_ALL_MODELS"] = True
+    app.register_blueprint(service_api_bp)
+
+    payload = app.test_client().get("/v1/openapi.json").get_json()
+    paths = payload["paths"]
+
+    assert _response_content_types(paths["/chat-messages"]["post"]) == {
+        "application/json",
+        "text/event-stream",
+    }
+    assert _response_content_types(paths["/workflow/{task_id}/events"]["get"]) == {"text/event-stream"}
+    assert _response_content_types(paths["/text-to-audio"]["post"]) == {"audio/mpeg"}
+    assert _response_content_types(paths["/files/{file_id}/preview"]["get"]) == {"application/octet-stream"}
+    assert _response_content_types(paths["/datasets/{dataset_id}/documents/download-zip"]["post"]) == {
+        "application/zip"
+    }
+
+
+def test_service_openapi_documents_uuid_params_and_deprecated_routes(monkeypatch: pytest.MonkeyPatch):
+    from configs import dify_config
+    from controllers.service_api import bp as service_api_bp
+
+    monkeypatch.setattr(dify_config, "SWAGGER_UI_ENABLED", True)
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["RESTX_INCLUDE_ALL_MODELS"] = True
+    app.register_blueprint(service_api_bp)
+
+    payload = app.test_client().get("/v1/openapi.json").get_json()
+    paths = payload["paths"]
+
+    dataset_params = _parameters_by_name(paths["/datasets/{dataset_id}"]["get"])
+    assert dataset_params["dataset_id"]["schema"] == {
+        "description": "Dataset ID",
+        "format": "uuid",
+        "type": "string",
+    }
+
+    conversation_params = _parameters_by_name(paths["/conversations/{c_id}"]["delete"])
+    assert conversation_params["c_id"]["schema"] == {
+        "description": "Conversation ID",
+        "format": "uuid",
+        "type": "string",
+    }
+
+    assert paths["/datasets/{dataset_id}/document/create_by_file"]["post"]["deprecated"] is True
+    assert paths["/datasets/{dataset_id}/documents/{document_id}/update_by_text"]["post"]["deprecated"] is True
+
+
+def test_service_openapi_does_not_encode_docs_coverage_boundaries(monkeypatch: pytest.MonkeyPatch):
+    from configs import dify_config
+    from controllers.service_api import bp as service_api_bp
+
+    monkeypatch.setattr(dify_config, "SWAGGER_UI_ENABLED", True)
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["RESTX_INCLUDE_ALL_MODELS"] = True
+    app.register_blueprint(service_api_bp)
+
+    payload = app.test_client().get("/v1/openapi.json").get_json()
+    paths = payload["paths"]
+
+    for path_item in paths.values():
+        assert isinstance(path_item, dict)
+        for method in ("delete", "get", "patch", "post", "put"):
+            operation = path_item.get(method)
+            if not isinstance(operation, dict):
+                continue
+            assert "x-dify-api-reference-visibility" not in operation
+            assert "x-dify-api-lifecycle" not in operation
+
+    assert paths["/datasets/{dataset_id}/document/create_by_text"]["post"]["deprecated"] is True
+    assert paths["/datasets/{dataset_id}/document/create_by_file"]["post"]["deprecated"] is True
+    assert paths["/datasets/{dataset_id}/documents/{document_id}/update-by-file"]["post"]["deprecated"] is True
+
+
+def test_service_openapi_documents_auth_and_compatibility_payloads(monkeypatch: pytest.MonkeyPatch):
+    from configs import dify_config
+    from controllers.service_api import bp as service_api_bp
+
+    monkeypatch.setattr(dify_config, "SWAGGER_UI_ENABLED", True)
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["RESTX_INCLUDE_ALL_MODELS"] = True
+    app.register_blueprint(service_api_bp)
+
+    payload = app.test_client().get("/v1/openapi.json").get_json()
+
+    assert payload["components"]["securitySchemes"]["Bearer"] == {
+        "bearerFormat": "API_KEY",
+        "description": "Use the Service API key as a Bearer token in the Authorization header.",
+        "scheme": "bearer",
+        "type": "http",
+    }
+
+    tag_unbinding_schema = payload["components"]["schemas"]["TagUnbindingPayload"]
+    assert tag_unbinding_schema["description"] == (
+        "Accepts either the legacy tag_id payload or the normalized tag_ids payload."
+    )
+    tag_id_schema, tag_ids_schema = tag_unbinding_schema["anyOf"]
+    assert tag_id_schema["properties"]["tag_id"]["description"] == ("Legacy single tag ID accepted by the Service API.")
+    assert tag_id_schema["required"] == ["tag_id", "target_id"]
+    assert tag_ids_schema["properties"]["tag_ids"]["minItems"] == 1
+    assert tag_ids_schema["required"] == ["tag_ids", "target_id"]
 
 
 def test_console_account_avatar_query_param_renders_as_query(monkeypatch: pytest.MonkeyPatch):

--- a/packages/contracts/generated/api/console/agent/zod.gen.ts
+++ b/packages/contracts/generated/api/console/agent/zod.gen.ts
@@ -2087,7 +2087,7 @@ export const zGetAgentInviteOptionsQuery = z.object({
 export const zGetAgentInviteOptionsResponse = zAgentInviteOptionsResponse
 
 export const zDeleteAgentByAgentIdPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 /**
@@ -2096,7 +2096,7 @@ export const zDeleteAgentByAgentIdPath = z.object({
 export const zDeleteAgentByAgentIdResponse = z.void()
 
 export const zGetAgentByAgentIdPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 /**
@@ -2107,7 +2107,7 @@ export const zGetAgentByAgentIdResponse = zAppDetailWithSite
 export const zPutAgentByAgentIdBody = zAgentAppUpdatePayload
 
 export const zPutAgentByAgentIdPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 /**
@@ -2116,7 +2116,7 @@ export const zPutAgentByAgentIdPath = z.object({
 export const zPutAgentByAgentIdResponse = zAppDetailWithSite
 
 export const zGetAgentByAgentIdChatMessagesPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 export const zGetAgentByAgentIdChatMessagesQuery = z.object({
@@ -2131,8 +2131,8 @@ export const zGetAgentByAgentIdChatMessagesQuery = z.object({
 export const zGetAgentByAgentIdChatMessagesResponse = zMessageInfiniteScrollPaginationResponse
 
 export const zGetAgentByAgentIdChatMessagesByMessageIdSuggestedQuestionsPath = z.object({
-  agent_id: z.string(),
-  message_id: z.string(),
+  agent_id: z.uuid(),
+  message_id: z.uuid(),
 })
 
 /**
@@ -2142,7 +2142,7 @@ export const zGetAgentByAgentIdChatMessagesByMessageIdSuggestedQuestionsResponse
   = zSuggestedQuestionsResponse
 
 export const zPostAgentByAgentIdChatMessagesByTaskIdStopPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
   task_id: z.string(),
 })
 
@@ -2152,7 +2152,7 @@ export const zPostAgentByAgentIdChatMessagesByTaskIdStopPath = z.object({
 export const zPostAgentByAgentIdChatMessagesByTaskIdStopResponse = zSimpleResultResponse
 
 export const zGetAgentByAgentIdComposerPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 /**
@@ -2163,7 +2163,7 @@ export const zGetAgentByAgentIdComposerResponse = zAgentAppComposerResponse
 export const zPutAgentByAgentIdComposerBody = zComposerSavePayload
 
 export const zPutAgentByAgentIdComposerPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 /**
@@ -2172,7 +2172,7 @@ export const zPutAgentByAgentIdComposerPath = z.object({
 export const zPutAgentByAgentIdComposerResponse = zAgentAppComposerResponse
 
 export const zGetAgentByAgentIdComposerCandidatesPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 /**
@@ -2183,7 +2183,7 @@ export const zGetAgentByAgentIdComposerCandidatesResponse = zAgentComposerCandid
 export const zPostAgentByAgentIdComposerValidateBody = zComposerSavePayload
 
 export const zPostAgentByAgentIdComposerValidatePath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 /**
@@ -2194,7 +2194,7 @@ export const zPostAgentByAgentIdComposerValidateResponse = zAgentComposerValidat
 export const zPostAgentByAgentIdCopyBody = zCopyAppPayload
 
 export const zPostAgentByAgentIdCopyPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 /**
@@ -2203,7 +2203,7 @@ export const zPostAgentByAgentIdCopyPath = z.object({
 export const zPostAgentByAgentIdCopyResponse = zAppDetailWithSite
 
 export const zGetAgentByAgentIdDriveFilesPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 export const zGetAgentByAgentIdDriveFilesQuery = z.object({
@@ -2216,7 +2216,7 @@ export const zGetAgentByAgentIdDriveFilesQuery = z.object({
 export const zGetAgentByAgentIdDriveFilesResponse = zAgentDriveListResponse
 
 export const zGetAgentByAgentIdDriveFilesDownloadPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 export const zGetAgentByAgentIdDriveFilesDownloadQuery = z.object({
@@ -2229,7 +2229,7 @@ export const zGetAgentByAgentIdDriveFilesDownloadQuery = z.object({
 export const zGetAgentByAgentIdDriveFilesDownloadResponse = zAgentDriveDownloadResponse
 
 export const zGetAgentByAgentIdDriveFilesPreviewPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 export const zGetAgentByAgentIdDriveFilesPreviewQuery = z.object({
@@ -2244,7 +2244,7 @@ export const zGetAgentByAgentIdDriveFilesPreviewResponse = zAgentDrivePreviewRes
 export const zPostAgentByAgentIdFeaturesBody = zAgentAppFeaturesPayload
 
 export const zPostAgentByAgentIdFeaturesPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 /**
@@ -2255,7 +2255,7 @@ export const zPostAgentByAgentIdFeaturesResponse = zSimpleResultResponse
 export const zPostAgentByAgentIdFeedbacksBody = zMessageFeedbackPayload
 
 export const zPostAgentByAgentIdFeedbacksPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 /**
@@ -2264,7 +2264,7 @@ export const zPostAgentByAgentIdFeedbacksPath = z.object({
 export const zPostAgentByAgentIdFeedbacksResponse = zSimpleResultResponse
 
 export const zDeleteAgentByAgentIdFilesPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 export const zDeleteAgentByAgentIdFilesQuery = z.object({
@@ -2279,7 +2279,7 @@ export const zDeleteAgentByAgentIdFilesResponse = zAgentDriveDeleteResponse
 export const zPostAgentByAgentIdFilesBody = zAgentDriveFilePayload
 
 export const zPostAgentByAgentIdFilesPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 /**
@@ -2288,7 +2288,7 @@ export const zPostAgentByAgentIdFilesPath = z.object({
 export const zPostAgentByAgentIdFilesResponse = zAgentDriveFileCommitResponse
 
 export const zGetAgentByAgentIdLogsPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 export const zGetAgentByAgentIdLogsQuery = z.object({
@@ -2307,8 +2307,8 @@ export const zGetAgentByAgentIdLogsQuery = z.object({
 export const zGetAgentByAgentIdLogsResponse = zAgentLogListResponse
 
 export const zGetAgentByAgentIdMessagesByMessageIdPath = z.object({
-  agent_id: z.string(),
-  message_id: z.string(),
+  agent_id: z.uuid(),
+  message_id: z.uuid(),
 })
 
 /**
@@ -2317,7 +2317,7 @@ export const zGetAgentByAgentIdMessagesByMessageIdPath = z.object({
 export const zGetAgentByAgentIdMessagesByMessageIdResponse = zMessageDetailResponse
 
 export const zGetAgentByAgentIdReferencingWorkflowsPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 /**
@@ -2326,7 +2326,7 @@ export const zGetAgentByAgentIdReferencingWorkflowsPath = z.object({
 export const zGetAgentByAgentIdReferencingWorkflowsResponse = zAgentReferencingWorkflowsResponse
 
 export const zGetAgentByAgentIdSandboxFilesPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 export const zGetAgentByAgentIdSandboxFilesQuery = z.object({
@@ -2340,7 +2340,7 @@ export const zGetAgentByAgentIdSandboxFilesQuery = z.object({
 export const zGetAgentByAgentIdSandboxFilesResponse = zSandboxListResponse
 
 export const zGetAgentByAgentIdSandboxFilesReadPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 export const zGetAgentByAgentIdSandboxFilesReadQuery = z.object({
@@ -2356,7 +2356,7 @@ export const zGetAgentByAgentIdSandboxFilesReadResponse = zSandboxReadResponse
 export const zPostAgentByAgentIdSandboxFilesUploadBody = zAgentSandboxUploadPayload
 
 export const zPostAgentByAgentIdSandboxFilesUploadPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 /**
@@ -2365,7 +2365,7 @@ export const zPostAgentByAgentIdSandboxFilesUploadPath = z.object({
 export const zPostAgentByAgentIdSandboxFilesUploadResponse = zSandboxUploadResponse
 
 export const zPostAgentByAgentIdSkillsStandardizePath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 /**
@@ -2374,7 +2374,7 @@ export const zPostAgentByAgentIdSkillsStandardizePath = z.object({
 export const zPostAgentByAgentIdSkillsStandardizeResponse = zAgentSkillStandardizeResponse
 
 export const zPostAgentByAgentIdSkillsUploadPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 /**
@@ -2383,7 +2383,7 @@ export const zPostAgentByAgentIdSkillsUploadPath = z.object({
 export const zPostAgentByAgentIdSkillsUploadResponse = zAgentSkillUploadResponse
 
 export const zDeleteAgentByAgentIdSkillsBySlugPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
   slug: z.string(),
 })
 
@@ -2393,7 +2393,7 @@ export const zDeleteAgentByAgentIdSkillsBySlugPath = z.object({
 export const zDeleteAgentByAgentIdSkillsBySlugResponse = zAgentDriveDeleteResponse
 
 export const zPostAgentByAgentIdSkillsBySlugInferToolsPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
   slug: z.string(),
 })
 
@@ -2403,7 +2403,7 @@ export const zPostAgentByAgentIdSkillsBySlugInferToolsPath = z.object({
 export const zPostAgentByAgentIdSkillsBySlugInferToolsResponse = zSkillToolInferenceResult
 
 export const zGetAgentByAgentIdStatisticsSummaryPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 export const zGetAgentByAgentIdStatisticsSummaryQuery = z.object({
@@ -2418,7 +2418,7 @@ export const zGetAgentByAgentIdStatisticsSummaryQuery = z.object({
 export const zGetAgentByAgentIdStatisticsSummaryResponse = zAgentStatisticSummaryEnvelopeResponse
 
 export const zGetAgentByAgentIdVersionsPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 /**
@@ -2427,8 +2427,8 @@ export const zGetAgentByAgentIdVersionsPath = z.object({
 export const zGetAgentByAgentIdVersionsResponse = zAgentConfigSnapshotListResponse
 
 export const zGetAgentByAgentIdVersionsByVersionIdPath = z.object({
-  agent_id: z.string(),
-  version_id: z.string(),
+  agent_id: z.uuid(),
+  version_id: z.uuid(),
 })
 
 /**

--- a/packages/contracts/generated/api/console/api-based-extension/zod.gen.ts
+++ b/packages/contracts/generated/api/console/api-based-extension/zod.gen.ts
@@ -37,7 +37,7 @@ export const zPostApiBasedExtensionBody = zApiBasedExtensionPayload
 export const zPostApiBasedExtensionResponse = zApiBasedExtensionResponse
 
 export const zDeleteApiBasedExtensionByIdPath = z.object({
-  id: z.string(),
+  id: z.uuid(),
 })
 
 /**
@@ -46,7 +46,7 @@ export const zDeleteApiBasedExtensionByIdPath = z.object({
 export const zDeleteApiBasedExtensionByIdResponse = z.void()
 
 export const zGetApiBasedExtensionByIdPath = z.object({
-  id: z.string(),
+  id: z.uuid(),
 })
 
 /**
@@ -57,7 +57,7 @@ export const zGetApiBasedExtensionByIdResponse = zApiBasedExtensionResponse
 export const zPostApiBasedExtensionByIdBody = zApiBasedExtensionPayload
 
 export const zPostApiBasedExtensionByIdPath = z.object({
-  id: z.string(),
+  id: z.uuid(),
 })
 
 /**

--- a/packages/contracts/generated/api/console/api-key-auth/zod.gen.ts
+++ b/packages/contracts/generated/api/console/api-key-auth/zod.gen.ts
@@ -50,7 +50,7 @@ export const zPostApiKeyAuthDataSourceBindingBody = zApiKeyAuthBindingPayload
 export const zPostApiKeyAuthDataSourceBindingResponse = zSimpleResultResponse
 
 export const zDeleteApiKeyAuthDataSourceByBindingIdPath = z.object({
-  binding_id: z.string(),
+  binding_id: z.uuid(),
 })
 
 /**

--- a/packages/contracts/generated/api/console/apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/apps/zod.gen.ts
@@ -3703,7 +3703,7 @@ export const zPostAppsWorkflowsOnlineUsersBody = zWorkflowOnlineUsersPayload
 export const zPostAppsWorkflowsOnlineUsersResponse = zWorkflowOnlineUsersResponse
 
 export const zDeleteAppsByAppIdPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -3712,7 +3712,7 @@ export const zDeleteAppsByAppIdPath = z.object({
 export const zDeleteAppsByAppIdResponse = z.void()
 
 export const zGetAppsByAppIdPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -3723,7 +3723,7 @@ export const zGetAppsByAppIdResponse = zAppDetailWithSite
 export const zPutAppsByAppIdBody = zUpdateAppPayload
 
 export const zPutAppsByAppIdPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -3732,7 +3732,7 @@ export const zPutAppsByAppIdPath = z.object({
 export const zPutAppsByAppIdResponse = zAppDetailWithSite
 
 export const zGetAppsByAppIdAdvancedChatWorkflowRunsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdAdvancedChatWorkflowRunsQuery = z.object({
@@ -3749,7 +3749,7 @@ export const zGetAppsByAppIdAdvancedChatWorkflowRunsResponse
   = zAdvancedChatWorkflowRunPaginationResponse
 
 export const zGetAppsByAppIdAdvancedChatWorkflowRunsCountPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdAdvancedChatWorkflowRunsCountQuery = z.object({
@@ -3768,7 +3768,7 @@ export const zPostAppsByAppIdAdvancedChatWorkflowsDraftHumanInputNodesByNodeIdFo
 
 export const zPostAppsByAppIdAdvancedChatWorkflowsDraftHumanInputNodesByNodeIdFormPreviewPath
   = z.object({
-    app_id: z.string(),
+    app_id: z.uuid(),
     node_id: z.string(),
   })
 
@@ -3783,7 +3783,7 @@ export const zPostAppsByAppIdAdvancedChatWorkflowsDraftHumanInputNodesByNodeIdFo
 
 export const zPostAppsByAppIdAdvancedChatWorkflowsDraftHumanInputNodesByNodeIdFormRunPath
   = z.object({
-    app_id: z.string(),
+    app_id: z.uuid(),
     node_id: z.string(),
   })
 
@@ -3797,7 +3797,7 @@ export const zPostAppsByAppIdAdvancedChatWorkflowsDraftIterationNodesByNodeIdRun
   = zIterationNodeRunPayload
 
 export const zPostAppsByAppIdAdvancedChatWorkflowsDraftIterationNodesByNodeIdRunPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
 })
 
@@ -3811,7 +3811,7 @@ export const zPostAppsByAppIdAdvancedChatWorkflowsDraftLoopNodesByNodeIdRunBody
   = zLoopNodeRunPayload
 
 export const zPostAppsByAppIdAdvancedChatWorkflowsDraftLoopNodesByNodeIdRunPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
 })
 
@@ -3824,7 +3824,7 @@ export const zPostAppsByAppIdAdvancedChatWorkflowsDraftLoopNodesByNodeIdRunRespo
 export const zPostAppsByAppIdAdvancedChatWorkflowsDraftRunBody = zAdvancedChatWorkflowRunPayload
 
 export const zPostAppsByAppIdAdvancedChatWorkflowsDraftRunPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -3833,7 +3833,7 @@ export const zPostAppsByAppIdAdvancedChatWorkflowsDraftRunPath = z.object({
 export const zPostAppsByAppIdAdvancedChatWorkflowsDraftRunResponse = zGeneratedAppResponse
 
 export const zGetAppsByAppIdAgentDriveFilesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdAgentDriveFilesQuery = z.object({
@@ -3847,7 +3847,7 @@ export const zGetAppsByAppIdAgentDriveFilesQuery = z.object({
 export const zGetAppsByAppIdAgentDriveFilesResponse = zAgentDriveListResponse
 
 export const zGetAppsByAppIdAgentDriveFilesDownloadPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdAgentDriveFilesDownloadQuery = z.object({
@@ -3861,7 +3861,7 @@ export const zGetAppsByAppIdAgentDriveFilesDownloadQuery = z.object({
 export const zGetAppsByAppIdAgentDriveFilesDownloadResponse = zAgentDriveDownloadResponse
 
 export const zGetAppsByAppIdAgentDriveFilesPreviewPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdAgentDriveFilesPreviewQuery = z.object({
@@ -3875,7 +3875,7 @@ export const zGetAppsByAppIdAgentDriveFilesPreviewQuery = z.object({
 export const zGetAppsByAppIdAgentDriveFilesPreviewResponse = zAgentDrivePreviewResponse
 
 export const zDeleteAppsByAppIdAgentFilesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zDeleteAppsByAppIdAgentFilesQuery = z.object({
@@ -3891,7 +3891,7 @@ export const zDeleteAppsByAppIdAgentFilesResponse = zAgentDriveDeleteResponse
 export const zPostAppsByAppIdAgentFilesBody = zAgentDriveFilePayload
 
 export const zPostAppsByAppIdAgentFilesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zPostAppsByAppIdAgentFilesQuery = z.object({
@@ -3904,7 +3904,7 @@ export const zPostAppsByAppIdAgentFilesQuery = z.object({
 export const zPostAppsByAppIdAgentFilesResponse = zAgentDriveFileCommitResponse
 
 export const zGetAppsByAppIdAgentLogsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdAgentLogsQuery = z.object({
@@ -3918,7 +3918,7 @@ export const zGetAppsByAppIdAgentLogsQuery = z.object({
 export const zGetAppsByAppIdAgentLogsResponse = zAgentLogResponse
 
 export const zPostAppsByAppIdAgentSkillsStandardizePath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zPostAppsByAppIdAgentSkillsStandardizeQuery = z.object({
@@ -3931,7 +3931,7 @@ export const zPostAppsByAppIdAgentSkillsStandardizeQuery = z.object({
 export const zPostAppsByAppIdAgentSkillsStandardizeResponse = zAgentSkillStandardizeResponse
 
 export const zPostAppsByAppIdAgentSkillsUploadPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -3940,7 +3940,7 @@ export const zPostAppsByAppIdAgentSkillsUploadPath = z.object({
 export const zPostAppsByAppIdAgentSkillsUploadResponse = zAgentSkillUploadResponse
 
 export const zDeleteAppsByAppIdAgentSkillsBySlugPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   slug: z.string(),
 })
 
@@ -3954,7 +3954,7 @@ export const zDeleteAppsByAppIdAgentSkillsBySlugQuery = z.object({
 export const zDeleteAppsByAppIdAgentSkillsBySlugResponse = zAgentDriveDeleteResponse
 
 export const zPostAppsByAppIdAgentSkillsBySlugInferToolsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   slug: z.string(),
 })
 
@@ -3971,7 +3971,7 @@ export const zPostAppsByAppIdAnnotationReplyByActionBody = zAnnotationReplyPaylo
 
 export const zPostAppsByAppIdAnnotationReplyByActionPath = z.object({
   action: z.string(),
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -3981,8 +3981,8 @@ export const zPostAppsByAppIdAnnotationReplyByActionResponse = zAnnotationJobSta
 
 export const zGetAppsByAppIdAnnotationReplyByActionStatusByJobIdPath = z.object({
   action: z.string(),
-  app_id: z.string(),
-  job_id: z.string(),
+  app_id: z.uuid(),
+  job_id: z.uuid(),
 })
 
 /**
@@ -3992,7 +3992,7 @@ export const zGetAppsByAppIdAnnotationReplyByActionStatusByJobIdResponse
   = zAnnotationJobStatusResponse
 
 export const zGetAppsByAppIdAnnotationSettingPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4004,8 +4004,8 @@ export const zPostAppsByAppIdAnnotationSettingsByAnnotationSettingIdBody
   = zAnnotationSettingUpdatePayload
 
 export const zPostAppsByAppIdAnnotationSettingsByAnnotationSettingIdPath = z.object({
-  annotation_setting_id: z.string(),
-  app_id: z.string(),
+  annotation_setting_id: z.uuid(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4015,7 +4015,7 @@ export const zPostAppsByAppIdAnnotationSettingsByAnnotationSettingIdResponse
   = zAnnotationSettingResponse
 
 export const zDeleteAppsByAppIdAnnotationsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4024,7 +4024,7 @@ export const zDeleteAppsByAppIdAnnotationsPath = z.object({
 export const zDeleteAppsByAppIdAnnotationsResponse = z.void()
 
 export const zGetAppsByAppIdAnnotationsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdAnnotationsQuery = z.object({
@@ -4041,7 +4041,7 @@ export const zGetAppsByAppIdAnnotationsResponse = zAnnotationList
 export const zPostAppsByAppIdAnnotationsBody = zCreateAnnotationPayload
 
 export const zPostAppsByAppIdAnnotationsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4050,7 +4050,7 @@ export const zPostAppsByAppIdAnnotationsPath = z.object({
 export const zPostAppsByAppIdAnnotationsResponse = zAnnotation
 
 export const zPostAppsByAppIdAnnotationsBatchImportPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4059,8 +4059,8 @@ export const zPostAppsByAppIdAnnotationsBatchImportPath = z.object({
 export const zPostAppsByAppIdAnnotationsBatchImportResponse = zAnnotationJobStatusResponse
 
 export const zGetAppsByAppIdAnnotationsBatchImportStatusByJobIdPath = z.object({
-  app_id: z.string(),
-  job_id: z.string(),
+  app_id: z.uuid(),
+  job_id: z.uuid(),
 })
 
 /**
@@ -4070,7 +4070,7 @@ export const zGetAppsByAppIdAnnotationsBatchImportStatusByJobIdResponse
   = zAnnotationJobStatusResponse
 
 export const zGetAppsByAppIdAnnotationsCountPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4079,7 +4079,7 @@ export const zGetAppsByAppIdAnnotationsCountPath = z.object({
 export const zGetAppsByAppIdAnnotationsCountResponse = zAnnotationCountResponse
 
 export const zGetAppsByAppIdAnnotationsExportPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4088,8 +4088,8 @@ export const zGetAppsByAppIdAnnotationsExportPath = z.object({
 export const zGetAppsByAppIdAnnotationsExportResponse = zAnnotationExportList
 
 export const zDeleteAppsByAppIdAnnotationsByAnnotationIdPath = z.object({
-  annotation_id: z.string(),
-  app_id: z.string(),
+  annotation_id: z.uuid(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4100,15 +4100,15 @@ export const zDeleteAppsByAppIdAnnotationsByAnnotationIdResponse = z.void()
 export const zPostAppsByAppIdAnnotationsByAnnotationIdBody = zUpdateAnnotationPayload
 
 export const zPostAppsByAppIdAnnotationsByAnnotationIdPath = z.object({
-  annotation_id: z.string(),
-  app_id: z.string(),
+  annotation_id: z.uuid(),
+  app_id: z.uuid(),
 })
 
 export const zPostAppsByAppIdAnnotationsByAnnotationIdResponse = z.union([zAnnotation, z.void()])
 
 export const zGetAppsByAppIdAnnotationsByAnnotationIdHitHistoriesPath = z.object({
-  annotation_id: z.string(),
-  app_id: z.string(),
+  annotation_id: z.uuid(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdAnnotationsByAnnotationIdHitHistoriesQuery = z.object({
@@ -4125,7 +4125,7 @@ export const zGetAppsByAppIdAnnotationsByAnnotationIdHitHistoriesResponse
 export const zPostAppsByAppIdApiEnableBody = zAppApiStatusPayload
 
 export const zPostAppsByAppIdApiEnablePath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4134,7 +4134,7 @@ export const zPostAppsByAppIdApiEnablePath = z.object({
 export const zPostAppsByAppIdApiEnableResponse = zAppDetail
 
 export const zPostAppsByAppIdAudioToTextPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4143,7 +4143,7 @@ export const zPostAppsByAppIdAudioToTextPath = z.object({
 export const zPostAppsByAppIdAudioToTextResponse = zAudioTranscriptResponse
 
 export const zGetAppsByAppIdChatConversationsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdChatConversationsQuery = z.object({
@@ -4165,8 +4165,8 @@ export const zGetAppsByAppIdChatConversationsQuery = z.object({
 export const zGetAppsByAppIdChatConversationsResponse = zConversationWithSummaryPagination
 
 export const zDeleteAppsByAppIdChatConversationsByConversationIdPath = z.object({
-  app_id: z.string(),
-  conversation_id: z.string(),
+  app_id: z.uuid(),
+  conversation_id: z.uuid(),
 })
 
 /**
@@ -4175,8 +4175,8 @@ export const zDeleteAppsByAppIdChatConversationsByConversationIdPath = z.object(
 export const zDeleteAppsByAppIdChatConversationsByConversationIdResponse = z.void()
 
 export const zGetAppsByAppIdChatConversationsByConversationIdPath = z.object({
-  app_id: z.string(),
-  conversation_id: z.string(),
+  app_id: z.uuid(),
+  conversation_id: z.uuid(),
 })
 
 /**
@@ -4185,7 +4185,7 @@ export const zGetAppsByAppIdChatConversationsByConversationIdPath = z.object({
 export const zGetAppsByAppIdChatConversationsByConversationIdResponse = zConversationDetail
 
 export const zGetAppsByAppIdChatMessagesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdChatMessagesQuery = z.object({
@@ -4200,8 +4200,8 @@ export const zGetAppsByAppIdChatMessagesQuery = z.object({
 export const zGetAppsByAppIdChatMessagesResponse = zMessageInfiniteScrollPaginationResponse
 
 export const zGetAppsByAppIdChatMessagesByMessageIdSuggestedQuestionsPath = z.object({
-  app_id: z.string(),
-  message_id: z.string(),
+  app_id: z.uuid(),
+  message_id: z.uuid(),
 })
 
 /**
@@ -4211,7 +4211,7 @@ export const zGetAppsByAppIdChatMessagesByMessageIdSuggestedQuestionsResponse
   = zSuggestedQuestionsResponse
 
 export const zPostAppsByAppIdChatMessagesByTaskIdStopPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   task_id: z.string(),
 })
 
@@ -4221,7 +4221,7 @@ export const zPostAppsByAppIdChatMessagesByTaskIdStopPath = z.object({
 export const zPostAppsByAppIdChatMessagesByTaskIdStopResponse = zSimpleResultResponse
 
 export const zGetAppsByAppIdCompletionConversationsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdCompletionConversationsQuery = z.object({
@@ -4239,8 +4239,8 @@ export const zGetAppsByAppIdCompletionConversationsQuery = z.object({
 export const zGetAppsByAppIdCompletionConversationsResponse = zConversationPagination
 
 export const zDeleteAppsByAppIdCompletionConversationsByConversationIdPath = z.object({
-  app_id: z.string(),
-  conversation_id: z.string(),
+  app_id: z.uuid(),
+  conversation_id: z.uuid(),
 })
 
 /**
@@ -4249,8 +4249,8 @@ export const zDeleteAppsByAppIdCompletionConversationsByConversationIdPath = z.o
 export const zDeleteAppsByAppIdCompletionConversationsByConversationIdResponse = z.void()
 
 export const zGetAppsByAppIdCompletionConversationsByConversationIdPath = z.object({
-  app_id: z.string(),
-  conversation_id: z.string(),
+  app_id: z.uuid(),
+  conversation_id: z.uuid(),
 })
 
 /**
@@ -4262,7 +4262,7 @@ export const zGetAppsByAppIdCompletionConversationsByConversationIdResponse
 export const zPostAppsByAppIdCompletionMessagesBody = zCompletionMessagePayload
 
 export const zPostAppsByAppIdCompletionMessagesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4271,7 +4271,7 @@ export const zPostAppsByAppIdCompletionMessagesPath = z.object({
 export const zPostAppsByAppIdCompletionMessagesResponse = zGeneratedAppResponse
 
 export const zPostAppsByAppIdCompletionMessagesByTaskIdStopPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   task_id: z.string(),
 })
 
@@ -4281,7 +4281,7 @@ export const zPostAppsByAppIdCompletionMessagesByTaskIdStopPath = z.object({
 export const zPostAppsByAppIdCompletionMessagesByTaskIdStopResponse = zSimpleResultResponse
 
 export const zGetAppsByAppIdConversationVariablesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdConversationVariablesQuery = z.object({
@@ -4296,7 +4296,7 @@ export const zGetAppsByAppIdConversationVariablesResponse = zPaginatedConversati
 export const zPostAppsByAppIdConvertToWorkflowBody = zConvertToWorkflowPayload
 
 export const zPostAppsByAppIdConvertToWorkflowPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4307,7 +4307,7 @@ export const zPostAppsByAppIdConvertToWorkflowResponse = zNewAppResponse
 export const zPostAppsByAppIdCopyBody = zCopyAppPayload
 
 export const zPostAppsByAppIdCopyPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4316,7 +4316,7 @@ export const zPostAppsByAppIdCopyPath = z.object({
 export const zPostAppsByAppIdCopyResponse = zAppDetailWithSite
 
 export const zGetAppsByAppIdExportPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdExportQuery = z.object({
@@ -4332,7 +4332,7 @@ export const zGetAppsByAppIdExportResponse = zAppExportResponse
 export const zPostAppsByAppIdFeedbacksBody = zMessageFeedbackPayload
 
 export const zPostAppsByAppIdFeedbacksPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4341,7 +4341,7 @@ export const zPostAppsByAppIdFeedbacksPath = z.object({
 export const zPostAppsByAppIdFeedbacksResponse = zSimpleResultResponse
 
 export const zGetAppsByAppIdFeedbacksExportPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdFeedbacksExportQuery = z.object({
@@ -4361,7 +4361,7 @@ export const zGetAppsByAppIdFeedbacksExportResponse = zTextFileResponse
 export const zPostAppsByAppIdIconBody = zAppIconPayload
 
 export const zPostAppsByAppIdIconPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4370,8 +4370,8 @@ export const zPostAppsByAppIdIconPath = z.object({
 export const zPostAppsByAppIdIconResponse = zAppDetail
 
 export const zGetAppsByAppIdMessagesByMessageIdPath = z.object({
-  app_id: z.string(),
-  message_id: z.string(),
+  app_id: z.uuid(),
+  message_id: z.uuid(),
 })
 
 /**
@@ -4382,7 +4382,7 @@ export const zGetAppsByAppIdMessagesByMessageIdResponse = zMessageDetailResponse
 export const zPostAppsByAppIdModelConfigBody = zModelConfigRequest
 
 export const zPostAppsByAppIdModelConfigPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4393,7 +4393,7 @@ export const zPostAppsByAppIdModelConfigResponse = zSimpleResultResponse
 export const zPostAppsByAppIdNameBody = zAppNamePayload
 
 export const zPostAppsByAppIdNamePath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4402,7 +4402,7 @@ export const zPostAppsByAppIdNamePath = z.object({
 export const zPostAppsByAppIdNameResponse = zAppDetail
 
 export const zPostAppsByAppIdPublishToCreatorsPlatformPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4411,7 +4411,7 @@ export const zPostAppsByAppIdPublishToCreatorsPlatformPath = z.object({
 export const zPostAppsByAppIdPublishToCreatorsPlatformResponse = zRedirectUrlResponse
 
 export const zGetAppsByAppIdServerPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4422,7 +4422,7 @@ export const zGetAppsByAppIdServerResponse = zAppMcpServerResponse
 export const zPostAppsByAppIdServerBody = zMcpServerCreatePayload
 
 export const zPostAppsByAppIdServerPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4433,7 +4433,7 @@ export const zPostAppsByAppIdServerResponse = zAppMcpServerResponse
 export const zPutAppsByAppIdServerBody = zMcpServerUpdatePayload
 
 export const zPutAppsByAppIdServerPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4444,7 +4444,7 @@ export const zPutAppsByAppIdServerResponse = zAppMcpServerResponse
 export const zPostAppsByAppIdSiteBody = zAppSiteUpdatePayload
 
 export const zPostAppsByAppIdSitePath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4455,7 +4455,7 @@ export const zPostAppsByAppIdSiteResponse = zAppSiteResponse
 export const zPostAppsByAppIdSiteEnableBody = zAppSiteStatusPayload
 
 export const zPostAppsByAppIdSiteEnablePath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4464,7 +4464,7 @@ export const zPostAppsByAppIdSiteEnablePath = z.object({
 export const zPostAppsByAppIdSiteEnableResponse = zAppDetail
 
 export const zPostAppsByAppIdSiteAccessTokenResetPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4473,7 +4473,7 @@ export const zPostAppsByAppIdSiteAccessTokenResetPath = z.object({
 export const zPostAppsByAppIdSiteAccessTokenResetResponse = zAppSiteResponse
 
 export const zDeleteAppsByAppIdStarPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4482,7 +4482,7 @@ export const zDeleteAppsByAppIdStarPath = z.object({
 export const zDeleteAppsByAppIdStarResponse = zSimpleResultResponse
 
 export const zPostAppsByAppIdStarPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4491,7 +4491,7 @@ export const zPostAppsByAppIdStarPath = z.object({
 export const zPostAppsByAppIdStarResponse = zSimpleResultResponse
 
 export const zGetAppsByAppIdStatisticsAverageResponseTimePath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdStatisticsAverageResponseTimeQuery = z.object({
@@ -4506,7 +4506,7 @@ export const zGetAppsByAppIdStatisticsAverageResponseTimeResponse
   = zAverageResponseTimeStatisticResponse
 
 export const zGetAppsByAppIdStatisticsAverageSessionInteractionsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdStatisticsAverageSessionInteractionsQuery = z.object({
@@ -4521,7 +4521,7 @@ export const zGetAppsByAppIdStatisticsAverageSessionInteractionsResponse
   = zAverageSessionInteractionStatisticResponse
 
 export const zGetAppsByAppIdStatisticsDailyConversationsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdStatisticsDailyConversationsQuery = z.object({
@@ -4536,7 +4536,7 @@ export const zGetAppsByAppIdStatisticsDailyConversationsResponse
   = zDailyConversationStatisticResponse
 
 export const zGetAppsByAppIdStatisticsDailyEndUsersPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdStatisticsDailyEndUsersQuery = z.object({
@@ -4550,7 +4550,7 @@ export const zGetAppsByAppIdStatisticsDailyEndUsersQuery = z.object({
 export const zGetAppsByAppIdStatisticsDailyEndUsersResponse = zDailyTerminalStatisticResponse
 
 export const zGetAppsByAppIdStatisticsDailyMessagesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdStatisticsDailyMessagesQuery = z.object({
@@ -4564,7 +4564,7 @@ export const zGetAppsByAppIdStatisticsDailyMessagesQuery = z.object({
 export const zGetAppsByAppIdStatisticsDailyMessagesResponse = zDailyMessageStatisticResponse
 
 export const zGetAppsByAppIdStatisticsTokenCostsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdStatisticsTokenCostsQuery = z.object({
@@ -4578,7 +4578,7 @@ export const zGetAppsByAppIdStatisticsTokenCostsQuery = z.object({
 export const zGetAppsByAppIdStatisticsTokenCostsResponse = zDailyTokenCostStatisticResponse
 
 export const zGetAppsByAppIdStatisticsTokensPerSecondPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdStatisticsTokensPerSecondQuery = z.object({
@@ -4592,7 +4592,7 @@ export const zGetAppsByAppIdStatisticsTokensPerSecondQuery = z.object({
 export const zGetAppsByAppIdStatisticsTokensPerSecondResponse = zTokensPerSecondStatisticResponse
 
 export const zGetAppsByAppIdStatisticsUserSatisfactionRatePath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdStatisticsUserSatisfactionRateQuery = z.object({
@@ -4609,7 +4609,7 @@ export const zGetAppsByAppIdStatisticsUserSatisfactionRateResponse
 export const zPostAppsByAppIdTextToAudioBody = zTextToSpeechPayload
 
 export const zPostAppsByAppIdTextToAudioPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4618,7 +4618,7 @@ export const zPostAppsByAppIdTextToAudioPath = z.object({
 export const zPostAppsByAppIdTextToAudioResponse = zAudioBinaryResponse
 
 export const zGetAppsByAppIdTextToAudioVoicesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdTextToAudioVoicesQuery = z.object({
@@ -4631,7 +4631,7 @@ export const zGetAppsByAppIdTextToAudioVoicesQuery = z.object({
 export const zGetAppsByAppIdTextToAudioVoicesResponse = zTextToSpeechVoiceListResponse
 
 export const zGetAppsByAppIdTracePath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4642,7 +4642,7 @@ export const zGetAppsByAppIdTraceResponse = zAppTraceResponse
 export const zPostAppsByAppIdTraceBody = zAppTracePayload
 
 export const zPostAppsByAppIdTracePath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4651,7 +4651,7 @@ export const zPostAppsByAppIdTracePath = z.object({
 export const zPostAppsByAppIdTraceResponse = zSimpleResultResponse
 
 export const zDeleteAppsByAppIdTraceConfigPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zDeleteAppsByAppIdTraceConfigQuery = z.object({
@@ -4664,7 +4664,7 @@ export const zDeleteAppsByAppIdTraceConfigQuery = z.object({
 export const zDeleteAppsByAppIdTraceConfigResponse = z.void()
 
 export const zGetAppsByAppIdTraceConfigPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdTraceConfigQuery = z.object({
@@ -4679,7 +4679,7 @@ export const zGetAppsByAppIdTraceConfigResponse = zTraceAppConfigResponse
 export const zPatchAppsByAppIdTraceConfigBody = zTraceConfigPayload
 
 export const zPatchAppsByAppIdTraceConfigPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4690,7 +4690,7 @@ export const zPatchAppsByAppIdTraceConfigResponse = zTraceAppConfigResponse
 export const zPostAppsByAppIdTraceConfigBody = zTraceConfigPayload
 
 export const zPostAppsByAppIdTraceConfigPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4701,7 +4701,7 @@ export const zPostAppsByAppIdTraceConfigResponse = zTraceAppConfigResponse
 export const zPostAppsByAppIdTriggerEnableBody = zParserEnable
 
 export const zPostAppsByAppIdTriggerEnablePath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4710,7 +4710,7 @@ export const zPostAppsByAppIdTriggerEnablePath = z.object({
 export const zPostAppsByAppIdTriggerEnableResponse = zWorkflowTriggerResponse
 
 export const zGetAppsByAppIdTriggersPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4719,7 +4719,7 @@ export const zGetAppsByAppIdTriggersPath = z.object({
 export const zGetAppsByAppIdTriggersResponse = zWorkflowTriggerListResponse
 
 export const zGetAppsByAppIdWorkflowAppLogsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdWorkflowAppLogsQuery = z.object({
@@ -4742,7 +4742,7 @@ export const zGetAppsByAppIdWorkflowAppLogsQuery = z.object({
 export const zGetAppsByAppIdWorkflowAppLogsResponse = zWorkflowAppLogPaginationResponse
 
 export const zGetAppsByAppIdWorkflowArchivedLogsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdWorkflowArchivedLogsQuery = z.object({
@@ -4765,7 +4765,7 @@ export const zGetAppsByAppIdWorkflowArchivedLogsQuery = z.object({
 export const zGetAppsByAppIdWorkflowArchivedLogsResponse = zWorkflowArchivedLogPaginationResponse
 
 export const zGetAppsByAppIdWorkflowRunsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdWorkflowRunsQuery = z.object({
@@ -4781,7 +4781,7 @@ export const zGetAppsByAppIdWorkflowRunsQuery = z.object({
 export const zGetAppsByAppIdWorkflowRunsResponse = zWorkflowRunPaginationResponse
 
 export const zGetAppsByAppIdWorkflowRunsCountPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdWorkflowRunsCountQuery = z.object({
@@ -4796,7 +4796,7 @@ export const zGetAppsByAppIdWorkflowRunsCountQuery = z.object({
 export const zGetAppsByAppIdWorkflowRunsCountResponse = zWorkflowRunCountResponse
 
 export const zPostAppsByAppIdWorkflowRunsTasksByTaskIdStopPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   task_id: z.string(),
 })
 
@@ -4806,8 +4806,8 @@ export const zPostAppsByAppIdWorkflowRunsTasksByTaskIdStopPath = z.object({
 export const zPostAppsByAppIdWorkflowRunsTasksByTaskIdStopResponse = zSimpleResultResponse
 
 export const zGetAppsByAppIdWorkflowRunsByRunIdPath = z.object({
-  app_id: z.string(),
-  run_id: z.string(),
+  app_id: z.uuid(),
+  run_id: z.uuid(),
 })
 
 /**
@@ -4816,8 +4816,8 @@ export const zGetAppsByAppIdWorkflowRunsByRunIdPath = z.object({
 export const zGetAppsByAppIdWorkflowRunsByRunIdResponse = zWorkflowRunDetailResponse
 
 export const zGetAppsByAppIdWorkflowRunsByRunIdExportPath = z.object({
-  app_id: z.string(),
-  run_id: z.string(),
+  app_id: z.uuid(),
+  run_id: z.uuid(),
 })
 
 /**
@@ -4826,8 +4826,8 @@ export const zGetAppsByAppIdWorkflowRunsByRunIdExportPath = z.object({
 export const zGetAppsByAppIdWorkflowRunsByRunIdExportResponse = zWorkflowRunExportResponse
 
 export const zGetAppsByAppIdWorkflowRunsByRunIdNodeExecutionsPath = z.object({
-  app_id: z.string(),
-  run_id: z.string(),
+  app_id: z.uuid(),
+  run_id: z.uuid(),
 })
 
 /**
@@ -4838,9 +4838,9 @@ export const zGetAppsByAppIdWorkflowRunsByRunIdNodeExecutionsResponse
 
 export const zGetAppsByAppIdWorkflowRunsByWorkflowRunIdAgentNodesByNodeIdSandboxFilesPath
   = z.object({
-    app_id: z.string(),
+    app_id: z.uuid(),
     node_id: z.string(),
-    workflow_run_id: z.string(),
+    workflow_run_id: z.uuid(),
   })
 
 export const zGetAppsByAppIdWorkflowRunsByWorkflowRunIdAgentNodesByNodeIdSandboxFilesQuery
@@ -4857,9 +4857,9 @@ export const zGetAppsByAppIdWorkflowRunsByWorkflowRunIdAgentNodesByNodeIdSandbox
 
 export const zGetAppsByAppIdWorkflowRunsByWorkflowRunIdAgentNodesByNodeIdSandboxFilesReadPath
   = z.object({
-    app_id: z.string(),
+    app_id: z.uuid(),
     node_id: z.string(),
-    workflow_run_id: z.string(),
+    workflow_run_id: z.uuid(),
   })
 
 export const zGetAppsByAppIdWorkflowRunsByWorkflowRunIdAgentNodesByNodeIdSandboxFilesReadQuery
@@ -4879,9 +4879,9 @@ export const zPostAppsByAppIdWorkflowRunsByWorkflowRunIdAgentNodesByNodeIdSandbo
 
 export const zPostAppsByAppIdWorkflowRunsByWorkflowRunIdAgentNodesByNodeIdSandboxFilesUploadPath
   = z.object({
-    app_id: z.string(),
+    app_id: z.uuid(),
     node_id: z.string(),
-    workflow_run_id: z.string(),
+    workflow_run_id: z.uuid(),
   })
 
 /**
@@ -4891,7 +4891,7 @@ export const zPostAppsByAppIdWorkflowRunsByWorkflowRunIdAgentNodesByNodeIdSandbo
   = zSandboxUploadResponse
 
 export const zGetAppsByAppIdWorkflowCommentsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4902,7 +4902,7 @@ export const zGetAppsByAppIdWorkflowCommentsResponse = zWorkflowCommentBasicList
 export const zPostAppsByAppIdWorkflowCommentsBody = zWorkflowCommentCreatePayload
 
 export const zPostAppsByAppIdWorkflowCommentsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4911,7 +4911,7 @@ export const zPostAppsByAppIdWorkflowCommentsPath = z.object({
 export const zPostAppsByAppIdWorkflowCommentsResponse = zWorkflowCommentCreate
 
 export const zGetAppsByAppIdWorkflowCommentsMentionUsersPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -4921,7 +4921,7 @@ export const zGetAppsByAppIdWorkflowCommentsMentionUsersResponse
   = zWorkflowCommentMentionUsersPayload
 
 export const zDeleteAppsByAppIdWorkflowCommentsByCommentIdPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   comment_id: z.string(),
 })
 
@@ -4931,7 +4931,7 @@ export const zDeleteAppsByAppIdWorkflowCommentsByCommentIdPath = z.object({
 export const zDeleteAppsByAppIdWorkflowCommentsByCommentIdResponse = z.void()
 
 export const zGetAppsByAppIdWorkflowCommentsByCommentIdPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   comment_id: z.string(),
 })
 
@@ -4943,7 +4943,7 @@ export const zGetAppsByAppIdWorkflowCommentsByCommentIdResponse = zWorkflowComme
 export const zPutAppsByAppIdWorkflowCommentsByCommentIdBody = zWorkflowCommentUpdatePayload
 
 export const zPutAppsByAppIdWorkflowCommentsByCommentIdPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   comment_id: z.string(),
 })
 
@@ -4955,7 +4955,7 @@ export const zPutAppsByAppIdWorkflowCommentsByCommentIdResponse = zWorkflowComme
 export const zPostAppsByAppIdWorkflowCommentsByCommentIdRepliesBody = zWorkflowCommentReplyPayload
 
 export const zPostAppsByAppIdWorkflowCommentsByCommentIdRepliesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   comment_id: z.string(),
 })
 
@@ -4966,7 +4966,7 @@ export const zPostAppsByAppIdWorkflowCommentsByCommentIdRepliesResponse
   = zWorkflowCommentReplyCreate
 
 export const zDeleteAppsByAppIdWorkflowCommentsByCommentIdRepliesByReplyIdPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   comment_id: z.string(),
   reply_id: z.string(),
 })
@@ -4980,7 +4980,7 @@ export const zPutAppsByAppIdWorkflowCommentsByCommentIdRepliesByReplyIdBody
   = zWorkflowCommentReplyPayload
 
 export const zPutAppsByAppIdWorkflowCommentsByCommentIdRepliesByReplyIdPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   comment_id: z.string(),
   reply_id: z.string(),
 })
@@ -4992,7 +4992,7 @@ export const zPutAppsByAppIdWorkflowCommentsByCommentIdRepliesByReplyIdResponse
   = zWorkflowCommentReplyUpdate
 
 export const zPostAppsByAppIdWorkflowCommentsByCommentIdResolvePath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   comment_id: z.string(),
 })
 
@@ -5002,7 +5002,7 @@ export const zPostAppsByAppIdWorkflowCommentsByCommentIdResolvePath = z.object({
 export const zPostAppsByAppIdWorkflowCommentsByCommentIdResolveResponse = zWorkflowCommentResolve
 
 export const zGetAppsByAppIdWorkflowStatisticsAverageAppInteractionsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdWorkflowStatisticsAverageAppInteractionsQuery = z.object({
@@ -5017,7 +5017,7 @@ export const zGetAppsByAppIdWorkflowStatisticsAverageAppInteractionsResponse
   = zWorkflowAverageAppInteractionStatisticResponse
 
 export const zGetAppsByAppIdWorkflowStatisticsDailyConversationsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdWorkflowStatisticsDailyConversationsQuery = z.object({
@@ -5032,7 +5032,7 @@ export const zGetAppsByAppIdWorkflowStatisticsDailyConversationsResponse
   = zWorkflowDailyRunsStatisticResponse
 
 export const zGetAppsByAppIdWorkflowStatisticsDailyTerminalsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdWorkflowStatisticsDailyTerminalsQuery = z.object({
@@ -5047,7 +5047,7 @@ export const zGetAppsByAppIdWorkflowStatisticsDailyTerminalsResponse
   = zWorkflowDailyTerminalsStatisticResponse
 
 export const zGetAppsByAppIdWorkflowStatisticsTokenCostsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdWorkflowStatisticsTokenCostsQuery = z.object({
@@ -5062,7 +5062,7 @@ export const zGetAppsByAppIdWorkflowStatisticsTokenCostsResponse
   = zWorkflowDailyTokenCostStatisticResponse
 
 export const zGetAppsByAppIdWorkflowsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdWorkflowsQuery = z.object({
@@ -5078,7 +5078,7 @@ export const zGetAppsByAppIdWorkflowsQuery = z.object({
 export const zGetAppsByAppIdWorkflowsResponse = zWorkflowPaginationResponse
 
 export const zGetAppsByAppIdWorkflowsDefaultWorkflowBlockConfigsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -5088,7 +5088,7 @@ export const zGetAppsByAppIdWorkflowsDefaultWorkflowBlockConfigsResponse
   = zDefaultBlockConfigsResponse
 
 export const zGetAppsByAppIdWorkflowsDefaultWorkflowBlockConfigsByBlockTypePath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   block_type: z.string(),
 })
 
@@ -5103,7 +5103,7 @@ export const zGetAppsByAppIdWorkflowsDefaultWorkflowBlockConfigsByBlockTypeRespo
   = zDefaultBlockConfigResponse
 
 export const zGetAppsByAppIdWorkflowsDraftPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -5114,7 +5114,7 @@ export const zGetAppsByAppIdWorkflowsDraftResponse = zWorkflowResponse
 export const zPostAppsByAppIdWorkflowsDraftBody = zSyncDraftWorkflowPayload
 
 export const zPostAppsByAppIdWorkflowsDraftPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -5123,7 +5123,7 @@ export const zPostAppsByAppIdWorkflowsDraftPath = z.object({
 export const zPostAppsByAppIdWorkflowsDraftResponse = zSyncDraftWorkflowResponse
 
 export const zGetAppsByAppIdWorkflowsDraftConversationVariablesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -5135,7 +5135,7 @@ export const zPostAppsByAppIdWorkflowsDraftConversationVariablesBody
   = zConversationVariableUpdatePayload
 
 export const zPostAppsByAppIdWorkflowsDraftConversationVariablesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -5144,7 +5144,7 @@ export const zPostAppsByAppIdWorkflowsDraftConversationVariablesPath = z.object(
 export const zPostAppsByAppIdWorkflowsDraftConversationVariablesResponse = zSimpleResultResponse
 
 export const zGetAppsByAppIdWorkflowsDraftEnvironmentVariablesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -5157,7 +5157,7 @@ export const zPostAppsByAppIdWorkflowsDraftEnvironmentVariablesBody
   = zEnvironmentVariableUpdatePayload
 
 export const zPostAppsByAppIdWorkflowsDraftEnvironmentVariablesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -5168,7 +5168,7 @@ export const zPostAppsByAppIdWorkflowsDraftEnvironmentVariablesResponse = zSimpl
 export const zPostAppsByAppIdWorkflowsDraftFeaturesBody = zWorkflowFeaturesPayload
 
 export const zPostAppsByAppIdWorkflowsDraftFeaturesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -5180,7 +5180,7 @@ export const zPostAppsByAppIdWorkflowsDraftHumanInputNodesByNodeIdDeliveryTestBo
   = zHumanInputDeliveryTestPayload
 
 export const zPostAppsByAppIdWorkflowsDraftHumanInputNodesByNodeIdDeliveryTestPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
 })
 
@@ -5194,7 +5194,7 @@ export const zPostAppsByAppIdWorkflowsDraftHumanInputNodesByNodeIdFormPreviewBod
   = zHumanInputFormPreviewPayload
 
 export const zPostAppsByAppIdWorkflowsDraftHumanInputNodesByNodeIdFormPreviewPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
 })
 
@@ -5208,7 +5208,7 @@ export const zPostAppsByAppIdWorkflowsDraftHumanInputNodesByNodeIdFormRunBody
   = zHumanInputFormSubmitPayload
 
 export const zPostAppsByAppIdWorkflowsDraftHumanInputNodesByNodeIdFormRunPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
 })
 
@@ -5221,7 +5221,7 @@ export const zPostAppsByAppIdWorkflowsDraftHumanInputNodesByNodeIdFormRunRespons
 export const zPostAppsByAppIdWorkflowsDraftIterationNodesByNodeIdRunBody = zIterationNodeRunPayload
 
 export const zPostAppsByAppIdWorkflowsDraftIterationNodesByNodeIdRunPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
 })
 
@@ -5233,7 +5233,7 @@ export const zPostAppsByAppIdWorkflowsDraftIterationNodesByNodeIdRunResponse = z
 export const zPostAppsByAppIdWorkflowsDraftLoopNodesByNodeIdRunBody = zLoopNodeRunPayload
 
 export const zPostAppsByAppIdWorkflowsDraftLoopNodesByNodeIdRunPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
 })
 
@@ -5243,7 +5243,7 @@ export const zPostAppsByAppIdWorkflowsDraftLoopNodesByNodeIdRunPath = z.object({
 export const zPostAppsByAppIdWorkflowsDraftLoopNodesByNodeIdRunResponse = zGeneratedAppResponse
 
 export const zGetAppsByAppIdWorkflowsDraftNodesByNodeIdAgentComposerPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
 })
 
@@ -5256,7 +5256,7 @@ export const zGetAppsByAppIdWorkflowsDraftNodesByNodeIdAgentComposerResponse
 export const zPutAppsByAppIdWorkflowsDraftNodesByNodeIdAgentComposerBody = zComposerSavePayload
 
 export const zPutAppsByAppIdWorkflowsDraftNodesByNodeIdAgentComposerPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
 })
 
@@ -5267,7 +5267,7 @@ export const zPutAppsByAppIdWorkflowsDraftNodesByNodeIdAgentComposerResponse
   = zWorkflowAgentComposerResponse
 
 export const zGetAppsByAppIdWorkflowsDraftNodesByNodeIdAgentComposerCandidatesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
 })
 
@@ -5281,7 +5281,7 @@ export const zPostAppsByAppIdWorkflowsDraftNodesByNodeIdAgentComposerImpactBody
   = zComposerSavePayload
 
 export const zPostAppsByAppIdWorkflowsDraftNodesByNodeIdAgentComposerImpactPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
 })
 
@@ -5295,7 +5295,7 @@ export const zPostAppsByAppIdWorkflowsDraftNodesByNodeIdAgentComposerSaveToRoste
   = zComposerSavePayload
 
 export const zPostAppsByAppIdWorkflowsDraftNodesByNodeIdAgentComposerSaveToRosterPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
 })
 
@@ -5309,7 +5309,7 @@ export const zPostAppsByAppIdWorkflowsDraftNodesByNodeIdAgentComposerValidateBod
   = zComposerSavePayload
 
 export const zPostAppsByAppIdWorkflowsDraftNodesByNodeIdAgentComposerValidatePath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
 })
 
@@ -5320,7 +5320,7 @@ export const zPostAppsByAppIdWorkflowsDraftNodesByNodeIdAgentComposerValidateRes
   = zAgentComposerValidateResponse
 
 export const zGetAppsByAppIdWorkflowsDraftNodesByNodeIdLastRunPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
 })
 
@@ -5333,7 +5333,7 @@ export const zGetAppsByAppIdWorkflowsDraftNodesByNodeIdLastRunResponse
 export const zPostAppsByAppIdWorkflowsDraftNodesByNodeIdRunBody = zDraftWorkflowNodeRunPayload
 
 export const zPostAppsByAppIdWorkflowsDraftNodesByNodeIdRunPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
 })
 
@@ -5344,7 +5344,7 @@ export const zPostAppsByAppIdWorkflowsDraftNodesByNodeIdRunResponse
   = zWorkflowRunNodeExecutionResponse
 
 export const zPostAppsByAppIdWorkflowsDraftNodesByNodeIdTriggerRunPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
 })
 
@@ -5354,7 +5354,7 @@ export const zPostAppsByAppIdWorkflowsDraftNodesByNodeIdTriggerRunPath = z.objec
 export const zPostAppsByAppIdWorkflowsDraftNodesByNodeIdTriggerRunResponse = zGeneratedAppResponse
 
 export const zDeleteAppsByAppIdWorkflowsDraftNodesByNodeIdVariablesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
 })
 
@@ -5364,7 +5364,7 @@ export const zDeleteAppsByAppIdWorkflowsDraftNodesByNodeIdVariablesPath = z.obje
 export const zDeleteAppsByAppIdWorkflowsDraftNodesByNodeIdVariablesResponse = z.void()
 
 export const zGetAppsByAppIdWorkflowsDraftNodesByNodeIdVariablesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
 })
 
@@ -5377,7 +5377,7 @@ export const zGetAppsByAppIdWorkflowsDraftNodesByNodeIdVariablesResponse
 export const zPostAppsByAppIdWorkflowsDraftRunBody = zDraftWorkflowRunPayload
 
 export const zPostAppsByAppIdWorkflowsDraftRunPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -5386,8 +5386,8 @@ export const zPostAppsByAppIdWorkflowsDraftRunPath = z.object({
 export const zPostAppsByAppIdWorkflowsDraftRunResponse = zGeneratedAppResponse
 
 export const zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsPath = z.object({
-  app_id: z.string(),
-  run_id: z.string(),
+  app_id: z.uuid(),
+  run_id: z.uuid(),
 })
 
 /**
@@ -5396,8 +5396,8 @@ export const zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsPath = z.object(
 export const zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsResponse = zWorkflowRunSnapshotView
 
 export const zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsEventsPath = z.object({
-  app_id: z.string(),
-  run_id: z.string(),
+  app_id: z.uuid(),
+  run_id: z.uuid(),
 })
 
 /**
@@ -5407,9 +5407,9 @@ export const zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsEventsResponse
   = zEventStreamResponse
 
 export const zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsByNodeIdPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
-  run_id: z.string(),
+  run_id: z.uuid(),
 })
 
 /**
@@ -5419,10 +5419,10 @@ export const zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsByNodeIdResponse
 
 export const zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsByNodeIdByOutputNamePreviewPath
   = z.object({
-    app_id: z.string(),
+    app_id: z.uuid(),
     node_id: z.string(),
     output_name: z.string(),
-    run_id: z.string(),
+    run_id: z.uuid(),
   })
 
 /**
@@ -5432,7 +5432,7 @@ export const zGetAppsByAppIdWorkflowsDraftRunsByRunIdNodeOutputsByNodeIdByOutput
   = zOutputPreviewView
 
 export const zGetAppsByAppIdWorkflowsDraftSystemVariablesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -5443,7 +5443,7 @@ export const zGetAppsByAppIdWorkflowsDraftSystemVariablesResponse = zWorkflowDra
 export const zPostAppsByAppIdWorkflowsDraftTriggerRunBody = zDraftWorkflowTriggerRunRequest
 
 export const zPostAppsByAppIdWorkflowsDraftTriggerRunPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -5454,7 +5454,7 @@ export const zPostAppsByAppIdWorkflowsDraftTriggerRunResponse = zGeneratedAppRes
 export const zPostAppsByAppIdWorkflowsDraftTriggerRunAllBody = zDraftWorkflowTriggerRunAllPayload
 
 export const zPostAppsByAppIdWorkflowsDraftTriggerRunAllPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -5463,7 +5463,7 @@ export const zPostAppsByAppIdWorkflowsDraftTriggerRunAllPath = z.object({
 export const zPostAppsByAppIdWorkflowsDraftTriggerRunAllResponse = zGeneratedAppResponse
 
 export const zDeleteAppsByAppIdWorkflowsDraftVariablesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -5472,7 +5472,7 @@ export const zDeleteAppsByAppIdWorkflowsDraftVariablesPath = z.object({
 export const zDeleteAppsByAppIdWorkflowsDraftVariablesResponse = z.void()
 
 export const zGetAppsByAppIdWorkflowsDraftVariablesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdWorkflowsDraftVariablesQuery = z.object({
@@ -5486,8 +5486,8 @@ export const zGetAppsByAppIdWorkflowsDraftVariablesQuery = z.object({
 export const zGetAppsByAppIdWorkflowsDraftVariablesResponse = zWorkflowDraftVariableListWithoutValue
 
 export const zDeleteAppsByAppIdWorkflowsDraftVariablesByVariableIdPath = z.object({
-  app_id: z.string(),
-  variable_id: z.string(),
+  app_id: z.uuid(),
+  variable_id: z.uuid(),
 })
 
 /**
@@ -5496,8 +5496,8 @@ export const zDeleteAppsByAppIdWorkflowsDraftVariablesByVariableIdPath = z.objec
 export const zDeleteAppsByAppIdWorkflowsDraftVariablesByVariableIdResponse = z.void()
 
 export const zGetAppsByAppIdWorkflowsDraftVariablesByVariableIdPath = z.object({
-  app_id: z.string(),
-  variable_id: z.string(),
+  app_id: z.uuid(),
+  variable_id: z.uuid(),
 })
 
 /**
@@ -5509,8 +5509,8 @@ export const zPatchAppsByAppIdWorkflowsDraftVariablesByVariableIdBody
   = zWorkflowDraftVariableUpdatePayload
 
 export const zPatchAppsByAppIdWorkflowsDraftVariablesByVariableIdPath = z.object({
-  app_id: z.string(),
-  variable_id: z.string(),
+  app_id: z.uuid(),
+  variable_id: z.uuid(),
 })
 
 /**
@@ -5519,8 +5519,8 @@ export const zPatchAppsByAppIdWorkflowsDraftVariablesByVariableIdPath = z.object
 export const zPatchAppsByAppIdWorkflowsDraftVariablesByVariableIdResponse = zWorkflowDraftVariable
 
 export const zPutAppsByAppIdWorkflowsDraftVariablesByVariableIdResetPath = z.object({
-  app_id: z.string(),
-  variable_id: z.string(),
+  app_id: z.uuid(),
+  variable_id: z.uuid(),
 })
 
 export const zPutAppsByAppIdWorkflowsDraftVariablesByVariableIdResetResponse = z.union([
@@ -5529,7 +5529,7 @@ export const zPutAppsByAppIdWorkflowsDraftVariablesByVariableIdResetResponse = z
 ])
 
 export const zGetAppsByAppIdWorkflowsPublishPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -5540,7 +5540,7 @@ export const zGetAppsByAppIdWorkflowsPublishResponse = zWorkflowResponse
 export const zPostAppsByAppIdWorkflowsPublishBody = zPublishWorkflowPayload
 
 export const zPostAppsByAppIdWorkflowsPublishPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -5549,8 +5549,8 @@ export const zPostAppsByAppIdWorkflowsPublishPath = z.object({
 export const zPostAppsByAppIdWorkflowsPublishResponse = zWorkflowPublishResponse
 
 export const zGetAppsByAppIdWorkflowsPublishedRunsByRunIdNodeOutputsPath = z.object({
-  app_id: z.string(),
-  run_id: z.string(),
+  app_id: z.uuid(),
+  run_id: z.uuid(),
 })
 
 /**
@@ -5560,8 +5560,8 @@ export const zGetAppsByAppIdWorkflowsPublishedRunsByRunIdNodeOutputsResponse
   = zWorkflowRunSnapshotView
 
 export const zGetAppsByAppIdWorkflowsPublishedRunsByRunIdNodeOutputsEventsPath = z.object({
-  app_id: z.string(),
-  run_id: z.string(),
+  app_id: z.uuid(),
+  run_id: z.uuid(),
 })
 
 /**
@@ -5571,9 +5571,9 @@ export const zGetAppsByAppIdWorkflowsPublishedRunsByRunIdNodeOutputsEventsRespon
   = zEventStreamResponse
 
 export const zGetAppsByAppIdWorkflowsPublishedRunsByRunIdNodeOutputsByNodeIdPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   node_id: z.string(),
-  run_id: z.string(),
+  run_id: z.uuid(),
 })
 
 /**
@@ -5584,10 +5584,10 @@ export const zGetAppsByAppIdWorkflowsPublishedRunsByRunIdNodeOutputsByNodeIdResp
 
 export const zGetAppsByAppIdWorkflowsPublishedRunsByRunIdNodeOutputsByNodeIdByOutputNamePreviewPath
   = z.object({
-    app_id: z.string(),
+    app_id: z.uuid(),
     node_id: z.string(),
     output_name: z.string(),
-    run_id: z.string(),
+    run_id: z.uuid(),
   })
 
 /**
@@ -5597,7 +5597,7 @@ export const zGetAppsByAppIdWorkflowsPublishedRunsByRunIdNodeOutputsByNodeIdByOu
   = zOutputPreviewView
 
 export const zGetAppsByAppIdWorkflowsTriggersWebhookPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetAppsByAppIdWorkflowsTriggersWebhookQuery = z.object({
@@ -5610,7 +5610,7 @@ export const zGetAppsByAppIdWorkflowsTriggersWebhookQuery = z.object({
 export const zGetAppsByAppIdWorkflowsTriggersWebhookResponse = zWebhookTriggerResponse
 
 export const zDeleteAppsByAppIdWorkflowsByWorkflowIdPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   workflow_id: z.string(),
 })
 
@@ -5622,7 +5622,7 @@ export const zDeleteAppsByAppIdWorkflowsByWorkflowIdResponse = z.void()
 export const zPatchAppsByAppIdWorkflowsByWorkflowIdBody = zWorkflowUpdatePayload
 
 export const zPatchAppsByAppIdWorkflowsByWorkflowIdPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   workflow_id: z.string(),
 })
 
@@ -5632,7 +5632,7 @@ export const zPatchAppsByAppIdWorkflowsByWorkflowIdPath = z.object({
 export const zPatchAppsByAppIdWorkflowsByWorkflowIdResponse = zWorkflowResponse
 
 export const zPostAppsByAppIdWorkflowsByWorkflowIdRestorePath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   workflow_id: z.string(),
 })
 
@@ -5642,7 +5642,7 @@ export const zPostAppsByAppIdWorkflowsByWorkflowIdRestorePath = z.object({
 export const zPostAppsByAppIdWorkflowsByWorkflowIdRestoreResponse = zWorkflowRestoreResponse
 
 export const zGetAppsByResourceIdApiKeysPath = z.object({
-  resource_id: z.string(),
+  resource_id: z.uuid(),
 })
 
 /**
@@ -5651,7 +5651,7 @@ export const zGetAppsByResourceIdApiKeysPath = z.object({
 export const zGetAppsByResourceIdApiKeysResponse = zApiKeyList
 
 export const zPostAppsByResourceIdApiKeysPath = z.object({
-  resource_id: z.string(),
+  resource_id: z.uuid(),
 })
 
 /**
@@ -5660,8 +5660,8 @@ export const zPostAppsByResourceIdApiKeysPath = z.object({
 export const zPostAppsByResourceIdApiKeysResponse = zApiKeyItem
 
 export const zDeleteAppsByResourceIdApiKeysByApiKeyIdPath = z.object({
-  api_key_id: z.string(),
-  resource_id: z.string(),
+  api_key_id: z.uuid(),
+  resource_id: z.uuid(),
 })
 
 /**
@@ -5670,7 +5670,7 @@ export const zDeleteAppsByResourceIdApiKeysByApiKeyIdPath = z.object({
 export const zDeleteAppsByResourceIdApiKeysByApiKeyIdResponse = z.void()
 
 export const zGetAppsByServerIdServerRefreshPath = z.object({
-  server_id: z.string(),
+  server_id: z.uuid(),
 })
 
 /**

--- a/packages/contracts/generated/api/console/data-source/zod.gen.ts
+++ b/packages/contracts/generated/api/console/data-source/zod.gen.ts
@@ -72,7 +72,7 @@ export const zPatchDataSourceIntegratesResponse = zSimpleResultResponse
 
 export const zGetDataSourceIntegratesByBindingIdByActionPath = z.object({
   action: z.string(),
-  binding_id: z.string(),
+  binding_id: z.uuid(),
 })
 
 /**
@@ -82,7 +82,7 @@ export const zGetDataSourceIntegratesByBindingIdByActionResponse = zDataSourceIn
 
 export const zPatchDataSourceIntegratesByBindingIdByActionPath = z.object({
   action: z.string(),
-  binding_id: z.string(),
+  binding_id: z.uuid(),
 })
 
 /**

--- a/packages/contracts/generated/api/console/datasets/zod.gen.ts
+++ b/packages/contracts/generated/api/console/datasets/zod.gen.ts
@@ -1502,7 +1502,7 @@ export const zGetDatasetsApiKeysResponse = zApiKeyList
 export const zPostDatasetsApiKeysResponse = zApiKeyItem
 
 export const zDeleteDatasetsApiKeysByApiKeyIdPath = z.object({
-  api_key_id: z.string(),
+  api_key_id: z.uuid(),
 })
 
 /**
@@ -1511,7 +1511,7 @@ export const zDeleteDatasetsApiKeysByApiKeyIdPath = z.object({
 export const zDeleteDatasetsApiKeysByApiKeyIdResponse = z.void()
 
 export const zGetDatasetsBatchImportStatusByJobIdPath = z.object({
-  job_id: z.string(),
+  job_id: z.uuid(),
 })
 
 /**
@@ -1522,7 +1522,7 @@ export const zGetDatasetsBatchImportStatusByJobIdResponse = zSegmentBatchImportS
 export const zPostDatasetsBatchImportStatusByJobIdBody = zBatchImportPayload
 
 export const zPostDatasetsBatchImportStatusByJobIdPath = z.object({
-  job_id: z.string(),
+  job_id: z.uuid(),
 })
 
 /**
@@ -1556,7 +1556,7 @@ export const zPostDatasetsExternalKnowledgeApiBody = zExternalKnowledgeApiPayloa
 export const zPostDatasetsExternalKnowledgeApiResponse = zExternalKnowledgeApiResponse
 
 export const zDeleteDatasetsExternalKnowledgeApiByExternalKnowledgeApiIdPath = z.object({
-  external_knowledge_api_id: z.string(),
+  external_knowledge_api_id: z.uuid(),
 })
 
 /**
@@ -1565,7 +1565,7 @@ export const zDeleteDatasetsExternalKnowledgeApiByExternalKnowledgeApiIdPath = z
 export const zDeleteDatasetsExternalKnowledgeApiByExternalKnowledgeApiIdResponse = z.void()
 
 export const zGetDatasetsExternalKnowledgeApiByExternalKnowledgeApiIdPath = z.object({
-  external_knowledge_api_id: z.string(),
+  external_knowledge_api_id: z.uuid(),
 })
 
 /**
@@ -1578,7 +1578,7 @@ export const zPatchDatasetsExternalKnowledgeApiByExternalKnowledgeApiIdBody
   = zExternalKnowledgeApiPayload
 
 export const zPatchDatasetsExternalKnowledgeApiByExternalKnowledgeApiIdPath = z.object({
-  external_knowledge_api_id: z.string(),
+  external_knowledge_api_id: z.uuid(),
 })
 
 /**
@@ -1588,7 +1588,7 @@ export const zPatchDatasetsExternalKnowledgeApiByExternalKnowledgeApiIdResponse
   = zExternalKnowledgeApiResponse
 
 export const zGetDatasetsExternalKnowledgeApiByExternalKnowledgeApiIdUseCheckPath = z.object({
-  external_knowledge_api_id: z.string(),
+  external_knowledge_api_id: z.uuid(),
 })
 
 /**
@@ -1647,7 +1647,7 @@ export const zGetDatasetsRetrievalSettingByVectorTypePath = z.object({
 export const zGetDatasetsRetrievalSettingByVectorTypeResponse = zRetrievalSettingResponse
 
 export const zDeleteDatasetsByDatasetIdPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -1656,7 +1656,7 @@ export const zDeleteDatasetsByDatasetIdPath = z.object({
 export const zDeleteDatasetsByDatasetIdResponse = z.void()
 
 export const zGetDatasetsByDatasetIdPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -1667,7 +1667,7 @@ export const zGetDatasetsByDatasetIdResponse = zDatasetDetailWithPartialMembersR
 export const zPatchDatasetsByDatasetIdBody = zDatasetUpdatePayload
 
 export const zPatchDatasetsByDatasetIdPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -1676,7 +1676,7 @@ export const zPatchDatasetsByDatasetIdPath = z.object({
 export const zPatchDatasetsByDatasetIdResponse = zDatasetDetailWithPartialMembersResponse
 
 export const zPostDatasetsByDatasetIdApiKeysByStatusPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
   status: z.string(),
 })
 
@@ -1686,7 +1686,7 @@ export const zPostDatasetsByDatasetIdApiKeysByStatusPath = z.object({
 export const zPostDatasetsByDatasetIdApiKeysByStatusResponse = zSimpleResultResponse
 
 export const zGetDatasetsByDatasetIdAutoDisableLogsPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -1696,7 +1696,7 @@ export const zGetDatasetsByDatasetIdAutoDisableLogsResponse = zAutoDisableLogsRe
 
 export const zGetDatasetsByDatasetIdBatchByBatchIndexingEstimatePath = z.object({
   batch: z.string(),
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -1706,7 +1706,7 @@ export const zGetDatasetsByDatasetIdBatchByBatchIndexingEstimateResponse = zOpaq
 
 export const zGetDatasetsByDatasetIdBatchByBatchIndexingStatusPath = z.object({
   batch: z.string(),
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -1715,7 +1715,7 @@ export const zGetDatasetsByDatasetIdBatchByBatchIndexingStatusPath = z.object({
 export const zGetDatasetsByDatasetIdBatchByBatchIndexingStatusResponse = zDocumentStatusListResponse
 
 export const zDeleteDatasetsByDatasetIdDocumentsPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -1724,7 +1724,7 @@ export const zDeleteDatasetsByDatasetIdDocumentsPath = z.object({
 export const zDeleteDatasetsByDatasetIdDocumentsResponse = z.void()
 
 export const zGetDatasetsByDatasetIdDocumentsPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 export const zGetDatasetsByDatasetIdDocumentsQuery = z.object({
@@ -1744,7 +1744,7 @@ export const zGetDatasetsByDatasetIdDocumentsResponse = zDocumentWithSegmentsLis
 export const zPostDatasetsByDatasetIdDocumentsBody = zKnowledgeConfig
 
 export const zPostDatasetsByDatasetIdDocumentsPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -1755,7 +1755,7 @@ export const zPostDatasetsByDatasetIdDocumentsResponse = zDatasetAndDocumentResp
 export const zPostDatasetsByDatasetIdDocumentsDownloadZipBody = zDocumentBatchDownloadZipPayload
 
 export const zPostDatasetsByDatasetIdDocumentsDownloadZipPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -1766,7 +1766,7 @@ export const zPostDatasetsByDatasetIdDocumentsDownloadZipResponse = zBinaryFileR
 export const zPostDatasetsByDatasetIdDocumentsGenerateSummaryBody = zGenerateSummaryPayload
 
 export const zPostDatasetsByDatasetIdDocumentsGenerateSummaryPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -1777,7 +1777,7 @@ export const zPostDatasetsByDatasetIdDocumentsGenerateSummaryResponse = zSimpleR
 export const zPostDatasetsByDatasetIdDocumentsMetadataBody = zMetadataOperationData
 
 export const zPostDatasetsByDatasetIdDocumentsMetadataPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -1787,7 +1787,7 @@ export const zPostDatasetsByDatasetIdDocumentsMetadataResponse = z.void()
 
 export const zPatchDatasetsByDatasetIdDocumentsStatusByActionBatchPath = z.object({
   action: z.string(),
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -1796,8 +1796,8 @@ export const zPatchDatasetsByDatasetIdDocumentsStatusByActionBatchPath = z.objec
 export const zPatchDatasetsByDatasetIdDocumentsStatusByActionBatchResponse = zSimpleResultResponse
 
 export const zDeleteDatasetsByDatasetIdDocumentsByDocumentIdPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -1806,8 +1806,8 @@ export const zDeleteDatasetsByDatasetIdDocumentsByDocumentIdPath = z.object({
 export const zDeleteDatasetsByDatasetIdDocumentsByDocumentIdResponse = z.void()
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdQuery = z.object({
@@ -1820,8 +1820,8 @@ export const zGetDatasetsByDatasetIdDocumentsByDocumentIdQuery = z.object({
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdResponse = zOpaqueObjectResponse
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdDownloadPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -1830,8 +1830,8 @@ export const zGetDatasetsByDatasetIdDocumentsByDocumentIdDownloadPath = z.object
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdDownloadResponse = zUrlResponse
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdIndexingEstimatePath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -1841,8 +1841,8 @@ export const zGetDatasetsByDatasetIdDocumentsByDocumentIdIndexingEstimateRespons
   = zOpaqueObjectResponse
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdIndexingStatusPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -1855,8 +1855,8 @@ export const zPutDatasetsByDatasetIdDocumentsByDocumentIdMetadataBody
   = zDocumentMetadataUpdatePayload
 
 export const zPutDatasetsByDatasetIdDocumentsByDocumentIdMetadataPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -1866,8 +1866,8 @@ export const zPutDatasetsByDatasetIdDocumentsByDocumentIdMetadataResponse
   = zSimpleResultMessageResponse
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdNotionSyncPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -1876,8 +1876,8 @@ export const zGetDatasetsByDatasetIdDocumentsByDocumentIdNotionSyncPath = z.obje
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdNotionSyncResponse = zSimpleResultResponse
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdPipelineExecutionLogPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -1887,8 +1887,8 @@ export const zGetDatasetsByDatasetIdDocumentsByDocumentIdPipelineExecutionLogRes
   = zOpaqueObjectResponse
 
 export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdProcessingPausePath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -1897,8 +1897,8 @@ export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdProcessingPausePath =
 export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdProcessingPauseResponse = z.void()
 
 export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdProcessingResumePath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -1908,8 +1908,8 @@ export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdProcessingResumeRespo
 
 export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdProcessingByActionPath = z.object({
   action: z.string(),
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -1921,8 +1921,8 @@ export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdProcessingByActionRes
 export const zPostDatasetsByDatasetIdDocumentsByDocumentIdRenameBody = zDocumentRenamePayload
 
 export const zPostDatasetsByDatasetIdDocumentsByDocumentIdRenamePath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -1933,8 +1933,8 @@ export const zPostDatasetsByDatasetIdDocumentsByDocumentIdRenameResponse = zDocu
 export const zPostDatasetsByDatasetIdDocumentsByDocumentIdSegmentBody = zSegmentCreatePayload
 
 export const zPostDatasetsByDatasetIdDocumentsByDocumentIdSegmentPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -1944,8 +1944,8 @@ export const zPostDatasetsByDatasetIdDocumentsByDocumentIdSegmentResponse = zSeg
 
 export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdSegmentByActionPath = z.object({
   action: z.string(),
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdSegmentByActionQuery = z.object({
@@ -1959,8 +1959,8 @@ export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdSegmentByActionRespon
   = zSimpleResultResponse
 
 export const zDeleteDatasetsByDatasetIdDocumentsByDocumentIdSegmentsPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 export const zDeleteDatasetsByDatasetIdDocumentsByDocumentIdSegmentsQuery = z.object({
@@ -1973,8 +1973,8 @@ export const zDeleteDatasetsByDatasetIdDocumentsByDocumentIdSegmentsQuery = z.ob
 export const zDeleteDatasetsByDatasetIdDocumentsByDocumentIdSegmentsResponse = z.void()
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdSegmentsPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdSegmentsQuery = z.object({
@@ -1993,8 +1993,8 @@ export const zGetDatasetsByDatasetIdDocumentsByDocumentIdSegmentsResponse
   = zConsoleSegmentListResponse
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBatchImportPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -2007,8 +2007,8 @@ export const zPostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBatchImportBod
   = zBatchImportPayload
 
 export const zPostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBatchImportPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -2018,9 +2018,9 @@ export const zPostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBatchImportRes
   = zSegmentBatchImportStatusResponse
 
 export const zDeleteDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
-  segment_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
+  segment_id: z.uuid(),
 })
 
 /**
@@ -2032,9 +2032,9 @@ export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdBo
   = zSegmentUpdatePayload
 
 export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
-  segment_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
+  segment_id: z.uuid(),
 })
 
 /**
@@ -2045,9 +2045,9 @@ export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdRe
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChildChunksPath
   = z.object({
-    dataset_id: z.string(),
-    document_id: z.string(),
-    segment_id: z.string(),
+    dataset_id: z.uuid(),
+    document_id: z.uuid(),
+    segment_id: z.uuid(),
   })
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChildChunksQuery
@@ -2068,9 +2068,9 @@ export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdCh
 
 export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChildChunksPath
   = z.object({
-    dataset_id: z.string(),
-    document_id: z.string(),
-    segment_id: z.string(),
+    dataset_id: z.uuid(),
+    document_id: z.uuid(),
+    segment_id: z.uuid(),
   })
 
 /**
@@ -2084,9 +2084,9 @@ export const zPostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChi
 
 export const zPostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChildChunksPath
   = z.object({
-    dataset_id: z.string(),
-    document_id: z.string(),
-    segment_id: z.string(),
+    dataset_id: z.uuid(),
+    document_id: z.uuid(),
+    segment_id: z.uuid(),
   })
 
 /**
@@ -2097,10 +2097,10 @@ export const zPostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChi
 
 export const zDeleteDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChildChunksByChildChunkIdPath
   = z.object({
-    child_chunk_id: z.string(),
-    dataset_id: z.string(),
-    document_id: z.string(),
-    segment_id: z.string(),
+    child_chunk_id: z.uuid(),
+    dataset_id: z.uuid(),
+    document_id: z.uuid(),
+    segment_id: z.uuid(),
   })
 
 /**
@@ -2114,10 +2114,10 @@ export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdCh
 
 export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChildChunksByChildChunkIdPath
   = z.object({
-    child_chunk_id: z.string(),
-    dataset_id: z.string(),
-    document_id: z.string(),
-    segment_id: z.string(),
+    child_chunk_id: z.uuid(),
+    dataset_id: z.uuid(),
+    document_id: z.uuid(),
+    segment_id: z.uuid(),
   })
 
 /**
@@ -2127,8 +2127,8 @@ export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdCh
   = zChildChunkDetailResponse
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdSummaryStatusPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -2138,8 +2138,8 @@ export const zGetDatasetsByDatasetIdDocumentsByDocumentIdSummaryStatusResponse
   = zOpaqueObjectResponse
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdWebsiteSyncPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -2148,7 +2148,7 @@ export const zGetDatasetsByDatasetIdDocumentsByDocumentIdWebsiteSyncPath = z.obj
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdWebsiteSyncResponse = zSimpleResultResponse
 
 export const zGetDatasetsByDatasetIdErrorDocsPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2159,7 +2159,7 @@ export const zGetDatasetsByDatasetIdErrorDocsResponse = zErrorDocsResponse
 export const zPostDatasetsByDatasetIdExternalHitTestingBody = zExternalHitTestingPayload
 
 export const zPostDatasetsByDatasetIdExternalHitTestingPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2170,7 +2170,7 @@ export const zPostDatasetsByDatasetIdExternalHitTestingResponse = zExternalRetri
 export const zPostDatasetsByDatasetIdHitTestingBody = zHitTestingPayload
 
 export const zPostDatasetsByDatasetIdHitTestingPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2179,7 +2179,7 @@ export const zPostDatasetsByDatasetIdHitTestingPath = z.object({
 export const zPostDatasetsByDatasetIdHitTestingResponse = zHitTestingResponse
 
 export const zGetDatasetsByDatasetIdIndexingStatusPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2188,7 +2188,7 @@ export const zGetDatasetsByDatasetIdIndexingStatusPath = z.object({
 export const zGetDatasetsByDatasetIdIndexingStatusResponse = zDocumentStatusListResponse
 
 export const zGetDatasetsByDatasetIdMetadataPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2199,7 +2199,7 @@ export const zGetDatasetsByDatasetIdMetadataResponse = zDatasetMetadataListRespo
 export const zPostDatasetsByDatasetIdMetadataBody = zMetadataArgs
 
 export const zPostDatasetsByDatasetIdMetadataPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2209,7 +2209,7 @@ export const zPostDatasetsByDatasetIdMetadataResponse = zDatasetMetadataResponse
 
 export const zPostDatasetsByDatasetIdMetadataBuiltInByActionPath = z.object({
   action: z.string(),
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2218,8 +2218,8 @@ export const zPostDatasetsByDatasetIdMetadataBuiltInByActionPath = z.object({
 export const zPostDatasetsByDatasetIdMetadataBuiltInByActionResponse = z.void()
 
 export const zDeleteDatasetsByDatasetIdMetadataByMetadataIdPath = z.object({
-  dataset_id: z.string(),
-  metadata_id: z.string(),
+  dataset_id: z.uuid(),
+  metadata_id: z.uuid(),
 })
 
 /**
@@ -2230,8 +2230,8 @@ export const zDeleteDatasetsByDatasetIdMetadataByMetadataIdResponse = z.void()
 export const zPatchDatasetsByDatasetIdMetadataByMetadataIdBody = zMetadataUpdatePayload
 
 export const zPatchDatasetsByDatasetIdMetadataByMetadataIdPath = z.object({
-  dataset_id: z.string(),
-  metadata_id: z.string(),
+  dataset_id: z.uuid(),
+  metadata_id: z.uuid(),
 })
 
 /**
@@ -2240,7 +2240,7 @@ export const zPatchDatasetsByDatasetIdMetadataByMetadataIdPath = z.object({
 export const zPatchDatasetsByDatasetIdMetadataByMetadataIdResponse = zDatasetMetadataResponse
 
 export const zGetDatasetsByDatasetIdNotionSyncPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2249,7 +2249,7 @@ export const zGetDatasetsByDatasetIdNotionSyncPath = z.object({
 export const zGetDatasetsByDatasetIdNotionSyncResponse = zSimpleResultResponse
 
 export const zGetDatasetsByDatasetIdPermissionPartUsersPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2258,7 +2258,7 @@ export const zGetDatasetsByDatasetIdPermissionPartUsersPath = z.object({
 export const zGetDatasetsByDatasetIdPermissionPartUsersResponse = zPartialMemberListResponse
 
 export const zGetDatasetsByDatasetIdQueriesPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2267,7 +2267,7 @@ export const zGetDatasetsByDatasetIdQueriesPath = z.object({
 export const zGetDatasetsByDatasetIdQueriesResponse = zDatasetQueryListResponse
 
 export const zGetDatasetsByDatasetIdRelatedAppsPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2278,7 +2278,7 @@ export const zGetDatasetsByDatasetIdRelatedAppsResponse = zRelatedAppListRespons
 export const zPostDatasetsByDatasetIdRetryBody = zDocumentRetryPayload
 
 export const zPostDatasetsByDatasetIdRetryPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2287,7 +2287,7 @@ export const zPostDatasetsByDatasetIdRetryPath = z.object({
 export const zPostDatasetsByDatasetIdRetryResponse = z.void()
 
 export const zGetDatasetsByDatasetIdUseCheckPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2296,7 +2296,7 @@ export const zGetDatasetsByDatasetIdUseCheckPath = z.object({
 export const zGetDatasetsByDatasetIdUseCheckResponse = zUsageCheckResponse
 
 export const zGetDatasetsByResourceIdApiKeysPath = z.object({
-  resource_id: z.string(),
+  resource_id: z.uuid(),
 })
 
 /**
@@ -2305,7 +2305,7 @@ export const zGetDatasetsByResourceIdApiKeysPath = z.object({
 export const zGetDatasetsByResourceIdApiKeysResponse = zApiKeyList
 
 export const zPostDatasetsByResourceIdApiKeysPath = z.object({
-  resource_id: z.string(),
+  resource_id: z.uuid(),
 })
 
 /**
@@ -2314,8 +2314,8 @@ export const zPostDatasetsByResourceIdApiKeysPath = z.object({
 export const zPostDatasetsByResourceIdApiKeysResponse = zApiKeyItem
 
 export const zDeleteDatasetsByResourceIdApiKeysByApiKeyIdPath = z.object({
-  api_key_id: z.string(),
-  resource_id: z.string(),
+  api_key_id: z.uuid(),
+  resource_id: z.uuid(),
 })
 
 /**

--- a/packages/contracts/generated/api/console/explore/zod.gen.ts
+++ b/packages/contracts/generated/api/console/explore/zod.gen.ts
@@ -86,7 +86,7 @@ export const zGetExploreAppsLearnDifyQuery = z.object({
 export const zGetExploreAppsLearnDifyResponse = zLearnDifyAppListResponse
 
 export const zGetExploreAppsByAppIdPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**

--- a/packages/contracts/generated/api/console/files/zod.gen.ts
+++ b/packages/contracts/generated/api/console/files/zod.gen.ts
@@ -69,7 +69,7 @@ export const zGetFilesUploadResponse = zUploadConfig
 export const zPostFilesUploadResponse = zFileResponse
 
 export const zGetFilesByFileIdPreviewPath = z.object({
-  file_id: z.string(),
+  file_id: z.uuid(),
 })
 
 /**

--- a/packages/contracts/generated/api/console/installed-apps/types.gen.ts
+++ b/packages/contracts/generated/api/console/installed-apps/types.gen.ts
@@ -68,7 +68,16 @@ export type ConversationInfiniteScrollPagination = {
   limit: number
 }
 
-export type ConversationRenamePayload = {
+export type ConversationRenamePayload = (
+  | {
+    auto_generate: true
+    name?: string | null
+  }
+  | {
+    auto_generate?: false
+    name: string
+  }
+) & {
   auto_generate?: boolean
   name?: string | null
 }

--- a/packages/contracts/generated/api/console/installed-apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/installed-apps/zod.gen.ts
@@ -530,7 +530,7 @@ export const zPostInstalledAppsBody = zInstalledAppCreatePayload
 export const zPostInstalledAppsResponse = zSimpleMessageResponse
 
 export const zDeleteInstalledAppsByInstalledAppIdPath = z.object({
-  installed_app_id: z.string(),
+  installed_app_id: z.uuid(),
 })
 
 /**
@@ -541,7 +541,7 @@ export const zDeleteInstalledAppsByInstalledAppIdResponse = z.void()
 export const zPatchInstalledAppsByInstalledAppIdBody = zInstalledAppUpdatePayload
 
 export const zPatchInstalledAppsByInstalledAppIdPath = z.object({
-  installed_app_id: z.string(),
+  installed_app_id: z.uuid(),
 })
 
 /**
@@ -550,7 +550,7 @@ export const zPatchInstalledAppsByInstalledAppIdPath = z.object({
 export const zPatchInstalledAppsByInstalledAppIdResponse = zSimpleResultMessageResponse
 
 export const zPostInstalledAppsByInstalledAppIdAudioToTextPath = z.object({
-  installed_app_id: z.string(),
+  installed_app_id: z.uuid(),
 })
 
 /**
@@ -561,7 +561,7 @@ export const zPostInstalledAppsByInstalledAppIdAudioToTextResponse = zAudioTrans
 export const zPostInstalledAppsByInstalledAppIdChatMessagesBody = zChatMessagePayload
 
 export const zPostInstalledAppsByInstalledAppIdChatMessagesPath = z.object({
-  installed_app_id: z.string(),
+  installed_app_id: z.uuid(),
 })
 
 /**
@@ -570,7 +570,7 @@ export const zPostInstalledAppsByInstalledAppIdChatMessagesPath = z.object({
 export const zPostInstalledAppsByInstalledAppIdChatMessagesResponse = zGeneratedAppResponse
 
 export const zPostInstalledAppsByInstalledAppIdChatMessagesByTaskIdStopPath = z.object({
-  installed_app_id: z.string(),
+  installed_app_id: z.uuid(),
   task_id: z.string(),
 })
 
@@ -584,7 +584,7 @@ export const zPostInstalledAppsByInstalledAppIdCompletionMessagesBody
   = zCompletionMessageExplorePayload
 
 export const zPostInstalledAppsByInstalledAppIdCompletionMessagesPath = z.object({
-  installed_app_id: z.string(),
+  installed_app_id: z.uuid(),
 })
 
 /**
@@ -593,7 +593,7 @@ export const zPostInstalledAppsByInstalledAppIdCompletionMessagesPath = z.object
 export const zPostInstalledAppsByInstalledAppIdCompletionMessagesResponse = zGeneratedAppResponse
 
 export const zPostInstalledAppsByInstalledAppIdCompletionMessagesByTaskIdStopPath = z.object({
-  installed_app_id: z.string(),
+  installed_app_id: z.uuid(),
   task_id: z.string(),
 })
 
@@ -604,7 +604,7 @@ export const zPostInstalledAppsByInstalledAppIdCompletionMessagesByTaskIdStopRes
   = zSimpleResultResponse
 
 export const zGetInstalledAppsByInstalledAppIdConversationsPath = z.object({
-  installed_app_id: z.string(),
+  installed_app_id: z.uuid(),
 })
 
 export const zGetInstalledAppsByInstalledAppIdConversationsQuery = z.object({
@@ -620,8 +620,8 @@ export const zGetInstalledAppsByInstalledAppIdConversationsResponse
   = zConversationInfiniteScrollPagination
 
 export const zDeleteInstalledAppsByInstalledAppIdConversationsByCIdPath = z.object({
-  c_id: z.string(),
-  installed_app_id: z.string(),
+  c_id: z.uuid(),
+  installed_app_id: z.uuid(),
 })
 
 /**
@@ -633,8 +633,8 @@ export const zPostInstalledAppsByInstalledAppIdConversationsByCIdNameBody
   = zConversationRenamePayload
 
 export const zPostInstalledAppsByInstalledAppIdConversationsByCIdNamePath = z.object({
-  c_id: z.string(),
-  installed_app_id: z.string(),
+  c_id: z.uuid(),
+  installed_app_id: z.uuid(),
 })
 
 /**
@@ -643,8 +643,8 @@ export const zPostInstalledAppsByInstalledAppIdConversationsByCIdNamePath = z.ob
 export const zPostInstalledAppsByInstalledAppIdConversationsByCIdNameResponse = zSimpleConversation
 
 export const zPatchInstalledAppsByInstalledAppIdConversationsByCIdPinPath = z.object({
-  c_id: z.string(),
-  installed_app_id: z.string(),
+  c_id: z.uuid(),
+  installed_app_id: z.uuid(),
 })
 
 /**
@@ -653,8 +653,8 @@ export const zPatchInstalledAppsByInstalledAppIdConversationsByCIdPinPath = z.ob
 export const zPatchInstalledAppsByInstalledAppIdConversationsByCIdPinResponse = zResultResponse
 
 export const zPatchInstalledAppsByInstalledAppIdConversationsByCIdUnpinPath = z.object({
-  c_id: z.string(),
-  installed_app_id: z.string(),
+  c_id: z.uuid(),
+  installed_app_id: z.uuid(),
 })
 
 /**
@@ -663,7 +663,7 @@ export const zPatchInstalledAppsByInstalledAppIdConversationsByCIdUnpinPath = z.
 export const zPatchInstalledAppsByInstalledAppIdConversationsByCIdUnpinResponse = zResultResponse
 
 export const zGetInstalledAppsByInstalledAppIdMessagesPath = z.object({
-  installed_app_id: z.string(),
+  installed_app_id: z.uuid(),
 })
 
 export const zGetInstalledAppsByInstalledAppIdMessagesQuery = z.object({
@@ -681,8 +681,8 @@ export const zPostInstalledAppsByInstalledAppIdMessagesByMessageIdFeedbacksBody
   = zMessageFeedbackPayload
 
 export const zPostInstalledAppsByInstalledAppIdMessagesByMessageIdFeedbacksPath = z.object({
-  installed_app_id: z.string(),
-  message_id: z.string(),
+  installed_app_id: z.uuid(),
+  message_id: z.uuid(),
 })
 
 /**
@@ -692,8 +692,8 @@ export const zPostInstalledAppsByInstalledAppIdMessagesByMessageIdFeedbacksRespo
   = zResultResponse
 
 export const zGetInstalledAppsByInstalledAppIdMessagesByMessageIdMoreLikeThisPath = z.object({
-  installed_app_id: z.string(),
-  message_id: z.string(),
+  installed_app_id: z.uuid(),
+  message_id: z.uuid(),
 })
 
 export const zGetInstalledAppsByInstalledAppIdMessagesByMessageIdMoreLikeThisQuery = z.object({
@@ -707,8 +707,8 @@ export const zGetInstalledAppsByInstalledAppIdMessagesByMessageIdMoreLikeThisRes
   = zGeneratedAppResponse
 
 export const zGetInstalledAppsByInstalledAppIdMessagesByMessageIdSuggestedQuestionsPath = z.object({
-  installed_app_id: z.string(),
-  message_id: z.string(),
+  installed_app_id: z.uuid(),
+  message_id: z.uuid(),
 })
 
 /**
@@ -718,7 +718,7 @@ export const zGetInstalledAppsByInstalledAppIdMessagesByMessageIdSuggestedQuesti
   = zSuggestedQuestionsResponse
 
 export const zGetInstalledAppsByInstalledAppIdMetaPath = z.object({
-  installed_app_id: z.string(),
+  installed_app_id: z.uuid(),
 })
 
 /**
@@ -727,7 +727,7 @@ export const zGetInstalledAppsByInstalledAppIdMetaPath = z.object({
 export const zGetInstalledAppsByInstalledAppIdMetaResponse = zExploreAppMetaResponse
 
 export const zGetInstalledAppsByInstalledAppIdParametersPath = z.object({
-  installed_app_id: z.string(),
+  installed_app_id: z.uuid(),
 })
 
 /**
@@ -736,7 +736,7 @@ export const zGetInstalledAppsByInstalledAppIdParametersPath = z.object({
 export const zGetInstalledAppsByInstalledAppIdParametersResponse = zParameters
 
 export const zGetInstalledAppsByInstalledAppIdSavedMessagesPath = z.object({
-  installed_app_id: z.string(),
+  installed_app_id: z.uuid(),
 })
 
 export const zGetInstalledAppsByInstalledAppIdSavedMessagesQuery = z.object({
@@ -753,7 +753,7 @@ export const zGetInstalledAppsByInstalledAppIdSavedMessagesResponse
 export const zPostInstalledAppsByInstalledAppIdSavedMessagesBody = zSavedMessageCreatePayload
 
 export const zPostInstalledAppsByInstalledAppIdSavedMessagesPath = z.object({
-  installed_app_id: z.string(),
+  installed_app_id: z.uuid(),
 })
 
 /**
@@ -762,8 +762,8 @@ export const zPostInstalledAppsByInstalledAppIdSavedMessagesPath = z.object({
 export const zPostInstalledAppsByInstalledAppIdSavedMessagesResponse = zResultResponse
 
 export const zDeleteInstalledAppsByInstalledAppIdSavedMessagesByMessageIdPath = z.object({
-  installed_app_id: z.string(),
-  message_id: z.string(),
+  installed_app_id: z.uuid(),
+  message_id: z.uuid(),
 })
 
 /**
@@ -774,7 +774,7 @@ export const zDeleteInstalledAppsByInstalledAppIdSavedMessagesByMessageIdRespons
 export const zPostInstalledAppsByInstalledAppIdTextToAudioBody = zTextToAudioPayload
 
 export const zPostInstalledAppsByInstalledAppIdTextToAudioPath = z.object({
-  installed_app_id: z.string(),
+  installed_app_id: z.uuid(),
 })
 
 /**
@@ -785,7 +785,7 @@ export const zPostInstalledAppsByInstalledAppIdTextToAudioResponse = zAudioBinar
 export const zPostInstalledAppsByInstalledAppIdWorkflowsRunBody = zWorkflowRunPayload
 
 export const zPostInstalledAppsByInstalledAppIdWorkflowsRunPath = z.object({
-  installed_app_id: z.string(),
+  installed_app_id: z.uuid(),
 })
 
 /**
@@ -794,7 +794,7 @@ export const zPostInstalledAppsByInstalledAppIdWorkflowsRunPath = z.object({
 export const zPostInstalledAppsByInstalledAppIdWorkflowsRunResponse = zGeneratedAppResponse
 
 export const zPostInstalledAppsByInstalledAppIdWorkflowsTasksByTaskIdStopPath = z.object({
-  installed_app_id: z.string(),
+  installed_app_id: z.uuid(),
   task_id: z.string(),
 })
 

--- a/packages/contracts/generated/api/console/installed-apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/installed-apps/zod.gen.ts
@@ -70,13 +70,22 @@ export const zCompletionMessageExplorePayload = z.object({
   retriever_from: z.string().optional().default('explore_app'),
 })
 
-/**
- * ConversationRenamePayload
- */
-export const zConversationRenamePayload = z.object({
-  auto_generate: z.boolean().optional().default(false),
-  name: z.string().nullish(),
-})
+export const zConversationRenamePayload = z.intersection(
+  z.union([
+    z.object({
+      auto_generate: z.literal(true),
+      name: z.string().nullish(),
+    }),
+    z.object({
+      auto_generate: z.literal(false).optional().default(false),
+      name: z.string().regex(/.*\S.*/),
+    }),
+  ]),
+  z.object({
+    auto_generate: z.boolean().optional().default(false),
+    name: z.string().nullish(),
+  }),
+)
 
 /**
  * ResultResponse

--- a/packages/contracts/generated/api/console/notion/zod.gen.ts
+++ b/packages/contracts/generated/api/console/notion/zod.gen.ts
@@ -48,7 +48,7 @@ export const zNotionIntegrateInfoListResponse = z.object({
 })
 
 export const zGetNotionPagesByPageIdByPageTypePreviewPath = z.object({
-  page_id: z.string(),
+  page_id: z.uuid(),
   page_type: z.string(),
 })
 

--- a/packages/contracts/generated/api/console/oauth/zod.gen.ts
+++ b/packages/contracts/generated/api/console/oauth/zod.gen.ts
@@ -117,7 +117,7 @@ export const zGetOauthDataSourceByProviderPath = z.object({
 export const zGetOauthDataSourceByProviderResponse = zOAuthDataSourceResponse
 
 export const zGetOauthDataSourceByProviderByBindingIdSyncPath = z.object({
-  binding_id: z.string(),
+  binding_id: z.uuid(),
   provider: z.string(),
 })
 

--- a/packages/contracts/generated/api/console/rag/zod.gen.ts
+++ b/packages/contracts/generated/api/console/rag/zod.gen.ts
@@ -777,7 +777,7 @@ export const zGetRagPipelinesRecommendedPluginsQuery = z.object({
 export const zGetRagPipelinesRecommendedPluginsResponse = zRagPipelineOpaqueResponse
 
 export const zPostRagPipelinesTransformDatasetsByDatasetIdPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -810,7 +810,7 @@ export const zGetRagPipelinesByPipelineIdExportsQuery = z.object({
 export const zGetRagPipelinesByPipelineIdExportsResponse = zSimpleDataResponse
 
 export const zGetRagPipelinesByPipelineIdWorkflowRunsPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 export const zGetRagPipelinesByPipelineIdWorkflowRunsQuery = z.object({
@@ -824,7 +824,7 @@ export const zGetRagPipelinesByPipelineIdWorkflowRunsQuery = z.object({
 export const zGetRagPipelinesByPipelineIdWorkflowRunsResponse = zWorkflowRunPaginationResponse
 
 export const zPostRagPipelinesByPipelineIdWorkflowRunsTasksByTaskIdStopPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
   task_id: z.string(),
 })
 
@@ -835,8 +835,8 @@ export const zPostRagPipelinesByPipelineIdWorkflowRunsTasksByTaskIdStopResponse
   = zSimpleResultResponse
 
 export const zGetRagPipelinesByPipelineIdWorkflowRunsByRunIdPath = z.object({
-  pipeline_id: z.string(),
-  run_id: z.string(),
+  pipeline_id: z.uuid(),
+  run_id: z.uuid(),
 })
 
 /**
@@ -845,8 +845,8 @@ export const zGetRagPipelinesByPipelineIdWorkflowRunsByRunIdPath = z.object({
 export const zGetRagPipelinesByPipelineIdWorkflowRunsByRunIdResponse = zWorkflowRunDetailResponse
 
 export const zGetRagPipelinesByPipelineIdWorkflowRunsByRunIdNodeExecutionsPath = z.object({
-  pipeline_id: z.string(),
-  run_id: z.string(),
+  pipeline_id: z.uuid(),
+  run_id: z.uuid(),
 })
 
 /**
@@ -856,7 +856,7 @@ export const zGetRagPipelinesByPipelineIdWorkflowRunsByRunIdNodeExecutionsRespon
   = zWorkflowRunNodeExecutionListResponse
 
 export const zGetRagPipelinesByPipelineIdWorkflowsPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 export const zGetRagPipelinesByPipelineIdWorkflowsQuery = z.object({
@@ -872,7 +872,7 @@ export const zGetRagPipelinesByPipelineIdWorkflowsQuery = z.object({
 export const zGetRagPipelinesByPipelineIdWorkflowsResponse = zWorkflowPaginationResponse
 
 export const zGetRagPipelinesByPipelineIdWorkflowsDefaultWorkflowBlockConfigsPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 /**
@@ -884,7 +884,7 @@ export const zGetRagPipelinesByPipelineIdWorkflowsDefaultWorkflowBlockConfigsRes
 export const zGetRagPipelinesByPipelineIdWorkflowsDefaultWorkflowBlockConfigsByBlockTypePath
   = z.object({
     block_type: z.string(),
-    pipeline_id: z.string(),
+    pipeline_id: z.uuid(),
   })
 
 export const zGetRagPipelinesByPipelineIdWorkflowsDefaultWorkflowBlockConfigsByBlockTypeQuery
@@ -899,7 +899,7 @@ export const zGetRagPipelinesByPipelineIdWorkflowsDefaultWorkflowBlockConfigsByB
   = zDefaultBlockConfigResponse
 
 export const zGetRagPipelinesByPipelineIdWorkflowsDraftPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 /**
@@ -910,7 +910,7 @@ export const zGetRagPipelinesByPipelineIdWorkflowsDraftResponse = zWorkflowRespo
 export const zPostRagPipelinesByPipelineIdWorkflowsDraftBody = zDraftWorkflowSyncPayload
 
 export const zPostRagPipelinesByPipelineIdWorkflowsDraftPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 /**
@@ -923,7 +923,7 @@ export const zPostRagPipelinesByPipelineIdWorkflowsDraftDatasourceNodesByNodeIdR
 
 export const zPostRagPipelinesByPipelineIdWorkflowsDraftDatasourceNodesByNodeIdRunPath = z.object({
   node_id: z.string(),
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 /**
@@ -936,7 +936,7 @@ export const zPostRagPipelinesByPipelineIdWorkflowsDraftDatasourceVariablesInspe
   = zDatasourceVariablesPayload
 
 export const zPostRagPipelinesByPipelineIdWorkflowsDraftDatasourceVariablesInspectPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 /**
@@ -946,7 +946,7 @@ export const zPostRagPipelinesByPipelineIdWorkflowsDraftDatasourceVariablesInspe
   = zWorkflowRunNodeExecutionResponse
 
 export const zGetRagPipelinesByPipelineIdWorkflowsDraftEnvironmentVariablesPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 /**
@@ -960,7 +960,7 @@ export const zPostRagPipelinesByPipelineIdWorkflowsDraftIterationNodesByNodeIdRu
 
 export const zPostRagPipelinesByPipelineIdWorkflowsDraftIterationNodesByNodeIdRunPath = z.object({
   node_id: z.string(),
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 /**
@@ -973,7 +973,7 @@ export const zPostRagPipelinesByPipelineIdWorkflowsDraftLoopNodesByNodeIdRunBody
 
 export const zPostRagPipelinesByPipelineIdWorkflowsDraftLoopNodesByNodeIdRunPath = z.object({
   node_id: z.string(),
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 /**
@@ -984,7 +984,7 @@ export const zPostRagPipelinesByPipelineIdWorkflowsDraftLoopNodesByNodeIdRunResp
 
 export const zGetRagPipelinesByPipelineIdWorkflowsDraftNodesByNodeIdLastRunPath = z.object({
   node_id: z.string(),
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 /**
@@ -998,7 +998,7 @@ export const zPostRagPipelinesByPipelineIdWorkflowsDraftNodesByNodeIdRunBody
 
 export const zPostRagPipelinesByPipelineIdWorkflowsDraftNodesByNodeIdRunPath = z.object({
   node_id: z.string(),
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 /**
@@ -1009,7 +1009,7 @@ export const zPostRagPipelinesByPipelineIdWorkflowsDraftNodesByNodeIdRunResponse
 
 export const zDeleteRagPipelinesByPipelineIdWorkflowsDraftNodesByNodeIdVariablesPath = z.object({
   node_id: z.string(),
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 /**
@@ -1019,7 +1019,7 @@ export const zDeleteRagPipelinesByPipelineIdWorkflowsDraftNodesByNodeIdVariables
 
 export const zGetRagPipelinesByPipelineIdWorkflowsDraftNodesByNodeIdVariablesPath = z.object({
   node_id: z.string(),
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 /**
@@ -1029,7 +1029,7 @@ export const zGetRagPipelinesByPipelineIdWorkflowsDraftNodesByNodeIdVariablesRes
   = zWorkflowDraftVariableList
 
 export const zGetRagPipelinesByPipelineIdWorkflowsDraftPreProcessingParametersPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 export const zGetRagPipelinesByPipelineIdWorkflowsDraftPreProcessingParametersQuery = z.object({
@@ -1043,7 +1043,7 @@ export const zGetRagPipelinesByPipelineIdWorkflowsDraftPreProcessingParametersRe
   = zRagPipelineStepParametersResponse
 
 export const zGetRagPipelinesByPipelineIdWorkflowsDraftProcessingParametersPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 export const zGetRagPipelinesByPipelineIdWorkflowsDraftProcessingParametersQuery = z.object({
@@ -1059,7 +1059,7 @@ export const zGetRagPipelinesByPipelineIdWorkflowsDraftProcessingParametersRespo
 export const zPostRagPipelinesByPipelineIdWorkflowsDraftRunBody = zDraftWorkflowRunPayload
 
 export const zPostRagPipelinesByPipelineIdWorkflowsDraftRunPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 /**
@@ -1068,7 +1068,7 @@ export const zPostRagPipelinesByPipelineIdWorkflowsDraftRunPath = z.object({
 export const zPostRagPipelinesByPipelineIdWorkflowsDraftRunResponse = zRagPipelineOpaqueResponse
 
 export const zGetRagPipelinesByPipelineIdWorkflowsDraftSystemVariablesPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 /**
@@ -1078,7 +1078,7 @@ export const zGetRagPipelinesByPipelineIdWorkflowsDraftSystemVariablesResponse
   = zWorkflowDraftVariableList
 
 export const zDeleteRagPipelinesByPipelineIdWorkflowsDraftVariablesPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 /**
@@ -1087,7 +1087,7 @@ export const zDeleteRagPipelinesByPipelineIdWorkflowsDraftVariablesPath = z.obje
 export const zDeleteRagPipelinesByPipelineIdWorkflowsDraftVariablesResponse = z.void()
 
 export const zGetRagPipelinesByPipelineIdWorkflowsDraftVariablesPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 export const zGetRagPipelinesByPipelineIdWorkflowsDraftVariablesQuery = z.object({
@@ -1102,8 +1102,8 @@ export const zGetRagPipelinesByPipelineIdWorkflowsDraftVariablesResponse
   = zWorkflowDraftVariableListWithoutValue
 
 export const zDeleteRagPipelinesByPipelineIdWorkflowsDraftVariablesByVariableIdPath = z.object({
-  pipeline_id: z.string(),
-  variable_id: z.string(),
+  pipeline_id: z.uuid(),
+  variable_id: z.uuid(),
 })
 
 /**
@@ -1112,8 +1112,8 @@ export const zDeleteRagPipelinesByPipelineIdWorkflowsDraftVariablesByVariableIdP
 export const zDeleteRagPipelinesByPipelineIdWorkflowsDraftVariablesByVariableIdResponse = z.void()
 
 export const zGetRagPipelinesByPipelineIdWorkflowsDraftVariablesByVariableIdPath = z.object({
-  pipeline_id: z.string(),
-  variable_id: z.string(),
+  pipeline_id: z.uuid(),
+  variable_id: z.uuid(),
 })
 
 /**
@@ -1126,8 +1126,8 @@ export const zPatchRagPipelinesByPipelineIdWorkflowsDraftVariablesByVariableIdBo
   = zWorkflowDraftVariablePatchPayload
 
 export const zPatchRagPipelinesByPipelineIdWorkflowsDraftVariablesByVariableIdPath = z.object({
-  pipeline_id: z.string(),
-  variable_id: z.string(),
+  pipeline_id: z.uuid(),
+  variable_id: z.uuid(),
 })
 
 /**
@@ -1137,8 +1137,8 @@ export const zPatchRagPipelinesByPipelineIdWorkflowsDraftVariablesByVariableIdRe
   = zWorkflowDraftVariable
 
 export const zPutRagPipelinesByPipelineIdWorkflowsDraftVariablesByVariableIdResetPath = z.object({
-  pipeline_id: z.string(),
-  variable_id: z.string(),
+  pipeline_id: z.uuid(),
+  variable_id: z.uuid(),
 })
 
 export const zPutRagPipelinesByPipelineIdWorkflowsDraftVariablesByVariableIdResetResponse = z.union(
@@ -1146,7 +1146,7 @@ export const zPutRagPipelinesByPipelineIdWorkflowsDraftVariablesByVariableIdRese
 )
 
 export const zGetRagPipelinesByPipelineIdWorkflowsPublishPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 /**
@@ -1155,7 +1155,7 @@ export const zGetRagPipelinesByPipelineIdWorkflowsPublishPath = z.object({
 export const zGetRagPipelinesByPipelineIdWorkflowsPublishResponse = zWorkflowResponse
 
 export const zPostRagPipelinesByPipelineIdWorkflowsPublishPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 /**
@@ -1170,7 +1170,7 @@ export const zPostRagPipelinesByPipelineIdWorkflowsPublishedDatasourceNodesByNod
 export const zPostRagPipelinesByPipelineIdWorkflowsPublishedDatasourceNodesByNodeIdPreviewPath
   = z.object({
     node_id: z.string(),
-    pipeline_id: z.string(),
+    pipeline_id: z.uuid(),
   })
 
 /**
@@ -1185,7 +1185,7 @@ export const zPostRagPipelinesByPipelineIdWorkflowsPublishedDatasourceNodesByNod
 export const zPostRagPipelinesByPipelineIdWorkflowsPublishedDatasourceNodesByNodeIdRunPath
   = z.object({
     node_id: z.string(),
-    pipeline_id: z.string(),
+    pipeline_id: z.uuid(),
   })
 
 /**
@@ -1195,7 +1195,7 @@ export const zPostRagPipelinesByPipelineIdWorkflowsPublishedDatasourceNodesByNod
   = zRagPipelineOpaqueResponse
 
 export const zGetRagPipelinesByPipelineIdWorkflowsPublishedPreProcessingParametersPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 export const zGetRagPipelinesByPipelineIdWorkflowsPublishedPreProcessingParametersQuery = z.object({
@@ -1209,7 +1209,7 @@ export const zGetRagPipelinesByPipelineIdWorkflowsPublishedPreProcessingParamete
   = zRagPipelineStepParametersResponse
 
 export const zGetRagPipelinesByPipelineIdWorkflowsPublishedProcessingParametersPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 export const zGetRagPipelinesByPipelineIdWorkflowsPublishedProcessingParametersQuery = z.object({
@@ -1225,7 +1225,7 @@ export const zGetRagPipelinesByPipelineIdWorkflowsPublishedProcessingParametersR
 export const zPostRagPipelinesByPipelineIdWorkflowsPublishedRunBody = zPublishedWorkflowRunPayload
 
 export const zPostRagPipelinesByPipelineIdWorkflowsPublishedRunPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
 })
 
 /**
@@ -1234,7 +1234,7 @@ export const zPostRagPipelinesByPipelineIdWorkflowsPublishedRunPath = z.object({
 export const zPostRagPipelinesByPipelineIdWorkflowsPublishedRunResponse = zRagPipelineOpaqueResponse
 
 export const zDeleteRagPipelinesByPipelineIdWorkflowsByWorkflowIdPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
   workflow_id: z.string(),
 })
 
@@ -1246,7 +1246,7 @@ export const zDeleteRagPipelinesByPipelineIdWorkflowsByWorkflowIdResponse = z.vo
 export const zPatchRagPipelinesByPipelineIdWorkflowsByWorkflowIdBody = zWorkflowUpdatePayload
 
 export const zPatchRagPipelinesByPipelineIdWorkflowsByWorkflowIdPath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
   workflow_id: z.string(),
 })
 
@@ -1256,7 +1256,7 @@ export const zPatchRagPipelinesByPipelineIdWorkflowsByWorkflowIdPath = z.object(
 export const zPatchRagPipelinesByPipelineIdWorkflowsByWorkflowIdResponse = zWorkflowResponse
 
 export const zPostRagPipelinesByPipelineIdWorkflowsByWorkflowIdRestorePath = z.object({
-  pipeline_id: z.string(),
+  pipeline_id: z.uuid(),
   workflow_id: z.string(),
 })
 

--- a/packages/contracts/generated/api/console/snippets/zod.gen.ts
+++ b/packages/contracts/generated/api/console/snippets/zod.gen.ts
@@ -387,7 +387,7 @@ export const zWorkflowDraftVariableListWithoutValue = z.object({
 })
 
 export const zGetSnippetsBySnippetIdWorkflowRunsPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 export const zGetSnippetsBySnippetIdWorkflowRunsQuery = z.object({
@@ -401,7 +401,7 @@ export const zGetSnippetsBySnippetIdWorkflowRunsQuery = z.object({
 export const zGetSnippetsBySnippetIdWorkflowRunsResponse = zWorkflowRunPaginationResponse
 
 export const zPostSnippetsBySnippetIdWorkflowRunsTasksByTaskIdStopPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
   task_id: z.string(),
 })
 
@@ -411,8 +411,8 @@ export const zPostSnippetsBySnippetIdWorkflowRunsTasksByTaskIdStopPath = z.objec
 export const zPostSnippetsBySnippetIdWorkflowRunsTasksByTaskIdStopResponse = zSimpleResultResponse
 
 export const zGetSnippetsBySnippetIdWorkflowRunsByRunIdPath = z.object({
-  run_id: z.string(),
-  snippet_id: z.string(),
+  run_id: z.uuid(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -421,8 +421,8 @@ export const zGetSnippetsBySnippetIdWorkflowRunsByRunIdPath = z.object({
 export const zGetSnippetsBySnippetIdWorkflowRunsByRunIdResponse = zWorkflowRunDetailResponse
 
 export const zGetSnippetsBySnippetIdWorkflowRunsByRunIdNodeExecutionsPath = z.object({
-  run_id: z.string(),
-  snippet_id: z.string(),
+  run_id: z.uuid(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -432,7 +432,7 @@ export const zGetSnippetsBySnippetIdWorkflowRunsByRunIdNodeExecutionsResponse
   = zWorkflowRunNodeExecutionListResponse
 
 export const zGetSnippetsBySnippetIdWorkflowsPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 export const zGetSnippetsBySnippetIdWorkflowsQuery = z.object({
@@ -446,7 +446,7 @@ export const zGetSnippetsBySnippetIdWorkflowsQuery = z.object({
 export const zGetSnippetsBySnippetIdWorkflowsResponse = zWorkflowPaginationResponse
 
 export const zGetSnippetsBySnippetIdWorkflowsDefaultWorkflowBlockConfigsPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -456,7 +456,7 @@ export const zGetSnippetsBySnippetIdWorkflowsDefaultWorkflowBlockConfigsResponse
   = zDefaultBlockConfigsResponse
 
 export const zGetSnippetsBySnippetIdWorkflowsDraftPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -467,7 +467,7 @@ export const zGetSnippetsBySnippetIdWorkflowsDraftResponse = zSnippetWorkflowRes
 export const zPostSnippetsBySnippetIdWorkflowsDraftBody = zSnippetDraftSyncPayload
 
 export const zPostSnippetsBySnippetIdWorkflowsDraftPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -476,7 +476,7 @@ export const zPostSnippetsBySnippetIdWorkflowsDraftPath = z.object({
 export const zPostSnippetsBySnippetIdWorkflowsDraftResponse = zWorkflowRestoreResponse
 
 export const zGetSnippetsBySnippetIdWorkflowsDraftConfigPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -485,7 +485,7 @@ export const zGetSnippetsBySnippetIdWorkflowsDraftConfigPath = z.object({
 export const zGetSnippetsBySnippetIdWorkflowsDraftConfigResponse = zSnippetDraftConfigResponse
 
 export const zGetSnippetsBySnippetIdWorkflowsDraftConversationVariablesPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -495,7 +495,7 @@ export const zGetSnippetsBySnippetIdWorkflowsDraftConversationVariablesResponse
   = zWorkflowDraftVariableList
 
 export const zGetSnippetsBySnippetIdWorkflowsDraftEnvironmentVariablesPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -509,7 +509,7 @@ export const zPostSnippetsBySnippetIdWorkflowsDraftIterationNodesByNodeIdRunBody
 
 export const zPostSnippetsBySnippetIdWorkflowsDraftIterationNodesByNodeIdRunPath = z.object({
   node_id: z.string(),
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -523,7 +523,7 @@ export const zPostSnippetsBySnippetIdWorkflowsDraftLoopNodesByNodeIdRunBody
 
 export const zPostSnippetsBySnippetIdWorkflowsDraftLoopNodesByNodeIdRunPath = z.object({
   node_id: z.string(),
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -534,7 +534,7 @@ export const zPostSnippetsBySnippetIdWorkflowsDraftLoopNodesByNodeIdRunResponse
 
 export const zGetSnippetsBySnippetIdWorkflowsDraftNodesByNodeIdLastRunPath = z.object({
   node_id: z.string(),
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -548,7 +548,7 @@ export const zPostSnippetsBySnippetIdWorkflowsDraftNodesByNodeIdRunBody
 
 export const zPostSnippetsBySnippetIdWorkflowsDraftNodesByNodeIdRunPath = z.object({
   node_id: z.string(),
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -559,7 +559,7 @@ export const zPostSnippetsBySnippetIdWorkflowsDraftNodesByNodeIdRunResponse
 
 export const zDeleteSnippetsBySnippetIdWorkflowsDraftNodesByNodeIdVariablesPath = z.object({
   node_id: z.string(),
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -569,7 +569,7 @@ export const zDeleteSnippetsBySnippetIdWorkflowsDraftNodesByNodeIdVariablesRespo
 
 export const zGetSnippetsBySnippetIdWorkflowsDraftNodesByNodeIdVariablesPath = z.object({
   node_id: z.string(),
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -581,7 +581,7 @@ export const zGetSnippetsBySnippetIdWorkflowsDraftNodesByNodeIdVariablesResponse
 export const zPostSnippetsBySnippetIdWorkflowsDraftRunBody = zSnippetDraftRunPayload
 
 export const zPostSnippetsBySnippetIdWorkflowsDraftRunPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -590,7 +590,7 @@ export const zPostSnippetsBySnippetIdWorkflowsDraftRunPath = z.object({
 export const zPostSnippetsBySnippetIdWorkflowsDraftRunResponse = zGeneratedAppResponse
 
 export const zGetSnippetsBySnippetIdWorkflowsDraftSystemVariablesPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -600,7 +600,7 @@ export const zGetSnippetsBySnippetIdWorkflowsDraftSystemVariablesResponse
   = zWorkflowDraftVariableList
 
 export const zDeleteSnippetsBySnippetIdWorkflowsDraftVariablesPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -609,7 +609,7 @@ export const zDeleteSnippetsBySnippetIdWorkflowsDraftVariablesPath = z.object({
 export const zDeleteSnippetsBySnippetIdWorkflowsDraftVariablesResponse = z.void()
 
 export const zGetSnippetsBySnippetIdWorkflowsDraftVariablesPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 export const zGetSnippetsBySnippetIdWorkflowsDraftVariablesQuery = z.object({
@@ -624,8 +624,8 @@ export const zGetSnippetsBySnippetIdWorkflowsDraftVariablesResponse
   = zWorkflowDraftVariableListWithoutValue
 
 export const zDeleteSnippetsBySnippetIdWorkflowsDraftVariablesByVariableIdPath = z.object({
-  snippet_id: z.string(),
-  variable_id: z.string(),
+  snippet_id: z.uuid(),
+  variable_id: z.uuid(),
 })
 
 /**
@@ -634,8 +634,8 @@ export const zDeleteSnippetsBySnippetIdWorkflowsDraftVariablesByVariableIdPath =
 export const zDeleteSnippetsBySnippetIdWorkflowsDraftVariablesByVariableIdResponse = z.void()
 
 export const zGetSnippetsBySnippetIdWorkflowsDraftVariablesByVariableIdPath = z.object({
-  snippet_id: z.string(),
-  variable_id: z.string(),
+  snippet_id: z.uuid(),
+  variable_id: z.uuid(),
 })
 
 /**
@@ -648,8 +648,8 @@ export const zPatchSnippetsBySnippetIdWorkflowsDraftVariablesByVariableIdBody
   = zWorkflowDraftVariableUpdatePayload
 
 export const zPatchSnippetsBySnippetIdWorkflowsDraftVariablesByVariableIdPath = z.object({
-  snippet_id: z.string(),
-  variable_id: z.string(),
+  snippet_id: z.uuid(),
+  variable_id: z.uuid(),
 })
 
 /**
@@ -659,8 +659,8 @@ export const zPatchSnippetsBySnippetIdWorkflowsDraftVariablesByVariableIdRespons
   = zWorkflowDraftVariable
 
 export const zPutSnippetsBySnippetIdWorkflowsDraftVariablesByVariableIdResetPath = z.object({
-  snippet_id: z.string(),
-  variable_id: z.string(),
+  snippet_id: z.uuid(),
+  variable_id: z.uuid(),
 })
 
 export const zPutSnippetsBySnippetIdWorkflowsDraftVariablesByVariableIdResetResponse = z.union([
@@ -669,7 +669,7 @@ export const zPutSnippetsBySnippetIdWorkflowsDraftVariablesByVariableIdResetResp
 ])
 
 export const zGetSnippetsBySnippetIdWorkflowsPublishPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -680,7 +680,7 @@ export const zGetSnippetsBySnippetIdWorkflowsPublishResponse = zSnippetWorkflowR
 export const zPostSnippetsBySnippetIdWorkflowsPublishBody = zPublishWorkflowPayload
 
 export const zPostSnippetsBySnippetIdWorkflowsPublishPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -689,7 +689,7 @@ export const zPostSnippetsBySnippetIdWorkflowsPublishPath = z.object({
 export const zPostSnippetsBySnippetIdWorkflowsPublishResponse = zWorkflowPublishResponse
 
 export const zPostSnippetsBySnippetIdWorkflowsByWorkflowIdRestorePath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
   workflow_id: z.string(),
 })
 

--- a/packages/contracts/generated/api/console/tags/zod.gen.ts
+++ b/packages/contracts/generated/api/console/tags/zod.gen.ts
@@ -52,7 +52,7 @@ export const zPostTagsBody = zTagBasePayload
 export const zPostTagsResponse = zTagResponse
 
 export const zDeleteTagsByTagIdPath = z.object({
-  tag_id: z.string(),
+  tag_id: z.uuid(),
 })
 
 /**
@@ -63,7 +63,7 @@ export const zDeleteTagsByTagIdResponse = z.void()
 export const zPatchTagsByTagIdBody = zTagUpdateRequestPayload
 
 export const zPatchTagsByTagIdPath = z.object({
-  tag_id: z.string(),
+  tag_id: z.uuid(),
 })
 
 /**

--- a/packages/contracts/generated/api/console/trial-apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/trial-apps/zod.gen.ts
@@ -435,7 +435,7 @@ export const zSiteWritable = z.object({
 })
 
 export const zGetTrialAppsByAppIdPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -444,7 +444,7 @@ export const zGetTrialAppsByAppIdPath = z.object({
 export const zGetTrialAppsByAppIdResponse = zTrialAppDetailWithSite
 
 export const zPostTrialAppsByAppIdAudioToTextPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -455,7 +455,7 @@ export const zPostTrialAppsByAppIdAudioToTextResponse = zAudioTranscriptResponse
 export const zPostTrialAppsByAppIdChatMessagesBody = zChatRequest
 
 export const zPostTrialAppsByAppIdChatMessagesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -466,7 +466,7 @@ export const zPostTrialAppsByAppIdChatMessagesResponse = zGeneratedAppResponse
 export const zPostTrialAppsByAppIdCompletionMessagesBody = zCompletionRequest
 
 export const zPostTrialAppsByAppIdCompletionMessagesPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -475,7 +475,7 @@ export const zPostTrialAppsByAppIdCompletionMessagesPath = z.object({
 export const zPostTrialAppsByAppIdCompletionMessagesResponse = zGeneratedAppResponse
 
 export const zGetTrialAppsByAppIdDatasetsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 export const zGetTrialAppsByAppIdDatasetsQuery = z.object({
@@ -490,8 +490,8 @@ export const zGetTrialAppsByAppIdDatasetsQuery = z.object({
 export const zGetTrialAppsByAppIdDatasetsResponse = zTrialDatasetList
 
 export const zGetTrialAppsByAppIdMessagesByMessageIdSuggestedQuestionsPath = z.object({
-  app_id: z.string(),
-  message_id: z.string(),
+  app_id: z.uuid(),
+  message_id: z.uuid(),
 })
 
 /**
@@ -501,7 +501,7 @@ export const zGetTrialAppsByAppIdMessagesByMessageIdSuggestedQuestionsResponse
   = zSuggestedQuestionsResponse
 
 export const zGetTrialAppsByAppIdParametersPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -510,7 +510,7 @@ export const zGetTrialAppsByAppIdParametersPath = z.object({
 export const zGetTrialAppsByAppIdParametersResponse = zParameters
 
 export const zGetTrialAppsByAppIdSitePath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -521,7 +521,7 @@ export const zGetTrialAppsByAppIdSiteResponse = zSite
 export const zPostTrialAppsByAppIdTextToAudioBody = zTextToSpeechRequest
 
 export const zPostTrialAppsByAppIdTextToAudioPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -530,7 +530,7 @@ export const zPostTrialAppsByAppIdTextToAudioPath = z.object({
 export const zPostTrialAppsByAppIdTextToAudioResponse = zAudioBinaryResponse
 
 export const zGetTrialAppsByAppIdWorkflowsPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -541,7 +541,7 @@ export const zGetTrialAppsByAppIdWorkflowsResponse = zTrialWorkflow
 export const zPostTrialAppsByAppIdWorkflowsRunBody = zWorkflowRunRequest
 
 export const zPostTrialAppsByAppIdWorkflowsRunPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
 })
 
 /**
@@ -550,7 +550,7 @@ export const zPostTrialAppsByAppIdWorkflowsRunPath = z.object({
 export const zPostTrialAppsByAppIdWorkflowsRunResponse = zGeneratedAppResponse
 
 export const zPostTrialAppsByAppIdWorkflowsTasksByTaskIdStopPath = z.object({
-  app_id: z.string(),
+  app_id: z.uuid(),
   task_id: z.string(),
 })
 

--- a/packages/contracts/generated/api/console/workspaces/types.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/types.gen.ts
@@ -32,7 +32,7 @@ export type AgentProviderListResponse = Array<{
 }>
 
 export type SnippetPagination = {
-  data?: Array<AnonymousInlineModelEfd591151Ea9>
+  data?: Array<AnonymousInlineModel744Ff9Cc03E6>
   has_more?: boolean
   limit?: number
   page?: number
@@ -769,7 +769,7 @@ export type WorkspaceCustomConfigResponse = {
   replace_webapp_logo?: string | null
 }
 
-export type AnonymousInlineModelEfd591151Ea9 = {
+export type AnonymousInlineModel744Ff9Cc03E6 = {
   author_name?: string
   created_at?: number
   created_by?: string

--- a/packages/contracts/generated/api/console/workspaces/zod.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/zod.gen.ts
@@ -776,7 +776,7 @@ export const zSnippet = z.object({
   version: z.int().optional(),
 })
 
-export const zAnonymousInlineModelEfd591151Ea9 = z.object({
+export const zAnonymousInlineModel744Ff9Cc03E6 = z.object({
   author_name: z.string().optional(),
   created_at: z.coerce
     .bigint()
@@ -810,7 +810,7 @@ export const zAnonymousInlineModelEfd591151Ea9 = z.object({
 })
 
 export const zSnippetPagination = z.object({
-  data: z.array(zAnonymousInlineModelEfd591151Ea9).optional(),
+  data: z.array(zAnonymousInlineModel744Ff9Cc03E6).optional(),
   has_more: z.boolean().optional(),
   limit: z.int().optional(),
   page: z.int().optional(),

--- a/packages/contracts/generated/api/console/workspaces/zod.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/zod.gen.ts
@@ -1927,7 +1927,7 @@ export const zPostWorkspacesCurrentCustomizedSnippetsImportsByImportIdConfirmRes
   = zSnippetImportResponse
 
 export const zDeleteWorkspacesCurrentCustomizedSnippetsBySnippetIdPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -1936,7 +1936,7 @@ export const zDeleteWorkspacesCurrentCustomizedSnippetsBySnippetIdPath = z.objec
 export const zDeleteWorkspacesCurrentCustomizedSnippetsBySnippetIdResponse = z.void()
 
 export const zGetWorkspacesCurrentCustomizedSnippetsBySnippetIdPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -1947,7 +1947,7 @@ export const zGetWorkspacesCurrentCustomizedSnippetsBySnippetIdResponse = zSnipp
 export const zPatchWorkspacesCurrentCustomizedSnippetsBySnippetIdBody = zUpdateSnippetPayload
 
 export const zPatchWorkspacesCurrentCustomizedSnippetsBySnippetIdPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -1956,7 +1956,7 @@ export const zPatchWorkspacesCurrentCustomizedSnippetsBySnippetIdPath = z.object
 export const zPatchWorkspacesCurrentCustomizedSnippetsBySnippetIdResponse = zSnippet
 
 export const zGetWorkspacesCurrentCustomizedSnippetsBySnippetIdCheckDependenciesPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -1966,7 +1966,7 @@ export const zGetWorkspacesCurrentCustomizedSnippetsBySnippetIdCheckDependencies
   = zSnippetDependencyCheckResponse
 
 export const zGetWorkspacesCurrentCustomizedSnippetsBySnippetIdExportPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 export const zGetWorkspacesCurrentCustomizedSnippetsBySnippetIdExportQuery = z.object({
@@ -1979,7 +1979,7 @@ export const zGetWorkspacesCurrentCustomizedSnippetsBySnippetIdExportQuery = z.o
 export const zGetWorkspacesCurrentCustomizedSnippetsBySnippetIdExportResponse = zTextFileResponse
 
 export const zPostWorkspacesCurrentCustomizedSnippetsBySnippetIdUseCountIncrementPath = z.object({
-  snippet_id: z.string(),
+  snippet_id: z.uuid(),
 })
 
 /**
@@ -2121,7 +2121,7 @@ export const zPostWorkspacesCurrentMembersSendOwnerTransferConfirmEmailResponse
   = zSimpleResultDataResponse
 
 export const zDeleteWorkspacesCurrentMembersByMemberIdPath = z.object({
-  member_id: z.string(),
+  member_id: z.uuid(),
 })
 
 /**
@@ -2132,7 +2132,7 @@ export const zDeleteWorkspacesCurrentMembersByMemberIdResponse = zMemberActionTe
 export const zPostWorkspacesCurrentMembersByMemberIdOwnerTransferBody = zOwnerTransferPayload
 
 export const zPostWorkspacesCurrentMembersByMemberIdOwnerTransferPath = z.object({
-  member_id: z.string(),
+  member_id: z.uuid(),
 })
 
 /**
@@ -2143,7 +2143,7 @@ export const zPostWorkspacesCurrentMembersByMemberIdOwnerTransferResponse = zSim
 export const zPutWorkspacesCurrentMembersByMemberIdUpdateRoleBody = zMemberRoleUpdatePayload
 
 export const zPutWorkspacesCurrentMembersByMemberIdUpdateRolePath = z.object({
-  member_id: z.string(),
+  member_id: z.uuid(),
 })
 
 /**

--- a/packages/contracts/generated/api/service/orpc.gen.ts
+++ b/packages/contracts/generated/api/service/orpc.gen.ts
@@ -6,6 +6,7 @@ import * as z from 'zod'
 import {
   zDeleteAppsAnnotationsByAnnotationIdPath,
   zDeleteAppsAnnotationsByAnnotationIdResponse,
+  zDeleteConversationsByCIdBody,
   zDeleteConversationsByCIdPath,
   zDeleteConversationsByCIdResponse,
   zDeleteDatasetsByDatasetIdDocumentsByDocumentIdPath,
@@ -72,6 +73,7 @@ import {
   zGetFormHumanInputByFormTokenResponse,
   zGetInfoResponse,
   zGetMessagesByMessageIdSuggestedPath,
+  zGetMessagesByMessageIdSuggestedQuery,
   zGetMessagesByMessageIdSuggestedResponse,
   zGetMessagesQuery,
   zGetMessagesResponse,
@@ -110,12 +112,15 @@ import {
   zPostAppsAnnotationReplyByActionResponse,
   zPostAppsAnnotationsBody,
   zPostAppsAnnotationsResponse,
+  zPostAudioToTextBody,
   zPostAudioToTextResponse,
   zPostChatMessagesBody,
+  zPostChatMessagesByTaskIdStopBody,
   zPostChatMessagesByTaskIdStopPath,
   zPostChatMessagesByTaskIdStopResponse,
   zPostChatMessagesResponse,
   zPostCompletionMessagesBody,
+  zPostCompletionMessagesByTaskIdStopBody,
   zPostCompletionMessagesByTaskIdStopPath,
   zPostCompletionMessagesByTaskIdStopResponse,
   zPostCompletionMessagesResponse,
@@ -179,6 +184,7 @@ import {
   zPostDatasetsByDatasetIdRetrieveBody,
   zPostDatasetsByDatasetIdRetrievePath,
   zPostDatasetsByDatasetIdRetrieveResponse,
+  zPostDatasetsPipelineFileUploadBody,
   zPostDatasetsPipelineFileUploadResponse,
   zPostDatasetsResponse,
   zPostDatasetsTagsBindingBody,
@@ -187,6 +193,7 @@ import {
   zPostDatasetsTagsResponse,
   zPostDatasetsTagsUnbindingBody,
   zPostDatasetsTagsUnbindingResponse,
+  zPostFilesUploadBody,
   zPostFilesUploadResponse,
   zPostFormHumanInputByFormTokenBody,
   zPostFormHumanInputByFormTokenPath,
@@ -201,6 +208,7 @@ import {
   zPostWorkflowsByWorkflowIdRunResponse,
   zPostWorkflowsRunBody,
   zPostWorkflowsRunResponse,
+  zPostWorkflowsTasksByTaskIdStopBody,
   zPostWorkflowsTasksByTaskIdStopPath,
   zPostWorkflowsTasksByTaskIdStopResponse,
   zPutAppsAnnotationsByAnnotationIdBody,
@@ -423,6 +431,7 @@ export const post3 = oc
     summary: 'Convert audio to text using speech-to-text',
     tags: ['service_api'],
   })
+  .input(z.object({ body: zPostAudioToTextBody }))
   .output(zPostAudioToTextResponse)
 
 export const audioToText = {
@@ -444,7 +453,12 @@ export const post4 = oc
     summary: 'Stop a running chat message generation',
     tags: ['service_api'],
   })
-  .input(z.object({ params: zPostChatMessagesByTaskIdStopPath }))
+  .input(
+    z.object({
+      body: zPostChatMessagesByTaskIdStopBody,
+      params: zPostChatMessagesByTaskIdStopPath,
+    }),
+  )
   .output(zPostChatMessagesByTaskIdStopResponse)
 
 export const stop = {
@@ -496,7 +510,12 @@ export const post6 = oc
     summary: 'Stop a running completion task',
     tags: ['service_api'],
   })
-  .input(z.object({ params: zPostCompletionMessagesByTaskIdStopPath }))
+  .input(
+    z.object({
+      body: zPostCompletionMessagesByTaskIdStopBody,
+      params: zPostCompletionMessagesByTaskIdStopPath,
+    }),
+  )
   .output(zPostCompletionMessagesByTaskIdStopResponse)
 
 export const stop2 = {
@@ -633,7 +652,7 @@ export const delete2 = oc
     summary: 'Delete a specific conversation',
     tags: ['service_api'],
   })
-  .input(z.object({ params: zDeleteConversationsByCIdPath }))
+  .input(z.object({ body: zDeleteConversationsByCIdBody, params: zDeleteConversationsByCIdPath }))
   .output(zDeleteConversationsByCIdResponse)
 
 export const byCId = {
@@ -685,6 +704,7 @@ export const post9 = oc
     summary: 'Upload a file for use in conversations',
     tags: ['service_api'],
   })
+  .input(z.object({ body: zPostDatasetsPipelineFileUploadBody }))
   .output(zPostDatasetsPipelineFileUploadResponse)
 
 export const fileUpload = {
@@ -835,9 +855,12 @@ export const post13 = oc
 
 /**
  * Create a new document by uploading a file
+ *
+ * @deprecated
  */
 export const post14 = oc
   .route({
+    deprecated: true,
     description: 'Create a new document by uploading a file',
     inputStructure: 'detailed',
     method: 'POST',
@@ -1937,6 +1960,7 @@ export const post33 = oc
     summary: 'Upload a file for use in conversations',
     tags: ['service_api'],
   })
+  .input(z.object({ body: zPostFilesUploadBody }))
   .output(zPostFilesUploadResponse)
 
 export const upload = {
@@ -2099,7 +2123,12 @@ export const get25 = oc
     summary: 'Get suggested follow-up questions for a message',
     tags: ['service_api'],
   })
-  .input(z.object({ params: zGetMessagesByMessageIdSuggestedPath }))
+  .input(
+    z.object({
+      params: zGetMessagesByMessageIdSuggestedPath,
+      query: zGetMessagesByMessageIdSuggestedQuery,
+    }),
+  )
   .output(zGetMessagesByMessageIdSuggestedResponse)
 
 export const suggested = {
@@ -2347,7 +2376,12 @@ export const post38 = oc
     summary: 'Stop a running workflow task',
     tags: ['service_api'],
   })
-  .input(z.object({ params: zPostWorkflowsTasksByTaskIdStopPath }))
+  .input(
+    z.object({
+      body: zPostWorkflowsTasksByTaskIdStopBody,
+      params: zPostWorkflowsTasksByTaskIdStopPath,
+    }),
+  )
   .output(zPostWorkflowsTasksByTaskIdStopResponse)
 
 export const stop3 = {

--- a/packages/contracts/generated/api/service/types.gen.ts
+++ b/packages/contracts/generated/api/service/types.gen.ts
@@ -232,12 +232,32 @@ export type ConversationListQuery = {
   sort_by?: '-created_at' | '-updated_at' | 'created_at' | 'updated_at'
 }
 
-export type ConversationRenamePayload = {
+export type ConversationRenamePayload = (
+  | {
+    auto_generate: true
+    name?: string | null
+  }
+  | {
+    auto_generate?: false
+    name: string
+  }
+) & {
   auto_generate?: boolean
   name?: string | null
 }
 
-export type ConversationRenamePayloadWithUser = {
+export type ConversationRenamePayloadWithUser = (
+  | {
+    auto_generate: true
+    name?: string | null
+    user?: string
+  }
+  | {
+    auto_generate?: false
+    name: string
+    user?: string
+  }
+) & {
   auto_generate?: boolean
   name?: string | null
   user?: string
@@ -693,7 +713,24 @@ export type DocumentTextCreatePayload = {
   text: string
 }
 
-export type DocumentTextUpdate = {
+export type DocumentTextUpdate = (
+  | {
+    doc_form?: string
+    doc_language?: string
+    name: string
+    process_rule?: ProcessRule | null
+    retrieval_model?: RetrievalModel | null
+    text: string
+  }
+  | {
+    doc_form?: string
+    doc_language?: string
+    name?: string | null
+    process_rule?: ProcessRule | null
+    retrieval_model?: RetrievalModel | null
+    text?: null
+  }
+) & {
   doc_form?: string
   doc_language?: string
   name?: string | null
@@ -1646,7 +1683,7 @@ export type GetAppFeedbacksResponse = GetAppFeedbacksResponses[keyof GetAppFeedb
 export type PostAppsAnnotationReplyByActionData = {
   body: AnnotationReplyActionPayload
   path: {
-    action: string
+    action: 'disable' | 'enable'
   }
   query?: never
   url: '/apps/annotation-reply/{action}'
@@ -2421,7 +2458,7 @@ export type PostDatasetsByDatasetIdDocumentsMetadataResponse
 export type PatchDatasetsByDatasetIdDocumentsStatusByActionData = {
   body: DocumentStatusPayload
   path: {
-    action: string
+    action: 'archive' | 'disable' | 'enable' | 'un_archive'
     dataset_id: string
   }
   query?: never
@@ -2982,7 +3019,7 @@ export type GetDatasetsByDatasetIdMetadataBuiltInResponse
 export type PostDatasetsByDatasetIdMetadataBuiltInByActionData = {
   body?: never
   path: {
-    action: string
+    action: 'disable' | 'enable'
     dataset_id: string
   }
   query?: never

--- a/packages/contracts/generated/api/service/types.gen.ts
+++ b/packages/contracts/generated/api/service/types.gen.ts
@@ -115,6 +115,23 @@ export type ChatRequestPayload = {
   workflow_id?: string | null
 }
 
+export type ChatRequestPayloadWithUser = {
+  auto_generate_name?: boolean
+  conversation_id?: string | null
+  files?: Array<{
+    [key: string]: unknown
+  }> | null
+  inputs: {
+    [key: string]: unknown
+  }
+  query: string
+  response_mode?: 'blocking' | 'streaming' | null
+  retriever_from?: string
+  trace_session_id?: string | null
+  user: string
+  workflow_id?: string | null
+}
+
 export type ChildChunkCreatePayload = {
   content: string
 }
@@ -165,6 +182,20 @@ export type CompletionRequestPayload = {
   trace_session_id?: string | null
 }
 
+export type CompletionRequestPayloadWithUser = {
+  files?: Array<{
+    [key: string]: unknown
+  }> | null
+  inputs: {
+    [key: string]: unknown
+  }
+  query?: string
+  response_mode?: 'blocking' | 'streaming' | null
+  retriever_from?: string
+  trace_session_id?: string | null
+  user: string
+}
+
 export type Condition = {
   comparison_operator:
     | '<'
@@ -206,6 +237,12 @@ export type ConversationRenamePayload = {
   name?: string | null
 }
 
+export type ConversationRenamePayloadWithUser = {
+  auto_generate?: boolean
+  name?: string | null
+  user?: string
+}
+
 export type ConversationVariableInfiniteScrollPaginationResponse = {
   data: Array<ConversationVariableResponse>
   has_more: boolean
@@ -223,6 +260,11 @@ export type ConversationVariableResponse = {
 }
 
 export type ConversationVariableUpdatePayload = {
+  value: unknown
+}
+
+export type ConversationVariableUpdatePayloadWithUser = {
+  user?: string
   value: unknown
 }
 
@@ -875,6 +917,14 @@ export type HumanInputFormSubmitPayload = {
   }
 }
 
+export type HumanInputFormSubmitPayloadWithUser = {
+  action: string
+  inputs: {
+    [key: string]: JsonValue2
+  }
+  user: string
+}
+
 export type HumanInputFormSubmitResponse = {
   [key: string]: never
 }
@@ -921,6 +971,12 @@ export type KnowledgeTagResponse = {
 export type MessageFeedbackPayload = {
   content?: string | null
   rating?: 'dislike' | 'like' | null
+}
+
+export type MessageFeedbackPayloadWithUser = {
+  content?: string | null
+  rating?: 'dislike' | 'like' | null
+  user: string
 }
 
 export type MessageFile = {
@@ -1025,6 +1081,10 @@ export type ModelStatus
 
 export type ModelType = 'llm' | 'moderation' | 'rerank' | 'speech2text' | 'text-embedding' | 'tts'
 
+export type OptionalServiceApiUserPayload = {
+  user?: string
+}
+
 export type ParagraphInputConfig = {
   default?: StringSource | null
   output_variable_name: string
@@ -1110,6 +1170,10 @@ export type ProviderWithModelsResponse = {
   provider: string
   status: CustomConfigurationStatus
   tenant_id: string
+}
+
+export type RequiredServiceApiUserPayload = {
+  user: string
 }
 
 export type RerankingModel = {
@@ -1356,11 +1420,17 @@ export type TagDeletePayload = {
   tag_id: string
 }
 
-export type TagUnbindingPayload = {
-  tag_id?: string | null
-  tag_ids?: Array<string>
-  target_id: string
-}
+export type TagUnbindingPayload
+  = | {
+    tag_id: string
+    tag_ids?: Array<string>
+    target_id: string
+  }
+  | {
+    tag_id?: string
+    tag_ids: Array<string>
+    target_id: string
+  }
 
 export type TagUpdatePayload = {
   name: string
@@ -1371,6 +1441,14 @@ export type TextToAudioPayload = {
   message_id?: string | null
   streaming?: boolean | null
   text?: string | null
+  voice?: string | null
+}
+
+export type TextToAudioPayloadWithUser = {
+  message_id?: string | null
+  streaming?: boolean | null
+  text?: string | null
+  user?: string
   voice?: string | null
 }
 
@@ -1472,6 +1550,18 @@ export type WorkflowRunPayload = {
   trace_session_id?: string | null
 }
 
+export type WorkflowRunPayloadWithUser = {
+  files?: Array<{
+    [key: string]: unknown
+  }> | null
+  inputs: {
+    [key: string]: unknown
+  }
+  response_mode?: 'blocking' | 'streaming' | null
+  trace_session_id?: string | null
+  user: string
+}
+
 export type WorkflowRunResponse = {
   created_at?: number | null
   elapsed_time?: number | number | null
@@ -1544,6 +1634,7 @@ export type GetAppFeedbacksData = {
 
 export type GetAppFeedbacksErrors = {
   401: unknown
+  403: unknown
 }
 
 export type GetAppFeedbacksResponses = {
@@ -1563,6 +1654,7 @@ export type PostAppsAnnotationReplyByActionData = {
 
 export type PostAppsAnnotationReplyByActionErrors = {
   401: unknown
+  403: unknown
 }
 
 export type PostAppsAnnotationReplyByActionResponses = {
@@ -1584,6 +1676,7 @@ export type GetAppsAnnotationReplyByActionStatusByJobIdData = {
 
 export type GetAppsAnnotationReplyByActionStatusByJobIdErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -1607,6 +1700,7 @@ export type GetAppsAnnotationsData = {
 
 export type GetAppsAnnotationsErrors = {
   401: unknown
+  403: unknown
 }
 
 export type GetAppsAnnotationsResponses = {
@@ -1625,6 +1719,7 @@ export type PostAppsAnnotationsData = {
 
 export type PostAppsAnnotationsErrors = {
   401: unknown
+  403: unknown
 }
 
 export type PostAppsAnnotationsResponses = {
@@ -1679,7 +1774,10 @@ export type PutAppsAnnotationsByAnnotationIdResponse
   = PutAppsAnnotationsByAnnotationIdResponses[keyof PutAppsAnnotationsByAnnotationIdResponses]
 
 export type PostAudioToTextData = {
-  body?: never
+  body: {
+    file: Blob | File
+    user?: string
+  }
   path?: never
   query?: never
   url: '/audio-to-text'
@@ -1688,6 +1786,7 @@ export type PostAudioToTextData = {
 export type PostAudioToTextErrors = {
   400: unknown
   401: unknown
+  403: unknown
   413: unknown
   415: unknown
   500: unknown
@@ -1700,7 +1799,7 @@ export type PostAudioToTextResponses = {
 export type PostAudioToTextResponse = PostAudioToTextResponses[keyof PostAudioToTextResponses]
 
 export type PostChatMessagesData = {
-  body: ChatRequestPayload
+  body: ChatRequestPayloadWithUser
   path?: never
   query?: never
   url: '/chat-messages'
@@ -1709,6 +1808,7 @@ export type PostChatMessagesData = {
 export type PostChatMessagesErrors = {
   400: unknown
   401: unknown
+  403: unknown
   404: unknown
   429: unknown
   500: unknown
@@ -1721,7 +1821,7 @@ export type PostChatMessagesResponses = {
 export type PostChatMessagesResponse = PostChatMessagesResponses[keyof PostChatMessagesResponses]
 
 export type PostChatMessagesByTaskIdStopData = {
-  body?: never
+  body: RequiredServiceApiUserPayload
   path: {
     task_id: string
   }
@@ -1731,6 +1831,7 @@ export type PostChatMessagesByTaskIdStopData = {
 
 export type PostChatMessagesByTaskIdStopErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -1742,7 +1843,7 @@ export type PostChatMessagesByTaskIdStopResponse
   = PostChatMessagesByTaskIdStopResponses[keyof PostChatMessagesByTaskIdStopResponses]
 
 export type PostCompletionMessagesData = {
-  body: CompletionRequestPayload
+  body: CompletionRequestPayloadWithUser
   path?: never
   query?: never
   url: '/completion-messages'
@@ -1751,6 +1852,7 @@ export type PostCompletionMessagesData = {
 export type PostCompletionMessagesErrors = {
   400: unknown
   401: unknown
+  403: unknown
   404: unknown
   500: unknown
 }
@@ -1763,7 +1865,7 @@ export type PostCompletionMessagesResponse
   = PostCompletionMessagesResponses[keyof PostCompletionMessagesResponses]
 
 export type PostCompletionMessagesByTaskIdStopData = {
-  body?: never
+  body: RequiredServiceApiUserPayload
   path: {
     task_id: string
   }
@@ -1773,6 +1875,7 @@ export type PostCompletionMessagesByTaskIdStopData = {
 
 export type PostCompletionMessagesByTaskIdStopErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -1790,12 +1893,14 @@ export type GetConversationsData = {
     last_id?: string
     limit?: number
     sort_by?: '-created_at' | '-updated_at' | 'created_at' | 'updated_at'
+    user?: string
   }
   url: '/conversations'
 }
 
 export type GetConversationsErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -1806,7 +1911,7 @@ export type GetConversationsResponses = {
 export type GetConversationsResponse = GetConversationsResponses[keyof GetConversationsResponses]
 
 export type DeleteConversationsByCIdData = {
-  body?: never
+  body: OptionalServiceApiUserPayload
   path: {
     c_id: string
   }
@@ -1816,6 +1921,7 @@ export type DeleteConversationsByCIdData = {
 
 export type DeleteConversationsByCIdErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -1827,7 +1933,7 @@ export type DeleteConversationsByCIdResponse
   = DeleteConversationsByCIdResponses[keyof DeleteConversationsByCIdResponses]
 
 export type PostConversationsByCIdNameData = {
-  body: ConversationRenamePayload
+  body: ConversationRenamePayloadWithUser
   path: {
     c_id: string
   }
@@ -1837,6 +1943,7 @@ export type PostConversationsByCIdNameData = {
 
 export type PostConversationsByCIdNameErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -1855,6 +1962,7 @@ export type GetConversationsByCIdVariablesData = {
   query?: {
     last_id?: string
     limit?: number
+    user?: string
     variable_name?: string
   }
   url: '/conversations/{c_id}/variables'
@@ -1862,6 +1970,7 @@ export type GetConversationsByCIdVariablesData = {
 
 export type GetConversationsByCIdVariablesErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -1873,7 +1982,7 @@ export type GetConversationsByCIdVariablesResponse
   = GetConversationsByCIdVariablesResponses[keyof GetConversationsByCIdVariablesResponses]
 
 export type PutConversationsByCIdVariablesByVariableIdData = {
-  body: ConversationVariableUpdatePayload
+  body: ConversationVariableUpdatePayloadWithUser
   path: {
     c_id: string
     variable_id: string
@@ -1885,6 +1994,7 @@ export type PutConversationsByCIdVariablesByVariableIdData = {
 export type PutConversationsByCIdVariablesByVariableIdErrors = {
   400: unknown
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -1910,6 +2020,7 @@ export type GetDatasetsData = {
 
 export type GetDatasetsErrors = {
   401: unknown
+  403: unknown
 }
 
 export type GetDatasetsResponses = {
@@ -1928,6 +2039,7 @@ export type PostDatasetsData = {
 export type PostDatasetsErrors = {
   400: unknown
   401: unknown
+  403: unknown
 }
 
 export type PostDatasetsResponses = {
@@ -1937,7 +2049,9 @@ export type PostDatasetsResponses = {
 export type PostDatasetsResponse = PostDatasetsResponses[keyof PostDatasetsResponses]
 
 export type PostDatasetsPipelineFileUploadData = {
-  body?: never
+  body: {
+    file: Blob | File
+  }
   path?: never
   query?: never
   url: '/datasets/pipeline/file-upload'
@@ -1946,6 +2060,7 @@ export type PostDatasetsPipelineFileUploadData = {
 export type PostDatasetsPipelineFileUploadErrors = {
   400: unknown
   401: unknown
+  403: unknown
   413: unknown
   415: unknown
 }
@@ -1985,6 +2100,7 @@ export type GetDatasetsTagsData = {
 
 export type GetDatasetsTagsErrors = {
   401: unknown
+  403: unknown
 }
 
 export type GetDatasetsTagsResponses = {
@@ -2078,6 +2194,7 @@ export type DeleteDatasetsByDatasetIdData = {
 
 export type DeleteDatasetsByDatasetIdErrors = {
   401: unknown
+  403: unknown
   404: unknown
   409: unknown
 }
@@ -2148,6 +2265,7 @@ export type PostDatasetsByDatasetIdDocumentCreateByFileData = {
 export type PostDatasetsByDatasetIdDocumentCreateByFileErrors = {
   400: unknown
   401: unknown
+  403: unknown
 }
 
 export type PostDatasetsByDatasetIdDocumentCreateByFileResponses = {
@@ -2169,6 +2287,7 @@ export type PostDatasetsByDatasetIdDocumentCreateByTextData = {
 export type PostDatasetsByDatasetIdDocumentCreateByTextErrors = {
   400: unknown
   401: unknown
+  403: unknown
 }
 
 export type PostDatasetsByDatasetIdDocumentCreateByTextResponses = {
@@ -2193,6 +2312,7 @@ export type PostDatasetsByDatasetIdDocumentCreateByFile2Data = {
 export type PostDatasetsByDatasetIdDocumentCreateByFile2Errors = {
   400: unknown
   401: unknown
+  403: unknown
 }
 
 export type PostDatasetsByDatasetIdDocumentCreateByFile2Responses = {
@@ -2214,6 +2334,7 @@ export type PostDatasetsByDatasetIdDocumentCreateByText2Data = {
 export type PostDatasetsByDatasetIdDocumentCreateByText2Errors = {
   400: unknown
   401: unknown
+  403: unknown
 }
 
 export type PostDatasetsByDatasetIdDocumentCreateByText2Responses = {
@@ -2239,6 +2360,7 @@ export type GetDatasetsByDatasetIdDocumentsData = {
 
 export type GetDatasetsByDatasetIdDocumentsErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2259,13 +2381,16 @@ export type PostDatasetsByDatasetIdDocumentsDownloadZipData = {
 }
 
 export type PostDatasetsByDatasetIdDocumentsDownloadZipErrors = {
-  401: unknown
-  403: unknown
-  404: unknown
+  401: Blob | File
+  403: Blob | File
+  404: Blob | File
 }
 
+export type PostDatasetsByDatasetIdDocumentsDownloadZipError
+  = PostDatasetsByDatasetIdDocumentsDownloadZipErrors[keyof PostDatasetsByDatasetIdDocumentsDownloadZipErrors]
+
 export type PostDatasetsByDatasetIdDocumentsDownloadZipResponses = {
-  200: BinaryFileResponse
+  200: Blob | File
 }
 
 export type PostDatasetsByDatasetIdDocumentsDownloadZipResponse
@@ -2282,6 +2407,7 @@ export type PostDatasetsByDatasetIdDocumentsMetadataData = {
 
 export type PostDatasetsByDatasetIdDocumentsMetadataErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2328,6 +2454,7 @@ export type GetDatasetsByDatasetIdDocumentsByBatchIndexingStatusData = {
 
 export type GetDatasetsByDatasetIdDocumentsByBatchIndexingStatusErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2401,6 +2528,7 @@ export type PatchDatasetsByDatasetIdDocumentsByDocumentIdData = {
 
 export type PatchDatasetsByDatasetIdDocumentsByDocumentIdErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2451,6 +2579,7 @@ export type GetDatasetsByDatasetIdDocumentsByDocumentIdSegmentsData = {
 
 export type GetDatasetsByDatasetIdDocumentsByDocumentIdSegmentsErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2474,6 +2603,7 @@ export type PostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsData = {
 export type PostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsErrors = {
   400: unknown
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2497,6 +2627,7 @@ export type DeleteDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdDat
 
 export type DeleteDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2520,6 +2651,7 @@ export type GetDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdData =
 
 export type GetDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2543,6 +2675,7 @@ export type PostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdData 
 
 export type PostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2570,6 +2703,7 @@ export type GetDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChildC
 
 export type GetDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChildChunksErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2593,6 +2727,7 @@ export type PostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChild
 
 export type PostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChildChunksErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2619,6 +2754,7 @@ export type DeleteDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChi
 export type DeleteDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChildChunksByChildChunkIdErrors
   = {
     401: unknown
+    403: unknown
     404: unknown
   }
 
@@ -2646,6 +2782,7 @@ export type PatchDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChil
 export type PatchDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChildChunksByChildChunkIdErrors
   = {
     401: unknown
+    403: unknown
     404: unknown
   }
 
@@ -2672,6 +2809,7 @@ export type PostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByFileData = {
 
 export type PostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByFileErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2694,6 +2832,7 @@ export type PostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByTextData = {
 
 export type PostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByTextErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2719,6 +2858,7 @@ export type PostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByFile2Data = {
 
 export type PostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByFile2Errors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2741,6 +2881,7 @@ export type PostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByText2Data = {
 
 export type PostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByText2Errors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2762,6 +2903,7 @@ export type PostDatasetsByDatasetIdHitTestingData = {
 
 export type PostDatasetsByDatasetIdHitTestingErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2783,6 +2925,7 @@ export type GetDatasetsByDatasetIdMetadataData = {
 
 export type GetDatasetsByDatasetIdMetadataErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2804,6 +2947,7 @@ export type PostDatasetsByDatasetIdMetadataData = {
 
 export type PostDatasetsByDatasetIdMetadataErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2825,6 +2969,7 @@ export type GetDatasetsByDatasetIdMetadataBuiltInData = {
 
 export type GetDatasetsByDatasetIdMetadataBuiltInErrors = {
   401: unknown
+  403: unknown
 }
 
 export type GetDatasetsByDatasetIdMetadataBuiltInResponses = {
@@ -2846,6 +2991,7 @@ export type PostDatasetsByDatasetIdMetadataBuiltInByActionData = {
 
 export type PostDatasetsByDatasetIdMetadataBuiltInByActionErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2868,6 +3014,7 @@ export type DeleteDatasetsByDatasetIdMetadataByMetadataIdData = {
 
 export type DeleteDatasetsByDatasetIdMetadataByMetadataIdErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2890,6 +3037,7 @@ export type PatchDatasetsByDatasetIdMetadataByMetadataIdData = {
 
 export type PatchDatasetsByDatasetIdMetadataByMetadataIdErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2913,6 +3061,7 @@ export type GetDatasetsByDatasetIdPipelineDatasourcePluginsData = {
 
 export type GetDatasetsByDatasetIdPipelineDatasourcePluginsErrors = {
   401: unknown
+  403: unknown
 }
 
 export type GetDatasetsByDatasetIdPipelineDatasourcePluginsResponses = {
@@ -2934,6 +3083,7 @@ export type PostDatasetsByDatasetIdPipelineDatasourceNodesByNodeIdRunData = {
 
 export type PostDatasetsByDatasetIdPipelineDatasourceNodesByNodeIdRunErrors = {
   401: unknown
+  403: unknown
 }
 
 export type PostDatasetsByDatasetIdPipelineDatasourceNodesByNodeIdRunResponses = {
@@ -2954,6 +3104,7 @@ export type PostDatasetsByDatasetIdPipelineRunData = {
 
 export type PostDatasetsByDatasetIdPipelineRunErrors = {
   401: unknown
+  403: unknown
 }
 
 export type PostDatasetsByDatasetIdPipelineRunResponses = {
@@ -2974,6 +3125,7 @@ export type PostDatasetsByDatasetIdRetrieveData = {
 
 export type PostDatasetsByDatasetIdRetrieveErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -2995,6 +3147,7 @@ export type GetDatasetsByDatasetIdTagsData = {
 
 export type GetDatasetsByDatasetIdTagsErrors = {
   401: unknown
+  403: unknown
 }
 
 export type GetDatasetsByDatasetIdTagsResponses = {
@@ -3015,6 +3168,7 @@ export type GetEndUsersByEndUserIdData = {
 
 export type GetEndUsersByEndUserIdErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -3026,7 +3180,10 @@ export type GetEndUsersByEndUserIdResponse
   = GetEndUsersByEndUserIdResponses[keyof GetEndUsersByEndUserIdResponses]
 
 export type PostFilesUploadData = {
-  body?: never
+  body: {
+    file: Blob | File
+    user?: string
+  }
   path?: never
   query?: never
   url: '/files/upload'
@@ -3035,6 +3192,7 @@ export type PostFilesUploadData = {
 export type PostFilesUploadErrors = {
   400: unknown
   401: unknown
+  403: unknown
   413: unknown
   415: unknown
 }
@@ -3052,18 +3210,22 @@ export type GetFilesByFileIdPreviewData = {
   }
   query?: {
     as_attachment?: boolean
+    user?: string
   }
   url: '/files/{file_id}/preview'
 }
 
 export type GetFilesByFileIdPreviewErrors = {
-  401: unknown
-  403: unknown
-  404: unknown
+  401: Blob | File
+  403: Blob | File
+  404: Blob | File
 }
 
+export type GetFilesByFileIdPreviewError
+  = GetFilesByFileIdPreviewErrors[keyof GetFilesByFileIdPreviewErrors]
+
 export type GetFilesByFileIdPreviewResponses = {
-  200: BinaryFileResponse
+  200: Blob | File
 }
 
 export type GetFilesByFileIdPreviewResponse
@@ -3080,6 +3242,7 @@ export type GetFormHumanInputByFormTokenData = {
 
 export type GetFormHumanInputByFormTokenErrors = {
   401: unknown
+  403: unknown
   404: unknown
   412: unknown
 }
@@ -3092,7 +3255,7 @@ export type GetFormHumanInputByFormTokenResponse
   = GetFormHumanInputByFormTokenResponses[keyof GetFormHumanInputByFormTokenResponses]
 
 export type PostFormHumanInputByFormTokenData = {
-  body: HumanInputFormSubmitPayload
+  body: HumanInputFormSubmitPayloadWithUser
   path: {
     form_token: string
   }
@@ -3103,6 +3266,7 @@ export type PostFormHumanInputByFormTokenData = {
 export type PostFormHumanInputByFormTokenErrors = {
   400: unknown
   401: unknown
+  403: unknown
   404: unknown
   412: unknown
 }
@@ -3123,6 +3287,7 @@ export type GetInfoData = {
 
 export type GetInfoErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -3139,12 +3304,14 @@ export type GetMessagesData = {
     conversation_id: string
     first_id?: string
     limit?: number
+    user?: string
   }
   url: '/messages'
 }
 
 export type GetMessagesErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -3155,7 +3322,7 @@ export type GetMessagesResponses = {
 export type GetMessagesResponse = GetMessagesResponses[keyof GetMessagesResponses]
 
 export type PostMessagesByMessageIdFeedbacksData = {
-  body: MessageFeedbackPayload
+  body: MessageFeedbackPayloadWithUser
   path: {
     message_id: string
   }
@@ -3165,6 +3332,7 @@ export type PostMessagesByMessageIdFeedbacksData = {
 
 export type PostMessagesByMessageIdFeedbacksErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -3180,13 +3348,16 @@ export type GetMessagesByMessageIdSuggestedData = {
   path: {
     message_id: string
   }
-  query?: never
+  query: {
+    user: string
+  }
   url: '/messages/{message_id}/suggested'
 }
 
 export type GetMessagesByMessageIdSuggestedErrors = {
   400: unknown
   401: unknown
+  403: unknown
   404: unknown
   500: unknown
 }
@@ -3207,6 +3378,7 @@ export type GetMetaData = {
 
 export type GetMetaErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -3225,6 +3397,7 @@ export type GetParametersData = {
 
 export type GetParametersErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -3253,20 +3426,23 @@ export type GetSiteResponses = {
 export type GetSiteResponse = GetSiteResponses[keyof GetSiteResponses]
 
 export type PostTextToAudioData = {
-  body: TextToAudioPayload
+  body: TextToAudioPayloadWithUser
   path?: never
   query?: never
   url: '/text-to-audio'
 }
 
 export type PostTextToAudioErrors = {
-  400: unknown
-  401: unknown
-  500: unknown
+  400: Blob | File
+  401: Blob | File
+  403: Blob | File
+  500: Blob | File
 }
 
+export type PostTextToAudioError = PostTextToAudioErrors[keyof PostTextToAudioErrors]
+
 export type PostTextToAudioResponses = {
-  200: AudioBinaryResponse
+  200: Blob | File
 }
 
 export type PostTextToAudioResponse = PostTextToAudioResponses[keyof PostTextToAudioResponses]
@@ -3286,6 +3462,7 @@ export type GetWorkflowByTaskIdEventsData = {
 
 export type GetWorkflowByTaskIdEventsErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -3314,6 +3491,7 @@ export type GetWorkflowsLogsData = {
 
 export type GetWorkflowsLogsErrors = {
   401: unknown
+  403: unknown
 }
 
 export type GetWorkflowsLogsResponses = {
@@ -3323,7 +3501,7 @@ export type GetWorkflowsLogsResponses = {
 export type GetWorkflowsLogsResponse = GetWorkflowsLogsResponses[keyof GetWorkflowsLogsResponses]
 
 export type PostWorkflowsRunData = {
-  body: WorkflowRunPayload
+  body: WorkflowRunPayloadWithUser
   path?: never
   query?: never
   url: '/workflows/run'
@@ -3332,6 +3510,7 @@ export type PostWorkflowsRunData = {
 export type PostWorkflowsRunErrors = {
   400: unknown
   401: unknown
+  403: unknown
   404: unknown
   429: unknown
   500: unknown
@@ -3354,6 +3533,7 @@ export type GetWorkflowsRunByWorkflowRunIdData = {
 
 export type GetWorkflowsRunByWorkflowRunIdErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -3365,7 +3545,7 @@ export type GetWorkflowsRunByWorkflowRunIdResponse
   = GetWorkflowsRunByWorkflowRunIdResponses[keyof GetWorkflowsRunByWorkflowRunIdResponses]
 
 export type PostWorkflowsTasksByTaskIdStopData = {
-  body?: never
+  body: RequiredServiceApiUserPayload
   path: {
     task_id: string
   }
@@ -3375,6 +3555,7 @@ export type PostWorkflowsTasksByTaskIdStopData = {
 
 export type PostWorkflowsTasksByTaskIdStopErrors = {
   401: unknown
+  403: unknown
   404: unknown
 }
 
@@ -3386,7 +3567,7 @@ export type PostWorkflowsTasksByTaskIdStopResponse
   = PostWorkflowsTasksByTaskIdStopResponses[keyof PostWorkflowsTasksByTaskIdStopResponses]
 
 export type PostWorkflowsByWorkflowIdRunData = {
-  body: WorkflowRunPayload
+  body: WorkflowRunPayloadWithUser
   path: {
     workflow_id: string
   }
@@ -3397,6 +3578,7 @@ export type PostWorkflowsByWorkflowIdRunData = {
 export type PostWorkflowsByWorkflowIdRunErrors = {
   400: unknown
   401: unknown
+  403: unknown
   404: unknown
   429: unknown
   500: unknown

--- a/packages/contracts/generated/api/service/zod.gen.ts
+++ b/packages/contracts/generated/api/service/zod.gen.ts
@@ -278,22 +278,42 @@ export const zConversationListQuery = z.object({
     .default('-updated_at'),
 })
 
-/**
- * ConversationRenamePayload
- */
-export const zConversationRenamePayload = z.object({
-  auto_generate: z.boolean().optional().default(false),
-  name: z.string().nullish(),
-})
+export const zConversationRenamePayload = z.intersection(
+  z.union([
+    z.object({
+      auto_generate: z.literal(true),
+      name: z.string().nullish(),
+    }),
+    z.object({
+      auto_generate: z.literal(false).optional().default(false),
+      name: z.string().regex(/.*\S.*/),
+    }),
+  ]),
+  z.object({
+    auto_generate: z.boolean().optional().default(false),
+    name: z.string().nullish(),
+  }),
+)
 
-/**
- * ConversationRenamePayload
- */
-export const zConversationRenamePayloadWithUser = z.object({
-  auto_generate: z.boolean().optional().default(false),
-  name: z.string().nullish(),
-  user: z.string().optional(),
-})
+export const zConversationRenamePayloadWithUser = z.intersection(
+  z.union([
+    z.object({
+      auto_generate: z.literal(true),
+      name: z.string().nullish(),
+      user: z.string().optional(),
+    }),
+    z.object({
+      auto_generate: z.literal(false).optional().default(false),
+      name: z.string().regex(/.*\S.*/),
+      user: z.string().optional(),
+    }),
+  ]),
+  z.object({
+    auto_generate: z.boolean().optional().default(false),
+    name: z.string().nullish(),
+    user: z.string().optional(),
+  }),
+)
 
 /**
  * ConversationVariableResponse
@@ -1995,17 +2015,34 @@ export const zDocumentTextCreatePayload = z.object({
   text: z.string(),
 })
 
-/**
- * DocumentTextUpdate
- */
-export const zDocumentTextUpdate = z.object({
-  doc_form: z.string().optional().default('text_model'),
-  doc_language: z.string().optional().default('English'),
-  name: z.string().nullish(),
-  process_rule: zProcessRule.nullish(),
-  retrieval_model: zRetrievalModel.nullish(),
-  text: z.string().nullish(),
-})
+export const zDocumentTextUpdate = z.intersection(
+  z.union([
+    z.object({
+      doc_form: z.string().optional().default('text_model'),
+      doc_language: z.string().optional().default('English'),
+      name: z.string(),
+      process_rule: zProcessRule.nullish(),
+      retrieval_model: zRetrievalModel.nullish(),
+      text: z.string(),
+    }),
+    z.object({
+      doc_form: z.string().optional().default('text_model'),
+      doc_language: z.string().optional().default('English'),
+      name: z.string().nullish(),
+      process_rule: zProcessRule.nullish(),
+      retrieval_model: zRetrievalModel.nullish(),
+      text: z.null().optional(),
+    }),
+  ]),
+  z.object({
+    doc_form: z.string().optional().default('text_model'),
+    doc_language: z.string().optional().default('English'),
+    name: z.string().nullish(),
+    process_rule: zProcessRule.nullish(),
+    retrieval_model: zRetrievalModel.nullish(),
+    text: z.string().nullish(),
+  }),
+)
 
 /**
  * HitTestingPayload
@@ -2185,7 +2222,7 @@ export const zGetAppFeedbacksResponse = zAppFeedbackListResponse
 export const zPostAppsAnnotationReplyByActionBody = zAnnotationReplyActionPayload
 
 export const zPostAppsAnnotationReplyByActionPath = z.object({
-  action: z.string(),
+  action: z.enum(['disable', 'enable']),
 })
 
 /**
@@ -2543,7 +2580,7 @@ export const zPostDatasetsByDatasetIdDocumentsMetadataResponse = zDatasetMetadat
 export const zPatchDatasetsByDatasetIdDocumentsStatusByActionBody = zDocumentStatusPayload
 
 export const zPatchDatasetsByDatasetIdDocumentsStatusByActionPath = z.object({
-  action: z.string(),
+  action: z.enum(['archive', 'disable', 'enable', 'un_archive']),
   dataset_id: z.uuid(),
 })
 
@@ -2846,7 +2883,7 @@ export const zGetDatasetsByDatasetIdMetadataBuiltInPath = z.object({
 export const zGetDatasetsByDatasetIdMetadataBuiltInResponse = zDatasetMetadataBuiltInFieldsResponse
 
 export const zPostDatasetsByDatasetIdMetadataBuiltInByActionPath = z.object({
-  action: z.string(),
+  action: z.enum(['disable', 'enable']),
   dataset_id: z.uuid(),
 })
 

--- a/packages/contracts/generated/api/service/zod.gen.ts
+++ b/packages/contracts/generated/api/service/zod.gen.ts
@@ -141,6 +141,22 @@ export const zChatRequestPayload = z.object({
 })
 
 /**
+ * ChatRequestPayload
+ */
+export const zChatRequestPayloadWithUser = z.object({
+  auto_generate_name: z.boolean().optional().default(true),
+  conversation_id: z.string().nullish(),
+  files: z.array(z.record(z.string(), z.unknown())).nullish(),
+  inputs: z.record(z.string(), z.unknown()),
+  query: z.string(),
+  response_mode: z.enum(['blocking', 'streaming']).nullish(),
+  retriever_from: z.string().optional().default('dev'),
+  trace_session_id: z.string().nullish(),
+  user: z.string(),
+  workflow_id: z.string().nullish(),
+})
+
+/**
  * ChildChunkCreatePayload
  */
 export const zChildChunkCreatePayload = z.object({
@@ -208,6 +224,19 @@ export const zCompletionRequestPayload = z.object({
 })
 
 /**
+ * CompletionRequestPayload
+ */
+export const zCompletionRequestPayloadWithUser = z.object({
+  files: z.array(z.record(z.string(), z.unknown())).nullish(),
+  inputs: z.record(z.string(), z.unknown()),
+  query: z.string().optional().default(''),
+  response_mode: z.enum(['blocking', 'streaming']).nullish(),
+  retriever_from: z.string().optional().default('dev'),
+  trace_session_id: z.string().nullish(),
+  user: z.string(),
+})
+
+/**
  * Condition
  *
  * Condition detail
@@ -258,6 +287,15 @@ export const zConversationRenamePayload = z.object({
 })
 
 /**
+ * ConversationRenamePayload
+ */
+export const zConversationRenamePayloadWithUser = z.object({
+  auto_generate: z.boolean().optional().default(false),
+  name: z.string().nullish(),
+  user: z.string().optional(),
+})
+
+/**
  * ConversationVariableResponse
  */
 export const zConversationVariableResponse = z.object({
@@ -283,6 +321,14 @@ export const zConversationVariableInfiniteScrollPaginationResponse = z.object({
  * ConversationVariableUpdatePayload
  */
 export const zConversationVariableUpdatePayload = z.object({
+  value: z.unknown(),
+})
+
+/**
+ * ConversationVariableUpdatePayload
+ */
+export const zConversationVariableUpdatePayloadWithUser = z.object({
+  user: z.string().optional(),
   value: z.unknown(),
 })
 
@@ -1072,6 +1118,15 @@ export const zHumanInputFormSubmitPayload = z.object({
 })
 
 /**
+ * HumanInputFormSubmitPayload
+ */
+export const zHumanInputFormSubmitPayloadWithUser = z.object({
+  action: z.string(),
+  inputs: z.record(z.string(), zJsonValue2),
+  user: z.string(),
+})
+
+/**
  * KnowledgeTagResponse
  */
 export const zKnowledgeTagResponse = z.object({
@@ -1092,6 +1147,15 @@ export const zKnowledgeTagListResponse = z.array(zKnowledgeTagResponse)
 export const zMessageFeedbackPayload = z.object({
   content: z.string().nullish(),
   rating: z.enum(['dislike', 'like']).nullish(),
+})
+
+/**
+ * MessageFeedbackPayload
+ */
+export const zMessageFeedbackPayloadWithUser = z.object({
+  content: z.string().nullish(),
+  rating: z.enum(['dislike', 'like']).nullish(),
+  user: z.string(),
 })
 
 /**
@@ -1236,6 +1300,13 @@ export const zModelType = z.enum([
 ])
 
 /**
+ * ServiceApiUserPayload
+ */
+export const zOptionalServiceApiUserPayload = z.object({
+  user: z.string().optional(),
+})
+
+/**
  * PermissionEnum
  *
  * Shared permission levels for resources (datasets, credentials, etc.)
@@ -1320,6 +1391,13 @@ export const zProviderWithModelsResponse = z.object({
  */
 export const zProviderWithModelsListResponse = z.object({
   data: z.array(zProviderWithModelsResponse),
+})
+
+/**
+ * ServiceApiUserPayload
+ */
+export const zRequiredServiceApiUserPayload = z.object({
+  user: z.string(),
 })
 
 /**
@@ -1654,13 +1732,20 @@ export const zTagDeletePayload = z.object({
 /**
  * TagUnbindingPayload
  *
- * Accept the legacy single-tag Service API payload while exposing a normalized tag_ids list internally.
+ * Accepts either the legacy tag_id payload or the normalized tag_ids payload.
  */
-export const zTagUnbindingPayload = z.object({
-  tag_id: z.string().nullish(),
-  tag_ids: z.array(z.string()).optional(),
-  target_id: z.string(),
-})
+export const zTagUnbindingPayload = z.union([
+  z.object({
+    tag_id: z.string(),
+    tag_ids: z.array(z.string()).min(1).optional(),
+    target_id: z.string(),
+  }),
+  z.object({
+    tag_id: z.string().optional(),
+    tag_ids: z.array(z.string()).min(1),
+    target_id: z.string(),
+  }),
+])
 
 /**
  * TagUpdatePayload
@@ -1677,6 +1762,17 @@ export const zTextToAudioPayload = z.object({
   message_id: z.string().nullish(),
   streaming: z.boolean().nullish(),
   text: z.string().nullish(),
+  voice: z.string().nullish(),
+})
+
+/**
+ * TextToAudioPayload
+ */
+export const zTextToAudioPayloadWithUser = z.object({
+  message_id: z.string().nullish(),
+  streaming: z.boolean().nullish(),
+  text: z.string().nullish(),
+  user: z.string().optional(),
   voice: z.string().nullish(),
 })
 
@@ -2006,6 +2102,17 @@ export const zWorkflowRunPayload = z.object({
 })
 
 /**
+ * WorkflowRunPayload
+ */
+export const zWorkflowRunPayloadWithUser = z.object({
+  files: z.array(z.record(z.string(), z.unknown())).nullish(),
+  inputs: z.record(z.string(), z.unknown()),
+  response_mode: z.enum(['blocking', 'streaming']).nullish(),
+  trace_session_id: z.string().nullish(),
+  user: z.string(),
+})
+
+/**
  * WorkflowRunResponse
  */
 export const zWorkflowRunResponse = z.object({
@@ -2088,7 +2195,7 @@ export const zPostAppsAnnotationReplyByActionResponse = zAnnotationJobStatusResp
 
 export const zGetAppsAnnotationReplyByActionStatusByJobIdPath = z.object({
   action: z.string(),
-  job_id: z.string(),
+  job_id: z.uuid(),
 })
 
 /**
@@ -2115,7 +2222,7 @@ export const zPostAppsAnnotationsBody = zAnnotationCreatePayload
 export const zPostAppsAnnotationsResponse = zAnnotation
 
 export const zDeleteAppsAnnotationsByAnnotationIdPath = z.object({
-  annotation_id: z.string(),
+  annotation_id: z.uuid(),
 })
 
 /**
@@ -2126,7 +2233,7 @@ export const zDeleteAppsAnnotationsByAnnotationIdResponse = z.void()
 export const zPutAppsAnnotationsByAnnotationIdBody = zAnnotationCreatePayload
 
 export const zPutAppsAnnotationsByAnnotationIdPath = z.object({
-  annotation_id: z.string(),
+  annotation_id: z.uuid(),
 })
 
 /**
@@ -2134,17 +2241,24 @@ export const zPutAppsAnnotationsByAnnotationIdPath = z.object({
  */
 export const zPutAppsAnnotationsByAnnotationIdResponse = zAnnotation
 
+export const zPostAudioToTextBody = z.object({
+  file: z.custom<Blob | File>(),
+  user: z.string().optional(),
+})
+
 /**
  * Audio successfully transcribed
  */
 export const zPostAudioToTextResponse = zAudioTranscriptResponse
 
-export const zPostChatMessagesBody = zChatRequestPayload
+export const zPostChatMessagesBody = zChatRequestPayloadWithUser
 
 /**
  * Message sent successfully
  */
 export const zPostChatMessagesResponse = zGeneratedAppResponse
+
+export const zPostChatMessagesByTaskIdStopBody = zRequiredServiceApiUserPayload
 
 export const zPostChatMessagesByTaskIdStopPath = z.object({
   task_id: z.string(),
@@ -2155,12 +2269,14 @@ export const zPostChatMessagesByTaskIdStopPath = z.object({
  */
 export const zPostChatMessagesByTaskIdStopResponse = zSimpleResultResponse
 
-export const zPostCompletionMessagesBody = zCompletionRequestPayload
+export const zPostCompletionMessagesBody = zCompletionRequestPayloadWithUser
 
 /**
  * Completion created successfully
  */
 export const zPostCompletionMessagesResponse = zGeneratedAppResponse
+
+export const zPostCompletionMessagesByTaskIdStopBody = zRequiredServiceApiUserPayload
 
 export const zPostCompletionMessagesByTaskIdStopPath = z.object({
   task_id: z.string(),
@@ -2178,6 +2294,7 @@ export const zGetConversationsQuery = z.object({
     .enum(['-created_at', '-updated_at', 'created_at', 'updated_at'])
     .optional()
     .default('-updated_at'),
+  user: z.string().optional(),
 })
 
 /**
@@ -2185,8 +2302,10 @@ export const zGetConversationsQuery = z.object({
  */
 export const zGetConversationsResponse = zConversationInfiniteScrollPagination
 
+export const zDeleteConversationsByCIdBody = zOptionalServiceApiUserPayload
+
 export const zDeleteConversationsByCIdPath = z.object({
-  c_id: z.string(),
+  c_id: z.uuid(),
 })
 
 /**
@@ -2194,10 +2313,10 @@ export const zDeleteConversationsByCIdPath = z.object({
  */
 export const zDeleteConversationsByCIdResponse = z.void()
 
-export const zPostConversationsByCIdNameBody = zConversationRenamePayload
+export const zPostConversationsByCIdNameBody = zConversationRenamePayloadWithUser
 
 export const zPostConversationsByCIdNamePath = z.object({
-  c_id: z.string(),
+  c_id: z.uuid(),
 })
 
 /**
@@ -2206,12 +2325,13 @@ export const zPostConversationsByCIdNamePath = z.object({
 export const zPostConversationsByCIdNameResponse = zSimpleConversation
 
 export const zGetConversationsByCIdVariablesPath = z.object({
-  c_id: z.string(),
+  c_id: z.uuid(),
 })
 
 export const zGetConversationsByCIdVariablesQuery = z.object({
   last_id: z.string().optional(),
   limit: z.int().gte(1).lte(100).optional().default(20),
+  user: z.string().optional(),
   variable_name: z.string().min(1).max(255).optional(),
 })
 
@@ -2221,11 +2341,12 @@ export const zGetConversationsByCIdVariablesQuery = z.object({
 export const zGetConversationsByCIdVariablesResponse
   = zConversationVariableInfiniteScrollPaginationResponse
 
-export const zPutConversationsByCIdVariablesByVariableIdBody = zConversationVariableUpdatePayload
+export const zPutConversationsByCIdVariablesByVariableIdBody
+  = zConversationVariableUpdatePayloadWithUser
 
 export const zPutConversationsByCIdVariablesByVariableIdPath = z.object({
-  c_id: z.string(),
-  variable_id: z.string(),
+  c_id: z.uuid(),
+  variable_id: z.uuid(),
 })
 
 /**
@@ -2252,6 +2373,10 @@ export const zPostDatasetsBody = zDatasetCreatePayload
  * Dataset created successfully
  */
 export const zPostDatasetsResponse = zDatasetDetailResponse
+
+export const zPostDatasetsPipelineFileUploadBody = z.object({
+  file: z.custom<Blob | File>(),
+})
 
 /**
  * File uploaded successfully
@@ -2299,7 +2424,7 @@ export const zPostDatasetsTagsUnbindingBody = zTagUnbindingPayload
 export const zPostDatasetsTagsUnbindingResponse = z.void()
 
 export const zDeleteDatasetsByDatasetIdPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2308,7 +2433,7 @@ export const zDeleteDatasetsByDatasetIdPath = z.object({
 export const zDeleteDatasetsByDatasetIdResponse = z.void()
 
 export const zGetDatasetsByDatasetIdPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2319,7 +2444,7 @@ export const zGetDatasetsByDatasetIdResponse = zDatasetDetailWithPartialMembersR
 export const zPatchDatasetsByDatasetIdBody = zDatasetUpdatePayload
 
 export const zPatchDatasetsByDatasetIdPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2333,7 +2458,7 @@ export const zPostDatasetsByDatasetIdDocumentCreateByFileBody = z.object({
 })
 
 export const zPostDatasetsByDatasetIdDocumentCreateByFilePath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2344,7 +2469,7 @@ export const zPostDatasetsByDatasetIdDocumentCreateByFileResponse = zDocumentAnd
 export const zPostDatasetsByDatasetIdDocumentCreateByTextBody = zDocumentTextCreatePayload
 
 export const zPostDatasetsByDatasetIdDocumentCreateByTextPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2358,7 +2483,7 @@ export const zPostDatasetsByDatasetIdDocumentCreateByFile2Body = z.object({
 })
 
 export const zPostDatasetsByDatasetIdDocumentCreateByFile2Path = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2369,7 +2494,7 @@ export const zPostDatasetsByDatasetIdDocumentCreateByFile2Response = zDocumentAn
 export const zPostDatasetsByDatasetIdDocumentCreateByText2Body = zDocumentTextCreatePayload
 
 export const zPostDatasetsByDatasetIdDocumentCreateByText2Path = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2378,7 +2503,7 @@ export const zPostDatasetsByDatasetIdDocumentCreateByText2Path = z.object({
 export const zPostDatasetsByDatasetIdDocumentCreateByText2Response = zDocumentAndBatchResponse
 
 export const zGetDatasetsByDatasetIdDocumentsPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 export const zGetDatasetsByDatasetIdDocumentsQuery = z.object({
@@ -2396,18 +2521,18 @@ export const zGetDatasetsByDatasetIdDocumentsResponse = zDocumentListResponse
 export const zPostDatasetsByDatasetIdDocumentsDownloadZipBody = zDocumentBatchDownloadZipPayload
 
 export const zPostDatasetsByDatasetIdDocumentsDownloadZipPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
  * ZIP archive generated successfully
  */
-export const zPostDatasetsByDatasetIdDocumentsDownloadZipResponse = zBinaryFileResponse
+export const zPostDatasetsByDatasetIdDocumentsDownloadZipResponse = z.custom<Blob | File>()
 
 export const zPostDatasetsByDatasetIdDocumentsMetadataBody = zMetadataOperationData
 
 export const zPostDatasetsByDatasetIdDocumentsMetadataPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2419,7 +2544,7 @@ export const zPatchDatasetsByDatasetIdDocumentsStatusByActionBody = zDocumentSta
 
 export const zPatchDatasetsByDatasetIdDocumentsStatusByActionPath = z.object({
   action: z.string(),
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2429,7 +2554,7 @@ export const zPatchDatasetsByDatasetIdDocumentsStatusByActionResponse = zSimpleR
 
 export const zGetDatasetsByDatasetIdDocumentsByBatchIndexingStatusPath = z.object({
   batch: z.string(),
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2439,8 +2564,8 @@ export const zGetDatasetsByDatasetIdDocumentsByBatchIndexingStatusResponse
   = zDocumentStatusListResponse
 
 export const zDeleteDatasetsByDatasetIdDocumentsByDocumentIdPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -2449,8 +2574,8 @@ export const zDeleteDatasetsByDatasetIdDocumentsByDocumentIdPath = z.object({
 export const zDeleteDatasetsByDatasetIdDocumentsByDocumentIdResponse = z.void()
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdQuery = z.object({
@@ -2468,8 +2593,8 @@ export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdBody = z.object({
 })
 
 export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -2478,8 +2603,8 @@ export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdPath = z.object({
 export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdResponse = zDocumentAndBatchResponse
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdDownloadPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -2488,8 +2613,8 @@ export const zGetDatasetsByDatasetIdDocumentsByDocumentIdDownloadPath = z.object
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdDownloadResponse = zUrlResponse
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdSegmentsPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdSegmentsQuery = z.object({
@@ -2507,8 +2632,8 @@ export const zGetDatasetsByDatasetIdDocumentsByDocumentIdSegmentsResponse = zSeg
 export const zPostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBody = zSegmentCreatePayload
 
 export const zPostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -2518,9 +2643,9 @@ export const zPostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsResponse
   = zSegmentCreateListResponse
 
 export const zDeleteDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
-  segment_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
+  segment_id: z.uuid(),
 })
 
 /**
@@ -2529,9 +2654,9 @@ export const zDeleteDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdP
 export const zDeleteDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdResponse = z.void()
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
-  segment_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
+  segment_id: z.uuid(),
 })
 
 /**
@@ -2544,9 +2669,9 @@ export const zPostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdBod
   = zSegmentUpdatePayload
 
 export const zPostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
-  segment_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
+  segment_id: z.uuid(),
 })
 
 /**
@@ -2557,9 +2682,9 @@ export const zPostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdRes
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChildChunksPath
   = z.object({
-    dataset_id: z.string(),
-    document_id: z.string(),
-    segment_id: z.string(),
+    dataset_id: z.uuid(),
+    document_id: z.uuid(),
+    segment_id: z.uuid(),
   })
 
 export const zGetDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChildChunksQuery
@@ -2580,9 +2705,9 @@ export const zPostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChi
 
 export const zPostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChildChunksPath
   = z.object({
-    dataset_id: z.string(),
-    document_id: z.string(),
-    segment_id: z.string(),
+    dataset_id: z.uuid(),
+    document_id: z.uuid(),
+    segment_id: z.uuid(),
   })
 
 /**
@@ -2593,10 +2718,10 @@ export const zPostDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChi
 
 export const zDeleteDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChildChunksByChildChunkIdPath
   = z.object({
-    child_chunk_id: z.string(),
-    dataset_id: z.string(),
-    document_id: z.string(),
-    segment_id: z.string(),
+    child_chunk_id: z.uuid(),
+    dataset_id: z.uuid(),
+    document_id: z.uuid(),
+    segment_id: z.uuid(),
   })
 
 /**
@@ -2610,10 +2735,10 @@ export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdCh
 
 export const zPatchDatasetsByDatasetIdDocumentsByDocumentIdSegmentsBySegmentIdChildChunksByChildChunkIdPath
   = z.object({
-    child_chunk_id: z.string(),
-    dataset_id: z.string(),
-    document_id: z.string(),
-    segment_id: z.string(),
+    child_chunk_id: z.uuid(),
+    dataset_id: z.uuid(),
+    document_id: z.uuid(),
+    segment_id: z.uuid(),
   })
 
 /**
@@ -2628,8 +2753,8 @@ export const zPostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByFileBody = z.o
 })
 
 export const zPostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByFilePath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -2641,8 +2766,8 @@ export const zPostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByFileResponse
 export const zPostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByTextBody = zDocumentTextUpdate
 
 export const zPostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByTextPath = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -2657,8 +2782,8 @@ export const zPostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByFile2Body = z.
 })
 
 export const zPostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByFile2Path = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -2670,8 +2795,8 @@ export const zPostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByFile2Response
 export const zPostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByText2Body = zDocumentTextUpdate
 
 export const zPostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByText2Path = z.object({
-  dataset_id: z.string(),
-  document_id: z.string(),
+  dataset_id: z.uuid(),
+  document_id: z.uuid(),
 })
 
 /**
@@ -2683,7 +2808,7 @@ export const zPostDatasetsByDatasetIdDocumentsByDocumentIdUpdateByText2Response
 export const zPostDatasetsByDatasetIdHitTestingBody = zHitTestingPayload
 
 export const zPostDatasetsByDatasetIdHitTestingPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2692,7 +2817,7 @@ export const zPostDatasetsByDatasetIdHitTestingPath = z.object({
 export const zPostDatasetsByDatasetIdHitTestingResponse = zHitTestingResponse
 
 export const zGetDatasetsByDatasetIdMetadataPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2703,7 +2828,7 @@ export const zGetDatasetsByDatasetIdMetadataResponse = zDatasetMetadataListRespo
 export const zPostDatasetsByDatasetIdMetadataBody = zMetadataArgs
 
 export const zPostDatasetsByDatasetIdMetadataPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2712,7 +2837,7 @@ export const zPostDatasetsByDatasetIdMetadataPath = z.object({
 export const zPostDatasetsByDatasetIdMetadataResponse = zDatasetMetadataResponse
 
 export const zGetDatasetsByDatasetIdMetadataBuiltInPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2722,7 +2847,7 @@ export const zGetDatasetsByDatasetIdMetadataBuiltInResponse = zDatasetMetadataBu
 
 export const zPostDatasetsByDatasetIdMetadataBuiltInByActionPath = z.object({
   action: z.string(),
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2732,8 +2857,8 @@ export const zPostDatasetsByDatasetIdMetadataBuiltInByActionResponse
   = zDatasetMetadataActionResponse
 
 export const zDeleteDatasetsByDatasetIdMetadataByMetadataIdPath = z.object({
-  dataset_id: z.string(),
-  metadata_id: z.string(),
+  dataset_id: z.uuid(),
+  metadata_id: z.uuid(),
 })
 
 /**
@@ -2744,8 +2869,8 @@ export const zDeleteDatasetsByDatasetIdMetadataByMetadataIdResponse = z.void()
 export const zPatchDatasetsByDatasetIdMetadataByMetadataIdBody = zMetadataUpdatePayload
 
 export const zPatchDatasetsByDatasetIdMetadataByMetadataIdPath = z.object({
-  dataset_id: z.string(),
-  metadata_id: z.string(),
+  dataset_id: z.uuid(),
+  metadata_id: z.uuid(),
 })
 
 /**
@@ -2754,7 +2879,7 @@ export const zPatchDatasetsByDatasetIdMetadataByMetadataIdPath = z.object({
 export const zPatchDatasetsByDatasetIdMetadataByMetadataIdResponse = zDatasetMetadataResponse
 
 export const zGetDatasetsByDatasetIdPipelineDatasourcePluginsPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 export const zGetDatasetsByDatasetIdPipelineDatasourcePluginsQuery = z.object({
@@ -2771,7 +2896,7 @@ export const zPostDatasetsByDatasetIdPipelineDatasourceNodesByNodeIdRunBody
   = zDatasourceNodeRunPayload
 
 export const zPostDatasetsByDatasetIdPipelineDatasourceNodesByNodeIdRunPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
   node_id: z.string(),
 })
 
@@ -2784,7 +2909,7 @@ export const zPostDatasetsByDatasetIdPipelineDatasourceNodesByNodeIdRunResponse
 export const zPostDatasetsByDatasetIdPipelineRunBody = zPipelineRunApiEntity
 
 export const zPostDatasetsByDatasetIdPipelineRunPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2795,7 +2920,7 @@ export const zPostDatasetsByDatasetIdPipelineRunResponse = zGeneratedAppResponse
 export const zPostDatasetsByDatasetIdRetrieveBody = zHitTestingPayload
 
 export const zPostDatasetsByDatasetIdRetrievePath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2804,7 +2929,7 @@ export const zPostDatasetsByDatasetIdRetrievePath = z.object({
 export const zPostDatasetsByDatasetIdRetrieveResponse = zHitTestingResponse
 
 export const zGetDatasetsByDatasetIdTagsPath = z.object({
-  dataset_id: z.string(),
+  dataset_id: z.uuid(),
 })
 
 /**
@@ -2813,7 +2938,7 @@ export const zGetDatasetsByDatasetIdTagsPath = z.object({
 export const zGetDatasetsByDatasetIdTagsResponse = zDatasetBoundTagListResponse
 
 export const zGetEndUsersByEndUserIdPath = z.object({
-  end_user_id: z.string(),
+  end_user_id: z.uuid(),
 })
 
 /**
@@ -2821,23 +2946,29 @@ export const zGetEndUsersByEndUserIdPath = z.object({
  */
 export const zGetEndUsersByEndUserIdResponse = zEndUserDetail
 
+export const zPostFilesUploadBody = z.object({
+  file: z.custom<Blob | File>(),
+  user: z.string().optional(),
+})
+
 /**
  * File uploaded successfully
  */
 export const zPostFilesUploadResponse = zFileResponse
 
 export const zGetFilesByFileIdPreviewPath = z.object({
-  file_id: z.string(),
+  file_id: z.uuid(),
 })
 
 export const zGetFilesByFileIdPreviewQuery = z.object({
   as_attachment: z.boolean().optional().default(false),
+  user: z.string().optional(),
 })
 
 /**
  * File retrieved successfully
  */
-export const zGetFilesByFileIdPreviewResponse = zBinaryFileResponse
+export const zGetFilesByFileIdPreviewResponse = z.custom<Blob | File>()
 
 export const zGetFormHumanInputByFormTokenPath = z.object({
   form_token: z.string(),
@@ -2848,7 +2979,7 @@ export const zGetFormHumanInputByFormTokenPath = z.object({
  */
 export const zGetFormHumanInputByFormTokenResponse = zHumanInputFormDefinitionResponse
 
-export const zPostFormHumanInputByFormTokenBody = zHumanInputFormSubmitPayload
+export const zPostFormHumanInputByFormTokenBody = zHumanInputFormSubmitPayloadWithUser
 
 export const zPostFormHumanInputByFormTokenPath = z.object({
   form_token: z.string(),
@@ -2868,6 +2999,7 @@ export const zGetMessagesQuery = z.object({
   conversation_id: z.string(),
   first_id: z.string().optional(),
   limit: z.int().gte(1).lte(100).optional().default(20),
+  user: z.string().optional(),
 })
 
 /**
@@ -2875,10 +3007,10 @@ export const zGetMessagesQuery = z.object({
  */
 export const zGetMessagesResponse = zMessageInfiniteScrollPagination
 
-export const zPostMessagesByMessageIdFeedbacksBody = zMessageFeedbackPayload
+export const zPostMessagesByMessageIdFeedbacksBody = zMessageFeedbackPayloadWithUser
 
 export const zPostMessagesByMessageIdFeedbacksPath = z.object({
-  message_id: z.string(),
+  message_id: z.uuid(),
 })
 
 /**
@@ -2887,7 +3019,11 @@ export const zPostMessagesByMessageIdFeedbacksPath = z.object({
 export const zPostMessagesByMessageIdFeedbacksResponse = zResultResponse
 
 export const zGetMessagesByMessageIdSuggestedPath = z.object({
-  message_id: z.string(),
+  message_id: z.uuid(),
+})
+
+export const zGetMessagesByMessageIdSuggestedQuery = z.object({
+  user: z.string(),
 })
 
 /**
@@ -2910,12 +3046,12 @@ export const zGetParametersResponse = zParameters
  */
 export const zGetSiteResponse = zSite
 
-export const zPostTextToAudioBody = zTextToAudioPayload
+export const zPostTextToAudioBody = zTextToAudioPayloadWithUser
 
 /**
  * Text successfully converted to audio
  */
-export const zPostTextToAudioResponse = zAudioBinaryResponse
+export const zPostTextToAudioResponse = z.custom<Blob | File>()
 
 export const zGetWorkflowByTaskIdEventsPath = z.object({
   task_id: z.string(),
@@ -2948,7 +3084,7 @@ export const zGetWorkflowsLogsQuery = z.object({
  */
 export const zGetWorkflowsLogsResponse = zWorkflowAppLogPaginationResponse
 
-export const zPostWorkflowsRunBody = zWorkflowRunPayload
+export const zPostWorkflowsRunBody = zWorkflowRunPayloadWithUser
 
 /**
  * Workflow executed successfully
@@ -2964,6 +3100,8 @@ export const zGetWorkflowsRunByWorkflowRunIdPath = z.object({
  */
 export const zGetWorkflowsRunByWorkflowRunIdResponse = zWorkflowRunResponse
 
+export const zPostWorkflowsTasksByTaskIdStopBody = zRequiredServiceApiUserPayload
+
 export const zPostWorkflowsTasksByTaskIdStopPath = z.object({
   task_id: z.string(),
 })
@@ -2973,7 +3111,7 @@ export const zPostWorkflowsTasksByTaskIdStopPath = z.object({
  */
 export const zPostWorkflowsTasksByTaskIdStopResponse = zSimpleResultResponse
 
-export const zPostWorkflowsByWorkflowIdRunBody = zWorkflowRunPayload
+export const zPostWorkflowsByWorkflowIdRunBody = zWorkflowRunPayloadWithUser
 
 export const zPostWorkflowsByWorkflowIdRunPath = z.object({
   workflow_id: z.string(),

--- a/packages/contracts/generated/api/web/types.gen.ts
+++ b/packages/contracts/generated/api/web/types.gen.ts
@@ -146,7 +146,16 @@ export type ConversationListQuery = {
   sort_by?: '-created_at' | '-updated_at' | 'created_at' | 'updated_at'
 }
 
-export type ConversationRenamePayload = {
+export type ConversationRenamePayload = (
+  | {
+    auto_generate: true
+    name?: string | null
+  }
+  | {
+    auto_generate?: false
+    name: string
+  }
+) & {
   auto_generate?: boolean
   name?: string | null
 }

--- a/packages/contracts/generated/api/web/zod.gen.ts
+++ b/packages/contracts/generated/api/web/zod.gen.ts
@@ -168,13 +168,22 @@ export const zConversationListQuery = z.object({
     .default('-updated_at'),
 })
 
-/**
- * ConversationRenamePayload
- */
-export const zConversationRenamePayload = z.object({
-  auto_generate: z.boolean().optional().default(false),
-  name: z.string().nullish(),
-})
+export const zConversationRenamePayload = z.intersection(
+  z.union([
+    z.object({
+      auto_generate: z.literal(true),
+      name: z.string().nullish(),
+    }),
+    z.object({
+      auto_generate: z.literal(false).optional().default(false),
+      name: z.string().regex(/.*\S.*/),
+    }),
+  ]),
+  z.object({
+    auto_generate: z.boolean().optional().default(false),
+    name: z.string().nullish(),
+  }),
+)
 
 /**
  * EmailCodeLoginSendPayload

--- a/packages/contracts/generated/api/web/zod.gen.ts
+++ b/packages/contracts/generated/api/web/zod.gen.ts
@@ -954,7 +954,7 @@ export const zGetConversationsQuery = z.object({
 export const zGetConversationsResponse = zConversationInfiniteScrollPagination
 
 export const zDeleteConversationsByCIdPath = z.object({
-  c_id: z.string(),
+  c_id: z.uuid(),
 })
 
 /**
@@ -965,7 +965,7 @@ export const zDeleteConversationsByCIdResponse = z.void()
 export const zPostConversationsByCIdNameBody = zConversationRenamePayload
 
 export const zPostConversationsByCIdNamePath = z.object({
-  c_id: z.string(),
+  c_id: z.uuid(),
 })
 
 export const zPostConversationsByCIdNameQuery = z.object({
@@ -979,7 +979,7 @@ export const zPostConversationsByCIdNameQuery = z.object({
 export const zPostConversationsByCIdNameResponse = zSimpleConversation
 
 export const zPatchConversationsByCIdPinPath = z.object({
-  c_id: z.string(),
+  c_id: z.uuid(),
 })
 
 /**
@@ -988,7 +988,7 @@ export const zPatchConversationsByCIdPinPath = z.object({
 export const zPatchConversationsByCIdPinResponse = zResultResponse
 
 export const zPatchConversationsByCIdUnpinPath = z.object({
-  c_id: z.string(),
+  c_id: z.uuid(),
 })
 
 /**
@@ -1106,7 +1106,7 @@ export const zGetMessagesResponse = zWebMessageInfiniteScrollPagination
 export const zPostMessagesByMessageIdFeedbacksBody = zMessageFeedbackPayload
 
 export const zPostMessagesByMessageIdFeedbacksPath = z.object({
-  message_id: z.string(),
+  message_id: z.uuid(),
 })
 
 export const zPostMessagesByMessageIdFeedbacksQuery = z.object({
@@ -1120,7 +1120,7 @@ export const zPostMessagesByMessageIdFeedbacksQuery = z.object({
 export const zPostMessagesByMessageIdFeedbacksResponse = zResultResponse
 
 export const zGetMessagesByMessageIdMoreLikeThisPath = z.object({
-  message_id: z.string(),
+  message_id: z.uuid(),
 })
 
 export const zGetMessagesByMessageIdMoreLikeThisQuery = z.object({
@@ -1133,7 +1133,7 @@ export const zGetMessagesByMessageIdMoreLikeThisQuery = z.object({
 export const zGetMessagesByMessageIdMoreLikeThisResponse = zGeneratedAppResponse
 
 export const zGetMessagesByMessageIdSuggestedQuestionsPath = z.object({
-  message_id: z.string(),
+  message_id: z.uuid(),
 })
 
 /**
@@ -1198,7 +1198,7 @@ export const zPostSavedMessagesQuery = z.object({
 export const zPostSavedMessagesResponse = zResultResponse
 
 export const zDeleteSavedMessagesByMessageIdPath = z.object({
-  message_id: z.string(),
+  message_id: z.uuid(),
 })
 
 /**


### PR DESCRIPTION
## Summary

Fixes #37589.

This PR updates the generated Service API OpenAPI contract so it reflects runtime behavior from the Service API controllers instead of relying on external documentation coverage.

## Changes

- Add Service API OpenAPI helpers for documentation-only JSON `user` request bodies, multipart file parameters, and non-JSON response media types.
- Derive JSON body `user` requiredness from `validate_app_token(fetch_user_arg=...)` metadata so the generated schema follows the runtime contract.
- Document query/form `user` parameters through the app-token decorator metadata.
- Represent multipart upload endpoints, SSE responses, audio/binary/archive responses, and standard Bearer auth more accurately.
- Derive `format: uuid` from Flask/Werkzeug `<uuid:...>` route converters instead of maintaining a parameter-name whitelist.
- Represent `TagUnbindingPayload` as the runtime-compatible legacy `tag_id` or normalized `tag_ids` payload shapes.
- Keep standard OpenAPI `deprecated: true` for known legacy aliases without adding custom public/internal/undocumented extensions based on docs coverage.
- Regenerate TypeScript contracts under `packages/contracts/generated/api`.

## Validation

- `uv run --project api ruff check api/controllers/service_api api/tests/unit_tests/controllers/test_swagger.py`
- `uv run --project api ruff format --check api/controllers/service_api api/tests/unit_tests/controllers/test_swagger.py`
- `uv run --project api pytest api/tests/unit_tests/controllers/test_swagger.py -q`
- `uv run --project api pytest api/tests/unit_tests/commands/test_generate_swagger_specs.py -q`
- `pnpm gen-api-contract`
- `pnpm type-check`
- `git diff --check`
