### PR TITLE
fix(web): prevent HTML elements in user questions from rendering as interactive widgets

### DIFF
--- a/web/app/components/base/chat/chat/question.tsx
+++ b/web/app/components/base/chat/chat/question.tsx
@@ -25,6 +25,11 @@ import { CssTransform } from '../embedded-chatbot/theme/utils'
 import ContentSwitch from './content-switch'
 import { useChatContext } from './context'
 
+// Prevent HTML elements that are specifically intended for LLM-generated content
+// (interactive widgets, think-blocks, variable references) from being rendered
+// when displaying user-authored questions. See: langgenius/dify#37414
+const QUESTION_DISALLOWED_ELEMENTS = ['button', 'form', 'input', 'textarea', 'label', 'details', 'variable', 'section']
+
 type QuestionProps = {
   item: ChatItem
   questionIcon?: ReactNode
@@ -206,7 +211,7 @@ const Question: FC<QuestionProps> = ({
             )
           }
           {!isEditing
-            ? <Markdown content={content} />
+            ? <Markdown content={content} customDisallowedElements={QUESTION_DISALLOWED_ELEMENTS} />
             : (
                 <div className="flex flex-col gap-4">
                   <div className="max-h-[158px] overflow-x-hidden overflow-y-auto pr-1">


### PR DESCRIPTION
## Summary

- User-authored messages are rendered through `<Markdown>`, which uses a sanitize schema that intentionally allows custom HTML elements (`button`, `form`, `details`, `variable`, `section`, etc.) for LLM-generated interactive content.
- When a user types raw HTML such as `<button class="primary-button">Confirm</button>`, it passes through the sanitizer and gets rendered as an actual interactive `MarkdownButton`, creating unexpected UI elements.
- Pass `customDisallowedElements` to the `<Markdown>` call in `question.tsx` to block these LLM-specific tags when displaying user-authored content.

Fixes #37414

## Changes

- `web/app/components/base/chat/chat/question.tsx`: add `QUESTION_DISALLOWED_ELEMENTS` constant (the set of tags reserved for LLM responses) and forward it as `customDisallowedElements` when rendering the question bubble.