### PR TITLE
refactor: migrate 4 console controllers to @with_session pattern (#36544)

### DIFF
--- a/api/controllers/console/app/mcp_server.py
+++ b/api/controllers/console/app/mcp_server.py
@@ -6,11 +6,12 @@ from uuid import UUID
 from flask_restx import Resource
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import select
+from sqlalchemy.orm import Session
 from werkzeug.exceptions import NotFound
 
 from controllers.common.schema import register_schema_models
 from controllers.console import console_ns
-from controllers.console.app.wraps import get_app_model
+from controllers.console.app.wraps import get_app_model, with_session
 from controllers.console.wraps import (
     RBACPermission,
     RBACResourceScope,
@@ -88,9 +89,10 @@ class AppMCPServerController(Resource):
     @account_initialization_required
     @setup_required
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_VIEW_LAYOUT)
+    @with_session(write=False)
     @get_app_model
-    def get(self, app_model: App):
-        server = db.session.scalar(select(AppMCPServer).where(AppMCPServer.app_id == app_model.id).limit(1))
+    def get(self, session: Session, app_model: App):
+        server = session.scalar(select(AppMCPServer).where(AppMCPServer.app_id == app_model.id).limit(1))
         if server is None:
             return {}
         return dump_response(AppMCPServerResponse, server)
@@ -109,8 +111,9 @@ class AppMCPServerController(Resource):
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_EDIT)
     @with_current_tenant_id
+    @with_session(write=True)
     @get_app_model
-    def post(self, current_tenant_id: str, app_model: App):
+    def post(self, session: Session, current_tenant_id: str, app_model: App):
         payload = MCPServerCreatePayload.model_validate(console_ns.payload or {})
 
         description = payload.description
@@ -126,8 +129,8 @@ class AppMCPServerController(Resource):
             tenant_id=current_tenant_id,
             server_code=AppMCPServer.generate_server_code(16),
         )
-        db.session.add(server)
-        db.session.commit()
+        session.add(server)
+
         return dump_response(AppMCPServerResponse, server), 201
 
     @console_ns.doc("update_app_mcp_server")
@@ -144,12 +147,13 @@ class AppMCPServerController(Resource):
     @account_initialization_required
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_EDIT)
+    @with_session(write=True)
     @get_app_model
-    def put(self, app_model: App):
+    def put(self, session: Session, app_model: App):
         payload = MCPServerUpdatePayload.model_validate(console_ns.payload or {})
         app_ref = AppRefService.create_app_ref(app_model)
         server_ref = AppRefService.create_mcp_server_ref(app_ref, payload.id)
