### PR TITLE
fix: accept legacy plugin daemon list responses

### DIFF
--- a/api/core/plugin/impl/base.py
+++ b/api/core/plugin/impl/base.py
@@ -12,7 +12,12 @@ from yarl import URL
 from configs import dify_config
 from core.helper.http_client_pooling import get_pooled_http_client
 from core.plugin.endpoint.exc import EndpointSetupFailedError
-from core.plugin.entities.plugin_daemon import PluginDaemonBasicResponse, PluginDaemonError, PluginDaemonInnerError
+from core.plugin.entities.plugin_daemon import (
+    PluginDaemonBasicResponse,
+    PluginDaemonError,
+    PluginDaemonInnerError,
+    PluginListResponse,
+)
 from core.plugin.impl.exc import (
     PluginDaemonBadRequestError,
     PluginDaemonClientSideError,
@@ -63,6 +68,28 @@ _httpx_client: httpx.Client = get_pooled_http_client(
     "plugin_daemon",
     lambda: httpx.Client(limits=httpx.Limits(max_keepalive_connections=50, max_connections=100), trust_env=False),
 )
+
+
+def _normalize_plugin_daemon_response_for_type(json_response: Any, type_: type[object]) -> Any:
+    if type_ is not PluginListResponse:
+        return json_response
+
+    if isinstance(json_response, list):
+        return {
+            "code": 0,
+            "message": "",
+            "data": {"list": json_response, "total": len(json_response)},
+        }
+
+    if isinstance(json_response, dict):
+        data = json_response.get("data")
+        if isinstance(data, list):
+            return {
+                **json_response,
+                "data": {"list": data, "total": len(data)},
+            }
+
+    return json_response
 
 
 class BasePluginClient:
@@ -273,6 +300,7 @@ class BasePluginClient:
             json_response = response.json()
             if transformer:
                 json_response = transformer(json_response)
+            json_response = _normalize_plugin_daemon_response_for_type(json_response, type_)
             # https://stackoverflow.com/questions/59634937/variable-foo-class-is-not-valid-as-type-but-why
             rep = PluginDaemonBasicResponse[type_].model_validate(json_response)  # type: ignore
         except Exception:

--- a/api/tests/unit_tests/core/plugin/impl/test_base_client_impl.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_base_client_impl.py
@@ -5,7 +5,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from core.plugin.endpoint.exc import EndpointSetupFailedError
-from core.plugin.entities.plugin_daemon import PluginDaemonInnerError
+from core.plugin.entities.plugin_daemon import PluginDaemonInnerError, PluginListResponse
 from core.plugin.impl.base import PLUGIN_DAEMON_MAX_PATH_LENGTH, BasePluginClient
 from core.plugin.impl.exc import PluginLLMPollingUnsupportedError
 from core.trigger.errors import (
@@ -120,6 +120,26 @@ class TestBasePluginClientImpl:
 
         assert result is True
         assert transformed == {"code": 0, "message": "", "data": True}
+
+    def test_request_with_plugin_daemon_response_accepts_legacy_plugin_list_data_array(self, mocker: MockerFixture):
+        client = BasePluginClient()
+        mocker.patch.object(client, "_request", return_value=_ResponseStub({"code": 0, "message": "", "data": []}))
+
+        result = client._request_with_plugin_daemon_response("GET", "plugin/tenant/management/list", PluginListResponse)
+
+        assert result.list == []
+        assert result.total == 0
+
+    def test_request_with_plugin_daemon_response_accepts_legacy_plugin_list_top_level_array(
+        self, mocker: MockerFixture
+    ):
+        client = BasePluginClient()
+        mocker.patch.object(client, "_request", return_value=_ResponseStub([]))
+
+        result = client._request_with_plugin_daemon_response("GET", "plugin/tenant/management/list", PluginListResponse)
+
+        assert result.list == []
+        assert result.total == 0
 
     def test_request_with_plugin_daemon_response_stream_malformed_json_error(self, mocker: MockerFixture):
         client = BasePluginClient()


### PR DESCRIPTION
## Summary

- Accept legacy plugin daemon list responses where the payload is returned as an array.
- Normalize those list responses into the current `{list, total}` shape before Pydantic validation.
- Add regression coverage for both `data: []` and top-level `[]` response forms.

## Motivation

`PluginListResponse` currently expects plugin daemon data in the object shape `{list, total}`. Older or mixed-version plugin daemon deployments may still return the list payload directly, which makes `_request_with_plugin_daemon_response` fail during response validation even though the request itself succeeded.

## Tests

- `uv run --project api --group dev pytest api/tests/unit_tests/core/plugin/impl/test_base_client_impl.py -k "legacy_plugin_list" -q`
- `uv run --project api --group dev pytest api/tests/unit_tests/core/plugin/impl/test_base_client_impl.py -q`
- `uv run --project api --group dev ruff check api/core/plugin/impl/base.py api/tests/unit_tests/core/plugin/impl/test_base_client_impl.py`
- `uv run --project api --group dev ruff format --check api/core/plugin/impl/base.py api/tests/unit_tests/core/plugin/impl/test_base_client_impl.py`
- `git diff --check`

Fixes #40837
