### PR TITLE
fix(docker): mount shared storage volume in api_websocket

### DIFF
--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -280,6 +280,8 @@ services:
       SERVER_WORKER_CONNECTIONS: ${API_WEBSOCKET_WORKER_CONNECTIONS:-1000}
       GUNICORN_TIMEOUT: ${API_WEBSOCKET_GUNICORN_TIMEOUT:-360}
     depends_on:
+      init_permissions:
+        condition: service_completed_successfully
       db_postgres:
         condition: service_healthy
         required: false
@@ -288,6 +290,9 @@ services:
         required: false
       redis:
         condition: service_started
+    volumes:
+      # Mount the storage directory to the container, for storing user files.
+      - ./volumes/app/storage:/app/api/storage
     networks:
       - ssrf_proxy_network
       - default

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -286,6 +286,8 @@ services:
       SERVER_WORKER_CONNECTIONS: ${API_WEBSOCKET_WORKER_CONNECTIONS:-1000}
       GUNICORN_TIMEOUT: ${API_WEBSOCKET_GUNICORN_TIMEOUT:-360}
     depends_on:
+      init_permissions:
+        condition: service_completed_successfully
       db_postgres:
         condition: service_healthy
         required: false
@@ -294,6 +296,9 @@ services:
         required: false
       redis:
         condition: service_started
+    volumes:
+      # Mount the storage directory to the container, for storing user files.
+      - ./volumes/app/storage:/app/api/storage
     networks:
       - ssrf_proxy_network
       - default


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #39422.

<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. -->

With the **documented default** configuration (`SECRET_KEY=` empty in `.env.example`, whose comment reads *"Leave empty to auto-generate a persistent key in the storage directory"*), the workflow-collaboration websocket cannot authenticate.

**Root cause.** `api` and `worker` both mount the shared storage volume (`./volumes/app/storage:/app/api/storage`), but `api_websocket` has **no `volumes:` block**, so it gets a container-local storage directory. When `SECRET_KEY` is empty, each container auto-generates its own key into *its* storage dir. `api` writes one key; `api_websocket`, not sharing the volume, never sees it and generates a different one:

```
docker exec docker-api-1           cat /app/api/storage/.dify_secret_key
→ 0LCnJVMO…bboX
docker exec docker-api_websocket-1 cat /app/api/storage/.dify_secret_key
→ 03wmntv…rZ91        # different key; its storage dir also lacks privkeys/ upload_files/ website_files/
```

The two `SECRET_KEY`s diverge, so JWTs minted by `api` fail verification in `api_websocket`:

```
jwt.exceptions.InvalidSignatureError: Signature verification failed
  File "/app/api/controllers/console/socketio/workflow.py", line 40, in socket_connect
werkzeug.exceptions.Unauthorized: 401 Unauthorized: Invalid token signature.
```

Setting `SECRET_KEY` explicitly is a workaround, not a fix — the documented empty-default path is broken.

**Fix.** Mount the shared storage volume in `api_websocket`, mirroring `api`/`worker`, and gate it on `init_permissions` (`service_completed_successfully`) as the other two storage consumers do, so all three api-image services share one `.dify_secret_key` and there is no first-start permissions race on the shared volume. The change is made in `docker-compose-template.yaml` and `docker-compose.yaml` was regenerated with `docker/generate_docker_compose` (not hand-edited).

**Verified.** After applying this change and recreating `api_websocket`, both containers read the same key and the `InvalidSignatureError` no longer appears in the websocket logs; the handshake returns 101.

**Prior art.** #39345 reports this exact traceback on 1.16.0. It was closed by the reporter ~24 minutes later with a single automated comment and **no human review**. That comment advised setting `SECRET_KEY` explicitly and noted both services inherit the same `security.env` — true, but not the cause: the divergence happens in the **auto-generate path**, which writes to the storage directory `api_websocket` does not mount. The missing volume was never identified. The reporter did nothing wrong.

**Scope.** Compose template + regenerated output only. Deliberately **not** included: making `SECRET_KEY` fail-loud instead of auto-generating (a startup-contract design call for maintainers), and the `Cannot receive from redis... retrying` loop in the same container — that is a separate defect, filed as #39423 with its own fix.

## Screenshots

| Before | After |
|--------|-------|
| Divergent `.dify_secret_key` between `api` and `api_websocket`; `InvalidSignatureError` in the websocket logs | Both containers read the same key; `InvalidSignatureError` gone; websocket handshake returns 101 |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Claude Code