### PR TITLE
[Security] Enforce dataset permissions on RAG objects

### DIFF
--- a/api/controllers/console/datasets/metadata.py
+++ b/api/controllers/console/datasets/metadata.py
@@ -2,7 +2,7 @@ from typing import Literal
 from uuid import UUID
 
 from flask_restx import Resource
-from werkzeug.exceptions import NotFound
+from werkzeug.exceptions import Forbidden, NotFound
 
 from controllers.common.controller_schemas import MetadataUpdatePayload
 from controllers.common.schema import register_response_schema_models, register_schema_models
@@ -33,6 +33,7 @@ from services.entities.knowledge_entities.knowledge_entities import (
     MetadataDetail,
     MetadataOperationData,
 )
+from services.errors.account import NoPermissionError
 from services.metadata_service import MetadataService
 
 register_schema_models(
@@ -78,12 +79,17 @@ class DatasetMetadataCreateApi(Resource):
     @console_ns.response(
         200, "Metadata retrieved successfully", console_ns.models[DatasetMetadataListResponse.__name__]
     )
+    @with_current_user
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_CREATE_AND_MANAGEMENT)
-    def get(self, dataset_id: UUID):
+    def get(self, current_user: Account, dataset_id: UUID):
         dataset_id_str = str(dataset_id)
         dataset = DatasetService.get_dataset(dataset_id_str)
         if dataset is None:
             raise NotFound("Dataset not found.")
+        try:
+            DatasetService.check_dataset_permission(dataset, current_user, db.session)
+        except NoPermissionError as e:
+            raise Forbidden(str(e))
         metadata = MetadataService.get_dataset_metadatas(db.session(), dataset)
         return dump_response(DatasetMetadataListResponse, metadata), 200
 

--- a/api/controllers/console/datasets/wraps.py
+++ b/api/controllers/console/datasets/wraps.py
@@ -2,11 +2,14 @@ from collections.abc import Callable
 from functools import wraps
 
 from sqlalchemy import select
+from werkzeug.exceptions import Forbidden
 
 from controllers.console.datasets.error import PipelineNotFoundError
 from extensions.ext_database import db
 from libs.login import current_account_with_tenant
 from models.dataset import Pipeline
+from services.dataset_service import DatasetService
+from services.errors.account import NoPermissionError
 
 
 def get_rag_pipeline[**P, R](view_func: Callable[P, R]) -> Callable[P, R]:
@@ -15,7 +18,7 @@ def get_rag_pipeline[**P, R](view_func: Callable[P, R]) -> Callable[P, R]:
         if not kwargs.get("pipeline_id"):
             raise ValueError("missing pipeline_id in path parameters")
 
-        _, current_tenant_id = current_account_with_tenant()
+        current_account, current_tenant_id = current_account_with_tenant()
 
         pipeline_id = kwargs.get("pipeline_id")
         pipeline_id = str(pipeline_id)
@@ -28,6 +31,15 @@ def get_rag_pipeline[**P, R](view_func: Callable[P, R]) -> Callable[P, R]:
 
         if not pipeline:
             raise PipelineNotFoundError()
+
+        dataset = pipeline.retrieve_dataset(db.session)
+        if not dataset:
+            raise PipelineNotFoundError()
+
+        try:
+            DatasetService.check_dataset_permission(dataset, current_account, db.session)
+        except NoPermissionError as e:
+            raise Forbidden(str(e))
 
         kwargs["pipeline"] = pipeline
 

--- a/api/tests/unit_tests/controllers/console/datasets/test_metadata.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_metadata.py
@@ -5,8 +5,9 @@ from unittest.mock import MagicMock, PropertyMock, patch
 import pytest
 from flask import Flask
 from pytest_mock import MockerFixture
-from werkzeug.exceptions import NotFound
+from werkzeug.exceptions import Forbidden, NotFound
 
