### PR TITLE
fix(web): handle missing answer in workflow preview

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/readonly-input-with-select-var.tsx
+++ b/web/app/components/workflow/nodes/_base/components/readonly-input-with-select-var.tsx
@@ -1,5 +1,4 @@
 'use client'
-import type { FC } from 'react'
 import { cn } from '@langgenius/dify-ui/cn'
 import * as React from 'react'
 import { VariableLabelInText } from '@/app/components/workflow/nodes/_base/components/variable/variable-label'
@@ -9,13 +8,13 @@ import { getNodeInfoById, isSystemVar } from './variable/utils'
 
 type Props = Readonly<{
   nodeId: string
-  value: string
+  value?: string
   className?: string
 }>
 
 const VAR_PLACEHOLDER = '@#!@#!'
 
-const ReadonlyInputWithSelectVar: FC<Props> = ({ nodeId, value, className }) => {
+function ReadonlyInputWithSelectVar({ nodeId, value = '', className }: Props) {
   const { getBeforeNodesInSameBranchIncludeParent } = useWorkflow()
   const availableNodes = getBeforeNodesInSameBranchIncludeParent(nodeId)
   const startNode = availableNodes.find((node: any) => {
@@ -61,4 +60,5 @@ const ReadonlyInputWithSelectVar: FC<Props> = ({ nodeId, value, className }) => 
 
   return <div className={cn('text-xs break-all', className)}>{res}</div>
 }
+
 export default React.memo(ReadonlyInputWithSelectVar)

--- a/web/app/components/workflow/nodes/answer/__tests__/node.spec.tsx
+++ b/web/app/components/workflow/nodes/answer/__tests__/node.spec.tsx
@@ -42,6 +42,13 @@ describe('AnswerNode', () => {
       expect(screen.getByText('Plain answer')).toBeInTheDocument()
     })
 
+    it('should render an empty panel when a saved answer is missing', () => {
+      renderNodeComponent(Node, createNodeData({ answer: undefined }))
+
+      expect(screen.getByText('workflow.nodes.answer.answer')).toBeInTheDocument()
+      expect(screen.queryByText('Plain answer')).not.toBeInTheDocument()
+    })
+
     it('should render referenced variables inside the readonly content', () => {
       mockUseWorkflow.mockReturnValue({
         getBeforeNodesInSameBranchIncludeParent: () => [


### PR DESCRIPTION
## What changed

- allow the readonly workflow value renderer to accept a missing persisted value
- render a missing value as empty text at the display boundary
- cover an Answer node with a missing saved answer in the existing component suite

## Why

Older or incomplete Answer node data can omit `answer`. The workflow canvas passed that value to the readonly renderer, which called `replaceAll` unconditionally and crashed the page.

## Impact

Workflows containing affected Answer nodes now remain renderable and show an empty Answer info panel. Existing plain-text and variable-reference rendering is unchanged.

## Validation

- `pnpm exec vp test run app/components/workflow/nodes/answer/__tests__/node.spec.tsx` (3 passed)
- changed-file `vp check` (0 errors; 2 pre-existing array-index key warnings)
- `pnpm --dir web lint:tss` (5907 passed)
- `pnpm check` formatting passed, but the repository-wide check remains blocked by 3 unrelated existing `AppRouterInstance.bfcacheId` errors in router mocks outside this change
