### PR TITLE
fix(web): make external-service sync effects pending-safe on cold caches

### DIFF
--- a/web/context/__tests__/amplitude-identity-sync.spec.ts
+++ b/web/context/__tests__/amplitude-identity-sync.spec.ts
@@ -1,0 +1,189 @@
+import type { GetAccountProfileResponse } from '@dify/contracts/api/console/account/types.gen'
+import { QueryClient } from '@tanstack/react-query'
+import { createStore } from 'jotai'
+import { queryClientAtom } from 'jotai-tanstack-query'
+import { setUserId, setUserProperties } from '@/app/components/base/amplitude'
+import { flushRegistrationSuccess } from '@/app/components/base/amplitude/registration-tracking'
+import { amplitudeIdentitySyncAtom } from '../amplitude-identity-sync'
+
+type ProfileQueryData = {
+  profile: GetAccountProfileResponse
+  meta: {
+    currentVersion: string | null
+    currentEnv: string | null
+  }
+}
+
+const profileQueryState = vi.hoisted(() => {
+  const state = {
+    resolve: (_value: unknown) => {},
+    queryFn: () =>
+      new Promise<unknown>((resolve) => {
+        state.resolve = resolve
+      }),
+  }
+  return state
+})
+
+const mockCurrentWorkspaceResponse = vi.hoisted(() => ({
+  id: 'workspace-1',
+  name: 'Workspace',
+  plan: 'sandbox',
+  status: 'normal',
+  created_at: 1704067200,
+  role: 'editor',
+  trial_credits: 200,
+  trial_credits_used: 0,
+  next_credit_reset_date: 1706745600,
+  custom_config: {},
+}))
+
+vi.mock('@/features/account-profile/client', () => ({
+  userProfileQueryOptions: () => ({
+    queryKey: ['user-profile'],
+    queryFn: profileQueryState.queryFn,
+  }),
+}))
+
+vi.mock('@/service/client', () => ({
+  consoleQuery: {
+    workspaces: {
+      current: {
+        post: {
+          key: () => ['current-workspace'],
+          queryOptions: (options: {
+            select?: (workspace?: typeof mockCurrentWorkspaceResponse) => unknown
+          }) => ({
+            queryKey: ['current-workspace'],
+            queryFn: async () => mockCurrentWorkspaceResponse,
+            ...options,
+          }),
+        },
+      },
+    },
+  },
+}))
+
+vi.mock('@/app/components/base/amplitude', () => ({
+  setUserId: vi.fn(),
+  setUserProperties: vi.fn(),
+}))
+
+vi.mock('@/app/components/base/amplitude/registration-tracking', () => ({
+  flushRegistrationSuccess: vi.fn(),
+}))
+
+function createProfileQueryData(overrides: Partial<GetAccountProfileResponse> = {}): ProfileQueryData {
+  return {
+    profile: {
+      id: 'user-1',
+      name: 'User',
+      email: 'user@example.com',
+      avatar: '',
+      avatar_url: '',
+      is_password_set: true,
+      ...overrides,
+    } as GetAccountProfileResponse,
+    meta: {
+      currentVersion: '1.0.0',
+      currentEnv: 'cloud',
+    },
+  }
+}
+
+function createTestStore() {
+  const store = createStore()
+  store.set(
+    queryClientAtom,
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    }),
+  )
+  return store
+}
+
+async function flushMicrotasks() {
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0)
+  })
+}
+
+// Regression for langgenius/dify#38840: the effect used to read a
+// resolved-suspense atom, which throws while the profile query is pending
+// (cold cache when the server-side prefetch is skipped).
+describe('amplitudeIdentitySyncAtom', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('cold profile cache', () => {
+    it('should not throw and should skip sync while the profile query is pending', async () => {
+      const store = createTestStore()
+
+      expect(() => store.sub(amplitudeIdentitySyncAtom, () => {})).not.toThrow()
+      await flushMicrotasks()
+
+      expect(setUserId).not.toHaveBeenCalled()
+      expect(setUserProperties).not.toHaveBeenCalled()
+      expect(flushRegistrationSuccess).not.toHaveBeenCalled()
+    })
+
+    it('should sync identity when the pending profile query resolves', async () => {
+      const store = createTestStore()
+      store.sub(amplitudeIdentitySyncAtom, () => {})
+      await flushMicrotasks()
+
+      profileQueryState.resolve(createProfileQueryData())
+
+      await vi.waitFor(() => {
+        expect(setUserId).toHaveBeenCalledWith('user@example.com')
+      })
+      expect(setUserProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'user@example.com',
+          workspace_id: 'workspace-1',
+          workspace_role: 'editor',
+        }),
+      )
+      expect(flushRegistrationSuccess).toHaveBeenCalledTimes(1)
+    })
+
+    it('should skip sync when the resolved profile has no id', async () => {
+      const store = createTestStore()
+      store.sub(amplitudeIdentitySyncAtom, () => {})
+      await flushMicrotasks()
+
+      profileQueryState.resolve(createProfileQueryData({ id: '', email: '', name: '' }))
+      await flushMicrotasks()
+
+      expect(setUserId).not.toHaveBeenCalled()
+      expect(setUserProperties).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('warm profile cache', () => {
+    it('should sync identity when the profile query is already cached', async () => {
+      const store = createStore()
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: false,
+            staleTime: Number.POSITIVE_INFINITY,
+          },
+        },
+      })
+      queryClient.setQueryData(['user-profile'], createProfileQueryData())
+      store.set(queryClientAtom, queryClient)
+
+      store.sub(amplitudeIdentitySyncAtom, () => {})
+
+      await vi.waitFor(() => {
+        expect(setUserId).toHaveBeenCalledWith('user@example.com')
+      })
+    })
+  })
+})

