### PR TITLE
fix(web): guard IME composition in tag input Enter handler

### DIFF
--- a/web/app/components/base/tag-input/index.tsx
+++ b/web/app/components/base/tag-input/index.tsx
@@ -48,6 +48,8 @@ const TagInput = ({ items, onChange, disableAdd, disableRemove, customizedConfir
     })
   }, [items, onChange, t, required])
   const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.nativeEvent.isComposing)
+      return
     if (isSpecialMode && e.key === 'Enter')
       setValue(`${value}↵`)
     if (e.key === customizedConfirmKey) {


### PR DESCRIPTION
`TagInput` confirms the current value on the `Enter` keydown (its default `customizedConfirmKey`), but it never checks whether an IME composition is in progress. When typing CJK text, the `Enter` that accepts an IME candidate also runs this handler, so the still-composing text is added as a tag before the conversion is finished.

The other Enter-confirmed inputs already guard against this with `e.nativeEvent.isComposing`:

- `web/app/components/base/chat/chat/question.tsx`
- `web/app/components/workflow/comment/mention-input.tsx`
- `web/features/tag-management/components/tag-item-editor.tsx`

This shared `TagInput` was the one place that was missed, so I applied the same guard: return early from `handleKeyDown` while a composition is active. For non-IME input `isComposing` is always `false`, so the behavior is unchanged. The Tab confirm mode (stop sequences) is covered as well, since the `↵` insert runs through this same handler.

### Steps to reproduce

1. Use a keyword/tag input such as the dataset segment keywords.
2. With a Japanese or Chinese IME, type a multi-character word and press Enter to accept the candidate.
3. Before: the unfinished text is added as a tag. After: Enter only accepts the IME candidate, and the tag is added on the next Enter.
