### PR TITLE
fix: match workflow trace entries by execution id to prevent parallel-branch misattribution

### DIFF
--- a/web/app/components/workflow/hooks/use-workflow-run-event/__tests__/use-workflow-agent-log.spec.ts
+++ b/web/app/components/workflow/hooks/use-workflow-run-event/__tests__/use-workflow-agent-log.spec.ts
@@ -88,4 +88,28 @@ describe('useWorkflowAgentLog', () => {
       store.getState().workflowRunningData!.tracing![0]!.execution_metadata!.agent_log,
     ).toHaveLength(1)
   })
+
+  it('routes agent log to the exact trace entry by node_execution_id, not the first node_id match', () => {
+    const { result, store } = renderWorkflowHook(() => useWorkflowAgentLog(), {
+      initialStoreState: {
+        workflowRunningData: baseRunningData({
+          tracing: [
+            { id: 'exec-1', node_id: 'n1', execution_metadata: {} },
+            { id: 'exec-2', node_id: 'n1', execution_metadata: {} },
+          ],
+        }),
+      },
+    })
+
+    result.current.handleWorkflowAgentLog({
+      data: { node_execution_id: 'exec-2', node_id: 'n1', message_id: 'm1' },
+    } as AgentLogResponse)
+
+    const tracing = store.getState().workflowRunningData!.tracing!
+    // exec-1 must not receive the log
+    expect(tracing[0]!.execution_metadata!.agent_log).toBeUndefined()
+    // exec-2 must receive it
+    expect(tracing[1]!.execution_metadata!.agent_log).toHaveLength(1)
+    expect(tracing[1]!.execution_metadata!.agent_log![0]!.message_id).toBe('m1')
+  })
 })

--- a/web/app/components/workflow/hooks/use-workflow-run-event/__tests__/use-workflow-node-started.spec.ts
+++ b/web/app/components/workflow/hooks/use-workflow-run-event/__tests__/use-workflow-node-started.spec.ts
@@ -84,4 +84,62 @@ describe('useWorkflowNodeStarted', () => {
     expect(tracing).toHaveLength(2)
     expect(tracing[1]!.status).toBe(NodeRunningStatus.Running)
   })
+
+  it('creates a new trace entry when the same node_id runs again with a different execution id (parallel branch / repeated run)', () => {
+    const { result, store } = renderViewportHook(() => useWorkflowNodeStarted(), {
+      initialStoreState: {
+        workflowRunningData: baseRunningData({
+          tracing: [{ id: 'exec-1', node_id: 'n1', status: NodeRunningStatus.Succeeded } as never],
+        }),
+      },
+    })
+
+    act(() => {
+      result.current.handleWorkflowNodeStarted(
+        createNodeStartedResponse({
+          data: { id: 'exec-2', node_id: 'n1' } as never,
+        }),
+        containerParams,
+      )
+    })
+
+    const tracing = store.getState().workflowRunningData!.tracing!
+    // The previous entry must be preserved and a new one appended
+    expect(tracing).toHaveLength(2)
+    expect(tracing[0]!.id).toBe('exec-1')
+    expect(tracing[0]!.status).toBe(NodeRunningStatus.Succeeded)
+    expect(tracing[1]!.id).toBe('exec-2')
+    expect(tracing[1]!.status).toBe(NodeRunningStatus.Running)
+  })
+
+  it('updates the exact trace entry matched by execution id, not the first node_id match', () => {
+    const { result, store } = renderViewportHook(() => useWorkflowNodeStarted(), {
+      initialStoreState: {
+        workflowRunningData: baseRunningData({
+          tracing: [
+            { id: 'exec-1', node_id: 'n1', status: NodeRunningStatus.Succeeded } as never,
+            { id: 'exec-2', node_id: 'n1', status: NodeRunningStatus.Succeeded } as never,
+          ],
+        }),
+      },
+    })
+
+    act(() => {
+      result.current.handleWorkflowNodeStarted(
+        createNodeStartedResponse({
+          data: { id: 'exec-2', node_id: 'n1' } as never,
+        }),
+        containerParams,
+      )
+    })
+
+    const tracing = store.getState().workflowRunningData!.tracing!
+    expect(tracing).toHaveLength(2)
+    // The first entry (exec-1) must be untouched
+    expect(tracing[0]!.id).toBe('exec-1')
+    expect(tracing[0]!.status).toBe(NodeRunningStatus.Succeeded)
+    // Only exec-2 should be updated to Running
+    expect(tracing[1]!.id).toBe('exec-2')
+    expect(tracing[1]!.status).toBe(NodeRunningStatus.Running)
+  })
 })

