### PR TITLE
test: move password reset coverage to unit tests

### DIFF
--- a/api/tests/unit_tests/controllers/console/auth/test_password_reset.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_password_reset.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
+from collections.abc import Iterator
 from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
-from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
-from controllers.console.auth import forgot_password as forgot_password_module
 from controllers.console.auth.error import (
     EmailCodeError,
     EmailPasswordResetLimitError,
@@ -24,16 +22,29 @@ from controllers.console.auth.forgot_password import (
 )
 from controllers.console.error import AccountNotFound, EmailSendIpLimitError
 from models.account import Account
+from models.engine import db
+from services.feature_service import SystemFeatureModel
+
+
+@pytest.fixture
+def database_app() -> Iterator[Flask]:
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    db.init_app(app)
+
+    with app.app_context():
+        Account.__table__.create(db.engine)
+        yield app
 
 
 @pytest.fixture(autouse=True)
 def enable_password_login_wrappers(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep endpoint decorators deterministic without requiring the configured app database."""
 
-    monkeypatch.setattr("controllers.console.wraps.dify_config", SimpleNamespace(EDITION="CLOUD"))
+    monkeypatch.setattr("controllers.console.wraps.dify_config.EDITION", "CLOUD")
     monkeypatch.setattr(
         "controllers.console.wraps.FeatureService.get_system_features",
-        lambda: SimpleNamespace(enable_email_password_login=True),
+        lambda: SystemFeatureModel(enable_email_password_login=True),
     )
 
 
@@ -328,15 +339,6 @@ class TestForgotPasswordCheckApi:
 class TestForgotPasswordResetApi:
     """Test cases for resetting password with verified token."""
 
-    @pytest.fixture
-    def mock_account(self):
-        """Create mock account object."""
-        account = MagicMock()
-        account.email = "test@example.com"
-        account.name = "Test User"
-        return account
-
-    @pytest.mark.parametrize("sqlite_session", [(Account,)], indirect=True)
     @patch("controllers.console.auth.forgot_password.AccountService.get_reset_password_data")
     @patch("controllers.console.auth.forgot_password.AccountService.revoke_reset_password_token")
     @patch("controllers.console.auth.forgot_password.AccountService.get_account_by_email_with_case_fallback")
@@ -347,9 +349,7 @@ class TestForgotPasswordResetApi:
         mock_get_account,
         mock_revoke_token,
         mock_get_data,
-        app: Flask,
-        monkeypatch: pytest.MonkeyPatch,
-        sqlite_session: Session,
+        database_app: Flask,
     ):
         """
         Test successful password reset.
@@ -361,18 +361,16 @@ class TestForgotPasswordResetApi:
         """
         # Arrange
         account = Account(name="Test User", email="test@example.com")
-        sqlite_session.add(account)
-        sqlite_session.commit()
+        db.session.add(account)
+        db.session.commit()
         account_id = account.id
 
-        database_session = scoped_session(sessionmaker(bind=sqlite_session.get_bind(), expire_on_commit=False))
-        monkeypatch.setattr(forgot_password_module, "db", SimpleNamespace(session=database_session))
         mock_get_data.return_value = {"email": "test@example.com", "phase": "reset"}
         mock_get_account.return_value = account
         mock_get_tenants.return_value = [MagicMock()]
 
         # Act
-        with app.test_request_context(
+        with database_app.test_request_context(
             "/forgot-password/resets",
             method="POST",
             json={"token": "valid_token", "new_password": "NewPass123!", "password_confirm": "NewPass123!"},
@@ -383,11 +381,10 @@ class TestForgotPasswordResetApi:
         # Assert
         assert response["result"] == "success"
         mock_revoke_token.assert_called_once_with("valid_token")
-        updated_account = database_session.get(Account, account_id)
+        updated_account = db.session.get(Account, account_id)
         assert updated_account is not None
         assert updated_account.password is not None
         assert updated_account.password_salt is not None
-        database_session.remove()
 
     @patch("controllers.console.auth.forgot_password.AccountService.get_reset_password_data")
     def test_reset_password_mismatch(self, mock_get_data, app: Flask):

--- a/api/tests/unit_tests/controllers/console/auth/test_password_reset.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_password_reset.py
@@ -1,11 +1,10 @@
 """Unit tests for password reset controller flows."""
 
 from __future__ import annotations
-from unittest.mock import MagicMock
-from collections.abc import Generator
 
+from collections.abc import Generator
 from contextlib import contextmanager
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
@@ -71,11 +70,14 @@ class TestForgotPasswordSendEmailApi:
         mock_send_email.return_value = "reset_token_123"
 
         # Act
-        with _bind_database_session(sqlite_session), app.test_request_context(
+        with (
+            _bind_database_session(sqlite_session),
+            app.test_request_context(
                 "/forgot-password", method="POST", json={"email": "test@example.com", "language": "en-US"}
-            ):
-                api = ForgotPasswordSendEmailApi()
-                response = api.post()
+            ),
+        ):
+            api = ForgotPasswordSendEmailApi()
+            response = api.post()
 
         # Assert
         assert response["result"] == "success"
@@ -133,11 +135,14 @@ class TestForgotPasswordSendEmailApi:
         mock_send_email.return_value = "token"
 
         # Act
-        with _bind_database_session(sqlite_session), app.test_request_context(
+        with (
+            _bind_database_session(sqlite_session),
+            app.test_request_context(
                 "/forgot-password", method="POST", json={"email": "test@example.com", "language": language_input}
-            ):
-                api = ForgotPasswordSendEmailApi()
-                api.post()
+            ),
+        ):
+            api = ForgotPasswordSendEmailApi()
+            api.post()
 
         # Assert
         call_args = mock_send_email.call_args
@@ -455,11 +460,14 @@ class TestForgotPasswordResetApi:
         mock_get_data.return_value = {"email": "nonexistent@example.com", "phase": "reset"}
 
         # Act & Assert
-        with _bind_database_session(sqlite_session), app.test_request_context(
+        with (
+            _bind_database_session(sqlite_session),
+            app.test_request_context(
                 "/forgot-password/resets",
                 method="POST",
                 json={"token": "token", "new_password": "NewPass123!", "password_confirm": "NewPass123!"},
-            ):
-                api = ForgotPasswordResetApi()
-                with pytest.raises(AccountNotFound):
-                    api.post()
+            ),
+        ):
+            api = ForgotPasswordResetApi()
+            with pytest.raises(AccountNotFound):
+                api.post()

--- a/api/tests/unit_tests/controllers/console/auth/test_password_reset.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_password_reset.py
@@ -1,13 +1,15 @@
-"""Testcontainers integration tests for password reset authentication flows."""
+"""Unit tests for password reset controller flows."""
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
+from controllers.console.auth import forgot_password as forgot_password_module
 from controllers.console.auth.error import (
     EmailCodeError,
     EmailPasswordResetLimitError,
@@ -21,16 +23,22 @@ from controllers.console.auth.forgot_password import (
     ForgotPasswordSendEmailApi,
 )
 from controllers.console.error import AccountNotFound, EmailSendIpLimitError
-from tests.test_containers_integration_tests.controllers.console.helpers import ensure_dify_setup
+from models.account import Account
+
+
+@pytest.fixture(autouse=True)
+def enable_password_login_wrappers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep endpoint decorators deterministic without requiring the configured app database."""
+
+    monkeypatch.setattr("controllers.console.wraps.dify_config", SimpleNamespace(EDITION="CLOUD"))
+    monkeypatch.setattr(
+        "controllers.console.wraps.FeatureService.get_system_features",
+        lambda: SimpleNamespace(enable_email_password_login=True),
+    )
 
 
 class TestForgotPasswordSendEmailApi:
     """Test cases for sending password reset emails."""
-
-    @pytest.fixture
-    def app(self, flask_app_with_containers: Flask, db_session_with_containers: Session):
-        ensure_dify_setup(db_session_with_containers)
-        return flask_app_with_containers
 
     @pytest.fixture
     def mock_account(self):
@@ -140,11 +148,6 @@ class TestForgotPasswordSendEmailApi:
 
 class TestForgotPasswordCheckApi:
     """Test cases for verifying password reset codes."""
-
-    @pytest.fixture
-    def app(self, flask_app_with_containers: Flask, db_session_with_containers: Session):
-        ensure_dify_setup(db_session_with_containers)
-        return flask_app_with_containers
 
     @patch("controllers.console.auth.forgot_password.AccountService.is_forgot_password_error_rate_limit")
     @patch("controllers.console.auth.forgot_password.AccountService.get_reset_password_data")
@@ -326,11 +329,6 @@ class TestForgotPasswordResetApi:
     """Test cases for resetting password with verified token."""
 
     @pytest.fixture
-    def app(self, flask_app_with_containers: Flask, db_session_with_containers: Session):
-        ensure_dify_setup(db_session_with_containers)
-        return flask_app_with_containers
-
-    @pytest.fixture
     def mock_account(self):
         """Create mock account object."""
         account = MagicMock()
@@ -338,20 +336,20 @@ class TestForgotPasswordResetApi:
         account.name = "Test User"
         return account
 
+    @pytest.mark.parametrize("sqlite_session", [(Account,)], indirect=True)
     @patch("controllers.console.auth.forgot_password.AccountService.get_reset_password_data")
     @patch("controllers.console.auth.forgot_password.AccountService.revoke_reset_password_token")
     @patch("controllers.console.auth.forgot_password.AccountService.get_account_by_email_with_case_fallback")
-    @patch("controllers.console.auth.forgot_password.db")
     @patch("controllers.console.auth.forgot_password.TenantService.get_join_tenants")
     def test_reset_password_success(
         self,
         mock_get_tenants,
-        mock_db,
         mock_get_account,
         mock_revoke_token,
         mock_get_data,
         app: Flask,
-        mock_account,
+        monkeypatch: pytest.MonkeyPatch,
+        sqlite_session: Session,
     ):
         """
         Test successful password reset.
@@ -362,9 +360,15 @@ class TestForgotPasswordResetApi:
         - Success response is returned
         """
         # Arrange
+        account = Account(name="Test User", email="test@example.com")
+        sqlite_session.add(account)
+        sqlite_session.commit()
+        account_id = account.id
+
+        database_session = scoped_session(sessionmaker(bind=sqlite_session.get_bind(), expire_on_commit=False))
+        monkeypatch.setattr(forgot_password_module, "db", SimpleNamespace(session=database_session))
         mock_get_data.return_value = {"email": "test@example.com", "phase": "reset"}
-        mock_get_account.return_value = mock_account
-        mock_db.session.merge.return_value = mock_account
+        mock_get_account.return_value = account
         mock_get_tenants.return_value = [MagicMock()]
 
         # Act
@@ -379,6 +383,11 @@ class TestForgotPasswordResetApi:
         # Assert
         assert response["result"] == "success"
         mock_revoke_token.assert_called_once_with("valid_token")
+        updated_account = database_session.get(Account, account_id)
+        assert updated_account is not None
+        assert updated_account.password is not None
+        assert updated_account.password_salt is not None
+        database_session.remove()
 
     @patch("controllers.console.auth.forgot_password.AccountService.get_reset_password_data")
     def test_reset_password_mismatch(self, mock_get_data, app: Flask):

--- a/api/tests/unit_tests/controllers/console/auth/test_password_reset.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_password_reset.py
@@ -1,12 +1,15 @@
 """Unit tests for password reset controller flows."""
 
 from __future__ import annotations
+from unittest.mock import MagicMock
+from collections.abc import Generator
 
-from collections.abc import Iterator
-from unittest.mock import MagicMock, patch
+from contextlib import contextmanager
+from unittest.mock import patch
 
 import pytest
 from flask import Flask
+from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
 from controllers.console.auth.error import (
     EmailCodeError,
@@ -21,20 +24,22 @@ from controllers.console.auth.forgot_password import (
     ForgotPasswordSendEmailApi,
 )
 from controllers.console.error import AccountNotFound, EmailSendIpLimitError
-from models.account import Account
-from models.engine import db
+from models.account import Account, Tenant, TenantAccountJoin
 from services.feature_service import SystemFeatureModel
 
+SQLITE_MODELS = (Account, Tenant, TenantAccountJoin)
 
-@pytest.fixture
-def database_app() -> Iterator[Flask]:
-    app = Flask(__name__)
-    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
-    db.init_app(app)
 
-    with app.app_context():
-        Account.__table__.create(db.engine)
-        yield app
+@contextmanager
+def _bind_database_session(session: Session) -> Generator[scoped_session[Session]]:
+    """Bind the controller's session proxy to the SQLite test engine."""
+
+    database_session = scoped_session(sessionmaker(bind=session.get_bind(), expire_on_commit=False))
+    try:
+        with patch("controllers.console.auth.forgot_password.db.session", database_session):
+            yield database_session
+    finally:
+        database_session.remove()
 
 
 @pytest.fixture(autouse=True)
@@ -51,39 +56,26 @@ def enable_password_login_wrappers(monkeypatch: pytest.MonkeyPatch) -> None:
 class TestForgotPasswordSendEmailApi:
     """Test cases for sending password reset emails."""
 
-    @pytest.fixture
-    def mock_account(self):
-        """Create mock account object."""
-        account = MagicMock()
-        account.email = "test@example.com"
-        account.name = "Test User"
-        return account
-
+    @pytest.mark.parametrize("sqlite_session", [SQLITE_MODELS], indirect=True)
     @patch("controllers.console.auth.forgot_password.AccountService.is_email_send_ip_limit")
-    @patch("controllers.console.auth.forgot_password.AccountService.get_account_by_email_with_case_fallback")
     @patch("controllers.console.auth.forgot_password.AccountService.send_reset_password_email")
-    @patch("controllers.console.auth.forgot_password.FeatureService.get_system_features")
     def test_send_reset_email_success(
         self,
-        mock_get_features,
         mock_send_email,
-        mock_get_account,
         mock_is_ip_limit,
         app: Flask,
-        mock_account,
+        sqlite_session: Session,
     ):
         # Arrange
         mock_is_ip_limit.return_value = False
-        mock_get_account.return_value = mock_account
         mock_send_email.return_value = "reset_token_123"
-        mock_get_features.return_value.is_allow_register = True
 
         # Act
-        with app.test_request_context(
-            "/forgot-password", method="POST", json={"email": "test@example.com", "language": "en-US"}
-        ):
-            api = ForgotPasswordSendEmailApi()
-            response = api.post()
+        with _bind_database_session(sqlite_session), app.test_request_context(
+                "/forgot-password", method="POST", json={"email": "test@example.com", "language": "en-US"}
+            ):
+                api = ForgotPasswordSendEmailApi()
+                response = api.post()
 
         # Assert
         assert response["result"] == "success"
@@ -117,20 +109,17 @@ class TestForgotPasswordSendEmailApi:
             (None, "en-US"),  # Defaults to en-US when not provided
         ],
     )
+    @pytest.mark.parametrize("sqlite_session", [SQLITE_MODELS], indirect=True)
     @patch("controllers.console.auth.forgot_password.AccountService.is_email_send_ip_limit")
-    @patch("controllers.console.auth.forgot_password.AccountService.get_account_by_email_with_case_fallback")
     @patch("controllers.console.auth.forgot_password.AccountService.send_reset_password_email")
-    @patch("controllers.console.auth.forgot_password.FeatureService.get_system_features")
     def test_send_reset_email_language_handling(
         self,
-        mock_get_features,
         mock_send_email,
-        mock_get_account,
         mock_is_ip_limit,
-        app: Flask,
-        mock_account,
         language_input,
         expected_language,
+        app: Flask,
+        sqlite_session: Session,
     ):
         """
         Test password reset email with different language preferences.
@@ -141,16 +130,14 @@ class TestForgotPasswordSendEmailApi:
         """
         # Arrange
         mock_is_ip_limit.return_value = False
-        mock_get_account.return_value = mock_account
         mock_send_email.return_value = "token"
-        mock_get_features.return_value.is_allow_register = True
 
         # Act
-        with app.test_request_context(
-            "/forgot-password", method="POST", json={"email": "test@example.com", "language": language_input}
-        ):
-            api = ForgotPasswordSendEmailApi()
-            api.post()
+        with _bind_database_session(sqlite_session), app.test_request_context(
+                "/forgot-password", method="POST", json={"email": "test@example.com", "language": language_input}
+            ):
+                api = ForgotPasswordSendEmailApi()
+                api.post()
 
         # Assert
         call_args = mock_send_email.call_args
@@ -167,10 +154,10 @@ class TestForgotPasswordCheckApi:
     @patch("controllers.console.auth.forgot_password.AccountService.reset_forgot_password_error_rate_limit")
     def test_verify_code_success(
         self,
-        mock_reset_rate_limit,
-        mock_generate_token,
-        mock_revoke_token,
-        mock_get_data,
+        mock_reset_rate_limit: MagicMock,
+        mock_generate_token: MagicMock,
+        mock_revoke_token: MagicMock,
+        mock_get_data: MagicMock,
         mock_is_rate_limit,
         app: Flask,
     ):
@@ -214,10 +201,10 @@ class TestForgotPasswordCheckApi:
     @patch("controllers.console.auth.forgot_password.AccountService.reset_forgot_password_error_rate_limit")
     def test_verify_code_preserves_token_email_case(
         self,
-        mock_reset_rate_limit,
-        mock_generate_token,
-        mock_revoke_token,
-        mock_get_data,
+        mock_reset_rate_limit: MagicMock,
+        mock_generate_token: MagicMock,
+        mock_revoke_token: MagicMock,
+        mock_get_data: MagicMock,
         mock_is_rate_limit,
         app: Flask,
     ):
@@ -339,17 +326,15 @@ class TestForgotPasswordCheckApi:
 class TestForgotPasswordResetApi:
     """Test cases for resetting password with verified token."""
 
+    @pytest.mark.parametrize("sqlite_session", [SQLITE_MODELS], indirect=True)
     @patch("controllers.console.auth.forgot_password.AccountService.get_reset_password_data")
     @patch("controllers.console.auth.forgot_password.AccountService.revoke_reset_password_token")
-    @patch("controllers.console.auth.forgot_password.AccountService.get_account_by_email_with_case_fallback")
-    @patch("controllers.console.auth.forgot_password.TenantService.get_join_tenants")
     def test_reset_password_success(
         self,
-        mock_get_tenants,
-        mock_get_account,
-        mock_revoke_token,
-        mock_get_data,
-        database_app: Flask,
+        mock_revoke_token: MagicMock,
+        mock_get_data: MagicMock,
+        app: Flask,
+        sqlite_session: Session,
     ):
         """
         Test successful password reset.
@@ -360,34 +345,40 @@ class TestForgotPasswordResetApi:
         - Success response is returned
         """
         # Arrange
-        account = Account(name="Test User", email="test@example.com")
-        db.session.add(account)
-        db.session.commit()
-        account_id = account.id
-
         mock_get_data.return_value = {"email": "test@example.com", "phase": "reset"}
-        mock_get_account.return_value = account
-        mock_get_tenants.return_value = [MagicMock()]
 
         # Act
-        with database_app.test_request_context(
-            "/forgot-password/resets",
-            method="POST",
-            json={"token": "valid_token", "new_password": "NewPass123!", "password_confirm": "NewPass123!"},
-        ):
-            api = ForgotPasswordResetApi()
-            response = api.post()
+        with _bind_database_session(sqlite_session) as database_session:
+            account = Account(name="Test User", email="test@example.com")
+            tenant = Tenant(name="Test Workspace")
+            database_session.add_all([account, tenant])
+            database_session.flush()
+            database_session.add(TenantAccountJoin(tenant_id=tenant.id, account_id=account.id))
+            database_session.commit()
+            account_id = account.id
+
+            with app.test_request_context(
+                "/forgot-password/resets",
+                method="POST",
+                json={
+                    "token": "valid_token",
+                    "new_password": "NewPass123!",
+                    "password_confirm": "NewPass123!",
+                },
+            ):
+                api = ForgotPasswordResetApi()
+                response = api.post()
+
+            updated_account = database_session.get(Account, account_id)
 
         # Assert
         assert response["result"] == "success"
         mock_revoke_token.assert_called_once_with("valid_token")
-        updated_account = db.session.get(Account, account_id)
         assert updated_account is not None
         assert updated_account.password is not None
         assert updated_account.password_salt is not None
 
-    @patch("controllers.console.auth.forgot_password.AccountService.get_reset_password_data")
-    def test_reset_password_mismatch(self, mock_get_data, app: Flask):
+    def test_reset_password_mismatch(self, app: Flask):
         """
         Test password reset with mismatched passwords.
 
@@ -395,9 +386,6 @@ class TestForgotPasswordResetApi:
         - PasswordMismatchError is raised when passwords don't match
         - No password update occurs
         """
-        # Arrange
-        mock_get_data.return_value = {"email": "test@example.com", "phase": "reset"}
-
         # Act & Assert
         with app.test_request_context(
             "/forgot-password/resets",
@@ -451,10 +439,12 @@ class TestForgotPasswordResetApi:
             with pytest.raises(InvalidTokenError):
                 api.post()
 
+    @pytest.mark.parametrize("sqlite_session", [SQLITE_MODELS], indirect=True)
     @patch("controllers.console.auth.forgot_password.AccountService.get_reset_password_data")
     @patch("controllers.console.auth.forgot_password.AccountService.revoke_reset_password_token")
-    @patch("controllers.console.auth.forgot_password.AccountService.get_account_by_email_with_case_fallback")
-    def test_reset_password_account_not_found(self, mock_get_account, mock_revoke_token, mock_get_data, app: Flask):
+    def test_reset_password_account_not_found(
+        self, mock_revoke_token, mock_get_data, app: Flask, sqlite_session: Session
+    ):
         """
         Test password reset for non-existent account.
 
@@ -463,14 +453,13 @@ class TestForgotPasswordResetApi:
         """
         # Arrange
         mock_get_data.return_value = {"email": "nonexistent@example.com", "phase": "reset"}
-        mock_get_account.return_value = None
 
         # Act & Assert
-        with app.test_request_context(
-            "/forgot-password/resets",
-            method="POST",
-            json={"token": "token", "new_password": "NewPass123!", "password_confirm": "NewPass123!"},
-        ):
-            api = ForgotPasswordResetApi()
-            with pytest.raises(AccountNotFound):
-                api.post()
+        with _bind_database_session(sqlite_session), app.test_request_context(
+                "/forgot-password/resets",
+                method="POST",
+                json={"token": "token", "new_password": "NewPass123!", "password_confirm": "NewPass123!"},
+            ):
+                api = ForgotPasswordResetApi()
+                with pytest.raises(AccountNotFound):
+                    api.post()


### PR DESCRIPTION
## What changed

Moves unit-level coverage out of the Testcontainers integration suite. Database-dependent unit paths use real in-memory SQLite sessions, while genuine container-backed coverage remains in the integration suite.

## Why

These cases mocked their service or session boundaries and therefore did not exercise container infrastructure. Keeping them in the unit suite makes their ownership and runtime requirements explicit.

## Impact

Production behavior is unchanged. Test classification is more accurate and the integration suite avoids unit-only work.

## Validation

- Ruff passed for all changed Python files.
- Changed unit suite: 662 passed.
- Remaining changed integration suite: 71 tests collected successfully.
