### PR TITLE
chore(api): Add true read-only sessions

### DIFF
--- a/api/controllers/common/session.py
+++ b/api/controllers/common/session.py
@@ -5,7 +5,7 @@ for a Resource handler and injects it as the first argument after `self`.
 Write handlers commit on success and roll back on failure. They use a regular
 Session context so existing services may commit an intermediate unit and keep
 using the same Session through SQLAlchemy's autobegin behavior. Pure read
-handlers may opt out with `write=False`.
+handlers opt into a guarded read-only session with `write=False`.
 """
 
 from collections.abc import Callable
@@ -55,7 +55,7 @@ def with_session[T, **P, R](
                         session.rollback()  # noqa: no-new-controller-sqlalchemy decorator owns transaction rollback
                         raise
 
-            with session_factory.create_session() as session:
+            with session_factory.create_readonly_session() as session:
                 return view(self, session, *args, **kwargs)
 
         return wrapper

--- a/api/controllers/console/agent/roster.py
+++ b/api/controllers/console/agent/roster.py
@@ -995,7 +995,7 @@ class AgentLogsApi(Resource):
     @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.AGENT_MANAGE, resource_required=False)
     @with_current_user
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def get(self, session: Session, tenant_id: str, current_user: Account, agent_id: UUID):
         app_model = _resolve_agent_runtime_app_model(session, tenant_id=tenant_id, agent_id=agent_id)
         query_data: dict[str, object] = dict(request.args.to_dict(flat=True))
@@ -1034,7 +1034,7 @@ class AgentLogMessagesApi(Resource):
     @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.AGENT_MANAGE, resource_required=False)
     @with_current_user
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def get(self, session: Session, tenant_id: str, current_user: Account, agent_id: UUID, conversation_id: UUID):
         app_model = _resolve_agent_runtime_app_model(session, tenant_id=tenant_id, agent_id=agent_id)
         query_data: dict[str, object] = dict(request.args.to_dict(flat=True))
@@ -1073,7 +1073,7 @@ class AgentLogSourcesApi(Resource):
     @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.AGENT_MANAGE, resource_required=False)
     @with_current_user
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def get(self, session: Session, tenant_id: str, current_user: Account, agent_id: UUID):
         app_model = _resolve_agent_runtime_app_model(session, tenant_id=tenant_id, agent_id=agent_id)
         payload = _agent_observability_service(session).list_log_sources(app=app_model, agent_id=str(agent_id))
@@ -1094,7 +1094,7 @@ class AgentStatisticsSummaryApi(Resource):
     @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.AGENT_MANAGE, resource_required=False)
     @with_current_user
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def get(self, session: Session, tenant_id: str, current_user: Account, agent_id: UUID):
         app_model = _resolve_agent_runtime_app_model(session, tenant_id=tenant_id, agent_id=agent_id)
         query = AgentStatisticsQuery.model_validate(request.args.to_dict(flat=True))

--- a/api/controllers/console/app/agent.py
+++ b/api/controllers/console/app/agent.py
@@ -339,7 +339,7 @@ class AgentLogApi(Resource):
     @login_required
     @account_initialization_required
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_VIEW_LAYOUT)
-    @with_session(write=False)
+    @with_session(write=True)
     @get_app_model(mode=[AppMode.AGENT_CHAT])
     def get(self, session: Session, app_model: App):
         """Get agent logs"""
@@ -517,7 +517,7 @@ class AgentSkillInferToolsByAgentApi(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def post(self, session: Session, tenant_id: str, agent_id: UUID, slug: str):
         app_model = resolve_agent_runtime_app_model(session=session, tenant_id=tenant_id, agent_id=agent_id)
         return _infer_skill_tools_for_app(session=session, app_model=app_model, slug=slug)
@@ -544,7 +544,7 @@ class AgentSkillInferToolsApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
-    @with_session(write=False)
+    @with_session(write=True)
     @get_app_model(mode=_WORKFLOW_AGENT_DRIVE_APP_MODES)
     def post(self, session: Session, app_model: App, slug: str):
         """Suggest CLI tools/env for a skill. Saving still goes through composer validation."""

--- a/api/controllers/console/app/agent_app_sandbox.py
+++ b/api/controllers/console/app/agent_app_sandbox.py
@@ -155,7 +155,7 @@ class AgentAppSandboxInfoResource(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def get(self, session: Session, tenant_id: str, agent_id: UUID):
         app_model = resolve_agent_runtime_app_model(session=session, tenant_id=tenant_id, agent_id=agent_id)
         query = query_params_from_request(AgentSandboxInfoQuery)
@@ -180,7 +180,7 @@ class AgentAppSandboxListResource(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def get(self, session: Session, tenant_id: str, agent_id: UUID):
         app_model = resolve_agent_runtime_app_model(session=session, tenant_id=tenant_id, agent_id=agent_id)
         query = query_params_from_request(AgentSandboxListQuery)
@@ -206,7 +206,7 @@ class AgentAppSandboxReadResource(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def get(self, session: Session, tenant_id: str, agent_id: UUID):
         app_model = resolve_agent_runtime_app_model(session=session, tenant_id=tenant_id, agent_id=agent_id)
         query = query_params_from_request(AgentSandboxFileQuery)
@@ -232,7 +232,7 @@ class AgentAppSandboxUploadResource(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def post(self, session: Session, tenant_id: str, agent_id: UUID):
         app_model = resolve_agent_runtime_app_model(session=session, tenant_id=tenant_id, agent_id=agent_id)
         payload = AgentSandboxUploadPayload.model_validate(request.get_json(silent=True) or {})

--- a/api/controllers/console/app/agent_drive_inspector.py
+++ b/api/controllers/console/app/agent_drive_inspector.py
@@ -182,7 +182,7 @@ class AgentDriveListByAgentApi(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def get(self, session: Session, tenant_id: str, agent_id: UUID):
         query = query_params_from_request(AgentDriveListByAgentQuery)
         resolve_agent_runtime_app_model(session=session, tenant_id=tenant_id, agent_id=agent_id)
@@ -205,7 +205,7 @@ class AgentDriveSkillListByAgentApi(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def get(self, session: Session, tenant_id: str, agent_id: UUID):
         resolve_agent_runtime_app_model(session=session, tenant_id=tenant_id, agent_id=agent_id)
         try:
@@ -225,7 +225,7 @@ class AgentDriveSkillInspectByAgentApi(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def get(self, session: Session, tenant_id: str, agent_id: UUID, skill_path: str):
         resolve_agent_runtime_app_model(session=session, tenant_id=tenant_id, agent_id=agent_id)
         try:
@@ -251,7 +251,7 @@ class AgentDrivePreviewByAgentApi(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def get(self, session: Session, tenant_id: str, agent_id: UUID):
         query = query_params_from_request(AgentDriveFileByAgentQuery)
         resolve_agent_runtime_app_model(session=session, tenant_id=tenant_id, agent_id=agent_id)
@@ -273,7 +273,7 @@ class AgentDriveDownloadByAgentApi(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def get(self, session: Session, tenant_id: str, agent_id: UUID):
         query = query_params_from_request(AgentDriveFileByAgentQuery)
         resolve_agent_runtime_app_model(session=session, tenant_id=tenant_id, agent_id=agent_id)

--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -590,7 +590,7 @@ class AppListApi(Resource):
     @login_required
     @account_initialization_required
     @enterprise_license_required
-    @with_session(write=False)
+    @with_session(write=True)
     @with_current_user_id
     @with_current_tenant_id
     def get(self, current_tenant_id: str, current_user_id: str, session: Session):
@@ -709,7 +709,7 @@ class StarredAppListApi(Resource):
     @login_required
     @account_initialization_required
     @enterprise_license_required
-    @with_session(write=False)
+    @with_session(write=True)
     @with_current_user_id
     @with_current_tenant_id
     def get(self, current_tenant_id: str, current_user_id: str, session: Session):
@@ -789,7 +789,7 @@ class AppApi(Resource):
     @with_current_user
     @with_current_tenant_id
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_VIEW_LAYOUT)
-    @with_session(write=False)
+    @with_session(write=True)
     @get_app_model(mode=None)
     def get(self, session: Session, current_tenant_id: str, current_user: Account, app_model: App):
         """Get app detail"""

--- a/api/controllers/console/app/completion.py
+++ b/api/controllers/console/app/completion.py
@@ -333,7 +333,7 @@ class AgentChatMessageStopApi(Resource):
     @account_initialization_required
     @with_current_user_id
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def post(self, session: Session, current_tenant_id: str, current_user_id: str, agent_id: UUID, task_id: str):
         app_model = resolve_agent_runtime_app_model(
             session=session,

--- a/api/controllers/console/app/generator.py
+++ b/api/controllers/console/app/generator.py
@@ -331,7 +331,7 @@ class InstructionGenerateApi(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def post(self, session: Session, current_tenant_id: str):
         args = InstructionGeneratePayload.model_validate(console_ns.payload)
         providers: list[type[CodeNodeProvider]] = [Python3CodeProvider, JavascriptCodeProvider]

--- a/api/controllers/console/app/message.py
+++ b/api/controllers/console/app/message.py
@@ -267,7 +267,7 @@ class MessageSuggestedQuestionApi(Resource):
     @account_initialization_required
     @with_current_user
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_VIEW_LAYOUT)
-    @with_session(write=False)
+    @with_session(write=True)
     @get_app_model(mode=[AppMode.CHAT, AppMode.AGENT_CHAT, AppMode.ADVANCED_CHAT, AppMode.AGENT])
     def get(self, session: Session, current_user: Account, app_model: App, message_id: UUID):
         return _get_message_suggested_questions(
@@ -291,7 +291,7 @@ class AgentMessageSuggestedQuestionApi(Resource):
     @account_initialization_required
     @with_current_user
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def get(self, session: Session, current_tenant_id: str, current_user: Account, agent_id: UUID, message_id: UUID):
         app_model = resolve_agent_runtime_app_model(
             session=session,

--- a/api/controllers/console/app/message.py
+++ b/api/controllers/console/app/message.py
@@ -155,7 +155,7 @@ class ChatMessageListApi(Resource):
     @edit_permission_required
     @with_current_user
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_VIEW_LAYOUT)
-    @with_session(write=False)
+    @with_session(write=True)
     @get_app_model(mode=[AppMode.CHAT, AppMode.AGENT_CHAT, AppMode.ADVANCED_CHAT, AppMode.AGENT])
     def get(self, session: Session, current_user: Account, app_model: App):
         return _list_chat_messages(session=session, app_model=app_model, current_user=current_user)
@@ -176,7 +176,7 @@ class AgentChatMessageListApi(Resource):
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_VIEW_LAYOUT)
     @with_current_user
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def get(self, session: Session, current_tenant_id: str, current_user: Account, agent_id: UUID):
         app_model = resolve_agent_runtime_app_model(
             session=session,
@@ -358,7 +358,7 @@ class MessageApi(Resource):
     @login_required
     @account_initialization_required
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_VIEW_LAYOUT)
-    @with_session(write=False)
+    @with_session(write=True)
     @get_app_model
     def get(self, session: Session, app_model: App, message_id: UUID):
         return _get_message_detail(session=session, app_model=app_model, message_id=message_id)
@@ -375,7 +375,7 @@ class AgentMessageApi(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def get(self, session: Session, current_tenant_id: str, agent_id: UUID, message_id: UUID):
         app_model = resolve_agent_runtime_app_model(
             session=session,

--- a/api/controllers/console/auth/login.py
+++ b/api/controllers/console/auth/login.py
@@ -355,7 +355,7 @@ class EmailCodeLoginApi(Resource):
 class RefreshTokenApi(Resource):
     @console_ns.response(200, "Success", console_ns.models[SimpleResultResponse.__name__])
     @console_ns.response(401, "Unauthorized", console_ns.models[SimpleResultMessageResponse.__name__])
-    @with_session(write=False)
+    @with_session(write=True)
     def post(self, session: Session):
         # Get refresh token from cookie instead of request body
         refresh_token = extract_refresh_token(request)

--- a/api/controllers/console/datasets/data_source.py
+++ b/api/controllers/console/datasets/data_source.py
@@ -228,7 +228,7 @@ class DataSourceNotionListApi(Resource):
     @console_ns.response(200, "Success", console_ns.models[NotionIntegrateInfoListResponse.__name__])
     @with_current_user
     @with_current_tenant_id
-    @with_session(write=False)
+    @with_session(write=True)
     def get(self, session: Session, current_tenant_id: str, current_user: Account) -> tuple[dict[str, Any], int]:
         query = DataSourceNotionListQuery.model_validate(request.args.to_dict(flat=True))
         datasource_provider_service = DatasourceProviderService()

--- a/api/controllers/console/datasets/datasets.py
+++ b/api/controllers/console/datasets/datasets.py
@@ -982,7 +982,7 @@ class DatasetRelatedAppListApi(Resource):
     @account_initialization_required
     @with_current_user
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_READONLY)
-    @with_session(write=False)
+    @with_session(write=True)
     def get(self, session: Session, current_user: Account, dataset_id: UUID):
         dataset_id_str = str(dataset_id)
         dataset = DatasetService.get_dataset(dataset_id_str, session)

--- a/api/controllers/console/explore/trial.py
+++ b/api/controllers/console/explore/trial.py
@@ -865,7 +865,7 @@ class TrialAppParameterApi(Resource):
 
 class AppApi(Resource):
     @console_ns.response(200, "Success", console_ns.models[TrialAppDetailResponse.__name__])
-    @with_session(write=False)
+    @with_session(write=True)
     @get_app_model_with_trial(None)
     def get(self, session: Session, app_model):
         """Get app detail"""

--- a/api/core/db/session_factory.py
+++ b/api/core/db/session_factory.py
@@ -1,13 +1,181 @@
-from sqlalchemy import Engine
-from sqlalchemy.orm import Session, sessionmaker
+import re
+from collections.abc import Generator, Iterable, Sequence
+from contextlib import AbstractContextManager, contextmanager
+from typing import Any, Protocol, TypeVar, override
+
+from sqlalchemy import Engine, event
+from sqlalchemy.engine import Connection
+from sqlalchemy.orm import ORMExecuteState, Session, sessionmaker
+from sqlalchemy.sql.dml import Delete, Insert, Update
+from sqlalchemy.sql.elements import TextClause
+
+_T = TypeVar("_T")
+
+READONLY_SESSION_FLAG = "dify_readonly_session"
+READONLY_CONNECTION_FLAG = "dify_readonly_connection"
+
+_LEADING_WRITE_SQL_RE = re.compile(
+    r"^\s*(?:--[^\n]*(?:\n|$)|/\*.*?\*/\s*)*"
+    r"(?:insert|update|delete|merge|replace|create|alter|drop|truncate|grant|revoke|call)\b",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+class ReadonlySession(Protocol):
+    """Structural read-only SQLAlchemy session capability for gradual typing.
+
+    A normal ``Session`` satisfies this protocol, so existing write sessions can
+    be passed to read-only helpers. The protocol intentionally omits mutation
+    methods such as ``add()``, ``delete()``, ``flush()``, and ``commit()``.
+    """
+
+    info: dict[Any, Any]
+
+    def get(self, entity: type[_T], ident: object, **kwargs: Any) -> _T | None: ...
+
+    def scalar(self, statement: Any, **kwargs: Any) -> Any: ...
+
+    def scalars(self, statement: Any, **kwargs: Any) -> Any: ...
+
+    def execute(self, statement: Any, params: Any | None = None, **kwargs: Any) -> Any: ...
+
+
+class ReadonlySessionError(RuntimeError):
+    """Base error for writes attempted through a read-only session."""
+
+
+class ReadonlySessionWriteError(ReadonlySessionError):
+    """Raised when a read-only session is asked to mutate database state."""
+
+
+class ReadonlySessionCommitError(ReadonlySessionError):
+    """Raised when code attempts to commit a read-only session."""
+
+
+def _is_readonly_session(session: Session) -> bool:
+    return bool(session.info.get(READONLY_SESSION_FLAG))
+
+
+def _looks_like_write_sql(statement: str) -> bool:
+    return bool(_LEADING_WRITE_SQL_RE.match(statement))
+
+
+class GuardedSession(Session):
+    """SQLAlchemy session with opt-in read-only write guards.
+
+    Only sessions created by ``create_readonly_session()`` use this subclass and
+    set ``READONLY_SESSION_FLAG``. Normal write sessions use SQLAlchemy's
+    standard ``Session`` class.
+    """
+
+    @override
+    def add(self, instance: object, _warn: bool = True) -> None:
+        if _is_readonly_session(self):
+            raise ReadonlySessionWriteError("Cannot add ORM objects with a read-only session.")
+        super().add(instance, _warn=_warn)
+
+    @override
+    def add_all(self, instances: Iterable[object]) -> None:
+        if _is_readonly_session(self):
+            raise ReadonlySessionWriteError("Cannot add ORM objects with a read-only session.")
+        super().add_all(instances)
+
+    @override
+    def delete(self, instance: object) -> None:
+        if _is_readonly_session(self):
+            raise ReadonlySessionWriteError("Cannot delete ORM objects with a read-only session.")
+        super().delete(instance)
+
+    @override
+    def merge(self, instance: _T, *, load: bool = True, options: Sequence[Any] | None = None) -> _T:
+        if _is_readonly_session(self):
+            raise ReadonlySessionWriteError("Cannot merge ORM objects with a read-only session.")
+        return super().merge(instance, load=load, options=options)
+
+    @override
+    def flush(self, objects: Sequence[object] | None = None) -> None:
+        if _is_readonly_session(self):
+            raise ReadonlySessionWriteError("Cannot flush a read-only session.")
+        super().flush(objects=objects)
+
+    @override
+    def commit(self) -> None:
+        if _is_readonly_session(self):
+            raise ReadonlySessionCommitError("Cannot commit a read-only session.")
+        super().commit()
+
+
+@event.listens_for(GuardedSession, "before_flush")
+def _prevent_readonly_flush(session: GuardedSession, _flush_context: object, _instances: object) -> None:
+    if _is_readonly_session(session):
+        raise ReadonlySessionWriteError("Cannot flush a read-only session.")
+
+
+@event.listens_for(GuardedSession, "do_orm_execute")
+def _prevent_readonly_orm_execute(state: ORMExecuteState) -> None:
+    session = state.session
+    if not _is_readonly_session(session):
+        return
+
+    statement = state.statement
+    if state.is_insert or state.is_update or state.is_delete or isinstance(statement, (Insert, Update, Delete)):
+        raise ReadonlySessionWriteError("Cannot execute DML with a read-only session.")
+    if isinstance(statement, TextClause) and _looks_like_write_sql(statement.text):
+        raise ReadonlySessionWriteError("Cannot execute write SQL with a read-only session.")
+
+
+@event.listens_for(Engine, "before_cursor_execute")
+def _prevent_readonly_connection_write(
+    conn: Connection,
+    _cursor: object,
+    statement: str,
+    _parameters: object,
+    _context: object,
+    _executemany: bool,
+) -> None:
+    if conn.info.get(READONLY_CONNECTION_FLAG) and _looks_like_write_sql(statement):
+        raise ReadonlySessionWriteError("Cannot execute write SQL with a read-only session connection.")
+
+
+def _start_native_readonly_transaction(session: Session) -> Connection:
+    connection = session.connection()
+    connection.info[READONLY_CONNECTION_FLAG] = True
+    dialect_name = connection.dialect.name
+
+    if dialect_name == "sqlite":
+        connection.exec_driver_sql("PRAGMA query_only = ON")
+    elif dialect_name == "postgresql":
+        connection.exec_driver_sql("BEGIN READ ONLY")
+    elif dialect_name in {"mysql", "mariadb"}:
+        connection.exec_driver_sql("START TRANSACTION READ ONLY")
+
+    return connection
+
+
+def _reset_readonly_connection(connection: Connection | None) -> None:
+    if connection is None:
+        return
+    try:
+        if connection.dialect.name == "sqlite":
+            connection.exec_driver_sql("PRAGMA query_only = OFF")
+    finally:
+        connection.info.pop(READONLY_CONNECTION_FLAG, None)
+
+
+def _assert_readonly_session_clean(session: Session) -> None:
+    if session.new or session.dirty or session.deleted:
+        raise ReadonlySessionWriteError("Read-only session contains pending ORM mutations.")
+
 
 _session_maker: sessionmaker[Session] | None = None
+_readonly_session_maker: sessionmaker[GuardedSession] | None = None
 
 
 def configure_session_factory(engine: Engine, expire_on_commit: bool = False):
     """Configure the global session factory"""
-    global _session_maker
+    global _session_maker, _readonly_session_maker
     _session_maker = sessionmaker(bind=engine, expire_on_commit=expire_on_commit)
+    _readonly_session_maker = sessionmaker(bind=engine, expire_on_commit=expire_on_commit, class_=GuardedSession)
 
 
 def get_session_maker() -> sessionmaker[Session]:
@@ -16,8 +184,33 @@ def get_session_maker() -> sessionmaker[Session]:
     return _session_maker
 
 
+def _get_readonly_session_maker() -> sessionmaker[GuardedSession]:
+    if _readonly_session_maker is None:
+        raise RuntimeError("Session factory not configured. Call configure_session_factory() first.")
+    return _readonly_session_maker
+
+
 def create_session() -> Session:
     return get_session_maker()()
+
+
+@contextmanager
+def create_readonly_session() -> Generator[GuardedSession]:
+    """Create a session that is read-only for both runtime checks and DB-native guards."""
+    session = _get_readonly_session_maker()()
+    old_autoflush = session.autoflush
+    session.autoflush = False
+    session.info[READONLY_SESSION_FLAG] = True
+    connection: Connection | None = None
+    try:
+        connection = _start_native_readonly_transaction(session)
+        yield session
+        _assert_readonly_session_clean(session)
+    finally:
+        _reset_readonly_connection(connection)
+        session.rollback()
+        session.autoflush = old_autoflush
+        session.close()
 
 
 # Class wrapper for convenience
@@ -33,6 +226,10 @@ class SessionFactory:
     @staticmethod
     def create_session() -> Session:
         return create_session()
+
+    @staticmethod
+    def create_readonly_session() -> AbstractContextManager[GuardedSession]:
+        return create_readonly_session()
 
 
 session_factory = SessionFactory()

--- a/api/core/db/session_factory.py
+++ b/api/core/db/session_factory.py
@@ -142,12 +142,16 @@ def _start_native_readonly_transaction(session: Session) -> Connection:
     connection.info[READONLY_CONNECTION_FLAG] = True
     dialect_name = connection.dialect.name
 
-    if dialect_name == "sqlite":
-        connection.exec_driver_sql("PRAGMA query_only = ON")
-    elif dialect_name == "postgresql":
-        connection.exec_driver_sql("BEGIN READ ONLY")
-    elif dialect_name in {"mysql", "mariadb"}:
-        connection.exec_driver_sql("START TRANSACTION READ ONLY")
+    try:
+        if dialect_name == "sqlite":
+            connection.exec_driver_sql("PRAGMA query_only = ON")
+        elif dialect_name == "postgresql":
+            connection.exec_driver_sql("BEGIN READ ONLY")
+        elif dialect_name in {"mysql", "mariadb"}:
+            connection.exec_driver_sql("START TRANSACTION READ ONLY")
+    except Exception:
+        connection.info.pop(READONLY_CONNECTION_FLAG, None)
+        raise
 
     return connection
 
@@ -195,7 +199,7 @@ def create_session() -> Session:
 
 
 @contextmanager
-def create_readonly_session() -> Generator[GuardedSession]:
+def create_readonly_session() -> Generator[GuardedSession, None, None]:
     """Create a session that is read-only for both runtime checks and DB-native guards."""
     session = _get_readonly_session_maker()()
     old_autoflush = session.autoflush

--- a/api/core/db/session_factory.py
+++ b/api/core/db/session_factory.py
@@ -13,6 +13,7 @@ _T = TypeVar("_T")
 
 READONLY_SESSION_FLAG = "dify_readonly_session"
 READONLY_CONNECTION_FLAG = "dify_readonly_connection"
+_READONLY_ACTIVE_CONNECTION_KEY = "dify_readonly_active_connection"
 
 _LEADING_WRITE_SQL_RE = re.compile(
     r"^\s*(?:--[^\n]*(?:\n|$)|/\*.*?\*/\s*)*"
@@ -25,8 +26,9 @@ class ReadonlySession(Protocol):
     """Structural read-only SQLAlchemy session capability for gradual typing.
 
     A normal ``Session`` satisfies this protocol, so existing write sessions can
