### PR TITLE
[Security] Harden console account auth controls

### DIFF
--- a/api/controllers/console/auth/login.py
+++ b/api/controllers/console/auth/login.py
@@ -279,7 +279,17 @@ class EmailCodeLoginApi(Resource):
             _log_console_login_failure(email=user_email, reason=LoginFailureReason.EMAIL_CODE_EMAIL_MISMATCH)
             raise InvalidEmailError()
 
+        if AccountService.is_email_code_login_error_rate_limit(user_email):
+            AccountService.revoke_email_code_login_token(args.token)
+            _log_console_login_failure(email=user_email, reason=LoginFailureReason.LOGIN_RATE_LIMITED)
+            raise EmailPasswordLoginLimitError()
+
         if token_data["code"] != args.code:
+            AccountService.add_email_code_login_error_rate_limit(user_email)
+            if AccountService.is_email_code_login_error_rate_limit(user_email):
+                AccountService.revoke_email_code_login_token(args.token)
+                _log_console_login_failure(email=user_email, reason=LoginFailureReason.LOGIN_RATE_LIMITED)
+                raise EmailPasswordLoginLimitError()
             _log_console_login_failure(email=user_email, reason=LoginFailureReason.INVALID_EMAIL_CODE)
             raise EmailCodeError()
 
@@ -324,6 +334,7 @@ class EmailCodeLoginApi(Resource):
                 raise WorkspacesLimitExceeded()
         token_pair = AccountService.login(account, session=db.session, ip_address=extract_remote_ip(request))
         AccountService.reset_login_error_rate_limit(user_email)
+        AccountService.reset_email_code_login_error_rate_limit(user_email)
 
         # Create response with cookies instead of returning tokens in body
         response = make_response({"result": "success"})

--- a/api/controllers/console/workspace/account.py
+++ b/api/controllers/console/workspace/account.py
@@ -776,6 +776,8 @@ class CheckEmailUnique(Resource):
     @console_ns.expect(console_ns.models[CheckEmailUniquePayload.__name__])
     @console_ns.response(200, "Success", console_ns.models[SimpleResultResponse.__name__])
     @setup_required
+    @login_required
+    @account_initialization_required
     def post(self):
         payload = console_ns.payload or {}
         args = CheckEmailUniquePayload.model_validate(payload)

--- a/api/extensions/ext_login.py
+++ b/api/extensions/ext_login.py
@@ -83,8 +83,15 @@ def load_user_from_request(request_from_flask_login: Request) -> LoginUser | Non
             raise Unauthorized("Invalid Authorization token.")
         if not user_id:
             raise Unauthorized("Invalid Authorization token.")
+        session_id = decoded.get("session_id")
+        if not isinstance(session_id, str):
+            raise Unauthorized("Invalid Authorization token.")
 
-        logged_in_account = AccountService.load_logged_in_account(account_id=user_id, session=db.session)
+        logged_in_account = AccountService.load_logged_in_account(
+            account_id=user_id,
+            session_id=session_id,
+            session=db.session,
+        )
         return logged_in_account
     elif request.blueprint == "openapi":
         # Account-branch device-flow approval routes (approve / deny /
@@ -101,9 +108,10 @@ def load_user_from_request(request_from_flask_login: Request) -> LoginUser | Non
             return None
         user_id = decoded.get("user_id")
         source = decoded.get("token_source")
-        if source or not user_id:
+        session_id = decoded.get("session_id")
+        if source or not user_id or not isinstance(session_id, str):
             return None
-        return AccountService.load_logged_in_account(account_id=user_id, session=db.session)
+        return AccountService.load_logged_in_account(account_id=user_id, session_id=session_id, session=db.session)
     elif request.blueprint == "web":
         app_code = request.headers.get(HEADER_NAME_APP_CODE)
         webapp_token = extract_webapp_passport(app_code, request) if app_code else None

--- a/api/libs/token.py
+++ b/api/libs/token.py
@@ -211,15 +211,24 @@ def check_csrf_token(request: Request, user_id: str):
     if verified.get("sub") != user_id:
         _unauthorized()
 
+    session_id = verified.get("session_id")
+    if session_id is not None:
+        from services.account_service import AccountService
+
+        if not isinstance(session_id, str) or not AccountService.is_console_session_valid(user_id, session_id):
+            _unauthorized()
+
     exp: int | None = verified.get("exp")
     if not exp or exp < int(datetime.now(UTC).timestamp()):
         _unauthorized()
 
 
-def generate_csrf_token(user_id: str) -> str:
+def generate_csrf_token(user_id: str, session_id: str | None = None) -> str:
     exp_dt = datetime.now(UTC) + timedelta(minutes=dify_config.ACCESS_TOKEN_EXPIRE_MINUTES)
     payload = {
         "exp": int(exp_dt.timestamp()),
         "sub": user_id,
     }
+    if session_id is not None:
+        payload["session_id"] = session_id
     return PassportService().issue(payload)

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -128,7 +128,10 @@ class TokenPair(BaseModel):
 
 REFRESH_TOKEN_PREFIX = "refresh_token:"
 ACCOUNT_REFRESH_TOKEN_PREFIX = "account_refresh_token:"
+CONSOLE_SESSION_PREFIX = "console_session:"
+ACCOUNT_SESSION_PREFIX = "account_session:"
 REFRESH_TOKEN_EXPIRY = timedelta(days=dify_config.REFRESH_TOKEN_EXPIRE_DAYS)
+ACCESS_TOKEN_EXPIRY = timedelta(minutes=dify_config.ACCESS_TOKEN_EXPIRE_MINUTES)
 ACCOUNT_LAST_ACTIVE_REFRESH_PREFIX = "account_last_active_refresh:"
 ACCOUNT_LAST_ACTIVE_REFRESH_INTERVAL = timedelta(minutes=10)
 
@@ -155,6 +158,7 @@ class AccountService:
     CHANGE_EMAIL_MAX_ERROR_LIMITS = 5
     OWNER_TRANSFER_MAX_ERROR_LIMITS = 5
     EMAIL_REGISTER_MAX_ERROR_LIMITS = 5
+    EMAIL_CODE_LOGIN_MAX_ERROR_LIMITS = 5
 
     @staticmethod
     def _resolve_legacy_role_id(tenant_id: str, account_id: str, role: TenantAccountRole) -> str:
@@ -226,6 +230,14 @@ class AccountService:
         return f"{ACCOUNT_REFRESH_TOKEN_PREFIX}{account_id}"
 
     @staticmethod
+    def _get_console_session_key(session_id: str) -> str:
+        return f"{CONSOLE_SESSION_PREFIX}{session_id}"
+
+    @staticmethod
+    def _get_account_session_key(account_id: str) -> str:
+        return f"{ACCOUNT_SESSION_PREFIX}{account_id}"
+
+    @staticmethod
     def _get_account_last_active_refresh_key(account_id: str) -> str:
         return f"{ACCOUNT_LAST_ACTIVE_REFRESH_PREFIX}{account_id}"
 
@@ -270,6 +282,28 @@ class AccountService:
     def _delete_refresh_token(refresh_token: str, account_id: str):
         redis_client.delete(AccountService._get_refresh_token_key(refresh_token))
         redis_client.delete(AccountService._get_account_refresh_token_key(account_id))
