### PR TITLE
feat(tools): add Dakera persistent memory provider

### DIFF
--- a/api/core/tools/builtin_tool/providers/dakera/_assets/icon.svg
+++ b/api/core/tools/builtin_tool/providers/dakera/_assets/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <!-- Brain/memory icon representing Dakera persistent memory -->
+  <rect width="48" height="48" rx="12" fill="#0F172A"/>
+  <!-- Stylised brain outline -->
+  <path d="M24 10C18.5 10 14 14.5 14 20C14 22.5 14.9 24.8 16.4 26.5C15.5 27.5 15 28.8 15 30.2C15 33.4 17.6 36 20.8 36H27.2C30.4 36 33 33.4 33 30.2C33 28.8 32.5 27.5 31.6 26.5C33.1 24.8 34 22.5 34 20C34 14.5 29.5 10 24 10Z" fill="#6366F1"/>
+  <!-- Horizontal connecting lines (memory synapses) -->
+  <line x1="19" y1="20" x2="29" y2="20" stroke="#E0E7FF" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="18" y1="24" x2="30" y2="24" stroke="#E0E7FF" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="20" y1="28" x2="28" y2="28" stroke="#E0E7FF" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/api/core/tools/builtin_tool/providers/dakera/dakera.py
+++ b/api/core/tools/builtin_tool/providers/dakera/dakera.py
@@ -1,0 +1,35 @@
+from typing import Any, override
+
+import httpx
+
+from core.tools.builtin_tool.provider import BuiltinToolProviderController
+from core.tools.errors import ToolProviderCredentialValidationError
+
+
+class DakeraProvider(BuiltinToolProviderController):
+    @override
+    def _validate_credentials(self, user_id: str, credentials: dict[str, Any]) -> None:
+        """Validate that the Dakera server is reachable with the provided credentials."""
+        api_url = credentials.get("api_url", "").rstrip("/")
+        api_key = credentials.get("api_key", "")
+
+        if not api_url:
+            raise ToolProviderCredentialValidationError("Dakera server URL is required.")
+
+        headers: dict[str, str] = {}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        try:
+            resp = httpx.get(f"{api_url}/health/live", headers=headers, timeout=5.0)
+            if resp.status_code not in (200, 204):
+                raise ToolProviderCredentialValidationError(
+                    f"Dakera health check failed with HTTP {resp.status_code}. "
+                    "Verify the server URL and API key."
+                )
+        except httpx.RequestError as exc:
+            raise ToolProviderCredentialValidationError(
+                f"Cannot reach Dakera server at {api_url}: {exc}. "
+                "Make sure the server is running: "
+                "docker run -p 3300:3300 -e DAKERA_API_KEY=demo ghcr.io/dakera-ai/dakera:latest"
+            )

