### PR TITLE
fix: filter agent files by type-specific model feature instead of vision alone

### DIFF
--- a/api/core/agent/base_agent_runner.py
+++ b/api/core/agent/base_agent_runner.py
@@ -38,6 +38,7 @@ from graphon.model_runtime.entities import (
     ToolPromptMessage,
     UserPromptMessage,
 )
+from graphon.file.enums import FileType
 from graphon.model_runtime.entities.message_entities import ImagePromptMessageContent, PromptMessageContentUnionTypes
 from graphon.model_runtime.entities.model_entities import ModelFeature
 from graphon.model_runtime.model_providers.base.large_language_model import LargeLanguageModel
@@ -46,6 +47,16 @@ from models.model import Conversation, Message, MessageAgentThought, MessageFile
 
 logger = logging.getLogger(__name__)
 _file_access_controller = DatabaseFileAccessController()
+
+# Maps each file type to the model feature required to pass it to the LLM.
+# Mirrors _REQUIRED_MODEL_FEATURE_BY_CONTENT_TYPE in graphon so that non-image
+# files (e.g. documents) are not dropped just because the model lacks vision.
+_REQUIRED_MODEL_FEATURE_BY_FILE_TYPE: dict[FileType, ModelFeature] = {
+    FileType.IMAGE: ModelFeature.VISION,
+    FileType.DOCUMENT: ModelFeature.DOCUMENT,
+    FileType.AUDIO: ModelFeature.AUDIO,
+    FileType.VIDEO: ModelFeature.VIDEO,
+}
 
 
 class BaseAgentRunner(AppRunner):
@@ -122,7 +133,14 @@ class BaseAgentRunner(AppRunner):
         model_schema = llm_model.get_model_schema(model_instance.model_name, model_instance.credentials)
         features = model_schema.features if model_schema and model_schema.features else []
         self.stream_tool_call = ModelFeature.STREAM_TOOL_CALL in features
-        self.files = application_generate_entity.files if ModelFeature.VISION in features else []
+        # Filter files by the model feature each file type requires, instead of
+        # gating all files on vision alone. Without this, document/audio/video
+        # files are silently dropped when the model does not support vision.
+        self.files = [
+            f
+            for f in (application_generate_entity.files or [])
+            if _REQUIRED_MODEL_FEATURE_BY_FILE_TYPE.get(f.type, ModelFeature.VISION) in features
+        ]
         self.query: str = ""
         self._current_thoughts: list[PromptMessage] = []
 

--- a/api/core/agent/base_agent_runner.py
+++ b/api/core/agent/base_agent_runner.py
@@ -28,6 +28,7 @@ from core.tools.utils.dataset_retriever_tool import DatasetRetrieverTool
 from extensions.ext_database import db
 from factories import file_factory
 from graphon.file import file_manager
