### PR TITLE
fix(api): reject trailing newline in email() validator

### DIFF
--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -221,8 +221,11 @@ def current_timestamp() -> int:
 def email(email):
     # Define a regex pattern for email addresses
     pattern = r"^[\w\.!#$%&'*+\-/=?^_`{|}~]+@([\w-]+\.)+[\w-]{2,}$"
-    # Check if the email matches the pattern
-    if re.match(pattern, email) is not None:
+    # Use fullmatch: re.match anchors the end with `$`, which in Python also
+    # matches just before a trailing newline, so "user@example.com\n" would
+    # pass -- a mail header-injection vector. fullmatch requires the whole
+    # string to match, rejecting any trailing newline.
+    if re.fullmatch(pattern, email) is not None:
         return email
 
     error = f"{email} is not a valid email."

--- a/api/tests/unit_tests/libs/test_helper.py
+++ b/api/tests/unit_tests/libs/test_helper.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 import pytest
 
-from libs.helper import OptionalTimestampField, escape_like_pattern, extract_tenant_id
+from libs.helper import OptionalTimestampField, email, escape_like_pattern, extract_tenant_id
 from models.account import Account
 from models.model import EndUser
 
@@ -126,3 +126,28 @@ class TestEscapeLikePattern:
         result = escape_like_pattern("test\\%_value")
         # Should be: test\\\%\_value
         assert result == "test\\\\\\%\\_value"
+
+
+class TestEmailValidator:
+    """Tests for the email() validator used by EmailStr on the auth surface."""
+
+    def test_accepts_valid_email(self):
+        assert email("user@example.com") == "user@example.com"
+
+    def test_accepts_valid_email_with_special_local_part(self):
+        assert email("o'brien+tag@example.co.uk") == "o'brien+tag@example.co.uk"
+
+    def test_rejects_trailing_newline(self):
+        # re.match anchors the end with `$`, which in Python also matches just
+        # before a trailing newline, so a CR/LF-bearing address slipped through
+        # -- a mail header-injection vector.
+        with pytest.raises(ValueError):
+            email("user@example.com\n")
+
+    def test_rejects_missing_domain(self):
+        with pytest.raises(ValueError):
+            email("user@")
+
+    def test_rejects_plain_string(self):
+        with pytest.raises(ValueError):
+            email("not-an-email")


### PR DESCRIPTION
Closes https://github.com/langgenius/dify/issues/39234

### Summary

`libs/helper.py::email()` validated with `re.match` against a `$`-anchored pattern. In Python `$` matches at end-of-string **or just before a trailing newline**, so `email("user@example.com\n")` returned the value as valid instead of raising.

`email()` backs the `EmailStr` type used across the auth surface (login, registration, forgot-password, activate, workspace member invite). A CR/LF in an accepted address is a mail header-injection primitive and defeats exact-match uniqueness/normalization (`"a@b.com\n" != "a@b.com"`).

### Change

```diff
-    if re.match(pattern, email) is not None:
+    if re.fullmatch(pattern, email) is not None:
```

`re.fullmatch` requires the entire string to match, rejecting a trailing newline. Behavior changes **only** for the trailing-newline case — every currently-valid address still validates (verified: `re.match` and `re.fullmatch` differ only on strings with content after the `$` match, i.e. a trailing `\n`).

### Tests

Adds `TestEmailValidator` to `tests/unit_tests/libs/test_helper.py` (the validator had no unit tests): accepts valid / special-local-part addresses, rejects trailing newline, missing domain, and plain strings. All 22 `test_helper` tests pass; `ruff check` and `ruff format --check` clean.