### PR TITLE
fix(trigger): make credentials optional in TriggerSubscriptionBuilderVerifyPayload

### DIFF
--- a/api/controllers/console/workspace/trigger_providers.py
+++ b/api/controllers/console/workspace/trigger_providers.py
@@ -53,7 +53,7 @@ class TriggerSubscriptionBuilderCreatePayload(BaseModel):
 
 
 class TriggerSubscriptionBuilderVerifyPayload(BaseModel):
-    credentials: dict[str, Any]
+    credentials: dict[str, Any] | None = None
 
 
 class TriggerSubscriptionBuilderUpdatePayload(BaseModel):


### PR DESCRIPTION
## Problem

OAuth-based trigger providers (e.g. Gmail Trigger) poll the verify endpoint every 3 seconds while the OAuth flow is pending. The `credentials` field is required in the Pydantic model, but OAuth credentials are written asynchronously by the callback — the polling request has no credentials yet, causing a `400 invalid_param` error:

```
1 validation error for TriggerSubscriptionBuilderVerifyPayload
credentials
  Field required [type=missing]
```

Closes #39198.

## Fix

Make `credentials` optional (`dict[str, Any] | None = None`) in `TriggerSubscriptionBuilderVerifyPayload`. The downstream `SubscriptionBuilderUpdater` already handles `None` credentials correctly — it does not overwrite existing stored credentials.

## Testing

- `python -c "import ast; ast.parse(open('api/controllers/console/workspace/trigger_providers.py').read())"` passes
- A polling request without `credentials` now returns `{"verified": false}` instead of `400 invalid_param`
- A polling request with `credentials` still works as before

## Checklist

- [x] Single-file change
- [x] No new dependencies
- [x] Commit references the issue