### PR TITLE
fix(notion-extractor): guard against empty table row results

### DIFF
--- a/api/core/rag/extractor/notion_extractor.py
+++ b/api/core/rag/extractor/notion_extractor.py
@@ -303,6 +303,12 @@ class NotionExtractor(BaseExtractor):
                 params=query_dict,
             )
             data = res.json()
+            if not data.get("results"):
+                if data.get("next_cursor") is None:
+                    done = True
+                else:
+                    start_cursor = data["next_cursor"]
+                continue
             # get table headers text
             table_header_cell_texts = []
             table_header_cells = data["results"][0]["table_row"]["cells"]


### PR DESCRIPTION
## Summary

`_read_table_rows()` in `notion_extractor.py` assumed Notion always returns at least one result when fetching table block children. When the API returns an empty `results` array, indexing `data['results'][0]` raised `IndexError`.

This PR adds a guard that skips empty pages and continues pagination instead of crashing.

Fixes #37817

## Changes

- `api/core/rag/extractor/notion_extractor.py`: check `data['results']` is non-empty before accessing the first row; if empty, advance the cursor or mark done and continue