### PR TITLE
fix(api): close race window in SegmentService.create_segment position lock

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -3374,12 +3374,12 @@ class SegmentService:
                     segment_document.word_count += len(args["answer"])
                     segment_document.answer = args["answer"]
 
-            session.add(segment_document)
-            # update document word count
-            assert document.word_count is not None
-            document.word_count += segment_document.word_count
-            session.add(document)
-            session.commit()
+                session.add(segment_document)
+                # update document word count
+                assert document.word_count is not None
+                document.word_count += segment_document.word_count
+                session.add(document)
+                session.commit()
 
             if args["attachment_ids"]:
                 for attachment_id in args["attachment_ids"]:

--- a/api/tests/unit_tests/services/test_dataset_service_segment.py
+++ b/api/tests/unit_tests/services/test_dataset_service_segment.py
@@ -526,6 +526,63 @@ class TestSegmentServiceMutations:
         assert {binding.attachment_id for binding in attachment_bindings} == {"att-1", "att-2"}
         assert mock_db.session.commit.call_count == 3
 
+    def test_create_segment_commits_before_releasing_position_lock(self, account_context):
+        """The read-check-insert-commit sequence must be fully covered by the redis lock.
+
+        Regression test for a race where `session.add`/`session.commit` sat outside the
+        `with redis_client.lock(...)` block, so two concurrent callers could read the same
+        `max_position` and commit segments with duplicate positions.
+        """
+        dataset = _make_dataset(indexing_technique="economy")
+        document = _make_document(
+            dataset_id=dataset.id,
+            tenant_id=dataset.tenant_id,
+            doc_form=IndexStructureType.QA_INDEX,
+            word_count=0,
+        )
+        args = {
+            "content": "question",
+            "answer": "answer",
+            "keywords": ["kw-1"],
+            "attachment_ids": [],
+        }
+
+        class RecordingLock:
+            def __init__(self, session: MagicMock):
+                self._session = session
+                self.commit_count_at_exit: int | None = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self.commit_count_at_exit = self._session.commit.call_count
+                return False
+
+        with (
+            patch("services.dataset_service.redis_client") as mock_redis,
+            patch("services.dataset_service.db") as mock_db,
+            patch("services.dataset_service.VectorService") as vector_service,
+            patch("services.dataset_service.helper.generate_text_hash", return_value="hash-1"),
+            patch("services.dataset_service.uuid.uuid4", return_value="node-1"),
+            patch("services.dataset_service.naive_utc_now", return_value="now"),
+        ):
+            recording_lock = RecordingLock(mock_db.session)
+            mock_redis.lock.return_value = recording_lock
+
+            mock_db.session.scalar.return_value = None
+            mock_db.session.get.return_value = SimpleNamespace(id="segment-1")
+
+            SegmentService.create_segment(
+                args=args,
+                document=document,
+                dataset=dataset,
+                session=mock_db.session,
+            )
+
+        assert recording_lock.commit_count_at_exit is not None
+        assert recording_lock.commit_count_at_exit >= 1
+
     def test_multi_create_segment_high_quality_marks_segments_error_when_vector_creation_fails(self, account_context):
         dataset = _make_dataset(indexing_technique="high_quality")
         document = _make_document(


### PR DESCRIPTION
## Summary

`SegmentService.create_segment` uses a per-document redis lock (`add_segment_lock_document_id_{document.id}`) so that "read the current max segment position, then insert at `max_position + 1`" is atomic across concurrent requests. The lock only covered the *read* of `max_position` — `session.add` / `session.commit` ran after the `with redis_client.lock(...)` block exited. Two concurrent "add segment" requests on the same document could both read the same `max_position` and commit segments with the identical `position`, silently corrupting segment ordering (there's no unique DB constraint to catch it).

Fixes #39022

## Fix

Moves `session.add(segment_document)`, the `document.word_count` update, and `session.commit()` inside the lock block, so the full read-check-insert-commit sequence is atomic — matching the pattern already used correctly by the sibling method `multi_create_segment`.

```diff
     with redis_client.lock(lock_name, timeout=600):
         max_position = session.scalar(...)
         segment_document = DocumentSegment(..., position=max_position + 1 if max_position else 1, ...)
         if document.doc_form == IndexStructureType.QA_INDEX:
             segment_document.word_count += len(args["answer"])
             segment_document.answer = args["answer"]

-    session.add(segment_document)
-    # update document word count
-    assert document.word_count is not None
-    document.word_count += segment_document.word_count
-    session.add(document)
-    session.commit()
+        session.add(segment_document)
+        # update document word count
+        assert document.word_count is not None
+        document.word_count += segment_document.word_count
+        session.add(document)
+        session.commit()

No dependencies added.
```

## Tests

Added a regression test that wraps the redis lock with a recorder tracking session.commit.call_count at __exit__ time, asserting at least one commit happened before the lock was released — this fails against the old code (where commit happens after __exit__) and passes against the fix.

- [x] uv run --project api python -m pytest api/tests/unit_tests/services/test_dataset_service_segment.py -q
- [x] ruff check / ruff format --check on the changed file

## Checklist

- [ ] This change requires a documentation update, included: Dify Document
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran make lint && make type-check (backend) and cd web && pnpm exec vp staged (frontend) to appease the lint gods