### PR TITLE
fix(agent): allow incomplete composer draft knowledge

### DIFF
--- a/api/models/agent_config_entities.py
+++ b/api/models/agent_config_entities.py
@@ -314,20 +314,15 @@ class AgentKnowledgeQueryConfig(BaseModel):
 
     Agent v2 stores knowledge as explicit ``knowledge.sets`` rather than the
     legacy flat ``datasets`` / ``query_mode`` / ``query_config`` shape. Each
-    set owns its own query policy, so ``user_query`` must carry an explicit
-    ``value`` while ``generated_query`` leaves that value empty.
+    set owns its own query policy. Mode-dependent completeness, such as
+    requiring ``value`` for ``user_query``, is enforced by composer publish
+    validation so draft saves can persist partially configured knowledge sets.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     mode: AgentKnowledgeQueryMode
     value: str | None = None
-
-    @model_validator(mode="after")
-    def validate_query(self) -> Self:
-        if self.mode == AgentKnowledgeQueryMode.USER_QUERY and not (self.value or "").strip():
-            raise ValueError("knowledge query.value is required for user_query mode")
-        return self
 
 
 class AgentKnowledgeModelConfig(BaseModel):
@@ -356,8 +351,9 @@ class AgentKnowledgeRetrievalConfig(BaseModel):
     """Per-set retrieval policy for Agent v2 knowledge retrieval.
 
     Retrieval settings now live on each knowledge set instead of one shared
-    flat config. A set may use either ``multiple`` retrieval with ``top_k`` or
-    ``single`` retrieval with a required model config.
+    flat config. Mode-dependent completeness, such as requiring ``top_k`` for
+    ``multiple`` or a model for ``single``, is enforced by composer publish
+    validation so draft saves can persist partially configured knowledge sets.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -370,14 +366,6 @@ class AgentKnowledgeRetrievalConfig(BaseModel):
     reranking_model: AgentKnowledgeRerankingModelConfig | None = None
     weights: AgentKnowledgeWeightedScoreConfig | None = None
     model: AgentKnowledgeModelConfig | None = None
-
-    @model_validator(mode="after")
-    def validate_mode_fields(self) -> Self:
-        if self.mode == "multiple" and self.top_k is None:
-            raise ValueError("knowledge retrieval.top_k is required for multiple mode")
-        if self.mode == "single" and self.model is None:
-            raise ValueError("knowledge retrieval.model is required for single mode")
-        return self
 
 
 class AgentKnowledgeMetadataCondition(BaseModel):
@@ -401,6 +389,8 @@ class AgentKnowledgeMetadataFilteringConfig(BaseModel):
     The Python attribute uses ``metadata_model_config`` for clarity because the
     model belongs to metadata filtering specifically, while the external API and
     generated schema keep the historical ``model_config`` field name via alias.
+    Mode-dependent completeness is enforced by composer publish validation so
+    draft saves can persist partially configured metadata filters.
     """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
@@ -409,14 +399,6 @@ class AgentKnowledgeMetadataFilteringConfig(BaseModel):
     # Internal name is explicit; wire format remains ``model_config``.
     metadata_model_config: AgentKnowledgeModelConfig | None = Field(default=None, alias="model_config")
     conditions: AgentKnowledgeMetadataConditions | None = None
-
-    @model_validator(mode="after")
-    def validate_mode_fields(self) -> Self:
-        if self.mode == "automatic" and self.metadata_model_config is None:
-            raise ValueError("metadata_filtering.model_config is required for automatic mode")
-        if self.mode == "manual" and (self.conditions is None or not self.conditions.conditions):
-            raise ValueError("metadata_filtering.conditions is required for manual mode")
-        return self
 
 
 class AgentKnowledgeSetConfig(BaseModel):

--- a/api/services/agent/composer_service.py
+++ b/api/services/agent/composer_service.py
@@ -168,7 +168,8 @@ class AgentComposerService:
 
         _backfill_cli_tool_ids(payload.agent_soul)
         _validate_composer_payload_for_strategy(payload)
