### PR TITLE
fix(web): render user chat input as plain text

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1324,11 +1324,6 @@
       "count": 1
     }
   },
-  "web/app/components/base/chat/chat/question.tsx": {
-    "jsx-a11y/no-autofocus": {
-      "count": 1
-    }
-  },
   "web/app/components/base/chat/chat/type.ts": {
     "ts/no-explicit-any": {
       "count": 5

--- a/web/app/components/base/chat/chat/__tests__/question.spec.tsx
+++ b/web/app/components/base/chat/chat/__tests__/question.spec.tsx
@@ -48,9 +48,6 @@ vi.mock('../content-switch', () => ({
   },
 }))
 vi.mock('copy-to-clipboard', () => ({ default: vi.fn() }))
-vi.mock('@/app/components/base/markdown', () => ({
-  Markdown: ({ content }: { content: string }) => <div className="markdown-body">{content}</div>,
-}))
 
 // Mock ResizeObserver and capture lifecycle for targeted coverage
 const observeMock = vi.fn()
@@ -132,11 +129,23 @@ describe('Question component', () => {
   it('should render the question content container and default avatar when hideAvatar is false', () => {
     const { container } = renderWithProvider(makeItem())
 
-    const markdown = container.querySelector('.markdown-body')
-    expect(markdown).toBeInTheDocument()
+    expect(screen.getByTestId('question-content')).toHaveTextContent('This is the question content')
 
     const avatar = container.querySelector('.size-10') || container.querySelector('.size-10.shrink-0')
     expect(avatar).toBeTruthy()
+  })
+
+  it('should render HTML-like user input as plain text', async () => {
+    const user = userEvent.setup()
+    const htmlInput = '<button class="primary-button">Confirm</button>'
+    renderWithProvider(makeItem({ content: htmlInput }))
+
+    const questionContent = screen.getByTestId('question-content')
+    expect(questionContent).toHaveTextContent(htmlInput)
+    expect(screen.queryByRole('button', { name: 'Confirm' })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'common.operation.copy' }))
+    expect(copy).toHaveBeenCalledWith(htmlInput)
   })
 
   it('should hide avatar when hideAvatar is true', () => {
@@ -223,9 +232,9 @@ describe('Question component', () => {
     })
   })
 
-  it('should cancel editing and revert to original markdown when cancel is clicked', async () => {
+  it('should cancel editing and revert to original content when cancel is clicked', async () => {
     const user = userEvent.setup()
-    const { container } = renderWithProvider(makeItem())
+    renderWithProvider(makeItem())
 
     const editBtn = screen.getByRole('button', { name: 'common.operation.edit' })
     await user.click(editBtn)
@@ -239,8 +248,7 @@ describe('Question component', () => {
 
     await waitFor(() => {
       expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
-      const md = container.querySelector('.markdown-body')
-      expect(md).toBeInTheDocument()
+      expect(screen.getByTestId('question-content')).toHaveTextContent('This is the question content')
     })
   })
 

--- a/web/app/components/base/chat/chat/question.tsx
+++ b/web/app/components/base/chat/chat/question.tsx
@@ -19,7 +19,6 @@ import { useTranslation } from 'react-i18next'
 import Textarea from 'react-textarea-autosize'
 import { FileList } from '@/app/components/base/file-uploader'
 import { User } from '@/app/components/base/icons/src/public/avatar'
-import { Markdown } from '@/app/components/base/markdown'
 import ActionButton from '../../action-button'
 import { CssTransform } from '../embedded-chatbot/theme/utils'
 import ContentSwitch from './content-switch'
@@ -206,7 +205,7 @@ const Question: FC<QuestionProps> = ({
             )
           }
           {!isEditing
-            ? <Markdown content={content} />
+            ? <div className="body-md-regular break-words whitespace-pre-wrap">{content}</div>
             : (
                 <div className="flex flex-col gap-4">
                   <div className="max-h-[158px] overflow-x-hidden overflow-y-auto pr-1">
@@ -214,6 +213,7 @@ const Question: FC<QuestionProps> = ({
                       className={cn(
                         'w-full resize-none bg-transparent p-0 body-lg-regular leading-7 text-text-primary outline-hidden',
                       )}
+                      // eslint-disable-next-line jsx-a11y/no-autofocus -- Edit mode opens from an explicit user action.
                       autoFocus
                       minRows={1}
                       value={editedContent}


### PR DESCRIPTION
## Summary
- Render user question bubble content as plain text instead of sending it through the shared Markdown renderer.
- Keep assistant answers and other rich Markdown paths unchanged.
- Add a regression test for HTML-like user input such as `<button class="primary-button">Confirm</button>`.

Fixes #37414

## Test plan
- [x] `pnpm test "app/components/base/chat/chat/__tests__/question.spec.tsx"`
- [x] `pnpm eslint --fix --pass-on-unpruned-suppressions "app/components/base/chat/chat/question.tsx" "app/components/base/chat/chat/__tests__/question.spec.tsx"`
