### PR TITLE
fix(web): prevent customization horizontal overflow

### DIFF
--- a/web/app/components/custom/custom-page/index.tsx
+++ b/web/app/components/custom/custom-page/index.tsx
@@ -20,7 +20,7 @@ const CustomPage = () => {
   const showContact = enableBilling && (plan.type === Plan.professional || plan.type === Plan.team)
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col overflow-x-hidden">
       {showBillingTip && (
         <div className="mb-1 flex justify-between rounded-xl bg-linear-to-r from-components-input-border-active-prompt-1 to-components-input-border-active-prompt-2 p-4 pl-6 shadow-lg backdrop-blur-xs">
           <div className="space-y-1 text-text-primary-on-surface">


### PR DESCRIPTION
## Summary

- Prevent the Customization settings tab from exposing horizontal overflow.
- Clip overflow at the tab root so the preview mock cannot expand the settings scroll area horizontally.

## Screenshots

| Before | After |
|--------|-------|
| Horizontal scrolling was available in Customization. | Horizontal overflow is clipped within Customization. |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

Validation: `pnpm check` completed formatting and Oxlint successfully; repository-wide ESLint remains blocked by existing `web/code_review.md` markdown errors. `pnpm exec vp test run app/components/custom/custom-web-app-brand/__tests__/index.spec.tsx` passed (11 tests).

From Codex