### PR TITLE
fix(ops): include app_id in agent-chat message trace metadata (#38795)

### DIFF
--- a/api/core/ops/ops_trace_manager.py
+++ b/api/core/ops/ops_trace_manager.py
@@ -917,11 +917,17 @@ class TraceTask:
         message_data = get_message_data(message_id)
         if not message_data:
             return {}
-        conversation_mode_stmt = select(Conversation.mode).where(Conversation.id == message_data.conversation_id)
-        conversation_modes = db.session.scalars(conversation_mode_stmt).all()
-        if not conversation_modes or len(conversation_modes) == 0:
+        # Fetch both the conversation mode and its app_id. The conversation is the
+        # authoritative source of app_id for message traces (used by agent-chat and
+        # other chat-based app modes), so tracing integrations (Langfuse, LangSmith,
+        # Opik, etc.) can reliably identify which app produced a trace.
+        conversation_stmt = select(Conversation.mode, Conversation.app_id).where(
+            Conversation.id == message_data.conversation_id
+        )
+        conversation_rows = db.session.execute(conversation_stmt).all()
+        if not conversation_rows:
             return {}
-        conversation_mode = conversation_modes[0]
+        conversation_mode, conversation_app_id = conversation_rows[0]
         created_at = message_data.created_at
         inputs = message_data.message
 
@@ -959,7 +965,10 @@ class TraceTask:
             "from_source": message_data.from_source,
             "message_id": message_id,
             "tenant_id": tenant_id,
-            "app_id": message_data.app_id,
+            # Prefer the app_id from the Conversation lookup (authoritative for chat-based
+            # app modes such as agent-chat); fall back to the message's app_id when the
+            # conversation lookup did not yield one.
+            "app_id": conversation_app_id or message_data.app_id,
             "user_id": message_data.from_end_user_id or message_data.from_account_id,
             "app_name": app_name,
             "workspace_name": workspace_name,

--- a/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
+++ b/api/tests/unit_tests/core/ops/test_ops_trace_manager.py
@@ -245,7 +245,13 @@ def encryption_mocks(monkeypatch: pytest.MonkeyPatch):
 @pytest.fixture
 def mock_db(monkeypatch: pytest.MonkeyPatch):
     session = MagicMock()
-    session.scalars.return_value.all.return_value = ["chat"]
+    # The message_trace path queries the Conversation table via db.session.execute(...)
+    # for (mode, app_id) and consumes the result via .all(). Return a single row that
+    # mimics a chat-based (e.g. agent-chat) conversation owned by "app-id".
+    conversation_result = MagicMock()
+    conversation_result.all.return_value = [("chat", "app-id")]
+    session.execute.return_value = conversation_result
+    session.scalars.return_value.all.return_value = [("chat", "app-id")]
     db_mock = MagicMock()
     db_mock.session = session
     db_mock.engine = MagicMock()
@@ -459,6 +465,27 @@ def test_trace_task_message_trace(trace_task_message, mock_db):
     task = TraceTask(trace_type=TraceTaskName.MESSAGE_TRACE, message_id="msg-id")
     result = task.message_trace("msg-id")
     assert result.message_id == "msg-id"
+    # Regression for #38795: agent-chat (and other chat-based) message traces must
+    # include app_id in metadata so tracing integrations can identify the source app.
+    assert result.metadata["app_id"] == "app-id"
+
+
+def test_trace_task_message_trace_app_id_from_conversation(trace_task_message, mock_db):
+    """app_id must come from the Conversation lookup, even when message_data.app_id differs.
+
+    Reproduces #38795: tracing providers rely on app_id being present and accurate in
+    MessageTraceInfo metadata for agent-chat apps.
+    """
+    # Simulate a conversation owned by a different app than the (stale) message app_id.
+    conversation_result = MagicMock()
+    conversation_result.all.return_value = [("agent-chat", "conversation-app-id")]
+    mock_db.execute.return_value = conversation_result
+    mock_db.scalars.return_value.all.return_value = [("agent-chat", "conversation-app-id")]
+
+    task = TraceTask(trace_type=TraceTaskName.MESSAGE_TRACE, message_id="msg-id")
+    result = task.message_trace("msg-id")
+    assert result.metadata["app_id"] == "conversation-app-id"
+    assert result.metadata["conversation_id"] == "conv-id"
 
 
 def test_trace_task_workflow_trace(workflow_repo_fixture, mock_db):


### PR DESCRIPTION
## Summary

Fixes https://github.com/langgenius/dify/issues/38795 — agent-chat (and other chat-based) app modes were missing app_id in their trace metadata, so Langfuse/LangSmith/Opik/Weave integrations could not identify which Dify app produced a trace.

The code already queried the Conversation table for mode; this change extends that lookup to also fetch app_id and uses it as the app_id in MessageTraceInfo metadata (falling back to message_data.app_id when the conversation lookup yields none). This matches the behaviour already present for advanced-chat (WorkflowTraceInfo).

### Changes
- api/core/ops/ops_trace_manager.py: extend the Conversation query to fetch (mode, app_id); set metadata app_id from conversation.app_id or message_data.app_id.
- api/tests/unit_tests/core/ops/test_ops_trace_manager.py: regression tests asserting app_id is present in message trace metadata and is sourced from the conversation lookup.

## Test plan
- pytest tests/unit_tests/core/ops/test_ops_trace_manager.py — all 34 tests pass, including the two new regression tests for #38795.
- New tests: test_trace_task_message_trace (asserts metadata["app_id"] == "app-id") and test_trace_task_message_trace_app_id_from_conversation (asserts app_id is taken from the Conversation lookup even when message_data.app_id differs).

## OpenJobs
- Listing: https://openjobs.bot/jobs/0641c27f-a3f3-4938-8314-3bb9d847d636
- bot: openjobs.bot