### PR TITLE
refactor(web): derive delete account button state

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -246,9 +246,6 @@
     }
   },
   "web/app/account/(commonLayout)/delete-account/components/verify-email.tsx": {
-    "eslint-react/set-state-in-effect": {
-      "count": 1
-    },
     "no-restricted-imports": {
       "count": 1
     }

--- a/web/app/account/(commonLayout)/delete-account/components/verify-email.tsx
+++ b/web/app/account/(commonLayout)/delete-account/components/verify-email.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { Button } from '@langgenius/dify-ui/button'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Input from '@/app/components/base/input'
 import Countdown from '@/app/components/signin/countdown'
@@ -18,13 +18,10 @@ export default function VerifyEmail(props: DeleteAccountProps) {
   const { t } = useTranslation()
   const emailToken = useAccountDeleteStore((state) => state.sendEmailToken)
   const [verificationCode, setVerificationCode] = useState<string>()
-  const [shouldButtonDisabled, setShouldButtonDisabled] = useState(true)
   const { mutate: sendEmail } = useSendDeleteAccountEmail()
   const { isPending: isDeleting, mutateAsync: confirmDeleteAccount } = useConfirmDeleteAccount()
 
-  useEffect(() => {
-    setShouldButtonDisabled(!(verificationCode && CODE_EXP.test(verificationCode)) || isDeleting)
-  }, [verificationCode, isDeleting])
+  const shouldButtonDisabled = !(verificationCode && CODE_EXP.test(verificationCode)) || isDeleting
 
   const handleConfirm = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary
- Derive the delete-account confirmation button disabled state during render
- Remove the extra state and effect used only to mirror verification code/deleting state

## Related Issue
Ref #25194

## Test Plan
- npm exec --yes pnpm@11.15.0 -- exec tsc --noEmit --pretty false --incremental false