### PR TITLE
fix(account): resolve account.id/email before session detach in reset-password flow

### DIFF
--- a/api/controllers/console/auth/forgot_password.py
+++ b/api/controllers/console/auth/forgot_password.py
@@ -82,9 +82,14 @@ class ForgotPasswordSendEmailApi(Resource):
             language = "en-US"
 
         account = AccountService.get_account_by_email_with_case_fallback(args.email, session=db.session())
+        # Read account.id here, while the request session is still bound, so the
+        # downstream token flow does not lazy-load it from a possibly-detached
+        # instance (DetachedInstanceError, #39287).
+        account_id = account.id if account else None
 
         token = AccountService.send_reset_password_email(
             account=account,
+            account_id=account_id,
             email=normalized_email,
             language=language,
             is_allow_register=FeatureService.get_system_features().is_allow_register,

--- a/api/controllers/console/auth/forgot_password.py
+++ b/api/controllers/console/auth/forgot_password.py
@@ -82,9 +82,14 @@ class ForgotPasswordSendEmailApi(Resource):
             language = "en-US"
 
         account = AccountService.get_account_by_email_with_case_fallback(req_data.email, session=db.session())
+        # Read account.id here, while the request session is still bound, so the
+        # downstream token flow does not lazy-load it from a possibly-detached
+        # instance (DetachedInstanceError, #39287).
+        account_id = account.id if account else None
 
         token = AccountService.send_reset_password_email(
             account=account,
+            account_id=account_id,
             email=normalized_email,
             language=language,
             is_allow_register=FeatureService.get_system_features().is_allow_register,

--- a/api/controllers/console/auth/login.py
+++ b/api/controllers/console/auth/login.py
@@ -228,9 +228,13 @@ class ResetPasswordSendEmailApi(Resource):
         except AccountRegisterError:
             raise AccountInFreezeError()
 
+        # Resolve account.id while the request session is still bound to avoid a
+        # DetachedInstanceError in the downstream token flow (#39287).
+        account_id = account.id if account else None
         token = AccountService.send_reset_password_email(
             email=normalized_email,
             account=account,
+            account_id=account_id,
             language=language,
             is_allow_register=FeatureService.get_system_features().is_allow_register,
         )

--- a/api/controllers/console/auth/login.py
+++ b/api/controllers/console/auth/login.py
@@ -266,9 +266,13 @@ class ResetPasswordSendEmailApi(Resource):
         except AccountRegisterError as exc:
             raise AccountInFreezeError() from exc
 
+        # Resolve account.id while the request session is still bound to avoid a
+        # DetachedInstanceError in the downstream token flow (#39287).
+        account_id = account.id if account else None
         token = AccountService.send_reset_password_email(
             email=normalized_email,
             account=account,
+            account_id=account_id,
             language=language,
             is_allow_register=FeatureService.get_system_features().is_allow_register,
         )

--- a/api/controllers/web/forgot_password.py
+++ b/api/controllers/web/forgot_password.py
@@ -73,7 +73,14 @@ class ForgotPasswordSendEmailApi(Resource):
         if account is None:
             raise AuthenticationFailedError()
         else:
-            token = AccountService.send_reset_password_email(account=account, email=normalized_email, language=language)
+            # Resolve account.id while the request session is still bound to avoid
+            # a DetachedInstanceError in the downstream token flow (#39287).
+            token = AccountService.send_reset_password_email(
+                account=account,
+                account_id=account.id,
+                email=normalized_email,
+                language=language,
+            )
 
         return {"result": "success", "data": token}
 

--- a/api/controllers/web/forgot_password.py
+++ b/api/controllers/web/forgot_password.py
@@ -77,7 +77,14 @@ class ForgotPasswordSendEmailApi(Resource):
         if account is None:
             raise AuthenticationFailedError()
         else:
-            token = AccountService.send_reset_password_email(account=account, email=normalized_email, language=language)
+            # Resolve account.id while the request session is still bound to avoid
+            # a DetachedInstanceError in the downstream token flow (#39287).
+            token = AccountService.send_reset_password_email(
+                account=account,
+                account_id=account.id,
+                email=normalized_email,
+                language=language,
+            )
 
         return {"result": "success", "data": token}
 

--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -499,11 +499,18 @@ class TokenManager:
         account: "Account | None" = None,
         email: str | None = None,
         additional_data: dict[str, Any] | None = None,
+        account_id: str | None = None,
     ) -> str:
-        if account is None and email is None:
+        if account is None and email is None and account_id is None:
             raise ValueError("Account or email must be provided")
 
-        account_id = account.id if account else None
+        # Prefer an explicitly-resolved account_id over account.id. The Account
+        # ORM object may have been loaded from a scoped session that has since
+        # been recycled (common under gevent), leaving it detached. Reading
+        # account.id on a detached instance raises DetachedInstanceError (#39287),
+        # so callers that already hold the id should pass it directly.
+        if account_id is None and account is not None:
+            account_id = account.id
         account_email = email if email is not None else account.email if account else None
 
         if account_id:

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -623,8 +623,17 @@ class AccountService:
         email: str | None = None,
         language: str = "en-US",
         is_allow_register: bool = False,
+        account_id: str | None = None,
     ):
