### PR TITLE
fix(web): tolerate legacy workflow variable data

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/variable/__tests__/legacy-data.spec.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/__tests__/legacy-data.spec.ts
@@ -1,0 +1,67 @@
+import type { HttpNodeType } from '@/app/components/workflow/nodes/http/types'
+import type { IterationNodeType } from '@/app/components/workflow/nodes/iteration/types'
+import type { Node } from '@/app/components/workflow/types'
+import { describe, expect, it } from 'vitest'
+import {
+  AuthorizationType,
+  BodyType,
+  Method,
+} from '@/app/components/workflow/nodes/http/types'
+import { BlockEnum, VarType } from '@/app/components/workflow/types'
+import { getNodeUsedVars } from '../utils'
+
+const createNode = <T>(data: Node<T>['data']): Node<T> => ({
+  id: 'node-1',
+  type: 'custom',
+  position: { x: 0, y: 0 },
+  data,
+})
+
+describe('legacy workflow variable data', () => {
+  it('tolerates HTTP request nodes with missing body data', () => {
+    const node = createNode<HttpNodeType>({
+      type: BlockEnum.HttpRequest,
+      title: 'HTTP Request',
+      desc: '',
+      variables: [],
+      method: Method.post,
+      url: 'https://{{#start.host#}}/items',
+      authorization: { type: AuthorizationType.none },
+      headers: 'Authorization: Bearer {{#env.API_KEY#}}',
+      params: '',
+      body: {
+        type: BodyType.json,
+        data: undefined as unknown as HttpNodeType['body']['data'],
+      },
+      timeout: {},
+      ssl_verify: true,
+    })
+
+    expect(getNodeUsedVars(node)).toEqual(
+      expect.arrayContaining([
+        ['start', 'host'],
+        ['env', 'API_KEY'],
+      ]),
+    )
+  })
+
+  it('ignores iteration nodes without a selected iterator', () => {
+    const node = createNode<IterationNodeType>({
+      type: BlockEnum.Iteration,
+      title: 'Iteration',
+      desc: '',
+      start_node_id: '',
+      iterator_selector: undefined as unknown as IterationNodeType['iterator_selector'],
+      iterator_input_type: VarType.arrayString,
+      output_selector: [],
+      output_type: VarType.arrayString,
+      is_parallel: false,
+      parallel_nums: 10,
+      error_handle_mode: undefined as unknown as IterationNodeType['error_handle_mode'],
+      flatten_output: true,
+      _isShowTips: false,
+    })
+
+    expect(getNodeUsedVars(node)).toEqual([])
+  })
+})

--- a/web/app/components/workflow/nodes/_base/components/variable/__tests__/legacy-data.spec.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/__tests__/legacy-data.spec.ts
@@ -2,11 +2,7 @@ import type { HttpNodeType } from '@/app/components/workflow/nodes/http/types'
 import type { IterationNodeType } from '@/app/components/workflow/nodes/iteration/types'
 import type { Node } from '@/app/components/workflow/types'
 import { describe, expect, it } from 'vitest'
-import {
-  AuthorizationType,
-  BodyType,
-  Method,
-} from '@/app/components/workflow/nodes/http/types'
+import { AuthorizationType, BodyType, Method } from '@/app/components/workflow/nodes/http/types'
 import { BlockEnum, VarType } from '@/app/components/workflow/types'
 import { getNodeUsedVars } from '../utils'
 

--- a/web/app/components/workflow/nodes/_base/components/variable/__tests__/utils.spec.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/__tests__/utils.spec.ts
@@ -1,9 +1,17 @@
 import type { AgentV2NodeType } from '@/app/components/workflow/nodes/agent-v2/types'
 import type { AnswerNodeType } from '@/app/components/workflow/nodes/answer/types'
+import type { HttpNodeType } from '@/app/components/workflow/nodes/http/types'
 import type { HumanInputNodeType } from '@/app/components/workflow/nodes/human-input/types'
+import type { IterationNodeType } from '@/app/components/workflow/nodes/iteration/types'
 import type { LLMNodeType } from '@/app/components/workflow/nodes/llm/types'
 import type { Node, PromptItem } from '@/app/components/workflow/types'
 import { describe, expect, it } from 'vitest'
