### PR TITLE
fix: can't create chat app when get tenant default model schema error

### DIFF
--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -323,6 +323,7 @@ class AppService:
         default_model_config = app_template.get("model_config")
         default_model_config = default_model_config.copy() if default_model_config else None
         if default_model_config and "model" in default_model_config:
+            default_model_dict = default_model_config["model"]
             # get model provider
             model_manager = ModelManager.for_tenant(tenant_id=account.current_tenant_id or "")
 
@@ -337,7 +338,7 @@ class AppService:
                 logger.exception("Get default model instance failed, tenant_id: %s", tenant_id)
                 model_instance = None
 
-            if model_instance:
+            if model_instance is not None:
                 if (
                     model_instance.model_name == default_model_config["model"]["name"]
                     and model_instance.provider == default_model_config["model"]["provider"]
@@ -345,17 +346,28 @@ class AppService:
                     default_model_dict = default_model_config["model"]
                 else:
                     llm_model = cast(LargeLanguageModel, model_instance.model_type_instance)
-                    model_schema = llm_model.get_model_schema(model_instance.model_name, model_instance.credentials)
-                    if model_schema is None:
-                        raise ValueError(f"model schema not found for model {model_instance.model_name}")
-
-                    default_model_dict = {
-                        "provider": model_instance.provider,
-                        "name": model_instance.model_name,
-                        "mode": model_schema.model_properties.get(ModelPropertyKey.MODE),
-                        "completion_params": {},
-                    }
-            else:
+                    try:
+                        model_schema = llm_model.get_model_schema(model_instance.model_name, model_instance.credentials)
+                        if model_schema is None:
+                            raise ValueError(f"model schema not found for model {model_instance.model_name}")
+                    except Exception:
+                        # A removed provider model must not prevent creating an app.
+                        logger.warning(
+                            "Default model schema is unavailable, tenant_id: %s, provider: %s, model: %s",
+                            tenant_id,
+                            model_instance.provider,
+                            model_instance.model_name,
+                            exc_info=True,
+                        )
+                        model_instance = None
+                    else:
+                        default_model_dict = {
+                            "provider": model_instance.provider,
+                            "name": model_instance.model_name,
+                            "mode": model_schema.model_properties.get(ModelPropertyKey.MODE),
+                            "completion_params": {},
+                        }
+            if model_instance is None:
                 try:
                     provider, model = model_manager.get_default_provider_model_name(
                         tenant_id=account.current_tenant_id or "", model_type=ModelType.LLM

--- a/api/tests/unit_tests/services/test_app_service.py
+++ b/api/tests/unit_tests/services/test_app_service.py
@@ -6,9 +6,58 @@ from unittest.mock import MagicMock, patch
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from models.model import App
+from graphon.model_runtime.entities.model_entities import ModelType
+from models import Account
+from models.model import App, AppMode, AppModelConfig
 from services.agent.errors import AgentNameConflictError
-from services.app_service import AppService
+from services.app_service import AppService, CreateAppParams
+
+
+class TestCreateApp:
+    def test_falls_back_when_default_model_schema_is_unavailable(self) -> None:
+        account = MagicMock(spec=Account, id="account-1", current_tenant_id="tenant-1")
+        model_type_instance = MagicMock()
+        model_type_instance.get_model_schema.side_effect = ValueError("Base model unknown-model not found")
+        model_instance = SimpleNamespace(
+            model_name="unknown-model",
+            provider="langgenius/openai/openai",
+            credentials={},
+            model_type_instance=model_type_instance,
+        )
+        model_manager = MagicMock()
+        model_manager.get_default_model_instance.return_value = model_instance
+        model_manager.get_default_provider_model_name.return_value = ("openai", "gpt-4o")
+        added_objects: list[object] = []
+
+        with (
+            patch("services.app_service.db") as mock_db,
+            patch("services.app_service.ModelManager.for_tenant", return_value=model_manager),
+            patch("services.app_service.app_was_created.send"),
+            patch("services.app_service.enterprise_rbac_service.try_sync_creator_access_policy_member_bindings"),
+            patch(
+                "services.app_service.FeatureService.get_system_features",
+                return_value=SimpleNamespace(webapp_auth=SimpleNamespace(enabled=False)),
+            ),
+            patch("services.app_service.dify_config.BILLING_ENABLED", False),
+        ):
+            mock_db.session.add.side_effect = added_objects.append
+            app = AppService().create_app(
+                "tenant-1",
+                CreateAppParams(name="Chat", mode=AppMode.CHAT.value),
+                account,
+            )
+
+        app_model_config = next(obj for obj in added_objects if isinstance(obj, AppModelConfig))
+        assert app.mode == AppMode.CHAT
+        assert app_model_config.model_dict == {
+            "provider": "openai",
+            "name": "gpt-4o",
+            "mode": "chat",
+            "completion_params": {},
+        }
+        model_manager.get_default_provider_model_name.assert_called_once_with(
+            tenant_id="tenant-1", model_type=ModelType.LLM
+        )
 
 
 class TestOpenapiVisibilityHelpers:


### PR DESCRIPTION
## Summary

Cherry-picks `30df1433cc511c6c19f2cd60afef77996a40edad` onto `hotfix/1.15.0-fix.14`.

Falls back to the tenant default provider and model when the stored default model schema is unavailable, so chat app creation can proceed. The regression test is adapted to the hotfix branch's existing `create_app` interface.

## Validation

- `BASE_SHA=myori/hotfix/1.15.0-fix.14 HEAD_SHA=HEAD MAIN_REF=myori/main bash .github/scripts/check-hotfix-cherry-picks.sh` -> verified 1 PR commit includes cherry-pick provenance from main
- `DEBUG=false uv run --project api pytest -o addopts='' api/tests/unit_tests/services/test_app_service.py -k falls_back_when_default_model_schema_is_unavailable` -> 1 passed, 18 deselected
- `git diff --check myori/hotfix/1.15.0-fix.14...HEAD` -> passed
