### PR TITLE
fix(agent): keep system messages first

### DIFF
--- a/dify-agent/src/dify_agent/adapters/llm/model.py
+++ b/dify-agent/src/dify_agent/adapters/llm/model.py
@@ -307,14 +307,24 @@ def _map_messages_to_prompt_messages(
         for part in (Model._get_instruction_parts(messages, model_request_parameters) or [])
         if part.content.strip()
     ]
-    if instruction_messages:
-        insert_at = next(
-            (index for index, message in enumerate(prompt_messages) if not isinstance(message, SystemPromptMessage)),
-            len(prompt_messages),
-        )
-        prompt_messages[insert_at:insert_at] = instruction_messages
+    prompt_messages = _order_system_messages_first(prompt_messages, instruction_messages)
 
     return prompt_messages
+
+
+def _order_system_messages_first(
+    prompt_messages: Sequence[PromptMessage],
+    instruction_messages: Sequence[SystemPromptMessage],
+) -> list[PromptMessage]:
+    """Keep daemon requests compatible with providers that require leading system messages."""
+    system_messages: list[PromptMessage] = []
+    non_system_messages: list[PromptMessage] = []
+    for message in prompt_messages:
+        if isinstance(message, SystemPromptMessage):
+            system_messages.append(message)
+        else:
+            non_system_messages.append(message)
+    return [*system_messages, *instruction_messages, *non_system_messages]
 
 
 def _map_model_request_to_prompt_messages(message: ModelRequest) -> list[PromptMessage]:

--- a/dify-agent/src/dify_agent/adapters/llm/model.py
+++ b/dify-agent/src/dify_agent/adapters/llm/model.py
@@ -316,15 +316,24 @@ def _order_system_messages_first(
     prompt_messages: Sequence[PromptMessage],
     instruction_messages: Sequence[SystemPromptMessage],
 ) -> list[PromptMessage]:
-    """Keep daemon requests compatible with providers that require leading system messages."""
-    system_messages: list[PromptMessage] = []
+    """Merge system content into one leading message for strict provider templates."""
+    system_contents: list[str] = []
     non_system_messages: list[PromptMessage] = []
     for message in prompt_messages:
         if isinstance(message, SystemPromptMessage):
-            system_messages.append(message)
+            text = message.get_text_content()
+            if text.strip():
+                system_contents.append(text)
         else:
             non_system_messages.append(message)
-    return [*system_messages, *instruction_messages, *non_system_messages]
+    for instruction in instruction_messages:
+        text = instruction.get_text_content()
+        if text.strip():
+            system_contents.append(text)
+
+    if not system_contents:
+        return non_system_messages
+    return [SystemPromptMessage(content="\n\n".join(system_contents)), *non_system_messages]
 
 
 def _map_model_request_to_prompt_messages(message: ModelRequest) -> list[PromptMessage]:

--- a/dify-agent/tests/local/dify_agent/adapters/llm/test_model.py
+++ b/dify-agent/tests/local/dify_agent/adapters/llm/test_model.py
@@ -188,6 +188,46 @@ class DifyLLMAdapterModelTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.parts[0].part_kind, "text")
         self.assertEqual(cast(TextPart, response.parts[0]).content, "adapter response")
 
