### PR TITLE
fix: make db.session pass from parameter (#37403)

### DIFF
--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -33,6 +33,7 @@ from extensions.ext_database import db
 from fields.base import ResponseModel
 from libs.helper import OptionalTimestampField, TimestampField, dump_response, to_timestamp
 from libs.login import login_required
+from flask_login import current_user
 from models.account import Account, Tenant, TenantAccountJoin, TenantCustomConfigDict, TenantStatus
 from services.account_service import TenantService
 from services.billing_service import BillingService, SubscriptionPlan
@@ -334,7 +335,7 @@ class TenantApi(Resource):
             else:
                 raise Unauthorized("workspace is archived")
 
-        return dump_response(TenantInfoResponse, WorkspaceService.get_tenant_info(tenant, db.session)), 200
+        return dump_response(TenantInfoResponse, WorkspaceService.get_tenant_info(tenant, db.session, current_user)), 200
 
 
 @console_ns.route("/workspaces/switch")
@@ -361,7 +362,7 @@ class SwitchWorkspaceApi(Resource):
 
         return {
             "result": "success",
-            "new_tenant": marshal(WorkspaceService.get_tenant_info(new_tenant, db.session), tenant_fields),
+            "new_tenant": marshal(WorkspaceService.get_tenant_info(new_tenant, db.session, current_user), tenant_fields),
         }
 
 
@@ -393,7 +394,7 @@ class CustomConfigWorkspaceApi(Resource):
 
         return {
             "result": "success",
-            "tenant": marshal(WorkspaceService.get_tenant_info(tenant, db.session), tenant_fields),
+            "tenant": marshal(WorkspaceService.get_tenant_info(tenant, db.session, current_user), tenant_fields),
         }
 
 
@@ -459,7 +460,7 @@ class WorkspaceInfoApi(Resource):
 
         return {
             "result": "success",
-            "tenant": marshal(WorkspaceService.get_tenant_info(tenant, db.session), tenant_fields),
+            "tenant": marshal(WorkspaceService.get_tenant_info(tenant, db.session, current_user), tenant_fields),
         }
 
 

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -334,7 +334,7 @@ class TenantApi(Resource):
             else:
                 raise Unauthorized("workspace is archived")
 
-        return dump_response(TenantInfoResponse, WorkspaceService.get_tenant_info(tenant)), 200
+        return dump_response(TenantInfoResponse, WorkspaceService.get_tenant_info(tenant, db.session)), 200
 
 
 @console_ns.route("/workspaces/switch")
@@ -359,7 +359,7 @@ class SwitchWorkspaceApi(Resource):
         if new_tenant is None:
             raise ValueError("Tenant not found")
 
-        return {"result": "success", "new_tenant": marshal(WorkspaceService.get_tenant_info(new_tenant), tenant_fields)}
+        return {"result": "success", "new_tenant": marshal(WorkspaceService.get_tenant_info(new_tenant, db.session), tenant_fields)}
 
 
 @console_ns.route("/workspaces/custom-config")
@@ -388,7 +388,7 @@ class CustomConfigWorkspaceApi(Resource):
         tenant.custom_config_dict = custom_config_dict
         db.session.commit()
 
-        return {"result": "success", "tenant": marshal(WorkspaceService.get_tenant_info(tenant), tenant_fields)}
+        return {"result": "success", "tenant": marshal(WorkspaceService.get_tenant_info(tenant, db.session), tenant_fields)}
 
 
 @console_ns.route("/workspaces/custom-config/webapp-logo/upload")
@@ -451,7 +451,7 @@ class WorkspaceInfoApi(Resource):
         tenant.name = args.name
         db.session.commit()
 
-        return {"result": "success", "tenant": marshal(WorkspaceService.get_tenant_info(tenant), tenant_fields)}
+        return {"result": "success", "tenant": marshal(WorkspaceService.get_tenant_info(tenant, db.session), tenant_fields)}
 
 
 @console_ns.route("/workspaces/current/permission")

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -2,6 +2,7 @@ import logging
 from datetime import datetime
 
 from flask import request
+from flask_login import current_user
 from flask_restx import Resource, fields, marshal
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import select
@@ -33,7 +34,6 @@ from extensions.ext_database import db
 from fields.base import ResponseModel
 from libs.helper import OptionalTimestampField, TimestampField, dump_response, to_timestamp
 from libs.login import login_required
-from flask_login import current_user
 from models.account import Account, Tenant, TenantAccountJoin, TenantCustomConfigDict, TenantStatus
 from services.account_service import TenantService
 from services.billing_service import BillingService, SubscriptionPlan
@@ -335,7 +335,9 @@ class TenantApi(Resource):
             else:
                 raise Unauthorized("workspace is archived")
 
-        return dump_response(TenantInfoResponse, WorkspaceService.get_tenant_info(tenant, db.session, current_user)), 200
+        return dump_response(
+            TenantInfoResponse, WorkspaceService.get_tenant_info(tenant, db.session, current_user)
+        ), 200
 
 
 @console_ns.route("/workspaces/switch")
@@ -362,7 +364,9 @@ class SwitchWorkspaceApi(Resource):
 
         return {
             "result": "success",
-            "new_tenant": marshal(WorkspaceService.get_tenant_info(new_tenant, db.session, current_user), tenant_fields),
+            "new_tenant": marshal(
+                WorkspaceService.get_tenant_info(new_tenant, db.session, current_user), tenant_fields
+            ),
         }
 
 

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -359,7 +359,10 @@ class SwitchWorkspaceApi(Resource):
         if new_tenant is None:
             raise ValueError("Tenant not found")
 
-        return {"result": "success", "new_tenant": marshal(WorkspaceService.get_tenant_info(new_tenant, db.session), tenant_fields)}
+        return {
+            "result": "success",
+            "new_tenant": marshal(WorkspaceService.get_tenant_info(new_tenant, db.session), tenant_fields),
+        }
 
 
 @console_ns.route("/workspaces/custom-config")
@@ -388,7 +391,10 @@ class CustomConfigWorkspaceApi(Resource):
         tenant.custom_config_dict = custom_config_dict
         db.session.commit()
 
-        return {"result": "success", "tenant": marshal(WorkspaceService.get_tenant_info(tenant, db.session), tenant_fields)}
+        return {
+            "result": "success",
+            "tenant": marshal(WorkspaceService.get_tenant_info(tenant, db.session), tenant_fields),
+        }
 
 
 @console_ns.route("/workspaces/custom-config/webapp-logo/upload")
@@ -451,7 +457,10 @@ class WorkspaceInfoApi(Resource):
         tenant.name = args.name
         db.session.commit()
 
-        return {"result": "success", "tenant": marshal(WorkspaceService.get_tenant_info(tenant, db.session), tenant_fields)}
+        return {
+            "result": "success",
+            "tenant": marshal(WorkspaceService.get_tenant_info(tenant, db.session), tenant_fields),
+        }
 
 
 @console_ns.route("/workspaces/current/permission")

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -1251,7 +1251,7 @@ class TenantService:
 
         from services.credit_pool_service import CreditPoolService
 
-        CreditPoolService.create_default_pool(tenant.id)
+        CreditPoolService.create_default_pool(tenant.id, db.session)
 
         return tenant
 

--- a/api/services/credit_pool_service.py
+++ b/api/services/credit_pool_service.py
@@ -14,7 +14,6 @@ from sqlalchemy.orm import Session
 from configs import dify_config
 from core.db.session_factory import session_factory
 from core.errors.error import QuotaExceededError
-from extensions.ext_database import db
 from extensions.ext_redis import redis_client
 from models import TenantCreditPool
 from models.enums import ProviderQuotaType
@@ -66,7 +65,7 @@ class CreditPoolService:
         )
 
     @classmethod
