### PR TITLE
refactor(web): remove basePath from hydration boundary

### DIFF
--- a/web/app/(commonLayout)/__tests__/hydration-boundary.spec.tsx
+++ b/web/app/(commonLayout)/__tests__/hydration-boundary.spec.tsx
@@ -107,7 +107,7 @@ describe('CommonLayoutHydrationBoundary', () => {
     })
   })
 
-  it('should hydrate common layout queries and render children', async () => {
+  it('should prefetch common layout queries and render children', async () => {
     const { CommonLayoutHydrationBoundary } = await import('../hydration-boundary')
 
     const element = await CommonLayoutHydrationBoundary({
@@ -163,7 +163,7 @@ describe('CommonLayoutHydrationBoundary', () => {
   it.each([
     ['not_setup', '/install'],
     ['not_init_validated', '/init'],
-  ])('should use a basePath-relative destination for %s errors', async (code, destination) => {
+  ])('should use an internal destination for %s errors', async (code, destination) => {
     mocks.basePath = '/workflow'
     mocks.profileQueryFn.mockRejectedValue(new Response(JSON.stringify({ code }), { status: 401 }))
     const { CommonLayoutHydrationBoundary } = await import('../hydration-boundary')

--- a/web/app/(commonLayout)/__tests__/hydration-boundary.spec.tsx
+++ b/web/app/(commonLayout)/__tests__/hydration-boundary.spec.tsx
@@ -147,7 +147,8 @@ describe('CommonLayoutHydrationBoundary', () => {
     )
   })
 
-  it('should default unauthorized refresh redirects to the home path when the pathname header is missing', async () => {
+  it('should use the internal home path when the pathname header is missing', async () => {
+    mocks.basePath = '/workflow'
     mocks.headers.mockResolvedValue(new Headers())
     mocks.profileQueryFn.mockRejectedValue(
       new Response(JSON.stringify({ code: 'unauthorized' }), { status: 401 }),

--- a/web/app/(commonLayout)/hydration-boundary.tsx
+++ b/web/app/(commonLayout)/hydration-boundary.tsx
@@ -10,7 +10,6 @@ import {
   resolveServerConsoleApiUrl,
   serverConsoleQuery,
 } from '@/service/server'
-import { basePath } from '@/utils/var'
 
 const CURRENT_PATHNAME_HEADER = 'x-dify-pathname'
 const CURRENT_SEARCH_HEADER = 'x-dify-search'
@@ -35,7 +34,7 @@ const parseConsoleErrorPayload = async (error: Response): Promise<ConsoleErrorPa
 
 const getCurrentPath = async () => {
   const requestHeaders = await headers()
-  const pathname = requestHeaders.get(CURRENT_PATHNAME_HEADER) || `${basePath}/`
+  const pathname = requestHeaders.get(CURRENT_PATHNAME_HEADER) || '/'
   const search = requestHeaders.get(CURRENT_SEARCH_HEADER) || ''
   return `${pathname}${search}`
 }


### PR DESCRIPTION
## Summary

- remove the remaining `basePath` dependency from `CommonLayoutHydrationBoundary`
- keep the missing-pathname fallback in Next's internal route space as `/`
- cover the fallback with a non-empty base path to prevent the mount prefix from leaking back into the boundary

## Why

This is a follow-up to #39273. The hydration boundary consumes normalized internal pathnames and calls Next.js `redirect()`, so it should not own the browser-facing mount prefix. The auth refresh route remains responsible for restoring the configured base path when it emits the final raw `Location` response.

The final navigation is unchanged: an internal `/` target still resolves to the configured base-path home, such as `/workflow/`.

## Validation

- `vp test run 'config/__tests__/server.spec.ts' 'service/__tests__/server.spec.ts' 'app/(commonLayout)/__tests__/hydration-boundary.spec.tsx' 'app/auth/refresh/__tests__/route.spec.ts'`
- `pnpm --dir web lint:tss`
- `pnpm check`
