### PR TITLE
refactor(api): migrate workspace tool endpoints to BaseModel

### DIFF
--- a/api/controllers/console/workspace/tool_providers.py
+++ b/api/controllers/console/workspace/tool_providers.py
@@ -1,16 +1,25 @@
 import io
 import logging
-from typing import Any, Literal
+from collections.abc import Iterable, Mapping
+from datetime import datetime
+from typing import Any, Literal, cast
 from urllib.parse import urlparse
 
 from flask import make_response, redirect, request, send_file
 from flask_restx import Resource
-from pydantic import BaseModel, Field, HttpUrl, RootModel, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    HttpUrl,
+    RootModel,
+    field_validator,
+    model_validator,
+)
 from sqlalchemy.orm import sessionmaker
 from werkzeug.exceptions import Forbidden
 
 from configs import dify_config
-from controllers.common.fields import BinaryFileResponse, RedirectResponse, SimpleResultResponse
+from controllers.common.fields import SimpleResultResponse
 from controllers.common.schema import (
     query_params_from_model,
     query_params_from_request,
@@ -31,22 +40,36 @@ from controllers.console.wraps import (
 )
 from core.db.session_factory import session_factory
 from core.entities.mcp_provider import IdentityMode, MCPAuthentication, MCPConfiguration
+from core.entities.provider_entities import ProviderConfig
 from core.mcp.auth.auth_flow import auth, handle_callback
 from core.mcp.error import MCPAuthError, MCPError, MCPRefreshTokenError
 from core.mcp.mcp_client import MCPClient
 from core.plugin.entities.plugin_daemon import CredentialType, PluginOAuthAuthorizationUrlResponse
 from core.plugin.impl.oauth import OAuthHandler
-from core.tools.entities.tool_entities import ApiProviderSchemaType, WorkflowToolParameterConfiguration
+from core.tools.entities.api_entities import (
+    ToolApiEntity,
+    ToolProviderCredentialApiEntity,
+    ToolProviderCredentialInfoApiEntity,
+    ToolProviderTypeApiLiteral,
+)
+from core.tools.entities.common_entities import I18nObject
+from core.tools.entities.tool_bundle import ApiToolBundle
+from core.tools.entities.tool_entities import (
+    ApiProviderSchemaType,
+    ToolLabel,
+    ToolProviderType,
+    WorkflowToolParameterConfiguration,
+)
 from extensions.ext_database import db
-from graphon.model_runtime.utils.encoders import jsonable_encoder
-from libs.helper import alphanumeric, uuid_value
+from fields.base import ResponseModel
+from libs.helper import alphanumeric, dump_response, uuid_value
 from libs.login import login_required
 from models import Account
 from models.provider_ids import ToolProviderID
 
 # from models.provider_ids import ToolProviderID
 from services.plugin.oauth_service import OAuthProxyService
-from services.tools.api_tools_manage_service import ApiToolManageService
+from services.tools.api_tools_manage_service import ApiToolManageService, ApiToolPreviewResult
 from services.tools.builtin_tools_manage_service import BuiltinToolManageService
 from services.tools.mcp_tools_manage_service import MCPToolManageService, OAuthDataType
 from services.tools.tool_labels_service import ToolLabelsService
@@ -85,8 +108,13 @@ class BuiltinToolAddPayload(BaseModel):
 
 class BuiltinToolUpdatePayload(BaseModel):
     credential_id: str
-    credentials: dict[str, Any] | None = Field(default=None)
+    credentials: dict[str, Any] | None = None
     name: str | None = Field(default=None, max_length=30)
+
+
+class ToolEmojiIcon(BaseModel):
+    background: str
+    content: str
 
 
 class ApiToolProviderBasePayload(BaseModel):
@@ -94,7 +122,7 @@ class ApiToolProviderBasePayload(BaseModel):
     schema_type: ApiProviderSchemaType
     schema_: str = Field(alias="schema")
     provider: str
-    icon: dict[str, Any]
+    icon: ToolEmojiIcon
     privacy_policy: str | None = None
     labels: list[str] | None = None
     custom_disclaimer: str = ""
@@ -144,7 +172,7 @@ class WorkflowToolBasePayload(BaseModel):
     name: str
     label: str
     description: str
-    icon: dict[str, Any]
+    icon: ToolEmojiIcon
     parameters: list[WorkflowToolParameterConfiguration] = Field(default_factory=list)
     privacy_policy: str | None = ""
     labels: list[str] | None = None
@@ -214,7 +242,7 @@ class BuiltinProviderDefaultCredentialPayload(BaseModel):
 
 
 class ToolOAuthCustomClientPayload(BaseModel):
-    client_params: dict[str, Any] | None = Field(default=None)
+    client_params: dict[str, Any] | None = None
     enable_oauth_custom_client: bool | None = True
 
 
@@ -225,12 +253,19 @@ class MCPProviderBasePayload(BaseModel):
     icon_type: str
     icon_background: str = ""
     server_identifier: str
-    configuration: dict[str, Any] | None = Field(default_factory=dict)
-    headers: dict[str, Any] | None = Field(default_factory=dict)
-    authentication: dict[str, Any] | None = Field(default_factory=dict)
+    configuration: MCPConfiguration | None = None
+    headers: dict[str, str] | None = None
+    authentication: MCPAuthentication | None = None
     # None means "leave unchanged" on update; the controller resolves it to a
     # concrete IdentityMode before calling the service (see _resolve_identity_mode).
     identity_mode: IdentityMode | None = None
+
+    @field_validator("authentication", "configuration", mode="before")
+    @classmethod
+    def empty_to_none(cls, value: object) -> object:
+        if value == {}:
+            return None
+        return value
 
 
 def _resolve_identity_mode(requested: IdentityMode | None, *, current: IdentityMode) -> IdentityMode:
@@ -276,16 +311,124 @@ class MCPCallbackQuery(BaseModel):
     state: str
 
 
-class ToolOAuthCustomClientResponse(RootModel[dict[str, Any]]):
-    root: dict[str, Any]
+class ApiProviderDetailResponse(ResponseModel):
+    schema_type: ApiProviderSchemaType
+    schema_: str = Field(alias="schema")
+    tools: list[ApiToolBundle]
+    icon: ToolEmojiIcon
+    description: str | None = None
+    credentials: Mapping[str, object] = Field(default_factory=dict)
+    privacy_policy: str | None = None
+    custom_disclaimer: str | None = None
+    labels: list[str] = Field(default_factory=list)
 
 
-class ToolOAuthClientSchemaResponse(RootModel[list[dict[str, Any]]]):
-    root: list[dict[str, Any]]
+class ApiSchemaParseResponse(ResponseModel):
+    schema_type: ApiProviderSchemaType
+    parameters_schema: list[ApiToolBundle]
+    credentials_schema: list[ProviderConfig]
+    warning: dict[str, str]
 
 
-class ToolProviderOpaqueResponse(RootModel[Any]):
-    root: Any
+class ApiProviderRemoteSchemaResponse(ResponseModel):
+    schema_: str = Field(alias="schema")
+
+
+class ApiToolPreviewResponse(RootModel[ApiToolPreviewResult]):
+    pass
+
+
+class BuiltinProviderOAuthClientSchemaResponse(ResponseModel):
+    schema_: list[ProviderConfig] = Field(alias="schema")
+    is_oauth_custom_client_enabled: bool
+    is_system_oauth_params_exists: bool
+    client_params: Mapping[str, object] | None = None
+    redirect_uri: str
+
+
+class MCPAuthResponse(ResponseModel):
+    result: Literal["success"] | None = None
+    authorization_url: str | None = None
+
+
+class ToolApiListResponse(RootModel[list[ToolApiEntity]]):
+    pass
+
+
+# TODO: This duplicates core.tools.entities.api_entities.ToolProviderApiEntity's
+# public response projection. Consolidate the core entity and controller response
+# shape when the tool-provider API serialization boundary is cleaned up.
+class ToolProviderApiEntityResponse(ResponseModel):
+    id: str
+    author: str
+    name: str
+    description: I18nObject
+    icon: str | Mapping[str, str]
+    icon_dark: str | Mapping[str, str] = ""
+    label: I18nObject
+    type: ToolProviderType
+    team_credentials: Mapping[str, object] = Field(default_factory=dict)
+    is_team_authorization: bool = False
+    allow_delete: bool = True
+    plugin_id: str | None = Field(default="", description="The plugin id of the tool")
+    plugin_unique_identifier: str | None = Field(default="", description="The unique identifier of the tool")
+    tools: list[ToolApiEntity] = Field(default_factory=list)
+    labels: list[str] = Field(default_factory=list)
+    server_url: str | None = Field(default="", description="The server url of the tool")
+    updated_at: int = Field(default_factory=lambda: int(datetime.now().timestamp()))
+    server_identifier: str | None = Field(default="", description="The server identifier of the MCP tool")
+    masked_headers: dict[str, str] | None = Field(default=None, description="The masked headers of the MCP tool")
+    original_headers: dict[str, str] | None = Field(default=None, description="The original headers of the MCP tool")
+    authentication: MCPAuthentication | None = Field(default=None, description="The OAuth config of the MCP tool")
+    is_dynamic_registration: bool = Field(default=True, description="Whether the MCP tool is dynamically registered")
+    configuration: MCPConfiguration | None = Field(
+        default=None, description="The timeout and sse_read_timeout of the MCP tool"
+    )
+    identity_mode: str = Field(default="off", description="Identity-forwarding mechanism: 'off' or 'idp_token'")
+    workflow_app_id: str | None = Field(default=None, description="The app id of the workflow tool")
+
+    @field_validator("tools", mode="before")
+    @classmethod
+    def convert_none_to_empty_list(cls, value: list[ToolApiEntity] | None) -> list[ToolApiEntity]:
+        return value if value is not None else []
+
+
+class ToolProviderListResponse(RootModel[list[ToolProviderApiEntityResponse]]):
+    pass
+
+
+def _dump_tool_provider_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    return ToolProviderApiEntityResponse.model_validate(payload).model_dump(mode="json", exclude_unset=True)
+
+
+def _dump_tool_provider_payload_list(payloads: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    return [_dump_tool_provider_payload(payload) for payload in payloads]
+
+
+class ToolProviderCredentialListResponse(RootModel[list[ToolProviderCredentialApiEntity]]):
+    pass
+
+
+class ProviderConfigListResponse(RootModel[list[ProviderConfig]]):
+    pass
+
+
+class ToolLabelListResponse(RootModel[list[ToolLabel]]):
+    pass
+
+
+class WorkflowToolDetailResponse(ResponseModel):
+    name: str
+    label: str
+    workflow_tool_id: str
+    workflow_app_id: str
+    icon: ToolEmojiIcon
+    description: str
+    parameters: list[WorkflowToolParameterConfiguration]
+    output_schema: Mapping[str, object] = Field(default_factory=dict)
+    tool: ToolApiEntity
+    synced: bool
+    privacy_policy: str | None = None
 
 
 register_schema_models(
@@ -297,6 +440,7 @@ register_schema_models(
     WorkflowToolGetQuery,
     WorkflowToolListQuery,
     MCPCallbackQuery,
+    ToolEmojiIcon,
     BuiltinToolCredentialDeletePayload,
     BuiltinToolAddPayload,
     BuiltinToolUpdatePayload,
@@ -317,63 +461,94 @@ register_schema_models(
 )
 register_response_schema_models(
     console_ns,
-    BinaryFileResponse,
-    PluginOAuthAuthorizationUrlResponse,
-    RedirectResponse,
     SimpleResultResponse,
-    ToolOAuthClientSchemaResponse,
-    ToolOAuthCustomClientResponse,
-    ToolProviderOpaqueResponse,
+    ApiProviderDetailResponse,
+    ApiSchemaParseResponse,
+    ApiProviderRemoteSchemaResponse,
+    ApiToolPreviewResponse,
+    BuiltinProviderOAuthClientSchemaResponse,
+    ToolApiListResponse,
+    ToolProviderApiEntityResponse,
+    ToolProviderCredentialInfoApiEntity,
+    ToolProviderCredentialListResponse,
+    ToolProviderListResponse,
+    ProviderConfigListResponse,
+    PluginOAuthAuthorizationUrlResponse,
+    ToolLabelListResponse,
+    MCPAuthResponse,
+    WorkflowToolDetailResponse,
 )
 
 
 @console_ns.route("/workspaces/current/tool-providers")
 class ToolProviderListApi(Resource):
     @console_ns.doc(params=query_params_from_model(ToolProviderListQuery))
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200, "Tool providers retrieved successfully", console_ns.models[ToolProviderListResponse.__name__]
+    )
     @setup_required
     @login_required
     @account_initialization_required
     @with_current_user
     @with_current_tenant_id
     def get(self, tenant_id: str, user: Account):
-        raw_args = request.args.to_dict()
-        query = ToolProviderListQuery.model_validate(raw_args)
+        query = query_params_from_request(ToolProviderListQuery)
 
-        return ToolCommonService.list_tool_providers(user.id, tenant_id, query.type)  # type: ignore
+        return _dump_tool_provider_payload_list(
+            ToolCommonService.list_tool_providers(
+                user.id, tenant_id, cast(ToolProviderTypeApiLiteral | None, query.type)
+            ),
+        )
 
 
 @console_ns.route("/workspaces/current/tool-provider/builtin/<path:provider>/tools")
 class ToolBuiltinProviderListToolsApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200,
+        "Builtin provider tools retrieved successfully",
+        console_ns.models[ToolApiListResponse.__name__],
+    )
     @setup_required
     @login_required
     @account_initialization_required
     @with_current_tenant_id
     def get(self, tenant_id: str, provider: str):
-        return jsonable_encoder(
+
+        return dump_response(
+            ToolApiListResponse,
             BuiltinToolManageService.list_builtin_tool_provider_tools(
                 tenant_id,
                 provider,
-            )
+            ),
         )
 
 
 @console_ns.route("/workspaces/current/tool-provider/builtin/<path:provider>/info")
 class ToolBuiltinProviderInfoApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200,
+        "Builtin provider info retrieved successfully",
+        console_ns.models[ToolProviderApiEntityResponse.__name__],
+    )
     @setup_required
     @login_required
     @account_initialization_required
     @with_current_tenant_id
     def get(self, tenant_id: str, provider: str):
-        return jsonable_encoder(BuiltinToolManageService.get_builtin_tool_provider_info(tenant_id, provider))
+
+        return _dump_tool_provider_payload(
+            BuiltinToolManageService.get_builtin_tool_provider_info(tenant_id, provider).to_dict()
+        )
 
 
 @console_ns.route("/workspaces/current/tool-provider/builtin/<path:provider>/delete")
 class ToolBuiltinProviderDeleteApi(Resource):
     @console_ns.expect(console_ns.models[BuiltinToolCredentialDeletePayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200,
+        "Builtin provider credential deleted successfully",
+        console_ns.models[SimpleResultResponse.__name__],
+    )
     @setup_required
     @login_required
     @is_admin_or_owner_required
@@ -381,19 +556,27 @@ class ToolBuiltinProviderDeleteApi(Resource):
     @account_initialization_required
     @with_current_tenant_id
     def post(self, tenant_id: str, provider: str):
+
         payload = BuiltinToolCredentialDeletePayload.model_validate(console_ns.payload or {})
 
-        return BuiltinToolManageService.delete_builtin_tool_provider(
-            tenant_id,
-            provider,
-            payload.credential_id,
+        return dump_response(
+            SimpleResultResponse,
+            BuiltinToolManageService.delete_builtin_tool_provider(
+                tenant_id,
+                provider,
+                payload.credential_id,
+            ),
         )
 
 
 @console_ns.route("/workspaces/current/tool-provider/builtin/<path:provider>/add")
 class ToolBuiltinProviderAddApi(Resource):
     @console_ns.expect(console_ns.models[BuiltinToolAddPayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200,
+        "Builtin provider added successfully",
+        console_ns.models[SimpleResultResponse.__name__],
+    )
     @setup_required
     @login_required
     @account_initialization_required
@@ -402,21 +585,28 @@ class ToolBuiltinProviderAddApi(Resource):
     def post(self, tenant_id: str, user: Account, provider: str):
         payload = BuiltinToolAddPayload.model_validate(console_ns.payload or {})
 
-        return BuiltinToolManageService.add_builtin_tool_provider(
-            user_id=user.id,
-            tenant_id=tenant_id,
-            provider=provider,
-            credentials=payload.credentials,
-            name=payload.name,
-            api_type=CredentialType.of(payload.type),
-            visibility=payload.visibility,
+        return dump_response(
+            SimpleResultResponse,
+            BuiltinToolManageService.add_builtin_tool_provider(
+                user_id=user.id,
+                tenant_id=tenant_id,
+                provider=provider,
+                credentials=payload.credentials,
+                name=payload.name,
+                api_type=CredentialType.of(payload.type),
+                visibility=payload.visibility,
+            ),
         )
 
 
 @console_ns.route("/workspaces/current/tool-provider/builtin/<path:provider>/update")
 class ToolBuiltinProviderUpdateApi(Resource):
     @console_ns.expect(console_ns.models[BuiltinToolUpdatePayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200,
+        "Builtin provider updated successfully",
+        console_ns.models[SimpleResultResponse.__name__],
+    )
     @setup_required
     @login_required
     @is_admin_or_owner_required
@@ -435,13 +625,17 @@ class ToolBuiltinProviderUpdateApi(Resource):
             credentials=payload.credentials,
             name=payload.name or "",
         )
-        return result
+        return dump_response(SimpleResultResponse, result)
 
 
 @console_ns.route("/workspaces/current/tool-provider/builtin/<path:provider>/credentials")
 class ToolBuiltinProviderGetCredentialsApi(Resource):
     @console_ns.doc(params=query_params_from_model(BuiltinCredentialListQuery))
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200,
+        "Builtin provider credentials retrieved successfully",
+        console_ns.models[ToolProviderCredentialListResponse.__name__],
+    )
     @setup_required
     @login_required
     @account_initialization_required
@@ -455,30 +649,32 @@ class ToolBuiltinProviderGetCredentialsApi(Resource):
             list_fields=("include_credential_ids",),
         )
 
-        return jsonable_encoder(
+        return dump_response(
+            ToolProviderCredentialListResponse,
             BuiltinToolManageService.get_builtin_tool_provider_credentials(
                 tenant_id=tenant_id,
                 provider_name=provider,
                 user=user,
                 include_credential_ids=query.include_credential_ids or None,
-            )
+            ),
         )
 
 
 @console_ns.route("/workspaces/current/tool-provider/builtin/<path:provider>/icon")
 class ToolBuiltinProviderIconApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[BinaryFileResponse.__name__])
+    @console_ns.response(200, "Builtin provider icon")
     @setup_required
     def get(self, provider: str):
         icon_bytes, mimetype = BuiltinToolManageService.get_builtin_tool_provider_icon(provider)
         icon_cache_max_age = dify_config.TOOL_ICON_CACHE_MAX_AGE
+        # response-contract:ignore binary send_file response
         return send_file(io.BytesIO(icon_bytes), mimetype=mimetype, max_age=icon_cache_max_age)
 
 
 @console_ns.route("/workspaces/current/tool-provider/api/add")
 class ToolApiProviderAddApi(Resource):
     @console_ns.expect(console_ns.models[ApiToolProviderAddPayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(200, "API provider added successfully", console_ns.models[SimpleResultResponse.__name__])
     @setup_required
     @login_required
     @is_admin_or_owner_required
@@ -489,66 +685,77 @@ class ToolApiProviderAddApi(Resource):
     def post(self, tenant_id: str, user: Account):
         payload = ApiToolProviderAddPayload.model_validate(console_ns.payload or {})
 
-        return ApiToolManageService.create_api_tool_provider(
-            user.id,
-            tenant_id,
-            payload.provider,
-            payload.icon,
-            payload.credentials,
-            payload.schema_type,
-            payload.schema_,
-            payload.privacy_policy or "",
-            payload.custom_disclaimer or "",
-            payload.labels or [],
+        return dump_response(
+            SimpleResultResponse,
+            ApiToolManageService.create_api_tool_provider(
+                user.id,
+                tenant_id,
+                payload.provider,
+                payload.icon.model_dump(mode="json"),
+                payload.credentials,
+                payload.schema_type,
+                payload.schema_,
+                payload.privacy_policy or "",
+                payload.custom_disclaimer or "",
+                payload.labels or [],
+            ),
         )
 
 
 @console_ns.route("/workspaces/current/tool-provider/api/remote")
 class ToolApiProviderGetRemoteSchemaApi(Resource):
     @console_ns.doc(params=query_params_from_model(UrlQuery))
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200,
+        "Remote API provider schema retrieved successfully",
+        console_ns.models[ApiProviderRemoteSchemaResponse.__name__],
+    )
     @setup_required
     @login_required
     @account_initialization_required
     @with_current_user
     @with_current_tenant_id
     def get(self, tenant_id: str, user: Account):
-        raw_args = request.args.to_dict()
-        query = UrlQuery.model_validate(raw_args)
+        query = query_params_from_request(UrlQuery)
 
-        return ApiToolManageService.get_api_tool_provider_remote_schema(
-            user.id,
-            tenant_id,
-            str(query.url),
+        return dump_response(
+            ApiProviderRemoteSchemaResponse,
+            ApiToolManageService.get_api_tool_provider_remote_schema(
+                user.id,
+                tenant_id,
+                str(query.url),
+            ),
         )
 
 
 @console_ns.route("/workspaces/current/tool-provider/api/tools")
 class ToolApiProviderListToolsApi(Resource):
     @console_ns.doc(params=query_params_from_model(ProviderQuery))
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200, "API provider tools retrieved successfully", console_ns.models[ToolApiListResponse.__name__]
+    )
     @setup_required
     @login_required
     @account_initialization_required
     @with_current_user
     @with_current_tenant_id
     def get(self, tenant_id: str, user: Account):
-        raw_args = request.args.to_dict()
-        query = ProviderQuery.model_validate(raw_args)
+        query = query_params_from_request(ProviderQuery)
 
-        return jsonable_encoder(
+        return dump_response(
+            ToolApiListResponse,
             ApiToolManageService.list_api_tool_provider_tools(
                 user.id,
                 tenant_id,
                 query.provider,
-            )
+            ),
         )
 
 
 @console_ns.route("/workspaces/current/tool-provider/api/update")
 class ToolApiProviderUpdateApi(Resource):
     @console_ns.expect(console_ns.models[ApiToolProviderUpdatePayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(200, "API provider updated successfully", console_ns.models[SimpleResultResponse.__name__])
     @setup_required
     @login_required
     @is_admin_or_owner_required
@@ -559,25 +766,28 @@ class ToolApiProviderUpdateApi(Resource):
     def post(self, tenant_id: str, user: Account):
         payload = ApiToolProviderUpdatePayload.model_validate(console_ns.payload or {})
 
-        return ApiToolManageService.update_api_tool_provider(
-            user.id,
-            tenant_id,
-            payload.provider,
-            payload.original_provider,
-            payload.icon,
-            payload.credentials,
-            payload.schema_type,
-            payload.schema_,
-            payload.privacy_policy,
-            payload.custom_disclaimer,
-            payload.labels or [],
+        return dump_response(
+            SimpleResultResponse,
+            ApiToolManageService.update_api_tool_provider(
+                user.id,
+                tenant_id,
+                payload.provider,
+                payload.original_provider,
+                payload.icon.model_dump(mode="json"),
+                payload.credentials,
+                payload.schema_type,
+                payload.schema_,
+                payload.privacy_policy,
+                payload.custom_disclaimer,
+                payload.labels or [],
+            ),
         )
 
 
 @console_ns.route("/workspaces/current/tool-provider/api/delete")
 class ToolApiProviderDeleteApi(Resource):
     @console_ns.expect(console_ns.models[ApiToolProviderDeletePayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(200, "API provider deleted successfully", console_ns.models[SimpleResultResponse.__name__])
     @setup_required
     @login_required
     @is_admin_or_owner_required
@@ -588,88 +798,106 @@ class ToolApiProviderDeleteApi(Resource):
     def post(self, tenant_id: str, user: Account):
         payload = ApiToolProviderDeletePayload.model_validate(console_ns.payload or {})
 
-        return ApiToolManageService.delete_api_tool_provider(
-            user.id,
-            tenant_id,
-            payload.provider,
+        return dump_response(
+            SimpleResultResponse,
+            ApiToolManageService.delete_api_tool_provider(
+                user.id,
+                tenant_id,
+                payload.provider,
+            ),
         )
 
 
 @console_ns.route("/workspaces/current/tool-provider/api/get")
 class ToolApiProviderGetApi(Resource):
     @console_ns.doc(params=query_params_from_model(ProviderQuery))
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200, "API provider retrieved successfully", console_ns.models[ApiProviderDetailResponse.__name__]
+    )
     @setup_required
     @login_required
     @account_initialization_required
     @with_current_user
     @with_current_tenant_id
     def get(self, tenant_id: str, user: Account):
-        raw_args = request.args.to_dict()
-        query = ProviderQuery.model_validate(raw_args)
+        query = query_params_from_request(ProviderQuery)
 
-        return ApiToolManageService.get_api_tool_provider(
-            user.id,
-            tenant_id,
-            query.provider,
+        return dump_response(
+            ApiProviderDetailResponse,
+            ApiToolManageService.get_api_tool_provider(
+                user.id,
+                tenant_id,
+                query.provider,
+            ),
         )
 
 
 @console_ns.route("/workspaces/current/tool-provider/builtin/<path:provider>/credential/schema/<path:credential_type>")
 class ToolBuiltinProviderCredentialsSchemaApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200,
+        "Builtin provider credential schema retrieved successfully",
+        console_ns.models[ProviderConfigListResponse.__name__],
+    )
     @setup_required
     @login_required
     @account_initialization_required
     @with_current_tenant_id
     def get(self, tenant_id: str, provider, credential_type):
-        return jsonable_encoder(
+
+        return dump_response(
+            ProviderConfigListResponse,
             BuiltinToolManageService.list_builtin_provider_credentials_schema(
                 provider, CredentialType.of(credential_type), tenant_id
-            )
+            ),
         )
 
 
 @console_ns.route("/workspaces/current/tool-provider/api/schema")
 class ToolApiProviderSchemaApi(Resource):
     @console_ns.expect(console_ns.models[ApiToolSchemaPayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(200, "API schema parsed successfully", console_ns.models[ApiSchemaParseResponse.__name__])
     @setup_required
     @login_required
     @account_initialization_required
     def post(self):
         payload = ApiToolSchemaPayload.model_validate(console_ns.payload or {})
 
-        return ApiToolManageService.parser_api_schema(
-            schema=payload.schema_,
-        )
+        return dump_response(ApiSchemaParseResponse, ApiToolManageService.parser_api_schema(schema=payload.schema_))
 
 
 @console_ns.route("/workspaces/current/tool-provider/api/test/pre")
 class ToolApiProviderPreviousTestApi(Resource):
     @console_ns.expect(console_ns.models[ApiToolTestPayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200,
+        "API tool test preview completed successfully",
+        console_ns.models[ApiToolPreviewResponse.__name__],
+    )
     @setup_required
     @login_required
     @account_initialization_required
     @with_current_tenant_id
     def post(self, current_tenant_id: str):
         payload = ApiToolTestPayload.model_validate(console_ns.payload or {})
-        return ApiToolManageService.test_api_tool_preview(
-            current_tenant_id,
-            payload.provider_name or "",
-            payload.tool_name,
-            payload.credentials,
-            payload.parameters,
-            payload.schema_type,
-            payload.schema_,
+        return dump_response(
+            ApiToolPreviewResponse,
+            ApiToolManageService.test_api_tool_preview(
+                current_tenant_id,
+                payload.provider_name or "",
+                payload.tool_name,
+                payload.credentials,
+                payload.parameters,
+                payload.schema_type,
+                payload.schema_,
+            ),
         )
 
 
 @console_ns.route("/workspaces/current/tool-provider/workflow/create")
 class ToolWorkflowProviderCreateApi(Resource):
     @console_ns.expect(console_ns.models[WorkflowToolCreatePayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(200, "Workflow tool created successfully", console_ns.models[SimpleResultResponse.__name__])
     @setup_required
     @login_required
     @is_admin_or_owner_required
@@ -680,24 +908,27 @@ class ToolWorkflowProviderCreateApi(Resource):
     def post(self, tenant_id: str, user: Account):
         payload = WorkflowToolCreatePayload.model_validate(console_ns.payload or {})
 
-        return WorkflowToolManageService.create_workflow_tool(
-            user_id=user.id,
-            tenant_id=tenant_id,
-            workflow_app_id=payload.workflow_app_id,
-            name=payload.name,
-            label=payload.label,
-            icon=payload.icon,
-            description=payload.description,
-            parameters=payload.parameters,
-            privacy_policy=payload.privacy_policy or "",
-            labels=payload.labels or [],
+        return dump_response(
+            SimpleResultResponse,
+            WorkflowToolManageService.create_workflow_tool(
+                user_id=user.id,
+                tenant_id=tenant_id,
+                workflow_app_id=payload.workflow_app_id,
+                name=payload.name,
+                label=payload.label,
+                icon=payload.icon.model_dump(mode="json"),
+                description=payload.description,
+                parameters=payload.parameters,
+                privacy_policy=payload.privacy_policy or "",
+                labels=payload.labels or [],
+            ),
         )
 
 
 @console_ns.route("/workspaces/current/tool-provider/workflow/update")
 class ToolWorkflowProviderUpdateApi(Resource):
     @console_ns.expect(console_ns.models[WorkflowToolUpdatePayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(200, "Workflow tool updated successfully", console_ns.models[SimpleResultResponse.__name__])
     @setup_required
     @login_required
     @is_admin_or_owner_required
@@ -708,24 +939,27 @@ class ToolWorkflowProviderUpdateApi(Resource):
     def post(self, tenant_id: str, user: Account):
         payload = WorkflowToolUpdatePayload.model_validate(console_ns.payload or {})
 
-        return WorkflowToolManageService.update_workflow_tool(
-            user.id,
-            tenant_id,
-            payload.workflow_tool_id,
-            payload.name,
-            payload.label,
-            payload.icon,
-            payload.description,
-            payload.parameters,
-            payload.privacy_policy or "",
-            payload.labels or [],
+        return dump_response(
+            SimpleResultResponse,
+            WorkflowToolManageService.update_workflow_tool(
+                user.id,
+                tenant_id,
+                payload.workflow_tool_id,
+                payload.name,
+                payload.label,
+                payload.icon.model_dump(mode="json"),
+                payload.description,
+                payload.parameters,
+                payload.privacy_policy or "",
+                payload.labels or [],
+            ),
         )
 
 
 @console_ns.route("/workspaces/current/tool-provider/workflow/delete")
 class ToolWorkflowProviderDeleteApi(Resource):
     @console_ns.expect(console_ns.models[WorkflowToolDeletePayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(200, "Workflow tool deleted successfully", console_ns.models[SimpleResultResponse.__name__])
     @setup_required
     @login_required
     @is_admin_or_owner_required
@@ -736,25 +970,29 @@ class ToolWorkflowProviderDeleteApi(Resource):
     def post(self, tenant_id: str, user: Account):
         payload = WorkflowToolDeletePayload.model_validate(console_ns.payload or {})
 
-        return WorkflowToolManageService.delete_workflow_tool(
-            user.id,
-            tenant_id,
-            payload.workflow_tool_id,
+        return dump_response(
+            SimpleResultResponse,
+            WorkflowToolManageService.delete_workflow_tool(
+                user.id,
+                tenant_id,
+                payload.workflow_tool_id,
+            ),
         )
 
 
 @console_ns.route("/workspaces/current/tool-provider/workflow/get")
 class ToolWorkflowProviderGetApi(Resource):
     @console_ns.doc(params=query_params_from_model(WorkflowToolGetQuery))
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200, "Workflow tool retrieved successfully", console_ns.models[WorkflowToolDetailResponse.__name__]
+    )
     @setup_required
     @login_required
     @account_initialization_required
     @with_current_user
     @with_current_tenant_id
     def get(self, tenant_id: str, user: Account):
-        raw_args = request.args.to_dict()
-        query = WorkflowToolGetQuery.model_validate(raw_args)
+        query = query_params_from_request(WorkflowToolGetQuery)
 
         if query.workflow_tool_id:
             tool = WorkflowToolManageService.get_workflow_tool_by_tool_id(
@@ -771,105 +1009,112 @@ class ToolWorkflowProviderGetApi(Resource):
         else:
             raise ValueError("incorrect workflow_tool_id or workflow_app_id")
 
-        return jsonable_encoder(tool)
+        return dump_response(WorkflowToolDetailResponse, tool)
 
 
 @console_ns.route("/workspaces/current/tool-provider/workflow/tools")
 class ToolWorkflowProviderListToolApi(Resource):
     @console_ns.doc(params=query_params_from_model(WorkflowToolListQuery))
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200, "Workflow provider tools retrieved successfully", console_ns.models[ToolApiListResponse.__name__]
+    )
     @setup_required
     @login_required
     @account_initialization_required
     @with_current_user
     @with_current_tenant_id
     def get(self, tenant_id: str, user: Account):
-        raw_args = request.args.to_dict()
-        query = WorkflowToolListQuery.model_validate(raw_args)
+        query = query_params_from_request(WorkflowToolListQuery)
 
-        return jsonable_encoder(
+        return dump_response(
+            ToolApiListResponse,
             WorkflowToolManageService.list_single_workflow_tools(
                 user.id,
                 tenant_id,
                 query.workflow_tool_id,
-            )
+            ),
         )
 
 
 @console_ns.route("/workspaces/current/tools/builtin")
 class ToolBuiltinListApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200, "Builtin tools retrieved successfully", console_ns.models[ToolProviderListResponse.__name__]
+    )
     @setup_required
     @login_required
     @account_initialization_required
     @with_current_user
     @with_current_tenant_id
     def get(self, tenant_id: str, user: Account):
-        return jsonable_encoder(
+        return _dump_tool_provider_payload_list(
             [
                 provider.to_dict()
                 for provider in BuiltinToolManageService.list_builtin_tools(
                     user.id,
                     tenant_id,
                 )
-            ]
+            ],
         )
 
 
 @console_ns.route("/workspaces/current/tools/api")
 class ToolApiListApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(200, "API tools retrieved successfully", console_ns.models[ToolProviderListResponse.__name__])
     @setup_required
     @login_required
     @account_initialization_required
     @with_current_tenant_id
     def get(self, tenant_id: str):
-        return jsonable_encoder(
+
+        return _dump_tool_provider_payload_list(
             [
                 provider.to_dict()
                 for provider in ApiToolManageService.list_api_tools(
                     tenant_id,
                 )
-            ]
+            ],
         )
 
 
 @console_ns.route("/workspaces/current/tools/workflow")
 class ToolWorkflowListApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200, "Workflow tools retrieved successfully", console_ns.models[ToolProviderListResponse.__name__]
+    )
     @setup_required
     @login_required
     @account_initialization_required
     @with_current_user
     @with_current_tenant_id
     def get(self, tenant_id: str, user: Account):
-        return jsonable_encoder(
+        return _dump_tool_provider_payload_list(
             [
                 provider.to_dict()
                 for provider in WorkflowToolManageService.list_tenant_workflow_tools(
                     user.id,
                     tenant_id,
                 )
-            ]
+            ],
         )
 
 
 @console_ns.route("/workspaces/current/tool-labels")
 class ToolLabelsApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(200, "Tool labels retrieved successfully", console_ns.models[ToolLabelListResponse.__name__])
     @setup_required
     @login_required
     @account_initialization_required
     @enterprise_license_required
     def get(self):
-        return jsonable_encoder(ToolLabelsService.list_tool_labels())
+        return dump_response(ToolLabelListResponse, ToolLabelsService.list_tool_labels())
 
 
 @console_ns.route("/oauth/plugin/<path:provider>/tool/authorization-url")
 class ToolPluginOAuthApi(Resource):
     @console_ns.response(
         200,
-        "Authorization URL retrieved successfully",
+        "Tool OAuth authorization URL generated successfully",
         console_ns.models[PluginOAuthAuthorizationUrlResponse.__name__],
     )
     @setup_required
@@ -901,7 +1146,8 @@ class ToolPluginOAuthApi(Resource):
             redirect_uri=redirect_uri,
             system_credentials=oauth_client_params,
         )
-        response = make_response(jsonable_encoder(authorization_url_response))
+        # response-contract:ignore cookie-bearing Flask response
+        response = make_response(dump_response(PluginOAuthAuthorizationUrlResponse, authorization_url_response))
         response.set_cookie(
             "context_id",
             context_id,
@@ -914,11 +1160,7 @@ class ToolPluginOAuthApi(Resource):
 
 @console_ns.route("/oauth/plugin/<path:provider>/tool/callback")
 class ToolOAuthCallback(Resource):
-    @console_ns.response(
-        302,
-        "Redirect to console OAuth callback page",
-        console_ns.models[RedirectResponse.__name__],
-    )
+    @console_ns.response(302, "Redirect to OAuth callback page")
     @setup_required
     def get(self, provider: str):
         context_id = request.cookies.get("context_id")
@@ -967,13 +1209,14 @@ class ToolOAuthCallback(Resource):
             api_type=CredentialType.OAUTH2,
             visibility="only_me",
         )
+        # response-contract:ignore redirect response
         return redirect(f"{dify_config.CONSOLE_WEB_URL}/oauth-callback")
 
 
 @console_ns.route("/workspaces/current/tool-provider/builtin/<path:provider>/default-credential")
 class ToolBuiltinProviderSetDefaultApi(Resource):
     @console_ns.expect(console_ns.models[BuiltinProviderDefaultCredentialPayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(200, "Default credential set successfully", console_ns.models[SimpleResultResponse.__name__])
     @setup_required
     @login_required
     @is_admin_or_owner_required
@@ -982,15 +1225,20 @@ class ToolBuiltinProviderSetDefaultApi(Resource):
     @with_current_tenant_id
     def post(self, current_tenant_id: str, provider: str):
         payload = BuiltinProviderDefaultCredentialPayload.model_validate(console_ns.payload or {})
-        return BuiltinToolManageService.set_default_provider(
-            tenant_id=current_tenant_id, provider=provider, id=payload.id
+        return dump_response(
+            SimpleResultResponse,
+            BuiltinToolManageService.set_default_provider(
+                tenant_id=current_tenant_id, provider=provider, id=payload.id
+            ),
         )
 
 
 @console_ns.route("/workspaces/current/tool-provider/builtin/<path:provider>/oauth/custom-client")
 class ToolOAuthCustomClient(Resource):
     @console_ns.expect(console_ns.models[ToolOAuthCustomClientPayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[SimpleResultResponse.__name__])
+    @console_ns.response(
+        200, "Custom OAuth client saved successfully", console_ns.models[SimpleResultResponse.__name__]
+    )
     @setup_required
     @login_required
     @is_admin_or_owner_required
@@ -1000,55 +1248,71 @@ class ToolOAuthCustomClient(Resource):
     def post(self, tenant_id: str, provider: str):
         payload = ToolOAuthCustomClientPayload.model_validate(console_ns.payload or {})
 
-        return BuiltinToolManageService.save_custom_oauth_client_params(
-            tenant_id=tenant_id,
-            provider=provider,
-            client_params=payload.client_params or {},
-            enable_oauth_custom_client=payload.enable_oauth_custom_client
-            if payload.enable_oauth_custom_client is not None
-            else True,
+        return dump_response(
+            SimpleResultResponse,
+            BuiltinToolManageService.save_custom_oauth_client_params(
+                tenant_id=tenant_id,
+                provider=provider,
+                client_params=payload.client_params or {},
+                enable_oauth_custom_client=payload.enable_oauth_custom_client
+                if payload.enable_oauth_custom_client is not None
+                else True,
+            ),
         )
 
+    @console_ns.response(
+        200,
+        "Custom OAuth client retrieved successfully",
+    )
     @setup_required
     @login_required
     @account_initialization_required
-    @console_ns.response(200, "Success", console_ns.models[ToolOAuthCustomClientResponse.__name__])
     @with_current_tenant_id
     def get(self, current_tenant_id: str, provider: str):
-        return jsonable_encoder(
-            BuiltinToolManageService.get_custom_oauth_client_params(tenant_id=current_tenant_id, provider=provider)
-        )
+        return BuiltinToolManageService.get_custom_oauth_client_params(tenant_id=current_tenant_id, provider=provider)
 
+    @console_ns.response(
+        200, "Custom OAuth client deleted successfully", console_ns.models[SimpleResultResponse.__name__]
+    )
     @setup_required
     @login_required
     @account_initialization_required
-    @console_ns.response(200, "Success", console_ns.models[SimpleResultResponse.__name__])
     @with_current_tenant_id
     def delete(self, current_tenant_id: str, provider: str):
-        return jsonable_encoder(
-            BuiltinToolManageService.delete_custom_oauth_client_params(tenant_id=current_tenant_id, provider=provider)
+        return dump_response(
+            SimpleResultResponse,
+            BuiltinToolManageService.delete_custom_oauth_client_params(tenant_id=current_tenant_id, provider=provider),
         )
 
 
 @console_ns.route("/workspaces/current/tool-provider/builtin/<path:provider>/oauth/client-schema")
 class ToolBuiltinProviderGetOauthClientSchemaApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[ToolOAuthClientSchemaResponse.__name__])
+    @console_ns.response(
+        200,
+        "Builtin provider OAuth client schema retrieved successfully",
+        console_ns.models[BuiltinProviderOAuthClientSchemaResponse.__name__],
+    )
     @setup_required
     @login_required
     @account_initialization_required
     @with_current_tenant_id
     def get(self, current_tenant_id: str, provider: str):
-        return jsonable_encoder(
+        return dump_response(
+            BuiltinProviderOAuthClientSchemaResponse,
             BuiltinToolManageService.get_builtin_tool_provider_oauth_client_schema(
                 tenant_id=current_tenant_id, provider_name=provider
-            )
+            ),
         )
 
 
 @console_ns.route("/workspaces/current/tool-provider/builtin/<path:provider>/credential/info")
 class ToolBuiltinProviderGetCredentialInfoApi(Resource):
     @console_ns.doc(params=query_params_from_model(BuiltinCredentialListQuery))
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200,
+        "Builtin provider credential info retrieved successfully",
+        console_ns.models[ToolProviderCredentialInfoApiEntity.__name__],
+    )
     @setup_required
     @login_required
     @account_initialization_required
@@ -1060,20 +1324,23 @@ class ToolBuiltinProviderGetCredentialInfoApi(Resource):
             list_fields=("include_credential_ids",),
         )
 
-        return jsonable_encoder(
+        return dump_response(
+            ToolProviderCredentialInfoApiEntity,
             BuiltinToolManageService.get_builtin_tool_provider_credential_info(
                 tenant_id=tenant_id,
                 provider=provider,
                 user=user,
                 include_credential_ids=query.include_credential_ids or None,
-            )
+            ),
         )
 
 
 @console_ns.route("/workspaces/current/tool-provider/mcp")
 class ToolProviderMCPApi(Resource):
     @console_ns.expect(console_ns.models[MCPProviderCreatePayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200, "MCP provider created successfully", console_ns.models[ToolProviderApiEntityResponse.__name__]
+    )
     @setup_required
     @login_required
     @account_initialization_required
@@ -1083,9 +1350,8 @@ class ToolProviderMCPApi(Resource):
     def post(self, tenant_id: str, user: Account):
         payload = MCPProviderCreatePayload.model_validate(console_ns.payload or {})
 
-        # Parse and validate models
-        configuration = MCPConfiguration.model_validate(payload.configuration or {})
-        authentication = MCPAuthentication.model_validate(payload.authentication) if payload.authentication else None
+        configuration = payload.configuration or MCPConfiguration()
+        authentication = payload.authentication
 
         # 1) Create provider in a short transaction (no network I/O inside)
         with session_factory.create_session() as session, session.begin():
@@ -1126,10 +1392,10 @@ class ToolProviderMCPApi(Resource):
             # Best-effort: if initial fetch fails (e.g., auth required), return created provider as-is
             logger.warning("Failed to fetch MCP tools after creation", exc_info=True)
 
-        return jsonable_encoder(result)
+        return _dump_tool_provider_payload(result.to_dict())
 
     @console_ns.expect(console_ns.models[MCPProviderUpdatePayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[SimpleResultResponse.__name__])
+    @console_ns.response(200, "MCP provider updated successfully", console_ns.models[SimpleResultResponse.__name__])
     @setup_required
     @login_required
     @account_initialization_required
@@ -1137,8 +1403,8 @@ class ToolProviderMCPApi(Resource):
     @with_current_tenant_id
     def put(self, current_tenant_id: str):
         payload = MCPProviderUpdatePayload.model_validate(console_ns.payload or {})
-        configuration = MCPConfiguration.model_validate(payload.configuration or {})
-        authentication = MCPAuthentication.model_validate(payload.authentication) if payload.authentication else None
+        configuration = payload.configuration or MCPConfiguration()
+        authentication = payload.authentication
 
         # Step 1: Get provider data for URL validation (short-lived session, no network I/O)
         validation_data = None
@@ -1180,7 +1446,7 @@ class ToolProviderMCPApi(Resource):
                 identity_mode=identity_mode,
             )
 
-        return {"result": "success"}
+        return SimpleResultResponse(result="success").model_dump(mode="json")
 
     @console_ns.expect(console_ns.models[MCPProviderDeletePayload.__name__])
     @console_ns.response(200, "Success", console_ns.models[SimpleResultResponse.__name__])
@@ -1196,13 +1462,13 @@ class ToolProviderMCPApi(Resource):
             service = MCPToolManageService(session=session)
             service.delete_provider(tenant_id=current_tenant_id, provider_id=payload.provider_id)
 
-        return {"result": "success"}
+        return SimpleResultResponse(result="success").model_dump(mode="json")
 
 
 @console_ns.route("/workspaces/current/tool-provider/mcp/auth")
 class ToolMCPAuthApi(Resource):
     @console_ns.expect(console_ns.models[MCPAuthPayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(200, "MCP provider authorized successfully", console_ns.models[MCPAuthResponse.__name__])
     @setup_required
     @login_required
     @account_initialization_required
@@ -1241,7 +1507,7 @@ class ToolMCPAuthApi(Resource):
                         credentials=provider_entity.credentials,
                         authed=True,
                     )
-                return {"result": "success"}
+                    return MCPAuthResponse(result="success").model_dump(mode="json")
         except MCPAuthError as e:
             try:
                 # Pass the extracted OAuth metadata hints to auth()
@@ -1254,7 +1520,7 @@ class ToolMCPAuthApi(Resource):
                 with sessionmaker(db.engine).begin() as session:
                     service = MCPToolManageService(session=session)
                     response = service.execute_auth_actions(auth_result)
-                    return response
+                    return dump_response(MCPAuthResponse, response)
             except MCPRefreshTokenError as e:
                 with sessionmaker(db.engine).begin() as session:
                     service = MCPToolManageService(session=session)
@@ -1277,7 +1543,9 @@ class ToolMCPAuthApi(Resource):
 
 @console_ns.route("/workspaces/current/tool-provider/mcp/tools/<path:provider_id>")
 class ToolMCPDetailApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200, "MCP provider retrieved successfully", console_ns.models[ToolProviderApiEntityResponse.__name__]
+    )
     @setup_required
     @login_required
     @account_initialization_required
@@ -1286,28 +1554,33 @@ class ToolMCPDetailApi(Resource):
         with sessionmaker(db.engine).begin() as session:
             service = MCPToolManageService(session=session)
             provider = service.get_provider(provider_id=provider_id, tenant_id=tenant_id)
-            return jsonable_encoder(ToolTransformService.mcp_provider_to_user_provider(provider, for_list=True))
+            return _dump_tool_provider_payload(
+                ToolTransformService.mcp_provider_to_user_provider(provider, for_list=True).to_dict()
+            )
 
 
 @console_ns.route("/workspaces/current/tools/mcp")
 class ToolMCPListAllApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(200, "MCP tools retrieved successfully", console_ns.models[ToolProviderListResponse.__name__])
     @setup_required
     @login_required
     @account_initialization_required
     @with_current_tenant_id
     def get(self, tenant_id: str):
+
         with sessionmaker(db.engine).begin() as session:
             service = MCPToolManageService(session=session)
             # Skip sensitive data decryption for list view to improve performance
             tools = service.list_providers(tenant_id=tenant_id, include_sensitive=False)
 
-            return [tool.to_dict() for tool in tools]
+            return _dump_tool_provider_payload_list([tool.to_dict() for tool in tools])
 
 
 @console_ns.route("/workspaces/current/tool-provider/mcp/update/<path:provider_id>")
 class ToolMCPUpdateApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[ToolProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200, "MCP provider tools refreshed successfully", console_ns.models[ToolProviderApiEntityResponse.__name__]
+    )
     @setup_required
     @login_required
     @account_initialization_required
@@ -1320,20 +1593,15 @@ class ToolMCPUpdateApi(Resource):
                 tenant_id=tenant_id,
                 provider_id=provider_id,
             )
-            return jsonable_encoder(tools)
+            return _dump_tool_provider_payload(tools.to_dict())
 
 
 @console_ns.route("/mcp/oauth/callback")
 class ToolMCPCallbackApi(Resource):
     @console_ns.doc(params=query_params_from_model(MCPCallbackQuery))
-    @console_ns.response(
-        302,
-        "Redirect to console OAuth callback page",
-        console_ns.models[RedirectResponse.__name__],
-    )
+    @console_ns.response(302, "Redirect to OAuth callback page")
     def get(self):
-        raw_args = request.args.to_dict()
-        query = MCPCallbackQuery.model_validate(raw_args)
+        query = query_params_from_request(MCPCallbackQuery)
         state_key = query.state
         authorization_code = query.code
 
@@ -1347,4 +1615,5 @@ class ToolMCPCallbackApi(Resource):
                 state_data.provider_id, state_data.tenant_id, tokens.model_dump(), OAuthDataType.TOKENS
             )
 
+        # response-contract:ignore redirect response
         return redirect(f"{dify_config.CONSOLE_WEB_URL}/oauth-callback")

--- a/api/controllers/console/workspace/trigger_providers.py
+++ b/api/controllers/console/workspace/trigger_providers.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Literal
+from typing import Any
 
 from flask import make_response, redirect, request
 from flask_restx import Resource
@@ -9,12 +9,11 @@ from werkzeug.exceptions import BadRequest, Forbidden
 
 from configs import dify_config
 from controllers.common.errors import NotFoundError
-from controllers.common.fields import BinaryFileResponse, RedirectResponse, SimpleResultResponse
+from controllers.common.fields import SimpleResultResponse
 from controllers.common.schema import register_response_schema_models, register_schema_models
-from core.entities.parameter_entities import AppSelectorScope, ModelSelectorScope, ToolSelectorScope
+from core.entities.provider_entities import ProviderConfig
 from core.plugin.entities.plugin_daemon import CredentialType
 from core.plugin.impl.oauth import OAuthHandler
-from core.tools.entities.common_entities import I18nObject
 from core.trigger.entities.api_entities import (
     SubscriptionBuilderApiEntity,
     TriggerProviderApiEntity,
@@ -24,7 +23,7 @@ from core.trigger.entities.entities import RequestLog, SubscriptionBuilderUpdate
 from core.trigger.trigger_manager import TriggerManager
 from extensions.ext_database import db
 from fields.base import ResponseModel
-from graphon.model_runtime.utils.encoders import jsonable_encoder
+from libs.helper import dump_response
 from libs.login import login_required
 from models.account import Account
 from models.provider_ids import TriggerProviderID
@@ -59,9 +58,9 @@ class TriggerSubscriptionBuilderVerifyPayload(BaseModel):
 
 class TriggerSubscriptionBuilderUpdatePayload(BaseModel):
     name: str | None = None
-    parameters: dict[str, Any] | None = Field(default=None)
-    properties: dict[str, Any] | None = Field(default=None)
-    credentials: dict[str, Any] | None = Field(default=None)
+    parameters: dict[str, Any] | None = None
+    properties: dict[str, Any] | None = None
+    credentials: dict[str, Any] | None = None
 
     @model_validator(mode="after")
     def check_at_least_one_field(self):
@@ -71,75 +70,48 @@ class TriggerSubscriptionBuilderUpdatePayload(BaseModel):
 
 
 class TriggerOAuthClientPayload(BaseModel):
-    client_params: dict[str, Any] | None = Field(default=None)
+    client_params: dict[str, Any] | None = None
     enabled: bool | None = None
 
 
-class TriggerOAuthAuthorizeResponse(BaseModel):
-    authorization_url: str
-    subscription_builder_id: str
-    subscription_builder: SubscriptionBuilderApiEntity
-
-
-class TriggerProviderConfigOptionResponse(BaseModel):
-    value: str = Field(..., description="The value of the option")
-    label: I18nObject = Field(..., description="The label of the option")
-
-
-class TriggerProviderConfigResponse(BaseModel):
-    type: Literal[
-        "secret-input",
-        "text-input",
-        "select",
-        "boolean",
-        "app-selector",
-        "model-selector",
-        "array[tools]",
-    ] = Field(..., description="The type of the credentials")
-    name: str = Field(..., description="The name of the credentials")
-    scope: AppSelectorScope | ModelSelectorScope | ToolSelectorScope | None = None
-    required: bool = False
-    default: int | str | float | bool | None = None
-    options: list[TriggerProviderConfigOptionResponse] | None = None
-    multiple: bool = False
-    label: I18nObject | None = None
-    help: I18nObject | None = None
-    url: str | None = None
-    placeholder: I18nObject | None = None
-
-
-class TriggerOAuthClientResponse(BaseModel):
-    configured: bool
-    system_configured: bool
-    custom_configured: bool
-    oauth_client_schema: list[TriggerProviderConfigResponse]
-    custom_enabled: bool
-    redirect_uri: str
-    params: dict[str, Any]
-
-
-class TriggerProviderOpaqueResponse(RootModel[Any]):
-    root: Any
-
-
 class TriggerProviderListResponse(RootModel[list[TriggerProviderApiEntity]]):
-    root: list[TriggerProviderApiEntity]
+    pass
 
 
-class TriggerSubscriptionListResponse(RootModel[list[TriggerProviderSubscriptionApiEntity]]):
-    root: list[TriggerProviderSubscriptionApiEntity]
+class TriggerProviderSubscriptionListResponse(RootModel[list[TriggerProviderSubscriptionApiEntity]]):
+    pass
 
 
 class TriggerSubscriptionBuilderCreateResponse(ResponseModel):
     subscription_builder: SubscriptionBuilderApiEntity
 
 
-class TriggerSubscriptionBuilderVerifyResponse(ResponseModel):
+class TriggerVerificationResponse(ResponseModel):
     verified: bool
 
 
 class TriggerSubscriptionBuilderLogsResponse(ResponseModel):
     logs: list[RequestLog]
+
+
+class TriggerOAuthAuthorizeResponse(ResponseModel):
+    authorization_url: str
+    subscription_builder_id: str
+    subscription_builder: SubscriptionBuilderApiEntity
+
+
+class TriggerOAuthClientResponse(ResponseModel):
+    configured: bool
+    system_configured: bool
+    custom_configured: bool
+    oauth_client_schema: list[ProviderConfig]
+    custom_enabled: bool
+    redirect_uri: str
+    params: dict[str, Any] = Field(default_factory=dict)
+
+
+class TriggerProviderErrorResponse(ResponseModel):
+    error: str
 
 
 register_schema_models(
@@ -151,27 +123,24 @@ register_schema_models(
 )
 register_response_schema_models(
     console_ns,
-    BinaryFileResponse,
-    RedirectResponse,
     SimpleResultResponse,
     TriggerOAuthAuthorizeResponse,
     TriggerOAuthClientResponse,
-    TriggerProviderOpaqueResponse,
     TriggerProviderApiEntity,
+    TriggerProviderErrorResponse,
     TriggerProviderListResponse,
-    TriggerProviderSubscriptionApiEntity,
-    TriggerSubscriptionListResponse,
-    SubscriptionBuilderApiEntity,
+    TriggerProviderSubscriptionListResponse,
     TriggerSubscriptionBuilderCreateResponse,
-    TriggerSubscriptionBuilderVerifyResponse,
-    RequestLog,
     TriggerSubscriptionBuilderLogsResponse,
+    SubscriptionBuilderApiEntity,
+    TriggerVerificationResponse,
 )
 
 
 @console_ns.route("/workspaces/current/trigger-provider/<path:provider>/icon")
 class TriggerProviderIconApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[BinaryFileResponse.__name__])
+    # response-contract:ignore binary trigger provider icon
+    @console_ns.response(200, "Trigger provider icon")
     @setup_required
     @login_required
     @account_initialization_required
@@ -182,31 +151,45 @@ class TriggerProviderIconApi(Resource):
 
 @console_ns.route("/workspaces/current/triggers")
 class TriggerProviderListApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[TriggerProviderListResponse.__name__])
+    @console_ns.response(
+        200,
+        "Trigger providers retrieved successfully",
+        console_ns.models[TriggerProviderListResponse.__name__],
+    )
     @setup_required
     @login_required
     @account_initialization_required
     @with_current_tenant_id
     def get(self, tenant_id: str):
         """List all trigger providers for the current tenant"""
-        return jsonable_encoder(TriggerProviderService.list_trigger_providers(tenant_id))
+        return dump_response(TriggerProviderListResponse, TriggerProviderService.list_trigger_providers(tenant_id))
 
 
 @console_ns.route("/workspaces/current/trigger-provider/<path:provider>/info")
 class TriggerProviderInfoApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[TriggerProviderApiEntity.__name__])
+    @console_ns.response(
+        200,
+        "Trigger provider retrieved successfully",
+        console_ns.models[TriggerProviderApiEntity.__name__],
+    )
     @setup_required
     @login_required
     @account_initialization_required
     @with_current_tenant_id
     def get(self, tenant_id: str, provider: str):
         """Get info for a trigger provider"""
-        return jsonable_encoder(TriggerProviderService.get_trigger_provider(tenant_id, TriggerProviderID(provider)))
+        provider_entity = TriggerProviderService.get_trigger_provider(tenant_id, TriggerProviderID(provider))
+        return provider_entity.model_dump(mode="json")
 
 
 @console_ns.route("/workspaces/current/trigger-provider/<path:provider>/subscriptions/list")
 class TriggerSubscriptionListApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[TriggerSubscriptionListResponse.__name__])
+    @console_ns.response(
+        200,
+        "Trigger subscriptions retrieved successfully",
+        console_ns.models[TriggerProviderSubscriptionListResponse.__name__],
+    )
+    @console_ns.response(404, "Trigger provider not found", console_ns.models[TriggerProviderErrorResponse.__name__])
     @setup_required
     @login_required
     @edit_permission_required
@@ -216,16 +199,18 @@ class TriggerSubscriptionListApi(Resource):
     @with_current_tenant_id
     def get(self, tenant_id: str, user: Account, provider: str):
         """List all trigger subscriptions for the current tenant's provider"""
+
         try:
-            return jsonable_encoder(
+            return dump_response(
+                TriggerProviderSubscriptionListResponse,
                 TriggerProviderService.list_trigger_provider_subscriptions(
                     tenant_id=tenant_id,
                     provider_id=TriggerProviderID(provider),
                     user=user,
-                )
+                ),
             )
         except ValueError as e:
-            return jsonable_encoder({"error": str(e)}), 404
+            return TriggerProviderErrorResponse(error=str(e)).model_dump(mode="json"), 404
         except Exception as e:
             logger.exception("Error listing trigger providers", exc_info=e)
             raise
@@ -236,7 +221,11 @@ class TriggerSubscriptionListApi(Resource):
 )
 class TriggerSubscriptionBuilderCreateApi(Resource):
     @console_ns.expect(console_ns.models[TriggerSubscriptionBuilderCreatePayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[TriggerSubscriptionBuilderCreateResponse.__name__])
+    @console_ns.response(
+        200,
+        "Trigger subscription builder created successfully",
+        console_ns.models[TriggerSubscriptionBuilderCreateResponse.__name__],
+    )
     @setup_required
     @login_required
     @edit_permission_required
@@ -246,6 +235,7 @@ class TriggerSubscriptionBuilderCreateApi(Resource):
     @with_current_tenant_id
     def post(self, tenant_id: str, user: Account, provider: str):
         """Add a new subscription instance for a trigger provider"""
+
         payload = TriggerSubscriptionBuilderCreatePayload.model_validate(console_ns.payload or {})
 
         try:
@@ -256,7 +246,9 @@ class TriggerSubscriptionBuilderCreateApi(Resource):
                 provider_id=TriggerProviderID(provider),
                 credential_type=credential_type,
             )
-            return jsonable_encoder({"subscription_builder": subscription_builder})
+            return TriggerSubscriptionBuilderCreateResponse(subscription_builder=subscription_builder).model_dump(
+                mode="json"
+            )
         except Exception as e:
             logger.exception("Error adding provider credential", exc_info=e)
             raise
@@ -266,7 +258,11 @@ class TriggerSubscriptionBuilderCreateApi(Resource):
     "/workspaces/current/trigger-provider/<path:provider>/subscriptions/builder/<path:subscription_builder_id>",
 )
 class TriggerSubscriptionBuilderGetApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[SubscriptionBuilderApiEntity.__name__])
+    @console_ns.response(
+        200,
+        "Trigger subscription builder retrieved successfully",
+        console_ns.models[SubscriptionBuilderApiEntity.__name__],
+    )
     @setup_required
     @login_required
     @edit_permission_required
@@ -274,9 +270,8 @@ class TriggerSubscriptionBuilderGetApi(Resource):
     @account_initialization_required
     def get(self, provider: str, subscription_builder_id: str):
         """Get a subscription instance for a trigger provider"""
-        return jsonable_encoder(
-            TriggerSubscriptionBuilderService.get_subscription_builder_by_id(subscription_builder_id)
-        )
+        subscription_builder = TriggerSubscriptionBuilderService.get_subscription_builder_by_id(subscription_builder_id)
+        return subscription_builder.model_dump(mode="json")
 
 
 @console_ns.route(
@@ -284,7 +279,11 @@ class TriggerSubscriptionBuilderGetApi(Resource):
 )
 class TriggerSubscriptionBuilderVerifyApi(Resource):
     @console_ns.expect(console_ns.models[TriggerSubscriptionBuilderVerifyPayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[TriggerSubscriptionBuilderVerifyResponse.__name__])
+    @console_ns.response(
+        200,
+        "Trigger subscription builder verified successfully",
+        console_ns.models[TriggerVerificationResponse.__name__],
+    )
     @setup_required
     @login_required
     @edit_permission_required
@@ -294,11 +293,12 @@ class TriggerSubscriptionBuilderVerifyApi(Resource):
     @with_current_tenant_id
     def post(self, tenant_id: str, user: Account, provider: str, subscription_builder_id: str):
         """Verify and update a subscription instance for a trigger provider"""
+
         payload = TriggerSubscriptionBuilderVerifyPayload.model_validate(console_ns.payload or {})
 
         try:
             # Use atomic update_and_verify to prevent race conditions
-            return TriggerSubscriptionBuilderService.update_and_verify_builder(
+            result = TriggerSubscriptionBuilderService.update_and_verify_builder(
                 tenant_id=tenant_id,
                 user_id=user.id,
                 provider_id=TriggerProviderID(provider),
@@ -307,6 +307,7 @@ class TriggerSubscriptionBuilderVerifyApi(Resource):
                     credentials=payload.credentials,
                 ),
             )
+            return dump_response(TriggerVerificationResponse, result)
         except Exception as e:
             logger.exception("Error verifying provider credential", exc_info=e)
             raise ValueError(str(e)) from e
@@ -317,7 +318,11 @@ class TriggerSubscriptionBuilderVerifyApi(Resource):
 )
 class TriggerSubscriptionBuilderUpdateApi(Resource):
     @console_ns.expect(console_ns.models[TriggerSubscriptionBuilderUpdatePayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[SubscriptionBuilderApiEntity.__name__])
+    @console_ns.response(
+        200,
+        "Trigger subscription builder updated successfully",
+        console_ns.models[SubscriptionBuilderApiEntity.__name__],
+    )
     @setup_required
     @login_required
     @edit_permission_required
@@ -326,21 +331,20 @@ class TriggerSubscriptionBuilderUpdateApi(Resource):
     @with_current_tenant_id
     def post(self, tenant_id: str, provider: str, subscription_builder_id: str):
         """Update a subscription instance for a trigger provider"""
+
         payload = TriggerSubscriptionBuilderUpdatePayload.model_validate(console_ns.payload or {})
         try:
-            return jsonable_encoder(
-                TriggerSubscriptionBuilderService.update_trigger_subscription_builder(
-                    tenant_id=tenant_id,
-                    provider_id=TriggerProviderID(provider),
-                    subscription_builder_id=subscription_builder_id,
-                    subscription_builder_updater=SubscriptionBuilderUpdater(
-                        name=payload.name,
-                        parameters=payload.parameters,
-                        properties=payload.properties,
-                        credentials=payload.credentials,
-                    ),
-                )
-            )
+            return TriggerSubscriptionBuilderService.update_trigger_subscription_builder(
+                tenant_id=tenant_id,
+                provider_id=TriggerProviderID(provider),
+                subscription_builder_id=subscription_builder_id,
+                subscription_builder_updater=SubscriptionBuilderUpdater(
+                    name=payload.name,
+                    parameters=payload.parameters,
+                    properties=payload.properties,
+                    credentials=payload.credentials,
+                ),
+            ).model_dump(mode="json")
         except Exception as e:
             logger.exception("Error updating provider credential", exc_info=e)
             raise
@@ -350,7 +354,11 @@ class TriggerSubscriptionBuilderUpdateApi(Resource):
     "/workspaces/current/trigger-provider/<path:provider>/subscriptions/builder/logs/<path:subscription_builder_id>",
 )
 class TriggerSubscriptionBuilderLogsApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[TriggerSubscriptionBuilderLogsResponse.__name__])
+    @console_ns.response(
+        200,
+        "Trigger subscription builder logs retrieved successfully",
+        console_ns.models[TriggerSubscriptionBuilderLogsResponse.__name__],
+    )
     @setup_required
     @login_required
     @edit_permission_required
@@ -358,9 +366,10 @@ class TriggerSubscriptionBuilderLogsApi(Resource):
     @account_initialization_required
     def get(self, provider: str, subscription_builder_id: str):
         """Get the request logs for a subscription instance for a trigger provider"""
+
         try:
             logs = TriggerSubscriptionBuilderService.list_logs(subscription_builder_id)
-            return jsonable_encoder({"logs": [log.model_dump(mode="json") for log in logs]})
+            return dump_response(TriggerSubscriptionBuilderLogsResponse, {"logs": logs})
         except Exception as e:
             logger.exception("Error getting request logs for subscription builder", exc_info=e)
             raise
@@ -371,7 +380,9 @@ class TriggerSubscriptionBuilderLogsApi(Resource):
 )
 class TriggerSubscriptionBuilderBuildApi(Resource):
     @console_ns.expect(console_ns.models[TriggerSubscriptionBuilderUpdatePayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[TriggerProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200, "Trigger subscription builder built successfully", console_ns.models[SimpleResultResponse.__name__]
+    )
     @setup_required
     @login_required
     @edit_permission_required
@@ -395,7 +406,7 @@ class TriggerSubscriptionBuilderBuildApi(Resource):
                     properties=payload.properties,
                 ),
             )
-            return 200
+            return SimpleResultResponse(result="success").model_dump(mode="json")
         except Exception as e:
             logger.exception("Error building provider credential", exc_info=e)
             raise ValueError(str(e)) from e
@@ -406,7 +417,9 @@ class TriggerSubscriptionBuilderBuildApi(Resource):
 )
 class TriggerSubscriptionUpdateApi(Resource):
     @console_ns.expect(console_ns.models[TriggerSubscriptionBuilderUpdatePayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[TriggerProviderOpaqueResponse.__name__])
+    @console_ns.response(
+        200, "Trigger subscription updated successfully", console_ns.models[SimpleResultResponse.__name__]
+    )
     @setup_required
     @login_required
     @edit_permission_required
@@ -415,6 +428,7 @@ class TriggerSubscriptionUpdateApi(Resource):
     @with_current_tenant_id
     def post(self, tenant_id: str, subscription_id: str):
         """Update a subscription instance"""
+
         request = TriggerSubscriptionBuilderUpdatePayload.model_validate(console_ns.payload or {})
 
         subscription = TriggerProviderService.get_subscription_by_id(
@@ -440,7 +454,7 @@ class TriggerSubscriptionUpdateApi(Resource):
                     name=request.name,
                     properties=request.properties,
                 )
-                return 200
+                return SimpleResultResponse(result="success").model_dump(mode="json")
 
             # For the rest cases(API_KEY, OAUTH2)
             # we need to call third party provider(e.g. GitHub) to rebuild the subscription
@@ -452,7 +466,7 @@ class TriggerSubscriptionUpdateApi(Resource):
                 credentials=request.credentials or subscription.credentials,
                 parameters=request.parameters or subscription.parameters,
             )
-            return 200
+            return SimpleResultResponse(result="success").model_dump(mode="json")
         except ValueError as e:
             raise BadRequest(str(e))
         except Exception as e:
@@ -473,6 +487,7 @@ class TriggerSubscriptionDeleteApi(Resource):
     @with_current_tenant_id
     def post(self, tenant_id: str, subscription_id: str):
         """Delete a subscription instance"""
+
         try:
             with sessionmaker(db.engine).begin() as session:
                 # Delete trigger provider subscription
@@ -487,7 +502,7 @@ class TriggerSubscriptionDeleteApi(Resource):
                     tenant_id=tenant_id,
                     subscription_id=subscription_id,
                 )
-            return {"result": "success"}
+            return SimpleResultResponse(result="success").model_dump(mode="json")
         except ValueError as e:
             raise BadRequest(str(e))
         except Exception as e:
@@ -497,9 +512,10 @@ class TriggerSubscriptionDeleteApi(Resource):
 
 @console_ns.route("/workspaces/current/trigger-provider/<path:provider>/subscriptions/oauth/authorize")
 class TriggerOAuthAuthorizeApi(Resource):
+    # response-contract:ignore cookie-bearing Flask response
     @console_ns.response(
         200,
-        "Authorization URL retrieved successfully",
+        "Trigger OAuth authorization URL generated successfully",
         console_ns.models[TriggerOAuthAuthorizeResponse.__name__],
     )
     @setup_required
@@ -509,10 +525,12 @@ class TriggerOAuthAuthorizeApi(Resource):
     @with_current_tenant_id
     def get(self, tenant_id: str, user: Account, provider: str):
         """Initiate OAuth authorization flow for a trigger provider"""
+
         try:
             provider_id = TriggerProviderID(provider)
             plugin_id = provider_id.plugin_id
             provider_name = provider_id.provider_name
+            tenant_id = tenant_id
 
             # Get OAuth client configuration
             oauth_client_params = TriggerProviderService.get_oauth_client(
@@ -556,15 +574,12 @@ class TriggerOAuthAuthorizeApi(Resource):
                 system_credentials=oauth_client_params,
             )
 
-            # Create response with cookie
             response = make_response(
-                jsonable_encoder(
-                    {
-                        "authorization_url": authorization_url_response.authorization_url,
-                        "subscription_builder_id": subscription_builder.id,
-                        "subscription_builder": subscription_builder,
-                    }
-                )
+                TriggerOAuthAuthorizeResponse(
+                    authorization_url=authorization_url_response.authorization_url,
+                    subscription_builder_id=subscription_builder.id,
+                    subscription_builder=subscription_builder,
+                ).model_dump(mode="json")
             )
             response.set_cookie(
                 "context_id",
@@ -583,11 +598,8 @@ class TriggerOAuthAuthorizeApi(Resource):
 
 @console_ns.route("/oauth/plugin/<path:provider>/trigger/callback")
 class TriggerOAuthCallbackApi(Resource):
-    @console_ns.response(
-        302,
-        "Redirect to console OAuth callback page",
-        console_ns.models[RedirectResponse.__name__],
-    )
+    # response-contract:ignore redirect response
+    @console_ns.response(302, "Redirect to OAuth callback page")
     @setup_required
     def get(self, provider: str):
         """Handle OAuth callback for trigger provider"""
@@ -653,7 +665,11 @@ class TriggerOAuthCallbackApi(Resource):
 
 @console_ns.route("/workspaces/current/trigger-provider/<path:provider>/oauth/client")
 class TriggerOAuthClientManageApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[TriggerOAuthClientResponse.__name__])
+    @console_ns.response(
+        200,
+        "Trigger OAuth client retrieved successfully",
+        console_ns.models[TriggerOAuthClientResponse.__name__],
+    )
     @setup_required
     @login_required
     @is_admin_or_owner_required
@@ -662,6 +678,7 @@ class TriggerOAuthClientManageApi(Resource):
     @with_current_tenant_id
     def get(self, tenant_id: str, provider: str):
         """Get OAuth client configuration for a provider"""
+
         try:
             provider_id = TriggerProviderID(provider)
 
@@ -682,24 +699,24 @@ class TriggerOAuthClientManageApi(Resource):
             )
             provider_controller = TriggerManager.get_trigger_provider(tenant_id, provider_id)
             redirect_uri = f"{dify_config.CONSOLE_API_URL}/console/api/oauth/plugin/{provider}/trigger/callback"
-            return jsonable_encoder(
-                {
-                    "configured": bool(custom_params or system_client_exists),
-                    "system_configured": system_client_exists,
-                    "custom_configured": bool(custom_params),
-                    "oauth_client_schema": provider_controller.get_oauth_client_schema(),
-                    "custom_enabled": is_custom_enabled,
-                    "redirect_uri": redirect_uri,
-                    "params": custom_params or {},
-                }
-            )
+            return TriggerOAuthClientResponse(
+                configured=bool(custom_params or system_client_exists),
+                system_configured=system_client_exists,
+                custom_configured=bool(custom_params),
+                oauth_client_schema=provider_controller.get_oauth_client_schema(),
+                custom_enabled=is_custom_enabled,
+                redirect_uri=redirect_uri,
+                params=dict(custom_params or {}),
+            ).model_dump(mode="json")
 
         except Exception as e:
             logger.exception("Error getting OAuth client", exc_info=e)
             raise
 
     @console_ns.expect(console_ns.models[TriggerOAuthClientPayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[SimpleResultResponse.__name__])
+    @console_ns.response(
+        200, "Trigger OAuth client saved successfully", console_ns.models[SimpleResultResponse.__name__]
+    )
     @setup_required
     @login_required
     @is_admin_or_owner_required
@@ -708,16 +725,18 @@ class TriggerOAuthClientManageApi(Resource):
     @with_current_tenant_id
     def post(self, tenant_id: str, provider: str):
         """Configure custom OAuth client for a provider"""
+
         payload = TriggerOAuthClientPayload.model_validate(console_ns.payload or {})
 
         try:
             provider_id = TriggerProviderID(provider)
-            return TriggerProviderService.save_custom_oauth_client_params(
+            result = TriggerProviderService.save_custom_oauth_client_params(
                 tenant_id=tenant_id,
                 provider_id=provider_id,
                 client_params=payload.client_params,
                 enabled=payload.enabled,
             )
+            return dump_response(SimpleResultResponse, result)
 
         except ValueError as e:
             raise BadRequest(str(e))
@@ -725,22 +744,26 @@ class TriggerOAuthClientManageApi(Resource):
             logger.exception("Error configuring OAuth client", exc_info=e)
             raise
 
+    @console_ns.response(
+        200, "Trigger OAuth client deleted successfully", console_ns.models[SimpleResultResponse.__name__]
+    )
     @setup_required
     @login_required
     @is_admin_or_owner_required
     @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.PLUGIN_PREFERENCES, resource_required=False)
     @account_initialization_required
-    @console_ns.response(200, "Success", console_ns.models[SimpleResultResponse.__name__])
     @with_current_tenant_id
     def delete(self, tenant_id: str, provider: str):
         """Remove custom OAuth client configuration"""
+
         try:
             provider_id = TriggerProviderID(provider)
 
-            return TriggerProviderService.delete_custom_oauth_client_params(
+            result = TriggerProviderService.delete_custom_oauth_client_params(
                 tenant_id=tenant_id,
                 provider_id=provider_id,
             )
+            return dump_response(SimpleResultResponse, result)
         except ValueError as e:
             raise BadRequest(str(e))
         except Exception as e:
@@ -753,7 +776,11 @@ class TriggerOAuthClientManageApi(Resource):
 )
 class TriggerSubscriptionVerifyApi(Resource):
     @console_ns.expect(console_ns.models[TriggerSubscriptionBuilderVerifyPayload.__name__])
-    @console_ns.response(200, "Success", console_ns.models[TriggerSubscriptionBuilderVerifyResponse.__name__])
+    @console_ns.response(
+        200,
+        "Trigger subscription verified successfully",
+        console_ns.models[TriggerVerificationResponse.__name__],
+    )
     @setup_required
     @login_required
     @edit_permission_required
@@ -763,6 +790,7 @@ class TriggerSubscriptionVerifyApi(Resource):
     @with_current_tenant_id
     def post(self, tenant_id: str, user: Account, provider: str, subscription_id: str):
         """Verify credentials for an existing subscription (edit mode only)"""
+
         verify_request = TriggerSubscriptionBuilderVerifyPayload.model_validate(console_ns.payload or {})
 
         try:
@@ -773,7 +801,7 @@ class TriggerSubscriptionVerifyApi(Resource):
                 subscription_id=subscription_id,
                 credentials=verify_request.credentials,
             )
-            return result
+            return dump_response(TriggerVerificationResponse, result)
         except ValueError as e:
             logger.warning("Credential verification failed", exc_info=e)
             raise BadRequest(str(e)) from e

--- a/api/controllers/console/workspace/trigger_providers.py
+++ b/api/controllers/console/workspace/trigger_providers.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from flask import make_response, redirect, request
 from flask_restx import Resource
-from pydantic import BaseModel, Field, RootModel, model_validator
+from pydantic import BaseModel, RootModel, model_validator
 from sqlalchemy.orm import sessionmaker
 from werkzeug.exceptions import BadRequest, Forbidden
 
@@ -107,7 +107,7 @@ class TriggerOAuthClientResponse(ResponseModel):
     oauth_client_schema: list[ProviderConfig]
     custom_enabled: bool
     redirect_uri: str
-    params: dict[str, Any] = Field(default_factory=dict)
+    params: dict[str, Any]
 
 
 class TriggerProviderErrorResponse(ResponseModel):

--- a/api/core/tools/entities/api_entities.py
+++ b/api/core/tools/entities/api_entities.py
@@ -74,8 +74,6 @@ class ToolProviderApiEntity(BaseModel):
                 for parameter in tool.get("parameters"):
                     if parameter.get("type") == ToolParameter.ToolParameterType.SYSTEM_FILES:
                         parameter["type"] = "files"
-                    if parameter.get("input_schema") is None:
-                        parameter.pop("input_schema", None)
         # -------------
         optional_fields = self.optional_field("server_url", self.server_url)
         match self.type:

--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -16,30 +16,16 @@ from yarl import URL
 
 import contexts
 from configs import dify_config
-from core.entities import PluginCredentialType
-from core.helper.provider_cache import ToolProviderCredentialsCache
-from core.plugin.impl.tool import PluginToolManager
-from core.tools.__base.tool_provider import ToolProviderController
-from core.tools.__base.tool_runtime import ToolRuntime
-from core.tools.mcp_tool.provider import MCPToolProviderController
-from core.tools.mcp_tool.tool import MCPTool
-from core.tools.plugin_tool.provider import PluginToolProviderController
-from core.tools.plugin_tool.tool import PluginTool
-from core.tools.utils.uuid_utils import is_valid_uuid
-from core.tools.workflow_as_tool.provider import WorkflowToolProviderController
-from extensions.ext_database import db
-from graphon.runtime import VariablePool
-from models.provider_ids import ToolProviderID
-from services.tools.mcp_tools_manage_service import MCPToolManageService
-
-if TYPE_CHECKING:
-    pass
-
 from core.agent.entities import AgentToolEntity
 from core.app.entities.app_invoke_entities import InvokeFrom
+from core.entities import PluginCredentialType
 from core.helper.module_import_helper import load_single_subclass_from_source
 from core.helper.position_helper import is_filtered
+from core.helper.provider_cache import ToolProviderCredentialsCache
+from core.plugin.impl.tool import PluginToolManager
 from core.tools.__base.tool import Tool
+from core.tools.__base.tool_provider import ToolProviderController
+from core.tools.__base.tool_runtime import ToolRuntime
 from core.tools.builtin_tool.provider import BuiltinToolProviderController
 from core.tools.builtin_tool.providers._positions import BuiltinToolProviderSort
 from core.tools.builtin_tool.tool import BuiltinTool
@@ -56,12 +42,21 @@ from core.tools.entities.tool_entities import (
     emoji_icon_adapter,
 )
 from core.tools.errors import ToolProviderNotFoundError
+from core.tools.mcp_tool.provider import MCPToolProviderController
+from core.tools.mcp_tool.tool import MCPTool
+from core.tools.plugin_tool.provider import PluginToolProviderController
+from core.tools.plugin_tool.tool import PluginTool
 from core.tools.tool_label_manager import ToolLabelManager
 from core.tools.utils.configuration import ToolParameterConfigurationManager
 from core.tools.utils.encryption import create_provider_encrypter, create_tool_provider_encrypter
+from core.tools.utils.uuid_utils import is_valid_uuid
+from core.tools.workflow_as_tool.provider import WorkflowToolProviderController
 from core.tools.workflow_as_tool.tool import WorkflowTool
-from graphon.model_runtime.utils.encoders import jsonable_encoder
+from extensions.ext_database import db
+from graphon.runtime import VariablePool
+from models.provider_ids import ToolProviderID
 from models.tools import ApiToolProvider, BuiltinToolProvider, WorkflowToolProvider
+from services.tools.mcp_tools_manage_service import MCPToolManageService
 from services.tools.tools_transform_service import ToolTransformService
 
 if TYPE_CHECKING:
@@ -921,23 +916,19 @@ class ToolManager:
 
         # add tool labels
         labels = ToolLabelManager.get_tool_labels(controller)
+        schema_type = provider_obj.schema_type
 
-        return cast(
-            dict,
-            jsonable_encoder(
-                {
-                    "schema_type": provider_obj.schema_type,
-                    "schema": provider_obj.schema,
-                    "tools": provider_obj.tools,
-                    "icon": icon,
-                    "description": provider_obj.description,
-                    "credentials": masked_credentials,
-                    "privacy_policy": provider_obj.privacy_policy,
-                    "custom_disclaimer": provider_obj.custom_disclaimer,
-                    "labels": labels,
-                }
-            ),
-        )
+        return {
+            "schema_type": getattr(schema_type, "value", schema_type),
+            "schema": provider_obj.schema,
+            "tools": [tool.model_dump(mode="json") for tool in provider_obj.tools],
+            "icon": icon,
+            "description": provider_obj.description,
+            "credentials": masked_credentials,
+            "privacy_policy": provider_obj.privacy_policy,
+            "custom_disclaimer": provider_obj.custom_disclaimer,
+            "labels": labels,
+        }
 
     @classmethod
     def generate_builtin_tool_icon_url(cls, provider_id: str) -> str:

--- a/api/core/tools/tool_manager.py
+++ b/api/core/tools/tool_manager.py
@@ -35,6 +35,7 @@ from core.tools.entities.api_entities import ToolProviderApiEntity, ToolProvider
 from core.tools.entities.common_entities import I18nObject
 from core.tools.entities.tool_entities import (
     ApiProviderAuthType,
+    ApiProviderSchemaType,
     EmojiIconDict,
     ToolInvokeFrom,
     ToolParameter,
@@ -917,9 +918,10 @@ class ToolManager:
         # add tool labels
         labels = ToolLabelManager.get_tool_labels(controller)
         schema_type = provider_obj.schema_type
+        schema_type_value = schema_type.value if isinstance(schema_type, ApiProviderSchemaType) else schema_type
 
         return {
-            "schema_type": getattr(schema_type, "value", schema_type),
+            "schema_type": schema_type_value,
             "schema": provider_obj.schema,
             "tools": [tool.model_dump(mode="json") for tool in provider_obj.tools],
             "icon": icon,

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -1794,7 +1794,7 @@ Get human input form preview for advanced chat workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Human input form preview | **application/json**: [HumanInputFormPreviewResponse](#humaninputformpreviewresponse)<br> |
+| 200 | Human input form preview retrieved | **application/json**: [HumanInputFormPreviewResponse](#humaninputformpreviewresponse)<br> |
 
 ### [POST] /apps/{app_id}/advanced-chat/workflows/draft/human-input/nodes/{node_id}/form/run
 **Submit human input form preview**
@@ -1816,9 +1816,9 @@ Submit human input form preview for advanced chat workflow
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Human input form submission result | **application/json**: [HumanInputFormSubmitResponse](#humaninputformsubmitresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Human input form submitted |
 
 ### [POST] /apps/{app_id}/advanced-chat/workflows/draft/iteration/nodes/{node_id}/run
 **Run draft workflow iteration node**
@@ -1840,11 +1840,11 @@ Run draft workflow iteration node for advanced chat
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Iteration node run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 403 | Permission denied |  |
-| 404 | Node not found |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Iteration node run started successfully |
+| 403 | Permission denied |
+| 404 | Node not found |
 
 ### [POST] /apps/{app_id}/advanced-chat/workflows/draft/loop/nodes/{node_id}/run
 **Run draft workflow loop node**
@@ -1866,11 +1866,11 @@ Run draft workflow loop node for advanced chat
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Loop node run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 403 | Permission denied |  |
-| 404 | Node not found |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Loop node run started successfully |
+| 403 | Permission denied |
+| 404 | Node not found |
 
 ### [POST] /apps/{app_id}/advanced-chat/workflows/draft/run
 **Run draft workflow**
@@ -1891,11 +1891,11 @@ Run draft workflow for advanced chat application
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Workflow run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 400 | Invalid request parameters |  |
-| 403 | Permission denied |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Workflow run started successfully |
+| 400 | Invalid request parameters |
+| 403 | Permission denied |
 
 ### [GET] /apps/{app_id}/agent/config/files
 #### Parameters
@@ -4084,9 +4084,9 @@ Get default block configurations for workflow
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Default block configurations retrieved successfully | **application/json**: [DefaultBlockConfigsResponse](#defaultblockconfigsresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Default block configurations retrieved successfully |
 
 ### [GET] /apps/{app_id}/workflows/default-workflow-block-configs/{block_type}
 **Get default block config**
@@ -4103,10 +4103,10 @@ Get default block configuration by type
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Default block configuration retrieved successfully | **application/json**: [DefaultBlockConfigResponse](#defaultblockconfigresponse)<br> |
-| 404 | Block type not found |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Default block configuration retrieved successfully |
+| 404 | Block type not found |
 
 ### [GET] /apps/{app_id}/workflows/draft
 **Get draft workflow**
@@ -4164,7 +4164,7 @@ Get conversation variables for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Conversation variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
+| 200 | Conversation variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
 | 404 | Draft workflow not found |  |
 
 ### [POST] /apps/{app_id}/workflows/draft/conversation-variables
@@ -4203,7 +4203,7 @@ Get environment variables for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Environment variables retrieved successfully | **application/json**: [EnvironmentVariableListResponse](#environmentvariablelistresponse)<br> |
+| 200 | Environment variables retrieved successfully | **application/json**: [WorkflowDraftEnvironmentVariableListResponse](#workflowdraftenvironmentvariablelistresponse)<br> |
 | 404 | Draft workflow not found |  |
 
 ### [POST] /apps/{app_id}/workflows/draft/environment-variables
@@ -4270,7 +4270,7 @@ Test human input delivery for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Human input delivery test result | **application/json**: [EmptyObjectResponse](#emptyobjectresponse)<br> |
+| 200 | Human input delivery tested | **application/json**: [HumanInputDeliveryTestResponse](#humaninputdeliverytestresponse)<br> |
 
 ### [POST] /apps/{app_id}/workflows/draft/human-input/nodes/{node_id}/form/preview
 **Preview human input form content and placeholders**
@@ -4294,7 +4294,7 @@ Get human input form preview for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Human input form preview | **application/json**: [HumanInputFormPreviewResponse](#humaninputformpreviewresponse)<br> |
+| 200 | Human input form preview retrieved | **application/json**: [HumanInputFormPreviewResponse](#humaninputformpreviewresponse)<br> |
 
 ### [POST] /apps/{app_id}/workflows/draft/human-input/nodes/{node_id}/form/run
 **Submit human input form preview**
@@ -4316,9 +4316,9 @@ Submit human input form preview for workflow
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Human input form submission result | **application/json**: [HumanInputFormSubmitResponse](#humaninputformsubmitresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Human input form submitted |
 
 ### [POST] /apps/{app_id}/workflows/draft/iteration/nodes/{node_id}/run
 **Run draft workflow iteration node**
@@ -4338,11 +4338,11 @@ Submit human input form preview for workflow
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Workflow iteration node run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 403 | Permission denied |  |
-| 404 | Node not found |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Workflow iteration node run started successfully |
+| 403 | Permission denied |
+| 404 | Node not found |
 
 ### [POST] /apps/{app_id}/workflows/draft/loop/nodes/{node_id}/run
 **Run draft workflow loop node**
@@ -4362,11 +4362,11 @@ Submit human input form preview for workflow
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Workflow loop node run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 403 | Permission denied |  |
-| 404 | Node not found |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Workflow loop node run started successfully |
+| 403 | Permission denied |
+| 404 | Node not found |
 
 ### [GET] /apps/{app_id}/workflows/draft/nodes/{node_id}/agent-composer
 #### Parameters
@@ -4553,7 +4553,7 @@ Get last run result for draft workflow node
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Trigger event received and node executed successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 200 | Trigger event received and node executed successfully | **application/json**: [WorkflowRunNodeExecutionResponse](#workflowrunnodeexecutionresponse)<br> |
 | 403 | Permission denied |  |
 | 500 | Internal server error |  |
 
@@ -4587,7 +4587,7 @@ Get variables for a specific node
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
+| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
 
 ### [POST] /apps/{app_id}/workflows/draft/run
 **Run draft workflow**
@@ -4606,10 +4606,10 @@ Get variables for a specific node
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Draft workflow run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 403 | Permission denied |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Draft workflow run started successfully |
+| 403 | Permission denied |
 
 ### [GET] /apps/{app_id}/workflows/draft/runs/{run_id}/node-outputs
 Snapshot of every node's declared outputs for a draft workflow run.
@@ -4695,7 +4695,7 @@ Get system variables for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
+| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
 
 ### [POST] /apps/{app_id}/workflows/draft/trigger/run
 **Poll for trigger events and execute full workflow when event arrives**
@@ -4710,15 +4710,15 @@ Get system variables for workflow
 
 | Required | Schema |
 | -------- | ------ |
-|  Yes | **application/json**: [DraftWorkflowTriggerRunRequest](#draftworkflowtriggerrunrequest)<br> |
+|  Yes | **application/json**: [DraftWorkflowTriggerRunPayload](#draftworkflowtriggerrunpayload)<br> |
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Trigger event received and workflow executed successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 403 | Permission denied |  |
-| 500 | Internal server error |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Trigger event received and workflow executed successfully |
+| 403 | Permission denied |
+| 500 | Internal server error |
 
 ### [POST] /apps/{app_id}/workflows/draft/trigger/run-all
 **Full workflow debug when the start node is a trigger**
@@ -4737,11 +4737,11 @@ Get system variables for workflow
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Workflow executed successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 403 | Permission denied |  |
-| 500 | Internal server error |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Workflow executed successfully |
+| 403 | Permission denied |
+| 500 | Internal server error |
 
 ### [DELETE] /apps/{app_id}/workflows/draft/variables
 Delete all draft workflow variables
@@ -4775,7 +4775,7 @@ Get draft workflow variables
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValue](#workflowdraftvariablelistwithoutvalue)<br> |
+| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValueResponse](#workflowdraftvariablelistwithoutvalueresponse)<br> |
 
 ### [DELETE] /apps/{app_id}/workflows/draft/variables/{variable_id}
 Delete a workflow variable
@@ -4808,7 +4808,7 @@ Get a specific workflow variable
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
+| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
 | 404 | Variable not found |  |
 
 ### [PATCH] /apps/{app_id}/workflows/draft/variables/{variable_id}
@@ -4831,7 +4831,7 @@ Update a workflow variable
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
+| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
 | 404 | Variable not found |  |
 
 ### [PUT] /apps/{app_id}/workflows/draft/variables/{variable_id}/reset
@@ -4848,7 +4848,7 @@ Reset a workflow variable to its default value
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
+| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
 | 204 | Variable reset (no content) |  |
 | 404 | Variable not found |  |
 
@@ -4888,7 +4888,7 @@ Get published workflow for an application
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow published successfully | **application/json**: [WorkflowPublishResponse](#workflowpublishresponse)<br> |
+| 200 | Workflow published successfully | **application/json**: [PublishWorkflowResponse](#publishworkflowresponse)<br> |
 
 ### [GET] /apps/{app_id}/workflows/published/runs/{run_id}/node-outputs
 Snapshot of every node's declared outputs for a published workflow run.
@@ -5033,7 +5033,7 @@ Restore a published workflow version into the draft workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow restored successfully | **application/json**: [WorkflowRestoreResponse](#workflowrestoreresponse)<br> |
+| 200 | Workflow restored successfully | **application/json**: [SyncDraftWorkflowResponse](#syncdraftworkflowresponse)<br> |
 | 400 | Source workflow must be published |  |
 | 404 | Workflow not found |  |
 
@@ -7847,7 +7847,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
+| 200 | Datasource plugins retrieved successfully | **application/json**: [DatasourcePluginListResponse](#datasourcepluginlistresponse)<br> |
 
 ### [POST] /rag/pipelines/imports
 #### Request Body
@@ -7902,7 +7902,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
+| 200 | Recommended plugins retrieved successfully | **application/json**: [RagPipelineRecommendedPluginResponse](#ragpipelinerecommendedpluginresponse)<br> |
 
 ### [POST] /rag/pipelines/transform/datasets/{dataset_id}
 #### Parameters
@@ -7915,7 +7915,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
+| 200 | Dataset transformed successfully | **application/json**: [RagPipelineTransformResponse](#ragpipelinetransformresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/customized/publish
 #### Parameters
@@ -8046,9 +8046,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Default block configs retrieved successfully | **application/json**: [DefaultBlockConfigsResponse](#defaultblockconfigsresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Default workflow block configurations retrieved successfully |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/default-workflow-block-configs/{block_type}
 **Get default block config**
@@ -8063,9 +8063,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Default block config retrieved successfully | **application/json**: [DefaultBlockConfigResponse](#defaultblockconfigresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Default workflow block configuration retrieved successfully |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft
 **Get draft rag pipeline's workflow**
@@ -8122,9 +8122,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/draft/datasource/variables-inspect
 **Set datasource variables**
@@ -8160,7 +8160,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Environment variables retrieved successfully | **application/json**: [EnvironmentVariableListResponse](#environmentvariablelistresponse)<br> |
+| 200 | Environment variables retrieved successfully | **application/json**: [RagPipelineEnvironmentVariableListResponse](#ragpipelineenvironmentvariablelistresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/draft/iteration/nodes/{node_id}/run
 **Run draft workflow iteration node**
@@ -8180,9 +8180,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/draft/loop/nodes/{node_id}/run
 **Run draft workflow loop node**
@@ -8202,9 +8202,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/nodes/{node_id}/last-run
 #### Parameters
@@ -8268,7 +8268,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
+| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/pre-processing/parameters
 **Get first step parameters of rag pipeline**
@@ -8284,7 +8284,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineStepParametersResponse](#ragpipelinestepparametersresponse)<br> |
+| 200 | First step parameters retrieved successfully | **application/json**: [RagPipelineVariablesResponse](#ragpipelinevariablesresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/processing/parameters
 **Get second step parameters of rag pipeline**
@@ -8300,7 +8300,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineStepParametersResponse](#ragpipelinestepparametersresponse)<br> |
+| 200 | Second step parameters retrieved successfully | **application/json**: [RagPipelineVariablesResponse](#ragpipelinevariablesresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/draft/run
 **Run draft workflow**
@@ -8319,9 +8319,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/system-variables
 #### Parameters
@@ -8334,7 +8334,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
+| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
 
 ### [DELETE] /rag/pipelines/{pipeline_id}/workflows/draft/variables
 #### Parameters
@@ -8347,7 +8347,7 @@ Initiate OAuth login process
 
 | Code | Description |
 | ---- | ----------- |
-| 204 | Workflow variables deleted successfully |
+| 204 | Variables deleted successfully |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/variables
 **Get draft workflow**
@@ -8356,15 +8356,13 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| limit | query |  | No | integer, <br>**Default:** 20 |
-| page | query |  | No | integer, <br>**Default:** 1 |
 | pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValue](#workflowdraftvariablelistwithoutvalue)<br> |
+| 200 | Variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValueResponse](#workflowdraftvariablelistwithoutvalueresponse)<br> |
 
 ### [DELETE] /rag/pipelines/{pipeline_id}/workflows/draft/variables/{variable_id}
 #### Parameters
@@ -8392,7 +8390,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
+| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
 
 ### [PATCH] /rag/pipelines/{pipeline_id}/workflows/draft/variables/{variable_id}
 #### Parameters
@@ -8412,7 +8410,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
+| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
 
 ### [PUT] /rag/pipelines/{pipeline_id}/workflows/draft/variables/{variable_id}/reset
 #### Parameters
@@ -8426,8 +8424,8 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
-| 204 | Variable reset (no content) |  |
+| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
+| 204 | Variable reset to empty state |  |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/publish
 **Get published pipeline**
@@ -8499,9 +8497,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/published/pre-processing/parameters
 **Get first step parameters of rag pipeline**
@@ -8517,7 +8515,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineStepParametersResponse](#ragpipelinestepparametersresponse)<br> |
+| 200 | First step parameters retrieved successfully | **application/json**: [RagPipelineVariablesResponse](#ragpipelinevariablesresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/published/processing/parameters
 **Get second step parameters of rag pipeline**
@@ -8533,7 +8531,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineStepParametersResponse](#ragpipelinestepparametersresponse)<br> |
+| 200 | Second step parameters retrieved successfully | **application/json**: [RagPipelineVariablesResponse](#ragpipelinevariablesresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/published/run
 **Run published workflow**
@@ -8552,9 +8550,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
 
 ### [DELETE] /rag/pipelines/{pipeline_id}/workflows/{workflow_id}
 **Delete a published workflow version that is not currently active on the pipeline**
@@ -8809,9 +8807,9 @@ Get all published workflows for a snippet
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Default block configs retrieved successfully | **application/json**: [DefaultBlockConfigsResponse](#defaultblockconfigsresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Default block configs retrieved successfully |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft
 **Get draft workflow for snippet**
@@ -8848,7 +8846,7 @@ Get all published workflows for a snippet
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Draft workflow synced successfully | **application/json**: [WorkflowRestoreResponse](#workflowrestoreresponse)<br> |
+| 200 | Draft workflow synced successfully | **application/json**: [SyncDraftWorkflowResponse](#syncdraftworkflowresponse)<br> |
 | 400 | Hash mismatch |  |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft/config
@@ -8879,7 +8877,7 @@ Conversation variables are not used in snippet workflows; returns an empty list 
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Conversation variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
+| 200 | Conversation variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft/environment-variables
 Get environment variables from snippet draft workflow graph
@@ -8894,7 +8892,7 @@ Get environment variables from snippet draft workflow graph
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Environment variables retrieved successfully | **application/json**: [EnvironmentVariableListResponse](#environmentvariablelistresponse)<br> |
+| 200 | Environment variables retrieved successfully | **application/json**: [WorkflowDraftEnvironmentVariableListResponse](#workflowdraftenvironmentvariablelistresponse)<br> |
 | 404 | Draft workflow not found |  |
 
 ### [POST] /snippets/{snippet_id}/workflows/draft/iteration/nodes/{node_id}/run
@@ -8921,7 +8919,7 @@ Returns an SSE event stream with iteration progress and results.
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Iteration node run started successfully (SSE stream) | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 200 | Iteration node run started successfully (SSE stream) | **application/json**: [EventStreamResponse](#eventstreamresponse)<br> |
 | 404 | Snippet or draft workflow not found |  |
 
 ### [POST] /snippets/{snippet_id}/workflows/draft/loop/nodes/{node_id}/run
@@ -8948,7 +8946,7 @@ Returns an SSE event stream with loop progress and results.
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Loop node run started successfully (SSE stream) | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 200 | Loop node run started successfully (SSE stream) | **application/json**: [EventStreamResponse](#eventstreamresponse)<br> |
 | 404 | Snippet or draft workflow not found |  |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft/nodes/{node_id}/last-run
@@ -9029,7 +9027,7 @@ Get variables for a specific node (snippet draft workflow)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
+| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
 
 ### [POST] /snippets/{snippet_id}/workflows/draft/run
 **Run draft workflow for snippet**
@@ -9053,7 +9051,7 @@ and returns an SSE event stream with execution progress and results.
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Draft workflow run started successfully (SSE stream) | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 200 | Draft workflow run started successfully (SSE stream) | **application/json**: [EventStreamResponse](#eventstreamresponse)<br> |
 | 404 | Snippet or draft workflow not found |  |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft/system-variables
@@ -9069,7 +9067,7 @@ System variables are not used in snippet workflows; returns an empty list for AP
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
+| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
 
 ### [DELETE] /snippets/{snippet_id}/workflows/draft/variables
 Delete all draft workflow variables for the current user (snippet scope)
@@ -9101,7 +9099,7 @@ List draft workflow variables without values (paginated, snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValue](#workflowdraftvariablelistwithoutvalue)<br> |
+| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValueResponse](#workflowdraftvariablelistwithoutvalueresponse)<br> |
 
 ### [DELETE] /snippets/{snippet_id}/workflows/draft/variables/{variable_id}
 Delete a draft workflow variable (snippet scope)
@@ -9134,7 +9132,7 @@ Get a specific draft workflow variable (snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
+| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
 | 404 | Variable not found |  |
 
 ### [PATCH] /snippets/{snippet_id}/workflows/draft/variables/{variable_id}
@@ -9157,7 +9155,7 @@ Update a draft workflow variable (snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
+| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
 | 404 | Variable not found |  |
 
 ### [PUT] /snippets/{snippet_id}/workflows/draft/variables/{variable_id}/reset
@@ -9174,7 +9172,7 @@ Reset a draft workflow variable to its default value (snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
+| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
 | 204 | Variable reset (no content) |  |
 | 404 | Variable not found |  |
 
@@ -9213,7 +9211,7 @@ Reset a draft workflow variable to its default value (snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow published successfully | **application/json**: [WorkflowPublishResponse](#workflowpublishresponse)<br> |
+| 200 | Workflow published successfully | **application/json**: [PublishWorkflowResponse](#publishworkflowresponse)<br> |
 | 400 | No draft workflow found |  |
 
 ### [PATCH] /snippets/{snippet_id}/workflows/{workflow_id}
@@ -9256,7 +9254,7 @@ Update published snippet workflow attributes
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow restored successfully | **application/json**: [WorkflowRestoreResponse](#workflowrestoreresponse)<br> |
+| 200 | Workflow restored successfully | **application/json**: [SyncDraftWorkflowResponse](#syncdraftworkflowresponse)<br> |
 | 400 | Source workflow must be published |  |
 | 404 | Workflow not found |  |
 
@@ -16697,6 +16695,25 @@ Model class for provider custom model configuration.
 | ---- | ---- | ----------- | -------- |
 | id | string |  | Yes |
 
+#### DatasourceEntity
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| description | [I18nObject](#i18nobject) | The label of the datasource | Yes |
+| identity | [DatasourceIdentity](#datasourceidentity) |  | Yes |
+| output_schema | object |  | No |
+| parameters | [ [DatasourceParameter](#datasourceparameter) ] |  | No |
+
+#### DatasourceIdentity
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| author | string | The author of the datasource | Yes |
+| icon | string |  | No |
+| label | [I18nObject](#i18nobject) | The label of the datasource | Yes |
+| name | string | The name of the datasource | Yes |
+| provider | string | The provider of the datasource | Yes |
+
 #### DatasourceNodeRunPayload
 
 | Name | Type | Description | Required |
@@ -16731,6 +16748,41 @@ Model class for provider custom model configuration.
 | oauth_custom_client_params | object | Masked plugin-defined OAuth client parameters, when configured for the tenant. | Yes |
 | redirect_uri | string |  | Yes |
 
+#### DatasourceParameter
+
+Overrides type
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| auto_generate | [PluginParameterAutoGenerate](#pluginparameterautogenerate) |  | No |
+| default | number<br>integer<br>string<br>boolean<br>[ object ]<br>object |  | No |
+| description | [I18nObject](#i18nobject) | The description of the parameter | Yes |
+| label | [I18nObject](#i18nobject) | The label presented to the user | Yes |
+| max | number<br>integer |  | No |
+| min | number<br>integer |  | No |
+| name | string | The name of the parameter | Yes |
+| options | [ [PluginParameterOption](#pluginparameteroption) ] |  | No |
+| placeholder | [I18nObject](#i18nobject) | The placeholder presented to the user | No |
+| precision | integer |  | No |
+| required | boolean |  | No |
+| scope | string |  | No |
+| template | [PluginParameterTemplate](#pluginparametertemplate) |  | No |
+| type | [DatasourceParameterType](#datasourceparametertype) | The type of the parameter | Yes |
+
+#### DatasourceParameterType
+
+removes TOOLS_SELECTOR from PluginParameterType
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| DatasourceParameterType | string | removes TOOLS_SELECTOR from PluginParameterType |  |
+
+#### DatasourcePluginListResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| DatasourcePluginListResponse | array |  |  |
+
 #### DatasourceProviderAuthListResponse
 
 | Name | Type | Description | Required |
@@ -16752,6 +16804,35 @@ Model class for provider custom model configuration.
 | plugin_id | string |  | Yes |
 | plugin_unique_identifier | string |  | Yes |
 | provider | string |  | Yes |
+
+#### DatasourceProviderEntityWithPlugin
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| credentials_schema | [ [ProviderConfig](#providerconfig) ] |  | No |
+| datasources | [ [DatasourceEntity](#datasourceentity) ] |  | No |
+| identity | [DatasourceProviderIdentity](#datasourceprovideridentity) |  | Yes |
+| oauth_schema | [OAuthSchema](#oauthschema) |  | No |
+| provider_type | [DatasourceProviderType](#datasourceprovidertype) |  | Yes |
+
+#### DatasourceProviderIdentity
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| author | string | The author of the tool | Yes |
+| description | [I18nObject](#i18nobject) | The description of the tool | Yes |
+| icon | string | The icon of the tool | Yes |
+| label | [I18nObject](#i18nobject) | The label of the tool | Yes |
+| name | string | The name of the tool | Yes |
+| tags | [ [ToolLabelEnum](#toollabelenum) ] | The tags of the tool | No |
+
+#### DatasourceProviderType
+
+Enum class for datasource provider
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| DatasourceProviderType | string | Enum class for datasource provider |  |
 
 #### DatasourceUpdateNamePayload
 
@@ -16860,18 +16941,6 @@ Per-output retry configuration that mirrors ``graphon.RetryConfig`` shape.
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | q | string |  | No |
-
-#### DefaultBlockConfigResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| DefaultBlockConfigResponse | object |  |  |
-
-#### DefaultBlockConfigsResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| DefaultBlockConfigsResponse | array |  |  |
 
 #### DefaultModelDataResponse
 
@@ -17081,12 +17150,6 @@ Request payload for bulk downloading documents as a zip archive.
 | ---- | ---- | ----------- | -------- |
 | node_id | string |  | Yes |
 
-#### DraftWorkflowTriggerRunRequest
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| node_id | string | Node ID | Yes |
-
 #### EducationActivatePayload
 
 | Name | Type | Description | Required |
@@ -17189,12 +17252,6 @@ Request payload for bulk downloading documents as a zip archive.
 | code | string |  | Yes |
 | email | string |  | Yes |
 | token | string |  | Yes |
-
-#### EmptyObjectResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| EmptyObjectResponse | object |  |  |
 
 #### EndpointCreatePayload
 
@@ -17332,27 +17389,6 @@ Request payload for bulk downloading documents as a zip archive.
 | name | string |  | No |
 | value |  |  | No |
 | value_type | string |  | No |
-
-#### EnvironmentVariableItemResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| description | string |  | No |
-| editable | boolean |  | Yes |
-| edited | boolean |  | Yes |
-| id | string |  | Yes |
-| name | string |  | Yes |
-| selector | [ string ] |  | Yes |
-| type | string |  | Yes |
-| value |  |  | Yes |
-| value_type | string |  | Yes |
-| visible | boolean |  | Yes |
-
-#### EnvironmentVariableListResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [EnvironmentVariableItemResponse](#environmentvariableitemresponse) ] |  | Yes |
 
 #### EnvironmentVariableUpdatePayload
 
@@ -17777,12 +17813,6 @@ Enum class for form type.
 | ---- | ---- | ----------- | -------- |
 | document_list | [ string ] |  | Yes |
 
-#### GeneratedAppResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| GeneratedAppResponse |  |  |  |
-
 #### GeneratorResponse
 
 | Name | Type | Description | Required |
@@ -17906,6 +17936,11 @@ Enum class for form type.
 | delivery_method_id | string | Delivery method ID | Yes |
 | inputs | object | Values used to fill missing upstream variables referenced in form_content | No |
 
+#### HumanInputDeliveryTestResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+
 #### HumanInputFormDefinition
 
 | Name | Type | Description | Required |
@@ -17931,12 +17966,13 @@ Enum class for form type.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| actions | [ object ] |  | No |
-| display_in_ui | boolean |  | No |
-| expiration_time | integer |  | No |
+| TYPE | string, <br>**Default:** human_input_required |  | No |
+| actions | [ [HumanInputUserActionResponse](#humaninputuseractionresponse) ] |  | No |
+| display_in_ui | boolean | Always false for draft preview responses. | No |
+| expiration_time | integer | Always null for draft preview responses. | No |
 | form_content | string |  | Yes |
 | form_id | string |  | Yes |
-| form_token | string |  | No |
+| form_token | string | Always null for draft preview responses. | No |
 | inputs | [ object ] |  | No |
 | node_id | string |  | Yes |
 | node_title | string |  | Yes |
@@ -17961,12 +17997,6 @@ Enum class for form type.
 | form_inputs | object | Values the user provides for the form's own fields | Yes |
 | inputs | object | Values used to fill missing upstream variables referenced in form_content | Yes |
 
-#### HumanInputFormSubmitResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| HumanInputFormSubmitResponse | object |  |  |
-
 #### HumanInputPauseTypeResponse
 
 | Name | Type | Description | Required |
@@ -17974,6 +18004,14 @@ Enum class for form type.
 | backstage_input_url | string |  | No |
 | form_id | string |  | Yes |
 | type | string |  | Yes |
+
+#### HumanInputUserActionResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| button_style | string, <br>**Default:** default |  | No |
+| id | string |  | Yes |
+| title | string |  | Yes |
 
 #### I18nObject
 
@@ -18196,7 +18234,7 @@ Input field definition for snippet parameters.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| JSONValue | string<br>integer<br>number<br>boolean<br>object<br>[ object ] |  |  |
+| JSONValue |  |  |  |
 
 #### JSONValueType
 
@@ -19692,6 +19730,16 @@ Shared permission levels for resources (datasets, credentials, etc.)
 | ---- | ---- | ----------- | -------- |
 | PluginDaemonOperationResponse |  |  |  |
 
+#### PluginDatasourceProviderEntity
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| declaration | [DatasourceProviderEntityWithPlugin](#datasourceproviderentitywithplugin) |  | Yes |
+| is_authorized | boolean |  | No |
+| plugin_id | string |  | Yes |
+| plugin_unique_identifier | string |  | Yes |
+| provider | string |  | Yes |
+
 #### PluginDebuggingKeyResponse
 
 | Name | Type | Description | Required |
@@ -20081,11 +20129,17 @@ Model class for provider with models response.
 
 #### PublishWorkflowPayload
 
-Payload for publishing snippet workflow.
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| marked_comment | string |  | No |
+| marked_name | string |  | No |
+
+#### PublishWorkflowResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| knowledge_base_setting | object |  | No |
+| created_at | integer |  | Yes |
+| result | string |  | Yes |
 
 #### PublishedWorkflowRunPayload
 
@@ -20170,6 +20224,27 @@ Whitelist scopes accepted by RBAC app and dataset access config APIs.
 | ---- | ---- | ----------- | -------- |
 | yaml_content | string |  | Yes |
 
+#### RagPipelineEnvironmentVariableListResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| items | [ [RagPipelineEnvironmentVariableResponse](#ragpipelineenvironmentvariableresponse) ] |  | Yes |
+
+#### RagPipelineEnvironmentVariableResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| description | string |  | Yes |
+| editable | boolean |  | Yes |
+| edited | boolean |  | Yes |
+| id | string |  | Yes |
+| name | string |  | Yes |
+| selector | [ string ] |  | Yes |
+| type | string |  | Yes |
+| value |  |  | Yes |
+| value_type | string |  | Yes |
+| visible | boolean |  | Yes |
+
 #### RagPipelineImportCheckDependenciesResponse
 
 | Name | Type | Description | Required |
@@ -20202,19 +20277,28 @@ Whitelist scopes accepted by RBAC app and dataset access config APIs.
 | pipeline_id | string |  | No |
 | status | [ImportStatus](#importstatus) |  | Yes |
 
-#### RagPipelineOpaqueResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| RagPipelineOpaqueResponse |  |  |  |
-
 #### RagPipelineRecommendedPluginQuery
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | type | string, <br>**Default:** all |  | No |
 
-#### RagPipelineStepParametersResponse
+#### RagPipelineRecommendedPluginResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| installed_recommended_plugins | [ object ] | Installed tool provider payloads. Shape follows the tool provider serializer. | Yes |
+| uninstalled_recommended_plugins | [ object ] | Marketplace plugin manifest payloads returned by the marketplace service. | Yes |
+
+#### RagPipelineTransformResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| dataset_id | string |  | Yes |
+| pipeline_id | string |  | Yes |
+| status | string |  | Yes |
+
+#### RagPipelineVariablesResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
@@ -21192,9 +21276,9 @@ The subscription constructor of the trigger provider
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| hash | string |  | No |
-| result | string |  | No |
-| updated_at | string |  | No |
+| hash | string |  | Yes |
+| result | string |  | Yes |
+| updated_at | integer |  | Yes |
 
 #### SystemConfigurationResponse
 
@@ -21454,6 +21538,12 @@ Available voices
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | data | [ [TokensPerSecondStatisticItem](#tokenspersecondstatisticitem) ] |  | Yes |
+
+#### ToolLabelEnum
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| ToolLabelEnum | string |  |  |
 
 #### ToolOAuthClientSchemaResponse
 
@@ -21748,6 +21838,20 @@ Enum class for tool provider
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | TriggerCreationMethod | string |  |  |
+
+#### TriggerDebugErrorResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| error | string |  | No |
+| status | string |  | Yes |
+
+#### TriggerDebugWaitingResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| retry_in | integer |  | Yes |
+| status | string |  | Yes |
 
 #### TriggerOAuthAuthorizeResponse
 
@@ -22400,46 +22504,35 @@ How a workflow node is bound to an Agent.
 | ---- | ---- | ----------- | -------- |
 | data | [ [WorkflowDailyTokenCostStatisticItem](#workflowdailytokencoststatisticitem) ] |  | Yes |
 
-#### WorkflowDraftEnvVariable
+#### WorkflowDraftEnvironmentVariableListResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| items | [ [WorkflowDraftEnvironmentVariableResponse](#workflowdraftenvironmentvariableresponse) ] |  | Yes |
+
+#### WorkflowDraftEnvironmentVariableResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | description | string |  | No |
-| edited | boolean |  | No |
-| id | string |  | No |
-| name | string |  | No |
-| selector | [ string ] |  | No |
-| type | string |  | No |
-| value_type | string |  | No |
-| visible | boolean |  | No |
+| editable | boolean |  | Yes |
+| edited | boolean |  | Yes |
+| id | string |  | Yes |
+| name | string |  | Yes |
+| selector | [ string ] |  | Yes |
+| type | string |  | Yes |
+| value |  |  | Yes |
+| value_type | string |  | Yes |
+| visible | boolean |  | Yes |
 
-#### WorkflowDraftEnvVariableList
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [WorkflowDraftEnvVariable](#workflowdraftenvvariable) ] |  | No |
-
-#### WorkflowDraftVariable
+#### WorkflowDraftVariableFullContentResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| description | string |  | No |
-| edited | boolean |  | No |
-| full_content | object |  | No |
-| id | string |  | No |
-| is_truncated | boolean |  | No |
-| name | string |  | No |
-| selector | [ string ] |  | No |
-| type | string |  | No |
-| value | string<br>integer<br>number<br>boolean<br>object<br>[ object ] |  | No |
-| value_type | string |  | No |
-| visible | boolean |  | No |
-
-#### WorkflowDraftVariableList
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [WorkflowDraftVariable](#workflowdraftvariable) ] |  | No |
+| download_url | string |  | Yes |
+| length | integer |  | Yes |
+| size_bytes | integer |  | Yes |
+| value_type | string |  | Yes |
 
 #### WorkflowDraftVariableListQuery
 
@@ -22448,19 +22541,41 @@ How a workflow node is bound to an Agent.
 | limit | integer, <br>**Default:** 20 | Items per page | No |
 | page | integer, <br>**Default:** 1 | Page number | No |
 
-#### WorkflowDraftVariableListWithoutValue
+#### WorkflowDraftVariableListResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| items | [ [WorkflowDraftVariableWithoutValue](#workflowdraftvariablewithoutvalue) ] |  | No |
-| total | integer |  | No |
+| items | [ [WorkflowDraftVariableResponse](#workflowdraftvariableresponse) ] |  | Yes |
+
+#### WorkflowDraftVariableListWithoutValueResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| items | [ [WorkflowDraftVariableWithoutValueResponse](#workflowdraftvariablewithoutvalueresponse) ] |  | Yes |
+| total | integer |  | Yes |
 
 #### WorkflowDraftVariablePatchPayload
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| name | string |  | No |
+| name | string | Variable name | No |
 | value |  |  | No |
+
+#### WorkflowDraftVariableResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| description | string |  | Yes |
+| edited | boolean |  | Yes |
+| full_content | [WorkflowDraftVariableFullContentResponse](#workflowdraftvariablefullcontentresponse) |  | Yes |
+| id | string |  | Yes |
+| is_truncated | boolean |  | Yes |
+| name | string |  | Yes |
+| selector | [ string ] |  | Yes |
+| type | string |  | Yes |
+| value |  |  | Yes |
+| value_type | string |  | Yes |
+| visible | boolean |  | Yes |
 
 #### WorkflowDraftVariableUpdatePayload
 
@@ -22469,19 +22584,19 @@ How a workflow node is bound to an Agent.
 | name | string | Variable name | No |
 | value |  | Variable value | No |
 
-#### WorkflowDraftVariableWithoutValue
+#### WorkflowDraftVariableWithoutValueResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| description | string |  | No |
-| edited | boolean |  | No |
-| id | string |  | No |
-| is_truncated | boolean |  | No |
-| name | string |  | No |
-| selector | [ string ] |  | No |
-| type | string |  | No |
-| value_type | string |  | No |
-| visible | boolean |  | No |
+| description | string |  | Yes |
+| edited | boolean |  | Yes |
+| id | string |  | Yes |
+| is_truncated | boolean |  | Yes |
+| name | string |  | Yes |
+| selector | [ string ] |  | Yes |
+| type | string |  | Yes |
+| value_type | string |  | Yes |
+| visible | boolean |  | Yes |
 
 #### WorkflowEnvironmentVariableResponse
 
@@ -22695,13 +22810,6 @@ tenant's default model. The underlying generator never raises — an empty
 | variable | string |  | No |
 | variable_selector | [ string<br>integer<br>number<br>boolean ] |  | No |
 
-#### WorkflowPublishResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| created_at | integer |  | Yes |
-| result | string |  | Yes |
-
 #### WorkflowResponse
 
 | Name | Type | Description | Required |
@@ -22721,14 +22829,6 @@ tenant's default model. The underlying generator never raises — an empty
 | updated_at | integer |  | Yes |
 | updated_by | [SimpleAccountResponse](#simpleaccountresponse) |  | No |
 | version | string |  | Yes |
-
-#### WorkflowRestoreResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| hash | string |  | Yes |
-| result | string |  | Yes |
-| updated_at | integer |  | Yes |
 
 #### WorkflowRunCountQuery
 

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -1794,7 +1794,7 @@ Get human input form preview for advanced chat workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Human input form preview retrieved | **application/json**: [HumanInputFormPreviewResponse](#humaninputformpreviewresponse)<br> |
+| 200 | Human input form preview | **application/json**: [HumanInputFormPreviewResponse](#humaninputformpreviewresponse)<br> |
 
 ### [POST] /apps/{app_id}/advanced-chat/workflows/draft/human-input/nodes/{node_id}/form/run
 **Submit human input form preview**
@@ -1816,9 +1816,9 @@ Submit human input form preview for advanced chat workflow
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Human input form submitted |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Human input form submission result | **application/json**: [HumanInputFormSubmitResponse](#humaninputformsubmitresponse)<br> |
 
 ### [POST] /apps/{app_id}/advanced-chat/workflows/draft/iteration/nodes/{node_id}/run
 **Run draft workflow iteration node**
@@ -1840,11 +1840,11 @@ Run draft workflow iteration node for advanced chat
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Iteration node run started successfully |
-| 403 | Permission denied |
-| 404 | Node not found |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Iteration node run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 403 | Permission denied |  |
+| 404 | Node not found |  |
 
 ### [POST] /apps/{app_id}/advanced-chat/workflows/draft/loop/nodes/{node_id}/run
 **Run draft workflow loop node**
@@ -1866,11 +1866,11 @@ Run draft workflow loop node for advanced chat
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Loop node run started successfully |
-| 403 | Permission denied |
-| 404 | Node not found |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Loop node run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 403 | Permission denied |  |
+| 404 | Node not found |  |
 
 ### [POST] /apps/{app_id}/advanced-chat/workflows/draft/run
 **Run draft workflow**
@@ -1891,11 +1891,11 @@ Run draft workflow for advanced chat application
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Workflow run started successfully |
-| 400 | Invalid request parameters |
-| 403 | Permission denied |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Workflow run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 400 | Invalid request parameters |  |
+| 403 | Permission denied |  |
 
 ### [GET] /apps/{app_id}/agent/config/files
 #### Parameters
@@ -4084,9 +4084,9 @@ Get default block configurations for workflow
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Default block configurations retrieved successfully |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Default block configurations retrieved successfully | **application/json**: [DefaultBlockConfigsResponse](#defaultblockconfigsresponse)<br> |
 
 ### [GET] /apps/{app_id}/workflows/default-workflow-block-configs/{block_type}
 **Get default block config**
@@ -4103,10 +4103,10 @@ Get default block configuration by type
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Default block configuration retrieved successfully |
-| 404 | Block type not found |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Default block configuration retrieved successfully | **application/json**: [DefaultBlockConfigResponse](#defaultblockconfigresponse)<br> |
+| 404 | Block type not found |  |
 
 ### [GET] /apps/{app_id}/workflows/draft
 **Get draft workflow**
@@ -4164,7 +4164,7 @@ Get conversation variables for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Conversation variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
+| 200 | Conversation variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
 | 404 | Draft workflow not found |  |
 
 ### [POST] /apps/{app_id}/workflows/draft/conversation-variables
@@ -4203,7 +4203,7 @@ Get environment variables for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Environment variables retrieved successfully | **application/json**: [WorkflowDraftEnvironmentVariableListResponse](#workflowdraftenvironmentvariablelistresponse)<br> |
+| 200 | Environment variables retrieved successfully | **application/json**: [EnvironmentVariableListResponse](#environmentvariablelistresponse)<br> |
 | 404 | Draft workflow not found |  |
 
 ### [POST] /apps/{app_id}/workflows/draft/environment-variables
@@ -4270,7 +4270,7 @@ Test human input delivery for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Human input delivery tested | **application/json**: [HumanInputDeliveryTestResponse](#humaninputdeliverytestresponse)<br> |
+| 200 | Human input delivery test result | **application/json**: [EmptyObjectResponse](#emptyobjectresponse)<br> |
 
 ### [POST] /apps/{app_id}/workflows/draft/human-input/nodes/{node_id}/form/preview
 **Preview human input form content and placeholders**
@@ -4294,7 +4294,7 @@ Get human input form preview for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Human input form preview retrieved | **application/json**: [HumanInputFormPreviewResponse](#humaninputformpreviewresponse)<br> |
+| 200 | Human input form preview | **application/json**: [HumanInputFormPreviewResponse](#humaninputformpreviewresponse)<br> |
 
 ### [POST] /apps/{app_id}/workflows/draft/human-input/nodes/{node_id}/form/run
 **Submit human input form preview**
@@ -4316,9 +4316,9 @@ Submit human input form preview for workflow
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Human input form submitted |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Human input form submission result | **application/json**: [HumanInputFormSubmitResponse](#humaninputformsubmitresponse)<br> |
 
 ### [POST] /apps/{app_id}/workflows/draft/iteration/nodes/{node_id}/run
 **Run draft workflow iteration node**
@@ -4338,11 +4338,11 @@ Submit human input form preview for workflow
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Workflow iteration node run started successfully |
-| 403 | Permission denied |
-| 404 | Node not found |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Workflow iteration node run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 403 | Permission denied |  |
+| 404 | Node not found |  |
 
 ### [POST] /apps/{app_id}/workflows/draft/loop/nodes/{node_id}/run
 **Run draft workflow loop node**
@@ -4362,11 +4362,11 @@ Submit human input form preview for workflow
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Workflow loop node run started successfully |
-| 403 | Permission denied |
-| 404 | Node not found |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Workflow loop node run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 403 | Permission denied |  |
+| 404 | Node not found |  |
 
 ### [GET] /apps/{app_id}/workflows/draft/nodes/{node_id}/agent-composer
 #### Parameters
@@ -4553,7 +4553,7 @@ Get last run result for draft workflow node
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Trigger event received and node executed successfully | **application/json**: [WorkflowRunNodeExecutionResponse](#workflowrunnodeexecutionresponse)<br> |
+| 200 | Trigger event received and node executed successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
 | 403 | Permission denied |  |
 | 500 | Internal server error |  |
 
@@ -4587,7 +4587,7 @@ Get variables for a specific node
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
+| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
 
 ### [POST] /apps/{app_id}/workflows/draft/run
 **Run draft workflow**
@@ -4606,10 +4606,10 @@ Get variables for a specific node
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Draft workflow run started successfully |
-| 403 | Permission denied |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Draft workflow run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 403 | Permission denied |  |
 
 ### [GET] /apps/{app_id}/workflows/draft/runs/{run_id}/node-outputs
 Snapshot of every node's declared outputs for a draft workflow run.
@@ -4695,7 +4695,7 @@ Get system variables for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
+| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
 
 ### [POST] /apps/{app_id}/workflows/draft/trigger/run
 **Poll for trigger events and execute full workflow when event arrives**
@@ -4710,15 +4710,15 @@ Get system variables for workflow
 
 | Required | Schema |
 | -------- | ------ |
-|  Yes | **application/json**: [DraftWorkflowTriggerRunPayload](#draftworkflowtriggerrunpayload)<br> |
+|  Yes | **application/json**: [DraftWorkflowTriggerRunRequest](#draftworkflowtriggerrunrequest)<br> |
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Trigger event received and workflow executed successfully |
-| 403 | Permission denied |
-| 500 | Internal server error |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Trigger event received and workflow executed successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 403 | Permission denied |  |
+| 500 | Internal server error |  |
 
 ### [POST] /apps/{app_id}/workflows/draft/trigger/run-all
 **Full workflow debug when the start node is a trigger**
@@ -4737,11 +4737,11 @@ Get system variables for workflow
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Workflow executed successfully |
-| 403 | Permission denied |
-| 500 | Internal server error |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Workflow executed successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 403 | Permission denied |  |
+| 500 | Internal server error |  |
 
 ### [DELETE] /apps/{app_id}/workflows/draft/variables
 Delete all draft workflow variables
@@ -4775,7 +4775,7 @@ Get draft workflow variables
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValueResponse](#workflowdraftvariablelistwithoutvalueresponse)<br> |
+| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValue](#workflowdraftvariablelistwithoutvalue)<br> |
 
 ### [DELETE] /apps/{app_id}/workflows/draft/variables/{variable_id}
 Delete a workflow variable
@@ -4808,7 +4808,7 @@ Get a specific workflow variable
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
+| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
 | 404 | Variable not found |  |
 
 ### [PATCH] /apps/{app_id}/workflows/draft/variables/{variable_id}
@@ -4831,7 +4831,7 @@ Update a workflow variable
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
+| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
 | 404 | Variable not found |  |
 
 ### [PUT] /apps/{app_id}/workflows/draft/variables/{variable_id}/reset
@@ -4848,7 +4848,7 @@ Reset a workflow variable to its default value
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
+| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
 | 204 | Variable reset (no content) |  |
 | 404 | Variable not found |  |
 
@@ -4888,7 +4888,7 @@ Get published workflow for an application
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow published successfully | **application/json**: [PublishWorkflowResponse](#publishworkflowresponse)<br> |
+| 200 | Workflow published successfully | **application/json**: [WorkflowPublishResponse](#workflowpublishresponse)<br> |
 
 ### [GET] /apps/{app_id}/workflows/published/runs/{run_id}/node-outputs
 Snapshot of every node's declared outputs for a published workflow run.
@@ -5033,7 +5033,7 @@ Restore a published workflow version into the draft workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow restored successfully | **application/json**: [SyncDraftWorkflowResponse](#syncdraftworkflowresponse)<br> |
+| 200 | Workflow restored successfully | **application/json**: [WorkflowRestoreResponse](#workflowrestoreresponse)<br> |
 | 400 | Source workflow must be published |  |
 | 404 | Workflow not found |  |
 
@@ -7460,9 +7460,9 @@ Get instruction generation template
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 302 | Redirect to console OAuth callback page | **application/json**: [RedirectResponse](#redirectresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 302 | Redirect to OAuth callback page |
 
 ### [GET] /notification
 Return the active in-product notification for the current user in their interface language (falls back to English if unavailable). The notification is NOT marked as seen here; call POST /notification/dismiss when the user explicitly closes the modal.
@@ -7667,7 +7667,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Authorization URL retrieved successfully | **application/json**: [PluginOAuthAuthorizationUrlResponse](#pluginoauthauthorizationurlresponse)<br> |
+| 200 | Tool OAuth authorization URL generated successfully | **application/json**: [PluginOAuthAuthorizationUrlResponse](#pluginoauthauthorizationurlresponse)<br> |
 
 ### [GET] /oauth/plugin/{provider}/tool/callback
 #### Parameters
@@ -7678,9 +7678,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 302 | Redirect to console OAuth callback page | **application/json**: [RedirectResponse](#redirectresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 302 | Redirect to OAuth callback page |
 
 ### [GET] /oauth/plugin/{provider}/trigger/callback
 **Handle OAuth callback for trigger provider**
@@ -7693,9 +7693,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 302 | Redirect to console OAuth callback page | **application/json**: [RedirectResponse](#redirectresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 302 | Redirect to OAuth callback page |
 
 ### [POST] /oauth/provider
 #### Request Body
@@ -7847,7 +7847,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Datasource plugins retrieved successfully | **application/json**: [DatasourcePluginListResponse](#datasourcepluginlistresponse)<br> |
+| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
 
 ### [POST] /rag/pipelines/imports
 #### Request Body
@@ -7902,7 +7902,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Recommended plugins retrieved successfully | **application/json**: [RagPipelineRecommendedPluginResponse](#ragpipelinerecommendedpluginresponse)<br> |
+| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
 
 ### [POST] /rag/pipelines/transform/datasets/{dataset_id}
 #### Parameters
@@ -7915,7 +7915,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Dataset transformed successfully | **application/json**: [RagPipelineTransformResponse](#ragpipelinetransformresponse)<br> |
+| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/customized/publish
 #### Parameters
@@ -8046,9 +8046,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Default workflow block configurations retrieved successfully |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Default block configs retrieved successfully | **application/json**: [DefaultBlockConfigsResponse](#defaultblockconfigsresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/default-workflow-block-configs/{block_type}
 **Get default block config**
@@ -8063,9 +8063,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Default workflow block configuration retrieved successfully |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Default block config retrieved successfully | **application/json**: [DefaultBlockConfigResponse](#defaultblockconfigresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft
 **Get draft rag pipeline's workflow**
@@ -8122,9 +8122,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Success |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/draft/datasource/variables-inspect
 **Set datasource variables**
@@ -8160,7 +8160,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Environment variables retrieved successfully | **application/json**: [RagPipelineEnvironmentVariableListResponse](#ragpipelineenvironmentvariablelistresponse)<br> |
+| 200 | Environment variables retrieved successfully | **application/json**: [EnvironmentVariableListResponse](#environmentvariablelistresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/draft/iteration/nodes/{node_id}/run
 **Run draft workflow iteration node**
@@ -8180,9 +8180,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Success |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/draft/loop/nodes/{node_id}/run
 **Run draft workflow loop node**
@@ -8202,9 +8202,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Success |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/nodes/{node_id}/last-run
 #### Parameters
@@ -8268,7 +8268,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
+| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/pre-processing/parameters
 **Get first step parameters of rag pipeline**
@@ -8284,7 +8284,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | First step parameters retrieved successfully | **application/json**: [RagPipelineVariablesResponse](#ragpipelinevariablesresponse)<br> |
+| 200 | Success | **application/json**: [RagPipelineStepParametersResponse](#ragpipelinestepparametersresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/processing/parameters
 **Get second step parameters of rag pipeline**
@@ -8300,7 +8300,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Second step parameters retrieved successfully | **application/json**: [RagPipelineVariablesResponse](#ragpipelinevariablesresponse)<br> |
+| 200 | Success | **application/json**: [RagPipelineStepParametersResponse](#ragpipelinestepparametersresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/draft/run
 **Run draft workflow**
@@ -8319,9 +8319,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Success |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/system-variables
 #### Parameters
@@ -8334,7 +8334,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
+| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
 
 ### [DELETE] /rag/pipelines/{pipeline_id}/workflows/draft/variables
 #### Parameters
@@ -8347,7 +8347,7 @@ Initiate OAuth login process
 
 | Code | Description |
 | ---- | ----------- |
-| 204 | Variables deleted successfully |
+| 204 | Workflow variables deleted successfully |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/variables
 **Get draft workflow**
@@ -8356,13 +8356,15 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
+| limit | query |  | No | integer, <br>**Default:** 20 |
+| page | query |  | No | integer, <br>**Default:** 1 |
 | pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValueResponse](#workflowdraftvariablelistwithoutvalueresponse)<br> |
+| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValue](#workflowdraftvariablelistwithoutvalue)<br> |
 
 ### [DELETE] /rag/pipelines/{pipeline_id}/workflows/draft/variables/{variable_id}
 #### Parameters
@@ -8390,7 +8392,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
+| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
 
 ### [PATCH] /rag/pipelines/{pipeline_id}/workflows/draft/variables/{variable_id}
 #### Parameters
@@ -8410,7 +8412,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
+| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
 
 ### [PUT] /rag/pipelines/{pipeline_id}/workflows/draft/variables/{variable_id}/reset
 #### Parameters
@@ -8424,8 +8426,8 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
-| 204 | Variable reset to empty state |  |
+| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
+| 204 | Variable reset (no content) |  |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/publish
 **Get published pipeline**
@@ -8497,9 +8499,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Success |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/published/pre-processing/parameters
 **Get first step parameters of rag pipeline**
@@ -8515,7 +8517,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | First step parameters retrieved successfully | **application/json**: [RagPipelineVariablesResponse](#ragpipelinevariablesresponse)<br> |
+| 200 | Success | **application/json**: [RagPipelineStepParametersResponse](#ragpipelinestepparametersresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/published/processing/parameters
 **Get second step parameters of rag pipeline**
@@ -8531,7 +8533,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Second step parameters retrieved successfully | **application/json**: [RagPipelineVariablesResponse](#ragpipelinevariablesresponse)<br> |
+| 200 | Success | **application/json**: [RagPipelineStepParametersResponse](#ragpipelinestepparametersresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/published/run
 **Run published workflow**
@@ -8550,9 +8552,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Success |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
 
 ### [DELETE] /rag/pipelines/{pipeline_id}/workflows/{workflow_id}
 **Delete a published workflow version that is not currently active on the pipeline**
@@ -8807,9 +8809,9 @@ Get all published workflows for a snippet
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Default block configs retrieved successfully |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Default block configs retrieved successfully | **application/json**: [DefaultBlockConfigsResponse](#defaultblockconfigsresponse)<br> |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft
 **Get draft workflow for snippet**
@@ -8846,7 +8848,7 @@ Get all published workflows for a snippet
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Draft workflow synced successfully | **application/json**: [SyncDraftWorkflowResponse](#syncdraftworkflowresponse)<br> |
+| 200 | Draft workflow synced successfully | **application/json**: [WorkflowRestoreResponse](#workflowrestoreresponse)<br> |
 | 400 | Hash mismatch |  |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft/config
@@ -8877,7 +8879,7 @@ Conversation variables are not used in snippet workflows; returns an empty list 
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Conversation variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
+| 200 | Conversation variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft/environment-variables
 Get environment variables from snippet draft workflow graph
@@ -8892,7 +8894,7 @@ Get environment variables from snippet draft workflow graph
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Environment variables retrieved successfully | **application/json**: [WorkflowDraftEnvironmentVariableListResponse](#workflowdraftenvironmentvariablelistresponse)<br> |
+| 200 | Environment variables retrieved successfully | **application/json**: [EnvironmentVariableListResponse](#environmentvariablelistresponse)<br> |
 | 404 | Draft workflow not found |  |
 
 ### [POST] /snippets/{snippet_id}/workflows/draft/iteration/nodes/{node_id}/run
@@ -8919,7 +8921,7 @@ Returns an SSE event stream with iteration progress and results.
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Iteration node run started successfully (SSE stream) | **application/json**: [EventStreamResponse](#eventstreamresponse)<br> |
+| 200 | Iteration node run started successfully (SSE stream) | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
 | 404 | Snippet or draft workflow not found |  |
 
 ### [POST] /snippets/{snippet_id}/workflows/draft/loop/nodes/{node_id}/run
@@ -8946,7 +8948,7 @@ Returns an SSE event stream with loop progress and results.
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Loop node run started successfully (SSE stream) | **application/json**: [EventStreamResponse](#eventstreamresponse)<br> |
+| 200 | Loop node run started successfully (SSE stream) | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
 | 404 | Snippet or draft workflow not found |  |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft/nodes/{node_id}/last-run
@@ -9027,7 +9029,7 @@ Get variables for a specific node (snippet draft workflow)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
+| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
 
 ### [POST] /snippets/{snippet_id}/workflows/draft/run
 **Run draft workflow for snippet**
@@ -9051,7 +9053,7 @@ and returns an SSE event stream with execution progress and results.
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Draft workflow run started successfully (SSE stream) | **application/json**: [EventStreamResponse](#eventstreamresponse)<br> |
+| 200 | Draft workflow run started successfully (SSE stream) | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
 | 404 | Snippet or draft workflow not found |  |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft/system-variables
@@ -9067,7 +9069,7 @@ System variables are not used in snippet workflows; returns an empty list for AP
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
+| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
 
 ### [DELETE] /snippets/{snippet_id}/workflows/draft/variables
 Delete all draft workflow variables for the current user (snippet scope)
@@ -9099,7 +9101,7 @@ List draft workflow variables without values (paginated, snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValueResponse](#workflowdraftvariablelistwithoutvalueresponse)<br> |
+| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValue](#workflowdraftvariablelistwithoutvalue)<br> |
 
 ### [DELETE] /snippets/{snippet_id}/workflows/draft/variables/{variable_id}
 Delete a draft workflow variable (snippet scope)
@@ -9132,7 +9134,7 @@ Get a specific draft workflow variable (snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
+| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
 | 404 | Variable not found |  |
 
 ### [PATCH] /snippets/{snippet_id}/workflows/draft/variables/{variable_id}
@@ -9155,7 +9157,7 @@ Update a draft workflow variable (snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
+| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
 | 404 | Variable not found |  |
 
 ### [PUT] /snippets/{snippet_id}/workflows/draft/variables/{variable_id}/reset
@@ -9172,7 +9174,7 @@ Reset a draft workflow variable to its default value (snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
+| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
 | 204 | Variable reset (no content) |  |
 | 404 | Variable not found |  |
 
@@ -9211,7 +9213,7 @@ Reset a draft workflow variable to its default value (snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow published successfully | **application/json**: [PublishWorkflowResponse](#publishworkflowresponse)<br> |
+| 200 | Workflow published successfully | **application/json**: [WorkflowPublishResponse](#workflowpublishresponse)<br> |
 | 400 | No draft workflow found |  |
 
 ### [PATCH] /snippets/{snippet_id}/workflows/{workflow_id}
@@ -9254,7 +9256,7 @@ Update published snippet workflow attributes
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow restored successfully | **application/json**: [SyncDraftWorkflowResponse](#syncdraftworkflowresponse)<br> |
+| 200 | Workflow restored successfully | **application/json**: [WorkflowRestoreResponse](#workflowrestoreresponse)<br> |
 | 400 | Source workflow must be published |  |
 | 404 | Workflow not found |  |
 
@@ -11658,7 +11660,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | Tool labels retrieved successfully | **application/json**: [ToolLabelListResponse](#toollabellistresponse)<br> |
 
 ### [POST] /workspaces/current/tool-provider/api/add
 #### Request Body
@@ -11671,7 +11673,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | API provider added successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 
 ### [POST] /workspaces/current/tool-provider/api/delete
 #### Request Body
@@ -11684,7 +11686,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | API provider deleted successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 
 ### [GET] /workspaces/current/tool-provider/api/get
 #### Parameters
@@ -11697,7 +11699,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | API provider retrieved successfully | **application/json**: [ApiProviderDetailResponse](#apiproviderdetailresponse)<br> |
 
 ### [GET] /workspaces/current/tool-provider/api/remote
 #### Parameters
@@ -11710,7 +11712,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | Remote API provider schema retrieved successfully | **application/json**: [ApiProviderRemoteSchemaResponse](#apiproviderremoteschemaresponse)<br> |
 
 ### [POST] /workspaces/current/tool-provider/api/schema
 #### Request Body
@@ -11723,7 +11725,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | API schema parsed successfully | **application/json**: [ApiSchemaParseResponse](#apischemaparseresponse)<br> |
 
 ### [POST] /workspaces/current/tool-provider/api/test/pre
 #### Request Body
@@ -11736,7 +11738,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | API tool test preview completed successfully | **application/json**: [ApiToolPreviewResponse](#apitoolpreviewresponse)<br> |
 
 ### [GET] /workspaces/current/tool-provider/api/tools
 #### Parameters
@@ -11749,7 +11751,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | API provider tools retrieved successfully | **application/json**: [ToolApiListResponse](#toolapilistresponse)<br> |
 
 ### [POST] /workspaces/current/tool-provider/api/update
 #### Request Body
@@ -11762,7 +11764,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | API provider updated successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 
 ### [POST] /workspaces/current/tool-provider/builtin/{provider}/add
 #### Parameters
@@ -11781,7 +11783,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | Builtin provider added successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 
 ### [GET] /workspaces/current/tool-provider/builtin/{provider}/credential/info
 #### Parameters
@@ -11795,7 +11797,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | Builtin provider credential info retrieved successfully | **application/json**: [ToolProviderCredentialInfoApiEntity](#toolprovidercredentialinfoapientity)<br> |
 
 ### [GET] /workspaces/current/tool-provider/builtin/{provider}/credential/schema/{credential_type}
 #### Parameters
@@ -11809,7 +11811,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | Builtin provider credential schema retrieved successfully | **application/json**: [ProviderConfigListResponse](#providerconfiglistresponse)<br> |
 
 ### [GET] /workspaces/current/tool-provider/builtin/{provider}/credentials
 #### Parameters
@@ -11823,7 +11825,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | Builtin provider credentials retrieved successfully | **application/json**: [ToolProviderCredentialListResponse](#toolprovidercredentiallistresponse)<br> |
 
 ### [POST] /workspaces/current/tool-provider/builtin/{provider}/default-credential
 #### Parameters
@@ -11842,7 +11844,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | Default credential set successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 
 ### [POST] /workspaces/current/tool-provider/builtin/{provider}/delete
 #### Parameters
@@ -11861,7 +11863,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | Builtin provider credential deleted successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 
 ### [GET] /workspaces/current/tool-provider/builtin/{provider}/icon
 #### Parameters
@@ -11872,9 +11874,9 @@ Returns permission flags that control workspace features like member invitations
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [BinaryFileResponse](#binaryfileresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Builtin provider icon |
 
 ### [GET] /workspaces/current/tool-provider/builtin/{provider}/info
 #### Parameters
@@ -11887,7 +11889,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | Builtin provider info retrieved successfully | **application/json**: [ToolProviderApiEntityResponse](#toolproviderapientityresponse)<br> |
 
 ### [GET] /workspaces/current/tool-provider/builtin/{provider}/oauth/client-schema
 #### Parameters
@@ -11900,7 +11902,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolOAuthClientSchemaResponse](#tooloauthclientschemaresponse)<br> |
+| 200 | Builtin provider OAuth client schema retrieved successfully | **application/json**: [BuiltinProviderOAuthClientSchemaResponse](#builtinprovideroauthclientschemaresponse)<br> |
 
 ### [DELETE] /workspaces/current/tool-provider/builtin/{provider}/oauth/custom-client
 #### Parameters
@@ -11913,7 +11915,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
+| 200 | Custom OAuth client deleted successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 
 ### [GET] /workspaces/current/tool-provider/builtin/{provider}/oauth/custom-client
 #### Parameters
@@ -11924,9 +11926,9 @@ Returns permission flags that control workspace features like member invitations
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolOAuthCustomClientResponse](#tooloauthcustomclientresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Custom OAuth client retrieved successfully |
 
 ### [POST] /workspaces/current/tool-provider/builtin/{provider}/oauth/custom-client
 #### Parameters
@@ -11945,7 +11947,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
+| 200 | Custom OAuth client saved successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 
 ### [GET] /workspaces/current/tool-provider/builtin/{provider}/tools
 #### Parameters
@@ -11958,7 +11960,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | Builtin provider tools retrieved successfully | **application/json**: [ToolApiListResponse](#toolapilistresponse)<br> |
 
 ### [POST] /workspaces/current/tool-provider/builtin/{provider}/update
 #### Parameters
@@ -11977,7 +11979,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | Builtin provider updated successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 
 ### [DELETE] /workspaces/current/tool-provider/mcp
 #### Request Body
@@ -12003,7 +12005,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | MCP provider created successfully | **application/json**: [ToolProviderApiEntityResponse](#toolproviderapientityresponse)<br> |
 
 ### [PUT] /workspaces/current/tool-provider/mcp
 #### Request Body
@@ -12016,7 +12018,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
+| 200 | MCP provider updated successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 
 ### [POST] /workspaces/current/tool-provider/mcp/auth
 #### Request Body
@@ -12029,7 +12031,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | MCP provider authorized successfully | **application/json**: [MCPAuthResponse](#mcpauthresponse)<br> |
 
 ### [GET] /workspaces/current/tool-provider/mcp/tools/{provider_id}
 #### Parameters
@@ -12042,7 +12044,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | MCP provider retrieved successfully | **application/json**: [ToolProviderApiEntityResponse](#toolproviderapientityresponse)<br> |
 
 ### [GET] /workspaces/current/tool-provider/mcp/update/{provider_id}
 #### Parameters
@@ -12055,7 +12057,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | MCP provider tools refreshed successfully | **application/json**: [ToolProviderApiEntityResponse](#toolproviderapientityresponse)<br> |
 
 ### [POST] /workspaces/current/tool-provider/workflow/create
 #### Request Body
@@ -12068,7 +12070,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | Workflow tool created successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 
 ### [POST] /workspaces/current/tool-provider/workflow/delete
 #### Request Body
@@ -12081,7 +12083,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | Workflow tool deleted successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 
 ### [GET] /workspaces/current/tool-provider/workflow/get
 #### Parameters
@@ -12095,7 +12097,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | Workflow tool retrieved successfully | **application/json**: [WorkflowToolDetailResponse](#workflowtooldetailresponse)<br> |
 
 ### [GET] /workspaces/current/tool-provider/workflow/tools
 #### Parameters
@@ -12108,7 +12110,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | Workflow provider tools retrieved successfully | **application/json**: [ToolApiListResponse](#toolapilistresponse)<br> |
 
 ### [POST] /workspaces/current/tool-provider/workflow/update
 #### Request Body
@@ -12121,7 +12123,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | Workflow tool updated successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 
 ### [GET] /workspaces/current/tool-providers
 #### Parameters
@@ -12134,35 +12136,35 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | Tool providers retrieved successfully | **application/json**: [ToolProviderListResponse](#toolproviderlistresponse)<br> |
 
 ### [GET] /workspaces/current/tools/api
 #### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | API tools retrieved successfully | **application/json**: [ToolProviderListResponse](#toolproviderlistresponse)<br> |
 
 ### [GET] /workspaces/current/tools/builtin
 #### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | Builtin tools retrieved successfully | **application/json**: [ToolProviderListResponse](#toolproviderlistresponse)<br> |
 
 ### [GET] /workspaces/current/tools/mcp
 #### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | MCP tools retrieved successfully | **application/json**: [ToolProviderListResponse](#toolproviderlistresponse)<br> |
 
 ### [GET] /workspaces/current/tools/workflow
 #### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [ToolProviderOpaqueResponse](#toolprovideropaqueresponse)<br> |
+| 200 | Workflow tools retrieved successfully | **application/json**: [ToolProviderListResponse](#toolproviderlistresponse)<br> |
 
 ### [GET] /workspaces/current/trigger-provider/{provider}/icon
 #### Parameters
@@ -12173,9 +12175,9 @@ Returns permission flags that control workspace features like member invitations
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [BinaryFileResponse](#binaryfileresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Trigger provider icon |
 
 ### [GET] /workspaces/current/trigger-provider/{provider}/info
 **Get info for a trigger provider**
@@ -12190,7 +12192,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [TriggerProviderApiEntity](#triggerproviderapientity)<br> |
+| 200 | Trigger provider retrieved successfully | **application/json**: [TriggerProviderApiEntity](#triggerproviderapientity)<br> |
 
 ### [DELETE] /workspaces/current/trigger-provider/{provider}/oauth/client
 **Remove custom OAuth client configuration**
@@ -12205,7 +12207,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
+| 200 | Trigger OAuth client deleted successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 
 ### [GET] /workspaces/current/trigger-provider/{provider}/oauth/client
 **Get OAuth client configuration for a provider**
@@ -12220,7 +12222,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [TriggerOAuthClientResponse](#triggeroauthclientresponse)<br> |
+| 200 | Trigger OAuth client retrieved successfully | **application/json**: [TriggerOAuthClientResponse](#triggeroauthclientresponse)<br> |
 
 ### [POST] /workspaces/current/trigger-provider/{provider}/oauth/client
 **Configure custom OAuth client for a provider**
@@ -12241,7 +12243,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
+| 200 | Trigger OAuth client saved successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 
 ### [POST] /workspaces/current/trigger-provider/{provider}/subscriptions/builder/build/{subscription_builder_id}
 **Build a subscription instance for a trigger provider**
@@ -12263,7 +12265,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [TriggerProviderOpaqueResponse](#triggerprovideropaqueresponse)<br> |
+| 200 | Trigger subscription builder built successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 
 ### [POST] /workspaces/current/trigger-provider/{provider}/subscriptions/builder/create
 **Add a new subscription instance for a trigger provider**
@@ -12284,7 +12286,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [TriggerSubscriptionBuilderCreateResponse](#triggersubscriptionbuildercreateresponse)<br> |
+| 200 | Trigger subscription builder created successfully | **application/json**: [TriggerSubscriptionBuilderCreateResponse](#triggersubscriptionbuildercreateresponse)<br> |
 
 ### [GET] /workspaces/current/trigger-provider/{provider}/subscriptions/builder/logs/{subscription_builder_id}
 **Get the request logs for a subscription instance for a trigger provider**
@@ -12300,7 +12302,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [TriggerSubscriptionBuilderLogsResponse](#triggersubscriptionbuilderlogsresponse)<br> |
+| 200 | Trigger subscription builder logs retrieved successfully | **application/json**: [TriggerSubscriptionBuilderLogsResponse](#triggersubscriptionbuilderlogsresponse)<br> |
 
 ### [POST] /workspaces/current/trigger-provider/{provider}/subscriptions/builder/update/{subscription_builder_id}
 **Update a subscription instance for a trigger provider**
@@ -12322,7 +12324,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [SubscriptionBuilderApiEntity](#subscriptionbuilderapientity)<br> |
+| 200 | Trigger subscription builder updated successfully | **application/json**: [SubscriptionBuilderApiEntity](#subscriptionbuilderapientity)<br> |
 
 ### [POST] /workspaces/current/trigger-provider/{provider}/subscriptions/builder/verify-and-update/{subscription_builder_id}
 **Verify and update a subscription instance for a trigger provider**
@@ -12344,7 +12346,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [TriggerSubscriptionBuilderVerifyResponse](#triggersubscriptionbuilderverifyresponse)<br> |
+| 200 | Trigger subscription builder verified successfully | **application/json**: [TriggerVerificationResponse](#triggerverificationresponse)<br> |
 
 ### [GET] /workspaces/current/trigger-provider/{provider}/subscriptions/builder/{subscription_builder_id}
 **Get a subscription instance for a trigger provider**
@@ -12360,7 +12362,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [SubscriptionBuilderApiEntity](#subscriptionbuilderapientity)<br> |
+| 200 | Trigger subscription builder retrieved successfully | **application/json**: [SubscriptionBuilderApiEntity](#subscriptionbuilderapientity)<br> |
 
 ### [GET] /workspaces/current/trigger-provider/{provider}/subscriptions/list
 **List all trigger subscriptions for the current tenant's provider**
@@ -12375,7 +12377,8 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [TriggerSubscriptionListResponse](#triggersubscriptionlistresponse)<br> |
+| 200 | Trigger subscriptions retrieved successfully | **application/json**: [TriggerProviderSubscriptionListResponse](#triggerprovidersubscriptionlistresponse)<br> |
+| 404 | Trigger provider not found | **application/json**: [TriggerProviderErrorResponse](#triggerprovidererrorresponse)<br> |
 
 ### [GET] /workspaces/current/trigger-provider/{provider}/subscriptions/oauth/authorize
 **Initiate OAuth authorization flow for a trigger provider**
@@ -12390,7 +12393,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Authorization URL retrieved successfully | **application/json**: [TriggerOAuthAuthorizeResponse](#triggeroauthauthorizeresponse)<br> |
+| 200 | Trigger OAuth authorization URL generated successfully | **application/json**: [TriggerOAuthAuthorizeResponse](#triggeroauthauthorizeresponse)<br> |
 
 ### [POST] /workspaces/current/trigger-provider/{provider}/subscriptions/verify/{subscription_id}
 **Verify credentials for an existing subscription (edit mode only)**
@@ -12412,7 +12415,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [TriggerSubscriptionBuilderVerifyResponse](#triggersubscriptionbuilderverifyresponse)<br> |
+| 200 | Trigger subscription verified successfully | **application/json**: [TriggerVerificationResponse](#triggerverificationresponse)<br> |
 
 ### [POST] /workspaces/current/trigger-provider/{subscription_id}/subscriptions/delete
 **Delete a subscription instance**
@@ -12448,7 +12451,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [TriggerProviderOpaqueResponse](#triggerprovideropaqueresponse)<br> |
+| 200 | Trigger subscription updated successfully | **application/json**: [SimpleResultResponse](#simpleresultresponse)<br> |
 
 ### [GET] /workspaces/current/triggers
 **List all trigger providers for the current tenant**
@@ -12457,7 +12460,7 @@ Returns permission flags that control workspace features like member invitations
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [TriggerProviderListResponse](#triggerproviderlistresponse)<br> |
+| 200 | Trigger providers retrieved successfully | **application/json**: [TriggerProviderListResponse](#triggerproviderlistresponse)<br> |
 
 ### [POST] /workspaces/custom-config
 #### Request Body
@@ -14870,6 +14873,26 @@ Legacy Chat App model config used only for follow-up question generation.
 | ---- | ---- | ----------- | -------- |
 | data | [ [ApiKeyItem](#apikeyitem) ] |  | Yes |
 
+#### ApiProviderDetailResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| credentials | object |  | No |
+| custom_disclaimer | string |  | No |
+| description | string |  | No |
+| icon | [ToolEmojiIcon](#toolemojiicon) |  | Yes |
+| labels | [ string ] |  | No |
+| privacy_policy | string |  | No |
+| schema | string |  | Yes |
+| schema_type | [ApiProviderSchemaType](#apiproviderschematype) |  | Yes |
+| tools | [ [ApiToolBundle](#apitoolbundle) ] |  | Yes |
+
+#### ApiProviderRemoteSchemaResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| schema | string |  | Yes |
+
 #### ApiProviderSchemaType
 
 Enum class for api provider schema type.
@@ -14878,13 +14901,52 @@ Enum class for api provider schema type.
 | ---- | ---- | ----------- | -------- |
 | ApiProviderSchemaType | string | Enum class for api provider schema type. |  |
 
+#### ApiSchemaParseResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| credentials_schema | [ [ProviderConfig](#providerconfig) ] |  | Yes |
+| parameters_schema | [ [ApiToolBundle](#apitoolbundle) ] |  | Yes |
+| schema_type | [ApiProviderSchemaType](#apiproviderschematype) |  | Yes |
+| warning | object |  | Yes |
+
+#### ApiToolBundle
+
+This class is used to store the schema information of an api based tool.
+ such as the url, the method, the parameters, etc.
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| author | string |  | Yes |
+| icon | string |  | No |
+| method | string |  | Yes |
+| openapi | object |  | Yes |
+| operation_id | string |  | No |
+| output_schema | object |  | No |
+| parameters | [ [ToolParameter](#toolparameter) ] |  | No |
+| server_url | string |  | Yes |
+| summary | string |  | No |
+
+#### ApiToolPreviewResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| ApiToolPreviewResponse |  |  |  |
+
+#### ApiToolPreviewResult
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| error | string |  | No |
+| result | string |  | No |
+
 #### ApiToolProviderAddPayload
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | credentials | object |  | Yes |
 | custom_disclaimer | string |  | No |
-| icon | object |  | Yes |
+| icon | [ToolEmojiIcon](#toolemojiicon) |  | Yes |
 | labels | [ string ] |  | No |
 | privacy_policy | string |  | No |
 | provider | string |  | Yes |
@@ -14903,7 +14965,7 @@ Enum class for api provider schema type.
 | ---- | ---- | ----------- | -------- |
 | credentials | object |  | Yes |
 | custom_disclaimer | string |  | No |
-| icon | object |  | Yes |
+| icon | [ToolEmojiIcon](#toolemojiicon) |  | Yes |
 | labels | [ string ] |  | No |
 | original_provider | string |  | Yes |
 | privacy_policy | string |  | No |
@@ -15378,6 +15440,16 @@ Retrieval settings for Amazon Bedrock knowledge base queries.
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | id | string |  | Yes |
+
+#### BuiltinProviderOAuthClientSchemaResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| client_params | object |  | No |
+| is_oauth_custom_client_enabled | boolean |  | Yes |
+| is_system_oauth_params_exists | boolean |  | Yes |
+| redirect_uri | string |  | Yes |
+| schema | [ [ProviderConfig](#providerconfig) ] |  | Yes |
 
 #### BuiltinToolAddPayload
 
@@ -16695,25 +16767,6 @@ Model class for provider custom model configuration.
 | ---- | ---- | ----------- | -------- |
 | id | string |  | Yes |
 
-#### DatasourceEntity
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| description | [I18nObject](#i18nobject) | The label of the datasource | Yes |
-| identity | [DatasourceIdentity](#datasourceidentity) |  | Yes |
-| output_schema | object |  | No |
-| parameters | [ [DatasourceParameter](#datasourceparameter) ] |  | No |
-
-#### DatasourceIdentity
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| author | string | The author of the datasource | Yes |
-| icon | string |  | No |
-| label | [I18nObject](#i18nobject) | The label of the datasource | Yes |
-| name | string | The name of the datasource | Yes |
-| provider | string | The provider of the datasource | Yes |
-
 #### DatasourceNodeRunPayload
 
 | Name | Type | Description | Required |
@@ -16748,41 +16801,6 @@ Model class for provider custom model configuration.
 | oauth_custom_client_params | object | Masked plugin-defined OAuth client parameters, when configured for the tenant. | Yes |
 | redirect_uri | string |  | Yes |
 
-#### DatasourceParameter
-
-Overrides type
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| auto_generate | [PluginParameterAutoGenerate](#pluginparameterautogenerate) |  | No |
-| default | number<br>integer<br>string<br>boolean<br>[ object ]<br>object |  | No |
-| description | [I18nObject](#i18nobject) | The description of the parameter | Yes |
-| label | [I18nObject](#i18nobject) | The label presented to the user | Yes |
-| max | number<br>integer |  | No |
-| min | number<br>integer |  | No |
-| name | string | The name of the parameter | Yes |
-| options | [ [PluginParameterOption](#pluginparameteroption) ] |  | No |
-| placeholder | [I18nObject](#i18nobject) | The placeholder presented to the user | No |
-| precision | integer |  | No |
-| required | boolean |  | No |
-| scope | string |  | No |
-| template | [PluginParameterTemplate](#pluginparametertemplate) |  | No |
-| type | [DatasourceParameterType](#datasourceparametertype) | The type of the parameter | Yes |
-
-#### DatasourceParameterType
-
-removes TOOLS_SELECTOR from PluginParameterType
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| DatasourceParameterType | string | removes TOOLS_SELECTOR from PluginParameterType |  |
-
-#### DatasourcePluginListResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| DatasourcePluginListResponse | array |  |  |
-
 #### DatasourceProviderAuthListResponse
 
 | Name | Type | Description | Required |
@@ -16804,35 +16822,6 @@ removes TOOLS_SELECTOR from PluginParameterType
 | plugin_id | string |  | Yes |
 | plugin_unique_identifier | string |  | Yes |
 | provider | string |  | Yes |
-
-#### DatasourceProviderEntityWithPlugin
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| credentials_schema | [ [ProviderConfig](#providerconfig) ] |  | No |
-| datasources | [ [DatasourceEntity](#datasourceentity) ] |  | No |
-| identity | [DatasourceProviderIdentity](#datasourceprovideridentity) |  | Yes |
-| oauth_schema | [OAuthSchema](#oauthschema) |  | No |
-| provider_type | [DatasourceProviderType](#datasourceprovidertype) |  | Yes |
-
-#### DatasourceProviderIdentity
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| author | string | The author of the tool | Yes |
-| description | [I18nObject](#i18nobject) | The description of the tool | Yes |
-| icon | string | The icon of the tool | Yes |
-| label | [I18nObject](#i18nobject) | The label of the tool | Yes |
-| name | string | The name of the tool | Yes |
-| tags | [ [ToolLabelEnum](#toollabelenum) ] | The tags of the tool | No |
-
-#### DatasourceProviderType
-
-Enum class for datasource provider
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| DatasourceProviderType | string | Enum class for datasource provider |  |
 
 #### DatasourceUpdateNamePayload
 
@@ -16941,6 +16930,18 @@ Per-output retry configuration that mirrors ``graphon.RetryConfig`` shape.
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | q | string |  | No |
+
+#### DefaultBlockConfigResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| DefaultBlockConfigResponse | object |  |  |
+
+#### DefaultBlockConfigsResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| DefaultBlockConfigsResponse | array |  |  |
 
 #### DefaultModelDataResponse
 
@@ -17150,6 +17151,12 @@ Request payload for bulk downloading documents as a zip archive.
 | ---- | ---- | ----------- | -------- |
 | node_id | string |  | Yes |
 
+#### DraftWorkflowTriggerRunRequest
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| node_id | string | Node ID | Yes |
+
 #### EducationActivatePayload
 
 | Name | Type | Description | Required |
@@ -17252,6 +17259,12 @@ Request payload for bulk downloading documents as a zip archive.
 | code | string |  | Yes |
 | email | string |  | Yes |
 | token | string |  | Yes |
+
+#### EmptyObjectResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| EmptyObjectResponse | object |  |  |
 
 #### EndpointCreatePayload
 
@@ -17389,6 +17402,27 @@ Request payload for bulk downloading documents as a zip archive.
 | name | string |  | No |
 | value |  |  | No |
 | value_type | string |  | No |
+
+#### EnvironmentVariableItemResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| description | string |  | No |
+| editable | boolean |  | Yes |
+| edited | boolean |  | Yes |
+| id | string |  | Yes |
+| name | string |  | Yes |
+| selector | [ string ] |  | Yes |
+| type | string |  | Yes |
+| value |  |  | Yes |
+| value_type | string |  | Yes |
+| visible | boolean |  | Yes |
+
+#### EnvironmentVariableListResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| items | [ [EnvironmentVariableItemResponse](#environmentvariableitemresponse) ] |  | Yes |
 
 #### EnvironmentVariableUpdatePayload
 
@@ -17813,6 +17847,12 @@ Enum class for form type.
 | ---- | ---- | ----------- | -------- |
 | document_list | [ string ] |  | Yes |
 
+#### GeneratedAppResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| GeneratedAppResponse |  |  |  |
+
 #### GeneratorResponse
 
 | Name | Type | Description | Required |
@@ -17936,11 +17976,6 @@ Enum class for form type.
 | delivery_method_id | string | Delivery method ID | Yes |
 | inputs | object | Values used to fill missing upstream variables referenced in form_content | No |
 
-#### HumanInputDeliveryTestResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-
 #### HumanInputFormDefinition
 
 | Name | Type | Description | Required |
@@ -17966,13 +18001,12 @@ Enum class for form type.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| TYPE | string, <br>**Default:** human_input_required |  | No |
-| actions | [ [HumanInputUserActionResponse](#humaninputuseractionresponse) ] |  | No |
-| display_in_ui | boolean | Always false for draft preview responses. | No |
-| expiration_time | integer | Always null for draft preview responses. | No |
+| actions | [ object ] |  | No |
+| display_in_ui | boolean |  | No |
+| expiration_time | integer |  | No |
 | form_content | string |  | Yes |
 | form_id | string |  | Yes |
-| form_token | string | Always null for draft preview responses. | No |
+| form_token | string |  | No |
 | inputs | [ object ] |  | No |
 | node_id | string |  | Yes |
 | node_title | string |  | Yes |
@@ -17997,6 +18031,12 @@ Enum class for form type.
 | form_inputs | object | Values the user provides for the form's own fields | Yes |
 | inputs | object | Values used to fill missing upstream variables referenced in form_content | Yes |
 
+#### HumanInputFormSubmitResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| HumanInputFormSubmitResponse | object |  |  |
+
 #### HumanInputPauseTypeResponse
 
 | Name | Type | Description | Required |
@@ -18004,14 +18044,6 @@ Enum class for form type.
 | backstage_input_url | string |  | No |
 | form_id | string |  | Yes |
 | type | string |  | Yes |
-
-#### HumanInputUserActionResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| button_style | string, <br>**Default:** default |  | No |
-| id | string |  | Yes |
-| title | string |  | Yes |
 
 #### I18nObject
 
@@ -18234,7 +18266,7 @@ Input field definition for snippet parameters.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| JSONValue |  |  |  |
+| JSONValue | string<br>integer<br>number<br>boolean<br>object<br>[ object ] |  |  |
 
 #### JSONValueType
 
@@ -18388,6 +18420,20 @@ Enum class for large language model mode.
 | authorization_code | string |  | No |
 | provider_id | string |  | Yes |
 
+#### MCPAuthResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| authorization_url | string |  | No |
+| result | string |  | No |
+
+#### MCPAuthentication
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| client_id | string |  | Yes |
+| client_secret | string |  | No |
+
 #### MCPCallbackQuery
 
 | Name | Type | Description | Required |
@@ -18395,12 +18441,19 @@ Enum class for large language model mode.
 | code | string |  | Yes |
 | state | string |  | Yes |
 
+#### MCPConfiguration
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| sse_read_timeout | number, <br>**Default:** 300 |  | No |
+| timeout | number, <br>**Default:** 30 |  | No |
+
 #### MCPProviderCreatePayload
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| authentication | object |  | No |
-| configuration | object |  | No |
+| authentication | [MCPAuthentication](#mcpauthentication) |  | No |
+| configuration | [MCPConfiguration](#mcpconfiguration) |  | No |
 | headers | object |  | No |
 | icon | string |  | Yes |
 | icon_background | string |  | No |
@@ -18420,8 +18473,8 @@ Enum class for large language model mode.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| authentication | object |  | No |
-| configuration | object |  | No |
+| authentication | [MCPAuthentication](#mcpauthentication) |  | No |
+| configuration | [MCPConfiguration](#mcpconfiguration) |  | No |
 | headers | object |  | No |
 | icon | string |  | Yes |
 | icon_background | string |  | No |
@@ -19730,16 +19783,6 @@ Shared permission levels for resources (datasets, credentials, etc.)
 | ---- | ---- | ----------- | -------- |
 | PluginDaemonOperationResponse |  |  |  |
 
-#### PluginDatasourceProviderEntity
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| declaration | [DatasourceProviderEntityWithPlugin](#datasourceproviderentitywithplugin) |  | Yes |
-| is_authorized | boolean |  | No |
-| plugin_id | string |  | Yes |
-| plugin_unique_identifier | string |  | Yes |
-| provider | string |  | Yes |
-
 #### PluginDebuggingKeyResponse
 
 | Name | Type | Description | Required |
@@ -19993,6 +20036,12 @@ Model class for common provider settings like credentials
 | type | [ProviderConfigType](#providerconfigtype) | The type of the credentials | Yes |
 | url | string |  | No |
 
+#### ProviderConfigListResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| ProviderConfigListResponse | array |  |  |
+
 #### ProviderConfigType
 
 | Name | Type | Description | Required |
@@ -20129,17 +20178,11 @@ Model class for provider with models response.
 
 #### PublishWorkflowPayload
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| marked_comment | string |  | No |
-| marked_name | string |  | No |
-
-#### PublishWorkflowResponse
+Payload for publishing snippet workflow.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| created_at | integer |  | Yes |
-| result | string |  | Yes |
+| knowledge_base_setting | object |  | No |
 
 #### PublishedWorkflowRunPayload
 
@@ -20224,27 +20267,6 @@ Whitelist scopes accepted by RBAC app and dataset access config APIs.
 | ---- | ---- | ----------- | -------- |
 | yaml_content | string |  | Yes |
 
-#### RagPipelineEnvironmentVariableListResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [RagPipelineEnvironmentVariableResponse](#ragpipelineenvironmentvariableresponse) ] |  | Yes |
-
-#### RagPipelineEnvironmentVariableResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| description | string |  | Yes |
-| editable | boolean |  | Yes |
-| edited | boolean |  | Yes |
-| id | string |  | Yes |
-| name | string |  | Yes |
-| selector | [ string ] |  | Yes |
-| type | string |  | Yes |
-| value |  |  | Yes |
-| value_type | string |  | Yes |
-| visible | boolean |  | Yes |
-
 #### RagPipelineImportCheckDependenciesResponse
 
 | Name | Type | Description | Required |
@@ -20277,28 +20299,19 @@ Whitelist scopes accepted by RBAC app and dataset access config APIs.
 | pipeline_id | string |  | No |
 | status | [ImportStatus](#importstatus) |  | Yes |
 
+#### RagPipelineOpaqueResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| RagPipelineOpaqueResponse |  |  |  |
+
 #### RagPipelineRecommendedPluginQuery
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | type | string, <br>**Default:** all |  | No |
 
-#### RagPipelineRecommendedPluginResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| installed_recommended_plugins | [ object ] | Installed tool provider payloads. Shape follows the tool provider serializer. | Yes |
-| uninstalled_recommended_plugins | [ object ] | Marketplace plugin manifest payloads returned by the marketplace service. | Yes |
-
-#### RagPipelineTransformResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| dataset_id | string |  | Yes |
-| pipeline_id | string |  | Yes |
-| status | string |  | Yes |
-
-#### RagPipelineVariablesResponse
+#### RagPipelineStepParametersResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
@@ -21276,9 +21289,9 @@ The subscription constructor of the trigger provider
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| hash | string |  | Yes |
-| result | string |  | Yes |
-| updated_at | integer |  | Yes |
+| hash | string |  | No |
+| result | string |  | No |
+| updated_at | string |  | No |
 
 #### SystemConfigurationResponse
 
@@ -21539,17 +21552,46 @@ Available voices
 | ---- | ---- | ----------- | -------- |
 | data | [ [TokensPerSecondStatisticItem](#tokenspersecondstatisticitem) ] |  | Yes |
 
-#### ToolLabelEnum
+#### ToolApiEntity
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| ToolLabelEnum | string |  |  |
+| author | string |  | Yes |
+| description | [I18nObject](#i18nobject) |  | Yes |
+| label | [I18nObject](#i18nobject) |  | Yes |
+| labels | [ string ] |  | No |
+| name | string |  | Yes |
+| output_schema | object |  | No |
+| parameters | [ [ToolParameter](#toolparameter) ] |  | No |
 
-#### ToolOAuthClientSchemaResponse
+#### ToolApiListResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| ToolOAuthClientSchemaResponse | array |  |  |
+| ToolApiListResponse | array |  |  |
+
+#### ToolEmojiIcon
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| background | string |  | Yes |
+| content | string |  | Yes |
+
+#### ToolLabel
+
+Tool label
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| icon | string | The icon of the tool | Yes |
+| label | [I18nObject](#i18nobject) | The label of the tool | Yes |
+| name | string | The name of the tool | Yes |
+
+#### ToolLabelListResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| ToolLabelListResponse | array |  |  |
 
 #### ToolOAuthCustomClientPayload
 
@@ -21558,11 +21600,29 @@ Available voices
 | client_params | object |  | No |
 | enable_oauth_custom_client | boolean |  | No |
 
-#### ToolOAuthCustomClientResponse
+#### ToolParameter
+
+Overrides type
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| ToolOAuthCustomClientResponse | object |  |  |
+| auto_generate | [PluginParameterAutoGenerate](#pluginparameterautogenerate) |  | No |
+| default | number<br>integer<br>string<br>boolean<br>[ object ]<br>object |  | No |
+| form | [ToolParameterForm](#toolparameterform) | The form of the parameter, schema/form/llm | Yes |
+| human_description | [I18nObject](#i18nobject) | The description presented to the user | No |
+| input_schema | object |  | No |
+| label | [I18nObject](#i18nobject) | The label presented to the user | Yes |
+| llm_description | string |  | No |
+| max | number<br>integer |  | No |
+| min | number<br>integer |  | No |
+| name | string | The name of the parameter | Yes |
+| options | [ [PluginParameterOption](#pluginparameteroption) ] |  | No |
+| placeholder | [I18nObject](#i18nobject) | The placeholder presented to the user | No |
+| precision | integer |  | No |
+| required | boolean |  | No |
+| scope | string |  | No |
+| template | [PluginParameterTemplate](#pluginparametertemplate) |  | No |
+| type | [ToolParameterType](#toolparametertype) | The type of the parameter | Yes |
 
 #### ToolParameterForm
 
@@ -21570,17 +21630,84 @@ Available voices
 | ---- | ---- | ----------- | -------- |
 | ToolParameterForm | string |  |  |
 
+#### ToolParameterType
+
+removes TOOLS_SELECTOR from PluginParameterType
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| ToolParameterType | string | removes TOOLS_SELECTOR from PluginParameterType |  |
+
+#### ToolProviderApiEntityResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| allow_delete | boolean, <br>**Default:** true |  | No |
+| authentication | [MCPAuthentication](#mcpauthentication) | The OAuth config of the MCP tool | No |
+| author | string |  | Yes |
+| configuration | [MCPConfiguration](#mcpconfiguration) | The timeout and sse_read_timeout of the MCP tool | No |
+| description | [I18nObject](#i18nobject) |  | Yes |
+| icon | string<br>object |  | Yes |
+| icon_dark | string<br>object |  | No |
+| id | string |  | Yes |
+| identity_mode | string, <br>**Default:** off | Identity-forwarding mechanism: 'off' or 'idp_token' | No |
+| is_dynamic_registration | boolean, <br>**Default:** true | Whether the MCP tool is dynamically registered | No |
+| is_team_authorization | boolean |  | No |
+| label | [I18nObject](#i18nobject) |  | Yes |
+| labels | [ string ] |  | No |
+| masked_headers | object | The masked headers of the MCP tool | No |
+| name | string |  | Yes |
+| original_headers | object | The original headers of the MCP tool | No |
+| plugin_id | string | The plugin id of the tool | No |
+| plugin_unique_identifier | string | The unique identifier of the tool | No |
+| server_identifier | string | The server identifier of the MCP tool | No |
+| server_url | string | The server url of the tool | No |
+| team_credentials | object |  | No |
+| tools | [ [ToolApiEntity](#toolapientity) ] |  | No |
+| type | [ToolProviderType](#toolprovidertype) |  | Yes |
+| updated_at | integer |  | No |
+| workflow_app_id | string | The app id of the workflow tool | No |
+
+#### ToolProviderCredentialApiEntity
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| created_by | string | User ID of the credential creator | No |
+| credential_type | [CredentialType](#credentialtype) | The type of the credential | Yes |
+| credentials | object | The credentials of the provider | No |
+| from_other_member | boolean | True when this credential is being returned only because a workflow/agent node still references it but it would normally be hidden from this user by the visibility filter (another member's only_me credential). The frontend renders it as 'borrowed' — selectable until the node switches away, but not editable/deletable. | No |
+| id | string | The unique id of the credential | Yes |
+| is_default | boolean | Whether the credential is the default credential for the provider in the workspace | No |
+| name | string | The name of the credential | Yes |
+| partial_member_list | [ string ] | List of user IDs allowed when visibility is partial_members | No |
+| provider | string | The provider of the credential | Yes |
+| visibility | string, <br>**Default:** all_team_members | Credential visibility: only_me, all_team_members, or partial_members | No |
+
+#### ToolProviderCredentialInfoApiEntity
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| credentials | [ [ToolProviderCredentialApiEntity](#toolprovidercredentialapientity) ] | The credentials of the provider | Yes |
+| is_oauth_custom_client_enabled | boolean | Whether the OAuth custom client is enabled for the provider | No |
+| supported_credential_types | [ [CredentialType](#credentialtype) ] | The supported credential types of the provider | Yes |
+
+#### ToolProviderCredentialListResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| ToolProviderCredentialListResponse | array |  |  |
+
 #### ToolProviderListQuery
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | type | string |  | No |
 
-#### ToolProviderOpaqueResponse
+#### ToolProviderListResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| ToolProviderOpaqueResponse |  |  |  |
+| ToolProviderListResponse | array |  |  |
 
 #### ToolProviderType
 
@@ -21839,20 +21966,6 @@ Enum class for tool provider
 | ---- | ---- | ----------- | -------- |
 | TriggerCreationMethod | string |  |  |
 
-#### TriggerDebugErrorResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| error | string |  | No |
-| status | string |  | Yes |
-
-#### TriggerDebugWaitingResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| retry_in | integer |  | Yes |
-| status | string |  | Yes |
-
 #### TriggerOAuthAuthorizeResponse
 
 | Name | Type | Description | Required |
@@ -21875,7 +21988,7 @@ Enum class for tool provider
 | configured | boolean |  | Yes |
 | custom_configured | boolean |  | Yes |
 | custom_enabled | boolean |  | Yes |
-| oauth_client_schema | [ [TriggerProviderConfigResponse](#triggerproviderconfigresponse) ] |  | Yes |
+| oauth_client_schema | [ [ProviderConfig](#providerconfig) ] |  | Yes |
 | params | object |  | Yes |
 | redirect_uri | string |  | Yes |
 | system_configured | boolean |  | Yes |
@@ -21898,40 +22011,17 @@ Enum class for tool provider
 | supported_creation_methods | [ [TriggerCreationMethod](#triggercreationmethod) ] | Supported creation methods for the trigger provider. like 'OAUTH', 'APIKEY', 'MANUAL'. | No |
 | tags | [ string ] | The tags of the trigger provider | No |
 
-#### TriggerProviderConfigOptionResponse
+#### TriggerProviderErrorResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| label | [I18nObject](#i18nobject) | The label of the option | Yes |
-| value | string | The value of the option | Yes |
-
-#### TriggerProviderConfigResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| default | integer<br>string<br>number<br>boolean |  | No |
-| help | [I18nObject](#i18nobject) |  | No |
-| label | [I18nObject](#i18nobject) |  | No |
-| multiple | boolean |  | No |
-| name | string | The name of the credentials | Yes |
-| options | [ [TriggerProviderConfigOptionResponse](#triggerproviderconfigoptionresponse) ] |  | No |
-| placeholder | [I18nObject](#i18nobject) |  | No |
-| required | boolean |  | No |
-| scope | [AppSelectorScope](#appselectorscope)<br>[ModelSelectorScope](#modelselectorscope)<br>[ToolSelectorScope](#toolselectorscope) |  | No |
-| type | string, <br>**Available values:** "app-selector", "array[tools]", "boolean", "model-selector", "secret-input", "select", "text-input" | The type of the credentials<br>*Enum:* `"app-selector"`, `"array[tools]"`, `"boolean"`, `"model-selector"`, `"secret-input"`, `"select"`, `"text-input"` | Yes |
-| url | string |  | No |
+| error | string |  | Yes |
 
 #### TriggerProviderListResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | TriggerProviderListResponse | array |  |  |
-
-#### TriggerProviderOpaqueResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| TriggerProviderOpaqueResponse |  |  |  |
 
 #### TriggerProviderSubscriptionApiEntity
 
@@ -21946,6 +22036,12 @@ Enum class for tool provider
 | properties | object | The properties of the subscription | Yes |
 | provider | string | The provider id of the subscription | Yes |
 | workflows_in_use | integer | The number of workflows using this subscription | Yes |
+
+#### TriggerProviderSubscriptionListResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| TriggerProviderSubscriptionListResponse | array |  |  |
 
 #### TriggerSubscriptionBuilderCreatePayload
 
@@ -21980,17 +22076,11 @@ Enum class for tool provider
 | ---- | ---- | ----------- | -------- |
 | credentials | object |  | Yes |
 
-#### TriggerSubscriptionBuilderVerifyResponse
+#### TriggerVerificationResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | verified | boolean |  | Yes |
-
-#### TriggerSubscriptionListResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| TriggerSubscriptionListResponse | array |  |  |
 
 #### UnaddedModelConfiguration
 
@@ -22504,35 +22594,46 @@ How a workflow node is bound to an Agent.
 | ---- | ---- | ----------- | -------- |
 | data | [ [WorkflowDailyTokenCostStatisticItem](#workflowdailytokencoststatisticitem) ] |  | Yes |
 
-#### WorkflowDraftEnvironmentVariableListResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [WorkflowDraftEnvironmentVariableResponse](#workflowdraftenvironmentvariableresponse) ] |  | Yes |
-
-#### WorkflowDraftEnvironmentVariableResponse
+#### WorkflowDraftEnvVariable
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | description | string |  | No |
-| editable | boolean |  | Yes |
-| edited | boolean |  | Yes |
-| id | string |  | Yes |
-| name | string |  | Yes |
-| selector | [ string ] |  | Yes |
-| type | string |  | Yes |
-| value |  |  | Yes |
-| value_type | string |  | Yes |
-| visible | boolean |  | Yes |
+| edited | boolean |  | No |
+| id | string |  | No |
+| name | string |  | No |
+| selector | [ string ] |  | No |
+| type | string |  | No |
+| value_type | string |  | No |
+| visible | boolean |  | No |
 
-#### WorkflowDraftVariableFullContentResponse
+#### WorkflowDraftEnvVariableList
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| download_url | string |  | Yes |
-| length | integer |  | Yes |
-| size_bytes | integer |  | Yes |
-| value_type | string |  | Yes |
+| items | [ [WorkflowDraftEnvVariable](#workflowdraftenvvariable) ] |  | No |
+
+#### WorkflowDraftVariable
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| description | string |  | No |
+| edited | boolean |  | No |
+| full_content | object |  | No |
+| id | string |  | No |
+| is_truncated | boolean |  | No |
+| name | string |  | No |
+| selector | [ string ] |  | No |
+| type | string |  | No |
+| value | string<br>integer<br>number<br>boolean<br>object<br>[ object ] |  | No |
+| value_type | string |  | No |
+| visible | boolean |  | No |
+
+#### WorkflowDraftVariableList
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| items | [ [WorkflowDraftVariable](#workflowdraftvariable) ] |  | No |
 
 #### WorkflowDraftVariableListQuery
 
@@ -22541,41 +22642,19 @@ How a workflow node is bound to an Agent.
 | limit | integer, <br>**Default:** 20 | Items per page | No |
 | page | integer, <br>**Default:** 1 | Page number | No |
 
-#### WorkflowDraftVariableListResponse
+#### WorkflowDraftVariableListWithoutValue
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| items | [ [WorkflowDraftVariableResponse](#workflowdraftvariableresponse) ] |  | Yes |
-
-#### WorkflowDraftVariableListWithoutValueResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [WorkflowDraftVariableWithoutValueResponse](#workflowdraftvariablewithoutvalueresponse) ] |  | Yes |
-| total | integer |  | Yes |
+| items | [ [WorkflowDraftVariableWithoutValue](#workflowdraftvariablewithoutvalue) ] |  | No |
+| total | integer |  | No |
 
 #### WorkflowDraftVariablePatchPayload
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| name | string | Variable name | No |
+| name | string |  | No |
 | value |  |  | No |
-
-#### WorkflowDraftVariableResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| description | string |  | Yes |
-| edited | boolean |  | Yes |
-| full_content | [WorkflowDraftVariableFullContentResponse](#workflowdraftvariablefullcontentresponse) |  | Yes |
-| id | string |  | Yes |
-| is_truncated | boolean |  | Yes |
-| name | string |  | Yes |
-| selector | [ string ] |  | Yes |
-| type | string |  | Yes |
-| value |  |  | Yes |
-| value_type | string |  | Yes |
-| visible | boolean |  | Yes |
 
 #### WorkflowDraftVariableUpdatePayload
 
@@ -22584,19 +22663,19 @@ How a workflow node is bound to an Agent.
 | name | string | Variable name | No |
 | value |  | Variable value | No |
 
-#### WorkflowDraftVariableWithoutValueResponse
+#### WorkflowDraftVariableWithoutValue
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| description | string |  | Yes |
-| edited | boolean |  | Yes |
-| id | string |  | Yes |
-| is_truncated | boolean |  | Yes |
-| name | string |  | Yes |
-| selector | [ string ] |  | Yes |
-| type | string |  | Yes |
-| value_type | string |  | Yes |
-| visible | boolean |  | Yes |
+| description | string |  | No |
+| edited | boolean |  | No |
+| id | string |  | No |
+| is_truncated | boolean |  | No |
+| name | string |  | No |
+| selector | [ string ] |  | No |
+| type | string |  | No |
+| value_type | string |  | No |
+| visible | boolean |  | No |
 
 #### WorkflowEnvironmentVariableResponse
 
@@ -22810,6 +22889,13 @@ tenant's default model. The underlying generator never raises — an empty
 | variable | string |  | No |
 | variable_selector | [ string<br>integer<br>number<br>boolean ] |  | No |
 
+#### WorkflowPublishResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| created_at | integer |  | Yes |
+| result | string |  | Yes |
+
 #### WorkflowResponse
 
 | Name | Type | Description | Required |
@@ -22829,6 +22915,14 @@ tenant's default model. The underlying generator never raises — an empty
 | updated_at | integer |  | Yes |
 | updated_by | [SimpleAccountResponse](#simpleaccountresponse) |  | No |
 | version | string |  | Yes |
+
+#### WorkflowRestoreResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| hash | string |  | Yes |
+| result | string |  | Yes |
+| updated_at | integer |  | Yes |
 
 #### WorkflowRunCountQuery
 
@@ -23038,7 +23132,7 @@ Query parameters for workflow runs.
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | description | string |  | Yes |
-| icon | object |  | Yes |
+| icon | [ToolEmojiIcon](#toolemojiicon) |  | Yes |
 | label | string |  | Yes |
 | labels | [ string ] |  | No |
 | name | string |  | Yes |
@@ -23050,6 +23144,22 @@ Query parameters for workflow runs.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
+| workflow_tool_id | string |  | Yes |
+
+#### WorkflowToolDetailResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| description | string |  | Yes |
+| icon | [ToolEmojiIcon](#toolemojiicon) |  | Yes |
+| label | string |  | Yes |
+| name | string |  | Yes |
+| output_schema | object |  | No |
+| parameters | [ [WorkflowToolParameterConfiguration](#workflowtoolparameterconfiguration) ] |  | Yes |
+| privacy_policy | string |  | No |
+| synced | boolean |  | Yes |
+| tool | [ToolApiEntity](#toolapientity) |  | Yes |
+| workflow_app_id | string |  | Yes |
 | workflow_tool_id | string |  | Yes |
 
 #### WorkflowToolGetQuery
@@ -23080,7 +23190,7 @@ Workflow tool configuration
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | description | string |  | Yes |
-| icon | object |  | Yes |
+| icon | [ToolEmojiIcon](#toolemojiicon) |  | Yes |
 | label | string |  | Yes |
 | labels | [ string ] |  | No |
 | name | string |  | Yes |

--- a/api/services/tools/api_tools_manage_service.py
+++ b/api/services/tools/api_tools_manage_service.py
@@ -1,8 +1,9 @@
 import json
 import logging
-from typing import Any, TypedDict, cast
+from typing import Any, Literal, TypedDict, cast
 
 from httpx import get
+from pydantic import TypeAdapter
 from sqlalchemy import select
 from sqlalchemy.orm import sessionmaker
 
@@ -22,7 +23,6 @@ from core.tools.tool_manager import ToolManager
 from core.tools.utils.encryption import create_tool_provider_encrypter
 from core.tools.utils.parser import ApiBasedToolSchemaParser
 from extensions.ext_database import db
-from graphon.model_runtime.utils.encoders import jsonable_encoder
 from models.tools import ApiToolProvider
 from services.tools.tools_transform_service import ToolTransformService
 
@@ -34,6 +34,27 @@ class ApiSchemaParseResult(TypedDict):
     parameters_schema: list[dict[str, Any]]
     credentials_schema: list[dict[str, Any]]
     warning: dict[str, str]
+
+
+class ApiToolPreviewResult(TypedDict, total=False):
+    result: str
+    error: str
+
+
+class RemoteSchemaResult(TypedDict):
+    schema: str
+
+
+class SimpleSuccessResult(TypedDict):
+    result: Literal["success"]
+
+
+def _dump_api_tool_bundles(tool_bundles: list[ApiToolBundle]) -> list[dict[str, Any]]:
+    return cast(list[dict[str, Any]], TypeAdapter(list[ApiToolBundle]).dump_python(tool_bundles, mode="json"))
+
+
+def _dump_provider_configs(configs: list[ProviderConfig]) -> list[dict[str, Any]]:
+    return cast(list[dict[str, Any]], TypeAdapter(list[ProviderConfig]).dump_python(configs, mode="json"))
 
 
 class ApiToolManageService:
@@ -80,14 +101,12 @@ class ApiToolManageService:
 
             return cast(
                 ApiSchemaParseResult,
-                jsonable_encoder(
-                    {
-                        "schema_type": schema_type,
-                        "parameters_schema": tool_bundles,
-                        "credentials_schema": credentials_schema,
-                        "warning": warnings,
-                    }
-                ),
+                {
+                    "schema_type": schema_type.value,
+                    "parameters_schema": _dump_api_tool_bundles(tool_bundles),
+                    "credentials_schema": _dump_provider_configs(credentials_schema),
+                    "warning": warnings,
+                },
             )
         except Exception as e:
             raise ValueError(f"invalid schema: {str(e)}")
@@ -118,7 +137,7 @@ class ApiToolManageService:
         privacy_policy: str,
         custom_disclaimer: str,
         labels: list[str],
-    ) -> dict[str, Any]:
+    ) -> SimpleSuccessResult:
         """
         Create a new API tool provider.
 
@@ -169,7 +188,7 @@ class ApiToolManageService:
                 schema=schema,
                 description=extra_info.get("description", ""),
                 schema_type_str=schema_type,
-                tools_str=json.dumps(jsonable_encoder(tool_bundles)),
+                tools_str=json.dumps(_dump_api_tool_bundles(tool_bundles)),
                 credentials_str="{}",
                 privacy_policy=privacy_policy,
                 custom_disclaimer=custom_disclaimer,
@@ -201,7 +220,7 @@ class ApiToolManageService:
         return {"result": "success"}
 
     @staticmethod
-    def get_api_tool_provider_remote_schema(user_id: str, tenant_id: str, url: str):
+    def get_api_tool_provider_remote_schema(user_id: str, tenant_id: str, url: str) -> RemoteSchemaResult:
         """
         get api tool provider remote schema
         """
@@ -276,7 +295,7 @@ class ApiToolManageService:
         privacy_policy: str | None,
         custom_disclaimer: str,
         labels: list[str],
-    ) -> dict[str, Any]:
+    ) -> SimpleSuccessResult:
         """
         Update an existing API tool provider.
 
@@ -322,7 +341,7 @@ class ApiToolManageService:
             provider.schema = schema
             provider.description = extra_info.get("description", "")
             provider.schema_type_str = schema_type
-            provider.tools_str = json.dumps(jsonable_encoder(tool_bundles))
+            provider.tools_str = json.dumps(_dump_api_tool_bundles(tool_bundles))
             provider.privacy_policy = privacy_policy
             provider.custom_disclaimer = custom_disclaimer
 
@@ -365,7 +384,7 @@ class ApiToolManageService:
         return {"result": "success"}
 
     @staticmethod
-    def delete_api_tool_provider(user_id: str, tenant_id: str, provider_name: str):
+    def delete_api_tool_provider(user_id: str, tenant_id: str, provider_name: str) -> SimpleSuccessResult:
         """
         Delete an API tool provider.
 
@@ -413,9 +432,9 @@ class ApiToolManageService:
         tool_name: str,
         credentials: dict[str, Any],
         parameters: dict[str, Any],
-        schema_type: ApiProviderSchemaType,
+        schema_type: ApiProviderSchemaType | str,
         schema: str,
-    ) -> dict[str, Any]:
+    ) -> ApiToolPreviewResult:
         """
         Test an API tool before adding the API tool provider.
 
@@ -464,7 +483,7 @@ class ApiToolManageService:
                 schema=schema,
                 description="",
                 schema_type_str=ApiProviderSchemaType.OPENAPI,
-                tools_str=json.dumps(jsonable_encoder(tool_bundles)),
+                tools_str=json.dumps(_dump_api_tool_bundles(tool_bundles)),
                 credentials_str=json.dumps(credentials),
             )
 

--- a/api/tests/test_containers_integration_tests/controllers/console/workspace/test_tool_provider.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/workspace/test_tool_provider.py
@@ -44,6 +44,7 @@ from controllers.console.workspace.tool_providers import (
     ToolWorkflowProviderUpdateApi,
     is_valid_url,
 )
+from core.tools.entities.api_entities import ToolProviderApiEntity as CoreToolProviderApiEntity
 from models.account import Account, TenantAccountRole
 from services.tools.mcp_tools_manage_service import ReconnectResult
 from tests.test_containers_integration_tests.controllers.console.helpers import (
@@ -58,6 +59,148 @@ def empty_mapping() -> dict[str, object]:
 
 def empty_list() -> list[object]:
     return []
+
+
+def emoji_icon() -> dict[str, str]:
+    return {"content": "tool", "background": "#252525"}
+
+
+def i18n(text: str) -> dict[str, str]:
+    return {"en_US": text}
+
+
+def tool_payload(name: str = "ping") -> dict[str, object]:
+    return {
+        "author": "langgenius",
+        "name": name,
+        "label": i18n(name.title()),
+        "description": i18n(f"{name} description"),
+        "parameters": [],
+        "labels": ["utilities"],
+        "output_schema": {},
+    }
+
+
+def provider_payload(
+    *,
+    provider_id: str = "provider-1",
+    name: str = "provider",
+    provider_type: str = "builtin",
+    tools: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    return {
+        "id": provider_id,
+        "author": "langgenius",
+        "name": name,
+        "description": i18n(f"{name} description"),
+        "icon": emoji_icon(),
+        "icon_dark": emoji_icon(),
+        "label": i18n(name.title()),
+        "type": provider_type,
+        "masked_credentials": {"api_key": "[__HIDDEN__]"},
+        "original_credentials": {"api_key": "sk-secret"},
+        "is_team_authorization": False,
+        "allow_delete": True,
+        "plugin_id": "langgenius/provider",
+        "plugin_unique_identifier": "langgenius/provider:1.0.0",
+        "tools": tools or [tool_payload()],
+        "labels": ["utilities"],
+        "server_url": "",
+        "updated_at": 1710000000,
+        "server_identifier": "",
+        "masked_headers": None,
+        "original_headers": None,
+        "authentication": None,
+        "is_dynamic_registration": True,
+        "configuration": None,
+        "identity_mode": "off",
+        "workflow_app_id": None,
+    }
+
+
+def provider_entity(
+    *,
+    provider_id: str = "provider-1",
+    name: str = "provider",
+    provider_type: str = "builtin",
+    tools: list[dict[str, object]] | None = None,
+) -> CoreToolProviderApiEntity:
+    return CoreToolProviderApiEntity.model_validate(
+        provider_payload(provider_id=provider_id, name=name, provider_type=provider_type, tools=tools)
+    )
+
+
+def credential_payload() -> dict[str, object]:
+    return {
+        "id": "credential-1",
+        "name": "Default credential",
+        "provider": "provider",
+        "credential_type": "api-key",
+        "is_default": True,
+        "credentials": {"api_key": "masked"},
+        "visibility": "all_team_members",
+        "created_by": "user-1",
+        "partial_member_list": [],
+        "from_other_member": False,
+    }
+
+
+def provider_config_payload() -> dict[str, object]:
+    return {"type": "secret-input", "name": "api_key", "required": True}
+
+
+def api_tool_bundle_payload() -> dict[str, object]:
+    return {
+        "server_url": "https://api.example.com",
+        "method": "get",
+        "summary": "Ping",
+        "operation_id": "ping",
+        "parameters": [],
+        "author": "langgenius",
+        "icon": None,
+        "openapi": {"operationId": "ping"},
+        "output_schema": {},
+    }
+
+
+def api_provider_detail_payload() -> dict[str, object]:
+    return {
+        "schema_type": "openapi",
+        "schema": "{}",
+        "tools": [api_tool_bundle_payload()],
+        "icon": emoji_icon(),
+        "description": "API provider",
+        "credentials": {},
+        "privacy_policy": "",
+        "custom_disclaimer": "",
+        "labels": ["utilities"],
+    }
+
+
+def credential_info_payload() -> dict[str, object]:
+    return {
+        "supported_credential_types": ["api-key", "oauth2"],
+        "is_oauth_custom_client_enabled": False,
+        "credentials": [credential_payload()],
+    }
+
+
+def oauth_client_schema_payload() -> dict[str, object]:
+    return {
+        "schema": [provider_config_payload()],
+        "is_oauth_custom_client_enabled": False,
+        "is_system_oauth_params_exists": True,
+        "client_params": {"client_id": "masked"},
+        "redirect_uri": "https://console.example.com/oauth/callback",
+    }
+
+
+def tool_label_payload() -> dict[str, object]:
+    return {
+        "name": "utilities",
+        "label": i18n("Utilities"),
+        "icon": "wrench",
+    }
 
 
 @pytest.fixture
@@ -127,7 +270,7 @@ def test_create_mcp_provider_populates_tools(
         with (
             patch(
                 "services.tools.tools_transform_service.ToolTransformService.mcp_provider_to_user_provider",
-                return_value={"id": "provider-1", "tools": [{"name": "ping"}]},
+                return_value=provider_entity(provider_id="provider-1", provider_type="mcp", tools=[tool_payload()]),
                 autospec=True,
             ),
         ):
@@ -138,13 +281,15 @@ def test_create_mcp_provider_populates_tools(
                 content_type="application/json",
             )
 
-    # Assert
-    assert resp.status_code == 200
-    body = resp.get_json()
-    assert body.get("id") == "provider-1"
-    # 若 transform 后包含 tools 字段，确保非空
-    assert isinstance(body.get("tools"), list)
-    assert body["tools"]
+        # Assert
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body.get("id") == "provider-1"
+        assert body["team_credentials"] == {"api_key": "[__HIDDEN__]"}
+        assert "masked_credentials" not in body
+        assert "original_credentials" not in body
+        assert isinstance(body.get("tools"), list)
+        assert body["tools"]
 
 
 class TestUtils:
@@ -170,10 +315,16 @@ class TestToolProviderListApi:
             app.test_request_context("/"),
             patch(
                 "controllers.console.workspace.tool_providers.ToolCommonService.list_tool_providers",
-                return_value=["p1"],
+                return_value=[provider_entity(provider_id="p1").to_dict()],
             ),
         ):
-            assert method(api, "t1", make_account(id="u1")) == ["p1"]
+            result = method(api, "t1", make_account(id="u1"))
+
+        assert result[0]["id"] == "p1"
+        assert result[0]["team_credentials"] == {"api_key": "[__HIDDEN__]"}
+        assert "masked_credentials" not in result[0]
+        assert "original_credentials" not in result[0]
+        assert result[0]["tools"][0]["name"] == "ping"
 
 
 class TestBuiltinProviderApis:
@@ -189,10 +340,10 @@ class TestBuiltinProviderApis:
             app.test_request_context("/"),
             patch(
                 "controllers.console.workspace.tool_providers.BuiltinToolManageService.list_builtin_tool_provider_tools",
-                return_value=[{"a": 1}],
+                return_value=[tool_payload()],
             ),
         ):
-            assert method(api, "t1", "provider") == [{"a": 1}]
+            assert method(api, "t1", "provider")[0]["name"] == "ping"
 
     def test_info(self, app: Flask) -> None:
         api = ToolBuiltinProviderInfoApi()
@@ -202,10 +353,15 @@ class TestBuiltinProviderApis:
             app.test_request_context("/"),
             patch(
                 "controllers.console.workspace.tool_providers.BuiltinToolManageService.get_builtin_tool_provider_info",
-                return_value={"x": 1},
+                return_value=provider_entity(),
             ),
         ):
-            assert method(api, "t1", "provider") == {"x": 1}
+            result = method(api, "t1", "provider")
+
+        assert result["id"] == "provider-1"
+        assert result["team_credentials"] == {"api_key": "[__HIDDEN__]"}
+        assert "masked_credentials" not in result
+        assert "original_credentials" not in result
 
     def test_delete(self, app: Flask) -> None:
         api = ToolBuiltinProviderDeleteApi()
@@ -240,10 +396,10 @@ class TestBuiltinProviderApis:
             app.test_request_context("/", json=payload),
             patch(
                 "controllers.console.workspace.tool_providers.BuiltinToolManageService.add_builtin_tool_provider",
-                return_value={"id": 1},
+                return_value={"result": "success"},
             ),
         ):
-            assert method(api, "t", make_account(), "provider")["id"] == 1
+            assert method(api, "t", make_account(), "provider")["result"] == "success"
 
     def test_update(self, app: Flask) -> None:
         api = ToolBuiltinProviderUpdateApi()
@@ -255,10 +411,10 @@ class TestBuiltinProviderApis:
             app.test_request_context("/", json=payload),
             patch(
                 "controllers.console.workspace.tool_providers.BuiltinToolManageService.update_builtin_tool_provider",
-                return_value={"ok": True},
+                return_value={"result": "success"},
             ),
         ):
-            assert method(api, "t", make_account(), "provider")["ok"]
+            assert method(api, "t", make_account(), "provider")["result"] == "success"
 
     def test_get_credentials(self, app: Flask) -> None:
         api = ToolBuiltinProviderGetCredentialsApi()
@@ -268,10 +424,10 @@ class TestBuiltinProviderApis:
             app.test_request_context("/"),
             patch(
                 "controllers.console.workspace.tool_providers.BuiltinToolManageService.get_builtin_tool_provider_credentials",
-                return_value={"k": "v"},
+                return_value=[credential_payload()],
             ),
         ):
-            assert method(api, "t", make_account(id="user-1"), "provider") == {"k": "v"}
+            assert method(api, "t", make_account(id="user-1"), "provider")[0]["id"] == "credential-1"
 
     def test_icon(self, app: Flask) -> None:
         api = ToolBuiltinProviderIconApi()
@@ -295,10 +451,10 @@ class TestBuiltinProviderApis:
             app.test_request_context("/"),
             patch(
                 "controllers.console.workspace.tool_providers.BuiltinToolManageService.list_builtin_provider_credentials_schema",
-                return_value={"schema": {}},
+                return_value=[provider_config_payload()],
             ),
         ):
-            assert method(api, "t", "provider", "oauth2") == {"schema": {}}
+            assert method(api, "t", "provider", "oauth2")[0]["name"] == "api_key"
 
     def test_set_default_credential(self, app: Flask) -> None:
         api = ToolBuiltinProviderSetDefaultApi()
@@ -308,10 +464,10 @@ class TestBuiltinProviderApis:
             app.test_request_context("/", json={"id": "c1"}),
             patch(
                 "controllers.console.workspace.tool_providers.BuiltinToolManageService.set_default_provider",
-                return_value={"ok": True},
+                return_value={"result": "success"},
             ),
         ):
-            assert method(api, "t", "provider")["ok"]
+            assert method(api, "t", "provider")["result"] == "success"
 
     def test_get_credential_info(self, app: Flask) -> None:
         api = ToolBuiltinProviderGetCredentialInfoApi()
@@ -321,10 +477,10 @@ class TestBuiltinProviderApis:
             app.test_request_context("/"),
             patch(
                 "controllers.console.workspace.tool_providers.BuiltinToolManageService.get_builtin_tool_provider_credential_info",
-                return_value={"info": "x"},
+                return_value=credential_info_payload(),
             ),
         ):
-            assert method(api, "t", make_account(), "provider") == {"info": "x"}
+            assert method(api, "t", make_account(), "provider")["credentials"][0]["id"] == "credential-1"
 
     def test_get_oauth_client_schema(self, app: Flask) -> None:
         api = ToolBuiltinProviderGetOauthClientSchemaApi()
@@ -334,10 +490,10 @@ class TestBuiltinProviderApis:
             app.test_request_context("/"),
             patch(
                 "controllers.console.workspace.tool_providers.BuiltinToolManageService.get_builtin_tool_provider_oauth_client_schema",
-                return_value={"schema": {}},
+                return_value=oauth_client_schema_payload(),
             ),
         ):
-            assert method(api, "t", "provider") == {"schema": {}}
+            assert method(api, "t", "provider")["schema"][0]["name"] == "api_key"
 
 
 class TestApiProviderApis:
@@ -354,30 +510,34 @@ class TestApiProviderApis:
             "schema_type": "openapi",
             "schema": "{}",
             "provider": "p",
-            "icon": empty_mapping(),
+            "icon": emoji_icon(),
         }
 
         with (
             app.test_request_context("/", json=payload),
             patch(
                 "controllers.console.workspace.tool_providers.ApiToolManageService.create_api_tool_provider",
-                return_value={"id": 1},
-            ),
+                return_value={"result": "success"},
+            ) as create_api_tool_provider,
         ):
-            assert method(api, "t", make_account())["id"] == 1
+            assert method(api, "t", make_account()) == {"result": "success"}
+
+        create_api_tool_provider.assert_called_once()
+        assert create_api_tool_provider.call_args.args[3] == emoji_icon()
 
     def test_remote_schema(self, app: Flask) -> None:
         api = ToolApiProviderGetRemoteSchemaApi()
         method = unwrap(api.get)
+        openapi_schema = '{"openapi":"3.0.0","info":{"title":"Demo API","version":"1.0.0"},"paths":{}}'
 
         with (
             app.test_request_context("/?url=http://x.com"),
             patch(
                 "controllers.console.workspace.tool_providers.ApiToolManageService.get_api_tool_provider_remote_schema",
-                return_value={"schema": "x"},
+                return_value={"schema": openapi_schema},
             ),
         ):
-            assert method(api, "t", make_account())["schema"] == "x"
+            assert method(api, "t", make_account()) == {"schema": openapi_schema}
 
     def test_list_tools(self, app: Flask) -> None:
         api = ToolApiProviderListToolsApi()
@@ -387,10 +547,10 @@ class TestApiProviderApis:
             app.test_request_context("/?provider=p"),
             patch(
                 "controllers.console.workspace.tool_providers.ApiToolManageService.list_api_tool_provider_tools",
-                return_value=[{"tool": 1}],
+                return_value=[tool_payload("api_ping")],
             ),
         ):
-            assert method(api, "t", make_account()) == [{"tool": 1}]
+            assert method(api, "t", make_account())[0]["name"] == "api_ping"
 
     def test_update(self, app: Flask) -> None:
         api = ToolApiProviderUpdateApi()
@@ -402,7 +562,7 @@ class TestApiProviderApis:
             "schema": "{}",
             "provider": "p",
             "original_provider": "o",
-            "icon": empty_mapping(),
+            "icon": emoji_icon(),
             "privacy_policy": "",
             "custom_disclaimer": "",
         }
@@ -411,10 +571,13 @@ class TestApiProviderApis:
             app.test_request_context("/", json=payload),
             patch(
                 "controllers.console.workspace.tool_providers.ApiToolManageService.update_api_tool_provider",
-                return_value={"ok": True},
-            ),
+                return_value={"result": "success"},
+            ) as update_api_tool_provider,
         ):
-            assert method(api, "t", make_account())["ok"]
+            assert method(api, "t", make_account()) == {"result": "success"}
+
+        update_api_tool_provider.assert_called_once()
+        assert update_api_tool_provider.call_args.args[4] == emoji_icon()
 
     def test_delete(self, app: Flask) -> None:
         api = ToolApiProviderDeleteApi()
@@ -437,10 +600,10 @@ class TestApiProviderApis:
             app.test_request_context("/?provider=p"),
             patch(
                 "controllers.console.workspace.tool_providers.ApiToolManageService.get_api_tool_provider",
-                return_value={"x": 1},
+                return_value=api_provider_detail_payload(),
             ),
         ):
-            assert method(api, "t", make_account()) == {"x": 1}
+            assert method(api, "t", make_account())["schema"] == "{}"
 
 
 class TestWorkflowApis:
@@ -457,7 +620,7 @@ class TestWorkflowApis:
             "name": "n",
             "label": "l",
             "description": "d",
-            "icon": empty_mapping(),
+            "icon": emoji_icon(),
             "parameters": empty_list(),
         }
 
@@ -465,10 +628,13 @@ class TestWorkflowApis:
             app.test_request_context("/", json=payload),
             patch(
                 "controllers.console.workspace.tool_providers.WorkflowToolManageService.create_workflow_tool",
-                return_value={"id": 1},
-            ),
+                return_value={"result": "success"},
+            ) as create_workflow_tool,
         ):
-            assert method(api, "t", make_account())["id"] == 1
+            assert method(api, "t", make_account()) == {"result": "success"}
+
+        create_workflow_tool.assert_called_once()
+        assert create_workflow_tool.call_args.kwargs["icon"] == emoji_icon()
 
     def test_update_invalid(self, app: Flask) -> None:
         api = ToolWorkflowProviderUpdateApi()
@@ -479,18 +645,21 @@ class TestWorkflowApis:
             "name": "Tool",
             "label": "Tool Label",
             "description": "A tool",
-            "icon": empty_mapping(),
+            "icon": emoji_icon(),
         }
 
         with (
             app.test_request_context("/", json=payload),
             patch(
                 "controllers.console.workspace.tool_providers.WorkflowToolManageService.update_workflow_tool",
-                return_value={"ok": True},
-            ),
+                return_value={"result": "success"},
+            ) as update_workflow_tool,
         ):
             result = method(api, "t", make_account())
-            assert result["ok"]
+            assert result == {"result": "success"}
+
+        update_workflow_tool.assert_called_once()
+        assert update_workflow_tool.call_args.args[5] == emoji_icon()
 
     def test_delete(self, app: Flask) -> None:
         api = ToolWorkflowProviderDeleteApi()
@@ -500,10 +669,10 @@ class TestWorkflowApis:
             app.test_request_context("/", json={"workflow_tool_id": "123e4567-e89b-12d3-a456-426614174000"}),
             patch(
                 "controllers.console.workspace.tool_providers.WorkflowToolManageService.delete_workflow_tool",
-                return_value={"ok": True},
+                return_value={"result": "success"},
             ),
         ):
-            assert method(api, "t", make_account())["ok"]
+            assert method(api, "t", make_account())["result"] == "success"
 
     def test_get_error(self, app: Flask) -> None:
         api = ToolWorkflowProviderGetApi()
@@ -525,49 +694,40 @@ class TestLists:
         api = ToolBuiltinListApi()
         method = unwrap(api.get)
 
-        m = MagicMock()
-        m.to_dict.return_value = {"x": 1}
-
         with (
             app.test_request_context("/"),
             patch(
                 "controllers.console.workspace.tool_providers.BuiltinToolManageService.list_builtin_tools",
-                return_value=[m],
+                return_value=[provider_entity(provider_id="builtin-1")],
             ),
         ):
-            assert method(api, "t", make_account()) == [{"x": 1}]
+            assert method(api, "t", make_account())[0]["id"] == "builtin-1"
 
     def test_api_list(self, app: Flask) -> None:
         api = ToolApiListApi()
         method = unwrap(api.get)
 
-        m = MagicMock()
-        m.to_dict.return_value = {"x": 1}
-
         with (
             app.test_request_context("/"),
             patch(
                 "controllers.console.workspace.tool_providers.ApiToolManageService.list_api_tools",
-                return_value=[m],
+                return_value=[provider_entity(provider_id="api-1", provider_type="api")],
             ),
         ):
-            assert method(api, "t") == [{"x": 1}]
+            assert method(api, "t")[0]["id"] == "api-1"
 
     def test_workflow_list(self, app: Flask) -> None:
         api = ToolWorkflowListApi()
         method = unwrap(api.get)
 
-        m = MagicMock()
-        m.to_dict.return_value = {"x": 1}
-
         with (
             app.test_request_context("/"),
             patch(
                 "controllers.console.workspace.tool_providers.WorkflowToolManageService.list_tenant_workflow_tools",
-                return_value=[m],
+                return_value=[provider_entity(provider_id="workflow-1", provider_type="workflow")],
             ),
         ):
-            assert method(api, "t", make_account()) == [{"x": 1}]
+            assert method(api, "t", make_account())[0]["id"] == "workflow-1"
 
 
 class TestLabels:
@@ -583,10 +743,10 @@ class TestLabels:
             app.test_request_context("/"),
             patch(
                 "controllers.console.workspace.tool_providers.ToolLabelsService.list_tool_labels",
-                return_value=["l1"],
+                return_value=[tool_label_payload()],
             ),
         ):
-            assert method(api) == ["l1"]
+            assert method(api)[0]["name"] == "utilities"
 
 
 class TestOAuth:
@@ -630,10 +790,10 @@ class TestOAuthCustomClient:
             app.test_request_context("/", json={"client_params": {"a": 1}}),
             patch(
                 "controllers.console.workspace.tool_providers.BuiltinToolManageService.save_custom_oauth_client_params",
-                return_value={"ok": True},
+                return_value={"result": "success"},
             ),
         ):
-            assert method(api, "t", "provider")["ok"]
+            assert method(api, "t", "provider") == {"result": "success"}
 
     def test_get_custom_client(self, app: Flask) -> None:
         api = ToolOAuthCustomClient()
@@ -656,7 +816,7 @@ class TestOAuthCustomClient:
             app.test_request_context("/"),
             patch(
                 "controllers.console.workspace.tool_providers.BuiltinToolManageService.delete_custom_oauth_client_params",
-                return_value={"ok": True},
+                return_value={"result": "success"},
             ),
         ):
-            assert method(api, "t", "provider")["ok"]
+            assert method(api, "t", "provider") == {"result": "success"}

--- a/api/tests/test_containers_integration_tests/controllers/console/workspace/test_trigger_providers.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/workspace/test_trigger_providers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from inspect import unwrap
 from unittest.mock import MagicMock, patch
 
@@ -29,6 +30,8 @@ from controllers.console.workspace.trigger_providers import (
     TriggerSubscriptionVerifyApi,
 )
 from core.plugin.entities.plugin_daemon import CredentialType
+from core.trigger.entities.api_entities import SubscriptionBuilderApiEntity, TriggerProviderApiEntity
+from core.trigger.entities.entities import RequestLog
 from models.account import Account
 
 
@@ -36,6 +39,47 @@ def mock_user() -> Account:
     user = Account(name="User", email="user.com")
     user.id = "u1"
     return user
+
+
+def trigger_provider() -> TriggerProviderApiEntity:
+    return TriggerProviderApiEntity(
+        author="Dify",
+        name="github",
+        label={"en_US": "GitHub"},
+        description={"en_US": "GitHub trigger provider"},
+        icon="icon.svg",
+        icon_dark=None,
+        tags=["code"],
+        plugin_id="plugin",
+        plugin_unique_identifier="plugin:github",
+        supported_creation_methods=[],
+        subscription_constructor=None,
+        subscription_schema=[],
+        events=[],
+    )
+
+
+def subscription_builder() -> SubscriptionBuilderApiEntity:
+    return SubscriptionBuilderApiEntity(
+        id="b1",
+        name="Builder",
+        provider="github",
+        endpoint="b1",
+        parameters={"repo": "dify"},
+        properties={"branch": "main"},
+        credentials={"token": "secret"},
+        credential_type=CredentialType.UNAUTHORIZED,
+    )
+
+
+def request_log() -> RequestLog:
+    return RequestLog(
+        id="log1",
+        endpoint="/hooks/b1",
+        request={"headers": {}, "body": {"event": "push"}},
+        response={"status": 200, "body": {"ok": True}},
+        created_at=datetime(2024, 1, 1),
+    )
 
 
 class TestTriggerProviderApis:
@@ -77,10 +121,10 @@ class TestTriggerProviderApis:
             app.test_request_context("/"),
             patch(
                 "controllers.console.workspace.trigger_providers.TriggerProviderService.get_trigger_provider",
-                return_value={"id": "p1"},
+                return_value=trigger_provider(),
             ),
         ):
-            assert method(api, "t1", "github") == {"id": "p1"}
+            assert method(api, "t1", "github")["name"] == "github"
 
 
 class TestTriggerSubscriptionListApi:
@@ -129,11 +173,11 @@ class TestTriggerSubscriptionBuilderApis:
             app.test_request_context("/", json={"credential_type": "UNAUTHORIZED"}),
             patch(
                 "controllers.console.workspace.trigger_providers.TriggerSubscriptionBuilderService.create_trigger_subscription_builder",
-                return_value={"id": "b1"},
+                return_value=subscription_builder(),
             ),
         ):
             result = method(api, "t1", mock_user(), "github")
-            assert "subscription_builder" in result
+            assert result["subscription_builder"]["id"] == "b1"
 
     def test_get_builder(self, app: Flask) -> None:
         api = TriggerSubscriptionBuilderGetApi()
@@ -143,10 +187,10 @@ class TestTriggerSubscriptionBuilderApis:
             app.test_request_context("/"),
             patch(
                 "controllers.console.workspace.trigger_providers.TriggerSubscriptionBuilderService.get_subscription_builder_by_id",
-                return_value={"id": "b1"},
+                return_value=subscription_builder(),
             ),
         ):
-            assert method(api, "github", "b1") == {"id": "b1"}
+            assert method(api, "github", "b1")["id"] == "b1"
 
     def test_verify_builder(self, app: Flask) -> None:
         api = TriggerSubscriptionBuilderVerifyApi()
@@ -156,10 +200,10 @@ class TestTriggerSubscriptionBuilderApis:
             app.test_request_context("/", json={"credentials": {"a": 1}}),
             patch(
                 "controllers.console.workspace.trigger_providers.TriggerSubscriptionBuilderService.update_and_verify_builder",
-                return_value={"ok": True},
+                return_value={"verified": True},
             ),
         ):
-            assert method(api, "t1", mock_user(), "github", "b1") == {"ok": True}
+            assert method(api, "t1", mock_user(), "github", "b1") == {"verified": True}
 
     def test_verify_builder_error(self, app: Flask) -> None:
         api = TriggerSubscriptionBuilderVerifyApi()
@@ -183,26 +227,24 @@ class TestTriggerSubscriptionBuilderApis:
             app.test_request_context("/", json={"name": "n"}),
             patch(
                 "controllers.console.workspace.trigger_providers.TriggerSubscriptionBuilderService.update_trigger_subscription_builder",
-                return_value={"id": "b1"},
+                return_value=subscription_builder(),
             ),
         ):
-            assert method(api, "t1", "github", "b1") == {"id": "b1"}
+            assert method(api, "t1", "github", "b1")["id"] == "b1"
 
     def test_logs(self, app: Flask) -> None:
         api = TriggerSubscriptionBuilderLogsApi()
         method = unwrap(api.get)
 
-        log = MagicMock()
-        log.model_dump.return_value = {"a": 1}
-
         with (
             app.test_request_context("/"),
             patch(
                 "controllers.console.workspace.trigger_providers.TriggerSubscriptionBuilderService.list_logs",
-                return_value=[log],
+                return_value=[request_log()],
             ),
         ):
-            assert "logs" in method(api, "github", "b1")
+            result = method(api, "github", "b1")
+            assert result["logs"][0]["id"] == "log1"
 
     def test_build(self, app: Flask) -> None:
         api = TriggerSubscriptionBuilderBuildApi()
@@ -215,7 +257,7 @@ class TestTriggerSubscriptionBuilderApis:
                 return_value=None,
             ),
         ):
-            assert method(api, "t1", mock_user(), "github", "b1") == 200
+            assert method(api, "t1", mock_user(), "github", "b1") == {"result": "success"}
 
 
 class TestTriggerSubscriptionCrud:
@@ -239,7 +281,7 @@ class TestTriggerSubscriptionCrud:
             ),
             patch("controllers.console.workspace.trigger_providers.TriggerProviderService.update_trigger_subscription"),
         ):
-            assert method(api, "t1", "s1") == 200
+            assert method(api, "t1", "s1") == {"result": "success"}
 
     def test_update_not_found(self, app: Flask) -> None:
         api = TriggerSubscriptionUpdateApi()
@@ -275,7 +317,7 @@ class TestTriggerSubscriptionCrud:
                 "controllers.console.workspace.trigger_providers.TriggerProviderService.rebuild_trigger_subscription"
             ),
         ):
-            assert method(api, "t1", "s1") == 200
+            assert method(api, "t1", "s1") == {"result": "success"}
 
     def test_delete_subscription(self, app: Flask) -> None:
         api = TriggerSubscriptionDeleteApi()
@@ -336,7 +378,7 @@ class TestTriggerOAuthApis:
             ),
             patch(
                 "controllers.console.workspace.trigger_providers.TriggerSubscriptionBuilderService.create_trigger_subscription_builder",
-                return_value=MagicMock(id="b1"),
+                return_value=subscription_builder(),
             ),
             patch(
                 "controllers.console.workspace.trigger_providers.OAuthProxyService.create_proxy_context",
@@ -480,7 +522,7 @@ class TestTriggerOAuthClientManageApi:
             ),
             patch(
                 "controllers.console.workspace.trigger_providers.TriggerManager.get_trigger_provider",
-                return_value=MagicMock(get_oauth_client_schema=lambda: {}),
+                return_value=MagicMock(get_oauth_client_schema=lambda: []),
             ),
         ):
             result = method(api, "t1", "github")
@@ -494,10 +536,10 @@ class TestTriggerOAuthClientManageApi:
             app.test_request_context("/", json={"enabled": True}),
             patch(
                 "controllers.console.workspace.trigger_providers.TriggerProviderService.save_custom_oauth_client_params",
-                return_value={"ok": True},
+                return_value={"result": "success"},
             ),
         ):
-            assert method(api, "t1", "github") == {"ok": True}
+            assert method(api, "t1", "github") == {"result": "success"}
 
     def test_delete_client(self, app: Flask) -> None:
         api = TriggerOAuthClientManageApi()
@@ -507,10 +549,10 @@ class TestTriggerOAuthClientManageApi:
             app.test_request_context("/"),
             patch(
                 "controllers.console.workspace.trigger_providers.TriggerProviderService.delete_custom_oauth_client_params",
-                return_value={"ok": True},
+                return_value={"result": "success"},
             ),
         ):
-            assert method(api, "t1", "github") == {"ok": True}
+            assert method(api, "t1", "github") == {"result": "success"}
 
     def test_oauth_client_post_value_error(self, app: Flask) -> None:
         api = TriggerOAuthClientManageApi()
@@ -540,10 +582,10 @@ class TestTriggerSubscriptionVerifyApi:
             app.test_request_context("/", json={"credentials": {}}),
             patch(
                 "controllers.console.workspace.trigger_providers.TriggerProviderService.verify_subscription_credentials",
-                return_value={"ok": True},
+                return_value={"verified": True},
             ),
         ):
-            assert method(api, "t1", mock_user(), "github", "s1") == {"ok": True}
+            assert method(api, "t1", mock_user(), "github", "s1") == {"verified": True}
 
     @pytest.mark.parametrize("raised_exception", [ValueError("bad"), Exception("boom")])
     def test_verify_errors(self, app: Flask, raised_exception: Exception) -> None:

--- a/api/tests/test_containers_integration_tests/services/tools/test_api_tools_manage_service.py
+++ b/api/tests/test_containers_integration_tests/services/tools/test_api_tools_manage_service.py
@@ -1,6 +1,7 @@
 import inspect
 import json
-from unittest.mock import patch
+from collections.abc import Iterator
+from unittest.mock import MagicMock, patch
 
 import pytest
 from faker import Faker
@@ -10,16 +11,18 @@ from sqlalchemy.orm import Session
 from core.tools.entities.tool_entities import ApiProviderSchemaType
 from core.tools.errors import ApiToolProviderNotFoundError
 from core.tools.tool_label_manager import ToolLabelManager
-from models import Account, Tenant
+from models import Account, AccountStatus, Tenant, TenantStatus
 from models.tools import ApiToolProvider
 from services.tools.api_tools_manage_service import ApiToolManageService
+
+MockDependencies = dict[str, MagicMock]
 
 
 class TestApiToolManageService:
     """Integration tests for ApiToolManageService using testcontainers."""
 
     @pytest.fixture
-    def mock_external_service_dependencies(self):
+    def mock_external_service_dependencies(self) -> Iterator[MockDependencies]:
         """Mock setup for external service dependencies."""
         with (
             patch("services.tools.api_tools_manage_service.ToolLabelManager") as mock_tool_label_manager,
@@ -39,7 +42,9 @@ class TestApiToolManageService:
                 "provider_controller": mock_provider_controller,
             }
 
-    def _create_test_account_and_tenant(self, db_session_with_containers: Session, mock_external_service_dependencies):
+    def _create_test_account_and_tenant(
+        self, db_session_with_containers: Session, mock_external_service_dependencies: MockDependencies
+    ) -> tuple[Account, Tenant]:
         """
         Helper method to create a test account and tenant for testing.
 
@@ -57,7 +62,7 @@ class TestApiToolManageService:
             email=fake.email(),
             name=fake.name(),
             interface_language="en-US",
-            status="active",
+            status=AccountStatus.ACTIVE,
         )
 
         db_session_with_containers.add(account)
@@ -66,7 +71,7 @@ class TestApiToolManageService:
         # Create tenant for the account
         tenant = Tenant(
             name=fake.company(),
-            status="normal",
+            status=TenantStatus.NORMAL,
         )
         db_session_with_containers.add(tenant)
         db_session_with_containers.commit()
@@ -88,7 +93,7 @@ class TestApiToolManageService:
 
         return account, tenant
 
-    def _create_test_openapi_schema(self):
+    def _create_test_openapi_schema(self) -> str:
         """Helper method to create a test OpenAPI schema."""
         return """
         {
@@ -121,8 +126,11 @@ class TestApiToolManageService:
         """
 
     def test_parser_api_schema_success(
-        self, flask_req_ctx_with_containers, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
+        self,
+        flask_req_ctx_with_containers: object,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies: MockDependencies,
+    ) -> None:
         """
         Test successful parsing of API schema.
 
@@ -148,6 +156,8 @@ class TestApiToolManageService:
         # Verify credentials schema structure
         credentials_schema = result["credentials_schema"]
         assert len(credentials_schema) == 3
+        assert all(isinstance(field, dict) for field in credentials_schema)
+        assert all(isinstance(tool, dict) for tool in result["parameters_schema"])
 
         # Check auth_type field
         auth_type_field = next(field for field in credentials_schema if field["name"] == "auth_type")
@@ -166,8 +176,11 @@ class TestApiToolManageService:
         assert api_key_value_field["default"] == ""
 
     def test_parser_api_schema_invalid_schema(
-        self, flask_req_ctx_with_containers, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
+        self,
+        flask_req_ctx_with_containers: object,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies: MockDependencies,
+    ) -> None:
         """
         Test parsing of invalid API schema.
 
@@ -186,8 +199,11 @@ class TestApiToolManageService:
         assert "invalid schema" in str(exc_info.value)
 
     def test_parser_api_schema_malformed_json(
-        self, flask_req_ctx_with_containers, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
+        self,
+        flask_req_ctx_with_containers: object,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies: MockDependencies,
+    ) -> None:
         """
         Test parsing of malformed JSON schema.
 
@@ -206,8 +222,11 @@ class TestApiToolManageService:
         assert "invalid schema" in str(exc_info.value)
 
     def test_convert_schema_to_tool_bundles_success(
-        self, flask_req_ctx_with_containers, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
+        self,
+        flask_req_ctx_with_containers: object,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies: MockDependencies,
+    ) -> None:
         """
         Test successful conversion of schema to tool bundles.
 
@@ -236,8 +255,11 @@ class TestApiToolManageService:
         assert tool_bundle.operation_id == "testOperation"
 
     def test_convert_schema_to_tool_bundles_with_extra_info(
-        self, flask_req_ctx_with_containers, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
+        self,
+        flask_req_ctx_with_containers: object,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies: MockDependencies,
+    ) -> None:
         """
         Test successful conversion of schema to tool bundles with extra info.
 
@@ -262,8 +284,11 @@ class TestApiToolManageService:
         assert isinstance(schema_type, str)
 
     def test_convert_schema_to_tool_bundles_invalid_schema(
-        self, flask_req_ctx_with_containers, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
+        self,
+        flask_req_ctx_with_containers: object,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies: MockDependencies,
+    ) -> None:
         """
         Test conversion of invalid schema to tool bundles.
 
@@ -282,8 +307,11 @@ class TestApiToolManageService:
         assert "invalid schema" in str(exc_info.value)
 
     def test_create_api_tool_provider_success(
-        self, flask_req_ctx_with_containers, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
+        self,
+        flask_req_ctx_with_containers: object,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies: MockDependencies,
+    ) -> None:
         """
         Test successful creation of API tool provider.
 
@@ -301,7 +329,7 @@ class TestApiToolManageService:
         )
 
         provider_name = fake.company()
-        icon = {"type": "emoji", "value": "🔧"}
+        icon = {"content": "🔧", "background": "#FFF"}
         credentials = {"auth_type": "none", "api_key_header": "X-API-Key", "api_key_value": ""}
         schema_type = ApiProviderSchemaType.OPENAPI
         schema = self._create_test_openapi_schema()
@@ -341,6 +369,7 @@ class TestApiToolManageService:
         assert provider.schema_type_str == schema_type
         assert provider.privacy_policy == privacy_policy
         assert provider.custom_disclaimer == custom_disclaimer
+        assert json.loads(provider.icon) == icon
 
         # Verify mock interactions
         mock_external_service_dependencies["tool_label_manager"].update_tool_labels.assert_called_once()
@@ -349,8 +378,11 @@ class TestApiToolManageService:
         mock_external_service_dependencies["provider_controller"].load_bundled_tools.assert_called_once()
 
     def test_create_api_tool_provider_duplicate_name(
-        self, flask_req_ctx_with_containers, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
+        self,
+        flask_req_ctx_with_containers: object,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies: MockDependencies,
+    ) -> None:
         """
         Test creation of API tool provider with duplicate name.
 
@@ -366,7 +398,7 @@ class TestApiToolManageService:
         )
 
         provider_name = fake.company()
-        icon = {"type": "emoji", "value": "🔧"}
+        icon = {"content": "🔧", "background": "#FFF"}
         credentials = {"auth_type": "none"}
         schema_type = ApiProviderSchemaType.OPENAPI
         schema = self._create_test_openapi_schema()
@@ -406,8 +438,11 @@ class TestApiToolManageService:
         assert f"provider {provider_name} already exists" in str(exc_info.value)
 
     def test_create_api_tool_provider_invalid_schema_type(
-        self, flask_req_ctx_with_containers, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
+        self,
+        flask_req_ctx_with_containers: object,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies: MockDependencies,
+    ) -> None:
         """
         Test creation of API tool provider with invalid schema type.
 
@@ -423,7 +458,7 @@ class TestApiToolManageService:
         )
 
         provider_name = fake.company()
-        icon = {"type": "emoji", "value": "🔧"}
+        icon = {"content": "🔧", "background": "#FFF"}
         credentials = {"auth_type": "none"}
         schema_type = "invalid_type"
         schema = self._create_test_openapi_schema()
@@ -438,8 +473,11 @@ class TestApiToolManageService:
         assert "validation error" in str(exc_info.value)
 
     def test_create_api_tool_provider_missing_auth_type(
-        self, flask_req_ctx_with_containers, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
+        self,
+        flask_req_ctx_with_containers: object,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies: MockDependencies,
+    ) -> None:
         """
         Test creation of API tool provider with missing auth type.
 
@@ -455,7 +493,7 @@ class TestApiToolManageService:
         )
 
         provider_name = fake.company()
-        icon = {"type": "emoji", "value": "🔧"}
+        icon = {"content": "🔧", "background": "#FFF"}
         credentials = {}  # Missing auth_type
         schema_type = ApiProviderSchemaType.OPENAPI
         schema = self._create_test_openapi_schema()
@@ -481,8 +519,11 @@ class TestApiToolManageService:
         assert "auth_type is required" in str(exc_info.value)
 
     def test_create_api_tool_provider_with_api_key_auth(
-        self, flask_req_ctx_with_containers, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
+        self,
+        flask_req_ctx_with_containers: object,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies: MockDependencies,
+    ) -> None:
         """
         Test successful creation of API tool provider with API key authentication.
 
@@ -498,7 +539,7 @@ class TestApiToolManageService:
         )
 
         provider_name = fake.company()
-        icon = {"type": "emoji", "value": "🔑"}
+        icon = {"content": "🔑", "background": "#FFF"}
         credentials = {"auth_type": "api_key", "api_key_header": "X-API-Key", "api_key_value": fake.uuid4()}
         schema_type = ApiProviderSchemaType.OPENAPI
         schema = self._create_test_openapi_schema()
@@ -542,8 +583,11 @@ class TestApiToolManageService:
         mock_external_service_dependencies["provider_controller"].from_db.assert_called_once()
 
     def test_delete_api_tool_provider_success(
-        self, flask_req_ctx_with_containers, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
+        self,
+        flask_req_ctx_with_containers: object,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies: MockDependencies,
+    ) -> None:
         """Test successful deletion of an API tool provider."""
         fake = Faker()
         account, tenant = self._create_test_account_and_tenant(
@@ -583,8 +627,8 @@ class TestApiToolManageService:
         assert deleted is None
 
     def test_delete_api_tool_provider_not_found(
-        self, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
+        self, db_session_with_containers: Session, mock_external_service_dependencies: MockDependencies
+    ) -> None:
         """Test deletion raises ValueError when provider not found."""
         fake = Faker()
         account, tenant = self._create_test_account_and_tenant(
@@ -595,14 +639,15 @@ class TestApiToolManageService:
             ApiToolManageService.delete_api_tool_provider(account.id, tenant.id, "nonexistent")
 
     def test_update_api_tool_provider_success(
-        self, flask_req_ctx_with_containers, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
+        self,
+        flask_req_ctx_with_containers: object,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies: MockDependencies,
+    ) -> None:
         fake = Faker()
 
         # Firmware fix for cache.delete() in update flow
         mock_encrypter = mock_external_service_dependencies["encrypter"]
-        from unittest.mock import MagicMock
-
         mock_cache = MagicMock()
         mock_cache.delete.return_value = None
         mock_encrypter.return_value = (mock_encrypter, mock_cache)
@@ -620,7 +665,7 @@ class TestApiToolManageService:
             user_id=account.id,
             tenant_id=tenant.id,
             provider_name=original_name,
-            icon={"type": "emoji", "value": "🔧"},
+            icon={"content": "🔧", "background": "#FFF"},
             credentials={"auth_type": "none"},
             schema_type=ApiProviderSchemaType.OPENAPI,
             schema=self._create_test_openapi_schema(),
@@ -646,7 +691,7 @@ class TestApiToolManageService:
             provider_name=new_name,
             original_provider=original_name,
             # new icon              - changed 2
-            icon={"type": "emoji", "value": "🚀"},
+            icon={"content": "🚀", "background": "#FFF"},
             credentials={"auth_type": "none"},
             _schema_type=ApiProviderSchemaType.OPENAPI,
             schema=self._create_test_openapi_schema(),
@@ -677,9 +722,7 @@ class TestApiToolManageService:
         # - changed 1
         assert updated_provider.name == new_name
         # - changed 2
-        icon_data = json.loads(updated_provider.icon)
-        assert icon_data["type"] == "emoji"
-        assert icon_data["value"] == "🚀"
+        assert json.loads(updated_provider.icon) == {"content": "🚀", "background": "#FFF"}
         # - changed 3
         assert updated_provider.privacy_policy == "https://new-policy.com"
         # - changed 4
@@ -712,8 +755,11 @@ class TestApiToolManageService:
         )
 
     def test_update_api_tool_provider_not_found(
-        self, flask_req_ctx_with_containers, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
+        self,
+        flask_req_ctx_with_containers: object,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies: MockDependencies,
+    ) -> None:
         """
         Test update raises ValueError when original provider not found.
 
@@ -733,7 +779,7 @@ class TestApiToolManageService:
             user_id=account.id,
             tenant_id=tenant.id,
             provider_name=existing_provider_name,
-            icon={"type": "emoji", "value": "🔧"},
+            icon={"content": "🔧", "background": "#FFF"},
             credentials={"auth_type": "none"},
             schema_type=ApiProviderSchemaType.OPENAPI,
             schema=self._create_test_openapi_schema(),
@@ -756,7 +802,7 @@ class TestApiToolManageService:
                 tenant_id=tenant.id,
                 provider_name=target_new_name,
                 original_provider=missing_original_name,
-                icon={"type": "emoji", "value": "🚀"},
+                icon={"content": "🚀", "background": "#FFF"},
                 credentials={"auth_type": "none"},
                 _schema_type=ApiProviderSchemaType.OPENAPI,
                 schema=self._create_test_openapi_schema(),
@@ -793,8 +839,11 @@ class TestApiToolManageService:
         mock_external_service_dependencies["provider_controller"].from_db.assert_not_called()
 
     def test_update_api_tool_provider_missing_auth_type(
-        self, flask_req_ctx_with_containers, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
+        self,
+        flask_req_ctx_with_containers: object,
+        db_session_with_containers: Session,
+        mock_external_service_dependencies: MockDependencies,
+    ) -> None:
         """Test update raises ValueError when auth_type is missing from credentials."""
         fake = Faker()
         account, tenant = self._create_test_account_and_tenant(
@@ -822,7 +871,7 @@ class TestApiToolManageService:
                 tenant_id=tenant.id,
                 provider_name=provider_name,
                 original_provider=provider_name,
-                icon={},
+                icon={"content": "🔧", "background": "#FFF"},
                 credentials={},
                 _schema_type=ApiProviderSchemaType.OPENAPI,
                 schema=schema,
@@ -832,8 +881,8 @@ class TestApiToolManageService:
             )
 
     def test_list_api_tool_provider_tools_not_found(
-        self, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
+        self, db_session_with_containers: Session, mock_external_service_dependencies: MockDependencies
+    ) -> None:
         """Test listing tools raises ValueError when provider not found."""
         fake = Faker()
         account, tenant = self._create_test_account_and_tenant(
@@ -844,8 +893,8 @@ class TestApiToolManageService:
             ApiToolManageService.list_api_tool_provider_tools(account.id, tenant.id, "nonexistent")
 
     def test_test_api_tool_preview_invalid_schema_type(
-        self, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
+        self, db_session_with_containers: Session, mock_external_service_dependencies: MockDependencies
+    ) -> None:
         """Test preview raises ValueError for invalid schema type."""
         fake = Faker()
         account, tenant = self._create_test_account_and_tenant(

--- a/api/tests/unit_tests/controllers/console/workspace/test_tool_providers.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_tool_providers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import builtins
 import importlib
 from contextlib import ExitStack, contextmanager
+from inspect import unwrap
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -423,7 +424,8 @@ def test_builtin_provider_credentials_get_reads_repeated_include_ids(
     app: Flask, controller_module, monkeypatch: pytest.MonkeyPatch
 ):
     user = _mock_account("user-tenant-cred")
-    service_mock = MagicMock(return_value=[{"cred": 1}])
+    credential_payload, expected = _credential_response(controller_module)
+    service_mock = MagicMock(return_value=[credential_payload])
     monkeypatch.setattr(
         controller_module.BuiltinToolManageService,
         "get_builtin_tool_provider_credentials",
@@ -434,7 +436,7 @@ def test_builtin_provider_credentials_get_reads_repeated_include_ids(
         api = controller_module.ToolBuiltinProviderGetCredentialsApi()
         resp = unwrap(api.get)(api, "tenant-cred", user, provider="demo")
 
-    assert resp == [{"cred": 1}]
+    assert resp == [expected]
     service_mock.assert_called_once_with(
         tenant_id="tenant-cred",
         provider_name="demo",

--- a/api/tests/unit_tests/controllers/console/workspace/test_tool_providers.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_tool_providers.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import builtins
 import importlib
 from contextlib import ExitStack, contextmanager
-from inspect import unwrap
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -13,6 +12,9 @@ import pytest
 from flask import Flask
 from flask.views import MethodView
 
+from core.tools.entities.api_entities import ToolProviderApiEntity as CoreToolProviderApiEntity
+from core.tools.entities.common_entities import I18nObject
+from core.tools.entities.tool_entities import ToolParameter
 from models import Account
 from models.account import TenantAccountRole
 
@@ -21,6 +23,7 @@ if not hasattr(builtins, "MethodView"):
 
 
 _CONTROLLER_MODULE: ModuleType | None = None
+_WRAPS_MODULE: ModuleType | None = None
 
 
 @contextmanager
@@ -69,10 +72,11 @@ def controller_module(monkeypatch: pytest.MonkeyPatch):
                 _CONTROLLER_MODULE = importlib.import_module(module_name)
 
     module = _CONTROLLER_MODULE
-    monkeypatch.setattr(module, "jsonable_encoder", lambda payload: payload)
 
     # Ensure decorators that consult deployment edition do not reach the database.
+    global _WRAPS_MODULE
     wraps_module = importlib.import_module("controllers.console.wraps")
+    _WRAPS_MODULE = wraps_module
     monkeypatch.setattr(module.dify_config, "EDITION", "CLOUD")
     monkeypatch.setattr(wraps_module.dify_config, "EDITION", "CLOUD")
 
@@ -88,19 +92,194 @@ def _mock_account(user_id: str = "user-123") -> Account:
     return user
 
 
+def _set_current_account(
+    monkeypatch: pytest.MonkeyPatch,
+    controller_module: ModuleType,
+    user: Account,
+    tenant_id: str,
+) -> None:
+    def _getter():
+        return user, tenant_id
+
+    monkeypatch.setattr(controller_module, "current_account_with_tenant", _getter, raising=False)
+    if _WRAPS_MODULE is not None:
+        monkeypatch.setattr(_WRAPS_MODULE, "current_account_with_tenant", _getter)
+
+    login_module = importlib.import_module("libs.login")
+    monkeypatch.setattr(login_module, "_get_user", lambda: user)
+
+
+def _i18n(text: str) -> dict[str, str]:
+    return {"en_US": text, "zh_Hans": text, "pt_BR": text, "ja_JP": text}
+
+
+def _tool_response(controller_module: ModuleType, name: str = "tool-a") -> tuple[dict, dict]:
+    expected = {
+        "author": "Dify",
+        "name": name,
+        "label": _i18n(name),
+        "description": _i18n(f"{name} description"),
+        "parameters": [],
+        "labels": [],
+        "output_schema": {},
+    }
+    tool = controller_module.ToolApiEntity.model_validate(expected)
+    return tool.model_dump(mode="json"), expected
+
+
+def _provider_entity_response(
+    controller_module: ModuleType, name: str = "provider", provider_type: str = "builtin"
+) -> tuple[CoreToolProviderApiEntity, dict]:
+    service_payload = {
+        "id": f"{name}-id",
+        "author": "Dify",
+        "name": name,
+        "description": _i18n(f"{name} description"),
+        "icon": "tool.svg",
+        "icon_dark": "",
+        "label": _i18n(name),
+        "type": provider_type,
+        "masked_credentials": {"api_key": "[__HIDDEN__]"},
+        "original_credentials": {"api_key": "sk-secret"},
+        "is_team_authorization": False,
+        "allow_delete": True,
+        "plugin_id": "",
+        "plugin_unique_identifier": "",
+        "tools": [],
+        "labels": [],
+        "server_url": "",
+        "updated_at": 1,
+        "server_identifier": "",
+        "masked_headers": None,
+        "original_headers": None,
+        "authentication": None,
+        "is_dynamic_registration": True,
+        "configuration": None,
+        "identity_mode": "off",
+        "workflow_app_id": None,
+    }
+    provider = CoreToolProviderApiEntity.model_validate(service_payload)
+    return provider, provider.to_dict()
+
+
+def _provider_list_item(
+    controller_module: ModuleType, name: str = "provider", provider_type: str = "builtin"
+) -> tuple[dict, dict]:
+    service_payload = {
+        "id": f"{name}-id",
+        "author": "Dify",
+        "name": name,
+        "description": _i18n(f"{name} description"),
+        "icon": "tool.svg",
+        "icon_dark": "",
+        "label": _i18n(name),
+        "type": provider_type,
+        "team_credentials": {"api_key": "[__HIDDEN__]"},
+        "is_team_authorization": False,
+        "allow_delete": True,
+        "plugin_id": "",
+        "plugin_unique_identifier": "",
+        "tools": [],
+        "labels": [],
+    }
+    expected = {
+        **service_payload,
+    }
+    provider = controller_module.ToolProviderApiEntityResponse.model_validate(expected)
+    return service_payload, provider.model_dump(mode="json", exclude_unset=True)
+
+
+def _credential_response(controller_module: ModuleType, credential_id: str = "cred-1") -> tuple[dict, dict]:
+    expected = {
+        "id": credential_id,
+        "name": "Credential",
+        "provider": "demo",
+        "credential_type": controller_module.CredentialType.API_KEY,
+        "is_default": False,
+        "credentials": {},
+        "visibility": "all_team_members",
+        "created_by": "",
+        "partial_member_list": [],
+        "from_other_member": False,
+    }
+    credential = controller_module.ToolProviderCredentialApiEntity.model_validate(expected)
+    return credential.model_dump(mode="json"), credential.model_dump(mode="json")
+
+
+def _provider_config_response(controller_module: ModuleType) -> tuple[dict, dict]:
+    expected = {
+        "type": "secret-input",
+        "name": "api_key",
+        "scope": None,
+        "required": False,
+        "default": None,
+        "options": None,
+        "multiple": False,
+        "label": None,
+        "help": None,
+        "url": None,
+        "placeholder": None,
+    }
+    config = controller_module.ProviderConfig.model_validate(expected)
+    return config.model_dump(mode="json"), expected
+
+
+def _api_provider_detail_response(controller_module: ModuleType) -> tuple[dict, dict]:
+    expected = {
+        "schema_type": "openapi",
+        "schema": "{}",
+        "tools": [],
+        "icon": {"background": "#252525", "content": "tool"},
+        "description": "provider description",
+        "credentials": {"auth_type": "none"},
+        "privacy_policy": "",
+        "custom_disclaimer": "",
+        "labels": [],
+    }
+    detail = controller_module.ApiProviderDetailResponse.model_validate(expected)
+    return detail.model_dump(mode="json", by_alias=True), expected
+
+
+def _workflow_detail_response(controller_module: ModuleType) -> tuple[dict, dict]:
+    tool_payload, tool_expected = _tool_response(controller_module, "workflow-tool")
+    expected = {
+        "name": "workflow-tool",
+        "label": "Workflow Tool",
+        "workflow_tool_id": "00000000-0000-0000-0000-000000000001",
+        "workflow_app_id": "00000000-0000-0000-0000-000000000002",
+        "icon": {"background": "#252525", "content": "tool"},
+        "description": "description",
+        "parameters": [],
+        "output_schema": {},
+        "tool": tool_expected,
+        "synced": True,
+        "privacy_policy": "",
+    }
+    service_payload = {**expected, "tool": tool_payload}
+    detail = controller_module.WorkflowToolDetailResponse.model_validate(service_payload)
+    return detail.model_dump(mode="json"), expected
+
+
+def _tool_label_response(controller_module: ModuleType, name: str = "search") -> tuple[dict, dict]:
+    expected = {"name": name, "label": _i18n(name), "icon": "search"}
+    label = controller_module.ToolLabel.model_validate(expected)
+    return label.model_dump(mode="json"), expected
+
+
 def test_tool_provider_list_calls_service_with_query(
     app: Flask, controller_module: ModuleType, monkeypatch: pytest.MonkeyPatch
 ):
     user = _mock_account()
+    _set_current_account(monkeypatch, controller_module, user, "tenant-456")
 
-    service_mock = MagicMock(return_value=[{"provider": "builtin"}])
+    service_payload, expected_response = _provider_list_item(controller_module, "builtin", "builtin")
+    service_mock = MagicMock(return_value=[service_payload])
     monkeypatch.setattr(controller_module.ToolCommonService, "list_tool_providers", service_mock)
 
     with app.test_request_context("/workspaces/current/tool-providers?type=builtin"):
-        api = controller_module.ToolProviderListApi()
-        response = unwrap(api.get)(api, "tenant-456", user)
+        response = controller_module.ToolProviderListApi().get()
 
-    assert response == [{"provider": "builtin"}]
+    assert response == [expected_response]
     service_mock.assert_called_once_with(user.id, "tenant-456", "builtin")
 
 
@@ -108,8 +287,9 @@ def test_builtin_provider_add_passes_payload(
     app: Flask, controller_module: ModuleType, monkeypatch: pytest.MonkeyPatch
 ):
     user = _mock_account()
+    _set_current_account(monkeypatch, controller_module, user, "tenant-456")
 
-    service_mock = MagicMock(return_value={"status": "ok"})
+    service_mock = MagicMock(return_value={"result": "success"})
     monkeypatch.setattr(controller_module.BuiltinToolManageService, "add_builtin_tool_provider", service_mock)
 
     payload = {
@@ -123,10 +303,9 @@ def test_builtin_provider_add_passes_payload(
         method="POST",
         json=payload,
     ):
-        api = controller_module.ToolBuiltinProviderAddApi()
-        response = unwrap(api.post)(api, "tenant-456", user, provider="openai")
+        response = controller_module.ToolBuiltinProviderAddApi().post(provider="openai")
 
-    assert response == {"status": "ok"}
+    assert response == {"result": "success"}
     service_mock.assert_called_once_with(
         user_id="user-123",
         tenant_id="tenant-456",
@@ -140,38 +319,88 @@ def test_builtin_provider_add_passes_payload(
 
 def test_builtin_provider_tools_get(app: Flask, controller_module, monkeypatch: pytest.MonkeyPatch):
     user = _mock_account("user-tenant-789")
+    _set_current_account(monkeypatch, controller_module, user, "tenant-789")
 
-    service_mock = MagicMock(return_value=[{"name": "tool-a"}])
+    service_payload, expected_response = _tool_response(controller_module, "tool-a")
+    service_mock = MagicMock(return_value=[service_payload])
     monkeypatch.setattr(controller_module.BuiltinToolManageService, "list_builtin_tool_provider_tools", service_mock)
-    monkeypatch.setattr(controller_module, "jsonable_encoder", lambda payload: payload)
 
     with app.test_request_context(
         "/workspaces/current/tool-provider/builtin/my-provider/tools",
         method="GET",
     ):
-        api = controller_module.ToolBuiltinProviderListToolsApi()
-        response = unwrap(api.get)(api, "tenant-789", provider="my-provider")
+        response = controller_module.ToolBuiltinProviderListToolsApi().get(provider="my-provider")
 
-    assert response == [{"name": "tool-a"}]
+    assert response == [expected_response]
     service_mock.assert_called_once_with("tenant-789", "my-provider")
 
 
 def test_builtin_provider_info_get(app: Flask, controller_module, monkeypatch: pytest.MonkeyPatch):
     user = _mock_account("user-tenant-9")
-    service_mock = MagicMock(return_value={"info": True})
+    _set_current_account(monkeypatch, controller_module, user, "tenant-9")
+    service_payload, expected_response = _provider_entity_response(controller_module, "demo", "builtin")
+    service_mock = MagicMock(return_value=service_payload)
     monkeypatch.setattr(controller_module.BuiltinToolManageService, "get_builtin_tool_provider_info", service_mock)
 
     with app.test_request_context("/info", method="GET"):
-        api = controller_module.ToolBuiltinProviderInfoApi()
-        resp = unwrap(api.get)(api, "tenant-9", provider="demo")
+        resp = controller_module.ToolBuiltinProviderInfoApi().get(provider="demo")
 
-    assert resp == {"info": True}
+    assert resp == expected_response
     service_mock.assert_called_once_with("tenant-9", "demo")
+
+
+def test_builtin_provider_info_uses_core_to_dict_tool_projection(
+    app: Flask, controller_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+):
+    user = _mock_account("user-tenant-9")
+    _set_current_account(monkeypatch, controller_module, user, "tenant-9")
+    tool_parameter = ToolParameter(
+        name="system_files",
+        label=I18nObject(en_US="System Files", zh_Hans="System Files"),
+        type=ToolParameter.ToolParameterType.SYSTEM_FILES,
+        form=ToolParameter.ToolParameterForm.LLM,
+        input_schema=None,
+    )
+    tool = controller_module.ToolApiEntity(
+        author="Dify",
+        name="demo-tool",
+        label=I18nObject(en_US="Demo Tool", zh_Hans="Demo Tool"),
+        description=I18nObject(en_US="Demo Tool description", zh_Hans="Demo Tool description"),
+        parameters=[tool_parameter],
+        labels=[],
+        output_schema={},
+    )
+    provider = CoreToolProviderApiEntity(
+        id="demo-id",
+        author="Dify",
+        name="demo",
+        description=I18nObject(en_US="demo description", zh_Hans="demo description"),
+        icon="tool.svg",
+        label=I18nObject(en_US="demo", zh_Hans="demo"),
+        type=controller_module.ToolProviderType.BUILT_IN,
+        masked_credentials={"api_key": "[__HIDDEN__]"},
+        original_credentials={"api_key": "sk-secret"},
+        tools=[tool],
+    )
+    service_mock = MagicMock(return_value=provider)
+    monkeypatch.setattr(controller_module.BuiltinToolManageService, "get_builtin_tool_provider_info", service_mock)
+
+    with app.test_request_context("/info", method="GET"):
+        resp = controller_module.ToolBuiltinProviderInfoApi().get(provider="demo")
+
+    parameter = resp["tools"][0]["parameters"][0]
+    assert parameter["type"] == "files"
+    assert parameter["input_schema"] is None
+    assert resp["team_credentials"] == {"api_key": "[__HIDDEN__]"}
+    assert "masked_credentials" not in resp
+    assert "original_credentials" not in resp
 
 
 def test_builtin_provider_credentials_get(app: Flask, controller_module, monkeypatch: pytest.MonkeyPatch):
     user = _mock_account("user-tenant-cred")
-    service_mock = MagicMock(return_value=[{"cred": 1}])
+    _set_current_account(monkeypatch, controller_module, user, "tenant-cred")
+    service_payload, expected_response = _credential_response(controller_module)
+    service_mock = MagicMock(return_value=[service_payload])
     monkeypatch.setattr(
         controller_module.BuiltinToolManageService,
         "get_builtin_tool_provider_credentials",
@@ -179,10 +408,9 @@ def test_builtin_provider_credentials_get(app: Flask, controller_module, monkeyp
     )
 
     with app.test_request_context("/creds", method="GET"):
-        api = controller_module.ToolBuiltinProviderGetCredentialsApi()
-        resp = unwrap(api.get)(api, "tenant-cred", user, provider="demo")
+        resp = controller_module.ToolBuiltinProviderGetCredentialsApi().get(provider="demo")
 
-    assert resp == [{"cred": 1}]
+    assert resp == [expected_response]
     service_mock.assert_called_once_with(
         tenant_id="tenant-cred",
         provider_name="demo",
@@ -217,46 +445,51 @@ def test_builtin_provider_credentials_get_reads_repeated_include_ids(
 
 def test_api_provider_remote_schema_get(app: Flask, controller_module, monkeypatch: pytest.MonkeyPatch):
     user = _mock_account()
-    service_mock = MagicMock(return_value={"schema": "ok"})
+    _set_current_account(monkeypatch, controller_module, user, "tenant-10")
+    openapi_schema = '{"openapi":"3.0.0","info":{"title":"Demo API","version":"1.0.0"},"paths":{}}'
+    service_mock = MagicMock(return_value={"schema": openapi_schema})
     monkeypatch.setattr(controller_module.ApiToolManageService, "get_api_tool_provider_remote_schema", service_mock)
 
     with app.test_request_context("/remote?url=https://example.com/"):
-        api = controller_module.ToolApiProviderGetRemoteSchemaApi()
-        resp = unwrap(api.get)(api, "tenant-10", user)
+        resp = controller_module.ToolApiProviderGetRemoteSchemaApi().get()
 
-    assert resp == {"schema": "ok"}
+    assert resp == {"schema": openapi_schema}
     service_mock.assert_called_once_with(user.id, "tenant-10", "https://example.com/")
 
 
 def test_api_provider_list_tools_get(app: Flask, controller_module, monkeypatch: pytest.MonkeyPatch):
     user = _mock_account()
-    service_mock = MagicMock(return_value=[{"tool": "t"}])
+    _set_current_account(monkeypatch, controller_module, user, "tenant-11")
+    service_payload, expected_response = _tool_response(controller_module, "t")
+    service_mock = MagicMock(return_value=[service_payload])
     monkeypatch.setattr(controller_module.ApiToolManageService, "list_api_tool_provider_tools", service_mock)
 
     with app.test_request_context("/tools?provider=foo"):
-        api = controller_module.ToolApiProviderListToolsApi()
-        resp = unwrap(api.get)(api, "tenant-11", user)
+        resp = controller_module.ToolApiProviderListToolsApi().get()
 
-    assert resp == [{"tool": "t"}]
+    assert resp == [expected_response]
     service_mock.assert_called_once_with(user.id, "tenant-11", "foo")
 
 
 def test_api_provider_get(app: Flask, controller_module, monkeypatch: pytest.MonkeyPatch):
     user = _mock_account()
-    service_mock = MagicMock(return_value={"provider": "foo"})
+    _set_current_account(monkeypatch, controller_module, user, "tenant-12")
+    service_payload, expected_response = _api_provider_detail_response(controller_module)
+    service_mock = MagicMock(return_value=service_payload)
     monkeypatch.setattr(controller_module.ApiToolManageService, "get_api_tool_provider", service_mock)
 
     with app.test_request_context("/get?provider=foo"):
-        api = controller_module.ToolApiProviderGetApi()
-        resp = unwrap(api.get)(api, "tenant-12", user)
+        resp = controller_module.ToolApiProviderGetApi().get()
 
-    assert resp == {"provider": "foo"}
+    assert resp == expected_response
     service_mock.assert_called_once_with(user.id, "tenant-12", "foo")
 
 
 def test_builtin_provider_credentials_schema_get(app: Flask, controller_module, monkeypatch: pytest.MonkeyPatch):
     user = _mock_account("user-tenant-13")
-    service_mock = MagicMock(return_value={"schema": True})
+    _set_current_account(monkeypatch, controller_module, user, "tenant-13")
+    service_payload, expected_response = _provider_config_response(controller_module)
+    service_mock = MagicMock(return_value=[service_payload])
     monkeypatch.setattr(
         controller_module.BuiltinToolManageService,
         "list_builtin_provider_credentials_schema",
@@ -264,16 +497,19 @@ def test_builtin_provider_credentials_schema_get(app: Flask, controller_module, 
     )
 
     with app.test_request_context("/schema", method="GET"):
-        api = controller_module.ToolBuiltinProviderCredentialsSchemaApi()
-        resp = unwrap(api.get)(api, "tenant-13", provider="demo", credential_type="api-key")
+        resp = controller_module.ToolBuiltinProviderCredentialsSchemaApi().get(
+            provider="demo", credential_type="api-key"
+        )
 
-    assert resp == {"schema": True}
+    assert resp == [expected_response]
     service_mock.assert_called_once()
 
 
 def test_workflow_provider_get_by_tool(app: Flask, controller_module, monkeypatch: pytest.MonkeyPatch):
     user = _mock_account()
-    tool_service = MagicMock(return_value={"wf": 1})
+    _set_current_account(monkeypatch, controller_module, user, "tenant-wf")
+    service_payload, expected_response = _workflow_detail_response(controller_module)
+    tool_service = MagicMock(return_value=service_payload)
     monkeypatch.setattr(
         controller_module.WorkflowToolManageService,
         "get_workflow_tool_by_tool_id",
@@ -282,16 +518,17 @@ def test_workflow_provider_get_by_tool(app: Flask, controller_module, monkeypatc
 
     tool_id = "00000000-0000-0000-0000-000000000001"
     with app.test_request_context(f"/workflow?workflow_tool_id={tool_id}"):
-        api = controller_module.ToolWorkflowProviderGetApi()
-        resp = unwrap(api.get)(api, "tenant-wf", user)
+        resp = controller_module.ToolWorkflowProviderGetApi().get()
 
-    assert resp == {"wf": 1}
+    assert resp == expected_response
     tool_service.assert_called_once_with(user.id, "tenant-wf", tool_id)
 
 
 def test_workflow_provider_get_by_app(app: Flask, controller_module, monkeypatch: pytest.MonkeyPatch):
     user = _mock_account()
-    service_mock = MagicMock(return_value={"app": 1})
+    _set_current_account(monkeypatch, controller_module, user, "tenant-wf2")
+    service_payload, expected_response = _workflow_detail_response(controller_module)
+    service_mock = MagicMock(return_value=service_payload)
     monkeypatch.setattr(
         controller_module.WorkflowToolManageService,
         "get_workflow_tool_by_app_id",
@@ -300,31 +537,32 @@ def test_workflow_provider_get_by_app(app: Flask, controller_module, monkeypatch
 
     app_id = "00000000-0000-0000-0000-000000000002"
     with app.test_request_context(f"/workflow?workflow_app_id={app_id}"):
-        api = controller_module.ToolWorkflowProviderGetApi()
-        resp = unwrap(api.get)(api, "tenant-wf2", user)
+        resp = controller_module.ToolWorkflowProviderGetApi().get()
 
-    assert resp == {"app": 1}
+    assert resp == expected_response
     service_mock.assert_called_once_with(user.id, "tenant-wf2", app_id)
 
 
 def test_workflow_provider_list_tools(app: Flask, controller_module, monkeypatch: pytest.MonkeyPatch):
     user = _mock_account()
-    service_mock = MagicMock(return_value=[{"id": 1}])
+    _set_current_account(monkeypatch, controller_module, user, "tenant-wf3")
+    service_payload, expected_response = _tool_response(controller_module, "workflow-tool")
+    service_mock = MagicMock(return_value=[service_payload])
     monkeypatch.setattr(controller_module.WorkflowToolManageService, "list_single_workflow_tools", service_mock)
 
     tool_id = "00000000-0000-0000-0000-000000000003"
     with app.test_request_context(f"/workflow/tools?workflow_tool_id={tool_id}"):
-        api = controller_module.ToolWorkflowProviderListToolApi()
-        resp = unwrap(api.get)(api, "tenant-wf3", user)
+        resp = controller_module.ToolWorkflowProviderListToolApi().get()
 
-    assert resp == [{"id": 1}]
+    assert resp == [expected_response]
     service_mock.assert_called_once_with(user.id, "tenant-wf3", tool_id)
 
 
 def test_builtin_tools_list(app: Flask, controller_module, monkeypatch: pytest.MonkeyPatch):
     user = _mock_account()
+    _set_current_account(monkeypatch, controller_module, user, "tenant-bt")
 
-    provider = SimpleNamespace(to_dict=lambda: {"name": "builtin"})
+    provider, expected_response = _provider_entity_response(controller_module, "builtin", "builtin")
     monkeypatch.setattr(
         controller_module.BuiltinToolManageService,
         "list_builtin_tools",
@@ -332,16 +570,16 @@ def test_builtin_tools_list(app: Flask, controller_module, monkeypatch: pytest.M
     )
 
     with app.test_request_context("/tools/builtin"):
-        api = controller_module.ToolBuiltinListApi()
-        resp = unwrap(api.get)(api, "tenant-bt", user)
+        resp = controller_module.ToolBuiltinListApi().get()
 
-    assert resp == [{"name": "builtin"}]
+    assert resp == [expected_response]
 
 
 def test_api_tools_list(app: Flask, controller_module, monkeypatch: pytest.MonkeyPatch):
     user = _mock_account("user-tenant-api")
+    _set_current_account(monkeypatch, controller_module, user, "tenant-api")
 
-    provider = SimpleNamespace(to_dict=lambda: {"name": "api"})
+    provider, expected_response = _provider_entity_response(controller_module, "api", "api")
     monkeypatch.setattr(
         controller_module.ApiToolManageService,
         "list_api_tools",
@@ -349,16 +587,16 @@ def test_api_tools_list(app: Flask, controller_module, monkeypatch: pytest.Monke
     )
 
     with app.test_request_context("/tools/api"):
-        api = controller_module.ToolApiListApi()
-        resp = unwrap(api.get)(api, "tenant-api")
+        resp = controller_module.ToolApiListApi().get()
 
-    assert resp == [{"name": "api"}]
+    assert resp == [expected_response]
 
 
 def test_workflow_tools_list(app: Flask, controller_module, monkeypatch: pytest.MonkeyPatch):
     user = _mock_account()
+    _set_current_account(monkeypatch, controller_module, user, "tenant-wf4")
 
-    provider = SimpleNamespace(to_dict=lambda: {"name": "wf"})
+    provider, expected_response = _provider_entity_response(controller_module, "wf", "workflow")
     monkeypatch.setattr(
         controller_module.WorkflowToolManageService,
         "list_tenant_workflow_tools",
@@ -366,20 +604,21 @@ def test_workflow_tools_list(app: Flask, controller_module, monkeypatch: pytest.
     )
 
     with app.test_request_context("/tools/workflow"):
-        api = controller_module.ToolWorkflowListApi()
-        resp = unwrap(api.get)(api, "tenant-wf4", user)
+        resp = controller_module.ToolWorkflowListApi().get()
 
-    assert resp == [{"name": "wf"}]
+    assert resp == [expected_response]
 
 
 def test_tool_labels_list(app: Flask, controller_module, monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(controller_module.ToolLabelsService, "list_tool_labels", lambda: ["a", "b"])
+    user = _mock_account("user-label")
+    _set_current_account(monkeypatch, controller_module, user, "tenant-labels")
+    service_payload, expected_response = _tool_label_response(controller_module, "a")
+    monkeypatch.setattr(controller_module.ToolLabelsService, "list_tool_labels", lambda: [service_payload])
 
     with app.test_request_context("/tool-labels"):
-        api = controller_module.ToolLabelsApi()
-        resp = unwrap(api.get)(api)
+        resp = controller_module.ToolLabelsApi().get()
 
-    assert resp == ["a", "b"]
+    assert resp == [expected_response]
 
 
 # --- _resolve_identity_mode: gating + None-resolution (PR #36839 review) ---

--- a/api/tests/unit_tests/services/controller_api.py
+++ b/api/tests/unit_tests/services/controller_api.py
@@ -1009,8 +1009,7 @@ class TestExternalDatasetApi:
 # 4. Provide default values when parameters are missing
 # 5. Raise BadRequest exceptions when validation fails
 #
-# Response formatting is handled by Flask-RESTX's marshal_with decorator
-# or marshal function, which:
+# Response formatting is handled by controller response schemas, which:
 #
 # 1. Formats response data according to defined models
 # 2. Handles nested objects and lists

--- a/packages/contracts/generated/api/console/oauth/zod.gen.ts
+++ b/packages/contracts/generated/api/console/oauth/zod.gen.ts
@@ -145,7 +145,7 @@ export const zGetOauthPluginByProviderToolAuthorizationUrlPath = z.object({
 })
 
 /**
- * Authorization URL retrieved successfully
+ * Tool OAuth authorization URL generated successfully
  */
 export const zGetOauthPluginByProviderToolAuthorizationUrlResponse
   = zPluginOAuthAuthorizationUrlResponse

--- a/packages/contracts/generated/api/console/workspaces/types.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/types.gen.ts
@@ -609,16 +609,14 @@ export type WorkspaceAccessMatrix = {
   pagination?: Pagination | null
 }
 
-export type ToolProviderOpaqueResponse = unknown
+export type ToolLabelListResponse = Array<ToolLabel>
 
 export type ApiToolProviderAddPayload = {
   credentials: {
     [key: string]: unknown
   }
   custom_disclaimer?: string
-  icon: {
-    [key: string]: unknown
-  }
+  icon: ToolEmojiIcon
   labels?: Array<string> | null
   privacy_policy?: string | null
   provider: string
@@ -630,8 +628,35 @@ export type ApiToolProviderDeletePayload = {
   provider: string
 }
 
+export type ApiProviderDetailResponse = {
+  credentials?: {
+    [key: string]: unknown
+  }
+  custom_disclaimer?: string | null
+  description?: string | null
+  icon: ToolEmojiIcon
+  labels?: Array<string>
+  privacy_policy?: string | null
+  schema: string
+  schema_type: ApiProviderSchemaType
+  tools: Array<ApiToolBundle>
+}
+
+export type ApiProviderRemoteSchemaResponse = {
+  schema: string
+}
+
 export type ApiToolSchemaPayload = {
   schema: string
+}
+
+export type ApiSchemaParseResponse = {
+  credentials_schema: Array<ProviderConfig>
+  parameters_schema: Array<ApiToolBundle>
+  schema_type: ApiProviderSchemaType
+  warning: {
+    [key: string]: string
+  }
 }
 
 export type ApiToolTestPayload = {
@@ -647,14 +672,16 @@ export type ApiToolTestPayload = {
   tool_name: string
 }
 
+export type ApiToolPreviewResponse = ApiToolPreviewResult
+
+export type ToolApiListResponse = Array<ToolApiEntity>
+
 export type ApiToolProviderUpdatePayload = {
   credentials: {
     [key: string]: unknown
   }
   custom_disclaimer?: string
-  icon: {
-    [key: string]: unknown
-  }
+  icon: ToolEmojiIcon
   labels?: Array<string> | null
   original_provider: string
   privacy_policy?: string | null
@@ -672,6 +699,16 @@ export type BuiltinToolAddPayload = {
   visibility?: string | null
 }
 
+export type ToolProviderCredentialInfoApiEntity = {
+  credentials: Array<ToolProviderCredentialApiEntity>
+  is_oauth_custom_client_enabled?: boolean
+  supported_credential_types: Array<CredentialType>
+}
+
+export type ProviderConfigListResponse = Array<ProviderConfig>
+
+export type ToolProviderCredentialListResponse = Array<ToolProviderCredentialApiEntity>
+
 export type BuiltinProviderDefaultCredentialPayload = {
   id: string
 }
@@ -680,12 +717,56 @@ export type BuiltinToolCredentialDeletePayload = {
   credential_id: string
 }
 
-export type ToolOAuthClientSchemaResponse = Array<{
-  [key: string]: unknown
-}>
+export type ToolProviderApiEntityResponse = {
+  allow_delete?: boolean
+  authentication?: McpAuthentication | null
+  author: string
+  configuration?: McpConfiguration | null
+  description: I18nObject
+  icon:
+    | string
+    | {
+      [key: string]: string
+    }
+  icon_dark?:
+    | string
+    | {
+      [key: string]: string
+    }
+  id: string
+  identity_mode?: string
+  is_dynamic_registration?: boolean
+  is_team_authorization?: boolean
+  label: I18nObject
+  labels?: Array<string>
+  masked_headers?: {
+    [key: string]: string
+  } | null
+  name: string
+  original_headers?: {
+    [key: string]: string
+  } | null
+  plugin_id?: string | null
+  plugin_unique_identifier?: string | null
+  server_identifier?: string | null
+  server_url?: string | null
+  team_credentials?: {
+    [key: string]: unknown
+  }
+  tools?: Array<ToolApiEntity>
+  type: ToolProviderType
+  updated_at?: number
+  workflow_app_id?: string | null
+}
 
-export type ToolOAuthCustomClientResponse = {
-  [key: string]: unknown
+export type BuiltinProviderOAuthClientSchemaResponse = {
+  client_params?: {
+    [key: string]: unknown
+  } | null
+  is_oauth_custom_client_enabled: boolean
+  is_system_oauth_params_exists: boolean
+  redirect_uri: string
+  schema: Array<ProviderConfig>
 }
 
 export type ToolOAuthCustomClientPayload = {
@@ -708,14 +789,10 @@ export type McpProviderDeletePayload = {
 }
 
 export type McpProviderCreatePayload = {
-  authentication?: {
-    [key: string]: unknown
-  } | null
-  configuration?: {
-    [key: string]: unknown
-  } | null
+  authentication?: McpAuthentication | null
+  configuration?: McpConfiguration | null
   headers?: {
-    [key: string]: unknown
+    [key: string]: string
   } | null
   icon: string
   icon_background?: string
@@ -727,14 +804,10 @@ export type McpProviderCreatePayload = {
 }
 
 export type McpProviderUpdatePayload = {
-  authentication?: {
-    [key: string]: unknown
-  } | null
-  configuration?: {
-    [key: string]: unknown
-  } | null
+  authentication?: McpAuthentication | null
+  configuration?: McpConfiguration | null
   headers?: {
-    [key: string]: unknown
+    [key: string]: string
   } | null
   icon: string
   icon_background?: string
@@ -751,11 +824,14 @@ export type McpAuthPayload = {
   provider_id: string
 }
 
+export type McpAuthResponse = {
+  authorization_url?: string | null
+  result?: 'success' | null
+}
+
 export type WorkflowToolCreatePayload = {
   description: string
-  icon: {
-    [key: string]: unknown
-  }
+  icon: ToolEmojiIcon
   label: string
   labels?: Array<string> | null
   name: string
@@ -768,11 +844,25 @@ export type WorkflowToolDeletePayload = {
   workflow_tool_id: string
 }
 
-export type WorkflowToolUpdatePayload = {
+export type WorkflowToolDetailResponse = {
   description: string
-  icon: {
+  icon: ToolEmojiIcon
+  label: string
+  name: string
+  output_schema?: {
     [key: string]: unknown
   }
+  parameters: Array<WorkflowToolParameterConfiguration>
+  privacy_policy?: string | null
+  synced: boolean
+  tool: ToolApiEntity
+  workflow_app_id: string
+  workflow_tool_id: string
+}
+
+export type WorkflowToolUpdatePayload = {
+  description: string
+  icon: ToolEmojiIcon
   label: string
   labels?: Array<string> | null
   name: string
@@ -780,6 +870,8 @@ export type WorkflowToolUpdatePayload = {
   privacy_policy?: string | null
   workflow_tool_id: string
 }
+
+export type ToolProviderListResponse = Array<ToolProviderApiEntityResponse>
 
 export type TriggerProviderApiEntity = {
   author: string
@@ -801,7 +893,7 @@ export type TriggerOAuthClientResponse = {
   configured: boolean
   custom_configured: boolean
   custom_enabled: boolean
-  oauth_client_schema: Array<TriggerProviderConfigResponse>
+  oauth_client_schema: Array<ProviderConfig>
   params: {
     [key: string]: unknown
   }
@@ -828,8 +920,6 @@ export type TriggerSubscriptionBuilderUpdatePayload = {
     [key: string]: unknown
   } | null
 }
-
-export type TriggerProviderOpaqueResponse = unknown
 
 export type TriggerSubscriptionBuilderCreatePayload = {
   credential_type?: string
@@ -866,11 +956,15 @@ export type TriggerSubscriptionBuilderVerifyPayload = {
   }
 }
 
-export type TriggerSubscriptionBuilderVerifyResponse = {
+export type TriggerVerificationResponse = {
   verified: boolean
 }
 
-export type TriggerSubscriptionListResponse = Array<TriggerProviderSubscriptionApiEntity>
+export type TriggerProviderSubscriptionListResponse = Array<TriggerProviderSubscriptionApiEntity>
+
+export type TriggerProviderErrorResponse = {
+  error: string
+}
 
 export type TriggerOAuthAuthorizeResponse = {
   authorization_url: string
@@ -1294,16 +1388,91 @@ export type AccessPolicyRole = {
   role_tag?: string
 }
 
+export type ToolLabel = {
+  icon: string
+  label: I18nObject
+  name: string
+}
+
+export type ToolEmojiIcon = {
+  background: string
+  content: string
+}
+
 export type ApiProviderSchemaType = 'openai_actions' | 'openai_plugin' | 'openapi' | 'swagger'
+
+export type ApiToolBundle = {
+  author: string
+  icon?: string | null
+  method: string
+  openapi: {
+    [key: string]: unknown
+  }
+  operation_id?: string | null
+  output_schema?: {
+    [key: string]: unknown
+  }
+  parameters?: Array<ToolParameter> | null
+  server_url: string
+  summary?: string | null
+}
+
+export type ProviderConfig = {
+  default?: number | string | number | boolean | null
+  help?: I18nObject | null
+  label?: I18nObject | null
+  multiple?: boolean
+  name: string
+  options?: Array<Option> | null
+  placeholder?: I18nObject | null
+  required?: boolean
+  scope?: AppSelectorScope | ModelSelectorScope | ToolSelectorScope | null
+  type: ProviderConfigType
+  url?: string | null
+}
+
+export type ApiToolPreviewResult = {
+  error?: string
+  result?: string
+}
+
+export type ToolApiEntity = {
+  author: string
+  description: I18nObject
+  label: I18nObject
+  labels?: Array<string>
+  name: string
+  output_schema?: {
+    [key: string]: unknown
+  }
+  parameters?: Array<ToolParameter> | null
+}
 
 export type CredentialType = 'api-key' | 'oauth2' | 'unauthorized'
 
-export type IdentityMode = 'idp_token' | 'off'
-
-export type WorkflowToolParameterConfiguration = {
-  description: string
-  form: ToolParameterForm
+export type ToolProviderCredentialApiEntity = {
+  created_by?: string
+  credential_type: CredentialType
+  credentials?: {
+    [key: string]: unknown
+  }
+  from_other_member?: boolean
+  id: string
+  is_default?: boolean
   name: string
+  partial_member_list?: Array<string>
+  provider: string
+  visibility?: string
+}
+
+export type McpAuthentication = {
+  client_id: string
+  client_secret?: string | null
+}
+
+export type McpConfiguration = {
+  sse_read_timeout?: number
+  timeout?: number
 }
 
 export type I18nObject = {
@@ -1311,6 +1480,23 @@ export type I18nObject = {
   ja_JP?: string | null
   pt_BR?: string | null
   zh_Hans?: string | null
+}
+
+export type ToolProviderType
+  = | 'api'
+    | 'app'
+    | 'builtin'
+    | 'dataset-retrieval'
+    | 'mcp'
+    | 'plugin'
+    | 'workflow'
+
+export type IdentityMode = 'idp_token' | 'off'
+
+export type WorkflowToolParameterConfiguration = {
+  description: string
+  form: ToolParameterForm
+  name: string
 }
 
 export type EventApiEntity = {
@@ -1329,42 +1515,7 @@ export type SubscriptionConstructor = {
   parameters?: Array<EventParameter>
 }
 
-export type ProviderConfig = {
-  default?: number | string | number | boolean | null
-  help?: I18nObject | null
-  label?: I18nObject | null
-  multiple?: boolean
-  name: string
-  options?: Array<Option> | null
-  placeholder?: I18nObject | null
-  required?: boolean
-  scope?: AppSelectorScope | ModelSelectorScope | ToolSelectorScope | null
-  type: ProviderConfigType
-  url?: string | null
-}
-
 export type TriggerCreationMethod = 'APIKEY' | 'MANUAL' | 'OAUTH'
-
-export type TriggerProviderConfigResponse = {
-  default?: number | string | number | boolean | null
-  help?: I18nObject | null
-  label?: I18nObject | null
-  multiple?: boolean
-  name: string
-  options?: Array<TriggerProviderConfigOptionResponse> | null
-  placeholder?: I18nObject | null
-  required?: boolean
-  scope?: AppSelectorScope | ModelSelectorScope | ToolSelectorScope | null
-  type:
-    | 'app-selector'
-    | 'array[tools]'
-    | 'boolean'
-    | 'model-selector'
-    | 'secret-input'
-    | 'select'
-    | 'text-input'
-  url?: string | null
-}
 
 export type RequestLog = {
   created_at: string
@@ -1591,15 +1742,6 @@ export type PluginCategoryBuiltinToolResponse = {
   [key: string]: unknown
 }
 
-export type ToolProviderType
-  = | 'api'
-    | 'app'
-    | 'builtin'
-    | 'dataset-retrieval'
-    | 'mcp'
-    | 'plugin'
-    | 'workflow'
-
 export type RbacRoleAccount = {
   account_id: string
   account_name?: string
@@ -1617,6 +1759,64 @@ export type PermissionCatalogItem = {
   key: string
   name: string
 }
+
+export type ToolParameter = {
+  auto_generate?: PluginParameterAutoGenerate | null
+  default?:
+    | number
+    | number
+    | string
+    | boolean
+    | Array<unknown>
+    | {
+      [key: string]: unknown
+    }
+    | null
+  form: ToolParameterForm
+  human_description?: I18nObject | null
+  input_schema?: {
+    [key: string]: unknown
+  } | null
+  label: I18nObject
+  llm_description?: string | null
+  max?: number | number | null
+  min?: number | number | null
+  name: string
+  options?: Array<PluginParameterOption>
+  placeholder?: I18nObject | null
+  precision?: number | null
+  required?: boolean
+  scope?: string | null
+  template?: PluginParameterTemplate | null
+  type: ToolParameterType
+}
+
+export type Option = {
+  label: I18nObject
+  value: string
+}
+
+export type AppSelectorScope = 'all' | 'chat' | 'completion' | 'workflow'
+
+export type ModelSelectorScope
+  = | 'llm'
+    | 'moderation'
+    | 'rerank'
+    | 'speech2text'
+    | 'text-embedding'
+    | 'tts'
+    | 'vision'
+
+export type ToolSelectorScope = 'all' | 'builtin' | 'custom' | 'workflow'
+
+export type ProviderConfigType
+  = | 'app-selector'
+    | 'array[tools]'
+    | 'boolean'
+    | 'model-selector'
+    | 'secret-input'
+    | 'select'
+    | 'text-input'
 
 export type ToolParameterForm = 'form' | 'llm' | 'schema'
 
@@ -1647,38 +1847,6 @@ export type EventParameter = {
 export type OAuthSchema = {
   client_schema?: Array<ProviderConfig>
   credentials_schema?: Array<ProviderConfig>
-}
-
-export type Option = {
-  label: I18nObject
-  value: string
-}
-
-export type AppSelectorScope = 'all' | 'chat' | 'completion' | 'workflow'
-
-export type ModelSelectorScope
-  = | 'llm'
-    | 'moderation'
-    | 'rerank'
-    | 'speech2text'
-    | 'text-embedding'
-    | 'tts'
-    | 'vision'
-
-export type ToolSelectorScope = 'all' | 'builtin' | 'custom' | 'workflow'
-
-export type ProviderConfigType
-  = | 'app-selector'
-    | 'array[tools]'
-    | 'boolean'
-    | 'model-selector'
-    | 'secret-input'
-    | 'select'
-    | 'text-input'
-
-export type TriggerProviderConfigOptionResponse = {
-  label: I18nObject
-  value: string
 }
 
 export type AiModelEntityResponse = {
@@ -1800,6 +1968,23 @@ export type PluginParameterOption = {
 export type PluginParameterTemplate = {
   enabled?: boolean
 }
+
+export type ToolParameterType
+  = | 'any'
+    | 'app-selector'
+    | 'array'
+    | 'boolean'
+    | 'checkbox'
+    | 'dynamic-select'
+    | 'file'
+    | 'files'
+    | 'model-selector'
+    | 'number'
+    | 'object'
+    | 'secret-input'
+    | 'select'
+    | 'string'
+    | 'system-files'
 
 export type EventParameterType
   = | 'app-selector'
@@ -4099,7 +4284,7 @@ export type GetWorkspacesCurrentToolLabelsData = {
 }
 
 export type GetWorkspacesCurrentToolLabelsResponses = {
-  200: ToolProviderOpaqueResponse
+  200: ToolLabelListResponse
 }
 
 export type GetWorkspacesCurrentToolLabelsResponse
@@ -4113,7 +4298,7 @@ export type PostWorkspacesCurrentToolProviderApiAddData = {
 }
 
 export type PostWorkspacesCurrentToolProviderApiAddResponses = {
-  200: ToolProviderOpaqueResponse
+  200: SimpleResultResponse
 }
 
 export type PostWorkspacesCurrentToolProviderApiAddResponse
@@ -4127,7 +4312,7 @@ export type PostWorkspacesCurrentToolProviderApiDeleteData = {
 }
 
 export type PostWorkspacesCurrentToolProviderApiDeleteResponses = {
-  200: ToolProviderOpaqueResponse
+  200: SimpleResultResponse
 }
 
 export type PostWorkspacesCurrentToolProviderApiDeleteResponse
@@ -4143,7 +4328,7 @@ export type GetWorkspacesCurrentToolProviderApiGetData = {
 }
 
 export type GetWorkspacesCurrentToolProviderApiGetResponses = {
-  200: ToolProviderOpaqueResponse
+  200: ApiProviderDetailResponse
 }
 
 export type GetWorkspacesCurrentToolProviderApiGetResponse
@@ -4159,7 +4344,7 @@ export type GetWorkspacesCurrentToolProviderApiRemoteData = {
 }
 
 export type GetWorkspacesCurrentToolProviderApiRemoteResponses = {
-  200: ToolProviderOpaqueResponse
+  200: ApiProviderRemoteSchemaResponse
 }
 
 export type GetWorkspacesCurrentToolProviderApiRemoteResponse
@@ -4173,7 +4358,7 @@ export type PostWorkspacesCurrentToolProviderApiSchemaData = {
 }
 
 export type PostWorkspacesCurrentToolProviderApiSchemaResponses = {
-  200: ToolProviderOpaqueResponse
+  200: ApiSchemaParseResponse
 }
 
 export type PostWorkspacesCurrentToolProviderApiSchemaResponse
@@ -4187,7 +4372,7 @@ export type PostWorkspacesCurrentToolProviderApiTestPreData = {
 }
 
 export type PostWorkspacesCurrentToolProviderApiTestPreResponses = {
-  200: ToolProviderOpaqueResponse
+  200: ApiToolPreviewResponse
 }
 
 export type PostWorkspacesCurrentToolProviderApiTestPreResponse
@@ -4203,7 +4388,7 @@ export type GetWorkspacesCurrentToolProviderApiToolsData = {
 }
 
 export type GetWorkspacesCurrentToolProviderApiToolsResponses = {
-  200: ToolProviderOpaqueResponse
+  200: ToolApiListResponse
 }
 
 export type GetWorkspacesCurrentToolProviderApiToolsResponse
@@ -4217,7 +4402,7 @@ export type PostWorkspacesCurrentToolProviderApiUpdateData = {
 }
 
 export type PostWorkspacesCurrentToolProviderApiUpdateResponses = {
-  200: ToolProviderOpaqueResponse
+  200: SimpleResultResponse
 }
 
 export type PostWorkspacesCurrentToolProviderApiUpdateResponse
@@ -4233,7 +4418,7 @@ export type PostWorkspacesCurrentToolProviderBuiltinByProviderAddData = {
 }
 
 export type PostWorkspacesCurrentToolProviderBuiltinByProviderAddResponses = {
-  200: ToolProviderOpaqueResponse
+  200: SimpleResultResponse
 }
 
 export type PostWorkspacesCurrentToolProviderBuiltinByProviderAddResponse
@@ -4251,7 +4436,7 @@ export type GetWorkspacesCurrentToolProviderBuiltinByProviderCredentialInfoData 
 }
 
 export type GetWorkspacesCurrentToolProviderBuiltinByProviderCredentialInfoResponses = {
-  200: ToolProviderOpaqueResponse
+  200: ToolProviderCredentialInfoApiEntity
 }
 
 export type GetWorkspacesCurrentToolProviderBuiltinByProviderCredentialInfoResponse
@@ -4270,7 +4455,7 @@ export type GetWorkspacesCurrentToolProviderBuiltinByProviderCredentialSchemaByC
 
 export type GetWorkspacesCurrentToolProviderBuiltinByProviderCredentialSchemaByCredentialTypeResponses
   = {
-    200: ToolProviderOpaqueResponse
+    200: ProviderConfigListResponse
   }
 
 export type GetWorkspacesCurrentToolProviderBuiltinByProviderCredentialSchemaByCredentialTypeResponse
@@ -4288,7 +4473,7 @@ export type GetWorkspacesCurrentToolProviderBuiltinByProviderCredentialsData = {
 }
 
 export type GetWorkspacesCurrentToolProviderBuiltinByProviderCredentialsResponses = {
-  200: ToolProviderOpaqueResponse
+  200: ToolProviderCredentialListResponse
 }
 
 export type GetWorkspacesCurrentToolProviderBuiltinByProviderCredentialsResponse
@@ -4304,7 +4489,7 @@ export type PostWorkspacesCurrentToolProviderBuiltinByProviderDefaultCredentialD
 }
 
 export type PostWorkspacesCurrentToolProviderBuiltinByProviderDefaultCredentialResponses = {
-  200: ToolProviderOpaqueResponse
+  200: SimpleResultResponse
 }
 
 export type PostWorkspacesCurrentToolProviderBuiltinByProviderDefaultCredentialResponse
@@ -4320,7 +4505,7 @@ export type PostWorkspacesCurrentToolProviderBuiltinByProviderDeleteData = {
 }
 
 export type PostWorkspacesCurrentToolProviderBuiltinByProviderDeleteResponses = {
-  200: ToolProviderOpaqueResponse
+  200: SimpleResultResponse
 }
 
 export type PostWorkspacesCurrentToolProviderBuiltinByProviderDeleteResponse
@@ -4336,7 +4521,9 @@ export type GetWorkspacesCurrentToolProviderBuiltinByProviderIconData = {
 }
 
 export type GetWorkspacesCurrentToolProviderBuiltinByProviderIconResponses = {
-  200: BinaryFileResponse
+  200: {
+    [key: string]: unknown
+  }
 }
 
 export type GetWorkspacesCurrentToolProviderBuiltinByProviderIconResponse
@@ -4352,7 +4539,7 @@ export type GetWorkspacesCurrentToolProviderBuiltinByProviderInfoData = {
 }
 
 export type GetWorkspacesCurrentToolProviderBuiltinByProviderInfoResponses = {
-  200: ToolProviderOpaqueResponse
+  200: ToolProviderApiEntityResponse
 }
 
 export type GetWorkspacesCurrentToolProviderBuiltinByProviderInfoResponse
@@ -4368,7 +4555,7 @@ export type GetWorkspacesCurrentToolProviderBuiltinByProviderOauthClientSchemaDa
 }
 
 export type GetWorkspacesCurrentToolProviderBuiltinByProviderOauthClientSchemaResponses = {
-  200: ToolOAuthClientSchemaResponse
+  200: BuiltinProviderOAuthClientSchemaResponse
 }
 
 export type GetWorkspacesCurrentToolProviderBuiltinByProviderOauthClientSchemaResponse
@@ -4400,7 +4587,9 @@ export type GetWorkspacesCurrentToolProviderBuiltinByProviderOauthCustomClientDa
 }
 
 export type GetWorkspacesCurrentToolProviderBuiltinByProviderOauthCustomClientResponses = {
-  200: ToolOAuthCustomClientResponse
+  200: {
+    [key: string]: unknown
+  }
 }
 
 export type GetWorkspacesCurrentToolProviderBuiltinByProviderOauthCustomClientResponse
@@ -4432,7 +4621,7 @@ export type GetWorkspacesCurrentToolProviderBuiltinByProviderToolsData = {
 }
 
 export type GetWorkspacesCurrentToolProviderBuiltinByProviderToolsResponses = {
-  200: ToolProviderOpaqueResponse
+  200: ToolApiListResponse
 }
 
 export type GetWorkspacesCurrentToolProviderBuiltinByProviderToolsResponse
@@ -4448,7 +4637,7 @@ export type PostWorkspacesCurrentToolProviderBuiltinByProviderUpdateData = {
 }
 
 export type PostWorkspacesCurrentToolProviderBuiltinByProviderUpdateResponses = {
-  200: ToolProviderOpaqueResponse
+  200: SimpleResultResponse
 }
 
 export type PostWorkspacesCurrentToolProviderBuiltinByProviderUpdateResponse
@@ -4476,7 +4665,7 @@ export type PostWorkspacesCurrentToolProviderMcpData = {
 }
 
 export type PostWorkspacesCurrentToolProviderMcpResponses = {
-  200: ToolProviderOpaqueResponse
+  200: ToolProviderApiEntityResponse
 }
 
 export type PostWorkspacesCurrentToolProviderMcpResponse
@@ -4504,7 +4693,7 @@ export type PostWorkspacesCurrentToolProviderMcpAuthData = {
 }
 
 export type PostWorkspacesCurrentToolProviderMcpAuthResponses = {
-  200: ToolProviderOpaqueResponse
+  200: McpAuthResponse
 }
 
 export type PostWorkspacesCurrentToolProviderMcpAuthResponse
@@ -4520,7 +4709,7 @@ export type GetWorkspacesCurrentToolProviderMcpToolsByProviderIdData = {
 }
 
 export type GetWorkspacesCurrentToolProviderMcpToolsByProviderIdResponses = {
-  200: ToolProviderOpaqueResponse
+  200: ToolProviderApiEntityResponse
 }
 
 export type GetWorkspacesCurrentToolProviderMcpToolsByProviderIdResponse
@@ -4536,7 +4725,7 @@ export type GetWorkspacesCurrentToolProviderMcpUpdateByProviderIdData = {
 }
 
 export type GetWorkspacesCurrentToolProviderMcpUpdateByProviderIdResponses = {
-  200: ToolProviderOpaqueResponse
+  200: ToolProviderApiEntityResponse
 }
 
 export type GetWorkspacesCurrentToolProviderMcpUpdateByProviderIdResponse
@@ -4550,7 +4739,7 @@ export type PostWorkspacesCurrentToolProviderWorkflowCreateData = {
 }
 
 export type PostWorkspacesCurrentToolProviderWorkflowCreateResponses = {
-  200: ToolProviderOpaqueResponse
+  200: SimpleResultResponse
 }
 
 export type PostWorkspacesCurrentToolProviderWorkflowCreateResponse
@@ -4564,7 +4753,7 @@ export type PostWorkspacesCurrentToolProviderWorkflowDeleteData = {
 }
 
 export type PostWorkspacesCurrentToolProviderWorkflowDeleteResponses = {
-  200: ToolProviderOpaqueResponse
+  200: SimpleResultResponse
 }
 
 export type PostWorkspacesCurrentToolProviderWorkflowDeleteResponse
@@ -4581,7 +4770,7 @@ export type GetWorkspacesCurrentToolProviderWorkflowGetData = {
 }
 
 export type GetWorkspacesCurrentToolProviderWorkflowGetResponses = {
-  200: ToolProviderOpaqueResponse
+  200: WorkflowToolDetailResponse
 }
 
 export type GetWorkspacesCurrentToolProviderWorkflowGetResponse
@@ -4597,7 +4786,7 @@ export type GetWorkspacesCurrentToolProviderWorkflowToolsData = {
 }
 
 export type GetWorkspacesCurrentToolProviderWorkflowToolsResponses = {
-  200: ToolProviderOpaqueResponse
+  200: ToolApiListResponse
 }
 
 export type GetWorkspacesCurrentToolProviderWorkflowToolsResponse
@@ -4611,7 +4800,7 @@ export type PostWorkspacesCurrentToolProviderWorkflowUpdateData = {
 }
 
 export type PostWorkspacesCurrentToolProviderWorkflowUpdateResponses = {
-  200: ToolProviderOpaqueResponse
+  200: SimpleResultResponse
 }
 
 export type PostWorkspacesCurrentToolProviderWorkflowUpdateResponse
@@ -4627,7 +4816,7 @@ export type GetWorkspacesCurrentToolProvidersData = {
 }
 
 export type GetWorkspacesCurrentToolProvidersResponses = {
-  200: ToolProviderOpaqueResponse
+  200: ToolProviderListResponse
 }
 
 export type GetWorkspacesCurrentToolProvidersResponse
@@ -4641,7 +4830,7 @@ export type GetWorkspacesCurrentToolsApiData = {
 }
 
 export type GetWorkspacesCurrentToolsApiResponses = {
-  200: ToolProviderOpaqueResponse
+  200: ToolProviderListResponse
 }
 
 export type GetWorkspacesCurrentToolsApiResponse
@@ -4655,7 +4844,7 @@ export type GetWorkspacesCurrentToolsBuiltinData = {
 }
 
 export type GetWorkspacesCurrentToolsBuiltinResponses = {
-  200: ToolProviderOpaqueResponse
+  200: ToolProviderListResponse
 }
 
 export type GetWorkspacesCurrentToolsBuiltinResponse
@@ -4669,7 +4858,7 @@ export type GetWorkspacesCurrentToolsMcpData = {
 }
 
 export type GetWorkspacesCurrentToolsMcpResponses = {
-  200: ToolProviderOpaqueResponse
+  200: ToolProviderListResponse
 }
 
 export type GetWorkspacesCurrentToolsMcpResponse
@@ -4683,7 +4872,7 @@ export type GetWorkspacesCurrentToolsWorkflowData = {
 }
 
 export type GetWorkspacesCurrentToolsWorkflowResponses = {
-  200: ToolProviderOpaqueResponse
+  200: ToolProviderListResponse
 }
 
 export type GetWorkspacesCurrentToolsWorkflowResponse
@@ -4699,7 +4888,9 @@ export type GetWorkspacesCurrentTriggerProviderByProviderIconData = {
 }
 
 export type GetWorkspacesCurrentTriggerProviderByProviderIconResponses = {
-  200: BinaryFileResponse
+  200: {
+    [key: string]: unknown
+  }
 }
 
 export type GetWorkspacesCurrentTriggerProviderByProviderIconResponse
@@ -4782,7 +4973,7 @@ export type PostWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilderBu
 
 export type PostWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilderBuildBySubscriptionBuilderIdResponses
   = {
-    200: TriggerProviderOpaqueResponse
+    200: SimpleResultResponse
   }
 
 export type PostWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilderBuildBySubscriptionBuilderIdResponse
@@ -4855,7 +5046,7 @@ export type PostWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilderVe
 
 export type PostWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilderVerifyAndUpdateBySubscriptionBuilderIdResponses
   = {
-    200: TriggerSubscriptionBuilderVerifyResponse
+    200: TriggerVerificationResponse
   }
 
 export type PostWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilderVerifyAndUpdateBySubscriptionBuilderIdResponse
@@ -4889,8 +5080,15 @@ export type GetWorkspacesCurrentTriggerProviderByProviderSubscriptionsListData =
   url: '/workspaces/current/trigger-provider/{provider}/subscriptions/list'
 }
 
+export type GetWorkspacesCurrentTriggerProviderByProviderSubscriptionsListErrors = {
+  404: TriggerProviderErrorResponse
+}
+
+export type GetWorkspacesCurrentTriggerProviderByProviderSubscriptionsListError
+  = GetWorkspacesCurrentTriggerProviderByProviderSubscriptionsListErrors[keyof GetWorkspacesCurrentTriggerProviderByProviderSubscriptionsListErrors]
+
 export type GetWorkspacesCurrentTriggerProviderByProviderSubscriptionsListResponses = {
-  200: TriggerSubscriptionListResponse
+  200: TriggerProviderSubscriptionListResponse
 }
 
 export type GetWorkspacesCurrentTriggerProviderByProviderSubscriptionsListResponse
@@ -4925,7 +5123,7 @@ export type PostWorkspacesCurrentTriggerProviderByProviderSubscriptionsVerifyByS
 
 export type PostWorkspacesCurrentTriggerProviderByProviderSubscriptionsVerifyBySubscriptionIdResponses
   = {
-    200: TriggerSubscriptionBuilderVerifyResponse
+    200: TriggerVerificationResponse
   }
 
 export type PostWorkspacesCurrentTriggerProviderByProviderSubscriptionsVerifyBySubscriptionIdResponse
@@ -4957,7 +5155,7 @@ export type PostWorkspacesCurrentTriggerProviderBySubscriptionIdSubscriptionsUpd
 }
 
 export type PostWorkspacesCurrentTriggerProviderBySubscriptionIdSubscriptionsUpdateResponses = {
-  200: TriggerProviderOpaqueResponse
+  200: SimpleResultResponse
 }
 
 export type PostWorkspacesCurrentTriggerProviderBySubscriptionIdSubscriptionsUpdateResponse

--- a/packages/contracts/generated/api/console/workspaces/zod.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/zod.gen.ts
@@ -474,15 +474,17 @@ export const zReplaceBindingsRequest = z.object({
 })
 
 /**
- * ToolProviderOpaqueResponse
- */
-export const zToolProviderOpaqueResponse = z.unknown()
-
-/**
  * ApiToolProviderDeletePayload
  */
 export const zApiToolProviderDeletePayload = z.object({
   provider: z.string(),
+})
+
+/**
+ * ApiProviderRemoteSchemaResponse
+ */
+export const zApiProviderRemoteSchemaResponse = z.object({
+  schema: z.string(),
 })
 
 /**
@@ -505,16 +507,6 @@ export const zBuiltinProviderDefaultCredentialPayload = z.object({
 export const zBuiltinToolCredentialDeletePayload = z.object({
   credential_id: z.string(),
 })
-
-/**
- * ToolOAuthClientSchemaResponse
- */
-export const zToolOAuthClientSchemaResponse = z.array(z.record(z.string(), z.unknown()))
-
-/**
- * ToolOAuthCustomClientResponse
- */
-export const zToolOAuthCustomClientResponse = z.record(z.string(), z.unknown())
 
 /**
  * ToolOAuthCustomClientPayload
@@ -549,6 +541,14 @@ export const zMcpAuthPayload = z.object({
 })
 
 /**
+ * MCPAuthResponse
+ */
+export const zMcpAuthResponse = z.object({
+  authorization_url: z.string().nullish(),
+  result: z.literal('success').nullish(),
+})
+
+/**
  * WorkflowToolDeletePayload
  */
 export const zWorkflowToolDeletePayload = z.object({
@@ -574,11 +574,6 @@ export const zTriggerSubscriptionBuilderUpdatePayload = z.object({
 })
 
 /**
- * TriggerProviderOpaqueResponse
- */
-export const zTriggerProviderOpaqueResponse = z.unknown()
-
-/**
  * TriggerSubscriptionBuilderCreatePayload
  */
 export const zTriggerSubscriptionBuilderCreatePayload = z.object({
@@ -593,10 +588,17 @@ export const zTriggerSubscriptionBuilderVerifyPayload = z.object({
 })
 
 /**
- * TriggerSubscriptionBuilderVerifyResponse
+ * TriggerVerificationResponse
  */
-export const zTriggerSubscriptionBuilderVerifyResponse = z.object({
+export const zTriggerVerificationResponse = z.object({
   verified: z.boolean(),
+})
+
+/**
+ * TriggerProviderErrorResponse
+ */
+export const zTriggerProviderErrorResponse = z.object({
+  error: z.string(),
 })
 
 /**
@@ -1250,6 +1252,14 @@ export const zWorkspaceAccessMatrix = z.object({
 })
 
 /**
+ * ToolEmojiIcon
+ */
+export const zToolEmojiIcon = z.object({
+  background: z.string(),
+  content: z.string(),
+})
+
+/**
  * ApiProviderSchemaType
  *
  * Enum class for api provider schema type.
@@ -1267,7 +1277,7 @@ export const zApiProviderSchemaType = z.enum([
 export const zApiToolProviderAddPayload = z.object({
   credentials: z.record(z.string(), z.unknown()),
   custom_disclaimer: z.string().optional().default(''),
-  icon: z.record(z.string(), z.unknown()),
+  icon: zToolEmojiIcon,
   labels: z.array(z.string()).nullish(),
   privacy_policy: z.string().nullish(),
   provider: z.string(),
@@ -1293,7 +1303,7 @@ export const zApiToolTestPayload = z.object({
 export const zApiToolProviderUpdatePayload = z.object({
   credentials: z.record(z.string(), z.unknown()),
   custom_disclaimer: z.string().optional().default(''),
-  icon: z.record(z.string(), z.unknown()),
+  icon: zToolEmojiIcon,
   labels: z.array(z.string()).nullish(),
   original_provider: z.string(),
   privacy_policy: z.string().nullish(),
@@ -1301,6 +1311,19 @@ export const zApiToolProviderUpdatePayload = z.object({
   schema: z.string(),
   schema_type: zApiProviderSchemaType,
 })
+
+/**
+ * ApiToolPreviewResult
+ */
+export const zApiToolPreviewResult = z.object({
+  error: z.string().optional(),
+  result: z.string().optional(),
+})
+
+/**
+ * ApiToolPreviewResponse
+ */
+export const zApiToolPreviewResponse = zApiToolPreviewResult
 
 /**
  * CredentialType
@@ -1348,6 +1371,95 @@ export const zTriggerOAuthAuthorizeResponse = z.object({
 })
 
 /**
+ * ToolProviderCredentialApiEntity
+ */
+export const zToolProviderCredentialApiEntity = z.object({
+  created_by: z.string().optional().default(''),
+  credential_type: zCredentialType,
+  credentials: z.record(z.string(), z.unknown()).optional(),
+  from_other_member: z.boolean().optional().default(false),
+  id: z.string(),
+  is_default: z.boolean().optional().default(false),
+  name: z.string(),
+  partial_member_list: z.array(z.string()).optional(),
+  provider: z.string(),
+  visibility: z.string().optional().default('all_team_members'),
+})
+
+/**
+ * ToolProviderCredentialInfoApiEntity
+ */
+export const zToolProviderCredentialInfoApiEntity = z.object({
+  credentials: z.array(zToolProviderCredentialApiEntity),
+  is_oauth_custom_client_enabled: z.boolean().optional().default(false),
+  supported_credential_types: z.array(zCredentialType),
+})
+
+/**
+ * ToolProviderCredentialListResponse
+ */
+export const zToolProviderCredentialListResponse = z.array(zToolProviderCredentialApiEntity)
+
+/**
+ * MCPAuthentication
+ */
+export const zMcpAuthentication = z.object({
+  client_id: z.string(),
+  client_secret: z.string().nullish(),
+})
+
+/**
+ * MCPConfiguration
+ */
+export const zMcpConfiguration = z.object({
+  sse_read_timeout: z.number().optional().default(300),
+  timeout: z.number().optional().default(30),
+})
+
+/**
+ * I18nObject
+ *
+ * Model class for i18n object.
+ */
+export const zI18nObject = z.object({
+  en_US: z.string(),
+  ja_JP: z.string().nullish(),
+  pt_BR: z.string().nullish(),
+  zh_Hans: z.string().nullish(),
+})
+
+/**
+ * ToolLabel
+ *
+ * Tool label
+ */
+export const zToolLabel = z.object({
+  icon: z.string(),
+  label: zI18nObject,
+  name: z.string(),
+})
+
+/**
+ * ToolLabelListResponse
+ */
+export const zToolLabelListResponse = z.array(zToolLabel)
+
+/**
+ * ToolProviderType
+ *
+ * Enum class for tool provider
+ */
+export const zToolProviderType = z.enum([
+  'api',
+  'app',
+  'builtin',
+  'dataset-retrieval',
+  'mcp',
+  'plugin',
+  'workflow',
+])
+
+/**
  * IdentityMode
  *
  * How Dify forwards the end-user's identity to an MCP server.
@@ -1358,9 +1470,9 @@ export const zIdentityMode = z.enum(['idp_token', 'off'])
  * MCPProviderCreatePayload
  */
 export const zMcpProviderCreatePayload = z.object({
-  authentication: z.record(z.string(), z.unknown()).nullish(),
-  configuration: z.record(z.string(), z.unknown()).nullish(),
-  headers: z.record(z.string(), z.unknown()).nullish(),
+  authentication: zMcpAuthentication.nullish(),
+  configuration: zMcpConfiguration.nullish(),
+  headers: z.record(z.string(), z.string()).nullish(),
   icon: z.string(),
   icon_background: z.string().optional().default(''),
   icon_type: z.string(),
@@ -1374,9 +1486,9 @@ export const zMcpProviderCreatePayload = z.object({
  * MCPProviderUpdatePayload
  */
 export const zMcpProviderUpdatePayload = z.object({
-  authentication: z.record(z.string(), z.unknown()).nullish(),
-  configuration: z.record(z.string(), z.unknown()).nullish(),
-  headers: z.record(z.string(), z.unknown()).nullish(),
+  authentication: zMcpAuthentication.nullish(),
+  configuration: zMcpConfiguration.nullish(),
+  headers: z.record(z.string(), z.string()).nullish(),
   icon: z.string(),
   icon_background: z.string().optional().default(''),
   icon_type: z.string(),
@@ -1385,18 +1497,6 @@ export const zMcpProviderUpdatePayload = z.object({
   provider_id: z.string(),
   server_identifier: z.string(),
   server_url: z.string(),
-})
-
-/**
- * I18nObject
- *
- * Model class for i18n object.
- */
-export const zI18nObject = z.object({
-  en_US: z.string(),
-  ja_JP: z.string().nullish(),
-  pt_BR: z.string().nullish(),
-  zh_Hans: z.string().nullish(),
 })
 
 /**
@@ -1438,9 +1538,11 @@ export const zTriggerProviderSubscriptionApiEntity = z.object({
 })
 
 /**
- * TriggerSubscriptionListResponse
+ * TriggerProviderSubscriptionListResponse
  */
-export const zTriggerSubscriptionListResponse = z.array(zTriggerProviderSubscriptionApiEntity)
+export const zTriggerProviderSubscriptionListResponse = z.array(
+  zTriggerProviderSubscriptionApiEntity,
+)
 
 /**
  * PluginDependencyType
@@ -1738,21 +1840,6 @@ export const zPluginCategoryBuiltinToolResponse = z.object({
 })
 
 /**
- * ToolProviderType
- *
- * Enum class for tool provider
- */
-export const zToolProviderType = z.enum([
-  'api',
-  'app',
-  'builtin',
-  'dataset-retrieval',
-  'mcp',
-  'plugin',
-  'workflow',
-])
-
-/**
  * PluginCategoryBuiltinToolProviderResponse
  */
 export const zPluginCategoryBuiltinToolProviderResponse = z.object({
@@ -1852,62 +1939,6 @@ export const zPermissionCatalogResponse = z.object({
 })
 
 /**
- * ToolParameterForm
- */
-export const zToolParameterForm = z.enum(['form', 'llm', 'schema'])
-
-/**
- * WorkflowToolParameterConfiguration
- *
- * Workflow tool configuration
- */
-export const zWorkflowToolParameterConfiguration = z.object({
-  description: z.string(),
-  form: zToolParameterForm,
-  name: z.string(),
-})
-
-/**
- * WorkflowToolCreatePayload
- */
-export const zWorkflowToolCreatePayload = z.object({
-  description: z.string(),
-  icon: z.record(z.string(), z.unknown()),
-  label: z.string(),
-  labels: z.array(z.string()).nullish(),
-  name: z.string(),
-  parameters: z.array(zWorkflowToolParameterConfiguration).optional(),
-  privacy_policy: z.string().nullish().default(''),
-  workflow_app_id: z.string(),
-})
-
-/**
- * WorkflowToolUpdatePayload
- */
-export const zWorkflowToolUpdatePayload = z.object({
-  description: z.string(),
-  icon: z.record(z.string(), z.unknown()),
-  label: z.string(),
-  labels: z.array(z.string()).nullish(),
-  name: z.string(),
-  parameters: z.array(zWorkflowToolParameterConfiguration).optional(),
-  privacy_policy: z.string().nullish().default(''),
-  workflow_tool_id: z.string(),
-})
-
-/**
- * EventIdentity
- *
- * The identity of the event
- */
-export const zEventIdentity = z.object({
-  author: z.string(),
-  label: zI18nObject,
-  name: z.string(),
-  provider: z.string().nullish(),
-})
-
-/**
  * Option
  */
 export const zOption = z.object({
@@ -1971,46 +2002,19 @@ export const zProviderConfig = z.object({
 })
 
 /**
- * OAuthSchema
- *
- * OAuth schema
+ * ProviderConfigListResponse
  */
-export const zOAuthSchema = z.object({
-  client_schema: z.array(zProviderConfig).optional(),
-  credentials_schema: z.array(zProviderConfig).optional(),
-})
+export const zProviderConfigListResponse = z.array(zProviderConfig)
 
 /**
- * TriggerProviderConfigOptionResponse
+ * BuiltinProviderOAuthClientSchemaResponse
  */
-export const zTriggerProviderConfigOptionResponse = z.object({
-  label: zI18nObject,
-  value: z.string(),
-})
-
-/**
- * TriggerProviderConfigResponse
- */
-export const zTriggerProviderConfigResponse = z.object({
-  default: z.union([z.int(), z.string(), z.number(), z.boolean()]).nullish(),
-  help: zI18nObject.nullish(),
-  label: zI18nObject.nullish(),
-  multiple: z.boolean().optional().default(false),
-  name: z.string(),
-  options: z.array(zTriggerProviderConfigOptionResponse).nullish(),
-  placeholder: zI18nObject.nullish(),
-  required: z.boolean().optional().default(false),
-  scope: z.union([zAppSelectorScope, zModelSelectorScope, zToolSelectorScope]).nullish(),
-  type: z.enum([
-    'app-selector',
-    'array[tools]',
-    'boolean',
-    'model-selector',
-    'secret-input',
-    'select',
-    'text-input',
-  ]),
-  url: z.string().nullish(),
+export const zBuiltinProviderOAuthClientSchemaResponse = z.object({
+  client_params: z.record(z.string(), z.unknown()).nullish(),
+  is_oauth_custom_client_enabled: z.boolean(),
+  is_system_oauth_params_exists: z.boolean(),
+  redirect_uri: z.string(),
+  schema: z.array(zProviderConfig),
 })
 
 /**
@@ -2020,10 +2024,76 @@ export const zTriggerOAuthClientResponse = z.object({
   configured: z.boolean(),
   custom_configured: z.boolean(),
   custom_enabled: z.boolean(),
-  oauth_client_schema: z.array(zTriggerProviderConfigResponse),
+  oauth_client_schema: z.array(zProviderConfig),
   params: z.record(z.string(), z.unknown()),
   redirect_uri: z.string(),
   system_configured: z.boolean(),
+})
+
+/**
+ * ToolParameterForm
+ */
+export const zToolParameterForm = z.enum(['form', 'llm', 'schema'])
+
+/**
+ * WorkflowToolParameterConfiguration
+ *
+ * Workflow tool configuration
+ */
+export const zWorkflowToolParameterConfiguration = z.object({
+  description: z.string(),
+  form: zToolParameterForm,
+  name: z.string(),
+})
+
+/**
+ * WorkflowToolCreatePayload
+ */
+export const zWorkflowToolCreatePayload = z.object({
+  description: z.string(),
+  icon: zToolEmojiIcon,
+  label: z.string(),
+  labels: z.array(z.string()).nullish(),
+  name: z.string(),
+  parameters: z.array(zWorkflowToolParameterConfiguration).optional(),
+  privacy_policy: z.string().nullish().default(''),
+  workflow_app_id: z.string(),
+})
+
+/**
+ * WorkflowToolUpdatePayload
+ */
+export const zWorkflowToolUpdatePayload = z.object({
+  description: z.string(),
+  icon: zToolEmojiIcon,
+  label: z.string(),
+  labels: z.array(z.string()).nullish(),
+  name: z.string(),
+  parameters: z.array(zWorkflowToolParameterConfiguration).optional(),
+  privacy_policy: z.string().nullish().default(''),
+  workflow_tool_id: z.string(),
+})
+
+/**
+ * EventIdentity
+ *
+ * The identity of the event
+ */
+export const zEventIdentity = z.object({
+  author: z.string(),
+  label: zI18nObject,
+  name: z.string(),
+  provider: z.string().nullish(),
+})
+
+/**
+ * OAuthSchema
+ *
+ * OAuth schema
+ */
+export const zOAuthSchema = z.object({
+  client_schema: z.array(zProviderConfig).optional(),
+  credentials_schema: z.array(zProviderConfig).optional(),
 })
 
 /**
@@ -2114,6 +2184,29 @@ export const zPluginParameterOption = z.object({
 export const zPluginParameterTemplate = z.object({
   enabled: z.boolean().optional().default(false),
 })
+
+/**
+ * ToolParameterType
+ *
+ * removes TOOLS_SELECTOR from PluginParameterType
+ */
+export const zToolParameterType = z.enum([
+  'any',
+  'app-selector',
+  'array',
+  'boolean',
+  'checkbox',
+  'dynamic-select',
+  'file',
+  'files',
+  'model-selector',
+  'number',
+  'object',
+  'secret-input',
+  'select',
+  'string',
+  'system-files',
+])
 
 /**
  * EventParameterType
@@ -2563,6 +2656,157 @@ export const zPluginParameterAutoGenerateType = z.enum(['prompt_instruction'])
 export const zPluginParameterAutoGenerate = z.object({
   type: zPluginParameterAutoGenerateType,
 })
+
+/**
+ * ToolParameter
+ *
+ * Overrides type
+ */
+export const zToolParameter = z.object({
+  auto_generate: zPluginParameterAutoGenerate.nullish(),
+  default: z
+    .union([
+      z.number(),
+      z.int(),
+      z.string(),
+      z.boolean(),
+      z.array(z.unknown()),
+      z.record(z.string(), z.unknown()),
+    ])
+    .nullish(),
+  form: zToolParameterForm,
+  human_description: zI18nObject.nullish(),
+  input_schema: z.record(z.string(), z.unknown()).nullish(),
+  label: zI18nObject,
+  llm_description: z.string().nullish(),
+  max: z.union([z.number(), z.int()]).nullish(),
+  min: z.union([z.number(), z.int()]).nullish(),
+  name: z.string(),
+  options: z.array(zPluginParameterOption).optional(),
+  placeholder: zI18nObject.nullish(),
+  precision: z.int().nullish(),
+  required: z.boolean().optional().default(false),
+  scope: z.string().nullish(),
+  template: zPluginParameterTemplate.nullish(),
+  type: zToolParameterType,
+})
+
+/**
+ * ApiToolBundle
+ *
+ * This class is used to store the schema information of an api based tool.
+ * such as the url, the method, the parameters, etc.
+ */
+export const zApiToolBundle = z.object({
+  author: z.string(),
+  icon: z.string().nullish(),
+  method: z.string(),
+  openapi: z.record(z.string(), z.unknown()),
+  operation_id: z.string().nullish(),
+  output_schema: z.record(z.string(), z.unknown()).optional(),
+  parameters: z.array(zToolParameter).nullish(),
+  server_url: z.string(),
+  summary: z.string().nullish(),
+})
+
+/**
+ * ApiProviderDetailResponse
+ */
+export const zApiProviderDetailResponse = z.object({
+  credentials: z.record(z.string(), z.unknown()).optional(),
+  custom_disclaimer: z.string().nullish(),
+  description: z.string().nullish(),
+  icon: zToolEmojiIcon,
+  labels: z.array(z.string()).optional(),
+  privacy_policy: z.string().nullish(),
+  schema: z.string(),
+  schema_type: zApiProviderSchemaType,
+  tools: z.array(zApiToolBundle),
+})
+
+/**
+ * ApiSchemaParseResponse
+ */
+export const zApiSchemaParseResponse = z.object({
+  credentials_schema: z.array(zProviderConfig),
+  parameters_schema: z.array(zApiToolBundle),
+  schema_type: zApiProviderSchemaType,
+  warning: z.record(z.string(), z.string()),
+})
+
+/**
+ * ToolApiEntity
+ */
+export const zToolApiEntity = z.object({
+  author: z.string(),
+  description: zI18nObject,
+  label: zI18nObject,
+  labels: z.array(z.string()).optional(),
+  name: z.string(),
+  output_schema: z.record(z.string(), z.unknown()).optional(),
+  parameters: z.array(zToolParameter).nullish(),
+})
+
+/**
+ * ToolApiListResponse
+ */
+export const zToolApiListResponse = z.array(zToolApiEntity)
+
+/**
+ * ToolProviderApiEntityResponse
+ */
+export const zToolProviderApiEntityResponse = z.object({
+  allow_delete: z.boolean().optional().default(true),
+  authentication: zMcpAuthentication.nullish(),
+  author: z.string(),
+  configuration: zMcpConfiguration.nullish(),
+  description: zI18nObject,
+  icon: z.union([z.string(), z.record(z.string(), z.string())]),
+  icon_dark: z
+    .union([z.string(), z.record(z.string(), z.string())])
+    .optional()
+    .default(''),
+  id: z.string(),
+  identity_mode: z.string().optional().default('off'),
+  is_dynamic_registration: z.boolean().optional().default(true),
+  is_team_authorization: z.boolean().optional().default(false),
+  label: zI18nObject,
+  labels: z.array(z.string()).optional(),
+  masked_headers: z.record(z.string(), z.string()).nullish(),
+  name: z.string(),
+  original_headers: z.record(z.string(), z.string()).nullish(),
+  plugin_id: z.string().nullish().default(''),
+  plugin_unique_identifier: z.string().nullish().default(''),
+  server_identifier: z.string().nullish().default(''),
+  server_url: z.string().nullish().default(''),
+  team_credentials: z.record(z.string(), z.unknown()).optional(),
+  tools: z.array(zToolApiEntity).optional(),
+  type: zToolProviderType,
+  updated_at: z.int().optional(),
+  workflow_app_id: z.string().nullish(),
+})
+
+/**
+ * WorkflowToolDetailResponse
+ */
+export const zWorkflowToolDetailResponse = z.object({
+  description: z.string(),
+  icon: zToolEmojiIcon,
+  label: z.string(),
+  name: z.string(),
+  output_schema: z.record(z.string(), z.unknown()).optional(),
+  parameters: z.array(zWorkflowToolParameterConfiguration),
+  privacy_policy: z.string().nullish(),
+  synced: z.boolean(),
+  tool: zToolApiEntity,
+  workflow_app_id: z.string(),
+  workflow_tool_id: z.string(),
+})
+
+/**
+ * ToolProviderListResponse
+ */
+export const zToolProviderListResponse = z.array(zToolProviderApiEntityResponse)
 
 /**
  * EventParameter
@@ -3948,71 +4192,71 @@ export const zGetWorkspacesCurrentRbacWorkspaceDatasetsAccessPoliciesByPolicyIdR
 export const zGetWorkspacesCurrentRbacWorkspaceDatasetsAccessPolicyResponse = zWorkspaceAccessMatrix
 
 /**
- * Success
+ * Tool labels retrieved successfully
  */
-export const zGetWorkspacesCurrentToolLabelsResponse = zToolProviderOpaqueResponse
+export const zGetWorkspacesCurrentToolLabelsResponse = zToolLabelListResponse
 
 export const zPostWorkspacesCurrentToolProviderApiAddBody = zApiToolProviderAddPayload
 
 /**
- * Success
+ * API provider added successfully
  */
-export const zPostWorkspacesCurrentToolProviderApiAddResponse = zToolProviderOpaqueResponse
+export const zPostWorkspacesCurrentToolProviderApiAddResponse = zSimpleResultResponse
 
 export const zPostWorkspacesCurrentToolProviderApiDeleteBody = zApiToolProviderDeletePayload
 
 /**
- * Success
+ * API provider deleted successfully
  */
-export const zPostWorkspacesCurrentToolProviderApiDeleteResponse = zToolProviderOpaqueResponse
+export const zPostWorkspacesCurrentToolProviderApiDeleteResponse = zSimpleResultResponse
 
 export const zGetWorkspacesCurrentToolProviderApiGetQuery = z.object({
   provider: z.string(),
 })
 
 /**
- * Success
+ * API provider retrieved successfully
  */
-export const zGetWorkspacesCurrentToolProviderApiGetResponse = zToolProviderOpaqueResponse
+export const zGetWorkspacesCurrentToolProviderApiGetResponse = zApiProviderDetailResponse
 
 export const zGetWorkspacesCurrentToolProviderApiRemoteQuery = z.object({
   url: z.url().min(1).max(2083),
 })
 
 /**
- * Success
+ * Remote API provider schema retrieved successfully
  */
-export const zGetWorkspacesCurrentToolProviderApiRemoteResponse = zToolProviderOpaqueResponse
+export const zGetWorkspacesCurrentToolProviderApiRemoteResponse = zApiProviderRemoteSchemaResponse
 
 export const zPostWorkspacesCurrentToolProviderApiSchemaBody = zApiToolSchemaPayload
 
 /**
- * Success
+ * API schema parsed successfully
  */
-export const zPostWorkspacesCurrentToolProviderApiSchemaResponse = zToolProviderOpaqueResponse
+export const zPostWorkspacesCurrentToolProviderApiSchemaResponse = zApiSchemaParseResponse
 
 export const zPostWorkspacesCurrentToolProviderApiTestPreBody = zApiToolTestPayload
 
 /**
- * Success
+ * API tool test preview completed successfully
  */
-export const zPostWorkspacesCurrentToolProviderApiTestPreResponse = zToolProviderOpaqueResponse
+export const zPostWorkspacesCurrentToolProviderApiTestPreResponse = zApiToolPreviewResponse
 
 export const zGetWorkspacesCurrentToolProviderApiToolsQuery = z.object({
   provider: z.string(),
 })
 
 /**
- * Success
+ * API provider tools retrieved successfully
  */
-export const zGetWorkspacesCurrentToolProviderApiToolsResponse = zToolProviderOpaqueResponse
+export const zGetWorkspacesCurrentToolProviderApiToolsResponse = zToolApiListResponse
 
 export const zPostWorkspacesCurrentToolProviderApiUpdateBody = zApiToolProviderUpdatePayload
 
 /**
- * Success
+ * API provider updated successfully
  */
-export const zPostWorkspacesCurrentToolProviderApiUpdateResponse = zToolProviderOpaqueResponse
+export const zPostWorkspacesCurrentToolProviderApiUpdateResponse = zSimpleResultResponse
 
 export const zPostWorkspacesCurrentToolProviderBuiltinByProviderAddBody = zBuiltinToolAddPayload
 
@@ -4021,10 +4265,9 @@ export const zPostWorkspacesCurrentToolProviderBuiltinByProviderAddPath = z.obje
 })
 
 /**
- * Success
+ * Builtin provider added successfully
  */
-export const zPostWorkspacesCurrentToolProviderBuiltinByProviderAddResponse
-  = zToolProviderOpaqueResponse
+export const zPostWorkspacesCurrentToolProviderBuiltinByProviderAddResponse = zSimpleResultResponse
 
 export const zGetWorkspacesCurrentToolProviderBuiltinByProviderCredentialInfoPath = z.object({
   provider: z.string(),
@@ -4035,10 +4278,10 @@ export const zGetWorkspacesCurrentToolProviderBuiltinByProviderCredentialInfoQue
 })
 
 /**
- * Success
+ * Builtin provider credential info retrieved successfully
  */
 export const zGetWorkspacesCurrentToolProviderBuiltinByProviderCredentialInfoResponse
-  = zToolProviderOpaqueResponse
+  = zToolProviderCredentialInfoApiEntity
 
 export const zGetWorkspacesCurrentToolProviderBuiltinByProviderCredentialSchemaByCredentialTypePath
   = z.object({
@@ -4047,10 +4290,10 @@ export const zGetWorkspacesCurrentToolProviderBuiltinByProviderCredentialSchemaB
   })
 
 /**
- * Success
+ * Builtin provider credential schema retrieved successfully
  */
 export const zGetWorkspacesCurrentToolProviderBuiltinByProviderCredentialSchemaByCredentialTypeResponse
-  = zToolProviderOpaqueResponse
+  = zProviderConfigListResponse
 
 export const zGetWorkspacesCurrentToolProviderBuiltinByProviderCredentialsPath = z.object({
   provider: z.string(),
@@ -4061,10 +4304,10 @@ export const zGetWorkspacesCurrentToolProviderBuiltinByProviderCredentialsQuery 
 })
 
 /**
- * Success
+ * Builtin provider credentials retrieved successfully
  */
 export const zGetWorkspacesCurrentToolProviderBuiltinByProviderCredentialsResponse
-  = zToolProviderOpaqueResponse
+  = zToolProviderCredentialListResponse
 
 export const zPostWorkspacesCurrentToolProviderBuiltinByProviderDefaultCredentialBody
   = zBuiltinProviderDefaultCredentialPayload
@@ -4074,10 +4317,10 @@ export const zPostWorkspacesCurrentToolProviderBuiltinByProviderDefaultCredentia
 })
 
 /**
- * Success
+ * Default credential set successfully
  */
 export const zPostWorkspacesCurrentToolProviderBuiltinByProviderDefaultCredentialResponse
-  = zToolProviderOpaqueResponse
+  = zSimpleResultResponse
 
 export const zPostWorkspacesCurrentToolProviderBuiltinByProviderDeleteBody
   = zBuiltinToolCredentialDeletePayload
@@ -4087,46 +4330,49 @@ export const zPostWorkspacesCurrentToolProviderBuiltinByProviderDeletePath = z.o
 })
 
 /**
- * Success
+ * Builtin provider credential deleted successfully
  */
 export const zPostWorkspacesCurrentToolProviderBuiltinByProviderDeleteResponse
-  = zToolProviderOpaqueResponse
+  = zSimpleResultResponse
 
 export const zGetWorkspacesCurrentToolProviderBuiltinByProviderIconPath = z.object({
   provider: z.string(),
 })
 
 /**
- * Success
+ * Builtin provider icon
  */
-export const zGetWorkspacesCurrentToolProviderBuiltinByProviderIconResponse = zBinaryFileResponse
+export const zGetWorkspacesCurrentToolProviderBuiltinByProviderIconResponse = z.record(
+  z.string(),
+  z.unknown(),
+)
 
 export const zGetWorkspacesCurrentToolProviderBuiltinByProviderInfoPath = z.object({
   provider: z.string(),
 })
 
 /**
- * Success
+ * Builtin provider info retrieved successfully
  */
 export const zGetWorkspacesCurrentToolProviderBuiltinByProviderInfoResponse
-  = zToolProviderOpaqueResponse
+  = zToolProviderApiEntityResponse
 
 export const zGetWorkspacesCurrentToolProviderBuiltinByProviderOauthClientSchemaPath = z.object({
   provider: z.string(),
 })
 
 /**
- * Success
+ * Builtin provider OAuth client schema retrieved successfully
  */
 export const zGetWorkspacesCurrentToolProviderBuiltinByProviderOauthClientSchemaResponse
-  = zToolOAuthClientSchemaResponse
+  = zBuiltinProviderOAuthClientSchemaResponse
 
 export const zDeleteWorkspacesCurrentToolProviderBuiltinByProviderOauthCustomClientPath = z.object({
   provider: z.string(),
 })
 
 /**
- * Success
+ * Custom OAuth client deleted successfully
  */
 export const zDeleteWorkspacesCurrentToolProviderBuiltinByProviderOauthCustomClientResponse
   = zSimpleResultResponse
@@ -4136,10 +4382,12 @@ export const zGetWorkspacesCurrentToolProviderBuiltinByProviderOauthCustomClient
 })
 
 /**
- * Success
+ * Custom OAuth client retrieved successfully
  */
-export const zGetWorkspacesCurrentToolProviderBuiltinByProviderOauthCustomClientResponse
-  = zToolOAuthCustomClientResponse
+export const zGetWorkspacesCurrentToolProviderBuiltinByProviderOauthCustomClientResponse = z.record(
+  z.string(),
+  z.unknown(),
+)
 
 export const zPostWorkspacesCurrentToolProviderBuiltinByProviderOauthCustomClientBody
   = zToolOAuthCustomClientPayload
@@ -4149,7 +4397,7 @@ export const zPostWorkspacesCurrentToolProviderBuiltinByProviderOauthCustomClien
 })
 
 /**
- * Success
+ * Custom OAuth client saved successfully
  */
 export const zPostWorkspacesCurrentToolProviderBuiltinByProviderOauthCustomClientResponse
   = zSimpleResultResponse
@@ -4159,10 +4407,9 @@ export const zGetWorkspacesCurrentToolProviderBuiltinByProviderToolsPath = z.obj
 })
 
 /**
- * Success
+ * Builtin provider tools retrieved successfully
  */
-export const zGetWorkspacesCurrentToolProviderBuiltinByProviderToolsResponse
-  = zToolProviderOpaqueResponse
+export const zGetWorkspacesCurrentToolProviderBuiltinByProviderToolsResponse = zToolApiListResponse
 
 export const zPostWorkspacesCurrentToolProviderBuiltinByProviderUpdateBody
   = zBuiltinToolUpdatePayload
@@ -4172,10 +4419,10 @@ export const zPostWorkspacesCurrentToolProviderBuiltinByProviderUpdatePath = z.o
 })
 
 /**
- * Success
+ * Builtin provider updated successfully
  */
 export const zPostWorkspacesCurrentToolProviderBuiltinByProviderUpdateResponse
-  = zToolProviderOpaqueResponse
+  = zSimpleResultResponse
 
 export const zDeleteWorkspacesCurrentToolProviderMcpBody = zMcpProviderDeletePayload
 
@@ -4187,57 +4434,57 @@ export const zDeleteWorkspacesCurrentToolProviderMcpResponse = zSimpleResultResp
 export const zPostWorkspacesCurrentToolProviderMcpBody = zMcpProviderCreatePayload
 
 /**
- * Success
+ * MCP provider created successfully
  */
-export const zPostWorkspacesCurrentToolProviderMcpResponse = zToolProviderOpaqueResponse
+export const zPostWorkspacesCurrentToolProviderMcpResponse = zToolProviderApiEntityResponse
 
 export const zPutWorkspacesCurrentToolProviderMcpBody = zMcpProviderUpdatePayload
 
 /**
- * Success
+ * MCP provider updated successfully
  */
 export const zPutWorkspacesCurrentToolProviderMcpResponse = zSimpleResultResponse
 
 export const zPostWorkspacesCurrentToolProviderMcpAuthBody = zMcpAuthPayload
 
 /**
- * Success
+ * MCP provider authorized successfully
  */
-export const zPostWorkspacesCurrentToolProviderMcpAuthResponse = zToolProviderOpaqueResponse
+export const zPostWorkspacesCurrentToolProviderMcpAuthResponse = zMcpAuthResponse
 
 export const zGetWorkspacesCurrentToolProviderMcpToolsByProviderIdPath = z.object({
   provider_id: z.string(),
 })
 
 /**
- * Success
+ * MCP provider retrieved successfully
  */
 export const zGetWorkspacesCurrentToolProviderMcpToolsByProviderIdResponse
-  = zToolProviderOpaqueResponse
+  = zToolProviderApiEntityResponse
 
 export const zGetWorkspacesCurrentToolProviderMcpUpdateByProviderIdPath = z.object({
   provider_id: z.string(),
 })
 
 /**
- * Success
+ * MCP provider tools refreshed successfully
  */
 export const zGetWorkspacesCurrentToolProviderMcpUpdateByProviderIdResponse
-  = zToolProviderOpaqueResponse
+  = zToolProviderApiEntityResponse
 
 export const zPostWorkspacesCurrentToolProviderWorkflowCreateBody = zWorkflowToolCreatePayload
 
 /**
- * Success
+ * Workflow tool created successfully
  */
-export const zPostWorkspacesCurrentToolProviderWorkflowCreateResponse = zToolProviderOpaqueResponse
+export const zPostWorkspacesCurrentToolProviderWorkflowCreateResponse = zSimpleResultResponse
 
 export const zPostWorkspacesCurrentToolProviderWorkflowDeleteBody = zWorkflowToolDeletePayload
 
 /**
- * Success
+ * Workflow tool deleted successfully
  */
-export const zPostWorkspacesCurrentToolProviderWorkflowDeleteResponse = zToolProviderOpaqueResponse
+export const zPostWorkspacesCurrentToolProviderWorkflowDeleteResponse = zSimpleResultResponse
 
 export const zGetWorkspacesCurrentToolProviderWorkflowGetQuery = z.object({
   workflow_app_id: z.string().optional(),
@@ -4245,70 +4492,73 @@ export const zGetWorkspacesCurrentToolProviderWorkflowGetQuery = z.object({
 })
 
 /**
- * Success
+ * Workflow tool retrieved successfully
  */
-export const zGetWorkspacesCurrentToolProviderWorkflowGetResponse = zToolProviderOpaqueResponse
+export const zGetWorkspacesCurrentToolProviderWorkflowGetResponse = zWorkflowToolDetailResponse
 
 export const zGetWorkspacesCurrentToolProviderWorkflowToolsQuery = z.object({
   workflow_tool_id: z.string(),
 })
 
 /**
- * Success
+ * Workflow provider tools retrieved successfully
  */
-export const zGetWorkspacesCurrentToolProviderWorkflowToolsResponse = zToolProviderOpaqueResponse
+export const zGetWorkspacesCurrentToolProviderWorkflowToolsResponse = zToolApiListResponse
 
 export const zPostWorkspacesCurrentToolProviderWorkflowUpdateBody = zWorkflowToolUpdatePayload
 
 /**
- * Success
+ * Workflow tool updated successfully
  */
-export const zPostWorkspacesCurrentToolProviderWorkflowUpdateResponse = zToolProviderOpaqueResponse
+export const zPostWorkspacesCurrentToolProviderWorkflowUpdateResponse = zSimpleResultResponse
 
 export const zGetWorkspacesCurrentToolProvidersQuery = z.object({
   type: z.enum(['api', 'builtin', 'mcp', 'model', 'workflow']).optional(),
 })
 
 /**
- * Success
+ * Tool providers retrieved successfully
  */
-export const zGetWorkspacesCurrentToolProvidersResponse = zToolProviderOpaqueResponse
+export const zGetWorkspacesCurrentToolProvidersResponse = zToolProviderListResponse
 
 /**
- * Success
+ * API tools retrieved successfully
  */
-export const zGetWorkspacesCurrentToolsApiResponse = zToolProviderOpaqueResponse
+export const zGetWorkspacesCurrentToolsApiResponse = zToolProviderListResponse
 
 /**
- * Success
+ * Builtin tools retrieved successfully
  */
-export const zGetWorkspacesCurrentToolsBuiltinResponse = zToolProviderOpaqueResponse
+export const zGetWorkspacesCurrentToolsBuiltinResponse = zToolProviderListResponse
 
 /**
- * Success
+ * MCP tools retrieved successfully
  */
-export const zGetWorkspacesCurrentToolsMcpResponse = zToolProviderOpaqueResponse
+export const zGetWorkspacesCurrentToolsMcpResponse = zToolProviderListResponse
 
 /**
- * Success
+ * Workflow tools retrieved successfully
  */
-export const zGetWorkspacesCurrentToolsWorkflowResponse = zToolProviderOpaqueResponse
+export const zGetWorkspacesCurrentToolsWorkflowResponse = zToolProviderListResponse
 
 export const zGetWorkspacesCurrentTriggerProviderByProviderIconPath = z.object({
   provider: z.string(),
 })
 
 /**
- * Success
+ * Trigger provider icon
  */
-export const zGetWorkspacesCurrentTriggerProviderByProviderIconResponse = zBinaryFileResponse
+export const zGetWorkspacesCurrentTriggerProviderByProviderIconResponse = z.record(
+  z.string(),
+  z.unknown(),
+)
 
 export const zGetWorkspacesCurrentTriggerProviderByProviderInfoPath = z.object({
   provider: z.string(),
 })
 
 /**
- * Success
+ * Trigger provider retrieved successfully
  */
 export const zGetWorkspacesCurrentTriggerProviderByProviderInfoResponse = zTriggerProviderApiEntity
 
@@ -4317,7 +4567,7 @@ export const zDeleteWorkspacesCurrentTriggerProviderByProviderOauthClientPath = 
 })
 
 /**
- * Success
+ * Trigger OAuth client deleted successfully
  */
 export const zDeleteWorkspacesCurrentTriggerProviderByProviderOauthClientResponse
   = zSimpleResultResponse
@@ -4327,7 +4577,7 @@ export const zGetWorkspacesCurrentTriggerProviderByProviderOauthClientPath = z.o
 })
 
 /**
- * Success
+ * Trigger OAuth client retrieved successfully
  */
 export const zGetWorkspacesCurrentTriggerProviderByProviderOauthClientResponse
   = zTriggerOAuthClientResponse
@@ -4340,7 +4590,7 @@ export const zPostWorkspacesCurrentTriggerProviderByProviderOauthClientPath = z.
 })
 
 /**
- * Success
+ * Trigger OAuth client saved successfully
  */
 export const zPostWorkspacesCurrentTriggerProviderByProviderOauthClientResponse
   = zSimpleResultResponse
@@ -4355,10 +4605,10 @@ export const zPostWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilder
   })
 
 /**
- * Success
+ * Trigger subscription builder built successfully
  */
 export const zPostWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilderBuildBySubscriptionBuilderIdResponse
-  = zTriggerProviderOpaqueResponse
+  = zSimpleResultResponse
 
 export const zPostWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilderCreateBody
   = zTriggerSubscriptionBuilderCreatePayload
@@ -4369,7 +4619,7 @@ export const zPostWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilder
   })
 
 /**
- * Success
+ * Trigger subscription builder created successfully
  */
 export const zPostWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilderCreateResponse
   = zTriggerSubscriptionBuilderCreateResponse
@@ -4381,7 +4631,7 @@ export const zGetWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilderL
   })
 
 /**
- * Success
+ * Trigger subscription builder logs retrieved successfully
  */
 export const zGetWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilderLogsBySubscriptionBuilderIdResponse
   = zTriggerSubscriptionBuilderLogsResponse
@@ -4396,7 +4646,7 @@ export const zPostWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilder
   })
 
 /**
- * Success
+ * Trigger subscription builder updated successfully
  */
 export const zPostWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilderUpdateBySubscriptionBuilderIdResponse
   = zSubscriptionBuilderApiEntity
@@ -4411,10 +4661,10 @@ export const zPostWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilder
   })
 
 /**
- * Success
+ * Trigger subscription builder verified successfully
  */
 export const zPostWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilderVerifyAndUpdateBySubscriptionBuilderIdResponse
-  = zTriggerSubscriptionBuilderVerifyResponse
+  = zTriggerVerificationResponse
 
 export const zGetWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilderBySubscriptionBuilderIdPath
   = z.object({
@@ -4423,7 +4673,7 @@ export const zGetWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilderB
   })
 
 /**
- * Success
+ * Trigger subscription builder retrieved successfully
  */
 export const zGetWorkspacesCurrentTriggerProviderByProviderSubscriptionsBuilderBySubscriptionBuilderIdResponse
   = zSubscriptionBuilderApiEntity
@@ -4433,10 +4683,10 @@ export const zGetWorkspacesCurrentTriggerProviderByProviderSubscriptionsListPath
 })
 
 /**
- * Success
+ * Trigger subscriptions retrieved successfully
  */
 export const zGetWorkspacesCurrentTriggerProviderByProviderSubscriptionsListResponse
-  = zTriggerSubscriptionListResponse
+  = zTriggerProviderSubscriptionListResponse
 
 export const zGetWorkspacesCurrentTriggerProviderByProviderSubscriptionsOauthAuthorizePath
   = z.object({
@@ -4444,7 +4694,7 @@ export const zGetWorkspacesCurrentTriggerProviderByProviderSubscriptionsOauthAut
   })
 
 /**
- * Authorization URL retrieved successfully
+ * Trigger OAuth authorization URL generated successfully
  */
 export const zGetWorkspacesCurrentTriggerProviderByProviderSubscriptionsOauthAuthorizeResponse
   = zTriggerOAuthAuthorizeResponse
@@ -4459,10 +4709,10 @@ export const zPostWorkspacesCurrentTriggerProviderByProviderSubscriptionsVerifyB
   })
 
 /**
- * Success
+ * Trigger subscription verified successfully
  */
 export const zPostWorkspacesCurrentTriggerProviderByProviderSubscriptionsVerifyBySubscriptionIdResponse
-  = zTriggerSubscriptionBuilderVerifyResponse
+  = zTriggerVerificationResponse
 
 export const zPostWorkspacesCurrentTriggerProviderBySubscriptionIdSubscriptionsDeletePath
   = z.object({
@@ -4484,13 +4734,13 @@ export const zPostWorkspacesCurrentTriggerProviderBySubscriptionIdSubscriptionsU
   })
 
 /**
- * Success
+ * Trigger subscription updated successfully
  */
 export const zPostWorkspacesCurrentTriggerProviderBySubscriptionIdSubscriptionsUpdateResponse
-  = zTriggerProviderOpaqueResponse
+  = zSimpleResultResponse
 
 /**
- * Success
+ * Trigger providers retrieved successfully
  */
 export const zGetWorkspacesCurrentTriggersResponse = zTriggerProviderListResponse
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

See #28015 . Migrating Flask-RESTX request/response payload and query param models to Pydantic BaseModels.

Affected:

- workspace tool provider APIs

Also fixing generated response contract output to stay fresh for this slice.

Recommended/Required to merge: None.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
