### PR TITLE
fix(workflow): preserve falsy inputs in single-node runs

### DIFF
--- a/api/core/workflow/workflow_entry.py
+++ b/api/core/workflow/workflow_entry.py
@@ -576,7 +576,7 @@ class WorkflowEntry:
 
             # get input value
             input_value = user_inputs.get(node_variable)
-            if not input_value:
+            if input_value is None:
                 input_value = user_inputs.get(node_variable_key)
             if input_value is None:
                 continue

--- a/api/tests/unit_tests/core/workflow/test_workflow_entry_helpers.py
+++ b/api/tests/unit_tests/core/workflow/test_workflow_entry_helpers.py
@@ -933,6 +933,20 @@ class TestMappingUserInputsBranches:
 
         variable_pool.add.assert_not_called()
 
+    @pytest.mark.parametrize("input_value", [False, 0, ""])
+    def test_preserves_explicit_falsy_user_inputs(self, input_value):
+        variable_pool = MagicMock()
+        variable_pool.get.return_value = None
+
+        workflow_entry.WorkflowEntry.mapping_user_inputs_to_variable_pool(
+            variable_mapping={"node.input": ["target", "input"]},
+            user_inputs={"node.input": input_value},
+            variable_pool=variable_pool,
+            tenant_id="tenant-id",
+        )
+
+        variable_pool.add.assert_called_once_with(["target", "input"], input_value)
+
     def test_merges_structured_output_values(self):
         variable_pool = MagicMock()
         variable_pool.get.side_effect = [


### PR DESCRIPTION
Fixes #38963

## Summary

- Preserve explicit `False`, `0`, and empty-string inputs during workflow single-node execution.
- Retain the existing short-key fallback only when the full key has no value.
- Cover the regression with parameterized unit tests.

The input mapper used a truthiness check before looking up the short-key alias. Valid falsy values therefore followed the missing-input path and were not placed in the variable pool.

## Screenshots

Not applicable; backend workflow execution change.

## Checks

- `uv run --project api --no-default-groups --group dev pytest api/tests/unit_tests/core/workflow/test_workflow_entry.py api/tests/unit_tests/core/workflow/test_workflow_entry_helpers.py -q` (47 passed)
- `ruff check` and `ruff format --check` on changed files
- `pyrefly check api/core/workflow/workflow_entry.py` (0 errors)
- `mypy api/core/workflow/workflow_entry.py --check-untyped-defs --disable-error-code=import-untyped` (success)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
