### PR TITLE
fix(vdb): correct malformed metadata-filter SQL in relyt and analyticdb

### DIFF
--- a/api/providers/vdb/vdb-analyticdb/src/dify_vdb_analyticdb/analyticdb_vector_sql.py
+++ b/api/providers/vdb/vdb-analyticdb/src/dify_vdb_analyticdb/analyticdb_vector_sql.py
@@ -212,7 +212,7 @@ class AnalyticdbVectorBySql:
         if not isinstance(top_k, int) or top_k <= 0:
             raise ValueError("top_k must be a positive integer")
         document_ids_filter = kwargs.get("document_ids_filter")
-        where_clause = "WHERE 1=1"
+        where_clause = "WHERE 1=1 "
         if document_ids_filter:
             document_ids = ", ".join(f"'{id}'" for id in document_ids_filter)
             where_clause += f"AND metadata_->>'document_id' IN ({document_ids})"

--- a/api/providers/vdb/vdb-analyticdb/tests/unit_tests/test_analyticdb_vector_sql.py
+++ b/api/providers/vdb/vdb-analyticdb/tests/unit_tests/test_analyticdb_vector_sql.py
@@ -227,6 +227,26 @@ def test_search_by_vector_returns_documents_above_threshold():
     assert docs[0].metadata["score"] == 0.8
 
 
+def test_search_by_vector_emits_well_formed_where_clause_with_filter():
+    vector = AnalyticdbVectorBySql.__new__(AnalyticdbVectorBySql)
+    vector.table_name = "dify.collection"
+    cursor = MagicMock()
+    cursor.__iter__.return_value = iter([])
+
+    @contextmanager
+    def _cursor_context():
+        yield cursor
+
+    vector._get_cursor = _cursor_context
+
+    vector.search_by_vector([0.1, 0.2], top_k=1, document_ids_filter=["doc-1"])
+
+    executed_sql = cursor.execute.call_args.args[0]
+    assert "WHERE 1=1 AND" in executed_sql
+    assert "1=1AND" not in executed_sql
+    assert "metadata_->>'document_id' IN ('doc-1')" in executed_sql
+
+
 @pytest.mark.parametrize("invalid_top_k", [0, "x", -1])
 def test_search_by_full_text_validates_top_k(invalid_top_k):
     vector = AnalyticdbVectorBySql.__new__(AnalyticdbVectorBySql)

--- a/api/providers/vdb/vdb-relyt/src/dify_vdb_relyt/relyt_vector.py
+++ b/api/providers/vdb/vdb-relyt/src/dify_vdb_relyt/relyt_vector.py
@@ -255,9 +255,9 @@ class RelytVector(BaseVector):
         filter_condition = ""
         if filter is not None:
             conditions = [
-                f"metadata->>'{key!r}' in ({', '.join(map(repr, value))})"
+                f"metadata->>'{key}' in ({', '.join(map(repr, value))})"
                 if len(value) > 1
-                else f"metadata->>'{key!r}' = {value[0]!r}"
+                else f"metadata->>'{key}' = {value[0]!r}"
                 for key, value in filter.items()
             ]
             filter_condition = f"WHERE {' AND '.join(conditions)}"

--- a/api/providers/vdb/vdb-relyt/tests/unit_tests/test_relyt_vector.py
+++ b/api/providers/vdb/vdb-relyt/tests/unit_tests/test_relyt_vector.py
@@ -320,3 +320,27 @@ def test_relyt_factory_existing_and_generated_collection(relyt_module, monkeypat
     assert vector_cls.call_args_list[0].kwargs["collection_name"] == "EXISTING_COLLECTION"
     assert vector_cls.call_args_list[1].kwargs["collection_name"] == "AUTO_COLLECTION"
     assert dataset_without_index.index_struct is not None
+
+
+def test_similarity_search_emits_well_formed_metadata_filter(relyt_module):
+    vector = relyt_module.RelytVector.__new__(relyt_module.RelytVector)
+    vector._collection_name = "collection_1"
+    vector.client = MagicMock()
+
+    conn = MagicMock()
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = None
+    conn.execute.return_value.fetchall.return_value = []
+    vector.client.connect.return_value = conn
+
+    vector.similarity_search_with_score_by_vector(
+        embedding=[0.1, 0.2, 0.3],
+        k=1,
+        filter={"document_id": ["doc-1", "doc-2"], "group_id": ["g-1"]},
+    )
+
+    executed_sql = str(conn.execute.call_args.args[0])
+    assert "metadata->>'document_id' in ('doc-1', 'doc-2')" in executed_sql
+    assert "metadata->>'group_id' in ('g-1')" in executed_sql
+    assert "''document_id''" not in executed_sql
+    assert "''group_id''" not in executed_sql


### PR DESCRIPTION
## Summary

- `api/providers/vdb/vdb-relyt/src/dify_vdb_relyt/relyt_vector.py`: drop the `{key!r}` → `{key}` in the metadata-filter predicate so the key renders as `document_id`, not `'document_id'`.
- `api/providers/vdb/vdb-analyticdb/src/dify_vdb_analyticdb/analyticdb_vector_sql.py`: `WHERE 1=1` → `WHERE 1=1 ` (trailing space) before the concatenated `AND metadata_->>'document_id' IN (...)`.
- `api/providers/vdb/vdb-relyt/tests/unit_tests/test_relyt_vector.py`: regression test asserting the emitted SQL contains `metadata->>'document_id' in (...)` and not `''document_id''`.
- `api/providers/vdb/vdb-analyticdb/tests/unit_tests/test_analyticdb_vector_sql.py`: regression test asserting the emitted SQL contains `WHERE 1=1 AND` and not `1=1AND`.

Refs #39507, #39487.

## Test Plan

- `uv run --project api pytest api/providers/vdb/vdb-relyt/tests/unit_tests/test_relyt_vector.py api/providers/vdb/vdb-analyticdb/tests/unit_tests/test_analyticdb_vector_sql.py -q`