### PR TITLE
fix: downgrade to landlock v1

### DIFF
--- a/dify-agent-runtime/cmd/runner/main.go
+++ b/dify-agent-runtime/cmd/runner/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -174,11 +173,8 @@ func childMode() {
 		jobDir := filepath.Dir(scriptPath)
 		cfg := landlock.ConfigFromEnv(home, cwd, jobDir)
 		if err := landlock.Restrict(cfg); err != nil {
-			if errors.Is(err, landlock.ErrNotSupported) {
-				fmt.Fprintf(os.Stderr, "shellctl-runner: WARNING: %v — running without filesystem isolation\n", err)
-			} else {
-				cmdutil.HandleError(err, 125, "landlock restrict")
-			}
+			// the landlock is best-effort, so we just log the error whatever it is
+			fmt.Fprintf(os.Stderr, "shellctl-runner: WARNING: %v — running without filesystem isolation\n", err)
 		}
 	}
 

--- a/dify-agent-runtime/internal/landlock/landlock_linux.go
+++ b/dify-agent-runtime/internal/landlock/landlock_linux.go
@@ -4,9 +4,7 @@ package landlock
 
 import (
 	"errors"
-	"fmt"
 	"os"
-	"syscall"
 
 	golandlock "github.com/landlock-lsm/go-landlock/landlock"
 )
@@ -14,21 +12,15 @@ import (
 // ErrNotSupported is returned when the kernel does not support Landlock.
 var ErrNotSupported = errors.New("landlock: not supported by kernel")
 
-// Restrict applies Landlock filesystem restrictions for the current process.
+// Restrict applies Landlock V1 filesystem restrictions for the current process.
 //
-// It first tries strict enforcement.  If the kernel lacks Landlock support,
-// it falls back to BestEffort (which may silently degrade) and returns
-// ErrNotSupported so callers can log a warning.
+// It uses BestEffort mode so it works on any kernel with Landlock (≥ 5.13).
+// If the kernel has no Landlock at all, ErrNotSupported is returned so callers
+// can log a warning.
 func Restrict(cfg *Config) error {
 	rules := buildRules(cfg)
 
-	if err := golandlock.V5.RestrictPaths(rules...); err != nil {
-		if !isNotSupported(err) {
-			return fmt.Errorf("landlock: restrict paths: %w", err)
-		}
-		if err2 := golandlock.V5.BestEffort().RestrictPaths(rules...); err2 != nil {
-			return fmt.Errorf("landlock: best-effort restrict paths: %w", err2)
-		}
+	if err := golandlock.V1.BestEffort().RestrictPaths(rules...); err != nil {
 		return ErrNotSupported
 	}
 	return nil
@@ -61,12 +53,6 @@ func buildRules(cfg *Config) []golandlock.Rule {
 		rules = append(rules, golandlock.RWFiles(rwDevFiles...))
 	}
 	return rules
-}
-
-// isNotSupported reports whether err indicates the kernel does not support
-// Landlock (ENOSYS = syscall absent, EOPNOTSUPP = feature disabled).
-func isNotSupported(err error) bool {
-	return errors.Is(err, syscall.ENOSYS) || errors.Is(err, syscall.EOPNOTSUPP)
 }
 
 func filterExisting(paths []string) []string {

--- a/dify-agent-runtime/internal/landlock/landlock_linux.go
+++ b/dify-agent-runtime/internal/landlock/landlock_linux.go
@@ -3,25 +3,17 @@
 package landlock
 
 import (
-	"errors"
 	"os"
 
 	golandlock "github.com/landlock-lsm/go-landlock/landlock"
 )
 
-// ErrNotSupported is returned when the kernel does not support Landlock.
-var ErrNotSupported = errors.New("landlock: not supported by kernel")
-
 // Restrict applies Landlock V1 filesystem restrictions for the current process.
-//
-// It uses BestEffort mode so it works on any kernel with Landlock (≥ 5.13).
-// If the kernel has no Landlock at all, ErrNotSupported is returned so callers
-// can log a warning.
 func Restrict(cfg *Config) error {
 	rules := buildRules(cfg)
 
-	if err := golandlock.V1.BestEffort().RestrictPaths(rules...); err != nil {
-		return ErrNotSupported
+	if err := golandlock.V1.RestrictPaths(rules...); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Currently, landlock is only used to restrict fs access. Downgrading to V1 ABI for better compatibility.
- Relax error handling.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
