### PR TITLE
fix(web): re-add handleChangeConversation to handleNewConversation deps (#38403)

### DIFF
--- a/web/app/components/base/chat/embedded-chatbot/__tests__/hooks.spec.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/__tests__/hooks.spec.tsx
@@ -132,6 +132,26 @@ const renderWithClient = async <T,>(hook: () => T) => {
   }
 }
 
+const renderWithClientProps = async <T, P>(
+  hook: (props: P) => T,
+  initialProps: P,
+) => {
+  const queryClient = createQueryClient()
+  const wrapper = createWrapper(queryClient)
+  let result: ReturnType<typeof renderHook<T, P>> | undefined
+  act(() => {
+    result = renderHook(hook, { wrapper, initialProps })
+  })
+  await waitFor(() => {
+    if (queryClient.isFetching() > 0)
+      throw new Error('Queries are still fetching')
+  }, { timeout: 2000 })
+  return {
+    queryClient,
+    ...result!,
+  }
+}
+
 const createConversationItem = (overrides: Partial<ConversationItem> = {}): ConversationItem => ({
   id: 'conversation-1',
   name: 'Conversation 1',
@@ -591,6 +611,68 @@ describe('useEmbeddedChatbot', () => {
       })
 
       expect(updateFeedback).toHaveBeenCalled()
+    })
+
+    // Scenario: regression for #38403 — handleNewConversation must regenerate when
+    // handleChangeConversation regenerates (its dep), so the embedded-chatbot reset
+    // button always invokes the freshest handleConversationIdInfoChange. Before the
+    // fix, handleChangeConversation was omitted from handleNewConversation's
+    // useCallback deps, leaving the reset click to capture a stale closure.
+    it('handleNewConversation tracks handleChangeConversation identity (regression for #38403)', async () => {
+      // Disable the URL-sourced conversation id so currentConversationId
+      // resolves via the localStorage branch only — this is the path the bug
+      // actually breaks.
+      mockStoreState.embeddedConversationId = null
+      mockStoreState.embeddedUserId = null
+      localStorage.setItem(CONVERSATION_ID_INFO, JSON.stringify({
+        'app-1': { DEFAULT: 'stored-conv-id' },
+      }))
+
+      const { result, rerender } = await renderWithClientProps(
+        () => useEmbeddedChatbot(AppSourceType.webApp),
+        undefined,
+      )
+
+      await waitFor(() => {
+        expect(result.current.currentConversationId).toBe('stored-conv-id')
+      }, { timeout: 3000 })
+
+      const firstHandleNewConversation = result.current.handleNewConversation
+      const firstHandleChangeConversation = result.current.handleChangeConversation
+      expect(typeof firstHandleNewConversation).toBe('function')
+      expect(typeof firstHandleChangeConversation).toBe('function')
+
+      // No-prop rerender: useCallback must short-circuit and preserve identity
+      // because no dependency reference changed.
+      await act(async () => {
+        rerender(undefined)
+      })
+
+      const secondHandleNewConversation = result.current.handleNewConversation
+      const secondHandleChangeConversation = result.current.handleChangeConversation
+
+      expect(secondHandleNewConversation).toBe(firstHandleNewConversation)
+      expect(secondHandleChangeConversation).toBe(firstHandleChangeConversation)
+
+      // Flip userId via the store mock; the new embeddedUserId propagates
+      // through the useEffect at hooks.tsx:75-77, which fires setUserId, which
+      // invalidates handleConversationIdInfoChange's `userId` dep, which
+      // invalidates handleChangeConversation's deps, which (with the fix)
+      // invalidates handleNewConversation's deps too.
+      mockStoreState.embeddedUserId = 'embedded-user-2'
+
+      await act(async () => {
+        rerender(undefined)
+      })
+
+      await waitFor(() => {
+        expect(result.current.handleChangeConversation).not.toBe(firstHandleChangeConversation)
+      })
+
+      // Regression assertion: with the dep re-added, handleNewConversation
+      // regenerates alongside handleChangeConversation. Without the fix, this
+      // would still reference firstHandleNewConversation (stale closure).
+      expect(result.current.handleNewConversation).not.toBe(firstHandleNewConversation)
     })
   })
 

--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -368,7 +368,7 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     handleChangeConversation('')
     handleNewConversationInputsChange(await getProcessedInputsFromUrlParams())
     setClearChatList(true)
-  }, [isTryApp, setShowNewConversationItemInList, handleNewConversationInputsChange, setClearChatList])
+  }, [isTryApp, setShowNewConversationItemInList, handleChangeConversation, handleNewConversationInputsChange, setClearChatList])
   const handleNewConversationCompleted = useCallback((newConversationId: string) => {
     setNewConversationId(newConversationId)
     handleConversationIdInfoChange(newConversationId)


### PR DESCRIPTION
Fixes #38403

### Problem

Since PR #31287 ("feat: frontend part of support try apps"), the embedded chatbot's `handleNewConversation` (`web/app/components/base/chat/embedded-chatbot/hooks.tsx`) was missing `handleChangeConversation` from its `useCallback` deps array.

```diff
-  }, [handleChangeConversation, setShowNewConversationItemInList, handleNewConversationInputsChange, setClearChatList])
+  }, [isTryApp, setShowNewConversationItemInList, handleNewConversationInputsChange, setClearChatList])
```

After URL→localStorage resolution or any state change that touched `handleConversationIdInfoChange`'s deps (`appId`, `conversationIdInfo`, `userId`), `handleChangeConversation` regenerates but `handleNewConversation` keeps the previous render's closure. Clicking reset then calls `handleChangeConversation('')` against a stale `handleConversationIdInfoChange` that closes over the previous `conversationIdInfo`. The `setConversationIdInfo({ ...conversationIdInfo, ... })` write hits the discarded snapshot rather than the live state, so `conversationIdInfo[appId][userId]` is never reset. The next message re-uses the old `conversation_id`.

### Fix

Re-add `handleChangeConversation` to `handleNewConversation`'s deps array. This restores the v1.6.0 deps (pre-#31287) and keeps the two callbacks in lockstep:

```diff
-  }, [isTryApp, setShowNewConversationItemInList, handleNewConversationInputsChange, setClearChatList])
+  }, [isTryApp, setShowNewConversationItemInList, handleChangeConversation, handleNewConversationInputsChange, setClearChatList])
```

`react/exhaustive-deps` is now satisfied on line 371. `useCallback` only re-emits when a dep reference changes; at steady state (no state mutation across renders) both callbacks short-circuit and preserve identity, so the rerender cost is unchanged.

### Test

Added a regression test in `web/app/components/base/chat/embedded-chatbot/__tests__/hooks.spec.tsx` that:
1. Stores a `conversation_id` in localStorage and disables URL/system-variable resolution so the path under test is the localStorage branch.
2. Captures the initial `handleNewConversation` and `handleChangeConversation` references.
3. A no-prop `rerender` preserves both references (validates `useCallback` memoization at steady state).
4. Flips `mockStoreState.embeddedUserId` to force the line-75 effect → `userId` state → `handleConversationIdInfoChange` deps → `handleChangeConversation` to regenerate.
5. Asserts `handleNewConversation` regenerates alongside `handleChangeConversation` — without the fix this assertion fails (`Object.is` equality on the stale closure).

Run with:
```
pnpm exec vitest run app/components/base/chat/embedded-chatbot/__tests__/hooks.spec.tsx
```

### Verification

- `pnpm exec vitest run` on the touched spec: **36/36 pass**
- `pnpm exec vitest run` on `app/components/base/chat/` (1355 tests across 73 files): **all pass**
- `pnpm exec eslint --fix --pass-on-unpruned-suppressions` on the two changed files: 0 errors, 4 pre-existing `exhaustive-deps` warnings on unrelated `useEffect` blocks (lines 74, 105, 250, 311) — none introduced by this change
- `pnpm exec tsgo --noEmit`: clean
- Confirmed the new test fails on the unpatched code (reverted the 1-line deps change → test failed with `expected [AsyncFunction] not to be [AsyncFunction]`), then restored the fix and re-ran → test passes

### Risk

Minimal. Pure deps-array change. No public-API change, no schema/migration/controller/frontend logic outside the touched file. The change only affects callers of `handleNewConversation` (the embedded chatbot reset button) — and only positively: they now reach the freshest `handleChangeConversation` instead of a stale one.

Reverts the same `useCallback` deps edit as PR #31287 did back when it introduced the Try Apps branch. If PR #31287 needed a smaller-deps form for performance reasons, please call that out in review and we can revisit (the call to `handleChangeConversation('')[']` only happens once per reset click so the cost change is negligible).

Made with [Cursor](https://cursor.com)