### PR TITLE
test: use sqlite3 session in test_extract_thread_messages

### DIFF
--- a/api/tests/unit_tests/core/prompt/test_extract_thread_messages.py
+++ b/api/tests/unit_tests/core/prompt/test_extract_thread_messages.py
@@ -1,9 +1,41 @@
-from unittest.mock import MagicMock
+from datetime import datetime, timedelta
+from decimal import Decimal
 from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
 
 from constants import UUID_NIL
 from core.prompt.utils.extract_thread_messages import extract_thread_messages
 from core.prompt.utils.get_thread_messages_length import get_thread_messages_length
+from models.enums import ConversationFromSource
+from models.model import Message
+
+def _persisted_message(
+    *,
+    message_id: str,
+    conversation_id: str,
+    parent_message_id: str,
+    answer: str,
+    created_at: datetime,
+) -> Message:
+    message = Message(
+        id=message_id,
+        app_id="app-id",
+        conversation_id=conversation_id,
+        query="question",
+        message={"role": "user", "content": "question"},
+        answer=answer,
+        message_unit_price=Decimal("0.0001"),
+        answer_unit_price=Decimal("0.0001"),
+        currency="USD",
+        from_source=ConversationFromSource.API,
+        parent_message_id=parent_message_id,
+        created_at=created_at,
+        updated_at=created_at,
+    )
+    message._inputs = {}
+    return message
 
 
 class MockMessage:
@@ -104,33 +136,64 @@ def test_extract_thread_messages_breaks_when_parent_is_none():
     assert result[0].id == id2
 
 
-def test_get_thread_messages_length_excludes_newly_created_empty_answer():
+@pytest.mark.parametrize("sqlite_session", [(Message,)], indirect=True)
+def test_get_thread_messages_length_excludes_newly_created_empty_answer(sqlite_session: Session):
     id1, id2 = str(uuid4()), str(uuid4())
+    now = datetime.now()
     messages = [
-        MockMessage(id2, id1, answer=""),  # newest generated message should be excluded
-        MockMessage(id1, UUID_NIL, answer="ok"),
+        _persisted_message(
+            message_id=id2,
+            conversation_id="conversation-1",
+            parent_message_id=id1,
+            answer="",
+            created_at=now,
+        ),
+        _persisted_message(
+            message_id=id1,
+            conversation_id="conversation-1",
+            parent_message_id=UUID_NIL,
+            answer="ok",
+            created_at=now - timedelta(seconds=1),
+        ),
+        _persisted_message(
+            message_id=str(uuid4()),
+            conversation_id="other-conversation",
+            parent_message_id=UUID_NIL,
+            answer="unrelated",
+            created_at=now + timedelta(seconds=1),
+        ),
     ]
+    sqlite_session.add_all(messages)
+    sqlite_session.commit()
 
-    session = MagicMock()
-    session.scalars.return_value.all.return_value = messages
-
-    length = get_thread_messages_length("conversation-1", session=session)
+    length = get_thread_messages_length("conversation-1", session=sqlite_session)
 
     assert length == 1
-    session.scalars.assert_called_once()
 
 
-def test_get_thread_messages_length_keeps_non_empty_latest_answer():
+@pytest.mark.parametrize("sqlite_session", [(Message,)], indirect=True)
+def test_get_thread_messages_length_keeps_non_empty_latest_answer(sqlite_session: Session):
     id1, id2 = str(uuid4()), str(uuid4())
+    now = datetime.now()
     messages = [
-        MockMessage(id2, id1, answer="latest-answer"),
-        MockMessage(id1, UUID_NIL, answer="older-answer"),
+        _persisted_message(
+            message_id=id2,
+            conversation_id="conversation-2",
+            parent_message_id=id1,
+            answer="latest-answer",
+            created_at=now,
+        ),
+        _persisted_message(
+            message_id=id1,
+            conversation_id="conversation-2",
+            parent_message_id=UUID_NIL,
+            answer="older-answer",
+            created_at=now - timedelta(seconds=1),
+        ),
     ]
+    sqlite_session.add_all(messages)
+    sqlite_session.commit()
 
-    session = MagicMock()
-    session.scalars.return_value.all.return_value = messages
-
-    length = get_thread_messages_length("conversation-2", session=session)
+    length = get_thread_messages_length("conversation-2", session=sqlite_session)
 
     assert length == 2
-    session.scalars.assert_called_once()

--- a/api/tests/unit_tests/core/prompt/test_extract_thread_messages.py
+++ b/api/tests/unit_tests/core/prompt/test_extract_thread_messages.py
@@ -11,6 +11,7 @@ from core.prompt.utils.get_thread_messages_length import get_thread_messages_len
 from models.enums import ConversationFromSource
 from models.model import Message
 
+
 def _persisted_message(
     *,
     message_id: str,


### PR DESCRIPTION
## Summary

- replace fabricated conversation message query results with persisted SQLite Message rows
- exercise descending creation order, parent threading, empty-answer exclusion, and conversation isolation
- retain the pure in-memory thread extraction cases

## Validation

- targeted pytest suite passed (10 tests)
- Ruff formatting and lint checks passed
- structural session-double scan passed

Part of #32454.