### PR TITLE
fix(agent): store active config publish state

### DIFF
--- a/api/migrations/versions/2026_06_26_1000-c3d4e5f6a7b8_add_agent_active_config_is_published.py
+++ b/api/migrations/versions/2026_06_26_1000-c3d4e5f6a7b8_add_agent_active_config_is_published.py
@@ -1,0 +1,37 @@
+"""add agent active config is published
+
+Revision ID: c3d4e5f6a7b8
+Revises: a2b3c4d5e6f7
+Create Date: 2026-06-26 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c3d4e5f6a7b8"
+down_revision = "a2b3c4d5e6f7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("agents", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "active_config_is_published",
+                sa.Boolean(),
+                server_default=sa.text("false"),
+                nullable=False,
+                comment=(
+                    "Whether the normal shared Agent draft has been published into the active config snapshot. "
+                    "User-scoped debug drafts do not affect this flag."
+                ),
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("agents", schema=None) as batch_op:
+        batch_op.drop_column("active_config_is_published")

--- a/api/models/agent.py
+++ b/api/models/agent.py
@@ -188,6 +188,16 @@ class Agent(DefaultFieldsMixin, Base):
     active_config_has_model: Mapped[bool] = mapped_column(
         sa.Boolean, nullable=False, default=False, server_default=sa.text("false")
     )
+    active_config_is_published: Mapped[bool] = mapped_column(
+        sa.Boolean,
+        nullable=False,
+        default=False,
+        server_default=sa.text("false"),
+        comment=(
+            "Whether the normal shared Agent draft has been published into the active config snapshot. "
+            "User-scoped debug drafts do not affect this flag."
+        ),
+    )
     status: Mapped[AgentStatus] = mapped_column(
         EnumText(AgentStatus, length=32), nullable=False, default=AgentStatus.ACTIVE
     )

--- a/api/services/agent/composer_service.py
+++ b/api/services/agent/composer_service.py
@@ -419,6 +419,7 @@ class AgentComposerService:
             account_id_for_audit=account_id,
         )
         agent.updated_by = account_id
+        agent.active_config_is_published = False
 
         db.session.commit()
         state = cls.load_agent_composer(tenant_id=tenant_id, agent_id=agent.id)
@@ -464,6 +465,7 @@ class AgentComposerService:
         )
         agent.active_config_snapshot_id = version.id
         agent.active_config_has_model = agent_soul_has_model(agent_soul)
+        agent.active_config_is_published = True
         agent.updated_by = account_id
         draft.base_snapshot_id = version.id
         draft.updated_by = account_id
@@ -564,6 +566,8 @@ class AgentComposerService:
             account_id_for_audit=account_id,
             base_snapshot_id=build_draft.base_snapshot_id,
         )
+        agent.active_config_is_published = False
+        agent.updated_by = account_id
         db.session.delete(build_draft)
         db.session.commit()
         return {"result": "success", "draft": cls._serialize_draft(normal_draft)}
@@ -982,6 +986,7 @@ class AgentComposerService:
                     raise ValueError("Inline workflow agent binding must point to a workflow-only agent")
                 agent.active_config_snapshot_id = version.id
                 agent.active_config_has_model = agent_soul_has_model(payload.agent_soul)
+                agent.active_config_is_published = True
                 agent.updated_by = account_id
                 binding.current_snapshot_id = version.id
             binding.updated_by = account_id
@@ -1080,6 +1085,7 @@ class AgentComposerService:
         agent = cls._require_agent(tenant_id=tenant_id, agent_id=binding.agent_id)
         agent.active_config_snapshot_id = version.id
         agent.active_config_has_model = agent_soul_has_model(payload.agent_soul)
+        agent.active_config_is_published = True
         agent.updated_by = account_id
         binding.current_snapshot_id = version.id
         if payload.node_job is not None:
@@ -1110,6 +1116,7 @@ class AgentComposerService:
         agent = cls._require_agent(tenant_id=tenant_id, agent_id=binding.agent_id)
         agent.active_config_snapshot_id = version.id
         agent.active_config_has_model = agent_soul_has_model(payload.agent_soul)
+        agent.active_config_is_published = True
         agent.updated_by = account_id
         binding.current_snapshot_id = version.id
         binding.updated_by = account_id
@@ -1270,6 +1277,7 @@ class AgentComposerService:
         )
         agent.active_config_snapshot_id = version.id
         agent.active_config_has_model = agent_soul_has_model(agent_soul)
+        agent.active_config_is_published = True
         return agent
 
     @classmethod
@@ -1417,6 +1425,7 @@ class AgentComposerService:
         )
         agent.active_config_snapshot_id = version.id
         agent.active_config_has_model = agent_soul_has_model(agent_soul)
+        agent.active_config_is_published = True
         agent.updated_by = account_id
         return agent
 
@@ -1607,6 +1616,8 @@ class AgentComposerService:
         elif draft.base_snapshot_id is None:
             draft.base_snapshot_id = agent.active_config_snapshot_id
         draft.updated_by = account_id_for_audit
+        if draft_type == AgentConfigDraftType.DRAFT and account_id is None:
+            agent.active_config_is_published = False
         db.session.flush()
         return draft
 

--- a/api/services/agent/roster_service.py
+++ b/api/services/agent/roster_service.py
@@ -86,7 +86,7 @@ class AgentRosterService:
         agent: Agent,
         active_version: AgentConfigSnapshot | None = None,
         published_references: list[AgentReferencingWorkflow] | None = None,
-        active_config_is_published: bool = False,
+        active_config_is_published: bool | None = None,
     ) -> dict[str, Any]:
         published_references = published_references or []
         return {
@@ -108,7 +108,9 @@ class AgentRosterService:
             "workflow_node_id": agent.workflow_node_id,
             "active_config_snapshot_id": agent.active_config_snapshot_id,
             "active_config_snapshot": AgentRosterService.serialize_version(active_version) if active_version else None,
-            "active_config_is_published": active_config_is_published,
+            "active_config_is_published": agent.active_config_is_published
+            if active_config_is_published is None
+            else active_config_is_published,
             "status": agent.status.value,
             "created_by": agent.created_by,
             "updated_by": agent.updated_by,
@@ -326,6 +328,7 @@ class AgentRosterService:
         self._session.add(revision)
         agent.active_config_snapshot_id = version.id
         agent.active_config_has_model = agent_soul_has_model(payload.agent_soul)
+        agent.active_config_is_published = True
 
         try:
             self._session.commit()
@@ -400,6 +403,7 @@ class AgentRosterService:
         self._session.add(revision)
         agent.active_config_snapshot_id = version.id
         agent.active_config_has_model = agent_soul_has_model(AgentSoulConfig())
+        agent.active_config_is_published = False
         self._session.flush()
         self._get_or_create_agent_app_debug_conversation(agent=agent, account_id=account_id)
         return agent
@@ -865,6 +869,7 @@ class AgentRosterService:
         target_version.version_note = source_version.version_note
         target_version.created_by = account_id
         target_agent.active_config_has_model = agent_soul_has_model(target_version.config_snapshot)
+        target_agent.active_config_is_published = source_agent.active_config_is_published
         target_agent.updated_by = account_id
 
     def _next_duplicate_agent_name(self, *, tenant_id: str, base_name: str) -> str:
@@ -978,37 +983,26 @@ class AgentRosterService:
         }
 
     def active_config_is_published(self, *, tenant_id: str, agent: Agent) -> bool:
-        """Return whether the editable draft matches the active published snapshot."""
+        """Return whether the normal shared draft has been published into the active snapshot."""
         return self.load_active_config_is_published_by_agent_id(tenant_id=tenant_id, agents=[agent]).get(
             agent.id,
             False,
         )
 
     def load_active_config_is_published_by_agent_id(self, *, tenant_id: str, agents: list[Agent]) -> dict[str, bool]:
-        """Return whether each Agent's normal draft is aligned with its active published snapshot."""
+        """Return each Agent's stored normal-draft publish state.
+
+        The flag is maintained by write paths: normal shared draft writes mark it
+        dirty, while publish/version creation paths mark it clean. User-scoped
+        debug drafts intentionally do not affect this state.
+        """
         agents = [agent for agent in agents if agent.id]
         if not agents:
             return {}
 
