### PR TITLE
fix: prevent app card meta overflow

### DIFF
--- a/web/app/components/apps/app-card.tsx
+++ b/web/app/components/apps/app-card.tsx
@@ -1076,7 +1076,7 @@ export function AppCard({ app, onlineUsers = [], onRefresh, onOpenTagManagement 
       <div className="flex h-[26px] shrink-0 items-start px-3" />
       <div
         className={cn(
-          'flex min-w-0 shrink-0 items-center pt-2 pb-3 pl-4 system-xs-regular text-text-tertiary',
+          'flex min-w-0 shrink-0 items-center overflow-hidden pt-2 pb-3 pl-4 system-xs-regular text-text-tertiary',
           app.access_mode ? 'pr-9' : 'pr-4',
         )}
       >
@@ -1087,7 +1087,7 @@ export function AppCard({ app, onlineUsers = [], onRefresh, onOpenTagManagement 
               <div className="shrink-0">·</div>
             </>
           )}
-          <div className="shrink-0">{editTimeText}</div>
+          <div className="min-w-0 truncate">{editTimeText}</div>
         </div>
       </div>
     </>


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes Linear SNP-509.

This PR prevents the app card footer metadata from overlapping the bottom-right access-mode icon when the author/time text is too long. The footer row now clips overflowing content, and the edited time text can shrink and truncate instead of forcing the row into the decorative icon area.

From Codex

## Screenshots

| Before | After |
|--------|-------|
| Footer metadata could run underneath the bottom-right access icon when space was tight. | Footer metadata stays within the available row width and truncates before the icon area. |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Validation:

- `CI=true pnpm -C web test app/components/apps/__tests__/app-card.spec.tsx`
- `CI=true pnpm -C web exec eslint app/components/apps/app-card.tsx app/components/apps/__tests__/app-card.spec.tsx` failed on pre-existing a11y lint issues outside this diff.
- `CI=true pnpm -C web exec vp staged` failed because the current `vite.config.ts` has no `staged` config.
