### PR TITLE
fix: correct misleading password length validation message

### DIFF
--- a/api/libs/password.py
+++ b/api/libs/password.py
@@ -13,7 +13,7 @@ def valid_password(password):
     if re.match(pattern, password) is not None:
         return password
 
-    raise ValueError("Password must contain letters and numbers, and the length must be greater than 8.")
+    raise ValueError("Password must contain letters and numbers, and the length must be at least 8 characters.")
 
 
 def hash_password(password_str, salt_byte):

--- a/api/tests/unit_tests/libs/test_password.py
+++ b/api/tests/unit_tests/libs/test_password.py
@@ -35,6 +35,13 @@ class TestValidPassword:
         with pytest.raises(ValueError):
             valid_password("")
 
+    def test_should_reject_password_shorter_than_minimum_length(self):
+        """A 7-character password with letters and numbers is rejected for length."""
+        with pytest.raises(ValueError) as exc_info:
+            valid_password("abc1234")
+
+        assert "at least 8" in str(exc_info.value)
+
 
 class TestPasswordHashing:
     """Test password hashing and comparison"""


### PR DESCRIPTION
## Summary

The password validator in `api/libs/password.py` rejects passwords shorter than 8 characters (regex `.{8,}`), but the error message says the length "must be greater than 8", which implies a 9-character minimum. Since 8-character passwords are accepted, the message is misleading.

This corrects the message to "...must be at least 8 characters." and adds a boundary test asserting that a 7-character password is rejected.

Verified by calling `valid_password` directly (8-char accepted, 7-char rejected) and running `ruff check` / `ruff format --check` on the changed files.

Fixes #37795

## Screenshots

N/A (backend error-message wording; no UI change).

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Cursor