### PR TITLE
test: replace logger mock with caplog in workflow collaboration test

### DIFF
--- a/api/tests/unit_tests/services/test_workflow_collaboration_service.py
+++ b/api/tests/unit_tests/services/test_workflow_collaboration_service.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import Mock, patch
 
 import pytest
@@ -427,16 +428,20 @@ class TestWorkflowCollaborationService:
         repository.delete_leader.assert_not_called()
 
     def test_broadcast_leader_change_logs_emit_errors(
-        self, service: tuple[WorkflowCollaborationService, Mock, Mock]
+        self,
+        service: tuple[WorkflowCollaborationService, Mock, Mock],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         collaboration_service, repository, socketio = service
         repository.get_session_sids.return_value = ["sid-1", "sid-2"]
         socketio.emit.side_effect = [RuntimeError("boom"), None]
 
-        with patch("services.workflow_collaboration_service.logging.exception") as exception_mock:
+        with caplog.at_level(logging.ERROR):
             collaboration_service.broadcast_leader_change("wf-1", "sid-2")
 
-        assert exception_mock.call_count == 1
+        error_records = [record for record in caplog.records if record.levelno == logging.ERROR]
+        assert len(error_records) == 1
+        assert "Failed to emit leader status to session sid-1" in caplog.text
 
     def test_broadcast_online_users_sorts_and_emits(
         self, service: tuple[WorkflowCollaborationService, Mock, Mock]


### PR DESCRIPTION
 #37468

## Summary

Replaces the remaining `logging.exception` patch in `test_workflow_collaboration_service.py` with pytest `caplog`, following the pattern requested in #37468.

Most files listed in the issue are already converted on `main`; this PR covers the last remaining logger mock in that area.

**Changes:**
- `test_broadcast_leader_change_logs_emit_errors`: use `caplog.at_level(logging.ERROR)` instead of patching `logging.exception`
- Assert one ERROR log record and verify the message via `caplog.text`

From Cursor

## Screenshots

N/A — test-only change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

**Test verification:** `uv run pytest tests/unit_tests/services/test_workflow_collaboration_service.py -q -o addopts=` (31 passed). Ruff check/format passed on the changed file.