### PR TITLE
feat(tools): add TwelveLabs video understanding builtin tool

### DIFF
--- a/api/core/tools/builtin_tool/_position.yaml
+++ b/api/core/tools/builtin_tool/_position.yaml
@@ -1,4 +1,5 @@
 - audio
 - code
 - time
+- twelvelabs
 - webscraper

--- a/api/core/tools/builtin_tool/providers/twelvelabs/_assets/icon.svg
+++ b/api/core/tools/builtin_tool/providers/twelvelabs/_assets/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <rect width="24" height="24" rx="6" fill="#1D1D2E"/>
+  <rect x="4" y="6" width="16" height="12" rx="2.5" stroke="#7B61FF" stroke-width="1.6"/>
+  <path d="M10.5 9.5L14.5 12L10.5 14.5V9.5Z" fill="#7B61FF"/>
+</svg>

--- a/api/core/tools/builtin_tool/providers/twelvelabs/tools/analyze.py
+++ b/api/core/tools/builtin_tool/providers/twelvelabs/tools/analyze.py
@@ -1,0 +1,66 @@
+from collections.abc import Generator
+from typing import Any, override
+
+from core.helper import ssrf_proxy
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.errors import ToolInvokeError, ToolProviderCredentialValidationError
+
+DEFAULT_BASE_URL = "https://api.twelvelabs.io/v1.3"
+
+
+class TwelveLabsAnalyzeTool(BuiltinTool):
+    @override
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: dict[str, Any],
+        conversation_id: str | None = None,
+        app_id: str | None = None,
+        message_id: str | None = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        api_key = self.runtime.credentials.get("api_key") if self.runtime else None
+        if not api_key:
+            raise ToolProviderCredentialValidationError("TwelveLabs API key is required.")
+        base_url = (self.runtime.credentials.get("base_url") or DEFAULT_BASE_URL).rstrip("/")
+
+        video_id = tool_parameters.get("video_id")
+        prompt = tool_parameters.get("prompt")
+        if not video_id:
+            yield self.create_text_message("Please provide a TwelveLabs video_id.")
+            return
+        if not prompt:
+            yield self.create_text_message("Please provide a prompt.")
+            return
+
+        payload: dict[str, Any] = {
+            "video_id": video_id,
+            "prompt": prompt,
+            "stream": False,
+        }
+        if tool_parameters.get("temperature") is not None:
+            payload["temperature"] = tool_parameters["temperature"]
+        if tool_parameters.get("max_tokens") is not None:
+            payload["max_tokens"] = tool_parameters["max_tokens"]
+
+        try:
+            response = ssrf_proxy.post(
+                f"{base_url}/analyze",
+                headers={"x-api-key": api_key, "Content-Type": "application/json"},
+                json=payload,
+                timeout=(10, 300),
+            )
+        except Exception as e:
+            raise ToolInvokeError(f"Failed to reach TwelveLabs API: {e}")
+
+        if response.status_code >= 400:
+            raise ToolInvokeError(f"TwelveLabs analyze failed ({response.status_code}): {response.text}")
+
+        try:
+            result = response.json()
+        except ValueError as e:
+            raise ToolInvokeError(f"TwelveLabs returned an invalid response: {e}")
+
+        text = result.get("data", "")
+        yield self.create_text_message(text)
+        yield self.create_json_message(result)

