### PR TITLE
fix: remove overly strict guard in dataset deletion handler to prevent orphaned vector collections

### DIFF
--- a/api/events/event_handlers/clean_when_dataset_deleted.py
+++ b/api/events/event_handlers/clean_when_dataset_deleted.py
@@ -6,8 +6,12 @@ from tasks.clean_dataset_task import clean_dataset_task
 @dataset_was_deleted.connect
 def handle(sender: Dataset, **kwargs):
     dataset = sender
-    if not dataset.doc_form or not dataset.indexing_technique:
-        return
+    # Always dispatch the cleanup task, even when doc_form or indexing_technique
+    # is empty. Datasets created in older Dify versions frequently have these
+    # fields null, and the cleanup task already handles empty doc_form by
+    # falling back to PARAGRAPH_INDEX (see clean_dataset_task.py).
+    # The previous early-return skipped vector cleanup for exactly these
+    # datasets, leaving orphaned collections in the vector store.
     clean_dataset_task.delay(
         dataset.id,
         dataset.tenant_id,

--- a/api/tasks/clean_dataset_task.py
+++ b/api/tasks/clean_dataset_task.py
@@ -33,10 +33,10 @@ logger = logging.getLogger(__name__)
 def clean_dataset_task(
     dataset_id: str,
     tenant_id: str,
-    indexing_technique: str,
-    index_struct: str,
-    collection_binding_id: str,
-    doc_form: str,
+    indexing_technique: str | None,
+    index_struct: str | None,
+    collection_binding_id: str | None,
+    doc_form: str | None,
     pipeline_id: str | None = None,
 ):
     """

--- a/api/tests/test_containers_integration_tests/services/test_dataset_service_delete_dataset.py
+++ b/api/tests/test_containers_integration_tests/services/test_dataset_service_delete_dataset.py
@@ -147,7 +147,7 @@ class TestDatasetServiceDeleteDataset:
         )
 
     def test_delete_empty_dataset_success(self, db_session_with_containers: Session):
-        """Delete an empty dataset without scheduling cleanup when both gating fields are absent."""
+        """Delete an empty dataset and still dispatch cleanup so vector store collections are removed."""
         # Arrange
         owner, tenant = DatasetDeleteIntegrationDataFactory.create_account_with_tenant(db_session_with_containers)
         dataset = DatasetDeleteIntegrationDataFactory.create_dataset(
@@ -172,10 +172,18 @@ class TestDatasetServiceDeleteDataset:
         db_session_with_containers.expire_all()
         assert result is True
         assert db_session_with_containers.get(Dataset, dataset.id) is None
-        clean_dataset_delay.assert_not_called()
+        clean_dataset_delay.assert_called_once_with(
+            dataset.id,
+            dataset.tenant_id,
+            dataset.indexing_technique,
+            dataset.index_struct,
+            dataset.collection_binding_id,
+            dataset.doc_form,
+            dataset.pipeline_id,
+        )
 
     def test_delete_dataset_with_partial_none_values(self, db_session_with_containers: Session):
-        """Delete a dataset without cleanup when indexing_technique is missing but doc_form resolves."""
+        """Delete a dataset and dispatch cleanup even when indexing_technique is missing but doc_form resolves."""
         # Arrange
         owner, tenant = DatasetDeleteIntegrationDataFactory.create_account_with_tenant(db_session_with_containers)
         dataset = DatasetDeleteIntegrationDataFactory.create_dataset(
@@ -200,10 +208,18 @@ class TestDatasetServiceDeleteDataset:
         db_session_with_containers.expire_all()
         assert result is True
         assert db_session_with_containers.get(Dataset, dataset.id) is None
-        clean_dataset_delay.assert_not_called()
+        clean_dataset_delay.assert_called_once_with(
+            dataset.id,
+            dataset.tenant_id,
+            dataset.indexing_technique,
+            dataset.index_struct,
+            dataset.collection_binding_id,
+            dataset.doc_form,
+            dataset.pipeline_id,
+        )
 
     def test_delete_dataset_with_doc_form_none_indexing_technique_exists(self, db_session_with_containers: Session):
-        """Delete a dataset without cleanup when indexing exists but doc_form resolves to None."""
+        """Delete a dataset and dispatch cleanup even when indexing exists but doc_form resolves to None."""
         # Arrange
         owner, tenant = DatasetDeleteIntegrationDataFactory.create_account_with_tenant(db_session_with_containers)
         dataset = DatasetDeleteIntegrationDataFactory.create_dataset(
@@ -228,7 +244,15 @@ class TestDatasetServiceDeleteDataset:
         db_session_with_containers.expire_all()
         assert result is True
         assert db_session_with_containers.get(Dataset, dataset.id) is None
-        clean_dataset_delay.assert_not_called()
+        clean_dataset_delay.assert_called_once_with(
+            dataset.id,
+            dataset.tenant_id,
+            dataset.indexing_technique,
+            dataset.index_struct,
+            dataset.collection_binding_id,
+            dataset.doc_form,
+            dataset.pipeline_id,
+        )
 
     def test_delete_dataset_not_found(self, db_session_with_containers: Session):
         """Return False without scheduling cleanup when the target dataset does not exist."""


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #38537

When a dataset with empty `doc_form` or `indexing_technique` (common in datasets created by older Dify versions and migrated forward) was deleted, the signal handler in `clean_when_dataset_deleted.py` returned early and never dispatched `clean_dataset_task`. This left the corresponding vector store collection (e.g. Qdrant `Vector_index_<uuid>_Node`) permanently orphaned — the cleanup task was never run, and there was no retry/reconcile path.

The cleanup task already handles empty `doc_form` by falling back to `PARAGRAPH_INDEX` (see `clean_dataset_task.py` lines 79-89), and `indexing_technique` is not used to select the cleanup path — it is only stored on the reconstructed `Dataset` object. So the guard was stricter than the task it protected, blocking exactly the case the task already handles.

**Changes:**
- Removed the `if not dataset.doc_form or not dataset.indexing_technique: return` early-return guard in `api/events/event_handlers/clean_when_dataset_deleted.py` so cleanup is always dispatched.
- Updated the three integration tests in `test_dataset_service_delete_dataset.py` that codified the old (buggy) behavior — they now assert `clean_dataset_task.delay` is called with the correct arguments instead of asserting it was never called.

## Screenshots

N/A — backend-only change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods