### PR TITLE
fix: guard chat tree against out-of-order parents

### DIFF
--- a/web/app/components/base/chat/__tests__/utils.spec.ts
+++ b/web/app/components/base/chat/__tests__/utils.spec.ts
@@ -490,6 +490,23 @@ describe('chat utils - url params and answer helpers', () => {
       expect(a1!.children![1]!.children![0]!.siblingIndex).toBe(1)
     })
 
+    it('buildChatItemTree keeps out-of-order children under their parent when the parent appears later', () => {
+      const list: IChatItem[] = [
+        { id: 'q2', isAnswer: false, parentMessageId: 'a1' } as IChatItem,
+        { id: 'a2', isAnswer: true } as IChatItem,
+        { id: 'q1', isAnswer: false, parentMessageId: null } as IChatItem,
+        { id: 'a1', isAnswer: true } as IChatItem,
+      ]
+
+      const tree = buildChatItemTree(list)
+
+      expect(tree).toHaveLength(1)
+      expect(tree[0]!.id).toBe('q1')
+      expect(tree[0]!.children![0]!.id).toBe('a1')
+      expect(tree[0]!.children![0]!.children![0]!.id).toBe('q2')
+      expect(tree[0]!.children![0]!.children![0]!.children![0]!.id).toBe('a2')
+    })
+
     it('getThreadMessages node without children', () => {
       const tree = [{ id: 'q1', isAnswer: false }]
       const thread = getThreadMessages(tree as unknown as ChatItemInTree[], 'q1')

--- a/web/app/components/base/chat/utils.ts
+++ b/web/app/components/base/chat/utils.ts
@@ -114,6 +114,16 @@ function buildChatItemTree(allMessages: IChatItem[]): ChatItemInTree[] {
   const map: Record<string, ChatItemInTree> = {}
   const rootNodes: ChatItemInTree[] = []
   const childrenCount: Record<string, number> = {}
+  const messageIds = new Set(allMessages.map(item => item.id))
+  const pendingChildren: Record<string, ChatItemInTree[]> = {}
+  const appendPendingChildren = (parentId: string) => {
+    const children = pendingChildren[parentId]
+    if (!children)
+      return
+
+    map[parentId]?.children?.push(...children)
+    delete pendingChildren[parentId]
+  }
 
   let lastAppendedLegacyAnswer: ChatItemInTree | null = null
   for (let i = 0; i < allMessages.length; i += 2) {
@@ -144,6 +154,8 @@ function buildChatItemTree(allMessages: IChatItem[]): ChatItemInTree[] {
 
     // Connect question and answer
     questionNode.children!.push(answerNode)
+    appendPendingChildren(question.id)
+    appendPendingChildren(answer.id)
 
     // Append to parent or add to root
     if (isLegacy) {
@@ -157,9 +169,13 @@ function buildChatItemTree(allMessages: IChatItem[]): ChatItemInTree[] {
     else {
       if (
         !parentMessageId
-        || !allMessages.some(item => item.id === parentMessageId) // parent message might not be fetched yet, in this case we will append the question to the root nodes
+        || !messageIds.has(parentMessageId) // parent message might not be fetched yet, in this case we will append the question to the root nodes
       ) {
         rootNodes.push(questionNode)
+      }
+      else if (!map[parentMessageId]) {
+        pendingChildren[parentMessageId] = pendingChildren[parentMessageId] || []
+        pendingChildren[parentMessageId]!.push(questionNode)
       }
       else {
         map[parentMessageId]!.children!.push(questionNode)


### PR DESCRIPTION
## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
