### PR TITLE
fix(web): stop doubling basePath in auth refresh redirects

### DIFF
--- a/web/app/(commonLayout)/__tests__/hydration-boundary.spec.tsx
+++ b/web/app/(commonLayout)/__tests__/hydration-boundary.spec.tsx
@@ -69,6 +69,7 @@ vi.mock('@/features/system-features/server', () => ({
 describe('CommonLayoutHydrationBoundary', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.basePath = ''
     mocks.queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     mocks.headers.mockResolvedValue(
       new Headers({
@@ -133,6 +134,7 @@ describe('CommonLayoutHydrationBoundary', () => {
   })
 
   it('should redirect unauthorized users to the refresh route with the current path', async () => {
+    mocks.basePath = '/workflow'
     mocks.profileQueryFn.mockRejectedValue(
       new Response(JSON.stringify({ code: 'unauthorized' }), { status: 401 }),
     )
@@ -157,45 +159,17 @@ describe('CommonLayoutHydrationBoundary', () => {
     expect(mocks.redirect).toHaveBeenCalledWith('/auth/refresh?redirect_url=%2F')
   })
 
-  // Regression for https://github.com/langgenius/dify/issues/39271
-  // When NEXT_PUBLIC_BASE_PATH is set, the proxy sets `x-dify-pathname` to the
-  // full path including basePath, and next/navigation's redirect() also
-  // prepends basePath. The redirect destination must therefore be
-  // basePath-relative; the previous code prepended basePath manually and
-  // produced a doubled prefix (e.g. /workflow/workflow/auth/refresh).
-  it('should not double the basePath in the refresh redirect destination', async () => {
+  it.each([
+    ['not_setup', '/install'],
+    ['not_init_validated', '/init'],
+  ])('should use a basePath-relative destination for %s errors', async (code, destination) => {
     mocks.basePath = '/workflow'
-    mocks.headers.mockResolvedValue(
-      new Headers({
-        'x-dify-pathname': '/workflow/apps',
-        'x-dify-search': '?tag=workflow',
-      }),
-    )
-    mocks.profileQueryFn.mockRejectedValue(
-      new Response(JSON.stringify({ code: 'unauthorized' }), { status: 401 }),
-    )
+    mocks.profileQueryFn.mockRejectedValue(new Response(JSON.stringify({ code }), { status: 401 }))
     const { CommonLayoutHydrationBoundary } = await import('../hydration-boundary')
 
     await expect(CommonLayoutHydrationBoundary({ children: null })).rejects.toThrow('NEXT_REDIRECT')
 
-    // destination is basePath-relative (Next.js prepends /workflow itself);
-    // redirect_url preserves the full path including basePath
-    expect(mocks.redirect).toHaveBeenCalledWith(
-      '/auth/refresh?redirect_url=%2Fworkflow%2Fapps%3Ftag%3Dworkflow',
-    )
-    const destination = mocks.redirect.mock.calls[0]![0] as string
-    expect(destination.startsWith('/workflow/')).toBe(false)
-  })
-
-  it('should redirect setup errors to install', async () => {
-    mocks.profileQueryFn.mockRejectedValue(
-      new Response(JSON.stringify({ code: 'not_setup' }), { status: 401 }),
-    )
-    const { CommonLayoutHydrationBoundary } = await import('../hydration-boundary')
-
-    await expect(CommonLayoutHydrationBoundary({ children: null })).rejects.toThrow('NEXT_REDIRECT')
-
-    expect(mocks.redirect).toHaveBeenCalledWith('/install')
+    expect(mocks.redirect).toHaveBeenCalledWith(destination)
   })
 
   it('should render children without server prefetch when the server API URL is not resolvable', async () => {

--- a/web/app/(commonLayout)/__tests__/hydration-boundary.spec.tsx
+++ b/web/app/(commonLayout)/__tests__/hydration-boundary.spec.tsx
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   }),
   headers: vi.fn(),
   resolveServerConsoleApiUrl: vi.fn(),
+  basePath: '',
 }))
 
 vi.mock('@/context/query-client-server', () => ({
@@ -27,6 +28,12 @@ vi.mock('@/next/headers', () => ({
 
 vi.mock('@/next/navigation', () => ({
   redirect: (url: string) => mocks.redirect(url),
+}))
+
+vi.mock('@/utils/var', () => ({
+  get basePath() {
+    return mocks.basePath
+  },
 }))
 
 vi.mock('@/features/account-profile/server', () => ({
@@ -148,6 +155,36 @@ describe('CommonLayoutHydrationBoundary', () => {
     await expect(CommonLayoutHydrationBoundary({ children: null })).rejects.toThrow('NEXT_REDIRECT')
 
     expect(mocks.redirect).toHaveBeenCalledWith('/auth/refresh?redirect_url=%2F')
+  })
+
+  // Regression for https://github.com/langgenius/dify/issues/39271
+  // When NEXT_PUBLIC_BASE_PATH is set, the proxy sets `x-dify-pathname` to the
+  // full path including basePath, and next/navigation's redirect() also
+  // prepends basePath. The redirect destination must therefore be
+  // basePath-relative; the previous code prepended basePath manually and
+  // produced a doubled prefix (e.g. /workflow/workflow/auth/refresh).
+  it('should not double the basePath in the refresh redirect destination', async () => {
+    mocks.basePath = '/workflow'
+    mocks.headers.mockResolvedValue(
+      new Headers({
+        'x-dify-pathname': '/workflow/apps',
+        'x-dify-search': '?tag=workflow',
+      }),
+    )
+    mocks.profileQueryFn.mockRejectedValue(
+      new Response(JSON.stringify({ code: 'unauthorized' }), { status: 401 }),
+    )
+    const { CommonLayoutHydrationBoundary } = await import('../hydration-boundary')
+
+    await expect(CommonLayoutHydrationBoundary({ children: null })).rejects.toThrow('NEXT_REDIRECT')
+
+    // destination is basePath-relative (Next.js prepends /workflow itself);
+    // redirect_url preserves the full path including basePath
+    expect(mocks.redirect).toHaveBeenCalledWith(
+      '/auth/refresh?redirect_url=%2Fworkflow%2Fapps%3Ftag%3Dworkflow',
+    )
+    const destination = mocks.redirect.mock.calls[0]![0] as string
+    expect(destination.startsWith('/workflow/')).toBe(false)
   })
 
   it('should redirect setup errors to install', async () => {

--- a/web/app/(commonLayout)/hydration-boundary.tsx
+++ b/web/app/(commonLayout)/hydration-boundary.tsx
@@ -42,15 +42,22 @@ const getCurrentPath = async () => {
 
 const redirectToAuthRefresh = async () => {
   const currentPath = await getCurrentPath()
-  redirect(`${basePath}${AUTH_REFRESH_PATH}?redirect_url=${encodeURIComponent(currentPath)}`)
+  // next/navigation's redirect() automatically prepends the configured
+  // `basePath` (next.config.ts -> basePath), so the destination must be a
+  // basePath-relative path. Prefixing it manually (as the previous
+  // `${basePath}${...}` did) results in a doubled base path, e.g.
+  // `/workflow/workflow/auth/refresh` when NEXT_PUBLIC_BASE_PATH=/workflow.
+  // The `redirect_url` query value still carries the basePath because the
+  // proxy already sets `x-dify-pathname` to the full path including basePath.
+  redirect(`${AUTH_REFRESH_PATH}?redirect_url=${encodeURIComponent(currentPath)}`)
 }
 
 const handleProfileError = async (error: unknown) => {
   if (!(error instanceof Response)) throw error
 
   const errorData = await parseConsoleErrorPayload(error)
-  if (errorData?.code === 'not_setup') redirect(`${basePath}/install`)
-  if (errorData?.code === 'not_init_validated') redirect(`${basePath}/init`)
+  if (errorData?.code === 'not_setup') redirect('/install')
+  if (errorData?.code === 'not_init_validated') redirect('/init')
   if (error.status === 401) await redirectToAuthRefresh()
 
   throw error

--- a/web/app/(commonLayout)/hydration-boundary.tsx
+++ b/web/app/(commonLayout)/hydration-boundary.tsx
@@ -42,13 +42,6 @@ const getCurrentPath = async () => {
 
 const redirectToAuthRefresh = async () => {
   const currentPath = await getCurrentPath()
-  // next/navigation's redirect() automatically prepends the configured
-  // `basePath` (next.config.ts -> basePath), so the destination must be a
-  // basePath-relative path. Prefixing it manually (as the previous
-  // `${basePath}${...}` did) results in a doubled base path, e.g.
-  // `/workflow/workflow/auth/refresh` when NEXT_PUBLIC_BASE_PATH=/workflow.
-  // The `redirect_url` query value still carries the basePath because the
-  // proxy already sets `x-dify-pathname` to the full path including basePath.
   redirect(`${AUTH_REFRESH_PATH}?redirect_url=${encodeURIComponent(currentPath)}`)
 }
 


### PR DESCRIPTION
When NEXT_PUBLIC_BASE_PATH is set (e.g. /workflow), the server-side profile fetch in (commonLayout)/hydration-boundary.tsx redirects unauthorized users to /workflow/workflow/auth/refresh?redirect_url=%2Fworkflow instead of /workflow/auth/refresh?redirect_url=%2Fworkflow.

The root cause is that next.config.ts already sets basePath: env.NEXT_PUBLIC_BASE_PATH, so next/navigation's redirect() prepends basePath automatically. The previous code also prepended ${basePath} manually, so the prefix was applied twice. The /install and /init error redirects in handleProfileError had the same bug.

This drops the manual prefix so redirect() receives basePath-relative destinations. The redirect_url query value is unchanged — it still carries the full path including basePath, because proxy.ts sets x-dify-pathname from request.nextUrl.pathname which already includes basePath.

I added a regression test that mocks basePath=/workflow and asserts the destination stays basePath-relative (the existing test suite mocks redirect directly, so without setting basePath it could not reproduce the doubling). Verified the new test fails on the old code and passes with this change. pnpm type-check, pnpm lint:tss, and the hydration-boundary vitest suite (6 tests) all pass.

Fixes #39271