### PR TITLE
fix(web): simplify completed drawer dismissal

### DIFF
--- a/web/app/components/datasets/documents/detail/completed/common/drawer.tsx
+++ b/web/app/components/datasets/documents/detail/completed/common/drawer.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
   Drawer,
@@ -11,7 +11,6 @@ import {
 
 type DrawerSide = 'right' | 'left' | 'bottom' | 'top'
 type DrawerSwipeDirection = 'right' | 'left' | 'down' | 'up'
-type DrawerOpenChange = NonNullable<ComponentProps<typeof Drawer>['onOpenChange']>
 
 type CompletedDrawerProps = {
   open: boolean
@@ -47,16 +46,6 @@ export function CompletedDrawer({
   panelContentClassName,
   modal = false,
 }: CompletedDrawerProps) {
-  const handleOpenChange: DrawerOpenChange = (nextOpen, eventDetails) => {
-    if (nextOpen)
-      return
-
-    if (eventDetails.reason === 'focus-out' || eventDetails.reason === 'outside-press')
-      return
-
-    onClose()
-  }
-
   if (!open)
     return null
 
@@ -66,7 +55,7 @@ export function CompletedDrawer({
       modal={modal}
       swipeDirection={SIDE_TO_SWIPE_DIRECTION[side]}
       disablePointerDismissal
-      onOpenChange={handleOpenChange}
+      onOpenChange={nextOpen => !nextOpen && onClose()}
     >
       <DrawerPortal>
         {modal && (


### PR DESCRIPTION
## Summary
- simplify CompletedDrawer close handling by relying on Base UI `disablePointerDismissal` for outside/focus dismissal
- keep the drawer controlled so parent document-detail state remains the source of truth
- leave modal overlay click behavior owned by the wrapper backdrop

## Rationale
Base UI Drawer documents that `disablePointerDismissal` prevents outside-press dismissal and, for non-modal drawers, also prevents focus-out dismissal. This lets the `onOpenChange` callback handle only true close intents instead of re-checking Base UI change reasons at the call site.

## Validation
- `pnpm eslint web/app/components/datasets/documents/detail/completed/common/drawer.tsx`
- `pnpm -C web type-check`
- `pnpm -C web test app/components/datasets/documents/detail/completed/common/__tests__/drawer.spec.tsx`
- `git diff --check`