### PR TITLE
fix: chat not pass doc if not support vision

### DIFF
--- a/web/app/components/app/configuration/config/config-document.tsx
+++ b/web/app/components/app/configuration/config/config-document.tsx
@@ -45,7 +45,7 @@ const ConfigDocument: FC = () => {
   if (!isShowDocumentConfig || (readonly && !isDocumentEnabled)) return null
 
   return (
-    <div className="mt-2 flex items-center gap-2 rounded-xl border-t-[0.5px] border-l-[0.5px] bg-background-section-burn p-2">
+    <div className="mt-2 flex items-center gap-2 rounded-xl border-t-[0.5px] border-l-[0.5px] border-effects-highlight bg-background-section-burn p-2">
       <div className="shrink-0 p-1">
         <div className="rounded-lg border-[0.5px] border-divider-subtle bg-util-colors-indigo-indigo-600 p-1 shadow-xs">
           <Document className="size-4 text-text-primary-on-surface" />
@@ -64,7 +64,7 @@ const ConfigDocument: FC = () => {
       </div>
       {!readonly && (
         <div className="flex shrink-0 items-center">
-          <div className="mr-3 ml-1 h-3.5 w-px bg-divider-subtle"></div>
+          <div className="mr-3 ml-1 h-3.5 w-px bg-divider-regular"></div>
           <Switch checked={isDocumentEnabled} onCheckedChange={handleChange} size="md" />
         </div>
       )}

--- a/web/app/components/app/configuration/debug/debug-with-single-model/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-single-model/__tests__/index.spec.tsx
@@ -16,6 +16,7 @@ import {
   ModelTypeEnum,
 } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import { CollectionType } from '@/app/components/tools/types'
+import { SupportUploadFileTypes } from '@/app/components/workflow/types'
 import { PromptMode } from '@/models/debug'
 import { renderWithAccountProfile as render } from '@/test/console/account-profile'
 import { AgentStrategy, AppModeEnum, ModelModeType, Resolution, TransferMethod } from '@/types/app'
@@ -461,6 +462,16 @@ const mockFile: FileEntity = {
   supportFileType: 'image',
 }
 
+const mockDocumentFile: FileEntity = {
+  id: 'file-2',
+  name: 'test.pdf',
+  size: 456,
+  type: 'application/pdf',
+  progress: 100,
+  transferMethod: TransferMethod.local_file,
+  supportFileType: SupportUploadFileTypes.document,
+}
+
 // Mock Chat component (complex with many dependencies)
 // This is a pragmatic mock that tests the integration at DebugWithSingleModel level
 vi.mock('@/app/components/base/chat/chat', () => ({
@@ -518,6 +529,13 @@ vi.mock('@/app/components/base/chat/chat', () => ({
           disabled={isResponding || readonly || inputDisabled}
         >
           Send With Files
+        </button>
+        <button
+          data-testid="send-with-mixed-files"
+          onClick={() => onSend?.('test message', [mockFile, mockDocumentFile])}
+          disabled={isResponding || readonly || inputDisabled}
+        >
+          Send With Mixed Files
         </button>
         {isResponding && (
           <button data-testid="stop-button" onClick={onStopResponding}>
@@ -1085,6 +1103,55 @@ describe('DebugWithSingleModel', () => {
 
       const body = mockSsePost.mock.calls[0]![1].body
       expect(body.files).toHaveLength(1)
+    })
+
+    it('should include only file types supported by the model', async () => {
+      mockUseProviderContext.mockReturnValue(
+        createMockProviderContext({
+          textGenerationModelList: [
+            {
+              provider: 'openai',
+              label: { en_US: 'OpenAI', zh_Hans: 'OpenAI' },
+              icon_small: { en_US: 'icon', zh_Hans: 'icon' },
+              status: ModelStatusEnum.active,
+              models: [
+                {
+                  model: 'gpt-3.5-turbo',
+                  label: { en_US: 'GPT-3.5', zh_Hans: 'GPT-3.5' },
+                  model_type: ModelTypeEnum.textGeneration,
+                  features: [ModelFeatureEnum.document],
+                  fetch_from: ConfigurationMethodEnum.predefinedModel,
+                  model_properties: {},
+                  deprecated: false,
+                  status: ModelStatusEnum.active,
+                  load_balancing_enabled: false,
+                },
+              ],
+            },
+          ],
+        }),
+      )
+      mockFeaturesState = {
+        ...defaultFeatures,
+        file: { enabled: true },
+      }
+
+      render(<DebugWithSingleModel ref={ref as RefObject<DebugWithSingleModelRefType>} />)
+      fireEvent.click(screen.getByTestId('send-with-mixed-files'))
+
+      await waitFor(() => {
+        expect(mockSsePost).toHaveBeenCalled()
+      })
+
+      const body = mockSsePost.mock.calls[0]![1].body
+      expect(body.files).toEqual([
+        {
+          type: SupportUploadFileTypes.document,
+          transfer_method: TransferMethod.local_file,
+          url: '',
+          upload_file_id: '',
+        },
+      ])
     })
   })
 })

--- a/web/app/components/app/configuration/debug/debug-with-single-model/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-single-model/__tests__/index.spec.tsx
@@ -531,11 +531,11 @@ vi.mock('@/app/components/base/chat/chat', () => ({
           Send With Files
         </button>
         <button
-          data-testid="send-with-mixed-files"
-          onClick={() => onSend?.('test message', [mockFile, mockDocumentFile])}
+          data-testid="send-with-document"
+          onClick={() => onSend?.('test message', [mockDocumentFile])}
           disabled={isResponding || readonly || inputDisabled}
         >
-          Send With Mixed Files
+          Send With Document
         </button>
         {isResponding && (
           <button data-testid="stop-button" onClick={onStopResponding}>
@@ -1003,7 +1003,7 @@ describe('DebugWithSingleModel', () => {
 
   // File Upload Tests
   describe('File Upload', () => {
-    it('should not include files when vision is not supported', async () => {
+    it('should include document files when document is supported without vision', async () => {
       mockUseDebugConfigurationContext.mockReturnValue({
         ...mockDebugConfigContext,
         modelConfig: createMockModelConfig({
@@ -1024,7 +1024,7 @@ describe('DebugWithSingleModel', () => {
                   model: 'gpt-3.5-turbo',
                   label: { en_US: 'GPT-3.5', zh_Hans: 'GPT-3.5' },
                   model_type: ModelTypeEnum.textGeneration,
-                  features: [], // No vision
+                  features: [ModelFeatureEnum.document],
                   fetch_from: ConfigurationMethodEnum.predefinedModel,
                   model_properties: {},
                   deprecated: false,
@@ -1044,14 +1044,21 @@ describe('DebugWithSingleModel', () => {
 
       render(<DebugWithSingleModel ref={ref as RefObject<DebugWithSingleModelRefType>} />)
 
-      fireEvent.click(screen.getByTestId('send-with-files'))
+      fireEvent.click(screen.getByTestId('send-with-document'))
 
       await waitFor(() => {
         expect(mockSsePost).toHaveBeenCalled()
       })
 
       const body = mockSsePost.mock.calls[0]![1].body
-      expect(body.files).toEqual([])
+      expect(body.files).toEqual([
+        {
+          type: SupportUploadFileTypes.document,
+          transfer_method: TransferMethod.local_file,
+          url: '',
+          upload_file_id: '',
+        },
+      ])
     })
 
     it('should support files when vision is enabled', async () => {
@@ -1103,55 +1110,6 @@ describe('DebugWithSingleModel', () => {
 
       const body = mockSsePost.mock.calls[0]![1].body
       expect(body.files).toHaveLength(1)
-    })
-
-    it('should include only file types supported by the model', async () => {
-      mockUseProviderContext.mockReturnValue(
-        createMockProviderContext({
-          textGenerationModelList: [
-            {
-              provider: 'openai',
-              label: { en_US: 'OpenAI', zh_Hans: 'OpenAI' },
-              icon_small: { en_US: 'icon', zh_Hans: 'icon' },
-              status: ModelStatusEnum.active,
-              models: [
-                {
-                  model: 'gpt-3.5-turbo',
-                  label: { en_US: 'GPT-3.5', zh_Hans: 'GPT-3.5' },
-                  model_type: ModelTypeEnum.textGeneration,
-                  features: [ModelFeatureEnum.document],
-                  fetch_from: ConfigurationMethodEnum.predefinedModel,
-                  model_properties: {},
-                  deprecated: false,
-                  status: ModelStatusEnum.active,
-                  load_balancing_enabled: false,
-                },
-              ],
-            },
-          ],
-        }),
-      )
-      mockFeaturesState = {
-        ...defaultFeatures,
-        file: { enabled: true },
-      }
-
-      render(<DebugWithSingleModel ref={ref as RefObject<DebugWithSingleModelRefType>} />)
-      fireEvent.click(screen.getByTestId('send-with-mixed-files'))
-
-      await waitFor(() => {
-        expect(mockSsePost).toHaveBeenCalled()
-      })
-
-      const body = mockSsePost.mock.calls[0]![1].body
-      expect(body.files).toEqual([
-        {
-          type: SupportUploadFileTypes.document,
-          transfer_method: TransferMethod.local_file,
-          url: '',
-          upload_file_id: '',
-        },
-      ])
     })
   })
 })

--- a/web/app/components/app/configuration/debug/debug-with-single-model/index.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-single-model/index.tsx
@@ -9,8 +9,6 @@ import Chat from '@/app/components/base/chat/chat'
 import { useChat } from '@/app/components/base/chat/chat/hooks'
 import { getLastAnswer, isValidGeneratedAnswer } from '@/app/components/base/chat/utils'
 import { useFeatures } from '@/app/components/base/features/hooks'
-import { ModelFeatureEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
-import { SupportUploadFileTypes } from '@/app/components/workflow/types'
 import { userProfileAtom } from '@/context/account-state'
 import { useDebugConfigurationContext } from '@/context/debug-configuration'
 import { useProviderContext } from '@/context/provider-context'
@@ -28,20 +26,6 @@ type DebugWithSingleModelProps = {
 export type DebugWithSingleModelRefType = {
   handleRestart: () => void
 }
-
-function getRequiredModelFeature(fileType: string): ModelFeatureEnum | undefined {
-  switch (fileType) {
-    case SupportUploadFileTypes.image:
-      return ModelFeatureEnum.vision
-    case SupportUploadFileTypes.document:
-      return ModelFeatureEnum.document
-    case SupportUploadFileTypes.audio:
-      return ModelFeatureEnum.audio
-    case SupportUploadFileTypes.video:
-      return ModelFeatureEnum.video
-  }
-}
-
 const DebugWithSingleModel = ({
   ref,
   checkCanSend,
@@ -112,16 +96,6 @@ const DebugWithSingleModel = ({
     (message, files, isRegenerate = false, parentAnswer: ChatItem | null = null) => {
       if (!canTestAndRun) return
       if (checkCanSend && !checkCanSend()) return
-      const currentProvider = textGenerationModelList.find(
-        (item) => item.provider === modelConfig.provider,
-      )
-      const currentModel = currentProvider?.models.find(
-        (model) => model.model === modelConfig.model_id,
-      )
-      const supportedFiles = files?.filter((file) => {
-        const requiredFeature = getRequiredModelFeature(file.supportFileType)
-        return requiredFeature ? currentModel?.features?.includes(requiredFeature) === true : false
-      })
 
       const configData = {
         ...config,
@@ -140,8 +114,7 @@ const DebugWithSingleModel = ({
         parent_message_id: (isRegenerate ? parentAnswer?.id : getLastAnswer(chatList)?.id) || null,
       }
 
-      if ((config.file_upload as any)?.enabled && supportedFiles?.length)
-        data.files = supportedFiles
+      if ((config.file_upload as any)?.enabled && files?.length) data.files = files
 
       handleSend(`apps/${appId}/chat-messages`, data, {
         onGetConversationMessages: (conversationId, getAbortController) =>

--- a/web/app/components/app/configuration/debug/debug-with-single-model/index.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-single-model/index.tsx
@@ -9,7 +9,6 @@ import Chat from '@/app/components/base/chat/chat'
 import { useChat } from '@/app/components/base/chat/chat/hooks'
 import { getLastAnswer, isValidGeneratedAnswer } from '@/app/components/base/chat/utils'
 import { useFeatures } from '@/app/components/base/features/hooks'
-import { ModelFeatureEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import { userProfileAtom } from '@/context/account-state'
 import { useDebugConfigurationContext } from '@/context/debug-configuration'
 import { useProviderContext } from '@/context/provider-context'
@@ -97,13 +96,6 @@ const DebugWithSingleModel = ({
     (message, files, isRegenerate = false, parentAnswer: ChatItem | null = null) => {
       if (!canTestAndRun) return
       if (checkCanSend && !checkCanSend()) return
-      const currentProvider = textGenerationModelList.find(
-        (item) => item.provider === modelConfig.provider,
-      )
-      const currentModel = currentProvider?.models.find(
-        (model) => model.model === modelConfig.model_id,
-      )
-      const supportVision = currentModel?.features?.includes(ModelFeatureEnum.vision)
 
       const configData = {
         ...config,
@@ -122,7 +114,7 @@ const DebugWithSingleModel = ({
         parent_message_id: (isRegenerate ? parentAnswer?.id : getLastAnswer(chatList)?.id) || null,
       }
 
-      if ((config.file_upload as any)?.enabled && files?.length && supportVision) data.files = files
+      if ((config.file_upload as any)?.enabled && files?.length) data.files = files
 
       handleSend(`apps/${appId}/chat-messages`, data, {
         onGetConversationMessages: (conversationId, getAbortController) =>

--- a/web/app/components/app/configuration/debug/debug-with-single-model/index.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-single-model/index.tsx
@@ -9,6 +9,8 @@ import Chat from '@/app/components/base/chat/chat'
 import { useChat } from '@/app/components/base/chat/chat/hooks'
 import { getLastAnswer, isValidGeneratedAnswer } from '@/app/components/base/chat/utils'
 import { useFeatures } from '@/app/components/base/features/hooks'
+import { ModelFeatureEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
+import { SupportUploadFileTypes } from '@/app/components/workflow/types'
 import { userProfileAtom } from '@/context/account-state'
 import { useDebugConfigurationContext } from '@/context/debug-configuration'
 import { useProviderContext } from '@/context/provider-context'
@@ -26,6 +28,20 @@ type DebugWithSingleModelProps = {
 export type DebugWithSingleModelRefType = {
   handleRestart: () => void
 }
+
+function getRequiredModelFeature(fileType: string): ModelFeatureEnum | undefined {
+  switch (fileType) {
+    case SupportUploadFileTypes.image:
+      return ModelFeatureEnum.vision
+    case SupportUploadFileTypes.document:
+      return ModelFeatureEnum.document
+    case SupportUploadFileTypes.audio:
+      return ModelFeatureEnum.audio
+    case SupportUploadFileTypes.video:
+      return ModelFeatureEnum.video
+  }
+}
+
 const DebugWithSingleModel = ({
   ref,
   checkCanSend,
@@ -96,6 +112,16 @@ const DebugWithSingleModel = ({
     (message, files, isRegenerate = false, parentAnswer: ChatItem | null = null) => {
       if (!canTestAndRun) return
       if (checkCanSend && !checkCanSend()) return
+      const currentProvider = textGenerationModelList.find(
+        (item) => item.provider === modelConfig.provider,
+      )
+      const currentModel = currentProvider?.models.find(
+        (model) => model.model === modelConfig.model_id,
+      )
+      const supportedFiles = files?.filter((file) => {
+        const requiredFeature = getRequiredModelFeature(file.supportFileType)
+        return requiredFeature ? currentModel?.features?.includes(requiredFeature) === true : false
+      })
 
       const configData = {
         ...config,
@@ -114,7 +140,8 @@ const DebugWithSingleModel = ({
         parent_message_id: (isRegenerate ? parentAnswer?.id : getLastAnswer(chatList)?.id) || null,
       }
 
-      if ((config.file_upload as any)?.enabled && files?.length) data.files = files
+      if ((config.file_upload as any)?.enabled && supportedFiles?.length)
+        data.files = supportedFiles
 
       handleSend(`apps/${appId}/chat-messages`, data, {
         onGetConversationMessages: (conversationId, getAbortController) =>


### PR DESCRIPTION

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
