### PR TITLE
fix(agent): stabilize tool call thought correlation

### DIFF
--- a/api/core/app/apps/agent_app/app_runner.py
+++ b/api/core/app/apps/agent_app/app_runner.py
@@ -346,6 +346,9 @@ class _AgentProcessRecorder:
             tool=tool_name,
             tool_input_delta=_json_or_text(args_delta),
         )
+        self._remember_tool_thought(
+            index=index, tool_call_id=tool_call_id, tool_name=tool_name, thought_id=thought_id
+        )
 
     def _record_tool_call_part(self, index: int, part: dict[str, Any]) -> None:
         self._close_thinking_segments()
@@ -363,6 +366,9 @@ class _AgentProcessRecorder:
             thought_id,
             tool=tool_name,
             tool_input=_json_or_text(part.get("args")),
+        )
+        self._remember_tool_thought(
+            index=index, tool_call_id=tool_call_id, tool_name=tool_name, thought_id=thought_id
         )
 
     def _record_tool_return_part(self, part: dict[str, Any]) -> None:
@@ -1085,5 +1091,6 @@ class AgentAppRunner:
                 return text
             return json.dumps(output, ensure_ascii=False)
         return json.dumps(output, ensure_ascii=False)
+
 
 __all__ = ["AgentAppRunner", "publish_message_end", "publish_text_answer", "publish_text_delta"]

