### PR TITLE
fix(api): don't mutate workflow.graph_dict in single-node run

### DIFF
--- a/api/core/app/apps/workflow_app_runner.py
+++ b/api/core/app/apps/workflow_app_runner.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from collections.abc import Mapping, Sequence
-from typing import Any, cast
+from typing import Any
 
 from pydantic import ValidationError
 
@@ -266,8 +266,6 @@ class WorkflowBasedAppRunner:
         if not graph_config:
             raise ValueError("workflow graph not found")
 
-        graph_config = cast(dict[str, Any], graph_config)
-
         if "nodes" not in graph_config or "edges" not in graph_config:
             raise ValueError("nodes or edges not found in workflow graph")
 
@@ -288,8 +286,6 @@ class WorkflowBasedAppRunner:
             or (start_node_id and node.get("id") == start_node_id)
         ]
 
-        graph_config["nodes"] = node_configs
-
         node_ids = [node.get("id") for node in node_configs]
 
         # filter edges only in the specified node type
@@ -300,7 +296,10 @@ class WorkflowBasedAppRunner:
             and (edge.get("target") is None or edge.get("target") in node_ids)
         ]
 
-        graph_config["edges"] = edge_configs
+        # Build a filtered copy instead of mutating `workflow.graph_dict`. That mapping is
+        # meant to be read-only (mutating it corrupts later reads such as the full-graph
+        # `extract_variable_selector_to_variable_mapping` call below and blocks caching it).
+        filtered_graph_config = {**graph_config, "nodes": node_configs, "edges": edge_configs}
 
         typed_node_configs = [NodeConfigDictAdapter.validate_python(node) for node in node_configs]
 
@@ -315,7 +314,7 @@ class WorkflowBasedAppRunner:
         )
         graph_init_context = DifyGraphInitContext(
             workflow_id=workflow.id,
-            graph_config=graph_config,
+            graph_config=filtered_graph_config,
             run_context=run_context,
             call_depth=0,
         )
@@ -384,7 +383,7 @@ class WorkflowBasedAppRunner:
 
         # init graph after constructor-time context has been loaded
         graph = Graph.init(
-            graph_config=graph_config, node_factory=node_factory, root_node_id=node_id, skip_validation=True
+            graph_config=filtered_graph_config, node_factory=node_factory, root_node_id=node_id, skip_validation=True
         )
 
         if not graph:

--- a/api/tests/unit_tests/core/app/apps/test_workflow_app_runner_core.py
+++ b/api/tests/unit_tests/core/app/apps/test_workflow_app_runner_core.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -176,6 +177,66 @@ class TestWorkflowBasedAppRunner:
 
         assert graph is not None
         assert variable_pool is graph_runtime_state.variable_pool
+
+    def test_get_graph_and_variable_pool_for_single_node_run_does_not_mutate_graph_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # `workflow.graph_dict` is a shared, read-only mapping; single-node run must filter a
+        # copy rather than mutate it (see issue #38353).
+        runner = WorkflowBasedAppRunner(queue_manager=SimpleNamespace(), app_id="app")
+        graph_runtime_state = GraphRuntimeState(
+            variable_pool=VariablePool.from_bootstrap(system_variables=default_system_variables()),
+            start_at=0.0,
+        )
+
+        graph_config = {
+            "nodes": [
+                {"id": "node-1", "data": {"type": "start", "version": "1"}},
+                {"id": "node-2", "data": {"type": "llm", "version": "1"}},
+            ],
+            "edges": [{"source": "node-1", "target": "node-2"}],
+        }
+        workflow = SimpleNamespace(tenant_id="tenant", id="workflow", graph_dict=graph_config)
+
+        captured: dict[str, Any] = {}
+        monkeypatch.setattr(
+            "core.app.apps.workflow_app_runner.Graph.init",
+            lambda **kwargs: captured.update(kwargs) or SimpleNamespace(),
+        )
+
+        class _NodeCls:
+            @staticmethod
+            def extract_variable_selector_to_variable_mapping(graph_config, config):
+                return {}
+
+        from core.app.apps import workflow_app_runner
+
+        monkeypatch.setattr(workflow_app_runner, "resolve_workflow_node_class", lambda **_kwargs: _NodeCls)
+        monkeypatch.setattr("core.app.apps.workflow_app_runner.load_into_variable_pool", lambda **kwargs: None)
+        monkeypatch.setattr(
+            "core.app.apps.workflow_app_runner.WorkflowEntry.mapping_user_inputs_to_variable_pool",
+            lambda **kwargs: None,
+        )
+
+        runner._get_graph_and_variable_pool_for_single_node_run(
+            workflow=workflow,
+            node_id="node-1",
+            user_inputs={},
+            graph_runtime_state=graph_runtime_state,
+            node_type_filter_key="iteration_id",
+            node_type_label="iteration",
+            user_id="00000000-0000-0000-0000-000000000001",
+        )
+
+        # The shared workflow graph dict is left intact...
+        assert graph_config["nodes"] == [
+            {"id": "node-1", "data": {"type": "start", "version": "1"}},
+            {"id": "node-2", "data": {"type": "llm", "version": "1"}},
+        ]
+        assert graph_config["edges"] == [{"source": "node-1", "target": "node-2"}]
+        # ...while the graph that is actually built uses the filtered copy (only the target node).
+        assert [node["id"] for node in captured["graph_config"]["nodes"]] == ["node-1"]
+        assert captured["graph_config"]["edges"] == []
 
     def test_get_graph_and_variable_pool_for_single_node_run_includes_trace_session_id(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

Fixes #38353.

`WorkflowBasedAppRunner._get_graph_and_variable_pool_for_single_node_run` filters the workflow graph down to a single iteration/loop node. To do that it `cast(dict, …)`-ed the mapping returned by `workflow.graph_dict` and mutated it in place:

```python
graph_config = cast(dict[str, Any], graph_config)
...
graph_config["nodes"] = node_configs
...
graph_config["edges"] = edge_configs
```

`Workflow.graph_dict` is declared as a read-only `Mapping[str, Any]`, and there's an explicit TODO on it noting it can't be cached because *"some code in the codebase may modify the returned dict"* (`api/models/workflow.py`). This method is exactly that code. It's only harmless today because the property re-decodes JSON on every access — so the later full-graph read in the same method (`extract_variable_selector_to_variable_mapping(graph_config=workflow.graph_dict, …)`) gets a fresh, unmutated dict. If `graph_dict` were ever cached, the mutation would corrupt that read.

## Fix

Build a filtered **copy** and pass it to `DifyGraphInitContext` and `Graph.init`, instead of mutating the source mapping:

```python
filtered_graph_config = {**graph_config, "nodes": node_configs, "edges": edge_configs}
```

The now-unused `cast` import is removed. Behavior is unchanged (the filtered graph still reaches graph init exactly as before), but `workflow.graph_dict` is no longer mutated — honoring its read-only contract and unblocking the caching TODO.

## Tests

Added `test_get_graph_and_variable_pool_for_single_node_run_does_not_mutate_graph_dict`, which runs the method against a multi-node graph and asserts:
- the shared `workflow.graph_dict` still contains all original nodes/edges (not filtered in place), and
- the graph actually built (`Graph.init`) receives the filtered copy (only the target node).

`uv run python -m pytest tests/unit_tests/core/app/apps/test_workflow_app_runner_core.py` → 15 passed. `ruff` clean; `pyrefly` reports 0 errors on the changed source file.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran the affected unit tests, `ruff`, and `pyrefly` — all pass.