### PR TITLE
fix(rag): strip <think> reasoning blocks from knowledge base summaries

### DIFF
--- a/api/core/rag/index_processor/processor/paragraph_index_processor.py
+++ b/api/core/rag/index_processor/processor/paragraph_index_processor.py
@@ -39,6 +39,7 @@ from graphon.model_runtime.entities.message_entities import (
     UserPromptMessage,
 )
 from graphon.model_runtime.entities.model_entities import ModelFeature, ModelType
+from graphon.nodes.llm.reasoning import split_reasoning
 from libs import helper
 from models import UploadFile
 from models.account import Account
@@ -488,6 +489,11 @@ class ParagraphIndexProcessor(BaseIndexProcessor):
 
         summary_content = result.message.get_text_content()
         usage = result.usage
+
+        # Reasoning models (e.g. qwen3, deepseek-r1) may inline <think>...</think>
+        # blocks in the text output. Strip them so the stored summary contains
+        # only the final answer, matching the behaviour of LLM workflow nodes.
+        summary_content, _reasoning = split_reasoning(summary_content, "separated")
 
         # Deduct quota for summary generation (same as workflow nodes)
         try:

--- a/api/tests/unit_tests/core/rag/indexing/processor/test_paragraph_index_processor.py
+++ b/api/tests/unit_tests/core/rag/indexing/processor/test_paragraph_index_processor.py
@@ -482,6 +482,43 @@ class TestParagraphIndexProcessor:
         assert sum(1 for r in caplog.records if r.levelno == logging.WARNING) == 1
         assert any("Failed to deduct quota for summary generation" in record.message for record in caplog.records)
 
+    def test_generate_summary_strips_reasoning_blocks(self) -> None:
+        """Reasoning models may inline <think>...</think> in the text output.
+
+        The stored summary must contain only the final answer, not the
+        chain-of-thought. See GitHub issue #38587.
+        """
+        model_instance = Mock()
+        model_instance.credentials = {"k": "v"}
+        model_instance.model_type_instance.get_model_schema.return_value = SimpleNamespace(features=[])
+        model_instance.invoke_llm.return_value = self._llm_result(
+            "<think>Let me analyze this document step by step.</think>"
+            "This document covers government credit card regulations."
+        )
+
+        with (
+            patch(
+                "core.rag.index_processor.processor.paragraph_index_processor.create_plugin_provider_manager"
+            ) as mock_provider_manager,
+            patch(
+                "core.rag.index_processor.processor.paragraph_index_processor.ModelInstance",
+                return_value=model_instance,
+            ),
+            patch("core.rag.index_processor.processor.paragraph_index_processor.deduct_llm_quota"),
+        ):
+            mock_provider_manager.return_value.get_provider_model_bundle.return_value = Mock()
+            summary, _ = ParagraphIndexProcessor.generate_summary(
+                "tenant-1",
+                "text content",
+                {"enable": True, "model_name": "model-a", "model_provider_name": "provider-a"},
+                session=Mock(),
+            )
+
+        assert "<think>" not in summary
+        assert "</think>" not in summary
+        assert "Let me analyze" not in summary
+        assert "government credit card regulations" in summary
+
     def test_generate_summary_handles_vision_and_image_conversion(self) -> None:
         model_instance = Mock()
         model_instance.credentials = {"k": "v"}


### PR DESCRIPTION
Reasoning models like qwen3 or deepseek-r1 sometimes inline <think>...</think> blocks in the text output rather than returning the chain-of-thought via the separated reasoning_content channel. The summary generation path in ParagraphIndexProcessor.generate_summary() called result.message.get_text_content() and stored the raw string, so the thinking content leaked into the stored knowledge base summary (issue #38587).

This applies split_reasoning(text, "separated") to the summary output — the same helper that LLM workflow nodes already use — so only the final answer is persisted. The change is a single post-processing step; no prompt or model invocation logic is touched. Added a unit test that feeds a mock LLM result with an inline <think> block and asserts the thinking content is removed while the answer survives.

Fixes #38587