### PR TITLE
fix(rag): use floor division for vector embedding batch count

### DIFF
--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -169,7 +169,7 @@ class Vector:
             start = time.time()
             logger.info("start embedding %s texts %s", len(texts), start)
             batch_size = 1000
-            total_batches = len(texts) + batch_size - 1
+            total_batches = (len(texts) + batch_size - 1) // batch_size
             for i in range(0, len(texts), batch_size):
                 batch = texts[i : i + batch_size]
                 batch_start = time.time()
@@ -186,7 +186,7 @@ class Vector:
             start = time.time()
             logger.info("start embedding %s files %s", len(file_documents), start)
             batch_size = 1000
-            total_batches = len(file_documents) + batch_size - 1
+            total_batches = (len(file_documents) + batch_size - 1) // batch_size
             for i in range(0, len(file_documents), batch_size):
                 batch = file_documents[i : i + batch_size]
                 batch_start = time.time()

--- a/api/tests/unit_tests/core/rag/datasource/vdb/test_vector_factory.py
+++ b/api/tests/unit_tests/core/rag/datasource/vdb/test_vector_factory.py
@@ -320,6 +320,29 @@ def test_create_batches_texts_and_skips_empty_input(vector_factory_module):
     vector._vector_processor.create.assert_not_called()
 
 
+def test_create_reports_correct_batch_count_in_logs(vector_factory_module, caplog):
+    import logging
+
+    vector = vector_factory_module.Vector.__new__(vector_factory_module.Vector)
+    vector._embeddings = MagicMock()
+    vector._vector_processor = MagicMock()
+
+    # 1001 texts with a batch_size of 1000 must produce exactly 2 batches.
+    docs = [Document(page_content=f"doc-{i}", metadata={"doc_id": f"id-{i}"}) for i in range(1001)]
+    vector._embeddings.embed_documents.side_effect = [
+        [[0.1] for _ in range(1000)],
+        [[0.2]],
+    ]
+
+    with caplog.at_level(logging.INFO, logger="core.rag.datasource.vdb.vector_factory"):
+        vector.create(texts=docs, trace_id="trace-1")
+
+    processing_lines = [r.message for r in caplog.records if "Processing batch" in r.message]
+    assert processing_lines, "expected at least one 'Processing batch' log line"
+    # The denominator (total_batches) must be the batch count, not item count.
+    assert all("/2 " in line for line in processing_lines), processing_lines
+
+
 def test_create_skips_empty_text_documents_before_embedding(vector_factory_module):
     vector = vector_factory_module.Vector.__new__(vector_factory_module.Vector)
     vector._embeddings = MagicMock()


### PR DESCRIPTION
The total_batches counter in Vector.create and Vector.create_multimodal was computed as len(texts) + batch_size - 1, which is missing the floor-division step. With a batch size of 1000, embedding 1001 documents logged "Processing batch 1/2000" instead of "Processing batch 1/2", so the progress denominator was off by ~batch_size. This only affects the info-level progress logs (the actual batching loop uses the correct range step), but it makes the logs misleading when debugging long embedding runs.

Changed both the text and multimodal paths to use ceiling division: (len(items) + batch_size - 1) // batch_size. Added a regression test that embeds 1001 docs and asserts the logged batch denominator is 2, not 2000 (verified it fails on the old formula).