### PR TITLE
fix: reject invalid built-in metadata actions

### DIFF
--- a/api/controllers/service_api/dataset/metadata.py
+++ b/api/controllers/service_api/dataset/metadata.py
@@ -26,6 +26,8 @@ from services.entities.knowledge_entities.knowledge_entities import (
 )
 from services.metadata_service import MetadataService
 
+from .error import InvalidActionError
+
 BUILT_IN_METADATA_ACTION_PARAM = {
     "description": "`enable` to activate built-in metadata fields, `disable` to deactivate them.",
     "enum": ["enable", "disable"],
@@ -251,6 +253,7 @@ class DatasetMetadataBuiltInFieldActionServiceApi(DatasetApiResource):
     @service_api_ns.doc(
         responses={
             200: "Action completed successfully",
+            400: "Bad request - invalid action",
             401: "Unauthorized - invalid API token",
             404: "Dataset not found",
         }
@@ -273,6 +276,8 @@ class DatasetMetadataBuiltInFieldActionServiceApi(DatasetApiResource):
                 MetadataService.enable_built_in_field(dataset, session)
             case "disable":
                 MetadataService.disable_built_in_field(dataset, session)
+            case _:
+                raise InvalidActionError()
         return dump_response(DatasetMetadataActionResponse, {"result": "success"}), 200
 
 

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_metadata.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_metadata.py
@@ -23,6 +23,7 @@ import pytest
 from flask import Flask
 from werkzeug.exceptions import NotFound
 
+from controllers.service_api.dataset.error import InvalidActionError
 from controllers.service_api.dataset.metadata import (
     DatasetMetadataBuiltInFieldActionServiceApi,
     DatasetMetadataBuiltInFieldServiceApi,
@@ -482,6 +483,40 @@ class TestDatasetMetadataBuiltInFieldAction:
                     dataset_id=mock_dataset.id,
                     action="enable",
                 )
+
+    @patch("controllers.service_api.dataset.metadata.MetadataService")
+    @patch("controllers.service_api.dataset.metadata.DatasetService")
+    @patch("controllers.service_api.dataset.metadata.current_user")
+    def test_unknown_action_raises_invalid_action_without_toggling(
+        self,
+        mock_current_user,
+        mock_dataset_svc,
+        mock_meta_svc,
+        app: Flask,
+        mock_tenant,
+        mock_dataset,
+    ):
+        """Test invalid action returns 400 and does not toggle built-in metadata fields."""
+        mock_dataset_svc.get_dataset.return_value = mock_dataset
+        mock_dataset_svc.check_dataset_permission.return_value = None
+
+        with app.test_request_context(
+            f"/datasets/{mock_dataset.id}/metadata/built-in/Enable",
+            method="POST",
+        ):
+            api = DatasetMetadataBuiltInFieldActionServiceApi()
+            session = MagicMock()
+            with pytest.raises(InvalidActionError):
+                self._call_post(
+                    api,
+                    session,
+                    tenant_id=mock_tenant.id,
+                    dataset_id=mock_dataset.id,
+                    action="Enable",
+                )
+
+        mock_meta_svc.enable_built_in_field.assert_not_called()
+        mock_meta_svc.disable_built_in_field.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- reject unsupported built-in metadata actions with the existing `InvalidActionError` instead of returning a false `200 success`
- document the `400` response for the Service API endpoint
- add a focused regression test that verifies invalid actions do not call either metadata toggle service

## Validation
- `uv run --project api pytest -o addopts='' api/tests/unit_tests/controllers/service_api/dataset/test_metadata.py -q` (15 passed)
- `uv run --project api pytest -o addopts='' api/tests/unit_tests/commands/test_generate_swagger_specs.py api/tests/unit_tests/controllers/test_swagger.py -q` (29 passed)
- `uv run --project api --dev ruff check api/controllers/service_api/dataset/metadata.py api/tests/unit_tests/controllers/service_api/dataset/test_metadata.py`
- `uv run --project api --dev ruff format --check api/controllers/service_api/dataset/metadata.py api/tests/unit_tests/controllers/service_api/dataset/test_metadata.py`
- `git diff --check origin/main...HEAD`

## Duplicate Check
- Checked issue #38855 timeline and related PRs for items 1, 3, 4, and 5.
- Searched open, closed, and merged PRs by issue item, endpoint, symbols, affected files, and behavior.
- Verified latest `origin/main` still lacks runtime validation for unknown actions; no active or equivalent fix for item 2 was found.

## Browser / Playwright
- Not applicable: this is a backend-only Flask Service API route-validation change with no browser-visible surface.

## Scope
This addresses only issue #38855 item 2’s unknown-action false-success behavior. The separate service-level exception-swallowing concern remains out of scope.