### PR TITLE
fix(api): sign tool file URLs generated by ToolFileMessageTransformer

### DIFF
--- a/api/core/app/features/rate_limiting/rate_limit.py
+++ b/api/core/app/features/rate_limiting/rate_limit.py
@@ -8,8 +8,21 @@ from typing import Any, Union
 
 from core.errors.error import AppInvokeQuotaExceededError
 from extensions.ext_redis import redis_client
+from extensions.redis_names import get_redis_key_prefix, serialize_redis_name_arg
 
 logger = logging.getLogger(__name__)
+
+# Atomically checks the active-request count against the cap and, if there is room,
+# registers the new request in the same round trip. Doing this check-and-set in Lua
+# closes the race where two concurrent HLEN checks could both pass before either HSET lands.
+_ENTER_SCRIPT = """
+local count = redis.call('HLEN', KEYS[1])
+if count >= tonumber(ARGV[1]) then
+    return 0
+end
+redis.call('HSET', KEYS[1], ARGV[2], ARGV[3])
+return 1
+"""
 
 
 class RateLimit:
@@ -78,13 +91,15 @@ class RateLimit:
         if not request_id:
             request_id = RateLimit.gen_request_key()
 
-        active_requests_count = redis_client.hlen(self.active_requests_key)
-        if active_requests_count >= self.max_active_requests:
+        prefixed_key = serialize_redis_name_arg(self.active_requests_key, get_redis_key_prefix())
+        admitted = redis_client.eval(
+            _ENTER_SCRIPT, 1, prefixed_key, self.max_active_requests, request_id, str(time.time())
+        )
+        if not admitted:
             raise AppInvokeQuotaExceededError(
                 f"Too many requests. Please try again later. The current maximum concurrent requests allowed "
                 f"for {self.client_id} is {self.max_active_requests}."
             )
-        redis_client.hset(self.active_requests_key, request_id, str(time.time()))
         return request_id
 
     def exit(self, request_id: str):

--- a/api/core/tools/utils/message_transformer.py
+++ b/api/core/tools/utils/message_transformer.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytz
 
 from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.signature import sign_tool_file
 from core.tools.tool_file_manager import ToolFileManager, resolve_extension
 from core.workflow.file_reference import parse_file_reference
 from graphon.file import File, FileTransferMethod, FileType
@@ -201,7 +202,7 @@ class ToolFileMessageTransformer:
 
     @classmethod
     def get_tool_file_url(cls, tool_file_id: str, extension: str | None) -> str:
-        return f"/files/tools/{tool_file_id}{extension or '.bin'}"
+        return sign_tool_file(tool_file_id=tool_file_id, extension=extension or ".bin")
 
     @staticmethod
     def _with_tool_file_meta(

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -3374,12 +3374,12 @@ class SegmentService:
                     segment_document.word_count += len(args["answer"])
                     segment_document.answer = args["answer"]
 
-            session.add(segment_document)
-            # update document word count
-            assert document.word_count is not None
-            document.word_count += segment_document.word_count
-            session.add(document)
-            session.commit()
+                session.add(segment_document)
+                # update document word count
+                assert document.word_count is not None
+                document.word_count += segment_document.word_count
+                session.add(document)
+                session.commit()
 
             if args["attachment_ids"]:
                 for attachment_id in args["attachment_ids"]:

--- a/api/tests/unit_tests/core/app/features/rate_limiting/test_rate_limit.py
+++ b/api/tests/unit_tests/core/app/features/rate_limiting/test_rate_limit.py
@@ -194,8 +194,7 @@ class TestRateLimitEnterExit:
             **{
                 "exists.return_value": False,
                 "setex.return_value": True,
-                "hlen.return_value": 2,
-                "hset.return_value": True,
+                "eval.return_value": 1,
             }
         )
 
@@ -203,7 +202,7 @@ class TestRateLimitEnterExit:
         request_id = rate_limit.enter()
 
         assert request_id != RateLimit._UNLIMITED_REQUEST_ID
-        redis_patch.hset.assert_called_once()
+        redis_patch.eval.assert_called_once()
 
     def test_should_generate_request_id_if_not_provided(self, redis_patch):
         """Test auto-generation of request ID."""
@@ -211,8 +210,7 @@ class TestRateLimitEnterExit:
             **{
                 "exists.return_value": False,
                 "setex.return_value": True,
-                "hlen.return_value": 0,
-                "hset.return_value": True,
+                "eval.return_value": 1,
             }
         )
 
@@ -227,8 +225,7 @@ class TestRateLimitEnterExit:
             **{
                 "exists.return_value": False,
                 "setex.return_value": True,
-                "hlen.return_value": 0,
-                "hset.return_value": True,
+                "eval.return_value": 1,
             }
         )
 
@@ -257,7 +254,7 @@ class TestRateLimitEnterExit:
             **{
                 "exists.return_value": False,
                 "setex.return_value": True,
-                "hlen.return_value": 5,  # At limit
+                "eval.return_value": 0,  # At limit: the atomic script refuses admission
             }
         )
 
@@ -275,8 +272,7 @@ class TestRateLimitEnterExit:
             **{
                 "exists.return_value": False,
                 "setex.return_value": True,
-                "hlen.return_value": 4,  # Under limit after exit
-                "hset.return_value": True,
+                "eval.return_value": 1,  # Under limit after exit
                 "hdel.return_value": 1,
             }
         )
@@ -296,7 +292,7 @@ class TestRateLimitEnterExit:
             **{
                 "exists.return_value": False,
                 "setex.return_value": True,
-                "hlen.return_value": 0,
+                "eval.return_value": 1,
             }
         )
 
@@ -484,25 +480,29 @@ class TestRateLimitConcurrency:
         assert len({id(inst) for inst in instances}) == 1  # All same instance
 
     def test_should_handle_concurrent_enter_requests(self, redis_patch):
-        """Test concurrent enter requests handling."""
-        # Setup mock to simulate realistic Redis behavior
-        request_count = 0
+        """Test concurrent enter requests handling.
 
-        def mock_hlen(key):
-            nonlocal request_count
-            return request_count
+        The mocked `eval` reproduces the atomicity the real Lua script gets for free from
+        Redis's single-threaded command execution: the check-and-increment happens under a
+        single lock, so the number of admitted requests can never exceed max_active_requests
+        even when many threads race to call enter() at once.
+        """
+        lock = threading.Lock()
+        hashes: dict[str, dict] = {}
 
-        def mock_hset(key, field, value):
-            nonlocal request_count
-            request_count += 1
-            return True
+        def mock_eval(script, numkeys, key, max_active_requests, field, value):
+            with lock:
+                bucket = hashes.setdefault(key, {})
+                if len(bucket) >= int(max_active_requests):
+                    return 0
+                bucket[field] = value
+                return 1
 
         redis_patch.configure_mock(
             **{
                 "exists.return_value": False,
                 "setex.return_value": True,
-                "hlen.side_effect": mock_hlen,
-                "hset.side_effect": mock_hset,
+                "eval.side_effect": mock_eval,
             }
         )
 
@@ -527,6 +527,8 @@ class TestRateLimitConcurrency:
         # Should have some successful requests and some quota exceeded
         assert len(results) + len(errors) == 5
         assert len(errors) > 0  # Some should be rejected
+        # The core regression check: admitted requests must never exceed the configured cap.
+        assert len(results) == 3
 
     @patch("time.time")
     def test_should_maintain_accurate_count_under_load(self, mock_time, redis_patch):
@@ -539,14 +541,20 @@ class TestRateLimitConcurrency:
 
         rate_limit = RateLimit("load_test_client", 10)
         active_requests = []
+        max_observed_concurrency = 0
+        observed_lock = threading.Lock()
 
         def enter_and_exit():
+            nonlocal max_observed_concurrency
             try:
                 request_id = rate_limit.enter()
-                active_requests.append(request_id)
+                with observed_lock:
+                    active_requests.append(request_id)
+                    max_observed_concurrency = max(max_observed_concurrency, len(active_requests))
                 time.sleep(0.01)  # Simulate some work
                 rate_limit.exit(request_id)
