### PR TITLE
fix(dify-ui): standardize story focus indicators

### DIFF
--- a/packages/dify-ui/src/alert-dialog/index.stories.tsx
+++ b/packages/dify-ui/src/alert-dialog/index.stories.tsx
@@ -13,7 +13,7 @@ import {
 } from '.'
 import { Button } from '../button'
 
-const triggerButtonClassName = 'rounded-lg border border-divider-subtle bg-components-button-secondary-bg px-3 py-1.5 text-sm text-text-secondary shadow-xs hover:bg-state-base-hover'
+const triggerButtonClassName = 'rounded-lg border border-divider-subtle bg-components-button-secondary-bg px-3 py-1.5 text-sm text-text-secondary shadow-xs outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid'
 
 const meta = {
   title: 'Base/UI/AlertDialog',

--- a/packages/dify-ui/src/collapsible/index.stories.tsx
+++ b/packages/dify-ui/src/collapsible/index.stories.tsx
@@ -97,7 +97,7 @@ export const Controlled: Story = {
       <div className="flex flex-col items-start gap-3">
         <button
           type="button"
-          className="rounded-lg border border-divider-subtle bg-components-button-secondary-bg px-3 py-1.5 system-sm-medium text-components-button-secondary-text shadow-xs shadow-shadow-shadow-3 hover:bg-state-base-hover focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-state-accent-solid"
+          className="rounded-lg border border-divider-subtle bg-components-button-secondary-bg px-3 py-1.5 system-sm-medium text-components-button-secondary-text shadow-xs shadow-shadow-shadow-3 outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid"
           onClick={() => setOpen(value => !value)}
         >
           {open ? 'Close panel' : 'Open panel'}

--- a/packages/dify-ui/src/context-menu/index.stories.tsx
+++ b/packages/dify-ui/src/context-menu/index.stories.tsx
@@ -22,7 +22,7 @@ import {
 const TriggerArea = ({ label = 'Right-click inside this area' }: { label?: string }) => (
   <ContextMenuTrigger
     aria-label="context menu trigger area"
-    render={<button type="button" className="flex h-44 w-80 items-center justify-center rounded-xl border border-divider-subtle bg-background-default-subtle px-6 text-center text-sm text-text-tertiary select-none" />}
+    render={<button type="button" className="flex h-44 w-80 items-center justify-center rounded-xl border border-divider-subtle bg-background-default-subtle px-6 text-center text-sm text-text-tertiary outline-hidden select-none focus-visible:ring-2 focus-visible:ring-state-accent-solid" />}
   >
     {label}
   </ContextMenuTrigger>

--- a/packages/dify-ui/src/dialog/index.stories.tsx
+++ b/packages/dify-ui/src/dialog/index.stories.tsx
@@ -4,7 +4,6 @@ import { expect, waitFor, within } from 'storybook/test'
 import {
   Dialog,
   DialogBackdrop,
-  DialogClose,
   DialogCloseButton,
   DialogContent,
   DialogDescription,
@@ -83,12 +82,16 @@ function ReleaseNoteSections() {
   )
 }
 
-function ReleaseNoteFooter() {
+function ReleaseNoteFooter({
+  onClose,
+}: {
+  onClose: () => void
+}) {
   return (
     <div className="flex shrink-0 justify-end border-t border-divider-subtle p-4">
-      <DialogClose render={<Button />}>
+      <Button onClick={onClose}>
         Close
-      </DialogClose>
+      </Button>
     </div>
   )
 }
@@ -302,10 +305,11 @@ export const FormDialog: Story = {
 }
 
 const OutsideScrollingContentDemo = () => {
+  const [open, setOpen] = React.useState(false)
   const popupRef = React.useRef<HTMLDivElement>(null)
 
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger
         render={<Button />}
       >
@@ -328,7 +332,7 @@ const OutsideScrollingContentDemo = () => {
                     description="This layout lets the outer dialog viewport scroll while the popup keeps its natural height."
                   />
                   <ReleaseNoteSections />
-                  <ReleaseNoteFooter />
+                  <ReleaseNoteFooter onClose={() => setOpen(false)} />
                 </DialogPopup>
               </ScrollAreaContent>
             </ScrollAreaViewport>
@@ -358,12 +362,11 @@ export const OutsidePopupElements: Story = {
         <DialogBackdrop className="min-h-dvh" />
         <DialogViewport className="grid place-items-center px-4 py-12 xl:py-6">
           <DialogPopup className="group/popup relative flex h-full w-full max-w-[70rem] justify-center border-0 bg-transparent shadow-none pointer-events-none transition-opacity data-starting-style:scale-100 data-starting-style:opacity-0 data-ending-style:scale-100 data-ending-style:opacity-0">
-            <DialogClose
+            <DialogCloseButton
               aria-label="Close"
               className="pointer-events-auto absolute right-0 -top-10 z-10 flex size-8 items-center justify-center rounded-lg border-[0.5px] border-components-button-secondary-border bg-components-button-secondary-bg text-text-tertiary shadow-xs outline-hidden hover:bg-components-button-secondary-bg-hover hover:text-text-secondary focus-visible:ring-2 focus-visible:ring-state-accent-solid xl:top-0"
             >
-              <span aria-hidden="true" className="i-ri-close-line size-4" />
-            </DialogClose>
+            </DialogCloseButton>
             <div className="pointer-events-auto flex h-full w-full max-w-[70rem] flex-col overflow-hidden rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-6 shadow-xl transition-[scale] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] group-data-starting-style/popup:scale-105">
               <div className="grid gap-2">
                 <DialogTitle className="text-lg leading-7 font-semibold text-text-primary">
@@ -384,9 +387,11 @@ export const OutsidePopupElements: Story = {
   ),
 }
 
-export const InsideScrollingContent: Story = {
-  render: () => (
-    <Dialog>
+const InsideScrollingContentDemo = () => {
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger
         render={<Button />}
       >
@@ -413,10 +418,14 @@ export const InsideScrollingContent: Story = {
                 <ScrollAreaThumb />
               </ScrollAreaScrollbar>
             </ScrollAreaRoot>
-            <ReleaseNoteFooter />
+            <ReleaseNoteFooter onClose={() => setOpen(false)} />
           </DialogPopup>
         </DialogViewport>
       </DialogPortal>
     </Dialog>
-  ),
+  )
+}
+
+export const InsideScrollingContent: Story = {
+  render: () => <InsideScrollingContentDemo />,
 }

--- a/packages/dify-ui/src/dialog/index.stories.tsx
+++ b/packages/dify-ui/src/dialog/index.stories.tsx
@@ -39,6 +39,56 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
+const releaseNoteItems = Array.from({ length: 24 }, (_, index) => ({
+  id: `improvement-${index + 1}`,
+  title: `Improvement #${index + 1}`,
+  body: 'Refined a workflow behavior so long content naturally overflows and scrolls inside the dialog.',
+}))
+
+function ReleaseNoteHeader({
+  title,
+  description,
+}: {
+  title: string
+  description: string
+}) {
+  return (
+    <div className="flex shrink-0 flex-col gap-2 p-6 pr-12 pb-4">
+      <DialogTitle className="text-lg leading-7 font-semibold text-text-primary">
+        {title}
+      </DialogTitle>
+      <DialogDescription className="text-sm leading-5 text-text-secondary">
+        {description}
+      </DialogDescription>
+    </div>
+  )
+}
+
+function ReleaseNoteSections() {
+  return (
+    <div className="flex flex-col gap-3 px-6 py-2 text-sm leading-5 text-text-secondary">
+      {releaseNoteItems.map(item => (
+        <section key={item.id} className="rounded-lg bg-background-default-subtle px-3 py-2">
+          <h3 className="font-medium text-text-primary">
+            {item.title}
+          </h3>
+          <p>{item.body}</p>
+        </section>
+      ))}
+    </div>
+  )
+}
+
+function ReleaseNoteFooter() {
+  return (
+    <div className="flex shrink-0 justify-end border-t border-divider-subtle p-4">
+      <BaseDialog.Close render={<Button />}>
+        Close
+      </BaseDialog.Close>
+    </div>
+  )
+}
+
 export const Default: Story = {
   render: () => (
     <Dialog>
@@ -247,6 +297,53 @@ export const FormDialog: Story = {
   render: () => <FormDialogDemo />,
 }
 
+const OutsideScrollingContentDemo = () => {
+  const popupRef = React.useRef<HTMLDivElement>(null)
+
+  return (
+    <Dialog>
+      <DialogTrigger
+        render={<Button />}
+      >
+        Review long release notes
+      </DialogTrigger>
+      <BaseDialog.Portal>
+        <BaseDialog.Backdrop
+          className="absolute inset-0 z-50 bg-background-overlay transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 motion-reduce:transition-none"
+        />
+        <BaseDialog.Viewport className="fixed inset-0 z-50">
+          <ScrollAreaRoot className="h-full overscroll-contain">
+            <ScrollAreaViewport aria-label="Scrollable dialog viewport" role="region" className="h-full max-h-full max-w-full overscroll-contain">
+              <ScrollAreaContent className="flex min-h-full items-center justify-center px-4 py-16">
+                <BaseDialog.Popup
+                  ref={popupRef}
+                  initialFocus={popupRef}
+                  className="relative mx-auto flex w-120 max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-xl outline-hidden transition-[transform,scale,opacity] duration-150 data-ending-style:translate-y-4 data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:translate-y-4 data-starting-style:scale-95 data-starting-style:opacity-0 motion-reduce:transition-none"
+                >
+                  <DialogCloseButton />
+                  <ReleaseNoteHeader
+                    title="Long release notes"
+                    description="This layout lets the outer dialog viewport scroll while the popup keeps its natural height."
+                  />
+                  <ReleaseNoteSections />
+                  <ReleaseNoteFooter />
+                </BaseDialog.Popup>
+              </ScrollAreaContent>
+            </ScrollAreaViewport>
+            <ScrollAreaScrollbar>
+              <ScrollAreaThumb />
+            </ScrollAreaScrollbar>
+          </ScrollAreaRoot>
+        </BaseDialog.Viewport>
+      </BaseDialog.Portal>
+    </Dialog>
+  )
+}
+
+export const OutsideScrollingContent: Story = {
+  render: () => <OutsideScrollingContentDemo />,
+}
+
 export const ScrollingContent: Story = {
   render: () => (
     <Dialog>
@@ -261,42 +358,24 @@ export const ScrollingContent: Story = {
         />
         <BaseDialog.Viewport className="fixed inset-0 z-50 flex items-center justify-center overflow-hidden p-4">
           <BaseDialog.Popup
-            className="flex max-h-[min(44rem,calc(100dvh-2rem))] w-120 max-w-[calc(100vw-2rem)] min-h-0 flex-col overflow-hidden rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-xl transition-[transform,scale,opacity] duration-150 data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:scale-95 data-starting-style:opacity-0 motion-reduce:transition-none"
+            className="relative flex h-[min(44rem,calc(100dvh-2rem))] w-120 max-w-[calc(100vw-2rem)] min-h-0 flex-col overflow-hidden rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-xl transition-[transform,scale,opacity] duration-150 data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:scale-95 data-starting-style:opacity-0 motion-reduce:transition-none"
           >
             <DialogCloseButton />
-            <div className="flex shrink-0 flex-col gap-2 p-6 pr-12 pb-4">
-              <DialogTitle className="text-lg leading-7 font-semibold text-text-primary">
-                Release notes
-              </DialogTitle>
-              <DialogDescription className="text-sm leading-5 text-text-secondary">
-                Highlights from the latest workspace update.
-              </DialogDescription>
-            </div>
-            <ScrollAreaRoot className="relative min-h-0 flex-1 overflow-hidden">
-              <ScrollAreaViewport aria-label="Release note improvements" role="region" className="h-full max-h-full max-w-full">
-                <ScrollAreaContent className="flex flex-col gap-3 px-6 py-2 text-sm leading-5 text-text-secondary">
-                  {Array.from({ length: 24 }, (_, index) => `improvement-${index + 1}`).map((id, index) => (
-                    <section key={id} className="rounded-lg bg-background-default-subtle px-3 py-2">
-                      <h3 className="font-medium text-text-primary">
-                        Improvement #
-                        {index + 1}
-                      </h3>
-                      <p>
-                        Refined a workflow behavior so long content naturally overflows and scrolls inside the dialog.
-                      </p>
-                    </section>
-                  ))}
+            <ReleaseNoteHeader
+              title="Release notes"
+              description="Highlights from the latest workspace update."
+            />
+            <ScrollAreaRoot className="relative flex min-h-0 flex-auto overflow-hidden">
+              <ScrollAreaViewport aria-label="Release note improvements" role="region" className="h-full max-h-full max-w-full overflow-y-auto overscroll-contain">
+                <ScrollAreaContent>
+                  <ReleaseNoteSections />
                 </ScrollAreaContent>
               </ScrollAreaViewport>
               <ScrollAreaScrollbar>
                 <ScrollAreaThumb />
               </ScrollAreaScrollbar>
             </ScrollAreaRoot>
-            <div className="flex shrink-0 justify-end border-t border-divider-subtle p-4">
-              <BaseDialog.Close render={<Button />}>
-                Close
-              </BaseDialog.Close>
-            </div>
+            <ReleaseNoteFooter />
           </BaseDialog.Popup>
         </BaseDialog.Viewport>
       </BaseDialog.Portal>

--- a/packages/dify-ui/src/dialog/index.stories.tsx
+++ b/packages/dify-ui/src/dialog/index.stories.tsx
@@ -312,15 +312,15 @@ const OutsideScrollingContentDemo = () => {
         Review long release notes
       </DialogTrigger>
       <DialogPortal>
-        <DialogBackdrop />
-        <DialogViewport>
-          <ScrollAreaRoot className="h-full overscroll-contain">
-            <ScrollAreaViewport aria-label="Scrollable dialog viewport" role="region" className="h-full max-h-full max-w-full overscroll-contain">
+        <DialogBackdrop className="duration-[600ms] ease-[cubic-bezier(0.22,1,0.36,1)] data-ending-style:duration-[350ms] data-ending-style:ease-[cubic-bezier(0.375,0.015,0.545,0.455)]" />
+        <DialogViewport className="group/dialog">
+          <ScrollAreaRoot className="h-full overscroll-contain group-data-ending-style/dialog:pointer-events-none">
+            <ScrollAreaViewport aria-label="Scrollable dialog viewport" role="region" className="h-full max-h-full max-w-full overscroll-contain group-data-ending-style/dialog:pointer-events-none">
               <ScrollAreaContent className="flex min-h-full items-center justify-center px-4 py-16">
                 <DialogPopup
                   ref={popupRef}
                   initialFocus={popupRef}
-                  className="relative mx-auto flex w-120 max-w-[calc(100vw-2rem)] flex-col overflow-hidden outline-hidden data-ending-style:translate-y-4 data-starting-style:translate-y-4"
+                  className="relative mx-auto flex w-120 max-w-[calc(100vw-2rem)] flex-col overflow-hidden outline-hidden transition-[translate] duration-[700ms] ease-[cubic-bezier(0.45,1.005,0,1.005)] data-starting-style:translate-y-[100dvh] data-starting-style:scale-100 data-starting-style:opacity-100 data-ending-style:translate-y-[max(100dvh,100%)] data-ending-style:scale-100 data-ending-style:opacity-100 data-ending-style:duration-[350ms] data-ending-style:ease-[cubic-bezier(0.375,0.015,0.545,0.455)]"
                 >
                   <DialogCloseButton />
                   <ReleaseNoteHeader

--- a/packages/dify-ui/src/dialog/index.stories.tsx
+++ b/packages/dify-ui/src/dialog/index.stories.tsx
@@ -4,7 +4,6 @@ import { expect, waitFor, within } from 'storybook/test'
 import {
   Dialog,
   DialogBackdrop,
-  DialogClose,
   DialogCloseButton,
   DialogContent,
   DialogDescription,
@@ -86,9 +85,9 @@ function ReleaseNoteSections() {
 function ReleaseNoteFooter() {
   return (
     <div className="flex shrink-0 justify-end border-t border-divider-subtle p-4">
-      <DialogClose render={<Button />}>
+      <DialogCloseButton render={<Button />}>
         Close
-      </DialogClose>
+      </DialogCloseButton>
     </div>
   )
 }
@@ -346,7 +345,45 @@ export const OutsideScrollingContent: Story = {
   render: () => <OutsideScrollingContentDemo />,
 }
 
-export const ScrollingContent: Story = {
+export const OutsidePopupElements: Story = {
+  render: () => (
+    <Dialog>
+      <DialogTrigger
+        render={<Button />}
+      >
+        Open uncontained dialog
+      </DialogTrigger>
+      <DialogPortal>
+        <DialogBackdrop className="min-h-dvh" />
+        <DialogViewport className="grid place-items-center px-4 py-12 xl:py-6">
+          <DialogPopup className="group/popup relative flex h-full w-full max-w-[70rem] justify-center border-0 bg-transparent shadow-none pointer-events-none transition-opacity data-starting-style:scale-100 data-starting-style:opacity-0 data-ending-style:scale-100 data-ending-style:opacity-0">
+            <DialogCloseButton
+              aria-label="Close"
+              className="pointer-events-auto absolute right-0 -top-10 z-10 flex size-8 items-center justify-center rounded-lg border-[0.5px] border-components-button-secondary-border bg-components-button-secondary-bg text-text-tertiary shadow-xs outline-hidden hover:bg-components-button-secondary-bg-hover hover:text-text-secondary focus-visible:ring-2 focus-visible:ring-state-accent-solid xl:top-0"
+            >
+              <span aria-hidden="true" className="i-ri-close-line size-4" />
+            </DialogCloseButton>
+            <div className="pointer-events-auto flex h-full w-full max-w-[70rem] flex-col overflow-hidden rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-6 shadow-xl transition-[scale] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] group-data-starting-style/popup:scale-105">
+              <div className="grid gap-2">
+                <DialogTitle className="text-lg leading-7 font-semibold text-text-primary">
+                  Knowledge review
+                </DialogTitle>
+                <DialogDescription className="text-sm leading-5 text-text-secondary">
+                  The close button is visually outside this panel but remains inside the popup for focus order and screen reader context.
+                </DialogDescription>
+              </div>
+              <div className="mt-6 grid flex-1 place-items-center rounded-xl bg-background-default-subtle text-sm text-text-tertiary">
+                Panel content
+              </div>
+            </div>
+          </DialogPopup>
+        </DialogViewport>
+      </DialogPortal>
+    </Dialog>
+  ),
+}
+
+export const InsideScrollingContent: Story = {
   render: () => (
     <Dialog>
       <DialogTrigger

--- a/packages/dify-ui/src/dialog/index.stories.tsx
+++ b/packages/dify-ui/src/dialog/index.stories.tsx
@@ -1,14 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { Dialog as BaseDialog } from '@base-ui/react/dialog'
 import * as React from 'react'
 import { expect, waitFor, within } from 'storybook/test'
 import {
   Dialog,
+  DialogBackdrop,
+  DialogClose,
   DialogCloseButton,
   DialogContent,
   DialogDescription,
+  DialogPopup,
+  DialogPortal,
   DialogTitle,
   DialogTrigger,
+  DialogViewport,
 } from '.'
 import { Button } from '../button'
 import { FieldControl, FieldDescription, FieldError, FieldLabel, FieldRoot } from '../field'
@@ -82,9 +86,9 @@ function ReleaseNoteSections() {
 function ReleaseNoteFooter() {
   return (
     <div className="flex shrink-0 justify-end border-t border-divider-subtle p-4">
-      <BaseDialog.Close render={<Button />}>
+      <DialogClose render={<Button />}>
         Close
-      </BaseDialog.Close>
+      </DialogClose>
     </div>
   )
 }
@@ -307,18 +311,16 @@ const OutsideScrollingContentDemo = () => {
       >
         Review long release notes
       </DialogTrigger>
-      <BaseDialog.Portal>
-        <BaseDialog.Backdrop
-          className="absolute inset-0 z-50 bg-background-overlay transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 motion-reduce:transition-none"
-        />
-        <BaseDialog.Viewport className="fixed inset-0 z-50">
+      <DialogPortal>
+        <DialogBackdrop />
+        <DialogViewport>
           <ScrollAreaRoot className="h-full overscroll-contain">
             <ScrollAreaViewport aria-label="Scrollable dialog viewport" role="region" className="h-full max-h-full max-w-full overscroll-contain">
               <ScrollAreaContent className="flex min-h-full items-center justify-center px-4 py-16">
-                <BaseDialog.Popup
+                <DialogPopup
                   ref={popupRef}
                   initialFocus={popupRef}
-                  className="relative mx-auto flex w-120 max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-xl outline-hidden transition-[transform,scale,opacity] duration-150 data-ending-style:translate-y-4 data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:translate-y-4 data-starting-style:scale-95 data-starting-style:opacity-0 motion-reduce:transition-none"
+                  className="relative mx-auto flex w-120 max-w-[calc(100vw-2rem)] flex-col overflow-hidden outline-hidden data-ending-style:translate-y-4 data-starting-style:translate-y-4"
                 >
                   <DialogCloseButton />
                   <ReleaseNoteHeader
@@ -327,15 +329,15 @@ const OutsideScrollingContentDemo = () => {
                   />
                   <ReleaseNoteSections />
                   <ReleaseNoteFooter />
-                </BaseDialog.Popup>
+                </DialogPopup>
               </ScrollAreaContent>
             </ScrollAreaViewport>
             <ScrollAreaScrollbar>
               <ScrollAreaThumb />
             </ScrollAreaScrollbar>
           </ScrollAreaRoot>
-        </BaseDialog.Viewport>
-      </BaseDialog.Portal>
+        </DialogViewport>
+      </DialogPortal>
     </Dialog>
   )
 }
@@ -352,13 +354,11 @@ export const ScrollingContent: Story = {
       >
         Review release notes
       </DialogTrigger>
-      <BaseDialog.Portal>
-        <BaseDialog.Backdrop
-          className="absolute inset-0 z-50 bg-background-overlay transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 motion-reduce:transition-none"
-        />
-        <BaseDialog.Viewport className="fixed inset-0 z-50 flex items-center justify-center overflow-hidden p-4">
-          <BaseDialog.Popup
-            className="relative flex h-[min(44rem,calc(100dvh-2rem))] w-120 max-w-[calc(100vw-2rem)] min-h-0 flex-col overflow-hidden rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-xl transition-[transform,scale,opacity] duration-150 data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:scale-95 data-starting-style:opacity-0 motion-reduce:transition-none"
+      <DialogPortal>
+        <DialogBackdrop />
+        <DialogViewport className="flex items-center justify-center overflow-hidden p-4">
+          <DialogPopup
+            className="relative flex h-[min(44rem,calc(100dvh-2rem))] w-120 max-w-[calc(100vw-2rem)] min-h-0 flex-col overflow-hidden"
           >
             <DialogCloseButton />
             <ReleaseNoteHeader
@@ -376,9 +376,9 @@ export const ScrollingContent: Story = {
               </ScrollAreaScrollbar>
             </ScrollAreaRoot>
             <ReleaseNoteFooter />
-          </BaseDialog.Popup>
-        </BaseDialog.Viewport>
-      </BaseDialog.Portal>
+          </DialogPopup>
+        </DialogViewport>
+      </DialogPortal>
     </Dialog>
   ),
 }

--- a/packages/dify-ui/src/dialog/index.stories.tsx
+++ b/packages/dify-ui/src/dialog/index.stories.tsx
@@ -12,8 +12,7 @@ import {
 import { Button } from '../button'
 import { FieldControl, FieldDescription, FieldError, FieldLabel, FieldRoot } from '../field'
 import { Form } from '../form'
-
-const triggerButtonClassName = 'rounded-lg border border-divider-subtle bg-components-button-secondary-bg px-3 py-1.5 text-sm text-text-secondary shadow-xs outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid'
+import { Input } from '../input'
 
 const meta = {
   title: 'Base/UI/Dialog',
@@ -36,7 +35,7 @@ export const Default: Story = {
   render: () => (
     <Dialog>
       <DialogTrigger
-        render={<button type="button" className={triggerButtonClassName} />}
+        render={<Button />}
       >
         Open dialog
       </DialogTrigger>
@@ -54,11 +53,10 @@ export const Default: Story = {
           <label className="text-xs font-medium text-text-tertiary" htmlFor="invite-email">
             Email address
           </label>
-          <input
+          <Input
             id="invite-email"
             type="email"
             placeholder="teammate@example.com"
-            className="h-9 w-full rounded-lg border border-transparent bg-components-input-bg-normal px-3 text-sm text-components-input-text-filled outline-hidden placeholder:text-components-input-text-placeholder hover:border-components-input-border-hover hover:bg-components-input-bg-hover focus:border-components-input-border-active focus:bg-components-input-bg-active focus:shadow-xs"
           />
         </div>
         <div className="mt-6 flex items-center justify-end">
@@ -89,7 +87,7 @@ export const WithoutCloseButton: Story = {
   render: () => (
     <Dialog>
       <DialogTrigger
-        render={<button type="button" className={triggerButtonClassName} />}
+        render={<Button />}
       >
         Start onboarding
       </DialogTrigger>
@@ -135,10 +133,10 @@ const ControlledDemo = () => {
               The workspace URL will stay the same, but the display name updates everywhere.
             </DialogDescription>
           </div>
-          <input
+          <Input
             type="text"
             defaultValue="Acme Workspace"
-            className="mt-4 h-9 w-full rounded-lg border border-transparent bg-components-input-bg-normal px-3 text-sm text-components-input-text-filled outline-hidden hover:border-components-input-border-hover hover:bg-components-input-bg-hover focus:border-components-input-border-active focus:bg-components-input-bg-active focus:shadow-xs"
+            className="mt-4"
           />
           <div className="mt-6 flex items-center justify-end gap-2">
             <Button variant="secondary" onClick={() => setOpen(false)}>
@@ -170,7 +168,7 @@ const FormDialogDemo = () => {
   return (
     <Dialog open={open} onOpenChange={setOpen} disablePointerDismissal>
       <DialogTrigger
-        render={<button type="button" className={triggerButtonClassName} />}
+        render={<Button />}
       >
         Configure API extension
       </DialogTrigger>
@@ -245,7 +243,7 @@ export const ScrollingContent: Story = {
   render: () => (
     <Dialog>
       <DialogTrigger
-        render={<button type="button" className={triggerButtonClassName} />}
+        render={<Button />}
       >
         Review release notes
       </DialogTrigger>

--- a/packages/dify-ui/src/dialog/index.stories.tsx
+++ b/packages/dify-ui/src/dialog/index.stories.tsx
@@ -4,6 +4,7 @@ import { expect, waitFor, within } from 'storybook/test'
 import {
   Dialog,
   DialogBackdrop,
+  DialogClose,
   DialogCloseButton,
   DialogContent,
   DialogDescription,
@@ -85,9 +86,9 @@ function ReleaseNoteSections() {
 function ReleaseNoteFooter() {
   return (
     <div className="flex shrink-0 justify-end border-t border-divider-subtle p-4">
-      <DialogCloseButton render={<Button />}>
+      <DialogClose render={<Button />}>
         Close
-      </DialogCloseButton>
+      </DialogClose>
     </div>
   )
 }
@@ -357,12 +358,12 @@ export const OutsidePopupElements: Story = {
         <DialogBackdrop className="min-h-dvh" />
         <DialogViewport className="grid place-items-center px-4 py-12 xl:py-6">
           <DialogPopup className="group/popup relative flex h-full w-full max-w-[70rem] justify-center border-0 bg-transparent shadow-none pointer-events-none transition-opacity data-starting-style:scale-100 data-starting-style:opacity-0 data-ending-style:scale-100 data-ending-style:opacity-0">
-            <DialogCloseButton
+            <DialogClose
               aria-label="Close"
               className="pointer-events-auto absolute right-0 -top-10 z-10 flex size-8 items-center justify-center rounded-lg border-[0.5px] border-components-button-secondary-border bg-components-button-secondary-bg text-text-tertiary shadow-xs outline-hidden hover:bg-components-button-secondary-bg-hover hover:text-text-secondary focus-visible:ring-2 focus-visible:ring-state-accent-solid xl:top-0"
             >
               <span aria-hidden="true" className="i-ri-close-line size-4" />
-            </DialogCloseButton>
+            </DialogClose>
             <div className="pointer-events-auto flex h-full w-full max-w-[70rem] flex-col overflow-hidden rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-6 shadow-xl transition-[scale] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] group-data-starting-style/popup:scale-105">
               <div className="grid gap-2">
                 <DialogTitle className="text-lg leading-7 font-semibold text-text-primary">

--- a/packages/dify-ui/src/dialog/index.stories.tsx
+++ b/packages/dify-ui/src/dialog/index.stories.tsx
@@ -13,7 +13,7 @@ import { Button } from '../button'
 import { FieldControl, FieldDescription, FieldError, FieldLabel, FieldRoot } from '../field'
 import { Form } from '../form'
 
-const triggerButtonClassName = 'rounded-lg border border-divider-subtle bg-components-button-secondary-bg px-3 py-1.5 text-sm text-text-secondary shadow-xs hover:bg-state-base-hover'
+const triggerButtonClassName = 'rounded-lg border border-divider-subtle bg-components-button-secondary-bg px-3 py-1.5 text-sm text-text-secondary shadow-xs outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid'
 
 const meta = {
   title: 'Base/UI/Dialog',
@@ -58,7 +58,7 @@ export const Default: Story = {
             id="invite-email"
             type="email"
             placeholder="teammate@example.com"
-            className="h-9 w-full rounded-lg border-[0.5px] border-components-input-border-active bg-components-input-bg-normal px-3 text-sm text-components-input-text-filled outline-hidden placeholder:text-components-input-text-placeholder focus:border-components-input-border-hover"
+            className="h-9 w-full rounded-lg border border-transparent bg-components-input-bg-normal px-3 text-sm text-components-input-text-filled outline-hidden placeholder:text-components-input-text-placeholder hover:border-components-input-border-hover hover:bg-components-input-bg-hover focus:border-components-input-border-active focus:bg-components-input-bg-active focus:shadow-xs"
           />
         </div>
         <div className="mt-6 flex items-center justify-end">
@@ -138,7 +138,7 @@ const ControlledDemo = () => {
           <input
             type="text"
             defaultValue="Acme Workspace"
-            className="mt-4 h-9 w-full rounded-lg border-[0.5px] border-components-input-border-active bg-components-input-bg-normal px-3 text-sm text-components-input-text-filled outline-hidden focus:border-components-input-border-hover"
+            className="mt-4 h-9 w-full rounded-lg border border-transparent bg-components-input-bg-normal px-3 text-sm text-components-input-text-filled outline-hidden hover:border-components-input-border-hover hover:bg-components-input-bg-hover focus:border-components-input-border-active focus:bg-components-input-bg-active focus:shadow-xs"
           />
           <div className="mt-6 flex items-center justify-end gap-2">
             <Button variant="secondary" onClick={() => setOpen(false)}>
@@ -201,7 +201,7 @@ const FormDialogDemo = () => {
                 href="https://docs.dify.ai/use-dify/workspace/api-extension/api-extension"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex w-fit items-center text-text-accent focus-visible:ring-1 focus-visible:ring-components-input-border-active focus-visible:outline-hidden"
+                className="inline-flex w-fit items-center text-text-accent outline-hidden focus-visible:ring-1 focus-visible:ring-components-input-border-active"
               >
                 View API extension docs
               </a>

--- a/packages/dify-ui/src/dialog/index.stories.tsx
+++ b/packages/dify-ui/src/dialog/index.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Dialog as BaseDialog } from '@base-ui/react/dialog'
 import * as React from 'react'
 import { expect, waitFor, within } from 'storybook/test'
 import {
@@ -13,6 +14,13 @@ import { Button } from '../button'
 import { FieldControl, FieldDescription, FieldError, FieldLabel, FieldRoot } from '../field'
 import { Form } from '../form'
 import { Input } from '../input'
+import {
+  ScrollAreaContent,
+  ScrollAreaRoot,
+  ScrollAreaScrollbar,
+  ScrollAreaThumb,
+  ScrollAreaViewport,
+} from '../scroll-area'
 
 const meta = {
   title: 'Base/UI/Dialog',
@@ -247,30 +255,51 @@ export const ScrollingContent: Story = {
       >
         Review release notes
       </DialogTrigger>
-      <DialogContent>
-        <DialogCloseButton />
-        <div className="flex flex-col gap-2 pr-8">
-          <DialogTitle className="text-lg leading-7 font-semibold text-text-primary">
-            Release notes
-          </DialogTitle>
-          <DialogDescription className="text-sm leading-5 text-text-secondary">
-            Highlights from the latest workspace update.
-          </DialogDescription>
-        </div>
-        <ul className="mt-4 flex flex-col gap-3 text-sm leading-5 text-text-secondary">
-          {Array.from({ length: 24 }, (_, index) => `improvement-${index + 1}`).map((id, index) => (
-            <li key={id} className="rounded-lg bg-background-default-subtle px-3 py-2">
-              <span className="font-medium text-text-primary">
-                Improvement #
-                {index + 1}
-                :
-              </span>
-              {' '}
-              Refined a workflow behavior so long content naturally overflows and scrolls inside the dialog.
-            </li>
-          ))}
-        </ul>
-      </DialogContent>
+      <BaseDialog.Portal>
+        <BaseDialog.Backdrop
+          className="absolute inset-0 z-50 bg-background-overlay transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 motion-reduce:transition-none"
+        />
+        <BaseDialog.Viewport className="fixed inset-0 z-50 flex items-center justify-center overflow-hidden p-4">
+          <BaseDialog.Popup
+            className="flex max-h-[min(44rem,calc(100dvh-2rem))] w-120 max-w-[calc(100vw-2rem)] min-h-0 flex-col overflow-hidden rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-xl transition-[transform,scale,opacity] duration-150 data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:scale-95 data-starting-style:opacity-0 motion-reduce:transition-none"
+          >
+            <DialogCloseButton />
+            <div className="flex shrink-0 flex-col gap-2 p-6 pr-12 pb-4">
+              <DialogTitle className="text-lg leading-7 font-semibold text-text-primary">
+                Release notes
+              </DialogTitle>
+              <DialogDescription className="text-sm leading-5 text-text-secondary">
+                Highlights from the latest workspace update.
+              </DialogDescription>
+            </div>
+            <ScrollAreaRoot className="relative min-h-0 flex-1 overflow-hidden">
+              <ScrollAreaViewport aria-label="Release note improvements" role="region" className="h-full max-h-full max-w-full">
+                <ScrollAreaContent className="flex flex-col gap-3 px-6 py-2 text-sm leading-5 text-text-secondary">
+                  {Array.from({ length: 24 }, (_, index) => `improvement-${index + 1}`).map((id, index) => (
+                    <section key={id} className="rounded-lg bg-background-default-subtle px-3 py-2">
+                      <h3 className="font-medium text-text-primary">
+                        Improvement #
+                        {index + 1}
+                      </h3>
+                      <p>
+                        Refined a workflow behavior so long content naturally overflows and scrolls inside the dialog.
+                      </p>
+                    </section>
+                  ))}
+                </ScrollAreaContent>
+              </ScrollAreaViewport>
+              <ScrollAreaScrollbar>
+                <ScrollAreaThumb />
+              </ScrollAreaScrollbar>
+            </ScrollAreaRoot>
+            <div className="flex shrink-0 justify-end border-t border-divider-subtle p-4">
+              <BaseDialog.Close render={<Button />}>
+                Close
+              </BaseDialog.Close>
+            </div>
+          </BaseDialog.Popup>
+        </BaseDialog.Viewport>
+      </BaseDialog.Portal>
     </Dialog>
   ),
 }

--- a/packages/dify-ui/src/dialog/index.tsx
+++ b/packages/dify-ui/src/dialog/index.tsx
@@ -9,6 +9,8 @@ export const DialogTrigger = BaseDialog.Trigger
 export const DialogTitle = BaseDialog.Title
 export const DialogDescription = BaseDialog.Description
 export const DialogPortal = BaseDialog.Portal
+// Prefer DialogCloseButton unless a custom close control is necessary.
+export const DialogClose = BaseDialog.Close
 
 type DialogBackdropProps = Omit<BaseDialog.Backdrop.Props, 'className'> & {
   className?: string
@@ -66,30 +68,23 @@ export function DialogPopup({
   )
 }
 
-type DialogCloseButtonProps = Omit<BaseDialog.Close.Props, 'children'> & {
-  children?: React.ReactNode
-}
+type DialogCloseButtonProps = Omit<BaseDialog.Close.Props, 'children'>
 
 export function DialogCloseButton({
-  children,
   className,
-  render,
-  'aria-label': ariaLabel,
+  'aria-label': ariaLabel = 'Close',
   ...props
 }: DialogCloseButtonProps) {
-  const isIconOnly = children === undefined
-
   return (
     <BaseDialog.Close
-      aria-label={ariaLabel ?? (isIconOnly ? 'Close' : undefined)}
-      render={render}
+      aria-label={ariaLabel}
       {...props}
       className={cn(
-        render === undefined && 'absolute top-6 end-6 z-10 flex h-5 w-5 cursor-pointer items-center justify-center rounded-2xl hover:bg-state-base-hover focus-visible:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+        'absolute top-6 end-6 z-10 flex h-5 w-5 cursor-pointer items-center justify-center rounded-2xl hover:bg-state-base-hover focus-visible:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
     >
-      {children ?? <span aria-hidden="true" className="i-ri-close-line h-4 w-4 text-text-tertiary" />}
+      <span aria-hidden="true" className="i-ri-close-line h-4 w-4 text-text-tertiary" />
     </BaseDialog.Close>
   )
 }

--- a/packages/dify-ui/src/dialog/index.tsx
+++ b/packages/dify-ui/src/dialog/index.tsx
@@ -57,7 +57,7 @@ export function DialogPopup({
   return (
     <BaseDialog.Popup
       className={cn(
-        'rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-xl',
+        'z-50 rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-xl',
         'transition-[transform,scale,opacity] duration-150 data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:scale-95 data-starting-style:opacity-0 motion-reduce:transition-none',
         className,
       )}

--- a/packages/dify-ui/src/dialog/index.tsx
+++ b/packages/dify-ui/src/dialog/index.tsx
@@ -9,7 +9,6 @@ export const DialogTrigger = BaseDialog.Trigger
 export const DialogTitle = BaseDialog.Title
 export const DialogDescription = BaseDialog.Description
 export const DialogPortal = BaseDialog.Portal
-export const DialogClose = BaseDialog.Close
 
 type DialogBackdropProps = Omit<BaseDialog.Backdrop.Props, 'className'> & {
   className?: string
@@ -67,23 +66,30 @@ export function DialogPopup({
   )
 }
 
-type DialogCloseButtonProps = Omit<BaseDialog.Close.Props, 'children'>
+type DialogCloseButtonProps = Omit<BaseDialog.Close.Props, 'children'> & {
+  children?: React.ReactNode
+}
 
 export function DialogCloseButton({
+  children,
   className,
-  'aria-label': ariaLabel = 'Close',
+  render,
+  'aria-label': ariaLabel,
   ...props
 }: DialogCloseButtonProps) {
+  const isIconOnly = children === undefined
+
   return (
     <BaseDialog.Close
-      aria-label={ariaLabel}
+      aria-label={ariaLabel ?? (isIconOnly ? 'Close' : undefined)}
+      render={render}
       {...props}
       className={cn(
-        'absolute top-6 end-6 z-10 flex h-5 w-5 cursor-pointer items-center justify-center rounded-2xl hover:bg-state-base-hover focus-visible:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+        render === undefined && 'absolute top-6 end-6 z-10 flex h-5 w-5 cursor-pointer items-center justify-center rounded-2xl hover:bg-state-base-hover focus-visible:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
     >
-      <span aria-hidden="true" className="i-ri-close-line h-4 w-4 text-text-tertiary" />
+      {children ?? <span aria-hidden="true" className="i-ri-close-line h-4 w-4 text-text-tertiary" />}
     </BaseDialog.Close>
   )
 }

--- a/packages/dify-ui/src/dialog/index.tsx
+++ b/packages/dify-ui/src/dialog/index.tsx
@@ -8,6 +8,64 @@ export const Dialog = BaseDialog.Root
 export const DialogTrigger = BaseDialog.Trigger
 export const DialogTitle = BaseDialog.Title
 export const DialogDescription = BaseDialog.Description
+export const DialogPortal = BaseDialog.Portal
+export const DialogClose = BaseDialog.Close
+
+type DialogBackdropProps = Omit<BaseDialog.Backdrop.Props, 'className'> & {
+  className?: string
+}
+
+export function DialogBackdrop({
+  className,
+  ...props
+}: DialogBackdropProps) {
+  return (
+    <BaseDialog.Backdrop
+      {...props}
+      className={cn(
+        'absolute inset-0 z-50 bg-background-overlay',
+        'transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 motion-reduce:transition-none',
+        className,
+      )}
+    />
+  )
+}
+
+type DialogViewportProps = Omit<BaseDialog.Viewport.Props, 'className'> & {
+  className?: string
+}
+
+export function DialogViewport({
+  className,
+  ...props
+}: DialogViewportProps) {
+  return (
+    <BaseDialog.Viewport
+      className={cn('fixed inset-0 z-50', className)}
+      {...props}
+    />
+  )
+}
+
+type DialogPopupProps = Omit<BaseDialog.Popup.Props, 'className'> & {
+  className?: string
+}
+
+export function DialogPopup({
+  className,
+  ...props
+}: DialogPopupProps) {
+  return (
+    <BaseDialog.Popup
+      className={cn(
+        'rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-xl',
+        'transition-[transform,scale,opacity] duration-150 data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:scale-95 data-starting-style:opacity-0 motion-reduce:transition-none',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
 
 type DialogCloseButtonProps = Omit<BaseDialog.Close.Props, 'children'>
 
@@ -44,24 +102,16 @@ export function DialogContent({
   backdropProps,
 }: DialogContentProps) {
   return (
-    <BaseDialog.Portal>
-      <BaseDialog.Backdrop
-        {...backdropProps}
+    <DialogPortal>
+      <DialogBackdrop {...backdropProps} className={backdropClassName} />
+      <DialogPopup
         className={cn(
-          'absolute inset-0 z-50 bg-background-overlay',
-          'transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 motion-reduce:transition-none',
-          backdropClassName,
-        )}
-      />
-      <BaseDialog.Popup
-        className={cn(
-          'fixed top-1/2 left-1/2 z-50 max-h-[80dvh] w-120 max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 overflow-y-auto overscroll-contain rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-6 shadow-xl',
-          'transition-[transform,scale,opacity] duration-150 data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:scale-95 data-starting-style:opacity-0 motion-reduce:transition-none',
+          'fixed top-1/2 left-1/2 max-h-[80dvh] w-120 max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 overflow-y-auto overscroll-contain p-6',
           className,
         )}
       >
         {children}
-      </BaseDialog.Popup>
-    </BaseDialog.Portal>
+      </DialogPopup>
+    </DialogPortal>
   )
 }

--- a/packages/dify-ui/src/dialog/index.tsx
+++ b/packages/dify-ui/src/dialog/index.tsx
@@ -78,7 +78,7 @@ export function DialogCloseButton({
       aria-label={ariaLabel}
       {...props}
       className={cn(
-        'absolute top-6 end-6 z-10 flex h-5 w-5 cursor-pointer items-center justify-center rounded-2xl hover:bg-state-base-hover focus-visible:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+        'absolute top-6 end-6 z-10 flex h-5 w-5 cursor-pointer items-center justify-center rounded-2xl hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
     >

--- a/packages/dify-ui/src/dialog/index.tsx
+++ b/packages/dify-ui/src/dialog/index.tsx
@@ -9,8 +9,6 @@ export const DialogTrigger = BaseDialog.Trigger
 export const DialogTitle = BaseDialog.Title
 export const DialogDescription = BaseDialog.Description
 export const DialogPortal = BaseDialog.Portal
-// Prefer DialogCloseButton unless a custom close control is necessary.
-export const DialogClose = BaseDialog.Close
 
 type DialogBackdropProps = Omit<BaseDialog.Backdrop.Props, 'className'> & {
   className?: string

--- a/packages/dify-ui/src/dropdown-menu/index.stories.tsx
+++ b/packages/dify-ui/src/dropdown-menu/index.stories.tsx
@@ -21,7 +21,7 @@ import {
 
 const TriggerButton = ({ label = 'Open Menu' }: { label?: string }) => (
   <DropdownMenuTrigger
-    render={<button type="button" className="rounded-lg border border-divider-subtle bg-components-button-secondary-bg px-3 py-1.5 text-sm text-text-secondary shadow-xs hover:bg-state-base-hover" />}
+    render={<button type="button" className="rounded-lg border border-divider-subtle bg-components-button-secondary-bg px-3 py-1.5 text-sm text-text-secondary shadow-xs outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid" />}
   >
     {label}
   </DropdownMenuTrigger>

--- a/packages/dify-ui/src/kbd/index.stories.tsx
+++ b/packages/dify-ui/src/kbd/index.stories.tsx
@@ -170,7 +170,7 @@ export const InTooltip: Story = {
           <button
             type="button"
             aria-label="Collapse sidebar"
-            className="inline-flex size-8 items-center justify-center rounded-lg border border-divider-subtle bg-components-button-secondary-bg text-text-secondary shadow-xs"
+            className="inline-flex size-8 items-center justify-center rounded-lg border border-divider-subtle bg-components-button-secondary-bg text-text-secondary shadow-xs outline-hidden focus-visible:ring-2 focus-visible:ring-state-accent-solid"
           >
             <span aria-hidden className="i-ri-sidebar-fold-line size-4" />
           </button>
@@ -204,7 +204,7 @@ export const InContextMenu: Story = {
         render={(
           <button
             type="button"
-            className="flex h-28 w-60 items-center justify-center rounded-xl border border-divider-subtle bg-background-default-subtle px-6 text-center system-sm-regular text-text-tertiary"
+            className="flex h-28 w-60 items-center justify-center rounded-xl border border-divider-subtle bg-background-default-subtle px-6 text-center system-sm-regular text-text-tertiary outline-hidden focus-visible:ring-2 focus-visible:ring-state-accent-solid"
           />
         )}
       >

--- a/packages/dify-ui/src/popover/index.stories.tsx
+++ b/packages/dify-ui/src/popover/index.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from '.'
 import { Kbd, KbdGroup } from '../kbd'
 
-const triggerButtonClassName = 'rounded-lg border border-divider-subtle bg-components-button-secondary-bg px-3 py-1.5 text-sm text-text-secondary shadow-xs hover:bg-state-base-hover'
+const triggerButtonClassName = 'rounded-lg border border-divider-subtle bg-components-button-secondary-bg px-3 py-1.5 text-sm text-text-secondary shadow-xs outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid'
 
 const meta = {
   title: 'Base/UI/Popover',
@@ -81,7 +81,7 @@ export const WithActions: Story = {
           <input
             type="email"
             placeholder="teammate@example.com"
-            className="h-8 rounded-md border-[0.5px] border-components-input-border-active bg-components-input-bg-normal px-2 text-sm text-components-input-text-filled outline-hidden placeholder:text-components-input-text-placeholder focus:border-components-input-border-hover"
+            className="h-8 rounded-md border border-transparent bg-components-input-bg-normal px-2 text-sm text-components-input-text-filled outline-hidden placeholder:text-components-input-text-placeholder hover:border-components-input-border-hover hover:bg-components-input-bg-hover focus:border-components-input-border-active focus:bg-components-input-bg-active focus:shadow-xs"
           />
           <div className="flex items-center justify-end gap-2">
             <PopoverClose
@@ -169,7 +169,7 @@ const PlacementsDemo = () => {
             key={value}
             type="button"
             onClick={() => setPlacement(value)}
-            className={`rounded-md border border-divider-subtle px-2 py-1 text-text-secondary ${
+            className={`rounded-md border border-divider-subtle px-2 py-1 text-text-secondary outline-hidden focus-visible:ring-2 focus-visible:ring-state-accent-solid ${
               placement === value ? 'bg-state-base-hover' : 'bg-components-button-secondary-bg'
             }`}
           >

--- a/packages/dify-ui/src/preview-card/index.stories.tsx
+++ b/packages/dify-ui/src/preview-card/index.stories.tsx
@@ -9,13 +9,13 @@ import {
 } from '.'
 
 const rowButtonClassName
-  = 'flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-text-secondary hover:bg-state-base-hover'
+  = 'flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-text-secondary outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid'
 
 const triggerButtonClassName
-  = 'rounded-lg border border-divider-subtle bg-components-button-secondary-bg px-3 py-1.5 text-sm text-text-secondary shadow-xs hover:bg-state-base-hover'
+  = 'rounded-lg border border-divider-subtle bg-components-button-secondary-bg px-3 py-1.5 text-sm text-text-secondary shadow-xs outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid'
 
 const inlineLinkClassName
-  = 'text-text-accent underline decoration-text-accent/60 decoration-1 underline-offset-2 outline-hidden hover:decoration-text-accent focus-visible:rounded-xs focus-visible:no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-text-accent data-[popup-open]:decoration-text-accent'
+  = 'text-text-accent underline decoration-text-accent/60 decoration-1 underline-offset-2 outline-hidden hover:decoration-text-accent focus-visible:rounded-xs focus-visible:no-underline focus-visible:ring-1 focus-visible:ring-components-input-border-active data-[popup-open]:decoration-text-accent'
 
 const meta = {
   title: 'Base/UI/PreviewCard',
@@ -154,7 +154,7 @@ const PlacementsDemo = () => {
             key={value}
             type="button"
             onClick={() => setPlacement(value)}
-            className={`rounded-md border border-divider-subtle px-2 py-1 text-text-secondary ${
+            className={`rounded-md border border-divider-subtle px-2 py-1 text-text-secondary outline-hidden focus-visible:ring-2 focus-visible:ring-state-accent-solid ${
               placement === value ? 'bg-state-base-hover' : 'bg-components-button-secondary-bg'
             }`}
           >

--- a/packages/dify-ui/src/radio-group/index.stories.tsx
+++ b/packages/dify-ui/src/radio-group/index.stories.tsx
@@ -136,7 +136,7 @@ function OptionCardsDemo() {
               variant="unstyled"
               nativeButton
               render={<button type="button" />}
-              className="w-full rounded-xl border border-components-option-card-option-border bg-components-option-card-option-bg p-4 text-left transition-colors hover:bg-state-base-hover data-checked:border-components-option-card-option-selected-border data-checked:bg-components-option-card-option-selected-bg"
+              className="w-full rounded-xl border border-components-option-card-option-border bg-components-option-card-option-bg p-4 text-left outline-hidden transition-colors hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid data-checked:border-components-option-card-option-selected-border data-checked:bg-components-option-card-option-selected-bg"
             >
               <div className="flex items-start justify-between gap-3">
                 <div>

--- a/packages/dify-ui/src/scroll-area/index.stories.tsx
+++ b/packages/dify-ui/src/scroll-area/index.stories.tsx
@@ -29,21 +29,6 @@ type Story = StoryObj<typeof meta>
 
 const verticalContentStyle = { minWidth: 0 } satisfies React.CSSProperties
 
-const appRows = [
-  { name: 'Invoice Copilot', meta: 'Pinned', icon: 'i-ri-file-list-3-line', selected: true, pinned: true },
-  { name: 'RAG Ops Console', meta: 'Ops', icon: 'i-ri-database-2-line', selected: false, pinned: true },
-  { name: 'Knowledge Studio', meta: 'Docs', icon: 'i-ri-book-open-line', selected: false, pinned: true },
-  { name: 'Workflow Studio', meta: 'Build', icon: 'i-ri-flow-chart', selected: false, pinned: true },
-  { name: 'Agent Playground', meta: 'Lab', icon: 'i-ri-robot-2-line', selected: false, pinned: false },
-  { name: 'Sales Briefing', meta: 'Team', icon: 'i-ri-presentation-line', selected: false, pinned: false },
-  { name: 'Support Triage', meta: 'Queue', icon: 'i-ri-customer-service-2-line', selected: false, pinned: false },
-  { name: 'Legal Review', meta: 'Beta', icon: 'i-ri-scales-3-line', selected: false, pinned: false },
-  { name: 'Release Watcher', meta: 'Feed', icon: 'i-ri-rocket-line', selected: false, pinned: false },
-  { name: 'Security Radar', meta: 'Risk', icon: 'i-ri-shield-check-line', selected: false, pinned: false },
-  { name: 'Partner Portal', meta: 'Ext', icon: 'i-ri-handshake-line', selected: false, pinned: false },
-  { name: 'QA Replays', meta: 'Debug', icon: 'i-ri-replay-line', selected: false, pinned: false },
-] as const
-
 const articleParagraphs = [
   'Vernacular architecture is building done outside any academic tradition, and without professional guidance. It is not a particular architectural movement or style, but rather a broad category, encompassing a wide range and variety of building types, with differing methods of construction, from around the world, both historical and extant and classical and modern.',
   'This type of architecture usually serves immediate, local needs, is constrained by the materials available in its particular region, and reflects local traditions and cultural practices. The study of vernacular architecture does not examine formally schooled architects, but instead the design skills and tradition of local builders.',
@@ -291,64 +276,4 @@ export const BothAxes: Story = {
       </ScrollAreaRoot>
     </StorySection>
   ),
-}
-
-export const AppSidebar: Story = {
-  render: () => {
-    const pinnedCount = appRows.filter(row => row.pinned).length
-
-    return (
-      <StorySection
-        eyebrow="Application"
-        title="Main navigation list"
-        description="A Dify-like sidebar keeps business UI outside the primitive while preserving the same Root, Viewport, Content, Scrollbar anatomy."
-      >
-        <div className="w-full max-w-70 rounded-xl bg-background-default-subtle p-3">
-          <div className="mb-4 flex h-8 items-center gap-2 rounded-lg bg-state-base-active px-2 text-text-accent">
-            <span className="i-ri-apps-fill size-4 shrink-0" aria-hidden />
-            <span className="min-w-0 truncate system-sm-semibold">Explore</span>
-          </div>
-          <div className="mb-1.5 flex items-center justify-between px-2">
-            <span className="system-xs-medium-uppercase text-text-tertiary">Web apps</span>
-            <span className="system-xs-medium text-text-quaternary">{appRows.length}</span>
-          </div>
-          <ScrollAreaRoot className="relative h-76 min-w-0">
-            <ScrollAreaViewport aria-label="Web apps" role="region" className="h-full max-h-full max-w-full rounded-lg bg-transparent">
-              <VerticalContent className="space-y-0.5 pr-3">
-                {appRows.map((row, index) => (
-                  <div key={row.name} className="space-y-0.5">
-                    <button
-                      type="button"
-                      className={cn(
-                        'flex h-8 w-full min-w-0 items-center justify-between gap-2 rounded-lg px-2 text-left transition-colors outline-none focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-solid focus-visible:outline-state-accent-solid',
-                        row.selected
-                          ? 'bg-state-base-active text-components-menu-item-text-active'
-                          : 'text-components-menu-item-text hover:bg-state-base-hover hover:text-components-menu-item-text-hover',
-                      )}
-                    >
-                      <span className="flex min-w-0 items-center gap-2">
-                        <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-components-icon-bg-blue-solid text-components-avatar-shape-fill-stop-100">
-                          <span aria-hidden className={cn(row.icon, 'size-3.5')} />
-                        </span>
-                        <span className="min-w-0 truncate system-sm-regular">{row.name}</span>
-                      </span>
-                      <span className="shrink-0 rounded-md border border-divider-subtle bg-components-panel-bg-alt px-1.5 py-0.5 system-2xs-medium-uppercase text-text-quaternary">
-                        {row.meta}
-                      </span>
-                    </button>
-                    {index === pinnedCount - 1 && index !== appRows.length - 1 && (
-                      <div className="my-1 h-px bg-divider-subtle" />
-                    )}
-                  </div>
-                ))}
-              </VerticalContent>
-            </ScrollAreaViewport>
-            <ScrollAreaScrollbar>
-              <ScrollAreaThumb />
-            </ScrollAreaScrollbar>
-          </ScrollAreaRoot>
-        </div>
-      </StorySection>
-    )
-  },
 }

--- a/packages/dify-ui/src/switch/index.stories.tsx
+++ b/packages/dify-ui/src/switch/index.stories.tsx
@@ -225,7 +225,7 @@ const LoadingDemo = () => {
   return (
     <div className="flex flex-col items-center space-y-4">
       <button
-        className="rounded-sm border px-2 py-1 text-xs"
+        className="rounded-sm border px-2 py-1 text-xs outline-hidden focus-visible:ring-2 focus-visible:ring-state-accent-solid"
         onClick={() => setLoading(!loading)}
       >
         {loading ? 'Stop Loading' : 'Start Loading'}

--- a/packages/dify-ui/src/toast/index.stories.tsx
+++ b/packages/dify-ui/src/toast/index.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import * as React from 'react'
 import { toast, ToastHost } from '.'
 
-const buttonClassName = 'rounded-lg border border-divider-subtle bg-components-button-secondary-bg px-3 py-2 text-sm text-text-secondary shadow-xs transition-colors hover:bg-state-base-hover'
+const buttonClassName = 'rounded-lg border border-divider-subtle bg-components-button-secondary-bg px-3 py-2 text-sm text-text-secondary shadow-xs outline-hidden transition-colors hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid'
 const cardClassName = 'flex min-h-[220px] flex-col gap-4 rounded-2xl border border-divider-subtle bg-components-panel-bg p-6 shadow-sm shadow-shadow-shadow-3'
 
 const ExampleCard = ({

--- a/packages/dify-ui/src/tooltip/index.stories.tsx
+++ b/packages/dify-ui/src/tooltip/index.stories.tsx
@@ -8,8 +8,8 @@ import {
   TooltipTrigger,
 } from '.'
 
-const iconButtonClassName = 'inline-flex h-8 w-8 items-center justify-center rounded-lg border border-divider-subtle bg-components-button-secondary-bg text-text-secondary shadow-xs hover:bg-state-base-hover'
-const triggerButtonClassName = 'rounded-lg border border-divider-subtle bg-components-button-secondary-bg px-3 py-1.5 text-sm text-text-secondary shadow-xs hover:bg-state-base-hover'
+const iconButtonClassName = 'inline-flex h-8 w-8 items-center justify-center rounded-lg border border-divider-subtle bg-components-button-secondary-bg text-text-secondary shadow-xs outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid'
+const triggerButtonClassName = 'rounded-lg border border-divider-subtle bg-components-button-secondary-bg px-3 py-1.5 text-sm text-text-secondary shadow-xs outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid'
 
 const meta = {
   title: 'Base/UI/Tooltip',
@@ -117,7 +117,7 @@ const PlacementsDemo = () => {
             key={value}
             type="button"
             onClick={() => setPlacement(value)}
-            className={`rounded-md border border-divider-subtle px-2 py-1 text-text-secondary ${
+            className={`rounded-md border border-divider-subtle px-2 py-1 text-text-secondary outline-hidden focus-visible:ring-2 focus-visible:ring-state-accent-solid ${
               placement === value ? 'bg-state-base-hover' : 'bg-components-button-secondary-bg'
             }`}
           >


### PR DESCRIPTION
## Summary
- Standardize story-local raw triggers, buttons, and links on Dify token focus rings instead of browser/default outline styles.
- Align raw dialog/popover inputs with Dify input focus treatment.
- Remove the unused ScrollArea AppSidebar story instead of carrying a local focus-style fix for it.

## Validation
- pnpm -C packages/dify-ui exec eslint src/alert-dialog/index.stories.tsx src/dialog/index.stories.tsx src/popover/index.stories.tsx src/dropdown-menu/index.stories.tsx src/context-menu/index.stories.tsx src/tooltip/index.stories.tsx src/preview-card/index.stories.tsx src/toast/index.stories.tsx src/kbd/index.stories.tsx src/switch/index.stories.tsx src/radio-group/index.stories.tsx src/collapsible/index.stories.tsx src/scroll-area/index.stories.tsx
- pnpm -C packages/dify-ui type-check
- git diff --check