### PR TITLE
chore(api): surface pyrefly output on type-check failures

### DIFF
--- a/api/libs/pyrefly_diagnostics.py
+++ b/api/libs/pyrefly_diagnostics.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import argparse
 import sys
 
-_DIAGNOSTIC_PREFIXES = ("ERROR ", "WARNING ")
+_DIAGNOSTIC_PREFIXES = ("ERROR ", "WARN ", "WARNING ")
 _LOCATION_PREFIX = "-->"
 
 
@@ -13,7 +14,7 @@ def extract_diagnostics(raw_output: str) -> str:
 
     The full pyrefly output includes code excerpts and carets, which create noisy
     diffs. This helper keeps only:
-    - diagnostic headline lines (``ERROR ...`` / ``WARNING ...``)
+    - diagnostic headline lines (``ERROR ...`` / ``WARN ...`` / ``WARNING ...``)
     - the following location line (``--> path:line:column``), when present
     """
 
@@ -36,11 +37,28 @@ def extract_diagnostics(raw_output: str) -> str:
     return "\n".join(diagnostics) + "\n"
 
 
+def render_diagnostics(raw_output: str, exit_code: int) -> str:
+    """Render concise diagnostics and fall back to raw output on unmatched failures."""
+
+    diagnostics = extract_diagnostics(raw_output)
+    if diagnostics:
+        return diagnostics
+
+    if exit_code != 0:
+        return raw_output
+
+    return ""
+
+
 def main() -> int:
     """Read pyrefly output from stdin and print normalized diagnostics."""
 
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--status", type=int, default=0)
+    args = parser.parse_args()
+
     raw_output = sys.stdin.read()
-    sys.stdout.write(extract_diagnostics(raw_output))
+    sys.stdout.write(render_diagnostics(raw_output, exit_code=args.status))
     return 0
 
 

--- a/api/tests/unit_tests/libs/test_pyrefly_diagnostics.py
+++ b/api/tests/unit_tests/libs/test_pyrefly_diagnostics.py
@@ -1,4 +1,4 @@
-from libs.pyrefly_diagnostics import extract_diagnostics
+from libs.pyrefly_diagnostics import extract_diagnostics, render_diagnostics
 
 
 def test_extract_diagnostics_keeps_only_summary_and_location_lines() -> None:
@@ -38,6 +38,37 @@ def test_extract_diagnostics_handles_error_without_location_line() -> None:
 
     # Assert
     assert diagnostics == "ERROR unexpected pyrefly output format [bad-format]\n"
+
+
+def test_extract_diagnostics_keeps_warn_headlines_and_location_lines() -> None:
+    # Arrange
+    raw_output = """INFO Checking project configured at `/tmp/project/pyrefly.toml`
+WARN Skipping include pattern `/tmp/project/tests` because it is matched by `project-excludes`.
+   --> tests/test_containers_integration_tests/pyrefly.toml:3:1
+"""
+
+    # Act
+    diagnostics = extract_diagnostics(raw_output)
+
+    # Assert
+    assert diagnostics == (
+        "WARN Skipping include pattern `/tmp/project/tests` because it is matched by `project-excludes`.\n"
+        "   --> tests/test_containers_integration_tests/pyrefly.toml:3:1\n"
+    )
+
+
+def test_render_diagnostics_falls_back_to_raw_output_for_nonzero_exit_without_matches() -> None:
+    # Arrange
+    raw_output = (
+        "INFO Checking project configured at `/tmp/project/pyrefly.toml`\n"
+        "No Python files matched pattern `/tmp/project/tests/test_containers_integration_tests`\n"
+    )
+
+    # Act
+    diagnostics = render_diagnostics(raw_output, exit_code=1)
+
+    # Assert
+    assert diagnostics == raw_output
 
 
 def test_extract_diagnostics_returns_empty_for_non_error_output() -> None:

--- a/dev/pyrefly-check-local
+++ b/dev/pyrefly-check-local
@@ -44,7 +44,7 @@ run_pyrefly() {
   local pyrefly_status=$?
   set -e
 
-  uv run --directory api python libs/pyrefly_diagnostics.py < "$tmp_output"
+  uv run --directory api python libs/pyrefly_diagnostics.py --status "$pyrefly_status" < "$tmp_output"
   rm -f "$tmp_output"
   return "$pyrefly_status"
 }


### PR DESCRIPTION
**AI disclosure**: This PR was primarily drafted with Codex using GPT-5.4. I have reviewed and edited the final diff, and I am responsible for the content.

Fixes #37932

## Summary

This fixes the local `pyrefly` wrapper used by `make type-check` so type-check failures stop disappearing behind the normalization layer.

- accept `WARN ` headline diagnostics from current `pyrefly` output
- add a fallback that prints the raw `pyrefly` output when the formatter cannot extract normalized diagnostics from a non-zero run
- pass the `pyrefly` exit status from `dev/pyrefly-check-local` into the formatter
- add focused unit coverage for both cases

Validation:

- `uv run --project api --dev pytest api/tests/unit_tests/libs/test_pyrefly_diagnostics.py -q`
- `printf 'INFO Checking project configured at \`/tmp/project/pyrefly.toml\`\nNo Python files matched pattern \`/tmp/project/tests/test_containers_integration_tests\`\n' | uv run --directory api python libs/pyrefly_diagnostics.py --status 1`

## Screenshots

| Before | After |
|--------|-------|
| `make type-check` could stop at `make: *** [Makefile:93: type-check] Error 1` without surfacing the underlying `pyrefly` failure. | The wrapper now prints either normalized `WARN ...` diagnostics or the raw `pyrefly` failure output before returning the non-zero exit. |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Codex
