### PR TITLE
fix(api): backport inner RBAC request timeout to 1.15.0-fix.10

### DIFF
--- a/api/configs/enterprise/__init__.py
+++ b/api/configs/enterprise/__init__.py
@@ -34,6 +34,12 @@ class EnterpriseFeatureConfig(BaseSettings):
         default=False,
     )
 
+    ENTERPRISE_RBAC_REQUEST_TIMEOUT: int = Field(
+        ge=1,
+        description="Maximum timeout in seconds for inner RBAC requests.",
+        default=30,
+    )
+
 
 class EnterpriseTelemetryConfig(BaseSettings):
     """

--- a/api/services/enterprise/rbac_service.py
+++ b/api/services/enterprise/rbac_service.py
@@ -745,6 +745,7 @@ def _inner_call(
         account_id=account_id,
         json=json,
         params=params,
+        timeout=dify_config.ENTERPRISE_RBAC_REQUEST_TIMEOUT,
     )
 
 


### PR DESCRIPTION
## What

Cherry-picks #38150 (`0d5f43520c`) onto the `hotfix/1.15.0-fix.10` line.

## Why

On this hotfix branch, `_inner_call` does not pass a `timeout` to `send_inner_rbac_request`, so httpx falls back to its **5s default** read timeout. The enterprise RBAC `/inner/api/rbac/my-permissions` handler regularly takes >5s, so requests are cut at ~5s:

- dify-api raises `httpx.ReadTimeout` on `GET /console/api/workspaces/current/rbac/my-permissions`, 500ing the console on workspace load.
- The RBAC service logs a paired `context canceled` (client dropped the connection) at `latency_ms` 5001–5002 — the httpx 5s default firing.

`main` already carries this fix; it was never backported to the hotfix line.

## Change

`_inner_call` now passes `timeout=dify_config.ENTERPRISE_RBAC_REQUEST_TIMEOUT` (default 30s), pulling in the `ENTERPRISE_RBAC_REQUEST_TIMEOUT` config field.

## Note

This raises the client cap to 30s and stops the 500s. The underlying RBAC `my-permissions` slowness (>5s per workspace load) is a separate upstream perf issue in dify-enterprise and should be tracked independently.