### PR TITLE
fix(api): return 400 instead of 500 when 'file' is missing from installed-app audio transcription

### DIFF
--- a/api/controllers/console/explore/audio.py
+++ b/api/controllers/console/explore/audio.py
@@ -54,7 +54,7 @@ class ChatAudioApi(InstalledAppResource):
         if app_model is None:
             raise AppUnavailableError()
 
-        file = request.files["file"]
+        file = request.files.get("file")
 
         try:
             response = AudioService.transcript_asr(

--- a/api/tests/unit_tests/controllers/console/explore/test_audio.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_audio.py
@@ -76,6 +76,15 @@ class TestChatAudioApi:
 
         assert resp == {"text": "ok"}
 
+    def test_post_missing_file_returns_no_audio_uploaded(self, app: Flask, installed_app):
+        with app.test_request_context(
+            "/",
+            data={},
+            content_type="multipart/form-data",
+        ):
+            with pytest.raises(NoAudioUploadedError):
+                self.method(installed_app)
+
     def test_app_unavailable(self, app: Flask, installed_app, audio_file):
         with (
             app.test_request_context(


### PR DESCRIPTION
## Summary

The installed-app audio-to-text endpoint (`POST /installed-apps/<installed_app_id>/audio-to-text`) returned 500 when callers omitted the multipart `file` field. Direct `request.files["file"]` access raised `KeyError` and Flask's default handler turned it into an unhandled 500.

Switched to `request.files.get("file")`. The service layer (`AudioService.transcript_asr`) already raises `NoAudioUploadedServiceError` when `file is None`, which the controller's existing `except NoAudioUploadedServiceError` block maps to `NoAudioUploadedError` (HTTP 400, code `no_audio_uploaded`). The sibling console endpoint at `api/controllers/console/app/audio.py:200` already uses this pattern.

Fixes #39184.

## Changes

- `api/controllers/console/explore/audio.py` (1 line): `request.files["file"]` -> `request.files.get("file")`
- `api/tests/unit_tests/controllers/console/explore/test_audio.py` (1 new test): posts an empty multipart body and asserts `NoAudioUploadedError` is raised.

## Verification

```
# From api/
uv run ruff check controllers/console/explore/audio.py tests/unit_tests/controllers/console/explore/test_audio.py
# All checks passed!

.venv/bin/python -m pytest tests/unit_tests/controllers/console/explore/test_audio.py -v
# 24 passed, 3 warnings in 4.86s
```

The new test (`test_post_missing_file_returns_no_audio_uploaded`) covers the previously untested missing-file path. All 24 tests in the file pass.

## Risk

None expected. Behavior change is from 500 (uncaught `KeyError`) to 400 (`NoAudioUploadedError`), matching the existing console endpoint. No new dependencies, no API contract change beyond the status code.
