### PR TITLE
chore(github): add e2e labeler and code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,9 @@
 /cli/ @GareArc
 /.github/workflows/cli-tests.yml @GareArc
 
+# E2E
+/e2e/ @lyzno1
+
 # Backend (default owner, more specific rules below will override)
 /api/ @QuantumGhost
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,3 +7,9 @@ web:
           - 'pnpm-lock.yaml'
           - 'pnpm-workspace.yaml'
           - '.nvmrc'
+
+e2e:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'e2e/**'
+          - '.github/workflows/web-e2e.yml'


### PR DESCRIPTION
## Summary
- add automatic PR labeling for E2E-related changes
- assign /e2e/ code ownership to @lyzno1

## Validation
- ruby -e 'require "yaml"; p YAML.load_file(".github/labeler.yml").keys'
- git diff --check

Label created separately with gh: e2e