### PR TITLE
fix(api): prefer streamable transport for unknown MCP paths

### DIFF
--- a/api/core/mcp/mcp_client.py
+++ b/api/core/mcp/mcp_client.py
@@ -10,7 +10,7 @@ from flask import has_request_context, request
 
 from core.mcp.client.sse_client import sse_client
 from core.mcp.client.streamable_client import streamablehttp_client
-from core.mcp.error import MCPConnectionError
+from core.mcp.error import MCPAuthError
 from core.mcp.session.client_session import ClientSession
 from core.mcp.types import CallToolResult, Tool
 
@@ -73,10 +73,12 @@ class MCPClient:
         else:
             try:
                 logger.debug("Not supported method %s found in URL path, trying default 'mcp' method.", method_name)
-                self.connect_server(sse_client, "sse")
-            except (MCPConnectionError, ValueError):
-                logger.debug("MCP connection failed with 'sse', falling back to 'mcp' method.")
                 self.connect_server(streamablehttp_client, "mcp")
+            except MCPAuthError:
+                raise
+            except Exception:
+                logger.debug("MCP connection failed with 'mcp', falling back to 'sse' method.", exc_info=True)
+                self.connect_server(sse_client, "sse")
 
     def connect_server(self, client_factory: Callable[..., AbstractContextManager[Any]], method_name: str) -> None:
         """

--- a/api/tests/unit_tests/core/mcp/test_mcp_client.py
+++ b/api/tests/unit_tests/core/mcp/test_mcp_client.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from core.entities.mcp_provider import MCPProviderEntity
 from core.mcp.auth_client import MCPClientWithAuthRetry
-from core.mcp.error import MCPAuthError, MCPConnectionError
+from core.mcp.error import MCPAuthError
 from core.mcp.mcp_client import MCPClient
 from core.mcp.types import CallToolResult, ListToolsResult, OAuthTokens, TextContent, Tool, ToolAnnotations
 
@@ -158,37 +158,10 @@ class TestMCPClient:
     @patch("core.mcp.mcp_client.sse_client")
     @patch("core.mcp.mcp_client.streamablehttp_client")
     @patch("core.mcp.mcp_client.ClientSession")
-    def test_initialize_with_unknown_method_fallback_to_sse(
+    def test_initialize_with_unknown_method_defaults_to_mcp(
         self, mock_client_session, mock_streamable_client, mock_sse_client
     ):
-        """Test initialization with unknown method falls back to SSE."""
-        # Setup mocks
-        mock_read_stream = Mock()
-        mock_write_stream = Mock()
-        mock_sse_client.return_value.__enter__.return_value = (mock_read_stream, mock_write_stream)
-
-        mock_session = Mock()
-        mock_client_session.return_value.__enter__.return_value = mock_session
-
-        client = MCPClient(server_url="http://test.example.com/unknown")
-        client._initialize()
-
-        # Verify SSE client was tried
-        mock_sse_client.assert_called_once()
-        mock_streamable_client.assert_not_called()
-
-        # Verify session was created
-        assert client._session == mock_session
-
-    @patch("core.mcp.mcp_client.sse_client")
-    @patch("core.mcp.mcp_client.streamablehttp_client")
-    @patch("core.mcp.mcp_client.ClientSession")
-    def test_initialize_fallback_from_sse_to_mcp(self, mock_client_session, mock_streamable_client, mock_sse_client):
-        """Test initialization falls back from SSE to MCP on connection error."""
-        # Setup SSE to fail
-        mock_sse_client.side_effect = MCPConnectionError("SSE connection failed")
-
-        # Setup MCP to succeed
+        """Test initialization with unknown method defaults to streamable HTTP."""
         mock_read_stream = Mock()
         mock_write_stream = Mock()
         mock_client_context = Mock()
@@ -204,12 +177,46 @@ class TestMCPClient:
         client = MCPClient(server_url="http://test.example.com/unknown")
         client._initialize()
 
-        # Verify both were tried
-        mock_sse_client.assert_called_once()
         mock_streamable_client.assert_called_once()
+        mock_sse_client.assert_not_called()
 
-        # Verify session was created with MCP
         assert client._session == mock_session
+
+    @patch("core.mcp.mcp_client.sse_client")
+    @patch("core.mcp.mcp_client.streamablehttp_client")
+    @patch("core.mcp.mcp_client.ClientSession")
+    def test_initialize_fallback_from_mcp_to_sse(self, mock_client_session, mock_streamable_client, mock_sse_client):
+        """Test initialization falls back from streamable HTTP to SSE on connection error."""
+        mock_streamable_client.side_effect = TimeoutError("MCP connection timed out")
+
+        mock_read_stream = Mock()
+        mock_write_stream = Mock()
+        mock_sse_client.return_value.__enter__.return_value = (mock_read_stream, mock_write_stream)
+
+        mock_session = Mock()
+        mock_client_session.return_value.__enter__.return_value = mock_session
+
+        client = MCPClient(server_url="http://test.example.com/unknown")
+        client._initialize()
+
+        mock_streamable_client.assert_called_once()
+        mock_sse_client.assert_called_once()
+
+        assert client._session == mock_session
+
+    @patch("core.mcp.mcp_client.sse_client")
+    @patch("core.mcp.mcp_client.streamablehttp_client")
+    def test_initialize_unknown_method_reraises_mcp_auth_error(self, mock_streamable_client, mock_sse_client):
+        """Test authentication failures are not retried with a different transport."""
+        mock_streamable_client.side_effect = MCPAuthError("unauthorized")
+
+        client = MCPClient(server_url="http://test.example.com/unknown")
+
+        with pytest.raises(MCPAuthError, match="unauthorized"):
+            client._initialize()
+
+        mock_streamable_client.assert_called_once()
+        mock_sse_client.assert_not_called()
 
     @patch("core.mcp.mcp_client.streamablehttp_client")
     @patch("core.mcp.mcp_client.ClientSession")


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Default unknown MCP endpoint paths to the streamable-http transport, matching the existing `_initialize` docstring.
- Fall back to SSE only when streamable-http connection setup fails.
- Preserve `MCPAuthError` propagation so auth failures are not retried as another transport.
- Fixes #39301

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Testing

- `api/.venv/bin/python -m py_compile api/core/mcp/mcp_client.py api/tests/unit_tests/core/mcp/test_mcp_client.py`
- Stubbed module-level fallback check covering default streamable-http, fallback to SSE, and auth-error propagation.
- Attempted `uv run --project api pytest api/tests/unit_tests/core/mcp/test_mcp_client.py -q`, but dependency sync could not complete because the pinned `flask-restx` git dependency timed out fetching from GitHub in this environment.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Codex
