### PR TITLE
fix(web): fill dataset create layout height

### DIFF
--- a/web/app/components/datasets/create/index.tsx
+++ b/web/app/components/datasets/create/index.tsx
@@ -131,9 +131,9 @@ const DatasetUpdateForm = ({ datasetId }: DatasetUpdateFormProps) => {
     return <AppUnavailable code={500} unknownReason={t('error.unavailable', { ns: 'datasetCreation' }) as string} />
 
   return (
-    <div className="flex flex-col overflow-hidden bg-components-panel-bg" style={{ height: 'calc(100vh - 56px)' }}>
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-components-panel-bg">
       <TopBar activeIndex={step - 1} datasetId={datasetId} />
-      <div style={{ height: 'calc(100% - 52px)' }}>
+      <div className="min-h-0 flex-1">
         {
           isLoadingAuthedDataSourceList && (
             <Loading type="app" />


### PR DESCRIPTION
## Summary
- Cherry-pick #38308 from main into hotfix/1.15.0-fix.1
- Fill dataset create layout height on the knowledge page

## Source commit
- 6ec56e7bd1ea4832af0c35b3a520ffbfb6c24fd7

## Testing
- Not run; cherry-pick only