### PR TITLE
fix: keep custom model credential state consistent

### DIFF
--- a/api/core/entities/provider_configuration.py
+++ b/api/core/entities/provider_configuration.py
@@ -1318,7 +1318,12 @@ class ProviderConfiguration(BaseModel):
 
     def switch_custom_model_credential(self, model_type: ModelType, model: str, credential_id: str):
         """
-        switch the custom model credential.
+        Switch the active custom model credential.
+
+        If the active ProviderModel row was removed while model-scoped
+        credentials still exist, selecting one of those credentials should
+        restore the active model instead of leaving the UI stuck in an
+        authorization-removed state.
 
         :param model_type: model type
         :param model: model name
@@ -1339,10 +1344,18 @@ class ProviderConfiguration(BaseModel):
 
             provider_model_record = self._get_custom_model_record(model_type=model_type, model=model, session=session)
             if not provider_model_record:
-                raise ValueError("The custom model record not found.")
+                provider_model_record = ProviderModel(
+                    tenant_id=self.tenant_id,
+                    provider_name=self.provider.provider,
+                    model_name=model,
+                    model_type=model_type,
+                    is_valid=True,
+                    credential_id=credential_record.id,
+                )
+            else:
+                provider_model_record.credential_id = credential_record.id
+                provider_model_record.updated_at = naive_utc_now()
 
-            provider_model_record.credential_id = credential_record.id
-            provider_model_record.updated_at = naive_utc_now()
             session.add(provider_model_record)
             session.commit()
 

--- a/api/core/entities/provider_configuration.py
+++ b/api/core/entities/provider_configuration.py
@@ -1236,13 +1236,19 @@ class ProviderConfiguration(BaseModel):
                 if provider_model_record and available_credentials_count <= 1:
                     # If all credentials are deleted, delete the custom model record
                     session.delete(provider_model_record)
+                    provider_model_credentials_cache = ProviderCredentialsCache(
+                        tenant_id=self.tenant_id,
+                        identity_id=provider_model_record.id,
+                        cache_type=ProviderCredentialsCacheType.MODEL,
+                    )
+                    provider_model_credentials_cache.delete()
                 elif provider_model_record and provider_model_record.credential_id == credential_id:
                     provider_model_record.credential_id = None
                     provider_model_record.updated_at = naive_utc_now()
                     provider_model_credentials_cache = ProviderCredentialsCache(
                         tenant_id=self.tenant_id,
                         identity_id=provider_model_record.id,
-                        cache_type=ProviderCredentialsCacheType.PROVIDER,
+                        cache_type=ProviderCredentialsCacheType.MODEL,
                     )
                     provider_model_credentials_cache.delete()
 
@@ -1351,31 +1357,84 @@ class ProviderConfiguration(BaseModel):
 
     def delete_custom_model(self, model_type: ModelType, model: str):
         """
-        Delete custom model.
+        Delete custom model and the credentials/configs that belong to that model.
+
+        A custom model can be reconstructed from provider model credentials even
+        after its ProviderModel row is removed, so removing a model must clean up
+        the model-scoped credentials and load balancing configs in the same write.
+
         :param model_type: model type
         :param model: model name
         :return:
         """
-        provider_models_changed = False
+        provider_model_record_deleted = False
+        provider_model_credentials_deleted = False
+        load_balancing_configs_deleted = False
         with Session(db.engine) as session:
             # get provider model
             provider_model_record = self._get_custom_model_record(model_type=model_type, model=model, session=session)
 
-            # delete provider model
-            if provider_model_record:
-                session.delete(provider_model_record)
-                session.commit()
-                provider_models_changed = True
+            credential_stmt = select(ProviderModelCredential).where(
+                ProviderModelCredential.tenant_id == self.tenant_id,
+                ProviderModelCredential.provider_name.in_(self._get_provider_names()),
+                ProviderModelCredential.model_name == model,
+                ProviderModelCredential.model_type == model_type,
+            )
+            credential_records = session.execute(credential_stmt).scalars().all()
 
-                provider_model_credentials_cache = ProviderCredentialsCache(
-                    tenant_id=self.tenant_id,
-                    identity_id=provider_model_record.id,
-                    cache_type=ProviderCredentialsCacheType.MODEL,
+            lb_stmt = select(LoadBalancingModelConfig).where(
+                LoadBalancingModelConfig.tenant_id == self.tenant_id,
+                LoadBalancingModelConfig.provider_name.in_(self._get_provider_names()),
+                LoadBalancingModelConfig.model_name == model,
+                LoadBalancingModelConfig.model_type == model_type,
+                LoadBalancingModelConfig.credential_source_type == CredentialSourceType.CUSTOM_MODEL,
+            )
+            load_balancing_configs = session.execute(lb_stmt).scalars().all()
+
+            try:
+                for lb_config in load_balancing_configs:
+                    lb_credentials_cache = ProviderCredentialsCache(
+                        tenant_id=self.tenant_id,
+                        identity_id=lb_config.id,
+                        cache_type=ProviderCredentialsCacheType.LOAD_BALANCING_MODEL,
+                    )
+                    lb_credentials_cache.delete()
+                    session.delete(lb_config)
+
+                for credential_record in credential_records:
+                    session.delete(credential_record)
+
+                if provider_model_record:
+                    session.delete(provider_model_record)
+                    provider_model_credentials_cache = ProviderCredentialsCache(
+                        tenant_id=self.tenant_id,
+                        identity_id=provider_model_record.id,
+                        cache_type=ProviderCredentialsCacheType.MODEL,
+                    )
+
+                    provider_model_credentials_cache.delete()
+
+                provider_model_record_deleted = provider_model_record is not None
+                provider_model_credentials_deleted = bool(credential_records)
+                load_balancing_configs_deleted = bool(load_balancing_configs)
+                has_deleted_records = (
+                    provider_model_record_deleted
+                    or provider_model_credentials_deleted
+                    or load_balancing_configs_deleted
                 )
 
-                provider_model_credentials_cache.delete()
-        if provider_models_changed:
-            self._invalidate_provider_configuration_cache(provider_models=True)
+                if has_deleted_records:
+                    session.commit()
+            except Exception:
+                session.rollback()
+                raise
+
+        if provider_model_record_deleted or provider_model_credentials_deleted or load_balancing_configs_deleted:
+            self._invalidate_provider_configuration_cache(
+                provider_models=provider_model_record_deleted,
+                provider_model_credentials=provider_model_credentials_deleted,
+                provider_load_balancing_configs=load_balancing_configs_deleted,
+            )
 
     def _get_provider_model_setting(
         self, model_type: ModelType, model: str, session: Session

--- a/api/core/entities/provider_configuration.py
+++ b/api/core/entities/provider_configuration.py
@@ -826,6 +826,24 @@ class ProviderConfiguration(BaseModel):
         if preferred_model_providers_changed:
             self._invalidate_provider_configuration_cache(preferred_model_providers=True)
 
+    def _get_custom_model_records(
+        self,
+        model_type: ModelType,
+        model: str,
+        session: Session,
+    ) -> list[ProviderModel]:
+        """
+        Get custom model records across canonical and legacy provider names.
+        """
+        stmt = select(ProviderModel).where(
+            ProviderModel.tenant_id == self.tenant_id,
+            ProviderModel.provider_name.in_(self._get_provider_names()),
+            ProviderModel.model_name == model,
+            ProviderModel.model_type == model_type,
+        )
+
+        return list(session.execute(stmt).scalars().all())
+
     def _get_custom_model_record(
         self,
         model_type: ModelType,
@@ -833,23 +851,20 @@ class ProviderConfiguration(BaseModel):
         session: Session,
     ) -> ProviderModel | None:
         """
-        Get custom model credentials.
+        Get the preferred custom model record.
         """
-        # get provider model
+        provider_model_records = self._get_custom_model_records(model_type=model_type, model=model, session=session)
+        if not provider_model_records:
+            return None
 
-        model_provider_id = ModelProviderID(self.provider.provider)
-        provider_names = [self.provider.provider]
-        if model_provider_id.is_langgenius():
-            provider_names.append(model_provider_id.provider_name)
-
-        stmt = select(ProviderModel).where(
-            ProviderModel.tenant_id == self.tenant_id,
-            ProviderModel.provider_name.in_(provider_names),
-            ProviderModel.model_name == model,
-            ProviderModel.model_type == model_type,
+        return next(
+            (
+                record
+                for record in provider_model_records
+                if getattr(record, "provider_name", None) == self.provider.provider
+            ),
+            provider_model_records[0],
         )
-
-        return session.execute(stmt).scalar_one_or_none()
 
     def _get_specific_custom_model_credential(
         self, model_type: ModelType, model: str, credential_id: str
@@ -1220,7 +1235,15 @@ class ProviderConfiguration(BaseModel):
                     session.delete(lb_config)
 
                 # Check if this is the currently active credential
-                provider_model_record = self._get_custom_model_record(model_type, model, session=session)
+                provider_model_records = self._get_custom_model_records(model_type, model, session=session)
+                provider_model_record = next(
+                    (
+                        record
+                        for record in provider_model_records
+                        if getattr(record, "provider_name", None) == self.provider.provider
+                    ),
+                    provider_model_records[0] if provider_model_records else None,
+                )
 
                 # Check available credentials count BEFORE deleting
                 # if this is the last credential, we need to delete the custom model record
@@ -1235,13 +1258,13 @@ class ProviderConfiguration(BaseModel):
 
                 if provider_model_record and available_credentials_count <= 1:
                     # If all credentials are deleted, delete the custom model record
-                    session.delete(provider_model_record)
-                    provider_model_credentials_cache = ProviderCredentialsCache(
-                        tenant_id=self.tenant_id,
-                        identity_id=provider_model_record.id,
-                        cache_type=ProviderCredentialsCacheType.MODEL,
-                    )
-                    provider_model_credentials_cache.delete()
+                    for record in provider_model_records:
+                        session.delete(record)
+                        ProviderCredentialsCache(
+                            tenant_id=self.tenant_id,
+                            identity_id=record.id,
+                            cache_type=ProviderCredentialsCacheType.MODEL,
+                        ).delete()
                 elif provider_model_record and provider_model_record.credential_id == credential_id:
                     provider_model_record.credential_id = None
                     provider_model_record.updated_at = naive_utc_now()
@@ -1385,7 +1408,7 @@ class ProviderConfiguration(BaseModel):
         load_balancing_configs_deleted = False
         with Session(db.engine) as session:
             # get provider model
-            provider_model_record = self._get_custom_model_record(model_type=model_type, model=model, session=session)
+            provider_model_records = self._get_custom_model_records(model_type=model_type, model=model, session=session)
 
             credential_stmt = select(ProviderModelCredential).where(
                 ProviderModelCredential.tenant_id == self.tenant_id,
@@ -1417,17 +1440,15 @@ class ProviderConfiguration(BaseModel):
                 for credential_record in credential_records:
                     session.delete(credential_record)
 
-                if provider_model_record:
+                for provider_model_record in provider_model_records:
                     session.delete(provider_model_record)
-                    provider_model_credentials_cache = ProviderCredentialsCache(
+                    ProviderCredentialsCache(
                         tenant_id=self.tenant_id,
                         identity_id=provider_model_record.id,
                         cache_type=ProviderCredentialsCacheType.MODEL,
-                    )
+                    ).delete()
 
-                    provider_model_credentials_cache.delete()
-
-                provider_model_record_deleted = provider_model_record is not None
+                provider_model_record_deleted = bool(provider_model_records)
                 provider_model_credentials_deleted = bool(credential_records)
                 load_balancing_configs_deleted = bool(load_balancing_configs)
                 has_deleted_records = (

--- a/api/core/entities/provider_configuration.py
+++ b/api/core/entities/provider_configuration.py
@@ -858,9 +858,7 @@ class ProviderConfiguration(BaseModel):
             return None
 
         return next(
-            (
-                record for record in provider_model_records if record.provider_name == self.provider.provider
-            ),
+            (record for record in provider_model_records if record.provider_name == self.provider.provider),
             provider_model_records[0],
         )
 
@@ -1235,9 +1233,7 @@ class ProviderConfiguration(BaseModel):
                 # Check if this is the currently active credential
                 provider_model_records = self._get_custom_model_records(model_type, model, session=session)
                 provider_model_record = next(
-                    (
-                        record for record in provider_model_records if record.provider_name == self.provider.provider
-                    ),
+                    (record for record in provider_model_records if record.provider_name == self.provider.provider),
                     provider_model_records[0] if provider_model_records else None,
                 )
 

--- a/api/core/entities/provider_configuration.py
+++ b/api/core/entities/provider_configuration.py
@@ -859,9 +859,7 @@ class ProviderConfiguration(BaseModel):
 
         return next(
             (
-                record
-                for record in provider_model_records
-                if getattr(record, "provider_name", None) == self.provider.provider
+                record for record in provider_model_records if record.provider_name == self.provider.provider
             ),
             provider_model_records[0],
         )
@@ -1238,9 +1236,7 @@ class ProviderConfiguration(BaseModel):
                 provider_model_records = self._get_custom_model_records(model_type, model, session=session)
                 provider_model_record = next(
                     (
-                        record
-                        for record in provider_model_records
-                        if getattr(record, "provider_name", None) == self.provider.provider
+                        record for record in provider_model_records if record.provider_name == self.provider.provider
                     ),
                     provider_model_records[0] if provider_model_records else None,
                 )

--- a/api/core/provider_manager.py
+++ b/api/core/provider_manager.py
@@ -73,6 +73,19 @@ _PROVIDER_CONFIGURATION_CACHE_VERSION_KEY = "provider_configurations:tenant:{ten
 _PROVIDER_CONFIGURATION_CACHE_SOURCE_KEY = "provider_configurations:tenant:{tenant_id}:source:{source}:v:{version}"
 
 
+def _append_unique_records[T](records: list[T], extra_records: Sequence[T]) -> list[T]:
+    seen_record_ids = {id(record) for record in records}
+    for record in extra_records:
+        record_id = id(record)
+        if record_id in seen_record_ids:
+            continue
+
+        records.append(record)
+        seen_record_ids.add(record_id)
+
+    return records
+
+
 class ProviderConfigurationCacheSource(StrEnum):
     PROVIDER_MODELS = "provider_models"
     PREFERRED_MODEL_PROVIDERS = "preferred_model_providers"
@@ -713,7 +726,8 @@ class ProviderManager:
             provider_model_records = provider_name_to_provider_model_records_dict.get(provider_entity.provider, [])
             provider_id_entity = ModelProviderID(provider_name)
             if provider_id_entity.is_langgenius():
-                provider_model_records.extend(
+                _append_unique_records(
+                    provider_model_records,
                     provider_name_to_provider_model_records_dict.get(provider_id_entity.provider_name, [])
                 )
             provider_model_credentials = provider_name_to_provider_model_credentials_dict.get(
@@ -721,7 +735,8 @@ class ProviderManager:
             )
             provider_id_entity = ModelProviderID(provider_name)
             if provider_id_entity.is_langgenius():
-                provider_model_credentials.extend(
+                _append_unique_records(
+                    provider_model_credentials,
                     provider_name_to_provider_model_credentials_dict.get(provider_id_entity.provider_name, [])
                 )
 
@@ -776,11 +791,13 @@ class ProviderManager:
 
             if provider_id_entity.is_langgenius():
                 if provider_model_settings is not None:
-                    provider_model_settings.extend(
+                    _append_unique_records(
+                        provider_model_settings,
                         provider_name_to_provider_model_settings_dict.get(provider_id_entity.provider_name, [])
                     )
                 if provider_load_balancing_configs is not None:
-                    provider_load_balancing_configs.extend(
+                    _append_unique_records(
+                        provider_load_balancing_configs,
                         provider_name_to_provider_load_balancing_model_configs_dict.get(
                             provider_id_entity.provider_name, []
                         )

--- a/api/core/provider_manager.py
+++ b/api/core/provider_manager.py
@@ -728,7 +728,7 @@ class ProviderManager:
             if provider_id_entity.is_langgenius():
                 _append_unique_records(
                     provider_model_records,
-                    provider_name_to_provider_model_records_dict.get(provider_id_entity.provider_name, [])
+                    provider_name_to_provider_model_records_dict.get(provider_id_entity.provider_name, []),
                 )
             provider_model_credentials = provider_name_to_provider_model_credentials_dict.get(
                 provider_entity.provider, []
@@ -737,7 +737,7 @@ class ProviderManager:
             if provider_id_entity.is_langgenius():
                 _append_unique_records(
                     provider_model_credentials,
-                    provider_name_to_provider_model_credentials_dict.get(provider_id_entity.provider_name, [])
+                    provider_name_to_provider_model_credentials_dict.get(provider_id_entity.provider_name, []),
                 )
 
             # Convert to custom configuration
@@ -793,14 +793,14 @@ class ProviderManager:
                 if provider_model_settings is not None:
                     _append_unique_records(
                         provider_model_settings,
-                        provider_name_to_provider_model_settings_dict.get(provider_id_entity.provider_name, [])
+                        provider_name_to_provider_model_settings_dict.get(provider_id_entity.provider_name, []),
                     )
                 if provider_load_balancing_configs is not None:
                     _append_unique_records(
                         provider_load_balancing_configs,
                         provider_name_to_provider_load_balancing_model_configs_dict.get(
                             provider_id_entity.provider_name, []
-                        )
+                        ),
                     )
 
             # Convert to model settings

--- a/api/tests/unit_tests/core/entities/test_entities_provider_configuration.py
+++ b/api/tests/unit_tests/core/entities/test_entities_provider_configuration.py
@@ -1411,8 +1411,11 @@ def test_add_model_credential_to_model_and_switch_custom_model_credential() -> N
     session.execute.return_value.scalar_one_or_none.return_value = credential_record
     with _patched_session(session):
         with patch.object(ProviderConfiguration, "_get_custom_model_record", return_value=None):
-            with pytest.raises(ValueError, match="custom model record not found"):
+            with patch("core.entities.provider_configuration.ProviderCredentialsCache") as mock_cache:
                 configuration.switch_custom_model_credential(ModelType.LLM, "gpt-4o", "cred-1")
+    session.add.assert_called_once()
+    session.commit.assert_called_once()
+    mock_cache.return_value.delete.assert_called_once()
 
     session = Mock()
     credential_record = SimpleNamespace(id="cred-1")

--- a/api/tests/unit_tests/core/entities/test_entities_provider_configuration.py
+++ b/api/tests/unit_tests/core/entities/test_entities_provider_configuration.py
@@ -1149,7 +1149,7 @@ def test_switch_active_provider_credential_success_and_failures() -> None:
 def test_get_custom_model_record_supports_plugin_id_alias() -> None:
     configuration = _build_provider_configuration(provider_name="langgenius/openai/openai")
     session = Mock()
-    custom_model_record = SimpleNamespace(id="model-1")
+    custom_model_record = SimpleNamespace(id="model-1", provider_name="openai")
     session.execute.return_value = _exec_result(scalars_all=[custom_model_record])
 
     result = configuration._get_custom_model_record(ModelType.LLM, "gpt-4o", session)
@@ -1276,7 +1276,9 @@ def test_create_update_delete_custom_model_credential_flow() -> None:
     configuration = _build_provider_configuration()
     session = Mock()
     session.flush.side_effect = lambda: None
-    provider_model_record = SimpleNamespace(id="model-1", credential_id="cred-1", updated_at=None)
+    provider_model_record = SimpleNamespace(
+        id="model-1", credential_id="cred-1", provider_name="openai", updated_at=None
+    )
     credential_record = SimpleNamespace(id="cred-1", encrypted_config="{}", credential_name="Old", updated_at=None)
 
     with _patched_session(session):
@@ -1325,7 +1327,9 @@ def test_create_update_delete_custom_model_credential_flow() -> None:
     session = Mock()
     credential_record = SimpleNamespace(id="cred-1")
     lb_config = SimpleNamespace(id="lb-1")
-    provider_model_record = SimpleNamespace(id="model-1", credential_id="cred-1", updated_at=None)
+    provider_model_record = SimpleNamespace(
+        id="model-1", credential_id="cred-1", provider_name="openai", updated_at=None
+    )
     session.execute.side_effect = [
         _exec_result(scalar_one_or_none=credential_record),
         _exec_result(scalars_all=[lb_config]),
@@ -1345,7 +1349,9 @@ def test_create_update_delete_custom_model_credential_flow() -> None:
         model_name="stored-model",
         model_type=ModelType.TEXT_EMBEDDING,
     )
-    provider_model_record = SimpleNamespace(id="model-2", credential_id="cred-2", updated_at=None)
+    provider_model_record = SimpleNamespace(
+        id="model-2", credential_id="cred-2", provider_name="openai", updated_at=None
+    )
     session.execute.side_effect = [
         _exec_result(scalar_one_or_none=None),
         _exec_result(scalar_one_or_none=mismatched_credential_record),
@@ -1445,7 +1451,7 @@ def test_delete_custom_model_and_model_setting_methods() -> None:
     )
 
     session = Mock()
-    provider_model_record = SimpleNamespace(id="model-1")
+    provider_model_record = SimpleNamespace(id="model-1", provider_name="openai")
     credential_record = SimpleNamespace(id="cred-1")
     lb_config = SimpleNamespace(id="lb-1")
     session.execute.side_effect = [
@@ -2095,7 +2101,9 @@ def test_delete_custom_model_credential_removes_custom_model_record_when_last_cr
     configuration = _build_provider_configuration()
     session = Mock()
     credential_record = SimpleNamespace(id="cred-1")
-    provider_model_record = SimpleNamespace(id="model-1", credential_id="cred-1", updated_at=None)
+    provider_model_record = SimpleNamespace(
+        id="model-1", credential_id="cred-1", provider_name="openai", updated_at=None
+    )
     session.execute.side_effect = [
         _exec_result(scalar_one_or_none=credential_record),
         _exec_result(scalars_all=[]),

--- a/api/tests/unit_tests/core/entities/test_entities_provider_configuration.py
+++ b/api/tests/unit_tests/core/entities/test_entities_provider_configuration.py
@@ -25,6 +25,7 @@ from core.entities.provider_entities import (
     SystemConfiguration,
     SystemConfigurationStatus,
 )
+from core.helper.model_provider_cache import ProviderCredentialsCacheType
 from graphon.model_runtime.entities.common_entities import I18nObject
 from graphon.model_runtime.entities.model_entities import AIModelEntity, FetchFrom, ModelType
 from graphon.model_runtime.entities.provider_entities import (
@@ -1336,6 +1337,7 @@ def test_create_update_delete_custom_model_credential_flow() -> None:
                 configuration.delete_custom_model_credential(ModelType.LLM, "gpt-4o", "cred-1")
     assert provider_model_record.credential_id is None
     assert mock_cache.return_value.delete.call_count == 2
+    assert mock_cache.call_args_list[-1].kwargs["cache_type"] == ProviderCredentialsCacheType.MODEL
 
     session = Mock()
     mismatched_credential_record = SimpleNamespace(
@@ -1428,13 +1430,45 @@ def test_delete_custom_model_and_model_setting_methods() -> None:
     configuration = _build_provider_configuration()
     session = Mock()
     provider_model_record = SimpleNamespace(id="model-1")
+    credential_record = SimpleNamespace(id="cred-1")
+    lb_config = SimpleNamespace(id="lb-1")
+    session.execute.side_effect = [
+        _exec_result(scalars_all=[credential_record]),
+        _exec_result(scalars_all=[lb_config]),
+    ]
     with _patched_session(session):
         with patch.object(ProviderConfiguration, "_get_custom_model_record", return_value=provider_model_record):
-            with patch("core.entities.provider_configuration.ProviderCredentialsCache") as mock_cache:
-                configuration.delete_custom_model(ModelType.LLM, "gpt-4o")
-    session.delete.assert_called_once_with(provider_model_record)
+            with patch.object(ProviderConfiguration, "_invalidate_provider_configuration_cache") as mock_invalidate:
+                with patch("core.entities.provider_configuration.ProviderCredentialsCache") as mock_cache:
+                    configuration.delete_custom_model(ModelType.LLM, "gpt-4o")
+    session.delete.assert_any_call(provider_model_record)
+    session.delete.assert_any_call(credential_record)
+    session.delete.assert_any_call(lb_config)
     session.commit.assert_called_once()
-    mock_cache.return_value.delete.assert_called_once()
+    assert mock_cache.return_value.delete.call_count == 2
+    mock_invalidate.assert_called_once_with(
+        provider_models=True,
+        provider_model_credentials=True,
+        provider_load_balancing_configs=True,
+    )
+
+    session = Mock()
+    residual_credential_record = SimpleNamespace(id="cred-2")
+    session.execute.side_effect = [
+        _exec_result(scalars_all=[residual_credential_record]),
+        _exec_result(scalars_all=[]),
+    ]
+    with _patched_session(session):
+        with patch.object(ProviderConfiguration, "_get_custom_model_record", return_value=None):
+            with patch.object(ProviderConfiguration, "_invalidate_provider_configuration_cache") as mock_invalidate:
+                configuration.delete_custom_model(ModelType.LLM, "gpt-4o")
+    session.delete.assert_called_once_with(residual_credential_record)
+    session.commit.assert_called_once()
+    mock_invalidate.assert_called_once_with(
+        provider_models=False,
+        provider_model_credentials=True,
+        provider_load_balancing_configs=False,
+    )
 
     session = Mock()
     existing = SimpleNamespace(enabled=False, updated_at=None)

--- a/api/tests/unit_tests/core/entities/test_entities_provider_configuration.py
+++ b/api/tests/unit_tests/core/entities/test_entities_provider_configuration.py
@@ -1150,7 +1150,7 @@ def test_get_custom_model_record_supports_plugin_id_alias() -> None:
     configuration = _build_provider_configuration(provider_name="langgenius/openai/openai")
     session = Mock()
     custom_model_record = SimpleNamespace(id="model-1")
-    session.execute.return_value.scalar_one_or_none.return_value = custom_model_record
+    session.execute.return_value = _exec_result(scalars_all=[custom_model_record])
 
     result = configuration._get_custom_model_record(ModelType.LLM, "gpt-4o", session)
     assert result is custom_model_record
@@ -1332,7 +1332,7 @@ def test_create_update_delete_custom_model_credential_flow() -> None:
         _exec_result(scalar=2),
     ]
     with _patched_session(session):
-        with patch.object(ProviderConfiguration, "_get_custom_model_record", return_value=provider_model_record):
+        with patch.object(ProviderConfiguration, "_get_custom_model_records", return_value=[provider_model_record]):
             with patch("core.entities.provider_configuration.ProviderCredentialsCache") as mock_cache:
                 configuration.delete_custom_model_credential(ModelType.LLM, "gpt-4o", "cred-1")
     assert provider_model_record.credential_id is None
@@ -1355,8 +1355,8 @@ def test_create_update_delete_custom_model_credential_flow() -> None:
     with _patched_session(session):
         with patch.object(
             ProviderConfiguration,
-            "_get_custom_model_record",
-            return_value=provider_model_record,
+            "_get_custom_model_records",
+            return_value=[provider_model_record],
         ) as mock_get_model:
             configuration.delete_custom_model_credential(ModelType.LLM, "request-model", "cred-2")
     mock_get_model.assert_called_once_with(ModelType.TEXT_EMBEDDING, "stored-model", session=session)
@@ -1432,6 +1432,19 @@ def test_add_model_credential_to_model_and_switch_custom_model_credential() -> N
 def test_delete_custom_model_and_model_setting_methods() -> None:
     configuration = _build_provider_configuration()
     session = Mock()
+    legacy_provider_model_record = SimpleNamespace(id="model-legacy", provider_name="openai")
+    canonical_provider_model_record = SimpleNamespace(id="model-canonical", provider_name="langgenius/openai/openai")
+    session.execute.return_value = _exec_result(
+        scalars_all=[legacy_provider_model_record, canonical_provider_model_record]
+    )
+    assert (
+        _build_provider_configuration(provider_name="langgenius/openai/openai")._get_custom_model_record(
+            ModelType.LLM, "gpt-4o", session
+        )
+        is canonical_provider_model_record
+    )
+
+    session = Mock()
     provider_model_record = SimpleNamespace(id="model-1")
     credential_record = SimpleNamespace(id="cred-1")
     lb_config = SimpleNamespace(id="lb-1")
@@ -1440,7 +1453,7 @@ def test_delete_custom_model_and_model_setting_methods() -> None:
         _exec_result(scalars_all=[lb_config]),
     ]
     with _patched_session(session):
-        with patch.object(ProviderConfiguration, "_get_custom_model_record", return_value=provider_model_record):
+        with patch.object(ProviderConfiguration, "_get_custom_model_records", return_value=[provider_model_record]):
             with patch.object(ProviderConfiguration, "_invalidate_provider_configuration_cache") as mock_invalidate:
                 with patch("core.entities.provider_configuration.ProviderCredentialsCache") as mock_cache:
                     configuration.delete_custom_model(ModelType.LLM, "gpt-4o")
@@ -1462,7 +1475,7 @@ def test_delete_custom_model_and_model_setting_methods() -> None:
         _exec_result(scalars_all=[]),
     ]
     with _patched_session(session):
-        with patch.object(ProviderConfiguration, "_get_custom_model_record", return_value=None):
+        with patch.object(ProviderConfiguration, "_get_custom_model_records", return_value=[]):
             with patch.object(ProviderConfiguration, "_invalidate_provider_configuration_cache") as mock_invalidate:
                 configuration.delete_custom_model(ModelType.LLM, "gpt-4o")
     session.delete.assert_called_once_with(residual_credential_record)
@@ -1472,6 +1485,28 @@ def test_delete_custom_model_and_model_setting_methods() -> None:
         provider_model_credentials=True,
         provider_load_balancing_configs=False,
     )
+
+    session = Mock()
+    provider_model_records = [
+        SimpleNamespace(id="model-legacy", provider_name="openai"),
+        SimpleNamespace(id="model-canonical", provider_name="langgenius/openai/openai"),
+    ]
+    credential_record = SimpleNamespace(id="cred-3")
+    session.execute.side_effect = [
+        _exec_result(scalars_all=provider_model_records),
+        _exec_result(scalars_all=[credential_record]),
+        _exec_result(scalars_all=[]),
+    ]
+    with _patched_session(session):
+        with patch.object(ProviderConfiguration, "_invalidate_provider_configuration_cache"):
+            with patch("core.entities.provider_configuration.ProviderCredentialsCache") as mock_cache:
+                _build_provider_configuration(provider_name="langgenius/openai/openai").delete_custom_model(
+                    ModelType.LLM, "gpt-4o"
+                )
+    session.delete.assert_any_call(provider_model_records[0])
+    session.delete.assert_any_call(provider_model_records[1])
+    session.delete.assert_any_call(credential_record)
+    assert mock_cache.return_value.delete.call_count == 2
 
     session = Mock()
     existing = SimpleNamespace(enabled=False, updated_at=None)
@@ -2068,7 +2103,7 @@ def test_delete_custom_model_credential_removes_custom_model_record_when_last_cr
     ]
 
     with _patched_session(session):
-        with patch.object(ProviderConfiguration, "_get_custom_model_record", return_value=provider_model_record):
+        with patch.object(ProviderConfiguration, "_get_custom_model_records", return_value=[provider_model_record]):
             configuration.delete_custom_model_credential(ModelType.LLM, "gpt-4o", "cred-1")
 
     assert any(call.args and call.args[0] is provider_model_record for call in session.delete.call_args_list)
@@ -2085,7 +2120,7 @@ def test_delete_custom_model_credential_rolls_back_on_error() -> None:
     ]
 
     with _patched_session(session):
-        with patch.object(ProviderConfiguration, "_get_custom_model_record", return_value=None):
+        with patch.object(ProviderConfiguration, "_get_custom_model_records", return_value=[]):
             with pytest.raises(RuntimeError, match="boom"):
                 configuration.delete_custom_model_credential(ModelType.LLM, "gpt-4o", "cred-1")
 

--- a/api/tests/unit_tests/core/test_provider_manager.py
+++ b/api/tests/unit_tests/core/test_provider_manager.py
@@ -418,6 +418,53 @@ def test_get_configurations_binds_manager_runtime_to_provider_configuration(
     provider_configuration.bind_model_runtime.assert_called_once_with(manager._model_runtime)
 
 
+def test_get_configurations_does_not_duplicate_legacy_alias_records(mocker: MockerFixture):
+    manager = _build_provider_manager(mocker)
+    provider_entity = Mock()
+    provider_entity.provider = "langgenius/openai/openai"
+    provider_entity.configurate_methods = ["customizable-model"]
+    provider_entity.supported_model_types = [ModelType.LLM]
+    provider_factory = Mock()
+    provider_factory.get_providers.return_value = [provider_entity]
+    model_record = SimpleNamespace(
+        id="model-1",
+        provider_name="openai",
+        model_name="gpt-4",
+        model_type=ModelType.LLM,
+        credential_id="cred-1",
+    )
+    credential_record = SimpleNamespace(
+        id="cred-1",
+        provider_name="openai",
+        model_name="gpt-4",
+        model_type=ModelType.LLM,
+        credential_name="primary",
+    )
+    custom_configuration = SimpleNamespace(provider=None, models=[])
+    system_configuration = SimpleNamespace(enabled=False, quota_configurations=[], current_quota_type=None)
+
+    with (
+        patch.object(manager, "_get_all_providers", return_value={}),
+        patch.object(manager, "_init_trial_provider_records", return_value={}),
+        patch.object(manager, "_get_all_provider_models", return_value={"openai": [model_record]}),
+        patch.object(manager, "_get_all_preferred_model_providers", return_value={}),
+        patch.object(manager, "_get_all_provider_model_settings", return_value={}),
+        patch.object(manager, "_get_all_provider_load_balancing_configs", return_value={}),
+        patch.object(manager, "_get_all_provider_model_credentials", return_value={"openai": [credential_record]}),
+        patch.object(manager, "_get_all_provider_credentials", return_value={}),
+        patch.object(manager, "_to_custom_configuration", return_value=custom_configuration) as mock_to_custom,
+        patch.object(manager, "_to_system_configuration", return_value=system_configuration),
+        patch.object(manager, "_to_model_settings", return_value=[]),
+        patch("core.provider_manager.ModelProviderFactory", return_value=provider_factory),
+        patch("core.provider_manager.ProviderConfiguration", return_value=Mock()),
+    ):
+        manager.get_configurations("tenant-id")
+
+    args = mock_to_custom.call_args.args
+    assert args[3] == [model_record]
+    assert args[4] == [credential_record]
+
+
 def test_get_configurations_reuses_cached_result_for_same_tenant(mocker: MockerFixture, mock_provider_entity):
     manager = _build_provider_manager(mocker)
     provider_configuration = Mock()


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This PR fixes stale custom model credential/provider state after custom model removal or credential switching.

This is separate from the legacy `model_type` migration handled by #36520/#36704. This PR targets custom model credential consistency, not legacy model type normalization.

Changes:
- Delete related `ProviderModelCredential` records when removing a custom model, so removed models are not rebuilt from orphaned credentials.
- Delete related custom-model load balancing configs when removing a custom model.
- Clear custom model credential cache with the correct `MODEL` cache type.
- Allow switching to a valid same-model custom credential to restore a missing active custom model record.
- Deduplicate custom model entries resolved through canonical and legacy provider aliases.

Fixes #38402

## Screenshots

| Before | After |
|--------|-------|
| Removed custom models could reappear from stale model-scoped credentials. | Removed custom models no longer reappear after their credentials and load-balancing configs are cleaned up. |
| A model could stay in an authorization-removed state and fail when switching to another valid credential. | Selecting a valid same-model credential restores the active custom model and saves successfully. |
| The same custom model could appear more than once through provider aliases. | Custom model entries are deduplicated across canonical and legacy provider aliases. |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Validation run:
- `uv run --project api pytest api/tests/unit_tests/core/entities/test_entities_provider_configuration.py api/tests/unit_tests/core/test_provider_manager.py -q`
- `uv run --project api ruff check api/core/entities/provider_configuration.py api/core/provider_manager.py api/tests/unit_tests/core/entities/test_entities_provider_configuration.py api/tests/unit_tests/core/test_provider_manager.py`
- `uv run --project api pyrefly check api/core/entities/provider_configuration.py api/core/provider_manager.py`
- `uv --directory api run mypy --check-untyped-defs --disable-error-code=import-untyped core/entities/provider_configuration.py core/provider_manager.py`
- `uv run --project api python scripts/check_no_new_getattr.py --mode ci --merge-target main`
- `make lint && make type-check`
- `cd web && pnpm exec vp staged`
