### PR TITLE
fix: re-inviting a removed member fails with "workspace not found"

### DIFF
--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -2042,7 +2042,11 @@ class RegisterService:
             )
             requires_setup = account.status == AccountStatus.PENDING
 
-            if not ta and (account.status == AccountStatus.PENDING or dify_config.RBAC_ENABLED):
+            # Re-create the workspace membership whenever the invited account has no
+            # join row for this tenant. Previously this only ran for PENDING accounts
+            # (or when RBAC was enabled), so re-inviting a removed ACTIVE member never
+            # re-added them — the invite link then failed with "workspace not found".
+            if not ta:
                 TenantService.create_tenant_member(tenant, account, session, tenant_join_role)
 
             # Support resend invitation email when the account is pending status


### PR DESCRIPTION


## Summary

Fixes #38073

When an active member is removed from a workspace their `TenantAccountJoin`
row is deleted but the `Account` record is kept. When that same account is
re-invited, `RegisterService.invite_new_member` only called
`TenantService.create_tenant_member` if the account was `PENDING` **or** RBAC
was enabled. A removed **ACTIVE** member matched neither condition, so they were
never re-added to the tenant. The invite email was still sent, but on login
`get_join_tenants` returned 0 workspaces and the user hit:

> "workspace not found, please contact system admin to invite you to join in a workspace"

### Fix

In `api/services/account_service.py`, re-create the membership whenever the
invited account has **no join row** (`ta is None`) for the target tenant,
instead of gating on account status / RBAC:

```python
# before
if not ta and (account.status == AccountStatus.PENDING or dify_config.RBAC_ENABLED):
    TenantService.create_tenant_member(tenant, account, session, tenant_join_role)

# after
if not ta:
    TenantService.create_tenant_member(tenant, account, session, tenant_join_role)

create_tenant_member is idempotent, so members who are still in the tenant are
unaffected — for them ta is set, this block is skipped, and the existing
AccountAlreadyInTenantError guard still fires.

Screenshots

┌─────────────────────────────────────────────┬─────────────────────────────────────┐
│                   Before                    │                After                │
├─────────────────────────────────────────────┼─────────────────────────────────────┤
│ Re-invited removed member sees "workspace   │ Re-invited removed member regains   │
│ not found" on login                         │ workspace access                    │
└─────────────────────────────────────────────┴─────────────────────────────────────┘

Checklist

- [ ] This change requires a documentation update, included: Dify Document (https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran make lint && make type-check (backend) and cd web && pnpm exec vp staged (frontend) to appease the lint gods
