### PR TITLE
fix(agent): expose message usage in history

### DIFF
--- a/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
+++ b/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
@@ -420,6 +420,7 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline[EasyUIAppGenerat
         message.total_price = usage.total_price
         message.currency = usage.currency
         self._task_state.llm_result.usage.latency = message.provider_response_latency
+        self._task_state.metadata.usage = self._task_state.llm_result.usage
         message.message_metadata = self._task_state.metadata.model_dump_json()
 
         if trace_manager:

--- a/api/fields/message_fields.py
+++ b/api/fields/message_fields.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime
+from decimal import Decimal
 from uuid import uuid4
 
-from pydantic import Field, field_validator
+from pydantic import Field, computed_field, field_validator
 
 from core.entities.execution_extra_content import ExecutionExtraContentDomainModel
 from fields.base import ResponseModel
@@ -55,9 +56,19 @@ class MessageListItem(ResponseModel):
     created_at: int | None = None
     agent_thoughts: list[AgentThought]
     message_files: list[MessageFile]
+    message_tokens: int = 0
+    answer_tokens: int = 0
+    provider_response_latency: float = 0
+    total_price: Decimal | None = None
+    currency: str | None = None
     status: str
     error: str | None = None
     extra_contents: list[ExecutionExtraContentDomainModel]
+
+    @computed_field
+    @property
+    def total_tokens(self) -> int:
+        return self.message_tokens + self.answer_tokens
 
     @field_validator("inputs", mode="before")
     @classmethod

--- a/api/tests/unit_tests/fields/test_message_fields.py
+++ b/api/tests/unit_tests/fields/test_message_fields.py
@@ -1,4 +1,6 @@
-from fields.message_fields import ExploreMessageListItem, MessageListItem
+from decimal import Decimal
+
+from fields.message_fields import ExploreMessageListItem, MessageListItem, WebMessageListItem
 
 
 def _base_kwargs():
@@ -34,3 +36,33 @@ class TestExploreMessageListItem:
         # Guard the public service-API contract: the base item must not leak metadata.
         payload = MessageListItem(**_base_kwargs()).model_dump(mode="json")
         assert "metadata" not in payload
+
+    def test_message_list_item_exposes_usage_fields(self):
+        payload = MessageListItem(
+            **_base_kwargs(),
+            message_tokens=7,
+            answer_tokens=11,
+            provider_response_latency=1.25,
+            total_price=Decimal("0.0001234"),
+            currency="USD",
+        ).model_dump(mode="json")
+
+        assert payload["message_tokens"] == 7
+        assert payload["answer_tokens"] == 11
+        assert payload["total_tokens"] == 18
+        assert payload["provider_response_latency"] == 1.25
+        assert payload["total_price"] == "0.0001234"
+        assert payload["currency"] == "USD"
+
+    def test_web_message_list_item_exposes_usage_and_metadata(self):
+        payload = WebMessageListItem(
+            **_base_kwargs(),
+            metadata={"usage": {"total_tokens": 18}},
+            message_tokens=7,
+            answer_tokens=11,
+        ).model_dump(mode="json")
+
+        assert payload["metadata"] == {"usage": {"total_tokens": 18}}
+        assert payload["message_tokens"] == 7
+        assert payload["answer_tokens"] == 11
+        assert payload["total_tokens"] == 18


### PR DESCRIPTION
## Summary

- expose persisted message usage fields in chat message history responses
- persist Agent App EasyUI `metadata.usage` before saving `message_metadata`
- add response model coverage for service/web history usage fields

## Root Cause

DIFY-2772 had two backend gaps:

1. `MessageListItem` / `WebMessageListItem` did not declare usage fields, so `TypeAdapter(WebMessageListItem)` dropped `message_tokens`, `answer_tokens`, latency, price, and currency even though `messages` table already had values.
2. EasyUI Agent App saved `message_metadata` before copying `llm_result.usage` into task metadata, so newly generated messages persisted token columns but left `message_metadata.usage` empty.

## Validation

Local:

- `uv run ruff check fields/message_fields.py core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py tests/unit_tests/fields/test_message_fields.py`
- `uv run python -m py_compile fields/message_fields.py core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py tests/unit_tests/fields/test_message_fields.py`
- direct serializer validation for `MessageListItem` and `WebMessageListItem`

Remote dev (`deploy/agent` applied first, then rebuilt `langgenius/dify-api:deploy-agent` and recreated `api`, `worker`, `worker_beat`, `priority_worker`, `worker-plugin_autoupgrade`):

- Existing history request for issue conversation returned `message_tokens`, `answer_tokens`, `total_tokens`, `provider_response_latency`, `total_price`, and `currency`.
- New Agent App SSE chat completed with `message_end` and returned usage fields in `/api/messages`.
- DB confirmed the new message persisted token columns and `message_metadata.usage`.
- Services stayed running after restart. Observed existing environment noise: OTEL metrics exporter 404 and one unrelated model quota 429 in logs.

Known local test limitation:

- `PYTHONFAULTHANDLER=1 uv run pytest tests/unit_tests/fields/test_message_fields.py -q` segfaults during pytest startup in `_pytest/capture.py` readline workaround before test collection. This matches the local API pytest startup issue seen on nearby agent fixes; targeted ruff/py_compile/serializer checks and remote E2E validation passed.
