### PR TITLE
fix(rate_limit): make enter() check-and-set atomic via Lua script

### DIFF
--- a/api/core/app/features/rate_limiting/rate_limit.py
+++ b/api/core/app/features/rate_limiting/rate_limit.py
@@ -21,6 +21,25 @@ class RateLimit:
     _instance_dict: dict[str, "RateLimit"] = {}
     max_active_requests: int
 
+    # Atomically enforce the active-request cap and admit a request in a single
+    # round trip. The previous implementation ran HLEN (check) and HSET (act) as
+    # two independent Redis calls, so N concurrent callers could all observe a
+    # count below the cap and all proceed to register, pushing the active count
+    # to ``max_active_requests - 1 + N``. Doing the check-and-set inside a Lua
+    # script makes Redis evaluate it single-threaded and eliminates the race.
+    #
+    # KEYS[1] = active requests hash key
+    # ARGV[1] = request id (hash field)
+    # ARGV[2] = timestamp to store as the field value
+    # ARGV[3] = max active requests cap
+    # Returns the stored value on admit, or nil on rejection.
+    _ADMIT_SCRIPT = """
+        if redis.call('HLEN', KEYS[1]) >= tonumber(ARGV[3]) then
+            return nil
+        end
+        return redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
+    """
+
     def __new__(cls, client_id: str, max_active_requests: int):
         if client_id not in cls._instance_dict:
             instance = super().__new__(cls)
@@ -46,6 +65,7 @@ class RateLimit:
         self.max_active_requests_key = self._MAX_ACTIVE_REQUESTS_KEY.format(client_id)
         self.last_recalculate_time = float("-inf")
         self.flush_cache(use_local_value=True)
+        self._admit_script = redis_client.register_script(self._ADMIT_SCRIPT)
 
     def flush_cache(self, use_local_value=False):
         self.last_recalculate_time = time.time()
@@ -78,13 +98,18 @@ class RateLimit:
         if not request_id:
             request_id = RateLimit.gen_request_key()
 
-        active_requests_count = redis_client.hlen(self.active_requests_key)
-        if active_requests_count >= self.max_active_requests:
+        # Admit atomically: the Lua script checks HLEN against the cap and only
+        # runs HSET when there is still headroom, all in one Redis round trip.
+        # It returns nil (None in Python) when the cap has been reached.
+        admitted = self._admit_script(
+            keys=[self.active_requests_key],
+            args=[request_id, str(time.time()), self.max_active_requests],
+        )
+        if admitted is None:
             raise AppInvokeQuotaExceededError(
                 f"Too many requests. Please try again later. The current maximum concurrent requests allowed "
                 f"for {self.client_id} is {self.max_active_requests}."
             )
-        redis_client.hset(self.active_requests_key, request_id, str(time.time()))
         return request_id
 
     def exit(self, request_id: str):

--- a/api/tests/unit_tests/core/app/features/rate_limiting/test_rate_limit.py
+++ b/api/tests/unit_tests/core/app/features/rate_limiting/test_rate_limit.py
@@ -1,7 +1,7 @@
 import threading
 import time
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -194,8 +194,7 @@ class TestRateLimitEnterExit:
             **{
                 "exists.return_value": False,
                 "setex.return_value": True,
-                "hlen.return_value": 2,
-                "hset.return_value": True,
+                "register_script.return_value": Mock(return_value=1),
             }
         )
 
@@ -203,7 +202,10 @@ class TestRateLimitEnterExit:
         request_id = rate_limit.enter()
 
         assert request_id != RateLimit._UNLIMITED_REQUEST_ID
-        redis_patch.hset.assert_called_once()
+        rate_limit._admit_script.assert_called_once()
+        call_kwargs = rate_limit._admit_script.call_args.kwargs
+        assert call_kwargs["keys"] == [rate_limit.active_requests_key]
+        assert call_kwargs["args"][2] == 5  # max_active_requests cap
 
     def test_should_generate_request_id_if_not_provided(self, redis_patch):
         """Test auto-generation of request ID."""
@@ -257,7 +259,7 @@ class TestRateLimitEnterExit:
             **{
                 "exists.return_value": False,
                 "setex.return_value": True,
-                "hlen.return_value": 5,  # At limit
+                "register_script.return_value": Mock(return_value=None),  # Lua script rejects (nil)
             }
         )
 
@@ -485,28 +487,31 @@ class TestRateLimitConcurrency:
 
     def test_should_handle_concurrent_enter_requests(self, redis_patch):
         """Test concurrent enter requests handling."""
-        # Setup mock to simulate realistic Redis behavior
-        request_count = 0
+        # The Lua admit script runs single-threaded inside Redis. We mirror that
+        # atomicity with a lock so the cap is enforced exactly, validating the
+        # race fix this PR introduces (the old hlen/hset pair could overshoot).
+        lock = threading.Lock()
+        count = 0
+        max_active = 3
 
-        def mock_hlen(key):
-            nonlocal request_count
-            return request_count
-
-        def mock_hset(key, field, value):
-            nonlocal request_count
-            request_count += 1
-            return True
+        def admit_script(keys=None, args=None):
+            nonlocal count
+            _request_id, _timestamp, cap = args
+            with lock:
+                if count >= cap:
+                    return None
+                count += 1
+                return 1
 
         redis_patch.configure_mock(
             **{
                 "exists.return_value": False,
                 "setex.return_value": True,
-                "hlen.side_effect": mock_hlen,
-                "hset.side_effect": mock_hset,
+                "register_script.return_value": admit_script,
             }
         )
 
