### PR TITLE
fix(web): re-fetch images on prop change without dropping their blob URLs

### DIFF
--- a/web/app/components/datasets/common/image-previewer/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/common/image-previewer/__tests__/index.spec.tsx
@@ -155,4 +155,30 @@ describe('ImagePreviewer', () => {
 
     await waitFor(() => expect(mockRevokeObjectURL).toHaveBeenCalledTimes(3))
   })
+
+  it('refetches when the images prop changes without releasing cached blob URLs', async () => {
+    const initialImages = [
+      { url: 'https://example.com/image1.png', name: 'image1.png', size: 1024 },
+      { url: 'https://example.com/image2.png', name: 'image2.png', size: 2048 },
+    ]
+    const nextImages = [
+      { url: 'https://example.com/image3.png', name: 'image3.png', size: 3072 },
+      { url: 'https://example.com/image4.png', name: 'image4.png', size: 4096 },
+    ]
+
+    const { rerender } = render(<ImagePreviewer images={initialImages} onClose={vi.fn()} />)
+    expect(await screen.findByRole('img', { name: 'image1.png' })).toBeInTheDocument()
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(mockRevokeObjectURL).not.toHaveBeenCalled()
+
+    rerender(<ImagePreviewer images={nextImages} onClose={vi.fn()} />)
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(4))
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com/image3.png')
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com/image4.png')
+
+    // Cached blob URLs for the previous images must NOT be revoked yet;
+    // releasing them here would render any still-mounted preview of the old
+    // list broken until they were re-fetched.
+    expect(mockRevokeObjectURL).not.toHaveBeenCalled()
+  })
 })

--- a/web/app/components/datasets/common/image-previewer/index.tsx
+++ b/web/app/components/datasets/common/image-previewer/index.tsx
@@ -96,14 +96,17 @@ const ImagePreviewer = ({ images, initialIndex = 0, onClose }: ImagePreviewerPro
 
   useEffect(() => {
     isMounted.current = true
-
     images.forEach((image) => {
       fetchImage(image)
     })
+  }, [images])
 
+  useEffect(() => {
     return () => {
       isMounted.current = false
-      // Cleanup released blob URLs not in current list
+      // Release blob URLs only on unmount; the loading effect above
+      // re-runs whenever the `images` prop changes and would otherwise
+      // wipe URLs still needed by the new list.
       imageCache.forEach(({ blobUrl }, key) => {
         if (blobUrl) URL.revokeObjectURL(blobUrl)
         imageCache.delete(key)


### PR DESCRIPTION
## Summary

- `web/app/components/datasets/common/image-previewer/index.tsx`: split the loading + cleanup effect into two — a `[images]`-deps fetch effect that re-runs on prop changes, and an unmount-only effect that revokes blob URLs and clears the cache.
- `web/app/components/datasets/common/image-previewer/__tests__/index.spec.tsx`: new test `refetches when the images prop changes without releasing cached blob URLs` — renders with one set, waits for them to load, re-renders with a different set, asserts the new fetches fire AND existing blob URLs are not released until unmount.

Fixes #39518.

## Why

The original effect was a single block with `[]` deps that both fetched and (on cleanup) revoked every cached blob URL. Reusing the previewer for a different image list never fetched the new images; naively adding `images` to the deps would wipe URLs still needed by the new list.

## Test Plan

- `pnpm --dir web test run app/components/datasets/common/image-previewer/__tests__/index.spec.tsx`