### PR TITLE
chore(api): add breadcrumb logs around vector backend factory resolution

### DIFF
--- a/api/core/rag/datasource/vdb/vector_backend_registry.py
+++ b/api/core/rag/datasource/vdb/vector_backend_registry.py
@@ -44,11 +44,13 @@ def _load_plugin_factory(vector_type: str) -> type[AbstractVectorFactory] | None
     for ep in _vector_backend_entry_points():
         if ep.name != vector_type:
             continue
+        logger.info("loading vector backend entry point %s (%s)", ep.name, ep.value)
         try:
             loaded = ep.load()
         except Exception:
             logger.exception("Failed to load vector backend entry point %s", ep.name)
             raise
+        logger.info("vector backend entry point %s loaded", ep.name)
         return loaded  # type: ignore[return-value]
     return None
 
@@ -77,6 +79,7 @@ def get_vector_factory_class(vector_type: str) -> type[AbstractVectorFactory]:
     if vector_type in _VECTOR_FACTORY_CACHE:
         return _VECTOR_FACTORY_CACHE[vector_type]
 
+    logger.info("vector backend cache miss, discovering entry points: %s", vector_type)
     plugin_cls = _load_plugin_factory(vector_type)
     if plugin_cls is not None:
         _VECTOR_FACTORY_CACHE[vector_type] = plugin_cls

--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -144,7 +144,20 @@ class Vector:
         if not vector_type:
             raise ValueError("Vector store must be specified.")
 
+        logger.info(
+            "resolving vector backend factory: type=%s tenant_id=%s dataset_id=%s",
+            vector_type,
+            self._dataset.tenant_id,
+            self._dataset.id,
+        )
         vector_factory_cls = self.get_vector_factory(vector_type)
+        logger.info(
+            "vector backend factory resolved: type=%s cls=%s tenant_id=%s dataset_id=%s",
+            vector_type,
+            vector_factory_cls.__name__,
+            self._dataset.tenant_id,
+            self._dataset.id,
+        )
         return vector_factory_cls().init_vector(self._dataset, self._attributes, self._embeddings)
 
     @staticmethod


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Diagnostic instrumentation only — no logic changes.

**Problem.** In production (Dify Cloud), some chat requests that use knowledge retrieval intermittently hang forever: the SSE stream keeps emitting pings but no answer or error ever arrives, and the message row stays `status=normal` with an empty answer, zero tokens and zero latency. No error is logged and no timeout fires at any layer.

**What we know so far.** Multiple independent live captures freeze at exactly the same spot: the last observed operation is the vector_db whitelist query inside `Vector._init_vector()`, and `TidbOnQdrantVectorFactory.init_vector()`'s first log line is never reached — i.e. the request parks somewhere inside factory resolution (`get_vector_factory_class()` / entry-point loading) and never reaches the plugin daemon or any external service. The API runs gevent workers, and a parked greenlet is invisible to py-spy (both default and `--native` modes show only idle hubs), so the exact parking statement cannot be captured from outside the process.

**What this PR does.** Adds five INFO-level breadcrumb logs bracketing each step of that gap, so the next hung request identifies its parking statement from the log tail alone:

| log tail of a hung request | parking location |
|---|---|
| `resolving vector backend factory` absent | before resolution (falsifies the current narrowing) |
| `resolving ...` present, no cache-miss line | cache-hit path, or inside logging itself (handler lock) |
| cache-miss line, no `loading vector backend entry point` | `entry_points()` metadata scan |
| `loading ...` present, no `... loaded` | inside `ep.load()` import (import lock / gevent interaction) |
| `vector backend factory resolved`, no `init_vector:` | factory call boundary |

**Log volume.** The two `_init_vector` lines fire once per `Vector` construction — the same rate as the existing `init_vector:` breadcrumb in the tidb_on_qdrant factory. The registry lines fire only on per-process first resolution (cache miss), effectively zero at steady state.

There is no public issue for this: it is an internally observed, production-only behavior (the affected backend path depends on cloud-side configuration not present in self-hosted deployments). Targeting `hotfix/1.15.0-fix.14` so the instrumentation rides the next production release; happy to forward-port to `main` as well if desired.

## Screenshots

N/A (backend-only log lines).

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Note on the last two unchecked boxes: the change is log-only (no behavior to test, no type surface); `ruff check` passes on both changed files, full `make type-check` was not run.