-    be passed to read-only helpers. The protocol intentionally omits mutation
-    methods such as ``add()``, ``delete()``, ``flush()``, and ``commit()``.
+    be passed to read-only helpers. Transaction rollback and session reset are
+    safe lifecycle operations; mutation methods such as ``add()``, ``delete()``,
+    ``flush()``, and ``commit()`` are intentionally omitted.
     """
 
     info: dict[Any, Any]
@@ -38,6 +40,10 @@ class ReadonlySession(Protocol):
     def scalars(self, statement: Any, **kwargs: Any) -> Any: ...
 
     def execute(self, statement: Any, params: Any | None = None, **kwargs: Any) -> Any: ...
+
+    def rollback(self) -> None: ...
+
+    def reset(self) -> None: ...
 
 
 class ReadonlySessionError(RuntimeError):
@@ -65,7 +71,8 @@ class GuardedSession(Session):
 
     Only sessions created by ``create_readonly_session()`` use this subclass and
     set ``READONLY_SESSION_FLAG``. Normal write sessions use SQLAlchemy's
-    standard ``Session`` class.
+    standard ``Session`` class. Rollback and reset replace the DB-native
+    read-only transaction so the reusable session remains guarded.
     """
 
     @override
@@ -103,6 +110,26 @@ class GuardedSession(Session):
         if _is_readonly_session(self):
             raise ReadonlySessionCommitError("Cannot commit a read-only session.")
         super().commit()
+
+    @override
+    def rollback(self) -> None:
+        if not _is_readonly_session(self):
+            super().rollback()
+            return
+
+        _reset_readonly_connection(self)
+        super().rollback()
+        _start_native_readonly_transaction(self)
+
+    @override
+    def reset(self) -> None:
+        if not _is_readonly_session(self):
+            super().reset()
+            return
+
+        _reset_readonly_connection(self)
+        super().reset()
+        _start_native_readonly_transaction(self)
 
 
 @event.listens_for(GuardedSession, "before_flush")
@@ -153,10 +180,12 @@ def _start_native_readonly_transaction(session: Session) -> Connection:
         connection.info.pop(READONLY_CONNECTION_FLAG, None)
         raise
 
+    session.info[_READONLY_ACTIVE_CONNECTION_KEY] = connection
     return connection
 
 
-def _reset_readonly_connection(connection: Connection | None) -> None:
+def _reset_readonly_connection(session: Session) -> None:
+    connection = session.info.pop(_READONLY_ACTIVE_CONNECTION_KEY, None)
     if connection is None:
         return
     try:
@@ -205,16 +234,17 @@ def create_readonly_session() -> Generator[GuardedSession, None, None]:
     old_autoflush = session.autoflush
     session.autoflush = False
     session.info[READONLY_SESSION_FLAG] = True
