### PR TITLE
test: move message cleanup coverage to unit tests

### DIFF
--- a/api/tests/test_containers_integration_tests/services/test_messages_clean_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_messages_clean_service.py
@@ -4,7 +4,7 @@ import datetime
 import json
 import uuid
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from faker import Faker
@@ -1172,65 +1172,8 @@ class TestMessagesCleanServiceIntegration:
         # Verify all messages were deleted
         assert db_session_with_containers.query(Message).where(Message.id.in_(msg_ids)).count() == 0
 
-    def test_from_time_range_validation(self):
-        """Test that from_time_range raises ValueError for invalid inputs."""
-        policy = MagicMock(spec=BillingDisabledPolicy)
-        now = datetime.datetime.now()
-
-        with pytest.raises(ValueError, match="start_from .* must be less than end_before"):
-            MessagesCleanService.from_time_range(policy, now, now)
-
-        with pytest.raises(ValueError, match="batch_size .* must be greater than 0"):
-            MessagesCleanService.from_time_range(policy, now - datetime.timedelta(days=1), now, batch_size=0)
-
-    def test_from_time_range_success(self):
-        """Test that from_time_range creates a service with correct parameters."""
-        policy = MagicMock(spec=BillingDisabledPolicy)
-        start = datetime.datetime(2024, 1, 1)
-        end = datetime.datetime(2024, 2, 1)
-
-        service = MessagesCleanService.from_time_range(policy, start, end)
-        assert service._start_from == start
-        assert service._end_before == end
-
-    def test_from_days_validation(self):
-        """Test that from_days raises ValueError for invalid inputs."""
-        policy = MagicMock(spec=BillingDisabledPolicy)
-
-        with pytest.raises(ValueError, match="days .* must be greater than or equal to 0"):
-            MessagesCleanService.from_days(policy, days=-1)
-
-        with pytest.raises(ValueError, match="batch_size .* must be greater than 0"):
-            MessagesCleanService.from_days(policy, days=30, batch_size=0)
-
-    def test_from_days_success(self):
-        """Test that from_days creates a service with correct parameters."""
-        policy = MagicMock(spec=BillingDisabledPolicy)
-
-        with patch("services.retention.conversation.messages_clean_service.naive_utc_now") as mock_now:
-            fixed_now = datetime.datetime(2024, 6, 1)
-            mock_now.return_value = fixed_now
-
-            service = MessagesCleanService.from_days(policy, days=10)
-            assert service._start_from is None
-            assert service._end_before == fixed_now - datetime.timedelta(days=10)
-
     def test_batch_delete_message_relations_empty(self, db_session_with_containers: Session):
         """Test that batch_delete_message_relations with empty list does nothing."""
         # Get execute call count before
         MessagesCleanService._batch_delete_message_relations(db_session_with_containers, [])
         # No exception means success — empty list is a no-op
-
-    def test_run_calls_clean_messages(self):
-        """Test that run() delegates to _clean_messages_by_time_range."""
-        policy = MagicMock(spec=BillingDisabledPolicy)
-        service = MessagesCleanService(
-            policy=policy,
-            end_before=datetime.datetime.now(),
-            batch_size=10,
-        )
-        with patch.object(service, "_clean_messages_by_time_range") as mock_clean:
-            mock_clean.return_value = {"total_deleted": 5}
-            result = service.run()
-            assert result == {"total_deleted": 5}
-            mock_clean.assert_called_once()


### PR DESCRIPTION
## What changed

Moves unit-level coverage out of the Testcontainers integration suite. Database-dependent unit paths use real in-memory SQLite sessions, while genuine container-backed coverage remains in the integration suite.

## Why

These cases mocked their service or session boundaries and therefore did not exercise container infrastructure. Keeping them in the unit suite makes their ownership and runtime requirements explicit.

## Impact

Production behavior is unchanged. Test classification is more accurate and the integration suite avoids unit-only work.

## Validation

- Ruff passed for all changed Python files.
- Changed unit suite: 662 passed.
- Remaining changed integration suite: 71 tests collected successfully.
