### PR TITLE
fix(web): echo OAuth state on authorize redirect

### DIFF
--- a/web/app/account/oauth/authorize/__tests__/page.spec.tsx
+++ b/web/app/account/oauth/authorize/__tests__/page.spec.tsx
@@ -63,7 +63,8 @@ describe('OAuthAuthorize', () => {
     vi.clearAllMocks()
     mocks.searchParams = new URLSearchParams({
       client_id: 'client-1',
-      redirect_uri: 'https://client.example.com/callback?state=state-1',
+      redirect_uri: 'https://client.example.com/callback',
+      state: 'state-1',
     })
     mocks.request.mockImplementation(async (url: string) => {
       if (url.endsWith('/oauth/provider/authorize')) return jsonResponse({ code: 'oauth-code' })
@@ -86,7 +87,7 @@ describe('OAuthAuthorize', () => {
     vi.unstubAllGlobals()
   })
 
-  it('authorizes the displayed app and redirects with the returned code', async () => {
+  it('authorizes the displayed app and redirects with the returned code and state', async () => {
     const user = userEvent.setup()
     renderPage()
 
@@ -95,7 +96,7 @@ describe('OAuthAuthorize', () => {
     const providerTransportRequest = providerRequest?.[2]?.request as Request
     await expect(providerTransportRequest.clone().json()).resolves.toEqual({
       client_id: 'client-1',
-      redirect_uri: 'https://client.example.com/callback?state=state-1',
+      redirect_uri: 'https://client.example.com/callback',
     })
 
     await user.click(screen.getByRole('button', { name: /continue/i }))
@@ -106,7 +107,7 @@ describe('OAuthAuthorize', () => {
     await expect(transportRequest.clone().json()).resolves.toEqual({ client_id: 'client-1' })
     await waitFor(() =>
       expect(globalThis.location.href).toBe(
-        'https://client.example.com/callback?state=state-1&code=oauth-code',
+        'https://client.example.com/callback?code=oauth-code&state=state-1',
       ),
     )
   })

--- a/web/app/account/oauth/authorize/page.tsx
+++ b/web/app/account/oauth/authorize/page.tsx
@@ -64,6 +64,7 @@ export default function OAuthAuthorize() {
   const searchParams = useSearchParams()
   const client_id = decodeURIComponent(searchParams.get('client_id') || '')
   const redirect_uri = decodeURIComponent(searchParams.get('redirect_uri') || '')
+  const state = searchParams.get('state')
   const hasOAuthParams = Boolean(client_id && redirect_uri)
   // Probe user profile. 401 stays as `error` (legitimate "not logged in" state),
   // other errors throw to the nearest error.tsx; jumpTo same-pathname guard in
@@ -117,6 +118,7 @@ export default function OAuthAuthorize() {
       const { code } = await authorize({ body: { client_id } })
       const url = new URL(redirect_uri)
       url.searchParams.set('code', code)
+      if (state) url.searchParams.set('state', state)
       globalThis.location.href = url.toString()
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #39458

When a client starts the OAuth provider authorization flow with a `state` query parameter, the confirmation page now reads that value and echoes it on the post-authorize redirect URL together with the issued `code`.

Previously the page only appended `code`, so clients that rely on `state` for CSRF validation could not complete the round-trip. The unit test was also updated to pass `state` as a real OAuth query parameter instead of embedding it inside `redirect_uri`.

Verification:

- `cd web && pnpm exec vitest run app/account/oauth/authorize/__tests__/page.spec.tsx` (pass)

## Screenshots

N/A — backend/query-parameter behavior only; no UI layout change.

<img width="2354" height="600" alt="image" src="https://github.com/user-attachments/assets/139dda3f-c5f0-443d-a483-cefb785d1764" />

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods