### PR TITLE
fix(agent): map config skill upload validation errors

### DIFF
--- a/api/services/agent/skill_package_service.py
+++ b/api/services/agent/skill_package_service.py
@@ -175,7 +175,10 @@ class SkillPackageService:
                         continue
                     raise SkillPackageError(
                         "files_outside_skill_root",
-                        "skill archive contains files outside the selected skill root",
+                        (
+                            "skill package must contain exactly one skill; "
+                            "multiple skill folders in one archive are not supported"
+                        ),
                         status_code=400,
                     )
                 normalized_path = safe_path.removeprefix(skill_root_prefix)

--- a/api/services/agent_config_service.py
+++ b/api/services/agent_config_service.py
@@ -496,13 +496,16 @@ class AgentConfigService:
                 user_id=user_id,
             )
             self._require_writable(target, surface=surface)
-            skill_ref, _package = self._skill_normalizer.normalize(
-                content=content,
-                filename=filename,
-                requested_name=None,
-                tenant_id=tenant_id,
-                user_id=user_id,
-            )
+            try:
+                skill_ref, _package = self._skill_normalizer.normalize(
+                    content=content,
+                    filename=filename,
+                    requested_name=None,
+                    tenant_id=tenant_id,
+                    user_id=user_id,
+                )
+            except SkillPackageError as exc:
+                raise AgentConfigServiceError(exc.code, exc.message, status_code=exc.status_code) from exc
             agent_soul = target.agent_soul.model_copy(deep=True)
             existing = {item.name: item for item in agent_soul.config_skills}
             order = [item.name for item in agent_soul.config_skills]

--- a/api/tests/unit_tests/services/test_agent_config_service.py
+++ b/api/tests/unit_tests/services/test_agent_config_service.py
@@ -340,6 +340,38 @@ def test_push_file_for_console_uses_service_owned_upload_lookup_and_naming() -> 
     session.commit.assert_called_once()
 
 
+def test_upload_skill_for_console_maps_package_validation_failures() -> None:
+    session = MagicMock()
+    service = AgentConfigService()
+    target = _target(kind=AgentConfigVersionKind.DRAFT, writable=False)
+    message = "skill package must contain exactly one skill; multiple skill folders in one archive are not supported"
+
+    with (
+        patch(f"{MODULE}.session_factory.create_session", return_value=_session_cm(session)),
+        patch.object(service, "_resolve_target_in_session", return_value=target),
+        patch.object(
+            service._skill_normalizer,
+            "normalize",
+            side_effect=SkillPackageError("files_outside_skill_root", message, status_code=400),
+        ),
+    ):
+        with pytest.raises(AgentConfigServiceError, match="exactly one skill") as exc_info:
+            service.upload_skill_for_console(
+                tenant_id=TENANT,
+                agent_id=AGENT,
+                user_id=USER,
+                config_version_id="draft-1",
+                config_version_kind=AgentConfigVersionKind.DRAFT,
+                content=b"bad-archive",
+                filename="skills.zip",
+            )
+
+    assert exc_info.value.code == "files_outside_skill_root"
+    assert exc_info.value.message == message
+    assert exc_info.value.status_code == 400
+    session.commit.assert_not_called()
+
+
 def test_apply_skill_updates_rejects_non_tool_file_refs() -> None:
     service = AgentConfigService()
 


### PR DESCRIPTION
## Summary
- map config skill package validation failures to `AgentConfigServiceError` so console upload returns a 4xx response instead of 500
- clarify the multi-skill archive error message: a skill package must contain exactly one skill
- add service coverage for config skill upload validation error mapping

## Verification
- `uv run ruff check services/agent/skill_package_service.py services/agent_config_service.py tests/unit_tests/services/test_agent_config_service.py`
- dev E2E on `https://agent.dify.dev` after deploying `deploy/agent` commit `2d5c5de654`:
  - Linear `skills.zip` multi-skill archive upload: `400 { code: "files_outside_skill_root", message: "skill package must contain exactly one skill; multiple skill folders in one archive are not supported" }`
  - valid single-skill zip upload: `201`
- local pytest is currently blocked by a local pytest/gevent capture segfault before tests start; direct Python verification of the new mapping passed.
