### PR TITLE
test(dify-agent): patch function result key cache

### DIFF
--- a/dify-agent/tests/local/dify_agent/client/test_client.py
+++ b/dify-agent/tests/local/dify_agent/client/test_client.py
@@ -137,7 +137,7 @@ class DisconnectingSyncStream(httpx.SyncByteStream):
 
 
 def test_sse_decoder_accepts_function_tool_result_part_alias(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(client_module, "_FUNCTION_TOOL_RESULT_PAYLOAD_KEY", "result")
+    monkeypatch.setattr(client_module, "_function_tool_result_payload_key_cache", "result")
     decoder = client_module._SSEDecoder()
     payload = _function_tool_result_payload("part")
 
@@ -153,7 +153,7 @@ def test_sse_decoder_accepts_function_tool_result_part_alias(monkeypatch: pytest
 def test_function_tool_result_payload_normalization_supports_old_part_schema(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(client_module, "_FUNCTION_TOOL_RESULT_PAYLOAD_KEY", "part")
+    monkeypatch.setattr(client_module, "_function_tool_result_payload_key_cache", "part")
     payload = _function_tool_result_payload("result")
 
     normalized = client_module._normalize_run_event_payload_for_local_pydantic_ai(payload)


### PR DESCRIPTION
## Summary

- update two `dify-agent` client compatibility tests to patch the lazy result-key cache
- restore coverage for both the legacy `part` field and the current `result` field

## Root cause

PR #37593 replaced `_FUNCTION_TOOL_RESULT_PAYLOAD_KEY` with `_function_tool_result_payload_key_cache`, but the two tests that force each schema variant continued patching the removed attribute. They therefore failed with `AttributeError` before exercising the normalization behavior.

This change only updates the test injection points. Production behavior is unchanged.

## Impact

The complete local `dify-agent` test suite passes again, and the compatibility behavior remains explicitly tested for both supported Pydantic AI event shapes.

## Verification

- `uv run --extra server --group dev python -m pytest tests/local -q` (`505 passed, 2 skipped`)
- `uv run --extra server --group dev python -m ruff check .`
- `uv run --extra server --extra grpc --group dev basedpyright --level error src examples tests` (`0 errors`)

Fixes #37699
