### PR TITLE
fix: clear uploader progress interval

### DIFF
--- a/web/app/components/base/file-uploader/hooks.ts
+++ b/web/app/components/base/file-uploader/hooks.ts
@@ -198,7 +198,7 @@ export const useFile = (fileConfig: FileUpload, noNeedToCheckEnable = true) => {
       if (file && file.progress < 80 && file.progress >= 0)
         handleUpdateFile({ ...file, progress: file.progress + 20 })
       else
-        clearTimeout(timer)
+        clearInterval(timer)
     }, 200)
   }, [fileStore, handleUpdateFile])
   const handleLoadFileFromLink = useCallback((url: string) => {


### PR DESCRIPTION
## Summary
- Use `clearInterval` for the remote file upload progress timer created with `setInterval`.
- Preserve the existing simulated progress behavior.

Fixes #37707

## Tests
- `git diff --check`
- `pnpm --dir web type-check`
- Commit-hook eslint task passed