### PR TITLE
feat: Require privileged role for workspace renames

### DIFF
--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -23,6 +23,7 @@ from controllers.console.error import AccountNotLinkTenantError
 from controllers.console.wraps import (
     account_initialization_required,
     cloud_edition_billing_resource_check,
+    is_admin_or_owner_required,
     only_edition_enterprise,
     setup_required,
     with_current_tenant_id,
@@ -436,10 +437,12 @@ class WebappLogoWorkspaceApi(Resource):
 class WorkspaceInfoApi(Resource):
     @console_ns.expect(console_ns.models[WorkspaceInfoPayload.__name__])
     @console_ns.response(200, "Success", console_ns.models[WorkspaceMutationResponse.__name__])
+    @console_ns.response(403, "Insufficient permissions")
     @setup_required
     @login_required
     @account_initialization_required
     # Change workspace name
+    @is_admin_or_owner_required
     @with_current_tenant_id
     def post(self, current_tenant_id: str):
         payload = console_ns.payload or {}

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -11861,6 +11861,7 @@ Returns permission flags that control workspace features like member invitations
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
 | 200 | Success | **application/json**: [WorkspaceMutationResponse](#workspacemutationresponse)<br> |
+| 403 | Insufficient permissions |  |
 
 ### [POST] /workspaces/switch
 #### Request Body

--- a/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from flask import Flask
 from werkzeug.datastructures import FileStorage
-from werkzeug.exceptions import Unauthorized
+from werkzeug.exceptions import Forbidden, Unauthorized
 
 import services
 from controllers.common.errors import (
@@ -30,7 +30,7 @@ from controllers.console.workspace.workspace import (
 )
 from enums.cloud_plan import CloudPlan
 from libs.datetime_utils import naive_utc_now
-from models.account import Account, Tenant, TenantCustomConfigDict, TenantStatus
+from models.account import Account, AccountStatus, Tenant, TenantAccountRole, TenantCustomConfigDict, TenantStatus
 
 
 def make_account(account_id: str = "u1") -> Account:
@@ -662,6 +662,69 @@ class TestWebappLogoWorkspaceApi:
 
 
 class TestWorkspaceInfoApi:
+    def test_post_rejects_normal_member_without_mutating_workspace(self, app: Flask):
+        tenant = make_tenant("t1", name="Original Name")
+        current_user = make_account_with_tenant(tenant)
+        current_user.status = AccountStatus.ACTIVE
+        current_user.role = TenantAccountRole.NORMAL
+        current_user_proxy = MagicMock()
+        current_user_proxy._get_current_object.return_value = current_user
+
+        with (
+            app.test_request_context("/workspaces/info", method="POST", json={"name": "Normal Rename"}),
+            patch("libs.login.dify_config.LOGIN_DISABLED", True),
+            patch("controllers.console.wraps.dify_config.EDITION", "CLOUD"),
+            patch("controllers.console.wraps.dify_config.RBAC_ENABLED", False),
+            patch("libs.login.current_user", current_user_proxy),
+            patch(
+                "controllers.console.wraps.current_account_with_tenant",
+                return_value=(current_user, "t1"),
+            ),
+            patch("controllers.console.workspace.workspace.db.get_or_404", return_value=tenant) as get_tenant_mock,
+            patch("controllers.console.workspace.workspace.db.session.commit") as commit_mock,
+            patch(
+                "controllers.console.workspace.workspace.WorkspaceService.get_tenant_info",
+                return_value={"name": "Normal Rename", "role": "normal"},
+            ),
+        ):
+            with pytest.raises(Forbidden):
+                WorkspaceInfoApi().post()
+
+        get_tenant_mock.assert_not_called()
+        commit_mock.assert_not_called()
+        assert tenant.name == "Original Name"
+
+    def test_post_allows_owner_to_mutate_workspace(self, app: Flask):
+        tenant = make_tenant("t1", name="Original Name")
+        current_user = make_account_with_tenant(tenant)
+        current_user.status = AccountStatus.ACTIVE
+        current_user.role = TenantAccountRole.OWNER
+        current_user_proxy = MagicMock()
+        current_user_proxy._get_current_object.return_value = current_user
+
+        with (
+            app.test_request_context("/workspaces/info", method="POST", json={"name": "Owner Rename"}),
+            patch("libs.login.dify_config.LOGIN_DISABLED", True),
+            patch("controllers.console.wraps.dify_config.EDITION", "CLOUD"),
+            patch("controllers.console.wraps.dify_config.RBAC_ENABLED", False),
+            patch("libs.login.current_user", current_user_proxy),
+            patch(
+                "controllers.console.wraps.current_account_with_tenant",
+                return_value=(current_user, "t1"),
+            ),
+            patch("controllers.console.workspace.workspace.db.get_or_404", return_value=tenant),
+            patch("controllers.console.workspace.workspace.db.session.commit") as commit_mock,
+            patch(
+                "controllers.console.workspace.workspace.WorkspaceService.get_tenant_info",
+                return_value={"name": "Owner Rename", "role": "owner"},
+            ),
+        ):
+            result = WorkspaceInfoApi().post()
+
+        assert result["result"] == "success"
+        assert tenant.name == "Owner Rename"
+        commit_mock.assert_called_once()
+
     def test_post_success(self, app: Flask):
         api = WorkspaceInfoApi()
         method = inspect.unwrap(api.post)

--- a/packages/contracts/generated/api/console/workspaces/types.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/types.gen.ts
@@ -4624,6 +4624,10 @@ export type PostWorkspacesInfoData = {
   url: '/workspaces/info'
 }
 
+export type PostWorkspacesInfoErrors = {
+  403: unknown
+}
+
 export type PostWorkspacesInfoResponses = {
   200: WorkspaceMutationResponse
 }


### PR DESCRIPTION
## Summary
Require admin or owner privileges before accepting workspace rename requests through the console workspace settings endpoint. This prevents normal workspace members from reaching the tenant mutation path while preserving owner/admin behavior.

close https://github.com/langgenius/dify/issues/38364
## Consequence
A non-admin workspace member can rename the shared workspace, altering tenant-wide metadata visible to every member without admin or owner approval.

## Reproduction
Workspace rename authorization bypass — actor: a normal workspace member (substitute your own equivalent)

1. Authenticate the normal workspace member:
   ```bash
   curl -i -X POST "$TARGET/console/api/login" \
     -H 'Content-Type: application/json' \
     --data '{"email":"<normal-member-email>","password":"<base64-normal-member-password>","remember_me":true}'
   ```
   -> Observed login success with access, refresh, and CSRF cookies.

2. Attempt to rename the shared workspace as that normal member:
   ```bash
   curl -i -X POST "$TARGET/console/api/workspaces/info" \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Bearer <normal-member-access-token>' \
     -H 'X-CSRF-Token: <normal-member-csrf-token>' \
     --cookie 'access_token=<normal-member-access-token>; refresh_token=<normal-member-refresh-token>; csrf_token=<normal-member-csrf-token>' \
     --data '{"name":"Niro Tenant Alpha POC1"}'
   ```
   -> Observed vulnerable output: HTTP 200 with `{"result":"success","tenant":{"name":"Niro Tenant Alpha POC1","role":"normal",...}}`.

3. Control — read the workspace as an owner:
   ```bash
   curl -i -X POST "$TARGET/console/api/workspaces/current" \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Bearer <owner-access-token>' \
     -H 'X-CSRF-Token: <owner-csrf-token>' \
     --cookie 'access_token=<owner-access-token>; refresh_token=<owner-refresh-token>; csrf_token=<owner-csrf-token>' \
     --data '{}'
   ```
   -> Observed owner output showed the shared workspace name changed to `Niro Tenant Alpha POC1`.

Expected secure: the normal member receives 403/permission denial and the workspace name remains unchanged; an owner can still rename the workspace.

## What changed
- Added the existing `is_admin_or_owner_required` guard to `WorkspaceInfoApi.post` before tenant lookup and mutation.
- Documented the endpoint's 403 response in the Flask-RESTX route metadata.
- Added route-level regression coverage for normal-member denial and owner success.

## Regression test
`api/tests/unit_tests/controllers/console/workspace/test_workspace.py::TestWorkspaceInfoApi` now asserts that a normal workspace member receives `Forbidden`, no tenant is loaded, no commit occurs, and the tenant name stays unchanged. The same group includes an owner control that proves privileged users can still rename the workspace.

## Validation
Red on unfixed code:
```text
FAILED api/tests/unit_tests/controllers/console/workspace/test_workspace.py::TestWorkspaceInfoApi::test_post_rejects_normal_member_without_mutating_workspace
E           Failed: DID NOT RAISE <class 'werkzeug.exceptions.Forbidden'>
1 failed, 3 passed, 3 warnings in 28.30s
```

Green after the fix:
```text
api/tests/unit_tests/controllers/console/workspace/test_workspace.py::TestWorkspaceInfoApi
4 passed, 3 warnings in 26.79s
```

Additional focused validation:
```text
api/tests/unit_tests/controllers/console/workspace/test_workspace.py
32 passed, 3 warnings in 27.70s
```

Scoped Ruff checks passed for both touched files:
```text
uv run --project api --dev ruff format --check api/controllers/console/workspace/workspace.py api/tests/unit_tests/controllers/console/workspace/test_workspace.py
uv run --project api --dev ruff check api/controllers/console/workspace/workspace.py api/tests/unit_tests/controllers/console/workspace/test_workspace.py
```

## Full suite
`make test` passed: main backend unit phase `12777 passed, 5 skipped, 601 warnings in 269.52s`; controller phase `3016 passed, 1 skipped, 6 warnings in 212.03s`.

## Residual risk
This PR proves the console workspace rename route authorization at unit level and the existing backend unit suite. It does not add an end-to-end browser/API harness test.

_Pentested and fixed by [Niro](https://github.com/apxlabs-ai/niro)_
