### PR TITLE
fix(web): hide broken table actions in Streamdown fullscreen

### DIFF
--- a/web/app/styles/markdown.css
+++ b/web/app/styles/markdown.css
@@ -615,6 +615,11 @@
   background-color: var(--color-background-section-burn);
 }
 
+/* Hide Streamdown controls that cannot locate the portaled fullscreen table. */
+[data-streamdown='table-fullscreen'] [role='presentation'] > div:first-child > div {
+  display: none;
+}
+
 [data-streamdown='table-fullscreen'] table[data-streamdown='table'] {
   border-color: var(--color-divider-regular);
 }


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix https://github.com/langgenius/dify/issues/38790

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
