### PR TITLE
fix(api): send valid body in external knowledge validation probe

### DIFF
--- a/api/services/external_knowledge_service.py
+++ b/api/services/external_knowledge_service.py
@@ -93,8 +93,20 @@ class ExternalDatasetService:
                 raise ValueError(f"invalid endpoint: {endpoint} must start with http:// or https://")
             else:
                 raise ValueError(f"invalid endpoint: {endpoint}")
+        # Send a minimal body shaped like the External Knowledge API retrieval contract so providers
+        # that require a JSON payload (e.g. RAGFlow) accept the validation probe instead of rejecting
+        # a body-less POST. Mirrors the request built in fetch_external_knowledge_retrieval.
+        validation_payload = {
+            "knowledge_id": "",
+            "query": "",
+            "retrieval_setting": {"top_k": 1, "score_threshold": 0.0},
+        }
         try:
-            response = ssrf_proxy.post(endpoint, headers={"Authorization": f"Bearer {api_key}"})
+            response = ssrf_proxy.post(
+                endpoint,
+                headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+                data=json.dumps(validation_payload),
+            )
         except Exception as e:
             raise ValueError(f"failed to connect to the endpoint: {endpoint}") from e
         if response.status_code == 502:

--- a/api/tests/unit_tests/services/test_external_dataset_service.py
+++ b/api/tests/unit_tests/services/test_external_dataset_service.py
@@ -613,6 +613,31 @@ class TestExternalDatasetServiceCheckEndpoint:
         # Act & Assert - should not raise
         ExternalDatasetService.check_endpoint_and_api_key(settings)
 
+    @patch("services.external_knowledge_service.ssrf_proxy")
+    def test_check_endpoint_sends_json_body(self, mock_proxy, factory: ExternalDatasetServiceTestDataFactory):
+        """Regression for #39402: the validation probe must POST a JSON body matching the
+        External Knowledge API retrieval contract, not a body-less request that providers
+        such as RAGFlow reject (empty POST -> 502 ERR_ZERO_SIZE_OBJECT)."""
+        # Arrange
+        settings = {"endpoint": "https://api.example.com", "api_key": "test-key"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_proxy.post.return_value = mock_response
+
+        # Act
+        ExternalDatasetService.check_endpoint_and_api_key(settings)
+
+        # Assert - a non-empty JSON body is sent with the JSON content type
+        mock_proxy.post.assert_called_once()
+        _, call_kwargs = mock_proxy.post.call_args
+        assert call_kwargs["headers"]["Content-Type"] == "application/json"
+        assert call_kwargs["headers"]["Authorization"] == "Bearer test-key"
+        sent_body = json.loads(call_kwargs["data"])
+        assert "knowledge_id" in sent_body
+        assert "query" in sent_body
+        assert sent_body["retrieval_setting"] == {"top_k": 1, "score_threshold": 0.0}
+
     def test_check_endpoint_missing_endpoint_key(self, factory: ExternalDatasetServiceTestDataFactory):
         """Test validation fails when endpoint key is missing."""
         # Arrange


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

The external knowledge endpoint validation probe issued a body-less POST, which providers that require a JSON payload (e.g. RAGFlow) reject: the empty POST yields a closed connection and Squid returns `502 ERR_ZERO_SIZE_OBJECT`, so valid external knowledge configs could not be saved.

Send a minimal body shaped like the External Knowledge API retrieval contract (`knowledge_id`, `query`, `retrieval_setting`), mirroring the request built in `fetch_external_knowledge_retrieval`, so the probe exercises the same contract the real retrieval uses.

Fixes #39402

## Screenshots

Backend request-shape fix with no UI surface; behaviour change is covered by the regression test.

| Before | After |
|--------|-------|
| Probe sends `POST` with no body → provider rejects → `502 ERR_ZERO_SIZE_OBJECT`, config cannot be saved | Probe sends a JSON body matching the retrieval contract → provider accepts the validation request |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods


From Claude Code