### PR TITLE
fix: show persistent error when workflow draft save fails

### DIFF
--- a/web/app/components/workflow/__tests__/workflow-edge-events.spec.tsx
+++ b/web/app/components/workflow/__tests__/workflow-edge-events.spec.tsx
@@ -38,6 +38,7 @@ const collaborationBridge = vi.hoisted(() => ({
 }))
 
 const toastInfoMock = vi.hoisted(() => vi.fn())
+const toastErrorMock = vi.hoisted(() => vi.fn())
 
 const workflowCommentState = vi.hoisted(() => ({
   comments: [] as Array<Record<string, unknown>>,
@@ -188,6 +189,7 @@ vi.mock('@/service/workflow', () => ({
 
 vi.mock('@langgenius/dify-ui/toast', () => ({
   toast: {
+    error: toastErrorMock,
     info: toastInfoMock,
   },
 }))
@@ -604,6 +606,22 @@ describe('Workflow edge event wiring', () => {
     })
 
     expect(store.getState().contextMenuTarget).toBeUndefined()
+  })
+
+  it('should show a persistent error toast when saving the draft on unmount fails', () => {
+    workflowHookMocks.handleSyncWorkflowDraft.mockImplementationOnce(
+      (_sync, _notRefreshWhenSyncError, callback) => {
+        callback?.onError?.()
+      },
+    )
+
+    const { unmount } = renderSubject()
+
+    unmount()
+
+    expect(toastErrorMock).toHaveBeenCalledWith('workflow.common.draftSaveFailed', {
+      timeout: 0,
+    })
   })
 
   it('should render confirm description and clear showConfirm when cancelled', async () => {

--- a/web/app/components/workflow/index.tsx
+++ b/web/app/components/workflow/index.tsx
@@ -364,9 +364,18 @@ export const Workflow: FC<WorkflowProps> = memo(
 
     useEffect(() => {
       return () => {
-        handleSyncWorkflowDraft(true, true)
+        handleSyncWorkflowDraft(true, true, {
+          onError: () => {
+            toast.error(
+              t(($) => $['common.draftSaveFailed'], { ns: 'workflow' }),
+              {
+                timeout: 0,
+              },
+            )
+          },
+        })
       }
-    }, [handleSyncWorkflowDraft])
+    }, [handleSyncWorkflowDraft, t])
 
     const handlePendingCommentPositionChange = useCallback(
       (position: NonNullable<WorkflowSliceShape['pendingComment']>) => {

--- a/web/i18n/ar-TN/workflow.json
+++ b/web/i18n/ar-TN/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "سير العمل الحالي",
   "common.debugAndPreview": "معاينة",
   "common.disconnect": "قطع الاتصال",
+  "common.draftSaveFailed": "فشل حفظ المسودة",
   "common.duplicate": "تكرار",
   "common.editing": "تعديل",
   "common.effectVarConfirm.content": "يتم استخدام المتغير في عقد أخرى. هل ما زلت تريد إزالته؟",

--- a/web/i18n/de-DE/workflow.json
+++ b/web/i18n/de-DE/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "Aktueller Arbeitsablauf",
   "common.debugAndPreview": "Vorschau",
   "common.disconnect": "Trennen",
+  "common.draftSaveFailed": "Entwurf konnte nicht gespeichert werden",
   "common.duplicate": "Duplizieren",
   "common.editing": "Bearbeitung",
   "common.effectVarConfirm.content": "Die Variable wird in anderen Knoten verwendet. Möchten Sie sie trotzdem entfernen?",

--- a/web/i18n/en-US/workflow.json
+++ b/web/i18n/en-US/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "Current Workflow",
   "common.debugAndPreview": "Preview",
   "common.disconnect": "Disconnect",
+  "common.draftSaveFailed": "Draft save failed",
   "common.duplicate": "Duplicate",
   "common.editing": "Editing",
   "common.effectVarConfirm.content": "The variable is used in other nodes. Do you still want to remove it?",

--- a/web/i18n/es-ES/workflow.json
+++ b/web/i18n/es-ES/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "Flujo de trabajo actual",
   "common.debugAndPreview": "Vista previa",
   "common.disconnect": "Desconectar",
+  "common.draftSaveFailed": "Error al guardar el borrador",
   "common.duplicate": "Duplicar",
   "common.editing": "Editando",
   "common.effectVarConfirm.content": "La variable se utiliza en otros nodos. ¿Aún quieres eliminarla?",

--- a/web/i18n/fa-IR/workflow.json
+++ b/web/i18n/fa-IR/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "گردش کار فعلی",
   "common.debugAndPreview": "اشکال‌زدایی و پیش‌نمایش",
   "common.disconnect": "قطع اتصال",
+  "common.draftSaveFailed": "ذخیره پیش‌نویس ناموفق بود",
   "common.duplicate": "تکثیر",
   "common.editing": "در حال ویرایش",
   "common.effectVarConfirm.content": "این متغیر در گره‌های دیگر استفاده شده است. آیا مطمئنید می‌خواهید آن را حذف کنید؟",

--- a/web/i18n/fr-FR/workflow.json
+++ b/web/i18n/fr-FR/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "Flux de travail actuel",
   "common.debugAndPreview": "Aperçu",
   "common.disconnect": "Déconnecter",
+  "common.draftSaveFailed": "Échec de l’enregistrement du brouillon",
   "common.duplicate": "Dupliquer",
   "common.editing": "Édition",
   "common.effectVarConfirm.content": "La variable est utilisée dans d'autres nœuds. Voulez-vous toujours la supprimer?",

--- a/web/i18n/hi-IN/workflow.json
+++ b/web/i18n/hi-IN/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "वर्तमान कार्यप्रवाह",
   "common.debugAndPreview": "पूर्वावलोकन",
   "common.disconnect": "अलग करना",
+  "common.draftSaveFailed": "ड्राफ़्ट सहेजना विफल रहा",
   "common.duplicate": "डुप्लिकेट करें",
   "common.editing": "संपादन",
   "common.effectVarConfirm.content": "वेरिएबल अन्य नोड्स में उपयोग किया जाता है। क्या आप अभी भी इसे हटाना चाहते हैं?",

--- a/web/i18n/id-ID/workflow.json
+++ b/web/i18n/id-ID/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "Alur Kerja Saat Ini",
   "common.debugAndPreview": "Pratayang",
   "common.disconnect": "Lepaskan",
+  "common.draftSaveFailed": "Gagal menyimpan draf",
   "common.duplicate": "Duplikat",
   "common.editing": "Mengedit",
   "common.effectVarConfirm.content": "Variabel ini digunakan di node lain. Apakah Anda masih ingin menghapusnya?",

--- a/web/i18n/it-IT/workflow.json
+++ b/web/i18n/it-IT/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "Flusso di lavoro corrente",
   "common.debugAndPreview": "Anteprima",
   "common.disconnect": "Disconnettere",
+  "common.draftSaveFailed": "Salvataggio della bozza non riuscito",
   "common.duplicate": "Duplica",
   "common.editing": "Modifica in corso",
   "common.effectVarConfirm.content": "La variabile è utilizzata in altri nodi. Vuoi comunque rimuoverla?",

--- a/web/i18n/ja-JP/workflow.json
+++ b/web/i18n/ja-JP/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "現在のワークフロー",
   "common.debugAndPreview": "プレビュー",
   "common.disconnect": "接続解除",
+  "common.draftSaveFailed": "下書きの保存に失敗しました",
   "common.duplicate": "複製",
   "common.editing": "編集中",
   "common.effectVarConfirm.content": "他のノードで変数が使用されています。それでも削除しますか？",

--- a/web/i18n/ko-KR/workflow.json
+++ b/web/i18n/ko-KR/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "현재 워크플로",
   "common.debugAndPreview": "미리보기",
   "common.disconnect": "연결 해제",
+  "common.draftSaveFailed": "초안 저장에 실패했습니다",
   "common.duplicate": "복제",
   "common.editing": "편집 중",
   "common.effectVarConfirm.content": "변수가 다른 노드에서 사용되고 있습니다. 그래도 제거하시겠습니까?",

--- a/web/i18n/nl-NL/workflow.json
+++ b/web/i18n/nl-NL/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "Current Workflow",
   "common.debugAndPreview": "Preview",
   "common.disconnect": "Disconnect",
+  "common.draftSaveFailed": "Opslaan van concept mislukt",
   "common.duplicate": "Duplicate",
   "common.editing": "Editing",
   "common.effectVarConfirm.content": "The variable is used in other nodes. Do you still want to remove it?",

--- a/web/i18n/pl-PL/workflow.json
+++ b/web/i18n/pl-PL/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "Bieżący przepływ pracy",
   "common.debugAndPreview": "Podgląd",
   "common.disconnect": "Odłączyć",
+  "common.draftSaveFailed": "Nie udało się zapisać wersji roboczej",
   "common.duplicate": "Duplikuj",
   "common.editing": "Edytowanie",
   "common.effectVarConfirm.content": "Zmienna jest używana w innych węzłach. Czy na pewno chcesz ją usunąć?",

--- a/web/i18n/pt-BR/workflow.json
+++ b/web/i18n/pt-BR/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "Fluxo de trabalho atual",
   "common.debugAndPreview": "Visualizar",
   "common.disconnect": "Desligar",
+  "common.draftSaveFailed": "Falha ao salvar o rascunho",
   "common.duplicate": "Duplicar",
   "common.editing": "Editando",
   "common.effectVarConfirm.content": "A variável é usada em outros nós. Você ainda deseja removê-la?",

--- a/web/i18n/ro-RO/workflow.json
+++ b/web/i18n/ro-RO/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "Flux de lucru curent",
   "common.debugAndPreview": "Previzualizare",
   "common.disconnect": "Deconecta",
+  "common.draftSaveFailed": "Salvarea schiței a eșuat",
   "common.duplicate": "Duplică",
   "common.editing": "Editare",
   "common.effectVarConfirm.content": "Variabila este utilizată în alte noduri. Doriți să o eliminați oricum?",

--- a/web/i18n/ru-RU/workflow.json
+++ b/web/i18n/ru-RU/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "Текущий рабочий процесс",
   "common.debugAndPreview": "Предпросмотр",
   "common.disconnect": "Разъединять",
+  "common.draftSaveFailed": "Не удалось сохранить черновик",
   "common.duplicate": "Дублировать",
   "common.editing": "Редактирование",
   "common.effectVarConfirm.content": "Переменная используется в других узлах. Вы все еще хотите удалить ее?",

--- a/web/i18n/sl-SI/workflow.json
+++ b/web/i18n/sl-SI/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "Trenutni potek dela",
   "common.debugAndPreview": "Predogled",
   "common.disconnect": "Odklop",
+  "common.draftSaveFailed": "Shranjevanje osnutka ni uspelo",
   "common.duplicate": "Podvojiti",
   "common.editing": "Urejanje",
   "common.effectVarConfirm.content": "Spremenljivka se uporablja v drugih vozliščih. Ali jo še vedno želite odstraniti?",

--- a/web/i18n/th-TH/workflow.json
+++ b/web/i18n/th-TH/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "เวิร์กโฟลว์ปัจจุบัน",
   "common.debugAndPreview": "ดูตัวอย่าง",
   "common.disconnect": "ยก เลิก",
+  "common.draftSaveFailed": "บันทึกฉบับร่างไม่สำเร็จ",
   "common.duplicate": "สำเนา",
   "common.editing": "แก้ไข",
   "common.effectVarConfirm.content": "ตัวแปรนี้ใช้ในโหนดอื่น คุณยังต้องการลบออกหรือไม่?",

--- a/web/i18n/tr-TR/workflow.json
+++ b/web/i18n/tr-TR/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "Mevcut İş Akışı",
   "common.debugAndPreview": "Önizleme",
   "common.disconnect": "Bağlantıyı Kes",
+  "common.draftSaveFailed": "Taslak kaydedilemedi",
   "common.duplicate": "Çoğalt",
   "common.editing": "Düzenleme",
   "common.effectVarConfirm.content": "Değişken diğer düğümlerde kullanılıyor. Yine de kaldırmak istiyor musunuz?",

--- a/web/i18n/uk-UA/workflow.json
+++ b/web/i18n/uk-UA/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "Поточний робочий процес",
   "common.debugAndPreview": "Попередній перегляд",
   "common.disconnect": "Відключити",
+  "common.draftSaveFailed": "Не вдалося зберегти чернетку",
   "common.duplicate": "Дублювати",
   "common.editing": "Редагування",
   "common.effectVarConfirm.content": "Змінна використовується в інших вузлах. Ви все ще хочете її видалити?",

--- a/web/i18n/vi-VN/workflow.json
+++ b/web/i18n/vi-VN/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "Quy trình làm việc hiện tại",
   "common.debugAndPreview": "Xem trước",
   "common.disconnect": "Ngắt kết nối",
+  "common.draftSaveFailed": "Lưu bản nháp thất bại",
   "common.duplicate": "Nhân bản",
   "common.editing": "Đang chỉnh sửa",
   "common.effectVarConfirm.content": "Biến được sử dụng trong các nút khác. Bạn có chắc chắn muốn xóa nó không?",

--- a/web/i18n/zh-Hans/workflow.json
+++ b/web/i18n/zh-Hans/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "整个工作流",
   "common.debugAndPreview": "预览",
   "common.disconnect": "断开连接",
+  "common.draftSaveFailed": "草稿保存失败",
   "common.duplicate": "复制",
   "common.editing": "编辑中",
   "common.effectVarConfirm.content": "该变量在其他节点中使用。您是否仍要删除它？",

--- a/web/i18n/zh-Hant/workflow.json
+++ b/web/i18n/zh-Hant/workflow.json
@@ -169,6 +169,7 @@
   "common.currentWorkflow": "當前工作流程",
   "common.debugAndPreview": "預覽",
   "common.disconnect": "斷開",
+  "common.draftSaveFailed": "草稿儲存失敗",
   "common.duplicate": "複製",
   "common.editing": "編輯中",
   "common.effectVarConfirm.content": "該變數在其他節點中使用。您是否仍要刪除它？",


### PR DESCRIPTION


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
