### PR TITLE
fix: eagerly validate conversation on service-api and explore chat endpoints

### DIFF
--- a/api/controllers/console/explore/completion.py
+++ b/api/controllers/console/explore/completion.py
@@ -36,6 +36,7 @@ from models import Account
 from models.model import AppMode, InstalledApp
 from services.app_generate_service import AppGenerateService
 from services.app_task_service import AppTaskService
+from services.conversation_service import ConversationService
 from services.errors.llm import InvokeRateLimitError
 
 from .. import console_ns
@@ -188,6 +189,15 @@ class ChatApi(InstalledAppResource):
         db.session.commit()
 
         try:
+            # Eagerly validate conversation to avoid hanging on invalid conversation_id
+            if payload.conversation_id:
+                ConversationService.get_conversation(
+                    app_model=app_model,
+                    conversation_id=payload.conversation_id,
+                    user=current_user,
+                    session=db.session(),
+                )
+
             response = AppGenerateService.generate(
                 session=session,
                 app_model=app_model,

--- a/api/controllers/service_api/app/completion.py
+++ b/api/controllers/service_api/app/completion.py
@@ -40,12 +40,14 @@ from core.errors.error import (
     QuotaExceededError,
 )
 from core.helper.trace_id_helper import get_external_trace_id, get_trace_session_id, omit_trace_session_id_from_payload
+from extensions.ext_database import db
 from graphon.model_runtime.errors.invoke import InvokeError
 from libs import helper
 from libs.helper import UUIDStrOrEmpty
 from models.model import App, AppMode, EndUser
 from services.app_generate_service import AppGenerateService
 from services.app_task_service import AppTaskService
+from services.conversation_service import ConversationService
 from services.errors.app import IsDraftWorkflowError, WorkflowIdFormatError, WorkflowNotFoundError
 from services.errors.llm import InvokeRateLimitError
 
@@ -377,6 +379,15 @@ class ChatApi(Resource):
         streaming = _resolve_agent_app_streaming(app_mode=app_mode, response_mode=payload.response_mode)
 
         try:
+            # Eagerly validate conversation to avoid hanging on invalid conversation_id
+            if payload.conversation_id:
+                ConversationService.get_conversation(
+                    app_model=app_model,
+                    conversation_id=payload.conversation_id,
+                    user=end_user,
+                    session=db.session(),
+                )
+
             response = AppGenerateService.generate(
                 session=session,
                 app_model=app_model,

--- a/api/tests/unit_tests/controllers/console/explore/test_completion.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_completion.py
@@ -1,3 +1,4 @@
+import uuid
 from inspect import unwrap
 from unittest.mock import MagicMock, PropertyMock, patch
 
@@ -309,6 +310,37 @@ class TestChatApi:
         ):
             with pytest.raises(completion_module.NotFound):
                 method(api, MagicMock(), user, chat_app)
+
+    def test_invalid_conversation_id_fails_fast_as_not_found(self, app: Flask, chat_app, user) -> None:
+        # A nonexistent conversation_id must fail fast as 404, before the streaming
+        # generator is created. Previously the lookup only ran inside the generator,
+        # so an invalid id surfaced as a hang instead of a clean error.
+        payload_patch = patch.object(
+            type(completion_module.console_ns),
+            "payload",
+            new_callable=PropertyMock,
+            return_value={"inputs": {}, "query": "hi", "conversation_id": str(uuid.uuid4())},
+        )
+        generate_mock = MagicMock(return_value={"ok": True})
+
+        api = completion_module.ChatApi()
+        method = unwrap(api.post)
+
+        with (
+            app.test_request_context("/", json={}),
+            payload_patch,
+            patch.object(
+                completion_module.ConversationService,
+                "get_conversation",
+                side_effect=completion_module.services.errors.conversation.ConversationNotExistsError(),
+            ),
+            patch.object(completion_module.AppGenerateService, "generate", generate_mock),
+        ):
+            with pytest.raises(completion_module.NotFound):
+                method(api, MagicMock(), user, chat_app)
+
+        # The lookup must run before generation, so the generator is never started.
+        generate_mock.assert_not_called()
 
     def test_app_unavailable_chat(self, app: Flask, chat_app, user, payload_patch):
         api = completion_module.ChatApi()

--- a/api/tests/unit_tests/controllers/service_api/app/test_completion.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_completion.py
@@ -555,9 +555,7 @@ class TestChatApiController:
             with pytest.raises(AgentNotPublishedError):
                 handler(api, session=Mock(), app_model=app_model, end_user=end_user)
 
-    def test_invalid_conversation_id_fails_fast_as_not_found(
-        self, app: Flask, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_invalid_conversation_id_fails_fast_as_not_found(self, app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
         # A well-formed but nonexistent conversation_id must fail fast as 404, before the
         # streaming generator is created. Previously the lookup only ran inside the generator,
         # so an invalid id surfaced as a hang instead of a clean error.

--- a/api/tests/unit_tests/controllers/service_api/app/test_completion.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_completion.py
@@ -42,6 +42,7 @@ from graphon.model_runtime.errors.invoke import InvokeError
 from models.model import App, AppMode, EndUser
 from services.app_generate_service import AppGenerateService
 from services.app_task_service import AppTaskService
+from services.conversation_service import ConversationService
 from services.errors.app import IsDraftWorkflowError, WorkflowIdFormatError, WorkflowNotFoundError
 from services.errors.conversation import ConversationNotExistsError
 from services.errors.llm import InvokeRateLimitError
@@ -553,6 +554,37 @@ class TestChatApiController:
         with app.test_request_context("/chat-messages", method="POST", json={"inputs": {}, "query": "hi"}):
             with pytest.raises(AgentNotPublishedError):
                 handler(api, session=Mock(), app_model=app_model, end_user=end_user)
+
+    def test_invalid_conversation_id_fails_fast_as_not_found(
+        self, app: Flask, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A well-formed but nonexistent conversation_id must fail fast as 404, before the
+        # streaming generator is created. Previously the lookup only ran inside the generator,
+        # so an invalid id surfaced as a hang instead of a clean error.
+        monkeypatch.setattr(
+            ConversationService,
+            "get_conversation",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(ConversationNotExistsError()),
+        )
+
+        generate_mock = Mock(return_value={"text": "unused"})
+        monkeypatch.setattr(AppGenerateService, "generate", generate_mock)
+
+        api = ChatApi()
+        handler = unwrap(api.post)
+        app_model = SimpleNamespace(mode=AppMode.CHAT.value, id="app-1")
+        end_user = SimpleNamespace()
+
+        with app.test_request_context(
+            "/chat-messages",
+            method="POST",
+            json={"inputs": {}, "query": "hi", "conversation_id": str(uuid.uuid4())},
+        ):
+            with pytest.raises(NotFound):
+                handler(api, session=Mock(), app_model=app_model, end_user=end_user)
+
+        # The lookup must run before generation, so the generator is never started.
+        generate_mock.assert_not_called()
 
 
 class TestChatStopApiController:


### PR DESCRIPTION
## Summary

Follow-up to #37224, which fixed the "hang on non-existing conversation_id" bug (#37197) on the web chat-messages endpoint. The merged commit (`31a50a3b20`) only changed `controllers/web/completion.py`, although its description also listed the Service API and console endpoints. As a result the same hang still reproduces on two other chat entry points:

- `controllers/service_api/app/completion.py` → `ChatApi`
- `controllers/console/explore/completion.py` → `ChatApi`

Both pass a user-supplied `conversation_id` straight into the streaming generator, where `ConversationNotExistsError` is raised lazily — after the controller's `try/except` has already returned the SSE response — so an invalid id hangs on ping events instead of returning `404`.

This adds the same eager `ConversationService.get_conversation()` pre-check before `AppGenerateService.generate()` on both endpoints. The lookup is identical to the one the generate pipeline already runs at entry (`core/app/apps/chat/app_generator.py` — same `app_model` / `user` / `session=db.session()` arguments), so valid conversations are unaffected; it only moves the existing check earlier so the error surfaces synchronously and is mapped to `404`.

`controllers/console/app/completion.py` (the debugger `ChatMessageApi`) was also named in #37224 but routes through `_create_chat_message`, which already validates the id for AGENT apps and uses a different error-mapping path; it's left as a separate follow-up (tracked in #38800) to keep this change focused and low-risk.

Fixes #38800

## Screenshots

N/A — backend error-handling change (an invalid `conversation_id` now returns `404` instead of hanging on SSE ping events).

## Test plan

- Added `test_invalid_conversation_id_fails_fast_as_not_found` to both endpoints' unit tests: an invalid `conversation_id` returns `404`, and `AppGenerateService.generate` is never reached (`assert_not_called`).
- Existing behavior is untouched: the check is guarded by `if payload.conversation_id:`, so the no-id and valid-id paths are unchanged.
- Ran locally on the touched files: `ruff check` clean; both controller test suites pass (`74 passed`). I did not run the full `make type-check` locally; CI will cover it.

## Checklist

- [ ] This change requires a documentation update
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Claude Code
