### PR TITLE
fix: remove read timeout from the Socket.IO pub/sub connection

### DIFF
--- a/api/extensions/ext_socketio.py
+++ b/api/extensions/ext_socketio.py
@@ -22,7 +22,13 @@ def _get_ssl_cert_reqs() -> ssl.VerifyMode:
 def _build_redis_options(redis_url: str) -> dict[str, Any]:
     """Build Redis options for Socket.IO's cross-process pub/sub manager."""
     options: dict[str, Any] = {
-        "socket_timeout": dify_config.REDIS_SOCKET_TIMEOUT,
+        # socketio.RedisManager runs a blocking pubsub.listen() loop that stays idle until an
+        # event arrives. A read timeout makes idling impossible: after REDIS_SOCKET_TIMEOUT
+        # seconds of silence the read raises TimeoutError, python-socketio logs the generic
+        # "Cannot receive from redis... retrying" and resubscribes, forever, so events are never
+        # delivered. This connection must therefore have no read timeout, independent of
+        # REDIS_SOCKET_TIMEOUT (which is correct for the non-blocking clients). Do not reintroduce.
+        "socket_timeout": None,
         "socket_connect_timeout": dify_config.REDIS_SOCKET_CONNECT_TIMEOUT,
         "health_check_interval": dify_config.REDIS_HEALTH_CHECK_INTERVAL,
         "protocol": dify_config.REDIS_SERIALIZATION_PROTOCOL,

--- a/api/tests/unit_tests/extensions/test_ext_socketio.py
+++ b/api/tests/unit_tests/extensions/test_ext_socketio.py
@@ -19,6 +19,19 @@ def test_create_socketio_client_manager_uses_pubsub_url_and_prefixed_channel(mon
     assert manager.channel == "tenant-a:socketio"
 
 
+def test_build_redis_options_omits_read_timeout_for_blocking_pubsub(monkeypatch) -> None:
+    # The pub/sub manager runs a blocking pubsub.listen() loop; a read timeout would turn every
+    # idle period into a recurring TimeoutError and break event delivery. The built options must
+    # not carry a read timeout even when REDIS_SOCKET_TIMEOUT is configured.
+    monkeypatch.setattr(ext_socketio.dify_config, "REDIS_SOCKET_TIMEOUT", 5.0)
+
+    options = ext_socketio._build_redis_options("redis://redis.example.com:6379/0")
+
+    assert options["socket_timeout"] is None
+    # socket_connect_timeout only bounds the initial connect, not idle reads, so it stays.
+    assert "socket_connect_timeout" in options
+
+
 def test_build_redis_options_includes_tls_options_for_rediss(monkeypatch) -> None:
     monkeypatch.setattr(ext_socketio.dify_config, "REDIS_SSL_CERT_REQS", "CERT_REQUIRED")
     monkeypatch.setattr(ext_socketio.dify_config, "REDIS_SSL_CA_CERTS", "/ca.pem")


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #39423.

<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. -->

Workflow collaboration is non-functional on a stock install because the Socket.IO cross-worker pub/sub channel never delivers events.

`api/extensions/ext_socketio.py` → `_build_redis_options` passed `socket_timeout = REDIS_SOCKET_TIMEOUT` (default **5.0**) into `socketio.RedisManager`. That manager runs a **blocking** `pubsub.listen()` loop that stays idle until a message arrives; a read timeout makes idling impossible. After ~5s of silence the read raises `redis.exceptions.TimeoutError`, python-socketio catches it, logs `Cannot receive from redis... retrying in 1 secs`, resubscribes, and repeats forever — so events are never delivered.

**Fix.** Pin `socket_timeout` to `None` for the pub/sub manager. redis-py's default is already `None`, so this is behaviourally identical to omitting the key; making it explicit lets the accompanying comment document that a blocking listener must carry no read timeout, independent of `REDIS_SOCKET_TIMEOUT` (which stays correct for the non-blocking clients). `socket_connect_timeout` (connect-time only) is kept.

**Proof by elimination** — DNS, `REDIS_*` env, `ping()` on RESP2 and RESP3, and `subscribe()` all pass in both containers:

| Check | Result |
|---|---|
| DNS `getent hosts redis` (api / api_websocket) | identical → 172.22.0.6 |
| `REDIS_*` env in both | identical |
| `normalized_pubsub_redis_url` | `redis://:***@redis:6379/0` (password present) |
| `Redis.from_url(...).ping()` protocol 2 and 3 | both `True` |
| manager `pubsub.subscribe(channel)` | `subscribed ok, channel='socketio'` |

**Discriminating experiment.** With the shipped options, `pubsub.listen()` raises `TimeoutError: Timeout reading from redis:6379` after ~5s. With `socket_timeout=None`, the same listener blocks silently for >35s and then **receives a message published from a second connection**. Only that one option changed. After deploying the patch, the retry loop stops entirely — 60 lines in the 3 minutes before, 0 in the 45s+ after.

**Why this was hard to see.** python-socketio logs the real exception into `extra={"redis_exception": str(exc)}`, which Dify's log formatter does not render — so only the generic retry line is visible. That is why #39345 (same traceback, 1.16.0) was closed on the advice to check Redis settings; the credentials were never the problem. The log-rendering gap is a separate defect and is intentionally **not** bundled here.

**Test.** Extends `api/tests/unit_tests/extensions/test_ext_socketio.py` — asserts the pub/sub options carry no read timeout even when `REDIS_SOCKET_TIMEOUT` is set. Fails on the old code (`assert 5.0 is None`), passes with the fix.

**Related.** #39422 is a separate defect in the same container (divergent `SECRET_KEY` from a missing storage mount). Both independently block the workflow editor; the fixes are independent.

## Screenshots

| Before | After |
|--------|-------|
| `Cannot receive from redis... retrying` loops indefinitely; no Socket.IO event is delivered | Loop gone; listener blocks correctly and receives published messages |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Claude Code