### PR TITLE
fix(api): correct DST spring-forward handling in parse_time_range

### DIFF
--- a/api/libs/datetime_utils.py
+++ b/api/libs/datetime_utils.py
@@ -70,8 +70,13 @@ def parse_time_range(
         except pytz.AmbiguousTimeError:
             return tz.localize(dt, is_dst=False).astimezone(utc)
         except pytz.NonExistentTimeError:
-            dt += datetime.timedelta(hours=1)
-            return tz.localize(dt, is_dst=None).astimezone(utc)
+            # Shift a non-existent (spring-forward) wall-clock time to the
+            # instant just after the gap. normalize() moves it forward by
+            # exactly the gap size for any DST offset change (30 min, 1 h,
+            # 2 h, ...), matching zoneinfo fold=0; a hardcoded +1 hour is
+            # wrong for non-one-hour gaps and can land inside a longer gap
+            # and re-raise.
+            return tz.normalize(tz.localize(dt, is_dst=False)).astimezone(utc)
 
     start_dt = _parse(start, "start")
     end_dt = _parse(end, "end")

--- a/api/tests/unit_tests/libs/test_datetime_utils.py
+++ b/api/tests/unit_tests/libs/test_datetime_utils.py
@@ -134,35 +134,35 @@ class TestParseTimeRange:
             assert end is not None
 
     def test_parse_time_range_dst_nonexistent_time(self):
-        """Test parsing during DST nonexistent time (spring forward)."""
-        with patch("pytz.timezone", autospec=True) as mock_timezone:
-            # Mock timezone that raises NonExistentTimeError
-            mock_tz = mock_timezone.return_value
+        """A non-existent (spring-forward) wall-clock time resolves to the
+        instant just after the gap, consistent with zoneinfo fold=0."""
+        # America/New_York springs forward 2024-03-10 02:00 -> 03:00, so
+        # 02:30 does not exist. The correct UTC instant is 07:30.
+        start, end = parse_time_range("2024-03-10 02:30", "2024-03-10 04:00", "America/New_York")
+        assert start == datetime.datetime(2024, 3, 10, 7, 30, tzinfo=pytz.UTC)
+        assert end == datetime.datetime(2024, 3, 10, 8, 0, tzinfo=pytz.UTC)
 
-            # Create a mock datetime object for the return value
-            mock_dt = datetime.datetime(2024, 1, 1, 10, 0, 0)
-            mock_utc_dt = mock_dt.replace(tzinfo=pytz.UTC)
+    def test_parse_time_range_dst_nonexistent_time_gap_longer_than_one_hour(self):
+        """A spring-forward gap longer than one hour must not raise.
 
-            # Create a proper mock for the localized datetime
-            from unittest.mock import MagicMock
+        Antarctica/Troll springs forward 2 hours (2024-03-31 01:00 -> 03:00),
+        so 01:30 is non-existent and a naive +1h adjustment lands at 02:30,
+        which is still inside the gap. The resolved instant matches
+        zoneinfo fold=0 (01:30 +00:00 == 01:30 UTC).
+        """
+        start, _ = parse_time_range("2024-03-31 01:30", None, "Antarctica/Troll")
+        assert start == datetime.datetime(2024, 3, 31, 1, 30, tzinfo=pytz.UTC)
 
-            mock_localized_dt = MagicMock()
-            mock_localized_dt.astimezone.return_value = mock_utc_dt
+    def test_parse_time_range_dst_nonexistent_time_sub_hour_gap(self):
+        """A spring-forward gap shorter than one hour resolves to the correct
+        instant, not one shifted by a hardcoded hour.
 
-            # Set up side effects: first call raises exception, second call succeeds
-            mock_tz.localize.side_effect = [
-                pytz.NonExistentTimeError("Non-existent time"),  # First call for start
-                mock_localized_dt,  # Second call for start (with adjusted time)
-                pytz.NonExistentTimeError("Non-existent time"),  # First call for end
-                mock_localized_dt,  # Second call for end (with adjusted time)
-            ]
-
-            start, end = parse_time_range("2024-01-01 10:00", "2024-01-01 18:00", "US/Eastern")
-
-            # Should adjust time forward by 1 hour for nonexistent times
-            assert mock_tz.localize.call_count == 4  # 2 calls per time (first fails, second succeeds)
-            assert start is not None
-            assert end is not None
+        Australia/Lord_Howe springs forward only 30 minutes (2024-10-06
+        02:00 +10:30 -> 02:30 +11:00), so 02:15 is non-existent. Per
+        zoneinfo fold=0 the instant is 02:15 +10:30 == 2024-10-05 15:45 UTC.
+        """
+        start, _ = parse_time_range("2024-10-06 02:15", None, "Australia/Lord_Howe")
+        assert start == datetime.datetime(2024, 10, 5, 15, 45, tzinfo=pytz.UTC)
 
     def test_parse_time_range_edge_cases(self):
         """Test edge cases for time parsing."""


### PR DESCRIPTION
Closes #39230

### Summary

`libs/datetime_utils.py::parse_time_range` resolved a non-existent (DST spring-forward) wall-clock time by adding a hardcoded one hour, assuming every gap is exactly one hour. Real tzdata has other gap sizes, producing two bugs:

- **Gaps > 1 h (e.g. Antarctica/Troll +2 h, Pacific/Apia 24 h):** `+1h` lands *inside* the gap, so the retry `tz.localize(..., is_dst=None)` raises `NonExistentTimeError` again — uncaught, leaking a raw pytz exception out of a function documented to raise only `ValueError`.
- **Gaps < 1 h (e.g. Australia/Lord_Howe +30 min):** the result is shifted by an hour instead of the actual gap, so the returned UTC instant is wrong (16:15 UTC instead of 15:45 UTC for 02:15), silently shifting analytics time-range bounds.

### Change

```diff
 except pytz.NonExistentTimeError:
-    dt += datetime.timedelta(hours=1)
-    return tz.localize(dt, is_dst=None).astimezone(utc)
+    return tz.normalize(tz.localize(dt, is_dst=False)).astimezone(utc)
```

`tz.normalize(tz.localize(dt, is_dst=False))` shifts a non-existent time forward by exactly the gap size for any offset change (30 min, 1 h, 2 h, ...), matching `zoneinfo` fold=0. It never re-raises. Standard one-hour gaps are unchanged (America/New_York 02:30 → 07:30 UTC). The `AmbiguousTimeError` (fall-back) branch is untouched.

Verified the fix matches stdlib `zoneinfo` fold=0 for Antarctica/Troll, Australia/Lord_Howe, Pacific/Apia, and America/New_York.

### Tests

Replaces the previous mock-based `test_parse_time_range_dst_nonexistent_time` (which patched `pytz.timezone` and asserted the old `localize` call sequence rather than a real result — it used Jan 1, not an actual DST transition) with real-timezone tests:

- standard 1 h gap — `America/New_York` 02:30 → 07:30 UTC (unchanged behavior),
- gap > 1 h — `Antarctica/Troll` 01:30 must not raise and resolves to 01:30 UTC,
- gap < 1 h — `Australia/Lord_Howe` 02:15 → 2024-10-05 15:45 UTC.

All 25 `test_datetime_utils` tests pass; the full `tests/unit_tests/libs` suite stays green; `ruff check` and `ruff format --check` clean.