--- a/web/app/components/workflow/hooks/use-workflow-run-event/use-workflow-agent-log.ts
+++ b/web/app/components/workflow/hooks/use-workflow-run-event/use-workflow-agent-log.ts
@@ -13,7 +13,13 @@ export const useWorkflowAgentLog = () => {
 
       setWorkflowRunningData(
         produce(workflowRunningData!, (draft) => {
-          const currentIndex = draft.tracing!.findIndex((item) => item.node_id === data.node_id)
+          // Prefer the unique node_execution_id so agent logs are routed to the
+          // exact trace entry that produced them, even when the same node runs
+          // multiple times in parallel branches or repeated debug runs. Fall
+          // back to node_id only for older events without a node_execution_id.
+          const currentIndex = data.node_execution_id
+            ? draft.tracing!.findIndex((item) => item.id === data.node_execution_id)
+            : draft.tracing!.findIndex((item) => item.node_id === data.node_id)
           if (currentIndex > -1) {
             const current = draft.tracing![currentIndex]
 

--- a/web/app/components/workflow/hooks/use-workflow-run-event/use-workflow-node-started.ts
+++ b/web/app/components/workflow/hooks/use-workflow-run-event/use-workflow-node-started.ts
@@ -22,9 +22,12 @@ export const useWorkflowNodeStarted = () => {
       const { workflowRunningData, setWorkflowRunningData } = workflowStore.getState()
       const { getNodes, setNodes, edges, setEdges, transform } = store.getState()
       const nodes = getNodes()
-      const currentIndex = workflowRunningData?.tracing?.findIndex(
-        (item) => item.node_id === data.node_id,
-      )
+      // Match by unique execution id first so that nodes executing multiple times
+      // (parallel branches, repeated debug runs) don't overwrite each other's trace
+      // entries. Fall back to node_id only for older events that carry no id.
+      const currentIndex = data.id
+        ? workflowRunningData?.tracing?.findIndex((item) => item.id === data.id)
+        : workflowRunningData?.tracing?.findIndex((item) => item.node_id === data.node_id)
       if (currentIndex && currentIndex > -1) {
         setWorkflowRunningData(
           produce(workflowRunningData!, (draft) => {


### PR DESCRIPTION
## Summary

Fixes #37645

When a workflow node executes multiple times — in parallel branches or repeated debug runs — the  and  event handlers matched trace entries by  only. Since  is the node **definition** identifier (not unique per execution), the first match always won, causing subsequent executions to overwrite or misroute to the wrong trace entry.

This was especially hard to notice because  already matched by the unique execution uid=501(shakti) gid=20(staff) groups=20(staff),12(everyone),61(localaccounts),79(_appserverusr),80(admin),81(_appserveradm),98(_lpadmin),701(com.apple.sharepoint.group.1),33(_appstore),100(_lpoperator),204(_developer),250(_analyticsusers),395(com.apple.access_ftp),398(com.apple.access_screensharing),399(com.apple.access_ssh),400(com.apple.access_remote_ae), so  and  events for the same execution could silently land on different trace entries.

## Root cause

In `use-workflow-node-started.ts`:
```typescript
// Before — matches by node definition id (not unique per run)
const currentIndex = workflowRunningData?.tracing?.findIndex(
  (item) => item.node_id === data.node_id,
)
```

In `use-workflow-agent-log.ts`:
```typescript
// Before — same issue
const currentIndex = draft.tracing!.findIndex((item) => item.node_id === data.node_id)
```

Compare with `use-workflow-node-finished.ts` which already does the right thing:
```typescript
const currentIndex = draft.tracing!.findIndex((item) => item.id === data.id)
```

## Fix

Both handlers now match by the unique execution identifier first, falling back to `node_id` only for older events that may not carry an execution id (backward compatibility):

- **`use-workflow-node-started.ts`**: match by `data.id` (the `NodeTracing.id` execution identifier), fall back to `node_id` when absent.
- **`use-workflow-agent-log.ts`**: match by `data.node_execution_id` (the `AgentLogItem.node_execution_id` field), fall back to `node_id` when absent.

This aligns the `started` and `agent_log` handlers with the `finished` handler's existing behavior, ensuring all three route to the same trace entry for a given execution.

## Observed symptoms (from #37645)

- In the Trace panel, a node's status/timing/output appears under the wrong parallel branch.
- Agent logs are misrouted to an incorrect node execution.
- On repeated runs in the same Debug & Preview session, earlier trace entries are overwritten or duplicated instead of being preserved with their unique execution IDs.
- The bug is silent — no error is thrown.

## Tests

Added regression tests for both handlers:

**`use-workflow-node-started.spec.ts`**:
- Creates a new trace entry when the same `node_id` runs again with a different execution id (parallel branch / repeated run)
- Updates the exact trace entry matched by execution id, not the first `node_id` match

**`use-workflow-agent-log.spec.ts`**:
- Routes agent log to the exact trace entry by `node_execution_id`, not the first `node_id` match

All 42 existing tests in the `use-workflow-run-event` suite continue to pass.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes