### PR TITLE
chore: Bump version to 1.16.0-rc1

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dify-api"
-version = "1.15.0"
+version = "1.16.0-rc1"
 requires-python = "~=3.12.0"
 
 dependencies = [

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1280,7 +1280,7 @@ wheels = [
 
 [[package]]
 name = "dify-agent"
-version = "0.1.0"
+version = "1.16.0rc1"
 source = { editable = "../dify-agent" }
 dependencies = [
     { name = "anyio" },
@@ -1338,7 +1338,7 @@ docs = [
 
 [[package]]
 name = "dify-api"
-version = "1.15.0"
+version = "1.16.0rc1"
 source = { virtual = "." }
 dependencies = [
     { name = "aliyun-log-python-sdk" },

--- a/dify-agent/pyproject.toml
+++ b/dify-agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dify-agent"
-version = "0.1.0"
+version = "1.16.0-rc1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12,<4.0"

--- a/dify-agent/uv.lock
+++ b/dify-agent/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "dify-agent"
-version = "0.1.0"
+version = "1.16.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -220,7 +220,7 @@ services:
   # API service
   api:
     <<: *shared-api-worker-config
-    image: langgenius/dify-api:1.15.0
+    image: langgenius/dify-api:1.16.0-rc1
     environment:
       MODE: api
       SENTRY_DSN: ${API_SENTRY_DSN:-}
@@ -267,7 +267,7 @@ services:
   # WebSocket service for workflow collaboration.
   api_websocket:
     <<: *shared-api-worker-config
-    image: langgenius/dify-api:1.15.0
+    image: langgenius/dify-api:1.16.0-rc1
     profiles:
       - collaboration
     environment:
@@ -293,7 +293,7 @@ services:
   # The Celery worker for processing all queues (dataset, workflow, mail, etc.)
   worker:
     <<: *shared-worker-config
-    image: langgenius/dify-api:1.15.0
+    image: langgenius/dify-api:1.16.0-rc1
     environment:
       MODE: worker
       SENTRY_DSN: ${API_SENTRY_DSN:-}
@@ -339,7 +339,7 @@ services:
   # Celery beat for scheduling periodic tasks.
   worker_beat:
     <<: *shared-worker-beat-config
-    image: langgenius/dify-api:1.15.0
+    image: langgenius/dify-api:1.16.0-rc1
     environment:
       MODE: beat
     depends_on:
@@ -372,7 +372,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:1.15.0
+    image: langgenius/dify-web:1.16.0-rc1
     restart: always
     env_file:
       - path: ./envs/core-services/web.env
@@ -524,7 +524,7 @@ services:
 
   # Local sandbox for Dify Agent shell workspaces.
   local_sandbox:
-    image: langgenius/dify-agent-local-sandbox:1.15.0
+    image: langgenius/dify-agent-local-sandbox:1.16.0-rc1
     restart: always
     environment:
       SHELLCTL_AUTH_TOKEN: ${DIFY_AGENT_SHELLCTL_AUTH_TOKEN:-}
@@ -626,7 +626,7 @@ services:
 
   # Dify Agent backend service.
   agent_backend:
-    image: langgenius/dify-agent-backend:1.15.0
+    image: langgenius/dify-agent-backend:1.16.0-rc1
     restart: always
     env_file:
       - path: ./envs/core-services/dify-agent.env

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -226,7 +226,7 @@ services:
   # API service
   api:
     <<: *shared-api-worker-config
-    image: langgenius/dify-api:1.15.0
+    image: langgenius/dify-api:1.16.0-rc1
     environment:
       MODE: api
       SENTRY_DSN: ${API_SENTRY_DSN:-}
@@ -273,7 +273,7 @@ services:
   # WebSocket service for workflow collaboration.
   api_websocket:
     <<: *shared-api-worker-config
-    image: langgenius/dify-api:1.15.0
+    image: langgenius/dify-api:1.16.0-rc1
     profiles:
       - collaboration
     environment:
@@ -299,7 +299,7 @@ services:
   # The Celery worker for processing all queues (dataset, workflow, mail, etc.)
   worker:
     <<: *shared-worker-config
-    image: langgenius/dify-api:1.15.0
+    image: langgenius/dify-api:1.16.0-rc1
     environment:
       MODE: worker
       SENTRY_DSN: ${API_SENTRY_DSN:-}
@@ -345,7 +345,7 @@ services:
   # Celery beat for scheduling periodic tasks.
   worker_beat:
     <<: *shared-worker-beat-config
-    image: langgenius/dify-api:1.15.0
+    image: langgenius/dify-api:1.16.0-rc1
     environment:
       MODE: beat
     depends_on:
@@ -378,7 +378,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:1.15.0
+    image: langgenius/dify-web:1.16.0-rc1
     restart: always
     env_file:
       - path: ./envs/core-services/web.env
@@ -530,7 +530,7 @@ services:
 
   # Local sandbox for Dify Agent shell workspaces.
   local_sandbox:
-    image: langgenius/dify-agent-local-sandbox:1.15.0
+    image: langgenius/dify-agent-local-sandbox:1.16.0-rc1
     restart: always
     environment:
       SHELLCTL_AUTH_TOKEN: ${DIFY_AGENT_SHELLCTL_AUTH_TOKEN:-}
@@ -632,7 +632,7 @@ services:
 
   # Dify Agent backend service.
   agent_backend:
-    image: langgenius/dify-agent-backend:1.15.0
+    image: langgenius/dify-agent-backend:1.16.0-rc1
     restart: always
     env_file:
       - path: ./envs/core-services/dify-agent.env

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dify-web",
   "type": "module",
-  "version": "1.15.0",
+  "version": "1.16.0-rc1",
   "private": true,
   "imports": {
     "#i18n": {


### PR DESCRIPTION
**AI disclosure**: This PR was AI-assisted with Codex using GPT-5.4.
I have reviewed the final diff, and I am responsible for the content.

## Summary

- Bump the Dify API package version to `1.16.0-rc1`.
- Bump the Dify web package version to `1.16.0-rc1`.
- Bump the Dify Agent package version to `1.16.0-rc1`.
- Update Docker Compose API, web, and Dify Agent image tags to `1.16.0-rc1`.
- Sync the local `dify-api` and `dify-agent` package versions in uv lockfiles.

Fixes #38599

Validation:

- `uv lock --project dify-agent`
- `uv lock --project api`
- `uv lock --project dify-agent --check`
- `uv lock --project api --check`
- `node -e "JSON.parse(require('fs').readFileSync('web/package.json', 'utf8'))"`
- `docker compose -f docker/docker-compose.yaml config --quiet --no-env-resolution`
- `docker compose -f docker/docker-compose-template.yaml config --quiet --no-env-resolution`
- `docker compose -f docker/docker-compose.yaml config --images --no-env-resolution | rg 'langgenius/dify-(api|web|agent-local-sandbox|agent-backend):'`
- `docker compose -f docker/docker-compose-template.yaml config --images --no-env-resolution | rg 'langgenius/dify-(api|web|agent-local-sandbox|agent-backend):'`
- `git diff --check`

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Codex
