### PR TITLE
fix(dify-ui): preserve link semantics in button story

### DIFF
--- a/packages/dify-ui/src/button/index.stories.tsx
+++ b/packages/dify-ui/src/button/index.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import * as React from 'react'
 import { expect, fn } from 'storybook/test'
-import { Button } from '.'
+import { Button, buttonVariants } from '.'
 
 const meta = {
   title: 'Base/UI/Button',
@@ -151,11 +151,24 @@ export const LargeSize: Story = {
   },
 }
 
-export const AsLink: Story = {
-  args: {
-    variant: 'ghost-accent',
-    render: <a href="https://example.com" />,
-    nativeButton: false,
-    children: 'Link Button',
+export const StyledLink: Story = {
+  render: () => (
+    <a className={buttonVariants({ variant: 'ghost-accent' })} href="https://example.com">
+      Link styled as a button
+    </a>
+  ),
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('link', { name: 'Link styled as a button' })).toHaveAttribute(
+      'href',
+      'https://example.com',
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Rendering an anchor through `Button` is an anti-pattern because Base UI enforces button semantics. Keep the native link and apply `buttonVariants` directly when a link needs button styling. See the [Base UI Button usage guidelines](https://base-ui.com/react/components/button#rendering-links-as-buttons).',
+      },
+    },
   },
 }

--- a/packages/dify-ui/src/button/index.tsx
+++ b/packages/dify-ui/src/button/index.tsx
@@ -6,7 +6,7 @@ import { Button as BaseButton } from '@base-ui/react/button'
 import { cva } from 'class-variance-authority'
 import { cn } from '../cn'
 
-const buttonVariants = cva(
+export const buttonVariants = cva(
   'inline-flex cursor-pointer items-center justify-center whitespace-nowrap outline-hidden focus-visible:ring-2 focus-visible:ring-state-accent-solid data-[disabled]:cursor-not-allowed',
   {
     variants: {


### PR DESCRIPTION
## Summary

- export `buttonVariants` so links can reuse Button presentation without inheriting button behavior
- replace the polymorphic anchor Story with a native `<a>` styled by `buttonVariants`
- document why rendering an anchor through Base UI Button is an anti-pattern
- assert the Story retains the implicit `link` role and `href`

## Why

Base UI Button enforces button semantics, including `role="button"`, keyboard interaction, and disabled behavior. Anchors already own navigation semantics and should be styled directly when they need a button appearance.

Reference: https://base-ui.com/react/components/button#rendering-links-as-buttons

## Verification

- `vp check packages/dify-ui/src/button/index.tsx packages/dify-ui/src/button/index.stories.tsx`
- `vp test run --project unit src/button/__tests__/index.spec.tsx`
- `pnpm -C packages/dify-ui type-check`
- `vp test --project storybook --run` (35 files, 195 tests)