### PR TITLE
fix(prompt): scope extract_thread_messages' no-parent check to the tracked message

### DIFF
--- a/api/core/prompt/utils/extract_thread_messages.py
+++ b/api/core/prompt/utils/extract_thread_messages.py
@@ -9,17 +9,18 @@ def extract_thread_messages(messages: Sequence[Message]):
     next_message = None
 
     for message in messages:
-        if not message.parent_message_id:
-            # If the message is regenerated and does not have a parent message, it is the start of a new thread
-            thread_messages.append(message)
-            break
-
         if not next_message:
             thread_messages.append(message)
+            if not message.parent_message_id:
+                # If the message is regenerated and does not have a parent message, it is the start of a new thread
+                break
             next_message = message.parent_message_id
         else:
             if next_message in {message.id, UUID_NIL}:
                 thread_messages.append(message)
+                if not message.parent_message_id:
+                    # Same "start of a new thread" case, but for the message currently being tracked
+                    break
                 next_message = message.parent_message_id
 
     return thread_messages

--- a/api/tests/unit_tests/core/prompt/test_extract_thread_messages.py
+++ b/api/tests/unit_tests/core/prompt/test_extract_thread_messages.py
@@ -137,6 +137,23 @@ def test_extract_thread_messages_breaks_when_parent_is_none():
     assert result[0].id == id2
 
 
+def test_extract_thread_messages_ignores_unrelated_regeneration_root():
+    # An earlier regeneration can leave a parent_message_id=None message in the
+    # same conversation that isn't an ancestor of the thread being walked. The
+    # unconditional "no parent" check must not grab it and stop the walk early.
+    id_a, id_b, id_c, id_x = str(uuid4()), str(uuid4()), str(uuid4()), str(uuid4())
+    messages = [
+        MockMessage(id_c, id_b),
+        MockMessage(id_x, None),  # unrelated regeneration root, not an ancestor of C
+        MockMessage(id_b, id_a),
+        MockMessage(id_a, None),  # true root of C's thread
+    ]
+
+    result = extract_thread_messages(messages)
+
+    assert [msg.id for msg in result] == [id_c, id_b, id_a]
+
+
 @pytest.mark.parametrize("sqlite_session", [(Message,)], indirect=True)
 def test_get_thread_messages_length_excludes_newly_created_empty_answer(sqlite_session: Session):
     id1, id2 = str(uuid4()), str(uuid4())


### PR DESCRIPTION
Fixes #39031

## Summary

`extract_thread_messages`' "start of a new thread" check (`if not message.parent_message_id`) ran unconditionally on every message in the loop, not just the one currently being tracked via `next_message`. A conversation can contain several `parent_message_id=None` messages — one per regeneration over its lifetime. If an unrelated, earlier regeneration root sits between the message being walked and its real parent in the `created_at DESC` ordering, the walk grabs that root and stops, losing the real ancestor chain.

This affects `core/memory/token_buffer_memory.py` (LLM conversation memory), `core/agent/base_agent_runner.py` (agent history) and `core/prompt/utils/get_thread_messages_length.py` (`advanced_chat` dialogue count).

The fix scopes the "no parent" check to the branch that already matched via `next_message`, applied on both sides of the loop. It is deliberately narrow — not the broader regeneration-branch-selection feature from the earlier (closed, unmerged) #36727, which added a separate `active_message_id` parameter and did not scope this check.

## Tests

- New regression test `test_extract_thread_messages_ignores_unrelated_regeneration_root`: fails on unfixed `main` (the walk stops at the unrelated regeneration root), passes with the fix.
- `tests/unit_tests/core/prompt/`, `core/memory/` and `core/agent/`: 356 passed.
- `ruff format --check` and `ruff check` clean on both changed files.

Rebased onto current `main`; the only conflict was the test file reorganisation in #38739, and the new test is placed alongside the existing `MockMessage`-based cases.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `ruff format` / `ruff check` and the backend unit tests listed above.

AI-assisted with agentic coding tools; all changes were reviewed and tested by me.

From Claude Code
