### PR TITLE
fix(vdb): remove deprecated SQL options for ADB-PG 7.0 compatibility

### DIFF
--- a/api/providers/vdb/vdb-analyticdb/src/dify_vdb_analyticdb/analyticdb_vector_sql.py
+++ b/api/providers/vdb/vdb-analyticdb/src/dify_vdb_analyticdb/analyticdb_vector_sql.py
@@ -144,7 +144,7 @@ class AnalyticdbVectorBySql:
                     f"id text PRIMARY KEY,"
                     f"vector real[], ref_doc_id text, page_content text, metadata_ jsonb, "
                     f"to_tsvector TSVECTOR"
-                    f") WITH (fillfactor=70) DISTRIBUTED BY (id);"
+                    f") DISTRIBUTED BY (id);"
                 )
                 if embedding_dimension is not None:
                     index_name = f"{self._collection_name}_embedding_idx"
@@ -153,7 +153,7 @@ class AnalyticdbVectorBySql:
                         cur.execute(
                             f"CREATE INDEX {index_name} ON {self.table_name} USING ann(vector) "
                             f"WITH(dim='{embedding_dimension}', distancemeasure='{self.config.metrics}', "
-                            f"pq_enable=0, external_storage=0)"
+                            f"pq_enable=0)"
                         )
                         cur.execute(f"CREATE INDEX ON {self.table_name} USING gin(to_tsvector)")
                     except Exception as e:


### PR DESCRIPTION
ADB-PG 7.0 no longer supports `fillfactor` in CREATE TABLE and `external_storage` in ANN index creation. Remove these options to fix errors when running against ADB-PG 7.0.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #38003

ADB-PG 7.0 no longer supports `fillfactor` in CREATE TABLE and `external_storage` in ANN index creation. Remove these options to fix errors when running against ADB-PG 7.0.

Changes:
- Remove `WITH (fillfactor=70)` from table creation SQL
- Remove `external_storage=0` from ANN index creation options

Tested on ADB-PG 7.0 environment.

## Screenshots

| Before | After |
|--------|-------|
| <img width="1542" height="577" alt="image" src="https://github.com/user-attachments/assets/9c5d7a6b-6863-4018-9b66-83653d0e9f2e" />  | <img width="1867" height="657" alt="image" src="https://github.com/user-attachments/assets/04e84533-bc96-41e2-b47c-5dd0d84d83bc" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
