### PR TITLE
fix(api): pass SSL verify flag to SSRF proxy mounts

### DIFF
--- a/api/core/helper/ssrf_proxy.py
+++ b/api/core/helper/ssrf_proxy.py
@@ -42,13 +42,16 @@ request_error = httpx.RequestError
 max_retries_exceeded_error = MaxRetriesExceededError
 
 
-def _create_proxy_mounts() -> dict[str, httpx.HTTPTransport]:
+def _create_proxy_mounts(verify: bool) -> dict[str, httpx.HTTPTransport]:
+    """Build per-scheme proxy transports with the same TLS policy as the SSRF client."""
     return {
         "http://": httpx.HTTPTransport(
             proxy=dify_config.SSRF_PROXY_HTTP_URL,
+            verify=verify,
         ),
         "https://": httpx.HTTPTransport(
             proxy=dify_config.SSRF_PROXY_HTTPS_URL,
+            verify=verify,
         ),
     }
 
@@ -63,7 +66,7 @@ def _build_ssrf_client(verify: bool) -> httpx.Client:
 
     if dify_config.SSRF_PROXY_HTTP_URL and dify_config.SSRF_PROXY_HTTPS_URL:
         return httpx.Client(
-            mounts=_create_proxy_mounts(),
+            mounts=_create_proxy_mounts(verify=verify),
             verify=verify,
             limits=_SSRF_CLIENT_LIMITS,
         )

--- a/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
+++ b/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
@@ -1,9 +1,11 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 
 from core.helper.ssrf_proxy import (
     SSRF_DEFAULT_MAX_RETRIES,
+    SSRFProxy,
+    _build_ssrf_client,
     _get_user_provided_host_header,
     make_request,
 )
@@ -33,6 +35,34 @@ def test_retry_exceed_max_retries(mock_get_client):
     with pytest.raises(Exception) as e:
         make_request("GET", "http://example.com", max_retries=SSRF_DEFAULT_MAX_RETRIES - 1)
     assert str(e.value) == f"Reached maximum retries ({SSRF_DEFAULT_MAX_RETRIES - 1}) for URL http://example.com"
+
+
+def test_build_ssrf_client_passes_ssl_verify_to_proxy_mount_transports():
+    mock_client = MagicMock()
+    http_transport = MagicMock()
+    https_transport = MagicMock()
+
+    with (
+        patch("core.helper.ssrf_proxy.dify_config.SSRF_PROXY_ALL_URL", None),
+        patch("core.helper.ssrf_proxy.dify_config.SSRF_PROXY_HTTP_URL", "http://proxy.example.com:8080"),
+        patch("core.helper.ssrf_proxy.dify_config.SSRF_PROXY_HTTPS_URL", "http://proxy.example.com:8443"),
+        patch("core.helper.ssrf_proxy.httpx.HTTPTransport", side_effect=[http_transport, https_transport]) as transport,
+        patch("core.helper.ssrf_proxy.httpx.Client", return_value=mock_client) as client,
+    ):
+        ssrf_client = _build_ssrf_client(verify=False)
+
+    assert ssrf_client is mock_client
+    transport.assert_has_calls(
+        [
+            call(proxy="http://proxy.example.com:8080", verify=False),
+            call(proxy="http://proxy.example.com:8443", verify=False),
+        ],
+    )
+    client.assert_called_once_with(
+        mounts={"http://": http_transport, "https://": https_transport},
+        verify=False,
+        limits=ANY,
+    )
 
 
 class TestGetUserProvidedHostHeader:


### PR DESCRIPTION
## Summary

Cherry-pick of #36455 to `lts/1.13.x`.

Fixes #26531.

When Dify is configured with separate SSRF HTTP/HTTPS proxy URLs, the HTTP request node's SSL verification setting now propagates into the per-scheme httpx transports. Add a regression test that covers the proxy-mounted SSRF client construction.

(cherry picked from commit 4c551e36bb1745a15cc1dfb0edd7642ea290925f)