### PR TITLE
fix: use Dify's own doc_id instead of content hash for Weaviate object UUIDs

### DIFF
--- a/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
@@ -280,17 +280,20 @@ class WeaviateVector(BaseVector):
     @override
     def _get_uuids(self, documents: list[Document]) -> list[str]:
         """
-        Generates deterministic UUIDs for documents based on their content.
-
-        Uses UUID5 with URL namespace to ensure consistent IDs for identical content.
+        Use Dify's own doc_id (index_node_id, set in each Document's metadata by
+        the caller) as the Weaviate object UUID instead of hashing the page
+        content. This keeps write-time IDs consistent with what delete_by_ids()
+        looks up, and stops segments with identical text across different
+        documents from colliding on the same Weaviate object.
+        Falls back to a fresh random UUID if a document has no usable doc_id.
         """
-        URL_NAMESPACE = _uuid.UUID("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
-
         uuids = []
         for doc in documents:
-            uuid_val = _uuid.uuid5(URL_NAMESPACE, doc.page_content)
-            uuids.append(str(uuid_val))
-
+            doc_id = (doc.metadata or {}).get("doc_id")
+            if doc_id and self._is_uuid(str(doc_id)):
+                uuids.append(str(doc_id))
+            else:
+                uuids.append(str(_uuid.uuid4()))
         return uuids
 
     @override

--- a/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
@@ -759,6 +759,37 @@ class TestWeaviateVector(unittest.TestCase):
         assert wv._is_uuid("123e4567-e89b-12d3-a456-426614174000") is True
         assert wv._is_uuid("not-a-uuid") is False
 
+    def test_get_uuids_returns_doc_id_from_metadata(self):
+        """_get_uuids should reuse Dify's own doc_id instead of hashing content."""
+        wv = WeaviateVector.__new__(WeaviateVector)
+        doc_id = "123e4567-e89b-12d3-a456-426614174000"
+        doc = Document(page_content="same content", metadata={"doc_id": doc_id})
+
+        assert wv._get_uuids([doc]) == [doc_id]
+
+    def test_get_uuids_does_not_collide_for_identical_content_across_documents(self):
+        """Two documents with identical page_content but different doc_id must not
+        produce the same Weaviate UUID, otherwise one overwrites the other."""
+        wv = WeaviateVector.__new__(WeaviateVector)
+        doc_id_a = "123e4567-e89b-12d3-a456-426614174000"
+        doc_id_b = "223e4567-e89b-12d3-a456-426614174000"
+        doc_a = Document(page_content="duplicate segment text", metadata={"doc_id": doc_id_a})
+        doc_b = Document(page_content="duplicate segment text", metadata={"doc_id": doc_id_b})
+
+        uuids = wv._get_uuids([doc_a, doc_b])
+
+        assert uuids == [doc_id_a, doc_id_b]
+        assert uuids[0] != uuids[1]
+
+    def test_get_uuids_falls_back_to_random_uuid_when_doc_id_missing(self):
+        wv = WeaviateVector.__new__(WeaviateVector)
+        doc = Document(page_content="no doc id here", metadata={})
+
+        uuids = wv._get_uuids([doc])
+
+        assert len(uuids) == 1
+        assert wv._is_uuid(uuids[0])
+
     def test_delete_by_metadata_field_returns_when_collection_is_missing(self):
         wv = WeaviateVector.__new__(WeaviateVector)
         wv._collection_name = self.collection_name


### PR DESCRIPTION
Fixes #39175

## Problem

`WeaviateVector._get_uuids()` generates the UUID used as each object's
primary key in Weaviate by hashing the segment's `page_content` with
`uuid5` and a fixed namespace:

```python
def _get_uuids(self, documents: list[Document]) -> list[str]:
    URL_NAMESPACE = _uuid.UUID("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
    uuids = []
    for doc in documents:
        uuid_val = _uuid.uuid5(URL_NAMESPACE, doc.page_content)
        uuids.append(str(uuid_val))
    return uuids
```

Meanwhile, `delete_by_ids()` in the same file looks segments up by
Dify's own `doc_id` (`DocumentSegment.index_node_id`, passed in via
`document.metadata["doc_id"]`). These two IDs are unrelated, causing:

1. **Disabling/deleting a document never actually removes its
   vectors from Weaviate** — `delete_by_ids()` gets 404s (silently
   swallowed), so vectors for disabled/deleted documents accumulate
   forever.
2. **Documents with identical segment content silently overwrite
   each other** — Weaviate's write is an upsert by UUID, so a
   byte-identical chunk in a different document replaces the
   original object.

## Fix

Use `doc.metadata["doc_id"]` as the Weaviate object UUID instead of
hashing content, falling back to a fresh random UUID only if `doc_id`
is missing or invalid. `delete_by_ids()` is unchanged — it was
already correct. This also brings `WeaviateVector` in line with the
default `_get_uuids()` already defined on the abstract base class
(`core/rag/datasource/vdb/vector_base.py`):

```python
def _get_uuids(self, texts: list[Document]) -> list[str]:
    return [text.metadata["doc_id"] for text in texts if text.metadata and "doc_id" in text.metadata]
```

## Relationship to existing PRs

- **#36140** combines `doc_id` into the content hash, which prevents
  collisions but leaves `delete_by_ids()` mismatched against the new
  hash, so deletion is still broken.
- **#37068** switches `delete_by_ids()` calls to
  `delete_by_metadata_field("doc_id", node_id)`, but only for the
  child-chunk update/delete call sites; the general document
  disable/delete path (`remove_document_from_index_task` /
  `clean_dataset_task`) still uses `delete_by_ids()` and remains
  affected. It also doesn't address write-time collisions.

This PR fixes both symptoms for the general document path in a
single, self-contained change to the Weaviate adapter, with no
changes needed to `vector_service.py` or other callers.

## Testing

Reproduced end-to-end locally with a clean Weaviate-backed
deployment and two documents that share one identical segment:

| Step | Before fix | After fix |
|---|---|---|
| Upload 2 docs, 5 segments each | 9 total objects (1 lost to collision) | 10 total objects (5 + 5) |
| Disable one document | Vector count unchanged | Drops to 0 |
| Re-enable it | N/A (never reached 0) | Back to 5 |
| Delete the other document | Orphaned vectors remain | Drops to 0 |

Added unit tests in `test_weaviate_vector.py` covering:
- `_get_uuids()` returns the given `doc_id` when present and valid
- Two documents with identical `page_content` but different `doc_id`
  produce different UUIDs (regression test for the collision bug)
- Falls back to a valid random UUID when `doc_id` is missing

## Screenshots

N/A — this is a backend logic fix with no UI changes. See the
before/after vector-count table above for the observable behavior
change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
