### PR TITLE
fix(agent): normalize empty streaming response fields

### DIFF
--- a/api/core/app/entities/task_entities.py
+++ b/api/core/app/entities/task_entities.py
@@ -122,7 +122,7 @@ class MessageStreamResponse(StreamResponse):
     event: StreamEvent = StreamEvent.MESSAGE
     id: str
     answer: str
-    from_variable_selector: list[str] | None = None
+    from_variable_selector: list[str] = Field(default_factory=list)
 
 
 class MessageAudioStreamResponse(StreamResponse):
@@ -151,7 +151,7 @@ class MessageEndStreamResponse(StreamResponse):
     event: StreamEvent = StreamEvent.MESSAGE_END
     id: str
     metadata: Mapping[str, object] = Field(default_factory=dict)
-    files: Sequence[Mapping[str, Any]] | None = None
+    files: Sequence[Mapping[str, Any]] = Field(default_factory=list)
 
 
 class MessageFileStreamResponse(StreamResponse):

--- a/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
+++ b/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from collections.abc import Generator
+from collections.abc import Generator, Mapping, Sequence
 from threading import Thread
 from typing import Any, cast
 
@@ -44,7 +44,7 @@ from core.app.entities.task_entities import (
 )
 from core.app.task_pipeline.based_generate_task_pipeline import BasedGenerateTaskPipeline
 from core.app.task_pipeline.message_cycle_manager import MessageCycleManager
-from core.app.task_pipeline.message_file_utils import prepare_file_dict
+from core.app.task_pipeline.message_file_utils import MessageFileInfoDict, prepare_file_dict
 from core.base.tts import AppGeneratorTTSPublisher, AudioTrunk
 from core.model_manager import ModelInstance
 from core.ops.entities.trace_entity import TraceTaskName
@@ -466,10 +466,10 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline[EasyUIAppGenerat
         :return:
         """
         self._task_state.metadata.usage = self._task_state.llm_result.usage
-        metadata_dict = self._task_state.metadata.model_dump()
+        metadata_dict = self._task_state.metadata.model_dump(exclude_none=True)
 
         # Fetch files associated with this message
-        files = None
+        files: list[MessageFileInfoDict] = []
         with Session(db.engine, expire_on_commit=False) as session:
             message_files = session.scalars(select(MessageFile).where(MessageFile.message_id == self._message_id)).all()
 
@@ -492,13 +492,13 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline[EasyUIAppGenerat
                     file_dict = prepare_file_dict(message_file, upload_files_map)
                     files_list.append(file_dict)
 
-                files = files_list or None
+                files = files_list
 
         return MessageEndStreamResponse(
             task_id=self._application_generate_entity.task_id,
             id=self._message_id,
             metadata=metadata_dict,
-            files=files,
+            files=cast(Sequence[Mapping[str, Any]], files),
         )
 
     def _agent_message_to_stream_response(self, answer: str, message_id: str) -> AgentMessageStreamResponse:

--- a/api/core/app/task_pipeline/message_cycle_manager.py
+++ b/api/core/app/task_pipeline/message_cycle_manager.py
@@ -257,7 +257,7 @@ class MessageCycleManager:
             task_id=self._application_generate_entity.task_id,
             id=message_id,
             answer=answer,
-            from_variable_selector=from_variable_selector,
+            from_variable_selector=from_variable_selector or [],
             event=event_type or StreamEvent.MESSAGE,
         )
 

--- a/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_based_generate_task_pipeline_core.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_based_generate_task_pipeline_core.py
@@ -1280,7 +1280,7 @@ class TestEasyUiBasedGenerateTaskPipeline:
         usage_metadata = cast(dict[str, object], response.metadata["usage"])
         assert usage_metadata["prompt_tokens"] == 1
 
-    def test_record_files_returns_none_when_message_has_no_files(self, monkeypatch: pytest.MonkeyPatch):
+    def test_record_files_returns_empty_list_when_message_has_no_files(self, monkeypatch: pytest.MonkeyPatch):
         conversation = _make_conversation(AppMode.CHAT)
         message = _make_message()
         pipeline = EasyUIBasedGenerateTaskPipeline(
@@ -1316,7 +1316,7 @@ class TestEasyUiBasedGenerateTaskPipeline:
 
         response = pipeline._message_end_to_stream_response()
 
-        assert response.files is None
+        assert response.files == []
 
     def test_record_files_handles_local_fallback_and_tool_url_variants(self, monkeypatch: pytest.MonkeyPatch):
         conversation = _make_conversation(AppMode.CHAT)

--- a/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_message_end_files.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_message_end_files.py
@@ -6,7 +6,7 @@ SSE event, which is critical for vision/image chat responses to render correctly
 
 Test Coverage:
 - Files array populated when MessageFile records exist
-- Files array is None when no MessageFile records exist
+- Files array is empty when no MessageFile records exist
 - Correct signed URL generation for LOCAL_FILE transfer method
 - Correct URL handling for REMOTE_URL transfer method
 - Correct URL handling for TOOL_FILE transfer method
@@ -90,7 +90,7 @@ class TestMessageEndStreamResponseFiles:
         return upload_file
 
     def test_message_end_with_no_files(self, mock_pipeline):
-        """Test that files array is None when no MessageFile records exist."""
+        """Test that files array is empty when no MessageFile records exist."""
         # Arrange
         with (
             patch("core.app.task_pipeline.easy_ui_based_generate_task_pipeline.db") as mock_db,
@@ -108,9 +108,10 @@ class TestMessageEndStreamResponseFiles:
 
             # Assert
             assert isinstance(result, MessageEndStreamResponse)
-            assert result.files is None
+            assert result.files == []
             assert result.id == mock_pipeline._message_id
             assert result.metadata == {"test": "metadata"}
+            mock_pipeline._task_state.metadata.model_dump.assert_called_once_with(exclude_none=True)
 
     def test_message_end_with_local_file(self, mock_pipeline, mock_message_file_local, mock_upload_file):
         """Test that files array is populated correctly for LOCAL_FILE transfer method."""


### PR DESCRIPTION
## Summary
- Return empty arrays instead of JSON null for empty streaming message fields (`from_variable_selector`, `files`).
- Drop `None` metadata fields from message-end SSE payloads so empty optional metadata does not surface as `null`.
- Update targeted task pipeline tests to assert the stable empty-array contract.

## Verification
- `uv run --project api --dev pyrefly check api/core/app/entities/task_entities.py api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py api/core/app/task_pipeline/message_cycle_manager.py`
- `uv run --project api --dev python -m py_compile ...` for touched source and test files
- Local response serialization check confirms `from_variable_selector: []` and `files: []`
- Deployed commit `78913abb97` to `deploy/agent` and verified on `https://agent.dify.dev` with real console login + agent streaming chat. SSE `message` returned `from_variable_selector: []`; `message_end` returned `files: []`; raw SSE had no JSON null.

Note: local pytest still segfaults during pytest initial capture/plugin startup before collecting tests in this workstation environment, so I used pyrefly/py_compile/serialization checks plus remote E2E for validation.