### PR TITLE
fix(dataset): clean deleted dataset in committed steps and bounded batches

### DIFF
--- a/api/tasks/clean_dataset_task.py
+++ b/api/tasks/clean_dataset_task.py
@@ -1,9 +1,12 @@
 import logging
 import time
+from collections.abc import Callable, Sequence
 
 import click
 from celery import shared_task
 from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.elements import ColumnElement
 
 from core.db.session_factory import session_factory
 from core.rag.index_processor.index_processor_factory import IndexProcessorFactory
@@ -12,6 +15,7 @@ from extensions.ext_storage import storage
 from models import WorkflowType
 from models.dataset import (
     AppDatasetJoin,
+    ChildChunk,
     Dataset,
     DatasetMetadata,
     DatasetMetadataBinding,
@@ -27,8 +31,17 @@ from models.workflow import Workflow
 
 logger = logging.getLogger(__name__)
 
+# The dataset row is already gone by the time this task runs, so if the cleanup
+# fails there is nothing left to trigger a retry. Deleting everything in a single
+# transaction meant one timeout/deadlock (e.g. on a multi-million-row dataset, or
+# a lock held by indexing that was still running at delete time) rolled the whole
+# task back and orphaned the documents, segments, child chunks and the vector
+# index forever. Instead: clean each concern independently and commit as we go, so
+# a failure in one step neither rolls back finished work nor skips the later steps,
+# and delete the large child tables in bounded batches.
+_DELETE_BATCH_SIZE = 1000
 
-# Add import statement for ValueError
+
 @shared_task(queue="dataset")
 def clean_dataset_task(
     dataset_id: str,
@@ -53,139 +66,54 @@ def clean_dataset_task(
     logger.info(click.style(f"Start clean dataset when dataset deleted: {dataset_id}", fg="green"))
     start_at = time.perf_counter()
 
+    # Treat None / empty / whitespace-only doc_form as the default paragraph index
+    # type so the vector database can still be cleaned up.
+    if doc_form is None or (isinstance(doc_form, str) and not doc_form.strip()):
+        from core.rag.index_processor.constant.index_type import IndexStructureType
+
+        doc_form = IndexStructureType.PARAGRAPH_INDEX
+        logger.info(
+            click.style(f"Invalid doc_form detected, using default index type for cleanup: {doc_form}", fg="yellow")
+        )
+
+    # Vector store / keyword index cleanup, isolated from the relational cleanup so a
+    # failure on either side does not prevent the other.
+    try:
+        dataset = Dataset(
+            id=dataset_id,
+            tenant_id=tenant_id,
+            indexing_technique=indexing_technique,
+            index_struct=index_struct,
+            collection_binding_id=collection_binding_id,
+        )
+        index_processor = IndexProcessorFactory(doc_form).init_index_processor()
+        index_processor.clean(dataset, None, with_keywords=True, delete_child_chunks=True)
+        logger.info(click.style(f"Successfully cleaned vector database for dataset: {dataset_id}", fg="green"))
+    except Exception:
+        logger.exception(click.style(f"Failed to clean vector database for dataset {dataset_id}", fg="red"))
+        logger.info(
+            click.style(f"Continuing with document and segment deletion for dataset: {dataset_id}", fg="yellow")
+        )
+
     with session_factory.create_session() as session:
         try:
-            dataset = Dataset(
-                id=dataset_id,
-                tenant_id=tenant_id,
-                indexing_technique=indexing_technique,
-                index_struct=index_struct,
-                collection_binding_id=collection_binding_id,
+            # Order matters: segments before documents; child chunks are a fallback in
+            # case the vector cleanup above did not remove them.
+            _run_step(session, dataset_id, "segments", lambda: _delete_segments(session, dataset_id))
+            _run_step(
+                session,
+                dataset_id,
+                "child chunks",
+                lambda: _delete_in_batches(session, ChildChunk, ChildChunk.dataset_id == dataset_id),
             )
-            documents = session.scalars(select(Document).where(Document.dataset_id == dataset_id)).all()
-            segments = session.scalars(select(DocumentSegment).where(DocumentSegment.dataset_id == dataset_id)).all()
-            # Use JOIN to fetch attachments with bindings in a single query
-            attachments_with_bindings = session.execute(
-                select(SegmentAttachmentBinding, UploadFile)
-                .join(UploadFile, UploadFile.id == SegmentAttachmentBinding.attachment_id)
-                .where(
-                    SegmentAttachmentBinding.tenant_id == tenant_id,
-                    SegmentAttachmentBinding.dataset_id == dataset_id,
-                )
-            ).all()
-
-            # Enhanced validation: Check if doc_form is None, empty string, or contains only whitespace
-            # This ensures all invalid doc_form values are properly handled
-            if doc_form is None or (isinstance(doc_form, str) and not doc_form.strip()):
-                # Use default paragraph index type for empty/invalid datasets to enable vector database cleanup
-                from core.rag.index_processor.constant.index_type import IndexStructureType
-
-                doc_form = IndexStructureType.PARAGRAPH_INDEX
-                logger.info(
-                    click.style(
-                        f"Invalid doc_form detected, using default index type for cleanup: {doc_form}",
-                        fg="yellow",
-                    )
-                )
-
-            # Add exception handling around IndexProcessorFactory.clean() to prevent single point of failure
-            # This ensures Document/Segment deletion can continue even if vector database cleanup fails
-            try:
-                index_processor = IndexProcessorFactory(doc_form).init_index_processor()
-                index_processor.clean(dataset, None, with_keywords=True, delete_child_chunks=True)
-                logger.info(click.style(f"Successfully cleaned vector database for dataset: {dataset_id}", fg="green"))
-            except Exception:
-                logger.exception(click.style(f"Failed to clean vector database for dataset {dataset_id}", fg="red"))
-                # Continue with document and segment deletion even if vector cleanup fails
-                logger.info(
-                    click.style(f"Continuing with document and segment deletion for dataset: {dataset_id}", fg="yellow")
-                )
-
-            if documents is None or len(documents) == 0:
-                logger.info(click.style(f"No documents found for dataset: {dataset_id}", fg="green"))
-            else:
-                logger.info(click.style(f"Cleaning documents for dataset: {dataset_id}", fg="green"))
-
-                for document in documents:
-                    session.delete(document)
-
-                segment_ids = [segment.id for segment in segments]
-                for segment in segments:
-                    image_upload_file_ids = get_image_upload_file_ids(segment.content)
-                    image_files = session.scalars(
-                        select(UploadFile).where(UploadFile.id.in_(image_upload_file_ids))
-                    ).all()
-                    for image_file in image_files:
-                        if image_file is None:
-                            continue
-                        try:
-                            storage.delete(image_file.key)
-                        except Exception:
-                            logger.exception(
-                                "Delete image_files failed when storage deleted, \
-                                              image_upload_file_is: %s",
-                                image_file.id,
-                            )
-                    stmt = delete(UploadFile).where(UploadFile.id.in_(image_upload_file_ids))
-                    session.execute(stmt)
-
-                segment_delete_stmt = delete(DocumentSegment).where(DocumentSegment.id.in_(segment_ids))
-                session.execute(segment_delete_stmt)
-            # delete segment attachments
-            if attachments_with_bindings:
-                attachment_ids = [attachment_file.id for _, attachment_file in attachments_with_bindings]
-                binding_ids = [binding.id for binding, _ in attachments_with_bindings]
-                for binding, attachment_file in attachments_with_bindings:
-                    try:
-                        storage.delete(attachment_file.key)
-                    except Exception:
-                        logger.exception(
-                            "Delete attachment_file failed when storage deleted, \
-                                            attachment_file_id: %s",
-                            binding.attachment_id,
-                        )
-                attachment_file_delete_stmt = delete(UploadFile).where(UploadFile.id.in_(attachment_ids))
-                session.execute(attachment_file_delete_stmt)
-
-                binding_delete_stmt = delete(SegmentAttachmentBinding).where(
-                    SegmentAttachmentBinding.id.in_(binding_ids)
-                )
-                session.execute(binding_delete_stmt)
-
-            session.execute(delete(DatasetProcessRule).where(DatasetProcessRule.dataset_id == dataset_id))
-            session.execute(delete(DatasetQuery).where(DatasetQuery.dataset_id == dataset_id))
-            session.execute(delete(AppDatasetJoin).where(AppDatasetJoin.dataset_id == dataset_id))
-            # delete dataset metadata
-            session.execute(delete(DatasetMetadata).where(DatasetMetadata.dataset_id == dataset_id))
-            session.execute(delete(DatasetMetadataBinding).where(DatasetMetadataBinding.dataset_id == dataset_id))
-            # delete pipeline and workflow
-            if pipeline_id:
-                session.execute(delete(Pipeline).where(Pipeline.id == pipeline_id))
-                session.execute(
-                    delete(Workflow).where(
-                        Workflow.tenant_id == tenant_id,
-                        Workflow.app_id == pipeline_id,
-                        Workflow.type == WorkflowType.RAG_PIPELINE,
-                    )
-                )
-            # delete files
-            if documents:
-                file_ids = []
-                for document in documents:
-                    if document.data_source_type == "upload_file":
-                        if document.data_source_info:
-                            data_source_info = document.data_source_info_dict
-                            if data_source_info and "upload_file_id" in data_source_info:
-                                file_id = data_source_info["upload_file_id"]
-                                file_ids.append(file_id)
-                files = session.scalars(select(UploadFile).where(UploadFile.id.in_(file_ids))).all()
-                for file in files:
-                    storage.delete(file.key)
-
-                file_delete_stmt = delete(UploadFile).where(UploadFile.id.in_(file_ids))
-                session.execute(file_delete_stmt)
-
-            session.commit()
+            _run_step(session, dataset_id, "documents", lambda: _delete_documents(session, dataset_id))
+            _run_step(session, dataset_id, "attachments", lambda: _delete_attachments(session, dataset_id, tenant_id))
+            _run_step(
+                session,
+                dataset_id,
+                "dataset metadata",
+                lambda: _delete_dataset_scoped_rows(session, dataset_id, tenant_id, pipeline_id),
+            )
             end_at = time.perf_counter()
             logger.info(
                 click.style(
@@ -193,19 +121,135 @@ def clean_dataset_task(
                     fg="green",
                 )
             )
-        except Exception:
-            # Add rollback to prevent dirty session state in case of exceptions
-            # This ensures the database session is properly cleaned up
-            try:
-                session.rollback()
-                logger.info(click.style(f"Rolled back database session for dataset: {dataset_id}", fg="yellow"))
-            except Exception:
-                logger.exception("Failed to rollback database session")
-
-            logger.exception("Cleaned dataset when dataset deleted failed")
         finally:
-            # Explicitly close the session for test expectations and safety
             try:
                 session.close()
             except Exception:
                 logger.exception("Failed to close database session")
+
+
+def _run_step(session: Session, dataset_id: str, name: str, step: Callable[[], None]) -> None:
+    """Run one cleanup step in isolation: a failure is logged and the (partial,
+    uncommitted) work is rolled back, but the remaining steps still run."""
+    try:
+        step()
+    except Exception:
+        logger.exception(click.style(f"Failed to clean {name} for dataset {dataset_id}", fg="red"))
+        try:
+            session.rollback()
+        except Exception:
+            logger.exception("Failed to rollback database session")
+
+
+def _delete_in_batches[Model](
+    session: Session,
+    model: type[Model],
+    condition: ColumnElement[bool],
+    batch_size: int = _DELETE_BATCH_SIZE,
+) -> None:
+    """Delete rows of ``model`` matching ``condition`` in bounded, individually
+    committed batches."""
+    while True:
+        ids: Sequence[str] = session.scalars(select(model.id).where(condition).limit(batch_size)).all()  # type: ignore[attr-defined]
+        if not ids:
+            break
+        session.execute(delete(model).where(model.id.in_(ids)))  # type: ignore[attr-defined]
+        session.commit()
+
+
+def _delete_segments(session: Session, dataset_id: str, batch_size: int = _DELETE_BATCH_SIZE) -> None:
+    """Delete document segments in batches, removing their inline image files first."""
+    while True:
+        segments = session.scalars(
+            select(DocumentSegment).where(DocumentSegment.dataset_id == dataset_id).limit(batch_size)
+        ).all()
+        if not segments:
+            break
+        image_upload_file_ids: list[str] = []
+        for segment in segments:
+            image_upload_file_ids.extend(get_image_upload_file_ids(segment.content))
+        _delete_upload_files(session, image_upload_file_ids)
+        session.execute(delete(DocumentSegment).where(DocumentSegment.id.in_([s.id for s in segments])))
+        session.commit()
+
+
+def _delete_documents(session: Session, dataset_id: str, batch_size: int = _DELETE_BATCH_SIZE) -> None:
+    """Delete documents in batches, removing their uploaded source files first."""
+    while True:
+        documents = session.scalars(
+            select(Document).where(Document.dataset_id == dataset_id).limit(batch_size)
+        ).all()
+        if not documents:
+            break
+        file_ids: list[str] = []
+        for document in documents:
+            if document.data_source_type == "upload_file" and document.data_source_info:
+                data_source_info = document.data_source_info_dict
+                if data_source_info and "upload_file_id" in data_source_info:
+                    file_ids.append(data_source_info["upload_file_id"])
+        _delete_upload_files(session, file_ids)
+        session.execute(delete(Document).where(Document.id.in_([d.id for d in documents])))
+        session.commit()
+
+
+def _delete_upload_files(session: Session, file_ids: Sequence[str]) -> None:
+    """Delete ``UploadFile`` rows and their object-storage blobs. Storage errors are
+    logged but do not keep the row: the dataset is already gone, so leaving the row
+    would orphan it forever (a stray blob can be reclaimed by storage GC instead)."""
+    if not file_ids:
+        return
+    files = session.scalars(select(UploadFile).where(UploadFile.id.in_(file_ids))).all()
+    for file in files:
+        try:
+            storage.delete(file.key)
+        except Exception:
+            logger.exception("Delete file failed when storage deleted, upload_file_id: %s", file.id)
+    session.execute(delete(UploadFile).where(UploadFile.id.in_(file_ids)))
+
+
+def _delete_attachments(session: Session, dataset_id: str, tenant_id: str) -> None:
+    """Delete segment attachments (upload files + bindings) for the dataset."""
+    attachments_with_bindings = session.execute(
+        select(SegmentAttachmentBinding, UploadFile)
+        .join(UploadFile, UploadFile.id == SegmentAttachmentBinding.attachment_id)
+        .where(
+            SegmentAttachmentBinding.tenant_id == tenant_id,
+            SegmentAttachmentBinding.dataset_id == dataset_id,
+        )
+    ).all()
+    if not attachments_with_bindings:
+        return
+    attachment_ids = [attachment_file.id for _, attachment_file in attachments_with_bindings]
+    binding_ids = [binding.id for binding, _ in attachments_with_bindings]
+    for binding, attachment_file in attachments_with_bindings:
+        try:
+            storage.delete(attachment_file.key)
+        except Exception:
+            logger.exception(
+                "Delete attachment_file failed when storage deleted, attachment_file_id: %s",
+                binding.attachment_id,
+            )
+    session.execute(delete(UploadFile).where(UploadFile.id.in_(attachment_ids)))
+    session.execute(delete(SegmentAttachmentBinding).where(SegmentAttachmentBinding.id.in_(binding_ids)))
+    session.commit()
+
+
+def _delete_dataset_scoped_rows(
+    session: Session, dataset_id: str, tenant_id: str, pipeline_id: str | None
+) -> None:
+    """Delete the remaining small dataset-scoped tables (and the pipeline/workflow)."""
+    session.execute(delete(DatasetProcessRule).where(DatasetProcessRule.dataset_id == dataset_id))
+    session.execute(delete(DatasetQuery).where(DatasetQuery.dataset_id == dataset_id))
+    session.execute(delete(AppDatasetJoin).where(AppDatasetJoin.dataset_id == dataset_id))
+    session.execute(delete(DatasetMetadata).where(DatasetMetadata.dataset_id == dataset_id))
+    session.execute(delete(DatasetMetadataBinding).where(DatasetMetadataBinding.dataset_id == dataset_id))
+    if pipeline_id:
+        session.execute(delete(Pipeline).where(Pipeline.id == pipeline_id))
+        session.execute(
+            delete(Workflow).where(
+                Workflow.tenant_id == tenant_id,
+                Workflow.app_id == pipeline_id,
+                Workflow.type == WorkflowType.RAG_PIPELINE,
+            )
+        )
+    session.commit()

--- a/api/tasks/clean_dataset_task.py
+++ b/api/tasks/clean_dataset_task.py
@@ -176,9 +176,7 @@ def _delete_segments(session: Session, dataset_id: str, batch_size: int = _DELET
 def _delete_documents(session: Session, dataset_id: str, batch_size: int = _DELETE_BATCH_SIZE) -> None:
     """Delete documents in batches, removing their uploaded source files first."""
     while True:
-        documents = session.scalars(
-            select(Document).where(Document.dataset_id == dataset_id).limit(batch_size)
-        ).all()
+        documents = session.scalars(select(Document).where(Document.dataset_id == dataset_id).limit(batch_size)).all()
         if not documents:
             break
         file_ids: list[str] = []
@@ -234,9 +232,7 @@ def _delete_attachments(session: Session, dataset_id: str, tenant_id: str) -> No
     session.commit()
 
 
-def _delete_dataset_scoped_rows(
-    session: Session, dataset_id: str, tenant_id: str, pipeline_id: str | None
-) -> None:
+def _delete_dataset_scoped_rows(session: Session, dataset_id: str, tenant_id: str, pipeline_id: str | None) -> None:
     """Delete the remaining small dataset-scoped tables (and the pipeline/workflow)."""
     session.execute(delete(DatasetProcessRule).where(DatasetProcessRule.dataset_id == dataset_id))
     session.execute(delete(DatasetQuery).where(DatasetQuery.dataset_id == dataset_id))

--- a/api/tasks/clean_dataset_task.py
+++ b/api/tasks/clean_dataset_task.py
@@ -1,9 +1,11 @@
 import logging
 import time
+from collections.abc import Callable, Sequence
 
 import click
 from celery import shared_task
 from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
 
 from core.db.session_factory import session_factory
 from core.rag.index_processor.index_processor_factory import IndexProcessorFactory
@@ -28,8 +30,19 @@ from tasks.refresh_billing_vector_space_task import schedule_billing_vector_spac
 
 logger = logging.getLogger(__name__)
 
+# The dataset row is already gone by the time this task runs, so if the cleanup fails
+# there is nothing left to trigger a retry. Deleting everything in a single transaction
+# meant one timeout or deadlock -- on a multi-million-row dataset, or on a lock held by
+# indexing that was still running at delete time -- rolled the whole task back and
+# orphaned the documents, segments, child chunks and the vector index forever. Instead,
+# clean each concern independently and commit as we go, so a failure in one step neither
+# rolls back finished work nor skips the later steps, and delete the large child tables in
+# bounded batches instead of one statement with a multi-million-element IN (...).
+#
+# Read through the module global (never as a default argument value) so tests can patch it.
+_DELETE_BATCH_SIZE = 1000
 
-# Add import statement for ValueError
+
 @shared_task(queue="dataset")
 def clean_dataset_task(
     dataset_id: str,
@@ -53,144 +66,50 @@ def clean_dataset_task(
     """
     logger.info(click.style(f"Start clean dataset when dataset deleted: {dataset_id}", fg="green"))
     start_at = time.perf_counter()
-    vector_cleanup_succeeded = False
+
+    # Enhanced validation: Check if doc_form is None, empty string, or contains only whitespace.
+    # Treating all invalid values as the default paragraph index type keeps the vector
+    # database cleanup reachable for empty/broken datasets.
+    if doc_form is None or (isinstance(doc_form, str) and not doc_form.strip()):
+        from core.rag.index_processor.constant.index_type import IndexStructureType
+
+        doc_form = IndexStructureType.PARAGRAPH_INDEX
+        logger.info(
+            click.style(f"Invalid doc_form detected, using default index type for cleanup: {doc_form}", fg="yellow")
+        )
+
+    dataset = Dataset(
+        id=dataset_id,
+        tenant_id=tenant_id,
+        indexing_technique=indexing_technique,
+        index_struct=index_struct,
+        collection_binding_id=collection_binding_id,
+    )
 
     with session_factory.create_session() as session:
         try:
-            dataset = Dataset(
-                id=dataset_id,
-                tenant_id=tenant_id,
-                indexing_technique=indexing_technique,
-                index_struct=index_struct,
-                collection_binding_id=collection_binding_id,
+            # The index cleanup is a step of its own with its own commit: the index
+            # processors flush their relational side effects (child chunks, summaries,
+            # keyword table) without committing, so a rollback in any later step would
+            # otherwise silently undo them while the vector store stays cleaned.
+            vector_cleanup_succeeded = _run_step(
+                session, dataset_id, "vector database", lambda: _clean_index(session, dataset, doc_form)
             )
-            documents = session.scalars(select(Document).where(Document.dataset_id == dataset_id)).all()
-            segments = session.scalars(select(DocumentSegment).where(DocumentSegment.dataset_id == dataset_id)).all()
-            # Use JOIN to fetch attachments with bindings in a single query
-            attachments_with_bindings = session.execute(
-                select(SegmentAttachmentBinding, UploadFile)
-                .join(UploadFile, UploadFile.id == SegmentAttachmentBinding.attachment_id)
-                .where(
-                    SegmentAttachmentBinding.tenant_id == tenant_id,
-                    SegmentAttachmentBinding.dataset_id == dataset_id,
-                )
-            ).all()
 
-            # Enhanced validation: Check if doc_form is None, empty string, or contains only whitespace
-            # This ensures all invalid doc_form values are properly handled
-            if doc_form is None or (isinstance(doc_form, str) and not doc_form.strip()):
-                # Use default paragraph index type for empty/invalid datasets to enable vector database cleanup
-                from core.rag.index_processor.constant.index_type import IndexStructureType
+            # Order matters: segments reference documents, so they go first.
+            _run_step(session, dataset_id, "segments", lambda: _delete_segments(session, dataset_id))
+            _run_step(session, dataset_id, "documents", lambda: _delete_documents(session, dataset_id))
+            _run_step(session, dataset_id, "attachments", lambda: _delete_attachments(session, tenant_id, dataset_id))
+            _run_step(
+                session,
+                dataset_id,
+                "dataset metadata",
+                lambda: _delete_dataset_scoped_rows(session, tenant_id, dataset_id, pipeline_id),
+            )
 
-                doc_form = IndexStructureType.PARAGRAPH_INDEX
-                logger.info(
-                    click.style(
-                        f"Invalid doc_form detected, using default index type for cleanup: {doc_form}",
-                        fg="yellow",
-                    )
-                )
-
-            # Add exception handling around IndexProcessorFactory.clean() to prevent single point of failure
-            # This ensures Document/Segment deletion can continue even if vector database cleanup fails
-            try:
-                index_processor = IndexProcessorFactory(doc_form).init_index_processor()
-                index_processor.clean(dataset, None, with_keywords=True, delete_child_chunks=True, session=session)
-                vector_cleanup_succeeded = True
-                logger.info(click.style(f"Successfully cleaned vector database for dataset: {dataset_id}", fg="green"))
-            except Exception:
-                logger.exception(click.style(f"Failed to clean vector database for dataset {dataset_id}", fg="red"))
-                # Continue with document and segment deletion even if vector cleanup fails
-                logger.info(
-                    click.style(f"Continuing with document and segment deletion for dataset: {dataset_id}", fg="yellow")
-                )
-
-            if documents is None or len(documents) == 0:
-                logger.info(click.style(f"No documents found for dataset: {dataset_id}", fg="green"))
-            else:
-                logger.info(click.style(f"Cleaning documents for dataset: {dataset_id}", fg="green"))
-
-                for document in documents:
-                    session.delete(document)
-
-                segment_ids = [segment.id for segment in segments]
-                for segment in segments:
-                    image_upload_file_ids = get_image_upload_file_ids(segment.content)
-                    image_files = session.scalars(
-                        select(UploadFile).where(UploadFile.id.in_(image_upload_file_ids))
-                    ).all()
-                    for image_file in image_files:
-                        if image_file is None:
-                            continue
-                        try:
-                            storage.delete(image_file.key)
-                        except Exception:
-                            logger.exception(
-                                "Delete image_files failed when storage deleted, \
-                                              image_upload_file_is: %s",
-                                image_file.id,
-                            )
-                    stmt = delete(UploadFile).where(UploadFile.id.in_(image_upload_file_ids))
-                    session.execute(stmt)
-
-                segment_delete_stmt = delete(DocumentSegment).where(DocumentSegment.id.in_(segment_ids))
-                session.execute(segment_delete_stmt)
-            # delete segment attachments
-            if attachments_with_bindings:
-                attachment_ids = [attachment_file.id for _, attachment_file in attachments_with_bindings]
-                binding_ids = [binding.id for binding, _ in attachments_with_bindings]
-                for binding, attachment_file in attachments_with_bindings:
-                    try:
-                        storage.delete(attachment_file.key)
-                    except Exception:
-                        logger.exception(
-                            "Delete attachment_file failed when storage deleted, \
-                                            attachment_file_id: %s",
-                            binding.attachment_id,
-                        )
-                attachment_file_delete_stmt = delete(UploadFile).where(UploadFile.id.in_(attachment_ids))
-                session.execute(attachment_file_delete_stmt)
-
-                binding_delete_stmt = delete(SegmentAttachmentBinding).where(
-                    SegmentAttachmentBinding.id.in_(binding_ids)
-                )
-                session.execute(binding_delete_stmt)
-
-            session.execute(delete(DatasetProcessRule).where(DatasetProcessRule.dataset_id == dataset_id))
-            session.execute(delete(DatasetQuery).where(DatasetQuery.dataset_id == dataset_id))
-            session.execute(delete(AppDatasetJoin).where(AppDatasetJoin.dataset_id == dataset_id))
-            # delete dataset metadata
-            session.execute(delete(DatasetMetadata).where(DatasetMetadata.dataset_id == dataset_id))
-            session.execute(delete(DatasetMetadataBinding).where(DatasetMetadataBinding.dataset_id == dataset_id))
-            # delete pipeline and workflow
-            if pipeline_id:
-                session.execute(delete(Pipeline).where(Pipeline.id == pipeline_id))
-                session.execute(
-                    delete(Workflow).where(
-                        Workflow.tenant_id == tenant_id,
-                        Workflow.app_id == pipeline_id,
-                        Workflow.type == WorkflowType.RAG_PIPELINE,
-                    )
-                )
-            # delete files
-            if documents:
-                file_ids = []
-                for document in documents:
-                    if document.data_source_type == "upload_file":
-                        if document.data_source_info:
-                            data_source_info = document.data_source_info_dict
-                            if data_source_info and "upload_file_id" in data_source_info:
-                                file_id = data_source_info["upload_file_id"]
-                                file_ids.append(file_id)
-                files = session.scalars(select(UploadFile).where(UploadFile.id.in_(file_ids))).all()
-                for file in files:
-                    storage.delete(file.key)
-
-                file_delete_stmt = delete(UploadFile).where(UploadFile.id.in_(file_ids))
-                session.execute(file_delete_stmt)
-
-            session.commit()
             if vector_cleanup_succeeded:
                 schedule_billing_vector_space_refresh(dataset.tenant_id)
+
             end_at = time.perf_counter()
             logger.info(
                 click.style(
@@ -198,19 +117,136 @@ def clean_dataset_task(
                     fg="green",
                 )
             )
-        except Exception:
-            # Add rollback to prevent dirty session state in case of exceptions
-            # This ensures the database session is properly cleaned up
-            try:
-                session.rollback()
-                logger.info(click.style(f"Rolled back database session for dataset: {dataset_id}", fg="yellow"))
-            except Exception:
-                logger.exception("Failed to rollback database session")
-
-            logger.exception("Cleaned dataset when dataset deleted failed")
         finally:
             # Explicitly close the session for test expectations and safety
             try:
                 session.close()
             except Exception:
                 logger.exception("Failed to close database session")
+
+
+def _run_step(session: Session, dataset_id: str, name: str, step: Callable[[], None]) -> bool:
+    """Run one cleanup step in isolation: a failure is logged and the (partial,
+    uncommitted) work is rolled back, but the remaining steps still run.
+
+    Returns whether the step completed successfully."""
+    try:
+        step()
+    except Exception:
+        logger.exception(click.style(f"Failed to clean {name} for dataset {dataset_id}", fg="red"))
+        try:
+            session.rollback()
+        except Exception:
+            logger.exception("Failed to rollback database session")
+        return False
+    return True
+
+
+def _clean_index(session: Session, dataset: Dataset, doc_form: str) -> None:
+    """Drop the vector/keyword index for the dataset and commit the relational rows
+    the index processor deleted along the way (child chunks, summaries, keywords)."""
+    index_processor = IndexProcessorFactory(doc_form).init_index_processor()
+    index_processor.clean(dataset, None, with_keywords=True, delete_child_chunks=True, session=session)
+    session.commit()
+    logger.info(click.style(f"Successfully cleaned vector database for dataset: {dataset.id}", fg="green"))
+
+
+def _delete_segments(session: Session, dataset_id: str) -> None:
+    """Delete document segments in batches, removing their inline image files first."""
+    while True:
+        segments = session.scalars(
+            select(DocumentSegment).where(DocumentSegment.dataset_id == dataset_id).limit(_DELETE_BATCH_SIZE)
+        ).all()
+        if not segments:
+            break
+        image_upload_file_ids: list[str] = []
+        for segment in segments:
+            image_upload_file_ids.extend(get_image_upload_file_ids(segment.content))
+        _delete_upload_files(session, image_upload_file_ids)
+        session.execute(delete(DocumentSegment).where(DocumentSegment.id.in_([segment.id for segment in segments])))
+        session.commit()
+
+
+def _delete_documents(session: Session, dataset_id: str) -> None:
+    """Delete documents in batches, removing their uploaded source files first."""
+    while True:
+        documents = session.scalars(
+            select(Document).where(Document.dataset_id == dataset_id).limit(_DELETE_BATCH_SIZE)
+        ).all()
+        if not documents:
+            break
+        file_ids: list[str] = []
+        for document in documents:
+            if document.data_source_type == "upload_file" and document.data_source_info:
+                data_source_info = document.data_source_info_dict
+                if data_source_info and "upload_file_id" in data_source_info:
+                    file_ids.append(data_source_info["upload_file_id"])
+        _delete_upload_files(session, file_ids)
+        session.execute(delete(Document).where(Document.id.in_([document.id for document in documents])))
+        session.commit()
+
+
+def _delete_upload_files(session: Session, file_ids: Sequence[str]) -> None:
+    """Delete ``UploadFile`` rows and their object-storage blobs in one statement.
+
+    Storage errors are logged but do not keep the row: the dataset is already gone, so
+    leaving the row would orphan it forever, while a stray blob can still be reclaimed
+    by storage garbage collection."""
+    if not file_ids:
+        return
+    files = session.scalars(select(UploadFile).where(UploadFile.id.in_(file_ids))).all()
+    for file in files:
+        try:
+            storage.delete(file.key)
+        except Exception:
+            logger.exception("Delete file failed when storage deleted, upload_file_id: %s", file.id)
+    session.execute(delete(UploadFile).where(UploadFile.id.in_(file_ids)))
+
+
+def _delete_attachments(session: Session, tenant_id: str, dataset_id: str) -> None:
+    """Delete segment attachments (upload files + bindings) for the dataset."""
+    # Use JOIN to fetch attachments with bindings in a single query
+    attachments_with_bindings = session.execute(
+        select(SegmentAttachmentBinding, UploadFile)
+        .join(UploadFile, UploadFile.id == SegmentAttachmentBinding.attachment_id)
+        .where(
+            SegmentAttachmentBinding.tenant_id == tenant_id,
+            SegmentAttachmentBinding.dataset_id == dataset_id,
+        )
+    ).all()
+    if not attachments_with_bindings:
+        return
+    attachment_ids = [attachment_file.id for _, attachment_file in attachments_with_bindings]
+    binding_ids = [binding.id for binding, _ in attachments_with_bindings]
+    for binding, attachment_file in attachments_with_bindings:
+        try:
+            storage.delete(attachment_file.key)
+        except Exception:
+            logger.exception(
+                "Delete attachment_file failed when storage deleted, attachment_file_id: %s",
+                binding.attachment_id,
+            )
+    session.execute(delete(UploadFile).where(UploadFile.id.in_(attachment_ids)))
+    session.execute(delete(SegmentAttachmentBinding).where(SegmentAttachmentBinding.id.in_(binding_ids)))
+    session.commit()
+
+
+def _delete_dataset_scoped_rows(session: Session, tenant_id: str, dataset_id: str, pipeline_id: str | None) -> None:
+    """Delete the remaining small dataset-scoped tables (and the pipeline/workflow)."""
+    session.execute(delete(DatasetProcessRule).where(DatasetProcessRule.dataset_id == dataset_id))
+    session.execute(delete(DatasetQuery).where(DatasetQuery.dataset_id == dataset_id))
+    session.execute(delete(AppDatasetJoin).where(AppDatasetJoin.dataset_id == dataset_id))
+    # delete dataset metadata
+    session.execute(delete(DatasetMetadata).where(DatasetMetadata.dataset_id == dataset_id))
+    session.execute(delete(DatasetMetadataBinding).where(DatasetMetadataBinding.dataset_id == dataset_id))
+    # delete pipeline and workflow
+    if pipeline_id:
+        session.execute(delete(Pipeline).where(Pipeline.id == pipeline_id))
+        session.execute(
+            delete(Workflow).where(
+                Workflow.tenant_id == tenant_id,
+                Workflow.app_id == pipeline_id,
+                Workflow.type == WorkflowType.RAG_PIPELINE,
+            )
+        )
+    session.commit()

--- a/api/tests/test_containers_integration_tests/tasks/test_clean_dataset_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_clean_dataset_task.py
@@ -827,11 +827,14 @@ class TestCleanDatasetTask:
         document = self._create_test_document(db_session_with_containers, account, tenant, dataset)
         segment = self._create_test_segment(db_session_with_containers, account, tenant, dataset, document)
         upload_file = self._create_test_upload_file(db_session_with_containers, account, tenant)
+        # Keep the id: the task deletes the row, so touching the (expired) instance
+        # afterwards would raise ObjectDeletedError instead of reporting the outcome.
+        upload_file_id = upload_file.id
 
         # Update document with file reference
         import json
 
-        document.data_source_info = json.dumps({"upload_file_id": upload_file.id})
+        document.data_source_info = json.dumps({"upload_file_id": upload_file_id})
         db_session_with_containers.commit()
 
         # Mock storage to raise exceptions
@@ -849,21 +852,16 @@ class TestCleanDatasetTask:
         )
 
         # Verify results
-        # Note: When storage operations fail, database deletions may be rolled back by implementation.
-        # This test focuses on ensuring the task handles the exception and continues execution/logging.
-
-        # Check that upload file was still deleted from database despite storage failure
-        # Note: When storage operations fail, the upload file may not be deleted
-        # This demonstrates that the cleanup process continues even with storage errors
+        # The dataset row is already gone, so nothing will retry this cleanup. A failure to
+        # delete the blob must therefore not keep the row: the row would be orphaned forever,
+        # whereas a stray blob can still be reclaimed by storage garbage collection.
+        db_session_with_containers.expire_all()
         remaining_files = db_session_with_containers.scalars(
-            select(UploadFile).where(UploadFile.id == upload_file.id)
+            select(UploadFile).where(UploadFile.id == upload_file_id)
         ).all()
-        # The upload file should still be deleted from the database even if storage cleanup fails
-        # However, this depends on the specific implementation of clean_dataset_task
-        if len(remaining_files) > 0:
-            print(f"Warning: Upload file {upload_file.id} was not deleted despite storage failure")
-            print("This demonstrates that the cleanup process continues even with storage errors")
-        # We don't assert here as the behavior depends on the specific implementation
+        assert remaining_files == [], (
+            f"Upload file {upload_file_id} outlived its dataset because the storage delete failed"
+        )
 
         # Verify that storage.delete was called
         mock_storage.delete.assert_called_once()

--- a/api/tests/unit_tests/tasks/test_clean_dataset_task.py
+++ b/api/tests/unit_tests/tasks/test_clean_dataset_task.py
@@ -218,6 +218,29 @@ def _persist_attachment(
     return binding, attachment_file
 
 
+def _persist_segment(
+    session_maker: sessionmaker[Session],
+    *,
+    dataset_id: str,
+    tenant_id: str,
+    document_id: str,
+    position: int = 1,
+) -> DocumentSegment:
+    segment = DocumentSegment(
+        tenant_id=tenant_id,
+        dataset_id=dataset_id,
+        document_id=document_id,
+        position=position,
+        content="segment",
+        word_count=1,
+        tokens=1,
+        created_by=str(uuid.uuid4()),
+    )
+    with session_maker.begin() as session:
+        session.add(segment)
+    return segment
+
+
 # ============================================================================
 # Test Basic Cleanup
 # ============================================================================
@@ -579,3 +602,121 @@ class TestIndexProcessorParameters:
             )
 
         schedule_refresh.assert_not_called()
+
+
+# ============================================================================
+# Test Step Isolation and Batching
+# ============================================================================
+
+
+class TestStepIsolation:
+    """Each cleanup step is committed on its own, so one failure cannot undo the rest."""
+
+    def test_cleanup_commits_more_than_once(
+        self,
+        orm_session_maker: sessionmaker[Session],
+        sqlite_session_factory: sessionmaker[Session],
+        dataset_id: str,
+        tenant_id: str,
+        collection_binding_id: str,
+        mock_storage: MagicMock,
+        mock_index_processor_factory: dict[str, MagicMock],
+        mock_get_image_upload_file_ids: MagicMock,
+    ):
+        """A single commit at the end is what strands data when any step fails."""
+        document = _persist_document(orm_session_maker, dataset_id=dataset_id, tenant_id=tenant_id)
+        _persist_segment(orm_session_maker, dataset_id=dataset_id, tenant_id=tenant_id, document_id=document.id)
+
+        commits: list[int] = []
+
+        def _count_commit(_session: Session) -> None:
+            commits.append(1)
+
+        event.listen(sqlite_session_factory, "after_commit", _count_commit)
+        try:
+            _run_clean_dataset(
+                dataset_id=dataset_id,
+                tenant_id=tenant_id,
+                collection_binding_id=collection_binding_id,
+            )
+        finally:
+            event.remove(sqlite_session_factory, "after_commit", _count_commit)
+
+        assert len(commits) > 1, (
+            f"Cleanup still runs as one transaction ({len(commits)} commit); a failure anywhere rolls back everything"
+        )
+
+    def test_failing_step_keeps_earlier_work_and_still_runs_later_steps(
+        self,
+        orm_session_maker: sessionmaker[Session],
+        dataset_id: str,
+        tenant_id: str,
+        collection_binding_id: str,
+        mock_storage: MagicMock,
+        mock_index_processor_factory: dict[str, MagicMock],
+        mock_get_image_upload_file_ids: MagicMock,
+    ):
+        """Segments are deleted before documents and metadata after them. With documents
+        failing, the committed segment deletion must survive and the metadata step must
+        still run."""
+        document = _persist_document(orm_session_maker, dataset_id=dataset_id, tenant_id=tenant_id)
+        segment = _persist_segment(
+            orm_session_maker, dataset_id=dataset_id, tenant_id=tenant_id, document_id=document.id
+        )
+        metadata = DatasetMetadata(
+            tenant_id=tenant_id,
+            dataset_id=dataset_id,
+            type="string",
+            name="meta",
+            created_by=str(uuid.uuid4()),
+        )
+        with orm_session_maker.begin() as session:
+            session.add(metadata)
+
+        with patch(
+            "tasks.clean_dataset_task._delete_documents",
+            side_effect=RuntimeError("deadlock on documents"),
+        ):
+            _run_clean_dataset(
+                dataset_id=dataset_id,
+                tenant_id=tenant_id,
+                collection_binding_id=collection_binding_id,
+            )
+
+        with orm_session_maker() as session:
+            assert session.get(DocumentSegment, segment.id) is None, (
+                "The committed segment deletion was rolled back by a later failure"
+            )
+            assert session.get(DatasetMetadata, metadata.id) is None, "A failed step skipped the steps after it"
+            assert session.get(Document, document.id) is not None, (
+                "Sanity check: the failing step should not have deleted its own rows"
+            )
+
+
+class TestBatchedDeletes:
+    """Large child tables are deleted in bounded batches."""
+
+    def test_documents_are_deleted_across_multiple_batches(
+        self,
+        orm_session_maker: sessionmaker[Session],
+        dataset_id: str,
+        tenant_id: str,
+        collection_binding_id: str,
+        mock_storage: MagicMock,
+        mock_index_processor_factory: dict[str, MagicMock],
+        mock_get_image_upload_file_ids: MagicMock,
+    ):
+        """With a batch size smaller than the row count the loop must still drain the
+        table, rather than stopping after the first batch."""
+        documents = [_persist_document(orm_session_maker, dataset_id=dataset_id, tenant_id=tenant_id) for _ in range(5)]
+
+        with patch("tasks.clean_dataset_task._DELETE_BATCH_SIZE", 2):
+            _run_clean_dataset(
+                dataset_id=dataset_id,
+                tenant_id=tenant_id,
+                collection_binding_id=collection_binding_id,
+            )
+
+        with orm_session_maker() as session:
+            remaining = [document.id for document in documents if session.get(Document, document.id) is not None]
+        assert not remaining, f"Batched delete left {len(remaining)} of 5 documents behind"


### PR DESCRIPTION
Rebased onto current `main` and rewritten. The child-chunk leak that used to be bundled here is now a separate, much smaller PR — #41261 — so this one is purely about how the cleanup transacts. Refs #38518.

### The problem

`clean_dataset_task` runs after the dataset row is already gone. If the cleanup fails there is no owner left to trigger a retry, so a failure is permanent by construction.

Today the whole cleanup is one transaction, and the child tables are addressed through `IN (...)` lists built from every matching row:

```python
segment_delete_stmt = delete(DocumentSegment).where(DocumentSegment.id.in_(segment_ids))
```

One timeout or deadlock — a large dataset, or a lock still held by indexing that was running when the delete was issued — rolls back everything and orphans the documents, segments, files and the vector index for good. The single `except Exception` at the end also flattens every failure into one message, so the log does not say which part gave up.

### The change

The cleanup becomes a sequence of independent steps, each committed as it completes:

1. index (vector store + keyword table)
2. segments
3. documents
4. attachments
5. the remaining dataset-scoped rows (process rules, queries, app joins, metadata, pipeline/workflow)

`_run_step` runs one step, and on failure logs it with the step's name, rolls back that step's uncommitted work, and lets the remaining steps proceed. Work that was already committed stays committed regardless of what happens later. Partial cleanup beats none, and the log now names the step that failed.

**The index cleanup is deliberately step one with its own commit.** The index processors flush their relational side effects — child chunks, summaries, the keyword table — via `session.flush()` without committing. Under the current single transaction, a rollback in any later step silently undoes those deletions while the vector store has already been cleaned, leaving the relational rows pointing at an index that no longer exists. Committing right after the processor returns closes that window.

**Segments and documents are deleted in bounded batches** (`_DELETE_BATCH_SIZE = 1000`) instead of one statement per table, so each transaction and each parameter list stays small. The constant is read through the module global rather than a default argument so tests can patch it.

This also matches two rules from `api/AGENTS.md`: *"Keep write transactions explicit and bounded"* and *"Celery tasks that may be retried or redelivered must keep side effects idempotent."*

### On the size of this diff

Most of it is one 200-line function being split into named steps; the batching itself is a `while` loop and a constant. I looked at whether the transactional restructuring and the batching could ship as two PRs, and they cannot usefully: the restructuring alone is the same size as this whole diff, because the movement of code *is* the change. What was genuinely separable is the child-chunk fix, now in #41261 at +9 lines.

### Tests

Three cases added to `tests/unit_tests/tasks/test_clean_dataset_task.py`, all failing on `main`:

- `test_cleanup_commits_more_than_once` — counts `after_commit` events; one commit is what strands data
- `test_failing_step_keeps_earlier_work_and_still_runs_later_steps` — makes the documents step raise, then asserts the committed segment deletion survived, the later metadata step still ran, and the failing step's own rows were left alone
- `test_documents_are_deleted_across_multiple_batches` — batch size patched below the row count, asserts the loop drains the table

The file passes: 11 tests. `ruff check` and `ruff format --check` are clean.
