### PR TITLE
fix(web): call clearInterval on a setInterval handle in file-uploader

### DIFF
--- a/web/app/components/base/file-uploader/__tests__/hooks.spec.ts
+++ b/web/app/components/base/file-uploader/__tests__/hooks.spec.ts
@@ -536,6 +536,38 @@ describe('useFile', () => {
       vi.useRealTimers()
     })
 
+    it('should not leak the interval handle when the timer self-clears', () => {
+      vi.useFakeTimers()
+      mockUploadRemoteFileInfo.mockReturnValue(new Promise(() => {}))
+
+      // File starts at 60 so one tick takes it to 80, then the next tick hits
+      // the self-clear branch (progress is no longer < 80).
+      mockStoreFiles = [
+        {
+          id: 'mock-uuid',
+          name: 'https://example.com/file.txt',
+          type: '',
+          size: 0,
+          progress: 60,
+          transferMethod: 'remote_url',
+          supportFileType: '',
+        },
+      ] as FileEntity[]
+
+      const clearSpy = vi.spyOn(globalThis, 'clearInterval')
+      const { result } = renderHook(() => useFile(defaultFileConfig))
+      result.current.handleLoadFileFromLink('https://example.com/file.txt')
+
+      // Drive past 80 — first tick increments to 80, second tick hits the
+      // `clearInterval(timer)` branch.
+      vi.advanceTimersByTime(2000)
+
+      expect(clearSpy).toHaveBeenCalled()
+
+      vi.useRealTimers()
+      clearSpy.mockRestore()
+    })
+
     it('should stop progress timer when progress is negative', () => {
       vi.useFakeTimers()
       mockUploadRemoteFileInfo.mockReturnValue(new Promise(() => {}))

--- a/web/app/components/base/file-uploader/hooks.ts
+++ b/web/app/components/base/file-uploader/hooks.ts
@@ -213,7 +213,7 @@ export const useFile = (fileConfig: FileUpload, noNeedToCheckEnable = true) => {
 
         if (file && file.progress < 80 && file.progress >= 0)
           handleUpdateFile({ ...file, progress: file.progress + 20 })
-        else clearTimeout(timer)
+        else clearInterval(timer)
       }, 200)
     },
     [fileStore, handleUpdateFile],


### PR DESCRIPTION
## Summary

- `web/app/components/base/file-uploader/hooks.ts`: in `startProgressTimer`, `clearTimeout(timer)` → `clearInterval(timer)` so the interval actually self-clears once `file.progress >= 80`.
- `web/app/components/base/file-uploader/__tests__/hooks.spec.ts`: new test seeding a file at `progress: 60`, calling `handleLoadFileFromLink`, advancing fake timers by 2000 ms, and asserting that `clearInterval` is called when the timer self-cancels.

Fixes #37707.

## Test Plan

- `pnpm --dir web test run app/components/base/file-uploader/__tests__/hooks.spec.ts`