### PR TITLE
fix(service-api): map completion-messages rate limit to 429

### DIFF
--- a/api/controllers/service_api/app/completion.py
+++ b/api/controllers/service_api/app/completion.py
@@ -260,6 +260,8 @@ class CompletionApi(Resource):
             raise ProviderQuotaExceededError()
         except ModelCurrentlyNotSupportError:
             raise ProviderModelCurrentlyNotSupportError()
+        except InvokeRateLimitError as ex:
+            raise InvokeRateLimitHttpError(ex.description)
         except InvokeError as e:
             raise CompletionRequestError(e.description)
         except ValueError as e:

--- a/api/tests/unit_tests/controllers/service_api/app/test_completion.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_completion.py
@@ -431,6 +431,29 @@ class TestCompletionControllerLogic:
 
     @patch("controllers.service_api.app.completion.service_api_ns")
     @patch("controllers.service_api.app.completion.AppGenerateService")
+    def test_completion_api_post_rate_limit_maps_to_429(
+        self, mock_generate_service, mock_service_api_ns, app: Flask, orm_session: Session
+    ):
+        """CompletionApi.post must map InvokeRateLimitError to a 429 HTTP error.
+
+        Regression test for the inconsistency where ChatApi.post mapped the
+        workspace rate-limit condition to 429 but CompletionApi.post let it
+        fall through to 500 internal_server_error (see issue #38855).
+        """
+        from controllers.service_api.app.completion import CompletionApi
+        from controllers.web.error import InvokeRateLimitError as InvokeRateLimitHttpError
+
+        app_model, end_user, _, _ = _persist_completion_state(orm_session, AppMode.COMPLETION)
+
+        mock_service_api_ns.payload = {"inputs": {}, "response_mode": "blocking"}
+        mock_generate_service.generate.side_effect = InvokeRateLimitError("Rate limit exceeded")
+
+        with app.test_request_context():
+            with pytest.raises(InvokeRateLimitHttpError):
+                unwrap(CompletionApi().post)(CompletionApi(), orm_session, app_model, end_user)
+
+    @patch("controllers.service_api.app.completion.service_api_ns")
+    @patch("controllers.service_api.app.completion.AppGenerateService")
     def test_chat_api_post_success(self, mock_generate_service, mock_service_api_ns, app: Flask, orm_session: Session):
         """Test ChatApi.post success path."""
         from controllers.service_api.app.completion import ChatApi


### PR DESCRIPTION
POST /v1/completion-messages currently returns 500 internal_server_error when the workspace rate limit is hit, while the sibling POST /v1/chat-messages endpoint correctly returns 429 rate_limit_error. The root cause is a missing exception handler: ChatApi.post catches InvokeRateLimitError and maps it to the HTTP error, but CompletionApi.post does not, so the same condition falls through to the generic 500 path.

This adds the identical except clause to CompletionApi.post so both generate endpoints surface the rate-limit condition consistently as 429. The required imports (InvokeRateLimitError from services.errors.llm and InvokeRateLimitHttpError from controllers.web.error) were already in place.

I also added a regression test (test_completion_api_post_rate_limit_maps_to_429) that mocks AppGenerateService.generate to raise InvokeRateLimitError and asserts CompletionApi.post re-raises it as the 429 HTTP error, mirroring the existing test for the chat endpoint.

This corresponds to item 3 (Rate limit surfaces as 500 on completion-messages but 429 on chat-messages) of the Service API audit reported in #38855.