### PR TITLE
fix(web): handle missing hit-testing document names

### DIFF
--- a/api/fields/hit_testing_fields.py
+++ b/api/fields/hit_testing_fields.py
@@ -14,7 +14,7 @@ class HitTestingQuery(ResponseModel):
 class HitTestingDocument(ResponseModel):
     id: str
     data_source_type: str
-    name: str
+    name: str | None
     doc_type: str | None
     doc_metadata: Any | None
 

--- a/api/tests/unit_tests/controllers/console/datasets/test_hit_testing.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_hit_testing.py
@@ -181,6 +181,43 @@ class TestHitTestingApi:
         assert result["records"][0]["files"] == []
         assert result["records"][0]["score"] is None
 
+    def test_hit_testing_success_with_null_document_name(self, app: Flask, dataset, dataset_id, account: Account):
+        api = HitTestingApi()
+        method = unwrap(api.post)
+
+        payload = {
+            "query": "what is vector search",
+        }
+        records = [hit_testing_record()]
+        records[0]["segment"]["document"]["name"] = None
+
+        with (
+            app.test_request_context("/"),
+            patch.object(
+                type(console_ns),
+                "payload",
+                new_callable=PropertyMock,
+                return_value=payload,
+            ),
+            patch.object(
+                HitTestingApi,
+                "get_and_validate_dataset",
+                return_value=dataset,
+            ),
+            patch.object(
+                HitTestingApi,
+                "hit_testing_args_check",
+            ),
+            patch.object(
+                HitTestingApi,
+                "perform_hit_testing",
+                return_value={"query": {"content": payload["query"]}, "records": records},
+            ),
+        ):
+            result = method(api, account, "tenant-1", dataset_id)
+
+        assert result["records"][0]["segment"]["document"]["name"] is None
+
     def test_hit_testing_dataset_not_found(self, app: Flask, dataset_id, account: Account):
         api = HitTestingApi()
         method = unwrap(api.post)

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_hit_testing.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_hit_testing.py
@@ -325,6 +325,42 @@ class TestHitTestingApiPost:
         assert record["summary"] is None
 
     @patch("controllers.service_api.dataset.hit_testing.service_api_ns")
