### PR TITLE
fix(agent): use soul file upload for app parameters

### DIFF
--- a/api/controllers/common/agent_app_parameters.py
+++ b/api/controllers/common/agent_app_parameters.py
@@ -1,7 +1,8 @@
-from typing import Any, cast
+from typing import Any
 
 from sqlalchemy import select
 
+from core.app.apps.agent_app.app_feature_projection import merge_agent_app_features
 from core.app.apps.agent_app.app_variable_projection import agent_app_variables_to_user_input_form
 from core.app.apps.agent_app.errors import AgentAppGeneratorError, AgentAppNotPublishedError
 from extensions.ext_database import db
@@ -15,7 +16,6 @@ def get_published_agent_app_feature_dict_and_user_input_form(
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     """Return public Agent App parameters backed by the published Agent Soul."""
     app_model_config = app_model.app_model_config
-    features_dict = cast(dict[str, Any], app_model_config.to_dict()) if app_model_config is not None else {}
 
     agent_id = app_model.bound_agent_id
     if not agent_id:
@@ -48,4 +48,5 @@ def get_published_agent_app_feature_dict_and_user_input_form(
         raise AgentAppGeneratorError("Agent published version not found")
 
     agent_soul = AgentSoulConfig.model_validate(snapshot.config_snapshot_dict)
+    features_dict = merge_agent_app_features(agent_soul=agent_soul, app_model_config=app_model_config)
     return features_dict, agent_app_variables_to_user_input_form(agent_soul.app_variables)

--- a/api/core/app/apps/agent_app/app_config_manager.py
+++ b/api/core/app/apps/agent_app/app_config_manager.py
@@ -21,6 +21,7 @@ from core.app.app_config.entities import (
     EasyUIBasedAppModelConfigFrom,
     PromptTemplateEntity,
 )
+from core.app.apps.agent_app.app_feature_projection import merge_agent_app_features
 from core.app.apps.agent_app.app_variable_projection import agent_app_variables_to_user_input_form
 from models.agent_config_entities import AgentSoulConfig
 from models.model import App, AppMode, AppModelConfig, AppModelConfigDict, Conversation
@@ -83,10 +84,7 @@ class AgentAppConfigManager(BaseAppConfigManager):
         ``app_model_config`` when one exists; model + prompt always come from
         the Agent Soul (the single source of truth for those).
         """
-        base: dict[str, Any] = dict(app_model_config.to_dict()) if app_model_config else {}
-        soul_features = agent_soul.app_features.model_dump(mode="json", exclude_none=True)
-        for key, value in soul_features.items():
-            base.setdefault(key, value)
+        base = merge_agent_app_features(agent_soul=agent_soul, app_model_config=app_model_config)
 
         model = agent_soul.model
         if model is not None:

--- a/api/core/app/apps/agent_app/app_feature_projection.py
+++ b/api/core/app/apps/agent_app/app_feature_projection.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+from models.agent_config_entities import AgentSoulConfig
+
+
+def merge_agent_app_features(
+    *,
+    agent_soul: AgentSoulConfig,
+    app_model_config: Any | None,
+) -> dict[str, Any]:
+    """Project public Agent App features from legacy config plus Agent Soul.
+
+    The hidden backing app may still carry legacy presentation fields such as
+    opening statements. Agent Soul is the source of truth for Agent-owned
+    features like file upload, so Soul fields override same-named legacy keys.
+    """
+    features: dict[str, Any] = dict(app_model_config.to_dict()) if app_model_config else {}
+    soul_features = agent_soul.app_features.model_dump(mode="json", exclude_none=True)
+    features.update(soul_features)
+    return features
+
+
+__all__ = ["merge_agent_app_features"]

--- a/api/tests/unit_tests/controllers/common/test_agent_app_parameters.py
+++ b/api/tests/unit_tests/controllers/common/test_agent_app_parameters.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+
+from controllers.common.agent_app_parameters import get_published_agent_app_feature_dict_and_user_input_form
+from core.app.app_config.common.parameters_mapping import get_parameters_from_feature_dict
+
+
+def test_published_agent_app_parameters_use_soul_file_upload(mocker):
+    app_model_config = SimpleNamespace(
+        to_dict=lambda: {
+            "opening_statement": "Hi from legacy presentation config",
+            "file_upload": {
+                "enabled": False,
+                "image": {"enabled": False},
+            },
+        }
+    )
+    app_model = SimpleNamespace(
+        tenant_id="tenant-1",
+        bound_agent_id="agent-1",
+        app_model_config=app_model_config,
+    )
+    agent = SimpleNamespace(
+        id="agent-1",
+        active_config_snapshot_id="snapshot-1",
+        active_config_is_published=True,
+    )
+    snapshot = SimpleNamespace(
+        config_snapshot_dict={
+            "app_features": {
+                "file_upload": {
+                    "enabled": True,
+                    "allowed_file_extensions": ["PNG"],
+                    "allowed_file_types": ["image"],
+                    "allowed_file_upload_methods": ["local_file"],
+                    "image": {"enabled": True},
+                    "number_limits": 2,
+                }
+            },
+            "app_variables": [{"name": "topic", "type": "string", "required": True}],
+        }
+    )
+    mocker.patch("controllers.common.agent_app_parameters.db.session.scalar", side_effect=[agent, snapshot])
+
+    features_dict, user_input_form = get_published_agent_app_feature_dict_and_user_input_form(app_model)
+    parameters = get_parameters_from_feature_dict(features_dict=features_dict, user_input_form=user_input_form)
+
+    assert parameters["opening_statement"] == "Hi from legacy presentation config"
+    assert parameters["file_upload"] == {
+        "enabled": True,
+        "allowed_file_extensions": ["PNG"],
+        "allowed_file_types": ["image"],
+        "allowed_file_upload_methods": ["local_file"],
+        "image": {"enabled": True},
+        "number_limits": 2,
+    }
+    assert parameters["user_input_form"] == [
+        {"text-input": {"label": "topic", "variable": "topic", "required": True}}
+    ]

--- a/api/tests/unit_tests/controllers/common/test_agent_app_parameters.py
+++ b/api/tests/unit_tests/controllers/common/test_agent_app_parameters.py
@@ -1,10 +1,11 @@
 from types import SimpleNamespace
 
+from controllers.common import agent_app_parameters
 from controllers.common.agent_app_parameters import get_published_agent_app_feature_dict_and_user_input_form
 from core.app.app_config.common.parameters_mapping import get_parameters_from_feature_dict
 
 
-def test_published_agent_app_parameters_use_soul_file_upload(mocker):
+def test_published_agent_app_parameters_use_soul_file_upload(monkeypatch):
     app_model_config = SimpleNamespace(
         to_dict=lambda: {
             "opening_statement": "Hi from legacy presentation config",
@@ -39,7 +40,8 @@ def test_published_agent_app_parameters_use_soul_file_upload(mocker):
             "app_variables": [{"name": "topic", "type": "string", "required": True}],
         }
     )
-    mocker.patch("controllers.common.agent_app_parameters.db.session.scalar", side_effect=[agent, snapshot])
+    query_results = iter([agent, snapshot])
+    monkeypatch.setattr(agent_app_parameters.db.session, "scalar", lambda _: next(query_results))
 
     features_dict, user_input_form = get_published_agent_app_feature_dict_and_user_input_form(app_model)
     parameters = get_parameters_from_feature_dict(features_dict=features_dict, user_input_form=user_input_form)

--- a/api/tests/unit_tests/core/app/apps/agent_app/test_app_config_manager.py
+++ b/api/tests/unit_tests/core/app/apps/agent_app/test_app_config_manager.py
@@ -75,7 +75,7 @@ def test_missing_soul_model_leaves_no_model_key():
     }
 
 
-def test_legacy_app_model_config_file_upload_takes_precedence():
+def test_soul_file_upload_overrides_legacy_app_model_config():
     fake_amc = SimpleNamespace(
         to_dict=lambda: {
             "file_upload": {
@@ -88,8 +88,12 @@ def test_legacy_app_model_config_file_upload_takes_precedence():
     d = AgentAppConfigManager._synthesize_config_dict(AgentSoulConfig(), fake_amc)  # type: ignore[arg-type]
 
     assert d["file_upload"] == {
-        "enabled": False,
-        "image": {"enabled": False},
+        "allowed_file_extensions": ["JPG", "JPEG", "PNG", "GIF", "WEBP", "SVG"],
+        "allowed_file_types": ["document", "image", "audio", "video"],
+        "allowed_file_upload_methods": ["local_file", "remote_url"],
+        "enabled": True,
+        "image": {"enabled": True},
+        "number_limits": 3,
     }
 
 


### PR DESCRIPTION
## Summary

- Use the published Agent Soul `app_features` as the override source for Agent App public parameters.
- Share the same feature projection for `/api/parameters` and Agent App runtime config synthesis.
- Add regression coverage for Soul file upload overriding stale hidden/backing app config.

## Verification

- `uv run --project api --dev ruff check api/core/app/apps/agent_app/app_feature_projection.py api/core/app/apps/agent_app/app_config_manager.py api/controllers/common/agent_app_parameters.py api/tests/unit_tests/controllers/common/test_agent_app_parameters.py api/tests/unit_tests/core/app/apps/agent_app/test_app_config_manager.py`
- `uv run --dev mypy --follow-imports=skip core/app/apps/agent_app/app_feature_projection.py core/app/apps/agent_app/app_config_manager.py controllers/common/agent_app_parameters.py`
- Remote dev API container: `.venv/bin/pytest -q -o addopts= tests/unit_tests/controllers/common/test_agent_app_parameters.py tests/unit_tests/core/app/apps/agent_app/test_app_config_manager.py` -> `7 passed`
- Verified `https://agent-app.dify.dev/api/parameters` for DIFY-2740 app returns `file_upload.enabled=true` with Agent Soul file upload types/methods.

## Notes

Local pytest on this machine still segfaults during pytest/gevent capture initialization before collecting tests, so target pytest was run in the dev API container instead.
