### PR TITLE
fix(app): sign multimodal tool file URL in MessageFile record

### DIFF
--- a/api/core/app/apps/base_app_runner.py
+++ b/api/core/app/apps/base_app_runner.py
@@ -32,7 +32,8 @@ from core.moderation.input_moderation import InputModeration
 from core.prompt.advanced_prompt_transform import AdvancedPromptTransform
 from core.prompt.entities.advanced_prompt_entities import ChatModelMessage, CompletionModelPromptTemplate, MemoryConfig
 from core.prompt.simple_prompt_transform import ModelMode, SimplePromptTransform
-from core.tools.tool_file_manager import ToolFileManager
+from core.tools.signature import sign_tool_file
+from core.tools.tool_file_manager import ToolFileManager, resolve_extension
 from graphon.file import FileTransferMethod, FileType
 from graphon.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta, LLMUsage
 from graphon.model_runtime.entities.message_entities import (
@@ -419,7 +420,6 @@ class AppRunner:
 
                 image_binary = base64.b64decode(base64_data)
                 mimetype = content.mime_type or "image/png"
-                extension = guess_extension(mimetype) or ".png"
 
                 tool_file = tool_file_manager.create_file_by_raw(
                     user_id=user_id,
@@ -427,7 +427,7 @@ class AppRunner:
                     conversation_id=None,
                     file_binary=image_binary,
                     mimetype=mimetype,
-                    filename=f"generated_image{extension}",
+                    filename=f"generated_image{guess_extension(mimetype) or '.png'}",
                 )
                 _logger.info("Image saved successfully, tool_file_id: %s", tool_file.id)
             else:
@@ -435,6 +435,12 @@ class AppRunner:
         except Exception:
             _logger.exception("Failed to save image file")
             return None
+
+        # Resolve the file extension once for both branches and build a signed URL.
+        # The /files/tools/<id> endpoint (controllers/files/tool_files.py) requires
+        # signed query parameters (timestamp, nonce, sign); an unsigned URL is
+        # rejected with a 400 ValidationError at request time.
+        extension = resolve_extension(filename=tool_file.name, mimetype=tool_file.mimetype)
 
         # Create MessageFile record.
         # Use an independent session so this side-effect write does not
@@ -444,7 +450,7 @@ class AppRunner:
             type=FileType.IMAGE,
             transfer_method=FileTransferMethod.TOOL_FILE,
             belongs_to=MessageFileBelongsTo.ASSISTANT,
-            url=f"/files/tools/{tool_file.id}",
+            url=sign_tool_file(tool_file_id=tool_file.id, extension=extension),
             upload_file_id=tool_file.id,
             created_by_role=(
                 CreatorUserRole.ACCOUNT if queue_manager.invoke_from.runs_as_account() else CreatorUserRole.END_USER

--- a/api/tests/unit_tests/core/app/apps/chat/test_base_app_runner_multimodal.py
+++ b/api/tests/unit_tests/core/app/apps/chat/test_base_app_runner_multimodal.py
@@ -42,6 +42,8 @@ class TestBaseAppRunnerMultimodal:
         """Create a mock tool file."""
         tool_file = MagicMock()
         tool_file.id = str(uuid4())
+        tool_file.name = "image.png"
+        tool_file.mimetype = "image/png"
         return tool_file
 
     @pytest.fixture
@@ -109,6 +111,14 @@ class TestBaseAppRunnerMultimodal:
                 assert call_kwargs["transfer_method"] == FileTransferMethod.TOOL_FILE
                 assert call_kwargs["belongs_to"] == "assistant"
                 assert call_kwargs["created_by"] == mock_user_id
+
+                # The stored URL must be signed (timestamp/nonce/sign query params)
+                # so the /files/tools/<id> endpoint accepts it instead of 400ing.
+                signed_url = call_kwargs["url"]
+                assert "timestamp=" in signed_url
+                assert "nonce=" in signed_url
+                assert "sign=" in signed_url
+                assert f"/files/tools/{mock_tool_file.id}" in signed_url
 
                 file_session.add.assert_called_once_with(mock_message_file)
                 file_session.flush.assert_called_once()


### PR DESCRIPTION
When an LLM returns image content (URL or base64), _handle_multimodal_image_content in base_app_runner.py stored an unsigned relative URL (/files/tools/<id>) in the MessageFile record. The /files/tools/<id>.<ext> endpoint validates timestamp, nonce, and sign query parameters via ToolFileQuery, so accessing these stored URLs fails with a 400 pydantic ValidationError (all three fields reported as missing).

This builds the URL through sign_tool_file(), the same helper ToolFileMessageTransformer already uses for its tool file links, so the stored MessageFile URL carries the required signature. The file extension is now resolved once after the file is saved (covering both the URL-fetch and base64 branches) via resolve_extension(filename, mimetype) instead of only being computed inside the base64 branch.

Added a regression assertion in test_handle_multimodal_image_content_with_url that the stored URL contains timestamp/nonce/sign and the tool file id. The existing multimodal test suite (7 tests) and base_app_runner tests (18 tests) pass, and ruff lint/format are clean.

This is the base_app_runner.py location called out in #39222; it complements #39225, which signs the ToolFileMessageTransformer.get_tool_file_url path.

Fixes #39222