### PR TITLE
fix(weaviate): delete vectors by document ID

### DIFF
--- a/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel, model_validator
 from weaviate.classes.data import DataObject
 from weaviate.classes.init import Auth
 from weaviate.classes.query import Filter, MetadataQuery
-from weaviate.exceptions import UnexpectedStatusCodeError, WeaviateQueryError
+from weaviate.exceptions import WeaviateQueryError
 
 from configs import dify_config
 from core.rag.datasource.vdb.field import Field
@@ -278,22 +278,6 @@ class WeaviateVector(BaseVector):
                 logger.warning("Could not add property %s: %s", prop.name, e)
 
     @override
-    def _get_uuids(self, documents: list[Document]) -> list[str]:
-        """
-        Generates deterministic UUIDs for documents based on their content.
-
-        Uses UUID5 with URL namespace to ensure consistent IDs for identical content.
-        """
-        URL_NAMESPACE = _uuid.UUID("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
-
-        uuids = []
-        for doc in documents:
-            uuid_val = _uuid.uuid5(URL_NAMESPACE, doc.page_content)
-            uuids.append(str(uuid_val))
-
-        return uuids
-
-    @override
     def add_texts(self, documents: list[Document], embeddings: list[list[float]], **kwargs):
         """
         Adds documents with their embeddings to the collection.
@@ -377,21 +361,16 @@ class WeaviateVector(BaseVector):
     @override
     def delete_by_ids(self, ids: list[str]) -> None:
         """
-        Deletes objects by their UUID identifiers.
+        Deletes objects by their Dify document IDs.
 
-        Silently ignores 404 errors for non-existent IDs.
+        Filtering on the stored ``doc_id`` also removes objects created when
+        Weaviate object UUIDs were derived from document content.
         """
-        if not self._client.collections.exists(self._collection_name):
+        if not ids or not self._client.collections.exists(self._collection_name):
             return
 
         col = self._client.collections.use(self._collection_name)
-
-        for uid in ids:
-            try:
-                col.data.delete_by_id(uid)
-            except UnexpectedStatusCodeError as e:
-                if getattr(e, "status_code", None) != 404:
-                    raise
+        col.data.delete_many(where=Filter.by_property("doc_id").contains_any(ids))
 
     @override
     def search_by_vector(self, query_vector: list[float], **kwargs: Any) -> list[Document]:

--- a/api/providers/vdb/vdb-weaviate/tests/integration_tests/test_weaviate.py
+++ b/api/providers/vdb/vdb-weaviate/tests/integration_tests/test_weaviate.py
@@ -18,6 +18,12 @@ class WeaviateVectorTest(AbstractVectorTest):
             attributes=self.attributes,
         )
 
+    def delete_by_ids(self, ids: list[str]) -> None:
+        super().delete_by_ids(ids)
+
+        assert not self.vector.text_exists(ids[0])
+        assert not self.vector.text_exists(ids[-1])
+
 
 def test_weaviate_vector(setup_mock_redis):
     WeaviateVectorTest().run_all_tests()

--- a/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
@@ -759,6 +759,17 @@ class TestWeaviateVector(unittest.TestCase):
         assert wv._is_uuid("123e4567-e89b-12d3-a456-426614174000") is True
         assert wv._is_uuid("not-a-uuid") is False
 
+    def test_get_uuids_uses_doc_ids_when_documents_have_identical_content(self):
+        wv = WeaviateVector.__new__(WeaviateVector)
+        first_doc_id = "123e4567-e89b-12d3-a456-426614174000"
+        second_doc_id = "123e4567-e89b-12d3-a456-426614174001"
+        documents = [
+            Document(page_content="identical content", metadata={"doc_id": first_doc_id}),
+            Document(page_content="identical content", metadata={"doc_id": second_doc_id}),
+        ]
+
+        assert wv._get_uuids(documents) == [first_doc_id, second_doc_id]
+
     def test_delete_by_metadata_field_returns_when_collection_is_missing(self):
         wv = WeaviateVector.__new__(WeaviateVector)
         wv._collection_name = self.collection_name
@@ -803,45 +814,41 @@ class TestWeaviateVector(unittest.TestCase):
         assert wv.text_exists("segment-1") is False
         assert wv.text_exists("segment-1") is True
 
-    def test_delete_by_ids_handles_missing_collections_and_404s(self):
-        class FakeUnexpectedStatusCodeError(Exception):
-            def __init__(self, status_code):
-                super().__init__(f"status={status_code}")
-                self.status_code = status_code
-
+    def test_delete_by_ids_returns_for_empty_ids_or_missing_collection(self):
         wv = WeaviateVector.__new__(WeaviateVector)
         wv._collection_name = self.collection_name
         wv._client = MagicMock()
-        wv._client.collections.exists.side_effect = [False, True]
-        mock_col = MagicMock()
-        wv._client.collections.use.return_value = mock_col
-        mock_col.data.delete_by_id.side_effect = [FakeUnexpectedStatusCodeError(404), None]
 
-        with patch.object(weaviate_vector_module, "UnexpectedStatusCodeError", FakeUnexpectedStatusCodeError):
-            wv.delete_by_ids(["ignored"])
-            wv.delete_by_ids(["missing-id", "ok-id"])
+        wv.delete_by_ids([])
 
-        assert mock_col.data.delete_by_id.call_count == 2
+        wv._client.collections.exists.assert_not_called()
 
-    def test_delete_by_ids_reraises_non_404_errors(self):
-        class FakeUnexpectedStatusCodeError(Exception):
-            def __init__(self, status_code):
-                super().__init__(f"status={status_code}")
-                self.status_code = status_code
+        wv._client.collections.exists.return_value = False
+        wv.delete_by_ids(["missing-id"])
 
+        wv._client.collections.use.assert_not_called()
+
+    def test_delete_by_ids_deletes_objects_by_doc_id_property(self):
         wv = WeaviateVector.__new__(WeaviateVector)
         wv._collection_name = self.collection_name
         wv._client = MagicMock()
         wv._client.collections.exists.return_value = True
         mock_col = MagicMock()
         wv._client.collections.use.return_value = mock_col
-        mock_col.data.delete_by_id.side_effect = FakeUnexpectedStatusCodeError(500)
+        ids = ["segment-1", "segment-2"]
+        expected_filter = object()
 
-        with (
-            patch.object(weaviate_vector_module, "UnexpectedStatusCodeError", FakeUnexpectedStatusCodeError),
-            pytest.raises(FakeUnexpectedStatusCodeError, match="status=500"),
-        ):
-            wv.delete_by_ids(["bad-id"])
+        with patch.object(weaviate_vector_module.Filter, "by_property") as mock_by_property:
+            mock_property_filter = MagicMock()
+            mock_by_property.return_value = mock_property_filter
+            mock_property_filter.contains_any.return_value = expected_filter
+
+            wv.delete_by_ids(ids)
+
+        mock_by_property.assert_called_once_with("doc_id")
+        mock_property_filter.contains_any.assert_called_once_with(ids)
+        mock_col.data.delete_many.assert_called_once_with(where=expected_filter)
+        mock_col.data.delete_by_id.assert_not_called()
 
     def test_json_serializable_converts_datetime(self):
         wv = WeaviateVector.__new__(WeaviateVector)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #39175

GitHub did not allow the external issue author to self-assign #39175, so maintainer assignment is still needed.

This PR fixes an identity mismatch in the Weaviate adapter:

- New objects now inherit `BaseVector._get_uuids()` and use the segment `doc_id` instead of a UUID derived only from `page_content`.
- `delete_by_ids()` deletes by the stored `doc_id` property instead of treating logical segment IDs as Weaviate object UUIDs.
- Property-based deletion also removes legacy objects whose UUIDs were derived from content.
- Regression coverage verifies deletion and prevents identical text from overwriting segments with different IDs.

This also addresses the storage collision described in #36137. Unlike the existing proposal in #36140, it aligns Weaviate with the shared `BaseVector` identity contract and fixes deletion of both new and legacy objects.

## Screenshots

Not applicable; this is a backend vector-store fix.

## Validation

- `make test TARGET_TESTS=./api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py` — 40 passed.
- Targeted `ruff format --check` and `ruff check` for the three changed files — passed.
- The Weaviate integration test was attempted against an existing local stack, but that stack does not expose gRPC port `50051`; the run timed out during batch insertion. The temporary test collection was removed. The regression assertion is included for CI's Docker-backed Weaviate test environment.
- Targeted Pyrefly reported four existing errors in unchanged lines of `weaviate_vector.py`; no error points to this diff.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

