### PR TITLE
fix: return 400 instead of 500 when file field is missing in audio-to-text endpoints (#39303)

### DIFF
--- a/api/controllers/console/explore/trial.py
+++ b/api/controllers/console/explore/trial.py
@@ -645,7 +645,7 @@ class TrialChatAudioApi(TrialAppResource):
     def post(self, current_user: Account, trial_app):
         app_model = trial_app
 
-        file = request.files["file"]
+        file = request.files.get("file")
 
         try:
             # Get IDs before they might be detached from session

--- a/api/controllers/service_api/app/audio.py
+++ b/api/controllers/service_api/app/audio.py
@@ -101,7 +101,7 @@ class AudioApi(Resource):
 
         Accepts an audio file upload and returns the transcribed text.
         """
-        file = request.files["file"]
+        file = request.files.get("file")
 
         try:
             response = AudioService.transcript_asr(

--- a/api/controllers/web/audio.py
+++ b/api/controllers/web/audio.py
@@ -76,7 +76,7 @@ class AudioApi(WebApiResource):
     @web_ns.response(200, "Success", web_ns.models[AudioToTextResponse.__name__])
     def post(self, app_model: App, end_user: EndUser):
         """Convert audio to text"""
-        file = request.files["file"]
+        file = request.files.get("file")
 
         try:
             response = AudioService.transcript_asr(


### PR DESCRIPTION
## Problem

Three sibling audio-to-text controllers raise `KeyError: 'file'` (HTTP 500) when a multipart POST omits the `file` field, instead of returning the existing 400 `no_audio_uploaded` error.

### Affected endpoints

| Endpoint | File | Line |
| --- | --- | --- |
| Web-app audio-to-text (public) | `api/controllers/web/audio.py` | 79 |
| Trial-app audio-to-text | `api/controllers/console/explore/trial.py` | 648 |
| Service API audio-to-text | `api/controllers/service_api/app/audio.py` | 104 |

PR #39219 already fixed one sibling (`api/controllers/console/explore/audio.py:57`). These three have the same bug and the same one-line fix.

### Current behaviour

```bash
curl -X POST $APP_URL/audio-to-text
```

Returns `500 Internal Server Error` with a stack trace pointing at `request.files["file"]`.

### Expected behaviour

Returns `400 Bad Request` with the existing `no_audio_uploaded` error payload. The service layer already supports this path: `AudioService._invoke_speech_to_text` raises `NoAudioUploadedServiceError()` when `file is None`, and each controller already has an `except NoAudioUploadedServiceError: raise NoAudioUploadedError()` handler.

## Fix

Replace `request.files["file"]` with `request.files.get("file")` in all three controllers. This matches the pattern already used in `api/controllers/console/app/audio.py:200`.

```diff
-file = request.files["file"]
+file = request.files.get("file")
```

## Backward compatibility

None. Existing callers that send a valid `file` field are unaffected. Clients that previously got a 500 for missing file will now get a 400 with the same `no_audio_uploaded` error payload the service layer was designed to emit.

Fixes #39303