### PR TITLE
fix(api): scope segment batch deletes

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -3900,7 +3900,14 @@ class SegmentService:
         session.add(document)
 
         # Delete database records
-        session.execute(delete(DocumentSegment).where(DocumentSegment.id.in_(segment_ids)))
+        session.execute(
+            delete(DocumentSegment).where(
+                DocumentSegment.id.in_(segment_db_ids),
+                DocumentSegment.dataset_id == dataset.id,
+                DocumentSegment.document_id == document.id,
+                DocumentSegment.tenant_id == current_user.current_tenant_id,
+            )
+        )
         session.commit()
 
     @classmethod

--- a/api/tests/unit_tests/services/test_dataset_service_segment.py
+++ b/api/tests/unit_tests/services/test_dataset_service_segment.py
@@ -858,7 +858,7 @@ class TestSegmentServiceMutations:
             # scalars() for child_node_ids
             session.scalars.return_value.all.return_value = ["child-1"]
 
-            SegmentService.delete_segments(["segment-1", "segment-2"], document, dataset, session)
+            SegmentService.delete_segments(["segment-1", "segment-2", "foreign-segment"], document, dataset, session)
 
         assert document.word_count == 0
         session.add.assert_called_once_with(document)
@@ -869,6 +869,13 @@ class TestSegmentServiceMutations:
             ["segment-1", "segment-2"],
             ["child-1"],
         )
+        delete_stmt = session.execute.call_args_list[1].args[0]
+        delete_sql = str(delete_stmt.compile(compile_kwargs={"literal_binds": True}))
+        assert "document_segments.id IN ('segment-1', 'segment-2')" in delete_sql
+        assert "document_segments.dataset_id = 'dataset-1'" in delete_sql
+        assert "document_segments.document_id = 'doc-1'" in delete_sql
+        assert "document_segments.tenant_id = 'tenant-1'" in delete_sql
+        assert "foreign-segment" not in delete_sql
         session.commit.assert_called()
 
     def test_update_segments_status_enables_only_segments_without_indexing_cache(self):


### PR DESCRIPTION
## Summary
- scope batch segment deletes to the tenant, dataset, and document selected by the verified rows
- use the scoped segment ids for database deletion instead of raw request ids
- add a regression assertion for mixed owned and foreign segment ids

## Root cause
PR #38177 added nested resource lookup safeguards for single segment and child chunk paths, but the batch segment delete path still deleted by the raw request id list after the scoped lookup.
A request that mixed valid ids with foreign ids could therefore delete records outside the selected document.

Follow-up to https://github.com/langgenius/dify/pull/38177#discussion_r3497051373.

## Tests
- env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy -u NO_PROXY -u no_proxy DEBUG=false uv run --project api pytest api/tests/unit_tests/services/test_dataset_service_segment.py -q
- uv run --project api ruff check api/services/dataset_service.py api/tests/unit_tests/services/test_dataset_service_segment.py
- uv run --project api ruff format --check api/services/dataset_service.py api/tests/unit_tests/services/test_dataset_service_segment.py

Fixes #39861