### PR TITLE
refactor: pass db.session explicitly in get_message_data (#37403)

### DIFF
--- a/api/core/ops/ops_trace_manager.py
+++ b/api/core/ops/ops_trace_manager.py
@@ -914,7 +914,7 @@ class TraceTask:
     def message_trace(self, message_id: str | None, **kwargs):
         if not message_id:
             return {}
-        message_data = get_message_data(message_id)
+        message_data = get_message_data(message_id, db.session)
         if not message_data:
             return {}
         conversation_mode_stmt = select(Conversation.mode).where(Conversation.id == message_data.conversation_id)
@@ -1004,7 +1004,7 @@ class TraceTask:
         if not moderation_result:
             return {}
         inputs = kwargs.get("inputs")
-        message_data = get_message_data(message_id)
+        message_data = get_message_data(message_id, db.session)
         if not message_data:
             return {}
         metadata = {
@@ -1042,7 +1042,7 @@ class TraceTask:
 
     def suggested_question_trace(self, message_id, timer, **kwargs):
         suggested_question = kwargs.get("suggested_question", [])
-        message_data = get_message_data(message_id)
+        message_data = get_message_data(message_id, db.session)
         if not message_data:
             return {}
         metadata = {
@@ -1093,7 +1093,7 @@ class TraceTask:
 
     def dataset_retrieval_trace(self, message_id, timer, **kwargs):
         documents = kwargs.get("documents")
-        message_data = get_message_data(message_id)
+        message_data = get_message_data(message_id, db.session)
         if not message_data:
             return {}
 
@@ -1183,7 +1183,7 @@ class TraceTask:
         tool_name = kwargs.get("tool_name", "")
         tool_inputs = kwargs.get("tool_inputs", {})
         tool_outputs = kwargs.get("tool_outputs", {})
-        message_data = get_message_data(message_id)
+        message_data = get_message_data(message_id, db.session)
         if not message_data:
             return {}
         tool_config = {}

--- a/api/core/ops/utils.py
+++ b/api/core/ops/utils.py
@@ -5,8 +5,8 @@ from urllib.parse import urlparse
 
 from pydantic import TypeAdapter
 from sqlalchemy import select
+from sqlalchemy.orm import scoped_session
 
-from models.engine import db
 from models.model import Message
 
 JSON_DICT_ADAPTER: TypeAdapter[dict[str, Any]] = TypeAdapter(dict[str, Any])
@@ -24,8 +24,8 @@ def filter_none_values(data: dict[str, Any]) -> dict[str, Any]:
     return new_data
 
 
-def get_message_data(message_id: str):
-    return db.session.scalar(select(Message).where(Message.id == message_id))
+def get_message_data(message_id: str, session: scoped_session):
+    return session.scalar(select(Message).where(Message.id == message_id))
 
 
 @contextmanager

--- a/api/tests/unit_tests/core/ops/test_utils.py
+++ b/api/tests/unit_tests/core/ops/test_utils.py
@@ -223,19 +223,18 @@ class TestFilterNoneValues:
 class TestGetMessageData:
     """Test cases for get_message_data function"""
 
-    @patch("core.ops.utils.db")
     @patch("core.ops.utils.Message")
     @patch("core.ops.utils.select")
-    def test_get_message_data(self, mock_select, mock_message, mock_db):
-        mock_scalar = mock_db.session.scalar
+    def test_get_message_data(self, mock_select, mock_message):
+        mock_session = MagicMock()
         mock_msg_instance = MagicMock()
-        mock_scalar.return_value = mock_msg_instance
+        mock_session.scalar.return_value = mock_msg_instance
 
-        result = get_message_data("message-id")
+        result = get_message_data("message-id", mock_session)
 
         assert result == mock_msg_instance
         mock_select.assert_called_once()
-        mock_scalar.assert_called_once()
+        mock_session.scalar.assert_called_once()
 
 
 class TestMeasureTime:


### PR DESCRIPTION
## Summary

Make session dependency explicit in `get_message_data` utility function, following the pattern from PR #37402.

### Changes

**`api/core/ops/utils.py`**
- `get_message_data(message_id, session)` — replaces internal `db.session` with explicit parameter
- Remove `from models.engine import db` import (no longer needed)
- Add `from sqlalchemy.orm import scoped_session` import

**Callers updated:**
- `api/core/ops/ops_trace_manager.py` — pass `db.session` to `get_message_data` (5 call sites)

**Tests updated:**
- `test_utils.py` — replace `@patch("core.ops.utils.db")` with mock session parameter

### Related
Closes #37403 (partial)

### Checklist
- [x] Tests pass
- [x] Lint clean (ruff)
- [x] Single atomic change