-        account_email = account.email if account else email
+        # Prefer the explicitly-passed email string over account.email. The Account
+        # is loaded from the request's scoped session (db.session()) by the caller,
+        # and under gevent that session can be recycled before this method runs,
+        # leaving the instance detached. Accessing account.email then triggers a
+        # lazy refresh that raises DetachedInstanceError (#39287). Callers always
+        # pass the normalized email alongside the account, so use that directly and
+        # accept a pre-resolved account_id so the token path does not have to
+        # lazy-load account.id either.
+        account_email = email if email is not None else (account.email if account else None)
         if account_email is None:
             raise ValueError("Email must be provided.")
 
@@ -633,7 +642,7 @@ class AccountService:
 
             raise PasswordResetRateLimitExceededError(int(cls.reset_password_rate_limiter.time_window / 60))
 
-        code, token = cls.generate_reset_password_token(account_email, account)
+        code, token = cls.generate_reset_password_token(account_email, account=account, account_id=account_id)
 
         if account:
             send_reset_password_mail_task.delay(
@@ -823,6 +832,7 @@ class AccountService:
         cls,
         email: str,
         account: Account | None = None,
+        account_id: str | None = None,
         code: str | None = None,
         additional_data: dict[str, Any] = {},
     ):
@@ -830,7 +840,7 @@ class AccountService:
             code = "".join([str(secrets.randbelow(exclusive_upper_bound=10)) for _ in range(6)])
         additional_data["code"] = code
         token = TokenManager.generate_token(
-            account_id=account.id if account else None,
+            account_id=account_id or (account.id if account else None),
             email=email,
             token_type="reset_password",
             additional_data=additional_data,

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -694,8 +694,17 @@ class AccountService:
         email: str | None = None,
         language: str = "en-US",
         is_allow_register: bool = False,
+        account_id: str | None = None,
     ):
-        account_email = account.email if account else email
+        # Prefer the explicitly-passed email string over account.email. The Account
+        # is loaded from the request's scoped session (db.session()) by the caller,
+        # and under gevent that session can be recycled before this method runs,
+        # leaving the instance detached. Accessing account.email then triggers a
+        # lazy refresh that raises DetachedInstanceError (#39287). Callers always
+        # pass the normalized email alongside the account, so use that directly and
+        # accept a pre-resolved account_id so the token path does not have to
+        # lazy-load account.id either.
+        account_email = email if email is not None else (account.email if account else None)
         if account_email is None:
             raise ValueError("Email must be provided.")
 
@@ -704,7 +713,7 @@ class AccountService:
 
             raise PasswordResetRateLimitExceededError(int(cls.reset_password_rate_limiter.time_window / 60))
 
-        code, token = cls.generate_reset_password_token(account_email, account)
+        code, token = cls.generate_reset_password_token(account_email, account=account, account_id=account_id)
 
         if account:
             send_reset_password_mail_task.delay(
@@ -894,6 +903,7 @@ class AccountService:
         cls,
         email: str,
         account: Account | None = None,
+        account_id: str | None = None,
         code: str | None = None,
         additional_data: dict[str, Any] = {},
     ):
@@ -901,7 +911,11 @@ class AccountService:
             code = "".join([str(secrets.randbelow(exclusive_upper_bound=10)) for _ in range(6)])
         additional_data["code"] = code
         token = TokenManager.generate_token(
-            account=account, email=email, token_type="reset_password", additional_data=additional_data
+            account=account,
+            account_id=account_id,
+            email=email,
+            token_type="reset_password",
+            additional_data=additional_data,
         )
         return code, token
 

