### PR TITLE
fix(web): improve marketplace install dialog accessibility

### DIFF
--- a/web/app/components/plugins/install-plugin/install-from-marketplace/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/install-plugin/install-from-marketplace/__tests__/index.spec.tsx
@@ -198,6 +198,20 @@ describe('InstallFromMarketplace', () => {
       expect(screen.getByText('plugin.installModal.installPlugin')).toBeInTheDocument()
     })
 
+    it('should expose the current step title as the dialog name', () => {
+      render(<InstallFromMarketplace {...defaultProps} />)
+
+      expect(screen.getByRole('dialog', { name: 'plugin.installModal.installPlugin' })).toBeInTheDocument()
+    })
+
+    it('should initially focus the safe cancel action', async () => {
+      render(<InstallFromMarketplace {...defaultProps} />)
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus()
+      })
+    })
+
     it('should render with bundle step when isBundle is true', () => {
       const dependencies = createMockDependencies()
       render(
@@ -293,7 +307,7 @@ describe('InstallFromMarketplace', () => {
       fireEvent.click(screen.getByTestId('install-fail-btn'))
 
       await waitFor(() => {
-        expect(screen.getByText('plugin.installModal.installFailed')).toBeInTheDocument()
+        expect(screen.getByRole('dialog', { name: 'plugin.installModal.installFailed' })).toBeInTheDocument()
       })
     })
   })

--- a/web/app/components/plugins/install-plugin/install-from-marketplace/index.tsx
+++ b/web/app/components/plugins/install-plugin/install-from-marketplace/index.tsx
@@ -2,7 +2,7 @@
 
 import type { Dependency, Plugin, PluginCategoryEnum, PluginManifestInMarket } from '../../types'
 import { cn } from '@langgenius/dify-ui/cn'
-import { Dialog, DialogCloseButton, DialogContent } from '@langgenius/dify-ui/dialog'
+import { Dialog, DialogCloseButton, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
 import * as React from 'react'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -84,12 +84,10 @@ const InstallFromMarketplace: React.FC<InstallFromMarketplaceProps> = ({
         backdropProps={{ forceRender: true }}
         className={cn('w-[560px] max-w-none! overflow-hidden! text-left align-middle', cn(modalClassName, 'shadows-shadow-xl flex max-h-[calc(100dvh-48px)] min-w-[560px] flex-col items-start rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg p-0'))}
       >
-        <DialogCloseButton />
-
         <div className="flex items-start gap-2 self-stretch pt-6 pr-14 pb-3 pl-6">
-          <div className="self-stretch title-2xl-semi-bold text-text-primary">
+          <DialogTitle className="self-stretch title-2xl-semi-bold text-text-primary">
             {getTitle()}
-          </div>
+          </DialogTitle>
         </div>
         {
           isBundle
@@ -134,6 +132,7 @@ const InstallFromMarketplace: React.FC<InstallFromMarketplaceProps> = ({
                 </>
               )
         }
+        <DialogCloseButton />
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
## Summary

- Expose the current installation step through DialogTitle so the dialog has an accessible name.
- Keep the close control in the focus loop while allowing the first step-owned safe action to receive initial focus.
- Cover the accessible name, initial focus, and failed-state title with focused tests.

## Root cause

The visible heading was a plain div, so assistive technology could not derive the dialog name from it. The close button also appeared before the step content in DOM order, causing the focus manager to select it as the default initial focus target.

## Validation

- pnpm --dir web test -- app/components/plugins/install-plugin/install-from-marketplace/__tests__/index.spec.tsx (64 tests passed)
- pnpm --dir web type-check
- git diff --check