### PR TITLE
fix: expose agent debug conversation message state

### DIFF
--- a/api/controllers/console/agent/roster.py
+++ b/api/controllers/console/agent/roster.py
@@ -248,12 +248,16 @@ class AgentAppDetailWithSite(GenericAppDetailWithSite):
     backing_app_id: str | None = None
     hidden_app_backed: bool = False
     debug_conversation_id: str | None = None
+    debug_conversation_has_messages: bool = False
+    debug_conversation_message_count: int = 0
     role: str | None = None
     active_config_is_published: bool = False
 
 
 class AgentDebugConversationRefreshResponse(BaseModel):
     debug_conversation_id: str
+    debug_conversation_has_messages: bool = False
+    debug_conversation_message_count: int = 0
 
 
 class AgentPublishPayload(BaseModel):
@@ -372,11 +376,17 @@ def _serialize_agent_app_detail(app_model, *, current_user: Account, agent_id: s
     payload["backing_app_id"] = roster_service.runtime_backing_app_id(agent)
     payload["hidden_app_backed"] = bool(agent.backing_app_id and agent.backing_app_id != agent.app_id)
     payload["id"] = agent.id
-    payload["debug_conversation_id"] = roster_service.get_or_create_agent_app_debug_conversation_id(
+    debug_conversation_id = roster_service.get_or_create_agent_app_debug_conversation_id(
         tenant_id=app_model.tenant_id,
         agent_id=agent.id,
         account_id=current_user.id,
     )
+    message_count = roster_service.count_agent_app_debug_conversation_messages(
+        conversation_id=debug_conversation_id,
+    )
+    payload["debug_conversation_id"] = debug_conversation_id
+    payload["debug_conversation_has_messages"] = message_count > 0
+    payload["debug_conversation_message_count"] = message_count
     payload["role"] = agent.role or ""
     payload["active_config_is_published"] = roster_service.active_config_is_published(
         tenant_id=app_model.tenant_id,
@@ -635,9 +645,11 @@ class AgentDebugConversationRefreshApi(Resource):
             agent_id=str(agent_id),
             account_id=current_user.id,
         )
-        return AgentDebugConversationRefreshResponse(debug_conversation_id=debug_conversation_id).model_dump(
-            mode="json"
-        )
+        return AgentDebugConversationRefreshResponse(
+            debug_conversation_id=debug_conversation_id,
+            debug_conversation_has_messages=False,
+            debug_conversation_message_count=0,
+        ).model_dump(mode="json")
 
 
 @console_ns.route("/agent/<uuid:agent_id>/publish")

--- a/api/services/agent/roster_service.py
+++ b/api/services/agent/roster_service.py
@@ -24,7 +24,7 @@ from models.agent import (
 )
 from models.agent_config_entities import AgentSoulConfig
 from models.enums import AppStatus, ConversationFromSource, ConversationStatus
-from models.model import App, AppMode, AppModelConfig, Conversation, IconType
+from models.model import App, AppMode, AppModelConfig, Conversation, IconType, Message
 from models.workflow import Workflow
 from services.agent.agent_soul_state import agent_soul_has_model
 from services.agent.composer_validator import ComposerConfigValidator
@@ -570,6 +570,18 @@ class AgentRosterService:
         if commit:
             self._session.commit()
         return conversation_id
+
+    def count_agent_app_debug_conversation_messages(self, *, conversation_id: str) -> int:
+        """Return the number of visible messages in an Agent App debug conversation."""
+
+        return (
+            self._session.scalar(
+                select(func.count(Message.id)).where(
+                    Message.conversation_id == conversation_id,
+                )
+            )
+            or 0
+        )
 
     def refresh_agent_app_debug_conversation_id(
         self, *, tenant_id: str, agent_id: str, account_id: str, commit: bool = True

--- a/api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
+++ b/api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
@@ -408,6 +408,11 @@ def test_agent_app_detail_update_delete_resolve_app_from_agent_id(
         lambda _self, **kwargs: "debug-conversation-detail",
     )
     monkeypatch.setattr(
+        roster_controller.AgentRosterService,
+        "count_agent_app_debug_conversation_messages",
+        lambda _self, **kwargs: 2,
+    )
+    monkeypatch.setattr(
         roster_controller.FeatureService,
         "get_system_features",
         lambda: SimpleNamespace(webapp_auth=SimpleNamespace(enabled=False)),
@@ -431,6 +436,8 @@ def test_agent_app_detail_update_delete_resolve_app_from_agent_id(
     assert detail["id"] == agent_id
     assert detail["app_id"] == "app-1"
     assert detail["debug_conversation_id"] == "debug-conversation-detail"
+    assert detail["debug_conversation_has_messages"] is True
+    assert detail["debug_conversation_message_count"] == 2
     assert detail["role"] == "Resolved role"
     assert detail["active_config_is_published"] is False
     assert "bound_agent_id" not in detail
@@ -445,6 +452,8 @@ def test_agent_app_detail_update_delete_resolve_app_from_agent_id(
     assert updated["id"] == agent_id
     assert updated["app_id"] == "app-1"
     assert updated["debug_conversation_id"] == "debug-conversation-detail"
+    assert updated["debug_conversation_has_messages"] is True
+    assert updated["debug_conversation_message_count"] == 2
     assert updated["role"] == "Resolved role"
     assert updated["active_config_is_published"] is False
     assert "bound_agent_id" not in updated
@@ -529,7 +538,11 @@ def test_agent_debug_conversation_refresh_uses_current_user(
             agent_id,
         )
 
-    assert response == {"debug_conversation_id": "new-debug-conversation-id"}
+    assert response == {
+        "debug_conversation_id": "new-debug-conversation-id",
+        "debug_conversation_has_messages": False,
+        "debug_conversation_message_count": 0,
+    }
     assert captured == {
         "tenant_id": "tenant-1",
         "agent_id": agent_id,

--- a/api/tests/unit_tests/services/agent/test_agent_services.py
+++ b/api/tests/unit_tests/services/agent/test_agent_services.py
@@ -2366,6 +2366,16 @@ def test_agent_app_debug_conversation_create_reuse_and_recreate():
     assert recreate_session.commits == 1
 
 
+def test_agent_app_debug_conversation_message_count():
+    session = FakeSession(scalar=[3])
+
+    count = AgentRosterService(session).count_agent_app_debug_conversation_messages(
+        conversation_id="debug-conversation-1",
+    )
+
+    assert count == 3
+
+
 def test_agent_app_debug_conversation_requires_app_binding():
     agent = Agent(
         id="agent-1",

--- a/packages/contracts/generated/api/console/agent/types.gen.ts
+++ b/packages/contracts/generated/api/console/agent/types.gen.ts
@@ -30,7 +30,9 @@ export type AgentAppDetailWithSite = {
   bound_agent_id?: string | null
   created_at?: number | null
   created_by?: string | null
+  debug_conversation_has_messages?: boolean
   debug_conversation_id?: string | null
+  debug_conversation_message_count?: number
   deleted_tools?: Array<DeletedTool>
   description?: string | null
   enable_api: boolean
@@ -205,7 +207,9 @@ export type AgentAppCopyPayload = {
 }
 
 export type AgentDebugConversationRefreshResponse = {
+  debug_conversation_has_messages?: boolean
   debug_conversation_id: string
+  debug_conversation_message_count?: number
 }
 
 export type AgentDriveListResponse = {
@@ -1690,7 +1694,9 @@ export type AgentAppDetailWithSiteWritable = {
   bound_agent_id?: string | null
   created_at?: number | null
   created_by?: string | null
+  debug_conversation_has_messages?: boolean
   debug_conversation_id?: string | null
+  debug_conversation_message_count?: number
   deleted_tools?: Array<DeletedTool>
   description?: string | null
   enable_api: boolean

--- a/packages/contracts/generated/api/console/agent/zod.gen.ts
+++ b/packages/contracts/generated/api/console/agent/zod.gen.ts
@@ -96,7 +96,9 @@ export const zSimpleResultResponse = z.object({
  * AgentDebugConversationRefreshResponse
  */
 export const zAgentDebugConversationRefreshResponse = z.object({
+  debug_conversation_has_messages: z.boolean().optional().default(false),
   debug_conversation_id: z.string(),
+  debug_conversation_message_count: z.int().optional().default(0),
 })
 
 /**
@@ -864,7 +866,9 @@ export const zAgentAppDetailWithSite = z.object({
   bound_agent_id: z.string().nullish(),
   created_at: z.int().nullish(),
   created_by: z.string().nullish(),
+  debug_conversation_has_messages: z.boolean().optional().default(false),
   debug_conversation_id: z.string().nullish(),
+  debug_conversation_message_count: z.int().optional().default(0),
   deleted_tools: z.array(zDeletedTool).optional(),
   description: z.string().nullish(),
   enable_api: z.boolean(),
@@ -2435,7 +2439,9 @@ export const zAgentAppDetailWithSiteWritable = z.object({
   bound_agent_id: z.string().nullish(),
   created_at: z.int().nullish(),
   created_by: z.string().nullish(),
+  debug_conversation_has_messages: z.boolean().optional().default(false),
   debug_conversation_id: z.string().nullish(),
+  debug_conversation_message_count: z.int().optional().default(0),
   deleted_tools: z.array(zDeletedTool).optional(),
   description: z.string().nullish(),
   enable_api: z.boolean(),


### PR DESCRIPTION
## Summary

- expose `debug_conversation_has_messages` and `debug_conversation_message_count` on Agent detail responses
- return empty debug conversation state from Agent preview restart/refresh responses
- add backend service/controller coverage and update generated Agent console contracts

## Dev verification

Deployed and verified first on `deploy/agent` / https://agent.dify.dev with API container `COMMIT_SHA=8fe485e16985bc49a772692e2f993f697f9cebd5`.

Real console API flow covered:
- create a temporary Agent through `POST /console/api/agent`
- configure its Agent Soul model/prompt through composer APIs
- confirm fresh detail returns `debug_conversation_has_messages=false` and `debug_conversation_message_count=0`
- confirm `GET /console/api/agent/{agent_id}/chat-messages` returns an empty list for the fresh debug conversation
- send a real debug chat through `POST /console/api/agent/{agent_id}/chat-messages`
- confirm detail returns `debug_conversation_has_messages=true` and `debug_conversation_message_count=1`
- call `POST /console/api/agent/{agent_id}/debug-conversation/refresh`
- confirm refresh response and follow-up detail both return `debug_conversation_has_messages=false` and `debug_conversation_message_count=0`
- delete the temporary Agent

## Tests

- `api/.venv/bin/ruff check api/controllers/console/agent/roster.py api/services/agent/roster_service.py api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py api/tests/unit_tests/services/agent/test_agent_services.py`

Note: focused pytest still exits with local process code 139 during pytest startup in this workspace, before assertion execution. The dev E2E above is the runtime verification for this issue.