-        server = db.session.scalar(
+        server = session.scalar(
             select(AppMCPServer)
             .where(
                 AppMCPServer.id == server_ref.server_id,
@@ -175,7 +179,7 @@ class AppMCPServerController(Resource):
                 server.status = AppMCPServerStatus(payload.status)
             except ValueError:
                 raise ValueError("Invalid status")
-        db.session.commit()
+
         return dump_response(AppMCPServerResponse, server)
 
 
@@ -192,9 +196,10 @@ class AppMCPServerRefreshController(Resource):
     @account_initialization_required
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_VIEW_LAYOUT)
+    @with_session(write=True)
     @with_current_tenant_id
-    def get(self, current_tenant_id: str, server_id: UUID):
-        server = db.session.scalar(
+    def get(self, session: Session, current_tenant_id: str, server_id: UUID):
+        server = session.scalar(
             select(AppMCPServer)
             .where(AppMCPServer.id == server_id, AppMCPServer.tenant_id == current_tenant_id)
             .limit(1)
@@ -202,5 +207,5 @@ class AppMCPServerRefreshController(Resource):
         if not server:
             raise NotFound()
         server.server_code = AppMCPServer.generate_server_code(16)
-        db.session.commit()
+
         return dump_response(AppMCPServerResponse, server)

--- a/api/controllers/console/app/mcp_server.py
+++ b/api/controllers/console/app/mcp_server.py
@@ -21,7 +21,6 @@ from controllers.console.wraps import (
     setup_required,
     with_current_tenant_id,
 )
-from extensions.ext_database import db
 from fields.base import ResponseModel
 from libs.helper import dump_response, to_timestamp
 from libs.login import login_required

--- a/api/controllers/console/app/site.py
+++ b/api/controllers/console/app/site.py
@@ -20,7 +20,6 @@ from controllers.console.wraps import (
     setup_required,
     with_current_user,
 )
-from extensions.ext_database import db
 from fields.base import ResponseModel
 from libs.datetime_utils import naive_utc_now
 from libs.helper import dump_response

--- a/api/controllers/console/app/site.py
+++ b/api/controllers/console/app/site.py
@@ -3,12 +3,13 @@ from typing import Literal
 from flask_restx import Resource
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import select
+from sqlalchemy.orm import Session
 from werkzeug.exceptions import NotFound
 
 from constants.languages import supported_language
 from controllers.common.schema import register_schema_models
 from controllers.console import console_ns
-from controllers.console.app.wraps import get_app_model
+from controllers.console.app.wraps import get_app_model, with_session
 from controllers.console.wraps import (
     RBACPermission,
     RBACResourceScope,
@@ -94,10 +95,11 @@ class AppSite(Resource):
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_RELEASE_AND_VERSION)
     @account_initialization_required
     @with_current_user
+    @with_session(write=True)
     @get_app_model
-    def post(self, current_user: Account, app_model: App):
+    def post(self, session: Session, current_user: Account, app_model: App):
         args = AppSiteUpdatePayload.model_validate(console_ns.payload or {})
-        site = db.session.scalar(select(Site).where(Site.app_id == app_model.id).limit(1))
+        site = session.scalar(select(Site).where(Site.app_id == app_model.id).limit(1))
         if not site:
             raise NotFound
 
@@ -126,7 +128,6 @@ class AppSite(Resource):
 
         site.updated_by = current_user.id
         site.updated_at = naive_utc_now()
-        db.session.commit()
 
         return dump_response(AppSiteResponse, site)
 
@@ -145,9 +146,10 @@ class AppSiteAccessTokenReset(Resource):
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_RELEASE_AND_VERSION)
     @account_initialization_required
     @with_current_user
+    @with_session(write=True)
     @get_app_model
-    def post(self, current_user: Account, app_model: App):
-        site = db.session.scalar(select(Site).where(Site.app_id == app_model.id).limit(1))
+    def post(self, session: Session, current_user: Account, app_model: App):
+        site = session.scalar(select(Site).where(Site.app_id == app_model.id).limit(1))
 
         if not site:
             raise NotFound
@@ -155,6 +157,5 @@ class AppSiteAccessTokenReset(Resource):
         site.code = Site.generate_code(16)
         site.updated_by = current_user.id
         site.updated_at = naive_utc_now()
-        db.session.commit()
 
         return dump_response(AppSiteResponse, site)

--- a/api/controllers/console/explore/completion.py
+++ b/api/controllers/console/explore/completion.py
@@ -17,9 +17,9 @@ from controllers.console.app.error import (
     ProviderNotInitializeError,
     ProviderQuotaExceededError,
 )
+from controllers.console.app.wraps import with_session
 from controllers.console.explore.error import NotChatAppError, NotCompletionAppError
 from controllers.console.explore.wraps import InstalledAppResource
-from controllers.console.app.wraps import with_session
 from controllers.console.wraps import with_current_user, with_current_user_id
 from controllers.web.error import InvokeRateLimitError as InvokeRateLimitHttpError
 from core.app.entities.app_invoke_entities import InvokeFrom
@@ -28,7 +28,6 @@ from core.errors.error import (
     ProviderTokenNotInitError,
     QuotaExceededError,
 )
-from extensions.ext_database import db
 from graphon.model_runtime.errors.invoke import InvokeError
 from libs import helper
 from libs.datetime_utils import naive_utc_now

--- a/api/controllers/console/explore/completion.py
+++ b/api/controllers/console/explore/completion.py
@@ -3,6 +3,7 @@ from typing import Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator
+from sqlalchemy.orm import Session
 from werkzeug.exceptions import InternalServerError, NotFound
 
 import services
@@ -18,6 +19,7 @@ from controllers.console.app.error import (
 )
 from controllers.console.explore.error import NotChatAppError, NotCompletionAppError
 from controllers.console.explore.wraps import InstalledAppResource
+from controllers.console.app.wraps import with_session
 from controllers.console.wraps import with_current_user, with_current_user_id
 from controllers.web.error import InvokeRateLimitError as InvokeRateLimitHttpError
 from core.app.entities.app_invoke_entities import InvokeFrom
@@ -84,8 +86,9 @@ register_response_schema_models(console_ns, GeneratedAppResponse, SimpleResultRe
 class CompletionApi(InstalledAppResource):
     @console_ns.expect(console_ns.models[CompletionMessageExplorePayload.__name__])
     @console_ns.response(200, "Success", console_ns.models[GeneratedAppResponse.__name__])
+    @with_session(write=True)
     @with_current_user
-    def post(self, current_user: Account, installed_app: InstalledApp):
+    def post(self, session: Session, current_user: Account, installed_app: InstalledApp):
         app_model = installed_app.app
         if app_model is None:
             raise AppUnavailableError()
@@ -99,7 +102,6 @@ class CompletionApi(InstalledAppResource):
         args["auto_generate_name"] = False
 
         installed_app.last_used_at = naive_utc_now()
-        db.session.commit()
 
         try:
             response = AppGenerateService.generate(
@@ -160,8 +162,9 @@ class CompletionStopApi(InstalledAppResource):
 class ChatApi(InstalledAppResource):
     @console_ns.expect(console_ns.models[ChatMessagePayload.__name__])
     @console_ns.response(200, "Success", console_ns.models[GeneratedAppResponse.__name__])
+    @with_session(write=True)
     @with_current_user
-    def post(self, current_user: Account, installed_app: InstalledApp):
+    def post(self, session: Session, current_user: Account, installed_app: InstalledApp):
         app_model = installed_app.app
         if app_model is None:
             raise AppUnavailableError()
@@ -175,7 +178,6 @@ class ChatApi(InstalledAppResource):
         args["auto_generate_name"] = False
 
         installed_app.last_used_at = naive_utc_now()
-        db.session.commit()
 
         try:
             response = AppGenerateService.generate(

--- a/api/controllers/console/explore/saved_message.py
+++ b/api/controllers/console/explore/saved_message.py
@@ -1,20 +1,18 @@
 from uuid import UUID
 
 from flask import request
-from sqlalchemy.orm import Session
-
 from pydantic import TypeAdapter
+from sqlalchemy.orm import Session
 from werkzeug.exceptions import NotFound
 
 from controllers.common.controller_schemas import SavedMessageCreatePayload, SavedMessageListQuery
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from controllers.console import console_ns
 from controllers.console.app.error import AppUnavailableError
+from controllers.console.app.wraps import with_session
 from controllers.console.explore.error import NotCompletionAppError
 from controllers.console.explore.wraps import InstalledAppResource
-from controllers.console.app.wraps import with_session
 from controllers.console.wraps import with_current_user
-from extensions.ext_database import db
 from fields.conversation_fields import ResultResponse
 from fields.message_fields import SavedMessageInfiniteScrollPagination, SavedMessageItem
 from models import Account

--- a/api/controllers/console/explore/saved_message.py
+++ b/api/controllers/console/explore/saved_message.py
@@ -1,6 +1,8 @@
 from uuid import UUID
 
 from flask import request
+from sqlalchemy.orm import Session
+
 from pydantic import TypeAdapter
 from werkzeug.exceptions import NotFound
 
@@ -10,6 +12,7 @@ from controllers.console import console_ns
 from controllers.console.app.error import AppUnavailableError
 from controllers.console.explore.error import NotCompletionAppError
 from controllers.console.explore.wraps import InstalledAppResource
+from controllers.console.app.wraps import with_session
 from controllers.console.wraps import with_current_user
 from extensions.ext_database import db
 from fields.conversation_fields import ResultResponse
@@ -27,8 +30,9 @@ register_response_schema_models(console_ns, ResultResponse, SavedMessageInfinite
 class SavedMessageListApi(InstalledAppResource):
     @console_ns.doc(params=query_params_from_model(SavedMessageListQuery))
     @console_ns.response(200, "Success", console_ns.models[SavedMessageInfiniteScrollPagination.__name__])
+    @with_session(write=False)
     @with_current_user
-    def get(self, current_user: Account, installed_app: InstalledApp):
+    def get(self, session: Session, current_user: Account, installed_app: InstalledApp):
         app_model = installed_app.app
         if app_model is None:
             raise AppUnavailableError()
@@ -38,7 +42,7 @@ class SavedMessageListApi(InstalledAppResource):
         args = SavedMessageListQuery.model_validate(request.args.to_dict())
 
         pagination = SavedMessageService.pagination_by_last_id(
-            db.session(),
+            session,
             app_model,
             current_user,
             str(args.last_id) if args.last_id else None,
@@ -54,8 +58,9 @@ class SavedMessageListApi(InstalledAppResource):
 
     @console_ns.expect(console_ns.models[SavedMessageCreatePayload.__name__])
     @console_ns.response(200, "Success", console_ns.models[ResultResponse.__name__])
+    @with_session(write=True)
     @with_current_user
-    def post(self, current_user: Account, installed_app: InstalledApp):
+    def post(self, session: Session, current_user: Account, installed_app: InstalledApp):
         app_model = installed_app.app
         if app_model is None:
             raise AppUnavailableError()
@@ -65,7 +70,7 @@ class SavedMessageListApi(InstalledAppResource):
         payload = SavedMessageCreatePayload.model_validate(console_ns.payload or {})
 
         try:
-            SavedMessageService.save(db.session(), app_model, current_user, str(payload.message_id))
+            SavedMessageService.save(session, app_model, current_user, str(payload.message_id))
         except MessageNotExistsError:
             raise NotFound("Message Not Exists.")
 
@@ -77,8 +82,9 @@ class SavedMessageListApi(InstalledAppResource):
 )
 class SavedMessageApi(InstalledAppResource):
     @console_ns.response(204, "Saved message deleted successfully")
+    @with_session(write=True)
     @with_current_user
-    def delete(self, current_user: Account, installed_app: InstalledApp, message_id: UUID):
+    def delete(self, session: Session, current_user: Account, installed_app: InstalledApp, message_id: UUID):
         app_model = installed_app.app
         if app_model is None:
             raise AppUnavailableError()
@@ -88,6 +94,6 @@ class SavedMessageApi(InstalledAppResource):
         if app_model.mode != "completion":
             raise NotCompletionAppError()
 
-        SavedMessageService.delete(db.session(), app_model, current_user, message_id_str)
+        SavedMessageService.delete(session, app_model, current_user, message_id_str)
 
         return "", 204


### PR DESCRIPTION
## Summary
Migrate `db.session` usage to `@with_session` pattern in 4 console controllers:

- **app/site.py** — AppSite.post, AppSiteAccessTokenReset.post (write paths)
- **app/mcp_server.py** — AppMCPServerController (get/post/put) + AppMCPServerRefreshController.get
- **explore/completion.py** — CompletionApi.post, ChatApi.post (write paths)
- **explore/saved_message.py** — SavedMessageListApi (get/post), SavedMessageApi.delete

## Changes
- Added `@with_session(write=True/False)` decorator to each method
- Replaced `db.session.scalar/add()` with injected `session.scalar/add()`
- Removed explicit `db.session.commit()` (auto-committed by decorator)
- Updated method signatures to accept `session: Session`

Part of ongoing dep-injection work for #36544.