### PR TITLE
fix: simplify help menu upgrade item

### DIFF
--- a/web/app/components/main-nav/__tests__/index.spec.tsx
+++ b/web/app/components/main-nav/__tests__/index.spec.tsx
@@ -678,9 +678,12 @@ describe('MainNav', () => {
     renderMainNav()
 
     fireEvent.click(screen.getByRole('button', { name: 'common.mainNav.help.openMenu' }))
-    expect(await screen.findByText('common.userProfile.contactUs')).toBeInTheDocument()
+    const contactUsItem = await screen.findByRole('menuitem', {
+      name: 'common.userProfile.contactUs billing.upgradeBtn.encourageShort',
+    })
+    expect(screen.queryByRole('button', { name: 'billing.upgradeBtn.encourageShort' })).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'billing.upgradeBtn.encourageShort' }))
+    fireEvent.click(contactUsItem)
 
     await waitFor(() => {
       expect(screen.queryByText('common.userProfile.forum')).not.toBeInTheDocument()

--- a/web/app/components/main-nav/components/__tests__/support-menu.spec.tsx
+++ b/web/app/components/main-nav/components/__tests__/support-menu.spec.tsx
@@ -142,13 +142,9 @@ describe('SupportMenu', () => {
     expect(screen.getByText('common.userProfile.contactUs')).toHaveClass('text-text-disabled')
     expect(screen.getByText('billing.upgradeBtn.encourageShort')).toHaveClass('system-xs-semibold-uppercase', 'text-saas-dify-blue-accessible')
     expect(screen.queryByText('common.userProfile.emailSupport')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'billing.upgradeBtn.encourageShort' })).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('menuitem', { name: 'common.userProfile.contactUs billing.upgradeBtn.encourageShort' }))
-
-    expect(mockSetShowPricingModal).not.toHaveBeenCalled()
-    expect(onContactUsClick).not.toHaveBeenCalled()
-
-    fireEvent.click(screen.getByRole('button', { name: 'billing.upgradeBtn.encourageShort' }))
 
     expect(mockSetShowPricingModal).toHaveBeenCalled()
     expect(openZendeskWindow).not.toHaveBeenCalled()

--- a/web/app/components/main-nav/components/support-menu.tsx
+++ b/web/app/components/main-nav/components/support-menu.tsx
@@ -29,9 +29,11 @@ export default function SupportMenu({ onContactUsClick }: SupportMenuProps) {
     <>
       {shouldShowUpgradeContact && (
         <DropdownMenuItem
-          className="mx-0 h-8 cursor-default gap-1 px-3 py-1"
-          onClick={(event) => {
-            event.preventDefault()
+          aria-label={`${t('userProfile.contactUs', { ns: 'common' })} ${t('upgradeBtn.encourageShort', { ns: 'billing' })}`}
+          className="mx-0 h-8 gap-1 px-3 py-1"
+          onClick={() => {
+            setShowPricingModal()
+            onContactUsClick?.()
           }}
         >
           <MenuItemContent
@@ -42,17 +44,12 @@ export default function SupportMenu({ onContactUsClick }: SupportMenuProps) {
               </span>
             )}
             trailing={(
-              <button
-                type="button"
-                className="max-w-30 shrink-0 truncate px-1 system-xs-semibold-uppercase text-saas-dify-blue-accessible transition-colors hover:text-saas-dify-blue-static-hover focus-visible:inset-ring-2 focus-visible:inset-ring-state-accent-solid focus-visible:outline-hidden"
-                onClick={(event) => {
-                  event.stopPropagation()
-                  setShowPricingModal()
-                  onContactUsClick?.()
-                }}
+              <span
+                aria-hidden
+                className="max-w-30 shrink-0 truncate px-1 system-xs-semibold-uppercase text-saas-dify-blue-accessible"
               >
                 {t('upgradeBtn.encourageShort', { ns: 'billing' })}
-              </button>
+              </span>
             )}
           />
         </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- make the upgrade-gated Contact Us row a single dropdown menu item
- keep the Upgrade text as a non-interactive trailing visual cue
- update the main-nav and support-menu tests to assert the menu item semantics

## Tests
- pnpm -C web test app/components/main-nav/components/__tests__/support-menu.spec.tsx
- pnpm -C web test app/components/main-nav/__tests__/index.spec.tsx
- pnpm -C web exec eslint app/components/main-nav/components/support-menu.tsx app/components/main-nav/components/__tests__/support-menu.spec.tsx app/components/main-nav/__tests__/index.spec.tsx
- pnpm -C web type-check
- git diff --check