### PR TITLE
fix(datasets): validate console dataset list pagination as >= 1

### DIFF
--- a/api/controllers/console/datasets/datasets.py
+++ b/api/controllers/console/datasets/datasets.py
@@ -136,8 +136,8 @@ class IndexingEstimatePayload(BaseModel):
 
 
 class ConsoleDatasetListQuery(BaseModel):
-    page: int = Field(default=1, description="Page number")
-    limit: int = Field(default=20, description="Number of items per page")
+    page: int = Field(default=1, ge=1, description="Page number")
+    limit: int = Field(default=20, ge=1, description="Number of items per page")
     keyword: str | None = Field(default=None, description="Search keyword")
     include_all: bool = Field(default=False, description="Include all datasets")
     ids: list[str] = Field(default_factory=list, description="Filter by dataset IDs")

--- a/api/tests/unit_tests/controllers/console/datasets/test_dataset_list_query.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_dataset_list_query.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from controllers.console.datasets.datasets import ConsoleDatasetListQuery
+
+
+def test_dataset_list_query_defaults() -> None:
+    query = ConsoleDatasetListQuery()
+    assert query.page == 1
+    assert query.limit == 20
+
+
+def test_dataset_list_query_accepts_valid_pagination() -> None:
+    query = ConsoleDatasetListQuery(page=3, limit=50)
+    assert query.page == 3
+    assert query.limit == 50
+
+
+def test_dataset_list_query_rejects_non_positive_page() -> None:
+    with pytest.raises(ValidationError):
+        ConsoleDatasetListQuery(page=0)
+    with pytest.raises(ValidationError):
+        ConsoleDatasetListQuery(page=-1)
+
+
+def test_dataset_list_query_rejects_non_positive_limit() -> None:
+    with pytest.raises(ValidationError):
+        ConsoleDatasetListQuery(limit=0)
+    with pytest.raises(ValidationError):
+        ConsoleDatasetListQuery(limit=-5)


### PR DESCRIPTION
## Summary

`ConsoleDatasetListQuery` (the query model for the console "list datasets" endpoint) declared `page` and `limit` as plain integers with only a default:

```python
class ConsoleDatasetListQuery(BaseModel):
    page: int = Field(default=1, description="Page number")
    limit: int = Field(default=20, description="Number of items per page")
```

So a request with `page=-1` or `limit=0` validates fine and flows straight into `DatasetService.get_datasets(query.page, query.limit, ...)` and on to the DB pagination, where a non-positive page/limit is meaningless and can error.

The annotation list queries already guard this — `AnnotationListQuery` uses `Field(default=1, ge=1)` for both `page` and `limit` in `controllers/console/app/annotation.py` and `controllers/service_api/app/annotation.py` (commit `c530a5d272`). This PR applies the same `ge=1` bound to the console dataset list query so the pagination convention is consistent.

## Test plan

Added `api/tests/unit_tests/controllers/console/datasets/test_dataset_list_query.py`, mirroring the existing `test_external_dataset_payload.py` style: it constructs the model directly and asserts defaults, a valid page/limit, and that non-positive `page`/`limit` raise `ValidationError`.

The negative cases pass after this change and fail on `main` (the values are accepted). I verified the `Field(ge=1)` behavior standalone; the test imports the controller module, so it runs under the project's existing unit-test environment / CI rather than my local shell (the full `api` dependencies, e.g. `flask_restx`, are not installed here). `ruff check` and `ruff format --check` pass on the changed files.

From Claude Code.