-        rate_limit = RateLimit("concurrent_client", 3)
+        rate_limit = RateLimit("concurrent_client", max_active)
         results = []
         errors = []
 
@@ -524,9 +529,10 @@ class TestRateLimitConcurrency:
         for t in threads:
             t.join()
 
-        # Should have some successful requests and some quota exceeded
-        assert len(results) + len(errors) == 5
-        assert len(errors) > 0  # Some should be rejected
+        # With atomic admission, exactly max_active requests are admitted and
+        # the rest are rejected — no overshoot from a check-then-act race.
+        assert len(results) == max_active
+        assert len(errors) == 5 - max_active
 
     @patch("time.time")
     def test_should_maintain_accurate_count_under_load(self, mock_time, redis_patch):

--- a/api/tests/unit_tests/core/app/features/test_rate_limit.py
+++ b/api/tests/unit_tests/core/app/features/test_rate_limit.py
@@ -1,0 +1,86 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.app.features.rate_limiting.rate_limit import RateLimit
+from core.errors.error import AppInvokeQuotaExceededError
+
+
+@pytest.fixture
+def rate_limit(monkeypatch):
+    """Build a RateLimit with cap=2 backed by a mocked Redis client.
+
+    The cached-per-client_id RateLimit instance means leftover state from one
+    test would leak into the next, so the class-level instance dict and the
+    ``initialized`` flag are reset here for isolation.
+    """
+    RateLimit._instance_dict.clear()
+    # Drop the cached instance so __init__ re-runs with fresh Redis state.
+    for key in list(RateLimit.__dict__):
+        if key == "initialized":
+            monkeypatch.delattr(RateLimit, "initialized", raising=False)
+    mock_redis = MagicMock()
+    mock_redis.exists.return_value = 0
+    # register_script returns a callable that we configure per test.
+    admit = MagicMock()
+    mock_redis.register_script.return_value = admit
+    with patch("core.app.features.rate_limiting.rate_limit.redis_client", mock_redis):
+        rl = RateLimit(client_id="test-client", max_active_requests=2)
+        yield rl, admit
+    RateLimit._instance_dict.clear()
+
+
+def test_enter_admits_when_below_cap(rate_limit):
+    rl, admit = rate_limit
+    admit.return_value = 1  # HSET returns the number of new fields added.
+
+    request_id = rl.enter()
+
+    admit.assert_called_once()
+    assert request_id  # a request id was returned
+
+
+def test_enter_rejects_when_cap_reached(rate_limit):
+    rl, admit = rate_limit
+    # The Lua script returns nil (decoded to None) when HLEN already equals the
+    # cap, i.e. the request was not admitted.
+    admit.return_value = None
+
+    with pytest.raises(AppInvokeQuotaExceededError):
+        rl.enter()
+
+
+def test_enter_returns_unlimited_id_when_disabled(monkeypatch):
+    RateLimit._instance_dict.clear()
+    monkeypatch.delattr(RateLimit, "initialized", raising=False)
+    mock_redis = MagicMock()
+    with patch("core.app.features.rate_limiting.rate_limit.redis_client", mock_redis):
+        rl = RateLimit(client_id="disabled-client", max_active_requests=0)
+
+    request_id = rl.enter(request_id="req-123")
+    assert request_id == RateLimit._UNLIMITED_REQUEST_ID
+    RateLimit._instance_dict.clear()
+
+
+def test_enter_respects_explicit_request_id(rate_limit):
+    rl, admit = rate_limit
+    admit.return_value = 1
+
+    request_id = rl.enter(request_id="explicit-id")
+    assert request_id == "explicit-id"
+    # The explicit id is forwarded to the script as the field name.
+    _, kwargs = admit.call_args
+    assert "explicit-id" in kwargs["args"]
+
+
+def test_enter_flush_cache_runs_after_interval(rate_limit, monkeypatch):
+    rl, admit = rate_limit
+    admit.return_value = 1
+    # Force the recalculation interval to look elapsed.
+    monkeypatch.setattr(rl, "last_recalculate_time", 0.0)
+    flush_spy = MagicMock()
+    monkeypatch.setattr(rl, "flush_cache", flush_spy)
+
+    rl.enter()
+
+    flush_spy.assert_called_once()


### PR DESCRIPTION
enter() enforced max_active_requests with two separate Redis calls — an HLEN check followed by an HSET write. Under concurrent requests for the same client_id, N callers could all read a count below the cap before any of them wrote, so all N would be admitted and the active count could climb to max_active_requests - 1 + N, defeating the limiter. This is the classic check-then-act race described in #39177.

I moved the check-and-set into a Lua script registered via redis_client.register_script(), matching the existing pattern in services/oauth_device_flow.py. Redis executes the script single-threaded, so HLEN and HSET now happen atomically in one round trip. The script returns nil when the cap is reached, which enter() maps to AppInvokeQuotaExceededError just as before. exit() is unchanged (a single HDEL is already safe to run independently).

Added api/tests/unit_tests/core/app/features/test_rate_limit.py covering the admit path, the cap-reached rejection, the disabled fast-path, explicit request_id forwarding, and the periodic flush_cache trigger. ruff check/format are clean and the suite passes locally (5 passed).

Fixes #39177