### PR TITLE
fix(web): include non-standard port in Web App shared/embedded URLs

### DIFF
--- a/web/app/components/app/app-publisher/index.tsx
+++ b/web/app/components/app/app-publisher/index.tsx
@@ -21,7 +21,7 @@ import {
   buildWorkflowLaunchUrl,
   createWorkflowLaunchInitialValues,
   isWorkflowLaunchInputSupported,
-
+  normalizeAppBaseUrl,
 } from '@/app/components/app/overview/app-card-utils'
 import EmbeddedModal from '@/app/components/app/overview/embedded'
 import { useStore as useAppStore } from '@/app/components/app/store'
@@ -135,8 +135,9 @@ export function AppPublisher({
   const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
   const { formatTimeFromNow } = useFormatTimeFromNow()
   const { app_base_url: appBaseURL = '', access_token: accessToken = '' } = appDetail?.site ?? {}
+  const normalizedAppBaseUrl = normalizeAppBaseUrl(appBaseURL)
 
-  const appURL = getPublisherAppUrl({ appBaseUrl: appBaseURL, accessToken, mode: appDetail?.mode })
+  const appURL = getPublisherAppUrl({ appBaseUrl: normalizedAppBaseUrl, accessToken, mode: appDetail?.mode })
   const isChatApp = [AppModeEnum.CHAT, AppModeEnum.AGENT_CHAT, AppModeEnum.COMPLETION].includes(appDetail?.mode || AppModeEnum.CHAT)
   const hiddenLaunchVariables: WorkflowHiddenStartVariable[] = (inputs ?? []).filter(input => input.hide === true)
   const supportedWorkflowLaunchVariables = hiddenLaunchVariables.filter(isWorkflowLaunchInputSupported)
@@ -462,7 +463,7 @@ export function AppPublisher({
           siteInfo={appDetail?.site}
           isShow={embeddingModalOpen}
           onClose={() => setEmbeddingModalOpen(false)}
-          appBaseUrl={appBaseURL}
+          appBaseUrl={normalizedAppBaseUrl}
           accessToken={accessToken}
           hiddenInputs={hiddenLaunchVariables}
         />

--- a/web/app/components/app/overview/__tests__/app-card-utils.spec.ts
+++ b/web/app/components/app/overview/__tests__/app-card-utils.spec.ts
@@ -16,6 +16,7 @@ import {
   hasWorkflowStartNode,
   isAppAccessConfigured,
   isWorkflowLaunchInputSupported,
+  normalizeAppBaseUrl,
 } from '../app-card-utils'
 
 describe('app-card-utils', () => {
@@ -322,5 +323,49 @@ describe('app-card-utils', () => {
     ])
 
     expect(result).toEqual({ count: '42', empty: '' })
+  })
+
+  describe('normalizeAppBaseUrl', () => {
+    const originalLocation = globalThis.window?.location
+
+    beforeEach(() => {
+      Object.defineProperty(globalThis, 'window', {
+        value: {
+          location: {
+            origin: 'http://192.168.113.55:8080',
+          },
+        },
+        writable: true,
+        configurable: true,
+      })
+    })
+
+    afterEach(() => {
+      Object.defineProperty(globalThis, 'window', {
+        value: originalLocation ? { location: originalLocation } : undefined,
+        writable: true,
+        configurable: true,
+      })
+    })
+
+    it('should return the current origin when the backend URL omits the non-standard port', () => {
+      expect(normalizeAppBaseUrl('http://192.168.113.55')).toBe('http://192.168.113.55:8080')
+    })
+
+    it('should keep the URL unchanged when it already has the correct port', () => {
+      expect(normalizeAppBaseUrl('http://192.168.113.55:8080')).toBe('http://192.168.113.55:8080')
+    })
+
+    it('should keep the URL unchanged when the hostname differs', () => {
+      expect(normalizeAppBaseUrl('http://other.host')).toBe('http://other.host')
+    })
+
+    it('should keep the URL unchanged when the protocol differs', () => {
+      expect(normalizeAppBaseUrl('https://192.168.113.55')).toBe('https://192.168.113.55')
+    })
+
+    it('should return empty string for empty input', () => {
+      expect(normalizeAppBaseUrl('')).toBe('')
+    })
   })
 })

--- a/web/app/components/app/overview/app-card-sections.tsx
+++ b/web/app/components/app/overview/app-card-sections.tsx
@@ -43,6 +43,7 @@ import EmbeddedModal from './embedded'
 import SettingsModal from './settings'
 import style from './style.module.css'
 import WorkflowHiddenInputFields from './workflow-hidden-input-fields'
+import { normalizeAppBaseUrl } from './app-card-utils'
 
 type AppInfo = AppDetailResponse & Partial<AppSSO>
 
@@ -459,7 +460,7 @@ export const AppCardDialogs = ({
         siteInfo={appInfo.site}
         isShow={showEmbedded}
         onClose={onCloseEmbedded}
-        appBaseUrl={appInfo.site?.app_base_url}
+        appBaseUrl={normalizeAppBaseUrl(appInfo.site?.app_base_url ?? '')}
         accessToken={appInfo.site?.access_token}
         hiddenInputs={hiddenInputs}
       />

--- a/web/app/components/app/overview/app-card-utils.ts
+++ b/web/app/components/app/overview/app-card-utils.ts
@@ -217,6 +217,33 @@ export const compressAndEncodeBase64 = async (input: string) => {
   return btoa(String.fromCharCode(...compressedUint8Array))
 }
 
+export const normalizeAppBaseUrl = (appBaseUrl: string): string => {
+  if (!appBaseUrl || typeof window === 'undefined')
+    return appBaseUrl
+
+  try {
+    const url = new URL(appBaseUrl)
+    const currentOrigin = new URL(window.location.origin)
+
+    // If the protocol and hostname match, but appBaseUrl has no explicit port
+    // while the current page has a non-standard port, use the current origin
+    // to ensure the port is included in generated URLs.
+    if (
+      url.protocol === currentOrigin.protocol
+      && url.hostname === currentOrigin.hostname
+      && !url.port
+      && currentOrigin.port
+    ) {
+      return currentOrigin.origin
+    }
+  }
+  catch {
+    // ignore invalid URL
+  }
+
+  return appBaseUrl
+}
+
 export const getAppCardDisplayState = ({
   appInfo,
   cardType,
@@ -240,7 +267,7 @@ export const getAppCardDisplayState = ({
   const toggleDisabled = hasInsufficientPermissions || appUnpublished || missingStartNode || triggerModeDisabled
   const runningStatus = (appUnpublished || missingStartNode) ? false : (isApp ? appInfo.enable_site : appInfo.enable_api)
   const appMode = getCardAppMode(appInfo.mode)
-  const appBaseUrl = appInfo.site?.app_base_url ?? ''
+  const appBaseUrl = normalizeAppBaseUrl(appInfo.site?.app_base_url ?? '')
   const accessToken = appInfo.site?.access_token ?? ''
 
   return {

--- a/web/app/components/app/overview/embedded/index.tsx
+++ b/web/app/components/app/overview/embedded/index.tsx
@@ -23,6 +23,7 @@ import {
   getEmbeddedIframeSnippet,
   getEmbeddedScriptSnippet,
   isWorkflowLaunchInputSupported,
+  normalizeAppBaseUrl,
 } from '../app-card-utils'
 import WorkflowHiddenInputFields from '../workflow-hidden-input-fields'
 import style from './style.module.css'


### PR DESCRIPTION
## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

This PR fixes a bug where Web App share/embed URLs omit the non-standard port (e.g., `:8080`) when users access Dify without configuring `APP_WEB_URL` in `.env`.

**Root cause:** Backend `Site.app_base_url` falls back to `request.url_root`, which often fails to preserve the original non-standard port behind a reverse proxy or when accessed directly with a custom port.

**Fix:** Introduces a frontend defensive helper `normalizeAppBaseUrl()` that detects when the backend-provided `appBaseUrl` shares the same protocol and hostname as the current page but lacks an explicit port. In that case, it replaces the URL with `window.location.origin`, ensuring the port is always included in generated share/embed links.

- Applied to `getAppCardDisplayState`, `app-publisher`, `app-card-sections` (EmbeddedModal), and `embedded/index`.
- Includes unit tests for `normalizeAppBaseUrl`.

Fixes #<issue_number>

## Screenshots

| Before | After |
|--------|-------|
| Generated URL: `http://192.168.113.55/chat/MGZppL0FDhCpU9HC` | Generated URL: `http://192.168.113.55:8080/chat/MGZppL0FDhCpU9HC` |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods