### PR TITLE
fix(firecrawl): add bounded timeout to scrape/crawl requests

### DIFF
--- a/api/core/rag/extractor/firecrawl/firecrawl_app.py
+++ b/api/core/rag/extractor/firecrawl/firecrawl_app.py
@@ -6,6 +6,12 @@ import httpx
 
 from extensions.ext_storage import storage
 
+# Bounded timeout for Firecrawl scrape/crawl requests. Without it httpx blocks
+# forever, so a stalled endpoint hangs the extractor thread (and, via the retry
+# loop, does it three times). The read budget is generous because a single
+# scrape can legitimately take a while; the connect budget stays short.
+FIRECRAWL_REQUEST_TIMEOUT: httpx.Timeout = httpx.Timeout(60.0, connect=10.0)
+
 
 class FirecrawlDocumentData(TypedDict):
     title: str | None
@@ -176,7 +182,7 @@ class FirecrawlApp:
     def _post_request(self, url, data, headers, retries=3, backoff_factor=0.5) -> httpx.Response:
         response: httpx.Response | None = None
         for attempt in range(retries):
-            response = httpx.post(url, headers=headers, json=data)
+            response = httpx.post(url, headers=headers, json=data, timeout=FIRECRAWL_REQUEST_TIMEOUT)
             if response.status_code == 502:
                 time.sleep(backoff_factor * (2**attempt))
             else:
@@ -187,7 +193,7 @@ class FirecrawlApp:
     def _get_request(self, url, headers, retries=3, backoff_factor=0.5) -> httpx.Response:
         response: httpx.Response | None = None
         for attempt in range(retries):
-            response = httpx.get(url, headers=headers)
+            response = httpx.get(url, headers=headers, timeout=FIRECRAWL_REQUEST_TIMEOUT)
             if response.status_code == 502:
                 time.sleep(backoff_factor * (2**attempt))
             else:

--- a/api/tests/unit_tests/core/rag/extractor/firecrawl/test_firecrawl.py
+++ b/api/tests/unit_tests/core/rag/extractor/firecrawl/test_firecrawl.py
@@ -324,6 +324,25 @@ class TestFirecrawlApp:
 
         assert sleep_mock.call_count == 4
 
+    def test_post_and_get_request_pass_bounded_timeout(self, mocker: MockerFixture):
+        """Both request helpers must send a bounded httpx timeout so a stalled Firecrawl
+        endpoint cannot hang the extractor thread (once per retry, three times over)."""
+        app = FirecrawlApp(api_key="fc-key", base_url="https://custom.firecrawl.dev")
+
+        post_mock = mocker.patch("httpx.post", return_value=_response(200))
+        app._post_request("u", {"x": 1}, {"h": 1})
+        post_timeout = post_mock.call_args.kwargs["timeout"]
+        assert post_timeout is firecrawl_module.FIRECRAWL_REQUEST_TIMEOUT
+        assert post_timeout.read is not None
+        assert post_timeout.connect is not None
+
+        get_mock = mocker.patch("httpx.get", return_value=_response(200))
+        app._get_request("u", {"h": 1})
+        get_timeout = get_mock.call_args.kwargs["timeout"]
+        assert get_timeout is firecrawl_module.FIRECRAWL_REQUEST_TIMEOUT
+        assert get_timeout.read is not None
+        assert get_timeout.connect is not None
+
     def test_handle_error_with_json_and_plain_text(self):
         app = FirecrawlApp(api_key="fc-key", base_url="https://custom.firecrawl.dev")
 


### PR DESCRIPTION
# Summary

`FirecrawlApp._post_request` and `_get_request` issue `httpx.post` / `httpx.get` with no timeout, so a stalled Firecrawl endpoint blocks the RAG extractor thread indefinitely, and the surrounding retry loop repeats that hang up to three times. This mirrors the bounded-timeout sweep already merged for the watercrawl client (#37515, #37685) and for Firecrawl credential validation (#37638): both helpers now pass a module-level `FIRECRAWL_REQUEST_TIMEOUT = httpx.Timeout(60.0, connect=10.0)`. The read budget stays generous because a single scrape can legitimately take a while, while the short connect budget and finite read mean an unresponsive endpoint fails fast instead of hanging the ingestion worker.

# Screenshots

Backend-only change, no UI.

# Checklist

- [x] I have added tests that prove my fix is effective.
- [x] `ruff format` and `ruff check` pass on the changed files.
- [x] This is a bug fix; no documentation update is required.

# Test

Added `test_post_and_get_request_pass_bounded_timeout`, which asserts both helpers send `FIRECRAWL_REQUEST_TIMEOUT` with a non-None read and connect budget. The firecrawl unit tests pass (32 passed), and `ruff format` / `ruff check` are clean on both files.

From Claude Code
