### PR TITLE
feat(mcp): support dynamic HTTP request headers in MCPClient

### DIFF
--- a/api/core/mcp/mcp_client.py
+++ b/api/core/mcp/mcp_client.py
@@ -1,9 +1,12 @@
 import logging
+import re
 from collections.abc import Callable
 from contextlib import AbstractContextManager, ExitStack
 from types import TracebackType
 from typing import Any
 from urllib.parse import urlparse
+
+from flask import has_request_context, request
 
 from core.mcp.client.sse_client import sse_client
 from core.mcp.client.streamable_client import streamablehttp_client
@@ -23,9 +26,21 @@ class MCPClient:
         sse_read_timeout: float | None = None,
     ):
         self.server_url = server_url
-        self.headers = headers or {}
+        self.headers = headers.copy() if headers else {}
         self.timeout = timeout
         self.sse_read_timeout = sse_read_timeout
+
+        # Substitute placeholders with incoming request headers if in a request context
+        if has_request_context() and self.headers:
+            pattern = re.compile(r"\{\{\s*request\.headers?\.(.+?)\s*\}\}", re.IGNORECASE)
+            for key, value in list(self.headers.items()):
+                if isinstance(value, str):
+
+                    def replace_func(match):
+                        header_name = match.group(1)
+                        return request.headers.get(header_name, "")
+
+                    self.headers[key] = pattern.sub(replace_func, value)
 
         # Initialize session and client objects
         self._session: ClientSession | None = None

--- a/api/tests/unit_tests/core/mcp/test_mcp_client.py
+++ b/api/tests/unit_tests/core/mcp/test_mcp_client.py
@@ -43,6 +43,57 @@ class TestMCPClient:
         assert client.timeout is None
         assert client.sse_read_timeout is None
 
+    def test_init_with_dynamic_request_headers(self):
+        """Test client initialization with dynamic request headers."""
+        from flask import Flask
+
+        app = Flask("test")
+        with app.test_request_context(headers={"X-Custom-Auth": "my-secret-token", "X-User-Id": "user123"}):
+            client = MCPClient(
+                server_url="http://test.example.com",
+                headers={
+                    "Authorization": "Bearer {{request.headers.X-Custom-Auth}}",
+                    "X-Request-User": "{{request.header.X-User-Id}}",
+                    "X-Static-Header": "static-val",
+                },
+            )
+
+            assert client.headers == {
+                "Authorization": "Bearer my-secret-token",
+                "X-Request-User": "user123",
+                "X-Static-Header": "static-val",
+            }
+
+    def test_init_with_dynamic_request_headers_missing(self):
+        """Test client initialization with dynamic request headers that are missing."""
+        from flask import Flask
+
+        app = Flask("test")
+        with app.test_request_context(headers={}):
+            client = MCPClient(
+                server_url="http://test.example.com",
+                headers={
+                    "Authorization": "Bearer {{request.headers.X-Custom-Auth}}",
+                },
+            )
+
+            assert client.headers == {
+                "Authorization": "Bearer ",
+            }
+
+    def test_init_with_dynamic_request_headers_no_context(self):
+        """Test client initialization with dynamic request headers but no request context."""
+        client = MCPClient(
+            server_url="http://test.example.com",
+            headers={
+                "Authorization": "Bearer {{request.headers.X-Custom-Auth}}",
+            },
+        )
+
+        assert client.headers == {
+            "Authorization": "Bearer {{request.headers.X-Custom-Auth}}",
+        }
+
     @patch("core.mcp.mcp_client.streamablehttp_client")
     @patch("core.mcp.mcp_client.ClientSession")
     def test_initialize_with_mcp_url(self, mock_client_session, mock_streamable_client):


### PR DESCRIPTION
Fixes #37912

## Summary

This PR enables dynamic HTTP request header injection into MCP (Model Context Protocol) client connections. Users can configure headers with placeholders (e.g. `{{request.headers.X-Custom-Auth}}` or `{{request.header.X-Custom-Auth}}`), which are dynamically substituted at runtime using the incoming HTTP request headers to Dify.

*   Modified `MCPClient.__init__` in `api/core/mcp/mcp_client.py` to check for Flask's request context and perform dynamic placeholder substitution.
*   Added comprehensive unit tests in `api/tests/unit_tests/core/mcp/test_mcp_client.py` validating matching, missing, and no-request-context behaviors.

## Screenshots
<img width="1024" height="665" alt="mcp" src="https://github.com/user-attachments/assets/15443057-1053-4f71-9841-2f1f37b8b28d" />


N/A (Backend change)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) to appease the lint gods