### PR TITLE
fix(web): suppress expected build draft 404 toasts

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/__tests__/page.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/__tests__/page.spec.tsx
@@ -6,6 +6,11 @@ import { AgentConfigurePage } from '../page'
 
 const mocks = vi.hoisted(() => ({
   applyBuildDraft: vi.fn(),
+  buildDraftQueryOptions: vi.fn((options?: object) => ({
+    ...options,
+    queryFn: vi.fn(),
+    queryKey: ['build-draft'],
+  })),
   checkoutBuildDraft: vi.fn(),
   discardBuildDraft: vi.fn(),
   finalizeBuildChat: vi.fn(),
@@ -168,11 +173,7 @@ vi.mock('@/service/client', () => ({
         },
         buildDraft: {
           get: {
-            queryOptions: (options?: object) => ({
-              ...options,
-              queryFn: vi.fn(),
-              queryKey: ['build-draft'],
-            }),
+            queryOptions: mocks.buildDraftQueryOptions,
           },
           checkout: {
             post: {
@@ -732,6 +733,46 @@ describe('AgentConfigurePage', () => {
         refetchOnReconnect: false,
         refetchOnWindowFocus: false,
       })
+    })
+
+    it('should mark missing build drafts as expected without using blanket silence', () => {
+      const queryClient = new QueryClient()
+      mocks.queryState.composer = {
+        data: {
+          agent_soul: {
+            prompt: {
+              system_prompt: 'draft prompt',
+            },
+          },
+        },
+        isFetching: false,
+        isError: false,
+        isPending: false,
+        isSuccess: true,
+        refetch: vi.fn(),
+      }
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <AgentConfigurePage agentId="agent-1" />
+        </QueryClientProvider>,
+      )
+
+      expect(mocks.buildDraftQueryOptions).toHaveBeenCalledWith(expect.objectContaining({
+        context: {
+          expectedErrorStatuses: [404],
+        },
+        input: {
+          params: {
+            agent_id: 'agent-1',
+          },
+        },
+      }))
+      expect(mocks.buildDraftQueryOptions).not.toHaveBeenCalledWith(expect.objectContaining({
+        context: expect.objectContaining({
+          silent: true,
+        }),
+      }))
     })
 
     it('should enter build draft mode when build draft data exists', () => {

--- a/web/features/agent-v2/agent-detail/configure/use-agent-configure-build-draft.ts
+++ b/web/features/agent-v2/agent-detail/configure/use-agent-configure-build-draft.ts
@@ -14,6 +14,7 @@ import { consoleQuery } from '@/service/client'
 import { usePrepareAgentBuildDraftBeforeRun } from './use-agent-build-draft-run'
 
 const isNotFoundResponse = (error: unknown) => error instanceof Response && error.status === 404
+const BUILD_DRAFT_EXPECTED_ERROR_STATUSES = [404] as const
 const BUILD_NOTE_FILE_ID = '__agent_config_build_note__'
 const BUILD_NOTE_FILE_NAME = 'build_note.md'
 
@@ -147,7 +148,6 @@ export function useAgentConfigureBuildDraftData({
   setSoulSourceOverride: (source: AgentConfigureSoulSource | null) => void
   soulSourceOverride: AgentConfigureSoulSource | null
 }) {
-  const shouldSilenceBuildDraftCheckRef = useRef(true)
   const buildDraftQueryInput = {
     params: {
       agent_id: agentId,
@@ -157,28 +157,16 @@ export function useAgentConfigureBuildDraftData({
     input: {
       params: buildDraftQueryInput.params,
     },
-    context: {},
-  })
-  const silentBuildDraftQueryOptions = consoleQuery.agent.byAgentId.buildDraft.get.queryOptions({
-    input: {
-      params: buildDraftQueryInput.params,
-    },
     context: {
-      silent: true,
+      expectedErrorStatuses: BUILD_DRAFT_EXPECTED_ERROR_STATUSES,
     },
-    queryKey: buildDraftQueryOptions.queryKey,
   })
   const buildDraftQuery = useQuery({
     ...buildDraftQueryOptions,
     enabled: !isViewingVersion && soulSourceOverride !== 'draft' && soulSourceOverride !== 'view-version',
     queryFn: async (context) => {
       try {
-        const queryOptions = shouldSilenceBuildDraftCheckRef.current
-          ? silentBuildDraftQueryOptions
-          : buildDraftQueryOptions
-
-        shouldSilenceBuildDraftCheckRef.current = false
-        return await queryOptions.queryFn(context)
+        return await buildDraftQueryOptions.queryFn(context)
       }
       catch (error) {
         if (isNotFoundResponse(error))

--- a/web/service/base.ts
+++ b/web/service/base.ts
@@ -99,6 +99,7 @@ export type IOtherOptions = {
   needAllResponseContent?: boolean
   deleteContentType?: boolean
   silent?: boolean
+  expectedErrorStatuses?: readonly number[]
 
   /** If true, behaves like standard fetch: no URL prefix, returns raw Response */
   fetchCompat?: boolean

--- a/web/service/client.spec.ts
+++ b/web/service/client.spec.ts
@@ -267,6 +267,39 @@ describe('consoleQuery transport context', () => {
     )
   })
 
+  it('should forward expected error statuses to the base request transport', async () => {
+    const request = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+      },
+    }))
+    const consoleQuery = await loadConsoleQueryWithRequest(request)
+    const queryOptions = consoleQuery.agent.byAgentId.buildDraft.get.queryOptions({
+      input: {
+        params: {
+          agent_id: 'agent-1',
+        },
+      },
+      context: {
+        expectedErrorStatuses: [404],
+      },
+    })
+
+    await Promise
+      .resolve(queryOptions.queryFn({ signal: new AbortController().signal } as QueryFunctionContext))
+      .catch(() => undefined)
+
+    expect(request).toHaveBeenCalledWith(
+      expect.stringContaining('/agent/agent-1/build-draft'),
+      expect.any(Object),
+      expect.objectContaining({
+        expectedErrorStatuses: [404],
+        fetchCompat: true,
+      }),
+    )
+  })
+
   it('should serialize trial app dataset ids as repeated query params', async () => {
     const request = vi.fn().mockResolvedValue(new Response(JSON.stringify({
       data: [],

--- a/web/service/client.ts
+++ b/web/service/client.ts
@@ -60,6 +60,7 @@ export function getBaseURL(path: string) {
 }
 
 export type ConsoleClientContext = TanstackQueryOperationContext & {
+  expectedErrorStatuses?: readonly number[]
   silent?: boolean
 }
 
@@ -73,6 +74,7 @@ function createConsoleOpenAPILink(contract: AnyContractRouter): ConsoleClientLin
         normalizeConsoleOpenAPIURL(input.url),
         init,
         {
+          expectedErrorStatuses: options.context.expectedErrorStatuses,
           fetchCompat: true,
           request: input,
           silent: options.context.silent,

--- a/web/service/fetch.spec.ts
+++ b/web/service/fetch.spec.ts
@@ -94,5 +94,80 @@ describe('base', () => {
 
       expect(toast.error).not.toHaveBeenCalled()
     })
+
+    it('should not display an error toast when the response status is expected', async () => {
+      const errorResponse = new Response(
+        JSON.stringify({
+          code: 'not_found',
+          message: 'Agent config version not found.',
+          status: 404,
+        }),
+        {
+          status: 404,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      )
+
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(errorResponse)
+
+      await expect(base('/agent/agent-1/build-draft', {}, { expectedErrorStatuses: [404] }))
+        .rejects
+        .toBeInstanceOf(Response)
+
+      expect(toast.error).not.toHaveBeenCalled()
+    })
+
+    it('should display an error toast when the response status is not expected', async () => {
+      const errorResponse = new Response(
+        JSON.stringify({
+          code: 'internal_server_error',
+          message: 'Server error',
+          status: 500,
+        }),
+        {
+          status: 500,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      )
+
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(errorResponse)
+
+      await expect(base('/agent/agent-1/build-draft', {}, { expectedErrorStatuses: [404] }))
+        .rejects
+        .toBeInstanceOf(Response)
+
+      expect(toast.error).toHaveBeenCalledWith('Server error')
+    })
+
+    it('should preserve silent behavior when expected error statuses are configured', async () => {
+      const errorResponse = new Response(
+        JSON.stringify({
+          code: 'internal_server_error',
+          message: 'Server error',
+          status: 500,
+        }),
+        {
+          status: 500,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      )
+
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(errorResponse)
+
+      await expect(base('/agent/agent-1/build-draft', {}, {
+        expectedErrorStatuses: [404],
+        silent: true,
+      }))
+        .rejects
+        .toBeInstanceOf(Response)
+
+      expect(toast.error).not.toHaveBeenCalled()
+    })
   })
 })

--- a/web/service/fetch.ts
+++ b/web/service/fetch.ts
@@ -68,7 +68,10 @@ const afterResponseErrorCode = (otherOptions: IOtherOptions): AfterResponseHook 
         errorData = data as ResponseError
       }
       catch {}
-      const shouldNotifyError = response.status !== 401 && errorData && !otherOptions.silent
+      const shouldNotifyError = response.status !== 401
+        && errorData
+        && !otherOptions.silent
+        && !otherOptions.expectedErrorStatuses?.includes(response.status)
 
       const errorMessage = errorData?.message || errorData?.error
       if (shouldNotifyError && errorMessage)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix https://github.com/langgenius/dify/issues/38646


## Background

Opening an Agent configuration page checks whether the current user already has
a build draft. A 404 response is expected when no build draft exists yet and
should switch the UI to the normal draft state without showing an error toast.

Previously, this lookup used a one-shot `silent` flag. The flag was cleared
before the first query completed.

## Root cause

In development, React StrictMode may unsubscribe and resubscribe the query
during the initial mount. Because oRPC consumes TanStack Query's AbortSignal,
the first query can be cancelled after the one-shot silent flag has already
been cleared.

The resubscribed query then reaches the API without `silent: true`. When the
expected 404 response is returned, the shared request transport displays it
through the global error toast.

Production does not run this development-only StrictMode lifecycle, so it
usually completes the first silent request. This explains why identical code
could show the toast locally but not in the deployed environment.

PR #37915 introduced a one-shot `silent` flag for the initial build-draft
lookup. The flag was cleared before the request completed, making the behavior
dependent on whether that first query invocation survived until the HTTP
response.

PR #38230 later introduced lazy-loaded console contract shards. This added an
asynchronous resolution window during which React StrictMode and TanStack Query
could cancel the first invocation after the silent flag had already been
consumed. The resubscribed invocation then reached the API without silent mode,
causing the expected 404 response to be displayed through the global error
toast.

PR #38162 subsequently migrated the lookup to the shared console client, but it
preserved the same silent-context behavior. Therefore, the shared-client
migration was not the root cause.

## Fix

- Add `expectedErrorStatuses` to the console query transport context.
- Forward expected statuses to the shared request transport.
- Suppress toast notifications only when the response status is explicitly
  expected.
- Continue rejecting the response so TanStack Query and the feature hook can
  handle the 404 normally.
- Mark 404 as expected for build-draft lookups.
- Remove the timing-dependent one-shot silent flag.

Unexpected errors, such as 500 responses, continue to display their error
toasts. Existing blanket `silent` behavior is also preserved.


## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
