### PR TITLE
fix(api): preserve remote upload file references

### DIFF
--- a/api/core/file/remote_fetcher.py
+++ b/api/core/file/remote_fetcher.py
@@ -74,6 +74,42 @@ def make_request(method: str, url: str, max_retries: int = SSRF_DEFAULT_MAX_RETR
     return ssrf_proxy.make_request(method=method, url=url, max_retries=max_retries, **kwargs)
 
 
+def resolve_signed_upload_file_id(url: str) -> str | None:
+    """Resolve a valid Dify upload preview URL back to its UploadFile id.
+
+    File-upload UI flows may round-trip the signed preview URL as a
+    ``remote_url`` input. Returning the backing record id lets file factories
+    preserve storage-backed file references for workflow nodes that need file
+    bytes, while forged, expired, tool, or datasource URLs continue through the
+    normal remote URL path.
+    """
+
+    parsed_url = urllib.parse.urlparse(url)
+    if not _is_dify_file_origin(parsed_url):
+        return None
+
+    signed_file_url = _parse_signed_file_path(parsed_url.path)
+    if signed_file_url is None or signed_file_url.record_kind != "upload":
+        return None
+
+    query = urllib.parse.parse_qs(parsed_url.query, keep_blank_values=True)
+    timestamp = _single_query_value(query, "timestamp")
+    nonce = _single_query_value(query, "nonce")
+    sign = _single_query_value(query, "sign")
+    if timestamp is None or nonce is None or sign is None:
+        return None
+
+    if not _verify_signed_file_url(
+        signed_file_url=signed_file_url,
+        timestamp=timestamp,
+        nonce=nonce,
+        sign=sign,
+    ):
+        return None
+
+    return signed_file_url.file_id
+
+
 class GraphonRemoteFileFetcher:
     """Graphon HTTP-client adapter backed by the unified remote-file fetcher.
 

--- a/api/factories/file_factory/builders.py
+++ b/api/factories/file_factory/builders.py
@@ -11,6 +11,7 @@ from sqlalchemy import select
 
 from core.app.file_access import FileAccessControllerProtocol
 from core.db.session_factory import session_factory
+from core.file import remote_fetcher
 from core.workflow.file_reference import build_file_reference
 from graphon.file import File, FileTransferMethod, FileType, FileUploadConfig, helpers, standardize_file_type
 from models import ToolFile, UploadFile
@@ -227,7 +228,7 @@ def _build_from_local_file(
             file_type=file_type,
             transfer_method=transfer_method,
             remote_url=row.source_url,
-            reference=build_file_reference(record_id=str(row.id)),
+            reference=build_file_reference(record_id=row.id),
             size=row.size,
             storage_key=row.key,
         )
@@ -242,6 +243,11 @@ def _build_from_remote_url(
     access_controller: FileAccessControllerProtocol,
 ) -> File:
     upload_file_id = resolve_mapping_file_id(mapping, "upload_file_id")
+    url = mapping.get("url") or mapping.get("remote_url")
+    if not upload_file_id:
+        if isinstance(url, str):
+            upload_file_id = remote_fetcher.resolve_signed_upload_file_id(url)
+
     if upload_file_id:
         try:
             uuid.UUID(upload_file_id)
@@ -266,6 +272,7 @@ def _build_from_remote_url(
                 specified_type=mapping.get("type"),
                 strict_type_validation=strict_type_validation,
             )
+            remote_url = upload_file.source_url or (url if isinstance(url, str) else None)
 
             return File(
                 file_id=mapping.get("id"),
@@ -274,13 +281,12 @@ def _build_from_remote_url(
                 mime_type=upload_file.mime_type,
                 file_type=file_type,
                 transfer_method=transfer_method,
-                remote_url=helpers.get_signed_file_url(upload_file_id=str(upload_file_id)),
-                reference=build_file_reference(record_id=str(upload_file.id)),
+                remote_url=remote_url or helpers.get_signed_file_url(upload_file_id=upload_file_id),
+                reference=build_file_reference(record_id=upload_file.id),
                 size=upload_file.size,
                 storage_key=upload_file.key,
             )
 
-    url = mapping.get("url") or mapping.get("remote_url")
     if not url:
         raise ValueError("Invalid file url")
 
@@ -340,7 +346,7 @@ def _build_from_tool_file(
             file_type=file_type,
             transfer_method=transfer_method,
             remote_url=tool_file.original_url,
-            reference=build_file_reference(record_id=str(tool_file.id)),
+            reference=build_file_reference(record_id=tool_file.id),
             extension=extension,
             mime_type=tool_file.mimetype,
             size=tool_file.size,
@@ -383,7 +389,7 @@ def _build_from_datasource_file(
             file_type=file_type,
             transfer_method=transfer_method,
             remote_url=datasource_file.source_url,
-            reference=build_file_reference(record_id=str(datasource_file.id)),
+            reference=build_file_reference(record_id=datasource_file.id),
             extension=extension,
             mime_type=datasource_file.mime_type,
             size=datasource_file.size,

--- a/api/tests/unit_tests/core/file/test_remote_fetcher.py
+++ b/api/tests/unit_tests/core/file/test_remote_fetcher.py
@@ -102,6 +102,35 @@ def test_get_signed_upload_file_url_reads_storage_without_ssrf(monkeypatch: pyte
     ssrf_make_request.assert_not_called()
 
 
+def test_resolve_signed_upload_file_id_accepts_valid_upload_preview_url(monkeypatch: pytest.MonkeyPatch):
+    _patch_file_fetcher_config(monkeypatch)
+    url = _signed_url(
+        base_url="http://localhost:5001",
+        path=f"/files/{UPLOAD_FILE_ID}/file-preview",
+        payload=f"file-preview|{UPLOAD_FILE_ID}",
+    )
+
+    assert remote_fetcher.resolve_signed_upload_file_id(url) == UPLOAD_FILE_ID
+
+
+def test_resolve_signed_upload_file_id_rejects_tool_preview_url(monkeypatch: pytest.MonkeyPatch):
+    _patch_file_fetcher_config(monkeypatch)
+    url = _signed_url(
+        base_url="http://localhost:5001",
+        path=f"/files/tools/{TOOL_FILE_ID}.txt",
+        payload=f"file-preview|{TOOL_FILE_ID}",
+    )
+
+    assert remote_fetcher.resolve_signed_upload_file_id(url) is None
+
+
+def test_resolve_signed_upload_file_id_rejects_invalid_signature(monkeypatch: pytest.MonkeyPatch):
+    _patch_file_fetcher_config(monkeypatch)
+    url = f"http://localhost:5001/files/{UPLOAD_FILE_ID}/file-preview?timestamp=1700000000&nonce=nonce&sign=invalid"
+
+    assert remote_fetcher.resolve_signed_upload_file_id(url) is None
+
+
 def test_make_request_resolves_upload_preview_url_generated_by_signer(monkeypatch: pytest.MonkeyPatch):
     _patch_file_fetcher_config(monkeypatch)
     _patch_signer_times(monkeypatch)

--- a/api/tests/unit_tests/factories/test_build_from_mapping.py
+++ b/api/tests/unit_tests/factories/test_build_from_mapping.py
@@ -52,6 +52,12 @@ def build_from_mapping(*, mapping, tenant_id, config=None, strict_type_validatio
     )
 
 
+def _parsed_file_reference(reference: str | None):
+    parsed_reference = parse_file_reference(reference)
+    assert parsed_reference is not None
+    return parsed_reference
+
+
 # Fixtures
 @pytest.fixture
 def mock_upload_file():
@@ -129,7 +135,7 @@ def test_build_from_mapping_backward_compatibility(mock_upload_file):
     assert file.transfer_method == FileTransferMethod.LOCAL_FILE
     assert file.type == FileType.IMAGE
     assert resolve_file_record_id(file.reference) == TEST_UPLOAD_FILE_ID
-    assert parse_file_reference(file.reference).storage_key is None
+    assert _parsed_file_reference(file.reference).storage_key is None
     assert file.storage_key == "test_key"
 
 
@@ -161,7 +167,7 @@ def test_build_from_mapping_accepts_opaque_related_id_for_tool_file(mock_tool_fi
     assert file.transfer_method == FileTransferMethod.TOOL_FILE
     assert file.type == FileType.DOCUMENT
     assert resolve_file_record_id(file.reference) == TEST_TOOL_FILE_ID
-    assert parse_file_reference(file.reference).storage_key is None
+    assert _parsed_file_reference(file.reference).storage_key is None
     assert file.storage_key == "tool_file.pdf"
 
 
@@ -211,6 +217,57 @@ def test_build_from_remote_url(mock_http_head):
     assert file.type == FileType.IMAGE
     assert file.filename == "remote_test.jpg"
     assert file.size == 2048
+
+
+def test_build_from_remote_url_recovers_upload_file_from_signed_preview_url(mock_upload_file, mock_http_head):
+    signed_preview_url = "http://localhost:5001/files/preview-id/file-preview?timestamp=1&nonce=n&sign=s"
+
+    with patch(
+        "factories.file_factory.builders.remote_fetcher.resolve_signed_upload_file_id",
+        return_value=TEST_UPLOAD_FILE_ID,
+    ) as resolve_signed_upload_file_id:
+        file = build_from_mapping(
+            mapping={
+                "transfer_method": "remote_url",
+                "url": signed_preview_url,
+                "type": "image",
+            },
+            tenant_id=TEST_TENANT_ID,
+        )
+
+    resolve_signed_upload_file_id.assert_called_once_with(signed_preview_url)
+    mock_http_head.assert_not_called()
+    assert file.transfer_method == FileTransferMethod.REMOTE_URL
+    assert file.type == FileType.IMAGE
+    assert file.filename == "test.jpg"
+    assert file.remote_url is not None
+    assert resolve_file_record_id(file.reference) == TEST_UPLOAD_FILE_ID
+    assert file.storage_key == "test_key"
+
+
+def test_build_from_remote_url_uses_signed_preview_url_when_upload_source_url_is_empty(
+    mock_upload_file, mock_http_head
+):
+    signed_preview_url = "http://localhost:5001/files/preview-id/file-preview?timestamp=1&nonce=n&sign=s"
+    mock_upload_file.return_value.source_url = None
+
+    with patch(
+        "factories.file_factory.builders.remote_fetcher.resolve_signed_upload_file_id",
+        return_value=TEST_UPLOAD_FILE_ID,
+    ):
+        file = build_from_mapping(
+            mapping={
+                "transfer_method": "remote_url",
+                "remote_url": signed_preview_url,
+                "type": "image",
+            },
+            tenant_id=TEST_TENANT_ID,
+        )
+
+    mock_http_head.assert_not_called()
+    assert file.remote_url == signed_preview_url
+    assert resolve_file_record_id(file.reference) == TEST_UPLOAD_FILE_ID
+    assert file.storage_key == "test_key"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes #36698.

Remote URL uploads in web apps are stored as `UploadFile` rows, but the UI can round-trip the returned signed preview URL back into workflow inputs as `transfer_method=remote_url`. The file factory previously treated that signed Dify preview URL as a plain external URL, which could either lose the storage-backed `reference`/`storage_key` required by document extractor nodes or build a graph `File` with a preview URL shape the file model rejects.

This PR makes that path storage-aware by:
- resolving valid Dify upload preview URLs back to their `UploadFile` id
- rejecting forged, expired, tool, and datasource preview URLs for this compatibility path
- rehydrating the remote-url input from the UploadFile row so workflow nodes keep canonical file references and storage keys
- preserving the original source URL when available, with the submitted absolute preview URL as the safe fallback

Pre-PR duplicate check: #36698 is open, unassigned, PR search for `#36698` returned 0 results, and the issue comments did not indicate an owner or existing fix.

## Screenshots

| Before | After |
|--------|-------|
| N/A - backend file mapping fix | N/A - backend file mapping fix |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Validation performed:
- `uv run --project api --no-sync pytest --no-cov api/tests/unit_tests/factories/test_build_from_mapping.py api/tests/unit_tests/core/file/test_remote_fetcher.py api/tests/unit_tests/controllers/web/test_remote_files.py`
- `uv run --project api --no-sync ruff check api/core/file/remote_fetcher.py api/factories/file_factory/builders.py api/tests/unit_tests/core/file/test_remote_fetcher.py api/tests/unit_tests/factories/test_build_from_mapping.py api/tests/unit_tests/controllers/web/test_remote_files.py`
- `uv run --project api --no-sync ruff format --check api/core/file/remote_fetcher.py api/factories/file_factory/builders.py api/tests/unit_tests/core/file/test_remote_fetcher.py api/tests/unit_tests/factories/test_build_from_mapping.py api/tests/unit_tests/controllers/web/test_remote_files.py`
- `uv run --project api --no-sync pyrefly check api/core/file/remote_fetcher.py api/factories/file_factory/builders.py api/tests/unit_tests/core/file/test_remote_fetcher.py api/tests/unit_tests/factories/test_build_from_mapping.py api/tests/unit_tests/controllers/web/test_remote_files.py`

From Codex