+import services
 from controllers.console import console_ns
 from controllers.console.datasets.metadata import (
     DatasetMetadataApi,
@@ -15,6 +16,7 @@ from controllers.console.datasets.metadata import (
     DatasetMetadataCreateApi,
     DocumentMetadataEditApi,
 )
+from extensions.ext_database import db
 from models.account import Account
 from services.dataset_service import DatasetService
 from services.entities.knowledge_entities.knowledge_entities import (
@@ -150,7 +152,7 @@ class TestDatasetMetadataCreateApi:
 
 
 class TestDatasetMetadataGetApi:
-    def test_get_metadata_success(self, app: Flask, dataset, dataset_id):
+    def test_get_metadata_success(self, app: Flask, current_user, dataset, dataset_id):
         api = DatasetMetadataCreateApi()
         method = unwrap(api.get)
 
@@ -162,6 +164,10 @@ class TestDatasetMetadataGetApi:
                 return_value=dataset,
             ),
             patch.object(
+                DatasetService,
+                "check_dataset_permission",
+            ) as mock_check_permission,
+            patch.object(
                 MetadataService,
                 "get_dataset_metadatas",
                 return_value={
@@ -170,13 +176,14 @@ class TestDatasetMetadataGetApi:
                 },
             ),
         ):
-            result, status = method(api, dataset_id)
+            result, status = method(api, current_user, dataset_id)
 
         assert status == 200
         assert result["doc_metadata"] == [{"id": "m1", "name": "author", "type": "string", "count": 0}]
         assert result["built_in_field_enabled"] is False
+        mock_check_permission.assert_called_once_with(dataset, current_user, db.session)
 
-    def test_get_metadata_dataset_not_found(self, app: Flask, dataset_id):
+    def test_get_metadata_dataset_not_found(self, app: Flask, current_user, dataset_id):
         api = DatasetMetadataCreateApi()
         method = unwrap(api.get)
 
@@ -189,7 +196,30 @@ class TestDatasetMetadataGetApi:
             ),
         ):
             with pytest.raises(NotFound):
-                method(api, dataset_id)
+                method(api, current_user, dataset_id)
+
+    def test_get_metadata_denies_user_without_dataset_permission(self, app: Flask, current_user, dataset, dataset_id):
+        api = DatasetMetadataCreateApi()
+        method = unwrap(api.get)
+
+        with (
+            app.test_request_context("/"),
+            patch.object(
+                DatasetService,
+                "get_dataset",
+                return_value=dataset,
+            ),
+            patch.object(
+                DatasetService,
+                "check_dataset_permission",
+                side_effect=services.errors.account.NoPermissionError("no access"),
+            ),
+            patch.object(MetadataService, "get_dataset_metadatas") as mock_get_metadata,
+        ):
+            with pytest.raises(Forbidden):
+                method(api, current_user, dataset_id)
+
+        mock_get_metadata.assert_not_called()
 
 
 class TestDatasetMetadataApi:

--- a/api/tests/unit_tests/controllers/console/datasets/test_wraps.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_wraps.py
@@ -2,7 +2,9 @@ from unittest.mock import Mock
 
 import pytest
 from pytest_mock import MockerFixture
+from werkzeug.exceptions import Forbidden
 
+import services
 from controllers.console.datasets.error import PipelineNotFoundError
 from controllers.console.datasets.wraps import get_rag_pipeline
 from models.dataset import Pipeline
@@ -39,6 +41,9 @@ class TestGetRagPipeline:
         pipeline = Mock(spec=Pipeline)
         pipeline.id = "pipeline-1"
         pipeline.tenant_id = "tenant-1"
+        dataset = Mock()
+        pipeline.retrieve_dataset.return_value = dataset
+        current_user = Mock()
 
         @get_rag_pipeline
         def dummy_view(**kwargs):
@@ -46,20 +51,26 @@ class TestGetRagPipeline:
 
         mocker.patch(
             "controllers.console.datasets.wraps.current_account_with_tenant",
-            return_value=(Mock(), "tenant-1"),
+            return_value=(current_user, "tenant-1"),
         )
 
         mocker.patch(
             "controllers.console.datasets.wraps.db.session.scalar",
             return_value=pipeline,
         )
+        mock_check_permission = mocker.patch(
+            "controllers.console.datasets.wraps.DatasetService.check_dataset_permission",
+        )
 
         result = dummy_view(pipeline_id="pipeline-1")
 
         assert result is pipeline
+        pipeline.retrieve_dataset.assert_called_once_with(mocker.ANY)
+        mock_check_permission.assert_called_once_with(dataset, current_user, mocker.ANY)
 
     def test_pipeline_id_removed_from_kwargs(self, mocker: MockerFixture):
         pipeline = Mock(spec=Pipeline)
