### PR TITLE
fix: fix miss session param

### DIFF
--- a/api/core/app/apps/agent_app/app_generator.py
+++ b/api/core/app/apps/agent_app/app_generator.py
@@ -332,7 +332,8 @@ class AgentAppGenerator(MessageBasedAppGenerator):
         worker_thread = threading.Thread(
             target=self._generate_worker,
             kwargs={
-                "flask_app": current_app._get_current_object(),  # type: ignore
+                "flask_app": current_app._get_current_object(), # type: ignore
+                "session": db.session(),
                 "context": context,
                 "application_generate_entity": application_generate_entity,
                 "queue_manager": queue_manager,

--- a/api/core/app/apps/agent_app/app_generator.py
+++ b/api/core/app/apps/agent_app/app_generator.py
@@ -332,7 +332,7 @@ class AgentAppGenerator(MessageBasedAppGenerator):
         worker_thread = threading.Thread(
             target=self._generate_worker,
             kwargs={
-                "flask_app": current_app._get_current_object(), # type: ignore
+                "flask_app": current_app._get_current_object(),  # type: ignore
                 "session": db.session(),
                 "context": context,
                 "application_generate_entity": application_generate_entity,

--- a/api/core/app/apps/agent_chat/app_generator.py
+++ b/api/core/app/apps/agent_chat/app_generator.py
@@ -205,6 +205,7 @@ class AgentChatAppGenerator(MessageBasedAppGenerator):
                 target=self._generate_worker,
                 kwargs={
                     "flask_app": current_app._get_current_object(),  # type: ignore
+                    "session": db.session(),
                     "context": context,
                     "application_generate_entity": application_generate_entity,
                     "queue_manager": queue_manager,

--- a/api/tests/unit_tests/core/app/apps/agent_chat/test_agent_chat_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/agent_chat/test_agent_chat_app_generator.py
@@ -116,10 +116,12 @@ class TestAgentChatAppGeneratorGenerate:
         )
 
         thread_obj = mocker.MagicMock()
-        mocker.patch(
+        thread_constructor = mocker.patch(
             "core.app.apps.agent_chat.app_generator.threading.Thread",
             return_value=thread_obj,
         )
+        session = mocker.MagicMock()
+        mocker.patch("core.app.apps.agent_chat.app_generator.db.session", return_value=session)
 
         mocker.patch(
             "core.app.apps.agent_chat.app_generator.AgentChatAppGenerateResponseConverter.convert",
@@ -144,6 +146,7 @@ class TestAgentChatAppGeneratorGenerate:
 
         assert result == {"result": "ok"}
         assert generate_entity.call_args.kwargs["extras"]["trace_session_id"] == "session-1"
+        assert thread_constructor.call_args.kwargs["kwargs"]["session"] is session
         thread_obj.start.assert_called_once()
 
     def test_generate_without_file_config(self, generator, mocker: MockerFixture):


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

:"account"}}
Exception in thread Thread-5 (_generate_worker):
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.12/threading.py", line 1012, in run
    self._target(*self._args, **self._kwargs)
TypeError: AgentChatAppGenerator._generate_worker() missing 1 required positional argument: 'session'

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
