### PR TITLE
fix: incorrect backgroud when dark mode and no plugins

### DIFF
--- a/web/app/components/plugins/plugin-page/empty/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/plugin-page/empty/__tests__/index.spec.tsx
@@ -118,12 +118,6 @@ const createMockFile = (name: string, type = 'application/octet-stream'): File =
   return new File(['test'], name, { type })
 }
 
-const integrationsSkeletonBackground = [
-  'radial-gradient(ellipse at 50% 48%,',
-  'var(--color-background-section-burn) 0%,',
-  'var(--color-components-panel-bg) 58%)',
-].join(' ')
-
 // Helper to wait for useEffect to complete (single tick)
 const flushEffects = async () => {
   await act(async () => {})
@@ -150,9 +144,9 @@ describe('Empty Component', () => {
       expect(fileInput.style.display).toBe('none')
       expect(fileInput.accept).toBe('.difypkg,.difybndl')
 
-      // Assert - skeleton cards (20 in the grid + 1 icon container)
-      const skeletonCards = container.querySelectorAll('.rounded-xl.bg-components-card-bg')
-      expect(skeletonCards.length).toBeGreaterThanOrEqual(20)
+      // Assert - placeholder cards (20 in the grid + 1 icon container)
+      const placeholderCards = container.querySelectorAll('.rounded-xl.bg-components-card-bg')
+      expect(placeholderCards.length).toBeGreaterThanOrEqual(20)
 
       // Assert - group icon container
       const iconContainer = document.querySelector('.size-14')
@@ -176,11 +170,13 @@ describe('Empty Component', () => {
       expect(container.querySelector('.i-custom-vender-integrations-trigger-active')).toBeInTheDocument()
       expect(container.querySelector('.i-custom-vender-integrations-trigger')).not.toBeInTheDocument()
 
-      const skeletonGrid = container.querySelector('.grid')
-      expect(skeletonGrid).toHaveClass('max-w-[1600px]', 'px-6', 'gap-x-[7px]', 'gap-y-[15px]', 'pt-2')
+      const placeholderGrid = container.querySelector('.grid')
+      expect(placeholderGrid).toHaveClass('pointer-events-none', 'max-w-[1600px]', 'px-6', 'gap-2')
+      expect(placeholderGrid).toHaveAttribute('aria-hidden', 'true')
+      expect(placeholderGrid).not.toHaveAttribute('style')
 
-      const skeletonCards = container.querySelectorAll('.h-\\[72px\\].rounded-lg')
-      expect(skeletonCards).toHaveLength(22)
+      const placeholderCards = container.querySelectorAll('.h-24.rounded-lg.bg-background-section-burn')
+      expect(placeholderCards).toHaveLength(14)
 
       const buttons = screen.getAllByRole('button')
       buttons.forEach(button => expect(button).toHaveClass('h-8', 'w-full', 'justify-start'))
@@ -197,8 +193,8 @@ describe('Empty Component', () => {
       expect(container.querySelector('.i-ri-drag-drop-line')).toBeInTheDocument()
       expect(container.firstElementChild).toHaveClass('bg-components-panel-bg')
 
-      const skeletonGrid = container.querySelector('.grid')
-      expect(skeletonGrid).toHaveClass('max-w-[1600px]', 'px-6', 'gap-x-[7px]', 'gap-y-[15px]', 'pt-2')
+      const placeholderGrid = container.querySelector('.grid')
+      expect(placeholderGrid).toHaveClass('max-w-[1600px]', 'px-6', 'gap-2')
       expect(container.querySelector('.items-center')).toBeInTheDocument()
       expect(container.querySelector('.-translate-y-7')).not.toBeInTheDocument()
       expect(container.querySelector('.i-custom-vender-integrations-agent-strategy-active')).toHaveClass('size-6', 'shrink-0')
@@ -214,10 +210,11 @@ describe('Empty Component', () => {
       expect(screen.getByText('plugin.installModal.dropIntegrationToInstall')).toBeInTheDocument()
       expect(container.querySelector('.i-ri-drag-drop-line')).toBeInTheDocument()
 
-      const skeletonGrid = container.querySelector('.grid')
-      expect(skeletonGrid).toHaveClass('max-w-[1600px]', 'px-6', 'gap-x-[7px]', 'gap-y-[15px]', 'pt-2')
-      expect(skeletonGrid).toHaveAttribute('style', `background: ${integrationsSkeletonBackground};`)
-      expect(container.querySelector('.h-\\[72px\\].rounded-lg')).toHaveClass('bg-background-section/50')
+      const placeholderGrid = container.querySelector('.grid')
+      expect(placeholderGrid).toHaveClass('max-w-[1600px]', 'px-6', 'gap-2')
+      expect(placeholderGrid).not.toHaveAttribute('style')
+      expect(container.querySelector('.h-24.rounded-lg')).toHaveClass('bg-background-section-burn')
+      expect(container.querySelector('.bg-linear-to-b')).toHaveClass('pointer-events-none', 'from-components-panel-bg-transparent', 'to-components-panel-bg')
       expect(container.querySelector('.i-custom-vender-integrations-extension-active')).toHaveClass('size-6', 'shrink-0')
     })
   })

--- a/web/app/components/plugins/plugin-page/empty/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/plugin-page/empty/__tests__/index.spec.tsx
@@ -135,7 +135,7 @@ describe('Empty Component', () => {
   describe('Rendering', () => {
     it('should render basic structure correctly', async () => {
       // Arrange & Act
-      const { container } = render(<Empty />)
+      render(<Empty />)
       await flushEffects()
 
       // Assert - file input
@@ -143,10 +143,6 @@ describe('Empty Component', () => {
       expect(fileInput).toBeInTheDocument()
       expect(fileInput.style.display).toBe('none')
       expect(fileInput.accept).toBe('.difypkg,.difybndl')
-
-      // Assert - placeholder cards (20 in the grid + 1 icon container)
-      const placeholderCards = container.querySelectorAll('.rounded-xl.bg-components-card-bg')
-      expect(placeholderCards.length).toBeGreaterThanOrEqual(20)
 
       // Assert - group icon container
       const iconContainer = document.querySelector('.size-14')
@@ -170,14 +166,6 @@ describe('Empty Component', () => {
       expect(container.querySelector('.i-custom-vender-integrations-trigger-active')).toBeInTheDocument()
       expect(container.querySelector('.i-custom-vender-integrations-trigger')).not.toBeInTheDocument()
 
-      const placeholderGrid = container.querySelector('.grid')
-      expect(placeholderGrid).toHaveClass('pointer-events-none', 'max-w-[1600px]', 'px-6', 'gap-2')
-      expect(placeholderGrid).toHaveAttribute('aria-hidden', 'true')
-      expect(placeholderGrid).not.toHaveAttribute('style')
-
-      const placeholderCards = container.querySelectorAll('.h-24.rounded-lg.bg-background-section-burn')
-      expect(placeholderCards).toHaveLength(14)
-
       const buttons = screen.getAllByRole('button')
       buttons.forEach(button => expect(button).toHaveClass('h-8', 'w-full', 'justify-start'))
     })
@@ -193,8 +181,6 @@ describe('Empty Component', () => {
       expect(container.querySelector('.i-ri-drag-drop-line')).toBeInTheDocument()
       expect(container.firstElementChild).toHaveClass('bg-components-panel-bg')
 
-      const placeholderGrid = container.querySelector('.grid')
-      expect(placeholderGrid).toHaveClass('max-w-[1600px]', 'px-6', 'gap-2')
       expect(container.querySelector('.items-center')).toBeInTheDocument()
       expect(container.querySelector('.-translate-y-7')).not.toBeInTheDocument()
       expect(container.querySelector('.i-custom-vender-integrations-agent-strategy-active')).toHaveClass('size-6', 'shrink-0')
@@ -210,11 +196,6 @@ describe('Empty Component', () => {
       expect(screen.getByText('plugin.installModal.dropIntegrationToInstall')).toBeInTheDocument()
       expect(container.querySelector('.i-ri-drag-drop-line')).toBeInTheDocument()
 
-      const placeholderGrid = container.querySelector('.grid')
-      expect(placeholderGrid).toHaveClass('max-w-[1600px]', 'px-6', 'gap-2')
-      expect(placeholderGrid).not.toHaveAttribute('style')
-      expect(container.querySelector('.h-24.rounded-lg')).toHaveClass('bg-background-section-burn')
-      expect(container.querySelector('.bg-linear-to-b')).toHaveClass('pointer-events-none', 'from-components-panel-bg-transparent', 'to-components-panel-bg')
       expect(container.querySelector('.i-custom-vender-integrations-extension-active')).toHaveClass('size-6', 'shrink-0')
     })
   })

--- a/web/app/components/plugins/plugin-page/empty/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/plugin-page/empty/__tests__/index.spec.tsx
@@ -118,6 +118,12 @@ const createMockFile = (name: string, type = 'application/octet-stream'): File =
   return new File(['test'], name, { type })
 }
 
+const integrationsSkeletonBackground = [
+  'radial-gradient(ellipse at 50% 48%,',
+  'var(--color-background-section-burn) 0%,',
+  'var(--color-components-panel-bg) 58%)',
+].join(' ')
+
 // Helper to wait for useEffect to complete (single tick)
 const flushEffects = async () => {
   await act(async () => {})
@@ -210,7 +216,8 @@ describe('Empty Component', () => {
 
       const skeletonGrid = container.querySelector('.grid')
       expect(skeletonGrid).toHaveClass('max-w-[1600px]', 'px-6', 'gap-x-[7px]', 'gap-y-[15px]', 'pt-2')
-      expect(skeletonGrid).toHaveStyle({ background: 'radial-gradient(ellipse at 50% 48%, #F3F4F7 0%, #FFFFFF 58%)' })
+      expect(skeletonGrid).toHaveAttribute('style', `background: ${integrationsSkeletonBackground};`)
+      expect(container.querySelector('.h-\\[72px\\].rounded-lg')).toHaveClass('bg-background-section/50')
       expect(container.querySelector('.i-custom-vender-integrations-extension-active')).toHaveClass('size-6', 'shrink-0')
     })
   })

--- a/web/app/components/plugins/plugin-page/empty/index.tsx
+++ b/web/app/components/plugins/plugin-page/empty/index.tsx
@@ -144,7 +144,7 @@ const Empty = ({
         )}
       >
         {Array.from({ length: placeholderItemCount }, (_, i) => (
-          <div key={i} className={cn(isIntegrationsCategory ? 'h-24 rounded-lg bg-background-section-burn' : 'h-24 rounded-xl bg-components-card-bg')} />
+          <div key={i} className={cn(isIntegrationsCategory ? 'h-24 rounded-lg bg-background-section-burn/30' : 'h-24 rounded-xl bg-components-card-bg')} />
         ))}
       </div>
       <div aria-hidden className="pointer-events-none absolute inset-0 z-20 bg-linear-to-b from-components-panel-bg-transparent to-components-panel-bg" />

--- a/web/app/components/plugins/plugin-page/empty/index.tsx
+++ b/web/app/components/plugins/plugin-page/empty/index.tsx
@@ -46,6 +46,12 @@ const ExtensionEmptyIcon = () => (
   <span aria-hidden className="i-custom-vender-integrations-extension-active size-6 shrink-0" />
 )
 
+const integrationsSkeletonBackground = [
+  'radial-gradient(ellipse at 50% 48%,',
+  'var(--color-background-section-burn) 0%,',
+  'var(--color-components-panel-bg) 58%)',
+].join(' ')
+
 type EmptyProps = {
   canInstall?: boolean
   contentInset?: PluginPageContentInset
@@ -143,11 +149,11 @@ const Empty = ({
           contentFrameClassName,
         )}
         style={isIntegrationsCategory
-          ? { background: 'radial-gradient(ellipse at 50% 48%, #F3F4F7 0%, #FFFFFF 58%)' }
+          ? { background: integrationsSkeletonBackground }
           : undefined}
       >
         {Array.from({ length: isIntegrationsCategory ? 22 : 20 }).fill(0).map((_, i) => (
-          <div key={i} className={cn(isIntegrationsCategory ? 'h-[72px] rounded-lg bg-[#F9FAFB]/[0.52]' : 'h-24 rounded-xl bg-components-card-bg')} />
+          <div key={i} className={cn(isIntegrationsCategory ? 'h-[72px] rounded-lg bg-background-section/50' : 'h-24 rounded-xl bg-components-card-bg')} />
         ))}
       </div>
       {/* mask */}

--- a/web/app/components/plugins/plugin-page/empty/index.tsx
+++ b/web/app/components/plugins/plugin-page/empty/index.tsx
@@ -46,12 +46,6 @@ const ExtensionEmptyIcon = () => (
   <span aria-hidden className="i-custom-vender-integrations-extension-active size-6 shrink-0" />
 )
 
-const integrationsSkeletonBackground = [
-  'radial-gradient(ellipse at 50% 48%,',
-  'var(--color-background-section-burn) 0%,',
-  'var(--color-components-panel-bg) 58%)',
-].join(' ')
-
 type EmptyProps = {
   canInstall?: boolean
   contentInset?: PluginPageContentInset
@@ -138,26 +132,22 @@ const Empty = ({
       : isIntegrationsExtension
         ? t('list.noExtensionFound', { ns: 'plugin' })
         : text
+  const placeholderItemCount = isIntegrationsCategory ? 14 : 20
 
   return (
     <div className="relative z-0 w-full grow bg-components-panel-bg">
-      {/* skeleton */}
       <div
+        aria-hidden
         className={cn(
-          'absolute top-0 left-1/2 z-10 grid h-full -translate-x-1/2 grid-cols-2 content-start overflow-hidden',
-          isIntegrationsCategory ? 'gap-x-[7px] gap-y-[15px] pt-2' : 'gap-2',
+          'pointer-events-none absolute top-0 left-1/2 z-10 grid h-full -translate-x-1/2 grid-cols-2 content-start gap-2 overflow-hidden',
           contentFrameClassName,
         )}
-        style={isIntegrationsCategory
-          ? { background: integrationsSkeletonBackground }
-          : undefined}
       >
-        {Array.from({ length: isIntegrationsCategory ? 22 : 20 }).fill(0).map((_, i) => (
-          <div key={i} className={cn(isIntegrationsCategory ? 'h-[72px] rounded-lg bg-background-section/50' : 'h-24 rounded-xl bg-components-card-bg')} />
+        {Array.from({ length: placeholderItemCount }, (_, i) => (
+          <div key={i} className={cn(isIntegrationsCategory ? 'h-24 rounded-lg bg-background-section-burn' : 'h-24 rounded-xl bg-components-card-bg')} />
         ))}
       </div>
-      {/* mask */}
-      <div className="absolute z-20 size-full bg-linear-to-b from-components-panel-bg-transparent to-components-panel-bg" />
+      <div aria-hidden className="pointer-events-none absolute inset-0 z-20 bg-linear-to-b from-components-panel-bg-transparent to-components-panel-bg" />
       <div className={cn(
         'relative z-30 flex h-full',
         showDropInstallTip ? 'flex-col' : 'items-center justify-center',
@@ -176,9 +166,9 @@ const Empty = ({
           >
             <div className="flex flex-col items-center gap-y-3">
               <div className={cn(
-                'relative -z-10 flex items-center justify-center border-dashed bg-components-card-bg',
+                'relative -z-10 flex items-center justify-center border-dashed bg-components-card-bg backdrop-blur-md',
                 isIntegrationsCategory
-                  ? 'size-[60px] rounded-[13px] border-[0.667px] border-divider-deep shadow-xl shadow-shadow-shadow-5'
+                  ? 'size-14 rounded-xl border border-divider-regular'
                   : 'size-14 rounded-xl border border-divider-deep shadow-xl shadow-shadow-shadow-5',
               )}
               >
@@ -202,11 +192,11 @@ const Empty = ({
                   </>
                 )}
               </div>
-              <div className={cn(isIntegrationsCategory ? 'system-sm-regular text-text-primary' : 'system-md-regular text-text-tertiary')}>
+              <div className={cn(isIntegrationsCategory ? 'system-sm-regular text-text-tertiary' : 'system-md-regular text-text-tertiary')}>
                 {emptyText}
               </div>
             </div>
-            <div className={cn('flex flex-col', isIntegrationsCategory ? 'w-[200px]' : 'w-[236px]')}>
+            <div className="flex w-[236px] flex-col">
               <input
                 type="file"
                 ref={fileInputRef}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix https://github.com/langgenius/dify/issues/38377

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
