### PR TITLE
fix: skip empty tool entries in legacy dataset config extraction

### DIFF
--- a/api/core/app/app_config/easy_ui_based_app/dataset/manager.py
+++ b/api/core/app/app_config/easy_ui_based_app/dataset/manager.py
@@ -213,6 +213,11 @@ class DatasetConfigManager:
             PlanningStrategy.REACT_ROUTER,
         }:
             for tool in config.get("agent_mode", {}).get("tools", []):
+                if not tool:
+                    # Skip malformed empty tool entries; list(tool.keys())[0]
+                    # would otherwise raise IndexError. The sibling convert()
+                    # already guards this with `if len(tool) == 1`.
+                    continue
                 key = list(tool.keys())[0]
                 if key == "dataset":
                     # old style, use tool name as key

--- a/api/tests/unit_tests/core/app/app_config/easy_ui_based_app/test_dataset_manager.py
+++ b/api/tests/unit_tests/core/app/app_config/easy_ui_based_app/test_dataset_manager.py
@@ -318,3 +318,26 @@ class TestIsDatasetExists:
             return_value=mock_dataset,
         )
         assert not DatasetConfigManager.is_dataset_exists("tenant1", valid_uuid)
+
+
+# ==============================
+# extract_dataset_config_for_legacy_compatibility tests
+# ==============================
+
+
+class TestExtractDatasetConfigForLegacyCompatibility:
+    def test_skips_empty_tool_entry(self):
+        # A malformed empty tool dict in agent_mode.tools must be skipped, not
+        # crash with `IndexError` on `list(tool.keys())[0]`. The sibling
+        # convert() already guards this with `if len(tool) == 1`.
+        config = {
+            "agent_mode": {
+                "enabled": True,
+                "strategy": PlanningStrategy.ROUTER,
+                "tools": [{}],
+            }
+        }
+
+        result = DatasetConfigManager.extract_dataset_config_for_legacy_compatibility("tenant1", AppMode.CHAT, config)
+
+        assert result["agent_mode"]["tools"] == [{}]


### PR DESCRIPTION
### Summary

`DatasetConfigManager.extract_dataset_config_for_legacy_compatibility` iterates `agent_mode.tools` and reads `list(tool.keys())[0]` without checking that the tool dict is non-empty. A malformed empty tool entry (`{}`) therefore raises `IndexError: list index out of range` before any dataset is resolved.

The sibling method `convert()` already guards this exact case with `if len(tool) == 1:`. This change skips empty tool entries in the legacy-compatibility path the same way, so a stray `{}` is ignored instead of crashing.

```python
config = {"agent_mode": {"enabled": True, "strategy": PlanningStrategy.ROUTER, "tools": [{}]}}
DatasetConfigManager.extract_dataset_config_for_legacy_compatibility("t", AppMode.CHAT, config)
# before: IndexError: list index out of range
# after:  the empty entry is skipped, config returned unchanged
```

### Testing

Added `TestExtractDatasetConfigForLegacyCompatibility::test_skips_empty_tool_entry` (the method previously had no direct coverage for this path). I confirmed the `IndexError` and the fix with a standalone repro of the slicing logic; the full unit test runs under CI, since the backend test environment isn't fully installable on my machine.

From Claude Code
