### PR TITLE
fix: use isolated session in _on_query to prevent premature commit

### DIFF
--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -1030,6 +1030,9 @@ class DatasetRetrieval:
     ):
         """
         Persist dataset query audit rows for retrieval requests.
+
+        Uses an independent session to avoid committing the request-scoped
+        db.session, which would break transaction isolation for the caller.
         """
         if not query and not attachment_ids:
             return
@@ -1059,9 +1062,9 @@ class DatasetRetrieval:
                     created_by=created_by,
                 )
                 dataset_queries.append(dataset_query)
-            if dataset_queries:
-                db.session.add_all(dataset_queries)
-        db.session.commit()
+        if dataset_queries:
+            with sessionmaker(bind=db.engine).begin() as session:
+                session.add_all(dataset_queries)
 
     def _retriever(
         self,


### PR DESCRIPTION
## Problem

`_on_query` calls `db.session.commit()` on the Flask-scoped SQLAlchemy session, which commits **all** pending dirty state from the current request, not just the `DatasetQuery` audit rows. If the downstream workflow fails, the subsequent `db.session.rollback()` cannot revert already-committed modifications, leaving dirty data (e.g. partially recorded token deductions, half-executed node state).

This is the same class of issue as [#37885](https://github.com/langgenius/dify/issues/37885) (billing decorator global commit).

## Root Cause

In `api/core/rag/retrieval/dataset_retrieval.py`, the `_on_query` method:
1. Used `db.session.add_all()` — adding to the shared request-scoped session.
2. Called `db.session.commit()` — flushing all pending changes globally.
3. Called `add_all()` inside the loop instead of after it, re-adding previously accumulated rows on each dataset_id iteration (a latent logic error).

## Fix

Follow the same pattern already demonstrated by `_on_retrieval_end` in the same file: use an **independent session** via `sessionmaker(bind=db.engine).begin()` so the audit log write is fully isolated from the request's main transaction. The context manager auto-commits on success and auto-rolls back on exception.

## Verification

- ✅ The existing `_on_retrieval_end` method (lines ~882-990) already uses `sessionmaker(bind=db.engine).begin()` — this fix applies the same proven pattern.
- ✅ No imports needed — `sessionmaker` is already imported at the top of the file.
- ✅ No behavioral change to callers — `_on_query` signature is unchanged.

Fixes #37886