### PR TITLE
fix(ci): skip merge commits in hotfix cherry-pick provenance checker

### DIFF
--- a/.github/scripts/check-hotfix-cherry-picks.sh
+++ b/.github/scripts/check-hotfix-cherry-picks.sh
@@ -60,7 +60,7 @@ while IFS= read -r commit_sha; do
     error "Commit $commit_sha ($subject) references source $source_sha, but that source is not reachable from main ($MAIN_REF). $REMEDIATION_HINT"
     failed=1
   fi
-done < <(git rev-list --reverse "$BASE_SHA..$HEAD_SHA")
+done < <(git rev-list --no-merges --reverse "$BASE_SHA..$HEAD_SHA")
 
 if [[ "$failed" -ne 0 ]]; then
   exit 1


### PR DESCRIPTION
The Hotfix Cherry-Pick Provenance workflow iterates every commit in the PR range via 'git rev-list --reverse', which includes merge commits. When a hotfix PR branch is synced with its base hotfix branch, the resulting merge commit has no cherry-pick provenance trailer (correctly, since it is not a cherry-pick), so the checker fails the PR even though every actual cherry-picked commit carries valid provenance.

This adds --no-merges to the rev-list so only single-parent commits are validated. Merge commits cannot reasonably carry a '(cherry picked from commit <sha>)' trailer and are not the commits the provenance rule is meant to police. The reporter reproduced this on PR #38990 where four cherry-picked commits all had valid provenance but the job failed on the sync merge commit.

Verified locally against a reproduction repo: before the change 'git rev-list --reverse BASE..HEAD' returns 4 commits (including the merge), after the change it returns 3 (only the cherry-picks), and the script still correctly flags commits that genuinely lack a source trailer.

Fixes #38996