### PR TITLE
fix(dataset): block dataset deletion while documents are actively indexing

### DIFF
--- a/api/controllers/console/datasets/datasets.py
+++ b/api/controllers/console/datasets/datasets.py
@@ -17,7 +17,12 @@ from controllers.console import console_ns
 from controllers.console.apikey import ApiKeyItem, ApiKeyList
 from controllers.console.app.error import ProviderNotInitializeError
 from controllers.console.app.wraps import with_session
-from controllers.console.datasets.error import DatasetInUseError, DatasetNameDuplicateError, IndexingEstimateError
+from controllers.console.datasets.error import (
+    DatasetIndexingInProgressError,
+    DatasetInUseError,
+    DatasetNameDuplicateError,
+    IndexingEstimateError,
+)
 from controllers.console.wraps import (
     RBACPermission,
     RBACResourceScope,
@@ -730,6 +735,8 @@ class DatasetApi(Resource):
                 raise NotFound("Dataset not found.")
         except services.errors.dataset.DatasetInUseError:
             raise DatasetInUseError()
+        except services.errors.dataset.DatasetIndexingInProgressError:
+            raise DatasetIndexingInProgressError()
 
 
 @console_ns.route("/datasets/<uuid:dataset_id>/use-check")

--- a/api/controllers/console/datasets/error.py
+++ b/api/controllers/console/datasets/error.py
@@ -55,6 +55,15 @@ class DatasetInUseError(BaseHTTPException):
     code = 409
 
 
+class DatasetIndexingInProgressError(BaseHTTPException):
+    error_code = "dataset_indexing_in_progress"
+    description = (
+        "Some documents in this dataset are still being indexed. "
+        "Wait for indexing to finish or pause the documents before deleting the dataset."
+    )
+    code = 409
+
+
 class IndexingEstimateError(BaseHTTPException):
     error_code = "indexing_estimate_error"
     description = "Knowledge indexing estimate failed: {message}"

--- a/api/controllers/service_api/dataset/dataset.py
+++ b/api/controllers/service_api/dataset/dataset.py
@@ -27,7 +27,12 @@ from controllers.common.schema import (
 from controllers.console.app.wraps import with_session
 from controllers.console.wraps import edit_permission_required
 from controllers.service_api import service_api_ns
-from controllers.service_api.dataset.error import DatasetInUseError, DatasetNameDuplicateError, InvalidActionError
+from controllers.service_api.dataset.error import (
+    DatasetIndexingInProgressError,
+    DatasetInUseError,
+    DatasetNameDuplicateError,
+    InvalidActionError,
+)
 from controllers.service_api.wraps import (
     DatasetApiResource,
     cloud_edition_billing_rate_limit_check,
@@ -718,7 +723,9 @@ class DatasetApi(DatasetApiResource):
             404: "`not_found` : Dataset not found.",
             409: (
                 "`dataset_in_use` : The knowledge base is being used by some apps. Please remove it from the "
-                "apps before deleting."
+                "apps before deleting. "
+                "`dataset_indexing_in_progress` : Some documents are still being indexed. Wait for indexing "
+                "to finish or pause the documents before deleting."
             ),
         },
     )
@@ -730,7 +737,7 @@ class DatasetApi(DatasetApiResource):
             204: "Dataset deleted successfully",
             401: "Unauthorized - invalid API token",
             404: "Dataset not found",
-            409: "Conflict - dataset is in use",
+            409: "Conflict - dataset is in use or documents are still indexing",
         }
     )
     @cloud_edition_billing_rate_limit_check("knowledge", "dataset")
@@ -761,6 +768,8 @@ class DatasetApi(DatasetApiResource):
                 raise NotFound("Dataset not found.")
         except services.errors.dataset.DatasetInUseError:
             raise DatasetInUseError()
+        except services.errors.dataset.DatasetIndexingInProgressError:
+            raise DatasetIndexingInProgressError()
 
 
 @service_api_ns.route("/datasets/<uuid:dataset_id>/documents/status/<string:action>")

--- a/api/controllers/service_api/dataset/error.py
+++ b/api/controllers/service_api/dataset/error.py
@@ -49,6 +49,15 @@ class DatasetInUseError(BaseHTTPException):
     code = 409
 
 
+class DatasetIndexingInProgressError(BaseHTTPException):
+    error_code = "dataset_indexing_in_progress"
+    description = (
+        "Some documents in this dataset are still being indexed. "
+        "Wait for indexing to finish or pause the documents before deleting the dataset."
+    )
+    code = 409
+
+
 class PipelineRunError(BaseHTTPException):
     error_code = "pipeline_run_error"
     description = "An error occurred while running the pipeline."

--- a/api/openapi/markdown/service-openapi.md
+++ b/api/openapi/markdown/service-openapi.md
@@ -806,7 +806,7 @@ Permanently delete a knowledge base and all its documents. The knowledge base mu
 | 401 | Unauthorized - invalid API token |
 | 403 | Forbidden - dataset API access or workspace access denied |
 | 404 | `not_found` : Dataset not found. |
-| 409 | `dataset_in_use` : The knowledge base is being used by some apps. Please remove it from the apps before deleting. |
+| 409 | `dataset_in_use` : The knowledge base is being used by some apps. Please remove it from the apps before deleting. `dataset_indexing_in_progress` : Some documents are still being indexed. Wait for indexing to finish or pause the documents before deleting. |
 
 ### [GET] /datasets/{dataset_id}
 **Get Knowledge Base**

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -82,7 +82,7 @@ from services.entities.knowledge_entities.rag_pipeline_entities import (
 )
 from services.errors.account import NoPermissionError
 from services.errors.chunk import ChildChunkDeleteIndexError, ChildChunkIndexingError
-from services.errors.dataset import DatasetNameDuplicateError
+from services.errors.dataset import DatasetIndexingInProgressError, DatasetNameDuplicateError
 from services.errors.document import DocumentIndexingError
 from services.errors.file import FileNotExistsError
 from services.external_knowledge_service import ExternalDatasetService
@@ -1331,13 +1331,46 @@ class DatasetService:
                 deal_dataset_index_update_task.delay(dataset.id, action)
 
     @staticmethod
+    def _has_documents_indexing(dataset_id: str, session: Session) -> bool:
+        """Return whether any document of the dataset is being indexed right now.
+
+        Deleting a dataset while documents are mid-indexing races the in-flight
+        pipeline against `clean_dataset_task`, orphaning segments, child chunks
+        and vector collections (#38518). Only the in-flight statuses matter:
+        a WAITING document's task no-ops once the dataset rows are gone, and
+        blocking on WAITING would strand users because the console offers no
+        pause control for queued documents. Paused documents are excluded so
+        pausing stays the escape hatch for stuck indexing runs.
+        """
+        stmt = select(
+            exists().where(
+                Document.dataset_id == dataset_id,
+                Document.indexing_status.in_(DocumentService._INDEXING_STATUSES),
+                Document.is_paused.is_not(True),
+            )
+        )
+        return bool(session.scalar(stmt))
+
+    @staticmethod
     def delete_dataset(dataset_id, user, session: Session):
+        """Delete a dataset after permission and in-flight indexing checks.
+
+        Raises:
+            NoPermissionError: If the user cannot access the dataset.
+            DatasetIndexingInProgressError: If any document is actively indexing.
+        """
         dataset = DatasetService.get_dataset(dataset_id, session)
 
         if dataset is None:
             return False
 
         DatasetService.check_dataset_permission(dataset, user, session)
+
+        if DatasetService._has_documents_indexing(dataset.id, session):
+            raise DatasetIndexingInProgressError(
+                "Some documents in this dataset are still being indexed. "
+                "Wait for indexing to finish or pause the documents before deleting the dataset."
+            )
 
         dataset_was_deleted.send(dataset)
 

--- a/api/services/errors/dataset.py
+++ b/api/services/errors/dataset.py
@@ -7,3 +7,7 @@ class DatasetNameDuplicateError(BaseServiceError):
 
 class DatasetInUseError(BaseServiceError):
     pass
