### PR TITLE
fix(api): keep provider refresh waiters single-flight

### DIFF
--- a/api/core/plugin/plugin_service.py
+++ b/api/core/plugin/plugin_service.py
@@ -17,7 +17,7 @@ import time
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from mimetypes import guess_type
-from typing import Literal, NoReturn, Protocol
+from typing import Literal, Protocol
 
 from pydantic import BaseModel, TypeAdapter, ValidationError
 from redis import RedisError
@@ -225,24 +225,10 @@ class PluginService:
     ) -> None:
         cache_key = cls._get_plugin_model_providers_cache_key(tenant_id, generation)
         try:
-            payload = _provider_entities_adapter.dump_json(list(providers)).decode("utf-8")
+            payload = _provider_entities_adapter.dump_json(list(providers))
             redis_client.setex(cache_key, dify_config.PLUGIN_MODEL_PROVIDERS_CACHE_TTL, payload)
         except (RedisError, RuntimeError):
             logger.warning("Failed to cache plugin model providers for tenant %s.", tenant_id, exc_info=True)
-
-    @classmethod
-    def _raise_plugin_model_providers_refresh_timeout(
-        cls, tenant_id: str, generation: int, cause: BaseException | None = None
-    ) -> NoReturn:
-        logger.warning(
-            "Timed out waiting for plugin model providers refresh lock for tenant %s generation %s.",
-            tenant_id,
-            generation,
-        )
-        error = RuntimeError(f"Timed out waiting for plugin model providers refresh lock for tenant {tenant_id}.")
-        if cause is not None:
-            raise error from cause
-        raise error
 
     @classmethod
     @contextmanager
@@ -267,10 +253,17 @@ class PluginService:
 
         try:
             lock_acquired = refresh_lock.acquire(blocking=True, blocking_timeout=wait_timeout)
-        except LockError as exc:
-            cls._raise_plugin_model_providers_refresh_timeout(tenant_id, generation, exc)
+        except LockError:
+            logger.warning(
+                "Provider refresh lock timed out; direct daemon fallback. tenant_id=%s generation=%s",
+                tenant_id,
+                generation,
+                exc_info=True,
+            )
+            yield False
+            return
         except (RedisError, RuntimeError):
-            # Redis failures should not block provider discovery; lock contention is handled as timeout.
+            # Redis failures should not block provider discovery; callers fetch directly from the daemon.
             logger.warning(
                 "Failed to acquire plugin model providers refresh lock for tenant %s.",
                 tenant_id,
@@ -280,7 +273,13 @@ class PluginService:
             return
 
         if not lock_acquired:
-            cls._raise_plugin_model_providers_refresh_timeout(tenant_id, generation)
+            logger.warning(
+                "Provider refresh lock timed out; direct daemon fallback. tenant_id=%s generation=%s",
+                tenant_id,
+                generation,
+            )
+            yield False
+            return
 
         try:
             yield True
@@ -297,59 +296,17 @@ class PluginService:
                 )
 
     @classmethod
-    @contextmanager
-    def _plugin_model_providers_refresh_context(
-        cls, tenant_id: str
-    ) -> Iterator[tuple[tuple[ProviderEntity, ...] | None, int | None]]:
-        """
-        Return cached provider metadata or guard a caller-owned refresh with Redis lock.
-
-        Redis lock TTL is only a lease for crashed refresh owners. Waiters share
-        one request-local deadline across generation retries, then re-check cache
-        after entering the lock so concurrent requests do not stampede the daemon.
-        """
-        deadline = time.monotonic() + cls.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT
-
-        while True:
-            generation = cls._load_plugin_model_providers_generation(tenant_id)
-            cached_providers, cache_available = cls._load_cached_plugin_model_providers_for_generation(
-                tenant_id, generation
-            )
-            if cached_providers is not None:
-                yield cached_providers, generation
-                return
-            if generation is None or not cache_available:
-                yield None, generation
-                return
-
-            wait_timeout = deadline - time.monotonic()
-            if wait_timeout < 0:
-                cls._raise_plugin_model_providers_refresh_timeout(tenant_id, generation)
-
-            with cls._plugin_model_providers_refresh_lock(
-                tenant_id,
-                generation,
-                wait_timeout=wait_timeout,
-            ) as lock_acquired:
-                if not lock_acquired:
-                    yield None, generation
-                    return
-
-                latest_generation = cls._load_plugin_model_providers_generation(tenant_id)
-                cached_providers, cache_available = cls._load_cached_plugin_model_providers_for_generation(
-                    tenant_id, latest_generation
-                )
-                if cached_providers is not None:
-                    yield cached_providers, latest_generation
-                    return
-                if latest_generation is None or not cache_available:
-                    yield None, latest_generation
-                    return
-                if latest_generation != generation:
-                    continue
-
-                yield None, generation
-                return
+    def _fetch_and_cache_plugin_model_providers(
+        cls, tenant_id: str, client: PluginModelClient | None, *, refresh_generation: int | None
+    ) -> tuple[ProviderEntity, ...]:
+        model_client = client or PluginModelClient()
+        providers = tuple(
+            cls._to_provider_entity(provider) for provider in model_client.fetch_model_providers(tenant_id)
+        )
+        generation = cls._load_plugin_model_providers_generation(tenant_id)
+        if generation is not None and generation == refresh_generation:
+            cls._store_cached_plugin_model_providers(tenant_id, generation, providers)
+        return providers
 
     @classmethod
     def invalidate_plugin_model_providers_cache(cls, tenant_id: str) -> None:
@@ -375,18 +332,68 @@ class PluginService:
         are intentionally owned by this service so tenant isolation and cache
         expiry are handled in one place.
         """
-        with cls._plugin_model_providers_refresh_context(tenant_id) as (cached_providers, refresh_generation):
+        deadline = time.monotonic() + cls.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT
+
+        while True:
+            generation = cls._load_plugin_model_providers_generation(tenant_id)
+            cached_providers, cache_available = cls._load_cached_plugin_model_providers_for_generation(
+                tenant_id, generation
+            )
             if cached_providers is not None:
                 return cached_providers
 
-            model_client = client or PluginModelClient()
-            providers = tuple(
-                cls._to_provider_entity(provider) for provider in model_client.fetch_model_providers(tenant_id)
-            )
-            generation = cls._load_plugin_model_providers_generation(tenant_id)
-            if generation is not None and generation == refresh_generation:
-                cls._store_cached_plugin_model_providers(tenant_id, generation, providers)
-            return providers
+            if generation is None or not cache_available:
+                return cls._fetch_and_cache_plugin_model_providers(
+                    tenant_id,
+                    client,
+                    refresh_generation=generation,
+                )
+
+            wait_timeout = deadline - time.monotonic()
+            if wait_timeout < 0:
+                logger.warning(
+                    "Provider refresh lock timed out; direct daemon fallback. tenant_id=%s generation=%s",
+                    tenant_id,
+                    generation,
+                )
+                return cls._fetch_and_cache_plugin_model_providers(
+                    tenant_id,
+                    client,
+                    refresh_generation=generation,
+                )
+
+            with cls._plugin_model_providers_refresh_lock(
+                tenant_id,
+                generation,
+                wait_timeout=wait_timeout,
+            ) as lock_acquired:
+                if not lock_acquired:
+                    return cls._fetch_and_cache_plugin_model_providers(
+                        tenant_id,
+                        client,
+                        refresh_generation=generation,
+                    )
+
+                latest_generation = cls._load_plugin_model_providers_generation(tenant_id)
+                cached_providers, cache_available = cls._load_cached_plugin_model_providers_for_generation(
+                    tenant_id, latest_generation
+                )
+                if cached_providers is not None:
+                    return cached_providers
+                if latest_generation is None or not cache_available:
+                    return cls._fetch_and_cache_plugin_model_providers(
+                        tenant_id,
+                        client,
+                        refresh_generation=latest_generation,
+                    )
+                if latest_generation != generation:
+                    continue
+
+                return cls._fetch_and_cache_plugin_model_providers(
+                    tenant_id,
+                    client,
+                    refresh_generation=generation,
+                )
 
     @staticmethod
     def fetch_latest_plugin_version(plugin_ids: Sequence[str]) -> Mapping[str, LatestPluginCache | None]:

--- a/api/core/plugin/plugin_service.py
+++ b/api/core/plugin/plugin_service.py
@@ -69,7 +69,7 @@ _provider_entities_adapter: TypeAdapter[list[ProviderEntity]] = TypeAdapter(list
 
 
 class _RedisLock(Protocol):
-    def acquire(self, *, blocking: bool = True) -> bool: ...
+    def acquire(self, *, blocking: bool = True, blocking_timeout: float | None = None) -> bool: ...
 
     def release(self) -> None: ...
 
@@ -91,6 +91,7 @@ class PluginService:
     PLUGIN_MODEL_PROVIDERS_GENERATION_REDIS_KEY_PREFIX = "plugin_model_providers_generation:tenant_id:"
     PLUGIN_MODEL_PROVIDERS_LOCK_REDIS_KEY_PREFIX = "plugin_model_providers_refresh_lock:tenant_id:"
     PLUGIN_MODEL_PROVIDERS_LOCK_TTL = 30
+    PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT = 2.0
     PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_INTERVAL = 0.05
     PLUGIN_INSTALL_TASK_TERMINAL_STATUSES = (PluginInstallTaskStatus.Success, PluginInstallTaskStatus.Failed)
     # Mirror the detail-panel endpoint query size so list reconciliation and
@@ -279,12 +280,20 @@ class PluginService:
 
     @classmethod
     def _try_acquire_plugin_model_providers_lock(
-        cls, tenant_id: str, generation: int
+        cls, tenant_id: str, generation: int, *, wait_timeout: float | None = None
     ) -> tuple[_RedisLock | None, bool]:
         lock_key = cls._get_plugin_model_providers_lock_key(tenant_id, generation)
+        blocking = wait_timeout is not None
         try:
-            lock = redis_client.lock(lock_key, timeout=cls.PLUGIN_MODEL_PROVIDERS_LOCK_TTL, blocking=False)
-            acquired = lock.acquire(blocking=False)
+            lock = redis_client.lock(
+                lock_key,
+                timeout=cls.PLUGIN_MODEL_PROVIDERS_LOCK_TTL,
+                sleep=cls.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_INTERVAL,
+            )
+            if blocking:
+                acquired = lock.acquire(blocking=True, blocking_timeout=wait_timeout)
+            else:
+                acquired = lock.acquire(blocking=False)
         except (RedisError, RuntimeError):
             logger.warning(
                 "Failed to acquire plugin model providers refresh lock for tenant %s.",
@@ -317,9 +326,9 @@ class PluginService:
         Return cached provider metadata or a lock granting permission to refresh it.
 
         Redis lock TTL is only a lease for crashed refresh owners; it is not a
-        waiter deadline. As long as Redis coordination is available, waiters keep
-        retrying the current generation until they either read cache or become
-        the next refresh owner.
+        waiter deadline. Waiters use Redis lock blocking with a short request
+        budget, then re-check cache before failing so requests do not hang behind
+        a stale or slow refresh owner.
         """
         while True:
             generation = cls._load_plugin_model_providers_generation(tenant_id)
