### PR TITLE
fix: merge system messages and place them first to comply with Qwen/v…

### DIFF
--- a/dify-agent/src/dify_agent/adapters/llm/model.py
+++ b/dify-agent/src/dify_agent/adapters/llm/model.py
@@ -304,14 +304,38 @@ def _map_messages_to_prompt_messages(
         for part in (Model._get_instruction_parts(messages, model_request_parameters) or [])
         if part.content.strip()
     ]
-    if instruction_messages:
-        insert_at = next(
-            (index for index, message in enumerate(prompt_messages) if not isinstance(message, SystemPromptMessage)),
-            len(prompt_messages),
-        )
-        prompt_messages[insert_at:insert_at] = instruction_messages
+    prompt_messages = _order_system_messages_first(prompt_messages, instruction_messages)
 
     return prompt_messages
+
+
+def _order_system_messages_first(
+    prompt_messages: Sequence[PromptMessage],
+    instruction_messages: Sequence[SystemPromptMessage],
+) -> list[PromptMessage]:
+    """Merge all system content into a single leading system message.
+
+    Some providers (e.g. vLLM serving Qwen3.5/3.6 chat templates) reject any
+    system message that is not exactly the first message, so sorting alone is
+    not enough: multiple system messages must be merged into one.
+    """
+    system_contents: list[str] = []
+    non_system_messages: list[PromptMessage] = []
+    for message in prompt_messages:
+        if isinstance(message, SystemPromptMessage):
+            text = message.get_text_content()
+            if text.strip():
+                system_contents.append(text)
+        else:
+            non_system_messages.append(message)
+    for instruction in instruction_messages:
+        text = instruction.get_text_content()
+        if text.strip():
+            system_contents.append(text)
+
+    if not system_contents:
+        return non_system_messages
+    return [SystemPromptMessage(content="\n\n".join(system_contents)), *non_system_messages]
 
 
 def _map_model_request_to_prompt_messages(message: ModelRequest) -> list[PromptMessage]:

--- a/dify-agent/src/dify_agent/adapters/llm/model.py
+++ b/dify-agent/src/dify_agent/adapters/llm/model.py
@@ -267,14 +267,38 @@ def _map_messages_to_prompt_messages(
         for part in (Model._get_instruction_parts(messages, model_request_parameters) or [])
         if part.content.strip()
     ]
-    if instruction_messages:
-        insert_at = next(
-            (index for index, message in enumerate(prompt_messages) if not isinstance(message, SystemPromptMessage)),
-            len(prompt_messages),
-        )
-        prompt_messages[insert_at:insert_at] = instruction_messages
+    prompt_messages = _order_system_messages_first(prompt_messages, instruction_messages)
 
     return prompt_messages
+
+
+def _order_system_messages_first(
+    prompt_messages: Sequence[PromptMessage],
+    instruction_messages: Sequence[SystemPromptMessage],
+) -> list[PromptMessage]:
+    """Merge all system content into a single leading system message.
+
+    Some providers (e.g. vLLM serving Qwen3.5/3.6 chat templates) reject any
+    system message that is not exactly the first message, so sorting alone is
+    not enough: multiple system messages must be merged into one.
+    """
+    system_contents: list[str] = []
+    non_system_messages: list[PromptMessage] = []
+    for message in prompt_messages:
+        if isinstance(message, SystemPromptMessage):
+            text = message.get_text_content()
+            if text.strip():
+                system_contents.append(text)
+        else:
+            non_system_messages.append(message)
+    for instruction in instruction_messages:
+        text = instruction.get_text_content()
+        if text.strip():
+            system_contents.append(text)
+
+    if not system_contents:
+        return non_system_messages
+    return [SystemPromptMessage(content="\n\n".join(system_contents)), *non_system_messages]
 
 
 def _map_model_request_to_prompt_messages(message: ModelRequest) -> list[PromptMessage]:

--- a/dify-agent/tests/local/dify_agent/adapters/llm/test_model.py
+++ b/dify-agent/tests/local/dify_agent/adapters/llm/test_model.py
@@ -171,12 +171,11 @@ class DifyLLMAdapterModelTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(set(tools_by_name), {"weather", "incident_summary"})
             self.assertEqual(tools_by_name["incident_summary"]["parameters"]["required"], ["title"])
             self.assertEqual(data["prompt_messages"][0]["role"], "system")
-            self.assertEqual(data["prompt_messages"][0]["content"], "request system")
-            self.assertEqual(data["prompt_messages"][1]["content"], "be concise")
-            self.assertEqual(data["prompt_messages"][2]["content"], "hello")
+            self.assertEqual(data["prompt_messages"][0]["content"], "request system\n\nbe concise")
+            self.assertEqual(data["prompt_messages"][1]["content"], "hello")
+            self.assertEqual(data["prompt_messages"][2]["role"], "tool")
             self.assertEqual(data["prompt_messages"][3]["role"], "tool")
