### PR TITLE
fix: mark batch segment import as error when processing fails

### DIFF
--- a/api/tasks/batch_create_segment_to_index_task.py
+++ b/api/tasks/batch_create_segment_to_index_task.py
@@ -104,80 +104,91 @@ def batch_create_segment_to_index_task(
         redis_client.setex(indexing_cache_key, 600, "error")
         return
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        suffix = Path(upload_file_key).suffix
-        file_path = f"{temp_dir}/{next(tempfile._get_candidate_names())}{suffix}"  # type: ignore
-        storage.download(upload_file_key, file_path)
+    try:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            suffix = Path(upload_file_key).suffix
+            file_path = f"{temp_dir}/{next(tempfile._get_candidate_names())}{suffix}"  # type: ignore
+            storage.download(upload_file_key, file_path)
 
-        df = pd.read_csv(file_path)
-        content = []
-        for _, row in df.iterrows():
-            if document_config["doc_form"] == IndexStructureType.QA_INDEX:
-                data = {"content": row.iloc[0], "answer": row.iloc[1]}
-            else:
-                data = {"content": row.iloc[0]}
-            content.append(data)
-        if len(content) == 0:
-            raise ValueError("The CSV file is empty.")
+            df = pd.read_csv(file_path)
+            content = []
+            for _, row in df.iterrows():
+                if document_config["doc_form"] == IndexStructureType.QA_INDEX:
+                    data = {"content": row.iloc[0], "answer": row.iloc[1]}
+                else:
+                    data = {"content": row.iloc[0]}
+                content.append(data)
+            if len(content) == 0:
+                raise ValueError("The CSV file is empty.")
 
-    document_segments = []
-    embedding_model = None
-    if dataset_config["indexing_technique"] == IndexTechniqueType.HIGH_QUALITY:
-        model_manager = ModelManager.for_tenant(tenant_id=dataset_config["tenant_id"])
-        embedding_model = model_manager.get_model_instance(
-            tenant_id=dataset_config["tenant_id"],
-            provider=dataset_config["embedding_model_provider"],
-            model_type=ModelType.TEXT_EMBEDDING,
-            model=dataset_config["embedding_model"],
-        )
-
-    word_count_change = 0
-    if embedding_model:
-        tokens_list = embedding_model.get_text_embedding_num_tokens(texts=[segment["content"] for segment in content])
-    else:
-        tokens_list = [0] * len(content)
-
-    with session_factory.create_session() as session, session.begin():
-        for segment, tokens in zip(content, tokens_list):
-            content = segment["content"]
-            doc_id = str(uuid.uuid4())
-            segment_hash = helper.generate_text_hash(content)
-            max_position = session.scalar(
-                select(func.max(DocumentSegment.position)).where(DocumentSegment.document_id == document_config["id"])
+        document_segments = []
+        embedding_model = None
+        if dataset_config["indexing_technique"] == IndexTechniqueType.HIGH_QUALITY:
+            model_manager = ModelManager.for_tenant(tenant_id=dataset_config["tenant_id"])
+            embedding_model = model_manager.get_model_instance(
+                tenant_id=dataset_config["tenant_id"],
+                provider=dataset_config["embedding_model_provider"],
+                model_type=ModelType.TEXT_EMBEDDING,
+                model=dataset_config["embedding_model"],
             )
-            segment_document = DocumentSegment(
-                tenant_id=tenant_id,
-                dataset_id=dataset_id,
-                document_id=document_id,
-                index_node_id=doc_id,
-                index_node_hash=segment_hash,
-                position=max_position + 1 if max_position else 1,
-                content=content,
-                word_count=len(content),
-                tokens=tokens,
-                created_by=user_id,
-                indexing_at=naive_utc_now(),
-                status=SegmentStatus.COMPLETED,
-                completed_at=naive_utc_now(),
+
+        word_count_change = 0
+        if embedding_model:
+            tokens_list = embedding_model.get_text_embedding_num_tokens(
+                texts=[segment["content"] for segment in content]
             )
-            if document_config["doc_form"] == IndexStructureType.QA_INDEX:
-                segment_document.answer = segment["answer"]
-                segment_document.word_count += len(segment["answer"])
-            word_count_change += segment_document.word_count
-            session.add(segment_document)
-            document_segments.append(segment_document)
+        else:
+            tokens_list = [0] * len(content)
 
-    with session_factory.create_session() as session, session.begin():
-        dataset_document = session.get(Document, document_id)
-        if dataset_document:
-            assert dataset_document.word_count is not None
-            dataset_document.word_count += word_count_change
-            session.add(dataset_document)
+        with session_factory.create_session() as session, session.begin():
+            for segment, tokens in zip(content, tokens_list):
+                content = segment["content"]
+                doc_id = str(uuid.uuid4())
+                segment_hash = helper.generate_text_hash(content)
+                max_position = session.scalar(
+                    select(func.max(DocumentSegment.position)).where(
+                        DocumentSegment.document_id == document_config["id"]
+                    )
+                )
+                segment_document = DocumentSegment(
+                    tenant_id=tenant_id,
+                    dataset_id=dataset_id,
+                    document_id=document_id,
+                    index_node_id=doc_id,
+                    index_node_hash=segment_hash,
+                    position=max_position + 1 if max_position else 1,
+                    content=content,
+                    word_count=len(content),
+                    tokens=tokens,
+                    created_by=user_id,
+                    indexing_at=naive_utc_now(),
+                    status=SegmentStatus.COMPLETED,
+                    completed_at=naive_utc_now(),
+                )
+                if document_config["doc_form"] == IndexStructureType.QA_INDEX:
+                    segment_document.answer = segment["answer"]
+                    segment_document.word_count += len(segment["answer"])
+                word_count_change += segment_document.word_count
+                session.add(segment_document)
+                document_segments.append(segment_document)
 
-    with session_factory.create_session() as session:
-        dataset = session.get(Dataset, dataset_id)
-        if dataset:
-            VectorService.create_segments_vector(None, document_segments, dataset, document_config["doc_form"], session)
+        with session_factory.create_session() as session, session.begin():
+            dataset_document = session.get(Document, document_id)
+            if dataset_document:
+                assert dataset_document.word_count is not None
+                dataset_document.word_count += word_count_change
+                session.add(dataset_document)
+
+        with session_factory.create_session() as session:
+            dataset = session.get(Dataset, dataset_id)
+            if dataset:
+                VectorService.create_segments_vector(
+                    None, document_segments, dataset, document_config["doc_form"], session
+                )
+    except Exception:
+        logger.exception("Segments batch created index failed")
+        redis_client.setex(indexing_cache_key, 600, "error")
+        return
 
     redis_client.setex(indexing_cache_key, 600, "completed")
     end_at = time.perf_counter()

--- a/api/tests/test_containers_integration_tests/tasks/test_batch_create_segment_to_index_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_batch_create_segment_to_index_task.py
@@ -157,7 +157,9 @@ class TestBatchCreateSegmentToIndexTask:
 
         return dataset
 
-    def _create_test_document(self, db_session_with_containers: Session, account, tenant, dataset):
+    def _create_test_document(
+        self, db_session_with_containers: Session, account, tenant, dataset, doc_form=IndexStructureType.PARAGRAPH_INDEX
+    ):
         """
         Helper method to create a test document for testing.
 
@@ -166,6 +168,7 @@ class TestBatchCreateSegmentToIndexTask:
             account: Account instance
             tenant: Tenant instance
             dataset: Dataset instance
+            doc_form: Index structure type for the document
 
         Returns:
             Document: Created document instance
@@ -184,7 +187,7 @@ class TestBatchCreateSegmentToIndexTask:
             indexing_status=IndexingStatus.COMPLETED,
             enabled=True,
             archived=False,
-            doc_form=IndexStructureType.PARAGRAPH_INDEX,
+            doc_form=doc_form,
             word_count=0,
         )
 
@@ -598,27 +601,78 @@ class TestBatchCreateSegmentToIndexTask:
 
         mock_storage.download.side_effect = mock_download
 
-        # Execute the task - should raise ValueError for empty CSV
+        # Execute the task - an empty CSV should mark the job as failed instead of raising
         job_id = str(uuid.uuid4())
-        with pytest.raises(ValueError, match="The CSV file is empty"):
-            batch_create_segment_to_index_task(
-                job_id=job_id,
-                upload_file_id=upload_file.id,
-                dataset_id=dataset.id,
-                document_id=document.id,
-                tenant_id=tenant.id,
-                user_id=account.id,
-            )
+        batch_create_segment_to_index_task(
+            job_id=job_id,
+            upload_file_id=upload_file.id,
+            dataset_id=dataset.id,
+            document_id=document.id,
+            tenant_id=tenant.id,
+            user_id=account.id,
+        )
 
         # Verify error handling
-        # Since exception was raised, no segments should be created
+        # The Redis status must move to "error" so the polling UI stops waiting
+        from extensions.ext_redis import redis_client
 
+        cache_key = f"segment_batch_import_{job_id}"
+        assert redis_client.get(cache_key) == b"error"
+
+        # No segments should be created
         segments = db_session_with_containers.scalars(select(DocumentSegment)).all()
         assert len(segments) == 0
 
         # Verify document remains unchanged
         db_session_with_containers.refresh(document)
         assert document.word_count == 0
+
+    def test_batch_create_segment_to_index_task_qa_csv_missing_answer_column(
+        self, db_session_with_containers: Session, mock_external_service_dependencies
+    ):
+        """
+        Test task failure when a QA document is imported from a CSV without an answer column.
+
+        Regression: any processing error (here row.iloc[1] on a single-column CSV) must set
+        the Redis status to "error" instead of leaving the job stuck at "waiting".
+        """
+        # Create test data
+        account, tenant = self._create_test_account_and_tenant(db_session_with_containers)
+        dataset = self._create_test_dataset(db_session_with_containers, account, tenant)
+        document = self._create_test_document(
+            db_session_with_containers, account, tenant, dataset, doc_form=IndexStructureType.QA_INDEX
+        )
+        upload_file = self._create_test_upload_file(db_session_with_containers, account, tenant)
+
+        # A QA import expects two columns; a single-column row makes row.iloc[1] fail
+        single_column_csv = "content\nonly-a-question\n"
+        mock_storage = mock_external_service_dependencies["storage"]
+
+        def mock_download(key, file_path):
+            Path(file_path).write_text(single_column_csv, encoding="utf-8")
+
+        mock_storage.download.side_effect = mock_download
+
+        # Execute the task - the processing error should mark the job as failed
+        job_id = str(uuid.uuid4())
+        batch_create_segment_to_index_task(
+            job_id=job_id,
+            upload_file_id=upload_file.id,
+            dataset_id=dataset.id,
+            document_id=document.id,
+            tenant_id=tenant.id,
+            user_id=account.id,
+        )
+
+        # The Redis status must move to "error" so the polling UI stops waiting
+        from extensions.ext_redis import redis_client
+
+        cache_key = f"segment_batch_import_{job_id}"
+        assert redis_client.get(cache_key) == b"error"
+
+        # No segments should be created
+        segments = db_session_with_containers.scalars(select(DocumentSegment)).all()
+        assert len(segments) == 0
 
     def test_batch_create_segment_to_index_task_position_calculation(
         self, db_session_with_containers: Session, mock_external_service_dependencies


### PR DESCRIPTION
## Summary

Batch segment import only marked the job as `error` when the setup phase failed. If the CSV
parsing, segment writes, or vector creation failed afterwards, the Redis job status was left
at `waiting` — which the controller writes with `setnx` (no TTL) — so the status endpoint kept
returning `waiting` and the frontend polled forever without ever surfacing the failure.

This wraps the processing phase in the same error handling already used for setup, so any
failure records an `error` status. The success path still records `completed`.

Fixes #38862

## How to test

Trigger a processing failure during batch segment import, for example:

- an empty CSV (header only, no rows), or
- a QA dataset with a single-column CSV (no answer column).

Before: the job status stays `waiting` and the UI keeps polling.
After: the job status becomes `error`.

Updated `test_batch_create_segment_to_index_task_empty_csv_file` to assert the job status
becomes `error`, and added `test_batch_create_segment_to_index_task_qa_csv_missing_answer_column`
for the single-column QA case.

## Checklist

- [x] I've added tests for the change.
- [ ] This change requires a documentation update.
