### PR TITLE
fix: invite existing active user to workspace as member

### DIFF
--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -2042,19 +2042,12 @@ class RegisterService:
             )
             requires_setup = account.status == AccountStatus.PENDING
 
-            if not ta and (account.status == AccountStatus.PENDING or dify_config.RBAC_ENABLED):
+            if not ta:
                 TenantService.create_tenant_member(tenant, account, session, tenant_join_role)
 
             # Support resend invitation email when the account is pending status
             if account.status != AccountStatus.PENDING:
-                if dify_config.RBAC_ENABLED and not ta:
-                    RBACService.MemberRoles.replace(
-                        tenant_id=str(tenant.id),
-                        account_id=inviter.id,
-                        member_account_id=account.id,
-                        role_ids=[role],
-                    )
-                if ta or dify_config.RBAC_ENABLED:
+                if ta:
                     raise AccountAlreadyInTenantError("Account already in tenant.")
 
         # Assign RBAC role if RBAC is enabled

--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -2026,10 +2026,10 @@ class TestRegisterService:
                 mock_task_dependencies.delay.assert_called_once()
                 mock_lookup.assert_called_once_with(mock_db_dependencies["db"].session, "existing@example.com")
 
-    def test_invite_existing_active_account_requires_acceptance_before_joining(
+    def test_invite_existing_active_account_is_added_as_member(
         self, mock_db_dependencies, mock_redis_dependencies, mock_task_dependencies
     ):
-        """Existing active accounts outside the tenant receive an invite without immediate membership."""
+        """Existing active accounts outside the tenant are added as a member when invited."""
         mock_tenant = MagicMock()
         mock_tenant.id = "tenant-456"
         mock_tenant.name = "Test Workspace"
@@ -2066,7 +2066,9 @@ class TestRegisterService:
                     "add",
                     session=mock_db_dependencies["db"].session,
                 )
-                mock_create_member.assert_not_called()
+                mock_create_member.assert_called_once_with(
+                    mock_tenant, mock_existing_account, mock_db_dependencies["db"].session, "admin"
+                )
                 mock_generate_token.assert_called_once_with(
                     mock_tenant, mock_existing_account, "admin", requires_setup=False
                 )
@@ -2221,10 +2223,10 @@ class TestRegisterService:
                     role_ids=["rbac-role-id-456"],
                 )
 
-    def test_invite_new_member_rbac_enabled_existing_active_account_adds_role_before_signin_response(
+    def test_invite_new_member_rbac_enabled_existing_active_account_creates_member(
         self, mock_db_dependencies, mock_redis_dependencies, mock_task_dependencies
     ):
-        """Existing active accounts still need an RBAC membership before the API returns the signin URL."""
+        """Existing active accounts outside the tenant are added as a member with RBAC role when invited."""
         mock_tenant = MagicMock()
         mock_tenant.id = "tenant-789"
         mock_inviter = TestAccountAssociatedDataFactory.create_account_mock(account_id="inviter-456", name="Inviter")
@@ -2245,16 +2247,20 @@ class TestRegisterService:
                 patch("services.account_service.TenantService.check_member_permission"),
                 patch("services.account_service.TenantService.create_tenant_member") as mock_create_member,
                 patch("services.account_service.RBACService") as mock_rbac_service,
+                patch("services.account_service.RegisterService.generate_invite_token") as mock_generate_token,
             ):
-                with pytest.raises(AccountAlreadyInTenantError):
-                    RegisterService.invite_new_member(
-                        tenant=mock_tenant,
-                        email="existing-rbac@example.com",
-                        language="en-US",
-                        role="rbac-role-id-456",
-                        inviter=mock_inviter,
-                        session=mock_db_dependencies["db"].session,
-                    )
+                mock_generate_token.return_value = "invite-token-rbac"
+
+                result = RegisterService.invite_new_member(
+                    tenant=mock_tenant,
+                    email="existing-rbac@example.com",
+                    language="en-US",
+                    role="rbac-role-id-456",
+                    inviter=mock_inviter,
+                    session=mock_db_dependencies["db"].session,
+                )
+
+                assert result == "invite-token-rbac"
 
                 mock_create_member.assert_called_once_with(
                     mock_tenant,
@@ -2268,7 +2274,7 @@ class TestRegisterService:
                     member_account_id=mock_existing_account.id,
                     role_ids=["rbac-role-id-456"],
                 )
-                mock_task_dependencies.delay.assert_not_called()
+                mock_task_dependencies.delay.assert_called_once()
 
     def test_invite_new_member_rbac_disabled_uses_legacy_role(
         self, mock_db_dependencies, mock_redis_dependencies, mock_task_dependencies


### PR DESCRIPTION
## Summary

When inviting an existing active account to a workspace, `RegisterService.invite_new_member` had a condition that required either `PENDING` account status or `RBAC_ENABLED`:

```python
if not ta and (account.status == AccountStatus.PENDING or dify_config.RBAC_ENABLED):
    TenantService.create_tenant_member(tenant, account, session, tenant_join_role)
```

When the invitee was an existing **active** user (e.g., owner of another workspace) and RBAC was disabled (the default), this condition evaluated to `False`. No `TenantAccountJoin` record was created, so the user never appeared in the member list — even though the API returned `result: "success"` and generated an invitation token.

## Fix

- Always call `create_tenant_member` when the user is not already in the workspace (`not ta`), regardless of account status or RBAC setting
- Remove the redundant inner `RBACService.MemberRoles.replace` call since the outer block already handles RBAC role assignment for all cases
- Error for already-in-tenant users now only raises when `ta` is truthy (user was already a member before this call)

## Tests

- Updated 2 tests to match the corrected behavior:
  - `test_invite_existing_active_account_is_added_as_member` — verifies `create_tenant_member` is called
  - `test_invite_new_member_rbac_enabled_existing_active_account_creates_member` — verifies RBAC role is assigned and invite succeeds
- All 99 tests in `test_account_service.py` pass

Fixes #38048