### PR TITLE
fix(cli): make auth devices revoke --yes a real flag

### DIFF
--- a/cli/src/commands/auth/devices/_shared/devices.test.ts
+++ b/cli/src/commands/auth/devices/_shared/devices.test.ts
@@ -146,6 +146,43 @@ describe('runDevicesRevoke', () => {
     expect(saved?.hosts[mock.url]).toBeUndefined()
   })
 
+  it('TTY without --yes: prompts and aborts on decline (no revoke)', async () => {
+    const base = bufferStreams('n\n')
+    const io = { ...base, isErrTTY: true }
+    const store = new MemStore()
+    const { reg, active } = buildRegistry(mock.url, 'tester@dify.ai', 'tok-1')
+    const http = testHttpClient(mock.url, 'dfoa_test')
+
+    await expect(runDevicesRevoke({ io, reg, active, store, http, all: true }))
+      .rejects
+      .toThrow(/aborted by user/)
+    expect(base.errBuf()).toContain('Revoke 2 session(s)? [y/N]')
+    expect(base.outBuf()).not.toContain('Revoked')
+  })
+
+  it('TTY without --yes: proceeds on accept', async () => {
+    const base = bufferStreams('y\n')
+    const io = { ...base, isErrTTY: true }
+    const store = new MemStore()
+    const { reg, active } = buildRegistry(mock.url, 'tester@dify.ai', 'tok-1')
+    const http = testHttpClient(mock.url, 'dfoa_test')
+
+    await runDevicesRevoke({ io, reg, active, store, http, target: 'tok-2', all: false })
+    expect(base.outBuf()).toContain('Revoked 1 session(s)')
+  })
+
+  it('TTY with --yes: skips prompt entirely', async () => {
+    const base = bufferStreams()
+    const io = { ...base, isErrTTY: true }
+    const store = new MemStore()
+    const { reg, active } = buildRegistry(mock.url, 'tester@dify.ai', 'tok-1')
+    const http = testHttpClient(mock.url, 'dfoa_test')
+
+    await runDevicesRevoke({ io, reg, active, store, http, target: 'tok-2', all: false, yes: true })
+    expect(base.errBuf()).not.toContain('[y/N]')
+    expect(base.outBuf()).toContain('Revoked 1 session(s)')
+  })
+
   it('no target + no --all: throws UsageMissingArg', async () => {
     const io = bufferStreams()
     const store = new MemStore()

--- a/cli/src/commands/auth/devices/_shared/devices.ts
+++ b/cli/src/commands/auth/devices/_shared/devices.ts
@@ -8,6 +8,7 @@ import { BaseError } from '@/errors/base'
 import { ErrorCode } from '@/errors/codes'
 import { LIMIT_DEFAULT, LIMIT_MAX, parseLimit } from '@/limit/limit'
 import { colorEnabled, colorScheme } from '@/sys/io/color'
+import { promptConfirm } from '@/sys/io/prompt'
 import { runWithSpinner } from '@/sys/io/spinner'
 
 export type DevicesListOptions = {
@@ -94,6 +95,17 @@ export async function runDevicesRevoke(opts: DevicesRevokeOptions): Promise<void
   if (ids.length === 0) {
     opts.io.out.write('no sessions to revoke\n')
     return
+  }
+
+  if (opts.yes !== true && opts.io.isErrTTY) {
+    const confirmed = await promptConfirm(opts.io, `Revoke ${ids.length} session(s)? [y/N] `)
+    if (!confirmed) {
+      throw new BaseError({
+        code: ErrorCode.UsageMissingArg,
+        message: 'aborted by user',
+        hint: 'pass --yes to skip confirmation',
+      })
+    }
   }
 
   for (const id of ids)

--- a/cli/src/commands/auth/devices/revoke/index.ts
+++ b/cli/src/commands/auth/devices/revoke/index.ts
@@ -21,7 +21,7 @@ export default class DevicesRevoke extends DifyCommand {
   static override flags = {
     'all': Flags.boolean({ description: 'revoke every session except the current one', default: false }),
     'http-retry': httpRetryFlag,
-    'yes': Flags.boolean({ description: 'skip confirmation prompt', default: false }),
+    'yes': Flags.boolean({ char: 'y', description: 'skip confirmation prompt', default: false }),
   }
 
   async run(argv: string[]): Promise<void> {

--- a/cli/src/commands/delete/member/run.ts
+++ b/cli/src/commands/delete/member/run.ts
@@ -1,11 +1,11 @@
 import type { ActiveContext } from '@/auth/hosts'
 import type { HttpClient } from '@/http/types'
 import type { IOStreams } from '@/sys/io/streams'
-import * as readline from 'node:readline'
 import { MembersClient } from '@/api/members'
 import { BaseError } from '@/errors/base'
 import { ErrorCode } from '@/errors/codes'
 import { colorEnabled, colorScheme } from '@/sys/io/color'
+import { promptConfirm } from '@/sys/io/prompt'
 import { runWithSpinner } from '@/sys/io/spinner'
 import { nullStreams } from '@/sys/io/streams'
 import { resolveWorkspaceId } from '@/workspace/resolver'
@@ -74,17 +74,5 @@ export async function runDeleteMember(
   return {
     data: new DeleteMemberOutput(opts.memberId, textLine),
     workspaceId: wsId,
-  }
-}
-
-async function promptConfirm(io: IOStreams, message: string): Promise<boolean> {
-  io.err.write(message)
-  const rl = readline.createInterface({ input: io.in, output: io.err, terminal: false })
-  try {
-    const line: string = await new Promise(resolve => rl.once('line', resolve))
-    return line.trim().toLowerCase() === 'y'
-  }
-  finally {
-    rl.close()
   }
 }

--- a/cli/src/sys/io/prompt.ts
+++ b/cli/src/sys/io/prompt.ts
@@ -33,6 +33,18 @@ function normalize(raw: string, opts: Pick<PromptTextOptions<unknown>, 'default'
   return trimmed
 }
 
+export async function promptConfirm(io: IOStreams, message: string): Promise<boolean> {
+  io.err.write(message)
+  const rl = readline.createInterface({ input: io.in, output: io.err, terminal: false })
+  try {
+    const line = await new Promise<string>(resolve => rl.once('line', resolve))
+    return line.trim().toLowerCase() === 'y'
+  }
+  finally {
+    rl.close()
+  }
+}
+
 export async function promptText<T>(opts: PromptTextOptions<T>): Promise<T> {
   const prompt = buildPromptLine(opts)
   const cs = colorScheme(colorEnabled(opts.io.isErrTTY))


### PR DESCRIPTION
## Summary

`auth devices revoke` is a destructive command but had **no** confirmation prompt — so its `--yes` flag ("skip confirmation prompt") was dead, doing nothing. `runDevicesRevoke` accepted `opts.yes` but never read it and revoked unconditionally (`devices.ts:99-100`). By contrast `delete member` (also destructive) has a real TTY-gated confirm.

This makes the flag honest by adding the missing prompt:

- Extract a shared `promptConfirm` into `sys/io/prompt.ts`; migrate `delete member` onto it (removes a duplicate copy).
- `runDevicesRevoke` now confirms before revoking on a TTY (`if (opts.yes !== true && opts.io.isErrTTY)`), prompting `Revoke N session(s)? [y/N]` and aborting on decline. `--yes` skips it. This guards `--all` in particular.
- Add `-y` short flag to `revoke` for parity with `delete member -y`.

Behavior: interactive terminals get the prompt; non-TTY (pipes/scripts/CI) get no prompt and revoke directly — no breaking change for automation.

Linear: WTA-957

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods.

<sub>CLI gate only: `pnpm type-check`, `pnpm lint`, and 30 targeted `pnpm test` all green. Backend/frontend gates N/A (CLI-only change).</sub>

From Claude Code
