### PR TITLE
fix: keep colons in HTTP node form body values on migration

### DIFF
--- a/web/app/components/workflow/nodes/http/__tests__/utils.spec.ts
+++ b/web/app/components/workflow/nodes/http/__tests__/utils.spec.ts
@@ -1,0 +1,53 @@
+import { BodyPayloadValueType } from '../types'
+import { transformToBodyPayload } from '../utils'
+
+describe('transformToBodyPayload', () => {
+  // Bodies without a key (json, raw-text, binary) keep the raw string untouched.
+  describe('when hasKey is false', () => {
+    it('should keep the whole string as a single text value', () => {
+      const result = transformToBodyPayload('{"url":"https://a:1"}', false)
+
+      expect(result).toEqual([
+        { type: BodyPayloadValueType.text, value: '{"url":"https://a:1"}' },
+      ])
+    })
+  })
+
+  // form-data / x-www-form-urlencoded bodies are stored as `key:value` lines.
+  describe('when hasKey is true', () => {
+    it('should split a simple key:value pair', () => {
+      const result = transformToBodyPayload('name:alice', true)
+
+      expect(result).toEqual([
+        { key: 'name', type: BodyPayloadValueType.text, value: 'alice' },
+      ])
+    })
+
+    it('should keep colons that belong to the value', () => {
+      const result = transformToBodyPayload('url:https://host:8080/path', true)
+
+      expect(result[0]).toEqual({
+        key: 'url',
+        type: BodyPayloadValueType.text,
+        value: 'https://host:8080/path',
+      })
+    })
+
+    it('should parse each line independently', () => {
+      const result = transformToBodyPayload('a:1\nb:2:3', true)
+
+      expect(result).toEqual([
+        { key: 'a', type: BodyPayloadValueType.text, value: '1' },
+        { key: 'b', type: BodyPayloadValueType.text, value: '2:3' },
+      ])
+    })
+
+    it('should use an empty value when the line has no colon', () => {
+      const result = transformToBodyPayload('lonelykey', true)
+
+      expect(result).toEqual([
+        { key: 'lonelykey', type: BodyPayloadValueType.text, value: '' },
+      ])
+    })
+  })
+})

--- a/web/app/components/workflow/nodes/http/__tests__/utils.spec.ts
+++ b/web/app/components/workflow/nodes/http/__tests__/utils.spec.ts
@@ -7,9 +7,7 @@ describe('transformToBodyPayload', () => {
     it('should keep the whole string as a single text value', () => {
       const result = transformToBodyPayload('{"url":"https://a:1"}', false)
 
-      expect(result).toEqual([
-        { type: BodyPayloadValueType.text, value: '{"url":"https://a:1"}' },
-      ])
+      expect(result).toEqual([{ type: BodyPayloadValueType.text, value: '{"url":"https://a:1"}' }])
     })
   })
 
@@ -18,9 +16,7 @@ describe('transformToBodyPayload', () => {
     it('should split a simple key:value pair', () => {
       const result = transformToBodyPayload('name:alice', true)
 
-      expect(result).toEqual([
-        { key: 'name', type: BodyPayloadValueType.text, value: 'alice' },
-      ])
+      expect(result).toEqual([{ key: 'name', type: BodyPayloadValueType.text, value: 'alice' }])
     })
 
     it('should keep colons that belong to the value', () => {
@@ -45,9 +41,7 @@ describe('transformToBodyPayload', () => {
     it('should use an empty value when the line has no colon', () => {
       const result = transformToBodyPayload('lonelykey', true)
 
-      expect(result).toEqual([
-        { key: 'lonelykey', type: BodyPayloadValueType.text, value: '' },
-      ])
+      expect(result).toEqual([{ key: 'lonelykey', type: BodyPayloadValueType.text, value: '' }])
     })
   })
 })

--- a/web/app/components/workflow/nodes/http/utils.ts
+++ b/web/app/components/workflow/nodes/http/utils.ts
@@ -11,11 +11,11 @@ export const transformToBodyPayload = (old: string, hasKey: boolean): BodyPayloa
     ]
   }
   const bodyPayload = old.split('\n').map((item) => {
-    const [key, value] = item.split(':')
+    const [key, ...others] = item.split(':')
     return {
       key: key || '',
       type: BodyPayloadValueType.text,
-      value: value || '',
+      value: others.join(':'),
     }
   })
   return bodyPayload


### PR DESCRIPTION
## Summary

`transformToBodyPayload` split each legacy `key:value` line with
`const [key, value] = item.split(':')`, which keeps only the first segment and drops
everything after the first colon. Form values that legitimately contain colons — URLs,
timestamps, `Bearer x:y` style tokens — were truncated when a node with a legacy string
body was loaded, and the truncated value was then persisted back on the next save.

This joins the remaining segments back into the value, matching the existing behavior in
`use-key-value-list.ts`.

Fixes #38860
Fixes https://github.com/langgenius/dify/issues/39565
Fixes https://github.com/langgenius/dify/issues/39551

## How to test

1. Import `curl --form "url=https://example.com:8080/path" https://api.example.com` into an HTTP Request node.
2. Save the workflow and reopen the node.
3. The `url` form value keeps the full `https://example.com:8080/path` instead of `https`.

Unit tests added in `web/app/components/workflow/nodes/http/__tests__/utils.spec.ts` cover
colon-containing values, multi-colon values, and the no-colon fallback.

## Checklist

- [x] I've added a test for the change.
- [ ] This change requires a documentation update.
