### PR TITLE
fix: bridge Dify design tokens for streamdown table fullscreen (cherry-pick #34224)

### DIFF
--- a/web/app/styles/markdown.css
+++ b/web/app/styles/markdown.css
@@ -582,6 +582,44 @@
   background-color: var(--color-components-menu-item-bg-hover);
 }
 
+[data-streamdown="table-fullscreen"] {
+  background-color: var(--color-components-panel-bg);
+  color: var(--color-text-primary);
+}
+
+[data-streamdown="table-fullscreen"] button {
+  color: var(--color-text-tertiary);
+}
+
+[data-streamdown="table-fullscreen"] button:hover {
+  color: var(--color-text-primary);
+  background-color: var(--color-background-section-burn);
+}
+
+[data-streamdown="table-fullscreen"] table[data-streamdown="table"] {
+  border-color: var(--color-divider-regular);
+}
+
+[data-streamdown="table-fullscreen"] [data-streamdown="table-header"] {
+  background-color: var(--color-background-section-burn);
+}
+
+[data-streamdown="table-fullscreen"] [data-streamdown="table-header"] th {
+  color: var(--color-text-tertiary);
+}
+
+[data-streamdown="table-fullscreen"] [data-streamdown="table-body"] {
+  border-color: var(--color-divider-subtle);
+}
+
+[data-streamdown="table-fullscreen"] [data-streamdown="table-body"] > tr {
+  border-color: var(--color-divider-subtle);
+}
+
+[data-streamdown="table-fullscreen"] [data-streamdown="table-body"] td {
+  color: var(--color-text-secondary);
+}
+
 .markdown-body table img {
   background-color: transparent;
 }


### PR DESCRIPTION
Cherry-pick of #34224 to LTS 1.13.x branch.

## Summary
Bridge Dify design tokens for streamdown table fullscreen mode.

(cherry picked from commit e2c73058bc11a2477ea13ad60e426bb2d9b00852)