### PR TITLE
fix(agent): accept legacy missing asset placeholders

### DIFF
--- a/api/models/agent_config_entities.py
+++ b/api/models/agent_config_entities.py
@@ -188,6 +188,14 @@ def validate_config_skill_name(name: str) -> str:
     return normalized
 
 
+def _normalize_legacy_missing_asset_file_id(value: Any) -> Any:
+    """Canonicalize the null placeholder emitted by early portable Agent DSLs."""
+
+    if isinstance(value, dict) and value.get("is_missing") is True and value.get("file_id") is None:
+        return {**value, "file_id": ""}
+    return value
+
+
 class AgentConfigFileRefConfig(BaseModel):
     """Stable Agent Soul reference to one config file payload."""
 
@@ -200,6 +208,11 @@ class AgentConfigFileRefConfig(BaseModel):
     size: int | None = None
     hash: str | None = None
     mime_type: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_legacy_file_id(cls, value: Any) -> Any:
+        return _normalize_legacy_missing_asset_file_id(value)
 
     @field_validator("name")
     @classmethod
@@ -230,6 +243,11 @@ class AgentConfigSkillRefConfig(BaseModel):
     size: int | None = None
     hash: str | None = None
     mime_type: str | None = "application/zip"
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_legacy_file_id(cls, value: Any) -> Any:
+        return _normalize_legacy_missing_asset_file_id(value)
 
     @field_validator("name")
     @classmethod

--- a/api/tests/unit_tests/services/agent/test_agent_dsl_service.py
+++ b/api/tests/unit_tests/services/agent/test_agent_dsl_service.py
@@ -159,9 +159,7 @@ def test_agent_package_normalizes_legacy_null_missing_asset_file_ids() -> None:
         AgentSoulConfig.model_validate(
             {
                 "config_skills": [{"name": "research", "file_id": "skill-file"}],
-                "config_files": [
-                    {"name": "guide.md", "file_kind": "tool_file", "file_id": "config-file"}
-                ],
+                "config_files": [{"name": "guide.md", "file_kind": "tool_file", "file_id": "config-file"}],
             }
         ),
     ).model_dump(mode="json")

--- a/api/tests/unit_tests/services/agent/test_agent_dsl_service.py
+++ b/api/tests/unit_tests/services/agent/test_agent_dsl_service.py
@@ -153,6 +153,45 @@ def test_agent_package_round_trips_as_strict_dsl_dto() -> None:
     assert restored == package
 
 
+def test_agent_package_normalizes_legacy_null_missing_asset_file_ids() -> None:
+    package = make_portable_agent_package(
+        _agent(),
+        AgentSoulConfig.model_validate(
+            {
+                "config_skills": [{"name": "research", "file_id": "skill-file"}],
+                "config_files": [
+                    {"name": "guide.md", "file_kind": "tool_file", "file_id": "config-file"}
+                ],
+            }
+        ),
+    ).model_dump(mode="json")
+    package["soul"]["config_skills"][0]["file_id"] = None
+    package["soul"]["config_files"][0]["file_id"] = None
+
+    restored = AgentPackage.model_validate(package)
+
+    assert restored.soul.config_skills[0].file_id == ""
+    assert restored.soul.config_files[0].file_id == ""
+    assert restored.model_dump(mode="json")["soul"]["config_skills"][0]["file_id"] == ""
+    assert restored.model_dump(mode="json")["soul"]["config_files"][0]["file_id"] == ""
+
+
+@pytest.mark.parametrize(
+    "asset",
+    [
+        {"name": "research", "file_id": None, "is_missing": False},
+        {"name": "guide.md", "file_kind": "tool_file", "file_id": None, "is_missing": False},
+    ],
+)
+def test_agent_package_rejects_null_file_id_for_available_assets(asset: dict) -> None:
+    package = make_portable_agent_package(_agent(), AgentSoulConfig()).model_dump(mode="json")
+    target = "config_files" if "file_kind" in asset else "config_skills"
+    package["soul"][target] = [asset]
+
+    with pytest.raises(ValidationError):
+        AgentPackage.model_validate(package)
+
+
 def test_import_warnings_cover_runtime_setup_removed_from_package(monkeypatch) -> None:
     soul = AgentSoulConfig.model_validate(
         {


### PR DESCRIPTION
## Summary

- accept the `file_id: null` placeholder emitted by early portable Agent DSL exports when `is_missing` is true
- canonicalize legacy placeholders to the current empty-string wire format without widening the generated API contract
- keep null/empty IDs invalid for available config skills and files

## Root cause

Early Agent DSL support exported omitted config assets with `file_id: null`. A follow-up changed the canonical representation and Pydantic field to a non-null string. Existing DSL files and persisted snapshots then failed during `AgentSoulConfig` deserialization before the composer response could be assembled.

## Verification

- `ruff`
- `pyrefly` and `mypy` for `agent_config_entities.py`
- 203 related Agent DSL, composer, app import, config service, and model tests
- 46 Agent v2 runtime request builder tests
- deployed commit `c0b286f0bb` to `deploy/agent` and verified on `https://agent.dify.dev`
- original DIFY-2802 Agent composer and legacy version detail return 200
- original attached DSL imports with expected setup warnings, returns canonical empty-string IDs, and supports composer load/save
- publish validation still rejects omitted assets with `config_asset_missing`
- E2E test app removed after verification

Linear: DIFY-2802