### PR TITLE
perf(web): lazy-load Vite plugins

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,8 +1,13 @@
 import { fileURLToPath } from 'node:url'
 import { defineConfig, lazyPlugins } from 'vite-plus'
+import { createCodeInspectorPlugin, createForceInspectorClientInjectionPlugin } from './plugins/vite/code-inspector.ts'
+import { customI18nHmrPlugin } from './plugins/vite/custom-i18n-hmr.ts'
+import { getRootClientInjectTarget } from './plugins/vite/inject-target.ts'
+import { nextStaticImageTestPlugin } from './plugins/vite/next-static-image-test.ts'
 
 const projectRoot = fileURLToPath(new URL('.', import.meta.url))
 const isCI = !!process.env.CI
+const rootClientInjectTarget = getRootClientInjectTarget(projectRoot)
 
 export default defineConfig(({ mode }) => {
   const isTest = mode === 'test'
@@ -14,8 +19,6 @@ export default defineConfig(({ mode }) => {
       const { default: react } = await import('@vitejs/plugin-react')
 
       if (isTest) {
-        const { nextStaticImageTestPlugin } = await import('./plugins/vite/next-static-image-test.ts')
-
         return [
           nextStaticImageTestPlugin({ projectRoot }),
           react(),
@@ -38,18 +41,11 @@ export default defineConfig(({ mode }) => {
         { default: tailwindcss },
         { default: vinext },
         { default: Inspect },
-        { createCodeInspectorPlugin, createForceInspectorClientInjectionPlugin },
-        { customI18nHmrPlugin },
-        { getRootClientInjectTarget },
       ] = await Promise.all([
         import('@tailwindcss/vite'),
         import('vinext'),
         import('vite-plugin-inspect'),
-        import('./plugins/vite/code-inspector.ts'),
-        import('./plugins/vite/custom-i18n-hmr.ts'),
-        import('./plugins/vite/inject-target.ts'),
       ])
-      const rootClientInjectTarget = getRootClientInjectTarget(projectRoot)
 
       return [
         Inspect(),

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,17 +1,8 @@
 import { fileURLToPath } from 'node:url'
-import tailwindcss from '@tailwindcss/vite'
-import react from '@vitejs/plugin-react'
-import vinext from 'vinext'
-import Inspect from 'vite-plugin-inspect'
-import { defineConfig } from 'vite-plus'
-import { createCodeInspectorPlugin, createForceInspectorClientInjectionPlugin } from './plugins/vite/code-inspector.ts'
-import { customI18nHmrPlugin } from './plugins/vite/custom-i18n-hmr.ts'
-import { getRootClientInjectTarget } from './plugins/vite/inject-target.ts'
-import { nextStaticImageTestPlugin } from './plugins/vite/next-static-image-test.ts'
+import { defineConfig, lazyPlugins } from 'vite-plus'
 
 const projectRoot = fileURLToPath(new URL('.', import.meta.url))
 const isCI = !!process.env.CI
-const rootClientInjectTarget = getRootClientInjectTarget(projectRoot)
 
 export default defineConfig(({ mode }) => {
   const isTest = mode === 'test'
@@ -19,42 +10,66 @@ export default defineConfig(({ mode }) => {
     || process.argv.some(arg => arg.toLowerCase().includes('storybook'))
 
   return {
-    plugins: isTest
-      ? [
+    plugins: lazyPlugins(async () => {
+      const { default: react } = await import('@vitejs/plugin-react')
+
+      if (isTest) {
+        const { nextStaticImageTestPlugin } = await import('./plugins/vite/next-static-image-test.ts')
+
+        return [
           nextStaticImageTestPlugin({ projectRoot }),
           react(),
           {
             // Stub .mdx files so components importing them can be unit-tested
             name: 'mdx-stub',
             enforce: 'pre',
-            transform(_, id) {
+            transform(_: string, id: string) {
               if (id.endsWith('.mdx'))
                 return { code: 'export default () => null', map: null }
             },
           },
         ]
-      : isStorybook
-        ? [
-            react(),
-          ]
-        : [
-            Inspect(),
-            createCodeInspectorPlugin({
-              injectTarget: rootClientInjectTarget,
-            }),
-            createForceInspectorClientInjectionPlugin({
-              injectTarget: rootClientInjectTarget,
-              projectRoot,
-            }),
-            tailwindcss(),
-            react(),
-            vinext({ react: false }),
-            customI18nHmrPlugin({ injectTarget: rootClientInjectTarget }),
-            // reactGrabOpenFilePlugin({
-            //   injectTarget: rootClientInjectTarget,
-            //   projectRoot,
-            // }),
-          ],
+      }
+
+      if (isStorybook)
+        return [react()]
+
+      const [
+        { default: tailwindcss },
+        { default: vinext },
+        { default: Inspect },
+        { createCodeInspectorPlugin, createForceInspectorClientInjectionPlugin },
+        { customI18nHmrPlugin },
+        { getRootClientInjectTarget },
+      ] = await Promise.all([
+        import('@tailwindcss/vite'),
+        import('vinext'),
+        import('vite-plugin-inspect'),
+        import('./plugins/vite/code-inspector.ts'),
+        import('./plugins/vite/custom-i18n-hmr.ts'),
+        import('./plugins/vite/inject-target.ts'),
+      ])
+      const rootClientInjectTarget = getRootClientInjectTarget(projectRoot)
+
+      return [
+        Inspect(),
+        createCodeInspectorPlugin({
+          injectTarget: rootClientInjectTarget,
+        }),
+        createForceInspectorClientInjectionPlugin({
+          injectTarget: rootClientInjectTarget,
+          projectRoot,
+        }),
+        tailwindcss(),
+        react(),
+        vinext({ react: false }),
+        customI18nHmrPlugin({ injectTarget: rootClientInjectTarget }),
+        // reactGrabOpenFilePlugin({
+        //   injectTarget: rootClientInjectTarget,
+        //   projectRoot,
+        // }),
+      ]
+    }),
     resolve: {
       tsconfigPaths: true,
       alias: [


### PR DESCRIPTION
## Summary

- lazy-load Web Vite plugins only when the dev, build, test, or Storybook pipeline runs
- avoid initializing vinext and other heavy plugins during Vite+ task discovery
- reduce the measured `vp run` fixed overhead from about 1.21s to 0.66s and warm workspace type-check time from about 3.12s to 2.84s

No associated issue.

## Screenshots

Not applicable — this is a tooling performance change with no UI impact.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Validation performed:

- `pnpm type-check`
- `pnpm exec eslint web/vite.config.ts`
- `pnpm --dir web exec vp test --run service/debug.spec.ts` (15 tests)
- started `vp dev` successfully
- commit-time staged ESLint hook

From Codex