### PR TITLE
test: move API token service coverage to unit tests

### DIFF
--- a/api/tests/unit_tests/services/test_api_token_service.py
+++ b/api/tests/unit_tests/services/test_api_token_service.py
@@ -2,34 +2,35 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from datetime import datetime
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
-from sqlalchemy.engine import Engine
+from flask import Flask
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import Unauthorized
 
 import services.api_token_service as api_token_service_module
+from models.engine import db
 from models.model import ApiToken
 from services.api_token_service import ApiTokenCache, CachedApiToken
 
 
 @pytest.fixture
-def api_token_db(
-    sqlite_engine: Engine,
-    sqlite_session: Session,
-    monkeypatch: pytest.MonkeyPatch,
-) -> Session:
-    """Route service-owned token queries to the SQLite seed database."""
+def api_token_db() -> Iterator[Session]:
+    """Provide the production database extension with an isolated SQLite token table."""
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    db.init_app(app)
 
-    monkeypatch.setattr(api_token_service_module, "db", SimpleNamespace(engine=sqlite_engine))
-    return sqlite_session
+    with app.app_context():
+        ApiToken.__table__.create(db.engine)
+        with Session(db.engine, expire_on_commit=False) as session:
+            yield session
 
 
-@pytest.mark.parametrize("sqlite_session", [(ApiToken,)], indirect=True)
 class TestQueryTokenFromDb:
     def test_should_return_api_token_and_cache_when_token_exists(self, api_token_db: Session) -> None:
         tenant_id = str(uuid4())

--- a/api/tests/unit_tests/services/test_api_token_service.py
+++ b/api/tests/unit_tests/services/test_api_token_service.py
@@ -1,11 +1,15 @@
+"""Unit tests for API token caching and SQLite-backed token lookup."""
+
 from __future__ import annotations
 
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
-from flask import Flask
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
 from werkzeug.exceptions import Unauthorized
 
 import services.api_token_service as api_token_service_module
@@ -13,10 +17,21 @@ from models.model import ApiToken
 from services.api_token_service import ApiTokenCache, CachedApiToken
 
 
+@pytest.fixture
+def api_token_db(
+    sqlite_engine: Engine,
+    sqlite_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Session:
+    """Route service-owned token queries to the SQLite seed database."""
+
+    monkeypatch.setattr(api_token_service_module, "db", SimpleNamespace(engine=sqlite_engine))
+    return sqlite_session
+
+
+@pytest.mark.parametrize("sqlite_session", [(ApiToken,)], indirect=True)
 class TestQueryTokenFromDb:
-    def test_should_return_api_token_and_cache_when_token_exists(
-        self, flask_app_with_containers: Flask, db_session_with_containers
-    ):
+    def test_should_return_api_token_and_cache_when_token_exists(self, api_token_db: Session) -> None:
         tenant_id = str(uuid4())
         app_id = str(uuid4())
         token_value = f"app-test-{uuid4()}"
@@ -27,8 +42,8 @@ class TestQueryTokenFromDb:
         api_token.tenant_id = tenant_id
         api_token.type = "app"
         api_token.token = token_value
-        db_session_with_containers.add(api_token)
-        db_session_with_containers.commit()
+        api_token_db.add(api_token)
+        api_token_db.commit()
 
         with (
             patch.object(api_token_service_module.ApiTokenCache, "set") as mock_cache_set,
@@ -41,9 +56,7 @@ class TestQueryTokenFromDb:
         mock_cache_set.assert_called_once()
         mock_record_usage.assert_called_once_with(token_value, "app")
 
-    def test_should_cache_null_and_raise_unauthorized_when_token_not_found(
-        self, flask_app_with_containers: Flask, db_session_with_containers
-    ):
+    def test_should_cache_null_and_raise_unauthorized_when_token_not_found(self, api_token_db: Session) -> None:
         with (
             patch.object(api_token_service_module.ApiTokenCache, "set") as mock_cache_set,
             patch.object(api_token_service_module, "record_token_usage") as mock_record_usage,


### PR DESCRIPTION
## What changed

Moves unit-level coverage out of the Testcontainers integration suite. Database-dependent unit paths use real in-memory SQLite sessions, while genuine container-backed coverage remains in the integration suite.

## Why

These cases mocked their service or session boundaries and therefore did not exercise container infrastructure. Keeping them in the unit suite makes their ownership and runtime requirements explicit.

## Impact

Production behavior is unchanged. Test classification is more accurate and the integration suite avoids unit-only work.

## Validation

- Ruff passed for all changed Python files.
- Changed unit suite: 662 passed.
- Remaining changed integration suite: 71 tests collected successfully.
