### PR TITLE
feat: configurable per-node first-token timeout for LLM nodes (v1)

### DIFF
--- a/api/core/app/app_config/easy_ui_based_app/model_config/converter.py
+++ b/api/core/app/app_config/easy_ui_based_app/model_config/converter.py
@@ -64,7 +64,7 @@ class ModelConfigConverter:
             del completion_params["stop"]
         # Workflow-only setting; drop it here so imported/hand-edited app configs
         # never forward it to providers.
-        completion_params.pop("first_token_timeout", None)
+        completion_params.pop("first_token_timeout_ms", None)
 
         model_schema = model_type_instance.get_model_schema(model_config.model, model_credentials)
 

--- a/api/core/app/app_config/easy_ui_based_app/model_config/converter.py
+++ b/api/core/app/app_config/easy_ui_based_app/model_config/converter.py
@@ -62,6 +62,9 @@ class ModelConfigConverter:
         if "stop" in completion_params:
             stop = completion_params["stop"]
             del completion_params["stop"]
+        # Workflow-only setting; drop it here so imported/hand-edited app configs
+        # never forward it to providers.
+        completion_params.pop("first_token_timeout", None)
 
         model_schema = model_type_instance.get_model_schema(model_config.model, model_credentials)
 

--- a/api/core/app/app_config/easy_ui_based_app/model_config/converter.py
+++ b/api/core/app/app_config/easy_ui_based_app/model_config/converter.py
@@ -62,8 +62,7 @@ class ModelConfigConverter:
         if "stop" in completion_params:
             stop = completion_params["stop"]
             del completion_params["stop"]
-        # Workflow-only setting; drop it here so imported/hand-edited app configs
-        # never forward it to providers.
+        # Workflow-only setting; never forward it to providers.
         completion_params.pop("first_token_timeout_ms", None)
 
         model_schema = model_type_instance.get_model_schema(model_config.model, model_credentials)

