### PR TITLE
fix(agent): avoid mismatched tool observations

### DIFF
--- a/api/core/app/apps/agent_app/app_runner.py
+++ b/api/core/app/apps/agent_app/app_runner.py
@@ -155,6 +155,7 @@ class _AgentProcessRecorder:
         self._thinking_by_index: dict[int, str] = {}
         self._tool_by_index: dict[int, str] = {}
         self._tool_by_call_id: dict[str, str] = {}
+        self._open_tool_by_name: dict[str, set[str]] = {}
 
     def handle_stream_event(self, event: AgentBackendStreamInternalEvent) -> None:
         data = event.data
@@ -220,7 +221,11 @@ class _AgentProcessRecorder:
 
         content = data.get("content")
         if content is not None:
-            self._record_tool_observation(None, content)
+            self._record_tool_observation(
+                tool_call_id=_string_or_none(data.get("tool_call_id")),
+                tool_name=_string_or_none(data.get("tool_name")),
+                observation=content,
+            )
 
     def _append_thinking(self, index: int, content_delta: str) -> None:
         thought_id = self._thinking_by_index.get(index)
@@ -237,7 +242,9 @@ class _AgentProcessRecorder:
         thought_id = self._lookup_tool_thought(index=index, tool_call_id=tool_call_id)
         if thought_id is None:
             thought_id = self._create_thought(tool=tool_name, tool_input=_json_or_text(args_delta))
