### PR TITLE
fix(security): harden AgentDriveArchiveMemberApi signed-URL verification

### DIFF
--- a/api/services/agent_drive_service.py
+++ b/api/services/agent_drive_service.py
@@ -41,6 +41,7 @@ from sqlalchemy.orm import Session
 
 from configs import dify_config
 from core.app.file_access.controller import DatabaseFileAccessController
+from extensions.ext_redis import redis_client
 from extensions.ext_storage import storage
 from factories import file_factory
 from libs.uuid_utils import uuidv7
@@ -53,6 +54,8 @@ logger = logging.getLogger(__name__)
 _MAX_KEY_LENGTH = 512
 _DRIVE_REF_PREFIX = "agent-"
 _SKILL_MD_SUFFIX = "/SKILL.md"
+_SIGNATURE_CLOCK_SKEW_SECONDS = 30
+_NONCE_KEY_PREFIX = "agent_drive_archive_nonce:"
 _SKILL_ARCHIVE_NAME = ".DIFY-SKILL-FULL.zip"
 _ARCHIVE_MEMBER_DOWNLOAD_PURPOSE = "agent-drive-archive-member"
 
@@ -1203,10 +1206,32 @@ class AgentDriveService:
             timestamp=timestamp,
             nonce=nonce,
         )
-        if sign != cls._sign_archive_member_payload(payload):
+        # Use a constant-time comparison to avoid leaking signature bytes
+        # via timing.
+        if not hmac.compare_digest(sign, cls._sign_archive_member_payload(payload)):
             return False
+        # Reject far-future timestamps in addition to checking the upper
+        # bound, so a captured URL cannot be made replayable forever by
+        # forging a timestamp far in the future.
         current_time = int(time.time())
-        return current_time - int(timestamp) <= dify_config.FILES_ACCESS_TIMEOUT
+        ts = int(timestamp)
+        if ts > current_time + _SIGNATURE_CLOCK_SKEW_SECONDS:
+            return False
+        if current_time - ts > dify_config.FILES_ACCESS_TIMEOUT:
+            return False
+        # Record the nonce in Redis with the same TTL as the access window
+        # so a captured URL cannot be replayed. setnx gives us atomic
+        # "first-use" semantics: a repeat attempt finds the key already
+        # present and is rejected.
+        nonce_key = f"{_NONCE_KEY_PREFIX}{tenant_id}:{agent_id}:{nonce}"
+        if not redis_client.set(
+            nonce_key,
+            "1",
+            ex=dify_config.FILES_ACCESS_TIMEOUT + _SIGNATURE_CLOCK_SKEW_SECONDS,
+            nx=True,
+        ):
+            return False
+        return True
 
     def load_archive_member_for_signed_request(
         self,

--- a/api/tests/unit_tests/services/test_agent_drive_service.py
+++ b/api/tests/unit_tests/services/test_agent_drive_service.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import datetime
 import io
+import time
 import zipfile
 from collections.abc import Generator
 from unittest.mock import patch
@@ -926,3 +927,178 @@ def test_skill_metadata_rejects_non_canonical_rows():
             session=session_factory.create_session(),
         )
     assert exc_info.value.code == "invalid_skill_key"
+
+
+# ---------------------------------------------------------------------------
+# verify_archive_member_signature hardening tests
+# ---------------------------------------------------------------------------
+#
+# Verifies the three security properties added to verify_archive_member_signature:
+#   1. constant-time signature comparison (hmac.compare_digest),
+#   2. rejection of far-future timestamps beyond the clock skew window,
+#   3. nonce replay protection via redis_client.set(..., nx=True).
+
+
+def _sign_archive_member_url(
+    *,
+    tenant_id: str,
+    agent_id: str,
+    key: str,
+    archive_file_kind: AgentDriveFileKind,
+    archive_file_id: str,
+    member_path: str,
+    timestamp: str,
+    nonce: str,
+) -> str:
+    return AgentDriveService._sign_archive_member_payload(
+        AgentDriveService._archive_member_signature_payload(
+            tenant_id=tenant_id,
+            agent_id=agent_id,
+            key=key,
+            archive_file_kind=archive_file_kind,
+            archive_file_id=archive_file_id,
+            member_path=member_path,
+            timestamp=timestamp,
+            nonce=nonce,
+        )
+    )
+
+
+def test_verify_archive_member_signature_rejects_tampered_signature():
+    now = int(time.time())
+    good = _sign_archive_member_url(
+        tenant_id=TENANT,
+        agent_id=AGENT,
+        key="pdf-toolkit/.DIFY-SKILL-FULL.zip",
+        archive_file_kind=AgentDriveFileKind.TOOL_FILE,
+        archive_file_id="file-id",
+        member_path="SKILL.md",
+        timestamp=str(now),
+        nonce="nonce-1",
+    )
+    tampered = "Z" + good[1:]
+    with patch("services.agent_drive_service.redis_client") as redis_mock:
+        assert (
+            AgentDriveService.verify_archive_member_signature(
+                tenant_id=TENANT,
+                agent_id=AGENT,
+                key="pdf-toolkit/.DIFY-SKILL-FULL.zip",
+                archive_file_kind=AgentDriveFileKind.TOOL_FILE,
+                archive_file_id="file-id",
+                member_path="SKILL.md",
+                timestamp=str(now),
+                nonce="nonce-1",
+                sign=tampered,
+            )
+            is False
+        )
+        redis_mock.set.assert_not_called()
+
+
+def test_verify_archive_member_signature_rejects_far_future_timestamp():
+    now = int(time.time())
+    future = now + (60 * 60)  # one hour in the future
+    good = _sign_archive_member_url(
+        tenant_id=TENANT,
+        agent_id=AGENT,
+        key="pdf-toolkit/.DIFY-SKILL-FULL.zip",
+        archive_file_kind=AgentDriveFileKind.TOOL_FILE,
+        archive_file_id="file-id",
+        member_path="SKILL.md",
+        timestamp=str(future),
+        nonce="nonce-2",
+    )
+    with patch("services.agent_drive_service.redis_client") as redis_mock:
+        assert (
+            AgentDriveService.verify_archive_member_signature(
+                tenant_id=TENANT,
+                agent_id=AGENT,
+                key="pdf-toolkit/.DIFY-SKILL-FULL.zip",
+                archive_file_kind=AgentDriveFileKind.TOOL_FILE,
+                archive_file_id="file-id",
+                member_path="SKILL.md",
+                timestamp=str(future),
+                nonce="nonce-2",
+                sign=good,
+            )
+            is False
+        )
+        redis_mock.set.assert_not_called()
+
+
+def test_verify_archive_member_signature_accepts_signature_within_skew_window():
+    now = int(time.time())
+    slightly_future = now + 5  # within the 30 s clock skew allowance
+    good = _sign_archive_member_url(
+        tenant_id=TENANT,
+        agent_id=AGENT,
+        key="pdf-toolkit/.DIFY-SKILL-FULL.zip",
+        archive_file_kind=AgentDriveFileKind.TOOL_FILE,
+        archive_file_id="file-id",
+        member_path="SKILL.md",
+        timestamp=str(slightly_future),
+        nonce="nonce-3",
+    )
+    with patch("services.agent_drive_service.redis_client") as redis_mock:
+        redis_mock.set.return_value = True
+        assert (
+            AgentDriveService.verify_archive_member_signature(
+                tenant_id=TENANT,
+                agent_id=AGENT,
+                key="pdf-toolkit/.DIFY-SKILL-FULL.zip",
+                archive_file_kind=AgentDriveFileKind.TOOL_FILE,
+                archive_file_id="file-id",
+                member_path="SKILL.md",
+                timestamp=str(slightly_future),
+                nonce="nonce-3",
+                sign=good,
+            )
+            is True
+        )
+        redis_mock.set.assert_called_once()
+        call = redis_mock.set.call_args
+        assert call.args[0] == f"agent_drive_archive_nonce:{TENANT}:{AGENT}:nonce-3"
+        assert call.kwargs.get("nx") is True
+
+
+def test_verify_archive_member_signature_rejects_replay_of_captured_nonce():
+    now = int(time.time())
+    good = _sign_archive_member_url(
+        tenant_id=TENANT,
+        agent_id=AGENT,
+        key="pdf-toolkit/.DIFY-SKILL-FULL.zip",
+        archive_file_kind=AgentDriveFileKind.TOOL_FILE,
+        archive_file_id="file-id",
+        member_path="SKILL.md",
+        timestamp=str(now),
+        nonce="nonce-replay",
+    )
+    with patch("services.agent_drive_service.redis_client") as redis_mock:
+        # First call wins (nx returns True), second call (the replay) finds the
+        # nonce already present and returns False from set(...).
+        redis_mock.set.side_effect = [True, False]
+        first = AgentDriveService.verify_archive_member_signature(
+            tenant_id=TENANT,
+            agent_id=AGENT,
+            key="pdf-toolkit/.DIFY-SKILL-FULL.zip",
+            archive_file_kind=AgentDriveFileKind.TOOL_FILE,
+            archive_file_id="file-id",
+            member_path="SKILL.md",
+            timestamp=str(now),
+            nonce="nonce-replay",
+            sign=good,
+        )
+        replay = AgentDriveService.verify_archive_member_signature(
+            tenant_id=TENANT,
+            agent_id=AGENT,
+            key="pdf-toolkit/.DIFY-SKILL-FULL.zip",
+            archive_file_kind=AgentDriveFileKind.TOOL_FILE,
+            archive_file_id="file-id",
+            member_path="SKILL.md",
+            timestamp=str(now),
+            nonce="nonce-replay",
+            sign=good,
+        )
+        assert first is True
+        assert replay is False
+        assert redis_mock.set.call_count == 2


### PR DESCRIPTION
## Summary

- `api/services/agent_drive_service.py`:
  - import `redis_client` from `extensions.ext_redis`
  - module-level constants `_SIGNATURE_CLOCK_SKEW_SECONDS` and `_NONCE_KEY_PREFIX`
  - in `verify_archive_member_signature`: use `hmac.compare_digest` for the signature comparison, reject timestamps more than 30 s in the future, and record the nonce in Redis with TTL `FILES_ACCESS_TIMEOUT + 30` via `SET ... NX` for atomic first-use semantics.
- `api/tests/unit_tests/services/test_agent_drive_service.py`: four tests covering tampered signature, far-future timestamp, signature within the skew window, and replayed nonce.

Fixes #39522.

## Why

`GET /files/agent-drive/archive-member` has no auth other than the signed URL. The prior signature check used `!=` (timing-leaking), accepted any non-negative timestamp (forged far-future timestamps stayed valid indefinitely), and never recorded the nonce (any captured URL was replayable for the entire access window).

## Test Plan

- `uv run --project api pytest "api/tests/unit_tests/services/test_agent_drive_service.py::test_verify_archive_member_signature_*" -q`