### PR TITLE
fix(web): prevent ssePost error handler from throwing

### DIFF
--- a/web/service/base.ts
+++ b/web/service/base.ts
@@ -611,7 +611,7 @@ export const ssePost = async (
       )
     })
     .catch((e) => {
-      if (e.toString() !== 'AbortError: The user aborted a request.' && !e.toString().errorMessage.includes('TypeError: Cannot assign to read only property'))
+      if (e.toString() !== 'AbortError: The user aborted a request.' && !e.toString().includes('TypeError: Cannot assign to read only property'))
         toast.error(String(e))
       onError?.(e)
     })


### PR DESCRIPTION
Re-submitted after fork recovery. Original PR #37799 was closed due to fork deletion. Fixes SSE error handler that was throwing instead of handling errors gracefully.