### PR TITLE
fix(agent-runtime): validate shellctl job IDs

### DIFF
--- a/dify-agent-runtime/internal/server/api.go
+++ b/dify-agent-runtime/internal/server/api.go
@@ -19,13 +19,13 @@ func Handler(svc *Service, config *Config) http.Handler {
 
 	mux.HandleFunc("GET /healthz", handleHealthz)
 	mux.HandleFunc("POST /v1/jobs/run", auth(handleRunJob(svc)))
-	mux.HandleFunc("POST /v1/jobs/{job_id}/wait", auth(handleWaitJob(svc, config)))
-	mux.HandleFunc("GET /v1/jobs/{job_id}/log/tail", auth(handleTailJob(svc, config)))
-	mux.HandleFunc("GET /v1/jobs/{job_id}", auth(handleJobStatus(svc)))
+	mux.HandleFunc("POST /v1/jobs/{job_id}/wait", auth(validJobID(handleWaitJob(svc, config))))
+	mux.HandleFunc("GET /v1/jobs/{job_id}/log/tail", auth(validJobID(handleTailJob(svc, config))))
+	mux.HandleFunc("GET /v1/jobs/{job_id}", auth(validJobID(handleJobStatus(svc))))
 	mux.HandleFunc("GET /v1/jobs", auth(handleListJobs(svc, config)))
-	mux.HandleFunc("POST /v1/jobs/{job_id}/input", auth(handleInputJob(svc, config)))
-	mux.HandleFunc("POST /v1/jobs/{job_id}/terminate", auth(handleTerminateJob(svc, config)))
-	mux.HandleFunc("DELETE /v1/jobs/{job_id}", auth(handleDeleteJob(svc, config)))
+	mux.HandleFunc("POST /v1/jobs/{job_id}/input", auth(validJobID(handleInputJob(svc, config))))
+	mux.HandleFunc("POST /v1/jobs/{job_id}/terminate", auth(validJobID(handleTerminateJob(svc, config))))
+	mux.HandleFunc("DELETE /v1/jobs/{job_id}", auth(validJobID(handleDeleteJob(svc, config))))
 
 	return requestLoggingMiddleware(recoveryMiddleware(mux))
 }
@@ -212,6 +212,16 @@ func handleDeleteJob(svc *Service, config *Config) http.HandlerFunc {
 }
 
 // Middleware
+
+func validJobID(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := ValidateJobID(r.PathValue("job_id")); err != nil {
+			writeServerError(w, err)
+			return
+		}
+		next(w, r)
+	}
+}
 
 // statusRecorder wraps ResponseWriter to capture the status code.
 type statusRecorder struct {

--- a/dify-agent-runtime/internal/server/api_test.go
+++ b/dify-agent-runtime/internal/server/api_test.go
@@ -152,6 +152,46 @@ func TestHealthzHandler(t *testing.T) {
 	}
 }
 
+func TestJobRoutesRejectMalformedJobIDBeforeCallingService(t *testing.T) {
+	handler := Handler(nil, &Config{})
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{name: "wait", method: http.MethodPost, path: "/v1/jobs/not-a-job-id/wait", body: `not-json`},
+		{name: "tail", method: http.MethodGet, path: "/v1/jobs/not-a-job-id/log/tail"},
+		{name: "status", method: http.MethodGet, path: "/v1/jobs/not-a-job-id"},
+		{name: "status encoded separator", method: http.MethodGet, path: "/v1/jobs/0123456789abc%2Fde"},
+		{name: "status dot dot", method: http.MethodGet, path: "/v1/jobs/%2e%2e"},
+		{name: "status whitespace", method: http.MethodGet, path: "/v1/jobs/0123456789abcde%20"},
+		{name: "status shell metacharacter", method: http.MethodGet, path: "/v1/jobs/0123456789abcde;"},
+		{name: "input", method: http.MethodPost, path: "/v1/jobs/not-a-job-id/input", body: `not-json`},
+		{name: "terminate", method: http.MethodPost, path: "/v1/jobs/not-a-job-id/terminate", body: `not-json`},
+		{name: "delete", method: http.MethodDelete, path: "/v1/jobs/not-a-job-id"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, strings.NewReader(tt.body))
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+			}
+			var result ErrorResponse
+			if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+				t.Fatal(err)
+			}
+			if result.Error.Code != "invalid_job_id" {
+				t.Fatalf("expected invalid_job_id, got %q", result.Error.Code)
+			}
+		})
+	}
+}
+
 func TestServerErrorFormat(t *testing.T) {
 	err := NewServerError(422, "validation_error", "bad input")
 	expected := "[422] validation_error: bad input"

--- a/dify-agent-runtime/internal/server/job_id_validation_test.go
+++ b/dify-agent-runtime/internal/server/job_id_validation_test.go
@@ -1,0 +1,51 @@
+package server
+
+import "testing"
+
+func TestServiceMethodsRejectMalformedJobIDBeforeUsingDependencies(t *testing.T) {
+	svc := &Service{}
+	jobID := "../../etc/passwd"
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{name: "wait", call: func() error {
+			_, err := svc.WaitJob(jobID, &WaitJobRequest{})
+			return err
+		}},
+		{name: "tail", call: func() error {
+			_, err := svc.TailJob(jobID, 1)
+			return err
+		}},
+		{name: "status", call: func() error {
+			_, err := svc.GetJobStatus(jobID)
+			return err
+		}},
+		{name: "input", call: func() error {
+			_, err := svc.SendInput(jobID, &InputJobRequest{})
+			return err
+		}},
+		{name: "terminate", call: func() error {
+			_, err := svc.TerminateJob(jobID, 0)
+			return err
+		}},
+		{name: "delete", call: func() error {
+			_, err := svc.DeleteJob(jobID, false, 0)
+			return err
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.call()
+			serverErr, ok := err.(*ServerError)
+			if !ok {
+				t.Fatalf("expected *ServerError, got %T (%v)", err, err)
+			}
+			if serverErr.StatusCode != 400 || serverErr.Code != "invalid_job_id" {
+				t.Fatalf("unexpected error: %#v", serverErr)
+			}
+		})
+	}
+}

--- a/dify-agent-runtime/internal/server/runtime.go
+++ b/dify-agent-runtime/internal/server/runtime.go
@@ -4,14 +4,26 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"regexp"
 	"time"
 )
+
+var jobIDPattern = regexp.MustCompile(`^[0-9a-f]{16}$`)
 
 // GenerateJobID produces a short random hex job identifier.
 func GenerateJobID() string {
 	b := make([]byte, 8)
 	_, _ = rand.Read(b)
 	return hex.EncodeToString(b)
+}
+
+// ValidateJobID enforces the exact lowercase hexadecimal format produced by
+// GenerateJobID before a caller can use the value in tmux targets or paths.
+func ValidateJobID(jobID string) error {
+	if !jobIDPattern.MatchString(jobID) {
+		return NewServerError(400, "invalid_job_id", "job id must be exactly 16 lowercase hexadecimal characters")
+	}
+	return nil
 }
 
 // FormatTimestamp returns an ISO-8601 UTC timestamp string.

--- a/dify-agent-runtime/internal/server/runtime_test.go
+++ b/dify-agent-runtime/internal/server/runtime_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"net/http"
 	"testing"
 	"time"
 )
@@ -24,6 +25,45 @@ func TestGenerateJobIDUniqueness(t *testing.T) {
 			t.Fatalf("collision at iteration %d: %s", i, id)
 		}
 		seen[id] = true
+	}
+}
+
+func TestValidateJobID(t *testing.T) {
+	tests := []struct {
+		name    string
+		jobID   string
+		wantErr bool
+	}{
+		{name: "generated", jobID: GenerateJobID()},
+		{name: "known valid", jobID: "0123456789abcdef"},
+		{name: "empty", jobID: "", wantErr: true},
+		{name: "too short", jobID: "0123456789abcde", wantErr: true},
+		{name: "too long", jobID: "0123456789abcdef0", wantErr: true},
+		{name: "uppercase", jobID: "0123456789ABCDEf", wantErr: true},
+		{name: "path separator", jobID: "0123456789abc/de", wantErr: true},
+		{name: "backslash", jobID: `0123456789abc\de`, wantErr: true},
+		{name: "dot dot", jobID: "../../etc/passwd", wantErr: true},
+		{name: "absolute path", jobID: "/tmp/shellctl-job", wantErr: true},
+		{name: "whitespace", jobID: "0123456789abcde ", wantErr: true},
+		{name: "shell metacharacter", jobID: "0123456789abcde;", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateJobID(tt.jobID)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateJobID(%q) error = %v, wantErr %v", tt.jobID, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				serverErr, ok := err.(*ServerError)
+				if !ok {
+					t.Fatalf("expected *ServerError, got %T", err)
+				}
+				if serverErr.StatusCode != http.StatusBadRequest || serverErr.Code != "invalid_job_id" {
+					t.Fatalf("unexpected error: %#v", serverErr)
+				}
+			}
+		})
 	}
 }
 

