### PR TITLE
test: move OpenDAL filesystem coverage to unit tests

### DIFF
--- a/api/tests/unit_tests/extensions/storage/test_opendal_fs_default_root.py
+++ b/api/tests/unit_tests/extensions/storage/test_opendal_fs_default_root.py
@@ -1,3 +1,5 @@
+"""Unit coverage for OpenDAL's local filesystem root selection."""
+
 from pathlib import Path
 
 import pytest


### PR DESCRIPTION
## What changed

Moves unit-level coverage out of the Testcontainers integration suite. Database-dependent unit paths use real in-memory SQLite sessions, while genuine container-backed coverage remains in the integration suite.

## Why

These cases mocked their service or session boundaries and therefore did not exercise container infrastructure. Keeping them in the unit suite makes their ownership and runtime requirements explicit.

## Impact

Production behavior is unchanged. Test classification is more accurate and the integration suite avoids unit-only work.

## Validation

- Ruff passed for all changed Python files.
- Changed unit suite: 662 passed.
- Remaining changed integration suite: 71 tests collected successfully.
