### PR TITLE
fix(web): skip console profile fetch on public webapp routes

### DIFF
--- a/web/hooks/use-timestamp.spec.ts
+++ b/web/hooks/use-timestamp.spec.ts
@@ -6,6 +6,14 @@ import { userProfileQueryOptions } from '@/features/account-profile/client'
 import { createAccountProfileQueryWrapper } from '@/test/account-profile-query'
 import useTimestamp from './use-timestamp'
 
+const navigationMocks = vi.hoisted(() => ({
+  usePathname: vi.fn(() => '/apps'),
+}))
+
+vi.mock('@/next/navigation', () => ({
+  usePathname: navigationMocks.usePathname,
+}))
+
 vi.mock('@/context/app-context', () => ({
   useAppContext: vi.fn(() => ({
     userProfile: {
@@ -40,6 +48,10 @@ const createEmptyQueryWrapper = () => {
 
   return { queryClient, wrapper: EmptyQueryWrapper }
 }
+
+beforeEach(() => {
+  navigationMocks.usePathname.mockReturnValue('/apps')
+})
 
 describe('useTimestamp', () => {
   describe('formatTime', () => {
@@ -90,6 +102,17 @@ describe('useTimestamp', () => {
     const { result } = renderHook(() => useTimestamp({ timezone: 'UTC' }), { wrapper })
 
     expect(result.current.formatTime(1704132000, 'YYYY-MM-DD HH:mm')).toBe('2024-01-01 18:00')
+    expect(queryClient.isFetching({ queryKey: userProfileQueryOptions().queryKey })).toBe(0)
+    expect(queryClient.getQueryState(userProfileQueryOptions().queryKey)?.fetchStatus).toBe('idle')
+  })
+
+  it('should not request account profile on public web app routes', () => {
+    navigationMocks.usePathname.mockReturnValue('/chat/app-code')
+    const { queryClient, wrapper } = createEmptyQueryWrapper()
+
+    const { result } = renderHook(() => useTimestamp(), { wrapper })
+
+    expect(result.current.formatTime(1704132000, 'YYYY-MM-DD HH:mm')).toMatch(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}/)
     expect(queryClient.isFetching({ queryKey: userProfileQueryOptions().queryKey })).toBe(0)
     expect(queryClient.getQueryState(userProfileQueryOptions().queryKey)?.fetchStatus).toBe('idle')
   })

--- a/web/hooks/use-timestamp.ts
+++ b/web/hooks/use-timestamp.ts
@@ -5,6 +5,9 @@ import timezone from 'dayjs/plugin/timezone'
 import utc from 'dayjs/plugin/utc'
 import { useCallback } from 'react'
 import { userProfileQueryOptions } from '@/features/account-profile/client'
+import { usePathname } from '@/next/navigation'
+import { isPublicWebAppRoute } from '@/utils/is-public-webapp-route'
+import { getBrowserTimezone } from '@/utils/timezone'
 
 dayjs.extend(utc)
 dayjs.extend(timezone)
@@ -13,17 +16,18 @@ type UseTimestampOptions = {
   timezone?: string
 }
 
-const getBrowserTimezone = () => {
-  return Intl.DateTimeFormat().resolvedOptions().timeZone
-}
-
 const useTimestamp = ({ timezone: timezoneOverride }: UseTimestampOptions = {}) => {
+  const pathname = usePathname()
+  const isPublicWebApp = isPublicWebAppRoute(pathname)
+  const shouldFetchAccountTimezone = timezoneOverride === undefined && !isPublicWebApp
   const { data: accountTimezone } = useQuery({
     ...userProfileQueryOptions(),
     select: data => data.profile.timezone ?? undefined,
-    enabled: timezoneOverride === undefined,
+    enabled: shouldFetchAccountTimezone,
   })
-  const resolvedTimezone = timezoneOverride ?? accountTimezone ?? getBrowserTimezone()
+  const resolvedTimezone = timezoneOverride
+    ?? (isPublicWebApp ? getBrowserTimezone() : accountTimezone)
+    ?? getBrowserTimezone()
 
   const formatTime = useCallback((value: number, format: string) => {
     return dayjs.unix(value).tz(resolvedTimezone).format(format)

--- a/web/utils/is-public-webapp-route.spec.ts
+++ b/web/utils/is-public-webapp-route.spec.ts
@@ -1,0 +1,23 @@
+import { isPublicWebAppRoute } from './is-public-webapp-route'
+
+describe('isPublicWebAppRoute', () => {
+  it.each([
+    '/chat/app-code',
+    '/chatbot/app-code',
+    '/completion/app-code',
+    '/workflow/app-code',
+    '/agent/app-code',
+  ])('returns true for %s', (pathname) => {
+    expect(isPublicWebAppRoute(pathname)).toBe(true)
+  })
+
+  it.each([
+    '/',
+    '/apps',
+    '/signin',
+    '/webapp-signin',
+    '/webapp-signin/check-code',
+  ])('returns false for %s', (pathname) => {
+    expect(isPublicWebAppRoute(pathname)).toBe(false)
+  })
+})

--- a/web/utils/is-public-webapp-route.ts
+++ b/web/utils/is-public-webapp-route.ts
@@ -1,0 +1,12 @@
+const PUBLIC_WEBAPP_ROUTE_PREFIXES = new Set([
+  'agent',
+  'chat',
+  'chatbot',
+  'completion',
+  'workflow',
+])
+
+export const isPublicWebAppRoute = (pathname: string): boolean => {
+  const firstSegment = pathname.split('/').filter(Boolean)[0]
+  return firstSegment ? PUBLIC_WEBAPP_ROUTE_PREFIXES.has(firstSegment) : false
+}


### PR DESCRIPTION
Fixes #38111. Skips console account profile fetch in useTimestamp on public webapp routes so anonymous visitors are not redirected to /signin before passport auth runs.