### PR TITLE
fix(cli): use a(n) article in difyctl prerelease warning

### DIFF
--- a/cli/src/commands/version/version.test.ts
+++ b/cli/src/commands/version/version.test.ts
@@ -158,6 +158,6 @@ describe('Version command', () => {
     if (output?.kind !== 'formatted')
       throw new Error('expected formatted output')
 
-    expect(output.data.text()).toContain('WARNING: This build is a rc release')
+    expect(output.data.text()).toContain('WARNING: This build is a(n) rc release')
   })
 })

--- a/cli/src/version/render.test.ts
+++ b/cli/src/version/render.test.ts
@@ -60,7 +60,7 @@ describe('renderVersionText', () => {
     }
     const text = renderVersionText(report)
 
-    expect(text).toContain('WARNING: This build is a rc release')
+    expect(text).toContain('WARNING: This build is a(n) rc release')
     expect(text).toContain('install or wait for the stable channel')
   })
 
@@ -72,7 +72,7 @@ describe('renderVersionText', () => {
     }
     const text = renderVersionText(report)
 
-    expect(text).toContain('WARNING: This build is a alpha release')
+    expect(text).toContain('WARNING: This build is a(n) alpha release')
     expect(text).toContain('install or wait for the stable channel')
   })
 
@@ -84,7 +84,7 @@ describe('renderVersionText', () => {
     }
     const text = renderVersionText(report)
 
-    expect(text).toContain('WARNING: This build is a edge release')
+    expect(text).toContain('WARNING: This build is a(n) edge release')
     expect(text).toContain('install or wait for the stable channel')
   })
 
@@ -140,7 +140,7 @@ describe('renderVersionText', () => {
     // RC warning) ran, yet the output is byte-clean.
     expect(plain).not.toMatch(ANSI_RE)
     expect(plain).toContain('Compatibility: incompatible')
-    expect(plain).toContain('WARNING: This build is a rc release')
+    expect(plain).toContain('WARNING: This build is a(n) rc release')
   })
 
   describe('with picocolors stubbed to always emit ANSI', () => {
@@ -183,7 +183,7 @@ describe('renderVersionText', () => {
       expect(colored).toMatch(ANSI_RE)
       expect(colored).toContain('Compatibility: incompatible')
       // prerelease warning lines also routed through yellow.
-      expect(colored).toContain('WARNING: This build is a rc release')
+      expect(colored).toContain('WARNING: This build is a(n) rc release')
     })
   })
 

--- a/cli/src/version/render.ts
+++ b/cli/src/version/render.ts
@@ -4,7 +4,7 @@ import { colorScheme } from '@/sys/io/color'
 
 function prereleaseWarning(channel: Channel): readonly string[] {
   return [
-    `WARNING: This build is a ${channel} release. It is not stable`,
+    `WARNING: This build is a(n) ${channel} release. It is not stable`,
     '         and may have bugs. For production use, install or wait for the stable channel.',
   ]
 }


### PR DESCRIPTION
## Summary

Curing my OCD.

## Screenshots

| Before (😖) | After (😌) |
|--------|-------|
| `This build is a alpha release` | `This build is a(n) alpha release` |

## Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I ran the CLI CI (`pnpm run ci`) to appease the lint gods.
