### PR TITLE
fix(web): adjust snippets input count badge color

### DIFF
--- a/web/app/components/snippets/components/snippet-collapsed-preview.tsx
+++ b/web/app/components/snippets/components/snippet-collapsed-preview.tsx
@@ -51,7 +51,7 @@ export function SnippetCollapsedPreview({
           )}
       <div
         className={cn(
-          'mt-4 flex min-w-6 items-center justify-center rounded-full bg-background-default-subtle px-2 text-2xs leading-4 font-normal text-text-tertiary',
+          'mt-4 flex min-w-6 items-center justify-center rounded-full border border-divider-subtle bg-components-badge-bg-gray-soft px-2 text-2xs leading-4 font-normal text-text-secondary',
           inputFieldCount > 99 ? 'h-5' : 'size-5',
         )}
         aria-label={`${inputFieldCount} ${t('inputVariables', { ns: 'snippet' })}`}


### PR DESCRIPTION
## Summary

adjust snippets input field count badge color

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