-            self.assertEqual(data["prompt_messages"][4]["role"], "tool")
-            self.assertEqual(data["prompt_messages"][5]["role"], "assistant")
+            self.assertEqual(data["prompt_messages"][4]["role"], "assistant")
             return build_stream_response(
                 LLMResultChunk(
                     model="demo-model",
@@ -290,6 +289,78 @@ class DifyLLMAdapterModelTests(unittest.IsolatedAsyncioTestCase):
         self.assertAlmostEqual(usage.latency, 1.2)
         self.assertEqual(usage.time_to_first_token, 0.2)
         self.assertEqual(usage.time_to_generate, 0.6)
+
+    async def test_request_merges_system_messages_before_history(self) -> None:
+        messages = [
+            ModelRequest(parts=[UserPromptPart("previous user")]),
+            ModelResponse(parts=[TextPart(content="previous answer")]),
+            ModelRequest(parts=[SystemPromptPart("current system"), UserPromptPart("current user")]),
+        ]
+        request_parameters = ModelRequestParameters(instruction_parts=[InstructionPart(content="runtime instruction")])
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            payload = json.loads(request.content.decode("utf-8"))
+            prompt_messages = payload["target"]["prompt_messages"]
+
+            self.assertEqual(
+                [message["role"] for message in prompt_messages],
+                ["system", "user", "assistant", "user"],
+            )
+            self.assertEqual(prompt_messages[0]["content"], "current system\n\nruntime instruction")
+            self.assertEqual(prompt_messages[1]["content"], "previous user")
+            self.assertEqual(prompt_messages[2]["content"], "previous answer")
+            self.assertEqual(prompt_messages[3]["content"], "current user")
+            return build_stream_response(*single_text_chunk("adapter response", prompt_tokens=11, completion_tokens=7))
+
+        async with self.mock_gateway_stream(httpx.MockTransport(handler)):
+            adapter = DifyLLMAdapterModel(
+                "demo-model",
+                self.make_provider(),
+                model_provider="openai",
+            )
+
+            response = await adapter.request(
+                messages,
+                model_settings=None,
+                model_request_parameters=request_parameters,
+            )
+
+        self.assertEqual(response.model_name, "demo-model")
+        self.assertEqual(cast(TextPart, response.parts[0]).content, "adapter response")
+
+    async def test_request_merges_scattered_system_messages_without_instructions(self) -> None:
+        messages = [
+            ModelRequest(parts=[SystemPromptPart("first system"), UserPromptPart("hello")]),
+            ModelResponse(parts=[TextPart(content="answer")]),
+            ModelRequest(parts=[SystemPromptPart("second system"), UserPromptPart("follow up")]),
+        ]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            payload = json.loads(request.content.decode("utf-8"))
+            prompt_messages = payload["target"]["prompt_messages"]
+
+            self.assertEqual(
+                [message["role"] for message in prompt_messages],
+                ["system", "user", "assistant", "user"],
+            )
+            self.assertEqual(prompt_messages[0]["content"], "first system\n\nsecond system")
+            return build_stream_response(*single_text_chunk("adapter response", prompt_tokens=11, completion_tokens=7))
+
+        async with self.mock_gateway_stream(httpx.MockTransport(handler)):
+            adapter = DifyLLMAdapterModel(
+                "demo-model",
+                self.make_provider(),
+                model_provider="openai",
+            )
+
+            response = await adapter.request(
+                messages,
+                model_settings=None,
+                model_request_parameters=ModelRequestParameters(),
+            )
+
+        self.assertEqual(response.model_name, "demo-model")
+        self.assertEqual(cast(TextPart, response.parts[0]).content, "adapter response")
 
     async def test_request_maps_tool_call_only_assistant_history_to_empty_string_content(self) -> None:
         messages = [

--- a/dify-agent/tests/local/dify_agent/adapters/llm/test_model.py
+++ b/dify-agent/tests/local/dify_agent/adapters/llm/test_model.py
@@ -148,12 +148,11 @@ class DifyLLMAdapterModelTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(set(tools_by_name), {"weather", "incident_summary"})
             self.assertEqual(tools_by_name["incident_summary"]["parameters"]["required"], ["title"])
             self.assertEqual(data["prompt_messages"][0]["role"], "system")
-            self.assertEqual(data["prompt_messages"][0]["content"], "request system")
-            self.assertEqual(data["prompt_messages"][1]["content"], "be concise")
-            self.assertEqual(data["prompt_messages"][2]["content"], "hello")
+            self.assertEqual(data["prompt_messages"][0]["content"], "request system\n\nbe concise")
+            self.assertEqual(data["prompt_messages"][1]["content"], "hello")
+            self.assertEqual(data["prompt_messages"][2]["role"], "tool")
             self.assertEqual(data["prompt_messages"][3]["role"], "tool")
-            self.assertEqual(data["prompt_messages"][4]["role"], "tool")
-            self.assertEqual(data["prompt_messages"][5]["role"], "assistant")
+            self.assertEqual(data["prompt_messages"][4]["role"], "assistant")
             return build_stream_response(
                 LLMResultChunk(
                     model="demo-model",
@@ -185,6 +184,80 @@ class DifyLLMAdapterModelTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.usage.input_tokens, 11)
         self.assertEqual(response.usage.output_tokens, 7)
         self.assertEqual(response.parts[0].part_kind, "text")
+        self.assertEqual(cast(TextPart, response.parts[0]).content, "adapter response")
+
+    async def test_request_merges_system_messages_before_history(self) -> None:
+        messages = [
+            ModelRequest(parts=[UserPromptPart("previous user")]),
+            ModelResponse(parts=[TextPart(content="previous answer")]),
+            ModelRequest(parts=[SystemPromptPart("current system"), UserPromptPart("current user")]),
+        ]
+        request_parameters = ModelRequestParameters(instruction_parts=[InstructionPart(content="runtime instruction")])
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            payload = json.loads(request.content.decode("utf-8"))
+            prompt_messages = payload["data"]["prompt_messages"]
+
+            self.assertEqual(
+                [message["role"] for message in prompt_messages],
+                ["system", "user", "assistant", "user"],
+            )
+            self.assertEqual(prompt_messages[0]["content"], "current system\n\nruntime instruction")
+            self.assertEqual(prompt_messages[1]["content"], "previous user")
+            self.assertEqual(prompt_messages[2]["content"], "previous answer")
+            self.assertEqual(prompt_messages[3]["content"], "current user")
+            return build_stream_response(*single_text_chunk("adapter response", prompt_tokens=11, completion_tokens=7))
+
+        async with self.mock_daemon_stream(httpx.MockTransport(handler)):
+            adapter = DifyLLMAdapterModel(
+                "demo-model",
+                self.make_provider(),
+                model_provider="openai",
+                credentials={"api_key": "secret"},
+            )
+
+            response = await adapter.request(
+                messages,
+                model_settings=None,
+                model_request_parameters=request_parameters,
+            )
+
+        self.assertEqual(response.model_name, "demo-model")
+        self.assertEqual(cast(TextPart, response.parts[0]).content, "adapter response")
+
+    async def test_request_merges_scattered_system_messages_without_instructions(self) -> None:
+        messages = [
+            ModelRequest(parts=[SystemPromptPart("first system"), UserPromptPart("hello")]),
+            ModelResponse(parts=[TextPart(content="answer")]),
+            ModelRequest(parts=[SystemPromptPart("second system"), UserPromptPart("follow up")]),
+        ]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            payload = json.loads(request.content.decode("utf-8"))
+            prompt_messages = payload["data"]["prompt_messages"]
+
+            self.assertEqual(
+                [message["role"] for message in prompt_messages],
+                ["system", "user", "assistant", "user"],
+            )
+            self.assertEqual(prompt_messages[0]["content"], "first system\n\nsecond system")
+            return build_stream_response(*single_text_chunk("adapter response", prompt_tokens=11, completion_tokens=7))
+
+        async with self.mock_daemon_stream(httpx.MockTransport(handler)):
+            adapter = DifyLLMAdapterModel(
+                "demo-model",
+                self.make_provider(),
+                model_provider="openai",
+                credentials={"api_key": "secret"},
+            )
+
+            response = await adapter.request(
+                messages,
+                model_settings=None,
+                model_request_parameters=ModelRequestParameters(),
+            )
+
+        self.assertEqual(response.model_name, "demo-model")
         self.assertEqual(cast(TextPart, response.parts[0]).content, "adapter response")
 
     async def test_request_maps_tool_call_only_assistant_history_to_empty_string_content(self) -> None:


### PR DESCRIPTION
…LLM requirement

Some LLM providers (e.g., Qwen via vLLM) require the system message to be the first element in the messages array. The current implementation inserts instruction messages at an arbitrary position, which causes a 400 error from these providers.

This change merges all system messages into one and places them first in the prompt messages array, ensuring compatibility with providers that enforce this ordering.

Fixes #39275
Fixes #39467
Fixes https://github.com/langgenius/dify/issues/41047

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods