### PR TITLE
fix(docker): use dynamic DNS resolution for all nginx upstreams

### DIFF
--- a/docker/nginx/conf.d/default.conf.template
+++ b/docker/nginx/conf.d/default.conf.template
@@ -3,19 +3,21 @@
 server {
     listen ${NGINX_PORT};
     server_name ${NGINX_SERVER_NAME};
+    resolver 127.0.0.11 valid=30s ipv6=off;
 
     location /console/api {
-      proxy_pass http://api:5001;
+      set $api_upstream api:5001;
+      proxy_pass http://$api_upstream;
       include proxy.conf;
     }
 
     location /api {
-      proxy_pass http://api:5001;
+      set $api_upstream api:5001;
+      proxy_pass http://$api_upstream;
       include proxy.conf;
     }
 
     location /socket.io/ {
-      resolver 127.0.0.11 valid=30s ipv6=off;
       set $socket_io_upstream ${NGINX_SOCKET_IO_UPSTREAM};
       proxy_pass http://$socket_io_upstream;
       include proxy.conf;
@@ -25,43 +27,51 @@ server {
     }
 
     location /v1 {
-      proxy_pass http://api:5001;
+      set $api_upstream api:5001;
+      proxy_pass http://$api_upstream;
       include proxy.conf;
     }
 
     location /openapi {
-      proxy_pass http://api:5001;
+      set $api_upstream api:5001;
+      proxy_pass http://$api_upstream;
       include proxy.conf;
     }
 
     location /files {
-      proxy_pass http://api:5001;
+      set $api_upstream api:5001;
+      proxy_pass http://$api_upstream;
       include proxy.conf;
     }
 
     location /explore {
-      proxy_pass http://web:3000;
+      set $web_upstream web:3000;
+      proxy_pass http://$web_upstream;
       include proxy.conf;
     }
 
     location /e/ {
-      proxy_pass http://plugin_daemon:5002;
+      set $plugin_daemon_upstream plugin_daemon:5002;
+      proxy_pass http://$plugin_daemon_upstream;
       proxy_set_header Dify-Hook-Url $scheme://$host$request_uri;
       include proxy.conf;
     }
 
     location / {
-      proxy_pass http://web:3000;
+      set $web_upstream web:3000;
+      proxy_pass http://$web_upstream;
       include proxy.conf;
     }
 
     location /mcp {
-      proxy_pass http://api:5001;
+      set $api_upstream api:5001;
+      proxy_pass http://$api_upstream;
       include proxy.conf;
     }
 
     location /triggers {
-      proxy_pass http://api:5001;
+      set $api_upstream api:5001;
+      proxy_pass http://$api_upstream;
       include proxy.conf;
     }
     


### PR DESCRIPTION
Apply the same resolver + variable proxy_pass pattern already used by /socket.io/ to api, web, and plugin_daemon upstreams. This prevents Nginx from caching incorrect upstream IPs when host DNS search domains resolve short service names to external addresses after restarts.

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #39154 

Fix 502 Bad Gateway errors caused by Nginx caching incorrect upstream IP addresses for Docker Compose service names (e.g. `api`, `web`) after container restarts.

**Problem:** When the host's DNS `search` domains cause short hostnames like `api` to resolve to external addresses instead of Docker embedded DNS, Nginx's static `proxy_pass http://api:5001` caches the wrong IP at startup permanently.

**Solution:** Apply the same dynamic DNS resolution pattern already used for `/socket.io/` to all upstream locations in `docker/nginx/conf.d/default.conf.template`:

- Add `resolver 127.0.0.11 valid=30s ipv6=off;` at server level
- Use variable-based `proxy_pass` for `api`, `web`, and `plugin_daemon` upstreams
- Remove duplicate resolver from `/socket.io/` location

**Test plan (manual, Docker Compose):**

- [x] Verified on production Docker Compose deployment (Dify 1.15.0)
- [x] `GET /console/api/system-features` returns 200 (not 502)
- [x] `GET /console/api/account/profile` returns 401 without token (not 502)
- [x] Multiple `docker compose restart nginx` — no regression

**Related issues:** #20914, #17004, #5822, #14054

No backend/frontend code changes. No new dependencies.

## Screenshots

N/A — infrastructure/nginx configuration change. Relevant log before fix:

```text
upstream: "http://47.110.173.36:5001/console/api/account/profile"
recv() failed (104: Connection reset by peer)
```

After fix, the same endpoints return 200/401 as expected.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
