### PR TITLE
refactor(test): replace SimpleNamespace with real UploadFile model in test_dataset_models.py

### DIFF
--- a/api/tests/unit_tests/models/test_dataset_models.py
+++ b/api/tests/unit_tests/models/test_dataset_models.py
@@ -12,7 +12,6 @@ This test suite covers:
 import json
 import pickle
 from datetime import UTC, datetime
-from types import SimpleNamespace
 from unittest.mock import Mock, patch
 from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
@@ -20,6 +19,7 @@ from uuid import uuid4
 import pytest
 
 from core.rag.index_processor.constant.index_type import IndexTechniqueType
+from extensions.storage.storage_type import StorageType
 from models.dataset import (
     AppDatasetJoin,
     ChildChunk,
@@ -32,12 +32,14 @@ from models.dataset import (
     ExternalKnowledgeBindings,
 )
 from models.enums import (
+    CreatorUserRole,
     DataSourceType,
     DocumentCreatedFrom,
     IndexingStatus,
     ProcessRuleMode,
     SegmentStatus,
 )
+from models.model import UploadFile
 
 
 class TestDatasetModelValidation:
@@ -719,13 +721,20 @@ class TestDocumentSegmentIndexing:
             created_by="user-1",
         )
         segment.id = "segment-1"
-        attachment = SimpleNamespace(
-            id="upload-1",
+        attachment = UploadFile(
+            tenant_id="tenant-1",
+            storage_type=StorageType.LOCAL,
+            key="upload-1-key",
             name="image.png",
             size=128,
             extension="png",
             mime_type="image/png",
+            created_by_role=CreatorUserRole.ACCOUNT,
+            created_by="user-1",
+            created_at=datetime(2023, 11, 14, tzinfo=UTC),
+            used=False,
         )
+        attachment.id = "upload-1"
 
         monkeypatch.setattr("models.dataset.time.time", lambda: 1700000000)
         monkeypatch.setattr("models.dataset.os.urandom", lambda _: b"\x01" * 16)


### PR DESCRIPTION
## Summary

Part of #37604 (incremental `SimpleNamespace` → real-model-instance cleanup the maintainer invited for file-by-file PRs).

This converts the single `SimpleNamespace` stand-in in `api/tests/unit_tests/models/test_dataset_models.py` (inside `test_document_segment_attachments_prefers_files_url_for_source_url`) to a real `UploadFile` ORM instance:

- Replace `SimpleNamespace(id=..., name=..., size=..., extension=..., mime_type=...)` with `UploadFile(...)`, supplying the constructor's required fields and setting `attachment.id` after construction (the `id` is auto-generated, mirroring the existing `segment.id = "segment-1"` style in the same test).
- The construction matches the established convention already used elsewhere in the suite (e.g. `tests/unit_tests/core/app/task_pipeline/test_easy_ui_based_generate_task_pipeline_core.py` and `tests/unit_tests/controllers/console/datasets/test_datasets.py`).
- Drop the now-unused `from types import SimpleNamespace` import; add `UploadFile`, `StorageType`, and `CreatorUserRole` imports.

Using a real model instance makes the test type-safe and surfaces attribute drift (renamed/removed fields) that `SimpleNamespace` silently hid.

This is a focused, behavior-preserving test refactor — no production code changes.

### Verification
- `uv run pytest tests/unit_tests/models/test_dataset_models.py` → 48 passed
- `uv run ruff check` / `ruff format --check` on the file → clean
- `uv run pyrefly check` on the file → no new errors introduced

## Screenshots

N/A — test-only change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran the file-scoped equivalents of `make lint` / `make type-check` (`ruff check`, `ruff format --check`, `pyrefly check`) on the changed file — clean / no new errors.

From Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBVXLzDtt5GcRQeJfStmUw