### PR TITLE
fix(dify-ui): support data-tone styling for Answer node buttons

### DIFF
--- a/web/app/components/base/markdown-blocks/__tests__/button.spec.tsx
+++ b/web/app/components/base/markdown-blocks/__tests__/button.spec.tsx
@@ -20,6 +20,7 @@ type TestNode = {
     dataMessage?: string
     dataLink?: string
     dataSize?: string
+    dataTone?: string
   }
   children?: Array<{ value?: string }>
 }

--- a/web/app/components/base/markdown-blocks/__tests__/form.spec.tsx
+++ b/web/app/components/base/markdown-blocks/__tests__/form.spec.tsx
@@ -746,7 +746,7 @@ describe('MarkdownForm', () => {
       const node = createRootNode([
         createElementNode(
           'button',
-          { dataVariant: 'ghost', dataSize: 'small', dataTone: 'default' },
+          { dataVariant: 'ghost', dataSize: 'small', dataTone: 'destructive' },
           [createTextNode('Delete')],
         ),
       ])
@@ -755,9 +755,8 @@ describe('MarkdownForm', () => {
 
       const button = screen.getByRole('button', { name: 'Delete' })
 
-      expect(button.className).toContain('bg-components-button-destructive-primary-bg')
-
-      expect(button.className).toContain('text-components-button-destructive-primary-text')
+      expect(button.className).toContain('bg-components-button-destructive-ghost-bg-hover')
+      expect(button.className).toContain('text-components-button-destructive-ghost-text')
     })
 
     it('should ignore invalid tone value', () => {

--- a/web/app/components/base/markdown-blocks/__tests__/form.spec.tsx
+++ b/web/app/components/base/markdown-blocks/__tests__/form.spec.tsx
@@ -712,12 +712,14 @@ describe('MarkdownForm', () => {
   })
 
   // Button variant and size props should only apply whitelisted values.
-  describe('Button variant and size', () => {
+  describe('Button variant, size, and tone', () => {
     it('should render button with valid variant and size', () => {
       const node = createRootNode([
-        createElementNode('button', { dataVariant: 'primary', dataSize: 'large' }, [
-          createTextNode('Go'),
-        ]),
+        createElementNode(
+          'button',
+          { dataVariant: 'primary', dataSize: 'large', dataTone: 'default' },
+          [createTextNode('Go')],
+        ),
       ])
 
       render(<MarkdownForm node={node} />)
@@ -726,16 +728,50 @@ describe('MarkdownForm', () => {
       expect(button)!.toBeInTheDocument()
     })
 
-    it('should ignore invalid variant and size values', () => {
+    it('should ignore invalid variant, size, and tone values', () => {
       const node = createRootNode([
-        createElementNode('button', { dataVariant: 'danger', dataSize: 'xl' }, [
-          createTextNode('Go'),
-        ]),
+        createElementNode(
+          'button',
+          { dataVariant: 'danger', dataSize: 'xl', dataTone: 'warning' },
+          [createTextNode('Go')],
+        ),
       ])
 
       render(<MarkdownForm node={node} />)
 
       expect(screen.getByRole('button', { name: 'Go' }))!.toBeInTheDocument()
+    })
+
+    it('should render destructive form button', () => {
+      const node = createRootNode([
+        createElementNode(
+          'button',
+          { dataVariant: 'ghost', dataSize: 'small', dataTone: 'default' },
+          [createTextNode('Delete')],
+        ),
+      ])
+
+      render(<MarkdownForm node={node} />)
+
+      const button = screen.getByRole('button', { name: 'Delete' })
+
+      expect(button.className).toContain('bg-components-button-destructive-primary-bg')
+
+      expect(button.className).toContain('text-components-button-destructive-primary-text')
+    })
+
+    it('should ignore invalid tone value', () => {
+      const node = createRootNode([
+        createElementNode('button', { dataVariant: 'primary', dataTone: 'warning' }, [
+          createTextNode('Invalid'),
+        ]),
+      ])
+
+      render(<MarkdownForm node={node} />)
+
+      const button = screen.getByRole('button', { name: 'Invalid' })
+
+      expect(button.className).not.toContain('bg-components-button-destructive-primary-bg')
     })
   })
 

--- a/web/app/components/base/markdown-blocks/button.tsx
+++ b/web/app/components/base/markdown-blocks/button.tsx
@@ -9,11 +9,13 @@ const MarkdownButton = ({ node }: any) => {
   const message = node.properties.dataMessage
   const link = node.properties.dataLink
   const size = node.properties.dataSize
+  const tone = node.properties.dataTone
 
   return (
     <Button
       variant={variant}
       size={size}
+      tone={tone}
       className={cn('h-auto! min-h-8 px-3! whitespace-normal select-none')}
       onClick={() => {
         if (link && isValidUrl(link)) {

--- a/web/app/components/base/markdown-blocks/form.tsx
+++ b/web/app/components/base/markdown-blocks/form.tsx
@@ -74,7 +74,6 @@ function isSafeName(name: unknown): name is string {
 
 const VALID_BUTTON_VARIANTS = new Set<string>([
   'primary',
-  'warning',
   'secondary',
   'secondary-accent',
   'ghost',
@@ -82,6 +81,8 @@ const VALID_BUTTON_VARIANTS = new Set<string>([
   'tertiary',
 ])
 const VALID_BUTTON_SIZES = new Set<string>(['small', 'medium', 'large'])
+
+const VALID_BUTTON_TONES = new Set<string>(['default', 'destructive'])
 
 type HastText = {
   type: 'text'
@@ -395,17 +396,23 @@ const MarkdownForm = ({ node }: { node: HastElement }) => {
         if (child.tagName === SUPPORTED_TAGS.BUTTON) {
           const rawVariant = str(child.properties.dataVariant)
           const rawSize = str(child.properties.dataSize)
+          const rawTone = str(child.properties.dataTone)
+
           const variant = VALID_BUTTON_VARIANTS.has(rawVariant)
             ? (rawVariant as ButtonProps['variant'])
             : undefined
           const size = VALID_BUTTON_SIZES.has(rawSize)
             ? (rawSize as ButtonProps['size'])
             : undefined
+          const tone = VALID_BUTTON_TONES.has(rawTone)
+            ? (rawTone as ButtonProps['tone'])
+            : undefined
 
           return (
             <Button
               variant={variant}
               size={size}
+              tone={tone}
               className="mt-4"
               key={key}
               disabled={isSubmitting}

--- a/web/app/components/base/markdown/streamdown-wrapper.tsx
+++ b/web/app/components/base/markdown/streamdown-wrapper.tsx
@@ -52,7 +52,7 @@ const mathPlugin = createMathPlugin({
  * minimise the attack surface when LLM-generated content is rendered.
  */
 const ALLOWED_TAGS: Record<string, string[]> = {
-  button: ['dataVariant', 'dataSize', 'dataMessage', 'dataLink'],
+  button: ['dataVariant', 'dataSize', 'dataTone', 'dataMessage', 'dataLink'],
   form: ['dataFormat'],
   input: ['type', 'name', 'value', 'placeholder', 'checked', 'dataTip', 'dataOptions'],
   textarea: ['name', 'placeholder', 'value'],


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #38895

This PR adds support for the `data-tone` attribute on buttons rendered from Answer node Markdown/HTML content.

Previously, the following button was rendered using the default primary styling instead of the destructive styling:

```html
<button
  data-message="stop"
  data-variant="primary"
  data-tone="destructive"
>
  ❌ Stop this task
</button>
```

The underlying Dify UI `Button` component already supports destructive styling through:

```tsx
<Button
  variant="primary"
  tone="destructive"
>
  ❌ Stop this task
</Button>
```

However, the Answer node Markdown rendering pipeline did not preserve or forward `data-tone` to the `tone` prop.

The issue occurred in two places:

1. `dataTone` was not included in the Streamdown sanitizer allowlist, so `data-tone` could be removed during HTML sanitization.
2. `MarkdownButton` read `dataVariant` and `dataSize`, but did not read `dataTone` or pass it to the Dify UI `Button` component.

This PR:

- Adds `dataTone` to the allowed attributes for Markdown `<button>` elements.
- Reads and validates `node.properties.dataTone` in `MarkdownButton`.
- Passes the validated value to the Dify UI `Button` through the `tone` prop.
- Adds equivalent tone support for buttons rendered inside Markdown forms.
- Supports the existing valid tone values:
  - `default`
  - `destructive`
- Adds test coverage for destructive and unsupported tone values.
- Keeps the existing styling unchanged when `data-tone` is omitted.
- Introduces no new dependencies.

### `data-variant="warning"` behavior

During investigation, `data-variant="warning"` was also tested as a possible way to render a destructive or warning-style button.

This approach is outdated and is not supported by the current Dify UI `Button` component.

The currently supported variants are:

- `primary`
- `secondary`
- `secondary-accent`
- `tertiary`
- `ghost`
- `ghost-accent`

Destructive styling is implemented by combining a supported variant with the `destructive` tone:

```tsx
<Button
  variant="primary"
  tone="destructive"
/>
```

Therefore, this PR does not add or restore a `warning` variant. The supported Answer node syntax is:

```html
<button
  data-message="stop"
  data-variant="primary"
  data-tone="destructive"
>
  ❌ Stop this task
</button>
```

### Documentation

The current supported-tags documentation still lists behavior that no longer fully matches the current implementation:

https://docs.dify.ai/en/cloud/use-dify/nodes/template#supported-tags

A related documentation update may be required to clarify:

- The supported `data-variant` values.
- That `data-variant="warning"` is unsupported.
- The supported `data-tone` values.
- How to define destructive Answer node buttons.

## Screenshots

| Before | After |
|--------|-------|
| `data-tone="destructive"` was ignored, and the button was rendered using the normal primary style.<br><br>Before: data-tone ignored<img width="445" height="176" alt="Dify_Button_Bug" src="https://github.com/user-attachments/assets/1de78cca-9b95-469c-8923-22819ebced39" /> | The existing destructive tone is applied when `data-variant="primary"` and `data-tone="destructive"` are provided.<br><br>After: destructive tone applied <img width="445" height="176" alt="Dify_Button_Expect" src="https://github.com/user-attachments/assets/54ff0904-610e-4745-a07a-6c44d3810447" /> |

### Additional verification

The UI test page verifies the supported Button tone combinations:

- Primary/default
- Primary/destructive
- Secondary/destructive
- Tertiary/destructive

<img width="600" alt="Dify_button_Tone_Modify_Example" src="https://github.com/user-attachments/assets/8aa162b4-b76f-4ce5-834f-c9099d4c8db1" />

## Test plan

### Automated tests

```bash
cd web

pnpm exec vitest run \
  app/components/base/markdown-blocks/__tests__/button.spec.tsx

pnpm exec vitest run \
  app/components/base/markdown-blocks/__tests__/form.spec.tsx
```

### Frontend validation

```bash
cd web
pnpm exec vp staged
```

### Manual verification

1. Add the following content to an Answer node:

   ```html
   <button
     data-message="stop"
     data-variant="primary"
     data-tone="destructive"
   >
     ❌ Stop this task
   </button>
   ```

2. Run the app in Preview.
3. Verify that:
   - The button is rendered using the destructive primary style.
   - Clicking the button sends `stop`.
   - Buttons without `data-tone` retain their existing appearance.
   - Unsupported tone values do not break rendering.
   - `data-variant="warning"` is not required and does not act as a supported variant.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint goods.
- [x] **_On Windows, running `pnpm exec vp staged` resulted in an error. I manually verified that the changes follow the existing code style and ran the relevant spec tests to validate the logic._**