### PR TITLE
refactor(tests): replace mock_logger with caplog in service tests (#37468)

### DIFF
--- a/api/tests/unit_tests/services/test_trigger_provider_service.py
+++ b/api/tests/unit_tests/services/test_trigger_provider_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
@@ -252,27 +253,28 @@ def test_add_trigger_subscription_should_raise_error_when_provider_limit_reached
     mock_session: MagicMock,
     provider_id: TriggerProviderID,
     provider_controller: MagicMock,
+    caplog,
 ) -> None:
     # Arrange
     _patch_redis_lock(mocker)
     mock_session.scalar.return_value = TriggerProviderService.__MAX_TRIGGER_PROVIDER_COUNT__
     _mock_get_trigger_provider(mocker, provider_controller)
-    mock_logger = mocker.patch("services.trigger.trigger_provider_service.logger")
 
     # Act + Assert
-    with pytest.raises(ValueError, match="Maximum number of providers"):
-        TriggerProviderService.add_trigger_subscription(
-            tenant_id="tenant-1",
-            user_id="user-1",
-            name="main",
-            provider_id=provider_id,
-            endpoint_id="endpoint-1",
-            credential_type=CredentialType.API_KEY,
-            parameters={},
-            properties={},
-            credentials={},
-        )
-    mock_logger.exception.assert_called_once()
+    with caplog.at_level(logging.ERROR, logger="services.trigger.trigger_provider_service"):
+        with pytest.raises(ValueError, match="Maximum number of providers"):
+            TriggerProviderService.add_trigger_subscription(
+                tenant_id="tenant-1",
+                user_id="user-1",
+                name="main",
+                provider_id=provider_id,
+                endpoint_id="endpoint-1",
+                credential_type=CredentialType.API_KEY,
+                parameters={},
+                properties={},
+                credentials={},
+            )
+    assert sum(1 for r in caplog.records if r.levelno >= logging.ERROR) == 1
 
 
 def test_add_trigger_subscription_should_raise_error_when_name_exists(


### PR DESCRIPTION
## Summary

\n\nReplace `unittest.mock.patch` logger patterns with pytest's `caplog` fixture in service test files.\n\nThe `caplog` fixture is more idiomatic for pytest, less brittle (doesn't depend on internal logger import paths), and more readable.\n\n### Changes:\n- `test_trigger_provider_service.py`: Replaced `mocker.patch(\"services.trigger.trigger_provider_service.logger\")` with `caplog.at_level()` context manager\n- All `mock_logger.warning.assert_called()` / `assert_not_called()` converted to `caplog.records` checks\n- All `str(mock_logger.xxx.call_args)` assertions converted to `caplog.text` checks\n\n### Conversion pattern:\n```python\n# Before:\nlogger = mocker.patch(\"services.trigger.trigger_provider_service.logger\")\n# ...\nlogger.warning.assert_called_once()\n\n# After:\nwith caplog.at_level(logging.WARNING, logger=\"services.trigger.trigger_provider_service\"):\n    # ...\n    assert any(\"expected msg\" in r.message for r in caplog.records)\n```\n\nCloses #37468