### PR TITLE
fix(api): make message history pagination deterministic

### DIFF
--- a/api/services/message_service.py
+++ b/api/services/message_service.py
@@ -2,8 +2,9 @@ import logging
 from collections.abc import Sequence
 from typing import cast
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.sql.elements import ColumnElement
 
 from core.app.apps.advanced_chat.app_config_manager import AdvancedChatAppConfigManager
 from core.app.entities.app_invoke_entities import InvokeFrom
@@ -60,6 +61,13 @@ def attach_message_extra_contents(messages: Sequence[Message]) -> None:
         message.set_extra_contents([content.model_dump(mode="json", exclude_none=True) for content in contents])
 
 
+def _message_before_cursor_condition(cursor_message: Message) -> ColumnElement[bool]:
+    return or_(
+        Message.created_at < cursor_message.created_at,
+        (Message.created_at == cursor_message.created_at) & (Message.id < cursor_message.id),
+    )
+
+
 class MessageService:
     @classmethod
     def pagination_by_first_id(
@@ -95,17 +103,16 @@ class MessageService:
                 select(Message)
                 .where(
                     Message.conversation_id == conversation.id,
-                    Message.created_at < first_message.created_at,
-                    Message.id != first_message.id,
+                    _message_before_cursor_condition(first_message),
                 )
-                .order_by(Message.created_at.desc())
+                .order_by(Message.created_at.desc(), Message.id.desc())
                 .limit(fetch_limit)
             ).all()
         else:
             history_messages = db.session.scalars(
                 select(Message)
                 .where(Message.conversation_id == conversation.id)
-                .order_by(Message.created_at.desc())
+                .order_by(Message.created_at.desc(), Message.id.desc())
                 .limit(fetch_limit)
             ).all()
 
@@ -158,12 +165,14 @@ class MessageService:
                 raise LastMessageNotExistsError()
 
             history_messages = db.session.scalars(
-                stmt.where(Message.created_at < last_message.created_at, Message.id != last_message.id)
-                .order_by(Message.created_at.desc())
+                stmt.where(_message_before_cursor_condition(last_message))
+                .order_by(Message.created_at.desc(), Message.id.desc())
                 .limit(fetch_limit)
             ).all()
         else:
-            history_messages = db.session.scalars(stmt.order_by(Message.created_at.desc()).limit(fetch_limit)).all()
+            history_messages = db.session.scalars(
+                stmt.order_by(Message.created_at.desc(), Message.id.desc()).limit(fetch_limit)
+            ).all()
 
         has_more = False
         if len(history_messages) > limit:

--- a/api/tests/unit_tests/services/test_message_service.py
+++ b/api/tests/unit_tests/services/test_message_service.py
@@ -1,13 +1,19 @@
 import json
 from datetime import datetime
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
+from sqlalchemy import Table, create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
 
 from graphon.model_runtime.entities.model_entities import ModelType
 from libs.infinite_scroll_pagination import InfiniteScrollPagination
-from models.enums import FeedbackFromSource, FeedbackRating
-from models.model import App, AppMode, EndUser, Message
+from models.enums import FeedbackFromSource, FeedbackRating, MessageStatus
+from models.model import App, AppMode, ConversationFromSource, EndUser, Message
 from services.errors.message import (
     FirstMessageNotExistsError,
     LastMessageNotExistsError,
@@ -15,6 +21,12 @@ from services.errors.message import (
     SuggestedQuestionsAfterAnswerDisabledError,
 )
 from services.message_service import MessageService, attach_message_extra_contents
+
+
+def _create_message_table(engine: Engine):
+    message_table = Message.__table__
+    assert isinstance(message_table, Table)
+    message_table.create(engine)
 
 
 class TestMessageServiceFactory:
@@ -25,24 +37,24 @@ class TestMessageServiceFactory:
         app_id: str = "app-123",
         mode: str = AppMode.ADVANCED_CHAT.value,
         name: str = "Test App",
-    ) -> MagicMock:
+    ) -> App:
         """Create a mock App object."""
         app = MagicMock(spec=App)
         app.id = app_id
         app.mode = mode
         app.name = name
-        return app
+        return cast(App, app)
 
     @staticmethod
     def create_end_user_mock(
         user_id: str = "user-456",
         session_id: str = "session-789",
-    ) -> MagicMock:
+    ) -> EndUser:
         """Create a mock EndUser object."""
         user = MagicMock(spec=EndUser)
         user.id = user_id
         user.session_id = session_id
