### PR TITLE
fix(core): keep in-progress messages in get_thread_messages_length

### DIFF
--- a/api/core/prompt/utils/get_thread_messages_length.py
+++ b/api/core/prompt/utils/get_thread_messages_length.py
@@ -17,8 +17,10 @@ def get_thread_messages_length(conversation_id: str, *, session: Session) -> int
     # Extract thread messages
     thread_messages = extract_thread_messages(messages)
 
-    # Exclude the newly created message with an empty answer
-    if thread_messages and not thread_messages[0].answer:
+    # Exclude only a freshly created placeholder message: one with an empty
+    # answer AND no produced tokens yet. An in-progress message whose answer is
+    # still streaming (empty answer but answer_tokens > 0) must be kept.
+    if thread_messages and not thread_messages[0].answer and thread_messages[0].answer_tokens == 0:
         thread_messages.pop(0)
 
     return len(thread_messages)

--- a/api/tests/unit_tests/core/prompt/test_extract_thread_messages.py
+++ b/api/tests/unit_tests/core/prompt/test_extract_thread_messages.py
@@ -19,6 +19,7 @@ def _persisted_message(
     parent_message_id: str,
     answer: str,
     created_at: datetime,
+    answer_tokens: int = 0,
 ) -> Message:
     message = Message(
         id=message_id,
@@ -34,16 +35,19 @@ def _persisted_message(
         parent_message_id=parent_message_id,
         created_at=created_at,
         updated_at=created_at,
+        message_tokens=0,
+        answer_tokens=answer_tokens,
     )
     message._inputs = {}
     return message
 
 
 class MockMessage:
-    def __init__(self, id, parent_message_id, answer="answer"):
+    def __init__(self, id, parent_message_id, answer="answer", answer_tokens=1):
         self.id = id
         self.parent_message_id = parent_message_id
         self.answer = answer
+        self.answer_tokens = answer_tokens
 
     def __getitem__(self, item):
         return getattr(self, item)
@@ -170,6 +174,37 @@ def test_get_thread_messages_length_excludes_newly_created_empty_answer(sqlite_s
     length = get_thread_messages_length("conversation-1", session=sqlite_session)
 
     assert length == 1
+
+
+@pytest.mark.parametrize("sqlite_session", [(Message,)], indirect=True)
+def test_get_thread_messages_length_keeps_in_progress_message_with_tokens(sqlite_session: Session):
+    # Regression for #37880: a streaming/in-progress message has an empty answer
+    # but answer_tokens > 0, so it must not be excluded from the thread length.
+    id1, id2 = str(uuid4()), str(uuid4())
+    now = datetime.now()
+    messages = [
+        _persisted_message(
+            message_id=id2,
+            conversation_id="conversation-in-progress",
+            parent_message_id=id1,
+            answer="",
+            created_at=now,
+            answer_tokens=5,
+        ),
+        _persisted_message(
+            message_id=id1,
+            conversation_id="conversation-in-progress",
+            parent_message_id=UUID_NIL,
+            answer="ok",
+            created_at=now - timedelta(seconds=1),
+        ),
+    ]
+    sqlite_session.add_all(messages)
+    sqlite_session.commit()
+
+    length = get_thread_messages_length("conversation-in-progress", session=sqlite_session)
+
+    assert length == 2
 
 
 @pytest.mark.parametrize("sqlite_session", [(Message,)], indirect=True)


### PR DESCRIPTION
get_thread_messages_length excluded the newest thread message whenever its answer was empty, even during streaming when answer_tokens > 0. This under-counted the thread length and skewed the dialogue_count passed to the agent generator in advanced_chat/app_generator.py.

The guard now also checks answer_tokens == 0, so only a freshly created placeholder message (empty answer and no tokens produced yet) is excluded. This matches the existing guard in TokenBufferMemory.get_history_prompt_messages, which already uses the same two-condition check.

I added a regression test for the in-progress case (empty answer, answer_tokens > 0) alongside the existing placeholder test. Both pass locally along with the rest of the extract_thread_messages suite.

Fixes #37880

The concrete caller that benefits: `AdvancedPromptGenerator.resume()` re-enters `_generate` with an existing message instead of creating one, so `thread_messages[0]` there is a pre-existing in-progress message rather than a fresh placeholder — exactly the case the old one-condition guard dropped, under-counting `dialogue_count` by one on every resume of a run whose answer column was still empty.
