### PR TITLE
refactor(web): migrate shell navigation app context consumers

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -310,14 +310,6 @@
       "count": 4
     }
   },
-  "web/app/components/app-sidebar/dataset-info/__tests__/index.spec.tsx": {
-    "jsx-a11y/click-events-have-key-events": {
-      "count": 1
-    },
-    "jsx-a11y/no-static-element-interactions": {
-      "count": 1
-    }
-  },
   "web/app/components/app-sidebar/dataset-info/menu-item.tsx": {
     "jsx-a11y/click-events-have-key-events": {
       "count": 1

--- a/web/__tests__/utils/mock-app-context-state.ts
+++ b/web/__tests__/utils/mock-app-context-state.ts
@@ -22,7 +22,7 @@ export type AppContextStateMockState = {
   isLoadingCurrentWorkspace?: boolean
   isLoadingWorkspacePermissionKeys?: boolean
   workspacePermissionKeys?: string[]
-  langGeniusVersionInfo?: LangGeniusVersionResponse
+  langGeniusVersionInfo?: Partial<LangGeniusVersionResponse>
   refreshUserProfile?: () => void
   refreshCurrentWorkspace?: () => void
 }
@@ -36,6 +36,8 @@ type AppContextStateAtomKind
     | 'workspaceRoleFlags'
     | 'isCurrentWorkspaceManager'
     | 'isCurrentWorkspaceOwner'
+    | 'isCurrentWorkspaceEditor'
+    | 'isCurrentWorkspaceDatasetOperator'
     | 'currentWorkspaceLoading'
     | 'workspacePermissionKeys'
     | 'workspacePermissionKeysLoading'
@@ -98,6 +100,11 @@ const getCurrentWorkspace = (state: AppContextStateMockState) => ({
   ...state.currentWorkspace,
 })
 
+const getLangGeniusVersionInfo = (state: AppContextStateMockState): LangGeniusVersionResponse => ({
+  ...defaultLangGeniusVersionInfo,
+  ...state.langGeniusVersionInfo,
+})
+
 export const createAppContextStateAtomMock = async (
   importOriginal: <T>() => Promise<T>,
   getState: () => AppContextStateMockState,
@@ -117,6 +124,8 @@ export const createAppContextStateAtomMock = async (
     workspaceRoleFlagsAtom: createMockAtom('workspaceRoleFlags'),
     isCurrentWorkspaceManagerAtom: createMockAtom('isCurrentWorkspaceManager'),
     isCurrentWorkspaceOwnerAtom: createMockAtom('isCurrentWorkspaceOwner'),
+    isCurrentWorkspaceEditorAtom: createMockAtom('isCurrentWorkspaceEditor'),
+    isCurrentWorkspaceDatasetOperatorAtom: createMockAtom('isCurrentWorkspaceDatasetOperator'),
     currentWorkspaceLoadingAtom: createMockAtom('currentWorkspaceLoading'),
     workspacePermissionKeysAtom: createMockAtom('workspacePermissionKeys'),
     workspacePermissionKeysLoadingAtom: createMockAtom('workspacePermissionKeysLoading'),
@@ -175,6 +184,12 @@ export const createAppContextStateJotaiMock = async (
       if (atom[APP_CONTEXT_STATE_ATOM_KIND] === 'isCurrentWorkspaceOwner')
         return state.isCurrentWorkspaceOwner ?? false
 
+      if (atom[APP_CONTEXT_STATE_ATOM_KIND] === 'isCurrentWorkspaceEditor')
+        return state.isCurrentWorkspaceEditor ?? false
+
+      if (atom[APP_CONTEXT_STATE_ATOM_KIND] === 'isCurrentWorkspaceDatasetOperator')
+        return state.isCurrentWorkspaceDatasetOperator ?? false
+
       if (atom[APP_CONTEXT_STATE_ATOM_KIND] === 'currentWorkspaceLoading')
         return state.isLoadingCurrentWorkspace ?? false
 
@@ -185,10 +200,10 @@ export const createAppContextStateJotaiMock = async (
         return state.isLoadingWorkspacePermissionKeys ?? false
 
       if (atom[APP_CONTEXT_STATE_ATOM_KIND] === 'langGeniusVersionInfo')
-        return state.langGeniusVersionInfo ?? defaultLangGeniusVersionInfo
+        return getLangGeniusVersionInfo(state)
 
       if (atom[APP_CONTEXT_STATE_ATOM_KIND] === 'langGeniusCurrentVersion')
-        return (state.langGeniusVersionInfo ?? defaultLangGeniusVersionInfo).current_version
+        return getLangGeniusVersionInfo(state).current_version
 
       throw new Error(`Unsupported app context state atom: ${atom[APP_CONTEXT_STATE_ATOM_KIND]}`)
     },

--- a/web/app/components/app-sidebar/__tests__/app-detail-section.spec.tsx
+++ b/web/app/components/app-sidebar/__tests__/app-detail-section.spec.tsx
@@ -8,6 +8,12 @@ let mockAppMode = 'chat'
 let mockPathname = '/app/app-1/logs'
 let mockAppPermissionKeys: string[] = []
 let mockIsRbacEnabled = true
+const mockAppContextState = vi.hoisted(() => ({
+  current: {
+    userProfile: { id: 'user-1' },
+    workspacePermissionKeys: [] as string[],
+  },
+}))
 
 const render = (ui: Parameters<typeof renderWithSystemFeatures>[0]) => renderWithSystemFeatures(ui, {
   systemFeatures: {
@@ -29,12 +35,15 @@ vi.mock('@/app/components/app/store', () => ({
   }),
 }))
 
-vi.mock('@/context/app-context', () => ({
-  useAppContext: () => ({
-    userProfile: { id: 'user-1' },
-    workspacePermissionKeys: [],
-  }),
-}))
+vi.mock('@/context/app-context-state', async (importOriginal) => {
+  const { createAppContextStateAtomMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateAtomMock(importOriginal, () => mockAppContextState.current)
+})
+
+vi.mock('jotai', async (importOriginal) => {
+  const { createAppContextStateJotaiMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateJotaiMock(importOriginal)
+})
 
 vi.mock('@/next/navigation', () => ({
   usePathname: () => mockPathname,

--- a/web/app/components/app-sidebar/__tests__/dataset-detail-section.spec.tsx
+++ b/web/app/components/app-sidebar/__tests__/dataset-detail-section.spec.tsx
@@ -8,6 +8,12 @@ let mockPathname = '/datasets/dataset-1/documents'
 let mockDataset: DataSet | undefined
 let mockRelatedApps: RelatedAppResponse | undefined
 let mockIsRbacEnabled = true
+const mockAppContextState = vi.hoisted(() => ({
+  current: {
+    userProfile: { id: 'user-1' },
+    workspacePermissionKeys: [] as string[],
+  },
+}))
 
 const render = (ui: Parameters<typeof renderWithSystemFeatures>[0]) => renderWithSystemFeatures(ui, {
   systemFeatures: {
@@ -19,12 +25,15 @@ vi.mock('@/next/navigation', () => ({
   usePathname: () => mockPathname,
 }))
 
-vi.mock('@/context/app-context', () => ({
-  useAppContext: () => ({
-    userProfile: { id: 'user-1' },
-    workspacePermissionKeys: [],
-  }),
-}))
+vi.mock('@/context/app-context-state', async (importOriginal) => {
+  const { createAppContextStateAtomMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateAtomMock(importOriginal, () => mockAppContextState.current)
+})
+
+vi.mock('jotai', async (importOriginal) => {
+  const { createAppContextStateJotaiMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateJotaiMock(importOriginal)
+})
 
 vi.mock('@/service/knowledge/use-dataset', () => ({
   useDatasetDetail: () => ({ data: mockDataset, refetch: vi.fn() }),

--- a/web/app/components/app-sidebar/app-detail-section.tsx
+++ b/web/app/components/app-sidebar/app-detail-section.tsx
@@ -16,12 +16,13 @@ import {
   RiTerminalWindowLine,
 } from '@remixicon/react'
 import { useSuspenseQuery } from '@tanstack/react-query'
+import { useAtomValue } from 'jotai'
 import { Fragment, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStore } from '@/app/components/app/store'
 import Divider from '@/app/components/base/divider'
 import Annotations from '@/app/components/base/icons/src/vender/Annotations'
-import { useAppContext } from '@/context/app-context'
+import { userProfileIdAtom, workspacePermissionKeysAtom } from '@/context/app-context-state'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { usePathname } from '@/next/navigation'
 import { AppModeEnum } from '@/types/app'
@@ -74,7 +75,8 @@ const AppDetailSection = ({
   const { t } = useTranslation()
   const pathname = usePathname()
   const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
-  const { userProfile, workspacePermissionKeys } = useAppContext()
+  const currentUserId = useAtomValue(userProfileIdAtom)
+  const workspacePermissionKeys = useAtomValue(workspacePermissionKeysAtom)
   const isRbacEnabled = systemFeatures.rbac_enabled
   const appDetail = useStore(state => state.appDetail)
   const appInfoActions = useAppInfoActions({
@@ -89,7 +91,7 @@ const AppDetailSection = ({
     const isWorkflowApp = appDetail.mode === AppModeEnum.WORKFLOW || appDetail.mode === AppModeEnum.ADVANCED_CHAT
     const supportsAnnotations = appDetail.mode !== AppModeEnum.WORKFLOW && appDetail.mode !== AppModeEnum.COMPLETION
     const appACLCapabilities = getAppACLCapabilities(appDetail.permission_keys, {
-      currentUserId: userProfile?.id,
+      currentUserId,
       resourceMaintainer: appDetail.maintainer,
       workspacePermissionKeys,
       isRbacEnabled,
@@ -148,7 +150,7 @@ const AppDetailSection = ({
         : []
       ),
     ]
-  }, [appDetail, t, userProfile?.id, workspacePermissionKeys, isRbacEnabled])
+  }, [appDetail, t, currentUserId, workspacePermissionKeys, isRbacEnabled])
 
   if (!appDetail)
     return null

--- a/web/app/components/app-sidebar/app-info/__tests__/app-info-detail-panel.spec.tsx
+++ b/web/app/components/app-sidebar/app-info/__tests__/app-info-detail-panel.spec.tsx
@@ -9,12 +9,24 @@ import AppInfoDetailPanel from '../app-info-detail-panel'
 const mockWorkspacePermissionKeys = vi.hoisted(() => ({
   value: ['app.create_and_management'] as string[],
 }))
-
-vi.mock('@/context/app-context', () => ({
-  useSelector: <T,>(selector: (state: { workspacePermissionKeys: string[] }) => T): T => selector({
-    workspacePermissionKeys: mockWorkspacePermissionKeys.value,
-  }),
+const mockAppContextState = vi.hoisted(() => ({
+  current: {
+    userProfile: { id: 'user-1' },
+    get workspacePermissionKeys() {
+      return mockWorkspacePermissionKeys.value
+    },
+  },
 }))
+
+vi.mock('@/context/app-context-state', async (importOriginal) => {
+  const { createAppContextStateAtomMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateAtomMock(importOriginal, () => mockAppContextState.current)
+})
+
+vi.mock('jotai', async (importOriginal) => {
+  const { createAppContextStateJotaiMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateJotaiMock(importOriginal)
+})
 
 vi.mock('../../../base/app-icon', () => ({
   default: ({ size, icon }: { size: string, icon: string }) => (

--- a/web/app/components/app-sidebar/app-info/app-info-detail-panel.tsx
+++ b/web/app/components/app-sidebar/app-info/app-info-detail-panel.tsx
@@ -10,11 +10,12 @@ import {
   RiFileDownloadLine,
   RiFileUploadLine,
 } from '@remixicon/react'
+import { useAtomValue } from 'jotai'
 import * as React from 'react'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import CardView from '@/app/(commonLayout)/app/(appDetailLayout)/[appId]/overview/card-view'
-import { useSelector as useAppContextWithSelector } from '@/context/app-context'
+import { userProfileIdAtom, workspacePermissionKeysAtom } from '@/context/app-context-state'
 import { AppModeEnum } from '@/types/app'
 import { getAppACLCapabilities, hasPermission } from '@/utils/permission'
 import AppIcon from '../../base/app-icon'
@@ -38,8 +39,8 @@ const AppInfoDetailPanel = ({
   exportCheck,
 }: AppInfoDetailPanelProps) => {
   const { t } = useTranslation()
-  const currentUserId = useAppContextWithSelector(state => state.userProfile?.id)
-  const workspacePermissionKeys = useAppContextWithSelector(state => state.workspacePermissionKeys)
+  const currentUserId = useAtomValue(userProfileIdAtom)
+  const workspacePermissionKeys = useAtomValue(workspacePermissionKeysAtom)
   const appACLCapabilities = useMemo(() => getAppACLCapabilities(appDetail.permission_keys, {
     currentUserId,
     resourceMaintainer: appDetail.maintainer,

--- a/web/app/components/app-sidebar/app-info/index.tsx
+++ b/web/app/components/app-sidebar/app-info/index.tsx
@@ -1,6 +1,7 @@
 import type { AppInfoActions } from './use-app-info-actions'
+import { useAtomValue } from 'jotai'
 import * as React from 'react'
-import { useSelector as useAppContextWithSelector } from '@/context/app-context'
+import { userProfileIdAtom, workspacePermissionKeysAtom } from '@/context/app-context-state'
 import { getAppACLCapabilities } from '@/utils/permission'
 import AppInfoDetailPanel from './app-info-detail-panel'
 import AppInfoModals from './app-info-modals'
@@ -86,8 +87,8 @@ export const AppInfoView = ({
     activeModal,
     secretEnvList,
   } = actions
-  const currentUserId = useAppContextWithSelector(state => state.userProfile?.id)
-  const workspacePermissionKeys = useAppContextWithSelector(state => state.workspacePermissionKeys)
+  const currentUserId = useAtomValue(userProfileIdAtom)
+  const workspacePermissionKeys = useAtomValue(workspacePermissionKeysAtom)
   const appACLCapabilities = getAppACLCapabilities(appDetail?.permission_keys, {
     currentUserId,
     resourceMaintainer: appDetail?.maintainer,

--- a/web/app/components/app-sidebar/dataset-detail-section.tsx
+++ b/web/app/components/app-sidebar/dataset-detail-section.tsx
@@ -13,12 +13,13 @@ import {
   RiLock2Line,
 } from '@remixicon/react'
 import { useSuspenseQuery } from '@tanstack/react-query'
+import { useAtomValue } from 'jotai'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import Divider from '@/app/components/base/divider'
 import { PipelineFill, PipelineLine } from '@/app/components/base/icons/src/vender/pipeline'
 import ExtraInfo from '@/app/components/datasets/extra-info'
-import { useAppContext } from '@/context/app-context'
+import { userProfileIdAtom, workspacePermissionKeysAtom } from '@/context/app-context-state'
 import DatasetDetailContext from '@/context/dataset-detail'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { usePathname } from '@/next/navigation'
@@ -43,16 +44,17 @@ const DatasetDetailSection = ({
   const pathname = usePathname()
   const datasetId = getDatasetIdFromPathname(pathname)
   const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
-  const { userProfile, workspacePermissionKeys } = useAppContext()
+  const currentUserId = useAtomValue(userProfileIdAtom)
+  const workspacePermissionKeys = useAtomValue(workspacePermissionKeysAtom)
   const isRbacEnabled = systemFeatures.rbac_enabled
   const { data: datasetRes, refetch: mutateDatasetRes } = useDatasetDetail(datasetId ?? '')
   const { data: relatedApps } = useDatasetRelatedApps(datasetId ?? '', { enabled: !!datasetId && !!datasetRes })
   const datasetACLCapabilities = useMemo(() => getDatasetACLCapabilities(datasetRes?.permission_keys, {
-    currentUserId: userProfile?.id,
+    currentUserId,
     resourceMaintainer: datasetRes?.maintainer,
     workspacePermissionKeys,
     isRbacEnabled,
-  }), [datasetRes?.maintainer, datasetRes?.permission_keys, isRbacEnabled, userProfile?.id, workspacePermissionKeys])
+  }), [currentUserId, datasetRes?.maintainer, datasetRes?.permission_keys, isRbacEnabled, workspacePermissionKeys])
 
   const isButtonDisabledWithPipeline = useMemo(() => {
     if (!datasetRes)

--- a/web/app/components/app-sidebar/dataset-info/__tests__/dropdown-callbacks.spec.tsx
+++ b/web/app/components/app-sidebar/dataset-info/__tests__/dropdown-callbacks.spec.tsx
@@ -21,6 +21,12 @@ const mockCheckIsUsedInApp = vi.fn()
 const mockDeleteDataset = vi.fn()
 const mockToast = vi.fn()
 let mockIsRbacEnabled = true
+const mockAppContextState = vi.hoisted(() => ({
+  current: {
+    userProfile: { id: 'user-1' },
+    workspacePermissionKeys: [] as string[],
+  },
+}))
 
 const render = (ui: Parameters<typeof renderWithSystemFeatures>[0]) => renderWithSystemFeatures(ui, {
   systemFeatures: {
@@ -102,12 +108,15 @@ vi.mock('@/context/dataset-detail', () => ({
   useDatasetDetailContextWithSelector: (selector: (state: { dataset?: DataSet }) => unknown) => selector({ dataset: mockDataset }),
 }))
 
-vi.mock('@/context/app-context', () => ({
-  useSelector: (selector: (state: { userProfile: { id: string }, workspacePermissionKeys: string[] }) => unknown) => selector({
-    userProfile: { id: 'user-1' },
-    workspacePermissionKeys: [],
-  }),
-}))
+vi.mock('@/context/app-context-state', async (importOriginal) => {
+  const { createAppContextStateAtomMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateAtomMock(importOriginal, () => mockAppContextState.current)
+})
+
+vi.mock('jotai', async (importOriginal) => {
+  const { createAppContextStateJotaiMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateJotaiMock(importOriginal)
+})
 
 vi.mock('@/service/knowledge/use-dataset', () => ({
   datasetDetailQueryKeyPrefix: ['dataset', 'detail'],

--- a/web/app/components/app-sidebar/dataset-info/__tests__/index.spec.tsx
+++ b/web/app/components/app-sidebar/dataset-info/__tests__/index.spec.tsx
@@ -25,6 +25,12 @@ const mockCheckIsUsedInApp = vi.fn()
 const mockDeleteDataset = vi.fn()
 const TestEditIcon = () => <span aria-hidden className="i-ri-edit-line" />
 let mockIsRbacEnabled = true
+const mockAppContextState = vi.hoisted(() => ({
+  current: {
+    userProfile: { id: 'user-1' },
+    workspacePermissionKeys: [] as string[],
+  },
+}))
 
 const render = (ui: Parameters<typeof renderWithSystemFeatures>[0]) => renderWithSystemFeatures(ui, {
   systemFeatures: {
@@ -115,12 +121,15 @@ vi.mock('@/context/dataset-detail', () => ({
   useDatasetDetailContextWithSelector: (selector: (state: { dataset?: DataSet }) => unknown) => selector({ dataset: mockDataset }),
 }))
 
-vi.mock('@/context/app-context', () => ({
-  useSelector: (selector: (state: { userProfile: { id: string }, workspacePermissionKeys: string[] }) => unknown) => selector({
-    userProfile: { id: 'user-1' },
-    workspacePermissionKeys: [],
-  }),
-}))
+vi.mock('@/context/app-context-state', async (importOriginal) => {
+  const { createAppContextStateAtomMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateAtomMock(importOriginal, () => mockAppContextState.current)
+})
+
+vi.mock('jotai', async (importOriginal) => {
+  const { createAppContextStateJotaiMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateJotaiMock(importOriginal)
+})
 
 vi.mock('@/service/knowledge/use-dataset', () => ({
   datasetDetailQueryKeyPrefix: ['dataset', 'detail'],
@@ -242,7 +251,7 @@ describe('MenuItem', () => {
       const handleClick = vi.fn()
 
       render(
-        <div onClick={parentClick}>
+        <div role="button" tabIndex={0} onClick={parentClick} onKeyDown={parentClick}>
           <MenuItem name="Edit" Icon={TestEditIcon} handleClick={handleClick} />
         </div>,
       )

--- a/web/app/components/app-sidebar/dataset-info/dropdown.tsx
+++ b/web/app/components/app-sidebar/dataset-info/dropdown.tsx
@@ -16,10 +16,11 @@ import {
 } from '@langgenius/dify-ui/dropdown-menu'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useSuspenseQuery } from '@tanstack/react-query'
+import { useAtomValue } from 'jotai'
 import * as React from 'react'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useSelector as useAppContextWithSelector } from '@/context/app-context'
+import { userProfileIdAtom, workspacePermissionKeysAtom } from '@/context/app-context-state'
 import { useDatasetDetailContextWithSelector } from '@/context/dataset-detail'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { useRouter } from '@/next/navigation'
@@ -69,8 +70,8 @@ const DropDown = ({
   const [showConfirmDelete, setShowConfirmDelete] = useState(false)
 
   const dataset = useDatasetDetailContextWithSelector(state => state.dataset) as DataSet
-  const currentUserId = useAppContextWithSelector(state => state.userProfile?.id)
-  const workspacePermissionKeys = useAppContextWithSelector(state => state.workspacePermissionKeys)
+  const currentUserId = useAtomValue(userProfileIdAtom)
+  const workspacePermissionKeys = useAtomValue(workspacePermissionKeysAtom)
   const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
   const isRbacEnabled = systemFeatures.rbac_enabled
   const datasetACLCapabilities = React.useMemo(() => getDatasetACLCapabilities(dataset?.permission_keys, {

--- a/web/app/components/app-sidebar/snippet-info/__tests__/dropdown.spec.tsx
+++ b/web/app/components/app-sidebar/snippet-info/__tests__/dropdown.spec.tsx
@@ -15,12 +15,23 @@ const mockDeleteMutate = vi.fn()
 let mockWorkspacePermissionKeys: string[] = ['snippets.create_and_modify', 'snippets.management']
 let mockDropdownOpen = false
 let mockDropdownOnOpenChange: ((open: boolean) => void) | undefined
-
-vi.mock('@/context/app-context', () => ({
-  useSelector: <T,>(selector: (state: { workspacePermissionKeys: string[] }) => T): T => selector({
-    workspacePermissionKeys: mockWorkspacePermissionKeys,
-  }),
+const mockAppContextState = vi.hoisted(() => ({
+  current: {
+    get workspacePermissionKeys() {
+      return mockWorkspacePermissionKeys
+    },
+  },
 }))
+
+vi.mock('@/context/app-context-state', async (importOriginal) => {
+  const { createAppContextStateAtomMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateAtomMock(importOriginal, () => mockAppContextState.current)
+})
+
+vi.mock('jotai', async (importOriginal) => {
+  const { createAppContextStateJotaiMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateJotaiMock(importOriginal)
+})
 
 vi.mock('@/next/navigation', () => ({
   useRouter: () => ({

--- a/web/app/components/app-sidebar/snippet-info/dropdown.tsx
+++ b/web/app/components/app-sidebar/snippet-info/dropdown.tsx
@@ -19,11 +19,12 @@ import {
   DropdownMenuTrigger,
 } from '@langgenius/dify-ui/dropdown-menu'
 import { toast } from '@langgenius/dify-ui/toast'
+import { useAtomValue } from 'jotai'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import CreateSnippetDialog from '@/app/components/snippets/create-snippet-dialog'
 import { canCreateAndModifySnippets, canManageSnippets } from '@/app/components/snippets/utils/permission'
-import { useSelector as useAppContextWithSelector } from '@/context/app-context'
+import { workspacePermissionKeysAtom } from '@/context/app-context-state'
 import { useRouter } from '@/next/navigation'
 import { useDeleteSnippetMutation, useExportSnippetMutation, useUpdateSnippetMutation } from '@/service/use-snippets'
 
@@ -36,7 +37,7 @@ type SnippetInfoDropdownProps = {
 const SnippetInfoDropdown = ({ snippet }: SnippetInfoDropdownProps) => {
   const { t } = useTranslation('snippet')
   const { replace } = useRouter()
-  const workspacePermissionKeys = useAppContextWithSelector(state => state.workspacePermissionKeys)
+  const workspacePermissionKeys = useAtomValue(workspacePermissionKeysAtom)
   const [open, setOpen] = React.useState(false)
   const [isEditDialogOpen, setIsEditDialogOpen] = React.useState(false)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false)

--- a/web/app/components/detail-sidebar/__tests__/index.spec.tsx
+++ b/web/app/components/detail-sidebar/__tests__/index.spec.tsx
@@ -1,6 +1,4 @@
-import type { Mock } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
-import { useAppContext } from '@/context/app-context'
 import { DetailSidebarFrame } from '..'
 import { DETAIL_SIDEBAR_STORAGE_KEY } from '../storage'
 
@@ -9,6 +7,13 @@ const { hotkeyRegistrations } = vi.hoisted(() => ({
     handler: (event: { preventDefault: () => void }) => void
     options?: { ignoreInputs?: boolean }
   }>(),
+}))
+const mockAppContextState = vi.hoisted(() => ({
+  current: {
+    langGeniusVersionInfo: {
+      current_env: '',
+    },
+  },
 }))
 
 vi.mock('@tanstack/react-hotkeys', async (importOriginal) => {
@@ -25,9 +30,15 @@ vi.mock('@tanstack/react-hotkeys', async (importOriginal) => {
   }
 })
 
-vi.mock('@/context/app-context', () => ({
-  useAppContext: vi.fn(),
-}))
+vi.mock('@/context/app-context-state', async (importOriginal) => {
+  const { createAppContextStateAtomMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateAtomMock(importOriginal, () => mockAppContextState.current)
+})
+
+vi.mock('jotai', async (importOriginal) => {
+  const { createAppContextStateJotaiMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateJotaiMock(importOriginal)
+})
 
 vi.mock('@/app/components/main-nav/components/account-section', () => ({
   default: ({ compact }: { compact?: boolean }) => (
@@ -64,11 +75,11 @@ describe('DetailSidebarFrame', () => {
   beforeEach(() => {
     localStorage.clear()
     hotkeyRegistrations.clear()
-    ;(useAppContext as Mock).mockReturnValue({
+    mockAppContextState.current = {
       langGeniusVersionInfo: {
         current_env: '',
       },
-    })
+    }
   })
 
   it('renders expanded detail content by default and registers the shortcut for focused inputs', () => {
@@ -83,11 +94,11 @@ describe('DetailSidebarFrame', () => {
   })
 
   it('collapses detail content from the top toggle and hides environment metadata', () => {
-    ;(useAppContext as Mock).mockReturnValue({
+    mockAppContextState.current = {
       langGeniusVersionInfo: {
         current_env: 'TESTING',
       },
-    })
+    }
 
     renderDetailSidebarFrame()
     fireEvent.click(screen.getByTestId('detail-toggle'))

--- a/web/app/components/detail-sidebar/index.tsx
+++ b/web/app/components/detail-sidebar/index.tsx
@@ -3,11 +3,12 @@
 import type { ReactNode } from 'react'
 import { cn } from '@langgenius/dify-ui/cn'
 import { useHotkey } from '@tanstack/react-hotkeys'
+import { useAtomValue } from 'jotai'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import EnvNav from '@/app/components/header/env-nav'
 import AccountSection from '@/app/components/main-nav/components/account-section'
 import HelpMenu from '@/app/components/main-nav/components/help-menu'
-import { useAppContext } from '@/context/app-context'
+import { langGeniusVersionInfoAtom } from '@/context/app-context-state'
 import { useDetailSidebarMode } from './storage'
 
 type DetailSidebarRenderProps = {
@@ -41,7 +42,7 @@ export function DetailSidebarFrame({
   renderTop,
   renderSection,
 }: DetailSidebarFrameProps) {
-  const { langGeniusVersionInfo } = useAppContext()
+  const langGeniusVersionInfo = useAtomValue(langGeniusVersionInfoAtom)
   const [storedDetailSidebarExpand, setStoredDetailSidebarExpand] = useDetailSidebarMode()
   const detailNavigationMode = storedDetailSidebarExpand === 'collapse' ? 'collapse' : 'expand'
   const detailNavigationExpanded = detailNavigationMode === 'expand'

--- a/web/app/components/main-nav/__tests__/index.spec.tsx
+++ b/web/app/components/main-nav/__tests__/index.spec.tsx
@@ -13,7 +13,6 @@ import { DETAIL_SIDEBAR_STORAGE_KEY } from '@/app/components/detail-sidebar/stor
 import { LEARN_DIFY_HIDDEN_STORAGE_KEY } from '@/app/components/explore/learn-dify/storage'
 import { useGotoAnythingOpen } from '@/app/components/goto-anything/atoms'
 import { ACCOUNT_SETTING_TAB } from '@/app/components/header/account-setting/constants'
-import { useAppContext, useSelector as useAppContextSelector } from '@/context/app-context'
 import { useModalContext } from '@/context/modal-context'
 import { useProviderContext } from '@/context/provider-context'
 import { usePathname, useRouter } from '@/next/navigation'
@@ -36,11 +35,6 @@ const mockAppContextState = vi.hoisted(() => ({
 
 vi.mock('@/features/agent-v2/feature-flag', () => ({
   isAgentV2Enabled: () => mockIsAgentV2Enabled(),
-}))
-
-vi.mock('@/context/app-context', () => ({
-  useAppContext: vi.fn(),
-  useSelector: vi.fn(),
 }))
 
 vi.mock('@/context/app-context-state', async (importOriginal) => {
@@ -251,8 +245,7 @@ const renderMainNav = (
   options: { store?: ReturnType<typeof createStore>, extra?: ReactNode } = {},
 ) => {
   const queryClient = createTestQueryClient()
-  const getMockAppContext = useAppContext as Mock
-  const currentAppContext = getMockAppContext() as AppContextValue
+  const currentAppContext = mockAppContextState.current ?? appContextValue
   mockAppContextState.current = currentAppContext
   queryClient.setQueryData(consoleQuery.workspaces.current.post.queryKey(), currentAppContext.currentWorkspace)
   queryClient.setQueryData(consoleQuery.workspaces.get.queryKey(), { workspaces: mockWorkspaces })
@@ -300,9 +293,7 @@ describe('MainNav', () => {
       forward: vi.fn(),
       refresh: vi.fn(),
     })
-    ;(useAppContext as Mock).mockReturnValue(appContextValue)
     mockAppContextState.current = appContextValue
-    ;(useAppContextSelector as Mock).mockImplementation((selector: (state: AppContextValue) => unknown) => selector((useAppContext as Mock)() as AppContextValue))
     ;(useProviderContext as Mock).mockReturnValue({
       enableBilling: true,
       isEducationAccount: false,
@@ -411,13 +402,13 @@ describe('MainNav', () => {
   })
 
   it('renders the desktop environment tag from the old header contract', () => {
-    ;(useAppContext as Mock).mockReturnValue({
+    mockAppContextState.current = {
       ...appContextValue,
       langGeniusVersionInfo: {
         ...appContextValue.langGeniusVersionInfo,
         current_env: 'TESTING',
       },
-    })
+    }
 
     renderMainNav()
 
@@ -453,7 +444,7 @@ describe('MainNav', () => {
   })
 
   it('keeps unrestricted main routes visible for dataset operators while hiding roster', () => {
-    ;(useAppContext as Mock).mockReturnValue({
+    mockAppContextState.current = {
       ...appContextValue,
       currentWorkspace: {
         ...appContextValue.currentWorkspace,
@@ -464,7 +455,7 @@ describe('MainNav', () => {
       isCurrentWorkspaceManager: false,
       isCurrentWorkspaceOwner: false,
       workspacePermissionKeys: datasetOperatorWorkspacePermissionKeys,
-    })
+    }
 
     renderMainNav()
 
@@ -479,7 +470,7 @@ describe('MainNav', () => {
   })
 
   it('keeps unrestricted main routes visible without route permission keys', () => {
-    ;(useAppContext as Mock).mockReturnValue({
+    mockAppContextState.current = {
       ...appContextValue,
       currentWorkspace: {
         ...appContextValue.currentWorkspace,
@@ -490,7 +481,7 @@ describe('MainNav', () => {
       isCurrentWorkspaceManager: false,
       isCurrentWorkspaceOwner: false,
       workspacePermissionKeys: ['app_library.access', 'tool.manage'],
-    })
+    }
 
     renderMainNav({ branding: { enabled: false }, enable_app_deploy: true })
 
@@ -742,7 +733,7 @@ describe('MainNav', () => {
   })
 
   it('limits invite members by member management permission', async () => {
-    ;(useAppContext as Mock).mockReturnValue({
+    mockAppContextState.current = {
       ...appContextValue,
       currentWorkspace: {
         ...appContextValue.currentWorkspace,
@@ -751,7 +742,7 @@ describe('MainNav', () => {
       isCurrentWorkspaceManager: false,
       isCurrentWorkspaceOwner: false,
       workspacePermissionKeys: ownerWorkspacePermissionKeys.filter(key => key !== 'workspace.member.manage'),
-    })
+    }
 
     renderMainNav()
 
@@ -762,7 +753,7 @@ describe('MainNav', () => {
   })
 
   it('keeps workspace settings visible and hides invite members without member management permission', () => {
-    ;(useAppContext as Mock).mockReturnValue({
+    mockAppContextState.current = {
       ...appContextValue,
       currentWorkspace: {
         ...appContextValue.currentWorkspace,
@@ -773,7 +764,7 @@ describe('MainNav', () => {
       isCurrentWorkspaceManager: false,
       isCurrentWorkspaceOwner: false,
       workspacePermissionKeys: datasetOperatorWorkspacePermissionKeys,
-    })
+    }
 
     renderMainNav()
 

--- a/web/app/components/main-nav/__tests__/layout.spec.tsx
+++ b/web/app/components/main-nav/__tests__/layout.spec.tsx
@@ -3,10 +3,16 @@ import type { Mock } from 'vitest'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { useStore as useAppStore } from '@/app/components/app/store'
-import { useAppContext } from '@/context/app-context'
 import { isAgentV2Enabled } from '@/features/agent-v2/feature-flag'
 import { usePathname } from '@/next/navigation'
 import MainNavLayout from '../layout'
+
+const mockAppContextState = vi.hoisted(() => ({
+  current: {
+    isCurrentWorkspaceDatasetOperator: false,
+    isCurrentWorkspaceEditor: true,
+  },
+}))
 
 vi.mock('@/app/components/header', () => ({
   default: () => <div data-testid="desktop-header">Header</div>,
@@ -30,9 +36,15 @@ vi.mock('@tanstack/react-query', async (importOriginal) => {
   }
 })
 
-vi.mock('@/context/app-context', () => ({
-  useAppContext: vi.fn(),
-}))
+vi.mock('@/context/app-context-state', async (importOriginal) => {
+  const { createAppContextStateAtomMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateAtomMock(importOriginal, () => mockAppContextState.current)
+})
+
+vi.mock('jotai', async (importOriginal) => {
+  const { createAppContextStateJotaiMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateJotaiMock(importOriginal)
+})
 
 vi.mock('@/features/agent-v2/feature-flag', () => ({
   isAgentV2Enabled: vi.fn(),
@@ -56,10 +68,10 @@ describe('MainNavLayout', () => {
     localStorage.clear()
     useAppStore.getState().setAppDetail()
     ;(usePathname as Mock).mockReturnValue('/apps')
-    ;(useAppContext as Mock).mockReturnValue({
+    mockAppContextState.current = {
       isCurrentWorkspaceDatasetOperator: false,
       isCurrentWorkspaceEditor: true,
-    })
+    }
     ;(useSuspenseQuery as Mock).mockReturnValue({
       data: {
         enable_app_deploy: true,
@@ -192,7 +204,7 @@ describe('MainNavLayout', () => {
     },
   ])('keeps the global main nav on $label', ({ pathname, appContext, systemFeatures }) => {
     ;(usePathname as Mock).mockReturnValue(pathname)
-    ;(useAppContext as Mock).mockReturnValue(appContext)
+    mockAppContextState.current = appContext
     ;(useSuspenseQuery as Mock).mockReturnValue({
       data: systemFeatures,
     })

--- a/web/app/components/main-nav/components/__tests__/support-menu.spec.tsx
+++ b/web/app/components/main-nav/components/__tests__/support-menu.spec.tsx
@@ -4,7 +4,6 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { openZendeskWindow } from '@/app/components/base/zendesk/utils'
 import { Plan } from '@/app/components/billing/type'
 import { mailToSupport } from '@/app/components/header/utils/util'
-import { useAppContext } from '@/context/app-context'
 import { useModalContext } from '@/context/modal-context'
 import { useProviderContext } from '@/context/provider-context'
 import SupportMenu from '../support-menu'
@@ -18,6 +17,12 @@ const { mockConfig, mockOpenZendeskWindow, mockMailToSupport, mockSetShowPricing
   mockOpenZendeskWindow: vi.fn(),
   mockMailToSupport: vi.fn(),
   mockSetShowPricingModal: vi.fn(),
+}))
+const mockAppContextState = vi.hoisted(() => ({
+  current: {
+    langGeniusVersionInfo: { current_version: '1.0.0' },
+    userProfile: { email: 'user@example.com' },
+  },
 }))
 
 vi.mock('@/app/components/base/zendesk/utils', () => ({
@@ -44,9 +49,15 @@ vi.mock('@/config', async (importOriginal) => {
   }
 })
 
-vi.mock('@/context/app-context', () => ({
-  useAppContext: vi.fn(),
-}))
+vi.mock('@/context/app-context-state', async (importOriginal) => {
+  const { createAppContextStateAtomMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateAtomMock(importOriginal, () => mockAppContextState.current)
+})
+
+vi.mock('jotai', async (importOriginal) => {
+  const { createAppContextStateJotaiMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateJotaiMock(importOriginal)
+})
 
 vi.mock('@/context/modal-context', () => ({
   useModalContext: vi.fn(),
@@ -62,10 +73,10 @@ describe('SupportMenu', () => {
     mockConfig.isCloudEdition = true
     mockConfig.supportEmailAddress = ''
     mockConfig.zendeskWidgetKey = 'zendesk-key'
-    ;(useAppContext as Mock).mockReturnValue({
+    mockAppContextState.current = {
       langGeniusVersionInfo: { current_version: '1.0.0' },
       userProfile: { email: 'user@example.com' },
-    })
+    }
     ;(useProviderContext as Mock).mockReturnValue({
       enableBilling: true,
       plan: { type: Plan.team },

--- a/web/app/components/main-nav/components/__tests__/workspace-card.spec.tsx
+++ b/web/app/components/main-nav/components/__tests__/workspace-card.spec.tsx
@@ -1,4 +1,3 @@
-import type { AppContextValue } from '@/context/app-context'
 import type { ModalContextState } from '@/context/modal-context'
 import type { ProviderContextState } from '@/context/provider-context'
 import type { ICurrentWorkspace, IWorkspace } from '@/models/common'
@@ -6,7 +5,6 @@ import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { createTestQueryClient, renderWithSystemFeatures } from '@/__tests__/utils/mock-system-features'
 import { Plan } from '@/app/components/billing/type'
 import { ACCOUNT_SETTING_TAB } from '@/app/components/header/account-setting/constants'
-import { useSelector as useAppContextSelector } from '@/context/app-context'
 import { useModalContext } from '@/context/modal-context'
 import { useProviderContext } from '@/context/provider-context'
 import { LicenseStatus } from '@/features/system-features/constants'
@@ -18,6 +16,11 @@ const { mockSwitchWorkspace, mockIsCloudEdition, mockCurrentWorkspaceQueryKey, m
   mockIsCloudEdition: { value: false },
   mockCurrentWorkspaceQueryKey: ['console', 'workspaces', 'current', 'post'] as const,
   mockWorkspacesQueryKey: ['console', 'workspaces', 'get'] as const,
+}))
+const mockAppContextState = vi.hoisted(() => ({
+  current: {
+    workspacePermissionKeys: [] as string[],
+  },
 }))
 
 vi.mock('@/config', async (importOriginal) => {
@@ -34,9 +37,15 @@ vi.mock('@/context/provider-context', () => ({
   useProviderContext: vi.fn(),
 }))
 
-vi.mock('@/context/app-context', () => ({
-  useSelector: vi.fn(),
-}))
+vi.mock('@/context/app-context-state', async (importOriginal) => {
+  const { createAppContextStateAtomMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateAtomMock(importOriginal, () => mockAppContextState.current)
+})
+
+vi.mock('jotai', async (importOriginal) => {
+  const { createAppContextStateJotaiMock } = await import('@/__tests__/utils/mock-app-context-state')
+  return createAppContextStateJotaiMock(importOriginal)
+})
 
 vi.mock('@/context/modal-context', () => ({
   useModalContext: vi.fn(),
@@ -127,9 +136,9 @@ const renderWorkspaceCard = (options?: RenderWorkspaceCardOptions) => {
 }
 
 const mockWorkspacePermissionKeys = (workspacePermissionKeys: string[]) => {
-  vi.mocked(useAppContextSelector).mockImplementation((selector: (state: AppContextValue) => unknown) => selector({
+  mockAppContextState.current = {
     workspacePermissionKeys,
-  } as AppContextValue))
+  }
 }
 
 describe('WorkspaceCard', () => {

--- a/web/app/components/main-nav/components/account-section.tsx
+++ b/web/app/components/main-nav/components/account-section.tsx
@@ -2,8 +2,9 @@
 
 import { Avatar } from '@langgenius/dify-ui/avatar'
 import { cn } from '@langgenius/dify-ui/cn'
+import { useAtomValue } from 'jotai'
 import AccountDropdown from '@/app/components/header/account-dropdown'
-import { useAppContext } from '@/context/app-context'
+import { userProfileAtom } from '@/context/app-context-state'
 
 type AccountSectionProps = {
   compact?: boolean
@@ -12,7 +13,7 @@ type AccountSectionProps = {
 const AccountSection = ({
   compact = false,
 }: AccountSectionProps) => {
-  const { userProfile } = useAppContext()
+  const userProfile = useAtomValue(userProfileAtom)
 
   return (
     <AccountDropdown

--- a/web/app/components/main-nav/components/help-menu.tsx
+++ b/web/app/components/main-nav/components/help-menu.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuTrigger,
 } from '@langgenius/dify-ui/dropdown-menu'
 import { useSuspenseQuery } from '@tanstack/react-query'
+import { useAtomValue } from 'jotai'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLearnDifyHiddenValue, useSetLearnDifyHidden } from '@/app/components/explore/learn-dify/storage'
@@ -21,7 +22,7 @@ import Compliance from '@/app/components/header/account-dropdown/compliance'
 import { ExternalLinkIndicator, MenuItemContent } from '@/app/components/header/account-dropdown/menu-item-content'
 import GithubStar from '@/app/components/header/github-star'
 import { IS_CLOUD_EDITION } from '@/config'
-import { useAppContext } from '@/context/app-context'
+import { isCurrentWorkspaceOwnerAtom, langGeniusVersionInfoAtom } from '@/context/app-context-state'
 import { useDocLink } from '@/context/i18n'
 import { env } from '@/env'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
@@ -51,7 +52,8 @@ const HelpMenu = ({
   const { t } = useTranslation()
   const docLink = useDocLink()
   const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
-  const { langGeniusVersionInfo, isCurrentWorkspaceOwner } = useAppContext()
+  const isCurrentWorkspaceOwner = useAtomValue(isCurrentWorkspaceOwnerAtom)
+  const langGeniusVersionInfo = useAtomValue(langGeniusVersionInfoAtom)
   const learnDifyHidden = useLearnDifyHiddenValue()
   const setLearnDifyHidden = useSetLearnDifyHidden()
   const [aboutVisible, setAboutVisible] = useState(false)

--- a/web/app/components/main-nav/components/support-menu.tsx
+++ b/web/app/components/main-nav/components/support-menu.tsx
@@ -1,11 +1,12 @@
 import { DropdownMenuItem, DropdownMenuLinkItem } from '@langgenius/dify-ui/dropdown-menu'
+import { useAtomValue } from 'jotai'
 import { useTranslation } from 'react-i18next'
 import { openZendeskWindow } from '@/app/components/base/zendesk/utils'
 import { Plan } from '@/app/components/billing/type'
 import { ExternalLinkIndicator, MenuItemContent } from '@/app/components/header/account-dropdown/menu-item-content'
 import { mailToSupport } from '@/app/components/header/utils/util'
 import { IS_CLOUD_EDITION, SUPPORT_EMAIL_ADDRESS, ZENDESK_WIDGET_KEY } from '@/config'
-import { useAppContext } from '@/context/app-context'
+import { langGeniusVersionInfoAtom, userProfileAtom } from '@/context/app-context-state'
 import { useModalContext } from '@/context/modal-context'
 import { useProviderContext } from '@/context/provider-context'
 
@@ -16,7 +17,8 @@ type SupportMenuProps = {
 export default function SupportMenu({ onContactUsClick }: SupportMenuProps) {
   const { t } = useTranslation()
   const { enableBilling, plan } = useProviderContext()
-  const { userProfile, langGeniusVersionInfo } = useAppContext()
+  const userProfile = useAtomValue(userProfileAtom)
+  const langGeniusVersionInfo = useAtomValue(langGeniusVersionInfoAtom)
   const { setShowPricingModal } = useModalContext()
   const hasDedicatedChannel = plan.type !== Plan.sandbox || Boolean(SUPPORT_EMAIL_ADDRESS.trim())
   const shouldShowUpgradeContact = IS_CLOUD_EDITION && enableBilling && plan.type === Plan.sandbox && !hasDedicatedChannel

--- a/web/app/components/main-nav/components/web-apps-section.tsx
+++ b/web/app/components/main-nav/components/web-apps-section.tsx
@@ -20,13 +20,14 @@ import {
 } from '@langgenius/dify-ui/scroll-area'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useVirtualizer } from '@tanstack/react-virtual'
+import { useAtomValue } from 'jotai'
 import { Fragment, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Divider from '@/app/components/base/divider'
 import { SearchInput } from '@/app/components/base/search-input'
 import { isInstalledAppPath } from '@/app/components/explore/installed-app/routes'
 import AppNavItem from '@/app/components/explore/sidebar/app-nav-item'
-import { useAppContext } from '@/context/app-context'
+import { workspacePermissionKeysAtom } from '@/context/app-context-state'
 import { usePathname } from '@/next/navigation'
 import { useGetInstalledApps, useUninstallApp, useUpdateAppPinStatus } from '@/service/use-explore'
 import { hasPermission } from '@/utils/permission'
@@ -301,7 +302,7 @@ const WebAppsSectionContent = () => {
 }
 
 const WebAppsSection = () => {
-  const { workspacePermissionKeys } = useAppContext()
+  const workspacePermissionKeys = useAtomValue(workspacePermissionKeysAtom)
   const canAccessAppLibrary = hasPermission(workspacePermissionKeys, 'app_library.access')
 
   if (!canAccessAppLibrary)

--- a/web/app/components/main-nav/components/workspace-card.tsx
+++ b/web/app/components/main-nav/components/workspace-card.tsx
@@ -10,6 +10,7 @@ import {
 } from '@langgenius/dify-ui/popover'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useMutation, useQuery } from '@tanstack/react-query'
+import { useAtomValue } from 'jotai'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Plan } from '@/app/components/billing/type'
@@ -17,7 +18,7 @@ import { ACCOUNT_SETTING_TAB } from '@/app/components/header/account-setting/con
 import LicenseNav from '@/app/components/header/license-env'
 import { buildIntegrationPath } from '@/app/components/integrations/routes'
 import { IS_CLOUD_EDITION } from '@/config'
-import { useSelector as useAppContextSelector } from '@/context/app-context'
+import { workspacePermissionKeysAtom } from '@/context/app-context-state'
 import { useModalContext } from '@/context/modal-context'
 import { useProviderContext } from '@/context/provider-context'
 import Link from '@/next/link'
@@ -232,7 +233,7 @@ export function WorkspaceCard() {
   const workspaces = workspacesData?.workspaces
   const currentWorkspaceInList = workspaces?.find(workspace => workspace.current)
   const { enableBilling } = useProviderContext()
-  const workspacePermissionKeys = useAppContextSelector(state => state.workspacePermissionKeys)
+  const workspacePermissionKeys = useAtomValue(workspacePermissionKeysAtom)
   const { setShowPricingModal, setShowAccountSettingModal } = useModalContext()
   const showCloudBilling = IS_CLOUD_EDITION && enableBilling
   const [open, setOpen] = useState(false)

--- a/web/app/components/main-nav/index.tsx
+++ b/web/app/components/main-nav/index.tsx
@@ -3,12 +3,17 @@
 import type { MainNavItem, MainNavProps } from './types'
 import { cn } from '@langgenius/dify-ui/cn'
 import { useSuspenseQuery } from '@tanstack/react-query'
+import { useAtomValue } from 'jotai'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import Badge from '@/app/components/base/badge'
 import DifyLogo from '@/app/components/base/logo/dify-logo'
 import EnvNav from '@/app/components/header/env-nav'
-import { useAppContext } from '@/context/app-context'
+import {
+  isCurrentWorkspaceDatasetOperatorAtom,
+  isCurrentWorkspaceEditorAtom,
+  langGeniusVersionInfoAtom,
+} from '@/context/app-context-state'
 import { isAgentV2Enabled } from '@/features/agent-v2/feature-flag'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import dynamic from '@/next/dynamic'
@@ -28,7 +33,9 @@ export function MainNav({
 }: MainNavProps) {
   const { t } = useTranslation()
   const pathname = usePathname()
-  const { langGeniusVersionInfo, isCurrentWorkspaceDatasetOperator, isCurrentWorkspaceEditor } = useAppContext()
+  const langGeniusVersionInfo = useAtomValue(langGeniusVersionInfoAtom)
+  const isCurrentWorkspaceDatasetOperator = useAtomValue(isCurrentWorkspaceDatasetOperatorAtom)
+  const isCurrentWorkspaceEditor = useAtomValue(isCurrentWorkspaceEditorAtom)
   const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
   const agentV2Enabled = isAgentV2Enabled()
   const showEnvTag = langGeniusVersionInfo.current_env === 'TESTING' || langGeniusVersionInfo.current_env === 'DEVELOPMENT'

--- a/web/app/components/main-nav/layout.tsx
+++ b/web/app/components/main-nav/layout.tsx
@@ -2,11 +2,12 @@
 
 import type { ReactNode } from 'react'
 import { useSuspenseQuery } from '@tanstack/react-query'
+import { useAtomValue } from 'jotai'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useShallow } from 'zustand/react/shallow'
 import { useStore as useAppStore } from '@/app/components/app/store'
-import { useAppContext } from '@/context/app-context'
+import { isCurrentWorkspaceDatasetOperatorAtom, isCurrentWorkspaceEditorAtom } from '@/context/app-context-state'
 import { isAgentV2Enabled } from '@/features/agent-v2/feature-flag'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { usePathname } from '@/next/navigation'
@@ -42,7 +43,8 @@ const MainNavLayout = ({
 }: MainNavLayoutProps) => {
   const { t } = useTranslation('common')
   const pathname = usePathname()
-  const { isCurrentWorkspaceDatasetOperator, isCurrentWorkspaceEditor } = useAppContext()
+  const isCurrentWorkspaceDatasetOperator = useAtomValue(isCurrentWorkspaceDatasetOperatorAtom)
+  const isCurrentWorkspaceEditor = useAtomValue(isCurrentWorkspaceEditorAtom)
   const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
   const shouldHideMainNav = shouldUseDetailSidebar(pathname, {
     agentV2Enabled: isAgentV2Enabled(),

--- a/web/context/app-context-state.ts
+++ b/web/context/app-context-state.ts
@@ -89,6 +89,14 @@ export const isCurrentWorkspaceManagerAtom = atom((get) => {
   return get(workspaceRoleFlagsAtom).isCurrentWorkspaceManager
 })
 
+export const isCurrentWorkspaceEditorAtom = atom((get) => {
+  return get(workspaceRoleFlagsAtom).isCurrentWorkspaceEditor
+})
+
+export const isCurrentWorkspaceDatasetOperatorAtom = atom((get) => {
+  return get(workspaceRoleFlagsAtom).isCurrentWorkspaceDatasetOperator
+})
+
 const workspacePermissionKeysQueryAtom = atomWithQuery((get) => {
   const workspaceId = get(currentWorkspaceIdAtom)
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Related to #38514.
- Migrates shell navigation AppContext consumers to direct bootstrap atom reads.
- Replaces broad context reads in main navigation, detail sidebar, and app sidebar surfaces with field-level app context state atoms.
- Adds scalar role flag atoms for editor and dataset operator checks used by the navigation shell.
- Updates affected shell/sidebar tests to mock the exact app-context-state atoms consumed by production code.

From Codex

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

## Validation

- `pnpm -C web exec eslint context/app-context-state.ts __tests__/utils/mock-app-context-state.ts app/components/main-nav/index.tsx app/components/main-nav/layout.tsx app/components/main-nav/components/web-apps-section.tsx app/components/main-nav/components/account-section.tsx app/components/main-nav/components/support-menu.tsx app/components/main-nav/components/help-menu.tsx app/components/main-nav/components/workspace-card.tsx app/components/detail-sidebar/index.tsx app/components/app-sidebar/app-detail-section.tsx app/components/app-sidebar/dataset-detail-section.tsx app/components/app-sidebar/app-info/index.tsx app/components/app-sidebar/app-info/app-info-detail-panel.tsx app/components/app-sidebar/dataset-info/dropdown.tsx app/components/app-sidebar/snippet-info/dropdown.tsx app/components/main-nav/__tests__/index.spec.tsx app/components/main-nav/__tests__/layout.spec.tsx app/components/main-nav/components/__tests__/support-menu.spec.tsx app/components/main-nav/components/__tests__/workspace-card.spec.tsx app/components/detail-sidebar/__tests__/index.spec.tsx app/components/app-sidebar/__tests__/app-detail-section.spec.tsx app/components/app-sidebar/__tests__/dataset-detail-section.spec.tsx app/components/app-sidebar/app-info/__tests__/app-info-detail-panel.spec.tsx app/components/app-sidebar/dataset-info/__tests__/index.spec.tsx app/components/app-sidebar/dataset-info/__tests__/dropdown-callbacks.spec.tsx app/components/app-sidebar/snippet-info/__tests__/dropdown.spec.tsx --cache --quiet`
- `pnpm -C web type-check`
- `pnpm -C web test app/components/main-nav/__tests__/index.spec.tsx app/components/main-nav/__tests__/layout.spec.tsx app/components/main-nav/components/__tests__/support-menu.spec.tsx app/components/main-nav/components/__tests__/workspace-card.spec.tsx app/components/detail-sidebar/__tests__/index.spec.tsx app/components/app-sidebar/__tests__/app-detail-section.spec.tsx app/components/app-sidebar/__tests__/dataset-detail-section.spec.tsx app/components/app-sidebar/app-info/__tests__/app-info-detail-panel.spec.tsx app/components/app-sidebar/dataset-info/__tests__/index.spec.tsx app/components/app-sidebar/dataset-info/__tests__/dropdown-callbacks.spec.tsx app/components/app-sidebar/snippet-info/__tests__/dropdown.spec.tsx`
