### PR TITLE
fix(api): map InvokeRateLimitError to 429 in CompletionApi

### DIFF
--- a/api/controllers/service_api/app/completion.py
+++ b/api/controllers/service_api/app/completion.py
@@ -260,6 +260,8 @@ class CompletionApi(Resource):
             raise ProviderQuotaExceededError()
         except ModelCurrentlyNotSupportError:
             raise ProviderModelCurrentlyNotSupportError()
+        except InvokeRateLimitError as ex:
+            raise InvokeRateLimitHttpError(ex.description)
         except InvokeError as e:
             raise CompletionRequestError(e.description)
         except ValueError as e:


### PR DESCRIPTION
POST /v1/completion-messages returns 500 internal_server_error when the workspace rate limit is hit, while POST /v1/chat-messages correctly returns 429 too_many_requests for the same condition. The only difference is that ChatApi.post catches InvokeRateLimitError and maps it via InvokeRateLimitHttpError, but CompletionApi.post is missing that handler and the exception falls through to the generic 500 catch-all.

This adds the same except InvokeRateLimitError clause to CompletionApi.post so both endpoints behave consistently. Both imports (InvokeRateLimitError from services.errors.llm and InvokeRateLimitHttpError from controllers.web.error) are already present in the file.

Identified as item 3 in the Service API audit issue #38855.