### PR TITLE
fix: handle UnicodeDecodeError in Redis cache helpers

### DIFF
--- a/api/core/helper/model_provider_cache.py
+++ b/api/core/helper/model_provider_cache.py
@@ -27,7 +27,7 @@ class ProviderCredentialsCache:
             try:
                 cached_provider_credentials = cached_provider_credentials.decode("utf-8")
                 cached_provider_credentials = json.loads(cached_provider_credentials)
-            except JSONDecodeError:
+            except (JSONDecodeError, UnicodeDecodeError):
                 return None
 
             return dict(cached_provider_credentials)

--- a/api/core/helper/provider_cache.py
+++ b/api/core/helper/provider_cache.py
@@ -24,7 +24,7 @@ class ProviderCredentialsCache(ABC):
             try:
                 cached_credentials = cached_credentials.decode("utf-8")
                 return dict(json.loads(cached_credentials))
-            except JSONDecodeError:
+            except (JSONDecodeError, UnicodeDecodeError):
                 return None
         return None
 

--- a/api/core/helper/tool_parameter_cache.py
+++ b/api/core/helper/tool_parameter_cache.py
@@ -30,7 +30,7 @@ class ToolParameterCache:
             try:
                 cached_tool_parameter = cached_tool_parameter.decode("utf-8")
                 cached_tool_parameter = json.loads(cached_tool_parameter)
-            except JSONDecodeError:
+            except (JSONDecodeError, UnicodeDecodeError):
                 return None
 
             return dict(cached_tool_parameter)

--- a/api/tests/unit_tests/core/helper/test_tool_parameter_cache.py
+++ b/api/tests/unit_tests/core/helper/test_tool_parameter_cache.py
@@ -23,6 +23,21 @@ def test_tool_parameter_cache_get_returns_decoded_dict(mocker: MockerFixture) ->
     redis_client_mock.get.assert_called_once_with(cache_key)
 
 
+def test_tool_parameter_cache_get_returns_none_for_invalid_utf8(mocker: MockerFixture) -> None:
+    redis_client_mock = mocker.patch("core.helper.tool_parameter_cache.redis_client")
+    cache = ToolParameterCache(
+        tenant_id="tenant",
+        provider="provider",
+        tool_name="tool",
+        cache_type=ToolParameterCacheType.PARAMETER,
+        identity_id="identity",
+    )
+
+    redis_client_mock.get.return_value = b"\xff"
+
+    assert cache.get() is None
+
+
 def test_tool_parameter_cache_get_returns_none_for_invalid_json(mocker: MockerFixture) -> None:
     redis_client_mock = mocker.patch("core.helper.tool_parameter_cache.redis_client")
     cache = ToolParameterCache(


### PR DESCRIPTION
## Summary

Redis-backed cache helpers in `provider_cache.py`, `tool_parameter_cache.py`, and `model_provider_cache.py` decode cached bytes with `.decode('utf-8')` before JSON parsing. If Redis contains corrupt/non-UTF-8 bytes, the decode call raises `UnicodeDecodeError` which propagates as an unhandled exception instead of gracefully returning `None` (the existing behavior for malformed JSON).

This change catches `UnicodeDecodeError` alongside the existing `JSONDecodeError` in all three cache `get()` methods, ensuring corrupt cache values are treated as cache misses and callers fall back to source-of-truth loading.

Closes #37834

## Changes

- **api/core/helper/provider_cache.py**: Add `UnicodeDecodeError` to except clause in `ProviderCredentialsCache.get()`
- **api/core/helper/tool_parameter_cache.py**: Add `UnicodeDecodeError` to except clause in `ToolParameterCache.get()`
- **api/core/helper/model_provider_cache.py**: Add `UnicodeDecodeError` to except clause in `ProviderCredentialsCache.get()`
- **api/tests/unit_tests/core/helper/test_tool_parameter_cache.py**: Add `test_tool_parameter_cache_get_returns_none_for_invalid_utf8`

## Testing

All 5 existing tests pass. New test verifies invalid UTF-8 bytes return `None`.