### PR TITLE
fix(ui): correct RTL layout for like and dislike buttons

### DIFF
--- a/web/app/components/base/chat/chat/answer/operation.tsx
+++ b/web/app/components/base/chat/chat/answer/operation.tsx
@@ -193,7 +193,7 @@ function Operation({
     <>
       <div
         className={cn(
-          'absolute flex justify-end gap-1',
+          'absolute flex justify-end gap-1 rtl:flex-row-reverse rtl:justify-start',
           hasWorkflowProcess && 'right-2 -bottom-4',
           !positionRight && 'right-2 -bottom-4',
           !hasWorkflowProcess && positionRight && 'top-[9px]!',
@@ -203,7 +203,7 @@ function Operation({
       >
         {shouldShowUserFeedbackBar && !humanInputFormDataList?.length && (
           <div className={cn(
-            'ml-1 items-center gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs',
+            'ml-1 items-center gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs rtl:mr-1 rtl:ml-0',
             hasUserFeedback ? 'flex' : `hidden ${answerActiveFlexClassName}`,
           )}
           >
@@ -245,7 +245,7 @@ function Operation({
         )}
         {shouldShowAdminFeedbackBar && !humanInputFormDataList?.length && (
           <div className={cn(
-            'ml-1 items-center gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs',
+            'ml-1 items-center gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs rtl:mr-1 rtl:ml-0',
             (hasAdminFeedback || hasUserFeedback) ? 'flex' : `hidden ${answerActiveFlexClassName}`,
           )}
           >
@@ -318,7 +318,7 @@ function Operation({
           </div>
         )}
         {!isOpeningStatement && (
-          <div className={cn('ml-1 hidden items-center gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs', answerActiveFlexClassName)} data-testid="operation-actions">
+          <div className={cn('ml-1 hidden items-center gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs rtl:mr-1 rtl:ml-0', answerActiveFlexClassName)} data-testid="operation-actions">
             {(config?.text_to_speech?.enabled && !humanInputFormDataList?.length) && (
               <NewAudioButton
                 id={id}


### PR DESCRIPTION
Fixes #36582

## Summary

This PR addresses the UI layout bug where the Like/Dislike buttons were incorrectly ordered in RTL (Right-to-Left) languages like Persian. 

**Motivation and Context:**
As confirmed in discussion #36582, the button container previously used LTR-specific Tailwind classes (`ml-1`, `justify-end`). In RTL mode, this caused the visual order to flip while click handlers remained bound to the original positions. I have updated the container using Tailwind's `rtl:` variant utilities to ensure correct rendering and interaction in both LTR and RTL contexts.

## Screenshots

| Before | After |
|<img width="150" height="37" alt="before" src="https://github.com/user-attachments/assets/12e9b03c-4b65-42c4-b055-0e43dc8a7d7d" />|<img width="983" height="362" alt="after" src="https://github.com/user-attachments/assets/e11ca9f5-4179-41c5-97a2-640022ba0705" />|
| Buttons appear reversed/misaligned in Persian | Buttons are correctly ordered for RTL flow |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods