### PR TITLE
fix(api): keep workflow log cleanup in one transaction

### DIFF
--- a/api/repositories/api_workflow_run_repository.py
+++ b/api/repositories/api_workflow_run_repository.py
@@ -401,6 +401,20 @@ class APIWorkflowRunRepository(WorkflowExecutionRepository, Protocol):
         """
         ...
 
+    def delete_runs_with_related_in_session(
+        self,
+        session: Session,
+        runs: Sequence[WorkflowRun],
+        delete_node_executions: Callable[[Session, Sequence[WorkflowRun]], tuple[int, int]] | None = None,
+        delete_trigger_logs: Callable[[Session, Sequence[str]], int] | None = None,
+    ) -> RunsWithRelatedCountsDict:
+        """
+        Delete workflow runs and related records using the caller-owned transaction.
+
+        The implementation must not commit or roll back the supplied session.
+        """
+        ...
+
     def get_pause_records_by_run_id(
         self,
         session: Session,

--- a/api/repositories/sqlalchemy_api_workflow_run_repository.py
+++ b/api/repositories/sqlalchemy_api_workflow_run_repository.py
@@ -593,56 +593,38 @@ class DifyAPISQLAlchemyWorkflowRunRepository(APIWorkflowRunRepository):
         delete_node_executions: Callable[[Session, Sequence[WorkflowRun]], tuple[int, int]] | None = None,
         delete_trigger_logs: Callable[[Session, Sequence[str]], int] | None = None,
     ) -> RunsWithRelatedCountsDict:
+        with self._session_maker.begin() as session:
+            return self.delete_runs_with_related_in_session(
+                session,
+                runs,
+                delete_node_executions=delete_node_executions,
+                delete_trigger_logs=delete_trigger_logs,
+            )
+
+    @override
+    def delete_runs_with_related_in_session(
+        self,
+        session: Session,
+        runs: Sequence[WorkflowRun],
+        delete_node_executions: Callable[[Session, Sequence[WorkflowRun]], tuple[int, int]] | None = None,
+        delete_trigger_logs: Callable[[Session, Sequence[str]], int] | None = None,
+    ) -> RunsWithRelatedCountsDict:
         if not runs:
-            return {
-                "runs": 0,
-                "node_executions": 0,
-                "offloads": 0,
-                "app_logs": 0,
-                "trigger_logs": 0,
-                "pauses": 0,
-                "pause_reasons": 0,
-            }
+            return self._empty_runs_with_related_counts()
 
-        with self._session_maker() as session:
-            run_ids = [run.id for run in runs]
-            if delete_node_executions:
-                node_executions_deleted, offloads_deleted = delete_node_executions(session, runs)
-            else:
-                node_executions_deleted, offloads_deleted = 0, 0
+        runs = list(runs)
 
-            app_logs_result = session.execute(delete(WorkflowAppLog).where(WorkflowAppLog.workflow_run_id.in_(run_ids)))
-            app_logs_deleted = cast(CursorResult, app_logs_result).rowcount or 0
+        def delete_node_executions_by_ids(active_session: Session, _run_ids: Sequence[str]) -> tuple[int, int]:
+            if delete_node_executions is None:
+                return 0, 0
+            return delete_node_executions(active_session, runs)
 
-            pause_stmt = select(WorkflowPause.id).where(WorkflowPause.workflow_run_id.in_(run_ids))
-            pause_ids = session.scalars(pause_stmt).all()
-            pause_reasons_deleted = 0
-            pauses_deleted = 0
-
-            if pause_ids:
-                pause_reasons_result = session.execute(
-                    delete(WorkflowPauseReason).where(WorkflowPauseReason.pause_id.in_(pause_ids))
-                )
-                pause_reasons_deleted = cast(CursorResult, pause_reasons_result).rowcount or 0
-                pauses_result = session.execute(delete(WorkflowPause).where(WorkflowPause.id.in_(pause_ids)))
-                pauses_deleted = cast(CursorResult, pauses_result).rowcount or 0
-
-            trigger_logs_deleted = delete_trigger_logs(session, run_ids) if delete_trigger_logs else 0
-
-            runs_result = session.execute(delete(WorkflowRun).where(WorkflowRun.id.in_(run_ids)))
-            runs_deleted = cast(CursorResult, runs_result).rowcount or 0
-
-            session.commit()
-
-            return {
-                "runs": runs_deleted,
-                "node_executions": node_executions_deleted,
-                "offloads": offloads_deleted,
-                "app_logs": app_logs_deleted,
-                "trigger_logs": trigger_logs_deleted,
-                "pauses": pauses_deleted,
-                "pause_reasons": pause_reasons_deleted,
-            }
+        return self._delete_runs_with_related_by_ids_in_session(
+            session,
+            [run.id for run in runs],
+            delete_node_executions=delete_node_executions_by_ids if delete_node_executions else None,
+            delete_trigger_logs=delete_trigger_logs,
+        )
 
     @override
     def delete_runs_with_related_by_ids(
@@ -651,48 +633,60 @@ class DifyAPISQLAlchemyWorkflowRunRepository(APIWorkflowRunRepository):
         delete_node_executions: Callable[[Session, Sequence[str]], tuple[int, int]] | None = None,
         delete_trigger_logs: Callable[[Session, Sequence[str]], int] | None = None,
     ) -> RunsWithRelatedCountsDict:
+        with self._session_maker.begin() as session:
+            return self._delete_runs_with_related_by_ids_in_session(
+                session,
+                run_ids,
+                delete_node_executions=delete_node_executions,
+                delete_trigger_logs=delete_trigger_logs,
+            )
+
+    def _delete_runs_with_related_by_ids_in_session(
+        self,
+        session: Session,
+        run_ids: Sequence[str],
+        delete_node_executions: Callable[[Session, Sequence[str]], tuple[int, int]] | None = None,
+        delete_trigger_logs: Callable[[Session, Sequence[str]], int] | None = None,
+    ) -> RunsWithRelatedCountsDict:
         if not run_ids:
             return self._empty_runs_with_related_counts()
 
         run_ids = list(run_ids)
-        with self._session_maker() as session:
-            if delete_node_executions:
-                node_executions_deleted, offloads_deleted = delete_node_executions(session, run_ids)
-            else:
-                node_executions_deleted, offloads_deleted = 0, 0
+        if delete_node_executions:
+            node_executions_deleted, offloads_deleted = delete_node_executions(session, run_ids)
+        else:
+            node_executions_deleted, offloads_deleted = 0, 0
 
-            app_logs_result = session.execute(delete(WorkflowAppLog).where(WorkflowAppLog.workflow_run_id.in_(run_ids)))
-            app_logs_deleted = cast(CursorResult, app_logs_result).rowcount or 0
+        app_logs_result = session.execute(delete(WorkflowAppLog).where(WorkflowAppLog.workflow_run_id.in_(run_ids)))
+        app_logs_deleted = cast(CursorResult, app_logs_result).rowcount or 0
 
-            pause_stmt = select(WorkflowPause.id).where(WorkflowPause.workflow_run_id.in_(run_ids))
-            pause_ids = session.scalars(pause_stmt).all()
-            pause_reasons_deleted = 0
-            pauses_deleted = 0
+        pause_stmt = select(WorkflowPause.id).where(WorkflowPause.workflow_run_id.in_(run_ids))
+        pause_ids = session.scalars(pause_stmt).all()
+        pause_reasons_deleted = 0
+        pauses_deleted = 0
 
-            if pause_ids:
-                pause_reasons_result = session.execute(
-                    delete(WorkflowPauseReason).where(WorkflowPauseReason.pause_id.in_(pause_ids))
-                )
-                pause_reasons_deleted = cast(CursorResult, pause_reasons_result).rowcount or 0
-                pauses_result = session.execute(delete(WorkflowPause).where(WorkflowPause.id.in_(pause_ids)))
-                pauses_deleted = cast(CursorResult, pauses_result).rowcount or 0
+        if pause_ids:
+            pause_reasons_result = session.execute(
+                delete(WorkflowPauseReason).where(WorkflowPauseReason.pause_id.in_(pause_ids))
+            )
+            pause_reasons_deleted = cast(CursorResult, pause_reasons_result).rowcount or 0
+            pauses_result = session.execute(delete(WorkflowPause).where(WorkflowPause.id.in_(pause_ids)))
+            pauses_deleted = cast(CursorResult, pauses_result).rowcount or 0
 
-            trigger_logs_deleted = delete_trigger_logs(session, run_ids) if delete_trigger_logs else 0
+        trigger_logs_deleted = delete_trigger_logs(session, run_ids) if delete_trigger_logs else 0
 
-            runs_result = session.execute(delete(WorkflowRun).where(WorkflowRun.id.in_(run_ids)))
-            runs_deleted = cast(CursorResult, runs_result).rowcount or 0
+        runs_result = session.execute(delete(WorkflowRun).where(WorkflowRun.id.in_(run_ids)))
+        runs_deleted = cast(CursorResult, runs_result).rowcount or 0
 
-            session.commit()
-
-            return {
-                "runs": runs_deleted,
-                "node_executions": node_executions_deleted,
-                "offloads": offloads_deleted,
-                "app_logs": app_logs_deleted,
-                "trigger_logs": trigger_logs_deleted,
-                "pauses": pauses_deleted,
-                "pause_reasons": pause_reasons_deleted,
-            }
+        return {
+            "runs": runs_deleted,
+            "node_executions": node_executions_deleted,
+            "offloads": offloads_deleted,
+            "app_logs": app_logs_deleted,
+            "trigger_logs": trigger_logs_deleted,
+            "pauses": pauses_deleted,
+            "pause_reasons": pause_reasons_deleted,
+        }
 
     @override
     def get_app_logs_by_run_id(

--- a/api/schedule/clean_workflow_runlogs_precise.py
+++ b/api/schedule/clean_workflow_runlogs_precise.py
@@ -155,7 +155,8 @@ def _delete_batch(
                 trigger_repo = SQLAlchemyWorkflowTriggerLogRepository(active_session)
                 return trigger_repo.delete_by_run_ids(run_ids)
 
-            workflow_run_repo.delete_runs_with_related(
+            workflow_run_repo.delete_runs_with_related_in_session(
+                session,
                 workflow_runs,
                 delete_node_executions=_delete_node_executions,
                 delete_trigger_logs=_delete_trigger_logs,

--- a/api/tests/unit_tests/schedule/test_clean_workflow_runlogs_precise.py
+++ b/api/tests/unit_tests/schedule/test_clean_workflow_runlogs_precise.py
@@ -1,0 +1,118 @@
+import sys
+from collections.abc import Callable, Iterator
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _NestedTransaction:
+    entered: bool
+    exited: bool
+
+    def __init__(self) -> None:
+        self.entered = False
+        self.exited = False
+
+    def __enter__(self) -> None:
+        self.entered = True
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: object | None,
+    ) -> bool:
+        self.exited = True
+        return False
+
+
+class _ExecuteResult:
+    rows: list[object]
+
+    def __init__(self, rows: list[object] | None = None) -> None:
+        self.rows = rows or []
+
+    def all(self) -> list[object]:
+        return self.rows
+
+
+class _CeleryStub:
+    def task(self, *_args: object, **_kwargs: object) -> Callable[[Callable[..., object]], Callable[..., object]]:
+        def decorator(func: Callable[..., object]) -> Callable[..., object]:
+            return func
+
+        return decorator
+
+
+def _load_cleanup_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    app_stub = ModuleType("app")
+    app_stub.celery = _CeleryStub()
+    monkeypatch.setitem(sys.modules, "app", app_stub)
+    sys.modules.pop("schedule.clean_workflow_runlogs_precise", None)
+
+    from schedule import clean_workflow_runlogs_precise as cleanup_module
+
+    return cleanup_module
+
+
+@pytest.fixture
+def cleanup_module(monkeypatch: pytest.MonkeyPatch) -> Iterator[ModuleType]:
+    yield _load_cleanup_module(monkeypatch)
+    sys.modules.pop("schedule.clean_workflow_runlogs_precise", None)
+
+
+def test_delete_batch_deletes_workflow_runs_with_the_caller_session(
+    cleanup_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cleanup = cleanup_module
+    session = MagicMock()
+    nested_transaction = _NestedTransaction()
+    session.begin_nested.return_value = nested_transaction
+    session.get_bind.return_value = object()
+    session.execute.side_effect = [
+        _ExecuteResult([SimpleNamespace(id="message-1", conversation_id="conversation-1")]),
+        *[_ExecuteResult() for _ in range(11)],
+    ]
+
+    node_execution_repo = MagicMock()
+    node_execution_repo.delete_by_runs.return_value = (2, 1)
+    trigger_log_repo = MagicMock()
+    trigger_log_repo.delete_by_run_ids.return_value = 3
+    monkeypatch.setattr(
+        cleanup.DifyAPIRepositoryFactory,
+        "create_api_workflow_node_execution_repository",
+        lambda *_args, **_kwargs: node_execution_repo,
+    )
+    monkeypatch.setattr(cleanup, "SQLAlchemyWorkflowTriggerLogRepository", lambda _active_session: trigger_log_repo)
+
+    workflow_runs = [SimpleNamespace(id="workflow-run-1")]
+    workflow_run_repo = MagicMock()
+    captured: dict[str, object] = {}
+
+    def delete_runs_with_related_in_session(
+        active_session: object,
+        runs: list[SimpleNamespace],
+        delete_node_executions: Callable[[object, list[SimpleNamespace]], tuple[int, int]],
+        delete_trigger_logs: Callable[[object, list[str]], int],
+    ) -> dict[str, int]:
+        captured["session"] = active_session
+        captured["runs"] = runs
+        captured["node_execution_counts"] = delete_node_executions(active_session, runs)
+        captured["trigger_log_count"] = delete_trigger_logs(active_session, ["workflow-run-1"])
+        return {"runs": 1}
+
+    workflow_run_repo.delete_runs_with_related_in_session.side_effect = delete_runs_with_related_in_session
+
+    assert cleanup._delete_batch(session, workflow_run_repo, workflow_runs, attempt_count=0) is True
+
+    assert nested_transaction.entered is True
+    assert nested_transaction.exited is True
+    assert captured["session"] is session
+    assert captured["runs"] == workflow_runs
+    assert captured["node_execution_counts"] == (2, 1)
+    assert captured["trigger_log_count"] == 3
+    workflow_run_repo.delete_runs_with_related_in_session.assert_called_once()
+    workflow_run_repo.delete_runs_with_related.assert_not_called()
+    node_execution_repo.delete_by_runs.assert_called_once_with(session, ["workflow-run-1"])
+    trigger_log_repo.delete_by_run_ids.assert_called_once_with(["workflow-run-1"])


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #36473

- Keep precise workflow log cleanup deletion inside the caller-owned batch transaction.
- Add a repository path for deleting workflow runs and related rows with an existing SQLAlchemy session, while preserving the existing public methods for other callers.
- Add unit coverage to ensure precise cleanup deletes message cascade rows and workflow-run related rows through the same session.

Duplicate check before opening:
- #36473 is open and unassigned.
- GitHub PR search for `repo:langgenius/dify is:pr 36473` returned 0 results.
- Non-bot issue comments did not show an owner, linked PR, or in-progress fix.

Validation:
- `uv run --project api --no-sync ruff check api/repositories/api_workflow_run_repository.py api/repositories/sqlalchemy_api_workflow_run_repository.py api/schedule/clean_workflow_runlogs_precise.py api/tests/unit_tests/schedule/test_clean_workflow_runlogs_precise.py`
- `uv run --project api --no-sync pytest --no-cov api/tests/unit_tests/schedule/test_clean_workflow_runlogs_precise.py api/tests/unit_tests/services/test_clear_free_plan_expired_workflow_run_logs.py api/tests/unit_tests/services/retention/workflow_run/test_clear_free_plan_expired_workflow_run_logs.py`

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Codex