### PR TITLE
fix(api): use CREATE INDEX CONCURRENTLY for agent_tenant_invitable_idx

### DIFF
--- a/api/migrations/versions/2026_06_12_1600-9f4b7c2d1a80_add_agent_active_config_has_model.py
+++ b/api/migrations/versions/2026_06_12_1600-9f4b7c2d1a80_add_agent_active_config_has_model.py
@@ -16,6 +16,10 @@ branch_labels = None
 depends_on = None
 
 
+def _is_pg(conn) -> bool:
+    return conn.dialect.name == "postgresql"
+
+
 def upgrade():
     with op.batch_alter_table("agents", schema=None) as batch_op:
         batch_op.add_column(
@@ -27,14 +31,37 @@ def upgrade():
             )
         )
 
-    op.create_index(
-        "agent_tenant_invitable_idx",
-        "agents",
-        ["tenant_id", "scope", "status", "active_config_has_model", "updated_at"],
-    )
+    # `CREATE INDEX CONCURRENTLY` cannot run within a transaction; wrap it in
+    # `autocommit_block` on PostgreSQL so the composite index is built without
+    # blocking concurrent INSERT/UPDATE/DELETE on the hot `agents` table.
+    # The `agents` table is written to on every Agent v2 chat turn, so a SHARE
+    # lock here would stall the entire Agent v2 surface area for the full
+    # index-build duration. See migration 4474872b0ee6 for the established
+    # pattern in this codebase.
+    conn = op.get_bind()
+    if _is_pg(conn):
+        with op.get_context().autocommit_block():
+            op.create_index(
+                "agent_tenant_invitable_idx",
+                "agents",
+                ["tenant_id", "scope", "status", "active_config_has_model", "updated_at"],
+                postgresql_concurrently=True,
+            )
+    else:
+        op.create_index(
+            "agent_tenant_invitable_idx",
+            "agents",
+            ["tenant_id", "scope", "status", "active_config_has_model", "updated_at"],
+        )
 
 
 def downgrade():
-    op.drop_index("agent_tenant_invitable_idx", table_name="agents")
+    conn = op.get_bind()
+    if _is_pg(conn):
+        with op.get_context().autocommit_block():
+            op.drop_index("agent_tenant_invitable_idx", postgresql_concurrently=True)
+    else:
+        op.drop_index("agent_tenant_invitable_idx", table_name="agents")
+
     with op.batch_alter_table("agents", schema=None) as batch_op:
         batch_op.drop_column("active_config_has_model")


### PR DESCRIPTION
## Summary

Wrap the composite index creation in migration `9f4b7c2d1a80` with `autocommit_block` + `postgresql_concurrently=True` on PostgreSQL, and add the matching `CONCURRENTLY` drop in `downgrade`.

Without this, `op.create_index(...)` takes a `SHARE` lock on the hot `agents` table for the full index-build duration. The table is written to on every Agent v2 chat turn, so the lock stalls the entire Agent v2 surface area while the migration is in flight.

Mirrors the established pattern in migrations `4474872b0ee6` and `6b5f9f8b1a2c`.

## Changes

- `api/migrations/versions/2026_06_12_1600-9f4b7c2d1a80_add_agent_active_config_has_model.py`
  - Add `_is_pg(conn)` helper.
  - `upgrade`: wrap `op.create_index("agent_tenant_invitable_idx", ...)` in `op.get_context().autocommit_block()` with `postgresql_concurrently=True` on PG; MySQL keeps the plain `op.create_index(...)` fallback.
  - `downgrade`: same pattern for `op.drop_index(...)`.

## Test plan

- [x] 1 file changed, 33 insertions(+), 6 deletions(-)
- [x] Python syntax OK
- [x] Follows the existing pattern in `4474872b0ee6` and `6b5f9f8b1a2c`
- [x] MySQL fallback preserved (no `postgresql_concurrently` kwarg there)

Fixes #37708