### PR TITLE
test: move console OAuth coverage to unit tests

### DIFF
--- a/api/tests/unit_tests/controllers/console/auth/test_oauth.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_oauth.py
@@ -1,4 +1,4 @@
-"""Testcontainers integration tests for OAuth controller endpoints."""
+"""Unit tests for OAuth controller endpoints."""
 
 from __future__ import annotations
 
@@ -16,15 +16,10 @@ from controllers.console.auth.oauth import (
 )
 from libs.oauth import OAuthUserInfo, encode_oauth_state
 from models.account import AccountStatus
-from services.account_service import AccountService
 from services.errors.account import AccountRegisterError
 
 
 class TestGetOAuthProviders:
-    @pytest.fixture
-    def app(self, flask_app_with_containers: Flask):
-        return flask_app_with_containers
-
     @pytest.mark.parametrize(
         ("github_config", "google_config", "expected_github", "expected_google"),
         [
@@ -64,10 +59,6 @@ class TestOAuthLogin:
     @pytest.fixture
     def resource(self):
         return OAuthLogin()
-
-    @pytest.fixture
-    def app(self, flask_app_with_containers: Flask):
-        return flask_app_with_containers
 
     @pytest.fixture
     def mock_oauth_provider(self):
@@ -180,10 +171,6 @@ class TestOAuthCallback:
     @pytest.fixture
     def resource(self):
         return OAuthCallback()
-
-    @pytest.fixture
-    def app(self, flask_app_with_containers: Flask):
-        return flask_app_with_containers
 
     @pytest.fixture
     def oauth_setup(self):
@@ -449,10 +436,6 @@ class TestOAuthCallback:
 
 class TestAccountGeneration:
     @pytest.fixture
-    def app(self, flask_app_with_containers: Flask):
-        return flask_app_with_containers
-
-    @pytest.fixture
     def user_info(self):
         return OAuthUserInfo(id="123", name="Test User", email="test@example.com")
 
@@ -468,39 +451,25 @@ class TestAccountGeneration:
         self,
         mock_account_model,
         mock_get_account,
-        flask_req_ctx_with_containers,
+        app: Flask,
         user_info: OAuthUserInfo,
         mock_account,
     ):
-        # Test OpenID found
-        mock_account_model.get_by_openid.return_value = mock_account
-        result = _get_account_by_openid_or_email("github", user_info)
-        assert result == mock_account
-        mock_account_model.get_by_openid.assert_called_once_with("github", "123")
-        mock_get_account.assert_not_called()
+        with app.test_request_context("/"):
+            # Test OpenID found
+            mock_account_model.get_by_openid.return_value = mock_account
+            result = _get_account_by_openid_or_email("github", user_info)
+            assert result == mock_account
+            mock_account_model.get_by_openid.assert_called_once_with("github", "123")
+            mock_get_account.assert_not_called()
 
-        # Test fallback to email lookup
-        mock_account_model.get_by_openid.return_value = None
-        mock_get_account.return_value = mock_account
+            # Test fallback to email lookup
+            mock_account_model.get_by_openid.return_value = None
+            mock_get_account.return_value = mock_account
 
-        result = _get_account_by_openid_or_email("github", user_info)
-        assert result == mock_account
-        mock_get_account.assert_called_once()
-
-    def test_get_account_by_email_with_case_fallback_falls_back_to_lowercase(self):
-        """Test that case fallback tries lowercase when exact match fails."""
-        mock_session = MagicMock()
-        first_result = MagicMock()
-        first_result.scalar_one_or_none.return_value = None
-        expected_account = MagicMock()
-        second_result = MagicMock()
-        second_result.scalar_one_or_none.return_value = expected_account
-        mock_session.execute.side_effect = [first_result, second_result]
-
-        result = AccountService.get_account_by_email_with_case_fallback("Case@Test.com", session=mock_session)
-
-        assert result is expected_account
-        assert mock_session.execute.call_count == 2
+            result = _get_account_by_openid_or_email("github", user_info)
+            assert result == mock_account
+            mock_get_account.assert_called_once()
 
     @pytest.mark.parametrize(
         ("allow_register", "existing_account", "should_create"),


### PR DESCRIPTION
## What changed

Moves unit-level coverage out of the Testcontainers integration suite. Database-dependent unit paths use real in-memory SQLite sessions, while genuine container-backed coverage remains in the integration suite.

## Why

These cases mocked their service or session boundaries and therefore did not exercise container infrastructure. Keeping them in the unit suite makes their ownership and runtime requirements explicit.

## Impact

Production behavior is unchanged. Test classification is more accurate and the integration suite avoids unit-only work.

## Validation

- Ruff passed for all changed Python files.
- Changed unit suite: 662 passed.
- Remaining changed integration suite: 71 tests collected successfully.
