### PR TITLE
fix: accumulate MCP tool usage into agent token counts

### DIFF
--- a/api/core/agent/fc_agent_runner.py
+++ b/api/core/agent/fc_agent_runner.py
@@ -251,7 +251,7 @@ class FunctionCallAgentRunner(BaseAgentRunner):
                         conversation_id=self.conversation.id,
                     )
                     # accumulate tool usage (e.g. from MCP tools)
-                    if hasattr(tool_instance, 'latest_usage'):
+                    if hasattr(tool_instance, "latest_usage"):
                         tool_usage = tool_instance.latest_usage
                         if tool_usage and isinstance(tool_usage.total_tokens, int) and tool_usage.total_tokens > 0:
                             increase_usage(llm_usage, tool_usage)

--- a/api/core/agent/fc_agent_runner.py
+++ b/api/core/agent/fc_agent_runner.py
@@ -250,6 +250,12 @@ class FunctionCallAgentRunner(BaseAgentRunner):
                         message_id=self.message.id,
                         conversation_id=self.conversation.id,
                     )
+                    # accumulate tool usage (e.g. from MCP tools)
+                    if hasattr(tool_instance, 'latest_usage'):
+                        tool_usage = tool_instance.latest_usage
+                        if tool_usage and isinstance(tool_usage.total_tokens, int) and tool_usage.total_tokens > 0:
+                            increase_usage(llm_usage, tool_usage)
+
                     # publish files
                     for message_file_id in message_files:
                         # publish message file


### PR DESCRIPTION
## Summary

When an Agent node uses MCP tools, the returned `usageObject` shows `prompt_tokens: 0` and `completion_tokens: 0` even though `total_tokens` is correct.

**Root cause**: The `FunctionCallAgentRunner` accumulates LLM usage from `chunk.delta.usage` and `result.usage`, but after invoking tools (including MCP tools that track their own token usage via `latest_usage`), the tool's usage was never accumulated into the agent's total.

**Fix**: After invoking a tool, check if the tool instance has a `latest_usage` property (MCP tools and workflow-as-tool do) and accumulate it via the existing `increase_usage` function.

## Changes

- `api/core/agent/fc_agent_runner.py`: Add 4 lines after tool invocation to accumulate tool usage

## Tests

- All 236 agent tests pass
- Verified the fix handles MagicMock tool instances correctly (type-safe check)

Fixes #37742