### PR TITLE
fix(workflow): re-fetch dataset details when workflow nodes change

### DIFF
--- a/web/app/components/workflow/datasets-detail-store/__tests__/provider.spec.tsx
+++ b/web/app/components/workflow/datasets-detail-store/__tests__/provider.spec.tsx
@@ -90,3 +90,40 @@ describe('datasets-detail-store provider', () => {
     })
   })
 })
+
+  it('should refetch dataset details when the nodes prop changes after mount', async () => {
+    mockFetchDatasets.mockResolvedValue({
+      data: [createDataset('dataset-1')],
+    })
+
+    const { rerender } = render(
+      <DatasetsDetailProvider nodes={[createWorkflowNode(['dataset-1'])]}>
+        <Consumer />
+      </DatasetsDetailProvider>,
+    )
+
+    await waitFor(() => expect(mockFetchDatasets).toHaveBeenCalledTimes(1))
+    expect(screen.getByText('dataset-count:1')).toBeInTheDocument()
+
+    mockFetchDatasets.mockClear()
+    mockFetchDatasets.mockResolvedValue({
+      data: [createDataset('dataset-2')],
+    })
+
+    // Mounted with new knowledge-retrieval nodes after the initial render —
+    // loading a different saved workflow, undo/redo, snippet insertion, etc.
+    rerender(
+      <DatasetsDetailProvider nodes={[createWorkflowNode(['dataset-2'])]}>
+        <Consumer />
+      </DatasetsDetailProvider>,
+    )
+
+    await waitFor(() =>
+      expect(mockFetchDatasets).toHaveBeenCalledWith({
+        url: '/datasets',
+        params: { page: 1, ids: ['dataset-2'] },
+      }),
+    )
+    await waitFor(() => expect(screen.getByText('dataset-count:1')).toBeInTheDocument())
+  })
+})

--- a/web/app/components/workflow/datasets-detail-store/provider.tsx
+++ b/web/app/components/workflow/datasets-detail-store/provider.tsx
@@ -43,7 +43,7 @@ const DatasetsDetailProvider: FC<DatasetsDetailProviderProps> = ({ nodes, childr
     }, [])
     if (allDatasetIds.length === 0) return
     updateDatasetsDetail(allDatasetIds)
-  }, [])
+  }, [nodes, updateDatasetsDetail])
 
   return (
     <DatasetsDetailContext.Provider value={storeRef.current!}>


### PR DESCRIPTION
## Summary

- `web/app/components/workflow/datasets-detail-store/provider.tsx`: add `nodes` and `updateDatasetsDetail` to the dep array of the dataset-fetching `useEffect` (was empty).
- `web/app/components/workflow/datasets-detail-store/__tests__/provider.spec.tsx`: new test `should refetch dataset details when the nodes prop changes after mount` — mounts with one node set, waits for fetch, re-renders with a different set, asserts the second fetch fires with the new IDs.

Fixes #39516.

## Why

The effect read `nodes` but the dep array was empty, so the fetch ran only on mount. Saved-workflow reloads, collaboration updates, undo/redo, snippet insertion, and knowledge-retrieval node add/remove did not refresh the dataset-detail store, leaving consumers (dataset pickers, dataset-name previews) showing stale or missing entries.

## Test Plan

- `pnpm --dir web test run app/components/workflow/datasets-detail-store/__tests__/provider.spec.tsx`