### PR TITLE
refactor: Use pytest caplog instead of logger patching in test_spec.py

### DIFF
--- a/api/tests/unit_tests/controllers/console/test_spec.py
+++ b/api/tests/unit_tests/controllers/console/test_spec.py
@@ -22,7 +22,7 @@ class TestSpecSchemaDefinitionsApi:
         assert status == 200
         assert resp == schema_definitions
 
-    def test_get_exception_returns_empty_list(self):
+    def test_get_exception_returns_empty_list(self, caplog):
         api = spec_module.SpecSchemaDefinitionsApi()
         method = unwrap(api.get)
 
@@ -31,14 +31,10 @@ class TestSpecSchemaDefinitionsApi:
                 spec_module,
                 "SchemaManager",
                 side_effect=Exception("boom"),
-            ),
-            patch.object(
-                spec_module.logger,
-                "exception",
-            ) as log_exception,
+            )
         ):
             resp, status = method(api)
 
         assert status == 200
         assert resp == []
-        log_exception.assert_called_once()
+        assert "boom" in caplog.text

--- a/api/tests/unit_tests/controllers/console/test_spec.py
+++ b/api/tests/unit_tests/controllers/console/test_spec.py
@@ -26,12 +26,10 @@ class TestSpecSchemaDefinitionsApi:
         api = spec_module.SpecSchemaDefinitionsApi()
         method = unwrap(api.get)
 
-        with (
-            patch.object(
-                spec_module,
-                "SchemaManager",
-                side_effect=Exception("boom"),
-            )
+        with patch.object(
+            spec_module,
+            "SchemaManager",
+            side_effect=Exception("boom"),
         ):
             resp, status = method(api)
 


### PR DESCRIPTION
This PR addresses issue #37468 by refactoring the test `test_get_exception_returns_empty_list` in `api/tests/unit_tests/controllers/console/test_spec.py` to use `pytest`'s `caplog` fixture instead of manually patching the logger. 

This is part of a larger effort to modernize the test suite and improve log verification. 

Changes:
- Removed `patch.object(spec_module.logger, "exception")`.
- Added `caplog` fixture to the test method.
- Asserted that the exception message is captured in `caplog.text`.