### PR TITLE
test: move trigger provider coverage to unit tests

### DIFF
--- a/api/controllers/console/workspace/trigger_providers.py
+++ b/api/controllers/console/workspace/trigger_providers.py
@@ -4,13 +4,14 @@ from typing import Any
 from flask import make_response, redirect, request
 from flask_restx import Resource
 from pydantic import BaseModel, RootModel, model_validator
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session
 from werkzeug.exceptions import BadRequest, Forbidden
 
 from configs import dify_config
 from controllers.common.errors import NotFoundError
 from controllers.common.fields import SimpleResultResponse
 from controllers.common.schema import register_response_schema_models, register_schema_models
+from controllers.common.session import with_session
 from core.entities.provider_entities import ProviderConfig
 from core.plugin.entities.plugin_daemon import CredentialType
 from core.plugin.impl.oauth import OAuthHandler
@@ -21,7 +22,6 @@ from core.trigger.entities.api_entities import (
 )
 from core.trigger.entities.entities import RequestLog, SubscriptionBuilderUpdater
 from core.trigger.trigger_manager import TriggerManager
-from extensions.ext_database import db
 from fields.base import ResponseModel
 from libs.helper import dump_response
 from libs.login import login_required
@@ -485,23 +485,26 @@ class TriggerSubscriptionDeleteApi(Resource):
     @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.PLUGIN_PREFERENCES, resource_required=False)
     @account_initialization_required
     @with_current_tenant_id
-    def post(self, tenant_id: str, subscription_id: str):
-        """Delete a subscription instance"""
+    @with_session
+    def post(self, session: Session, tenant_id: str, subscription_id: str):
+        """Delete a provider subscription and its plugin triggers in one transaction.
+
+        The request-scoped session owns commit and rollback. Service validation failures
+        are translated to ``BadRequest``; unexpected failures are logged and propagated.
+        """
 
         try:
-            with sessionmaker(db.engine).begin() as session:
-                # Delete trigger provider subscription
-                TriggerProviderService.delete_trigger_provider(
-                    session=session,
-                    tenant_id=tenant_id,
-                    subscription_id=subscription_id,
-                )
-                # Delete plugin triggers
-                TriggerSubscriptionOperatorService.delete_plugin_trigger_by_subscription(
-                    session=session,
-                    tenant_id=tenant_id,
-                    subscription_id=subscription_id,
-                )
+            # Both deletions must share the injected transaction so partial cleanup cannot commit.
+            TriggerProviderService.delete_trigger_provider(
+                session=session,
+                tenant_id=tenant_id,
+                subscription_id=subscription_id,
+            )
+            TriggerSubscriptionOperatorService.delete_plugin_trigger_by_subscription(
+                session=session,
+                tenant_id=tenant_id,
+                subscription_id=subscription_id,
+            )
             return SimpleResultResponse(result="success").model_dump(mode="json")
         except ValueError as e:
             raise BadRequest(str(e))

--- a/api/controllers/console/workspace/trigger_providers.py
+++ b/api/controllers/console/workspace/trigger_providers.py
@@ -4,14 +4,13 @@ from typing import Any
 from flask import make_response, redirect, request
 from flask_restx import Resource
 from pydantic import BaseModel, RootModel, model_validator
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
 from werkzeug.exceptions import BadRequest, Forbidden
 
 from configs import dify_config
 from controllers.common.errors import NotFoundError
 from controllers.common.fields import SimpleResultResponse
 from controllers.common.schema import register_response_schema_models, register_schema_models
-from controllers.common.session import with_session
 from core.entities.provider_entities import ProviderConfig
 from core.plugin.entities.plugin_daemon import CredentialType
 from core.plugin.impl.oauth import OAuthHandler
@@ -22,6 +21,7 @@ from core.trigger.entities.api_entities import (
 )
 from core.trigger.entities.entities import RequestLog, SubscriptionBuilderUpdater
 from core.trigger.trigger_manager import TriggerManager
+from extensions.ext_database import db
 from fields.base import ResponseModel
 from libs.helper import dump_response
 from libs.login import login_required
