### PR TITLE
docs: note minimum Docker Compose version

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Dify is an open-source LLM app development platform. Its intuitive interface com
 
 <br/>
 
-The easiest way to start the Dify server is through [Docker Compose](docker/docker-compose.yaml). Before running Dify with the following commands, make sure that [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) are installed on your machine:
+The easiest way to start the Dify server is through [Docker Compose](docker/docker-compose.yaml). Before running Dify with the following commands, make sure that [Docker](https://docs.docker.com/get-docker/) and Docker Compose v2.24.0 or later are installed on your machine:
 
 ```bash
 cd dify

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,7 +16,7 @@ Welcome to the new `docker` directory for deploying Dify using Docker Compose. T
 
 ### How to Deploy Dify with `docker-compose.yaml`
 
-1. **Prerequisites**: Ensure Docker and Docker Compose are installed on your system.
+1. **Prerequisites**: Ensure Docker and Docker Compose v2.24.0 or later are installed on your system.
 2. **Environment Setup**:
    - Navigate to the `docker` directory.
    - Copy `.env.example` to `.env`.


### PR DESCRIPTION
## Summary
- Document that the Docker Compose deployment requires Docker Compose v2.24.0 or later.
- Add the prerequisite to both the root quick start and the Docker deployment README.

Fixes #38887

## Testing
- `git diff --check`
- Commit hook: `eslint --fix --pass-on-unpruned-suppressions --no-error-on-unmatched-pattern --no-warn-ignored`
- Commit hook: `vp check --fix --no-error-on-unmatched-pattern`
