### PR TITLE
test(e2e): wait for app list before menu interaction

### DIFF
--- a/e2e/features/step-definitions/accessibility/keyboard-navigation.steps.ts
+++ b/e2e/features/step-definitions/accessibility/keyboard-navigation.steps.ts
@@ -72,6 +72,7 @@ When('I open and close the create app menu using the keyboard', async function (
   const page = this.getPage()
   const trigger = getCreateAppMenuTrigger(this)
 
+  await expect(page.getByRole('heading', { name: 'Build your first App' })).toBeVisible()
   await trigger.press('Enter')
   await expect(trigger).toHaveAttribute('aria-expanded', 'true')
   await page.keyboard.press('Escape')


### PR DESCRIPTION
## Summary

- keep the Create app menu keyboard and focus-restoration coverage
- wait for the user-visible empty app list state before pressing Enter on the menu trigger

## Root cause

After workspace permissions were prefetched on the server, the Create trigger became available in the initial HTML before the client-owned app list had finished resolving. Playwright could therefore press Enter on an actionable DOM button before the deeper app subtree was ready for the Base UI interaction. Waiting for the `Build your first App` heading provides a web-first, user-visible readiness boundary for the empty-workspace E2E fixture.

## Testing

- `pnpm -C e2e type-check`
- `vp check e2e/features/step-definitions/accessibility/keyboard-navigation.steps.ts`
- `git diff --check`