### PR TITLE
fix(web): support punctuation in markdown form field names

### DIFF
--- a/web/app/components/base/markdown-blocks/__tests__/form.spec.tsx
+++ b/web/app/components/base/markdown-blocks/__tests__/form.spec.tsx
@@ -534,6 +534,26 @@ describe('MarkdownForm', () => {
 
   // Unicode letters should be valid form field names.
   describe('Unicode name support', () => {
+    it('should include fields whose names contain supported full-width and half-width punctuation', async () => {
+      const user = userEvent.setup()
+      const node = createRootNode(
+        [
+          createElementNode('input', { type: 'hidden', name: '字段（）！＊＆－', value: 'full-width' }),
+          createElementNode('input', { type: 'hidden', name: 'field()!*&-', value: 'half-width' }),
+          createElementNode('button', {}, [createTextNode('Submit')]),
+        ],
+        { dataFormat: 'json' },
+      )
+
+      render(<MarkdownForm node={node} />)
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }))
+
+      await waitFor(() => {
+        expect(mockOnSend).toHaveBeenCalledWith('{"字段（）！＊＆－":"full-width","field()!*&-":"half-width"}')
+      })
+    })
+
     it('should include Unicode-named fields from all supported controls in JSON output', async () => {
       const user = userEvent.setup()
       const node = createRootNode(

--- a/web/app/components/base/markdown-blocks/form.tsx
+++ b/web/app/components/base/markdown-blocks/form.tsx
@@ -43,7 +43,7 @@ const SUPPORTED_TYPES_SET = new Set<string>(Object.values(SUPPORTED_TYPES))
 
 const SAFE_NAME_RE = (() => {
   try {
-    return new RegExp('^\\p{L}[\\p{L}\\p{M}\\p{N}_-]*$', 'u')
+    return new RegExp('^\\p{L}[\\p{L}\\p{M}\\p{N}_()!*&（）！＊＆－-]*$', 'u')
   }
   catch {
     // Fallback for browsers without Unicode property escape support.


### PR DESCRIPTION
## Summary

support punctuation in markdown form field names.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
