### PR TITLE
fix(agent): persist agent token usage

### DIFF
--- a/api/clients/agent_backend/event_adapter.py
+++ b/api/clients/agent_backend/event_adapter.py
@@ -67,6 +67,7 @@ class AgentBackendRunSucceededInternalEvent(AgentBackendInternalEventBase):
     type: Literal[AgentBackendInternalEventType.RUN_SUCCEEDED] = AgentBackendInternalEventType.RUN_SUCCEEDED
     output: JsonValue
     session_snapshot: CompositorSessionSnapshot
+    usage: dict[str, JsonValue] | None = None
 
 
 class AgentBackendDeferredToolCallInternalEvent(AgentBackendInternalEventBase):
@@ -76,6 +77,7 @@ class AgentBackendDeferredToolCallInternalEvent(AgentBackendInternalEventBase):
     deferred_tool_call: DeferredToolCallPayload
     message: str | None = None
     session_snapshot: CompositorSessionSnapshot
+    usage: dict[str, JsonValue] | None = None
 
 
 class AgentBackendRunFailedInternalEvent(AgentBackendInternalEventBase):
@@ -140,6 +142,7 @@ class AgentBackendRunEventAdapter:
                             deferred_tool_call=event.data.deferred_tool_call,
                             message=_deferred_tool_call_message(event.data.deferred_tool_call),
                             session_snapshot=event.data.session_snapshot,
+                            usage=_agent_run_usage(event.data.usage),
                         )
                     ]
                 return [
@@ -148,6 +151,7 @@ class AgentBackendRunEventAdapter:
                         source_event_id=event.id,
                         output=event.data.output,
                         session_snapshot=event.data.session_snapshot,
+                        usage=_agent_run_usage(event.data.usage),
                     )
                 ]
             case RunFailedEvent():
@@ -184,3 +188,13 @@ def _deferred_tool_call_message(payload: DeferredToolCallPayload) -> str:
             return title
 
     return f"Agent backend requested external input via deferred tool '{payload.tool_name}'."
+
+
+def _agent_run_usage(usage: object | None) -> dict[str, JsonValue] | None:
+    """Return JSON-safe usage metadata from optional Agent backend usage."""
+    if usage is None:
+        return None
+    dumped = _EVENT_DATA_ADAPTER.dump_python(usage, mode="json")
+    if not isinstance(dumped, dict):
+        return None
+    return cast(dict[str, JsonValue], dumped)

--- a/api/core/app/apps/agent_app/app_runner.py
+++ b/api/core/app/apps/agent_app/app_runner.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Mapping
 from decimal import Decimal
 from typing import Any, Literal
 
@@ -74,12 +75,23 @@ def _prompt_messages_from_query(user_query: str | None) -> list[PromptMessage]:
     return [UserPromptMessage(content=user_query)]
 
 
+def _llm_usage_from_agent_backend(usage: Mapping[str, Any] | None) -> LLMUsage | None:
+    if usage is None:
+        return None
+    try:
+        return LLMUsage.from_metadata(usage)
+    except (TypeError, ValueError):
+        logger.warning("Failed to parse Agent backend usage metadata: %s", usage, exc_info=True)
+        return None
+
+
 def publish_text_answer(
     *,
     queue_manager: AppQueueManager,
     model_name: str,
     answer: str,
     user_query: str | None = None,
+    usage: LLMUsage | None = None,
 ) -> None:
     """Publish a complete assistant answer as one chunk + message-end.
 
@@ -99,6 +111,7 @@ def publish_text_answer(
         model_name=model_name,
         answer=answer,
         user_query=user_query,
+        usage=usage,
     )
 
 
@@ -127,6 +140,7 @@ def publish_message_end(
     model_name: str,
     answer: str,
     user_query: str | None = None,
+    usage: LLMUsage | None = None,
 ) -> None:
     """Publish the terminal assistant result without emitting another delta."""
     prompt_messages = _prompt_messages_from_query(user_query)
@@ -136,7 +150,7 @@ def publish_message_end(
                 model=model_name,
                 prompt_messages=prompt_messages,
                 message=AssistantPromptMessage(content=answer),
-                usage=LLMUsage.empty_usage(),
+                usage=usage or LLMUsage.empty_usage(),
             ),
         ),
         PublishFrom.APPLICATION_MANAGER,
@@ -512,6 +526,7 @@ class AgentAppRunner:
             answer=answer,
             query=query,
             streamed_answer=streamed_answer,
+            usage=_llm_usage_from_agent_backend(terminal.usage),
         )
         self._save_session(
             scope=scope,
@@ -793,10 +808,17 @@ class AgentAppRunner:
         answer: str,
         query: str | None,
         streamed_answer: str,
+        usage: LLMUsage | None,
     ) -> None:
         """Finish a successful streamed turn without duplicating the final text."""
         if not streamed_answer:
-            self._publish_answer(queue_manager=queue_manager, model_name=model_name, answer=answer, query=query)
+            publish_text_answer(
+                queue_manager=queue_manager,
+                model_name=model_name,
+                answer=answer,
+                user_query=query,
+                usage=usage,
+            )
             return
 
         if answer.startswith(streamed_answer):
@@ -812,7 +834,13 @@ class AgentAppRunner:
                 "using terminal output for message persistence."
             )
 
-        publish_message_end(queue_manager=queue_manager, model_name=model_name, answer=answer, user_query=query)
+        publish_message_end(
+            queue_manager=queue_manager,
+            model_name=model_name,
+            answer=answer,
+            user_query=query,
+            usage=usage,
+        )
 
     def _save_session(
         self,

--- a/api/core/workflow/nodes/agent_v2/output_adapter.py
+++ b/api/core/workflow/nodes/agent_v2/output_adapter.py
@@ -333,6 +333,8 @@ class WorkflowAgentOutputAdapter:
         session_snapshot = None
         if isinstance(event, AgentBackendRunSucceededInternalEvent | AgentBackendDeferredToolCallInternalEvent):
             session_snapshot = event.session_snapshot
+            if event.usage is not None:
+                agent_backend["usage"] = dict(event.usage)
         if session_snapshot is not None:
             agent_backend["session_snapshot"] = {
                 "layer_count": len(session_snapshot.layers),

--- a/api/services/agent/observability_service.py
+++ b/api/services/agent/observability_service.py
@@ -619,9 +619,7 @@ WHERE
     @staticmethod
     def _statistics_message_scope_sql(source_filter: AgentSourceFilter) -> str:
         app_scope = "m.app_id = :app_id"
-        if source_filter.invoke_from is None:
-            app_scope += " AND m.invoke_from != :debugger"
-        else:
+        if source_filter.invoke_from is not None:
             app_scope += " AND m.invoke_from = :source"
         workflow_binding_filters = []
         if source_filter.app_id:

--- a/api/tests/unit_tests/clients/agent_backend/test_event_adapter.py
+++ b/api/tests/unit_tests/clients/agent_backend/test_event_adapter.py
@@ -1,6 +1,7 @@
 import pytest
 from agenton.compositor import CompositorSessionSnapshot
 from dify_agent.protocol import (
+    AgentRunUsage,
     DeferredToolCallPayload,
     PydanticAIStreamRunEvent,
     RunCancelledEvent,
@@ -59,7 +60,11 @@ def test_event_adapter_maps_run_succeeded_to_final_output():
         RunSucceededEvent(
             id="3-0",
             run_id="run-1",
-            data=RunSucceededEventData(output={"summary": "done"}, session_snapshot=snapshot),
+            data=RunSucceededEventData(
+                output={"summary": "done"},
+                session_snapshot=snapshot,
+                usage=AgentRunUsage(prompt_tokens=2, completion_tokens=3),
+            ),
         )
     )
 
@@ -69,6 +74,7 @@ def test_event_adapter_maps_run_succeeded_to_final_output():
             source_event_id="3-0",
             output={"summary": "done"},
             session_snapshot=snapshot,
+            usage={"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5},
         )
     ]
 

--- a/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
+++ b/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
@@ -14,6 +14,7 @@ import pytest
 from agenton.compositor import CompositorSessionSnapshot
 from dify_agent.layers.ask_human import AskHumanToolResult
 from dify_agent.protocol import (
+    AgentRunUsage,
     CancelRunRequest,
     CancelRunResponse,
     PydanticAIStreamRunEvent,
@@ -136,6 +137,7 @@ class _StreamingFakeAgentBackendRunClient(FakeAgentBackendRunClient):
             data=RunSucceededEventData(
                 output={"text": "hello agent"},
                 session_snapshot=CompositorSessionSnapshot(layers=[]),
+                usage=AgentRunUsage(prompt_tokens=3, completion_tokens=5),
             ),
         )
 
@@ -392,6 +394,9 @@ def test_successful_turn_forwards_agent_backend_stream_text_deltas_without_dupli
     assert [event.chunk.delta.message.content for event in chunk_events] == ["hello ", "agent"]
     assert len(end_events) == 1
     assert end_events[0].llm_result.message.content == "hello agent"
+    assert end_events[0].llm_result.usage.prompt_tokens == 3
+    assert end_events[0].llm_result.usage.completion_tokens == 5
+    assert end_events[0].llm_result.usage.total_tokens == 8
     assert store.saved
 
 

--- a/api/tests/unit_tests/services/agent/test_agent_observability_service.py
+++ b/api/tests/unit_tests/services/agent/test_agent_observability_service.py
@@ -50,6 +50,23 @@ def test_resolve_source_filters_accepts_multiple_structured_sources() -> None:
     assert AgentObservabilityService.resolve_source_filters(("all", "webapp:app-1"))[0].kind == "all"
 
 
+def test_statistics_all_source_includes_debugger_messages() -> None:
+    source_filter = AgentObservabilityService.resolve_source_filter("all")
+
+    scope_sql = AgentObservabilityService._statistics_message_scope_sql(source_filter)
+
+    assert "m.app_id = :app_id" in scope_sql
+    assert "m.invoke_from != :debugger" not in scope_sql
+
+
+def test_statistics_explicit_source_filters_invoke_from() -> None:
+    source_filter = AgentObservabilityService.resolve_source_filter("debugger")
+
+    scope_sql = AgentObservabilityService._statistics_message_scope_sql(source_filter)
+
+    assert "m.invoke_from = :source" in scope_sql
+
+
 def test_apply_status_filter_accepts_multiple_statuses() -> None:
     class FakeStmt:
         def __init__(self):

--- a/dify-agent/src/dify_agent/protocol/__init__.py
+++ b/dify-agent/src/dify_agent/protocol/__init__.py
@@ -9,6 +9,7 @@ from .schemas import (
     DIFY_AGENT_MODEL_LAYER_ID,
     DIFY_AGENT_OUTPUT_LAYER_ID,
     RUN_EVENT_ADAPTER,
+    AgentRunUsage,
     BaseRunEvent,
     CancelRunRequest,
     CancelRunResponse,
@@ -55,6 +56,7 @@ from .sandbox import (
 
 __all__ = [
     "BaseRunEvent",
+    "AgentRunUsage",
     "CancelRunRequest",
     "CancelRunResponse",
     "CreateRunRequest",

--- a/dify-agent/src/dify_agent/protocol/schemas.py
+++ b/dify-agent/src/dify_agent/protocol/schemas.py
@@ -252,12 +252,29 @@ class DeferredToolCallPayload(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
 
+class AgentRunUsage(BaseModel):
+    """Token usage reported by the model request behind one Agent run."""
+
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _derive_total_tokens(self) -> AgentRunUsage:
+        if self.total_tokens == 0 and (self.prompt_tokens > 0 or self.completion_tokens > 0):
+            self.total_tokens = self.prompt_tokens + self.completion_tokens
+        return self
+
+
 class RunSucceededEventData(BaseModel):
     """Terminal success payload for final output or deferred tool continuation."""
 
     output: JsonValue | None = None
     deferred_tool_call: DeferredToolCallPayload | None = None
     session_snapshot: CompositorSessionSnapshot
+    usage: AgentRunUsage | None = None
 
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
@@ -276,6 +293,8 @@ class RunSucceededEventData(BaseModel):
             data["output"] = self.output
         if "deferred_tool_call" in self.model_fields_set:
             data["deferred_tool_call"] = self.deferred_tool_call
+        if self.usage is not None:
+            data["usage"] = self.usage
         return data
 
 
@@ -361,6 +380,7 @@ class RunEventsResponse(BaseModel):
 
 __all__ = [
     "BaseRunEvent",
+    "AgentRunUsage",
     "CancelRunRequest",
     "CancelRunResponse",
     "CreateRunRequest",

--- a/dify-agent/src/dify_agent/runtime/event_sink.py
+++ b/dify-agent/src/dify_agent/runtime/event_sink.py
@@ -17,6 +17,7 @@ from pydantic_ai.messages import AgentStreamEvent
 
 from agenton.compositor import CompositorSessionSnapshot
 from dify_agent.protocol.schemas import (
+    AgentRunUsage,
     DeferredToolCallPayload,
     EmptyRunEventData,
     PydanticAIStreamRunEvent,
@@ -103,6 +104,7 @@ async def emit_run_succeeded(
     output: JsonValue | None | object = _UNSET,
     deferred_tool_call: DeferredToolCallPayload | object = _UNSET,
     session_snapshot: CompositorSessionSnapshot,
+    usage: AgentRunUsage | None = None,
 ) -> str:
     """Emit the terminal success event with output or deferred continuation.
 
