### PR TITLE
fix(agent): constrain workflow file output schema

### DIFF
--- a/api/core/workflow/nodes/agent_v2/runtime_request_builder.py
+++ b/api/core/workflow/nodes/agent_v2/runtime_request_builder.py
@@ -98,6 +98,7 @@ _AGENT_STUB_FILE_TRANSFER_METHODS: Mapping[FileTransferMethod, AgentStubFileTran
     FileTransferMethod.DATASOURCE_FILE: "datasource_file",
     FileTransferMethod.REMOTE_URL: "remote_url",
 }
+_CANONICAL_DIFY_FILE_REFERENCE_PATTERN = r"^dify-file-ref:eyJyZWNvcmRfaWQiOi[A-Za-z0-9_-]+={0,2}$"
 
 
 class WorkflowAgentRuntimeRequestBuildError(ValueError):
@@ -553,8 +554,72 @@ class WorkflowAgentRuntimeRequestBuilder:
                     array_schema["items"]["description"] = array_item.description
                 return array_schema
             case DeclaredOutputType.FILE:
-                return cast(dict[str, Any], AgentStubFileMapping.model_json_schema())
+                return WorkflowAgentRuntimeRequestBuilder._agent_stub_output_file_mapping_schema()
         assert_never(output_type)
+
+    @staticmethod
+    def _agent_stub_output_file_mapping_schema() -> dict[str, Any]:
+        """JSON Schema for Agent-produced output file mappings.
+
+        ``AgentStubFileMapping.model_json_schema()`` cannot express the model's
+        ``after`` validator: only ``remote_url`` may carry ``url``; every other
+        method must carry a canonical ``reference``. The structured-output model
+        needs that relationship in the schema, otherwise it may emit
+        ``{"transfer_method": "local_file", "url": "..."}``, which passes the
+        broad generated schema but fails API-side output type checking.
+
+        For files produced inside an Agent run, the supported persisted shape is
+        narrower than every downloadable mapping: the sandbox must upload the
+        local artifact via ``dify-agent file upload <path>``, which returns a
+        ``tool_file`` mapping. ``local_file`` and ``datasource_file`` are valid
+        for existing file references in workflow context, not for newly produced
+        Agent output files.
+        """
+        return {
+            "title": "AgentStubFileMapping",
+            "description": (
+                "Agent output file mapping. Use `tool_file` with `reference` for files uploaded by "
+                "`dify-agent file upload <path>`; use `remote_url` only for files already reachable by URL."
+            ),
+            "anyOf": [
+                {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["transfer_method", "reference"],
+                    "properties": {
+                        "transfer_method": {
+                            "type": "string",
+                            "enum": ["tool_file"],
+                        },
+                        "reference": {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": _CANONICAL_DIFY_FILE_REFERENCE_PATTERN,
+                            "description": (
+                                "Canonical Dify file reference returned by `dify-agent file upload <path>`. "
+                                "Never use a local path, filename, URL, or synthesized dify-file-ref here."
+                            ),
+                        },
+                    },
+                },
+                {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["transfer_method", "url"],
+                    "properties": {
+                        "transfer_method": {
+                            "type": "string",
+                            "enum": ["remote_url"],
+                        },
+                        "url": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "Remote URL for a file that is already publicly reachable.",
+                        },
+                    },
+                },
+            ],
+        }
 
     @staticmethod
     def _build_output_description(declared_outputs: Sequence[DeclaredOutputConfig]) -> str | None:
@@ -563,7 +628,9 @@ class WorkflowAgentRuntimeRequestBuilder:
             if output.type == DeclaredOutputType.FILE:
                 file_output_lines.append(
                     f"- `{output.name}`: create the file in the sandbox, run `dify-agent file upload <path>`, "
-                    f"and set `final_output.{output.name}` to the returned AgentStubFileMapping JSON object."
+                    f"and set `final_output.{output.name}` to the returned AgentStubFileMapping JSON object. "
+                    "Do not call `final_output` before the upload command succeeds. Do not use the local path, "
+                    "filename, URL, or a synthesized/base64-encoded value as the `reference`."
                 )
             elif (
                 output.type == DeclaredOutputType.ARRAY
@@ -572,7 +639,9 @@ class WorkflowAgentRuntimeRequestBuilder:
             ):
                 file_output_lines.append(
                     f"- `{output.name}`: for every produced file, run `dify-agent file upload <path>` and set "
-                    f"`final_output.{output.name}` to an array of the returned AgentStubFileMapping JSON objects."
+                    f"`final_output.{output.name}` to an array of the returned AgentStubFileMapping JSON objects. "
+                    "Do not call `final_output` before all upload commands succeed. Do not use local paths, filenames, "
+                    "URLs, or synthesized/base64-encoded values as `reference` values."
                 )
         if not file_output_lines:
             return None
@@ -580,7 +649,8 @@ class WorkflowAgentRuntimeRequestBuilder:
         return "\n".join(
             [
                 "When filling file outputs, do not return a local filesystem path directly.",
-                "Upload each sandbox-local file through the Agent Stub CLI first:",
+                "Upload each sandbox-local file through the Agent Stub CLI first. Copy the JSON printed by "
+                "`dify-agent file upload <path>` verbatim into the final output; never invent the `reference` value.",
                 *file_output_lines,
             ]
         )

--- a/api/services/agent/prompt_mentions.py
+++ b/api/services/agent/prompt_mentions.py
@@ -318,8 +318,9 @@ def _format_output_mention(output: DeclaredOutputConfig) -> str:
     if output.type == DeclaredOutputType.FILE:
         return (
             f"{output.name} (file output; create the file locally, run "
-            f"`dify-agent file upload <path>`, then use the returned AgentStubFileMapping JSON "
-            f"as final_output.{output.name})"
+            f"`dify-agent file upload <path>`, then copy the returned AgentStubFileMapping JSON "
+            f"as final_output.{output.name}; do not call final_output before upload succeeds, and do not use "
+            "the local path, filename, URL, or a synthesized dify-file-ref as the reference)"
         )
     if (
         output.type == DeclaredOutputType.ARRAY
@@ -328,8 +329,9 @@ def _format_output_mention(output: DeclaredOutputConfig) -> str:
     ):
         return (
             f"{output.name} (array[file] output; upload each produced file with "
-            f"`dify-agent file upload <path>`, then use the returned AgentStubFileMapping JSON objects "
-            f"as final_output.{output.name})"
+            f"`dify-agent file upload <path>`, then copy the returned AgentStubFileMapping JSON objects "
+            f"as final_output.{output.name}; do not call final_output before all uploads succeed, and do not use "
+            "local paths, filenames, URLs, or synthesized dify-file-ref values as references)"
         )
     return f"{output.name} ({output.type.value})"
 

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_runtime_request_builder.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_runtime_request_builder.py
@@ -289,16 +289,23 @@ def test_builds_workflow_run_request_with_file_output_schema_and_reserved_metada
     output_schema = dumped["composition"]["layers"][-1]["config"]["json_schema"]
     output_description = dumped["composition"]["layers"][-1]["config"]["description"]
     report_schema = output_schema["properties"]["report"]
-    assert report_schema["additionalProperties"] is False
-    assert report_schema["required"] == ["transfer_method"]
-    assert report_schema["properties"]["transfer_method"]["enum"] == [
-        "local_file",
-        "tool_file",
-        "datasource_file",
-        "remote_url",
-    ]
+    report_schema_branches = {
+        branch["properties"]["transfer_method"]["enum"][0]: branch for branch in report_schema["anyOf"]
+    }
+    assert set(report_schema_branches) == {"tool_file", "remote_url"}
+    tool_file_branch = report_schema_branches["tool_file"]
+    assert tool_file_branch["additionalProperties"] is False
+    assert tool_file_branch["required"] == ["transfer_method", "reference"]
+    assert set(tool_file_branch["properties"]) == {"transfer_method", "reference"}
+    assert tool_file_branch["properties"]["reference"]["pattern"].startswith("^dify-file-ref:")
+    remote_url_branch = report_schema_branches["remote_url"]
+    assert remote_url_branch["additionalProperties"] is False
+    assert remote_url_branch["required"] == ["transfer_method", "url"]
+    assert set(remote_url_branch["properties"]) == {"transfer_method", "url"}
     assert "dify-agent file upload <path>" in output_description
     assert "final_output.report" in output_description
+    assert "never invent the `reference` value" in output_description
+    assert "Do not call `final_output` before the upload command succeeds" in output_description
     assert output_schema["properties"]["confidence"]["type"] == "number"
     assert output_schema["required"] == ["report"]
     assert layers[DIFY_AGENT_MODEL_LAYER_ID]["config"]["model_settings"] == {"temperature": 0.2}

--- a/api/tests/unit_tests/services/agent/test_prompt_mentions.py
+++ b/api/tests/unit_tests/services/agent/test_prompt_mentions.py
@@ -243,8 +243,10 @@ def test_node_job_resolver_resolves_each_kind(node_job: WorkflowNodeJobConfig):
 
     assert expanded == (
         "Read START/tenders and produce qna_report (file output; create the file locally, run "
-        "`dify-agent file upload <path>`, then use the returned AgentStubFileMapping JSON "
-        "as final_output.qna_report); if unsure contact EMAIL · David Hayes."
+        "`dify-agent file upload <path>`, then copy the returned AgentStubFileMapping JSON "
+        "as final_output.qna_report; do not call final_output before upload succeeds, and do not use "
+        "the local path, filename, URL, or a synthesized dify-file-ref as the reference); "
+        "if unsure contact EMAIL · David Hayes."
     )
 
 


### PR DESCRIPTION
## Summary
- narrow Workflow Agent file output schema to valid produced-file mappings: `tool_file + reference` or `remote_url + url`
- require canonical `dify-file-ref` shape for `tool_file.reference` so filenames and synthesized references are rejected before API type checking
- strengthen runtime output instructions and prompt mention expansion so agents must run `dify-agent file upload <path>` and copy the returned JSON verbatim

## Verification
- deployed to `deploy/agent`: https://github.com/langgenius/dify/actions/runs/28437707288
- reproduced DIFY-2629 curl against `agent.dify.dev` via the EC2 host; workflow now succeeds and returns a downloadable `joke.txt` tool file from the Agent output
- `uv run ruff check core/workflow/nodes/agent_v2/runtime_request_builder.py services/agent/prompt_mentions.py tests/unit_tests/core/workflow/nodes/agent_v2/test_runtime_request_builder.py tests/unit_tests/services/agent/test_prompt_mentions.py`
- `uv run mypy core/workflow/nodes/agent_v2/runtime_request_builder.py services/agent/prompt_mentions.py --follow-imports=skip --ignore-missing-imports`

Linear: DIFY-2629