### PR TITLE
fix: include signed content in hit testing results

### DIFF
--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -58,8 +58,9 @@ class HitTestingService:
     @staticmethod
     def _dump_retrieval_record(record: RetrievalSegments) -> dict[str, Any]:
         dumped_record = record.model_dump()
-        if record.segment and isinstance(dumped_record.get("segment"), dict):
-            dumped_record["segment"]["sign_content"] = record.segment.sign_content
+        dumped_segment = dumped_record.get("segment")
+        if record.segment and isinstance(dumped_segment, dict):
+            dumped_segment["sign_content"] = record.segment.sign_content
         return dumped_record
 
     @classmethod

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -55,6 +55,13 @@ class HitTestingService:
             "doc_metadata": document.doc_metadata,
         }
 
+    @staticmethod
+    def _dump_retrieval_record(record: RetrievalSegments) -> dict[str, Any]:
+        dumped_record = record.model_dump()
+        if record.segment and isinstance(dumped_record.get("segment"), dict):
+            dumped_record["segment"]["sign_content"] = record.segment.sign_content
+        return dumped_record
+
     @classmethod
     def _dump_retrieval_records(cls, records: list[RetrievalSegments]) -> list[dict[str, Any]]:
         document_ids = {
@@ -65,7 +72,7 @@ class HitTestingService:
             if isinstance(document_id, str) and document_id
         }
         if not document_ids:
-            return [record.model_dump() for record in records]
+            return [cls._dump_retrieval_record(record) for record in records]
 
         documents = {
             document.id: cls._dump_dataset_document(document)
@@ -79,7 +86,7 @@ class HitTestingService:
         for retrieval_record in records:
             segment = retrieval_record.segment
             if not segment or not isinstance(segment.document_id, str) or not segment.document_id:
-                records_with_documents.append(retrieval_record.model_dump())
+                records_with_documents.append(cls._dump_retrieval_record(retrieval_record))
                 continue
 
             document_id = segment.document_id
@@ -88,7 +95,7 @@ class HitTestingService:
                 missing_document_ids.add(document_id)
                 continue
 
-            record = retrieval_record.model_dump()
+            record = cls._dump_retrieval_record(retrieval_record)
             segment_dict = record["segment"]
             segment_dict["created_at"] = segment.created_at
             segment_dict["document"] = document

--- a/api/tests/test_containers_integration_tests/services/test_hit_testing_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_hit_testing_service.py
@@ -125,6 +125,7 @@ def _build_segment(
     tenant_id: str | None = None,
     dataset_id: str | None = None,
     created_by: str | None = None,
+    content: str = "segment content",
 ) -> DocumentSegment:
     return DocumentSegment(
         tenant_id=tenant_id or str(uuid4()),
@@ -132,7 +133,7 @@ def _build_segment(
         document_id=document_id,
         created_by=created_by or str(uuid4()),
         position=1,
-        content="segment content",
+        content=content,
         word_count=2,
         tokens=2,
         status=SegmentStatus.COMPLETED,
@@ -487,6 +488,18 @@ class TestHitTestingService:
         assert records[0].segment.id == segment.id
         assert records[0].segment.document_id == ""
         assert records[0].score == 0.95
+
+    def test_dump_retrieval_records_includes_signed_segment_content(self) -> None:
+        upload_file_id = str(uuid4())
+        segment = _build_segment(document_id="", content=f"![head](/files/{upload_file_id}/file-preview)")
+        record = RetrievalSegments.model_validate({"segment": segment, "score": 0.95})
+
+        [dumped_record] = HitTestingService._dump_retrieval_records([record])
+
+        sign_content = dumped_record["segment"]["sign_content"]
+        assert f"/files/{upload_file_id}/file-preview?timestamp=" in sign_content
+        assert "nonce=" in sign_content
+        assert "sign=" in sign_content
 
     def test_dump_retrieval_records_injects_documents(self, db_session_with_containers: Session) -> None:
         document = _create_dataset_document(db_session_with_containers)


### PR DESCRIPTION
## Summary
- Add a shared hit-testing retrieval record dump helper that preserves `DocumentSegment.sign_content`.
- Keep injected dataset document metadata behavior unchanged.
- Add regression coverage for file preview URLs in hit-testing records.

Fixes #36532

## Tests
- `python -m compileall -q services/hit_testing_service.py tests/test_containers_integration_tests/services/test_hit_testing_service.py`
- Commit hook Ruff checks passed

## Notes
- `python -m pytest -q tests/test_containers_integration_tests/services/test_hit_testing_service.py -k "signed_segment_content or dump_retrieval_records"` could not run in this local shell because `pytest` is not installed.