### PR TITLE
fix(api): close TOCTOU race in RateLimit.enter()

### DIFF
--- a/api/core/app/features/rate_limiting/rate_limit.py
+++ b/api/core/app/features/rate_limiting/rate_limit.py
@@ -8,8 +8,21 @@ from typing import Any, Union
 
 from core.errors.error import AppInvokeQuotaExceededError
 from extensions.ext_redis import redis_client
+from extensions.redis_names import get_redis_key_prefix, serialize_redis_name_arg
 
 logger = logging.getLogger(__name__)
+
+# Atomically checks the active-request count against the cap and, if there is room,
+# registers the new request in the same round trip. Doing this check-and-set in Lua
+# closes the race where two concurrent HLEN checks could both pass before either HSET lands.
+_ENTER_SCRIPT = """
+local count = redis.call('HLEN', KEYS[1])
+if count >= tonumber(ARGV[1]) then
+    return 0
+end
+redis.call('HSET', KEYS[1], ARGV[2], ARGV[3])
+return 1
+"""
 
 
 class RateLimit:
@@ -78,13 +91,15 @@ class RateLimit:
         if not request_id:
             request_id = RateLimit.gen_request_key()
 
-        active_requests_count = redis_client.hlen(self.active_requests_key)
-        if active_requests_count >= self.max_active_requests:
+        prefixed_key = serialize_redis_name_arg(self.active_requests_key, get_redis_key_prefix())
+        admitted = redis_client.eval(
+            _ENTER_SCRIPT, 1, prefixed_key, self.max_active_requests, request_id, str(time.time())
+        )
+        if not admitted:
             raise AppInvokeQuotaExceededError(
                 f"Too many requests. Please try again later. The current maximum concurrent requests allowed "
                 f"for {self.client_id} is {self.max_active_requests}."
             )
-        redis_client.hset(self.active_requests_key, request_id, str(time.time()))
         return request_id
 
     def exit(self, request_id: str):

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -3374,12 +3374,12 @@ class SegmentService:
                     segment_document.word_count += len(args["answer"])
                     segment_document.answer = args["answer"]
 
-            session.add(segment_document)
-            # update document word count
-            assert document.word_count is not None
-            document.word_count += segment_document.word_count
-            session.add(document)
-            session.commit()
+                session.add(segment_document)
+                # update document word count
+                assert document.word_count is not None
+                document.word_count += segment_document.word_count
+                session.add(document)
+                session.commit()
 
             if args["attachment_ids"]:
                 for attachment_id in args["attachment_ids"]:

--- a/api/tests/unit_tests/core/app/features/rate_limiting/test_rate_limit.py
+++ b/api/tests/unit_tests/core/app/features/rate_limiting/test_rate_limit.py
@@ -194,8 +194,7 @@ class TestRateLimitEnterExit:
             **{
                 "exists.return_value": False,
                 "setex.return_value": True,
-                "hlen.return_value": 2,
-                "hset.return_value": True,
+                "eval.return_value": 1,
             }
         )
 
@@ -203,7 +202,7 @@ class TestRateLimitEnterExit:
         request_id = rate_limit.enter()
 
         assert request_id != RateLimit._UNLIMITED_REQUEST_ID
-        redis_patch.hset.assert_called_once()
+        redis_patch.eval.assert_called_once()
 
     def test_should_generate_request_id_if_not_provided(self, redis_patch):
         """Test auto-generation of request ID."""
@@ -211,8 +210,7 @@ class TestRateLimitEnterExit:
             **{
                 "exists.return_value": False,
                 "setex.return_value": True,
-                "hlen.return_value": 0,
-                "hset.return_value": True,
+                "eval.return_value": 1,
             }
         )
 
@@ -227,8 +225,7 @@ class TestRateLimitEnterExit:
             **{
                 "exists.return_value": False,
                 "setex.return_value": True,
-                "hlen.return_value": 0,
-                "hset.return_value": True,
+                "eval.return_value": 1,
             }
         )
 
