### PR TITLE
fix(ci): run CLI checks for contract changes

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -72,6 +72,7 @@ jobs:
               - 'docker/volumes/sandbox/conf/**'
             cli:
               - 'cli/**'
+              - 'packages/contracts/**'
               - 'packages/tsconfig/**'
               - 'package.json'
               - 'pnpm-lock.yaml'


### PR DESCRIPTION
## Summary

- trigger CLI CI when `packages/contracts/**` changes
- align the path filter with the CLI's direct `@dify/contracts` workspace dependency

## Why

The CLI consumes `@dify/contracts`, but the main CI change detector only watched `cli/**` and `packages/tsconfig/**`. Contract changes could therefore bypass CLI checks and introduce an undetected compatibility regression.

## Impact

Contract changes now run the existing CLI test and Docker build workflows. No test commands or runtime behavior are changed.

## Validation

- `git diff --check`
- parsed `.github/workflows/main-ci.yml` with Ruby YAML
- verified `cli/package.json` declares `@dify/contracts` as `workspace:*`
