### PR TITLE
refactor(api): migrate web chat endpoints to BaseModel

### DIFF
--- a/api/controllers/web/audio.py
+++ b/api/controllers/web/audio.py
@@ -1,13 +1,11 @@
 import logging
 
 from flask import request
-from flask_restx import fields, marshal_with
 from pydantic import field_validator
 from werkzeug.exceptions import InternalServerError
 
 import services
 from controllers.common.controller_schemas import TextToAudioPayload as TextToAudioPayloadBase
-from controllers.common.fields import AudioBinaryResponse, AudioTranscriptResponse
 from controllers.web import web_ns
 from controllers.web.error import (
     AppUnavailableError,
@@ -23,8 +21,9 @@ from controllers.web.error import (
 from controllers.web.wraps import WebApiResource
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from extensions.ext_database import db
+from fields.base import ResponseModel
 from graphon.model_runtime.errors.invoke import InvokeError
-from libs.helper import uuid_value
+from libs.helper import dump_response, uuid_value
 from models.model import App, EndUser
 from services.app_ref_service import AppRefService
 from services.audio_service import AudioService
@@ -38,6 +37,10 @@ from services.errors.audio import (
 from ..common.schema import register_response_schema_models, register_schema_models
 
 
+class AudioToTextResponse(ResponseModel):
+    text: str
+
+
 class TextToAudioPayload(TextToAudioPayloadBase):
     @field_validator("message_id")
     @classmethod
@@ -48,18 +51,13 @@ class TextToAudioPayload(TextToAudioPayloadBase):
 
 
 register_schema_models(web_ns, TextToAudioPayload)
-register_response_schema_models(web_ns, AudioBinaryResponse, AudioTranscriptResponse)
+register_response_schema_models(web_ns, AudioToTextResponse)
 
 logger = logging.getLogger(__name__)
 
 
 @web_ns.route("/audio-to-text")
 class AudioApi(WebApiResource):
-    audio_to_text_response_fields = {
-        "text": fields.String,
-    }
-
-    @marshal_with(audio_to_text_response_fields)
     @web_ns.doc("Audio to Text")
     @web_ns.doc(description="Convert audio file to text using speech-to-text service.")
     @web_ns.doc(
@@ -73,7 +71,7 @@ class AudioApi(WebApiResource):
             500: "Internal Server Error",
         }
     )
-    @web_ns.response(200, "Success", web_ns.models[AudioTranscriptResponse.__name__])
+    @web_ns.response(200, "Success", web_ns.models[AudioToTextResponse.__name__])
     def post(self, app_model: App, end_user: EndUser):
         """Convert audio to text"""
         file = request.files["file"]
@@ -81,7 +79,7 @@ class AudioApi(WebApiResource):
         try:
             response = AudioService.transcript_asr(app_model=app_model, file=file, end_user=end_user.external_user_id)
 
-            return response
+            return dump_response(AudioToTextResponse, response)
         except services.errors.app_model_config.AppModelConfigBrokenError:
             logger.exception("App model config broken.")
             raise AppUnavailableError()
@@ -122,7 +120,8 @@ class TextApi(WebApiResource):
             500: "Internal Server Error",
         }
     )
-    @web_ns.response(200, "Success", web_ns.models[AudioBinaryResponse.__name__])
+    # response-contract:ignore provider audio bytes; TODO: model binary audio response if shape is standardized.
+    @web_ns.response(200, "Success")
     def post(self, app_model: App, end_user: EndUser):
         """Convert text to audio"""
         try:
@@ -139,7 +138,7 @@ class TextApi(WebApiResource):
                     message_id,
                     end_user_id=end_user.id,
                 )
-            response = AudioService.transcript_tts(
+            return AudioService.transcript_tts(
                 app_model=app_model,
                 session=db.session,
                 text=text,
@@ -147,8 +146,6 @@ class TextApi(WebApiResource):
                 end_user=end_user.external_user_id,
                 message_ref=message_ref,
             )
-
-            return response
         except services.errors.app_model_config.AppModelConfigBrokenError:
             logger.exception("App model config broken.")
             raise AppUnavailableError()

--- a/api/controllers/web/completion.py
+++ b/api/controllers/web/completion.py
@@ -132,6 +132,7 @@ class CompletionApi(WebApiResource):
                 streaming=streaming,
             )
 
+            # response-contract:ignore compact_generate_response
             return helper.compact_generate_response(response)
         except services.errors.conversation.ConversationNotExistsError:
             raise NotFound("Conversation Not Exists.")
@@ -184,7 +185,7 @@ class CompletionStopApi(WebApiResource):
             app_mode=AppMode.value_of(app_model.mode),
         )
 
-        return {"result": "success"}, 200
+        return SimpleResultResponse(result="success").model_dump(mode="json"), 200
 
 
 @web_ns.route("/chat-messages")
@@ -231,6 +232,7 @@ class ChatApi(WebApiResource):
                 streaming=streaming,
             )
 
+            # response-contract:ignore compact_generate_response
             return helper.compact_generate_response(response)
         except services.errors.conversation.ConversationNotExistsError:
             raise NotFound("Conversation Not Exists.")
@@ -286,4 +288,4 @@ class ChatStopApi(WebApiResource):
             app_mode=app_mode,
         )
 
-        return {"result": "success"}, 200
+        return SimpleResultResponse(result="success").model_dump(mode="json"), 200

--- a/api/controllers/web/files.py
+++ b/api/controllers/web/files.py
@@ -13,6 +13,7 @@ from controllers.web import web_ns
 from controllers.web.wraps import WebApiResource
 from extensions.ext_database import db
 from fields.file_fields import FileResponse
+from libs.helper import dump_response
 from models.model import App, EndUser
 from services.file_service import FileService
 
@@ -84,5 +85,4 @@ class FileApi(WebApiResource):
         except services.errors.file.UnsupportedFileTypeError:
             raise UnsupportedFileTypeError()
 
-        response = FileResponse.model_validate(upload_file, from_attributes=True)
-        return response.model_dump(mode="json"), 201
+        return dump_response(FileResponse, upload_file), 201

--- a/api/controllers/web/human_input_file_upload.py
+++ b/api/controllers/web/human_input_file_upload.py
@@ -29,6 +29,7 @@ from extensions.ext_database import db
 from fields.file_fields import FileResponse, FileWithSignedUrl
 from graphon.file import helpers as file_helpers
 from libs.exception import BaseHTTPException
+from libs.helper import dump_response
 from repositories.factory import DifyAPIRepositoryFactory
 from services.file_service import FileService
 from services.human_input_file_upload_service import (
@@ -141,8 +142,7 @@ def _upload_local_file(context):
     except services.errors.file.BlockedFileExtensionError as exc:
         raise BlockedFileExtensionError() from exc
 
-    response = FileResponse.model_validate(upload_file, from_attributes=True)
-    return upload_file.id, response
+    return upload_file.id, dump_response(FileResponse, upload_file)
 
 
 def _upload_remote_file(context, url: str):
@@ -186,7 +186,7 @@ def _upload_remote_file(context, url: str):
         created_by=upload_file.created_by,
         created_at=int(upload_file.created_at.timestamp()),
     )
-    return upload_file.id, response
+    return upload_file.id, response.model_dump(mode="json")
 
 
 @web_ns.route("/human-input-forms/files")
@@ -209,4 +209,5 @@ class HumanInputFileUploadApi(Resource):
             file_id, response = _upload_local_file(context=context)
 
         upload_service.record_upload_file(context=context, file_id=file_id)
-        return response.model_dump(mode="json"), 201
+        # response-contract:ignore pre-dumped response. See above
+        return response, 201

--- a/api/controllers/web/human_input_form.py
+++ b/api/controllers/web/human_input_form.py
@@ -19,9 +19,9 @@ from controllers.common.schema import register_response_schema_models, register_
 from controllers.web import web_ns
 from controllers.web.error import WebFormRateLimitExceededError
 from controllers.web.site import WebAppSiteResponse
+from core.workflow.nodes.human_input.entities import FormInputConfig, UserActionConfig
 from extensions.ext_database import db
 from fields.base import ResponseModel
-from graphon.nodes.human_input.entities import FormInputConfig, UserActionConfig
 from libs.helper import RateLimiter, dump_response, extract_remote_ip, to_timestamp
 from models.account import TenantStatus
 from models.model import App, Site

--- a/api/controllers/web/human_input_form.py
+++ b/api/controllers/web/human_input_form.py
@@ -2,14 +2,12 @@
 Web App Human Input Form APIs.
 """
 
-import json
 import logging
 from collections.abc import Sequence
-from typing import Any, NotRequired, TypedDict
+from typing import Self
 
-from flask import Response, request
+from flask import request
 from flask_restx import Resource
-from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
 from sqlalchemy.orm import sessionmaker
 from werkzeug.exceptions import Forbidden
@@ -20,35 +18,58 @@ from controllers.common.human_input import HumanInputFormSubmitPayload, stringif
 from controllers.common.schema import register_response_schema_models, register_schema_models
 from controllers.web import web_ns
 from controllers.web.error import WebFormRateLimitExceededError
-from controllers.web.site import serialize_app_site_payload
-from core.workflow.nodes.human_input.entities import FormInputConfig
+from controllers.web.site import WebAppSiteResponse
 from extensions.ext_database import db
-from libs.helper import RateLimiter, extract_remote_ip, to_timestamp
+from fields.base import ResponseModel
+from graphon.nodes.human_input.entities import FormInputConfig, UserActionConfig
+from libs.helper import RateLimiter, dump_response, extract_remote_ip, to_timestamp
 from models.account import TenantStatus
 from models.model import App, Site
 from repositories.factory import DifyAPIRepositoryFactory
+from services.feature_service import FeatureService
 from services.human_input_file_upload_service import HumanInputFileUploadService
 from services.human_input_service import Form, FormNotFoundError, HumanInputService
 
 logger = logging.getLogger(__name__)
 
 
-class HumanInputUploadTokenResponse(BaseModel):
+class HumanInputUploadTokenResponse(ResponseModel):
     upload_token: str
     expires_at: int
 
 
-class HumanInputFormDefinitionResponse(BaseModel):
-    form_content: Any
-    inputs: Any
+class HumanInputFormDefinitionResponse(ResponseModel):
+    form_content: str
+    inputs: list[FormInputConfig]
     resolved_default_values: dict[str, str]
-    user_actions: Any
+    user_actions: list[UserActionConfig]
     expiration_time: int
-    site: dict[str, Any] | None = Field(default=None)
+    site: WebAppSiteResponse | None = None
+
+    @classmethod
+    def from_form(
+        cls,
+        form: Form,
+        *,
+        inputs: Sequence[FormInputConfig] = (),
+        site: WebAppSiteResponse | None = None,
+    ) -> Self:
+        definition_payload = form.get_definition().model_dump(mode="json")
+        expiration_time = to_timestamp(form.expiration_time)
+        if expiration_time is None:
+            raise ValueError("Human input form expiration_time is required")
+        return cls(
+            form_content=definition_payload["rendered_content"],
+            inputs=list(inputs),
+            resolved_default_values=stringify_form_default_values(definition_payload["default_values"]),
+            user_actions=definition_payload["user_actions"],
+            expiration_time=expiration_time,
+            site=site,
+        )
 
 
-class HumanInputFormSubmitResponse(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+class HumanInputFormSubmitResponse(ResponseModel):
+    pass
 
 
 register_schema_models(web_ns, HumanInputFormSubmitPayload)
@@ -86,40 +107,26 @@ def _create_upload_service() -> HumanInputFileUploadService:
     )
 
 
-class FormDefinitionPayload(TypedDict):
-    form_content: Any
-    inputs: Any
-    resolved_default_values: dict[str, str]
-    user_actions: Any
-    expiration_time: int
-    site: NotRequired[dict]
-
-
-def _jsonify_form_definition(
-    form: Form,
-    *,
-    inputs: Sequence[FormInputConfig] = (),
-    site_payload: dict | None = None,
-) -> Response:
-    """Return the form payload (optionally with site) as a JSON response."""
-    definition_payload = form.get_definition().model_dump(mode="json")
-    payload: FormDefinitionPayload = {
-        "form_content": definition_payload["rendered_content"],
-        "inputs": [i.model_dump(mode="json") for i in inputs],
-        "resolved_default_values": stringify_form_default_values(definition_payload["default_values"]),
-        "user_actions": definition_payload["user_actions"],
-        "expiration_time": to_timestamp(form.expiration_time),
-    }
-    if site_payload is not None:
-        payload["site"] = site_payload
-    return Response(json.dumps(payload, ensure_ascii=False), mimetype="application/json")
-
-
 @web_ns.route("/form/human_input/<string:form_token>/upload-token")
 class HumanInputFormUploadTokenApi(Resource):
     """API for issuing HITL upload tokens for active human input forms."""
 
-    @web_ns.response(200, "Success", web_ns.models[HumanInputUploadTokenResponse.__name__])
+    @web_ns.doc("create_human_input_form_upload_token")
+    @web_ns.doc(description="Issue an upload token for an active human input form")
+    @web_ns.doc(params={"form_token": "Human input form token"})
+    @web_ns.doc(
+        responses={
+            200: "Upload token issued successfully",
+            404: "Form not found",
+            412: "Form already submitted or expired",
+            429: "Too many requests",
+        }
+    )
+    @web_ns.response(
+        200,
+        "Upload token issued successfully",
+        web_ns.models[HumanInputUploadTokenResponse.__name__],
+    )
     def post(self, form_token: str):
         """
         Issue an upload token for a human input form.
@@ -136,11 +143,9 @@ class HumanInputFormUploadTokenApi(Resource):
         except FormNotFoundError:
             raise NotFoundError("Form not found")
 
-        response = HumanInputUploadTokenResponse(
-            upload_token=token.upload_token,
-            expires_at=to_timestamp(token.expires_at),
-        )
-        return response.model_dump(mode="json"), 200
+        return HumanInputUploadTokenResponse(
+            upload_token=token.upload_token, expires_at=to_timestamp(token.expires_at)
+        ).model_dump(mode="json"), 200
 
 
 @web_ns.route("/form/human_input/<string:form_token>")
@@ -150,7 +155,23 @@ class HumanInputFormApi(Resource):
     # NOTE(QuantumGhost): this endpoint is unauthenticated on purpose for now.
 
     # def get(self, _app_model: App, _end_user: EndUser, form_token: str):
-    @web_ns.response(200, "Success", web_ns.models[HumanInputFormDefinitionResponse.__name__])
+    @web_ns.doc("get_human_input_form")
+    @web_ns.doc(description="Get a human input form definition by token")
+    @web_ns.doc(params={"form_token": "Human input form token"})
+    @web_ns.doc(
+        responses={
+            200: "Form retrieved successfully",
+            403: "Forbidden",
+            404: "Form not found",
+            412: "Form already submitted or expired",
+            429: "Too many requests",
+        }
+    )
+    @web_ns.response(
+        200,
+        "Form retrieved successfully",
+        web_ns.models[HumanInputFormDefinitionResponse.__name__],
+    )
     def get(self, form_token: str):
         """
         Get human input form definition by token.
@@ -172,17 +193,47 @@ class HumanInputFormApi(Resource):
 
         service.ensure_form_active(form)
         app_model, site = _get_app_site_from_form(form)
+        tenant = app_model.tenant
+        if tenant is None:
+            raise Forbidden()
         inputs = service.resolve_form_inputs(form)
+        features = FeatureService.get_features(app_model.tenant_id, exclude_vector_space=True)
 
-        return _jsonify_form_definition(
-            form,
-            inputs=inputs,
-            site_payload=serialize_app_site_payload(app_model, site, None),
+        return dump_response(
+            HumanInputFormDefinitionResponse,
+            HumanInputFormDefinitionResponse.from_form(
+                form,
+                inputs=inputs,
+                site=WebAppSiteResponse.from_app_site(
+                    tenant=tenant,
+                    app_model=app_model,
+                    site=site,
+                    end_user_id=None,
+                    features=features,
+                    can_replace_logo=features.can_replace_logo,
+                ),
+            ),
         )
 
     # def post(self, _app_model: App, _end_user: EndUser, form_token: str):
-    @web_ns.response(200, "Success", web_ns.models[HumanInputFormSubmitResponse.__name__])
     @web_ns.expect(web_ns.models[HumanInputFormSubmitPayload.__name__])
+    @web_ns.doc("submit_human_input_form")
+    @web_ns.doc(description="Submit a human input form by token")
+    @web_ns.doc(params={"form_token": "Human input form token"})
+    @web_ns.doc(
+        responses={
+            200: "Form submitted successfully",
+            400: "Bad request - invalid submission data",
+            404: "Form not found",
+            412: "Form already submitted or expired",
+            429: "Too many requests",
+        }
+    )
+    @web_ns.response(
+        200,
+        "Form submitted successfully",
+        web_ns.models[HumanInputFormSubmitResponse.__name__],
+    )
     def post(self, form_token: str):
         """
         Submit human input form by token.
@@ -225,7 +276,7 @@ class HumanInputFormApi(Resource):
         except FormNotFoundError:
             raise NotFoundError("Form not found")
 
-        return {}, 200
+        return HumanInputFormSubmitResponse().model_dump(mode="json"), 200
 
 
 def _get_app_site_from_form(form: Form) -> tuple[App, Site]:
@@ -238,7 +289,7 @@ def _get_app_site_from_form(form: Form) -> tuple[App, Site]:
     if site is None:
         raise Forbidden()
 
-    if app_model.tenant and app_model.tenant.status == TenantStatus.ARCHIVE:
+    if app_model.tenant is None or app_model.tenant.status == TenantStatus.ARCHIVE:
         raise Forbidden()
 
     return app_model, site

--- a/api/controllers/web/message.py
+++ b/api/controllers/web/message.py
@@ -186,6 +186,7 @@ class MessageMoreLikeThisApi(WebApiResource):
                 streaming=streaming,
             )
 
+            # response-contract:ignore compact_generate_response
             return helper.compact_generate_response(response)
         except MessageNotExistsError:
             raise NotFound("Message Not Exists.")

--- a/api/controllers/web/remote_files.py
+++ b/api/controllers/web/remote_files.py
@@ -65,11 +65,10 @@ class RemoteFileInfoApi(WebApiResource):
             # failed back to get method
             resp = remote_fetcher.make_request("GET", decoded_url, timeout=3)
         resp.raise_for_status()
-        info = RemoteFileInfo(
+        return RemoteFileInfo(
             file_type=resp.headers.get("Content-Type", "application/octet-stream"),
             file_length=int(resp.headers.get("Content-Length", -1)),
-        )
-        return info.model_dump(mode="json")
+        ).model_dump(mode="json")
 
 
 @web_ns.route("/remote-files/upload")
@@ -141,7 +140,7 @@ class RemoteFileUploadApi(WebApiResource):
         except services.errors.file.UnsupportedFileTypeError:
             raise UnsupportedFileTypeError
 
-        payload1 = FileWithSignedUrl(
+        return FileWithSignedUrl(
             id=upload_file.id,
             name=upload_file.name,
             size=upload_file.size,
@@ -150,5 +149,4 @@ class RemoteFileUploadApi(WebApiResource):
             mime_type=upload_file.mime_type,
             created_by=upload_file.created_by,
             created_at=int(upload_file.created_at.timestamp()),
-        )
-        return payload1.model_dump(mode="json"), 201
+        ).model_dump(mode="json"), 201

--- a/api/controllers/web/saved_message.py
+++ b/api/controllers/web/saved_message.py
@@ -49,9 +49,7 @@ class SavedMessageListApi(WebApiResource):
         adapter = TypeAdapter(SavedMessageItem)
         items = [adapter.validate_python(message, from_attributes=True) for message in pagination.data]
         return SavedMessageInfiniteScrollPagination(
-            limit=pagination.limit,
-            has_more=pagination.has_more,
-            data=items,
+            limit=pagination.limit, has_more=pagination.has_more, data=items
         ).model_dump(mode="json")
 
     @web_ns.doc("Save Message")
@@ -102,6 +100,7 @@ class SavedMessageApi(WebApiResource):
             500: "Internal Server Error",
         }
     )
+    @web_ns.response(204, "Message removed successfully")
     def delete(self, app_model: App, end_user: EndUser, message_id: UUID):
         message_id_str = str(message_id)
 

--- a/api/controllers/web/site.py
+++ b/api/controllers/web/site.py
@@ -1,7 +1,6 @@
-from typing import Any, cast
+from typing import Any, Self
 
-from flask_restx import fields, marshal, marshal_with
-from pydantic import Field
+from pydantic import AliasChoices, Field, computed_field
 from sqlalchemy import select
 from werkzeug.exceptions import Forbidden
 
@@ -11,30 +10,19 @@ from controllers.web import web_ns
 from controllers.web.wraps import WebApiResource
 from extensions.ext_database import db
 from fields.base import ResponseModel
-from libs.helper import AppIconUrlField
-from models.account import TenantStatus
+from libs.helper import build_icon_url
+from models.account import Tenant, TenantStatus
 from models.model import App, EndUser, Site
 from services.feature_service import FeatureModel, FeatureService
 
 
-class AppSiteModelConfigResponse(ResponseModel):
-    opening_statement: str | None = None
-    suggested_questions: Any
-    suggested_questions_after_answer: Any
-    more_like_this: Any
-    model: Any
-    user_input_form: Any
-    pre_prompt: str | None = None
-
-
-class AppSiteResponse(ResponseModel):
-    title: str | None = None
+class WebSiteResponse(ResponseModel):
+    title: str
     chat_color_theme: str | None = None
-    chat_color_theme_inverted: bool | None = None
+    chat_color_theme_inverted: bool
     icon_type: str | None = None
     icon: str | None = None
     icon_background: str | None = None
-    icon_url: str | None = None
     description: str | None = None
     copyright: str | None = None
     privacy_policy: str | None = None
@@ -45,65 +33,98 @@ class AppSiteResponse(ResponseModel):
     show_workflow_steps: bool | None = None
     use_icon_as_answer_icon: bool | None = None
 
