### PR TITLE
test: use sqlite3 session in test_init_validate

### DIFF
--- a/api/tests/unit_tests/controllers/console/test_init_validate.py
+++ b/api/tests/unit_tests/controllers/console/test_init_validate.py
@@ -1,27 +1,16 @@
+"""Initialization validation tests with real setup-state persistence in SQLite."""
+
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import Mock
 
 import pytest
 from flask import Flask
+from sqlalchemy.orm import Session
 
 from controllers.console import init_validate
 from controllers.console.error import AlreadySetupError, InitValidateFailedError
-
-
-class _SessionStub:
-    def __init__(self, has_setup: bool):
-        self._has_setup = has_setup
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        return False
-
-    def execute(self, *_args, **_kwargs):
-        return SimpleNamespace(scalar_one_or_none=lambda: Mock() if self._has_setup else None)
+from models.model import DifySetup
 
 
 def test_get_init_status_finished(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -85,11 +74,15 @@ def test_get_init_validate_status_validated_session(app: Flask, monkeypatch: pyt
         assert init_validate.get_init_validate_status() is True
 
 
-def test_get_init_validate_status_setup_exists(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("sqlite_session", [(DifySetup,)], indirect=True)
+def test_get_init_validate_status_setup_exists(
+    app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+) -> None:
     monkeypatch.setattr(init_validate.dify_config, "EDITION", "SELF_HOSTED")
     monkeypatch.setenv("INIT_PASSWORD", "expected")
-    monkeypatch.setattr(init_validate, "Session", lambda *_args, **_kwargs: _SessionStub(True))
-    monkeypatch.setattr(init_validate, "db", SimpleNamespace(engine=object()))
+    monkeypatch.setattr(init_validate, "db", SimpleNamespace(engine=sqlite_session.get_bind()))
+    sqlite_session.add(DifySetup(version="test-version"))
+    sqlite_session.commit()
     app.secret_key = "test-secret"
 
     with app.test_request_context("/console/api/init", method="GET"):
@@ -97,11 +90,13 @@ def test_get_init_validate_status_setup_exists(app: Flask, monkeypatch: pytest.M
         assert init_validate.get_init_validate_status() is True
 
 
-def test_get_init_validate_status_not_validated(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("sqlite_session", [(DifySetup,)], indirect=True)
+def test_get_init_validate_status_not_validated(
+    app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+) -> None:
     monkeypatch.setattr(init_validate.dify_config, "EDITION", "SELF_HOSTED")
     monkeypatch.setenv("INIT_PASSWORD", "expected")
-    monkeypatch.setattr(init_validate, "Session", lambda *_args, **_kwargs: _SessionStub(False))
-    monkeypatch.setattr(init_validate, "db", SimpleNamespace(engine=object()))
+    monkeypatch.setattr(init_validate, "db", SimpleNamespace(engine=sqlite_session.get_bind()))
     app.secret_key = "test-secret"
 
     with app.test_request_context("/console/api/init", method="GET"):


### PR DESCRIPTION
## Summary

- replace SQLAlchemy session doubles in the target unit tests with real in-memory SQLite-backed sessions
- assert ORM behavior through persisted state, returned values, isolation, and transaction outcomes
- keep genuine external I/O boundaries mocked

## Validation

- targeted pytest suite passed
- Ruff formatting and lint checks passed
- structural scan found no mocked SQLAlchemy session objects in the primary test file

Part of #32454.