-    connection: Connection | None = None
     try:
-        connection = _start_native_readonly_transaction(session)
+        _start_native_readonly_transaction(session)
         yield session
         _assert_readonly_session_clean(session)
     finally:
-        _reset_readonly_connection(connection)
-        session.rollback()
-        session.autoflush = old_autoflush
-        session.close()
+        try:
+            _reset_readonly_connection(session)
+        finally:
+            Session.rollback(session)
+            session.autoflush = old_autoflush
+            session.close()
 
 
 # Class wrapper for convenience

--- a/api/core/db/session_factory.py
+++ b/api/core/db/session_factory.py
@@ -4,8 +4,9 @@ from contextlib import AbstractContextManager, contextmanager
 from typing import Any, Protocol, TypeVar, override
 
 from sqlalchemy import Engine, event
-from sqlalchemy.engine import Connection
+from sqlalchemy.engine import Connection, Result, ScalarResult
 from sqlalchemy.orm import ORMExecuteState, Session, sessionmaker
+from sqlalchemy.sql import Executable
 from sqlalchemy.sql.dml import Delete, Insert, Update
 from sqlalchemy.sql.elements import TextClause
 
@@ -31,15 +32,13 @@ class ReadonlySession(Protocol):
     ``flush()``, and ``commit()`` are intentionally omitted.
     """
 
-    info: dict[Any, Any]
+    def get(self, entity: type[_T], ident: Any) -> _T | None: ...
 
-    def get(self, entity: type[_T], ident: object, **kwargs: Any) -> _T | None: ...
+    def scalar(self, statement: Executable) -> Any: ...
 
-    def scalar(self, statement: Any, **kwargs: Any) -> Any: ...
+    def scalars(self, statement: Executable) -> ScalarResult[Any]: ...
 
-    def scalars(self, statement: Any, **kwargs: Any) -> Any: ...
-
-    def execute(self, statement: Any, params: Any | None = None, **kwargs: Any) -> Any: ...
+    def execute(self, statement: Executable) -> Result[Any]: ...
 
     def rollback(self) -> None: ...
 

--- a/api/tests/unit_tests/controllers/common/test_session.py
+++ b/api/tests/unit_tests/controllers/common/test_session.py
@@ -1,10 +1,30 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pytest
-from sqlalchemy import Engine, literal, select
-from sqlalchemy.orm import Session
+from sqlalchemy import Engine, Integer, String, create_engine, literal, select, text, update
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
 
 from controllers.common import session as session_module
+from core.db import session_factory as session_factory_module
+from core.db.session_factory import (
+    ReadonlySessionCommitError,
+    ReadonlySessionWriteError,
+    configure_session_factory,
+    get_session_maker,
+)
+
+
+class ControllerSessionBase(DeclarativeBase):
+    pass
+
+
+class ControllerSessionWidget(ControllerSessionBase):
+    __tablename__ = "controller_session_widgets"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
 
 
 class FakeSession:
@@ -44,6 +64,23 @@ class FakeSessionContext:
         self.exited = True
         self.exc_type = exc_type
         self.session.closed = True
+
+
+@pytest.fixture
+def sqlite_controller_session_factory() -> Iterator[None]:
+    old_session_maker = session_factory_module._session_maker
+    old_readonly_session_maker = session_factory_module._readonly_session_maker
+    engine = create_engine("sqlite:///:memory:")
+    ControllerSessionBase.metadata.create_all(engine)
+    configure_session_factory(engine)
+    try:
+        with get_session_maker().begin() as session:
+            session.add(ControllerSessionWidget(id=1, name="one"))
+        yield
+    finally:
+        session_factory_module._session_maker = old_session_maker
+        session_factory_module._readonly_session_maker = old_readonly_session_maker
+        engine.dispose()
 
 
 def test_with_session_write_commits_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -121,7 +158,7 @@ def test_with_session_write_allows_commit_then_more_database_work(
 def test_with_session_read_mode_does_not_commit(monkeypatch: pytest.MonkeyPatch) -> None:
     session = FakeSession()
     session_context = FakeSessionContext(session)
-    monkeypatch.setattr(session_module.session_factory, "create_session", lambda: session_context)
+    monkeypatch.setattr(session_module.session_factory, "create_readonly_session", lambda: session_context)
 
     class Handler:
         @session_module.with_session(write=False)
@@ -152,3 +189,78 @@ def test_with_session_preserves_wrapped_metadata(monkeypatch: pytest.MonkeyPatch
 
     assert Handler.get.__name__ == "get"
     assert Handler.get.__doc__ == "handler docs"
+
+
+def test_with_session_read_mode_allows_reads_and_blocks_representative_writes(
+    sqlite_controller_session_factory: None,
+) -> None:
+    del sqlite_controller_session_factory
+
+    class Handler:
+        @session_module.with_session(write=False)
+        def read_scalar(self, session: Session) -> str:
+            name = session.scalar(select(ControllerSessionWidget.name).where(ControllerSessionWidget.id == 1))
+            assert name is not None
+            return name
+
+        @session_module.with_session(write=False)
+        def read_text(self, session: Session) -> str:
+            return session.execute(text("SELECT name FROM controller_session_widgets WHERE id = 1")).scalar_one()
+
+        @session_module.with_session(write=False)
+        def read_get(self, session: Session) -> str:
+            widget = session.get(ControllerSessionWidget, 1)
+            assert widget is not None
+            return widget.name
+
+        @session_module.with_session(write=False)
+        def write_add(self, session: Session) -> None:
+            session.add(ControllerSessionWidget(id=2, name="two"))
+
+        @session_module.with_session(write=False)
+        def write_core_update(self, session: Session) -> None:
+            session.execute(
+                update(ControllerSessionWidget).where(ControllerSessionWidget.id == 1).values(name="updated")
+            )
+
+        @session_module.with_session(write=False)
+        def write_driver_insert(self, session: Session) -> None:
+            session.connection().exec_driver_sql(
+                "INSERT INTO controller_session_widgets (id, name) VALUES (3, 'three')"
+            )
+
+        @session_module.with_session(write=False)
+        def write_dirty_return(self, session: Session) -> str:
+            widget = session.get(ControllerSessionWidget, 1)
+            assert widget is not None
+            widget.name = "dirty"
+            return "return before read-only context exit"
+
+        @session_module.with_session(write=False)
+        def write_commit(self, session: Session) -> None:
+            session.commit()
+
+        @session_module.with_session(write=True)
+        def valid_write(self, session: Session) -> None:
+            session.add(ControllerSessionWidget(id=4, name="four"))
+
+    handler = Handler()
+    assert handler.read_scalar() == "one"
+    assert handler.read_text() == "one"
+    assert handler.read_get() == "one"
+
+    with pytest.raises(ReadonlySessionWriteError, match="add ORM objects"):
+        handler.write_add()
+    with pytest.raises(ReadonlySessionWriteError, match="DML"):
+        handler.write_core_update()
+    with pytest.raises(ReadonlySessionWriteError, match="write SQL"):
+        handler.write_driver_insert()
+    with pytest.raises(ReadonlySessionWriteError, match="pending ORM mutations"):
+        handler.write_dirty_return()
+    with pytest.raises(ReadonlySessionCommitError, match="commit"):
+        handler.write_commit()
+
+    handler.valid_write()
+    with get_session_maker()() as session:
+        names = session.scalars(select(ControllerSessionWidget.name).order_by(ControllerSessionWidget.id)).all()
+    assert names == ["one", "four"]

--- a/api/tests/unit_tests/controllers/console/app/test_wraps.py
+++ b/api/tests/unit_tests/controllers/console/app/test_wraps.py
@@ -163,7 +163,7 @@ def test_get_app_model_with_trial_prefers_injected_session(monkeypatch: pytest.M
         "session",
         SimpleNamespace(scalar=lambda *_args, **_kwargs: pytest.fail("db.session should not be used")),
     )
-    monkeypatch.setattr(session_module.session_factory, "create_session", lambda: nullcontext(session))
+    monkeypatch.setattr(session_module.session_factory, "create_readonly_session", lambda: nullcontext(session))
 
     class Handler:
         @with_session(write=False)

--- a/api/tests/unit_tests/controllers/console/explore/test_trial.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_trial.py
@@ -158,13 +158,19 @@ def test_trial_dataset_list_preserves_slim_dataset_fields(app: Flask):
 
 
 @pytest.mark.parametrize(
-    "api_type",
-    [module.TrialSitApi, module.TrialAppParameterApi, module.AppApi, module.AppWorkflowApi, module.DatasetListApi],
+    ("api_type", "write"),
+    [
+        (module.TrialSitApi, False),
+        (module.TrialAppParameterApi, False),
+        (module.AppApi, True),
+        (module.AppWorkflowApi, False),
+        (module.DatasetListApi, False),
+    ],
 )
-def test_trial_app_handlers_use_explicit_read_session(api_type: type) -> None:
+def test_trial_app_handlers_use_explicit_session(api_type: type, write: bool) -> None:
     source = getsource(api_type.get)
 
-    assert "@with_session(write=False)\n    @get_app_model_with_trial(None)" in source
+    assert f"@with_session(write={write})\n    @get_app_model_with_trial(None)" in source
     assert tuple(signature(api_type.get).parameters)[:3] == ("self", "session", "app_model")
 
 
@@ -176,9 +182,10 @@ def test_trial_app_detail_serializes_with_explicit_session(app: Flask, monkeypat
     build_view = MagicMock(return_value=response_view)
     validated = MagicMock()
     validated.model_dump.return_value = {"id": "app-1"}
+    model_validate = MagicMock(return_value=validated)
     monkeypatch.setattr(module, "AppService", lambda: SimpleNamespace(get_app=get_app))
     monkeypatch.setattr(module, "AppResponseView", build_view)
-    monkeypatch.setattr(module.TrialAppDetailResponse, "model_validate", MagicMock(return_value=validated))
+    monkeypatch.setattr(module.TrialAppDetailResponse, "model_validate", model_validate)
 
     with app.test_request_context("/"):
         result = unwrap(module.AppApi.get)(module.AppApi(), session, app_model)
@@ -186,7 +193,7 @@ def test_trial_app_detail_serializes_with_explicit_session(app: Flask, monkeypat
     assert result == {"id": "app-1"}
     get_app.assert_called_once_with(app_model, session=session)
     build_view.assert_called_once_with(app_model, session=session)
-    module.TrialAppDetailResponse.model_validate.assert_called_once_with(response_view, from_attributes=True)
+    model_validate.assert_called_once_with(response_view, from_attributes=True)
 
 
 class TestTrialAppFileUploadApi:

--- a/api/tests/unit_tests/controllers/openapi/test_workspaces_members.py
+++ b/api/tests/unit_tests/controllers/openapi/test_workspaces_members.py
@@ -97,7 +97,11 @@ def database_session(sqlite_engine: Engine):
     tables = [model.metadata.tables[model.__tablename__] for model in models]
     TypeBase.metadata.create_all(sqlite_engine, tables=tables)
     session_maker = sessionmaker(bind=sqlite_engine, expire_on_commit=False)
-    factory = SimpleNamespace(get_session_maker=lambda: session_maker, create_session=session_maker)
+    factory = SimpleNamespace(
+        get_session_maker=lambda: session_maker,
+        create_session=session_maker,
+        create_readonly_session=session_maker,
+    )
     with patch("controllers.common.session.session_factory", factory), session_maker() as session:
         yield session
 

--- a/api/tests/unit_tests/core/db/test_session_factory.py
+++ b/api/tests/unit_tests/core/db/test_session_factory.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import Integer, String, create_engine, select, text, update
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from core.db import session_factory as session_factory_module
+from core.db.session_factory import (
+    GuardedSession,
+    ReadonlySessionCommitError,
+    ReadonlySessionWriteError,
+    configure_session_factory,
+    create_readonly_session,
+    create_session,
+    get_session_maker,
+)
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Widget(Base):
+    __tablename__ = "widgets"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+
+
+@pytest.fixture
+def sqlite_session_factory() -> Iterator[None]:
+    old_session_maker = session_factory_module._session_maker
+    old_readonly_session_maker = session_factory_module._readonly_session_maker
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    configure_session_factory(engine)
+    try:
+        with get_session_maker().begin() as session:
+            session.add(Widget(id=1, name="one"))
+        yield
+    finally:
+        session_factory_module._session_maker = old_session_maker
+        session_factory_module._readonly_session_maker = old_readonly_session_maker
+        engine.dispose()
+
+
+def test_write_sessions_use_plain_sqlalchemy_session(sqlite_session_factory: None) -> None:
+    del sqlite_session_factory
+
+    with create_session() as session:
+        assert not isinstance(session, GuardedSession)
+
+    with create_readonly_session() as session:
+        assert isinstance(session, GuardedSession)
+
+
+def test_readonly_session_allows_reads(sqlite_session_factory: None) -> None:
+    del sqlite_session_factory
+
+    with create_readonly_session() as session:
+        assert session.scalar(select(Widget.name).where(Widget.id == 1)) == "one"
+        assert session.execute(text("SELECT name FROM widgets WHERE id = 1")).scalar_one() == "one"
+
+
+def test_readonly_session_blocks_orm_write_apis(sqlite_session_factory: None) -> None:
+    del sqlite_session_factory
+
+    with create_readonly_session() as session:
+        with pytest.raises(ReadonlySessionWriteError, match="add ORM objects"):
+            session.add(Widget(id=2, name="two"))
+        with pytest.raises(ReadonlySessionWriteError, match="flush"):
+            session.flush()
+        with pytest.raises(ReadonlySessionCommitError, match="commit"):
+            session.commit()
+
+
+def test_readonly_session_blocks_core_and_raw_writes(sqlite_session_factory: None) -> None:
+    del sqlite_session_factory
+
+    with create_readonly_session() as session:
+        with pytest.raises(ReadonlySessionWriteError, match="DML"):
+            session.execute(update(Widget).where(Widget.id == 1).values(name="updated"))
+        with pytest.raises(ReadonlySessionWriteError, match="write SQL"):
+            session.execute(text("INSERT INTO widgets (id, name) VALUES (2, 'two')"))
+        with pytest.raises(ReadonlySessionWriteError, match="write SQL"):
+            session.connection().exec_driver_sql("INSERT INTO widgets (id, name) VALUES (3, 'three')")
+
+
+def _dirty_widget_in_readonly_session() -> None:
+    with create_readonly_session() as session:
+        widget = session.get(Widget, 1)
+        assert widget is not None
+        widget.name = "dirty"
+
+
+def test_readonly_session_rejects_dirty_orm_objects_on_exit(sqlite_session_factory: None) -> None:
+    del sqlite_session_factory
+
+    with pytest.raises(ReadonlySessionWriteError, match="pending ORM mutations"):
+        _dirty_widget_in_readonly_session()
+
+    with get_session_maker().begin() as session:
+        assert session.scalar(select(Widget.name).where(Widget.id == 1)) == "one"
+
+
+def test_sqlite_query_only_is_reset_after_readonly_session(sqlite_session_factory: None) -> None:
+    del sqlite_session_factory
+
+    with create_readonly_session() as session:
+        assert session.scalar(select(Widget.name).where(Widget.id == 1)) == "one"
+
+    with get_session_maker().begin() as session:
+        session.add(Widget(id=2, name="two"))
+
+    with get_session_maker()() as session:
+        assert session.scalar(select(Widget.name).where(Widget.id == 2)) == "two"

--- a/api/tests/unit_tests/core/db/test_session_factory.py
+++ b/api/tests/unit_tests/core/db/test_session_factory.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from collections.abc import Iterator
 
 import pytest
-from sqlalchemy import Integer, String, create_engine, select, text, update
+from sqlalchemy import Engine, Integer, String, create_engine, event, select, text, update
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from core.db import session_factory as session_factory_module
 from core.db.session_factory import (
+    READONLY_CONNECTION_FLAG,
     GuardedSession,
     ReadonlySessionCommitError,
     ReadonlySessionWriteError,
@@ -30,7 +31,7 @@ class Widget(Base):
 
 
 @pytest.fixture
-def sqlite_session_factory() -> Iterator[None]:
+def sqlite_session_factory() -> Iterator[Engine]:
     old_session_maker = session_factory_module._session_maker
     old_readonly_session_maker = session_factory_module._readonly_session_maker
     engine = create_engine("sqlite:///:memory:")
@@ -39,14 +40,14 @@ def sqlite_session_factory() -> Iterator[None]:
     try:
         with get_session_maker().begin() as session:
             session.add(Widget(id=1, name="one"))
-        yield
+        yield engine
     finally:
         session_factory_module._session_maker = old_session_maker
         session_factory_module._readonly_session_maker = old_readonly_session_maker
         engine.dispose()
 
 
-def test_write_sessions_use_plain_sqlalchemy_session(sqlite_session_factory: None) -> None:
+def test_write_sessions_use_plain_sqlalchemy_session(sqlite_session_factory: Engine) -> None:
     del sqlite_session_factory
 
     with create_session() as session:
@@ -56,7 +57,7 @@ def test_write_sessions_use_plain_sqlalchemy_session(sqlite_session_factory: Non
         assert isinstance(session, GuardedSession)
 
 
-def test_readonly_session_allows_reads(sqlite_session_factory: None) -> None:
+def test_readonly_session_allows_reads(sqlite_session_factory: Engine) -> None:
     del sqlite_session_factory
 
     with create_readonly_session() as session:
@@ -64,7 +65,7 @@ def test_readonly_session_allows_reads(sqlite_session_factory: None) -> None:
         assert session.execute(text("SELECT name FROM widgets WHERE id = 1")).scalar_one() == "one"
 
 
-def test_readonly_session_blocks_orm_write_apis(sqlite_session_factory: None) -> None:
+def test_readonly_session_blocks_orm_write_apis(sqlite_session_factory: Engine) -> None:
     del sqlite_session_factory
 
     with create_readonly_session() as session:
@@ -76,7 +77,7 @@ def test_readonly_session_blocks_orm_write_apis(sqlite_session_factory: None) ->
             session.commit()
 
 
-def test_readonly_session_blocks_core_and_raw_writes(sqlite_session_factory: None) -> None:
+def test_readonly_session_blocks_core_and_raw_writes(sqlite_session_factory: Engine) -> None:
     del sqlite_session_factory
 
     with create_readonly_session() as session:
@@ -95,7 +96,7 @@ def _dirty_widget_in_readonly_session() -> None:
         widget.name = "dirty"
 
 
-def test_readonly_session_rejects_dirty_orm_objects_on_exit(sqlite_session_factory: None) -> None:
+def test_readonly_session_rejects_dirty_orm_objects_on_exit(sqlite_session_factory: Engine) -> None:
     del sqlite_session_factory
 
     with pytest.raises(ReadonlySessionWriteError, match="pending ORM mutations"):
@@ -105,7 +106,7 @@ def test_readonly_session_rejects_dirty_orm_objects_on_exit(sqlite_session_facto
         assert session.scalar(select(Widget.name).where(Widget.id == 1)) == "one"
 
 
-def test_sqlite_query_only_is_reset_after_readonly_session(sqlite_session_factory: None) -> None:
+def test_sqlite_query_only_is_reset_after_readonly_session(sqlite_session_factory: Engine) -> None:
     del sqlite_session_factory
 
     with create_readonly_session() as session:
@@ -116,3 +117,29 @@ def test_sqlite_query_only_is_reset_after_readonly_session(sqlite_session_factor
 
     with get_session_maker()() as session:
         assert session.scalar(select(Widget.name).where(Widget.id == 2)) == "two"
+
+
+def test_readonly_setup_failure_does_not_poison_pooled_connection(sqlite_session_factory: Engine) -> None:
+    engine = sqlite_session_factory
+
+    def fail_readonly_setup(*_args: object) -> None:
+        statement = _args[2]
+        if statement == "PRAGMA query_only = ON":
+            raise RuntimeError("readonly setup failed")
+
+    event.listen(engine, "before_cursor_execute", fail_readonly_setup)
+    try:
+        with pytest.raises(RuntimeError, match="readonly setup failed"):
+            with create_readonly_session():
+                pass
+    finally:
+        event.remove(engine, "before_cursor_execute", fail_readonly_setup)
+
+    with engine.connect() as connection:
+        assert READONLY_CONNECTION_FLAG not in connection.info
+
+    with get_session_maker().begin() as session:
+        session.add(Widget(id=4, name="four"))
+
+    with get_session_maker()() as session:
+        assert session.scalar(select(Widget.name).where(Widget.id == 4)) == "four"

--- a/api/tests/unit_tests/core/db/test_session_factory.py
+++ b/api/tests/unit_tests/core/db/test_session_factory.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 
 import pytest
 from sqlalchemy import Engine, Integer, String, create_engine, event, select, text, update
@@ -10,6 +10,7 @@ from core.db import session_factory as session_factory_module
 from core.db.session_factory import (
     READONLY_CONNECTION_FLAG,
     GuardedSession,
+    ReadonlySession,
     ReadonlySessionCommitError,
     ReadonlySessionWriteError,
     configure_session_factory,
@@ -63,6 +64,29 @@ def test_readonly_session_allows_reads(sqlite_session_factory: Engine) -> None:
     with create_readonly_session() as session:
         assert session.scalar(select(Widget.name).where(Widget.id == 1)) == "one"
         assert session.execute(text("SELECT name FROM widgets WHERE id = 1")).scalar_one() == "one"
+
+
+def _rollback_session(session: ReadonlySession) -> None:
+    session.rollback()
+
+
+def _reset_session(session: ReadonlySession) -> None:
+    session.reset()
+
+
+@pytest.mark.parametrize("restart_session", [_rollback_session, _reset_session])
+def test_readonly_session_allows_restart_and_preserves_guards(
+    sqlite_session_factory: Engine,
+    restart_session: Callable[[ReadonlySession], None],
+) -> None:
+    del sqlite_session_factory
+
+    with create_readonly_session() as session:
+        restart_session(session)
+
+        assert session.scalar(select(Widget.name).where(Widget.id == 1)) == "one"
+        with pytest.raises(ReadonlySessionWriteError, match="write SQL"):
+            session.connection().exec_driver_sql("INSERT INTO widgets (id, name) VALUES (2, 'two')")
 
 
 def test_readonly_session_blocks_orm_write_apis(sqlite_session_factory: Engine) -> None:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

No issue.

Add infrastrucrture to prevent mislabelling writing session as readonly like those in #38559 .

Typing using `ReadonlySession` is not applied yet. We will do this gradually.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
