### PR TITLE
fix(api): strip reasoning blocks in suggested questions parser

### DIFF
--- a/api/core/llm_generator/output_parser/suggested_questions_after_answer.py
+++ b/api/core/llm_generator/output_parser/suggested_questions_after_answer.py
@@ -7,6 +7,27 @@ from core.llm_generator.prompts import DEFAULT_SUGGESTED_QUESTIONS_AFTER_ANSWER_
 
 logger = logging.getLogger(__name__)
 
+_THINK_TAG_RE = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
+
+
+def _strip_reasoning_blocks(text: str) -> str:
+    stripped = _THINK_TAG_RE.sub("", text)
+    open_tag = "<think>"
+    lower = stripped.lower()
+    while True:
+        open_idx = lower.find(open_tag)
+        if open_idx == -1:
+            break
+        tail = stripped[open_idx + len(open_tag) :]
+        array_start = tail.find("[")
+        if array_start != -1:
+            stripped = tail[array_start:]
+            lower = stripped.lower()
+            break
+        stripped = stripped[:open_idx]
+        lower = stripped.lower()
+    return stripped.strip()
+
 
 class SuggestedQuestionsAfterAnswerOutputParser:
     def __init__(self, instruction_prompt: str | None = None) -> None:
@@ -23,7 +44,7 @@ class SuggestedQuestionsAfterAnswerOutputParser:
         return self._instruction_prompt
 
     def parse(self, text: str) -> Sequence[str]:
-        stripped_text = text.strip()
+        stripped_text = _strip_reasoning_blocks(text)
         action_match = re.search(r"\[.*?\]", stripped_text, re.DOTALL)
         questions: list[str] = []
         if action_match is not None:

--- a/api/tests/unit_tests/core/llm_generator/output_parser/test_suggested_questions_after_answer.py
+++ b/api/tests/unit_tests/core/llm_generator/output_parser/test_suggested_questions_after_answer.py
@@ -1,0 +1,41 @@
+import pytest
+
+from core.llm_generator.output_parser.suggested_questions_after_answer import (
+    SuggestedQuestionsAfterAnswerOutputParser,
+)
+
+
+@pytest.fixture
+def parser() -> SuggestedQuestionsAfterAnswerOutputParser:
+    return SuggestedQuestionsAfterAnswerOutputParser()
+
+
+class TestSuggestedQuestionsAfterAnswerOutputParser:
+    def test_parse_plain_json_array(self, parser: SuggestedQuestionsAfterAnswerOutputParser):
+        questions = parser.parse('["Question 1?", "Question 2?"]')
+        assert questions == ["Question 1?", "Question 2?"]
+
+    def test_parse_strips_closed_reasoning_block(self, parser: SuggestedQuestionsAfterAnswerOutputParser):
+        text = (
+            "<think>\nThe user asked about Python.\n</think>\n"
+            '["What are Python decorators?", "How does async work in Python?"]'
+        )
+        questions = parser.parse(text)
+        assert questions == ["What are Python decorators?", "How does async work in Python?"]
+
+    def test_parse_strips_empty_reasoning_block(self, parser: SuggestedQuestionsAfterAnswerOutputParser):
+        text = '<think></think>\n["What is recursion?", "How do hash maps work?"]'
+        questions = parser.parse(text)
+        assert questions == ["What is recursion?", "How do hash maps work?"]
+
+    def test_parse_handles_unclosed_reasoning_block(self, parser: SuggestedQuestionsAfterAnswerOutputParser):
+        text = (
+            "<think>\nThe model was reasoning but output was truncated"
+            '["Can you explain closures?", "What are generators?"]'
+        )
+        questions = parser.parse(text)
+        assert questions == ["Can you explain closures?", "What are generators?"]
+
+    def test_parse_ignores_non_string_entries(self, parser: SuggestedQuestionsAfterAnswerOutputParser):
+        questions = parser.parse('["Valid?", 42, null, "Also valid?"]')
+        assert questions == ["Valid?", "Also valid?"]

--- a/api/tests/unit_tests/core/llm_generator/test_llm_generator.py
+++ b/api/tests/unit_tests/core/llm_generator/test_llm_generator.py
@@ -102,6 +102,17 @@ class TestLLMGenerator:
             "temperature": 0.0,
         }
 
+    def test_generate_suggested_questions_after_answer_strips_reasoning_blocks(self, mock_model_instance):
+        mock_response = MagicMock()
+        mock_response.message.get_text_content.return_value = (
+            "<think>\nReasoning about follow-ups.\n</think>\n"
+            '["Follow-up one?", "Follow-up two?"]'
+        )
+        mock_model_instance.invoke_llm.return_value = mock_response
+
+        questions = LLMGenerator.generate_suggested_questions_after_answer("tenant_id", "histories")
+        assert questions == ["Follow-up one?", "Follow-up two?"]
+
     def test_generate_suggested_questions_after_answer_auth_error(self, mock_model_instance):
         with patch("core.llm_generator.llm_generator.ModelManager.for_tenant") as mock_manager:
             mock_manager.return_value.get_default_model_instance.side_effect = InvokeAuthorizationError("Auth failed")

--- a/api/tests/unit_tests/core/llm_generator/test_llm_generator.py
+++ b/api/tests/unit_tests/core/llm_generator/test_llm_generator.py
@@ -105,8 +105,7 @@ class TestLLMGenerator:
     def test_generate_suggested_questions_after_answer_strips_reasoning_blocks(self, mock_model_instance):
         mock_response = MagicMock()
         mock_response.message.get_text_content.return_value = (
-            "<think>\nReasoning about follow-ups.\n</think>\n"
-            '["Follow-up one?", "Follow-up two?"]'
+            '<think>\nReasoning about follow-ups.\n</think>\n["Follow-up one?", "Follow-up two?"]'
         )
         mock_model_instance.invoke_llm.return_value = mock_response
 


### PR DESCRIPTION
Closing after maintainer review on #38092.

Verified on latest `main`: the 500 reported in the issue matches #36459 (merged May 2026), not the reasoning-tag parsing change in this PR. Reasoning-model output is already handled in open #34652.

No remaining repro for the issue as filed on current main.