### PR TITLE
fix: respect legacy plugin permissions without RBAC

### DIFF
--- a/web/app/components/plugins/install-plugin/hooks/__tests__/use-workspace-plugin-install-permission.spec.ts
+++ b/web/app/components/plugins/install-plugin/hooks/__tests__/use-workspace-plugin-install-permission.spec.ts
@@ -1,38 +1,19 @@
+import { renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { renderHookWithSystemFeatures as renderHook } from '@/__tests__/utils/mock-system-features'
-import { PermissionType } from '@/app/components/plugins/types'
-import { usePluginPermissionSettings } from '@/service/use-plugins'
 import useWorkspacePluginInstallPermission from '../use-workspace-plugin-install-permission'
 
 let mockWorkspacePermissionKeys: string[] = []
-let mockIsCurrentWorkspaceManager = false
-let mockIsCurrentWorkspaceOwner = false
 
 vi.mock('@/context/app-context', () => ({
   useAppContext: () => ({
-    isCurrentWorkspaceManager: mockIsCurrentWorkspaceManager,
-    isCurrentWorkspaceOwner: mockIsCurrentWorkspaceOwner,
     langGeniusVersionInfo: { current_version: '1.0.0' },
     workspacePermissionKeys: mockWorkspacePermissionKeys,
   }),
 }))
 
-vi.mock('@/service/use-plugins', () => ({
-  usePluginPermissionSettings: vi.fn(),
-}))
-
 describe('useWorkspacePluginInstallPermission', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
     mockWorkspacePermissionKeys = []
-    mockIsCurrentWorkspaceManager = false
-    mockIsCurrentWorkspaceOwner = false
-    vi.mocked(usePluginPermissionSettings).mockReturnValue({
-      data: {
-        install_permission: PermissionType.everyone,
-        debug_permission: PermissionType.everyone,
-      },
-    } as ReturnType<typeof usePluginPermissionSettings>)
   })
 
   it('should grant install and update capabilities with plugin.install', () => {
@@ -96,63 +77,5 @@ describe('useWorkspacePluginInstallPermission', () => {
     expect(result.current.canManagePlugin).toBe(false)
     expect(result.current.canDebugPlugin).toBe(false)
     expect(result.current.canSetPluginPreferences).toBe(false)
-  })
-
-  it('should deny install, update, manage, and debug when legacy plugin permissions are noOne and RBAC is disabled', () => {
-    mockWorkspacePermissionKeys = ['plugin.install', 'plugin.manage', 'plugin.debug']
-    mockIsCurrentWorkspaceManager = true
-    vi.mocked(usePluginPermissionSettings).mockReturnValue({
-      data: {
-        install_permission: PermissionType.noOne,
-        debug_permission: PermissionType.noOne,
-      },
-    } as ReturnType<typeof usePluginPermissionSettings>)
-
-    const { result } = renderHook(() => useWorkspacePluginInstallPermission(), {
-      systemFeatures: { rbac_enabled: false },
-    })
-
-    expect(result.current.canInstallPlugin).toBe(false)
-    expect(result.current.canUpdatePlugin).toBe(false)
-    expect(result.current.canViewInstalledPlugins).toBe(true)
-    expect(result.current.canManagePlugin).toBe(false)
-    expect(result.current.canDebugPlugin).toBe(false)
-  })
-
-  it('should deny plugin actions until legacy plugin permissions are available when RBAC is disabled', () => {
-    mockWorkspacePermissionKeys = ['plugin.install', 'plugin.manage', 'plugin.debug']
-    mockIsCurrentWorkspaceManager = true
-    vi.mocked(usePluginPermissionSettings).mockReturnValue({
-      data: undefined,
-    } as ReturnType<typeof usePluginPermissionSettings>)
-
-    const { result } = renderHook(() => useWorkspacePluginInstallPermission(), {
-      systemFeatures: { rbac_enabled: false },
-    })
-
-    expect(result.current.canInstallPlugin).toBe(false)
-    expect(result.current.canUpdatePlugin).toBe(false)
-    expect(result.current.canManagePlugin).toBe(false)
-    expect(result.current.canDebugPlugin).toBe(false)
-  })
-
-  it('should ignore legacy plugin permissions when RBAC is enabled', () => {
-    mockWorkspacePermissionKeys = ['plugin.install', 'plugin.manage', 'plugin.debug']
-    vi.mocked(usePluginPermissionSettings).mockReturnValue({
-      data: {
-        install_permission: PermissionType.noOne,
-        debug_permission: PermissionType.noOne,
-      },
-    } as ReturnType<typeof usePluginPermissionSettings>)
-
-    const { result } = renderHook(() => useWorkspacePluginInstallPermission(), {
-      systemFeatures: { rbac_enabled: true },
-    })
-
-    expect(result.current.canInstallPlugin).toBe(true)
-    expect(result.current.canUpdatePlugin).toBe(true)
-    expect(result.current.canViewInstalledPlugins).toBe(true)
-    expect(result.current.canManagePlugin).toBe(true)
-    expect(result.current.canDebugPlugin).toBe(true)
   })
 })

