### PR TITLE
ci: simplify test workflow execution

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -47,9 +47,6 @@ jobs:
       - name: Install dependencies
         run: uv sync --project api --dev
 
-      - name: Run dify config tests
-        run: uv run --project api pytest api/tests/unit_tests/configs/test_env_consistency.py
-
       - name: Run Unit Tests
         run: |
           uv run --project api pytest \

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -81,7 +81,6 @@ jobs:
               - '.npmrc'
               - '.nvmrc'
               - '.github/workflows/cli-tests.yml'
-              - '.github/workflows/cli-docker-build.yml'
               - '.github/actions/setup-web/**'
             web:
               - 'web/**'

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -135,16 +135,6 @@ jobs:
             exit 1
           fi
 
-          if [[ -d cucumber-report ]]; then
-            rm -rf cucumber-report-non-external
-            mv cucumber-report cucumber-report-non-external
-          fi
-
-          if [[ -d .logs ]]; then
-            rm -rf .logs-non-external
-            mv .logs .logs-non-external
-          fi
-
           teardown_external_runtime() {
             local run_status=$?
             trap - EXIT

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -17,8 +17,6 @@ jobs:
   test:
     name: Web Tests (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: depot-ubuntu-24.04-4
-    env:
-      VITEST_COVERAGE_SCOPE: app-components
     strategy:
       fail-fast: false
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ test:
 		echo "Target: $(TARGET_TESTS)"; \
 		uv run --project api --dev pytest $(TARGET_TESTS); \
 	else \
+		set -e; \
 		echo "Running backend unit tests"; \
 		uv run --project api --dev pytest -p no:benchmark --timeout "$${PYTEST_TIMEOUT:-20}" -n auto \
 			api/tests/unit_tests \
@@ -124,6 +125,7 @@ test-all:
 		echo "Target: $(TARGET_TESTS)"; \
 		uv run --project api --dev pytest $(TARGET_TESTS); \
 	else \
+		set -e; \
 		echo "Running backend unit tests"; \
 		uv run --project api --dev pytest -p no:benchmark --timeout "$${PYTEST_TIMEOUT:-20}" -n auto \
 			api/tests/unit_tests \

--- a/api/tests/unit_tests/configs/test_dify_config.py
+++ b/api/tests/unit_tests/configs/test_dify_config.py
@@ -8,8 +8,13 @@ from yarl import URL
 from configs.app_config import DifyConfig
 
 
+def _clear_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in tuple(os.environ):
+        monkeypatch.delenv(name)
+
+
 def _set_basic_config_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    os.environ.clear()
+    _clear_environment(monkeypatch)
     monkeypatch.setenv("CONSOLE_API_URL", "https://example.com")
     monkeypatch.setenv("CONSOLE_WEB_URL", "https://example.com")
     monkeypatch.setenv("DB_TYPE", "postgresql")
@@ -51,7 +56,7 @@ def test_dify_config_preserves_explicit_secret_key(
 
 def test_dify_config(monkeypatch: pytest.MonkeyPatch):
     # clear system environment variables
-    os.environ.clear()
+    _clear_environment(monkeypatch)
 
     # Set environment variables using monkeypatch
     monkeypatch.setenv("CONSOLE_API_URL", "https://example.com")
@@ -140,7 +145,7 @@ def test_new_user_default_models_reject_duplicate_model_types(monkeypatch: pytes
 def test_http_timeout_defaults(monkeypatch: pytest.MonkeyPatch):
     """Test that HTTP timeout defaults are correctly set"""
     # clear system environment variables
-    os.environ.clear()
+    _clear_environment(monkeypatch)
 
     # Set minimal required env vars
     monkeypatch.setenv("DB_TYPE", "postgresql")
@@ -160,7 +165,7 @@ def test_http_timeout_defaults(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_internal_files_url_falls_back_to_server_console_api_url(monkeypatch: pytest.MonkeyPatch):
-    os.environ.clear()
+    _clear_environment(monkeypatch)
     monkeypatch.setenv("SERVER_CONSOLE_API_URL", "http://api:5001")
 
     config = DifyConfig(_env_file=None)
@@ -169,7 +174,7 @@ def test_internal_files_url_falls_back_to_server_console_api_url(monkeypatch: py
 
 
 def test_internal_files_url_prefers_explicit_value(monkeypatch: pytest.MonkeyPatch):
-    os.environ.clear()
+    _clear_environment(monkeypatch)
     monkeypatch.setenv("INTERNAL_FILES_URL", "http://files-internal:5001")
     monkeypatch.setenv("SERVER_CONSOLE_API_URL", "http://api:5001")
 
@@ -183,7 +188,7 @@ def test_internal_files_url_prefers_explicit_value(monkeypatch: pytest.MonkeyPat
 def test_flask_configs(monkeypatch: pytest.MonkeyPatch):
     flask_app = Flask("app")
     # clear system environment variables
-    os.environ.clear()
+    _clear_environment(monkeypatch)
 
     # Set environment variables using monkeypatch
     monkeypatch.setenv("CONSOLE_API_URL", "https://example.com")
@@ -290,7 +295,7 @@ def test_db_session_timezone_override_can_disable_app_level_timezone_injection(m
 
 
 def test_pubsub_redis_url_default(monkeypatch: pytest.MonkeyPatch):
-    os.environ.clear()
+    _clear_environment(monkeypatch)
 
     monkeypatch.setenv("CONSOLE_API_URL", "https://example.com")
     monkeypatch.setenv("CONSOLE_WEB_URL", "https://example.com")
@@ -313,7 +318,7 @@ def test_pubsub_redis_url_default(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_pubsub_redis_url_override(monkeypatch: pytest.MonkeyPatch):
-    os.environ.clear()
+    _clear_environment(monkeypatch)
 
     monkeypatch.setenv("CONSOLE_API_URL", "https://example.com")
     monkeypatch.setenv("CONSOLE_WEB_URL", "https://example.com")
@@ -330,7 +335,7 @@ def test_pubsub_redis_url_override(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_pubsub_redis_url_required_when_default_unavailable(monkeypatch: pytest.MonkeyPatch):
-    os.environ.clear()
+    _clear_environment(monkeypatch)
 
     monkeypatch.setenv("CONSOLE_API_URL", "https://example.com")
     monkeypatch.setenv("CONSOLE_WEB_URL", "https://example.com")
@@ -346,7 +351,7 @@ def test_pubsub_redis_url_required_when_default_unavailable(monkeypatch: pytest.
 
 
 def test_dify_config_exposes_redis_key_prefix_default(monkeypatch: pytest.MonkeyPatch):
-    os.environ.clear()
+    _clear_environment(monkeypatch)
 
     monkeypatch.setenv("CONSOLE_API_URL", "https://example.com")
     monkeypatch.setenv("CONSOLE_WEB_URL", "https://example.com")
@@ -363,7 +368,7 @@ def test_dify_config_exposes_redis_key_prefix_default(monkeypatch: pytest.Monkey
 
 
 def test_dify_config_reads_redis_key_prefix_from_env(monkeypatch: pytest.MonkeyPatch):
-    os.environ.clear()
+    _clear_environment(monkeypatch)
 
     monkeypatch.setenv("CONSOLE_API_URL", "https://example.com")
     monkeypatch.setenv("CONSOLE_WEB_URL", "https://example.com")
@@ -415,7 +420,7 @@ def test_celery_broker_url_with_special_chars_password(
     from kombu.utils.url import parse_url
 
     # clear system environment variables
-    os.environ.clear()
+    _clear_environment(monkeypatch)
 
     # Set up basic required environment variables (following existing pattern)
     monkeypatch.setenv("CONSOLE_API_URL", "https://example.com")


### PR DESCRIPTION
## Summary

- Stop `make test` and `make test-all` on the first failing test suite.
- Remove a duplicate API configuration test invocation.
- Remove a stale CLI workflow path filter and an unused web coverage variable.
- Remove duplicate E2E report and log relocation before the external-runtime lane.
- Restore process environment variables after config tests to prevent xdist order-dependent failures.
- Preserve the existing test selection, coverage collection, and artifact upload paths.

Fixes #39317

## Screenshots

Not applicable.

## Validation

- Parsed all four edited workflow files as YAML.
- Ran `make -n test`.
- Ran `make -n test-all`.
- Ran the config test module followed by the previously failing KnowledgeFS test.
- Ran Ruff check and format validation for the changed Python file.
- Ran `git diff --check`.

## Checklist

- [x] This change does not require a documentation update.
- [x] The associated issue exists and is assigned.
- [x] The change is atomic and existing test collection covers the removed duplicate invocation.
- [x] Relevant configuration and regression validation completed.

From OpenAI agent