### PR TITLE
feat: add batch sync for Notion and Website documents in knowledge base

### DIFF
--- a/api/controllers/common/controller_schemas.py
+++ b/api/controllers/common/controller_schemas.py
@@ -204,6 +204,8 @@ class WorkflowUpdatePayload(BaseModel):
 
 DOCUMENT_BATCH_DOWNLOAD_ZIP_MAX_DOCS = 100
 
+DOCUMENT_BATCH_SYNC_MAX_DOCS = 100
+
 
 class ChildChunkCreatePayload(BaseModel):
     content: str = Field(description="Child chunk text content.")
@@ -221,6 +223,17 @@ class DocumentBatchDownloadZipPayload(BaseModel):
         min_length=1,
         max_length=DOCUMENT_BATCH_DOWNLOAD_ZIP_MAX_DOCS,
         description="List of document IDs to include in the ZIP download.",
+    )
+
+
+class DocumentBatchSyncPayload(BaseModel):
+    """Request payload for re-syncing documents from their original data source."""
+
+    document_ids: list[UUID] = Field(
+        ...,
+        min_length=1,
+        max_length=DOCUMENT_BATCH_SYNC_MAX_DOCS,
+        description="List of document IDs to re-sync from their original data source.",
     )
 
 

--- a/api/controllers/console/datasets/data_source.py
+++ b/api/controllers/console/datasets/data_source.py
@@ -411,6 +411,28 @@ class DataSourceNotionDatasetSyncApi(Resource):
         return {"result": "success"}, 200
 
 
+@console_ns.route("/datasets/<uuid:dataset_id>/website-sync")
+class DataSourceWebsiteDatasetSyncApi(Resource):
+    @setup_required
+    @login_required
+    @account_initialization_required
+    @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_CREATE_AND_MANAGEMENT)
+    def get(self, dataset_id: UUID) -> tuple[dict[str, str], int]:
+        dataset_id_str = str(dataset_id)
+        dataset = DatasetService.get_dataset(dataset_id_str)
+        if dataset is None:
+            raise NotFound("Dataset not found.")
+        documents = DocumentService.get_document_by_dataset_id(dataset_id_str)
+        for document in documents:
+            if document.data_source_type != "website_crawl" or document.archived:
+                continue
+            try:
+                DocumentService.sync_website_document(dataset_id_str, document)
+            except ValueError:
+                pass
+        return {"result": "success"}, 200
+
+
 @console_ns.route("/datasets/<uuid:dataset_id>/documents/<uuid:document_id>/notion/sync")
 class DataSourceNotionDocumentSyncApi(Resource):
     @setup_required

--- a/api/controllers/console/datasets/data_source.py
+++ b/api/controllers/console/datasets/data_source.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from collections.abc import Generator
 from datetime import datetime
 from typing import Any, Literal, cast
@@ -9,7 +10,7 @@ from flask_restx import Resource
 from pydantic import BaseModel, Field, field_serializer
 from sqlalchemy import select
 from sqlalchemy.orm import Session
-from werkzeug.exceptions import NotFound
+from werkzeug.exceptions import Forbidden, NotFound
 
 from controllers.common.fields import SimpleResultResponse, TextContentResponse
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
@@ -29,6 +30,7 @@ from libs.login import login_required
 from models import Account, DataSourceOauthBinding, Document
 from services.dataset_service import DatasetService, DocumentService
 from services.datasource_provider_service import DatasourceProviderService
+from services.errors.account import NoPermissionError
 from tasks.document_indexing_sync_task import document_indexing_sync_task
 
 from .. import console_ns
