### PR TITLE
fix: don't report a declined collaboration sync as a draft save failure

### DIFF
--- a/web/app/components/workflow-app/hooks/__tests__/use-nodes-sync-draft.spec.ts
+++ b/web/app/components/workflow-app/hooks/__tests__/use-nodes-sync-draft.spec.ts
@@ -670,7 +670,10 @@ describe('useNodesSyncDraft — a declined collaboration sync is not a failure',
   it('STILL calls onError when a genuine draft POST fails (collaboration ready)', async () => {
     // When the pre-check passes and the actual POST rejects, that is a real failure and must report.
     mockCollaborationCanPersistLocalGraph.mockReturnValue(true)
-    const error = { json: vi.fn().mockResolvedValue({ code: 'internal_server_error' }), bodyUsed: false }
+    const error = {
+      json: vi.fn().mockResolvedValue({ code: 'internal_server_error' }),
+      bodyUsed: false,
+    }
     mockSyncWorkflowDraft.mockRejectedValue(error)
     const callbacks = { onError: vi.fn(), onSuccess: vi.fn(), onSettled: vi.fn() }
 

--- a/web/app/components/workflow-app/hooks/__tests__/use-nodes-sync-draft.spec.ts
+++ b/web/app/components/workflow-app/hooks/__tests__/use-nodes-sync-draft.spec.ts
@@ -609,3 +609,78 @@ describe('useNodesSyncDraft — handleRefreshWorkflowDraft(true) on 409', () => 
     expect(mockPostWithKeepalive).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('useNodesSyncDraft — a declined collaboration sync is not a failure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    reactFlowState = {
+      getNodes: mockGetNodes,
+      edges: [],
+      transform: [0, 0, 1],
+    }
+    workflowStoreState = {
+      appId: 'app-1',
+      isWorkflowDataLoaded: true,
+      syncWorkflowDraftHash: 'hash-123',
+      environmentVariables: [],
+      conversationVariables: [],
+      setSyncWorkflowDraftHash: mockSetSyncWorkflowDraftHash,
+      setDraftUpdatedAt: mockSetDraftUpdatedAt,
+    }
+    featuresState = {
+      features: {
+        opening: { enabled: false, opening_statement: '', suggested_questions: [] },
+        suggested: {},
+        text2speech: {},
+        speech2text: {},
+        citation: {},
+        moderation: {},
+        file: {},
+      },
+    }
+    mockGetNodesReadOnly.mockReturnValue(false)
+    mockGetNodes.mockReturnValue([
+      { id: 'n1', position: { x: 0, y: 0 }, data: { type: BlockEnum.Start } },
+    ])
+    mockSyncWorkflowDraft.mockResolvedValue({ hash: 'new', updated_at: 1 })
+    isCollaborationEnabled = true
+    // isConnected=false keeps doSyncWorkflowDraft on the local-sync path (not the leader request),
+    // so the collaboration pre-check in performLocalSync is exercised.
+    mockCollaborationIsConnected.mockReturnValue(false)
+    mockCollaborationGetIsLeader.mockReturnValue(true)
+    mockCollaborationCanFlushGraphOnPageClose.mockReturnValue(true)
+  })
+
+  it('does NOT call onError and makes no POST when canPersistLocalGraph() declines', async () => {
+    // The collaboration pre-check declines to persist the local graph: no request is made and the
+    // CRDT/server holds the graph, so this is a no-op, not a save failure.
+    mockCollaborationCanPersistLocalGraph.mockReturnValue(false)
+    const callbacks = { onError: vi.fn(), onSuccess: vi.fn(), onSettled: vi.fn() }
+
+    const { result } = renderUseNodesSyncDraft()
+    await act(async () => {
+      await result.current.doSyncWorkflowDraft(true, callbacks)
+    })
+
+    expect(mockSyncWorkflowDraft).not.toHaveBeenCalled()
+    expect(callbacks.onError).not.toHaveBeenCalled()
+    expect(callbacks.onSettled).toHaveBeenCalled()
+  })
+
+  it('STILL calls onError when a genuine draft POST fails (collaboration ready)', async () => {
+    // When the pre-check passes and the actual POST rejects, that is a real failure and must report.
+    mockCollaborationCanPersistLocalGraph.mockReturnValue(true)
+    const error = { json: vi.fn().mockResolvedValue({ code: 'internal_server_error' }), bodyUsed: false }
+    mockSyncWorkflowDraft.mockRejectedValue(error)
+    const callbacks = { onError: vi.fn(), onSuccess: vi.fn(), onSettled: vi.fn() }
+
+    const { result } = renderUseNodesSyncDraft()
+    await act(async () => {
+      await result.current.doSyncWorkflowDraft(true, callbacks)
+    })
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(mockSyncWorkflowDraft).toHaveBeenCalled()
+    expect(callbacks.onError).toHaveBeenCalled()
+  })
+})

