### PR TITLE
chore: improve static check performance

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   autofix:
     if: github.repository == 'langgenius/dify'
-    runs-on: depot-ubuntu-24.04
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - name: Complete merge group check
         if: github.event_name == 'merge_group'

--- a/lint.config.ts
+++ b/lint.config.ts
@@ -2,8 +2,6 @@ import type { OxlintConfig } from 'vite-plus/lint'
 import path from 'node:path'
 
 const rootDir = import.meta.dirname
-const webDir = path.resolve(rootDir, 'web')
-const webTailwindEntry = path.resolve(webDir, 'app/styles/globals.css')
 const difyUiPackageJson = path.resolve(rootDir, 'packages/dify-ui/package.json')
 
 /**
@@ -81,10 +79,6 @@ export const lintConfig = {
     'eslint-plugin-no-barrel-files',
     '@tanstack/eslint-plugin-query',
     'eslint-plugin-storybook',
-    {
-      name: 'tailwindcss',
-      specifier: 'eslint-plugin-better-tailwindcss',
-    },
     'eslint-plugin-hyoban',
   ],
   options: {
@@ -94,10 +88,6 @@ export const lintConfig = {
     typeCheck: true,
   },
   settings: {
-    'better-tailwindcss': {
-      cwd: webDir,
-      entryPoint: webTailwindEntry,
-    },
     'react-x': {
       additionalStateHooks: '/^use\\w*State(?:s)?|useAtom$/u',
     },
@@ -829,14 +819,6 @@ export const lintConfig = {
       rules: {
         'storybook/no-uninstalled-addons': 'error',
       },
-    },
-    {
-      files: ['web/**/*.{ts,cts,mts}', 'web/**/*.tsx'],
-      rules: {
-        'tailwindcss/no-duplicate-classes': 'error',
-        'tailwindcss/no-unknown-classes': 'warn',
-      },
-      excludeFiles: ['web/**/__tests__/**', 'web/**/*.spec.{ts,tsx}', 'web/**/*.test.{ts,tsx}'],
     },
     {
       files: ['web/**/*.tsx'],

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "eslint": "catalog:",
     "eslint-markdown": "catalog:",
     "eslint-plugin-antfu": "catalog:",
-    "eslint-plugin-better-tailwindcss": "catalog:",
     "eslint-plugin-command": "catalog:",
     "eslint-plugin-erasable-syntax-only": "catalog:",
     "eslint-plugin-hyoban": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,9 +336,6 @@ catalogs:
     eslint-plugin-antfu:
       specifier: 3.2.3
       version: 3.2.3
-    eslint-plugin-better-tailwindcss:
-      specifier: 4.6.1
-      version: 4.6.1
     eslint-plugin-command:
       specifier: 3.5.2
       version: 3.5.2
@@ -707,9 +704,6 @@ importers:
       eslint-plugin-antfu:
         specifier: 'catalog:'
         version: 3.2.3(eslint@10.6.0(jiti@2.7.0)(supports-color@10.2.2))
-      eslint-plugin-better-tailwindcss:
-        specifier: 'catalog:'
-        version: 4.6.1(@typescript/typescript6@6.0.2)(eslint@10.6.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint@1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@26.0.1)(@typescript/typescript6@6.0.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.0.1)(@typescript/typescript6@6.0.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))(esbuild@0.28.1)(happy-dom@20.10.6)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)))(tailwindcss@4.3.2)
       eslint-plugin-command:
         specifier: 'catalog:'
         version: 3.5.2(@typescript-eslint/typescript-estree@8.63.0(@typescript/typescript6@6.0.2))(@typescript-eslint/utils@8.63.0(@typescript/typescript6@6.0.2)(eslint@10.6.0(jiti@2.7.0)(supports-color@10.2.2)))(eslint@10.6.0(jiti@2.7.0)(supports-color@10.2.2))
@@ -6373,19 +6367,6 @@ packages:
     resolution: {integrity: sha512-U2fnz/H0gFPxpuC7QpaHa0Jv2AgCZ5hunp36SOP/yWo8yFzgvMh8X4pZ4uN4IKoqtBhk7G3HuVa93Urf51+sZg==}
     peerDependencies:
       eslint: '*'
-
-  eslint-plugin-better-tailwindcss@4.6.1:
-    resolution: {integrity: sha512-Lr8mPyuaZ+dS6ATuJaPwcOFOpOUsRBs5TXyOPqiTzLy0SvK4+0G6usbklCuQn4QabwFtNKdSXwl2WxOIPvu0lQ==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23.0.0}
-    peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
-      oxlint: ^1.35.0
-      tailwindcss: ^3.3.0 || ^4.1.17
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      oxlint:
-        optional: true
 
   eslint-plugin-command@3.5.2:
     resolution: {integrity: sha512-PA59QAkQDwvcCMEt5lYLJLI3zDGVKJeC4id/pcRY2XdRYhSGW7iyYT1VC1N3bmpuvu6Qb/9QptiS3GJMjeGTJg==}
@@ -14628,24 +14609,6 @@ snapshots:
     dependencies:
       eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
 
-  eslint-plugin-better-tailwindcss@4.6.1(@typescript/typescript6@6.0.2)(eslint@10.6.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint@1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@26.0.1)(@typescript/typescript6@6.0.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.0.1)(@typescript/typescript6@6.0.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))(esbuild@0.28.1)(happy-dom@20.10.6)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)))(tailwindcss@4.3.2):
-    dependencies:
-      '@eslint/css-tree': 4.0.4
-      '@valibot/to-json-schema': 1.7.1(valibot@1.4.2(@typescript/typescript6@6.0.2))
-      enhanced-resolve: 5.24.1
-      jiti: 2.7.0
-      synckit: 0.11.13
-      tailwind-csstree: 0.3.3
-      tailwindcss: 4.3.2
-      tsconfig-paths-webpack-plugin: 4.2.0
-      valibot: 1.4.2(@typescript/typescript6@6.0.2)
-    optionalDependencies:
-      eslint: 10.6.0(jiti@2.7.0)(supports-color@10.2.2)
-      oxlint: 1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@26.0.1)(@typescript/typescript6@6.0.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@26.0.1)(@typescript/typescript6@6.0.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))(esbuild@0.28.1)(happy-dom@20.10.6)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - '@eslint/css'
-      - typescript
-
   eslint-plugin-command@3.5.2(@typescript-eslint/typescript-estree@8.63.0(@typescript/typescript6@6.0.2))(@typescript-eslint/utils@8.63.0(@typescript/typescript6@6.0.2)(eslint@10.6.0(jiti@2.7.0)(supports-color@10.2.2)))(eslint@10.6.0(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@es-joy/jsdoccomment': 0.84.0
@@ -19339,7 +19302,6 @@ time:
   es-toolkit@1.49.0: '2026-06-26T00:26:01.050Z'
   eslint-markdown@0.12.1: '2026-07-10T23:35:26.055Z'
   eslint-plugin-antfu@3.2.3: '2026-05-11T02:24:38.348Z'
-  eslint-plugin-better-tailwindcss@4.6.1: '2026-07-03T15:13:24.013Z'
   eslint-plugin-command@3.5.2: '2026-02-25T04:29:02.155Z'
   eslint-plugin-erasable-syntax-only@0.4.2: '2026-06-18T00:56:01.038Z'
   eslint-plugin-hyoban@0.14.1: '2026-03-08T02:51:00.805Z'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -161,7 +161,6 @@ catalog:
   eslint: 10.6.0
   eslint-markdown: 0.12.1
   eslint-plugin-antfu: 3.2.3
-  eslint-plugin-better-tailwindcss: 4.6.1
   eslint-plugin-command: 3.5.2
   eslint-plugin-erasable-syntax-only: 0.4.2
   eslint-plugin-hyoban: 0.14.1

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,7 +71,7 @@ export default defineConfig({
     sortPackageJson: true,
     sortTailwindcss: {
       functions: ['cn', 'clsx', 'cva', 'tw', 'twMerge'],
-      preserveDuplicates: true,
+      preserveDuplicates: false,
       stylesheet: 'web/app/styles/globals.css',
     },
   },

--- a/web/app/components/plugins/card/index.tsx
+++ b/web/app/components/plugins/card/index.tsx
@@ -77,7 +77,6 @@ const Card = ({
   const cornerMarkText = categoriesMap[type === 'bundle' ? type : category]?.label ?? ''
 
   const wrapClassName = cn(
-    // oxlint-disable-next-line tailwindcss/no-unknown-classes -- Used by page feedback tooling to identify plugin cards.
     'hover-bg-components-panel-on-panel-item-bg relative overflow-hidden rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-on-panel-item-bg shadow-xs',
     isMarketplaceVariant &&
       'h-[148px] transition-all group-hover:bg-components-panel-on-panel-item-bg-hover group-hover:shadow-md',

--- a/web/app/components/workflow/block-selector/tabs.tsx
+++ b/web/app/components/workflow/block-selector/tabs.tsx
@@ -123,8 +123,7 @@ const TabHeaderItem = ({
     tab.disabled
       ? 'cursor-not-allowed text-text-disabled opacity-60'
       : activeTab === tab.key
-        ? // oxlint-disable-next-line tailwindcss/no-unknown-classes
-          'sm-no-bottom cursor-default bg-components-panel-bg text-text-accent'
+        ? 'sm-no-bottom cursor-default bg-components-panel-bg text-text-accent'
         : 'cursor-pointer text-text-tertiary',
   )
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Improve static-check performance as the first implementation step of the broader `vp check` work tracked in #38865.

- remove the `eslint-plugin-better-tailwindcss` JavaScript plugin registration and settings;
- remove `tailwindcss/no-duplicate-classes` and `tailwindcss/no-unknown-classes`;
- configure the Tailwind formatter with `preserveDuplicates: false` so formatting removes duplicate utility classes;
- remove the root dependency, workspace catalog entry, and lockfile records;
- remove two inline suppressions that only targeted the deleted rule;
- keep all Tailwind CSS build dependencies and application behavior unchanged;
- run the autofix job on the same `depot-ubuntu-24.04-4` runner used by the main static-check job.

This removes unknown-class lint coverage. Duplicate-class handling moves from a lint diagnostic to formatter deduplication. These trade-offs are isolated in this PR so they can be reviewed independently from the React, JSDoc, RegExp, and type-aware optimization candidates in the parent issue. The autofix runner change aligns its available CPU with the main CI `vp check` environment.

### Benchmark

The original configuration and the directly removed variant were each measured three times in the same window on an Apple M4 Pro with 24 GiB RAM:

| Configuration | Runs | Median wall time | Median user CPU | Registered rules | Visible warnings |
| --- | --- | ---: | ---: | ---: | ---: |
| Original configuration | 27.54 s, 28.30 s, 28.84 s | 28.30 s | 61.34 s | 401 | 2,599 |
| Tailwind lint plugin removed | 22.75 s, 22.69 s, 22.95 s | 22.75 s | 54.65 s | 399 | 2,439 |

Median lint wall time fell by 5.55 seconds (19.6%), and median user CPU fell by 6.69 CPU-seconds (10.9%). Maximum RSS was inconclusive because the run ranges overlapped. The measured removal variant retained the two obsolete inline suppressions; after cleaning them up, the final full check reports 2,437 warnings.

Benchmark command:

```sh
/usr/bin/time -lp pnpm lint:oxlint --format default --silent
```

Part of #38865.

## Screenshots

Not applicable; this change only affects static-check configuration.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Validation:

- `pnpm check` passes with 0 Oxlint errors, 2,437 existing warnings, and a successful ESLint fallback.
- `vp fmt --check vite.config.ts` passes with duplicate preservation disabled.
- ESLint and YAML parsing pass for `.github/workflows/autofix.yml`.
- `pnpm install --frozen-lockfile` passes and removes the plugin package from the local dependency tree.
- `git diff --check` passes.
- `cd web && pnpm exec vp staged` cannot run because `web/vite.config.ts` has no `staged` configuration. Running `pnpm exec vp staged` from the repository root with `lint.config.ts` staged reaches the configured tasks but reports existing standalone type-resolution errors for `node:path` and `import.meta.dirname`; the complete `pnpm check` successfully checks the same file. The subsequent workflow and formatter configuration commits pass the pre-commit hook.

No runtime test was added because this change only updates lint/format configuration, a CI runner label, and development dependencies.

From Codex