@@ -257,7 +254,7 @@ class TestRateLimitEnterExit:
             **{
                 "exists.return_value": False,
                 "setex.return_value": True,
-                "hlen.return_value": 5,  # At limit
+                "eval.return_value": 0,  # At limit: the atomic script refuses admission
             }
         )
 
@@ -275,8 +272,7 @@ class TestRateLimitEnterExit:
             **{
                 "exists.return_value": False,
                 "setex.return_value": True,
-                "hlen.return_value": 4,  # Under limit after exit
-                "hset.return_value": True,
+                "eval.return_value": 1,  # Under limit after exit
                 "hdel.return_value": 1,
             }
         )
@@ -296,7 +292,7 @@ class TestRateLimitEnterExit:
             **{
                 "exists.return_value": False,
                 "setex.return_value": True,
-                "hlen.return_value": 0,
+                "eval.return_value": 1,
             }
         )
 
@@ -484,25 +480,29 @@ class TestRateLimitConcurrency:
         assert len({id(inst) for inst in instances}) == 1  # All same instance
 
     def test_should_handle_concurrent_enter_requests(self, redis_patch):
-        """Test concurrent enter requests handling."""
-        # Setup mock to simulate realistic Redis behavior
-        request_count = 0
+        """Test concurrent enter requests handling.
 
-        def mock_hlen(key):
-            nonlocal request_count
-            return request_count
+        The mocked `eval` reproduces the atomicity the real Lua script gets for free from
+        Redis's single-threaded command execution: the check-and-increment happens under a
+        single lock, so the number of admitted requests can never exceed max_active_requests
+        even when many threads race to call enter() at once.
+        """
+        lock = threading.Lock()
+        hashes: dict[str, dict] = {}
 
-        def mock_hset(key, field, value):
-            nonlocal request_count
-            request_count += 1
-            return True
+        def mock_eval(script, numkeys, key, max_active_requests, field, value):
+            with lock:
+                bucket = hashes.setdefault(key, {})
+                if len(bucket) >= int(max_active_requests):
+                    return 0
+                bucket[field] = value
+                return 1
 
         redis_patch.configure_mock(
             **{
                 "exists.return_value": False,
                 "setex.return_value": True,
-                "hlen.side_effect": mock_hlen,
-                "hset.side_effect": mock_hset,
+                "eval.side_effect": mock_eval,
             }
         )
 
@@ -527,6 +527,8 @@ class TestRateLimitConcurrency:
         # Should have some successful requests and some quota exceeded
         assert len(results) + len(errors) == 5
         assert len(errors) > 0  # Some should be rejected
+        # The core regression check: admitted requests must never exceed the configured cap.
+        assert len(results) == 3
 
     @patch("time.time")
     def test_should_maintain_accurate_count_under_load(self, mock_time, redis_patch):
@@ -539,14 +541,20 @@ class TestRateLimitConcurrency:
 
         rate_limit = RateLimit("load_test_client", 10)
         active_requests = []
+        max_observed_concurrency = 0
+        observed_lock = threading.Lock()
 
         def enter_and_exit():
+            nonlocal max_observed_concurrency
             try:
                 request_id = rate_limit.enter()
-                active_requests.append(request_id)
+                with observed_lock:
+                    active_requests.append(request_id)
+                    max_observed_concurrency = max(max_observed_concurrency, len(active_requests))
                 time.sleep(0.01)  # Simulate some work
                 rate_limit.exit(request_id)
-                active_requests.remove(request_id)
+                with observed_lock:
+                    active_requests.remove(request_id)
             except AppInvokeQuotaExceededError:
                 pass  # Expected under load
 
@@ -559,25 +567,23 @@ class TestRateLimitConcurrency:
 
         # All requests should have been cleaned up
         assert len(active_requests) == 0
+        # The cap must hold at every point in time, not just at the end.
+        assert max_observed_concurrency <= 10
 
     def _create_mock_redis(self):
         """Create a thread-safe mock Redis for concurrency tests."""
         import threading
 
         lock = threading.Lock()
-        data = {}
         hashes = {}
 
-        def mock_hlen(key):
+        def mock_eval(script, numkeys, key, max_active_requests, field, value):
             with lock:
