### PR TITLE
fix(api): return 400 instead of 500 when 'file' is missing from trial-app audio-to-text

### DIFF
--- a/api/controllers/console/explore/trial.py
+++ b/api/controllers/console/explore/trial.py
@@ -645,7 +645,7 @@ class TrialChatAudioApi(TrialAppResource):
     def post(self, current_user: Account, trial_app):
         app_model = trial_app
 
-        file = request.files["file"]
+        file = request.files.get("file")
 
         try:
             # Get IDs before they might be detached from session

--- a/api/tests/unit_tests/controllers/console/explore/test_trial.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_trial.py
@@ -838,6 +838,29 @@ class TestTrialChatAudioApi:
             with pytest.raises(module.NoAudioUploadedError):
                 method(api, account, trial_app_chat)
 
+    def test_missing_file_field_returns_400(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
+        """A multipart POST with no `file` field must surface as 400, not 500.
+
+        Verifies the controller passes file=None to AudioService.transcript_asr
+        instead of raising a KeyError that would yield HTTP 500.
+        """
+
+        def fake_asr(*args, **kwargs):
+            assert kwargs["file"] is None
+            raise module.services.errors.audio.NoAudioUploadedServiceError()
+
+        api = module.TrialChatAudioApi()
+        method = unwrap(api.post)
+
+        with (
+            app.test_request_context("/", method="POST", data={}, content_type="multipart/form-data"),
+            patch.object(module.AudioService, "transcript_asr", side_effect=fake_asr),
+        ):
+            with pytest.raises(module.NoAudioUploadedError) as exc_info:
+                method(api, account, trial_app_chat)
+
+        assert exc_info.value.code == 400
+
     def test_audio_too_large(self, app: Flask, trial_app_chat: MagicMock, account: Account) -> None:
         api = module.TrialChatAudioApi()
         method = unwrap(api.post)


### PR DESCRIPTION
## Summary

The trial-app audio-to-text endpoint (`POST /installed-apps/<id>/audio-to-text` via the trial app flow) returns HTTP 500 with a `KeyError` stack trace when a client submits a multipart POST without the `file` field. It should return HTTP 400 with the existing `no_audio_uploaded` error payload.

Same fix as PR #39219 (sibling `explore/audio.py`) and PR #39304 (sibling `web/audio.py`). See issue #39303 for the family of three sibling endpoints.

## What changed

- `api/controllers/console/explore/trial.py:649` — `request.files["file"]` → `request.files.get("file")`.
- `api/tests/unit_tests/controllers/console/explore/test_trial.py` — new `TestTrialChatAudioApi.test_missing_file_field_returns_400` asserts the controller raises `NoAudioUploadedError` (HTTP 400) when the multipart `file` field is absent.

## How it works

The service layer already handles `file=None` cleanly:

```python
# api/services/audio_service.py
def _invoke_speech_to_text(cls, app_model, file, end_user):
    if file is None:
        raise NoAudioUploadedServiceError()
```

The controller already catches that and maps it to the documented 400:

```python
except NoAudioUploadedServiceError:
    raise NoAudioUploadedError()
```

The previous `request.files["file"]` access crashed with `KeyError` before this path could fire, so the `except NoAudioUploadedServiceError` clause was unreachable for this case.

## Verification

- `ruff check` and `ruff format --check` pass.
- `pytest tests/unit_tests/controllers/console/explore/test_trial.py::TestTrialChatAudioApi` — 10 passed, including the new `test_missing_file_field_returns_400`.
- Existing tests for the happy path and all error paths remain green.

## Backward compatibility

None. Clients that send a valid `file` field see no change. Clients that previously got a 500 for missing `file` will now get a 400 with the same `no_audio_uploaded` error payload the service was already designed to emit.

## Related

- Fixes #39303 (second of three siblings: web-app, trial-app, service API)
- Mirrors PR #39219 for `explore/audio.py`
- Mirrors PR #39304 for `web/audio.py`