### PR TITLE
fix: backport document upload and auto-upgrade fallback fixes

### DIFF
--- a/api/controllers/console/workspace/plugin.py
+++ b/api/controllers/console/workspace/plugin.py
@@ -399,12 +399,10 @@ register_enum_models(
 )
 
 
-def _default_auto_upgrade_settings(
-    tenant_id: str,
-    category: TenantPluginAutoUpgradeStrategy.PluginCategory,
-) -> AutoUpgradeSettingsResponse:
+def _missing_auto_upgrade_settings(tenant_id: str) -> AutoUpgradeSettingsResponse:
+    """Represent a missing persisted strategy as effectively disabled."""
     return {
-        "strategy_setting": PluginAutoUpgradeService.default_strategy_setting_for_category(category),
+        "strategy_setting": TenantPluginAutoUpgradeStrategy.StrategySetting.DISABLED,
         "upgrade_time_of_day": PluginAutoUpgradeService.default_upgrade_time_of_day(tenant_id),
         "upgrade_mode": TenantPluginAutoUpgradeStrategy.UpgradeMode.EXCLUDE,
         "exclude_plugins": [],
@@ -1090,9 +1088,7 @@ class PluginFetchAutoUpgradeApi(Resource):
         args = ParserAutoUpgradeFetch.model_validate(request.args.to_dict(flat=True))
         auto_upgrade = PluginAutoUpgradeService.get_strategy(tenant_id, args.category)
         auto_upgrade_dict = (
-            _auto_upgrade_settings_to_dict(auto_upgrade)
-            if auto_upgrade
-            else _default_auto_upgrade_settings(tenant_id, args.category)
+            _auto_upgrade_settings_to_dict(auto_upgrade) if auto_upgrade else _missing_auto_upgrade_settings(tenant_id)
         )
 
         return jsonable_encoder(

--- a/api/tests/unit_tests/controllers/console/workspace/test_plugin.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_plugin.py
@@ -1110,6 +1110,36 @@ class TestPluginFetchAutoUpgradeApi:
         assert result["category"] == TenantPluginAutoUpgradeStrategy.PluginCategory.TOOL
         assert result["auto_upgrade"]["upgrade_time_of_day"] == 1
 
+    def test_returns_disabled_settings_when_strategy_is_missing(self, app: Flask):
+        api = PluginFetchAutoUpgradeApi()
+        method = unwrap(api.get)
+
+        with (
+            app.test_request_context(
+                f"/?category={TenantPluginAutoUpgradeStrategy.PluginCategory.MODEL.value}"
+            ),
+            patch(
+                "controllers.console.workspace.plugin.PluginAutoUpgradeService.get_strategy",
+                return_value=None,
+            ),
+            patch(
+                "controllers.console.workspace.plugin.PluginAutoUpgradeService.default_upgrade_time_of_day",
+                return_value=78300,
+            ),
+        ):
+            result = method(api, "t1")
+
+        assert result == {
+            "category": TenantPluginAutoUpgradeStrategy.PluginCategory.MODEL,
+            "auto_upgrade": {
+                "strategy_setting": TenantPluginAutoUpgradeStrategy.StrategySetting.DISABLED,
+                "upgrade_time_of_day": 78300,
+                "upgrade_mode": TenantPluginAutoUpgradeStrategy.UpgradeMode.EXCLUDE,
+                "exclude_plugins": [],
+                "include_plugins": [],
+            },
+        }
+
 
 class TestPluginAutoUpgradeExcludePluginApi:
     def test_success(self, app: Flask):

--- a/web/app/components/app/configuration/config/config-document.tsx
+++ b/web/app/components/app/configuration/config/config-document.tsx
@@ -49,7 +49,7 @@ const ConfigDocument: FC = () => {
     return null
 
   return (
-    <div className="mt-2 flex items-center gap-2 rounded-xl border-t-[0.5px] border-l-[0.5px] bg-background-section-burn p-2">
+    <div className="mt-2 flex items-center gap-2 rounded-xl border-t-[0.5px] border-l-[0.5px] border-effects-highlight bg-background-section-burn p-2">
       <div className="shrink-0 p-1">
         <div className="rounded-lg border-[0.5px] border-divider-subtle bg-util-colors-indigo-indigo-600 p-1 shadow-xs">
           <Document className="size-4 text-text-primary-on-surface" />
@@ -66,7 +66,7 @@ const ConfigDocument: FC = () => {
       </div>
       {!readonly && (
         <div className="flex shrink-0 items-center">
-          <div className="mr-3 ml-1 h-3.5 w-px bg-divider-subtle"></div>
+          <div className="mr-3 ml-1 h-3.5 w-px bg-divider-regular"></div>
           <Switch
             checked={isDocumentEnabled}
             onCheckedChange={handleChange}

--- a/web/app/components/app/configuration/debug/debug-with-single-model/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-single-model/__tests__/index.spec.tsx
@@ -11,6 +11,7 @@ import { createRef } from 'react'
 import { useStore as useAppStore } from '@/app/components/app/store'
 import { ConfigurationMethodEnum, ModelFeatureEnum, ModelStatusEnum, ModelTypeEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import { CollectionType } from '@/app/components/tools/types'
+import { SupportUploadFileTypes } from '@/app/components/workflow/types'
 import { PromptMode } from '@/models/debug'
 import { AgentStrategy, AppModeEnum, ModelModeType, Resolution, TransferMethod } from '@/types/app'
 import DebugWithSingleModel from '../index'
@@ -436,6 +437,16 @@ const mockFile: FileEntity = {
   supportFileType: 'image',
 }
 
+const mockDocumentFile: FileEntity = {
+  id: 'file-2',
+  name: 'test.pdf',
+  size: 456,
+  type: 'application/pdf',
+  progress: 100,
+  transferMethod: TransferMethod.local_file,
+  supportFileType: SupportUploadFileTypes.document,
+}
+
 // Mock Chat component (complex with many dependencies)
 // This is a pragmatic mock that tests the integration at DebugWithSingleModel level
 vi.mock('@/app/components/base/chat/chat', () => ({
@@ -493,6 +504,13 @@ vi.mock('@/app/components/base/chat/chat', () => ({
           disabled={isResponding || readonly || inputDisabled}
         >
           Send With Files
+        </button>
+        <button
+          data-testid="send-with-document"
+          onClick={() => onSend?.('test message', [mockDocumentFile])}
+          disabled={isResponding || readonly || inputDisabled}
+        >
+          Send With Document
         </button>
         {isResponding && (
           <button data-testid="stop-button" onClick={onStopResponding}>
@@ -950,7 +968,7 @@ describe('DebugWithSingleModel', () => {
 
   // File Upload Tests
   describe('File Upload', () => {
-    it('should not include files when vision is not supported', async () => {
+    it('should include document files when document is supported without vision', async () => {
       mockUseDebugConfigurationContext.mockReturnValue({
         ...mockDebugConfigContext,
         modelConfig: createMockModelConfig({
@@ -970,7 +988,7 @@ describe('DebugWithSingleModel', () => {
                 model: 'gpt-3.5-turbo',
                 label: { en_US: 'GPT-3.5', zh_Hans: 'GPT-3.5' },
                 model_type: ModelTypeEnum.textGeneration,
-                features: [], // No vision
+                features: [ModelFeatureEnum.document],
                 fetch_from: ConfigurationMethodEnum.predefinedModel,
                 model_properties: {},
                 deprecated: false,
@@ -989,14 +1007,21 @@ describe('DebugWithSingleModel', () => {
 
       render(<DebugWithSingleModel ref={ref as RefObject<DebugWithSingleModelRefType>} />)
 
-      fireEvent.click(screen.getByTestId('send-with-files'))
+      fireEvent.click(screen.getByTestId('send-with-document'))
 
       await waitFor(() => {
         expect(mockSsePost).toHaveBeenCalled()
       })
 
       const body = mockSsePost.mock.calls[0]![1].body
-      expect(body.files).toEqual([])
+      expect(body.files).toEqual([
+        {
+          type: SupportUploadFileTypes.document,
+          transfer_method: TransferMethod.local_file,
+          url: '',
+          upload_file_id: '',
+        },
+      ])
     })
 
     it('should support files when vision is enabled', async () => {

--- a/web/app/components/app/configuration/debug/debug-with-single-model/index.tsx
+++ b/web/app/components/app/configuration/debug/debug-with-single-model/index.tsx
@@ -8,10 +8,8 @@ import Chat from '@/app/components/base/chat/chat'
 import { useChat } from '@/app/components/base/chat/chat/hooks'
 import { getLastAnswer, isValidGeneratedAnswer } from '@/app/components/base/chat/utils'
 import { useFeatures } from '@/app/components/base/features/hooks'
-import { ModelFeatureEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import { useAppContext } from '@/context/app-context'
 import { useDebugConfigurationContext } from '@/context/debug-configuration'
-import { useProviderContext } from '@/context/provider-context'
 import {
   fetchConversationMessages,
   fetchSuggestedQuestions,
@@ -50,7 +48,6 @@ const DebugWithSingleModel = (
   } = useDebugConfigurationContext()
   const debugInputReadonly = !canTestAndRun
   const canManageAnnotation = !readonly && canTestAndRun
-  const { textGenerationModelList } = useProviderContext()
   const features = useFeatures(s => s.features)
   const configTemplate = useConfigFromDebugContext()
   const config = useMemo(() => {
@@ -98,9 +95,6 @@ const DebugWithSingleModel = (
       return
     if (checkCanSend && !checkCanSend())
       return
-    const currentProvider = textGenerationModelList.find(item => item.provider === modelConfig.provider)
-    const currentModel = currentProvider?.models.find(model => model.model === modelConfig.model_id)
-    const supportVision = currentModel?.features?.includes(ModelFeatureEnum.vision)
 
     const configData = {
       ...config,
@@ -119,7 +113,7 @@ const DebugWithSingleModel = (
       parent_message_id: (isRegenerate ? parentAnswer?.id : getLastAnswer(chatList)?.id) || null,
     }
 
-    if ((config.file_upload as any)?.enabled && files?.length && supportVision)
+    if ((config.file_upload as any)?.enabled && files?.length)
       data.files = files
 
     handleSend(
@@ -130,7 +124,7 @@ const DebugWithSingleModel = (
         onGetSuggestedQuestions: (responseItemId, getAbortController) => fetchSuggestedQuestions(appId, responseItemId, getAbortController),
       },
     )
-  }, [appId, canTestAndRun, chatList, checkCanSend, completionParams, config, handleSend, inputs, modelConfig.mode, modelConfig.model_id, modelConfig.provider, textGenerationModelList])
+  }, [appId, canTestAndRun, chatList, checkCanSend, completionParams, config, handleSend, inputs, modelConfig.mode, modelConfig.model_id, modelConfig.provider])
 
   const doRegenerate = useCallback((chatItem: ChatItem, editedQuestion?: { message: string, files?: FileEntity[] }) => {
     const question = editedQuestion ? chatItem : chatList.find(item => item.id === chatItem.parentMessageId)!


### PR DESCRIPTION
## Summary

Backports two fixes from `main` onto `hotfix/1.15.0-fix.17`:

- Allow document-capable chat models to pass document uploads even when they do not support vision.
- Return an effectively disabled plugin auto-upgrade configuration when no persisted strategy exists, instead of presenting the new-workspace default as an active user setting.

## Cherry-picks

- `2beafdc457fce09bc7b67cb9d16d69dc0f1f50b1` → `8937f34440763321b6d989e1f5d8d5d6b4773635`
- `aef1c6772116bd7e92cb1787bd2a3571ad63ee37` → `0c464ea081379cd322b5965462d7ecfd642946e9`

## Validation

- Hotfix provenance check: 2/2 commits verified against `myori/main`.
- Backend: `TestPluginFetchAutoUpgradeApi` — 2 passed.
- Frontend: `debug-with-single-model` regression suite — 23 passed.
- Frontend type check: passed.
- `git diff --check`: passed.
- Targeted ESLint reports five pre-existing `no-explicit-any` errors and three pre-existing warnings in the older hotfix implementation; this backport adds no new `any` usage.