### PR TITLE
fix(cli): document HITL pause exit code as 0, not 2

### DIFF
--- a/cli/src/commands/resume/app/guide.ts
+++ b/cli/src/commands/resume/app/guide.ts
@@ -1,14 +1,15 @@
 export const agentGuide = `
 WHEN TO USE
   Continue a workflow that paused for human input. run app (or a prior
-  resume app) exits 2 and prints a JSON object with status "paused",
+  resume app) exits 0 and prints a JSON object with status "paused",
   form_token, workflow_run_id and resolved_default_values. Resume with:
     difyctl resume app <app_id> <form_token> --workflow-run-id <id> \\
       --inputs '{"name":"Alice"}' -o json
 
 LOOP
-  A resume can pause again (exit 2 with a new form_token). Repeat until
-  exit 0. Pass --stream to print events live.
+  A resume can pause again (exit 0 with a new form_token and status
+  "paused"). Repeat until the output is no longer a pause. Pass --stream
+  to print events live.
 
 ERROR RECOVERY
   not logged in (exit 4)    difyctl auth login

--- a/cli/src/commands/run/app/guide.ts
+++ b/cli/src/commands/run/app/guide.ts
@@ -16,7 +16,7 @@ APP MODES
                          JSON object via --inputs.
   agent-chat             Conversational with autonomous tool use.
 
-HITL PAUSE (exit code 2)
+HITL PAUSE (exit code 0 — success-with-pending)
   When a workflow pauses for human input, stdout receives a JSON object
   with status "paused", form_token, workflow_run_id, and resolved_default_values.
   Resume with:

--- a/cli/src/help/contract.ts
+++ b/cli/src/help/contract.ts
@@ -14,9 +14,9 @@ export type Contract = {
 }
 
 const EXIT_CODE_DESCRIPTIONS: Readonly<Record<number, string>> = {
-  [ExitCode.Success]: 'success',
+  [ExitCode.Success]: 'success (also a workflow paused for human input — check stdout for status "paused")',
   [ExitCode.Generic]: 'generic error',
-  [ExitCode.Usage]: 'usage error (bad flag / missing arg), or a workflow paused for human input',
+  [ExitCode.Usage]: 'usage error (bad flag / missing arg)',
   [ExitCode.Auth]: 'auth error (not logged in / token expired)',
   [ExitCode.VersionCompat]: 'version / compatibility error',
 }
@@ -42,7 +42,7 @@ export const CONTRACT: Contract = {
   },
   hitl: {
     description:
-      'When a workflow pauses for human input, `run app` exits 2 and writes a JSON object to stdout with status "paused", form_token, workflow_run_id and resolved_default_values.',
+      'When a workflow pauses for human input, `run app` exits 0 (success-with-pending) and writes a JSON object to stdout with status "paused", form_token, workflow_run_id and resolved_default_values.',
     resume:
       'difyctl resume app <app_id> <form_token> --workflow-run-id <id> [--inputs \'{"key":"value"}\']',
   },

--- a/cli/src/help/skill-template.ts
+++ b/cli/src/help/skill-template.ts
@@ -26,7 +26,7 @@ output formats, error envelope, HITL protocol). Treat that JSON as the
 source of truth; this file only bootstraps you into it.
 
 ## The one non-obvious thing: HITL pauses are not failures
-A run can pause for human input. It exits with **code 2** and emits a
+A run can pause for human input. It exits with **code 0** and emits a
 \`paused\` JSON payload — this is success-with-pending, NOT a crash.
 Resume as the payload instructs (see \`difyctl resume app --help\`).
 


### PR DESCRIPTION
## Summary

A workflow that pauses for human input exits **0**, but every agent-facing self-description said **exit 2**.

- Runtime: `streaming-structured.ts:69` and `streaming-text.ts:54` call `exit(0)` on `HitlPauseError`; `test/e2e/suites/run/run-app-hitl.e2e.ts` asserts exit 0 throughout.
- Docs (said 2): `help/contract.ts` (`exitCodes[2]` description + `hitl.description`), `run/app/guide.ts`, `resume/app/guide.ts`, and the installed SKILL.md source `help/skill-template.ts`.

Exit code 2 means "usage error (bad flag / missing arg)". Documenting a legitimate pause as 2 conflated it with bad arguments — an agent onboarding from the docs (installing the skill, reading `help -o json`) would either miss the pause (treat it as plain success) or mistake it for a usage error.

This aligns all five doc spots with the runtime: a pause is **exit 0 (success-with-pending)**; agents detect it via the stdout `status:"paused"` payload, not the exit code.

Changes:
- `contract.ts` — move the pause note from `exitCodes[2]` to `exitCodes[0]`; `hitl.description` now says exits 0.
- `run/app/guide.ts` — `HITL PAUSE` header → exit code 0.
- `resume/app/guide.ts` — exits 0; the loop now repeats "until the output is no longer a pause" instead of "until exit 0" (which was meaningless once pause is 0).
- `skill-template.ts` — SKILL.md says code 0.

Runtime and e2e are unchanged — they were already correct. Considered but rejected: making the runtime exit 2 (would formalize the pause-as-usage-error harm) and adding a dedicated pause exit code (breaks the frozen 0/1/2/4/6/7 taxonomy; needs contract-owner sign-off).

Closes WTA-955

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change — no new test; these are help-text strings already exercised by the existing help/guide/skill suites (133 tests green), and the runtime exit-0 behavior is already pinned by `run-app-hitl.e2e.ts`.
- [ ] I've updated the documentation accordingly.
- [x] CLI-only change: ran the CLI gate in `cli/` — `pnpm type-check` (clean) and `pnpm test` over `src/help src/commands/run/app src/commands/resume/app src/commands/skills` (133 passed). Backend `make` / web `vp` gates are not applicable.

From Claude Code