### PR TITLE
fix(trigger): surface webhook trigger quota exceeded as 429 response

### DIFF
--- a/api/controllers/trigger/webhook.py
+++ b/api/controllers/trigger/webhook.py
@@ -7,6 +7,7 @@ from werkzeug.exceptions import NotFound, RequestEntityTooLarge
 from controllers.trigger import bp
 from core.trigger.debug.event_bus import TriggerDebugEventBus
 from core.trigger.debug.events import WebhookDebugEvent, build_webhook_pool_key
+from services.errors.app import QuotaExceededError
 from services.trigger.webhook_service import RawWebhookDataDict, WebhookService
 
 logger = logging.getLogger(__name__)
@@ -60,8 +61,15 @@ def handle_webhook(webhook_id: str):
         response_data, status_code = WebhookService.generate_webhook_response(node_config)
         return jsonify(response_data), status_code
 
-    except ValueError as e:
-        raise NotFound(str(e))
+    except QuotaExceededError:
+        return jsonify(
+            {
+                "error": "Too Many Requests",
+                "message": "Trigger event quota exceeded. Please upgrade your plan.",
+            }
+        ), 429
+    except ValueError as error:
+        raise NotFound(str(error))
     except RequestEntityTooLarge:
         raise
     except Exception as e:

--- a/api/services/trigger/webhook_service.py
+++ b/api/services/trigger/webhook_service.py
@@ -101,6 +101,7 @@ class WebhookService:
                 - Mapping[str, Any]: The node configuration data
 
         Raises:
+            QuotaExceededError: If the app trigger is rate limited
             ValueError: If webhook not found, app trigger not found, trigger disabled, or workflow not found
         """
         with Session(db.engine) as session:
@@ -141,8 +142,10 @@ class WebhookService:
                 # Only check enabled status if not in debug mode
 
                 if app_trigger.status == AppTriggerStatus.RATE_LIMITED:
-                    raise ValueError(
-                        f"Webhook trigger is rate limited for webhook {webhook_id}, please upgrade your plan."
+                    raise QuotaExceededError(
+                        feature=QuotaType.TRIGGER.value,
+                        tenant_id=webhook_trigger.tenant_id,
+                        required=1,
                     )
 
                 if app_trigger.status != AppTriggerStatus.ENABLED:
@@ -799,6 +802,7 @@ class WebhookService:
             workflow: The workflow to execute
 
         Raises:
+            QuotaExceededError: If the tenant has exhausted its trigger quota
             ValueError: If tenant owner is not found
             Exception: If workflow execution fails
         """

--- a/api/tests/test_containers_integration_tests/services/test_webhook_service_relationships.py
+++ b/api/tests/test_containers_integration_tests/services/test_webhook_service_relationships.py
@@ -201,8 +201,12 @@ class TestWebhookServiceLookupWithContainers:
             db_session_with_containers, app=app, node_id="node-1", status=AppTriggerStatus.RATE_LIMITED
         )
 
-        with pytest.raises(ValueError, match="rate limited"):
+        with pytest.raises(QuotaExceededError) as exc_info:
             WebhookService.get_webhook_trigger_and_workflow(webhook_trigger.webhook_id)
+
+        assert exc_info.value.feature == QuotaType.TRIGGER.value
+        assert exc_info.value.tenant_id == tenant.id
+        assert exc_info.value.required == 1
 
     def test_get_webhook_trigger_and_workflow_raises_when_app_trigger_disabled(
         self, db_session_with_containers: Session, flask_app_with_containers: Flask

--- a/api/tests/unit_tests/controllers/trigger/test_webhook.py
+++ b/api/tests/unit_tests/controllers/trigger/test_webhook.py
@@ -5,6 +5,7 @@ import pytest
 from werkzeug.exceptions import NotFound, RequestEntityTooLarge
 
 import controllers.trigger.webhook as module
+from services.errors.app import QuotaExceededError
 
 
 @pytest.fixture(autouse=True)
@@ -82,6 +83,39 @@ class TestHandleWebhook:
 
         assert status == 400
         assert response["error"] == "Bad Request"
+
+    @patch.object(module.WebhookService, "get_webhook_trigger_and_workflow")
+    @patch.object(module.WebhookService, "extract_and_validate_webhook_data")
+    @patch.object(
+        module.WebhookService,
+        "trigger_workflow_execution",
+        side_effect=QuotaExceededError(feature="trigger", tenant_id="tenant-1", required=1),
+    )
+    def test_quota_exceeded(self, mock_trigger, mock_extract, mock_get):
+        mock_get.return_value = (DummyWebhookTrigger(), "workflow", "node_config")
+        mock_extract.return_value = {"input": "x"}
+
+        response, status = module.handle_webhook("wh-1")
+
+        assert status == 429
+        assert response == {
+            "error": "Too Many Requests",
+            "message": "Trigger event quota exceeded. Please upgrade your plan.",
+        }
+
+    @patch.object(
+        module.WebhookService,
+        "get_webhook_trigger_and_workflow",
+        side_effect=QuotaExceededError(feature="trigger", tenant_id="tenant-1", required=1),
+    )
+    def test_rate_limited(self, mock_get):
+        response, status = module.handle_webhook("wh-1")
+
+        assert status == 429
+        assert response == {
+            "error": "Too Many Requests",
+            "message": "Trigger event quota exceeded. Please upgrade your plan.",
+        }
 
     @patch.object(module.WebhookService, "get_webhook_trigger_and_workflow", side_effect=ValueError("missing"))
     def test_value_error_not_found(self, mock_get):


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
