### PR TITLE
fix(dify-agent): make TextPromptMessageContent JSON serializable

### DIFF
--- a/dify-agent/src/dify_agent/plugin_daemon_transport.py
+++ b/dify-agent/src/dify_agent/plugin_daemon_transport.py
@@ -11,6 +11,7 @@ import json
 from typing import TypedDict
 
 from pydantic import BaseModel
+from graphon.model_runtime.entities.message_entities import TextPromptMessageContent
 
 
 class PluginDaemonErrorPayload(TypedDict):
@@ -24,6 +25,8 @@ def to_plugin_daemon_jsonable(value: object) -> object:
     """Convert nested request data into JSON-safe daemon payload values."""
     if isinstance(value, BaseModel):
         return value.model_dump(mode="json")
+    if isinstance(value, TextPromptMessageContent):
+        return value.data
     if isinstance(value, dict):
         return {key: to_plugin_daemon_jsonable(item) for key, item in value.items()}
     if isinstance(value, list | tuple):


### PR DESCRIPTION
## Summary
Fixes #37628: `dify-agent` fails when invoking `CurrentTime` tool because `TextPromptMessageContent` is not JSON serializable.

## Root Cause
The `to_plugin_daemon_jsonable` function in `dify-agent/src/dify_agent/plugin_daemon_transport.py` lacked specific handling for `TextPromptMessageContent` objects, causing them to fail during JSON serialization when the CurrentTime tool was invoked.

## Fix
Added explicit serialization handling for `TextPromptMessageContent` by extracting its `data` attribute before JSON encoding.

## Testing
- The CurrentTime tool should now return serializable JSON when invoked by `dify-agent`
- No breaking changes to existing serialization paths
