### PR TITLE
fix: add bounded timeout to Firecrawl credential validation

### DIFF
--- a/api/services/auth/firecrawl/firecrawl.py
+++ b/api/services/auth/firecrawl/firecrawl.py
@@ -5,6 +5,10 @@ import httpx
 
 from services.auth.api_key_auth_base import ApiKeyAuthBase, AuthCredentials
 
+# Explicit bounded timeout for credential-validation requests so a slow or
+# hanging Firecrawl endpoint cannot block the worker indefinitely.
+_CREDENTIAL_TIMEOUT = httpx.Timeout(10.0)
+
 
 class FirecrawlAuth(ApiKeyAuthBase):
     def __init__(self, credentials: AuthCredentials):
@@ -42,7 +46,7 @@ class FirecrawlAuth(ApiKeyAuthBase):
         return f"{self.base_url.rstrip('/')}/{path.lstrip('/')}"
 
     def _post_request(self, url, data, headers):
-        return httpx.post(url, headers=headers, json=data)
+        return httpx.post(url, headers=headers, json=data, timeout=_CREDENTIAL_TIMEOUT)
 
     def _handle_error(self, response):
         try:

--- a/api/tests/unit_tests/services/auth/test_firecrawl_auth.py
+++ b/api/tests/unit_tests/services/auth/test_firecrawl_auth.py
@@ -86,6 +86,7 @@ class TestFirecrawlAuth:
             "https://api.firecrawl.dev/v1/crawl",
             headers={"Content-Type": "application/json", "Authorization": "Bearer test_api_key_123"},
             json=expected_data,
+            timeout=httpx.Timeout(10.0),
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Adds an explicit 10-second `httpx.Timeout` to the Firecrawl auth provider's `_post_request()` method, matching the pattern already used by the Jina auth provider.

**Why:** The Firecrawl credential-validation POST (`v1/crawl`) had no bounded timeout. A slow or hanging Firecrawl endpoint could block the worker indefinitely.

**Changes:**
- `api/services/auth/firecrawl/firecrawl.py` — define `_CREDENTIAL_TIMEOUT=httpx.Timeout(10.0)` and pass it to `httpx.post()`.
- `api/tests/unit_tests/services/auth/test_firecrawl_auth.py` — update the `assert_called_once_with` assertion to include the `timeout` keyword argument.

Fixes #37521