### PR TITLE
fix(workflow): tolerate absent upstream jinja2 variables in LLM nodes (#38655)

### DIFF
--- a/api/core/workflow/node_factory.py
+++ b/api/core/workflow/node_factory.py
@@ -109,11 +109,68 @@ def _import_node_package(package_name: str, *, excluded_modules: frozenset[str] 
         importlib.import_module(module_name)
 
 
+def _patch_graphon_jinja_variable_tolerance() -> None:
+    """Make ``LLMNode`` tolerate jinja2 variables that are absent at run time.
+
+    Issue #38655: when a conditional branch feeds an LLM node whose Jinja2
+    template guards a variable with ``{% if var is defined and var %}``, Dify
+    crashed *before* template evaluation with ``Variable <name> not found``.
+    The crash came from graphon's ``LLMNode._fetch_jinja_inputs`` which raises
+    ``VariableNotFoundError`` for every entry in ``prompt_config.jinja2_variables``
+    whose upstream selector is missing from the variable pool.
+
+    graphon's own renderer (``_render_jinja2_message``) already treats a missing
+    variable as an empty string, so the only behaviour that actually depends on
+    the collected mapping is the strict pre-check. We replace that pre-check with
+    one that tolerates an absent upstream variable: an omitted selector simply
+    resolves to an empty string during rendering, which makes the user-written
+    ``is defined`` guard decide whether the branch renders. This keeps every
+    existing "variable truly required" path intact (prompt-template inputs,
+    context, memory) while letting optional jinja2 variables fail soft.
+
+    graphon is an external pinned dependency, so we monkey-patch the live class
+    once at registration time rather than fork the package.
+    """
+    from graphon.nodes.base.entities import VariableSelector
+    from graphon.nodes.llm.entities import LLMNodeData
+    from graphon.nodes.llm.node import LLMNode
+
+    if getattr(LLMNode._fetch_jinja_inputs, "_dify_missing_var_patched", False):
+        return
+
+    original_fetch = LLMNode._fetch_jinja_inputs
+
+    def _patched_fetch_jinja_inputs(self, node_data: LLMNodeData) -> dict[str, str]:
+        if not node_data.prompt_config:
+            return {}
+
+        variables: dict[str, str] = {}
+        for variable_selector in node_data.prompt_config.jinja2_variables or []:
+            variable = self.graph_runtime_state.variable_pool.get(
+                variable_selector.value_selector
+            )
+            if variable is None:
+                # Absent upstream variable: tolerate it so user-authored
+                # ``{% if <var> is defined %}`` guards work as expected.
+                continue
+            variables[variable_selector.variable] = self._stringify_jinja_variable(variable)
+        return variables
+
+    # Preserve introspectability / test references.
+    _patched_fetch_jinja_inputs._dify_missing_var_patched = True  # type: ignore[attr-defined]
+    _patched_fetch_jinja_inputs.__wrapped__ = original_fetch  # type: ignore[attr-defined]
+    LLMNode._fetch_jinja_inputs = _patched_fetch_jinja_inputs  # type: ignore[misc]
+
+
 @lru_cache(maxsize=1)
 def register_nodes() -> None:
     """Import production node modules so they self-register with ``Node``."""
     _import_node_package("graphon.nodes")
     _import_node_package("core.workflow.nodes")
+    # Issue #38655: tolerate absent upstream jinja2 variables in LLM nodes so
+    # user-authored ``{% if var is defined %}`` guards work instead of crashing
+    # with ``Variable <name> not found``.
+    _patch_graphon_jinja_variable_tolerance()
 
 
 def get_node_type_classes_mapping() -> Mapping[NodeType, Mapping[str, type[Node]]]:

--- a/api/tests/unit_tests/core/workflow/nodes/llm/test_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/llm/test_node.py
@@ -895,7 +895,11 @@ def test_fetch_jinja_inputs_serializes_supported_segment_types(llm_node):
     }
 
 
-def test_fetch_jinja_inputs_raises_for_missing_variable(llm_node):
+def test_fetch_jinja_inputs_tolerates_missing_variable(llm_node):
+    from core.workflow import node_factory as _node_factory
+
+    _node_factory.register_nodes()
+
     node_data = llm_node.node_data.model_copy(
         update={
             "prompt_config": PromptConfig(
@@ -904,8 +908,12 @@ def test_fetch_jinja_inputs_raises_for_missing_variable(llm_node):
         }
     )
 
-    with pytest.raises(VariableNotFoundError, match="Variable missing not found"):
-        llm_node._fetch_jinja_inputs(node_data)
+    # Issue #38655: an absent upstream variable must NOT crash the node with
+    # ``VariableNotFoundError``. The user-authored ``{% if missing is defined %}``
+    # guard should decide whether the branch renders instead.
+    result = llm_node._fetch_jinja_inputs(node_data)
+
+    assert result == {}
 
 
 def test_fetch_inputs_collects_prompt_and_memory_variables(llm_node):

--- a/api/tests/unit_tests/core/workflow/test_node_factory.py
+++ b/api/tests/unit_tests/core/workflow/test_node_factory.py
@@ -1155,3 +1155,78 @@ class TestDifyNodeFactoryMemory:
             node_data_memory=memory_config,
             model_instance=sentinel.model_instance,
         )
+
+
+class TestJinjaMissingVariableTolerance:
+    """Regression coverage for issue #38655.
+
+    When a conditional branch feeds an LLM node whose Jinja2 template guards an
+    optional upstream variable with ``{% if var is defined and var %}``, Dify must
+    NOT crash with ``Variable <name> not found``. ``LLMNode._fetch_jinja_inputs``
+    is patched by ``register_nodes()`` (see ``_patch_graphon_jinja_variable_tolerance``)
+    so that absent upstream variables are tolerated and the user-authored ``is
+    defined`` guard decides whether the branch renders.
+    """
+
+    @staticmethod
+    def _make_llm_node(*, jinja2_variables):
+        node_factory.register_nodes()
+        from graphon.nodes.base.entities import VariableSelector
+        from graphon.nodes.llm.entities import LLMNodeData, PromptConfig
+
+        node_data = LLMNodeData.model_validate(
+            {
+                "type": BuiltinNodeTypes.LLM,
+                "title": "LLM",
+                "model": {"provider": "provider", "name": "model", "mode": "chat", "completion_params": {}},
+                "prompt_template": [{"role": "system", "text": "x"}],
+                "context": {"enabled": False, "variable_selector": []},
+                "vision": {"enabled": False},
+                "prompt_config": PromptConfig(
+                    jinja2_variables=[
+                        VariableSelector(variable=v.variable, value_selector=list(v.value_selector))
+                        for v in jinja2_variables
+                    ]
+                ),
+            }
+        )
+        node = LLMNode.__new__(LLMNode)
+        variable_pool = MagicMock()
+        variable_pool.get.side_effect = lambda selector: {
+            ("present_node", "present"): StringSegment(value="hello"),
+        }.get(tuple(selector))
+        node.graph_runtime_state = SimpleNamespace(variable_pool=variable_pool)
+        node._stringify_jinja_variable = LLMNode._stringify_jinja_variable
+        return node, node_data
+
+    def test_absent_jinja_variable_is_tolerated(self):
+        from graphon.nodes.llm.exc import VariableNotFoundError
+
+        node, node_data = self._make_llm_node(
+            jinja2_variables=[
+                SimpleNamespace(variable="present", value_selector=("present_node", "present")),
+                SimpleNamespace(variable="missing", value_selector=("missing_node", "missing")),
+            ]
+        )
+
+        # Must not raise VariableNotFoundError for the absent upstream variable.
+        try:
+            result = node._fetch_jinja_inputs(node_data=node_data)
+        except VariableNotFoundError:
+            pytest.fail("VariableNotFoundError raised for an absent optional jinja2 variable (#38655)")
+
+        assert "present" in result
+        assert "missing" not in result
+
+    def test_only_present_variables_collected(self):
+        node, node_data = self._make_llm_node(
+            jinja2_variables=[
+                SimpleNamespace(variable="present", value_selector=("present_node", "present")),
+                SimpleNamespace(variable="missing", value_selector=("missing_node", "missing")),
+            ]
+        )
+
+        result = node._fetch_jinja_inputs(node_data=node_data)
+
+        assert result == {"present": "hello"}
+        assert "missing" not in result


### PR DESCRIPTION
## Summary

Fixes https://github.com/langgenius/dify/issues/38655 — when a conditional branch feeds an LLM node whose Jinja2 template guards an optional upstream variable with `{% if var is defined and var %}`, Dify crashed **before** template evaluation with `Variable <name> not found`.

The crash originated in graphon's `LLMNode._fetch_jinja_inputs`, which raised `VariableNotFoundError` for every entry in `prompt_config.jinja2_variables` whose upstream selector was missing from the variable pool. graphon's own renderer (`_render_jinja2_message`) already treats a missing variable as an empty string, so the strict pre-check was the only thing failing.

## Fix

Patch graphon's `LLMNode._fetch_jinja_inputs` at node-registration time (`register_nodes` in `api/core/workflow/node_factory.py`) so an absent upstream jinja2 variable is tolerated and skipped instead of raising. The user-authored `is defined` guard now decides whether the branch renders — exactly as the issue requests.

- graphon is an external pinned dependency (`graphon==0.6.0`), so we monkey-patch the live class once at registration time rather than fork the package.
- Prompt-template inputs, context and memory paths are unchanged (still required).
- The patch is idempotent (guarded by a marker attribute).

## Testing notes

Unit tests added / updated:
- `api/tests/unit_tests/core/workflow/test_node_factory.py::TestJinjaMissingVariableTolerance`
  - `test_absent_jinja_variable_is_tolerated`: absent jinja2 variable no longer raises `VariableNotFoundError`; present variables still collected.
  - `test_only_present_variables_collected`: only present upstream variables are returned in the jinja input mapping.
- `api/tests/unit_tests/core/workflow/nodes/llm/test_node.py`
  - Updated `test_fetch_jinja_inputs_raises_for_missing_variable` -> `test_fetch_jinja_inputs_tolerates_missing_variable` to assert the new intended behavior (returns `{}` instead of raising).

Run with:
```
uv run --project api --python 3.12 --no-default-groups --group dev --group storage --group tools --group trace-all pytest api/tests/unit_tests/core/workflow/test_node_factory.py::TestJinjaMissingVariableTolerance api/tests/unit_tests/core/workflow/nodes/llm/test_node.py -k jinja -q
```
Result: all green (the regression suite for the LLM node jinja path passes).

## OpenJobs

- openjobs.bot
- https://openjobs.bot/jobs/b13fc23b-8eff-477a-afa3-79bdcd77f665
- b13fc23b-8eff-477a-afa3-79bdcd77f665

Refs: https://github.com/langgenius/dify/issues/38655
