### PR TITLE
chore: Replace @patch logger.warning with caplog fixture in credit_pool_service test

### DIFF
--- a/api/tests/unit_tests/services/test_credit_pool_service.py
+++ b/api/tests/unit_tests/services/test_credit_pool_service.py
@@ -347,7 +347,9 @@ def test_check_and_deduct_credits_releases_billing_reservation_when_commit_fails
     )
 
 
-def test_check_and_deduct_credits_logs_when_billing_release_fails() -> None:
+def test_check_and_deduct_credits_logs_when_billing_release_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     with (
         patch("services.credit_pool_service.dify_config.BILLING_ENABLED", True),
         patch("services.billing_service.BillingService.quota_reserve") as quota_reserve,
@@ -355,7 +357,6 @@ def test_check_and_deduct_credits_logs_when_billing_release_fails() -> None:
         patch(
             "services.billing_service.BillingService.quota_release", side_effect=RuntimeError("release failed")
         ) as quota_release,
-        patch("services.credit_pool_service.logger.warning") as logger_warning,
     ):
         quota_reserve.return_value = {"reservation_id": "reservation-1", "available": 7, "reserved": 3}
 
@@ -368,9 +369,9 @@ def test_check_and_deduct_credits_logs_when_billing_release_fails() -> None:
         bucket="trial",
         reservation_id="reservation-1",
     )
-    logger_warning.assert_called_once()
-    assert logger_warning.call_args.args[3] == "reservation-1"
-    assert logger_warning.call_args.kwargs["exc_info"] is True
+    assert len(caplog.records) == 1
+    assert "reservation-1" in caplog.records[0].message
+    assert caplog.records[0].exc_info is not None
 
 
 def test_deduct_credits_capped_uses_billing_consume_capped_when_enabled() -> None:


### PR DESCRIPTION
Replace `patch("services.credit_pool_service.logger.warning")` with `caplog` fixture in `test_check_and_deduct_credits_logs_when_billing_release_fails`.

- Removed the `@patch` logger mock
- Added `caplog: pytest.LogCaptureFixture` to function signature
- Replaced `logger_warning.assert_called_once()` / `call_args` checks with `caplog.records` assertions

Refs #37468