### PR TITLE
chore: use zstd for plugin model provider cache

### DIFF
--- a/api/core/plugin/plugin_service.py
+++ b/api/core/plugin/plugin_service.py
@@ -4,7 +4,7 @@ This module owns plugin daemon management calls that are shared by API services
 and core runtimes. Plugin model provider discovery is cached here, alongside
 plugin install, uninstall, and upgrade invalidation, so all cache mutations for
 plugin-owned provider metadata stay tenant-scoped and in one place.
-Provider cache payloads may be stored as prefixed zlib bytes; readers also
+Provider cache payloads may be stored as prefixed zstd bytes; readers also
 accept legacy plain JSON payloads for rolling upgrades and existing Redis keys.
 
 The console plugin list also normalizes endpoint setup counters against live
@@ -16,12 +16,12 @@ metadata.
 
 import logging
 import time
-import zlib
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from mimetypes import guess_type
 from typing import Literal, Protocol
 
+import zstandard
 from pydantic import BaseModel, TypeAdapter, ValidationError
 from redis import RedisError
 from redis.exceptions import LockError
@@ -95,7 +95,7 @@ class PluginService:
     PLUGIN_MODEL_PROVIDERS_LOCK_TTL = 30
     PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_TIMEOUT = 2.0
     PLUGIN_MODEL_PROVIDERS_LOCK_WAIT_INTERVAL = 0.05
-    PLUGIN_MODEL_PROVIDERS_CACHE_COMPRESSION_PREFIX = b"\x00dify-plugin-model-providers-zlib-v1:"
+    PLUGIN_MODEL_PROVIDERS_CACHE_COMPRESSION_PREFIX = b"\x00dify-plugin-model-providers-zstd-v1:"
     PLUGIN_MODEL_PROVIDERS_CACHE_COMPRESSION_MIN_BYTES = 64 * 1024
     PLUGIN_INSTALL_TASK_TERMINAL_STATUSES = (PluginInstallTaskStatus.Success, PluginInstallTaskStatus.Failed)
     # Mirror the detail-panel endpoint query size so list reconciliation and
@@ -152,7 +152,7 @@ class PluginService:
         if len(payload) < cls.PLUGIN_MODEL_PROVIDERS_CACHE_COMPRESSION_MIN_BYTES:
             return payload
 
-        return cls.PLUGIN_MODEL_PROVIDERS_CACHE_COMPRESSION_PREFIX + zlib.compress(payload, level=1)
+        return cls.PLUGIN_MODEL_PROVIDERS_CACHE_COMPRESSION_PREFIX + zstandard.compress(payload, level=1)
 
     @classmethod
     def _decode_plugin_model_providers_cache_payload(cls, payload: bytes | bytearray | str) -> bytes | bytearray | str:
@@ -164,8 +164,8 @@ class PluginService:
             return payload
 
         try:
-            return zlib.decompress(payload[len(prefix) :])
-        except zlib.error as exc:
+            return zstandard.decompress(payload[len(prefix) :])
+        except zstandard.ZstdError as exc:
             raise ValueError("Invalid compressed plugin model providers cache payload.") from exc
 
     @classmethod

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "opentelemetry-propagator-b3>=1.41.1,<2.0.0",
     "readabilipy==0.3.0",
     "resend>=2.27.0,<3.0.0",
+    "zstandard>=0.25.0,<1.0.0",
     # Emerging: newer and fast-moving, use compatible pins
     "fastopenapi[flask]==0.7.0",
     "graphon==0.6.0",

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "opentelemetry-propagator-b3>=1.41.1,<2.0.0",
     "readabilipy==0.3.0",
     "resend>=2.27.0,<3.0.0",
-    "zstandard>=0.25.0,<1.0.0",
+    "zstandard==0.25.0",
     # Emerging: newer and fast-moving, use compatible pins
     "fastopenapi[flask]==0.7.0",
     "graphon==0.6.0",

--- a/api/tests/unit_tests/services/plugin/test_plugin_service.py
+++ b/api/tests/unit_tests/services/plugin/test_plugin_service.py
@@ -1,10 +1,10 @@
 import datetime
 import uuid
-import zlib
 from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
+import zstandard
 from pydantic import TypeAdapter
 from redis import RedisError
 
@@ -154,7 +154,7 @@ class TestPluginModelProviderCache:
         prefix = PluginService.PLUGIN_MODEL_PROVIDERS_CACHE_COMPRESSION_PREFIX
         assert stored_payload.startswith(prefix)
         assert len(stored_payload) < len(raw_payload)
-        assert zlib.decompress(stored_payload[len(prefix) :]) == raw_payload
+        assert zstandard.decompress(stored_payload[len(prefix) :]) == raw_payload
 
     def test_fetch_plugin_model_providers_reads_compressed_cached_provider_without_calling_daemon(self) -> None:
         """Compressed tenant cache entries are decoded before provider schema validation."""
@@ -166,7 +166,7 @@ class TestPluginModelProviderCache:
 
         from core.plugin.plugin_service import PluginService
 
-        compressed_payload = PluginService.PLUGIN_MODEL_PROVIDERS_CACHE_COMPRESSION_PREFIX + zlib.compress(
+        compressed_payload = PluginService.PLUGIN_MODEL_PROVIDERS_CACHE_COMPRESSION_PREFIX + zstandard.compress(
             cached_payload, level=1
         )
 

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1375,6 +1375,7 @@ dependencies = [
     { name = "resend" },
     { name = "sendgrid" },
     { name = "sseclient-py" },
+    { name = "zstandard" },
 ]
 
 [package.dev-dependencies]
@@ -1658,6 +1659,7 @@ requires-dist = [
     { name = "resend", specifier = ">=2.27.0,<3.0.0" },
     { name = "sendgrid", specifier = ">=6.12.5,<7.0.0" },
     { name = "sseclient-py", specifier = ">=1.8.0,<2.0.0" },
+    { name = "zstandard", specifier = ">=0.25.0,<1.0.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1659,7 +1659,7 @@ requires-dist = [
     { name = "resend", specifier = ">=2.27.0,<3.0.0" },
     { name = "sendgrid", specifier = ">=6.12.5,<7.0.0" },
     { name = "sseclient-py", specifier = ">=1.8.0,<2.0.0" },
-    { name = "zstandard", specifier = ">=0.25.0,<1.0.0" },
+    { name = "zstandard", specifier = "==0.25.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

the follow of https://github.com/langgenius/dify/pull/38374

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