--- a/api/core/tools/builtin_tool/providers/dakera/dakera.yaml
+++ b/api/core/tools/builtin_tool/providers/dakera/dakera.yaml
@@ -1,0 +1,64 @@
+identity:
+  author: Dakera
+  name: dakera
+  label:
+    en_US: Dakera Memory
+    zh_Hans: Dakera 记忆
+    pt_BR: Dakera Memory
+  description:
+    en_US: >-
+      Self-hosted persistent memory for AI agents. Dakera stores and semantically
+      recalls memories across sessions using decay-weighted importance scoring —
+      so agents remember what matters without accumulating stale context.
+    zh_Hans: >-
+      面向 AI 代理的自托管持久记忆。Dakera 使用衰减权重重要性评分跨会话存储和语义召回记忆，
+      让代理在不积累过时上下文的情况下记住重要事项。
+    pt_BR: >-
+      Memória persistente auto-hospedada para agentes de IA. O Dakera armazena e
+      recupera semanticamente memórias entre sessões usando pontuação de importância
+      ponderada por decaimento.
+  icon: icon.svg
+  tags:
+    - productivity
+    - utilities
+credentials_for_provider:
+  api_url:
+    type: secret-input
+    required: true
+    label:
+      en_US: Dakera Server URL
+      zh_Hans: Dakera 服务器地址
+      pt_BR: URL do Servidor Dakera
+    placeholder:
+      en_US: http://localhost:3300
+      zh_Hans: http://localhost:3300
+      pt_BR: http://localhost:3300
+    help:
+      en_US: >-
+        Base URL of your self-hosted Dakera server, e.g. http://localhost:3300.
+        Self-host with: docker run -p 3300:3300 -e DAKERA_API_KEY=demo ghcr.io/dakera-ai/dakera:latest
+      zh_Hans: >-
+        自托管 Dakera 服务器的基础地址，例如 http://localhost:3300
+      pt_BR: >-
+        URL base do seu servidor Dakera auto-hospedado, ex: http://localhost:3300
+    url: https://dakera.ai
+  api_key:
+    type: secret-input
+    required: false
+    label:
+      en_US: Dakera API Key
+      zh_Hans: Dakera API 密钥
+      pt_BR: Chave de API Dakera
+    placeholder:
+      en_US: dk_...
+      zh_Hans: dk_...
+      pt_BR: dk_...
+    help:
+      en_US: >-
+        API key for your Dakera server. Leave empty for unauthenticated local development
+        (when the server is started without DAKERA_API_KEY).
+      zh_Hans: >-
+        Dakera 服务器的 API 密钥。本地开发时如未设置认证可留空。
+      pt_BR: >-
+        Chave de API do servidor Dakera. Deixe vazio para desenvolvimento local sem autenticação.
+    url: https://dakera.ai

--- a/api/core/tools/builtin_tool/providers/dakera/tools/recall.py
+++ b/api/core/tools/builtin_tool/providers/dakera/tools/recall.py
@@ -1,0 +1,78 @@
+from collections.abc import Generator
+from typing import Any, override
+
+import httpx
+
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.errors import ToolInvokeError
+
+
+class DakeraRecallTool(BuiltinTool):
+    """Recall semantically relevant memories from a self-hosted Dakera server."""
+
+    @override
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: dict[str, Any],
+        conversation_id: str | None = None,
+        app_id: str | None = None,
+        message_id: str | None = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        credentials = self.runtime.credentials or {}
+        api_url = credentials.get("api_url", "").rstrip("/")
+        api_key = credentials.get("api_key", "")
+
+        if not api_url:
+            raise ToolInvokeError("Dakera server URL is not configured.")
+
+        query = tool_parameters.get("query", "").strip()
+        if not query:
+            raise ToolInvokeError("Query is required.")
+
+        agent_id = tool_parameters.get("agent_id") or "dify-agent"
+        session_id = tool_parameters.get("session_id") or None
+        top_k = int(tool_parameters.get("top_k") or 5)
+        top_k = max(1, min(20, top_k))
+
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        body: dict[str, Any] = {
+            "agent_id": agent_id,
+            "query": query,
+            "top_k": top_k,
+        }
+        if session_id:
+            body["session_id"] = session_id
+
+        try:
+            resp = httpx.post(
+                f"{api_url}/v1/memory/search",
+                headers=headers,
+                json=body,
+                timeout=10.0,
+            )
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise ToolInvokeError(f"Dakera recall failed: HTTP {exc.response.status_code}")
+        except httpx.RequestError as exc:
+            raise ToolInvokeError(f"Cannot reach Dakera server at {api_url}: {exc}")
+
+        data = resp.json()
+        memories: list[dict[str, Any]] = data.get("memories", [])
+
+        if not memories:
+            yield self.create_text_message("No relevant memories found.")
+            return
+
+        lines: list[str] = [f"Found {len(memories)} relevant {'memory' if len(memories) == 1 else 'memories'}:\n"]
+        for i, item in enumerate(memories, 1):
+            mem = item.get("memory", {})
+            score = item.get("score", 0.0)
+            content = mem.get("content", "")
+            lines.append(f"{i}. [{score:.3f}] {content}")
+
+        yield self.create_text_message("\n".join(lines))

