### PR TITLE
fix: include CSRF token when fetching skill file content

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/skills/__tests__/index.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/skills/__tests__/index.spec.tsx
@@ -219,6 +219,7 @@ describe('AgentSkills', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.stubGlobal('fetch', mocks.fetch)
+    document.cookie = 'csrf_token=csrf-token; path=/'
     mocks.fetch.mockResolvedValue(
       new Response('downloaded skill file', {
         headers: { 'Content-Type': 'application/octet-stream' },
@@ -295,6 +296,7 @@ describe('AgentSkills', () => {
   })
 
   afterEach(() => {
+    document.cookie = 'csrf_token=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/'
     vi.unstubAllGlobals()
   })
 
@@ -752,6 +754,9 @@ describe('AgentSkills', () => {
       'http://localhost:5001/console/api/agent/agent-1/config/skills/Tender%20Analyzer/files/content?path=references%2Fguide.md',
       {
         credentials: 'include',
+        headers: {
+          'X-CSRF-Token': 'csrf-token',
+        },
       },
     )
     expect(mocks.downloadBlob).toHaveBeenCalledWith({

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/skills/use-skill-detail.ts
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/skills/use-skill-detail.ts
@@ -6,9 +6,10 @@ import type { AgentSkillDetail, AgentSkillDetailDownloadAction } from './detail-
 import type { AgentFileNode, AgentSkill } from '@/features/agent-v2/agent-composer/form-state'
 import { toast } from '@langgenius/dify-ui/toast'
 import { queryOptions, skipToken, useQuery, useQueryClient } from '@tanstack/react-query'
+import Cookies from 'js-cookie'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { API_PREFIX } from '@/config'
+import { API_PREFIX, CSRF_COOKIE_NAME, CSRF_HEADER_NAME } from '@/config'
 import { consoleQuery } from '@/service/client'
 import { downloadBlob } from '@/utils/download'
 import { getDriveFileIconType } from '../files/file-icon'
@@ -27,6 +28,9 @@ const resolveSkillFileContentUrl = (url: string) => {
 const fetchSkillFileContent = async (url: string) => {
   const response = await globalThis.fetch(resolveSkillFileContentUrl(url), {
     credentials: 'include',
+    headers: {
+      [CSRF_HEADER_NAME]: Cookies.get(CSRF_COOKIE_NAME()) || '',
+    },
   })
   if (!response.ok) throw new Error(`Failed to download skill file: ${response.status}`)
 


### PR DESCRIPTION
## Summary

- Send the `X-CSRF-Token` header alongside session cookies when fetching protected skill file blobs for previews and downloads.
- Add regression coverage verifying that authenticated skill content requests include both credentials and the matching CSRF token.

Fixes DIFY-2839

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.