### PR TITLE
fix: correct media event names in AudioPlayer

### DIFF
--- a/web/app/components/base/audio-btn/__tests__/audio.spec.ts
+++ b/web/app/components/base/audio-btn/__tests__/audio.spec.ts
@@ -20,7 +20,7 @@ vi.mock('@/service/share', () => ({
   textToAudioStream: (...args: unknown[]) => mockTextToAudioStream(...args),
 }))
 
-type AudioEventName = 'ended' | 'paused' | 'loaded' | 'play' | 'timeupdate' | 'loadeddate' | 'canplay' | 'error' | 'sourceopen'
+type AudioEventName = 'ended' | 'pause' | 'play' | 'timeupdate' | 'loadeddata' | 'canplay' | 'error' | 'sourceopen'
 
 type AudioEventListener = () => void
 
@@ -285,10 +285,9 @@ describe('AudioPlayer', () => {
       audio!.emit('play')
       audio!.emit('ended')
       audio!.emit('error')
-      audio!.emit('paused')
-      audio!.emit('loaded')
+      audio!.emit('pause')
+      audio!.emit('loadeddata')
       audio!.emit('timeupdate')
-      audio!.emit('loadeddate')
       audio!.emit('canplay')
 
       expect(player.callback).toBe(callback)

--- a/web/app/components/base/audio-btn/audio.ts
+++ b/web/app/components/base/audio-btn/audio.ts
@@ -66,10 +66,10 @@ export default class AudioPlayer {
       this.audio.addEventListener('ended', () => {
         callback('ended')
       }, false)
-      this.audio.addEventListener('paused', () => {
+      this.audio.addEventListener('pause', () => {
         callback('paused')
       }, true)
-      this.audio.addEventListener('loaded', () => {
+      this.audio.addEventListener('loadeddata', () => {
         callback('loaded')
       }, true)
       this.audio.addEventListener('play', () => {
@@ -78,7 +78,7 @@ export default class AudioPlayer {
       this.audio.addEventListener('timeupdate', () => {
         callback('timeupdate')
       }, true)
-      this.audio.addEventListener('loadeddate', () => {
+      this.audio.addEventListener('loadeddata', () => {
         callback('loadeddate')
       }, true)
       this.audio.addEventListener('canplay', () => {


### PR DESCRIPTION
fix: correct media event names in AudioPlayer

`AudioPlayer.setCallback` registers listeners on events that `HTMLMediaElement` never emits:

- `'paused'` → real event is `'pause'`
- `'loaded'` → no such media event; should be `'loadeddata'`
- `'loadeddate'` → typo of `'loadeddata'`

Because the names are wrong, these listeners never fire in a real browser. The unit test hides this because the mock emits the same misspelled names.

This PR fixes the three `addEventListener` calls to use real DOM event names, and updates the test mocks accordingly. The callback string values passed to consumers are preserved.

Fixes #37840
