### PR TITLE
fix(agent): require model before publishing roster agent

### DIFF
--- a/api/services/agent/composer_service.py
+++ b/api/services/agent/composer_service.py
@@ -33,6 +33,7 @@ from models.workflow import Workflow
 from services.agent.agent_soul_state import agent_soul_has_model
 from services.agent.composer_validator import ComposerConfigValidator
 from services.agent.errors import (
+    AgentModelNotConfiguredError,
     AgentNameConflictError,
     AgentNotFoundError,
     AgentVersionConflictError,
@@ -510,6 +511,8 @@ class AgentComposerService:
                 version_note=version_note,
             )
         )
+        if not agent_soul_has_model(agent_soul):
+            raise AgentModelNotConfiguredError()
         cls.validate_knowledge_datasets(tenant_id=tenant_id, agent_soul=agent_soul)
         version = cls._create_config_version(
             tenant_id=tenant_id,

--- a/api/services/agent/errors.py
+++ b/api/services/agent/errors.py
@@ -1,5 +1,7 @@
 from werkzeug.exceptions import BadRequest, Conflict, NotFound
 
+from libs.exception import BaseHTTPException
+
 
 class AgentNotFoundError(NotFound):
     description = "Agent not found."
@@ -19,6 +21,12 @@ class AgentArchivedError(Conflict):
 
 class AgentVersionConflictError(Conflict):
     description = "Agent config version changed. Please reload and try again."
+
+
+class AgentModelNotConfiguredError(BaseHTTPException):
+    error_code = "agent_model_not_configured"
+    description = "Agent App requires the Agent Soul model to be configured."
+    code = 400
 
 
 class AgentSoulLockedError(BadRequest):

--- a/api/tests/unit_tests/services/agent/test_agent_services.py
+++ b/api/tests/unit_tests/services/agent/test_agent_services.py
@@ -36,6 +36,7 @@ from services.agent.agent_soul_state import agent_soul_has_model
 from services.agent.composer_service import AgentComposerService
 from services.agent.composer_validator import ComposerConfigValidator
 from services.agent.errors import (
+    AgentModelNotConfiguredError,
     AgentNameConflictError,
     AgentNotFoundError,
     AgentVersionConflictError,
@@ -574,6 +575,55 @@ def test_save_agent_app_composer_keeps_published_when_draft_matches_active_snaps
 
     assert agent.active_config_is_published is True
     assert fake_session.commits == 1
+
+
+def test_publish_agent_app_draft_rejects_missing_model(monkeypatch: pytest.MonkeyPatch):
+    agent = Agent(
+        id="agent-1",
+        tenant_id="tenant-1",
+        name="Iris",
+        description="",
+        agent_kind=AgentKind.DIFY_AGENT,
+        scope=AgentScope.ROSTER,
+        source=AgentSource.AGENT_APP,
+        status=AgentStatus.ACTIVE,
+        active_config_snapshot_id="version-1",
+        active_config_is_published=False,
+    )
+    draft = AgentConfigDraft(
+        tenant_id="tenant-1",
+        agent_id="agent-1",
+        draft_type=AgentConfigDraftType.DRAFT,
+        draft_owner_key="",
+        base_snapshot_id="version-1",
+        config_snapshot=AgentSoulConfig(),
+    )
+    fake_session = FakeSession(scalar=[agent, draft])
+
+    def fail_create_config_version(**_kwargs):
+        raise AssertionError("config version must not be created when Agent Soul has no model")
+
+    def fail_validate_knowledge_datasets(**_kwargs):
+        raise AssertionError("knowledge datasets must not be validated when Agent Soul has no model")
+
+    monkeypatch.setattr(composer_service.db, "session", fake_session)
+    monkeypatch.setattr(composer_service.ComposerConfigValidator, "validate_publish_payload", lambda payload: None)
+    monkeypatch.setattr(AgentComposerService, "validate_knowledge_datasets", fail_validate_knowledge_datasets)
+    monkeypatch.setattr(AgentComposerService, "_create_config_version", fail_create_config_version)
+
+    with pytest.raises(AgentModelNotConfiguredError) as exc_info:
+        AgentComposerService.publish_agent_app_draft(
+            tenant_id="tenant-1",
+            agent_id="agent-1",
+            account_id="account-1",
+            version_note="ship it",
+        )
+
+    assert exc_info.value.error_code == "agent_model_not_configured"
+    assert agent.active_config_snapshot_id == "version-1"
+    assert agent.active_config_is_published is False
+    assert draft.base_snapshot_id == "version-1"
+    assert fake_session.commits == 0
 
 
 def test_publish_agent_app_draft_creates_published_snapshot(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Summary
- block roster Agent App publish when the Agent Soul has no model configured
- return the stable `agent_model_not_configured` console API error before creating a config version
- add unit coverage for the rejected publish path so active snapshot and publish state stay unchanged

## Verification
- `uv run --project api --dev ruff check api/services/agent/errors.py api/services/agent/composer_service.py api/tests/unit_tests/services/agent/test_agent_services.py`
- `uv run --project api --dev pyrefly check api/services/agent/errors.py api/services/agent/composer_service.py`
- `uv run --project api --dev python -m py_compile api/services/agent/errors.py api/services/agent/composer_service.py api/tests/unit_tests/services/agent/test_agent_services.py`
- Deployed commit `078bed410813be99eb783e3bb483789d4f9ee4fb` to `agent.dify.dev` from `deploy/agent`
- Real console API regression on `agent.dify.dev`: create roster Agent without model, publish returns 400 `agent_model_not_configured`, versions remain unchanged, `active_config_snapshot_id` remains null, `active_config_is_published` remains false

Note: local pytest runner still exits with code 139 during startup in this workstation environment, before collecting the targeted tests. The new guard path was additionally verified by direct service invocation locally and by real HTTPS console API on dev.
