### PR TITLE
fix(workflow): avoid false draft save error during Strict Mode initia…

### DIFF
--- a/web/app/components/workflow-app/components/workflow-main.tsx
+++ b/web/app/components/workflow-app/components/workflow-main.tsx
@@ -421,6 +421,7 @@ const WorkflowMain = ({ nodes, edges, viewport }: WorkflowMainProps) => {
         viewport={viewport}
         onWorkflowDataUpdate={handleWorkflowDataUpdate}
         hooksStore={hooksStore as unknown as Partial<HooksStoreShape>}
+        isCollaborationEnabled={isCollaborationEnabled}
         cursors={filteredCursors}
         myUserId={myUserId}
         onlineUsers={onlineUsers}

--- a/web/app/components/workflow/__tests__/workflow-edge-events.spec.tsx
+++ b/web/app/components/workflow/__tests__/workflow-edge-events.spec.tsx
@@ -25,6 +25,7 @@ const reactFlowBridge = vi.hoisted(() => ({
 }))
 
 const collaborationBridge = vi.hoisted(() => ({
+  canPersistLocalGraph: vi.fn(),
   graphImportHandler: null as null | ((payload: { nodes: Node[]; edges: Edge[] }) => void),
   historyActionHandler: null as null | ((payload: unknown) => void),
   restoreIntentHandler: null as
@@ -196,6 +197,7 @@ vi.mock('@langgenius/dify-ui/toast', () => ({
 
 vi.mock('../collaboration/core/collaboration-manager', () => ({
   collaborationManager: {
+    canPersistLocalGraph: collaborationBridge.canPersistLocalGraph,
     onGraphImport: (handler: (payload: { nodes: Node[]; edges: Edge[] }) => void) => {
       collaborationBridge.graphImportHandler = handler
       return vi.fn()
@@ -453,12 +455,18 @@ function renderSubject(options?: {
   nodes?: Node[]
   edges?: Edge[]
   initialStoreState?: Record<string, unknown>
+  isCollaborationEnabled?: boolean
 }) {
-  const { nodes = baseNodes, edges = baseEdges, initialStoreState } = options ?? {}
+  const {
+    nodes = baseNodes,
+    edges = baseEdges,
+    initialStoreState,
+    isCollaborationEnabled,
+  } = options ?? {}
 
   return renderWorkflowComponent(
     <ReactFlowProvider>
-      <Workflow nodes={nodes} edges={edges}>
+      <Workflow nodes={nodes} edges={edges} isCollaborationEnabled={isCollaborationEnabled}>
         <ReactFlowEdgeBootstrap nodes={nodes} edges={edges} />
       </Workflow>
     </ReactFlowProvider>,
@@ -514,6 +522,7 @@ vi.mock('@/context/permission-state', async () => {
 describe('Workflow edge event wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    collaborationBridge.canPersistLocalGraph.mockReturnValue(true)
     eventEmitterState.subscription = null
     reactFlowBridge.store = null
     collaborationBridge.graphImportHandler = null
@@ -615,13 +624,24 @@ describe('Workflow edge event wiring', () => {
       },
     )
 
-    const { unmount } = renderSubject()
+    const { unmount } = renderSubject({ isCollaborationEnabled: true })
 
     unmount()
 
     expect(toastErrorMock).toHaveBeenCalledWith('workflow.common.draftSaveFailed', {
       timeout: 0,
     })
+  })
+
+  it('should skip the unmount save while the collaborative graph is not ready', () => {
+    collaborationBridge.canPersistLocalGraph.mockReturnValue(false)
+
+    const { unmount } = renderSubject({ isCollaborationEnabled: true })
+
+    unmount()
+
+    expect(workflowHookMocks.handleSyncWorkflowDraft).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
   })
 
   it('should render confirm description and clear showConfirm when cancelled', async () => {

--- a/web/app/components/workflow/index.tsx
+++ b/web/app/components/workflow/index.tsx
@@ -125,6 +125,7 @@ export type WorkflowProps = {
   viewport?: Viewport
   children?: React.ReactNode
   onWorkflowDataUpdate?: (v: WorkflowDataUpdatePayload) => void
+  isCollaborationEnabled?: boolean
   cursors?: Record<string, CursorPosition>
   myUserId?: string | null
   onlineUsers?: OnlineUser[]
@@ -168,6 +169,7 @@ export const Workflow: FC<WorkflowProps> = memo(
     viewport,
     children,
     onWorkflowDataUpdate,
+    isCollaborationEnabled = false,
     cursors,
     myUserId,
     onlineUsers,
@@ -364,6 +366,8 @@ export const Workflow: FC<WorkflowProps> = memo(
 
     useEffect(() => {
       return () => {
+        if (isCollaborationEnabled && !collaborationManager.canPersistLocalGraph()) return
+
         handleSyncWorkflowDraft(true, true, {
           onError: () => {
             toast.error(
@@ -375,7 +379,7 @@ export const Workflow: FC<WorkflowProps> = memo(
           },
         })
       }
-    }, [handleSyncWorkflowDraft, t])
+    }, [handleSyncWorkflowDraft, isCollaborationEnabled, t])
 
     const handlePendingCommentPositionChange = useCallback(
       (position: NonNullable<WorkflowSliceShape['pendingComment']>) => {


### PR DESCRIPTION
…lization

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix https://github.com/langgenius/dify/issues/39352

## Root Cause
React Strict Mode re-runs effect setup and cleanup during the initial mount in development only.

The Workflow cleanup triggers a draft save. At that moment, collaboration hydration has not completed and the CRDT graph is not trusted, so canPersistLocalGraph() returns false. The save is skipped without sending a backend request, but the skipped save still invokes the error callback and is incorrectly displayed as a real draft save failure.

Production builds do not perform this synthetic cleanup during initial mount. However, the same false error could still occur if a user genuinely leaves the workflow before collaboration initialization completes.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
