### PR TITLE
fix: prevent build reset from clearing preview chat

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/__tests__/page.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/__tests__/page.spec.tsx
@@ -429,6 +429,7 @@ vi.mock('../components/preview/build-chat', async () => {
 
 vi.mock('../components/preview/preview-chat', () => ({
   AgentPreviewChat: (props: {
+    clearChatList?: boolean
     conversationId?: string | null
     draftType?: 'debug_build'
     onSaveDraftBeforeRun?: () => Promise<unknown>
@@ -437,6 +438,7 @@ vi.mock('../components/preview/preview-chat', () => ({
     return (
       <div role="region" aria-label="preview-chat">
         <span>{`preview:${props.conversationId ?? 'none'}`}</span>
+        <span>{`clear:${props.clearChatList ? 'yes' : 'no'}`}</span>
         <span>{`draftType:${props.draftType ?? 'draft'}`}</span>
         <button
           type="button"
@@ -1408,6 +1410,31 @@ describe('AgentConfigurePage', () => {
         },
         expect.any(Object),
       )
+    })
+
+    it('should not carry a Build clear command into Preview mode', async () => {
+      const user = userEvent.setup()
+      mocks.queryState.composer = {
+        data: {},
+        isFetching: false,
+        isError: false,
+        isPending: false,
+        isSuccess: true,
+        refetch: vi.fn(),
+      }
+
+      render(
+        <QueryClientProvider client={new QueryClient()}>
+          <AgentConfigurePage agentId="agent-1" />
+        </QueryClientProvider>,
+      )
+
+      await user.click(screen.getByRole('button', { name: 'restart preview' }))
+      expect(screen.getByRole('region', { name: 'build-chat' })).toHaveTextContent('clear:yes')
+
+      await user.click(screen.getByRole('button', { name: 'preview mode' }))
+
+      expect(screen.getByRole('region', { name: 'preview-chat' })).toHaveTextContent('clear:no')
     })
 
     it('should not keep a stale clear command after the composer content remounts', async () => {

--- a/web/features/agent-v2/agent-detail/configure/components/composer-session.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/composer-session.tsx
@@ -284,7 +284,12 @@ function AgentConfigurePageComposerContent({
   } = configureData
   const { t } = useTranslation('agentV2')
   const { t: tCommon } = useTranslation('common')
-  const [clearPreviewChat, setClearPreviewChat] = useState(false)
+  const [clearChatByMode, setClearChatByMode] = useState<
+    Record<AgentConfigureRightPanelMode, boolean>
+  >({
+    build: false,
+    preview: false,
+  })
   const [completedBuildConversationId, setCompletedBuildConversationId] = useState<string | null>(
     null,
   )
@@ -310,9 +315,9 @@ function AgentConfigurePageComposerContent({
     } finally {
       setCompletedBuildConversationId(null)
       setConversationId({ mode: 'build', conversationId: null })
-      setClearPreviewChat(true)
+      setClearChatByMode((current) => ({ ...current, build: true }))
     }
-  }, [onRefreshDebugConversationAsync, setClearPreviewChat, setConversationId])
+  }, [onRefreshDebugConversationAsync, setClearChatByMode, setConversationId])
   const rebaseComposerDraftFromSoulConfig = useCallback(
     (agentSoulConfig?: AgentSoulConfig) => {
       rebaseComposerDraft({
@@ -436,7 +441,7 @@ function AgentConfigurePageComposerContent({
     }
 
     resetConversation(rightPanelChatMode)
-    setClearPreviewChat(true)
+    setClearChatByMode((current) => ({ ...current, [rightPanelChatMode]: true }))
   }
 
   return (
@@ -524,14 +529,19 @@ function AgentConfigurePageComposerContent({
                 agentIconType={agentIconType}
                 agentName={agentQuery.data?.name}
                 agentSoulConfig={buildDraft.agentSoulConfig}
-                clearChatList={clearPreviewChat}
+                clearChatList={clearChatByMode[rightPanelChatMode]}
                 controllerRef={rightPanelChatControllerRef}
                 conversationIds={conversationIds}
                 mode={rightPanelChatMode}
                 speechToTextDraftType={
                   rightPanelChatMode === 'build' && buildDraft.isActive ? 'debug_build' : 'draft'
                 }
-                onClearChatListChange={setClearPreviewChat}
+                onClearChatListChange={(clearChatList) => {
+                  setClearChatByMode((current) => ({
+                    ...current,
+                    [rightPanelChatMode]: clearChatList,
+                  }))
+                }}
                 onConversationComplete={(mode, completedConversationId) => {
                   if (mode !== 'build' || !isBuildCallbackCurrent(buildCallbackGeneration)) return
 


### PR DESCRIPTION
## Summary
- Scope chat clear signals by right panel mode.
- Ensure a delayed Build reset can only clear the Build conversation and cannot affect an active Preview conversation.
- Add a regression test covering switching to Preview while a Build clear command is pending.


Fixes DIFY-2832