### PR TITLE
fix(api): tolerate legacy `service_api` end-user type on load

### DIFF
--- a/api/models/enums.py
+++ b/api/models/enums.py
@@ -214,6 +214,18 @@ class EndUserType(StrEnum):
     SERVICE_API = "service-api"
     TRIGGER = "trigger"
 
+    @classmethod
+    @override
+    def _missing_(cls, value):
+        # Legacy rows persisted the service-api type with an underscore before it
+        # was normalized to the hyphenated value. The
+        # `4f7b2c8d9a10_normalize_legacy_end_user_type` migration rewrites those
+        # rows, but tolerate the old value here as well so an unmigrated end user
+        # keeps loading instead of failing enum validation on every request.
+        if value == "service_api":
+            return cls.SERVICE_API
+        return super()._missing_(value)
+
 
 class DocumentDocType(StrEnum):
     """Document doc_type classification"""

--- a/api/tests/unit_tests/models/test_end_user_type.py
+++ b/api/tests/unit_tests/models/test_end_user_type.py
@@ -2,6 +2,9 @@ import ast
 import inspect
 from pathlib import Path
 
+import pytest
+from sqlalchemy.engine.default import DefaultDialect
+
 from models.enums import EndUserType
 from models.model import EndUser
 from models.types import EnumText
@@ -22,6 +25,24 @@ def test_end_user_type_covers_persisted_creation_values():
 
 def test_end_user_type_is_plain_persisted_value_enum():
     assert not hasattr(EndUserType, "from_invoke_from")
+
+
+def test_end_user_type_accepts_legacy_service_api_value():
+    # Legacy rows stored the service-api type with an underscore before it was
+    # normalized to the hyphenated value; loading them must not raise. See #38201.
+    assert EndUserType("service_api") is EndUserType.SERVICE_API
+    assert EndUserType("service-api") is EndUserType.SERVICE_API
+
+
+def test_end_user_type_still_rejects_unknown_values():
+    with pytest.raises(ValueError):
+        EndUserType("not-a-real-end-user-type")
+
+
+def test_enum_text_deserializes_legacy_service_api_value():
+    # Exercises the actual column load path that raised for unmigrated rows.
+    column_type = EnumText(EndUserType)
+    assert column_type.process_result_value("service_api", DefaultDialect()) is EndUserType.SERVICE_API
 
 
 def test_end_user_service_creation_methods_accept_end_user_type():


### PR DESCRIPTION
## Summary

Fixes #38201.

v1.15.0 renamed the `EndUserType` enum value from `service_api` (underscore) to `service-api` (hyphen) and shipped the `4f7b2c8d9a10_normalize_legacy_end_user_type` migration to rewrite existing rows.

However, if an `end_users` row still holds the legacy `service_api` value — the migration hasn't been run yet, or a row was created by an old instance during the upgrade window — the column's `EnumText` type deserializes it via `EndUserType(value)`:

```python
# api/models/types.py — EnumText.process_result_value
return self._enum_class(value)   # EndUserType("service_api") -> ValueError
```

That raises `'service_api' is not a valid EndUserType`, which surfaces as **HTTP 400 on every request for that end user** (e.g. `POST /v1/chat-messages`). The reporter had to hand-fix it with SQL.

### Fix

Add a `_missing_` handler to `EndUserType` that maps the legacy `service_api` value to `SERVICE_API`, exactly mirroring the existing `CreatorUserRole._missing_` (which tolerates the legacy `end-user` value) in the same file. Unmigrated end users then load gracefully instead of hard-failing.

- Only the exact legacy string `service_api` is tolerated; all other unknown values still raise.
- No schema or migration change; the canonical persisted value remains `service-api`.

## Tests

Added to `api/tests/unit_tests/models/test_end_user_type.py`:
- legacy `service_api` and canonical `service-api` both resolve to `EndUserType.SERVICE_API`
- unknown values still raise `ValueError`
- `EnumText.process_result_value("service_api", ...)` (the actual column load path that failed) returns `EndUserType.SERVICE_API`

`uv run python -m pytest tests/unit_tests/models/test_end_user_type.py` → 9 passed. `ruff` and `pyrefly` clean.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `ruff` (lint) and `pyrefly` (type-check) on the changed files plus the focused unit tests — all pass.

From Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBVXLzDtt5GcRQeJfStmUw