### PR TITLE
refactor(web): centralize main nav route access

### DIFF
--- a/web/app/(commonLayout)/__tests__/role-route-guard.spec.tsx
+++ b/web/app/(commonLayout)/__tests__/role-route-guard.spec.tsx
@@ -87,7 +87,7 @@ describe('RoleRouteGuard', () => {
     })
   })
 
-  it('should redirect dataset operator on protected routes', () => {
+  it('should redirect dataset operator on guarded routes', () => {
     setCurrentWorkspaceQuery({ role: 'dataset_operator' })
 
     expect(() => renderGuard(<div>content</div>)).toThrow('NEXT_REDIRECT:/datasets')
@@ -95,13 +95,14 @@ describe('RoleRouteGuard', () => {
     expect(mocks.redirect).toHaveBeenCalledWith('/datasets')
   })
 
-  it('should redirect dataset operator on routes missing from the allowlist', () => {
+  it('should allow dataset operator on routes outside the guarded list', () => {
     mockPathname = '/new-route'
     setCurrentWorkspaceQuery({ role: 'dataset_operator' })
 
-    expect(() => renderGuard(<div>content</div>)).toThrow('NEXT_REDIRECT:/datasets')
+    renderGuard(<div>content</div>)
 
-    expect(mocks.redirect).toHaveBeenCalledWith('/datasets')
+    expect(screen.getByText('content')).toBeInTheDocument()
+    expect(mocks.redirect).not.toHaveBeenCalled()
   })
 
   it('should redirect dataset operator on deployments routes', () => {
@@ -113,25 +114,25 @@ describe('RoleRouteGuard', () => {
     expect(mocks.redirect).toHaveBeenCalledWith('/datasets')
   })
 
-  it('should prefer dataset operator redirect when app deploy is disabled', () => {
+  it('should prefer app deploy redirect when app deploy is disabled', () => {
     mockPathname = '/deployments/create'
     setCurrentWorkspaceQuery({ role: 'dataset_operator' })
 
-    expect(() => renderGuard(<div>content</div>, { enable_app_deploy: false })).toThrow('NEXT_REDIRECT:/datasets')
+    expect(() => renderGuard(<div>content</div>, { enable_app_deploy: false })).toThrow('NEXT_REDIRECT:/')
 
-    expect(mocks.redirect).toHaveBeenCalledWith('/datasets')
+    expect(mocks.redirect).toHaveBeenCalledWith('/')
   })
 
   it('should redirect app deploy routes when app deploy is disabled', () => {
     mockPathname = '/deployments/create'
     setCurrentWorkspaceQuery({ role: 'editor' })
 
-    expect(() => renderGuard(<div>content</div>, { enable_app_deploy: false })).toThrow('NEXT_REDIRECT:/apps')
+    expect(() => renderGuard(<div>content</div>, { enable_app_deploy: false })).toThrow('NEXT_REDIRECT:/')
 
-    expect(mocks.redirect).toHaveBeenCalledWith('/apps')
+    expect(mocks.redirect).toHaveBeenCalledWith('/')
   })
 
-  it('should allow dataset operator on configured routes', () => {
+  it('should allow dataset operator on non-guarded routes', () => {
     mockPathname = '/plugins'
     setCurrentWorkspaceQuery({ role: 'dataset_operator' })
 
@@ -141,7 +142,7 @@ describe('RoleRouteGuard', () => {
     expect(mocks.redirect).not.toHaveBeenCalled()
   })
 
-  it('should not block configured routes while workspace is loading', () => {
+  it('should not block non-guarded routes while workspace is loading', () => {
     mockPathname = '/plugins'
     setCurrentWorkspaceQuery({ isPending: true })
 

--- a/web/app/(commonLayout)/__tests__/role-route-guard.spec.tsx
+++ b/web/app/(commonLayout)/__tests__/role-route-guard.spec.tsx
@@ -47,14 +47,14 @@ vi.mock('@/service/client', () => ({
 
 const mockUseQuery = vi.mocked(useQuery)
 
-function renderGuard(children: ReactNode) {
+function renderGuard(children: ReactNode, systemFeatures: { enable_app_deploy?: boolean } = {}) {
   return renderWithSystemFeatures(
     <RoleRouteGuard>
       {children}
     </RoleRouteGuard>,
     {
       systemFeatures: {
-        enable_app_deploy: true,
+        enable_app_deploy: systemFeatures.enable_app_deploy ?? true,
       },
     },
   )
@@ -87,7 +87,16 @@ describe('RoleRouteGuard', () => {
     })
   })
 
-  it('should redirect dataset operator on guarded routes', () => {
+  it('should redirect dataset operator on protected routes', () => {
+    setCurrentWorkspaceQuery({ role: 'dataset_operator' })
+
+    expect(() => renderGuard(<div>content</div>)).toThrow('NEXT_REDIRECT:/datasets')
+
+    expect(mocks.redirect).toHaveBeenCalledWith('/datasets')
+  })
+
+  it('should redirect dataset operator on routes missing from the allowlist', () => {
+    mockPathname = '/new-route'
     setCurrentWorkspaceQuery({ role: 'dataset_operator' })
 
     expect(() => renderGuard(<div>content</div>)).toThrow('NEXT_REDIRECT:/datasets')
@@ -104,7 +113,25 @@ describe('RoleRouteGuard', () => {
     expect(mocks.redirect).toHaveBeenCalledWith('/datasets')
   })
 
-  it('should allow dataset operator on non-guarded routes', () => {
+  it('should prefer dataset operator redirect when app deploy is disabled', () => {
+    mockPathname = '/deployments/create'
+    setCurrentWorkspaceQuery({ role: 'dataset_operator' })
+
+    expect(() => renderGuard(<div>content</div>, { enable_app_deploy: false })).toThrow('NEXT_REDIRECT:/datasets')
+
+    expect(mocks.redirect).toHaveBeenCalledWith('/datasets')
+  })
+
+  it('should redirect app deploy routes when app deploy is disabled', () => {
+    mockPathname = '/deployments/create'
+    setCurrentWorkspaceQuery({ role: 'editor' })
+
+    expect(() => renderGuard(<div>content</div>, { enable_app_deploy: false })).toThrow('NEXT_REDIRECT:/apps')
+
+    expect(mocks.redirect).toHaveBeenCalledWith('/apps')
+  })
+
+  it('should allow dataset operator on configured routes', () => {
     mockPathname = '/plugins'
     setCurrentWorkspaceQuery({ role: 'dataset_operator' })
 
@@ -114,7 +141,7 @@ describe('RoleRouteGuard', () => {
     expect(mocks.redirect).not.toHaveBeenCalled()
   })
 
-  it('should not block non-guarded routes while workspace is loading', () => {
+  it('should not block configured routes while workspace is loading', () => {
     mockPathname = '/plugins'
     setCurrentWorkspaceQuery({ isPending: true })
 

--- a/web/app/(commonLayout)/role-route-guard.tsx
+++ b/web/app/(commonLayout)/role-route-guard.tsx
@@ -3,15 +3,10 @@
 import type { ReactNode } from 'react'
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import Loading from '@/app/components/base/loading'
+import { isDatasetOperatorAllowedRoute, isPathUnderRoute } from '@/app/components/main-nav/routes'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { redirect, usePathname } from '@/next/navigation'
 import { consoleQuery } from '@/service/client'
-
-const datasetOperatorRedirectRoutes = ['/', '/apps', '/app', '/deployments', '/snippets', '/roster', '/explore', '/tools', '/integrations'] as const
-
-function isPathUnderRoute(pathname: string, route: string) {
-  return pathname === route || pathname.startsWith(`${route}/`)
-}
 
 export function RoleRouteGuard({ children }: { children: ReactNode }) {
   const currentWorkspaceRoleQuery = useQuery(consoleQuery.workspaces.current.post.queryOptions({
@@ -19,7 +14,7 @@ export function RoleRouteGuard({ children }: { children: ReactNode }) {
   }))
   const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
   const pathname = usePathname()
-  const shouldGuardRoute = datasetOperatorRedirectRoutes.some(route => isPathUnderRoute(pathname, route))
+  const shouldGuardRoute = !isDatasetOperatorAllowedRoute(pathname)
   const shouldRedirectDatasetOperator = shouldGuardRoute
     && !currentWorkspaceRoleQuery.isPending
     && currentWorkspaceRoleQuery.data === 'dataset_operator'
@@ -29,11 +24,11 @@ export function RoleRouteGuard({ children }: { children: ReactNode }) {
   if (shouldGuardRoute && currentWorkspaceRoleQuery.isPending)
     return <Loading type="app" />
 
-  if (shouldRedirectAppDeploy)
-    redirect('/apps')
-
   if (shouldRedirectDatasetOperator)
     redirect('/datasets')
+
+  if (shouldRedirectAppDeploy)
+    redirect('/')
 
   return <>{children}</>
 }

--- a/web/app/(commonLayout)/role-route-guard.tsx
+++ b/web/app/(commonLayout)/role-route-guard.tsx
@@ -3,10 +3,15 @@
 import type { ReactNode } from 'react'
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import Loading from '@/app/components/base/loading'
-import { isDatasetOperatorAllowedRoute, isPathUnderRoute } from '@/app/components/main-nav/routes'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { redirect, usePathname } from '@/next/navigation'
 import { consoleQuery } from '@/service/client'
+
+const datasetOperatorRedirectRoutes = ['/', '/apps', '/app', '/deployments', '/snippets', '/roster', '/explore', '/tools', '/integrations'] as const
+
+function isPathUnderRoute(pathname: string, route: string) {
+  return pathname === route || pathname.startsWith(`${route}/`)
+}
 
 export function RoleRouteGuard({ children }: { children: ReactNode }) {
   const currentWorkspaceRoleQuery = useQuery(consoleQuery.workspaces.current.post.queryOptions({
@@ -14,7 +19,7 @@ export function RoleRouteGuard({ children }: { children: ReactNode }) {
   }))
   const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
   const pathname = usePathname()
-  const shouldGuardRoute = !isDatasetOperatorAllowedRoute(pathname)
+  const shouldGuardRoute = datasetOperatorRedirectRoutes.some(route => isPathUnderRoute(pathname, route))
   const shouldRedirectDatasetOperator = shouldGuardRoute
     && !currentWorkspaceRoleQuery.isPending
     && currentWorkspaceRoleQuery.data === 'dataset_operator'
@@ -24,11 +29,11 @@ export function RoleRouteGuard({ children }: { children: ReactNode }) {
   if (shouldGuardRoute && currentWorkspaceRoleQuery.isPending)
     return <Loading type="app" />
 
-  if (shouldRedirectDatasetOperator)
-    redirect('/datasets')
-
   if (shouldRedirectAppDeploy)
     redirect('/')
+
+  if (shouldRedirectDatasetOperator)
+    redirect('/datasets')
 
   return <>{children}</>
 }

--- a/web/app/components/main-nav/index.tsx
+++ b/web/app/components/main-nav/index.tsx
@@ -15,7 +15,6 @@ import DatasetDetailTop from '@/app/components/app-sidebar/dataset-detail-top'
 import { useStore as useAppStore } from '@/app/components/app/store'
 import DifyLogo from '@/app/components/base/logo/dify-logo'
 import EnvNav from '@/app/components/header/env-nav'
-import { buildIntegrationPath } from '@/app/components/integrations/routes'
 import { useAppContext } from '@/context/app-context'
 import { AgentDetailSection, AgentDetailTop } from '@/features/agent-v2/agent-detail/navigation'
 import { isAgentV2Enabled } from '@/features/agent-v2/feature-flag'
@@ -29,6 +28,7 @@ import MainNavLink from './components/nav-link'
 import { MainNavSearchButton } from './components/search-button'
 import WebAppsSection from './components/web-apps-section'
 import { WorkspaceCard } from './components/workspace-card'
+import { isMainNavRouteVisible, MAIN_NAV_ROUTES } from './routes'
 
 const DATASET_COLLECTION_ROUTES = new Set(['create', 'create-from-pipeline', 'connect'])
 const DATASET_DOCUMENT_CREATION_ROUTES = new Set(['create', 'create-from-pipeline'])
@@ -185,73 +185,20 @@ const MainNav = ({
     ignoreInputs: false,
   })
 
-  const navItems = useMemo<MainNavItem[]>(() => [
-    ...(!isCurrentWorkspaceDatasetOperator
-      ? [
-          {
-            href: '/',
-            label: t('mainNav.home', { ns: 'common' }),
-            active: (path: string) => path === '/' || path === '/explore/apps',
-            icon: 'i-custom-vender-main-nav-home',
-            activeIcon: 'i-custom-vender-main-nav-home-active',
-          },
-          {
-            href: '/apps',
-            label: t('menus.apps', { ns: 'common' }),
-            active: (path: string) => path.startsWith('/apps') || path.startsWith('/app/') || path.startsWith('/snippets'),
-            icon: 'i-custom-vender-main-nav-studio',
-            activeIcon: 'i-custom-vender-main-nav-studio-active',
-          },
-          ...(agentV2Enabled
-            ? [{
-                href: '/roster',
-                label: t('menus.roster', { ns: 'common' }),
-                active: (path: string) => path.startsWith('/roster'),
-                icon: 'i-custom-vender-main-nav-roster',
-                activeIcon: 'i-custom-vender-main-nav-roster-active',
-              }]
-            : []),
-        ]
-      : []),
-    ...((isCurrentWorkspaceEditor || isCurrentWorkspaceDatasetOperator)
-      ? [
-          {
-            href: '/datasets',
-            label: t('menus.datasets', { ns: 'common' }),
-            active: (path: string) => path.startsWith('/datasets'),
-            icon: 'i-custom-vender-main-nav-knowledge',
-            activeIcon: 'i-custom-vender-main-nav-knowledge-active',
-          },
-        ]
-      : []),
-    ...(!isCurrentWorkspaceDatasetOperator
-      ? [
-          {
-            href: buildIntegrationPath('provider'),
-            label: t('mainNav.integrations', { ns: 'common' }),
-            active: (path: string) => path.startsWith('/integrations') || path.startsWith('/tools'),
-            icon: 'i-custom-vender-main-nav-integrations',
-            activeIcon: 'i-custom-vender-main-nav-integrations-active',
-          },
-        ]
-      : []),
-    {
-      href: '/marketplace',
-      label: t('mainNav.marketplace', { ns: 'common' }),
-      active: path => path.startsWith('/marketplace') || path.startsWith('/plugins'),
-      icon: 'i-custom-vender-main-nav-marketplace',
-      activeIcon: 'i-custom-vender-main-nav-marketplace-active',
-    },
-    ...(canUseAppDeploy
-      ? [{
-          href: '/deployments',
-          label: t('menus.deployments', { ns: 'common' }),
-          active: (path: string) => path.startsWith('/deployments'),
-          icon: 'i-ri-rocket-line',
-          activeIcon: 'i-ri-rocket-fill',
-        }]
-      : []),
-  ], [agentV2Enabled, canUseAppDeploy, isCurrentWorkspaceDatasetOperator, isCurrentWorkspaceEditor, t])
+  const navItems = useMemo<MainNavItem[]>(() => MAIN_NAV_ROUTES
+    .filter(route => isMainNavRouteVisible(route, {
+      agentV2Enabled,
+      canUseAppDeploy,
+      isCurrentWorkspaceDatasetOperator,
+      isCurrentWorkspaceEditor,
+    }))
+    .map(route => ({
+      href: route.href,
+      label: t(route.labelKey, { ns: 'common' }),
+      active: route.active,
+      icon: route.icon,
+      activeIcon: route.activeIcon,
+    })), [agentV2Enabled, canUseAppDeploy, isCurrentWorkspaceDatasetOperator, isCurrentWorkspaceEditor, t])
 
   const renderLogo = () => {
     const appTitle = systemFeatures.branding.enabled && systemFeatures.branding.application_title ? systemFeatures.branding.application_title : 'Dify'

--- a/web/app/components/main-nav/routes.ts
+++ b/web/app/components/main-nav/routes.ts
@@ -1,0 +1,115 @@
+import { buildIntegrationPath } from '@/app/components/integrations/routes'
+
+export type MainNavRouteVisibility = 'all' | 'notDatasetOperator' | 'editorOrDatasetOperator' | 'appDeployEditor'
+
+export type MainNavRouteConfig = {
+  key: string
+  href: string
+  labelKey: string
+  active: (pathname: string) => boolean
+  icon: string
+  activeIcon: string
+  visibility: MainNavRouteVisibility
+  feature?: 'agentV2'
+  datasetOperatorAccess?: boolean
+}
+
+export type MainNavRouteVisibilityOptions = {
+  agentV2Enabled: boolean
+  canUseAppDeploy: boolean
+  isCurrentWorkspaceDatasetOperator: boolean
+  isCurrentWorkspaceEditor: boolean
+}
+
+export function isPathUnderRoute(pathname: string, route: string) {
+  return pathname === route || pathname.startsWith(`${route}/`)
+}
+
+export const MAIN_NAV_ROUTES = [
+  {
+    key: 'home',
+    href: '/',
+    labelKey: 'mainNav.home',
+    active: (path: string) => path === '/' || path === '/explore/apps',
+    icon: 'i-custom-vender-main-nav-home',
+    activeIcon: 'i-custom-vender-main-nav-home-active',
+    visibility: 'notDatasetOperator',
+  },
+  {
+    key: 'apps',
+    href: '/apps',
+    labelKey: 'menus.apps',
+    active: (path: string) => isPathUnderRoute(path, '/apps') || isPathUnderRoute(path, '/app') || isPathUnderRoute(path, '/snippets'),
+    icon: 'i-custom-vender-main-nav-studio',
+    activeIcon: 'i-custom-vender-main-nav-studio-active',
+    visibility: 'notDatasetOperator',
+  },
+  {
+    key: 'roster',
+    href: '/roster',
+    labelKey: 'menus.roster',
+    active: (path: string) => isPathUnderRoute(path, '/roster'),
+    icon: 'i-custom-vender-main-nav-roster',
+    activeIcon: 'i-custom-vender-main-nav-roster-active',
+    visibility: 'notDatasetOperator',
+    feature: 'agentV2',
+  },
+  {
+    key: 'datasets',
+    href: '/datasets',
+    labelKey: 'menus.datasets',
+    active: (path: string) => isPathUnderRoute(path, '/datasets'),
+    icon: 'i-custom-vender-main-nav-knowledge',
+    activeIcon: 'i-custom-vender-main-nav-knowledge-active',
+    visibility: 'editorOrDatasetOperator',
+    datasetOperatorAccess: true,
+  },
+  {
+    key: 'integrations',
+    href: buildIntegrationPath('provider'),
+    labelKey: 'mainNav.integrations',
+    active: (path: string) => isPathUnderRoute(path, '/integrations') || isPathUnderRoute(path, '/tools'),
+    icon: 'i-custom-vender-main-nav-integrations',
+    activeIcon: 'i-custom-vender-main-nav-integrations-active',
+    visibility: 'notDatasetOperator',
+  },
+  {
+    key: 'marketplace',
+    href: '/marketplace',
+    labelKey: 'mainNav.marketplace',
+    active: (path: string) => isPathUnderRoute(path, '/marketplace') || isPathUnderRoute(path, '/plugins'),
+    icon: 'i-custom-vender-main-nav-marketplace',
+    activeIcon: 'i-custom-vender-main-nav-marketplace-active',
+    visibility: 'all',
+    datasetOperatorAccess: true,
+  },
+  {
+    key: 'deployments',
+    href: '/deployments',
+    labelKey: 'menus.deployments',
+    active: (path: string) => isPathUnderRoute(path, '/deployments'),
+    icon: 'i-ri-rocket-line',
+    activeIcon: 'i-ri-rocket-fill',
+    visibility: 'appDeployEditor',
+  },
+] as const satisfies readonly MainNavRouteConfig[]
+
+export function isMainNavRouteVisible(route: MainNavRouteConfig, options: MainNavRouteVisibilityOptions) {
+  if (route.feature === 'agentV2' && !options.agentV2Enabled)
+    return false
+
+  if (route.visibility === 'all')
+    return true
+
+  if (route.visibility === 'notDatasetOperator')
+    return !options.isCurrentWorkspaceDatasetOperator
+
+  if (route.visibility === 'editorOrDatasetOperator')
+    return options.isCurrentWorkspaceEditor || options.isCurrentWorkspaceDatasetOperator
+
+  return options.canUseAppDeploy
+}
+
+export function isDatasetOperatorAllowedRoute(pathname: string) {
+  return MAIN_NAV_ROUTES.some(route => 'datasetOperatorAccess' in route && route.datasetOperatorAccess && route.active(pathname))
+}

--- a/web/app/components/main-nav/routes.ts
+++ b/web/app/components/main-nav/routes.ts
@@ -1,6 +1,6 @@
 import { buildIntegrationPath } from '@/app/components/integrations/routes'
 
-export type MainNavRouteVisibility = 'all' | 'notDatasetOperator' | 'editorOrDatasetOperator' | 'appDeployEditor'
+type MainNavRouteVisibility = 'all' | 'notDatasetOperator' | 'editorOrDatasetOperator' | 'appDeployEditor'
 
 export type MainNavRouteConfig = {
   key: string
@@ -11,7 +11,6 @@ export type MainNavRouteConfig = {
   activeIcon: string
   visibility: MainNavRouteVisibility
   feature?: 'agentV2'
-  datasetOperatorAccess?: boolean
 }
 
 export type MainNavRouteVisibilityOptions = {
@@ -21,7 +20,7 @@ export type MainNavRouteVisibilityOptions = {
   isCurrentWorkspaceEditor: boolean
 }
 
-export function isPathUnderRoute(pathname: string, route: string) {
+function isPathUnderRoute(pathname: string, route: string) {
   return pathname === route || pathname.startsWith(`${route}/`)
 }
 
@@ -62,7 +61,6 @@ export const MAIN_NAV_ROUTES = [
     icon: 'i-custom-vender-main-nav-knowledge',
     activeIcon: 'i-custom-vender-main-nav-knowledge-active',
     visibility: 'editorOrDatasetOperator',
-    datasetOperatorAccess: true,
   },
   {
     key: 'integrations',
@@ -81,7 +79,6 @@ export const MAIN_NAV_ROUTES = [
     icon: 'i-custom-vender-main-nav-marketplace',
     activeIcon: 'i-custom-vender-main-nav-marketplace-active',
     visibility: 'all',
-    datasetOperatorAccess: true,
   },
   {
     key: 'deployments',
@@ -108,8 +105,4 @@ export function isMainNavRouteVisible(route: MainNavRouteConfig, options: MainNa
     return options.isCurrentWorkspaceEditor || options.isCurrentWorkspaceDatasetOperator
 
   return options.canUseAppDeploy
-}
-
-export function isDatasetOperatorAllowedRoute(pathname: string) {
-  return MAIN_NAV_ROUTES.some(route => 'datasetOperatorAccess' in route && route.datasetOperatorAccess && route.active(pathname))
 }


### PR DESCRIPTION
## Summary

- Move main navigation route metadata into a colocated `main-nav/routes.ts` config.
- Derive `MainNav` items from the same route config instead of duplicating role branches inline.
- Keep `RoleRouteGuard` on the previous dataset-operator guarded-route blacklist so unlisted routes preserve their existing behavior.
- Cover the updated guard behavior, including guarded routes, unguarded routes, `/plugins`, and app-deploy-disabled redirects to `/`.

## Validation

- `pnpm -C web exec eslint 'app/(commonLayout)/role-route-guard.tsx' 'app/(commonLayout)/__tests__/role-route-guard.spec.tsx' app/components/main-nav/index.tsx app/components/main-nav/routes.ts`
- `pnpm -C web type-check`
- `pnpm -C web lint:tss`
- `pnpm -C web test 'app/(commonLayout)/__tests__/role-route-guard.spec.tsx' app/components/main-nav/__tests__/index.spec.tsx`
- `git diff --check`
