### PR TITLE
fix: can not typing in the change node search field

### DIFF
--- a/web/app/components/workflow/node-actions-menu/__tests__/details.spec.tsx
+++ b/web/app/components/workflow/node-actions-menu/__tests__/details.spec.tsx
@@ -31,6 +31,7 @@ vi.mock('@/app/components/workflow/block-selector', () => ({
     ignoreNodeIds,
     forceEnableStartTab,
     allowUserInputSelection,
+    isolateKeyboardEvents,
   }: any) => (
     <div>
       <div>{trigger()}</div>
@@ -39,6 +40,7 @@ vi.mock('@/app/components/workflow/block-selector', () => ({
       <div>{`ignore:${(ignoreNodeIds || []).join(',')}`}</div>
       <div>{`force-start:${String(forceEnableStartTab)}`}</div>
       <div>{`allow-start:${String(allowUserInputSelection)}`}</div>
+      <div>{`isolate-keyboard:${String(isolateKeyboardEvents)}`}</div>
       <button type="button" onClick={() => onSelect(BlockEnum.HttpRequest)}>
         select-http
       </button>
@@ -172,6 +174,7 @@ describe('node actions menu details', () => {
     expect(screen.getByText('ignore:')).toBeInTheDocument()
     expect(screen.getByText('force-start:false')).toBeInTheDocument()
     expect(screen.getByText('allow-start:false')).toBeInTheDocument()
+    expect(screen.getByText('isolate-keyboard:true')).toBeInTheDocument()
     expect(handleNodeChange).toHaveBeenCalledWith(
       'node-1',
       BlockEnum.HttpRequest,

--- a/web/app/components/workflow/node-actions-menu/change-block-menu-trigger.tsx
+++ b/web/app/components/workflow/node-actions-menu/change-block-menu-trigger.tsx
@@ -83,6 +83,7 @@ export function ChangeBlockMenuTrigger({
       ignoreNodeIds={ignoreNodeIds}
       forceEnableStartTab={nodeData.type === BlockEnum.Start}
       allowUserInputSelection={allowStartNodeSelection}
+      isolateKeyboardEvents
     />
   )
 }


### PR DESCRIPTION
## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
