### PR TITLE
fix(web): escape prompt editor typeahead query before building RegExp

### DIFF
--- a/web/app/components/base/prompt-editor/plugins/component-picker-block/__tests__/hooks.spec.tsx
+++ b/web/app/components/base/prompt-editor/plugins/component-picker-block/__tests__/hooks.spec.tsx
@@ -542,6 +542,39 @@ describe('useVariableOptions', () => {
   })
 
   /**
+   * Regression: text typed after a `{` trigger (e.g. `source_url})` from a markdown
+   * link) becomes the queryString and was passed unescaped to `new RegExp`, throwing a
+   * SyntaxError during render and crashing the prompt editor. See issue #38384.
+   */
+  describe('when queryString contains regex special characters', () => {
+    const vars: Option[] = [{ value: 'source_url', name: 'source_url' }]
+
+    it.each([
+      'source_url})',
+      'a[b',
+      'trailing\\',
+    ])('should not throw when queryString is %j', (queryString) => {
+      expect(() =>
+        renderHook(() => useVariableOptions(makeVariableBlock(vars), queryString), { wrapper }),
+      ).not.toThrow()
+    })
+
+    it('should match the queryString literally instead of as a regex pattern', () => {
+      const dottedVars: Option[] = [
+        { value: 'a.b', name: 'a.b' },
+        { value: 'axb', name: 'axb' },
+      ]
+      const { result } = renderHook(
+        () => useVariableOptions(makeVariableBlock(dottedVars), 'a.b'),
+        { wrapper },
+      )
+      // Escaped `a\.b` matches only the literal 'a.b', not 'axb'; addOption is always appended.
+      expect(result.current).toHaveLength(2)
+      expect(result.current[0]!.key).toBe('a.b')
+    })
+  })
+
+  /**
    * addOption – calling onSelectMenuOption triggers editor.update() which
    * in turn calls $insertNodes with {{ and }} custom text nodes.
    * We only verify update() was invoked since the full DOM mutation requires
@@ -704,6 +737,20 @@ describe('useExternalToolOptions', () => {
         { wrapper },
       )
       expect(result.current).toHaveLength(1)
+    })
+
+    /**
+     * Regression: the queryString is passed straight to `new RegExp`, so regex special
+     * characters from arbitrary prompt text must not throw during render. See issue #38384.
+     */
+    it.each([
+      'weather})',
+      'a[b',
+      'trailing\\',
+    ])('should not throw when queryString is %j', (queryString) => {
+      expect(() =>
+        renderHook(() => useExternalToolOptions(makeExternalToolBlock({}, [sampleTool]), queryString), { wrapper }),
+      ).not.toThrow()
     })
   })
 

--- a/web/app/components/base/prompt-editor/plugins/component-picker-block/hooks.tsx
+++ b/web/app/components/base/prompt-editor/plugins/component-picker-block/hooks.tsx
@@ -35,6 +35,12 @@ import { PickerBlockMenuOption } from './menu'
 import { PromptMenuItem } from './prompt-option'
 import { VariableMenuItem } from './variable-option'
 
+// The typeahead query string comes from arbitrary prompt text after a `{` trigger
+// (e.g. `source_url})` from a markdown link), so it must be escaped before being
+// used to build a RegExp. An unescaped value can be invalid regex syntax and throw
+// during render, crashing the editor. See issue #38384.
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
 export const usePromptOptions = (
   contextBlock?: ContextBlockType,
   queryBlock?: QueryBlockType,
@@ -182,7 +188,7 @@ export const useVariableOptions = (
     if (!queryString)
       return baseOptions
 
-    const regex = new RegExp(queryString, 'i')
+    const regex = new RegExp(escapeRegExp(queryString), 'i')
 
     return baseOptions.filter(option => regex.test(option.key))
   }, [editor, queryString, variableBlock])
@@ -260,7 +266,7 @@ export const useExternalToolOptions = (
     if (!queryString)
       return baseToolOptions
 
-    const regex = new RegExp(queryString, 'i')
+    const regex = new RegExp(escapeRegExp(queryString), 'i')
 
     return baseToolOptions.filter(option => regex.test(option.key))
   }, [editor, queryString, externalToolBlockType])


### PR DESCRIPTION
Fixes #38384

## Summary

The `{`-triggered component picker in the prompt editor builds a regular expression directly from the typeahead query string:

```ts
const regex = new RegExp(queryString, "i")
```

The query string is arbitrary prompt text that follows a `{`. A common prompt such as:

```
- [Open manual]({source_url})
```

makes the query string `source_url})`, which is **invalid regex syntax** (`Unmatched ")"`). `new RegExp` throws a `SyntaxError` during render, and the whole prompt editor crashes with an unexpected component rendering error. Other characters such as `[` (unterminated character class) or a trailing `\` fail the same way.

## Fix

Escape the query string before constructing the `RegExp`, using the same inline `escapeRegExp` idiom already used elsewhere in the codebase (`goto-anything`, `agent-v2`, `console-openapi-url`):

```ts
const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
...
const regex = new RegExp(escapeRegExp(queryString), "i")
```

This is applied at both call sites (`useVariableOptions` and `useExternalToolOptions`). As a side benefit, the typeahead now matches the query **literally** instead of interpreting user-typed text as a regex pattern, which is the expected behavior when filtering variable / tool names.

## Testing

Added regression tests to the existing `component-picker-block/__tests__/hooks.spec.tsx`:

- Crash-guard cases (`source_url})`, `a[b`, trailing `\`) for both `useVariableOptions` and `useExternalToolOptions` — verified these **fail** on the unescaped code (exact `SyntaxError`) and **pass** with the fix.
- A literal-match assertion confirming `a.b` matches only `a.b`, not `axb`.

- `pnpm test` on the spec: 67/67 pass
- `pnpm eslint` on changed files: 0 errors
- `pnpm type-check`: passes