### PR TITLE
fix: clean orphan segments during dataset deletion

### DIFF
--- a/api/tasks/clean_dataset_task.py
+++ b/api/tasks/clean_dataset_task.py
@@ -109,6 +109,11 @@ def clean_dataset_task(
                 for document in documents:
                     session.delete(document)
 
+            # Segments may outlive their documents when document deletion and dataset deletion
+            # race in separate async tasks. Always clean dataset-scoped segments even if the
+            # document rows are already gone, otherwise quota calculation can keep seeing
+            # orphaned document_segments after the dataset has been deleted.
+            if segments:
                 segment_ids = [segment.id for segment in segments]
                 for segment in segments:
                     image_upload_file_ids = get_image_upload_file_ids(segment.content)

--- a/api/tests/unit_tests/tasks/test_clean_dataset_task.py
+++ b/api/tests/unit_tests/tasks/test_clean_dataset_task.py
@@ -373,6 +373,49 @@ class TestSegmentAttachmentCleanup:
 class TestEdgeCases:
     """Test edge cases and boundary conditions."""
 
+    def test_clean_dataset_task_deletes_orphan_segments_without_documents(
+        self,
+        dataset_id: str,
+        tenant_id: str,
+        collection_binding_id: str,
+        mock_db_session,
+        mock_storage,
+        mock_index_processor_factory,
+        mock_get_image_upload_file_ids,
+        mock_segment,
+    ):
+        """
+        Test dataset cleanup deletes segments even when document rows are already gone.
+
+        Scenario:
+        - Document deletion and dataset deletion run as separate async tasks
+        - The document row is already deleted before clean_dataset_task runs
+        - Dataset-scoped document_segments still exist and must be removed
+
+        Expected behavior:
+        - Orphan document_segments are still deleted by dataset_id cleanup
+        """
+        documents_result = MagicMock()
+        documents_result.all.return_value = []
+        segments_result = MagicMock()
+        segments_result.all.return_value = [mock_segment]
+        image_files_result = MagicMock()
+        image_files_result.all.return_value = []
+        mock_db_session.session.scalars.side_effect = [documents_result, segments_result, image_files_result]
+
+        clean_dataset_task(
+            dataset_id=dataset_id,
+            tenant_id=tenant_id,
+            indexing_technique=IndexTechniqueType.HIGH_QUALITY,
+            index_struct='{"type": "paragraph"}',
+            collection_binding_id=collection_binding_id,
+            doc_form=IndexStructureType.PARAGRAPH_INDEX,
+        )
+
+        mock_get_image_upload_file_ids.assert_called_once_with(mock_segment.content)
+        execute_sqls = [" ".join(str(c[0][0]).split()) for c in mock_db_session.session.execute.call_args_list]
+        assert any("DELETE FROM document_segments" in sql for sql in execute_sqls)
+
     def test_clean_dataset_task_session_always_closed(
         self,
         dataset_id: str,


### PR DESCRIPTION
## Summary

Fixes #37066.

When document deletion and dataset deletion race in separate async tasks, the document row can be gone before `clean_dataset_task` runs while dataset-scoped `document_segments` still remain. `clean_dataset_task` previously skipped segment cleanup when `documents` was empty, leaving orphan segments behind. This patch always cleans dataset-scoped segments, even if the document rows are already gone.

## Changes

- Move `DocumentSegment` cleanup outside the `documents` existence branch in `clean_dataset_task`.
- Add a regression unit test for orphan segment cleanup when no document rows are found.

## Test Plan

```bash
cd api
uv run pytest -o addopts='' tests/unit_tests/tasks/test_clean_dataset_task.py::TestEdgeCases::test_clean_dataset_task_deletes_orphan_segments_without_documents -q -s
uv run pytest -o addopts='' tests/unit_tests/tasks/test_clean_dataset_task.py -q
cd ..
git diff --check
cd api && uv run ruff check tasks/clean_dataset_task.py tests/unit_tests/tasks/test_clean_dataset_task.py
```

## Real behavior proof

behavior: Dataset deletion cleanup now deletes dataset-scoped `document_segments` even when the corresponding `documents` rows have already been deleted by a racing async document-delete task.
environment: Repository `langgenius/dify`, worktree `/datad/github/dify-issue37066`, branch `fix/issue-37066-knowledge-storage`, commit `870bc5f89`, Python 3.12 via `uv`.
steps: Ran the targeted regression test and full clean_dataset_task unit test file after the patch:
```bash
cd /datad/github/dify-issue37066/api
uv run pytest -o addopts='' tests/unit_tests/tasks/test_clean_dataset_task.py::TestEdgeCases::test_clean_dataset_task_deletes_orphan_segments_without_documents -q -s
uv run pytest -o addopts='' tests/unit_tests/tasks/test_clean_dataset_task.py -q
```
evidence: Targeted test output:
```text
.
1 passed, 2 warnings in 1.83s
```
Full file output:
```text
........                                                                 [100%]
8 passed, 2 warnings in 2.07s
```
observedResult: The new test constructs a dataset cleanup run with zero documents but one remaining segment, and verifies that `DELETE FROM document_segments` is issued. Existing clean_dataset_task unit tests still pass.
notTested: Full Dify backend test suite and live Dify Cloud billing/quota recalculation were not run locally. Pytest was invoked with `-o addopts=''` because this local environment lacked pytest coverage plugin support for the repository-level `pytest.ini` coverage addopts.