@@ -331,13 +340,39 @@ class PluginService:
             if generation is None or not cache_available:
                 return None, None, generation
 
-            refresh_lock, lock_available = cls._try_acquire_plugin_model_providers_lock(tenant_id, generation)
-            if refresh_lock is not None:
-                return None, refresh_lock, generation
+            refresh_lock, lock_available = cls._try_acquire_plugin_model_providers_lock(
+                tenant_id,
+                generation,
+                wait_timeout=cls.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT,
+            )
             if not lock_available:
                 return None, None, generation
 
-            time.sleep(cls.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_INTERVAL)
+            latest_generation = cls._load_plugin_model_providers_generation(tenant_id)
+            cached_providers, cache_available = cls._load_cached_plugin_model_providers_for_generation(
+                tenant_id, latest_generation
+            )
+            if cached_providers is not None:
+                if refresh_lock is not None:
+                    cls._release_plugin_model_providers_lock(tenant_id, refresh_lock)
+                return cached_providers, None, latest_generation
+            if latest_generation is None or not cache_available:
+                if refresh_lock is not None:
+                    cls._release_plugin_model_providers_lock(tenant_id, refresh_lock)
+                return None, None, latest_generation
+            if latest_generation != generation:
+                if refresh_lock is not None:
+                    cls._release_plugin_model_providers_lock(tenant_id, refresh_lock)
+                continue
+            if refresh_lock is not None:
+                return None, refresh_lock, generation
+
+            logger.warning(
+                "Timed out waiting for plugin model providers refresh lock for tenant %s generation %s.",
+                tenant_id,
+                generation,
+            )
+            raise RuntimeError(f"Timed out waiting for plugin model providers refresh lock for tenant {tenant_id}.")
 
     @classmethod
     def invalidate_plugin_model_providers_cache(cls, tenant_id: str) -> None:

--- a/api/core/plugin/plugin_service.py
+++ b/api/core/plugin/plugin_service.py
@@ -14,9 +14,10 @@ metadata.
 
 import logging
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from mimetypes import guess_type
-from typing import ClassVar, Literal, Protocol
+from typing import Literal, NoReturn, Protocol
 
 from pydantic import BaseModel, TypeAdapter, ValidationError
 from redis import RedisError
@@ -75,8 +76,6 @@ class _RedisLock(Protocol):
 
 
 class PluginService:
-    _plugin_model_providers_memory_cache: ClassVar[dict[str, tuple[int, float, tuple[ProviderEntity, ...]]]] = {}
-
     class LatestPluginCache(BaseModel):
         plugin_id: str
         version: str
@@ -144,10 +143,6 @@ class PluginService:
         return declaration
 
     @classmethod
-    def _copy_provider_entities(cls, providers: Sequence[ProviderEntity]) -> tuple[ProviderEntity, ...]:
-        return tuple(provider.model_copy(deep=True) for provider in providers)
-
-    @classmethod
     def _load_plugin_model_providers_generation(cls, tenant_id: str) -> int | None:
         cache_key = cls._get_plugin_model_providers_generation_cache_key(tenant_id)
         try:
@@ -178,54 +173,13 @@ class PluginService:
             return None
 
     @classmethod
-    def _load_in_memory_plugin_model_providers(
-        cls, memory_cache_key: str, generation: int
-    ) -> tuple[ProviderEntity, ...] | None:
-        cached_entry = cls._plugin_model_providers_memory_cache.get(memory_cache_key)
-        if cached_entry is None:
-            return None
-
-        cached_generation, expires_at, providers = cached_entry
-        if cached_generation != generation or time.monotonic() >= expires_at:
-            cls._plugin_model_providers_memory_cache.pop(memory_cache_key, None)
-            return None
-
-        return cls._copy_provider_entities(providers)
-
-    @classmethod
-    def _store_in_memory_plugin_model_providers(
-        cls, memory_cache_key: str, generation: int, providers: Sequence[ProviderEntity]
-    ) -> None:
-        ttl = dify_config.PLUGIN_MODEL_PROVIDERS_CACHE_TTL
-        if ttl <= 0:
-            cls._plugin_model_providers_memory_cache.pop(memory_cache_key, None)
-            return
-
-        cls._plugin_model_providers_memory_cache[memory_cache_key] = (
-            generation,
-            time.monotonic() + ttl,
-            cls._copy_provider_entities(providers),
-        )
-
-    @classmethod
     def _load_cached_plugin_model_providers_for_generation(
         cls, tenant_id: str, generation: int | None
     ) -> tuple[tuple[ProviderEntity, ...] | None, bool]:
-        if generation is not None:
-            in_memory_cached_providers = cls._load_in_memory_plugin_model_providers(tenant_id, generation)
-            if in_memory_cached_providers is not None:
-                return in_memory_cached_providers, True
-
         if generation is None:
             return None, False
 
-        cache_keys = []
-        cache_keys.append(cls._get_plugin_model_providers_cache_key(tenant_id, generation))
-        if generation == 0:
-            cache_keys.append(cls._get_plugin_model_providers_cache_key(tenant_id))
-
-        if not cache_keys:
-            return None, True
+        cache_keys = [cls._get_plugin_model_providers_cache_key(tenant_id, generation)]
 
         try:
             cached_provider_entries = redis_client.mget(cache_keys)
@@ -246,8 +200,6 @@ class PluginService:
 
             try:
                 providers = tuple(_provider_entities_adapter.validate_json(cached_providers))
-                if generation is not None:
-                    cls._store_in_memory_plugin_model_providers(tenant_id, generation, providers)
                 return providers, True
             except (TypeError, ValueError, ValidationError):
                 logger.warning(
@@ -279,105 +231,129 @@ class PluginService:
             logger.warning("Failed to cache plugin model providers for tenant %s.", tenant_id, exc_info=True)
 
     @classmethod
-    def _try_acquire_plugin_model_providers_lock(
-        cls, tenant_id: str, generation: int, *, wait_timeout: float | None = None
-    ) -> tuple[_RedisLock | None, bool]:
+    def _raise_plugin_model_providers_refresh_timeout(
+        cls, tenant_id: str, generation: int, cause: BaseException | None = None
+    ) -> NoReturn:
+        logger.warning(
+            "Timed out waiting for plugin model providers refresh lock for tenant %s generation %s.",
+            tenant_id,
+            generation,
+        )
+        error = RuntimeError(f"Timed out waiting for plugin model providers refresh lock for tenant {tenant_id}.")
+        if cause is not None:
+            raise error from cause
+        raise error
+
+    @classmethod
+    @contextmanager
+    def _plugin_model_providers_refresh_lock(
+        cls, tenant_id: str, generation: int, *, wait_timeout: float
+    ) -> Iterator[bool]:
         lock_key = cls._get_plugin_model_providers_lock_key(tenant_id, generation)
-        blocking = wait_timeout is not None
         try:
-            lock = redis_client.lock(
+            refresh_lock: _RedisLock = redis_client.lock(
                 lock_key,
                 timeout=cls.PLUGIN_MODEL_PROVIDERS_LOCK_TTL,
                 sleep=cls.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_INTERVAL,
             )
-            if blocking:
-                acquired = lock.acquire(blocking=True, blocking_timeout=wait_timeout)
-            else:
-                acquired = lock.acquire(blocking=False)
         except (RedisError, RuntimeError):
+            logger.warning(
+                "Failed to create plugin model providers refresh lock for tenant %s.",
+                tenant_id,
+                exc_info=True,
+            )
+            yield False
+            return
+
+        try:
+            lock_acquired = refresh_lock.acquire(blocking=True, blocking_timeout=wait_timeout)
+        except LockError as exc:
+            cls._raise_plugin_model_providers_refresh_timeout(tenant_id, generation, exc)
+        except (RedisError, RuntimeError):
+            # Redis failures should not block provider discovery; lock contention is handled as timeout.
             logger.warning(
                 "Failed to acquire plugin model providers refresh lock for tenant %s.",
                 tenant_id,
                 exc_info=True,
             )
-            return None, False
+            yield False
+            return
 
-        if not acquired:
-            return None, True
+        if not lock_acquired:
+            cls._raise_plugin_model_providers_refresh_timeout(tenant_id, generation)
 
-        return lock, True
-
-    @classmethod
-    def _release_plugin_model_providers_lock(cls, tenant_id: str, lock: _RedisLock) -> None:
         try:
-            lock.release()
-        except (LockError, RedisError, RuntimeError):
-            logger.warning(
-                "Failed to release plugin model providers refresh lock for tenant %s.",
-                tenant_id,
-                exc_info=True,
-            )
+            yield True
+        finally:
+            try:
+                refresh_lock.release()
+            except (LockError, RedisError, RuntimeError):
+                # Release failures must not hide the daemon result or the original exception.
+                logger.warning(
+                    "Failed to release plugin model providers refresh lock for tenant %s generation %s.",
+                    tenant_id,
+                    generation,
+                    exc_info=True,
+                )
 
     @classmethod
-    def _load_or_acquire_plugin_model_providers_refresh(
+    @contextmanager
+    def _plugin_model_providers_refresh_context(
         cls, tenant_id: str
-    ) -> tuple[tuple[ProviderEntity, ...] | None, _RedisLock | None, int | None]:
+    ) -> Iterator[tuple[tuple[ProviderEntity, ...] | None, int | None]]:
         """
-        Return cached provider metadata or a lock granting permission to refresh it.
+        Return cached provider metadata or guard a caller-owned refresh with Redis lock.
 
-        Redis lock TTL is only a lease for crashed refresh owners; it is not a
-        waiter deadline. Waiters use Redis lock blocking with a short request
-        budget, then re-check cache before failing so requests do not hang behind
-        a stale or slow refresh owner.
+        Redis lock TTL is only a lease for crashed refresh owners. Waiters share
+        one request-local deadline across generation retries, then re-check cache
+        after entering the lock so concurrent requests do not stampede the daemon.
         """
+        deadline = time.monotonic() + cls.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT
+
         while True:
             generation = cls._load_plugin_model_providers_generation(tenant_id)
             cached_providers, cache_available = cls._load_cached_plugin_model_providers_for_generation(
                 tenant_id, generation
             )
             if cached_providers is not None:
-                return cached_providers, None, generation
+                yield cached_providers, generation
+                return
             if generation is None or not cache_available:
-                return None, None, generation
+                yield None, generation
+                return
 
-            refresh_lock, lock_available = cls._try_acquire_plugin_model_providers_lock(
+            wait_timeout = deadline - time.monotonic()
+            if wait_timeout < 0:
+                cls._raise_plugin_model_providers_refresh_timeout(tenant_id, generation)
+
+            with cls._plugin_model_providers_refresh_lock(
                 tenant_id,
                 generation,
-                wait_timeout=cls.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT,
-            )
-            if not lock_available:
-                return None, None, generation
+                wait_timeout=wait_timeout,
+            ) as lock_acquired:
+                if not lock_acquired:
+                    yield None, generation
+                    return
 
-            latest_generation = cls._load_plugin_model_providers_generation(tenant_id)
-            cached_providers, cache_available = cls._load_cached_plugin_model_providers_for_generation(
-                tenant_id, latest_generation
-            )
-            if cached_providers is not None:
-                if refresh_lock is not None:
-                    cls._release_plugin_model_providers_lock(tenant_id, refresh_lock)
-                return cached_providers, None, latest_generation
-            if latest_generation is None or not cache_available:
-                if refresh_lock is not None:
-                    cls._release_plugin_model_providers_lock(tenant_id, refresh_lock)
-                return None, None, latest_generation
-            if latest_generation != generation:
-                if refresh_lock is not None:
-                    cls._release_plugin_model_providers_lock(tenant_id, refresh_lock)
-                continue
-            if refresh_lock is not None:
-                return None, refresh_lock, generation
+                latest_generation = cls._load_plugin_model_providers_generation(tenant_id)
+                cached_providers, cache_available = cls._load_cached_plugin_model_providers_for_generation(
+                    tenant_id, latest_generation
+                )
+                if cached_providers is not None:
+                    yield cached_providers, latest_generation
+                    return
+                if latest_generation is None or not cache_available:
+                    yield None, latest_generation
+                    return
+                if latest_generation != generation:
+                    continue
 
-            logger.warning(
-                "Timed out waiting for plugin model providers refresh lock for tenant %s generation %s.",
-                tenant_id,
-                generation,
-            )
-            raise RuntimeError(f"Timed out waiting for plugin model providers refresh lock for tenant {tenant_id}.")
+                yield None, generation
+                return
 
     @classmethod
     def invalidate_plugin_model_providers_cache(cls, tenant_id: str) -> None:
-        """Invalidate tenant-scoped provider metadata across Redis and worker-local mirrors."""
-        cls._plugin_model_providers_memory_cache.pop(tenant_id, None)
+        """Invalidate tenant-scoped provider metadata stored in Redis."""
         cache_key = cls._get_plugin_model_providers_cache_key(tenant_id)
         generation_key = cls._get_plugin_model_providers_generation_cache_key(tenant_id)
         try:
@@ -399,25 +375,18 @@ class PluginService:
         are intentionally owned by this service so tenant isolation and cache
         expiry are handled in one place.
         """
-        cached_providers, refresh_lock, refresh_generation = cls._load_or_acquire_plugin_model_providers_refresh(
-            tenant_id
-        )
-        if cached_providers is not None:
-            return cached_providers
+        with cls._plugin_model_providers_refresh_context(tenant_id) as (cached_providers, refresh_generation):
+            if cached_providers is not None:
+                return cached_providers
 
-        model_client = client or PluginModelClient()
-        try:
+            model_client = client or PluginModelClient()
             providers = tuple(
                 cls._to_provider_entity(provider) for provider in model_client.fetch_model_providers(tenant_id)
             )
             generation = cls._load_plugin_model_providers_generation(tenant_id)
             if generation is not None and generation == refresh_generation:
-                cls._store_in_memory_plugin_model_providers(tenant_id, generation, providers)
                 cls._store_cached_plugin_model_providers(tenant_id, generation, providers)
             return providers
-        finally:
-            if refresh_lock is not None:
-                cls._release_plugin_model_providers_lock(tenant_id, refresh_lock)
 
     @staticmethod
     def fetch_latest_plugin_version(plugin_ids: Sequence[str]) -> Mapping[str, LatestPluginCache | None]:

--- a/api/core/plugin/plugin_service.py
+++ b/api/core/plugin/plugin_service.py
@@ -16,7 +16,7 @@ import logging
 import time
 from collections.abc import Mapping, Sequence
 from mimetypes import guess_type
-from typing import Any, ClassVar, Literal
+from typing import ClassVar, Literal, Protocol
 
 from pydantic import BaseModel, TypeAdapter, ValidationError
 from redis import RedisError
@@ -68,6 +68,12 @@ logger = logging.getLogger(__name__)
 _provider_entities_adapter: TypeAdapter[list[ProviderEntity]] = TypeAdapter(list[ProviderEntity])
 
 
+class _RedisLock(Protocol):
+    def acquire(self, *, blocking: bool = True) -> bool: ...
+
+    def release(self) -> None: ...
+
+
 class PluginService:
     _plugin_model_providers_memory_cache: ClassVar[dict[str, tuple[int, float, tuple[ProviderEntity, ...]]]] = {}
 
@@ -85,7 +91,6 @@ class PluginService:
     PLUGIN_MODEL_PROVIDERS_GENERATION_REDIS_KEY_PREFIX = "plugin_model_providers_generation:tenant_id:"
     PLUGIN_MODEL_PROVIDERS_LOCK_REDIS_KEY_PREFIX = "plugin_model_providers_refresh_lock:tenant_id:"
     PLUGIN_MODEL_PROVIDERS_LOCK_TTL = 30
-    PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT = 2.0
     PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_INTERVAL = 0.05
     PLUGIN_INSTALL_TASK_TERMINAL_STATUSES = (PluginInstallTaskStatus.Success, PluginInstallTaskStatus.Failed)
     # Mirror the detail-panel endpoint query size so list reconciliation and
@@ -202,14 +207,6 @@ class PluginService:
         )
 
     @classmethod
-    def _load_cached_plugin_model_providers(
-        cls, tenant_id: str, *, client: PluginModelClient | None = None
-    ) -> tuple[ProviderEntity, ...] | None:
-        generation = cls._load_plugin_model_providers_generation(tenant_id)
-        cached_providers, _ = cls._load_cached_plugin_model_providers_for_generation(tenant_id, generation)
-        return cached_providers
-
-    @classmethod
     def _load_cached_plugin_model_providers_for_generation(
         cls, tenant_id: str, generation: int | None
     ) -> tuple[tuple[ProviderEntity, ...] | None, bool]:
@@ -281,7 +278,9 @@ class PluginService:
             logger.warning("Failed to cache plugin model providers for tenant %s.", tenant_id, exc_info=True)
 
     @classmethod
-    def _try_acquire_plugin_model_providers_lock(cls, tenant_id: str, generation: int) -> tuple[Any | None, bool]:
+    def _try_acquire_plugin_model_providers_lock(
+        cls, tenant_id: str, generation: int
+    ) -> tuple[_RedisLock | None, bool]:
         lock_key = cls._get_plugin_model_providers_lock_key(tenant_id, generation)
         try:
             lock = redis_client.lock(lock_key, timeout=cls.PLUGIN_MODEL_PROVIDERS_LOCK_TTL, blocking=False)
@@ -300,7 +299,7 @@ class PluginService:
         return lock, True
 
     @classmethod
-    def _release_plugin_model_providers_lock(cls, tenant_id: str, lock: Any) -> None:
+    def _release_plugin_model_providers_lock(cls, tenant_id: str, lock: _RedisLock) -> None:
         try:
             lock.release()
         except (LockError, RedisError, RuntimeError):
@@ -311,17 +310,34 @@ class PluginService:
             )
 
     @classmethod
-    def _wait_for_plugin_model_providers_refresh(
-        cls, tenant_id: str, *, client: PluginModelClient | None = None
-    ) -> tuple[ProviderEntity, ...] | None:
-        deadline = time.monotonic() + cls.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT
-        while time.monotonic() < deadline:
-            time.sleep(cls.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_INTERVAL)
-            cached_providers = cls._load_cached_plugin_model_providers(tenant_id, client=client)
-            if cached_providers is not None:
-                return cached_providers
+    def _load_or_acquire_plugin_model_providers_refresh(
+        cls, tenant_id: str
+    ) -> tuple[tuple[ProviderEntity, ...] | None, _RedisLock | None, int | None]:
+        """
+        Return cached provider metadata or a lock granting permission to refresh it.
 
-        return None
+        Redis lock TTL is only a lease for crashed refresh owners; it is not a
+        waiter deadline. As long as Redis coordination is available, waiters keep
+        retrying the current generation until they either read cache or become
+        the next refresh owner.
+        """
+        while True:
+            generation = cls._load_plugin_model_providers_generation(tenant_id)
+            cached_providers, cache_available = cls._load_cached_plugin_model_providers_for_generation(
+                tenant_id, generation
+            )
+            if cached_providers is not None:
+                return cached_providers, None, generation
+            if generation is None or not cache_available:
+                return None, None, generation
+
+            refresh_lock, lock_available = cls._try_acquire_plugin_model_providers_lock(tenant_id, generation)
+            if refresh_lock is not None:
+                return None, refresh_lock, generation
+            if not lock_available:
+                return None, None, generation
+
+            time.sleep(cls.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_INTERVAL)
 
     @classmethod
     def invalidate_plugin_model_providers_cache(cls, tenant_id: str) -> None:
@@ -348,24 +364,11 @@ class PluginService:
         are intentionally owned by this service so tenant isolation and cache
         expiry are handled in one place.
         """
-        generation = cls._load_plugin_model_providers_generation(tenant_id)
-        cached_providers, cache_available = cls._load_cached_plugin_model_providers_for_generation(
-            tenant_id, generation
+        cached_providers, refresh_lock, refresh_generation = cls._load_or_acquire_plugin_model_providers_refresh(
+            tenant_id
         )
         if cached_providers is not None:
             return cached_providers
-
-        refresh_lock: Any | None = None
-        refresh_generation = generation
-        if generation is not None and cache_available:
-            lock_wait_deadline = time.monotonic() + cls.PLUGIN_MODEL_PROVIDERS_LOCK_TTL
-            while time.monotonic() < lock_wait_deadline:
-                refresh_lock, lock_available = cls._try_acquire_plugin_model_providers_lock(tenant_id, generation)
-                if refresh_lock is not None or not lock_available:
-                    break
-                refreshed_providers = cls._wait_for_plugin_model_providers_refresh(tenant_id, client=client)
-                if refreshed_providers is not None:
-                    return refreshed_providers
 
         model_client = client or PluginModelClient()
         try:

--- a/api/tests/unit_tests/core/plugin/test_model_runtime_adapter.py
+++ b/api/tests/unit_tests/core/plugin/test_model_runtime_adapter.py
@@ -3,7 +3,7 @@
 import datetime
 import uuid
 from types import SimpleNamespace
-from unittest.mock import Mock, patch, sentinel
+from unittest.mock import MagicMock, Mock, patch, sentinel
 
 import pytest
 
@@ -44,7 +44,13 @@ class _FakeRedis:
     def delete(self, key: str) -> None:
         self._values.pop(key, None)
 
-    def lock(self, key: str, *, timeout: int, blocking: bool) -> "_FakeRedisLock":
+    def lock(
+        self,
+        key: str,
+        *,
+        timeout: int,
+        sleep: float,
+    ) -> "_FakeRedisLock":
         return _FakeRedisLock(self, key)
 
 
@@ -54,7 +60,7 @@ class _FakeRedisLock:
         self._key = key
         self._acquired = False
 
-    def acquire(self, *, blocking: bool) -> bool:
+    def acquire(self, *, blocking: bool = True, blocking_timeout: float | None = None) -> bool:
         if self._key in self._redis._values:
             return False
 
@@ -66,13 +72,6 @@ class _FakeRedisLock:
         if self._acquired:
             self._redis.delete(self._key)
             self._acquired = False
-
-
-@pytest.fixture(autouse=True)
-def clear_plugin_model_provider_memory_cache() -> None:
-    PluginService._plugin_model_providers_memory_cache.clear()
-    yield
-    PluginService._plugin_model_providers_memory_cache.clear()
 
 
 def _build_model_schema() -> AIModelEntity:
@@ -436,10 +435,10 @@ class TestPluginModelRuntime:
             "redis_client",
             SimpleNamespace(
                 get=Mock(return_value=None),
-                mget=Mock(return_value=[None, None]),
+                mget=Mock(return_value=[None]),
                 delete=Mock(),
                 setex=Mock(),
-                lock=Mock(return_value=SimpleNamespace(acquire=Mock(return_value=True), release=Mock())),
+                lock=Mock(return_value=MagicMock()),
             ),
         )
         monkeypatch.setattr(plugin_service_module.dify_config, "PLUGIN_MODEL_PROVIDERS_CACHE_TTL", 0)

--- a/api/tests/unit_tests/services/plugin/test_plugin_service.py
+++ b/api/tests/unit_tests/services/plugin/test_plugin_service.py
@@ -270,12 +270,12 @@ class TestPluginModelProviderCache:
         client.fetch_model_providers.assert_not_called()
         assert [provider.provider for provider in result] == ["langgenius/openai/openai"]
 
-    def test_fetch_plugin_model_providers_retries_lock_after_wait_timeout(self) -> None:
-        """Only a lock owner should refresh the daemon when the first refresh takes too long."""
+    def test_fetch_plugin_model_providers_keeps_waiting_until_refresh_lock_is_owned(self) -> None:
+        """Only a lock owner should refresh the daemon, even when the first lock owner exceeds the lock TTL."""
         with (
             patch(f"{MODULE}.redis_client") as redis_client,
-            patch(f"{MODULE}.time.sleep"),
-            patch(f"{MODULE}.PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT", 0),
+            patch(f"{MODULE}.time.sleep") as sleep,
+            patch(f"{MODULE}.PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_TTL", 0),
         ):
             redis_client.get.return_value = None
             redis_client.mget.return_value = [None, None]
@@ -291,9 +291,57 @@ class TestPluginModelProviderCache:
             call(blocking=False),
             call(blocking=False),
         ]
+        sleep.assert_called_once_with(PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_INTERVAL)
         client.fetch_model_providers.assert_called_once_with("tenant-1")
         redis_client.lock.return_value.release.assert_called_once_with()
         assert [provider.provider for provider in result] == ["langgenius/openai/openai"]
+
+    def test_fetch_plugin_model_providers_restarts_lock_path_after_generation_changes(self) -> None:
+        """Waiters re-read provider generation before trying to become the next refresh owner."""
+        generation_key = _provider_generation_key("tenant-1")
+        stale_cache_key = _provider_cache_key("tenant-1", 0)
+        legacy_cache_key = _provider_cache_key("tenant-1")
+        new_cache_key = _provider_cache_key("tenant-1", 1)
+        with (
+            patch(f"{MODULE}.redis_client") as redis_client,
+            patch(f"{MODULE}.time.sleep") as sleep,
+        ):
+            redis_client.get.side_effect = [None, b"1", b"1"]
+            redis_client.mget.side_effect = [[None, None], [None]]
+            redis_client.lock.return_value.acquire.side_effect = [False, True]
+            client = Mock()
+            client.fetch_model_providers.return_value = [_build_plugin_model_provider(provider="anthropic")]
+
+            from core.plugin.plugin_service import PluginService
+
+            result = PluginService.fetch_plugin_model_providers(tenant_id="tenant-1", client=client)
+
+        assert redis_client.get.call_args_list == [
+            call(generation_key),
+            call(generation_key),
+            call(generation_key),
+        ]
+        assert redis_client.mget.call_args_list == [
+            call([stale_cache_key, legacy_cache_key]),
+            call([new_cache_key]),
+        ]
+        assert redis_client.lock.call_args_list == [
+            call(
+                PluginService._get_plugin_model_providers_lock_key("tenant-1", 0),
+                timeout=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_TTL,
+                blocking=False,
+            ),
+            call(
+                PluginService._get_plugin_model_providers_lock_key("tenant-1", 1),
+                timeout=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_TTL,
+                blocking=False,
+            ),
+        ]
+        sleep.assert_called_once_with(PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_INTERVAL)
+        client.fetch_model_providers.assert_called_once_with("tenant-1")
+        redis_client.setex.assert_called_once()
+        assert redis_client.setex.call_args.args[0] == new_cache_key
+        assert [provider.provider for provider in result] == ["langgenius/anthropic/anthropic"]
 
     def test_fetch_plugin_model_providers_releases_owned_refresh_lock_after_store(self) -> None:
         """The refresh owner releases only its token after storing provider metadata."""

--- a/api/tests/unit_tests/services/plugin/test_plugin_service.py
+++ b/api/tests/unit_tests/services/plugin/test_plugin_service.py
@@ -131,7 +131,7 @@ class TestPluginModelProviderCache:
     def test_fetch_plugin_model_providers_returns_cached_provider_without_calling_daemon(self) -> None:
         """A valid tenant cache entry is reused across runtime calls without plugin daemon access."""
         cached_provider = _build_provider_entity()
-        cached_payload = TypeAdapter(list[ProviderEntity]).dump_json([cached_provider]).decode("utf-8")
+        cached_payload = TypeAdapter(list[ProviderEntity]).dump_json([cached_provider])
         generation_key = _provider_generation_key("tenant-1")
         cache_key = _provider_cache_key("tenant-1", 0)
 
@@ -229,7 +229,7 @@ class TestPluginModelProviderCache:
     def test_fetch_plugin_model_providers_waits_for_concurrent_refresh_cache_fill(self) -> None:
         """A cache miss waits for the active tenant refresh instead of stampeding the daemon."""
         cached_provider = _build_provider_entity()
-        cached_payload = TypeAdapter(list[ProviderEntity]).dump_json([cached_provider]).decode("utf-8")
+        cached_payload = TypeAdapter(list[ProviderEntity]).dump_json([cached_provider])
         cache_key = _provider_cache_key("tenant-1", 0)
 
         with (
@@ -262,8 +262,9 @@ class TestPluginModelProviderCache:
         client.fetch_model_providers.assert_not_called()
         assert [provider.provider for provider in result] == ["langgenius/openai/openai"]
 
-    def test_fetch_plugin_model_providers_fails_when_refresh_lock_wait_times_out(self) -> None:
-        """A request should fail fast instead of waiting indefinitely behind an active refresh lock."""
+    def test_fetch_plugin_model_providers_falls_back_when_refresh_lock_wait_times_out(self) -> None:
+        """A request should stop waiting and fetch directly instead of surfacing lock contention."""
+        cache_key = _provider_cache_key("tenant-1", 0)
         with (
             patch(f"{MODULE}.redis_client") as redis_client,
             patch(f"{MODULE}.PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT", 0),
@@ -277,8 +278,7 @@ class TestPluginModelProviderCache:
 
             from core.plugin.plugin_service import PluginService
 
-            with pytest.raises(RuntimeError, match="Timed out waiting for plugin model providers refresh lock"):
-                PluginService.fetch_plugin_model_providers(tenant_id="tenant-1", client=client)
+            result = PluginService.fetch_plugin_model_providers(tenant_id="tenant-1", client=client)
 
         redis_client.lock.assert_called_once_with(
             PluginService._get_plugin_model_providers_lock_key("tenant-1", 0),
@@ -287,7 +287,10 @@ class TestPluginModelProviderCache:
         )
         redis_client.lock.return_value.acquire.assert_called_once_with(blocking=True, blocking_timeout=0)
         redis_client.lock.return_value.release.assert_not_called()
-        client.fetch_model_providers.assert_not_called()
+        client.fetch_model_providers.assert_called_once_with("tenant-1")
+        redis_client.setex.assert_called_once()
+        assert redis_client.setex.call_args.args[0] == cache_key
+        assert [provider.provider for provider in result] == ["langgenius/openai/openai"]
 
     def test_fetch_plugin_model_providers_restarts_lock_path_after_generation_changes(self) -> None:
         """Waiters re-read provider generation before trying to become the next refresh owner."""
@@ -342,8 +345,8 @@ class TestPluginModelProviderCache:
         assert redis_client.setex.call_args.args[0] == new_cache_key
         assert [provider.provider for provider in result] == ["langgenius/anthropic/anthropic"]
 
-    def test_fetch_plugin_model_providers_fails_when_generation_retries_exhaust_wait_budget(self) -> None:
-        """Generation retry loops share one request-local lock wait deadline."""
+    def test_fetch_plugin_model_providers_falls_back_when_generation_retries_exhaust_wait_budget(self) -> None:
+        """Generation retry loops share one request-local lock wait deadline before direct fetch fallback."""
         generation_key = _provider_generation_key("tenant-1")
         stale_cache_key = _provider_cache_key("tenant-1", 0)
         new_cache_key = _provider_cache_key("tenant-1", 1)
@@ -352,16 +355,17 @@ class TestPluginModelProviderCache:
             patch(f"{MODULE}.redis_client") as redis_client,
             patch(f"{MODULE}.time.monotonic", side_effect=[100.0, 100.0, 102.1]),
         ):
-            redis_client.get.side_effect = [None, b"1", b"1"]
+            redis_client.get.side_effect = [None, b"1", b"1", b"1"]
             redis_client.mget.side_effect = [[None], [None], [None]]
             client = Mock()
+            client.fetch_model_providers.return_value = [_build_plugin_model_provider(provider="anthropic")]
 
             from core.plugin.plugin_service import PluginService
 
-            with pytest.raises(RuntimeError, match="Timed out waiting for plugin model providers refresh lock"):
-                PluginService.fetch_plugin_model_providers(tenant_id="tenant-1", client=client)
+            result = PluginService.fetch_plugin_model_providers(tenant_id="tenant-1", client=client)
 
         assert redis_client.get.call_args_list == [
+            call(generation_key),
             call(generation_key),
             call(generation_key),
             call(generation_key),
@@ -378,7 +382,10 @@ class TestPluginModelProviderCache:
         )
         redis_client.lock.return_value.acquire.assert_called_once_with(blocking=True, blocking_timeout=2.0)
         redis_client.lock.return_value.release.assert_called_once()
-        client.fetch_model_providers.assert_not_called()
+        client.fetch_model_providers.assert_called_once_with("tenant-1")
+        redis_client.setex.assert_called_once()
+        assert redis_client.setex.call_args.args[0] == new_cache_key
+        assert [provider.provider for provider in result] == ["langgenius/anthropic/anthropic"]
 
     def test_fetch_plugin_model_providers_releases_owned_refresh_lock_after_store(self) -> None:
         """The refresh owner releases only its token after storing provider metadata."""
@@ -549,7 +556,7 @@ class TestPluginModelProviderCache:
 
     def test_fetch_plugin_model_providers_reuses_cached_empty_provider_list(self) -> None:
         """A cached empty list should prevent repeated daemon fetches for tenants without plugin models."""
-        empty_payload = TypeAdapter(list[ProviderEntity]).dump_json([]).decode("utf-8")
+        empty_payload = TypeAdapter(list[ProviderEntity]).dump_json([])
         cache_key = _provider_cache_key("tenant-1", 0)
 
         with patch(f"{MODULE}.redis_client") as redis_client:

--- a/api/tests/unit_tests/services/plugin/test_plugin_service.py
+++ b/api/tests/unit_tests/services/plugin/test_plugin_service.py
@@ -169,8 +169,9 @@ class TestPluginModelProviderCache:
             patch(f"{MODULE}.redis_client") as redis_client,
             patch(f"{MODULE}.dify_config") as mock_config,
         ):
-            redis_client.get.side_effect = [None, None]
-            redis_client.mget.return_value = ["not-json", None]
+            redis_client.get.side_effect = [None, None, None]
+            redis_client.mget.side_effect = [["not-json", None], [None, None]]
+            redis_client.lock.return_value.acquire.return_value = True
             mock_config.PLUGIN_MODEL_PROVIDERS_CACHE_TTL = 86400
             client = Mock()
             client.fetch_model_providers.return_value = [_build_plugin_model_provider()]
@@ -184,8 +185,11 @@ class TestPluginModelProviderCache:
         assert redis_client.setex.call_args.args[0] == cache_key
         assert redis_client.setex.call_args.args[1] == 86400
         assert [provider.provider for provider in result] == ["langgenius/openai/openai"]
-        redis_client.get.assert_has_calls([call(generation_key), call(generation_key)])
-        redis_client.mget.assert_called_once_with([cache_key, legacy_cache_key])
+        redis_client.get.assert_has_calls([call(generation_key), call(generation_key), call(generation_key)])
+        assert redis_client.mget.call_args_list == [
+            call([cache_key, legacy_cache_key]),
+            call([cache_key, legacy_cache_key]),
+        ]
 
     def test_fetch_plugin_model_providers_refetches_when_cache_read_fails(self) -> None:
         """Redis read failures do not block provider discovery for the tenant."""
@@ -242,13 +246,10 @@ class TestPluginModelProviderCache:
         cache_key = _provider_cache_key("tenant-1", 0)
         legacy_cache_key = _provider_cache_key("tenant-1")
 
-        with (
-            patch(f"{MODULE}.redis_client") as redis_client,
-            patch(f"{MODULE}.time.sleep") as sleep,
-        ):
+        with patch(f"{MODULE}.redis_client") as redis_client:
             redis_client.get.return_value = None
             redis_client.mget.side_effect = [[None, None], [cached_payload, None]]
-            redis_client.lock.return_value.acquire.return_value = False
+            redis_client.lock.return_value.acquire.return_value = True
             client = Mock()
             client.fetch_model_providers.return_value = [_build_plugin_model_provider(provider="anthropic")]
 
@@ -259,42 +260,45 @@ class TestPluginModelProviderCache:
         redis_client.lock.assert_called_once_with(
             PluginService._get_plugin_model_providers_lock_key("tenant-1", 0),
             timeout=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_TTL,
-            blocking=False,
+            sleep=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_INTERVAL,
         )
-        redis_client.lock.return_value.acquire.assert_called_once_with(blocking=False)
+        redis_client.lock.return_value.acquire.assert_called_once_with(
+            blocking=True,
+            blocking_timeout=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT,
+        )
         assert redis_client.mget.call_args_list == [
             call([cache_key, legacy_cache_key]),
             call([cache_key, legacy_cache_key]),
         ]
-        sleep.assert_called()
+        redis_client.lock.return_value.release.assert_called_once_with()
         client.fetch_model_providers.assert_not_called()
         assert [provider.provider for provider in result] == ["langgenius/openai/openai"]
 
-    def test_fetch_plugin_model_providers_keeps_waiting_until_refresh_lock_is_owned(self) -> None:
-        """Only a lock owner should refresh the daemon, even when the first lock owner exceeds the lock TTL."""
+    def test_fetch_plugin_model_providers_fails_when_refresh_lock_wait_times_out(self) -> None:
+        """A request should fail fast instead of waiting indefinitely behind an active refresh lock."""
         with (
             patch(f"{MODULE}.redis_client") as redis_client,
-            patch(f"{MODULE}.time.sleep") as sleep,
-            patch(f"{MODULE}.PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_TTL", 0),
+            patch(f"{MODULE}.PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT", 0),
         ):
             redis_client.get.return_value = None
             redis_client.mget.return_value = [None, None]
-            redis_client.lock.return_value.acquire.side_effect = [False, True]
+            redis_client.lock.return_value.acquire.return_value = False
             client = Mock()
             client.fetch_model_providers.return_value = [_build_plugin_model_provider()]
 
             from core.plugin.plugin_service import PluginService
 
-            result = PluginService.fetch_plugin_model_providers(tenant_id="tenant-1", client=client)
+            with pytest.raises(RuntimeError, match="Timed out waiting for plugin model providers refresh lock"):
+                PluginService.fetch_plugin_model_providers(tenant_id="tenant-1", client=client)
 
-        assert redis_client.lock.return_value.acquire.call_args_list == [
-            call(blocking=False),
-            call(blocking=False),
-        ]
-        sleep.assert_called_once_with(PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_INTERVAL)
-        client.fetch_model_providers.assert_called_once_with("tenant-1")
-        redis_client.lock.return_value.release.assert_called_once_with()
-        assert [provider.provider for provider in result] == ["langgenius/openai/openai"]
+        redis_client.lock.assert_called_once_with(
+            PluginService._get_plugin_model_providers_lock_key("tenant-1", 0),
+            timeout=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_TTL,
+            sleep=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_INTERVAL,
+        )
+        redis_client.lock.return_value.acquire.assert_called_once_with(blocking=True, blocking_timeout=0)
+        redis_client.lock.return_value.release.assert_not_called()
+        client.fetch_model_providers.assert_not_called()
 
     def test_fetch_plugin_model_providers_restarts_lock_path_after_generation_changes(self) -> None:
         """Waiters re-read provider generation before trying to become the next refresh owner."""
@@ -304,11 +308,10 @@ class TestPluginModelProviderCache:
         new_cache_key = _provider_cache_key("tenant-1", 1)
         with (
             patch(f"{MODULE}.redis_client") as redis_client,
-            patch(f"{MODULE}.time.sleep") as sleep,
         ):
-            redis_client.get.side_effect = [None, b"1", b"1"]
-            redis_client.mget.side_effect = [[None, None], [None]]
-            redis_client.lock.return_value.acquire.side_effect = [False, True]
+            redis_client.get.side_effect = [None, b"1", b"1", b"1", b"1"]
+            redis_client.mget.side_effect = [[None, None], [None], [None], [None]]
+            redis_client.lock.return_value.acquire.side_effect = [True, True]
             client = Mock()
             client.fetch_model_providers.return_value = [_build_plugin_model_provider(provider="anthropic")]
 
@@ -320,24 +323,32 @@ class TestPluginModelProviderCache:
             call(generation_key),
             call(generation_key),
             call(generation_key),
+            call(generation_key),
+            call(generation_key),
         ]
         assert redis_client.mget.call_args_list == [
             call([stale_cache_key, legacy_cache_key]),
+            call([new_cache_key]),
+            call([new_cache_key]),
             call([new_cache_key]),
         ]
         assert redis_client.lock.call_args_list == [
             call(
                 PluginService._get_plugin_model_providers_lock_key("tenant-1", 0),
                 timeout=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_TTL,
-                blocking=False,
+                sleep=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_INTERVAL,
             ),
             call(
                 PluginService._get_plugin_model_providers_lock_key("tenant-1", 1),
                 timeout=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_TTL,
-                blocking=False,
+                sleep=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_INTERVAL,
             ),
         ]
