### PR TITLE
fix(agent): pass workflow files to agent node runtime

### DIFF
--- a/api/core/workflow/nodes/agent_v2/runtime_request_builder.py
+++ b/api/core/workflow/nodes/agent_v2/runtime_request_builder.py
@@ -48,7 +48,7 @@ from clients.agent_backend import (
 )
 from configs import dify_config
 from core.app.entities.app_invoke_entities import DifyRunContext, InvokeFrom
-from core.workflow.system_variables import SystemVariableKey, get_system_text
+from core.workflow.system_variables import SystemVariableKey, get_system_text, get_system_value
 from graphon.file import File, FileTransferMethod
 from graphon.variables.segments import Segment
 from models.agent import Agent, AgentConfigSnapshot, WorkflowAgentNodeBinding
@@ -354,16 +354,21 @@ class WorkflowAgentRuntimeRequestBuilder:
     ) -> str:
         lines: list[str] = []
         query = get_system_text(context.variable_pool, SystemVariableKey.QUERY)
+        uploaded_files = self._summarize_uploaded_workflow_files(context.variable_pool)
         resolved_outputs = self._resolve_previous_node_outputs(
             context.variable_pool,
             node_job.previous_node_output_refs,
         )
-        if not query and not resolved_outputs:
+        if not query and uploaded_files is None and not resolved_outputs:
             return ""
 
         lines.append("Workflow context loaded for this run:")
         if query:
             lines.append(f"- User query: {query}")
+
+        if uploaded_files is not None:
+            lines.append("- Uploaded workflow files:")
+            lines.append(f"  - sys.files: {uploaded_files}")
 
         if resolved_outputs:
             lines.append("- Previous node outputs:")
@@ -372,6 +377,14 @@ class WorkflowAgentRuntimeRequestBuilder:
 
         lines.append("The above workflow context is run-specific. Do not treat it as Agent Soul or persistent memory.")
         return "\n".join(lines)
+
+    def _summarize_uploaded_workflow_files(self, variable_pool: VariablePoolReader) -> str | None:
+        files = get_system_value(variable_pool, SystemVariableKey.FILES)
+        if files is None:
+            return None
+        if isinstance(files, list | tuple) and not files:
+            return None
+        return self._summarize_value(files)
 
     def _build_workflow_task_prompt(
         self,

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_runtime_request_builder.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_runtime_request_builder.py
@@ -227,6 +227,15 @@ def _previous_node_prompt_payload(result, selector: str) -> object:
     raise AssertionError(f"missing prompt payload for {selector}")
 
 
+def _uploaded_workflow_files_prompt_payload(result) -> object:
+    prefix = "  - sys.files: "
+    user_prompt = _workflow_user_prompt(result)
+    for line in user_prompt.splitlines():
+        if line.startswith(prefix):
+            return json.loads(line.removeprefix(prefix))
+    raise AssertionError("missing prompt payload for sys.files")
+
+
 def test_builds_create_run_request_from_agent_soul_and_node_job():
     result = WorkflowAgentRuntimeRequestBuilder(credentials_provider=FakeCredentialsProvider()).build(_context())
 
@@ -1250,6 +1259,48 @@ def test_previous_node_file_array_uses_agent_stub_download_mappings_in_workflow_
             "url": "https://example.com/second.pdf",
         },
     ]
+
+
+def test_uploaded_workflow_files_are_included_without_prompt_marker():
+    file_reference = build_file_reference(record_id="uploaded-file-1")
+
+    class UploadedFilesVariablePool(FakeVariablePool):
+        def get(self, selector):
+            if list(selector) == ["sys", "files"]:
+                return ArrayFileSegment(
+                    value=[
+                        File(
+                            type=FileType.DOCUMENT,
+                            transfer_method=FileTransferMethod.LOCAL_FILE,
+                            reference=file_reference,
+                            remote_url=None,
+                            filename="requirements.pdf",
+                            extension=".pdf",
+                            mime_type="application/pdf",
+                            size=12,
+                        )
+                    ]
+                )
+            return super().get(selector)
+
+    context = replace(_context(), variable_pool=UploadedFilesVariablePool())
+    context.binding.node_job_config = WorkflowNodeJobConfig.model_validate(
+        {
+            "workflow_prompt": "Answer the user's question.",
+        }
+    )
+
+    result = WorkflowAgentRuntimeRequestBuilder(credentials_provider=FakeCredentialsProvider()).build(context)
+
+    user_prompt = _workflow_user_prompt(result)
+    assert "- Uploaded workflow files:" in user_prompt
+    assert _uploaded_workflow_files_prompt_payload(result) == [
+        {
+            "transfer_method": "local_file",
+            "reference": file_reference,
+        }
+    ]
+    assert "Previous node outputs:" not in user_prompt
 
 
 def test_previous_node_remote_url_file_mapping_is_not_truncated_in_workflow_context():

--- a/web/app/components/workflow/nodes/agent-v2/__tests__/default.spec.ts
+++ b/web/app/components/workflow/nodes/agent-v2/__tests__/default.spec.ts
@@ -101,6 +101,10 @@ describe('agent/default', () => {
     })
   })
 
+  it('reuses the legacy agent node help document', () => {
+    expect(nodeDefault.metaData.helpLinkUri).toBe('agent')
+  })
+
   it('identifies version 2 agent data as Agent v2', () => {
     expect(isAgentV2NodeData(createPayload({ type: BlockEnum.Agent }))).toBe(true)
     expect(isAgentV2NodeData({

--- a/web/app/components/workflow/nodes/agent-v2/default.ts
+++ b/web/app/components/workflow/nodes/agent-v2/default.ts
@@ -7,6 +7,7 @@ import { hasValidAgentBinding } from './types'
 const metaData = genNodeMetaData({
   sort: 3,
   type: BlockEnum.AgentV2,
+  helpLinkUri: 'agent',
 })
 
 const nodeDefault: NodeDefault<AgentV2NodeType> = {


### PR DESCRIPTION
## Summary\n- include workflow uploaded sys.files in Agent v2 workflow context prompt\n- serialize uploaded workflow files with the existing agent file mapping format\n- add unit coverage for sys.files without explicit prompt markers\n\n## Verification\n- uv run --project api --dev ruff check api/core/workflow/nodes/agent_v2/runtime_request_builder.py api/tests/unit_tests/core/workflow/nodes/agent_v2/test_runtime_request_builder.py\n- uv run --project api --dev ruff format --check api/core/workflow/nodes/agent_v2/runtime_request_builder.py api/tests/unit_tests/core/workflow/nodes/agent_v2/test_runtime_request_builder.py\n- git diff --check origin/feat/agent-v2...HEAD\n- dev E2E on https://agent.dify.dev: created workflow app, configured inline Agent v2 with OpenAI gpt-5.5, uploaded local file, ran draft workflow Start -> Agent v2 -> End; workflow succeeded and Agent returned FILE_SEEN with dify-file-ref\n\nNote: local pytest crashes before test collection in the existing api/.venv gevent import path (segmentation fault in _pytest/capture.py); not a test assertion failure.