### PR TITLE
ci: run autofix before main CI on pull requests

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,7 +1,6 @@
 name: autofix.ci
 on:
-  pull_request:
-    branches: ["main"]
+  workflow_call:
   merge_group:
     branches: ["main"]
     types: [checks_requested]

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -21,8 +21,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  run-autofix:
+    name: Run Autofix
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/autofix.yml
+    permissions:
+      contents: write
+      pull-requests: write
+
   pre_job:
     name: Skip Duplicate Checks
+    needs: run-autofix
+    if: always() && (needs.run-autofix.result == 'success' || needs.run-autofix.result == 'skipped' || needs.run-autofix.result == 'failure')
     runs-on: depot-ubuntu-24.04
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip || 'false' }}


### PR DESCRIPTION
Fixes #38291

## Summary

Runs `autofix.ci` as the first job in `main-ci.yml` for pull requests, so downstream tests and style checks run against autofixed code instead of racing with a separate autofix workflow.

- Add a `run-autofix` job to `main-ci.yml` that calls `autofix.yml` via `workflow_call`
- Gate `pre_job` (and the rest of the pipeline) on autofix completing
- Remove the standalone `pull_request` trigger from `autofix.yml` to prevent parallel runs
- Keep `push` and `merge_group` triggers on `autofix.yml` unchanged

This uses a reusable workflow call rather than `workflow_run` so child workflows continue to check out the PR head normally without extra ref plumbing.

From Cursor

## Test plan
- [ ] Open a PR with a deliberate ruff formatting issue and confirm autofix runs before API/Web tests
- [ ] Confirm merge group and push-to-main CI still run without waiting on autofix
- [ ] Confirm a PR that needs no autofix changes still completes the full pipeline after the autofix job