-        sleep.assert_called_once_with(PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_INTERVAL)
+        assert redis_client.lock.return_value.acquire.call_args_list == [
+            call(blocking=True, blocking_timeout=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT),
+            call(blocking=True, blocking_timeout=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT),
+        ]
+        assert redis_client.lock.return_value.release.call_count == 2
         client.fetch_model_providers.assert_called_once_with("tenant-1")
         redis_client.setex.assert_called_once()
         assert redis_client.setex.call_args.args[0] == new_cache_key
@@ -362,10 +373,16 @@ class TestPluginModelProviderCache:
         redis_client.lock.assert_called_once_with(
             PluginService._get_plugin_model_providers_lock_key("tenant-1", 0),
             timeout=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_TTL,
-            blocking=False,
+            sleep=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_INTERVAL,
         )
-        redis_client.lock.return_value.acquire.assert_called_once_with(blocking=False)
-        redis_client.mget.assert_called_once_with([cache_key, legacy_cache_key])
+        redis_client.lock.return_value.acquire.assert_called_once_with(
+            blocking=True,
+            blocking_timeout=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT,
+        )
+        assert redis_client.mget.call_args_list == [
+            call([cache_key, legacy_cache_key]),
+            call([cache_key, legacy_cache_key]),
+        ]
         redis_client.lock.return_value.release.assert_called_once_with()
         redis_client.eval.assert_not_called()
         client.fetch_model_providers.assert_called_once_with("tenant-1")