-    def create_default_pool(cls, tenant_id: str) -> TenantCreditPool:
+    def create_default_pool(cls, tenant_id: str, session: Session) -> TenantCreditPool:
         """create default credit pool for new tenant"""
         credit_pool = TenantCreditPool(
             tenant_id=tenant_id,
@@ -74,8 +73,8 @@ class CreditPoolService:
             quota_used=0,
             pool_type=ProviderQuotaType.TRIAL,
         )
-        db.session.add(credit_pool)
-        db.session.commit()
+        session.add(credit_pool)
+        session.commit()
         return credit_pool
 
     @classmethod

--- a/api/services/credit_pool_service.py
+++ b/api/services/credit_pool_service.py
@@ -65,7 +65,7 @@ class CreditPoolService:
         )
 
     @classmethod
-    def create_default_pool(cls, tenant_id: str, session: Session) -> TenantCreditPool:
+    def create_default_pool(cls, tenant_id: str, session: Any) -> TenantCreditPool:
         """create default credit pool for new tenant"""
         credit_pool = TenantCreditPool(
             tenant_id=tenant_id,

--- a/api/services/credit_pool_service.py
+++ b/api/services/credit_pool_service.py
@@ -74,7 +74,6 @@ class CreditPoolService:
             pool_type=ProviderQuotaType.TRIAL,
         )
         session.add(credit_pool)
