### PR TITLE
fix(api): prevent HITL pause from aborting workflow resume

### DIFF
--- a/api/core/app/apps/workflow/app_queue_manager.py
+++ b/api/core/app/apps/workflow/app_queue_manager.py
@@ -9,6 +9,7 @@ from core.app.entities.queue_entities import (
     QueueStopEvent,
     QueueWorkflowFailedEvent,
     QueueWorkflowPartialSuccessEvent,
+    QueueWorkflowPausedEvent,
     QueueWorkflowSucceededEvent,
     WorkflowQueueMessage,
 )
@@ -39,6 +40,7 @@ class WorkflowAppQueueManager(AppQueueManager):
             | QueueMessageEndEvent
             | QueueWorkflowSucceededEvent
             | QueueWorkflowFailedEvent
+            | QueueWorkflowPausedEvent
             | QueueWorkflowPartialSuccessEvent,
         ):
             self.stop_listen(execution_terminal=True)

--- a/api/core/app/apps/workflow/app_queue_manager.py
+++ b/api/core/app/apps/workflow/app_queue_manager.py
@@ -33,6 +33,8 @@ class WorkflowAppQueueManager(AppQueueManager):
 
         self._q.put(message)
 
+        # A paused workflow remains resumable, but the current listener segment is complete.
+        # Treat it as terminal here so listener cleanup does not abort the workflow before it resumes.
         if isinstance(
             event,
             QueueStopEvent

--- a/api/core/app/apps/workflow/app_queue_manager.py
+++ b/api/core/app/apps/workflow/app_queue_manager.py
@@ -33,8 +33,11 @@ class WorkflowAppQueueManager(AppQueueManager):
 
         self._q.put(message)
 
-        # A paused workflow remains resumable, but the current listener segment is complete.
-        # Treat it as terminal here so listener cleanup does not abort the workflow before it resumes.
+        # A pause ends only the current listener segment; the workflow stays PAUSED and
+        # resumes with the same task ID. Without this marker, listen() cleanup calls
+        # _abort_execution(), whose stop flag and abort command can stop the resumed run.
+        # This is a compatibility workaround: cancellation policy belongs to the execution
+        # owner, not the response-stream listener.
         if isinstance(
             event,
             QueueStopEvent

--- a/api/tests/unit_tests/core/app/apps/workflow/test_app_queue_manager.py
+++ b/api/tests/unit_tests/core/app/apps/workflow/test_app_queue_manager.py
@@ -5,7 +5,12 @@ from unittest.mock import patch
 from core.app.apps.base_app_queue_manager import PublishFrom
 from core.app.apps.workflow.app_queue_manager import WorkflowAppQueueManager
 from core.app.entities.app_invoke_entities import InvokeFrom
-from core.app.entities.queue_entities import QueueMessageEndEvent, QueuePingEvent, QueueStopEvent
+from core.app.entities.queue_entities import (
+    QueueMessageEndEvent,
+    QueuePingEvent,
+    QueueStopEvent,
+    QueueWorkflowPausedEvent,
+)
 
 
 class TestWorkflowAppQueueManager:
@@ -97,5 +102,25 @@ class TestWorkflowAppQueueManager:
             manager.publish(QueueMessageEndEvent(llm_result=None), PublishFrom.APPLICATION_MANAGER)
 
             _ = list(manager.listen())
+
+            graph_engine_manager.return_value.send_stop_command.assert_not_called()
+
+    def test_workflow_pause_does_not_abort_execution(self):
+        with (
+            patch("core.app.apps.base_app_queue_manager.redis_client") as redis_client,
+            patch("core.app.apps.base_app_queue_manager.GraphEngineManager") as graph_engine_manager,
+        ):
+            redis_client.get.return_value = None
+            manager = WorkflowAppQueueManager(
+                task_id="task",
+                user_id="user",
+                invoke_from=InvokeFrom.DEBUGGER,
+                app_mode="workflow",
+            )
+            manager.publish(QueueWorkflowPausedEvent(), PublishFrom.APPLICATION_MANAGER)
+            listener = manager.listen()
+
+            assert isinstance(next(listener).event, QueueWorkflowPausedEvent)
+            listener.close()
 
             graph_engine_manager.return_value.send_stop_command.assert_not_called()


### PR DESCRIPTION
## Summary

- Treat `QueueWorkflowPausedEvent` as terminal for the current `WorkflowAppQueueManager` listener segment.
- Prevent listener cleanup after a legitimate HITL pause from setting the shared stop flag and aborting the resumed workflow.
- Preserve cancellation for genuine client disconnects and add a queue-lifecycle regression test.

Fixes #39448

## Screenshots

Not applicable (backend-only change).

## Checklist

- [x] This change does not require a documentation update.
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I've added a test for each change that was introduced, and kept this as a single atomic change.
- [x] Targeted backend lint, type checks, and relevant unit tests passed.

## Tests

- `uv run --project api --no-sync pytest api/tests/unit_tests/core/app/apps/test_base_app_queue_manager.py api/tests/unit_tests/core/app/apps/workflow/test_app_queue_manager.py api/tests/unit_tests/core/app/apps/workflow/test_generate_task_pipeline_core.py api/tests/unit_tests/core/app/apps/advanced_chat/test_generate_task_pipeline_core.py api/tests/unit_tests/core/app/apps/test_message_based_app_queue_manager.py -q` (80 passed)
- Ruff format and lint checks passed for the changed files.
- Mypy passed for `core/app/apps/workflow/app_queue_manager.py`.
- Pyrefly reported 0 errors for the changed module.