### PR TITLE
fix(agent-v2): restore keyboard access to row actions

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/common/configurable-item.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/common/configurable-item.tsx
@@ -24,7 +24,7 @@ export function ConfigureSectionConfigurableItem({
   const hasBadge = badge !== undefined && badge !== null
 
   return (
-    <div className="group flex min-h-8 items-center gap-1 overflow-hidden rounded-lg border-[0.5px] border-components-panel-border-subtle bg-components-panel-on-panel-item-bg py-1.5 pr-1.5 pl-2 shadow-xs shadow-shadow-shadow-3 focus-within:border-components-panel-border focus-within:bg-components-panel-on-panel-item-bg-hover focus-within:shadow-sm hover:border-components-panel-border hover:bg-components-panel-on-panel-item-bg-hover hover:shadow-sm">
+    <div className="group relative flex min-h-8 items-center gap-1 overflow-hidden rounded-lg border-[0.5px] border-components-panel-border-subtle bg-components-panel-on-panel-item-bg py-1.5 pr-1.5 pl-2 shadow-xs shadow-shadow-shadow-3 focus-within:border-components-panel-border focus-within:bg-components-panel-on-panel-item-bg-hover focus-within:shadow-sm hover:border-components-panel-border hover:bg-components-panel-on-panel-item-bg-hover hover:shadow-sm">
       <div className="flex min-w-0 flex-1 items-center gap-2 py-0.5 pr-1">
         {icon}
         <span className="min-w-0 truncate system-sm-medium text-text-primary">
@@ -32,7 +32,7 @@ export function ConfigureSectionConfigurableItem({
         </span>
       </div>
       {!readOnly && (
-        <div className="hidden shrink-0 items-center gap-1 group-focus-within:flex group-hover:flex">
+        <div className="pointer-events-none absolute top-1/2 right-1.5 flex -translate-y-1/2 items-center gap-1 bg-components-panel-on-panel-item-bg-hover opacity-0 group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100">
           <button
             type="button"
             aria-label={editAriaLabel}
@@ -52,7 +52,7 @@ export function ConfigureSectionConfigurableItem({
         </div>
       )}
       {hasBadge && (
-        <span className="shrink-0 rounded-[5px] border border-divider-deep bg-components-badge-bg-dimm px-1 py-0.5 system-2xs-medium-uppercase text-text-tertiary group-focus-within:hidden group-hover:hidden">
+        <span className="shrink-0 rounded-[5px] border border-divider-deep bg-components-badge-bg-dimm px-1 py-0.5 system-2xs-medium-uppercase text-text-tertiary group-focus-within:opacity-0 group-hover:opacity-0">
           {badge}
         </span>
       )}

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/knowledge/__tests__/index.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/knowledge/__tests__/index.spec.tsx
@@ -141,30 +141,6 @@ describe('AgentKnowledgeRetrieval', () => {
         name: 'agentV2.agentDetail.configure.knowledgeRetrieval.remove:{"name":"agentV2.agentDetail.configure.knowledgeRetrieval.retrievalOne"}',
       })).not.toBeInTheDocument()
     })
-
-    it('should keep row actions out of layout until hover or focus', () => {
-      renderKnowledgeRetrieval()
-
-      const editButton = screen.getByRole('button', {
-        name: 'agentV2.agentDetail.configure.knowledgeRetrieval.edit:{"name":"agentV2.agentDetail.configure.knowledgeRetrieval.retrievalOne"}',
-      })
-      const removeButton = screen.getByRole('button', {
-        name: 'agentV2.agentDetail.configure.knowledgeRetrieval.remove:{"name":"agentV2.agentDetail.configure.knowledgeRetrieval.retrievalOne"}',
-      })
-      const actionGroup = editButton.parentElement
-
-      expect(actionGroup).toHaveClass('hidden')
-      expect(actionGroup).toHaveClass(
-        'group-focus-within:flex',
-        'group-hover:flex',
-      )
-      expect(removeButton).toHaveClass(
-        'hover:bg-state-destructive-hover',
-        'hover:text-text-destructive',
-        'focus-visible:bg-state-destructive-hover',
-        'focus-visible:text-text-destructive',
-      )
-    })
   })
 
   describe('User Interactions', () => {


### PR DESCRIPTION
## Summary

- keep configurable row actions in the keyboard tab order while visually hidden
- reveal actions on hover or focus without reserving layout space
- remove the class-level test that encoded the inaccessible display behavior

## Testing

- pnpm -C web test features/agent-v2/agent-detail/configure/components/orchestrate/knowledge/__tests__/index.spec.tsx --run
- pnpm -C web exec eslint features/agent-v2/agent-detail/configure/components/orchestrate/common/configurable-item.tsx features/agent-v2/agent-detail/configure/components/orchestrate/knowledge/__tests__/index.spec.tsx
- git diff --check