### PR TITLE
fix(web): stabilize deployment state hydration

### DIFF
--- a/web/app/(commonLayout)/layout.tsx
+++ b/web/app/(commonLayout)/layout.tsx
@@ -27,25 +27,26 @@ export default async function Layout({ children }: { children: ReactNode }) {
       <OAuthRegistrationAnalytics />
       <EducationVerifyActionRecorder />
       <CommonLayoutHydrationBoundary>
-        <AppContextProvider>
-          <EventEmitterContextProvider>
-            <ProviderContextProvider>
-              <ModalContextProvider>
-                <NextRouteStateBridge />
-                <MainNavLayout>
-                  <RoleRouteGuard>
-                    {children}
-                  </RoleRouteGuard>
-                </MainNavLayout>
-                <InSiteMessageNotification />
-                <PartnerStack />
-                <ReadmePanel />
-                <GotoAnything />
-                <WorkflowGeneratorMount />
-              </ModalContextProvider>
-            </ProviderContextProvider>
-          </EventEmitterContextProvider>
-        </AppContextProvider>
+        <NextRouteStateBridge>
+          <AppContextProvider>
+            <EventEmitterContextProvider>
+              <ProviderContextProvider>
+                <ModalContextProvider>
+                  <MainNavLayout>
+                    <RoleRouteGuard>
+                      {children}
+                    </RoleRouteGuard>
+                  </MainNavLayout>
+                  <InSiteMessageNotification />
+                  <PartnerStack />
+                  <ReadmePanel />
+                  <GotoAnything />
+                  <WorkflowGeneratorMount />
+                </ModalContextProvider>
+              </ProviderContextProvider>
+            </EventEmitterContextProvider>
+          </AppContextProvider>
+        </NextRouteStateBridge>
       </CommonLayoutHydrationBoundary>
       <Zendesk />
     </>

--- a/web/app/components/next-route-state/atoms.ts
+++ b/web/app/components/next-route-state/atoms.ts
@@ -7,6 +7,8 @@ type NextRouteState = {
   params: NextRouteParams
 }
 
+// Mirrors Next router state. NextRouteStateBridge force-hydrates this atom on
+// render so feature atoms can read route state without calling router hooks.
 const nextRouteStateAtom = atom<NextRouteState>({
   pathname: '',
   params: {},

--- a/web/app/components/next-route-state/index.tsx
+++ b/web/app/components/next-route-state/index.tsx
@@ -1,24 +1,25 @@
 'use client'
 
+import type { ReactNode } from 'react'
 import type { NextRouteParams } from './atoms'
-import { useIsomorphicLayoutEffect } from 'foxact/use-isomorphic-layout-effect'
-import { useSetAtom } from 'jotai'
+import { useHydrateAtoms } from 'jotai/utils'
 import { useParams, usePathname } from '@/next/navigation'
 import {
   setNextRouteStateAtom,
 } from './atoms'
 
-export function NextRouteStateBridge() {
+export function NextRouteStateBridge({ children }: {
+  children: ReactNode
+}) {
   const pathname = usePathname()
   const params = useParams<NextRouteParams>()
-  const setNextRouteState = useSetAtom(setNextRouteStateAtom)
 
-  useIsomorphicLayoutEffect(() => {
-    setNextRouteState({
+  useHydrateAtoms([
+    [setNextRouteStateAtom, {
       pathname,
       params,
-    })
-  }, [params, pathname, setNextRouteState])
+    }],
+  ] as const, { dangerouslyForceHydrate: true })
 
-  return null
+  return children
 }

--- a/web/features/deployments/create-release/ui/dialog.tsx
+++ b/web/features/deployments/create-release/ui/dialog.tsx
@@ -43,9 +43,11 @@ function CreateReleaseCloseButton() {
 
 export function CreateReleaseDialogContent() {
   return (
-    <ScopeProvider atoms={[createReleaseFormAtom]}>
-      <CreateReleaseDialogSurface />
-    </ScopeProvider>
+    <DialogContent className="top-[18dvh] w-140 max-w-[calc(100vw-32px)] translate-y-0 overflow-hidden p-0">
+      <ScopeProvider atoms={[createReleaseFormAtom]} name="CreateReleaseForm">
+        <CreateReleaseDialogSurface />
+      </ScopeProvider>
+    </DialogContent>
   )
 }
 
@@ -75,7 +77,7 @@ function CreateReleaseDialogSurface() {
   }
 
   return (
-    <DialogContent className="top-[18dvh] w-140 max-w-[calc(100vw-32px)] translate-y-0 overflow-hidden p-0">
+    <>
       <CreateReleaseCloseButton />
       <form
         noValidate
@@ -105,6 +107,6 @@ function CreateReleaseDialogSurface() {
 
         <CreateReleaseActions />
       </form>
-    </DialogContent>
+    </>
   )
 }

--- a/web/features/deployments/list/index.tsx
+++ b/web/features/deployments/list/index.tsx
@@ -1,36 +1,7 @@
 'use client'
 
-import type { ReactNode } from 'react'
-import { ScopeProvider } from 'jotai-scope'
-import { useQueryState } from 'nuqs'
-import {
-  deploymentsListEnvironmentIdAtom,
-  deploymentsListKeywordsAtom,
-  envFilterQueryState,
-  keywordsQueryState,
-} from './state'
+import { DeploymentsListStateBoundary } from './state'
 import { DeploymentsListShell } from './ui/shell'
-
-function DeploymentsListStateBoundary({ children }: {
-  children: ReactNode
-}) {
-  const [envFilter] = useQueryState('env', envFilterQueryState)
-  const [keywords] = useQueryState('keywords', keywordsQueryState)
-  const stateKey = `${envFilter ?? 'all'}:${keywords}`
-
-  return (
-    <ScopeProvider
-      key={stateKey}
-      atoms={[
-        [deploymentsListEnvironmentIdAtom, envFilter],
-        [deploymentsListKeywordsAtom, keywords],
-      ]}
-      name="DeploymentsList"
-    >
-      {children}
-    </ScopeProvider>
-  )
-}
 
 export function DeploymentsList() {
   return (

--- a/web/features/deployments/list/state/index.ts
+++ b/web/features/deployments/list/state/index.ts
@@ -17,8 +17,8 @@ export const keywordsQueryState = parseAsString.withDefault('').withOptions({ hi
 
 // Mirrors nuqs URL state. DeploymentsListStateBoundary force-hydrates these
 // atoms on render so query atoms can read URL filters through Jotai.
-export const deploymentsListKeywordsAtom = atom('')
-export const deploymentsListEnvironmentIdAtom = atom<string | null>(null)
+const deploymentsListKeywordsAtom = atom('')
+const deploymentsListEnvironmentIdAtom = atom<string | null>(null)
 
 export function DeploymentsListStateBoundary({ children }: {
   children: ReactNode

--- a/web/features/deployments/list/state/index.ts
+++ b/web/features/deployments/list/state/index.ts
@@ -2,10 +2,12 @@
 
 import type { ListAppInstanceSummariesResponse } from '@dify/contracts/enterprise/types.gen'
 import type { InfiniteData, QueryKey } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
 import { keepPreviousData } from '@tanstack/react-query'
 import { atom } from 'jotai'
 import { atomWithInfiniteQuery, atomWithQuery } from 'jotai-tanstack-query'
-import { parseAsString } from 'nuqs'
+import { useHydrateAtoms } from 'jotai/utils'
+import { parseAsString, useQueryState } from 'nuqs'
 import { consoleQuery } from '@/service/client'
 import { getNextPageParamFromPagination, SOURCE_APPS_PAGE_SIZE } from '../../shared/domain/pagination'
 import { deploymentStatusPollingInterval } from '../../shared/domain/runtime-status'
@@ -13,8 +15,24 @@ import { deploymentStatusPollingInterval } from '../../shared/domain/runtime-sta
 export const envFilterQueryState = parseAsString.withOptions({ history: 'push' })
 export const keywordsQueryState = parseAsString.withDefault('').withOptions({ history: 'push' })
 
+// Mirrors nuqs URL state. DeploymentsListStateBoundary force-hydrates these
+// atoms on render so query atoms can read URL filters through Jotai.
 export const deploymentsListKeywordsAtom = atom('')
 export const deploymentsListEnvironmentIdAtom = atom<string | null>(null)
+
+export function DeploymentsListStateBoundary({ children }: {
+  children: ReactNode
+}) {
+  const [envFilter] = useQueryState('env', envFilterQueryState)
+  const [keywords] = useQueryState('keywords', keywordsQueryState)
+
+  useHydrateAtoms([
+    [deploymentsListEnvironmentIdAtom, envFilter],
+    [deploymentsListKeywordsAtom, keywords],
+  ] as const, { dangerouslyForceHydrate: true })
+
+  return children
+}
 
 function listDeploymentStatusPollingInterval(data?: InfiniteData<ListAppInstanceSummariesResponse>) {
   const rows = data?.pages?.flatMap(page =>


### PR DESCRIPTION
## Summary

- Replace the deployments list ScopeProvider-based URL mirror with a force-hydrated Jotai boundary.
- Move the common Next route state bridge to wrap the provider tree and force-hydrate route state during render.
- Keep the create release form ScopeProvider inside the dialog portal content so the form store resets when the dialog unmounts.

No linked issue.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This does not apply to typos!)
- [ ] I have added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I have updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Validation:

- `pnpm eslint --cache --fix app/components/next-route-state/atoms.ts app/components/next-route-state/index.tsx app/'(commonLayout)'/layout.tsx features/deployments/create-release/ui/dialog.tsx features/deployments/list/index.tsx features/deployments/list/state/index.ts`
- `pnpm type-check`
- `pnpm test features/deployments/create-release/state/__tests__/index.spec.ts features/deployments/create-release/state/__tests__/dsl-enabled.spec.ts features/deployments/detail/__tests__/state.spec.ts features/deployments/detail/versions-tab/__tests__/state.spec.ts features/deployments/nav/__tests__/state.spec.ts`

From Codex
