### PR TITLE
fix: remove premature db.session.close() in ToolEngine._create_message_files

### DIFF
--- a/api/core/tools/tool_engine.py
+++ b/api/core/tools/tool_engine.py
@@ -379,6 +379,4 @@ class ToolEngine:
 
             result.append(message_file.id)
 
-        db.session.close()
-
         return result


### PR DESCRIPTION
## Summary

Fixes #37884.

`ToolEngine._create_message_files` explicitly calls `db.session.close()` after persisting binary attachments from multimodal tool responses. Closing the global scoped session inside a local utility method violently severs the database connection bound to the current request/Celery-task context.

Any subsequent ORM access in the same lifecycle — agent reasoning history, billing log writes, lazy-loaded attributes — then raises `sqlalchemy.orm.exc.DetachedInstanceError` or connection errors, aborting the agent execution silently.

**Fix:** Remove the `db.session.close()` call. The scoped session lifecycle is managed by Flask request teardown or Celery task teardown, not by individual utility methods. The `add / commit / refresh` sequence per file is preserved; only the session-closing call is removed.

**Precedent in this codebase:**
- PR #26830 removed the same pattern from `CacheEmbedding.embed_documents`
- PR #36903 and PR #26893 moved session management out of tool-path utilities for the same reason

## Tests

- [ ] Unit tests cover the save path; no new tests needed for a one-line removal
- [ ] Existing `api/tests/unit_tests/core/tools/` tests pass unmodified

## Checklist

- [x] A human has tested this change
- [x] Changes are backwards-compatible