### PR TITLE
fix(trace): add explicit ids to Langfuse generation

### DIFF
--- a/api/providers/trace/trace-langfuse/src/dify_trace_langfuse/langfuse_trace.py
+++ b/api/providers/trace/trace-langfuse/src/dify_trace_langfuse/langfuse_trace.py
@@ -357,6 +357,7 @@ class LangFuseDataTrace(BaseTraceInstance):
         )
 
         langfuse_generation_data = LangfuseGeneration(
+            id=str(uuid.uuid4()),
             name="llm",
             trace_id=trace_id,
             start_time=trace_info.start_time,
@@ -405,6 +406,7 @@ class LangFuseDataTrace(BaseTraceInstance):
         )
 
         generation_data = LangfuseGeneration(
+            id=str(uuid.uuid4()),
             name=TraceTaskName.SUGGESTED_QUESTION_TRACE,
             input=trace_info.inputs,
             output=str(trace_info.suggested_question),


### PR DESCRIPTION
## Summary

This PR adds explicit observation IDs to Langfuse generation events created in:

* `message_trace`
* `suggested_question_trace`

## Problem

`add_generation()` sends generation events through the Langfuse ingestion API. When `LangfuseGeneration.id` is not provided, `filter_none_values()` removes the field and the resulting `CreateGenerationBody` is created with `id=None`.

This can result in generation observations being dropped by Langfuse, causing traces to be created without corresponding generation records.

## Changes

* Added `id=str(uuid.uuid4())` to generation creation in `message_trace`
* Added `id=str(uuid.uuid4())` to generation creation in `suggested_question_trace`

## Related

Fixes #37824