+
+
+class DatasetIndexingInProgressError(BaseServiceError):
+    pass

--- a/api/tests/test_containers_integration_tests/controllers/service_api/dataset/test_dataset.py
+++ b/api/tests/test_containers_integration_tests/controllers/service_api/dataset/test_dataset.py
@@ -40,7 +40,12 @@ from controllers.service_api.dataset.dataset import (
     TagUnbindingPayload,
     TagUpdatePayload,
 )
-from controllers.service_api.dataset.error import DatasetInUseError, DatasetNameDuplicateError, InvalidActionError
+from controllers.service_api.dataset.error import (
+    DatasetIndexingInProgressError,
+    DatasetInUseError,
+    DatasetNameDuplicateError,
+    InvalidActionError,
+)
 from models.account import Account
 from models.dataset import Dataset, DatasetPermissionEnum
 from models.enums import TagType
@@ -814,6 +819,27 @@ class TestDatasetApiDelete:
         ):
             api = DatasetApi()
             with pytest.raises(DatasetInUseError):
+                unwrap(api.delete)(api, _=mock_dataset.tenant_id, dataset_id=mock_dataset.id)
+
+    @patch("controllers.service_api.dataset.dataset.current_user")
+    @patch("controllers.service_api.dataset.dataset.DatasetService")
+    def test_delete_dataset_indexing_in_progress(
+        self,
+        mock_dataset_svc,
+        mock_current_user,
+        app: Flask,
+        mock_dataset,
+    ):
+        from controllers.service_api.dataset.dataset import DatasetApi
+
+        mock_dataset_svc.delete_dataset.side_effect = services.errors.dataset.DatasetIndexingInProgressError()
+
+        with app.test_request_context(
+            f"/datasets/{mock_dataset.id}",
+            method="DELETE",
+        ):
+            api = DatasetApi()
+            with pytest.raises(DatasetIndexingInProgressError):
                 unwrap(api.delete)(api, _=mock_dataset.tenant_id, dataset_id=mock_dataset.id)
 
 

--- a/api/tests/unit_tests/controllers/console/datasets/test_datasets.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_datasets.py
@@ -30,7 +30,12 @@ from controllers.console.datasets.datasets import (
     DatasetRetrievalSettingMockApi,
     DatasetUseCheckApi,
 )
-from controllers.console.datasets.error import DatasetInUseError, DatasetNameDuplicateError, IndexingEstimateError
+from controllers.console.datasets.error import (
+    DatasetIndexingInProgressError,
+    DatasetInUseError,
+    DatasetNameDuplicateError,
+    IndexingEstimateError,
+)
 from core.entities.knowledge_entities import IndexingEstimate
 from core.errors.error import LLMBadRequestError, ProviderTokenNotInitError
 from core.provider_manager import ProviderManager
@@ -1153,6 +1158,24 @@ class TestDatasetApiDelete:
             ),
         ):
             with pytest.raises(DatasetInUseError):
+                method(api, user, dataset_id)
+
+    def test_delete_dataset_indexing_in_progress(self, app: Flask):
+        api = DatasetApi()
+        method = unwrap(api.delete)
+
+        dataset_id = "dataset-id"
+        user = make_account()
+
+        with (
+            app.test_request_context(f"/datasets/{dataset_id}"),
+            patch.object(
+                DatasetService,
+                "delete_dataset",
+                side_effect=services.errors.dataset.DatasetIndexingInProgressError(),
+            ),
+        ):
+            with pytest.raises(DatasetIndexingInProgressError):
                 method(api, user, dataset_id)
 
 

--- a/api/tests/unit_tests/services/dataset_service_test_helpers.py
+++ b/api/tests/unit_tests/services/dataset_service_test_helpers.py
@@ -67,7 +67,7 @@ from services.entities.knowledge_entities.rag_pipeline_entities import (
 )
 from services.errors.account import NoPermissionError
 from services.errors.chunk import ChildChunkDeleteIndexError, ChildChunkIndexingError
-from services.errors.dataset import DatasetNameDuplicateError
+from services.errors.dataset import DatasetIndexingInProgressError, DatasetNameDuplicateError
 from services.errors.document import DocumentIndexingError
 from services.errors.file import FileNotExistsError
 
@@ -82,6 +82,7 @@ __all__ = [
     "DataSource",
     "Dataset",
     "DatasetCollectionBindingService",
+    "DatasetIndexingInProgressError",
     "DatasetNameDuplicateError",
     "DatasetPermissionEnum",
     "DatasetPermissionService",

--- a/api/tests/unit_tests/services/test_dataset_service_dataset.py
+++ b/api/tests/unit_tests/services/test_dataset_service_dataset.py
@@ -1,6 +1,7 @@
 """Unit tests for DatasetService and dataset-related collaborators."""
 
 from .dataset_service_test_helpers import (
+    DatasetIndexingInProgressError,
     DatasetNameDuplicateError,
     DatasetPermissionEnum,
     DatasetPermissionService,
@@ -1409,6 +1410,83 @@ class TestDatasetServicePermissionsAndLifecycle:
                 dataset=SimpleNamespace(id="dataset-1"),
                 session=session,
             )
+
+    @staticmethod
+    def _delete_dataset(*, has_active_indexing: bool):
+        """Run DatasetService.delete_dataset with the indexing-guard query mocked.
+
+        The guard's EXISTS query is the only `session.scalar` call in the flow,
+        so its return value directly simulates whether documents are indexing.
+        """
+        dataset = DatasetServiceUnitDataFactory.create_dataset_mock()
+        user = DatasetServiceUnitDataFactory.create_user_mock()
+        session = MagicMock()
+        session.scalar.return_value = has_active_indexing
+
+        with (
+            patch.object(DatasetService, "get_dataset", return_value=dataset),
+            patch.object(DatasetService, "check_dataset_permission"),
+            patch("services.dataset_service.dataset_was_deleted") as deleted_signal,
+        ):
+            result = DatasetService.delete_dataset(dataset.id, user, session)
+
+        return result, dataset, session, deleted_signal
+
+    def test_delete_dataset_blocks_while_documents_are_indexing(self):
+        # Deleting mid-indexing races the in-flight pipeline against cleanup and
+        # orphans segments/chunks/vector tables. See issue #38522.
+        with pytest.raises(DatasetIndexingInProgressError):
+            self._delete_dataset(has_active_indexing=True)
+
+    def test_delete_dataset_does_not_delete_or_signal_when_blocked(self):
+        dataset = DatasetServiceUnitDataFactory.create_dataset_mock()
+        user = DatasetServiceUnitDataFactory.create_user_mock()
+        session = MagicMock()
+        session.scalar.return_value = True
+
+        with (
+            patch.object(DatasetService, "get_dataset", return_value=dataset),
+            patch.object(DatasetService, "check_dataset_permission"),
+            patch("services.dataset_service.dataset_was_deleted") as deleted_signal,
+        ):
+            with pytest.raises(DatasetIndexingInProgressError):
+                DatasetService.delete_dataset(dataset.id, user, session)
+
+        deleted_signal.send.assert_not_called()
+        session.delete.assert_not_called()
+        session.commit.assert_not_called()
+
+    def test_delete_dataset_proceeds_when_no_documents_are_indexing(self):
+        result, dataset, session, deleted_signal = self._delete_dataset(has_active_indexing=False)
+
+        assert result is True
+        deleted_signal.send.assert_called_once_with(dataset)
+        session.delete.assert_called_once_with(dataset)
+        session.commit.assert_called_once_with()
+
+    def test_delete_dataset_guard_queries_active_unpaused_documents(self):
+        _, dataset, session, _ = self._delete_dataset(has_active_indexing=False)
+
+        statement = session.scalar.call_args.args[0]
+        compiled = statement.compile()
+        sql = str(compiled)
+
+        assert "EXISTS" in sql
+        assert "documents.dataset_id" in sql
+        # Paused documents must not block deletion: pausing is the escape hatch
+        # for datasets whose indexing is stuck. WAITING documents don't block
+        # either — their queued task no-ops once the dataset rows are gone, and
+        # the console has no pause control for queued documents.
+        assert "documents.is_paused IS NOT true" in sql
+        assert dataset.id in compiled.params.values()
+        status_lists = [value for value in compiled.params.values() if isinstance(value, list)]
+        assert len(status_lists) == 1
+        assert set(status_lists[0]) == {
+            "parsing",
+            "cleaning",
+            "splitting",
+            "indexing",
+        }
 
 
 class TestDatasetCollectionBindingService:


### PR DESCRIPTION
Fixes #38522
Related: #38518

## Summary

`DatasetService.delete_dataset` fires `dataset_was_deleted` and removes the dataset row with no check for in-flight indexing. Deleting a dataset mid-ingest races the running indexing pipeline against `clean_dataset_task`: the pipeline keeps writing segments/chunks/vectors for rows the cleanup just removed, and its long-lived transactions can block the cleanup itself. #38518 reports the fallout at production scale — ~2.4M orphaned `document_segments`, ~830k `child_chunks`, and ~34 GB of orphaned pgvector tables.

## Fix

`delete_dataset` now checks for actively indexing documents before doing anything, and raises a new `DatasetIndexingInProgressError` when found. Both delete endpoints (console and service API) map it to a **409** with a clear message, exactly like the existing `DatasetInUseError` handling on the same endpoints:

```python
if DatasetService._has_documents_indexing(dataset.id, session):
    raise DatasetIndexingInProgressError(...)
```

The guard matches a document when:

- `indexing_status` ∈ `DocumentService._INDEXING_STATUSES` (`parsing` / `cleaning` / `splitting` / `indexing` — the same set the document list uses for its "indexing" display status), **and**
- `is_paused IS NOT true`

Both conditions are deliberate:

- **Paused documents don't block deletion.** Pausing is the escape hatch: if an indexing run is stuck (e.g., crashed worker), the user pauses the document(s) from the console and deletes. Without this exclusion a stuck run would block deletion forever.
- **`waiting` (queued) documents don't block deletion.** A queued task no-ops once the dataset rows are gone (`_document_indexing` loads the dataset first and returns if missing), so queued documents can't produce orphaned writes. Blocking on them would also strand console users — the UI has no pause control for queued documents (the pause button appears only for the four in-flight statuses).

#38522 sketches two options: pause-and-await, or reject with a clear error. This implements the reject option. Pause-and-await inside a synchronous HTTP handler means unbounded blocking of a web worker, and `is_paused` checkpoints are honored by the legacy indexing runner but not by the RAG-pipeline ingestion path that produced #38518 — so awaiting wouldn't reliably close the race anyway. Rejecting closes it at the entry point regardless of ingestion path.

The check-then-delete window (a document *starting* to index between the check and the commit) remains, as acknowledged in the issue; closing it fully needs dataset-level locking across all status-mutating paths and is out of scope here. #38519 (cleanup robustness) complements this guard for anything that slips through.

## Changes

- `services/dataset_service.py` — `_has_documents_indexing` helper + guard in `delete_dataset`
- `services/errors/dataset.py` — `DatasetIndexingInProgressError`
- `controllers/console/datasets/{error,datasets}.py`, `controllers/service_api/dataset/{error,dataset}.py` — 409 mapping on both delete endpoints, service-API OpenAPI docs updated with the new 409 cause
- Frontend: no change needed — the shared fetch layer already toasts non-2xx `message` bodies on this endpoint (same path `dataset_in_use` uses today)

## Testing

- New service-level unit tests: guard raises and does **not** signal/delete when a document is actively indexing; deletion proceeds when documents are paused/completed; guard query shape (in-flight statuses only, `is_paused IS NOT true`, EXISTS on `documents.dataset_id`)
- New controller tests for the 409 mapping: console (unit) and service API (containers integration, mirroring the existing `test_delete_dataset_in_use`)
- `tests/unit_tests/services/test_dataset_service_dataset.py`: 83 passed · `tests/unit_tests/controllers/console/datasets/test_datasets.py`: 71 passed
- `ruff check` / `ruff format`: clean · `pyrefly check` on all changed source files: 0 errors