### PR TITLE
test(api): guard and document the DEBUG gevent server path (#39205)

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -468,7 +468,9 @@ SENDGRID_API_KEY=
 # Sentry configuration
 SENTRY_DSN=
 
-# DEBUG
+# DEBUG=true runs a single-process gevent debug server (python -m app) instead
+# of Gunicorn; use it only for local debugging. For verbose logs in production
+# keep DEBUG=false and set LOG_LEVEL=DEBUG.
 DEBUG=false
 ENABLE_REQUEST_LOGGING=False
 SQLALCHEMY_ECHO=false

--- a/api/tests/unit_tests/test_app_debug_gevent.py
+++ b/api/tests/unit_tests/test_app_debug_gevent.py
@@ -1,0 +1,97 @@
+
+import ast
+from pathlib import Path
+
+# tests/unit_tests/ -> tests/ -> api/
+APP_PY = Path(__file__).parents[2] / "app.py"
+
+
+def _load_app_module() -> ast.Module:
+    return ast.parse(APP_PY.read_text(encoding="utf-8"), filename=str(APP_PY))
+
+
+def _dotted_name(node: ast.expr) -> str | None:
+    """Return the dotted call target, e.g. ``monkey.patch_all`` from a call node."""
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+def _is_main_guard(node: ast.stmt) -> bool:
+    """True for an ``if __name__ == "__main__":`` statement."""
+    if not isinstance(node, ast.If):
+        return False
+    test = node.test
+    return (
+        isinstance(test, ast.Compare)
+        and isinstance(test.left, ast.Name)
+        and test.left.id == "__name__"
+        and len(test.ops) == 1
+        and isinstance(test.ops[0], ast.Eq)
+        and len(test.comparators) == 1
+        and isinstance(test.comparators[0], ast.Constant)
+        and test.comparators[0].value == "__main__"
+    )
+
+
+def _contains_call(node: ast.AST, dotted_target: str) -> bool:
+    return any(
+        isinstance(child, ast.Call) and _dotted_name(child.func) == dotted_target for child in ast.walk(node)
+    )
+
+
+def _first_call_lineno(tree: ast.AST, dotted_target: str) -> int | None:
+    linenos = [
+        child.lineno
+        for child in ast.walk(tree)
+        if isinstance(child, ast.Call) and _dotted_name(child.func) == dotted_target
+    ]
+    return min(linenos) if linenos else None
+
+
+def test_app_py_exists() -> None:
+    # Arrange / Act / Assert
+    assert APP_PY.is_file(), f"expected api/app.py at {APP_PY}"
+
+
+def test_debug_server_monkey_patches_inside_main_guard() -> None:
+    # Arrange
+    module = _load_app_module()
+
+    # Act
+    patch_guards = [node for node in module.body if _is_main_guard(node) and _contains_call(node, "monkey.patch_all")]
+
+    # Assert
+    assert patch_guards, (
+        "api/app.py must call gevent monkey.patch_all() inside an "
+        "`if __name__ == '__main__'` guard so the `python -m app` (DEBUG=true) "
+        "server is cooperatively scheduled. Removing it re-introduces the "
+        "deadlock from issue #39205 (regressed once in PR #27611, fixed in PR #38975)."
+    )
+
+
+def test_monkey_patch_runs_before_app_factory_import() -> None:
+    # Arrange
+    module = _load_app_module()
+
+    # Act
+    patch_lineno = _first_call_lineno(module, "monkey.patch_all")
+    app_factory_import_linenos = [
+        node.lineno
+        for node in ast.walk(module)
+        if isinstance(node, ast.ImportFrom) and node.module == "app_factory"
+    ]
+
+    # Assert
+    assert patch_lineno is not None, "gevent monkey.patch_all() call not found in api/app.py"
+    assert app_factory_import_linenos, "expected a `from app_factory import ...` statement in api/app.py"
+    assert patch_lineno < min(app_factory_import_linenos), (
+        "gevent monkey.patch_all() must run BEFORE app_factory is imported; patching "
+        "after other imports leaves blocking I/O (sockets, locks) unpatched and "
+        "re-introduces the DEBUG=true deadlock from issue #39205."
+    )

--- a/api/tests/unit_tests/test_app_debug_gevent.py
+++ b/api/tests/unit_tests/test_app_debug_gevent.py
@@ -1,4 +1,3 @@
-
 import ast
 from pathlib import Path
 
@@ -40,9 +39,7 @@ def _is_main_guard(node: ast.stmt) -> bool:
 
 
 def _contains_call(node: ast.AST, dotted_target: str) -> bool:
-    return any(
-        isinstance(child, ast.Call) and _dotted_name(child.func) == dotted_target for child in ast.walk(node)
-    )
+    return any(isinstance(child, ast.Call) and _dotted_name(child.func) == dotted_target for child in ast.walk(node))
 
 
 def _first_call_lineno(tree: ast.AST, dotted_target: str) -> int | None:
@@ -82,9 +79,7 @@ def test_monkey_patch_runs_before_app_factory_import() -> None:
     # Act
     patch_lineno = _first_call_lineno(module, "monkey.patch_all")
     app_factory_import_linenos = [
-        node.lineno
-        for node in ast.walk(module)
-        if isinstance(node, ast.ImportFrom) and node.module == "app_factory"
+        node.lineno for node in ast.walk(module) if isinstance(node, ast.ImportFrom) and node.module == "app_factory"
     ]
 
     # Assert

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -52,6 +52,10 @@ LOG_FILE_MAX_SIZE=20
 LOG_FILE_BACKUP_COUNT=5
 LOG_DATEFORMAT=%Y-%m-%d %H:%M:%S
 LOG_TZ=UTC
+# DEBUG=true makes the API container run a single-process gevent debug server
+# (python -m app) instead of Gunicorn. Use it only for local debugging, never
+# in production. For verbose logs in production keep DEBUG=false and set
+# LOG_LEVEL=DEBUG. FLASK_DEBUG only affects the Flask CLI, not the API server.
 DEBUG=false
 FLASK_DEBUG=false
 ENABLE_REQUEST_LOGGING=False


### PR DESCRIPTION

## Summary

Follow-up hardening + docs for the `DEBUG=true` deadlock in #39205.

When `DEBUG=true`, `docker/entrypoint.sh` runs `python -m app`, which serves the
API through a single-threaded gevent `pywsgi` server. That server only stays
responsive if the stdlib is monkey-patched **before** any other import pulls in
sockets or locks. Without it, the agent strategy plugin call chain deadlocks:
the API makes a blocking `httpx` call to the plugin daemon
(`core/plugin/impl/base.py`, 600s timeout), while the daemon's agent strategy
calls **back** into the API via backwards invocation
(`core/plugin/backwards_invocation/`) — a request the pinned single thread can
never serve. Both sides wait until the ~10 min timeout fires.

The patch was removed in #27611 (believing Gunicorn/Celery cover it — but the
`python -m app` path uses neither) and restored in #38975. This PR does not
change that fix; it prevents the regression from recurring and documents the
flag so users stop enabling `DEBUG=true`/`FLASK_DEBUG=true` in production.

## Changes

- `api/tests/unit_tests/test_app_debug_gevent.py` — pure-AST unit test (no
  fixtures / no heavy imports) asserting that `api/app.py`:
  - calls `gevent monkey.patch_all()` inside an `if __name__ == "__main__"`
    guard (guarded so `gunicorn app:socketio_app` doesn't double-patch), and
  - runs that patch **before** `from app_factory import ...`.
- `docker/.env.example`, `api/.env.example` — comment explaining that
  `DEBUG=true` switches to the single-process gevent debug server (local
  debugging only), that `LOG_LEVEL=DEBUG` is the way to get verbose logs in
  production, and that `FLASK_DEBUG` affects only the Flask CLI, not the server.

No production code changes. The deadlock fix itself already landed in #38975.

## Verification

- New test passes against current `app.py`; fails against the pre-#38975
  (#27611) version on both assertions, confirming it catches the regression.
- `docker/.env.example` change is comment-only; re-running
  `docker/generate_docker_compose` produces a byte-identical
  `docker/docker-compose.yaml` (the generator skips comment lines).

Related to #39205