+    @computed_field(return_type=str | None)  # type: ignore[prop-decorator]
+    @property
+    def icon_url(self) -> str | None:
+        return build_icon_url(self.icon_type, self.icon)
 
-class AppSiteInfoResponse(ResponseModel):
+
+class WebModelConfigResponse(ResponseModel):
+    opening_statement: str | None = None
+    suggested_questions: Any = Field(
+        default=None,
+        validation_alias=AliasChoices("suggested_questions_list", "suggested_questions"),
+    )
+    suggested_questions_after_answer: Any = Field(
+        default=None,
+        validation_alias=AliasChoices("suggested_questions_after_answer_dict", "suggested_questions_after_answer"),
+    )
+    more_like_this: Any = Field(
+        default=None,
+        validation_alias=AliasChoices("more_like_this_dict", "more_like_this"),
+    )
+    model: Any = Field(default=None, validation_alias=AliasChoices("model_dict", "model"))
+    user_input_form: Any = Field(
+        default=None,
+        validation_alias=AliasChoices("user_input_form_list", "user_input_form"),
+    )
+    pre_prompt: str | None = None
+
+
+class WebAppCustomConfigResponse(ResponseModel):
+    remove_webapp_brand: bool
+    replace_webapp_logo: str | None = None
+
+
+class WebAppSiteResponse(ResponseModel):
     app_id: str
     end_user_id: str | None = None
     enable_site: bool
-    site: AppSiteResponse
-    model_config_: AppSiteModelConfigResponse | None = Field(default=None, alias="model_config")
-    plan: str | None = None
+    site: WebSiteResponse
+    model_config_: WebModelConfigResponse | None = Field(
+        default=None, validation_alias="model_config", serialization_alias="model_config"
+    )
+    plan: str
     can_replace_logo: bool
-    custom_config: dict[str, Any] | None = Field(default=None)
+    custom_config: WebAppCustomConfigResponse | None = None
+
+    @classmethod
+    def from_app_site(
+        cls,
+        *,
+        tenant: Tenant,
+        app_model: App,
+        site: Site,
+        end_user_id: str | None,
+        features: FeatureModel,
+        can_replace_logo: bool,
+    ) -> Self:
+        custom_config = None
+        if can_replace_logo:
+            replace_webapp_logo = (
+                f"{dify_config.FILES_URL}/files/workspaces/{tenant.id}/webapp-logo"
+                if tenant.custom_config_dict.get("replace_webapp_logo")
+                else None
+            )
+            custom_config = WebAppCustomConfigResponse(
+                remove_webapp_brand=tenant.custom_config_dict.get("remove_webapp_brand", False),
+                replace_webapp_logo=replace_webapp_logo,
+            )
+
+        site_response = WebSiteResponse.model_validate(site, from_attributes=True)
+        if features.billing.enabled and not features.webapp_copyright_enabled:
+            site_response.copyright = None
+            site_response.input_placeholder = None
+
+        return cls(
+            app_id=app_model.id,
+            end_user_id=end_user_id,
+            enable_site=app_model.enable_site,
+            site=site_response,
+            model_config_=None,
+            plan=tenant.plan,
+            can_replace_logo=can_replace_logo,
+            custom_config=custom_config,
+        )
 
 
-register_response_schema_models(web_ns, AppSiteInfoResponse)
+register_response_schema_models(
+    web_ns, WebSiteResponse, WebModelConfigResponse, WebAppCustomConfigResponse, WebAppSiteResponse
+)
 
 
 @web_ns.route("/site")
 class AppSiteApi(WebApiResource):
-    """Resource for app sites."""
-
-    model_config_fields = {
-        "opening_statement": fields.String,
-        "suggested_questions": fields.Raw(attribute="suggested_questions_list"),
-        "suggested_questions_after_answer": fields.Raw(attribute="suggested_questions_after_answer_dict"),
-        "more_like_this": fields.Raw(attribute="more_like_this_dict"),
-        "model": fields.Raw(attribute="model_dict"),
-        "user_input_form": fields.Raw(attribute="user_input_form_list"),
-        "pre_prompt": fields.String,
-    }
-
-    site_fields = {
-        "title": fields.String,
-        "chat_color_theme": fields.String,
-        "chat_color_theme_inverted": fields.Boolean,
-        "icon_type": fields.String,
-        "icon": fields.String,
-        "icon_background": fields.String,
-        "icon_url": AppIconUrlField,
-        "description": fields.String,
-        "copyright": fields.String,
-        "privacy_policy": fields.String,
-        "input_placeholder": fields.String,
-        "custom_disclaimer": fields.String,
-        "default_language": fields.String,
-        "prompt_public": fields.Boolean,
-        "show_workflow_steps": fields.Boolean,
-        "use_icon_as_answer_icon": fields.Boolean,
-    }
-
-    app_fields = {
-        "app_id": fields.String,
-        "end_user_id": fields.String,
-        "enable_site": fields.Boolean,
-        "site": fields.Nested(site_fields),
-        "model_config": fields.Nested(model_config_fields, allow_null=True),
-        "plan": fields.String,
-        "can_replace_logo": fields.Boolean,
-        "custom_config": fields.Raw(attribute="custom_config"),
-    }
-
     @web_ns.doc("Get App Site Info")
     @web_ns.doc(description="Retrieve app site information and configuration.")
     @web_ns.doc(
@@ -116,79 +137,26 @@ class AppSiteApi(WebApiResource):
             500: "Internal Server Error",
         }
     )
-    @web_ns.response(200, "Success", web_ns.models[AppSiteInfoResponse.__name__])
-    @marshal_with(app_fields)
+    @web_ns.response(200, "Success", web_ns.models[WebAppSiteResponse.__name__])
     def get(self, app_model: App, end_user: EndUser):
         """Retrieve app site info."""
         # get site
         site = db.session.scalar(select(Site).where(Site.app_id == app_model.id).limit(1))
 
-        if not site:
+        if site is None:
             raise Forbidden()
 
-        if app_model.tenant and app_model.tenant.status == TenantStatus.ARCHIVE:
+        tenant = app_model.tenant
+        if tenant is None or tenant.status == TenantStatus.ARCHIVE:
             raise Forbidden()
 
         features = FeatureService.get_features(app_model.tenant_id, exclude_vector_space=True)
 
-        return AppSiteInfo(
-            app_model.tenant,
-            app_model,
-            serialize_runtime_site(site, features),
-            end_user.id,
-            features.can_replace_logo,
-        )
-
-
-class AppSiteInfo:
-    """Class to store site information."""
-
-    def __init__(self, tenant, app, site, end_user, can_replace_logo):
-        """Initialize AppSiteInfo instance."""
-        self.app_id = app.id
-        self.end_user_id = end_user
-        self.enable_site = app.enable_site
-        self.site = site
-        self.model_config = None
-        self.plan = tenant.plan
-        self.can_replace_logo = can_replace_logo
-
-        if can_replace_logo:
-            base_url = dify_config.FILES_URL
-            remove_webapp_brand = tenant.custom_config_dict.get("remove_webapp_brand", False)
-            replace_webapp_logo = (
-                f"{base_url}/files/workspaces/{tenant.id}/webapp-logo"
-                if tenant.custom_config_dict.get("replace_webapp_logo")
-                else None
-            )
-            self.custom_config = {
-                "remove_webapp_brand": remove_webapp_brand,
-                "replace_webapp_logo": replace_webapp_logo,
-            }
-
-
-def serialize_site(site: Site) -> dict[str, Any]:
-    """Serialize Site model using the same schema as AppSiteApi."""
-    return cast(dict[str, Any], marshal(site, AppSiteApi.site_fields))
-
-
-def serialize_runtime_site(site: Site, features: FeatureModel) -> dict[str, Any]:
-    site_payload = serialize_site(site)
-    if not features.billing.enabled or features.webapp_copyright_enabled:
-        return site_payload
-
-    site_payload["copyright"] = None
-    site_payload["input_placeholder"] = None
-    return site_payload
-
-
-def serialize_app_site_payload(app_model: App, site: Site, end_user_id: str | None) -> dict[str, Any]:
-    features = FeatureService.get_features(app_model.tenant_id, exclude_vector_space=True)
-    app_site_info = AppSiteInfo(
-        app_model.tenant,
-        app_model,
-        serialize_runtime_site(site, features),
-        end_user_id,
-        features.can_replace_logo,
-    )
-    return cast(dict[str, Any], marshal(app_site_info, AppSiteApi.app_fields))
+        return WebAppSiteResponse.from_app_site(
+            tenant=tenant,
+            app_model=app_model,
+            site=site,
+            end_user_id=end_user.id,
+            features=features,
+            can_replace_logo=features.can_replace_logo,
+        ).model_dump(mode="json")

--- a/api/controllers/web/workflow.py
+++ b/api/controllers/web/workflow.py
@@ -76,6 +76,7 @@ class WorkflowRunApi(WebApiResource):
                 streaming=True,
             )
 
+            # response-contract:ignore compact_generate_response
             return helper.compact_generate_response(response)
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)
@@ -129,4 +130,4 @@ class WorkflowTaskStopApi(WebApiResource):
         # New graph engine command channel mechanism
         GraphEngineManager(redis_client).send_stop_command(task_id)
 
-        return {"result": "success"}
+        return SimpleResultResponse(result="success").model_dump(mode="json")

--- a/api/core/rag/extractor/extract_processor.py
+++ b/api/core/rag/extractor/extract_processor.py
@@ -1,7 +1,7 @@
 import re
 import tempfile
 from pathlib import Path
-from typing import Union
+from typing import Literal, overload
 from urllib.parse import unquote
 
 from configs import dify_config
@@ -40,10 +40,22 @@ USER_AGENT = (
 
 
 class ExtractProcessor:
+    @overload
+    @classmethod
+    def load_from_upload_file(
+        cls, upload_file: UploadFile, return_text: Literal[True], is_automatic: bool = False
+    ) -> str: ...
+
+    @overload
+    @classmethod
+    def load_from_upload_file(
+        cls, upload_file: UploadFile, return_text: Literal[False] = False, is_automatic: bool = False
+    ) -> list[Document]: ...
+
     @classmethod
     def load_from_upload_file(
         cls, upload_file: UploadFile, return_text: bool = False, is_automatic: bool = False
-    ) -> Union[list[Document], str]:
+    ) -> list[Document] | str:
         extract_setting = ExtractSetting(
             datasource_type=DatasourceType.FILE, upload_file=upload_file, document_model="text_model"
         )
@@ -53,8 +65,16 @@ class ExtractProcessor:
         else:
             return cls.extract(extract_setting, is_automatic)
 
+    @overload
     @classmethod
-    def load_from_url(cls, url: str, return_text: bool = False) -> Union[list[Document], str]:
+    def load_from_url(cls, url: str, return_text: Literal[True]) -> str: ...
+
+    @overload
+    @classmethod
+    def load_from_url(cls, url: str, return_text: Literal[False] = False) -> list[Document]: ...
+
+    @classmethod
+    def load_from_url(cls, url: str, return_text: bool = False) -> list[Document] | str:
         response = remote_fetcher.make_request("GET", url, headers={"User-Agent": USER_AGENT})
 
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/api/fields/file_fields.py
+++ b/api/fields/file_fields.py
@@ -11,14 +11,14 @@ from libs.helper import to_timestamp
 class UploadConfig(ResponseModel):
     file_size_limit: int
     batch_count_limit: int
-    file_upload_limit: int | None = None
+    file_upload_limit: int
     image_file_size_limit: int
     video_file_size_limit: int
     audio_file_size_limit: int
     workflow_file_upload_limit: int
     image_file_batch_limit: int
     single_chunk_attachment_limit: int
-    attachment_image_file_size_limit: int | None = None
+    attachment_image_file_size_limit: int
 
 
 class FileResponse(ResponseModel):

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -21932,11 +21932,11 @@ Payload for updating a snippet.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| attachment_image_file_size_limit | integer |  | No |
+| attachment_image_file_size_limit | integer |  | Yes |
 | audio_file_size_limit | integer |  | Yes |
 | batch_count_limit | integer |  | Yes |
 | file_size_limit | integer |  | Yes |
