### PR TITLE
fix: handle unknown rowcount in workflow deletes

### DIFF
--- a/api/repositories/sqlalchemy_api_workflow_node_execution_repository.py
+++ b/api/repositories/sqlalchemy_api_workflow_node_execution_repository.py
@@ -286,7 +286,7 @@ class DifyAPISQLAlchemyWorkflowNodeExecutionRepository(DifyAPIWorkflowNodeExecut
                 delete_stmt = delete(WorkflowNodeExecutionModel).where(WorkflowNodeExecutionModel.id.in_(execution_ids))
                 result = cast(CursorResult, session.execute(delete_stmt))
                 session.commit()
-                total_deleted += result.rowcount
+                total_deleted += result.rowcount or 0
 
                 # If we deleted fewer than the batch size, we're done
                 if len(execution_ids) < batch_size:
@@ -334,7 +334,7 @@ class DifyAPISQLAlchemyWorkflowNodeExecutionRepository(DifyAPIWorkflowNodeExecut
                 delete_stmt = delete(WorkflowNodeExecutionModel).where(WorkflowNodeExecutionModel.id.in_(execution_ids))
                 result = cast(CursorResult, session.execute(delete_stmt))
                 session.commit()
-                total_deleted += result.rowcount
+                total_deleted += result.rowcount or 0
 
                 # If we deleted fewer than the batch size, we're done
                 if len(execution_ids) < batch_size:
@@ -393,7 +393,7 @@ class DifyAPISQLAlchemyWorkflowNodeExecutionRepository(DifyAPIWorkflowNodeExecut
             stmt = delete(WorkflowNodeExecutionModel).where(WorkflowNodeExecutionModel.id.in_(execution_ids))
             result = cast(CursorResult, session.execute(stmt))
             session.commit()
-            return result.rowcount
+            return result.rowcount or 0
 
     @override
     def delete_by_runs(self, session: Session, run_ids: Sequence[str]) -> tuple[int, int]:

--- a/api/repositories/sqlalchemy_api_workflow_run_repository.py
+++ b/api/repositories/sqlalchemy_api_workflow_run_repository.py
@@ -320,7 +320,7 @@ class DifyAPISQLAlchemyWorkflowRunRepository(APIWorkflowRunRepository):
             result = cast(CursorResult, session.execute(stmt))
             session.commit()
 
-            deleted_count = result.rowcount
+            deleted_count = result.rowcount or 0
             logger.info("Deleted %s workflow runs by IDs", deleted_count)
             return deleted_count
 
@@ -357,7 +357,7 @@ class DifyAPISQLAlchemyWorkflowRunRepository(APIWorkflowRunRepository):
                 result = cast(CursorResult, session.execute(delete_stmt))
                 session.commit()
 
-                batch_deleted = result.rowcount
+                batch_deleted = result.rowcount or 0
                 total_deleted += batch_deleted
 
                 logger.info("Deleted batch of %s workflow runs for app %s", batch_deleted, app_id)

--- a/api/tests/unit_tests/repositories/test_sqlalchemy_api_workflow_node_execution_repository.py
+++ b/api/tests/unit_tests/repositories/test_sqlalchemy_api_workflow_node_execution_repository.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from repositories.sqlalchemy_api_workflow_node_execution_repository import (
+    DifyAPISQLAlchemyWorkflowNodeExecutionRepository,
+)
+
+
+class _FakeScalarResult:
+    def __init__(self, rows: list[str]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[str]:
+        return self._rows
+
+
+class _FakeExecuteResult:
+    rowcount: int | None
+
+    def __init__(self, *, rowcount: int | None = None, scalar_rows: list[str] | None = None) -> None:
+        self.rowcount = rowcount
+        self._scalar_rows = scalar_rows or []
+
+    def scalars(self) -> _FakeScalarResult:
+        return _FakeScalarResult(self._scalar_rows)
+
+
+class _FakeSession:
+    def __init__(self, execute_results: list[_FakeExecuteResult]) -> None:
+        self._execute_results = execute_results
+
+    def __enter__(self) -> _FakeSession:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        return None
+
+    def execute(self, _stmt: object) -> _FakeExecuteResult:
+        return self._execute_results.pop(0)
+
+    def commit(self) -> None:
+        return None
+
+
+class _FakeSessionMaker:
+    def __init__(self, sessions: list[_FakeSession]) -> None:
+        self._sessions = sessions
+
+    def __call__(self) -> _FakeSession:
+        return self._sessions.pop(0)
+
+
+def test_delete_expired_executions_treats_unknown_rowcount_as_zero() -> None:
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(scalar_rows=["execution-1"]),
+            _FakeExecuteResult(rowcount=None),
+        ]
+    )
+    repository = DifyAPISQLAlchemyWorkflowNodeExecutionRepository(_FakeSessionMaker([session]))
+
+    assert repository.delete_expired_executions("tenant-1", datetime(2024, 1, 1, tzinfo=UTC)) == 0
+
+
+def test_delete_executions_by_app_treats_unknown_rowcount_as_zero() -> None:
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(scalar_rows=["execution-1"]),
+            _FakeExecuteResult(rowcount=None),
+        ]
+    )
+    repository = DifyAPISQLAlchemyWorkflowNodeExecutionRepository(_FakeSessionMaker([session]))
+
+    assert repository.delete_executions_by_app("tenant-1", "app-1") == 0
+
+
+def test_delete_executions_by_ids_treats_unknown_rowcount_as_zero() -> None:
+    session = _FakeSession([_FakeExecuteResult(rowcount=None)])
+    repository = DifyAPISQLAlchemyWorkflowNodeExecutionRepository(_FakeSessionMaker([session]))
+
+    assert repository.delete_executions_by_ids(["execution-1"]) == 0

--- a/api/tests/unit_tests/repositories/test_sqlalchemy_api_workflow_run_repository.py
+++ b/api/tests/unit_tests/repositories/test_sqlalchemy_api_workflow_run_repository.py
@@ -6,7 +6,54 @@ from types import SimpleNamespace
 from graphon.nodes.human_input.entities import FormDefinition, ParagraphInputConfig, UserActionConfig
 from graphon.nodes.human_input.enums import FormInputType
 from models.human_input import RecipientType
-from repositories.sqlalchemy_api_workflow_run_repository import _build_human_input_required_reason
+from repositories.sqlalchemy_api_workflow_run_repository import (
+    DifyAPISQLAlchemyWorkflowRunRepository,
+    _build_human_input_required_reason,
+)
+
+
+class _FakeScalarResult:
+    def __init__(self, rows: list[str]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[str]:
+        return self._rows
+
+
+class _FakeExecuteResult:
+    rowcount: int | None
+
+    def __init__(self, *, rowcount: int | None = None) -> None:
+        self.rowcount = rowcount
+
+
+class _FakeSession:
+    def __init__(self, *, execute_results: list[_FakeExecuteResult], scalar_batches: list[list[str]] | None = None):
+        self._execute_results = execute_results
+        self._scalar_batches = scalar_batches or []
+
+    def __enter__(self) -> _FakeSession:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        return None
+
+    def execute(self, _stmt: object) -> _FakeExecuteResult:
+        return self._execute_results.pop(0)
+
+    def scalars(self, _stmt: object) -> _FakeScalarResult:
+        return _FakeScalarResult(self._scalar_batches.pop(0))
+
+    def commit(self) -> None:
+        return None
+
+
+class _FakeSessionMaker:
+    def __init__(self, sessions: list[_FakeSession]) -> None:
+        self._sessions = sessions
+
+    def __call__(self) -> _FakeSession:
+        return self._sessions.pop(0)
 
 
 def _build_form_model() -> SimpleNamespace:
@@ -31,6 +78,23 @@ def _build_form_model() -> SimpleNamespace:
 
 def _build_reason_model() -> SimpleNamespace:
     return SimpleNamespace(form_id="form-1", node_id="node-1")
+
+
+def test_delete_runs_by_ids_treats_unknown_rowcount_as_zero() -> None:
+    session = _FakeSession(execute_results=[_FakeExecuteResult(rowcount=None)])
+    repository = DifyAPISQLAlchemyWorkflowRunRepository(_FakeSessionMaker([session]))
+
+    assert repository.delete_runs_by_ids(["run-1"]) == 0
+
+
+def test_delete_runs_by_app_treats_unknown_rowcount_as_zero() -> None:
+    session = _FakeSession(
+        scalar_batches=[["run-1"]],
+        execute_results=[_FakeExecuteResult(rowcount=None)],
+    )
+    repository = DifyAPISQLAlchemyWorkflowRunRepository(_FakeSessionMaker([session]))
+
+    assert repository.delete_runs_by_app("tenant-1", "app-1") == 0
 
 
 def test_build_human_input_required_reason_prefers_standalone_web_app_token() -> None:


### PR DESCRIPTION
## Summary
- Normalize SQLAlchemy delete `rowcount=None` to `0` in workflow run and workflow node execution cleanup paths.
- Keep the affected repository methods returning `int` consistently across database drivers.
- Add unit coverage for unknown rowcount behavior in the affected delete methods.

Fixes #37643

## Tests
- `pytest -q tests/unit_tests/repositories/test_sqlalchemy_api_workflow_run_repository.py tests/unit_tests/repositories/test_sqlalchemy_api_workflow_node_execution_repository.py`
- `ruff check api/repositories/sqlalchemy_api_workflow_node_execution_repository.py api/repositories/sqlalchemy_api_workflow_run_repository.py api/tests/unit_tests/repositories/test_sqlalchemy_api_workflow_run_repository.py api/tests/unit_tests/repositories/test_sqlalchemy_api_workflow_node_execution_repository.py`
- `ruff format --check api/repositories/sqlalchemy_api_workflow_node_execution_repository.py api/repositories/sqlalchemy_api_workflow_run_repository.py api/tests/unit_tests/repositories/test_sqlalchemy_api_workflow_run_repository.py api/tests/unit_tests/repositories/test_sqlalchemy_api_workflow_node_execution_repository.py`
- `python -m py_compile api/repositories/sqlalchemy_api_workflow_node_execution_repository.py api/repositories/sqlalchemy_api_workflow_run_repository.py api/tests/unit_tests/repositories/test_sqlalchemy_api_workflow_run_repository.py api/tests/unit_tests/repositories/test_sqlalchemy_api_workflow_node_execution_repository.py`