### PR TITLE
fix(api): accept structured plugin finish reasons

### DIFF
--- a/api/core/plugin/impl/base.py
+++ b/api/core/plugin/impl/base.py
@@ -277,7 +277,7 @@ class BasePluginClient:
             rep = PluginDaemonBasicResponse[type_].model_validate(json_response)  # type: ignore
         except Exception:
             msg = (
-                f"Failed to parse response from plugin daemon to PluginDaemonBasicResponse [{str(type_.__name__)}],"
+                f"Failed to parse response from plugin daemon to PluginDaemonBasicResponse [{type_.__name__}],"
                 f" url: {path}"
             )
             logger.exception(msg)
@@ -305,13 +305,18 @@ class BasePluginClient:
         data: bytes | dict[str, Any] | None = None,
         params: dict[str, Any] | None = None,
         files: dict[str, Any] | None = None,
+        transformer: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
     ) -> Generator[T, None, None]:
         """
         Make a stream request to the plugin daemon inner API and yield the response as a model.
         """
         for line in self._stream_request(method, path, params, headers, data, files):
             try:
-                rep = PluginDaemonBasicResponse[type_].model_validate_json(line)  # type: ignore
+                if transformer:
+                    line_data = transformer(json.loads(line))
+                    rep = PluginDaemonBasicResponse[type_].model_validate(line_data)  # type: ignore
+                else:
+                    rep = PluginDaemonBasicResponse[type_].model_validate_json(line)  # type: ignore
             except (ValueError, TypeError):
                 # TODO modify this when line_data has code and message
                 try:

--- a/api/core/plugin/impl/model.py
+++ b/api/core/plugin/impl/model.py
@@ -25,6 +25,24 @@ _POLLING_UNSUPPORTED_INVOKE_ERROR_TYPES = frozenset((NotImplementedError.__name_
 _POLLING_UNSUPPORTED_ERROR_MESSAGE = "does not support polling"
 
 
+def _normalize_llm_chunk_finish_reason(response_frame: dict[str, Any]) -> dict[str, Any]:
+    data = response_frame.get("data")
+    if not isinstance(data, dict):
+        return response_frame
+
+    delta = data.get("delta")
+    if not isinstance(delta, dict):
+        return response_frame
+
+    finish_reason = delta.get("finish_reason")
+    if isinstance(finish_reason, dict):
+        finish_type = finish_reason.get("type")
+        if isinstance(finish_type, str):
+            delta["finish_reason"] = finish_type
+
+    return response_frame
+
+
 class PluginModelClient(BasePluginClient):
     @staticmethod
     def _dispatch_payload(*, user_id: str | None, data: dict[str, Any]) -> dict[str, Any]:
@@ -194,6 +212,7 @@ class PluginModelClient(BasePluginClient):
                 "X-Plugin-ID": plugin_id,
                 "Content-Type": "application/json",
             },
+            transformer=_normalize_llm_chunk_finish_reason,
         )
 
         try:

--- a/api/tests/unit_tests/core/plugin/impl/test_model_client.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_model_client.py
@@ -164,6 +164,47 @@ class TestPluginModelClient:
         assert call_kwargs["path"] == "plugin/tenant-1/dispatch/llm/invoke"
         assert call_kwargs["data"]["data"]["stream"] is False
         assert call_kwargs["data"]["data"]["model_parameters"] == {"temperature": 0.1}
+        assert call_kwargs["transformer"] is not None
+
+    def test_invoke_llm_normalizes_object_finish_reason_from_plugin_daemon(self, mocker: MockerFixture):
+        client = PluginModelClient()
+        mocker.patch.object(
+            client,
+            "_stream_request",
+            return_value=iter(
+                [
+                    json.dumps(
+                        {
+                            "code": 0,
+                            "message": "",
+                            "data": {
+                                "model": "qwen3",
+                                "prompt_messages": [],
+                                "delta": {
+                                    "index": 0,
+                                    "message": {"role": "assistant", "content": "done", "name": None},
+                                    "finish_reason": {"type": "length", "length": 512},
+                                },
+                            },
+                        }
+                    )
+                ]
+            ),
+        )
+
+        result = list(
+            client.invoke_llm(
+                tenant_id="tenant-1",
+                user_id="user-1",
+                plugin_id="org/plugin:1",
+                provider="provider-a",
+                model="qwen3",
+                credentials={"api_key": "key"},
+                prompt_messages=[],
+            )
+        )
+
+        assert result[0].delta.finish_reason == "length"
 
     def test_invoke_llm_wraps_plugin_daemon_inner_error(self, mocker: MockerFixture):
         client = PluginModelClient()
@@ -449,8 +490,8 @@ class TestPluginModelClient:
             provider="provider-a",
             model="rerank-a",
             credentials={},
-            query={"type": "text", "value": "q"},
-            docs=[{"type": "image", "value": "doc"}],
+            query={"content_type": "text", "content": "q"},
+            docs=[{"content_type": "image", "content": "doc"}],
             score_threshold=0.1,
             top_n=3,
         )
@@ -469,8 +510,8 @@ class TestPluginModelClient:
                 "provider-a",
                 "rerank-a",
                 {},
-                {"type": "text"},
-                [{"type": "image"}],
+                {"content_type": "text", "content": "q"},
+                [{"content_type": "image", "content": "doc"}],
             )
 
     def test_invoke_tts(self, mocker: MockerFixture):


### PR DESCRIPTION
## Summary
- Normalize plugin LLM stream frames where `delta.finish_reason` arrives as a provider-specific object such as `{ "type": "length", "length": 512 }` before validating them as `LLMResultChunk`.
- Keep the core runtime contract unchanged: downstream code still receives a string finish reason (`"length"`, `"stop"`, etc.).
- Refresh multimodal rerank test fixtures to the current `MultimodalRerankInput` typed-dict shape so the touched test module remains pyrefly-clean.

Fixes #36196

## Duplicate / ownership check
- Issue #36196 is open and has no assignees.
- PR search for `repo:langgenius/dify type:pr "#36196"` returned 0 results.
- Issue comments showed no non-bot work-in-progress or PR ownership signal.

## Tests
- `uv run --project api --no-sync pytest --no-cov api/tests/unit_tests/core/plugin/impl/test_model_client.py api/tests/unit_tests/core/plugin/impl/test_base_client_impl.py`
- `uv run --project api --no-sync ruff check api/core/plugin/impl/base.py api/core/plugin/impl/model.py api/tests/unit_tests/core/plugin/impl/test_model_client.py`
- `uv run --project api --no-sync ruff format --check api/core/plugin/impl/base.py api/core/plugin/impl/model.py api/tests/unit_tests/core/plugin/impl/test_model_client.py`
- `uv run --project api --no-sync pyrefly check api/core/plugin/impl/base.py api/core/plugin/impl/model.py api/tests/unit_tests/core/plugin/impl/test_model_client.py`

From Codex.