### PR TITLE
test: move hit testing service coverage to unit tests

### DIFF
--- a/api/tests/test_containers_integration_tests/services/test_hit_testing_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_hit_testing_service.py
@@ -153,31 +153,6 @@ def _create_segment(db_session: Session, *, document: DatasetDocument | None = N
 
 
 class TestHitTestingService:
-    # ── Utility methods (pure logic, no DB) ────────────────────────────
-
-    def test_escape_query_for_search_should_escape_double_quotes(self) -> None:
-        query = 'test "query" with quotes'
-        result = HitTestingService.escape_query_for_search(query)
-        assert result == 'test \\"query\\" with quotes'
-
-    def test_hit_testing_args_check_should_pass_with_valid_query(self) -> None:
-        HitTestingService.hit_testing_args_check({"query": "valid query"})
-
-    def test_hit_testing_args_check_should_pass_with_valid_attachments(self) -> None:
-        HitTestingService.hit_testing_args_check({"attachment_ids": ["id1", "id2"]})
-
-    def test_hit_testing_args_check_should_raise_error_when_no_query_or_attachments(self) -> None:
-        with pytest.raises(ValueError, match="Query or attachment_ids is required"):
-            HitTestingService.hit_testing_args_check({})
-
-    def test_hit_testing_args_check_should_raise_error_when_query_too_long(self) -> None:
-        with pytest.raises(ValueError, match="Query cannot exceed 250 characters"):
-            HitTestingService.hit_testing_args_check({"query": "a" * 251})
-
-    def test_hit_testing_args_check_should_raise_error_when_attachments_not_list(self) -> None:
-        with pytest.raises(ValueError, match="Attachment_ids must be a list"):
-            HitTestingService.hit_testing_args_check({"attachment_ids": "not a list"})
-
     # ── Response formatting ────────────────────────────────────────────
 
     @patch("core.rag.datasource.retrieval_service.RetrievalService.format_retrieval_documents")

--- a/api/tests/unit_tests/services/test_hit_testing_service.py
+++ b/api/tests/unit_tests/services/test_hit_testing_service.py
@@ -1,0 +1,32 @@
+"""Unit tests for the database-independent hit-testing helpers."""
+
+import pytest
+
+from services.hit_testing_service import HitTestingService
+
+
+class TestHitTestingServiceArguments:
+    def test_escape_query_for_search_should_escape_double_quotes(self) -> None:
+        query = 'test "query" with quotes'
+
+        result = HitTestingService.escape_query_for_search(query)
+
+        assert result == 'test \\"query\\" with quotes'
+
+    def test_hit_testing_args_check_should_pass_with_valid_query(self) -> None:
+        HitTestingService.hit_testing_args_check({"query": "valid query"})
+
+    def test_hit_testing_args_check_should_pass_with_valid_attachments(self) -> None:
+        HitTestingService.hit_testing_args_check({"attachment_ids": ["id1", "id2"]})
+
+    def test_hit_testing_args_check_should_raise_error_when_no_query_or_attachments(self) -> None:
+        with pytest.raises(ValueError, match="Query or attachment_ids is required"):
+            HitTestingService.hit_testing_args_check({})
+
+    def test_hit_testing_args_check_should_raise_error_when_query_too_long(self) -> None:
+        with pytest.raises(ValueError, match="Query cannot exceed 250 characters"):
+            HitTestingService.hit_testing_args_check({"query": "a" * 251})
+
+    def test_hit_testing_args_check_should_raise_error_when_attachments_not_list(self) -> None:
+        with pytest.raises(ValueError, match="Attachment_ids must be a list"):
+            HitTestingService.hit_testing_args_check({"attachment_ids": "not a list"})


### PR DESCRIPTION
## What changed

Moves unit-level coverage out of the Testcontainers integration suite. Database-dependent unit paths use real in-memory SQLite sessions, while genuine container-backed coverage remains in the integration suite.

## Why

These cases mocked their service or session boundaries and therefore did not exercise container infrastructure. Keeping them in the unit suite makes their ownership and runtime requirements explicit.

## Impact

Production behavior is unchanged. Test classification is more accurate and the integration suite avoids unit-only work.

## Validation

- Ruff passed for all changed Python files.
- Changed unit suite: 662 passed.
- Remaining changed integration suite: 71 tests collected successfully.
