### PR TITLE
fix: skip empty tool entries in agent_chat config validation

### DIFF
--- a/api/core/app/apps/agent_chat/app_config_manager.py
+++ b/api/core/app/apps/agent_chat/app_config_manager.py
@@ -200,6 +200,11 @@ class AgentChatAppConfigManager(BaseAppConfigManager):
             raise ValueError("tools in agent_mode must be a list of objects")
 
         for tool in agent_mode["tools"]:
+            if not tool:
+                # Skip malformed empty tool entries; list(tool.keys())[0]
+                # would otherwise raise IndexError (same guard as the sibling
+                # dataset/manager.py and variables/manager.py).
+                continue
             key = list(tool.keys())[0]
             if key in OLD_TOOLS:
                 # old style, use tool name as key

--- a/api/tests/unit_tests/core/app/apps/agent_chat/test_agent_chat_app_config_manager.py
+++ b/api/tests/unit_tests/core/app/apps/agent_chat/test_agent_chat_app_config_manager.py
@@ -301,3 +301,18 @@ class TestValidateAgentModeAndSetDefaults:
         updated, _ = AgentChatAppConfigManager.validate_agent_mode_and_set_defaults("tenant", config)
         assert updated["agent_mode"]["tools"][0]["dataset"]["enabled"] is False
         assert updated["agent_mode"]["tools"][1]["enabled"] is False
+
+    def test_empty_tool_entry_is_skipped(self):
+        # A malformed empty `{}` tool entry must be skipped, not crash with
+        # IndexError on list(tool.keys())[0] — same guard as the sibling
+        # dataset/manager.py (#37669) and variables/manager.py (#37671).
+        config = {
+            "agent_mode": {
+                "enabled": True,
+                "strategy": PlanningStrategy.ROUTER.value,
+                "tools": [{}],
+            }
+        }
+        updated, keys = AgentChatAppConfigManager.validate_agent_mode_and_set_defaults("tenant", config)
+        assert keys == ["agent_mode"]
+        assert updated["agent_mode"]["tools"] == [{}]


### PR DESCRIPTION
`validate_agent_mode_and_set_defaults` iterates `agent_mode["tools"]` and immediately does `key = list(tool.keys())[0]`, which raises `IndexError` when a tool entry is an empty dict `{}` (e.g. from a malformed or legacy/migrated config), crashing config validation.

This adds the same `if not tool: continue` guard that was already merged for the sibling `dataset/manager.py` (#37669) and is present in `variables/manager.py` (#37671), so an empty tool entry is skipped instead of crashing. Added a unit test in `test_agent_chat_app_config_manager.py` covering the empty-entry case (it raised `IndexError` before, passes after).

From Claude Code.
