### PR TITLE
fix(web): align web app nav item width

### DIFF
--- a/web/app/components/main-nav/components/web-apps-section.tsx
+++ b/web/app/components/main-nav/components/web-apps-section.tsx
@@ -226,7 +226,7 @@ const WebAppsSectionContent = () => {
             className="overflow-x-hidden"
             role="region"
           >
-            <ScrollAreaContent className="w-full max-w-full min-w-0! pr-5 pl-2">
+            <ScrollAreaContent className="w-full max-w-full min-w-0! px-2">
               {isPending && (
                 <WebAppsSkeleton />
               )}


### PR DESCRIPTION
## Summary
- Restores the Web Apps section content padding to `px-2` so installed app rows align with the main nav item track.
- Keeps the fix scoped to the Web Apps list and leaves the default ScrollArea scrollbar styling unchanged.

## Regression Source
- Introduced by `9d3ac1b7b32c074889b36f0d96dd1ed6dde6fe5b` (`fix: simplify scroll area composition (#38113)`), which changed `ScrollAreaContent` in `web-apps-section.tsx` from `px-2` to `pr-5 pl-2`.
- In the 240px main sidebar, that reduced the row track from `240 - 8 - 8 = 224px` to `240 - 8 - 20 = 212px`, making Web App items narrower than the Figma nav shell design.

## Tests
- `pnpm -C web exec eslint app/components/main-nav/components/web-apps-section.tsx`
- `git diff --check`