-| file_upload_limit | integer |  | No |
+| file_upload_limit | integer |  | Yes |
 | image_file_batch_limit | integer |  | Yes |
 | image_file_size_limit | integer |  | Yes |
 | single_chunk_attachment_limit | integer |  | Yes |

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -1794,7 +1794,7 @@ Get human input form preview for advanced chat workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Human input form preview | **application/json**: [HumanInputFormPreviewResponse](#humaninputformpreviewresponse)<br> |
+| 200 | Human input form preview retrieved | **application/json**: [HumanInputFormPreviewResponse](#humaninputformpreviewresponse)<br> |
 
 ### [POST] /apps/{app_id}/advanced-chat/workflows/draft/human-input/nodes/{node_id}/form/run
 **Submit human input form preview**
@@ -1816,9 +1816,9 @@ Submit human input form preview for advanced chat workflow
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Human input form submission result | **application/json**: [HumanInputFormSubmitResponse](#humaninputformsubmitresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Human input form submitted |
 
 ### [POST] /apps/{app_id}/advanced-chat/workflows/draft/iteration/nodes/{node_id}/run
 **Run draft workflow iteration node**
@@ -1840,11 +1840,11 @@ Run draft workflow iteration node for advanced chat
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Iteration node run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 403 | Permission denied |  |
-| 404 | Node not found |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Iteration node run started successfully |
+| 403 | Permission denied |
+| 404 | Node not found |
 
 ### [POST] /apps/{app_id}/advanced-chat/workflows/draft/loop/nodes/{node_id}/run
 **Run draft workflow loop node**
@@ -1866,11 +1866,11 @@ Run draft workflow loop node for advanced chat
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Loop node run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 403 | Permission denied |  |
-| 404 | Node not found |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Loop node run started successfully |
+| 403 | Permission denied |
+| 404 | Node not found |
 
 ### [POST] /apps/{app_id}/advanced-chat/workflows/draft/run
 **Run draft workflow**
@@ -1891,11 +1891,11 @@ Run draft workflow for advanced chat application
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Workflow run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 400 | Invalid request parameters |  |
-| 403 | Permission denied |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Workflow run started successfully |
+| 400 | Invalid request parameters |
+| 403 | Permission denied |
 
 ### [GET] /apps/{app_id}/agent/config/files
 #### Parameters
@@ -4084,9 +4084,9 @@ Get default block configurations for workflow
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Default block configurations retrieved successfully | **application/json**: [DefaultBlockConfigsResponse](#defaultblockconfigsresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Default block configurations retrieved successfully |
 
 ### [GET] /apps/{app_id}/workflows/default-workflow-block-configs/{block_type}
 **Get default block config**
@@ -4103,10 +4103,10 @@ Get default block configuration by type
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Default block configuration retrieved successfully | **application/json**: [DefaultBlockConfigResponse](#defaultblockconfigresponse)<br> |
-| 404 | Block type not found |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Default block configuration retrieved successfully |
+| 404 | Block type not found |
 
 ### [GET] /apps/{app_id}/workflows/draft
 **Get draft workflow**
@@ -4164,7 +4164,7 @@ Get conversation variables for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Conversation variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
+| 200 | Conversation variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
 | 404 | Draft workflow not found |  |
 
 ### [POST] /apps/{app_id}/workflows/draft/conversation-variables
@@ -4203,7 +4203,7 @@ Get environment variables for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Environment variables retrieved successfully | **application/json**: [EnvironmentVariableListResponse](#environmentvariablelistresponse)<br> |
+| 200 | Environment variables retrieved successfully | **application/json**: [WorkflowDraftEnvironmentVariableListResponse](#workflowdraftenvironmentvariablelistresponse)<br> |
 | 404 | Draft workflow not found |  |
 
 ### [POST] /apps/{app_id}/workflows/draft/environment-variables
@@ -4270,7 +4270,7 @@ Test human input delivery for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Human input delivery test result | **application/json**: [EmptyObjectResponse](#emptyobjectresponse)<br> |
+| 200 | Human input delivery tested | **application/json**: [HumanInputDeliveryTestResponse](#humaninputdeliverytestresponse)<br> |
 
 ### [POST] /apps/{app_id}/workflows/draft/human-input/nodes/{node_id}/form/preview
 **Preview human input form content and placeholders**
@@ -4294,7 +4294,7 @@ Get human input form preview for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Human input form preview | **application/json**: [HumanInputFormPreviewResponse](#humaninputformpreviewresponse)<br> |
+| 200 | Human input form preview retrieved | **application/json**: [HumanInputFormPreviewResponse](#humaninputformpreviewresponse)<br> |
 
 ### [POST] /apps/{app_id}/workflows/draft/human-input/nodes/{node_id}/form/run
 **Submit human input form preview**
@@ -4316,9 +4316,9 @@ Submit human input form preview for workflow
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Human input form submission result | **application/json**: [HumanInputFormSubmitResponse](#humaninputformsubmitresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Human input form submitted |
 
 ### [POST] /apps/{app_id}/workflows/draft/iteration/nodes/{node_id}/run
 **Run draft workflow iteration node**
@@ -4338,11 +4338,11 @@ Submit human input form preview for workflow
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Workflow iteration node run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 403 | Permission denied |  |
-| 404 | Node not found |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Workflow iteration node run started successfully |
+| 403 | Permission denied |
+| 404 | Node not found |
 
 ### [POST] /apps/{app_id}/workflows/draft/loop/nodes/{node_id}/run
 **Run draft workflow loop node**
@@ -4362,11 +4362,11 @@ Submit human input form preview for workflow
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Workflow loop node run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 403 | Permission denied |  |
-| 404 | Node not found |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Workflow loop node run started successfully |
+| 403 | Permission denied |
+| 404 | Node not found |
 
 ### [GET] /apps/{app_id}/workflows/draft/nodes/{node_id}/agent-composer
 #### Parameters
@@ -4553,7 +4553,7 @@ Get last run result for draft workflow node
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Trigger event received and node executed successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 200 | Trigger event received and node executed successfully | **application/json**: [WorkflowRunNodeExecutionResponse](#workflowrunnodeexecutionresponse)<br> |
 | 403 | Permission denied |  |
 | 500 | Internal server error |  |
 
@@ -4587,7 +4587,7 @@ Get variables for a specific node
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
+| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
 
 ### [POST] /apps/{app_id}/workflows/draft/run
 **Run draft workflow**
@@ -4606,10 +4606,10 @@ Get variables for a specific node
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Draft workflow run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 403 | Permission denied |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Draft workflow run started successfully |
+| 403 | Permission denied |
 
 ### [GET] /apps/{app_id}/workflows/draft/runs/{run_id}/node-outputs
 Snapshot of every node's declared outputs for a draft workflow run.
@@ -4695,7 +4695,7 @@ Get system variables for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
+| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
 
 ### [POST] /apps/{app_id}/workflows/draft/trigger/run
 **Poll for trigger events and execute full workflow when event arrives**
@@ -4710,15 +4710,15 @@ Get system variables for workflow
 
 | Required | Schema |
 | -------- | ------ |
-|  Yes | **application/json**: [DraftWorkflowTriggerRunRequest](#draftworkflowtriggerrunrequest)<br> |
+|  Yes | **application/json**: [DraftWorkflowTriggerRunPayload](#draftworkflowtriggerrunpayload)<br> |
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Trigger event received and workflow executed successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 403 | Permission denied |  |
-| 500 | Internal server error |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Trigger event received and workflow executed successfully |
+| 403 | Permission denied |
+| 500 | Internal server error |
 
 ### [POST] /apps/{app_id}/workflows/draft/trigger/run-all
 **Full workflow debug when the start node is a trigger**
@@ -4737,11 +4737,11 @@ Get system variables for workflow
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Workflow executed successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 403 | Permission denied |  |
-| 500 | Internal server error |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Workflow executed successfully |
+| 403 | Permission denied |
+| 500 | Internal server error |
 
 ### [DELETE] /apps/{app_id}/workflows/draft/variables
 Delete all draft workflow variables
@@ -4775,7 +4775,7 @@ Get draft workflow variables
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValue](#workflowdraftvariablelistwithoutvalue)<br> |
+| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValueResponse](#workflowdraftvariablelistwithoutvalueresponse)<br> |
 
 ### [DELETE] /apps/{app_id}/workflows/draft/variables/{variable_id}
 Delete a workflow variable
@@ -4808,7 +4808,7 @@ Get a specific workflow variable
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
+| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
 | 404 | Variable not found |  |
 
 ### [PATCH] /apps/{app_id}/workflows/draft/variables/{variable_id}
@@ -4831,7 +4831,7 @@ Update a workflow variable
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
+| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
 | 404 | Variable not found |  |
 
 ### [PUT] /apps/{app_id}/workflows/draft/variables/{variable_id}/reset
@@ -4848,7 +4848,7 @@ Reset a workflow variable to its default value
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
+| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
 | 204 | Variable reset (no content) |  |
 | 404 | Variable not found |  |
 
@@ -4888,7 +4888,7 @@ Get published workflow for an application
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow published successfully | **application/json**: [WorkflowPublishResponse](#workflowpublishresponse)<br> |
+| 200 | Workflow published successfully | **application/json**: [PublishWorkflowResponse](#publishworkflowresponse)<br> |
 
 ### [GET] /apps/{app_id}/workflows/published/runs/{run_id}/node-outputs
 Snapshot of every node's declared outputs for a published workflow run.
@@ -5033,7 +5033,7 @@ Restore a published workflow version into the draft workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow restored successfully | **application/json**: [WorkflowRestoreResponse](#workflowrestoreresponse)<br> |
+| 200 | Workflow restored successfully | **application/json**: [SyncDraftWorkflowResponse](#syncdraftworkflowresponse)<br> |
 | 400 | Source workflow must be published |  |
 | 404 | Workflow not found |  |
 
@@ -7847,7 +7847,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
+| 200 | Datasource plugins retrieved successfully | **application/json**: [DatasourcePluginListResponse](#datasourcepluginlistresponse)<br> |
 
 ### [POST] /rag/pipelines/imports
 #### Request Body
@@ -7902,7 +7902,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
+| 200 | Recommended plugins retrieved successfully | **application/json**: [RagPipelineRecommendedPluginResponse](#ragpipelinerecommendedpluginresponse)<br> |
 
 ### [POST] /rag/pipelines/transform/datasets/{dataset_id}
 #### Parameters
@@ -7915,7 +7915,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
+| 200 | Dataset transformed successfully | **application/json**: [RagPipelineTransformResponse](#ragpipelinetransformresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/customized/publish
 #### Parameters
@@ -8046,9 +8046,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Default block configs retrieved successfully | **application/json**: [DefaultBlockConfigsResponse](#defaultblockconfigsresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Default workflow block configurations retrieved successfully |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/default-workflow-block-configs/{block_type}
 **Get default block config**
@@ -8063,9 +8063,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Default block config retrieved successfully | **application/json**: [DefaultBlockConfigResponse](#defaultblockconfigresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Default workflow block configuration retrieved successfully |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft
 **Get draft rag pipeline's workflow**
@@ -8122,9 +8122,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/draft/datasource/variables-inspect
 **Set datasource variables**
@@ -8160,7 +8160,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Environment variables retrieved successfully | **application/json**: [EnvironmentVariableListResponse](#environmentvariablelistresponse)<br> |
+| 200 | Environment variables retrieved successfully | **application/json**: [RagPipelineEnvironmentVariableListResponse](#ragpipelineenvironmentvariablelistresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/draft/iteration/nodes/{node_id}/run
 **Run draft workflow iteration node**
@@ -8180,9 +8180,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/draft/loop/nodes/{node_id}/run
 **Run draft workflow loop node**
@@ -8202,9 +8202,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/nodes/{node_id}/last-run
 #### Parameters
@@ -8268,7 +8268,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
+| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/pre-processing/parameters
 **Get first step parameters of rag pipeline**
@@ -8284,7 +8284,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineStepParametersResponse](#ragpipelinestepparametersresponse)<br> |
+| 200 | First step parameters retrieved successfully | **application/json**: [RagPipelineVariablesResponse](#ragpipelinevariablesresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/processing/parameters
 **Get second step parameters of rag pipeline**
@@ -8300,7 +8300,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineStepParametersResponse](#ragpipelinestepparametersresponse)<br> |
+| 200 | Second step parameters retrieved successfully | **application/json**: [RagPipelineVariablesResponse](#ragpipelinevariablesresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/draft/run
 **Run draft workflow**
@@ -8319,9 +8319,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/system-variables
 #### Parameters
@@ -8334,7 +8334,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
+| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
 
 ### [DELETE] /rag/pipelines/{pipeline_id}/workflows/draft/variables
 #### Parameters
@@ -8347,7 +8347,7 @@ Initiate OAuth login process
 
 | Code | Description |
 | ---- | ----------- |
-| 204 | Workflow variables deleted successfully |
+| 204 | Variables deleted successfully |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/variables
 **Get draft workflow**
@@ -8356,15 +8356,13 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| limit | query |  | No | integer, <br>**Default:** 20 |
-| page | query |  | No | integer, <br>**Default:** 1 |
 | pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValue](#workflowdraftvariablelistwithoutvalue)<br> |
+| 200 | Variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValueResponse](#workflowdraftvariablelistwithoutvalueresponse)<br> |
 
 ### [DELETE] /rag/pipelines/{pipeline_id}/workflows/draft/variables/{variable_id}
 #### Parameters
@@ -8392,7 +8390,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
+| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
 
 ### [PATCH] /rag/pipelines/{pipeline_id}/workflows/draft/variables/{variable_id}
 #### Parameters
@@ -8412,7 +8410,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
+| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
 
 ### [PUT] /rag/pipelines/{pipeline_id}/workflows/draft/variables/{variable_id}/reset
 #### Parameters
@@ -8426,8 +8424,8 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
-| 204 | Variable reset (no content) |  |
+| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
+| 204 | Variable reset to empty state |  |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/publish
 **Get published pipeline**
@@ -8499,9 +8497,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/published/pre-processing/parameters
 **Get first step parameters of rag pipeline**
@@ -8517,7 +8515,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineStepParametersResponse](#ragpipelinestepparametersresponse)<br> |
+| 200 | First step parameters retrieved successfully | **application/json**: [RagPipelineVariablesResponse](#ragpipelinevariablesresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/published/processing/parameters
 **Get second step parameters of rag pipeline**
@@ -8533,7 +8531,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineStepParametersResponse](#ragpipelinestepparametersresponse)<br> |
+| 200 | Second step parameters retrieved successfully | **application/json**: [RagPipelineVariablesResponse](#ragpipelinevariablesresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/published/run
 **Run published workflow**
@@ -8552,9 +8550,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
 
 ### [DELETE] /rag/pipelines/{pipeline_id}/workflows/{workflow_id}
 **Delete a published workflow version that is not currently active on the pipeline**
@@ -8809,9 +8807,9 @@ Get all published workflows for a snippet
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Default block configs retrieved successfully | **application/json**: [DefaultBlockConfigsResponse](#defaultblockconfigsresponse)<br> |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Default block configs retrieved successfully |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft
 **Get draft workflow for snippet**
@@ -8848,7 +8846,7 @@ Get all published workflows for a snippet
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Draft workflow synced successfully | **application/json**: [WorkflowRestoreResponse](#workflowrestoreresponse)<br> |
+| 200 | Draft workflow synced successfully | **application/json**: [SyncDraftWorkflowResponse](#syncdraftworkflowresponse)<br> |
 | 400 | Hash mismatch |  |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft/config
@@ -8879,7 +8877,7 @@ Conversation variables are not used in snippet workflows; returns an empty list 
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Conversation variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
+| 200 | Conversation variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft/environment-variables
 Get environment variables from snippet draft workflow graph
@@ -8894,7 +8892,7 @@ Get environment variables from snippet draft workflow graph
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Environment variables retrieved successfully | **application/json**: [EnvironmentVariableListResponse](#environmentvariablelistresponse)<br> |
+| 200 | Environment variables retrieved successfully | **application/json**: [WorkflowDraftEnvironmentVariableListResponse](#workflowdraftenvironmentvariablelistresponse)<br> |
 | 404 | Draft workflow not found |  |
 
 ### [POST] /snippets/{snippet_id}/workflows/draft/iteration/nodes/{node_id}/run
@@ -8921,7 +8919,7 @@ Returns an SSE event stream with iteration progress and results.
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Iteration node run started successfully (SSE stream) | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 200 | Iteration node run started successfully (SSE stream) | **application/json**: [EventStreamResponse](#eventstreamresponse)<br> |
 | 404 | Snippet or draft workflow not found |  |
 
 ### [POST] /snippets/{snippet_id}/workflows/draft/loop/nodes/{node_id}/run
@@ -8948,7 +8946,7 @@ Returns an SSE event stream with loop progress and results.
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Loop node run started successfully (SSE stream) | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 200 | Loop node run started successfully (SSE stream) | **application/json**: [EventStreamResponse](#eventstreamresponse)<br> |
 | 404 | Snippet or draft workflow not found |  |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft/nodes/{node_id}/last-run
@@ -9029,7 +9027,7 @@ Get variables for a specific node (snippet draft workflow)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
+| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
 
 ### [POST] /snippets/{snippet_id}/workflows/draft/run
 **Run draft workflow for snippet**
@@ -9053,7 +9051,7 @@ and returns an SSE event stream with execution progress and results.
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Draft workflow run started successfully (SSE stream) | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 200 | Draft workflow run started successfully (SSE stream) | **application/json**: [EventStreamResponse](#eventstreamresponse)<br> |
 | 404 | Snippet or draft workflow not found |  |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft/system-variables
@@ -9069,7 +9067,7 @@ System variables are not used in snippet workflows; returns an empty list for AP
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
+| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
 
 ### [DELETE] /snippets/{snippet_id}/workflows/draft/variables
 Delete all draft workflow variables for the current user (snippet scope)
@@ -9101,7 +9099,7 @@ List draft workflow variables without values (paginated, snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValue](#workflowdraftvariablelistwithoutvalue)<br> |
+| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValueResponse](#workflowdraftvariablelistwithoutvalueresponse)<br> |
 
 ### [DELETE] /snippets/{snippet_id}/workflows/draft/variables/{variable_id}
 Delete a draft workflow variable (snippet scope)
@@ -9134,7 +9132,7 @@ Get a specific draft workflow variable (snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
+| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
 | 404 | Variable not found |  |
 
 ### [PATCH] /snippets/{snippet_id}/workflows/draft/variables/{variable_id}
@@ -9157,7 +9155,7 @@ Update a draft workflow variable (snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
+| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
 | 404 | Variable not found |  |
 
 ### [PUT] /snippets/{snippet_id}/workflows/draft/variables/{variable_id}/reset
@@ -9174,7 +9172,7 @@ Reset a draft workflow variable to its default value (snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
+| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
 | 204 | Variable reset (no content) |  |
 | 404 | Variable not found |  |
 
@@ -9213,7 +9211,7 @@ Reset a draft workflow variable to its default value (snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow published successfully | **application/json**: [WorkflowPublishResponse](#workflowpublishresponse)<br> |
+| 200 | Workflow published successfully | **application/json**: [PublishWorkflowResponse](#publishworkflowresponse)<br> |
 | 400 | No draft workflow found |  |
 
 ### [PATCH] /snippets/{snippet_id}/workflows/{workflow_id}
@@ -9256,7 +9254,7 @@ Update published snippet workflow attributes
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow restored successfully | **application/json**: [WorkflowRestoreResponse](#workflowrestoreresponse)<br> |
+| 200 | Workflow restored successfully | **application/json**: [SyncDraftWorkflowResponse](#syncdraftworkflowresponse)<br> |
 | 400 | Source workflow must be published |  |
 | 404 | Workflow not found |  |
 
@@ -16697,6 +16695,25 @@ Model class for provider custom model configuration.
 | ---- | ---- | ----------- | -------- |
 | id | string |  | Yes |
 
+#### DatasourceEntity
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| description | [I18nObject](#i18nobject) | The label of the datasource | Yes |
+| identity | [DatasourceIdentity](#datasourceidentity) |  | Yes |
+| output_schema | object |  | No |
+| parameters | [ [DatasourceParameter](#datasourceparameter) ] |  | No |
+
+#### DatasourceIdentity
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| author | string | The author of the datasource | Yes |
+| icon | string |  | No |
+| label | [I18nObject](#i18nobject) | The label of the datasource | Yes |
+| name | string | The name of the datasource | Yes |
+| provider | string | The provider of the datasource | Yes |
+
 #### DatasourceNodeRunPayload
 
 | Name | Type | Description | Required |
@@ -16731,6 +16748,41 @@ Model class for provider custom model configuration.
 | oauth_custom_client_params | object | Masked plugin-defined OAuth client parameters, when configured for the tenant. | Yes |
 | redirect_uri | string |  | Yes |
 
+#### DatasourceParameter
+
+Overrides type
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| auto_generate | [PluginParameterAutoGenerate](#pluginparameterautogenerate) |  | No |
+| default | number<br>integer<br>string<br>boolean<br>[ object ]<br>object |  | No |
+| description | [I18nObject](#i18nobject) | The description of the parameter | Yes |
+| label | [I18nObject](#i18nobject) | The label presented to the user | Yes |
+| max | number<br>integer |  | No |
+| min | number<br>integer |  | No |
+| name | string | The name of the parameter | Yes |
+| options | [ [PluginParameterOption](#pluginparameteroption) ] |  | No |
+| placeholder | [I18nObject](#i18nobject) | The placeholder presented to the user | No |
+| precision | integer |  | No |
+| required | boolean |  | No |
+| scope | string |  | No |
+| template | [PluginParameterTemplate](#pluginparametertemplate) |  | No |
+| type | [DatasourceParameterType](#datasourceparametertype) | The type of the parameter | Yes |
+
+#### DatasourceParameterType
+
+removes TOOLS_SELECTOR from PluginParameterType
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| DatasourceParameterType | string | removes TOOLS_SELECTOR from PluginParameterType |  |
+
+#### DatasourcePluginListResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| DatasourcePluginListResponse | array |  |  |
+
 #### DatasourceProviderAuthListResponse
 
 | Name | Type | Description | Required |
@@ -16752,6 +16804,35 @@ Model class for provider custom model configuration.
 | plugin_id | string |  | Yes |
 | plugin_unique_identifier | string |  | Yes |
 | provider | string |  | Yes |
+
+#### DatasourceProviderEntityWithPlugin
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| credentials_schema | [ [ProviderConfig](#providerconfig) ] |  | No |
+| datasources | [ [DatasourceEntity](#datasourceentity) ] |  | No |
+| identity | [DatasourceProviderIdentity](#datasourceprovideridentity) |  | Yes |
+| oauth_schema | [OAuthSchema](#oauthschema) |  | No |
+| provider_type | [DatasourceProviderType](#datasourceprovidertype) |  | Yes |
+
+#### DatasourceProviderIdentity
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| author | string | The author of the tool | Yes |
+| description | [I18nObject](#i18nobject) | The description of the tool | Yes |
+| icon | string | The icon of the tool | Yes |
+| label | [I18nObject](#i18nobject) | The label of the tool | Yes |
+| name | string | The name of the tool | Yes |
+| tags | [ [ToolLabelEnum](#toollabelenum) ] | The tags of the tool | No |
+
+#### DatasourceProviderType
+
+Enum class for datasource provider
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| DatasourceProviderType | string | Enum class for datasource provider |  |
 
 #### DatasourceUpdateNamePayload
 
@@ -16860,18 +16941,6 @@ Per-output retry configuration that mirrors ``graphon.RetryConfig`` shape.
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | q | string |  | No |
-
-#### DefaultBlockConfigResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| DefaultBlockConfigResponse | object |  |  |
-
-#### DefaultBlockConfigsResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| DefaultBlockConfigsResponse | array |  |  |
 
 #### DefaultModelDataResponse
 
@@ -17081,12 +17150,6 @@ Request payload for bulk downloading documents as a zip archive.
 | ---- | ---- | ----------- | -------- |
 | node_id | string |  | Yes |
 
-#### DraftWorkflowTriggerRunRequest
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| node_id | string | Node ID | Yes |
-
 #### EducationActivatePayload
 
 | Name | Type | Description | Required |
@@ -17189,12 +17252,6 @@ Request payload for bulk downloading documents as a zip archive.
 | code | string |  | Yes |
 | email | string |  | Yes |
 | token | string |  | Yes |
-
-#### EmptyObjectResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| EmptyObjectResponse | object |  |  |
 
 #### EndpointCreatePayload
 
@@ -17332,27 +17389,6 @@ Request payload for bulk downloading documents as a zip archive.
 | name | string |  | No |
 | value |  |  | No |
 | value_type | string |  | No |
-
-#### EnvironmentVariableItemResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| description | string |  | No |
-| editable | boolean |  | Yes |
-| edited | boolean |  | Yes |
-| id | string |  | Yes |
-| name | string |  | Yes |
-| selector | [ string ] |  | Yes |
-| type | string |  | Yes |
-| value |  |  | Yes |
-| value_type | string |  | Yes |
-| visible | boolean |  | Yes |
-
-#### EnvironmentVariableListResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [EnvironmentVariableItemResponse](#environmentvariableitemresponse) ] |  | Yes |
 
 #### EnvironmentVariableUpdatePayload
 
@@ -17777,12 +17813,6 @@ Enum class for form type.
 | ---- | ---- | ----------- | -------- |
 | document_list | [ string ] |  | Yes |
 
-#### GeneratedAppResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| GeneratedAppResponse |  |  |  |
-
 #### GeneratorResponse
 
 | Name | Type | Description | Required |
@@ -17906,6 +17936,11 @@ Enum class for form type.
 | delivery_method_id | string | Delivery method ID | Yes |
 | inputs | object | Values used to fill missing upstream variables referenced in form_content | No |
 
+#### HumanInputDeliveryTestResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+
 #### HumanInputFormDefinition
 
 | Name | Type | Description | Required |
@@ -17931,12 +17966,13 @@ Enum class for form type.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| actions | [ object ] |  | No |
-| display_in_ui | boolean |  | No |
-| expiration_time | integer |  | No |
+| TYPE | string, <br>**Default:** human_input_required |  | No |
+| actions | [ [HumanInputUserActionResponse](#humaninputuseractionresponse) ] |  | No |
+| display_in_ui | boolean | Always false for draft preview responses. | No |
+| expiration_time | integer | Always null for draft preview responses. | No |
 | form_content | string |  | Yes |
 | form_id | string |  | Yes |
-| form_token | string |  | No |
+| form_token | string | Always null for draft preview responses. | No |
 | inputs | [ object ] |  | No |
 | node_id | string |  | Yes |
 | node_title | string |  | Yes |
@@ -17961,12 +17997,6 @@ Enum class for form type.
 | form_inputs | object | Values the user provides for the form's own fields | Yes |
 | inputs | object | Values used to fill missing upstream variables referenced in form_content | Yes |
 
-#### HumanInputFormSubmitResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| HumanInputFormSubmitResponse | object |  |  |
-
 #### HumanInputPauseTypeResponse
 
 | Name | Type | Description | Required |
@@ -17974,6 +18004,14 @@ Enum class for form type.
 | backstage_input_url | string |  | No |
 | form_id | string |  | Yes |
 | type | string |  | Yes |
+
+#### HumanInputUserActionResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| button_style | string, <br>**Default:** default |  | No |
+| id | string |  | Yes |
+| title | string |  | Yes |
 
 #### I18nObject
 
@@ -18196,7 +18234,7 @@ Input field definition for snippet parameters.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| JSONValue | string<br>integer<br>number<br>boolean<br>object<br>[ object ] |  |  |
+| JSONValue |  |  |  |
 
 #### JSONValueType
 
@@ -19692,6 +19730,16 @@ Shared permission levels for resources (datasets, credentials, etc.)
 | ---- | ---- | ----------- | -------- |
 | PluginDaemonOperationResponse |  |  |  |
 
+#### PluginDatasourceProviderEntity
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| declaration | [DatasourceProviderEntityWithPlugin](#datasourceproviderentitywithplugin) |  | Yes |
+| is_authorized | boolean |  | No |
+| plugin_id | string |  | Yes |
+| plugin_unique_identifier | string |  | Yes |
+| provider | string |  | Yes |
+
 #### PluginDebuggingKeyResponse
 
 | Name | Type | Description | Required |
@@ -20081,11 +20129,17 @@ Model class for provider with models response.
 
 #### PublishWorkflowPayload
 
-Payload for publishing snippet workflow.
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| marked_comment | string |  | No |
+| marked_name | string |  | No |
+
+#### PublishWorkflowResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| knowledge_base_setting | object |  | No |
+| created_at | integer |  | Yes |
+| result | string |  | Yes |
 
 #### PublishedWorkflowRunPayload
 
@@ -20170,6 +20224,27 @@ Whitelist scopes accepted by RBAC app and dataset access config APIs.
 | ---- | ---- | ----------- | -------- |
 | yaml_content | string |  | Yes |
 
+#### RagPipelineEnvironmentVariableListResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| items | [ [RagPipelineEnvironmentVariableResponse](#ragpipelineenvironmentvariableresponse) ] |  | Yes |
+
+#### RagPipelineEnvironmentVariableResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| description | string |  | Yes |
+| editable | boolean |  | Yes |
+| edited | boolean |  | Yes |
+| id | string |  | Yes |
+| name | string |  | Yes |
+| selector | [ string ] |  | Yes |
+| type | string |  | Yes |
+| value |  |  | Yes |
+| value_type | string |  | Yes |
+| visible | boolean |  | Yes |
+
 #### RagPipelineImportCheckDependenciesResponse
 
 | Name | Type | Description | Required |
@@ -20202,19 +20277,28 @@ Whitelist scopes accepted by RBAC app and dataset access config APIs.
 | pipeline_id | string |  | No |
 | status | [ImportStatus](#importstatus) |  | Yes |
 
-#### RagPipelineOpaqueResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| RagPipelineOpaqueResponse |  |  |  |
-
 #### RagPipelineRecommendedPluginQuery
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | type | string, <br>**Default:** all |  | No |
 
-#### RagPipelineStepParametersResponse
+#### RagPipelineRecommendedPluginResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| installed_recommended_plugins | [ object ] | Installed tool provider payloads. Shape follows the tool provider serializer. | Yes |
+| uninstalled_recommended_plugins | [ object ] | Marketplace plugin manifest payloads returned by the marketplace service. | Yes |
+
+#### RagPipelineTransformResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| dataset_id | string |  | Yes |
+| pipeline_id | string |  | Yes |
+| status | string |  | Yes |
+
+#### RagPipelineVariablesResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
@@ -21192,9 +21276,9 @@ The subscription constructor of the trigger provider
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| hash | string |  | No |
-| result | string |  | No |
-| updated_at | string |  | No |
+| hash | string |  | Yes |
+| result | string |  | Yes |
+| updated_at | integer |  | Yes |
 
 #### SystemConfigurationResponse
 
@@ -21454,6 +21538,12 @@ Available voices
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | data | [ [TokensPerSecondStatisticItem](#tokenspersecondstatisticitem) ] |  | Yes |
+
+#### ToolLabelEnum
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| ToolLabelEnum | string |  |  |
 
 #### ToolOAuthClientSchemaResponse
 
@@ -21748,6 +21838,20 @@ Enum class for tool provider
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | TriggerCreationMethod | string |  |  |
+
+#### TriggerDebugErrorResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| error | string |  | No |
+| status | string |  | Yes |
+
+#### TriggerDebugWaitingResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| retry_in | integer |  | Yes |
+| status | string |  | Yes |
 
 #### TriggerOAuthAuthorizeResponse
 
@@ -22400,46 +22504,35 @@ How a workflow node is bound to an Agent.
 | ---- | ---- | ----------- | -------- |
 | data | [ [WorkflowDailyTokenCostStatisticItem](#workflowdailytokencoststatisticitem) ] |  | Yes |
 
-#### WorkflowDraftEnvVariable
+#### WorkflowDraftEnvironmentVariableListResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| items | [ [WorkflowDraftEnvironmentVariableResponse](#workflowdraftenvironmentvariableresponse) ] |  | Yes |
+
+#### WorkflowDraftEnvironmentVariableResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | description | string |  | No |
-| edited | boolean |  | No |
-| id | string |  | No |
-| name | string |  | No |
-| selector | [ string ] |  | No |
-| type | string |  | No |
-| value_type | string |  | No |
-| visible | boolean |  | No |
+| editable | boolean |  | Yes |
+| edited | boolean |  | Yes |
+| id | string |  | Yes |
+| name | string |  | Yes |
+| selector | [ string ] |  | Yes |
+| type | string |  | Yes |
+| value |  |  | Yes |
+| value_type | string |  | Yes |
+| visible | boolean |  | Yes |
 
-#### WorkflowDraftEnvVariableList
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [WorkflowDraftEnvVariable](#workflowdraftenvvariable) ] |  | No |
-
-#### WorkflowDraftVariable
+#### WorkflowDraftVariableFullContentResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| description | string |  | No |
-| edited | boolean |  | No |
-| full_content | object |  | No |
-| id | string |  | No |
-| is_truncated | boolean |  | No |
-| name | string |  | No |
-| selector | [ string ] |  | No |
-| type | string |  | No |
-| value | string<br>integer<br>number<br>boolean<br>object<br>[ object ] |  | No |
-| value_type | string |  | No |
-| visible | boolean |  | No |
-
-#### WorkflowDraftVariableList
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [WorkflowDraftVariable](#workflowdraftvariable) ] |  | No |
+| download_url | string |  | Yes |
+| length | integer |  | Yes |
+| size_bytes | integer |  | Yes |
+| value_type | string |  | Yes |
 
 #### WorkflowDraftVariableListQuery
 
@@ -22448,19 +22541,41 @@ How a workflow node is bound to an Agent.
 | limit | integer, <br>**Default:** 20 | Items per page | No |
 | page | integer, <br>**Default:** 1 | Page number | No |
 
-#### WorkflowDraftVariableListWithoutValue
+#### WorkflowDraftVariableListResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| items | [ [WorkflowDraftVariableWithoutValue](#workflowdraftvariablewithoutvalue) ] |  | No |
-| total | integer |  | No |
+| items | [ [WorkflowDraftVariableResponse](#workflowdraftvariableresponse) ] |  | Yes |
+
+#### WorkflowDraftVariableListWithoutValueResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| items | [ [WorkflowDraftVariableWithoutValueResponse](#workflowdraftvariablewithoutvalueresponse) ] |  | Yes |
+| total | integer |  | Yes |
 
 #### WorkflowDraftVariablePatchPayload
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| name | string |  | No |
+| name | string | Variable name | No |
 | value |  |  | No |
+
+#### WorkflowDraftVariableResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| description | string |  | Yes |
+| edited | boolean |  | Yes |
+| full_content | [WorkflowDraftVariableFullContentResponse](#workflowdraftvariablefullcontentresponse) |  | Yes |
+| id | string |  | Yes |
+| is_truncated | boolean |  | Yes |
+| name | string |  | Yes |
+| selector | [ string ] |  | Yes |
+| type | string |  | Yes |
+| value |  |  | Yes |
+| value_type | string |  | Yes |
+| visible | boolean |  | Yes |
 
 #### WorkflowDraftVariableUpdatePayload
 
@@ -22469,19 +22584,19 @@ How a workflow node is bound to an Agent.
 | name | string | Variable name | No |
 | value |  | Variable value | No |
 
-#### WorkflowDraftVariableWithoutValue
+#### WorkflowDraftVariableWithoutValueResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| description | string |  | No |
-| edited | boolean |  | No |
-| id | string |  | No |
-| is_truncated | boolean |  | No |
-| name | string |  | No |
-| selector | [ string ] |  | No |
-| type | string |  | No |
-| value_type | string |  | No |
-| visible | boolean |  | No |
+| description | string |  | Yes |
+| edited | boolean |  | Yes |
+| id | string |  | Yes |
+| is_truncated | boolean |  | Yes |
+| name | string |  | Yes |
+| selector | [ string ] |  | Yes |
+| type | string |  | Yes |
+| value_type | string |  | Yes |
+| visible | boolean |  | Yes |
 
 #### WorkflowEnvironmentVariableResponse
 
@@ -22695,13 +22810,6 @@ tenant's default model. The underlying generator never raises — an empty
 | variable | string |  | No |
 | variable_selector | [ string<br>integer<br>number<br>boolean ] |  | No |
 
-#### WorkflowPublishResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| created_at | integer |  | Yes |
-| result | string |  | Yes |
-
 #### WorkflowResponse
 
 | Name | Type | Description | Required |
@@ -22721,14 +22829,6 @@ tenant's default model. The underlying generator never raises — an empty
 | updated_at | integer |  | Yes |
 | updated_by | [SimpleAccountResponse](#simpleaccountresponse) |  | No |
 | version | string |  | Yes |
-
-#### WorkflowRestoreResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| hash | string |  | Yes |
-| result | string |  | Yes |
-| updated_at | integer |  | Yes |
 
 #### WorkflowRunCountQuery
 

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -1794,7 +1794,7 @@ Get human input form preview for advanced chat workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Human input form preview retrieved | **application/json**: [HumanInputFormPreviewResponse](#humaninputformpreviewresponse)<br> |
+| 200 | Human input form preview | **application/json**: [HumanInputFormPreviewResponse](#humaninputformpreviewresponse)<br> |
 
 ### [POST] /apps/{app_id}/advanced-chat/workflows/draft/human-input/nodes/{node_id}/form/run
 **Submit human input form preview**
@@ -1816,9 +1816,9 @@ Submit human input form preview for advanced chat workflow
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Human input form submitted |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Human input form submission result | **application/json**: [HumanInputFormSubmitResponse](#humaninputformsubmitresponse)<br> |
 
 ### [POST] /apps/{app_id}/advanced-chat/workflows/draft/iteration/nodes/{node_id}/run
 **Run draft workflow iteration node**
@@ -1840,11 +1840,11 @@ Run draft workflow iteration node for advanced chat
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Iteration node run started successfully |
-| 403 | Permission denied |
-| 404 | Node not found |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Iteration node run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 403 | Permission denied |  |
+| 404 | Node not found |  |
 
 ### [POST] /apps/{app_id}/advanced-chat/workflows/draft/loop/nodes/{node_id}/run
 **Run draft workflow loop node**
@@ -1866,11 +1866,11 @@ Run draft workflow loop node for advanced chat
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Loop node run started successfully |
-| 403 | Permission denied |
-| 404 | Node not found |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Loop node run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 403 | Permission denied |  |
+| 404 | Node not found |  |
 
 ### [POST] /apps/{app_id}/advanced-chat/workflows/draft/run
 **Run draft workflow**
@@ -1891,11 +1891,11 @@ Run draft workflow for advanced chat application
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Workflow run started successfully |
-| 400 | Invalid request parameters |
-| 403 | Permission denied |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Workflow run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 400 | Invalid request parameters |  |
+| 403 | Permission denied |  |
 
 ### [GET] /apps/{app_id}/agent/config/files
 #### Parameters
@@ -4084,9 +4084,9 @@ Get default block configurations for workflow
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Default block configurations retrieved successfully |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Default block configurations retrieved successfully | **application/json**: [DefaultBlockConfigsResponse](#defaultblockconfigsresponse)<br> |
 
 ### [GET] /apps/{app_id}/workflows/default-workflow-block-configs/{block_type}
 **Get default block config**
@@ -4103,10 +4103,10 @@ Get default block configuration by type
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Default block configuration retrieved successfully |
-| 404 | Block type not found |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Default block configuration retrieved successfully | **application/json**: [DefaultBlockConfigResponse](#defaultblockconfigresponse)<br> |
+| 404 | Block type not found |  |
 
 ### [GET] /apps/{app_id}/workflows/draft
 **Get draft workflow**
@@ -4164,7 +4164,7 @@ Get conversation variables for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Conversation variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
+| 200 | Conversation variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
 | 404 | Draft workflow not found |  |
 
 ### [POST] /apps/{app_id}/workflows/draft/conversation-variables
@@ -4203,7 +4203,7 @@ Get environment variables for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Environment variables retrieved successfully | **application/json**: [WorkflowDraftEnvironmentVariableListResponse](#workflowdraftenvironmentvariablelistresponse)<br> |
+| 200 | Environment variables retrieved successfully | **application/json**: [EnvironmentVariableListResponse](#environmentvariablelistresponse)<br> |
 | 404 | Draft workflow not found |  |
 
 ### [POST] /apps/{app_id}/workflows/draft/environment-variables
@@ -4270,7 +4270,7 @@ Test human input delivery for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Human input delivery tested | **application/json**: [HumanInputDeliveryTestResponse](#humaninputdeliverytestresponse)<br> |
+| 200 | Human input delivery test result | **application/json**: [EmptyObjectResponse](#emptyobjectresponse)<br> |
 
 ### [POST] /apps/{app_id}/workflows/draft/human-input/nodes/{node_id}/form/preview
 **Preview human input form content and placeholders**
@@ -4294,7 +4294,7 @@ Get human input form preview for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Human input form preview retrieved | **application/json**: [HumanInputFormPreviewResponse](#humaninputformpreviewresponse)<br> |
+| 200 | Human input form preview | **application/json**: [HumanInputFormPreviewResponse](#humaninputformpreviewresponse)<br> |
 
 ### [POST] /apps/{app_id}/workflows/draft/human-input/nodes/{node_id}/form/run
 **Submit human input form preview**
@@ -4316,9 +4316,9 @@ Submit human input form preview for workflow
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Human input form submitted |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Human input form submission result | **application/json**: [HumanInputFormSubmitResponse](#humaninputformsubmitresponse)<br> |
 
 ### [POST] /apps/{app_id}/workflows/draft/iteration/nodes/{node_id}/run
 **Run draft workflow iteration node**
@@ -4338,11 +4338,11 @@ Submit human input form preview for workflow
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Workflow iteration node run started successfully |
-| 403 | Permission denied |
-| 404 | Node not found |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Workflow iteration node run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 403 | Permission denied |  |
+| 404 | Node not found |  |
 
 ### [POST] /apps/{app_id}/workflows/draft/loop/nodes/{node_id}/run
 **Run draft workflow loop node**
@@ -4362,11 +4362,11 @@ Submit human input form preview for workflow
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Workflow loop node run started successfully |
-| 403 | Permission denied |
-| 404 | Node not found |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Workflow loop node run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 403 | Permission denied |  |
+| 404 | Node not found |  |
 
 ### [GET] /apps/{app_id}/workflows/draft/nodes/{node_id}/agent-composer
 #### Parameters
@@ -4553,7 +4553,7 @@ Get last run result for draft workflow node
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Trigger event received and node executed successfully | **application/json**: [WorkflowRunNodeExecutionResponse](#workflowrunnodeexecutionresponse)<br> |
+| 200 | Trigger event received and node executed successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
 | 403 | Permission denied |  |
 | 500 | Internal server error |  |
 
@@ -4587,7 +4587,7 @@ Get variables for a specific node
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
+| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
 
 ### [POST] /apps/{app_id}/workflows/draft/run
 **Run draft workflow**
@@ -4606,10 +4606,10 @@ Get variables for a specific node
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Draft workflow run started successfully |
-| 403 | Permission denied |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Draft workflow run started successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 403 | Permission denied |  |
 
 ### [GET] /apps/{app_id}/workflows/draft/runs/{run_id}/node-outputs
 Snapshot of every node's declared outputs for a draft workflow run.
@@ -4695,7 +4695,7 @@ Get system variables for workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
+| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
 
 ### [POST] /apps/{app_id}/workflows/draft/trigger/run
 **Poll for trigger events and execute full workflow when event arrives**
@@ -4710,15 +4710,15 @@ Get system variables for workflow
 
 | Required | Schema |
 | -------- | ------ |
-|  Yes | **application/json**: [DraftWorkflowTriggerRunPayload](#draftworkflowtriggerrunpayload)<br> |
+|  Yes | **application/json**: [DraftWorkflowTriggerRunRequest](#draftworkflowtriggerrunrequest)<br> |
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Trigger event received and workflow executed successfully |
-| 403 | Permission denied |
-| 500 | Internal server error |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Trigger event received and workflow executed successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 403 | Permission denied |  |
+| 500 | Internal server error |  |
 
 ### [POST] /apps/{app_id}/workflows/draft/trigger/run-all
 **Full workflow debug when the start node is a trigger**
@@ -4737,11 +4737,11 @@ Get system variables for workflow
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Workflow executed successfully |
-| 403 | Permission denied |
-| 500 | Internal server error |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Workflow executed successfully | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 403 | Permission denied |  |
+| 500 | Internal server error |  |
 
 ### [DELETE] /apps/{app_id}/workflows/draft/variables
 Delete all draft workflow variables
@@ -4775,7 +4775,7 @@ Get draft workflow variables
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValueResponse](#workflowdraftvariablelistwithoutvalueresponse)<br> |
+| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValue](#workflowdraftvariablelistwithoutvalue)<br> |
 
 ### [DELETE] /apps/{app_id}/workflows/draft/variables/{variable_id}
 Delete a workflow variable
@@ -4808,7 +4808,7 @@ Get a specific workflow variable
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
+| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
 | 404 | Variable not found |  |
 
 ### [PATCH] /apps/{app_id}/workflows/draft/variables/{variable_id}
@@ -4831,7 +4831,7 @@ Update a workflow variable
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
+| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
 | 404 | Variable not found |  |
 
 ### [PUT] /apps/{app_id}/workflows/draft/variables/{variable_id}/reset
@@ -4848,7 +4848,7 @@ Reset a workflow variable to its default value
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
+| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
 | 204 | Variable reset (no content) |  |
 | 404 | Variable not found |  |
 
@@ -4888,7 +4888,7 @@ Get published workflow for an application
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow published successfully | **application/json**: [PublishWorkflowResponse](#publishworkflowresponse)<br> |
+| 200 | Workflow published successfully | **application/json**: [WorkflowPublishResponse](#workflowpublishresponse)<br> |
 
 ### [GET] /apps/{app_id}/workflows/published/runs/{run_id}/node-outputs
 Snapshot of every node's declared outputs for a published workflow run.
@@ -5033,7 +5033,7 @@ Restore a published workflow version into the draft workflow
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow restored successfully | **application/json**: [SyncDraftWorkflowResponse](#syncdraftworkflowresponse)<br> |
+| 200 | Workflow restored successfully | **application/json**: [WorkflowRestoreResponse](#workflowrestoreresponse)<br> |
 | 400 | Source workflow must be published |  |
 | 404 | Workflow not found |  |
 
@@ -7847,7 +7847,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Datasource plugins retrieved successfully | **application/json**: [DatasourcePluginListResponse](#datasourcepluginlistresponse)<br> |
+| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
 
 ### [POST] /rag/pipelines/imports
 #### Request Body
@@ -7902,7 +7902,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Recommended plugins retrieved successfully | **application/json**: [RagPipelineRecommendedPluginResponse](#ragpipelinerecommendedpluginresponse)<br> |
+| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
 
 ### [POST] /rag/pipelines/transform/datasets/{dataset_id}
 #### Parameters
@@ -7915,7 +7915,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Dataset transformed successfully | **application/json**: [RagPipelineTransformResponse](#ragpipelinetransformresponse)<br> |
+| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/customized/publish
 #### Parameters
@@ -8046,9 +8046,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Default workflow block configurations retrieved successfully |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Default block configs retrieved successfully | **application/json**: [DefaultBlockConfigsResponse](#defaultblockconfigsresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/default-workflow-block-configs/{block_type}
 **Get default block config**
@@ -8063,9 +8063,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Default workflow block configuration retrieved successfully |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Default block config retrieved successfully | **application/json**: [DefaultBlockConfigResponse](#defaultblockconfigresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft
 **Get draft rag pipeline's workflow**
@@ -8122,9 +8122,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Success |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/draft/datasource/variables-inspect
 **Set datasource variables**
@@ -8160,7 +8160,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Environment variables retrieved successfully | **application/json**: [RagPipelineEnvironmentVariableListResponse](#ragpipelineenvironmentvariablelistresponse)<br> |
+| 200 | Environment variables retrieved successfully | **application/json**: [EnvironmentVariableListResponse](#environmentvariablelistresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/draft/iteration/nodes/{node_id}/run
 **Run draft workflow iteration node**
@@ -8180,9 +8180,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Success |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/draft/loop/nodes/{node_id}/run
 **Run draft workflow loop node**
@@ -8202,9 +8202,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Success |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/nodes/{node_id}/last-run
 #### Parameters
@@ -8268,7 +8268,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
+| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/pre-processing/parameters
 **Get first step parameters of rag pipeline**
@@ -8284,7 +8284,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | First step parameters retrieved successfully | **application/json**: [RagPipelineVariablesResponse](#ragpipelinevariablesresponse)<br> |
+| 200 | Success | **application/json**: [RagPipelineStepParametersResponse](#ragpipelinestepparametersresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/processing/parameters
 **Get second step parameters of rag pipeline**
@@ -8300,7 +8300,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Second step parameters retrieved successfully | **application/json**: [RagPipelineVariablesResponse](#ragpipelinevariablesresponse)<br> |
+| 200 | Success | **application/json**: [RagPipelineStepParametersResponse](#ragpipelinestepparametersresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/draft/run
 **Run draft workflow**
@@ -8319,9 +8319,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Success |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/system-variables
 #### Parameters
@@ -8334,7 +8334,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
+| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
 
 ### [DELETE] /rag/pipelines/{pipeline_id}/workflows/draft/variables
 #### Parameters
@@ -8347,7 +8347,7 @@ Initiate OAuth login process
 
 | Code | Description |
 | ---- | ----------- |
-| 204 | Variables deleted successfully |
+| 204 | Workflow variables deleted successfully |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/draft/variables
 **Get draft workflow**
@@ -8356,13 +8356,15 @@ Initiate OAuth login process
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
+| limit | query |  | No | integer, <br>**Default:** 20 |
+| page | query |  | No | integer, <br>**Default:** 1 |
 | pipeline_id | path |  | Yes | string (uuid) |
 
 #### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValueResponse](#workflowdraftvariablelistwithoutvalueresponse)<br> |
+| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValue](#workflowdraftvariablelistwithoutvalue)<br> |
 
 ### [DELETE] /rag/pipelines/{pipeline_id}/workflows/draft/variables/{variable_id}
 #### Parameters
@@ -8390,7 +8392,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
+| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
 
 ### [PATCH] /rag/pipelines/{pipeline_id}/workflows/draft/variables/{variable_id}
 #### Parameters
@@ -8410,7 +8412,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
+| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
 
 ### [PUT] /rag/pipelines/{pipeline_id}/workflows/draft/variables/{variable_id}/reset
 #### Parameters
@@ -8424,8 +8426,8 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
-| 204 | Variable reset to empty state |  |
+| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
+| 204 | Variable reset (no content) |  |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/publish
 **Get published pipeline**
@@ -8497,9 +8499,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Success |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/published/pre-processing/parameters
 **Get first step parameters of rag pipeline**
@@ -8515,7 +8517,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | First step parameters retrieved successfully | **application/json**: [RagPipelineVariablesResponse](#ragpipelinevariablesresponse)<br> |
+| 200 | Success | **application/json**: [RagPipelineStepParametersResponse](#ragpipelinestepparametersresponse)<br> |
 
 ### [GET] /rag/pipelines/{pipeline_id}/workflows/published/processing/parameters
 **Get second step parameters of rag pipeline**
@@ -8531,7 +8533,7 @@ Initiate OAuth login process
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Second step parameters retrieved successfully | **application/json**: [RagPipelineVariablesResponse](#ragpipelinevariablesresponse)<br> |
+| 200 | Success | **application/json**: [RagPipelineStepParametersResponse](#ragpipelinestepparametersresponse)<br> |
 
 ### [POST] /rag/pipelines/{pipeline_id}/workflows/published/run
 **Run published workflow**
@@ -8550,9 +8552,9 @@ Initiate OAuth login process
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Success |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Success | **application/json**: [RagPipelineOpaqueResponse](#ragpipelineopaqueresponse)<br> |
 
 ### [DELETE] /rag/pipelines/{pipeline_id}/workflows/{workflow_id}
 **Delete a published workflow version that is not currently active on the pipeline**
@@ -8807,9 +8809,9 @@ Get all published workflows for a snippet
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Default block configs retrieved successfully |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Default block configs retrieved successfully | **application/json**: [DefaultBlockConfigsResponse](#defaultblockconfigsresponse)<br> |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft
 **Get draft workflow for snippet**
@@ -8846,7 +8848,7 @@ Get all published workflows for a snippet
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Draft workflow synced successfully | **application/json**: [SyncDraftWorkflowResponse](#syncdraftworkflowresponse)<br> |
+| 200 | Draft workflow synced successfully | **application/json**: [WorkflowRestoreResponse](#workflowrestoreresponse)<br> |
 | 400 | Hash mismatch |  |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft/config
@@ -8877,7 +8879,7 @@ Conversation variables are not used in snippet workflows; returns an empty list 
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Conversation variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
+| 200 | Conversation variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft/environment-variables
 Get environment variables from snippet draft workflow graph
@@ -8892,7 +8894,7 @@ Get environment variables from snippet draft workflow graph
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Environment variables retrieved successfully | **application/json**: [WorkflowDraftEnvironmentVariableListResponse](#workflowdraftenvironmentvariablelistresponse)<br> |
+| 200 | Environment variables retrieved successfully | **application/json**: [EnvironmentVariableListResponse](#environmentvariablelistresponse)<br> |
 | 404 | Draft workflow not found |  |
 
 ### [POST] /snippets/{snippet_id}/workflows/draft/iteration/nodes/{node_id}/run
@@ -8919,7 +8921,7 @@ Returns an SSE event stream with iteration progress and results.
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Iteration node run started successfully (SSE stream) | **application/json**: [EventStreamResponse](#eventstreamresponse)<br> |
+| 200 | Iteration node run started successfully (SSE stream) | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
 | 404 | Snippet or draft workflow not found |  |
 
 ### [POST] /snippets/{snippet_id}/workflows/draft/loop/nodes/{node_id}/run
@@ -8946,7 +8948,7 @@ Returns an SSE event stream with loop progress and results.
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Loop node run started successfully (SSE stream) | **application/json**: [EventStreamResponse](#eventstreamresponse)<br> |
+| 200 | Loop node run started successfully (SSE stream) | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
 | 404 | Snippet or draft workflow not found |  |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft/nodes/{node_id}/last-run
@@ -9027,7 +9029,7 @@ Get variables for a specific node (snippet draft workflow)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
+| 200 | Node variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
 
 ### [POST] /snippets/{snippet_id}/workflows/draft/run
 **Run draft workflow for snippet**
@@ -9051,7 +9053,7 @@ and returns an SSE event stream with execution progress and results.
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Draft workflow run started successfully (SSE stream) | **application/json**: [EventStreamResponse](#eventstreamresponse)<br> |
+| 200 | Draft workflow run started successfully (SSE stream) | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
 | 404 | Snippet or draft workflow not found |  |
 
 ### [GET] /snippets/{snippet_id}/workflows/draft/system-variables
@@ -9067,7 +9069,7 @@ System variables are not used in snippet workflows; returns an empty list for AP
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableListResponse](#workflowdraftvariablelistresponse)<br> |
+| 200 | System variables retrieved successfully | **application/json**: [WorkflowDraftVariableList](#workflowdraftvariablelist)<br> |
 
 ### [DELETE] /snippets/{snippet_id}/workflows/draft/variables
 Delete all draft workflow variables for the current user (snippet scope)
@@ -9099,7 +9101,7 @@ List draft workflow variables without values (paginated, snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValueResponse](#workflowdraftvariablelistwithoutvalueresponse)<br> |
+| 200 | Workflow variables retrieved successfully | **application/json**: [WorkflowDraftVariableListWithoutValue](#workflowdraftvariablelistwithoutvalue)<br> |
 
 ### [DELETE] /snippets/{snippet_id}/workflows/draft/variables/{variable_id}
 Delete a draft workflow variable (snippet scope)
@@ -9132,7 +9134,7 @@ Get a specific draft workflow variable (snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
+| 200 | Variable retrieved successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
 | 404 | Variable not found |  |
 
 ### [PATCH] /snippets/{snippet_id}/workflows/draft/variables/{variable_id}
@@ -9155,7 +9157,7 @@ Update a draft workflow variable (snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
+| 200 | Variable updated successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
 | 404 | Variable not found |  |
 
 ### [PUT] /snippets/{snippet_id}/workflows/draft/variables/{variable_id}/reset
@@ -9172,7 +9174,7 @@ Reset a draft workflow variable to its default value (snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariableResponse](#workflowdraftvariableresponse)<br> |
+| 200 | Variable reset successfully | **application/json**: [WorkflowDraftVariable](#workflowdraftvariable)<br> |
 | 204 | Variable reset (no content) |  |
 | 404 | Variable not found |  |
 
@@ -9211,7 +9213,7 @@ Reset a draft workflow variable to its default value (snippet scope)
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow published successfully | **application/json**: [PublishWorkflowResponse](#publishworkflowresponse)<br> |
+| 200 | Workflow published successfully | **application/json**: [WorkflowPublishResponse](#workflowpublishresponse)<br> |
 | 400 | No draft workflow found |  |
 
 ### [PATCH] /snippets/{snippet_id}/workflows/{workflow_id}
@@ -9254,7 +9256,7 @@ Update published snippet workflow attributes
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Workflow restored successfully | **application/json**: [SyncDraftWorkflowResponse](#syncdraftworkflowresponse)<br> |
+| 200 | Workflow restored successfully | **application/json**: [WorkflowRestoreResponse](#workflowrestoreresponse)<br> |
 | 400 | Source workflow must be published |  |
 | 404 | Workflow not found |  |
 
@@ -16695,25 +16697,6 @@ Model class for provider custom model configuration.
 | ---- | ---- | ----------- | -------- |
 | id | string |  | Yes |
 
-#### DatasourceEntity
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| description | [I18nObject](#i18nobject) | The label of the datasource | Yes |
-| identity | [DatasourceIdentity](#datasourceidentity) |  | Yes |
-| output_schema | object |  | No |
-| parameters | [ [DatasourceParameter](#datasourceparameter) ] |  | No |
-
-#### DatasourceIdentity
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| author | string | The author of the datasource | Yes |
-| icon | string |  | No |
-| label | [I18nObject](#i18nobject) | The label of the datasource | Yes |
-| name | string | The name of the datasource | Yes |
-| provider | string | The provider of the datasource | Yes |
-
 #### DatasourceNodeRunPayload
 
 | Name | Type | Description | Required |
@@ -16748,41 +16731,6 @@ Model class for provider custom model configuration.
 | oauth_custom_client_params | object | Masked plugin-defined OAuth client parameters, when configured for the tenant. | Yes |
 | redirect_uri | string |  | Yes |
 
-#### DatasourceParameter
-
-Overrides type
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| auto_generate | [PluginParameterAutoGenerate](#pluginparameterautogenerate) |  | No |
-| default | number<br>integer<br>string<br>boolean<br>[ object ]<br>object |  | No |
-| description | [I18nObject](#i18nobject) | The description of the parameter | Yes |
-| label | [I18nObject](#i18nobject) | The label presented to the user | Yes |
-| max | number<br>integer |  | No |
-| min | number<br>integer |  | No |
-| name | string | The name of the parameter | Yes |
-| options | [ [PluginParameterOption](#pluginparameteroption) ] |  | No |
-| placeholder | [I18nObject](#i18nobject) | The placeholder presented to the user | No |
-| precision | integer |  | No |
-| required | boolean |  | No |
-| scope | string |  | No |
-| template | [PluginParameterTemplate](#pluginparametertemplate) |  | No |
-| type | [DatasourceParameterType](#datasourceparametertype) | The type of the parameter | Yes |
-
-#### DatasourceParameterType
-
-removes TOOLS_SELECTOR from PluginParameterType
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| DatasourceParameterType | string | removes TOOLS_SELECTOR from PluginParameterType |  |
-
-#### DatasourcePluginListResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| DatasourcePluginListResponse | array |  |  |
-
 #### DatasourceProviderAuthListResponse
 
 | Name | Type | Description | Required |
@@ -16804,35 +16752,6 @@ removes TOOLS_SELECTOR from PluginParameterType
 | plugin_id | string |  | Yes |
 | plugin_unique_identifier | string |  | Yes |
 | provider | string |  | Yes |
-
-#### DatasourceProviderEntityWithPlugin
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| credentials_schema | [ [ProviderConfig](#providerconfig) ] |  | No |
-| datasources | [ [DatasourceEntity](#datasourceentity) ] |  | No |
-| identity | [DatasourceProviderIdentity](#datasourceprovideridentity) |  | Yes |
-| oauth_schema | [OAuthSchema](#oauthschema) |  | No |
-| provider_type | [DatasourceProviderType](#datasourceprovidertype) |  | Yes |
-
-#### DatasourceProviderIdentity
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| author | string | The author of the tool | Yes |
-| description | [I18nObject](#i18nobject) | The description of the tool | Yes |
-| icon | string | The icon of the tool | Yes |
-| label | [I18nObject](#i18nobject) | The label of the tool | Yes |
-| name | string | The name of the tool | Yes |
-| tags | [ [ToolLabelEnum](#toollabelenum) ] | The tags of the tool | No |
-
-#### DatasourceProviderType
-
-Enum class for datasource provider
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| DatasourceProviderType | string | Enum class for datasource provider |  |
 
 #### DatasourceUpdateNamePayload
 
@@ -16941,6 +16860,18 @@ Per-output retry configuration that mirrors ``graphon.RetryConfig`` shape.
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | q | string |  | No |
+
+#### DefaultBlockConfigResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| DefaultBlockConfigResponse | object |  |  |
+
+#### DefaultBlockConfigsResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| DefaultBlockConfigsResponse | array |  |  |
 
 #### DefaultModelDataResponse
 
@@ -17150,6 +17081,12 @@ Request payload for bulk downloading documents as a zip archive.
 | ---- | ---- | ----------- | -------- |
 | node_id | string |  | Yes |
 
+#### DraftWorkflowTriggerRunRequest
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| node_id | string | Node ID | Yes |
+
 #### EducationActivatePayload
 
 | Name | Type | Description | Required |
@@ -17252,6 +17189,12 @@ Request payload for bulk downloading documents as a zip archive.
 | code | string |  | Yes |
 | email | string |  | Yes |
 | token | string |  | Yes |
+
+#### EmptyObjectResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| EmptyObjectResponse | object |  |  |
 
 #### EndpointCreatePayload
 
@@ -17389,6 +17332,27 @@ Request payload for bulk downloading documents as a zip archive.
 | name | string |  | No |
 | value |  |  | No |
 | value_type | string |  | No |
+
+#### EnvironmentVariableItemResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| description | string |  | No |
+| editable | boolean |  | Yes |
+| edited | boolean |  | Yes |
+| id | string |  | Yes |
+| name | string |  | Yes |
+| selector | [ string ] |  | Yes |
+| type | string |  | Yes |
+| value |  |  | Yes |
+| value_type | string |  | Yes |
+| visible | boolean |  | Yes |
+
+#### EnvironmentVariableListResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| items | [ [EnvironmentVariableItemResponse](#environmentvariableitemresponse) ] |  | Yes |
 
 #### EnvironmentVariableUpdatePayload
 
@@ -17813,6 +17777,12 @@ Enum class for form type.
 | ---- | ---- | ----------- | -------- |
 | document_list | [ string ] |  | Yes |
 
+#### GeneratedAppResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| GeneratedAppResponse |  |  |  |
+
 #### GeneratorResponse
 
 | Name | Type | Description | Required |
@@ -17936,11 +17906,6 @@ Enum class for form type.
 | delivery_method_id | string | Delivery method ID | Yes |
 | inputs | object | Values used to fill missing upstream variables referenced in form_content | No |
 
-#### HumanInputDeliveryTestResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-
 #### HumanInputFormDefinition
 
 | Name | Type | Description | Required |
@@ -17966,13 +17931,12 @@ Enum class for form type.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| TYPE | string, <br>**Default:** human_input_required |  | No |
-| actions | [ [HumanInputUserActionResponse](#humaninputuseractionresponse) ] |  | No |
-| display_in_ui | boolean | Always false for draft preview responses. | No |
-| expiration_time | integer | Always null for draft preview responses. | No |
+| actions | [ object ] |  | No |
+| display_in_ui | boolean |  | No |
+| expiration_time | integer |  | No |
 | form_content | string |  | Yes |
 | form_id | string |  | Yes |
-| form_token | string | Always null for draft preview responses. | No |
+| form_token | string |  | No |
 | inputs | [ object ] |  | No |
 | node_id | string |  | Yes |
 | node_title | string |  | Yes |
@@ -17997,6 +17961,12 @@ Enum class for form type.
 | form_inputs | object | Values the user provides for the form's own fields | Yes |
 | inputs | object | Values used to fill missing upstream variables referenced in form_content | Yes |
 
+#### HumanInputFormSubmitResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| HumanInputFormSubmitResponse | object |  |  |
+
 #### HumanInputPauseTypeResponse
 
 | Name | Type | Description | Required |
@@ -18004,14 +17974,6 @@ Enum class for form type.
 | backstage_input_url | string |  | No |
 | form_id | string |  | Yes |
 | type | string |  | Yes |
-
-#### HumanInputUserActionResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| button_style | string, <br>**Default:** default |  | No |
-| id | string |  | Yes |
-| title | string |  | Yes |
 
 #### I18nObject
 
@@ -18234,7 +18196,7 @@ Input field definition for snippet parameters.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| JSONValue |  |  |  |
+| JSONValue | string<br>integer<br>number<br>boolean<br>object<br>[ object ] |  |  |
 
 #### JSONValueType
 
@@ -19730,16 +19692,6 @@ Shared permission levels for resources (datasets, credentials, etc.)
 | ---- | ---- | ----------- | -------- |
 | PluginDaemonOperationResponse |  |  |  |
 
-#### PluginDatasourceProviderEntity
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| declaration | [DatasourceProviderEntityWithPlugin](#datasourceproviderentitywithplugin) |  | Yes |
-| is_authorized | boolean |  | No |
-| plugin_id | string |  | Yes |
-| plugin_unique_identifier | string |  | Yes |
-| provider | string |  | Yes |
-
 #### PluginDebuggingKeyResponse
 
 | Name | Type | Description | Required |
@@ -20129,17 +20081,11 @@ Model class for provider with models response.
 
 #### PublishWorkflowPayload
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| marked_comment | string |  | No |
-| marked_name | string |  | No |
-
-#### PublishWorkflowResponse
+Payload for publishing snippet workflow.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| created_at | integer |  | Yes |
-| result | string |  | Yes |
+| knowledge_base_setting | object |  | No |
 
 #### PublishedWorkflowRunPayload
 
@@ -20224,27 +20170,6 @@ Whitelist scopes accepted by RBAC app and dataset access config APIs.
 | ---- | ---- | ----------- | -------- |
 | yaml_content | string |  | Yes |
 
-#### RagPipelineEnvironmentVariableListResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [RagPipelineEnvironmentVariableResponse](#ragpipelineenvironmentvariableresponse) ] |  | Yes |
-
-#### RagPipelineEnvironmentVariableResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| description | string |  | Yes |
-| editable | boolean |  | Yes |
-| edited | boolean |  | Yes |
-| id | string |  | Yes |
-| name | string |  | Yes |
-| selector | [ string ] |  | Yes |
-| type | string |  | Yes |
-| value |  |  | Yes |
-| value_type | string |  | Yes |
-| visible | boolean |  | Yes |
-
 #### RagPipelineImportCheckDependenciesResponse
 
 | Name | Type | Description | Required |
@@ -20277,28 +20202,19 @@ Whitelist scopes accepted by RBAC app and dataset access config APIs.
 | pipeline_id | string |  | No |
 | status | [ImportStatus](#importstatus) |  | Yes |
 
+#### RagPipelineOpaqueResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| RagPipelineOpaqueResponse |  |  |  |
+
 #### RagPipelineRecommendedPluginQuery
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | type | string, <br>**Default:** all |  | No |
 
-#### RagPipelineRecommendedPluginResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| installed_recommended_plugins | [ object ] | Installed tool provider payloads. Shape follows the tool provider serializer. | Yes |
-| uninstalled_recommended_plugins | [ object ] | Marketplace plugin manifest payloads returned by the marketplace service. | Yes |
-
-#### RagPipelineTransformResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| dataset_id | string |  | Yes |
-| pipeline_id | string |  | Yes |
-| status | string |  | Yes |
-
-#### RagPipelineVariablesResponse
+#### RagPipelineStepParametersResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
@@ -21276,9 +21192,9 @@ The subscription constructor of the trigger provider
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| hash | string |  | Yes |
-| result | string |  | Yes |
-| updated_at | integer |  | Yes |
+| hash | string |  | No |
+| result | string |  | No |
+| updated_at | string |  | No |
 
 #### SystemConfigurationResponse
 
@@ -21538,12 +21454,6 @@ Available voices
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | data | [ [TokensPerSecondStatisticItem](#tokenspersecondstatisticitem) ] |  | Yes |
-
-#### ToolLabelEnum
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| ToolLabelEnum | string |  |  |
 
 #### ToolOAuthClientSchemaResponse
 
@@ -21838,20 +21748,6 @@ Enum class for tool provider
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | TriggerCreationMethod | string |  |  |
-
-#### TriggerDebugErrorResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| error | string |  | No |
-| status | string |  | Yes |
-
-#### TriggerDebugWaitingResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| retry_in | integer |  | Yes |
-| status | string |  | Yes |
 
 #### TriggerOAuthAuthorizeResponse
 
@@ -22504,35 +22400,46 @@ How a workflow node is bound to an Agent.
 | ---- | ---- | ----------- | -------- |
 | data | [ [WorkflowDailyTokenCostStatisticItem](#workflowdailytokencoststatisticitem) ] |  | Yes |
 
-#### WorkflowDraftEnvironmentVariableListResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [WorkflowDraftEnvironmentVariableResponse](#workflowdraftenvironmentvariableresponse) ] |  | Yes |
-
-#### WorkflowDraftEnvironmentVariableResponse
+#### WorkflowDraftEnvVariable
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | description | string |  | No |
-| editable | boolean |  | Yes |
-| edited | boolean |  | Yes |
-| id | string |  | Yes |
-| name | string |  | Yes |
-| selector | [ string ] |  | Yes |
-| type | string |  | Yes |
-| value |  |  | Yes |
-| value_type | string |  | Yes |
-| visible | boolean |  | Yes |
+| edited | boolean |  | No |
+| id | string |  | No |
+| name | string |  | No |
+| selector | [ string ] |  | No |
+| type | string |  | No |
+| value_type | string |  | No |
+| visible | boolean |  | No |
 
-#### WorkflowDraftVariableFullContentResponse
+#### WorkflowDraftEnvVariableList
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| download_url | string |  | Yes |
-| length | integer |  | Yes |
-| size_bytes | integer |  | Yes |
-| value_type | string |  | Yes |
+| items | [ [WorkflowDraftEnvVariable](#workflowdraftenvvariable) ] |  | No |
+
+#### WorkflowDraftVariable
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| description | string |  | No |
+| edited | boolean |  | No |
+| full_content | object |  | No |
+| id | string |  | No |
+| is_truncated | boolean |  | No |
+| name | string |  | No |
+| selector | [ string ] |  | No |
+| type | string |  | No |
+| value | string<br>integer<br>number<br>boolean<br>object<br>[ object ] |  | No |
+| value_type | string |  | No |
+| visible | boolean |  | No |
+
+#### WorkflowDraftVariableList
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| items | [ [WorkflowDraftVariable](#workflowdraftvariable) ] |  | No |
 
 #### WorkflowDraftVariableListQuery
 
@@ -22541,41 +22448,19 @@ How a workflow node is bound to an Agent.
 | limit | integer, <br>**Default:** 20 | Items per page | No |
 | page | integer, <br>**Default:** 1 | Page number | No |
 
-#### WorkflowDraftVariableListResponse
+#### WorkflowDraftVariableListWithoutValue
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| items | [ [WorkflowDraftVariableResponse](#workflowdraftvariableresponse) ] |  | Yes |
-
-#### WorkflowDraftVariableListWithoutValueResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| items | [ [WorkflowDraftVariableWithoutValueResponse](#workflowdraftvariablewithoutvalueresponse) ] |  | Yes |
-| total | integer |  | Yes |
+| items | [ [WorkflowDraftVariableWithoutValue](#workflowdraftvariablewithoutvalue) ] |  | No |
+| total | integer |  | No |
 
 #### WorkflowDraftVariablePatchPayload
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| name | string | Variable name | No |
+| name | string |  | No |
 | value |  |  | No |
-
-#### WorkflowDraftVariableResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| description | string |  | Yes |
-| edited | boolean |  | Yes |
-| full_content | [WorkflowDraftVariableFullContentResponse](#workflowdraftvariablefullcontentresponse) |  | Yes |
-| id | string |  | Yes |
-| is_truncated | boolean |  | Yes |
-| name | string |  | Yes |
-| selector | [ string ] |  | Yes |
-| type | string |  | Yes |
-| value |  |  | Yes |
-| value_type | string |  | Yes |
-| visible | boolean |  | Yes |
 
 #### WorkflowDraftVariableUpdatePayload
 
@@ -22584,19 +22469,19 @@ How a workflow node is bound to an Agent.
 | name | string | Variable name | No |
 | value |  | Variable value | No |
 
-#### WorkflowDraftVariableWithoutValueResponse
+#### WorkflowDraftVariableWithoutValue
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| description | string |  | Yes |
-| edited | boolean |  | Yes |
-| id | string |  | Yes |
-| is_truncated | boolean |  | Yes |
-| name | string |  | Yes |
-| selector | [ string ] |  | Yes |
-| type | string |  | Yes |
-| value_type | string |  | Yes |
-| visible | boolean |  | Yes |
+| description | string |  | No |
+| edited | boolean |  | No |
+| id | string |  | No |
+| is_truncated | boolean |  | No |
+| name | string |  | No |
+| selector | [ string ] |  | No |
+| type | string |  | No |
+| value_type | string |  | No |
+| visible | boolean |  | No |
 
 #### WorkflowEnvironmentVariableResponse
 
@@ -22810,6 +22695,13 @@ tenant's default model. The underlying generator never raises — an empty
 | variable | string |  | No |
 | variable_selector | [ string<br>integer<br>number<br>boolean ] |  | No |
 
+#### WorkflowPublishResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| created_at | integer |  | Yes |
+| result | string |  | Yes |
+
 #### WorkflowResponse
 
 | Name | Type | Description | Required |
@@ -22829,6 +22721,14 @@ tenant's default model. The underlying generator never raises — an empty
 | updated_at | integer |  | Yes |
 | updated_by | [SimpleAccountResponse](#simpleaccountresponse) |  | No |
 | version | string |  | Yes |
+
+#### WorkflowRestoreResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| hash | string |  | Yes |
+| result | string |  | Yes |
+| updated_at | integer |  | Yes |
 
 #### WorkflowRunCountQuery
 

--- a/api/openapi/markdown/web-openapi.md
+++ b/api/openapi/markdown/web-openapi.md
@@ -21,7 +21,7 @@ Convert audio file to text using speech-to-text service.
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [AudioTranscriptResponse](#audiotranscriptresponse)<br> |
+| 200 | Success | **application/json**: [AudioToTextResponse](#audiototextresponse)<br> |
 | 400 | Bad Request |  |
 | 401 | Unauthorized |  |
 | 403 | Forbidden |  |
@@ -40,14 +40,14 @@ Create a chat message for conversational applications.
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 400 | Bad Request |  |
-| 401 | Unauthorized |  |
-| 403 | Forbidden |  |
-| 404 | App Not Found |  |
-| 500 | Internal Server Error |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
+| 400 | Bad Request |
+| 401 | Unauthorized |
+| 403 | Forbidden |
+| 404 | App Not Found |
+| 500 | Internal Server Error |
 
 ### [POST] /chat-messages/{task_id}/stop
 Stop a running chat message task.
@@ -80,14 +80,14 @@ Create a completion message for text generation applications.
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 400 | Bad Request |  |
-| 401 | Unauthorized |  |
-| 403 | Forbidden |  |
-| 404 | App Not Found |  |
-| 500 | Internal Server Error |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
+| 400 | Bad Request |
+| 401 | Unauthorized |
+| 403 | Forbidden |
+| 404 | App Not Found |
+| 500 | Internal Server Error |
 
 ### [POST] /completion-messages/{task_id}/stop
 Stop a running completion message task.
@@ -346,23 +346,29 @@ Verify password reset token validity
 ### [GET] /form/human_input/{form_token}
 **Get human input form definition by token**
 
+Get a human input form definition by token
 GET /api/form/human_input/<form_token>
 
 #### Parameters
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| form_token | path |  | Yes | string |
+| form_token | path | Human input form token | Yes | string |
 
 #### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [HumanInputFormDefinitionResponse](#humaninputformdefinitionresponse)<br> |
+| 200 | Form retrieved successfully | **application/json**: [HumanInputFormDefinitionResponse](#humaninputformdefinitionresponse)<br> |
+| 403 | Forbidden |  |
+| 404 | Form not found |  |
+| 412 | Form already submitted or expired |  |
+| 429 | Too many requests |  |
 
 ### [POST] /form/human_input/{form_token}
 **Submit human input form by token**
 
+Submit a human input form by token
 POST /api/form/human_input/<form_token>
 
 Request body:
@@ -377,7 +383,7 @@ Request body:
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| form_token | path |  | Yes | string |
+| form_token | path | Human input form token | Yes | string |
 
 #### Request Body
 
@@ -389,24 +395,32 @@ Request body:
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [HumanInputFormSubmitResponse](#humaninputformsubmitresponse)<br> |
+| 200 | Form submitted successfully | **application/json**: [HumanInputFormSubmitResponse](#humaninputformsubmitresponse)<br> |
+| 400 | Bad request - invalid submission data |  |
+| 404 | Form not found |  |
+| 412 | Form already submitted or expired |  |
+| 429 | Too many requests |  |
 
 ### [POST] /form/human_input/{form_token}/upload-token
 **Issue an upload token for a human input form**
 
+Issue an upload token for an active human input form
 POST /api/form/human_input/<form_token>/upload-token
 
 #### Parameters
 
 | Name | Located in | Description | Required | Schema |
 | ---- | ---------- | ----------- | -------- | ------ |
-| form_token | path |  | Yes | string |
+| form_token | path | Human input form token | Yes | string |
 
 #### Responses
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [HumanInputUploadTokenResponse](#humaninputuploadtokenresponse)<br> |
+| 200 | Upload token issued successfully | **application/json**: [HumanInputUploadTokenResponse](#humaninputuploadtokenresponse)<br> |
+| 404 | Form not found |  |
+| 412 | Form already submitted or expired |  |
+| 429 | Too many requests |  |
 
 ### [POST] /human-input-forms/files
 **Upload one local file or remote URL file for a HITL human input form**
@@ -526,14 +540,14 @@ Generate a new completion similar to an existing message (completion apps only).
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 400 | Bad Request - Not a completion app or feature disabled |  |
-| 401 | Unauthorized |  |
-| 403 | Forbidden |  |
-| 404 | Message Not Found |  |
-| 500 | Internal Server Error |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
+| 400 | Bad Request - Not a completion app or feature disabled |
+| 401 | Unauthorized |
+| 403 | Forbidden |
+| 404 | Message Not Found |
+| 500 | Internal Server Error |
 
 ### [GET] /messages/{message_id}/suggested-questions
 Get suggested follow-up questions after a message (chat apps only).
@@ -752,7 +766,7 @@ Retrieve app site information and configuration.
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [AppSiteInfoResponse](#appsiteinforesponse)<br> |
+| 200 | Success | **application/json**: [WebAppSiteResponse](#webappsiteresponse)<br> |
 | 400 | Bad Request |  |
 | 401 | Unauthorized |  |
 | 403 | Forbidden |  |
@@ -799,13 +813,13 @@ Convert text to audio using text-to-speech service.
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [AudioBinaryResponse](#audiobinaryresponse)<br> |
-| 400 | Bad Request |  |
-| 401 | Unauthorized |  |
-| 403 | Forbidden |  |
-| 500 | Internal Server Error |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
+| 400 | Bad Request |
+| 401 | Unauthorized |
+| 403 | Forbidden |
+| 500 | Internal Server Error |
 
 ### [GET] /webapp/access-mode
 Retrieve the access mode for a web application (public or restricted).
@@ -856,14 +870,14 @@ Execute a workflow with provided inputs and files.
 
 #### Responses
 
-| Code | Description | Schema |
-| ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
-| 400 | Bad Request |  |
-| 401 | Unauthorized |  |
-| 403 | Forbidden |  |
-| 404 | App Not Found |  |
-| 500 | Internal Server Error |  |
+| Code | Description |
+| ---- | ----------- |
+| 200 | Success |
+| 400 | Bad Request |
+| 401 | Unauthorized |
+| 403 | Forbidden |
+| 404 | App Not Found |
+| 500 | Internal Server Error |
 
 ### [POST] /workflows/tasks/{task_id}/stop
 **Stop workflow task**
@@ -967,59 +981,7 @@ Returns Server-Sent Events stream.
 | ---- | ---- | ----------- | -------- |
 | appId | string | Application ID | Yes |
 
-#### AppSiteInfoResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| app_id | string |  | Yes |
-| can_replace_logo | boolean |  | Yes |
-| custom_config | object |  | No |
-| enable_site | boolean |  | Yes |
-| end_user_id | string |  | No |
-| model_config | [AppSiteModelConfigResponse](#appsitemodelconfigresponse) |  | No |
-| plan | string |  | No |
-| site | [AppSiteResponse](#appsiteresponse) |  | Yes |
-
-#### AppSiteModelConfigResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| model |  |  | Yes |
-| more_like_this |  |  | Yes |
-| opening_statement | string |  | No |
-| pre_prompt | string |  | No |
-| suggested_questions |  |  | Yes |
-| suggested_questions_after_answer |  |  | Yes |
-| user_input_form |  |  | Yes |
-
-#### AppSiteResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| chat_color_theme | string |  | No |
-| chat_color_theme_inverted | boolean |  | No |
-| copyright | string |  | No |
-| custom_disclaimer | string |  | No |
-| default_language | string |  | No |
-| description | string |  | No |
-| icon | string |  | No |
-| icon_background | string |  | No |
-| icon_type | string |  | No |
-| icon_url | string |  | No |
-| input_placeholder | string |  | No |
-| privacy_policy | string |  | No |
-| prompt_public | boolean |  | No |
-| show_workflow_steps | boolean |  | No |
-| title | string |  | No |
-| use_icon_as_answer_icon | boolean |  | No |
-
-#### AudioBinaryResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| AudioBinaryResponse | string |  |  |
-
-#### AudioTranscriptResponse
+#### AudioToTextResponse
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
@@ -1217,12 +1179,6 @@ Button styles for user actions.
 | ---- | ---- | ----------- | -------- |
 | FormInputConfig | [ParagraphInputConfig](#paragraphinputconfig)<br>[SelectInputConfig](#selectinputconfig)<br>[FileInputConfig](#fileinputconfig)<br>[FileListInputConfig](#filelistinputconfig) |  |  |
 
-#### GeneratedAppResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| GeneratedAppResponse |  |  |  |
-
 #### HumanInputContent
 
 | Name | Type | Description | Required |
@@ -1261,11 +1217,11 @@ Parsed multipart form fields for HITL uploads.
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | expiration_time | integer |  | Yes |
-| form_content |  |  | Yes |
-| inputs |  |  | Yes |
+| form_content | string |  | Yes |
+| inputs | [ [FormInputConfig](#forminputconfig) ] |  | Yes |
 | resolved_default_values | object |  | Yes |
-| site | object |  | No |
-| user_actions |  |  | Yes |
+| site | [WebAppSiteResponse](#webappsiteresponse) |  | No |
+| user_actions | [ [UserActionConfig](#useractionconfig) ] |  | Yes |
 
 #### HumanInputFormSubmissionData
 
@@ -1307,7 +1263,7 @@ Parsed multipart form fields for HITL uploads.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| JSONValue | string<br>integer<br>number<br>boolean<br>object<br>[ object ] |  |  |
+| JSONValue |  |  |  |
 
 #### JSONValueType
 
@@ -1688,6 +1644,26 @@ in form definiton, or a variable while the workflow is running.
 | ---- | ---- | ----------- | -------- |
 | protocol | string |  | Yes |
 
+#### WebAppCustomConfigResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| remove_webapp_brand | boolean |  | Yes |
+| replace_webapp_logo | string |  | No |
+
+#### WebAppSiteResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| app_id | string |  | Yes |
+| can_replace_logo | boolean |  | Yes |
+| custom_config | [WebAppCustomConfigResponse](#webappcustomconfigresponse) |  | No |
+| enable_site | boolean |  | Yes |
+| end_user_id | string |  | No |
+| model_config | [WebModelConfigResponse](#webmodelconfigresponse) |  | No |
+| plan | string |  | Yes |
+| site | [WebSiteResponse](#websiteresponse) |  | Yes |
+
 #### WebMessageInfiniteScrollPagination
 
 | Name | Type | Description | Required |
@@ -1715,6 +1691,39 @@ in form definiton, or a variable while the workflow is running.
 | query | string |  | Yes |
 | retriever_resources | [ [RetrieverResource](#retrieverresource) ] |  | Yes |
 | status | string |  | Yes |
+
+#### WebModelConfigResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| model |  |  | No |
+| more_like_this |  |  | No |
+| opening_statement | string |  | No |
+| pre_prompt | string |  | No |
+| suggested_questions |  |  | No |
+| suggested_questions_after_answer |  |  | No |
+| user_input_form |  |  | No |
+
+#### WebSiteResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| chat_color_theme | string |  | No |
+| chat_color_theme_inverted | boolean |  | Yes |
+| copyright | string |  | No |
+| custom_disclaimer | string |  | No |
+| default_language | string |  | No |
+| description | string |  | No |
+| icon | string |  | No |
+| icon_background | string |  | No |
+| icon_type | string |  | No |
+| icon_url | string |  | Yes |
+| input_placeholder | string |  | No |
+| privacy_policy | string |  | No |
+| prompt_public | boolean |  | No |
+| show_workflow_steps | boolean |  | No |
+| title | string |  | Yes |
+| use_icon_as_answer_icon | boolean |  | No |
 
 #### WorkflowRunPayload
 

--- a/api/openapi/markdown/web-openapi.md
+++ b/api/openapi/markdown/web-openapi.md
@@ -40,14 +40,14 @@ Create a chat message for conversational applications.
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Success |
-| 400 | Bad Request |
-| 401 | Unauthorized |
-| 403 | Forbidden |
-| 404 | App Not Found |
-| 500 | Internal Server Error |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Success | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 400 | Bad Request |  |
+| 401 | Unauthorized |  |
+| 403 | Forbidden |  |
+| 404 | App Not Found |  |
+| 500 | Internal Server Error |  |
 
 ### [POST] /chat-messages/{task_id}/stop
 Stop a running chat message task.
@@ -80,14 +80,14 @@ Create a completion message for text generation applications.
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Success |
-| 400 | Bad Request |
-| 401 | Unauthorized |
-| 403 | Forbidden |
-| 404 | App Not Found |
-| 500 | Internal Server Error |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Success | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 400 | Bad Request |  |
+| 401 | Unauthorized |  |
+| 403 | Forbidden |  |
+| 404 | App Not Found |  |
+| 500 | Internal Server Error |  |
 
 ### [POST] /completion-messages/{task_id}/stop
 Stop a running completion message task.
@@ -540,14 +540,14 @@ Generate a new completion similar to an existing message (completion apps only).
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Success |
-| 400 | Bad Request - Not a completion app or feature disabled |
-| 401 | Unauthorized |
-| 403 | Forbidden |
-| 404 | Message Not Found |
-| 500 | Internal Server Error |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Success | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 400 | Bad Request - Not a completion app or feature disabled |  |
+| 401 | Unauthorized |  |
+| 403 | Forbidden |  |
+| 404 | Message Not Found |  |
+| 500 | Internal Server Error |  |
 
 ### [GET] /messages/{message_id}/suggested-questions
 Get suggested follow-up questions after a message (chat apps only).
@@ -870,14 +870,14 @@ Execute a workflow with provided inputs and files.
 
 #### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Success |
-| 400 | Bad Request |
-| 401 | Unauthorized |
-| 403 | Forbidden |
-| 404 | App Not Found |
-| 500 | Internal Server Error |
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | Success | **application/json**: [GeneratedAppResponse](#generatedappresponse)<br> |
+| 400 | Bad Request |  |
+| 401 | Unauthorized |  |
+| 403 | Forbidden |  |
+| 404 | App Not Found |  |
+| 500 | Internal Server Error |  |
 
 ### [POST] /workflows/tasks/{task_id}/stop
 **Stop workflow task**
@@ -1179,6 +1179,12 @@ Button styles for user actions.
 | ---- | ---- | ----------- | -------- |
 | FormInputConfig | [ParagraphInputConfig](#paragraphinputconfig)<br>[SelectInputConfig](#selectinputconfig)<br>[FileInputConfig](#fileinputconfig)<br>[FileListInputConfig](#filelistinputconfig) |  |  |
 
+#### GeneratedAppResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| GeneratedAppResponse |  |  |  |
+
 #### HumanInputContent
 
 | Name | Type | Description | Required |
@@ -1263,7 +1269,7 @@ Parsed multipart form fields for HITL uploads.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| JSONValue |  |  |  |
+| JSONValue | string<br>integer<br>number<br>boolean<br>object<br>[ object ] |  |  |
 
 #### JSONValueType
 

--- a/api/services/file_service.py
+++ b/api/services/file_service.py
@@ -173,7 +173,7 @@ class FileService:
 
         return upload_file
 
-    def get_file_preview(self, file_id: str, tenant_id: str):
+    def get_file_preview(self, file_id: str, tenant_id: str) -> str:
         """
         Return a short text preview extracted from a document file.
         """
@@ -191,9 +191,7 @@ class FileService:
             raise UnsupportedFileTypeError()
 
         text = ExtractProcessor.load_from_upload_file(upload_file, return_text=True)
-        text = text[0:PREVIEW_WORDS_LIMIT] if text else ""
-
-        return text
+        return text[0:PREVIEW_WORDS_LIMIT] if text else ""
 
     def get_image_preview(self, file_id: str, timestamp: str, nonce: str, sign: str):
         result = file_helpers.verify_image_signature(

--- a/api/tests/test_containers_integration_tests/controllers/web/test_site.py
+++ b/api/tests/test_containers_integration_tests/controllers/web/test_site.py
@@ -2,22 +2,22 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import Forbidden
 
-from controllers.web.site import AppSiteApi, AppSiteInfo
+from controllers.web.site import AppSiteApi, WebAppSiteResponse, WebModelConfigResponse
 from models import Tenant, TenantStatus
-from models.model import App, AppMode, CustomizeTokenStrategy, Site
+from models.account import TenantCustomConfigDict
+from models.model import App, AppMode, AppModelConfig, CustomizeTokenStrategy, EndUser, Site
 from services.feature_service import FeatureModel
 
 
 @pytest.fixture
-def app(flask_app_with_containers) -> Flask:
+def app(flask_app_with_containers: Flask) -> Flask:
     return flask_app_with_containers
 
 
@@ -42,95 +42,201 @@ def _create_app(db_session: Session, tenant_id: str, *, enable_site: bool = True
 
 
 def _create_site(db_session: Session, app_id: str) -> Site:
-    site = Site(
+    site = _site_model(app_id=app_id)
+    db_session.add(site)
+    db_session.commit()
+    return site
+
+
+def _end_user(tenant_id: str, app_id: str) -> EndUser:
+    return EndUser(
+        tenant_id=tenant_id,
+        app_id=app_id,
+        type="browser",
+        session_id=f"session-{app_id}",
+    )
+
+
+def _site_model(*, app_id: str) -> Site:
+    return Site(
         app_id=app_id,
         title="Site",
         icon_type="emoji",
         icon="robot",
         icon_background="#fff",
         description="desc",
+        input_placeholder="Ask the app",
         default_language="en",
         chat_color_theme="light",
         chat_color_theme_inverted=False,
-        input_placeholder="Ask the app",
+        custom_disclaimer="",
         customize_token_strategy=CustomizeTokenStrategy.NOT_ALLOW,
         code=f"code-{app_id[-6:]}",
         prompt_public=False,
         show_workflow_steps=True,
         use_icon_as_answer_icon=False,
     )
-    db_session.add(site)
-    db_session.commit()
-    return site
 
 
 class TestAppSiteApi:
     @patch("controllers.web.site.FeatureService.get_features")
-    def test_happy_path(self, mock_features, app: Flask, db_session_with_containers: Session) -> None:
+    def test_happy_path(self, mock_features: MagicMock, app: Flask, db_session_with_containers: Session) -> None:
         app.config["RESTX_MASK_HEADER"] = "X-Fields"
         tenant = _create_tenant(db_session_with_containers)
         app_model = _create_app(db_session_with_containers, tenant.id)
         _create_site(db_session_with_containers, app_model.id)
-        end_user = SimpleNamespace(id="eu-1")
-        mock_features.return_value = FeatureModel(can_replace_logo=False, webapp_copyright_enabled=True)
+        end_user = _end_user(tenant.id, app_model.id)
+        mock_features.return_value = FeatureModel(can_replace_logo=False)
 
         with app.test_request_context("/site"):
             result = AppSiteApi().get(app_model, end_user)
 
         assert result["app_id"] == app_model.id
+        assert result["end_user_id"] == end_user.id
         assert result["plan"] == "basic"
         assert result["enable_site"] is True
-        assert result["site"]["input_placeholder"] == "Ask the app"
 
     def test_missing_site_raises_forbidden(self, app: Flask, db_session_with_containers: Session) -> None:
         app.config["RESTX_MASK_HEADER"] = "X-Fields"
         tenant = _create_tenant(db_session_with_containers)
         app_model = _create_app(db_session_with_containers, tenant.id)
-        end_user = SimpleNamespace(id="eu-1")
+        end_user = _end_user(tenant.id, app_model.id)
 
         with app.test_request_context("/site"):
             with pytest.raises(Forbidden):
                 AppSiteApi().get(app_model, end_user)
 
-    @patch("controllers.web.site.FeatureService.get_features")
-    def test_archived_tenant_raises_forbidden(
-        self, mock_features, app: Flask, db_session_with_containers: Session
-    ) -> None:
+    def test_archived_tenant_raises_forbidden(self, app: Flask, db_session_with_containers: Session) -> None:
         app.config["RESTX_MASK_HEADER"] = "X-Fields"
         tenant = _create_tenant(db_session_with_containers, status=TenantStatus.ARCHIVE)
         app_model = _create_app(db_session_with_containers, tenant.id)
         _create_site(db_session_with_containers, app_model.id)
-        end_user = SimpleNamespace(id="eu-1")
-        mock_features.return_value = FeatureModel(can_replace_logo=False, webapp_copyright_enabled=True)
+        end_user = _end_user(tenant.id, app_model.id)
 
         with app.test_request_context("/site"):
             with pytest.raises(Forbidden):
                 AppSiteApi().get(app_model, end_user)
 
 
-class TestAppSiteInfo:
+def _tenant_model(*, plan: str = "basic", custom_config: TenantCustomConfigDict | None = None) -> Tenant:
+    tenant = Tenant(name="test-tenant", plan=plan)
+    tenant.custom_config_dict = custom_config or {}
+    return tenant
+
+
+def _app_model(*, tenant: Tenant, enable_site: bool = True) -> App:
+    app_model = App(
+        tenant_id=tenant.id,
+        mode=AppMode.CHAT,
+        name="test-app",
+        enable_site=enable_site,
+        enable_api=True,
+    )
+    app_model.id = "app-test"
+    return app_model
+
+
+class TestWebAppSiteResponse:
     def test_basic_fields(self) -> None:
-        tenant = SimpleNamespace(id="tenant-1", plan="basic", custom_config_dict={})
-        site_obj = SimpleNamespace()
-        info = AppSiteInfo(tenant, SimpleNamespace(id="app-1", enable_site=True), site_obj, "eu-1", False)
-
-        assert info.app_id == "app-1"
-        assert info.end_user_id == "eu-1"
-        assert info.enable_site is True
-        assert info.plan == "basic"
-        assert info.can_replace_logo is False
-        assert info.model_config is None
-
-    @patch("controllers.web.site.dify_config", SimpleNamespace(FILES_URL="https://files.example.com"))
-    def test_can_replace_logo_sets_custom_config(self) -> None:
-        tenant = SimpleNamespace(
-            id="tenant-1",
-            plan="pro",
-            custom_config_dict={"remove_webapp_brand": True, "replace_webapp_logo": True},
+        tenant = _tenant_model()
+        app_model = _app_model(tenant=tenant)
+        response = WebAppSiteResponse.from_app_site(
+            tenant=tenant,
+            app_model=app_model,
+            site=_site_model(app_id=app_model.id),
+            end_user_id="eu-1",
+            features=FeatureModel(can_replace_logo=False, webapp_copyright_enabled=True),
+            can_replace_logo=False,
         )
-        site_obj = SimpleNamespace()
-        info = AppSiteInfo(tenant, SimpleNamespace(id="app-1", enable_site=True), site_obj, "eu-1", True)
 
-        assert info.can_replace_logo is True
-        assert info.custom_config["remove_webapp_brand"] is True
-        assert "webapp-logo" in info.custom_config["replace_webapp_logo"]
+        assert response.app_id == app_model.id
+        assert response.end_user_id == "eu-1"
+        assert response.enable_site is True
+        assert response.plan == "basic"
+        assert response.can_replace_logo is False
+        assert response.model_config_ is None
+        assert response.custom_config is None
+        assert response.site.input_placeholder == "Ask the app"
+        assert response.site.custom_disclaimer == ""
+
+    def test_nullable_site_fields_preserve_none(self) -> None:
+        tenant = _tenant_model()
+        app_model = _app_model(tenant=tenant)
+        site = _site_model(app_id=app_model.id)
+        site.chat_color_theme = None
+        site.icon_type = None
+        site.icon = None
+        site.icon_background = None
+        site.description = None
+        site.copyright = None
+        site.privacy_policy = None
+
+        response = WebAppSiteResponse.from_app_site(
+            tenant=tenant,
+            app_model=app_model,
+            site=site,
+            end_user_id=None,
+            features=FeatureModel(can_replace_logo=False, webapp_copyright_enabled=True),
+            can_replace_logo=False,
+        )
+
+        dumped = response.model_dump(mode="json")
+        assert dumped["end_user_id"] is None
+        assert dumped["site"]["chat_color_theme"] is None
+        assert dumped["site"]["icon_type"] is None
+        assert dumped["site"]["icon"] is None
+        assert dumped["site"]["icon_background"] is None
+        assert dumped["site"]["description"] is None
+        assert dumped["site"]["copyright"] is None
+        assert dumped["site"]["privacy_policy"] is None
+        assert dumped["site"]["custom_disclaimer"] == ""
+
+    @patch("controllers.web.site.dify_config.FILES_URL", "https://files.example.com")
+    def test_can_replace_logo_sets_custom_config(self) -> None:
+        tenant = _tenant_model(
+            plan="pro",
+            custom_config={"remove_webapp_brand": True, "replace_webapp_logo": "enabled"},
+        )
+        app_model = _app_model(tenant=tenant)
+        response = WebAppSiteResponse.from_app_site(
+            tenant=tenant,
+            app_model=app_model,
+            site=_site_model(app_id=app_model.id),
+            end_user_id="eu-1",
+            features=FeatureModel(can_replace_logo=True, webapp_copyright_enabled=True),
+            can_replace_logo=True,
+        )
+
+        assert response.can_replace_logo is True
+        assert response.custom_config is not None
+        assert response.custom_config.remove_webapp_brand is True
+        assert response.custom_config.replace_webapp_logo is not None
+        assert "webapp-logo" in response.custom_config.replace_webapp_logo
+
+
+class TestWebModelConfigResponse:
+    def test_serializes_internal_model_config_properties_to_public_keys(self) -> None:
+        model_config = AppModelConfig(
+            app_id="app-test",
+            opening_statement="Hello",
+            suggested_questions='["Question?"]',
+            suggested_questions_after_answer='{"enabled": true}',
+            more_like_this='{"enabled": false}',
+            model='{"provider": "openai", "name": "gpt-4o", "mode": "chat"}',
+            user_input_form='[{"text-input": {"label": "Name", "variable": "name", "required": true}}]',
+            pre_prompt="System prompt",
+            created_by="account-1",
+            updated_by="account-1",
+        )
+
+        dumped = WebModelConfigResponse.model_validate(model_config, from_attributes=True).model_dump(mode="json")
+
+        assert dumped == {
+            "opening_statement": "Hello",
+            "suggested_questions": ["Question?"],
+            "suggested_questions_after_answer": {"enabled": True},
+            "more_like_this": {"enabled": False},
+            "model": {"provider": "openai", "name": "gpt-4o", "mode": "chat"},
+            "user_input_form": [{"text-input": {"label": "Name", "variable": "name", "required": True}}],
+            "pre_prompt": "System prompt",
+        }

--- a/api/tests/unit_tests/controllers/web/test_human_input_form.py
+++ b/api/tests/unit_tests/controllers/web/test_human_input_form.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
@@ -107,13 +106,13 @@ def test_get_form_includes_site(monkeypatch: pytest.MonkeyPatch, app: Flask):
         icon="robot",
         icon_background="#fff",
         description="desc",
+        input_placeholder="Ask the app",
         default_language="en",
         chat_color_theme="light",
         chat_color_theme_inverted=False,
         copyright=None,
         privacy_policy=None,
-        input_placeholder="Ask me anything",
-        custom_disclaimer=None,
+        custom_disclaimer="",
         prompt_public=False,
         show_workflow_steps=True,
         use_icon_as_answer_icon=False,
@@ -139,7 +138,7 @@ def test_get_form_includes_site(monkeypatch: pytest.MonkeyPatch, app: Flask):
     with app.test_request_context("/api/form/human_input/token-1", method="GET"):
         response = HumanInputFormApi().get("token-1")
 
-    body = json.loads(response.get_data(as_text=True))
+    body = response
     assert set(body.keys()) == {
         "site",
         "form_content",
@@ -168,8 +167,8 @@ def test_get_form_includes_site(monkeypatch: pytest.MonkeyPatch, app: Flask):
             "description": "desc",
             "copyright": None,
             "privacy_policy": None,
-            "input_placeholder": "Ask me anything",
-            "custom_disclaimer": None,
+            "input_placeholder": "Ask the app",
+            "custom_disclaimer": "",
             "default_language": "en",
             "prompt_public": False,
             "show_workflow_steps": True,
@@ -186,72 +185,6 @@ def test_get_form_includes_site(monkeypatch: pytest.MonkeyPatch, app: Flask):
     service_mock.get_form_by_token.assert_called_once_with("token-1")
     limiter_mock.is_rate_limited.assert_called_once_with("203.0.113.10")
     limiter_mock.increment_rate_limit.assert_called_once_with("203.0.113.10")
-
-
-def test_serialize_app_site_payload_masks_paid_webapp_fields_when_feature_disabled(monkeypatch: pytest.MonkeyPatch):
-    """Runtime site payload hides paid-only fields for plans that cannot use them."""
-
-    tenant = SimpleNamespace(id="tenant-1", plan="sandbox", custom_config_dict={})
-    app_model = SimpleNamespace(id="app-1", tenant_id="tenant-1", tenant=tenant, enable_site=True)
-    site_model = SimpleNamespace(
-        title="My Site",
-        icon_type="emoji",
-        icon="robot",
-        icon_background="#fff",
-        description="desc",
-        default_language="en",
-        chat_color_theme="light",
-        chat_color_theme_inverted=False,
-        copyright="Dify",
-        privacy_policy=None,
-        input_placeholder="Ask me anything",
-        custom_disclaimer=None,
-        prompt_public=False,
-        show_workflow_steps=True,
-        use_icon_as_answer_icon=False,
-    )
-    features = FeatureModel(can_replace_logo=False, webapp_copyright_enabled=False)
-    features.billing.enabled = True
-    monkeypatch.setattr(site_module.FeatureService, "get_features", lambda tenant_id, **_kwargs: features)
-
-    payload = site_module.serialize_app_site_payload(app_model, site_model, end_user_id=None)
-
-    assert payload["site"]["copyright"] is None
-    assert payload["site"]["input_placeholder"] is None
-
-
-def test_serialize_app_site_payload_keeps_paid_webapp_fields_when_billing_disabled(monkeypatch: pytest.MonkeyPatch):
-    """Self-hosted community runtimes keep site fields because billing is not enforcing the paid gate."""
-
-    tenant = SimpleNamespace(id="tenant-1", plan="basic", custom_config_dict={})
-    app_model = SimpleNamespace(id="app-1", tenant_id="tenant-1", tenant=tenant, enable_site=True)
-    site_model = SimpleNamespace(
-        title="My Site",
-        icon_type="emoji",
-        icon="robot",
-        icon_background="#fff",
-        description="desc",
-        default_language="en",
-        chat_color_theme="light",
-        chat_color_theme_inverted=False,
-        copyright="Dify",
-        privacy_policy=None,
-        input_placeholder="Ask me anything",
-        custom_disclaimer=None,
-        prompt_public=False,
-        show_workflow_steps=True,
-        use_icon_as_answer_icon=False,
-    )
-    monkeypatch.setattr(
-        site_module.FeatureService,
-        "get_features",
-        lambda tenant_id, **_kwargs: FeatureModel(can_replace_logo=False, webapp_copyright_enabled=False),
-    )
-
-    payload = site_module.serialize_app_site_payload(app_model, site_model, end_user_id=None)
-
-    assert payload["site"]["copyright"] == "Dify"
-    assert payload["site"]["input_placeholder"] == "Ask me anything"
 
 
 def test_get_form_uses_runtime_select_options(monkeypatch: pytest.MonkeyPatch, app: Flask):
@@ -319,13 +252,13 @@ def test_get_form_uses_runtime_select_options(monkeypatch: pytest.MonkeyPatch, a
         icon="robot",
         icon_background="#fff",
         description="desc",
+        input_placeholder="Ask the app",
         default_language="en",
         chat_color_theme="light",
         chat_color_theme_inverted=False,
         copyright=None,
         privacy_policy=None,
-        input_placeholder="Ask me anything",
-        custom_disclaimer=None,
+        custom_disclaimer="",
         prompt_public=False,
         show_workflow_steps=True,
         use_icon_as_answer_icon=False,
@@ -346,7 +279,7 @@ def test_get_form_uses_runtime_select_options(monkeypatch: pytest.MonkeyPatch, a
     with app.test_request_context("/api/form/human_input/token-1", method="GET"):
         response = HumanInputFormApi().get("token-1")
 
-    body = json.loads(response.get_data(as_text=True))
+    body = response
     assert body["inputs"] == [input_config.model_dump(mode="json") for input_config in runtime_inputs]
     service_mock.resolve_form_inputs.assert_called_once_with(form)
 
@@ -444,13 +377,13 @@ def test_get_form_allows_backstage_token(monkeypatch: pytest.MonkeyPatch, app: F
         icon="robot",
         icon_background="#fff",
         description="desc",
+        input_placeholder="Ask the app",
         default_language="en",
         chat_color_theme="light",
         chat_color_theme_inverted=False,
         copyright=None,
         privacy_policy=None,
-        input_placeholder="Ask me anything",
-        custom_disclaimer=None,
+        custom_disclaimer="",
         prompt_public=False,
         show_workflow_steps=True,
         use_icon_as_answer_icon=False,
@@ -473,7 +406,7 @@ def test_get_form_allows_backstage_token(monkeypatch: pytest.MonkeyPatch, app: F
     with app.test_request_context("/api/form/human_input/token-1", method="GET"):
         response = HumanInputFormApi().get("token-1")
 
-    body = json.loads(response.get_data(as_text=True))
+    body = response
     assert set(body.keys()) == {
         "site",
         "form_content",
@@ -502,8 +435,8 @@ def test_get_form_allows_backstage_token(monkeypatch: pytest.MonkeyPatch, app: F
             "description": "desc",
             "copyright": None,
             "privacy_policy": None,
-            "input_placeholder": "Ask me anything",
-            "custom_disclaimer": None,
+            "input_placeholder": "Ask the app",
+            "custom_disclaimer": "",
             "default_language": "en",
             "prompt_public": False,
             "show_workflow_steps": True,

--- a/packages/contracts/generated/api/console/files/types.gen.ts
+++ b/packages/contracts/generated/api/console/files/types.gen.ts
@@ -9,11 +9,11 @@ export type AllowedExtensionsResponse = {
 }
 
 export type UploadConfig = {
-  attachment_image_file_size_limit?: number | null
+  attachment_image_file_size_limit: number
   audio_file_size_limit: number
   batch_count_limit: number
   file_size_limit: number
-  file_upload_limit?: number | null
+  file_upload_limit: number
   image_file_batch_limit: number
   image_file_size_limit: number
   single_chunk_attachment_limit: number

--- a/packages/contracts/generated/api/console/files/zod.gen.ts
+++ b/packages/contracts/generated/api/console/files/zod.gen.ts
@@ -13,11 +13,11 @@ export const zAllowedExtensionsResponse = z.object({
  * UploadConfig
  */
 export const zUploadConfig = z.object({
-  attachment_image_file_size_limit: z.int().nullish(),
+  attachment_image_file_size_limit: z.int(),
   audio_file_size_limit: z.int(),
   batch_count_limit: z.int(),
   file_size_limit: z.int(),
-  file_upload_limit: z.int().nullish(),
+  file_upload_limit: z.int(),
   image_file_batch_limit: z.int(),
   image_file_size_limit: z.int(),
   single_chunk_attachment_limit: z.int(),

--- a/packages/contracts/generated/api/web/orpc.gen.ts
+++ b/packages/contracts/generated/api/web/orpc.gen.ts
@@ -453,11 +453,13 @@ export const forgotPassword = {
 /**
  * Issue an upload token for a human input form
  *
+ * Issue an upload token for an active human input form
  * POST /api/form/human_input/<form_token>/upload-token
  */
 export const post13 = oc
   .route({
-    description: 'POST /api/form/human_input/<form_token>/upload-token',
+    description:
+      'Issue an upload token for an active human input form\nPOST /api/form/human_input/<form_token>/upload-token',
     inputStructure: 'detailed',
     method: 'POST',
     operationId: 'postFormHumanInputByFormTokenUploadToken',
@@ -475,11 +477,13 @@ export const uploadToken = {
 /**
  * Get human input form definition by token
  *
+ * Get a human input form definition by token
  * GET /api/form/human_input/<form_token>
  */
 export const get2 = oc
   .route({
-    description: 'GET /api/form/human_input/<form_token>',
+    description:
+      'Get a human input form definition by token\nGET /api/form/human_input/<form_token>',
     inputStructure: 'detailed',
     method: 'GET',
     operationId: 'getFormHumanInputByFormToken',
@@ -493,6 +497,7 @@ export const get2 = oc
 /**
  * Submit human input form by token
  *
+ * Submit a human input form by token
  * POST /api/form/human_input/<form_token>
  *
  * Request body:
@@ -506,7 +511,7 @@ export const get2 = oc
 export const post14 = oc
   .route({
     description:
-      'POST /api/form/human_input/<form_token>\n\nRequest body:\n{\n    "inputs": {\n        "content": "User input content"\n    },\n    "action": "Approve"\n}',
+      'Submit a human input form by token\nPOST /api/form/human_input/<form_token>\n\nRequest body:\n{\n    "inputs": {\n        "content": "User input content"\n    },\n    "action": "Approve"\n}',
     inputStructure: 'detailed',
     method: 'POST',
     operationId: 'postFormHumanInputByFormToken',

--- a/packages/contracts/generated/api/web/types.gen.ts
+++ b/packages/contracts/generated/api/web/types.gen.ts
@@ -213,6 +213,8 @@ export type FormInputConfig
     type: 'file-list'
   } & FileListInputConfig)
 
+export type GeneratedAppResponse = JsonValue
+
 export type HumanInputContent = {
   form_definition?: HumanInputFormDefinition | null
   form_submission_data?: HumanInputFormSubmissionData | null
@@ -282,7 +284,16 @@ export type JsonObject = {
   [key: string]: unknown
 }
 
-export type JsonValue = unknown
+export type JsonValue
+  = | string
+    | number
+    | number
+    | boolean
+    | {
+      [key: string]: unknown
+    }
+    | Array<unknown>
+    | null
 
 export type JsonValueType = unknown
 
@@ -645,6 +656,8 @@ export type WorkflowRunPayload = {
   }
 }
 
+export type GeneratedAppResponseWritable = JsonValue
+
 export type HumanInputFormDefinitionResponseWritable = {
   expiration_time: number
   form_content: string
@@ -727,9 +740,7 @@ export type PostChatMessagesErrors = {
 }
 
 export type PostChatMessagesResponses = {
-  200: {
-    [key: string]: unknown
-  }
+  200: GeneratedAppResponse
 }
 
 export type PostChatMessagesResponse = PostChatMessagesResponses[keyof PostChatMessagesResponses]
@@ -774,9 +785,7 @@ export type PostCompletionMessagesErrors = {
 }
 
 export type PostCompletionMessagesResponses = {
-  200: {
-    [key: string]: unknown
-  }
+  200: GeneratedAppResponse
 }
 
 export type PostCompletionMessagesResponse
@@ -1255,9 +1264,7 @@ export type GetMessagesByMessageIdMoreLikeThisErrors = {
 }
 
 export type GetMessagesByMessageIdMoreLikeThisResponses = {
-  200: {
-    [key: string]: unknown
-  }
+  200: GeneratedAppResponse
 }
 
 export type GetMessagesByMessageIdMoreLikeThisResponse
@@ -1599,9 +1606,7 @@ export type PostWorkflowsRunErrors = {
 }
 
 export type PostWorkflowsRunResponses = {
-  200: {
-    [key: string]: unknown
-  }
+  200: GeneratedAppResponse
 }
 
 export type PostWorkflowsRunResponse = PostWorkflowsRunResponses[keyof PostWorkflowsRunResponses]

--- a/packages/contracts/generated/api/web/types.gen.ts
+++ b/packages/contracts/generated/api/web/types.gen.ts
@@ -46,51 +46,7 @@ export type AppPermissionQuery = {
   appId: string
 }
 
-export type AppSiteInfoResponse = {
-  app_id: string
-  can_replace_logo: boolean
-  custom_config?: {
-    [key: string]: unknown
-  } | null
-  enable_site: boolean
-  end_user_id?: string | null
-  model_config?: AppSiteModelConfigResponse | null
-  plan?: string | null
-  site: AppSiteResponse
-}
-
-export type AppSiteModelConfigResponse = {
-  model: unknown
-  more_like_this: unknown
-  opening_statement?: string | null
-  pre_prompt?: string | null
-  suggested_questions: unknown
-  suggested_questions_after_answer: unknown
-  user_input_form: unknown
-}
-
-export type AppSiteResponse = {
-  chat_color_theme?: string | null
-  chat_color_theme_inverted?: boolean | null
-  copyright?: string | null
-  custom_disclaimer?: string | null
-  default_language?: string | null
-  description?: string | null
-  icon?: string | null
-  icon_background?: string | null
-  icon_type?: string | null
-  icon_url?: string | null
-  input_placeholder?: string | null
-  privacy_policy?: string | null
-  prompt_public?: boolean | null
-  show_workflow_steps?: boolean | null
-  title?: string | null
-  use_icon_as_answer_icon?: boolean | null
-}
-
-export type AudioBinaryResponse = Blob | File
-
-export type AudioTranscriptResponse = {
+export type AudioToTextResponse = {
   text: string
 }
 
@@ -257,8 +213,6 @@ export type FormInputConfig
     type: 'file-list'
   } & FileListInputConfig)
 
-export type GeneratedAppResponse = JsonValue
-
 export type HumanInputContent = {
   form_definition?: HumanInputFormDefinition | null
   form_submission_data?: HumanInputFormSubmissionData | null
@@ -288,15 +242,13 @@ export type HumanInputFormDefinition = {
 
 export type HumanInputFormDefinitionResponse = {
   expiration_time: number
-  form_content: unknown
-  inputs: unknown
+  form_content: string
+  inputs: Array<FormInputConfig>
   resolved_default_values: {
     [key: string]: string
   }
-  site?: {
-    [key: string]: unknown
-  } | null
-  user_actions: unknown
+  site?: WebAppSiteResponse | null
+  user_actions: Array<UserActionConfig>
 }
 
 export type HumanInputFormSubmissionData = {
@@ -318,7 +270,7 @@ export type HumanInputFormSubmitPayload = {
 }
 
 export type HumanInputFormSubmitResponse = {
-  [key: string]: never
+  [key: string]: unknown
 }
 
 export type HumanInputUploadTokenResponse = {
@@ -330,16 +282,7 @@ export type JsonObject = {
   [key: string]: unknown
 }
 
-export type JsonValue
-  = | string
-    | number
-    | number
-    | boolean
-    | {
-      [key: string]: unknown
-    }
-    | Array<unknown>
-    | null
+export type JsonValue = unknown
 
 export type JsonValueType = unknown
 
@@ -619,6 +562,22 @@ export type WebAppAuthSsoModel = {
   protocol: string
 }
 
+export type WebAppCustomConfigResponse = {
+  remove_webapp_brand: boolean
+  replace_webapp_logo?: string | null
+}
+
+export type WebAppSiteResponse = {
+  app_id: string
+  can_replace_logo: boolean
+  custom_config?: WebAppCustomConfigResponse | null
+  enable_site: boolean
+  end_user_id?: string | null
+  model_config?: WebModelConfigResponse | null
+  plan: string
+  site: WebSiteResponse
+}
+
 export type WebMessageInfiniteScrollPagination = {
   data: Array<WebMessageListItem>
   has_more: boolean
@@ -645,6 +604,35 @@ export type WebMessageListItem = {
   status: string
 }
 
+export type WebModelConfigResponse = {
+  model?: unknown
+  more_like_this?: unknown
+  opening_statement?: string | null
+  pre_prompt?: string | null
+  suggested_questions?: unknown
+  suggested_questions_after_answer?: unknown
+  user_input_form?: unknown
+}
+
+export type WebSiteResponse = {
+  chat_color_theme?: string | null
+  chat_color_theme_inverted: boolean
+  copyright?: string | null
+  custom_disclaimer?: string | null
+  default_language?: string | null
+  description?: string | null
+  icon?: string | null
+  icon_background?: string | null
+  icon_type?: string | null
+  readonly icon_url: string | null
+  input_placeholder?: string | null
+  privacy_policy?: string | null
+  prompt_public?: boolean | null
+  show_workflow_steps?: boolean | null
+  title: string
+  use_icon_as_answer_icon?: boolean | null
+}
+
 export type WorkflowRunPayload = {
   files?: Array<{
     transfer_method: 'local_file' | 'remote_url'
@@ -655,6 +643,50 @@ export type WorkflowRunPayload = {
   inputs: {
     [key: string]: unknown
   }
+}
+
+export type HumanInputFormDefinitionResponseWritable = {
+  expiration_time: number
+  form_content: string
+  inputs: Array<FormInputConfig>
+  resolved_default_values: {
+    [key: string]: string
+  }
+  site?: WebAppSiteResponseWritable | null
+  user_actions: Array<UserActionConfig>
+}
+
+export type HumanInputFormSubmitResponseWritable = {
+  [key: string]: unknown
+}
+
+export type WebAppSiteResponseWritable = {
+  app_id: string
+  can_replace_logo: boolean
+  custom_config?: WebAppCustomConfigResponse | null
+  enable_site: boolean
+  end_user_id?: string | null
+  model_config?: WebModelConfigResponse | null
+  plan: string
+  site: WebSiteResponseWritable
+}
+
+export type WebSiteResponseWritable = {
+  chat_color_theme?: string | null
+  chat_color_theme_inverted: boolean
+  copyright?: string | null
+  custom_disclaimer?: string | null
+  default_language?: string | null
+  description?: string | null
+  icon?: string | null
+  icon_background?: string | null
+  icon_type?: string | null
+  input_placeholder?: string | null
+  privacy_policy?: string | null
+  prompt_public?: boolean | null
+  show_workflow_steps?: boolean | null
+  title: string
+  use_icon_as_answer_icon?: boolean | null
 }
 
 export type PostAudioToTextData = {
@@ -674,7 +706,7 @@ export type PostAudioToTextErrors = {
 }
 
 export type PostAudioToTextResponses = {
-  200: AudioTranscriptResponse
+  200: AudioToTextResponse
 }
 
 export type PostAudioToTextResponse = PostAudioToTextResponses[keyof PostAudioToTextResponses]
@@ -695,7 +727,9 @@ export type PostChatMessagesErrors = {
 }
 
 export type PostChatMessagesResponses = {
-  200: GeneratedAppResponse
+  200: {
+    [key: string]: unknown
+  }
 }
 
 export type PostChatMessagesResponse = PostChatMessagesResponses[keyof PostChatMessagesResponses]
@@ -740,7 +774,9 @@ export type PostCompletionMessagesErrors = {
 }
 
 export type PostCompletionMessagesResponses = {
-  200: GeneratedAppResponse
+  200: {
+    [key: string]: unknown
+  }
 }
 
 export type PostCompletionMessagesResponse
@@ -1021,6 +1057,13 @@ export type GetFormHumanInputByFormTokenData = {
   url: '/form/human_input/{form_token}'
 }
 
+export type GetFormHumanInputByFormTokenErrors = {
+  403: unknown
+  404: unknown
+  412: unknown
+  429: unknown
+}
+
 export type GetFormHumanInputByFormTokenResponses = {
   200: HumanInputFormDefinitionResponse
 }
@@ -1037,6 +1080,13 @@ export type PostFormHumanInputByFormTokenData = {
   url: '/form/human_input/{form_token}'
 }
 
+export type PostFormHumanInputByFormTokenErrors = {
+  400: unknown
+  404: unknown
+  412: unknown
+  429: unknown
+}
+
 export type PostFormHumanInputByFormTokenResponses = {
   200: HumanInputFormSubmitResponse
 }
@@ -1051,6 +1101,12 @@ export type PostFormHumanInputByFormTokenUploadTokenData = {
   }
   query?: never
   url: '/form/human_input/{form_token}/upload-token'
+}
+
+export type PostFormHumanInputByFormTokenUploadTokenErrors = {
+  404: unknown
+  412: unknown
+  429: unknown
 }
 
 export type PostFormHumanInputByFormTokenUploadTokenResponses = {
@@ -1199,7 +1255,9 @@ export type GetMessagesByMessageIdMoreLikeThisErrors = {
 }
 
 export type GetMessagesByMessageIdMoreLikeThisResponses = {
-  200: GeneratedAppResponse
+  200: {
+    [key: string]: unknown
+  }
 }
 
 export type GetMessagesByMessageIdMoreLikeThisResponse
@@ -1421,7 +1479,7 @@ export type GetSiteErrors = {
 }
 
 export type GetSiteResponses = {
-  200: AppSiteInfoResponse
+  200: WebAppSiteResponse
 }
 
 export type GetSiteResponse = GetSiteResponses[keyof GetSiteResponses]
@@ -1458,7 +1516,9 @@ export type PostTextToAudioErrors = {
 }
 
 export type PostTextToAudioResponses = {
-  200: AudioBinaryResponse
+  200: {
+    [key: string]: unknown
+  }
 }
 
 export type PostTextToAudioResponse = PostTextToAudioResponses[keyof PostTextToAudioResponses]
@@ -1539,7 +1599,9 @@ export type PostWorkflowsRunErrors = {
 }
 
 export type PostWorkflowsRunResponses = {
-  200: GeneratedAppResponse
+  200: {
+    [key: string]: unknown
+  }
 }
 
 export type PostWorkflowsRunResponse = PostWorkflowsRunResponses[keyof PostWorkflowsRunResponses]

--- a/packages/contracts/generated/api/web/zod.gen.ts
+++ b/packages/contracts/generated/api/web/zod.gen.ts
@@ -47,63 +47,9 @@ export const zAppPermissionQuery = z.object({
 })
 
 /**
- * AppSiteModelConfigResponse
+ * AudioToTextResponse
  */
-export const zAppSiteModelConfigResponse = z.object({
-  model: z.unknown(),
-  more_like_this: z.unknown(),
-  opening_statement: z.string().nullish(),
-  pre_prompt: z.string().nullish(),
-  suggested_questions: z.unknown(),
-  suggested_questions_after_answer: z.unknown(),
-  user_input_form: z.unknown(),
-})
-
-/**
- * AppSiteResponse
- */
-export const zAppSiteResponse = z.object({
-  chat_color_theme: z.string().nullish(),
-  chat_color_theme_inverted: z.boolean().nullish(),
-  copyright: z.string().nullish(),
-  custom_disclaimer: z.string().nullish(),
-  default_language: z.string().nullish(),
-  description: z.string().nullish(),
-  icon: z.string().nullish(),
-  icon_background: z.string().nullish(),
-  icon_type: z.string().nullish(),
-  icon_url: z.string().nullish(),
-  input_placeholder: z.string().nullish(),
-  privacy_policy: z.string().nullish(),
-  prompt_public: z.boolean().nullish(),
-  show_workflow_steps: z.boolean().nullish(),
-  title: z.string().nullish(),
-  use_icon_as_answer_icon: z.boolean().nullish(),
-})
-
-/**
- * AppSiteInfoResponse
- */
-export const zAppSiteInfoResponse = z.object({
-  app_id: z.string(),
-  can_replace_logo: z.boolean(),
-  custom_config: z.record(z.string(), z.unknown()).nullish(),
-  enable_site: z.boolean(),
-  end_user_id: z.string().nullish(),
-  model_config: zAppSiteModelConfigResponse.nullish(),
-  plan: z.string().nullish(),
-  site: zAppSiteResponse,
-})
-
-/**
- * AudioBinaryResponse
- */
-export const zAudioBinaryResponse = z.custom<Blob | File>()
-
-/**
- * AudioTranscriptResponse
- */
-export const zAudioTranscriptResponse = z.object({
+export const zAudioToTextResponse = z.object({
   text: z.string(),
 })
 
@@ -322,21 +268,9 @@ export const zHumanInputFileUploadFormPayload = z.object({
 })
 
 /**
- * HumanInputFormDefinitionResponse
- */
-export const zHumanInputFormDefinitionResponse = z.object({
-  expiration_time: z.int(),
-  form_content: z.unknown(),
-  inputs: z.unknown(),
-  resolved_default_values: z.record(z.string(), z.string()),
-  site: z.record(z.string(), z.unknown()).nullish(),
-  user_actions: z.unknown(),
-})
-
-/**
  * HumanInputFormSubmitResponse
  */
-export const zHumanInputFormSubmitResponse = z.record(z.string(), z.never())
+export const zHumanInputFormSubmitResponse = z.record(z.string(), z.unknown())
 
 /**
  * HumanInputUploadTokenResponse
@@ -348,16 +282,7 @@ export const zHumanInputUploadTokenResponse = z.object({
 
 export const zJsonObject = z.record(z.string(), z.unknown())
 
-export const zJsonValue = z
-  .union([
-    z.string(),
-    z.int(),
-    z.number(),
-    z.boolean(),
-    z.record(z.string(), z.unknown()),
-    z.array(z.unknown()),
-  ])
-  .nullable()
+export const zJsonValue = z.unknown()
 
 /**
  * AgentThought
@@ -375,11 +300,6 @@ export const zAgentThought = z.object({
   tool_input: z.string().nullish(),
   tool_labels: zJsonValue,
 })
-
-/**
- * GeneratedAppResponse
- */
-export const zGeneratedAppResponse = zJsonValue
 
 export const zJsonValueType = z.unknown()
 
@@ -883,6 +803,14 @@ export const zSystemFeatureModel = z.object({
 })
 
 /**
+ * WebAppCustomConfigResponse
+ */
+export const zWebAppCustomConfigResponse = z.object({
+  remove_webapp_brand: z.boolean(),
+  replace_webapp_logo: z.string().nullish(),
+})
+
+/**
  * WebMessageListItem
  */
 export const zWebMessageListItem = z.object({
@@ -913,6 +841,67 @@ export const zWebMessageInfiniteScrollPagination = z.object({
 })
 
 /**
+ * WebModelConfigResponse
+ */
+export const zWebModelConfigResponse = z.object({
+  model: z.unknown().optional(),
+  more_like_this: z.unknown().optional(),
+  opening_statement: z.string().nullish(),
+  pre_prompt: z.string().nullish(),
+  suggested_questions: z.unknown().optional(),
+  suggested_questions_after_answer: z.unknown().optional(),
+  user_input_form: z.unknown().optional(),
+})
+
+/**
+ * WebSiteResponse
+ */
+export const zWebSiteResponse = z.object({
+  chat_color_theme: z.string().nullish(),
+  chat_color_theme_inverted: z.boolean(),
+  copyright: z.string().nullish(),
+  custom_disclaimer: z.string().nullish(),
+  default_language: z.string().nullish(),
+  description: z.string().nullish(),
+  icon: z.string().nullish(),
+  icon_background: z.string().nullish(),
+  icon_type: z.string().nullish(),
+  icon_url: z.string().nullable(),
+  input_placeholder: z.string().nullish(),
+  privacy_policy: z.string().nullish(),
+  prompt_public: z.boolean().nullish(),
+  show_workflow_steps: z.boolean().nullish(),
+  title: z.string(),
+  use_icon_as_answer_icon: z.boolean().nullish(),
+})
+
+/**
+ * WebAppSiteResponse
+ */
+export const zWebAppSiteResponse = z.object({
+  app_id: z.string(),
+  can_replace_logo: z.boolean(),
+  custom_config: zWebAppCustomConfigResponse.nullish(),
+  enable_site: z.boolean(),
+  end_user_id: z.string().nullish(),
+  model_config: zWebModelConfigResponse.nullish(),
+  plan: z.string(),
+  site: zWebSiteResponse,
+})
+
+/**
+ * HumanInputFormDefinitionResponse
+ */
+export const zHumanInputFormDefinitionResponse = z.object({
+  expiration_time: z.int(),
+  form_content: z.string(),
+  inputs: z.array(zFormInputConfig),
+  resolved_default_values: z.record(z.string(), z.string()),
+  site: zWebAppSiteResponse.nullish(),
+  user_actions: z.array(zUserActionConfig),
+})
+
+/**
  * WorkflowRunPayload
  */
 export const zWorkflowRunPayload = z.object({
@@ -930,16 +919,68 @@ export const zWorkflowRunPayload = z.object({
 })
 
 /**
+ * HumanInputFormSubmitResponse
+ */
+export const zHumanInputFormSubmitResponseWritable = z.record(z.string(), z.unknown())
+
+/**
+ * WebSiteResponse
+ */
+export const zWebSiteResponseWritable = z.object({
+  chat_color_theme: z.string().nullish(),
+  chat_color_theme_inverted: z.boolean(),
+  copyright: z.string().nullish(),
+  custom_disclaimer: z.string().nullish(),
+  default_language: z.string().nullish(),
+  description: z.string().nullish(),
+  icon: z.string().nullish(),
+  icon_background: z.string().nullish(),
+  icon_type: z.string().nullish(),
+  input_placeholder: z.string().nullish(),
+  privacy_policy: z.string().nullish(),
+  prompt_public: z.boolean().nullish(),
+  show_workflow_steps: z.boolean().nullish(),
+  title: z.string(),
+  use_icon_as_answer_icon: z.boolean().nullish(),
+})
+
+/**
+ * WebAppSiteResponse
+ */
+export const zWebAppSiteResponseWritable = z.object({
+  app_id: z.string(),
+  can_replace_logo: z.boolean(),
+  custom_config: zWebAppCustomConfigResponse.nullish(),
+  enable_site: z.boolean(),
+  end_user_id: z.string().nullish(),
+  model_config: zWebModelConfigResponse.nullish(),
+  plan: z.string(),
+  site: zWebSiteResponseWritable,
+})
+
+/**
+ * HumanInputFormDefinitionResponse
+ */
+export const zHumanInputFormDefinitionResponseWritable = z.object({
+  expiration_time: z.int(),
+  form_content: z.string(),
+  inputs: z.array(zFormInputConfig),
+  resolved_default_values: z.record(z.string(), z.string()),
+  site: zWebAppSiteResponseWritable.nullish(),
+  user_actions: z.array(zUserActionConfig),
+})
+
+/**
  * Success
  */
-export const zPostAudioToTextResponse = zAudioTranscriptResponse
+export const zPostAudioToTextResponse = zAudioToTextResponse
 
 export const zPostChatMessagesBody = zChatMessagePayload
 
 /**
  * Success
  */
-export const zPostChatMessagesResponse = zGeneratedAppResponse
+export const zPostChatMessagesResponse = z.record(z.string(), z.unknown())
 
 export const zPostChatMessagesByTaskIdStopPath = z.object({
   task_id: z.string(),
@@ -955,7 +996,7 @@ export const zPostCompletionMessagesBody = zCompletionMessagePayload
 /**
  * Success
  */
-export const zPostCompletionMessagesResponse = zGeneratedAppResponse
+export const zPostCompletionMessagesResponse = z.record(z.string(), z.unknown())
 
 export const zPostCompletionMessagesByTaskIdStopPath = z.object({
   task_id: z.string(),
@@ -1069,7 +1110,7 @@ export const zGetFormHumanInputByFormTokenPath = z.object({
 })
 
 /**
- * Success
+ * Form retrieved successfully
  */
 export const zGetFormHumanInputByFormTokenResponse = zHumanInputFormDefinitionResponse
 
@@ -1080,7 +1121,7 @@ export const zPostFormHumanInputByFormTokenPath = z.object({
 })
 
 /**
- * Success
+ * Form submitted successfully
  */
 export const zPostFormHumanInputByFormTokenResponse = zHumanInputFormSubmitResponse
 
@@ -1089,7 +1130,7 @@ export const zPostFormHumanInputByFormTokenUploadTokenPath = z.object({
 })
 
 /**
- * Success
+ * Upload token issued successfully
  */
 export const zPostFormHumanInputByFormTokenUploadTokenResponse = zHumanInputUploadTokenResponse
 
@@ -1158,7 +1199,7 @@ export const zGetMessagesByMessageIdMoreLikeThisQuery = z.object({
 /**
  * Success
  */
-export const zGetMessagesByMessageIdMoreLikeThisResponse = zGeneratedAppResponse
+export const zGetMessagesByMessageIdMoreLikeThisResponse = z.record(z.string(), z.unknown())
 
 export const zGetMessagesByMessageIdSuggestedQuestionsPath = z.object({
   message_id: z.uuid(),
@@ -1237,7 +1278,7 @@ export const zDeleteSavedMessagesByMessageIdResponse = z.void()
 /**
  * Success
  */
-export const zGetSiteResponse = zAppSiteInfoResponse
+export const zGetSiteResponse = zWebAppSiteResponse
 
 /**
  * System features retrieved successfully
@@ -1249,7 +1290,7 @@ export const zPostTextToAudioBody = zTextToAudioPayload
 /**
  * Success
  */
-export const zPostTextToAudioResponse = zAudioBinaryResponse
+export const zPostTextToAudioResponse = z.record(z.string(), z.unknown())
 
 export const zGetWebappAccessModeQuery = z.object({
   appCode: z.string().optional(),
@@ -1284,7 +1325,7 @@ export const zPostWorkflowsRunBody = zWorkflowRunPayload
 /**
  * Success
  */
-export const zPostWorkflowsRunResponse = zGeneratedAppResponse
+export const zPostWorkflowsRunResponse = z.record(z.string(), z.unknown())
 
 export const zPostWorkflowsTasksByTaskIdStopPath = z.object({
   task_id: z.string(),

--- a/packages/contracts/generated/api/web/zod.gen.ts
+++ b/packages/contracts/generated/api/web/zod.gen.ts
@@ -282,7 +282,16 @@ export const zHumanInputUploadTokenResponse = z.object({
 
 export const zJsonObject = z.record(z.string(), z.unknown())
 
-export const zJsonValue = z.unknown()
+export const zJsonValue = z
+  .union([
+    z.string(),
+    z.int(),
+    z.number(),
+    z.boolean(),
+    z.record(z.string(), z.unknown()),
+    z.array(z.unknown()),
+  ])
+  .nullable()
 
 /**
  * AgentThought
@@ -300,6 +309,11 @@ export const zAgentThought = z.object({
   tool_input: z.string().nullish(),
   tool_labels: zJsonValue,
 })
+
+/**
+ * GeneratedAppResponse
+ */
+export const zGeneratedAppResponse = zJsonValue
 
 export const zJsonValueType = z.unknown()
 
@@ -919,6 +933,11 @@ export const zWorkflowRunPayload = z.object({
 })
 
 /**
+ * GeneratedAppResponse
+ */
+export const zGeneratedAppResponseWritable = zJsonValue
+
+/**
  * HumanInputFormSubmitResponse
  */
 export const zHumanInputFormSubmitResponseWritable = z.record(z.string(), z.unknown())
@@ -980,7 +999,7 @@ export const zPostChatMessagesBody = zChatMessagePayload
 /**
  * Success
  */
-export const zPostChatMessagesResponse = z.record(z.string(), z.unknown())
+export const zPostChatMessagesResponse = zGeneratedAppResponse
 
 export const zPostChatMessagesByTaskIdStopPath = z.object({
   task_id: z.string(),
@@ -996,7 +1015,7 @@ export const zPostCompletionMessagesBody = zCompletionMessagePayload
 /**
  * Success
  */
-export const zPostCompletionMessagesResponse = z.record(z.string(), z.unknown())
+export const zPostCompletionMessagesResponse = zGeneratedAppResponse
 
 export const zPostCompletionMessagesByTaskIdStopPath = z.object({
   task_id: z.string(),
@@ -1199,7 +1218,7 @@ export const zGetMessagesByMessageIdMoreLikeThisQuery = z.object({
 /**
  * Success
  */
-export const zGetMessagesByMessageIdMoreLikeThisResponse = z.record(z.string(), z.unknown())
+export const zGetMessagesByMessageIdMoreLikeThisResponse = zGeneratedAppResponse
 
 export const zGetMessagesByMessageIdSuggestedQuestionsPath = z.object({
   message_id: z.uuid(),
@@ -1325,7 +1344,7 @@ export const zPostWorkflowsRunBody = zWorkflowRunPayload
 /**
  * Success
  */
-export const zPostWorkflowsRunResponse = z.record(z.string(), z.unknown())
+export const zPostWorkflowsRunResponse = zGeneratedAppResponse
 
 export const zPostWorkflowsTasksByTaskIdStopPath = z.object({
   task_id: z.string(),

--- a/web/app/components/base/chat/chat/answer/human-input-content/human-input-form.tsx
+++ b/web/app/components/base/chat/chat/answer/human-input-content/human-input-form.tsx
@@ -36,7 +36,7 @@ const HumanInputForm = ({
     setIsSubmitting(false)
   }
 
-  const isActionDisabled = isSubmitting || hasInvalidSelectOrFileInput(renderedFormInputs, inputs)
+  const isActionDisabled = isSubmitting || !formToken || hasInvalidSelectOrFileInput(renderedFormInputs, inputs)
 
   return (
     <>
@@ -55,7 +55,7 @@ const HumanInputForm = ({
             key={action.id}
             disabled={isActionDisabled}
             variant={getButtonStyle(action.button_style) as ButtonProps['variant']}
-            onClick={() => submit(formToken, action.id, inputs)}
+            onClick={() => formToken && submit(formToken, action.id, inputs)}
           >
             {action.title}
           </Button>

--- a/web/types/workflow.ts
+++ b/web/types/workflow.ts
@@ -342,10 +342,10 @@ export type HumanInputFormData = {
   form_content: string
   inputs: FormInputItem[]
   actions: UserAction[]
-  form_token: string
+  form_token: string | null
   resolved_default_values: Record<string, HumanInputResolvedValue>
   display_in_ui: boolean
-  expiration_time: number
+  expiration_time: number | null
 }
 
 export type HumanInputRequiredResponse = {


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

See #28015 . Migrating Flask-RESTX request/response payload and query param models to Pydantic BaseModels.

Affected:

- web chat, completion, file, workflow APIs

Also fixing generated response contract output to stay fresh for this slice.

Recommended/Required to merge: None.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
