### PR TITLE
fix: prevent agent preview actions from being clipped

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/components/composer-session.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/composer-session.tsx
@@ -516,6 +516,7 @@ function AgentConfigurePageComposerContent({
             ) : (
               <AgentConfigureRightPanelChat
                 agentId={agentId}
+                answerActionPosition="below"
                 agentIcon={agentQuery.data?.icon}
                 agentIconBackground={agentQuery.data?.icon_background}
                 agentIconType={agentIconType}


### PR DESCRIPTION
## Summary

- Position Agent Configure chat response actions below messages so hover controls remain fully visible.

Fixes DIFY-2836

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.