### PR TITLE
fix: harden uploaded filename validation

### DIFF
--- a/api/services/file_service.py
+++ b/api/services/file_service.py
@@ -59,9 +59,15 @@ class FileService:
         # get file extension
         extension = os.path.splitext(filename)[1].lstrip(".").lower()
 
-        # Only reject path separators here. The original filename is stored as metadata,
-        # while the storage key is UUID-based.
-        if any(c in filename for c in ["/", "\\"]):
+        # Reject path separators, NUL bytes, control characters, and bare dot-names.
+        # The original filename is stored as display metadata (and may surface in ZIP
+        # entries, response headers, or logs), while the storage key is UUID-based.
+        if (
+            not filename
+            or filename in {".", ".."}
+            or any(c in filename for c in ("/", "\\"))
+            or any(ord(c) < 0x20 or ord(c) == 0x7F for c in filename)
+        ):
             raise ValueError("Filename contains invalid characters")
 
         if len(filename) > 200:

--- a/api/tests/unit_tests/services/test_file_service.py
+++ b/api/tests/unit_tests/services/test_file_service.py
@@ -88,6 +88,24 @@ class TestFileService:
         with pytest.raises(ValueError, match="Filename contains invalid characters"):
             file_service.upload_file(filename="invalid/file.txt", content=b"", mimetype="text/plain", user=MagicMock())
 
+    @pytest.mark.parametrize(
+        "bad_filename",
+        [
+            "invalid\\file.txt",
+            "bad\x00name.txt",
+            "bad\nname.txt",
+            "bad\rname.txt",
+            "tab\tname.txt",
+            "del\x7fname.txt",
+            ".",
+            "..",
+            "",
+        ],
+    )
+    def test_upload_file_rejects_invalid_filenames(self, file_service, bad_filename):
+        with pytest.raises(ValueError, match="Filename contains invalid characters"):
+            file_service.upload_file(filename=bad_filename, content=b"", mimetype="text/plain", user=MagicMock())
+
     def test_upload_file_long_filename(self, file_service: FileService, mock_db_session):
         # Setup
         long_name = "a" * 210 + ".txt"


### PR DESCRIPTION
## Summary

`FileService.upload_file` only rejected the path separators `/` and `\` in the original filename. That name is stored as display metadata (`UploadFile.name`) and can surface in ZIP entry names, `Content-Disposition` headers, and log lines.

This additionally rejects NUL bytes, control characters (CR/LF etc. - header/log injection vectors), and the bare dot-names `.` / `..`. The storage key is already UUID-based, so this is defense-in-depth, and the existing `ValueError("Filename contains invalid characters")` message/behavior is unchanged. Legitimate names (spaces, accented/CJK characters, `..` as a substring such as `v1..2.zip`) are still accepted.

Adds a parametrized unit test covering the new rejections. Verified with `ruff check` and `ruff format` on the changed files.

Fixes #37809

## Screenshots

N/A (backend input validation; no UI change).

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Cursor
