### PR TITLE
fix(web): use real HTMLMediaElement events in audio-btn player

### DIFF
--- a/web/app/components/base/audio-btn/__tests__/audio.spec.ts
+++ b/web/app/components/base/audio-btn/__tests__/audio.spec.ts
@@ -20,7 +20,7 @@ vi.mock('@/service/share', () => ({
   textToAudioStream: (...args: unknown[]) => mockTextToAudioStream(...args),
 }))
 
-type AudioEventName = 'ended' | 'paused' | 'loaded' | 'play' | 'timeupdate' | 'loadeddate' | 'canplay' | 'error' | 'sourceopen'
+type AudioEventName = 'ended' | 'pause' | 'play' | 'timeupdate' | 'loadeddata' | 'canplay' | 'error' | 'sourceopen'
 
 type AudioEventListener = () => void
 
@@ -285,10 +285,9 @@ describe('AudioPlayer', () => {
       audio!.emit('play')
       audio!.emit('ended')
       audio!.emit('error')
-      audio!.emit('paused')
-      audio!.emit('loaded')
+      audio!.emit('pause')
+      audio!.emit('loadeddata')
       audio!.emit('timeupdate')
-      audio!.emit('loadeddate')
       audio!.emit('canplay')
 
       expect(player.callback).toBe(callback)

--- a/web/app/components/base/audio-btn/audio.ts
+++ b/web/app/components/base/audio-btn/audio.ts
@@ -66,20 +66,18 @@ export default class AudioPlayer {
       this.audio.addEventListener('ended', () => {
         callback('ended')
       }, false)
-      this.audio.addEventListener('paused', () => {
+      this.audio.addEventListener('pause', () => {
         callback('paused')
       }, true)
-      this.audio.addEventListener('loaded', () => {
+      this.audio.addEventListener('loadeddata', () => {
         callback('loaded')
+        callback('loadeddate')
       }, true)
       this.audio.addEventListener('play', () => {
         callback('play')
       }, true)
       this.audio.addEventListener('timeupdate', () => {
         callback('timeupdate')
-      }, true)
-      this.audio.addEventListener('loadeddate', () => {
-        callback('loadeddate')
       }, true)
       this.audio.addEventListener('canplay', () => {
         callback('canplay')


### PR DESCRIPTION
Fixes #37840. Register pause and loadeddata listeners instead of invalid paused, loaded, and loadeddate event names. Callback contract unchanged.