### PR TITLE
fix(web): add backdrop blur to skip nav

### DIFF
--- a/web/app/components/main-nav/skip-nav.tsx
+++ b/web/app/components/main-nav/skip-nav.tsx
@@ -26,7 +26,7 @@ export function SkipNav({
       href={MAIN_CONTENT_HREF}
       onClick={handleClick}
       className={cn(
-        'fixed top-2 left-2 z-60 inline-flex h-9 -translate-y-[calc(100%+0.75rem)] items-center justify-center rounded-lg border-[0.5px] border-components-button-secondary-border bg-components-button-secondary-bg px-3 system-sm-medium text-components-button-secondary-text outline-hidden transition-transform duration-150 focus-visible:translate-y-0 focus-visible:shadow-lg focus-visible:ring-2 focus-visible:shadow-shadow-shadow-5 focus-visible:ring-state-accent-solid motion-reduce:transition-none',
+        'fixed top-2 left-2 z-60 inline-flex h-9 -translate-y-[calc(100%+0.75rem)] items-center justify-center rounded-lg border-[0.5px] border-components-button-secondary-border bg-components-button-secondary-bg px-3 system-sm-medium text-components-button-secondary-text outline-hidden backdrop-blur-[5px] transition-transform duration-150 focus-visible:translate-y-0 focus-visible:shadow-lg focus-visible:ring-2 focus-visible:shadow-shadow-shadow-5 focus-visible:ring-state-accent-solid motion-reduce:transition-none',
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary

- Add backdrop blur to the skip navigation link so the translucent secondary-button surface remains readable in dark mode.

## Tests

- pnpm -C web test app/components/main-nav/__tests__/layout.spec.tsx app/components/main-nav/__tests__/skip-nav.spec.tsx