--- a/api/core/tools/builtin_tool/providers/twelvelabs/tools/analyze.yaml
+++ b/api/core/tools/builtin_tool/providers/twelvelabs/tools/analyze.yaml
@@ -1,0 +1,63 @@
+identity:
+  name: analyze
+  author: mohit-twelvelabs
+  label:
+    en_US: Analyze Video
+    zh_Hans: 分析视频
+description:
+  human:
+    en_US: Generate text about an indexed video using the TwelveLabs Pegasus model (summaries, Q&A, descriptions).
+    zh_Hans: 使用 TwelveLabs Pegasus 模型对已索引的视频生成文本（摘要、问答、描述）。
+  llm: >-
+    Analyze an indexed video with the TwelveLabs Pegasus model and return generated text.
+    Requires the video_id of a video already uploaded to a TwelveLabs index, plus a prompt
+    describing what to generate (e.g. "Summarize this video" or "What happens at the end?").
+parameters:
+  - name: video_id
+    type: string
+    required: true
+    label:
+      en_US: Video ID
+      zh_Hans: 视频 ID
+    human_description:
+      en_US: The ID of a video that has already been indexed in TwelveLabs.
+      zh_Hans: 已在 TwelveLabs 中完成索引的视频 ID。
+    llm_description: The TwelveLabs video_id of the indexed video to analyze.
+    form: llm
+  - name: prompt
+    type: string
+    required: true
+    label:
+      en_US: Prompt
+      zh_Hans: 提示词
+    human_description:
+      en_US: Instruction describing what to generate from the video.
+      zh_Hans: 描述要从视频生成什么内容的指令。
+    llm_description: The instruction describing what text to generate from the video.
+    form: llm
+  - name: temperature
+    type: number
+    required: false
+    label:
+      en_US: Temperature
+      zh_Hans: 温度
+    human_description:
+      en_US: Sampling temperature between 0 and 1. Higher values produce more varied output.
+      zh_Hans: 0 到 1 之间的采样温度，值越高输出越多样。
+    form: form
+    default: 0.2
+    min: 0
+    max: 1
+  - name: max_tokens
+    type: number
+    required: false
+    label:
+      en_US: Max Tokens
+      zh_Hans: 最大 Token 数
+    human_description:
+      en_US: Maximum number of tokens to generate.
+      zh_Hans: 生成的最大 token 数。
+    form: form
+    default: 2048
+    min: 1
+    max: 4096

--- a/api/core/tools/builtin_tool/providers/twelvelabs/twelvelabs.py
+++ b/api/core/tools/builtin_tool/providers/twelvelabs/twelvelabs.py
@@ -1,0 +1,33 @@
+from typing import Any, override
+
+from core.helper import ssrf_proxy
+from core.tools.builtin_tool.provider import BuiltinToolProviderController
+from core.tools.builtin_tool.providers.twelvelabs.tools.analyze import DEFAULT_BASE_URL
+from core.tools.errors import ToolProviderCredentialValidationError
+
+
+class TwelveLabsToolProvider(BuiltinToolProviderController):
+    @override
+    def _validate_credentials(self, user_id: str, credentials: dict[str, Any]):
+        api_key = credentials.get("api_key")
+        if not api_key:
+            raise ToolProviderCredentialValidationError("TwelveLabs API key is required.")
+
+        base_url = (credentials.get("base_url") or DEFAULT_BASE_URL).rstrip("/")
+        try:
+            # A cheap authenticated call: listing indexes verifies the key without spending analyze quota.
+            response = ssrf_proxy.get(
+                f"{base_url}/indexes",
+                headers={"x-api-key": api_key},
+                params={"page_limit": 1},
+                timeout=(10, 30),
+            )
+        except Exception as e:
+            raise ToolProviderCredentialValidationError(f"Failed to reach TwelveLabs API: {e}")
+
+        if response.status_code in (401, 403):
+            raise ToolProviderCredentialValidationError("Invalid TwelveLabs API key.")
+        if response.status_code >= 400:
+            raise ToolProviderCredentialValidationError(
+                f"TwelveLabs credential validation failed ({response.status_code}): {response.text}"
+            )

--- a/api/core/tools/builtin_tool/providers/twelvelabs/twelvelabs.yaml
+++ b/api/core/tools/builtin_tool/providers/twelvelabs/twelvelabs.yaml
@@ -1,0 +1,38 @@
+identity:
+  author: mohit-twelvelabs
+  name: twelvelabs
+  label:
+    en_US: TwelveLabs
+    zh_Hans: TwelveLabs
+  description:
+    en_US: Video understanding powered by the TwelveLabs Pegasus model.
+    zh_Hans: 由 TwelveLabs Pegasus 模型驱动的视频理解能力。
+  icon: icon.svg
+  tags:
+    - videos
+credentials_for_provider:
+  api_key:
+    type: secret-input
+    required: true
+    label:
+      en_US: API Key
+      zh_Hans: API 密钥
+    placeholder:
+      en_US: Enter your TwelveLabs API key
+      zh_Hans: 输入你的 TwelveLabs API 密钥
+    help:
+      en_US: Get a free API key at https://twelvelabs.io
+      zh_Hans: 在 https://twelvelabs.io 获取免费 API 密钥
+    url: https://twelvelabs.io
+  base_url:
+    type: text-input
+    required: false
+    label:
+      en_US: API Base URL
+      zh_Hans: API 基础地址
+    placeholder:
+      en_US: https://api.twelvelabs.io/v1.3
+      zh_Hans: https://api.twelvelabs.io/v1.3
+    help:
+      en_US: Override the TwelveLabs API base URL. Defaults to https://api.twelvelabs.io/v1.3
+      zh_Hans: 覆盖 TwelveLabs API 基础地址，默认为 https://api.twelvelabs.io/v1.3

