### PR TITLE
fix(agent): enable default file upload feature

### DIFF
--- a/api/core/app/apps/agent_app/app_config_manager.py
+++ b/api/core/app/apps/agent_app/app_config_manager.py
@@ -3,9 +3,9 @@
 An Agent App has no legacy ``app_model_config``: its model / prompt live in the
 bound Agent Soul snapshot. To ride the existing chat message + SSE pipeline we
 synthesize an ``app_model_config``-shaped dict from the Soul (model + system
-prompt) plus any app-level feature flags (opening statement, follow-up, …)
-stored on ``app_model_config`` when present, then reuse the same sub-managers
-the chat app type uses.
+prompt) plus app-level feature flags from Agent Soul, while preserving any
+legacy ``app_model_config`` feature flags when present. Then we reuse the same
+sub-managers the chat app type uses.
 """
 
 from typing import Any, cast
@@ -79,12 +79,14 @@ class AgentAppConfigManager(BaseAppConfigManager):
     ) -> dict[str, Any]:
         """Shape a Soul + feature flags into an ``app_model_config``-style dict.
 
-        Feature flags (opening statement / follow-up / tts / stt / citations /
-        moderation / annotation) come from ``app_model_config`` when present
-        (Q3: stored there), otherwise defaults; model + prompt always come from
+        Feature flags come from Agent Soul and fill gaps in the legacy
+        ``app_model_config`` when one exists; model + prompt always come from
         the Agent Soul (the single source of truth for those).
         """
         base: dict[str, Any] = dict(app_model_config.to_dict()) if app_model_config else {}
+        soul_features = agent_soul.app_features.model_dump(mode="json", exclude_none=True)
+        for key, value in soul_features.items():
+            base.setdefault(key, value)
 
         model = agent_soul.model
         if model is not None:

--- a/api/models/agent_config_entities.py
+++ b/api/models/agent_config_entities.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field, WithJsonSchema, field_validat
 
 from core.rag.entities.metadata_entities import ConditionValue, SupportedComparisonOperator
 from core.workflow.file_reference import is_canonical_file_reference
-from graphon.file import FileTransferMethod
+from graphon.file import FileTransferMethod, FileType
 
 
 class AgentKnowledgeQueryMode(StrEnum):
@@ -547,6 +547,23 @@ class AgentSensitiveWordAvoidanceFeatureConfig(AgentFeatureToggleConfig):
     config: AgentModerationProviderConfig | None = None
 
 
+class AgentFileUploadImageFeatureConfig(AgentFeatureToggleConfig):
+    enabled: bool = True
+
+
+class AgentFileUploadFeatureConfig(AgentFeatureToggleConfig):
+    enabled: bool = True
+    allowed_file_extensions: list[str] = Field(default_factory=lambda: ["JPG", "JPEG", "PNG", "GIF", "WEBP", "SVG"])
+    allowed_file_types: list[FileType] = Field(
+        default_factory=lambda: [FileType.DOCUMENT, FileType.IMAGE, FileType.AUDIO, FileType.VIDEO]
+    )
+    allowed_file_upload_methods: list[FileTransferMethod] = Field(
+        default_factory=lambda: [FileTransferMethod.LOCAL_FILE, FileTransferMethod.REMOTE_URL]
+    )
+    image: AgentFileUploadImageFeatureConfig = Field(default_factory=AgentFileUploadImageFeatureConfig)
+    number_limits: int = 3
+
+
 class AgentSoulAppFeaturesConfig(AgentFlexibleConfig):
     opening_statement: str | None = None
     suggested_questions: list[str] | None = None
@@ -555,6 +572,7 @@ class AgentSoulAppFeaturesConfig(AgentFlexibleConfig):
     text_to_speech: AgentTextToSpeechFeatureConfig | None = None
     retriever_resource: AgentFeatureToggleConfig | None = None
     sensitive_word_avoidance: AgentSensitiveWordAvoidanceFeatureConfig | None = None
+    file_upload: AgentFileUploadFeatureConfig = Field(default_factory=AgentFileUploadFeatureConfig)
 
 
 class WorkflowPreviousNodeOutputRef(AgentFlexibleConfig):

--- a/api/tests/unit_tests/core/app/apps/agent_app/test_app_config_manager.py
+++ b/api/tests/unit_tests/core/app/apps/agent_app/test_app_config_manager.py
@@ -65,6 +65,32 @@ def test_missing_soul_model_leaves_no_model_key():
     d = AgentAppConfigManager._synthesize_config_dict(AgentSoulConfig(), None)
     assert "model" not in d
     assert d["pre_prompt"] == ""
+    assert d["file_upload"] == {
+        "allowed_file_extensions": ["JPG", "JPEG", "PNG", "GIF", "WEBP", "SVG"],
+        "allowed_file_types": ["document", "image", "audio", "video"],
+        "allowed_file_upload_methods": ["local_file", "remote_url"],
+        "enabled": True,
+        "image": {"enabled": True},
+        "number_limits": 3,
+    }
+
+
+def test_legacy_app_model_config_file_upload_takes_precedence():
+    fake_amc = SimpleNamespace(
+        to_dict=lambda: {
+            "file_upload": {
+                "enabled": False,
+                "image": {"enabled": False},
+            },
+        }
+    )
+
+    d = AgentAppConfigManager._synthesize_config_dict(AgentSoulConfig(), fake_amc)  # type: ignore[arg-type]
+
+    assert d["file_upload"] == {
+        "enabled": False,
+        "image": {"enabled": False},
+    }
 
 
 def test_prompt_type_defaults_to_simple():

--- a/api/tests/unit_tests/services/agent/test_agent_composer_entities.py
+++ b/api/tests/unit_tests/services/agent/test_agent_composer_entities.py
@@ -14,6 +14,23 @@ from services.entities.agent_entities import (
 )
 
 
+def test_default_agent_soul_enables_file_upload_feature():
+    agent_soul = AgentSoulConfig()
+
+    file_upload = agent_soul.model_dump(mode="json")["app_features"]["file_upload"]
+    assert file_upload == {
+        "allowed_file_extensions": ["JPG", "JPEG", "PNG", "GIF", "WEBP", "SVG"],
+        "allowed_file_types": ["document", "image", "audio", "video"],
+        "allowed_file_upload_methods": ["local_file", "remote_url"],
+        "enabled": True,
+        "image": {"enabled": True},
+        "number_limits": 3,
+    }
+    # The product default should be visible in API responses, but it must not
+    # make workflow-only payload validation treat app_features as user-authored.
+    assert bool(agent_soul.app_features) is False
+
+
 def test_workflow_variant_rejects_agent_app_only_fields():
     with pytest.raises(ValueError):
         ComposerSavePayload.model_validate(


### PR DESCRIPTION
## Summary

- Enable the default Agent Soul `app_features.file_upload` config for newly created Agent v2 roster agents.
- Bridge Agent Soul app feature defaults into the Agent App runtime config synthesis, while preserving legacy `app_model_config` values when present.
- Add focused tests for the default DTO shape, workflow composer validation safety, and runtime precedence.

## Verification

- Deployed `9846ce0cde2df5954fc93cf12ac0c738fdf07517` to `deploy/agent` and verified `https://agent.dify.dev` is running that image.
- Real console API E2E on `https://agent.dify.dev`:
  - `POST /console/api/agent` created agent `019f3557-f45f-7ad4-a34f-56ae2c906dec`.
  - `GET /console/api/agent/{agent_id}/composer` returned default `agent_soul.app_features.file_upload`:
    - `enabled: true`
    - allowed extensions: `JPG/JPEG/PNG/GIF/WEBP/SVG`
    - allowed types: `document/image/audio/video`
    - upload methods: `local_file/remote_url`
    - `image.enabled: true`
    - `number_limits: 3`
  - Remote runtime synthesis check converts the active snapshot into `FileUploadConfig` with the same upload/type/limit semantics.
- Local checks:
  - `uv run --project api --dev pyrefly check ...` passed.
  - `uv run --project api --dev python -m py_compile ...` passed.
  - Direct Python behavior check passed.

## Note

Local targeted pytest currently segfaults before test collection in `_pytest/capture.py` while loading native extensions. This happened before any test assertion ran, so I used pyrefly, py_compile, direct behavior validation, and remote E2E for this change.
