### PR TITLE
fix(hit_testing): use flush() instead of commit() to preserve transaction context

### DIFF
--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -183,7 +183,12 @@ class HitTestingService:
                 created_by=account.id,
             )
             session.add(dataset_query)
-        session.commit()
+        # Flush the DatasetQuery row so it gets a primary key and is visible
+        # to the subsequent read in compact_retrieve_response(), but do NOT
+        # commit here — the caller owns the transaction context and an early
+        # commit closes it, causing "Can't operate on closed transaction"
+        # (InvalidRequestError) on the next query (#38998).
+        session.flush()
 
         return cls.compact_retrieve_response(query, all_documents, session=session)
 


### PR DESCRIPTION
HitTestingService.retrieve() called session.commit() after adding the DatasetQuery row, then passed the same session to compact_retrieve_response() which issued another query. Because the controller wraps the whole call in a transaction context manager, the explicit commit closed the transaction before the document lookup ran, raising:

  sqlalchemy.exc.InvalidRequestError: Can't operate on closed transaction inside context manager

Replace commit() with flush() so the new row is materialised (gets a primary key, visible to subsequent reads within the same transaction) while leaving the outer context to manage the final commit.

external_retrieve() also calls commit() but its follow-up compact_external_retrieve_response() does not touch the session, so it is left unchanged.

Fixes #38998