### PR TITLE
fix(tools): stop closing scoped session in _create_message_files

### DIFF
--- a/api/core/tools/tool_engine.py
+++ b/api/core/tools/tool_engine.py
@@ -379,6 +379,4 @@ class ToolEngine:
 
             result.append(message_file.id)
 
-        db.session.close()
-
         return result

--- a/api/tests/unit_tests/core/tools/test_tool_engine.py
+++ b/api/tests/unit_tests/core/tools/test_tool_engine.py
@@ -142,7 +142,7 @@ def test_create_message_files_and_invoke_generator():
 
     assert ids == ["mf-1", "mf-2"]
     assert mock_db.session.add.call_count == 2
-    mock_db.session.close.assert_called_once()
+    mock_db.session.close.assert_not_called()
 
     tool = _build_tool()
     invoked = list(ToolEngine._invoke(tool, {"a": 1}, user_id="u"))


### PR DESCRIPTION
## Summary
- Remove premature `db.session.close()` from `ToolEngine._create_message_files`
- Keeps the request-scoped SQLAlchemy session alive for downstream agent operations in the same lifecycle

Fixes #37884

## Test plan
- [x] `uv run pytest tests/unit_tests/core/tools/test_tool_engine.py::test_create_message_files_and_invoke_generator -q -o addopts=`


Made with [Cursor](https://cursor.com)