-        session.commit()
         return credit_pool
 
     @classmethod

--- a/api/services/workspace_service.py
+++ b/api/services/workspace_service.py
@@ -1,5 +1,6 @@
 from sqlalchemy import select
 from sqlalchemy.orm import Session
+from typing import Any
 
 from configs import dify_config
 from enums.cloud_plan import CloudPlan
@@ -10,7 +11,7 @@ from services.feature_service import FeatureService
 
 class WorkspaceService:
     @classmethod
-    def get_tenant_info(cls, tenant: Tenant, session: Session, user: Account):
+    def get_tenant_info(cls, tenant: Any, session: Any, user: Any):
         if not tenant:
             return None
         tenant_info: dict[str, object] = {

--- a/api/services/workspace_service.py
+++ b/api/services/workspace_service.py
@@ -1,10 +1,10 @@
-from sqlalchemy import select
-from sqlalchemy.orm import Session
 from typing import Any
+
+from sqlalchemy import select
 
 from configs import dify_config
 from enums.cloud_plan import CloudPlan
-from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
+from models.account import TenantAccountJoin, TenantAccountRole
 from services.account_service import TenantService
 from services.feature_service import FeatureService
 

--- a/api/services/workspace_service.py
+++ b/api/services/workspace_service.py
@@ -1,9 +1,9 @@
 from flask_login import current_user
 from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from configs import dify_config
 from enums.cloud_plan import CloudPlan
-from extensions.ext_database import db
 from models.account import Tenant, TenantAccountJoin, TenantAccountRole
 from services.account_service import TenantService
 from services.feature_service import FeatureService
@@ -11,7 +11,7 @@ from services.feature_service import FeatureService
 
 class WorkspaceService:
     @classmethod
-    def get_tenant_info(cls, tenant: Tenant):
+    def get_tenant_info(cls, tenant: Tenant, session: Session):
         if not tenant:
             return None
         tenant_info: dict[str, object] = {
@@ -25,7 +25,7 @@ class WorkspaceService:
         }
 
         # Get role of user
-        tenant_account_join = db.session.scalar(
+        tenant_account_join = session.scalar(
             select(TenantAccountJoin)
             .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.account_id == current_user.id)
             .limit(1)

--- a/api/services/workspace_service.py
+++ b/api/services/workspace_service.py
@@ -1,17 +1,16 @@
-from flask_login import current_user
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from configs import dify_config
 from enums.cloud_plan import CloudPlan
-from models.account import Tenant, TenantAccountJoin, TenantAccountRole
+from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole
 from services.account_service import TenantService
 from services.feature_service import FeatureService
 
 
 class WorkspaceService:
     @classmethod
-    def get_tenant_info(cls, tenant: Tenant, session: Session):
+    def get_tenant_info(cls, tenant: Tenant, session: Session, user: Account):
         if not tenant:
             return None
         tenant_info: dict[str, object] = {
@@ -27,7 +26,7 @@ class WorkspaceService:
         # Get role of user
         tenant_account_join = session.scalar(
             select(TenantAccountJoin)
-            .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.account_id == current_user.id)
+            .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.account_id == user.id)
             .limit(1)
         )
         assert tenant_account_join is not None, "TenantAccountJoin not found"

--- a/api/tests/test_containers_integration_tests/services/test_credit_pool_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_credit_pool_service.py
@@ -35,11 +35,10 @@ class TestCreditPoolService:
         db_session.add(pool)
         db_session.commit()
 
-    @pytest.mark.usefixtures("db_session_with_containers")
-    def test_create_default_pool(self) -> None:
+    def test_create_default_pool(self, db_session_with_containers: Session) -> None:
         tenant_id = self._create_tenant_id()
 
-        pool = CreditPoolService.create_default_pool(tenant_id)
+        pool = CreditPoolService.create_default_pool(tenant_id, db_session_with_containers)
 
         assert isinstance(pool, TenantCreditPool)
         assert pool.tenant_id == tenant_id

--- a/api/tests/test_containers_integration_tests/services/test_workspace_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_workspace_service.py
@@ -104,7 +104,7 @@ class TestWorkspaceService:
         # Mock current_user for flask_login
         with patch("services.workspace_service.current_user", account):
             # Act: Execute the method under test
-            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers, account)
 
             # Assert: Verify the expected outcomes
             assert result is not None
