### PR TITLE
fix: make enterprise inner API timeout configurable

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -72,7 +72,9 @@ RUN \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g npm@latest
+# Pinned to the 11.x line: npm@latest floats, and 12.x requires node >=22.22.2,
+# which the pinned NODE_PACKAGE_VERSION above does not satisfy.
+RUN npm install -g npm@11
 
 RUN groupadd -r -g ${dify_uid} dify && \
     useradd -r -u ${dify_uid} -g ${dify_uid} -s /bin/bash dify && \

--- a/api/configs/enterprise/__init__.py
+++ b/api/configs/enterprise/__init__.py
@@ -1,4 +1,4 @@
-from pydantic import Field, PositiveFloat
+from pydantic import Field
 from pydantic_settings import BaseSettings
 
 
@@ -19,7 +19,6 @@ class EnterpriseFeatureConfig(BaseSettings):
         default=False,
     )
 
-    ENTERPRISE_API_TIMEOUT: PositiveFloat = Field(
-        description="Timeout in seconds for requests to the enterprise inner API.",
-        default=90.0,
+    ENTERPRISE_REQUEST_TIMEOUT: int = Field(
+        ge=1, description="Maximum timeout in seconds for enterprise requests", default=90
     )

--- a/api/configs/enterprise/__init__.py
+++ b/api/configs/enterprise/__init__.py
@@ -1,4 +1,4 @@
-from pydantic import Field
+from pydantic import Field, PositiveFloat
 from pydantic_settings import BaseSettings
 
 
@@ -17,4 +17,9 @@ class EnterpriseFeatureConfig(BaseSettings):
     CAN_REPLACE_LOGO: bool = Field(
         description="Allow customization of the enterprise logo.",
         default=False,
+    )
+
+    ENTERPRISE_API_TIMEOUT: PositiveFloat = Field(
+        description="Timeout in seconds for requests to the enterprise inner API.",
+        default=90.0,
     )

--- a/api/services/enterprise/base.py
+++ b/api/services/enterprise/base.py
@@ -4,6 +4,8 @@ from typing import Any
 
 import httpx
 
+from configs import dify_config
+
 
 class BaseRequest:
     proxies: Mapping[str, str] | None = {
@@ -39,7 +41,14 @@ class BaseRequest:
         url = f"{cls.base_url}{endpoint}"
         mounts = cls._build_mounts()
         with httpx.Client(mounts=mounts) as client:
-            response = client.request(method, url, json=json, params=params, headers=headers)
+            response = client.request(
+                method,
+                url,
+                json=json,
+                params=params,
+                headers=headers,
+                timeout=dify_config.ENTERPRISE_API_TIMEOUT,
+            )
         return response.json()
 
 

--- a/api/services/enterprise/base.py
+++ b/api/services/enterprise/base.py
@@ -47,7 +47,7 @@ class BaseRequest:
                 json=json,
                 params=params,
                 headers=headers,
-                timeout=dify_config.ENTERPRISE_API_TIMEOUT,
+                timeout=dify_config.ENTERPRISE_REQUEST_TIMEOUT,
             )
         return response.json()
 


### PR DESCRIPTION
Replaces #39334, whose branch sat under `hotfix/**` and could not be updated (the `hotfix` ruleset requires changes go through a PR).

## Problem

Requests to the enterprise inner API relied on httpx's implicit 5s default. No call site passed `timeout`, and no env or config could change it.

On tenants with enough installed apps, `POST /webapp/permission/batch` exceeds that budget and `/console/api/installed-apps` fails with `httpx.ReadTimeout`, so the Explore page cannot render.

## Change

Adds `ENTERPRISE_REQUEST_TIMEOUT` to `EnterpriseFeatureConfig` and passes it to `client.request` in `BaseRequest.send_request`.

The name and `int` type deliberately match what already exists on `main` (added in #33158, which is not an ancestor of this branch). Using a different name here would leave two env vars controlling one behavior after this branch merges forward, silently orphaning any deployment configured on the other name.

Default is `90` on this branch. The enterprise server enforces its own `SERVER_TIMEOUT` (default `60s`), so a client budget above that lets the server terminate a runaway request first and return a clean 504 instead of the two timers racing.

Note this raises the effective budget for **all** enterprise inner-API calls on this branch, not just the batch permission one — a stalled enterprise pod holds a gunicorn worker longer than it used to.

## Also included: unrelated CI fix

`api/Dockerfile` ran `npm install -g npm@latest` against a pinned `NODE_PACKAGE_VERSION=22.22.0`. npm 12 requires node `^22.22.2 || ^24.15.0 || >=26.0.0`, so the install now fails with `EBADENGINE` and the API image cannot build:

```
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.9.4","node":"v22.22.0"}
```

This is a pre-existing float, not a regression from this change — the step passed on 2026-03-15 and broke when npm 12 raised its node floor. Pinned to `npm@11` (engine `>=22.9.0`) so the build stops tracking npm's release schedule. Happy to split this into its own PR if preferred; it is bundled only because this PR cannot go green without it.

## Scope

Mitigation, not a root-cause fix. It makes the Explore page slow rather than broken, and only when the request completes inside the window — the enterprise-side 60s cap still applies.

The underlying cause is a per-app N+1 in the enterprise `permission/batch` handler: it loops `IsUserAllowedToAccessWebAppByAppID` per app id, ~6 queries each, two of them against tables with no indexes. Fixed enterprise-side and tracked separately.

Main-branch equivalent: #39335.

Ref: CUS-1422