### PR TITLE
fix: change email not work (#39182)

### DIFF
--- a/web/app/account/(commonLayout)/account-page/email-change-modal.tsx
+++ b/web/app/account/(commonLayout)/account-page/email-change-modal.tsx
@@ -59,7 +59,7 @@ function isFetchResponseError(error: unknown): error is FetchResponseError {
 const EmailChangeModal = ({ onClose, email }: Props) => {
   const { t } = useTranslation()
   const router = useRouter()
-  const [step, setStep] = useState<Step>(STEP.newEmail)
+  const [step, setStep] = useState<Step>(STEP.start)
   const [code, setCode] = useState<string>('')
   const [mail, setMail] = useState<string>('')
   const [time, setTime] = useState<number>(0)


### PR DESCRIPTION
## Summary

Cherry-picks `aff8a49bbfd41cbdf74d0df1bbe46b66ab687312` onto `hotfix/1.15.0-fix.13`.

Restores old-email verification as the first step before accepting a new email address.

## Validation

- `BASE_SHA=myori/hotfix/1.15.0-fix.13 HEAD_SHA=HEAD MAIN_REF=myori/main bash .github/scripts/check-hotfix-cherry-picks.sh` -> verified 1 PR commit includes cherry-pick provenance from main
- `git diff --check myori/hotfix/1.15.0-fix.13...HEAD` -> passed
- `pnpm --dir web type-check` -> passed
- `pnpm exec eslint --no-cache 'web/app/account/(commonLayout)/account-page/email-change-modal.tsx'` -> passed with 0 errors (1 pre-existing icon-style warning)