--- a/api/core/app/llm/model_access.py
+++ b/api/core/app/llm/model_access.py
@@ -141,19 +141,20 @@ def _normalize_completion_params(
     returned config entity aligned here so callers do not need to duplicate
     normalization logic.
 
-    ``first_token_timeout`` is user-facing config in seconds; it is consumed here and
-    never forwarded to providers. Invalid values (non-numeric, bool, non-positive)
-    disable the gate.
+    ``first_token_timeout_ms`` is user-facing config in milliseconds; it is consumed
+    here and never forwarded to providers. This is the only place the value is
+    converted to the seconds used everywhere downstream. Invalid values
+    (non-numeric, bool, non-positive) disable the gate.
     """
     normalized_parameters = dict(completion_params)
     stop = normalized_parameters.pop("stop", [])
     if not isinstance(stop, list) or not all(isinstance(item, str) for item in stop):
         stop = []
 
-    raw_timeout = normalized_parameters.pop("first_token_timeout", None)
+    raw_timeout_ms = normalized_parameters.pop("first_token_timeout_ms", None)
     first_token_timeout: float | None = None
-    if isinstance(raw_timeout, (int, float)) and not isinstance(raw_timeout, bool) and raw_timeout > 0:
-        first_token_timeout = float(raw_timeout)
+    if isinstance(raw_timeout_ms, (int, float)) and not isinstance(raw_timeout_ms, bool) and raw_timeout_ms > 0:
+        first_token_timeout = float(raw_timeout_ms) / 1000
 
     return normalized_parameters, stop, first_token_timeout
 

--- a/api/core/app/llm/model_access.py
+++ b/api/core/app/llm/model_access.py
@@ -144,10 +144,8 @@ def _normalize_completion_params(
     returned config entity aligned here so callers do not need to duplicate
     normalization logic.
 
-    ``first_token_timeout_ms`` is user-facing config in milliseconds; it is consumed
-    here and never forwarded to providers. This is the only place the value is
-    converted to the seconds used everywhere downstream. Invalid values
-    (non-numeric, bool, non-positive) disable the gate.
+    ``first_token_timeout_ms`` never reaches providers; this is the only ms->s
+    conversion on the path. Invalid values disable the gate.
     """
     normalized_parameters = dict(completion_params)
     stop = normalized_parameters.pop("stop", [])

--- a/api/core/app/llm/model_access.py
+++ b/api/core/app/llm/model_access.py
@@ -128,21 +128,34 @@ def build_dify_model_access(run_context: DifyRunContext) -> tuple[CredentialsPro
     )
 
 
-def _normalize_completion_params(completion_params: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+def _normalize_completion_params(
+    completion_params: dict[str, Any],
+) -> tuple[dict[str, Any], list[str], float | None]:
     """
-    Split node-level completion params into provider parameters and stop sequences.
+    Split node-level completion params into provider parameters, stop sequences,
+    and the first-token timeout.
 
     Workflow LLM-compatible nodes still consume runtime invocation settings from
-    ``ModelInstance.parameters`` and ``ModelInstance.stop``. Keep the
-    ``ModelInstance`` view and the returned config entity aligned here so callers
-    do not need to duplicate normalization logic.
+    ``ModelInstance.parameters``, ``ModelInstance.stop`` and
+    ``ModelInstance.first_token_timeout``. Keep the ``ModelInstance`` view and the
+    returned config entity aligned here so callers do not need to duplicate
+    normalization logic.
+
+    ``first_token_timeout`` is user-facing config in seconds; it is consumed here and
+    never forwarded to providers. Invalid values (non-numeric, bool, non-positive)
+    disable the gate.
     """
     normalized_parameters = dict(completion_params)
     stop = normalized_parameters.pop("stop", [])
     if not isinstance(stop, list) or not all(isinstance(item, str) for item in stop):
         stop = []
 
-    return normalized_parameters, stop
+    raw_timeout = normalized_parameters.pop("first_token_timeout", None)
+    first_token_timeout: float | None = None
+    if isinstance(raw_timeout, (int, float)) and not isinstance(raw_timeout, bool) and raw_timeout > 0:
+        first_token_timeout = float(raw_timeout)
+
+    return normalized_parameters, stop, first_token_timeout
 
 
 def fetch_model_config(
@@ -178,12 +191,13 @@ def fetch_model_config(
     if model_schema is None:
         raise ModelNotExistError(f"Model {node_data_model.name} schema does not exist.")
 
-    parameters, stop = _normalize_completion_params(node_data_model.completion_params)
+    parameters, stop, first_token_timeout = _normalize_completion_params(node_data_model.completion_params)
     model_instance.provider = node_data_model.provider
     model_instance.model_name = node_data_model.name
     model_instance.credentials = credentials
     model_instance.parameters = parameters
     model_instance.stop = tuple(stop)
+    model_instance.first_token_timeout = first_token_timeout
 
     return model_instance, ModelConfigWithCredentialsEntity(
         provider=node_data_model.provider,

--- a/api/core/app/llm/model_access.py
+++ b/api/core/app/llm/model_access.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from copy import deepcopy
 from typing import Any
 
@@ -13,6 +14,8 @@ from graphon.model_runtime.entities.model_entities import ModelType
 from graphon.nodes.llm.entities import ModelConfig
 from graphon.nodes.llm.exc import LLMModeRequiredError, ModelNotExistError
 from graphon.nodes.llm.protocols import CredentialsProvider
+
+logger = logging.getLogger(__name__)
 
 
 class DifyCredentialsProvider:
@@ -155,6 +158,8 @@ def _normalize_completion_params(
     first_token_timeout: float | None = None
     if isinstance(raw_timeout_ms, (int, float)) and not isinstance(raw_timeout_ms, bool) and raw_timeout_ms > 0:
         first_token_timeout = float(raw_timeout_ms) / 1000
+    elif raw_timeout_ms is not None:
+        logger.debug("Ignoring invalid first_token_timeout_ms in completion_params: %r", raw_timeout_ms)
 
     return normalized_parameters, stop, first_token_timeout
 

--- a/api/core/app/llm/model_access.py
+++ b/api/core/app/llm/model_access.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from copy import deepcopy
 from typing import Any
 
@@ -13,6 +14,8 @@ from graphon.model_runtime.entities.model_entities import ModelFeature, ModelPro
 from graphon.nodes.llm.entities import ModelConfig
 from graphon.nodes.llm.exc import LLMModeRequiredError, ModelNotExistError
 from graphon.nodes.llm.protocols import CredentialsProvider
+
+logger = logging.getLogger(__name__)
 
 
 class DifyCredentialsProvider:
@@ -188,6 +191,8 @@ def _normalize_completion_params(
     first_token_timeout: float | None = None
     if isinstance(raw_timeout_ms, (int, float)) and not isinstance(raw_timeout_ms, bool) and raw_timeout_ms > 0:
         first_token_timeout = float(raw_timeout_ms) / 1000
+    elif raw_timeout_ms is not None:
+        logger.debug("Ignoring invalid first_token_timeout_ms in completion_params: %r", raw_timeout_ms)
 
     return normalized_parameters, stop, first_token_timeout
 

--- a/api/core/app/llm/model_access.py
+++ b/api/core/app/llm/model_access.py
@@ -174,19 +174,20 @@ def _normalize_completion_params(
     returned config entity aligned here so callers do not need to duplicate
     normalization logic.
 
-    ``first_token_timeout`` is user-facing config in seconds; it is consumed here and
-    never forwarded to providers. Invalid values (non-numeric, bool, non-positive)
-    disable the gate.
+    ``first_token_timeout_ms`` is user-facing config in milliseconds; it is consumed
+    here and never forwarded to providers. This is the only place the value is
+    converted to the seconds used everywhere downstream. Invalid values
+    (non-numeric, bool, non-positive) disable the gate.
     """
     normalized_parameters = dict(completion_params)
     stop = normalized_parameters.pop("stop", [])
     if not isinstance(stop, list) or not all(isinstance(item, str) for item in stop):
         stop = []
 
-    raw_timeout = normalized_parameters.pop("first_token_timeout", None)
+    raw_timeout_ms = normalized_parameters.pop("first_token_timeout_ms", None)
     first_token_timeout: float | None = None
-    if isinstance(raw_timeout, (int, float)) and not isinstance(raw_timeout, bool) and raw_timeout > 0:
-        first_token_timeout = float(raw_timeout)
+    if isinstance(raw_timeout_ms, (int, float)) and not isinstance(raw_timeout_ms, bool) and raw_timeout_ms > 0:
+        first_token_timeout = float(raw_timeout_ms) / 1000
 
     return normalized_parameters, stop, first_token_timeout
 

--- a/api/core/app/llm/model_access.py
+++ b/api/core/app/llm/model_access.py
@@ -177,10 +177,8 @@ def _normalize_completion_params(
     returned config entity aligned here so callers do not need to duplicate
     normalization logic.
 
-    ``first_token_timeout_ms`` is user-facing config in milliseconds; it is consumed
-    here and never forwarded to providers. This is the only place the value is
-    converted to the seconds used everywhere downstream. Invalid values
-    (non-numeric, bool, non-positive) disable the gate.
+    ``first_token_timeout_ms`` never reaches providers; this is the only ms->s
+    conversion on the path. Invalid values disable the gate.
     """
     normalized_parameters = dict(completion_params)
     stop = normalized_parameters.pop("stop", [])

--- a/api/core/app/llm/model_access.py
+++ b/api/core/app/llm/model_access.py
@@ -161,21 +161,34 @@ def resolve_model_supports_vision(
     return ModelFeature.VISION in (model_instance.get_model_schema().features or [])
 
 
-def _normalize_completion_params(completion_params: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+def _normalize_completion_params(
+    completion_params: dict[str, Any],
+) -> tuple[dict[str, Any], list[str], float | None]:
     """
-    Split node-level completion params into provider parameters and stop sequences.
+    Split node-level completion params into provider parameters, stop sequences,
+    and the first-token timeout.
 
     Workflow LLM-compatible nodes still consume runtime invocation settings from
-    ``ModelInstance.parameters`` and ``ModelInstance.stop``. Keep the
-    ``ModelInstance`` view and the returned config entity aligned here so callers
-    do not need to duplicate normalization logic.
+    ``ModelInstance.parameters``, ``ModelInstance.stop`` and
+    ``ModelInstance.first_token_timeout``. Keep the ``ModelInstance`` view and the
+    returned config entity aligned here so callers do not need to duplicate
+    normalization logic.
+
+    ``first_token_timeout`` is user-facing config in seconds; it is consumed here and
+    never forwarded to providers. Invalid values (non-numeric, bool, non-positive)
+    disable the gate.
     """
     normalized_parameters = dict(completion_params)
     stop = normalized_parameters.pop("stop", [])
     if not isinstance(stop, list) or not all(isinstance(item, str) for item in stop):
         stop = []
 
-    return normalized_parameters, stop
+    raw_timeout = normalized_parameters.pop("first_token_timeout", None)
+    first_token_timeout: float | None = None
+    if isinstance(raw_timeout, (int, float)) and not isinstance(raw_timeout, bool) and raw_timeout > 0:
+        first_token_timeout = float(raw_timeout)
+
+    return normalized_parameters, stop, first_token_timeout
 
 
 def fetch_model_config(
@@ -214,12 +227,13 @@ def fetch_model_config(
     if model_schema is None:
         raise ModelNotExistError(f"Model {node_data_model.name} schema does not exist.")
 
-    parameters, stop = _normalize_completion_params(node_data_model.completion_params)
+    parameters, stop, first_token_timeout = _normalize_completion_params(node_data_model.completion_params)
     model_instance.provider = node_data_model.provider
     model_instance.model_name = node_data_model.name
     model_instance.credentials = credentials
     model_instance.parameters = parameters
     model_instance.stop = tuple(stop)
+    model_instance.first_token_timeout = first_token_timeout
 
     return model_instance, ModelConfigWithCredentialsEntity(
         provider=node_data_model.provider,

--- a/api/core/model_manager.py
+++ b/api/core/model_manager.py
@@ -47,6 +47,7 @@ class ModelInstance:
         # Runtime LLM invocation fields.
         self.parameters: Mapping[str, Any] = {}
         self.stop: Sequence[str] = ()
+        self.first_token_timeout: float | None = None
         self.model_type_instance = self.provider_model_bundle.model_type_instance
         self.load_balancing_manager = self._get_load_balancing_manager(
             configuration=provider_model_bundle.configuration,

--- a/api/core/model_manager.py
+++ b/api/core/model_manager.py
@@ -64,6 +64,7 @@ class ModelInstance:
         # Runtime LLM invocation fields.
         self.parameters: Mapping[str, Any] = {}
         self.stop: Sequence[str] = ()
+        self.first_token_timeout: float | None = None
         self.model_type_instance = self.provider_model_bundle.model_type_instance
         self.load_balancing_manager = self._get_load_balancing_manager(
             configuration=provider_model_bundle.configuration,

--- a/api/core/plugin/impl/base.py
+++ b/api/core/plugin/impl/base.py
@@ -57,13 +57,15 @@ match _plugin_daemon_timeout_config:
 
 
 def _read_timeout_for(first_token_timeout: float | None) -> httpx.Timeout | None:
-    """Narrow the daemon request timeout's ``read`` component to the first-token budget.
+    """Replace the daemon request timeout's ``read`` component with the first-token budget.
 
     The daemon withholds the response headers until the model's first token and sends no
     heartbeat before it, so httpx's ``read`` timeout (which covers both the header wait and
-    each body read) measures time-to-first-token. A non-positive budget disables the gate
-    and keeps the default timeout. ``httpx.Timeout(base, read=x)`` is rejected when ``base``
-    is a ``Timeout``, so the other components are copied explicitly.
+    each body read) measures time-to-first-token. The budget replaces the operator-level
+    read timeout outright rather than narrowing it — deliberately, so slow reasoning models
+    can be granted more headroom than ``PLUGIN_DAEMON_TIMEOUT``. A non-positive budget
+    disables the gate and keeps the default timeout. ``httpx.Timeout(base, read=x)`` is
+    rejected when ``base`` is a ``Timeout``, so the other components are copied explicitly.
     """
     base = plugin_daemon_request_timeout
     if not first_token_timeout or first_token_timeout <= 0:
@@ -243,7 +245,12 @@ class BasePluginClient:
             if first_token_gate and not first_token_seen:
                 raise FirstTokenTimeoutError(f"The first token was not received within {first_token_timeout}s.") from e
             logger.exception("Stream request to Plugin Daemon Service failed")
-            raise PluginDaemonInnerError(code=-500, message="Request to Plugin Daemon Service failed")
+            message = "Request to Plugin Daemon Service failed"
+            if first_token_gate:
+                # The narrowed read window also bounds inter-token gaps; name the setting
+                # so a mid-stream stall is traceable to the user's configuration.
+                message += f" (stream stalled beyond the {first_token_timeout}s first-token timeout window)"
+            raise PluginDaemonInnerError(code=-500, message=message)
         except httpx.RequestError:
             logger.exception("Stream request to Plugin Daemon Service failed")
             raise PluginDaemonInnerError(code=-500, message="Request to Plugin Daemon Service failed")

--- a/api/core/plugin/impl/base.py
+++ b/api/core/plugin/impl/base.py
@@ -25,6 +25,7 @@ from core.plugin.impl.exc import (
     PluginPermissionDeniedError,
     PluginUniqueIdentifierError,
 )
+from core.plugin.impl.first_token_timeout import FirstTokenTimeoutError, first_token_timeout_ctx
 from core.trigger.errors import (
     EventIgnoreError,
     TriggerInvokeError,
@@ -53,6 +54,24 @@ match _plugin_daemon_timeout_config:
         plugin_daemon_request_timeout = _plugin_daemon_timeout_config
     case _:
         plugin_daemon_request_timeout = httpx.Timeout(_plugin_daemon_timeout_config)
+
+
+def _read_timeout_for(first_token_timeout: float | None) -> httpx.Timeout | None:
+    """Narrow the daemon request timeout's ``read`` component to the first-token budget.
+
+    The daemon withholds the response headers until the model's first token and sends no
+    heartbeat before it, so httpx's ``read`` timeout (which covers both the header wait and
+    each body read) measures time-to-first-token. A non-positive budget disables the gate
+    and keeps the default timeout. ``httpx.Timeout(base, read=x)`` is rejected when ``base``
+    is a ``Timeout``, so the other components are copied explicitly.
+    """
+    base = plugin_daemon_request_timeout
+    if not first_token_timeout or first_token_timeout <= 0:
+        return base
+    if base is None:
+        return httpx.Timeout(None, read=first_token_timeout)
+    return httpx.Timeout(connect=base.connect, read=first_token_timeout, write=base.write, pool=base.pool)
+
 
 logger = logging.getLogger(__name__)
 
@@ -181,30 +200,50 @@ class BasePluginClient:
         """
         url, headers, prepared_data, params, files = self._prepare_request(path, headers, data, params, files)
 
+        first_token_timeout = first_token_timeout_ctx.get()
+        # Non-positive (None / 0 / negative) disables the gate; the read timeout stays default.
+        first_token_gate = bool(first_token_timeout and first_token_timeout > 0)
         stream_kwargs: dict[str, Any] = {
             "method": method,
             "url": url,
             "headers": headers,
             "params": params,
             "files": files,
-            "timeout": plugin_daemon_request_timeout,
+            # The daemon holds the response headers until the first token, so a per-request
+            # read timeout equal to the first-token budget gates time-to-first-token.
+            "timeout": _read_timeout_for(first_token_timeout),
         }
         if isinstance(prepared_data, dict):
             stream_kwargs["data"] = prepared_data
         elif prepared_data is not None:
             stream_kwargs["content"] = prepared_data
 
+        first_token_seen = False
+
         try:
             with _httpx_client.stream(**stream_kwargs) as response:
                 for raw_line in response.iter_lines():
+                    # Blank keep-alive frames don't count as the first token, but each is still a
+                    # successful read that refreshes httpx's read window -- first-token gating relies
+                    # on the daemon sending no keep-alive before the first token.
                     if not raw_line:
                         continue
                     line = raw_line.decode("utf-8") if isinstance(raw_line, bytes) else raw_line
                     line = line.strip()
                     if line.startswith("data:"):
                         line = line[5:].strip()
-                    if line:
-                        yield line
+                    if not line:
+                        continue
+                    first_token_seen = True
+                    yield line
+        except httpx.ReadTimeout as e:
+            # Gate on: a read timeout before the first line means the first token was too slow.
+            # After the first line (inter-token stall), or with the gate off, it's a plain
+            # transport error.
+            if first_token_gate and not first_token_seen:
+                raise FirstTokenTimeoutError(f"The first token was not received within {first_token_timeout}s.") from e
+            logger.exception("Stream request to Plugin Daemon Service failed")
+            raise PluginDaemonInnerError(code=-500, message="Request to Plugin Daemon Service failed")
         except httpx.RequestError:
             logger.exception("Stream request to Plugin Daemon Service failed")
             raise PluginDaemonInnerError(code=-500, message="Request to Plugin Daemon Service failed")

--- a/api/core/plugin/impl/base.py
+++ b/api/core/plugin/impl/base.py
@@ -59,13 +59,9 @@ match _plugin_daemon_timeout_config:
 def _read_timeout_for(first_token_timeout: float | None) -> httpx.Timeout | None:
     """Replace the daemon request timeout's ``read`` component with the first-token budget.
 
-    The daemon withholds the response headers until the model's first token and sends no
-    heartbeat before it, so httpx's ``read`` timeout (which covers both the header wait and
-    each body read) measures time-to-first-token. The budget replaces the operator-level
-    read timeout outright rather than narrowing it — deliberately, so slow reasoning models
-    can be granted more headroom than ``PLUGIN_DAEMON_TIMEOUT``. A non-positive budget
-    disables the gate and keeps the default timeout. ``httpx.Timeout(base, read=x)`` is
-    rejected when ``base`` is a ``Timeout``, so the other components are copied explicitly.
+    Deliberately a replacement rather than a narrowing, so the budget may exceed
+    ``PLUGIN_DAEMON_TIMEOUT`` for slow reasoning models. ``httpx.Timeout(base, read=x)``
+    rejects a ``Timeout`` base, so the other components are copied explicitly.
     """
     base = plugin_daemon_request_timeout
     if not first_token_timeout or first_token_timeout <= 0:
@@ -203,7 +199,6 @@ class BasePluginClient:
         url, headers, prepared_data, params, files = self._prepare_request(path, headers, data, params, files)
 
         first_token_timeout = first_token_timeout_ctx.get()
-        # Non-positive (None / 0 / negative) disables the gate; the read timeout stays default.
         first_token_gate = bool(first_token_timeout and first_token_timeout > 0)
         stream_kwargs: dict[str, Any] = {
             "method": method,
@@ -211,8 +206,7 @@ class BasePluginClient:
             "headers": headers,
             "params": params,
             "files": files,
-            # The daemon holds the response headers until the first token, so a per-request
-            # read timeout equal to the first-token budget gates time-to-first-token.
+            # The daemon sends nothing before the first token, so the read timeout gates TTFT.
             "timeout": _read_timeout_for(first_token_timeout),
         }
         if isinstance(prepared_data, dict):
@@ -225,9 +219,8 @@ class BasePluginClient:
         try:
             with _httpx_client.stream(**stream_kwargs) as response:
                 for raw_line in response.iter_lines():
-                    # Blank keep-alive frames don't count as the first token, but each is still a
-                    # successful read that refreshes httpx's read window -- first-token gating relies
-                    # on the daemon sending no keep-alive before the first token.
+                    # Blank frames don't count as the first token, yet each read refreshes the
+                    # read window -- gating relies on no keep-alives before the first token.
                     if not raw_line:
                         continue
                     line = raw_line.decode("utf-8") if isinstance(raw_line, bytes) else raw_line
@@ -239,16 +232,13 @@ class BasePluginClient:
                     first_token_seen = True
                     yield line
         except httpx.ReadTimeout as e:
-            # Gate on: a read timeout before the first line means the first token was too slow.
-            # After the first line (inter-token stall), or with the gate off, it's a plain
-            # transport error.
             if first_token_gate and not first_token_seen:
                 raise FirstTokenTimeoutError(f"The first token was not received within {first_token_timeout}s.") from e
             logger.exception("Stream request to Plugin Daemon Service failed")
             message = "Request to Plugin Daemon Service failed"
             if first_token_gate:
-                # The narrowed read window also bounds inter-token gaps; name the setting
-                # so a mid-stream stall is traceable to the user's configuration.
+                # An inter-token stall past the read window is a plain transport error,
+                # but name the window so it stays traceable to the user's setting.
                 message += f" (stream stalled beyond the {first_token_timeout}s first-token timeout window)"
             raise PluginDaemonInnerError(code=-500, message=message)
         except httpx.RequestError:

--- a/api/core/plugin/impl/base.py
+++ b/api/core/plugin/impl/base.py
@@ -299,7 +299,12 @@ class BasePluginClient:
             if first_token_gate and not first_token_seen:
                 raise FirstTokenTimeoutError(f"The first token was not received within {first_token_timeout}s.") from e
             logger.exception("Stream request to Plugin Daemon Service failed")
-            raise PluginDaemonInnerError(code=-500, message="Request to Plugin Daemon Service failed")
+            message = "Request to Plugin Daemon Service failed"
+            if first_token_gate:
+                # The narrowed read window also bounds inter-token gaps; name the setting
+                # so a mid-stream stall is traceable to the user's configuration.
+                message += f" (stream stalled beyond the {first_token_timeout}s first-token timeout window)"
+            raise PluginDaemonInnerError(code=-500, message=message) from e
         except httpx.RequestError:
             logger.exception("Stream request to Plugin Daemon Service failed")
             raise PluginDaemonInnerError(code=-500, message="Request to Plugin Daemon Service failed")

--- a/api/core/plugin/impl/base.py
+++ b/api/core/plugin/impl/base.py
@@ -99,11 +99,10 @@ def _get_plugin_daemon_request_timeout() -> httpx.Timeout | None:
 def _resolve_stream_timeout(first_token_timeout: float | None) -> httpx.Timeout | None:
     """Fold a first-token budget into the timeout a streaming daemon request uses.
 
-    The daemon withholds the response headers until the model's first token and sends no
-    heartbeat before it, so httpx's ``read`` timeout measures time-to-first-token. A
-    positive budget therefore replaces that component -- deliberately a replacement, so a
-    slow reasoning model may exceed ``PLUGIN_DAEMON_TIMEOUT``. A context-scoped override is
-    a ceiling its caller asked for, so it is only ever narrowed.
+    The budget deliberately replaces the ``read`` component rather than narrowing it, so it
+    may exceed ``PLUGIN_DAEMON_TIMEOUT`` for slow reasoning models -- but a context-scoped
+    override is a ceiling its caller asked for and is only ever narrowed.
+    ``httpx.Timeout(base, read=x)`` rejects a ``Timeout`` base, so the rest is copied.
     """
     base = _get_plugin_daemon_request_timeout()
     if not first_token_timeout or first_token_timeout <= 0:
@@ -116,7 +115,6 @@ def _resolve_stream_timeout(first_token_timeout: float | None) -> httpx.Timeout 
 
     if base is None:
         return httpx.Timeout(None, read=read)
-    # ``httpx.Timeout(base, read=x)`` is rejected when ``base`` is a ``Timeout``.
     return httpx.Timeout(connect=base.connect, read=read, write=base.write, pool=base.pool)
 
 
@@ -259,7 +257,6 @@ class BasePluginClient:
         url, headers, prepared_data, params, files = self._prepare_request(path, headers, data, params, files)
 
         first_token_timeout = first_token_timeout_ctx.get()
-        # Non-positive (None / 0 / negative) disables the gate; the read timeout stays default.
         first_token_gate = bool(first_token_timeout and first_token_timeout > 0)
         stream_kwargs: dict[str, Any] = {
             "method": method,
@@ -267,6 +264,7 @@ class BasePluginClient:
             "headers": headers,
             "params": params,
             "files": files,
+            # The daemon sends nothing before the first token, so the read timeout gates TTFT.
             "timeout": _resolve_stream_timeout(first_token_timeout),
         }
         if isinstance(prepared_data, dict):
@@ -279,9 +277,8 @@ class BasePluginClient:
         try:
             with _httpx_client.stream(**stream_kwargs) as response:
                 for raw_line in response.iter_lines():
-                    # Blank keep-alive frames don't count as the first token, but each is still a
-                    # successful read that refreshes httpx's read window -- first-token gating relies
-                    # on the daemon sending no keep-alive before the first token.
+                    # Blank frames don't count as the first token, yet each read refreshes the
+                    # read window -- gating relies on no keep-alives before the first token.
                     if not raw_line:
                         continue
                     line = raw_line.decode("utf-8") if isinstance(raw_line, bytes) else raw_line
@@ -293,16 +290,13 @@ class BasePluginClient:
                     first_token_seen = True
                     yield line
         except httpx.ReadTimeout as e:
-            # Gate on: a read timeout before the first line means the first token was too slow.
-            # After the first line (inter-token stall), or with the gate off, it's a plain
-            # transport error.
             if first_token_gate and not first_token_seen:
                 raise FirstTokenTimeoutError(f"The first token was not received within {first_token_timeout}s.") from e
             logger.exception("Stream request to Plugin Daemon Service failed")
             message = "Request to Plugin Daemon Service failed"
             if first_token_gate:
-                # The narrowed read window also bounds inter-token gaps; name the setting
-                # so a mid-stream stall is traceable to the user's configuration.
+                # An inter-token stall past the read window is a plain transport error,
+                # but name the window so it stays traceable to the user's setting.
                 message += f" (stream stalled beyond the {first_token_timeout}s first-token timeout window)"
             raise PluginDaemonInnerError(code=-500, message=message) from e
         except httpx.RequestError:

--- a/api/core/plugin/impl/base.py
+++ b/api/core/plugin/impl/base.py
@@ -33,6 +33,7 @@ from core.plugin.impl.exc import (
     PluginRuntimeError,
     PluginUniqueIdentifierError,
 )
+from core.plugin.impl.first_token_timeout import FirstTokenTimeoutError, first_token_timeout_ctx
 from core.trigger.errors import (
     EventIgnoreError,
     TriggerInvokeError,
@@ -93,6 +94,30 @@ def use_plugin_daemon_request_timeout(timeout_seconds: float) -> Generator[None,
 
 def _get_plugin_daemon_request_timeout() -> httpx.Timeout | None:
     return _plugin_daemon_request_timeout_override.get() or plugin_daemon_request_timeout
+
+
+def _resolve_stream_timeout(first_token_timeout: float | None) -> httpx.Timeout | None:
+    """Fold a first-token budget into the timeout a streaming daemon request uses.
+
+    The daemon withholds the response headers until the model's first token and sends no
+    heartbeat before it, so httpx's ``read`` timeout measures time-to-first-token. A
+    positive budget therefore replaces that component -- deliberately a replacement, so a
+    slow reasoning model may exceed ``PLUGIN_DAEMON_TIMEOUT``. A context-scoped override is
+    a ceiling its caller asked for, so it is only ever narrowed.
+    """
+    base = _get_plugin_daemon_request_timeout()
+    if not first_token_timeout or first_token_timeout <= 0:
+        return base
+
+    read = first_token_timeout
+    override = _plugin_daemon_request_timeout_override.get()
+    if override is not None and override.read is not None:
+        read = min(read, override.read)
+
+    if base is None:
+        return httpx.Timeout(None, read=read)
+    # ``httpx.Timeout(base, read=x)`` is rejected when ``base`` is a ``Timeout``.
+    return httpx.Timeout(connect=base.connect, read=read, write=base.write, pool=base.pool)
 
 
 def _normalize_plugin_daemon_response_for_type(json_response: Any, type_: type[object]) -> Any:
@@ -233,30 +258,48 @@ class BasePluginClient:
         """
         url, headers, prepared_data, params, files = self._prepare_request(path, headers, data, params, files)
 
+        first_token_timeout = first_token_timeout_ctx.get()
+        # Non-positive (None / 0 / negative) disables the gate; the read timeout stays default.
+        first_token_gate = bool(first_token_timeout and first_token_timeout > 0)
         stream_kwargs: dict[str, Any] = {
             "method": method,
             "url": url,
             "headers": headers,
             "params": params,
             "files": files,
-            "timeout": _get_plugin_daemon_request_timeout(),
+            "timeout": _resolve_stream_timeout(first_token_timeout),
         }
         if isinstance(prepared_data, dict):
             stream_kwargs["data"] = prepared_data
         elif prepared_data is not None:
             stream_kwargs["content"] = prepared_data
 
+        first_token_seen = False
+
         try:
             with _httpx_client.stream(**stream_kwargs) as response:
                 for raw_line in response.iter_lines():
+                    # Blank keep-alive frames don't count as the first token, but each is still a
+                    # successful read that refreshes httpx's read window -- first-token gating relies
+                    # on the daemon sending no keep-alive before the first token.
                     if not raw_line:
                         continue
                     line = raw_line.decode("utf-8") if isinstance(raw_line, bytes) else raw_line
                     line = line.strip()
                     if line.startswith("data:"):
                         line = line[5:].strip()
-                    if line:
-                        yield line
+                    if not line:
+                        continue
+                    first_token_seen = True
+                    yield line
+        except httpx.ReadTimeout as e:
+            # Gate on: a read timeout before the first line means the first token was too slow.
+            # After the first line (inter-token stall), or with the gate off, it's a plain
+            # transport error.
+            if first_token_gate and not first_token_seen:
+                raise FirstTokenTimeoutError(f"The first token was not received within {first_token_timeout}s.") from e
+            logger.exception("Stream request to Plugin Daemon Service failed")
+            raise PluginDaemonInnerError(code=-500, message="Request to Plugin Daemon Service failed")
         except httpx.RequestError:
             logger.exception("Stream request to Plugin Daemon Service failed")
             raise PluginDaemonInnerError(code=-500, message="Request to Plugin Daemon Service failed")

--- a/api/core/plugin/impl/first_token_timeout.py
+++ b/api/core/plugin/impl/first_token_timeout.py
@@ -1,7 +1,7 @@
 """First-token timeout plumbing for LLM streaming through the plugin daemon.
 
-The timeout is configured per model in ``completion_params.first_token_timeout``
-(seconds). Dify pops it at the workflow model-config boundary
+The timeout is configured per model in ``completion_params.first_token_timeout_ms``
+(milliseconds). Dify pops it at the workflow model-config boundary
 (``core.app.llm.model_access._normalize_completion_params``) into
 ``ModelInstance.first_token_timeout``, and the workflow LLM adapter
 (``DifyPreparedLLM``) carries it down to the plugin-daemon transport through a
@@ -14,9 +14,11 @@ headers until the model emits its first token and sends no heartbeat in the mean
 the ``read`` timeout measures time-to-first-token directly; on expiry httpx raises
 ``httpx.ReadTimeout`` and the transport surfaces it as ``FirstTokenTimeoutError``.
 
-Units: this value is in **seconds** everywhere -- the web UI field, the value stored in
-``completion_params``, and the float that feeds straight into ``httpx.Timeout(read=...)``.
-There is no millisecond representation anywhere on this path; do not add a conversion.
+Units: the user-facing value (web UI field, ``completion_params``) is **milliseconds**;
+everything downstream of the pop point -- ``ModelInstance.first_token_timeout``, this
+ContextVar, and the float fed straight into ``httpx.Timeout(read=...)`` -- is **seconds**.
+The ms->s conversion happens exactly once, in ``_normalize_completion_params``; do not
+add another one.
 
 Threading: the ContextVar only reaches the transport when ``_stream_request`` runs in the same
 thread/context that ``_guarded_stream`` set it in. A future model-runtime layer that prefetches

--- a/api/core/plugin/impl/first_token_timeout.py
+++ b/api/core/plugin/impl/first_token_timeout.py
@@ -1,29 +1,15 @@
 """First-token timeout plumbing for LLM streaming through the plugin daemon.
 
-The timeout is configured per model in ``completion_params.first_token_timeout_ms``
-(milliseconds). Dify pops it at the workflow model-config boundary
-(``core.app.llm.model_access._normalize_completion_params``) into
-``ModelInstance.first_token_timeout``, and the workflow LLM adapter
-(``DifyPreparedLLM``) carries it down to the plugin-daemon transport through a
-:class:`~contextvars.ContextVar`, so the intermediate model-runtime layers (which
-don't take the value as a parameter) stay untouched.
+Configured per model as ``completion_params.first_token_timeout_ms`` and popped into
+``ModelInstance.first_token_timeout`` by ``_normalize_completion_params`` -- the only
+ms->s conversion; everything below the pop point is seconds. ``DifyPreparedLLM`` sets
+the ContextVar around invocation, and ``BasePluginClient._stream_request`` applies it
+as the per-request httpx ``read`` timeout. The daemon sends neither response headers
+nor keep-alives before the first token, so the read timeout measures
+time-to-first-token directly.
 
-Enforcement lives in the transport (``BasePluginClient._stream_request``): the value is
-applied as httpx's per-request ``read`` timeout. The daemon withholds the HTTP response
-headers until the model emits its first token and sends no heartbeat in the meantime, so
-the ``read`` timeout measures time-to-first-token directly; on expiry httpx raises
-``httpx.ReadTimeout`` and the transport surfaces it as ``FirstTokenTimeoutError``.
-
-Units: the user-facing value (web UI field, ``completion_params``) is **milliseconds**;
-everything downstream of the pop point -- ``ModelInstance.first_token_timeout``, this
-ContextVar, and the float fed straight into ``httpx.Timeout(read=...)`` -- is **seconds**.
-The ms->s conversion happens exactly once, in ``_normalize_completion_params``; do not
-add another one.
-
-Threading: the ContextVar only reaches the transport when ``_stream_request`` runs in the same
-thread/context that ``_guarded_stream`` set it in. A future model-runtime layer that prefetches
-the SSE stream on a background thread would read the default (``None``), so the gate silently
-disables -- fail-open: no false timeouts, just no enforcement.
+The ContextVar only reaches the transport on the thread that set it; a
+background-thread stream consumer would read ``None`` and the gate fails open.
 """
 
 from contextvars import ContextVar
@@ -37,6 +23,5 @@ class FirstTokenTimeoutError(InvokeError):
     description = "The first streamed token was not received in time."
 
 
-# Seconds to wait for the first streamed token; ``None`` (or non-positive) disables the gate.
-# Set by the workflow LLM adapter around the invoke generator, read in ``_stream_request``.
+# Seconds; None or non-positive disables the gate.
 first_token_timeout_ctx: ContextVar[float | None] = ContextVar("first_token_timeout", default=None)

--- a/api/core/plugin/impl/first_token_timeout.py
+++ b/api/core/plugin/impl/first_token_timeout.py
@@ -1,0 +1,40 @@
+"""First-token timeout plumbing for LLM streaming through the plugin daemon.
+
+The timeout is configured per model in ``completion_params.first_token_timeout``
+(seconds). Dify pops it at the workflow model-config boundary
+(``core.app.llm.model_access._normalize_completion_params``) into
+``ModelInstance.first_token_timeout``, and the workflow LLM adapter
+(``DifyPreparedLLM``) carries it down to the plugin-daemon transport through a
+:class:`~contextvars.ContextVar`, so the intermediate model-runtime layers (which
+don't take the value as a parameter) stay untouched.
+
+Enforcement lives in the transport (``BasePluginClient._stream_request``): the value is
+applied as httpx's per-request ``read`` timeout. The daemon withholds the HTTP response
+headers until the model emits its first token and sends no heartbeat in the meantime, so
+the ``read`` timeout measures time-to-first-token directly; on expiry httpx raises
+``httpx.ReadTimeout`` and the transport surfaces it as ``FirstTokenTimeoutError``.
+
+Units: this value is in **seconds** everywhere -- the web UI field, the value stored in
+``completion_params``, and the float that feeds straight into ``httpx.Timeout(read=...)``.
+There is no millisecond representation anywhere on this path; do not add a conversion.
+
+Threading: the ContextVar only reaches the transport when ``_stream_request`` runs in the same
+thread/context that ``_guarded_stream`` set it in. A future model-runtime layer that prefetches
+the SSE stream on a background thread would read the default (``None``), so the gate silently
+disables -- fail-open: no false timeouts, just no enforcement.
+"""
+
+from contextvars import ContextVar
+
+from graphon.model_runtime.errors.invoke import InvokeError
+
+
+class FirstTokenTimeoutError(InvokeError):
+    """The model did not stream its first token within the configured budget."""
+
+    description = "The first streamed token was not received in time."
+
+
+# Seconds to wait for the first streamed token; ``None`` (or non-positive) disables the gate.
+# Set by the workflow LLM adapter around the invoke generator, read in ``_stream_request``.
+first_token_timeout_ctx: ContextVar[float | None] = ContextVar("first_token_timeout", default=None)

--- a/api/core/workflow/node_runtime.py
+++ b/api/core/workflow/node_runtime.py
@@ -22,6 +22,7 @@ from core.llm_generator.output_parser.errors import OutputParserError
 from core.llm_generator.output_parser.structured_output import invoke_llm_with_structured_output
 from core.model_manager import ModelInstance
 from core.plugin.impl.exc import PluginDaemonClientSideError, PluginInvokeError
+from core.plugin.impl.first_token_timeout import first_token_timeout_ctx
 from core.plugin.impl.plugin import PluginInstaller
 from core.prompt.utils.prompt_message_util import PromptMessageUtil
 from core.repositories.human_input_repository import (
@@ -147,6 +148,51 @@ class DifyFileReferenceFactory(FileReferenceFactoryProtocol):
         )
 
 
+def _guarded_stream(
+    seconds: float,
+    inner: Generator[Any, None, None],
+) -> Generator[Any, None, None]:
+    """Iterate ``inner`` with the first-token-timeout ContextVar set.
+
+    Setting it inside the generator keeps it active for exactly the span of iteration,
+    which is when the plugin-daemon transport (`_stream_request`) reads it to arm the
+    first-token watchdog. Enforcement stays in the transport; this only carries the value.
+
+    This assumes the transport runs in the same thread as this iteration: a background-thread
+    SSE prefetch would not see the ContextVar and the gate would fail open (no enforcement).
+    """
+    token = first_token_timeout_ctx.set(seconds)
+    try:
+        yield from inner
+    finally:
+        first_token_timeout_ctx.reset(token)
+
+
+def _with_first_token_timeout[T](first_token_timeout: float | None, invoke: Callable[[], T]) -> T:
+    """Run ``invoke`` with the first-token-timeout ContextVar applied.
+
+    ``first_token_timeout`` is in **seconds** and comes from
+    ``ModelInstance.first_token_timeout``, populated at the workflow model-config
+    boundary from ``completion_params`` (see ``core.app.llm.model_access``). This is
+    the single chokepoint both ``invoke_llm`` and ``invoke_llm_with_structured_output``
+    funnel through.
+
+    A streaming result is lazy, so its generator is wrapped to keep the ContextVar set
+    during iteration; a non-stream result is produced eagerly under the gate. A
+    non-positive timeout (None / 0 / negative) is treated as disabled.
+    """
+    if first_token_timeout is None or first_token_timeout <= 0:
+        return invoke()
+    token = first_token_timeout_ctx.set(first_token_timeout)
+    try:
+        result = invoke()
+    finally:
+        first_token_timeout_ctx.reset(token)
+    if isinstance(result, Generator):
+        return cast("T", _guarded_stream(first_token_timeout, result))
+    return result
+
+
 class DifyPreparedLLM(LLMProtocol):
     """Workflow-layer adapter that hides the full `ModelInstance` API from `graphon` nodes."""
 
@@ -225,13 +271,16 @@ class DifyPreparedLLM(LLMProtocol):
         stop: Sequence[str] | None,
         stream: bool,
     ) -> LLMResult | Generator[LLMResultChunk, None, None]:
-        return self._model_instance.invoke_llm(
-            prompt_messages=list(prompt_messages),
-            model_parameters=dict(model_parameters),
-            tools=list(tools or []),
-            stop=list(stop or []),
-            stream=stream,
-            request_metadata=self._request_metadata,
+        return _with_first_token_timeout(
+            self._model_instance.first_token_timeout,
+            lambda: self._model_instance.invoke_llm(
+                prompt_messages=list(prompt_messages),
+                model_parameters=dict(model_parameters),
+                tools=list(tools or []),
+                stop=list(stop or []),
+                stream=stream,
+                request_metadata=self._request_metadata,
+            ),
         )
 
     @overload
@@ -266,15 +315,18 @@ class DifyPreparedLLM(LLMProtocol):
         stop: Sequence[str] | None,
         stream: bool,
     ) -> LLMResultWithStructuredOutput | Generator[LLMResultChunkWithStructuredOutput, None, None]:
-        return invoke_llm_with_structured_output(
-            provider=self.provider,
-            model_schema=self.get_model_schema(),
-            model_instance=self._model_instance,
-            prompt_messages=prompt_messages,
-            json_schema=json_schema,
-            model_parameters=model_parameters,
-            stop=list(stop or []),
-            stream=stream,
+        return _with_first_token_timeout(
+            self._model_instance.first_token_timeout,
+            lambda: invoke_llm_with_structured_output(
+                provider=self.provider,
+                model_schema=self.get_model_schema(),
+                model_instance=self._model_instance,
+                prompt_messages=prompt_messages,
+                json_schema=json_schema,
+                model_parameters=model_parameters,
+                stop=list(stop or []),
+                stream=stream,
+            ),
         )
 
     @override

--- a/api/core/workflow/node_runtime.py
+++ b/api/core/workflow/node_runtime.py
@@ -154,12 +154,9 @@ def _guarded_stream(
 ) -> Generator[Any, None, None]:
     """Iterate ``inner`` with the first-token-timeout ContextVar set.
 
-    Setting it inside the generator keeps it active for exactly the span of iteration,
-    which is when the plugin-daemon transport (`_stream_request`) reads it to arm the
-    first-token watchdog. Enforcement stays in the transport; this only carries the value.
-
-    This assumes the transport runs in the same thread as this iteration: a background-thread
-    SSE prefetch would not see the ContextVar and the gate would fail open (no enforcement).
+    Keeps the value active for exactly the span of iteration, which is when the
+    plugin-daemon transport reads it. Same-thread only: a background-thread SSE
+    prefetch would not see it and the gate fails open.
     """
     token = first_token_timeout_ctx.set(seconds)
     try:
@@ -171,15 +168,9 @@ def _guarded_stream(
 def _with_first_token_timeout[T](first_token_timeout: float | None, invoke: Callable[[], T]) -> T:
     """Run ``invoke`` with the first-token-timeout ContextVar applied.
 
-    ``first_token_timeout`` is in **seconds** and comes from
-    ``ModelInstance.first_token_timeout``, populated at the workflow model-config
-    boundary from ``completion_params`` (see ``core.app.llm.model_access``). This is
-    the single chokepoint both ``invoke_llm`` and ``invoke_llm_with_structured_output``
-    funnel through.
-
-    A streaming result is lazy, so its generator is wrapped to keep the ContextVar set
-    during iteration; a non-stream result is produced eagerly under the gate. A
-    non-positive timeout (None / 0 / negative) is treated as disabled.
+    ``first_token_timeout`` is seconds, from ``ModelInstance.first_token_timeout``.
+    A streaming result is lazy, so its generator is wrapped to keep the ContextVar
+    set during iteration; a non-positive timeout disables the gate.
     """
     if first_token_timeout is None or first_token_timeout <= 0:
         return invoke()

--- a/api/core/workflow/node_runtime.py
+++ b/api/core/workflow/node_runtime.py
@@ -23,6 +23,7 @@ from core.llm_generator.output_parser.structured_output import invoke_llm_with_s
 from core.model_context import use_credit_usage_metadata
 from core.model_manager import ModelInstance, QuotaManagedModelInstance
 from core.plugin.impl.exc import PluginDaemonClientSideError, PluginInvokeError
+from core.plugin.impl.first_token_timeout import first_token_timeout_ctx
 from core.plugin.impl.plugin import PluginInstaller
 from core.prompt.utils.prompt_message_util import PromptMessageUtil
 from core.repositories.human_input_repository import (
@@ -176,6 +177,51 @@ class DifyFileReferenceFactory(FileReferenceFactoryProtocol):
         )
 
 
+def _guarded_stream(
+    seconds: float,
+    inner: Generator[Any, None, None],
+) -> Generator[Any, None, None]:
+    """Iterate ``inner`` with the first-token-timeout ContextVar set.
+
+    Setting it inside the generator keeps it active for exactly the span of iteration,
+    which is when the plugin-daemon transport (`_stream_request`) reads it to arm the
+    first-token watchdog. Enforcement stays in the transport; this only carries the value.
+
+    This assumes the transport runs in the same thread as this iteration: a background-thread
+    SSE prefetch would not see the ContextVar and the gate would fail open (no enforcement).
+    """
+    token = first_token_timeout_ctx.set(seconds)
+    try:
+        yield from inner
+    finally:
+        first_token_timeout_ctx.reset(token)
+
+
+def _with_first_token_timeout[T](first_token_timeout: float | None, invoke: Callable[[], T]) -> T:
+    """Run ``invoke`` with the first-token-timeout ContextVar applied.
+
+    ``first_token_timeout`` is in **seconds** and comes from
+    ``ModelInstance.first_token_timeout``, populated at the workflow model-config
+    boundary from ``completion_params`` (see ``core.app.llm.model_access``). This is
+    the single chokepoint both ``invoke_llm`` and ``invoke_llm_with_structured_output``
+    funnel through.
+
+    A streaming result is lazy, so its generator is wrapped to keep the ContextVar set
+    during iteration; a non-stream result is produced eagerly under the gate. A
+    non-positive timeout (None / 0 / negative) is treated as disabled.
+    """
+    if first_token_timeout is None or first_token_timeout <= 0:
+        return invoke()
+    token = first_token_timeout_ctx.set(first_token_timeout)
+    try:
+        result = invoke()
+    finally:
+        first_token_timeout_ctx.reset(token)
+    if isinstance(result, Generator):
+        return cast("T", _guarded_stream(first_token_timeout, result))
+    return result
+
+
 class DifyPreparedLLM(LLMProtocol):
     """Workflow-layer adapter that hides the full `ModelInstance` API from `graphon` nodes."""
 
@@ -254,13 +300,16 @@ class DifyPreparedLLM(LLMProtocol):
         stop: Sequence[str] | None,
         stream: bool,
     ) -> LLMResult | Generator[LLMResultChunk, None, None]:
-        return self._model_instance.invoke_llm(
-            prompt_messages=list(prompt_messages),
-            model_parameters=dict(model_parameters),
-            tools=list(tools or []),
-            stop=list(stop or []),
-            stream=stream,
-            request_metadata=self._request_metadata,
+        return _with_first_token_timeout(
+            self._model_instance.first_token_timeout,
+            lambda: self._model_instance.invoke_llm(
+                prompt_messages=list(prompt_messages),
+                model_parameters=dict(model_parameters),
+                tools=list(tools or []),
+                stop=list(stop or []),
+                stream=stream,
+                request_metadata=self._request_metadata,
+            ),
         )
 
     @overload
@@ -295,16 +344,19 @@ class DifyPreparedLLM(LLMProtocol):
         stop: Sequence[str] | None,
         stream: bool,
     ) -> LLMResultWithStructuredOutput | Generator[LLMResultChunkWithStructuredOutput, None, None]:
-        return invoke_llm_with_structured_output(
-            provider=self.provider,
-            model_schema=self.get_model_schema(),
-            model_instance=self._model_instance,
-            prompt_messages=prompt_messages,
-            json_schema=json_schema,
-            model_parameters=model_parameters,
-            stop=list(stop or []),
-            stream=stream,
-            request_metadata=self._request_metadata,
+        return _with_first_token_timeout(
+            self._model_instance.first_token_timeout,
+            lambda: invoke_llm_with_structured_output(
+                provider=self.provider,
+                model_schema=self.get_model_schema(),
+                model_instance=self._model_instance,
+                prompt_messages=prompt_messages,
+                json_schema=json_schema,
+                model_parameters=model_parameters,
+                stop=list(stop or []),
+                stream=stream,
+                request_metadata=self._request_metadata,
+            ),
         )
 
     @override

--- a/api/core/workflow/node_runtime.py
+++ b/api/core/workflow/node_runtime.py
@@ -183,12 +183,9 @@ def _guarded_stream(
 ) -> Generator[Any, None, None]:
     """Iterate ``inner`` with the first-token-timeout ContextVar set.
 
-    Setting it inside the generator keeps it active for exactly the span of iteration,
-    which is when the plugin-daemon transport (`_stream_request`) reads it to arm the
-    first-token watchdog. Enforcement stays in the transport; this only carries the value.
-
-    This assumes the transport runs in the same thread as this iteration: a background-thread
-    SSE prefetch would not see the ContextVar and the gate would fail open (no enforcement).
+    Keeps the value active for exactly the span of iteration, which is when the
+    plugin-daemon transport reads it. Same-thread only: a background-thread SSE
+    prefetch would not see it and the gate fails open.
     """
     token = first_token_timeout_ctx.set(seconds)
     try:
@@ -200,15 +197,9 @@ def _guarded_stream(
 def _with_first_token_timeout[T](first_token_timeout: float | None, invoke: Callable[[], T]) -> T:
     """Run ``invoke`` with the first-token-timeout ContextVar applied.
 
-    ``first_token_timeout`` is in **seconds** and comes from
-    ``ModelInstance.first_token_timeout``, populated at the workflow model-config
-    boundary from ``completion_params`` (see ``core.app.llm.model_access``). This is
-    the single chokepoint both ``invoke_llm`` and ``invoke_llm_with_structured_output``
-    funnel through.
-
-    A streaming result is lazy, so its generator is wrapped to keep the ContextVar set
-    during iteration; a non-stream result is produced eagerly under the gate. A
-    non-positive timeout (None / 0 / negative) is treated as disabled.
+    ``first_token_timeout`` is seconds, from ``ModelInstance.first_token_timeout``.
+    A streaming result is lazy, so its generator is wrapped to keep the ContextVar
+    set during iteration; a non-positive timeout disables the gate.
     """
     if first_token_timeout is None or first_token_timeout <= 0:
         return invoke()

--- a/api/tests/unit_tests/core/app/app_config/easy_ui_based_app/test_model_config_converter.py
+++ b/api/tests/unit_tests/core/app/app_config/easy_ui_based_app/test_model_config_converter.py
@@ -100,6 +100,14 @@ class TestModelConfigConverter:
         assert result.parameters == {"temperature": 0.7}
         assert result.stop == ["\n"]
 
+    def test_convert_drops_first_token_timeout_ms(self, mock_app_config, patch_provider_manager):
+        """The workflow-only setting must never reach providers through app configs."""
+        mock_app_config.model.parameters = {"temperature": 0.7, "first_token_timeout_ms": 2000}
+
+        result = ModelConfigConverter.convert(mock_app_config)
+
+        assert result.parameters == {"temperature": 0.7}
+
     def test_convert_mode_from_schema_valid(self, mock_app_config, mock_provider_bundle, mocker: MockerFixture):
         mock_app_config.model.mode = None
 

--- a/api/tests/unit_tests/core/plugin/impl/test_first_token_timeout.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_first_token_timeout.py
@@ -162,8 +162,7 @@ def test_read_timeout_after_first_line_is_transport_error(mocker: MockerFixture)
     first_token_timeout_ctx.set(0.5)
 
     # First token already seen -> a later read timeout is an inter-token stall, not a
-    # first-token timeout. With the gate on, the message names the configured window so
-    # the stall is traceable to the user's setting.
+    # first-token timeout.
     with pytest.raises(PluginDaemonInnerError) as exc_info:
         list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
     assert "0.5s first-token timeout window" in exc_info.value.message
@@ -196,14 +195,10 @@ def test_non_timeout_request_error_is_transport_error(mocker: MockerFixture) -> 
 
 
 def test_first_token_timeout_error_survives_graphon_invoke_error_transform() -> None:
-    """Pin the graphon behavior the error_type contract depends on.
-
-    Workflow observability surfaces error_type == "FirstTokenTimeoutError" only because
-    graphon's ``AIModel._transform_invoke_error`` returns the original exception unchanged:
-    ``InvokeError`` subclasses ``ValueError`` and the default mapping carries a
-    ``ValueError -> [ValueError]`` passthrough entry. If a graphon bump changes either
-    fact, the error type silently degrades to a generic ``InvokeError`` and per-type
-    error handling / observability breaks — this test turns that into a loud failure.
+    """error_type == "FirstTokenTimeoutError" relies on graphon passing the exception
+    through ``_transform_invoke_error`` unchanged (``InvokeError`` subclasses
+    ``ValueError``, whose mapping entry returns the original error). A graphon bump
+    breaking either fact would silently degrade the type — fail loudly here instead.
     """
     from graphon.model_runtime.errors.invoke import InvokeError
     from graphon.model_runtime.model_providers.base.ai_model import AIModel

--- a/api/tests/unit_tests/core/plugin/impl/test_first_token_timeout.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_first_token_timeout.py
@@ -162,9 +162,24 @@ def test_read_timeout_after_first_line_is_transport_error(mocker: MockerFixture)
     first_token_timeout_ctx.set(0.5)
 
     # First token already seen -> a later read timeout is an inter-token stall, not a
-    # first-token timeout.
-    with pytest.raises(PluginDaemonInnerError):
+    # first-token timeout. With the gate on, the message names the configured window so
+    # the stall is traceable to the user's setting.
+    with pytest.raises(PluginDaemonInnerError) as exc_info:
         list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+    assert "0.5s first-token timeout window" in exc_info.value.message
+
+
+def test_read_timeout_after_first_line_with_gate_off_keeps_plain_message(mocker: MockerFixture) -> None:
+    client = BasePluginClient()
+    mocker.patch(
+        "httpx.Client.stream",
+        return_value=_LinesThenRaiseStream([b"data: hello"], httpx.ReadTimeout("inter-token")),
+    )
+    # ctx is None (autouse fixture) -> gate off -> no window hint in the message.
+
+    with pytest.raises(PluginDaemonInnerError) as exc_info:
+        list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+    assert "first-token timeout window" not in exc_info.value.message
 
 
 def test_non_timeout_request_error_is_transport_error(mocker: MockerFixture) -> None:
@@ -175,3 +190,31 @@ def test_non_timeout_request_error_is_transport_error(mocker: MockerFixture) -> 
     # Only a ReadTimeout maps to FirstTokenTimeoutError; other transport errors do not.
     with pytest.raises(PluginDaemonInnerError):
         list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+
+
+# --- graphon error-transform contract -----------------------------------------------------
+
+
+def test_first_token_timeout_error_survives_graphon_invoke_error_transform() -> None:
+    """Pin the graphon behavior the error_type contract depends on.
+
+    Workflow observability surfaces error_type == "FirstTokenTimeoutError" only because
+    graphon's ``AIModel._transform_invoke_error`` returns the original exception unchanged:
+    ``InvokeError`` subclasses ``ValueError`` and the default mapping carries a
+    ``ValueError -> [ValueError]`` passthrough entry. If a graphon bump changes either
+    fact, the error type silently degrades to a generic ``InvokeError`` and per-type
+    error handling / observability breaks — this test turns that into a loud failure.
+    """
+    from graphon.model_runtime.errors.invoke import InvokeError
+    from graphon.model_runtime.model_providers.base.ai_model import AIModel
+
+    class _ProbeModel:
+        _invoke_error_mapping = AIModel._invoke_error_mapping
+        provider_display_name = "probe"
+
+    assert issubclass(InvokeError, ValueError)
+
+    error = FirstTokenTimeoutError("The first token was not received within 1.5s.")
+    transformed = AIModel._transform_invoke_error(_ProbeModel(), error)  # type: ignore[arg-type]
+
+    assert transformed is error

--- a/api/tests/unit_tests/core/plugin/impl/test_first_token_timeout.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_first_token_timeout.py
@@ -1,0 +1,177 @@
+import httpx
+import pytest
+from pytest_mock import MockerFixture
+
+from core.plugin.entities.plugin_daemon import PluginDaemonInnerError
+from core.plugin.impl import base as base_mod
+from core.plugin.impl.first_token_timeout import FirstTokenTimeoutError, first_token_timeout_ctx
+
+BasePluginClient = base_mod.BasePluginClient
+
+
+@pytest.fixture(autouse=True)
+def _isolate_ctx():
+    """Keep the first-token-timeout ContextVar from leaking between tests."""
+    token = first_token_timeout_ctx.set(None)
+    try:
+        yield
+    finally:
+        first_token_timeout_ctx.reset(token)
+
+
+class _PlainStream:
+    """Fully buffered fake httpx stream context."""
+
+    def __init__(self, lines: list[object]) -> None:
+        self._lines = lines
+
+    def __enter__(self) -> "_PlainStream":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def iter_lines(self):
+        return iter(self._lines)
+
+
+class _RaiseOnEnterStream:
+    """Fake stream whose context entry raises — models a timeout while awaiting headers."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    def __enter__(self) -> "_RaiseOnEnterStream":
+        raise self._exc
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+
+class _LinesThenRaiseStream:
+    """Yields some lines, then raises — models a stall after the first token(s)."""
+
+    def __init__(self, lines: list[object], exc: BaseException) -> None:
+        self._lines = lines
+        self._exc = exc
+
+    def __enter__(self) -> "_LinesThenRaiseStream":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def iter_lines(self):
+        yield from self._lines
+        raise self._exc
+
+
+# --- _read_timeout_for ------------------------------------------------------------------
+
+
+def test_read_timeout_for_narrows_read_only() -> None:
+    base = base_mod.plugin_daemon_request_timeout
+    timeout = base_mod._read_timeout_for(5.0)
+
+    assert timeout is not base
+    assert timeout.read == 5.0
+    # The other components are preserved from the default timeout.
+    assert timeout.connect == base.connect
+    assert timeout.write == base.write
+    assert timeout.pool == base.pool
+
+
+@pytest.mark.parametrize("disabled", [None, 0.0, -1.0])
+def test_read_timeout_for_disabled_returns_base_unchanged(disabled: float | None) -> None:
+    assert base_mod._read_timeout_for(disabled) is base_mod.plugin_daemon_request_timeout
+
+
+def test_read_timeout_for_with_no_base_timeout(mocker: MockerFixture) -> None:
+    mocker.patch("core.plugin.impl.base.plugin_daemon_request_timeout", None)
+
+    timeout = base_mod._read_timeout_for(5.0)
+
+    assert timeout.read == 5.0
+    assert timeout.connect is None
+    assert timeout.write is None
+    assert timeout.pool is None
+
+
+# --- _stream_request timeout wiring ------------------------------------------------------
+
+
+def test_stream_request_narrows_read_when_gate_enabled(mocker: MockerFixture) -> None:
+    client = BasePluginClient()
+    stream = mocker.patch("httpx.Client.stream", return_value=_PlainStream([b"data: hi"]))
+    first_token_timeout_ctx.set(1.5)
+
+    result = list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+
+    assert result == ["hi"]
+    assert stream.call_args.kwargs["timeout"].read == 1.5
+
+
+@pytest.mark.parametrize("disabled", [None, 0.0])
+def test_stream_request_keeps_default_timeout_when_gate_disabled(mocker: MockerFixture, disabled: float | None) -> None:
+    client = BasePluginClient()
+    stream = mocker.patch("httpx.Client.stream", return_value=_PlainStream([b"data: hi"]))
+    first_token_timeout_ctx.set(disabled)
+
+    list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+
+    assert stream.call_args.kwargs["timeout"] is base_mod.plugin_daemon_request_timeout
+
+
+def test_stream_request_forwards_all_lines(mocker: MockerFixture) -> None:
+    client = BasePluginClient()
+    mocker.patch("httpx.Client.stream", return_value=_PlainStream([b"", b"data: hello", "world"]))
+    first_token_timeout_ctx.set(1.0)
+
+    result = list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+
+    assert result == ["hello", "world"]
+
+
+# --- _stream_request timeout semantics ---------------------------------------------------
+
+
+def test_read_timeout_before_first_line_raises_first_token_timeout(mocker: MockerFixture) -> None:
+    client = BasePluginClient()
+    mocker.patch("httpx.Client.stream", return_value=_RaiseOnEnterStream(httpx.ReadTimeout("headers")))
+    first_token_timeout_ctx.set(0.5)
+
+    with pytest.raises(FirstTokenTimeoutError):
+        list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+
+
+def test_read_timeout_with_gate_disabled_is_transport_error(mocker: MockerFixture) -> None:
+    client = BasePluginClient()
+    mocker.patch("httpx.Client.stream", return_value=_RaiseOnEnterStream(httpx.ReadTimeout("headers")))
+    # ctx is None (autouse fixture) -> gate off -> a read timeout is just a transport error.
+
+    with pytest.raises(PluginDaemonInnerError):
+        list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+
+
+def test_read_timeout_after_first_line_is_transport_error(mocker: MockerFixture) -> None:
+    client = BasePluginClient()
+    mocker.patch(
+        "httpx.Client.stream",
+        return_value=_LinesThenRaiseStream([b"data: hello"], httpx.ReadTimeout("inter-token")),
+    )
+    first_token_timeout_ctx.set(0.5)
+
+    # First token already seen -> a later read timeout is an inter-token stall, not a
+    # first-token timeout.
+    with pytest.raises(PluginDaemonInnerError):
+        list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+
+
+def test_non_timeout_request_error_is_transport_error(mocker: MockerFixture) -> None:
+    client = BasePluginClient()
+    mocker.patch("httpx.Client.stream", return_value=_RaiseOnEnterStream(httpx.ConnectError("boom")))
+    first_token_timeout_ctx.set(0.5)
+
+    # Only a ReadTimeout maps to FirstTokenTimeoutError; other transport errors do not.
+    with pytest.raises(PluginDaemonInnerError):
+        list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))

--- a/api/tests/unit_tests/core/plugin/impl/test_first_token_timeout.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_first_token_timeout.py
@@ -1,0 +1,222 @@
+from collections.abc import Generator, Iterator
+
+import httpx
+import pytest
+from pytest_mock import MockerFixture
+
+from core.plugin.entities.plugin_daemon import PluginDaemonInnerError
+from core.plugin.impl import base as base_mod
+from core.plugin.impl.base import use_plugin_daemon_request_timeout
+from core.plugin.impl.first_token_timeout import FirstTokenTimeoutError, first_token_timeout_ctx
+
+BasePluginClient = base_mod.BasePluginClient
+
+
+@pytest.fixture(autouse=True)
+def _isolate_ctx() -> Generator[None, None, None]:
+    """Keep the first-token-timeout ContextVar from leaking between tests."""
+    token = first_token_timeout_ctx.set(None)
+    try:
+        yield
+    finally:
+        first_token_timeout_ctx.reset(token)
+
+
+class _PlainStream:
+    """Fully buffered fake httpx stream context."""
+
+    def __init__(self, lines: list[object]) -> None:
+        self._lines = lines
+
+    def __enter__(self) -> "_PlainStream":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def iter_lines(self) -> Iterator[object]:
+        return iter(self._lines)
+
+
+class _RaiseOnEnterStream:
+    """Fake stream whose context entry raises — models a timeout while awaiting headers."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    def __enter__(self) -> "_RaiseOnEnterStream":
+        raise self._exc
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+
+class _LinesThenRaiseStream:
+    """Yields some lines, then raises — models a stall after the first token(s)."""
+
+    def __init__(self, lines: list[object], exc: BaseException) -> None:
+        self._lines = lines
+        self._exc = exc
+
+    def __enter__(self) -> "_LinesThenRaiseStream":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def iter_lines(self) -> Generator[object, None, None]:
+        yield from self._lines
+        raise self._exc
+
+
+# --- _resolve_stream_timeout ------------------------------------------------------------
+
+
+def _resolved(first_token_timeout: float | None) -> httpx.Timeout:
+    """Resolve where a concrete ``Timeout`` is guaranteed, narrowed off ``Timeout | None``."""
+    timeout = base_mod._resolve_stream_timeout(first_token_timeout)
+    assert timeout is not None
+    return timeout
+
+
+def test_resolve_stream_timeout_narrows_read_only() -> None:
+    base = base_mod.plugin_daemon_request_timeout
+    assert base is not None
+    timeout = _resolved(5.0)
+
+    assert timeout is not base
+    assert timeout.read == 5.0
+    # The other components are preserved from the default timeout.
+    assert timeout.connect == base.connect
+    assert timeout.write == base.write
+    assert timeout.pool == base.pool
+
+
+@pytest.mark.parametrize("disabled", [None, 0.0, -1.0])
+def test_resolve_stream_timeout_disabled_returns_base_unchanged(disabled: float | None) -> None:
+    assert base_mod._resolve_stream_timeout(disabled) is base_mod.plugin_daemon_request_timeout
+
+
+def test_resolve_stream_timeout_with_no_base_timeout(mocker: MockerFixture) -> None:
+    mocker.patch("core.plugin.impl.base.plugin_daemon_request_timeout", None)
+
+    timeout = _resolved(5.0)
+
+    assert timeout.read == 5.0
+    assert timeout.connect is None
+    assert timeout.write is None
+    assert timeout.pool is None
+
+
+def test_resolve_stream_timeout_narrows_to_an_active_override() -> None:
+    """An override is a ceiling its caller asked for, so a looser budget cannot widen it."""
+    with use_plugin_daemon_request_timeout(30.0):
+        assert _resolved(60.0).read == 30.0
+        assert _resolved(5.0).read == 5.0
+
+
+def test_resolve_stream_timeout_without_budget_returns_the_override() -> None:
+    with use_plugin_daemon_request_timeout(30.0):
+        assert _resolved(None).read == 30.0
+
+
+# --- _stream_request timeout wiring ------------------------------------------------------
+
+
+def test_stream_request_narrows_read_when_gate_enabled(mocker: MockerFixture) -> None:
+    client = BasePluginClient()
+    stream = mocker.patch("httpx.Client.stream", return_value=_PlainStream([b"data: hi"]))
+    first_token_timeout_ctx.set(1.5)
+
+    result = list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+
+    assert result == ["hi"]
+    assert stream.call_args.kwargs["timeout"].read == 1.5
+
+
+@pytest.mark.parametrize("disabled", [None, 0.0])
+def test_stream_request_keeps_default_timeout_when_gate_disabled(mocker: MockerFixture, disabled: float | None) -> None:
+    client = BasePluginClient()
+    stream = mocker.patch("httpx.Client.stream", return_value=_PlainStream([b"data: hi"]))
+    first_token_timeout_ctx.set(disabled)
+
+    list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+
+    assert stream.call_args.kwargs["timeout"] is base_mod.plugin_daemon_request_timeout
+
+
+def test_stream_request_forwards_all_lines(mocker: MockerFixture) -> None:
+    client = BasePluginClient()
+    mocker.patch("httpx.Client.stream", return_value=_PlainStream([b"", b"data: hello", "world"]))
+    first_token_timeout_ctx.set(1.0)
+
+    result = list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+
+    assert result == ["hello", "world"]
+
+
+# --- _stream_request timeout semantics ---------------------------------------------------
+
+
+def test_read_timeout_before_first_line_raises_first_token_timeout(mocker: MockerFixture) -> None:
+    client = BasePluginClient()
+    mocker.patch("httpx.Client.stream", return_value=_RaiseOnEnterStream(httpx.ReadTimeout("headers")))
+    first_token_timeout_ctx.set(0.5)
+
+    with pytest.raises(FirstTokenTimeoutError):
+        list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+
+
+def test_read_timeout_with_gate_disabled_is_transport_error(mocker: MockerFixture) -> None:
+    client = BasePluginClient()
+    mocker.patch("httpx.Client.stream", return_value=_RaiseOnEnterStream(httpx.ReadTimeout("headers")))
+    # ctx is None (autouse fixture) -> gate off -> a read timeout is just a transport error.
+
+    with pytest.raises(PluginDaemonInnerError):
+        list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+
+
+def test_read_timeout_after_first_line_is_transport_error(mocker: MockerFixture) -> None:
+    client = BasePluginClient()
+    mocker.patch(
+        "httpx.Client.stream",
+        return_value=_LinesThenRaiseStream([b"data: hello"], httpx.ReadTimeout("inter-token")),
+    )
+    first_token_timeout_ctx.set(0.5)
+
+    # First token already seen -> a later read timeout is an inter-token stall, not a
+    # first-token timeout.
+    with pytest.raises(PluginDaemonInnerError):
+        list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+
+
+def test_non_timeout_request_error_is_transport_error(mocker: MockerFixture) -> None:
+    client = BasePluginClient()
+    mocker.patch("httpx.Client.stream", return_value=_RaiseOnEnterStream(httpx.ConnectError("boom")))
+    first_token_timeout_ctx.set(0.5)
+
+    # Only a ReadTimeout maps to FirstTokenTimeoutError; other transport errors do not.
+    with pytest.raises(PluginDaemonInnerError):
+        list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+
+
+def test_stream_request_honors_the_context_scoped_override(mocker: MockerFixture) -> None:
+    """Every model invocation streams, so the override must reach `_stream_request` too."""
+    client = BasePluginClient()
+    stream = mocker.patch("httpx.Client.stream", return_value=_PlainStream([b"data: hi"]))
+
+    with use_plugin_daemon_request_timeout(30.0):
+        list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+
+    assert stream.call_args.kwargs["timeout"].read == 30.0
+
+
+def test_stream_request_takes_the_tighter_of_override_and_budget(mocker: MockerFixture) -> None:
+    client = BasePluginClient()
+    stream = mocker.patch("httpx.Client.stream", return_value=_PlainStream([b"data: hi"]))
+    first_token_timeout_ctx.set(60.0)
+
+    with use_plugin_daemon_request_timeout(30.0):
+        list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+
+    assert stream.call_args.kwargs["timeout"].read == 30.0

--- a/api/tests/unit_tests/core/plugin/impl/test_first_token_timeout.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_first_token_timeout.py
@@ -185,8 +185,7 @@ def test_read_timeout_after_first_line_is_transport_error(mocker: MockerFixture)
     first_token_timeout_ctx.set(0.5)
 
     # First token already seen -> a later read timeout is an inter-token stall, not a
-    # first-token timeout. With the gate on, the message names the configured window so
-    # the stall is traceable to the user's setting.
+    # first-token timeout.
     with pytest.raises(PluginDaemonInnerError) as exc_info:
         list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
     assert "0.5s first-token timeout window" in exc_info.value.message
@@ -241,14 +240,10 @@ def test_stream_request_takes_the_tighter_of_override_and_budget(mocker: MockerF
 
 
 def test_first_token_timeout_error_survives_graphon_invoke_error_transform() -> None:
-    """Pin the graphon behavior the error_type contract depends on.
-
-    Workflow observability surfaces error_type == "FirstTokenTimeoutError" only because
-    graphon's ``AIModel._transform_invoke_error`` returns the original exception unchanged:
-    ``InvokeError`` subclasses ``ValueError`` and the default mapping carries a
-    ``ValueError -> [ValueError]`` passthrough entry. If a graphon bump changes either
-    fact, the error type silently degrades to a generic ``InvokeError`` and per-type
-    error handling / observability breaks — this test turns that into a loud failure.
+    """error_type == "FirstTokenTimeoutError" relies on graphon passing the exception
+    through ``_transform_invoke_error`` unchanged (``InvokeError`` subclasses
+    ``ValueError``, whose mapping entry returns the original error). A graphon bump
+    breaking either fact would silently degrade the type — fail loudly here instead.
     """
     from graphon.model_runtime.errors.invoke import InvokeError
     from graphon.model_runtime.model_providers.base.ai_model import AIModel

--- a/api/tests/unit_tests/core/plugin/impl/test_first_token_timeout.py
+++ b/api/tests/unit_tests/core/plugin/impl/test_first_token_timeout.py
@@ -185,9 +185,24 @@ def test_read_timeout_after_first_line_is_transport_error(mocker: MockerFixture)
     first_token_timeout_ctx.set(0.5)
 
     # First token already seen -> a later read timeout is an inter-token stall, not a
-    # first-token timeout.
-    with pytest.raises(PluginDaemonInnerError):
+    # first-token timeout. With the gate on, the message names the configured window so
+    # the stall is traceable to the user's setting.
+    with pytest.raises(PluginDaemonInnerError) as exc_info:
         list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+    assert "0.5s first-token timeout window" in exc_info.value.message
+
+
+def test_read_timeout_after_first_line_with_gate_off_keeps_plain_message(mocker: MockerFixture) -> None:
+    client = BasePluginClient()
+    mocker.patch(
+        "httpx.Client.stream",
+        return_value=_LinesThenRaiseStream([b"data: hello"], httpx.ReadTimeout("inter-token")),
+    )
+    # ctx is None (autouse fixture) -> gate off -> no window hint in the message.
+
+    with pytest.raises(PluginDaemonInnerError) as exc_info:
+        list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
+    assert "first-token timeout window" not in exc_info.value.message
 
 
 def test_non_timeout_request_error_is_transport_error(mocker: MockerFixture) -> None:
@@ -220,3 +235,31 @@ def test_stream_request_takes_the_tighter_of_override_and_budget(mocker: MockerF
         list(client._stream_request("POST", "plugin/tenant/stream", data={"k": "v"}))
 
     assert stream.call_args.kwargs["timeout"].read == 30.0
+
+
+# --- graphon error-transform contract -----------------------------------------------------
+
+
+def test_first_token_timeout_error_survives_graphon_invoke_error_transform() -> None:
+    """Pin the graphon behavior the error_type contract depends on.
+
+    Workflow observability surfaces error_type == "FirstTokenTimeoutError" only because
+    graphon's ``AIModel._transform_invoke_error`` returns the original exception unchanged:
+    ``InvokeError`` subclasses ``ValueError`` and the default mapping carries a
+    ``ValueError -> [ValueError]`` passthrough entry. If a graphon bump changes either
+    fact, the error type silently degrades to a generic ``InvokeError`` and per-type
+    error handling / observability breaks — this test turns that into a loud failure.
+    """
+    from graphon.model_runtime.errors.invoke import InvokeError
+    from graphon.model_runtime.model_providers.base.ai_model import AIModel
+
+    class _ProbeModel:
+        _invoke_error_mapping = AIModel._invoke_error_mapping
+        provider_display_name = "probe"
+
+    assert issubclass(InvokeError, ValueError)
+
+    error = FirstTokenTimeoutError("The first token was not received within 1.5s.")
+    transformed = AIModel._transform_invoke_error(_ProbeModel(), error)  # type: ignore[arg-type]
+
+    assert transformed is error

--- a/api/tests/unit_tests/core/workflow/nodes/llm/test_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/llm/test_node.py
@@ -295,6 +295,7 @@ def test_fetch_model_config_hydrates_model_instance_runtime_settings(model_confi
         "temperature": 0.7,
         "max_tokens": 256,
         "stop": ["Observation:", "Human:"],
+        "first_token_timeout": 30,
     }
 
     model_instance = mock.MagicMock(
@@ -336,6 +337,7 @@ def test_fetch_model_config_hydrates_model_instance_runtime_settings(model_confi
         "max_tokens": 256,
     }
     assert hydrated_model_instance.stop == ("Observation:", "Human:")
+    assert hydrated_model_instance.first_token_timeout == 30.0
     assert model_config_with_credentials.parameters == {
         "temperature": 0.7,
         "max_tokens": 256,
@@ -345,10 +347,48 @@ def test_fetch_model_config_hydrates_model_instance_runtime_settings(model_confi
         "temperature": 0.7,
         "max_tokens": 256,
         "stop": ["Observation:", "Human:"],
+        "first_token_timeout": 30,
     }
     mock_credentials_provider.fetch.assert_called_once_with("openai", "gpt-3.5-turbo")
     mock_model_factory.init_model_instance.assert_called_once_with("openai", "gpt-3.5-turbo")
     provider_model.raise_for_status.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("raw_timeout", "expected"),
+    [
+        (30, 30.0),
+        (1.5, 1.5),
+        (0, None),
+        (-5, None),
+        (True, None),
+        ("30", None),
+        (None, None),
+    ],
+)
+def test_normalize_completion_params_extracts_first_token_timeout(raw_timeout: object, expected: float | None):
+    from core.app.llm.model_access import _normalize_completion_params
+
+    completion_params = {"temperature": 0.7, "first_token_timeout": raw_timeout}
+
+    parameters, stop, first_token_timeout = _normalize_completion_params(completion_params)
+
+    assert first_token_timeout == expected
+    assert "first_token_timeout" not in parameters
+    assert parameters == {"temperature": 0.7}
+    assert stop == []
+    # The caller's dict is left untouched.
+    assert completion_params == {"temperature": 0.7, "first_token_timeout": raw_timeout}
+
+
+def test_normalize_completion_params_without_first_token_timeout_key():
+    from core.app.llm.model_access import _normalize_completion_params
+
+    parameters, stop, first_token_timeout = _normalize_completion_params({"temperature": 0.7, "stop": ["Human:"]})
+
+    assert first_token_timeout is None
+    assert parameters == {"temperature": 0.7}
+    assert stop == ["Human:"]
 
 
 def test_fetch_model_config_reuses_validated_provider_model_from_dify_credentials_provider(

--- a/api/tests/unit_tests/core/workflow/nodes/llm/test_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/llm/test_node.py
@@ -295,7 +295,7 @@ def test_fetch_model_config_hydrates_model_instance_runtime_settings(model_confi
         "temperature": 0.7,
         "max_tokens": 256,
         "stop": ["Observation:", "Human:"],
-        "first_token_timeout": 30,
+        "first_token_timeout_ms": 30000,
     }
 
     model_instance = mock.MagicMock(
@@ -347,7 +347,7 @@ def test_fetch_model_config_hydrates_model_instance_runtime_settings(model_confi
         "temperature": 0.7,
         "max_tokens": 256,
         "stop": ["Observation:", "Human:"],
-        "first_token_timeout": 30,
+        "first_token_timeout_ms": 30000,
     }
     mock_credentials_provider.fetch.assert_called_once_with("openai", "gpt-3.5-turbo")
     mock_model_factory.init_model_instance.assert_called_once_with("openai", "gpt-3.5-turbo")
@@ -355,30 +355,31 @@ def test_fetch_model_config_hydrates_model_instance_runtime_settings(model_confi
 
 
 @pytest.mark.parametrize(
-    ("raw_timeout", "expected"),
+    ("raw_timeout_ms", "expected"),
     [
-        (30, 30.0),
-        (1.5, 1.5),
+        (30000, 30.0),
+        (1500, 1.5),
+        (100, 0.1),
         (0, None),
         (-5, None),
         (True, None),
-        ("30", None),
+        ("30000", None),
         (None, None),
     ],
 )
-def test_normalize_completion_params_extracts_first_token_timeout(raw_timeout: object, expected: float | None):
+def test_normalize_completion_params_extracts_first_token_timeout(raw_timeout_ms: object, expected: float | None):
     from core.app.llm.model_access import _normalize_completion_params
 
-    completion_params = {"temperature": 0.7, "first_token_timeout": raw_timeout}
+    completion_params = {"temperature": 0.7, "first_token_timeout_ms": raw_timeout_ms}
 
     parameters, stop, first_token_timeout = _normalize_completion_params(completion_params)
 
     assert first_token_timeout == expected
-    assert "first_token_timeout" not in parameters
+    assert "first_token_timeout_ms" not in parameters
     assert parameters == {"temperature": 0.7}
     assert stop == []
     # The caller's dict is left untouched.
-    assert completion_params == {"temperature": 0.7, "first_token_timeout": raw_timeout}
+    assert completion_params == {"temperature": 0.7, "first_token_timeout_ms": raw_timeout_ms}
 
 
 def test_normalize_completion_params_without_first_token_timeout_key():

--- a/api/tests/unit_tests/core/workflow/nodes/llm/test_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/llm/test_node.py
@@ -295,7 +295,7 @@ def test_fetch_model_config_hydrates_model_instance_runtime_settings(model_confi
         "temperature": 0.7,
         "max_tokens": 256,
         "stop": ["Observation:", "Human:"],
-        "first_token_timeout": 30,
+        "first_token_timeout_ms": 30000,
     }
 
     model_instance = mock.MagicMock(
@@ -347,7 +347,7 @@ def test_fetch_model_config_hydrates_model_instance_runtime_settings(model_confi
         "temperature": 0.7,
         "max_tokens": 256,
         "stop": ["Observation:", "Human:"],
-        "first_token_timeout": 30,
+        "first_token_timeout_ms": 30000,
     }
     mock_credentials_provider.fetch.assert_called_once_with("openai", "gpt-3.5-turbo")
     mock_model_factory.init_model_instance.assert_called_once_with("openai", "gpt-3.5-turbo")
@@ -382,30 +382,31 @@ def test_fetch_model_config_rejects_unconfigured_model(provider: str, model_name
 
 
 @pytest.mark.parametrize(
-    ("raw_timeout", "expected"),
+    ("raw_timeout_ms", "expected"),
     [
-        (30, 30.0),
-        (1.5, 1.5),
+        (30000, 30.0),
+        (1500, 1.5),
+        (100, 0.1),
         (0, None),
         (-5, None),
         (True, None),
-        ("30", None),
+        ("30000", None),
         (None, None),
     ],
 )
-def test_normalize_completion_params_extracts_first_token_timeout(raw_timeout: object, expected: float | None):
+def test_normalize_completion_params_extracts_first_token_timeout(raw_timeout_ms: object, expected: float | None):
     from core.app.llm.model_access import _normalize_completion_params
 
-    completion_params = {"temperature": 0.7, "first_token_timeout": raw_timeout}
+    completion_params = {"temperature": 0.7, "first_token_timeout_ms": raw_timeout_ms}
 
     parameters, stop, first_token_timeout = _normalize_completion_params(completion_params)
 
     assert first_token_timeout == expected
-    assert "first_token_timeout" not in parameters
+    assert "first_token_timeout_ms" not in parameters
     assert parameters == {"temperature": 0.7}
     assert stop == []
     # The caller's dict is left untouched.
-    assert completion_params == {"temperature": 0.7, "first_token_timeout": raw_timeout}
+    assert completion_params == {"temperature": 0.7, "first_token_timeout_ms": raw_timeout_ms}
 
 
 def test_normalize_completion_params_without_first_token_timeout_key():

--- a/api/tests/unit_tests/core/workflow/nodes/llm/test_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/llm/test_node.py
@@ -295,6 +295,7 @@ def test_fetch_model_config_hydrates_model_instance_runtime_settings(model_confi
         "temperature": 0.7,
         "max_tokens": 256,
         "stop": ["Observation:", "Human:"],
+        "first_token_timeout": 30,
     }
 
     model_instance = mock.MagicMock(
@@ -336,6 +337,7 @@ def test_fetch_model_config_hydrates_model_instance_runtime_settings(model_confi
         "max_tokens": 256,
     }
     assert hydrated_model_instance.stop == ("Observation:", "Human:")
+    assert hydrated_model_instance.first_token_timeout == 30.0
     assert model_config_with_credentials.parameters == {
         "temperature": 0.7,
         "max_tokens": 256,
@@ -345,6 +347,7 @@ def test_fetch_model_config_hydrates_model_instance_runtime_settings(model_confi
         "temperature": 0.7,
         "max_tokens": 256,
         "stop": ["Observation:", "Human:"],
+        "first_token_timeout": 30,
     }
     mock_credentials_provider.fetch.assert_called_once_with("openai", "gpt-3.5-turbo")
     mock_model_factory.init_model_instance.assert_called_once_with("openai", "gpt-3.5-turbo")
@@ -376,6 +379,43 @@ def test_fetch_model_config_rejects_unconfigured_model(provider: str, model_name
 
     credentials_provider.fetch.assert_not_called()
     model_factory.init_model_instance.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("raw_timeout", "expected"),
+    [
+        (30, 30.0),
+        (1.5, 1.5),
+        (0, None),
+        (-5, None),
+        (True, None),
+        ("30", None),
+        (None, None),
+    ],
+)
+def test_normalize_completion_params_extracts_first_token_timeout(raw_timeout: object, expected: float | None):
+    from core.app.llm.model_access import _normalize_completion_params
+
+    completion_params = {"temperature": 0.7, "first_token_timeout": raw_timeout}
+
+    parameters, stop, first_token_timeout = _normalize_completion_params(completion_params)
+
+    assert first_token_timeout == expected
+    assert "first_token_timeout" not in parameters
+    assert parameters == {"temperature": 0.7}
+    assert stop == []
+    # The caller's dict is left untouched.
+    assert completion_params == {"temperature": 0.7, "first_token_timeout": raw_timeout}
+
+
+def test_normalize_completion_params_without_first_token_timeout_key():
+    from core.app.llm.model_access import _normalize_completion_params
+
+    parameters, stop, first_token_timeout = _normalize_completion_params({"temperature": 0.7, "stop": ["Human:"]})
+
+    assert first_token_timeout is None
+    assert parameters == {"temperature": 0.7}
+    assert stop == ["Human:"]
 
 
 def test_fetch_model_config_reuses_validated_provider_model_from_dify_credentials_provider(

--- a/api/tests/unit_tests/core/workflow/test_node_runtime.py
+++ b/api/tests/unit_tests/core/workflow/test_node_runtime.py
@@ -8,6 +8,7 @@ from core.app.entities.app_invoke_entities import DIFY_RUN_CONTEXT_KEY, DifyRunC
 from core.app.file_access import FileAccessScope, bind_file_access_scope, grant_retriever_segment_access
 from core.llm_generator.output_parser.errors import OutputParserError
 from core.plugin.impl.exc import PluginLLMPollingUnsupportedError
+from core.plugin.impl.first_token_timeout import first_token_timeout_ctx
 from core.plugin.impl.model import PluginModelClient
 from core.plugin.impl.model_runtime import PluginModelRuntime
 from core.plugin.plugin_service import PluginService
@@ -82,6 +83,7 @@ class _ModelInstanceStub:
         self.model_name = "gpt-4o-mini"
         self.parameters = {"temperature": 0.2}
         self.stop = ("stop",)
+        self.first_token_timeout: float | None = None
         self.credentials = {"api_key": "secret"}
         self.model_type_instance = _ModelTypeInstanceStub(
             model_schema=model_schema,
@@ -199,6 +201,164 @@ def test_dify_prepared_llm_wraps_model_instance_calls() -> None:
         stream=False,
         request_metadata={"app_id": "app-id"},
     )
+
+
+def test_dify_prepared_llm_sets_first_token_timeout_ctx_during_streaming() -> None:
+    observed: list[float | None] = []
+
+    def _fake_invoke(**_kwargs: object):
+        def _gen():
+            observed.append(first_token_timeout_ctx.get())
+            yield "chunk-1"
+            observed.append(first_token_timeout_ctx.get())
+            yield "chunk-2"
+
+        return _gen()
+
+    model_instance = _ModelInstanceStub(model_schema=_build_model_schema())
+    model_instance.invoke_llm = _fake_invoke  # type: ignore[assignment]
+    model_instance.first_token_timeout = 1.5
+    prepared = DifyPreparedLLM(model_instance)
+
+    generator = prepared.invoke_llm(
+        prompt_messages=[],
+        model_parameters={},
+        tools=None,
+        stop=None,
+        stream=True,
+    )
+    # The ContextVar is set inside the generator (during iteration), not on this frame.
+    assert first_token_timeout_ctx.get() is None
+
+    result = list(generator)
+
+    assert result == ["chunk-1", "chunk-2"]
+    assert observed == [1.5, 1.5]
+    # Reset once the generator is exhausted.
+    assert first_token_timeout_ctx.get() is None
+
+
+def test_dify_prepared_llm_leaves_ctx_unset_when_no_first_token_timeout() -> None:
+    observed: list[float | None] = []
+
+    def _fake_invoke(**_kwargs: object):
+        def _gen():
+            observed.append(first_token_timeout_ctx.get())
+            yield "chunk"
+
+        return _gen()
+
+    model_instance = _ModelInstanceStub(model_schema=_build_model_schema())
+    model_instance.invoke_llm = _fake_invoke  # type: ignore[assignment]
+    prepared = DifyPreparedLLM(model_instance)
+
+    result = list(
+        prepared.invoke_llm(
+            prompt_messages=[],
+            model_parameters={},
+            tools=None,
+            stop=None,
+            stream=True,
+        )
+    )
+
+    assert result == ["chunk"]
+    assert observed == [None]
+
+
+def test_dify_prepared_llm_sets_first_token_timeout_ctx_for_non_stream_eager_path() -> None:
+    observed: list[float | None] = []
+
+    def _fake_invoke(**_kwargs: object):
+        # A non-stream call resolves eagerly; the ContextVar must be set during this call.
+        observed.append(first_token_timeout_ctx.get())
+        return sentinel.result
+
+    model_instance = _ModelInstanceStub(model_schema=_build_model_schema())
+    model_instance.invoke_llm = _fake_invoke  # type: ignore[assignment]
+    model_instance.first_token_timeout = 1.5
+    prepared = DifyPreparedLLM(model_instance)
+
+    result = prepared.invoke_llm(
+        prompt_messages=[],
+        model_parameters={},
+        tools=None,
+        stop=None,
+        stream=False,
+    )
+
+    # The non-generator result is returned unchanged, and the gate is reset once it returns.
+    assert result is sentinel.result
+    assert observed == [1.5]
+    assert first_token_timeout_ctx.get() is None
+
+
+def test_dify_prepared_llm_propagates_first_token_timeout_ctx_through_structured_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: list[float | None] = []
+
+    def _fake_structured(**_kwargs: object):
+        def _gen():
+            observed.append(first_token_timeout_ctx.get())
+            yield "chunk-1"
+            observed.append(first_token_timeout_ctx.get())
+            yield "chunk-2"
+
+        return _gen()
+
+    monkeypatch.setattr(node_runtime, "invoke_llm_with_structured_output", _fake_structured)
+    model_instance = _ModelInstanceStub(model_schema=_build_model_schema())
+    model_instance.first_token_timeout = 1.5
+    prepared = DifyPreparedLLM(model_instance)
+
+    generator = prepared.invoke_llm_with_structured_output(
+        prompt_messages=[],
+        json_schema={"type": "object"},
+        model_parameters={},
+        stop=None,
+        stream=True,
+    )
+    # Lazy: the ContextVar is set during iteration, not on this frame.
+    assert first_token_timeout_ctx.get() is None
+
+    result = list(generator)
+
+    assert result == ["chunk-1", "chunk-2"]
+    assert observed == [1.5, 1.5]
+    assert first_token_timeout_ctx.get() is None
+
+
+def test_dify_prepared_llm_resets_first_token_timeout_ctx_when_stream_raises() -> None:
+    observed: list[float | None] = []
+
+    def _fake_invoke(**_kwargs: object):
+        def _gen():
+            observed.append(first_token_timeout_ctx.get())
+            yield "chunk-1"
+            raise RuntimeError("boom")
+
+        return _gen()
+
+    model_instance = _ModelInstanceStub(model_schema=_build_model_schema())
+    model_instance.invoke_llm = _fake_invoke  # type: ignore[assignment]
+    model_instance.first_token_timeout = 1.5
+    prepared = DifyPreparedLLM(model_instance)
+
+    generator = prepared.invoke_llm(
+        prompt_messages=[],
+        model_parameters={},
+        tools=None,
+        stop=None,
+        stream=True,
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        list(generator)
+
+    # The try/finally in _guarded_stream resets the ContextVar even when iteration errors out.
+    assert observed == [1.5]
+    assert first_token_timeout_ctx.get() is None
 
 
 def test_dify_prepared_llm_requires_model_schema() -> None:

--- a/api/tests/unit_tests/core/workflow/test_node_runtime.py
+++ b/api/tests/unit_tests/core/workflow/test_node_runtime.py
@@ -13,6 +13,7 @@ from core.app.file_access import FileAccessScope, bind_file_access_scope, grant_
 from core.llm_generator.output_parser.errors import OutputParserError
 from core.model_manager import QuotaManagedModelInstance
 from core.plugin.impl.exc import PluginLLMPollingUnsupportedError
+from core.plugin.impl.first_token_timeout import first_token_timeout_ctx
 from core.plugin.impl.model import PluginModelClient
 from core.plugin.impl.model_runtime import PluginModelRuntime
 from core.plugin.plugin_service import PluginService
@@ -141,6 +142,7 @@ class _ModelInstanceStub:
         self.model_name = "gpt-4o-mini"
         self.parameters = {"temperature": 0.2}
         self.stop = ("stop",)
+        self.first_token_timeout: float | None = None
         self.credentials = {"api_key": "secret"}
         self.model_type_instance = _ModelTypeInstanceStub(
             model_schema=model_schema,
@@ -264,6 +266,164 @@ def test_dify_prepared_llm_wraps_model_instance_calls() -> None:
         stream=False,
         request_metadata={"app_id": "app-id"},
     )
+
+
+def test_dify_prepared_llm_sets_first_token_timeout_ctx_during_streaming() -> None:
+    observed: list[float | None] = []
+
+    def _fake_invoke(**_kwargs: object):
+        def _gen():
+            observed.append(first_token_timeout_ctx.get())
+            yield "chunk-1"
+            observed.append(first_token_timeout_ctx.get())
+            yield "chunk-2"
+
+        return _gen()
+
+    model_instance = _ModelInstanceStub(model_schema=_build_model_schema())
+    model_instance.invoke_llm = _fake_invoke  # type: ignore[assignment]
+    model_instance.first_token_timeout = 1.5
+    prepared = DifyPreparedLLM(model_instance)
+
+    generator = prepared.invoke_llm(
+        prompt_messages=[],
+        model_parameters={},
+        tools=None,
+        stop=None,
+        stream=True,
+    )
+    # The ContextVar is set inside the generator (during iteration), not on this frame.
+    assert first_token_timeout_ctx.get() is None
+
+    result = list(generator)
+
+    assert result == ["chunk-1", "chunk-2"]
+    assert observed == [1.5, 1.5]
+    # Reset once the generator is exhausted.
+    assert first_token_timeout_ctx.get() is None
+
+
+def test_dify_prepared_llm_leaves_ctx_unset_when_no_first_token_timeout() -> None:
+    observed: list[float | None] = []
+
+    def _fake_invoke(**_kwargs: object):
+        def _gen():
+            observed.append(first_token_timeout_ctx.get())
+            yield "chunk"
+
+        return _gen()
+
+    model_instance = _ModelInstanceStub(model_schema=_build_model_schema())
+    model_instance.invoke_llm = _fake_invoke  # type: ignore[assignment]
+    prepared = DifyPreparedLLM(model_instance)
+
+    result = list(
+        prepared.invoke_llm(
+            prompt_messages=[],
+            model_parameters={},
+            tools=None,
+            stop=None,
+            stream=True,
+        )
+    )
+
+    assert result == ["chunk"]
+    assert observed == [None]
+
+
+def test_dify_prepared_llm_sets_first_token_timeout_ctx_for_non_stream_eager_path() -> None:
+    observed: list[float | None] = []
+
+    def _fake_invoke(**_kwargs: object):
+        # A non-stream call resolves eagerly; the ContextVar must be set during this call.
+        observed.append(first_token_timeout_ctx.get())
+        return sentinel.result
+
+    model_instance = _ModelInstanceStub(model_schema=_build_model_schema())
+    model_instance.invoke_llm = _fake_invoke  # type: ignore[assignment]
+    model_instance.first_token_timeout = 1.5
+    prepared = DifyPreparedLLM(model_instance)
+
+    result = prepared.invoke_llm(
+        prompt_messages=[],
+        model_parameters={},
+        tools=None,
+        stop=None,
+        stream=False,
+    )
+
+    # The non-generator result is returned unchanged, and the gate is reset once it returns.
+    assert result is sentinel.result
+    assert observed == [1.5]
+    assert first_token_timeout_ctx.get() is None
+
+
+def test_dify_prepared_llm_propagates_first_token_timeout_ctx_through_structured_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: list[float | None] = []
+
+    def _fake_structured(**_kwargs: object):
+        def _gen():
+            observed.append(first_token_timeout_ctx.get())
+            yield "chunk-1"
+            observed.append(first_token_timeout_ctx.get())
+            yield "chunk-2"
+
+        return _gen()
+
+    monkeypatch.setattr(node_runtime, "invoke_llm_with_structured_output", _fake_structured)
+    model_instance = _ModelInstanceStub(model_schema=_build_model_schema())
+    model_instance.first_token_timeout = 1.5
+    prepared = DifyPreparedLLM(model_instance)
+
+    generator = prepared.invoke_llm_with_structured_output(
+        prompt_messages=[],
+        json_schema={"type": "object"},
+        model_parameters={},
+        stop=None,
+        stream=True,
+    )
+    # Lazy: the ContextVar is set during iteration, not on this frame.
+    assert first_token_timeout_ctx.get() is None
+
+    result = list(generator)
+
+    assert result == ["chunk-1", "chunk-2"]
+    assert observed == [1.5, 1.5]
+    assert first_token_timeout_ctx.get() is None
+
+
+def test_dify_prepared_llm_resets_first_token_timeout_ctx_when_stream_raises() -> None:
+    observed: list[float | None] = []
+
+    def _fake_invoke(**_kwargs: object):
+        def _gen():
+            observed.append(first_token_timeout_ctx.get())
+            yield "chunk-1"
+            raise RuntimeError("boom")
+
+        return _gen()
+
+    model_instance = _ModelInstanceStub(model_schema=_build_model_schema())
+    model_instance.invoke_llm = _fake_invoke  # type: ignore[assignment]
+    model_instance.first_token_timeout = 1.5
+    prepared = DifyPreparedLLM(model_instance)
+
+    generator = prepared.invoke_llm(
+        prompt_messages=[],
+        model_parameters={},
+        tools=None,
+        stop=None,
+        stream=True,
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        list(generator)
+
+    # The try/finally in _guarded_stream resets the ContextVar even when iteration errors out.
+    assert observed == [1.5]
+    assert first_token_timeout_ctx.get() is None
 
 
 def test_dify_prepared_llm_requires_model_schema() -> None:

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
@@ -393,7 +393,7 @@ describe('ModelParameterModal', () => {
 
     openSettings()
 
-    expect(screen.getByTestId('param-first_token_timeout')).toBeInTheDocument()
+    expect(screen.getByTestId('param-first_token_timeout_ms')).toBeInTheDocument()
   })
 
   it('should not append the first token timeout parameter outside workflow', () => {
@@ -402,7 +402,7 @@ describe('ModelParameterModal', () => {
     openSettings()
 
     expect(screen.getByTestId('param-stop')).toBeInTheDocument()
-    expect(screen.queryByTestId('param-first_token_timeout')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('param-first_token_timeout_ms')).not.toBeInTheDocument()
   })
 
   it('should render the empty loading fallback when rules resolve to an empty list', () => {

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
@@ -388,16 +388,26 @@ describe('ModelParameterModal', () => {
     expect(screen.getByText(/debugAsSingleModel/i)).toBeInTheDocument()
   })
 
-  it('should append the first token timeout parameter only in workflow advanced mode', () => {
-    render(<ModelParameterModal {...defaultProps} isAdvancedMode isInWorkflow />)
+  it('should append the first token timeout parameter when the panel supports it', () => {
+    render(
+      <ModelParameterModal
+        {...defaultProps}
+        isAdvancedMode
+        isInWorkflow
+        supportFirstTokenTimeout
+      />,
+    )
 
     openSettings()
 
     expect(screen.getByTestId('param-first_token_timeout_ms')).toBeInTheDocument()
   })
 
-  it('should not append the first token timeout parameter outside workflow', () => {
-    render(<ModelParameterModal {...defaultProps} isAdvancedMode />)
+  it('should not append the first token timeout parameter for workflow panels that do not support it', () => {
+    // Being in a workflow is not enough: panels whose model config is not consumed
+    // by fetch_model_config (knowledge retrieval, tool/trigger model params) must
+    // not render a dead setting.
+    render(<ModelParameterModal {...defaultProps} isAdvancedMode isInWorkflow />)
 
     openSettings()
 

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
@@ -404,9 +404,8 @@ describe('ModelParameterModal', () => {
   })
 
   it('should not append the first token timeout parameter for workflow panels that do not support it', () => {
-    // Being in a workflow is not enough: panels whose model config is not consumed
-    // by fetch_model_config (knowledge retrieval, tool/trigger model params) must
-    // not render a dead setting.
+    // Workflow context alone must not render it — that would be dead config on
+    // panels the backend does not consume.
     render(<ModelParameterModal {...defaultProps} isAdvancedMode isInWorkflow />)
 
     openSettings()

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
@@ -388,6 +388,23 @@ describe('ModelParameterModal', () => {
     expect(screen.getByText(/debugAsSingleModel/i)).toBeInTheDocument()
   })
 
+  it('should append the first token timeout parameter only in workflow advanced mode', () => {
+    render(<ModelParameterModal {...defaultProps} isAdvancedMode isInWorkflow />)
+
+    openSettings()
+
+    expect(screen.getByTestId('param-first_token_timeout')).toBeInTheDocument()
+  })
+
+  it('should not append the first token timeout parameter outside workflow', () => {
+    render(<ModelParameterModal {...defaultProps} isAdvancedMode />)
+
+    openSettings()
+
+    expect(screen.getByTestId('param-stop')).toBeInTheDocument()
+    expect(screen.queryByTestId('param-first_token_timeout')).not.toBeInTheDocument()
+  })
+
   it('should render the empty loading fallback when rules resolve to an empty list', () => {
     parameterRules = []
     isRulesLoading = true

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
@@ -415,6 +415,23 @@ describe('ModelParameterModal', () => {
     expect(screen.getByText(/debugAsSingleModel/i)).toBeInTheDocument()
   })
 
+  it('should append the first token timeout parameter only in workflow advanced mode', () => {
+    render(<ModelParameterModal {...defaultProps} isAdvancedMode isInWorkflow />)
+
+    openSettings()
+
+    expect(screen.getByTestId('param-first_token_timeout')).toBeInTheDocument()
+  })
+
+  it('should not append the first token timeout parameter outside workflow', () => {
+    render(<ModelParameterModal {...defaultProps} isAdvancedMode />)
+
+    openSettings()
+
+    expect(screen.getByTestId('param-stop')).toBeInTheDocument()
+    expect(screen.queryByTestId('param-first_token_timeout')).not.toBeInTheDocument()
+  })
+
   it('should render the empty loading fallback when rules resolve to an empty list', () => {
     parameterRules = []
     isRulesLoading = true

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
@@ -420,7 +420,7 @@ describe('ModelParameterModal', () => {
 
     openSettings()
 
-    expect(screen.getByTestId('param-first_token_timeout')).toBeInTheDocument()
+    expect(screen.getByTestId('param-first_token_timeout_ms')).toBeInTheDocument()
   })
 
   it('should not append the first token timeout parameter outside workflow', () => {
@@ -429,7 +429,7 @@ describe('ModelParameterModal', () => {
     openSettings()
 
     expect(screen.getByTestId('param-stop')).toBeInTheDocument()
-    expect(screen.queryByTestId('param-first_token_timeout')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('param-first_token_timeout_ms')).not.toBeInTheDocument()
   })
 
   it('should render the empty loading fallback when rules resolve to an empty list', () => {

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
@@ -415,16 +415,26 @@ describe('ModelParameterModal', () => {
     expect(screen.getByText(/debugAsSingleModel/i)).toBeInTheDocument()
   })
 
-  it('should append the first token timeout parameter only in workflow advanced mode', () => {
-    render(<ModelParameterModal {...defaultProps} isAdvancedMode isInWorkflow />)
+  it('should append the first token timeout parameter when the panel supports it', () => {
+    render(
+      <ModelParameterModal
+        {...defaultProps}
+        isAdvancedMode
+        isInWorkflow
+        supportFirstTokenTimeout
+      />,
+    )
 
     openSettings()
 
     expect(screen.getByTestId('param-first_token_timeout_ms')).toBeInTheDocument()
   })
 
-  it('should not append the first token timeout parameter outside workflow', () => {
-    render(<ModelParameterModal {...defaultProps} isAdvancedMode />)
+  it('should not append the first token timeout parameter for workflow panels that do not support it', () => {
+    // Being in a workflow is not enough: panels whose model config is not consumed
+    // by fetch_model_config (knowledge retrieval, tool/trigger model params) must
+    // not render a dead setting.
+    render(<ModelParameterModal {...defaultProps} isAdvancedMode isInWorkflow />)
 
     openSettings()
 

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/__tests__/index.spec.tsx
@@ -431,9 +431,8 @@ describe('ModelParameterModal', () => {
   })
 
   it('should not append the first token timeout parameter for workflow panels that do not support it', () => {
-    // Being in a workflow is not enough: panels whose model config is not consumed
-    // by fetch_model_config (knowledge retrieval, tool/trigger model params) must
-    // not render a dead setting.
+    // Workflow context alone must not render it — that would be dead config on
+    // panels the backend does not consume.
     render(<ModelParameterModal {...defaultProps} isAdvancedMode isInWorkflow />)
 
     openSettings()

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
@@ -40,6 +40,10 @@ export type ModelParameterModalProps = {
   renderTrigger?: (v: TriggerProps) => ReactNode
   readonly?: boolean
   isInWorkflow?: boolean
+  // Only LLM-compatible node panels (LLM / question classifier / parameter
+  // extractor) should pass this: the backend consumes the value solely on
+  // their model-config path, so rendering it elsewhere yields dead config.
+  supportFirstTokenTimeout?: boolean
   scope?: string
   nodesOutputVars?: NodeOutPutVar[]
   availableNodes?: Node[]
@@ -59,6 +63,7 @@ const ModelParameterModal: FC<ModelParameterModalProps> = ({
   renderTrigger,
   readonly,
   isInWorkflow,
+  supportFirstTokenTimeout,
   nodesOutputVars,
   availableNodes,
 }) => {
@@ -223,7 +228,9 @@ const ModelParameterModal: FC<ModelParameterModalProps> = ({
                 [
                   ...parameterRules,
                   ...(isAdvancedMode ? [STOP_PARAMETER_RULE] : []),
-                  ...(isAdvancedMode && isInWorkflow ? [FIRST_TOKEN_TIMEOUT_PARAMETER_RULE] : []),
+                  ...(isAdvancedMode && supportFirstTokenTimeout
+                    ? [FIRST_TOKEN_TIMEOUT_PARAMETER_RULE]
+                    : []),
                 ].map((parameter) => (
                   <ParameterItem
                     key={`${modelId}-${parameter.name}`}

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
@@ -40,9 +40,8 @@ export type ModelParameterModalProps = {
   renderTrigger?: (v: TriggerProps) => ReactNode
   readonly?: boolean
   isInWorkflow?: boolean
-  // Only LLM-compatible node panels (LLM / question classifier / parameter
-  // extractor) should pass this: the backend consumes the value solely on
-  // their model-config path, so rendering it elsewhere yields dead config.
+  // Pass only from panels whose model config the backend consumes
+  // (LLM / question classifier / parameter extractor); elsewhere it is dead config.
   supportFirstTokenTimeout?: boolean
   scope?: string
   nodesOutputVars?: NodeOutPutVar[]

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
@@ -9,7 +9,11 @@ import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ArrowNarrowLeft } from '@/app/components/base/icons/src/vender/line/arrows'
 import Loading from '@/app/components/base/loading'
-import { PROVIDER_WITH_PRESET_TONE, STOP_PARAMETER_RULE } from '@/config'
+import {
+  FIRST_TOKEN_TIMEOUT_PARAMETER_RULE,
+  PROVIDER_WITH_PRESET_TONE,
+  STOP_PARAMETER_RULE,
+} from '@/config'
 import { useModelParameterRules } from '@/service/use-common'
 import { useTextGenerationCurrentProviderAndModelAndModelList } from '../hooks'
 import ModelSelector from '../model-selector'
@@ -216,22 +220,24 @@ const ModelParameterModal: FC<ModelParameterModalProps> = ({
                   <Loading />
                 </div>
               ) : (
-                [...parameterRules, ...(isAdvancedMode ? [STOP_PARAMETER_RULE] : [])].map(
-                  (parameter) => (
-                    <ParameterItem
-                      key={`${modelId}-${parameter.name}`}
-                      parameterRule={parameter}
-                      value={completionParams?.[parameter.name]}
-                      onChange={(v) => handleParamChange(parameter.name, v)}
-                      onSwitch={(checked, assignValue) =>
-                        handleSwitch(parameter.name, checked, assignValue)
-                      }
-                      isInWorkflow={isInWorkflow}
-                      nodesOutputVars={nodesOutputVars}
-                      availableNodes={availableNodes}
-                    />
-                  ),
-                )
+                [
+                  ...parameterRules,
+                  ...(isAdvancedMode ? [STOP_PARAMETER_RULE] : []),
+                  ...(isAdvancedMode && isInWorkflow ? [FIRST_TOKEN_TIMEOUT_PARAMETER_RULE] : []),
+                ].map((parameter) => (
+                  <ParameterItem
+                    key={`${modelId}-${parameter.name}`}
+                    parameterRule={parameter}
+                    value={completionParams?.[parameter.name]}
+                    onChange={(v) => handleParamChange(parameter.name, v)}
+                    onSwitch={(checked, assignValue) =>
+                      handleSwitch(parameter.name, checked, assignValue)
+                    }
+                    isInWorkflow={isInWorkflow}
+                    nodesOutputVars={nodesOutputVars}
+                    availableNodes={availableNodes}
+                  />
+                ))
               )}
             </div>
           )}

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
@@ -15,7 +15,11 @@ import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ArrowNarrowLeft } from '@/app/components/base/icons/src/vender/line/arrows'
 import Loading from '@/app/components/base/loading'
-import { PROVIDER_WITH_PRESET_TONE, STOP_PARAMETER_RULE } from '@/config'
+import {
+  FIRST_TOKEN_TIMEOUT_PARAMETER_RULE,
+  PROVIDER_WITH_PRESET_TONE,
+  STOP_PARAMETER_RULE,
+} from '@/config'
 import { useModelParameterRules } from '@/service/use-common'
 import { ModelStatusEnum } from '../declarations'
 import { useTextGenerationCurrentProviderAndModelAndModelList } from '../hooks'
@@ -238,22 +242,24 @@ const ModelParameterModal: FC<ModelParameterModalProps> = ({
                   <Loading />
                 </div>
               ) : (
-                [...parameterRules, ...(isAdvancedMode ? [STOP_PARAMETER_RULE] : [])].map(
-                  (parameter) => (
-                    <ParameterItem
-                      key={`${modelId}-${parameter.name}`}
-                      parameterRule={parameter}
-                      value={completionParams?.[parameter.name]}
-                      onChange={(v) => handleParamChange(parameter.name, v)}
-                      onSwitch={(checked, assignValue) =>
-                        handleSwitch(parameter.name, checked, assignValue)
-                      }
-                      isInWorkflow={isInWorkflow}
-                      nodesOutputVars={nodesOutputVars}
-                      availableNodes={availableNodes}
-                    />
-                  ),
-                )
+                [
+                  ...parameterRules,
+                  ...(isAdvancedMode ? [STOP_PARAMETER_RULE] : []),
+                  ...(isAdvancedMode && isInWorkflow ? [FIRST_TOKEN_TIMEOUT_PARAMETER_RULE] : []),
+                ].map((parameter) => (
+                  <ParameterItem
+                    key={`${modelId}-${parameter.name}`}
+                    parameterRule={parameter}
+                    value={completionParams?.[parameter.name]}
+                    onChange={(v) => handleParamChange(parameter.name, v)}
+                    onSwitch={(checked, assignValue) =>
+                      handleSwitch(parameter.name, checked, assignValue)
+                    }
+                    isInWorkflow={isInWorkflow}
+                    nodesOutputVars={nodesOutputVars}
+                    availableNodes={availableNodes}
+                  />
+                ))
               )}
             </div>
           )}

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
@@ -52,6 +52,10 @@ export type ModelParameterModalProps = Pick<PopoverContentProps, 'placement'> & 
   readonly?: boolean
   modelSelectorReadonly?: boolean
   isInWorkflow?: boolean
+  // Only LLM-compatible node panels (LLM / question classifier / parameter
+  // extractor) should pass this: the backend consumes the value solely on
+  // their model-config path, so rendering it elsewhere yields dead config.
+  supportFirstTokenTimeout?: boolean
   scope?: string
   nodesOutputVars?: NodeOutPutVar[]
   availableNodes?: Node[]
@@ -79,6 +83,7 @@ const ModelParameterModal: FC<ModelParameterModalProps> = ({
   readonly,
   modelSelectorReadonly,
   isInWorkflow,
+  supportFirstTokenTimeout,
   nodesOutputVars,
   availableNodes,
   modelList,
@@ -245,7 +250,9 @@ const ModelParameterModal: FC<ModelParameterModalProps> = ({
                 [
                   ...parameterRules,
                   ...(isAdvancedMode ? [STOP_PARAMETER_RULE] : []),
-                  ...(isAdvancedMode && isInWorkflow ? [FIRST_TOKEN_TIMEOUT_PARAMETER_RULE] : []),
+                  ...(isAdvancedMode && supportFirstTokenTimeout
+                    ? [FIRST_TOKEN_TIMEOUT_PARAMETER_RULE]
+                    : []),
                 ].map((parameter) => (
                   <ParameterItem
                     key={`${modelId}-${parameter.name}`}

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/index.tsx
@@ -52,9 +52,8 @@ export type ModelParameterModalProps = Pick<PopoverContentProps, 'placement'> & 
   readonly?: boolean
   modelSelectorReadonly?: boolean
   isInWorkflow?: boolean
-  // Only LLM-compatible node panels (LLM / question classifier / parameter
-  // extractor) should pass this: the backend consumes the value solely on
-  // their model-config path, so rendering it elsewhere yields dead config.
+  // Pass only from panels whose model config the backend consumes
+  // (LLM / question classifier / parameter extractor); elsewhere it is dead config.
   supportFirstTokenTimeout?: boolean
   scope?: string
   nodesOutputVars?: NodeOutPutVar[]

--- a/web/app/components/workflow/nodes/llm/panel.tsx
+++ b/web/app/components/workflow/nodes/llm/panel.tsx
@@ -117,6 +117,7 @@ const Panel: FC<NodePanelProps<LLMNodeType>> = ({ id, data }) => {
             popupClassName="w-[387px]!"
             isInWorkflow
             isAdvancedMode={true}
+            supportFirstTokenTimeout
             provider={model?.provider}
             completionParams={model?.completion_params}
             modelId={model?.name}

--- a/web/app/components/workflow/nodes/llm/panel.tsx
+++ b/web/app/components/workflow/nodes/llm/panel.tsx
@@ -255,6 +255,7 @@ const Panel: FC<NodePanelProps<LLMNodeType>> = ({ id, data }) => {
               popupClassName="w-[387px]!"
               isInWorkflow
               isAdvancedMode={true}
+              supportFirstTokenTimeout
               provider={model?.provider}
               completionParams={model?.completion_params}
               modelId={model?.name}

--- a/web/app/components/workflow/nodes/parameter-extractor/panel.tsx
+++ b/web/app/components/workflow/nodes/parameter-extractor/panel.tsx
@@ -61,6 +61,7 @@ const Panel: FC<NodePanelProps<ParameterExtractorNodeType>> = ({ id, data }) => 
             popupClassName="w-[387px]!"
             isInWorkflow
             isAdvancedMode={true}
+            supportFirstTokenTimeout
             provider={model?.provider}
             completionParams={model?.completion_params}
             modelId={model?.name}

--- a/web/app/components/workflow/nodes/question-classifier/panel.tsx
+++ b/web/app/components/workflow/nodes/question-classifier/panel.tsx
@@ -50,6 +50,7 @@ const Panel: FC<NodePanelProps<QuestionClassifierNodeType>> = ({ id, data }) => 
             popupClassName="w-[387px]!"
             isInWorkflow
             isAdvancedMode={true}
+            supportFirstTokenTimeout
             provider={model?.provider}
             completionParams={model.completion_params}
             modelId={model.name}

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -328,6 +328,27 @@ export const STOP_PARAMETER_RULE: ModelParameterRule = {
   },
 }
 
+// Synthetic rule consumed by the Dify backend before the request reaches the
+// model provider; only enforced for workflow LLM-compatible nodes.
+export const FIRST_TOKEN_TIMEOUT_PARAMETER_RULE: ModelParameterRule = {
+  default: 60,
+  min: 1,
+  max: 1800,
+  precision: 0,
+  help: {
+    en_US:
+      'Max seconds to wait for the first streamed token. On timeout the node fails; combine with node retry to re-run it automatically.',
+    zh_Hans: '等待首个流式 Token 的最长秒数。超时后节点失败，可配合节点重试自动重跑。',
+  },
+  label: {
+    en_US: 'First token timeout',
+    zh_Hans: '首个 Token 超时',
+  },
+  name: 'first_token_timeout',
+  required: false,
+  type: 'int',
+}
+
 export const PARTNER_STACK_CONFIG = {
   cookieName: 'partner_stack_info',
   saveCookieDays: 90,

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -331,7 +331,7 @@ export const STOP_PARAMETER_RULE: ModelParameterRule = {
 // Synthetic rule consumed by the Dify backend before the request reaches the
 // model provider; only enforced for workflow LLM-compatible nodes.
 export const FIRST_TOKEN_TIMEOUT_PARAMETER_RULE: ModelParameterRule = {
-  default: 10000,
+  default: 2000,
   min: 100,
   max: 600000,
   precision: 0,

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -328,8 +328,7 @@ export const STOP_PARAMETER_RULE: ModelParameterRule = {
   },
 }
 
-// Synthetic rule consumed by the Dify backend before the request reaches the
-// model provider; only enforced for workflow LLM-compatible nodes.
+// Consumed by the Dify backend, never sent to model providers.
 export const FIRST_TOKEN_TIMEOUT_PARAMETER_RULE: ModelParameterRule = {
   default: 2000,
   min: 100,

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -337,8 +337,9 @@ export const FIRST_TOKEN_TIMEOUT_PARAMETER_RULE: ModelParameterRule = {
   precision: 0,
   help: {
     en_US:
-      'Max milliseconds to wait for the first streamed token. On timeout the node fails; combine with node retry to re-run it automatically.',
-    zh_Hans: '等待首个流式 Token 的最长毫秒数。超时后节点失败，可配合节点重试自动重跑。',
+      'Max milliseconds to wait for the first streamed token; the same window also bounds each gap between tokens. On timeout the node fails; combine with node retry to re-run it automatically.',
+    zh_Hans:
+      '等待首个流式 Token 的最长毫秒数；同一窗口也约束后续每次 Token 间隔。超时后节点失败，可配合节点重试自动重跑。',
   },
   label: {
     en_US: 'First token timeout (ms)',

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -331,20 +331,20 @@ export const STOP_PARAMETER_RULE: ModelParameterRule = {
 // Synthetic rule consumed by the Dify backend before the request reaches the
 // model provider; only enforced for workflow LLM-compatible nodes.
 export const FIRST_TOKEN_TIMEOUT_PARAMETER_RULE: ModelParameterRule = {
-  default: 60,
-  min: 1,
-  max: 1800,
+  default: 10000,
+  min: 100,
+  max: 600000,
   precision: 0,
   help: {
     en_US:
-      'Max seconds to wait for the first streamed token. On timeout the node fails; combine with node retry to re-run it automatically.',
-    zh_Hans: '等待首个流式 Token 的最长秒数。超时后节点失败，可配合节点重试自动重跑。',
+      'Max milliseconds to wait for the first streamed token. On timeout the node fails; combine with node retry to re-run it automatically.',
+    zh_Hans: '等待首个流式 Token 的最长毫秒数。超时后节点失败，可配合节点重试自动重跑。',
   },
   label: {
-    en_US: 'First token timeout',
-    zh_Hans: '首个 Token 超时',
+    en_US: 'First token timeout (ms)',
+    zh_Hans: '首个 Token 超时（毫秒）',
   },
-  name: 'first_token_timeout',
+  name: 'first_token_timeout_ms',
   required: false,
   type: 'int',
 }

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -350,7 +350,7 @@ export const STOP_PARAMETER_RULE: ModelParameterRule = {
 // Synthetic rule consumed by the Dify backend before the request reaches the
 // model provider; only enforced for workflow LLM-compatible nodes.
 export const FIRST_TOKEN_TIMEOUT_PARAMETER_RULE: ModelParameterRule = {
-  default: 10000,
+  default: 2000,
   min: 100,
   max: 600000,
   precision: 0,

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -350,20 +350,20 @@ export const STOP_PARAMETER_RULE: ModelParameterRule = {
 // Synthetic rule consumed by the Dify backend before the request reaches the
 // model provider; only enforced for workflow LLM-compatible nodes.
 export const FIRST_TOKEN_TIMEOUT_PARAMETER_RULE: ModelParameterRule = {
-  default: 60,
-  min: 1,
-  max: 1800,
+  default: 10000,
+  min: 100,
+  max: 600000,
   precision: 0,
   help: {
     en_US:
-      'Max seconds to wait for the first streamed token. On timeout the node fails; combine with node retry to re-run it automatically.',
-    zh_Hans: '等待首个流式 Token 的最长秒数。超时后节点失败，可配合节点重试自动重跑。',
+      'Max milliseconds to wait for the first streamed token. On timeout the node fails; combine with node retry to re-run it automatically.',
+    zh_Hans: '等待首个流式 Token 的最长毫秒数。超时后节点失败，可配合节点重试自动重跑。',
   },
   label: {
-    en_US: 'First token timeout',
-    zh_Hans: '首个 Token 超时',
+    en_US: 'First token timeout (ms)',
+    zh_Hans: '首个 Token 超时（毫秒）',
   },
-  name: 'first_token_timeout',
+  name: 'first_token_timeout_ms',
   required: false,
   type: 'int',
 }

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -356,8 +356,9 @@ export const FIRST_TOKEN_TIMEOUT_PARAMETER_RULE: ModelParameterRule = {
   precision: 0,
   help: {
     en_US:
-      'Max milliseconds to wait for the first streamed token. On timeout the node fails; combine with node retry to re-run it automatically.',
-    zh_Hans: '等待首个流式 Token 的最长毫秒数。超时后节点失败，可配合节点重试自动重跑。',
+      'Max milliseconds to wait for the first streamed token; the same window also bounds each gap between tokens. On timeout the node fails; combine with node retry to re-run it automatically.',
+    zh_Hans:
+      '等待首个流式 Token 的最长毫秒数；同一窗口也约束后续每次 Token 间隔。超时后节点失败，可配合节点重试自动重跑。',
   },
   label: {
     en_US: 'First token timeout (ms)',

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -347,8 +347,7 @@ export const STOP_PARAMETER_RULE: ModelParameterRule = {
   },
 }
 
-// Synthetic rule consumed by the Dify backend before the request reaches the
-// model provider; only enforced for workflow LLM-compatible nodes.
+// Consumed by the Dify backend, never sent to model providers.
 export const FIRST_TOKEN_TIMEOUT_PARAMETER_RULE: ModelParameterRule = {
   default: 2000,
   min: 100,

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -347,6 +347,27 @@ export const STOP_PARAMETER_RULE: ModelParameterRule = {
   },
 }
 
+// Synthetic rule consumed by the Dify backend before the request reaches the
+// model provider; only enforced for workflow LLM-compatible nodes.
+export const FIRST_TOKEN_TIMEOUT_PARAMETER_RULE: ModelParameterRule = {
+  default: 60,
+  min: 1,
+  max: 1800,
+  precision: 0,
+  help: {
+    en_US:
+      'Max seconds to wait for the first streamed token. On timeout the node fails; combine with node retry to re-run it automatically.',
+    zh_Hans: '等待首个流式 Token 的最长秒数。超时后节点失败，可配合节点重试自动重跑。',
+  },
+  label: {
+    en_US: 'First token timeout',
+    zh_Hans: '首个 Token 超时',
+  },
+  name: 'first_token_timeout',
+  required: false,
+  type: 'int',
+}
+
 export const PARTNER_STACK_CONFIG = {
   cookieName: 'partner_stack_info',
   saveCookieDays: 90,


### PR DESCRIPTION
## Summary

Adds an opt-in **first-token timeout** for workflow LLM-compatible nodes (LLM, question classifier, parameter extractor — in both workflow and chatflow). If the model does not stream its first token within the budget, the node fails with `FirstTokenTimeoutError` and is handled by the node's existing error strategy (retry / fail-branch / default). Off by default — no behavior change unless enabled. Works on the pinned `graphon==0.6.0`; no graphon changes required.

```mermaid
flowchart LR
  UI["web · model parameter panel<br/>first_token_timeout_ms<br/>(milliseconds, opt-in)"] --> CP["model.completion_params"]
  CP -->|"popped at the Dify boundary<br/>_normalize_completion_params"| MI["ModelInstance<br/>.first_token_timeout"]
  MI -->|"DifyPreparedLLM"| CV["api · ContextVar"]
  CV --> HX["httpx per-request<br/>read timeout"]
  HX -->|"first token too slow"| ERR["FirstTokenTimeoutError"]
  ERR --> STRAT["node error strategy<br/>retry / fail-branch / default"]
```

## How it works

- The config rides the same channel as `stop`: a synthetic frontend rule (`FIRST_TOKEN_TIMEOUT_PARAMETER_RULE` — int, milliseconds, default 2000, range 100–600000) writes `completion_params.first_token_timeout_ms`. It renders only in panels that pass `supportFirstTokenTimeout` (LLM / question classifier / parameter extractor), so surfaces whose model config is not consumed by this path never show a dead setting.
- Dify pops the key at the workflow model-config boundary (`_normalize_completion_params` in `core/app/llm/model_access.py`) into `ModelInstance.first_token_timeout` — the single ms→s conversion on the whole path. graphon and providers never see the key; invalid values (non-numeric, bool, non-positive) disable the gate.
- `DifyPreparedLLM` carries the value to the plugin-daemon transport through a `ContextVar`; enforcement is httpx's per-request `read` timeout in `BasePluginClient._stream_request`. The daemon withholds the SSE response headers until the model's first token, so the read timeout measures time-to-first-token directly.
- `FirstTokenTimeoutError` is Dify-local (`core/plugin/impl/first_token_timeout.py`, subclassing graphon's `InvokeError`); graphon's retry handler treats it like any node failure. A pin test asserts the type survives graphon's `_transform_invoke_error` unchanged, so `error_type` stays `FirstTokenTimeoutError` in run logs.

**Semantics** — the budget bounds **any single silent gap on the stream**; time-to-first-token is simply the first such gap (the daemon sends neither headers nor keep-alives before the first token, so the first gap ≡ TTFT). The `read` window resets on every received chunk, which means:

- it is a **stall detector, not a total-duration SLA** — a stream that keeps emitting within the window can run indefinitely;
- healthy inter-chunk gaps (tens of ms) sit an order of magnitude below any sane budget (≥ hundreds of ms), so normal streams never trip it mid-way;
- restricting the window to the first read only would require re-arming the connection's timeout mid-stream; keeping it for the whole stream is a deliberate simplicity trade-off, and also reaps streams that die mid-way instead of hanging until the daemon default.

| Situation | Surfaced as |
|---|---|
| No first token within the budget | `FirstTokenTimeoutError` → node error strategy |
| Inter-token gap exceeds the budget (after the first token) | transport error whose message names the configured window |
| Parameter not enabled / non-positive | gate disabled — no behavior change |

The budget deliberately **replaces** the operator-level `PLUGIN_DAEMON_TIMEOUT` read component for that request, so slow reasoning models can be granted more headroom than the daemon default.

**Coverage:** workflow / chatflow LLM, question classifier and parameter extractor nodes (all `LLMCompatibleNodeData`). Not rendered and not enforced elsewhere — agent nodes (models invoked by strategy plugins via backwards invocation), other workflow surfaces embedding the shared model panel (knowledge-retrieval, tool/trigger model params), and easy-UI apps (whose model-config converter also drops the key defensively).

## Screenshots

_The setting appears in the model parameter panel (next to Stop sequences) for the three supported node types. Screenshot to follow._

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