@@ -415,7 +432,7 @@ class TestPluginModelProviderCache:
     def test_fetch_plugin_model_providers_skips_cache_write_when_generation_changes_during_refresh(self) -> None:
         """A refresh that started before invalidation must not populate the newer generation cache."""
         with patch(f"{MODULE}.redis_client") as redis_client:
-            redis_client.get.side_effect = [None, "1"]
+            redis_client.get.side_effect = [None, None, "1"]
             redis_client.mget.return_value = [None, None]
             redis_client.lock.return_value.acquire.return_value = True
             client = Mock()
@@ -474,7 +491,7 @@ class TestPluginModelProviderCache:
             patch(f"{MODULE}.redis_client") as redis_client,
             patch(f"{MODULE}.PluginModelClient") as client_cls,
         ):
-            redis_client.get.side_effect = [None, None, None]
+            redis_client.get.return_value = None
             redis_client.mget.return_value = [None, None]
             client = client_cls.return_value
             client.fetch_model_providers.return_value = [_build_plugin_model_provider()]
@@ -543,8 +560,9 @@ class TestPluginModelProviderCache:
         generation_key = _provider_generation_key("tenant-1")
         new_cache_key = _provider_cache_key("tenant-1", 1)
         with patch(f"{MODULE}.redis_client") as redis_client:
-            redis_client.get.side_effect = [b"1", b"1"]
+            redis_client.get.side_effect = [b"1", b"1", b"1"]
             redis_client.mget.return_value = [None]
+            redis_client.lock.return_value.acquire.return_value = True
             client = Mock()
             client.fetch_model_providers.return_value = [_build_plugin_model_provider(provider="anthropic")]
 
@@ -554,8 +572,11 @@ class TestPluginModelProviderCache:
             result = PluginService.fetch_plugin_model_providers(tenant_id="tenant-1", client=client)
 
         client.fetch_model_providers.assert_called_once_with("tenant-1")
-        redis_client.get.assert_has_calls([call(generation_key), call(generation_key)])
-        redis_client.mget.assert_called_once_with([new_cache_key])
+        redis_client.get.assert_has_calls([call(generation_key), call(generation_key), call(generation_key)])
+        assert redis_client.mget.call_args_list == [
+            call([new_cache_key]),
+            call([new_cache_key]),
+        ]
         redis_client.setex.assert_called_once()
         assert redis_client.setex.call_args.args[0] == new_cache_key
         assert PluginService._plugin_model_providers_memory_cache["tenant-1"][0] == 1

--- a/api/tests/unit_tests/services/plugin/test_plugin_service.py
+++ b/api/tests/unit_tests/services/plugin/test_plugin_service.py
@@ -14,15 +14,6 @@ from graphon.model_runtime.entities.provider_entities import ConfigurateMethod, 
 MODULE = "core.plugin.plugin_service"
 
 
-@pytest.fixture(autouse=True)
-def clear_plugin_model_provider_memory_cache() -> None:
-    from core.plugin.plugin_service import PluginService
-
-    PluginService._plugin_model_providers_memory_cache.clear()
-    yield
-    PluginService._plugin_model_providers_memory_cache.clear()
-
-
 class _FakeSession:
     def __init__(self) -> None:
         self.execute = Mock()
@@ -143,11 +134,10 @@ class TestPluginModelProviderCache:
         cached_payload = TypeAdapter(list[ProviderEntity]).dump_json([cached_provider]).decode("utf-8")
         generation_key = _provider_generation_key("tenant-1")
         cache_key = _provider_cache_key("tenant-1", 0)
-        legacy_cache_key = _provider_cache_key("tenant-1")
 
         with patch(f"{MODULE}.redis_client") as redis_client:
             redis_client.get.return_value = None
-            redis_client.mget.return_value = [cached_payload, None]
+            redis_client.mget.return_value = [cached_payload]
 
             from core.plugin.plugin_service import PluginService
 
@@ -158,20 +148,18 @@ class TestPluginModelProviderCache:
         client.fetch_model_providers.assert_not_called()
         redis_client.setex.assert_not_called()
         redis_client.get.assert_called_once_with(generation_key)
-        redis_client.mget.assert_called_once_with([cache_key, legacy_cache_key])
+        redis_client.mget.assert_called_once_with([cache_key])
 
     def test_fetch_plugin_model_providers_deletes_invalid_cache_and_refetches(self) -> None:
         """Invalid generation-scoped cache payloads are removed before falling back to the daemon."""
         generation_key = _provider_generation_key("tenant-1")
         cache_key = _provider_cache_key("tenant-1", 0)
-        legacy_cache_key = _provider_cache_key("tenant-1")
         with (
             patch(f"{MODULE}.redis_client") as redis_client,
             patch(f"{MODULE}.dify_config") as mock_config,
         ):
             redis_client.get.side_effect = [None, None, None]
-            redis_client.mget.side_effect = [["not-json", None], [None, None]]
-            redis_client.lock.return_value.acquire.return_value = True
+            redis_client.mget.side_effect = [["not-json"], [None]]
             mock_config.PLUGIN_MODEL_PROVIDERS_CACHE_TTL = 86400
             client = Mock()
             client.fetch_model_providers.return_value = [_build_plugin_model_provider()]
@@ -187,8 +175,8 @@ class TestPluginModelProviderCache:
         assert [provider.provider for provider in result] == ["langgenius/openai/openai"]
         redis_client.get.assert_has_calls([call(generation_key), call(generation_key), call(generation_key)])
         assert redis_client.mget.call_args_list == [
-            call([cache_key, legacy_cache_key]),
-            call([cache_key, legacy_cache_key]),
+            call([cache_key]),
+            call([cache_key]),
         ]
 
     def test_fetch_plugin_model_providers_refetches_when_cache_read_fails(self) -> None:
@@ -208,7 +196,6 @@ class TestPluginModelProviderCache:
     def test_fetch_plugin_model_providers_refetches_when_cached_payload_batch_read_fails(self) -> None:
         """Redis mget failures do not block provider discovery for the tenant."""
         cache_key = _provider_cache_key("tenant-1", 0)
-        legacy_cache_key = _provider_cache_key("tenant-1")
         with patch(f"{MODULE}.redis_client") as redis_client:
             redis_client.get.return_value = None
             redis_client.mget.side_effect = RedisError("redis unavailable")
@@ -220,14 +207,14 @@ class TestPluginModelProviderCache:
             result = PluginService.fetch_plugin_model_providers(tenant_id="tenant-1", client=client)
 
         client.fetch_model_providers.assert_called_once_with("tenant-1")
-        redis_client.mget.assert_called_once_with([cache_key, legacy_cache_key])
+        redis_client.mget.assert_called_once_with([cache_key])
         assert [provider.provider for provider in result] == ["langgenius/openai/openai"]
 
     def test_fetch_plugin_model_providers_returns_fresh_result_when_cache_write_fails(self) -> None:
         """Redis write failures are non-fatal after fresh provider data has been fetched."""
         with patch(f"{MODULE}.redis_client") as redis_client:
             redis_client.get.return_value = None
-            redis_client.mget.return_value = [None, None]
+            redis_client.mget.return_value = [None]
             redis_client.setex.side_effect = RedisError("redis unavailable")
             client = Mock()
             client.fetch_model_providers.return_value = [_build_plugin_model_provider()]
@@ -244,12 +231,13 @@ class TestPluginModelProviderCache:
         cached_provider = _build_provider_entity()
         cached_payload = TypeAdapter(list[ProviderEntity]).dump_json([cached_provider]).decode("utf-8")
         cache_key = _provider_cache_key("tenant-1", 0)
-        legacy_cache_key = _provider_cache_key("tenant-1")
 
-        with patch(f"{MODULE}.redis_client") as redis_client:
+        with (
+            patch(f"{MODULE}.redis_client") as redis_client,
+            patch(f"{MODULE}.time.monotonic", return_value=100.0),
+        ):
             redis_client.get.return_value = None
-            redis_client.mget.side_effect = [[None, None], [cached_payload, None]]
-            redis_client.lock.return_value.acquire.return_value = True
+            redis_client.mget.side_effect = [[None], [cached_payload]]
             client = Mock()
             client.fetch_model_providers.return_value = [_build_plugin_model_provider(provider="anthropic")]
 
@@ -267,10 +255,10 @@ class TestPluginModelProviderCache:
             blocking_timeout=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT,
         )
         assert redis_client.mget.call_args_list == [
-            call([cache_key, legacy_cache_key]),
-            call([cache_key, legacy_cache_key]),
+            call([cache_key]),
+            call([cache_key]),
         ]
-        redis_client.lock.return_value.release.assert_called_once_with()
+        redis_client.lock.return_value.release.assert_called_once()
         client.fetch_model_providers.assert_not_called()
         assert [provider.provider for provider in result] == ["langgenius/openai/openai"]
 
@@ -279,9 +267,10 @@ class TestPluginModelProviderCache:
         with (
             patch(f"{MODULE}.redis_client") as redis_client,
             patch(f"{MODULE}.PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT", 0),
+            patch(f"{MODULE}.time.monotonic", return_value=100.0),
         ):
             redis_client.get.return_value = None
-            redis_client.mget.return_value = [None, None]
+            redis_client.mget.return_value = [None]
             redis_client.lock.return_value.acquire.return_value = False
             client = Mock()
             client.fetch_model_providers.return_value = [_build_plugin_model_provider()]
@@ -304,14 +293,13 @@ class TestPluginModelProviderCache:
         """Waiters re-read provider generation before trying to become the next refresh owner."""
         generation_key = _provider_generation_key("tenant-1")
         stale_cache_key = _provider_cache_key("tenant-1", 0)
-        legacy_cache_key = _provider_cache_key("tenant-1")
         new_cache_key = _provider_cache_key("tenant-1", 1)
         with (
             patch(f"{MODULE}.redis_client") as redis_client,
+            patch(f"{MODULE}.time.monotonic", side_effect=[100.0, 100.0, 100.5, 101.0]),
         ):
             redis_client.get.side_effect = [None, b"1", b"1", b"1", b"1"]
-            redis_client.mget.side_effect = [[None, None], [None], [None], [None]]
-            redis_client.lock.return_value.acquire.side_effect = [True, True]
+            redis_client.mget.side_effect = [[None], [None], [None], [None]]
             client = Mock()
             client.fetch_model_providers.return_value = [_build_plugin_model_provider(provider="anthropic")]
 
@@ -327,7 +315,7 @@ class TestPluginModelProviderCache:
             call(generation_key),
         ]
         assert redis_client.mget.call_args_list == [
-            call([stale_cache_key, legacy_cache_key]),
+            call([stale_cache_key]),
             call([new_cache_key]),
             call([new_cache_key]),
             call([new_cache_key]),
@@ -345,8 +333,8 @@ class TestPluginModelProviderCache:
             ),
         ]
         assert redis_client.lock.return_value.acquire.call_args_list == [
-            call(blocking=True, blocking_timeout=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT),
-            call(blocking=True, blocking_timeout=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT),
+            call(blocking=True, blocking_timeout=2.0),
+            call(blocking=True, blocking_timeout=1.5),
         ]
         assert redis_client.lock.return_value.release.call_count == 2
         client.fetch_model_providers.assert_called_once_with("tenant-1")
@@ -354,15 +342,54 @@ class TestPluginModelProviderCache:
         assert redis_client.setex.call_args.args[0] == new_cache_key
         assert [provider.provider for provider in result] == ["langgenius/anthropic/anthropic"]
 
+    def test_fetch_plugin_model_providers_fails_when_generation_retries_exhaust_wait_budget(self) -> None:
+        """Generation retry loops share one request-local lock wait deadline."""
+        generation_key = _provider_generation_key("tenant-1")
+        stale_cache_key = _provider_cache_key("tenant-1", 0)
+        new_cache_key = _provider_cache_key("tenant-1", 1)
+
+        with (
+            patch(f"{MODULE}.redis_client") as redis_client,
+            patch(f"{MODULE}.time.monotonic", side_effect=[100.0, 100.0, 102.1]),
+        ):
+            redis_client.get.side_effect = [None, b"1", b"1"]
+            redis_client.mget.side_effect = [[None], [None], [None]]
+            client = Mock()
+
+            from core.plugin.plugin_service import PluginService
+
+            with pytest.raises(RuntimeError, match="Timed out waiting for plugin model providers refresh lock"):
+                PluginService.fetch_plugin_model_providers(tenant_id="tenant-1", client=client)
+
+        assert redis_client.get.call_args_list == [
+            call(generation_key),
+            call(generation_key),
+            call(generation_key),
+        ]
+        assert redis_client.mget.call_args_list == [
+            call([stale_cache_key]),
+            call([new_cache_key]),
+            call([new_cache_key]),
+        ]
+        redis_client.lock.assert_called_once_with(
+            PluginService._get_plugin_model_providers_lock_key("tenant-1", 0),
+            timeout=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_TTL,
+            sleep=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_INTERVAL,
+        )
+        redis_client.lock.return_value.acquire.assert_called_once_with(blocking=True, blocking_timeout=2.0)
+        redis_client.lock.return_value.release.assert_called_once()
+        client.fetch_model_providers.assert_not_called()
+
     def test_fetch_plugin_model_providers_releases_owned_refresh_lock_after_store(self) -> None:
         """The refresh owner releases only its token after storing provider metadata."""
         cache_key = _provider_cache_key("tenant-1", 0)
-        legacy_cache_key = _provider_cache_key("tenant-1")
 
-        with patch(f"{MODULE}.redis_client") as redis_client:
+        with (
+            patch(f"{MODULE}.redis_client") as redis_client,
+            patch(f"{MODULE}.time.monotonic", return_value=100.0),
+        ):
             redis_client.get.return_value = None
-            redis_client.mget.return_value = [None, None]
-            redis_client.lock.return_value.acquire.return_value = True
+            redis_client.mget.return_value = [None]
             client = Mock()
             client.fetch_model_providers.return_value = [_build_plugin_model_provider()]
 
@@ -380,11 +407,86 @@ class TestPluginModelProviderCache:
             blocking_timeout=PluginService.PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT,
         )
         assert redis_client.mget.call_args_list == [
-            call([cache_key, legacy_cache_key]),
-            call([cache_key, legacy_cache_key]),
+            call([cache_key]),
+            call([cache_key]),
         ]
-        redis_client.lock.return_value.release.assert_called_once_with()
+        redis_client.lock.return_value.release.assert_called_once()
         redis_client.eval.assert_not_called()
+        client.fetch_model_providers.assert_called_once_with("tenant-1")
+        assert [provider.provider for provider in result] == ["langgenius/openai/openai"]
+
+    def test_fetch_plugin_model_providers_returns_fresh_result_when_refresh_lock_release_fails(self) -> None:
+        """Release failures are logged, not allowed to hide a successful daemon refresh."""
+        cache_key = _provider_cache_key("tenant-1", 0)
+
+        with (
+            patch(f"{MODULE}.redis_client") as redis_client,
+            patch(f"{MODULE}.time.monotonic", return_value=100.0),
+        ):
+            redis_client.get.return_value = None
+            redis_client.mget.return_value = [None]
+            redis_client.lock.return_value.release.side_effect = RedisError("release failed")
+            client = Mock()
+            client.fetch_model_providers.return_value = [_build_plugin_model_provider()]
+
+            from core.plugin.plugin_service import PluginService
+
+            result = PluginService.fetch_plugin_model_providers(tenant_id="tenant-1", client=client)
+
+        assert redis_client.mget.call_args_list == [
+            call([cache_key]),
+            call([cache_key]),
+        ]
+        client.fetch_model_providers.assert_called_once_with("tenant-1")
+        redis_client.setex.assert_called_once()
+        redis_client.lock.return_value.release.assert_called_once()
+        assert [provider.provider for provider in result] == ["langgenius/openai/openai"]
+
+    def test_fetch_plugin_model_providers_releases_owned_refresh_lock_when_fetch_fails(self) -> None:
+        """Release failures must not hide the daemon failure that happened while owning the lock."""
+        cache_key = _provider_cache_key("tenant-1", 0)
+
+        with (
+            patch(f"{MODULE}.redis_client") as redis_client,
+            patch(f"{MODULE}.time.monotonic", return_value=100.0),
+        ):
+            redis_client.get.return_value = None
+            redis_client.mget.return_value = [None]
+            redis_client.lock.return_value.release.side_effect = RedisError("release failed")
+            client = Mock()
+            client.fetch_model_providers.side_effect = RuntimeError("daemon failed")
+
+            from core.plugin.plugin_service import PluginService
+
+            with pytest.raises(RuntimeError, match="daemon failed"):
+                PluginService.fetch_plugin_model_providers(tenant_id="tenant-1", client=client)
+
+        assert redis_client.mget.call_args_list == [
+            call([cache_key]),
+            call([cache_key]),
+        ]
+        client.fetch_model_providers.assert_called_once_with("tenant-1")
+        redis_client.setex.assert_not_called()
+        redis_client.lock.return_value.release.assert_called_once()
+
+    def test_fetch_plugin_model_providers_falls_back_when_refresh_lock_acquire_fails(self) -> None:
+        """Redis acquire failures degrade to a direct daemon fetch instead of hiding provider data."""
+        with (
+            patch(f"{MODULE}.redis_client") as redis_client,
+            patch(f"{MODULE}.time.monotonic", return_value=100.0),
+        ):
+            redis_client.get.return_value = None
+            redis_client.mget.return_value = [None]
+            redis_client.lock.return_value.acquire.side_effect = RedisError("redis unavailable")
+            client = Mock()
+            client.fetch_model_providers.return_value = [_build_plugin_model_provider()]
+
+            from core.plugin.plugin_service import PluginService
+
+            result = PluginService.fetch_plugin_model_providers(tenant_id="tenant-1", client=client)
+
+        redis_client.lock.return_value.acquire.assert_called_once()
+        redis_client.lock.return_value.release.assert_not_called()
         client.fetch_model_providers.assert_called_once_with("tenant-1")
         assert [provider.provider for provider in result] == ["langgenius/openai/openai"]
 
@@ -395,7 +497,7 @@ class TestPluginModelProviderCache:
             patch(f"{MODULE}.time.sleep") as sleep,
         ):
             redis_client.get.return_value = None
-            redis_client.mget.return_value = [None, None]
+            redis_client.mget.return_value = [None]
             redis_client.lock.side_effect = RedisError("redis unavailable")
             redis_client.set.side_effect = AssertionError("raw redis set must not be used for refresh locks")
             client = Mock()
@@ -415,8 +517,7 @@ class TestPluginModelProviderCache:
         cache_key = _provider_cache_key("tenant-1", 0)
         with patch(f"{MODULE}.redis_client") as redis_client:
             redis_client.get.return_value = None
-            redis_client.mget.return_value = [None, None]
-            redis_client.lock.return_value.acquire.return_value = True
+            redis_client.mget.return_value = [None]
             client = Mock()
             client.fetch_model_providers.return_value = []
 
@@ -427,14 +528,13 @@ class TestPluginModelProviderCache:
         assert result == ()
         redis_client.setex.assert_called_once()
         assert redis_client.setex.call_args.args[0] == cache_key
-        redis_client.lock.return_value.release.assert_called_once_with()
+        redis_client.lock.return_value.release.assert_called_once()
 
     def test_fetch_plugin_model_providers_skips_cache_write_when_generation_changes_during_refresh(self) -> None:
         """A refresh that started before invalidation must not populate the newer generation cache."""
         with patch(f"{MODULE}.redis_client") as redis_client:
             redis_client.get.side_effect = [None, None, "1"]
-            redis_client.mget.return_value = [None, None]
-            redis_client.lock.return_value.acquire.return_value = True
+            redis_client.mget.return_value = [None]
             client = Mock()
             client.fetch_model_providers.return_value = []
 
@@ -445,17 +545,16 @@ class TestPluginModelProviderCache:
         assert result == ()
         client.fetch_model_providers.assert_called_once_with("tenant-1")
         redis_client.setex.assert_not_called()
-        redis_client.lock.return_value.release.assert_called_once_with()
+        redis_client.lock.return_value.release.assert_called_once()
 
     def test_fetch_plugin_model_providers_reuses_cached_empty_provider_list(self) -> None:
         """A cached empty list should prevent repeated daemon fetches for tenants without plugin models."""
         empty_payload = TypeAdapter(list[ProviderEntity]).dump_json([]).decode("utf-8")
         cache_key = _provider_cache_key("tenant-1", 0)
-        legacy_cache_key = _provider_cache_key("tenant-1")
 
         with patch(f"{MODULE}.redis_client") as redis_client:
             redis_client.get.return_value = None
-            redis_client.mget.return_value = [empty_payload, None]
+            redis_client.mget.return_value = [empty_payload]
             client = Mock()
 
             from core.plugin.plugin_service import PluginService
@@ -463,7 +562,7 @@ class TestPluginModelProviderCache:
             result = PluginService.fetch_plugin_model_providers(tenant_id="tenant-1", client=client)
 
         assert result == ()
-        redis_client.mget.assert_called_once_with([cache_key, legacy_cache_key])
+        redis_client.mget.assert_called_once_with([cache_key])
         client.fetch_model_providers.assert_not_called()
 
     def test_fetch_plugin_model_providers_creates_default_client_on_cache_miss(self) -> None:
@@ -473,7 +572,7 @@ class TestPluginModelProviderCache:
             patch(f"{MODULE}.PluginModelClient") as client_cls,
         ):
             redis_client.get.return_value = None
-            redis_client.mget.return_value = [None, None]
+            redis_client.mget.return_value = [None]
             client = client_cls.return_value
             client.fetch_model_providers.return_value = [_build_plugin_model_provider()]
 
@@ -484,35 +583,6 @@ class TestPluginModelProviderCache:
         client_cls.assert_called_once_with()
         client.fetch_model_providers.assert_called_once_with("tenant-1")
         assert [provider.provider for provider in result] == ["langgenius/openai/openai"]
-
-    def test_fetch_plugin_model_providers_reuses_process_local_cache(self) -> None:
-        generation_key = _provider_generation_key("tenant-1")
-        with (
-            patch(f"{MODULE}.redis_client") as redis_client,
-            patch(f"{MODULE}.PluginModelClient") as client_cls,
-        ):
-            redis_client.get.return_value = None
-            redis_client.mget.return_value = [None, None]
-            client = client_cls.return_value
-            client.fetch_model_providers.return_value = [_build_plugin_model_provider()]
-
-            from core.plugin.plugin_service import PluginService
-
-            first_result = PluginService.fetch_plugin_model_providers(tenant_id="tenant-1")
-            redis_client.get.reset_mock()
-            redis_client.mget.reset_mock()
-            redis_client.setex.reset_mock()
-            client.fetch_model_providers.reset_mock()
-
-            second_result = PluginService.fetch_plugin_model_providers(tenant_id="tenant-1")
-
-        redis_client.get.assert_called_once_with(generation_key)
-        redis_client.mget.assert_not_called()
-        redis_client.setex.assert_not_called()
-        client.fetch_model_providers.assert_not_called()
-        assert [provider.provider for provider in second_result] == ["langgenius/openai/openai"]
-        assert second_result[0] == first_result[0]
-        assert second_result[0] is not first_result[0]
 
     def test_invalidate_plugin_model_providers_cache_uses_redis_pipeline(self) -> None:
         with patch(f"{MODULE}.redis_client") as redis_client:
@@ -541,34 +611,17 @@ class TestPluginModelProviderCache:
         pipe.incr.assert_called_once_with(_provider_generation_key("tenant-1"))
         pipe.execute.assert_called_once_with()
 
-    def test_invalidate_plugin_model_providers_cache_clears_process_local_cache(self) -> None:
-        with patch(f"{MODULE}.redis_client") as redis_client:
-            pipe = redis_client.pipeline.return_value
-
-            from core.plugin.plugin_service import PluginService
-
-            PluginService._store_in_memory_plugin_model_providers("tenant-1", 0, [_build_provider_entity()])
-            PluginService.invalidate_plugin_model_providers_cache("tenant-1")
-
-        assert PluginService._plugin_model_providers_memory_cache == {}
-        redis_client.pipeline.assert_called_once_with(transaction=False)
-        pipe.delete.assert_called_once_with(_provider_cache_key("tenant-1"))
-        pipe.incr.assert_called_once_with(_provider_generation_key("tenant-1"))
-        pipe.execute.assert_called_once_with()
-
-    def test_fetch_plugin_model_providers_ignores_stale_process_local_cache_after_generation_bump(self) -> None:
+    def test_fetch_plugin_model_providers_uses_new_generation_cache_after_generation_bump(self) -> None:
         generation_key = _provider_generation_key("tenant-1")
         new_cache_key = _provider_cache_key("tenant-1", 1)
         with patch(f"{MODULE}.redis_client") as redis_client:
             redis_client.get.side_effect = [b"1", b"1", b"1"]
             redis_client.mget.return_value = [None]
-            redis_client.lock.return_value.acquire.return_value = True
             client = Mock()
             client.fetch_model_providers.return_value = [_build_plugin_model_provider(provider="anthropic")]
 
             from core.plugin.plugin_service import PluginService
 
-            PluginService._store_in_memory_plugin_model_providers("tenant-1", 0, [_build_provider_entity()])
             result = PluginService.fetch_plugin_model_providers(tenant_id="tenant-1", client=client)
 
         client.fetch_model_providers.assert_called_once_with("tenant-1")
@@ -579,7 +632,8 @@ class TestPluginModelProviderCache:
         ]
         redis_client.setex.assert_called_once()
         assert redis_client.setex.call_args.args[0] == new_cache_key
-        assert PluginService._plugin_model_providers_memory_cache["tenant-1"][0] == 1
+        redis_client.lock.return_value.acquire.assert_called_once()
+        redis_client.lock.return_value.release.assert_called_once()
         assert [provider.provider for provider in result] == ["langgenius/anthropic/anthropic"]
 
 

--- a/api/tests/unit_tests/services/test_agent_config_service.py
+++ b/api/tests/unit_tests/services/test_agent_config_service.py
@@ -75,7 +75,9 @@ def _zip_bytes(members: dict[str, bytes]) -> bytes:
     buffer = io.BytesIO()
     with zipfile.ZipFile(buffer, "w") as archive:
         for name, payload in members.items():
-            archive.writestr(name, payload)
+            zip_info = zipfile.ZipInfo(filename=name)
+            zip_info.date_time = (1980, 1, 1, 0, 0, 0)
+            archive.writestr(zip_info, payload)
     return buffer.getvalue()
 
 
@@ -418,8 +420,8 @@ def test_apply_env_text_supports_delete_comments_export_and_keeps_unmentioned_va
 @pytest.mark.parametrize(
     "archive_bytes",
     [
-        b"not-a-zip-archive",
-        _zip_bytes({"README.md": b"missing skill md"}),
+        pytest.param(b"not-a-zip-archive", id="not-a-zip-archive"),
+        pytest.param(_zip_bytes({"README.md": b"missing skill md"}), id="missing-skill-md"),
     ],
 )
 def test_inspect_skill_maps_invalid_archives_to_service_errors(archive_bytes: bytes) -> None:


### PR DESCRIPTION
## Summary

This is a follow-up to #37388 for the provider-list refresh path tracked under #34264.

The previous single-flight lock prevented ordinary cache-miss stampedes, but waiters could still fall through to the plugin daemon after the lock TTL deadline.
That made the Redis lock TTL act as both a crashed-owner lease and a waiter deadline.

This PR makes the coordination contract explicit:

- Redis lock TTL is only a lock lease.
- Waiters keep reading the current provider generation and cache until they either read cache or acquire the refresh lock.
- Redis cache or lock failures still fall back to direct daemon discovery to preserve availability.
- Generation changes naturally restart the cache/lock path on the new generation.

## CI Stability

This PR also fixes #38277.

`test_inspect_skill_maps_invalid_archives_to_service_errors` generated ZIP bytes during pytest collection.
Because `zipfile.writestr(name, payload)` stores the current timestamp in ZIP entry metadata, xdist workers could collect different parametrized node ids and fail before running tests.

The ZIP fixture now uses a fixed entry timestamp, and the parametrized cases have stable ids.

## Tests

- env DEBUG=false HTTP_PROXY= HTTPS_PROXY= ALL_PROXY= NO_PROXY= http_proxy= https_proxy= all_proxy= no_proxy= uv run --project api pytest -o addopts='' api/tests/unit_tests/services/plugin/test_plugin_service.py api/tests/unit_tests/core/plugin/test_model_runtime_adapter.py -q
- uv run --project api ruff check api/core/plugin/plugin_service.py api/tests/unit_tests/services/plugin/test_plugin_service.py api/tests/unit_tests/core/plugin/test_model_runtime_adapter.py
- env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy DEBUG=false uv run --project api pytest -p no:benchmark -n 2 api/tests/unit_tests/services/test_agent_config_service.py::test_inspect_skill_maps_invalid_archives_to_service_errors
- git diff --check

Refs #34264
Fixes #38277
