### PR TITLE
fix: align member invitation state and errors

### DIFF
--- a/api/controllers/console/workspace/error.py
+++ b/api/controllers/console/workspace/error.py
@@ -35,3 +35,9 @@ class InvalidAccountDeletionCodeError(BaseHTTPException):
     error_code = "invalid_account_deletion_code"
     description = "Invalid account deletion code."
     code = 400
+
+
+class InvalidMemberRoleError(BaseHTTPException):
+    error_code = "invalid_role"
+    description = "Invalid role."
+    code = 400

--- a/api/controllers/console/workspace/members.py
+++ b/api/controllers/console/workspace/members.py
@@ -108,7 +108,7 @@ class MemberInviteResponse(ResponseModel):
 
 
 class MemberInviteErrorResponse(ResponseModel):
-    code: Literal["invalid_role", "limit_exceeded"]
+    code: Literal["invalid_param", "invalid_role", "limit_exceeded"]
     message: str
     status: Literal[400]
 

--- a/api/controllers/console/workspace/members.py
+++ b/api/controllers/console/workspace/members.py
@@ -24,6 +24,7 @@ from controllers.console.auth.error import (
     OwnerTransferLimitError,
 )
 from controllers.console.error import EmailSendIpLimitError, WorkspaceMembersLimitExceeded
+from controllers.console.workspace.error import InvalidMemberRoleError
 from controllers.console.wraps import (
     account_initialization_required,
     is_allow_transfer_owner,
@@ -106,6 +107,12 @@ class MemberInviteResponse(ResponseModel):
     tenant_id: str
 
 
+class MemberInviteErrorResponse(ResponseModel):
+    code: Literal["invalid_role", "limit_exceeded"]
+    message: str
+    status: Literal[400]
+
+
 register_enum_models(console_ns, TenantAccountRole)
 register_schema_models(
     console_ns,
@@ -120,6 +127,7 @@ register_response_schema_models(
     AccountWithRoleResponse,
     AccountWithRoleListResponse,
     MemberActionResponse,
+    MemberInviteErrorResponse,
     MemberInviteResponse,
     MemberInviteSuccessResponse,
     MemberInviteAlreadyMemberResponse,
@@ -249,6 +257,11 @@ class MemberInviteEmailApi(Resource):
 
     @console_ns.expect(console_ns.models[MemberInvitePayload.__name__])
     @console_ns.response(HTTPStatus.CREATED, "Success", console_ns.models[MemberInviteResponse.__name__])
+    @console_ns.response(
+        HTTPStatus.BAD_REQUEST,
+        "Invalid role or workspace member limit exceeded",
+        console_ns.models[MemberInviteErrorResponse.__name__],
+    )
     @setup_required
     @login_required
     @account_initialization_required
@@ -262,14 +275,14 @@ class MemberInviteEmailApi(Resource):
         interface_language = args.language
         if not dify_config.RBAC_ENABLED:
             if not TenantAccountRole.is_valid_role(invitee_role):
-                return {"code": "invalid-role", "message": "Invalid role"}, HTTPStatus.BAD_REQUEST
+                raise InvalidMemberRoleError()
             if not TenantAccountRole.is_non_owner_role(TenantAccountRole(invitee_role)):
-                return {"code": "invalid-role", "message": "Invalid role"}, HTTPStatus.BAD_REQUEST
+                raise InvalidMemberRoleError()
         inviter = current_user
         if not inviter.current_tenant:
             raise ValueError("No current tenant")
         if not _is_role_enabled(invitee_role, inviter.current_tenant.id):
-            return {"code": "invalid-role", "message": "Invalid role"}, HTTPStatus.BAD_REQUEST
+            raise InvalidMemberRoleError()
 
         # Check workspace permission for member invitations
         from libs.workspace_permission import check_workspace_member_invite_permission

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -10203,6 +10203,7 @@ Update a plugin endpoint
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
 | 201 | Success | **application/json**: [MemberInviteResponse](#memberinviteresponse)<br> |
+| 400 | Invalid role or workspace member limit exceeded | **application/json**: [MemberInviteErrorResponse](#memberinviteerrorresponse)<br> |
 
 ### [POST] /workspaces/current/members/owner-transfer-check
 #### Request Body
@@ -18648,6 +18649,14 @@ Enum class for large language model mode.
 | email | string |  | Yes |
 | message | string |  | Yes |
 | status | string |  | Yes |
+
+#### MemberInviteErrorResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| code | string, <br>**Available values:** "invalid_role", "limit_exceeded" | *Enum:* `"invalid_role"`, `"limit_exceeded"` | Yes |
+| message | string |  | Yes |
+| status | integer |  | Yes |
 
 #### MemberInviteFailedResponse
 

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -18654,7 +18654,7 @@ Enum class for large language model mode.
 
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
-| code | string, <br>**Available values:** "invalid_role", "limit_exceeded" | *Enum:* `"invalid_role"`, `"limit_exceeded"` | Yes |
+| code | string, <br>**Available values:** "invalid_param", "invalid_role", "limit_exceeded" | *Enum:* `"invalid_param"`, `"invalid_role"`, `"limit_exceeded"` | Yes |
 | message | string |  | Yes |
 | status | integer |  | Yes |
 

--- a/api/tests/unit_tests/controllers/console/test_workspace_members.py
+++ b/api/tests/unit_tests/controllers/console/test_workspace_members.py
@@ -5,6 +5,7 @@ from unittest.mock import ANY, patch
 import pytest
 from flask import Flask, g
 
+from controllers.console.workspace.error import InvalidMemberRoleError
 from controllers.console.workspace.members import MemberInviteEmailApi
 from models.account import Account, TenantAccountRole
 
@@ -150,10 +151,11 @@ class TestMemberInviteEmailApi:
                 account._current_tenant = tenant
                 g._login_user = account
                 g._current_tenant = tenant
-                response, status_code = MemberInviteEmailApi().post()
+                with pytest.raises(InvalidMemberRoleError) as exc_info:
+                    MemberInviteEmailApi().post()
 
-        assert status_code == 400
-        assert response["code"] == "invalid-role"
+        assert exc_info.value.error_code == "invalid_role"
+        assert exc_info.value.data == {"code": "invalid_role", "message": "Invalid role.", "status": 400}
 
     @patch("controllers.console.workspace.members.FeatureService.get_features")
     @patch("controllers.console.workspace.members.current_account_with_tenant")
@@ -186,7 +188,7 @@ class TestMemberInviteEmailApi:
                 account._current_tenant = tenant
                 g._login_user = account
                 g._current_tenant = tenant
-                response, status_code = MemberInviteEmailApi().post()
+                with pytest.raises(InvalidMemberRoleError) as exc_info:
+                    MemberInviteEmailApi().post()
 
-        assert status_code == 400
-        assert response["code"] == "invalid-role"
+        assert exc_info.value.error_code == "invalid_role"

--- a/api/tests/unit_tests/controllers/console/workspace/test_members.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_members.py
@@ -15,6 +15,7 @@ from controllers.console.auth.error import (
     OwnerTransferLimitError,
 )
 from controllers.console.error import EmailSendIpLimitError, WorkspaceMembersLimitExceeded
+from controllers.console.workspace.error import InvalidMemberRoleError
 from controllers.console.workspace.members import (
     DatasetOperatorMemberListApi,
     MemberInviteEmailApi,
@@ -253,10 +254,10 @@ class TestMemberInviteEmailApi:
         }
 
         with app.test_request_context("/", json=payload):
-            result, status = method(api, MagicMock())
+            with pytest.raises(InvalidMemberRoleError) as exc_info:
+                method(api, MagicMock())
 
-        assert status == 400
-        assert result["code"] == "invalid-role"
+        assert exc_info.value.error_code == "invalid_role"
 
     def test_invite_generic_exception(self, app: Flask):
         api = MemberInviteEmailApi()

--- a/api/tests/unit_tests/controllers/console/workspace/test_members.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_members.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
+from flask_restx import Resource
 
 from controllers.console.auth.error import (
     CannotTransferOwnerToSelfError,
@@ -19,12 +20,14 @@ from controllers.console.workspace.error import InvalidMemberRoleError
 from controllers.console.workspace.members import (
     DatasetOperatorMemberListApi,
     MemberInviteEmailApi,
+    MemberInviteErrorResponse,
     MemberListApi,
     MemberUpdateRoleApi,
     OwnerTransfer,
     OwnerTransferCheckApi,
     SendOwnerTransferEmailApi,
 )
+from libs.external_api import ExternalApi
 from services.errors.account import AccountAlreadyInTenantError
 
 
@@ -258,6 +261,25 @@ class TestMemberInviteEmailApi:
                 method(api, MagicMock())
 
         assert exc_info.value.error_code == "invalid_role"
+
+    def test_invite_invalid_payload_matches_documented_error_response(self):
+        app = Flask(__name__)
+        api = ExternalApi(app)
+        method = unwrap(MemberInviteEmailApi.post)
+
+        @api.route("/workspaces/current/members/invite-email")
+        class MemberInviteValidationApi(Resource):
+            def post(self):
+                return method(MemberInviteEmailApi(), MagicMock())
+
+        response = app.test_client().post(
+            "/workspaces/current/members/invite-email",
+            json={"emails": [], "role": "normal"},
+        )
+
+        assert response.status_code == 400
+        error = MemberInviteErrorResponse.model_validate(response.get_json())
+        assert error.code == "invalid_param"
 
     def test_invite_generic_exception(self, app: Flask):
         api = MemberInviteEmailApi()

--- a/api/tests/unit_tests/controllers/test_swagger.py
+++ b/api/tests/unit_tests/controllers/test_swagger.py
@@ -592,7 +592,11 @@ def test_console_member_invite_documents_bad_request_response(monkeypatch: pytes
     assert response_schema["$ref"] == "#/components/schemas/MemberInviteErrorResponse"
     assert payload["components"]["schemas"]["MemberInviteErrorResponse"] == {
         "properties": {
-            "code": {"enum": ["invalid_role", "limit_exceeded"], "title": "Code", "type": "string"},
+            "code": {
+                "enum": ["invalid_param", "invalid_role", "limit_exceeded"],
+                "title": "Code",
+                "type": "string",
+            },
             "message": {"title": "Message", "type": "string"},
             "status": {"const": 400, "title": "Status", "type": "integer"},
         },

--- a/api/tests/unit_tests/controllers/test_swagger.py
+++ b/api/tests/unit_tests/controllers/test_swagger.py
@@ -574,6 +574,34 @@ def test_console_account_avatar_query_param_renders_as_query(monkeypatch: pytest
     assert params["avatar"]["required"] is True
 
 
+def test_console_member_invite_documents_bad_request_response(monkeypatch: pytest.MonkeyPatch):
+    from configs import dify_config
+    from controllers.console import bp as console_bp
+
+    monkeypatch.setattr(dify_config, "SWAGGER_UI_ENABLED", True)
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["RESTX_INCLUDE_ALL_MODELS"] = True
+    app.register_blueprint(console_bp)
+
+    payload = app.test_client().get("/console/api/openapi.json").get_json()
+    operation = payload["paths"]["/workspaces/current/members/invite-email"]["post"]
+    response_schema = operation["responses"]["400"]["content"]["application/json"]["schema"]
+
+    assert response_schema["$ref"] == "#/components/schemas/MemberInviteErrorResponse"
+    assert payload["components"]["schemas"]["MemberInviteErrorResponse"] == {
+        "properties": {
+            "code": {"enum": ["invalid_role", "limit_exceeded"], "title": "Code", "type": "string"},
+            "message": {"title": "Message", "type": "string"},
+            "status": {"const": 400, "title": "Status", "type": "integer"},
+        },
+        "required": ["code", "message", "status"],
+        "title": "MemberInviteErrorResponse",
+        "type": "object",
+    }
+
+
 def test_console_plugin_category_list_exported_schema_uses_typed_items(tmp_path):
     from dev.generate_swagger_specs import generate_specs
 

--- a/packages/contracts/generated/api/console/workspaces/types.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/types.gen.ts
@@ -183,7 +183,7 @@ export type MemberInviteResponse = {
 }
 
 export type MemberInviteErrorResponse = {
-  code: 'invalid_role' | 'limit_exceeded'
+  code: 'invalid_param' | 'invalid_role' | 'limit_exceeded'
   message: string
   status: 400
 }

--- a/packages/contracts/generated/api/console/workspaces/types.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/types.gen.ts
@@ -182,6 +182,12 @@ export type MemberInviteResponse = {
   tenant_id: string
 }
 
+export type MemberInviteErrorResponse = {
+  code: 'invalid_role' | 'limit_exceeded'
+  message: string
+  status: 400
+}
+
 export type OwnerTransferCheckPayload = {
   code: string
   token: string
@@ -2903,6 +2909,13 @@ export type PostWorkspacesCurrentMembersInviteEmailData = {
   query?: never
   url: '/workspaces/current/members/invite-email'
 }
+
+export type PostWorkspacesCurrentMembersInviteEmailErrors = {
+  400: MemberInviteErrorResponse
+}
+
+export type PostWorkspacesCurrentMembersInviteEmailError =
+  PostWorkspacesCurrentMembersInviteEmailErrors[keyof PostWorkspacesCurrentMembersInviteEmailErrors]
 
 export type PostWorkspacesCurrentMembersInviteEmailResponses = {
   201: MemberInviteResponse

--- a/packages/contracts/generated/api/console/workspaces/zod.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/zod.gen.ts
@@ -96,6 +96,15 @@ export const zMemberInvitePayload = z.object({
 })
 
 /**
+ * MemberInviteErrorResponse
+ */
+export const zMemberInviteErrorResponse = z.object({
+  code: z.enum(['invalid_role', 'limit_exceeded']),
+  message: z.string(),
+  status: z.literal(400),
+})
+
+/**
  * OwnerTransferCheckPayload
  */
 export const zOwnerTransferCheckPayload = z.object({

--- a/packages/contracts/generated/api/console/workspaces/zod.gen.ts
+++ b/packages/contracts/generated/api/console/workspaces/zod.gen.ts
@@ -99,7 +99,7 @@ export const zMemberInvitePayload = z.object({
  * MemberInviteErrorResponse
  */
 export const zMemberInviteErrorResponse = z.object({
-  code: z.enum(['invalid_role', 'limit_exceeded']),
+  code: z.enum(['invalid_param', 'invalid_role', 'limit_exceeded']),
   message: z.string(),
   status: z.literal(400),
 })

--- a/web/app/components/header/account-setting/members-page/index.tsx
+++ b/web/app/components/header/account-setting/members-page/index.tsx
@@ -42,9 +42,8 @@ const MembersPage = () => {
   const { data: systemFeatures } = useSuspenseQuery(systemFeaturesQueryOptions())
   const [inviteModalVisible, setInviteModalVisible] = useState(false)
   const [invitationResults, setInvitationResults] = useState<
-    MemberInviteResponse['invitation_results']
-  >([])
-  const [invitedModalVisible, setInvitedModalVisible] = useState(false)
+    MemberInviteResponse['invitation_results'] | null
+  >(null)
   const accounts = data?.accounts || []
   const { plan, enableBilling, isAllowTransferWorkspace } = useProviderContext()
   const isNotUnlimitedMemberPlan =
@@ -166,10 +165,7 @@ const MembersPage = () => {
                 trigger={<InviteButton />}
                 isEmailSetup={systemFeatures.is_email_setup}
                 onOpenChange={setInviteModalVisible}
-                onSend={(invitationResults) => {
-                  setInvitedModalVisible(true)
-                  setInvitationResults(invitationResults)
-                }}
+                onSend={setInvitationResults}
               />
             )}
           </div>
@@ -203,10 +199,10 @@ const MembersPage = () => {
           </div>
         </div>
       </div>
-      {invitedModalVisible && (
+      {invitationResults && (
         <InvitedModal
           invitationResults={invitationResults}
-          onCancel={() => setInvitedModalVisible(false)}
+          onCancel={() => setInvitationResults(null)}
         />
       )}
       {editWorkspaceModalVisible && (

--- a/web/app/components/header/account-setting/members-page/invite-modal/README.md
+++ b/web/app/components/header/account-setting/members-page/invite-modal/README.md
@@ -1,0 +1,21 @@
+# Member Invitations
+
+Owns the workspace member invitation form, including email recipient composition, role selection, submission errors, and invitation request state.
+
+Base UI Form owns field registration, validation, external field errors, and invalid-field focus. TanStack Query owns invitation mutation state. This module keeps only the controlled email composition value and business submission outcome.
+
+## Internal Modules
+
+None.
+
+## External Modules
+
+| Module                                       | Why this module uses it                                       |
+| -------------------------------------------- | ------------------------------------------------------------- |
+| `@dify/contracts/api/console/workspaces`     | Types invite responses and documented invite error codes.     |
+| `context/i18n`                               | Provides the current locale for role queries and invitations. |
+| `context/provider-context`                   | Provides workspace seat limits and refresh capability.        |
+| `models/access-control`                      | Types workspace role options.                                 |
+| `service/access-control/use-workspace-roles` | Loads paginated role options.                                 |
+| `service/client`                             | Executes the invitation mutation.                             |
+| `service/use-common`                         | Invalidates member list queries after a successful invite.    |

--- a/web/app/components/header/account-setting/members-page/invite-modal/__tests__/index.spec.tsx
+++ b/web/app/components/header/account-setting/members-page/invite-modal/__tests__/index.spec.tsx
@@ -598,6 +598,45 @@ describe('InviteModal', () => {
     })
   })
 
+  it('should clear an email server error when a recipient is removed before retrying', async () => {
+    const user = userEvent.setup()
+    inviteMember
+      .mockRejectedValueOnce({
+        code: 'BAD_REQUEST',
+        data: { body: { code: 'limit_exceeded', message: 'Backend message' } },
+      })
+      .mockResolvedValueOnce({
+        result: 'success',
+        invitation_results: [],
+        tenant_id: 'tenant-id',
+      } satisfies MemberInviteResponse)
+    renderModal()
+
+    await addRecipients(user, 'first@example.com, second@example.com')
+    await selectAdminRole(user)
+    await user.click(screen.getByRole('button', { name: /members\.sendInvite/i }))
+
+    expect(await screen.findByText(/members\.inviteLimitExceeded/i)).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', { name: /operation\.remove.*second@example\.com/i }),
+    )
+    expect(screen.queryByText(/members\.inviteLimitExceeded/i)).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /members\.sendInvite/i }))
+
+    await waitFor(() => {
+      expect(inviteMember).toHaveBeenCalledTimes(2)
+      expect(inviteMember.mock.calls[1]?.[0]).toEqual({
+        body: {
+          emails: ['first@example.com'],
+          role: 'admin',
+          language: 'en-US',
+        },
+      })
+    })
+  })
+
   it('keeps unknown request failures as a persistent form error', async () => {
     const user = userEvent.setup()
     inviteMember.mockRejectedValue(new Error('Network failed'))

--- a/web/app/components/header/account-setting/members-page/invite-modal/__tests__/index.spec.tsx
+++ b/web/app/components/header/account-setting/members-page/invite-modal/__tests__/index.spec.tsx
@@ -61,9 +61,20 @@ describe('InviteModal', () => {
                 permission_keys: [],
                 role_tag: '',
               },
+              {
+                id: 'editor',
+                tenant_id: 'tenant-id',
+                type: 'workspace',
+                category: 'global_system_default',
+                name: 'Editor',
+                description: 'Can build and edit apps',
+                is_builtin: true,
+                permission_keys: [],
+                role_tag: '',
+              },
             ],
             pagination: {
-              total_count: 1,
+              total_count: 2,
               per_page: 20,
               current_page: 1,
               total_pages: 1,
@@ -503,7 +514,7 @@ describe('InviteModal', () => {
 
   it.each([
     ['limit_exceeded', /members\.inviteLimitExceeded/i, 'emails', 'textbox'],
-    ['invalid-role', /members\.invalidRole/i, 'role', 'combobox'],
+    ['invalid_role', /members\.invalidRole/i, 'role', 'combobox'],
   ])('maps %s server validation to the owning field', async (code, message, fieldName, role) => {
     const user = userEvent.setup()
     inviteMember.mockRejectedValue({
@@ -524,6 +535,29 @@ describe('InviteModal', () => {
       }),
     ).toHaveFocus()
     expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
+  it('keeps a role server error visible when the user only opens the selector', async () => {
+    const user = userEvent.setup()
+    inviteMember.mockRejectedValue({
+      code: 'BAD_REQUEST',
+      data: { body: { code: 'invalid_role', message: 'Backend message' } },
+    })
+    renderModal()
+
+    await addRecipients(user, 'user@example.com')
+    await selectAdminRole(user)
+    await user.click(screen.getByRole('button', { name: /members\.sendInvite/i }))
+
+    expect(await screen.findByText(/members\.invalidRole/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('combobox', { name: /members\.role/i }))
+
+    expect(screen.getByText(/members\.invalidRole/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('option', { name: /Editor/i }))
+
+    expect(screen.queryByText(/members\.invalidRole/i)).not.toBeInTheDocument()
   })
 
   it('should clear an email server error when the user edits and successfully retries', async () => {

--- a/web/app/components/header/account-setting/members-page/invite-modal/__tests__/invite-error.spec.ts
+++ b/web/app/components/header/account-setting/members-page/invite-modal/__tests__/invite-error.spec.ts
@@ -1,7 +1,7 @@
 import { getInviteErrorCode } from '../invite-error'
 
 describe('getInviteErrorCode', () => {
-  it.each(['invalid_role', 'limit_exceeded'])(
+  it.each(['invalid_param', 'invalid_role', 'limit_exceeded'])(
     'reads the documented %s code from the contract error body',
     (code) => {
       expect(getInviteErrorCode({ data: { body: { code } } })).toBe(code)

--- a/web/app/components/header/account-setting/members-page/invite-modal/__tests__/invite-error.spec.ts
+++ b/web/app/components/header/account-setting/members-page/invite-modal/__tests__/invite-error.spec.ts
@@ -1,0 +1,15 @@
+import { getInviteErrorCode } from '../invite-error'
+
+describe('getInviteErrorCode', () => {
+  it.each(['invalid_role', 'limit_exceeded'])(
+    'reads the documented %s code from the contract error body',
+    (code) => {
+      expect(getInviteErrorCode({ data: { body: { code } } })).toBe(code)
+    },
+  )
+
+  it('ignores transport and undocumented error codes', () => {
+    expect(getInviteErrorCode({ code: 'BAD_REQUEST' })).toBeNull()
+    expect(getInviteErrorCode({ data: { body: { code: 'invalid-role' } } })).toBeNull()
+  })
+})

--- a/web/app/components/header/account-setting/members-page/invite-modal/__tests__/role-selector.spec.tsx
+++ b/web/app/components/header/account-setting/members-page/invite-modal/__tests__/role-selector.spec.tsx
@@ -1,7 +1,6 @@
 import type { Role, RoleListResponse } from '@/models/access-control'
 import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { useState } from 'react'
 import { vi } from 'vitest'
 import { useWorkspaceRoleList } from '@/service/access-control/use-workspace-roles'
 import { RoleSelector } from '../role-selector'
@@ -40,28 +39,27 @@ const createPage = (data: Role[]): RoleListResponse => ({
 const mockUseWorkspaceRoleList = ({
   data = roles,
   isLoading = false,
+  error = null,
   hasNextPage = false,
   fetchNextPage = vi.fn(),
 }: {
   data?: Role[]
   isLoading?: boolean
+  error?: Error | null
   hasNextPage?: boolean
   fetchNextPage?: () => void
 } = {}) => {
   vi.mocked(useWorkspaceRoleList).mockReturnValue({
     data: { pages: [createPage(data)], pageParams: [1] },
     isLoading,
-    error: null,
+    error,
     hasNextPage,
     isFetchingNextPage: false,
     fetchNextPage,
   } as unknown as ReturnType<typeof useWorkspaceRoleList>)
 }
 
-const RoleSelectorWrapper = ({ initialRole = null }: { initialRole?: Role | null }) => {
-  const [role, setRole] = useState<Role | null>(initialRole)
-  return <RoleSelector value={role} onChange={setRole} />
-}
+const RoleSelectorWrapper = () => <RoleSelector />
 
 const getTrigger = () => screen.getByRole('combobox', { name: /members\.role/i })
 const getListbox = () => screen.getByRole('listbox', { name: /members\.role/i })
@@ -128,6 +126,18 @@ describe('RoleSelector', () => {
     mockUseWorkspaceRoleList({ data: [] })
     rerender(<RoleSelectorWrapper />)
     expect(within(getListbox()).getByText(/dynamicSelect\.noData/i)).toBeInTheDocument()
+  })
+
+  it('shows an error instead of treating a failed role query as empty', async () => {
+    const user = userEvent.setup()
+    mockUseWorkspaceRoleList({ data: [], error: new Error('Failed to load roles') })
+    render(<RoleSelectorWrapper />)
+
+    await user.click(getTrigger())
+
+    expect(within(getListbox()).getByText(/dynamicSelect\.error/i)).toBeInTheDocument()
+    expect(within(getListbox()).queryByText(/dynamicSelect\.noData/i)).not.toBeInTheDocument()
+    expect(within(getListbox()).queryByRole('button')).not.toBeInTheDocument()
   })
 
   it('loads another role page when the list sentinel becomes visible', async () => {

--- a/web/app/components/header/account-setting/members-page/invite-modal/__tests__/role-selector.spec.tsx
+++ b/web/app/components/header/account-setting/members-page/invite-modal/__tests__/role-selector.spec.tsx
@@ -140,6 +140,17 @@ describe('RoleSelector', () => {
     expect(within(getListbox()).queryByRole('button')).not.toBeInTheDocument()
   })
 
+  it('keeps loaded roles available when a later request fails', async () => {
+    const user = userEvent.setup()
+    mockUseWorkspaceRoleList({ error: new Error('Failed to load another role page') })
+    render(<RoleSelectorWrapper />)
+
+    await user.click(getTrigger())
+
+    expect(within(getListbox()).getByRole('option', { name: /Admin/i })).toBeInTheDocument()
+    expect(within(getListbox()).queryByText(/dynamicSelect\.error/i)).not.toBeInTheDocument()
+  })
+
   it('loads another role page when the list sentinel becomes visible', async () => {
     const user = userEvent.setup()
     const fetchNextPage = vi.fn()

--- a/web/app/components/header/account-setting/members-page/invite-modal/email-recipients-field.tsx
+++ b/web/app/components/header/account-setting/members-page/invite-modal/email-recipients-field.tsx
@@ -38,7 +38,6 @@ export function EmailRecipientsField({
   const chipButtonRef = useRef<Array<HTMLButtonElement | null>>([])
   const selectDraftOnRenderRef = useRef(false)
   const [draftTouched, setDraftTouched] = useState(false)
-  const inputRef = internalInputRef
   const hasInvalidRecipient = recipients.some(({ isValid }) => !isValid)
   const draftRecipients = mergeEmailRecipients([], draft)
   const hasInvalidDraft = Boolean(
@@ -70,19 +69,19 @@ export function EmailRecipientsField({
   }
 
   const focusInput = (select = false) => {
-    inputRef.current?.focus()
+    internalInputRef.current?.focus()
     if (select) {
       selectDraftOnRenderRef.current = true
-      inputRef.current?.select()
+      internalInputRef.current?.select()
     }
   }
 
   useEffect(() => {
     if (!selectDraftOnRenderRef.current) return
 
-    inputRef.current?.select()
+    internalInputRef.current?.select()
     selectDraftOnRenderRef.current = false
-  }, [draft, inputRef])
+  }, [draft])
 
   const removeRecipient = (index: number, focus: 'input' | 'neighbor') => {
     const nextRecipients = recipients.filter((_, recipientIndex) => recipientIndex !== index)
@@ -247,7 +246,7 @@ export function EmailRecipientsField({
           </ul>
         )}
         <FieldControl
-          ref={inputRef}
+          ref={internalInputRef}
           type="text"
           disabled={disabled}
           autoComplete="off"

--- a/web/app/components/header/account-setting/members-page/invite-modal/email-recipients-field.tsx
+++ b/web/app/components/header/account-setting/members-page/invite-modal/email-recipients-field.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { KeyboardEvent, RefObject } from 'react'
+import type { KeyboardEvent } from 'react'
 import type { EmailRecipient } from './email-recipients'
 import { cn } from '@langgenius/dify-ui/cn'
 import {
@@ -19,10 +19,7 @@ type EmailRecipientsFieldProps = {
   draft: string
   onRecipientsChange: (recipients: EmailRecipient[]) => void
   onDraftChange: (draft: string) => void
-  onChange?: () => void
-  error?: string
   disabled?: boolean
-  inputRef?: RefObject<HTMLInputElement | null>
 }
 
 function isRightToLeft(element: HTMLElement) {
@@ -34,17 +31,14 @@ export function EmailRecipientsField({
   draft,
   onRecipientsChange,
   onDraftChange,
-  onChange,
-  error,
   disabled = false,
-  inputRef: externalInputRef,
 }: EmailRecipientsFieldProps) {
   const { t } = useTranslation()
   const internalInputRef = useRef<HTMLInputElement>(null)
   const chipButtonRef = useRef<Array<HTMLButtonElement | null>>([])
   const selectDraftOnRenderRef = useRef(false)
   const [draftTouched, setDraftTouched] = useState(false)
-  const inputRef = externalInputRef ?? internalInputRef
+  const inputRef = internalInputRef
   const hasInvalidRecipient = recipients.some(({ isValid }) => !isValid)
   const draftRecipients = mergeEmailRecipients([], draft)
   const hasInvalidDraft = Boolean(
@@ -53,7 +47,7 @@ export function EmailRecipientsField({
   const fieldError =
     hasInvalidRecipient || hasInvalidDraft
       ? t(($) => $['members.emailInvalid'], { ns: 'common' })
-      : error
+      : null
 
   const validateRecipients = (value: unknown) => {
     const nextDraft = typeof value === 'string' ? value : draft
@@ -69,12 +63,10 @@ export function EmailRecipientsField({
 
   const updateRecipients = (nextRecipients: EmailRecipient[]) => {
     onRecipientsChange(nextRecipients)
-    onChange?.()
   }
 
   const updateDraft = (nextDraft: string) => {
     onDraftChange(nextDraft)
-    onChange?.()
   }
 
   const focusInput = (select = false) => {
@@ -320,7 +312,7 @@ export function EmailRecipientsField({
         <FieldError match>{fieldError}</FieldError>
       ) : (
         <>
-          <FieldError match="customError" />
+          <FieldError />
           <FieldDescription className="group-data-invalid/field:hidden">
             {t(($) => $['members.emailRecipientsTip'], { ns: 'common' })}
           </FieldDescription>

--- a/web/app/components/header/account-setting/members-page/invite-modal/email-recipients-field.tsx
+++ b/web/app/components/header/account-setting/members-page/invite-modal/email-recipients-field.tsx
@@ -19,6 +19,7 @@ type EmailRecipientsFieldProps = {
   draft: string
   onRecipientsChange: (recipients: EmailRecipient[]) => void
   onDraftChange: (draft: string) => void
+  onChange?: () => void
   disabled?: boolean
 }
 
@@ -31,6 +32,7 @@ export function EmailRecipientsField({
   draft,
   onRecipientsChange,
   onDraftChange,
+  onChange,
   disabled = false,
 }: EmailRecipientsFieldProps) {
   const { t } = useTranslation()
@@ -62,10 +64,12 @@ export function EmailRecipientsField({
 
   const updateRecipients = (nextRecipients: EmailRecipient[]) => {
     onRecipientsChange(nextRecipients)
+    onChange?.()
   }
 
   const updateDraft = (nextDraft: string) => {
     onDraftChange(nextDraft)
+    onChange?.()
   }
 
   const focusInput = (select = false) => {

--- a/web/app/components/header/account-setting/members-page/invite-modal/index.tsx
+++ b/web/app/components/header/account-setting/members-page/invite-modal/index.tsx
@@ -1,10 +1,8 @@
 'use client'
 
 import type { MemberInviteResponse } from '@dify/contracts/api/console/workspaces/types.gen'
-import type { FormProps } from '@langgenius/dify-ui/form'
 import type { ReactElement } from 'react'
 import type { EmailRecipient } from './email-recipients'
-import type { Role } from '@/models/access-control'
 import { Button } from '@langgenius/dify-ui/button'
 import {
   Dialog,
@@ -16,7 +14,7 @@ import {
 } from '@langgenius/dify-ui/dialog'
 import { Form } from '@langgenius/dify-ui/form'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocale } from '@/context/i18n'
 import { useProviderContextSelector } from '@/context/provider-context'
@@ -35,12 +33,15 @@ type InviteModalProps = {
   onSend: (invitationResults: MemberInviteResponse['invitation_results']) => void
 }
 
-type SubmitError = {
-  target: 'emails' | 'role' | 'form'
-  message: string
-} | null
-
-type FormSubmitHandler = NonNullable<FormProps['onSubmit']>
+type InviteFieldName = 'emails' | 'role'
+type InviteFormValues = {
+  emails: string
+  role: string
+}
+type SubmissionError =
+  | { kind: 'fields'; errors: Partial<Record<InviteFieldName, string>> }
+  | { kind: 'form'; message: string }
+  | null
 
 type InviteFormProps = Omit<InviteModalProps, 'open' | 'trigger'>
 
@@ -52,90 +53,75 @@ function InviteForm({ isEmailSetup, onOpenChange, onSend }: InviteFormProps) {
   const refreshLicenseLimit = useProviderContextSelector((state) => state.refreshLicenseLimit)
   const [recipients, setRecipients] = useState<EmailRecipient[]>([])
   const [draft, setDraft] = useState('')
-  const [role, setRole] = useState<Role | null>(null)
-  const [submitError, setSubmitError] = useState<SubmitError>(null)
-  const emailInputRef = useRef<HTMLInputElement>(null)
-  const roleTriggerRef = useRef<HTMLButtonElement>(null)
-  const emailServerError = submitError?.target === 'emails' ? submitError.message : undefined
-  const roleError = submitError?.target === 'role' ? submitError.message : undefined
+  const [submissionError, setSubmissionError] = useState<SubmissionError>(null)
+  const fieldErrors = submissionError?.kind === 'fields' ? submissionError.errors : undefined
   const currentSize = licenseLimit.workspace_members.size ?? 0
   const memberLimit = licenseLimit.workspace_members.limit
   const remainingSeats = memberLimit > 0 ? Math.max(memberLimit - currentSize, 0) : null
   const effectiveRecipients = mergeEmailRecipients(recipients, draft)
   const validRecipientCount = effectiveRecipients.filter(({ isValid }) => isValid).length
   const exceedsRemainingSeats = remainingSeats !== null && validRecipientCount > remainingSeats
-  const formErrors = {
-    ...(emailServerError ? { emails: emailServerError } : {}),
-    ...(roleError ? { role: roleError } : {}),
-  }
 
-  const { mutateAsync, isPending } = useMutation(
+  const { mutate, isPending } = useMutation(
     consoleQuery.workspaces.current.members.inviteEmail.post.mutationOptions({
       context: { silent: true },
     }),
   )
 
-  const clearSubmitError = (target: 'emails' | 'role') => {
-    setSubmitError((error) => (error?.target === target ? null : error))
-  }
-
-  useEffect(() => {
-    if (submitError?.target === 'emails') emailInputRef.current?.focus()
-    if (submitError?.target === 'role') roleTriggerRef.current?.focus()
-  }, [submitError])
-
-  const handleSubmit: FormSubmitHandler = async (event) => {
-    event.preventDefault()
+  const handleSubmit = ({ role }: InviteFormValues) => {
     if (isPending) return
 
     setRecipients(effectiveRecipients)
     setDraft('')
-
-    if (!role) return
-
-    setSubmitError(null)
-    try {
-      const response = await mutateAsync({
+    setSubmissionError(null)
+    mutate(
+      {
         body: {
           emails: effectiveRecipients.map(({ value }) => value),
-          role: role.id,
+          role,
           language: locale,
         },
-      })
-
-      refreshLicenseLimit()
-      void queryClient.invalidateQueries({ queryKey: commonQueryKeys.members })
-      onOpenChange(false)
-      onSend(response.invitation_results)
-    } catch (error) {
-      switch (getInviteErrorCode(error)) {
-        case 'limit_exceeded':
-          setSubmitError({
-            target: 'emails',
-            message: t(($) => $['members.inviteLimitExceeded'], { ns: 'common' }),
-          })
-          break
-        case 'invalid-role':
-          setSubmitError({
-            target: 'role',
-            message: t(($) => $['members.invalidRole'], { ns: 'common' }),
-          })
-          break
-        default:
-          setSubmitError({
-            target: 'form',
-            message: t(($) => $['members.inviteFailed'], { ns: 'common' }),
-          })
-      }
-    }
+      },
+      {
+        onSuccess: (response) => {
+          refreshLicenseLimit()
+          void queryClient.invalidateQueries({ queryKey: commonQueryKeys.members })
+          onOpenChange(false)
+          onSend(response.invitation_results)
+        },
+        onError: (error) => {
+          switch (getInviteErrorCode(error)) {
+            case 'limit_exceeded':
+              setSubmissionError({
+                kind: 'fields',
+                errors: {
+                  emails: t(($) => $['members.inviteLimitExceeded'], { ns: 'common' }),
+                },
+              })
+              break
+            case 'invalid_role':
+              setSubmissionError({
+                kind: 'fields',
+                errors: { role: t(($) => $['members.invalidRole'], { ns: 'common' }) },
+              })
+              break
+            default:
+              setSubmissionError({
+                kind: 'form',
+                message: t(($) => $['members.inviteFailed'], { ns: 'common' }),
+              })
+          }
+        },
+      },
+    )
   }
 
   return (
-    <Form
+    <Form<InviteFormValues>
       aria-label={t(($) => $['members.inviteTeamMember'], { ns: 'common' })}
-      errors={formErrors}
+      errors={fieldErrors}
       className="grid gap-5 pt-5"
-      onSubmit={handleSubmit}
+      onFormSubmit={handleSubmit}
     >
       {!isEmailSetup && (
         <div className="flex items-start gap-1.5 rounded-lg bg-state-warning-hover p-2 text-text-warning">
@@ -150,19 +136,9 @@ function InviteForm({ isEmailSetup, onOpenChange, onSend }: InviteFormProps) {
         draft={draft}
         onRecipientsChange={setRecipients}
         onDraftChange={setDraft}
-        onChange={() => clearSubmitError('emails')}
-        error={emailServerError}
         disabled={isPending}
-        inputRef={emailInputRef}
       />
-      <RoleSelector
-        value={role}
-        onChange={setRole}
-        onInteract={() => clearSubmitError('role')}
-        error={roleError}
-        disabled={isPending}
-        triggerRef={roleTriggerRef}
-      />
+      <RoleSelector hasServerError={Boolean(fieldErrors?.role)} disabled={isPending} />
       {exceedsRemainingSeats && (
         <div
           role="status"
@@ -179,9 +155,9 @@ function InviteForm({ isEmailSetup, onOpenChange, onSend }: InviteFormProps) {
           </span>
         </div>
       )}
-      {submitError?.target === 'form' && (
+      {submissionError?.kind === 'form' && (
         <div role="alert" className="body-xs-regular text-text-destructive">
-          {submitError.message}
+          {submissionError.message}
         </div>
       )}
       <Button

--- a/web/app/components/header/account-setting/members-page/invite-modal/index.tsx
+++ b/web/app/components/header/account-setting/members-page/invite-modal/index.tsx
@@ -68,6 +68,10 @@ function InviteForm({ isEmailSetup, onOpenChange, onSend }: InviteFormProps) {
     }),
   )
 
+  const clearEmailSubmissionError = () => {
+    setSubmissionError((error) => (error?.kind === 'fields' && error.errors.emails ? null : error))
+  }
+
   const handleSubmit = ({ role }: InviteFormValues) => {
     if (isPending) return
 
@@ -136,6 +140,7 @@ function InviteForm({ isEmailSetup, onOpenChange, onSend }: InviteFormProps) {
         draft={draft}
         onRecipientsChange={setRecipients}
         onDraftChange={setDraft}
+        onChange={clearEmailSubmissionError}
         disabled={isPending}
       />
       <RoleSelector hasServerError={Boolean(fieldErrors?.role)} disabled={isPending} />

--- a/web/app/components/header/account-setting/members-page/invite-modal/invite-error.ts
+++ b/web/app/components/header/account-setting/members-page/invite-modal/invite-error.ts
@@ -2,7 +2,11 @@ import type { MemberInviteErrorResponse } from '@dify/contracts/api/console/work
 
 type InviteErrorCode = MemberInviteErrorResponse['code']
 
-const INVITE_ERROR_CODES = new Set<InviteErrorCode>(['invalid_role', 'limit_exceeded'])
+const INVITE_ERROR_CODES = new Set<InviteErrorCode>([
+  'invalid_param',
+  'invalid_role',
+  'limit_exceeded',
+])
 
 function getRecord(value: unknown) {
   return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null

--- a/web/app/components/header/account-setting/members-page/invite-modal/invite-error.ts
+++ b/web/app/components/header/account-setting/members-page/invite-modal/invite-error.ts
@@ -1,12 +1,20 @@
+import type { MemberInviteErrorResponse } from '@dify/contracts/api/console/workspaces/types.gen'
+
+type InviteErrorCode = MemberInviteErrorResponse['code']
+
+const INVITE_ERROR_CODES = new Set<InviteErrorCode>(['invalid_role', 'limit_exceeded'])
+
 function getRecord(value: unknown) {
   return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null
 }
 
-export function getInviteErrorCode(error: unknown) {
+export function getInviteErrorCode(error: unknown): InviteErrorCode | null {
   const errorRecord = getRecord(error)
   const dataRecord = getRecord(errorRecord?.data)
   const bodyRecord = getRecord(dataRecord?.body)
   const code = bodyRecord?.code ?? errorRecord?.code
 
-  return typeof code === 'string' ? code : null
+  return typeof code === 'string' && INVITE_ERROR_CODES.has(code as InviteErrorCode)
+    ? (code as InviteErrorCode)
+    : null
 }

--- a/web/app/components/header/account-setting/members-page/invite-modal/role-selector.tsx
+++ b/web/app/components/header/account-setting/members-page/invite-modal/role-selector.tsx
@@ -164,7 +164,7 @@ export function RoleSelector({ hasServerError = false, disabled = false }: RoleS
             <div className="px-3 py-6 text-center system-sm-regular text-text-tertiary">
               {t(($) => $.loading, { ns: 'common' })}
             </div>
-          ) : rolesError ? (
+          ) : rolesError && roles.length === 0 ? (
             <div className="px-3 py-6 text-center system-sm-regular text-text-destructive-secondary">
               {t(($) => $['dynamicSelect.error'], { ns: 'common' })}
             </div>

--- a/web/app/components/header/account-setting/members-page/invite-modal/role-selector.tsx
+++ b/web/app/components/header/account-setting/members-page/invite-modal/role-selector.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import type { Ref } from 'react'
 import type { Role } from '@/models/access-control'
 import { Field, FieldError } from '@langgenius/dify-ui/field'
 import {
@@ -20,12 +19,8 @@ import { getAccessControlTemplateLanguage } from '@/i18n-config/language'
 import { useWorkspaceRoleList } from '@/service/access-control/use-workspace-roles'
 
 type RoleSelectorProps = {
-  value: Role | null
-  onChange: (role: Role | null) => void
-  onInteract?: () => void
-  error?: string
+  hasServerError?: boolean
   disabled?: boolean
-  triggerRef?: Ref<HTMLButtonElement>
 }
 
 const PAGE_SIZE = 20
@@ -51,14 +46,7 @@ function getLegacyRoleDescriptionKey(role: Role) {
   return candidateKeys.find(isLegacyRoleKey)
 }
 
-export function RoleSelector({
-  value,
-  onChange,
-  onInteract,
-  error,
-  disabled = false,
-  triggerRef,
-}: RoleSelectorProps) {
+export function RoleSelector({ hasServerError = false, disabled = false }: RoleSelectorProps) {
   const { t } = useTranslation()
   const locale = useLocale()
   const [open, setOpen] = useState(false)
@@ -150,27 +138,19 @@ export function RoleSelector({
   }
 
   return (
-    <Field name="role" invalid={Boolean(error)}>
+    <Field name="role">
       <Select<Role>
         name="role"
         required
         disabled={disabled}
-        value={value}
         open={open}
-        onOpenChange={(nextOpen) => {
-          setOpen(nextOpen)
-          onInteract?.()
-        }}
-        onValueChange={(nextRole) => {
-          onChange(nextRole)
-          onInteract?.()
-        }}
+        onOpenChange={setOpen}
         itemToStringLabel={(role) => role.name}
         itemToStringValue={(role) => role.id}
         isItemEqualToValue={(role, selectedRole) => role.id === selectedRole.id}
       >
         <SelectLabel>{t(($) => $['members.role'], { ns: 'common' })}</SelectLabel>
-        <SelectTrigger ref={triggerRef}>
+        <SelectTrigger>
           <SelectValue placeholder={t(($) => $['members.selectRole'], { ns: 'common' })} />
         </SelectTrigger>
         <SelectContent
@@ -183,6 +163,10 @@ export function RoleSelector({
           {rolesLoading ? (
             <div className="px-3 py-6 text-center system-sm-regular text-text-tertiary">
               {t(($) => $.loading, { ns: 'common' })}
+            </div>
+          ) : rolesError ? (
+            <div className="px-3 py-6 text-center system-sm-regular text-text-destructive-secondary">
+              {t(($) => $['dynamicSelect.error'], { ns: 'common' })}
             </div>
           ) : roles.length === 0 ? (
             <div className="px-3 py-6 text-center system-sm-regular text-text-tertiary">
@@ -208,10 +192,13 @@ export function RoleSelector({
           )}
         </SelectContent>
       </Select>
-      <FieldError match="valueMissing">
-        {t(($) => $['members.selectRole'], { ns: 'common' })}
-      </FieldError>
-      <FieldError match={Boolean(error)}>{error}</FieldError>
+      {hasServerError ? (
+        <FieldError />
+      ) : (
+        <FieldError match="valueMissing">
+          {t(($) => $['members.selectRole'], { ns: 'common' })}
+        </FieldError>
+      )}
     </Field>
   )
 }


### PR DESCRIPTION
## Summary

- consolidate invitation form state around Base UI validation and form-owned role values
- distinguish role query failures from empty results and remove redundant invitation result visibility state
- normalize the invite invalid-role response to `invalid_role`, document its 400 response, and regenerate API contracts

## Why

The invite flow duplicated field errors and focus state across the feature and Base UI Form, cleared role errors when the selector merely opened, and treated role query failures as empty data. The backend also returned a manually written kebab-case error code alongside snake-case exception codes.

The invite endpoint and frontend now use `invalid_role` as a clean break. The frontend intentionally does not recognize the legacy `invalid-role` code.

## Validation

- `pnpm -C web test ...`: 99 tests passed across 6 focused files
- `pnpm -C web type-check`
- `pnpm check`
- focused backend controller and Swagger tests: 44 passed
- `pnpm --filter @dify/contracts test`: 4 passed
- `pnpm --filter @dify/contracts type-check`
- Ruff check and format check
- `git diff --check`