### PR TITLE
fix(web): don't redirect silent 401s to the console sign-in page

### DIFF
--- a/web/service/base.spec.ts
+++ b/web/service/base.spec.ts
@@ -393,3 +393,60 @@ describe('HTTP methods', () => {
     expect(typeof del).toBe('function')
   })
 })
+
+describe('request 401 sign-in redirect', () => {
+  const originalLocation = globalThis.location
+  const hrefSetter = vi.fn<(value: string) => void>()
+
+  const mock401OnPublicPage = () => {
+    // Refresh fails, so the handler falls through to the sign-in redirect branch.
+    refreshAccessTokenOrReLoginMock.mockRejectedValue(new Error('refresh failed'))
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ message: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: {
+        origin: 'https://example.com',
+        pathname: '/chat/abc',
+        search: '',
+        get href() {
+          return 'https://example.com/chat/abc'
+        },
+        set href(value: string) {
+          hrefSetter(value)
+        },
+      },
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: originalLocation,
+    })
+  })
+
+  it('does not redirect to sign-in for a silent request (best-effort call on a public page)', async () => {
+    mock401OnPublicPage()
+
+    await expect(get('/account/profile', {}, { silent: true })).rejects.toBeDefined()
+
+    expect(hrefSetter).not.toHaveBeenCalled()
+  })
+
+  it('redirects to sign-in for a non-silent request', async () => {
+    mock401OnPublicPage()
+
+    await expect(get('/account/profile', {}, {})).rejects.toBeDefined()
+
+    expect(hrefSetter).toHaveBeenCalledWith(expect.stringContaining('/signin'))
+  })
+})

--- a/web/service/base.ts
+++ b/web/service/base.ts
@@ -949,7 +949,12 @@ export const request = async<T>(url: string, options = {}, otherOptions?: IOther
       if (window.location.pathname === `${basePath}/device`)
         return Promise.reject(err)
       if (window.location.pathname !== `${basePath}/signin` || !IS_CE_EDITION) {
-        jumpTo(buildSigninUrlWithRedirect())
+        // A silent request is best-effort (e.g. the background timezone profile
+        // lookup that the shared chat renders on a public web-app page). A 401
+        // from it must not hijack navigation to the console sign-in page; reject
+        // and let the caller fall back instead. See issue #38158.
+        if (!silent)
+          jumpTo(buildSigninUrlWithRedirect())
         return Promise.reject(err)
       }
       if (!silent) {


### PR DESCRIPTION
## Summary

Fixes #38158.

In v1.15.0, public Web App share links (e.g. `http://<host>/chat/<token>`) became inaccessible to anonymous users — opening one redirects to the console sign-in page.

### Root cause

The shared chat component renders a background timezone lookup:

`useTimestamp()` (`web/hooks/use-timestamp.ts`) → `userProfileQueryOptions()` → `GET /console/api/account/profile`, issued as a **`silent`** best-effort request.

On a public Web App page there is no console session, so that request returns 401. In `service/base.ts`, `request()` attempts a token refresh and — when it fails — unconditionally called `jumpTo(buildSigninUrlWithRedirect())`, navigating the anonymous visitor to the console `/signin`. The `silent` flag was only honored in the sibling branch just below (the already-on-`/signin` case), not here.

### Fix

Gate that redirect on `!silent`, matching the adjacent branch:

```diff
       if (window.location.pathname !== `${basePath}/signin` || !IS_CE_EDITION) {
-        jumpTo(buildSigninUrlWithRedirect())
+        if (!silent)
+          jumpTo(buildSigninUrlWithRedirect())
         return Promise.reject(err)
       }
```

- Token refresh is still attempted first; this only affects the final redirect after refresh fails.
- Non-silent requests still redirect exactly as before.
- Silent, best-effort requests (like the timezone lookup) now reject quietly and let the caller fall back — so the public chat renders with the browser timezone instead of bouncing to sign-in.

`silent` already means "don't disrupt the user" (it suppresses the error toast in the sibling branch); extending it to "don't hijack navigation" is the consistent behavior.

## Tests

Added to `web/service/base.spec.ts` (drive the real `request()` path with a mocked 401 + failed refresh on a public `/chat/...` page):
- a **silent** request does **not** navigate to sign-in
- a **non-silent** request **does** navigate to sign-in

`pnpm test service/base.spec.ts` → 15 passed. `pnpm type-check` clean; `pnpm eslint` adds no new errors (base.ts's pre-existing legacy errors are tracked in `eslint-suppressions.json`).

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `pnpm test` (affected suite), `pnpm type-check`, and `pnpm eslint` — all pass.