### PR TITLE
fix: remove aria-busy from loading button

### DIFF
--- a/packages/dify-ui/src/button/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/button/__tests__/index.spec.tsx
@@ -120,9 +120,9 @@ describe('Button', () => {
       expect(button).toHaveFocus()
     })
 
-    it('sets aria-busy when loading', async () => {
+    it('does not set aria-busy when loading', async () => {
       const screen = await render(<Button loading>Click me</Button>)
-      await expect.element(screen.getByRole('button')).toHaveAttribute('aria-busy', 'true')
+      await expect.element(screen.getByRole('button')).not.toHaveAttribute('aria-busy')
     })
 
     it('does not set aria-busy when not loading', async () => {

--- a/packages/dify-ui/src/button/index.stories.tsx
+++ b/packages/dify-ui/src/button/index.stories.tsx
@@ -98,7 +98,7 @@ export const Loading: Story = {
     const button = canvas.getByRole('button', { name: 'Loading Button' })
 
     await expect(button).toHaveAttribute('aria-disabled', 'true')
-    await expect(button).toHaveAttribute('aria-busy', 'true')
+    await expect(button).not.toHaveAttribute('aria-busy')
 
     button.focus()
     await expect(button).toHaveFocus()

--- a/packages/dify-ui/src/button/index.tsx
+++ b/packages/dify-ui/src/button/index.tsx
@@ -125,7 +125,6 @@ export function Button({
       className={cn(buttonVariants({ variant, size, tone, className }))}
       disabled={disabled || loading}
       focusableWhenDisabled={focusableWhenDisabled ?? loading}
-      aria-busy={loading || undefined}
       {...props}
     >
       {children}

--- a/web/app/components/header/account-dropdown/__tests__/compliance.spec.tsx
+++ b/web/app/components/header/account-dropdown/__tests__/compliance.spec.tsx
@@ -229,7 +229,7 @@ describe('Compliance', () => {
       })
     })
 
-    // isPending branches: spinner visible, disabled class, guard blocks second call
+    // isPending branches: spinner visible, loading button contract, guard blocks second call
     it('should show spinner and guard against duplicate download when isPending is true', async () => {
       // Arrange
       let resolveDownload: (value: { url: string }) => void
@@ -250,12 +250,12 @@ describe('Compliance', () => {
       expect(menuItem).not.toBeNull()
       fireEvent.click(menuItem!)
 
-      // Assert - button should become busy while mutation is pending
+      // Assert - button should enter the loading-disabled state while mutation is pending
       await waitFor(() => {
-        const busyButton = menuItem!.querySelector('button[aria-busy="true"]')
-        expect(busyButton).not.toBeNull()
-        expectLoadingButton(busyButton)
-        expect(busyButton!.querySelector('.animate-spin')).not.toBeNull()
+        const loadingButton = menuItem!.querySelector('button[aria-disabled="true"]')
+        expect(loadingButton).not.toBeNull()
+        expectLoadingButton(loadingButton)
+        expect(loadingButton!.querySelector('.animate-spin')).not.toBeNull()
       }, { timeout: 10000 })
 
       // Cleanup: resolve the pending promise
@@ -287,9 +287,9 @@ describe('Compliance', () => {
 
       // Wait for mutation to start and React to re-render (isPending=true)
       await waitFor(() => {
-        const busyButton = menuItem!.querySelector('button[aria-busy="true"]')
-        expect(busyButton).not.toBeNull()
-        expectLoadingButton(busyButton)
+        const loadingButton = menuItem!.querySelector('button[aria-disabled="true"]')
+        expect(loadingButton).not.toBeNull()
+        expectLoadingButton(loadingButton)
         expect(getDocDownloadUrl).toHaveBeenCalledTimes(1)
       }, { timeout: 10000 })
 

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/__tests__/publish-bar.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/__tests__/publish-bar.spec.tsx
@@ -442,7 +442,7 @@ describe('AgentConfigurePublishBar', () => {
 
     expect(screen.getByText('agentV2.agentDetail.configure.publishBar.publishing')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'agentV2.agentDetail.configure.publishBar.publishing' })).toHaveAttribute('aria-disabled', 'true')
-    expect(screen.getByRole('button', { name: 'agentV2.agentDetail.configure.publishBar.publishing' })).toHaveAttribute('aria-busy', 'true')
+    expect(screen.getByRole('button', { name: 'agentV2.agentDetail.configure.publishBar.publishing' })).not.toHaveAttribute('aria-busy')
     expect(screen.queryByText('display:Mod')).not.toBeInTheDocument()
     expect(hotkeyRegistrations.get('Mod+Shift+P')?.options).toEqual(
       expect.objectContaining({ enabled: false, ignoreInputs: false }),
@@ -512,7 +512,7 @@ describe('AgentConfigurePublishBar', () => {
     rerender(rerenderPublishBar({ isPublishing: true }))
     expect(await screen.findByRole('button', {
       name: 'agentV2.agentDetail.configure.publishBar.publishing',
-    })).toHaveAttribute('aria-busy', 'true')
+    })).not.toHaveAttribute('aria-busy')
 
     await act(async () => {
       publishDeferred.resolve()

--- a/web/test/button.ts
+++ b/web/test/button.ts
@@ -2,7 +2,6 @@ import { expect } from 'vitest'
 
 export const expectLoadingButton = (button: Element | null) => {
   expect(button).toBeInstanceOf(HTMLButtonElement)
-  expect(button).toHaveAttribute('aria-busy', 'true')
   expect(button).toHaveAttribute('aria-disabled', 'true')
   expect(button).not.toHaveAttribute('disabled')
 }


### PR DESCRIPTION
## Summary
- remove the default `aria-busy` attribute from Dify UI loading buttons
- keep loading buttons disabled via Base UI while preserving the existing focusable-when-loading default and explicit opt-out
- update primitive, story, and web helper tests to treat `aria-disabled` as the loading button contract

## Rationale
`aria-busy` is intended for content or regions whose updates are incomplete. A loading action button should not imply that every pending button needs `aria-busy`; call sites that need spoken progress should use a status/live-region pattern.

## Tests
- `pnpm -C packages/dify-ui test src/button/__tests__/index.spec.tsx`
- `pnpm -C packages/dify-ui test:storybook src/button/index.stories.tsx`
- `pnpm -C packages/dify-ui type-check`
- `pnpm -C web test features/agent-v2/agent-detail/configure/components/orchestrate/__tests__/publish-bar.spec.tsx`
- `pnpm -C web type-check`
- `git diff --check`