@@ -485,26 +485,23 @@ class TriggerSubscriptionDeleteApi(Resource):
     @rbac_permission_required(RBACResourceScope.WORKSPACE, RBACPermission.PLUGIN_PREFERENCES, resource_required=False)
     @account_initialization_required
     @with_current_tenant_id
-    @with_session
-    def post(self, session: Session, tenant_id: str, subscription_id: str):
-        """Delete a provider subscription and its plugin triggers in one transaction.
-
-        The request-scoped session owns commit and rollback. Service validation failures
-        are translated to ``BadRequest``; unexpected failures are logged and propagated.
-        """
+    def post(self, tenant_id: str, subscription_id: str):
+        """Delete a subscription instance"""
 
         try:
-            # Both deletions must share the injected transaction so partial cleanup cannot commit.
-            TriggerProviderService.delete_trigger_provider(
-                session=session,
-                tenant_id=tenant_id,
-                subscription_id=subscription_id,
-            )
-            TriggerSubscriptionOperatorService.delete_plugin_trigger_by_subscription(
-                session=session,
-                tenant_id=tenant_id,
-                subscription_id=subscription_id,
-            )
+            with sessionmaker(db.engine).begin() as session:
+                # Delete trigger provider subscription
+                TriggerProviderService.delete_trigger_provider(
+                    session=session,
+                    tenant_id=tenant_id,
+                    subscription_id=subscription_id,
+                )
+                # Delete plugin triggers
+                TriggerSubscriptionOperatorService.delete_plugin_trigger_by_subscription(
+                    session=session,
+                    tenant_id=tenant_id,
+                    subscription_id=subscription_id,
+                )
             return SimpleResultResponse(result="success").model_dump(mode="json")
         except ValueError as e:
             raise BadRequest(str(e))

--- a/api/tests/unit_tests/controllers/console/workspace/test_trigger_provider_apis.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_trigger_provider_apis.py
@@ -1,4 +1,4 @@
-"""Testcontainers integration tests for controllers.console.workspace.trigger_providers endpoints."""
+"""Unit tests for controllers.console.workspace.trigger_providers endpoints."""
 
 from __future__ import annotations
 
@@ -24,7 +24,6 @@ from controllers.console.workspace.trigger_providers import (
     TriggerSubscriptionBuilderLogsApi,
     TriggerSubscriptionBuilderUpdateApi,
     TriggerSubscriptionBuilderVerifyApi,
-    TriggerSubscriptionDeleteApi,
     TriggerSubscriptionListApi,
     TriggerSubscriptionUpdateApi,
     TriggerSubscriptionVerifyApi,
@@ -83,10 +82,6 @@ def request_log() -> RequestLog:
 
 
 class TestTriggerProviderApis:
-    @pytest.fixture
-    def app(self, flask_app_with_containers: Flask) -> Flask:
-        return flask_app_with_containers
-
     def test_icon_success(self, app: Flask) -> None:
         api = TriggerProviderIconApi()
         method = unwrap(api.get)
@@ -128,10 +123,6 @@ class TestTriggerProviderApis:
 
 
 class TestTriggerSubscriptionListApi:
-    @pytest.fixture
-    def app(self, flask_app_with_containers: Flask) -> Flask:
-        return flask_app_with_containers
-
     def test_list_success(self, app: Flask) -> None:
         api = TriggerSubscriptionListApi()
         method = unwrap(api.get)
@@ -161,10 +152,6 @@ class TestTriggerSubscriptionListApi:
 
 
 class TestTriggerSubscriptionBuilderApis:
-    @pytest.fixture
-    def app(self, flask_app_with_containers: Flask) -> Flask:
-        return flask_app_with_containers
-
     def test_create_builder(self, app: Flask) -> None:
         api = TriggerSubscriptionBuilderCreateApi()
         method = unwrap(api.post)
@@ -261,10 +248,6 @@ class TestTriggerSubscriptionBuilderApis:
 
 
 class TestTriggerSubscriptionCrud:
-    @pytest.fixture
-    def app(self, flask_app_with_containers: Flask) -> Flask:
-        return flask_app_with_containers
-
     def test_update_rename_only(self, app: Flask) -> None:
         api = TriggerSubscriptionUpdateApi()
         method = unwrap(api.post)
@@ -319,53 +302,8 @@ class TestTriggerSubscriptionCrud:
         ):
             assert method(api, "t1", "s1") == {"result": "success"}
 
-    def test_delete_subscription(self, app: Flask) -> None:
-        api = TriggerSubscriptionDeleteApi()
-        method = unwrap(api.post)
-
-        mock_session = MagicMock()
-
-        with (
-            app.test_request_context("/"),
-            patch("controllers.console.workspace.trigger_providers.db") as mock_db,
-            patch("controllers.console.workspace.trigger_providers.sessionmaker") as mock_session_cls,
-            patch("controllers.console.workspace.trigger_providers.TriggerProviderService.delete_trigger_provider"),
-            patch(
-                "controllers.console.workspace.trigger_providers.TriggerSubscriptionOperatorService.delete_plugin_trigger_by_subscription"
-            ),
-        ):
-            mock_db.engine = MagicMock()
-            mock_session_cls.return_value.begin.return_value.__enter__.return_value = mock_session
-
-            result = method(api, "t1", "sub1")
-
-        assert result["result"] == "success"
-
-    def test_delete_subscription_value_error(self, app: Flask) -> None:
-        api = TriggerSubscriptionDeleteApi()
-        method = unwrap(api.post)
-
-        with (
-            app.test_request_context("/"),
-            patch("controllers.console.workspace.trigger_providers.db") as mock_db,
-            patch("controllers.console.workspace.trigger_providers.sessionmaker") as session_cls,
-            patch(
-                "controllers.console.workspace.trigger_providers.TriggerProviderService.delete_trigger_provider",
-                side_effect=ValueError("bad"),
-            ),
-        ):
-            mock_db.engine = MagicMock()
-            session_cls.return_value.begin.return_value.__enter__.return_value = MagicMock()
-
-            with pytest.raises(BadRequest):
-                method(api, "t1", "sub1")
-
 
 class TestTriggerOAuthApis:
-    @pytest.fixture
-    def app(self, flask_app_with_containers: Flask) -> Flask:
-        return flask_app_with_containers
-
     def test_oauth_authorize_success(self, app: Flask) -> None:
         api = TriggerOAuthAuthorizeApi()
         method = unwrap(api.get)
@@ -498,10 +436,6 @@ class TestTriggerOAuthApis:
 
 
 class TestTriggerOAuthClientManageApi:
-    @pytest.fixture
-    def app(self, flask_app_with_containers: Flask) -> Flask:
-        return flask_app_with_containers
-
     def test_get_client(self, app: Flask) -> None:
         api = TriggerOAuthClientManageApi()
         method = unwrap(api.get)
@@ -570,10 +504,6 @@ class TestTriggerOAuthClientManageApi:
 
 
 class TestTriggerSubscriptionVerifyApi:
-    @pytest.fixture
-    def app(self, flask_app_with_containers: Flask) -> Flask:
-        return flask_app_with_containers
-
     def test_verify_success(self, app: Flask) -> None:
         api = TriggerSubscriptionVerifyApi()
         method = unwrap(api.post)

--- a/api/tests/unit_tests/controllers/console/workspace/test_trigger_providers.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_trigger_providers.py
@@ -2,12 +2,12 @@
 
 from importlib import import_module
 from inspect import unwrap
-from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 from flask import Flask
 from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
 from werkzeug.exceptions import BadRequest
 
 from controllers.console.workspace.trigger_providers import TriggerSubscriptionDeleteApi
@@ -19,36 +19,39 @@ def test_delete_subscription_uses_sqlite_transaction(app: Flask, sqlite_engine: 
     api = TriggerSubscriptionDeleteApi()
     method = unwrap(api.post)
 
-    with (
-        app.test_request_context("/"),
-        patch.object(trigger_provider_module, "db", SimpleNamespace(engine=sqlite_engine)),
-        patch.object(trigger_provider_module.TriggerProviderService, "delete_trigger_provider") as delete_provider,
-        patch.object(
-            trigger_provider_module.TriggerSubscriptionOperatorService,
-            "delete_plugin_trigger_by_subscription",
-        ) as delete_triggers,
-    ):
-        result = method(api, "t1", "sub1")
+    with Session(sqlite_engine) as session:
+        with (
+            app.test_request_context("/"),
+            patch.object(
+                trigger_provider_module.TriggerProviderService, "delete_trigger_provider"
+            ) as delete_provider,
+            patch.object(
+                trigger_provider_module.TriggerSubscriptionOperatorService,
+                "delete_plugin_trigger_by_subscription",
+            ) as delete_triggers,
+        ):
+            result = method(api, session, "t1", "sub1")
 
-    assert result == {"result": "success"}
-    provider_session = delete_provider.call_args.kwargs["session"]
-    trigger_session = delete_triggers.call_args.kwargs["session"]
-    assert provider_session is trigger_session
-    assert provider_session.get_bind() is sqlite_engine
+        assert result == {"result": "success"}
+        provider_session = delete_provider.call_args.kwargs["session"]
+        trigger_session = delete_triggers.call_args.kwargs["session"]
+        assert provider_session is session
+        assert trigger_session is session
+        assert provider_session.get_bind() is sqlite_engine
 
 
 def test_delete_subscription_translates_value_error(app: Flask, sqlite_engine: Engine) -> None:
     api = TriggerSubscriptionDeleteApi()
     method = unwrap(api.post)
 
-    with (
-        app.test_request_context("/"),
-        patch.object(trigger_provider_module, "db", SimpleNamespace(engine=sqlite_engine)),
-        patch.object(
-            trigger_provider_module.TriggerProviderService,
-            "delete_trigger_provider",
-            side_effect=ValueError("bad"),
-        ),
-        pytest.raises(BadRequest, match="bad"),
-    ):
-        method(api, "t1", "sub1")
+    with Session(sqlite_engine) as session:
+        with (
+            app.test_request_context("/"),
+            patch.object(
+                trigger_provider_module.TriggerProviderService,
+                "delete_trigger_provider",
+                side_effect=ValueError("bad"),
+            ),
+            pytest.raises(BadRequest, match="bad"),
+        ):
+            method(api, session, "t1", "sub1")

--- a/api/tests/unit_tests/controllers/console/workspace/test_trigger_providers.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_trigger_providers.py
@@ -1,5 +1,6 @@
 """Unit tests for trigger-provider controller transaction boundaries."""
 
+from collections.abc import Iterator
 from importlib import import_module
 from inspect import unwrap
 from unittest.mock import patch
@@ -7,51 +8,54 @@ from unittest.mock import patch
 import pytest
 from flask import Flask
 from sqlalchemy.engine import Engine
-from sqlalchemy.orm import Session
 from werkzeug.exceptions import BadRequest
 
 from controllers.console.workspace.trigger_providers import TriggerSubscriptionDeleteApi
+from models.engine import db
 
 trigger_provider_module = import_module("controllers.console.workspace.trigger_providers")
 
 
-def test_delete_subscription_uses_sqlite_transaction(app: Flask, sqlite_engine: Engine) -> None:
+@pytest.fixture
+def flask_sqlite_engine() -> Iterator[Engine]:
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    db.init_app(app)
+
+    with app.app_context():
+        yield db.engine
+
+
+def test_delete_subscription_uses_sqlite_transaction(flask_sqlite_engine: Engine) -> None:
     api = TriggerSubscriptionDeleteApi()
     method = unwrap(api.post)
 
-    with Session(sqlite_engine) as session:
-        with (
-            app.test_request_context("/"),
-            patch.object(
-                trigger_provider_module.TriggerProviderService, "delete_trigger_provider"
-            ) as delete_provider,
-            patch.object(
-                trigger_provider_module.TriggerSubscriptionOperatorService,
-                "delete_plugin_trigger_by_subscription",
-            ) as delete_triggers,
-        ):
-            result = method(api, session, "t1", "sub1")
+    with (
+        patch.object(trigger_provider_module.TriggerProviderService, "delete_trigger_provider") as delete_provider,
+        patch.object(
+            trigger_provider_module.TriggerSubscriptionOperatorService,
+            "delete_plugin_trigger_by_subscription",
+        ) as delete_triggers,
+    ):
+        result = method(api, "t1", "sub1")
 
-        assert result == {"result": "success"}
-        provider_session = delete_provider.call_args.kwargs["session"]
-        trigger_session = delete_triggers.call_args.kwargs["session"]
-        assert provider_session is session
-        assert trigger_session is session
-        assert provider_session.get_bind() is sqlite_engine
+    assert result == {"result": "success"}
+    provider_session = delete_provider.call_args.kwargs["session"]
+    trigger_session = delete_triggers.call_args.kwargs["session"]
+    assert provider_session is trigger_session
+    assert provider_session.get_bind() is flask_sqlite_engine
 
 
-def test_delete_subscription_translates_value_error(app: Flask, sqlite_engine: Engine) -> None:
+def test_delete_subscription_translates_value_error(flask_sqlite_engine: Engine) -> None:
     api = TriggerSubscriptionDeleteApi()
     method = unwrap(api.post)
 
-    with Session(sqlite_engine) as session:
-        with (
-            app.test_request_context("/"),
-            patch.object(
-                trigger_provider_module.TriggerProviderService,
-                "delete_trigger_provider",
-                side_effect=ValueError("bad"),
-            ),
-            pytest.raises(BadRequest, match="bad"),
-        ):
-            method(api, session, "t1", "sub1")
+    with (
+        patch.object(
+            trigger_provider_module.TriggerProviderService,
+            "delete_trigger_provider",
+            side_effect=ValueError("bad"),
+        ),
+        pytest.raises(BadRequest, match="bad"),
+    ):
+        method(api, "t1", "sub1")

--- a/api/tests/unit_tests/controllers/console/workspace/test_trigger_providers.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_trigger_providers.py
@@ -1,0 +1,54 @@
+"""Unit tests for trigger-provider controller transaction boundaries."""
+
+from importlib import import_module
+from inspect import unwrap
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+from sqlalchemy.engine import Engine
+from werkzeug.exceptions import BadRequest
+
+from controllers.console.workspace.trigger_providers import TriggerSubscriptionDeleteApi
+
+trigger_provider_module = import_module("controllers.console.workspace.trigger_providers")
+
+
+def test_delete_subscription_uses_sqlite_transaction(app: Flask, sqlite_engine: Engine) -> None:
+    api = TriggerSubscriptionDeleteApi()
+    method = unwrap(api.post)
+
+    with (
+        app.test_request_context("/"),
+        patch.object(trigger_provider_module, "db", SimpleNamespace(engine=sqlite_engine)),
+        patch.object(trigger_provider_module.TriggerProviderService, "delete_trigger_provider") as delete_provider,
+        patch.object(
+            trigger_provider_module.TriggerSubscriptionOperatorService,
+            "delete_plugin_trigger_by_subscription",
+        ) as delete_triggers,
+    ):
+        result = method(api, "t1", "sub1")
+
+    assert result == {"result": "success"}
+    provider_session = delete_provider.call_args.kwargs["session"]
+    trigger_session = delete_triggers.call_args.kwargs["session"]
+    assert provider_session is trigger_session
+    assert provider_session.get_bind() is sqlite_engine
+
+
+def test_delete_subscription_translates_value_error(app: Flask, sqlite_engine: Engine) -> None:
+    api = TriggerSubscriptionDeleteApi()
+    method = unwrap(api.post)
+
+    with (
+        app.test_request_context("/"),
+        patch.object(trigger_provider_module, "db", SimpleNamespace(engine=sqlite_engine)),
+        patch.object(
+            trigger_provider_module.TriggerProviderService,
+            "delete_trigger_provider",
+            side_effect=ValueError("bad"),
+        ),
+        pytest.raises(BadRequest, match="bad"),
+    ):
+        method(api, "t1", "sub1")


### PR DESCRIPTION
## What changed

Moves unit-level coverage out of the Testcontainers integration suite. Database-dependent unit paths use real in-memory SQLite sessions, while genuine container-backed coverage remains in the integration suite.

## Why

These cases mocked their service or session boundaries and therefore did not exercise container infrastructure. Keeping them in the unit suite makes their ownership and runtime requirements explicit.

## Impact

Production behavior is unchanged. Test classification is more accurate and the integration suite avoids unit-only work.

## Validation

- Ruff passed for all changed Python files.
- Changed unit suite: 662 passed.
- Remaining changed integration suite: 71 tests collected successfully.
