### PR TITLE
feat: make enterprise inner API timeout configurable

### DIFF
--- a/api/configs/enterprise/__init__.py
+++ b/api/configs/enterprise/__init__.py
@@ -1,4 +1,4 @@
-from pydantic import Field
+from pydantic import Field, PositiveFloat
 from pydantic_settings import BaseSettings
 
 
@@ -17,4 +17,9 @@ class EnterpriseFeatureConfig(BaseSettings):
     CAN_REPLACE_LOGO: bool = Field(
         description="Allow customization of the enterprise logo.",
         default=False,
+    )
+
+    ENTERPRISE_API_TIMEOUT: PositiveFloat = Field(
+        description="Timeout in seconds for requests to the enterprise inner API.",
+        default=90.0,
     )

--- a/api/services/enterprise/base.py
+++ b/api/services/enterprise/base.py
@@ -4,6 +4,8 @@ from typing import Any
 
 import httpx
 
+from configs import dify_config
+
 
 class BaseRequest:
     proxies: Mapping[str, str] | None = {
@@ -39,7 +41,14 @@ class BaseRequest:
         url = f"{cls.base_url}{endpoint}"
         mounts = cls._build_mounts()
         with httpx.Client(mounts=mounts) as client:
-            response = client.request(method, url, json=json, params=params, headers=headers)
+            response = client.request(
+                method,
+                url,
+                json=json,
+                params=params,
+                headers=headers,
+                timeout=dify_config.ENTERPRISE_API_TIMEOUT,
+            )
         return response.json()
 
 


### PR DESCRIPTION
## Summary

Requests to the enterprise inner API relied on httpx's implicit 5s default — no call site passed `timeout`, and no env or config could change it.

On tenants with enough installed apps, `POST /webapp/permission/batch` exceeds that budget and `/console/api/installed-apps` fails with `httpx.ReadTimeout`, so the Explore page cannot render.

Adds `ENTERPRISE_API_TIMEOUT` (`EnterpriseFeatureConfig`, `PositiveFloat`, default `90.0`) and passes it to `client.request` in `BaseRequest.send_request`.

## Why 90s

The enterprise server enforces its own request timeout (`SERVER_TIMEOUT`, default `60s`). Defaulting the client above that means the server terminates a runaway request first and returns a clean 504, instead of the two timers racing.

Note this raises the effective budget for **all** enterprise inner-API calls, not just the batch permission one — a stalled enterprise pod now holds a gunicorn worker longer than it used to.


Ref: CUS-1422