### PR TITLE
fix: expose inline agent debug conversation seed

### DIFF
--- a/api/controllers/console/agent/composer.py
+++ b/api/controllers/console/agent/composer.py
@@ -57,8 +57,9 @@ class WorkflowAgentComposerApi(Resource):
     @login_required
     @account_initialization_required
     @get_app_model(mode=[AppMode.WORKFLOW, AppMode.ADVANCED_CHAT])
+    @with_current_user_id
     @with_current_tenant_id
-    def get(self, tenant_id: str, app_model: App, node_id: str):
+    def get(self, tenant_id: str, account_id: str, app_model: App, node_id: str):
         query = WorkflowAgentComposerQuery.model_validate(request.args.to_dict(flat=True))
         return dump_response(
             WorkflowAgentComposerResponse,
@@ -66,6 +67,7 @@ class WorkflowAgentComposerApi(Resource):
                 tenant_id=tenant_id,
                 app_id=app_model.id,
                 node_id=node_id,
+                account_id=account_id,
                 snapshot_id=query.snapshot_id,
             ),
         )

--- a/api/fields/agent_fields.py
+++ b/api/fields/agent_fields.py
@@ -371,6 +371,7 @@ class WorkflowAgentComposerResponse(ResponseModel):
     backing_app_id: str | None = None
     hidden_app_backed: bool = False
     chat_endpoint: str | None = None
+    debug_conversation_id: str | None = None
     workflow_id: str | None = None
     node_id: str | None = None
 

--- a/api/services/agent/composer_service.py
+++ b/api/services/agent/composer_service.py
@@ -103,7 +103,7 @@ def _agent_soul_config_json(agent_soul: AgentSoulConfig | dict[str, Any]) -> dic
 class AgentComposerService:
     @classmethod
     def load_workflow_composer(
-        cls, *, tenant_id: str, app_id: str, node_id: str, snapshot_id: str | None = None
+        cls, *, tenant_id: str, app_id: str, node_id: str, account_id: str | None = None, snapshot_id: str | None = None
     ) -> dict[str, Any]:
         workflow = cls._get_draft_workflow(tenant_id=tenant_id, app_id=app_id)
         binding = cls._get_workflow_binding(tenant_id=tenant_id, workflow_id=workflow.id, node_id=node_id)
@@ -119,7 +119,7 @@ class AgentComposerService:
             agent=agent,
             snapshot_id=snapshot_id,
         )
-        return cls._serialize_workflow_state(binding=binding, agent=agent, version=version)
+        return cls._serialize_workflow_state(binding=binding, agent=agent, version=version, account_id=account_id)
 
     @classmethod
     def _workflow_composer_version(
@@ -1849,6 +1849,7 @@ class AgentComposerService:
         binding: WorkflowAgentNodeBinding,
         agent: Agent | None,
         version: AgentConfigSnapshot | None,
+        account_id: str | None = None,
     ) -> dict[str, Any]:
         locked = bool(agent and agent.scope == AgentScope.ROSTER)
         save_options = [ComposerSaveStrategy.NODE_JOB_ONLY.value]
@@ -1862,6 +1863,12 @@ class AgentComposerService:
             )
         else:
             save_options.append(ComposerSaveStrategy.SAVE_TO_ROSTER.value)
+        debug_conversation_id = cls._workflow_inline_debug_conversation_id(
+            tenant_id=binding.tenant_id,
+            binding=binding,
+            agent=agent,
+            account_id=account_id,
+        )
         return {
             "variant": ComposerVariant.WORKFLOW.value,
             "agent": cls._serialize_agent(agent) if agent else None,
@@ -1896,9 +1903,34 @@ class AgentComposerService:
             "backing_app_id": agent.backing_app_id if agent else None,
             "hidden_app_backed": bool(agent and agent.scope == AgentScope.WORKFLOW_ONLY and agent.backing_app_id),
             "chat_endpoint": f"/console/api/agent/{agent.id}/chat-messages" if agent else None,
+            "debug_conversation_id": debug_conversation_id,
             "workflow_id": binding.workflow_id,
             "node_id": binding.node_id,
         }
+
+    @staticmethod
+    def _workflow_inline_debug_conversation_id(
+        *,
+        tenant_id: str,
+        binding: WorkflowAgentNodeBinding,
+        agent: Agent | None,
+        account_id: str | None,
+    ) -> str | None:
+        if (
+            not account_id
+            or not agent
+            or binding.binding_type != WorkflowAgentBindingType.INLINE_AGENT
+            or agent.scope != AgentScope.WORKFLOW_ONLY
+        ):
+            return None
+
+        from services.agent.roster_service import AgentRosterService
+
+        return AgentRosterService(db.session).get_or_create_agent_app_debug_conversation_id(
+            tenant_id=tenant_id,
+            agent_id=agent.id,
+            account_id=account_id,
+        )
 
     @classmethod
     def _serialize_agent(cls, agent: Agent) -> dict[str, Any]:

