### PR TITLE
refactor: pass db.session explicitly in sync_account_deletion (#37403)

### DIFF
--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -545,7 +545,7 @@ class AccountService:
         # Queue account deletion sync tasks for all workspaces BEFORE account deletion (enterprise only)
         from services.enterprise.account_deletion_sync import sync_account_deletion
 
-        sync_success = sync_account_deletion(account_id=account.id, source="account_deleted")
+        sync_success = sync_account_deletion(account_id=account.id, source="account_deleted", session=db.session)
         if not sync_success:
             logger.warning(
                 "Enterprise account deletion sync failed for account %s; proceeding with local deletion.",

--- a/api/services/enterprise/account_deletion_sync.py
+++ b/api/services/enterprise/account_deletion_sync.py
@@ -5,9 +5,9 @@ from datetime import UTC, datetime
 
 from redis import RedisError
 from sqlalchemy import select
+from sqlalchemy.orm import scoped_session
 
 from configs import dify_config
-from extensions.ext_database import db
 from extensions.ext_redis import redis_client
 from models.account import TenantAccountJoin
 
@@ -87,7 +87,7 @@ def sync_workspace_member_removal(workspace_id: str, member_id: str, *, source: 
     return _queue_task(workspace_id=workspace_id, member_id=member_id, source=source)
 
 
-def sync_account_deletion(account_id: str, *, source: str) -> bool:
+def sync_account_deletion(account_id: str, *, source: str, session: scoped_session) -> bool:
     """
     Sync full account deletion across all workspaces (enterprise only).
 
@@ -105,7 +105,7 @@ def sync_account_deletion(account_id: str, *, source: str) -> bool:
         return True
 
     # Fetch all workspaces the account belongs to
-    workspace_joins = db.session.scalars(
+    workspace_joins = session.scalars(
         select(TenantAccountJoin).where(TenantAccountJoin.account_id == account_id)
     ).all()
 

--- a/api/services/enterprise/account_deletion_sync.py
+++ b/api/services/enterprise/account_deletion_sync.py
@@ -105,9 +105,7 @@ def sync_account_deletion(account_id: str, *, source: str, session: scoped_sessi
         return True
 
     # Fetch all workspaces the account belongs to
-    workspace_joins = session.scalars(
-        select(TenantAccountJoin).where(TenantAccountJoin.account_id == account_id)
-    ).all()
+    workspace_joins = session.scalars(select(TenantAccountJoin).where(TenantAccountJoin.account_id == account_id)).all()
 
     # Queue sync task for each workspace
     success = True


### PR DESCRIPTION
## Summary

Make session dependency explicit in `sync_account_deletion` enterprise function, following the pattern from PR #37402.

### Changes

**`api/services/enterprise/account_deletion_sync.py`**
- `sync_account_deletion(account_id, *, source, session)` — replaces internal `db.session` with explicit parameter
- Remove `from extensions.ext_database import db` import (no longer needed)
- Add `from sqlalchemy.orm import scoped_session` import

**Callers updated:**
- `api/services/account_service.py` — pass `db.session` to `sync_account_deletion`

### Related
Closes #37403 (partial)

### Checklist
- [x] Tests pass
- [x] Lint clean (ruff)
- [x] Single atomic change