### PR TITLE
fix(workflow): hide Agent V2 in chatflow

### DIFF
--- a/web/app/components/workflow-app/hooks/__tests__/use-available-nodes-meta-data.spec.ts
+++ b/web/app/components/workflow-app/hooks/__tests__/use-available-nodes-meta-data.spec.ts
@@ -40,6 +40,18 @@ describe('useAvailableNodesMetaData', () => {
     )
   })
 
+  it('should expose legacy Agent instead of Agent v2 in chat mode when Agent v2 is enabled', () => {
+    mockUseIsChatMode.mockReturnValue(true)
+
+    const { result } = renderHook(() => useAvailableNodesMetaData())
+    const nodeTypes = result.current.nodes.map((node) => node.metaData.type)
+
+    expect(nodeTypes).toContain(BlockEnum.Agent)
+    expect(nodeTypes).not.toContain(BlockEnum.AgentV2)
+    expect(result.current.nodesMap?.[BlockEnum.Agent]).toBeDefined()
+    expect(result.current.nodesMap?.[BlockEnum.AgentV2]).toBeUndefined()
+  })
+
   it('should include workflow-specific trigger and end nodes outside chat mode', () => {
     mockUseIsChatMode.mockReturnValue(false)
 

--- a/web/app/components/workflow-app/hooks/use-available-nodes-meta-data.ts
+++ b/web/app/components/workflow-app/hooks/use-available-nodes-meta-data.ts
@@ -31,6 +31,7 @@ export const useAvailableNodesMetaData = () => {
   const isChatMode = useIsChatMode()
   const docLink = useDocLink()
   const agentV2Enabled = isAgentV2Enabled()
+  const shouldUseAgentV2 = agentV2Enabled && !isChatMode
 
   const startNodeMetaData = useMemo(
     () => ({
@@ -45,7 +46,7 @@ export const useAvailableNodesMetaData = () => {
 
   const mergedNodesMetaData = useMemo(() => {
     const commonNodes = WORKFLOW_COMMON_NODES.filter((node) =>
-      agentV2Enabled
+      shouldUseAgentV2
         ? node.metaData.type !== BlockEnum.Agent
         : node.metaData.type !== BlockEnum.AgentV2,
     )
@@ -63,7 +64,7 @@ export const useAvailableNodesMetaData = () => {
             TriggerPluginDefault,
           ]),
     ]
-  }, [agentV2Enabled, isChatMode, startNodeMetaData])
+  }, [isChatMode, shouldUseAgentV2, startNodeMetaData])
 
   const availableNodesMetaData = useMemo(
     () =>


### PR DESCRIPTION
## Summary

- keep the legacy Agent node available in Chatflow when Agent V2 is enabled
- keep Agent V2 available in Workflow without changing global navigation or route gating
- cover both the node list and node metadata map with a focused regression test

## Why

Agent V2 does not yet support conversation-level memory in Chatflow. The existing node-version mutual exclusion only considered the global feature flag, so enabling Agent V2 also exposed it in Chatflow.

## Validation

- `vp test run app/components/workflow-app/hooks/__tests__/use-available-nodes-meta-data.spec.ts`
- `vp check web/app/components/workflow-app/hooks/use-available-nodes-meta-data.ts web/app/components/workflow-app/hooks/__tests__/use-available-nodes-meta-data.spec.ts`
- `pnpm check`
- `pnpm --dir web lint:tss`

Fixes DIFY-2827