### PR TITLE
fix(agent-v2): link API reference to agent guide

### DIFF
--- a/e2e/features/step-definitions/agent-v2/access-point-service-api.steps.ts
+++ b/e2e/features/step-definitions/agent-v2/access-point-service-api.steps.ts
@@ -149,7 +149,7 @@ When('I open the Agent v2 API Reference', async function (this: DifyWorld) {
   const apiReferenceLink = page.getByRole('link', { name: 'API Reference' })
 
   await expect(apiReferenceLink).toBeVisible()
-  await expect(apiReferenceLink).toHaveAttribute('href', /\/api-reference\/guides\/get-started/)
+  await expect(apiReferenceLink).toHaveAttribute('href', /\/api-reference\/guides\/agent/)
   await expect(apiReferenceLink).toHaveAttribute('target', '_blank')
 
   const [apiReferencePage] = await Promise.all([
@@ -164,7 +164,7 @@ Then('the Agent v2 API Reference should open in a new tab', async function (this
   const apiReferencePage = this.agentBuilder.accessPoint.apiReferencePage
   if (!apiReferencePage) throw new Error('No Agent v2 API Reference page was opened.')
 
-  await expect(apiReferencePage).toHaveURL(/\/api-reference\/guides\/get-started/)
+  await expect(apiReferencePage).toHaveURL(/\/api-reference\/guides\/agent/)
   await apiReferencePage.close()
   this.agentBuilder.accessPoint.apiReferencePage = undefined
 })

--- a/web/features/agent-v2/agent-detail/access/components/service-api-access-card.tsx
+++ b/web/features/agent-v2/agent-detail/access/components/service-api-access-card.tsx
@@ -88,7 +88,7 @@ export function ServiceApiAccessCard({ agentId }: { agentId: string }) {
           </span>
         </Button>
         <a
-          href={docLink('/api-reference/guides/get-started')}
+          href={docLink('/api-reference/guides/agent')}
           target="_blank"
           rel="noreferrer"
           aria-label={t(($) => $['agentDetail.access.serviceApi.actions.apiReference'])}


### PR DESCRIPTION
## What changed

- Point the Agent v2 Access Point API Reference action to the dedicated New Agent API guide.
- Update the existing Cucumber/Playwright assertion to cover the new destination.

## Why

The previous link opened the generic API getting-started page. Agent v2 has a dedicated API overview at `/api-reference/guides/agent`, which directly documents the `agent` app mode and its endpoints.

## Validation

- `vp check web/features/agent-v2/agent-detail/access/components/service-api-access-card.tsx e2e/features/step-definitions/agent-v2/access-point-service-api.steps.ts`
- `pnpm exec eslint --quiet web/features/agent-v2/agent-detail/access/components/service-api-access-card.tsx e2e/features/step-definitions/agent-v2/access-point-service-api.steps.ts`
- `pnpm -C e2e type-check`