### PR TITLE
fix: avoid logging SECRET_KEY and OAuth client secrets in setup CLI

### DIFF
--- a/api/commands/plugin.py
+++ b/api/commands/plugin.py
@@ -8,7 +8,6 @@ from pydantic import TypeAdapter
 from sqlalchemy import delete, func, select
 from sqlalchemy.engine import CursorResult
 
-from configs import dify_config
 from core.helper import encrypter
 from core.plugin.entities.plugin_daemon import CredentialType
 from core.plugin.impl.plugin import PluginInstaller
@@ -41,12 +40,10 @@ def setup_system_tool_oauth_client(provider, client_params):
 
     try:
         # json validate
-        click.echo(click.style(f"Validating client params: {client_params}", fg="yellow"))
+        click.echo(click.style("Validating client params...", fg="yellow"))
         client_params_dict = TypeAdapter(dict[str, Any]).validate_json(client_params)
         click.echo(click.style("Client params validated successfully.", fg="green"))
 
-        click.echo(click.style(f"Encrypting client params: {client_params}", fg="yellow"))
-        click.echo(click.style(f"Using SECRET_KEY: `{dify_config.SECRET_KEY}`", fg="yellow"))
         oauth_client_params = encrypt_system_params(client_params_dict)
         click.echo(click.style("Client params encrypted successfully.", fg="green"))
     except Exception as e:
@@ -91,12 +88,10 @@ def setup_system_trigger_oauth_client(provider, client_params):
 
     try:
         # json validate
-        click.echo(click.style(f"Validating client params: {client_params}", fg="yellow"))
+        click.echo(click.style("Validating client params...", fg="yellow"))
         client_params_dict = TypeAdapter(dict[str, Any]).validate_json(client_params)
         click.echo(click.style("Client params validated successfully.", fg="green"))
 
-        click.echo(click.style(f"Encrypting client params: {client_params}", fg="yellow"))
-        click.echo(click.style(f"Using SECRET_KEY: `{dify_config.SECRET_KEY}`", fg="yellow"))
         oauth_client_params = encrypt_system_params(client_params_dict)
         click.echo(click.style("Client params encrypted successfully.", fg="green"))
     except Exception as e:
@@ -138,7 +133,7 @@ def setup_datasource_oauth_client(provider, client_params):
 
     try:
         # json validate
-        click.echo(click.style(f"Validating client params: {client_params}", fg="yellow"))
+        click.echo(click.style("Validating client params...", fg="yellow"))
         client_params_dict = TypeAdapter(dict[str, Any]).validate_json(client_params)
         click.echo(click.style("Client params validated successfully.", fg="green"))
     except Exception as e:
@@ -168,7 +163,6 @@ def setup_datasource_oauth_client(provider, client_params):
     db.session.commit()
     click.echo(click.style(f"provider: {provider_name}", fg="green"))
     click.echo(click.style(f"plugin_id: {plugin_id}", fg="green"))
-    click.echo(click.style(f"params: {json.dumps(client_params_dict, indent=2, ensure_ascii=False)}", fg="green"))
     click.echo(click.style(f"Datasource oauth client setup successfully. id: {oauth_client.id}", fg="green"))
 
 


### PR DESCRIPTION
## Summary

The OAuth-client setup CLI commands in `api/commands/plugin.py` (`setup-system-tool-oauth-client`, `setup-system-trigger-oauth-client`, `setup-datasource-oauth-client`) printed the full `SECRET_KEY` and the raw/parsed `client_params` (which include `client_secret`) to stdout. These can leak into shell history and CI/operator logs (CWE-532).

This removes the `SECRET_KEY` echo, stops printing the raw/parsed client params, and keeps only the non-sensitive progress messages. `SECRET_KEY` was the only use of `dify_config` in this module, so its now-unused import is removed as well.

Verified with `ruff check` on the changed file.

Fixes #37807

## Screenshots

N/A (CLI stdout wording; no UI change).

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. (This change only removes sensitive stdout output; there is no new logic to unit-test.)
- [ ] I've updated the documentation accordingly.
- [x] I ran `ruff check` on the changed file.

From Cursor
