### PR TITLE
fix: don't open the node settings panel when clicking a node in comment mode

### DIFF
--- a/web/app/components/workflow/nodes/_base/__tests__/node.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/__tests__/node.spec.tsx
@@ -2,7 +2,7 @@ import type { PropsWithChildren } from 'react'
 import type { CommonNodeType } from '@/app/components/workflow/types'
 import { fireEvent, screen } from '@testing-library/react'
 import { renderWorkflowComponent } from '@/app/components/workflow/__tests__/workflow-test-env'
-import { BlockEnum, NodeRunningStatus } from '@/app/components/workflow/types'
+import { BlockEnum, ControlMode, NodeRunningStatus } from '@/app/components/workflow/types'
 import BaseNode from '../node'
 
 const mockHasNodeInspectVars = vi.fn()
@@ -159,6 +159,23 @@ describe('BaseNode', () => {
     fireEvent.click(node)
 
     expect(selectWorkflowNode).toHaveBeenCalledWith('node-1')
+  })
+
+  it('should not select the node from the title button while in comment mode', async () => {
+    const { selectWorkflowNode } = await import('@/app/components/workflow/utils/node-navigation')
+
+    renderWorkflowComponent(
+      <BaseNode id="node-1" data={toNodeData(createData())}>
+        <div>Body</div>
+      </BaseNode>,
+      { initialStoreState: { controlMode: ControlMode.Comment } },
+    )
+
+    const node = screen.getByRole('button', { name: 'Node title' })
+
+    fireEvent.click(node)
+
+    expect(selectWorkflowNode).not.toHaveBeenCalled()
   })
 
   it('should keep header metadata outside the selectable button', () => {

--- a/web/app/components/workflow/nodes/_base/node.tsx
+++ b/web/app/components/workflow/nodes/_base/node.tsx
@@ -240,7 +240,13 @@ const BaseNode: FC<BaseNodeProps> = ({ id, data, children }) => {
             type="button"
             aria-label={data.title}
             className="mr-1 flex min-w-0 grow appearance-none items-center rounded-md border-0 bg-transparent p-0 text-left focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden"
-            onClick={() => selectWorkflowNode(id)}
+            onClick={() => {
+              // In comment mode, clicking a node should not open the node settings panel:
+              // the right-hand panel covers the canvas region where the comment is anchored.
+              // Mirrors the comment-mode guard in use-nodes-interactions' handleNodeClick.
+              if (controlMode === ControlMode.Comment) return
+              selectWorkflowNode(id)
+            }}
           >
             <BlockIcon className="mr-2 shrink-0" type={data.type} size="md" toolIcon={toolIcon} />
             <div className="flex min-w-0 grow items-center system-sm-semibold-uppercase text-text-primary">


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #39496

Comment mode already guards against opening the node **settings** panel: `handleNodeClick` early-returns when `controlMode === ControlMode.Comment` (`web/app/components/workflow/hooks/use-nodes-interactions.ts:483`), so clicking a node while commenting is intentionally not supposed to select it. The node title button bypasses that guard — its `onClick` calls `selectWorkflowNode(id)` unconditionally (`web/app/components/workflow/nodes/_base/node.tsx:243`), which sets `data.selected = true` and renders the right-hand settings panel. This PR closes that inconsistency so the title button honours the same comment-mode guard the main click path already has.

**User impact.** The settings panel is a fixed right-hand panel (~400px). It covers the canvas region where the comment is anchored, so you can't see what you're annotating while you type. (There's secondary friction too — dismissing the panel before each additional comment, and one action split across three surfaces — but I'd class those as UX judgement, not the defect; the defect is the guard inconsistency.)

**Current vs fixed behaviour**
- *Current:* in comment mode, clicking a node selects it and opens the node settings panel, alongside the comment surfaces.
- *Fixed:* in comment mode, clicking a node no longer selects it, so the settings panel doesn't open. Comment placement is unchanged. **Outside** comment mode, node selection is completely unchanged.

```diff
-            onClick={() => selectWorkflowNode(id)}
+            onClick={() => {
+              // In comment mode, clicking a node should not open the node settings panel:
+              // the right-hand panel covers the canvas region where the comment is anchored.
+              // Mirrors the comment-mode guard in use-nodes-interactions' handleNodeClick.
+              if (controlMode === ControlMode.Comment) return
+              selectWorkflowNode(id)
+            }}
```

The shared `selectWorkflowNode` util is deliberately left untouched — it also powers "go to node" from the command palette (`web/app/components/goto-anything/index.tsx:331`) — so only the title-button click path is gated.

## Videos

**Before** — comment mode, clicking a node opens the node settings panel over the canvas.

https://github.com/user-attachments/assets/c3a575b4-4852-4567-a50f-8608765a5821

---

**After** — comment mode, clicking a node places the comment without opening the node settings panel. The same take also shows the negative control: outside comment mode, clicking a node still opens the settings panel normally.


https://github.com/user-attachments/assets/3e1d3d61-4203-4fe4-a040-b77f530c2aa8

> The arguments here are about *sequence and occlusion* — which surface appears, in what order, and what it covers — which still images can't convey, so both captures are screen recordings.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

<!-- frontend-only change: ran the frontend `vp` checks (format + lint + type-check) on the changed files; did not run the backend make targets. -->

From Claude Code