### PR TITLE
fix(agent): parse thinking tags from content parts

### DIFF
--- a/dify-agent/src/dify_agent/adapters/llm/model.py
+++ b/dify-agent/src/dify_agent/adapters/llm/model.py
@@ -565,13 +565,7 @@ def _chunk_to_stream_events(
     elif isinstance(message.content, list):
         for part in _map_assistant_content_to_response_parts(message.content):
             if isinstance(part, TextPart):
-                events.extend(
-                    parts_manager.handle_text_delta(
-                        vendor_part_id=None,
-                        content=part.content,
-                        provider_name=provider_name,
-                    )
-                )
+                events.extend(embedded_thinking_parser.parse(parts_manager, part.content, provider_name))
             else:
                 events.append(parts_manager.handle_part(vendor_part_id=None, part=part))
 

--- a/dify-agent/tests/local/dify_agent/adapters/llm/test_model.py
+++ b/dify-agent/tests/local/dify_agent/adapters/llm/test_model.py
@@ -5,6 +5,7 @@ from typing import cast
 from unittest.mock import patch
 
 import httpx
+from graphon.model_runtime.entities.message_entities import TextPromptMessageContent
 from pydantic_ai.exceptions import ModelHTTPError, UserError
 from pydantic_ai.messages import (
     InstructionPart,
@@ -310,6 +311,62 @@ class DifyLLMAdapterModelTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(cast(TextPart, response.parts[0]).content, "adapter response")
         self.assertEqual(response.usage.input_tokens, 11)
         self.assertEqual(response.usage.output_tokens, 7)
+
+    async def test_request_stream_splits_embedded_thinking_tags_from_text_content_parts(self) -> None:
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return build_stream_response(
+                LLMResultChunk(
+                    model="demo-model",
+                    delta=LLMResultChunkDelta(
+                        index=0,
+                        message=AssistantPromptMessage(
+                            content=[TextPromptMessageContent(data="before<think>reasoning")],
+                            tool_calls=[],
+                        ),
+                    ),
+                ),
+                LLMResultChunk(
+                    model="demo-model",
+                    delta=LLMResultChunkDelta(
+                        index=1,
+                        message=AssistantPromptMessage(
+                            content=[TextPromptMessageContent(data=" continues</think>after")],
+                            tool_calls=[],
+                        ),
+                    ),
+                ),
+                LLMResultChunk(
+                    model="demo-model",
+                    delta=LLMResultChunkDelta(
+                        index=2,
+                        message=AssistantPromptMessage(content="", tool_calls=[]),
+                        usage=make_usage(prompt_tokens=6, completion_tokens=4),
+                        finish_reason="stop",
+                    ),
+                ),
+            )
+
+        async with self.mock_daemon_stream(httpx.MockTransport(handler)):
+            adapter = DifyLLMAdapterModel(
+                "demo-model",
+                self.make_provider(),
+                model_provider="openai",
+                credentials={"api_key": "secret"},
+            )
+
+            async with adapter.request_stream(
+                [ModelRequest(parts=[UserPromptPart("hello")])],
+                model_settings=None,
+                model_request_parameters=ModelRequestParameters(),
+            ) as stream:
+                events = [event async for event in stream]
+                response = stream.get()
+
+        self.assertTrue(events)
+        self.assertEqual([part.part_kind for part in response.parts], ["text", "thinking", "text"])
+        self.assertEqual(cast(TextPart, response.parts[0]).content, "before")
+        self.assertEqual(cast(ThinkingPart, response.parts[1]).content, "reasoning continues")
+        self.assertEqual(cast(TextPart, response.parts[2]).content, "after")
 
     async def test_request_stream_yields_response_parts_and_usage(self) -> None:
         def handler(_request: httpx.Request) -> httpx.Response:


### PR DESCRIPTION
## Summary

Fix Agent v2 streaming thinking parsing when the plugin daemon returns assistant content as text content parts instead of a plain string.

Previously `DifyStreamedResponse` only ran the embedded `<think>...</think>` parser for `message.content: str`. If a provider/plugin returned `message.content` as `list[TextPromptMessageContent]`, the adapter sent the content as normal text and skipped thinking extraction.

## What changed

- Route `TextPart` content produced from assistant content parts through `_EmbeddedThinkingParser`.
- Add a streaming regression test for split `<think>` tags across text content parts.

## Verification

- `cd dify-agent && make check`
- `cd dify-agent && .venv/bin/python -m pytest tests/local/dify_agent/adapters/llm/test_model.py -q`
- Deployed to `deploy/agent` and verified `agent.dify.dev` agent backend container parses content-part `<think>` chunks into `text / thinking / text`.

## Note

This fixes the API/agent backend consumer side. I also confirmed the current OpenAI plugin installed on `agent.dify.dev` does not yet wrap GPT streaming `reasoning` / `reasoning_content` fields into `<think>` chunks, while Claude/Anthropic already does. GPT thinking display still needs the OpenAI plugin producer-side mapping or plugin upgrade.