--- a/api/tests/unit_tests/core/tools/test_builtin_tools_extra.py
+++ b/api/tests/unit_tests/core/tools/test_builtin_tools_extra.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import calendar
 import math
+import os
 from datetime import date
 from types import SimpleNamespace
 from zoneinfo import ZoneInfo
@@ -22,12 +23,14 @@ from core.tools.builtin_tool.providers.time.tools.localtime_to_timestamp import 
 from core.tools.builtin_tool.providers.time.tools.timestamp_to_localtime import TimestampToLocaltimeTool
 from core.tools.builtin_tool.providers.time.tools.timezone_conversion import TimezoneConversionTool
 from core.tools.builtin_tool.providers.time.tools.weekday import WeekdayTool
+from core.tools.builtin_tool.providers.twelvelabs.tools.analyze import TwelveLabsAnalyzeTool
+from core.tools.builtin_tool.providers.twelvelabs.twelvelabs import TwelveLabsToolProvider
 from core.tools.builtin_tool.providers.webscraper.tools.webscraper import WebscraperTool
 from core.tools.builtin_tool.providers.webscraper.webscraper import WebscraperProvider
 from core.tools.builtin_tool.tool import BuiltinTool
 from core.tools.entities.common_entities import I18nObject
 from core.tools.entities.tool_entities import ToolEntity, ToolIdentity, ToolInvokeMessage
-from core.tools.errors import ToolInvokeError
+from core.tools.errors import ToolInvokeError, ToolProviderCredentialValidationError
 from graphon.file import FileType
 from graphon.model_runtime.entities.model_entities import ModelPropertyKey
 
@@ -342,3 +345,108 @@ def test_provider_classes_and_builtin_sort(monkeypatch: pytest.MonkeyPatch):
     )
     sorted_providers = BuiltinToolProviderSort.sort(providers)
     assert [p.name for p in sorted_providers] == ["a", "b"]
+
+
+def _build_twelvelabs_tool(credentials: dict[str, str]) -> TwelveLabsAnalyzeTool:
+    entity = ToolEntity(
+        identity=ToolIdentity(
+            author="mohit-twelvelabs",
+            name="analyze",
+            label=I18nObject(en_US="Analyze Video"),
+            provider="twelvelabs",
+        ),
+        parameters=[],
+    )
+    runtime = ToolRuntime(tenant_id="tenant-1", credentials=credentials, invoke_from=InvokeFrom.DEBUGGER)
+    return TwelveLabsAnalyzeTool(provider="twelvelabs", entity=entity, runtime=runtime)
+
+
+def test_twelvelabs_provider_and_tool_load():
+    # Real YAML-driven __init__ exercises provider identity + tool loading.
+    provider = TwelveLabsToolProvider()
+    assert provider.entity.identity.name == "twelvelabs"
+    tool_names = {tool.entity.identity.name for tool in provider.get_tools()}
+    assert "analyze" in tool_names
+    # api_key is a required secret credential.
+    schema = {c.name: c for c in provider.get_credentials_schema()}
+    assert schema["api_key"].required is True
+
+
+def test_twelvelabs_missing_credentials():
+    tool = _build_twelvelabs_tool(credentials={})
+    with pytest.raises(ToolProviderCredentialValidationError):
+        list(tool.invoke(user_id="u", tool_parameters={"video_id": "v", "prompt": "p"}))
+
+
+def test_twelvelabs_missing_params():
+    tool = _build_twelvelabs_tool(credentials={"api_key": "k"})
+    no_video = list(tool.invoke(user_id="u", tool_parameters={"prompt": "p"}))[0].message.text
+    assert "video_id" in no_video
+    no_prompt = list(tool.invoke(user_id="u", tool_parameters={"video_id": "v"}))[0].message.text
+    assert "prompt" in no_prompt
+
+
+def test_twelvelabs_analyze_no_network(monkeypatch: pytest.MonkeyPatch):
+    tool = _build_twelvelabs_tool(credentials={"api_key": "k"})
+    captured: dict[str, object] = {}
+
+    class _Resp:
+        status_code = 200
+
+        @staticmethod
+        def json() -> dict[str, object]:
+            return {"id": "abc", "data": "A calm forest scene.", "finish_reason": "stop"}
+
+    def _fake_post(url: str, **kwargs: object) -> _Resp:
+        captured["url"] = url
+        captured["headers"] = kwargs.get("headers")
+        captured["json"] = kwargs.get("json")
+        return _Resp()
+
+    monkeypatch.setattr("core.tools.builtin_tool.providers.twelvelabs.tools.analyze.ssrf_proxy.post", _fake_post)
+    messages = list(
+        tool.invoke(
+            user_id="u",
+            tool_parameters={"video_id": "vid123", "prompt": "Describe.", "temperature": 0.3},
+        )
+    )
+    assert messages[0].message.text == "A calm forest scene."
+    assert captured["url"] == "https://api.twelvelabs.io/v1.3/analyze"
+    assert captured["headers"]["x-api-key"] == "k"  # type: ignore[index]
+    assert captured["json"]["video_id"] == "vid123"  # type: ignore[index]
+    assert captured["json"]["stream"] is False  # type: ignore[index]
+
+
+def test_twelvelabs_analyze_http_error(monkeypatch: pytest.MonkeyPatch):
+    tool = _build_twelvelabs_tool(credentials={"api_key": "k"})
+
+    class _Resp:
+        status_code = 404
+        text = "not found"
+
+    monkeypatch.setattr(
+        "core.tools.builtin_tool.providers.twelvelabs.tools.analyze.ssrf_proxy.post",
+        lambda *a, **k: _Resp(),
+    )
+    with pytest.raises(ToolInvokeError, match="404"):
+        list(tool.invoke(user_id="u", tool_parameters={"video_id": "v", "prompt": "p"}))
+
+
+@pytest.mark.skipif(not os.environ.get("TWELVELABS_API_KEY"), reason="requires TWELVELABS_API_KEY")
+def test_twelvelabs_analyze_live():
+    """Live smoke test: validates credentials against the real TwelveLabs API.
+
+    Set TWELVELABS_API_KEY (and optionally TWELVELABS_VIDEO_ID for a full analyze run).
+    """
+    api_key = os.environ["TWELVELABS_API_KEY"]
+    provider = TwelveLabsToolProvider()
+    provider._validate_credentials("u", {"api_key": api_key})  # raises on a bad key
+
+    video_id = os.environ.get("TWELVELABS_VIDEO_ID")
+    if not video_id:
+        pytest.skip("set TWELVELABS_VIDEO_ID to run a full analyze call")
+    tool = _build_twelvelabs_tool(credentials={"api_key": api_key})
+    text = list(tool.invoke(user_id="u", tool_parameters={"video_id": video_id, "prompt": "Summarize this video."}))[
+        0
+    ].message.text
+    assert text


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## Summary