--- a/api/core/tools/builtin_tool/providers/dakera/tools/recall.yaml
+++ b/api/core/tools/builtin_tool/providers/dakera/tools/recall.yaml
@@ -1,0 +1,78 @@
+identity:
+  name: recall
+  author: Dakera
+  label:
+    en_US: Recall Memory
+    zh_Hans: 召回记忆
+    pt_BR: Recuperar Memória
+description:
+  human:
+    en_US: >-
+      Retrieve semantically relevant memories from Dakera. Use this when you need
+      context from prior conversations, stored knowledge, or user preferences.
+    zh_Hans: >-
+      从 Dakera 中检索语义相关的记忆。当您需要来自之前对话、存储的知识或用户偏好的上下文时使用此工具。
+    pt_BR: >-
+      Recupera memórias semanticamente relevantes do Dakera. Use quando precisar de
+      contexto de conversas anteriores, conhecimento armazenado ou preferências do usuário.
+  llm: >-
+    Recall semantically relevant memories from persistent storage. Provide a natural-language
+    query describing what you want to remember. Returns a ranked list of relevant memories
+    with scores, most relevant first.
+parameters:
+  - name: query
+    type: string
+    required: true
+    label:
+      en_US: Query
+      zh_Hans: 查询
+      pt_BR: Consulta
+    human_description:
+      en_US: Natural-language description of what you want to recall.
+      zh_Hans: 您想要召回的内容的自然语言描述。
+      pt_BR: Descrição em linguagem natural do que você deseja recuperar.
+    llm_description: Semantic search query — describe what you want to remember in plain language.
+    form: llm
+  - name: agent_id
+    type: string
+    required: false
+    default: "dify-agent"
+    label:
+      en_US: Agent ID
+      zh_Hans: 代理 ID
+      pt_BR: ID do Agente
+    human_description:
+      en_US: >-
+        Namespace for memories. Use different agent IDs to isolate memories between
+        different agents or users.
+      zh_Hans: 记忆的命名空间。使用不同的代理 ID 来隔离不同代理或用户之间的记忆。
+      pt_BR: Namespace para memórias. Use diferentes IDs de agente para isolar memórias.
+    llm_description: Agent namespace — use the same value as in the store tool to retrieve the right memories.
+    form: form
+  - name: session_id
+    type: string
+    required: false
+    label:
+      en_US: Session ID
+      zh_Hans: 会话 ID
+      pt_BR: ID da Sessão
+    human_description:
+      en_US: Restrict recall to a specific session. Leave empty to search across all sessions.
+      zh_Hans: 将召回限制在特定会话中。留空则搜索所有会话。
+      pt_BR: Restringe a recuperação a uma sessão específica. Deixe vazio para pesquisar em todas.
+    llm_description: Optional session scope. Omit to search across all sessions for this agent.
+    form: llm
+  - name: top_k
+    type: number
+    required: false
+    default: 5
+    label:
+      en_US: Top K
+      zh_Hans: 召回数量
+      pt_BR: Top K
+    human_description:
+      en_US: Maximum number of memories to retrieve (1–20).
+      zh_Hans: 要检索的最大记忆数量（1–20）。
+      pt_BR: Número máximo de memórias a recuperar (1–20).
+    llm_description: Number of memories to return. Default 5.
+    form: form