@@ -36,6 +38,7 @@ from ..wraps import (
     RBACPermission,
     RBACResourceScope,
     account_initialization_required,
+    cloud_edition_billing_rate_limit_check,
     is_admin_or_owner_required,
     model_validate,
     rbac_permission_required,
@@ -43,6 +46,8 @@ from ..wraps import (
     with_current_tenant_id,
     with_current_user,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class NotionEstimatePayload(BaseModel):
@@ -432,6 +437,44 @@ class DataSourceNotionDatasetSyncApi(Resource):
         for document in documents:
             document_indexing_sync_task.delay(dataset_id_str, document.id)
         return {"result": "success"}, 200
+
+
+@console_ns.route("/datasets/<uuid:dataset_id>/website-sync")
+class DataSourceWebsiteDatasetSyncApi(Resource):
+    """Re-sync every website document in a dataset from its source."""
+
+    @console_ns.doc("sync_dataset_website_documents")
+    @console_ns.doc(description="Re-sync all website documents in a dataset from their source")
+    @setup_required
+    @login_required
+    @account_initialization_required
+    @cloud_edition_billing_rate_limit_check("knowledge")
+    @console_ns.response(200, "Success", console_ns.models[SimpleResultResponse.__name__])
+    @with_current_user
+    # Same permission as WebsiteDocumentSyncApi, the per-document sync this batches.
+    @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_EDIT)
+    @with_session
+    def get(self, session: Session, current_user: Account, dataset_id: UUID) -> tuple[dict[str, str], int]:
+        dataset_id_str = str(dataset_id)
+        dataset = DatasetService.get_dataset(dataset_id_str, session)
+        if dataset is None:
+            raise NotFound("Dataset not found.")
+        # RBAC is a no-op when RBAC_ENABLED is false, so scope the dataset to the caller explicitly.
+        try:
+            DatasetService.check_dataset_permission(dataset, current_user, session)
+        except NoPermissionError as e:
+            raise Forbidden(str(e))
+
+        documents = DocumentService.get_document_by_dataset_id(dataset_id_str, session)
+        for document in documents:
+            if document.data_source_type != "website_crawl" or document.archived:
+                continue
+            try:
+                DocumentService.sync_website_document(dataset, document, session)
+            except ValueError:
+                # Raised when the document is already syncing; skip it instead of failing the batch.
+                logger.warning("Skipped syncing document %s: sync already in progress", document.id)
+        return SimpleResultResponse(result="success").model_dump(mode="json"), 200
 
 
 @console_ns.route("/datasets/<uuid:dataset_id>/documents/<uuid:document_id>/notion/sync")

--- a/api/controllers/console/datasets/datasets_document.py
+++ b/api/controllers/console/datasets/datasets_document.py
@@ -17,7 +17,7 @@ from werkzeug.exceptions import Forbidden, NotFound
 
 import services
 from configs import dify_config
-from controllers.common.controller_schemas import DocumentBatchDownloadZipPayload
+from controllers.common.controller_schemas import DocumentBatchDownloadZipPayload, DocumentBatchSyncPayload
 from controllers.common.fields import SimpleResultMessageResponse, SimpleResultResponse, UrlResponse
 from controllers.common.schema import register_response_schema_models, register_schema_models
 from controllers.common.session import with_session
@@ -274,6 +274,7 @@ register_schema_models(
     GenerateSummaryPayload,
     DocumentMetadataUpdatePayload,
     DocumentBatchDownloadZipPayload,
+    DocumentBatchSyncPayload,
 )
 register_response_schema_models(
     console_ns,
@@ -1223,6 +1224,43 @@ class DocumentBatchDownloadZipApi(DocumentResource):
             response.call_on_close(cleanup.close)
         # response-contract:ignore binary ZIP download response
         return response
+
+
+@console_ns.route("/datasets/<uuid:dataset_id>/documents/batch-sync")
+class DocumentBatchSyncApi(DocumentResource):
+    """Re-sync multiple Notion/website documents from their source in one request."""
+
+    @console_ns.doc("batch_sync_dataset_documents")
+    @console_ns.doc(description="Re-sync selected dataset documents from their original data source")
+    @console_ns.response(200, "Success", console_ns.models[SimpleResultResponse.__name__])
+    @setup_required
+    @login_required
+    @account_initialization_required
+    @cloud_edition_billing_rate_limit_check("knowledge")
+    @console_ns.expect(console_ns.models[DocumentBatchSyncPayload.__name__])
+    @with_current_user
+    @with_current_tenant_id
+    # Same permission as the per-document sync endpoints this batches (WebsiteDocumentSyncApi).
+    @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_EDIT)
+    @with_session
+    def post(self, session: Session, current_tenant_id: str, current_user: Account, dataset_id: UUID):
+        """Queue a source re-sync for each requested document."""
+        payload = DocumentBatchSyncPayload.model_validate(console_ns.payload or {})
+
+        synced_count = DocumentService.batch_sync_documents(
+            dataset_id=str(dataset_id),
+            document_ids=[str(document_id) for document_id in payload.document_ids],
+            tenant_id=current_tenant_id,
+            current_user=current_user,
+            session=session,
+        )
+        logger.info(
+            "Queued %s of %s requested documents for sync in dataset %s",
+            synced_count,
+            len(payload.document_ids),
+            dataset_id,
+        )
+        return SimpleResultResponse(result="success").model_dump(mode="json"), 200
 
 
 @console_ns.route("/datasets/<uuid:dataset_id>/documents/<uuid:document_id>/processing/<string:action>")

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -99,6 +99,7 @@ from tasks.deal_dataset_vector_index_task import deal_dataset_vector_index_task
 from tasks.delete_segment_from_index_task import delete_segment_from_index_task
 from tasks.disable_segment_from_index_task import disable_segment_from_index_task
 from tasks.disable_segments_from_index_task import disable_segments_from_index_task
+from tasks.document_indexing_sync_task import document_indexing_sync_task
 from tasks.document_indexing_update_task import document_indexing_update_task
 from tasks.enable_segments_to_index_task import enable_segments_to_index_task
 from tasks.recover_document_indexing_task import recover_document_indexing_task
@@ -2176,6 +2177,67 @@ class DocumentService:
         redis_client.setex(sync_indexing_cache_key, 600, 1)
 
         sync_website_document_indexing_task.delay(dataset.id, document.id)
+
+    @staticmethod
+    def batch_sync_documents(
+        *,
+        dataset_id: str,
+        document_ids: Sequence[str],
+        tenant_id: str,
+        current_user: Account,
+        session: Session,
+    ) -> int:
+        """Re-sync the given documents from their original data source.
+
+        Only Notion and website documents can be synced; documents of any other source, and archived
+        or disabled documents, are skipped. A website document that is already syncing is skipped
+        rather than failing the whole batch (Notion syncs carry no such lock, matching the existing
+        per-document Notion sync endpoint). Returns the number of documents queued for syncing.
+        """
+        dataset = DatasetService.get_dataset(dataset_id, session)
+        if not dataset:
+            raise NotFound("Dataset not found.")
+        try:
+            DatasetService.check_dataset_permission(dataset, current_user, session)
+        except NoPermissionError as e:
+            raise Forbidden(str(e))
+
+        dataset_ref = DatasetRefService.create_dataset_ref(dataset)
+        document_id_list: list[str] = [str(document_id) for document_id in document_ids]
+        documents = DocumentService.get_documents_by_ids(dataset_ref, document_id_list, session)
+        documents_by_id: dict[str, Document] = {str(document.id): document for document in documents}
+
+        missing_document_ids: set[str] = set(document_id_list) - set(documents_by_id.keys())
+        if missing_document_ids:
+            raise NotFound("Document not found.")
+
+        # Reject the batch on ownership grounds before queueing anything, so an unauthorised id
+        # cannot leave the rest of the selection half-synced.
+        for document in documents_by_id.values():
+            if document.tenant_id != tenant_id:
+                raise Forbidden("No permission.")
+
+        synced_count = 0
+        for document in documents_by_id.values():
+            # Re-indexing re-enables a document's segments, so never sync one the user has disabled.
+            # This also keeps the batch consistent with the dataset-wide sync endpoints, which read
+            # through get_document_by_dataset_id and therefore only see enabled documents.
+            if document.archived or not document.enabled:
+                continue
+            try:
+                if document.data_source_type == "notion_import":
+                    document_indexing_sync_task.delay(dataset_id, document.id)
+                elif document.data_source_type == "website_crawl":
+                    DocumentService.sync_website_document(dataset, document, session)
+                else:
+                    continue
+            except ValueError:
+                # Raised when the document is already syncing; skip it instead of failing the batch.
+                logger.warning("Skipped syncing document %s: sync already in progress", document.id)
+                continue
+            synced_count += 1
+
+        return synced_count
 
     @staticmethod
     def get_documents_position(dataset_id, session: Session):

--- a/api/tests/unit_tests/services/test_dataset_service_document.py
+++ b/api/tests/unit_tests/services/test_dataset_service_document.py
@@ -24,9 +24,12 @@ from .dataset_service_test_helpers import (
     DocumentService,
     FileInfo,
     FileNotExistsError,
+    Forbidden,
     IndexStructureType,
     InfoList,
     KnowledgeConfig,
+    MagicMock,
+    NoPermissionError,
     NotFound,
     NotionIcon,
     NotionInfo,
@@ -542,6 +545,200 @@ class TestDocumentServiceMutations:
         assert synced.data_source_info_dict["mode"] == "scrape"
         mock_redis.setex.assert_called_once_with(f"document_{document.id}_is_sync", 600, 1)
         sync_task.delay.assert_called_once_with(dataset.id, document.id)
+
+    def test_batch_sync_documents_only_syncs_requested_documents(self):
+        session = MagicMock()
+        account = create_autospec(Account, instance=True)
+        account.id = "user-1"
+        account.current_tenant_id = "tenant-1"
+
+        notion_doc = DatasetServiceUnitDataFactory.create_document_mock(
+            document_id="doc-1", tenant_id="tenant-1", data_source_type="notion_import"
+        )
+        website_doc = DatasetServiceUnitDataFactory.create_document_mock(
+            document_id="doc-2", tenant_id="tenant-1", data_source_type="website_crawl"
+        )
+
+        with (
+            patch.object(DatasetService, "get_dataset", return_value=MagicMock()),
+            patch.object(DatasetService, "check_dataset_permission"),
+            patch.object(DocumentService, "get_documents_by_ids", return_value=[notion_doc, website_doc]),
+            patch.object(DocumentService, "sync_website_document") as sync_website,
+            patch("services.dataset_service.document_indexing_sync_task") as notion_task,
+        ):
+            synced = DocumentService.batch_sync_documents(
+                dataset_id="dataset-1",
+                document_ids=["doc-1", "doc-2"],
+                tenant_id="tenant-1",
+                current_user=account,
+                session=session,
+            )
+
+        assert synced == 2
+        notion_task.delay.assert_called_once_with("dataset-1", "doc-1")
+        sync_website.assert_called_once_with("dataset-1", website_doc, session)
+
+    def test_batch_sync_documents_skips_disabled_documents(self):
+        session = MagicMock()
+        account = create_autospec(Account, instance=True)
+
+        disabled_doc = DatasetServiceUnitDataFactory.create_document_mock(
+            document_id="doc-1", tenant_id="tenant-1", data_source_type="website_crawl", enabled=False
+        )
+
+        with (
+            patch.object(DatasetService, "get_dataset", return_value=MagicMock()),
+            patch.object(DatasetService, "check_dataset_permission"),
+            patch.object(DocumentService, "get_documents_by_ids", return_value=[disabled_doc]),
+            patch.object(DocumentService, "sync_website_document") as sync_website,
+        ):
+            synced = DocumentService.batch_sync_documents(
+                dataset_id="dataset-1",
+                document_ids=["doc-1"],
+                tenant_id="tenant-1",
+                current_user=account,
+                session=session,
+            )
+
+        # Re-indexing re-enables segments, so a disabled document must never be synced.
+        assert synced == 0
+        sync_website.assert_not_called()
+
+    def test_batch_sync_documents_skips_archived_and_unsupported_sources(self):
+        session = MagicMock()
+        account = create_autospec(Account, instance=True)
+
+        archived_doc = DatasetServiceUnitDataFactory.create_document_mock(
+            document_id="doc-1", tenant_id="tenant-1", data_source_type="notion_import", archived=True
+        )
+        upload_doc = DatasetServiceUnitDataFactory.create_document_mock(
+            document_id="doc-2", tenant_id="tenant-1", data_source_type="upload_file"
+        )
+
+        with (
+            patch.object(DatasetService, "get_dataset", return_value=MagicMock()),
+            patch.object(DatasetService, "check_dataset_permission"),
+            patch.object(DocumentService, "get_documents_by_ids", return_value=[archived_doc, upload_doc]),
+            patch.object(DocumentService, "sync_website_document") as sync_website,
+            patch("services.dataset_service.document_indexing_sync_task") as notion_task,
+        ):
+            synced = DocumentService.batch_sync_documents(
+                dataset_id="dataset-1",
+                document_ids=["doc-1", "doc-2"],
+                tenant_id="tenant-1",
+                current_user=account,
+                session=session,
+            )
+
+        assert synced == 0
+        notion_task.delay.assert_not_called()
+        sync_website.assert_not_called()
+
+    def test_batch_sync_documents_skips_documents_already_syncing(self):
+        session = MagicMock()
+        account = create_autospec(Account, instance=True)
+
+        first = DatasetServiceUnitDataFactory.create_document_mock(
+            document_id="doc-1", tenant_id="tenant-1", data_source_type="website_crawl"
+        )
+        second = DatasetServiceUnitDataFactory.create_document_mock(
+            document_id="doc-2", tenant_id="tenant-1", data_source_type="website_crawl"
+        )
+
+        with (
+            patch.object(DatasetService, "get_dataset", return_value=MagicMock()),
+            patch.object(DatasetService, "check_dataset_permission"),
+            patch.object(DocumentService, "get_documents_by_ids", return_value=[first, second]),
+            patch.object(
+                DocumentService,
+                "sync_website_document",
+                side_effect=[ValueError("Document is being synced"), None],
+            ),
+        ):
+            synced = DocumentService.batch_sync_documents(
+                dataset_id="dataset-1",
+                document_ids=["doc-1", "doc-2"],
+                tenant_id="tenant-1",
+                current_user=account,
+                session=session,
+            )
+
+        # The locked document is skipped, the rest of the batch still runs.
+        assert synced == 1
+
+    def test_batch_sync_documents_rejects_documents_from_another_tenant(self):
+        session = MagicMock()
+        account = create_autospec(Account, instance=True)
+
+        foreign_doc = DatasetServiceUnitDataFactory.create_document_mock(
+            document_id="doc-1", tenant_id="tenant-2", data_source_type="notion_import"
+        )
+
+        with (
+            patch.object(DatasetService, "get_dataset", return_value=MagicMock()),
+            patch.object(DatasetService, "check_dataset_permission"),
+            patch.object(DocumentService, "get_documents_by_ids", return_value=[foreign_doc]),
+            patch("services.dataset_service.document_indexing_sync_task") as notion_task,
+        ):
+            with pytest.raises(Forbidden):
+                DocumentService.batch_sync_documents(
+                    dataset_id="dataset-1",
+                    document_ids=["doc-1"],
+                    tenant_id="tenant-1",
+                    current_user=account,
+                    session=session,
+                )
+
+        notion_task.delay.assert_not_called()
+
+    def test_batch_sync_documents_raises_when_a_document_is_missing(self):
+        session = MagicMock()
+        account = create_autospec(Account, instance=True)
+
+        with (
+            patch.object(DatasetService, "get_dataset", return_value=MagicMock()),
+            patch.object(DatasetService, "check_dataset_permission"),
+            patch.object(DocumentService, "get_documents_by_ids", return_value=[]),
+        ):
+            with pytest.raises(NotFound):
+                DocumentService.batch_sync_documents(
+                    dataset_id="dataset-1",
+                    document_ids=["doc-1"],
+                    tenant_id="tenant-1",
+                    current_user=account,
+                    session=session,
+                )
+
+    def test_batch_sync_documents_raises_when_dataset_is_missing(self):
+        session = MagicMock()
+        account = create_autospec(Account, instance=True)
+
+        with patch.object(DatasetService, "get_dataset", return_value=None):
+            with pytest.raises(NotFound):
+                DocumentService.batch_sync_documents(
+                    dataset_id="dataset-1",
+                    document_ids=["doc-1"],
+                    tenant_id="tenant-1",
+                    current_user=account,
+                    session=session,
+                )
+
+    def test_batch_sync_documents_translates_permission_error_to_forbidden(self):
+        session = MagicMock()
+        account = create_autospec(Account, instance=True)
+
+        with (
+            patch.object(DatasetService, "get_dataset", return_value=MagicMock()),
+            patch.object(DatasetService, "check_dataset_permission", side_effect=NoPermissionError("nope")),
+        ):
+            with pytest.raises(Forbidden):
+                DocumentService.batch_sync_documents(
+                    dataset_id="dataset-1",
+                    document_ids=["doc-1"],
+                    tenant_id="tenant-1",
+                    current_user=account,
+                    session=session,
+                )
 
 
 class TestDocumentServiceSaveDocumentWithoutDatasetId:

--- a/web/app/components/datasets/documents/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/documents/__tests__/index.spec.tsx
@@ -88,6 +88,8 @@ vi.mock('@/features/system-features/state', async () => {
 // Mock document service hooks
 const mockInvalidDocumentList = vi.fn()
 const mockInvalidDocumentDetail = vi.fn()
+const mockBatchSyncNotion = vi.fn()
+const mockBatchSyncWebsite = vi.fn()
 
 vi.mock('@/service/knowledge/use-document', () => ({
   useDocumentList: vi.fn(() => ({
@@ -120,6 +122,8 @@ vi.mock('@/service/knowledge/use-document', () => ({
   })),
   useInvalidDocumentList: vi.fn(() => mockInvalidDocumentList),
   useInvalidDocumentDetail: vi.fn(() => mockInvalidDocumentDetail),
+  useBatchSyncNotion: vi.fn(() => ({ mutateAsync: mockBatchSyncNotion })),
+  useBatchSyncWebsite: vi.fn(() => ({ mutateAsync: mockBatchSyncWebsite })),
 }))
 
 // Mock segment service hooks

--- a/web/app/components/datasets/documents/components/document-list/hooks/__tests__/use-document-actions-with-query-client.spec.tsx
+++ b/web/app/components/datasets/documents/components/document-list/hooks/__tests__/use-document-actions-with-query-client.spec.tsx
@@ -15,6 +15,8 @@ const mockUseDocumentDisable = vi.mocked(useDocument.useDocumentDisable)
 const mockUseDocumentDelete = vi.mocked(useDocument.useDocumentDelete)
 const mockUseDocumentBatchRetryIndex = vi.mocked(useDocument.useDocumentBatchRetryIndex)
 const mockUseDocumentDownloadZip = vi.mocked(useDocument.useDocumentDownloadZip)
+const mockUseBatchSyncNotion = vi.mocked(useDocument.useBatchSyncNotion)
+const mockUseBatchSyncWebsite = vi.mocked(useDocument.useBatchSyncWebsite)
 
 const createConsoleQueryClient = () =>
   new QueryClient({
@@ -77,6 +79,12 @@ describe('useDocumentActions', () => {
       ...createMockMutation(),
       isPending: false,
     } as unknown as ReturnType<typeof useDocument.useDocumentDownloadZip>)
+    mockUseBatchSyncNotion.mockReturnValue(
+      createMockMutation() as unknown as ReturnType<typeof useDocument.useBatchSyncNotion>,
+    )
+    mockUseBatchSyncWebsite.mockReturnValue(
+      createMockMutation() as unknown as ReturnType<typeof useDocument.useBatchSyncWebsite>,
+    )
   })
 
   describe('handleAction', () => {
@@ -91,6 +99,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate,
             onClearSelection,
           }),
@@ -118,6 +127,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate,
             onClearSelection,
           }),
@@ -144,6 +154,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate,
             onClearSelection,
           }),
@@ -172,6 +183,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1', 'doc2'],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate,
             onClearSelection,
           }),
@@ -199,6 +211,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate,
             onClearSelection,
           }),
@@ -229,6 +242,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: ['doc1'],
+            syncableSelectedDocs: [],
             onUpdate: vi.fn(),
             onClearSelection: vi.fn(),
           }),
@@ -257,6 +271,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1', 'doc2'],
             downloadableSelectedIds: ['doc1'],
+            syncableSelectedDocs: [],
             onUpdate: vi.fn(),
             onClearSelection: vi.fn(),
           }),
@@ -287,6 +302,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: [],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate: vi.fn(),
             onClearSelection: vi.fn(),
           }),
@@ -309,6 +325,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate,
             onClearSelection,
           }),
@@ -334,6 +351,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate,
             onClearSelection,
           }),
@@ -363,6 +381,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: ['doc1'],
+            syncableSelectedDocs: [],
             onUpdate: vi.fn(),
             onClearSelection: vi.fn(),
           }),
@@ -391,6 +410,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: ['doc1'],
+            syncableSelectedDocs: [],
             onUpdate: vi.fn(),
             onClearSelection: vi.fn(),
           }),
@@ -417,6 +437,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate,
             onClearSelection: vi.fn(),
           }),
@@ -443,6 +464,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate,
             onClearSelection: vi.fn(),
           }),

--- a/web/app/components/datasets/documents/components/document-list/hooks/__tests__/use-document-actions-with-query-client.spec.tsx
+++ b/web/app/components/datasets/documents/components/document-list/hooks/__tests__/use-document-actions-with-query-client.spec.tsx
@@ -1,8 +1,9 @@
 import type { ReactNode } from 'react'
+import type { SimpleDocumentDetail } from '@/models/datasets'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
-import { DocumentActionType } from '@/models/datasets'
+import { DataSourceType, DocumentActionType } from '@/models/datasets'
 import * as useDocument from '@/service/knowledge/use-document'
 import { useDocumentActions } from '../use-document-actions'
 
@@ -15,6 +16,26 @@ const mockUseDocumentDisable = vi.mocked(useDocument.useDocumentDisable)
 const mockUseDocumentDelete = vi.mocked(useDocument.useDocumentDelete)
 const mockUseDocumentBatchRetryIndex = vi.mocked(useDocument.useDocumentBatchRetryIndex)
 const mockUseDocumentDownloadZip = vi.mocked(useDocument.useDocumentDownloadZip)
+const mockUseBatchSyncDocuments = vi.mocked(useDocument.useBatchSyncDocuments)
+
+type LocalDoc = SimpleDocumentDetail & { percent?: number }
+const createMockDoc = (overrides: Partial<LocalDoc> = {}): LocalDoc =>
+  ({
+    id: 'doc1',
+    name: 'Test.txt',
+    data_source_type: DataSourceType.FILE,
+    data_source_info: {},
+    word_count: 100,
+    hit_count: 0,
+    created_at: 0,
+    position: 1,
+    doc_form: 'text_model',
+    enabled: true,
+    archived: false,
+    display_status: 'available',
+    created_from: 'api',
+    ...overrides,
+  }) as LocalDoc
 
 const createConsoleQueryClient = () =>
   new QueryClient({
@@ -77,6 +98,9 @@ describe('useDocumentActions', () => {
       ...createMockMutation(),
       isPending: false,
     } as unknown as ReturnType<typeof useDocument.useDocumentDownloadZip>)
+    mockUseBatchSyncDocuments.mockReturnValue(
+      createMockMutation() as unknown as ReturnType<typeof useDocument.useBatchSyncDocuments>,
+    )
   })
 
   describe('handleAction', () => {
@@ -91,6 +115,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate,
             onClearSelection,
           }),
@@ -118,6 +143,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate,
             onClearSelection,
           }),
@@ -144,6 +170,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate,
             onClearSelection,
           }),
@@ -172,6 +199,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1', 'doc2'],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate,
             onClearSelection,
           }),
@@ -199,6 +227,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate,
             onClearSelection,
           }),
@@ -229,6 +258,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: ['doc1'],
+            syncableSelectedDocs: [],
             onUpdate: vi.fn(),
             onClearSelection: vi.fn(),
           }),
@@ -257,6 +287,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1', 'doc2'],
             downloadableSelectedIds: ['doc1'],
+            syncableSelectedDocs: [],
             onUpdate: vi.fn(),
             onClearSelection: vi.fn(),
           }),
@@ -287,6 +318,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: [],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate: vi.fn(),
             onClearSelection: vi.fn(),
           }),
@@ -309,6 +341,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate,
             onClearSelection,
           }),
@@ -334,6 +367,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate,
             onClearSelection,
           }),
@@ -363,6 +397,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: ['doc1'],
+            syncableSelectedDocs: [],
             onUpdate: vi.fn(),
             onClearSelection: vi.fn(),
           }),
@@ -391,6 +426,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: ['doc1'],
+            syncableSelectedDocs: [],
             onUpdate: vi.fn(),
             onClearSelection: vi.fn(),
           }),
@@ -406,6 +442,105 @@ describe('useDocumentActions', () => {
     })
   })
 
