### PR TITLE
fix(web): prevent plugin cards from overlapping marketplace panel

### DIFF
--- a/web/app/components/plugins/install-plugin/base/loading-error.tsx
+++ b/web/app/components/plugins/install-plugin/base/loading-error.tsx
@@ -14,7 +14,7 @@ const LoadingError: FC = () => {
       <CheckboxSkeleton
         className="shrink-0"
       />
-      <div className="hover-bg-components-panel-on-panel-item-bg relative grow rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-on-panel-item-bg p-4 pb-3 shadow-xs">
+      <div className="relative grow rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-on-panel-item-bg p-4 pb-3 shadow-xs">
         <div className="flex">
           <div
             className="relative flex h-10 w-10 items-center justify-center gap-2 rounded-[10px] border-[0.5px]

--- a/web/app/components/plugins/install-plugin/base/loading.tsx
+++ b/web/app/components/plugins/install-plugin/base/loading.tsx
@@ -9,7 +9,7 @@ const Loading = () => {
       <CheckboxSkeleton
         className="shrink-0"
       />
-      <div className="hover-bg-components-panel-on-panel-item-bg relative grow rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-on-panel-item-bg p-4 pb-3 shadow-xs">
+      <div className="relative grow rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-on-panel-item-bg p-4 pb-3 shadow-xs">
         <Placeholder
           wrapClassName="w-full"
         />

--- a/web/app/components/plugins/plugin-item/index.tsx
+++ b/web/app/components/plugins/plugin-item/index.tsx
@@ -110,7 +110,7 @@ const PluginItem: FC<Props> = ({
         setCurrentPluginID(plugin.plugin_id)
       }}
     >
-      <div className={cn('hover-bg-components-panel-on-panel-item-bg relative z-10 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-on-panel-item-bg p-4 pb-3 shadow-xs', className)}>
+      <div className={cn('relative rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-on-panel-item-bg p-4 pb-3 shadow-xs', className)}>
         {/* Header */}
         <div className="flex">
           <div className="flex size-10 items-center justify-center overflow-hidden rounded-xl border border-components-panel-border-subtle">

--- a/web/app/components/plugins/plugin-page/plugin-list-skeleton.tsx
+++ b/web/app/components/plugins/plugin-page/plugin-list-skeleton.tsx
@@ -8,7 +8,7 @@ const PluginCardSkeleton = () => (
     data-testid="plugin-card-skeleton"
     className="relative overflow-hidden rounded-xl border-[1.5px] border-background-section-burn bg-background-section-burn p-1"
   >
-    <div className="relative z-10 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-on-panel-item-bg p-4 pb-3 shadow-xs">
+    <div className="relative rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-on-panel-item-bg p-4 pb-3 shadow-xs">
       <div className="flex">
         <SkeletonRectangle className="size-10 shrink-0 animate-pulse rounded-xl" />
         <div className="ml-3 w-0 grow">


### PR DESCRIPTION
## Summary
- remove the stale z-index from installed plugin card inner surfaces so they stay in normal scroll content paint order
- remove the same z-index from the matching plugin list skeleton
- drop the undefined hover-bg marker from plugin item and install loading surfaces; keep the documented page-feedback marker in marketplace cards untouched

## Verification
- pnpm --dir web exec vitest run app/components/plugins/plugin-item/__tests__/index.spec.tsx
- git diff --check

## Notes
- `pnpm --dir web exec eslint app/components/plugins/plugin-item/index.tsx` still reports existing `any`, non-interactive click handler, and Remix icon warnings/errors unrelated to this patch.
Refs SNP-516