### PR TITLE
fix(e2e): follow agent roster create menu

### DIFF
--- a/dify-agent-runtime/README.md
+++ b/dify-agent-runtime/README.md
@@ -67,23 +67,23 @@ make test
 
 Each agent job runs inside a Landlock sandbox that restricts filesystem access:
 
-| Access | Paths (defaults) |
-|--------|------------------|
-| **Read-Write** | `$HOME` (always, includes `$CWD/.tmp` as `TMPDIR`) |
-| **Read-Write (dev)** | `/dev/null`, `/dev/zero`, `/dev/urandom`, `/dev/random`, `/dev/tty` |
+| Access               | Paths (defaults)                                                                                              |
+| -------------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Read-Write**       | `$HOME` (always, includes `$CWD/.tmp` as `TMPDIR`)                                                            |
+| **Read-Write (dev)** | `/dev/null`, `/dev/zero`, `/dev/urandom`, `/dev/random`, `/dev/tty`                                           |
 | **Read-Only + Exec** | `/usr`, `/bin`, `/sbin`, `/lib`, `/lib64`, `/etc`, `/proc`, `/opt/dify-agent-tools`, `/opt/homebrew`, `/snap` |
-| **Denied** | Everything else (`/tmp`, other agents' homes, `/var`, `/srv`, etc.) |
+| **Denied**           | Everything else (`/tmp`, other agents' homes, `/var`, `/srv`, etc.)                                           |
 
 The runner automatically creates `$CWD/.tmp` and sets `TMPDIR`, `TMP`, `TEMP` to it, so temp files stay isolated per workspace.
 
 ### Environment Variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `ENABLE_PATH_ISOLATION` | `true` | Set to `false` to disable Landlock entirely |
-| `LANDLOCK_RW_PATHS` | *(empty)* | Comma-separated RW directories (besides `$HOME`) |
-| `LANDLOCK_RO_PATHS` | `/usr,/bin,...` | Comma-separated RO+exec directories |
-| `LANDLOCK_RW_DEV_PATHS` | `/dev/null,...` | Comma-separated device files with RW access |
+| Variable                | Default         | Description                                      |
+| ----------------------- | --------------- | ------------------------------------------------ |
+| `ENABLE_PATH_ISOLATION` | `true`          | Set to `false` to disable Landlock entirely      |
+| `LANDLOCK_RW_PATHS`     | _(empty)_       | Comma-separated RW directories (besides `$HOME`) |
+| `LANDLOCK_RO_PATHS`     | `/usr,/bin,...` | Comma-separated RO+exec directories              |
+| `LANDLOCK_RW_DEV_PATHS` | `/dev/null,...` | Comma-separated device files with RW access      |
 
 Requires Linux ≥ 5.13. On unsupported kernels, a warning is printed to stderr.
 

--- a/e2e/features/step-definitions/agent-v2/agent-roster.steps.ts
+++ b/e2e/features/step-definitions/agent-v2/agent-roster.steps.ts
@@ -11,7 +11,8 @@ When('I create an Agent v2 test agent from the Agent Roster', async function (th
   const agentDescription = 'Created by Dify E2E through the Agent Roster UI.'
 
   await page.goto('/agents')
-  await page.getByRole('button', { name: 'Create agent' }).click()
+  await page.getByRole('button', { name: 'Create' }).click()
+  await page.getByRole('menuitem', { name: 'Create from Blank' }).click()
 
   const dialog = page.getByRole('dialog', { name: 'Create agent' })
   await expect(dialog).toBeVisible()


### PR DESCRIPTION
## Summary

- update the Agent Roster creation E2E flow to use the new shared Create menu
- select `Create from Blank` before asserting and completing the existing Create agent dialog

## Root cause

PR #39012 replaced the top-level `Create agent` button with a shared `Create` dropdown so the roster can support both blank creation and DSL import. The E2E scenario still targeted the removed button and timed out in post-merge run https://github.com/langgenius/dify/actions/runs/29407149264/job/87325397484.

## Validation

- reproduced before the fix with `pnpm -C e2e e2e:full -- --tags @agent-create`
- passed after the fix: 1 scenario, 8 steps
- `pnpm -C e2e type-check`
- focused ESLint for the changed step definition
- `pnpm lint:oxlint:fix`
- `git diff --check`