### PR TITLE
test: move plugin parameter service coverage to unit tests

### DIFF
--- a/api/tests/unit_tests/services/plugin/test_plugin_parameter_service.py
+++ b/api/tests/unit_tests/services/plugin/test_plugin_parameter_service.py
@@ -1,4 +1,4 @@
-"""Tests for services.plugin.plugin_parameter_service.PluginParameterService.
+"""Unit tests for services.plugin.plugin_parameter_service.PluginParameterService.
 
 Covers: dynamic select options via tool and trigger credential paths,
 HIDDEN_VALUE replacement, and error handling for missing records.
@@ -7,15 +7,30 @@ HIDDEN_VALUE replacement, and error handling for missing records.
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
-from flask import Flask
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
 
+import services.plugin.plugin_parameter_service as plugin_parameter_module
 from core.plugin.entities.plugin_daemon import CredentialType
 from models.tools import BuiltinToolProvider
 from services.plugin.plugin_parameter_service import PluginParameterService
+
+
+@pytest.fixture
+def plugin_parameter_db(
+    sqlite_engine: Engine,
+    sqlite_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Session:
+    """Route service-owned credential lookups to the SQLite seed database."""
+
+    monkeypatch.setattr(plugin_parameter_module, "db", SimpleNamespace(engine=sqlite_engine))
+    return sqlite_session
 
 
 class TestGetDynamicSelectOptionsTool:
@@ -45,14 +60,14 @@ class TestGetDynamicSelectOptionsTool:
     @patch("services.plugin.plugin_parameter_service.DynamicSelectClient")
     @patch("services.plugin.plugin_parameter_service.create_tool_provider_encrypter")
     @patch("services.plugin.plugin_parameter_service.ToolManager")
+    @pytest.mark.parametrize("sqlite_session", [(BuiltinToolProvider,)], indirect=True)
     def test_fetches_credentials_with_credential_id(
         self,
         mock_tool_mgr: MagicMock,
         mock_encrypter_fn: MagicMock,
         mock_client_cls,
-        flask_app_with_containers: Flask,
-        db_session_with_containers: Session,
-    ):
+        plugin_parameter_db: Session,
+    ) -> None:
         tenant_id = str(uuid4())
         provider_ctrl = MagicMock()
         provider_ctrl.need_credentials = True
@@ -70,8 +85,8 @@ class TestGetDynamicSelectOptionsTool:
             encrypted_credentials=json.dumps({"api_key": "encrypted"}),
             credential_type=CredentialType.API_KEY,
         )
-        db_session_with_containers.add(db_record)
-        db_session_with_containers.commit()
+        plugin_parameter_db.add(db_record)
+        plugin_parameter_db.commit()
 
         result = PluginParameterService.get_dynamic_select_options(
             tenant_id=tenant_id,
@@ -88,13 +103,13 @@ class TestGetDynamicSelectOptionsTool:
 
     @patch("services.plugin.plugin_parameter_service.create_tool_provider_encrypter")
     @patch("services.plugin.plugin_parameter_service.ToolManager")
+    @pytest.mark.parametrize("sqlite_session", [(BuiltinToolProvider,)], indirect=True)
     def test_raises_when_tool_provider_not_found(
         self,
         mock_tool_mgr: MagicMock,
         mock_encrypter_fn: MagicMock,
-        flask_app_with_containers: Flask,
-        db_session_with_containers: Session,
-    ):
+        plugin_parameter_db: Session,
+    ) -> None:
         provider_ctrl = MagicMock()
         provider_ctrl.need_credentials = True
         mock_tool_mgr.get_builtin_provider.return_value = provider_ctrl

--- a/api/tests/unit_tests/services/plugin/test_plugin_parameter_service.py
+++ b/api/tests/unit_tests/services/plugin/test_plugin_parameter_service.py
@@ -7,30 +7,31 @@ HIDDEN_VALUE replacement, and error handling for missing records.
 from __future__ import annotations
 
 import json
-from types import SimpleNamespace
+from collections.abc import Iterator
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
-from sqlalchemy.engine import Engine
+from flask import Flask
 from sqlalchemy.orm import Session
 
-import services.plugin.plugin_parameter_service as plugin_parameter_module
 from core.plugin.entities.plugin_daemon import CredentialType
+from models.engine import db
 from models.tools import BuiltinToolProvider
 from services.plugin.plugin_parameter_service import PluginParameterService
 
 
 @pytest.fixture
-def plugin_parameter_db(
-    sqlite_engine: Engine,
-    sqlite_session: Session,
-    monkeypatch: pytest.MonkeyPatch,
-) -> Session:
-    """Route service-owned credential lookups to the SQLite seed database."""
+def plugin_parameter_db() -> Iterator[Session]:
+    """Provide the production database extension with an isolated SQLite credential table."""
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    db.init_app(app)
 
-    monkeypatch.setattr(plugin_parameter_module, "db", SimpleNamespace(engine=sqlite_engine))
-    return sqlite_session
+    with app.app_context():
+        BuiltinToolProvider.__table__.create(db.engine)
+        with Session(db.engine, expire_on_commit=False) as session:
+            yield session
 
 
 class TestGetDynamicSelectOptionsTool:
@@ -60,7 +61,6 @@ class TestGetDynamicSelectOptionsTool:
     @patch("services.plugin.plugin_parameter_service.DynamicSelectClient")
     @patch("services.plugin.plugin_parameter_service.create_tool_provider_encrypter")
     @patch("services.plugin.plugin_parameter_service.ToolManager")
-    @pytest.mark.parametrize("sqlite_session", [(BuiltinToolProvider,)], indirect=True)
     def test_fetches_credentials_with_credential_id(
         self,
         mock_tool_mgr: MagicMock,
@@ -103,7 +103,6 @@ class TestGetDynamicSelectOptionsTool:
 
     @patch("services.plugin.plugin_parameter_service.create_tool_provider_encrypter")
     @patch("services.plugin.plugin_parameter_service.ToolManager")
-    @pytest.mark.parametrize("sqlite_session", [(BuiltinToolProvider,)], indirect=True)
     def test_raises_when_tool_provider_not_found(
         self,
         mock_tool_mgr: MagicMock,


### PR DESCRIPTION
## What changed

Moves unit-level coverage out of the Testcontainers integration suite. Database-dependent unit paths use real in-memory SQLite sessions, while genuine container-backed coverage remains in the integration suite.

## Why

These cases mocked their service or session boundaries and therefore did not exercise container infrastructure. Keeping them in the unit suite makes their ownership and runtime requirements explicit.

## Impact

Production behavior is unchanged. Test classification is more accurate and the integration suite avoids unit-only work.

## Validation

- Ruff passed for all changed Python files.
- Changed unit suite: 662 passed.
- Remaining changed integration suite: 71 tests collected successfully.
