### PR TITLE
fix: keep workflow error cards compact with tracing context (#37939)

### DIFF
--- a/web/app/components/base/chat/chat/answer/workflow-process.tsx
+++ b/web/app/components/base/chat/chat/answer/workflow-process.tsx
@@ -32,8 +32,9 @@ const WorkflowProcessItem = ({
   const paused = data.status === WorkflowRunningStatus.Paused
   const latestNode = data.tracing[data.tracing.length - 1]
   const fallbackTitle = t('common.workflowProcess', { ns: 'workflow' })
+  const hasTracing = data.tracing.length > 0
   const collapsedTitle = failed
-    ? data.error || latestNode?.error || latestNode?.title || fallbackTitle
+    ? (hasTracing ? (latestNode?.title || latestNode?.error) : data.error) || latestNode?.title || fallbackTitle
     : latestNode?.title || fallbackTitle
 
   useEffect(() => {
@@ -98,7 +99,7 @@ const WorkflowProcessItem = ({
         <div
           className={cn(
             'min-w-0 grow truncate system-xs-medium',
-            collapse && failed && data.error ? 'text-text-destructive' : 'text-text-secondary',
+            collapse && failed && data.error && !hasTracing ? 'text-text-destructive' : 'text-text-secondary',
           )}
           data-testid="workflow-process-title"
         >

--- a/web/app/components/base/chat/chat/answer/workflow-process.tsx
+++ b/web/app/components/base/chat/chat/answer/workflow-process.tsx
@@ -34,7 +34,7 @@ const WorkflowProcessItem = ({
   const fallbackTitle = t('common.workflowProcess', { ns: 'workflow' })
   const hasTracing = data.tracing.length > 0
   const collapsedTitle = failed
-    ? (hasTracing ? (latestNode?.title || latestNode?.error) : data.error) || latestNode?.title || fallbackTitle
+    ? (hasTracing ? (latestNode?.title || fallbackTitle) : (data.error || fallbackTitle))
     : latestNode?.title || fallbackTitle
 
   useEffect(() => {
@@ -113,7 +113,7 @@ const WorkflowProcessItem = ({
             {
               failed && data.error && (
                 <div
-                  className="mb-1.5 rounded-lg border-[0.5px] border-state-destructive-border bg-state-destructive-hover px-2 py-1.5 system-xs-regular text-text-destructive"
+                  className="mb-1.5 rounded-lg border-[0.5px] border-state-destructive-border bg-state-destructive-hover px-2 py-1.5 system-xs-regular text-text-destructive whitespace-pre-wrap break-words"
                   data-testid="workflow-process-error"
                 >
                   {data.error}


### PR DESCRIPTION
Fixes #37939

## Problem
When a workflow fails and  is populated, the collapsed workflow card title is replaced by the raw workflow error string — even when tracing already identifies which node failed. This makes the collapsed UI noisy and redundant, since the same error is already shown in the expanded error panel.

## Fix
When tracing context exists (), the collapsed title now prefers the failing node's title or error () over the raw  string. The full workflow error remains visible in the dedicated error box when the card is expanded.

- : Adjust collapsed title priority chain to stay compact when tracing is available
- Text color is also updated: destructive red is only applied when the collapsed title actually shows an error (no tracing context), not when it shows a node title