### PR TITLE
fix(api): wire dedicated timeout into inner RBAC requests

### DIFF
--- a/api/configs/enterprise/__init__.py
+++ b/api/configs/enterprise/__init__.py
@@ -34,6 +34,12 @@ class EnterpriseFeatureConfig(BaseSettings):
         default=False,
     )
 
+    ENTERPRISE_RBAC_REQUEST_TIMEOUT: int = Field(
+        ge=1,
+        description="Maximum timeout in seconds for inner RBAC requests.",
+        default=30,
+    )
+
 
 class EnterpriseTelemetryConfig(BaseSettings):
     """

--- a/api/services/enterprise/rbac_service.py
+++ b/api/services/enterprise/rbac_service.py
@@ -743,6 +743,7 @@ def _inner_call(
         account_id=account_id,
         json=json,
         params=params,
+        timeout=dify_config.ENTERPRISE_RBAC_REQUEST_TIMEOUT,
     )
 
 


### PR DESCRIPTION
## Summary

Inner RBAC requests (`/inner/api/rbac/*`) had no explicit timeout, so they fell through to httpx's library default of 5 seconds. In workspaces with many apps, the RBAC server needs longer than 5s to aggregate permissions, so the Python client cut the connection mid-request and the RBAC server logged `context canceled`.

This adds a dedicated `ENTERPRISE_RBAC_REQUEST_TIMEOUT` config (default `30`) and passes it from `_inner_call` to `EnterpriseRequest.send_inner_rbac_request`.

It is kept separate from the existing shared `ENTERPRISE_REQUEST_TIMEOUT` (used by the plugin manager) so the RBAC window can be tuned independently without changing other enterprise request timeouts.

### Changes

- `api/configs/enterprise/__init__.py` — add `ENTERPRISE_RBAC_REQUEST_TIMEOUT` (`ge=1`, default `30`)
- `api/services/enterprise/rbac_service.py` — pass `timeout=dify_config.ENTERPRISE_RBAC_REQUEST_TIMEOUT` in `_inner_call`

### Deployment

Operators can raise `ENTERPRISE_RBAC_REQUEST_TIMEOUT` further if a workspace has an unusually large number of apps. The default of 30 replaces the previous effective 5s.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
