### PR TITLE
fix: run user_connect authorization inside Flask app context

### DIFF
--- a/api/controllers/console/socketio/workflow.py
+++ b/api/controllers/console/socketio/workflow.py
@@ -69,7 +69,8 @@ def handle_user_connect(sid, data):
     if not workflow_id:
         return {"msg": "workflow_id is required"}, 400
 
-    result = collaboration_service.authorize_and_join_workflow_room(workflow_id, sid, session=db.session())
+    with sio.app.app_context():
+        result = collaboration_service.authorize_and_join_workflow_room(workflow_id, sid, session=db.session())
     if not result:
         return {"msg": "unauthorized"}, 401
 


### PR DESCRIPTION
## Summary

Since #38227, workflow collaboration is broken: every `user_connect` event is rejected with `{"msg": "unauthorized"}, 401`.

That PR changed `handle_user_connect` to pass `session=db.session()` explicitly. Socket.IO event handlers run in plain gevent greenlets with no Flask application context, so evaluating `db.session()` (a Flask-SQLAlchemy scoped session keyed on the app context) raises:

```
RuntimeError: Working outside of application context.
```

The greenlet dies, the client is never joined to the workflow room, and all subsequent `collaboration_event` relays also return 401 (no sid mapping). The traceback only appears on the websocket worker's stderr, which is why the failure surfaced as a silent 401.

Fix: wrap the authorization call in `with sio.app.app_context():`, matching the existing pattern in the `connect` handler (`socket_connect`) a few lines above. This is the only event handler that touches the database; the others are Redis-only.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods