### PR TITLE
chore(docker): remove redundant feature preview env

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -155,9 +155,6 @@ ENABLE_WEBSITE_JINAREADER=true
 ENABLE_WEBSITE_FIRECRAWL=true
 ENABLE_WEBSITE_WATERCRAWL=true
 NEXT_PUBLIC_ENABLE_SINGLE_DOLLAR_LATEX=false
-# Enable preview features still in development (currently the /create and
-# /refine slash commands in the "Go to Anything" command palette).
-NEXT_PUBLIC_ENABLE_FEATURE_PREVIEW=true
 NEXT_PUBLIC_ENABLE_AGENT_V2=true
 EXPERIMENTAL_ENABLE_VINEXT=false
 


### PR DESCRIPTION
## Summary

- Remove `NEXT_PUBLIC_ENABLE_FEATURE_PREVIEW` and its explanatory comment from the root `docker/.env.example`.
- Keep the flag available in the web-specific Docker environment template.
- Preserve the web container's existing default behavior when the variable is absent.

This keeps the root Docker environment example limited to configuration required for startup while retaining the optional feature control in its service-specific location.

Fixes #39034