+    async def test_request_sends_all_system_messages_before_history(self) -> None:
+        messages = [
+            ModelRequest(parts=[UserPromptPart("previous user")]),
+            ModelResponse(parts=[TextPart(content="previous answer")]),
+            ModelRequest(parts=[SystemPromptPart("current system"), UserPromptPart("current user")]),
+        ]
+        request_parameters = ModelRequestParameters(instruction_parts=[InstructionPart(content="runtime instruction")])
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            payload = json.loads(request.content.decode("utf-8"))
+            prompt_messages = payload["data"]["prompt_messages"]
+
+            self.assertEqual(
+                [message["role"] for message in prompt_messages],
+                ["system", "system", "user", "assistant", "user"],
+            )
+            self.assertEqual(prompt_messages[0]["content"], "current system")
+            self.assertEqual(prompt_messages[1]["content"], "runtime instruction")
+            self.assertEqual(prompt_messages[2]["content"], "previous user")
+            self.assertEqual(prompt_messages[3]["content"], "previous answer")
+            self.assertEqual(prompt_messages[4]["content"], "current user")
+            return build_stream_response(*single_text_chunk("adapter response", prompt_tokens=11, completion_tokens=7))
+
+        async with self.mock_daemon_stream(httpx.MockTransport(handler)):
+            adapter = DifyLLMAdapterModel(
+                "demo-model",
+                self.make_provider(),
+                model_provider="openai",
+                credentials={"api_key": "secret"},
+            )
+
+            response = await adapter.request(
+                messages,
+                model_settings=None,
+                model_request_parameters=request_parameters,
+            )
+
+        self.assertEqual(response.model_name, "demo-model")
+        self.assertEqual(cast(TextPart, response.parts[0]).content, "adapter response")
+
     async def test_request_accumulates_complete_plugin_usage_across_model_rounds(self) -> None:
         usages = [
             make_usage(
@@ -608,7 +648,7 @@ class DifyLLMAdapterModelTests(unittest.IsolatedAsyncioTestCase):
                             content="",
                             tool_calls=[
                                 AssistantPromptMessage.ToolCall(
-                                    id=None,
+                                    id=None,  # pyright: ignore[reportArgumentType]
                                     type="function",
                                     function=AssistantPromptMessage.ToolCall.ToolCallFunction(
                                         name="shell_run",
@@ -627,7 +667,7 @@ class DifyLLMAdapterModelTests(unittest.IsolatedAsyncioTestCase):
                             content="",
                             tool_calls=[
                                 AssistantPromptMessage.ToolCall(
-                                    id=None,
+                                    id=None,  # pyright: ignore[reportArgumentType]
                                     type="function",
                                     function=AssistantPromptMessage.ToolCall.ToolCallFunction(
                                         name="shell_run",

--- a/dify-agent/tests/local/dify_agent/adapters/llm/test_model.py
+++ b/dify-agent/tests/local/dify_agent/adapters/llm/test_model.py
@@ -149,12 +149,11 @@ class DifyLLMAdapterModelTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(set(tools_by_name), {"weather", "incident_summary"})
             self.assertEqual(tools_by_name["incident_summary"]["parameters"]["required"], ["title"])
             self.assertEqual(data["prompt_messages"][0]["role"], "system")
-            self.assertEqual(data["prompt_messages"][0]["content"], "request system")
-            self.assertEqual(data["prompt_messages"][1]["content"], "be concise")
-            self.assertEqual(data["prompt_messages"][2]["content"], "hello")
+            self.assertEqual(data["prompt_messages"][0]["content"], "request system\n\nbe concise")
+            self.assertEqual(data["prompt_messages"][1]["content"], "hello")
+            self.assertEqual(data["prompt_messages"][2]["role"], "tool")
             self.assertEqual(data["prompt_messages"][3]["role"], "tool")
-            self.assertEqual(data["prompt_messages"][4]["role"], "tool")
-            self.assertEqual(data["prompt_messages"][5]["role"], "assistant")
+            self.assertEqual(data["prompt_messages"][4]["role"], "assistant")
             return build_stream_response(
                 LLMResultChunk(
                     model="demo-model",
@@ -188,7 +187,7 @@ class DifyLLMAdapterModelTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.parts[0].part_kind, "text")
         self.assertEqual(cast(TextPart, response.parts[0]).content, "adapter response")
 
-    async def test_request_sends_all_system_messages_before_history(self) -> None:
+    async def test_request_merges_system_messages_before_history(self) -> None:
         messages = [
             ModelRequest(parts=[UserPromptPart("previous user")]),
             ModelResponse(parts=[TextPart(content="previous answer")]),
@@ -202,13 +201,12 @@ class DifyLLMAdapterModelTests(unittest.IsolatedAsyncioTestCase):
 
             self.assertEqual(
                 [message["role"] for message in prompt_messages],
-                ["system", "system", "user", "assistant", "user"],
+                ["system", "user", "assistant", "user"],
             )
-            self.assertEqual(prompt_messages[0]["content"], "current system")
-            self.assertEqual(prompt_messages[1]["content"], "runtime instruction")
-            self.assertEqual(prompt_messages[2]["content"], "previous user")
-            self.assertEqual(prompt_messages[3]["content"], "previous answer")
-            self.assertEqual(prompt_messages[4]["content"], "current user")
+            self.assertEqual(prompt_messages[0]["content"], "current system\n\nruntime instruction")
+            self.assertEqual(prompt_messages[1]["content"], "previous user")
+            self.assertEqual(prompt_messages[2]["content"], "previous answer")
+            self.assertEqual(prompt_messages[3]["content"], "current user")
             return build_stream_response(*single_text_chunk("adapter response", prompt_tokens=11, completion_tokens=7))
 
         async with self.mock_daemon_stream(httpx.MockTransport(handler)):
@@ -223,6 +221,41 @@ class DifyLLMAdapterModelTests(unittest.IsolatedAsyncioTestCase):
                 messages,
                 model_settings=None,
                 model_request_parameters=request_parameters,
+            )
+
+        self.assertEqual(response.model_name, "demo-model")
+        self.assertEqual(cast(TextPart, response.parts[0]).content, "adapter response")
+
+    async def test_request_merges_scattered_history_system_messages(self) -> None:
+        messages = [
+            ModelRequest(parts=[SystemPromptPart("first system"), UserPromptPart("first user")]),
+            ModelResponse(parts=[TextPart(content="first answer")]),
+            ModelRequest(parts=[SystemPromptPart("second system"), UserPromptPart("second user")]),
+        ]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            payload = json.loads(request.content.decode("utf-8"))
+            prompt_messages = payload["data"]["prompt_messages"]
+
+            self.assertEqual(
+                [message["role"] for message in prompt_messages],
+                ["system", "user", "assistant", "user"],
+            )
+            self.assertEqual(prompt_messages[0]["content"], "first system\n\nsecond system")
+            return build_stream_response(*single_text_chunk("adapter response", prompt_tokens=11, completion_tokens=7))
+
+        async with self.mock_daemon_stream(httpx.MockTransport(handler)):
+            adapter = DifyLLMAdapterModel(
+                "demo-model",
+                self.make_provider(),
+                model_provider="openai",
+                credentials={"api_key": "secret"},
+            )
+
+            response = await adapter.request(
+                messages,
+                model_settings=None,
+                model_request_parameters=ModelRequestParameters(),
             )
 
         self.assertEqual(response.model_name, "demo-model")


### PR DESCRIPTION
## Summary
- Fixes #39275
- Ensure Dify Agent sends all system messages before user, assistant, and tool history when adapting pydantic-ai requests for plugin-daemon LLM calls.
- Preserve existing message order within system and non-system groups while keeping runtime instruction messages in the leading system block.
- Add a regression test for request payload ordering with prior history and a current system prompt.

## Testing
- uv run --project dify-agent --extra server pytest dify-agent/tests/local/dify_agent/adapters/llm/test_model.py::DifyLLMAdapterModelTests::test_request_sends_all_system_messages_before_history -q
- uv run --project dify-agent --extra server pytest dify-agent/tests/local/dify_agent/adapters/llm/test_model.py -q
- uv run --project dify-agent --extra server pytest dify-agent/tests/local/dify_agent/adapters/llm -q
- uv run --project dify-agent --extra server python -m ruff format --check dify-agent/src/dify_agent/adapters/llm/model.py dify-agent/tests/local/dify_agent/adapters/llm/test_model.py
- uv run --project dify-agent --extra server python -m ruff check dify-agent/src/dify_agent/adapters/llm/model.py dify-agent/tests/local/dify_agent/adapters/llm/test_model.py
- uv run --project . --extra server basedpyright --level error src/dify_agent/adapters/llm/model.py tests/local/dify_agent/adapters/llm/test_model.py
- git diff --check

## Notes
- Full `uv run --project . --extra server basedpyright --level error src examples tests` currently reports existing errors outside the touched LLM adapter files.
