### PR TITLE
ci: emit pyrefly diagnostics as GitHub workflow commands

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Run Type Checks
         if: steps.changed-files.outputs.any_changed == 'true'
+        env:
+          PYREFLY_OUTPUT_FORMAT: github
         run: make type-check-core
 
       - name: Dotenv check

--- a/dev/pyrefly-check-local
+++ b/dev/pyrefly-check-local
@@ -28,6 +28,10 @@ pyrefly_args=(
   "--project-excludes=tests/"
 )
 
+if [[ "${PYREFLY_OUTPUT_FORMAT:-}" == "github" ]]; then
+  pyrefly_args+=("--output-format=github")
+fi
+
 if [[ -f "$EXCLUDES_FILE" ]]; then
   while IFS= read -r exclude; do
     [[ -z "$exclude" || "${exclude:0:1}" == "#" ]] && continue
@@ -36,6 +40,14 @@ if [[ -f "$EXCLUDES_FILE" ]]; then
 fi
 
 run_pyrefly() {
+  if [[ "${PYREFLY_OUTPUT_FORMAT:-}" == "github" ]]; then
+    set +e
+    "$@"
+    local pyrefly_status=$?
+    set -e
+    return "$pyrefly_status"
+  fi
+
   local tmp_output
   tmp_output="$(mktemp)"
 
@@ -62,11 +74,17 @@ fi
 run_pyrefly "${pyrefly_command[@]}" || status=$?
 
 if (( ${#target_paths[@]} == 0 )); then
+  test_containers_args=(
+    "--summary=none"
+    "--use-ignore-files=false"
+    "--config=$TEST_CONTAINERS_CONFIG"
+  )
+  if [[ "${PYREFLY_OUTPUT_FORMAT:-}" == "github" ]]; then
+    test_containers_args+=("--output-format=github")
+  fi
   run_pyrefly \
     uv run --directory api --dev pyrefly check \
-    "--summary=none" \
-    "--use-ignore-files=false" \
-    "--config=$TEST_CONTAINERS_CONFIG" \
+    "${test_containers_args[@]}" \
     || status=$?
 fi
 


### PR DESCRIPTION
#36189

## Summary

Enables GitHub-formatted pyrefly output in CI style checks so type errors appear as inline PR annotations.

The previous attempt (#36205) added `outputformat` to `pyproject.toml`, which used the wrong config key and would also affect local runs. This PR instead:

- Sets `PYREFLY_OUTPUT_FORMAT=github` in the `style.yml` type-check step
- Teaches `dev/pyrefly-check-local` to pass `--output-format=github` and stream output directly in that mode
- Keeps the existing `pyrefly_diagnostics.py` formatting for local `make type-check` runs

From Cursor

## Test plan
- [x] Verified `pyrefly check --output-format=github` emits `::error` workflow commands locally
- [ ] CI style check on this PR should show inline pyrefly annotations if any type errors are reported