### PR TITLE
fix: add bounded timeout to Jina credential validation requests

### DIFF
--- a/api/services/auth/jina.py
+++ b/api/services/auth/jina.py
@@ -8,7 +8,10 @@ from services.auth.api_key_auth_base import ApiKeyAuthBase, AuthCredentials
 
 _http_client: httpx.Client = get_pooled_http_client(
     "auth:jina_standalone",
-    lambda: httpx.Client(limits=httpx.Limits(max_keepalive_connections=50, max_connections=100)),
+    lambda: httpx.Client(
+        timeout=httpx.Timeout(10.0),
+        limits=httpx.Limits(max_keepalive_connections=50, max_connections=100),
+    ),
 )
 
 

--- a/api/services/auth/jina/jina.py
+++ b/api/services/auth/jina/jina.py
@@ -8,7 +8,10 @@ from services.auth.api_key_auth_base import ApiKeyAuthBase, AuthCredentials
 
 _http_client: httpx.Client = get_pooled_http_client(
     "auth:jina",
-    lambda: httpx.Client(limits=httpx.Limits(max_keepalive_connections=50, max_connections=100)),
+    lambda: httpx.Client(
+        timeout=httpx.Timeout(10.0),
+        limits=httpx.Limits(max_keepalive_connections=50, max_connections=100),
+    ),
 )
 
 


### PR DESCRIPTION
## Summary

Add a bounded 10-second timeout to the `httpx.Client` used for Jina credential validation. Without an explicit timeout, the POST to `https://r.jina.ai` could hang indefinitely if the remote endpoint is unresponsive, blocking the credential validation flow.

## Changes

- **`api/services/auth/jina/jina.py`** — Added `timeout=httpx.Timeout(10.0)` to the pooled `httpx.Client` builder
- **`api/services/auth/jina.py`** — Same change for the standalone variant

## Motivation

The `validate_credentials()` method calls `_post_request()` which uses a pooled `httpx.Client` created without any timeout. If Jina's API is slow or unreachable, the request blocks forever, causing the credential validation to hang. A 10-second bounded timeout ensures the request fails fast with a clear `httpx.TimeoutException` instead.

Fixes #37524