### PR TITLE
fix: set app-level cache key to prevent duplicate annotation jobs

### DIFF
--- a/api/services/annotation_service.py
+++ b/api/services/annotation_service.py
@@ -167,6 +167,9 @@ class AppAnnotationService:
 
         # async job
         job_id = str(uuid.uuid4())
+        # Set the app-level cache key so concurrent requests see the in-progress job.
+        # The task deletes this key in its finally block.
+        redis_client.setex(enable_app_annotation_key, 3600, job_id)
         enable_app_annotation_job_key = f"enable_app_annotation_job_{str(job_id)}"
         # send batch add segments task
         redis_client.setnx(enable_app_annotation_job_key, "waiting")
@@ -192,6 +195,9 @@ class AppAnnotationService:
 
         # async job
         job_id = str(uuid.uuid4())
+        # Set the app-level cache key so concurrent requests see the in-progress job.
+        # The task deletes this key in its finally block.
+        redis_client.setex(disable_app_annotation_key, 3600, job_id)
         disable_app_annotation_job_key = f"disable_app_annotation_job_{str(job_id)}"
         # send batch add segments task
         redis_client.setnx(disable_app_annotation_job_key, "waiting")


### PR DESCRIPTION
## Problem

`enable_app_annotation` and `disable_app_annotation` check app-level redis keys (`enable_app_annotation_{app_id}` / `disable_app_annotation_{app_id}`) via `redis_client.get()` but **never set them** on cache miss. This means concurrent requests all see a cache miss and enqueue duplicate Celery tasks.

The task `finally` blocks already delete these keys, confirming the intended lifecycle:

1. Service sets app-level key → indicates "processing"
2. Task runs
3. Task `finally` deletes app-level key

But step 1 was missing.

## Fix

Add `redis_client.setex(enable_app_annotation_key, 3600, job_id)` after the cache-miss check and before enqueuing the task. Same for `disable_app_annotation`. TTL of 3600s provides a safety net if the task fails to clean up.

Fixes #37646