### PR TITLE
fix(dataset_service): widen create_segment lock to cover insert and commit

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -3393,41 +3393,47 @@ class SegmentService:
                     segment_document.word_count += len(args["answer"])
                     segment_document.answer = args["answer"]
 
-            session.add(segment_document)
-            # update document word count
-            assert document.word_count is not None
-            document.word_count += segment_document.word_count
-            session.add(document)
-            session.commit()
+                # Persist the segment and the document word-count update inside
+                # the lock so the read-max-position / insert / commit sequence is
+                # atomic across concurrent requests. Otherwise two callers can
+                # both read the same max_position before either commits, producing
+                # duplicate positions. This matches multi_create_segment, which
+                # keeps session.add()/commit() within its lock block.
+                session.add(segment_document)
+                # update document word count
+                assert document.word_count is not None
+                document.word_count += segment_document.word_count
+                session.add(document)
+                session.commit()
 
-            if args["attachment_ids"]:
-                for attachment_id in args["attachment_ids"]:
-                    binding = SegmentAttachmentBinding(
-                        tenant_id=current_user.current_tenant_id,
-                        dataset_id=document.dataset_id,
-                        document_id=document.id,
-                        segment_id=segment_document.id,
-                        attachment_id=attachment_id,
+                if args["attachment_ids"]:
+                    for attachment_id in args["attachment_ids"]:
+                        binding = SegmentAttachmentBinding(
+                            tenant_id=current_user.current_tenant_id,
+                            dataset_id=document.dataset_id,
+                            document_id=document.id,
+                            segment_id=segment_document.id,
+                            attachment_id=attachment_id,
+                        )
+                        session.add(binding)
+                    session.commit()
+
+                # save vector index
+                try:
+                    keywords = args.get("keywords")
+                    keywords_list = [keywords] if keywords is not None else None
+                    VectorService.create_segments_vector(
+                        keywords_list, [segment_document], dataset, document.doc_form, session=session
                     )
-                    session.add(binding)
-                session.commit()
-
-            # save vector index
-            try:
-                keywords = args.get("keywords")
-                keywords_list = [keywords] if keywords is not None else None
-                VectorService.create_segments_vector(
-                    keywords_list, [segment_document], dataset, document.doc_form, session=session
-                )
-            except Exception as e:
-                logger.exception("create segment index failed")
-                segment_document.enabled = False
-                segment_document.disabled_at = naive_utc_now()
-                segment_document.status = SegmentStatus.ERROR
-                segment_document.error = str(e)
-                session.commit()
-            segment = session.get(DocumentSegment, segment_document.id)
-            return segment
+                except Exception as e:
+                    logger.exception("create segment index failed")
+                    segment_document.enabled = False
+                    segment_document.disabled_at = naive_utc_now()
+                    segment_document.status = SegmentStatus.ERROR
+                    segment_document.error = str(e)
+                    session.commit()
+                segment = session.get(DocumentSegment, segment_document.id)
+                return segment
         except LockNotOwnedError:
             pass
 


### PR DESCRIPTION
SegmentService.create_segment currently wraps only the max_position read and the DocumentSegment construction in its per-document Redis lock (add_segment_lock_document_id_{document.id}). The session.add(), the document word-count update, session.add(document) and session.commit() all run *after* the lock has been released. That leaves a classic check-then-act window: two concurrent create-segment requests for the same document can both read the same max_position before either commits, so both insert a segment at the identical position value. Since there's no unique constraint on (document_id, position), both inserts succeed silently and segment ordering gets corrupted.

This moves session.add()/commit() (plus the attachment-binding write and the vector-index write that depend on the committed segment id) inside the with redis_client.lock(...) block, so the read-position / insert / commit sequence is atomic under the lock. This mirrors the existing multi_create_segment method, which already keeps its session.add()/commit() within its own lock block — so create_segment now follows the same established pattern.

Verified against the existing unit tests (test_dataset_service_segment.py and test_dataset_service_lock_not_owned.py, 45 tests pass). No behaviour change in the non-contended path; the only difference is the lock is held until commit instead of being released early.

Fixes #39022

### Checklist

- [x] My code follows the style guidelines of this project (Ruff clean)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (existing unit tests cover the lock-held path)