### PR TITLE
fix(workspace): expose last opened in contract

### DIFF
--- a/api/controllers/console/workspace/workspace.py
+++ b/api/controllers/console/workspace/workspace.py
@@ -102,6 +102,7 @@ class TenantListItemResponse(ResponseModel):
     plan: str | None = None
     status: str | None = None
     created_at: int | None = None
+    last_opened_at: int | None = None
     current: bool
 
     @field_validator("plan", "status", mode="before")
@@ -113,9 +114,9 @@ class TenantListItemResponse(ResponseModel):
             return value
         return str(getattr(value, "value", value))
 
-    @field_validator("created_at", mode="before")
+    @field_validator("created_at", "last_opened_at", mode="before")
     @classmethod
-    def _normalize_created_at(cls, value: datetime | int | None):
+    def _normalize_timestamp(cls, value: datetime | int | None):
         return to_timestamp(value)
 
 

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -21199,6 +21199,7 @@ Tag type
 | created_at | integer |  | No |
 | current | boolean |  | Yes |
 | id | string |  | Yes |
+| last_opened_at | integer |  | No |
 | name | string |  | No |
 | plan | string |  | No |
 | status | string |  | No |

--- a/packages/contracts/generated/api/console/workspaces/types.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/types.gen.ts
@@ -939,6 +939,7 @@ export type TenantListItemResponse = {
   created_at?: number | null
   current: boolean
   id: string
+  last_opened_at?: number | null
   name?: string | null
   plan?: string | null
   status?: string | null

--- a/packages/contracts/generated/api/console/workspaces/zod.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/zod.gen.ts
@@ -684,6 +684,7 @@ export const zTenantListItemResponse = z.object({
   created_at: z.int().nullish(),
   current: z.boolean(),
   id: z.string(),
+  last_opened_at: z.int().nullish(),
   name: z.string().nullish(),
   plan: z.string().nullish(),
   status: z.string().nullish(),

--- a/web/app/components/main-nav/components/workspace-switcher.tsx
+++ b/web/app/components/main-nav/components/workspace-switcher.tsx
@@ -21,13 +21,10 @@ const workspaceSwitchActionIconClassName = 'size-3.5 shrink-0'
 const workspaceSwitchListClassName = 'max-h-[240px] overflow-y-auto overscroll-contain scroll-py-1'
 const workspaceSwitchI18nKey = (key: string) => key as 'mainNav.workspace.settings'
 type WorkspaceSort = 'lastOpened' | 'createdAt'
-type WorkspaceListItem = TenantListItemResponse & {
-  last_opened_at?: number | null
-}
 
-const getWorkspaceName = (workspace: WorkspaceListItem) => workspace.name || workspace.id
-const getWorkspaceCreatedAt = (workspace: WorkspaceListItem) => workspace.created_at ?? 0
-const getWorkspaceLastOpenedAt = (workspace: WorkspaceListItem) => workspace.last_opened_at ?? 0
+const getWorkspaceName = (workspace: TenantListItemResponse) => workspace.name || workspace.id
+const getWorkspaceCreatedAt = (workspace: TenantListItemResponse) => workspace.created_at ?? 0
+const getWorkspaceLastOpenedAt = (workspace: TenantListItemResponse) => workspace.last_opened_at ?? 0
 
 function WorkspaceSwitchControls({
   searchText,
@@ -123,7 +120,7 @@ function WorkspaceSwitchControls({
 }
 
 type WorkspaceSwitcherProps = {
-  workspaces: WorkspaceListItem[]
+  workspaces: TenantListItemResponse[]
   onSwitchWorkspace: (workspaceId: string) => void
 }
 


### PR DESCRIPTION
## Summary
- add `last_opened_at` to the `/workspaces` response schema
- regenerate console workspace contracts with `vpr @dify/contracts#gen-api-contract`
- remove the frontend local type extension now that the generated contract owns the field

## Testing
- `vpr @dify/contracts#gen-api-contract`
- `make api-contract-lint`
- `uv run --project api --dev pytest api/tests/unit_tests/controllers/console/workspace/test_workspace.py`
- `pnpm exec eslint web/app/components/main-nav/components/workspace-switcher.tsx web/app/components/main-nav/components/workspace-card.tsx web/app/components/main-nav/components/__tests__/workspace-card.spec.tsx`
- `pnpm -C packages/contracts type-check`
- `pnpm -C web test app/components/main-nav/components/__tests__/workspace-card.spec.tsx`
- `git diff --check`

## Notes
- The endpoint already returned `last_opened_at` at runtime via legacy marshal fields. This PR aligns the Pydantic response model and generated contract with that runtime response, following `api/controllers/API_SCHEMA_GUIDE.md` as the response schema source of truth.