-            self._remember_tool_thought(index=index, tool_call_id=tool_call_id, thought_id=thought_id)
+            self._remember_tool_thought(
+                index=index, tool_call_id=tool_call_id, tool_name=tool_name, thought_id=thought_id
+            )
             return
 
         self._update_thought(
@@ -252,7 +259,9 @@ class _AgentProcessRecorder:
         thought_id = self._lookup_tool_thought(index=index, tool_call_id=tool_call_id)
         if thought_id is None:
             thought_id = self._create_thought(tool=tool_name, tool_input=_json_or_text(part.get("args")))
-            self._remember_tool_thought(index=index, tool_call_id=tool_call_id, thought_id=thought_id)
+            self._remember_tool_thought(
+                index=index, tool_call_id=tool_call_id, tool_name=tool_name, thought_id=thought_id
+            )
             return
 
         self._update_thought(
@@ -263,17 +272,18 @@ class _AgentProcessRecorder:
 
     def _record_tool_return_part(self, part: dict[str, Any]) -> None:
         tool_call_id = _string_or_none(part.get("tool_call_id"))
+        tool_name = _string_or_none(part.get("tool_name"))
         content = part.get("content")
         if content is None:
             content = part
-        self._record_tool_observation(tool_call_id, content)
+        self._record_tool_observation(tool_call_id=tool_call_id, tool_name=tool_name, observation=content)
 
-    def _record_tool_observation(self, tool_call_id: str | None, observation: Any) -> None:
-        thought_id = self._tool_by_call_id.get(tool_call_id) if tool_call_id else None
-        if thought_id is None and self._tool_by_index:
-            thought_id = next(reversed(self._tool_by_index.values()))
+    def _record_tool_observation(self, *, tool_call_id: str | None, tool_name: str | None, observation: Any) -> None:
+        thought_id = self._lookup_observation_thought(tool_call_id=tool_call_id, tool_name=tool_name)
         if thought_id is None:
-            thought_id = self._create_thought()
+            thought_id = self._create_thought(tool=tool_name)
+        else:
+            self._mark_tool_observed(thought_id)
         self._update_thought(thought_id, observation=_json_or_text(observation))
 
     def _lookup_tool_thought(self, *, index: int, tool_call_id: str | None) -> str | None:
@@ -281,10 +291,27 @@ class _AgentProcessRecorder:
             return self._tool_by_call_id[tool_call_id]
         return self._tool_by_index.get(index)
 
-    def _remember_tool_thought(self, *, index: int, tool_call_id: str | None, thought_id: str) -> None:
+    def _remember_tool_thought(
+        self, *, index: int, tool_call_id: str | None, tool_name: str | None, thought_id: str
+    ) -> None:
         self._tool_by_index[index] = thought_id
         if tool_call_id:
             self._tool_by_call_id[tool_call_id] = thought_id
+        if tool_name:
+            self._open_tool_by_name.setdefault(tool_name, set()).add(thought_id)
+
+    def _lookup_observation_thought(self, *, tool_call_id: str | None, tool_name: str | None) -> str | None:
+        if tool_call_id:
+            return self._tool_by_call_id.get(tool_call_id)
+        if tool_name:
+            open_thought_ids = self._open_tool_by_name.get(tool_name, set())
+            if len(open_thought_ids) == 1:
+                return next(iter(open_thought_ids))
+        return None
+
+    def _mark_tool_observed(self, thought_id: str) -> None:
+        for open_thought_ids in self._open_tool_by_name.values():
+            open_thought_ids.discard(thought_id)
 
     def _create_thought(
         self, *, thought: str | None = None, tool: str | None = None, tool_input: str | None = None

--- a/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
+++ b/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
@@ -38,6 +38,7 @@ from pydantic_ai.messages import (
 from clients.agent_backend import (
     AgentBackendError,
     AgentBackendRunEventAdapter,
+    AgentBackendStreamInternalEvent,
     FakeAgentBackendRunClient,
     FakeAgentBackendScenario,
 )
@@ -402,6 +403,94 @@ def test_successful_turn_persists_thinking_and_tool_process_events(monkeypatch):
     assert rows[1].tool == "bash"
     assert rows[1].tool_input == '{"cmd": "ls"}'
     assert rows[1].observation == "ok"
+
+
+def test_tool_result_without_identity_does_not_attach_to_previous_tool(monkeypatch):
+    fake_session = _FakeDbSession()
+    monkeypatch.setattr(app_runner_module.db, "session", fake_session)
+    qm = _FakeQueueManager()
+    recorder = app_runner_module._AgentProcessRecorder(
+        dify_context=_dify_ctx(),
+        message_id="msg-1",
+        queue_manager=qm,  # type: ignore[arg-type]
+    )
+
+    recorder.handle_stream_event(
+        AgentBackendStreamInternalEvent(
+            run_id="run-1",
+            data={
+                "event_kind": "function_tool_call",
+                "part": {
+                    "part_kind": "tool-call",
+                    "tool_name": "shell_run",
+                    "args": {"script": "npx skills find browser"},
+                    "tool_call_id": "shell-call-1",
+                },
+            },
+        )
+    )
+    recorder.handle_stream_event(
+        AgentBackendStreamInternalEvent(
+            run_id="run-1",
+            data={
+                "event_kind": "function_tool_result",
+                "content": "Knowledge base search results: browser skill",
+            },
+        )
+    )
+
+    rows = sorted(fake_session.rows.values(), key=lambda row: row.position)
+    assert len(rows) == 2
+    assert rows[0].tool == "shell_run"
+    assert rows[0].tool_input == '{"script": "npx skills find browser"}'
+    assert rows[0].observation is None
+    assert rows[1].tool is None
+    assert rows[1].tool_input is None
+    assert rows[1].observation == "Knowledge base search results: browser skill"
+
+
+def test_tool_result_without_call_id_matches_unique_open_tool_name(monkeypatch):
+    fake_session = _FakeDbSession()
+    monkeypatch.setattr(app_runner_module.db, "session", fake_session)
+    qm = _FakeQueueManager()
+    recorder = app_runner_module._AgentProcessRecorder(
+        dify_context=_dify_ctx(),
+        message_id="msg-1",
+        queue_manager=qm,  # type: ignore[arg-type]
+    )
+
+    recorder.handle_stream_event(
+        AgentBackendStreamInternalEvent(
+            run_id="run-1",
+            data={
+                "event_kind": "function_tool_call",
+                "part": {
+                    "part_kind": "tool-call",
+                    "tool_name": "knowledge_base_search",
+                    "args": {"query": "browser"},
+                },
+            },
+        )
+    )
+    recorder.handle_stream_event(
+        AgentBackendStreamInternalEvent(
+            run_id="run-1",
+            data={
+                "event_kind": "function_tool_result",
+                "part": {
+                    "part_kind": "tool-return",
+                    "tool_name": "knowledge_base_search",
+                    "content": "Knowledge base search results: browser skill",
+                },
+            },
+        )
+    )
+
+    rows = sorted(fake_session.rows.values(), key=lambda row: row.position)
+    assert len(rows) == 1
+    assert rows[0].tool == "knowledge_base_search"
+    assert rows[0].tool_input == '{"query": "browser"}'
+    assert rows[0].observation == "Knowledge base search results: browser skill"
 
 
 def test_prior_session_snapshot_is_threaded_into_request():


### PR DESCRIPTION
## Summary
- tighten Agent App process recorder matching so tool observations only attach by `tool_call_id` or a unique open `tool_name`
- create a separate observation thought when a tool result has no reliable identity instead of attaching it to the previous tool
- add unit coverage for the DIFY-2628 mismatch case and the unique tool-name fallback

## Verification
- `uv run --project api --dev ruff check api/core/app/apps/agent_app/app_runner.py api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py`
- `uv run --project api --dev ruff format --check api/core/app/apps/agent_app/app_runner.py api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py`
- local recorder smoke script: no-id result creates a separate observation thought instead of mutating the previous shell tool
- deployed to `deploy/agent` and verified on `https://agent.dify.dev`
  - created test Agent `019f1649-0c68-7bc2-81de-5f03e5f8259f`
  - successful runtime chat message `19a1f25d-54cf-4657-827b-8f8c16aba407`
  - DB thought `81b3a2a3-d946-46c5-a6a4-d5928eaae4f7` has `tool=shell_run`, `tool_input={"script":"echo DIFY2628_OK"}`, and matching shell output observation
  - recent mismatch query for `tool='shell_run' AND observation ILIKE 'Knowledge base search results:%'` returned `0`

Note: full local pytest currently segfaults during pytest capture initialization in the local macOS env before collecting tests; the failure is outside this change. The targeted logic was validated with ruff, py_compile, a direct recorder smoke script, and dev runtime E2E.
