### PR TITLE
fix(web): keep input field dialog actions visible

### DIFF
--- a/web/app/components/base/prompt-editor/plugins/hitl-input-block/__tests__/input-field.spec.tsx
+++ b/web/app/components/base/prompt-editor/plugins/hitl-input-block/__tests__/input-field.spec.tsx
@@ -93,7 +93,7 @@ describe('InputField', () => {
     fileUploadSettingMaxLength = 4
   })
 
-  it('should keep the header and actions visible while the field content scrolls internally', () => {
+  it('should keep the header and actions visible while long field content scrolls', () => {
     const { container } = render(
       <InputField
         nodeId="node-layout"
@@ -109,10 +109,11 @@ describe('InputField', () => {
     const scrollBody = panel?.children[1]
     const footer = panel?.lastElementChild
 
-    expect(panel).toHaveClass('max-h-(--shortcut-popup-max-height)', 'overflow-hidden')
-    expect(header).toHaveClass('shrink-0', 'pb-2')
-    expect(scrollBody).toHaveClass('min-h-0', 'flex-1', 'overflow-y-auto')
-    expect(footer).toHaveClass('shrink-0', 'bg-components-panel-bg')
+    expect(panel).toHaveClass('overflow-y-auto')
+    expect(panel).toHaveAttribute('style', 'max-height: var(--shortcut-popup-max-height, 80dvh);')
+    expect(header).toHaveClass('sticky', 'top-0', 'pb-2')
+    expect(scrollBody).toHaveClass('p-3', 'pt-0', 'pb-0')
+    expect(footer).toHaveClass('sticky', 'bottom-0', 'bg-components-panel-bg')
     expect(footer).not.toHaveClass('border-t')
   })
 

--- a/web/app/components/base/prompt-editor/plugins/hitl-input-block/input-field.tsx
+++ b/web/app/components/base/prompt-editor/plugins/hitl-input-block/input-field.tsx
@@ -216,11 +216,16 @@ const InputField: React.FC<InputFieldProps> = ({
   }, [handleSave])
 
   return (
-    <div className="flex max-h-(--shortcut-popup-max-height) w-[372px] flex-col overflow-hidden rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[5px]">
-      <div className="shrink-0 p-3 pb-2">
+    <div
+      className="w-[372px] overflow-y-auto rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-[5px]"
+      style={{
+        maxHeight: 'var(--shortcut-popup-max-height, 80dvh)',
+      }}
+    >
+      <div className="sticky top-0 z-10 bg-components-panel-bg p-3 pb-2">
         <div className="system-md-semibold text-text-primary">{t(`${i18nPrefix}.title`, { ns: 'workflow' })}</div>
       </div>
-      <div className="min-h-0 flex-1 overflow-y-auto p-3 pt-0 pb-0">
+      <div className="p-3 pt-0 pb-0">
         <div className="mt-3">
           <div className="system-xs-medium text-text-secondary">
             {t(`${i18nPrefix}.fieldType`, { ns: 'workflow' })}
@@ -334,7 +339,7 @@ const InputField: React.FC<InputFieldProps> = ({
           </div>
         )}
       </div>
-      <div className="shrink-0 bg-components-panel-bg p-3">
+      <div className="sticky bottom-0 z-10 bg-components-panel-bg p-3">
         <div className="flex justify-end space-x-2">
           <Button onClick={onCancel}>{t('operation.cancel', { ns: 'common' })}</Button>
           {isEdit


### PR DESCRIPTION
## Summary

Fix #37979 

## Screenshots

| Before | After |
|--------|-------|
| <img width="1024" height="1522" alt="img_v3_02131_0c698c43-b736-4b2d-8dea-4647072e245g" src="https://github.com/user-attachments/assets/b3eb1e48-3e57-4c94-bd73-717728977ef0" /> | <img width="1224" height="1640" alt="img_v3_02131_9b77ea54-bdbf-4d77-90b6-52320c0ba45g" src="https://github.com/user-attachments/assets/b9d6a704-fef5-492f-a41e-f5ba9c712317" /> |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
