### PR TITLE
fix(api): unify conversation and message timestamp defaults

### DIFF
--- a/api/models/model.py
+++ b/api/models/model.py
@@ -24,6 +24,7 @@ from extensions.storage.storage_type import StorageType
 from graphon.enums import WorkflowExecutionStatus
 from graphon.file import FILE_MODEL_IDENTITY, File, FileTransferMethod, FileType
 from graphon.file import helpers as file_helpers
+from libs.datetime_utils import naive_utc_now
 from libs.helper import generate_string  # type: ignore[import-not-found]
 from libs.url_utils import normalize_api_base_url
 from libs.uuid_utils import uuidv7
@@ -1144,9 +1145,20 @@ class Conversation(Base):
     read_at = mapped_column(sa.DateTime)
     read_account_id = mapped_column(StringUUID)
     dialogue_count: Mapped[int] = mapped_column(default=0)
-    created_at = mapped_column(sa.DateTime, nullable=False, server_default=func.current_timestamp())
+    # Keep conversation timestamps on the same naive-UTC convention as the
+    # application write paths instead of mixing DB-local current_timestamp().
+    created_at = mapped_column(
+        sa.DateTime,
+        nullable=False,
+        default=naive_utc_now,
+        server_default=func.current_timestamp(),
+    )
     updated_at = mapped_column(
-        sa.DateTime, nullable=False, server_default=func.current_timestamp(), onupdate=func.current_timestamp()
+        sa.DateTime,
+        nullable=False,
+        default=naive_utc_now,
+        server_default=func.current_timestamp(),
+        onupdate=naive_utc_now,
     )
 
     messages = db.relationship("Message", backref="conversation", lazy="select", passive_deletes="all")
@@ -1491,9 +1503,19 @@ class Message(Base):
     )
     from_end_user_id: Mapped[str | None] = mapped_column(StringUUID)
     from_account_id: Mapped[str | None] = mapped_column(StringUUID)
-    created_at: Mapped[datetime] = mapped_column(sa.DateTime, server_default=func.current_timestamp())
+    # Messages share the same timestamp contract as conversations so MySQL
+    # DATETIME rows do not mix DB-local creation times with UTC updates.
+    created_at: Mapped[datetime] = mapped_column(
+        sa.DateTime,
+        default=naive_utc_now,
+        server_default=func.current_timestamp(),
+    )
     updated_at: Mapped[datetime] = mapped_column(
-        sa.DateTime, nullable=False, server_default=func.current_timestamp(), onupdate=func.current_timestamp()
+        sa.DateTime,
+        nullable=False,
+        default=naive_utc_now,
+        server_default=func.current_timestamp(),
+        onupdate=naive_utc_now,
     )
     agent_based: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
     workflow_run_id: Mapped[str | None] = mapped_column(StringUUID)

--- a/api/tests/unit_tests/models/test_model.py
+++ b/api/tests/unit_tests/models/test_model.py
@@ -5,6 +5,7 @@ import pytest
 
 from core.workflow.file_reference import build_file_reference
 from graphon.file import FILE_MODEL_IDENTITY, FileTransferMethod
+from libs.datetime_utils import naive_utc_now
 from models.model import Conversation, Message
 
 
@@ -121,3 +122,19 @@ def test_inputs_restore_external_remote_url_file_mappings(owner_cls: type[Conver
 
     assert restored_file.transfer_method == FileTransferMethod.REMOTE_URL
     assert restored_file.remote_url == "https://example.com/report.pdf"
+
+
+@pytest.mark.parametrize("owner_cls", [Conversation, Message])
+def test_timestamp_columns_use_naive_utc_defaults(owner_cls: type[Conversation] | type[Message]) -> None:
+    created_at_column = owner_cls.__table__.c.created_at
+    updated_at_column = owner_cls.__table__.c.updated_at
+
+    assert created_at_column.default is not None
+    assert created_at_column.default.arg.__name__ == naive_utc_now.__name__
+    assert created_at_column.default.arg.__module__ == naive_utc_now.__module__
+    assert updated_at_column.default is not None
+    assert updated_at_column.default.arg.__name__ == naive_utc_now.__name__
+    assert updated_at_column.default.arg.__module__ == naive_utc_now.__module__
+    assert updated_at_column.onupdate is not None
+    assert updated_at_column.onupdate.arg.__name__ == naive_utc_now.__name__
+    assert updated_at_column.onupdate.arg.__module__ == naive_utc_now.__module__


### PR DESCRIPTION
PR body:

> [!IMPORTANT]
>
> 1. Make sure you have read our [[contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #38553.

This PR fixes a timezone inconsistency in `Conversation` and `Message` timestamps on MySQL.

Previously, `created_at` could be written by DB-side `CURRENT_TIMESTAMP()`, while several update paths explicitly assigned `updated_at = naive_utc_now()`. Because MySQL `DATETIME` does not store timezone information, that mixed DB-local creation timestamps with application-side UTC update timestamps and could produce an 8-hour discrepancy on non-UTC MySQL servers.

This change unifies the timestamp contract for `Conversation` and `Message` by using `naive_utc_now` for both `created_at` and `updated_at` defaults, and for `updated_at` on update, while keeping the existing DB `server_default` as a fallback. It also adds a regression test to lock in that behavior.

From Codex

## Screenshots

| Before | After |
|--------|-------|
| N/A (backend timestamp model change) | N/A (backend timestamp model change) |

## Checklist

- [ ] This change requires a documentation update, included: [[Dify Document](https://github.com/langgenius/dify-docs)](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

