### PR TITLE
fix(dev): use gevent WebSocket server for local API

### DIFF
--- a/dev/start-api
+++ b/dev/start-api
@@ -8,4 +8,4 @@ cd "$SCRIPT_DIR/../api"
 uv run flask db upgrade
 
 uv run \
-  flask run --host 0.0.0.0 --port=5001 --debug
+  dotenv -f .env run --no-override -- python -m app


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Update the local API startup command to run Dify through `python -m app` instead of Flask's development server.
The default collboration mode is enabled, only flask server not work.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
