### PR TITLE
fix: use MESSAGE event type for LLM text chunks

### DIFF
--- a/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
+++ b/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
@@ -74,7 +74,6 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline[EasyUIAppGenerat
     """
 
     _task_state: EasyUITaskState
-    _precomputed_event_type: StreamEvent | None = None
 
     def __init__(
         self,
@@ -342,15 +341,10 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline[EasyUIAppGenerat
                     current_content += delta_text
                     self._task_state.llm_result.message.content = current_content
 
-                    # Determine the event type once, on first LLM chunk, and reuse for subsequent chunks
-                    if not hasattr(self, "_precomputed_event_type") or self._precomputed_event_type is None:
-                        self._precomputed_event_type = self._message_cycle_manager.get_message_event_type(
-                            message_id=self._message_id
-                        )
                     yield self._message_cycle_manager.message_to_stream_response(
                         answer=delta_text,
                         message_id=self._message_id,
-                        event_type=self._precomputed_event_type,
+                        event_type=StreamEvent.MESSAGE,
                     )
                 case QueueMessageReplaceEvent():
                     yield self._message_cycle_manager.message_replace_to_stream_response(answer=event.text)

--- a/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_based_generate_task_pipeline.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_based_generate_task_pipeline.py
@@ -144,10 +144,8 @@ class TestEasyUIBasedGenerateTaskPipelineProcessStreamResponse:
             pipeline._task_state = mock_task_state
             return pipeline
 
-    def test_get_message_event_type_called_once_when_first_llm_chunk_arrives(
-        self, pipeline, mock_message_cycle_manager
-    ):
-        """Expect get_message_event_type to be called when processing the first LLM chunk event."""
+    def test_get_message_event_type_not_called_for_llm_text_chunks(self, pipeline, mock_message_cycle_manager):
+        """Expect LLM text chunks to always use MESSAGE event type."""
         # Setup a minimal LLM chunk event
         chunk = Mock()
         chunk.delta.message.content = "hi"
@@ -162,7 +160,10 @@ class TestEasyUIBasedGenerateTaskPipelineProcessStreamResponse:
         list(pipeline._process_stream_response(publisher=None, trace_manager=None))
 
         # Assert
-        mock_message_cycle_manager.get_message_event_type.assert_called_once_with(message_id="test-message-id")
+        mock_message_cycle_manager.get_message_event_type.assert_not_called()
+        mock_message_cycle_manager.message_to_stream_response.assert_called_once_with(
+            answer="hi", message_id="test-message-id", event_type=StreamEvent.MESSAGE
+        )
 
     def test_llm_chunk_event_with_text_content(self, pipeline, mock_message_cycle_manager, mock_task_state):
         """Test handling of LLM chunk events with text content."""


### PR DESCRIPTION
Fixes #36990

This is a rebased version of #31414 against the current `main` branch.

## Summary

This PR fixes streamed LLM text chunks being mislabeled as `message_file` whenever the same assistant message has files, causing API/web clients to treat text chunks as file events and drop streamed text.

## Root cause

`EasyUIBasedGenerateTaskPipeline._process_stream_response()` cached `_precomputed_event_type` from `MessageCycleManager.get_message_event_type()`. When an assistant `MessageFile` existed for the same message, that cached value could be `StreamEvent.MESSAGE_FILE`, and it was then reused for `QueueLLMChunkEvent` text chunks.

Text chunks and file metadata are separate stream payloads. `QueueLLMChunkEvent` should always be emitted as `StreamEvent.MESSAGE`; `QueueMessageFileEvent` remains responsible for `StreamEvent.MESSAGE_FILE` file metadata.

## Changes

- Remove the stale `_precomputed_event_type` state from `EasyUIBasedGenerateTaskPipeline`.
- Emit `QueueLLMChunkEvent` chunks explicitly as `StreamEvent.MESSAGE`.
- Update the unit test to assert that `get_message_event_type()` is not called for LLM text chunks and that text chunks use `StreamEvent.MESSAGE`.

## Verification

- [x] `git diff --check upstream/main...HEAD`
- [ ] `uv run --project api pytest api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_based_generate_task_pipeline.py -q` was not run locally because this environment does not have `uv` or `pytest` installed.

Note: #37005 applies the same main behavioral fix, but leaves the cached event-type state behind and relies on the default stream event. This PR removes the stale state and makes the text-chunk event invariant explicit.