### PR TITLE
fix(web): use chat mode for agent prompt generation

### DIFF
--- a/web/app/components/app/configuration/config/automatic/__tests__/get-automatic-res.spec.tsx
+++ b/web/app/components/app/configuration/config/automatic/__tests__/get-automatic-res.spec.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
-import { AppModeEnum } from '@/types/app'
+import { AppModeEnum, ModelModeType } from '@/types/app'
 import GetAutomaticRes from '../get-automatic-res'
 
 const mockGenerateBasicAppFirstTimeRule = vi.fn()
@@ -235,6 +235,34 @@ describe('GetAutomaticRes', () => {
       variables: ['city'],
       opening_statement: 'hello there',
     }))
+  })
+
+  it('should use chat model mode for agent app prompt generation', async () => {
+    mockGenerateBasicAppFirstTimeRule.mockResolvedValue({
+      prompt: 'generated prompt',
+    })
+
+    render(
+      <GetAutomaticRes
+        mode={AppModeEnum.AGENT_CHAT}
+        isShow
+        onClose={mockOnClose}
+        onFinished={mockOnFinished}
+        flowId="flow-1"
+        isBasicMode
+      />,
+    )
+
+    fireEvent.click(screen.getByText('set-basic-instruction'))
+    fireEvent.click(screen.getByText('generate.generate'))
+
+    await waitFor(() => {
+      expect(mockGenerateBasicAppFirstTimeRule).toHaveBeenCalledWith(expect.objectContaining({
+        model_config: expect.objectContaining({
+          mode: ModelModeType.chat,
+        }),
+      }))
+    })
   })
 
   it('should close overwrite confirmation without applying the generated result when cancelled', async () => {

--- a/web/app/components/app/configuration/config/automatic/get-automatic-res.tsx
+++ b/web/app/components/app/configuration/config/automatic/get-automatic-res.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'react'
 import type { FormValue } from '@/app/components/header/account-setting/model-provider-page/declarations'
 // type
 import type { GenRes } from '@/service/debug'
-import type { AppModeEnum, CompletionParams, Model, ModelModeType } from '@/types/app'
+import { AppModeEnum, ModelModeType, type CompletionParams, type Model } from '@/types/app'
 import {
   AlertDialog,
   AlertDialogActions,
@@ -63,6 +63,13 @@ type IGetAutomaticResProps = {
   isBasicMode?: boolean
 }
 
+const getInitialModelMode = (mode: AppModeEnum): ModelModeType => {
+  if (mode === AppModeEnum.COMPLETION)
+    return ModelModeType.completion
+
+  return ModelModeType.chat
+}
+
 const TryLabel: FC<{
   Icon: any
   text: string
@@ -95,7 +102,7 @@ const GetAutomaticRes: FC<IGetAutomaticResProps> = ({
   const [model, setModel] = React.useState<Model>(storedModel || {
     name: '',
     provider: '',
-    mode: mode as unknown as ModelModeType,
+    mode: getInitialModelMode(mode),
     completion_params: {} as CompletionParams,
   })
   const {


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

This PR normalizes the initial model mode used by prompt auto-generation so Agent apps send an LLM mode (`chat`) to `/rule-generate` instead of the app mode (`agent-chat`).

`agent-chat` is an app mode, but `model_config.mode` is validated by the backend as an LLM mode and only accepts `chat` or `completion`. In a fresh session without a stored auto-generation model, Agent apps currently initialize the auto-generation model with `agent-chat`, which causes `/rule-generate` to fail with HTTP 400 before rule generation starts.

The fix maps the initial auto-generation model mode from the app mode to a valid LLM mode: `completion` remains `completion`, while Agent/basic chat-style prompt generation uses `chat`. Stored auto-generation model settings are still preserved when present.

A regression test was added for `AppModeEnum.AGENT_CHAT` basic prompt generation to verify that `generateBasicAppFirstTimeRule` receives `model_config.mode` as `chat`.

Fixes #38539.

From Codex

## Screenshots

| Before | After |
|--------|-------|
| `/rule-generate` receives `model_config.mode: "agent-chat"` in a fresh Agent app session and fails backend validation with HTTP 400. | `/rule-generate` receives `model_config.mode: "chat"` in a fresh Agent app session and can pass backend model mode validation. |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Note: I added a focused regression test in `web/app/components/app/configuration/config/automatic/__tests__/get-automatic-res.spec.tsx` and verified `git diff --check` locally. I attempted to run the focused frontend test with `pnpm -C web test app/components/app/configuration/config/automatic/__tests__/get-automatic-res.spec.tsx`, but local dependency bootstrap could not complete because `pnpm install` repeatedly timed out while downloading registry tarballs.