-                active_requests.remove(request_id)
+                with observed_lock:
+                    active_requests.remove(request_id)
             except AppInvokeQuotaExceededError:
                 pass  # Expected under load
 
@@ -559,25 +567,23 @@ class TestRateLimitConcurrency:
 
         # All requests should have been cleaned up
         assert len(active_requests) == 0
+        # The cap must hold at every point in time, not just at the end.
+        assert max_observed_concurrency <= 10
 
     def _create_mock_redis(self):
         """Create a thread-safe mock Redis for concurrency tests."""
         import threading
 
         lock = threading.Lock()
-        data = {}
         hashes = {}
 
-        def mock_hlen(key):
+        def mock_eval(script, numkeys, key, max_active_requests, field, value):
             with lock:
-                return len(hashes.get(key, {}))
-
-        def mock_hset(key, field, value):
-            with lock:
-                if key not in hashes:
-                    hashes[key] = {}
-                hashes[key][field] = str(value).encode("utf-8")
-                return True
+                bucket = hashes.setdefault(key, {})
+                if len(bucket) >= int(max_active_requests):
+                    return 0
+                bucket[field] = str(value).encode("utf-8")
+                return 1
 
         def mock_hdel(key, *fields):
             with lock:
@@ -593,7 +599,6 @@ class TestRateLimitConcurrency:
         return {
             "exists.return_value": False,
             "setex.return_value": True,
-            "hlen.side_effect": mock_hlen,
-            "hset.side_effect": mock_hset,
+            "eval.side_effect": mock_eval,
             "hdel.side_effect": mock_hdel,
         }

--- a/api/tests/unit_tests/core/tools/utils/test_message_transformer.py
+++ b/api/tests/unit_tests/core/tools/utils/test_message_transformer.py
@@ -1,9 +1,23 @@
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
 import core.tools.utils.message_transformer as mt
 from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.signature import verify_tool_file_signature
+
+
+def _is_signed(url: str) -> bool:
+    query = parse_qs(urlparse(url).query)
+    if not ({"timestamp", "nonce", "sign"} <= query.keys()):
+        return False
+    return verify_tool_file_signature(
+        mt.ToolFileMessageTransformer._extract_tool_file_id(url) or "",
+        query["timestamp"][0],
+        query["nonce"][0],
+        query["sign"][0],
+    )
 
 
 class _FakeToolFile:
@@ -83,7 +97,8 @@ def test_transform_tool_invoke_messages_mimetype_key_present_but_none():
     o = out[0]
     assert o.type == ToolInvokeMessage.MessageType.BINARY_LINK
     assert isinstance(o.message, ToolInvokeMessage.TextMessage)
-    assert o.message.text.endswith(".bin")
+    assert urlparse(o.message.text).path.endswith(".bin")
+    assert _is_signed(o.message.text)
     # meta is preserved (still contains mime_type: None)
     assert "mime_type" in (o.meta or {})
     assert o.meta["mime_type"] is None
@@ -110,7 +125,8 @@ def test_transform_tool_invoke_messages_prefers_filename_extension_over_mimetype
     assert _FakeToolFileManager.last_call["filename"] == "report.docx"
     assert len(out) == 1
     assert isinstance(out[0].message, ToolInvokeMessage.TextMessage)
-    assert out[0].message.text.endswith(".docx")
+    assert urlparse(out[0].message.text).path.endswith(".docx")
+    assert _is_signed(out[0].message.text)
 
 
 def test_transform_tool_invoke_messages_parses_existing_tool_file_link_meta():
@@ -131,3 +147,19 @@ def test_transform_tool_invoke_messages_parses_existing_tool_file_link_meta():
 
     assert len(out) == 1
     assert out[0].meta["tool_file_id"] == "existing-tool-file"