+import {
+  AuthorizationType,
+  BodyPayloadValueType,
+  BodyType,
+  Method,
+} from '@/app/components/workflow/nodes/http/types'
 import { DeliveryMethodType } from '@/app/components/workflow/nodes/human-input/types'
 import {
   BlockEnum,
@@ -211,6 +219,53 @@ describe('variable utils', () => {
 
       expect(getNodeUsedVars(node)).toContainEqual(['start', 'tender'])
     })
+
+    it('should tolerate legacy http request nodes with missing body data', () => {
+      const node = createNode<HttpNodeType>({
+        type: BlockEnum.HttpRequest,
+        title: 'HTTP Request',
+        desc: '',
+        variables: [],
+        method: Method.post,
+        url: 'https://{{#start.host#}}/items',
+        authorization: { type: AuthorizationType.none },
+        headers: 'Authorization: Bearer {{#env.API_KEY#}}',
+        params: '',
+        body: {
+          type: BodyType.json,
+          data: undefined as unknown as HttpNodeType['body']['data'],
+        },
+        timeout: {},
+        ssl_verify: true,
+      })
+
+      expect(getNodeUsedVars(node)).toEqual(
+        expect.arrayContaining([
+          ['start', 'host'],
+          ['env', 'API_KEY'],
+        ]),
+      )
+    })
+
+    it('should ignore iteration nodes without a selected iterator', () => {
+      const node = createNode<IterationNodeType>({
+        type: BlockEnum.Iteration,
+        title: 'Iteration',
+        desc: '',
+        start_node_id: '',
+        iterator_selector: undefined as unknown as IterationNodeType['iterator_selector'],
+        iterator_input_type: VarType.arrayString,
+        output_selector: [],
+        output_type: VarType.arrayString,
+        is_parallel: false,
+        parallel_nums: 10,
+        error_handle_mode: undefined as unknown as IterationNodeType['error_handle_mode'],
+        flatten_output: true,
+        _isShowTips: false,
+      })
+
+      expect(getNodeUsedVars(node)).toEqual([])
+    })
   })
 
   describe('updateNodeVars', () => {
@@ -322,6 +377,70 @@ describe('variable utils', () => {
           selector: ['env', 'RENAMED_KEY'],
         },
       })
+    })
+
+    it('should replace http request references and tolerate missing body data', () => {
+      const node = createNode<HttpNodeType>({
+        type: BlockEnum.HttpRequest,
+        title: 'HTTP Request',
+        desc: '',
+        variables: [],
+        method: Method.post,
+        url: 'https://{{#env.API_HOST#}}/items',
+        authorization: { type: AuthorizationType.none },
+        headers: 'Authorization: Bearer {{#env.API_KEY#}}',
+        params: 'page={{#env.PAGE#}}',
+        body: {
+          type: BodyType.formData,
+          data: [
+            {
+              type: BodyPayloadValueType.text,
+              value: '{{#env.API_KEY#}}',
+            },
+            {
+              type: BodyPayloadValueType.file,
+              file: ['env', 'UPLOAD'],
+            },
+          ],
+        },
+        timeout: {},
+        ssl_verify: true,
+      })
+
+      const updatedNode = updateNodeVars(node, ['env', 'API_KEY'], ['env', 'RENAMED_KEY'])
+
+      expect((updatedNode.data as HttpNodeType).url).toBe('https://{{#env.API_HOST#}}/items')
+      expect((updatedNode.data as HttpNodeType).headers).toBe(
+        'Authorization: Bearer {{#env.RENAMED_KEY#}}',
+      )
+      expect((updatedNode.data as HttpNodeType).params).toBe('page={{#env.PAGE#}}')
+      expect((updatedNode.data as HttpNodeType).body.data).toMatchObject([
+        { value: '{{#env.RENAMED_KEY#}}' },
+        { file: ['env', 'UPLOAD'] },
+      ])
+
+      const updatedFileNode = updateNodeVars(node, ['env', 'UPLOAD'], ['env', 'RENAMED_UPLOAD'])
+      expect((updatedFileNode.data as HttpNodeType).body.data).toMatchObject([
+        { value: '{{#env.API_KEY#}}' },
+        { file: ['env', 'RENAMED_UPLOAD'] },
+      ])
+
+      const nodeWithoutBody = createNode<HttpNodeType>({
+        ...node.data,
+        body: undefined as unknown as HttpNodeType['body'],
+      })
+
+      let updatedNodeWithoutBody: Node
+      expect(() => {
+        updatedNodeWithoutBody = updateNodeVars(
+          nodeWithoutBody,
+          ['env', 'API_HOST'],
+          ['env', 'RENAMED_HOST'],
+        )
+      }).not.toThrow()
+      expect((updatedNodeWithoutBody!.data as HttpNodeType).url).toBe(
+        'https://{{#env.RENAMED_HOST#}}/items',
+      )
     })
   })
 })

--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -3,7 +3,7 @@ import type { AnswerNodeType } from '../../../answer/types'
 import type { CodeNodeType } from '../../../code/types'
 import type { DocExtractorNodeType } from '../../../document-extractor/types'
 import type { EndNodeType } from '../../../end/types'
-import type { HttpNodeType } from '../../../http/types'
+import type { BodyPayload, HttpNodeType } from '../../../http/types'
 import type { IfElseNodeType } from '../../../if-else/types'
 import type { IterationNodeType } from '../../../iteration/types'
 import type { KnowledgeRetrievalNodeType } from '../../../knowledge-retrieval/types'
@@ -1201,6 +1201,18 @@ const matchNotSystemVars = (prompts: string[]) => {
   return uniqVars
 }
 
+const getHttpBodyUsedVars = (payload: HttpNodeType): ValueSelector[] => {
+  const bodyData = payload.body?.data
+  if (typeof bodyData === 'string') return matchNotSystemVars([bodyData])
+  if (!Array.isArray(bodyData)) return []
+
+  const bodyTextVars = matchNotSystemVars(bodyData.map((item) => item.value || ''))
+  const bodyFileVars = bodyData.flatMap((item) =>
+    Array.isArray(item.file) && item.file.length > 0 ? [item.file] : [],
+  )
+  return [...bodyTextVars, ...bodyFileVars]
+}
+
 const replaceOldVarInText = (text: string, oldVar: ValueSelector, newVar: ValueSelector) => {
   if (!text || typeof text !== 'string') return text
 
@@ -1312,14 +1324,8 @@ export const getNodeUsedVars = (node: Node): ValueSelector[] => {
     }
     case BlockEnum.HttpRequest: {
       const payload = data as HttpNodeType
-      res = matchNotSystemVars([
-        payload.url,
-        payload.headers,
-        payload.params,
-        typeof payload.body.data === 'string'
-          ? payload.body.data
-          : payload.body.data.map((d) => d.value).join(''),
-      ])
+      res = matchNotSystemVars([payload.url, payload.headers, payload.params])
+      res.push(...getHttpBodyUsedVars(payload))
       break
     }
     case BlockEnum.Tool: {
@@ -1393,7 +1399,8 @@ export const getNodeUsedVars = (node: Node): ValueSelector[] => {
     }
 
     case BlockEnum.Iteration: {
-      res = [(data as IterationNodeType).iterator_selector]
+      const selector = (data as IterationNodeType).iterator_selector
+      res = Array.isArray(selector) && selector.length > 0 ? [selector] : []
       break
     }
 
@@ -1429,7 +1436,9 @@ export const getNodeUsedVars = (node: Node): ValueSelector[] => {
       break
     }
   }
-  return res || []
+  return (res || []).filter(
+    (selector): selector is ValueSelector => Array.isArray(selector) && selector.length > 0,
+  )
 }
 
 // can be used in iteration node