--- a/web/context/__tests__/amplitude-identity-sync.spec.ts
+++ b/web/context/__tests__/amplitude-identity-sync.spec.ts
@@ -114,9 +114,7 @@ async function flushAsync() {
   })
 }
 
-// Regression for langgenius/dify#38840: the effect used to read a
-// resolved-suspense atom, which throws while the profile query is pending
-// (cold cache when the server-side prefetch is skipped).
+// Regression for langgenius/dify#38840: reading a resolved-suspense atom throws while pending.
 describe('amplitudeIdentitySyncAtom', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/web/context/__tests__/amplitude-identity-sync.spec.ts
+++ b/web/context/__tests__/amplitude-identity-sync.spec.ts
@@ -73,7 +73,9 @@ vi.mock('@/app/components/base/amplitude/registration-tracking', () => ({
   flushRegistrationSuccess: vi.fn(),
 }))
 
-function createProfileQueryData(overrides: Partial<GetAccountProfileResponse> = {}): ProfileQueryData {
+function createProfileQueryData(
+  overrides: Partial<GetAccountProfileResponse> = {},
+): ProfileQueryData {
   return {
     profile: {
       id: 'user-1',
@@ -209,7 +211,10 @@ describe('amplitudeIdentitySyncAtom', () => {
       await flushAsync()
       const settledCallCount = vi.mocked(setUserId).mock.calls.length
 
-      queryClient.setQueryData(['user-profile'], createProfileQueryData({ avatar: 'changed-avatar' }))
+      queryClient.setQueryData(
+        ['user-profile'],
+        createProfileQueryData({ avatar: 'changed-avatar' }),
+      )
       await flushAsync()
 
       expect(setUserId).toHaveBeenCalledTimes(settledCallCount)

--- a/web/context/__tests__/amplitude-identity-sync.spec.ts
+++ b/web/context/__tests__/amplitude-identity-sync.spec.ts
@@ -106,7 +106,7 @@ function createTestStore() {
   return store
 }
 
-async function flushMicrotasks() {
+async function flushAsync() {
   await new Promise((resolve) => {
     setTimeout(resolve, 0)
   })
@@ -125,7 +125,7 @@ describe('amplitudeIdentitySyncAtom', () => {
       const store = createTestStore()
 
       expect(() => store.sub(amplitudeIdentitySyncAtom, () => {})).not.toThrow()
-      await flushMicrotasks()
+      await flushAsync()
 
       expect(setUserId).not.toHaveBeenCalled()
       expect(setUserProperties).not.toHaveBeenCalled()
@@ -135,7 +135,7 @@ describe('amplitudeIdentitySyncAtom', () => {
     it('should sync identity when the pending profile query resolves', async () => {
       const store = createTestStore()
       store.sub(amplitudeIdentitySyncAtom, () => {})
-      await flushMicrotasks()
+      await flushAsync()
 
       profileQueryState.resolve(createProfileQueryData())
 
@@ -155,10 +155,10 @@ describe('amplitudeIdentitySyncAtom', () => {
     it('should skip sync when the resolved profile has no id', async () => {
       const store = createTestStore()
       store.sub(amplitudeIdentitySyncAtom, () => {})
-      await flushMicrotasks()
+      await flushAsync()
 
       profileQueryState.resolve(createProfileQueryData({ id: '', email: '', name: '' }))
-      await flushMicrotasks()
+      await flushAsync()
 
       expect(setUserId).not.toHaveBeenCalled()
       expect(setUserProperties).not.toHaveBeenCalled()
@@ -184,6 +184,36 @@ describe('amplitudeIdentitySyncAtom', () => {
       await vi.waitFor(() => {
         expect(setUserId).toHaveBeenCalledWith('user@example.com')
       })
+    })
+
+    it('should not re-sync identity when the effect re-runs with the same profile', async () => {
+      const store = createStore()
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: false,
+            staleTime: Number.POSITIVE_INFINITY,
+          },
+        },
+      })
+      queryClient.setQueryData(['user-profile'], createProfileQueryData())
+      queryClient.setQueryData(['current-workspace'], mockCurrentWorkspaceResponse)
+      store.set(queryClientAtom, queryClient)
+
+      store.sub(amplitudeIdentitySyncAtom, () => {})
+      await vi.waitFor(() => {
+        expect(setUserProperties).toHaveBeenCalledWith(
+          expect.objectContaining({ workspace_id: 'workspace-1' }),
+        )
+      })
+      await flushAsync()
+      const settledCallCount = vi.mocked(setUserId).mock.calls.length
+
+      queryClient.setQueryData(['user-profile'], createProfileQueryData({ avatar: 'changed-avatar' }))
+      await flushAsync()
+
+      expect(setUserId).toHaveBeenCalledTimes(settledCallCount)
+      expect(setUserProperties).toHaveBeenCalledTimes(settledCallCount)
     })
   })
 })

--- a/web/context/__tests__/zendesk-conversation-sync.spec.ts
+++ b/web/context/__tests__/zendesk-conversation-sync.spec.ts
@@ -1,0 +1,235 @@
+import type { GetAccountProfileResponse } from '@dify/contracts/api/console/account/types.gen'
+import { QueryClient } from '@tanstack/react-query'
+import { createStore } from 'jotai'
+import { queryClientAtom } from 'jotai-tanstack-query'
+import { setZendeskConversationFields } from '@/app/components/base/zendesk/utils'
+import { ZENDESK_FIELD_IDS } from '@/config'
+import { zendeskConversationSyncAtom } from '../zendesk-conversation-sync'
+
+type ProfileQueryData = {
+  profile: GetAccountProfileResponse
+  meta: {
+    currentVersion: string | null
+    currentEnv: string | null
+  }
+}
+
+const profileQueryState = vi.hoisted(() => {
+  const state = {
+    resolve: (_value: unknown) => {},
+    queryFn: () =>
+      new Promise<unknown>((resolve) => {
+        state.resolve = resolve
+      }),
+  }
+  return state
+})
+
+const mockCurrentWorkspaceQueryState = vi.hoisted(() => ({
+  isPending: true,
+}))
+
+const mockCurrentWorkspaceResponse = vi.hoisted(() => ({
+  id: 'workspace-1',
+  name: 'Workspace',
+  plan: 'sandbox',
+  status: 'normal',
+  created_at: 1704067200,
+  role: 'editor',
+  trial_credits: 200,
+  trial_credits_used: 0,
+  next_credit_reset_date: 1706745600,
+  custom_config: {},
+}))
+
+const mockSystemFeaturesState = vi.hoisted(() => ({
+  data: {
+    branding: {
+      enabled: false,
+    },
+  },
+}))
+
+const mockLangGeniusVersionState = vi.hoisted(() => ({
+  data: {
+    version: '1.0.1',
+    release_date: '',
+    release_notes: '',
+    features: {
+      can_replace_logo: false,
+      model_load_balancing_enabled: false,
+    },
+    can_auto_update: false,
+  },
+}))
+
+vi.mock('@/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/config')>()
+  return {
+    ...actual,
+    ZENDESK_FIELD_IDS: {
+      ENVIRONMENT: 'environment-field',
+      VERSION: 'version-field',
+      EMAIL: 'email-field',
+      WORKSPACE_ID: 'workspace-id-field',
+    },
+  }
+})
+
+vi.mock('@/features/account-profile/client', () => ({
+  userProfileQueryOptions: () => ({
+    queryKey: ['user-profile'],
+    queryFn: profileQueryState.queryFn,
+  }),
+}))
+
+vi.mock('@/features/system-features/client', () => ({
+  systemFeaturesQueryOptions: () => ({
+    queryKey: ['system-features'],
+    queryFn: async () => mockSystemFeaturesState.data,
+  }),
+}))
+
+vi.mock('@/service/client', () => ({
+  consoleQuery: {
+    workspaces: {
+      current: {
+        post: {
+          key: () => ['current-workspace'],
+          queryOptions: (options: {
+            select?: (workspace?: typeof mockCurrentWorkspaceResponse) => unknown
+          }) => ({
+            queryKey: ['current-workspace'],
+            queryFn: async () => {
+              if (mockCurrentWorkspaceQueryState.isPending) return new Promise(() => {})
+
+              return mockCurrentWorkspaceResponse
+            },
+            ...options,
+          }),
+        },
+      },
+    },
+    version: {
+      get: {
+        queryOptions: (options: {
+          enabled?: boolean
+          input?: {
+            query: {
+              current_version: string
+            }
+          }
+        }) => ({
+          queryKey: ['version', options.input?.query.current_version],
+          queryFn: async () => mockLangGeniusVersionState.data,
+          ...options,
+        }),
+      },
+    },
+  },
+}))
+
+vi.mock('@/app/components/base/zendesk/utils', () => ({
+  setZendeskConversationFields: vi.fn(),
+}))
+
+function createProfileQueryData(): ProfileQueryData {
+  return {
+    profile: {
+      id: 'user-1',
+      name: 'User',
+      email: 'user@example.com',
+      avatar: '',
+      avatar_url: '',
+      is_password_set: true,
+    } as GetAccountProfileResponse,
+    meta: {
+      currentVersion: '1.0.0',
+      currentEnv: 'cloud',
+    },
+  }
+}
+
+function createTestStore() {
+  const store = createStore()
+  store.set(
+    queryClientAtom,
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    }),
+  )
+  return store
+}
+
+async function flushMicrotasks() {
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0)
+  })
+}
+
+// Regression for langgenius/dify#38840: the effect used to read
+// resolved-suspense atoms (profile directly, and meta/system-features via
+// langGeniusVersionInfoAtom), which throw while their queries are pending.
+describe('zendeskConversationSyncAtom', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCurrentWorkspaceQueryState.isPending = true
+  })
+
+  describe('cold caches', () => {
+    it('should not throw and should skip all field syncs while queries are pending', async () => {
+      const store = createTestStore()
+
+      expect(() => store.sub(zendeskConversationSyncAtom, () => {})).not.toThrow()
+      await flushMicrotasks()
+
+      expect(setZendeskConversationFields).not.toHaveBeenCalled()
+    })
+
+    it('should sync all fields when the pending queries resolve', async () => {
+      mockCurrentWorkspaceQueryState.isPending = false
+      const store = createTestStore()
+      store.sub(zendeskConversationSyncAtom, () => {})
+      await flushMicrotasks()
+
+      profileQueryState.resolve(createProfileQueryData())
+
+      await vi.waitFor(() => {
+        expect(setZendeskConversationFields).toHaveBeenCalledWith([
+          {
+            id: ZENDESK_FIELD_IDS.EMAIL,
+            value: 'user@example.com',
+          },
+        ])
+      })
+      await vi.waitFor(() => {
+        expect(setZendeskConversationFields).toHaveBeenCalledWith([
+          {
+            id: ZENDESK_FIELD_IDS.ENVIRONMENT,
+            value: 'cloud',
+          },
+        ])
+      })
+      await vi.waitFor(() => {
+        expect(setZendeskConversationFields).toHaveBeenCalledWith([
+          {
+            id: ZENDESK_FIELD_IDS.VERSION,
+            value: '1.0.1',
+          },
+        ])
+      })
+      await vi.waitFor(() => {
+        expect(setZendeskConversationFields).toHaveBeenCalledWith([
+          {
+            id: ZENDESK_FIELD_IDS.WORKSPACE_ID,
+            value: 'workspace-1',
+          },
+        ])
+      })
+    })
+  })
+})

--- a/web/context/__tests__/zendesk-conversation-sync.spec.ts
+++ b/web/context/__tests__/zendesk-conversation-sync.spec.ts
@@ -165,7 +165,7 @@ function createTestStore() {
   return store
 }
 
-async function flushMicrotasks() {
+async function flushAsync() {
   await new Promise((resolve) => {
     setTimeout(resolve, 0)
   })
@@ -185,7 +185,7 @@ describe('zendeskConversationSyncAtom', () => {
       const store = createTestStore()
 
       expect(() => store.sub(zendeskConversationSyncAtom, () => {})).not.toThrow()
-      await flushMicrotasks()
+      await flushAsync()
 
       expect(setZendeskConversationFields).not.toHaveBeenCalled()
     })
@@ -194,7 +194,7 @@ describe('zendeskConversationSyncAtom', () => {
       mockCurrentWorkspaceQueryState.isPending = false
       const store = createTestStore()
       store.sub(zendeskConversationSyncAtom, () => {})
-      await flushMicrotasks()
+      await flushAsync()
 
       profileQueryState.resolve(createProfileQueryData())
 

--- a/web/context/__tests__/zendesk-conversation-sync.spec.ts
+++ b/web/context/__tests__/zendesk-conversation-sync.spec.ts
@@ -171,9 +171,7 @@ async function flushAsync() {
   })
 }
 
-// Regression for langgenius/dify#38840: the effect used to read
-// resolved-suspense atoms (profile directly, and meta/system-features via
-// langGeniusVersionInfoAtom), which throw while their queries are pending.
+// Regression for langgenius/dify#38840: reading resolved-suspense atoms throws while pending.
 describe('zendeskConversationSyncAtom', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/web/context/account-state.ts
+++ b/web/context/account-state.ts
@@ -9,10 +9,7 @@ const accountProfileQueryAtom = atomWithResolvedSuspenseQuery(() => userProfileQ
 
 const accountProfilePendingQueryAtom = atomWithQuery(() => userProfileQueryOptions())
 
-/**
- * Render-path only — throws while the profile query is pending.
- * atomEffect / non-render readers must use `userProfileOrNullAtom` instead.
- */
+/** Render-path only — throws while pending; effects use `userProfileOrNullAtom`. */
 export const userProfileAtom = atom((get) => {
   return get(accountProfileQueryAtom).data.profile
 })
@@ -25,20 +22,15 @@ export const userProfileEmailAtom = atom((get) => {
   return get(userProfileAtom).email
 })
 
-/**
- * Render-path only — throws while the profile query is pending.
- * atomEffect / non-render readers must use `accountProfileMetaOrNullAtom` instead.
- */
+/** Render-path only — throws while pending; effects use `accountProfileMetaOrNullAtom`. */
 export const accountProfileMetaAtom = atom((get) => {
   return get(accountProfileQueryAtom).data.meta
 })
 
-/** Pending-safe: `null` until the profile query resolves. For atomEffect / non-render readers. */
 export const userProfileOrNullAtom = atom((get) => {
   return get(accountProfilePendingQueryAtom).data?.profile ?? null
 })
 
-/** Pending-safe: `null` until the profile query resolves. For atomEffect / non-render readers. */
 export const accountProfileMetaOrNullAtom = atom((get) => {
   return get(accountProfilePendingQueryAtom).data?.meta ?? null
 })

--- a/web/context/account-state.ts
+++ b/web/context/account-state.ts
@@ -1,12 +1,18 @@
 'use client'
 
 import { atom } from 'jotai'
-import { queryClientAtom } from 'jotai-tanstack-query'
+import { atomWithQuery, queryClientAtom } from 'jotai-tanstack-query'
 import { userProfileQueryOptions } from '@/features/account-profile/client'
 import { atomWithResolvedSuspenseQuery } from '@/utils/query-atoms'
 
 const accountProfileQueryAtom = atomWithResolvedSuspenseQuery(() => userProfileQueryOptions())
 
+const accountProfilePendingQueryAtom = atomWithQuery(() => userProfileQueryOptions())
+
+/**
+ * Render-path only — throws while the profile query is pending.
+ * atomEffect / non-render readers must use `userProfileOrNullAtom` instead.
+ */
 export const userProfileAtom = atom((get) => {
   return get(accountProfileQueryAtom).data.profile
 })
@@ -19,8 +25,22 @@ export const userProfileEmailAtom = atom((get) => {
   return get(userProfileAtom).email
 })
 
+/**
+ * Render-path only — throws while the profile query is pending.
+ * atomEffect / non-render readers must use `accountProfileMetaOrNullAtom` instead.
+ */
 export const accountProfileMetaAtom = atom((get) => {
   return get(accountProfileQueryAtom).data.meta
+})
+
+/** Pending-safe: `null` until the profile query resolves. For atomEffect / non-render readers. */
+export const userProfileOrNullAtom = atom((get) => {
+  return get(accountProfilePendingQueryAtom).data?.profile ?? null
+})
+
+/** Pending-safe: `null` until the profile query resolves. For atomEffect / non-render readers. */
+export const accountProfileMetaOrNullAtom = atom((get) => {
+  return get(accountProfilePendingQueryAtom).data?.meta ?? null
 })
 
 export const refreshUserProfileAtom = atom(null, (get) => {

--- a/web/context/amplitude-identity-sync.ts
+++ b/web/context/amplitude-identity-sync.ts
@@ -6,7 +6,7 @@ import { atom } from 'jotai'
 import { atomEffect } from 'jotai-effect'
 import { setUserId, setUserProperties } from '@/app/components/base/amplitude'
 import { flushRegistrationSuccess } from '@/app/components/base/amplitude/registration-tracking'
-import { userProfileAtom } from './account-state'
+import { userProfileOrNullAtom } from './account-state'
 import { currentWorkspaceAtom } from './workspace-state'
 
 type AmplitudeProperties = Record<string, string | number | boolean>
@@ -38,10 +38,10 @@ function buildAmplitudeProperties({
 }
 
 export const amplitudeIdentitySyncAtom = atomEffect((get, set) => {
-  const userProfile = get(userProfileAtom)
+  const userProfile = get(userProfileOrNullAtom)
   const currentWorkspace = get(currentWorkspaceAtom)
 
-  if (!userProfile.id) return
+  if (!userProfile?.id) return
 
   const properties = buildAmplitudeProperties({
     currentWorkspace,

--- a/web/context/system-features-state.ts
+++ b/web/context/system-features-state.ts
@@ -9,15 +9,11 @@ const systemFeaturesQueryAtom = atomWithResolvedSuspenseQuery(() => systemFeatur
 
 const systemFeaturesPendingQueryAtom = atomWithQuery(() => systemFeaturesQueryOptions())
 
-/**
- * Render-path only — throws while the system-features query is pending.
- * atomEffect / non-render readers must use `systemFeaturesOrNullAtom` instead.
- */
+/** Render-path only — throws while pending; effects use `systemFeaturesOrNullAtom`. */
 export const systemFeaturesAtom = atom((get) => {
   return get(systemFeaturesQueryAtom).data
 })
 
-/** Pending-safe: `null` until the system-features query resolves. For atomEffect / non-render readers. */
 export const systemFeaturesOrNullAtom = atom((get) => {
   return get(systemFeaturesPendingQueryAtom).data ?? null
 })

--- a/web/context/system-features-state.ts
+++ b/web/context/system-features-state.ts
@@ -1,13 +1,25 @@
 'use client'
 
 import { atom } from 'jotai'
+import { atomWithQuery } from 'jotai-tanstack-query'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { atomWithResolvedSuspenseQuery } from '@/utils/query-atoms'
 
 const systemFeaturesQueryAtom = atomWithResolvedSuspenseQuery(() => systemFeaturesQueryOptions())
 
+const systemFeaturesPendingQueryAtom = atomWithQuery(() => systemFeaturesQueryOptions())
+
+/**
+ * Render-path only — throws while the system-features query is pending.
+ * atomEffect / non-render readers must use `systemFeaturesOrNullAtom` instead.
+ */
 export const systemFeaturesAtom = atom((get) => {
   return get(systemFeaturesQueryAtom).data
+})
+
+/** Pending-safe: `null` until the system-features query resolves. For atomEffect / non-render readers. */
+export const systemFeaturesOrNullAtom = atom((get) => {
+  return get(systemFeaturesPendingQueryAtom).data ?? null
 })
 
 export const datasetRbacEnabledAtom = atom((get) => {

--- a/web/context/system-features-state.ts
+++ b/web/context/system-features-state.ts
@@ -10,7 +10,7 @@ const systemFeaturesQueryAtom = atomWithResolvedSuspenseQuery(() => systemFeatur
 const systemFeaturesPendingQueryAtom = atomWithQuery(() => systemFeaturesQueryOptions())
 
 /** Render-path only — throws while pending; effects use `systemFeaturesOrNullAtom`. */
-export const systemFeaturesAtom = atom((get) => {
+const systemFeaturesAtom = atom((get) => {
   return get(systemFeaturesQueryAtom).data
 })
 

--- a/web/context/version-state.ts
+++ b/web/context/version-state.ts
@@ -11,7 +11,9 @@ import { systemFeaturesOrNullAtom } from './system-features-state'
 const versionQueryAtom = atomWithQuery((get) => {
   const meta = get(accountProfileMetaOrNullAtom)
   const systemFeatures = get(systemFeaturesOrNullAtom)
-  const enabled = Boolean(meta?.currentVersion && systemFeatures && !systemFeatures.branding.enabled)
+  const enabled = Boolean(
+    meta?.currentVersion && systemFeatures && !systemFeatures.branding.enabled,
+  )
 
   return consoleQuery.version.get.queryOptions({
     input: {

--- a/web/context/version-state.ts
+++ b/web/context/version-state.ts
@@ -25,11 +25,7 @@ const versionQueryAtom = atomWithQuery((get) => {
   })
 })
 
-/**
- * Render-path only — reads the resolved-suspense profile meta and throws while
- * it is pending. atomEffect / non-render readers must use
- * `langGeniusVersionInfoOrDefaultAtom` instead.
- */
+/** Render-path only — throws while pending; effects use `langGeniusVersionInfoOrDefaultAtom`. */
 export const langGeniusVersionInfoAtom = atom((get) => {
   const meta = get(accountProfileMetaAtom)
   const versionData = get(versionQueryAtom).data
@@ -42,7 +38,6 @@ export const langGeniusVersionInfoAtom = atom((get) => {
   })
 })
 
-/** Pending-safe: `initialLangGeniusVersionInfo` until profile meta and version data resolve. For atomEffect / non-render readers. */
 export const langGeniusVersionInfoOrDefaultAtom = atom((get) => {
   const meta = get(accountProfileMetaOrNullAtom)
   const versionData = get(versionQueryAtom).data

--- a/web/context/version-state.ts
+++ b/web/context/version-state.ts
@@ -3,31 +3,49 @@
 import { atom } from 'jotai'
 import { atomWithQuery } from 'jotai-tanstack-query'
 import { consoleQuery } from '@/service/client'
-import { accountProfileMetaAtom } from './account-state'
+import { accountProfileMetaAtom, accountProfileMetaOrNullAtom } from './account-state'
 import { initialLangGeniusVersionInfo } from './app-context-defaults'
 import { getLangGeniusVersionInfo } from './app-context-normalizers'
-import { systemFeaturesAtom } from './system-features-state'
+import { systemFeaturesOrNullAtom } from './system-features-state'
 
 const versionQueryAtom = atomWithQuery((get) => {
-  const meta = get(accountProfileMetaAtom)
-  const systemFeatures = get(systemFeaturesAtom)
-  const enabled = Boolean(meta.currentVersion && !systemFeatures.branding.enabled)
+  const meta = get(accountProfileMetaOrNullAtom)
+  const systemFeatures = get(systemFeaturesOrNullAtom)
+  const enabled = Boolean(meta?.currentVersion && systemFeatures && !systemFeatures.branding.enabled)
 
   return consoleQuery.version.get.queryOptions({
     input: {
       query: {
-        current_version: meta.currentVersion ?? '',
+        current_version: meta?.currentVersion ?? '',
       },
     },
     enabled,
   })
 })
 
+/**
+ * Render-path only — reads the resolved-suspense profile meta and throws while
+ * it is pending. atomEffect / non-render readers must use
+ * `langGeniusVersionInfoOrDefaultAtom` instead.
+ */
 export const langGeniusVersionInfoAtom = atom((get) => {
   const meta = get(accountProfileMetaAtom)
   const versionData = get(versionQueryAtom).data
 
   if (!versionData) return initialLangGeniusVersionInfo
+
+  return getLangGeniusVersionInfo({
+    meta,
+    versionData,
+  })
+})
+
+/** Pending-safe: `initialLangGeniusVersionInfo` until profile meta and version data resolve. For atomEffect / non-render readers. */
+export const langGeniusVersionInfoOrDefaultAtom = atom((get) => {
+  const meta = get(accountProfileMetaOrNullAtom)
+  const versionData = get(versionQueryAtom).data
+
+  if (!meta || !versionData) return initialLangGeniusVersionInfo
 
   return getLangGeniusVersionInfo({
     meta,

--- a/web/context/zendesk-conversation-sync.ts
+++ b/web/context/zendesk-conversation-sync.ts
@@ -4,8 +4,8 @@ import { atom } from 'jotai'
 import { atomEffect } from 'jotai-effect'
 import { setZendeskConversationFields } from '@/app/components/base/zendesk/utils'
 import { ZENDESK_FIELD_IDS } from '@/config'
-import { userProfileAtom } from './account-state'
-import { langGeniusVersionInfoAtom } from './version-state'
+import { userProfileOrNullAtom } from './account-state'
+import { langGeniusVersionInfoOrDefaultAtom } from './version-state'
 import { currentWorkspaceAtom } from './workspace-state'
 
 type ZendeskSyncState = {
@@ -42,9 +42,9 @@ function syncZendeskField({
 }
 
 export const zendeskConversationSyncAtom = atomEffect((get, set) => {
-  const userProfile = get(userProfileAtom)
+  const userProfile = get(userProfileOrNullAtom)
   const currentWorkspace = get(currentWorkspaceAtom)
-  const langGeniusVersionInfo = get(langGeniusVersionInfoAtom)
+  const langGeniusVersionInfo = get(langGeniusVersionInfoOrDefaultAtom)
   const state = get.peek(zendeskConversationSyncStateAtom)
   const nextState = { ...state }
 
@@ -70,7 +70,7 @@ export const zendeskConversationSyncAtom = atomEffect((get, set) => {
   didSync =
     syncZendeskField({
       fieldId: ZENDESK_FIELD_IDS.EMAIL,
-      value: userProfile.email,
+      value: userProfile?.email ?? '',
       previousValue: state.email,
       setNextValue: (value) => {
         nextState.email = value


### PR DESCRIPTION
Fixes #38840

## Summary

On cold login — no warm React Query cache and the server-side profile prefetch skipped (`SERVER_CONSOLE_API_PREFIX` unset with a relative `API_PREFIX`, common in same-origin Docker/enterprise deploys) — the console repeatedly throws:

```
TypeError: Suspense query must be resolved before reading: [["console","account","profile","get"],{"type":"query"}]
```

`amplitudeIdentitySyncAtom` and `zendeskConversationSyncAtom` are `jotai-effect` atoms that read resolved-suspense atoms (`userProfileAtom`, and `langGeniusVersionInfoAtom` → `accountProfileMetaAtom` / `systemFeaturesAtom`). `atomEffect` callbacks run in jotai-effect's scheduler outside React render/Suspense, so nothing absorbs the pending state and the deliberate throw from `atomWithResolvedSuspenseQuery` escapes on every query-state change until resolution.

### Fix

Give the two effects pending-safe read paths instead of the throwing atoms:

- `userProfileOrNullAtom` / `accountProfileMetaOrNullAtom` (`account-state.ts`) and `systemFeaturesOrNullAtom` (`system-features-state.ts`): `atomWithQuery`-backed siblings with the same query keys — shared cache, no duplicate fetch — returning `null` while pending.
- `langGeniusVersionInfoOrDefaultAtom` (`version-state.ts`): returns `initialLangGeniusVersionInfo` until profile meta and version data resolve.
- Effects read the safe atoms and no-op while pending; they re-run automatically when the queries resolve, so telemetry sync behavior is unchanged post-resolution.
- `versionQueryAtom` now gates `enabled` on actually-resolved system features (`meta?.currentVersion && systemFeatures && !systemFeatures.branding.enabled`), so the `/version` check cannot fire before the real `branding.enabled` flag is known.
- Throwing atoms and all their render consumers are untouched except JSDoc marking each flavor's contract (render-path-only vs pending-safe).

### Tests

New specs deterministically reproduce the bug with a vanilla jotai store and a never-resolving `queryFn` (they fail with the exact production `TypeError` before the fix):

- `context/__tests__/amplitude-identity-sync.spec.ts` — cold-cache no-throw, sync on resolution, empty-profile skip, warm-cache sync, identity dedup on re-run
- `context/__tests__/zendesk-conversation-sync.spec.ts` — cold-cache no-throw, all-field sync on resolution

`pnpm lint`, `pnpm type-check`, `vp fmt --check`, and the full context/utils test scope (284 tests incl. the console-bootstrap warm-path regression net) all pass.

### Possible follow-up

A lint rule preventing `atomEffect` bodies from reading resolved-suspense atoms would make this invariant self-enforcing; with only two effects today the JSDoc contract notes cover it.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods