### PR TITLE
fix: stream answer nodes inside iteration/loop containers

### DIFF
--- a/api/core/app/apps/advanced_chat/app_generator.py
+++ b/api/core/app/apps/advanced_chat/app_generator.py
@@ -46,6 +46,7 @@ from core.ops.ops_trace_manager import TraceQueueManager
 from core.prompt.utils.get_thread_messages_length import get_thread_messages_length
 from core.repositories import DifyCoreRepositoryFactory
 from core.repositories.factory import WorkflowExecutionRepository, WorkflowNodeExecutionRepository
+from core.workflow.response_stream_filter import DifyResponseStreamFilter
 from extensions.ext_database import db
 from factories import file_factory
 from graphon.filters import ResponseStreamFilter
@@ -575,7 +576,7 @@ class AdvancedChatAppGenerator(MessageBasedAppGenerator):
             )
 
             graph_layers: list[GraphEngineLayer] = list(graph_engine_layers)
-            resolved_response_stream_filter = response_stream_filter or ResponseStreamFilter()
+            resolved_response_stream_filter = response_stream_filter or DifyResponseStreamFilter()
             if pause_state_config is not None:
                 graph_layers.append(
                     PauseStatePersistenceLayer(

--- a/api/core/app/apps/workflow/app_generator.py
+++ b/api/core/app/apps/workflow/app_generator.py
@@ -41,6 +41,7 @@ from core.helper.trace_id_helper import (
 from core.ops.ops_trace_manager import TraceQueueManager
 from core.repositories import DifyCoreRepositoryFactory
 from core.repositories.factory import WorkflowExecutionRepository, WorkflowNodeExecutionRepository
+from core.workflow.response_stream_filter import DifyResponseStreamFilter
 from extensions.ext_database import db
 from factories import file_factory
 from graphon.filters import ResponseStreamFilter
@@ -363,7 +364,7 @@ class WorkflowAppGenerator(BaseAppGenerator):
                 app_mode=app_model.mode,
             )
 
-            resolved_response_stream_filter = response_stream_filter or ResponseStreamFilter()
+            resolved_response_stream_filter = response_stream_filter or DifyResponseStreamFilter()
             if pause_state_config is not None:
                 graph_layers.append(
                     PauseStatePersistenceLayer(

--- a/api/core/app/layers/pause_state_persist_layer.py
+++ b/api/core/app/layers/pause_state_persist_layer.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from core.app.entities.app_invoke_entities import AdvancedChatAppGenerateEntity, WorkflowAppGenerateEntity
 from core.repositories.human_input_repository import HumanInputFormSubmissionRepository
 from core.workflow.nodes.human_input.boundary import enrich_graph_pause_reasons
+from core.workflow.response_stream_filter import DifyResponseStreamFilter
 from core.workflow.system_variables import SystemVariableKey, get_system_text
 from graphon.filters import ResponseStreamFilter
 from graphon.graph_engine.layers import GraphEngineLayer
@@ -60,7 +61,7 @@ class WorkflowResumptionContext(BaseModel):
         return self.generate_entity.entity
 
     def get_response_stream_filter(self) -> ResponseStreamFilter:
-        response_stream_filter = ResponseStreamFilter()
+        response_stream_filter = DifyResponseStreamFilter()
         if self.serialized_response_stream_filter_state is not None:
             response_stream_filter.loads(self.serialized_response_stream_filter_state)
         return response_stream_filter

--- a/api/core/workflow/response_stream_filter.py
+++ b/api/core/workflow/response_stream_filter.py
@@ -1,0 +1,35 @@
+from collections.abc import Iterable
+from typing import override
+
+from graphon.filters import ResponseStreamFilter
+from graphon.graph_events import GraphEngineEvent, NodeRunStreamChunkEvent
+
+
+class DifyResponseStreamFilter(ResponseStreamFilter):
+    """ResponseStreamFilter that supports response nodes inside container nodes.
+
+    Response nodes (answer) placed inside an iteration or loop run in a child
+    graph, and the container node forwards their events to the parent engine.
+    The base filter registers them from the parent graph config but can never
+    activate their streaming sessions — they have no traversal path from the
+    parent root — so their output silently disappears from the response stream.
+
+    This subclass leaves child-graph response nodes to the child engine's own
+    filter (see ``_WorkflowChildEngineBuilder``) and passes the stream chunks
+    the container forwards straight through to the caller.
+    """
+
+    @override
+    def _register(self, response_node_id: str) -> None:
+        # Response nodes with no traversal path from this graph's root live in
+        # a container's child graph; the child engine streams them instead.
+        root_node_id = self._bound_graph.root_node.id
+        if response_node_id != root_node_id and not self._find_all_paths(root_node_id, response_node_id):
+            return
+        super()._register(response_node_id)
+
+    @override
+    def on_event(self, event: GraphEngineEvent) -> Iterable[GraphEngineEvent]:
+        if isinstance(event, NodeRunStreamChunkEvent) and (event.in_iteration_id or event.in_loop_id):
+            return [event]
+        return super().on_event(event)

--- a/api/core/workflow/workflow_entry.py
+++ b/api/core/workflow/workflow_entry.py
@@ -16,6 +16,7 @@ from core.workflow.node_factory import (
     is_start_node_type,
     resolve_workflow_node_class,
 )
+from core.workflow.response_stream_filter import DifyResponseStreamFilter
 from core.workflow.system_variables import (
     default_system_variables,
     get_node_creation_preload_selectors,
@@ -65,8 +66,39 @@ def iter_dify_graph_engine_events(
     yield from filter_graph_events(
         engine.run(),
         context=GraphEventFilterContext.from_engine(engine),
-        filters=[response_stream_filter or ResponseStreamFilter()],
+        filters=[response_stream_filter or DifyResponseStreamFilter()],
     )
+
+
+class ResponseFilteredChildEngine:
+    """Wraps a child GraphEngine so its events pass through Dify's response stream filter.
+
+    Container nodes (iteration/loop) consume child engine events directly,
+    bypassing ``iter_dify_graph_engine_events``, so the child engine must
+    synthesize streaming for response nodes inside its own graph. The parent
+    filter passes the forwarded chunks through (see ``DifyResponseStreamFilter``).
+
+    ``GraphEngine`` is ``@final``, so this wraps rather than subclasses it and
+    explicitly delegates the members container nodes access on the returned
+    engine: ``run``, ``graph_runtime_state`` and ``request_abort``.
+    """
+
+    def __init__(self, engine: GraphEngine) -> None:
+        self._engine = engine
+
+    def run(self) -> Generator[GraphEngineEvent, None, None]:
+        yield from filter_graph_events(
+            self._engine.run(),
+            context=GraphEventFilterContext.from_engine(self._engine),
+            filters=[DifyResponseStreamFilter()],
+        )
+
+    @property
+    def graph_runtime_state(self) -> GraphRuntimeState:
+        return self._engine.graph_runtime_state
+
+    def request_abort(self, reason: str | None = None) -> None:
+        self._engine.request_abort(reason)
 
 
 class _WorkflowChildEngineBuilder:
@@ -103,7 +135,7 @@ class _WorkflowChildEngineBuilder:
         parent_graph_runtime_state: GraphRuntimeState,
         root_node_id: str,
         variable_pool: VariablePool | None = None,
-    ) -> GraphEngine:
+    ) -> ResponseFilteredChildEngine:
         """Build a child engine with a fresh runtime state and only child-safe layers."""
         child_graph_runtime_state = GraphRuntimeState(
             variable_pool=variable_pool if variable_pool is not None else parent_graph_runtime_state.variable_pool,
@@ -137,7 +169,7 @@ class _WorkflowChildEngineBuilder:
             child_engine_builder=self,
         )
         child_engine.layer(LLMQuotaLayer(tenant_id=self.tenant_id))
-        return child_engine
+        return ResponseFilteredChildEngine(child_engine)
 
 
 class _NodeConfigDict(TypedDict):
@@ -206,7 +238,7 @@ class WorkflowEntry:
             command_channel = InMemoryChannel()
 
         self.command_channel = command_channel
-        self._response_stream_filter = response_stream_filter or ResponseStreamFilter()
+        self._response_stream_filter = response_stream_filter or DifyResponseStreamFilter()
         execution_context = capture_current_context()
         graph_runtime_state.execution_context = execution_context
         self._child_engine_builder = _WorkflowChildEngineBuilder(tenant_id=tenant_id)

--- a/api/tests/fixtures/workflow/iteration_contains_answer.yml
+++ b/api/tests/fixtures/workflow/iteration_contains_answer.yml
@@ -1,0 +1,210 @@
+app:
+  description: 'Chatflow with an answer node inside an iteration node.
+
+
+    The iteration processes the conversation variable ["apple", "banana"]; the
+
+    inner answer node streams the current item, and a final answer node streams
+
+    "done" after the iteration completes.'
+  icon: 🤖
+  icon_background: '#FFEAD5'
+  mode: advanced-chat
+  name: iteration_contains_answer
+  use_icon_as_answer_icon: false
+dependencies: []
+kind: app
+version: 0.3.1
+workflow:
+  conversation_variables:
+  - description: ''
+    id: e208ec58-4503-48a9-baf8-17aae67e5fa1
+    name: fruits
+    selector:
+    - conversation
+    - fruits
+    value:
+    - apple
+    - banana
+    value_type: array[string]
+  environment_variables: []
+  features:
+    file_upload:
+      enabled: false
+    opening_statement: ''
+    retriever_resource:
+      enabled: true
+    sensitive_word_avoidance:
+      enabled: false
+    speech_to_text:
+      enabled: false
+    suggested_questions: []
+    suggested_questions_after_answer:
+      enabled: false
+    text_to_speech:
+      enabled: false
+  graph:
+    edges:
+    - data:
+        isInIteration: false
+        isInLoop: false
+        sourceType: start
+        targetType: iteration
+      id: start-source-iteration-target
+      source: start_node
+      sourceHandle: source
+      target: iteration_node
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: true
+        isInLoop: false
+        iteration_id: iteration_node
+        sourceType: iteration-start
+        targetType: answer
+      id: iteration-start-source-answer-inner-target
+      source: iteration_nodestart
+      sourceHandle: source
+      target: answer_in_iteration
+      targetHandle: target
+      type: custom
+      zIndex: 1002
+    - data:
+        isInIteration: false
+        isInLoop: false
+        sourceType: iteration
+        targetType: answer
+      id: iteration-source-answer-final-target
+      source: iteration_node
+      sourceHandle: source
+      target: answer_final
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    nodes:
+    - data:
+        desc: ''
+        selected: false
+        title: Start
+        type: start
+        variables: []
+      height: 54
+      id: start_node
+      position:
+        x: 80
+        y: 282
+      positionAbsolute:
+        x: 80
+        y: 282
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        error_handle_mode: terminated
+        flatten_output: false
+        height: 178
+        is_parallel: false
+        iterator_input_type: array[string]
+        iterator_selector:
+        - conversation
+        - fruits
+        output_selector:
+        - answer_in_iteration
+        - answer
+        output_type: array[string]
+        parallel_nums: 10
+        selected: false
+        start_node_id: iteration_nodestart
+        title: Iteration
+        type: iteration
+        width: 388
+      height: 178
+      id: iteration_node
+      position:
+        x: 684
+        y: 282
+      positionAbsolute:
+        x: 684
+        y: 282
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 388
+      zIndex: 1
+    - data:
+        desc: ''
+        isInIteration: true
+        selected: false
+        title: ''
+        type: iteration-start
+      draggable: false
+      height: 48
+      id: iteration_nodestart
+      parentId: iteration_node
+      position:
+        x: 24
+        y: 68
+      positionAbsolute:
+        x: 708
+        y: 350
+      selectable: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom-iteration-start
+      width: 44
+      zIndex: 1002
+    - data:
+        answer: '{{#iteration_node.item#}}
+
+          '
+        desc: ''
+        isInIteration: true
+        isInLoop: false
+        iteration_id: iteration_node
+        selected: false
+        title: Answer In Iteration
+        type: answer
+        variables: []
+      height: 105
+      id: answer_in_iteration
+      parentId: iteration_node
+      position:
+        x: 128
+        y: 68
+      positionAbsolute:
+        x: 812
+        y: 350
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+      zIndex: 1002
+    - data:
+        answer: done
+        desc: ''
+        selected: false
+        title: Final Answer
+        type: answer
+        variables: []
+      height: 105
+      id: answer_final
+      position:
+        x: 1132
+        y: 282
+      positionAbsolute:
+        x: 1132
+        y: 282
+      selected: true
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    viewport:
+      x: -476
+      y: 3
+      zoom: 1

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_answer_in_container_streaming.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_answer_in_container_streaming.py
@@ -1,0 +1,62 @@
+"""Regression coverage for answer nodes inside iteration/loop containers (#38867).
+
+Answer nodes inside a container run in a child graph, so the parent
+ResponseStreamFilter can never activate their streaming sessions. The child
+engine must synthesize their stream chunks and the parent filter must pass the
+forwarded chunks through, otherwise the inner answer never reaches the client.
+"""
+
+from core.workflow.workflow_entry import iter_dify_graph_engine_events
+from graphon.graph_engine import GraphEngine, GraphEngineConfig
+from graphon.graph_engine.command_channels import InMemoryChannel
+from graphon.graph_events import (
+    GraphRunSucceededEvent,
+    NodeRunStreamChunkEvent,
+)
+
+from .test_table_runner import TableTestRunner, _TableTestChildEngineBuilder
+
+
+def _run_fixture(fixture_name: str, query: str) -> list[object]:
+    runner = TableTestRunner()
+    fixture_data = runner.workflow_runner.load_fixture(fixture_name)
+    graph, graph_runtime_state = runner.workflow_runner.create_graph_from_fixture(
+        fixture_data=fixture_data,
+        query=query,
+    )
+    engine = GraphEngine(
+        workflow_id="test_workflow",
+        graph=graph,
+        graph_runtime_state=graph_runtime_state,
+        command_channel=InMemoryChannel(),
+        config=GraphEngineConfig(),
+        child_engine_builder=_TableTestChildEngineBuilder(use_mock_factory=False, mock_config=None),
+    )
+    return list(iter_dify_graph_engine_events(engine))
+
+
+def test_answer_in_iteration_streams_each_item():
+    events = _run_fixture("iteration_contains_answer", query="hi")
+
+    success_events = [e for e in events if isinstance(e, GraphRunSucceededEvent)]
+    assert len(success_events) > 0, "Workflow should complete successfully"
+
+    stream_chunk_events = [e for e in events if isinstance(e, NodeRunStreamChunkEvent)]
+    streamed_answer = "".join(event.chunk for event in stream_chunk_events)
+    assert streamed_answer == "apple\nbanana\ndone"
+
+    # The inner answer chunks are forwarded by the iteration container
+    in_iteration_chunks = [e for e in stream_chunk_events if e.in_iteration_id == "iteration_node"]
+    assert "".join(event.chunk for event in in_iteration_chunks) == "apple\nbanana\n"
+
+
+def test_answer_in_loop_streams_each_round():
+    events = _run_fixture("loop_contains_answer", query="hi")
+
+    success_events = [e for e in events if isinstance(e, GraphRunSucceededEvent)]
+    assert len(success_events) > 0, "Workflow should complete successfully"
+
+    stream_chunk_events = [e for e in events if isinstance(e, NodeRunStreamChunkEvent)]
+    streamed_answer = "".join(event.chunk for event in stream_chunk_events)
+    assert streamed_answer == "1\n2\nhi + 2"
+    assert success_events[-1].outputs["answer"] == "1\n2\nhi + 2"

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_table_runner.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_table_runner.py
@@ -24,7 +24,7 @@ from core.tools.utils.yaml_utils import _load_yaml_file
 from core.workflow.node_factory import DifyNodeFactory, get_default_root_node_id
 from core.workflow.system_variables import build_bootstrap_variables, build_system_variables
 from core.workflow.variable_pool_initializer import add_node_inputs_to_pool, add_variables_to_pool
-from core.workflow.workflow_entry import iter_dify_graph_engine_events
+from core.workflow.workflow_entry import ResponseFilteredChildEngine, iter_dify_graph_engine_events
 from graphon.entities import GraphInitParams
 from graphon.graph import Graph
 from graphon.graph_engine import GraphEngine, GraphEngineConfig
@@ -95,7 +95,9 @@ class _TableTestChildEngineBuilder:
             config=GraphEngineConfig(),
             child_engine_builder=self,
         )
-        return child_engine
+        # Mirror production (_WorkflowChildEngineBuilder): child engines apply
+        # Dify's response stream filter to their own events.
+        return ResponseFilteredChildEngine(child_engine)
 
 
 @dataclass

--- a/api/tests/unit_tests/core/workflow/test_workflow_entry_helpers.py
+++ b/api/tests/unit_tests/core/workflow/test_workflow_entry_helpers.py
@@ -139,6 +139,11 @@ class TestWorkflowChildEngineBuilder:
             patch.object(workflow_entry, "DifyNodeFactory", return_value=sentinel.factory) as dify_node_factory,
             patch.object(workflow_entry.Graph, "init", return_value=child_graph) as graph_init,
             patch.object(workflow_entry, "GraphEngine", return_value=child_engine) as graph_engine_cls,
+            patch.object(
+                workflow_entry,
+                "ResponseFilteredChildEngine",
+                return_value=sentinel.filtered_child_engine,
+            ) as filtered_child_engine_cls,
             patch.object(workflow_entry, "GraphEngineConfig", return_value=sentinel.graph_engine_config),
             patch.object(workflow_entry, "InMemoryChannel", return_value=sentinel.command_channel),
             patch.object(workflow_entry, "LLMQuotaLayer", return_value=sentinel.llm_quota_layer) as llm_quota_layer_cls,
@@ -151,7 +156,8 @@ class TestWorkflowChildEngineBuilder:
                 variable_pool=sentinel.child_variable_pool,
             )
 
-        assert result is child_engine
+        assert result is sentinel.filtered_child_engine
+        filtered_child_engine_cls.assert_called_once_with(child_engine)
         graph_runtime_state_cls.assert_called_once_with(
             variable_pool=sentinel.child_variable_pool,
             start_at=123.0,
@@ -394,7 +400,7 @@ class TestWorkflowEntryRun:
             ) as from_engine,
             patch.object(
                 workflow_entry,
-                "ResponseStreamFilter",
+                "DifyResponseStreamFilter",
                 return_value=sentinel.response_stream_filter,
             ) as response_stream_filter_cls,
             patch.object(


### PR DESCRIPTION
## Summary

Fixes #38867. An answer node inside an iteration (or loop) executes but never streams: no SSE `message` events are produced for it, and the persisted message loses the iteration content. Worked in 1.14.2, broken since 1.15.0.

## Root Cause

Since graphon 0.5, answer-node streaming is synthesized by `ResponseStreamFilter` sessions rather than emitted by the node. Answer nodes inside a container run in the container's **child graph**, which breaks the wiring twice:

1. The parent run's filter registers the inner answer node (it appears in the top-level graph config) but can never activate its streaming session — `_build_paths_map` finds no traversal path from the parent root to it, so the session sits pending forever.
2. Child engines built by `_WorkflowChildEngineBuilder` had no response stream filter at all, so nothing synthesized the inner answer's chunks there either.

The node itself runs fine (correct `node_finished` output), which is why the workflow "succeeds" while the user sees nothing — only `message_end` arrives.

## Fix

Dify-side wiring only, no graphon changes (same approach as #38540):

- `DifyResponseStreamFilter` (new, `api/core/workflow/response_stream_filter.py`): skips registering response nodes that have no path from the graph root (they belong to a container's child graph), and passes stream chunks forwarded by containers (`in_iteration_id`/`in_loop_id` set) straight through.
- `_WorkflowChildEngineBuilder` now wraps child engines in `ResponseFilteredChildEngine`, so each iteration/loop pass synthesizes streaming for its own response nodes with a fresh filter (sessions are one-shot, and inner answers run once per pass).
- All existing construction sites (`iter_dify_graph_engine_events`, `WorkflowEntry`, both app generators, `PauseStatePersistenceLayer`) construct the subclass; pause/resume serialization is inherited unchanged.

## Before / After

Chatflow: `start → iteration([apple, banana] → inner answer "{{item}}\n") → answer "done"` (fixture `iteration_contains_answer.yml`):

|  | Streamed to client |
|--------|-------|
| Before | `'done'` |
| After | `'apple\nbanana\ndone'` |

Loop chatflow (existing, previously orphaned fixture `loop_contains_answer.yml`):

|  | Streamed to client |
|--------|-------|
| Before | `'hi + 2'` (inner loop answers lost) |
| After | `'1\n2\nhi + 2'` |

After-fix event stream shows the inner answer chunks forwarded live during each iteration pass:

```
NodeRunIterationNextEvent   node=iteration_node
NodeRunStreamChunkEvent     selector=['iteration_node', 'item'] chunk='apple' in_iteration_id=iteration_node
NodeRunStreamChunkEvent     selector=['answer_in_iteration', 'answer'] chunk='\n' in_iteration_id=iteration_node
...
NodeRunStreamChunkEvent     selector=['answer_final', 'answer'] chunk='done'
```

`is_final` on the per-pass chunks is not propagated into `QueueTextChunkEvent` (only text/selector/container ids), so the SSE message pipeline is unaffected by multiple per-pass final markers.

## Tests

- New `test_answer_in_container_streaming.py`: regression coverage for both the iteration case (#38867) and the loop case, using real (non-mock) nodes through the production child-engine builder path. Both fail without this fix (streamed answer collapses to the outer answer only).
- Updated `test_workflow_entry_helpers.py` construction assertions; `_TableTestChildEngineBuilder` mirrors production child-engine wrapping.
- `uv run pytest tests/unit_tests` — 15756 passed, 6 skipped.
- `make lint && make type-check` — clean.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Claude Code
