### PR TITLE
fix: invalidate credential cache after OAuth refresh

### DIFF
--- a/api/services/trigger/trigger_provider_service.py
+++ b/api/services/trigger/trigger_provider_service.py
@@ -475,7 +475,7 @@ class TriggerProviderService:
                 tenant_id=tenant_id, provider_id=provider_id
             )
             # Create encrypter
-            encrypter, cache = create_provider_encrypter(
+            encrypter, _ = create_provider_encrypter(
                 tenant_id=tenant_id,
                 config=[x.to_basic_provider_config() for x in provider_controller.get_oauth_client_schema()],
                 cache=NoOpProviderCredentialCache(),
@@ -506,13 +506,19 @@ class TriggerProviderService:
             subscription.credentials = dict(encrypter.encrypt(dict(refreshed_credentials.credentials)))
             subscription.credential_expires_at = refreshed_credentials.expires_at
 
-            # Clear cache
-            cache.delete()
-
-            return {
+            provider_id_value = subscription.provider_id
+            result = {
                 "result": "success",
                 "expires_at": refreshed_credentials.expires_at,
             }
+
+        # Clear the trigger runtime credential cache after the DB commit so dispatch uses the refreshed token.
+        delete_cache_for_subscription(
+            tenant_id=tenant_id,
+            provider_id=provider_id_value,
+            subscription_id=subscription_id,
+        )
+        return result
 
     @classmethod
     def refresh_subscription(

--- a/api/tests/unit_tests/services/test_trigger_provider_service.py
+++ b/api/tests/unit_tests/services/test_trigger_provider_service.py
@@ -558,6 +558,7 @@ def test_refresh_oauth_token_should_refresh_and_persist_new_credentials(
         return_value=(cred_enc, cache),
     )
     mocker.patch.object(TriggerProviderService, "get_oauth_client", return_value={"client_id": "id"})
+    mock_delete_cache = mocker.patch("services.trigger.trigger_provider_service.delete_cache_for_subscription")
     refreshed = SimpleNamespace(credentials={"access_token": "new"}, expires_at=12345)
     oauth_handler = MagicMock()
     oauth_handler.refresh_credentials.return_value = refreshed
@@ -571,7 +572,12 @@ def test_refresh_oauth_token_should_refresh_and_persist_new_credentials(
     assert subscription.credentials == {"access_token": "new"}
     assert subscription.credential_expires_at == 12345
 
-    cache.delete.assert_called_once()
+    cache.delete.assert_not_called()
+    mock_delete_cache.assert_called_once_with(
+        tenant_id="tenant-1",
+        provider_id=str(provider_id),
+        subscription_id="sub-1",
+    )
 
 
 def test_refresh_subscription_should_raise_error_when_subscription_missing(


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

fix https://github.com/langgenius/dify/issues/37629

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
