### PR TITLE
fix(tts): raise clear error when no TTS voice is available

### DIFF
--- a/api/core/base/tts/app_generator_tts_publisher.py
+++ b/api/core/base/tts/app_generator_tts_publisher.py
@@ -65,6 +65,8 @@ class AppGeneratorTTSPublisher:
             tenant_id=self.tenant_id, model_type=ModelType.TTS
         )
         self.voices = self.model_instance.get_tts_voices(language=language)
+        if not self.voices:
+            raise ValueError("Sorry, no voice available.")
         values = [voice.get("value") for voice in self.voices]
         self.voice = voice
         if not voice or voice not in values:

--- a/api/tests/unit_tests/core/base/test_app_generator_tts_publisher.py
+++ b/api/tests/unit_tests/core/base/test_app_generator_tts_publisher.py
@@ -146,6 +146,14 @@ class TestAppGeneratorTTSPublisher:
         publisher = AppGeneratorTTSPublisher("tenant", "invalid_voice")
         assert publisher.voice == "voice1"
 
+    def test_initialization_no_voices_raises(self, mock_model_manager, mock_model_instance):
+        # A TTS model can have no voices for the requested language. The audio tool and
+        # audio_service already guard this and raise "Sorry, no voice available."; the
+        # publisher was the one path that didn't, so it crashed with IndexError on voices[0].
+        mock_model_instance.get_tts_voices.return_value = []
+        with pytest.raises(ValueError, match="Sorry, no voice available."):
+            AppGeneratorTTSPublisher("tenant", "voice1")
+
     def test_publish_puts_message_in_queue(self, mock_model_manager):
         publisher = AppGeneratorTTSPublisher("tenant", "voice1")
         message = MagicMock()


### PR DESCRIPTION
## Summary

`AppGeneratorTTSPublisher.__init__` reads `self.voices[0]` without first checking the list is non-empty:

```python
self.voices = self.model_instance.get_tts_voices(language=language)
values = [voice.get("value") for voice in self.voices]
self.voice = voice
if not voice or voice not in values:
    self.voice = self.voices[0].get("value")   # IndexError when voices == []
```

`get_tts_voices(language=...)` filters the model's voices by language, so a TTS model with no voice for the requested language returns `[]`. When auto-play TTS is enabled, the publisher is constructed unguarded on the streaming path (`advanced_chat` / `workflow` / `easy_ui` task pipelines), so an empty list crashes the whole response with a bare `IndexError` instead of a meaningful error.

The other two places that call `get_tts_voices()` already handle this — both `api/core/tools/builtin_tool/providers/audio/tools/tts.py` and `api/services/audio_service.py` guard the empty case and `raise ValueError("Sorry, no voice available.")`. The publisher was the one path that didn't. This change brings it in line with them.

## Verification

- Added `test_initialization_no_voices_raises` to the existing publisher unit tests. It reproduces the crash on `main` (fails with `IndexError: list index out of range`) and passes with the guard in place.
- `uv run --dev pytest tests/unit_tests/core/base/test_app_generator_tts_publisher.py` → 30 passed.
- `ruff check` and `ruff format --check` clean on the two changed files.

## Screenshots

Not applicable — backend error-handling fix, no UI change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

> Note on the last box: this is backend-only with no public type-surface change. I ran `ruff check` + `ruff format --check` on the two changed files (clean) and the unit tests above; I didn't run the full `make type-check` / web lint locally.

From Claude Code
