### PR TITLE
fix(web): keep signup email validation in the app language

### DIFF
--- a/web/app/signup/components/input-mail.spec.tsx
+++ b/web/app/signup/components/input-mail.spec.tsx
@@ -156,6 +156,29 @@ describe('InputMail Form', () => {
       expect(mockOnSuccess).not.toHaveBeenCalled()
     })
 
+    // Regression for #39011: the email input is type="email", so the browser
+    // runs native constraint validation on submit. For a value it rejects (e.g.
+    // "abc", no "@") it blocks submit and shows its own message in the browser's
+    // language before handleSubmit — and the app's translated error.emailInValid
+    // — can run. fireEvent.submit bypasses native validation, so this asserts on
+    // the input's own validity and requires the form to opt out via noValidate.
+    it('should disable native validation so localized errors can fire', () => {
+      const { container } = renderForm()
+      const form = container.querySelector('form')
+      const input = screen.getByLabelText('login.email') as HTMLInputElement
+
+      fireEvent.change(input, { target: { value: 'abc' } })
+
+      // The browser considers this invalid for type="email"...
+      expect(input.checkValidity()).toBe(false)
+      expect(input.validity.valid).toBe(false)
+
+      // ...so the form must opt out of native validation, otherwise the browser
+      // preempts submit and reports the error itself, ignoring the app language.
+      expect(form).not.toBeNull()
+      expect((form as HTMLFormElement).noValidate).toBe(true)
+    })
+
     it('should not call onSuccess when mutation does not succeed', async () => {
       mockSubmitMail.mockResolvedValue({ result: 'failed', data: 'token' })
       renderForm()

--- a/web/app/signup/components/input-mail.tsx
+++ b/web/app/signup/components/input-mail.tsx
@@ -46,6 +46,7 @@ export default function Form({ onSuccess }: Props) {
 
   return (
     <form
+      noValidate
       onSubmit={(e) => {
         e.preventDefault()
         handleSubmit()


### PR DESCRIPTION
## Summary

The signup form's `<input type="email">` lives in a `<form>` without `noValidate`, so the browser runs native constraint validation before the submit handler fires. For a value the browser rejects (e.g. `abc`), `handleSubmit` never runs — and `handleSubmit` is where the translated `error.emailInValid` toast lives. The user sees the **browser's** message in the **browser's** language, ignoring the app language:

| browser | shown today |
| --- | --- |
| de | Die E-Mail-Adresse muss ein @-Zeichen enthalten. In der Angabe "abc" fehlt ein @-Zeichen. |
| ja | メール アドレスに「@」を挿入してください。「abc」内に「@」がありません。 |
| fr | Veuillez inclure "@" dans l'adresse e-mail. Il manque un symbole "@" dans "abc". |

Because `emailRegex` and the browser disagree on what counts as invalid, the translated message was only reachable for the rarer typo:

- `abc` — browser rejects → browser's language, `handleSubmit` never runs
- `a@b` — browser accepts, `emailRegex` rejects → 请输入有效的邮箱地址

This is a side effect of #30455 / #30456, which moved this form from `onSubmit={noop}` + button `onClick` to a real `<form onSubmit>` with `type="submit"`. That's the right call for form semantics, but submitting for real also runs the browser's constraint validation first.

### Fix

Add `noValidate` to the form. The app already validates both the empty and invalid cases, and `error.emailEmpty` / `error.emailInValid` are already translated in all 23 locales — this just lets them fire. `type="email"` stays, so the mobile email keyboard is unaffected; `noValidate` only turns off constraint validation. No new strings and nothing for translators.

### Test

The existing `input-mail.spec.tsx` drives the form with `fireEvent.submit`, which dispatches the event directly and skips constraint validation — so it can't reproduce this. The new regression test asserts on the input's own validity state (the browser really does reject `abc` for `type="email"`) and on the form's `noValidate` opt-out, which is what a browser honors.

Verified locally: the new test fails without the fix (`expected false to be true` on `noValidate`) and passes with it; all 8 cases in the file are green. No new lint or type-check errors on the touched files.

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] This change requires a documentation update — N/A, no new strings or user-facing docs.

Fixes #39011

Diagnosis, root cause, and the proposed fix are my own, from the original report in #39011. Implementation and the regression test were written with Claude Code.

From Claude Code
