### PR TITLE
fix(rag): preserve spaces when recursive-splitting on the space separator

### DIFF
--- a/api/core/rag/splitter/fixed_text_splitter.py
+++ b/api/core/rag/splitter/fixed_text_splitter.py
@@ -101,7 +101,14 @@ class FixedRecursiveCharacterTextSplitter(EnhanceRecursiveCharacterTextSplitter)
             splits = [s for s in splits if (s not in {"", "\n"})]
         _good_splits = []
         _good_splits_lengths = []  # cache the lengths of the splits
-        _separator = "" if self._keep_separator else separator
+        # The " " separator uses `re.split(r" +", text)` above, which discards the
+        # spaces rather than re-appending them (unlike the keep_separator append
+        # path for other separators). So the spaces must be reinserted when merging
+        # the splits back together; pass the real separator to `_merge_splits`.
+        if self._keep_separator and separator == " ":
+            _separator = " "
+        else:
+            _separator = "" if self._keep_separator else separator
         s_lens = self._length_function(splits)
         if separator != "":
             for s, s_len in zip(splits, s_lens):

--- a/api/tests/unit_tests/core/rag/splitter/test_text_splitter.py
+++ b/api/tests/unit_tests/core/rag/splitter/test_text_splitter.py
@@ -952,6 +952,26 @@ class TestFixedRecursiveCharacterTextSplitter:
         assert "word1" in combined
         assert "word2" in combined
 
+    def test_recursive_space_split_preserves_spaces(self):
+        """Regression test: recursive splitting on " " must keep spaces between words.
+
+        Previously, when a chunk exceeded `chunk_size` and was recursively split on
+        the " " separator, the spaces were dropped and words were concatenated
+        (e.g. "word1word2" instead of "word1 word2"). See issue #39403.
+        """
+        text = " ".join([f"word{i}" for i in range(10)])
+        splitter = FixedRecursiveCharacterTextSplitter(
+            fixed_separator="\n\n", chunk_size=30, chunk_overlap=5
+        )
+
+        result = splitter.split_text(text)
+
+        # The text exceeds the chunk size, so recursive splitting on " " is triggered.
+        assert len(result) > 1
+        # Every chunk must contain at least one space (words are not glued together).
+        for chunk in result:
+            assert " " in chunk, f"Spaces were dropped from chunk: {chunk!r}"
+
     def test_character_level_splitting(self):
         """Test character-level splitting when no separator works."""
         text = "verylongwordwithoutspaces"

--- a/api/tests/unit_tests/core/rag/splitter/test_text_splitter.py
+++ b/api/tests/unit_tests/core/rag/splitter/test_text_splitter.py
@@ -960,9 +960,7 @@ class TestFixedRecursiveCharacterTextSplitter:
         (e.g. "word1word2" instead of "word1 word2"). See issue #39403.
         """
         text = " ".join([f"word{i}" for i in range(10)])
-        splitter = FixedRecursiveCharacterTextSplitter(
-            fixed_separator="\n\n", chunk_size=30, chunk_overlap=5
-        )
+        splitter = FixedRecursiveCharacterTextSplitter(fixed_separator="\n\n", chunk_size=30, chunk_overlap=5)
 
         result = splitter.split_text(text)
 


### PR DESCRIPTION
When a chunk larger than chunk_size is recursively split on the space separator, the spaces between words were being dropped, so adjacent words got concatenated ('word1word2' instead of 'word1 word2'). This affects CJK and Korean text with normal inter-word spaces, and any language once a paragraph exceeds the chunk size and the splitter falls through the separator hierarchy to ' '.

The root cause is in FixedRecursiveCharacterTextSplitter.recursive_split_text: the ' ' separator uses re.split(r' +', text), which discards the spaces. The keep_separator logic then passes an empty separator to _merge_splits, assuming the separator was already re-appended — but the re.split path never re-appends it, so _join_docs joins the words with no spaces.

The fix passes the real ' ' separator to _merge_splits for the space case, so spaces are reinserted when chunks are merged back together. Other separators are unaffected since they go through the append path that does preserve the separator. Added a regression test (test_recursive_space_split_preserves_spaces) that splits space-delimited text exceeding chunk_size and asserts every output chunk contains spaces.

Closes #39403