### PR TITLE
fix(agent): support workflow file output mappings

### DIFF
--- a/api/core/workflow/nodes/agent_v2/runtime_request_builder.py
+++ b/api/core/workflow/nodes/agent_v2/runtime_request_builder.py
@@ -493,7 +493,10 @@ class WorkflowAgentRuntimeRequestBuilder:
         schema: dict[str, Any] = {"type": "object", "properties": properties}
         if required:
             schema["required"] = required
-        return AgentBackendOutputConfig(json_schema=schema)
+        return AgentBackendOutputConfig(
+            json_schema=schema,
+            description=WorkflowAgentRuntimeRequestBuilder._build_output_description(effective_outputs),
+        )
 
     @staticmethod
     def effective_declared_outputs(
@@ -550,47 +553,37 @@ class WorkflowAgentRuntimeRequestBuilder:
                     array_schema["items"]["description"] = array_item.description
                 return array_schema
             case DeclaredOutputType.FILE:
-                return {
-                    "oneOf": [
-                        {
-                            "type": "object",
-                            "additionalProperties": False,
-                            "properties": {
-                                "transfer_method": {"const": FileTransferMethod.LOCAL_FILE.value},
-                                "reference": {"type": "string"},
-                            },
-                            "required": ["transfer_method", "reference"],
-                        },
-                        {
-                            "type": "object",
-                            "additionalProperties": False,
-                            "properties": {
-                                "transfer_method": {"const": FileTransferMethod.TOOL_FILE.value},
-                                "reference": {"type": "string"},
-                            },
-                            "required": ["transfer_method", "reference"],
-                        },
-                        {
-                            "type": "object",
-                            "additionalProperties": False,
-                            "properties": {
-                                "transfer_method": {"const": FileTransferMethod.DATASOURCE_FILE.value},
-                                "reference": {"type": "string"},
-                            },
-                            "required": ["transfer_method", "reference"],
-                        },
-                        {
-                            "type": "object",
-                            "additionalProperties": False,
-                            "properties": {
-                                "transfer_method": {"const": FileTransferMethod.REMOTE_URL.value},
-                                "url": {"type": "string"},
-                            },
-                            "required": ["transfer_method", "url"],
-                        },
-                    ],
-                }
+                return cast(dict[str, Any], AgentStubFileMapping.model_json_schema())
         assert_never(output_type)
+
+    @staticmethod
+    def _build_output_description(declared_outputs: Sequence[DeclaredOutputConfig]) -> str | None:
+        file_output_lines: list[str] = []
+        for output in declared_outputs:
+            if output.type == DeclaredOutputType.FILE:
+                file_output_lines.append(
+                    f"- `{output.name}`: create the file in the sandbox, run `dify-agent file upload <path>`, "
+                    f"and set `final_output.{output.name}` to the returned AgentStubFileMapping JSON object."
+                )
+            elif (
+                output.type == DeclaredOutputType.ARRAY
+                and output.array_item is not None
+                and output.array_item.type == DeclaredOutputType.FILE
+            ):
+                file_output_lines.append(
+                    f"- `{output.name}`: for every produced file, run `dify-agent file upload <path>` and set "
+                    f"`final_output.{output.name}` to an array of the returned AgentStubFileMapping JSON objects."
+                )
+        if not file_output_lines:
+            return None
+
+        return "\n".join(
+            [
+                "When filling file outputs, do not return a local filesystem path directly.",
+                "Upload each sandbox-local file through the Agent Stub CLI first:",
+                *file_output_lines,
+            ]
+        )
 
     @staticmethod
     def _apply_child_properties(schema: dict[str, Any], children: Sequence[DeclaredOutputChildConfig]) -> None:

--- a/api/services/agent/prompt_mentions.py
+++ b/api/services/agent/prompt_mentions.py
@@ -33,6 +33,8 @@ from enum import StrEnum
 from models.agent_config_entities import (
     AgentHumanContactConfig,
     AgentSoulConfig,
+    DeclaredOutputConfig,
+    DeclaredOutputType,
     WorkflowNodeJobConfig,
     WorkflowPreviousNodeOutputRef,
 )
@@ -50,6 +52,8 @@ class MentionKind(StrEnum):
 
 
 MENTION_PATTERN = re.compile(
+    r"(?:\[§(?P<reversed_output_id>[^:§]+?):(?P<reversed_output_label>[^:§]*?):(?P<reversed_output_kind>output)§\])"
+    r"|"
     r"(?:\[§(?P<bracket_kind>skill|file|tool|cli_tool|knowledge|human|node_output|output):"
     r"(?P<bracket_id>[^:§]+?)(?::(?P<bracket_label>[^§]*?))?§\])"
     r"|(?:§(?P<legacy_kind>output):(?P<legacy_id>[^:§]+?)(?::(?P<legacy_label>[^§]*?))?§)"
@@ -111,6 +115,8 @@ MentionResolver = Callable[[PromptMention], str | None]
 
 
 def _mention_groups(match: re.Match[str]) -> tuple[str, str, str | None]:
+    if match.group("reversed_output_kind"):
+        return MentionKind.OUTPUT.value, match.group("reversed_output_id"), match.group("reversed_output_label")
     kind = match.group("bracket_kind") or match.group("legacy_kind")
     ref_id = match.group("bracket_id") or match.group("legacy_id")
     label = match.group("bracket_label") or match.group("legacy_label")
@@ -298,7 +304,7 @@ def build_node_job_mention_resolver(node_job: WorkflowNodeJobConfig) -> MentionR
             case MentionKind.OUTPUT:
                 for output in node_job.declared_outputs:
                     if output.name == mention.ref_id:
-                        return f"{output.name} ({output.type.value})"
+                        return _format_output_mention(output)
             case MentionKind.HUMAN:
                 return _resolve_human_contact(node_job.human_contacts, mention.ref_id)
             case _:
@@ -306,6 +312,26 @@ def build_node_job_mention_resolver(node_job: WorkflowNodeJobConfig) -> MentionR
         return None
 
     return _resolve
+
+
+def _format_output_mention(output: DeclaredOutputConfig) -> str:
+    if output.type == DeclaredOutputType.FILE:
+        return (
+            f"{output.name} (file output; create the file locally, run "
+            f"`dify-agent file upload <path>`, then use the returned AgentStubFileMapping JSON "
+            f"as final_output.{output.name})"
+        )
+    if (
+        output.type == DeclaredOutputType.ARRAY
+        and output.array_item
+        and output.array_item.type == DeclaredOutputType.FILE
+    ):
+        return (
+            f"{output.name} (array[file] output; upload each produced file with "
+            f"`dify-agent file upload <path>`, then use the returned AgentStubFileMapping JSON objects "
+            f"as final_output.{output.name})"
+        )
+    return f"{output.name} ({output.type.value})"
 
 
 def _resolve_human_contact(contacts: list[AgentHumanContactConfig], ref_id: str) -> str | None:

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_runtime_request_builder.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_runtime_request_builder.py
@@ -287,13 +287,18 @@ def test_builds_workflow_run_request_with_file_output_schema_and_reserved_metada
     assert layers[DIFY_EXECUTION_CONTEXT_LAYER_ID]["config"]["invoke_from"] == "service-api"
     assert dumped["idempotency_key"] == "node-exec-1"
     output_schema = dumped["composition"]["layers"][-1]["config"]["json_schema"]
+    output_description = dumped["composition"]["layers"][-1]["config"]["description"]
     report_schema = output_schema["properties"]["report"]
-    assert len(report_schema["oneOf"]) == 4
-    assert all(branch["additionalProperties"] is False for branch in report_schema["oneOf"])
-    assert report_schema["oneOf"][0]["required"] == ["transfer_method", "reference"]
-    assert report_schema["oneOf"][1]["required"] == ["transfer_method", "reference"]
-    assert report_schema["oneOf"][2]["required"] == ["transfer_method", "reference"]
-    assert report_schema["oneOf"][3]["required"] == ["transfer_method", "url"]
+    assert report_schema["additionalProperties"] is False
+    assert report_schema["required"] == ["transfer_method"]
+    assert report_schema["properties"]["transfer_method"]["enum"] == [
+        "local_file",
+        "tool_file",
+        "datasource_file",
+        "remote_url",
+    ]
+    assert "dify-agent file upload <path>" in output_description
+    assert "final_output.report" in output_description
     assert output_schema["properties"]["confidence"]["type"] == "number"
     assert output_schema["required"] == ["report"]
     assert layers[DIFY_AGENT_MODEL_LAYER_ID]["config"]["model_settings"] == {"temperature": 0.2}

--- a/api/tests/unit_tests/services/agent/test_prompt_mentions.py
+++ b/api/tests/unit_tests/services/agent/test_prompt_mentions.py
@@ -241,7 +241,19 @@ def test_node_job_resolver_resolves_each_kind(node_job: WorkflowNodeJobConfig):
 
     expanded = expand_prompt_mentions(prompt, resolver)
 
-    assert expanded == ("Read START/tenders and produce qna_report (file); if unsure contact EMAIL · David Hayes.")
+    assert expanded == (
+        "Read START/tenders and produce qna_report (file output; create the file locally, run "
+        "`dify-agent file upload <path>`, then use the returned AgentStubFileMapping JSON "
+        "as final_output.qna_report); if unsure contact EMAIL · David Hayes."
+    )
+
+
+def test_node_job_resolver_accepts_legacy_reversed_output_token(node_job: WorkflowNodeJobConfig):
+    resolver = build_node_job_mention_resolver(node_job)
+
+    expanded = expand_prompt_mentions("[§qna_report:qna_report:output§]", resolver)
+
+    assert "final_output.qna_report" in expanded
 
 
 def test_node_job_resolver_matches_ref_by_node_id_and_output_fields():


### PR DESCRIPTION
## Summary
- support legacy workflow output mention tokens like `[§name:label:output§]` while keeping canonical `[§output:name:label§]`
- use `AgentStubFileMapping` schema for file outputs sent to agent backend
- add runtime instructions telling the agent to upload generated files with `dify-agent file upload <path>` and return the mapping JSON

## Verification
- deployed and verified on `deploy/agent` via https://github.com/langgenius/dify/actions/runs/28416623614
- verified in the remote `langgenius-api-1` container that reversed output tokens expand and file output schema exposes `local_file/tool_file/datasource_file/remote_url` transfer methods
- `uv run ruff check services/agent/prompt_mentions.py core/workflow/nodes/agent_v2/runtime_request_builder.py tests/unit_tests/services/agent/test_prompt_mentions.py tests/unit_tests/core/workflow/nodes/agent_v2/test_runtime_request_builder.py`
- `uv run mypy services/agent/prompt_mentions.py core/workflow/nodes/agent_v2/runtime_request_builder.py --follow-imports=skip --ignore-missing-imports`

## Frontend note
Please emit canonical file output mentions as `[§output:<name>:<label>§]`. Backend temporarily accepts `[§<name>:<label>:output§]` for compatibility, but canonical order should be used going forward.

Linear: DIFY-2629