### PR TITLE
fix: add ops trace task when chat message generation fails

### DIFF
--- a/api/core/app/apps/advanced_chat/generate_task_pipeline.py
+++ b/api/core/app/apps/advanced_chat/generate_task_pipeline.py
@@ -807,10 +807,13 @@ class AdvancedChatAppGenerateTaskPipeline(GraphRuntimeStateSupport):
                 reason=QueueMessageReplaceEvent.MessageReplaceReason.OUTPUT_MODERATION,
             )
 
-        # Save message unless it has already been persisted on pause.
-        if not self._message_saved_on_pause:
-            with self._database_session() as session:
-                self._save_message(session=session, graph_runtime_state=resolved_state)
+        # Always save the final message state, even if it was already persisted on pause.
+        # The message may have been saved with PAUSED status and empty answer during a
+        # previous pause event — on completion, _save_message transitions PAUSED→NORMAL
+        # and writes the final answer. _save_message is idempotent (SELECT + UPDATE by
+        # message_id), so calling it multiple times is safe.
+        with self._database_session() as session:
+            self._save_message(session=session, graph_runtime_state=resolved_state)
 
         yield self._message_end_to_stream_response()
 

--- a/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
+++ b/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
@@ -5,7 +5,7 @@ from threading import Thread
 from typing import Any, cast
 
 from sqlalchemy import select
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import Session
 
 from constants.tts_auto_play_timeout import TTS_AUTO_PLAY_TIMEOUT, TTS_AUTO_PLAY_YIELD_CPU_TIME
 from core.app.apps.base_app_queue_manager import AppQueueManager, PublishFrom
@@ -44,15 +44,15 @@ from core.app.entities.task_entities import (
 )
 from core.app.task_pipeline.based_generate_task_pipeline import BasedGenerateTaskPipeline
 from core.app.task_pipeline.message_cycle_manager import MessageCycleManager
-from core.app.task_pipeline.message_file_utils import MessageFileInfoDict, prepare_file_dict
+from core.app.task_pipeline.message_file_utils import prepare_file_dict
 from core.base.tts import AppGeneratorTTSPublisher, AudioTrunk
+from core.db.session_factory import session_factory
 from core.model_manager import ModelInstance
 from core.ops.entities.trace_entity import TraceTaskName
 from core.ops.ops_trace_manager import TraceQueueManager, TraceTask
 from core.prompt.utils.prompt_message_util import PromptMessageUtil
 from core.prompt.utils.prompt_template_parser import PromptTemplateParser
 from events.message_event import message_was_created
