### PR TITLE
fix(web): include tracing provider in toggle payload

### DIFF
--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/__tests__/panel-provider-resolution.spec.ts
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/__tests__/panel-provider-resolution.spec.ts
@@ -1,0 +1,51 @@
+import type { ConfiguredTracingProviders } from '../provider-resolution'
+import { getConfiguredTracingProvider, resolveTracingProvider } from '../provider-resolution'
+import { TracingProvider } from '../type'
+
+const baseConfigs: ConfiguredTracingProviders = {
+  langFuseConfig: null,
+  langSmithConfig: null,
+  opikConfig: null,
+  weaveConfig: null,
+  arizeConfig: null,
+  phoenixConfig: null,
+  aliyunConfig: null,
+  mlflowConfig: null,
+  databricksConfig: null,
+  tencentConfig: null,
+}
+
+describe('tracing provider resolution', () => {
+  it('returns null when no tracing provider config exists', () => {
+    expect(getConfiguredTracingProvider(baseConfigs)).toBeNull()
+  })
+
+  it('falls back to configured provider when tracing status provider is null', () => {
+    const configs: ConfiguredTracingProviders = {
+      ...baseConfigs,
+      langFuseConfig: { host: 'https://cloud.langfuse.com' } as ConfiguredTracingProviders['langFuseConfig'],
+    }
+
+    expect(resolveTracingProvider({ enabled: false, tracing_provider: null }, configs)).toBe(TracingProvider.langfuse)
+  })
+
+  it('keeps the tracing status provider when present', () => {
+    const configs: ConfiguredTracingProviders = {
+      ...baseConfigs,
+      langFuseConfig: { host: 'https://cloud.langfuse.com' } as ConfiguredTracingProviders['langFuseConfig'],
+      langSmithConfig: { endpoint: 'https://api.smith.langchain.com' } as ConfiguredTracingProviders['langSmithConfig'],
+    }
+
+    expect(resolveTracingProvider({ enabled: false, tracing_provider: TracingProvider.langSmith }, configs)).toBe(TracingProvider.langSmith)
+  })
+
+  it('uses the configured provider priority order when multiple are set', () => {
+    const configs: ConfiguredTracingProviders = {
+      ...baseConfigs,
+      opikConfig: { project: 'opik-project' } as ConfiguredTracingProviders['opikConfig'],
+      langSmithConfig: { project: 'langsmith-project' } as ConfiguredTracingProviders['langSmithConfig'],
+    }
+
+    expect(getConfiguredTracingProvider(configs)).toBe(TracingProvider.langSmith)
+  })
+})

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/panel.tsx
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/panel.tsx
@@ -29,6 +29,7 @@ import { usePathname } from '@/next/navigation'
 import { fetchTracingConfig as doFetchTracingConfig, fetchTracingStatus, updateTracingStatus } from '@/service/apps'
 import { getAppACLCapabilities } from '@/utils/permission'
 import ConfigButton from './config-button'
+import { resolveTracingProvider } from './provider-resolution'
 import TracingIcon from './tracing-icon'
 import { TracingProvider } from './type'
 
@@ -64,12 +65,6 @@ const Panel: FC = () => {
     }
   }
 
-  const handleTracingEnabledChange = (enabled: boolean) => {
-    handleTracingStatusChange({
-      tracing_provider: tracingStatus?.tracing_provider || null,
-      enabled,
-    })
-  }
   const handleChooseProvider = (provider: TracingProvider) => {
     handleTracingStatusChange({
       tracing_provider: provider,
@@ -103,6 +98,26 @@ const Panel: FC = () => {
   const [databricksConfig, setDatabricksConfig] = useState<DatabricksConfig | null>(null)
   const [tencentConfig, setTencentConfig] = useState<TencentConfig | null>(null)
   const hasConfiguredTracing = !!(langSmithConfig || langFuseConfig || opikConfig || weaveConfig || arizeConfig || phoenixConfig || aliyunConfig || mlflowConfig || databricksConfig || tencentConfig)
+
+  const handleTracingEnabledChange = (enabled: boolean) => {
+    const tracingProvider = resolveTracingProvider(tracingStatus, {
+      langFuseConfig,
+      langSmithConfig,
+      opikConfig,
+      weaveConfig,
+      arizeConfig,
+      phoenixConfig,
+      aliyunConfig,
+      mlflowConfig,
+      databricksConfig,
+      tencentConfig,
+    })
+
+    handleTracingStatusChange({
+      tracing_provider: tracingProvider,
+      enabled,
+    })
+  }
 
   const fetchTracingConfig = async () => {
     const getArizeConfig = async () => {

--- a/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/provider-resolution.ts
+++ b/web/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/provider-resolution.ts
@@ -1,0 +1,52 @@
+import type {
+  AliyunConfig,
+  ArizeConfig,
+  DatabricksConfig,
+  LangFuseConfig,
+  LangSmithConfig,
+  MLflowConfig,
+  OpikConfig,
+  PhoenixConfig,
+  TencentConfig,
+  TracingProvider,
+  WeaveConfig,
+} from './type'
+import type { TracingStatus } from '@/models/app'
+
+export type ConfiguredTracingProviders = {
+  langFuseConfig: LangFuseConfig | null
+  langSmithConfig: LangSmithConfig | null
+  opikConfig: OpikConfig | null
+  weaveConfig: WeaveConfig | null
+  arizeConfig: ArizeConfig | null
+  phoenixConfig: PhoenixConfig | null
+  aliyunConfig: AliyunConfig | null
+  mlflowConfig: MLflowConfig | null
+  databricksConfig: DatabricksConfig | null
+  tencentConfig: TencentConfig | null
+}
+
+const configuredProviderOrder: Array<[TracingProvider, keyof ConfiguredTracingProviders]> = [
+  ['langfuse', 'langFuseConfig'],
+  ['langsmith', 'langSmithConfig'],
+  ['opik', 'opikConfig'],
+  ['weave', 'weaveConfig'],
+  ['arize', 'arizeConfig'],
+  ['phoenix', 'phoenixConfig'],
+  ['aliyun', 'aliyunConfig'],
+  ['mlflow', 'mlflowConfig'],
+  ['databricks', 'databricksConfig'],
+  ['tencent', 'tencentConfig'],
+]
+
+export const getConfiguredTracingProvider = (configs: ConfiguredTracingProviders): TracingProvider | null => {
+  for (const [provider, configKey] of configuredProviderOrder) {
+    if (configs[configKey])
+      return provider
+  }
+  return null
+}
+
+export const resolveTracingProvider = (tracingStatus: TracingStatus | null, configs: ConfiguredTracingProviders): TracingProvider | null => {
+  return tracingStatus?.tracing_provider ?? getConfiguredTracingProvider(configs)
+}


### PR DESCRIPTION
## Summary
- Fix tracing toggle updates to include a provider when the saved app tracing status has `tracing_provider = null` but provider configs already exist.
- Extract provider resolution into a dedicated helper to keep `panel.tsx` focused on UI behavior and avoid component export lint violations.
- Add regression tests for fallback, explicit provider preservation, and provider-priority resolution.

Fixes #37174

## Test plan
- [x] `pnpm test "app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/__tests__/panel-provider-resolution.spec.ts"`
- [x] `pnpm eslint --fix --pass-on-unpruned-suppressions "app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/panel.tsx" "app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/provider-resolution.ts" "app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/tracing/__tests__/panel-provider-resolution.spec.ts"`
