### PR TITLE
fix: reuse tenant-scoped end user in plugin backwards invocation so file inputs pass ownership checks

### DIFF
--- a/api/core/plugin/backwards_invocation/app.py
+++ b/api/core/plugin/backwards_invocation/app.py
@@ -81,8 +81,23 @@ class PluginAppBackwardsInvocation(BaseBackwardsInvocation):
             try:
                 user = cls._get_user(user_id, app)
             except ValueError:
-                # Plugins such as WeCom Bot pass external sender IDs rather than EndUser UUIDs.
-                user = EndUserService.get_or_create_end_user(app, user_id=user_id)
+                # The inner-api layer (get_user_tenant) resolves an empty or external
+                # user id into a tenant-scoped EndUser whose app_id is NULL, so the
+                # app-scoped lookup above misses it. Reuse that record instead of
+                # minting a new app-bound end user: plugin file uploads are owned by
+                # the tenant-scoped record (tool_files.user_id), and the file access
+                # controller enforces ToolFile.user_id == invoking user, so invoking
+                # under a fresh identity makes every file-carrying invocation fail
+                # with "ToolFile ... not found".
+                stmt = select(EndUser).where(
+                    EndUser.id == user_id,
+                    EndUser.tenant_id == app.tenant_id,
+                )
+                user = session.scalar(stmt)
+                if user is None:
+                    # Plugins such as WeCom Bot pass external sender IDs rather than
+                    # EndUser UUIDs; keep the get-or-create behavior for those.
+                    user = EndUserService.get_or_create_end_user(app, user_id=user_id)
 
         conversation_id = conversation_id or ""
 


### PR DESCRIPTION
## Summary

Follow-up to #38098, which fixed the *text-only* half of this scenario.

When an endpoint plugin reverse-invokes an app (`self.session.app.chat.invoke`), the request reaches `/inner/api/invoke/app` with an empty `user_id`. The `get_user_tenant` layer resolves it into a **tenant-scoped anonymous `EndUser` whose `app_id` is NULL**, and passes that record's UUID to `PluginAppBackwardsInvocation.invoke_app`.

`_get_user` filters `EndUser` by `app_id == app.id`, so it can never match that record, and the `ValueError` fallback from #38098 then **creates a different, app-bound end user** via `get_or_create_end_user(app, user_id=user_id)`.

Plugin file uploads, however, are owned by the *tenant-scoped* record (`tool_files.user_id` is set from the `get_user_tenant` identity), and the file access controller enforces `ToolFile.user_id == invoking user` (`core/app/file_access/controller.py`). With upload identity ≠ invocation identity, **every file-carrying invocation from an endpoint plugin fails**:

```
File ".../factories/file_factory/builders.py", line 327, in _build_from_tool_file
    raise ValueError(f"ToolFile {tool_file_id} not found")
ValueError: ToolFile fc48dfc7-fc04-4aa4-bab1-1b7fa44c2416 not found
```

Text-only invocations succeed (thanks to #38098); the same invocation with an image/document input fails.

## Fix

In the `ValueError` fallback, first re-resolve the id as a **tenant-scoped** `EndUser` (this is safe: `user_id` here is the server-resolved id produced by `get_user_tenant`, not the raw untrusted payload value) and reuse it, so the invocation runs under the same identity that owns the uploaded files. Only when that lookup misses (e.g. external sender IDs such as WeCom Bot) fall back to the existing get-or-create behavior.

## Reproduction

1. Install any endpoint plugin that uploads a file via `session.file.upload` and then calls `session.app.chat.invoke` with a `tool_file` input (e.g. a Slack/WeCom connector forwarding image attachments).
2. Trigger the endpoint with an attachment.
3. Before this fix: HTTP 400 `user not found` (pre-#38098) or `ToolFile ... not found` (post-#38098). After this fix: invocation succeeds and the app receives the file.

## Testing

- Backported this change onto a production 1.15.0 deployment running a Slack endpoint plugin (12 workspaces): text-only and image-attachment invocations both succeed; `ToolFile ... not found` no longer occurs; conversation continuity via cached `conversation_id` keeps working.
- `python -m py_compile` clean; the change only touches the existing fallback branch and uses the `session` already threaded into `invoke_app`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
