### PR TITLE
test: use sqlite3 session in test_schedule_service

### DIFF
--- a/api/tests/unit_tests/services/test_schedule_service.py
+++ b/api/tests/unit_tests/services/test_schedule_service.py
@@ -5,7 +5,6 @@ from typing import Any
 from unittest.mock import MagicMock, Mock
 
 import pytest
-from sqlalchemy.orm import Session
 
 from core.trigger.constants import TRIGGER_SCHEDULE_NODE_TYPE
 from core.workflow.nodes.trigger_schedule.entities import VisualConfig
@@ -495,11 +494,6 @@ class TestScheduleWithTimezone(unittest.TestCase):
         assert summer_next is not None
         # 10 AM EDT = 14:00 UTC
         assert summer_next.hour == 14
-
-
-@pytest.fixture
-def session_mock() -> MagicMock:
-    return MagicMock(spec=Session)
 
 
 def _workflow(**kwargs: Any) -> Workflow:


### PR DESCRIPTION
## Summary

- remove an unused mocked SQLAlchemy Session fixture from the schedule-service tests
- leave the active scheduling and external-boundary coverage unchanged

## Validation

- targeted pytest suite passed (50 tests)
- Ruff formatting and lint checks passed
- structural session-double scan passed

Part of #32454.