@@ -151,7 +151,7 @@ class TestWorkspaceService:
         # Mock current_user for flask_login
         with patch("services.workspace_service.current_user", account):
             # Act: Execute the method under test
-            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers, account)
 
             # Assert: Verify the expected outcomes
             assert result is not None
@@ -206,7 +206,7 @@ class TestWorkspaceService:
         # Mock current_user for flask_login
         with patch("services.workspace_service.current_user", account):
             # Act: Execute the method under test
-            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers, account)
 
             # Assert: Verify the expected outcomes
             assert result is not None
@@ -261,7 +261,7 @@ class TestWorkspaceService:
         # Mock current_user for flask_login
         with patch("services.workspace_service.current_user", account):
             # Act: Execute the method under test
-            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers, account)
 
             # Assert: Verify the expected outcomes
             assert result is not None
@@ -291,7 +291,7 @@ class TestWorkspaceService:
         # Arrange: No test data needed for this test
 
         # Act: Execute the method under test with None tenant
-        result = WorkspaceService.get_tenant_info(None, db_session_with_containers)
+        result = WorkspaceService.get_tenant_info(None, db_session_with_containers, None)
 
         # Assert: Verify the expected outcomes
         assert result is None
@@ -341,7 +341,7 @@ class TestWorkspaceService:
             # Mock current_user for flask_login
             with patch("services.workspace_service.current_user", account):
                 # Act: Execute the method under test
-                result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
+                result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers, account)
 
                 # Assert: Verify the expected outcomes
                 assert result is not None
@@ -398,7 +398,7 @@ class TestWorkspaceService:
         # Mock current_user for flask_login
         with patch("services.workspace_service.current_user", account):
             # Act: Execute the method under test
-            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers, account)
 
             # Assert: Verify the expected outcomes
             assert result is not None
@@ -448,7 +448,7 @@ class TestWorkspaceService:
         # Mock current_user for flask_login
         with patch("services.workspace_service.current_user", account):
             # Act: Execute the method under test
-            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers, account)
 
             # Assert: Verify the expected outcomes
             assert result is not None
@@ -513,7 +513,7 @@ class TestWorkspaceService:
             # Mock current_user for flask_login
             with patch("services.workspace_service.current_user", account):
                 # Act: Execute the method under test
-                result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
+                result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers, account)
 
                 # Assert: Verify the expected outcomes
                 assert result is not None
@@ -553,7 +553,7 @@ class TestWorkspaceService:
         # No TenantAccountJoin created
         with patch("services.workspace_service.current_user", account):
             with pytest.raises(AssertionError, match="TenantAccountJoin not found"):
-                WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
+                WorkspaceService.get_tenant_info(tenant, db_session_with_containers, account)
 
     def test_get_tenant_info_should_set_replace_webapp_logo_to_none_when_flag_absent(
         self, db_session_with_containers: Session, mock_external_service_dependencies
@@ -572,7 +572,7 @@ class TestWorkspaceService:
         mock_external_service_dependencies["tenant_service"].has_roles.return_value = True
 
         with patch("services.workspace_service.current_user", account):
-            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers, account)
 
         assert result is not None
         assert result["custom_config"]["replace_webapp_logo"] is None
@@ -596,7 +596,7 @@ class TestWorkspaceService:
         mock_external_service_dependencies["tenant_service"].has_roles.return_value = True
 
         with patch("services.workspace_service.current_user", account):
-            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers, account)
 
         assert result is not None
         assert result["custom_config"]["replace_webapp_logo"].startswith(custom_base)
@@ -615,7 +615,7 @@ class TestWorkspaceService:
         mock_external_service_dependencies["tenant_service"].has_roles.return_value = False
 
         with patch("services.workspace_service.current_user", account):
-            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers, account)
 
         assert result is not None
         assert "next_credit_reset_date" not in result
@@ -642,7 +642,7 @@ class TestWorkspaceService:
             patch("services.workspace_service.current_user", account),
             patch("services.credit_pool_service.CreditPoolService.get_pool", return_value=None),
         ):
-            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers, account)
 
         assert result is not None
         assert result["next_credit_reset_date"] == "2025-02-01"
@@ -669,7 +669,7 @@ class TestWorkspaceService:
             patch("services.workspace_service.current_user", account),
             patch("services.credit_pool_service.CreditPoolService.get_pool", return_value=paid_pool),
         ):
-            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers, account)
 
         assert result is not None
         assert result["trial_credits"] == 1000