--- a/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
+++ b/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
@@ -858,6 +858,67 @@ def test_tool_result_without_identity_does_not_attach_to_previous_tool(monkeypat
     assert rows[1].observation == "Knowledge base search results: browser skill"
 
 
+def test_tool_call_part_binds_late_call_id_to_delta_row(monkeypatch):
+    fake_session = _FakeDbSession()
+    monkeypatch.setattr(app_runner_module.db, "session", fake_session)
+    qm = _FakeQueueManager()
+    recorder = app_runner_module._AgentProcessRecorder(
+        dify_context=_dify_ctx(),
+        message_id="msg-1",
+        queue_manager=qm,  # type: ignore[arg-type]
+    )
+
+    recorder.handle_stream_event(
+        AgentBackendStreamInternalEvent(
+            run_id="run-1",
+            data={
+                "event_kind": "part_delta",
+                "index": 0,
+                "delta": {
+                    "part_delta_kind": "tool_call",
+                    "tool_name_delta": "knowledge_base_search",
+                    "args_delta": {"query": "browser"},
+                },
+            },
+        )
+    )
+    recorder.handle_stream_event(
+        AgentBackendStreamInternalEvent(
+            run_id="run-1",
+            data={
+                "event_kind": "part_start",
+                "index": 0,
+                "part": {
+                    "part_kind": "tool-call",
+                    "tool_name": "knowledge_base_search",
+                    "args": {"query": "browser"},
+                    "tool_call_id": "tool-call-1",
+                },
+            },
+        )
+    )
+    recorder.handle_stream_event(
+        AgentBackendStreamInternalEvent(
+            run_id="run-1",
+            data={
+                "event_kind": "function_tool_result",
+                "part": {
+                    "part_kind": "tool-return",
+                    "tool_name": "knowledge_base_search",
+                    "content": "Knowledge base search results: browser skill",
+                    "tool_call_id": "tool-call-1",
+                },
+            },
+        )
+    )
+
+    rows = sorted(fake_session.rows.values(), key=lambda row: row.position)
+    assert len(rows) == 1
+    assert rows[0].tool == "knowledge_base_search"
+    assert rows[0].tool_input == '{"query": "browser"}'
+    assert rows[0].observation == "Knowledge base search results: browser skill"
+
+
 def test_thinking_after_tool_starts_new_snapshot_row(monkeypatch):
     fake_session = _FakeDbSession()
     monkeypatch.setattr(app_runner_module.db, "session", fake_session)

--- a/dify-agent/src/dify_agent/adapters/llm/model.py
+++ b/dify-agent/src/dify_agent/adapters/llm/model.py
@@ -334,7 +334,7 @@ def _map_model_response_to_prompt_message(
     content_parts: list[PromptMessageContentUnionTypes] = []
     tool_calls: list[AssistantPromptMessage.ToolCall] = []
 
-    for part in message.parts:
+    for index, part in enumerate(message.parts):
         if isinstance(part, TextPart):
             if part.content:
                 content_parts.append(TextPromptMessageContent(data=part.content))
@@ -346,7 +346,7 @@ def _map_model_response_to_prompt_message(
         elif isinstance(part, ToolCallPart):
             tool_calls.append(
                 AssistantPromptMessage.ToolCall(
-                    id=part.tool_call_id or f"tool-call-{part.tool_name}",
+                    id=part.tool_call_id or f"tool-call-{index}-{part.tool_name}",
                     type="function",
                     function=AssistantPromptMessage.ToolCall.ToolCallFunction(
                         name=part.tool_name,

--- a/dify-agent/tests/local/dify_agent/adapters/llm/test_model.py
+++ b/dify-agent/tests/local/dify_agent/adapters/llm/test_model.py
@@ -242,6 +242,45 @@ class DifyLLMAdapterModelTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.parts[0].part_kind, "text")
         self.assertEqual(cast(TextPart, response.parts[0]).content, "adapter response")
 
+    async def test_request_uses_unique_fallback_ids_for_same_name_tool_calls(self) -> None:
+        messages = [
+            ModelRequest(parts=[UserPromptPart("hello")]),
+            ModelResponse(
+                parts=[
+                    ToolCallPart(tool_name="lookup", args={"query": "first"}, tool_call_id=""),
+                    ToolCallPart(tool_name="lookup", args={"query": "second"}, tool_call_id=""),
+                ]
+            ),
+        ]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            payload = json.loads(request.content.decode("utf-8"))
+            prompt_messages = payload["data"]["prompt_messages"]
+            tool_calls = prompt_messages[1]["tool_calls"]
+
+            self.assertEqual(tool_calls[0]["id"], "tool-call-0-lookup")
+            self.assertEqual(tool_calls[1]["id"], "tool-call-1-lookup")
+
+            return build_stream_response(*single_text_chunk("adapter response", prompt_tokens=11, completion_tokens=7))
+
+        async with self.mock_daemon_stream(httpx.MockTransport(handler)):
+            adapter = DifyLLMAdapterModel(
+                "demo-model",
+                self.make_provider(),
+                model_provider="openai",
+                credentials={"api_key": "secret"},
+            )
+
+            response = await adapter.request(
+                messages,
+                model_settings=None,
+                model_request_parameters=ModelRequestParameters(),
+            )
+
+        self.assertEqual(response.model_name, "demo-model")
+        self.assertEqual(response.parts[0].part_kind, "text")
+        self.assertEqual(cast(TextPart, response.parts[0]).content, "adapter response")
+
     async def test_request_collapses_text_only_assistant_history_parts_to_string_content(self) -> None:
         messages = [
             ModelRequest(parts=[UserPromptPart("initial request")]),


### PR DESCRIPTION
## Summary
- Bind late-arriving `tool_call_id` / tool name metadata back to the existing agent thought row when a tool call was first created from a delta event.
- Use position-scoped fallback tool call IDs when replaying assistant tool-call history to the agent backend, so same-name fallback calls do not collide.
- Add regressions for late tool-call ID binding and same-name fallback tool call IDs.

## Verification
- `uv run ruff check core/app/apps/agent_app/app_runner.py tests/unit_tests/core/app/apps/agent_app/test_app_runner.py`
- `uv run ruff check src/dify_agent/adapters/llm/model.py tests/local/dify_agent/adapters/llm/test_model.py`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run pytest tests/local/dify_agent/adapters/llm/test_model.py`
- `make type-check-core`
- Manual API recorder regression on local feat branch: `part_delta -> part_start(tool_call_id) -> function_tool_result(tool_call_id)` persisted one thought row with non-empty request and observation.
- Deployed first to `deploy/agent` at `98bcfd41b9`; build/push workflow succeeded: https://github.com/langgenius/dify/actions/runs/28930775001
- Verified `agent.dify.dev` runtime containers include the API recorder change and agent backend fallback change.
- WebApp runtime regression against `https://agent-app.dify.dev/agent/N0wAxZxHz9opP4g0`: one `current_time` tool call, one thought id, request `{}` retained, observation attached to the same thought, no observation-only empty request tool row.
- Remote agent backend fallback regression: same-name fallback calls produced `tool-call-0-lookup` and `tool-call-1-lookup`.

Note: local API pytest runner still exits 139 in this workstation environment, so the API recorder case was validated through a direct fake-session regression script instead of pytest.
