### PR TITLE
fix(e2e): probe shellctl health in preflight

### DIFF
--- a/e2e/features/agent-v2/support/preflight/agent-backend.ts
+++ b/e2e/features/agent-v2/support/preflight/agent-backend.ts
@@ -36,18 +36,20 @@ const getAgentBackendURL = () => {
   return undefined
 }
 
-const checkRuntimeOpenApi = async ({
+const checkRuntimeEndpoint = async ({
+  path,
   remediation,
   title,
   url,
   world,
 }: {
+  path: string
   remediation: string
   title: string
   url: string
   world: DifyWorld
 }) => {
-  const healthURL = `${url}/openapi.json`
+  const healthURL = `${url}${path}`
   try {
     const response = await fetch(healthURL)
     if (response.ok) return undefined
@@ -85,7 +87,8 @@ export async function skipMissingAgentBackendRuntime(world: DifyWorld) {
     )
   }
 
-  const agentBackendBlock = await checkRuntimeOpenApi({
+  const agentBackendBlock = await checkRuntimeEndpoint({
+    path: '/openapi.json',
     remediation:
       'Start a healthy dify-agent server and make sure AGENT_BACKEND_BASE_URL points to it before running Agent v2 runtime scenarios.',
     title: 'Agent v2 runtime backend',
@@ -96,7 +99,8 @@ export async function skipMissingAgentBackendRuntime(world: DifyWorld) {
 
   const shellctlURL = getShellctlURL()
   if (shellctlURL) {
-    const shellctlBlock = await checkRuntimeOpenApi({
+    const shellctlBlock = await checkRuntimeEndpoint({
+      path: '/healthz',
       remediation:
         'Start the shellctl local sandbox, or run with E2E_START_AGENT_BACKEND=1 so E2E starts it together with dify-agent.',
       title: 'Agent v2 shellctl sandbox',

--- a/e2e/tests/agent-backend-preflight.test.ts
+++ b/e2e/tests/agent-backend-preflight.test.ts
@@ -1,0 +1,33 @@
+import type { DifyWorld } from '../features/support/world'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { skipMissingAgentBackendRuntime } from '../features/agent-v2/support/preflight/agent-backend'
+
+describe('skipMissingAgentBackendRuntime', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps runtime scenarios runnable when the Go shellctl health endpoint is available', async () => {
+    vi.stubEnv('E2E_AGENT_BACKEND_URL', 'http://agent-backend.test/')
+    vi.stubEnv('E2E_SHELLCTL_URL', 'http://shellctl.test/')
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      const url = input.toString()
+      if (
+        url === 'http://agent-backend.test/openapi.json' ||
+        url === 'http://shellctl.test/healthz'
+      ) {
+        return new Response()
+      }
+
+      return new Response(null, { status: 404, statusText: 'Not Found' })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const attach = vi.fn()
+    const world = { attach } as unknown as DifyWorld
+
+    await expect(skipMissingAgentBackendRuntime(world)).resolves.toBe('http://agent-backend.test')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(attach).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- keep the standalone dify-agent readiness probe on `/openapi.json`
- probe the Go shellctl sandbox through `/healthz`
- add a behavior-focused regression test that keeps runtime scenarios runnable when shellctl exposes its real health contract

## Root cause

The shellctl Go rewrite replaced the old FastAPI OpenAPI surface with a dedicated `/healthz` endpoint. The E2E runner startup probe was aligned in #38968, but the Agent v2 scenario preflight still reused an OpenAPI-only helper for both dify-agent and shellctl.

In post-merge run [29387157554](https://github.com/langgenius/dify/actions/runs/29387157554), shellctl returned `200` from `/healthz`, while the stale scenario preflight requested `/openapi.json` and received `404` ten times. Cucumber converted those blocked preconditions into ten skipped external runtime scenarios.

## Validation

- focused regression test failed against the stale shellctl `/openapi.json` probe and passed after the endpoint split
- `pnpm -C e2e test:unit` (3 files, 9 tests)
- `pnpm -C e2e type-check`
- `vp lint --fix --quiet`
- `git diff --check`

External runtime is intentionally not enabled in pull request CI for this fix.
