### PR TITLE
feat(oauth): expose stable account id on provider account endpoint

### DIFF
--- a/api/controllers/console/auth/oauth_server.py
+++ b/api/controllers/console/auth/oauth_server.py
@@ -56,6 +56,7 @@ class OAuthProviderTokenResponse(BaseModel):
 
 
 class OAuthProviderAccountResponse(BaseModel):
+    id: str
     name: str
     email: str
     avatar: str | None = None
@@ -251,6 +252,7 @@ class OAuthServerUserAccountApi(Resource):
     def post(self, oauth_provider_app: OAuthProviderApp, account: Account):
         return jsonable_encoder(
             {
+                "id": account.id,
                 "name": account.name,
                 "email": account.email,
                 "avatar": account.avatar,

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -19559,6 +19559,7 @@ Coarse node-level status used by Inspector to pick a banner.
 | ---- | ---- | ----------- | -------- |
 | avatar | string |  | No |
 | email | string |  | Yes |
+| id | string |  | Yes |
 | interface_language | string |  | Yes |
 | name | string |  | Yes |
 | timezone | string |  | Yes |

--- a/api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth_server.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/auth/test_oauth_server.py
@@ -318,6 +318,7 @@ def test_oauth_account_successful_retrieval(
 
     assert response.status_code == 200
     assert response.get_json() == {
+        "id": account.id,
         "name": "Test User",
         "email": account.email,
         "avatar": "avatar_url",

--- a/api/tests/unit_tests/controllers/console/auth/test_oauth_server.py
+++ b/api/tests/unit_tests/controllers/console/auth/test_oauth_server.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from inspect import unwrap
 from unittest.mock import patch
 
-from controllers.console.auth.oauth_server import OAuthServerUserAuthorizeApi
+from controllers.console.auth.oauth_server import OAuthServerUserAccountApi, OAuthServerUserAuthorizeApi
 from models import Account
 from models.account import AccountStatus, TenantAccountRole
 from models.model import OAuthProviderApp
@@ -45,3 +45,13 @@ def test_oauth_authorize_uses_injected_current_user() -> None:
 
     sign_oauth_authorization_code.assert_called_once_with("client-1", "account-1")
     assert response == {"code": "authorization-code"}
+
+
+def test_oauth_account_returns_stable_account_id() -> None:
+    api = OAuthServerUserAccountApi()
+    method = unwrap(api.post)
+    account = _make_account()
+
+    response = method(api, _make_oauth_provider_app(), account)
+
+    assert response["id"] == "account-1"

--- a/packages/contracts/generated/api/console/oauth/types.gen.ts
+++ b/packages/contracts/generated/api/console/oauth/types.gen.ts
@@ -40,6 +40,7 @@ export type OAuthClientPayload = {
 export type OAuthProviderAccountResponse = {
   avatar?: string | null
   email: string
+  id: string
   interface_language: string
   name: string
   timezone: string

--- a/packages/contracts/generated/api/console/oauth/zod.gen.ts
+++ b/packages/contracts/generated/api/console/oauth/zod.gen.ts
@@ -60,6 +60,7 @@ export const zOAuthClientPayload = z.object({
 export const zOAuthProviderAccountResponse = z.object({
   avatar: z.string().nullish(),
   email: z.string(),
+  id: z.string(),
   interface_language: z.string(),
   name: z.string(),
   timezone: z.string(),


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #39469

The OAuth provider account endpoint (`POST /console/api/oauth/provider/account`) returned only mutable profile fields (`name`, `email`, `avatar`, `interface_language`, `timezone`). OAuth clients that treat email as the stable subject can create duplicate local users after a Dify account email change.

This change:

- Adds required `id: str` to `OAuthProviderAccountResponse`
- Returns the immutable `Account.id` from `OAuthServerUserAccountApi`
- Keeps all existing response fields for backward compatibility
- Adds unit and container integration coverage for the new field

### Verification

- `uv run --project api pytest api/tests/unit_tests/controllers/console/auth/test_oauth_server.py -q` (passed)

## Screenshots

Not applicable (API response schema change only).

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

## Considered and deferred

- packages/contracts/generated/api/console/oauth/* [BOT-SCOPE]: generated OpenAPI contracts still omit `id`; regenerating them is outside this commit's file set. Runtime response schema is updated via OAuthProviderAccountResponse.
- api/models/model.py OAuth scope defaults [BOT-NIT]: default scope string does not list a read:id claim; this endpoint already returns a fixed payload and does not enforce field-level scopes.