### PR TITLE
fix: fix mcp output_schema is optional

### DIFF
--- a/api/core/tools/mcp_tool/tool.py
+++ b/api/core/tools/mcp_tool/tool.py
@@ -103,8 +103,8 @@ class MCPTool(Tool):
                 case _:
                     logger.warning("Unsupported content type=%s", type(content))
 
-        # handle MCP structured output
-        if self.entity.output_schema and result.structuredContent:
+        # outputSchema is optional in MCP, so preserve structuredContent even when no schema was declared.
+        if result.structuredContent:
             for k, v in result.structuredContent.items():
                 yield self.create_variable_message(k, v)
 

--- a/api/core/tools/mcp_tool/tool.py
+++ b/api/core/tools/mcp_tool/tool.py
@@ -103,10 +103,12 @@ class MCPTool(Tool):
                 case _:
                     logger.warning("Unsupported content type=%s", type(content))
 
-        # outputSchema is optional in MCP, so preserve structuredContent even when no schema was declared.
-        if result.structuredContent:
+        # handle MCP structured output
+        if self.entity.output_schema and result.structuredContent:
             for k, v in result.structuredContent.items():
                 yield self.create_variable_message(k, v)
+        elif result.structuredContent:
+            yield self.create_json_message(result.structuredContent)
 
     def _process_text_content(self, content: TextContent) -> Generator[ToolInvokeMessage, None, None]:
         """Process text content and yield appropriate messages."""

--- a/api/tests/unit_tests/tools/test_mcp_tool.py
+++ b/api/tests/unit_tests/tools/test_mcp_tool.py
@@ -135,6 +135,18 @@ class TestMCPToolInvoke:
         values = {m.message.variable_name: m.message.variable_value for m in var_msgs}
         assert values == {"a": 1, "b": "x"}
 
+    def test_invoke_yields_variables_when_structured_content_has_no_output_schema(self, orm_session: Session) -> None:
+        tool = _make_mcp_tool()
+        result = CallToolResult(content=[], structuredContent={"a": 1, "b": "x"})
+
+        with patch.object(tool, "invoke_remote_mcp_tool", return_value=result):
+            messages = list(tool._invoke(session=orm_session, user_id="test_user", tool_parameters={}))
+
+        variable_messages = [
+            message.message for message in messages if isinstance(message.message, ToolInvokeMessage.VariableMessage)
+        ]
+        assert {message.variable_name: message.variable_value for message in variable_messages} == {"a": 1, "b": "x"}
+
 
 class TestMCPToolUsageExtraction:
     """Test usage metadata extraction from MCP tool results."""

--- a/api/tests/unit_tests/tools/test_mcp_tool.py
+++ b/api/tests/unit_tests/tools/test_mcp_tool.py
@@ -135,17 +135,18 @@ class TestMCPToolInvoke:
         values = {m.message.variable_name: m.message.variable_value for m in var_msgs}
         assert values == {"a": 1, "b": "x"}
 
-    def test_invoke_yields_variables_when_structured_content_has_no_output_schema(self, orm_session: Session) -> None:
+    def test_invoke_yields_json_when_structured_content_has_no_output_schema(self, orm_session: Session) -> None:
         tool = _make_mcp_tool()
         result = CallToolResult(content=[], structuredContent={"a": 1, "b": "x"})
 
         with patch.object(tool, "invoke_remote_mcp_tool", return_value=result):
             messages = list(tool._invoke(session=orm_session, user_id="test_user", tool_parameters={}))
 
-        variable_messages = [
-            message.message for message in messages if isinstance(message.message, ToolInvokeMessage.VariableMessage)
-        ]
-        assert {message.variable_name: message.variable_value for message in variable_messages} == {"a": 1, "b": "x"}
+        assert len(messages) == 1
+        msg = messages[0]
+        assert msg.type == ToolInvokeMessage.MessageType.JSON
+        assert isinstance(msg.message, ToolInvokeMessage.JsonMessage)
+        assert msg.message.json_object == {"a": 1, "b": "x"}
 
 
 class TestMCPToolUsageExtraction:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #39418

Now the `structuredOutput` goes into json output if the schema is not defined.

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
