### PR TITLE
fix(web): add hover and focus affordance to node panel title input

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/title-description-input.tsx
+++ b/web/app/components/workflow/nodes/_base/components/title-description-input.tsx
@@ -54,7 +54,8 @@ export const TitleInput = memo(({
       onKeyDown={handleKeyDown}
       className={`
         mr-2 h-7 min-w-0 grow appearance-none rounded-md border border-transparent bg-transparent px-1 system-xl-semibold text-text-primary
-        outline-hidden focus:shadow-xs
+        outline-hidden hover:border-components-input-border-hover hover:bg-components-input-bg-hover
+        focus:border-components-input-border-active focus:bg-components-input-bg-active focus:shadow-xs
       `}
       placeholder={t($ => $['common.addTitle'], { ns: 'workflow' }) || ''}
       onBlur={handleBlur}


### PR DESCRIPTION
## Summary

Fixes #38595

In the workflow node panel, the node title is an always-editable input styled as static text. Its only edit-state cue is `focus:shadow-xs`, which is nearly invisible in dark mode — clicking a node name (e.g. List Operator) gives no visual indication that editing has begun, and hovering gives no hint the title is editable at all.

This change reuses the border/background state tokens from the base Input component (`components-input-border-hover/-active`, `components-input-bg-hover/-active`) on the title input, so it shows a subtle input affordance on hover and a clearly active state while editing. The tokens are defined in both themes, so light mode gets the same (already-legible) treatment.

One file, two class-list lines: `web/app/components/workflow/nodes/_base/components/title-description-input.tsx`.

Note: the title input is shared by all node panels, so every node type gets the same affordance — consistent with the issue's "nodes such as list operators" wording.

## Screenshots

Dark mode, List Operator panel, captured from a local run of this branch.

| State | Before | After |
|-------|--------|-------|
| Resting | ![before-resting](https://raw.githubusercontent.com/rhinocap/dify/assets-38595/before-resting.png) | ![after-resting](https://raw.githubusercontent.com/rhinocap/dify/assets-38595/after-resting.png) |
| Hover | ![before-hover](https://raw.githubusercontent.com/rhinocap/dify/assets-38595/before-hover.png) | ![after-hover](https://raw.githubusercontent.com/rhinocap/dify/assets-38595/after-hover.png) |
| Editing (focus) | ![before-focus](https://raw.githubusercontent.com/rhinocap/dify/assets-38595/before-focus.png) | ![after-focus](https://raw.githubusercontent.com/rhinocap/dify/assets-38595/after-focus.png) |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Frontend only: ran `eslint` on the changed file and a full `tsc --noEmit` — both clean. No behavior change, styling only, so no new test.

From Claude Code