--- a/web/app/components/workflow-app/hooks/use-nodes-sync-draft.ts
+++ b/web/app/components/workflow-app/hooks/use-nodes-sync-draft.ts
@@ -151,7 +151,11 @@ const useNodesSyncDraftBase = (getNodesReadOnly: () => boolean) => {
       if (getNodesReadOnly()) return null
 
       if (isCollaborationEnabled && !collaborationManager.canPersistLocalGraph()) {
-        callback?.onError?.()
+        // Collaboration declined to persist the local graph (e.g. the graph view is no longer
+        // active while leaving the editor). No request is made, and the shared CRDT/server holds
+        // the graph, so this is a no-op rather than a save failure — it must not surface a
+        // "Draft save failed" toast. Genuine failures (the syncWorkflowDraft rejection below and
+        // the leader-sync catch) still call onError.
         callback?.onSettled?.()
         return null
       }


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

Fixes #39481.

Opening a workflow and then navigating back to Home shows a persistent "Draft save failed" toast when collaboration is enabled — even though no draft request is made and no save actually fails.

This surfaces from the interaction of two independently-correct changes:

- #39353 (which fixed #39352 / #39355) guarded the unmount cleanup in `web/app/components/workflow/index.tsx` on `!collaborationManager.canPersistLocalGraph()`.
- #39370 changed that guard to `!collaborationManager.canFlushGraphOnPageClose()` so that draft saves are skipped when non-leader collaborators leave the page.

`canFlushGraphOnPageClose()` and `canPersistLocalGraph()` share `crdtTrusted && !graphReloadRequired`, but differ otherwise: `canFlushGraphOnPageClose()` additionally requires `isLeader` and has a sole-user exception (`collaboration-manager.ts:762-770`), while `canPersistLocalGraph()` additionally requires `graphViewActive !== false`. So when the sole leader leaves the editor, `canFlushGraphOnPageClose()` returns `true` (sole user) and the cleanup proceeds — but `performLocalSync` then declines via `canPersistLocalGraph()` and called `callback?.onError?.()`, which the cleanup turns into the toast. No request is sent on that path, and in collaboration mode the shared CRDT/server already holds the graph.

This change stops that declined pre-check from reporting an error, in `web/app/components/workflow-app/hooks/use-nodes-sync-draft.ts`: it keeps `onSettled` and the early return and only drops the `onError` call. Genuine failures are unaffected — the `syncWorkflowDraft` POST rejection and the leader-sync request rejection still call `onError`.

Scope and limits:
- This only stops *reporting* a deliberate decline; it does not change *when* syncing happens, and it does not touch the cleanup guard, `canPersistLocalGraph`, `canFlushGraphOnPageClose`, or `index.tsx`. If you'd prefer a fix upstream of the guard (for example, reconciling the two predicates), I'm happy to close this in favour of that.
- Reproduced on a from-source build of current `main`; the toast disappears when collaboration is disabled (`ENABLE_COLLABORATION_MODE=false`), confirming the path is collaboration-gated.
- I could not trace from source exactly what sets `graphViewActive` to `false` during in-app navigation (the only setter I found fires on tab-visibility change), so that trigger is described as observed rather than proven.
- Frontend-only change, so I ran `cd web && pnpm exec vp lint` and `tsc --noEmit` rather than the backend `make lint && make type-check`. My changed lines are clean; `vp lint` reports one pre-existing unrelated error in the same file (`use-nodes-sync-draft.ts:26`, `no-restricted-imports '@/service/fetch'`) that is untouched by this diff.

From Claude Code

## Screenshots

**Before**
<img width="1280" height="432" alt="2026-07-23_16-17-15" src="https://github.com/user-attachments/assets/4feac9d4-d0f5-48b6-b128-df17f4f7c0aa" />
"Draft save failed" toast appears on Home after leaving a workflow editor with collaboration enabled

**After**
<img width="1280" height="431" alt="2026-07-23_16-33-20" src="https://github.com/user-attachments/assets/edadb526-9ed9-447c-bb00-a561c2ca2c9b" />
No toast; leaving the editor is silent

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods