### PR TITLE
fix: guard against None rowcount in workflow deletion methods

### DIFF
--- a/api/repositories/sqlalchemy_api_workflow_node_execution_repository.py
+++ b/api/repositories/sqlalchemy_api_workflow_node_execution_repository.py
@@ -286,7 +286,7 @@ class DifyAPISQLAlchemyWorkflowNodeExecutionRepository(DifyAPIWorkflowNodeExecut
                 delete_stmt = delete(WorkflowNodeExecutionModel).where(WorkflowNodeExecutionModel.id.in_(execution_ids))
                 result = cast(CursorResult, session.execute(delete_stmt))
                 session.commit()
-                total_deleted += result.rowcount
+                total_deleted += result.rowcount or 0
 
                 # If we deleted fewer than the batch size, we're done
                 if len(execution_ids) < batch_size:
@@ -334,7 +334,7 @@ class DifyAPISQLAlchemyWorkflowNodeExecutionRepository(DifyAPIWorkflowNodeExecut
                 delete_stmt = delete(WorkflowNodeExecutionModel).where(WorkflowNodeExecutionModel.id.in_(execution_ids))
                 result = cast(CursorResult, session.execute(delete_stmt))
                 session.commit()
-                total_deleted += result.rowcount
+                total_deleted += result.rowcount or 0
 
                 # If we deleted fewer than the batch size, we're done
                 if len(execution_ids) < batch_size:
@@ -393,7 +393,7 @@ class DifyAPISQLAlchemyWorkflowNodeExecutionRepository(DifyAPIWorkflowNodeExecut
             stmt = delete(WorkflowNodeExecutionModel).where(WorkflowNodeExecutionModel.id.in_(execution_ids))
             result = cast(CursorResult, session.execute(stmt))
             session.commit()
-            return result.rowcount
+            return result.rowcount or 0
 
     @override
     def delete_by_runs(self, session: Session, run_ids: Sequence[str]) -> tuple[int, int]:

--- a/api/repositories/sqlalchemy_api_workflow_run_repository.py
+++ b/api/repositories/sqlalchemy_api_workflow_run_repository.py
@@ -320,7 +320,7 @@ class DifyAPISQLAlchemyWorkflowRunRepository(APIWorkflowRunRepository):
             result = cast(CursorResult, session.execute(stmt))
             session.commit()
 
-            deleted_count = result.rowcount
+            deleted_count = result.rowcount or 0
             logger.info("Deleted %s workflow runs by IDs", deleted_count)
             return deleted_count
 
@@ -357,7 +357,7 @@ class DifyAPISQLAlchemyWorkflowRunRepository(APIWorkflowRunRepository):
                 result = cast(CursorResult, session.execute(delete_stmt))
                 session.commit()
 
-                batch_deleted = result.rowcount
+                batch_deleted = result.rowcount or 0
                 total_deleted += batch_deleted
 
                 logger.info("Deleted batch of %s workflow runs for app %s", batch_deleted, app_id)


### PR DESCRIPTION
## Problem

Five batch-delete workflow methods use `result.rowcount` directly in `+=` or `return` statements. Some DBAPI drivers return `CursorResult.rowcount` as `None` (valid per SQLAlchemy spec), causing:

```
TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'
```

## Affected methods

- `WorkflowNodeExecutionRepository`: `delete_expired_executions`, `delete_executions_by_app`, `delete_executions_by_ids`
- `WorkflowRunRepository`: `delete_runs_by_ids`, `delete_runs_by_app`

## Fix

Apply `result.rowcount or 0` consistently — matching the pattern already used by sibling methods in the same files (e.g. `delete_by_runs`, `delete_by_app_id` in the run repository).

Fixes #37643