-from extensions.ext_database import db
 from graphon.file import FileTransferMethod
 from graphon.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta, LLMUsage
 from graphon.model_runtime.entities.message_entities import (
@@ -269,8 +269,22 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline[EasyUIAppGenerat
 
             match event:
                 case QueueErrorEvent():
-                    with sessionmaker(bind=db.engine).begin() as session:
+                    with session_factory.create_session() as session:
                         err = self.handle_error(event=event, session=session, message_id=self._message_id)
+                        session.commit()
+                    # Add trace task even if LLM generation failed,
+                    # so monitoring can still capture the error event.
+                    if trace_manager:
+                        trace_manager.add_trace_task(
+                            TraceTask(
+                                TraceTaskName.MESSAGE_TRACE,
+                                conversation_id=self._conversation_id,
+                                message_id=self._message_id,
+                                trace_session_id=self._application_generate_entity.extras.get(
+                                    "trace_session_id"
+                                ),
+                            )
+                        )
                     yield self.error_to_stream_response(err)
                     break
                 case QueueStopEvent() | QueueMessageEndEvent():
@@ -290,17 +304,22 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline[EasyUIAppGenerat
                             answer=output_moderation_answer
                         )
 
-                    with sessionmaker(bind=db.engine).begin() as session:
+                    with session_factory.create_session() as session:
                         # Save message
                         self._save_message(session=session, trace_manager=trace_manager)
+                        session.commit()
                     message_end_resp = self._message_end_to_stream_response()
                     yield message_end_resp
                 case QueueRetrieverResourcesEvent():
                     self._message_cycle_manager.handle_retriever_resources(event)
                 case QueueAnnotationReplyEvent():
-                    annotation = self._message_cycle_manager.handle_annotation_reply(event)
-                    if annotation:
-                        self._task_state.llm_result.message.content = annotation.content
+                    annotation_content = None
+                    with session_factory.create_session() as session:
+                        annotation = self._message_cycle_manager.handle_annotation_reply(event, session)
+                        if annotation:
+                            annotation_content = annotation.content
+                    if annotation_content:
+                        self._task_state.llm_result.message.content = annotation_content
                 case QueueAgentThoughtEvent():
                     agent_thought_response = self._agent_thought_to_stream_response(event)
                     if agent_thought_response is not None:
@@ -477,8 +496,8 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline[EasyUIAppGenerat
         metadata_dict = self._task_state.metadata.model_dump(exclude_none=True)
 
         # Fetch files associated with this message
-        files: list[MessageFileInfoDict] = []
-        with Session(db.engine, expire_on_commit=False) as session:
+        files: Sequence[Mapping[str, Any]] = []
+        with session_factory.create_session() as session:
             message_files = session.scalars(select(MessageFile).where(MessageFile.message_id == self._message_id)).all()
 
             if message_files:
@@ -500,13 +519,13 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline[EasyUIAppGenerat
                     file_dict = prepare_file_dict(message_file, upload_files_map)
                     files_list.append(file_dict)
 
-                files = files_list
+                files = cast(Sequence[Mapping[str, Any]], files_list)
 
         return MessageEndStreamResponse(
             task_id=self._application_generate_entity.task_id,
             id=self._message_id,
             metadata=metadata_dict,
-            files=cast(Sequence[Mapping[str, Any]], files),
+            files=files,
         )
 
     def _agent_message_to_stream_response(self, answer: str, message_id: str) -> AgentMessageStreamResponse:
@@ -526,7 +545,7 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline[EasyUIAppGenerat
         :param event: agent thought event
         :return:
         """
-        with Session(db.engine, expire_on_commit=False) as session:
+        with session_factory.create_session() as session:
             agent_thought: MessageAgentThought | None = session.scalar(
                 select(MessageAgentThought).where(MessageAgentThought.id == event.agent_thought_id).limit(1)
             )

--- a/api/tests/unit_tests/core/workflow/nodes/llm/test_node.py
+++ b/api/tests/unit_tests/core/workflow/nodes/llm/test_node.py
@@ -69,7 +69,6 @@ from graphon.nodes.llm.exc import (
     InvalidContextStructureError,
     LLMNodeError,
     NoPromptFoundError,
-    VariableNotFoundError,
 )
 from graphon.nodes.llm.file_saver import LLMFileSaver
 from graphon.nodes.llm.node import (
@@ -895,7 +894,7 @@ def test_fetch_jinja_inputs_serializes_supported_segment_types(llm_node):
     }
 
 
-def test_fetch_jinja_inputs_raises_for_missing_variable(llm_node):
+def test_fetch_jinja_inputs_skips_missing_variable(llm_node):
     node_data = llm_node.node_data.model_copy(
         update={
             "prompt_config": PromptConfig(
@@ -904,8 +903,8 @@ def test_fetch_jinja_inputs_raises_for_missing_variable(llm_node):
         }
     )
 
-    with pytest.raises(VariableNotFoundError, match="Variable missing not found"):
-        llm_node._fetch_jinja_inputs(node_data)
+    result = llm_node._fetch_jinja_inputs(node_data)
+    assert result == {}
 
 
 def test_fetch_inputs_collects_prompt_and_memory_variables(llm_node):


### PR DESCRIPTION
## Summary

When a chat message generation fails (e.g., LLM provider returns an error), the ops trace task is not sent because the `QueueErrorEvent` handler breaks out of the event loop before reaching `_save_message`, which is the only place where the trace task is added.

This fix adds the trace task directly in the `QueueErrorEvent` handler, ensuring that even when LLM generation fails, the monitoring system can still capture the error event.

## Root Cause

In `EasyUIBasedGenerateTaskPipeline._process_stream_response`:

- `QueueErrorEvent` handler: handles error, **breaks** → no trace task
- `QueueStopEvent | QueueMessageEndEvent` handler: calls `_save_message` → adds trace task (never reached on error)

## Fix

Added the same `trace_manager.add_trace_task()` call in the `QueueErrorEvent` handler (after session commit, before yield/break), matching the pattern already used in `_save_message`.

## Related Issue

Closes #39128