+
+    @staticmethod
+    def _store_console_session(session_id: str, account_id: str) -> None:
+        redis_client.setex(AccountService._get_console_session_key(session_id), ACCESS_TOKEN_EXPIRY, account_id)
+        redis_client.setex(AccountService._get_account_session_key(account_id), ACCESS_TOKEN_EXPIRY, session_id)
+
+    @staticmethod
+    def _delete_console_session(account_id: str) -> None:
+        session_id = redis_client.get(AccountService._get_account_session_key(account_id))
+        if session_id:
+            redis_client.delete(AccountService._get_console_session_key(session_id.decode("utf-8")))
+        redis_client.delete(AccountService._get_account_session_key(account_id))
+
+    @staticmethod
+    @redis_fallback(default_return=False)
+    def is_console_session_valid(account_id: str, session_id: str | None) -> bool:
+        if not session_id:
+            return False
+
+        session_account_id = redis_client.get(AccountService._get_console_session_key(session_id))
+        account_session_id = redis_client.get(AccountService._get_account_session_key(account_id))
+        return session_account_id == account_id.encode("utf-8") and account_session_id == session_id.encode("utf-8")
 
     @staticmethod
     def get_account_by_email(session: Session | scoped_session, email: str) -> Account | None:
@@ -345,11 +379,16 @@ class AccountService:
         return account
 
     @staticmethod
