### PR TITLE
fix(api): update vector space billing quota on dataset deletion

### DIFF
--- a/api/tasks/clean_dataset_task.py
+++ b/api/tasks/clean_dataset_task.py
@@ -77,6 +77,7 @@ def clean_dataset_task(
             # Calculate vector space usage before deletion
             vector_size_mb = 0
             from configs import dify_config
+
             if dify_config.BILLING_ENABLED and segments and indexing_technique == "high_quality":
                 total_words_size = sum(segment.word_count * 3 for segment in segments if segment.word_count)
                 total_vector_size = 1536 * 4 * len(segments)
@@ -200,9 +201,10 @@ def clean_dataset_task(
             try:
                 if vector_size_mb > 0:
                     from services.billing_service import BillingService
+
                     BillingService.update_tenant_feature_plan_usage(tenant_id, "vector_space", -vector_size_mb)
             except Exception:
-                logger.exception(f"Failed to update vector_space billing usage for dataset {dataset_id}")
+                logger.exception("Failed to update vector_space billing usage for dataset %s", dataset_id)
 
             end_at = time.perf_counter()
             logger.info(

--- a/api/tasks/clean_dataset_task.py
+++ b/api/tasks/clean_dataset_task.py
@@ -74,6 +74,16 @@ def clean_dataset_task(
                 )
             ).all()
 
+            # Calculate vector space usage before deletion
+            vector_size_mb = 0
+            from configs import dify_config
+            if dify_config.BILLING_ENABLED and segments and indexing_technique == "high_quality":
+                total_words_size = sum(segment.word_count * 3 for segment in segments if segment.word_count)
+                total_vector_size = 1536 * 4 * len(segments)
+                vector_size_mb = int((total_words_size + total_vector_size) / 1024 / 1024)
+                if vector_size_mb < 1 and (total_words_size + total_vector_size) > 0:
+                    vector_size_mb = 1
+
             # Enhanced validation: Check if doc_form is None, empty string, or contains only whitespace
             # This ensures all invalid doc_form values are properly handled
             if doc_form is None or (isinstance(doc_form, str) and not doc_form.strip()):
@@ -186,6 +196,14 @@ def clean_dataset_task(
                 session.execute(file_delete_stmt)
 
             session.commit()
+
+            try:
+                if vector_size_mb > 0:
+                    from services.billing_service import BillingService
+                    BillingService.update_tenant_feature_plan_usage(tenant_id, "vector_space", -vector_size_mb)
+            except Exception:
+                logger.exception(f"Failed to update vector_space billing usage for dataset {dataset_id}")
+
             end_at = time.perf_counter()
             logger.info(
                 click.style(

--- a/api/tasks/clean_document_task.py
+++ b/api/tasks/clean_document_task.py
@@ -55,10 +55,11 @@ def clean_document_task(document_id: str, dataset_id: str, doc_form: str, file_i
 
             index_node_ids = [segment.index_node_id for segment in segments if segment.index_node_id]
             segment_contents = [segment.content for segment in segments]
-            
+
             # Calculate vector space usage before deletion
             vector_size_mb = 0
             from configs import dify_config
+
             if dify_config.BILLING_ENABLED and segments and dataset.indexing_technique == "high_quality":
                 total_words_size = sum(segment.word_count * 3 for segment in segments if segment.word_count)
                 total_vector_size = 1536 * 4 * len(segments)
@@ -160,13 +161,14 @@ def clean_document_task(document_id: str, dataset_id: str, doc_form: str, file_i
                 DatasetMetadataBinding.document_id == document_id,
             )
         )
-        
+
     try:
         if vector_size_mb > 0:
             from services.billing_service import BillingService
+
             BillingService.update_tenant_feature_plan_usage(tenant_id, "vector_space", -vector_size_mb)
     except Exception:
-        logger.exception(f"Failed to update vector_space billing usage for document {document_id}")
+        logger.exception("Failed to update vector_space billing usage for document %s", document_id)
 
     end_at = time.perf_counter()
     logger.info(

--- a/api/tasks/clean_document_task.py
+++ b/api/tasks/clean_document_task.py
@@ -55,6 +55,18 @@ def clean_document_task(document_id: str, dataset_id: str, doc_form: str, file_i
 
             index_node_ids = [segment.index_node_id for segment in segments if segment.index_node_id]
             segment_contents = [segment.content for segment in segments]
+            
+            # Calculate vector space usage before deletion
+            vector_size_mb = 0
+            from configs import dify_config
+            if dify_config.BILLING_ENABLED and segments and dataset.indexing_technique == "high_quality":
+                total_words_size = sum(segment.word_count * 3 for segment in segments if segment.word_count)
+                total_vector_size = 1536 * 4 * len(segments)
+                vector_size_mb = int((total_words_size + total_vector_size) / 1024 / 1024)
+                if vector_size_mb < 1 and (total_words_size + total_vector_size) > 0:
+                    vector_size_mb = 1
+            tenant_id = dataset.tenant_id
+
         except Exception:
             logger.exception("Cleaned document when document deleted failed")
             return
@@ -148,6 +160,13 @@ def clean_document_task(document_id: str, dataset_id: str, doc_form: str, file_i
                 DatasetMetadataBinding.document_id == document_id,
             )
         )
+        
+    try:
+        if vector_size_mb > 0:
+            from services.billing_service import BillingService
+            BillingService.update_tenant_feature_plan_usage(tenant_id, "vector_space", -vector_size_mb)
+    except Exception:
+        logger.exception(f"Failed to update vector_space billing usage for document {document_id}")
 
     end_at = time.perf_counter()
     logger.info(


### PR DESCRIPTION
Fixes #37066

### Description
This PR fixes an issue where the Knowledge Storage quota remained at 50/50 MB even after deleting all datasets. The background deletion tasks (`clean_dataset_task.py` and `clean_document_task.py`) now correctly calculate the vector size of the deleted segments and send a negative delta to the billing service to free up the quota.