### PR TITLE
fix: configure MonacoEnvironment.getWorkerUrl to prevent worker 404 fallback

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/editor/code-editor/index.tsx
+++ b/web/app/components/workflow/nodes/_base/components/editor/code-editor/index.tsx
@@ -20,7 +20,7 @@ if (typeof window !== 'undefined') {
   // Configure worker URL to prevent the worker label from being appended as a URL fragment.
   // Without this, Monaco generates URLs like workerMain.js#editorWorkerService, which browsers
   // encode to %23, causing a 404 and forcing the worker to fall back to the main thread.
-  self.MonacoEnvironment = {
+  ;(self as any).MonacoEnvironment = {
     getWorkerUrl: () => `${window.location.origin}${basePath}/vs/base/worker/workerMain.js`,
   }
 }

--- a/web/app/components/workflow/nodes/_base/components/editor/code-editor/index.tsx
+++ b/web/app/components/workflow/nodes/_base/components/editor/code-editor/index.tsx
@@ -14,8 +14,16 @@ import Base from '../base'
 import './style.css'
 
 // load file from local instead of cdn https://github.com/suren-atoyan/monaco-react/issues/482
-if (typeof window !== 'undefined')
+if (typeof window !== 'undefined') {
   loader.config({ paths: { vs: `${window.location.origin}${basePath}/vs` } })
+
+  // Configure worker URL to prevent the worker label from being appended as a URL fragment.
+  // Without this, Monaco generates URLs like workerMain.js#editorWorkerService, which browsers
+  // encode to %23, causing a 404 and forcing the worker to fall back to the main thread.
+  self.MonacoEnvironment = {
+    getWorkerUrl: () => `${window.location.origin}${basePath}/vs/base/worker/workerMain.js`,
+  }
+}
 
 const CODE_EDITOR_LINE_HEIGHT = 18
 

--- a/web/app/components/workflow/nodes/_base/components/editor/code-editor/index.tsx
+++ b/web/app/components/workflow/nodes/_base/components/editor/code-editor/index.tsx
@@ -20,7 +20,7 @@ if (typeof window !== 'undefined') {
   // Configure worker URL to prevent the worker label from being appended as a URL fragment.
   // Without this, Monaco generates URLs like workerMain.js#editorWorkerService, which browsers
   // encode to %23, causing a 404 and forcing the worker to fall back to the main thread.
-  ;(self as any).MonacoEnvironment = {
+  window.MonacoEnvironment = {
     getWorkerUrl: () => `${window.location.origin}${basePath}/vs/base/worker/workerMain.js`,
   }
 }

--- a/web/global.d.ts
+++ b/web/global.d.ts
@@ -20,5 +20,9 @@ declare global {
   interface Window {
     gtag?: Gtag
     dataLayer?: unknown[]
+    MonacoEnvironment?: {
+      getWorkerUrl?: (workerId: string, label: string) => string
+      getWorker?: (workerId: string, label: string) => Worker
+    }
   }
 }


### PR DESCRIPTION
## Problem

Fixes #39340

Monaco Editor's Web Worker always fails to load because `MonacoEnvironment.getWorkerUrl` is not configured. Without it, Monaco appends the worker label as a URL fragment (`workerMain.js#editorWorkerService`), which browsers encode to `%23`, causing a 404. The worker falls back to the main thread every time.

## Solution

Add `self.MonacoEnvironment.getWorkerUrl` configuration that returns the worker URL without the `#label` fragment. The worker name is preserved via the `name` parameter of `new Worker()`.

## Changes

File: `web/app/components/workflow/nodes/_base/components/editor/code-editor/index.tsx`

Before:
```typescript
if (typeof window !== 'undefined')
  loader.config({ paths: { vs: `${window.location.origin}${basePath}/vs` } })
```

After:
```typescript
if (typeof window !== 'undefined') {
  loader.config({ paths: { vs: `${window.location.origin}${basePath}/vs` } })

  // Configure worker URL to prevent the worker label from being appended as a URL fragment.
  // Without this, Monaco generates URLs like workerMain.js#editorWorkerService, which browsers
  // encode to %23, causing a 404 and forcing the worker to fall back to the main thread.
  self.MonacoEnvironment = {
    getWorkerUrl: () => `${window.location.origin}${basePath}/vs/base/worker/workerMain.js`,
  }
}
```

## Testing

- [x] Verified `workerMain.js` loads successfully (304, 2ms) without `%23` encoding
- [x] Verified worker types: `editorWorkerService` and `json` both affected
- [x] No breaking changes - `getWorkerUrl` is the standard Monaco Editor configuration

## Impact

- Eliminates unnecessary 404 responses (~350KB each, 100-700ms latency)
- Worker runs in a dedicated thread instead of main thread
- Reduces server load from SSR-rendered 404 pages
