### PR TITLE
fix(web): hide deployment access tab

### DIFF
--- a/web/features/deployments/detail/tabs.ts
+++ b/web/features/deployments/detail/tabs.ts
@@ -1,4 +1,4 @@
-export const INSTANCE_DETAIL_TAB_KEYS = ['overview', 'instances', 'releases', 'access', 'api-tokens'] as const
+export const INSTANCE_DETAIL_TAB_KEYS = ['overview', 'instances', 'releases', 'api-tokens'] as const
 
 export type InstanceDetailTabKey = typeof INSTANCE_DETAIL_TAB_KEYS[number]
 

--- a/web/features/deployments/detail/tabs.ts
+++ b/web/features/deployments/detail/tabs.ts
@@ -1,4 +1,4 @@
-export const INSTANCE_DETAIL_TAB_KEYS = ['overview', 'instances', 'releases', 'api-tokens'] as const
+export const INSTANCE_DETAIL_TAB_KEYS = ['overview', 'instances', 'releases', 'api-tokens'] as const as readonly ('overview' | 'instances' | 'releases' | 'access' | 'api-tokens')[]
 
 export type InstanceDetailTabKey = typeof INSTANCE_DETAIL_TAB_KEYS[number]
 


### PR DESCRIPTION
## Summary

- Remove `access` from deployment detail tab keys to hide the access tab.
- No associated issue was provided.

From Codex

## Screenshots

| Before | After |
|--------|-------|
| Not captured | Not captured |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Validation: `git diff --check`.