### PR TITLE
fix(agent): sync generated observability contracts

### DIFF
--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -663,7 +663,7 @@ Commit an uploaded file into the Agent App drive under files/<name>
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| agent_id | path |  | Yes | string |
+| agent_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
@@ -703,8 +703,8 @@ Commit an uploaded file into the Agent App drive under files/<name>
 | source | query | Filter by all, console/explore, api/service-api, web-app, debugger, openapi, or trigger | No | string |
 | start | query | Start date (YYYY-MM-DD HH:MM) | No | string |
 | status | query | Filter by success, failed, or paused | No | string |
-| agent_id | path |  | Yes | string |
-| conversation_id | path |  | Yes | string |
+| agent_id | path |  | Yes | string (uuid) |
+| conversation_id | path |  | Yes | string (uuid) |
 
 #### Responses
 

--- a/packages/contracts/generated/api/console/agent/zod.gen.ts
+++ b/packages/contracts/generated/api/console/agent/zod.gen.ts
@@ -2347,7 +2347,7 @@ export const zPostAgentByAgentIdFilesPath = z.object({
 export const zPostAgentByAgentIdFilesResponse = zAgentDriveFileCommitResponse
 
 export const zGetAgentByAgentIdLogSourcesPath = z.object({
-  agent_id: z.string(),
+  agent_id: z.uuid(),
 })
 
 /**
@@ -2375,8 +2375,8 @@ export const zGetAgentByAgentIdLogsQuery = z.object({
 export const zGetAgentByAgentIdLogsResponse = zAgentLogListResponse
 
 export const zGetAgentByAgentIdLogsByConversationIdMessagesPath = z.object({
-  agent_id: z.string(),
-  conversation_id: z.string(),
+  agent_id: z.uuid(),
+  conversation_id: z.uuid(),
 })
 
 export const zGetAgentByAgentIdLogsByConversationIdMessagesQuery = z.object({


### PR DESCRIPTION
## Summary

- Sync generated OpenAPI markdown for the new agent observability routes
- Sync generated zod path validators so UUID path params match the backend route converters

## Testing

- `cd api && uv run dev/generate_swagger_markdown_docs.py --swagger-dir ../packages/contracts/openapi --markdown-dir openapi/markdown --keep-swagger-json`
- `pnpm --dir packages/contracts gen-api-contract-from-openapi`
- `git diff --check`

Focused on fixing the current `autofix.ci` failure only.
