### PR TITLE
fix: preserve web app URL port through nginx

### DIFF
--- a/api/tests/unit_tests/test_nginx_proxy_template.py
+++ b/api/tests/unit_tests/test_nginx_proxy_template.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_nginx_proxy_preserves_original_host_header_port():
+    repo_root = Path(__file__).resolve().parents[3]
+    proxy_template = repo_root / "docker" / "nginx" / "proxy.conf.template"
+
+    config = proxy_template.read_text()
+
+    assert "proxy_set_header Host $http_host;" in config
+    assert "proxy_set_header Host $host;" not in config

--- a/docker/nginx/proxy.conf.template
+++ b/docker/nginx/proxy.conf.template
@@ -1,6 +1,6 @@
 # Please do not directly edit this file. Instead, modify the .env variables related to NGINX configuration.
 
-proxy_set_header Host $host;
+proxy_set_header Host $http_host;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $scheme;
 proxy_set_header X-Forwarded-Port $server_port;


### PR DESCRIPTION
## Summary
- Forward Host as $http_host so the original host header including port reaches the backend, with a template regression test.

## Tests
- git diff --check passed
- python3 -m compileall -q api/tests/unit_tests/test_nginx_proxy_template.py passed
- manual direct execution of test_nginx_proxy_template.py passed
- python3 -m pytest api/tests/unit_tests/test_nginx_proxy_template.py -q blocked: pytest missing
- docker compose -f docker/docker-compose.yaml config blocked: docker/.env missing

## Notes
- Related issue: https://github.com/langgenius/dify/issues/37780