### PR TITLE
fix: dispatch dataset cleanup when doc_form is missing

### DIFF
--- a/api/events/event_handlers/clean_when_dataset_deleted.py
+++ b/api/events/event_handlers/clean_when_dataset_deleted.py
@@ -6,7 +6,10 @@ from tasks.clean_dataset_task import clean_dataset_task
 @dataset_was_deleted.connect
 def handle(sender: Dataset, **kwargs):
     dataset = sender
-    if not dataset.doc_form or not dataset.indexing_technique:
+    # `clean_dataset_task` can recover a missing doc_form before selecting the
+    # cleanup processor, so only missing indexing_technique still blocks
+    # dispatch here.
+    if not dataset.indexing_technique:
         return
     clean_dataset_task.delay(
         dataset.id,

--- a/api/tasks/clean_dataset_task.py
+++ b/api/tasks/clean_dataset_task.py
@@ -36,7 +36,7 @@ def clean_dataset_task(
     indexing_technique: str,
     index_struct: str,
     collection_binding_id: str,
-    doc_form: str,
+    doc_form: str | None,
     pipeline_id: str | None = None,
 ):
     """
@@ -46,7 +46,7 @@ def clean_dataset_task(
     :param indexing_technique: indexing technique
     :param index_struct: index struct dict
     :param collection_binding_id: collection binding id
-    :param doc_form: dataset form
+    :param doc_form: dataset form, which may be missing for migrated datasets
 
     Usage: clean_dataset_task.delay(dataset_id, tenant_id, indexing_technique, index_struct)
     """

--- a/api/tests/test_containers_integration_tests/services/test_dataset_service_delete_dataset.py
+++ b/api/tests/test_containers_integration_tests/services/test_dataset_service_delete_dataset.py
@@ -203,7 +203,7 @@ class TestDatasetServiceDeleteDataset:
         clean_dataset_delay.assert_not_called()
 
     def test_delete_dataset_with_doc_form_none_indexing_technique_exists(self, db_session_with_containers: Session):
-        """Delete a dataset without cleanup when indexing exists but doc_form resolves to None."""
+        """Delete a dataset with cleanup when indexing exists but doc_form resolves to None."""
         # Arrange
         owner, tenant = DatasetDeleteIntegrationDataFactory.create_account_with_tenant(db_session_with_containers)
         dataset = DatasetDeleteIntegrationDataFactory.create_dataset(
@@ -228,7 +228,15 @@ class TestDatasetServiceDeleteDataset:
         db_session_with_containers.expire_all()
         assert result is True
         assert db_session_with_containers.get(Dataset, dataset.id) is None
-        clean_dataset_delay.assert_not_called()
+        clean_dataset_delay.assert_called_once_with(
+            dataset.id,
+            dataset.tenant_id,
+            dataset.indexing_technique,
+            dataset.index_struct,
+            dataset.collection_binding_id,
+            dataset.doc_form,
+            dataset.pipeline_id,
+        )
 
     def test_delete_dataset_not_found(self, db_session_with_containers: Session):
         """Return False without scheduling cleanup when the target dataset does not exist."""


### PR DESCRIPTION

> [!IMPORTANT]
>
> 1. Make sure you have read our [[contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #38537

This PR fixes the dataset deletion path for migrated datasets whose `doc_form` is missing.

The delete event handler previously returned early when either `doc_form` or `indexing_technique` was empty, which meant `clean_dataset_task` was never dispatched for some migrated datasets. However, `clean_dataset_task` already handles an empty `doc_form` by falling back to `PARAGRAPH_INDEX`, so the handler was blocking a case the downstream cleanup path could already recover from.

This change keeps the existing safeguard for missing `indexing_technique`, but stops skipping cleanup when only `doc_form` is missing.

Changes included in this PR:
- narrow the dataset deletion guard in `clean_when_dataset_deleted.py`
- update the existing integration test expectation for the `doc_form=None` case
- add a focused unit test for the event handler dispatch behavior

Local verification:
- `uv run --project api --group dev pytest api/tests/unit_tests/events/event_handlers/test_clean_when_dataset_deleted.py`
- `uv run --project api --group dev ruff check api/events/event_handlers/clean_when_dataset_deleted.py api/tests/unit_tests/events/event_handlers/test_clean_when_dataset_deleted.py api/tests/test_containers_integration_tests/services/test_dataset_service_delete_dataset.py`


## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [[Dify Document](https://github.com/langgenius/dify-docs)](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods