### PR TITLE
fix: return json success for trigger providers

### DIFF
--- a/api/controllers/console/workspace/trigger_providers.py
+++ b/api/controllers/console/workspace/trigger_providers.py
@@ -331,7 +331,7 @@ class TriggerSubscriptionBuilderBuildApi(Resource):
                     properties=payload.properties,
                 ),
             )
-            return 200
+            return dump_response(SimpleResultResponse, {"result": "success"})
         except Exception as e:
             logger.exception("Error building provider credential", exc_info=e)
             raise ValueError(str(e)) from e
@@ -376,7 +376,7 @@ class TriggerSubscriptionUpdateApi(Resource):
                     name=request.name,
                     properties=request.properties,
                 )
-                return 200
+                return dump_response(SimpleResultResponse, {"result": "success"})
 
             # For the rest cases(API_KEY, OAUTH2)
             # we need to call third party provider(e.g. GitHub) to rebuild the subscription
@@ -388,7 +388,7 @@ class TriggerSubscriptionUpdateApi(Resource):
                 credentials=request.credentials or subscription.credentials,
                 parameters=request.parameters or subscription.parameters,
             )
-            return 200
+            return dump_response(SimpleResultResponse, {"result": "success"})
         except ValueError as e:
             raise BadRequest(str(e))
         except Exception as e:


### PR DESCRIPTION
Summary
- replace the bare integer responses in trigger provider build/update endpoints with the standard `SimpleResultResponse` JSON envelope
- keep the existing success status while avoiding a raw `200` response body for strict JSON clients

Tests
- `python -m compileall -q controllers/console/workspace/trigger_providers.py`
- commit hook: Ruff linter passed
- commit hook: Pyrefly type check passed
- commit hook: staged eslint task passed

Notes
- Fixes #37709