--- a/api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
+++ b/api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py
@@ -1154,9 +1154,10 @@ def test_workflow_composer_get_put_validate_candidates_impact_and_save(
 
     with app.test_request_context("?snapshot_id=preview-version"):
         workflow_state = unwrap(WorkflowAgentComposerApi.get)(
-            WorkflowAgentComposerApi(), "tenant-1", app_model, "node-1"
+            WorkflowAgentComposerApi(), "tenant-1", account_id, app_model, "node-1"
         )
     assert workflow_state["node_id"] == "node-1"
+    assert captured_load["account_id"] == account_id
     assert captured_load["snapshot_id"] == "preview-version"
     with app.test_request_context(json=payload):
         saved_state = unwrap(WorkflowAgentComposerApi.put)(

--- a/api/tests/unit_tests/services/agent/test_agent_services.py
+++ b/api/tests/unit_tests/services/agent/test_agent_services.py
@@ -236,6 +236,62 @@ def test_load_workflow_composer_uses_inline_preview_snapshot(monkeypatch: pytest
     assert result == {"agent": "inline-agent-1", "version": "inline-preview-version"}
 
 
+def test_workflow_inline_debug_conversation_seed(monkeypatch: pytest.MonkeyPatch):
+    captured: dict[str, object] = {}
+
+    class FakeRosterService:
+        def __init__(self, session):
+            captured["session"] = session
+
+        def get_or_create_agent_app_debug_conversation_id(self, **kwargs):
+            captured.update(kwargs)
+            return "debug-conversation-1"
+
+    monkeypatch.setattr(roster_service, "AgentRosterService", FakeRosterService)
+
+    binding = SimpleNamespace(binding_type=WorkflowAgentBindingType.INLINE_AGENT)
+    agent = SimpleNamespace(id="inline-agent-1", scope=AgentScope.WORKFLOW_ONLY)
+
+    debug_conversation_id = AgentComposerService._workflow_inline_debug_conversation_id(
+        tenant_id="tenant-1",
+        binding=binding,
+        agent=agent,
+        account_id="account-1",
+    )
+
+    assert debug_conversation_id == "debug-conversation-1"
+    assert captured["tenant_id"] == "tenant-1"
+    assert captured["agent_id"] == "inline-agent-1"
+    assert captured["account_id"] == "account-1"
+
+
+def test_workflow_inline_debug_conversation_seed_skips_non_inline(monkeypatch: pytest.MonkeyPatch):
+    class UnexpectedRosterService:
+        def __init__(self, session):
+            raise AssertionError("roster service should not be used")
+
+    monkeypatch.setattr(roster_service, "AgentRosterService", UnexpectedRosterService)
+
+    assert (
+        AgentComposerService._workflow_inline_debug_conversation_id(
+            tenant_id="tenant-1",
+            binding=SimpleNamespace(binding_type=WorkflowAgentBindingType.ROSTER_AGENT),
+            agent=SimpleNamespace(id="agent-1", scope=AgentScope.ROSTER),
+            account_id="account-1",
+        )
+        is None
+    )
+    assert (
+        AgentComposerService._workflow_inline_debug_conversation_id(
+            tenant_id="tenant-1",
+            binding=SimpleNamespace(binding_type=WorkflowAgentBindingType.INLINE_AGENT),
+            agent=SimpleNamespace(id="inline-agent-1", scope=AgentScope.WORKFLOW_ONLY),
+            account_id=None,
+        )
+        is None
+    )
+
+
 def test_load_workflow_composer_rejects_preview_without_binding(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(AgentComposerService, "_get_draft_workflow", lambda **kwargs: SimpleNamespace(id="workflow-1"))
     monkeypatch.setattr(AgentComposerService, "_get_workflow_binding", lambda **kwargs: None)

--- a/packages/contracts/generated/api/console/apps/types.gen.ts
+++ b/packages/contracts/generated/api/console/apps/types.gen.ts
@@ -975,6 +975,7 @@ export type WorkflowAgentComposerResponse = {
   backing_app_id?: string | null
   binding?: AgentComposerBindingResponse | null
   chat_endpoint?: string | null
+  debug_conversation_id?: string | null
   effective_declared_outputs?: Array<DeclaredOutputConfig>
   hidden_app_backed?: boolean
   impact_summary?: AgentComposerImpactResponse | null

--- a/packages/contracts/generated/api/console/apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/apps/zod.gen.ts
@@ -3659,6 +3659,7 @@ export const zWorkflowAgentComposerResponse = z.object({
   backing_app_id: z.string().nullish(),
   binding: zAgentComposerBindingResponse.nullish(),
   chat_endpoint: z.string().nullish(),
+  debug_conversation_id: z.string().nullish(),
   effective_declared_outputs: z.array(zDeclaredOutputConfig).optional(),
   hidden_app_backed: z.boolean().optional().default(false),
   impact_summary: zAgentComposerImpactResponse.nullish(),


### PR DESCRIPTION
## Summary

- Expose `debug_conversation_id` on workflow agent composer GET responses for inline workflow-only agents.
- Resolve the seed from the current user's Agent debug conversation, matching roster configure behavior.
- Keep roster/empty composer states unchanged by returning `null` outside inline workflow-only bindings.
- Update generated console app contracts and unit coverage for the controller/service path.

## Verification

- `api/.venv/bin/ruff check api/controllers/console/agent/composer.py api/services/agent/composer_service.py api/fields/agent_fields.py api/tests/unit_tests/controllers/console/agent/test_agent_controllers.py api/tests/unit_tests/services/agent/test_agent_services.py`
- Focused pytest command exits with local process code 139 during startup before assertions, consistent with the current local environment issue.
- Deployed commit `5bdee93ece20e60fe475aa2c0e410d17fa3c6683` to `deploy/agent` and verified `agent.dify.dev` API/agent-backend containers report the same `COMMIT_SHA`.
- Real dev E2E on `https://agent.dify.dev`:
  - created a temporary workflow app
  - initialized workflow draft
  - created a workflow-only inline agent through workflow composer PUT
  - checked out build draft
  - called workflow composer GET twice and confirmed the same non-empty `debug_conversation_id`
  - sent a real `debug_build` chat through `/console/api/agent/{agent_id}/chat-messages`
  - loaded `/console/api/agent/{agent_id}/chat-messages?conversation_id={debug_conversation_id}` and confirmed the chat history persisted
  - cleaned up the temporary app