+from graphon.file.enums import FileType
 from graphon.model_runtime.entities import (
     AssistantPromptMessage,
     LLMUsage,
@@ -38,7 +39,6 @@ from graphon.model_runtime.entities import (
     ToolPromptMessage,
     UserPromptMessage,
 )
-from graphon.file.enums import FileType
 from graphon.model_runtime.entities.message_entities import ImagePromptMessageContent, PromptMessageContentUnionTypes
 from graphon.model_runtime.entities.model_entities import ModelFeature
 from graphon.model_runtime.model_providers.base.large_language_model import LargeLanguageModel

--- a/api/tests/unit_tests/core/agent/test_base_agent_runner.py
+++ b/api/tests/unit_tests/core/agent/test_base_agent_runner.py
@@ -561,6 +561,61 @@ class TestBaseAgentRunnerInit:
         assert get_dataset_tools.call_args.kwargs["session"] is caller_session
         assert global_session.mock_calls == []
 
+    def test_init_filters_files_by_type_not_vision(self, mocker: MockerFixture):
+        """Regression test for https://github.com/langgenius/dify/issues/39431
+
+        Documents should be kept when the model supports DOCUMENT, even if it
+        does not support VISION. The old code gated all files on VISION alone.
+        """
+        from graphon.file.enums import FileType
+        from graphon.file.models import File
+
+        caller_session = mocker.MagicMock()
+        caller_session.scalar.return_value = 0
+        global_session = mocker.MagicMock()
+        mocker.patch.object(model_module.db, "session", global_session)
+        mocker.patch.object(BaseAgentRunner, "organize_agent_history", return_value=[])
+        mocker.patch.object(module.DatasetRetrieverTool, "get_dataset_tools", return_value=[])
+
+        llm = mocker.MagicMock()
+        # Model supports DOCUMENT but NOT VISION
+        llm.get_model_schema.return_value = mocker.MagicMock(
+            features=[module.ModelFeature.DOCUMENT]
+        )
+        model_instance = mocker.MagicMock(model_type_instance=llm, model="m", credentials="c")
+
+        app_config = mocker.MagicMock()
+        app_config.app_id = "app1"
+        app_config.agent = None
+        app_config.dataset = mocker.MagicMock(dataset_ids=[], retrieve_config={"k": "v"})
+        app_config.additional_features = mocker.MagicMock(show_retrieve_source=False)
+
+        doc_file = File(type=FileType.DOCUMENT, transfer_method="local_file", url="http://x")
+        image_file = File(type=FileType.IMAGE, transfer_method="local_file", url="http://y")
+
+        app_generate = mocker.MagicMock(
+            invoke_from="test", inputs={}, files=[doc_file, image_file]
+        )
+
+        runner = BaseAgentRunner(
+            session=caller_session,
+            tenant_id="tenant",
+            application_generate_entity=app_generate,
+            conversation=mocker.MagicMock(),
+            app_config=app_config,
+            model_config=mocker.MagicMock(),
+            config=mocker.MagicMock(),
+            queue_manager=mocker.MagicMock(),
+            message=mocker.MagicMock(id="msg1", conversation_id="conv1"),
+            user_id="user",
+            model_instance=model_instance,
+        )
+
+        # Document file should be kept; image file should be filtered out
+        assert doc_file in runner.files
+        assert image_file not in runner.files
+        assert len(runner.files) == 1
+
 
 class TestBaseAgentRunnerCoverage:
     def test_init_prompt_tools_adds_dataset_tools(self, runner: BaseAgentRunner, mocker: MockerFixture):

--- a/api/tests/unit_tests/core/agent/test_base_agent_runner.py
+++ b/api/tests/unit_tests/core/agent/test_base_agent_runner.py
@@ -579,9 +579,7 @@ class TestBaseAgentRunnerInit:
 
         llm = mocker.MagicMock()
         # Model supports DOCUMENT but NOT VISION
-        llm.get_model_schema.return_value = mocker.MagicMock(
-            features=[module.ModelFeature.DOCUMENT]
-        )
+        llm.get_model_schema.return_value = mocker.MagicMock(features=[module.ModelFeature.DOCUMENT])
         model_instance = mocker.MagicMock(model_type_instance=llm, model="m", credentials="c")
 
         app_config = mocker.MagicMock()
@@ -593,9 +591,7 @@ class TestBaseAgentRunnerInit:
         doc_file = File(type=FileType.DOCUMENT, transfer_method="local_file", url="http://x")
         image_file = File(type=FileType.IMAGE, transfer_method="local_file", url="http://y")
 
-        app_generate = mocker.MagicMock(
-            invoke_from="test", inputs={}, files=[doc_file, image_file]
-        )
+        app_generate = mocker.MagicMock(invoke_from="test", inputs={}, files=[doc_file, image_file])
 
         runner = BaseAgentRunner(
             session=caller_session,

--- a/api/tests/unit_tests/core/agent/test_base_agent_runner.py
+++ b/api/tests/unit_tests/core/agent/test_base_agent_runner.py
@@ -539,7 +539,12 @@ class TestBaseAgentRunnerInit:
         from graphon.file.enums import FileTransferMethod, FileType
         from graphon.file.models import File
 
-        file1 = File(file_type=FileType.IMAGE, transfer_method=FileTransferMethod.LOCAL_FILE, url="http://x")
+        file1 = File(
+            file_type=FileType.IMAGE,
+            transfer_method=FileTransferMethod.LOCAL_FILE,
+            upload_file_id="f1",
+            url="http://x",
+        )
         app_generate = mocker.MagicMock(invoke_from="test", inputs={}, files=[file1])
         message = mocker.MagicMock(id="msg1", conversation_id="conv1")
 
@@ -592,8 +597,18 @@ class TestBaseAgentRunnerInit:
         app_config.dataset = mocker.MagicMock(dataset_ids=[], retrieve_config={"k": "v"})
         app_config.additional_features = mocker.MagicMock(show_retrieve_source=False)
 
-        doc_file = File(file_type=FileType.DOCUMENT, transfer_method=FileTransferMethod.LOCAL_FILE, url="http://x")
-        image_file = File(file_type=FileType.IMAGE, transfer_method=FileTransferMethod.LOCAL_FILE, url="http://y")
+        doc_file = File(
+            file_type=FileType.DOCUMENT,
+            transfer_method=FileTransferMethod.LOCAL_FILE,
+            upload_file_id="doc1",
+            url="http://x",
+        )
+        image_file = File(
+            file_type=FileType.IMAGE,
+            transfer_method=FileTransferMethod.LOCAL_FILE,
+            upload_file_id="img1",
+            url="http://y",
+        )
 
         app_generate = mocker.MagicMock(invoke_from="test", inputs={}, files=[doc_file, image_file])
 

--- a/api/tests/unit_tests/core/agent/test_base_agent_runner.py
+++ b/api/tests/unit_tests/core/agent/test_base_agent_runner.py
@@ -536,7 +536,11 @@ class TestBaseAgentRunnerInit:
         app_config.dataset = mocker.MagicMock(dataset_ids=["d1"], retrieve_config={"k": "v"})
         app_config.additional_features = mocker.MagicMock(show_retrieve_source=True)
 
-        app_generate = mocker.MagicMock(invoke_from="test", inputs={}, files=["file1"])
+        from graphon.file.enums import FileTransferMethod, FileType
+        from graphon.file.models import File
+
+        file1 = File(file_type=FileType.IMAGE, transfer_method=FileTransferMethod.LOCAL_FILE, url="http://x")
+        app_generate = mocker.MagicMock(invoke_from="test", inputs={}, files=[file1])
         message = mocker.MagicMock(id="msg1", conversation_id="conv1")
 
         runner = BaseAgentRunner(
@@ -554,7 +558,7 @@ class TestBaseAgentRunnerInit:
         )
 
         assert runner.stream_tool_call is True
-        assert runner.files == ["file1"]
+        assert runner.files == [file1]
         assert runner.dataset_tools == ["ds_tool"]
         assert runner.agent_thought_count == 2
         organize_agent_history.assert_called_once_with(session=caller_session, prompt_messages=[])
@@ -567,7 +571,7 @@ class TestBaseAgentRunnerInit:
         Documents should be kept when the model supports DOCUMENT, even if it
         does not support VISION. The old code gated all files on VISION alone.
         """
-        from graphon.file.enums import FileType
+        from graphon.file.enums import FileTransferMethod, FileType
         from graphon.file.models import File
 
         caller_session = mocker.MagicMock()
@@ -588,8 +592,8 @@ class TestBaseAgentRunnerInit:
         app_config.dataset = mocker.MagicMock(dataset_ids=[], retrieve_config={"k": "v"})
         app_config.additional_features = mocker.MagicMock(show_retrieve_source=False)
 
-        doc_file = File(type=FileType.DOCUMENT, transfer_method="local_file", url="http://x")
-        image_file = File(type=FileType.IMAGE, transfer_method="local_file", url="http://y")
+        doc_file = File(file_type=FileType.DOCUMENT, transfer_method=FileTransferMethod.LOCAL_FILE, url="http://x")
+        image_file = File(file_type=FileType.IMAGE, transfer_method=FileTransferMethod.LOCAL_FILE, url="http://y")
 
         app_generate = mocker.MagicMock(invoke_from="test", inputs={}, files=[doc_file, image_file])
 

--- a/api/tests/unit_tests/core/agent/test_fc_agent_runner.py
+++ b/api/tests/unit_tests/core/agent/test_fc_agent_runner.py
@@ -240,6 +240,9 @@ class TestOrganizeUserQuery:
         assert len(result) == 1
 
     def test_with_files_uses_image_detail_config(self, runner: FunctionCallAgentRunner, mocker: MockerFixture):
+        from graphon.file.enums import FileTransferMethod, FileType
+        from graphon.file.models import File
+
         file_content = TextPromptMessageContent(data="file-content")
         mock_to_prompt = mocker.patch(
             "core.agent.fc_agent_runner.file_manager.to_prompt_message_content",
@@ -248,13 +251,19 @@ class TestOrganizeUserQuery:
 
         image_config = MagicMock(detail=ImagePromptMessageContent.DETAIL.HIGH)
         runner.application_generate_entity.file_upload_config = MagicMock(image_config=image_config)
-        runner.files = ["file1"]
+        test_file = File(
+            file_type=FileType.IMAGE,
+            transfer_method=FileTransferMethod.REMOTE_URL,
+            remote_url="https://example.com/file1.png",
+            filename="file1.png",
+        )
+        runner.files = [test_file]
 
         result = runner._organize_user_query("query", [])
 
         assert len(result) == 1
         assert isinstance(result[0].content, list)
-        mock_to_prompt.assert_called_once_with("file1", image_detail_config=ImagePromptMessageContent.DETAIL.HIGH)
+        mock_to_prompt.assert_called_once_with(test_file, image_detail_config=ImagePromptMessageContent.DETAIL.HIGH)
 
 
 # ==============================


### PR DESCRIPTION
### Related Issues/PRs

Fixes #39431

### What changes are proposed in this pull request?

When a model does not declare the `VISION` feature (e.g. qwen-long), all uploaded files were silently dropped because the agent runner gated `self.files` on a single `ModelFeature.VISION` check. This meant document files like Excel spreadsheets never reached the LLM even when the model supported the `DOCUMENT` feature.

The fix filters each file by the model feature its type requires, mirroring the existing `_REQUIRED_MODEL_FEATURE_BY_CONTENT_TYPE` mapping in graphon:
- `IMAGE` → `VISION`
- `DOCUMENT` → `DOCUMENT`
- `AUDIO` → `AUDIO`
- `VIDEO` → `VIDEO`

This ensures non-image files are passed through when the model supports them, instead of being dropped just because the model lacks vision.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New regression test `test_init_filters_files_by_type_not_vision` verifies that a document file is kept when the model supports `DOCUMENT` but not `VISION`, while an image file is correctly filtered out.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Files uploaded to agents are no longer silently dropped when the model does not support vision but does support the file type (e.g. documents).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release