### PR TITLE
fix: stale credential cache in get_cached_provider_credentials for dynamic-select

### DIFF
--- a/api/services/plugin/plugin_parameter_service.py
+++ b/api/services/plugin/plugin_parameter_service.py
@@ -4,11 +4,12 @@ from typing import Any, Literal
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from core.helper.provider_cache import NoOpProviderCredentialCache
+from core.helper.provider_encryption import create_provider_encrypter
 from core.plugin.entities.parameters import PluginParameterOption
 from core.plugin.entities.plugin_daemon import CredentialType
 from core.plugin.impl.dynamic_select import DynamicSelectClient
 from core.tools.tool_manager import ToolManager
-from core.tools.utils.encryption import create_tool_provider_encrypter
 from core.trigger.entities.api_entities import TriggerProviderSubscriptionApiEntity
 from core.trigger.entities.entities import SubscriptionBuilder
 from extensions.ext_database import db
@@ -44,10 +45,11 @@ class PluginParameterService:
         match provider_type:
             case "tool":
                 provider_controller = ToolManager.get_builtin_provider(provider, tenant_id)
-                # init tool configuration
-                encrypter, _ = create_tool_provider_encrypter(
+                # init tool configuration (no caching — dynamic-select needs fresh credentials)
+                encrypter, _ = create_provider_encrypter(
                     tenant_id=tenant_id,
-                    controller=provider_controller,
+                    config=[x.to_basic_provider_config() for x in provider_controller.get_credentials_schema()],
+                    cache=NoOpProviderCredentialCache(),
                 )
 
                 # check if credentials are required

--- a/api/tests/test_containers_integration_tests/services/plugin/test_plugin_parameter_service.py
+++ b/api/tests/test_containers_integration_tests/services/plugin/test_plugin_parameter_service.py
@@ -43,7 +43,7 @@ class TestGetDynamicSelectOptionsTool:
         assert call_kwargs[0][5] == {}  # empty credentials
 
     @patch("services.plugin.plugin_parameter_service.DynamicSelectClient")
-    @patch("services.plugin.plugin_parameter_service.create_tool_provider_encrypter")
+    @patch("services.plugin.plugin_parameter_service.create_provider_encrypter")
     @patch("services.plugin.plugin_parameter_service.ToolManager")
     def test_fetches_credentials_with_credential_id(
         self,
@@ -86,7 +86,7 @@ class TestGetDynamicSelectOptionsTool:
 
         assert result == ["opt1"]
 
-    @patch("services.plugin.plugin_parameter_service.create_tool_provider_encrypter")
+    @patch("services.plugin.plugin_parameter_service.create_provider_encrypter")
     @patch("services.plugin.plugin_parameter_service.ToolManager")
     def test_raises_when_tool_provider_not_found(
         self,


### PR DESCRIPTION
Replace create_tool_provider_encrypter (uses SingletonProviderCredentialsCache) with create_provider_encrypter using NoOpProviderCredentialCache so every dynamic-select call decrypts fresh credentials from the database. The trigger path was unaffected since it reads credentials directly from the subscription record, not through the cached encrypter.

Closes #38633