### PR TITLE
fix: parse_json_markdown handles top-level JSON arrays correctly

### DIFF
--- a/api/libs/json_in_md_parser.py
+++ b/api/libs/json_in_md_parser.py
@@ -6,24 +6,40 @@ from core.llm_generator.output_parser.errors import OutputParserError
 def parse_json_markdown(json_string: str):
     # Get json from the backticks/braces
     json_string = json_string.strip()
-    starts = ["```json", "```", "``", "`", "{", "["]
-    ends = ["```", "``", "`", "}", "]"]
     end_index = -1
     start_index = 0
     parsed: dict = {}
-    for s in starts:
-        start_index = json_string.find(s)
-        if start_index != -1:
-            if json_string[start_index] not in ("{", "["):
-                start_index += len(s)
+
+    # Try markdown fences first (explicit delimiters)
+    for s in ["```json", "```", "``", "`"]:
+        idx = json_string.find(s)
+        if idx != -1:
+            start_index = idx + len(s)
             break
+
+    # If no fence found, find the earliest opening bracket
+    if start_index == 0:
+        bracket_candidates = [(json_string.find("["), "["), (json_string.find("{"), "{")]
+        bracket_candidates = [(i, c) for i, c in bracket_candidates if i != -1]
+        if bracket_candidates:
+            start_index = min(bracket_candidates)[0]
+
     if start_index != -1:
-        for e in ends:
+        # Try markdown fences first
+        for e in ["```", "``", "`"]:
             end_index = json_string.rfind(e, start_index)
             if end_index != -1:
                 if json_string[end_index] in ("}", "]"):
                     end_index += 1
                 break
+
+        # If no fence found, find the latest closing bracket
+        if end_index == -1:
+            bracket_ends = [json_string.rfind(e, start_index) for e in ("]", "}")]
+            bracket_ends = [i for i in bracket_ends if i != -1]
+            if bracket_ends:
+                end_index = max(bracket_ends) + 1
+
     if start_index != -1 and end_index != -1 and start_index < end_index:
         extracted_content = json_string[start_index:end_index].strip()
         parsed = json.loads(extracted_content)

--- a/api/tests/unit_tests/libs/test_json_in_md_parser.py
+++ b/api/tests/unit_tests/libs/test_json_in_md_parser.py
@@ -88,6 +88,11 @@ def test_parse_and_check_json_markdown_multiple_blocks_fails():
         parse_and_check_json_markdown(src, [])
 
 
+def test_parse_json_markdown_top_level_array():
+    src = '[{"a": 1}, {"b": 2}]'
+    assert parse_json_markdown(src) == [{"a": 1}, {"b": 2}]
+
+
 def test_parse_and_check_json_markdown_handles_think_fenced_and_raw_variants():
     expected = {"keywords": ["2"], "category_id": "2", "category_name": "2"}
     cases = [


### PR DESCRIPTION
## Summary

`parse_json_markdown()` in `api/libs/json_in_md_parser.py` could not parse raw top-level JSON arrays containing objects like `[{"a": 1}, {"b": 2}]`. The parser used sequential `find`/`rfind` for brackets which caused two issues:

1. `find('{')` matched inner braces before the outer `[` in JSON arrays
2. `rfind('}')` matched inner braces before the closing `]` in JSON arrays

This change uses `min`/`max` across bracket candidates to find the earliest opening bracket and the latest closing bracket, correctly handling nested structures.

Closes #37820

## Changes

- **api/libs/json_in_md_parser.py**: Refactor bracket detection to use `min` for opening brackets and `max` for closing brackets instead of sequential find with break
- **api/tests/unit_tests/libs/test_json_in_md_parser.py**: Add `test_parse_json_markdown_top_level_array`

## Testing

All 11 existing tests pass. New test verifies top-level array parsing.