+
+
+def test_get_tool_file_url_returns_signed_url():
+    url = mt.ToolFileMessageTransformer.get_tool_file_url(tool_file_id="signed-tool-file", extension=".png")
+
+    parsed = urlparse(url)
+    query = parse_qs(parsed.query)
+    assert parsed.path.endswith("/files/tools/signed-tool-file.png")
+    assert {"timestamp", "nonce", "sign"} <= query.keys()
+    assert verify_tool_file_signature("signed-tool-file", query["timestamp"][0], query["nonce"][0], query["sign"][0])
+
+
+def test_get_tool_file_url_defaults_missing_extension_to_bin():
+    url = mt.ToolFileMessageTransformer.get_tool_file_url(tool_file_id="signed-tool-file", extension=None)
+
+    assert urlparse(url).path.endswith("/files/tools/signed-tool-file.bin")

--- a/api/tests/unit_tests/services/test_dataset_service_segment.py
+++ b/api/tests/unit_tests/services/test_dataset_service_segment.py
@@ -526,6 +526,63 @@ class TestSegmentServiceMutations:
         assert {binding.attachment_id for binding in attachment_bindings} == {"att-1", "att-2"}
         assert mock_db.session.commit.call_count == 3
 
+    def test_create_segment_commits_before_releasing_position_lock(self, account_context):
+        """The read-check-insert-commit sequence must be fully covered by the redis lock.
+
+        Regression test for a race where `session.add`/`session.commit` sat outside the
+        `with redis_client.lock(...)` block, so two concurrent callers could read the same
+        `max_position` and commit segments with duplicate positions.
+        """
+        dataset = _make_dataset(indexing_technique="economy")
+        document = _make_document(
+            dataset_id=dataset.id,
+            tenant_id=dataset.tenant_id,
+            doc_form=IndexStructureType.QA_INDEX,
+            word_count=0,
+        )
+        args = {
+            "content": "question",
+            "answer": "answer",
+            "keywords": ["kw-1"],
+            "attachment_ids": [],
+        }
+
+        class RecordingLock:
+            def __init__(self, session: MagicMock):
+                self._session = session
+                self.commit_count_at_exit: int | None = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self.commit_count_at_exit = self._session.commit.call_count
+                return False
+
+        with (
+            patch("services.dataset_service.redis_client") as mock_redis,
+            patch("services.dataset_service.db") as mock_db,
+            patch("services.dataset_service.VectorService") as vector_service,
+            patch("services.dataset_service.helper.generate_text_hash", return_value="hash-1"),
+            patch("services.dataset_service.uuid.uuid4", return_value="node-1"),
+            patch("services.dataset_service.naive_utc_now", return_value="now"),
+        ):
+            recording_lock = RecordingLock(mock_db.session)
+            mock_redis.lock.return_value = recording_lock
+
+            mock_db.session.scalar.return_value = None
+            mock_db.session.get.return_value = SimpleNamespace(id="segment-1")
+
+            SegmentService.create_segment(
+                args=args,
+                document=document,
+                dataset=dataset,
+                session=mock_db.session,
+            )
+
+        assert recording_lock.commit_count_at_exit is not None
+        assert recording_lock.commit_count_at_exit >= 1
+
     def test_multi_create_segment_high_quality_marks_segments_error_when_vector_creation_fails(self, account_context):
         dataset = _make_dataset(indexing_technique="high_quality")
         document = _make_document(

--- a/api/tests/unit_tests/services/test_dataset_service_segment.py
+++ b/api/tests/unit_tests/services/test_dataset_service_segment.py
@@ -559,25 +559,26 @@ class TestSegmentServiceMutations:
                 self.commit_count_at_exit = self._session.commit.call_count
                 return False
 
+        session = MagicMock()
+
         with (
             patch("services.dataset_service.redis_client") as mock_redis,
-            patch("services.dataset_service.db") as mock_db,
-            patch("services.dataset_service.VectorService") as vector_service,
+            patch("services.dataset_service.VectorService"),
             patch("services.dataset_service.helper.generate_text_hash", return_value="hash-1"),
             patch("services.dataset_service.uuid.uuid4", return_value="node-1"),
             patch("services.dataset_service.naive_utc_now", return_value="now"),
         ):
-            recording_lock = RecordingLock(mock_db.session)
+            recording_lock = RecordingLock(session)
             mock_redis.lock.return_value = recording_lock
 
-            mock_db.session.scalar.return_value = None
-            mock_db.session.get.return_value = SimpleNamespace(id="segment-1")
+            session.scalar.return_value = None
+            session.get.return_value = SimpleNamespace(id="segment-1")
 
             SegmentService.create_segment(
                 args=args,
                 document=document,
                 dataset=dataset,
-                session=mock_db.session,
+                session=session,
             )
 
         assert recording_lock.commit_count_at_exit is not None


### PR DESCRIPTION
## Summary

Fixes #39222.

Tool-generated files — image-generation output, tool blobs, document references — came back with URLs that Dify's own `/files/tools/<id>` endpoint rejects with a 400, because the URL was never signed. Opening one fails immediately:

```
GET /files/tools/44111312-4099-465c-ae7b-1e661dce50c4.png HTTP/1.1" 400

pydantic_core._pydantic_core.ValidationError: 3 validation errors for ToolFileQuery
timestamp / nonce / sign  Field required
```

## Root cause

`/files/tools/<id>` requires `timestamp`, `nonce` and `sign` query params, validated by `ToolFileQuery` (`api/controllers/files/tool_files.py`) against an HMAC signature. That endpoint is behaving correctly — the bug is upstream, in `ToolFileMessageTransformer.get_tool_file_url()` (`message_transformer.py:203-204`), which built a bare unsigned path:

```python
# before
return f"/files/tools/{tool_file_id}{extension or '.bin'}"
```

That returned string becomes the literal URL text in the agent's answer or workflow output, and nothing re-signs it downstream — so it 400s the moment a user clicks it.

## Fix

```python
# after
return sign_tool_file(tool_file_id=tool_file_id, extension=extension or ".bin")
```

`sign_tool_file()` (`core/tools/signature.py`) is the same HMAC signer already used for every other tool-file URL in the codebase, so this brings the one remaining path into line rather than inventing a scheme.

This function is the single choke point for all three tool-output types — IMAGE, BLOB and FILE messages, producing IMAGE_LINK / BINARY_LINK / LINK respectively — so the one-line change covers all of them.

**Behavior note:** the returned URL is now absolute rather than relative, because `sign_tool_file` binds the signed path to `FILES_URL`. That is required for the signature to be verifiable and matches how `sign_tool_file` is used everywhere else.

### Why `base_app_runner.py` was not touched

The issue also names the unsigned `MessageFile.url` in `base_app_runner.py`. That value never reaches a client as-is: it is only used internally to recover `tool_file_id` (via `Message.message_files` in `models/model.py`), and is then re-signed fresh through `File.generate_url()` before display. It isn't part of this bug, so it was left alone to keep the change scoped.

## Tests

Existing tests asserted on the raw unsigned suffix (`.endswith(".bin")`), which no longer holds once a query string is appended. They now check the URL *path* and additionally round-trip the signature through `verify_tool_file_signature()`, so they assert the URL is genuinely valid rather than merely shaped correctly.

Two new tests cover `get_tool_file_url` directly: one verifying the signature is valid, one confirming the missing-extension `.bin` fallback still applies.

```
uv run --project api --dev pytest api/tests/unit_tests/core/tools/utils/test_message_transformer.py -q   # 5 passed
uv run --project api --dev pytest api/tests/unit_tests/core/tools/test_signature.py -q                   # 8 passed
```

`ruff check` and `ruff format --check` are clean on the changed files.

## Note on the diff

This branch is stacked on #39179, so the file list here also shows that PR's rate-limit and segment-lock changes. **The change under review in this PR is `api/core/tools/utils/message_transformer.py` and its test file** (commit `3a4574b`); everything else belongs to #39179 and will drop out of this diff once that merges. Happy to rebase onto `main` if reviewing it standalone is easier.

## Screenshots

Not applicable — backend-only fix; the visible effect is that tool file links load instead of returning 400.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `vp staged` (frontend) to appease the lint gods