@@ -1674,13 +1683,18 @@ export const updateNodeVars = (
         payload.url = replaceOldVarInText(payload.url, oldVarSelector, newVarSelector)
         payload.headers = replaceOldVarInText(payload.headers, oldVarSelector, newVarSelector)
         payload.params = replaceOldVarInText(payload.params, oldVarSelector, newVarSelector)
+        if (!payload.body) break
         if (typeof payload.body.data === 'string') {
           payload.body.data = replaceOldVarInText(payload.body.data, oldVarSelector, newVarSelector)
-        } else {
-          payload.body.data = payload.body.data.map((d) => {
+        } else if (Array.isArray(payload.body.data)) {
+          payload.body.data = (payload.body.data as BodyPayload).map((d) => {
             return {
               ...d,
               value: replaceOldVarInText(d.value || '', oldVarSelector, newVarSelector),
+              file:
+                Array.isArray(d.file) && d.file.join('.') === oldVarSelector.join('.')
+                  ? newVarSelector
+                  : d.file,
             }
           })
         }

--- a/web/app/components/workflow/nodes/_base/components/variable/utils.ts
+++ b/web/app/components/workflow/nodes/_base/components/variable/utils.ts
@@ -3,7 +3,7 @@ import type { AnswerNodeType } from '../../../answer/types'
 import type { CodeNodeType } from '../../../code/types'
 import type { DocExtractorNodeType } from '../../../document-extractor/types'
 import type { EndNodeType } from '../../../end/types'
-import type { HttpNodeType } from '../../../http/types'
+import type { BodyPayload, HttpNodeType } from '../../../http/types'
 import type { IfElseNodeType } from '../../../if-else/types'
 import type { IterationNodeType } from '../../../iteration/types'
 import type { KnowledgeRetrievalNodeType } from '../../../knowledge-retrieval/types'
@@ -1203,6 +1203,18 @@ const matchNotSystemVars = (prompts: string[]) => {
   return uniqVars
 }
 
+const getHttpBodyUsedVars = (payload: HttpNodeType): ValueSelector[] => {
+  const bodyData = payload.body?.data
+  if (typeof bodyData === 'string') return matchNotSystemVars([bodyData])
+  if (!Array.isArray(bodyData)) return []
+
+  const bodyTextVars = matchNotSystemVars(bodyData.map((item) => item.value || ''))
+  const bodyFileVars = bodyData.flatMap((item) =>
+    Array.isArray(item.file) && item.file.length > 0 ? [item.file] : [],
+  )
+  return [...bodyTextVars, ...bodyFileVars]
+}
+
 const replaceOldVarInText = (text: string, oldVar: ValueSelector, newVar: ValueSelector) => {
   if (!text || typeof text !== 'string') return text
 
@@ -1315,14 +1327,8 @@ export const getNodeUsedVars = (node: Node): ValueSelector[] => {
     }
     case BlockEnum.HttpRequest: {
       const payload = data as HttpNodeType
-      res = matchNotSystemVars([
-        payload.url,
-        payload.headers,
-        payload.params,
-        typeof payload.body.data === 'string'
-          ? payload.body.data
-          : payload.body.data.map((d) => d.value).join(''),
-      ])
+      res = matchNotSystemVars([payload.url, payload.headers, payload.params])
+      res.push(...getHttpBodyUsedVars(payload))
       break
     }
     case BlockEnum.Tool: {
@@ -1396,7 +1402,8 @@ export const getNodeUsedVars = (node: Node): ValueSelector[] => {
     }
 
     case BlockEnum.Iteration: {
-      res = [(data as IterationNodeType).iterator_selector]
+      const selector = (data as IterationNodeType).iterator_selector
+      res = Array.isArray(selector) && selector.length > 0 ? [selector] : []
       break
     }
 
@@ -1432,7 +1439,9 @@ export const getNodeUsedVars = (node: Node): ValueSelector[] => {
       break
     }
   }
-  return res || []
+  return (res || []).filter(
+    (selector): selector is ValueSelector => Array.isArray(selector) && selector.length > 0,
+  )
 }
 
 // can be used in iteration node
@@ -1682,13 +1691,18 @@ export const updateNodeVars = (
         payload.url = replaceOldVarInText(payload.url, oldVarSelector, newVarSelector)
         payload.headers = replaceOldVarInText(payload.headers, oldVarSelector, newVarSelector)
         payload.params = replaceOldVarInText(payload.params, oldVarSelector, newVarSelector)
+        if (!payload.body) break
         if (typeof payload.body.data === 'string') {
           payload.body.data = replaceOldVarInText(payload.body.data, oldVarSelector, newVarSelector)
-        } else {
-          payload.body.data = payload.body.data.map((d) => {
+        } else if (Array.isArray(payload.body.data)) {
+          payload.body.data = (payload.body.data as BodyPayload).map((d) => {
             return {
               ...d,
               value: replaceOldVarInText(d.value || '', oldVarSelector, newVarSelector),
+              file:
+                Array.isArray(d.file) && d.file.join('.') === oldVarSelector.join('.')
+                  ? newVarSelector
+                  : d.file,
             }
           })
         }


### PR DESCRIPTION
## Summary
- Fixes #39327
- Guard workflow variable extraction against legacy HTTP Request nodes with missing body data.
- Ignore empty Iteration selectors and filter invalid variable selectors before callers consume them.
- Keep HTTP body text and file selectors updateable during variable renames.

## Testing
- pnpm exec vitest run app/components/workflow/nodes/_base/components/variable/__tests__/utils.spec.ts
- pnpm exec tsc --noEmit --project tsconfig.json
- git diff --check
- pre-commit staged check: vp check --fix --no-error-on-unmatched-pattern