### PR TITLE
fix(splitter): preserve spaces when recursive splitting on space separator with keep_separator=True

### DIFF
--- a/api/core/rag/splitter/fixed_text_splitter.py
+++ b/api/core/rag/splitter/fixed_text_splitter.py
@@ -4,12 +4,26 @@ from __future__ import annotations
 
 import codecs
 import re
-from collections.abc import Set as AbstractSet
+from collections.abc import Sequence, Set as AbstractSet
 from typing import Any, Literal, override
 
 from core.model_manager import ModelInstance
 from core.rag.splitter.text_splitter import RecursiveCharacterTextSplitter
 from graphon.model_runtime.model_providers.base.tokenizers.gpt2_tokenizer import GPT2Tokenizer
+
+
+def _reattach_trailing_separator(chunks: Sequence[str], trailing_separator: str) -> list[str]:
+    """Re-attach ``trailing_separator`` to all but the last merged chunk.
+
+    The base ``_join_docs`` strips outer whitespace from each merged chunk, which
+    silently drops the trailing space (or other separator) when ``keep_separator``
+    is True and the chunk came from a space-separated split. To keep the original
+    text reconstructable, we re-attach the requested trailing separator here.
+    Returns ``chunks`` unchanged when ``trailing_separator`` is empty.
+    """
+    if not trailing_separator or len(chunks) <= 1:
+        return list(chunks)
+    return [c + trailing_separator for c in chunks[:-1]] + [chunks[-1]]
 
 
 class EnhanceRecursiveCharacterTextSplitter(RecursiveCharacterTextSplitter):
@@ -88,7 +102,23 @@ class FixedRecursiveCharacterTextSplitter(EnhanceRecursiveCharacterTextSplitter)
         # Now that we have the separator, split the text
         if separator:
             if separator == " ":
-                splits = re.split(r" +", text)
+                if self._keep_separator:
+                    # Keep one space at the tail of every split except the last so the
+                    # original text can be reconstructed when the merges below use the
+                    # empty ``_separator``. ``str.split`` collapses runs of whitespace
+                    # into the splits, so we instead walk the source string and emit
+                    # a single trailing space at every position where one existed.
+                    splits: list[str] = []
+                    tail = text
+                    while True:
+                        idx = tail.find(" ")
+                        if idx == -1:
+                            splits.append(tail)
+                            break
+                        splits.append(tail[: idx + 1])
+                        tail = tail[idx + 1 :]
+                else:
+                    splits = re.split(r" +", text)
             else:
                 splits = text.split(separator)
                 if self._keep_separator:
@@ -102,6 +132,12 @@ class FixedRecursiveCharacterTextSplitter(EnhanceRecursiveCharacterTextSplitter)
         _good_splits = []
         _good_splits_lengths = []  # cache the lengths of the splits
         _separator = "" if self._keep_separator else separator
+        # When ``keep_separator`` is True we want to preserve the trailing
+        # separator on every merged chunk except the last so that concatenating
+        # the chunks reproduces the original text. The base ``_join_docs``
+        # strips outer whitespace, so we remember the requested trailing
+        # separator here and re-attach it after the merge below.
+        _trailing_separator = separator if self._keep_separator else ""
         s_lens = self._length_function(splits)
         if separator != "":
             for s, s_len in zip(splits, s_lens):
@@ -111,7 +147,7 @@ class FixedRecursiveCharacterTextSplitter(EnhanceRecursiveCharacterTextSplitter)
                 else:
                     if _good_splits:
                         merged_text = self._merge_splits(_good_splits, _separator, _good_splits_lengths)
-                        final_chunks.extend(merged_text)
+                        final_chunks.extend(_reattach_trailing_separator(merged_text, _trailing_separator))
                         _good_splits = []
                         _good_splits_lengths = []
                     if not new_separators:
@@ -122,7 +158,7 @@ class FixedRecursiveCharacterTextSplitter(EnhanceRecursiveCharacterTextSplitter)
 
             if _good_splits:
                 merged_text = self._merge_splits(_good_splits, _separator, _good_splits_lengths)
-                final_chunks.extend(merged_text)
+                final_chunks.extend(_reattach_trailing_separator(merged_text, _trailing_separator))
         else:
             current_part = ""
             current_length = 0

--- a/api/core/rag/splitter/fixed_text_splitter.py
+++ b/api/core/rag/splitter/fixed_text_splitter.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import codecs
 import re
-from collections.abc import Sequence, Set as AbstractSet
+from collections.abc import Sequence
+from collections.abc import Set as AbstractSet
 from typing import Any, Literal, override
 
 from core.model_manager import ModelInstance

--- a/api/tests/unit_tests/core/rag/splitter/test_text_splitter.py
+++ b/api/tests/unit_tests/core/rag/splitter/test_text_splitter.py
@@ -1090,6 +1090,96 @@ class TestFixedRecursiveCharacterTextSplitter:
         assert "aa" in chunks
         assert any(len(chunk) >= 40 for chunk in chunks)
 
+    # ------------------------------------------------------------------
+    # Regression tests for #39403
+    # `FixedRecursiveCharacterTextSplitter.recursive_split_text` was dropping
+    # whitespace between words when ``keep_separator=True`` selected the
+    # ``" "`` separator. The splits already excluded the spaces (via
+    # ``re.split(r" +", text)``) and the base ``_join_docs`` strips outer
+    # whitespace, so concatenating the resulting chunks no longer reproduced
+    # the original text. The fix re-attaches a single space to every chunk
+    # except the last so ``"".join(chunks) == text``.
+    # ------------------------------------------------------------------
+
+    def test_keep_separator_space_preserves_spaces_korean(self):
+        """Korean paragraph (issue #39403 repro) joins back to original text."""
+        text = "여름철에는 항상 기상상황에 주목하며 주변 사람들과 함께 정보를 공유합니다."
+        splitter = FixedRecursiveCharacterTextSplitter(
+            fixed_separator="\n\n",
+            chunk_size=20,
+            chunk_overlap=0,
+            keep_separator=True,
+        )
+
+        result = splitter.split_text(text)
+
+        assert len(result) > 1, "expected recursive split to produce multiple chunks"
+        # The original text must be exactly reconstructable by concatenating the
+        # chunks — i.e., spaces are preserved on every non-final chunk boundary.
+        assert "".join(result) == text
+
+    def test_keep_separator_space_preserves_spaces_english(self):
+        """English paragraph reconstructs cleanly under keep_separator=True + small chunk_size."""
+        text = "The quick brown fox jumps over the lazy dog"
+        splitter = FixedRecursiveCharacterTextSplitter(
+            fixed_separator="\n\n",
+            chunk_size=15,
+            chunk_overlap=0,
+            keep_separator=True,
+        )
+
+        result = splitter.split_text(text)
+
+        assert len(result) > 1
+        assert "".join(result) == text
+
+    def test_keep_separator_false_unaffected_by_fix(self):
+        """When keep_separator=False, spaces are dropped exactly as before (issue #39403 unchanged behavior)."""
+        text = "여름철에는 항상 기상상황에 주목하며 주변 사람들과 함께 정보를 공유합니다."
+        splitter = FixedRecursiveCharacterTextSplitter(
+            fixed_separator="\n\n",
+            chunk_size=20,
+            chunk_overlap=0,
+            keep_separator=False,
+        )
+
+        result = splitter.split_text(text)
+
+        # No trailing-space char on any chunk
+        for chunk in result:
+            assert not chunk.endswith(" "), f"chunk {chunk!r} should not end with a space when keep_separator=False"
+        # Joining with " " still reconstructs the original because spaces are the joiner
+        assert " ".join(result) == text
+
+    def test_keep_separator_space_single_chunk_unchanged(self):
+        """Text shorter than chunk_size + keep_separator=True returns the text unchanged."""
+        text = "short text"
+        splitter = FixedRecursiveCharacterTextSplitter(
+            fixed_separator="\n\n",
+            chunk_size=100,
+            chunk_overlap=0,
+            keep_separator=True,
+        )
+
+        result = splitter.split_text(text)
+
+        assert result == [text]
+
+    def test_keep_separator_space_does_not_double_space(self):
+        """Fix must not append a trailing space to the LAST chunk (would produce a dangling space)."""
+        text = "alpha beta gamma"
+        splitter = FixedRecursiveCharacterTextSplitter(
+            fixed_separator="\n\n",
+            chunk_size=8,
+            chunk_overlap=0,
+            keep_separator=True,
+        )
+
+        result = splitter.split_text(text)
+
+        assert "".join(result) == text
+        assert result[-1] == result[-1].rstrip(), "last chunk must not carry a trailing space"
+
 
 # ============================================================================
 # Test Metadata Preservation


### PR DESCRIPTION
Fixes langgenius/dify#39403.

## Problem

`FixedRecursiveCharacterTextSplitter.recursive_split_text` was dropping whitespace between words when `keep_separator=True` selected the `" "` separator. After splitting with `re.split(r" +", text)` (which silently strips the spaces) and the base `_join_docs` then stripping outer whitespace from each merged chunk, concatenating the chunks no longer reproduced the original text.

## Repro (from the issue)

```python
text = "여름철에는 항상 기상상황에 주목하며 주변 사람들과 함께 정보를 공유합니다."
splitter = FixedRecursiveCharacterTextSplitter(
    fixed_separator="\n\n", chunk_size=20, chunk_overlap=0, keep_separator=True,
)
result = splitter.split_text(text)
assert "".join(result) == text  # FAILS — joins to text without spaces
```

## Fix

1. In the `separator == " "` branch, when `keep_separator=True`, walk the source string and emit one trailing space on every split except the last so the merged chunks carry the inter-word whitespace.
2. After `_merge_splits`, re-attach the trailing separator to all but the last chunk to compensate for `_join_docs`'s outer-whitespace strip.

`keep_separator=False` and other separator branches are untouched.

## Tests added

In `TestFixedRecursiveCharacterTextSplitter`:

- `test_keep_separator_space_preserves_spaces_korean` — exact repro from the issue.
- `test_keep_separator_space_preserves_spaces_english` — English paragraph reconstructs cleanly under small chunk_size.
- `test_keep_separator_false_unaffected_by_fix` — unchanged behavior when `keep_separator=False`.
- `test_keep_separator_space_single_chunk_unchanged` — short text (no recursive split) returns the text unchanged.
- `test_keep_separator_space_does_not_double_space` — last chunk must not carry a trailing space.

## Verification

- Full `tests/unit_tests/core/rag/splitter/` suite: 109 passed, 4 skipped, 0 regressions.
- Related `tests/unit_tests/core/rag/indexing/test_index_processor_base.py`: 15 passed.
- Sanity-checked the tests: 3 of the 5 new tests fail on pre-fix code (the 2 that exercise `keep_separator=False` and the single-chunk path correctly pass on both).

Made with [Cursor](https://cursor.com)