--- a/web/app/components/plugins/install-plugin/hooks/__tests__/use-workspace-plugin-install-permission.spec.ts
+++ b/web/app/components/plugins/install-plugin/hooks/__tests__/use-workspace-plugin-install-permission.spec.ts
@@ -1,19 +1,38 @@
-import { renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHookWithSystemFeatures as renderHook } from '@/__tests__/utils/mock-system-features'
+import { PermissionType } from '@/app/components/plugins/types'
+import { usePluginPermissionSettings } from '@/service/use-plugins'
 import useWorkspacePluginInstallPermission from '../use-workspace-plugin-install-permission'
 
 let mockWorkspacePermissionKeys: string[] = []
+let mockIsCurrentWorkspaceManager = false
+let mockIsCurrentWorkspaceOwner = false
 
 vi.mock('@/context/app-context', () => ({
   useAppContext: () => ({
+    isCurrentWorkspaceManager: mockIsCurrentWorkspaceManager,
+    isCurrentWorkspaceOwner: mockIsCurrentWorkspaceOwner,
     langGeniusVersionInfo: { current_version: '1.0.0' },
     workspacePermissionKeys: mockWorkspacePermissionKeys,
   }),
 }))
 
+vi.mock('@/service/use-plugins', () => ({
+  usePluginPermissionSettings: vi.fn(),
+}))
+
 describe('useWorkspacePluginInstallPermission', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     mockWorkspacePermissionKeys = []
+    mockIsCurrentWorkspaceManager = false
+    mockIsCurrentWorkspaceOwner = false
+    vi.mocked(usePluginPermissionSettings).mockReturnValue({
+      data: {
+        install_permission: PermissionType.everyone,
+        debug_permission: PermissionType.everyone,
+      },
+    } as ReturnType<typeof usePluginPermissionSettings>)
   })
 
   it('should grant install and update capabilities with plugin.install', () => {
@@ -77,5 +96,63 @@ describe('useWorkspacePluginInstallPermission', () => {
     expect(result.current.canManagePlugin).toBe(false)
     expect(result.current.canDebugPlugin).toBe(false)
     expect(result.current.canSetPluginPreferences).toBe(false)
+  })
+
+  it('should deny install, update, manage, and debug when legacy plugin permissions are noOne and RBAC is disabled', () => {
+    mockWorkspacePermissionKeys = ['plugin.install', 'plugin.manage', 'plugin.debug']
+    mockIsCurrentWorkspaceManager = true
+    vi.mocked(usePluginPermissionSettings).mockReturnValue({
+      data: {
+        install_permission: PermissionType.noOne,
+        debug_permission: PermissionType.noOne,
+      },
+    } as ReturnType<typeof usePluginPermissionSettings>)
+
+    const { result } = renderHook(() => useWorkspacePluginInstallPermission(), {
+      systemFeatures: { rbac_enabled: false },
+    })
+
+    expect(result.current.canInstallPlugin).toBe(false)
+    expect(result.current.canUpdatePlugin).toBe(false)
+    expect(result.current.canViewInstalledPlugins).toBe(true)
+    expect(result.current.canManagePlugin).toBe(false)
+    expect(result.current.canDebugPlugin).toBe(false)
+  })
+
+  it('should deny plugin actions until legacy plugin permissions are available when RBAC is disabled', () => {
+    mockWorkspacePermissionKeys = ['plugin.install', 'plugin.manage', 'plugin.debug']
+    mockIsCurrentWorkspaceManager = true
+    vi.mocked(usePluginPermissionSettings).mockReturnValue({
+      data: undefined,
+    } as ReturnType<typeof usePluginPermissionSettings>)
+
+    const { result } = renderHook(() => useWorkspacePluginInstallPermission(), {
+      systemFeatures: { rbac_enabled: false },
+    })
+
+    expect(result.current.canInstallPlugin).toBe(false)
+    expect(result.current.canUpdatePlugin).toBe(false)
+    expect(result.current.canManagePlugin).toBe(false)
+    expect(result.current.canDebugPlugin).toBe(false)
+  })
+
+  it('should ignore legacy plugin permissions when RBAC is enabled', () => {
+    mockWorkspacePermissionKeys = ['plugin.install', 'plugin.manage', 'plugin.debug']
+    vi.mocked(usePluginPermissionSettings).mockReturnValue({
+      data: {
+        install_permission: PermissionType.noOne,
+        debug_permission: PermissionType.noOne,
+      },
+    } as ReturnType<typeof usePluginPermissionSettings>)
+
+    const { result } = renderHook(() => useWorkspacePluginInstallPermission(), {
+      systemFeatures: { rbac_enabled: true },
+    })
+
+    expect(result.current.canInstallPlugin).toBe(true)
+    expect(result.current.canUpdatePlugin).toBe(true)
+    expect(result.current.canViewInstalledPlugins).toBe(true)
+    expect(result.current.canManagePlugin).toBe(true)
+    expect(result.current.canDebugPlugin).toBe(true)
   })
 })

