### PR TITLE
test: use SQLite in Aliyun trace utilities

### DIFF
--- a/api/providers/conftest.py
+++ b/api/providers/conftest.py
@@ -1,0 +1,35 @@
+"""Shared database fixtures for provider tests.
+
+Provider tests live outside ``tests/unit_tests`` and therefore cannot use that
+suite's SQLite fixtures. Keep this fixture scoped to ``providers`` so each
+provider package can exercise real SQLAlchemy queries without a service
+database or mocked sessions.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from models.base import TypeBase
+
+
+@pytest.fixture
+def sqlite3_session(request: pytest.FixtureRequest) -> Iterator[Session]:
+    """Yield an isolated SQLite session with the parametrized model tables.
+
+    Pass the required ORM classes through indirect parametrization. The engine
+    is per-test so committed rows and identity-map state cannot leak between
+    provider packages.
+    """
+
+    models: tuple[type[TypeBase], ...] = request.param
+    engine = create_engine("sqlite:///:memory:")
+    tables = [model.metadata.tables[model.__tablename__] for model in models]
+    TypeBase.metadata.create_all(engine, tables=tables)
+    try:
+        with Session(engine, expire_on_commit=False) as session:
+            yield session
+    finally:
+        engine.dispose()

--- a/api/providers/trace/trace-aliyun/tests/unit_tests/aliyun_trace/test_aliyun_trace_utils.py
+++ b/api/providers/trace/trace-aliyun/tests/unit_tests/aliyun_trace/test_aliyun_trace_utils.py
@@ -1,3 +1,5 @@
+"""Unit tests for Aliyun trace utility transformations and database lookups."""
+
 import json
 from collections.abc import Mapping
 from typing import Any, cast
@@ -25,11 +27,13 @@ from dify_trace_aliyun.utils import (
     serialize_json_data,
 )
 from opentelemetry.trace import Link, StatusCode
+from sqlalchemy.orm import Session
 
 from core.rag.models.document import Document
 from graphon.entities import WorkflowNodeExecution
 from graphon.enums import WorkflowNodeExecutionStatus
 from models import EndUser
+from models.enums import EndUserType
 
 
 def test_get_user_id_from_message_data_no_end_user(monkeypatch: pytest.MonkeyPatch):
@@ -40,35 +44,40 @@ def test_get_user_id_from_message_data_no_end_user(monkeypatch: pytest.MonkeyPat
     assert get_user_id_from_message_data(message_data) == "account_id"
 
 
-def test_get_user_id_from_message_data_with_end_user(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize("sqlite3_session", [(EndUser,)], indirect=True)
+def test_get_user_id_from_message_data_with_end_user(monkeypatch: pytest.MonkeyPatch, sqlite3_session: Session) -> None:
     message_data = MagicMock()
     message_data.from_account_id = "account_id"
     message_data.from_end_user_id = "end_user_id"
 
-    end_user_data = MagicMock(spec=EndUser)
-    end_user_data.session_id = "session_id"
-
-    mock_session = MagicMock()
-    mock_session.get.return_value = end_user_data
+    end_user_data = EndUser(
+        id="end_user_id",
+        tenant_id="tenant_id",
+        app_id="app_id",
+        type=EndUserType.BROWSER,
+        session_id="session_id",
+    )
+    sqlite3_session.add(end_user_data)
+    sqlite3_session.commit()
 
     from dify_trace_aliyun.utils import db
 
-    monkeypatch.setattr(db, "session", mock_session)
+    monkeypatch.setattr(db, "session", sqlite3_session)
 
     assert get_user_id_from_message_data(message_data) == "session_id"
 
 
-def test_get_user_id_from_message_data_end_user_not_found(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize("sqlite3_session", [(EndUser,)], indirect=True)
+def test_get_user_id_from_message_data_end_user_not_found(
+    monkeypatch: pytest.MonkeyPatch, sqlite3_session: Session
+) -> None:
     message_data = MagicMock()
     message_data.from_account_id = "account_id"
     message_data.from_end_user_id = "end_user_id"
 
-    mock_session = MagicMock()
-    mock_session.get.return_value = None
-
     from dify_trace_aliyun.utils import db
 
-    monkeypatch.setattr(db, "session", mock_session)
+    monkeypatch.setattr(db, "session", sqlite3_session)
 
     assert get_user_id_from_message_data(message_data) == "account_id"
 


### PR DESCRIPTION
## What changed

- replace mocked `EndUser` lookup sessions with `sqlite3_session`
- persist a real `EndUser` ORM record for the found-user path

## Why

Real SQLite queries cover SQLAlchemy identity and lookup behavior that session mocks bypass.

Depends on #38982. Until that fixture PR is merged, this stacked PR also displays its prerequisite file.

## Validation

- `uv run pytest -q -o addopts='' providers/trace/trace-aliyun/tests/unit_tests/aliyun_trace/test_aliyun_trace_utils.py` (12 passed)
- Ruff check and format check passed
