### PR TITLE
fix(web): keep HITL input-field save button visible in the edit dialog

### DIFF
--- a/web/app/components/base/prompt-editor/plugins/hitl-input-block/__tests__/input-field.spec.tsx
+++ b/web/app/components/base/prompt-editor/plugins/hitl-input-block/__tests__/input-field.spec.tsx
@@ -109,7 +109,11 @@ describe('InputField', () => {
     const scrollBody = panel?.children[1]
     const footer = panel?.lastElementChild
 
-    expect(panel).toHaveClass('max-h-(--shortcut-popup-max-height)', 'overflow-hidden')
+    // The max-height falls back to a viewport unit so the panel stays bounded
+    // (and the footer/actions reachable via the internal scroll) even when it is
+    // rendered outside the shortcuts popup that defines --shortcut-popup-max-height,
+    // e.g. inside the edit dialog. See issue #37979.
+    expect(panel).toHaveClass('max-h-[var(--shortcut-popup-max-height,80dvh)]', 'overflow-hidden')
     expect(header).toHaveClass('shrink-0', 'pb-2')
     expect(scrollBody).toHaveClass('min-h-0', 'flex-1', 'overflow-y-auto')
     expect(footer).toHaveClass('shrink-0', 'bg-components-panel-bg')

--- a/web/app/components/base/prompt-editor/plugins/hitl-input-block/input-field.tsx
+++ b/web/app/components/base/prompt-editor/plugins/hitl-input-block/input-field.tsx
@@ -216,7 +216,7 @@ const InputField: React.FC<InputFieldProps> = ({
   }, [handleSave])
 
   return (
-    <div className="flex max-h-(--shortcut-popup-max-height) w-[372px] flex-col overflow-hidden rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[5px]">
+    <div className="flex max-h-[var(--shortcut-popup-max-height,80dvh)] w-[372px] flex-col overflow-hidden rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[5px]">
       <div className="shrink-0 p-3 pb-2">
         <div className="system-md-semibold text-text-primary">{t(`${i18nPrefix}.title`, { ns: 'workflow' })}</div>
       </div>


### PR DESCRIPTION
## Summary

Fixes #37979 — in a HITL (human-in-the-loop) node, after adding a **File List** field and reopening the node to edit it, the field editor's **Save** button disappears.

### Root cause

The field-editor popover (`InputField`) caps its height with `max-h-(--shortcut-popup-max-height)` and relies on an internal `overflow-y-auto` body + pinned `shrink-0` footer so the actions stay visible while content scrolls.

That CSS variable is **only** provided by the shortcuts-popup plugin used on the *add* path (`shortcuts-popup-plugin`). When a field is reopened for **editing**, `InputField` is rendered inside a `Dialog` (`component-ui.tsx`), where `--shortcut-popup-max-height` is undefined — so the popover gets **no height cap**. Its body then expands to fit all content and `DialogContent`'s `overflow-hidden` clips the footer.

Only the **File List** field config is tall enough (file types + upload methods + max-number slider) to overflow, which is why the bug is specific to adding a File List field; shorter field types still fit.

### Fix

Give the height cap a `80dvh` fallback (matching `DialogContent`'s own `max-h-[80dvh]`) so the popover stays bounded in **any** container:

```diff
- max-h-(--shortcut-popup-max-height)
+ max-h-[var(--shortcut-popup-max-height,80dvh)]
```

On the add path the variable still takes precedence (behavior unchanged); in the edit dialog it falls back to `80dvh`, the body scrolls internally, and the footer/actions remain visible.

## Screenshots

| Before | After |
|--------|-------|
| Save button clipped/hidden after reopening a HITL node with a File List field | Save button stays visible; popover scrolls internally |

_(Behavioral CSS fix — see the reproduction video in #37979.)_

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran the relevant frontend checks (`pnpm test` on the affected suite — 89/89 pass, `pnpm type-check` clean, `pnpm eslint` adds no new errors).

From Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBVXLzDtt5GcRQeJfStmUw