### PR TITLE
fix: plugin installation task popover layout when some failed too long

### DIFF
--- a/web/app/components/plugins/plugin-page/plugin-tasks/components/error-plugin-item.tsx
+++ b/web/app/components/plugins/plugin-page/plugin-tasks/components/error-plugin-item.tsx
@@ -111,7 +111,7 @@ const ErrorPluginItem: FC<ErrorPluginItemProps> = ({ plugin, getIconUrl, languag
           </span>
         )}
         statusText={(
-          <span className="block max-w-full wrap-break-word whitespace-pre-line">
+          <span className="block max-w-full min-w-0 [overflow-wrap:anywhere] break-words whitespace-pre-wrap">
             {plugin.message || errorMsg}
           </span>
         )}

--- a/web/app/components/plugins/plugin-page/plugin-tasks/components/plugin-item.tsx
+++ b/web/app/components/plugins/plugin-page/plugin-tasks/components/plugin-item.tsx
@@ -29,7 +29,7 @@ const PluginItem: FC<PluginItemProps> = ({
   const pluginName = plugin.labels[language] || plugin.plugin_unique_identifier
 
   return (
-    <div className="group/item flex gap-1 rounded-lg p-2 hover:bg-state-base-hover">
+    <div className="group/item flex w-full max-w-full min-w-0 gap-1 overflow-hidden rounded-lg p-2 hover:bg-state-base-hover">
       <div className="relative shrink-0 self-start">
         {hasPluginIcon
           ? (
@@ -44,11 +44,11 @@ const PluginItem: FC<PluginItemProps> = ({
           {statusIcon}
         </div>
       </div>
-      <div className="flex min-w-0 grow flex-col gap-0.5 px-1">
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5 px-1 [overflow-wrap:anywhere]">
         <div className="truncate system-sm-medium text-text-secondary">
           {plugin.labels[language]}
         </div>
-        <div className={`min-w-0 system-xs-regular wrap-break-word ${statusClassName || 'text-text-tertiary'}`}>
+        <div className={`max-w-full min-w-0 system-xs-regular [overflow-wrap:anywhere] wrap-break-word ${statusClassName || 'text-text-tertiary'}`}>
           {statusText}
         </div>
         {action}

--- a/web/app/components/plugins/plugin-page/plugin-tasks/components/plugin-task-list.tsx
+++ b/web/app/components/plugins/plugin-page/plugin-tasks/components/plugin-task-list.tsx
@@ -33,15 +33,15 @@ function PluginTaskList({
 
   return (
     <div
-      className="w-[360px] rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-1 shadow-lg"
+      className="w-[360px] max-w-[calc(100vw-32px)] overflow-hidden rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-1 shadow-lg"
       data-testid="plugin-task-list"
     >
       <ScrollArea
         className="max-h-[420px] overflow-hidden"
         label={t('task.installing', { ns: 'plugin' })}
         slotClassNames={{
-          viewport: 'overscroll-contain',
-          content: 'min-w-0',
+          viewport: 'max-h-[420px] overscroll-contain',
+          content: 'w-full! max-w-full! min-w-0! overflow-x-hidden!',
         }}
       >
         {runningPlugins.length > 0 && (
@@ -103,13 +103,10 @@ function PluginTaskList({
                 {t('task.clearAll', { ns: 'plugin' })}
               </Button>
             </div>
-            <ScrollArea
-              className="overflow-hidden"
-              label={errorSectionTitle}
-              slotClassNames={{
-                viewport: 'overscroll-contain',
-                content: 'min-w-0',
-              }}
+            <div
+              aria-label={errorSectionTitle}
+              className="w-full max-w-full min-w-0 overflow-hidden"
+              role="region"
             >
               {errorPlugins.map(plugin => (
                 <ErrorPluginItem
@@ -120,7 +117,7 @@ function PluginTaskList({
                   onClear={() => onClearSingle(plugin.taskId, plugin.plugin_unique_identifier)}
                 />
               ))}
-            </ScrollArea>
+            </div>
           </>
         )}
       </ScrollArea>


### PR DESCRIPTION


> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix https://github.com/langgenius/dify/issues/37999

Fix plugin installation task popover layout when failed plugin errors contain long continuous strings, such as S3 `HostID` values.

## Changes

- Constrain the plugin task popover width and `ScrollArea.Content` width to prevent long error strings from expanding the popup horizontally.
- Allow failed plugin error messages to preserve line breaks and wrap long continuous strings inside the popup.
- Add width constraints to plugin task items so plugin identifiers and error text cannot overflow the item container.
- Avoid nesting a second `ScrollArea` inside the failed plugins section, so mouse wheel scrolling is handled by the outer task list scroll container.


## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
