### PR TITLE
[Security] Enforce workspace management rights

### DIFF
--- a/api/controllers/console/explore/installed_app.py
+++ b/api/controllers/console/explore/installed_app.py
@@ -23,8 +23,8 @@ from fields.base import ResponseModel
 from graphon.file import helpers as file_helpers
 from libs.datetime_utils import naive_utc_now
 from libs.helper import to_timestamp
-from libs.login import login_required
-from models import Account, App, AppModelConfig, InstalledApp, RecommendedApp, Workflow
+from libs.login import current_account_with_tenant, login_required
+from models import Account, App, AppModelConfig, InstalledApp, RecommendedApp, TenantAccountRole, Workflow
 from models.model import AppMode, IconType
 from services.account_service import TenantService
 from services.enterprise.enterprise_service import EnterpriseService
@@ -44,6 +44,12 @@ class InstalledAppsListQuery(BaseModel):
 
 
 logger = logging.getLogger(__name__)
+
+
+def _require_current_workspace_manager() -> None:
+    current_user, _ = current_account_with_tenant()
+    if not TenantAccountRole.is_privileged_role(current_user.current_role):
+        raise Forbidden()
 
 
 def _build_icon_url(icon_type: str | IconType | None, icon: str | None) -> str | None:
@@ -304,6 +310,7 @@ class InstalledAppApi(InstalledAppResource):
     @console_ns.response(200, "Success", console_ns.models[SimpleResultMessageResponse.__name__])
     @console_ns.expect(console_ns.models[InstalledAppUpdatePayload.__name__])
     def patch(self, installed_app: InstalledApp):
+        _require_current_workspace_manager()
         payload = InstalledAppUpdatePayload.model_validate(console_ns.payload or {})
 
         commit_args = False

--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -5,7 +5,7 @@ from flask import request
 from flask_restx import Resource, fields, marshal
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import select
-from werkzeug.exceptions import Unauthorized
+from werkzeug.exceptions import Forbidden, Unauthorized
 
 import services
 from configs import dify_config
@@ -32,8 +32,8 @@ from enums.cloud_plan import CloudPlan
 from extensions.ext_database import db
 from fields.base import ResponseModel
 from libs.helper import OptionalTimestampField, TimestampField, dump_response, to_timestamp
-from libs.login import login_required
-from models.account import Account, Tenant, TenantAccountJoin, TenantCustomConfigDict, TenantStatus
+from libs.login import current_account_with_tenant, login_required
+from models.account import Account, Tenant, TenantAccountJoin, TenantAccountRole, TenantCustomConfigDict, TenantStatus
 from services.account_service import TenantService
 from services.billing_service import BillingService, SubscriptionPlan
 from services.enterprise.enterprise_service import EnterpriseService
@@ -42,6 +42,12 @@ from services.file_service import FileService
 from services.workspace_service import WorkspaceService
 
 logger = logging.getLogger(__name__)
+
+
+def _require_current_workspace_manager() -> None:
+    current_user, _ = current_account_with_tenant()
+    if not TenantAccountRole.is_privileged_role(current_user.current_role):
+        raise Forbidden()
 
 
 class WorkspaceListQuery(BaseModel):
@@ -447,6 +453,7 @@ class WorkspaceInfoApi(Resource):
 
         if not current_tenant_id:
             raise ValueError("No current tenant")
+        _require_current_workspace_manager()
         tenant = db.get_or_404(Tenant, current_tenant_id)
         tenant.name = args.name
         db.session.commit()

--- a/api/tests/unit_tests/controllers/console/explore/test_installed_app.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_installed_app.py
@@ -8,6 +8,7 @@ from flask import Flask
 from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
 import controllers.console.explore.installed_app as module
+from models.account import TenantAccountRole
 
 type Payload = dict[str, object]
 type PayloadPatch = Callable[[Payload], AbstractContextManager[object]]
@@ -26,6 +27,7 @@ def current_user(tenant_id: str) -> MagicMock:
     user = MagicMock()
     user.id = "u1"
     user.current_tenant = MagicMock(id=tenant_id)
+    user.current_role = TenantAccountRole.OWNER
     return user
 
 
@@ -388,13 +390,16 @@ class TestInstalledAppApi:
         with pytest.raises(BadRequest):
             method(api, tenant_id, installed_app)
 
-    def test_patch_update_pin(self, app: Flask, payload_patch: PayloadPatch, installed_app: MagicMock) -> None:
+    def test_patch_update_pin(
+        self, app: Flask, current_user: MagicMock, tenant_id: str, payload_patch: PayloadPatch, installed_app: MagicMock
+    ) -> None:
         api = module.InstalledAppApi()
         method = unwrap(api.patch)
 
         with (
             app.test_request_context("/", json={"is_pinned": True}),
             payload_patch({"is_pinned": True}),
+            patch.object(module, "current_account_with_tenant", return_value=(current_user, tenant_id), create=True),
             patch.object(module.db, "session"),
         ):
             result = method(installed_app)
@@ -402,11 +407,38 @@ class TestInstalledAppApi:
         assert installed_app.is_pinned is True
         assert result["result"] == "success"
 
-    def test_patch_no_change(self, app: Flask, payload_patch: PayloadPatch, installed_app: MagicMock) -> None:
+    def test_patch_forbids_normal_member_pin_change(
+        self, app: Flask, current_user: MagicMock, tenant_id: str, payload_patch: PayloadPatch, installed_app: MagicMock
+    ) -> None:
+        api = module.InstalledAppApi()
+        method = unwrap(api.patch)
+        current_user.current_role = TenantAccountRole.NORMAL
+        session = MagicMock()
+
+        with (
+            app.test_request_context("/", json={"is_pinned": True}),
+            payload_patch({"is_pinned": True}),
+            patch.object(module, "current_account_with_tenant", return_value=(current_user, tenant_id), create=True),
+            patch.object(module.db, "session", session),
+        ):
+            with pytest.raises(Forbidden):
+                method(installed_app)
+
+        assert installed_app.is_pinned is False
+        session.commit.assert_not_called()
+
+    def test_patch_no_change(
+        self, app: Flask, current_user: MagicMock, tenant_id: str, payload_patch: PayloadPatch, installed_app: MagicMock
+    ) -> None:
         api = module.InstalledAppApi()
         method = unwrap(api.patch)
 
-        with app.test_request_context("/", json={}), payload_patch({}), patch.object(module.db, "session"):
+        with (
+            app.test_request_context("/", json={}),
+            payload_patch({}),
+            patch.object(module, "current_account_with_tenant", return_value=(current_user, tenant_id), create=True),
+            patch.object(module.db, "session"),
+        ):
             result = method(installed_app)
 
         assert result["result"] == "success"

--- a/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from flask import Flask
 from werkzeug.datastructures import FileStorage
