### PR TITLE
fix(web): cache server console context

### DIFF
--- a/web/service/server.ts
+++ b/web/service/server.ts
@@ -5,6 +5,7 @@ import type { JsonifiedClient } from '@orpc/openapi-client'
 import { createORPCClient, onError } from '@orpc/client'
 import { OpenAPILink } from '@orpc/openapi-client/fetch'
 import { createTanstackQueryUtils } from '@orpc/tanstack-query'
+import { cache } from 'react'
 import {
   API_PREFIX,
   CSRF_COOKIE_NAME,
@@ -93,7 +94,7 @@ function createServerConsoleOpenAPILink(contract: AnyContractRouter): ServerCons
   })
 }
 
-export const getServerConsoleClientContext = async (): Promise<ServerConsoleClientContext> => {
+export const getServerConsoleClientContext = cache(async (): Promise<ServerConsoleClientContext> => {
   const { cookies, headers } = await import('@/next/headers')
   const requestHeaders = await headers()
   const cookieStore = await cookies()
@@ -102,7 +103,7 @@ export const getServerConsoleClientContext = async (): Promise<ServerConsoleClie
     cookie: requestHeaders.get('cookie') || undefined,
     csrfToken: cookieStore.get(CSRF_COOKIE_NAME())?.value,
   }
-}
+})
 
 export const getServerConsoleRequestHeaders = async () =>
   createServerConsoleRequestHeaders(await getServerConsoleClientContext())


### PR DESCRIPTION
## Summary
- Cache the server console request context with React `cache()` for request-scoped dedupe.
- Preserve the existing server-only console transport and forwarded cookie/csrf behavior.

## Verification
- `pnpm -C web test -- service/__tests__/server.spec.ts`
- `pnpm -C web test -- app/(commonLayout)/__tests__/hydration-boundary.spec.tsx`
- `pnpm -C web test -- features/system-features/__tests__/system-features.spec.ts`
- `git diff --check`

## Manual Check
- Temporary server logging showed one `/` render previously called `getServerConsoleClientContext()` 3 times.
- After wrapping with React `cache()`, the same page render emitted one context log per request wave.
