### PR TITLE
fix(web): derive publish shortcut display from hotkey

### DIFF
--- a/web/app/components/app/app-publisher/__tests__/index.spec.tsx
+++ b/web/app/components/app/app-publisher/__tests__/index.spec.tsx
@@ -30,6 +30,7 @@ const sectionProps = vi.hoisted(() => ({
   actions: null as null | Record<string, any>,
 }))
 const hotkeyMocks = vi.hoisted(() => ({
+  hotkeys: [] as string[],
   handlers: [] as Array<(event: { preventDefault: () => void }) => void>,
 }))
 
@@ -44,7 +45,8 @@ vi.mock('react-i18next', () => ({
 }))
 
 vi.mock('@tanstack/react-hotkeys', () => ({
-  useHotkey: (_hotkey: string, handler: (event: { preventDefault: () => void }) => void) => {
+  useHotkey: (hotkey: string, handler: (event: { preventDefault: () => void }) => void) => {
+    hotkeyMocks.hotkeys.push(hotkey)
     hotkeyMocks.handlers.push(handler)
   },
 }))
@@ -190,6 +192,7 @@ vi.mock('../sections', () => ({
 describe('AppPublisher', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    hotkeyMocks.hotkeys.length = 0
     hotkeyMocks.handlers.length = 0
     sectionProps.summary = null
     sectionProps.access = null
@@ -240,6 +243,7 @@ describe('AppPublisher', () => {
         enabled: true,
       })
     })
+    expect(sectionProps.summary?.publishShortcut).toEqual(['Mod', 'Shift', 'P'])
     expect(mockRefetch).not.toHaveBeenCalled()
   })
 
@@ -477,6 +481,7 @@ describe('AppPublisher', () => {
       />,
     )
 
+    expect(hotkeyMocks.hotkeys).toContain('Mod+Shift+P')
     hotkeyMocks.handlers[0]!({ preventDefault })
 
     await waitFor(() => {

--- a/web/app/components/app/app-publisher/index.tsx
+++ b/web/app/components/app/app-publisher/index.tsx
@@ -1,3 +1,4 @@
+import type { RegisterableHotkey } from '@tanstack/react-hotkeys'
 import type { FormEvent } from 'react'
 import type { ModelAndParameter } from '../configuration/debug/types'
 import type { WorkflowHiddenStartVariable, WorkflowLaunchInputValue } from '@/app/components/app/overview/app-card-utils'
@@ -82,7 +83,8 @@ export type AppPublisherProps = {
   hasHumanInputNode?: boolean
 }
 
-const PUBLISH_SHORTCUT = ['ctrl', '⇧', 'P']
+const PUBLISH_HOTKEY = 'Mod+Shift+P' satisfies RegisterableHotkey
+const PUBLISH_SHORTCUT = PUBLISH_HOTKEY.split('+')
 
 export type AppPublisherPublishParams = ModelAndParameter | PublishWorkflowParams
 
@@ -290,7 +292,7 @@ export function AppPublisher({
     }
   }
 
-  useHotkey('Mod+Shift+P', (e) => {
+  useHotkey(PUBLISH_HOTKEY, (e) => {
     e.preventDefault()
     if (publishDisabled || published)
       return


### PR DESCRIPTION
## Summary

- Add a single `PUBLISH_HOTKEY` source for the app publisher publish shortcut.
- Derive the displayed shortcut tokens from that hotkey so `formatForDisplay` can render platform-aware labels.
- Cover both the registered hotkey and the summary shortcut props in the app publisher spec.

## Root Cause

The publish action still registered `Mod+Shift+P`, but the app publisher display constant had regressed to `ctrl + ⇧ + P`. Without the old platform helper, that made macOS show Control instead of Command and left the UI out of sync with the actual binding.

## Validation

- `pnpm -C web test app/components/app/app-publisher/__tests__/index.spec.tsx`
- `pnpm --dir web exec eslint app/components/app/app-publisher/index.tsx app/components/app/app-publisher/__tests__/index.spec.tsx`
- `git diff --check HEAD`
