### PR TITLE
fix(web): skip incompatible alias in Storybook

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -67,10 +67,12 @@ export default defineConfig(({ mode }) => {
     }),
     resolve: {
       tsconfigPaths: true,
-      alias: [
-        // Use the base64 build in Vite-based pipelines (vinext/vitest) to avoid wasm loader incompatibilities.
-        { find: /^loro-crdt$/, replacement: 'loro-crdt/base64' },
-      ],
+      alias: isStorybook
+        ? []
+        : [
+            // Use the base64 build in vinext/vitest to avoid wasm loader incompatibilities.
+            { find: /^loro-crdt$/, replacement: 'loro-crdt/base64' },
+          ],
     },
 
     // vinext related config


### PR DESCRIPTION
## Summary

- Skip the regex-based `loro-crdt` alias when Vite runs under Storybook, avoiding Rolldown's `ViteAlias` conversion failure.
- Keep the base64 alias for vinext and Vitest, where it is still needed to avoid WASM loader incompatibilities.
- Let Storybook bundle Loro's standard WASM build; the existing PostCSS pipeline continues to process the shared Tailwind styles correctly.

Fixes #38527

## Screenshots

Not applicable. This is a build configuration fix; the Storybook preview was verified in the browser after the build passed.

## Testing

- `pnpm --dir web storybook:build`
- `vp check web/vite.config.ts`
- Full Vite+ check (no errors; existing warnings only)
- ESLint
- `web/node_modules/.bin/tsslint --project web/tsconfig.json` (5,912 passed)
- Storybook dev browser verification: `ActionButton` rendered with its expected Tailwind styles (`24px` by `24px`, `inline-flex`)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs) (not required for this build configuration fix)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] The change is atomic and was regression-tested with a full static Storybook build.
- [x] Documentation is not required for this build configuration fix.
- [x] I ran the relevant frontend Vite+, ESLint, and TypeScript checks.

From Codex