--- a/web/app/components/plugins/install-plugin/hooks/use-workspace-plugin-install-permission.ts
+++ b/web/app/components/plugins/install-plugin/hooks/use-workspace-plugin-install-permission.ts
@@ -1,57 +1,34 @@
-import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { useAppContext } from '@/context/app-context'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
-import { usePluginPermissionSettings } from '@/service/use-plugins'
 import { hasPermission } from '@/utils/permission'
-import { hasLegacyPluginPermissionAccess } from '../../plugin-permissions'
 
 const pluginReadAndUpdatePermissionKeys = ['plugin.install', 'plugin.manage']
 
 const useWorkspacePluginInstallPermission = () => {
   const {
-    isCurrentWorkspaceManager,
-    isCurrentWorkspaceOwner,
     langGeniusVersionInfo,
     workspacePermissionKeys,
   } = useAppContext()
-  const { data: rbacEnabled } = useQuery({
-    ...systemFeaturesQueryOptions(),
-    select: s => s.rbac_enabled,
-  })
-  const permissionQuery = usePluginPermissionSettings()
-  const { data: permissions } = permissionQuery
-  const isAdminOrOwner = isCurrentWorkspaceManager || isCurrentWorkspaceOwner
-  const legacyCanInstallPlugin = hasLegacyPluginPermissionAccess({
-    isAdminOrOwner,
-    permission: permissions?.install_permission,
-    rbacEnabled,
-  })
-  const legacyCanDebugPlugin = hasLegacyPluginPermissionAccess({
-    isAdminOrOwner,
-    permission: permissions?.debug_permission,
-    rbacEnabled,
-  })
 
   const canInstallPlugin = useMemo(() => {
-    return hasPermission(workspacePermissionKeys, 'plugin.install') && legacyCanInstallPlugin
-  }, [legacyCanInstallPlugin, workspacePermissionKeys])
+    return hasPermission(workspacePermissionKeys, 'plugin.install')
+  }, [workspacePermissionKeys])
 
   const canUpdatePlugin = useMemo(() => {
-    return hasPermission(workspacePermissionKeys, pluginReadAndUpdatePermissionKeys) && legacyCanInstallPlugin
-  }, [legacyCanInstallPlugin, workspacePermissionKeys])
+    return hasPermission(workspacePermissionKeys, pluginReadAndUpdatePermissionKeys)
+  }, [workspacePermissionKeys])
 
   const canViewInstalledPlugins = useMemo(() => {
     return hasPermission(workspacePermissionKeys, pluginReadAndUpdatePermissionKeys)
   }, [workspacePermissionKeys])
 
   const canManagePlugin = useMemo(() => {
-    return hasPermission(workspacePermissionKeys, 'plugin.manage') && legacyCanInstallPlugin
-  }, [legacyCanInstallPlugin, workspacePermissionKeys])
+    return hasPermission(workspacePermissionKeys, 'plugin.manage')
+  }, [workspacePermissionKeys])
 
   const canDebugPlugin = useMemo(() => {
-    return hasPermission(workspacePermissionKeys, 'plugin.debug') && legacyCanDebugPlugin
-  }, [legacyCanDebugPlugin, workspacePermissionKeys])
+    return hasPermission(workspacePermissionKeys, 'plugin.debug')
+  }, [workspacePermissionKeys])
 
   const canSetPluginPreferences = useMemo(() => {
     return hasPermission(workspacePermissionKeys, 'plugin.plugin_preferences')

--- a/web/app/components/plugins/install-plugin/hooks/use-workspace-plugin-install-permission.ts
+++ b/web/app/components/plugins/install-plugin/hooks/use-workspace-plugin-install-permission.ts
@@ -1,31 +1,57 @@
+import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { useAppContext } from '@/context/app-context'
+import { systemFeaturesQueryOptions } from '@/features/system-features/client'
+import { usePluginPermissionSettings } from '@/service/use-plugins'
 import { hasPermission } from '@/utils/permission'
+import { hasLegacyPluginPermissionAccess } from '../../plugin-permissions'
 
 const pluginReadAndUpdatePermissionKeys = ['plugin.install', 'plugin.manage']
 
 const useWorkspacePluginInstallPermission = () => {
-  const { langGeniusVersionInfo, workspacePermissionKeys } = useAppContext()
+  const {
+    isCurrentWorkspaceManager,
+    isCurrentWorkspaceOwner,
+    langGeniusVersionInfo,
+    workspacePermissionKeys,
+  } = useAppContext()
+  const { data: rbacEnabled } = useQuery({
+    ...systemFeaturesQueryOptions(),
+    select: s => s.rbac_enabled,
+  })
+  const permissionQuery = usePluginPermissionSettings()
+  const { data: permissions } = permissionQuery
+  const isAdminOrOwner = isCurrentWorkspaceManager || isCurrentWorkspaceOwner
+  const legacyCanInstallPlugin = hasLegacyPluginPermissionAccess({
+    isAdminOrOwner,
+    permission: permissions?.install_permission,
+    rbacEnabled,
+  })
+  const legacyCanDebugPlugin = hasLegacyPluginPermissionAccess({
+    isAdminOrOwner,
+    permission: permissions?.debug_permission,
+    rbacEnabled,
+  })
 
   const canInstallPlugin = useMemo(() => {
-    return hasPermission(workspacePermissionKeys, 'plugin.install')
-  }, [workspacePermissionKeys])
+    return hasPermission(workspacePermissionKeys, 'plugin.install') && legacyCanInstallPlugin
+  }, [legacyCanInstallPlugin, workspacePermissionKeys])
 
   const canUpdatePlugin = useMemo(() => {
-    return hasPermission(workspacePermissionKeys, pluginReadAndUpdatePermissionKeys)
-  }, [workspacePermissionKeys])
+    return hasPermission(workspacePermissionKeys, pluginReadAndUpdatePermissionKeys) && legacyCanInstallPlugin
+  }, [legacyCanInstallPlugin, workspacePermissionKeys])
 
   const canViewInstalledPlugins = useMemo(() => {
     return hasPermission(workspacePermissionKeys, pluginReadAndUpdatePermissionKeys)
   }, [workspacePermissionKeys])
 
   const canManagePlugin = useMemo(() => {
-    return hasPermission(workspacePermissionKeys, 'plugin.manage')
-  }, [workspacePermissionKeys])
+    return hasPermission(workspacePermissionKeys, 'plugin.manage') && legacyCanInstallPlugin
+  }, [legacyCanInstallPlugin, workspacePermissionKeys])
 
   const canDebugPlugin = useMemo(() => {
-    return hasPermission(workspacePermissionKeys, 'plugin.debug')
-  }, [workspacePermissionKeys])
+    return hasPermission(workspacePermissionKeys, 'plugin.debug') && legacyCanDebugPlugin
+  }, [legacyCanDebugPlugin, workspacePermissionKeys])
 
   const canSetPluginPreferences = useMemo(() => {
     return hasPermission(workspacePermissionKeys, 'plugin.plugin_preferences')

--- a/web/app/components/plugins/plugin-page/__tests__/use-reference-setting.spec.ts
+++ b/web/app/components/plugins/plugin-page/__tests__/use-reference-setting.spec.ts
@@ -164,7 +164,7 @@ describe('useReferenceSetting Hook', () => {
       expect(result.current.canDebugger).toBe(false)
     })
 
-    it('should use plugin keys even when legacy admin permission is configured', () => {
+    it('should use plugin keys even when legacy admin permission is configured and RBAC is enabled', () => {
       vi.mocked(useAppContext).mockReturnValue({
         isCurrentWorkspaceManager: false,
         isCurrentWorkspaceOwner: false,
@@ -179,10 +179,39 @@ describe('useReferenceSetting Hook', () => {
         },
       } as ReturnType<typeof usePluginPermissionSettings>)
 
-      const { result } = renderHook(() => useReferenceSetting(PluginCategoryEnum.tool))
+      const { result } = renderHook(() => useReferenceSetting(PluginCategoryEnum.tool), {
+        systemFeatures: { rbac_enabled: true },
+      })
 
       expect(result.current.canManagement).toBe(true)
       expect(result.current.canDebugger).toBe(true)
+    })
+
+    it('should apply legacy noOne plugin permissions when RBAC is disabled', () => {
+      vi.mocked(useAppContext).mockReturnValue({
+        isCurrentWorkspaceManager: true,
+        isCurrentWorkspaceOwner: false,
+        langGeniusVersionInfo: { current_version: '1.0.0', latest_version: '', version: '' },
+        workspacePermissionKeys: ['plugin.install', 'plugin.manage', 'plugin.debug'],
+      } as ReturnType<typeof useAppContext>)
+      vi.mocked(usePluginPermissionSettings).mockReturnValue({
+        data: {
+          install_permission: PermissionType.noOne,
+          debug_permission: PermissionType.noOne,
+        },
+      } as ReturnType<typeof usePluginPermissionSettings>)
+
+      const { result } = renderHook(() => useReferenceSetting(PluginCategoryEnum.tool), {
+        systemFeatures: { rbac_enabled: false },
+      })
+
+      expect(result.current.canInstallPlugin).toBe(false)
+      expect(result.current.canManagement).toBe(false)
+      expect(result.current.canUpdatePlugin).toBe(false)
+      expect(result.current.canViewInstalledPlugins).toBe(true)
+      expect(result.current.canManagePlugin).toBe(false)
+      expect(result.current.canDebugPlugin).toBe(false)
+      expect(result.current.canDebugger).toBe(false)
     })
   })
 
@@ -446,13 +475,31 @@ describe('useCanInstallPluginFromMarketplace Hook', () => {
     expect(result.current.canInstallPluginFromMarketplace).toBe(false)
   })
 
-  it('should not fetch legacy plugin permissions or category auto-upgrade settings', () => {
+  it('should fetch legacy plugin permissions but not category auto-upgrade settings', () => {
     renderHook(() => useCanInstallPluginFromMarketplace(), {
       systemFeatures: { enable_marketplace: true },
     })
 
-    expect(usePluginPermissionSettings).not.toHaveBeenCalled()
+    expect(usePluginPermissionSettings).toHaveBeenCalled()
     expect(usePluginAutoUpgradeSettings).not.toHaveBeenCalled()
+  })
+
+  it('should return false when legacy install permission is noOne and RBAC is disabled', () => {
+    vi.mocked(usePluginPermissionSettings).mockReturnValue({
+      data: {
+        install_permission: PermissionType.noOne,
+        debug_permission: PermissionType.everyone,
+      },
+    } as ReturnType<typeof usePluginPermissionSettings>)
+
+    const { result } = renderHook(() => useCanInstallPluginFromMarketplace(), {
+      systemFeatures: {
+        enable_marketplace: true,
+        rbac_enabled: false,
+      },
+    })
+
+    expect(result.current.canInstallPluginFromMarketplace).toBe(false)
   })
 
   it('should use plugin.install when marketplace and RBAC are enabled', () => {

--- a/web/app/components/plugins/plugin-page/use-reference-setting.ts
+++ b/web/app/components/plugins/plugin-page/use-reference-setting.ts
@@ -7,6 +7,7 @@ import { useAppContext } from '@/context/app-context'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { useInvalidateReferenceSettings, useMutationPluginPermissionSettings, useMutationReferenceSettings, usePluginAutoUpgradeSettings, usePluginPermissionSettings } from '@/service/use-plugins'
 import { hasPermission } from '@/utils/permission'
+import { hasLegacyPluginPermissionAccess } from '../plugin-permissions'
 
 const pluginReadAndUpdatePermissionKeys = ['plugin.install', 'plugin.manage']
 
@@ -26,7 +27,11 @@ const useCanSetPluginSettings = () => {
 
 export const usePluginSettingsAccess = () => {
   const { t } = useTranslation()
-  const { workspacePermissionKeys, langGeniusVersionInfo } = useAppContext()
+  const { isCurrentWorkspaceManager, isCurrentWorkspaceOwner, workspacePermissionKeys, langGeniusVersionInfo } = useAppContext()
+  const { data: rbacEnabled } = useSuspenseQuery({
+    ...systemFeaturesQueryOptions(),
+    select: s => s.rbac_enabled,
+  })
   const { canSetPermissions, canSetPluginPreferences } = useCanSetPluginSettings()
   const permissionQuery = usePluginPermissionSettings()
   const { data: permissions } = permissionQuery
@@ -35,11 +40,22 @@ export const usePluginSettingsAccess = () => {
       toast.success(t('api.actionSuccess', { ns: 'common' }))
     },
   })
-  const canInstallPlugin = hasPermission(workspacePermissionKeys, 'plugin.install')
-  const canUpdatePlugin = hasPermission(workspacePermissionKeys, pluginReadAndUpdatePermissionKeys)
+  const isAdminOrOwner = isCurrentWorkspaceManager || isCurrentWorkspaceOwner
+  const legacyCanInstallPlugin = hasLegacyPluginPermissionAccess({
+    isAdminOrOwner,
+    permission: permissions?.install_permission,
+    rbacEnabled,
+  })
+  const legacyCanDebugPlugin = hasLegacyPluginPermissionAccess({
+    isAdminOrOwner,
+    permission: permissions?.debug_permission,
+    rbacEnabled,
+  })
+  const canInstallPlugin = hasPermission(workspacePermissionKeys, 'plugin.install') && legacyCanInstallPlugin
+  const canUpdatePlugin = hasPermission(workspacePermissionKeys, pluginReadAndUpdatePermissionKeys) && legacyCanInstallPlugin
   const canViewInstalledPlugins = hasPermission(workspacePermissionKeys, pluginReadAndUpdatePermissionKeys)
-  const canManagePlugin = hasPermission(workspacePermissionKeys, 'plugin.manage')
-  const canDebugPlugin = hasPermission(workspacePermissionKeys, 'plugin.debug')
+  const canManagePlugin = hasPermission(workspacePermissionKeys, 'plugin.manage') && legacyCanInstallPlugin
+  const canDebugPlugin = hasPermission(workspacePermissionKeys, 'plugin.debug') && legacyCanDebugPlugin
 
   return {
     permission: permissions,
@@ -102,12 +118,18 @@ const useReferenceSetting = (category: PluginCategoryEnum) => {
 }
 
 export const useCanInstallPluginFromMarketplace = () => {
-  const { data: marketplaceAccess } = useSuspenseQuery({
-    ...systemFeaturesQueryOptions(),
-    select: s => s.enable_marketplace,
+  const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
+  const marketplaceAccess = systemFeatures.enable_marketplace
+  const rbacEnabled = systemFeatures.rbac_enabled
+  const { isCurrentWorkspaceManager, isCurrentWorkspaceOwner, workspacePermissionKeys } = useAppContext()
+  const permissionQuery = usePluginPermissionSettings()
+  const { data: permissions } = permissionQuery
+  const legacyCanInstallPlugin = hasLegacyPluginPermissionAccess({
+    isAdminOrOwner: isCurrentWorkspaceManager || isCurrentWorkspaceOwner,
+    permission: permissions?.install_permission,
+    rbacEnabled,
   })
-  const { workspacePermissionKeys } = useAppContext()
-  const canInstallPlugin = hasPermission(workspacePermissionKeys, 'plugin.install')
+  const canInstallPlugin = hasPermission(workspacePermissionKeys, 'plugin.install') && legacyCanInstallPlugin
 
   const canInstallPluginFromMarketplace = useMemo(() => {
     return Boolean(marketplaceAccess && canInstallPlugin)

--- a/web/app/components/plugins/plugin-permissions.ts
+++ b/web/app/components/plugins/plugin-permissions.ts
@@ -1,0 +1,27 @@
+import { PermissionType } from './types'
+
+type LegacyPluginPermissionAccessOptions = {
+  isAdminOrOwner: boolean
+  permission?: PermissionType
+  rbacEnabled?: boolean
+}
+
+export const hasLegacyPluginPermissionAccess = ({
+  isAdminOrOwner,
+  permission,
+  rbacEnabled,
+}: LegacyPluginPermissionAccessOptions) => {
+  if (rbacEnabled !== false)
+    return true
+
+  if (!permission)
+    return false
+
+  if (permission === PermissionType.everyone)
+    return true
+
+  if (permission === PermissionType.admin)
+    return isAdminOrOwner
+
+  return false
+}

--- a/web/app/components/tools/marketplace/__tests__/index.spec.tsx
+++ b/web/app/components/tools/marketplace/__tests__/index.spec.tsx
@@ -34,8 +34,8 @@ vi.mock('@/app/components/plugins/marketplace/list', () => ({
   },
 }))
 
-vi.mock('@/app/components/plugins/install-plugin/hooks/use-workspace-plugin-install-permission', () => ({
-  default: () => ({
+vi.mock('@/app/components/plugins/plugin-page/use-reference-setting', () => ({
+  usePluginSettingsAccess: () => ({
     canInstallPlugin: mockCanInstallPlugin(),
   }),
 }))

--- a/web/app/components/tools/marketplace/__tests__/index.spec.tsx
+++ b/web/app/components/tools/marketplace/__tests__/index.spec.tsx
@@ -15,6 +15,10 @@ const { mockRouterPush } = vi.hoisted(() => ({
   mockRouterPush: vi.fn(),
 }))
 
+const { mockCanInstallPlugin } = vi.hoisted(() => ({
+  mockCanInstallPlugin: vi.fn(() => true),
+}))
+
 const listRenderSpy = vi.fn()
 vi.mock('@/app/components/plugins/marketplace/list', () => ({
   default: (props: {
@@ -28,6 +32,12 @@ vi.mock('@/app/components/plugins/marketplace/list', () => ({
     listRenderSpy(props)
     return <div data-testid="marketplace-list" />
   },
+}))
+
+vi.mock('@/app/components/plugins/install-plugin/hooks/use-workspace-plugin-install-permission', () => ({
+  default: () => ({
+    canInstallPlugin: mockCanInstallPlugin(),
+  }),
 }))
 
 const mockUseMarketplaceCollectionsAndPlugins = vi.fn()
@@ -108,6 +118,7 @@ const createMarketplaceContext = (overrides: Partial<ReturnType<typeof useMarket
 describe('Marketplace', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockCanInstallPlugin.mockReturnValue(true)
   })
 
   // Rendering the marketplace panel based on loading and visibility state.
@@ -152,6 +163,28 @@ describe('Marketplace', () => {
         cardContainerClassName: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3',
         onCollectionMoreClick: expect.any(Function),
         showInstallButton: true,
+      }))
+    })
+
+    it('should hide install actions when plugin install permission is missing', () => {
+      mockCanInstallPlugin.mockReturnValue(false)
+      const marketplaceContext = createMarketplaceContext({
+        isLoading: false,
+        plugins: [createPlugin()],
+      })
+
+      render(
+        <Marketplace
+          searchPluginText=""
+          filterPluginTags={[]}
+          isMarketplaceArrowVisible={false}
+          showMarketplacePanel={vi.fn()}
+          marketplaceContext={marketplaceContext}
+        />,
+      )
+
+      expect(listRenderSpy).toHaveBeenCalledWith(expect.objectContaining({
+        showInstallButton: false,
       }))
     })
   })

--- a/web/app/components/tools/marketplace/index.tsx
+++ b/web/app/components/tools/marketplace/index.tsx
@@ -10,6 +10,7 @@ import { useTheme } from 'next-themes'
 import { useTranslation } from 'react-i18next'
 import { useLocale } from '#i18n'
 import Loading from '@/app/components/base/loading'
+import useWorkspacePluginInstallPermission from '@/app/components/plugins/install-plugin/hooks/use-workspace-plugin-install-permission'
 import List from '@/app/components/plugins/marketplace/list'
 import { useRouter } from '@/next/navigation'
 import { getMarketplaceUrl } from '@/utils/var'
@@ -35,6 +36,7 @@ const Marketplace = ({
   const { t } = useTranslation()
   const { theme } = useTheme()
   const router = useRouter()
+  const { canInstallPlugin } = useWorkspacePluginInstallPermission()
   const {
     isLoading,
     marketplaceCollections,
@@ -127,7 +129,7 @@ const Marketplace = ({
                 marketplaceCollections={marketplaceCollections || []}
                 marketplaceCollectionPluginsMap={marketplaceCollectionPluginsMap || {}}
                 plugins={plugins}
-                showInstallButton
+                showInstallButton={canInstallPlugin}
                 cardContainerClassName={cardContainerClassName}
                 onCollectionMoreClick={handleCollectionMoreClick}
               />

--- a/web/app/components/tools/marketplace/index.tsx
+++ b/web/app/components/tools/marketplace/index.tsx
@@ -10,8 +10,8 @@ import { useTheme } from 'next-themes'
 import { useTranslation } from 'react-i18next'
 import { useLocale } from '#i18n'
 import Loading from '@/app/components/base/loading'
-import useWorkspacePluginInstallPermission from '@/app/components/plugins/install-plugin/hooks/use-workspace-plugin-install-permission'
 import List from '@/app/components/plugins/marketplace/list'
+import { usePluginSettingsAccess } from '@/app/components/plugins/plugin-page/use-reference-setting'
 import { useRouter } from '@/next/navigation'
 import { getMarketplaceUrl } from '@/utils/var'
 import { toolsContentInsetClassNames, toolsUnifiedContentFrameClassName } from '../content-inset'
@@ -36,7 +36,7 @@ const Marketplace = ({
   const { t } = useTranslation()
   const { theme } = useTheme()
   const router = useRouter()
-  const { canInstallPlugin } = useWorkspacePluginInstallPermission()
+  const { canInstallPlugin } = usePluginSettingsAccess()
   const {
     isLoading,
     marketplaceCollections,


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This PR fixes plugin action visibility when RBAC is disabled.

Root cause: after the RBAC integration, several plugin install/debug entry points relied only on workspace permission keys. In SaaS with RBAC disabled, legacy plugin permission settings such as `No one`, `Admins`, and `Everyone` still define whether Install and Debug actions should be available. That mismatch allowed some Install actions to remain visible and could mount Debug flows that later failed with permission errors.

Changes:

- Add a shared frontend helper for applying legacy plugin permission settings only when RBAC is disabled.
- Apply that helper in plugin settings access and workspace plugin install permission hooks.
- Keep RBAC-enabled behavior unchanged: RBAC permission keys remain the source of truth.
- Hide Tools marketplace install actions when the current user cannot install plugins.
- Add focused tests for RBAC on/off behavior and marketplace install visibility.

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This does not apply to typos!)
- [x] I have added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I have updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Validation run locally:

- `pnpm --filter dify-web test app/components/plugins/install-plugin/hooks/__tests__/use-workspace-plugin-install-permission.spec.ts app/components/plugins/plugin-page/__tests__/use-reference-setting.spec.ts app/components/tools/marketplace/__tests__/index.spec.tsx`
- `pnpm --filter dify-web type-check`
- `pnpm lint web/app/components/plugins/plugin-permissions.ts web/app/components/plugins/plugin-page/use-reference-setting.ts web/app/components/plugins/install-plugin/hooks/use-workspace-plugin-install-permission.ts web/app/components/tools/marketplace/index.tsx web/app/components/plugins/plugin-page/__tests__/use-reference-setting.spec.ts web/app/components/plugins/install-plugin/hooks/__tests__/use-workspace-plugin-install-permission.spec.ts web/app/components/tools/marketplace/__tests__/index.spec.tsx`
- `git diff --check`

From Codex