### PR TITLE
fix(web): align external API and service API buttons vertically in datasets header

### DIFF
--- a/web/app/components/datasets/extra-info/service-api/index.tsx
+++ b/web/app/components/datasets/extra-info/service-api/index.tsx
@@ -31,7 +31,7 @@ const ServiceApi = ({
   }, [])
 
   return (
-    <div>
+    <div className="flex items-center">
       <Popover
         open={open}
         onOpenChange={setOpen}

--- a/web/app/components/datasets/list/header.tsx
+++ b/web/app/components/datasets/list/header.tsx
@@ -54,7 +54,7 @@ const DatasetListHeader = ({
           {canConnectExternalDataset && (
             <button
               type="button"
-              className="flex items-center justify-center gap-1 overflow-hidden rounded-md px-1.5 py-1 text-text-tertiary hover:bg-state-base-hover"
+              className="flex h-6 items-center justify-center gap-1 overflow-hidden rounded-md px-1.5 py-1 text-text-tertiary hover:bg-state-base-hover"
               onClick={onExternalApiClick}
             >
               <span aria-hidden className="i-custom-vender-solid-development-api-connection-mod size-3.5 shrink-0" />


### PR DESCRIPTION
### What this PR does / why we need it

Currently, in the datasets list header, the `External Knowledge API` button and the `Service API` button are not perfectly vertically aligned. This is caused by a difference in their DOM structure and flex properties:

1. The `External Knowledge API` button lacks an explicit `h-6` class, making its height dependent on padding and line-height.
2. The `Service API` button is wrapped in a block-level `<div>` which interferes with the `items-center` flex alignment of the parent container.

This PR fixes the vertical alignment by:
- Adding `h-6` to the `External Knowledge API` button to ensure a strict 24px height.
- Changing the `Service API` outer wrapper to `<div className="flex items-center">`.

### Which issue(s) this PR fixes

Fixes #38279
