### PR TITLE
fix(api): return 400 instead of 500 when installed-app audio-to-text has no 'file' field (#39184)

### DIFF
--- a/api/controllers/console/explore/audio.py
+++ b/api/controllers/console/explore/audio.py
@@ -54,7 +54,7 @@ class ChatAudioApi(InstalledAppResource):
         if app_model is None:
             raise AppUnavailableError()
 
-        file = request.files["file"]
+        file = request.files.get("file")
 
         try:
             response = AudioService.transcript_asr(

--- a/api/tests/unit_tests/controllers/console/explore/test_audio.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_audio.py
@@ -108,6 +108,37 @@ class TestChatAudioApi:
             with pytest.raises(NoAudioUploadedError):
                 self.method(installed_app)
 
+    def test_missing_file_field_raises_no_audio_uploaded(self, app: Flask, installed_app):
+        # Regression test for https://github.com/langgenius/dify/issues/39184.
+        #
+        # The endpoint previously did ``request.files["file"]`` which raised
+        # ``KeyError`` (and Flask turned it into a 500) when the caller didn't
+        # include a ``file`` field. Switching to ``request.files.get("file")``
+        # lets the service layer's existing ``NoAudioUploadedServiceError``
+        # fire and the controller maps it to a 400 ``NoAudioUploadedError``
+        # — matching the sibling console-side endpoint at
+        # ``api/controllers/console/app/audio.py:200``.
+        with (
+            app.test_request_context(
+                "/",
+                data={},
+                content_type="multipart/form-data",
+            ),
+            patch.object(
+                audio_module.AudioService,
+                "transcript_asr",
+                side_effect=NoAudioUploadedServiceError(),
+            ) as transcript_mock,
+        ):
+            with pytest.raises(NoAudioUploadedError):
+                self.method(installed_app)
+            # The service is still consulted — it is the service that detects
+            # the missing file and raises the typed error. We only assert
+            # that the service was called (not the request-files indexing);
+            # the absence of a KeyError on the request is verified by the
+            # fact that the except handler maps to NoAudioUploadedError.
+            transcript_mock.assert_called_once()
+
     def test_audio_too_large(self, app: Flask, installed_app, audio_file):
         with (
             app.test_request_context(


### PR DESCRIPTION
## Summary

`POST /installed-apps/<installed_app_id>/audio-to-text` read the
multipart `file` field with `request.files["file"]`, which raises
`KeyError` when the caller omits the field. Flask's default error
handler then returns a 500 with no useful context, even though the
controller already maps `NoAudioUploadedServiceError` to
`NoAudioUploadedError` (HTTP 400, code `no_audio_uploaded`).

The sibling console-side endpoint at
`api/controllers/console/app/audio.py:200` already uses
`request.files.get("file")`, which lets the service layer's existing
`if file is None: raise NoAudioUploadedServiceError()` check fire and
flow through the same exception handler — a 400 with the right error
code.

Switch the installed-app endpoint to the same `request.files.get(...)`
pattern so the contract is consistent across the two paths.

## Reproduction

```bash
curl -X POST \
  -H "Authorization: Bearer <token>" \
  https://<host>/installed-apps/<id>/audio-to-text
# -> 500 Internal Server Error (with a generic message)
```

Send a multipart request with an empty body or with any field other
than `file`. The same call against `POST /apps/<app_id>/audio-to-text`
already returns 400.

## Fix

One-character behavior change in `ChatAudioApi.post`:

```diff
-        file = request.files["file"]
+        file = request.files.get("file")
```

The service layer (`AudioService.transcript_asr`) already raises
`NoAudioUploadedServiceError` when `file is None`, and the existing
`except NoAudioUploadedServiceError` handler in the controller maps
it to `NoAudioUploadedError`. No new error class needed.

## Regression test

`test_missing_file_field_raises_no_audio_uploaded` posts an empty
multipart body and asserts `NoAudioUploadedError` is raised. The test
crashes the test runner on the un-fixed code (`KeyError` escapes
Flask's test_request_context error handler) and passes with the fix.

## Verification

- `uv run pytest tests/unit_tests/controllers/console/explore/test_audio.py::TestChatAudioApi`
  → **13 passed**.
- `ruff check` on changed files → clean.
- `ruff format --check` on changed files → already formatted.

Fixes #39184