### PR TITLE
fix: don't close the active comment panel when a different comment is resolved

### DIFF
--- a/web/app/components/workflow/hooks/__tests__/use-workflow-comment.spec.ts
+++ b/web/app/components/workflow/hooks/__tests__/use-workflow-comment.spec.ts
@@ -669,4 +669,66 @@ describe('useWorkflowComment', () => {
 
     expect(store.getState().pendingComment).toBeNull()
   })
+
+  it('does not overwrite the active comment when a different comment is resolved/refreshed', async () => {
+    const commentA = baseComment()
+    const commentB: WorkflowCommentList = {
+      ...baseComment(),
+      id: 'comment-2',
+      content: 'second',
+      position_x: 50,
+      position_y: 80,
+    }
+    const activeBDetail = { ...baseCommentDetail(), id: commentB.id, content: 'B detail' }
+    // refreshActiveComment(A) — reached via resolving A — fetches A's detail:
+    mockFetchWorkflowComment.mockResolvedValue({
+      ...baseCommentDetail(),
+      id: commentA.id,
+      content: 'A detail (must not clobber B)',
+    })
+    mockResolveWorkflowComment.mockResolvedValue({})
+    mockFetchWorkflowComments.mockResolvedValue({ data: [{ ...commentA, resolved: true }, commentB] })
+
+    const { result, store } = renderWorkflowHook(() => useWorkflowComment(), {
+      queryClient: createSeededQueryClient(),
+      initialStoreState: {
+        comments: [commentA, commentB],
+        activeCommentId: commentB.id,
+        activeCommentDetail: activeBDetail,
+      },
+    })
+
+    await act(async () => {
+      await result.current.handleCommentResolve(commentA.id)
+    })
+
+    // B is still the selected comment; A's fetched detail must not replace it.
+    expect(store.getState().activeCommentId).toBe(commentB.id)
+    expect(store.getState().activeCommentDetail?.id).toBe(commentB.id)
+  })
+
+  it('still refreshes the active comment', async () => {
+    const commentA = baseComment()
+    mockFetchWorkflowComment.mockResolvedValue({
+      ...baseCommentDetail(),
+      id: commentA.id,
+      content: 'refreshed content',
+    })
+
+    const { result, store } = renderWorkflowHook(() => useWorkflowComment(), {
+      queryClient: createSeededQueryClient(),
+      initialStoreState: {
+        comments: [commentA],
+        activeCommentId: commentA.id,
+        activeCommentDetail: { ...baseCommentDetail(), id: commentA.id, content: 'stale content' },
+      },
+    })
+
+    await act(async () => {
+      await result.current.refreshActiveComment(commentA.id)
+    })
+
+    expect(store.getState().activeCommentDetail?.id).toBe(commentA.id)
+    expect(store.getState().activeCommentDetail?.content).toBe('refreshed content')
+  })
 })

--- a/web/app/components/workflow/hooks/__tests__/use-workflow-comment.spec.ts
+++ b/web/app/components/workflow/hooks/__tests__/use-workflow-comment.spec.ts
@@ -687,7 +687,9 @@ describe('useWorkflowComment', () => {
       content: 'A detail (must not clobber B)',
     })
     mockResolveWorkflowComment.mockResolvedValue({})
-    mockFetchWorkflowComments.mockResolvedValue({ data: [{ ...commentA, resolved: true }, commentB] })
+    mockFetchWorkflowComments.mockResolvedValue({
+      data: [{ ...commentA, resolved: true }, commentB],
+    })
 
     const { result, store } = renderWorkflowHook(() => useWorkflowComment(), {
       queryClient: createSeededQueryClient(),

--- a/web/app/components/workflow/hooks/use-workflow-comment.ts
+++ b/web/app/components/workflow/hooks/use-workflow-comment.ts
@@ -98,7 +98,9 @@ export const useWorkflowComment = () => {
         [commentId]: detail,
       }
       setCommentDetailCache(commentDetailCacheRef.current)
-      setActiveComment(detail)
+      // Only apply the fetched detail if this comment is still the active one;
+      // otherwise a refresh for another comment can clobber the current selection.
+      if (activeCommentIdRef.current === commentId) setActiveComment(detail)
     },
     [appId, setActiveComment, setCommentDetailCache],
   )


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. -->

Fixes #39475.

The diagnosis and the fix in this PR are @AlexMultiAgent's, from #39475: `refreshActiveComment` in `web/app/components/workflow/hooks/use-workflow-comment.ts` calls `setActiveComment(detail)` unconditionally, whereas every other `setActiveComment` site in the file first guards on `activeCommentIdRef.current === commentId`. This PR applies their proposed guard and adds a regression test; my contribution is reproducing the bug in the running app and verifying the fix.

**Reproduction** (self-hosted 1.16.0, collaboration enabled; deterministic, 3× consecutive, no network throttling):
1. Add two comments A and B on a workflow canvas.
2. Select B — B's detail panel opens.
3. Resolve A from the comment list.
4. B's detail panel disappears; A's panel does not open.

(Control: resolving A while A's own panel is open closes A's panel — correct.)

**Why it presents as the panel disappearing, rather than the snap-back described in #39475:** `handleCommentResolve` calls `refreshActiveComment(commentId)` with the resolved comment's id, so `setActiveComment` flips the active detail to A. The detail popup only renders where `activeComment?.id === comment.id` over `visibleComments` (`web/app/components/workflow/index.tsx`), and `visibleComments` filters out resolved comments — so A's marker is removed once it is resolved (A's panel can't render) and B's marker no longer matches the now-A active detail (B's panel unmounts). Same unguarded `setActiveComment`; the trigger comment is simply resolved rather than still visible.

**The fix** applies the fetched detail only when its comment is still the active one:
```diff
-      setActiveComment(detail)
+      // Only apply the fetched detail if this comment is still the active one;
+      // otherwise a refresh for another comment can clobber the current selection.
+      if (activeCommentIdRef.current === commentId) setActiveComment(detail)
```
Refreshes of the active comment are unaffected (covered by a test).

**Verified** on from-source builds of current `main`: the before/after recordings below are the same app and sequence, with and without this change.

**Not established:** this was traced from source and reproduced in the UI, but the trace is static — I did not instrument the running bundle. The `collaborationManager.emitCommentsUpdate` local-loopback path and the `showResolvedComments` toggle were not separately exercised; with "show resolved" on, A's marker would remain and the symptom would instead match #39475's snap-back, further indicating the same root cause.

Frontend-only change, so I ran `cd web && pnpm exec vp lint` and `tsc --noEmit` rather than the backend `make lint && make type-check`; the changed files are clean.

From Claude Code

## Videos
Click the links below to see videos of the bug and its fix.

**Before**
[Comment B's detail panel is open; resolving comment A from the list closes B's panel, and A's panel does not open.](https://github.com/user-attachments/assets/d7d58eb2-ee27-477f-b75d-94f803faf829)

**After**
[Same app and sequence, built from this branch: resolving A leaves B's detail panel open.](https://github.com/user-attachments/assets/1ec0644a-eb23-44b4-a19e-e321078a4ce6)

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods