### PR TITLE
fix(web): create inline agent for default Agent v2 nodes

### DIFF
--- a/web/app/components/workflow/hooks/__tests__/use-nodes-interactions.spec.ts
+++ b/web/app/components/workflow/hooks/__tests__/use-nodes-interactions.spec.ts
@@ -548,6 +548,73 @@ describe('useNodesInteractions', () => {
     expect(mockHandleSyncWorkflowDraft).toHaveBeenCalledWith(true, true)
   })
 
+  it('creates an inline agent binding when Agent v2 default data is pending inline', () => {
+    currentNodes = [
+      createNode({
+        id: 'node-1',
+        width: 100,
+        data: {
+          type: BlockEnum.Code,
+          title: 'Code',
+          desc: '',
+        },
+      }),
+    ]
+    rfState.nodes = currentNodes as unknown as typeof rfState.nodes
+    rfState.edges = []
+    rfState.setNodes.mockImplementation((nextNodes) => {
+      rfState.nodes = nextNodes
+    })
+    runtimeNodesMetaDataMap.value = {
+      [BlockEnum.AgentV2]: {
+        defaultValue: {
+          type: BlockEnum.AgentV2,
+          title: 'Agent',
+          desc: '',
+          agent_binding: {
+            binding_type: 'inline_agent',
+          },
+          agent_node_kind: 'dify_agent',
+          version: '2',
+        },
+        metaData: {
+          isSingleton: false,
+        },
+      },
+    }
+
+    const { result } = renderWorkflowHook(() => useNodesInteractions(), {
+      historyStore: {
+        nodes: currentNodes,
+        edges: [],
+      },
+    })
+
+    act(() => {
+      result.current.handleNodeAdd(
+        {
+          nodeType: BlockEnum.AgentV2,
+        },
+        { prevNodeId: 'node-1' },
+      )
+    })
+
+    const agentNode = rfState.nodes.find(node => node.data.type === BlockEnum.AgentV2)
+    const firstSetNodesPayload = rfState.setNodes.mock.calls[0]?.[0]
+    const pendingAgentNode = firstSetNodesPayload.find((node: Node) => node.data.type === BlockEnum.AgentV2)
+
+    expect(pendingAgentNode?.data._isTempNode).toBe(true)
+    expect(agentNode?.data.agent_binding).toEqual({
+      binding_type: 'inline_agent',
+      agent_id: 'inline-agent-1',
+      current_snapshot_id: 'inline-snapshot-1',
+    })
+    expect(mockCreateInlineAgentBinding).toHaveBeenCalledWith(agentNode?.id, expect.objectContaining({
+      onSuccess: expect.any(Function),
+    }))
+    expect(mockHandleSyncWorkflowDraft).toHaveBeenCalledWith(true, true)
+  })
+
   it('cancels selection state with collaborative nodes snapshot', () => {
     currentNodes = [
       createNode({

--- a/web/app/components/workflow/hooks/use-nodes-interactions.ts
+++ b/web/app/components/workflow/hooks/use-nodes-interactions.ts
@@ -88,14 +88,27 @@ const ENTRY_NODE_WRAPPER_OFFSET = {
   y: 21, // Adjusted based on visual testing feedback
 } as const
 
-function needsPendingInlineAgentBinding(defaultValue?: BlockDefaultValue) {
-  if (!defaultValue || !('agent_binding' in defaultValue))
+function needsPendingInlineAgentBinding(defaultValue?: unknown) {
+  if (!defaultValue || typeof defaultValue !== 'object' || !('agent_binding' in defaultValue))
     return false
 
-  const binding = defaultValue.agent_binding
+  const binding = (defaultValue as {
+    agent_binding?: {
+      agent_id?: string
+      binding_type?: string
+      current_snapshot_id?: string
+    }
+  }).agent_binding
 
-  return binding.binding_type === 'inline_agent'
+  return binding?.binding_type === 'inline_agent'
     && (!binding.agent_id || !binding.current_snapshot_id)
+}
+
+function agentV2NodeDefaultsNeedInlineBinding(defaultValue?: unknown, pluginDefaultValue?: unknown) {
+  return needsPendingInlineAgentBinding({
+    ...(defaultValue && typeof defaultValue === 'object' ? defaultValue : {}),
+    ...(pluginDefaultValue && typeof pluginDefaultValue === 'object' ? pluginDefaultValue : {}),
+  })
 }
 
 const pruneClipboardNodesWithFilteredAncestors = (
@@ -926,7 +939,8 @@ export const useNodesInteractions = () => {
         return
       const { defaultValue } = nodeMetaData
       const nodesWithSameType = getNodesWithSameDefaultDataType(nodes, nodeType, defaultValue)
-      const shouldCreateInlineAgentBinding = nodeType === BlockEnum.AgentV2 && needsPendingInlineAgentBinding(pluginDefaultValue)
+      const shouldCreateInlineAgentBinding = nodeType === BlockEnum.AgentV2
+        && agentV2NodeDefaultsNeedInlineBinding(defaultValue, pluginDefaultValue)
       const { newNode, newIterationStartNode, newLoopStartNode }
         = generateNewNode({
           type: getNodeCustomTypeByNodeDataType(nodeType),
@@ -1506,7 +1520,8 @@ export const useNodesInteractions = () => {
         return
       const { defaultValue } = nodeMetaData
       const nodesWithSameType = getNodesWithSameDefaultDataType(nodes, nodeType, defaultValue)
-      const shouldCreateInlineAgentBinding = nodeType === BlockEnum.AgentV2 && needsPendingInlineAgentBinding(pluginDefaultValue)
+      const shouldCreateInlineAgentBinding = nodeType === BlockEnum.AgentV2
+        && agentV2NodeDefaultsNeedInlineBinding(defaultValue, pluginDefaultValue)
       const {
         newNode: newCurrentNode,
         newIterationStartNode,

--- a/web/app/components/workflow/nodes/agent-v2/__tests__/default.spec.ts
+++ b/web/app/components/workflow/nodes/agent-v2/__tests__/default.spec.ts
@@ -93,6 +93,9 @@ describe('agent/default', () => {
 
   it('creates Agent v2 graph data by default', () => {
     expect(nodeDefault.defaultValue).toMatchObject({
+      agent_binding: {
+        binding_type: 'inline_agent',
+      },
       agent_node_kind: 'dify_agent',
       version: '2',
     })

--- a/web/app/components/workflow/nodes/agent-v2/default.ts
+++ b/web/app/components/workflow/nodes/agent-v2/default.ts
@@ -12,6 +12,9 @@ const metaData = genNodeMetaData({
 const nodeDefault: NodeDefault<AgentV2NodeType> = {
   metaData,
   defaultValue: {
+    agent_binding: {
+      binding_type: 'inline_agent',
+    },
     agent_node_kind: 'dify_agent',
     version: '2',
   },


### PR DESCRIPTION
## Summary

- Make the Agent v2 node default graph data request a pending inline agent binding.
- Update node insertion/replacement logic to inspect the merged default/plugin payload before deciding whether to create inline backing.
- Add regression coverage for the default Agent v2 data and the node-add inline binding path.

## Verification

Local:
- `pnpm --filter dify-web test app/components/workflow/nodes/agent-v2/__tests__/default.spec.ts app/components/workflow/hooks/__tests__/use-nodes-interactions.spec.ts`
- `rm -rf web/.next && pnpm --filter dify-web type-check`
- `git diff --check origin/feat/agent-v2...HEAD`

Dev (`https://agent.dify.dev`, deployed via `deploy/agent` commit `fe444c35d401fb956c21e9a81330277c667275f6`):
- Login with a dedicated E2E account.
- Workflow app: create app -> initialize draft -> create inline Agent backing via `PUT /agent-composer` -> sync draft containing Agent node -> read draft/composer, verified inline binding is projected back.
- Advanced-chat app: same flow, verified inline binding is projected back.
