### PR TITLE
fix: use f-string for error messages in resume_workflow_execution

### DIFF
--- a/api/tasks/async_workflow_tasks.py
+++ b/api/tasks/async_workflow_tasks.py
@@ -237,13 +237,13 @@ def resume_workflow_execution(task_data_dict: dict[str, Any]) -> None:
         workflow = session.scalar(select(Workflow).where(Workflow.id == workflow_run.workflow_id))
         if workflow is None:
             raise WorkflowNotFoundError(
-                "Workflow not found: workflow_run_id=%s, workflow_id=%s", workflow_run.id, workflow_run.workflow_id
+                f"Workflow not found: workflow_run_id={workflow_run.id}, workflow_id={workflow_run.workflow_id}"
             )
         user = _get_user(session, workflow_run)
         app_model = session.scalar(select(App).where(App.id == workflow_run.app_id))
         if app_model is None:
             raise _AppNotFoundError(
-                "App not found: app_id=%s, workflow_run_id=%s", workflow_run.app_id, workflow_run.id
+                f"App not found: app_id={workflow_run.app_id}, workflow_run_id={workflow_run.id}"
             )
 
     workflow_execution_repository = DifyCoreRepositoryFactory.create_workflow_execution_repository(

--- a/api/tasks/async_workflow_tasks.py
+++ b/api/tasks/async_workflow_tasks.py
@@ -242,9 +242,7 @@ def resume_workflow_execution(task_data_dict: dict[str, Any]) -> None:
         user = _get_user(session, workflow_run)
         app_model = session.scalar(select(App).where(App.id == workflow_run.app_id))
         if app_model is None:
-            raise _AppNotFoundError(
-                f"App not found: app_id={workflow_run.app_id}, workflow_run_id={workflow_run.id}"
-            )
+            raise _AppNotFoundError(f"App not found: app_id={workflow_run.app_id}, workflow_run_id={workflow_run.id}")
 
     workflow_execution_repository = DifyCoreRepositoryFactory.create_workflow_execution_repository(
         session_factory=session_factory,


### PR DESCRIPTION
## Problem

`WorkflowNotFoundError` and `_AppNotFoundError` in `resume_workflow_execution` are raised with printf-style `%s` placeholders as separate positional args:

```python
raise WorkflowNotFoundError(
    "Workflow not found: workflow_run_id=%s, workflow_id=%s",
    workflow_run.id,
    workflow_run.workflow_id,
)
```

Since both exception classes are plain `Exception` subclasses with no custom `__init__`, Python stores all args verbatim in `exc.args`. `str(exc)` renders the raw tuple with literal `%s` instead of interpolated IDs, making logs and Sentry events hard to read.

## Fix

Pre-format messages with f-strings before raising:

```python
raise WorkflowNotFoundError(
    f"Workflow not found: workflow_run_id={workflow_run.id}, workflow_id={workflow_run.workflow_id}"
)
```

Fixes #37642