This PR adds an **opt-in TwelveLabs video understanding builtin tool** so Dify workflows and agents can reason over video, not just text and images.

**What it adds**
- A new builtin tool provider `twelvelabs` (under `api/core/tools/builtin_tool/providers/twelvelabs/`).
- An **Analyze Video** tool backed by the TwelveLabs **Pegasus** model: given the `video_id` of a video already indexed in TwelveLabs plus a prompt, it returns generated text (summaries, Q&A, descriptions). Optional `temperature` and `max_tokens` parameters are supported.
- Provider credentials: an `api_key` (secret) and an optional `base_url` override (defaults to `https://api.twelvelabs.io/v1.3`). Credentials are validated with a cheap authenticated call to `/indexes`.
- Registration in `_position.yaml`, an SVG icon, and en_US / zh_Hans labels following the existing builtin-tool conventions.

**Why it helps Dify**
Video understanding is a common gap in LLM apps. This lets builders drop a node into a workflow that turns an indexed video into text an agent or downstream node can use, with no new Python dependency — it calls the public REST API through `ssrf_proxy`, exactly like other HTTP-based builtin tools.

**Opt-in / non-breaking**
The provider is inert until a user supplies an API key. No defaults change and no existing behavior is touched.

**How it was tested**
- Unit tests added in `test_builtin_tools_extra.py`: YAML-driven provider + tool loading, missing-credential and missing-parameter paths, a no-network mocked invoke asserting request wiring (URL, `x-api-key` header, payload), and HTTP error handling.
- A live smoke test gated on `TWELVELABS_API_KEY` (skipped without it). I ran the full suite against the real API with a valid key and an indexed sample video — all 6 tests pass, and a real `/analyze` call returned a correct one-sentence summary of the test video.
- `ruff check`, `ruff format --check`, and `mypy` are clean on the changed files.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

---

Note: per CONTRIBUTING I should open an issue first — I'm happy to file one to track this if maintainers prefer, and to adjust scope based on your guidance. No related issue exists yet, so this PR doubles as the proposal.

From Claude Code
