### PR TITLE
fix(api): PaginatedResult.pages should be 0 for an empty result set

### DIFF
--- a/api/libs/pagination.py
+++ b/api/libs/pagination.py
@@ -23,9 +23,9 @@ class PaginatedResult[T]:
 
     @property
     def pages(self) -> int:
-        if self.per_page == 0:
+        if self.total == 0 or self.per_page == 0:
             return 0
-        return max(1, math.ceil(self.total / self.per_page))
+        return math.ceil(self.total / self.per_page)
 
     @property
     def has_next(self) -> bool:

--- a/api/tests/unit_tests/libs/test_pagination.py
+++ b/api/tests/unit_tests/libs/test_pagination.py
@@ -1,0 +1,52 @@
+import math
+
+import pytest
+
+from libs.pagination import PaginatedResult
+
+
+class TestPaginatedResultPages:
+    def test_pages_is_zero_for_empty_result(self):
+        # Parity with Flask-SQLAlchemy's Pagination.pages, which PaginatedResult
+        # was introduced to replace as a drop-in (#38280): an empty result set
+        # has zero pages, not one.
+        result = PaginatedResult(items=[], total=0, page=1, per_page=20)
+        assert result.pages == 0
+
+    def test_has_next_is_false_for_empty_result(self):
+        result = PaginatedResult(items=[], total=0, page=1, per_page=20)
+        assert result.has_next is False
+
+    @pytest.mark.parametrize(
+        ("total", "per_page", "expected_pages"),
+        [
+            (1, 20, 1),
+            (20, 20, 1),
+            (21, 20, 2),
+            (40, 20, 2),
+            (41, 20, 3),
+        ],
+    )
+    def test_pages_for_non_empty_result(self, total, per_page, expected_pages):
+        result = PaginatedResult(items=[object()], total=total, page=1, per_page=per_page)
+        assert result.pages == expected_pages == math.ceil(total / per_page)
+
+    def test_pages_is_zero_when_per_page_is_zero(self):
+        result = PaginatedResult(items=[], total=0, page=1, per_page=0)
+        assert result.pages == 0
+
+
+class TestPaginatedResultHasNext:
+    def test_has_next_true_when_more_pages_remain(self):
+        result = PaginatedResult(items=[object()], total=41, page=1, per_page=20)
+        assert result.has_next is True
+
+    def test_has_next_false_on_last_page(self):
+        result = PaginatedResult(items=[object()], total=41, page=3, per_page=20)
+        assert result.has_next is False
+
+
+def test_paginated_result_is_iterable():
+    items = [1, 2, 3]
+    result = PaginatedResult(items=items, total=3, page=1, per_page=20)
+    assert list(result) == items


### PR DESCRIPTION
Closes #39228

### Summary

`libs.pagination.PaginatedResult` was introduced in #38280 as a drop-in replacement for Flask-SQLAlchemy's `db.paginate`, but its `pages` property used `max(1, ceil(total / per_page))` and therefore returned **1** when `total == 0`. Flask-SQLAlchemy's `Pagination.pages` returns **0** for an empty result set, so the refactor silently changed observable behavior.

`pages` is serialized directly as `total_pages` in the dataset segment / child-chunk list endpoints (all of which used `db.paginate` before #38280):

- `api/controllers/console/datasets/datasets_segments.py:291`
- `api/controllers/console/datasets/datasets_segments.py:793`
- `api/controllers/service_api/dataset/segment.py:659`

An empty list was reported as `{"total": 0, "total_pages": 1}`, producing a phantom page in clients.

### Change

```diff
 @property
 def pages(self) -> int:
-    if self.per_page == 0:
-        return 0
-    return max(1, math.ceil(self.total / self.per_page))
+    if self.total == 0 or self.per_page == 0:
+        return 0
+    return math.ceil(self.total / self.per_page)
```

This restores `db.paginate` parity. `has_next` is unaffected — `page < pages` already evaluated to `False` (`1 < 1`) for the empty-page-1 case, which the tests confirm.

### Tests

Adds `api/tests/unit_tests/libs/test_pagination.py` (the module had no unit tests): empty result → `pages == 0` / `has_next is False`, non-empty page counts (1/20/21/40/41 items per 20), last-page `has_next is False`, `per_page == 0`, and iteration. All 11 pass; the full `tests/unit_tests/libs` suite (563 tests) stays green; `ruff check` and `ruff format --check` clean.

### Notes

The other `.pages` references in the codebase are unrelated (Notion `info.pages`), and the three `total_pages` call sites serialize the value directly without assuming `pages >= 1`, so no caller relies on the old floor.