### PR TITLE
refactor(web): avoid direct setState in effect in edit custom collection modal

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -4249,7 +4249,7 @@
   },
   "web/app/components/tools/edit-custom-collection-modal/index.tsx": {
     "eslint-react/set-state-in-effect": {
-      "count": 4
+      "count": 1
     },
     "jsx_a11y/click-events-have-key-events": {
       "count": 1

--- a/web/app/components/tools/edit-custom-collection-modal/index.tsx
+++ b/web/app/components/tools/edit-custom-collection-modal/index.tsx
@@ -80,14 +80,17 @@ const EditCustomCollectionModal: FC<Props> = ({
 
   const originalProvider = isEdit ? payload.provider : ''
 
-  // Sync customCollection state when payload changes
-  useEffect(() => {
+  // Sync state with the payload prop during render instead of in an effect.
+  // Tracking the previous payload keeps the sync running only when payload actually changes.
+  const [prevPayload, setPrevPayload] = useState(payload)
+  if (payload !== prevPayload) {
+    setPrevPayload(payload)
     if (isEdit) {
       setCustomCollection(payload)
       setParamsSchemas(payload.tools || [])
       setLabels(payload.labels || [])
     }
-  }, [isEdit, payload])
+  }
 
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
   const emoji = customCollection.icon


### PR DESCRIPTION
This PR refactors the state synchronization with the payload prop in the edit custom collection modal. Instead of running a direct setState inside a useEffect hook (which can cause unnecessary re-renders and is flagged by react-hooks-extra/no-direct-set-state-in-use-effect), the synchronization is performed during render and guarded by tracking the previous payload in a state ref.