### PR TITLE
test: use sqlite3 session in test_app_dsl_service

### DIFF
--- a/api/tests/unit_tests/services/test_app_dsl_service.py
+++ b/api/tests/unit_tests/services/test_app_dsl_service.py
@@ -1,29 +1,37 @@
 from unittest.mock import Mock
 
 import pytest
+from sqlalchemy.orm import Session
 
 from services.app_dsl_service import AppDslService
 from services.entities.dsl_entities import ImportStatus
 
 
-def test_import_app_rejects_oversized_yaml_content_before_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("sqlite_session", [()], indirect=True)
+def test_import_app_rejects_oversized_yaml_content_before_parsing(
+    monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+) -> None:
     monkeypatch.setattr("services.app_dsl_service.DSL_MAX_SIZE", 3)
-    service = AppDslService(session=Mock())
+    service = AppDslService(session=sqlite_session)
     account = Mock(current_tenant_id="tenant-1")
 
     result = service.import_app(account=account, import_mode="yaml-content", yaml_content="你你")
 
     assert result.status == ImportStatus.FAILED
     assert result.error == "File size exceeds the limit of 10MB"
+    assert not sqlite_session.in_transaction()
 
 
-def test_import_app_rejects_oversized_yaml_url_bytes_before_decode(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("sqlite_session", [()], indirect=True)
+def test_import_app_rejects_oversized_yaml_url_bytes_before_decode(
+    monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+) -> None:
     monkeypatch.setattr("services.app_dsl_service.DSL_MAX_SIZE", 1)
     response = Mock()
     response.raise_for_status.return_value = None
     response.content = b"\xff\xff"
     monkeypatch.setattr("services.app_dsl_service.remote_fetcher.make_request", Mock(return_value=response))
-    service = AppDslService(session=Mock())
+    service = AppDslService(session=sqlite_session)
 
     result = service.import_app(
         account=Mock(current_tenant_id="tenant-1"),
@@ -33,14 +41,18 @@ def test_import_app_rejects_oversized_yaml_url_bytes_before_decode(monkeypatch: 
 
     assert result.status == ImportStatus.FAILED
     assert result.error == "File size exceeds the limit of 10MB"
+    assert not sqlite_session.in_transaction()
 
 
-def test_import_app_returns_decode_error_for_invalid_yaml_url_bytes(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("sqlite_session", [()], indirect=True)
+def test_import_app_returns_decode_error_for_invalid_yaml_url_bytes(
+    monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+) -> None:
     response = Mock()
     response.raise_for_status.return_value = None
     response.content = b"\xff"
     monkeypatch.setattr("services.app_dsl_service.remote_fetcher.make_request", Mock(return_value=response))
-    service = AppDslService(session=Mock())
+    service = AppDslService(session=sqlite_session)
 
     result = service.import_app(
         account=Mock(current_tenant_id="tenant-1"),
@@ -50,3 +62,4 @@ def test_import_app_returns_decode_error_for_invalid_yaml_url_bytes(monkeypatch:
 
     assert result.status == ImportStatus.FAILED
     assert "utf-8" in result.error
+    assert not sqlite_session.in_transaction()


### PR DESCRIPTION
## Summary

- replace all mocked ORM sessions in app-DSL validation paths with real SQLite sessions
- verify early validation exits do not begin database transactions
- retain URL fetching as the external mocked boundary

## Validation

- targeted pytest suite passed (3 tests)
- Ruff formatting and lint checks passed
- structural session-double scan passed

Part of #32454.