@@ -697,7 +697,7 @@ class TestWorkspaceService:
             patch("services.workspace_service.current_user", account),
             patch("services.credit_pool_service.CreditPoolService.get_pool", side_effect=[paid_pool, None]),
         ):
-            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers, account)
 
         assert result is not None
         assert result["trial_credits"] == -1
@@ -726,7 +726,7 @@ class TestWorkspaceService:
             patch("services.workspace_service.current_user", account),
             patch("services.credit_pool_service.CreditPoolService.get_pool", side_effect=[paid_pool, trial_pool]),
         ):
-            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers, account)
 
         assert result is not None
         assert result["trial_credits"] == 100
@@ -754,7 +754,7 @@ class TestWorkspaceService:
             patch("services.workspace_service.current_user", account),
             patch("services.credit_pool_service.CreditPoolService.get_pool", side_effect=[None, trial_pool]),
         ):
-            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers, account)
 
         assert result is not None
         assert result["trial_credits"] == 50
@@ -785,7 +785,7 @@ class TestWorkspaceService:
             patch("services.workspace_service.current_user", account),
             patch("services.credit_pool_service.CreditPoolService.get_pool", side_effect=[paid_pool, trial_pool]),
         ):
-            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers, account)
 
         assert result is not None
         assert result["trial_credits"] == 200
@@ -811,7 +811,7 @@ class TestWorkspaceService:
             patch("services.workspace_service.current_user", account),
             patch("services.credit_pool_service.CreditPoolService.get_pool", side_effect=[None, None]),
         ):
-            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers, account)
 
         assert result is not None
         assert "trial_credits" not in result

--- a/api/tests/test_containers_integration_tests/services/test_workspace_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_workspace_service.py
@@ -104,7 +104,7 @@ class TestWorkspaceService:
         # Mock current_user for flask_login
         with patch("services.workspace_service.current_user", account):
             # Act: Execute the method under test
-            result = WorkspaceService.get_tenant_info(tenant)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
 
             # Assert: Verify the expected outcomes
             assert result is not None
@@ -151,7 +151,7 @@ class TestWorkspaceService:
         # Mock current_user for flask_login
         with patch("services.workspace_service.current_user", account):
             # Act: Execute the method under test
-            result = WorkspaceService.get_tenant_info(tenant)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
 
             # Assert: Verify the expected outcomes
             assert result is not None
@@ -206,7 +206,7 @@ class TestWorkspaceService:
         # Mock current_user for flask_login
         with patch("services.workspace_service.current_user", account):
             # Act: Execute the method under test
-            result = WorkspaceService.get_tenant_info(tenant)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
 
             # Assert: Verify the expected outcomes
             assert result is not None
@@ -261,7 +261,7 @@ class TestWorkspaceService:
         # Mock current_user for flask_login
         with patch("services.workspace_service.current_user", account):
             # Act: Execute the method under test
-            result = WorkspaceService.get_tenant_info(tenant)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
 
             # Assert: Verify the expected outcomes
             assert result is not None
@@ -291,7 +291,7 @@ class TestWorkspaceService:
         # Arrange: No test data needed for this test
 
         # Act: Execute the method under test with None tenant
-        result = WorkspaceService.get_tenant_info(None)
+        result = WorkspaceService.get_tenant_info(None, db_session_with_containers)
 
         # Assert: Verify the expected outcomes
         assert result is None
@@ -341,7 +341,7 @@ class TestWorkspaceService:
             # Mock current_user for flask_login
             with patch("services.workspace_service.current_user", account):
                 # Act: Execute the method under test
-                result = WorkspaceService.get_tenant_info(tenant)
+                result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
 
                 # Assert: Verify the expected outcomes
                 assert result is not None
@@ -398,7 +398,7 @@ class TestWorkspaceService:
         # Mock current_user for flask_login
         with patch("services.workspace_service.current_user", account):
             # Act: Execute the method under test
-            result = WorkspaceService.get_tenant_info(tenant)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
 
             # Assert: Verify the expected outcomes
             assert result is not None
@@ -448,7 +448,7 @@ class TestWorkspaceService:
         # Mock current_user for flask_login
         with patch("services.workspace_service.current_user", account):
             # Act: Execute the method under test
-            result = WorkspaceService.get_tenant_info(tenant)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
 
             # Assert: Verify the expected outcomes
             assert result is not None
@@ -513,7 +513,7 @@ class TestWorkspaceService:
             # Mock current_user for flask_login
             with patch("services.workspace_service.current_user", account):
                 # Act: Execute the method under test
-                result = WorkspaceService.get_tenant_info(tenant)
+                result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
 
                 # Assert: Verify the expected outcomes
                 assert result is not None
@@ -553,7 +553,7 @@ class TestWorkspaceService:
         # No TenantAccountJoin created
         with patch("services.workspace_service.current_user", account):
             with pytest.raises(AssertionError, match="TenantAccountJoin not found"):
-                WorkspaceService.get_tenant_info(tenant)
+                WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
 
     def test_get_tenant_info_should_set_replace_webapp_logo_to_none_when_flag_absent(
         self, db_session_with_containers: Session, mock_external_service_dependencies
@@ -572,7 +572,7 @@ class TestWorkspaceService:
         mock_external_service_dependencies["tenant_service"].has_roles.return_value = True
 
         with patch("services.workspace_service.current_user", account):
-            result = WorkspaceService.get_tenant_info(tenant)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
 
         assert result is not None
         assert result["custom_config"]["replace_webapp_logo"] is None
@@ -596,7 +596,7 @@ class TestWorkspaceService:
         mock_external_service_dependencies["tenant_service"].has_roles.return_value = True
 
         with patch("services.workspace_service.current_user", account):
-            result = WorkspaceService.get_tenant_info(tenant)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
 
         assert result is not None
         assert result["custom_config"]["replace_webapp_logo"].startswith(custom_base)
@@ -615,7 +615,7 @@ class TestWorkspaceService:
         mock_external_service_dependencies["tenant_service"].has_roles.return_value = False
 
         with patch("services.workspace_service.current_user", account):
-            result = WorkspaceService.get_tenant_info(tenant)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
 
         assert result is not None
         assert "next_credit_reset_date" not in result
@@ -642,7 +642,7 @@ class TestWorkspaceService:
             patch("services.workspace_service.current_user", account),
             patch("services.credit_pool_service.CreditPoolService.get_pool", return_value=None),
         ):
-            result = WorkspaceService.get_tenant_info(tenant)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
 
         assert result is not None
         assert result["next_credit_reset_date"] == "2025-02-01"
@@ -669,7 +669,7 @@ class TestWorkspaceService:
             patch("services.workspace_service.current_user", account),
             patch("services.credit_pool_service.CreditPoolService.get_pool", return_value=paid_pool),
         ):
-            result = WorkspaceService.get_tenant_info(tenant)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
 
         assert result is not None
         assert result["trial_credits"] == 1000
@@ -697,7 +697,7 @@ class TestWorkspaceService:
             patch("services.workspace_service.current_user", account),
             patch("services.credit_pool_service.CreditPoolService.get_pool", side_effect=[paid_pool, None]),
         ):
-            result = WorkspaceService.get_tenant_info(tenant)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
 
         assert result is not None
         assert result["trial_credits"] == -1
@@ -726,7 +726,7 @@ class TestWorkspaceService:
             patch("services.workspace_service.current_user", account),
             patch("services.credit_pool_service.CreditPoolService.get_pool", side_effect=[paid_pool, trial_pool]),
         ):
-            result = WorkspaceService.get_tenant_info(tenant)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
 
         assert result is not None
         assert result["trial_credits"] == 100
@@ -754,7 +754,7 @@ class TestWorkspaceService:
             patch("services.workspace_service.current_user", account),
             patch("services.credit_pool_service.CreditPoolService.get_pool", side_effect=[None, trial_pool]),
         ):
-            result = WorkspaceService.get_tenant_info(tenant)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
 
         assert result is not None
         assert result["trial_credits"] == 50
@@ -785,7 +785,7 @@ class TestWorkspaceService:
             patch("services.workspace_service.current_user", account),
             patch("services.credit_pool_service.CreditPoolService.get_pool", side_effect=[paid_pool, trial_pool]),
         ):
-            result = WorkspaceService.get_tenant_info(tenant)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
 
         assert result is not None
         assert result["trial_credits"] == 200
@@ -811,7 +811,7 @@ class TestWorkspaceService:
             patch("services.workspace_service.current_user", account),
             patch("services.credit_pool_service.CreditPoolService.get_pool", side_effect=[None, None]),
         ):
-            result = WorkspaceService.get_tenant_info(tenant)
+            result = WorkspaceService.get_tenant_info(tenant, db_session_with_containers)
 
         assert result is not None
         assert "trial_credits" not in result


### PR DESCRIPTION
Resolves #37403. Refactored WorkspaceService and CreditPoolService to accept session parameter.