### PR TITLE
feat(cli): prepare for alpha release

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@langgenius/difyctl",
   "type": "module",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-alpha",
   "description": "Dify command-line interface",
   "difyctl": {
-    "channel": "rc",
+    "channel": "alpha",
     "compat": {
-      "minDify": "1.14.0",
+      "minDify": "1.15.0",
       "maxDify": "1.15.0"
     },
     "release": {

--- a/cli/scripts/lib/resolve-buildinfo.ts
+++ b/cli/scripts/lib/resolve-buildinfo.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-export const BUILD_CHANNELS = ['dev', 'rc', 'stable'] as const
+export const BUILD_CHANNELS = ['dev', 'alpha', 'rc', 'edge', 'stable'] as const
 export type BuildChannel = (typeof BUILD_CHANNELS)[number]
 
 export type BuildInfo = {

--- a/cli/scripts/release-naming.mjs
+++ b/cli/scripts/release-naming.mjs
@@ -26,9 +26,9 @@ const SEMVER_CORE_LEN = 3
 // Add channels here: { name, prerelease, versionForm }.
 const CHANNELS = [
   { name: 'stable', prerelease: false, versionForm: /^\d+\.\d+\.\d+(\+[0-9A-Z.-]+)?$/i },
-  { name: 'alpha',  prerelease: true,  versionForm: /^\d+\.\d+\.\d+-alpha(\.\d+)?$/ },
-  { name: 'rc',     prerelease: true,  versionForm: /^\d+\.\d+\.\d+-rc\.\d+$/ },
-  { name: 'edge',   prerelease: true,  versionForm: /^\d+\.\d+\.\d+-edge\.[0-9a-f]{7,40}$/ },
+  { name: 'alpha', prerelease: true, versionForm: /^\d+\.\d+\.\d+-alpha(\.\d+)?$/ },
+  { name: 'rc', prerelease: true, versionForm: /^\d+\.\d+\.\d+-rc\.\d+$/ },
+  { name: 'edge', prerelease: true, versionForm: /^\d+\.\d+\.\d+-edge\.[0-9a-f]{7,40}$/ },
 ]
 
 const channelByName = name => CHANNELS.find(c => c.name === name)

--- a/cli/scripts/release-naming.mjs
+++ b/cli/scripts/release-naming.mjs
@@ -26,8 +26,9 @@ const SEMVER_CORE_LEN = 3
 // Add channels here: { name, prerelease, versionForm }.
 const CHANNELS = [
   { name: 'stable', prerelease: false, versionForm: /^\d+\.\d+\.\d+(\+[0-9A-Z.-]+)?$/i },
-  { name: 'rc', prerelease: true, versionForm: /^\d+\.\d+\.\d+-rc\.\d+$/ },
-  { name: 'edge', prerelease: true, versionForm: /^\d+\.\d+\.\d+-edge\.[0-9a-f]{7,40}$/ },
+  { name: 'alpha',  prerelease: true,  versionForm: /^\d+\.\d+\.\d+-alpha(\.\d+)?$/ },
+  { name: 'rc',     prerelease: true,  versionForm: /^\d+\.\d+\.\d+-rc\.\d+$/ },
+  { name: 'edge',   prerelease: true,  versionForm: /^\d+\.\d+\.\d+-edge\.[0-9a-f]{7,40}$/ },
 ]
 
 const channelByName = name => CHANNELS.find(c => c.name === name)

--- a/cli/scripts/release-naming.test.ts
+++ b/cli/scripts/release-naming.test.ts
@@ -15,13 +15,13 @@ function run(args: string[]): { code: number, stdout: string, stderr: string } {
   }
 }
 
-describe('release-naming compat-check (compat 1.14.0..1.15.0)', () => {
+describe('release-naming compat-check (compat 1.15.0..1.15.0)', () => {
   it('accepts a version inside the window', () => {
-    expect(run(['compat-check', '1.14.7']).code).toBe(0)
+    expect(run(['compat-check', '1.15.0']).code).toBe(0)
   })
 
   it('accepts the inclusive lower bound', () => {
-    expect(run(['compat-check', '1.14.0']).code).toBe(0)
+    expect(run(['compat-check', '1.15.0']).code).toBe(0)
   })
 
   it('accepts the inclusive upper bound', () => {
@@ -29,26 +29,22 @@ describe('release-naming compat-check (compat 1.14.0..1.15.0)', () => {
   })
 
   it('accepts a v-prefixed tag', () => {
-    expect(run(['compat-check', 'v1.14.2']).code).toBe(0)
+    expect(run(['compat-check', 'v1.15.0']).code).toBe(0)
   })
 
   it('rejects a version below the lower bound', () => {
-    expect(run(['compat-check', '1.13.9']).code).not.toBe(0)
+    expect(run(['compat-check', '1.14.9']).code).not.toBe(0)
   })
 
   it('rejects a version above the upper bound', () => {
     expect(run(['compat-check', '1.15.1']).code).not.toBe(0)
   })
 
-  it('treats a prerelease of the upper bound as in range (1.15.0-rc1 <= 1.15.0)', () => {
-    expect(run(['compat-check', '1.15.0-rc1']).code).toBe(0)
+  it('treats a prerelease of the bound as below it (1.15.0-rc1 < 1.15.0)', () => {
+    expect(run(['compat-check', '1.15.0-rc1']).code).not.toBe(0)
   })
 
-  it('treats a prerelease of the lower bound as below it (1.14.0-rc1 < 1.14.0)', () => {
-    expect(run(['compat-check', '1.14.0-rc1']).code).not.toBe(0)
-  })
-
-  it('ignores build metadata on the upper bound (1.15.0+build == 1.15.0)', () => {
+  it('ignores build metadata on the bound (1.15.0+build == 1.15.0)', () => {
     expect(run(['compat-check', '1.15.0+build123']).code).toBe(0)
   })
 
@@ -64,7 +60,7 @@ describe('release-naming compat-check (compat 1.14.0..1.15.0)', () => {
 describe('release-naming github-env', () => {
   it('emits difyctlTag = tagPrefix + version', () => {
     const { stdout } = run(['github-env'])
-    expect(stdout).toMatch(/^difyctlTag=difyctl-v0\.1\.0-rc\.1$/m)
+    expect(stdout).toMatch(/^difyctlTag=difyctl-v0\.1\.0-alpha$/m)
   })
 
   it('still emits the existing trace fields', () => {
@@ -79,8 +75,8 @@ describe('release-naming edge channel', () => {
     expect(run(['channels']).stdout).toMatch(/^edge$/m)
   })
 
-  it('edge-version derives <pkgcore>-edge.<sha> stripping the rc prerelease', () => {
-    // package.json version is 0.1.0-rc.1 -> core 0.1.0
+  it('edge-version derives <pkgcore>-edge.<sha> stripping the alpha prerelease', () => {
+    // package.json version is 0.1.0-alpha -> core 0.1.0
     expect(run(['edge-version', '2fd7b82']).stdout.trim()).toBe('0.1.0-edge.2fd7b82')
   })
 

--- a/cli/scripts/release-r2-edge.test.ts
+++ b/cli/scripts/release-r2-edge.test.ts
@@ -81,7 +81,7 @@ describe('release-r2-edge manifest', () => {
 
   it('carries the compat window from package.json', () => {
     const { json } = buildManifest()
-    expect(json.compat).toEqual({ minDify: '1.14.0', maxDify: '1.15.0' })
+    expect(json.compat).toEqual({ minDify: '1.15.0', maxDify: '1.15.0' })
   })
 
   it('lists all 5 targets with asset name + sha256 from the checksums file', () => {

--- a/cli/src/commands/version/version.test.ts
+++ b/cli/src/commands/version/version.test.ts
@@ -158,6 +158,6 @@ describe('Version command', () => {
     if (output?.kind !== 'formatted')
       throw new Error('expected formatted output')
 
-    expect(output.data.text()).toContain('WARNING: This build is a release candidate')
+    expect(output.data.text()).toContain('WARNING: This build is a rc release')
   })
 })

--- a/cli/src/version/info.ts
+++ b/cli/src/version/info.ts
@@ -1,7 +1,7 @@
 import { arch, platform } from '@/sys/index'
 import { compatString } from './compat'
 
-export type Channel = 'dev' | 'edge' | 'rc' | 'stable'
+export type Channel = 'dev' | 'alpha' | 'edge' | 'rc' | 'stable'
 
 export type VersionInfo = {
   version: string

--- a/cli/src/version/render.test.ts
+++ b/cli/src/version/render.test.ts
@@ -52,7 +52,7 @@ describe('renderVersionText', () => {
     expect(text).not.toContain('WARNING:')
   })
 
-  it('appends RC warning when channel is rc', () => {
+  it('appends warning when channel is rc', () => {
     const report: VersionReport = {
       client: baseClient({ channel: 'rc' }),
       server: { endpoint: '', reachable: false },
@@ -60,8 +60,43 @@ describe('renderVersionText', () => {
     }
     const text = renderVersionText(report)
 
-    expect(text).toContain('WARNING: This build is a release candidate')
+    expect(text).toContain('WARNING: This build is a rc release')
     expect(text).toContain('install the stable channel')
+  })
+
+  it('appends warning when channel is alpha', () => {
+    const report: VersionReport = {
+      client: baseClient({ channel: 'alpha' }),
+      server: { endpoint: '', reachable: false },
+      compat: { ...compatible(), status: 'unknown', detail: 'server probe skipped' },
+    }
+    const text = renderVersionText(report)
+
+    expect(text).toContain('WARNING: This build is a alpha release')
+    expect(text).toContain('install the stable channel')
+  })
+
+  it('appends warning when channel is edge', () => {
+    const report: VersionReport = {
+      client: baseClient({ channel: 'edge' }),
+      server: { endpoint: '', reachable: false },
+      compat: { ...compatible(), status: 'unknown', detail: 'server probe skipped' },
+    }
+    const text = renderVersionText(report)
+
+    expect(text).toContain('WARNING: This build is a edge release')
+    expect(text).toContain('install the stable channel')
+  })
+
+  it('does not append warning when channel is stable', () => {
+    const report: VersionReport = {
+      client: baseClient({ channel: 'stable' }),
+      server: { endpoint: '', reachable: false },
+      compat: { ...compatible(), status: 'unknown', detail: 'server probe skipped' },
+    }
+    const text = renderVersionText(report)
+
+    expect(text).not.toContain('WARNING:')
   })
 
   it('shows "(skipped …)" when server.endpoint is empty', () => {
@@ -105,7 +140,7 @@ describe('renderVersionText', () => {
     // RC warning) ran, yet the output is byte-clean.
     expect(plain).not.toMatch(ANSI_RE)
     expect(plain).toContain('Compatibility: incompatible')
-    expect(plain).toContain('WARNING: This build is a release candidate')
+    expect(plain).toContain('WARNING: This build is a rc release')
   })
 
   describe('with picocolors stubbed to always emit ANSI', () => {
@@ -147,8 +182,8 @@ describe('renderVersionText', () => {
       const colored = render(report, { color: true })
       expect(colored).toMatch(ANSI_RE)
       expect(colored).toContain('Compatibility: incompatible')
-      // RC warning lines also routed through yellow.
-      expect(colored).toContain('release candidate')
+      // prerelease warning lines also routed through yellow.
+      expect(colored).toContain('WARNING: This build is a rc release')
     })
   })
 

--- a/cli/src/version/render.test.ts
+++ b/cli/src/version/render.test.ts
@@ -61,7 +61,7 @@ describe('renderVersionText', () => {
     const text = renderVersionText(report)
 
     expect(text).toContain('WARNING: This build is a rc release')
-    expect(text).toContain('install the stable channel')
+    expect(text).toContain('install or wait for the stable channel')
   })
 
   it('appends warning when channel is alpha', () => {
@@ -73,7 +73,7 @@ describe('renderVersionText', () => {
     const text = renderVersionText(report)
 
     expect(text).toContain('WARNING: This build is a alpha release')
-    expect(text).toContain('install the stable channel')
+    expect(text).toContain('install or wait for the stable channel')
   })
 
   it('appends warning when channel is edge', () => {
@@ -85,7 +85,7 @@ describe('renderVersionText', () => {
     const text = renderVersionText(report)
 
     expect(text).toContain('WARNING: This build is a edge release')
-    expect(text).toContain('install the stable channel')
+    expect(text).toContain('install or wait for the stable channel')
   })
 
   it('does not append warning when channel is stable', () => {

--- a/cli/src/version/render.ts
+++ b/cli/src/version/render.ts
@@ -1,6 +1,6 @@
+import type { Channel } from './info'
 import type { VersionReport } from './probe'
 import { colorScheme } from '@/sys/io/color'
-import type { Channel } from './info'
 
 const PRERELEASE_CHANNELS = new Set<Channel>(['alpha', 'rc', 'edge'])
 

--- a/cli/src/version/render.ts
+++ b/cli/src/version/render.ts
@@ -2,12 +2,10 @@ import type { Channel } from './info'
 import type { VersionReport } from './probe'
 import { colorScheme } from '@/sys/io/color'
 
-const PRERELEASE_CHANNELS = new Set<Channel>(['alpha', 'rc', 'edge'])
-
 function prereleaseWarning(channel: Channel): readonly string[] {
   return [
     `WARNING: This build is a ${channel} release. It is not stable`,
-    '         and may have bugs. For production use, install the stable channel.',
+    '         and may have bugs. For production use, install or wait for the stable channel.',
   ]
 }
 
@@ -54,7 +52,7 @@ export function renderVersionText(report: VersionReport, opts: RenderOptions = {
   const verdictText = `Compatibility: ${COMPAT_LABEL[compat.status]} — ${compat.detail}`
   lines.push(compat.status === 'unsupported' ? c.yellow(verdictText) : verdictText)
 
-  if (PRERELEASE_CHANNELS.has(client.channel)) {
+  if (client.channel !== 'stable') {
     lines.push('')
     for (const line of prereleaseWarning(client.channel))
       lines.push(c.yellow(line))

--- a/cli/src/version/render.ts
+++ b/cli/src/version/render.ts
@@ -1,10 +1,15 @@
 import type { VersionReport } from './probe'
 import { colorScheme } from '@/sys/io/color'
+import type { Channel } from './info'
 
-const RC_WARNING_LINES = [
-  'WARNING: This build is a release candidate. It is in beta test, not stable,',
-  '         and may have bugs. For production use, install the stable channel.',
-] as const
+const PRERELEASE_CHANNELS = new Set<Channel>(['alpha', 'rc', 'edge'])
+
+function prereleaseWarning(channel: Channel): readonly string[] {
+  return [
+    `WARNING: This build is a ${channel} release. It is not stable`,
+    '         and may have bugs. For production use, install the stable channel.',
+  ]
+}
 
 export type RenderOptions = {
   readonly color?: boolean
@@ -49,9 +54,9 @@ export function renderVersionText(report: VersionReport, opts: RenderOptions = {
   const verdictText = `Compatibility: ${COMPAT_LABEL[compat.status]} — ${compat.detail}`
   lines.push(compat.status === 'unsupported' ? c.yellow(verdictText) : verdictText)
 
-  if (client.channel === 'rc') {
+  if (PRERELEASE_CHANNELS.has(client.channel)) {
     lines.push('')
-    for (const line of RC_WARNING_LINES)
+    for (const line of prereleaseWarning(client.channel))
       lines.push(c.yellow(line))
   }
 


### PR DESCRIPTION
## Summary

- Adds `alpha` channel to `cli/scripts/release-naming.mjs` with version form `/^\d+\.\d+\.\d+-alpha(\.\d+)?$/` — supports both `0.1.0-alpha` and `0.1.0-alpha.1`
- Bumps `cli/package.json` to `0.1.0-alpha`, channel `alpha`, compat window `1.15.0..1.15.0`
- OpenAPI availability starts at Dify 1.15.0, hence `minDify` raised from `1.14.0`
- Adds `alpha` to `BUILD_CHANNELS` in `resolve-buildinfo.ts` and `Channel` type in `info.ts` (both previously missing)
- `difyctl version` now shows a prerelease warning for any non-stable channel (`!= stable`) instead of an explicit allowlist; warning text softened to "install or wait for the stable channel"

Closes WTA-972

## Test plan

- [ ] `node cli/scripts/release-naming.mjs validate` passes
- [ ] `node cli/scripts/release-naming.mjs compat-check 1.15.0` passes
- [ ] `node cli/scripts/release-naming.mjs validate-version 0.1.0-alpha alpha` passes
- [ ] `node cli/scripts/release-naming.mjs validate-version 0.1.0-alpha.1 alpha` passes
- [ ] `node cli/scripts/release-naming.mjs channels` includes `alpha`
- [ ] `difyctl version` on an alpha build shows `WARNING: This build is a alpha release … install or wait for the stable channel`
- [ ] `difyctl version` on a stable build shows no warning