### PR TITLE
fix: strip reasoning/thinking blocks from knowledge base summary output

### DIFF
--- a/api/core/rag/index_processor/processor/paragraph_index_processor.py
+++ b/api/core/rag/index_processor/processor/paragraph_index_processor.py
@@ -461,6 +461,9 @@ class ParagraphIndexProcessor(BaseIndexProcessor):
             raise ValueError("Expected LLMResult when stream=False")
 
         summary_content = result.message.get_text_content()
+        # Strip reasoning/thinking blocks emitted by reasoning models (e.g. deepseek-r1, qwen3)
+        # so only the final summary text is persisted.
+        summary_content = re.sub(r"<think>.*?</think>", "", summary_content, flags=re.IGNORECASE | re.DOTALL).strip()
         usage = result.usage
 
         # Deduct quota for summary generation (same as workflow nodes)

--- a/api/tests/unit_tests/core/rag/indexing/processor/test_paragraph_index_processor.py
+++ b/api/tests/unit_tests/core/rag/indexing/processor/test_paragraph_index_processor.py
@@ -420,6 +420,36 @@ class TestParagraphIndexProcessor:
         assert sum(1 for r in caplog.records if r.levelno == logging.WARNING) == 1
         assert any("Failed to deduct quota for summary generation" in record.message for record in caplog.records)
 
+    def test_generate_summary_strips_reasoning_block(self) -> None:
+        model_instance = Mock()
+        model_instance.credentials = {"k": "v"}
+        model_instance.model_type_instance.get_model_schema.return_value = SimpleNamespace(features=[])
+        model_instance.invoke_llm.return_value = self._llm_result(
+            "<think>\nLet me consider the key points.\n</think>\nFinal summary text."
+        )
+
+        with (
+            patch(
+                "core.rag.index_processor.processor.paragraph_index_processor.create_plugin_provider_manager"
+            ) as mock_provider_manager,
+            patch(
+                "core.rag.index_processor.processor.paragraph_index_processor.ModelInstance",
+                return_value=model_instance,
+            ),
+            patch(
+                "core.rag.index_processor.processor.paragraph_index_processor.deduct_llm_quota",
+            ),
+        ):
+            mock_provider_manager.return_value.get_provider_model_bundle.return_value = Mock()
+            summary, _ = ParagraphIndexProcessor.generate_summary(
+                "tenant-1",
+                "text content",
+                {"enable": True, "model_name": "model-a", "model_provider_name": "provider-a"},
+                document_language="English",
+            )
+
+        assert summary == "Final summary text."
+
     def test_generate_summary_handles_vision_and_image_conversion(self) -> None:
         model_instance = Mock()
         model_instance.credentials = {"k": "v"}


### PR DESCRIPTION
## Summary

When a reasoning-capable model (e.g. DeepSeek-R1, Qwen3) is used to generate a knowledge base document summary, the model's `<think>...</think>` reasoning block was included verbatim in the persisted summary, instead of only the final answer. Other parts of Dify (LLM/Agent nodes, question classifiers, suggested questions) already filter this out, but `ParagraphIndexProcessor.generate_summary()` did not.

## Changes

- `api/core/rag/index_processor/processor/paragraph_index_processor.py`: strip `<think>...</think>` blocks from `summary_content` right after it's extracted from the LLM result, before it's returned/persisted.
- `api/tests/unit_tests/core/rag/indexing/processor/test_paragraph_index_processor.py`: add a regression test verifying a summary containing a reasoning block is reduced to just the final text.

Fixes #38587