### PR TITLE
[Security] Enforce tenant ownership on trial app reads

### DIFF
--- a/api/controllers/console/explore/trial.py
+++ b/api/controllers/console/explore/trial.py
@@ -36,7 +36,7 @@ from controllers.console.app.error import (
     ProviderQuotaExceededError,
     UnsupportedAudioTypeError,
 )
-from controllers.console.app.wraps import get_app_model_with_trial
+from controllers.console.app.wraps import get_app_model
 from controllers.console.explore.error import (
     AppSuggestedQuestionsAfterAnswerDisabledError,
     NotChatAppError,
@@ -44,7 +44,7 @@ from controllers.console.explore.error import (
     NotWorkflowAppError,
 )
 from controllers.console.explore.wraps import TrialAppResource, trial_feature_enable
-from controllers.console.wraps import with_current_user
+from controllers.console.wraps import account_initialization_required, with_current_user
 from controllers.web.error import InvokeRateLimitError as InvokeRateLimitHttpError
 from core.app.app_config.common.parameters_mapping import get_parameters_from_feature_dict
 from core.app.apps.base_app_queue_manager import AppQueueManager
@@ -76,6 +76,7 @@ from graphon.graph_engine.manager import GraphEngineManager
 from graphon.model_runtime.errors.invoke import InvokeError
 from libs import helper
 from libs.helper import uuid_value
+from libs.login import login_required
 from models import Account
 from models.account import TenantStatus
 from models.model import AppMode, Site
@@ -507,7 +508,9 @@ class TrialSitApi(Resource):
     """Resource for trial app sites."""
 
     @console_ns.response(200, "Success", console_ns.models[SiteResponse.__name__])
-    @get_app_model_with_trial(None)
+    @login_required
+    @account_initialization_required
+    @get_app_model
     def get(self, app_model):
         """Retrieve app site info.
 
@@ -529,7 +532,9 @@ class TrialAppParameterApi(Resource):
     """Resource for app variables."""
 
     @console_ns.response(200, "Success", console_ns.models[ParametersResponse.__name__])
-    @get_app_model_with_trial(None)
+    @login_required
+    @account_initialization_required
+    @get_app_model
     def get(self, app_model):
         """Retrieve app parameters."""
 
@@ -558,7 +563,9 @@ class TrialAppParameterApi(Resource):
 
 class AppApi(Resource):
     @console_ns.response(200, "Success", app_detail_with_site_model)
-    @get_app_model_with_trial(None)
+    @login_required
+    @account_initialization_required
+    @get_app_model
     @marshal_with(app_detail_with_site_model)
     def get(self, app_model):
         """Get app detail"""
@@ -571,7 +578,9 @@ class AppApi(Resource):
 
 class AppWorkflowApi(Resource):
     @console_ns.response(200, "Success", workflow_model)
-    @get_app_model_with_trial(None)
+    @login_required
+    @account_initialization_required
+    @get_app_model
     @marshal_with(workflow_model)
     def get(self, app_model):
         """Get workflow detail"""
@@ -585,7 +594,9 @@ class AppWorkflowApi(Resource):
 class DatasetListApi(Resource):
     @console_ns.doc(params=query_params_from_model(TrialDatasetListQuery))
     @console_ns.response(200, "Success", dataset_list_model)
-    @get_app_model_with_trial(None)
+    @login_required
+    @account_initialization_required
+    @get_app_model
     def get(self, app_model):
         page = request.args.get("page", default=1, type=int)
         limit = request.args.get("limit", default=20, type=int)

--- a/api/tests/unit_tests/controllers/console/explore/test_trial.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_trial.py
@@ -1,15 +1,18 @@
 from inspect import unwrap as inspect_unwrap
 from io import BytesIO
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
-from flask import Flask
+from flask import Flask, Response, g
 from werkzeug.exceptions import Forbidden, InternalServerError, NotFound
 
 import controllers.console.explore.trial as module
+from configs import dify_config
 from controllers.console.app.error import (
+    AppNotFoundError,
     AppUnavailableError,
     CompletionRequestError,
     ConversationCompletedError,
@@ -30,12 +33,14 @@ from core.errors.error import (
 )
 from graphon.model_runtime.errors.invoke import InvokeError
 from models import Account
-from models.account import TenantStatus
+from models.account import AccountStatus, TenantStatus
 from models.model import AppMode
 from services.errors.conversation import ConversationNotExistsError
 from services.errors.llm import InvokeRateLimitError
 
 unwrap: Any = inspect_unwrap
+TENANT_A_APP_ID = "79b2c301-d895-44c3-b231-afed8857afcb"
+TENANT_B_ID = "98aff511-4a83-4be4-a186-a456bc0c1150"
 
 
 @pytest.fixture
@@ -95,6 +100,109 @@ def valid_parameters() -> dict[str, object]:
 def test_trial_workflow_uses_trial_scoped_simple_account_model() -> None:
     assert module.simple_account_model.name == "TrialSimpleAccount"
     assert hasattr(module.simple_account_model, "items")
+
+
+def _private_trial_app_from_tenant_a() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=TENANT_A_APP_ID,
+        tenant_id="tenant-a",
+        status="normal",
+        tenant=SimpleNamespace(status=TenantStatus.NORMAL),
+        mode=AppMode.CHAT,
+        workflow_id="workflow-a",
+        workflow=None,
+        app_model_config=SimpleNamespace(to_dict=lambda: {"user_input_form": []}),
+    )
+
+
+def _cross_tenant_scalar(stmt: object) -> object | None:
+    where_criteria = getattr(stmt, "_where_criteria", ())
+    if any("tenant_id" in str(criterion) for criterion in where_criteria):
+        return None
+
+    sql = str(stmt)
+    if "sites" in sql:
+        return SimpleNamespace(
+            title="Private site",
+            code="site-secret",
+            chat_color_theme=None,
+            chat_color_theme_inverted=False,
+            default_language="en-US",
+            show_workflow_steps=False,
+            use_icon_as_answer_icon=False,
+        )
+    return _private_trial_app_from_tenant_a()
+
+
+def test_trial_app_detail_read_requires_authenticated_console_user(app: Flask) -> None:
+    api = module.AppApi()
+
+    class LoginManager:
+        def load_user_from_request_context(self) -> None:
+            g._login_user = None
+
+        def unauthorized(self) -> Response:
+            return Response(status=401)
+
+    original_login_disabled = dify_config.LOGIN_DISABLED
+    dify_config.LOGIN_DISABLED = False
+    app.login_manager = LoginManager()
+    try:
+        with (
+            app.test_request_context(f"/trial-apps/{TENANT_A_APP_ID}", method="GET"),
+            patch.object(module.db.session, "scalar", side_effect=AssertionError("private app was loaded")),
+        ):
+            result = api.get(app_id=TENANT_A_APP_ID)
+    finally:
+        dify_config.LOGIN_DISABLED = original_login_disabled
+
+    assert isinstance(result, Response)
+    assert result.status_code == 401
+
+
+@pytest.mark.parametrize(
+    ("resource_cls", "path"),
+    [
+        (module.TrialSitApi, f"/trial-apps/{TENANT_A_APP_ID}/site"),
+        (module.TrialAppParameterApi, f"/trial-apps/{TENANT_A_APP_ID}/parameters"),
+        (module.AppApi, f"/trial-apps/{TENANT_A_APP_ID}"),
+        (module.AppWorkflowApi, f"/trial-apps/{TENANT_A_APP_ID}/workflows"),
+        (module.DatasetListApi, f"/trial-apps/{TENANT_A_APP_ID}/datasets?ids=dataset-a"),
+    ],
+)
+def test_trial_app_read_handlers_reject_cross_tenant_app_ids(
+    app: Flask,
+    account: Account,
+    resource_cls: type,
+    path: str,
+    valid_parameters: dict[str, object],
+) -> None:
+    account._current_tenant = SimpleNamespace(id=TENANT_B_ID)
+    account.status = AccountStatus.ACTIVE
+    api = resource_cls()
+
+    original_login_disabled = dify_config.LOGIN_DISABLED
+    dify_config.LOGIN_DISABLED = True
+    try:
+        with (
+            app.test_request_context(path, method="GET"),
+            patch("controllers.console.wraps.current_account_with_tenant", return_value=(account, TENANT_B_ID)),
+            patch("controllers.console.app.wraps.current_account_with_tenant", return_value=(account, TENANT_B_ID)),
+            patch.object(module.db.session, "scalar", side_effect=_cross_tenant_scalar),
+            patch.object(module.db.session, "get", return_value=SimpleNamespace(id="workflow-a")),
+            patch.object(module.AppService, "get_app", side_effect=lambda app_model: app_model),
+            patch.object(module.DatasetService, "get_datasets_by_ids", return_value=([], 0)),
+            patch.object(module, "get_parameters_from_feature_dict", return_value=valid_parameters),
+            patch.object(
+                module.ParametersResponse,
+                "model_validate",
+                return_value=SimpleNamespace(model_dump=lambda mode=None: {"ok": True}),
+            ),
+        ):
+            with pytest.raises(AppNotFoundError):
+                api.get(app_id=TENANT_A_APP_ID)
+    finally:
+        dify_config.LOGIN_DISABLED = original_login_disabled
 
 
 class TestTrialAppWorkflowRunApi:


### PR DESCRIPTION
Summary
Protect console trial-app read endpoints by requiring an authenticated, initialized console account and loading the app through the tenant-scoped app resolver. This keeps private app parameters, site metadata, app details, workflow details, and dataset lists inside the owning workspace.

Risk
Previously, callers who knew an app ID could reach trial-app read handlers without the normal console tenant boundary, exposing private app configuration and site secrets across workspaces or without authentication.

What changed
- Replaced the unscoped trial app loader on trial-app read handlers with the tenant-scoped `get_app_model` decorator.
- Added console authentication and account-initialization checks to trial-app site, parameter, detail, workflow, and dataset read endpoints.
- Added regression tests for unauthenticated app-detail loading and cross-tenant reads across all affected trial-app read handlers.

Validation
- Red: before the fix, the targeted regression run failed with `AssertionError: private app was loaded` for unauthenticated app detail access and `Failed: DID NOT RAISE AppNotFoundError` for the cross-tenant read handlers.
- Green: `uv run --project api --dev pytest --timeout=20 -q api/tests/unit_tests/controllers/console/explore/test_trial.py -k 'trial_app_detail_read_requires_authenticated_console_user or trial_app_read_handlers_reject_cross_tenant_app_ids'` -> `6 passed, 64 deselected`.
- Green: `uv run --project api --dev pytest --timeout=20 api/tests/unit_tests/controllers/console/explore/test_trial.py` -> `70 passed`.
- Green: `uv run --project api --dev ruff check api/controllers/console/explore/trial.py api/tests/unit_tests/controllers/console/explore/test_trial.py` -> `All checks passed!`.
- Green: `uv run --project api --dev ruff format --check api/controllers/console/explore/trial.py api/tests/unit_tests/controllers/console/explore/test_trial.py` -> `2 files already formatted`.
- Green: `make type-check PATH_TO_CHECK=api/controllers/console/explore/trial.py` -> `Success: no issues found in 1579 source files`.
- Green: `make test` -> main unit phase `12777 passed, 5 skipped`; controller phase `3020 passed, 1 skipped`.
- Niro PR pentest completed with no generated findings; residual coverage gap: the live target did not appear to serve this PR's behavior and still allowed the original reads, so live-target closure could not be asserted from that environment.

_Pentested and fixed by [Niro](https://github.com/apxlabs-ai/niro)_