### PR TITLE
fix: allow duplicate End node output variables across branches

### DIFF
--- a/web/app/components/workflow/hooks/__tests__/use-checklist.spec.ts
+++ b/web/app/components/workflow/hooks/__tests__/use-checklist.spec.ts
@@ -423,7 +423,7 @@ describe('useChecklist', () => {
     ])
   })
 
-  it('should detect duplicate output variables across end nodes', () => {
+  it('should allow duplicate output variables across end nodes (different branches)', () => {
     const startNode = createNode({ id: 'start', data: { type: BlockEnum.Start, title: 'Start' } })
     const firstEndNode = createNode({
       id: 'end-1',
@@ -454,8 +454,9 @@ describe('useChecklist', () => {
     const firstWarning = result.current.find((item: ChecklistItem) => item.id === 'end-1')
     const secondWarning = result.current.find((item: ChecklistItem) => item.id === 'end-2')
 
-    expect(firstWarning?.errorMessages.some(message => message.includes('duplicateOutputVariable'))).toBe(true)
-    expect(secondWarning?.errorMessages.some(message => message.includes('duplicateOutputVariable'))).toBe(true)
+    // Different branches → only one End node executes, so duplicate output variables are allowed
+    expect(firstWarning?.errorMessages.some(message => message.includes('duplicateOutputVariable'))).toBe(false)
+    expect(secondWarning?.errorMessages.some(message => message.includes('duplicateOutputVariable'))).toBe(false)
   })
 
   it('should sync checklist items to the workflow store without render phase update warnings', async () => {

--- a/web/app/components/workflow/hooks/use-checklist.ts
+++ b/web/app/components/workflow/hooks/use-checklist.ts
@@ -108,43 +108,6 @@ const START_NODE_TYPES: BlockEnum[] = [
   BlockEnum.TriggerPlugin,
 ]
 
-const getDuplicateEndOutputMessages = (
-  nodes: Node[],
-  t: ReturnType<typeof useTranslation>['t'],
-) => {
-  const variableOccurrences = new Map<string, string[]>()
-
-  nodes.forEach((node) => {
-    if (node.type !== CUSTOM_NODE || node.data.type !== BlockEnum.End)
-      return
-
-    const outputs = ((node.data as { outputs?: Array<{ variable?: string }> }).outputs) || []
-    outputs.forEach((output) => {
-      const variable = output.variable?.trim()
-      if (!variable)
-        return
-
-      const occurrences = variableOccurrences.get(variable) || []
-      occurrences.push(node.id)
-      variableOccurrences.set(variable, occurrences)
-    })
-  })
-
-  const nodeMessages = new Map<string, string[]>()
-  variableOccurrences.forEach((nodeIds, variable) => {
-    if (nodeIds.length <= 1)
-      return
-
-    Array.from(new Set(nodeIds)).forEach((nodeId) => {
-      const messages = nodeMessages.get(nodeId) || []
-      messages.push(t('errorMsg.duplicateOutputVariable', { ns: 'workflow', variable }))
-      nodeMessages.set(nodeId, messages)
-    })
-  })
-
-  return nodeMessages
-}
-
 export const useChecklist = (nodes: Node[], edges: Edge[], options?: { flowType?: FlowType }) => {
   const { t } = useTranslation()
   const language = useGetLanguage()
@@ -233,7 +196,6 @@ export const useChecklist = (nodes: Node[], edges: Edge[], options?: { flowType?
   const needWarningNodes = useMemo<ChecklistItem[]>(() => {
     const list: ChecklistItem[] = []
     const filteredNodes = nodes.filter(node => node.type === CUSTOM_NODE)
-    const duplicateEndOutputMessages = getDuplicateEndOutputMessages(filteredNodes, t)
     const { validNodes } = getValidTreeNodes(filteredNodes, edges)
     const installedPluginIds = new Set(modelProviders.map(p => extractPluginId(p.provider)))
 
@@ -308,8 +270,6 @@ export const useChecklist = (nodes: Node[], edges: Edge[], options?: { flowType?
           }
           if (hasInvalidVar)
             errorMessages.push(t('errorMsg.invalidVariable', { ns: 'workflow' }))
-
-          errorMessages.push(...(duplicateEndOutputMessages.get(node!.id) || []))
         }
 
         const isStartNodeMeta = nodesExtraData?.[node!.data.type as BlockEnum]?.metaData.isStart ?? false
@@ -446,7 +406,6 @@ export const useChecklistBeforePublish = () => {
     } = workflowStore.getState()
     const nodes = getNodes()
     const filteredNodes = nodes.filter(node => node.type === CUSTOM_NODE)
-    const duplicateEndOutputMessages = getDuplicateEndOutputMessages(filteredNodes, t)
     const { validNodes, maxDepth } = getValidTreeNodes(filteredNodes, edges)
 
     if (maxDepth > MAX_TREE_DEPTH) {
@@ -558,12 +517,6 @@ export const useChecklistBeforePublish = () => {
 
       if (errorMessage) {
         toast.error(`[${node!.data.title}] ${errorMessage}`)
-        return false
-      }
-
-      const duplicateOutputMessages = duplicateEndOutputMessages.get(node!.id) || []
-      if (duplicateOutputMessages.length > 0) {
-        toast.error(`[${node!.data.title}] ${duplicateOutputMessages[0]}`)
         return false
       }
 


### PR DESCRIPTION
## Summary

Remove the duplicate End output variable check that was unnecessarily blocking workflow publishing. In a workflow with conditional branches, only one End node executes per run, so having two End nodes in different branches with the same output variable name is not a conflict.

Fixes #38440

## Changes

- **`web/app/components/workflow/hooks/use-checklist.ts`**: Removed `getDuplicateEndOutputMessages()` function and all its call sites
- **`web/app/components/workflow/hooks/__tests__/use-checklist.spec.ts`**: Updated test to verify that duplicate output variable names across End nodes are now allowed (instead of detected as errors)