### PR TITLE
fix(chat): enhance pointer event handling in chat components

### DIFF
--- a/web/app/components/base/chat/chat-with-history/__tests__/chat-wrapper.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/__tests__/chat-wrapper.spec.tsx
@@ -136,6 +136,9 @@ const defaultChatHookReturn: Partial<ChatHookReturn> = {
   suggestedQuestions: [],
 }
 
+const getChatInputDisabledSurface = (element: HTMLElement) =>
+  element.closest('.pointer-events-none.opacity-50')
+
 describe('ChatWrapper', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -327,7 +330,7 @@ describe('ChatWrapper', () => {
     render(<ChatWrapper />)
     const textboxes = screen.getAllByRole('textbox')
     const chatInput = textboxes[textboxes.length - 1]
-    const disabledContainer = chatInput!.closest('.pointer-events-none')
+    const disabledContainer = getChatInputDisabledSurface(chatInput!)
     expect(disabledContainer)!.toBeInTheDocument()
     expect(disabledContainer)!.toHaveClass('opacity-50')
   })
@@ -344,7 +347,7 @@ describe('ChatWrapper', () => {
     render(<ChatWrapper />)
     const textboxes = screen.getAllByRole('textbox')
     const chatInput = textboxes[textboxes.length - 1]
-    const container = chatInput!.closest('.pointer-events-none')
+    const container = getChatInputDisabledSurface(chatInput!)
     expect(container).not.toBeInTheDocument()
   })
 
@@ -368,7 +371,7 @@ describe('ChatWrapper', () => {
     render(<ChatWrapper />)
     const textboxes = screen.getAllByRole('textbox')
     const chatInput = textboxes[textboxes.length - 1]
-    const container = chatInput!.closest('.pointer-events-none')
+    const container = getChatInputDisabledSurface(chatInput!)
     expect(container)!.toBeInTheDocument()
   })
 
@@ -391,7 +394,7 @@ describe('ChatWrapper', () => {
 
     render(<ChatWrapper />)
     const textarea = screen.getByRole('textbox')
-    const container = textarea.closest('.pointer-events-none')
+    const container = getChatInputDisabledSurface(textarea)
     expect(container).not.toBeInTheDocument()
   })
 
@@ -418,7 +421,7 @@ describe('ChatWrapper', () => {
     render(<ChatWrapper />)
     const textboxes = screen.getAllByRole('textbox')
     const chatInput = textboxes[textboxes.length - 1]
-    const container = chatInput!.closest('.pointer-events-none')
+    const container = getChatInputDisabledSurface(chatInput!)
     expect(container)!.toBeInTheDocument()
   })
 
@@ -444,7 +447,7 @@ describe('ChatWrapper', () => {
 
     render(<ChatWrapper />)
     const textarea = screen.getByRole('textbox')
-    const container = textarea.closest('.pointer-events-none')
+    const container = getChatInputDisabledSurface(textarea)
     expect(container).not.toBeInTheDocument()
   })
 
@@ -463,7 +466,7 @@ describe('ChatWrapper', () => {
 
     render(<ChatWrapper />)
     const textarea = screen.getByRole('textbox')
-    const container = textarea.closest('.pointer-events-none')
+    const container = getChatInputDisabledSurface(textarea)
     expect(container)!.toBeInTheDocument()
   })
 
@@ -479,7 +482,7 @@ describe('ChatWrapper', () => {
 
     render(<ChatWrapper />)
     const textarea = screen.getByRole('textbox')
-    const container = textarea.closest('.pointer-events-none')
+    const container = getChatInputDisabledSurface(textarea)
     expect(container).not.toBeInTheDocument()
   })
 
@@ -1108,7 +1111,7 @@ describe('ChatWrapper', () => {
     render(<ChatWrapper />)
     const textboxes = screen.getAllByRole('textbox')
     const chatInput = textboxes[textboxes.length - 1]
-    const container = chatInput!.closest('.pointer-events-none')
+    const container = getChatInputDisabledSurface(chatInput!)
     expect(container)!.toBeInTheDocument()
   })
 
@@ -1250,7 +1253,7 @@ describe('ChatWrapper', () => {
     // This tests line 106 - early return when hasEmptyInput is set
     const textboxes = screen.getAllByRole('textbox')
     const chatInput = textboxes[textboxes.length - 1]
-    const container = chatInput!.closest('.pointer-events-none')
+    const container = getChatInputDisabledSurface(chatInput!)
     expect(container)!.toBeInTheDocument()
   })
 
@@ -1278,7 +1281,7 @@ describe('ChatWrapper', () => {
     // This tests line 109 - early return when fileIsUploading is set
     const textboxes = screen.getAllByRole('textbox')
     const chatInput = textboxes[textboxes.length - 1]
-    const container = chatInput!.closest('.pointer-events-none')
+    const container = getChatInputDisabledSurface(chatInput!)
     expect(container)!.toBeInTheDocument()
   })
 
@@ -1821,7 +1824,7 @@ describe('ChatWrapper', () => {
     render(<ChatWrapper />)
     const textboxes = screen.getAllByRole('textbox')
     const chatInput = textboxes[textboxes.length - 1]
-    const container = chatInput!.closest('.pointer-events-none')
+    const container = getChatInputDisabledSurface(chatInput!)
     // Should not be disabled because it's not required
     // Should not be disabled because it's not required
     // Should not be disabled because it's not required

--- a/web/app/components/base/chat/chat/__tests__/index.spec.tsx
+++ b/web/app/components/base/chat/chat/__tests__/index.spec.tsx
@@ -955,6 +955,22 @@ describe('Chat', () => {
       expect(screen.getByTestId('chat-footer')).toHaveClass('bg-chat-input-mask')
     })
 
+    it('should let footer blank space pass pointer events through', () => {
+      renderChat({ noChatInput: false })
+      const footer = screen.getByTestId('chat-footer')
+      expect(footer).toHaveClass('pointer-events-none')
+      expect(footer.firstElementChild).toHaveClass('pointer-events-none')
+    })
+
+    it('should keep the stop responding button clickable inside the pass-through footer', () => {
+      renderChat({
+        isResponding: true,
+        noStopResponding: false,
+        noChatInput: true,
+      })
+      expect(screen.getByRole('button', { name: /stopResponding/i })).toHaveClass('pointer-events-auto')
+    })
+
     it('should apply chatFooterClassName when footer has content', () => {
       renderChat({
         noChatInput: false,

--- a/web/app/components/base/chat/chat/chat-input-area/__tests__/index.spec.tsx
+++ b/web/app/components/base/chat/chat/chat-input-area/__tests__/index.spec.tsx
@@ -316,7 +316,12 @@ describe('ChatInputArea', () => {
 
     it('should apply disabled styles when the disabled prop is true', () => {
       const { container } = render(<ChatInputArea visionConfig={mockVisionConfig} disabled />)
-      expect(container.firstChild).toHaveClass('opacity-50')
+      expect(container.firstChild).toHaveClass('pointer-events-none', 'opacity-50')
+    })
+
+    it('should restore pointer events on the input surface', () => {
+      const { container } = render(<ChatInputArea visionConfig={mockVisionConfig} />)
+      expect(container.firstChild).toHaveClass('pointer-events-auto')
     })
 
     it('should apply drag-active styles when a file is being dragged over', () => {

--- a/web/app/components/base/chat/chat/chat-input-area/index.tsx
+++ b/web/app/components/base/chat/chat/chat-input-area/index.tsx
@@ -164,7 +164,7 @@ const ChatInputArea = ({ readonly, botName, customPlaceholder, showFeatureBar, s
   const operation = (<Operation ref={holdSpaceRef} readonly={readonly} fileConfig={visionConfig} speechToTextConfig={speechToTextConfig} onShowVoiceInput={handleShowVoiceInput} onSend={handleSend} sendButtonLabel={sendButtonLabel} disabled={!canSend} theme={theme} />)
   return (
     <>
-      <div className={cn('relative z-10 overflow-hidden rounded-xl border border-components-chat-input-border bg-components-panel-bg-blur pb-[9px] shadow-md', isDragActive && 'border border-dashed border-components-option-card-option-selected-border', disabled && 'pointer-events-none border-components-panel-border opacity-50 shadow-none')}>
+      <div className={cn('pointer-events-auto relative z-10 overflow-hidden rounded-xl border border-components-chat-input-border bg-components-panel-bg-blur pb-[9px] shadow-md', isDragActive && 'border border-dashed border-components-option-card-option-selected-border', disabled && 'pointer-events-none border-components-panel-border opacity-50 shadow-none')}>
         <div className="relative max-h-[158px] overflow-x-hidden overflow-y-auto px-[9px] pt-[9px]">
           <FileListInChatInput fileConfig={visionConfig!} />
           <div ref={wrapperRef} className="flex items-center justify-between">
@@ -201,7 +201,11 @@ const ChatInputArea = ({ readonly, botName, customPlaceholder, showFeatureBar, s
         </div>
         {isMultipleLine && (<div className="px-[9px]">{operation}</div>)}
       </div>
-      {showFeatureBar && (<FeatureBar showFileUpload={showFileUpload} disabled={featureBarDisabled} onFeatureBarClick={featureBarReadonly ? noop : onFeatureBarClick} hideEditEntrance={featureBarReadonly} />)}
+      {showFeatureBar && (
+        <div className="pointer-events-auto">
+          <FeatureBar showFileUpload={showFileUpload} disabled={featureBarDisabled} onFeatureBarClick={featureBarReadonly ? noop : onFeatureBarClick} hideEditEntrance={featureBarReadonly} />
+        </div>
+      )}
     </>
   )
 }

--- a/web/app/components/base/chat/chat/index.tsx
+++ b/web/app/components/base/chat/chat/index.tsx
@@ -219,17 +219,20 @@ const Chat: FC<ChatProps> = ({
         </div>
         <div
           data-testid="chat-footer"
-          className={`absolute bottom-0 z-10 flex justify-center bg-chat-input-mask ${(hasTryToAsk || !noChatInput || !noStopResponding) && chatFooterClassName}`}
+          className={cn(
+            'pointer-events-none absolute bottom-0 z-10 flex justify-center bg-chat-input-mask',
+            (hasTryToAsk || !noChatInput || !noStopResponding) && chatFooterClassName,
+          )}
           ref={chatFooterRef}
         >
           <div
             ref={chatFooterInnerRef}
-            className={cn('relative', chatFooterInnerClassName, isTryApp && 'px-0')}
+            className={cn('pointer-events-none relative', chatFooterInnerClassName, isTryApp && 'px-0')}
           >
             {
               !noStopResponding && isResponding && (
                 <div data-testid="stop-responding-container" className="mb-2 flex justify-center">
-                  <Button className="border-components-panel-border bg-components-panel-bg text-components-button-secondary-text" onClick={onStopResponding}>
+                  <Button className="pointer-events-auto border-components-panel-border bg-components-panel-bg text-components-button-secondary-text" onClick={onStopResponding}>
                     <div className="mr-[5px] i-custom-vender-solid-mediaAndDevices-stop-circle h-3.5 w-3.5" />
                     <span className="text-xs font-normal">{t('operation.stopResponding', { ns: 'appDebug' })}</span>
                   </Button>

--- a/web/app/components/base/chat/chat/try-to-ask.tsx
+++ b/web/app/components/base/chat/chat/try-to-ask.tsx
@@ -29,7 +29,7 @@ const TryToAsk: FC<TryToAskProps> = ({
               size="small"
               key={index}
               variant="secondary-accent"
-              className="mr-1 mb-1 last:mr-0"
+              className="pointer-events-auto mr-1 mb-1 last:mr-0"
               onClick={() => onSend(suggestQuestion)}
             >
               {suggestQuestion}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

Fixes inner ticket 3232

Problem: the chat footer spans the full conversation width, so the blank space around the composer intercepted pointer events and blocked interactions with the content underneath.

Fix: make the footer and inner layout pass pointer events through by default, then restore pointer events only on the actual interactive controls, including the chat input, feature bar, suggested-question buttons, and stop-responding button.

## Screenshots

Before:

https://github.com/user-attachments/assets/261144d2-4069-4768-91df-4bc55c334e2e

After:

https://github.com/user-attachments/assets/103faec5-b697-4500-a001-1e9268c72b07

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
