### PR TITLE
fix: ignore exiting toast pointer events

### DIFF
--- a/packages/dify-ui/src/toast/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/toast/__tests__/index.spec.tsx
@@ -166,6 +166,16 @@ describe('@langgenius/dify-ui/toast', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
+  it('should disable pointer events while a toast is exiting', async () => {
+    const screen = await render(<ToastHost />)
+
+    toast('Dismiss me')
+
+    await expect.element(screen.getByText('Dismiss me')).toBeInTheDocument()
+    const toastRoot = screen.getByRole('dialog', { name: 'Dismiss me' }).element()
+    expect(toastRoot).toHaveClass('data-ending-style:pointer-events-none')
+  })
+
   it('should keep zero-timeout toasts persistent', async () => {
     const screen = await render(<ToastHost />)
 

--- a/packages/dify-ui/src/toast/index.tsx
+++ b/packages/dify-ui/src/toast/index.tsx
@@ -159,7 +159,7 @@ function ToastCard({
         '[transition:transform_500ms_cubic-bezier(0.22,1,0.36,1),opacity_500ms,height_150ms] motion-reduce:transition-none',
         'transform-[translateX(var(--toast-swipe-movement-x))_translateY(calc(var(--toast-swipe-movement-y)+(var(--toast-index)*var(--toast-peek))+(var(--toast-shrink)*var(--toast-current-height))))_scale(var(--toast-scale))]',
         'data-expanded:h-(--toast-height) data-expanded:transform-[translateX(var(--toast-swipe-movement-x))_translateY(calc(var(--toast-offset-y)+var(--toast-swipe-movement-y)+(var(--toast-index)*8px)))_scale(1)]',
-        'data-ending-style:transform-[translateY(-150%)] data-ending-style:opacity-0',
+        'data-ending-style:pointer-events-none data-ending-style:transform-[translateY(-150%)] data-ending-style:opacity-0',
         'data-ending-style:data-[swipe-direction=down]:transform-[translateY(calc(var(--toast-swipe-movement-y)+150%))]',
         'data-ending-style:data-[swipe-direction=right]:transform-[translateX(calc(var(--toast-swipe-movement-x)+150%))]',
         'data-limited:pointer-events-none data-limited:opacity-0 data-starting-style:transform-[translateY(-150%)] data-starting-style:opacity-0',


### PR DESCRIPTION
Summary\n- Disable pointer events on toast roots while Base UI marks them as exiting.\n- Cover the toast root class so invisible exiting toasts cannot block underlying controls.\n\nTests\n- pnpm --filter @langgenius/dify-ui test -- src/toast/__tests__/index.spec.tsx\n\nFixes #38047