-        return user
+        return cast(EndUser, user)
 
     @staticmethod
     def create_conversation_mock(
@@ -88,6 +100,42 @@ class TestMessageServicePaginationByFirstId:
     def factory(self):
         """Provide test data factory."""
         return TestMessageServiceFactory()
+
+    @pytest.fixture
+    def sqlite_session(self):
+        engine = create_engine("sqlite:///:memory:")
+        _create_message_table(engine)
+        with Session(engine) as session:
+            yield session
+        engine.dispose()
+
+    @staticmethod
+    def _seed_messages_with_same_timestamp(session: Session):
+        created_at = datetime(2024, 1, 1, 12, 0, 0)
+        session.add_all(
+            [
+                Message(
+                    id=f"msg-{index:03d}",
+                    app_id="app-123",
+                    conversation_id="conv-001",
+                    _inputs={},
+                    query=f"query-{index}",
+                    message={},
+                    message_unit_price=Decimal(0),
+                    answer=f"answer-{index}",
+                    answer_unit_price=Decimal(0),
+                    total_price=Decimal(0),
+                    currency="USD",
+                    status=MessageStatus.NORMAL,
+                    from_source=ConversationFromSource.API,
+                    created_at=created_at,
+                    updated_at=created_at,
+                    app_mode=AppMode.CHAT,
+                )
+                for index in range(1, 5)
+            ]
+        )
+        session.commit()
 
     # Test 01: No user provided
     def test_pagination_by_first_id_no_user(self, factory: TestMessageServiceFactory):
@@ -360,6 +408,35 @@ class TestMessageServicePaginationByFirstId:
         assert result.has_more is False
         assert result.limit == 10
 
+    def test_pagination_by_first_id_keeps_same_timestamp_rows(
+        self,
+        sqlite_session: Session,
+        factory: TestMessageServiceFactory,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        self._seed_messages_with_same_timestamp(sqlite_session)
+
+        monkeypatch.setattr("services.message_service.db", SimpleNamespace(session=sqlite_session))
+        monkeypatch.setattr(
+            "services.message_service.ConversationService.get_conversation",
+            lambda **_kwargs: SimpleNamespace(id="conv-001"),
+        )
+        monkeypatch.setattr(
+            "services.message_service._create_execution_extra_content_repository",
+            lambda: SimpleNamespace(get_by_message_ids=lambda message_ids: [[] for _ in message_ids]),
+        )
+
+        result = MessageService.pagination_by_first_id(
+            app_model=factory.create_app_mock(),
+            user=factory.create_end_user_mock(),
+            conversation_id="conv-001",
+            first_id="msg-003",
+            limit=2,
+        )
+
+        assert [message.id for message in result.data] == ["msg-001", "msg-002"]
+        assert result.has_more is False
+
 
 class TestMessageServicePaginationByLastId:
     """
@@ -376,6 +453,42 @@ class TestMessageServicePaginationByLastId:
     def factory(self):
         """Provide test data factory."""
         return TestMessageServiceFactory()
+
+    @pytest.fixture
+    def sqlite_session(self):
+        engine = create_engine("sqlite:///:memory:")
+        _create_message_table(engine)
+        with Session(engine) as session:
+            yield session
+        engine.dispose()
+
+    @staticmethod
+    def _seed_messages_with_same_timestamp(session: Session):
+        created_at = datetime(2024, 1, 1, 12, 0, 0)
+        session.add_all(
+            [
+                Message(
+                    id=f"msg-{index:03d}",
+                    app_id="app-123",
+                    conversation_id="conv-001",
+                    _inputs={},
+                    query=f"query-{index}",
+                    message={},
+                    message_unit_price=Decimal(0),
+                    answer=f"answer-{index}",
+                    answer_unit_price=Decimal(0),
+                    total_price=Decimal(0),
+                    currency="USD",
+                    status=MessageStatus.NORMAL,
+                    from_source=ConversationFromSource.API,
+                    created_at=created_at,
+                    updated_at=created_at,
+                    app_mode=AppMode.CHAT,
+                )
+                for index in range(1, 5)
+            ]
+        )
+        session.commit()
 
     # Test 09: No user provided
     def test_pagination_by_last_id_no_user(self, factory: TestMessageServiceFactory):
@@ -584,6 +697,27 @@ class TestMessageServicePaginationByLastId:
         assert len(result.data) == 10  # Last message trimmed
         assert result.has_more is True
         assert result.limit == 10
+
+    def test_pagination_by_last_id_keeps_same_timestamp_rows(
+        self,
+        sqlite_session: Session,
+        factory: TestMessageServiceFactory,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        self._seed_messages_with_same_timestamp(sqlite_session)
+
+        monkeypatch.setattr("services.message_service.db", SimpleNamespace(session=sqlite_session))
+
+        result = MessageService.pagination_by_last_id(
+            app_model=factory.create_app_mock(),
+            user=factory.create_end_user_mock(),
+            last_id="msg-003",
+            limit=2,
+            conversation_id=None,
+        )
+
+        assert [message.id for message in result.data] == ["msg-002", "msg-001"]
+        assert result.has_more is False
 
 
 class TestMessageServiceUtilities:


### PR DESCRIPTION
## Summary

Fixes #35996.

Message history pagination used `created_at < cursor.created_at` as the only cursor condition while ordering only by `created_at desc`. When multiple API-created messages share the same timestamp, the next page skips the remaining rows with that timestamp, so history appears to lose records.

This PR makes message pagination deterministic by:
- ordering message history pages by `created_at desc, id desc`
- using a matching cursor predicate for rows before the current cursor: older timestamp, or same timestamp with a smaller id
- covering both `first_id` and `last_id` pagination paths with SQLite-backed regression tests using same-timestamp messages

Pre-PR duplicate check: #35996 is open, unassigned, PR search for `35996` returned 0 results, and no issue comments indicated an owner or existing fix.

## Screenshots

| Before | After |
|--------|-------|
| N/A - backend pagination fix | N/A - backend pagination fix |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Validation performed:
- `uv run --project api --no-sync pytest --no-cov api/tests/unit_tests/services/test_message_service.py`
- `uv run --project api --no-sync ruff format --check api/services/message_service.py api/tests/unit_tests/services/test_message_service.py`
- `uv run --project api --no-sync ruff check api/services/message_service.py api/tests/unit_tests/services/test_message_service.py`

- `uv run --project api --no-sync pyrefly check api/tests/unit_tests/services/test_message_service.py`

From Codex