-        cls.validate_knowledge_datasets(tenant_id=tenant_id, agent_soul=payload.agent_soul)
+        if payload.save_strategy in _PUBLISH_SAVE_STRATEGIES:
+            cls.validate_knowledge_datasets(tenant_id=tenant_id, agent_soul=payload.agent_soul)
         workflow = cls._get_draft_workflow(tenant_id=tenant_id, app_id=app_id)
         binding = cls._get_workflow_binding(tenant_id=tenant_id, workflow_id=workflow.id, node_id=node_id)
 
@@ -357,7 +358,6 @@ class AgentComposerService:
             raise ValueError("agent_soul is required")
         _backfill_cli_tool_ids(payload.agent_soul)
         _validate_composer_payload_for_strategy(payload)
-        cls.validate_knowledge_datasets(tenant_id=tenant_id, agent_soul=payload.agent_soul)
 
         agent = cls._get_agent_app_agent(tenant_id=tenant_id, app_id=app_id)
         if not agent:
@@ -401,7 +401,6 @@ class AgentComposerService:
             raise ValueError("agent_soul is required")
         _backfill_cli_tool_ids(payload.agent_soul)
         _validate_composer_payload_for_strategy(payload)
-        cls.validate_knowledge_datasets(tenant_id=tenant_id, agent_soul=payload.agent_soul)
         agent = cls._require_agent(tenant_id=tenant_id, agent_id=agent_id)
         return cls._save_agent_composer_for_agent(
             tenant_id=tenant_id,
@@ -591,7 +590,6 @@ class AgentComposerService:
             raise ValueError("agent_soul is required")
         _backfill_cli_tool_ids(payload.agent_soul)
         ComposerConfigValidator.validate_draft_save_payload(payload)
-        cls.validate_knowledge_datasets(tenant_id=tenant_id, agent_soul=payload.agent_soul)
         agent = cls._require_agent(tenant_id=tenant_id, agent_id=agent_id)
         build_draft = cls._save_agent_draft(
             tenant_id=tenant_id,

--- a/api/services/agent/composer_validator.py
+++ b/api/services/agent/composer_validator.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
+from models.agent_config_entities import AgentKnowledgeQueryMode
 from services.agent.errors import AgentSoulLockedError, InvalidComposerConfigError, PlaintextSecretNotAllowedError
 from services.agent.prompt_mentions import (
     MAX_MENTIONS_PER_PROMPT,
@@ -228,8 +229,39 @@ class ComposerConfigValidator:
     @classmethod
     def validate_agent_soul(cls, agent_soul: AgentSoulConfig) -> None:
         dumped = agent_soul.model_dump(mode="json")
+        cls._validate_knowledge_runtime_config(agent_soul)
         cls._reject_plaintext_secrets(dumped, path="agent_soul")
         cls._validate_shell_config(dumped)
+
+    @classmethod
+    def _validate_knowledge_runtime_config(cls, agent_soul: AgentSoulConfig) -> None:
+        """Validate knowledge settings that are required only for publish/run.
+
+        Draft composer saves must be able to persist partially configured
+        knowledge sets while a user is still editing the panel. These checks
+        stay in the publish validator so invalid runtime configs are still
+        blocked before a version can be published or executed.
+        """
+        for knowledge_set in agent_soul.knowledge.sets:
+            if (
+                knowledge_set.query.mode == AgentKnowledgeQueryMode.USER_QUERY
+                and not (knowledge_set.query.value or "").strip()
+            ):
+                raise InvalidComposerConfigError("knowledge query.value is required for user_query mode")
+
+            retrieval = knowledge_set.retrieval
+            if retrieval.mode == "multiple" and retrieval.top_k is None:
+                raise InvalidComposerConfigError("knowledge retrieval.top_k is required for multiple mode")
+            if retrieval.mode == "single" and retrieval.model is None:
+                raise InvalidComposerConfigError("knowledge retrieval.model is required for single mode")
+
+            metadata_filtering = knowledge_set.metadata_filtering
+            if metadata_filtering.mode == "automatic" and metadata_filtering.metadata_model_config is None:
+                raise InvalidComposerConfigError("metadata_filtering.model_config is required for automatic mode")
+            if metadata_filtering.mode == "manual" and (
+                metadata_filtering.conditions is None or not metadata_filtering.conditions.conditions
+            ):
+                raise InvalidComposerConfigError("metadata_filtering.conditions is required for manual mode")
 
     @classmethod
     def validate_node_job(cls, node_job: WorkflowNodeJobConfig) -> None:

--- a/api/tests/unit_tests/services/agent/test_agent_composer_entities.py
+++ b/api/tests/unit_tests/services/agent/test_agent_composer_entities.py
@@ -274,6 +274,16 @@ def test_knowledge_query_mode_uses_stable_backend_enums():
             },
             "knowledge set dataset ids must be unique",
         ),
+    ],
+)
+def test_knowledge_sets_contract_rejects_invalid_configs(knowledge_payload, match: str):
+    with pytest.raises(ValidationError, match=match):
+        AgentSoulConfig.model_validate({"knowledge": knowledge_payload})
+
+
+@pytest.mark.parametrize(
+    ("knowledge_payload", "match"),
+    [
         (
             {
                 "sets": [
@@ -334,9 +344,25 @@ def test_knowledge_query_mode_uses_stable_backend_enums():
         ),
     ],
 )
-def test_knowledge_sets_contract_rejects_invalid_configs(knowledge_payload, match: str):
-    with pytest.raises(ValidationError, match=match):
-        AgentSoulConfig.model_validate({"knowledge": knowledge_payload})
+def test_knowledge_runtime_requirements_block_publish_but_not_draft_save(knowledge_payload, match: str):
+    draft_payload = ComposerSavePayload.model_validate(
+        {
+            "variant": ComposerVariant.AGENT_APP,
+            "save_strategy": ComposerSaveStrategy.SAVE_TO_CURRENT_VERSION,
+            "agent_soul": {"knowledge": knowledge_payload},
+        }
+    )
+    ComposerConfigValidator.validate_draft_save_payload(draft_payload)
+
+    publish_payload = ComposerSavePayload.model_validate(
+        {
+            "variant": ComposerVariant.AGENT_APP,
+            "save_strategy": ComposerSaveStrategy.SAVE_AS_NEW_VERSION,
+            "agent_soul": {"knowledge": knowledge_payload},
+        }
+    )
+    with pytest.raises(InvalidComposerConfigError, match=match):
+        ComposerConfigValidator.validate_publish_payload(publish_payload)
 
 
 def test_agent_soul_model_config_is_first_class_without_credentials():

--- a/api/tests/unit_tests/services/agent/test_agent_services.py
+++ b/api/tests/unit_tests/services/agent/test_agent_services.py
@@ -4257,31 +4257,7 @@ def test_dataset_rows_filters_malformed_ids(monkeypatch: pytest.MonkeyPatch):
     assert captured == {}
 
 
-@pytest.mark.parametrize(
-    ("variant", "save_call"),
-    [
-        (
-            ComposerVariant.AGENT_APP,
-            lambda payload: AgentComposerService.save_agent_app_composer(
-                tenant_id="tenant-1",
-                app_id="app-1",
-                account_id="account-1",
-                payload=payload,
-            ),
-        ),
-        (
-            ComposerVariant.WORKFLOW,
-            lambda payload: AgentComposerService.save_workflow_composer(
-                tenant_id="tenant-1",
-                app_id="app-1",
-                node_id="node-1",
-                account_id="account-1",
-                payload=payload,
-            ),
-        ),
-    ],
-)
-def test_composer_save_rejects_malformed_knowledge_dataset_ids(monkeypatch: pytest.MonkeyPatch, variant, save_call):
+def test_validate_knowledge_datasets_rejects_malformed_ids_without_dataset_lookup(monkeypatch: pytest.MonkeyPatch):
     captured = {"calls": 0}
 
     def fake_get_datasets_by_ids(ids, tenant_id):
@@ -4294,60 +4270,29 @@ def test_composer_save_rejects_malformed_knowledge_dataset_ids(monkeypatch: pyte
 
     monkeypatch.setattr(dataset_service_module.DatasetService, "get_datasets_by_ids", fake_get_datasets_by_ids)
 
-    payload = ComposerSavePayload.model_validate(
+    agent_soul = AgentSoulConfig.model_validate(
         {
-            "variant": variant.value,
-            "save_strategy": ComposerSaveStrategy.SAVE_TO_CURRENT_VERSION.value,
-            "soul_lock": {"locked": False},
-            "agent_soul": {
-                "knowledge": {
-                    "sets": [
-                        {
-                            "id": "support",
-                            "name": "Support KB",
-                            "datasets": [{"id": "not-a-uuid"}],
-                            "query": {"mode": "generated_query"},
-                            "retrieval": {"mode": "multiple", "top_k": 4},
-                        }
-                    ]
-                }
+            "knowledge": {
+                "sets": [
+                    {
+                        "id": "support",
+                        "name": "Support KB",
+                        "datasets": [{"id": "not-a-uuid"}],
+                        "query": {"mode": "generated_query"},
+                        "retrieval": {"mode": "multiple", "top_k": 4},
+                    }
+                ]
             },
         }
     )
 
     with pytest.raises(InvalidComposerConfigError, match="not-a-uuid"):
-        save_call(payload)
+        AgentComposerService.validate_knowledge_datasets(tenant_id="tenant-1", agent_soul=agent_soul)
 
     assert captured == {"calls": 0}
 
 
-@pytest.mark.parametrize(
-    ("variant", "save_call"),
-    [
-        (
-            ComposerVariant.AGENT_APP,
-            lambda payload: AgentComposerService.save_agent_app_composer(
-                tenant_id="tenant-1",
-                app_id="app-1",
-                account_id="account-1",
-                payload=payload,
-            ),
-        ),
-        (
-            ComposerVariant.WORKFLOW,
-            lambda payload: AgentComposerService.save_workflow_composer(
-                tenant_id="tenant-1",
-                app_id="app-1",
-                node_id="node-1",
-                account_id="account-1",
-                payload=payload,
-            ),
-        ),
-    ],
-)
-def test_composer_save_rejects_missing_or_out_of_scope_knowledge_datasets(
-    monkeypatch: pytest.MonkeyPatch, variant, save_call
-):
+def test_validate_knowledge_datasets_rejects_missing_or_out_of_scope_datasets(monkeypatch: pytest.MonkeyPatch):
     captured = {}
     missing_dataset_id = "550e8400-e29b-41d4-a716-446655440000"
 
@@ -4360,20 +4305,70 @@ def test_composer_save_rejects_missing_or_out_of_scope_knowledge_datasets(
 
     monkeypatch.setattr(dataset_service_module.DatasetService, "get_datasets_by_ids", fake_get_datasets_by_ids)
 
+    agent_soul = AgentSoulConfig.model_validate(
+        {
+            "knowledge": {
+                "sets": [
+                    {
+                        "id": "support",
+                        "name": "Support KB",
+                        "datasets": [{"id": missing_dataset_id}],
+                        "query": {"mode": "generated_query"},
+                        "retrieval": {"mode": "multiple", "top_k": 4},
+                    }
+                ]
+            },
+        }
+    )
+
+    with pytest.raises(InvalidComposerConfigError, match=missing_dataset_id):
+        AgentComposerService.validate_knowledge_datasets(tenant_id="tenant-1", agent_soul=agent_soul)
+
+    assert captured == {"ids": [missing_dataset_id], "tenant_id": "tenant-1"}
+
+
+def test_save_agent_composer_allows_incomplete_knowledge_draft(monkeypatch: pytest.MonkeyPatch):
+    agent = SimpleNamespace(
+        id="agent-1",
+        source=AgentSource.AGENT_APP,
+        active_config_snapshot_id="version-1",
+        active_config_is_published=True,
+        updated_by=None,
+    )
+    active_version = SimpleNamespace(config_snapshot_dict=AgentSoulConfig().model_dump(mode="json"))
+    fake_session = FakeSession(scalar=[agent])
+    saved = {}
+
+    import services.dataset_service as dataset_service_module
+
+    monkeypatch.setattr(composer_service.db, "session", fake_session)
+    monkeypatch.setattr(
+        dataset_service_module.DatasetService,
+        "get_datasets_by_ids",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("draft save must skip dataset lookup")),
+    )
+    monkeypatch.setattr(
+        AgentComposerService,
+        "_save_agent_draft",
+        lambda **kwargs: saved.update(kwargs) or SimpleNamespace(id="draft-1"),
+    )
+    monkeypatch.setattr(AgentComposerService, "_get_version_if_present", lambda **_kwargs: active_version)
+    monkeypatch.setattr(AgentComposerService, "load_agent_composer", lambda **_kwargs: {"loaded": True})
+
     payload = ComposerSavePayload.model_validate(
         {
-            "variant": variant.value,
+            "variant": ComposerVariant.AGENT_APP.value,
             "save_strategy": ComposerSaveStrategy.SAVE_TO_CURRENT_VERSION.value,
-            "soul_lock": {"locked": False},
             "agent_soul": {
                 "knowledge": {
                     "sets": [
                         {
                             "id": "support",
                             "name": "Support KB",
-                            "datasets": [{"id": missing_dataset_id}],
+                            "datasets": [{"id": "not-a-uuid"}],
                             "query": {"mode": "generated_query"},
-                            "retrieval": {"mode": "multiple", "top_k": 4},
+                            "retrieval": {"mode": "single"},
+                            "metadata_filtering": {"mode": "automatic"},
                         }
                     ]
                 }
@@ -4381,10 +4376,20 @@ def test_composer_save_rejects_missing_or_out_of_scope_knowledge_datasets(
         }
     )
 
-    with pytest.raises(InvalidComposerConfigError, match=missing_dataset_id):
-        save_call(payload)
+    result = AgentComposerService.save_agent_composer(
+        tenant_id="tenant-1",
+        agent_id="agent-1",
+        account_id="account-1",
+        payload=payload,
+    )
 
-    assert captured == {"ids": [missing_dataset_id], "tenant_id": "tenant-1"}
+    assert result["loaded"] is True
+    assert saved["draft_type"] == AgentConfigDraftType.DRAFT
+    assert saved["agent_soul"].knowledge.sets[0].retrieval.mode == "single"
+    assert saved["agent_soul"].knowledge.sets[0].retrieval.model is None
+    assert saved["agent_soul"].knowledge.sets[0].metadata_filtering.mode == "automatic"
+    assert saved["agent_soul"].knowledge.sets[0].metadata_filtering.metadata_model_config is None
+    assert fake_session.commits == 1
 
 
 def test_workspace_dify_tools_returns_provider_and_tool_granularities(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Summary

- Allow Agent v2 composer draft saves to persist incomplete knowledge config while the user is still editing.
- Move mode-dependent knowledge completeness checks from Agent Soul Pydantic models into publish/runtime validation.
- Keep publish/validate strict: missing `user_query.value`, `single` retrieval model, missing `multiple.top_k`, and automatic/manual metadata filter requirements still block publish/validate.
- Skip tenant dataset existence checks during normal draft/build-draft saves; keep them for publish/save-as-version/save-to-roster paths.

## Dev verification

Deployed `04015f902bd04a2c4addb9c24a8285313deb9b88` to `deploy/agent` and verified `https://agent.dify.dev` is running the new API image.

Real console API flow:

1. `POST /console/api/agent` created test agent `019f357b-7a71-7810-8676-c8e20084b59b`.
2. `PUT /console/api/agent/{agent_id}/composer` with incomplete knowledge config returned `200` and persisted the draft:
   - `retrieval.mode = single`
   - `retrieval.model = null`
   - `metadata_filtering.mode = automatic`
   - `metadata_model_config = null`
   - dataset id intentionally malformed: `not-a-uuid`
3. `GET /console/api/agent/{agent_id}/composer` confirmed the incomplete config was saved.
4. `POST /console/api/agent/{agent_id}/composer/validate` still returned `400` with `knowledge retrieval.model is required for single mode`.

## Local verification

- `uv run --project api --dev pyrefly check api/models/agent_config_entities.py api/services/agent/composer_validator.py api/services/agent/composer_service.py api/tests/unit_tests/services/agent/test_agent_composer_entities.py`
- `uv run --project api --dev python -m py_compile ...`
- Direct Python behavior check for draft-save vs publish validation split.

Note: local targeted pytest still segfaults before test collection in `_pytest/capture.py` while loading native extensions, same as recent agent work. No test assertions run before the crash.
