### PR TITLE
fix(workflow): preserve explicit falsy user inputs (#38963)

### DIFF
--- a/api/core/workflow/workflow_entry.py
+++ b/api/core/workflow/workflow_entry.py
@@ -575,8 +575,11 @@ class WorkflowEntry:
             variable_key_list = list(variable_key_list)
 
             # get input value
-            input_value = user_inputs.get(node_variable)
-            if not input_value:
+            # Preserve explicit falsy values from the full key; only fall back to
+            # the short-key alias when the full key is absent.
+            if node_variable in user_inputs:
+                input_value = user_inputs[node_variable]
+            else:
                 input_value = user_inputs.get(node_variable_key)
             if input_value is None:
                 continue

--- a/api/tests/unit_tests/core/workflow/test_workflow_entry_helpers.py
+++ b/api/tests/unit_tests/core/workflow/test_workflow_entry_helpers.py
@@ -907,6 +907,20 @@ class TestWorkflowEntryHelpers:
 
 
 class TestMappingUserInputsBranches:
+    @pytest.mark.parametrize("explicit_value", [False, 0, ""])
+    def test_preserves_explicit_falsy_user_input_values(self, explicit_value):
+        variable_pool = MagicMock()
+        variable_pool.get.return_value = None
+
+        workflow_entry.WorkflowEntry.mapping_user_inputs_to_variable_pool(
+            variable_mapping={"node.input": ["target", "input"]},
+            user_inputs={"node.input": explicit_value},
+            variable_pool=variable_pool,
+            tenant_id="tenant-id",
+        )
+
+        variable_pool.add.assert_called_once_with(["target", "input"], explicit_value)
+
     def test_rejects_invalid_node_variable_key(self):
         class EmptySplitKey(UserString):
             def split(self, _sep=None):


### PR DESCRIPTION
- `uv run --project api --python 3.12 --no-default-groups --group dev --group storage --group tools --group trace-all pytest api/tests/unit_tests/core/workflow/test_workflow_entry_helpers.py::TestMappingUserInputsBranches api/tests/unit_tests/core/workflow/test_workflow_entry.py -q`
- Result: 17 passed, 2 warnings.

Commit: 976999d1bc37967d996a105534352cbf94b2cfdd

Refs: https://github.com/langgenius/dify/issues/38963
OpenJobs: openjobs.bot | https://openjobs.bot/jobs/a976bccf-829e-4ac8-9d39-0706cbba25d9 | a976bccf-829e-4ac8-9d39-0706cbba25d9

Refs: https://github.com/langgenius/dify/issues/38655
OpenJobs: openjobs.bot | https://openjobs.bot/jobs/b13fc23b-8eff-477a-afa3-79bdcd77f665 | b13fc23b-8eff-477a-afa3-79bdcd77f665
