### PR TITLE
fix: CodeExecutor.execute_code raises CodeExecutionError for unsupported languages

### DIFF
--- a/api/core/helper/code_executor/code_executor.py
+++ b/api/core/helper/code_executor/code_executor.py
@@ -74,12 +74,16 @@ class CodeExecutor:
         :param code: code
         :return:
         """
+        running_language = cls.code_language_to_running_language.get(language)
+        if running_language is None:
+            raise CodeExecutionError(f"Unsupported language {language}")
+
         url = code_execution_endpoint_url / "v1" / "sandbox" / "run"
 
         headers = {"X-Api-Key": dify_config.CODE_EXECUTION_API_KEY}
 
         data = {
-            "language": cls.code_language_to_running_language.get(language),
+            "language": running_language,
             "code": code,
             "preload": preload,
             "enable_network": True,

--- a/api/tests/unit_tests/core/helper/code_executor/test_code_executor.py
+++ b/api/tests/unit_tests/core/helper/code_executor/test_code_executor.py
@@ -9,6 +9,11 @@ from pytest_mock import MockerFixture
 from core.helper.code_executor import code_executor as code_executor_module
 
 
+def test_execute_code_raises_for_unsupported_language() -> None:
+    with pytest.raises(code_executor_module.CodeExecutionError, match="Unsupported language"):
+        code_executor_module.CodeExecutor.execute_code(cast(Any, "ruby"), preload="", code="print(1)")
+
+
 def test_execute_workflow_code_template_raises_for_unsupported_language() -> None:
     with pytest.raises(code_executor_module.CodeExecutionError, match="Unsupported language"):
         code_executor_module.CodeExecutor.execute_workflow_code_template(cast(Any, "ruby"), "print(1)", {})


### PR DESCRIPTION
## Summary

Previously, `execute_code` used `code_language_to_running_language.get(language)` which returned `None` for unsupported languages, sending `"language": null` to the sandbox service and producing a cryptic remote error.

This change adds an explicit guard that raises `CodeExecutionError('Unsupported language ...')` before the sandbox call, matching the existing behavior of `execute_workflow_code_template`.

Closes #37874

## Changes

- **api/core/helper/code_executor/code_executor.py**: Add guard clause for unsupported language at the start of `execute_code`
- **api/tests/unit_tests/core/helper/code_executor/test_code_executor.py**: Add test `test_execute_code_raises_for_unsupported_language`

## Testing

All existing tests pass. New test verifies the unsupported language path raises `CodeExecutionError`.