-        published_agent_ids = self._load_published_active_snapshot_agent_ids(tenant_id=tenant_id, agents=agents)
-        drafts = self._session.scalars(
-            select(AgentConfigDraft).where(
-                AgentConfigDraft.tenant_id == tenant_id,
-                AgentConfigDraft.agent_id.in_([agent.id for agent in agents]),
-                AgentConfigDraft.draft_type == AgentConfigDraftType.DRAFT,
-                AgentConfigDraft.account_id.is_(None),
-            )
-        ).all()
-        drafts_by_agent_id = {draft.agent_id: draft for draft in drafts}
-        result: dict[str, bool] = {}
-        for agent in agents:
-            draft = drafts_by_agent_id.get(agent.id)
-            result[agent.id] = (
-                agent.id in published_agent_ids
-                and bool(agent.active_config_snapshot_id)
-                and (draft is None or draft.base_snapshot_id == agent.active_config_snapshot_id)
-            )
-        return result
+        return {
+            agent.id: bool(agent.active_config_snapshot_id and agent.active_config_is_published) for agent in agents
+        }
 
     def list_agent_versions(self, *, tenant_id: str, agent_id: str) -> list[dict[str, Any]]:
         agent = self._get_agent(tenant_id=tenant_id, agent_id=agent_id, roster_only=True)
