### PR TITLE
fix(tts): stabilize automatic TTS playback across app modes

### DIFF
--- a/api/core/app/apps/advanced_chat/generate_task_pipeline.py
+++ b/api/core/app/apps/advanced_chat/generate_task_pipeline.py
@@ -64,6 +64,7 @@ from core.app.entities.task_entities import (
     MessageEndStreamResponse,
     PingStreamResponse,
     ReasoningChunkStreamResponse,
+    StreamEvent,
     StreamResponse,
     WorkflowPauseStreamResponse,
     WorkflowTaskState,
@@ -367,6 +368,8 @@ class AdvancedChatAppGenerateTaskPipeline(GraphRuntimeStateSupport):
                 tenant_id, features_dict["text_to_speech"].get("voice"), features_dict["text_to_speech"].get("language")
             )
 
+        workflow_finished_response: StreamResponse | None = None
+        workflow_error_response: StreamResponse | None = None
         for response in self._process_stream_response(tts_publisher=tts_publisher, trace_manager=trace_manager):
             while True:
                 audio_response = self._listen_audio_msg(publisher=tts_publisher, task_id=task_id)
@@ -374,7 +377,12 @@ class AdvancedChatAppGenerateTaskPipeline(GraphRuntimeStateSupport):
                     yield audio_response
                 else:
                     break
-            yield response
+            if tts_publisher and self._base_task_pipeline.stream and response.event == StreamEvent.WORKFLOW_FINISHED:
+                workflow_finished_response = response
+            elif workflow_finished_response is not None and response.event == StreamEvent.ERROR:
+                workflow_error_response = response
+            else:
+                yield response
 
         start_listener_time = time.time()
         while (time.time() - start_listener_time) < TTS_AUTO_PLAY_TIMEOUT:
@@ -395,6 +403,10 @@ class AdvancedChatAppGenerateTaskPipeline(GraphRuntimeStateSupport):
                 break
         if tts_publisher:
             yield MessageAudioEndStreamResponse(audio="", task_id=task_id)
+        if workflow_finished_response is not None:
+            yield workflow_finished_response
+        if workflow_error_response is not None:
+            yield workflow_error_response
 
     @contextmanager
     def _database_session(self):

--- a/api/core/app/apps/workflow/generate_task_pipeline.py
+++ b/api/core/app/apps/workflow/generate_task_pipeline.py
@@ -49,6 +49,7 @@ from core.app.entities.task_entities import (
     MessageAudioStreamResponse,
     PingStreamResponse,
     ReasoningChunkStreamResponse,
+    StreamEvent,
     StreamResponse,
     TextChunkStreamResponse,
     WorkflowAppBlockingResponse,
@@ -267,6 +268,7 @@ class WorkflowAppGenerateTaskPipeline(GraphRuntimeStateSupport):
                 tenant_id, features_dict["text_to_speech"].get("voice"), features_dict["text_to_speech"].get("language")
             )
 
+        workflow_finished_response: StreamResponse | None = None
         for response in self._process_stream_response(tts_publisher=tts_publisher, trace_manager=trace_manager):
             while True:
                 audio_response = self._listen_audio_msg(publisher=tts_publisher, task_id=task_id)
@@ -274,7 +276,10 @@ class WorkflowAppGenerateTaskPipeline(GraphRuntimeStateSupport):
                     yield audio_response
                 else:
                     break
-            yield response
+            if tts_publisher and self._base_task_pipeline.stream and response.event == StreamEvent.WORKFLOW_FINISHED:
+                workflow_finished_response = response
+            else:
+                yield response
 
         start_listener_time = time.time()
         while (time.time() - start_listener_time) < TTS_AUTO_PLAY_TIMEOUT:
@@ -290,12 +295,15 @@ class WorkflowAppGenerateTaskPipeline(GraphRuntimeStateSupport):
                 if audio_trunk.status == "finish":
                     break
                 else:
+                    start_listener_time = time.time()
                     yield MessageAudioStreamResponse(audio=audio_trunk.audio, task_id=task_id)
             except Exception:
                 logger.exception("Fails to get audio trunk, task_id: %s", task_id)
                 break
         if tts_publisher:
             yield MessageAudioEndStreamResponse(audio="", task_id=task_id)
+        if workflow_finished_response is not None:
+            yield workflow_finished_response
 
     @contextmanager
     def _database_session(self):

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py
@@ -45,10 +45,12 @@ from core.app.entities.task_entities import (
     AnnotationReply,
     AnnotationReplyAccount,
     HumanInputRequiredResponse,
+    MessageAudioEndStreamResponse,
     MessageAudioStreamResponse,
     MessageEndStreamResponse,
     PingStreamResponse,
     ReasoningChunkStreamResponse,
+    StreamEvent,
 )
 from core.base.tts.app_generator_tts_publisher import AudioTrunk
 from core.workflow.nodes.human_input.entities import UserActionConfig
@@ -278,6 +280,66 @@ class TestAdvancedChatGenerateTaskPipeline:
         response = pipeline._listen_audio_msg(publisher=publisher, task_id="task")
 
         assert isinstance(response, MessageAudioStreamResponse)
