### PR TITLE
refactor: replace patch logger with caplog in test_version.py

### DIFF
--- a/api/tests/unit_tests/controllers/console/test_version.py
+++ b/api/tests/unit_tests/controllers/console/test_version.py
@@ -65,7 +65,7 @@ class TestCheckVersionUpdate:
         assert result.features.can_replace_logo is True
         assert result.features.model_load_balancing_enabled is False
 
-    def test_http_error_fallback(self):
+    def test_http_error_fallback(self, caplog: pytest.LogCaptureFixture):
         query = version_module.VersionQuery(current_version="1.0.0")
 
         with (
@@ -79,15 +79,12 @@ class TestCheckVersionUpdate:
                 "get",
                 side_effect=Exception("boom"),
             ),
-            patch.object(
-                version_module.logger,
-                "warning",
-            ) as log_warning,
+            caplog.at_level(logging.WARNING, logger="controllers.console.version"),
         ):
             result = version_module.check_version_update(query)
 
         assert result.version == "1.0.0"
-        log_warning.assert_called_once()
+        assert "Check update version error" in caplog.text
 
     def test_new_version_available(self):
         query = version_module.VersionQuery(current_version="1.0.0")


### PR DESCRIPTION
## Summary

Replace `unittest.mock.patch.object(logger, 'warning')` with pytest's `caplog` fixture for capturing log output in `test_http_error_fallback`.

## Changes

- **File**: `api/tests/unit_tests/controllers/console/test_version.py`
- **Function**: `test_http_error_fallback`
- Added `caplog: pytest.LogCaptureFixture` parameter
- Removed `patch.object(version_module.logger, "warning", ) as log_warning`
- Added `caplog.at_level(logging.WARNING, logger="controllers.console.version")`
- Changed `log_warning.assert_called_once()` to `assert "Check update version error" in caplog.text`

## Related Issues

#37468

## Testing

- All 7 tests in `test_version.py` pass
- Verified the modified test still correctly validates warning log output