@@ -1130,6 +1124,7 @@ class AgentRosterService:
         draft.base_snapshot_id = version.id
         draft.config_snapshot = AgentSoulConfig.model_validate(version.config_snapshot_dict)
         draft.updated_by = account_id
+        agent.active_config_is_published = version.id == agent.active_config_snapshot_id
         agent.updated_by = account_id
         self._session.commit()
         return {

--- a/api/tests/unit_tests/services/agent/test_agent_services.py
+++ b/api/tests/unit_tests/services/agent/test_agent_services.py
@@ -387,6 +387,7 @@ def test_save_agent_app_composer_creates_agent_when_missing(monkeypatch: pytest.
     assert result == {"loaded": True}
     assert fake_session.added[0].name == "Analyst"
     assert fake_session.added[0].active_config_snapshot_id is None
+    assert fake_session.added[0].active_config_is_published is False
     assert fake_session.commits == 1
 
 
@@ -434,7 +435,12 @@ def test_save_agent_app_composer_rejects_version_save_strategy():
 
 
 def test_save_agent_app_composer_updates_normal_draft(monkeypatch: pytest.MonkeyPatch):
-    agent = SimpleNamespace(id="agent-1", active_config_snapshot_id="version-1", updated_by=None)
+    agent = SimpleNamespace(
+        id="agent-1",
+        active_config_snapshot_id="version-1",
+        active_config_is_published=True,
+        updated_by=None,
+    )
     fake_session = FakeSession(scalar=[agent])
     saved = {}
 
@@ -462,6 +468,7 @@ def test_save_agent_app_composer_updates_normal_draft(monkeypatch: pytest.Monkey
     assert result == {"loaded": True}
     assert saved["draft_type"] == AgentConfigDraftType.DRAFT
     assert saved["agent_soul"].model_dump(mode="json") == _agent_soul_with_model().model_dump(mode="json")
+    assert agent.active_config_is_published is False
     assert fake_session._scalar == []
     assert fake_session.commits == 1
 
@@ -514,6 +521,7 @@ def test_publish_agent_app_draft_creates_published_snapshot(monkeypatch: pytest.
     assert created["previous_snapshot_id"] == "version-1"
     assert agent.active_config_snapshot_id == "version-2"
     assert agent.active_config_has_model is True
+    assert agent.active_config_is_published is True
     assert fake_session.commits == 1
 
 
@@ -528,6 +536,7 @@ def test_agent_app_build_draft_checkout_and_apply_use_user_isolated_draft(monkey
         source=AgentSource.AGENT_APP,
         status=AgentStatus.ACTIVE,
         active_config_snapshot_id="version-1",
+        active_config_is_published=True,
     )
     normal_draft = AgentConfigDraft(
         tenant_id="tenant-1",
@@ -568,6 +577,7 @@ def test_agent_app_build_draft_checkout_and_apply_use_user_isolated_draft(monkey
     assert applied["result"] == "success"
     assert applied["draft"]["id"] == normal_draft.id
     assert normal_draft.config_snapshot_dict == build_draft.config_snapshot_dict
+    assert agent.active_config_is_published is False
     assert fake_session.deleted == [build_draft]
     assert fake_session.commits == 1
 
@@ -1680,7 +1690,11 @@ def test_composer_current_version_and_error_paths(monkeypatch: pytest.MonkeyPatc
         config_snapshot='{"prompt":{"system_prompt":"old"}}',
     )
     monkeypatch.setattr(AgentComposerService, "_require_version", lambda **kwargs: version)
-    monkeypatch.setattr(AgentComposerService, "_require_agent", lambda **kwargs: SimpleNamespace(updated_by=None))
+    monkeypatch.setattr(
+        AgentComposerService,
+        "_require_agent",
+        lambda **kwargs: SimpleNamespace(updated_by=None, active_config_is_published=False),
+    )
 
     result = AgentComposerService._save_to_current_version(
         tenant_id="tenant-1", account_id="account-1", binding=binding, payload=payload
@@ -1730,6 +1744,7 @@ def test_roster_list_and_invite_options(monkeypatch: pytest.MonkeyPatch):
     version.created_at = version_created_at
     agent.active_config_snapshot_id = "version-1"
     agent.active_config_has_model = True
+    agent.active_config_is_published = True
     unconfigured_agent = Agent(
         id="agent-2",
         tenant_id="tenant-1",
@@ -1816,7 +1831,7 @@ def test_invite_options_uses_db_filtered_pagination(monkeypatch: pytest.MonkeyPa
     assert [item["id"] for item in result["data"]] == ["agent-2"]
 
 
-def test_active_config_is_published_flags_handle_matching_and_empty_snapshots():
+def test_active_config_is_published_flags_use_stored_agent_state():
     agent = Agent(
         id="agent-1",
         tenant_id="tenant-1",
@@ -1827,6 +1842,7 @@ def test_active_config_is_published_flags_handle_matching_and_empty_snapshots():
         source=AgentSource.AGENT_APP,
         status=AgentStatus.ACTIVE,
         active_config_snapshot_id="version-1",
+        active_config_is_published=True,
     )
     draft_agent = Agent(
         id="agent-2",
@@ -1838,20 +1854,27 @@ def test_active_config_is_published_flags_handle_matching_and_empty_snapshots():
         source=AgentSource.AGENT_APP,
         status=AgentStatus.ACTIVE,
         active_config_snapshot_id=None,
+        active_config_is_published=True,
     )
-    published_draft = AgentConfigDraft(
+    dirty_agent = Agent(
+        id="agent-3",
         tenant_id="tenant-1",
-        agent_id="agent-1",
-        draft_type=AgentConfigDraftType.DRAFT,
-        draft_owner_key="",
-        base_snapshot_id="version-1",
-        config_snapshot=AgentSoulConfig(),
+        name="Dirty",
+        description="",
+        agent_kind=AgentKind.DIFY_AGENT,
+        scope=AgentScope.ROSTER,
+        source=AgentSource.AGENT_APP,
+        status=AgentStatus.ACTIVE,
+        active_config_snapshot_id="version-3",
+        active_config_is_published=False,
     )
-    service = AgentRosterService(FakeSession(scalars=[["agent-1"], [published_draft], ["agent-1"], [published_draft]]))
+    service = AgentRosterService(FakeSession())
 
-    flags = service.load_active_config_is_published_by_agent_id(tenant_id="tenant-1", agents=[agent, draft_agent])
+    flags = service.load_active_config_is_published_by_agent_id(
+        tenant_id="tenant-1", agents=[agent, draft_agent, dirty_agent]
+    )
 
-    assert flags == {"agent-1": True, "agent-2": False}
+    assert flags == {"agent-1": True, "agent-2": False, "agent-3": False}
     assert service.active_config_is_published(tenant_id="tenant-1", agent=agent) is True
     assert AgentRosterService(FakeSession()).load_active_config_is_published_by_agent_id(
         tenant_id="tenant-1",
@@ -2298,6 +2321,7 @@ def test_restore_roster_agent_version_switches_active_snapshot(monkeypatch: pyte
         source=AgentSource.AGENT_APP,
         status=AgentStatus.ACTIVE,
         active_config_snapshot_id="version-4",
+        active_config_is_published=True,
     )
     version = AgentConfigSnapshot(
         id="version-2",
@@ -2324,6 +2348,7 @@ def test_restore_roster_agent_version_switches_active_snapshot(monkeypatch: pyte
         "restored_version_id": "version-2",
     }
     assert agent.active_config_snapshot_id == "version-4"
+    assert agent.active_config_is_published is False
     assert agent.updated_by == "account-1"
     assert fake_session.commits == 1
     draft = fake_session.added[0]


### PR DESCRIPTION
## Summary
- Store `active_config_is_published` on `agents` instead of deriving it from revision/draft base snapshot state.
- Mark normal shared draft saves dirty (`false`) and publish/version creation paths clean (`true`); debug build drafts do not affect the flag.
- Add migration and update Agent service tests for the new state-machine semantics.

## Verification
- `api/.venv/bin/ruff check models/agent.py services/agent/roster_service.py services/agent/composer_service.py tests/unit_tests/services/agent/test_agent_services.py`
- `api/.venv/bin/ruff format --check models/agent.py services/agent/roster_service.py services/agent/composer_service.py tests/unit_tests/services/agent/test_agent_services.py migrations/versions/2026_06_26_1000-c3d4e5f6a7b8_add_agent_active_config_is_published.py`
- `api/.venv/bin/python -m compileall -q api/models/agent.py api/services/agent/roster_service.py api/services/agent/composer_service.py api/tests/unit_tests/services/agent/test_agent_services.py`
- Deployed `a643bd59b3` to `deploy/agent`; applied migration on `agent.dify.dev`.
- E2E on `https://agent.dify.dev`: create Agent App -> detail false; save composer draft -> detail false; publish -> detail true; save draft again -> detail false.
- Runtime smoke: `/console/api/agent/{agent_id}/chat-messages` reaches runtime validation and returns expected `model is required` for the model-less test Agent, not a server error.

## Notes
- Local `pytest` for `api/tests/unit_tests/services/agent/test_agent_services.py` currently segfaults during pytest initialization in this local venv before running tests; no assertion output is produced.
