### PR TITLE
Fix issue #38655: missing-variable Jinja branch crash

### DIFF
--- a/api/core/workflow/node_factory.py
+++ b/api/core/workflow/node_factory.py
@@ -456,7 +456,7 @@ class DifyNodeFactory(NodeFactory):
             BuiltinNodeTypes.AGENT: lambda: self._build_agent_node_init_kwargs(node_class=node_class),
         }
         node_init_kwargs = node_init_kwargs_factories.get(node_type, lambda: {})()
-        constructor_node_data = resolved_node_data.model_dump(mode="python", by_alias=True)
+        constructor_node_data = self._prepare_constructor_node_data(resolved_node_data)
         return node_class(
             node_id=node_id,
             data=constructor_node_data,
@@ -597,6 +597,44 @@ class DifyNodeFactory(NodeFactory):
     @staticmethod
     def _supports_plugin_llm_polling(model_instance: ModelInstance) -> bool:
         return model_instance.get_model_schema().support_polling
+
+    def _prepare_constructor_node_data(self, node_data: BaseNodeData) -> dict[str, object]:
+        """Serialize node data for constructors while preserving Jinja undefined semantics.
+
+        LLM prompt templates treat missing upstream variables as undefined so user-authored
+        `is defined` checks can decide the control flow. If a branch does not produce a variable,
+        omit it from the renderer inputs instead of materializing an empty string here.
+        """
+
+        prompt_config = getattr(node_data, "prompt_config", None)
+        if isinstance(prompt_config, Mapping):
+            jinja2_variables = prompt_config.get("jinja2_variables")
+        else:
+            jinja2_variables = getattr(prompt_config, "jinja2_variables", None)
+
+        if getattr(node_data, "type", None) == BuiltinNodeTypes.LLM and jinja2_variables:
+            filtered_variables = []
+            for variable_selector in jinja2_variables:
+                if isinstance(variable_selector, Mapping):
+                    value_selector = variable_selector.get("value_selector")
+                else:
+                    value_selector = getattr(variable_selector, "value_selector", None)
+                if value_selector is None:
+                    continue
+                if self.graph_runtime_state.variable_pool.get(value_selector) is not None:
+                    filtered_variables.append(variable_selector)
+
+            if len(filtered_variables) != len(jinja2_variables):
+                if isinstance(prompt_config, Mapping):
+                    updated_prompt_config: object = dict(prompt_config)
+                    updated_prompt_config["jinja2_variables"] = filtered_variables
+                else:
+                    updated_prompt_config = prompt_config.model_copy(  # type: ignore[union-attr]
+                        update={"jinja2_variables": filtered_variables}
+                    )
+                node_data = node_data.model_copy(update={"prompt_config": updated_prompt_config})
+
+        return node_data.model_dump(mode="python", by_alias=True)
 
     def _build_retriever_attachment_loader(self, node_data: LLMNodeData) -> DifyRetrieverAttachmentLoader:
         return DifyRetrieverAttachmentLoader(

--- a/api/tests/unit_tests/core/workflow/test_node_factory.py
+++ b/api/tests/unit_tests/core/workflow/test_node_factory.py
@@ -800,6 +800,47 @@ class TestDifyNodeFactoryCreateNode:
         assert "structured_output_switch_on" not in data
         assert LLMNodeData.model_validate(data).structured_output_enabled is True
 
+    def test_create_node_drops_missing_jinja_variables_before_constructor(
+        self,
+        monkeypatch,
+        factory,
+    ):
+        created_node = object()
+        constructor = _node_constructor(return_value=created_node)
+        monkeypatch.setattr(factory, "_resolve_node_class", MagicMock(return_value=constructor))
+        monkeypatch.setattr(factory, "_build_llm_compatible_node_init_kwargs", MagicMock(return_value={}))
+        factory.graph_runtime_state.variable_pool.get.side_effect = lambda selector: {
+            ("source-node", "present"): sentinel.present_variable,
+        }.get(tuple(selector))
+
+        node_config = {
+            "id": "llm-node-id",
+            "data": {
+                "type": BuiltinNodeTypes.LLM,
+                "title": "LLM",
+                "model": {"provider": "provider", "name": "model", "mode": "chat", "completion_params": {}},
+                "prompt_template": [{"role": "system", "text": "{{ present }}{% if missing is defined %}x{% endif %}"}],
+                "prompt_config": {
+                    "jinja2_variables": [
+                        {"variable": "present", "value_selector": ["source-node", "present"]},
+                        {"variable": "missing", "value_selector": ["source-node", "missing"]},
+                    ]
+                },
+                "context": {"enabled": False, "variable_selector": []},
+                "vision": {"enabled": False},
+            },
+        }
+
+        factory.create_node(node_config)
+
+        data = constructor.call_args.kwargs["data"]
+        assert isinstance(data, Mapping)
+        assert data["prompt_config"]["jinja2_variables"] == [
+            {"variable": "present", "value_selector": ["source-node", "present"]},
+        ]
+        factory.graph_runtime_state.variable_pool.get.assert_any_call(["source-node", "present"])
+        factory.graph_runtime_state.variable_pool.get.assert_any_call(["source-node", "missing"])
+
     def test_create_node_preserves_structured_output_switch_after_graphon_constructor(self, monkeypatch, factory):
         factory.graph_init_params = SimpleNamespace(
             workflow_id="workflow-id",


### PR DESCRIPTION
Fixes https://github.com/langgenius/dify/issues/38655\n\nOpenJobs: https://openjobs.bot/jobs/b13fc23b-8eff-477a-afa3-79bdcd77f665\nListing ID: b13fc23b-8eff-477a-afa3-79bdcd77f665\nMentioning openjobs.bot as required.\n\nWhat changed:\n- Filter missing upstream Jinja variables before constructing LLM prompt inputs so absent branch outputs stay undefined in Jinja instead of crashing template preparation.\n- Added a regression test covering a branch-fed LLM prompt where one Jinja variable is present and one is missing.\n\nTesting notes:\n- uv run --project api --no-default-groups --group dev pytest api/tests/unit_tests/core/workflow/test_node_factory.py -q\n- Result: 55 passed, 2 warnings\n