### PR TITLE
fix(web): defer permission query until workspace is ready

### DIFF
--- a/web/context/permission-state.ts
+++ b/web/context/permission-state.ts
@@ -4,10 +4,15 @@ import { atom } from 'jotai'
 import { atomWithQuery } from 'jotai-tanstack-query'
 import { consoleQuery } from '@/service/client'
 import { emptyWorkspacePermissionKeys } from './app-context-normalizers'
+import { currentWorkspaceIdAtom } from './workspace-state'
 
-const workspacePermissionKeysQueryAtom = atomWithQuery(() =>
-  consoleQuery.workspaces.current.rbac.myPermissions.get.queryOptions(),
-)
+const workspacePermissionKeysQueryAtom = atomWithQuery((get) => {
+  const workspaceId = get(currentWorkspaceIdAtom)
+
+  return consoleQuery.workspaces.current.rbac.myPermissions.get.queryOptions({
+    enabled: workspaceId === undefined || Boolean(workspaceId),
+  })
+})
 
 export const workspacePermissionKeysAtom = atom((get) => {
   return (


### PR DESCRIPTION
## Summary

- keep the generated current-workspace permission query and cache key
- restore the current workspace identity as a readiness dependency
- defer the client permission request until the workspace is available

## Why

This is a focused A/B change for the deterministic Linux WebKit E2E failure after permission SSR hydration. It tests whether the client permission atom starting before the current workspace is ready causes permission-gated navigation and app controls to diverge during hydration.

## Testing

- `pnpm vitest run context/__tests__/console-bootstrap.spec.tsx app/components/main-nav/__tests__/index.spec.tsx app/components/apps/__tests__/list.spec.tsx features/agent-v2/__tests__/permissions.spec.tsx`
- `vp check web/context/permission-state.ts`
- `git diff --check`