### PR TITLE
fix: editor should not manage member

### DIFF
--- a/api/services/enterprise/rbac_service.py
+++ b/api/services/enterprise/rbac_service.py
@@ -364,7 +364,6 @@ _LEGACY_WORKSPACE_ADMIN_KEYS: list[str] = [
 ]
 
 _LEGACY_WORKSPACE_EDITOR_KEYS: list[str] = [
-    "workspace.member.manage",
     "api_extension.manage",
     "plugin.install",
     "credential.use",


### PR DESCRIPTION
## Summary

Cherry-picks `faaa4708a697e327ad0b5cc5f3828cb65c647585` onto `hotfix/1.15.0-fix.4`.

This removes `workspace.member.manage` from the legacy workspace editor permission set, so editors no longer inherit member-management permission when RBAC is disabled.

## Validation

- `BASE_SHA=myori/hotfix/1.15.0-fix.4 HEAD_SHA=HEAD MAIN_REF=myori/main bash .github/scripts/check-hotfix-cherry-picks.sh` -> verified 1 PR commit includes cherry-pick provenance from main
- `DEBUG=false uv run --project api pytest api/tests/unit_tests/services/enterprise/test_rbac_service.py` -> 64 passed