### PR TITLE
fix: prevent chat attachments from scrolling out of view

### DIFF
--- a/web/app/components/base/chat/chat/chat-input-area/index.tsx
+++ b/web/app/components/base/chat/chat/chat-input-area/index.tsx
@@ -309,8 +309,10 @@ const ChatInputArea = ({
           disabled && 'pointer-events-none border-components-panel-border opacity-50 shadow-none',
         )}
       >
-        <div className="relative max-h-[158px] overflow-x-hidden overflow-y-auto px-[9px] pt-[9px]">
+        <div className="px-[9px] pt-[9px]">
           <FileListInChatInput fileConfig={visionConfig!} />
+        </div>
+        <div className="relative max-h-[158px] overflow-x-hidden overflow-y-auto px-[9px]">
           <div ref={wrapperRef} className="flex items-center justify-between">
             <div className="relative flex w-full grow items-center">
               <div
@@ -356,7 +358,9 @@ const ChatInputArea = ({
             </div>
             {!isMultipleLine && operation}
           </div>
-          {showVoiceInput && speechToTextTarget && (
+        </div>
+        {showVoiceInput && speechToTextTarget && (
+          <div className="px-[9px]">
             <VoiceInput
               ref={voiceInputRef}
               target={speechToTextTarget}
@@ -366,8 +370,8 @@ const ChatInputArea = ({
               onError={handleVoiceInputError}
               onStartError={handleVoiceInputStartError}
             />
-          )}
-        </div>
+          </div>
+        )}
         {isMultipleLine && <div className="px-[9px]">{operation}</div>}
       </div>
       {shouldShowFooterNotice && (


### PR DESCRIPTION
## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
