### PR TITLE
fix(api): strip leftover type/config when sensitive-word avoidance is disabled

### DIFF
--- a/api/core/app/app_config/common/sensitive_word_avoidance/manager.py
+++ b/api/core/app/app_config/common/sensitive_word_avoidance/manager.py
@@ -65,6 +65,12 @@ def _normalize_raw(raw: Any) -> Any:
             raw = {**raw, "enabled": False}
         elif raw.get("enabled") is True and raw.get("config") is None:
             raw = {**raw, "config": {}}
+        elif raw.get("enabled") is False:
+            # When the moderation is disabled, the client may still send
+            # leftover 'type' / 'config' fields (e.g. {"enabled": false, "type": "", "config": {}}).
+            # Strip them so the discriminator-tagged union in
+            # SensitiveWordAvoidanceDisabledConfig (extra="forbid") does not reject the payload.
+            raw = {key: value for key, value in raw.items() if key in {"enabled"}}
     return raw
 
 

--- a/api/tests/unit_tests/core/app/app_config/common/test_sensitive_word_avoidance_manager.py
+++ b/api/tests/unit_tests/core/app/app_config/common/test_sensitive_word_avoidance_manager.py
@@ -97,6 +97,11 @@ class TestSensitiveWordAvoidanceConfigManagerValidateAndSetDefaults:
             {"sensitive_word_avoidance": {"enabled": False}},
             {"sensitive_word_avoidance": {"enabled": None}},
             {"sensitive_word_avoidance": {}},
+            # Regression for issue #38327: client sends leftover type/config fields
+            # alongside enabled=False. The normalize step must strip them so the
+            # discriminator-tagged union (extra="forbid") does not reject the payload.
+            {"sensitive_word_avoidance": {"enabled": False, "type": "", "config": {}}},
+            {"sensitive_word_avoidance": {"enabled": False, "type": "keywords", "config": {"k": "v"}}},
         ],
     )
     def test_validate_disables_when_enabled_false_or_missing(self, config):


### PR DESCRIPTION
Fixes #38409

## Summary

When a chat request carries `{"sensitive_word_avoidance": {"enabled": false, "type": "", "config": {}}}`, the existing `_normalize_raw()` in `core/app/app_config/common/sensitive_word_avoidance/manager.py` falls through every branch: `enabled` is not `None`, `enabled` is not `True`, so the leftover `type`/`config` fields are passed straight through to the discriminator-tagged union.

`SensitiveWordAvoidanceDisabledConfig` is declared with `extra="forbid"`, so pydantic raises `ValidationError("Extra inputs are not permitted: type, config")` and the API returns HTTP 400 `invalid_param` ??matching the trace in issue #38327.

## Changes

- `api/core/app/app_config/common/sensitive_word_avoidance/manager.py`: extend `_normalize_raw()` to drop every key other than `"enabled"` when `enabled is False`. This matches the intent of the disabled schema (only `enabled` matters).
- `api/tests/unit_tests/core/app/app_config/common/test_sensitive_word_avoidance_manager.py`: add two parametrize cases to `test_validate_disables_when_enabled_false_or_missing` covering the regression (empty leftover fields and non-empty leftover fields).

## Diff stat

```
api/core/app/app_config/common/sensitive_word_avoidance/manager.py                                       | 6 ++++++
api/tests/unit_tests/core/app/app_config/common/test_sensitive_word_avoidance_manager.py                  | 5 +++++
2 files changed, 11 insertions(+)
```

## Test plan

- [ ] New parametrize cases `{"enabled": False, "type": "", "config": {}}` and `{"enabled": False, "type": "keywords", "config": {"k": "v"}}` pass ??confirming the normalize step strips leftover fields and the union no longer raises `Extra inputs are not permitted`.
- [ ] All existing `TestSensitiveWordAvoidanceConfigManager*` tests continue to pass.
- [ ] Manual: send a chat request to an agent app with the offending payload ??confirm HTTP 200 and the moderation-disabled flow runs.
- [ ] `ruff check api/core/app/app_config/common/sensitive_word_avoidance/manager.py` clean.

## Risk / behavior preservation

- The disabled case already returns `None` from `convert()` and only persists `{enabled: False}` from `validate_and_set_defaults().model_dump()`, so the cleanup only affects the input-normalization boundary, not the persisted shape.
- The `enabled is True` branch and the `enabled is None` branch are untouched.
- `ModerationFactory.validate_config` is still called for each enabled config, unchanged.
- No schema, migration, controller, or frontend changes.

## Related

- Issue #38327 ??agent app validation error (no linked PR).
- Discovered by `peaks-loop` session `2026-07-02-session-95565c` during an issue sweep on 2026-07-02.

## Automation

Generated via peaks-loop (full-auto mode). Red-line scope was limited to `core/app/app_config/common/sensitive_word_avoidance/manager.py` and the matching parametrize list in its unit-test file. Commit message includes the peaks-loop provenance line for traceability.

?? Generated with [Claude Code](https://claude.com/claude-code) via peaks-loop