### PR TITLE
chore: add web shell code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -250,5 +250,26 @@
 # Frontend - Workspace
 /web/app/components/header/account-dropdown/workplace-selector/ @iamjoel @zxhlyh
 
+# Frontend - App Shell and Console Bootstrap
+/web/app/layout.tsx @iamjoel @lyzno1
+/web/app/error.tsx @iamjoel @lyzno1
+/web/app/(commonLayout)/layout.tsx @iamjoel @lyzno1
+/web/app/(commonLayout)/providers.tsx @iamjoel @lyzno1
+/web/app/(commonLayout)/hydration-boundary.tsx @iamjoel @lyzno1
+/web/app/(commonLayout)/profile-bootstrap-gate.tsx @iamjoel @lyzno1
+/web/app/(commonLayout)/error.tsx @iamjoel @lyzno1
+/web/app/account/(commonLayout)/layout.tsx @iamjoel @lyzno1
+/web/app/components/main-nav/* @iamjoel @lyzno1
+/web/app/components/main-nav/components/* @iamjoel @lyzno1
+/web/app/components/goto-anything/* @iamjoel @lyzno1
+/web/app/components/goto-anything/actions/* @iamjoel @lyzno1
+/web/app/components/goto-anything/actions/commands/* @iamjoel @lyzno1
+/web/app/components/goto-anything/components/* @iamjoel @lyzno1
+/web/context/query-client.tsx @iamjoel @lyzno1
+/web/context/query-client-server.ts @iamjoel @lyzno1
+/web/proxy.ts @iamjoel @lyzno1
+/web/app/auth/refresh/route.ts @iamjoel @lyzno1
+/web/service/server.ts @iamjoel @lyzno1
+
 # Docker
 /docker/* @laipz8200

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -261,10 +261,6 @@
 /web/app/account/(commonLayout)/layout.tsx @iamjoel @lyzno1
 /web/app/components/main-nav/* @iamjoel @lyzno1
 /web/app/components/main-nav/components/* @iamjoel @lyzno1
-/web/app/components/goto-anything/* @iamjoel @lyzno1
-/web/app/components/goto-anything/actions/* @iamjoel @lyzno1
-/web/app/components/goto-anything/actions/commands/* @iamjoel @lyzno1
-/web/app/components/goto-anything/components/* @iamjoel @lyzno1
 /web/context/query-client.tsx @iamjoel @lyzno1
 /web/context/query-client-server.ts @iamjoel @lyzno1
 /web/proxy.ts @iamjoel @lyzno1


### PR DESCRIPTION
## Summary

- add `@lyzno1` as a co-owner for the root and common app shells
- cover the console bootstrap, Main Nav, query client, proxy, auth refresh, and server client runtime paths
- keep existing owners and avoid test and contracts ownership

## Why

These paths form the shared Web app-shell and console-bootstrap boundary and have been maintained across the recent bootstrap, permission hydration, navigation, and routing changes.

Single-level wildcard rules are used for Main Nav runtime files so nested test directories remain outside this ownership scope.

## Validation

- `git diff --check`
- verified every added path exists
- confirmed the diff contains no test or contracts rules
- confirmed the branch has no Goto Anything ownership rules