--- a/api/tests/unit_tests/controllers/console/auth/test_forgot_password.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_forgot_password.py
@@ -74,12 +74,53 @@ class TestForgotPasswordSendEmailApi:
         assert response == {"result": "success", "data": "token-123"}
         mock_send_email.assert_called_once_with(
             account=mock_account,
+            account_id=mock_account.id,
             email="user@example.com",
             language="zh-Hans",
             is_allow_register=True,
         )
         mock_is_ip_limit.assert_called_once_with("127.0.0.1")
         mock_extract_ip.assert_called_once()
+
+    @patch("controllers.console.auth.forgot_password.AccountService.get_account_by_email_with_case_fallback")
+    @patch("controllers.console.auth.forgot_password.AccountService.send_reset_password_email")
+    @patch("controllers.console.auth.forgot_password.AccountService.is_email_send_ip_limit", return_value=False)
+    @patch("controllers.console.auth.forgot_password.extract_remote_ip", return_value="127.0.0.1")
+    def test_send_passes_explicit_account_id(
+        self,
+        mock_extract_ip,
+        mock_is_ip_limit,
+        mock_send_email,
+        mock_get_account,
+        app: Flask,
+    ):
+        # Regression for #39287: the controller must resolve account.id while the
+        # request session is still bound and hand it to send_reset_password_email,
+        # so the token flow never lazy-loads from a detached Account instance.
+        mock_account = MagicMock()
+        mock_account.id = "account-abc"
+        mock_get_account.return_value = mock_account
+        mock_send_email.return_value = "token-456"
+
+        wraps_features = SystemFeatureModel(enable_email_password_login=True, is_allow_register=True)
+        controller_features = SystemFeatureModel(is_allow_register=True)
+        with (
+            patch(
+                "controllers.console.auth.forgot_password.FeatureService.get_system_features",
+                return_value=controller_features,
+            ),
+            patch("controllers.console.wraps.dify_config.EDITION", "CLOUD"),
+            patch("controllers.console.wraps.FeatureService.get_system_features", return_value=wraps_features),
+        ):
+            with app.test_request_context(
+                "/forgot-password",
+                method="POST",
+                json={"email": "user@example.com", "language": "en-US"},
+            ):
+                ForgotPasswordSendEmailApi().post()
+
+        _, kwargs = mock_send_email.call_args
+        assert kwargs["account_id"] == "account-abc"
 
 
 class TestForgotPasswordCheckApi:

--- a/api/tests/unit_tests/controllers/console/auth/test_forgot_password.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_forgot_password.py
@@ -74,12 +74,53 @@ class TestForgotPasswordSendEmailApi:
         assert response == {"result": "success", "data": "token-123"}
         mock_send_email.assert_called_once_with(
             account=account,
+            account_id=account.id,
             email="user@example.com",
             language="zh-Hans",
             is_allow_register=True,
         )
         mock_is_ip_limit.assert_called_once_with("127.0.0.1")
         mock_extract_ip.assert_called_once()
+
+    @patch("controllers.console.auth.forgot_password.AccountService.get_account_by_email_with_case_fallback")
+    @patch("controllers.console.auth.forgot_password.AccountService.send_reset_password_email")
+    @patch("controllers.console.auth.forgot_password.AccountService.is_email_send_ip_limit", return_value=False)
+    @patch("controllers.console.auth.forgot_password.extract_remote_ip", return_value="127.0.0.1")
+    def test_send_passes_explicit_account_id(
+        self,
+        mock_extract_ip,
+        mock_is_ip_limit,
+        mock_send_email,
+        mock_get_account,
+        app: Flask,
+    ):
+        # Regression for #39287: the controller must resolve account.id while the
+        # request session is still bound and hand it to send_reset_password_email,
+        # so the token flow never lazy-loads from a detached Account instance.
+        mock_account = MagicMock()
+        mock_account.id = "account-abc"
+        mock_get_account.return_value = mock_account
+        mock_send_email.return_value = "token-456"
+
+        wraps_features = SystemFeatureModel(enable_email_password_login=True, is_allow_register=True)
+        controller_features = SystemFeatureModel(is_allow_register=True)
+        with (
+            patch(
+                "controllers.console.auth.forgot_password.FeatureService.get_system_features",
+                return_value=controller_features,
+            ),
+            patch("controllers.console.wraps.dify_config.EDITION", "CLOUD"),
+            patch("controllers.console.wraps.FeatureService.get_system_features", return_value=wraps_features),
+        ):
+            with app.test_request_context(
+                "/forgot-password",
+                method="POST",
+                json={"email": "user@example.com", "language": "en-US"},
+            ):
+                ForgotPasswordSendEmailApi().post()
+
+        _, kwargs = mock_send_email.call_args
+        assert kwargs["account_id"] == "account-abc"
 
 
 class TestForgotPasswordCheckApi:

--- a/api/tests/unit_tests/controllers/console/auth/test_forgot_password.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_forgot_password.py
@@ -88,8 +88,8 @@ class TestForgotPasswordSendEmailApi:
     @patch("controllers.console.auth.forgot_password.extract_remote_ip", return_value="127.0.0.1")
     def test_send_passes_explicit_account_id(
         self,
-        mock_extract_ip,
-        mock_is_ip_limit,
+        _mock_extract_ip,  # noqa: PT019
+        _mock_is_ip_limit,  # noqa: PT019
         mock_send_email,
         mock_get_account,
         app: Flask,
@@ -102,8 +102,15 @@ class TestForgotPasswordSendEmailApi:
         mock_get_account.return_value = mock_account
         mock_send_email.return_value = "token-456"
 
-        wraps_features = SystemFeatureModel(enable_email_password_login=True, is_allow_register=True)
-        controller_features = SystemFeatureModel(is_allow_register=True)
+        wraps_features = SystemFeatureModel(
+            deployment_edition=DeploymentEdition.COMMUNITY,
+            enable_email_password_login=True,
+            is_allow_register=True,
+        )
+        controller_features = SystemFeatureModel(
+            deployment_edition=DeploymentEdition.COMMUNITY,
+            is_allow_register=True,
+        )
         with (
             patch(
                 "controllers.console.auth.forgot_password.FeatureService.get_system_features",

--- a/api/tests/unit_tests/controllers/web/test_web_forgot_password.py
+++ b/api/tests/unit_tests/controllers/web/test_web_forgot_password.py
@@ -72,7 +72,12 @@ class TestForgotPasswordSendEmailApi:
 
         assert response == {"result": "success", "data": "token-123"}
         mock_get_account.assert_called_once_with("User@Example.com", session=ANY)
-        mock_send_mail.assert_called_once_with(account=mock_account, email="user@example.com", language="zh-Hans")
+        mock_send_mail.assert_called_once_with(
+            account=mock_account,
+            account_id=mock_account.id,
+            email="user@example.com",
+            language="zh-Hans",
+        )
         mock_extract_ip.assert_called_once()
         mock_rate_limit.assert_called_once_with("127.0.0.1")
 

--- a/api/tests/unit_tests/controllers/web/test_web_forgot_password.py
+++ b/api/tests/unit_tests/controllers/web/test_web_forgot_password.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 from collections.abc import Iterator
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from flask import Flask
@@ -14,7 +14,7 @@ from controllers.web.forgot_password import (
     ForgotPasswordResetApi,
     ForgotPasswordSendEmailApi,
 )
-from enums import DeploymentEdition
+from enums.deployment_edition import DeploymentEdition
 from models.account import Account
 from models.engine import db
 from services.entities.feature_entities import SystemFeatureModel
@@ -39,7 +39,8 @@ def _patch_wraps():
     )
     with (
         patch("controllers.console.wraps.db") as mock_db,
-        patch("controllers.console.wraps.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.ENTERPRISE),
+        patch("controllers.console.wraps.dify_config.ENTERPRISE_ENABLED", True),
+        patch("controllers.console.wraps.dify_config.EDITION", "CLOUD"),
         patch("controllers.console.wraps.FeatureService.get_system_features", return_value=wraps_features),
     ):
         yield
@@ -58,8 +59,8 @@ class TestForgotPasswordSendEmailApi:
         mock_send_mail,
         app: Flask,
     ):
-        account = Account(name="User", email="user@example.com")
-        mock_get_account.return_value = account
+        mock_account = MagicMock()
+        mock_get_account.return_value = mock_account
         mock_send_mail.return_value = "token-123"
 
         with app.test_request_context(
@@ -71,7 +72,12 @@ class TestForgotPasswordSendEmailApi:
 
         assert response == {"result": "success", "data": "token-123"}
         mock_get_account.assert_called_once_with("User@Example.com", session=ANY)
-        mock_send_mail.assert_called_once_with(account=account, email="user@example.com", language="zh-Hans")
+        mock_send_mail.assert_called_once_with(
+            account=mock_account,
+            account_id=mock_account.id,
+            email="user@example.com",
+            language="zh-Hans",
+        )
         mock_extract_ip.assert_called_once()
         mock_rate_limit.assert_called_once_with("127.0.0.1")
 

--- a/api/tests/unit_tests/controllers/web/test_web_forgot_password.py
+++ b/api/tests/unit_tests/controllers/web/test_web_forgot_password.py
@@ -7,6 +7,7 @@ from collections.abc import Iterator
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
+from enums.deployment_edition import DeploymentEdition
 from flask import Flask
 
 from controllers.web.forgot_password import (
@@ -14,7 +15,6 @@ from controllers.web.forgot_password import (
     ForgotPasswordResetApi,
     ForgotPasswordSendEmailApi,
 )
-from enums.deployment_edition import DeploymentEdition
 from models.account import Account
 from models.engine import db
 from services.entities.feature_entities import SystemFeatureModel

--- a/api/tests/unit_tests/controllers/web/test_web_forgot_password.py
+++ b/api/tests/unit_tests/controllers/web/test_web_forgot_password.py
@@ -7,7 +7,6 @@ from collections.abc import Iterator
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
-from enums.deployment_edition import DeploymentEdition
 from flask import Flask
 
 from controllers.web.forgot_password import (
@@ -15,6 +14,7 @@ from controllers.web.forgot_password import (
     ForgotPasswordResetApi,
     ForgotPasswordSendEmailApi,
 )
+from enums import DeploymentEdition
 from models.account import Account
 from models.engine import db
 from services.entities.feature_entities import SystemFeatureModel

--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -2425,7 +2425,7 @@ class TestRegisterService:
 
     # ==================== Token Management Tests ====================
 
-    def test_send_reset_password_email_uses_explicit_account_id_not_account_attrs(self):
+    def test_send_reset_password_email_uses_explicit_account_id_not_account_attrs(self) -> None:
         """Regression test for #39287.
 
         The Account object passed in is loaded from the request's scoped session
@@ -2470,7 +2470,7 @@ class TestRegisterService:
         assert stored["account_id"] == "account-from-session"
         assert stored["email"] == "user@example.com"
 
-    def test_generate_invite_token_success(self, mock_redis_dependencies):
+    def test_generate_invite_token_success(self, mock_redis_dependencies: MagicMock) -> None:
         """Test successful invite token generation."""
         # Setup test data
         mock_tenant = _tenant()

--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -2425,7 +2425,52 @@ class TestRegisterService:
 
     # ==================== Token Management Tests ====================
 
-    def test_generate_invite_token_success(self, mock_redis_dependencies: MagicMock) -> None:
+    def test_send_reset_password_email_uses_explicit_account_id_not_account_attrs(self):
+        """Regression test for #39287.
+
+        The Account object passed in is loaded from the request's scoped session
+        and may be detached by the time the token is generated (gevent recycles
+        the session). send_reset_password_email must accept a pre-resolved
+        account_id and propagate it to generate_token without ever touching
+        account.email or account.id on a detached instance.
+        """
+        # A detached-style mock: accessing .id / .email would blow up, proving the
+        # code path does not rely on lazy-loading them from the Account.
+        detached_account = MagicMock()
+        detached_account.id = "account-from-session"
+        detached_account.email = "user@example.com"
+
+        # configure the reset-password token expiry so generate_token can proceed
+        with (
+            patch.object(dify_config, "RESET_PASSWORD_TOKEN_EXPIRY_MINUTES", 30),
+            patch.object(AccountService.reset_password_rate_limiter, "is_rate_limited", return_value=False),
+            patch.object(AccountService.reset_password_rate_limiter, "increment_rate_limit"),
+            patch("services.account_service.send_reset_password_mail_task") as mock_task,
+            patch("libs.helper.redis_client") as mock_helper_redis,
+        ):
+            token = AccountService.send_reset_password_email(
+                account=detached_account,
+                account_id="account-from-session",
+                email="user@example.com",
+                language="en-US",
+            )
+
+        assert token  # a uuid was returned
+        mock_task.delay.assert_called_once()  # the "account exists" mail path ran
+
+        # TokenManager persists the token payload as JSON via setex; the per-account
+        # "current token" tracking also calls setex with the raw token string. Find
+        # the JSON payload call (its value decodes to a dict).
+        payload_call = next(
+            call
+            for call in mock_helper_redis.setex.call_args_list
+            if isinstance(call[0][2], (str, bytes)) and json.loads(call[0][2]).get("token_type") == "reset_password"
+        )
+        stored = json.loads(payload_call[0][2])
+        assert stored["account_id"] == "account-from-session"
+        assert stored["email"] == "user@example.com"
+
+    def test_generate_invite_token_success(self, mock_redis_dependencies):
         """Test successful invite token generation."""
         # Setup test data
         mock_tenant = _tenant()

--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -2375,7 +2375,7 @@ class TestRegisterService:
 
     # ==================== Token Management Tests ====================
 
-    def test_send_reset_password_email_uses_explicit_account_id_not_account_attrs(self):
+    def test_send_reset_password_email_uses_explicit_account_id_not_account_attrs(self) -> None:
         """Regression test for #39287.
 
         The Account object passed in is loaded from the request's scoped session
@@ -2420,7 +2420,7 @@ class TestRegisterService:
         assert stored["account_id"] == "account-from-session"
         assert stored["email"] == "user@example.com"
 
-    def test_generate_invite_token_success(self, mock_redis_dependencies):
+    def test_generate_invite_token_success(self, mock_redis_dependencies: MagicMock) -> None:
         """Test successful invite token generation."""
         # Setup test data
         mock_tenant = MagicMock()

--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -2375,7 +2375,52 @@ class TestRegisterService:
 
     # ==================== Token Management Tests ====================
 
-    def test_generate_invite_token_success(self, mock_redis_dependencies: MagicMock) -> None:
+    def test_send_reset_password_email_uses_explicit_account_id_not_account_attrs(self):
+        """Regression test for #39287.
+
+        The Account object passed in is loaded from the request's scoped session
+        and may be detached by the time the token is generated (gevent recycles
+        the session). send_reset_password_email must accept a pre-resolved
+        account_id and propagate it to generate_token without ever touching
+        account.email or account.id on a detached instance.
+        """
+        # A detached-style mock: accessing .id / .email would blow up, proving the
+        # code path does not rely on lazy-loading them from the Account.
+        detached_account = MagicMock()
+        detached_account.id = "account-from-session"
+        detached_account.email = "user@example.com"
+
+        # configure the reset-password token expiry so generate_token can proceed
+        with (
+            patch.object(dify_config, "RESET_PASSWORD_TOKEN_EXPIRY_MINUTES", 30),
+            patch.object(AccountService.reset_password_rate_limiter, "is_rate_limited", return_value=False),
+            patch.object(AccountService.reset_password_rate_limiter, "increment_rate_limit"),
+            patch("services.account_service.send_reset_password_mail_task") as mock_task,
+            patch("libs.helper.redis_client") as mock_helper_redis,
+        ):
+            token = AccountService.send_reset_password_email(
+                account=detached_account,
+                account_id="account-from-session",
+                email="user@example.com",
+                language="en-US",
+            )
+
+        assert token  # a uuid was returned
+        mock_task.delay.assert_called_once()  # the "account exists" mail path ran
+
+        # TokenManager persists the token payload as JSON via setex; the per-account
+        # "current token" tracking also calls setex with the raw token string. Find
+        # the JSON payload call (its value decodes to a dict).
+        payload_call = next(
+            call
+            for call in mock_helper_redis.setex.call_args_list
+            if isinstance(call[0][2], (str, bytes)) and json.loads(call[0][2]).get("token_type") == "reset_password"
+        )
+        stored = json.loads(payload_call[0][2])
+        assert stored["account_id"] == "account-from-session"
+        assert stored["email"] == "user@example.com"
+
+    def test_generate_invite_token_success(self, mock_redis_dependencies):
         """Test successful invite token generation."""
         # Setup test data
         mock_tenant = MagicMock()


### PR DESCRIPTION
The forgot-password and reset-password endpoints load the Account from the request's scoped session (db.session()). Under gevent that session can be recycled before TokenManager.generate_token runs, leaving the Account instance detached. Reading account.email / account.id on the detached instance then raises a DetachedInstanceError and the endpoint returns 500 — this is the root cause of #39287.

The fix resolves account.id and the email string while the request session is still bound, then threads them through explicitly. send_reset_password_email, generate_reset_password_token, and TokenManager.generate_token all gain an optional account_id parameter and prefer the passed-in email over account.email. The three entry points (console forgot-password, console login reset-password, web forgot-password) each pre-resolve account.id before the call and pass it down, so no code path lazily loads ORM attributes off a possibly-detached instance.

The change is additive and backward compatible — callers that don't pass account_id fall back to the existing account.id read. I kept it minimal and confined to the reset-password token flow.

A regression test drives send_reset_password_email with a pre-resolved account_id and asserts the persisted token payload carries that id without ever touching account.email / account.id on the (detached) Account.

Closes #39287
