### PR TITLE
fix(cli): align run app --conversation mode list with runtime gate

### DIFF
--- a/cli/src/commands/run/app/_strategies/streaming-structured.ts
+++ b/cli/src/commands/run/app/_strategies/streaming-structured.ts
@@ -1,7 +1,7 @@
 import type { RunContext, RunStrategy } from './index'
 import type { SseEvent } from '@/http/sse'
 import { buildRunBody } from '@/api/app-run'
-import { chatConversationHint, newAppRunObject, RUN_MODES } from '@/commands/run/app/handlers'
+import { CHAT_MODES, chatConversationHint, newAppRunObject } from '@/commands/run/app/handlers'
 import { renderHitlHint, renderHitlOutput } from '@/commands/run/app/hitl-render'
 import { collect, HitlPauseError } from '@/commands/run/app/sse-collector'
 import { formatted, stringifyOutput } from '@/framework/output'
@@ -9,8 +9,6 @@ import { handle, unhandle } from '@/sys/index'
 import { colorEnabled, colorScheme } from '@/sys/io/color'
 import { startSpinner } from '@/sys/io/spinner'
 import { extractThinkBlocks, stripThinkBlocks } from '@/sys/io/think-filter'
-
-const CHAT_MODES: ReadonlySet<string> = new Set([RUN_MODES.Chat, RUN_MODES.AgentChat, RUN_MODES.AdvancedChat])
 
 async function* captureTaskId(
   iter: AsyncIterable<SseEvent>,

--- a/cli/src/commands/run/app/guide.ts
+++ b/cli/src/commands/run/app/guide.ts
@@ -9,12 +9,12 @@ WORKFLOW
        difyctl run app <id> --inputs '{"key":"value"}' -o json
 
 APP MODES
-  chat / advanced-chat   Conversational. Accepts --conversation <id> to
-                         resume an existing thread.
+  chat / agent-chat /    Conversational. Accept --conversation <id> to
+  advanced-chat          resume an existing thread. agent-chat adds
+                         autonomous tool use.
   completion             Single-turn. Ignores --conversation.
   workflow               Multi-step graph. Pass all input variables as a
                          JSON object via --inputs.
-  agent-chat             Conversational with autonomous tool use.
 
 HITL PAUSE (exit code 2)
   When a workflow pauses for human input, stdout receives a JSON object

--- a/cli/src/commands/run/app/handlers.ts
+++ b/cli/src/commands/run/app/handlers.ts
@@ -11,6 +11,12 @@ export const RUN_MODES = {
 
 export type RunMode = typeof RUN_MODES[keyof typeof RUN_MODES]
 
+export const CHAT_MODES: ReadonlySet<string> = new Set<RunMode>([
+  RUN_MODES.Chat,
+  RUN_MODES.AgentChat,
+  RUN_MODES.AdvancedChat,
+])
+
 export type AppRunObject = FormattedPrintable
 
 export function newAppRunObject(mode: string, resp: Record<string, unknown>): AppRunObject {

--- a/cli/src/commands/run/app/index.ts
+++ b/cli/src/commands/run/app/index.ts
@@ -4,6 +4,7 @@ import { httpRetryFlag } from '@/commands/_shared/global-flags'
 import { Args, Flags } from '@/framework/flags'
 import { OutputFormat } from '@/framework/output'
 import { agentGuide } from './guide'
+import { CHAT_MODES } from './handlers'
 import { runApp } from './run'
 
 export default class RunApp extends DifyCommand {
@@ -30,7 +31,7 @@ export default class RunApp extends DifyCommand {
     'inputs': Flags.string({ description: 'Input variables as a JSON object, e.g. --inputs \'{"key":"value"}\'. Mutually exclusive with --inputs-file.' }),
     'inputs-file': Flags.string({ description: 'Path to a JSON file containing the inputs object. Mutually exclusive with --inputs.' }),
     'file': Flags.stringArray({ description: 'Named file input: --file key=@path for a local file or --file key=https://url for a remote URL. Repeatable.', default: [] }),
-    'conversation': Flags.string({ description: 'Resume a chat conversation by id (chat/advanced-chat only)' }),
+    'conversation': Flags.string({ description: `Resume a chat conversation by id (${[...CHAT_MODES].join('/')} only)` }),
     'workflow-id': Flags.string({ description: 'Pin to a specific published workflow version' }),
     'workspace': Flags.string({ description: 'Workspace id (overrides DIFY_WORKSPACE_ID and stored default)' }),
     'stream': Flags.boolean({ description: 'Print output live as tokens/events arrive (default: collect and print at end)', default: false }),


### PR DESCRIPTION
## Summary

The `run app` `--conversation` flag description listed `chat/advanced-chat only`, excluding **agent-chat**. But agent-chat is conversational — it returns a `conversation_id` and the CLI's continue-hint already fires for it (`CHAT_MODES` includes agent-chat). The help text had drifted from the actual runtime gate, so an agent running an agent-chat app was told to use `--conversation` yet `--help` said it was unsupported.

Root cause: the conversational-mode set was restated in multiple unlinked places (the runtime gate `CHAT_MODES`, the flag description string, and the agent guide), free to drift.

Changes:
- Lift `CHAT_MODES` into `handlers.ts` as a single source of truth (values reference `RUN_MODES`, so renames propagate via the type checker).
- `streaming-structured.ts` imports the shared set instead of redefining it.
- Derive the `--conversation` description from `CHAT_MODES` so the help text cannot diverge from the gate again.
- Correct the agent guide's `APP MODES` block to group agent-chat with the other conversational modes.

No behavior change — the runtime gate was already correct; this aligns the documentation/help with it and removes the drift vector.

Closes WTA-954

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced — no new test added; this is a help-text + refactor change with no behavior change, covered by the existing `run/app` suite (90 tests green).
- [ ] I've updated the documentation accordingly.
- [x] CLI-only change: ran the CLI gate in `cli/` — `pnpm type-check` (clean) and `pnpm test src/commands/run/app` (90 passed). Backend `make` / web `vp` gates are not applicable.

From Claude Code