### PR TITLE
fix: return friendly error for unpublished agent app

### DIFF
--- a/api/controllers/common/agent_app_parameters.py
+++ b/api/controllers/common/agent_app_parameters.py
@@ -1,0 +1,51 @@
+from typing import Any, cast
+
+from sqlalchemy import select
+
+from core.app.apps.agent_app.app_variable_projection import agent_app_variables_to_user_input_form
+from core.app.apps.agent_app.errors import AgentAppGeneratorError, AgentAppNotPublishedError
+from extensions.ext_database import db
+from models.agent import Agent, AgentConfigSnapshot, AgentStatus
+from models.agent_config_entities import AgentSoulConfig
+from models.model import App
+
+
+def get_published_agent_app_feature_dict_and_user_input_form(
+    app_model: App,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Return public Agent App parameters backed by the published Agent Soul."""
+    app_model_config = app_model.app_model_config
+    features_dict = cast(dict[str, Any], app_model_config.to_dict()) if app_model_config is not None else {}
+
+    agent_id = app_model.bound_agent_id
+    if not agent_id:
+        raise AgentAppGeneratorError("Agent App has no bound Agent")
+
+    agent = db.session.scalar(
+        select(Agent)
+        .where(
+            Agent.tenant_id == app_model.tenant_id,
+            Agent.id == agent_id,
+            Agent.status == AgentStatus.ACTIVE,
+        )
+        .limit(1)
+    )
+    if agent is None:
+        raise AgentAppGeneratorError("Agent App has no bound Agent")
+    if not agent.active_config_snapshot_id or not agent.active_config_is_published:
+        raise AgentAppNotPublishedError("Agent has not been published")
+
+    snapshot = db.session.scalar(
+        select(AgentConfigSnapshot)
+        .where(
+            AgentConfigSnapshot.tenant_id == app_model.tenant_id,
+            AgentConfigSnapshot.agent_id == agent.id,
+            AgentConfigSnapshot.id == agent.active_config_snapshot_id,
+        )
+        .limit(1)
+    )
+    if snapshot is None:
+        raise AgentAppGeneratorError("Agent published version not found")
+
+    agent_soul = AgentSoulConfig.model_validate(snapshot.config_snapshot_dict)
+    return features_dict, agent_app_variables_to_user_input_form(agent_soul.app_variables)

--- a/api/controllers/service_api/app/app.py
+++ b/api/controllers/service_api/app/app.py
@@ -2,19 +2,16 @@ from typing import Any, cast
 
 from flask_restx import Resource
 from pydantic import Field
-from sqlalchemy import select
 
+from controllers.common.agent_app_parameters import get_published_agent_app_feature_dict_and_user_input_form
 from controllers.common.fields import Parameters
 from controllers.common.schema import register_response_schema_models
 from controllers.service_api import service_api_ns
-from controllers.service_api.app.error import AppUnavailableError
+from controllers.service_api.app.error import AgentNotPublishedError, AppUnavailableError
 from controllers.service_api.wraps import validate_app_token
 from core.app.app_config.common.parameters_mapping import get_parameters_from_feature_dict
-from core.app.apps.agent_app.app_variable_projection import agent_app_variables_to_user_input_form
-from extensions.ext_database import db
+from core.app.apps.agent_app.errors import AgentAppGeneratorError, AgentAppNotPublishedError
 from fields.base import ResponseModel
-from models.agent import Agent, AgentConfigSnapshot, AgentScope, AgentSource, AgentStatus
-from models.agent_config_entities import AgentSoulConfig
 from models.model import App, AppMode
 from services.app_service import AppService
 
@@ -35,37 +32,12 @@ register_response_schema_models(service_api_ns, Parameters, AppMetaResponse, App
 
 
 def _get_agent_app_feature_dict_and_user_input_form(app_model: App) -> tuple[dict[str, Any], list[dict[str, Any]]]:
-    app_model_config = app_model.app_model_config
-    features_dict = cast(dict[str, Any], app_model_config.to_dict()) if app_model_config is not None else {}
-
-    agent = db.session.scalar(
-        select(Agent)
-        .where(
-            Agent.tenant_id == app_model.tenant_id,
-            Agent.app_id == app_model.id,
-            Agent.scope == AgentScope.ROSTER,
-            Agent.source == AgentSource.AGENT_APP,
-            Agent.status == AgentStatus.ACTIVE,
-        )
-        .limit(1)
-    )
-    if agent is None or not agent.active_config_snapshot_id:
+    try:
+        return get_published_agent_app_feature_dict_and_user_input_form(app_model)
+    except AgentAppNotPublishedError:
+        raise AgentNotPublishedError()
+    except AgentAppGeneratorError:
         raise AppUnavailableError()
-
-    snapshot = db.session.scalar(
-        select(AgentConfigSnapshot)
-        .where(
-            AgentConfigSnapshot.tenant_id == app_model.tenant_id,
-            AgentConfigSnapshot.agent_id == agent.id,
-            AgentConfigSnapshot.id == agent.active_config_snapshot_id,
-        )
-        .limit(1)
-    )
-    if snapshot is None:
-        raise AppUnavailableError()
-
-    agent_soul = AgentSoulConfig.model_validate(snapshot.config_snapshot_dict)
-    return features_dict, agent_app_variables_to_user_input_form(agent_soul.app_variables)
 
 
 @service_api_ns.route("/parameters")

--- a/api/controllers/service_api/app/completion.py
+++ b/api/controllers/service_api/app/completion.py
@@ -15,6 +15,7 @@ from controllers.common.schema import register_response_schema_models, register_
 from controllers.console.app.wraps import with_session
 from controllers.service_api import service_api_ns
 from controllers.service_api.app.error import (
+    AgentNotPublishedError,
     AppUnavailableError,
     CompletionRequestError,
     ConversationCompletedError,
@@ -31,6 +32,7 @@ from controllers.service_api.schema import (
 )
 from controllers.service_api.wraps import FetchUserArg, WhereisUserArg, validate_app_token
 from controllers.web.error import InvokeRateLimitError as InvokeRateLimitHttpError
+from core.app.apps.agent_app.errors import AgentAppNotPublishedError
 from core.app.entities.app_invoke_entities import InvokeFrom
 from core.errors.error import (
     ModelCurrentlyNotSupportError,
@@ -248,6 +250,8 @@ class CompletionApi(Resource):
         except services.errors.app_model_config.AppModelConfigBrokenError:
             logger.exception("App model config broken.")
             raise AppUnavailableError()
+        except AgentAppNotPublishedError:
+            raise AgentNotPublishedError()
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)
         except QuotaExceededError:
@@ -403,6 +407,8 @@ class ChatApi(Resource):
         except services.errors.app_model_config.AppModelConfigBrokenError:
             logger.exception("App model config broken.")
             raise AppUnavailableError()
+        except AgentAppNotPublishedError:
+            raise AgentNotPublishedError()
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)
         except QuotaExceededError:

--- a/api/controllers/service_api/app/error.py
+++ b/api/controllers/service_api/app/error.py
@@ -7,6 +7,12 @@ class AppUnavailableError(BaseHTTPException):
     code = 400
 
 
+class AgentNotPublishedError(BaseHTTPException):
+    error_code = "agent_not_published"
+    description = "Agent has not been published. Please publish the Agent before using the API."
+    code = 400
+
+
 class NotCompletionAppError(BaseHTTPException):
     error_code = "not_completion_app"
     description = "Please check if your Completion app mode matches the right API route."

--- a/api/controllers/web/app.py
+++ b/api/controllers/web/app.py
@@ -8,8 +8,10 @@ from werkzeug.exceptions import Unauthorized
 
 from constants import HEADER_NAME_APP_CODE
 from controllers.common import fields
+from controllers.common.agent_app_parameters import get_published_agent_app_feature_dict_and_user_input_form
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from core.app.app_config.common.parameters_mapping import get_parameters_from_feature_dict
+from core.app.apps.agent_app.errors import AgentAppGeneratorError, AgentAppNotPublishedError
 from libs.passport import PassportService
 from libs.token import extract_webapp_passport
 from models.model import App, AppMode, EndUser
@@ -19,7 +21,7 @@ from services.feature_service import FeatureService
 from services.webapp_auth_service import WebAppAuthService
 
 from . import web_ns
-from .error import AppUnavailableError
+from .error import AgentNotPublishedError, AppUnavailableError
 from .wraps import WebApiResource
 
 logger = logging.getLogger(__name__)
@@ -74,12 +76,21 @@ class AppParameterApi(WebApiResource):
     @web_ns.response(200, "Success", web_ns.models[fields.Parameters.__name__])
     def get(self, app_model: App, end_user: EndUser):
         """Retrieve app parameters."""
-        if app_model.mode in {AppMode.ADVANCED_CHAT, AppMode.WORKFLOW}:
+        features_dict: dict[str, Any]
+        user_input_form: list[dict[str, Any]]
+        if app_model.mode == AppMode.AGENT:
+            try:
+                features_dict, user_input_form = get_published_agent_app_feature_dict_and_user_input_form(app_model)
+            except AgentAppNotPublishedError:
+                raise AgentNotPublishedError()
+            except AgentAppGeneratorError:
+                raise AppUnavailableError()
+        elif app_model.mode in {AppMode.ADVANCED_CHAT, AppMode.WORKFLOW}:
             workflow = app_model.workflow
             if workflow is None:
                 raise AppUnavailableError()
 
-            features_dict: dict[str, Any] = workflow.features_dict
+            features_dict = workflow.features_dict
             user_input_form = workflow.user_input_form(to_old_structure=True)
         else:
             app_model_config = app_model.app_model_config

--- a/api/controllers/web/completion.py
+++ b/api/controllers/web/completion.py
@@ -11,6 +11,7 @@ from controllers.common.schema import register_response_schema_models, register_
 from controllers.console.app.wraps import with_session
 from controllers.web import web_ns
 from controllers.web.error import (
+    AgentNotPublishedError,
     AppUnavailableError,
     CompletionRequestError,
     ConversationCompletedError,
@@ -22,6 +23,7 @@ from controllers.web.error import (
 )
 from controllers.web.error import InvokeRateLimitError as InvokeRateLimitHttpError
 from controllers.web.wraps import WebApiResource
+from core.app.apps.agent_app.errors import AgentAppNotPublishedError
 from core.app.entities.app_invoke_entities import InvokeFrom
 from core.errors.error import (
     ModelCurrentlyNotSupportError,
@@ -138,6 +140,8 @@ class CompletionApi(WebApiResource):
         except services.errors.app_model_config.AppModelConfigBrokenError:
             logger.exception("App model config broken.")
             raise AppUnavailableError()
+        except AgentAppNotPublishedError:
+            raise AgentNotPublishedError()
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)
         except QuotaExceededError:
@@ -235,6 +239,8 @@ class ChatApi(WebApiResource):
         except services.errors.app_model_config.AppModelConfigBrokenError:
             logger.exception("App model config broken.")
             raise AppUnavailableError()
+        except AgentAppNotPublishedError:
+            raise AgentNotPublishedError()
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)
         except QuotaExceededError:

--- a/api/controllers/web/error.py
+++ b/api/controllers/web/error.py
@@ -7,6 +7,12 @@ class AppUnavailableError(BaseHTTPException):
     code = 400
 
 
+class AgentNotPublishedError(BaseHTTPException):
+    error_code = "agent_not_published"
+    description = "Agent has not been published. Please publish the Agent before using the web app."
+    code = 400
+
+
 class NotCompletionAppError(BaseHTTPException):
     error_code = "not_completion_app"
     description = "Please check if your Completion app mode matches the right API route."

--- a/api/core/app/apps/agent_app/app_generator.py
+++ b/api/core/app/apps/agent_app/app_generator.py
@@ -32,6 +32,7 @@ from constants import UUID_NIL
 from core.app.app_config.easy_ui_based_app.model_config.converter import ModelConfigConverter
 from core.app.apps.agent_app.app_config_manager import AgentAppConfigManager
 from core.app.apps.agent_app.app_runner import AgentAppRunner
+from core.app.apps.agent_app.errors import AgentAppGeneratorError, AgentAppNotPublishedError
 from core.app.apps.agent_app.generate_response_converter import AgentAppGenerateResponseConverter
 from core.app.apps.agent_app.runtime_request_builder import AgentAppRuntimeRequestBuilder
 from core.app.apps.agent_app.session_store import AgentAppRuntimeSessionStore
@@ -62,10 +63,6 @@ from models.agent_config_entities import AgentSoulConfig
 from services.conversation_service import ConversationService
 
 logger = logging.getLogger(__name__)
-
-
-class AgentAppGeneratorError(ValueError):
-    """Raised when an Agent App turn cannot be set up."""
 
 
 def _append_prompt_file_mappings(query: str, prompt_file_mappings: Sequence[JsonValue]) -> str:
@@ -614,6 +611,8 @@ class AgentAppGenerator(MessageBasedAppGenerator):
                 "build_draft" if draft.draft_type == AgentConfigDraftType.DEBUG_BUILD else "draft"
             )
             return agent, draft.id, config_version_kind, agent_soul
+        if not agent.active_config_snapshot_id or not agent.active_config_is_published:
+            raise AgentAppNotPublishedError("Agent has not been published")
         _, snapshot, agent_soul = self._resolve_agent_by_id(
             tenant_id=app_model.tenant_id,
             agent_id=agent.id,
@@ -709,4 +708,4 @@ class AgentAppGenerator(MessageBasedAppGenerator):
         return agent, draft, agent_soul
 
 
-__all__ = ["AgentAppGenerator", "AgentAppGeneratorError"]
+__all__ = ["AgentAppGenerator", "AgentAppGeneratorError", "AgentAppNotPublishedError"]

--- a/api/core/app/apps/agent_app/errors.py
+++ b/api/core/app/apps/agent_app/errors.py
@@ -1,0 +1,6 @@
+class AgentAppGeneratorError(ValueError):
+    """Raised when an Agent App turn cannot be set up."""
+
+
+class AgentAppNotPublishedError(AgentAppGeneratorError):
+    """Raised when a public Agent App runtime is requested before publish."""

--- a/api/tests/unit_tests/controllers/openapi/test_error_contract.py
+++ b/api/tests/unit_tests/controllers/openapi/test_error_contract.py
@@ -35,6 +35,7 @@ from controllers.openapi._errors import (
     RecipientSurfaceMismatch,
 )
 from controllers.service_api.app.error import (
+    AgentNotPublishedError,
     AppUnavailableError,
     CompletionRequestError,
     ConversationCompletedError,
@@ -306,6 +307,7 @@ ERROR_MATRIX = [
     (InternalServerError(), 500, "internal_server_error"),
     (BadGateway("x"), 502, "bad_gateway"),
     (AppUnavailableError(), 400, "app_unavailable"),
+    (AgentNotPublishedError(), 400, "agent_not_published"),
     (ConversationCompletedError(), 400, "conversation_completed"),
     (ProviderNotInitializeError(), 400, "provider_not_initialize"),
     (ProviderQuotaExceededError(), 400, "provider_quota_exceeded"),

--- a/api/tests/unit_tests/controllers/service_api/app/test_app.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_app.py
@@ -9,7 +9,8 @@ import pytest
 from flask import Flask
 
 from controllers.service_api.app.app import AppInfoApi, AppMetaApi, AppParameterApi
-from controllers.service_api.app.error import AppUnavailableError
+from controllers.service_api.app.error import AgentNotPublishedError, AppUnavailableError
+from core.app.apps.agent_app.errors import AgentAppNotPublishedError
 from models.account import TenantStatus
 from models.model import App, AppMode
 from tests.unit_tests.conftest import setup_mock_tenant_owner_execute_result
@@ -184,6 +185,41 @@ class TestAppParameterApi:
             {"text-input": {"label": "topic", "variable": "topic", "required": True}}
         ]
         mock_get_agent_parameters.assert_called_once_with(mock_app_model)
+
+    @patch("controllers.service_api.wraps.user_logged_in")
+    @patch("controllers.service_api.wraps.current_app")
+    @patch("controllers.service_api.wraps.validate_and_get_api_token")
+    @patch("controllers.service_api.wraps.db")
+    @patch(
+        "controllers.service_api.app.app.get_published_agent_app_feature_dict_and_user_input_form",
+        side_effect=AgentAppNotPublishedError("Agent has not been published"),
+    )
+    def test_get_parameters_for_unpublished_agent_app_raises_friendly_error(
+        self,
+        mock_get_agent_parameters,
+        mock_db,
+        mock_validate_token,
+        mock_current_app,
+        mock_user_logged_in,
+        app: Flask,
+        mock_app_model,
+    ):
+        _configure_current_app_mock(mock_current_app)
+
+        mock_app_model.mode = AppMode.AGENT
+        mock_api_token = Mock()
+        mock_api_token.app_id = mock_app_model.id
+        mock_api_token.tenant_id = mock_app_model.tenant_id
+        mock_validate_token.return_value = mock_api_token
+
+        mock_tenant = Mock()
+        mock_tenant.status = TenantStatus.NORMAL
+        mock_db.session.get.side_effect = [mock_app_model, mock_tenant]
+        setup_mock_tenant_owner_execute_result(mock_db, mock_tenant, Mock(current_tenant=mock_tenant))
+
+        with app.test_request_context("/parameters", method="GET", headers={"Authorization": "Bearer test_token"}):
+            with pytest.raises(AgentNotPublishedError):
+                AppParameterApi().get()
 
     @patch("controllers.service_api.wraps.user_logged_in")
     @patch("controllers.service_api.wraps.current_app")

--- a/api/tests/unit_tests/controllers/service_api/app/test_completion.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_completion.py
@@ -31,10 +31,12 @@ from controllers.service_api.app.completion import (
     CompletionStopApi,
 )
 from controllers.service_api.app.error import (
+    AgentNotPublishedError,
     AppUnavailableError,
     ConversationCompletedError,
     NotChatAppError,
 )
+from core.app.apps.agent_app.errors import AgentAppNotPublishedError
 from core.errors.error import QuotaExceededError
 from graphon.model_runtime.errors.invoke import InvokeError
 from models.model import App, AppMode, EndUser
@@ -514,6 +516,24 @@ class TestChatApiController:
 
         with app.test_request_context("/chat-messages", method="POST", json={"inputs": {}, "query": "hi"}):
             with pytest.raises(BadRequest):
+                handler(api, session=Mock(), app_model=app_model, end_user=end_user)
+
+    def test_agent_not_published_error_mapped(self, app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            AppGenerateService,
+            "generate",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AgentAppNotPublishedError("Agent has not been published")
+            ),
+        )
+
+        api = ChatApi()
+        handler = unwrap(api.post)
+        app_model = SimpleNamespace(mode=AppMode.AGENT.value)
+        end_user = SimpleNamespace()
+
+        with app.test_request_context("/chat-messages", method="POST", json={"inputs": {}, "query": "hi"}):
+            with pytest.raises(AgentNotPublishedError):
                 handler(api, session=Mock(), app_model=app_model, end_user=end_user)
 
 

--- a/api/tests/unit_tests/controllers/web/test_app.py
+++ b/api/tests/unit_tests/controllers/web/test_app.py
@@ -9,7 +9,8 @@ import pytest
 from flask import Flask
 
 from controllers.web.app import AppAccessMode, AppMeta, AppParameterApi, AppWebAuthPermission
-from controllers.web.error import AppUnavailableError
+from controllers.web.error import AgentNotPublishedError, AppUnavailableError
+from core.app.apps.agent_app.errors import AgentAppNotPublishedError
 
 
 # ---------------------------------------------------------------------------
@@ -78,6 +79,18 @@ class TestAppParameterApi:
         app_model = SimpleNamespace(mode="chat", app_model_config=None)
         with app.test_request_context("/parameters"):
             with pytest.raises(AppUnavailableError):
+                AppParameterApi().get(app_model, SimpleNamespace())
+
+    def test_agent_mode_unpublished_raises_friendly_error(self, app: Flask) -> None:
+        app_model = SimpleNamespace(mode="agent")
+        with (
+            app.test_request_context("/parameters"),
+            patch(
+                "controllers.web.app.get_published_agent_app_feature_dict_and_user_input_form",
+                side_effect=AgentAppNotPublishedError("Agent has not been published"),
+            ),
+        ):
+            with pytest.raises(AgentNotPublishedError):
                 AppParameterApi().get(app_model, SimpleNamespace())
 
 

--- a/api/tests/unit_tests/controllers/web/test_completion.py
+++ b/api/tests/unit_tests/controllers/web/test_completion.py
@@ -10,6 +10,7 @@ from flask import Flask
 
 from controllers.web.completion import ChatApi, ChatStopApi, CompletionApi, CompletionStopApi
 from controllers.web.error import (
+    AgentNotPublishedError,
     CompletionRequestError,
     NotChatAppError,
     NotCompletionAppError,
@@ -17,6 +18,7 @@ from controllers.web.error import (
     ProviderNotInitializeError,
     ProviderQuotaExceededError,
 )
+from core.app.apps.agent_app.errors import AgentAppNotPublishedError
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from graphon.model_runtime.errors.invoke import InvokeError
 
@@ -141,6 +143,19 @@ class TestChatApi:
         with app.test_request_context("/chat-messages", method="POST"):
             with pytest.raises(CompletionRequestError):
                 ChatApi().post(_chat_app(), _end_user())
+
+    @patch(
+        "controllers.web.completion.AppGenerateService.generate",
+        side_effect=AgentAppNotPublishedError("Agent has not been published"),
+    )
+    @patch("controllers.web.completion.web_ns")
+    def test_agent_not_published_error_mapped(self, mock_ns: MagicMock, mock_gen: MagicMock, app: Flask) -> None:
+        mock_ns.payload = {"inputs": {}, "query": "x"}
+        app_model = SimpleNamespace(id="app-1", mode="agent")
+
+        with app.test_request_context("/chat-messages", method="POST"):
+            with pytest.raises(AgentNotPublishedError):
+                ChatApi().post(app_model, _end_user())
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/unit_tests/controllers/web/test_error.py
+++ b/api/tests/unit_tests/controllers/web/test_error.py
@@ -6,6 +6,7 @@ import pytest
 
 from controllers.common.errors import InvalidArgumentError, NotFoundError
 from controllers.web.error import (
+    AgentNotPublishedError,
     AppMoreLikeThisDisabledError,
     AppSuggestedQuestionsAfterAnswerDisabledError,
     AppUnavailableError,
@@ -29,6 +30,7 @@ from controllers.web.error import (
 
 _ERROR_SPECS: list[tuple[type, str, int]] = [
     (AppUnavailableError, "app_unavailable", 400),
+    (AgentNotPublishedError, "agent_not_published", 400),
     (NotCompletionAppError, "not_completion_app", 400),
     (NotChatAppError, "not_chat_app", 400),
     (NotWorkflowAppError, "not_workflow_app", 400),

--- a/api/tests/unit_tests/core/app/apps/agent_app/test_resolve_agent.py
+++ b/api/tests/unit_tests/core/app/apps/agent_app/test_resolve_agent.py
@@ -13,7 +13,7 @@ from typing import Any
 import pytest
 
 from core.app.apps.agent_app import app_generator as gen_mod
-from core.app.apps.agent_app.app_generator import AgentAppGenerator, AgentAppGeneratorError
+from core.app.apps.agent_app.app_generator import AgentAppGenerator, AgentAppGeneratorError, AgentAppNotPublishedError
 from core.app.entities.app_invoke_entities import InvokeFrom
 
 _SOUL_DICT = {
@@ -78,7 +78,7 @@ class TestResolveAgentById:
 
 class TestResolveAgent:
     def test_success_chains_to_resolve_by_id(self, monkeypatch: pytest.MonkeyPatch):
-        bound_agent = SimpleNamespace(id="agent-1", active_config_snapshot_id="snap-1")
+        bound_agent = SimpleNamespace(id="agent-1", active_config_snapshot_id="snap-1", active_config_is_published=True)
         inner_agent = SimpleNamespace(id="agent-1")
         snapshot = _snapshot()
         # scalar order: bound agent (in _resolve_agent), then agent + snapshot (in _resolve_agent_by_id)
@@ -96,6 +96,23 @@ class TestResolveAgent:
         assert config_id == snapshot.id
         assert config_version_kind == "snapshot"
         assert soul.model is not None
+
+    def test_unpublished_agent_raises_before_model_resolution(self, monkeypatch: pytest.MonkeyPatch):
+        bound_agent = SimpleNamespace(
+            id="agent-1",
+            active_config_snapshot_id="snap-1",
+            active_config_is_published=False,
+        )
+        _patch_session(monkeypatch, [bound_agent])
+        app_model = SimpleNamespace(id="app-1", tenant_id="t1")
+
+        with pytest.raises(AgentAppNotPublishedError, match="not been published"):
+            AgentAppGenerator()._resolve_agent(
+                app_model,
+                invoke_from=InvokeFrom.WEB_APP,
+                draft_type=None,
+                user=SimpleNamespace(id="user-1"),
+            )  # type: ignore[arg-type]
 
     def test_unbound_app_raises(self, monkeypatch: pytest.MonkeyPatch):
         _patch_session(monkeypatch, [None])


### PR DESCRIPTION
## Summary

- Return a dedicated `agent_not_published` error when an Agent App is opened through webapp/service API before publish.
- Guard both parameters and runtime message endpoints before resolving the empty Agent Soul model.
- Share Agent App parameter projection between web and service API so hidden backing apps and roster-backed apps use the same published snapshot path.

## Root Cause

Unpublished Agent Apps have an active config snapshot, but `active_config_is_published=false` and the snapshot can contain an empty Agent Soul. Public webapp/runtime paths were resolving that empty snapshot and later failed with `model is required`, which surfaced an unfriendly error to users.

## Testing

- `python -m compileall -q` on touched production files
- `git diff --check origin/feat/agent-v2...HEAD`
- `uv run --project api --dev ruff check <touched files>`
- `./dev/pyrefly-check-local <touched production files>`
- Deployed commit `622b3b5ee0` to `deploy/agent` and verified on dev:
  - Created a new unpublished Agent App.
  - Enabled its webapp site.
  - `GET https://agent-app.dify.dev/api/parameters` returns `400 agent_not_published`.
  - `POST https://agent-app.dify.dev/api/chat-messages` returns `400 agent_not_published`.
  - Response no longer contains `model is required`.

Note: local full pytest currently exits with code 139 before tests execute during pytest capture/conftest loading, unrelated to these touched files.