+    @patch("controllers.console.datasets.hit_testing_base.HitTestingService")
+    @patch("controllers.console.datasets.hit_testing_base.DatasetService")
+    def test_post_allows_null_document_name(
+        self,
+        mock_dataset_svc,
+        mock_hit_svc,
+        mock_ns,
+        app: Flask,
+    ):
+        dataset_id = str(uuid.uuid4())
+        tenant_id = str(uuid.uuid4())
+
+        mock_dataset = self._dataset(dataset_id, tenant_id)
+        account = self._account(tenant_id)
+
+        mock_dataset_svc.get_dataset.return_value = mock_dataset
+        mock_dataset_svc.check_dataset_permission.return_value = None
+
+        record = hit_testing_record()
+        record["segment"]["document"]["name"] = None
+        mock_hit_svc.retrieve.return_value = {
+            "query": {"content": "legacy query"},
+            "records": [record],
+        }
+        mock_hit_svc.hit_testing_args_check.return_value = None
+
+        mock_ns.payload = {"query": "legacy query"}
+
+        with app.test_request_context():
+            g._login_user = account
+            api = HitTestingApi()
+            response = HitTestingApi.post.__wrapped__(api, tenant_id, dataset_id)
+
+        assert response["records"][0]["segment"]["document"]["name"] is None
+
+    @patch("controllers.service_api.dataset.hit_testing.service_api_ns")
     @patch("controllers.console.datasets.hit_testing_base.DatasetService")
     def test_post_dataset_not_found(
         self,

--- a/web/app/components/datasets/hit-testing/components/__tests__/chunk-detail-modal.spec.tsx
+++ b/web/app/components/datasets/hit-testing/components/__tests__/chunk-detail-modal.spec.tsx
@@ -78,6 +78,24 @@ describe('ChunkDetailModal', () => {
     expect(screen.getByRole('dialog')).toHaveTextContent('chunkDetail')
   })
 
+  it('should render a visible fallback title when document name is null', () => {
+    const payload = makePayload({
+      segment: { document: { name: null } },
+    })
+
+    expect(() => {
+      render(<ChunkDetailModal payload={payload} onHide={onHide} />)
+    }).not.toThrow()
+
+    expect(screen.getByText('--')).toBeInTheDocument()
+    expect(screen.getByTestId('markdown')).toHaveTextContent('chunk content')
+  })
+
+  it('should render the document name when present', () => {
+    render(<ChunkDetailModal payload={makePayload()} onHide={onHide} />)
+    expect(screen.getByText('file.pdf')).toBeInTheDocument()
+  })
+
   it('should render segment index tag and score', () => {
     render(<ChunkDetailModal payload={makePayload()} onHide={onHide} />)
     expect(screen.getByTestId('segment-index-tag')).toHaveTextContent('1')

--- a/web/app/components/datasets/hit-testing/components/__tests__/result-item.spec.tsx
+++ b/web/app/components/datasets/hit-testing/components/__tests__/result-item.spec.tsx
@@ -74,6 +74,19 @@ describe('ResultItem', () => {
     expect(screen.getByTestId('result-item-footer')).toHaveTextContent('file.pdf')
   })
 
+  it('should render a visible fallback title when document name is null', () => {
+    const payload = makePayload({
+      segment: { document: { name: null } },
+    })
+
+    expect(() => {
+      render(<ResultItem payload={payload} />)
+    }).not.toThrow()
+
+    expect(screen.getByTestId('markdown')).toHaveTextContent('test content')
+    expect(screen.getByTestId('result-item-footer')).toHaveTextContent('--')
+  })
+
   it('should render keywords when no child_chunks', () => {
     const payload = makePayload({
       segment: { keywords: ['key1', 'key2'] },

--- a/web/app/components/datasets/hit-testing/components/chunk-detail-modal.tsx
+++ b/web/app/components/datasets/hit-testing/components/chunk-detail-modal.tsx
@@ -32,7 +32,9 @@ const ChunkDetailModal = ({
   const { segment, score, child_chunks, files, summary } = payload
   const { position, content, sign_content, keywords, document, answer } = segment
   const isParentChildRetrieval = !!(child_chunks && child_chunks.length > 0)
-  const extension = document.name.split('.').slice(-1)[0] as FileAppearanceTypeEnum
+  const documentName = document.name ?? ''
+  const documentTitle = documentName || '--'
+  const extension = documentName.split('.').slice(-1)[0] as FileAppearanceTypeEnum
   const heighClassName = isParentChildRetrieval ? 'h-[min(627px,80vh)] overflow-y-auto' : 'h-[min(539px,80vh)] overflow-y-auto'
   const labelPrefix = isParentChildRetrieval ? t('segment.parentChunk', { ns: 'datasetDocuments' }) : t('segment.chunk', { ns: 'datasetDocuments' })
 
@@ -83,7 +85,7 @@ const ChunkDetailModal = ({
                 <Dot />
                 <div className="flex grow items-center space-x-1">
                   <FileIcon type={extension} size="sm" />
-                  <span className="w-0 grow truncate text-[13px] font-normal text-text-secondary">{document.name}</span>
+                  <span className="w-0 grow truncate text-[13px] font-normal text-text-secondary">{documentTitle}</span>
                 </div>
               </div>
               <Score value={score} />

--- a/web/app/components/datasets/hit-testing/components/result-item.tsx
+++ b/web/app/components/datasets/hit-testing/components/result-item.tsx
@@ -30,7 +30,9 @@ const ResultItem = ({
   const data = segment
   const { position, word_count, content, sign_content, keywords, document } = data
   const isParentChildRetrieval = !!(child_chunks && child_chunks.length > 0)
-  const extension = document.name.split('.').slice(-1)[0] as FileAppearanceTypeEnum
+  const documentName = document.name ?? ''
+  const documentTitle = documentName || '--'
+  const extension = documentName.split('.').slice(-1)[0] as FileAppearanceTypeEnum
   const fileType = extensionToFileType(extension)
   const [isFold, {
     toggle: toggleFold,
@@ -104,7 +106,7 @@ const ResultItem = ({
         )}
       </div>
       {/* Foot */}
-      <ResultItemFooter docType={fileType} docTitle={document.name} showDetailModal={showDetailModal} />
+      <ResultItemFooter docType={fileType} docTitle={documentTitle} showDetailModal={showDetailModal} />
 
       {
         isShowDetailModal && (

--- a/web/models/datasets.ts
+++ b/web/models/datasets.ts
@@ -646,7 +646,7 @@ type Segment = {
 type Document = {
   id: string
   data_source_type: string
-  name: string
+  name: string | null
   doc_type: DocType
 }
 


### PR DESCRIPTION
Closes #37064

## Summary

Hit-testing results can still fail when a returned segment carries incomplete document metadata. This patch keeps both the result card and the chunk-detail modal renderable when the document name is missing, and it widens the shared hit-testing response DTO so the same `name = null` payload survives response serialization before the frontend fallback renders.

## Root cause

`result-item.tsx` and `chunk-detail-modal.tsx` both called `document.name.split('.')` during render and both rendered `document.name` directly. The hit-testing TypeScript model also marked `Document.name` as required, which hid the incomplete-payload path from the component layer and the original tests. On the API side, the shared `HitTestingDocument` response model still required `name: str`, so `dump_response(HitTestingResponse, ...)` could reject the same payload before the frontend fallback ever rendered.

## Scope

This does not reopen backend hit-testing retrieval or enrichment work from #36106. The patch stays on the two current hit-testing consumers that still dereference `document.name`, the narrow web type that masks the null-name path, the shared hit-testing response DTO, and the focused controller tests for the two API surfaces that serialize through that DTO.

## Verification

- `pnpm -C web test app/components/datasets/hit-testing/components/__tests__/result-item.spec.tsx`
- `pnpm -C web test app/components/datasets/hit-testing/components/__tests__/chunk-detail-modal.spec.tsx`
- `pnpm -C web type-check`
- `uv run --project api --dev ruff check api/fields/hit_testing_fields.py api/tests/unit_tests/controllers/console/datasets/test_hit_testing.py api/tests/unit_tests/controllers/service_api/dataset/test_hit_testing.py`
- `git diff --check`
