### PR TITLE
fix: use isolated session in cloud_edition_billing_rate_limit_check to prevent premature commit

### DIFF
--- a/api/controllers/service_api/wraps.py
+++ b/api/controllers/service_api/wraps.py
@@ -12,6 +12,7 @@ from flask_restx import Resource
 from flask_restx.utils import merge
 from pydantic import BaseModel
 from sqlalchemy import select
+from sqlalchemy.orm import sessionmaker
 from werkzeug.exceptions import Forbidden, NotFound, Unauthorized
 
 from configs import dify_config
@@ -263,14 +264,15 @@ def cloud_edition_billing_rate_limit_check[**P, R](
                     request_count = redis_client.zcard(key)
 
                     if request_count > knowledge_rate_limit.limit:
-                        # add ratelimit record
+                        # add ratelimit record using an isolated session
+                        # to avoid committing the request-scoped db.session
                         rate_limit_log = RateLimitLog(
                             tenant_id=api_token.tenant_id,
                             subscription_plan=knowledge_rate_limit.subscription_plan,
                             operation="knowledge",
                         )
-                        db.session.add(rate_limit_log)
-                        db.session.commit()
+                        with sessionmaker(bind=db.engine).begin() as session:
+                            session.add(rate_limit_log)
                         raise Forbidden(
                             "Sorry, you have reached the knowledge base request rate limit of your subscription."
                         )


### PR DESCRIPTION
## Root Cause

The `cloud_edition_billing_rate_limit_check` decorator in `api/controllers/service_api/wraps.py` was calling `db.session.commit()` on the Flask-scoped SQLAlchemy session to persist the `RateLimitLog` entry. Since `db.session` is the global request-scoped session, this commit flushes **all** pending dirty objects — not just the rate limit log.

When the request exceeds the rate limit, the flow is:
1. Various upstream interceptors/middleware make pending modifications to `db.session` (e.g. updating `last_active` timestamps, initializing temporary state)
2. `db.session.add(rate_limit_log)`
3. `db.session.commit()` — commits everything, including half-finished context data
4. `raise Forbidden(...)` — request aborted, but dirty data is already persisted

This violates transaction isolation and can leave partial/inconsistent data in the database.

## Fix

Replaced `db.session.add()` + `db.session.commit()` with an isolated session using `sessionmaker(bind=db.engine).begin()`:

```python
with sessionmaker(bind=db.engine).begin() as session:
    session.add(rate_limit_log)
```

This pattern creates a completely independent database session/transaction for the RateLimitLog write. The transaction is auto-committed on context exit (or rolled back on exception), and has zero impact on the Flask request-scoped `db.session`.

This is the same pattern used elsewhere in the codebase for isolated writes that must not interfere with the request transaction (e.g., `sessionmaker(bind=db.engine).begin()` was already used in `DatasetRetrieval._on_retrieval_end` and recently applied to `_on_query` in #37975).

## Testing

1. Set up a Dify instance with rate limiting enabled for knowledge base access
2. Send API requests that exceed the rate limit
3. Before the fix: any pending session state from upstream middleware would be committed prematurely
4. After the fix: only the `RateLimitLog` is written, via a dedicated session — the request-scoped session remains untouched
5. Verify the `Forbidden` response is still raised correctly when rate limited

Fixes #37885