-                return len(hashes.get(key, {}))
-
-        def mock_hset(key, field, value):
-            with lock:
-                if key not in hashes:
-                    hashes[key] = {}
-                hashes[key][field] = str(value).encode("utf-8")
-                return True
+                bucket = hashes.setdefault(key, {})
+                if len(bucket) >= int(max_active_requests):
+                    return 0
+                bucket[field] = str(value).encode("utf-8")
+                return 1
 
         def mock_hdel(key, *fields):
             with lock:
@@ -593,7 +599,6 @@ class TestRateLimitConcurrency:
         return {
             "exists.return_value": False,
             "setex.return_value": True,
-            "hlen.side_effect": mock_hlen,
-            "hset.side_effect": mock_hset,
+            "eval.side_effect": mock_eval,
             "hdel.side_effect": mock_hdel,
         }

--- a/api/tests/unit_tests/services/test_dataset_service_segment.py
+++ b/api/tests/unit_tests/services/test_dataset_service_segment.py
@@ -526,6 +526,63 @@ class TestSegmentServiceMutations:
         assert {binding.attachment_id for binding in attachment_bindings} == {"att-1", "att-2"}
         assert mock_db.session.commit.call_count == 3
 
+    def test_create_segment_commits_before_releasing_position_lock(self, account_context):
+        """The read-check-insert-commit sequence must be fully covered by the redis lock.
+
+        Regression test for a race where `session.add`/`session.commit` sat outside the
+        `with redis_client.lock(...)` block, so two concurrent callers could read the same
+        `max_position` and commit segments with duplicate positions.
+        """
+        dataset = _make_dataset(indexing_technique="economy")
+        document = _make_document(
+            dataset_id=dataset.id,
+            tenant_id=dataset.tenant_id,
+            doc_form=IndexStructureType.QA_INDEX,
+            word_count=0,
+        )
+        args = {
+            "content": "question",
+            "answer": "answer",
+            "keywords": ["kw-1"],
+            "attachment_ids": [],
+        }
+
+        class RecordingLock:
+            def __init__(self, session: MagicMock):
+                self._session = session
+                self.commit_count_at_exit: int | None = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self.commit_count_at_exit = self._session.commit.call_count
+                return False
+
+        with (
+            patch("services.dataset_service.redis_client") as mock_redis,
+            patch("services.dataset_service.db") as mock_db,
+            patch("services.dataset_service.VectorService") as vector_service,
+            patch("services.dataset_service.helper.generate_text_hash", return_value="hash-1"),
+            patch("services.dataset_service.uuid.uuid4", return_value="node-1"),
+            patch("services.dataset_service.naive_utc_now", return_value="now"),
+        ):
+            recording_lock = RecordingLock(mock_db.session)
+            mock_redis.lock.return_value = recording_lock
+
+            mock_db.session.scalar.return_value = None
+            mock_db.session.get.return_value = SimpleNamespace(id="segment-1")
+
+            SegmentService.create_segment(
+                args=args,
+                document=document,
+                dataset=dataset,
+                session=mock_db.session,
+            )
+
+        assert recording_lock.commit_count_at_exit is not None
+        assert recording_lock.commit_count_at_exit >= 1
+
     def test_multi_create_segment_high_quality_marks_segments_error_when_vector_creation_fails(self, account_context):
         dataset = _make_dataset(indexing_technique="high_quality")
         document = _make_document(

--- a/api/tests/unit_tests/services/test_dataset_service_segment.py
+++ b/api/tests/unit_tests/services/test_dataset_service_segment.py
@@ -559,25 +559,26 @@ class TestSegmentServiceMutations:
                 self.commit_count_at_exit = self._session.commit.call_count
                 return False
 
+        session = MagicMock()
+
         with (
             patch("services.dataset_service.redis_client") as mock_redis,
-            patch("services.dataset_service.db") as mock_db,
-            patch("services.dataset_service.VectorService") as vector_service,
+            patch("services.dataset_service.VectorService"),
             patch("services.dataset_service.helper.generate_text_hash", return_value="hash-1"),
             patch("services.dataset_service.uuid.uuid4", return_value="node-1"),
             patch("services.dataset_service.naive_utc_now", return_value="now"),
         ):
-            recording_lock = RecordingLock(mock_db.session)
+            recording_lock = RecordingLock(session)
             mock_redis.lock.return_value = recording_lock
 
-            mock_db.session.scalar.return_value = None
-            mock_db.session.get.return_value = SimpleNamespace(id="segment-1")
+            session.scalar.return_value = None
+            session.get.return_value = SimpleNamespace(id="segment-1")
 
             SegmentService.create_segment(
                 args=args,
                 document=document,
                 dataset=dataset,
-                session=mock_db.session,
+                session=session,
             )
 
         assert recording_lock.commit_count_at_exit is not None


### PR DESCRIPTION
## Summary

Fixes #39177.

Two check-then-act concurrency races where a read and its dependent write were not covered by a single atomic operation, so concurrent callers could both observe the pre-write state and both act on it.

### 1. `RateLimit.enter()` — unsynchronized `HLEN` / `HSET`

`api/core/app/features/rate_limiting/rate_limit.py` enforced the per-app concurrency cap with two separate Redis round trips: `hlen()` to compare the active-request count against `max_active_requests`, then `hset()` to register the request. Nothing held between them, so under load N callers could all read a count below the cap before any of them wrote, and all N were admitted — letting active requests exceed the configured maximum.

The check and the write now happen in one Lua script (`_ENTER_SCRIPT`), which Redis executes single-threaded, so no other client can interleave:

```diff
-        active_requests_count = redis_client.hlen(self.active_requests_key)
-        if active_requests_count >= self.max_active_requests:
+        prefixed_key = serialize_redis_name_arg(self.active_requests_key, get_redis_key_prefix())
+        admitted = redis_client.eval(
+            _ENTER_SCRIPT, 1, prefixed_key, self.max_active_requests, request_id, str(time.time())
+        )
+        if not admitted:
             raise AppInvokeQuotaExceededError(...)
-        redis_client.hset(self.active_requests_key, request_id, str(time.time()))
```

One subtlety worth a reviewer's attention: `eval` is **not** wrapped by `RedisClientWrapper`, unlike `hlen`/`hset`, which auto-prefix their keys. The key is therefore prefixed manually using the same `serialize_redis_name_arg` / `get_redis_key_prefix` helpers the wrapper uses internally, so `REDIS_KEY_PREFIX` keeps working exactly as before.

### 2. `SegmentService.create_segment()` — commit outside the position lock

`api/services/dataset_service.py` guards segment-position assignment with `redis_client.lock(f"add_segment_lock_document_id_{document.id}")`. The `max_position` read sat inside that lock, but `session.add(segment_document)` and `session.commit()` sat **outside** it — so the lock was released before the row was durable. Two concurrent callers could each read the same `max_position` and then commit segments with duplicate positions.

The fix indents the add/commit into the `with` block, so the full read → compute → insert → commit sequence is covered by the lock.

## Changes

- `rate_limit.py` — replace the `hlen` + `hset` pair with an atomic `eval` of `_ENTER_SCRIPT`; prefix the key manually since `eval` bypasses the wrapper.
- `dataset_service.py` — move the segment `add`/`commit` inside the existing document lock (indentation only; no logic change).
- Tests for both, described below.

## Tests

**Rate limit** — existing tests mocked `hlen`/`hset` and were updated to mock `eval`. More importantly, `test_should_handle_concurrent_enter_requests` previously used a mock whose `hlen`/`hset` pair reproduced the very race being fixed, and only asserted that *some* requests were rejected. The mock now emulates what Redis gives the real script for free — a lock around the check-and-set — and the test asserts the exact admitted count (`len(results) == 3`), which is the actual regression: admitted requests must never exceed the cap.

**Segment lock** — new `test_create_segment_commits_before_releasing_position_lock` installs a recording lock object that captures `session.commit.call_count` at `__exit__`, then asserts at least one commit had already landed before the lock was released. That fails against the pre-fix code, where the count at exit is 0.

## Screenshots

Not applicable — backend-only concurrency fix, no UI change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods

No new dependencies.
