### PR TITLE
fix(account): show validation error message in reset-password/reset-email CLI

### DIFF
--- a/api/commands/account.py
+++ b/api/commands/account.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from constants.languages import languages
 from extensions.ext_database import db
 from libs.helper import email as email_validate
-from libs.password import hash_password, password_pattern, valid_password
+from libs.password import hash_password, valid_password
 from services.account_service import AccountService, RegisterService, TenantService
 
 
@@ -33,8 +33,8 @@ def reset_password(email, new_password, password_confirm):
 
     try:
         valid_password(new_password)
-    except:
-        click.echo(click.style(f"Invalid password. Must match {password_pattern}", fg="red"))
+    except ValueError as e:
+        click.echo(click.style(str(e), fg="red"))
         return
 
     # generate password salt
@@ -75,8 +75,8 @@ def reset_email(email, new_email, email_confirm):
 
     try:
         email_validate(normalized_new_email)
-    except:
-        click.echo(click.style(f"Invalid email: {new_email}", fg="red"))
+    except ValueError as e:
+        click.echo(click.style(str(e), fg="red"))
         return
 
     with Session(db.engine) as session:

--- a/api/commands/account.py
+++ b/api/commands/account.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from constants.languages import languages
 from extensions.ext_database import db
 from libs.helper import email as email_validate
-from libs.password import hash_password, password_pattern, valid_password
+from libs.password import hash_password, valid_password
 from services.account_service import AccountService, RegisterService, TenantService
 
 
@@ -33,8 +33,8 @@ def reset_password(email, new_password, password_confirm):
 
     try:
         valid_password(new_password)
-    except ValueError:
-        click.echo(click.style(f"Invalid password. Must match {password_pattern}", fg="red"))
+    except ValueError as e:
+        click.echo(click.style(str(e), fg="red"))
         return
 
     # generate password salt
@@ -75,8 +75,8 @@ def reset_email(email, new_email, email_confirm):
 
     try:
         email_validate(normalized_new_email)
-    except ValueError:
-        click.echo(click.style(f"Invalid email: {new_email}", fg="red"))
+    except ValueError as e:
+        click.echo(click.style(str(e), fg="red"))
         return
 
     with Session(db.engine) as session:


### PR DESCRIPTION
The reset-password and reset-email click commands wrapped valid_password / email_validate in a bare except: that discarded the ValueError both helpers raise. valid_password raises "Password must contain letters and numbers, and the length must be at least 8 characters." and email_validate raises "<addr> is not a valid email.", but operators only ever saw a raw regex pattern or a generic "Invalid email" line, with no indication of which rule was actually violated.

This catches ValueError specifically and echoes str(e), so the actionable reason is shown to whoever is running the command. Narrowing away from the bare except also lets KeyboardInterrupt / SystemExit propagate normally instead of being silently swallowed.

password_pattern is removed from the import since nothing in the file references it anymore.

Verified with ruff check / ruff format (both clean) and the pre-commit hooks pass. These two commands had no existing tests and I did not add coverage for a two-line error-message change, but happy to add a CliRunner test if the maintainers prefer.