-from werkzeug.exceptions import Unauthorized
+from werkzeug.exceptions import Forbidden, Unauthorized
 
 import services
 from controllers.common.errors import (
@@ -30,12 +30,13 @@ from controllers.console.workspace.workspace import (
 )
 from enums.cloud_plan import CloudPlan
 from libs.datetime_utils import naive_utc_now
-from models.account import Account, Tenant, TenantCustomConfigDict, TenantStatus
+from models.account import Account, Tenant, TenantAccountRole, TenantCustomConfigDict, TenantStatus
 
 
-def make_account(account_id: str = "u1") -> Account:
+def make_account(account_id: str = "u1", *, role: TenantAccountRole = TenantAccountRole.OWNER) -> Account:
     account = Account(name="Test User", email=f"{account_id}@example.com")
     account.id = account_id
+    account.role = role
     return account
 
 
@@ -667,11 +668,17 @@ class TestWorkspaceInfoApi:
         method = inspect.unwrap(api.post)
 
         tenant = make_tenant()
+        user = make_account(role=TenantAccountRole.OWNER)
 
         payload = {"name": "New Name"}
 
         with (
             app.test_request_context("/workspaces/info", json=payload),
+            patch(
+                "controllers.console.workspace.workspace.current_account_with_tenant",
+                return_value=(user, "t1"),
+                create=True,
+            ),
             patch("controllers.console.workspace.workspace.db.get_or_404", return_value=tenant),
             patch("controllers.console.workspace.workspace.db.session.commit"),
             patch(
@@ -682,6 +689,32 @@ class TestWorkspaceInfoApi:
             result = method(api, "t1")
 
         assert result["result"] == "success"
+
+    def test_post_forbids_normal_member_rename(self, app: Flask):
+        api = WorkspaceInfoApi()
+        method = inspect.unwrap(api.post)
+        tenant = make_tenant()
+        user = make_account(role=TenantAccountRole.NORMAL)
+
+        with (
+            app.test_request_context("/workspaces/info", json={"name": "Renamed By Normal"}),
+            patch(
+                "controllers.console.workspace.workspace.current_account_with_tenant",
+                return_value=(user, "t1"),
+                create=True,
+            ),
+            patch("controllers.console.workspace.workspace.db.get_or_404", return_value=tenant),
+            patch("controllers.console.workspace.workspace.db.session.commit") as commit,
+            patch(
+                "controllers.console.workspace.workspace.WorkspaceService.get_tenant_info",
+                return_value={"name": "Renamed By Normal"},
+            ),
+        ):
+            with pytest.raises(Forbidden):
+                method(api, "t1")
+
+        assert tenant.name == "Tenant t1"
+        commit.assert_not_called()
 
     def test_no_current_tenant(self, app: Flask):
         api = WorkspaceInfoApi()


### PR DESCRIPTION
## Summary

Owner/admin workspace management rights are now required before changing shared installed-app pin state or renaming a workspace. The checks use the existing workspace role model and run before either endpoint mutates or commits shared tenant state.

## Risk

A normal workspace member could modify shared workspace settings that affect other members, including installed-app pinning and the workspace display name.

## What changed

- Added owner/admin role checks to installed-app `PATCH` before applying `is_pinned` updates.
- Added owner/admin role checks to workspace-info `POST` before changing the tenant name.
- Added regression tests proving normal members are rejected and owners can still perform the operations.

## Validation

Red baseline before the fix:

```text
uv run --project api --dev pytest api/tests/unit_tests/controllers/console/explore/test_installed_app.py api/tests/unit_tests/controllers/console/workspace/test_workspace.py
FAILED api/tests/unit_tests/controllers/console/explore/test_installed_app.py::TestInstalledAppApi::test_patch_forbids_normal_member_pin_change - Failed: DID NOT RAISE <class 'werkzeug.exceptions.Forbidden'>
FAILED api/tests/unit_tests/controllers/console/workspace/test_workspace.py::TestWorkspaceInfoApi::test_post_forbids_normal_member_rename - Failed: DID NOT RAISE <class 'werkzeug.exceptions.Forbidden'>
```

Green after the fix:

```text
uv run --project api --dev pytest api/tests/unit_tests/controllers/console/explore/test_installed_app.py api/tests/unit_tests/controllers/console/workspace/test_workspace.py
49 passed, 3 warnings in 26.15s

make lint
✅ Linting complete

make type-check
Success: no issues found in 1579 source files
✅ Type checks complete

make test
12777 passed, 5 skipped, 605 warnings in 199.29s
3016 passed, 1 skipped, 6 warnings in 173.86s
✅ Unit tests complete
```

Residual risk: integration tests are CI-only for this repository, so this PR validates the controller authorization invariant in unit coverage and the full local backend unit suite.

_Pentested and fixed by [Niro](https://github.com/apxlabs-ai/niro)_
