### PR TITLE
build(deps): update Bleach sanitizer security fix

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = "~=3.12.0"
 
 dependencies = [
     # Legacy: mature and widely deployed
-    "bleach>=6.3.0,<7.0.0",
+    "bleach>=6.4.0,<7.0.0",
     "boto3>=1.43.24,<2.0.0",
     "celery>=5.6.3,<6.0.0",
     "croniter>=6.2.2,<7.0.0",

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1619,7 +1619,7 @@ vdb-xinference = [
 requires-dist = [
     { name = "aliyun-log-python-sdk", specifier = "==0.9.44" },
     { name = "azure-identity", specifier = ">=1.25.3,<2.0.0" },
-    { name = "bleach", specifier = ">=6.3.0,<7.0.0" },
+    { name = "bleach", specifier = ">=6.4.0,<7.0.0" },
     { name = "boto3", specifier = ">=1.43.24,<2.0.0" },
     { name = "celery", specifier = ">=5.6.3,<6.0.0" },
     { name = "croniter", specifier = ">=6.2.2,<7.0.0" },


### PR DESCRIPTION
This PR updates the API `bleach` dependency lower bound to the advisory-fixed sanitizer release. After rebasing onto current `main`, the previous LangSmith part of this PR is no longer needed because `main` already has `langsmith==0.8.18`.

## Advisory

### `bleach` advisories

- `GHSA-gj48-438w-jh9v`: `clean()` / `Cleaner()` sanitization issue for dangerous URI schemes in allowed `formaction` attributes
- `GHSA-g75f-g53v-794x`: `linkify(parse_email=True)` CPU exhaustion issue
- `GHSA-8rfp-98v4-mmr6`: URI sanitization issue involving Unicode characters above `U+00A0`
- Patched version used here: `6.4.0`
- GitHub advisories:
  - https://github.com/mozilla/bleach/security/advisories/GHSA-gj48-438w-jh9v
  - https://github.com/mozilla/bleach/security/advisories/GHSA-g75f-g53v-794x
  - https://github.com/mozilla/bleach/security/advisories/GHSA-8rfp-98v4-mmr6

## Dependency evidence

`bleach` is part of the API dependency set:

- `api/pyproject.toml`: `bleach>=6.4.0,<7.0.0`
- `api/uv.lock`: the `dify-api` package metadata now requires `bleach>=6.4.0,<7.0.0`
- `api/uv.lock`: the resolved package entry is `bleach==6.4.0`

## Direct code usage

Static usage review outside generated/dependency directories found `bleach` imported by `api/core/workflow/human_input_adapter.py` and used for HTML/text sanitization. This makes the dependency runtime-linked rather than metadata-only.

## What changed

- Raised the API `bleach` lower bound from `>=6.3.0` to `>=6.4.0`.
- Updated the matching `api/uv.lock` `requires-dist` entry.

## What users will see

Expected user-visible behavior change: none. This is dependency remediation for an existing sanitizer dependency.

## Surface area

- Internal / non-user-facing dependency resolution
- Runtime-linked API sanitizer dependency

## Fix choice and alternatives considered

This uses the smallest advisory-fixed version Guardian identified:

- `bleach 6.3.0 -> 6.4.0`: minor jump, moderate compatibility risk because sanitizer behavior can intentionally become stricter.

I did not broaden unrelated dependency ranges or update unrelated packages.

## Validation performed

- Rebased onto current `main` and resolved `api/uv.lock` conflict.
- Confirmed `api/pyproject.toml`, `api/providers/trace/trace-langsmith/pyproject.toml`, and `api/uv.lock` parse as TOML with Python 3.11 `tomllib`.
- Checked the diff with `git diff --check`.
- Performed static usage search for `bleach`.

Validation not run:

- I did not run the full Dify test suite or application services.
- Maintainers should run the normal API dependency lock validation and targeted tests for `human_input_adapter` sanitization behavior.

Powered by Guardian: https://github.com/gateway/guardian
