### PR TITLE
fix(workflow): handle CursorResult.rowcount=None in deletion methods

### DIFF
--- a/api/repositories/sqlalchemy_api_workflow_node_execution_repository.py
+++ b/api/repositories/sqlalchemy_api_workflow_node_execution_repository.py
@@ -286,7 +286,7 @@ class DifyAPISQLAlchemyWorkflowNodeExecutionRepository(DifyAPIWorkflowNodeExecut
                 delete_stmt = delete(WorkflowNodeExecutionModel).where(WorkflowNodeExecutionModel.id.in_(execution_ids))
                 result = cast(CursorResult, session.execute(delete_stmt))
                 session.commit()
-                total_deleted += result.rowcount
+                total_deleted += (result.rowcount or 0)
 
                 # If we deleted fewer than the batch size, we're done
                 if len(execution_ids) < batch_size:
@@ -334,7 +334,7 @@ class DifyAPISQLAlchemyWorkflowNodeExecutionRepository(DifyAPIWorkflowNodeExecut
                 delete_stmt = delete(WorkflowNodeExecutionModel).where(WorkflowNodeExecutionModel.id.in_(execution_ids))
                 result = cast(CursorResult, session.execute(delete_stmt))
                 session.commit()
-                total_deleted += result.rowcount
+                total_deleted += (result.rowcount or 0)
 
                 # If we deleted fewer than the batch size, we're done
                 if len(execution_ids) < batch_size:
@@ -393,7 +393,7 @@ class DifyAPISQLAlchemyWorkflowNodeExecutionRepository(DifyAPIWorkflowNodeExecut
             stmt = delete(WorkflowNodeExecutionModel).where(WorkflowNodeExecutionModel.id.in_(execution_ids))
             result = cast(CursorResult, session.execute(stmt))
             session.commit()
-            return result.rowcount
+            return result.rowcount or 0
 
     @override
     def delete_by_runs(self, session: Session, run_ids: Sequence[str]) -> tuple[int, int]:

--- a/api/repositories/sqlalchemy_api_workflow_node_execution_repository.py
+++ b/api/repositories/sqlalchemy_api_workflow_node_execution_repository.py
@@ -286,7 +286,7 @@ class DifyAPISQLAlchemyWorkflowNodeExecutionRepository(DifyAPIWorkflowNodeExecut
                 delete_stmt = delete(WorkflowNodeExecutionModel).where(WorkflowNodeExecutionModel.id.in_(execution_ids))
                 result = cast(CursorResult, session.execute(delete_stmt))
                 session.commit()
-                total_deleted += (result.rowcount or 0)
+                total_deleted += result.rowcount or 0
 
                 # If we deleted fewer than the batch size, we're done
                 if len(execution_ids) < batch_size:
@@ -334,7 +334,7 @@ class DifyAPISQLAlchemyWorkflowNodeExecutionRepository(DifyAPIWorkflowNodeExecut
                 delete_stmt = delete(WorkflowNodeExecutionModel).where(WorkflowNodeExecutionModel.id.in_(execution_ids))
                 result = cast(CursorResult, session.execute(delete_stmt))
                 session.commit()
-                total_deleted += (result.rowcount or 0)
+                total_deleted += result.rowcount or 0
 
                 # If we deleted fewer than the batch size, we're done
                 if len(execution_ids) < batch_size:

--- a/api/repositories/sqlalchemy_api_workflow_run_repository.py
+++ b/api/repositories/sqlalchemy_api_workflow_run_repository.py
@@ -320,7 +320,7 @@ class DifyAPISQLAlchemyWorkflowRunRepository(APIWorkflowRunRepository):
             result = cast(CursorResult, session.execute(stmt))
             session.commit()
 
-            deleted_count = result.rowcount
+            deleted_count = result.rowcount or 0
             logger.info("Deleted %s workflow runs by IDs", deleted_count)
             return deleted_count
 
@@ -357,7 +357,7 @@ class DifyAPISQLAlchemyWorkflowRunRepository(APIWorkflowRunRepository):
                 result = cast(CursorResult, session.execute(delete_stmt))
                 session.commit()
 
-                batch_deleted = result.rowcount
+                batch_deleted = result.rowcount or 0
                 total_deleted += batch_deleted
 
                 logger.info("Deleted batch of %s workflow runs for app %s", batch_deleted, app_id)


### PR DESCRIPTION
## Summary
Fixes #37643: Five workflow deletion methods crash with `TypeError` when `CursorResult.rowcount` is `None`.

## Root Cause
SQLAlchemy's `CursorResult.rowcount` can return `None` for certain database drivers and operations. The workflow deletion methods did not guard against `None`, causing `TypeError` when arithmetic was attempted on the result. Some methods in the codebase already used the defensive `result.rowcount or 0` pattern, but these five locations did not.

## Fix
Added `or 0` to all five `result.rowcount` accesses across:
- `api/repositories/sqlalchemy_api_workflow_node_execution_repository.py` (4 locations)
- `api/repositories/sqlalchemy_api_workflow_run_repository.py` (2 locations)

## Testing
- Workflow deletion no longer crashes with `TypeError` when the driver returns `None` for rowcount
- No change to behavior when rowcount is a valid integer