--- a/dify-agent-runtime/internal/server/service.go
+++ b/dify-agent-runtime/internal/server/service.go
@@ -318,6 +318,9 @@ func (s *Service) waitForPipeReady(jobID, readyFile string) error {
 
 // WaitJob blocks until output, completion, truncation, or timeout.
 func (s *Service) WaitJob(jobID string, req *WaitJobRequest) (*JobResult, error) {
+	if err := ValidateJobID(jobID); err != nil {
+		return nil, err
+	}
 	row, err := s.db.GetJob(jobID)
 	if err != nil {
 		return nil, err
@@ -408,6 +411,9 @@ func (s *Service) WaitJob(jobID string, req *WaitJobRequest) (*JobResult, error)
 
 // TailJob returns the tail of a job's output.
 func (s *Service) TailJob(jobID string, outputLimit int) (*JobResult, error) {
+	if err := ValidateJobID(jobID); err != nil {
+		return nil, err
+	}
 	row, err := s.db.GetJob(jobID)
 	if err != nil {
 		return nil, err
@@ -425,6 +431,9 @@ func (s *Service) TailJob(jobID string, outputLimit int) (*JobResult, error) {
 
 // GetJobStatus materializes the current status from SQLite + live tmux state.
 func (s *Service) GetJobStatus(jobID string) (*JobStatusView, error) {
+	if err := ValidateJobID(jobID); err != nil {
+		return nil, err
+	}
 	sessionExists, pipeActive, err := s.liveRuntimeState(jobID)
 	if err != nil {
 		return nil, err
@@ -467,6 +476,9 @@ func (s *Service) ListJobs(status *JobStatusName, limit int) (*ListJobsResponse,
 
 // SendInput sends input to a running job and waits.
 func (s *Service) SendInput(jobID string, req *InputJobRequest) (*JobResult, error) {
+	if err := ValidateJobID(jobID); err != nil {
+		return nil, err
+	}
 	view, err := s.GetJobStatus(jobID)
 	if err != nil {
 		return nil, err
@@ -496,6 +508,9 @@ func (s *Service) SendInput(jobID string, req *InputJobRequest) (*JobResult, err
 
 // TerminateJob terminates a running job.
 func (s *Service) TerminateJob(jobID string, graceSeconds float64) (*JobStatusView, error) {
+	if err := ValidateJobID(jobID); err != nil {
+		return nil, err
+	}
 	view, err := s.GetJobStatus(jobID)
 	if err != nil {
 		return nil, err
@@ -522,6 +537,9 @@ func (s *Service) TerminateJob(jobID string, graceSeconds float64) (*JobStatusVi
 
 // DeleteJob deletes a job and its artifacts.
 func (s *Service) DeleteJob(jobID string, force bool, graceSeconds float64) (*DeleteJobResponse, error) {
+	if err := ValidateJobID(jobID); err != nil {
+		return nil, err
+	}
 	view, err := s.GetJobStatus(jobID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- add a shared validator for the current shellctl job-id contract: exactly 16 lowercase hexadecimal characters, matching `GenerateJobID`
- reject malformed path job IDs at every shellctl HTTP route with a structured `400 invalid_job_id` response before request decoding or service work
- enforce the same invariant at every public service entrypoint before SQLite, tmux, temporary-file, or artifact-path access
- cover generated/valid IDs plus path separators, `..`, absolute-path-looking values, whitespace, uppercase, wrong lengths, and shell metacharacters

The original issue referenced the former Python shellctl server. That server was replaced by the Go `dify-agent-runtime` in #38841, so this applies the requested defense-in-depth validation to the current implementation.

Fixes #38610

Issue: https://github.com/langgenius/dify/issues/38610

## Test plan

- `go test ./internal/server -run 'TestValidateJobID|TestJobRoutesRejectMalformedJobIDBeforeCallingService|TestServiceMethodsRejectMalformedJobIDBeforeUsingDependencies' -count=1 -v`
- `go vet ./...`
- verified the broader Windows failures are unchanged from upstream baseline (`TestConfigPaths` assumes POSIX paths and `TestDumpCLIHelpMatchesCheckedIn` is already stale); the focused server tests pass and Linux CI will run the repository's canonical `go test -race -count=1 ./...`

## OpenJobs

Work completed for [openjobs.bot](https://openjobs.bot), listing `48bf71d4-afb3-4b52-8ecd-d0c8de84476e`.

From Hermes Agent.
