### PR TITLE
fix: update message answer on completion after resume from pause

### DIFF
--- a/api/core/app/apps/advanced_chat/generate_task_pipeline.py
+++ b/api/core/app/apps/advanced_chat/generate_task_pipeline.py
@@ -807,10 +807,11 @@ class AdvancedChatAppGenerateTaskPipeline(GraphRuntimeStateSupport):
                 reason=QueueMessageReplaceEvent.MessageReplaceReason.OUTPUT_MODERATION,
             )
 
-        # Save message unless it has already been persisted on pause.
-        if not self._message_saved_on_pause:
-            with self._database_session() as session:
-                self._save_message(session=session, graph_runtime_state=resolved_state)
+        # Always save the final message state, even if it was already
+        # persisted on pause. The previous snapshot (PAUSED status, empty
+        # answer) must be replaced with the completed answer.
+        with self._database_session() as session:
+            self._save_message(session=session, graph_runtime_state=resolved_state)
 
         yield self._message_end_to_stream_response()
 


### PR DESCRIPTION
Fixes #38614

## Summary

When a ChatFlow workflow pauses (e.g., Human Input node) after a Question Classifier or Condition Branch node, the message is saved with `PAUSED` status and an empty answer. When the workflow resumes and completes, `_handle_advanced_chat_message_end_event` skipped saving the final state because `_message_saved_on_pause` was `True`, leaving the message stuck with `PAUSED` status and no answer in the conversation.

## Root Cause

In `_handle_workflow_paused_event`, the message is saved and its status is set to `PAUSED`. On completion, `_handle_advanced_chat_message_end_event` guarded against double-saving with `if not self._message_saved_on_pause`, which skipped the update for resumed workflows. The final answer text was available in `_task_state.answer`, but never persisted.

## Fix

Removed the `_message_saved_on_pause` guard so `_save_message` is always called on completion. `_save_message` uses `_get_message` (a SELECT by message_id) and updates the existing message in-place, so calling it again on completion overwrites the stale `PAUSED` snapshot with the correct answer and `NORMAL` status. This is safe because `_save_message` is idempotent — it only modifies the already-existing DB row.