@@ -112,13 +114,15 @@ async def emit_run_succeeded(
     Without that sentinel, ``output=None`` would be indistinguishable from
     “output field absent”, which would break nullable-success payloads.
     """
-    data: dict[str, JsonValue | DeferredToolCallPayload | CompositorSessionSnapshot | None] = {
+    data: dict[str, JsonValue | DeferredToolCallPayload | CompositorSessionSnapshot | AgentRunUsage | None] = {
         "session_snapshot": session_snapshot,
     }
     if output is not _UNSET:
         data["output"] = cast(JsonValue | None, output)
     if deferred_tool_call is not _UNSET:
         data["deferred_tool_call"] = cast(DeferredToolCallPayload, deferred_tool_call)
+    if usage is not None:
+        data["usage"] = usage
 
     return await emit_run_event(
         sink,

--- a/dify-agent/src/dify_agent/runtime/runner.py
+++ b/dify-agent/src/dify_agent/runtime/runner.py
@@ -42,6 +42,7 @@ from dify_agent.layers.dify_plugin.llm_layer import DifyPluginLLMLayer
 from dify_agent.layers.dify_plugin.tools_layer import DifyPluginToolsLayer
 from dify_agent.layers.knowledge.layer import DifyKnowledgeBaseLayer
 from dify_agent.protocol.schemas import (
+    AgentRunUsage,
     CreateRunRequest,
     DIFY_AGENT_MODEL_LAYER_ID,
     DeferredToolCallPayload,
@@ -83,6 +84,7 @@ class RunSuccessOutcome:
     output: JsonValue | None
     deferred_tool_call: DeferredToolCallPayload | None
     session_snapshot: CompositorSessionSnapshot
+    usage: AgentRunUsage | None
 
 
 class AgentRunRunner:
@@ -135,6 +137,7 @@ class AgentRunRunner:
                 else {"deferred_tool_call": outcome.deferred_tool_call}
             ),
             session_snapshot=outcome.session_snapshot,
+            usage=outcome.usage,
         )
         await self.sink.update_status(self.run_id, "succeeded")
 
@@ -170,6 +173,7 @@ class AgentRunRunner:
         output: JsonValue | None = None
         deferred_tool_call: DeferredToolCallPayload | None = None
         result_kind: Literal["output", "deferred_tool_call"] | None = None
+        usage: AgentRunUsage | None = None
         try:
             async with compositor.enter(configs=layer_configs, session_snapshot=self.request.session_snapshot) as run:
                 entered_run = True
@@ -217,6 +221,7 @@ class AgentRunRunner:
                     deferred_tool_results=deferred_tool_results,
                     event_stream_handler=handle_events,
                 )
+                usage = _serialize_agent_usage(_result_usage(result))
                 append_successful_run_history(history_layer, result.new_messages())
                 if isinstance(result.output, DeferredToolRequests):
                     if ask_human_layer is None:
@@ -251,12 +256,37 @@ class AgentRunRunner:
             output=output,
             deferred_tool_call=deferred_tool_call,
             session_snapshot=run.session_snapshot,
+            usage=usage,
         )
 
 
 def _serialize_agent_output(output: object) -> JsonValue:
     """Convert arbitrary pydantic-ai output into the public JSON-safe payload type."""
     return cast(JsonValue, _AGENT_OUTPUT_ADAPTER.dump_python(output, mode="json"))
+
+
+def _result_usage(result: object) -> object | None:
+    """Return pydantic-ai result usage across method/property API variants."""
+    usage = getattr(result, "usage", None)
+    if hasattr(usage, "input_tokens") or hasattr(usage, "output_tokens"):
+        return usage
+    if callable(usage):
+        return usage()
+    return usage
+
+
+def _serialize_agent_usage(usage: object | None) -> AgentRunUsage | None:
+    """Convert pydantic-ai request usage into the public Agent run usage shape."""
+    if usage is None:
+        return None
+    input_tokens = int(getattr(usage, "input_tokens", 0) or 0)
+    output_tokens = int(getattr(usage, "output_tokens", 0) or 0)
+    total_tokens = int(getattr(usage, "total_tokens", 0) or 0)
+    return AgentRunUsage(
+        prompt_tokens=input_tokens,
+        completion_tokens=output_tokens,
+        total_tokens=total_tokens,
+    )
 
 
 def _resolve_agent_output_type(output_type: OutputSpec[object], allow_deferred_tools: bool) -> OutputSpec[object]:

--- a/dify-agent/tests/local/dify_agent/protocol/test_protocol_schemas.py
+++ b/dify-agent/tests/local/dify_agent/protocol/test_protocol_schemas.py
@@ -12,6 +12,7 @@ from dify_agent.layers.dify_plugin import DIFY_PLUGIN_LLM_LAYER_TYPE_ID, DIFY_PL
 from dify_agent.layers.output import DIFY_OUTPUT_LAYER_TYPE_ID, DifyOutputLayerConfig
 from dify_agent.protocol import DIFY_AGENT_HISTORY_LAYER_ID, DIFY_AGENT_MODEL_LAYER_ID, DIFY_AGENT_OUTPUT_LAYER_ID
 from dify_agent.protocol.schemas import (
+    AgentRunUsage,
     RUN_EVENT_ADAPTER,
     CreateRunRequest,
     DeferredToolCallPayload,
@@ -171,6 +172,7 @@ def test_create_run_request_accepts_dto_first_public_composition_and_normalizes_
         "conversation_id": None,
         "agent_id": None,
         "agent_config_version_id": None,
+        "agent_config_version_kind": None,
         "agent_mode": "workflow_run",
         "invoke_from": "service-api",
         "trace_id": "trace-1",
@@ -401,6 +403,27 @@ def test_run_succeeded_event_round_trips_explicit_json_null_output() -> None:
     assert decoded.data.deferred_tool_call is None
     assert b'"output":null' in payload
     assert b'"deferred_tool_call"' not in payload
+
+
+def test_run_succeeded_event_round_trips_usage() -> None:
+    event = RunSucceededEvent(
+        run_id="run-usage",
+        data=RunSucceededEventData(
+            output="done",
+            session_snapshot=CompositorSessionSnapshot(layers=[]),
+            usage=AgentRunUsage(prompt_tokens=3, completion_tokens=5),
+        ),
+    )
+
+    payload = RUN_EVENT_ADAPTER.dump_json(event)
+    decoded = RUN_EVENT_ADAPTER.validate_json(payload)
+
+    assert isinstance(decoded, RunSucceededEvent)
+    assert decoded.data.usage is not None
+    assert decoded.data.usage.prompt_tokens == 3
+    assert decoded.data.usage.completion_tokens == 5
+    assert decoded.data.usage.total_tokens == 8
+    assert b'"usage"' in payload
 
 
 def test_on_exit_accept_layer_overrides() -> None:

--- a/dify-agent/tests/local/dify_agent/runtime/test_runner.py
+++ b/dify-agent/tests/local/dify_agent/runtime/test_runner.py
@@ -378,6 +378,8 @@ def test_runner_emits_terminal_success_and_snapshot(monkeypatch: pytest.MonkeyPa
     terminal = sink.events["run-1"][-1]
     assert isinstance(terminal, RunSucceededEvent)
     assert terminal.data.output == "done"
+    assert terminal.data.usage is not None
+    assert terminal.data.usage.total_tokens > 0
     assert [layer.name for layer in terminal.data.session_snapshot.layers] == [
         "prompt",
         "renamed-execution-context",


### PR DESCRIPTION
## Summary

- Add token usage to dify-agent `run_succeeded` terminal events.
- Map agent backend usage through the API event adapter and persist it in Agent App message usage.
- Preserve terminal usage in Workflow Agent Node metadata for downstream output adaptation.
- Make Agent Roster monitoring `source=all` include debugger/build-preview messages, so the monitoring page reflects Build/Preview usage.

## Root Cause

The issue was backend-side, not frontend-side:

1. dify-agent had usage available from `agent.run(...)`, but did not expose it in the public terminal success event.
2. API Agent App runner always ended messages with `LLMUsage.empty_usage()`, so `messages.message_tokens` and `messages.answer_tokens` stayed at 0.
3. Monitoring summary aggregates token fields from `messages`; after token persistence was fixed, `source=all` still excluded debugger messages, so Build/Preview usage remained hidden unless `source=debugger` was selected.

## Verification

- `cd dify-agent && uv run pytest tests/local/dify_agent/protocol/test_protocol_schemas.py::test_run_succeeded_event_round_trips_usage tests/local/dify_agent/runtime/test_runner.py::test_runner_emits_terminal_success_and_snapshot tests/local/dify_agent/runtime/test_runner.py::test_runner_preserves_explicit_json_null_output tests/local/dify_agent/runtime/test_runner.py::test_runner_emits_deferred_tool_call_and_persists_pending_history tests/local/dify_agent/runtime/test_runner.py::test_runner_passes_dynamic_dify_knowledge_tools_to_agent -q`
- `cd api && uv run ruff check clients/agent_backend/event_adapter.py core/app/apps/agent_app/app_runner.py core/workflow/nodes/agent_v2/output_adapter.py services/agent/observability_service.py tests/unit_tests/clients/agent_backend/test_event_adapter.py tests/unit_tests/core/app/apps/agent_app/test_app_runner.py tests/unit_tests/services/agent/test_agent_observability_service.py`
- `cd api && uv run pyrefly check clients/agent_backend/event_adapter.py core/app/apps/agent_app/app_runner.py core/workflow/nodes/agent_v2/output_adapter.py services/agent/observability_service.py`
- `git diff --check origin/feat/agent-v2...HEAD`

API pytest is currently failing locally with exit 139 during pytest startup in this environment, before test assertions run.

Remote dev validation on `agent.dify.dev` after deploying `deploy/agent`:

- API and agent backend containers updated to `ce01bb7ad447ba28f61cd2e23d3721648b9a5176`.
- Real Agent chat returned `message_end.metadata.usage` with non-zero tokens.
- Latest DB message persisted `message_tokens=3471`, `answer_tokens=18`.
- Monitoring `GET /console/api/agent/{agent_id}/statistics/summary?source=all` returned `total_tokens=6943` and non-zero `tokens_per_second`.
