### PR TITLE
test: scope agent build draft e2e selector

### DIFF
--- a/e2e/features/step-definitions/agent-v2/build-draft.steps.ts
+++ b/e2e/features/step-definitions/agent-v2/build-draft.steps.ts
@@ -1,4 +1,4 @@
-import type { Response } from '@playwright/test'
+import type { Page, Response } from '@playwright/test'
 import type { DifyWorld } from '../../support/world'
 import { readFile } from 'node:fs/promises'
 import { Given, Then, When } from '@cucumber/cucumber'
@@ -33,6 +33,9 @@ import {
 } from './configure-helpers'
 
 const BUILD_DRAFT_RUNTIME_STEP_TIMEOUT_MS = 180_000
+
+const getBuildDraftBar = (page: Page) =>
+  page.getByRole('group', { name: 'Build draft' })
 
 Given(
   'an Agent v2 Build draft adds the supported E2E files, skills, and env',
@@ -138,7 +141,7 @@ When(
     await page.getByRole('button', { name: 'Start build' }).click()
     expect((await checkoutResponsePromise).ok()).toBe(true)
     expect((await chatResponsePromise).ok()).toBe(true)
-    await expect(page.getByText('Build draft')).toBeVisible({ timeout: 120_000 })
+    await expect(getBuildDraftBar(page)).toBeVisible({ timeout: 120_000 })
     await expect(page.getByRole('button', { exact: true, name: 'Apply' })).toBeEnabled({ timeout: 120_000 })
     await expect(page.getByRole('button', { exact: true, name: 'Discard' })).toBeEnabled()
   },
@@ -245,7 +248,7 @@ Then('Agent v2 Build chat unavailable Skill and Tool recovery should be availabl
 Then('I should see the Agent v2 Build draft pending changes', async function (this: DifyWorld) {
   const page = this.getPage()
 
-  await expect(page.getByText('Build draft')).toBeVisible({ timeout: 30_000 })
+  await expect(getBuildDraftBar(page)).toBeVisible({ timeout: 30_000 })
   await expect(page.getByRole('button', { exact: true, name: 'Apply' })).toBeEnabled()
   await expect(page.getByRole('button', { exact: true, name: 'Discard' })).toBeEnabled()
 })
@@ -401,7 +404,7 @@ Then(
 Then('the Agent v2 Build draft should no longer be active', async function (this: DifyWorld) {
   const page = this.getPage()
 
-  await expect(page.getByText('Build draft')).not.toBeVisible()
+  await expect(getBuildDraftBar(page)).not.toBeVisible()
   await expect(page.getByRole('button', { name: 'Apply' })).not.toBeVisible()
   await expect(page.getByRole('button', { name: 'Discard' })).not.toBeVisible()
 })

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/build-draft-bar.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/build-draft-bar.tsx
@@ -55,6 +55,8 @@ export function AgentBuildDraftBar({
     <CollapsibleRoot
       open={open}
       onOpenChange={handleOpenChange}
+      role="group"
+      aria-label={t('agentDetail.configure.buildDraft.title')}
       className="group/build-draft pointer-events-auto relative w-full max-w-full min-w-0 overflow-hidden rounded-xl border-[1.5px] border-[#A0BDFF] bg-components-panel-bg-blur shadow-lg shadow-shadow-shadow-5 backdrop-blur-[10px]"
     >
       <AgentBuildGridTexture


### PR DESCRIPTION
## Summary
- Give the Agent v2 Build draft bar an accessible named group boundary.
- Scope Build draft E2E assertions to getByRole("group", { name: "Build draft" }) instead of matching page-wide text.

## Root Cause
The post-merge E2E failure was not a Build draft state regression. The checkout and chat requests succeeded, but the page-wide Build draft text locator matched both the Build draft bar title and generated chat content, causing a strict-mode violation.

## Semantics
The bar is a local group of controls for the pending Build draft: changes, Discard, and Apply. It is not a page landmark, live status region, or toolbar, so role="group" is the narrow accessible contract used by the test.

## Verification
- pnpm -C e2e type-check
- pnpm -C web type-check
- pnpm exec eslint e2e/features/step-definitions/agent-v2/build-draft.steps.ts web/features/agent-v2/agent-detail/configure/components/orchestrate/build-draft-bar.tsx --fix
- pnpm -C web test -- features/agent-v2/agent-detail/configure/components/orchestrate/__tests__/build-draft-bar.spec.tsx
- git diff --check
- pnpm -C e2e e2e:middleware:up
- E2E_START_AGENT_BACKEND=1 pnpm -C e2e e2e -- --tags "not @skip and not @preview" --name "Generating a Build draft leaves the normal Agent configuration unchanged"
- pnpm -C e2e e2e:middleware:down

Note: vpr lint --fix --quiet was attempted earlier but this local workspace failed while loading web/next.config.ts because code-inspector-plugin was missing from local node_modules, before linting this patch.