### PR TITLE
perf: select one message per run in SQL with DISTINCT ON

### DIFF
--- a/api/services/workflow_run_service.py
+++ b/api/services/workflow_run_service.py
@@ -80,18 +80,31 @@ class WorkflowRunService:
         run_ids = [workflow_run.id for workflow_run in workflow_runs]
         messages_by_run_id: dict[str, Message] = {}
         if run_ids:
+            # Pick a single message per run in SQL via DISTINCT ON, instead of
+            # loading every matching row and de-duplicating in Python. This
+            # avoids fetching extra Message rows when a run has more than one
+            # message, and makes the selection rule explicit: the most recent
+            # message per run (created_at desc, id desc as a stable tie-break),
+            # rather than depending on the row return order.
             messages = db.session.scalars(
-                select(Message).where(
+                select(Message)
+                .where(
                     Message.app_id == app_model.id,
                     Message.workflow_run_id.in_(run_ids),
+                )
+                .distinct(Message.workflow_run_id)
+                .order_by(
+                    Message.workflow_run_id,
+                    Message.created_at.desc(),
+                    Message.id.desc(),
                 )
             ).all()
             for loaded_message in messages:
                 run_id = loaded_message.workflow_run_id
                 if run_id is None:
                     continue
-                # setdefault mirrors scalar()'s single-row-per-run semantics.
-                messages_by_run_id.setdefault(run_id, loaded_message)
+                # DISTINCT ON already guarantees one row per run.
+                messages_by_run_id[run_id] = loaded_message
 
         with_message_workflow_runs = []
         for workflow_run in workflow_runs:

--- a/api/tests/unit_tests/services/test_workflow_run_service.py
+++ b/api/tests/unit_tests/services/test_workflow_run_service.py
@@ -172,6 +172,41 @@ class TestWorkflowRunServiceQueries:
         # Exactly one message query for the whole page, independent of run count.
         assert fake_session.scalars.call_count == 1
 
+    def test_get_paginate_advanced_chat_workflow_runs_dedups_one_message_per_run_in_sql(
+        self,
+        repository_factory_mocks: tuple[MagicMock, MagicMock, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The 'one message per run' selection is pushed into SQL (DISTINCT ON)
+        with an explicit ordering, so extra Message rows are not loaded and the
+        chosen row does not depend on the database's row return order.
+        """
+        from sqlalchemy.dialects import postgresql
+
+        service = WorkflowRunService(session_factory=MagicMock(name="session_factory"))
+        app_model = _app_model(tenant_id="tenant-1", id="app-1")
+        pagination = SimpleNamespace(data=[SimpleNamespace(id="run-1", status="succeeded")])
+        monkeypatch.setattr(service, "get_paginate_workflow_runs", MagicMock(return_value=pagination))
+
+        captured: dict[str, Any] = {}
+
+        def fake_scalars(stmt: Any) -> Any:
+            captured["stmt"] = stmt
+            result = MagicMock()
+            result.all.return_value = []
+            return result
+
+        monkeypatch.setattr(service_module, "db", SimpleNamespace(session=SimpleNamespace(scalars=fake_scalars)))
+
+        service.get_paginate_advanced_chat_workflow_runs(app_model=app_model, args={})
+
+        compiled = str(captured["stmt"].compile(dialect=postgresql.dialect()))
+        # De-duplication happens in SQL, not in Python.
+        assert "DISTINCT ON" in compiled
+        assert "workflow_run_id" in compiled
+        # The aggregation rule is explicit: most recent message per run.
+        assert "created_at DESC" in compiled
+
     def test_get_workflow_run_should_delegate_to_repository_by_tenant_and_app(
         self,
         repository_factory_mocks: tuple[MagicMock, MagicMock, Any],


### PR DESCRIPTION
## Summary

Follow-up to #38359, addressing the reviewer suggestion:

> One possible follow-up: can we push the "one message per run" selection into SQL as well, so we don't load extra Message rows when multiple rows share the same workflow_run_id? If we do that, we should first make the aggregation rule explicit (for example latest or lowest-id message), since the current Python setdefault preserves whichever row comes back first.

### Before
`get_paginate_advanced_chat_workflow_runs` loaded every Message matching the page's run ids (`workflow_run_id IN (...)`) and de-duplicated to one per run in Python via `setdefault`, so:
- extra Message rows were fetched when a run had more than one message, and
- the kept row depended on the database row return order.

### After
Select a single message per run directly in SQL:

```
SELECT DISTINCT ON (workflow_run_id) ...
WHERE app_id = :app_id AND workflow_run_id IN (:run_ids)
ORDER BY workflow_run_id, created_at DESC, id DESC
```

- One row per run, so no extra Message rows are loaded.
- The aggregation rule is explicit and stable: the most recent message per run (`created_at` desc, `id` desc as a tie-break), rather than order-dependent.

`Message.id` is a UUID, so "lowest-id" is not time-ordered; `created_at` is used instead (there is a composite `(created_at, id)` index that supports this ordering).

### Notes
- Still one query for the whole page (no N+1), same as #38359.
- `DISTINCT ON` is PostgreSQL-specific, matching dify's supported database.

## Testing
- Added `test_get_paginate_advanced_chat_workflow_runs_dedups_one_message_per_run_in_sql`: compiles the query for the PostgreSQL dialect and asserts it uses `DISTINCT ON` with the explicit `created_at DESC` ordering (de-duplication happens in SQL, not Python).
- Existing workflow-run-service tests remain valid; `ruff check` and `ruff format` are clean.