### PR TITLE
fix: typing into the trailing Params/Headers row in the HTTP node no longer destroys the row

### DIFF
--- a/web/app/components/workflow/nodes/http/components/key-value/__tests__/key-value-row-lifecycle.spec.tsx
+++ b/web/app/components/workflow/nodes/http/components/key-value/__tests__/key-value-row-lifecycle.spec.tsx
@@ -87,9 +87,7 @@ describe('HTTP key/value table — trailing-row lifecycle (F-HTTP-PARAMS-TABLE)'
 
     // And its editor must NOT have been remounted (stable instance id) — a remount
     // is what wipes the in-progress keystroke in the real Lexical editor.
-    const sinceIdx = getKeyInputs().findIndex(
-      (el) => (el as HTMLInputElement).value === 'since',
-    )
+    const sinceIdx = getKeyInputs().findIndex((el) => (el as HTMLInputElement).value === 'since')
     const valueIdAfter = getValueInputs()[sinceIdx]!.getAttribute('data-instanceid')
     expect(valueIdAfter).toBe(valueIdBefore)
   })

--- a/web/app/components/workflow/nodes/http/components/key-value/__tests__/key-value-row-lifecycle.spec.tsx
+++ b/web/app/components/workflow/nodes/http/components/key-value/__tests__/key-value-row-lifecycle.spec.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import * as React from 'react'
+import { useState } from 'react'
+import useKeyValueList from '../../../hooks/use-key-value-list'
+import KeyValue from '../index'
+
+// The HTTP node's key/value editor renders a Lexical `PromptEditor` at its leaf
+// (`input-item` -> `input-support-select-var` -> `PromptEditor`). Lexical's real
+// contenteditable behaviour is not modelled by happy-dom, and the existing
+// PromptEditor tests mock it out for the same reason. The row-lifecycle bug under
+// test lives *above* the editor — in `use-key-value-list` + `item.tsx`'s
+// onChange/onAdd orchestration — so we mock only the leaf editor with a plain
+// controlled input that honours the same `{ value, onChange }` contract.
+vi.mock('../key-value-edit/input-item', () => ({
+  __esModule: true,
+  default: ({
+    value,
+    onChange,
+    instanceId,
+  }: {
+    value: string
+    onChange: (v: string) => void
+    instanceId?: string
+  }) => (
+    <input
+      data-instanceid={instanceId}
+      data-field={instanceId?.startsWith('http-key-') ? 'key' : 'value'}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}))
+
+// Mirrors the production wiring in `use-config.ts`:
+//   const { list, setList, addItem } = useKeyValueList(inputs.params, handleFieldChange('params'))
+//   <KeyValue list={list} onChange={setList} onAdd={addItem} .../>
+function ParamsHarness({ initialValue = '' }: { initialValue?: string }) {
+  const [paramStr, setParamStr] = useState(initialValue)
+  const { list, setList, addItem } = useKeyValueList(paramStr, setParamStr)
+  return (
+    <>
+      <div data-testid="param-string">{paramStr}</div>
+      <KeyValue
+        nodeId="test-node"
+        readonly={false}
+        list={list}
+        onChange={setList}
+        onAdd={addItem}
+        isSupportFile={false}
+      />
+    </>
+  )
+}
+
+const getKeyInputs = () =>
+  screen.getAllByRole('textbox').filter((el) => el.getAttribute('data-field') === 'key')
+const getValueInputs = () =>
+  screen.getAllByRole('textbox').filter((el) => el.getAttribute('data-field') === 'value')
+
+describe('HTTP key/value table — trailing-row lifecycle (F-HTTP-PARAMS-TABLE)', () => {
+  it('keeps the row after typing a key then a single character into the trailing row value', async () => {
+    const user = userEvent.setup()
+    render(<ParamsHarness />)
+
+    // One empty trailing row is rendered initially.
+    expect(getValueInputs()).toHaveLength(1)
+
+    // Type a key into the trailing row.
+    await user.type(getKeyInputs()[0]!, 'since')
+    expect((getKeyInputs()[0] as HTMLInputElement).value).toBe('since')
+
+    // Capture the trailing row's editor identity BEFORE typing into value.
+    const valueIdBefore = getValueInputs()[0]!.getAttribute('data-instanceid')
+
+    // Type a single non-space character into the trailing row's VALUE field.
+    await user.type(getValueInputs()[0]!, 'x')
+
+    // The row that had key "since" must still exist and hold value "x".
+    await waitFor(() => {
+      const keyInputs = getKeyInputs().map((el) => (el as HTMLInputElement).value)
+      const valueInputs = getValueInputs().map((el) => (el as HTMLInputElement).value)
+      const idx = keyInputs.indexOf('since')
+      expect(idx).toBeGreaterThanOrEqual(0)
+      expect(valueInputs[idx]).toBe('x')
+    })
+
+    // And its editor must NOT have been remounted (stable instance id) — a remount
+    // is what wipes the in-progress keystroke in the real Lexical editor.
+    const sinceIdx = getKeyInputs().findIndex(
+      (el) => (el as HTMLInputElement).value === 'since',
+    )
+    const valueIdAfter = getValueInputs()[sinceIdx]!.getAttribute('data-instanceid')
+    expect(valueIdAfter).toBe(valueIdBefore)
+  })
+})

--- a/web/app/components/workflow/nodes/http/hooks/use-key-value-list.ts
+++ b/web/app/components/workflow/nodes/http/hooks/use-key-value-list.ts
@@ -1,7 +1,7 @@
 import type { KeyValue } from '../types'
 import { useBoolean } from 'ahooks'
 import { uniqueId } from 'es-toolkit/compat'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 const UNIQUE_ID_PREFIX = 'key-value-'
 const strToKeyValueList = (value: string) => {
@@ -29,39 +29,52 @@ const stringifyList = (items: KeyValue[], noFilter?: boolean) => {
 
 const useKeyValueList = (value: string, onChange: (value: string) => void, noFilter?: boolean) => {
   const [list, doSetList] = useState<KeyValue[]>(() => (value ? strToKeyValueList(value) : []))
+  // Mirror the latest committed list synchronously so callbacks never close over
+  // a stale render-time value when several updates fire within one event — e.g.
+  // an `onChange` immediately followed by `onAdd` while typing into the trailing row.
+  const listRef = useRef(list)
+  const commitList = useCallback((next: KeyValue[]) => {
+    listRef.current = next
+    doSetList(next)
+  }, [])
   const setList = useCallback(
     (nextList: KeyValue[]) => {
       const normalized = normalizeList(nextList)
-      doSetList(normalized)
+      commitList(normalized)
       if (noFilter) return
 
       const newValue = stringifyList(normalized, noFilter)
       if (newValue !== value) onChange(newValue)
     },
-    [noFilter, onChange, value],
+    [commitList, noFilter, onChange, value],
   )
 
   useEffect(() => {
     Promise.resolve().then(() => {
-      doSetList((prev) => {
-        const targetItems = value ? strToKeyValueList(value) : []
-        const currentValue = stringifyList(prev, noFilter)
-        const targetValue = stringifyList(targetItems, noFilter)
-        if (currentValue === targetValue) return prev
-        return normalizeList(targetItems)
-      })
+      const prev = listRef.current
+      const targetItems = value ? strToKeyValueList(value) : []
+      const currentValue = stringifyList(prev, noFilter)
+      const targetValue = stringifyList(targetItems, noFilter)
+      if (currentValue === targetValue) return
+      // Preserve ids of rows that already exist (matched positionally) so the
+      // Lexical editor is not remounted; only genuinely new rows get a fresh id.
+      const reconciled = targetItems.map((item, index) => ({
+        ...item,
+        id: prev[index]?.id || item.id,
+      }))
+      commitList(normalizeList(reconciled))
     })
-  }, [value, noFilter])
+  }, [value, noFilter, commitList])
   const addItem = useCallback(() => {
     setList([
-      ...list,
+      ...listRef.current,
       {
         id: uniqueId(UNIQUE_ID_PREFIX),
         key: '',
         value: '',
       },
     ])
-  }, [list, setList])
+  }, [setList])
 
   const [isKeyValueEdit, { toggle: toggleIsKeyValueEdit }] = useBoolean(true)
 


### PR DESCRIPTION
## Summary

Fixes #39551.

In the HTTP Request node's **Params** and **Headers** key/value tables, typing any non-space character into the trailing (uncommitted) row destroyed the entire row — both the just-typed value and any key already entered. Values could only be entered by pasting.

**Root cause:** params/headers are stored as a newline-joined string, and every change round-trips list → string → list. Two mechanisms in the shared `use-key-value-list.ts` hook combined to drop input:

1. A microtask `useEffect` re-derived the list from the string on each change and reassigned *every* row's `id`, remounting the Lexical editor mid-keystroke and dropping the character being typed.
2. The add-row handler closed over a stale list, so an `onChange` immediately followed by an `onAdd` let the add overwrite the value that was just typed.

**Fix:** hold a `listRef` mirror so the add path no longer closes over a stale list, and preserve `id`s for rows that already exist — only assigning a new `id` to a genuinely new row — so the editor is no longer remounted on every keystroke. Both tables share the hook, so this fixes Params and Headers together. The newline-joined-string storage model is left unchanged (deliberately out of scope for this fix).

**Test:** added a regression test in the existing Vitest suite that mounts the key-value editor, types into the trailing row's value, and asserts the row survives with its key and value intact. It fails on current `main` and passes with this change; the full workflow-nodes suite and `tsc --noEmit` stay green.

**Not addressed here:** pressing Enter in the trailing row's key field still migrates the existing value into the newly-created row. That stems from the same newline-joined-string storage model and would require changing it, so it's left as a documented follow-up in #39551.

## Screenshots

**Before**
*Typing `open` into the trailing Params value row on `main` — the row is destroyed on the first character, losing both the key and the value.*

https://github.com/user-attachments/assets/73cd5d37-0fea-4cee-b1fd-7ec56a369654

---

**After**
*Same sequence with the fix — the row survives, key and value are preserved, and a new empty row appears as expected.*

https://github.com/user-attachments/assets/aaf7d220-8c03-4233-b23a-b6450b32b795

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Claude Code