### PR TITLE
fix: try streamable-http first and catch httpx timeouts in MCP client fallback (#39301)

### DIFF
--- a/api/core/mcp/mcp_client.py
+++ b/api/core/mcp/mcp_client.py
@@ -6,6 +6,7 @@ from types import TracebackType
 from typing import Any
 from urllib.parse import urlparse
 
+import httpx
 from flask import has_request_context, request
 
 from core.mcp.client.sse_client import sse_client
@@ -71,12 +72,17 @@ class MCPClient:
             client_factory = connection_methods[method_name]
             self.connect_server(client_factory, method_name)
         else:
+            # Try streamable-http first — it is the MCP default transport.
+            # SSE is the fallback for servers that only support the older transport.
+            # We try streamable-http first because a streamable-http server does not
+            # respond to the SSE GET, causing httpx.ReadTimeout (which the previous
+            # except clause did not catch, blocking for sse_read_timeout ~300s). (#39301)
             try:
-                logger.debug("Not supported method %s found in URL path, trying default 'mcp' method.", method_name)
-                self.connect_server(sse_client, "sse")
-            except (MCPConnectionError, ValueError):
-                logger.debug("MCP connection failed with 'sse', falling back to 'mcp' method.")
+                logger.debug("Not supported method %s found in URL path, trying streamable-http first.", method_name)
                 self.connect_server(streamablehttp_client, "mcp")
+            except (MCPConnectionError, ValueError, httpx.TimeoutException, httpx.ConnectError) as e:
+                logger.debug("MCP connection failed with streamable-http, falling back to 'sse' method: %s", e)
+                self.connect_server(sse_client, "sse")
 
     def connect_server(self, client_factory: Callable[..., AbstractContextManager[Any]], method_name: str) -> None:
         """

--- a/api/tests/unit_tests/core/mcp/test_mcp_client.py
+++ b/api/tests/unit_tests/core/mcp/test_mcp_client.py
@@ -158,37 +158,11 @@ class TestMCPClient:
     @patch("core.mcp.mcp_client.sse_client")
     @patch("core.mcp.mcp_client.streamablehttp_client")
     @patch("core.mcp.mcp_client.ClientSession")
-    def test_initialize_with_unknown_method_fallback_to_sse(
+    def test_initialize_with_unknown_method_fallback_to_streamable_http(
         self, mock_client_session, mock_streamable_client, mock_sse_client
     ):
-        """Test initialization with unknown method falls back to SSE."""
+        """Test initialization with unknown method tries streamable-http first."""
         # Setup mocks
-        mock_read_stream = Mock()
-        mock_write_stream = Mock()
-        mock_sse_client.return_value.__enter__.return_value = (mock_read_stream, mock_write_stream)
-
-        mock_session = Mock()
-        mock_client_session.return_value.__enter__.return_value = mock_session
-
-        client = MCPClient(server_url="http://test.example.com/unknown")
-        client._initialize()
-
-        # Verify SSE client was tried
-        mock_sse_client.assert_called_once()
-        mock_streamable_client.assert_not_called()
-
-        # Verify session was created
-        assert client._session == mock_session
-
-    @patch("core.mcp.mcp_client.sse_client")
-    @patch("core.mcp.mcp_client.streamablehttp_client")
-    @patch("core.mcp.mcp_client.ClientSession")
-    def test_initialize_fallback_from_sse_to_mcp(self, mock_client_session, mock_streamable_client, mock_sse_client):
-        """Test initialization falls back from SSE to MCP on connection error."""
-        # Setup SSE to fail
-        mock_sse_client.side_effect = MCPConnectionError("SSE connection failed")
-
-        # Setup MCP to succeed
         mock_read_stream = Mock()
         mock_write_stream = Mock()
         mock_client_context = Mock()
@@ -204,11 +178,67 @@ class TestMCPClient:
         client = MCPClient(server_url="http://test.example.com/unknown")
         client._initialize()
 
-        # Verify both were tried
-        mock_sse_client.assert_called_once()
+        # Verify streamable-http client was tried first
         mock_streamable_client.assert_called_once()
+        mock_sse_client.assert_not_called()
 
-        # Verify session was created with MCP
+        # Verify session was created
+        assert client._session == mock_session
+
+    @patch("core.mcp.mcp_client.sse_client")
+    @patch("core.mcp.mcp_client.streamablehttp_client")
+    @patch("core.mcp.mcp_client.ClientSession")
+    def test_initialize_fallback_from_streamable_http_to_sse(
+        self, mock_client_session, mock_streamable_client, mock_sse_client
+    ):
+        """Test initialization falls back from streamable-http to SSE on connection error."""
+        # Setup streamable-http to fail
+        mock_streamable_client.side_effect = MCPConnectionError("streamable-http connection failed")
+
+        # Setup SSE to succeed
+        mock_read_stream = Mock()
+        mock_write_stream = Mock()
+        mock_sse_client.return_value.__enter__.return_value = (mock_read_stream, mock_write_stream)
+
+        mock_session = Mock()
+        mock_client_session.return_value.__enter__.return_value = mock_session
+
+        client = MCPClient(server_url="http://test.example.com/unknown")
+        client._initialize()
+
+        # Verify both were tried
+        mock_streamable_client.assert_called_once()
+        mock_sse_client.assert_called_once()
+
+        # Verify session was created with SSE
+        assert client._session == mock_session
+
+    @patch("core.mcp.mcp_client.sse_client")
+    @patch("core.mcp.mcp_client.streamablehttp_client")
+    @patch("core.mcp.mcp_client.ClientSession")
+    def test_initialize_fallback_on_httpx_timeout(self, mock_client_session, mock_streamable_client, mock_sse_client):
+        """Test initialization falls back from streamable-http to SSE on httpx.ReadTimeout (#39301)."""
+        import httpx
+
+        # Setup streamable-http to fail with ReadTimeout (the bug from #39301)
+        mock_streamable_client.side_effect = httpx.ReadTimeout("timed out")
+
+        # Setup SSE to succeed
+        mock_read_stream = Mock()
+        mock_write_stream = Mock()
+        mock_sse_client.return_value.__enter__.return_value = (mock_read_stream, mock_write_stream)
+
+        mock_session = Mock()
+        mock_client_session.return_value.__enter__.return_value = mock_session
+
+        client = MCPClient(server_url="http://test.example.com/unknown")
+        client._initialize()
+
+        # Verify both were tried
+        mock_streamable_client.assert_called_once()
+        mock_sse_client.assert_called_once()
+
+        # Verify session was created with SSE
         assert client._session == mock_session
 
     @patch("core.mcp.mcp_client.streamablehttp_client")


### PR DESCRIPTION
## Problem

When an MCP server URL path's last segment isn't `mcp` or `sse` (e.g. `http://host:8089/share/v1/mcp/<share_id>`), the client tried SSE first. A streamable-http server does not respond to the SSE GET, so the connect hangs until `sse_read_timeout` (default **300s**) and raises `httpx.ReadTimeout`.

The `except (MCPConnectionError, ValueError)` clause did **not** catch `httpx.ReadTimeout` (nor `httpx.ConnectError`), so the fallback to `streamablehttp_client` never triggered. The timeout propagated and the auth call failed after a long block, with the browser giving up first (HTTP 499).

## Fix

Two changes in `api/core/mcp/mcp_client.py`:

1. **Try streamable-http first** — it is the MCP default transport. SSE is the fallback for servers that only support the older transport. This avoids the 300s hang on streamable-http servers.

2. **Catch `httpx.TimeoutException` and `httpx.ConnectError`** in the except clause so the SSE fallback actually fires on timeout/connection errors.

```diff
-            try:
-                self.connect_server(sse_client, "sse")
-            except (MCPConnectionError, ValueError):
-                self.connect_server(streamablehttp_client, "mcp")
+            try:
+                self.connect_server(streamablehttp_client, "mcp")
+            except (MCPConnectionError, ValueError, httpx.TimeoutException, httpx.ConnectError) as e:
+                self.connect_server(sse_client, "sse")
```

## Tests

Updated existing tests to reflect the new order (streamable-http first):
- `test_initialize_with_unknown_method_fallback_to_streamable_http` — verifies streamable-http is tried first
- `test_initialize_fallback_from_streamable_http_to_sse` — verifies fallback to SSE on `MCPConnectionError`
- `test_initialize_fallback_on_httpx_timeout` — new test verifying `httpx.ReadTimeout` triggers the SSE fallback (the exact bug from #39301)

Fixes #39301