### PR TITLE
fix(workflow): reset cleared variable selector to constant/null

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/__tests__/form-input-item.helpers.spec.ts
+++ b/web/app/components/workflow/nodes/_base/components/__tests__/form-input-item.helpers.spec.ts
@@ -157,6 +157,20 @@ describe('form-input-item helpers', () => {
     expect(normalizeVariableSelectorValue('')).toBe('')
   })
 
+  it('should detect empty selector values as cleared', () => {
+    // Both empty string and empty array are "cleared" selectors.
+    // The FormInputItem uses these checks to reset to constant/null
+    // instead of persisting type=variable with an empty value.
+    const empty = normalizeVariableSelectorValue('')
+    expect(!empty || (Array.isArray(empty) && empty.length === 0)).toBe(true)
+
+    const emptyArray = normalizeVariableSelectorValue([])
+    expect(!emptyArray || (Array.isArray(emptyArray) && emptyArray.length === 0)).toBe(true)
+
+    const valid = normalizeVariableSelectorValue(['start', 'input'])
+    expect(!valid || (Array.isArray(valid) && valid.length === 0)).toBe(false)
+  })
+
   it('should derive remaining target variable types and label states', () => {
     const objectState = getFormInputState(createSchema({ type: FormTypeEnum.object }), undefined)
     const arrayState = getFormInputState(createSchema({ type: FormTypeEnum.array }), undefined)

--- a/web/app/components/workflow/nodes/_base/components/form-input-item.tsx
+++ b/web/app/components/workflow/nodes/_base/components/form-input-item.tsx
@@ -247,12 +247,27 @@ const FormInputItem: FC<Props> = ({
   }
 
   const handleVariableSelectorChange = (newValue: ValueSelector | string, variable: string) => {
+    const normalized = normalizeVariableSelectorValue(newValue)
+    // When the variable selector is cleared (empty string or empty array),
+    // reset to constant/null instead of persisting type=variable with an
+    // empty value, which fails backend ToolInput validation.
+    if (!normalized || (Array.isArray(normalized) && normalized.length === 0)) {
+      onChange({
+        ...value,
+        [variable]: {
+          ...varInput,
+          type: VarKindType.constant,
+          value: null,
+        },
+      })
+      return
+    }
     onChange({
       ...value,
       [variable]: {
         ...varInput,
         type: VarKindType.variable,
-        value: normalizeVariableSelectorValue(newValue),
+        value: normalized,
       },
     })
   }


### PR DESCRIPTION
When a user selects a variable for an optional file or files form parameter in a tool node and then clears it, VarReferencePicker calls onChange([]) (or onChange('') in some paths). The previous handleVariableSelectorChange kept type=variable with an empty value, which the backend ToolInput validator rejects with 'value must be a list' — crashing the workflow run before the tool is even invoked.

This change makes handleVariableSelectorChange detect an empty selector (empty string or empty array) and reset to {type: constant, value: null}, matching the initial untouched state. A helper test covers the empty-selector detection.

Closes #39045