### PR TITLE
fix: merge completion_params into model_parameters in Agent node to prevent 'required' validation error

### DIFF
--- a/api/core/workflow/nodes/agent/runtime_support.py
+++ b/api/core/workflow/nodes/agent/runtime_support.py
@@ -180,6 +180,14 @@ class AgentRuntimeSupport:
                         user_id=user_id,
                         value=value,
                     )
+                    # Merge completion_params into model_parameters so the plugin
+                    # daemon receives temperature, max_tokens, etc. as top-level
+                    # keys rather than nested under completion_params. Some model
+                    # providers (e.g. Tongyi Qwen) validate required fields from
+                    # model_parameters and fail with 'required' when they are
+                    # missing or nested.
+                    completion_params = value.pop("completion_params", None) or {}
+                    value["model_parameters"] = completion_params
                     history_prompt_messages = []
                     if node_data.memory:
                         memory = self.fetch_memory(


### PR DESCRIPTION
When an Agent node runs inside a Chatflow, the model selector parameter
value includes completion_params (temperature, max_tokens, etc.) nested
inside the dict. The plugin daemon expects these as a top-level
model_parameters key. Some model providers (e.g. Tongyi Qwen) validate
required fields from model_parameters and fail with:

    InvokeError: [models] Error: 'required'

when the parameters are missing or nested under completion_params.

This fix pops completion_params from the model selector value and
reassigns it as model_parameters, matching the format the plugin daemon's
LLM dispatch protocol expects.

Fixes #39274
