### PR TITLE
fix(web): improve main nav focus outline

### DIFF
--- a/web/app/components/main-nav/components/nav-link.tsx
+++ b/web/app/components/main-nav/components/nav-link.tsx
@@ -34,7 +34,7 @@ const MainNavLink = ({
       aria-current={activated ? 'page' : undefined}
       title={item.label}
       className={cn(
-        'group relative flex h-8 w-full items-center gap-2 rounded-[10px] px-2 py-1.5 outline-hidden transition-colors focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:ring-inset',
+        'group relative flex h-8 w-full items-center gap-2 rounded-[10px] px-2 py-1.5 outline-hidden transition-colors focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-state-accent-solid focus-visible:outline-solid',
         'not-aria-[current=page]:bg-components-main-nav-nav-button-bg not-aria-[current=page]:system-md-medium not-aria-[current=page]:text-components-main-nav-nav-button-text not-aria-[current=page]:hover:bg-components-main-nav-nav-button-bg-hover not-aria-[current=page]:hover:text-components-main-nav-nav-button-text',
         'aria-[current=page]:dify-blue-glass-surface aria-[current=page]:z-1',
       )}


### PR DESCRIPTION
## Summary

- Replaces the main nav link focus-visible ring with a focus-visible outline.
- Keeps the active `aria-current="page"` glass styling and route semantics unchanged.

## Problem

Active main nav links use `dify-blue-glass-surface`, which owns a layered glass treatment with gradients, pseudo-element edges, inner glow, and box shadows. The previous focus indicator used Tailwind ring utilities, which are also rendered through box-shadow. In the active state that indicator was either visually swallowed by the glass treatment or competed with the same rendering layer, making keyboard focus difficult to see.

Using `outline` makes the focus indicator independent from the glass box-shadow stack, so the active item can keep its visual treatment while the keyboard focus indicator remains visible.

## Testing

- `pnpm --dir web exec eslint app/components/main-nav/components/nav-link.tsx`
- `git diff --check`

No unit test was added. A CSS class assertion here would only lock the implementation detail (`outline` vs `ring`) rather than verify a user-observable focus indicator. The change is intentionally kept to the owning nav link styles.