### PR TITLE
fix(web): save agent configure draft on route leave

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/__tests__/use-agent-configure-sync.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/__tests__/use-agent-configure-sync.spec.tsx
@@ -315,6 +315,40 @@ describe('useAgentConfigureSync', () => {
     })
   })
 
+  it('should save the latest dirty draft when Configure unmounts before autosave runs', async () => {
+    const { store, unmount } = renderUseAgentConfigureSync()
+
+    act(() => {
+      store.set(agentComposerDraftAtom, {
+        ...defaultAgentSoulConfigFormState,
+        prompt: 'Route leave prompt',
+      })
+    })
+
+    expect(composerPutMutationFn).not.toHaveBeenCalled()
+
+    await act(async () => {
+      unmount()
+      await Promise.resolve()
+    })
+
+    expect(composerPutMutationFn).toHaveBeenCalledTimes(1)
+    expect(composerPutMutationFn).toHaveBeenCalledWith(expect.objectContaining({
+      params: {
+        agent_id: 'agent-1',
+      },
+      body: expect.objectContaining({
+        variant: 'agent_app',
+        save_strategy: 'save_to_current_version',
+        agent_soul: expect.objectContaining({
+          prompt: expect.objectContaining({
+            system_prompt: 'Route leave prompt',
+          }),
+        }),
+      }),
+    }))
+  })
+
   it('should include Agent Soul files when autosaving file changes', async () => {
     const { store } = renderUseAgentConfigureSync()
 

--- a/web/features/agent-v2/agent-detail/configure/use-agent-configure-sync.ts
+++ b/web/features/agent-v2/agent-detail/configure/use-agent-configure-sync.ts
@@ -209,12 +209,6 @@ export function useAgentConfigureSync({
   }, [debouncedSaveDraft, getAgentSoulDraft, store])
 
   useEffect(() => {
-    return () => {
-      debouncedSaveDraft.flush?.()
-    }
-  }, [debouncedSaveDraft])
-
-  useEffect(() => {
     const saveDraftWhenPageHidden = () => {
       if (document.visibilityState === 'hidden')
         saveDirtyDraftOnPageClose()
@@ -229,6 +223,12 @@ export function useAgentConfigureSync({
     return () => {
       document.removeEventListener('visibilitychange', saveDraftWhenPageHidden)
       window.removeEventListener('beforeunload', saveDraftBeforeUnload)
+    }
+  }, [saveDirtyDraftOnPageClose])
+
+  useEffect(() => {
+    return () => {
+      saveDirtyDraftOnPageClose()
     }
   }, [saveDirtyDraftOnPageClose])
 


### PR DESCRIPTION
## Summary
- Save the latest dirty Agent Configure draft when the Configure surface unmounts during client-side navigation.
- Reuse the existing page-close dirty-draft save path instead of only flushing the debounced autosave callback.
- Add coverage for leaving Configure before the debounce window fires.

## Root cause
The failing E2E scenario changed the Agent Configure prompt and immediately navigated away. The backend log showed no second `PUT /console/api/agent/:id/composer` after the UI edit, so the saved prompt remained the initial value. This was a product-side route-leave persistence gap, not a backend save issue and not a case where the E2E should wait longer.

## Product/test boundary
- The Configure persistence E2E is valid because it covers real user data loss on immediate SPA navigation.
- The external-runtime CI links failed before the external runtime step: the shared `e2e:full` preflight hit a stale docs URL assertion on an older commit. Current `main` already contains the docs URL update.
- A local true external-runtime chain passed after prepare/run, so external runtime itself was not the blocker reproduced by those CI links.

## Verification
- `pnpm -C web test features/agent-v2/agent-detail/configure/__tests__/use-agent-configure-sync.spec.tsx`
- `E2E_FORCE_WEB_BUILD=1 pnpm -C e2e e2e:full -- --name "Leaving Configure immediately after editing preserves prompt changes"`
- `pnpm -C e2e e2e:external:prepare`
- `pnpm -C e2e e2e:external`