### PR TITLE
fix(web): clamp unit index in formatFileSize/formatTime to avoid undefined unit

### DIFF
--- a/web/utils/format.spec.ts
+++ b/web/utils/format.spec.ts
@@ -64,6 +64,9 @@ describe('formatFileSize', () => {
   it('should format petabytes correctly', () => {
     expect(formatFileSize(1500000000000000)).toBe('1.33 PB')
   })
+  it('should clamp to PB instead of an undefined unit for very large sizes', () => {
+    expect(formatFileSize(1024 ** 6)).toBe('1024.00 PB')
+  })
 })
 describe('formatTime', () => {
   it('should return the input if it is falsy', () => {
@@ -80,6 +83,9 @@ describe('formatTime', () => {
   })
   it('should handle large numbers', () => {
     expect(formatTime(7200)).toBe('2.00 h')
+  })
+  it('should clamp to hours instead of an undefined unit for very large durations', () => {
+    expect(formatTime(216000)).toBe('60.00 h')
   })
 })
 describe('formatNumberAbbreviated', () => {

--- a/web/utils/format.ts
+++ b/web/utils/format.ts
@@ -75,7 +75,7 @@ export const formatFileSize = (fileSize: number) => {
     return fileSize
   const units = ['', 'K', 'M', 'G', 'T', 'P']
   let index = 0
-  while (fileSize >= 1024 && index < units.length) {
+  while (fileSize >= 1024 && index < units.length - 1) {
     fileSize = fileSize / 1024
     index++
   }
@@ -94,7 +94,7 @@ export const formatTime = (seconds: number) => {
     return seconds
   const units = ['sec', 'min', 'h']
   let index = 0
-  while (seconds >= 60 && index < units.length) {
+  while (seconds >= 60 && index < units.length - 1) {
     seconds = seconds / 60
     index++
   }


### PR DESCRIPTION
## Summary

`formatFileSize` and `formatTime` in `web/utils/format.ts` use the loop guard `index < units.length`, which lets `index` advance one past the last unit. For very large inputs the unit becomes `undefined`: `formatFileSize(1024 ** 6)` returns `"1.00 undefinedB"` and `formatTime(216000)` (60h) returns `"1.00 undefined"`.

This changes the guard to `index < units.length - 1` so the index clamps at the last unit (`PB` / `h`), and adds unit tests for both functions.

Fixes #37838

## Screenshots

N/A — no UI change (pure utility functions in `web/utils/format.ts`).

## Checklist

- [ ] This change requires a documentation update
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran the frontend lint (eslint) and the `format.spec.ts` suite (41 passed)

From Claude Code
