### PR TITLE
fix: preserve parallel fail-fast failure source

### DIFF
--- a/api/core/app/workflow/layers/persistence.py
+++ b/api/core/app/workflow/layers/persistence.py
@@ -12,7 +12,7 @@ state.
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Union, override
+from typing import Any, TypedDict, Union, override
 
 from core.app.entities.app_invoke_entities import AdvancedChatAppGenerateEntity, WorkflowAppGenerateEntity
 from core.app.workflow.retry_history import RETRY_HISTORY_PROCESS_DATA_KEY, WorkflowNodeRetryAttempt
@@ -23,7 +23,7 @@ from core.repositories.factory import WorkflowExecutionRepository, WorkflowNodeE
 from core.workflow.system_variables import SystemVariableKey
 from core.workflow.variable_prefixes import SYSTEM_VARIABLE_NODE_ID
 from core.workflow.workflow_run_outputs import project_node_outputs_for_workflow_run
-from graphon.entities import WorkflowExecution, WorkflowNodeExecution
+from graphon.entities import GraphFailureSource, WorkflowExecution, WorkflowNodeExecution
 from graphon.enums import (
     WorkflowExecutionStatus,
     WorkflowNodeExecutionMetadataKey,
@@ -54,6 +54,12 @@ from services.workflow.inspector_events import (
 from services.workflow.inspector_events import (
     publish_workflow_completed as _inspector_publish_workflow_completed,
 )
+
+
+class _FailureSourceMetadata(TypedDict):
+    node_execution_id: str
+    node_id: str
+    node_title: str
 
 
 @dataclass(slots=True)
@@ -190,7 +196,10 @@ class WorkflowPersistenceLayer(GraphEngineLayer):
         execution.exceptions_count = event.exceptions_count
         self._populate_completion_statistics(execution)
 
-        self._fail_running_node_executions(error_message=event.error)
+        self._fail_running_node_executions(
+            error_message=event.error,
+            failure_source=event.failure_source,
+        )
         self._workflow_execution_repository.save(execution)
         self._enqueue_trace_task(execution)
         _inspector_publish_workflow_completed(workflow_run_id=execution.id_, status=str(execution.status.value))
@@ -444,15 +453,40 @@ class WorkflowPersistenceLayer(GraphEngineLayer):
         self._workflow_node_execution_repository.save(domain_execution)
         self._workflow_node_execution_repository.save_execution_data(domain_execution)
 
-    def _fail_running_node_executions(self, *, error_message: str) -> None:
+    def _fail_running_node_executions(
+        self,
+        *,
+        error_message: str,
+        failure_source: GraphFailureSource | None = None,
+    ) -> None:
+        """Finalize active nodes, annotating those stopped by a fatal node failure."""
         now = naive_utc_now()
+        affected_statuses = {WorkflowNodeExecutionStatus.RUNNING}
+        source_metadata: _FailureSourceMetadata | None = None
+        if failure_source is not None:
+            affected_statuses.add(WorkflowNodeExecutionStatus.RETRY)
+            source_execution = self._node_execution_cache.get(failure_source.node_execution_id)
+            source_metadata = {
+                "node_execution_id": failure_source.node_execution_id,
+                "node_id": failure_source.node_id,
+                "node_title": source_execution.title if source_execution is not None else failure_source.node_id,
+            }
+
         for execution in self._node_execution_cache.values():
-            if execution.status == WorkflowNodeExecutionStatus.RUNNING:
-                execution.status = WorkflowNodeExecutionStatus.FAILED
-                execution.error = error_message
-                execution.finished_at = now
-                execution.elapsed_time = max((now - execution.created_at).total_seconds(), 0.0)
-                self._workflow_node_execution_repository.save(execution)
+            if execution.status not in affected_statuses:
+                continue
+            if failure_source is not None and execution.id == failure_source.node_execution_id:
+                continue
+
+            execution.status = WorkflowNodeExecutionStatus.FAILED
+            execution.error = error_message
+            if source_metadata is not None:
+                metadata = dict(execution.metadata or {})
+                metadata[WorkflowNodeExecutionMetadataKey.FAILURE_SOURCE] = source_metadata
+                execution.metadata = metadata
+            execution.finished_at = now
+            execution.elapsed_time = max((now - execution.created_at).total_seconds(), 0.0)
+            self._workflow_node_execution_repository.save(execution)
 
     def _enqueue_trace_task(self, execution: WorkflowExecution) -> None:
         if not self._trace_manager:

--- a/api/tests/unit_tests/core/app/workflow/test_persistence_layer.py
+++ b/api/tests/unit_tests/core/app/workflow/test_persistence_layer.py
@@ -9,7 +9,7 @@ from core.app.entities.app_invoke_entities import WorkflowAppGenerateEntity
 from core.app.workflow.layers.persistence import PersistenceWorkflowInfo, WorkflowPersistenceLayer
 from core.ops.ops_trace_manager import TraceTask, TraceTaskName
 from core.workflow.system_variables import SystemVariableKey, build_system_variables
-from graphon.entities import WorkflowNodeExecution
+from graphon.entities import GraphFailureSource, WorkflowNodeExecution
 from graphon.entities.pause_reason import SchedulingPause
 from graphon.enums import (
     BuiltinNodeTypes,
@@ -50,6 +50,31 @@ class _RepoRecorder:
 
 def _naive_utc_now() -> datetime:
     return datetime.now(UTC).replace(tzinfo=None)
+
+
+def _make_node_execution(
+    execution_id: str,
+    *,
+    node_id: str,
+    title: str,
+    status: WorkflowNodeExecutionStatus,
+    error: str | None = None,
+    metadata: dict[WorkflowNodeExecutionMetadataKey, object] | None = None,
+) -> WorkflowNodeExecution:
+    return WorkflowNodeExecution(
+        id=execution_id,
+        node_execution_id=execution_id,
+        workflow_id="workflow-id",
+        workflow_execution_id="run-id",
+        index=1,
+        node_id=node_id,
+        node_type=BuiltinNodeTypes.CODE,
+        title=title,
+        status=status,
+        error=error,
+        metadata=metadata,
+        created_at=_naive_utc_now(),
+    )
 
 
 def _make_layer(
@@ -668,3 +693,128 @@ class TestWorkflowPersistenceLayer:
         layer._handle_graph_run_succeeded(GraphRunSucceededEvent(outputs={"ok": True}))
         assert exec_repo.saved
         assert not trace_tasks
+
+
+def test_graph_failure_marks_running_and_retry_nodes_with_source() -> None:
+    layer, _, node_repo, _ = _make_layer()
+    layer._handle_graph_run_started()
+    source = _make_node_execution(
+        "execution-a",
+        node_id="node-a",
+        title="HTTP Request",
+        status=WorkflowNodeExecutionStatus.FAILED,
+        error="source error",
+    )
+    running = _make_node_execution(
+        "execution-b",
+        node_id="node-b",
+        title="Code",
+        status=WorkflowNodeExecutionStatus.RUNNING,
+        metadata={WorkflowNodeExecutionMetadataKey.TOTAL_TOKENS: 12},
+    )
+    retrying = _make_node_execution(
+        "execution-c",
+        node_id="node-c",
+        title="LLM",
+        status=WorkflowNodeExecutionStatus.RETRY,
+        error="retry error",
+    )
+    succeeded = _make_node_execution(
+        "execution-d",
+        node_id="node-d",
+        title="Answer",
+        status=WorkflowNodeExecutionStatus.SUCCEEDED,
+    )
+    layer._node_execution_cache = {item.id: item for item in (source, running, retrying, succeeded)}
+
+    layer._handle_graph_run_failed(
+        GraphRunFailedEvent(
+            error="graph failed",
+            exceptions_count=1,
+            failure_source=GraphFailureSource(
+                node_execution_id="execution-a",
+                node_id="node-a",
+            ),
+        )
+    )
+
+    expected_source = {
+        "node_execution_id": "execution-a",
+        "node_id": "node-a",
+        "node_title": "HTTP Request",
+    }
+    assert source.error == "source error"
+    assert source.metadata is None
+    assert running.status == WorkflowNodeExecutionStatus.FAILED
+    assert running.error == "graph failed"
+    assert running.metadata == {
+        WorkflowNodeExecutionMetadataKey.TOTAL_TOKENS: 12,
+        WorkflowNodeExecutionMetadataKey.FAILURE_SOURCE: expected_source,
+    }
+    assert retrying.status == WorkflowNodeExecutionStatus.FAILED
+    assert retrying.error == "graph failed"
+    assert retrying.metadata == {
+        WorkflowNodeExecutionMetadataKey.FAILURE_SOURCE: expected_source,
+    }
+    assert succeeded.status == WorkflowNodeExecutionStatus.SUCCEEDED
+    assert [item.id for item in node_repo.saved] == ["execution-b", "execution-c"]
+
+
+def test_graph_failure_uses_node_id_when_source_execution_is_missing() -> None:
+    layer, _, _, _ = _make_layer()
+    layer._handle_graph_run_started()
+    running = _make_node_execution(
+        "execution-b",
+        node_id="node-b",
+        title="Code",
+        status=WorkflowNodeExecutionStatus.RUNNING,
+    )
+    layer._node_execution_cache[running.id] = running
+
+    layer._handle_graph_run_failed(
+        GraphRunFailedEvent(
+            error="graph failed",
+            failure_source=GraphFailureSource(
+                node_execution_id="missing-execution",
+                node_id="node-a",
+            ),
+        )
+    )
+
+    assert running.metadata == {
+        WorkflowNodeExecutionMetadataKey.FAILURE_SOURCE: {
+            "node_execution_id": "missing-execution",
+            "node_id": "node-a",
+            "node_title": "node-a",
+        }
+    }
+
+
+def test_unattributed_graph_failure_preserves_legacy_retry_state() -> None:
+    layer, _, _, _ = _make_layer()
+    layer._handle_graph_run_started()
+    running = _make_node_execution(
+        "execution-b",
+        node_id="node-b",
+        title="Code",
+        status=WorkflowNodeExecutionStatus.RUNNING,
+    )
+    retrying = _make_node_execution(
+        "execution-c",
+        node_id="node-c",
+        title="LLM",
+        status=WorkflowNodeExecutionStatus.RETRY,
+        error="retry error",
+    )
+    layer._node_execution_cache = {
+        running.id: running,
+        retrying.id: retrying,
+    }
+
+    layer._handle_graph_run_failed(GraphRunFailedEvent(error="graph failed"))
+
+    assert running.status == WorkflowNodeExecutionStatus.FAILED
+    assert running.metadata is None
+    assert retrying.status == WorkflowNodeExecutionStatus.RETRY
+    assert retrying.error == "retry error"
+    assert retrying.metadata is None

--- a/web/app/components/workflow/hooks/use-workflow-run-event/__tests__/use-workflow-finished.spec.ts
+++ b/web/app/components/workflow/hooks/use-workflow-run-event/__tests__/use-workflow-finished.spec.ts
@@ -1,35 +1,328 @@
-import type { WorkflowFinishedResponse } from '@/types/workflow'
-import { baseRunningData, renderWorkflowHook } from '../../../__tests__/workflow-test-env'
-import { useWorkflowFinished } from '../use-workflow-finished'
+import type { ReactNode } from 'react'
+import type { NodeTracing, WorkflowFinishedResponse } from '@/types/workflow'
+import { toast } from '@langgenius/dify-ui/toast'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { createElement } from 'react'
+import { useEdges, useNodes } from 'reactflow'
+import { WorkflowContext } from '@/app/components/workflow/context'
+import { fetchTracingList } from '@/service/log'
+import { createEdge, createNode } from '../../../__tests__/fixtures'
+import {
+  baseRunningData,
+  createTestWorkflowStore,
+  renderWorkflowFlowHook,
+} from '../../../__tests__/workflow-test-env'
+import { NodeRunningStatus, WorkflowRunningStatus } from '../../../types'
+import { useFailedWorkflowRunReconciliation, useWorkflowFinished } from '../use-workflow-finished'
+
+vi.mock('@/service/log', () => ({
+  fetchTracingList: vi.fn(),
+}))
+
+vi.mock('@langgenius/dify-ui/toast', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}))
+
+const mockFetchTracingList = vi.mocked(fetchTracingList)
+const mockToastError = vi.mocked(toast.error)
+
+const staleTracing = [
+  {
+    id: 'source-execution',
+    index: 1,
+    node_id: 'source-node',
+    title: 'Fail Fast Call',
+    status: NodeRunningStatus.Failed,
+    error: 'source failed',
+  },
+  {
+    id: 'slow-execution-a',
+    index: 2,
+    node_id: 'slow-node-a',
+    title: 'Slow LLM Call',
+    status: NodeRunningStatus.Running,
+  },
+  {
+    id: 'slow-execution-b',
+    index: 3,
+    node_id: 'slow-node-b',
+    title: 'Slow LLM Call (1)',
+    status: NodeRunningStatus.Running,
+  },
+] as NodeTracing[]
+
+const persistedTracing = [
+  staleTracing[0],
+  {
+    ...staleTracing[1],
+    status: NodeRunningStatus.Failed,
+    error: 'graph failed',
+    execution_metadata: {
+      failure_source: {
+        node_execution_id: 'source-execution',
+        node_id: 'source-node',
+        node_title: 'Fail Fast Call',
+      },
+    },
+  },
+  {
+    ...staleTracing[2],
+    status: NodeRunningStatus.Failed,
+    error: 'graph failed',
+    execution_metadata: {
+      failure_source: {
+        node_execution_id: 'source-execution',
+        node_id: 'source-node',
+        node_title: 'Fail Fast Call',
+      },
+    },
+  },
+] as NodeTracing[]
+
+const getWorkflowRunAndTraceUrl = vi.fn((runId?: string) => ({
+  runUrl: `/runs/${runId}`,
+  traceUrl: `/runs/${runId}/node-executions`,
+}))
+
+function renderFinishedHook() {
+  const store = createTestWorkflowStore({
+    workflowRunningData: baseRunningData({
+      result: {
+        id: 'run-1',
+        status: WorkflowRunningStatus.Running,
+      },
+      tracing: staleTracing,
+    }),
+  })
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(WorkflowContext.Provider, { value: store }, children)
+
+  return {
+    ...renderHook(() => useWorkflowFinished(), { wrapper }),
+    store,
+  }
+}
+
+function renderReconciliationHook() {
+  return renderWorkflowFlowHook(
+    () => {
+      useFailedWorkflowRunReconciliation()
+      return {
+        nodes: useNodes(),
+        edges: useEdges(),
+      }
+    },
+    {
+      nodes: [
+        createNode({
+          id: 'source-node',
+          data: { _runningStatus: NodeRunningStatus.Failed },
+        }),
+        createNode({
+          id: 'slow-node-a',
+          data: { _runningStatus: NodeRunningStatus.Running },
+        }),
+        createNode({
+          id: 'slow-node-b',
+          data: { _runningStatus: NodeRunningStatus.Running },
+        }),
+      ],
+      edges: [
+        createEdge({
+          id: 'edge-a',
+          source: 'source-node',
+          target: 'slow-node-a',
+          data: { _targetRunningStatus: NodeRunningStatus.Running },
+        }),
+        createEdge({
+          id: 'edge-b',
+          source: 'source-node',
+          target: 'slow-node-b',
+          data: { _targetRunningStatus: NodeRunningStatus.Running },
+        }),
+      ],
+      initialStoreState: {
+        workflowRunningData: baseRunningData({
+          result: {
+            id: 'run-1',
+            status: WorkflowRunningStatus.Running,
+          },
+          tracing: staleTracing,
+        }),
+      },
+      hooksStoreProps: {
+        getWorkflowRunAndTraceUrl,
+      },
+    },
+  )
+}
+
+function workflowFinished(
+  status: WorkflowRunningStatus,
+  outputs: Record<string, string> = {},
+  runId = 'run-1',
+): WorkflowFinishedResponse {
+  return {
+    data: {
+      id: runId,
+      status,
+      outputs,
+      error: status === WorkflowRunningStatus.Failed ? 'graph failed' : undefined,
+    },
+  } as WorkflowFinishedResponse
+}
 
 describe('useWorkflowFinished', () => {
-  it('merges data into result and activates result tab for single string output', () => {
-    const { result, store } = renderWorkflowHook(() => useWorkflowFinished(), {
-      initialStoreState: { workflowRunningData: baseRunningData() },
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('initializes and records a failed result without a hooks-store provider', () => {
+    const { result, store } = renderFinishedHook()
+
+    act(() => {
+      result.current.handleWorkflowFinished(workflowFinished(WorkflowRunningStatus.Failed))
     })
 
-    result.current.handleWorkflowFinished({
-      data: { status: 'succeeded', outputs: { answer: 'hello' } },
-    } as WorkflowFinishedResponse)
+    expect(store.getState().workflowRunningData!.result.status).toBe(WorkflowRunningStatus.Failed)
+    expect(mockFetchTracingList).not.toHaveBeenCalled()
+  })
+
+  it('merges successful data and activates the result tab for a string output', () => {
+    const { result, store } = renderFinishedHook()
+
+    act(() => {
+      result.current.handleWorkflowFinished(
+        workflowFinished(WorkflowRunningStatus.Succeeded, { answer: 'hello' }),
+      )
+    })
 
     const state = store.getState().workflowRunningData!
-    expect(state.result.status).toBe('succeeded')
+    expect(state.result.status).toBe(WorkflowRunningStatus.Succeeded)
     expect(state.resultTabActive).toBe(true)
     expect(state.resultText).toBe('hello')
+    expect(mockFetchTracingList).not.toHaveBeenCalled()
   })
 
   it('does not activate the result tab for multi-key outputs', () => {
-    const { result, store } = renderWorkflowHook(() => useWorkflowFinished(), {
-      initialStoreState: { workflowRunningData: baseRunningData() },
+    const { result, store } = renderFinishedHook()
+
+    act(() => {
+      result.current.handleWorkflowFinished(
+        workflowFinished(WorkflowRunningStatus.Succeeded, { a: 'hello', b: 'world' }),
+      )
     })
 
-    result.current.handleWorkflowFinished({
-      data: { status: 'succeeded', outputs: { a: 'hello', b: 'world' } },
-    } as WorkflowFinishedResponse)
-
     const state = store.getState().workflowRunningData!
-    expect(state.result.status).toBe('succeeded')
     expect(state.resultTabActive).toBe(false)
     expect(state.resultText).toBe('')
+  })
+})
+
+describe('useFailedWorkflowRunReconciliation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reconciles failed tracing and canvas state from persisted executions once', async () => {
+    mockFetchTracingList.mockResolvedValue({ data: persistedTracing })
+    const { result, store } = renderReconciliationHook()
+
+    act(() => {
+      store.getState().setWorkflowRunningData(
+        baseRunningData({
+          result: { id: 'run-1', status: WorkflowRunningStatus.Failed },
+          tracing: staleTracing,
+        }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(mockFetchTracingList).toHaveBeenCalledWith({
+        url: '/runs/run-1/node-executions',
+      })
+      expect(store.getState().workflowRunningData!.tracing).toEqual(persistedTracing)
+      expect(result.current.nodes.find((node) => node.id === 'slow-node-a')!.data).toMatchObject({
+        _runningStatus: NodeRunningStatus.Failed,
+      })
+      expect(result.current.nodes.find((node) => node.id === 'slow-node-b')!.data).toMatchObject({
+        _runningStatus: NodeRunningStatus.Failed,
+      })
+      expect(result.current.edges.find((edge) => edge.id === 'edge-a')!.data).toMatchObject({
+        _targetRunningStatus: NodeRunningStatus.Failed,
+      })
+      expect(result.current.edges.find((edge) => edge.id === 'edge-b')!.data).toMatchObject({
+        _targetRunningStatus: NodeRunningStatus.Failed,
+      })
+    })
+
+    expect(mockFetchTracingList).toHaveBeenCalledTimes(1)
+    expect(
+      store.getState().workflowRunningData!.tracing![1]!.execution_metadata?.failure_source,
+    ).toEqual({
+      node_execution_id: 'source-execution',
+      node_id: 'source-node',
+      node_title: 'Fail Fast Call',
+    })
+  })
+
+  it('ignores a reconciliation response after a newer run starts', async () => {
+    let resolveTracing: ((value: { data: NodeTracing[] }) => void) | undefined
+    mockFetchTracingList.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveTracing = resolve
+        }),
+    )
+    const { store } = renderReconciliationHook()
+
+    act(() => {
+      store.getState().setWorkflowRunningData(
+        baseRunningData({
+          result: { id: 'run-1', status: WorkflowRunningStatus.Failed },
+          tracing: staleTracing,
+        }),
+      )
+    })
+    await waitFor(() => {
+      expect(mockFetchTracingList).toHaveBeenCalledTimes(1)
+    })
+
+    const newRunTracing = [{ ...staleTracing[1], id: 'new-execution' }] as NodeTracing[]
+    act(() => {
+      store.getState().setWorkflowRunningData(
+        baseRunningData({
+          result: { id: 'run-2', status: WorkflowRunningStatus.Running },
+          tracing: newRunTracing,
+        }),
+      )
+    })
+    await act(async () => {
+      resolveTracing!({ data: persistedTracing })
+    })
+
+    expect(store.getState().workflowRunningData!.tracing).toEqual(newRunTracing)
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
+
+  it('keeps stale tracing and reports an active run reconciliation failure', async () => {
+    mockFetchTracingList.mockRejectedValue(new Error('trace refresh failed'))
+    const { store } = renderReconciliationHook()
+
+    act(() => {
+      store.getState().setWorkflowRunningData(
+        baseRunningData({
+          result: { id: 'run-1', status: WorkflowRunningStatus.Failed },
+          tracing: staleTracing,
+        }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('Error: trace refresh failed')
+    })
+    expect(store.getState().workflowRunningData!.tracing).toEqual(staleTracing)
   })
 })

--- a/web/app/components/workflow/hooks/use-workflow-run-event/use-workflow-finished.ts
+++ b/web/app/components/workflow/hooks/use-workflow-run-event/use-workflow-finished.ts
@@ -1,8 +1,86 @@
-import type { WorkflowFinishedResponse } from '@/types/workflow'
+import type { NodeRunningStatus } from '@/app/components/workflow/types'
+import type { NodeTracing, WorkflowFinishedResponse } from '@/types/workflow'
+import { toast } from '@langgenius/dify-ui/toast'
 import { produce } from 'immer'
-import { useCallback } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
+import { useStoreApi } from 'reactflow'
 import { getFilesInLogs } from '@/app/components/base/file-uploader/utils'
-import { useWorkflowStore } from '@/app/components/workflow/store'
+import { useHooksStore } from '@/app/components/workflow/hooks-store'
+import { useStore, useWorkflowStore } from '@/app/components/workflow/store'
+import { WorkflowRunningStatus } from '@/app/components/workflow/types'
+import { fetchTracingList } from '@/service/log'
+
+function getLatestExecutionsByNodeId(tracing: NodeTracing[]) {
+  const latestExecutions = new Map<string, NodeTracing>()
+  tracing.forEach((execution) => {
+    const current = latestExecutions.get(execution.node_id)
+    if (!current || execution.index >= current.index)
+      latestExecutions.set(execution.node_id, execution)
+  })
+  return latestExecutions
+}
+
+export const useFailedWorkflowRunReconciliation = () => {
+  const store = useStoreApi()
+  const workflowStore = useWorkflowStore()
+  const getWorkflowRunAndTraceUrl = useHooksStore((state) => state.getWorkflowRunAndTraceUrl)
+  const failedRunId = useStore((state) => {
+    const result = state.workflowRunningData?.result as { id?: string; status: string } | undefined
+    return result?.status === WorkflowRunningStatus.Failed ? result.id : undefined
+  })
+  const reconciledRunIdRef = useRef<string | undefined>(undefined)
+
+  useEffect(() => {
+    if (!failedRunId || reconciledRunIdRef.current === failedRunId) return
+    reconciledRunIdRef.current = failedRunId
+
+    const reconcile = async () => {
+      try {
+        const { traceUrl } = getWorkflowRunAndTraceUrl(failedRunId)
+        const { data: tracing } = await fetchTracingList({ url: traceUrl })
+        const { workflowRunningData, setWorkflowRunningData } = workflowStore.getState()
+        const activeRunId = (workflowRunningData?.result as { id?: string } | undefined)?.id
+        if (!workflowRunningData || activeRunId !== failedRunId) return
+
+        setWorkflowRunningData(
+          produce(workflowRunningData, (draft) => {
+            draft.tracing = tracing
+          }),
+        )
+
+        const latestExecutions = getLatestExecutionsByNodeId(tracing)
+        const { getNodes, setNodes, edges, setEdges } = store.getState()
+        setNodes(
+          produce(getNodes(), (draft) => {
+            draft.forEach((node) => {
+              const execution = latestExecutions.get(node.id)
+              if (execution) node.data._runningStatus = execution.status as NodeRunningStatus
+            })
+          }),
+        )
+        setEdges(
+          produce(edges, (draft) => {
+            draft.forEach((edge) => {
+              const execution = latestExecutions.get(edge.target)
+              if (execution) {
+                edge.data = {
+                  ...edge.data,
+                  _targetRunningStatus: execution.status as NodeRunningStatus,
+                }
+              }
+            })
+          }),
+        )
+      } catch (error) {
+        const result = workflowStore.getState().workflowRunningData?.result
+        const activeRunId = (result as { id?: string } | undefined)?.id
+        if (activeRunId === failedRunId) toast.error(`${error}`)
+      }
+    }
+
+    void reconcile()
+  }, [failedRunId, getWorkflowRunAndTraceUrl, store, workflowStore])
+}
 
 export const useWorkflowFinished = () => {
   const workflowStore = useWorkflowStore()

--- a/web/app/components/workflow/index.tsx
+++ b/web/app/components/workflow/index.tsx
@@ -71,6 +71,7 @@ import {
 } from './hooks'
 import { HooksStoreContextProvider, useHooksStore } from './hooks-store'
 import { useWorkflowComment } from './hooks/use-workflow-comment'
+import { useFailedWorkflowRunReconciliation } from './hooks/use-workflow-run-event/use-workflow-finished'
 import { useWorkflowSearch } from './hooks/use-workflow-search'
 import { shouldPreventWorkflowBrowserDefault } from './hotkeys'
 import CustomNode from './nodes'
@@ -777,10 +778,16 @@ type WorkflowWithInnerContextProps = WorkflowProps & {
   myUserId?: string | null
   onlineUsers?: OnlineUser[]
 }
+const FailedWorkflowRunReconciliation = () => {
+  useFailedWorkflowRunReconciliation()
+  return null
+}
+
 export const WorkflowWithInnerContext = memo(
   ({ hooksStore, cursors, myUserId, onlineUsers, ...restProps }: WorkflowWithInnerContextProps) => {
     return (
       <HooksStoreContextProvider {...hooksStore}>
+        <FailedWorkflowRunReconciliation />
         <Workflow {...restProps} cursors={cursors} myUserId={myUserId} onlineUsers={onlineUsers} />
       </HooksStoreContextProvider>
     )

--- a/web/app/components/workflow/run/__tests__/node.spec.tsx
+++ b/web/app/components/workflow/run/__tests__/node.spec.tsx
@@ -67,6 +67,50 @@ describe('Run NodePanel', () => {
     })
   })
 
+  it('explains when another node caused the failure', () => {
+    render(
+      <NodePanel
+        nodeInfo={createNodeInfo({
+          expand: true,
+          status: NodeRunningStatus.Failed,
+          error: 'upstream exploded',
+          execution_metadata: {
+            total_tokens: 0,
+            total_price: 0,
+            currency: 'USD',
+            failure_source: {
+              node_execution_id: 'source-execution',
+              node_id: 'source-node',
+              node_title: 'HTTP Request',
+            },
+          },
+        })}
+      />,
+    )
+
+    expect(screen.getByText(/workflow\.tracing\.terminatedByNodeFailure/)).toHaveTextContent(
+      'HTTP Request',
+    )
+    expect(screen.getByText(/workflow\.tracing\.terminatedByNodeFailure/)).toHaveTextContent(
+      'upstream exploded',
+    )
+  })
+
+  it('keeps the original error for a failure without a source', () => {
+    render(
+      <NodePanel
+        nodeInfo={createNodeInfo({
+          expand: true,
+          status: NodeRunningStatus.Failed,
+          error: 'own failure',
+        })}
+      />,
+    )
+
+    expect(screen.getByText('own failure')).toBeInTheDocument()
+    expect(screen.queryByText(/workflow\.tracing\.terminatedByNodeFailure/)).not.toBeInTheDocument()
+  })
+
   it('forwards iteration details through the real iteration trigger', async () => {
     const handleShowIterationDetail = vi.fn()
     const details = [

--- a/web/app/components/workflow/run/node.tsx
+++ b/web/app/components/workflow/run/node.tsx
@@ -251,7 +251,15 @@ const NodePanel: FC<Props> = ({
                 </StatusContainer>
               )}
               {nodeInfo.status === 'failed' && (
-                <StatusContainer status="failed">{nodeInfo.error}</StatusContainer>
+                <StatusContainer status="failed">
+                  {nodeInfo.execution_metadata?.failure_source
+                    ? t(($) => $['tracing.terminatedByNodeFailure'], {
+                        ns: 'workflow',
+                        node: nodeInfo.execution_metadata.failure_source.node_title,
+                        error: nodeInfo.error,
+                      })
+                    : nodeInfo.error}
+                </StatusContainer>
               )}
               {nodeInfo.status === 'retry' && (
                 <StatusContainer status="failed">{nodeInfo.error}</StatusContainer>

--- a/web/i18n/ar-TN/workflow.json
+++ b/web/i18n/ar-TN/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "الأدوات المساعدة",
   "tabs.workflowTool": "سير العمل",
   "tracing.stopBy": "توقف بواسطة {{user}}",
+  "tracing.terminatedByNodeFailure": "هذه العقدة لم تفشل بحد ذاتها. تم إنهاؤها لأن العقدة «{{node}}» فشلت: {{error}}",
   "triggerStatus.disabled": "مشغل • معطل",
   "triggerStatus.enabled": "مشغل",
   "variableReference.assignedVarsDescription": "يجب أن تكون المتغيرات المعينة متغيرات قابلة للكتابة، مثل متغيرات المحادثة.",

--- a/web/i18n/de-DE/workflow.json
+++ b/web/i18n/de-DE/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "Dienstprogramme",
   "tabs.workflowTool": "Workflow",
   "tracing.stopBy": "Gestoppt von {{user}}",
+  "tracing.terminatedByNodeFailure": "Dieser Knoten selbst ist nicht fehlgeschlagen. Er wurde beendet, weil „{{node}}“ fehlgeschlagen ist: {{error}}",
   "triggerStatus.disabled": "AUSLÖSER • DEAKTIVIERT",
   "triggerStatus.enabled": "AUSLÖSER",
   "variableReference.assignedVarsDescription": "Zugewiesene Variablen müssen beschreibbare Variablen sein, z. B. Konversationsvariablen.",

--- a/web/i18n/en-US/workflow.json
+++ b/web/i18n/en-US/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "Utilities",
   "tabs.workflowTool": "Workflow",
   "tracing.stopBy": "Stop by {{user}}",
+  "tracing.terminatedByNodeFailure": "This node itself did not fail. It was terminated because “{{node}}” failed: {{error}}",
   "triggerStatus.disabled": "TRIGGER • DISABLED",
   "triggerStatus.enabled": "TRIGGER",
   "variableReference.assignedVarsDescription": "Assigned variables must be writable variables, such as conversation variables.",

--- a/web/i18n/es-ES/workflow.json
+++ b/web/i18n/es-ES/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "Utilidades",
   "tabs.workflowTool": "Flujo de trabajo",
   "tracing.stopBy": "Pásate por {{user}}",
+  "tracing.terminatedByNodeFailure": "Este nodo no falló por sí mismo. Se terminó porque «{{node}}» falló: {{error}}",
   "triggerStatus.disabled": "DISPARADOR • DESACTIVADO",
   "triggerStatus.enabled": "DISPARADOR",
   "variableReference.assignedVarsDescription": "Las variables asignadas deben ser variables grabables, como las variables de conversación.",

--- a/web/i18n/fa-IR/workflow.json
+++ b/web/i18n/fa-IR/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "ابزارهای کاربردی",
   "tabs.workflowTool": "گردش کار",
   "tracing.stopBy": "متوقف‌شده توسط {{user}}",
+  "tracing.terminatedByNodeFailure": "این گره به‌خودی‌خود با خطا مواجه نشد. چون گره «{{node}}» با خطا مواجه شد، این گره متوقف شد: {{error}}",
   "triggerStatus.disabled": "تریگر • غیرفعال",
   "triggerStatus.enabled": "تریگر",
   "variableReference.assignedVarsDescription": "متغیرهای تخصیص‌یافته باید قابل‌نوشتن باشند (مانند متغیرهای مکالمه).",

--- a/web/i18n/fr-FR/workflow.json
+++ b/web/i18n/fr-FR/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "Utilitaires",
   "tabs.workflowTool": "Workflow",
   "tracing.stopBy": "Arrêté par {{user}}",
+  "tracing.terminatedByNodeFailure": "Ce nœud n'a pas échoué lui-même. Il a été interrompu parce que « {{node}} » a échoué : {{error}}",
   "triggerStatus.disabled": "DÉCLENCHEUR • DÉSACTIVÉ",
   "triggerStatus.enabled": "DÉCLENCHEUR",
   "variableReference.assignedVarsDescription": "Les variables affectées doivent être accessibles en écriture, telles que des variables de conversation.",

--- a/web/i18n/hi-IN/workflow.json
+++ b/web/i18n/hi-IN/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "उपयोगिताएं",
   "tabs.workflowTool": "वर्कफ़्लो",
   "tracing.stopBy": "{{user}} द्वारा रोका गया",
+  "tracing.terminatedByNodeFailure": "यह नोड स्वयं विफल नहीं हुआ। इसे समाप्त किया गया क्योंकि “{{node}}” विफल हुआ: {{error}}",
   "triggerStatus.disabled": "ट्रिगर • अक्षम",
   "triggerStatus.enabled": "ट्रिगर",
   "variableReference.assignedVarsDescription": "असाइन किए गए चर लिखने योग्य चर होने चाहिए, जैसे वार्तालाप चर।",

--- a/web/i18n/id-ID/workflow.json
+++ b/web/i18n/id-ID/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "Utilitas",
   "tabs.workflowTool": "Alur kerja",
   "tracing.stopBy": "Singgah di {{user}}",
+  "tracing.terminatedByNodeFailure": "Node ini tidak gagal dengan sendirinya. Node ini dihentikan karena “{{node}}” gagal: {{error}}",
   "triggerStatus.disabled": "PEICU • DINONAKTIFKAN",
   "triggerStatus.enabled": "PEICU",
   "variableReference.assignedVarsDescription": "Variabel yang ditetapkan harus berupa variabel yang dapat ditulis, seperti variabel percakapan.",

--- a/web/i18n/it-IT/workflow.json
+++ b/web/i18n/it-IT/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "Utility",
   "tabs.workflowTool": "Workflow",
   "tracing.stopBy": "Interrotto da {{user}}",
+  "tracing.terminatedByNodeFailure": "Questo nodo non ha generato direttamente un errore. È stato terminato perché “{{node}}” non è riuscito: {{error}}",
   "triggerStatus.disabled": "ATTIVATORE • DISABILITATO",
   "triggerStatus.enabled": "GRILLETTO",
   "variableReference.assignedVarsDescription": "Le variabili assegnate devono essere variabili scrivibili, ad esempio variabili di conversazione.",

--- a/web/i18n/ja-JP/workflow.json
+++ b/web/i18n/ja-JP/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "ツール",
   "tabs.workflowTool": "ワークフロー",
   "tracing.stopBy": "{{user}}によって停止",
+  "tracing.terminatedByNodeFailure": "このノード自体ではエラーは発生していません。「{{node}}」ノードが失敗したため、このノードは終了しました：{{error}}",
   "triggerStatus.disabled": "トリガー • 無効",
   "triggerStatus.enabled": "トリガー",
   "variableReference.assignedVarsDescription": "代入される変数は、会話変数などの書き込み可能な変数である必要があります。",

--- a/web/i18n/ko-KR/workflow.json
+++ b/web/i18n/ko-KR/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "유틸리티",
   "tabs.workflowTool": "워크플로",
   "tracing.stopBy": "{{user}}에 의해 중지됨",
+  "tracing.terminatedByNodeFailure": "이 노드 자체에서는 오류가 발생하지 않았습니다. “{{node}}” 노드가 실패하여 이 노드가 종료되었습니다: {{error}}",
   "triggerStatus.disabled": "트리거 • 비활성화",
   "triggerStatus.enabled": "트리거",
   "variableReference.assignedVarsDescription": "할당된 변수는 대화 변수와 같은 쓰기 가능한 변수여야 합니다.",

--- a/web/i18n/nl-NL/workflow.json
+++ b/web/i18n/nl-NL/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "Utilities",
   "tabs.workflowTool": "Workflow",
   "tracing.stopBy": "Stop by {{user}}",
+  "tracing.terminatedByNodeFailure": "Dit knooppunt is niet zelf mislukt. Het is beëindigd omdat ‘{{node}}’ is mislukt: {{error}}",
   "triggerStatus.disabled": "TRIGGER • DISABLED",
   "triggerStatus.enabled": "TRIGGER",
   "variableReference.assignedVarsDescription": "Assigned variables must be writable variables, such as conversation variables.",

--- a/web/i18n/pl-PL/workflow.json
+++ b/web/i18n/pl-PL/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "Narzędzia pomocnicze",
   "tabs.workflowTool": "Przepływ pracy",
   "tracing.stopBy": "Zatrzymane przez {{user}}",
+  "tracing.terminatedByNodeFailure": "Ten węzeł sam nie uległ awarii. Został zakończony, ponieważ węzeł „{{node}}” uległ awarii: {{error}}",
   "triggerStatus.disabled": "WYZWALACZ • WYŁĄCZONY",
   "triggerStatus.enabled": "WYZWALACZ",
   "variableReference.assignedVarsDescription": "Przypisane zmienne muszą być zmiennymi zapisywalnymi, takimi jak zmienne konwersacji.",

--- a/web/i18n/pt-BR/workflow.json
+++ b/web/i18n/pt-BR/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "Utilitários",
   "tabs.workflowTool": "Fluxo de trabalho",
   "tracing.stopBy": "Parado por {{user}}",
+  "tracing.terminatedByNodeFailure": "Este nó não falhou por conta própria. Ele foi encerrado porque “{{node}}” falhou: {{error}}",
   "triggerStatus.disabled": "DISPARADOR • DESATIVADO",
   "triggerStatus.enabled": "GATILHO",
   "variableReference.assignedVarsDescription": "As variáveis atribuídas devem ser variáveis graváveis, como variáveis de conversação.",

--- a/web/i18n/ro-RO/workflow.json
+++ b/web/i18n/ro-RO/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "Utilități",
   "tabs.workflowTool": "Flux de lucru",
   "tracing.stopBy": "Oprit de {{user}}",
+  "tracing.terminatedByNodeFailure": "Acest nod nu a eșuat el însuși. A fost oprit deoarece nodul „{{node}}” a eșuat: {{error}}",
   "triggerStatus.disabled": "TRIGGER • DEZACTIVAT",
   "triggerStatus.enabled": "DECLANȘATOR",
   "variableReference.assignedVarsDescription": "Variabilele atribuite trebuie să fie variabile inscripționabile, cum ar fi variabilele de conversație.",

--- a/web/i18n/ru-RU/workflow.json
+++ b/web/i18n/ru-RU/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "Утилиты",
   "tabs.workflowTool": "Рабочий процесс",
   "tracing.stopBy": "Остановлено {{user}}",
+  "tracing.terminatedByNodeFailure": "Сам этот узел не завершился с ошибкой. Он был остановлен, потому что узел «{{node}}» завершился с ошибкой: {{error}}",
   "triggerStatus.disabled": "ТРЕВОГА • ОТКЛЮЧЕНО",
   "triggerStatus.enabled": "СПУСКОВОЙ МЕХАНИЗМ",
   "variableReference.assignedVarsDescription": "Назначаемые переменные должны быть доступными для записи, например переменными беседы.",

--- a/web/i18n/sl-SI/workflow.json
+++ b/web/i18n/sl-SI/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "Komunalne storitve",
   "tabs.workflowTool": "Potek dela",
   "tracing.stopBy": "Ohranjaj se pri {{user}}",
+  "tracing.terminatedByNodeFailure": "To vozlišče samo ni odpovedalo. Končano je bilo, ker je odpovedalo vozlišče »{{node}}«: {{error}}",
   "triggerStatus.disabled": "SPROŽILEC • ONEMOGOČENO",
   "triggerStatus.enabled": "SPROŽILEC",
   "variableReference.assignedVarsDescription": "Dodeljene spremenljivke morajo biti spremenljivke, ki jih je mogoče pisati, kot so spremenljivke za pogovor.",

--- a/web/i18n/th-TH/workflow.json
+++ b/web/i18n/th-TH/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "สาธารณูปโภค",
   "tabs.workflowTool": "เวิร์กโฟลว์",
   "tracing.stopBy": "แวะที่ {{user}}",
+  "tracing.terminatedByNodeFailure": "โหนดนี้ไม่ได้เกิดข้อผิดพลาดด้วยตัวเอง แต่ถูกยุติเนื่องจากโหนด “{{node}}” ล้มเหลว: {{error}}",
   "triggerStatus.disabled": "ทริกเกอร์ • ปิดการใช้งาน",
   "triggerStatus.enabled": "ทริกเกอร์",
   "variableReference.assignedVarsDescription": "ตัวแปรที่กําหนดต้องเป็นตัวแปรที่เขียนได้ เช่น ตัวแปรการสนทนา",

--- a/web/i18n/tr-TR/workflow.json
+++ b/web/i18n/tr-TR/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "Yardımcı Araçlar",
   "tabs.workflowTool": "İş akışı",
   "tracing.stopBy": "{{user}} tarafından durduruldu",
+  "tracing.terminatedByNodeFailure": "Bu düğümün kendisinde hata oluşmadı. “{{node}}” düğümü başarısız olduğu için sonlandırıldı: {{error}}",
   "triggerStatus.disabled": "TETİKLEYİCİ • DEVRE DIŞI",
   "triggerStatus.enabled": "TETİK",
   "variableReference.assignedVarsDescription": "Atanan değişkenler, konuşma değişkenleri gibi yazılabilir değişkenler olmalıdır.",

--- a/web/i18n/uk-UA/workflow.json
+++ b/web/i18n/uk-UA/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "Утиліти",
   "tabs.workflowTool": "Робочий процес",
   "tracing.stopBy": "Зупинено користувачем {{user}}",
+  "tracing.terminatedByNodeFailure": "Сам цей вузол не завершився з помилкою. Його було зупинено, оскільки вузол «{{node}}» завершився з помилкою: {{error}}",
   "triggerStatus.disabled": "ТРІГЕР • ВІДСУТНІЙ",
   "triggerStatus.enabled": "СПУСКОВИЙ МЕХАНІЗМ",
   "variableReference.assignedVarsDescription": "Призначені змінні мають бути доступними для запису, такими як змінні розмови.",

--- a/web/i18n/vi-VN/workflow.json
+++ b/web/i18n/vi-VN/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "Tiện ích",
   "tabs.workflowTool": "Quy trình làm việc",
   "tracing.stopBy": "Dừng bởi {{user}}",
+  "tracing.terminatedByNodeFailure": "Bản thân nút này không gặp lỗi. Nút đã bị kết thúc vì “{{node}}” gặp lỗi: {{error}}",
   "triggerStatus.disabled": "KÍCH HOẠT • VÔ HIỆU HÓA",
   "triggerStatus.enabled": "KÍCH HOẠT",
   "variableReference.assignedVarsDescription": "Các biến được gán phải là các biến có thể ghi, chẳng hạn như các biến hội thoại.",

--- a/web/i18n/zh-Hans/workflow.json
+++ b/web/i18n/zh-Hans/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "工具",
   "tabs.workflowTool": "工作流",
   "tracing.stopBy": "由{{user}}终止",
+  "tracing.terminatedByNodeFailure": "此节点本身未发生错误。由于「{{node}}」节点失败，此节点被终止：{{error}}",
   "triggerStatus.disabled": "触发器 • 已禁用",
   "triggerStatus.enabled": "触发器",
   "variableReference.assignedVarsDescription": "赋值变量必须是可写入的变量，例如会话变量。",

--- a/web/i18n/zh-Hant/workflow.json
+++ b/web/i18n/zh-Hant/workflow.json
@@ -1274,6 +1274,7 @@
   "tabs.utilities": "工具",
   "tabs.workflowTool": "工作流",
   "tracing.stopBy": "由{{user}}終止",
+  "tracing.terminatedByNodeFailure": "此節點本身未發生錯誤。由於「{{node}}」節點失敗，此節點已終止：{{error}}",
   "triggerStatus.disabled": "觸發器 • 已停用",
   "triggerStatus.enabled": "觸發",
   "variableReference.assignedVarsDescription": "分配的變數必須是可寫變數，例如對話變數。",

--- a/web/types/workflow.ts
+++ b/web/types/workflow.ts
@@ -83,6 +83,11 @@ export type NodeTracing = {
       icon?: string
     }
     loop_variable_map?: Record<string, any>
+    failure_source?: {
+      node_execution_id: string
+      node_id: string
+      node_title: string
+    }
   }
   metadata: {
     iterator_length: number


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #39151.

Companion PR: [langgenius/graphon#221](https://github.com/langgenius/graphon/pull/221).

Parallel fail-fast currently loses the identity of the node execution that caused the graph failure. Dify therefore cannot distinguish the source node from collateral running or retrying nodes that were terminated by the graph, and live Test Run state can remain stale because those collateral nodes do not emit their own `node_finished` event.

This PR:

- finalizes collateral `RUNNING` and `RETRY` executions as failed while preserving the fatal node execution as the source;
- stores `failure_source` metadata with the source execution ID, node ID, and node title;
- renders a localized causal message so collateral nodes are not presented as having produced the error themselves; and
- treats failed `workflow_finished` as a synchronization signal, refetching the persisted trace inside the workflow context and projecting its authoritative statuses onto Tracing, canvas nodes, and incoming edges.

### Merge and rollout order

This PR depends on the new Graphon contract in [langgenius/graphon#221](https://github.com/langgenius/graphon/pull/221). The required order is:

1. Merge the Graphon companion PR.
2. Release a Graphon version containing that change.
3. Update Dify's `graphon` dependency and lockfile to that released version.
4. Merge and deploy this Dify change.

The Dify fix does not become effective until the dependency update in step 3. This PR should remain blocked/draft until the released Graphon version is available and the Dify dependency is updated.

### Compatibility when applied alone

The full Dify backend change is **not compatible** with the currently pinned `graphon==0.6.0`: it imports the new `GraphFailureSource` contract and metadata enum and consumes `GraphRunFailedEvent.failure_source`. Applying only this Dify change without updating Graphon would fail during API imports rather than degrade gracefully.

The Web portion is independently backward-compatible: `failure_source` is optional and the UI falls back to the existing raw node error when it is absent. The Graphon companion change is also backward-compatible for existing consumers because the new event and snapshot field defaults to `None`.

### Before-After
#### Before

https://github.com/user-attachments/assets/4a4a6bc0-859b-46d4-82be-29b45f22a5de




#### After

https://github.com/user-attachments/assets/923a19bb-31e4-45a7-86c5-77fa5e7ed2b0


### Validation

- Backend persistence tests: 27 passed with the companion Graphon checkout installed as an editable overlay.
- Web focused tests: 12 passed across the failed-run reconciliation and node presentation suites.
- Web TypeScript type-check: passed.
- Backend targeted Ruff format and lint checks: passed.
- i18n completeness check: passed for all supported locales.
- Graphon companion validation: 612 tests plus Ruff and `ty` checks passed.
- `pnpm exec vp staged` could not run because the current repository configuration has no `staged` config; the focused tests, type-check, formatting check, and i18n check above were run directly instead.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Codex
