### PR TITLE
fix: web app user avatar display incorrect black

### DIFF
--- a/web/app/components/base/chat/chat/__tests__/question.spec.tsx
+++ b/web/app/components/base/chat/chat/__tests__/question.spec.tsx
@@ -501,6 +501,16 @@ describe('Question component', () => {
     expect(onRegenerate).toHaveBeenCalled()
   })
 
+  it('should render default question avatar icon when questionIcon is not provided', () => {
+    const { container } = renderWithProvider(
+      makeItem(),
+      vi.fn() as unknown as OnRegenerate,
+    )
+
+    const defaultIcon = container.querySelector('.question-default-user-icon')
+    expect(defaultIcon).toBeInTheDocument()
+  })
+
   it('should render custom questionIcon when provided', () => {
     const { container } = renderWithProvider(
       makeItem(),
@@ -509,7 +519,7 @@ describe('Question component', () => {
     )
 
     expect(screen.getByTestId('custom-question-icon')).toBeInTheDocument()
-    const defaultIcon = container.querySelector('.i-custom-public-avatar-user')
+    const defaultIcon = container.querySelector('.question-default-user-icon')
     expect(defaultIcon).not.toBeInTheDocument()
   })
 

--- a/web/app/components/base/chat/chat/question.tsx
+++ b/web/app/components/base/chat/chat/question.tsx
@@ -15,6 +15,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import Textarea from 'react-textarea-autosize'
 import { FileList } from '@/app/components/base/file-uploader'
+import { User } from '@/app/components/base/icons/src/public/avatar'
 import { Markdown } from '@/app/components/base/markdown'
 import { cn } from '@/utils/classnames'
 import ActionButton from '../../action-button'
@@ -243,7 +244,7 @@ const Question: FC<QuestionProps> = ({
           {
             questionIcon || (
               <div className="h-full w-full rounded-full border-[0.5px] border-black/5">
-                <div className="i-custom-public-avatar-user h-full w-full" />
+                <User className="question-default-user-icon h-full w-full" />
               </div>
             )
           }


### PR DESCRIPTION
Cherry-pick of #34624 to lts/1.13.x.

Fixes web app user avatar displaying incorrectly as black.

Changes:
- `web/app/components/base/chat/chat/question.tsx`: Fix avatar color rendering
- `web/app/components/base/chat/chat/__tests__/question.spec.tsx`: Add/update test coverage

(cherry picked from commit 6acb1929ceb74c6ba8bf3b44208b5d60cabae4ed)