--- a/api/core/tools/builtin_tool/providers/dakera/tools/store.py
+++ b/api/core/tools/builtin_tool/providers/dakera/tools/store.py
@@ -1,0 +1,69 @@
+from collections.abc import Generator
+from typing import Any, override
+
+import httpx
+
+from core.tools.builtin_tool.tool import BuiltinTool
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.errors import ToolInvokeError
+
+
+class DakeraStoreTool(BuiltinTool):
+    """Persist a memory in a self-hosted Dakera server for future recall."""
+
+    @override
+    def _invoke(
+        self,
+        user_id: str,
+        tool_parameters: dict[str, Any],
+        conversation_id: str | None = None,
+        app_id: str | None = None,
+        message_id: str | None = None,
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        credentials = self.runtime.credentials or {}
+        api_url = credentials.get("api_url", "").rstrip("/")
+        api_key = credentials.get("api_key", "")
+
+        if not api_url:
+            raise ToolInvokeError("Dakera server URL is not configured.")
+
+        content = tool_parameters.get("content", "").strip()
+        if not content:
+            raise ToolInvokeError("Content is required.")
+
+        agent_id = tool_parameters.get("agent_id") or "dify-agent"
+        session_id = tool_parameters.get("session_id") or conversation_id or None
+        tags_raw = tool_parameters.get("tags") or ""
+        tags = [t.strip() for t in tags_raw.split(",") if t.strip()] if tags_raw else []
+
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        body: dict[str, Any] = {
+            "content": content,
+            "agent_id": agent_id,
+        }
+        if session_id:
+            body["session_id"] = session_id
+        if tags:
+            body["tags"] = tags
+
+        try:
+            resp = httpx.post(
+                f"{api_url}/v1/memory/store",
+                headers=headers,
+                json=body,
+                timeout=10.0,
+            )
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise ToolInvokeError(f"Dakera store failed: HTTP {exc.response.status_code}")
+        except httpx.RequestError as exc:
+            raise ToolInvokeError(f"Cannot reach Dakera server at {api_url}: {exc}")
+
+        data = resp.json()
+        memory = data.get("memory", {})
+        memory_id = memory.get("id", "unknown")
+
+        yield self.create_text_message(f"Memory stored successfully (id: {memory_id}).")

--- a/api/core/tools/builtin_tool/providers/dakera/tools/store.yaml
+++ b/api/core/tools/builtin_tool/providers/dakera/tools/store.yaml
@@ -1,0 +1,80 @@
+identity:
+  name: store
+  author: Dakera
+  label:
+    en_US: Store Memory
+    zh_Hans: 存储记忆
+    pt_BR: Armazenar Memória
+description:
+  human:
+    en_US: >-
+      Persist a memory in Dakera for future recall. Use this when you learn something
+      important that should be remembered across future sessions — user preferences,
+      decisions, key facts, or context.
+    zh_Hans: >-
+      在 Dakera 中持久化记忆以便将来召回。当您了解到应该在未来会话中记住的重要信息时使用此工具
+      ——用户偏好、决策、关键事实或上下文。
+    pt_BR: >-
+      Persiste uma memória no Dakera para recuperação futura. Use quando aprender algo
+      importante que deve ser lembrado em sessões futuras.
+  llm: >-
+    Store a memory for future recall across sessions. Write the memory as a concise,
+    self-contained fact. Avoid vague summaries — be specific. Returns the ID of the
+    stored memory.
+parameters:
+  - name: content
+    type: string
+    required: true
+    label:
+      en_US: Content
+      zh_Hans: 内容
+      pt_BR: Conteúdo
+    human_description:
+      en_US: The memory to store. Be specific and self-contained.
+      zh_Hans: 要存储的记忆。请具体且独立表述。
+      pt_BR: A memória a armazenar. Seja específico e independente.
+    llm_description: >-
+      The memory to persist. Write a concise, factual, self-contained statement.
+      Good: "Alice prefers Rust over Python for backend services."
+      Bad: "User has preferences."
+    form: llm
+  - name: agent_id
+    type: string
+    required: false
+    default: "dify-agent"
+    label:
+      en_US: Agent ID
+      zh_Hans: 代理 ID
+      pt_BR: ID do Agente
+    human_description:
+      en_US: Namespace for this memory. Use the same agent ID in recall to retrieve it.
+      zh_Hans: 此记忆的命名空间。在召回时使用相同的代理 ID 来检索它。
+      pt_BR: Namespace para esta memória. Use o mesmo ID de agente na recuperação.
+    llm_description: Agent namespace. Must match the agent_id used in the recall tool.
+    form: form
+  - name: session_id
+    type: string
+    required: false
+    label:
+      en_US: Session ID
+      zh_Hans: 会话 ID
+      pt_BR: ID da Sessão
+    human_description:
+      en_US: Tag this memory with a session ID for session-scoped recall.
+      zh_Hans: 用会话 ID 标记此记忆，以便进行会话范围的召回。
+      pt_BR: Marque esta memória com um ID de sessão para recuperação com escopo de sessão.
+    llm_description: Optional session tag. Provide the conversation ID to enable session-scoped recall.
+    form: llm
+  - name: tags
+    type: string
+    required: false
+    label:
+      en_US: Tags
+      zh_Hans: 标签
+      pt_BR: Tags
+    human_description:
+      en_US: Comma-separated tags for categorising this memory (e.g. "preference,ui,dark-mode").
+      zh_Hans: 用逗号分隔的标签，用于对此记忆进行分类（例如：preference,ui,dark-mode）。
+      pt_BR: Tags separadas por vírgula para categorizar esta memória.
+    llm_description: Optional comma-separated tags to categorize the memory, e.g. "preference,decision".
+    form: llm


### PR DESCRIPTION
## Summary

This PR adds a new **Dakera** built-in tool provider to Dify, enabling agents to store and semantically recall memories across sessions using a self-hosted persistent memory server.

Dakera is an open-core memory server built in Rust that uses decay-weighted importance scoring — memories that are relevant get surfaced, stale ones fade naturally.

### What's included

**Provider** (`api/core/tools/builtin_tool/providers/dakera/`)

| File | Purpose |
|------|---------|
| `dakera.yaml` | Provider manifest with credentials (`api_url`, `api_key`) |
| `dakera.py` | `DakeraProvider` — validates credentials by hitting `/health/live` |
| `tools/store.yaml` / `tools/store.py` | **Store Memory** tool — `POST /v1/memory/store` |
| `tools/recall.yaml` / `tools/recall.py` | **Recall Memory** tool — `POST /v1/memory/search` |
| `_assets/icon.svg` | Provider icon |

### Tool parameters

**Store Memory**
- `content` (required) — the fact to persist
- `agent_id` — namespace (default: `dify-agent`)
- `session_id` — optional session tag (auto-filled from `conversation_id`)
- `tags` — comma-separated category tags

**Recall Memory**
- `query` (required) — natural-language search query
- `agent_id` — namespace to search within
- `session_id` — optional session scope
- `top_k` — number of results, 1–20 (default 5)

### Quick start

```bash
# Self-host Dakera (single container, no external deps)
docker run -p 3300:3300 -e DAKERA_API_KEY=demo \
  ghcr.io/dakera-ai/dakera:latest
```

Then configure the Dify tool with:
- **Dakera Server URL**: `http://localhost:3300` (or your server address)
- **Dakera API Key**: your key (leave empty for unauthenticated local dev)

### Technical notes

- Uses `httpx` (already a Dify dependency) — no new deps required
- Credential validation is a live HTTP check against `/health/live`
- `store.py` falls back to Dify's `conversation_id` for `session_id` so memories are automatically scoped to the current conversation
- Follows the same pattern as `webscraper` and other built-in providers

## Test plan

- [ ] Self-host Dakera locally with `docker run -p 3300:3300 -e DAKERA_API_KEY=demo ghcr.io/dakera-ai/dakera:latest`
- [ ] In Dify, navigate to Tools → Built-in → Dakera Memory and configure credentials
- [ ] Create an Agent with both Store Memory and Recall Memory tools
- [ ] Store: "Alice prefers Rust over Python for backend services"
- [ ] Recall with query "Alice's programming preferences" → verify the stored memory appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)