### PR TITLE
fix(web): align workspace card hover state

### DIFF
--- a/web/app/components/main-nav/components/workspace-card.tsx
+++ b/web/app/components/main-nav/components/workspace-card.tsx
@@ -106,12 +106,12 @@ function WorkspaceCardTrigger({
   const showStatus = status !== undefined && status !== null
 
   return (
-    <div className="overflow-hidden rounded-xl border border-components-card-border bg-components-card-bg text-left shadow-xs transition-colors hover:bg-components-card-bg-alt">
+    <div className="overflow-hidden rounded-xl border border-components-card-border bg-components-card-bg text-left shadow-xs">
       <PopoverTrigger
         aria-label={t(($) => $['mainNav.workspace.openMenu'], { ns: 'common' })}
         title={name}
         className={cn(
-          'flex w-full items-center gap-1.5 py-1.5 pr-3 pl-1.5 text-left transition-colors focus-visible:inset-ring-2 focus-visible:inset-ring-state-accent-solid focus-visible:outline-hidden',
+          'flex w-full items-center gap-1.5 py-1.5 pr-3 pl-1.5 text-left transition-colors hover:bg-state-base-hover focus-visible:inset-ring-2 focus-visible:inset-ring-state-accent-solid focus-visible:outline-hidden',
           showCloudBilling ? 'rounded-t-xl' : 'rounded-xl',
           open && 'bg-linear-to-b from-background-section-burn to-background-section',
         )}


### PR DESCRIPTION
## Summary

- move the workspace card hover background from the full card wrapper to the workspace popover trigger
- use the semantic `state-base-hover` token while preserving the existing open and focus-visible states

## Why

The hover state was owned by the full card wrapper and used `components-card-bg-alt`. In the light theme, that changes the card from `#fcfcfd` to `#fff`, so the feedback is nearly imperceptible. It also applies when hovering the billing actions in the lower half of the card.

The Figma interaction assigns `state/base/hover` to the upper workspace trigger, which is the actual control that opens the workspace menu.

## Impact

Hover feedback is now visible only on the upper workspace menu trigger. Billing links, popup behavior, and keyboard focus styling are unchanged.

## Validation

- `vp check web/app/components/main-nav/components/workspace-card.tsx`
- `pnpm -C web test app/components/main-nav/components/__tests__/workspace-card.spec.tsx` (16 passed)
- `git diff --check`