### PR TITLE
fix(web): prevent chatbot/share pages from redirecting to signin

### DIFF
--- a/web/hooks/use-is-share-page.ts
+++ b/web/hooks/use-is-share-page.ts
@@ -1,0 +1,18 @@
+'use client'
+import { useMemo } from 'react'
+import { usePathname } from '@/next/navigation'
+import { basePath } from '@/utils/var'
+
+const SHARE_PATH_PREFIXES = ['/chatbot', '/chat', '/completion', '/workflow', '/webapp-signin', '/agent']
+
+/**
+ * Detect whether the current page is a share (public) page.
+ * Share pages have no console session and must not issue console API requests.
+ */
+export function useIsSharePage(): boolean {
+  const pathname = usePathname()
+  return useMemo(
+    () => SHARE_PATH_PREFIXES.some(prefix => pathname.startsWith(`${basePath}${prefix}`)),
+    [pathname],
+  )
+}

--- a/web/hooks/use-timestamp.ts
+++ b/web/hooks/use-timestamp.ts
@@ -6,6 +6,7 @@ import utc from 'dayjs/plugin/utc'
 import { useCallback } from 'react'
 import { useLocale } from '@/context/i18n'
 import { userProfileQueryOptions } from '@/features/account-profile/client'
+import { useIsSharePage } from '@/hooks/use-is-share-page'
 import { formatToLocalTime } from '@/utils/format'
 
 dayjs.extend(utc)
@@ -23,10 +24,13 @@ const getIntlLocale = (locale: string) => locale.replace('_', '-')
 
 const useTimestamp = ({ timezone: timezoneOverride }: UseTimestampOptions = {}) => {
   const locale = useLocale()
+  const isSharePage = useIsSharePage()
   const { data: accountTimezone } = useQuery({
     ...userProfileQueryOptions(),
     select: (data) => data.profile.timezone ?? undefined,
-    enabled: timezoneOverride === undefined,
+    // 注：share 页面（chatbot/chat/completion/workflow）没有控制台登录态，
+    // 请求 /account/profile 会 401 并触发跳转 signin，因此禁用
+    enabled: timezoneOverride === undefined && !isSharePage,
   })
   const resolvedTimezone = timezoneOverride ?? accountTimezone ?? getBrowserTimezone()
 


### PR DESCRIPTION
## Summary
Fix embedded chatbot pages (`/chatbot`, `/chat`, `/completion`, `/workflow`) unexpectedly redirecting to `/signin`.

## Problem
`useTimestamp` hook unconditionally calls `userProfileQueryOptions()` which requests `/console/api/account/profile`. On share pages there is no console session, so the request returns 401. The global 401 handler in `base.ts` then attempts `refresh-token` (also 401) and finally redirects to `/signin`, completely breaking embedded chatbot access for all users.

This is easily reproducible: open any chatbot embed URL in an incognito window.

## Solution
- Add `useIsSharePage()` hook that detects share page paths
- In `useTimestamp`, disable the profile query on share pages (`enabled: false`)
- The existing `getBrowserTimezone()` fallback already handles this case gracefully

This ensures share pages never issue console API requests while keeping console pages unaffected.

## Testing
- Opened `/chatbot/<token>` in incognito - no redirect, chatbot loads normally
- Verified `/console/api/account/profile` request is no longer made on share pages
- Console pages still use user's configured timezone from profile