+
+    def test_wrapper_process_stream_response_emits_workflow_finished_after_audio_end(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        pipeline = _make_pipeline()
+        pipeline._base_task_pipeline.stream = True
+        pipeline._workflow_features_dict = {
+            "text_to_speech": {"enabled": True, "autoPlay": "enabled", "voice": "v", "language": "en"}
+        }
+        workflow_finished = SimpleNamespace(event=StreamEvent.WORKFLOW_FINISHED)
+        pipeline._process_stream_response = lambda **kwargs: iter([workflow_finished])
+
+        class _Publisher:
+            def __init__(self, *args, **kwargs):
+                self.audio = iter(
+                    [AudioTrunk(status="stream", audio="data"), None, AudioTrunk(status="finish", audio="")]
+                )
+
+            def check_and_get_audio(self):
+                return next(self.audio)
+
+        monkeypatch.setattr(
+            "core.app.apps.advanced_chat.generate_task_pipeline.AppGeneratorTTSPublisher",
+            _Publisher,
+        )
+
+        responses = list(pipeline._wrapper_process_stream_response())
+
+        assert isinstance(responses[-2], MessageAudioEndStreamResponse)
+        assert responses[-1] is workflow_finished
+
+    def test_wrapper_process_stream_response_preserves_failed_workflow_event_order(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        pipeline = _make_pipeline()
+        pipeline._base_task_pipeline.stream = True
+        pipeline._workflow_features_dict = {
+            "text_to_speech": {"enabled": True, "autoPlay": "enabled", "voice": "v", "language": "en"}
+        }
+        workflow_finished = SimpleNamespace(event=StreamEvent.WORKFLOW_FINISHED)
+        error = SimpleNamespace(event=StreamEvent.ERROR)
+        pipeline._process_stream_response = lambda **kwargs: iter([workflow_finished, error])
+
+        class _Publisher:
+            def __init__(self, *args, **kwargs):
+                self.audio = iter([None, None, AudioTrunk(status="finish", audio="")])
+
+            def check_and_get_audio(self):
+                return next(self.audio)
+
+        monkeypatch.setattr(
+            "core.app.apps.advanced_chat.generate_task_pipeline.AppGeneratorTTSPublisher",
+            _Publisher,
+        )
+
+        responses = list(pipeline._wrapper_process_stream_response())
+
+        assert isinstance(responses[-3], MessageAudioEndStreamResponse)
+        assert responses[-2] is workflow_finished
+        assert responses[-1] is error
 
     def test_handle_ping_event(self):
         pipeline = _make_pipeline()

--- a/api/tests/unit_tests/core/app/apps/workflow/test_generate_task_pipeline_core.py
+++ b/api/tests/unit_tests/core/app/apps/workflow/test_generate_task_pipeline_core.py
@@ -43,6 +43,7 @@ from core.app.entities.task_entities import (
     MessageAudioStreamResponse,
     PingStreamResponse,
     ReasoningChunkStreamResponse,
+    StreamEvent,
     WorkflowAppPausedBlockingResponse,
     WorkflowFinishStreamResponse,
     WorkflowStartStreamResponse,
@@ -483,6 +484,36 @@ class TestWorkflowGenerateTaskPipeline:
         assert any(isinstance(item, MessageAudioStreamResponse) for item in responses)
         assert any(isinstance(item, MessageAudioEndStreamResponse) for item in responses)
 
+    def test_wrapper_process_stream_response_emits_workflow_finished_after_audio_end(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        pipeline = _make_pipeline()
+        pipeline._base_task_pipeline.stream = True
+        pipeline._workflow_features_dict = {
+            "text_to_speech": {"enabled": True, "autoPlay": "enabled", "voice": "v", "language": "en"}
+        }
+        workflow_finished = SimpleNamespace(event=StreamEvent.WORKFLOW_FINISHED)
+        pipeline._process_stream_response = lambda **kwargs: iter([workflow_finished])
+
+        class _Publisher:
+            def __init__(self, *args, **kwargs):
+                self.audio = iter(
+                    [AudioTrunk(status="stream", audio="data"), None, AudioTrunk(status="finish", audio="")]
+                )
+
+            def check_and_get_audio(self):
+                return next(self.audio)
+
+        monkeypatch.setattr(
+            "core.app.apps.workflow.generate_task_pipeline.AppGeneratorTTSPublisher",
+            _Publisher,
+        )
+
+        responses = list(pipeline._wrapper_process_stream_response())
+
+        assert isinstance(responses[-2], MessageAudioEndStreamResponse)
+        assert responses[-1] is workflow_finished
+
     def test_init_with_end_user_sets_role_and_system_user(self):
         app_config = WorkflowUIBasedAppConfig(
             tenant_id="tenant",
@@ -638,6 +669,40 @@ class TestWorkflowGenerateTaskPipeline:
         responses = list(pipeline._wrapper_process_stream_response())
 
         assert sleep_spy
+        assert any(isinstance(item, MessageAudioEndStreamResponse) for item in responses)
+
+    def test_wrapper_process_stream_response_resets_idle_timeout_after_audio_chunk(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        pipeline = _make_pipeline()
+        pipeline._workflow_features_dict = {
+            "text_to_speech": {"enabled": True, "autoPlay": "enabled", "voice": "v", "language": "en"}
+        }
+        pipeline._process_stream_response = lambda **kwargs: iter([])
+
+        class _Publisher:
+            calls = 0
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def check_and_get_audio(self):
+                _Publisher.calls += 1
+                if _Publisher.calls == 1:
+                    return AudioTrunk(status="stream", audio="data")
+                return AudioTrunk(status="finish", audio="")
+
+        time_values = iter([0.0, 4.9, 4.9, 9.8])
+        monkeypatch.setattr("core.app.apps.workflow.generate_task_pipeline.time.time", lambda: next(time_values))
+        monkeypatch.setattr(
+            "core.app.apps.workflow.generate_task_pipeline.AppGeneratorTTSPublisher",
+            _Publisher,
+        )
+
+        responses = list(pipeline._wrapper_process_stream_response())
+
+        assert _Publisher.calls == 2
+        assert any(isinstance(item, MessageAudioStreamResponse) for item in responses)
         assert any(isinstance(item, MessageAudioEndStreamResponse) for item in responses)
 
     def test_wrapper_process_stream_response_handles_audio_exception(

--- a/web/app/components/app/configuration/debug/index.tsx
+++ b/web/app/components/app/configuration/debug/index.tsx
@@ -2,6 +2,7 @@
 import type { FC } from 'react'
 import type { DebugWithSingleModelRefType } from './debug-with-single-model'
 import type { ModelAndParameter } from './types'
+import type AudioPlayer from '@/app/components/base/audio-btn/audio'
 import type { ModelParameterModalProps } from '@/app/components/header/account-setting/model-provider-page/model-parameter-modal'
 import type { Inputs } from '@/models/debug'
 import type { ModelConfig as BackendModelConfig, VisionFile, VisionSettings } from '@/types/app'
@@ -17,6 +18,7 @@ import * as React from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useContext } from 'use-context-selector'
+import { v4 as uuidV4 } from 'uuid'
 import { useShallow } from 'zustand/react/shallow'
 import ChatUserInput from '@/app/components/app/configuration/debug/chat-user-input'
 import PromptValuePanel from '@/app/components/app/configuration/prompt-value-panel'
@@ -24,6 +26,7 @@ import { useStore as useAppStore } from '@/app/components/app/store'
 import TextGeneration from '@/app/components/app/text-generate/item'
 import ActionButton, { ActionButtonState } from '@/app/components/base/action-button'
 import AgentLogModal from '@/app/components/base/agent-log-modal'
+import { AudioPlayerManager } from '@/app/components/base/audio-btn/audio.player.manager'
 import { useFeatures, useFeaturesStore } from '@/app/components/base/features/hooks'
 import { RefreshCcw01 } from '@/app/components/base/icons/src/vender/line/arrows'
 import PromptLogModal from '@/app/components/base/prompt-log-modal'
@@ -38,7 +41,7 @@ import { useEventEmitterContextContext } from '@/context/event-emitter'
 import { useProviderContext } from '@/context/provider-context'
 import { sendCompletionMessage } from '@/service/debug'
 import { AppSourceType } from '@/service/share'
-import { AppModeEnum, ModelModeType, TransferMethod } from '@/types/app'
+import { AppModeEnum, ModelModeType, TransferMethod, TtsAutoPlay } from '@/types/app'
 import { formatBooleanInputs, promptVariablesToUserInputsForm } from '@/utils/model-config'
 import GroupName from '../base/group-name'
 import CannotQueryDataset from '../base/warning-mask/cannot-query-dataset'
@@ -206,8 +209,17 @@ const Debug: FC<IDebug> = ({
 
   const [completionRes, setCompletionRes] = useState('')
   const [messageId, setMessageId] = useState<string | null>(null)
+  const autoTTSPlayerRef = useRef<AudioPlayer | null>(null)
+  const completionAbortControllerRef = useRef<AbortController | null>(null)
   const features = useFeatures((s) => s.features)
   const featuresStore = useFeaturesStore()
+
+  useEffect(() => {
+    return () => {
+      completionAbortControllerRef.current?.abort()
+      AudioPlayerManager.getInstance().destroyAutoPlayAudioPlayer(autoTTSPlayerRef.current)
+    }
+  }, [])
 
   const sendTextCompletion = async () => {
     if (isResponding) {
@@ -221,6 +233,32 @@ const Debug: FC<IDebug> = ({
     }
 
     if (!checkCanSend()) return
+
+    AudioPlayerManager.getInstance().destroyAutoPlayAudioPlayer(autoTTSPlayerRef.current)
+    autoTTSPlayerRef.current = null
+    let player: AudioPlayer | null = null
+    const getOrCreatePlayer = () => {
+      if (!player) {
+        player = AudioPlayerManager.getInstance().getAutoPlayAudioPlayer(
+          `/apps/${appId}/text-to-audio`,
+          false,
+          uuidV4(),
+          'none',
+          'none',
+          null,
+        )
+        autoTTSPlayerRef.current = player
+      }
+
+      return player
+    }
+    const destroyPlayer = () => {
+      AudioPlayerManager.getInstance().destroyAutoPlayAudioPlayer(player)
+      if (autoTTSPlayerRef.current === player) autoTTSPlayerRef.current = null
+    }
+    const isTTSAutoPlayEnabled =
+      !!features.text2speech?.enabled && features.text2speech.autoPlay === TtsAutoPlay.enabled
+    if (isTTSAutoPlayEnabled) getOrCreatePlayer().preparePlayback()
 
     const postDatasets = dataSets.map(({ id }) => ({
       dataset: {
@@ -287,6 +325,7 @@ const Debug: FC<IDebug> = ({
     setCompletionRes('')
     setMessageId('')
     let res: string[] = []
+    let requestAbortController: AbortController | null = null
 
     setRespondingTrue()
     sendCompletionMessage(appId, data, {
@@ -300,11 +339,30 @@ const Debug: FC<IDebug> = ({
         setCompletionRes(res.join(''))
       },
       onCompleted() {
+        if (completionAbortControllerRef.current === requestAbortController)
+          completionAbortControllerRef.current = null
         setRespondingFalse()
       },
       onError() {
+        if (completionAbortControllerRef.current === requestAbortController)
+          completionAbortControllerRef.current = null
+        destroyPlayer()
         setRespondingFalse()
       },
+      getAbortController(abortController) {
+        requestAbortController = abortController
+        completionAbortControllerRef.current = abortController
+      },
+      onTTSChunk: isTTSAutoPlayEnabled
+        ? (_messageId, audio) => {
+            if (audio) void getOrCreatePlayer().playAudioWithAudio(audio, true)
+          }
+        : undefined,
+      onTTSEnd: isTTSAutoPlayEnabled
+        ? (_messageId, audio) => {
+            void getOrCreatePlayer().playAudioWithAudio(audio, false)
+          }
+        : undefined,
     })
   }
 

--- a/web/app/components/base/audio-btn/__tests__/audio.player.manager.spec.ts
+++ b/web/app/components/base/audio-btn/__tests__/audio.player.manager.spec.ts
@@ -165,4 +165,52 @@ describe('AudioPlayerManager', () => {
       expect(() => manager.resetMsgId('msg-updated')).not.toThrow()
     })
   })
+
+  describe('automatic playback ownership', () => {
+    it('should release only the active automatic playback player', () => {
+      const manager = AudioPlayerManager.getInstance()
+      const player = manager.getAutoPlayAudioPlayer(
+        '/text-to-audio',
+        false,
+        'auto-1',
+        'hello',
+        'en-US',
+        null,
+      )
+
+      manager.destroyAutoPlayAudioPlayer(player)
+
+      expect(mockState.instances[0]!.destroy).toHaveBeenCalledTimes(1)
+
+      manager.getAudioPlayer('/text-to-audio', false, 'next', 'world', 'en-US', null)
+      expect(mockAudioPlayerConstructor).toHaveBeenCalledTimes(2)
+    })
+
+    it('should not release an automatic player after another player replaced it', () => {
+      const manager = AudioPlayerManager.getInstance()
+      const player = manager.getAutoPlayAudioPlayer(
+        '/text-to-audio',
+        false,
+        'auto-1',
+        'hello',
+        'en-US',
+        null,
+      )
+      manager.getAudioPlayer('/text-to-audio', false, 'manual-1', 'world', 'en-US', null)
+
+      manager.destroyAutoPlayAudioPlayer(player)
+
+      expect(mockState.instances[0]!.destroy).toHaveBeenCalledTimes(1)
+      expect(mockState.instances[1]!.destroy).not.toHaveBeenCalled()
+    })
+
+    it('should release the current automatic player without requiring its owner', () => {
+      const manager = AudioPlayerManager.getInstance()
+      manager.getAutoPlayAudioPlayer('/text-to-audio', false, 'auto-1', 'hello', 'en-US', null)
+
+      manager.destroyCurrentAutoPlayAudioPlayer()
+
+      expect(mockState.instances[0]!.destroy).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/web/app/components/base/audio-btn/__tests__/audio.spec.ts
+++ b/web/app/components/base/audio-btn/__tests__/audio.spec.ts
@@ -379,6 +379,19 @@ describe('AudioPlayer', () => {
   })
 
   describe('playback control', () => {
+    it('should prepare the media element and audio context during a user action', async () => {
+      const player = new AudioPlayer('/text-to-audio', true, 'msg-1', 'hello', 'en-US', null)
+      const audio = testState.audios[0]
+      const audioContext = testState.audioContexts[0]
+      audioContext!.state = 'suspended'
+
+      player.preparePlayback()
+      await Promise.resolve()
+
+      expect(audioContext!.resume).toHaveBeenCalledTimes(1)
+      expect(audio!.play).toHaveBeenCalledTimes(1)
+    })
+
     it('should request streaming audio when playAudio is called before loading', async () => {
       mockTextToAudioStream.mockResolvedValue(
         makeAudioResponse(200, [

--- a/web/app/components/base/audio-btn/audio.player.manager.ts
+++ b/web/app/components/base/audio-btn/audio.player.manager.ts
@@ -10,6 +10,7 @@ declare global {
 export class AudioPlayerManager {
   private static instance: AudioPlayerManager
   private audioPlayers: AudioPlayer | null = null
+  private autoPlayAudioPlayer: AudioPlayer | null = null
   private msgId: string | undefined
 
   public static getInstance(): AudioPlayerManager {
@@ -34,6 +35,7 @@ export class AudioPlayerManager {
       return this.audioPlayers
     } else {
       if (this.audioPlayers) {
+        if (this.autoPlayAudioPlayer === this.audioPlayers) this.autoPlayAudioPlayer = null
         try {
           this.audioPlayers.destroy()
         } catch {}
@@ -43,6 +45,37 @@ export class AudioPlayerManager {
       this.audioPlayers = new AudioPlayer(url, isPublic, id, msgContent, voice, callback)
       return this.audioPlayers
     }
+  }
+
+  public getAutoPlayAudioPlayer(
+    url: string,
+    isPublic: boolean,
+    id: string | undefined,
+    msgContent: string | null | undefined,
+    voice: string | undefined,
+    callback: ((event: string) => void) | null,
+  ): AudioPlayer {
+    const player = this.getAudioPlayer(url, isPublic, id, msgContent, voice, callback)
+    this.autoPlayAudioPlayer = player
+    return player
+  }
+
+  public destroyAutoPlayAudioPlayer(player: AudioPlayer | null) {
+    if (!player || player !== this.autoPlayAudioPlayer) return
+
+    this.autoPlayAudioPlayer = null
+    if (this.audioPlayers === player) {
+      this.audioPlayers = null
+      this.msgId = undefined
+    }
+
+    try {
+      player.destroy()
+    } catch {}
+  }
+
+  public destroyCurrentAutoPlayAudioPlayer() {
+    this.destroyAutoPlayAudioPlayer(this.autoPlayAudioPlayer)
   }
 
   public resetMsgId(msgId: string) {

--- a/web/app/components/base/audio-btn/audio.ts
+++ b/web/app/components/base/audio-btn/audio.ts
@@ -70,6 +70,14 @@ export default class AudioPlayer {
     this.msgId = msgId
   }
 
+  public preparePlayback() {
+    const pendingOperations: Promise<unknown>[] = []
+    if (this.audioContext.state === 'suspended') pendingOperations.push(this.audioContext.resume())
+    if (this.audio.paused || this.audio.ended) pendingOperations.push(this.audio.play())
+
+    void Promise.allSettled(pendingOperations)
+  }
+
   private listenMediaSource(contentType: string) {
     this.sourceOpenListener = () => {
       if (this.destroyed || this.sourceBuffer) return

--- a/web/app/components/base/chat/chat/__tests__/hooks.spec.tsx
+++ b/web/app/components/base/chat/chat/__tests__/hooks.spec.tsx
@@ -19,6 +19,11 @@ vi.mock('@/app/components/base/audio-btn/audio.player.manager', () => ({
   AudioPlayerManager: {
     getInstance: () => ({
       getAudioPlayer: vi.fn().mockReturnValue({ playAudioWithAudio: vi.fn() }),
+      getAutoPlayAudioPlayer: vi.fn().mockReturnValue({
+        playAudioWithAudio: vi.fn(),
+        preparePlayback: vi.fn(),
+      }),
+      destroyAutoPlayAudioPlayer: vi.fn(),
       resetMsgId: vi.fn(),
     }),
   },

--- a/web/app/components/base/chat/chat/hooks.ts
+++ b/web/app/components/base/chat/chat/hooks.ts
@@ -8,7 +8,6 @@ import type { VisionFile } from '@/types/app'
 import type { FileResponse, ReasoningChunkResponse } from '@/types/workflow'
 import { toast } from '@langgenius/dify-ui/toast'
 import { uniqBy } from 'es-toolkit/compat'
-import { noop } from 'es-toolkit/function'
 import { produce, setAutoFreeze } from 'immer'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -25,7 +24,7 @@ import { NodeRunningStatus, WorkflowRunningStatus } from '@/app/components/workf
 import useTimestamp from '@/hooks/use-timestamp'
 import { useParams, usePathname } from '@/next/navigation'
 import { sseGet, ssePost } from '@/service/base'
-import { TransferMethod } from '@/types/app'
+import { TransferMethod, TtsAutoPlay } from '@/types/app'
 import { getThreadMessages } from '../utils'
 import { getProcessedInputs, processOpeningStatement } from './utils'
 
@@ -230,6 +229,7 @@ export const useChat = (
   const startWorkflowEventsSubscriptionRef = useRef<
     ((workflowRunId: string, options: IOtherOptions) => void) | null
   >(null)
+  const autoTTSPlayerRef = useRef<AudioPlayer | null>(null)
   const params = useParams()
   const pathname = usePathname()
 
@@ -521,6 +521,12 @@ export const useChat = (
 
   useEffect(() => resetWorkflowEventsSubscription, [resetWorkflowEventsSubscription])
 
+  const destroyAutoTTSPlayer = useCallback(() => {
+    if (autoTTSPlayerRef.current)
+      AudioPlayerManager.getInstance().destroyAutoPlayAudioPlayer(autoTTSPlayerRef.current)
+    autoTTSPlayerRef.current = null
+  }, [])
+
   const handleStop = useCallback(() => {
     hasStopRespondedRef.current = true
     handleResponding(false)
@@ -531,7 +537,8 @@ export const useChat = (
       suggestedQuestionsAbortControllerRef.current.abort()
     if (workflowEventsAbortControllerRef.current) workflowEventsAbortControllerRef.current.abort()
     resetWorkflowEventsSubscription()
-  }, [stopChat, handleResponding, resetWorkflowEventsSubscription])
+    destroyAutoTTSPlayer()
+  }, [stopChat, handleResponding, resetWorkflowEventsSubscription, destroyAutoTTSPlayer])
 
   const handleRestart = useCallback(
     (cb?: any) => {
@@ -558,21 +565,29 @@ export const useChat = (
 
     let player: AudioPlayer | null = null
     const getOrCreatePlayer = () => {
-      if (!player)
-        player = AudioPlayerManager.getInstance().getAudioPlayer(
+      if (!player) {
+        player = AudioPlayerManager.getInstance().getAutoPlayAudioPlayer(
           ttsUrl,
           ttsIsPublic,
           uuidV4(),
           'none',
           'none',
-          noop,
+          null,
         )
+        autoTTSPlayerRef.current = player
+      }
 
       return player
     }
+    const destroyPlayer = () => {
+      if (player) AudioPlayerManager.getInstance().destroyAutoPlayAudioPlayer(player)
+      if (autoTTSPlayerRef.current === player) autoTTSPlayerRef.current = null
+    }
 
-    return getOrCreatePlayer
+    return { destroyPlayer, getOrCreatePlayer }
   }, [params.token, params.appId, pathname])
+
+  useEffect(() => destroyAutoTTSPlayer, [destroyAutoTTSPlayer])
 
   const handleResume = useCallback(
     async (
@@ -590,7 +605,9 @@ export const useChat = (
         workflowEventsAbortControllerRef.current?.abort()
         workflowEventsAbortControllerRef.current = null
       }
-      const getOrCreatePlayer = createAudioPlayerManager()
+      const { destroyPlayer, getOrCreatePlayer } = createAudioPlayerManager()
+      if (config?.text_to_speech?.enabled && config.text_to_speech.autoPlay === TtsAutoPlay.enabled)
+        getOrCreatePlayer().preparePlayback()
       let hasSettled = false
       const settleSend = (hasError?: boolean) => {
         if (hasSettled) return
@@ -775,6 +792,7 @@ export const useChat = (
           })
         },
         onError() {
+          destroyPlayer()
           if (requestGeneration !== workflowRequestGenerationRef.current) return
 
           handleResponding(false)
@@ -1024,6 +1042,8 @@ export const useChat = (
       updateChatTreeNode,
       handleResponding,
       createAudioPlayerManager,
+      config?.text_to_speech?.autoPlay,
+      config?.text_to_speech?.enabled,
       config?.suggested_questions_after_answer,
       options.isNewAgent,
       ensureWorkflowEventsSubscription,
@@ -1182,7 +1202,9 @@ export const useChat = (
         onConversationComplete?.(conversationIdRef.current, workflowRunId)
       }
 
-      const getOrCreatePlayer = createAudioPlayerManager()
+      const { destroyPlayer, getOrCreatePlayer } = createAudioPlayerManager()
+      if (config?.text_to_speech?.enabled && config.text_to_speech.autoPlay === TtsAutoPlay.enabled)
+        getOrCreatePlayer().preparePlayback()
 
       const otherOptions: IOtherOptions = {
         isPublicAPI,
@@ -1474,6 +1496,7 @@ export const useChat = (
           responseItem.content = messageReplace.answer
         },
         onError() {
+          destroyPlayer()
           if (requestGeneration !== workflowRequestGenerationRef.current) return
 
           handleResponding(false)
@@ -1809,6 +1832,8 @@ export const useChat = (
       chatTree.length,
       threadMessages,
       config?.suggested_questions_after_answer,
+      config?.text_to_speech?.autoPlay,
+      config?.text_to_speech?.enabled,
       updateCurrentQAOnTree,
       updateChatTreeNode,
       handleResponding,

--- a/web/app/components/explore/try-app/app/__tests__/text-generation.spec.tsx
+++ b/web/app/components/explore/try-app/app/__tests__/text-generation.spec.tsx
@@ -1,7 +1,24 @@
 import type { AppData } from '@/models/share'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TtsAutoPlay } from '@/types/app'
 import TextGeneration from '../text-generation'
+
+const { mockDestroyAutoPlayAudioPlayer, mockGetAutoPlayAudioPlayer, mockPreparePlayback } =
+  vi.hoisted(() => ({
+    mockDestroyAutoPlayAudioPlayer: vi.fn(),
+    mockGetAutoPlayAudioPlayer: vi.fn(),
+    mockPreparePlayback: vi.fn(),
+  }))
+
+vi.mock('@/app/components/base/audio-btn/audio.player.manager', () => ({
+  AudioPlayerManager: {
+    getInstance: () => ({
+      destroyAutoPlayAudioPlayer: mockDestroyAutoPlayAudioPlayer,
+      getAutoPlayAudioPlayer: mockGetAutoPlayAudioPlayer,
+    }),
+  },
+}))
 
 const mockUpdateAppInfo = vi.fn()
 const mockUpdateAppParams = vi.fn()
@@ -9,7 +26,7 @@ const mockAppParams = {
   user_input_form: [],
   more_like_this: { enabled: false },
   file_upload: null,
-  text_to_speech: { enabled: false },
+  text_to_speech: { enabled: false, autoPlay: undefined as TtsAutoPlay | undefined },
   system_parameters: {},
 }
 let mockStoreAppParams: typeof mockAppParams | null = mockAppParams
@@ -72,13 +89,23 @@ vi.mock('@/app/components/share/text-generation/result', () => ({
     appId,
     onCompleted,
     onRunStart,
+    ttsAutoPlayEnabled,
+    autoTTSPlayerRef,
   }: {
     isWorkflow: boolean
     appId: string
     onCompleted: () => void
     onRunStart: () => void
+    ttsAutoPlayEnabled?: boolean
+    autoTTSPlayerRef?: { current: unknown }
   }) => (
-    <div data-testid="result-component" data-is-workflow={isWorkflow} data-app-id={appId}>
+    <div
+      data-testid="result-component"
+      data-is-workflow={isWorkflow}
+      data-app-id={appId}
+      data-tts-auto-play={String(!!ttsAutoPlayEnabled)}
+      data-has-auto-player={String(!!autoTTSPlayerRef?.current)}
+    >
       <button data-testid="complete-button" onClick={onCompleted}>
         Complete
       </button>
@@ -115,6 +142,9 @@ describe('TextGeneration', () => {
   beforeEach(() => {
     mockStoreAppParams = mockAppParams
     mockMediaType = 'pc'
+    mockGetAutoPlayAudioPlayer.mockReturnValue({
+      preparePlayback: mockPreparePlayback,
+    })
     mockUseGetTryAppParams.mockReturnValue({
       data: mockAppParams,
     })
@@ -238,6 +268,45 @@ describe('TextGeneration', () => {
       fireEvent.click(screen.getByTestId('send-button'))
 
       expect(screen.getByTestId('result-component')).toBeInTheDocument()
+    })
+
+    it('prepares automatic playback directly from the send action', async () => {
+      mockStoreAppParams = {
+        ...mockAppParams,
+        text_to_speech: { enabled: true, autoPlay: TtsAutoPlay.enabled },
+      }
+
+      render(<TextGeneration appId="test-app-id" appData={createMockAppData()} />)
+
+      await waitFor(() => expect(screen.getByTestId('send-button')).toBeInTheDocument())
+      fireEvent.click(screen.getByTestId('send-button'))
+
+      expect(mockGetAutoPlayAudioPlayer).toHaveBeenCalledWith(
+        'trial-apps/test-app-id/text-to-audio',
+        false,
+        expect.stringMatching(/^text-generation-\d+$/),
+        'none',
+        'none',
+        null,
+      )
+      expect(mockPreparePlayback).toHaveBeenCalledTimes(1)
+      expect(screen.getByTestId('result-component')).toHaveAttribute('data-tts-auto-play', 'true')
+      expect(screen.getByTestId('result-component')).toHaveAttribute('data-has-auto-player', 'true')
+    })
+
+    it('does not prepare automatic playback when text to speech is disabled', async () => {
+      mockStoreAppParams = {
+        ...mockAppParams,
+        text_to_speech: { enabled: false, autoPlay: TtsAutoPlay.enabled },
+      }
+
+      render(<TextGeneration appId="test-app-id" appData={createMockAppData()} />)
+
+      await waitFor(() => expect(screen.getByTestId('send-button')).toBeInTheDocument())
+      fireEvent.click(screen.getByTestId('send-button'))
+
+      expect(mockGetAutoPlayAudioPlayer).not.toHaveBeenCalled()
+      expect(screen.getByTestId('result-component')).toHaveAttribute('data-tts-auto-play', 'false')
     })
   })
 

--- a/web/app/components/explore/try-app/app/text-generation.tsx
+++ b/web/app/components/explore/try-app/app/text-generation.tsx
@@ -1,6 +1,7 @@
 'use client'
 import type { FC } from 'react'
 import type { InputValueTypes, Task } from '../../../share/text-generation/types'
+import type AudioPlayer from '@/app/components/base/audio-btn/audio'
 import type { MoreLikeThisConfig, PromptConfig, TextToSpeechConfig } from '@/models/debug'
 import type { AppData, CustomConfigValueType, SiteInfo } from '@/models/share'
 import type { VisionFile, VisionSettings } from '@/types/app'
@@ -13,15 +14,16 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Alert from '@/app/components/base/alert'
 import AppIcon from '@/app/components/base/app-icon'
+import { AudioPlayerManager } from '@/app/components/base/audio-btn/audio.player.manager'
 import Loading from '@/app/components/base/loading'
 import Res from '@/app/components/share/text-generation/result'
 import { TaskStatus } from '@/app/components/share/text-generation/types'
 import { appDefaultIconBackground } from '@/config'
 import { useWebAppStore } from '@/context/web-app-context'
 import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
-import { AppSourceType } from '@/service/share'
+import { AppSourceType, getUrl } from '@/service/share'
 import { useGetTryAppParams } from '@/service/use-try-app'
-import { Resolution, TransferMethod } from '@/types/app'
+import { Resolution, TransferMethod, TtsAutoPlay } from '@/types/app'
 import { userInputsFormToPromptVariables } from '@/utils/model-config'
 import RunOnce from '../../../share/text-generation/run-once'
 
@@ -62,6 +64,7 @@ const TextGeneration: FC<Props> = ({ appId, className, isWorkflow, appData }) =>
   const [moreLikeThisConfig, setMoreLikeThisConfig] = useState<MoreLikeThisConfig | null>(null)
   const [textToSpeechConfig, setTextToSpeechConfig] = useState<TextToSpeechConfig | null>(null)
   const [controlSend, setControlSend] = useState(0)
+  const autoTTSPlayerRef = useRef<AudioPlayer | null>(null)
   const [visionConfig, setVisionConfig] = useState<VisionSettings>({
     enabled: false,
     number_limits: 2,
@@ -79,9 +82,31 @@ const TextGeneration: FC<Props> = ({ appId, className, isWorkflow, appData }) =>
   }
 
   const handleSend = () => {
-    setControlSend(Date.now())
+    const runId = Date.now()
+    AudioPlayerManager.getInstance().destroyAutoPlayAudioPlayer(autoTTSPlayerRef.current)
+    autoTTSPlayerRef.current = null
+    if (textToSpeechConfig?.enabled && textToSpeechConfig.autoPlay === TtsAutoPlay.enabled) {
+      const player = AudioPlayerManager.getInstance().getAutoPlayAudioPlayer(
+        getUrl('text-to-audio', AppSourceType.tryApp, appId),
+        false,
+        `text-generation-${runId}`,
+        'none',
+        'none',
+        null,
+      )
+      autoTTSPlayerRef.current = player
+      player.preparePlayback()
+    }
+    setControlSend(runId)
     showResultPanel()
   }
+
+  useEffect(() => {
+    return () => {
+      AudioPlayerManager.getInstance().destroyAutoPlayAudioPlayer(autoTTSPlayerRef.current)
+      autoTTSPlayerRef.current = null
+    }
+  }, [])
 
   const [resultExisted, setResultExisted] = useState(false)
 
@@ -150,6 +175,10 @@ const TextGeneration: FC<Props> = ({ appId, className, isWorkflow, appData }) =>
       visionConfig={visionConfig}
       completionFiles={completionFiles}
       isShowTextToSpeech={!!textToSpeechConfig?.enabled}
+      ttsAutoPlayEnabled={
+        !!textToSpeechConfig?.enabled && textToSpeechConfig.autoPlay === TtsAutoPlay.enabled
+      }
+      autoTTSPlayerRef={autoTTSPlayerRef}
       siteInfo={siteInfo}
       onRunStart={() => setResultExisted(true)}
     />

--- a/web/app/components/share/text-generation/__tests__/index.spec.tsx
+++ b/web/app/components/share/text-generation/__tests__/index.spec.tsx
@@ -1,6 +1,7 @@
 import type { TextGenerationRunControl } from '../types'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import { AccessMode } from '@/models/access-control'
+import { TtsAutoPlay } from '@/types/app'
 import TextGeneration from '../index'
 
 const {
@@ -13,6 +14,9 @@ const {
   mockSetIsCallBatchAPI,
   mockResetBatchExecution,
   mockHandleRunBatch,
+  mockGetAutoPlayAudioPlayer,
+  mockDestroyAutoPlayAudioPlayer,
+  mockPreparePlayback,
 } = vi.hoisted(() => ({
   mockMode: { value: 'create' },
   mockMedia: { value: 'pc' },
@@ -23,6 +27,18 @@ const {
   mockSetIsCallBatchAPI: vi.fn(),
   mockResetBatchExecution: vi.fn(),
   mockHandleRunBatch: vi.fn(),
+  mockGetAutoPlayAudioPlayer: vi.fn(),
+  mockDestroyAutoPlayAudioPlayer: vi.fn(),
+  mockPreparePlayback: vi.fn(),
+}))
+
+vi.mock('@/app/components/base/audio-btn/audio.player.manager', () => ({
+  AudioPlayerManager: {
+    getInstance: () => ({
+      getAutoPlayAudioPlayer: mockGetAutoPlayAudioPlayer,
+      destroyAutoPlayAudioPlayer: mockDestroyAutoPlayAudioPlayer,
+    }),
+  },
 }))
 
 vi.mock('@/hooks/use-breakpoints', () => ({
@@ -159,6 +175,9 @@ describe('TextGeneration', () => {
     mockMedia.value = 'pc'
     mockAppStateRef.value = createAppState()
     mockBatchStateRef.value = createBatchState()
+    mockGetAutoPlayAudioPlayer.mockReturnValue({
+      preparePlayback: mockPreparePlayback,
+    })
   })
 
   afterEach(() => {
@@ -201,6 +220,47 @@ describe('TextGeneration', () => {
     expect(mockResetBatchExecution).toHaveBeenCalledTimes(1)
     expect(screen.getByTestId('show-result')).toHaveTextContent('shown')
     expect(Number(screen.getByTestId('control-send').textContent)).toBeGreaterThan(0)
+  })
+
+  it('should prepare automatic playback directly from the run-once action', () => {
+    mockAppStateRef.value = createAppState({
+      textToSpeechConfig: { enabled: true, autoPlay: TtsAutoPlay.enabled },
+    })
+    render(<TextGeneration />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'run-once' }))
+
+    expect(mockGetAutoPlayAudioPlayer).toHaveBeenCalledWith(
+      'text-to-audio',
+      true,
+      expect.stringMatching(/^text-generation-\d+$/),
+      'none',
+      'none',
+      null,
+    )
+    expect(mockPreparePlayback).toHaveBeenCalledTimes(1)
+    expect(resultPanelPropsSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        textToSpeechAutoPlayEnabled: true,
+        autoTTSPlayerRef: expect.objectContaining({
+          current: expect.objectContaining({ preparePlayback: mockPreparePlayback }),
+        }),
+      }),
+    )
+  })
+
+  it('should not prepare automatic playback when text to speech is disabled', () => {
+    mockAppStateRef.value = createAppState({
+      textToSpeechConfig: { enabled: false, autoPlay: TtsAutoPlay.enabled },
+    })
+    render(<TextGeneration />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'run-once' }))
+
+    expect(mockGetAutoPlayAudioPlayer).not.toHaveBeenCalled()
+    expect(resultPanelPropsSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ textToSpeechAutoPlayEnabled: false }),
+    )
   })
 
   it('should orchestrate batch runs through the batch hook and expose the result panel', async () => {

--- a/web/app/components/share/text-generation/__tests__/text-generation-result-panel.spec.tsx
+++ b/web/app/components/share/text-generation/__tests__/text-generation-result-panel.spec.tsx
@@ -86,6 +86,8 @@ const baseProps = {
   showTaskList: batchTasks,
   siteInfo,
   textToSpeechEnabled: true,
+  textToSpeechAutoPlayEnabled: false,
+  autoTTSPlayerRef: { current: null },
   visionConfig,
 }
 

--- a/web/app/components/share/text-generation/index.tsx
+++ b/web/app/components/share/text-generation/index.tsx
@@ -1,15 +1,19 @@
 'use client'
 import type { FC } from 'react'
 import type { InputValueTypes, TextGenerationRunControl, TextGenerationTranslate } from './types'
+import type AudioPlayer from '@/app/components/base/audio-btn/audio'
 import type { VisionFile } from '@/types/app'
 import { cn } from '@langgenius/dify-ui/cn'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useBoolean } from 'ahooks'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { AudioPlayerManager } from '@/app/components/base/audio-btn/audio.player.manager'
 import Loading from '@/app/components/base/loading'
 import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
 import { useSearchParams } from '@/next/navigation'
+import { AppSourceType, getUrl } from '@/service/share'
+import { TtsAutoPlay } from '@/types/app'
 import { useTextGenerationAppState } from './hooks/use-text-generation-app-state'
 import { useTextGenerationBatch } from './hooks/use-text-generation-batch'
 import TextGenerationResultPanel from './text-generation-result-panel'
@@ -41,6 +45,7 @@ const TextGeneration: FC<IMainProps> = ({ isInstalledApp = false, isWorkflow = f
   const [controlSend, setControlSend] = useState(0)
   const [controlStopResponding, setControlStopResponding] = useState(0)
   const [resultExisted, setResultExisted] = useState(false)
+  const autoTTSPlayerRef = useRef<AudioPlayer | null>(null)
   const [isShowResultPanel, { setTrue: showResultPanelState, setFalse: hideResultPanel }] =
     useBoolean(false)
   const notify = useCallback(
@@ -103,11 +108,40 @@ const TextGeneration: FC<IMainProps> = ({ isInstalledApp = false, isWorkflow = f
     setResultExisted(true)
   }, [])
   const handleRunOnce = useCallback(() => {
+    const runId = Date.now()
+    AudioPlayerManager.getInstance().destroyAutoPlayAudioPlayer(autoTTSPlayerRef.current)
+    autoTTSPlayerRef.current = null
+    if (textToSpeechConfig?.enabled && textToSpeechConfig.autoPlay === TtsAutoPlay.enabled) {
+      const player = AudioPlayerManager.getInstance().getAutoPlayAudioPlayer(
+        getUrl('text-to-audio', appSourceType, appId),
+        appSourceType === AppSourceType.webApp,
+        `text-generation-${runId}`,
+        'none',
+        'none',
+        null,
+      )
+      autoTTSPlayerRef.current = player
+      player.preparePlayback()
+    }
     setIsCallBatchAPI(false)
-    setControlSend(Date.now())
+    setControlSend(runId)
     resetBatchExecution()
     showResultPanel()
-  }, [resetBatchExecution, setIsCallBatchAPI, showResultPanel])
+  }, [
+    appId,
+    appSourceType,
+    resetBatchExecution,
+    setIsCallBatchAPI,
+    showResultPanel,
+    textToSpeechConfig?.autoPlay,
+    textToSpeechConfig?.enabled,
+  ])
+  useEffect(() => {
+    return () => {
+      AudioPlayerManager.getInstance().destroyAutoPlayAudioPlayer(autoTTSPlayerRef.current)
+      autoTTSPlayerRef.current = null
+    }
+  }, [])
   const handleRunBatch = useCallback(
     (data: string[][]) => {
       runBatchExecution(data, {
@@ -190,6 +224,10 @@ const TextGeneration: FC<IMainProps> = ({ isInstalledApp = false, isWorkflow = f
         showTaskList={showTaskList}
         siteInfo={siteInfo}
         textToSpeechEnabled={!!textToSpeechConfig?.enabled}
+        textToSpeechAutoPlayEnabled={
+          !!textToSpeechConfig?.enabled && textToSpeechConfig.autoPlay === TtsAutoPlay.enabled
+        }
+        autoTTSPlayerRef={autoTTSPlayerRef}
         visionConfig={visionConfig}
       />
     </div>

--- a/web/app/components/share/text-generation/result/hooks/__tests__/use-result-sender.spec.ts
+++ b/web/app/components/share/text-generation/result/hooks/__tests__/use-result-sender.spec.ts
@@ -1,5 +1,6 @@
 import type { ResultInputValue } from '../../result-request'
 import type { ResultRunStateController } from '../use-result-run-state'
+import type AudioPlayer from '@/app/components/base/audio-btn/audio'
 import type { PromptConfig } from '@/models/debug'
 import type { AppSourceType } from '@/service/share'
 import type { VisionSettings } from '@/types/app'
@@ -18,6 +19,8 @@ const {
   sendWorkflowMessageMock,
   sleepMock,
   validateResultRequestMock,
+  getAutoPlayAudioPlayerMock,
+  destroyAutoPlayAudioPlayerMock,
 } = vi.hoisted(() => ({
   buildResultRequestDataMock: vi.fn(),
   createWorkflowStreamHandlersMock: vi.fn(),
@@ -31,6 +34,17 @@ const {
   sendWorkflowMessageMock: vi.fn(),
   sleepMock: vi.fn(),
   validateResultRequestMock: vi.fn(),
+  getAutoPlayAudioPlayerMock: vi.fn(),
+  destroyAutoPlayAudioPlayerMock: vi.fn(),
+}))
+
+vi.mock('@/app/components/base/audio-btn/audio.player.manager', () => ({
+  AudioPlayerManager: {
+    getInstance: () => ({
+      getAutoPlayAudioPlayer: getAutoPlayAudioPlayerMock,
+      destroyAutoPlayAudioPlayer: destroyAutoPlayAudioPlayerMock,
+    }),
+  },
 }))
 
 vi.mock('@/app/components/base/amplitude', () => ({
@@ -90,6 +104,8 @@ type CompletionHandlers = {
   ) => void
   onError: () => void
   onMessageReplace: (messageReplace: { answer: string }) => void
+  onTTSChunk?: (messageId: string, audio: string) => void
+  onTTSEnd?: (messageId: string, audio: string) => void
 }
 
 const createRunStateHarness = (): RunStateHarness => {
@@ -184,6 +200,8 @@ type RenderSenderOptions = {
   isWorkflow?: boolean
   runState?: ResultRunStateController
   taskId?: number
+  ttsAutoPlayEnabled?: boolean
+  autoTTSPlayerRef?: { current: AudioPlayer | null }
 }
 
 const renderSender = ({
@@ -195,6 +213,8 @@ const renderSender = ({
   isWorkflow = false,
   runState,
   taskId,
+  ttsAutoPlayEnabled,
+  autoTTSPlayerRef,
 }: RenderSenderOptions = {}) => {
   const notify = vi.fn()
   const onCompleted = vi.fn()
@@ -221,7 +241,9 @@ const renderSender = ({
         runState: runState || createRunStateHarness().runState,
         t: withSelectorKey((key: string) => key),
         taskId,
+        ttsAutoPlayEnabled,
         visionConfig,
+        autoTTSPlayerRef,
       }),
     {
       initialProps: {
@@ -364,6 +386,65 @@ describe('useResultSender', () => {
     expect(harness.runState.resetRunState).toHaveBeenCalled()
     expect(harness.runState.setMessageId).toHaveBeenCalledWith('message-1')
     expect(onCompleted).toHaveBeenCalledWith('Replaced', 7, true)
+  })
+
+  it('should reuse the player prepared by the run action for automatic tts chunks', async () => {
+    const harness = createRunStateHarness()
+    const preparedPlayer = {
+      playAudioWithAudio: vi.fn(),
+      preparePlayback: vi.fn(),
+    } as unknown as AudioPlayer
+    const autoTTSPlayerRef = { current: preparedPlayer }
+    let completionHandlers: CompletionHandlers | undefined
+    sendCompletionMessageMock.mockImplementation(async (_data, handlers) => {
+      completionHandlers = handlers as CompletionHandlers
+    })
+
+    const { rerender } = renderSender({
+      controlSend: 0,
+      runState: harness.runState,
+      ttsAutoPlayEnabled: true,
+      autoTTSPlayerRef,
+    })
+
+    rerender({ controlRetry: 0, controlSend: 123 })
+    await waitFor(() => expect(completionHandlers).toBeDefined())
+
+    completionHandlers!.onTTSChunk?.('message-1', 'audio-chunk')
+    completionHandlers!.onTTSEnd?.('message-1', 'audio-end')
+
+    expect(getAutoPlayAudioPlayerMock).not.toHaveBeenCalled()
+    expect(preparedPlayer.playAudioWithAudio).toHaveBeenNthCalledWith(1, 'audio-chunk', true)
+    expect(preparedPlayer.playAudioWithAudio).toHaveBeenNthCalledWith(2, 'audio-end', false)
+  })
+
+  it('should ignore late tts chunks after the prepared player is destroyed', async () => {
+    const harness = createRunStateHarness()
+    const preparedPlayer = {
+      playAudioWithAudio: vi.fn(),
+      preparePlayback: vi.fn(),
+    } as unknown as AudioPlayer
+    const autoTTSPlayerRef = { current: preparedPlayer as AudioPlayer | null }
+    let completionHandlers: CompletionHandlers | undefined
+    sendCompletionMessageMock.mockImplementation(async (_data, handlers) => {
+      completionHandlers = handlers as CompletionHandlers
+    })
+
+    const { rerender } = renderSender({
+      controlSend: 0,
+      runState: harness.runState,
+      ttsAutoPlayEnabled: true,
+      autoTTSPlayerRef,
+    })
+
+    rerender({ controlRetry: 0, controlSend: 123 })
+    await waitFor(() => expect(completionHandlers).toBeDefined())
+
+    destroyAutoPlayAudioPlayerMock(preparedPlayer)
+    autoTTSPlayerRef.current = null
+    completionHandlers!.onTTSChunk?.('message-1', 'late-audio-chunk')
+
+    expect(preparedPlayer.playAudioWithAudio).not.toHaveBeenCalled()
   })
 
   it('should trigger workflow sends on retry and report workflow request failures', async () => {

--- a/web/app/components/share/text-generation/result/hooks/use-result-run-state.ts
+++ b/web/app/components/share/text-generation/result/hooks/use-result-run-state.ts
@@ -1,9 +1,11 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react'
+import type AudioPlayer from '@/app/components/base/audio-btn/audio'
 import type { FeedbackType } from '@/app/components/base/chat/chat/type'
 import type { WorkflowProcess } from '@/app/components/base/chat/types'
 import type { AppSourceType } from '@/service/share'
 import { useBoolean } from 'ahooks'
 import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
+import { AudioPlayerManager } from '@/app/components/base/audio-btn/audio.player.manager'
 import { stopChatMessageResponding, stopWorkflowMessage, updateFeedback } from '@/service/share'
 
 type Notify = (payload: { type: 'error'; message: string }) => void
@@ -27,6 +29,7 @@ type UseResultRunStateOptions = {
   onRunControlChange?: (
     control: { onStop: () => Promise<void> | void; isStopping: boolean } | null,
   ) => void
+  autoTTSPlayerRef?: MutableRefObject<AudioPlayer | null>
 }
 
 export type ResultRunStateController = {
@@ -84,6 +87,7 @@ export const useResultRunState = ({
   isWorkflow,
   notify,
   onRunControlChange,
+  autoTTSPlayerRef: providedAutoTTSPlayerRef,
 }: UseResultRunStateOptions): ResultRunStateController => {
   const [isResponding, { setTrue: setRespondingTrue, setFalse: setRespondingFalse }] =
     useBoolean(false)
@@ -97,6 +101,8 @@ export const useResultRunState = ({
   })
   const [controlClearMoreLikeThis, setControlClearMoreLikeThis] = useState(0)
   const abortControllerRef = useRef<AbortController | null>(null)
+  const fallbackAutoTTSPlayerRef = useRef<AudioPlayer | null>(null)
+  const autoTTSPlayerRef = providedAutoTTSPlayerRef ?? fallbackAutoTTSPlayerRef
   const [{ currentTaskId, isStopping }, dispatchRunControl] = useReducer(runControlReducer, {
     currentTaskId: null,
     isStopping: false,
@@ -163,6 +169,9 @@ export const useResultRunState = ({
   )
 
   const handleStop = useCallback(async () => {
+    if (autoTTSPlayerRef.current)
+      AudioPlayerManager.getInstance().destroyAutoPlayAudioPlayer(autoTTSPlayerRef.current)
+    autoTTSPlayerRef.current = null
     if (!currentTaskId || isStopping) return
 
     setIsStopping(true)
@@ -177,7 +186,16 @@ export const useResultRunState = ({
     } finally {
       setIsStopping(false)
     }
-  }, [appId, appSourceType, currentTaskId, isStopping, isWorkflow, notify, setIsStopping])
+  }, [
+    appId,
+    appSourceType,
+    autoTTSPlayerRef,
+    currentTaskId,
+    isStopping,
+    isWorkflow,
+    notify,
+    setIsStopping,
+  ])
 
   const clearMoreLikeThis = useCallback(() => {
     setControlClearMoreLikeThis(Date.now())
@@ -186,6 +204,9 @@ export const useResultRunState = ({
   useEffect(() => {
     const abortCurrentRequest = () => {
       abortControllerRef.current?.abort()
+      if (autoTTSPlayerRef.current)
+        AudioPlayerManager.getInstance().destroyAutoPlayAudioPlayer(autoTTSPlayerRef.current)
+      autoTTSPlayerRef.current = null
     }
 
     if (controlStopResponding) {
@@ -195,7 +216,7 @@ export const useResultRunState = ({
     }
 
     return abortCurrentRequest
-  }, [controlStopResponding, resetRunState, setRespondingFalse])
+  }, [autoTTSPlayerRef, controlStopResponding, resetRunState, setRespondingFalse])
 
   useEffect(() => {
     if (!onRunControlChange) return

--- a/web/app/components/share/text-generation/result/hooks/use-result-sender.ts
+++ b/web/app/components/share/text-generation/result/hooks/use-result-sender.ts
@@ -1,13 +1,17 @@
+import type { MutableRefObject } from 'react'
 import type { TextGenerationTranslate } from '../../types'
 import type { ResultInputValue } from '../result-request'
 import type { ResultRunStateController } from './use-result-run-state'
+import type AudioPlayer from '@/app/components/base/audio-btn/audio'
 import type { PromptConfig } from '@/models/debug'
 import type { VisionFile, VisionSettings } from '@/types/app'
 import { useCallback, useEffect, useRef } from 'react'
+import { v4 as uuidV4 } from 'uuid'
 import { trackEvent } from '@/app/components/base/amplitude'
+import { AudioPlayerManager } from '@/app/components/base/audio-btn/audio.player.manager'
 import { TEXT_GENERATION_TIMEOUT_MS } from '@/config'
 import { useWebAppStore } from '@/context/web-app-context'
-import { AppSourceType, sendCompletionMessage, sendWorkflowMessage } from '@/service/share'
+import { AppSourceType, getUrl, sendCompletionMessage, sendWorkflowMessage } from '@/service/share'
 import { sleep } from '@/utils'
 import { buildResultRequestData, validateResultRequest } from '../result-request'
 import { createWorkflowStreamHandlers } from '../workflow-stream-handlers'
@@ -31,7 +35,9 @@ type UseResultSenderOptions = {
   runState: ResultRunStateController
   t: TextGenerationTranslate
   taskId?: number
+  ttsAutoPlayEnabled?: boolean
   visionConfig: VisionSettings
+  autoTTSPlayerRef?: MutableRefObject<AudioPlayer | null>
 }
 
 const logRequestError = (notify: Notify, error: unknown) => {
@@ -57,168 +63,234 @@ export const useResultSender = ({
   runState,
   t,
   taskId,
+  ttsAutoPlayEnabled = false,
   visionConfig,
+  autoTTSPlayerRef: providedAutoTTSPlayerRef,
 }: UseResultSenderOptions) => {
   const { clearMoreLikeThis } = runState
   const appMode = useWebAppStore((state) => state.appInfo?.mode)
+  const fallbackAutoTTSPlayerRef = useRef<AudioPlayer | null>(null)
+  const autoTTSPlayerRef = providedAutoTTSPlayerRef ?? fallbackAutoTTSPlayerRef
 
-  const handleSend = useCallback(async () => {
-    if (runState.isResponding) {
-      notify({
-        type: 'info',
-        message: t(($) => $['errorMessage.waitForResponse'], { ns: 'appDebug' }),
+  const handleSend = useCallback(
+    async (preparedPlayerId?: string) => {
+      let player = autoTTSPlayerRef.current
+      let acceptsTTS = true
+      const destroyAutoTTSPlayer = () => {
+        acceptsTTS = false
+        if (player) AudioPlayerManager.getInstance().destroyAutoPlayAudioPlayer(player)
+        if (autoTTSPlayerRef.current === player) autoTTSPlayerRef.current = null
+      }
+      const releasePreparedPlayer = () => {
+        if (player) AudioPlayerManager.getInstance().destroyAutoPlayAudioPlayer(player)
+        if (autoTTSPlayerRef.current === player) autoTTSPlayerRef.current = null
+        player = null
+      }
+
+      if (runState.isResponding) {
+        destroyAutoTTSPlayer()
+        notify({
+          type: 'info',
+          message: t(($) => $['errorMessage.waitForResponse'], { ns: 'appDebug' }),
+        })
+        return false
+      }
+
+      const validation = validateResultRequest({
+        completionFiles,
+        inputs,
+        isCallBatchAPI,
+        promptConfig,
+        t,
       })
-      return false
-    }
+      if (!validation.canSend) {
+        destroyAutoTTSPlayer()
+        notify(validation.notification!)
+        return false
+      }
 
-    const validation = validateResultRequest({
+      const data = buildResultRequestData({
+        completionFiles,
+        inputs,
+        promptConfig,
+        visionConfig,
+      })
+
+      if (!preparedPlayerId) releasePreparedPlayer()
+
+      const getOrCreatePlayer = () => {
+        if (!acceptsTTS) return null
+        if (player && autoTTSPlayerRef.current !== player) {
+          acceptsTTS = false
+          return null
+        }
+        if (!player) {
+          player = AudioPlayerManager.getInstance().getAutoPlayAudioPlayer(
+            getUrl('text-to-audio', appSourceType, appId || ''),
+            appSourceType === AppSourceType.webApp,
+            preparedPlayerId || uuidV4(),
+            'none',
+            'none',
+            null,
+          )
+          autoTTSPlayerRef.current = player
+        }
+
+        return player
+      }
+
+      if (ttsAutoPlayEnabled) getOrCreatePlayer()?.preparePlayback()
+
+      runState.prepareForNewRun()
+
+      if (!isPC) {
+        onShowRes()
+        onRunStart()
+      }
+
+      runState.setRespondingTrue()
+
+      if (appSourceType === AppSourceType.webApp && appMode)
+        trackEvent('webapp_run', { app_mode: appMode })
+
+      let isEnd = false
+      let isTimeout = false
+      let completionChunks: string[] = []
+      let tempMessageId = ''
+
+      void (async () => {
+        await sleep(TEXT_GENERATION_TIMEOUT_MS)
+        if (!isEnd) {
+          destroyAutoTTSPlayer()
+          runState.setRespondingFalse()
+          onCompleted(runState.getCompletionRes(), taskId, false)
+          runState.resetRunState()
+          isTimeout = true
+        }
+      })()
+
+      if (isWorkflow) {
+        const otherOptions = createWorkflowStreamHandlers({
+          getCompletionRes: runState.getCompletionRes,
+          getWorkflowProcessData: runState.getWorkflowProcessData,
+          isPublicAPI: appSourceType === AppSourceType.webApp,
+          isTimedOut: () => isTimeout,
+          markEnded: () => {
+            isEnd = true
+          },
+          notify,
+          onCompleted,
+          onStreamError: destroyAutoTTSPlayer,
+          resetRunState: runState.resetRunState,
+          setCompletionRes: runState.setCompletionRes,
+          setCurrentTaskId: runState.setCurrentTaskId,
+          setIsStopping: runState.setIsStopping,
+          setMessageId: runState.setMessageId,
+          setRespondingFalse: runState.setRespondingFalse,
+          setWorkflowProcessData: runState.setWorkflowProcessData,
+          t,
+          taskId,
+          getOrCreatePlayer: ttsAutoPlayEnabled ? getOrCreatePlayer : undefined,
+        })
+
+        void sendWorkflowMessage(data, otherOptions, appSourceType, appId).catch((error) => {
+          destroyAutoTTSPlayer()
+          runState.setRespondingFalse()
+          runState.resetRunState()
+          logRequestError(notify, error)
+        })
+        return true
+      }
+
+      void sendCompletionMessage(
+        data,
+        {
+          onData: (chunk, _isFirstMessage, { messageId, taskId: nextTaskId }) => {
+            tempMessageId = messageId
+            if (nextTaskId && nextTaskId.trim() !== '')
+              runState.setCurrentTaskId((prev) => prev ?? nextTaskId)
+
+            completionChunks.push(chunk)
+            runState.setCompletionRes(completionChunks.join(''))
+          },
+          onCompleted: () => {
+            if (isTimeout) {
+              notify({
+                type: 'warning',
+                message: t(($) => $['warningMessage.timeoutExceeded'], { ns: 'appDebug' }),
+              })
+              return
+            }
+
+            runState.setRespondingFalse()
+            runState.resetRunState()
+            runState.setMessageId(tempMessageId)
+            onCompleted(runState.getCompletionRes(), taskId, true)
+            isEnd = true
+          },
+          onMessageReplace: (messageReplace) => {
+            completionChunks = [messageReplace.answer]
+            runState.setCompletionRes(completionChunks.join(''))
+          },
+          onError: () => {
+            destroyAutoTTSPlayer()
+            if (isTimeout) {
+              notify({
+                type: 'warning',
+                message: t(($) => $['warningMessage.timeoutExceeded'], { ns: 'appDebug' }),
+              })
+              return
+            }
+
+            runState.setRespondingFalse()
+            runState.resetRunState()
+            onCompleted(runState.getCompletionRes(), taskId, false)
+            isEnd = true
+          },
+          getAbortController: (abortController) => {
+            runState.abortControllerRef.current = abortController
+          },
+          onTTSChunk: ttsAutoPlayEnabled
+            ? (_messageId, audio) => {
+                const player = getOrCreatePlayer()
+                if (audio && player) void player.playAudioWithAudio(audio, true)
+              }
+            : undefined,
+          onTTSEnd: ttsAutoPlayEnabled
+            ? (_messageId, audio) => {
+                const player = getOrCreatePlayer()
+                if (player) void player.playAudioWithAudio(audio, false)
+              }
+            : undefined,
+        },
+        appSourceType,
+        appId,
+      )
+
+      return true
+    },
+    [
+      appId,
+      appMode,
+      appSourceType,
+      autoTTSPlayerRef,
       completionFiles,
       inputs,
       isCallBatchAPI,
+      isPC,
+      isWorkflow,
+      notify,
+      onCompleted,
+      onRunStart,
+      onShowRes,
       promptConfig,
+      runState,
       t,
-    })
-    if (!validation.canSend) {
-      notify(validation.notification!)
-      return false
-    }
-
-    const data = buildResultRequestData({
-      completionFiles,
-      inputs,
-      promptConfig,
+      taskId,
+      ttsAutoPlayEnabled,
       visionConfig,
-    })
-
-    runState.prepareForNewRun()
-
-    if (!isPC) {
-      onShowRes()
-      onRunStart()
-    }
-
-    runState.setRespondingTrue()
-
-    if (appSourceType === AppSourceType.webApp && appMode)
-      trackEvent('webapp_run', { app_mode: appMode })
-
-    let isEnd = false
-    let isTimeout = false
-    let completionChunks: string[] = []
-    let tempMessageId = ''
-
-    void (async () => {
-      await sleep(TEXT_GENERATION_TIMEOUT_MS)
-      if (!isEnd) {
-        runState.setRespondingFalse()
-        onCompleted(runState.getCompletionRes(), taskId, false)
-        runState.resetRunState()
-        isTimeout = true
-      }
-    })()
-
-    if (isWorkflow) {
-      const otherOptions = createWorkflowStreamHandlers({
-        getCompletionRes: runState.getCompletionRes,
-        getWorkflowProcessData: runState.getWorkflowProcessData,
-        isPublicAPI: appSourceType === AppSourceType.webApp,
-        isTimedOut: () => isTimeout,
-        markEnded: () => {
-          isEnd = true
-        },
-        notify,
-        onCompleted,
-        resetRunState: runState.resetRunState,
-        setCompletionRes: runState.setCompletionRes,
-        setCurrentTaskId: runState.setCurrentTaskId,
-        setIsStopping: runState.setIsStopping,
-        setMessageId: runState.setMessageId,
-        setRespondingFalse: runState.setRespondingFalse,
-        setWorkflowProcessData: runState.setWorkflowProcessData,
-        t,
-        taskId,
-      })
-
-      void sendWorkflowMessage(data, otherOptions, appSourceType, appId).catch((error) => {
-        runState.setRespondingFalse()
-        runState.resetRunState()
-        logRequestError(notify, error)
-      })
-      return true
-    }
-
-    void sendCompletionMessage(
-      data,
-      {
-        onData: (chunk, _isFirstMessage, { messageId, taskId: nextTaskId }) => {
-          tempMessageId = messageId
-          if (nextTaskId && nextTaskId.trim() !== '')
-            runState.setCurrentTaskId((prev) => prev ?? nextTaskId)
-
-          completionChunks.push(chunk)
-          runState.setCompletionRes(completionChunks.join(''))
-        },
-        onCompleted: () => {
-          if (isTimeout) {
-            notify({
-              type: 'warning',
-              message: t(($) => $['warningMessage.timeoutExceeded'], { ns: 'appDebug' }),
-            })
-            return
-          }
-
-          runState.setRespondingFalse()
-          runState.resetRunState()
-          runState.setMessageId(tempMessageId)
-          onCompleted(runState.getCompletionRes(), taskId, true)
-          isEnd = true
-        },
-        onMessageReplace: (messageReplace) => {
-          completionChunks = [messageReplace.answer]
-          runState.setCompletionRes(completionChunks.join(''))
-        },
-        onError: () => {
-          if (isTimeout) {
-            notify({
-              type: 'warning',
-              message: t(($) => $['warningMessage.timeoutExceeded'], { ns: 'appDebug' }),
-            })
-            return
-          }
-
-          runState.setRespondingFalse()
-          runState.resetRunState()
-          onCompleted(runState.getCompletionRes(), taskId, false)
-          isEnd = true
-        },
-        getAbortController: (abortController) => {
-          runState.abortControllerRef.current = abortController
-        },
-      },
-      appSourceType,
-      appId,
-    )
-
-    return true
-  }, [
-    appId,
-    appMode,
-    appSourceType,
-    completionFiles,
-    inputs,
-    isCallBatchAPI,
-    isPC,
-    isWorkflow,
-    notify,
-    onCompleted,
-    onRunStart,
-    onShowRes,
-    promptConfig,
-    runState,
-    t,
-    taskId,
-    visionConfig,
-  ])
+    ],
+  )
 
   const handleSendRef = useRef(handleSend)
 
@@ -229,7 +301,7 @@ export const useResultSender = ({
   useEffect(() => {
     if (!controlSend) return
 
-    void handleSendRef.current()
+    void handleSendRef.current(`text-generation-${controlSend}`)
     clearMoreLikeThis()
   }, [clearMoreLikeThis, controlSend])
 

--- a/web/app/components/share/text-generation/result/index.tsx
+++ b/web/app/components/share/text-generation/result/index.tsx
@@ -1,13 +1,14 @@
 'use client'
-import type { FC } from 'react'
+import type { FC, MutableRefObject } from 'react'
 import type { TextGenerationTranslate } from '../types'
+import type AudioPlayer from '@/app/components/base/audio-btn/audio'
 import type { PromptConfig } from '@/models/debug'
 import type { SiteInfo } from '@/models/share'
 import type { AppSourceType } from '@/service/share'
 import type { VisionFile, VisionSettings } from '@/types/app'
 import { Button } from '@langgenius/dify-ui/button'
 import { toast } from '@langgenius/dify-ui/toast'
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import TextGenerationRes from '@/app/components/app/text-generate/item'
@@ -25,6 +26,7 @@ type IResultProps = {
   appId?: string
   isError: boolean
   isShowTextToSpeech: boolean
+  ttsAutoPlayEnabled?: boolean
   promptConfig: PromptConfig | null
   moreLikeThisEnabled: boolean
   inputs: Record<string, any>
@@ -46,6 +48,7 @@ type IResultProps = {
     } | null,
   ) => void
   hideInlineStopButton?: boolean
+  autoTTSPlayerRef?: MutableRefObject<AudioPlayer | null>
 }
 const Result: FC<IResultProps> = ({
   isWorkflow,
@@ -56,6 +59,7 @@ const Result: FC<IResultProps> = ({
   appId,
   isError,
   isShowTextToSpeech,
+  ttsAutoPlayEnabled = false,
   promptConfig,
   moreLikeThisEnabled,
   inputs,
@@ -72,6 +76,7 @@ const Result: FC<IResultProps> = ({
   onRunStart,
   onRunControlChange,
   hideInlineStopButton = false,
+  autoTTSPlayerRef: providedAutoTTSPlayerRef,
 }) => {
   const { t } = useTranslation()
   const translateResultKey = useCallback<TextGenerationTranslate>(
@@ -84,6 +89,8 @@ const Result: FC<IResultProps> = ({
     },
     [],
   )
+  const fallbackAutoTTSPlayerRef = useRef<AudioPlayer | null>(null)
+  const autoTTSPlayerRef = providedAutoTTSPlayerRef ?? fallbackAutoTTSPlayerRef
   const runState = useResultRunState({
     appId,
     appSourceType,
@@ -91,6 +98,7 @@ const Result: FC<IResultProps> = ({
     isWorkflow,
     notify,
     onRunControlChange,
+    autoTTSPlayerRef,
   })
   const { handleSend } = useResultSender({
     appId,
@@ -110,7 +118,9 @@ const Result: FC<IResultProps> = ({
     runState,
     t: translateResultKey,
     taskId,
+    ttsAutoPlayEnabled,
     visionConfig,
+    autoTTSPlayerRef,
   })
   const isNoData = !runState.completionRes
   const renderTextGenerationRes = () => (

--- a/web/app/components/share/text-generation/result/workflow-stream-handlers.ts
+++ b/web/app/components/share/text-generation/result/workflow-stream-handlers.ts
@@ -1,5 +1,6 @@
 import type { Dispatch, SetStateAction } from 'react'
 import type { TextGenerationTranslate } from '../types'
+import type AudioPlayer from '@/app/components/base/audio-btn/audio'
 import type { WorkflowProcess } from '@/app/components/base/chat/types'
 import type { IOtherOptions } from '@/service/base'
 import type {
@@ -22,6 +23,7 @@ type CreateWorkflowStreamHandlersParams = {
   markEnded: () => void
   notify: Notify
   onCompleted: (completionRes: string, taskId?: number, success?: boolean) => void
+  onStreamError?: () => void
   resetRunState: () => void
   setCompletionRes: (res: string) => void
   setCurrentTaskId: Dispatch<SetStateAction<string | null>>
@@ -31,6 +33,7 @@ type CreateWorkflowStreamHandlersParams = {
   setWorkflowProcessData: (data: WorkflowProcess | undefined) => void
   t: TextGenerationTranslate
   taskId?: number
+  getOrCreatePlayer?: () => AudioPlayer | null
 }
 
 const createInitialWorkflowProcess = (): WorkflowProcess => ({
@@ -269,6 +272,7 @@ export const createWorkflowStreamHandlers = ({
   markEnded,
   notify,
   onCompleted,
+  onStreamError = () => {},
   resetRunState,
   setCompletionRes,
   setCurrentTaskId,
@@ -278,11 +282,13 @@ export const createWorkflowStreamHandlers = ({
   setWorkflowProcessData,
   t,
   taskId,
+  getOrCreatePlayer,
 }: CreateWorkflowStreamHandlersParams): IOtherOptions => {
   let tempMessageId = ''
   let hasStartedResumeStream = false
 
   const finishWithFailure = () => {
+    onStreamError()
     setRespondingFalse()
     resetRunState()
     onCompleted(getCompletionRes(), taskId, false)
@@ -431,6 +437,19 @@ export const createWorkflowStreamHandlers = ({
       }
       setWorkflowProcessData(applyWorkflowPaused(getWorkflowProcessData()))
     },
+    onTTSChunk: getOrCreatePlayer
+      ? (_messageId, audio) => {
+          const player = getOrCreatePlayer()
+          if (audio && player) void player.playAudioWithAudio(audio, true)
+        }
+      : undefined,
+    onTTSEnd: getOrCreatePlayer
+      ? (_messageId, audio) => {
+          const player = getOrCreatePlayer()
+          if (player) void player.playAudioWithAudio(audio, false)
+        }
+      : undefined,
+    onError: finishWithFailure,
   }
 
   return otherOptions

--- a/web/app/components/share/text-generation/text-generation-result-panel.tsx
+++ b/web/app/components/share/text-generation/text-generation-result-panel.tsx
@@ -1,5 +1,6 @@
-import type { FC } from 'react'
+import type { FC, MutableRefObject } from 'react'
 import type { InputValueTypes, Task, TextGenerationRunControl } from './types'
+import type AudioPlayer from '@/app/components/base/audio-btn/audio'
 import type { PromptConfig } from '@/models/debug'
 import type { SiteInfo } from '@/models/share'
 import type { AppSourceType } from '@/service/share'
@@ -41,6 +42,8 @@ type TextGenerationResultPanelProps = {
   showTaskList: Task[]
   siteInfo: SiteInfo
   textToSpeechEnabled: boolean
+  textToSpeechAutoPlayEnabled: boolean
+  autoTTSPlayerRef: MutableRefObject<AudioPlayer | null>
   visionConfig: VisionSettings
 }
 
@@ -74,6 +77,8 @@ const TextGenerationResultPanel: FC<TextGenerationResultPanelProps> = ({
   showTaskList,
   siteInfo,
   textToSpeechEnabled,
+  textToSpeechAutoPlayEnabled,
+  autoTTSPlayerRef,
   visionConfig,
 }) => {
   const { t } = useTranslation()
@@ -101,6 +106,8 @@ const TextGenerationResultPanel: FC<TextGenerationResultPanelProps> = ({
       visionConfig={visionConfig}
       completionFiles={completionFiles}
       isShowTextToSpeech={textToSpeechEnabled}
+      ttsAutoPlayEnabled={textToSpeechAutoPlayEnabled && !isCallBatchAPI}
+      autoTTSPlayerRef={autoTTSPlayerRef}
       siteInfo={siteInfo}
       onRunStart={onRunStart}
       onRunControlChange={!isCallBatchAPI ? onRunControlChange : undefined}

--- a/web/app/components/workflow-app/hooks/__tests__/use-workflow-run-callbacks.spec.ts
+++ b/web/app/components/workflow-app/hooks/__tests__/use-workflow-run-callbacks.spec.ts
@@ -197,7 +197,6 @@ describe('useWorkflowRun callbacks helpers', () => {
         onNodeStarted: restOnNodeStarted,
       },
       baseSseOptions,
-      player,
       setAbortController,
     })
 
@@ -428,7 +427,6 @@ describe('useWorkflowRun callbacks helpers', () => {
       callbacks: userCallbacks,
       restCallback: {},
       baseSseOptions,
-      player,
       setAbortController,
     })
 

--- a/web/app/components/workflow-app/hooks/__tests__/use-workflow-run.spec.ts
+++ b/web/app/components/workflow-app/hooks/__tests__/use-workflow-run.spec.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react'
 import { TriggerType } from '@/app/components/workflow/header/test-run-menu'
 import { WorkflowRunningStatus } from '@/app/components/workflow/types'
+import { TtsAutoPlay } from '@/types/app'
 import { useWorkflowRun } from '../use-workflow-run'
 
 type DebugAbortControllerRef = {
@@ -57,7 +58,12 @@ const mocks = vi.hoisted(() => {
   const workflowStoreSetState = vi.fn((partial: Record<string, unknown>) => {
     Object.assign(workflowStoreState, partial)
   })
-  const featuresStoreState = {
+  const featuresStoreState: {
+    features: {
+      file: { enabled: boolean }
+      text2speech?: { enabled: boolean; autoPlay: TtsAutoPlay }
+    }
+  } = {
     features: {
       file: {
         enabled: true,
@@ -88,6 +94,10 @@ const mocks = vi.hoisted(() => {
     mockStopWorkflowRun: vi.fn(),
     mockTrackEvent: vi.fn(),
     mockGetAudioPlayer: vi.fn(),
+    mockGetAutoPlayAudioPlayer: vi.fn(),
+    mockDestroyAutoPlayAudioPlayer: vi.fn(),
+    mockDestroyCurrentAutoPlayAudioPlayer: vi.fn(),
+    mockPreparePlayback: vi.fn(),
     mockResetMsgId: vi.fn(),
     mockCreateBaseWorkflowRunCallbacks: vi.fn(),
     mockCreateFinalWorkflowRunCallbacks: vi.fn(),
@@ -142,6 +152,9 @@ vi.mock('@/app/components/base/audio-btn/audio.player.manager', () => ({
   AudioPlayerManager: {
     getInstance: () => ({
       getAudioPlayer: mocks.mockGetAudioPlayer,
+      getAutoPlayAudioPlayer: mocks.mockGetAutoPlayAudioPlayer,
+      destroyAutoPlayAudioPlayer: mocks.mockDestroyAutoPlayAudioPlayer,
+      destroyCurrentAutoPlayAudioPlayer: mocks.mockDestroyCurrentAutoPlayAudioPlayer,
       resetMsgId: mocks.mockResetMsgId,
     }),
   },
@@ -267,8 +280,9 @@ describe('useWorkflowRun', () => {
         headers: { 'content-type': 'text/event-stream' },
       }),
     )
-    mocks.mockGetAudioPlayer.mockReturnValue({
+    mocks.mockGetAutoPlayAudioPlayer.mockReturnValue({
       playAudioWithAudio: vi.fn(),
+      preparePlayback: mocks.mockPreparePlayback,
     })
     mocks.runEventHandlers.handleWorkflowFailed.mockImplementation(() => {
       const workflowRunningData = mocks.workflowStoreState.workflowRunningData
@@ -368,6 +382,39 @@ describe('useWorkflowRun', () => {
         getAbortController: expect.any(Function),
       }),
     )
+  })
+
+  it('should prepare automatic playback before waiting for the workflow draft sync', async () => {
+    let resolveDraftSync!: () => void
+    mocks.mockDoSyncWorkflowDraft.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveDraftSync = resolve
+      }),
+    )
+    mocks.featuresStoreState.features = {
+      file: { enabled: true },
+      text2speech: { enabled: true, autoPlay: TtsAutoPlay.enabled },
+    }
+    const { result } = renderHook(() => useWorkflowRun())
+
+    let runPromise!: Promise<void>
+    await act(async () => {
+      runPromise = result.current.handleRun({ inputs: { query: 'hello' } })
+      await Promise.resolve()
+    })
+
+    expect(mocks.mockPreparePlayback).toHaveBeenCalledTimes(1)
+    expect(mocks.mockPreparePlayback.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.mockDoSyncWorkflowDraft.mock.invocationCallOrder[0]!,
+    )
+    expect(mocks.mockSsePost).not.toHaveBeenCalled()
+
+    resolveDraftSync()
+    await act(async () => {
+      await runPromise
+    })
+
+    expect(mocks.mockSsePost).toHaveBeenCalledTimes(1)
   })
 
   it.each([
@@ -594,17 +641,17 @@ describe('useWorkflowRun', () => {
 
     publicBaseCallbackFactoryContext.getOrCreatePlayer()
 
-    expect(mocks.mockGetAudioPlayer).toHaveBeenCalledWith(
+    expect(mocks.mockGetAutoPlayAudioPlayer).toHaveBeenCalledWith(
       '/text-to-audio',
       true,
       expect.any(String),
       'none',
       'none',
-      expect.any(Function),
+      null,
     )
 
     mocks.mockSsePost.mockClear()
-    mocks.mockGetAudioPlayer.mockClear()
+    mocks.mockGetAutoPlayAudioPlayer.mockClear()
 
     await act(async () => {
       await result.current.handleRun({ appId: 'app-2' })
@@ -617,13 +664,13 @@ describe('useWorkflowRun', () => {
 
     privateBaseCallbackFactoryContext.getOrCreatePlayer()
 
-    expect(mocks.mockGetAudioPlayer).toHaveBeenCalledWith(
+    expect(mocks.mockGetAutoPlayAudioPlayer).toHaveBeenCalledWith(
       '/apps/app-2/text-to-audio',
       false,
       expect.any(String),
       'none',
       'none',
-      expect.any(Function),
+      null,
     )
   })
 
@@ -641,6 +688,7 @@ describe('useWorkflowRun', () => {
     expect(mocks.mockStopWorkflowRun).toHaveBeenCalledWith(
       '/apps/app-1/workflow-runs/tasks/task-1/stop',
     )
+    expect(mocks.mockDestroyCurrentAutoPlayAudioPlayer).toHaveBeenCalledTimes(1)
     expect(mocks.workflowStoreState.setWorkflowRunningData).toHaveBeenCalledWith(
       expect.objectContaining({
         result: expect.objectContaining({
@@ -675,6 +723,7 @@ describe('useWorkflowRun', () => {
     expect(scheduleAbort).toHaveBeenCalled()
     expect(allTriggersAbort).toHaveBeenCalled()
     expect(refAbortSpy).toHaveBeenCalled()
+    expect(mocks.mockDestroyCurrentAutoPlayAudioPlayer).toHaveBeenCalledTimes(2)
   })
 
   it('should restore published workflow graph, features, and environment variables', () => {

--- a/web/app/components/workflow-app/hooks/use-workflow-run-callbacks.ts
+++ b/web/app/components/workflow-app/hooks/use-workflow-run-callbacks.ts
@@ -84,7 +84,6 @@ type BaseCallbacksContext = CallbackContext & {
 
 type FinalCallbacksContext = CallbackContext & {
   baseSseOptions: IOtherOptions
-  player: AudioPlayer | null
   setAbortController: (controller: AbortController) => void
 }
 
@@ -302,7 +301,6 @@ export const createFinalWorkflowRunCallbacks = ({
   callbacks,
   restCallback,
   baseSseOptions,
-  player,
   setAbortController,
 }: FinalCallbacksContext): IOtherOptions => {
   const {
@@ -429,14 +427,6 @@ export const createFinalWorkflowRunCallbacks = ({
     },
     onReasoning: (params) => {
       handleWorkflowReasoning(params)
-    },
-    onTTSChunk: (messageId: string, audio: string) => {
-      if (!audio || audio === '') return
-      player?.playAudioWithAudio(audio, true)
-      AudioPlayerManager.getInstance().resetMsgId(messageId)
-    },
-    onTTSEnd: (_messageId: string, audio: string) => {
-      player?.playAudioWithAudio(audio, false)
     },
     onWorkflowPaused: (params) => {
       handleWorkflowPaused()

--- a/web/app/components/workflow-app/hooks/use-workflow-run.ts
+++ b/web/app/components/workflow-app/hooks/use-workflow-run.ts
@@ -3,9 +3,8 @@ import type AudioPlayer from '@/app/components/base/audio-btn/audio'
 import type { Node } from '@/app/components/workflow/types'
 import type { IOtherOptions } from '@/service/base'
 import type { VersionHistory } from '@/types/workflow'
-import { noop } from 'es-toolkit/function'
 import { produce } from 'immer'
-import { useCallback, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useReactFlow, useStoreApi } from 'reactflow'
 import { v4 as uuidV4 } from 'uuid'
 import { useStore as useAppStore } from '@/app/components/app/store'
@@ -21,7 +20,7 @@ import { usePathname } from '@/next/navigation'
 import { ssePost } from '@/service/base'
 import { useInvalidAllLastRun, useInvalidateWorkflowRunHistory } from '@/service/use-workflow'
 import { stopWorkflowRun } from '@/service/workflow'
-import { AppModeEnum } from '@/types/app'
+import { AppModeEnum, TtsAutoPlay } from '@/types/app'
 import { useConfigsMap } from './use-configs-map'
 import { useNodesSyncDraft, useNodesSyncDraftByCanEdit } from './use-nodes-sync-draft'
 import {
@@ -127,6 +126,20 @@ const useWorkflowRunBase = (doSyncWorkflowDraft: DoSyncWorkflowDraft) => {
   })
 
   const abortControllerRef = useRef<AbortController | null>(null)
+  const autoTTSPlayerRef = useRef<AudioPlayer | null>(null)
+
+  const destroyAutoTTSPlayer = useCallback(() => {
+    if (autoTTSPlayerRef.current)
+      AudioPlayerManager.getInstance().destroyAutoPlayAudioPlayer(autoTTSPlayerRef.current)
+    autoTTSPlayerRef.current = null
+  }, [])
+
+  const destroyCurrentAutoTTSPlayer = useCallback(() => {
+    AudioPlayerManager.getInstance().destroyCurrentAutoPlayAudioPlayer()
+    autoTTSPlayerRef.current = null
+  }, [])
+
+  useEffect(() => destroyAutoTTSPlayer, [destroyAutoTTSPlayer])
 
   const {
     handleWorkflowStarted,
@@ -201,7 +214,40 @@ const useWorkflowRunBase = (doSyncWorkflowDraft: DoSyncWorkflowDraft) => {
         })
       })
       setNodes(newNodes)
-      await doSyncWorkflowDraft()
+
+      destroyAutoTTSPlayer()
+      const { ttsUrl, ttsIsPublic } = buildTTSConfig(resolvedParams, pathname)
+      let player: AudioPlayer | null = null
+      const getOrCreatePlayer = () => {
+        if (!player) {
+          player = AudioPlayerManager.getInstance().getAutoPlayAudioPlayer(
+            ttsUrl,
+            ttsIsPublic,
+            uuidV4(),
+            'none',
+            'none',
+            null,
+          )
+          autoTTSPlayerRef.current = player
+        }
+
+        return player
+      }
+      const destroyPlayer = () => {
+        if (player) AudioPlayerManager.getInstance().destroyAutoPlayAudioPlayer(player)
+        if (autoTTSPlayerRef.current === player) autoTTSPlayerRef.current = null
+      }
+
+      const textToSpeech = featuresStore?.getState().features.text2speech
+      if (textToSpeech?.enabled && textToSpeech.autoPlay === TtsAutoPlay.enabled)
+        getOrCreatePlayer().preparePlayback()
+
+      try {
+        await doSyncWorkflowDraft()
+      } catch (error) {
+        destroyPlayer()
+        throw error
+      }
 
       const {
         onWorkflowStarted,
@@ -236,11 +282,15 @@ const useWorkflowRunBase = (doSyncWorkflowDraft: DoSyncWorkflowDraft) => {
       const url = resolveWorkflowRunUrl(appDetail, runMode, isInWorkflowDebug)
       const requestBody = buildWorkflowRunRequestBody(runMode, resolvedParams, options)
 
-      if (!url) return
+      if (!url) {
+        destroyPlayer()
+        return
+      }
 
       const validationMessage = validateWorkflowRunRequest(runMode, options)
       if (validationMessage) {
         console.error(validationMessage)
+        destroyPlayer()
         return
       }
 
@@ -270,24 +320,6 @@ const useWorkflowRunBase = (doSyncWorkflowDraft: DoSyncWorkflowDraft) => {
         runMode,
         options,
       )
-
-      const { ttsUrl, ttsIsPublic } = buildTTSConfig(resolvedParams, pathname)
-      // Lazy initialization: Only create AudioPlayer when TTS is actually needed
-      // This prevents opening audio channel unnecessarily
-      let player: AudioPlayer | null = null
-      const getOrCreatePlayer = () => {
-        if (!player)
-          player = AudioPlayerManager.getInstance().getAudioPlayer(
-            ttsUrl,
-            ttsIsPublic,
-            uuidV4(),
-            'none',
-            'none',
-            noop,
-          )
-
-        return player
-      }
 
       const clearAbortController = () => {
         abortControllerRef.current = null
@@ -327,6 +359,10 @@ const useWorkflowRunBase = (doSyncWorkflowDraft: DoSyncWorkflowDraft) => {
         handleWorkflowReasoning,
         handleWorkflowPaused,
       }
+      const handleRunError: NonNullable<IOtherOptions['onError']> = (params, code) => {
+        destroyPlayer()
+        onError?.(params, code)
+      }
       const userCallbacks = {
         onWorkflowStarted,
         onWorkflowFinished,
@@ -340,7 +376,7 @@ const useWorkflowRunBase = (doSyncWorkflowDraft: DoSyncWorkflowDraft) => {
         onLoopFinish,
         onNodeRetry,
         onAgentLog,
-        onError,
+        onError: handleRunError,
         onWorkflowPaused,
         onHumanInputRequired,
         onHumanInputFormFilled,
@@ -429,7 +465,6 @@ const useWorkflowRunBase = (doSyncWorkflowDraft: DoSyncWorkflowDraft) => {
         callbacks: userCallbacks,
         restCallback,
         baseSseOptions,
-        player,
         setAbortController: (controller) => {
           abortControllerRef.current = controller
         },
@@ -472,6 +507,8 @@ const useWorkflowRunBase = (doSyncWorkflowDraft: DoSyncWorkflowDraft) => {
       handleWorkflowNodeHumanInputRequired,
       handleWorkflowNodeHumanInputFormFilled,
       handleWorkflowNodeHumanInputFormTimeout,
+      destroyAutoTTSPlayer,
+      featuresStore,
     ],
   )
 
@@ -498,6 +535,7 @@ const useWorkflowRunBase = (doSyncWorkflowDraft: DoSyncWorkflowDraft) => {
       if (taskId) {
         const appId = useAppStore.getState().appDetail?.id
         stopWorkflowRun(`/apps/${appId}/workflow-runs/tasks/${taskId}/stop`)
+        destroyCurrentAutoTTSPlayer()
         setStoppedState()
         return
       }
@@ -521,9 +559,10 @@ const useWorkflowRunBase = (doSyncWorkflowDraft: DoSyncWorkflowDraft) => {
       if (abortControllerRef.current) abortControllerRef.current.abort()
 
       abortControllerRef.current = null
+      destroyCurrentAutoTTSPlayer()
       setStoppedState()
     },
-    [workflowStore],
+    [destroyCurrentAutoTTSPlayer, workflowStore],
   )
 
   const handleRestoreFromPublishedWorkflow = useCallback(

--- a/web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/handle-stop-restart.spec.ts
+++ b/web/app/components/workflow/panel/debug-and-preview/__tests__/hooks/handle-stop-restart.spec.ts
@@ -11,12 +11,21 @@ const mockSetLoopTimes = vi.fn()
 const mockSubmitHumanInputForm = vi.fn()
 const mockSseGet = vi.fn()
 const mockStopChat = vi.fn()
+const mockDestroyCurrentAutoPlayAudioPlayer = vi.fn()
 const mockGetNodes = vi.fn((): any[] => [])
 
 let mockWorkflowRunningData: any = null
 
 vi.mock('@/service/base', () => ({
   sseGet: (...args: any[]) => mockSseGet(...args),
+}))
+
+vi.mock('@/app/components/base/audio-btn/audio.player.manager', () => ({
+  AudioPlayerManager: {
+    getInstance: () => ({
+      destroyCurrentAutoPlayAudioPlayer: mockDestroyCurrentAutoPlayAudioPlayer,
+    }),
+  },
 }))
 
 vi.mock('@/service/use-workflow', () => ({
@@ -84,6 +93,7 @@ describe('useChat – handleStop', () => {
       result.current.handleStop()
     })
     expect(result.current.isResponding).toBe(false)
+    expect(mockDestroyCurrentAutoPlayAudioPlayer).toHaveBeenCalledTimes(1)
   })
 
   it('should not call stopChat when taskId is empty even if stopChat is provided', () => {

--- a/web/app/components/workflow/panel/debug-and-preview/hooks.ts
+++ b/web/app/components/workflow/panel/debug-and-preview/hooks.ts
@@ -10,6 +10,7 @@ import { produce, setAutoFreeze } from 'immer'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStoreApi } from 'reactflow'
+import { AudioPlayerManager } from '@/app/components/base/audio-btn/audio.player.manager'
 import { enrichSubmittedHumanInputFormData } from '@/app/components/base/chat/chat/answer/human-input-content/submitted-utils'
 import { getProcessedInputs, processOpeningStatement } from '@/app/components/base/chat/chat/utils'
 import { getThreadMessages } from '@/app/components/base/chat/utils'
@@ -182,6 +183,7 @@ export const useChat = (
   const handleStop = useCallback(() => {
     hasStopRespondedRef.current = true
     handleResponding(false)
+    AudioPlayerManager.getInstance().destroyCurrentAutoPlayAudioPlayer()
     if (stopChat && taskIdRef.current) stopChat(taskIdRef.current)
     setIterTimes(DEFAULT_ITER_TIMES)
     setLoopTimes(DEFAULT_LOOP_TIMES)

--- a/web/service/__tests__/completion-message.spec.ts
+++ b/web/service/__tests__/completion-message.spec.ts
@@ -1,0 +1,69 @@
+import { sendCompletionMessage as sendDebugCompletionMessage } from '../debug'
+import { AppSourceType, sendCompletionMessage as sendSharedCompletionMessage } from '../share'
+
+const { ssePostMock } = vi.hoisted(() => ({
+  ssePostMock: vi.fn(),
+}))
+
+vi.mock('../base', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../base')>()
+  return {
+    ...actual,
+    ssePost: ssePostMock,
+  }
+})
+
+const createCallbacks = () => ({
+  onData: vi.fn(),
+  onCompleted: vi.fn(),
+  onError: vi.fn(),
+  onMessageReplace: vi.fn(),
+  onTTSChunk: vi.fn(),
+  onTTSEnd: vi.fn(),
+  getAbortController: vi.fn(),
+})
+
+describe('completion message services', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ssePostMock.mockResolvedValue(undefined)
+  })
+
+  it('should forward tts callbacks for app debugging', async () => {
+    const callbacks = createCallbacks()
+
+    await sendDebugCompletionMessage('app-1', { inputs: { query: 'hello' } }, callbacks)
+
+    expect(ssePostMock).toHaveBeenCalledWith(
+      'apps/app-1/completion-messages',
+      { body: { inputs: { query: 'hello' }, response_mode: 'streaming' } },
+      expect.objectContaining({
+        onTTSChunk: callbacks.onTTSChunk,
+        onTTSEnd: callbacks.onTTSEnd,
+        getAbortController: callbacks.getAbortController,
+      }),
+    )
+  })
+
+  it('should forward tts callbacks for shared text-generation apps', async () => {
+    const callbacks = createCallbacks()
+
+    await sendSharedCompletionMessage(
+      { inputs: { query: 'hello' } },
+      callbacks,
+      AppSourceType.installedApp,
+      'installed-1',
+    )
+
+    expect(ssePostMock).toHaveBeenCalledWith(
+      'installed-apps/installed-1/completion-messages',
+      { body: { inputs: { query: 'hello' }, response_mode: 'streaming' } },
+      expect.objectContaining({
+        isPublicAPI: false,
+        onTTSChunk: callbacks.onTTSChunk,
+        onTTSEnd: callbacks.onTTSEnd,
+        getAbortController: callbacks.getAbortController,
+      }),
+    )
+  })
+})

--- a/web/service/base.ts
+++ b/web/service/base.ts
@@ -95,8 +95,8 @@ type IOnParallelBranchStarted = (parallelBranchStarted: ParallelBranchStartedRes
 type IOnParallelBranchFinished = (parallelBranchFinished: ParallelBranchFinishedResponse) => void
 type IOnTextChunk = (textChunk: TextChunkResponse) => void
 type IOnReasoning = (reasoningChunk: ReasoningChunkResponse) => void
-type IOnTTSChunk = (messageId: string, audioStr: string, audioType?: string) => void
-type IOnTTSEnd = (messageId: string, audioStr: string, audioType?: string) => void
+export type IOnTTSChunk = (messageId: string, audioStr: string, audioType?: string) => void
+export type IOnTTSEnd = (messageId: string, audioStr: string, audioType?: string) => void
 type IOnTextReplace = (textReplace: TextReplaceResponse) => void
 type IOnLoopStarted = (workflowStarted: LoopStartedResponse) => void
 type IOnLoopNext = (workflowStarted: LoopNextResponse) => void

--- a/web/service/debug.ts
+++ b/web/service/debug.ts
@@ -1,4 +1,11 @@
-import type { IOnCompleted, IOnData, IOnError, IOnMessageReplace } from './base'
+import type {
+  IOnCompleted,
+  IOnData,
+  IOnError,
+  IOnMessageReplace,
+  IOnTTSChunk,
+  IOnTTSEnd,
+} from './base'
 import type { ChatPromptConfig, CompletionPromptConfig } from '@/models/debug'
 import type { AppModeEnum, ModelModeType } from '@/types/app'
 import { get, post, ssePost } from './base'
@@ -30,11 +37,17 @@ export const sendCompletionMessage = async (
     onCompleted,
     onError,
     onMessageReplace,
+    onTTSChunk,
+    onTTSEnd,
+    getAbortController,
   }: {
     onData: IOnData
     onCompleted: IOnCompleted
     onError: IOnError
     onMessageReplace: IOnMessageReplace
+    onTTSChunk?: IOnTTSChunk
+    onTTSEnd?: IOnTTSEnd
+    getAbortController?: (abortController: AbortController) => void
   },
 ) => {
   return ssePost(
@@ -45,7 +58,15 @@ export const sendCompletionMessage = async (
         response_mode: 'streaming',
       },
     },
-    { onData, onCompleted, onError, onMessageReplace },
+    {
+      onData,
+      onCompleted,
+      onError,
+      onMessageReplace,
+      onTTSChunk,
+      onTTSEnd,
+      getAbortController,
+    },
   )
 }
 

--- a/web/service/share.ts
+++ b/web/service/share.ts
@@ -1,4 +1,12 @@
-import type { IOnCompleted, IOnData, IOnError, IOnMessageReplace, IOtherOptions } from './base'
+import type {
+  IOnCompleted,
+  IOnData,
+  IOnError,
+  IOnMessageReplace,
+  IOnTTSChunk,
+  IOnTTSEnd,
+  IOtherOptions,
+} from './base'
 import type { FormData as HumanInputFormData } from '@/app/(humanInputLayout)/form/[token]/form'
 import type { FeedbackType } from '@/app/components/base/chat/chat/type'
 import type { ChatConfig } from '@/app/components/base/chat/types'
@@ -76,12 +84,16 @@ export const sendCompletionMessage = async (
     onError,
     onMessageReplace,
     getAbortController,
+    onTTSChunk,
+    onTTSEnd,
   }: {
     onData: IOnData
     onCompleted: IOnCompleted
     onError: IOnError
     onMessageReplace: IOnMessageReplace
     getAbortController?: (abortController: AbortController) => void
+    onTTSChunk?: IOnTTSChunk
+    onTTSEnd?: IOnTTSEnd
   },
   appSourceType: AppSourceType,
   installedAppId = '',
@@ -101,6 +113,8 @@ export const sendCompletionMessage = async (
       onError,
       onMessageReplace,
       getAbortController,
+      onTTSChunk,
+      onTTSEnd,
     },
   )
 }


### PR DESCRIPTION
## Summary

Fixes #39456

Automatic TTS playback could start too late, stop before the remaining audio was emitted, or be affected by callbacks from a previous run. The behavior was inconsistent across Chat, Completion, Workflow, Explore, and app-debug flows.

This PR stabilizes the complete automatic-playback lifecycle:

- Prepare audio playback synchronously from the user's send or run action.
- Keep workflow completion behind queued TTS chunks and the final audio event.
- Reset the audio idle timeout whenever a new chunk arrives.
- Route Completion and Workflow TTS events to the automatic player.
- Track player ownership so stale callbacks cannot affect a newer run.
- Destroy owned players on stop, error, timeout, replacement, and unmount.

The change spans multiple app modes because they use separate streaming entry points but share the same automatic TTS playback contract. No unrelated playback behavior is changed.

## Review guide

The implementation can be reviewed in three parts:

1. **Backend stream ordering**
   - Ensure queued TTS output is flushed before workflow or message completion.

2. **Frontend player lifecycle**
   - Prepare playback during the user gesture.
   - Reuse only the player owned by the active run.
   - Clean up players on every terminal path.

3. **Streaming integrations**
   - Forward TTS callbacks through Chat, Completion, Workflow, Explore, and debug request paths.
   - Cover repeated runs, late callbacks, stop, error, timeout, and unmount behavior.

## Scope

Batch runs and multi-model debugging remain outside the existing automatic-playback scope.

## Screenshots

Not applicable. This change affects audio playback behavior without visual changes.

## Validation

- API pipeline tests: 67 passed
- Related frontend tests: 11 files, 208 tests passed
- `make lint`
- `make type-check`
- `pnpm check`
- `pnpm exec vp staged --diff 'origin/main...HEAD' --no-stash`
- `pnpm build`
- GitHub CI passed
- Manually verified automatic TTS playback in Chrome, Safari, and Firefox

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Codex
