### PR TITLE
fix(api): return 400 instead of 500 when 'file' is missing from web-app audio-to-text

### DIFF
--- a/api/controllers/web/audio.py
+++ b/api/controllers/web/audio.py
@@ -76,7 +76,7 @@ class AudioApi(WebApiResource):
     @web_ns.response(200, "Success", web_ns.models[AudioToTextResponse.__name__])
     def post(self, app_model: App, end_user: EndUser):
         """Convert audio to text"""
-        file = request.files["file"]
+        file = request.files.get("file")
 
         try:
             response = AudioService.transcript_asr(

--- a/api/tests/unit_tests/controllers/web/test_audio.py
+++ b/api/tests/unit_tests/controllers/web/test_audio.py
@@ -131,9 +131,7 @@ class TestAudioApi:
             raise NoAudioUploadedServiceError()
 
         with patch("controllers.web.audio.AudioService.transcript_asr", side_effect=fake_asr):
-            with app.test_request_context(
-                "/audio-to-text", method="POST", data={}, content_type="multipart/form-data"
-            ):
+            with app.test_request_context("/audio-to-text", method="POST", data={}, content_type="multipart/form-data"):
                 with pytest.raises(NoAudioUploadedError) as exc_info:
                     AudioApi().post(_app_model(), _end_user())
 

--- a/api/tests/unit_tests/controllers/web/test_audio.py
+++ b/api/tests/unit_tests/controllers/web/test_audio.py
@@ -119,6 +119,26 @@ class TestAudioApi:
             with pytest.raises(ProviderModelCurrentlyNotSupportError):
                 AudioApi().post(_app_model(), _end_user())
 
+    def test_missing_file_field_returns_400(self, app: Flask) -> None:
+        """A multipart POST with no `file` field must surface as 400, not 500.
+
+        Verifies the controller passes file=None to AudioService.transcript_asr
+        instead of raising a KeyError that would yield HTTP 500.
+        """
+
+        def fake_asr(*args, **kwargs):
+            assert kwargs["file"] is None
+            raise NoAudioUploadedServiceError()
+
+        with patch("controllers.web.audio.AudioService.transcript_asr", side_effect=fake_asr):
+            with app.test_request_context(
+                "/audio-to-text", method="POST", data={}, content_type="multipart/form-data"
+            ):
+                with pytest.raises(NoAudioUploadedError) as exc_info:
+                    AudioApi().post(_app_model(), _end_user())
+
+        assert exc_info.value.code == 400
+
 
 # ---------------------------------------------------------------------------
 # TextApi (text-to-audio)


### PR DESCRIPTION
## Summary

The web-app audio-to-text endpoint (`POST /audio-to-text`) returns HTTP 500 with a `KeyError` stack trace when a client submits a multipart POST without the `file` field. It should return HTTP 400 with the existing `no_audio_uploaded` error payload.

Same fix as PR #39219 (sibling `explore/audio.py`). See issue #39303 for the family of three sibling endpoints.

## What changed

- `api/controllers/web/audio.py:79` — `request.files["file"]` → `request.files.get("file")`.
- `api/tests/unit_tests/controllers/web/test_audio.py` — new `test_missing_file_field_returns_400` asserts the controller raises `NoAudioUploadedError` (HTTP 400) when the multipart `file` field is absent.

## How it works

The service layer already handles `file=None` cleanly:

```python
# api/services/audio_service.py
def _invoke_speech_to_text(cls, app_model, file, end_user):
    if file is None:
        raise NoAudioUploadedServiceError()
```

The controller already catches that and maps it to the documented 400:

```python
except NoAudioUploadedServiceError:
    raise NoAudioUploadedError()
```

The previous `request.files["file"]` access crashed with `KeyError` before this path could fire, so the `except NoAudioUploadedServiceError` clause was unreachable for this case.

## Verification

- `ruff check` and `ruff format --check` pass.
- `pytest tests/unit_tests/controllers/web/test_audio.py` — 13 passed, including the new `test_missing_file_field_returns_400`.
- Existing tests for the happy path and all error paths remain green.

## Backward compatibility

None. Clients that send a valid `file` field see no change. Clients that previously got a 500 for missing `file` will now get a 400 with the same `no_audio_uploaded` error payload the service was already designed to emit.

## Related

- Fixes #39303 (first of three siblings: web-app, trial-app, service API)
- Mirrors PR #39219 for the `explore/audio.py` sibling