### PR TITLE
fix(web): agent tool credentials mismatch

### DIFF
--- a/web/app/components/app/configuration/config/agent/agent-tools/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/config/agent/agent-tools/__tests__/index.spec.tsx
@@ -454,6 +454,33 @@ describe('AgentTools', () => {
     expect(formattingDispatcherMock).toHaveBeenCalled()
   })
 
+  it('should update only the selected tool credential when tools share a provider', async () => {
+    const { getModelConfig } = renderAgentTools([
+      createAgentTool({
+        credential_id: 'credential-search',
+        notAuthor: true,
+      }),
+      createAgentTool({
+        credential_id: 'credential-translate',
+        notAuthor: true,
+        tool_label: 'Translate Tool',
+        tool_name: 'translate',
+      }),
+    ])
+    const authorizationButtons = screen.getAllByRole('button', { name: /tools.notAuthorized/ })
+    await userEvent.click(authorizationButtons[1])
+    settingPanelCredentialId = 'credential-updated'
+    await userEvent.click(screen.getByRole('button', { name: 'auth-from-panel' }))
+
+    await waitFor(() => {
+      const tools = getModelConfig().agentConfig.tools as AgentTool[]
+      expect(tools.map(tool => tool.credential_id)).toEqual([
+        'credential-search',
+        'credential-updated',
+      ])
+    })
+  })
+
   it('should reinstate deleted tools after plugin install success event', async () => {
     const { getModelConfig } = renderAgentTools([
       createAgentTool({

--- a/web/app/components/app/configuration/config/agent/agent-tools/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/config/agent/agent-tools/__tests__/index.spec.tsx
@@ -468,7 +468,10 @@ describe('AgentTools', () => {
       }),
     ])
     const authorizationButtons = screen.getAllByRole('button', { name: /tools.notAuthorized/ })
-    await userEvent.click(authorizationButtons[1])
+    const secondAuthorizationButton = authorizationButtons[1]
+    if (!secondAuthorizationButton)
+      throw new Error('Second authorization button not found')
+    await userEvent.click(secondAuthorizationButton)
     settingPanelCredentialId = 'credential-updated'
     await userEvent.click(screen.getByRole('button', { name: 'auth-from-panel' }))
 

--- a/web/app/components/app/configuration/config/agent/agent-tools/index.tsx
+++ b/web/app/components/app/configuration/config/agent/agent-tools/index.tsx
@@ -136,7 +136,7 @@ const AgentTools: FC = () => {
 
   const handleAuthorizationItemClick = useCallback((credentialId: string) => {
     const newModelConfig = produce(modelConfig, (draft) => {
-      const tool = (draft.agentConfig.tools).find((item: any) => item.provider_id === currentTool?.provider_id)
+      const tool = (draft.agentConfig.tools).find((item: any) => item.provider_id === currentTool?.provider_id && item.tool_name === currentTool?.tool_name)
       if (tool)
         (tool as AgentTool).credential_id = credentialId
     })


### PR DESCRIPTION
## Summary

Fixes an issue where updating credentials for one Agent tool could incorrectly update another tool from the same provider. Tool credentials are now matched using both `provider_id` and `tool_name`. A regression test has been added to verify that only the selected tool’s credential is updated.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
