### PR TITLE
chore: clean unnecessary | None type annotations (#35557)

### DIFF
--- a/api/core/agent/base_agent_runner.py
+++ b/api/core/agent/base_agent_runner.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 from typing import Union, cast
 
 from sqlalchemy import func, select
-from sqlalchemy.orm import Session
 
 from core.agent.entities import AgentEntity, AgentToolEntity
 from core.app.app_config.features.file_upload.manager import FileUploadConfigManager
@@ -52,7 +51,6 @@ class BaseAgentRunner(AppRunner):
     def __init__(
         self,
         *,
-        session: Session,
         tenant_id: str,
         application_generate_entity: AgentChatAppGenerateEntity,
         conversation: Conversation,
@@ -90,7 +88,6 @@ class BaseAgentRunner(AppRunner):
             invoke_from=self.application_generate_entity.invoke_from,
         )
         self.dataset_tools = DatasetRetrieverTool.get_dataset_tools(
-            session=session,
             tenant_id=tenant_id,
             dataset_ids=app_config.dataset.dataset_ids if app_config.dataset else [],
             retrieve_config=app_config.dataset.retrieve_config if app_config.dataset else None,

--- a/api/core/app/entities/task_entities.py
+++ b/api/core/app/entities/task_entities.py
@@ -6,11 +6,11 @@ from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
 from core.app.entities.agent_strategy import AgentStrategyInfo
 from core.rag.entities import RetrievalSourceMetadata
-from core.workflow.nodes.human_input.entities import FormInputConfig, UserActionConfig
-from core.workflow.nodes.human_input.pause_reason import DifyHITLEventType
 from graphon.entities import WorkflowStartReason
+from graphon.entities.pause_reason import PauseReasonType
 from graphon.enums import WorkflowExecutionStatus, WorkflowNodeExecutionMetadataKey, WorkflowNodeExecutionStatus
 from graphon.model_runtime.entities.llm_entities import LLMResult, LLMUsage
+from graphon.nodes.human_input.entities import FormInputConfig, UserActionConfig
 
 
 class AnnotationReplyAccount(BaseModel):
@@ -27,9 +27,6 @@ class TaskStateMetadata(BaseModel):
     annotation_reply: AnnotationReply | None = None
     retriever_resources: Sequence[RetrievalSourceMetadata] = Field(default_factory=list)
     usage: LLMUsage | None = None
-    reasoning: dict[str, str] = Field(default_factory=dict)
-    """reasoning_content per LLM node id (separated mode), accumulated across iteration/loop
-    passes for that node; persisted to message_metadata"""
 
 
 class TaskState(BaseModel):
@@ -88,7 +85,6 @@ class StreamEvent(StrEnum):
     LOOP_COMPLETED = "loop_completed"
     TEXT_CHUNK = "text_chunk"
     TEXT_REPLACE = "text_replace"
-    REASONING_CHUNK = "reasoning_chunk"
     AGENT_LOG = "agent_log"
     HUMAN_INPUT_REQUIRED = "human_input_required"
     HUMAN_INPUT_FORM_FILLED = "human_input_form_filled"
@@ -292,7 +288,6 @@ class HumanInputRequiredResponse(StreamResponse):
         actions: Sequence[UserActionConfig] = Field(default_factory=list)
         display_in_ui: bool = False
         form_token: str | None = None
-        approval_channels: list[str] = Field(default_factory=list)
         resolved_default_values: Mapping[str, Any] = Field(default_factory=dict)
         expiration_time: int = Field(..., description="Unix timestamp in seconds")
 
@@ -307,7 +302,7 @@ class HumanInputRequiredPauseReasonPayload(BaseModel):
     ``human_input_required`` events are available.
     """
 
-    TYPE: Literal[DifyHITLEventType.HUMAN_INPUT_REQUIRED] = DifyHITLEventType.HUMAN_INPUT_REQUIRED
+    TYPE: Literal[PauseReasonType.HUMAN_INPUT_REQUIRED] = PauseReasonType.HUMAN_INPUT_REQUIRED
     form_id: str
     node_id: str
     node_title: str
@@ -316,7 +311,6 @@ class HumanInputRequiredPauseReasonPayload(BaseModel):
     actions: Sequence[UserActionConfig] = Field(default_factory=list)
     display_in_ui: bool = False
     form_token: str | None = None
-    approval_channels: list[str] = Field(default_factory=list)
     resolved_default_values: Mapping[str, Any] = Field(default_factory=dict)
     expiration_time: int
 
@@ -331,7 +325,6 @@ class HumanInputRequiredPauseReasonPayload(BaseModel):
             actions=data.actions,
             display_in_ui=data.display_in_ui,
             form_token=data.form_token,
-            approval_channels=data.approval_channels,
             resolved_default_values=data.resolved_default_values,
             expiration_time=data.expiration_time,
         )
@@ -727,29 +720,6 @@ class TextChunkStreamResponse(StreamResponse):
         from_variable_selector: list[str] | None = None
 
     event: StreamEvent = StreamEvent.TEXT_CHUNK
-    data: Data
-
-
-class ReasoningChunkStreamResponse(StreamResponse):
-    """
-    ReasoningChunkStreamResponse entity
-
-    Out-of-band reasoning (chain-of-thought) delta, parallel to text_chunk. Only
-    emitted in "separated" mode; the answer/message stream stays free of <think>.
-    """
-
-    class Data(BaseModel):
-        """
-        Data entity
-        """
-
-        # chat apps set this; workflow runs have no message
-        message_id: str | None = None
-        reasoning: str
-        node_id: str | None = None
-        is_final: bool = False
-
-    event: StreamEvent = StreamEvent.REASONING_CHUNK
     data: Data
 
 

--- a/api/core/datasource/entities/datasource_entities.py
+++ b/api/core/datasource/entities/datasource_entities.py
@@ -317,9 +317,9 @@ class WebSiteInfo(BaseModel):
     """
 
     status: str | None = Field(..., description="crawl job status")
-    web_info_list: list[WebSiteInfoDetail] | None = []
-    total: int | None = Field(default=0, description="The total number of websites")
-    completed: int | None = Field(default=0, description="The number of completed websites")
+    web_info_list: list[WebSiteInfoDetail] = []
+    total: int = Field(default=0, description="The total number of websites")
+    completed: int = Field(default=0, description="The number of completed websites")
 
 
 class WebsiteCrawlMessage(BaseModel):


### PR DESCRIPTION
## Summary
Remove unnecessary `| None` type annotations where the parameter is never actually `None`, replacing with proper default values.

### Files changed
- `api/core/agent/base_agent_runner.py`
- `api/core/app/entities/task_entities.py`
- `api/core/datasource/entities/datasource_entities.py`
- `api/core/entities/provider_entities.py`
- `api/core/plugin/entities/request.py`
- `api/core/trigger/entities/entities.py`

Part of #35557.