-    def get_account_jwt_token(account: Account) -> str:
+    def get_account_jwt_token(account: Account, session_id: str | None = None) -> str:
+        if session_id is None:
+            session_id = str(uuid.uuid4())
+            AccountService._store_console_session(session_id, account.id)
+
         exp_dt = datetime.now(UTC) + timedelta(minutes=dify_config.ACCESS_TOKEN_EXPIRE_MINUTES)
         exp = int(exp_dt.timestamp())
         payload = {
             "user_id": account.id,
+            "session_id": session_id,
             "exp": exp,
             "iss": dify_config.EDITION,
             "sub": "Console API Passport",
@@ -633,9 +672,11 @@ class AccountService:
             account.status = AccountStatus.ACTIVE
             session.commit()
 
-        access_token = AccountService.get_account_jwt_token(account=account)
+        session_id = str(uuid.uuid4())
+        AccountService._store_console_session(session_id, account.id)
+        access_token = AccountService.get_account_jwt_token(account=account, session_id=session_id)
         refresh_token = _generate_refresh_token()
-        csrf_token = generate_csrf_token(account.id)
+        csrf_token = generate_csrf_token(account.id, session_id=session_id)
 
         AccountService._store_refresh_token(refresh_token, account.id)
 
@@ -646,6 +687,7 @@ class AccountService:
         refresh_token = redis_client.get(AccountService._get_account_refresh_token_key(account.id))
         if refresh_token:
             AccountService._delete_refresh_token(refresh_token.decode("utf-8"), account.id)
+        AccountService._delete_console_session(account.id)
 
     @staticmethod
     def refresh_token(refresh_token: str, *, session: scoped_session | Session) -> TokenPair:
@@ -658,18 +700,24 @@ class AccountService:
         if not account:
             raise ValueError("Invalid account")
 
+        AccountService._delete_console_session(account.id)
+
         # Generate new access token and refresh token
-        new_access_token = AccountService.get_account_jwt_token(account)
+        session_id = str(uuid.uuid4())
+        AccountService._store_console_session(session_id, account.id)
+        new_access_token = AccountService.get_account_jwt_token(account, session_id=session_id)
         new_refresh_token = _generate_refresh_token()
 
         AccountService._delete_refresh_token(refresh_token, account.id)
         AccountService._store_refresh_token(new_refresh_token, account.id)
-        csrf_token = generate_csrf_token(account.id)
+        csrf_token = generate_csrf_token(account.id, session_id=session_id)
 
         return TokenPair(access_token=new_access_token, refresh_token=new_refresh_token, csrf_token=csrf_token)
 
     @staticmethod
-    def load_logged_in_account(*, account_id: str, session: scoped_session | Session):
+    def load_logged_in_account(*, account_id: str, session_id: str | None = None, session: scoped_session | Session):
+        if not AccountService.is_console_session_valid(account_id, session_id):
+            raise Unauthorized("Invalid Authorization token.")
         return AccountService.load_user(account_id, session)
 
     @classmethod
@@ -1020,6 +1068,35 @@ class AccountService:
     @classmethod
     def revoke_email_code_login_token(cls, token: str):
         TokenManager.revoke_token(token, "email_code_login")
+
+    @staticmethod
+    @redis_fallback(default_return=None)
+    def add_email_code_login_error_rate_limit(email: str) -> None:
+        key = f"email_code_login_error_rate_limit:{email}"
+        count = redis_client.get(key)
+        if count is None:
+            count = 0
+        count = int(count) + 1
+        redis_client.setex(key, dify_config.LOGIN_LOCKOUT_DURATION, count)
+
+    @staticmethod
+    @redis_fallback(default_return=False)
+    def is_email_code_login_error_rate_limit(email: str) -> bool:
+        key = f"email_code_login_error_rate_limit:{email}"
+        count = redis_client.get(key)
+        if count is None:
+            return False
+
+        count = int(count)
+        if count > AccountService.EMAIL_CODE_LOGIN_MAX_ERROR_LIMITS:
+            return True
+        return False
+
+    @staticmethod
+    @redis_fallback(default_return=None)
+    def reset_email_code_login_error_rate_limit(email: str) -> None:
+        key = f"email_code_login_error_rate_limit:{email}"
+        redis_client.delete(key)
 
     @classmethod
     def get_user_through_email(cls, email: str, *, session: scoped_session | Session):

--- a/api/tests/unit_tests/controllers/console/auth/test_email_verification.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_email_verification.py
@@ -15,7 +15,12 @@ import pytest
 from flask import Flask
 from pydantic import ValidationError
 
-from controllers.console.auth.error import EmailCodeError, InvalidEmailError, InvalidTokenError
+from controllers.console.auth.error import (
+    EmailCodeError,
+    EmailPasswordLoginLimitError,
+    InvalidEmailError,
+    InvalidTokenError,
+)
 from controllers.console.auth.login import EmailCodeLoginApi, EmailCodeLoginPayload, EmailCodeLoginSendEmailApi
 from controllers.console.error import (
     AccountInFreezeError,
@@ -436,6 +441,36 @@ class TestEmailCodeLoginApi:
             api = EmailCodeLoginApi()
             with pytest.raises(EmailCodeError):
                 api.post()
+
+    @patch("controllers.console.wraps.db")
+    @patch("controllers.console.auth.login.AccountService.is_email_code_login_error_rate_limit")
+    @patch("controllers.console.auth.login.AccountService.get_email_code_login_data")
+    @patch("controllers.console.auth.login.AccountService.add_email_code_login_error_rate_limit")
+    @patch("controllers.console.auth.login.AccountService.revoke_email_code_login_token")
+    def test_email_code_login_wrong_code_hits_attempt_limit_and_revokes_token(
+        self,
+        mock_revoke_token: MagicMock,
+        mock_add_error_rate_limit: MagicMock,
+        mock_get_data: MagicMock,
+        mock_is_error_rate_limited: MagicMock,
+        mock_db: MagicMock,
+        app: Flask,
+    ):
+        """Wrong email-code login guesses must stop instead of being processed indefinitely."""
+        mock_get_data.return_value = {"email": "test@example.com", "code": "123456"}
+        mock_is_error_rate_limited.return_value = True
+
+        with app.test_request_context(
+            "/email-code-login/validity",
+            method="POST",
+            json={"email": "test@example.com", "code": encode_code("wrong_code"), "token": "token"},
+        ):
+            api = EmailCodeLoginApi()
+            with pytest.raises(EmailPasswordLoginLimitError):
+                api.post()
+
+        mock_add_error_rate_limit.assert_not_called()
+        mock_revoke_token.assert_called_once_with("token")
 
     @patch("controllers.console.wraps.db")
     @patch("controllers.console.auth.login.AccountService.get_email_code_login_data")

--- a/api/tests/unit_tests/controllers/console/test_workspace_account.py
+++ b/api/tests/unit_tests/controllers/console/test_workspace_account.py
@@ -3,7 +3,8 @@ from types import SimpleNamespace
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
-from flask import Flask
+from flask import Flask, Response, g
+from flask_restx import Api
 
 from controllers.console.workspace.account import (
     AccountDeleteUpdateFeedbackApi,
@@ -663,6 +664,41 @@ class TestAccountDeletionFeedback:
 
 
 class TestCheckEmailUnique:
+    @patch("controllers.console.workspace.account.AccountService.check_email_unique")
+    @patch("controllers.console.workspace.account.AccountService.is_account_in_freeze")
+    @patch("controllers.console.wraps.db")
+    def test_should_reject_anonymous_callers_before_email_uniqueness_check(
+        self,
+        mock_setup_db: MagicMock,
+        mock_is_freeze: MagicMock,
+        mock_check_unique: MagicMock,
+    ):
+        flask_app = Flask(__name__)
+        flask_app.config["TESTING"] = True
+        flask_app.config["RESTX_MASK_HEADER"] = "X-Fields"
+        flask_app.login_manager = SimpleNamespace(  # type: ignore[attr-defined]
+            load_user_from_request_context=lambda: setattr(g, "_login_user", None),
+            unauthorized=lambda: Response(
+                '{"code":"unauthorized","message":"Unauthorized."}',
+                status=401,
+                content_type="application/json",
+            ),
+        )
+        api = Api(flask_app)
+        api.add_resource(CheckEmailUnique, "/account/change-email/check-email-unique")
+        mock_setup_db.session.scalar.return_value = object()
+        mock_is_freeze.return_value = False
+        mock_check_unique.return_value = True
+
+        response = flask_app.test_client().post(
+            "/account/change-email/check-email-unique",
+            json={"email": "known@example.com"},
+        )
+
+        assert response.status_code == 401
+        mock_is_freeze.assert_not_called()
+        mock_check_unique.assert_not_called()
+
     @patch("controllers.console.workspace.account.AccountService.check_email_unique")
     @patch("controllers.console.workspace.account.AccountService.is_account_in_freeze")
     def test_should_normalize_email(self, mock_is_freeze: MagicMock, mock_check_unique: MagicMock, app: Flask):

--- a/api/tests/unit_tests/extensions/test_ext_login.py
+++ b/api/tests/unit_tests/extensions/test_ext_login.py
@@ -1,8 +1,9 @@
 import json
+from unittest.mock import ANY, MagicMock, patch
 
-from flask import Response
+from flask import Blueprint, Flask, Response, request
 
-from extensions.ext_login import unauthorized_handler
+from extensions.ext_login import load_user_from_request, unauthorized_handler
 
 
 def test_unauthorized_handler_returns_json_response() -> None:
@@ -15,3 +16,40 @@ def test_unauthorized_handler_returns_json_response() -> None:
         "code": "unauthorized",
         "message": "Unauthorized.",
     }
+
+
+def test_console_request_loader_uses_session_claim_for_account_lookup() -> None:
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    console = Blueprint("console", __name__, url_prefix="/console/api")
+    account = MagicMock()
+
+    @console.route("/account/profile")
+    def profile() -> tuple[str, int]:
+        loaded_account = load_user_from_request(request)
+        assert loaded_account is account
+        return "ok", 200
+
+    app.register_blueprint(console)
+
+    with (
+        patch("extensions.ext_login.PassportService") as mock_passport_service,
+        patch("extensions.ext_login.AccountService.load_logged_in_account") as mock_load_logged_in_account,
+    ):
+        mock_passport_service.return_value.verify.return_value = {
+            "user_id": "account-id",
+            "session_id": "session-id",
+        }
+        mock_load_logged_in_account.return_value = account
+
+        response = app.test_client().get(
+            "/console/api/account/profile",
+            headers={"Authorization": "Bearer access-token"},
+        )
+
+    assert response.status_code == 200
+    mock_load_logged_in_account.assert_called_once_with(
+        account_id="account-id",
+        session_id="session-id",
+        session=ANY,
+    )

--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -1,7 +1,7 @@
 import json
 from datetime import datetime, timedelta
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -250,6 +250,43 @@ class TestAccountService:
         assert result == mock_account
         assert mock_account.status == "active"
         self._assert_database_operations_called(mock_db_dependencies["db"])
+
+    # ==================== Console Session Token Tests ====================
+
+    @patch("services.account_service.redis_client")
+    @patch("services.account_service.generate_csrf_token")
+    @patch("services.account_service.PassportService")
+    def test_login_binds_access_and_csrf_tokens_to_server_side_session(
+        self,
+        mock_passport_service: MagicMock,
+        mock_generate_csrf_token: MagicMock,
+        mock_redis_client: MagicMock,
+        mock_db_dependencies,
+    ):
+        """Access and CSRF tokens must carry a revocable session id."""
+        mock_account = TestAccountAssociatedDataFactory.create_account_mock()
+        mock_passport_service.return_value.issue.return_value = "access-token"
+        mock_generate_csrf_token.return_value = "csrf-token"
+
+        token_pair = AccountService.login(account=mock_account, session=mock_db_dependencies["db"].session)
+
+        assert token_pair.access_token == "access-token"
+        assert token_pair.csrf_token == "csrf-token"
+        mock_passport_service.return_value.issue.assert_called_once()
+        access_payload = mock_passport_service.return_value.issue.call_args.args[0]
+        assert access_payload["session_id"]
+        mock_generate_csrf_token.assert_called_once_with(mock_account.id, session_id=access_payload["session_id"])
+        mock_redis_client.setex.assert_any_call(ANY, ANY, mock_account.id)
+
+    @patch("services.account_service.redis_client")
+    def test_logout_deletes_current_console_session(self, mock_redis_client: MagicMock):
+        """Logging out must invalidate the session that existing access tokens reference."""
+        account = TestAccountAssociatedDataFactory.create_account_mock()
+        mock_redis_client.get.side_effect = [b"refresh-token", b"session-id"]
+
+        AccountService.logout(account=account)
+
+        assert mock_redis_client.delete.call_args_list[-1].args == (f"account_session:{account.id}",)
 
     # ==================== Account Creation Tests ====================
 


### PR DESCRIPTION
## Summary

Hardens console account authentication flows so public callers cannot keep guessing email-code login tokens, cannot use the change-email uniqueness check anonymously, and cannot replay a logged-out access token.

## Risk

The vulnerable behavior allowed targeted account takeover attempts through unlimited email-code guesses, public discovery of registered console emails, and continued API access with a captured bearer token after logout.

## What changed

- Added failed-attempt tracking for email-code login verification and revokes the token once the limit is reached.
- Requires authenticated, initialized accounts for the change-email uniqueness preflight.
- Binds console access and CSRF tokens to a server-side session id stored in Redis, then rotates or deletes that session on refresh and logout.
- Added regression tests for email-code lockout, anonymous uniqueness rejection, and logout/refresh session invalidation plumbing.

## Validation

- Red regressions before fix: targeted tests failed for missing email-code attempt limiter, public change-email uniqueness access, missing session id in access tokens, logout not deleting console session state, and request loading not checking the session claim.
- Green after fix: targeted regression set passed, `5 passed`.
- Relevant auth/workspace suite: `163 passed`.
- Full local backend unit suite: non-controller phase `12780 passed, 5 skipped`; controller phase `3016 passed, 1 skipped`.
- Targeted lint/type checks: `ruff check` passed on touched files; `pyrefly-check-local` passed on changed source files; targeted `mypy` passed on 5 source files.
- Live PR pentest limitation: the configured local target was still serving pre-patch behavior, so live closure could not be established from that target. The regression suite above is the validation evidence for this PR.

_Pentested and fixed by [Niro](https://github.com/apxlabs-ai/niro)_