### PR TITLE
fix(agent): accept chat feature follow-up model config

### DIFF
--- a/api/models/agent_config_entities.py
+++ b/api/models/agent_config_entities.py
@@ -516,9 +516,18 @@ class AgentTextToSpeechFeatureConfig(AgentFeatureToggleConfig):
     autoPlay: str | None = None
 
 
+class AgentSuggestedQuestionsAfterAnswerModelConfig(AgentFlexibleConfig):
+    """Legacy Chat App model config used only for follow-up question generation."""
+
+    provider: str = Field(min_length=1, max_length=255)
+    name: str = Field(min_length=1, max_length=255)
+    mode: str | None = Field(default=None, max_length=64)
+    completion_params: dict[str, Any] | None = None
+
+
 class AgentSuggestedQuestionsAfterAnswerFeatureConfig(AgentFeatureToggleConfig):
     prompt: str | None = None
-    model: AgentSoulModelConfig | None = None
+    model: AgentSuggestedQuestionsAfterAnswerModelConfig | None = None
 
 
 class AgentModerationIOConfig(AgentFlexibleConfig):

--- a/api/tests/unit_tests/services/agent/test_agent_composer_entities.py
+++ b/api/tests/unit_tests/services/agent/test_agent_composer_entities.py
@@ -124,6 +124,38 @@ def test_agent_app_soul_allows_app_features_and_variables():
     assert payload.agent_soul.app_variables[0].name == "company_name"
 
 
+def test_agent_app_soul_accepts_legacy_follow_up_model_config():
+    payload = ComposerSavePayload.model_validate(
+        {
+            "variant": ComposerVariant.AGENT_APP,
+            "save_strategy": ComposerSaveStrategy.SAVE_TO_CURRENT_VERSION,
+            "agent_soul": {
+                "app_features": {
+                    "suggested_questions_after_answer": {
+                        "enabled": True,
+                        "prompt": "Suggest useful follow-up questions.",
+                        "model": {
+                            "provider": "openai",
+                            "name": "gpt-4o-mini",
+                            "mode": "chat",
+                            "completion_params": {"temperature": 0.7, "max_tokens": 128},
+                        },
+                    },
+                },
+            },
+        }
+    )
+
+    assert payload.agent_soul is not None
+    follow_up = payload.agent_soul.app_features.suggested_questions_after_answer
+    assert follow_up is not None
+    assert follow_up.enabled is True
+    assert follow_up.model is not None
+    assert follow_up.model.provider == "openai"
+    assert follow_up.model.name == "gpt-4o-mini"
+    assert follow_up.model.completion_params == {"temperature": 0.7, "max_tokens": 128}
+
+
 def test_composer_save_payload_accepts_new_roster_metadata():
     payload = ComposerSavePayload.model_validate(
         {


### PR DESCRIPTION
## Summary

- Accept the legacy Chat App follow-up question model config shape in Agent v2 `app_features.suggested_questions_after_answer.model`.
- Keep Agent Soul primary model config unchanged; this only affects the optional follow-up question feature model.
- Add a composer payload regression test for `{ provider, name, mode, completion_params }`.

## Verification

- Deployed commit `2662b4b483` to `deploy/agent` and refreshed `https://agent.dify.dev` with the existing remote deploy script.
- Verified real console APIs on `https://agent.dify.dev` using Linear's agent id `019f2146-2290-7db4-b058-7d360be8c04b`:
  - `GET /console/api/agent/{agent_id}/composer` -> 200
  - `PUT /console/api/agent/{agent_id}/composer` with `suggested_questions_after_answer.model = { provider, name, mode, completion_params }` -> 200
  - Response preserved `model.provider=openai` and `model.name=gpt-4o-mini`
  - `POST /console/api/agent/{agent_id}/chat-messages` ordinary streaming run -> 200, returned message event
- Local direct DTO/feature-manager validation passed on the deploy branch.

## Notes

- Local pytest on this workspace exits with code 139 even for the targeted test, before assertions.
- On the `feat/agent-v2` target branch, importing `services.entities.agent_entities` currently also hits an unrelated existing enum mismatch: `PauseReasonType.LEGACY_HUMAN_INPUT_REQUIRED` is referenced but missing. I did not include that unrelated fix in this PR.
- `make type-check-core` is blocked in this local environment by existing missing provider modules under trace/vdb providers, unrelated to this change.
