### PR TITLE
fix(web): unify detail sidebar home control

### DIFF
--- a/web/app/components/app-sidebar/__tests__/dataset-detail-top.spec.tsx
+++ b/web/app/components/app-sidebar/__tests__/dataset-detail-top.spec.tsx
@@ -4,14 +4,6 @@ import { createStore, Provider as JotaiProvider } from 'jotai'
 import { useGotoAnythingOpen } from '@/app/components/goto-anything/atoms'
 import DatasetDetailTop from '../dataset-detail-top'
 
-const mockBack = vi.fn()
-
-vi.mock('@/next/navigation', () => ({
-  useRouter: () => ({
-    back: mockBack,
-  }),
-}))
-
 vi.mock('../toggle-button', () => ({
   default: ({ expand, handleToggle, icon }: { expand: boolean, handleToggle: () => void, icon?: ReactNode }) => (
     <button type="button" data-testid="toggle-button" data-expand={expand} data-has-icon={Boolean(icon)} onClick={handleToggle}>
@@ -41,14 +33,15 @@ describe('DatasetDetailTop', () => {
     vi.clearAllMocks()
   })
 
-  it('links the home icon to home and labels the breadcrumb as datasets', () => {
+  it('links the combined home control to home and labels the breadcrumb as datasets', () => {
     renderWithGotoAnythingStore(<DatasetDetailTop />)
 
     expect(screen.getByRole('link', { name: 'common.mainNav.home' })).toHaveAttribute('href', '/')
     expect(screen.getByRole('link', { name: 'common.menus.datasets' })).toHaveAttribute('href', '/datasets')
+    expect(screen.queryByRole('button', { name: 'common.operation.back' })).not.toBeInTheDocument()
   })
 
-  it('keeps the back button and quick search actions', () => {
+  it('keeps the quick search action', () => {
     renderWithGotoAnythingStore(
       <>
         <DatasetDetailTop />
@@ -57,10 +50,8 @@ describe('DatasetDetailTop', () => {
     )
     expect(screen.getByTestId('goto-anything-open')).toHaveTextContent('false')
 
-    fireEvent.click(screen.getByRole('button', { name: 'common.operation.back' }))
     fireEvent.click(screen.getByRole('button', { name: 'app.gotoAnything.searchTitle' }))
 
-    expect(mockBack).toHaveBeenCalledTimes(1)
     expect(screen.getByTestId('goto-anything-open')).toHaveTextContent('true')
   })
 

--- a/web/app/components/app-sidebar/dataset-detail-top.tsx
+++ b/web/app/components/app-sidebar/dataset-detail-top.tsx
@@ -7,7 +7,6 @@ import { useTranslation } from 'react-i18next'
 import SidebarLeftArrowIcon from '@/app/components/base/icons/src/vender/SidebarLeftArrowIcon'
 import { useSetGotoAnythingOpen } from '@/app/components/goto-anything/atoms'
 import Link from '@/next/link'
-import { useRouter } from '@/next/navigation'
 import ToggleButton from './toggle-button'
 
 type DatasetDetailTopProps = {
@@ -22,7 +21,6 @@ const DatasetDetailTop = ({
   onToggle,
 }: DatasetDetailTopProps) => {
   const { t } = useTranslation()
-  const router = useRouter()
   const setGotoAnythingOpen = useSetGotoAnythingOpen()
 
   if (!expand) {
@@ -43,23 +41,14 @@ const DatasetDetailTop = ({
   return (
     <div className="flex items-center py-2 pr-2 pl-1">
       <div className="flex min-w-0 flex-1 items-center gap-px">
-        <div className="flex shrink-0 items-center rounded-lg py-2 pr-1.5 pl-0.5 transition-colors hover:bg-background-default-hover">
-          <button
-            type="button"
-            aria-label={t('operation.back', { ns: 'common' })}
-            className="flex size-4 items-center justify-center text-text-tertiary hover:text-text-secondary"
-            onClick={() => router.back()}
-          >
-            <span aria-hidden className="i-ri-arrow-left-s-line size-4" />
-          </button>
-          <Link
-            href="/"
-            aria-label={t('mainNav.home', { ns: 'common' })}
-            className="flex size-4 items-center justify-center text-text-tertiary hover:text-text-secondary"
-          >
-            <span aria-hidden className="i-custom-vender-main-nav-app-home size-4" />
-          </Link>
-        </div>
+        <Link
+          href="/"
+          aria-label={t('mainNav.home', { ns: 'common' })}
+          className="flex shrink-0 items-center rounded-lg py-2 pr-1.5 pl-0.5 text-text-tertiary transition-colors hover:bg-background-default-hover hover:text-text-secondary"
+        >
+          <span aria-hidden className="i-ri-arrow-left-s-line size-4" />
+          <span aria-hidden className="i-custom-vender-main-nav-app-home size-4" />
+        </Link>
         {expand && (
           <>
             <span className="shrink-0 system-md-regular text-text-quaternary">

--- a/web/features/agent-v2/agent-detail/__tests__/navigation.spec.tsx
+++ b/web/features/agent-v2/agent-detail/__tests__/navigation.spec.tsx
@@ -1,6 +1,6 @@
 import type { AgentAppDetailWithSite } from '@dify/contracts/api/console/agent/types.gen'
 import { render, screen } from '@testing-library/react'
-import { AgentDetailSection } from '../navigation'
+import { AgentDetailSection, AgentDetailTop } from '../navigation'
 
 const mocks = vi.hoisted(() => ({
   pathname: '/roster/agent/agent-1/configure',
@@ -69,5 +69,19 @@ describe('AgentDetailSection', () => {
     expect(agentAvatar?.parentElement?.parentElement).toHaveClass('mr-2')
     expect(agentName.parentElement).toHaveClass('h-10')
     expect(agentName.parentElement?.parentElement).toHaveClass('h-13', 'py-1.5', 'pl-1.5', 'pr-2')
+  })
+})
+
+describe('AgentDetailTop', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('links the combined home control to home', () => {
+    render(<AgentDetailTop />)
+
+    expect(screen.getByRole('link', { name: 'common.mainNav.home' })).toHaveAttribute('href', '/')
+    expect(screen.getByRole('link', { name: 'common.menus.roster' })).toHaveAttribute('href', '/roster')
+    expect(screen.queryByRole('button', { name: 'common.operation.back' })).not.toBeInTheDocument()
   })
 })

--- a/web/features/agent-v2/agent-detail/navigation.tsx
+++ b/web/features/agent-v2/agent-detail/navigation.tsx
@@ -17,7 +17,7 @@ import Divider from '@/app/components/base/divider'
 import SidebarLeftArrowIcon from '@/app/components/base/icons/src/vender/SidebarLeftArrowIcon'
 import { useSetGotoAnythingOpen } from '@/app/components/goto-anything/atoms'
 import Link from '@/next/link'
-import { usePathname, useRouter } from '@/next/navigation'
+import { usePathname } from '@/next/navigation'
 import { consoleQuery } from '@/service/client'
 import { getAgentDetailPath, getAgentIdFromPathname } from './routes'
 
@@ -88,7 +88,6 @@ export function AgentDetailTop({
 }: AgentDetailTopProps) {
   const { t: tApp } = useTranslation('app')
   const { t: tCommon } = useTranslation('common')
-  const router = useRouter()
   const setGotoAnythingOpen = useSetGotoAnythingOpen()
 
   if (!expand) {
@@ -109,23 +108,14 @@ export function AgentDetailTop({
   return (
     <div className="flex items-center py-2 pr-2 pl-1">
       <div className="flex min-w-0 flex-1 items-center gap-px">
-        <div className="flex shrink-0 items-center rounded-lg py-2 pr-1.5 pl-0.5 transition-colors hover:bg-background-default-hover">
-          <button
-            type="button"
-            aria-label={tCommon('operation.back')}
-            className="flex size-4 items-center justify-center text-text-tertiary hover:text-text-secondary focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden"
-            onClick={() => router.back()}
-          >
-            <span aria-hidden className="i-ri-arrow-left-s-line size-4" />
-          </button>
-          <Link
-            href="/"
-            aria-label={tCommon('mainNav.home')}
-            className="flex size-4 items-center justify-center text-text-tertiary hover:text-text-secondary focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden"
-          >
-            <span aria-hidden className="i-custom-vender-main-nav-app-home size-4" />
-          </Link>
-        </div>
+        <Link
+          href="/"
+          aria-label={tCommon('mainNav.home')}
+          className="flex shrink-0 items-center rounded-lg py-2 pr-1.5 pl-0.5 text-text-tertiary transition-colors hover:bg-background-default-hover hover:text-text-secondary focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden"
+        >
+          <span aria-hidden className="i-ri-arrow-left-s-line size-4" />
+          <span aria-hidden className="i-custom-vender-main-nav-app-home size-4" />
+        </Link>
         <span className="shrink-0 system-md-regular text-text-quaternary">
           /
         </span>

--- a/web/features/deployments/detail/__tests__/index.spec.tsx
+++ b/web/features/deployments/detail/__tests__/index.spec.tsx
@@ -4,6 +4,7 @@ import { Provider as JotaiProvider } from 'jotai'
 import { NextRouteStateBridge } from '@/app/components/next-route-state'
 import { useParams, usePathname } from '@/next/navigation'
 import { InstanceDetail } from '..'
+import { DeploymentDetailTop } from '../deployment-sidebar'
 
 vi.mock('@/next/navigation', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/next/navigation')>()
@@ -58,5 +59,23 @@ describe('InstanceDetail', () => {
     expect(screen.getByText('Deployment detail content')).toBeInTheDocument()
     expect(screen.queryByRole('main')).not.toBeInTheDocument()
     expect(screen.queryByRole('complementary', { name: 'Detail sidebar' })).not.toBeInTheDocument()
+  })
+})
+
+describe('DeploymentDetailTop', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('links the combined home control to home', () => {
+    render(
+      <JotaiProvider>
+        <DeploymentDetailTop />
+      </JotaiProvider>,
+    )
+
+    expect(screen.getByRole('link', { name: 'common.mainNav.home' })).toHaveAttribute('href', '/')
+    expect(screen.getByRole('link', { name: 'common.menus.deployments' })).toHaveAttribute('href', '/deployments')
+    expect(screen.queryByRole('button', { name: 'common.operation.back' })).not.toBeInTheDocument()
   })
 })

--- a/web/features/deployments/detail/deployment-sidebar.tsx
+++ b/web/features/deployments/detail/deployment-sidebar.tsx
@@ -16,7 +16,7 @@ import SidebarLeftArrowIcon from '@/app/components/base/icons/src/vender/Sidebar
 import { SkeletonContainer, SkeletonRectangle } from '@/app/components/base/skeleton'
 import { useSetGotoAnythingOpen } from '@/app/components/goto-anything/atoms'
 import Link from '@/next/link'
-import { usePathname, useRouter } from '@/next/navigation'
+import { usePathname } from '@/next/navigation'
 import { DeploymentActionsMenu } from '../deployment-actions'
 import { deploymentRouteAppInstanceIdAtom } from '../route-state'
 import { TitleTooltip } from '../shared/components/title-tooltip'
@@ -187,7 +187,6 @@ export function DeploymentDetailTop({
   onToggle?: () => void
 }) {
   const { t } = useTranslation()
-  const router = useRouter()
   const setGotoAnythingOpen = useSetGotoAnythingOpen()
 
   if (!expand) {
@@ -208,23 +207,14 @@ export function DeploymentDetailTop({
   return (
     <div className="flex items-center py-2 pr-2 pl-1">
       <div className="flex min-w-0 flex-1 items-center gap-px">
-        <div className="flex shrink-0 items-center rounded-lg py-2 pr-1.5 pl-0.5 transition-colors hover:bg-background-default-hover">
-          <button
-            type="button"
-            aria-label={t('operation.back', { ns: 'common' })}
-            className="flex size-4 items-center justify-center text-text-tertiary hover:text-text-secondary"
-            onClick={() => router.back()}
-          >
-            <span aria-hidden className="i-ri-arrow-left-s-line size-4" />
-          </button>
-          <Link
-            href="/"
-            aria-label={t('mainNav.home', { ns: 'common' })}
-            className="flex size-4 items-center justify-center text-text-tertiary hover:text-text-secondary"
-          >
-            <span aria-hidden className="i-custom-vender-main-nav-app-home size-4" />
-          </Link>
-        </div>
+        <Link
+          href="/"
+          aria-label={t('mainNav.home', { ns: 'common' })}
+          className="flex shrink-0 items-center rounded-lg py-2 pr-1.5 pl-0.5 text-text-tertiary transition-colors hover:bg-background-default-hover hover:text-text-secondary"
+        >
+          <span aria-hidden className="i-ri-arrow-left-s-line size-4" />
+          <span aria-hidden className="i-custom-vender-main-nav-app-home size-4" />
+        </Link>
         <span className="shrink-0 system-md-regular text-text-quaternary">
           /
         </span>


### PR DESCRIPTION
## Summary

Unifies the detail-sidebar home control so the arrow and home icon behave as a single navigation target.

- Replaces separate back buttons plus home links with a single home link in dataset, deployment, and agent detail sidebars.
- Keeps existing app detail sidebar behavior aligned with the same single-link contract.
- Adds focused regression coverage to assert the combined home control routes to `/` and does not expose a separate back button.

From Codex

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Verification:

- `CI=true pnpm -C web test app/components/app-sidebar/__tests__/dataset-detail-top.spec.tsx features/agent-v2/agent-detail/__tests__/navigation.spec.tsx features/deployments/detail/__tests__/index.spec.tsx`
- `CI=true pnpm -C web lint:tss`
- `git diff --check HEAD^ HEAD`
