### PR TITLE
fix(agent): decouple roster from app quota

### DIFF
--- a/api/controllers/console/agent/roster.py
+++ b/api/controllers/console/agent/roster.py
@@ -26,7 +26,6 @@ from controllers.console.app.app import (
 )
 from controllers.console.wraps import (
     account_initialization_required,
-    cloud_edition_billing_resource_check,
     edit_permission_required,
     enterprise_license_required,
     setup_required,
@@ -335,7 +334,6 @@ class AgentAppListApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
-    @cloud_edition_billing_resource_check("apps")
     @edit_permission_required
     @with_current_user
     @with_current_tenant_id
@@ -414,7 +412,6 @@ class AgentAppCopyApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
-    @cloud_edition_billing_resource_check("apps")
     @edit_permission_required
     @with_current_user
     @with_current_tenant_id

--- a/api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
+++ b/api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
@@ -1,4 +1,4 @@
-from inspect import unwrap
+from inspect import getsource, unwrap
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -175,6 +175,11 @@ def test_agent_v2_console_routes_are_agent_id_first() -> None:
         "/apps/<uuid:app_id>/agent-sandbox/files",
     ):
         assert route not in paths
+
+
+def test_agent_app_write_routes_do_not_reuse_app_billing_quota() -> None:
+    for route_class in (AgentAppListApi, AgentAppCopyApi):
+        assert '@cloud_edition_billing_resource_check("apps")' not in getsource(route_class)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- remove the shared app billing quota decorator from Agent Roster create and duplicate routes
- keep the normal `/console/api/apps` quota enforcement unchanged
- add a regression test asserting Agent Roster write routes do not reuse `cloud_edition_billing_resource_check("apps")`

## Verification

- `git diff --check origin/main...HEAD`
- `uv run ruff check controllers/console/agent/roster.py tests/unit_tests/controllers/console/agent/test_agent_controllers.py`
- `PATH_TO_CHECK='api/controllers/console/agent/roster.py api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py' make type-check-core`
- Deployed commit `4d82ecdeef` to `deploy/agent`, pulled/recreated API services on `https://agent.dify.dev`
- Remote E2E with real console APIs:
  - filled app quota from `13/50` to `50/50` using temporary apps
  - confirmed normal app creation returns `403` with `The number of apps has reached the limit of your subscription.`
  - confirmed `POST /console/api/agent` still returns `201` at app quota limit
  - confirmed `POST /console/api/agent/{agent_id}/copy` still returns `201` at app quota limit
  - cleaned up all temporary apps and agents; final app quota returned to `13/50`

## Notes

- Focused local pytest currently segfaults during pytest initialization before collecting tests in this workspace; lint, type-check, and remote E2E completed successfully.

Fixes DIFY-2523.