+        pipeline.retrieve_dataset.return_value = Mock()
 
         @get_rag_pipeline
         def dummy_view(**kwargs):
@@ -75,6 +86,9 @@ class TestGetRagPipeline:
             "controllers.console.datasets.wraps.db.session.scalar",
             return_value=pipeline,
         )
+        mocker.patch(
+            "controllers.console.datasets.wraps.DatasetService.check_dataset_permission",
+        )
 
         result = dummy_view(pipeline_id="pipeline-1")
 
@@ -82,6 +96,7 @@ class TestGetRagPipeline:
 
     def test_pipeline_id_cast_to_string(self, mocker: MockerFixture):
         pipeline = Mock(spec=Pipeline)
+        pipeline.retrieve_dataset.return_value = Mock()
 
         @get_rag_pipeline
         def dummy_view(**kwargs):
@@ -96,6 +111,9 @@ class TestGetRagPipeline:
             "controllers.console.datasets.wraps.db.session.scalar",
             return_value=pipeline,
         )
+        mocker.patch(
+            "controllers.console.datasets.wraps.DatasetService.check_dataset_permission",
+        )
 
         result = dummy_view(pipeline_id=123)
 
@@ -104,3 +122,29 @@ class TestGetRagPipeline:
         stmt = mock_scalar.call_args[0][0]
         where_clauses = stmt.whereclause.clauses
         assert where_clauses[0].right.value == "123"
+
+    def test_pipeline_denied_when_user_lacks_backing_dataset_permission(self, mocker: MockerFixture):
+        pipeline = Mock(spec=Pipeline)
+        dataset = Mock()
+        pipeline.retrieve_dataset.return_value = dataset
+        current_user = Mock()
+
+        @get_rag_pipeline
+        def dummy_view(**kwargs):
+            return kwargs["pipeline"]
+
+        mocker.patch(
+            "controllers.console.datasets.wraps.current_account_with_tenant",
+            return_value=(current_user, "tenant-1"),
+        )
+        mocker.patch(
+            "controllers.console.datasets.wraps.db.session.scalar",
+            return_value=pipeline,
+        )
+        mocker.patch(
+            "controllers.console.datasets.wraps.DatasetService.check_dataset_permission",
+            side_effect=services.errors.account.NoPermissionError("no access"),
+        )
+
+        with pytest.raises(Forbidden):
+            dummy_view(pipeline_id="pipeline-1")


### PR DESCRIPTION
Summary
Dataset metadata reads and RAG pipeline object routes now enforce the same dataset permission checks used by dataset write paths before returning metadata or draft workflow state.

Risk
A workspace user could read dataset metadata from another tenant, and a same-workspace editor could read or update another user's private RAG pipeline draft when they knew the object identifier.

What changed
- Added dataset permission enforcement to the console dataset metadata GET handler.
- Added backing dataset permission enforcement in the shared RAG pipeline wrapper before draft workflow handlers receive a pipeline.
- Added regression coverage for denied dataset metadata reads and denied RAG pipeline access before handler execution.

Validation
- Red on unfixed code: `uv run --project api --dev pytest api/tests/unit_tests/controllers/console/datasets/test_metadata.py::TestDatasetMetadataGetApi api/tests/unit_tests/controllers/console/datasets/test_wraps.py::TestGetRagPipeline -q` failed with `7 failed, 2 passed` because metadata GET did not accept a current user and the RAG wrapper had no dataset permission gate.
- Green after fix: same targeted command passed with `9 passed, 3 warnings`.
- Modified-file suite: `uv run --project api --dev pytest api/tests/unit_tests/controllers/console/datasets/test_metadata.py api/tests/unit_tests/controllers/console/datasets/test_wraps.py -q` passed with `16 passed, 3 warnings`.
- Style check: `uv run --project api --dev ruff check ...` passed for all touched files.
- Full local backend unit suite: `make test` passed with `12777 passed, 5 skipped` in the first phase and `3016 passed, 1 skipped` in the controller phase.

Residual risk
Integration tests are CI-only for this repository and were not run locally.

_Pentested and fixed by [Niro](https://github.com/apxlabs-ai/niro)_
