### PR TITLE
fix(web): clarify unpublished explore app handling

### DIFF
--- a/web/__tests__/app/app-publisher-flow.test.tsx
+++ b/web/__tests__/app/app-publisher-flow.test.tsx
@@ -215,7 +215,7 @@ describe('App Publisher Flow', () => {
     fireEvent.click(screen.getByText('common.openInExplore'))
 
     await waitFor(() => {
-      expect(mockToastError).toHaveBeenCalledWith('No app found in Explore')
+      expect(mockToastError).toHaveBeenCalledWith('notPublishedYet')
     })
   })
 })

--- a/web/app/components/app/app-publisher/__tests__/index.spec.tsx
+++ b/web/app/components/app/app-publisher/__tests__/index.spec.tsx
@@ -562,7 +562,7 @@ describe('AppPublisher', () => {
     fireEvent.click(screen.getByText('publisher-open-in-explore'))
 
     await waitFor(() => {
-      expect(mockToastError).toHaveBeenCalledWith('No app found in Explore')
+      expect(mockToastError).toHaveBeenCalledWith('notPublishedYet')
     })
   })
 

--- a/web/app/components/app/app-publisher/index.tsx
+++ b/web/app/components/app/app-publisher/index.tsx
@@ -231,7 +231,7 @@ export function AppPublisher({
       const { installed_apps } = await fetchInstalledAppList(appDetail.id)
       if (installed_apps?.length > 0)
         return `${basePath}${buildInstalledAppPath(installed_apps[0]!.id)}`
-      throw new Error('No app found in Explore')
+      throw new Error(t('notPublishedYet', { ns: 'app' }))
     }, {
       onError: (err) => {
         toast.error(`${err.message || err}`)

--- a/web/app/components/apps/__tests__/app-card.spec.tsx
+++ b/web/app/components/apps/__tests__/app-card.spec.tsx
@@ -14,6 +14,10 @@ import { StarredAppCard } from '../starred-app-card'
 
 let mockWebappAuthEnabled = false
 let mockRbacEnabled = true
+const mockUserCanAccessApp = vi.hoisted(() => ({
+  result: true as boolean | undefined,
+  isLoading: false,
+}))
 
 const render = (ui: React.ReactElement) => renderWithSystemFeatures(ui, {
   systemFeatures: {
@@ -118,15 +122,15 @@ vi.mock('@/service/explore', () => ({
 
 vi.mock('@/service/access-control', () => ({
   useGetUserCanAccessApp: () => ({
-    data: { result: true },
-    isLoading: false,
+    data: mockUserCanAccessApp.result === undefined ? undefined : { result: mockUserCanAccessApp.result },
+    isLoading: mockUserCanAccessApp.isLoading,
   }),
 }))
 
 vi.mock('@/service/access-control/use-app-access-control', () => ({
   useGetUserCanAccessApp: () => ({
-    data: { result: true },
-    isLoading: false,
+    data: mockUserCanAccessApp.result === undefined ? undefined : { result: mockUserCanAccessApp.result },
+    isLoading: mockUserCanAccessApp.isLoading,
   }),
 }))
 
@@ -380,6 +384,8 @@ describe('AppCard', () => {
     mockOpenAsyncWindow.mockReset()
     mockWebappAuthEnabled = false
     mockRbacEnabled = true
+    mockUserCanAccessApp.result = true
+    mockUserCanAccessApp.isLoading = false
     mockDeleteMutationPending = false
     mockToggleStarMutationPending = false
     mockAppContext.isCurrentWorkspaceEditor = true
@@ -1733,6 +1739,28 @@ describe('AppCard', () => {
   })
 
   describe('Open in Explore - No App Found', () => {
+    it('should tell workflow users to publish before opening in explore', async () => {
+      const workflowApp = createMockApp({
+        mode: AppModeEnum.WORKFLOW,
+        workflow: undefined,
+      })
+      render(<AppCard app={workflowApp} />)
+
+      fireEvent.click(screen.getByTestId('dropdown-menu-trigger'))
+      await waitFor(() => {
+        expect(screen.getByText('app.openInExplore')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText('app.openInExplore'))
+
+      expect(mockOpenAsyncWindow).not.toHaveBeenCalled()
+      expect(exploreService.fetchInstalledAppList).not.toHaveBeenCalled()
+      expect(toastMocks.record).toHaveBeenCalledWith({
+        type: 'error',
+        message: 'app.notPublishedYet',
+      })
+    })
+
     it('should handle case when installed_apps is empty array', async () => {
       (exploreService.fetchInstalledAppList as Mock).mockResolvedValueOnce({ installed_apps: [] })
 
@@ -1756,6 +1784,10 @@ describe('AppCard', () => {
 
       await waitFor(() => {
         expect(exploreService.fetchInstalledAppList).toHaveBeenCalled()
+        expect(toastMocks.record).toHaveBeenCalledWith({
+          type: 'error',
+          message: 'app.notPublishedYet',
+        })
       })
     })
 
@@ -1941,6 +1973,31 @@ describe('AppCard', () => {
       fireEvent.click(screen.getByTestId('dropdown-menu-trigger'))
       await waitFor(() => {
         expect(screen.getByText('app.openInExplore')).toBeInTheDocument()
+      })
+    })
+
+    it('should keep open in explore visible for unpublished workflow apps while access check is pending', async () => {
+      mockUserCanAccessApp.result = false
+      mockUserCanAccessApp.isLoading = true
+      const workflowApp = createMockApp({
+        mode: AppModeEnum.WORKFLOW,
+        workflow: undefined,
+      })
+
+      render(<AppCard app={workflowApp} />)
+
+      fireEvent.click(screen.getByTestId('dropdown-menu-trigger'))
+      await waitFor(() => {
+        expect(screen.getByText('app.openInExplore')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText('app.openInExplore'))
+
+      expect(mockOpenAsyncWindow).not.toHaveBeenCalled()
+      expect(exploreService.fetchInstalledAppList).not.toHaveBeenCalled()
+      expect(toastMocks.record).toHaveBeenCalledWith({
+        type: 'error',
+        message: 'app.notPublishedYet',
       })
     })
 

--- a/web/app/components/apps/app-card.tsx
+++ b/web/app/components/apps/app-card.tsx
@@ -90,6 +90,11 @@ const ACCESS_MODE_LABEL_KEYS = {
   [AccessMode.EXTERNAL_MEMBERS]: 'accessItemsDescription.external',
 } as const
 
+const APP_MODES_REQUIRING_PUBLISHED_WORKFLOW_IN_EXPLORE = new Set<AppModeEnum>([
+  AppModeEnum.ADVANCED_CHAT,
+  AppModeEnum.WORKFLOW,
+])
+
 type AppCardProps = {
   app: App
   onlineUsers?: WorkflowOnlineUser[]
@@ -102,6 +107,10 @@ type AppAccessModeIconProps = {
 }
 
 const getAppResourceMaintainer = (app: App) => app.maintainer
+
+function requiresPublishedWorkflowInExplore(app: App) {
+  return APP_MODES_REQUIRING_PUBLISHED_WORKFLOW_IN_EXPLORE.has(app.mode)
+}
 
 function AppAccessModeIcon({ accessMode }: AppAccessModeIconProps) {
   const { t } = useTranslation()
@@ -182,12 +191,17 @@ function AppCardOperationsMenu({
   async function handleOpenInstalledApp(e: MouseEvent<HTMLElement>) {
     e.stopPropagation()
     e.preventDefault()
+    if (requiresPublishedWorkflowInExplore(app) && !app.workflow?.id) {
+      toast.error(t('notPublishedYet', { ns: 'app' }))
+      return
+    }
+
     try {
       await openAsyncWindow(async () => {
         const { installed_apps } = await fetchInstalledAppList(app.id)
         if (installed_apps?.length > 0)
           return `${basePath}${buildInstalledAppPath(installed_apps[0]!.id)}`
-        throw new Error('No app found in Explore')
+        throw new Error(t('notPublishedYet', { ns: 'app' }))
       }, {
         onError: (err) => {
           toast.error(`${err.message || err}`)
@@ -272,9 +286,12 @@ function AppCardOperationsMenuContent(props: AppCardOperationsMenuContentProps) 
     appId: props.app.id,
     enabled: systemFeatures.webapp_auth.enabled,
   })
+  const needsPublishBeforeExplore = requiresPublishedWorkflowInExplore(props.app) && !props.app.workflow?.id
 
   const shouldShowOpenInExploreOption = !props.app.has_draft_trigger
     && (
+      needsPublishBeforeExplore
+      ||
       !systemFeatures.webapp_auth.enabled
       || (!isGettingUserCanAccessApp && Boolean(userCanAccessApp?.result))
     )

--- a/web/app/components/apps/app-card.tsx
+++ b/web/app/components/apps/app-card.tsx
@@ -291,8 +291,7 @@ function AppCardOperationsMenuContent(props: AppCardOperationsMenuContentProps) 
   const shouldShowOpenInExploreOption = !props.app.has_draft_trigger
     && (
       needsPublishBeforeExplore
-      ||
-      !systemFeatures.webapp_auth.enabled
+      || !systemFeatures.webapp_auth.enabled
       || (!isGettingUserCanAccessApp && Boolean(userCanAccessApp?.result))
     )
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes langgenius/dify#38259

This PR improves the "Open in Explore" behavior for unpublished Workflow / Advanced Chat apps in Studio:

- Show the existing `App is not published yet` message before opening Explore when a Workflow / Advanced Chat app has no published workflow.
- Keep the "Open in Explore" action visible for unpublished Workflow / Advanced Chat apps when enterprise WebApp Auth is enabled, so users get a clear publishing-required message instead of a hidden action.
- Replace the hardcoded `No app found in Explore` fallback with the existing localized `notPublishedYet` message.
- Apply the same empty installed-app fallback to AppPublisher.
- Add regression tests for unpublished workflow apps and WebApp Auth enabled scenarios.

From Codex.

## Screenshots

| Before | After |
|--------|-------|
|<img width="1000" height="80" alt="SCR-20260701-nzhm" src="https://github.com/user-attachments/assets/9a81af66-4bfd-4b10-b40a-de291a267704" /> | <img width="1000" height="83" alt="SCR-20260701-nzlb" src="https://github.com/user-attachments/assets/8ab24630-2a00-47ca-8c2d-3adc51c36175" /> |
| Clicking "Open in Explore" for an unpublished app could open a new tab and fail with app unavailable / "No app found in Explore", or hide the action when WebApp Auth was enabled. | Clicking "Open in Explore" shows `App is not published yet` immediately without opening a broken new tab. |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Tested with:

```bash
pnpm -C web test run app/components/apps/__tests__/app-card.spec.tsx app/components/app/app-publisher/__tests__/index.spec.tsx --reporter=verbose
```

Result: `2 passed, 133 passed`.

Note: `pnpm -C web exec vp staged` currently fails because no `staged` config is defined in `vite.config.ts`.
