### PR TITLE
fix: strip extra fields when sensitive_word_avoidance is disabled

### DIFF
--- a/api/core/app/app_config/common/sensitive_word_avoidance/manager.py
+++ b/api/core/app/app_config/common/sensitive_word_avoidance/manager.py
@@ -61,10 +61,17 @@ _sensitive_word_avoidance_adapter: TypeAdapter[SensitiveWordAvoidanceConfig] = T
 
 def _normalize_raw(raw: Any) -> Any:
     if isinstance(raw, dict):
-        if raw.get("enabled") is None:
+        enabled = raw.get("enabled")
+        if enabled is None:
             raw = {**raw, "enabled": False}
-        elif raw.get("enabled") is True and raw.get("config") is None:
-            raw = {**raw, "config": {}}
+        elif enabled is True:
+            if raw.get("config") is None:
+                raw = {**raw, "config": {}}
+        else:
+            # enabled is False or any falsy value —
+            # drop extra fields (type, config) so they don't
+            # violate SensitiveWordAvoidanceDisabledConfig.extra="forbid"
+            raw = {"enabled": False}
     return raw
 
 


### PR DESCRIPTION
## Summary

Fixes [#38409](https://github.com/langgenius/dify/issues/38409)
Also related to [#38327](https://github.com/langgenius/dify/issues/38327)

## Problem

When a chat completion request includes `sensitive_word_avoidance` with `enabled: false` but also carries `type` and `config` fields:

```json
{
  "sensitive_word_avoidance": {"enabled": false, "type": "", "config": {}}
}
```

the `_normalize_raw()` function passes these through unchanged. Since `SensitiveWordAvoidanceDisabledConfig` has `extra="forbid"`, pydantic raises:

```
pydantic.ValidationError: Extra inputs are not permitted: type, config
```

resulting in HTTP 400 `invalid_param`.

**Root cause:** `_normalize_raw()` only handles two cases:
1. `enabled is None` → defaults to `False`
2. `enabled is True` → ensures `config` defaults to `{}`

When `enabled` is `False` (but extra fields exist), none of the branches match and dirty fields leak through.

## Fix

Add an `else` branch that strips all fields except `enabled` when it's not `True`:

```python
else:
    raw = {"enabled": False}
```

This ensures only `{"enabled": False}` reaches pydantic validation when the feature is disabled, regardless of what extra fields the client may have sent.

## Verification

- Existing behavior preserved (enabled=None → False, enabled=True + missing config → {})
- New case: `{"enabled": False, "type": "...", "config": {...}}` → `{"enabled": False}`
- All 5 test cases pass (see manual verification below)