+  describe('handleBatchSync', () => {
+    it('should sync only the selected documents', async () => {
+      const syncMutateAsync = vi.fn().mockResolvedValue({ result: 'success' })
+      mockUseBatchSyncDocuments.mockReturnValue({
+        mutateAsync: syncMutateAsync,
+      } as unknown as ReturnType<typeof useDocument.useBatchSyncDocuments>)
+
+      const onUpdate = vi.fn()
+      const onClearSelection = vi.fn()
+
+      const { result } = renderHook(
+        () =>
+          useDocumentActions({
+            datasetId: 'ds1',
+            selectedIds: ['doc1', 'doc2', 'doc3'],
+            downloadableSelectedIds: [],
+            syncableSelectedDocs: [
+              createMockDoc({ id: 'doc1', data_source_type: DataSourceType.NOTION }),
+              createMockDoc({ id: 'doc2', data_source_type: DataSourceType.WEB }),
+            ],
+            onUpdate,
+            onClearSelection,
+          }),
+        { wrapper: createWrapper() },
+      )
+
+      await act(async () => {
+        await result.current.handleBatchSync()
+      })
+
+      expect(syncMutateAsync).toHaveBeenCalledWith({
+        datasetId: 'ds1',
+        documentIds: ['doc1', 'doc2'],
+      })
+      expect(onClearSelection).toHaveBeenCalled()
+      await waitFor(() => expect(onUpdate).toHaveBeenCalled())
+    })
+
+    it('should not call the API when nothing syncable is selected', async () => {
+      const syncMutateAsync = vi.fn()
+      mockUseBatchSyncDocuments.mockReturnValue({
+        mutateAsync: syncMutateAsync,
+      } as unknown as ReturnType<typeof useDocument.useBatchSyncDocuments>)
+
+      const onUpdate = vi.fn()
+
+      const { result } = renderHook(
+        () =>
+          useDocumentActions({
+            datasetId: 'ds1',
+            selectedIds: ['doc1'],
+            downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
+            onUpdate,
+            onClearSelection: vi.fn(),
+          }),
+        { wrapper: createWrapper() },
+      )
+
+      await act(async () => {
+        await result.current.handleBatchSync()
+      })
+
+      expect(syncMutateAsync).not.toHaveBeenCalled()
+      expect(onUpdate).not.toHaveBeenCalled()
+    })
+
+    it('should keep the selection when the sync request fails', async () => {
+      mockUseBatchSyncDocuments.mockReturnValue({
+        mutateAsync: vi.fn().mockRejectedValue(new Error('boom')),
+      } as unknown as ReturnType<typeof useDocument.useBatchSyncDocuments>)
+
+      const onUpdate = vi.fn()
+      const onClearSelection = vi.fn()
+
+      const { result } = renderHook(
+        () =>
+          useDocumentActions({
+            datasetId: 'ds1',
+            selectedIds: ['doc1'],
+            downloadableSelectedIds: [],
+            syncableSelectedDocs: [
+              createMockDoc({ id: 'doc1', data_source_type: DataSourceType.NOTION }),
+            ],
+            onUpdate,
+            onClearSelection,
+          }),
+        { wrapper: createWrapper() },
+      )
+
+      await act(async () => {
+        await result.current.handleBatchSync()
+      })
+
+      expect(onClearSelection).not.toHaveBeenCalled()
+      expect(onUpdate).not.toHaveBeenCalled()
+    })
+  })
+
   describe('all action types', () => {
     it('should handle summary action', async () => {
       mockMutateAsync.mockResolvedValue({ result: 'success' })
@@ -417,6 +552,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate,
             onClearSelection: vi.fn(),
           }),
@@ -443,6 +579,7 @@ describe('useDocumentActions', () => {
             datasetId: 'ds1',
             selectedIds: ['doc1'],
             downloadableSelectedIds: [],
+            syncableSelectedDocs: [],
             onUpdate,
             onClearSelection: vi.fn(),
           }),

--- a/web/app/components/datasets/documents/components/document-list/hooks/__tests__/use-document-actions.spec.ts
+++ b/web/app/components/datasets/documents/components/document-list/hooks/__tests__/use-document-actions.spec.ts
@@ -15,6 +15,8 @@ const mockDisable = vi.fn()
 const mockDelete = vi.fn()
 const mockRetryIndex = vi.fn()
 const mockDownloadZip = vi.fn()
+const mockBatchSyncNotion = vi.fn()
+const mockBatchSyncWebsite = vi.fn()
 let mockIsDownloadingZip = false
 
 vi.mock('@/service/knowledge/use-document', () => ({
@@ -25,6 +27,8 @@ vi.mock('@/service/knowledge/use-document', () => ({
   useDocumentDelete: () => ({ mutateAsync: mockDelete }),
   useDocumentBatchRetryIndex: () => ({ mutateAsync: mockRetryIndex }),
   useDocumentDownloadZip: () => ({ mutateAsync: mockDownloadZip, isPending: mockIsDownloadingZip }),
+  useBatchSyncNotion: () => ({ mutateAsync: mockBatchSyncNotion }),
+  useBatchSyncWebsite: () => ({ mutateAsync: mockBatchSyncWebsite }),
 }))
 
 vi.mock('@langgenius/dify-ui/toast', () => ({
@@ -44,6 +48,7 @@ describe('useDocumentActions', () => {
     datasetId: 'ds-1',
     selectedIds: ['doc-1', 'doc-2'],
     downloadableSelectedIds: ['doc-1'],
+    syncableSelectedDocs: [],
     onUpdate: vi.fn(),
     onClearSelection: vi.fn(),
   }

--- a/web/app/components/datasets/documents/components/document-list/hooks/__tests__/use-document-actions.spec.ts
+++ b/web/app/components/datasets/documents/components/document-list/hooks/__tests__/use-document-actions.spec.ts
@@ -15,6 +15,7 @@ const mockDisable = vi.fn()
 const mockDelete = vi.fn()
 const mockRetryIndex = vi.fn()
 const mockDownloadZip = vi.fn()
+const mockBatchSyncDocuments = vi.fn()
 let mockIsDownloadingZip = false
 
 vi.mock('@/service/knowledge/use-document', () => ({
@@ -25,6 +26,7 @@ vi.mock('@/service/knowledge/use-document', () => ({
   useDocumentDelete: () => ({ mutateAsync: mockDelete }),
   useDocumentBatchRetryIndex: () => ({ mutateAsync: mockRetryIndex }),
   useDocumentDownloadZip: () => ({ mutateAsync: mockDownloadZip, isPending: mockIsDownloadingZip }),
+  useBatchSyncDocuments: () => ({ mutateAsync: mockBatchSyncDocuments }),
 }))
 
 vi.mock('@langgenius/dify-ui/toast', () => ({
@@ -44,6 +46,7 @@ describe('useDocumentActions', () => {
     datasetId: 'ds-1',
     selectedIds: ['doc-1', 'doc-2'],
     downloadableSelectedIds: ['doc-1'],
+    syncableSelectedDocs: [],
     onUpdate: vi.fn(),
     onClearSelection: vi.fn(),
   }

--- a/web/app/components/datasets/documents/components/document-list/hooks/__tests__/use-document-selection.spec.ts
+++ b/web/app/components/datasets/documents/components/document-list/hooks/__tests__/use-document-selection.spec.ts
@@ -103,6 +103,43 @@ describe('useDocumentSelection', () => {
     })
   })
 
+  describe('syncableSelectedDocs', () => {
+    it('should return non-archived NOTION and WEB docs from selection', () => {
+      const docs = [
+        createMockDocument({ id: 'doc1', data_source_type: DataSourceType.FILE }),
+        createMockDocument({ id: 'doc2', data_source_type: DataSourceType.NOTION, archived: false }),
+        createMockDocument({ id: 'doc3', data_source_type: DataSourceType.WEB, archived: false }),
+        createMockDocument({ id: 'doc4', data_source_type: DataSourceType.NOTION, archived: true }),
+      ]
+      const onSelectedIdChange = vi.fn()
+
+      const { result } = renderHook(() =>
+        useDocumentSelection({
+          documents: docs,
+          selectedIds: ['doc1', 'doc2', 'doc3', 'doc4'],
+          onSelectedIdChange,
+        }),
+      )
+
+      expect(result.current.syncableSelectedDocs.map((d) => d.id)).toEqual(['doc2', 'doc3'])
+    })
+
+    it('should return empty array when only FILE docs selected', () => {
+      const docs = [createMockDocument({ id: 'doc1', data_source_type: DataSourceType.FILE })]
+      const onSelectedIdChange = vi.fn()
+
+      const { result } = renderHook(() =>
+        useDocumentSelection({
+          documents: docs,
+          selectedIds: ['doc1'],
+          onSelectedIdChange,
+        }),
+      )
+
+      expect(result.current.syncableSelectedDocs).toEqual([])
+    })
+  })
+
   describe('clearSelection', () => {
     it('should call onSelectedIdChange with empty array', () => {
       const onSelectedIdChange = vi.fn()

--- a/web/app/components/datasets/documents/components/document-list/hooks/__tests__/use-document-selection.spec.ts
+++ b/web/app/components/datasets/documents/components/document-list/hooks/__tests__/use-document-selection.spec.ts
@@ -103,6 +103,100 @@ describe('useDocumentSelection', () => {
     })
   })
 
+  describe('syncableSelectedDocs', () => {
+    it('should return Notion and Website docs from selection', () => {
+      const notionDoc = createMockDocument({
+        id: 'doc1',
+        data_source_type: DataSourceType.NOTION,
+        archived: false,
+      })
+      const webDoc = createMockDocument({
+        id: 'doc2',
+        data_source_type: DataSourceType.WEB,
+        archived: false,
+      })
+      const fileDoc = createMockDocument({
+        id: 'doc3',
+        data_source_type: DataSourceType.FILE,
+        archived: false,
+      })
+      const onSelectedIdChange = vi.fn()
+
+      const { result } = renderHook(() =>
+        useDocumentSelection({
+          documents: [notionDoc, webDoc, fileDoc],
+          selectedIds: ['doc1', 'doc2', 'doc3'],
+          onSelectedIdChange,
+        }),
+      )
+
+      expect(result.current.syncableSelectedDocs).toHaveLength(2)
+      expect(result.current.syncableSelectedDocs.map((d) => d.id)).toEqual(['doc1', 'doc2'])
+    })
+
+    it('should exclude archived documents', () => {
+      const archivedNotion = createMockDocument({
+        id: 'doc1',
+        data_source_type: DataSourceType.NOTION,
+        archived: true,
+      })
+      const activeNotion = createMockDocument({
+        id: 'doc2',
+        data_source_type: DataSourceType.NOTION,
+        archived: false,
+      })
+      const onSelectedIdChange = vi.fn()
+
+      const { result } = renderHook(() =>
+        useDocumentSelection({
+          documents: [archivedNotion, activeNotion],
+          selectedIds: ['doc1', 'doc2'],
+          onSelectedIdChange,
+        }),
+      )
+
+      expect(result.current.syncableSelectedDocs).toHaveLength(1)
+      expect(result.current.syncableSelectedDocs[0]!.id).toBe('doc2')
+    })
+
+    it('should return empty array when only file docs are selected', () => {
+      const docs = [
+        createMockDocument({ id: 'doc1', data_source_type: DataSourceType.FILE }),
+        createMockDocument({ id: 'doc2', data_source_type: DataSourceType.FILE }),
+      ]
+      const onSelectedIdChange = vi.fn()
+
+      const { result } = renderHook(() =>
+        useDocumentSelection({
+          documents: docs,
+          selectedIds: ['doc1', 'doc2'],
+          onSelectedIdChange,
+        }),
+      )
+
+      expect(result.current.syncableSelectedDocs).toEqual([])
+    })
+
+    it('should only include selected docs (not all syncable docs)', () => {
+      const docs = [
+        createMockDocument({ id: 'doc1', data_source_type: DataSourceType.NOTION }),
+        createMockDocument({ id: 'doc2', data_source_type: DataSourceType.WEB }),
+      ]
+      const onSelectedIdChange = vi.fn()
+
+      const { result } = renderHook(() =>
+        useDocumentSelection({
+          documents: docs,
+          selectedIds: ['doc1'],
+          onSelectedIdChange,
+        }),
+      )
+
+      expect(result.current.syncableSelectedDocs).toHaveLength(1)
+      expect(result.current.syncableSelectedDocs[0]!.id).toBe('doc1')
+    })
+  })
+
   describe('clearSelection', () => {
     it('should call onSelectedIdChange with empty array', () => {
       const onSelectedIdChange = vi.fn()

--- a/web/app/components/datasets/documents/components/document-list/hooks/use-document-actions.ts
+++ b/web/app/components/datasets/documents/components/document-list/hooks/use-document-actions.ts
@@ -2,8 +2,10 @@ import type { CommonResponse } from '@/models/common'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { DocumentActionType } from '@/models/datasets'
+import { DataSourceType, DocumentActionType } from '@/models/datasets'
 import {
+  useBatchSyncNotion,
+  useBatchSyncWebsite,
   useDocumentArchive,
   useDocumentBatchRetryIndex,
   useDocumentDelete,
@@ -19,6 +21,7 @@ type UseDocumentActionsOptions = {
   datasetId: string
   selectedIds: string[]
   downloadableSelectedIds: string[]
+  syncableSelectedDocs: Array<{ data_source_type: DataSourceType }>
   onUpdate: () => void
   onClearSelection: () => void
 }
@@ -39,6 +42,7 @@ export const useDocumentActions = ({
   datasetId,
   selectedIds,
   downloadableSelectedIds,
+  syncableSelectedDocs,
   onUpdate,
   onClearSelection,
 }: UseDocumentActionsOptions) => {
@@ -51,6 +55,8 @@ export const useDocumentActions = ({
   const { mutateAsync: deleteDocument } = useDocumentDelete()
   const { mutateAsync: retryIndexDocument } = useDocumentBatchRetryIndex()
   const { mutateAsync: requestDocumentsZip, isPending: isDownloadingZip } = useDocumentDownloadZip()
+  const { mutateAsync: batchSyncNotion } = useBatchSyncNotion()
+  const { mutateAsync: batchSyncWebsite } = useBatchSyncWebsite()
 
   type SupportedActionType =
     | typeof DocumentActionType.archive
@@ -120,10 +126,25 @@ export const useDocumentActions = ({
     downloadBlob({ data: blob, fileName: generateDocsZipFileName() })
   }, [datasetId, downloadableSelectedIds, isDownloadingZip, requestDocumentsZip, t])
 
+  const handleBatchSync = useCallback(async () => {
+    const hasNotion = syncableSelectedDocs.some((doc) => doc.data_source_type === DataSourceType.NOTION)
+    const hasWebsite = syncableSelectedDocs.some((doc) => doc.data_source_type === DataSourceType.WEB)
+    const calls: Promise<CommonResponse>[] = []
+    if (hasNotion) calls.push(batchSyncNotion({ datasetId }))
+    if (hasWebsite) calls.push(batchSyncWebsite({ datasetId }))
+    const results = await Promise.allSettled(calls)
+    if (results.some((r) => r.status === 'rejected'))
+      toast.error(t(($) => $['actionMsg.modifiedUnsuccessfully'], { ns: 'common' }))
+    else
+      toast.success(t(($) => $['actionMsg.modifiedSuccessfully'], { ns: 'common' }))
+    onUpdate()
+  }, [batchSyncNotion, batchSyncWebsite, datasetId, onUpdate, syncableSelectedDocs, t])
+
   return {
     handleAction,
     handleBatchReIndex,
     handleBatchDownload,
+    handleBatchSync,
     isDownloadingZip,
   }
 }

--- a/web/app/components/datasets/documents/components/document-list/hooks/use-document-actions.ts
+++ b/web/app/components/datasets/documents/components/document-list/hooks/use-document-actions.ts
@@ -1,9 +1,11 @@
 import type { CommonResponse } from '@/models/common'
+import type { SimpleDocumentDetail } from '@/models/datasets'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { DocumentActionType } from '@/models/datasets'
 import {
+  useBatchSyncDocuments,
   useDocumentArchive,
   useDocumentBatchRetryIndex,
   useDocumentDelete,
@@ -15,10 +17,13 @@ import {
 import { asyncRunSafe } from '@/utils'
 import { downloadBlob } from '@/utils/download'
 
+type LocalDoc = SimpleDocumentDetail & { percent?: number }
+
 type UseDocumentActionsOptions = {
   datasetId: string
   selectedIds: string[]
   downloadableSelectedIds: string[]
+  syncableSelectedDocs: LocalDoc[]
   onUpdate: () => void
   onClearSelection: () => void
 }
@@ -39,6 +44,7 @@ export const useDocumentActions = ({
   datasetId,
   selectedIds,
   downloadableSelectedIds,
+  syncableSelectedDocs,
   onUpdate,
   onClearSelection,
 }: UseDocumentActionsOptions) => {
@@ -51,6 +57,7 @@ export const useDocumentActions = ({
   const { mutateAsync: deleteDocument } = useDocumentDelete()
   const { mutateAsync: retryIndexDocument } = useDocumentBatchRetryIndex()
   const { mutateAsync: requestDocumentsZip, isPending: isDownloadingZip } = useDocumentDownloadZip()
+  const { mutateAsync: batchSyncDocuments, isPending: isSyncingDocuments } = useBatchSyncDocuments()
 
   type SupportedActionType =
     | typeof DocumentActionType.archive
@@ -120,10 +127,38 @@ export const useDocumentActions = ({
     downloadBlob({ data: blob, fileName: generateDocsZipFileName() })
   }, [datasetId, downloadableSelectedIds, isDownloadingZip, requestDocumentsZip, t])
 
+  const handleBatchSync = useCallback(async () => {
+    if (isSyncingDocuments || syncableSelectedDocs.length === 0) return
+
+    const [e] = await asyncRunSafe<CommonResponse>(
+      batchSyncDocuments({
+        datasetId,
+        documentIds: syncableSelectedDocs.map((doc) => doc.id),
+      }),
+    )
+    if (!e) {
+      onClearSelection()
+      toast.success(t(($) => $['actionMsg.modifiedSuccessfully'], { ns: 'common' }))
+      onUpdate()
+    } else {
+      toast.error(t(($) => $['actionMsg.modifiedUnsuccessfully'], { ns: 'common' }))
+    }
+  }, [
+    batchSyncDocuments,
+    isSyncingDocuments,
+    datasetId,
+    syncableSelectedDocs,
+    onClearSelection,
+    onUpdate,
+    t,
+  ])
+
   return {
     handleAction,
     handleBatchReIndex,
     handleBatchDownload,
+    handleBatchSync,
     isDownloadingZip,
+    isSyncingDocuments,
   }
 }

--- a/web/app/components/datasets/documents/components/document-list/hooks/use-document-selection.ts
+++ b/web/app/components/datasets/documents/components/document-list/hooks/use-document-selection.ts
@@ -26,6 +26,16 @@ export const useDocumentSelection = ({
       .map((doc) => doc.id)
   }, [documents, selectedIds])
 
+  const syncableSelectedDocs = useMemo(() => {
+    const selectedSet = new Set(selectedIds)
+    return documents.filter(
+      (doc) =>
+        selectedSet.has(doc.id)
+        && !doc.archived
+        && (doc.data_source_type === DataSourceType.NOTION || doc.data_source_type === DataSourceType.WEB),
+    )
+  }, [documents, selectedIds])
+
   const clearSelection = useCallback(() => {
     onSelectedIdChange([])
   }, [onSelectedIdChange])
@@ -33,6 +43,7 @@ export const useDocumentSelection = ({
   return {
     hasErrorDocumentsSelected,
     downloadableSelectedIds,
+    syncableSelectedDocs,
     clearSelection,
   }
 }

--- a/web/app/components/datasets/documents/components/document-list/hooks/use-document-selection.ts
+++ b/web/app/components/datasets/documents/components/document-list/hooks/use-document-selection.ts
@@ -26,6 +26,17 @@ export const useDocumentSelection = ({
       .map((doc) => doc.id)
   }, [documents, selectedIds])
 
+  const syncableSelectedDocs = useMemo(() => {
+    const selectedSet = new Set(selectedIds)
+    return documents.filter(
+      (doc) =>
+        selectedSet.has(doc.id) &&
+        !doc.archived &&
+        (doc.data_source_type === DataSourceType.NOTION ||
+          doc.data_source_type === DataSourceType.WEB),
+    )
+  }, [documents, selectedIds])
+
   const clearSelection = useCallback(() => {
     onSelectedIdChange([])
   }, [onSelectedIdChange])
@@ -33,6 +44,7 @@ export const useDocumentSelection = ({
   return {
     hasErrorDocumentsSelected,
     downloadableSelectedIds,
+    syncableSelectedDocs,
     clearSelection,
   }
 }

--- a/web/app/components/datasets/documents/components/documents-header.tsx
+++ b/web/app/components/datasets/documents/components/documents-header.tsx
@@ -57,6 +57,8 @@ type DocumentsHeaderProps = {
 
   // Actions
   onAddDocument: () => void
+  onSyncAll?: () => void
+  isSyncingAll?: boolean
 }
 
 const DocumentsHeader: FC<DocumentsHeaderProps> = ({
@@ -85,6 +87,8 @@ const DocumentsHeader: FC<DocumentsHeaderProps> = ({
   onDeleteMetaData,
   onBuiltInEnabledChange,
   onAddDocument,
+  onSyncAll,
+  isSyncingAll,
 }) => {
   const { t } = useTranslation()
   const docLink = useDocLink()
@@ -206,6 +210,12 @@ const DocumentsHeader: FC<DocumentsHeaderProps> = ({
               isBuiltInEnabled={builtInEnabled}
               onIsBuiltInEnabledChange={onBuiltInEnabledChange}
             />
+          )}
+          {embeddingAvailable && canEditDocument && (isDataSourceNotion || isDataSourceWeb) && onSyncAll && (
+            <Button variant="secondary" onClick={onSyncAll} disabled={isSyncingAll} className="shrink-0">
+              <span className={`mr-1 i-ri-refresh-line size-4 ${isSyncingAll ? 'animate-spin' : ''}`} />
+              {t(($) => $['batchAction.syncAll'], { ns: 'dataset' })}
+            </Button>
           )}
           {embeddingAvailable && canAddDocument && (
             <Button variant="primary" onClick={onAddDocument} className="shrink-0">

--- a/web/app/components/datasets/documents/components/documents-header.tsx
+++ b/web/app/components/datasets/documents/components/documents-header.tsx
@@ -56,6 +56,8 @@ type DocumentsHeaderProps = {
   onBuiltInEnabledChange: (enabled: boolean) => void
 
   // Actions
+  onSyncAll?: () => void
+  isSyncingAll?: boolean
   onAddDocument: () => void
 }
 
@@ -84,6 +86,8 @@ const DocumentsHeader: FC<DocumentsHeaderProps> = ({
   onRenameMetaData,
   onDeleteMetaData,
   onBuiltInEnabledChange,
+  onSyncAll,
+  isSyncingAll = false,
   onAddDocument,
 }) => {
   const { t } = useTranslation()
@@ -200,6 +204,20 @@ const DocumentsHeader: FC<DocumentsHeaderProps> = ({
               onIsBuiltInEnabledChange={onBuiltInEnabledChange}
             />
           )}
+          {embeddingAvailable &&
+            canEditDocument &&
+            (isDataSourceNotion || isDataSourceWeb) &&
+            onSyncAll && (
+              <Button
+                variant="secondary"
+                className="shrink-0"
+                loading={isSyncingAll}
+                onClick={onSyncAll}
+              >
+                <span className="i-ri-loop-left-line size-4" />
+                {t(($) => $['batchAction.syncAll'], { ns: 'dataset' })}
+              </Button>
+            )}
           {embeddingAvailable && canAddDocument && (
             <Button variant="primary" onClick={onAddDocument} className="shrink-0">
               <span className="i-heroicons-plus-solid size-4 stroke-current" />

--- a/web/app/components/datasets/documents/components/list.tsx
+++ b/web/app/components/datasets/documents/components/list.tsx
@@ -90,7 +90,7 @@ const DocumentList = ({
   })
 
   // Selection
-  const { hasErrorDocumentsSelected, downloadableSelectedIds, clearSelection } =
+  const { hasErrorDocumentsSelected, downloadableSelectedIds, syncableSelectedDocs, clearSelection } =
     useDocumentSelection({
       documents,
       selectedIds,
@@ -99,10 +99,11 @@ const DocumentList = ({
   const documentIds = useMemo(() => documents.map((doc) => doc.id), [documents])
 
   // Actions
-  const { handleAction, handleBatchReIndex, handleBatchDownload } = useDocumentActions({
+  const { handleAction, handleBatchReIndex, handleBatchDownload, handleBatchSync } = useDocumentActions({
     datasetId,
     selectedIds,
     downloadableSelectedIds,
+    syncableSelectedDocs,
     onUpdate,
     onClearSelection: clearSelection,
   })
@@ -243,6 +244,11 @@ const DocumentList = ({
           onBatchReIndex={
             datasetACLCapabilities.canEdit && hasErrorDocumentsSelected
               ? handleBatchReIndex
+              : undefined
+          }
+          onBatchSync={
+            datasetACLCapabilities.canEdit && syncableSelectedDocs.length > 0
+              ? handleBatchSync
               : undefined
           }
           onCancel={clearSelection}

--- a/web/app/components/datasets/documents/components/list.tsx
+++ b/web/app/components/datasets/documents/components/list.tsx
@@ -95,19 +95,30 @@ const DocumentList = ({
   })
 
   // Selection
-  const { hasErrorDocumentsSelected, downloadableSelectedIds, clearSelection } =
-    useDocumentSelection({
-      documents,
-      selectedIds,
-      onSelectedIdChange,
-    })
+  const {
+    hasErrorDocumentsSelected,
+    downloadableSelectedIds,
+    syncableSelectedDocs,
+    clearSelection,
+  } = useDocumentSelection({
+    documents,
+    selectedIds,
+    onSelectedIdChange,
+  })
   const documentIds = useMemo(() => documents.map((doc) => doc.id), [documents])
 
   // Actions
-  const { handleAction, handleBatchReIndex, handleBatchDownload } = useDocumentActions({
+  const {
+    handleAction,
+    handleBatchReIndex,
+    handleBatchDownload,
+    handleBatchSync,
+    isSyncingDocuments,
+  } = useDocumentActions({
     datasetId,
     selectedIds,
     downloadableSelectedIds,
+    syncableSelectedDocs,
     onUpdate,
     onClearSelection: clearSelection,
   })
@@ -250,6 +261,12 @@ const DocumentList = ({
               ? handleBatchReIndex
               : undefined
           }
+          onBatchSync={
+            datasetACLCapabilities.canEdit && syncableSelectedDocs.length > 0
+              ? handleBatchSync
+              : undefined
+          }
+          isSyncing={isSyncingDocuments}
           onCancel={clearSelection}
         />
       )}

--- a/web/app/components/datasets/documents/detail/completed/common/__tests__/batch-action.spec.tsx
+++ b/web/app/components/datasets/documents/detail/completed/common/__tests__/batch-action.spec.tsx
@@ -149,6 +149,27 @@ describe('BatchAction', () => {
       expect(screen.getByText(/batchAction\.reIndex/i)).toBeInTheDocument()
     })
 
+    it('should render sync button when onBatchSync is provided', () => {
+      render(<BatchAction {...defaultProps} onBatchSync={vi.fn()} />)
+
+      expect(screen.getByText(/batchAction\.sync/i)).toBeInTheDocument()
+    })
+
+    it('should not render sync button when onBatchSync is not provided', () => {
+      render(<BatchAction {...defaultProps} />)
+
+      expect(screen.queryByText(/batchAction\.sync/i)).not.toBeInTheDocument()
+    })
+
+    it('should call onBatchSync when sync button is clicked', () => {
+      const mockOnBatchSync = vi.fn()
+      render(<BatchAction {...defaultProps} onBatchSync={mockOnBatchSync} />)
+
+      fireEvent.click(screen.getByText(/batchAction\.sync/i))
+
+      expect(mockOnBatchSync).toHaveBeenCalledTimes(1)
+    })
+
     it('should call onBatchDownload when download button is clicked', () => {
       const mockOnBatchDownload = vi.fn()
       render(<BatchAction {...defaultProps} onBatchDownload={mockOnBatchDownload} />)

--- a/web/app/components/datasets/documents/detail/completed/common/batch-action.tsx
+++ b/web/app/components/datasets/documents/detail/completed/common/batch-action.tsx
@@ -17,6 +17,7 @@ import {
   RiDeleteBinLine,
   RiDownload2Line,
   RiDraftLine,
+  RiLoopLeftLine,
   RiRefreshLine,
 } from '@remixicon/react'
 import { useSuspenseQuery } from '@tanstack/react-query'
@@ -39,6 +40,8 @@ type IBatchActionProps = {
   onArchive?: () => void
   onEditMetadata?: () => void
   onBatchReIndex?: () => void
+  onBatchSync?: () => void
+  isSyncing?: boolean
   onCancel: () => void
 }
 
@@ -53,6 +56,8 @@ const BatchAction: FC<IBatchActionProps> = ({
   onBatchDelete,
   onEditMetadata,
   onBatchReIndex,
+  onBatchSync,
+  isSyncing = false,
   onCancel,
 }) => {
   const { t } = useTranslation()
@@ -118,6 +123,12 @@ const BatchAction: FC<IBatchActionProps> = ({
           <Button variant="ghost" onClick={onBatchReIndex}>
             <RiRefreshLine className="size-4" />
             <span>{t(($) => $[`${i18nPrefix}.reIndex`], { ns: 'dataset' })}</span>
+          </Button>
+        )}
+        {onBatchSync && (
+          <Button variant="ghost" onClick={onBatchSync} loading={isSyncing}>
+            <RiLoopLeftLine className="size-4" />
+            <span>{t(($) => $[`${i18nPrefix}.sync`], { ns: 'dataset' })}</span>
           </Button>
         )}
         {onBatchDownload && (

--- a/web/app/components/datasets/documents/detail/completed/common/batch-action.tsx
+++ b/web/app/components/datasets/documents/detail/completed/common/batch-action.tsx
@@ -39,6 +39,7 @@ type IBatchActionProps = {
   onArchive?: () => void
   onEditMetadata?: () => void
   onBatchReIndex?: () => void
+  onBatchSync?: () => void
   onCancel: () => void
 }
 
@@ -53,6 +54,7 @@ const BatchAction: FC<IBatchActionProps> = ({
   onBatchDelete,
   onEditMetadata,
   onBatchReIndex,
+  onBatchSync,
   onCancel,
 }) => {
   const { t } = useTranslation()
@@ -125,6 +127,14 @@ const BatchAction: FC<IBatchActionProps> = ({
             <RiRefreshLine className="size-4" />
             <span className="px-0.5">
               {t(($) => $[`${i18nPrefix}.reIndex`], { ns: 'dataset' })}
+            </span>
+          </Button>
+        )}
+        {onBatchSync && (
+          <Button variant="ghost" className="gap-x-0.5 px-3" onClick={onBatchSync}>
+            <RiRefreshLine className="size-4" />
+            <span className="px-0.5">
+              {t(($) => $[`${i18nPrefix}.sync`], { ns: 'dataset' })}
             </span>
           </Button>
         )}

--- a/web/app/components/datasets/documents/index.tsx
+++ b/web/app/components/datasets/documents/index.tsx
@@ -1,7 +1,9 @@
 'use client'
 import type { FC } from 'react'
 import { useAtomValue } from 'jotai'
-import { useCallback } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from '@langgenius/dify-ui/toast'
 import Loading from '@/app/components/base/loading'
 import { userProfileIdAtom } from '@/context/account-state'
 import { useDatasetDetailContextWithSelector } from '@/context/dataset-detail'
@@ -10,6 +12,8 @@ import { useProviderContext } from '@/context/provider-context'
 import { DataSourceType } from '@/models/datasets'
 import { useRouter } from '@/next/navigation'
 import {
+  useBatchSyncNotion,
+  useBatchSyncWebsite,
   useDocumentList,
   useInvalidDocumentDetail,
   useInvalidDocumentList,
@@ -31,7 +35,11 @@ const POLLING_INTERVAL = 2500
 const TERMINAL_INDEXING_STATUSES = new Set(['completed', 'paused', 'error'])
 const FORCED_POLLING_STATUSES = new Set(['queuing', 'indexing', 'paused'])
 
+const MAX_WAIT_MS = 300_000
+const MIN_WAIT_MS = 3_000
+
 const Documents: FC<IDocumentsProps> = ({ datasetId }) => {
+  const { t } = useTranslation()
   const router = useRouter()
   const { plan } = useProviderContext()
   const isFreePlan = plan.type === 'sandbox'
@@ -131,6 +139,54 @@ const Documents: FC<IDocumentsProps> = ({ datasetId }) => {
     router.push(`/datasets/${datasetId}/documents/create`)
   }, [dataset?.runtime_mode, datasetACLCapabilities.canUse, datasetId, router])
 
+  const { mutateAsync: batchSyncNotion } = useBatchSyncNotion()
+  const { mutateAsync: batchSyncWebsite } = useBatchSyncWebsite()
+  const [isSyncingAll, setIsSyncingAll] = useState(false)
+  const documentsListRef = useRef(documentsRes?.data)
+  useEffect(() => { documentsListRef.current = documentsRes?.data }, [documentsRes?.data])
+
+  const handleSyncAll = useCallback(async () => {
+    setIsSyncingAll(true)
+    try {
+      const calls = []
+      if (dataset?.data_source_type === DataSourceType.NOTION)
+        calls.push(batchSyncNotion({ datasetId }))
+      else if (dataset?.data_source_type === DataSourceType.WEB)
+        calls.push(batchSyncWebsite({ datasetId }))
+      else {
+        calls.push(batchSyncNotion({ datasetId }))
+        calls.push(batchSyncWebsite({ datasetId }))
+      }
+      const results = await Promise.allSettled(calls)
+      if (results.some((r) => r.status === 'rejected')) {
+        toast.error(t(($) => $['actionMsg.modifiedUnsuccessfully'], { ns: 'common' }))
+        return
+      }
+      const startTime = Date.now()
+      await new Promise<void>((resolve) => {
+        const poll = () => {
+          invalidDocumentList()
+          setTimeout(() => {
+            const elapsed = Date.now() - startTime
+            if (elapsed > MAX_WAIT_MS) { resolve(); return }
+            const docs = documentsListRef.current ?? []
+            const allTerminal =
+              docs.length === 0 || docs.every((d) => TERMINAL_INDEXING_STATUSES.has(d.indexing_status))
+            if (allTerminal && elapsed >= MIN_WAIT_MS)
+              resolve()
+            else
+              poll()
+          }, POLLING_INTERVAL)
+        }
+        poll()
+      })
+      toast.success(t(($) => $['actionMsg.modifiedSuccessfully'], { ns: 'common' }))
+    }
+    finally {
+      setIsSyncingAll(false)
+    }
+  }, [batchSyncNotion, batchSyncWebsite, dataset?.data_source_type, datasetId, invalidDocumentList, t])
+
   const total = documentsRes?.total || 0
   const documentsList = documentsRes?.data
 
@@ -199,6 +255,8 @@ const Documents: FC<IDocumentsProps> = ({ datasetId }) => {
         onDeleteMetaData={handleDeleteMetaData}
         onBuiltInEnabledChange={setBuiltInEnabled}
         onAddDocument={routeToDocCreate}
+        onSyncAll={handleSyncAll}
+        isSyncingAll={isSyncingAll}
       />
       <div className="flex h-0 grow flex-col px-6 pt-4">{renderContent()}</div>
     </div>

--- a/web/app/components/datasets/documents/index.tsx
+++ b/web/app/components/datasets/documents/index.tsx
@@ -1,9 +1,11 @@
 'use client'
 
 import type { FC } from 'react'
+import { toast } from '@langgenius/dify-ui/toast'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { useAtomValue } from 'jotai'
 import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
 import Loading from '@/app/components/base/loading'
 import { useDatasetDetailContextWithSelector } from '@/context/dataset-detail'
 import { workspacePermissionKeysAtom } from '@/context/permission-state'
@@ -12,12 +14,15 @@ import { userProfileQueryOptions } from '@/features/account-profile/client'
 import { DataSourceType } from '@/models/datasets'
 import { useRouter } from '@/next/navigation'
 import {
+  useBatchSyncNotion,
+  useBatchSyncWebsite,
   useDocumentList,
   useInvalidDocumentDetail,
   useInvalidDocumentList,
 } from '@/service/knowledge/use-document'
 import { useChildSegmentListKey, useSegmentListKey } from '@/service/knowledge/use-segment'
 import { useInvalid } from '@/service/use-base'
+import { asyncRunSafe } from '@/utils'
 import { getDatasetACLCapabilities } from '@/utils/permission'
 import useEditDocumentMetadata from '../metadata/hooks/use-edit-dataset-metadata'
 import DocumentsHeader from './components/documents-header'
@@ -35,6 +40,7 @@ const FORCED_POLLING_STATUSES = new Set(['queuing', 'indexing', 'paused'])
 
 const Documents: FC<IDocumentsProps> = ({ datasetId }) => {
   const router = useRouter()
+  const { t } = useTranslation()
   const { plan } = useProviderContext()
   const isFreePlan = plan.type === 'sandbox'
 
@@ -126,6 +132,41 @@ const Documents: FC<IDocumentsProps> = ({ datasetId }) => {
     onUpdateDocList: invalidDocumentList,
   })
 
+  const total = documentsRes?.total || 0
+  const documentsList = documentsRes?.data
+
+  const { mutateAsync: batchSyncNotion, isPending: isSyncingNotion } = useBatchSyncNotion()
+  const { mutateAsync: batchSyncWebsite, isPending: isSyncingWebsite } = useBatchSyncWebsite()
+  const isSyncingAll = isSyncingNotion || isSyncingWebsite
+
+  const handleSyncAll = useCallback(async () => {
+    const isNotion = dataset?.data_source_type === DataSourceType.NOTION
+    const isWebsite = dataset?.data_source_type === DataSourceType.WEB
+    // The Sync All button is only rendered for Notion/website knowledge bases.
+    if (!isNotion && !isWebsite) return
+
+    const [e] = await asyncRunSafe(
+      isNotion ? batchSyncNotion({ datasetId }) : batchSyncWebsite({ datasetId }),
+    )
+    if (e) {
+      toast.error(t(($) => $['actionMsg.modifiedUnsuccessfully'], { ns: 'common' }))
+      return
+    }
+
+    // The request only queues the sync; the work happens on Celery workers. Refresh once so the
+    // documents flip out of a terminal status, after which the list's own refetch interval
+    // (see useDocumentList above) reports per-document progress until everything settles.
+    invalidDocumentList()
+    toast.success(t(($) => $['actionMsg.modifiedSuccessfully'], { ns: 'common' }))
+  }, [
+    batchSyncNotion,
+    batchSyncWebsite,
+    dataset?.data_source_type,
+    datasetId,
+    invalidDocumentList,
+    t,
+  ])
+
   // Route to document creation page
   const routeToDocCreate = useCallback(() => {
     if (!datasetACLCapabilities.canUse) return
@@ -135,9 +176,6 @@ const Documents: FC<IDocumentsProps> = ({ datasetId }) => {
     }
     router.push(`/datasets/${datasetId}/documents/create`)
   }, [dataset?.runtime_mode, datasetACLCapabilities.canUse, datasetId, router])
-
-  const total = documentsRes?.total || 0
-  const documentsList = documentsRes?.data
 
   // Render content based on loading and data state
   const renderContent = () => {
@@ -203,6 +241,8 @@ const Documents: FC<IDocumentsProps> = ({ datasetId }) => {
         onRenameMetaData={handleRename}
         onDeleteMetaData={handleDeleteMetaData}
         onBuiltInEnabledChange={setBuiltInEnabled}
+        onSyncAll={datasetACLCapabilities.canEdit ? handleSyncAll : undefined}
+        isSyncingAll={isSyncingAll}
         onAddDocument={routeToDocCreate}
       />
       <div className="flex h-0 grow flex-col px-6 pt-4">{renderContent()}</div>

--- a/web/i18n/ar-TN/dataset.json
+++ b/web/i18n/ar-TN/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "تمكين",
   "batchAction.reIndex": "إعادة الفهرسة",
   "batchAction.selected": "محدد",
+  "batchAction.sync": "مزامنة",
+  "batchAction.syncAll": "مزامنة الكل",
   "chunkingMode.general": "عام",
   "chunkingMode.graph": "رسم بياني",
   "chunkingMode.parentChild": "الأصل والطفل",

--- a/web/i18n/de-DE/dataset.json
+++ b/web/i18n/de-DE/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "Ermöglichen",
   "batchAction.reIndex": "Neu indexieren",
   "batchAction.selected": "Ausgewählt",
+  "batchAction.sync": "Synchronisieren",
+  "batchAction.syncAll": "Alle synchronisieren",
   "chunkingMode.general": "Allgemein",
   "chunkingMode.graph": "Graph",
   "chunkingMode.parentChild": "Eltern-Kind",

--- a/web/i18n/en-US/dataset.json
+++ b/web/i18n/en-US/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "Enable",
   "batchAction.reIndex": "Re-index",
   "batchAction.selected": "Selected",
+  "batchAction.sync": "Sync",
+  "batchAction.syncAll": "Sync All",
   "chunkingMode.general": "General",
   "chunkingMode.graph": "Graph",
   "chunkingMode.parentChild": "Parent-child",

--- a/web/i18n/es-ES/dataset.json
+++ b/web/i18n/es-ES/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "Habilitar",
   "batchAction.reIndex": "Reindexar",
   "batchAction.selected": "Seleccionado",
+  "batchAction.sync": "Sincronizar",
+  "batchAction.syncAll": "Sincronizar todo",
   "chunkingMode.general": "General",
   "chunkingMode.graph": "gráfico",
   "chunkingMode.parentChild": "Padre-hijo",

--- a/web/i18n/fa-IR/dataset.json
+++ b/web/i18n/fa-IR/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "فعال",
   "batchAction.reIndex": "بازفهرست‌گذاری",
   "batchAction.selected": "انتخاب",
+  "batchAction.sync": "همگام‌سازی",
+  "batchAction.syncAll": "همگام‌سازی همه",
   "chunkingMode.general": "عمومی",
   "chunkingMode.graph": "گراف",
   "chunkingMode.parentChild": "پدر و مادر و فرزند",

--- a/web/i18n/fr-FR/dataset.json
+++ b/web/i18n/fr-FR/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "Activer",
   "batchAction.reIndex": "Réindexer",
   "batchAction.selected": "Sélectionné",
+  "batchAction.sync": "Synchroniser",
+  "batchAction.syncAll": "Tout synchroniser",
   "chunkingMode.general": "Généralités",
   "chunkingMode.graph": "Graphique",
   "chunkingMode.parentChild": "Parent-enfant",

--- a/web/i18n/hi-IN/dataset.json
+++ b/web/i18n/hi-IN/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "योग्य बनाना",
   "batchAction.reIndex": "पुनः अनुक्रमित करें",
   "batchAction.selected": "चयनित",
+  "batchAction.sync": "सिंक",
+  "batchAction.syncAll": "सभी सिंक करें",
   "chunkingMode.general": "सामान्य",
   "chunkingMode.graph": "ग्राफ",
   "chunkingMode.parentChild": "माता-पिता का बच्चा",

--- a/web/i18n/hi-IN/dataset.json
+++ b/web/i18n/hi-IN/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "योग्य बनाना",
   "batchAction.reIndex": "पुनः अनुक्रमित करें",
   "batchAction.selected": "चयनित",
+  "batchAction.sync": "सिंक करें",
+  "batchAction.syncAll": "सभी सिंक करें",
   "chunkingMode.general": "सामान्य",
   "chunkingMode.graph": "ग्राफ",
   "chunkingMode.parentChild": "माता-पिता का बच्चा",

--- a/web/i18n/id-ID/dataset.json
+++ b/web/i18n/id-ID/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "Mengaktifkan",
   "batchAction.reIndex": "Indeks ulang",
   "batchAction.selected": "Dipilih",
+  "batchAction.sync": "Sinkronkan",
+  "batchAction.syncAll": "Sinkronkan Semua",
   "chunkingMode.general": "Umum",
   "chunkingMode.graph": "Grafik",
   "chunkingMode.parentChild": "Orang tua-anak",

--- a/web/i18n/it-IT/dataset.json
+++ b/web/i18n/it-IT/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "Abilitare",
   "batchAction.reIndex": "Reindicizza",
   "batchAction.selected": "Selezionato",
+  "batchAction.sync": "Sincronizza",
+  "batchAction.syncAll": "Sincronizza tutto",
   "chunkingMode.general": "Generale",
   "chunkingMode.graph": "Grafico",
   "chunkingMode.parentChild": "Genitore-figlio",

--- a/web/i18n/ja-JP/dataset.json
+++ b/web/i18n/ja-JP/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "有効にする",
   "batchAction.reIndex": "再インデックス",
   "batchAction.selected": "選択済み",
+  "batchAction.sync": "同期",
+  "batchAction.syncAll": "全て同期",
   "chunkingMode.general": "汎用",
   "chunkingMode.graph": "グラフ",
   "chunkingMode.parentChild": "親子",

--- a/web/i18n/ko-KR/dataset.json
+++ b/web/i18n/ko-KR/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "사용",
   "batchAction.reIndex": "재색인",
   "batchAction.selected": "선택한",
+  "batchAction.sync": "동기화",
+  "batchAction.syncAll": "모두 동기화",
   "chunkingMode.general": "일반",
   "chunkingMode.graph": "그래프",
   "chunkingMode.parentChild": "부모 - 자식",

--- a/web/i18n/lo-LA/dataset.json
+++ b/web/i18n/lo-LA/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "ເປີດໃຊ້ງານ",
   "batchAction.reIndex": "ສ້າງດັດຊະນີໃໝ່",
   "batchAction.selected": "ເລືອກແລ້ວ",
+  "batchAction.sync": "ຊິງຄ໌",
+  "batchAction.syncAll": "ຊິງຄ໌ທັງໝົດ",
   "chunkingMode.general": "ທົ່ວໄປ",
   "chunkingMode.graph": "ກຣາຟ",
   "chunkingMode.parentChild": "ແມ່-ລູກ",

--- a/web/i18n/nl-NL/dataset.json
+++ b/web/i18n/nl-NL/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "Enable",
   "batchAction.reIndex": "Re-index",
   "batchAction.selected": "Selected",
+  "batchAction.sync": "Synchroniseren",
+  "batchAction.syncAll": "Alles synchroniseren",
   "chunkingMode.general": "General",
   "chunkingMode.graph": "Graph",
   "chunkingMode.parentChild": "Parent-child",

--- a/web/i18n/pl-PL/dataset.json
+++ b/web/i18n/pl-PL/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "Umożliwiać",
   "batchAction.reIndex": "Ponowna indeksacja",
   "batchAction.selected": "Wybrany",
+  "batchAction.sync": "Synchronizuj",
+  "batchAction.syncAll": "Synchronizuj wszystko",
   "chunkingMode.general": "Ogólne",
   "chunkingMode.graph": "Wykres",
   "chunkingMode.parentChild": "Rodzic-dziecko",

--- a/web/i18n/pt-BR/dataset.json
+++ b/web/i18n/pt-BR/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "Habilitar",
   "batchAction.reIndex": "Reindexar",
   "batchAction.selected": "Selecionado",
+  "batchAction.sync": "Sincronizar",
+  "batchAction.syncAll": "Sincronizar tudo",
   "chunkingMode.general": "Geral",
   "chunkingMode.graph": "Gráfico",
   "chunkingMode.parentChild": "Pai-filho",

--- a/web/i18n/ro-RO/dataset.json
+++ b/web/i18n/ro-RO/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "Activa",
   "batchAction.reIndex": "Reindexare",
   "batchAction.selected": "Selectat",
+  "batchAction.sync": "Sincronizare",
+  "batchAction.syncAll": "Sincronizare totală",
   "chunkingMode.general": "General",
   "chunkingMode.graph": "Grafic",
   "chunkingMode.parentChild": "Părinte-copil",

--- a/web/i18n/ro-RO/dataset.json
+++ b/web/i18n/ro-RO/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "Activa",
   "batchAction.reIndex": "Reindexare",
   "batchAction.selected": "Selectat",
+  "batchAction.sync": "Sincronizare",
+  "batchAction.syncAll": "Sincronizează tot",
   "chunkingMode.general": "General",
   "chunkingMode.graph": "Grafic",
   "chunkingMode.parentChild": "Părinte-copil",

--- a/web/i18n/ru-RU/dataset.json
+++ b/web/i18n/ru-RU/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "Давать возможность",
   "batchAction.reIndex": "Переиндексация",
   "batchAction.selected": "Выбранный",
+  "batchAction.sync": "Синхронизировать",
+  "batchAction.syncAll": "Синхронизировать все",
   "chunkingMode.general": "Общее",
   "chunkingMode.graph": "График",
   "chunkingMode.parentChild": "Родитель-дочерний",

--- a/web/i18n/ru-RU/dataset.json
+++ b/web/i18n/ru-RU/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "Давать возможность",
   "batchAction.reIndex": "Переиндексация",
   "batchAction.selected": "Выбранный",
+  "batchAction.sync": "Синхронизировать",
+  "batchAction.syncAll": "Синхронизировать всё",
   "chunkingMode.general": "Общее",
   "chunkingMode.graph": "График",
   "chunkingMode.parentChild": "Родитель-дочерний",

--- a/web/i18n/sl-SI/dataset.json
+++ b/web/i18n/sl-SI/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "Omogočiti",
   "batchAction.reIndex": "Ponovno indeksiraj",
   "batchAction.selected": "Izbrane",
+  "batchAction.sync": "Sinhroniziraj",
+  "batchAction.syncAll": "Sinhroniziraj vse",
   "chunkingMode.general": "Splošno",
   "chunkingMode.graph": "Graf",
   "chunkingMode.parentChild": "Starš-otrok",

--- a/web/i18n/th-TH/dataset.json
+++ b/web/i18n/th-TH/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "เปิด",
   "batchAction.reIndex": "สร้างดัชนีใหม่",
   "batchAction.selected": "เลือก",
+  "batchAction.sync": "ซิงค์",
+  "batchAction.syncAll": "ซิงค์ทั้งหมด",
   "chunkingMode.general": "ทั่วไป",
   "chunkingMode.graph": "กราฟ",
   "chunkingMode.parentChild": "พ่อแม่ลูก",

--- a/web/i18n/tr-TR/dataset.json
+++ b/web/i18n/tr-TR/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "Etkinleştir",
   "batchAction.reIndex": "Yeniden dizinle",
   "batchAction.selected": "Seçilmiş",
+  "batchAction.sync": "Senkronize Et",
+  "batchAction.syncAll": "Tümünü Senkronize Et",
   "chunkingMode.general": "Genel",
   "chunkingMode.graph": "Grafik",
   "chunkingMode.parentChild": "Ebeveyn-çocuk",

--- a/web/i18n/uk-UA/dataset.json
+++ b/web/i18n/uk-UA/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "Вмикати",
   "batchAction.reIndex": "Повторно індексувати",
   "batchAction.selected": "Вибрані",
+  "batchAction.sync": "Синхронізувати",
+  "batchAction.syncAll": "Синхронізувати все",
   "chunkingMode.general": "Загальне",
   "chunkingMode.graph": "Графік",
   "chunkingMode.parentChild": "Батьки-діти",

--- a/web/i18n/vi-VN/dataset.json
+++ b/web/i18n/vi-VN/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "Kích hoạt",
   "batchAction.reIndex": "Tái lập chỉ mục",
   "batchAction.selected": "Chọn",
+  "batchAction.sync": "Đồng bộ",
+  "batchAction.syncAll": "Đồng bộ tất cả",
   "chunkingMode.general": "Tổng quát",
   "chunkingMode.graph": "Đồ thị",
   "chunkingMode.parentChild": "Cha mẹ-con cái",

--- a/web/i18n/zh-Hans/dataset.json
+++ b/web/i18n/zh-Hans/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "启用",
   "batchAction.reIndex": "重新索引",
   "batchAction.selected": "已选择",
+  "batchAction.sync": "同步",
+  "batchAction.syncAll": "全部同步",
   "chunkingMode.general": "通用",
   "chunkingMode.graph": "图",
   "chunkingMode.parentChild": "父子",

--- a/web/i18n/zh-Hant/dataset.json
+++ b/web/i18n/zh-Hant/dataset.json
@@ -11,6 +11,8 @@
   "batchAction.enable": "使",
   "batchAction.reIndex": "重新建立索引",
   "batchAction.selected": "選擇",
+  "batchAction.sync": "同步",
+  "batchAction.syncAll": "全部同步",
   "chunkingMode.general": "常規",
   "chunkingMode.graph": "圖形",
   "chunkingMode.parentChild": "父子",

--- a/web/service/knowledge/__tests__/use-document-sync.spec.tsx
+++ b/web/service/knowledge/__tests__/use-document-sync.spec.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+import { useBatchSyncDocuments, useBatchSyncNotion, useBatchSyncWebsite } from '../use-document'
+
+// Mocked through the module path rather than an import binding: web/service/** may not import the
+// legacy fetch helpers directly (no-restricted-imports in lint.config.ts).
+const mockPost = vi.hoisted(() => vi.fn())
+const mockGet = vi.hoisted(() => vi.fn())
+
+vi.mock('../../base', () => ({
+  post: mockPost,
+  get: mockGet,
+  patch: vi.fn(),
+  del: vi.fn(),
+}))
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('document sync hooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPost.mockResolvedValue({ result: 'success' })
+    mockGet.mockResolvedValue({ result: 'success' })
+  })
+
+  // Guards the bug this endpoint exists to fix: the batch action must sync the documents the user
+  // selected, not every document in the knowledge base.
+  it('should post the selected document ids to the batch-sync endpoint', async () => {
+    const { result } = renderHook(() => useBatchSyncDocuments(), { wrapper: createWrapper() })
+
+    await act(async () => {
+      await result.current.mutateAsync({ datasetId: 'ds1', documentIds: ['doc1', 'doc2'] })
+    })
+
+    expect(mockPost).toHaveBeenCalledWith('/datasets/ds1/documents/batch-sync', {
+      body: { document_ids: ['doc1', 'doc2'] },
+    })
+    expect(mockGet).not.toHaveBeenCalled()
+  })
+
+  it('should sync the whole dataset for Notion Sync All', async () => {
+    const { result } = renderHook(() => useBatchSyncNotion(), { wrapper: createWrapper() })
+
+    await act(async () => {
+      await result.current.mutateAsync({ datasetId: 'ds1' })
+    })
+
+    expect(mockGet).toHaveBeenCalledWith('/datasets/ds1/notion/sync')
+  })
+
+  it('should sync the whole dataset for website Sync All', async () => {
+    const { result } = renderHook(() => useBatchSyncWebsite(), { wrapper: createWrapper() })
+
+    await act(async () => {
+      await result.current.mutateAsync({ datasetId: 'ds1' })
+    })
+
+    expect(mockGet).toHaveBeenCalledWith('/datasets/ds1/website-sync')
+  })
+})

--- a/web/service/knowledge/use-document.ts
+++ b/web/service/knowledge/use-document.ts
@@ -145,6 +145,22 @@ export const useSyncWebsite = () => {
   })
 }
 
+export const useBatchSyncNotion = () => {
+  return useMutation({
+    mutationFn: ({ datasetId }: { datasetId: string }) => {
+      return get<CommonResponse>(`/datasets/${datasetId}/notion/sync`)
+    },
+  })
+}
+
+export const useBatchSyncWebsite = () => {
+  return useMutation({
+    mutationFn: ({ datasetId }: { datasetId: string }) => {
+      return get<CommonResponse>(`/datasets/${datasetId}/website-sync`)
+    },
+  })
+}
+
 const useDocumentDetailKey = [NAME_SPACE, 'documentDetail', 'withoutMetaData']
 type DocumentDetailRefetchInterval = UseQueryOptions<DocumentDetailResponse>['refetchInterval']
 

--- a/web/service/knowledge/use-document.ts
+++ b/web/service/knowledge/use-document.ts
@@ -145,6 +145,32 @@ export const useSyncWebsite = () => {
   })
 }
 
+export const useBatchSyncNotion = () => {
+  return useMutation({
+    mutationFn: ({ datasetId }: { datasetId: string }) => {
+      return get<CommonResponse>(`/datasets/${datasetId}/notion/sync`)
+    },
+  })
+}
+
+export const useBatchSyncWebsite = () => {
+  return useMutation({
+    mutationFn: ({ datasetId }: { datasetId: string }) => {
+      return get<CommonResponse>(`/datasets/${datasetId}/website-sync`)
+    },
+  })
+}
+
+export const useBatchSyncDocuments = () => {
+  return useMutation({
+    mutationFn: ({ datasetId, documentIds }: { datasetId: string; documentIds: string[] }) => {
+      return post<CommonResponse>(`/datasets/${datasetId}/documents/batch-sync`, {
+        body: { document_ids: documentIds },
+      })
+    },
+  })
+}
+
 const useDocumentDetailKey = [NAME_SPACE, 'documentDetail', 'withoutMetaData']
 type DocumentDetailRefetchInterval = UseQueryOptions<DocumentDetailResponse>['refetchInterval']
 


### PR DESCRIPTION
## Summary

Fixes #38168

- Add **Sync** button to the batch action bar when Notion/Website documents are selected
- Add **Sync All** button to the document list header for Notion/Website-backed knowledge bases
- Add `GET /datasets/<id>/website-sync` backend endpoint (mirrors existing Notion sync API)

## Screenshots

| Before | After |
|--------|-------|
| Batch action bar: Re-index, Download, Delete | Batch action bar: Re-index, **Sync**, Download, Delete (for Notion/Website docs) |
| No sync option in document list header | **Sync All** button in header for Notion/Website knowledge bases |

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
- [x] This PR is linked to an issue (#38168)
- [x] There are test cases for the new functionality
- [x] All 24 locale files updated with `batchAction.sync` and `batchAction.syncAll` keys
- [x] Frontend: `pnpm exec vp staged` compatible changes