### PR TITLE
feat(web): show the User Input default value beneath the field name with a working tooltip

### DIFF
--- a/web/app/components/workflow/nodes/start/components/__tests__/var-item.spec.tsx
+++ b/web/app/components/workflow/nodes/start/components/__tests__/var-item.spec.tsx
@@ -1,5 +1,7 @@
 import type { InputVar } from '@/app/components/workflow/types'
+import { TooltipProvider } from '@langgenius/dify-ui/tooltip'
 import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { InputVarType } from '@/app/components/workflow/types'
 import VarItem from '../var-item'
 
@@ -33,28 +35,72 @@ describe('StartVarItem', () => {
     expect(handleRemove).toHaveBeenCalledTimes(1)
   })
 
-  it('renders the default value indicator when a field has a default', () => {
-    render(<VarItem readonly={false} payload={createPayload({ default: 'hello' })} />)
+  describe('default value indicator', () => {
+    it('renders beneath the field name, not in the required metadata zone', () => {
+      render(
+        <VarItem readonly={false} payload={createPayload({ required: true, default: 'hello' })} />,
+      )
 
-    const value = screen.getByTestId('var-item-default-value')
-    expect(value).toHaveTextContent('hello')
-    expect(value).toHaveAttribute('title', 'hello')
-  })
+      const defaultLine = screen.getByTestId('var-item-default')
+      const nameEl = screen.getByText('query')
 
-  it('renders no default indicator when a field has no default', () => {
-    render(<VarItem readonly={false} payload={createPayload()} />)
+      // POSITION: the default sits on its own line directly beneath the name line
+      // (its previous sibling in the identity column), left-aligned under the name.
+      expect(defaultLine.previousElementSibling).toContainElement(nameEl)
 
-    expect(screen.queryByTestId('var-item-default-value')).toBeNull()
-  })
+      // It shares the identity column with the name...
+      const identityColumn = defaultLine.parentElement!
+      expect(identityColumn).toContainElement(nameEl)
 
-  it('truncates a long default while keeping the full value in the tooltip', () => {
-    const longDefault = 'x'.repeat(200)
-    render(<VarItem readonly={false} payload={createPayload({ default: longDefault })} />)
+      // ...and is NOT in the right-hand metadata zone where `required` lives.
+      const requiredEl = screen.getByText('workflow.nodes.start.required')
+      expect(identityColumn).not.toContainElement(requiredEl)
+    })
 
-    const value = screen.getByTestId('var-item-default-value')
-    // Full value is preserved for the hover tooltip...
-    expect(value).toHaveAttribute('title', longDefault)
-    // ...while the visible text is clipped via the truncate utility, keeping row height fixed.
-    expect(value).toHaveClass('truncate')
+    it('shows nothing when no default is set', () => {
+      render(<VarItem readonly={false} payload={createPayload()} />)
+      expect(screen.queryByTestId('var-item-default')).toBeNull()
+    })
+
+    it('treats an empty-string default as unset (shows nothing)', () => {
+      render(<VarItem readonly={false} payload={createPayload({ default: '' })} />)
+      expect(screen.queryByTestId('var-item-default')).toBeNull()
+    })
+
+    it.each([
+      { label: 'false', value: false as const, text: 'false' },
+      { label: '0', value: 0 as const, text: '0' },
+    ])('still shows a falsy-but-set default ($label)', ({ value, text }) => {
+      render(<VarItem readonly={false} payload={createPayload({ default: value })} />)
+      expect(screen.getByTestId('var-item-default-value')).toHaveTextContent(text)
+    })
+
+    it('shows the FULL value in a tooltip on hover and does not disappear', async () => {
+      const user = userEvent.setup()
+      const longDefault = `sentinel-${'x'.repeat(200)}`
+      // delay={0} mirrors the app's global TooltipProvider (delay 300ms in prod) but
+      // opens instantly so the test is deterministic.
+      render(
+        <TooltipProvider delay={0}>
+          <VarItem readonly={false} payload={createPayload({ default: longDefault })} />
+        </TooltipProvider>,
+      )
+
+      const trigger = screen.getByTestId('var-item-default-value')
+      // Only the truncated trigger carries the value before hover.
+      expect(screen.getAllByText(longDefault)).toHaveLength(1)
+
+      await user.hover(trigger)
+
+      // Hovering flips the row's hover state (which swaps the right-hand metadata zone
+      // for the edit/remove buttons) — the default line lives OUTSIDE that zone, so the
+      // tooltip trigger stays mounted and the portal tooltip shows the FULL value.
+      const tooltip = await screen.findByText(longDefault, {
+        selector: '[data-base-ui-portal] *',
+      })
+      expect(tooltip).toBeInTheDocument()
+      // Trigger is still present (did not unmount on hover).
+      expect(screen.getByTestId('var-item-default-value')).toBeInTheDocument()
+    })
   })
 })

--- a/web/app/components/workflow/nodes/start/components/__tests__/var-item.spec.tsx
+++ b/web/app/components/workflow/nodes/start/components/__tests__/var-item.spec.tsx
@@ -32,4 +32,29 @@ describe('StartVarItem', () => {
     fireEvent.click(screen.getByRole('button', { name: 'common.operation.remove' }))
     expect(handleRemove).toHaveBeenCalledTimes(1)
   })
+
+  it('renders the default value indicator when a field has a default', () => {
+    render(<VarItem readonly={false} payload={createPayload({ default: 'hello' })} />)
+
+    const value = screen.getByTestId('var-item-default-value')
+    expect(value).toHaveTextContent('hello')
+    expect(value).toHaveAttribute('title', 'hello')
+  })
+
+  it('renders no default indicator when a field has no default', () => {
+    render(<VarItem readonly={false} payload={createPayload()} />)
+
+    expect(screen.queryByTestId('var-item-default-value')).toBeNull()
+  })
+
+  it('truncates a long default while keeping the full value in the tooltip', () => {
+    const longDefault = 'x'.repeat(200)
+    render(<VarItem readonly={false} payload={createPayload({ default: longDefault })} />)
+
+    const value = screen.getByTestId('var-item-default-value')
+    // Full value is preserved for the hover tooltip...
+    expect(value).toHaveAttribute('title', longDefault)
+    // ...while the visible text is clipped via the truncate utility, keeping row height fixed.
+    expect(value).toHaveClass('truncate')
+  })
 })

--- a/web/app/components/workflow/nodes/start/components/var-item.tsx
+++ b/web/app/components/workflow/nodes/start/components/var-item.tsx
@@ -52,6 +52,13 @@ const VarItem: FC<Props> = ({
     },
     [onChange, hideEditVarModal],
   )
+
+  // A default value can legitimately be `false` or `0`, so guard on nullish/empty
+  // rather than falsiness. Rows without a default render nothing extra.
+  const hasDefault =
+    payload.default !== undefined && payload.default !== null && payload.default !== ''
+  const defaultText = hasDefault ? String(payload.default) : ''
+
   return (
     <div
       ref={ref}
@@ -93,6 +100,20 @@ const VarItem: FC<Props> = ({
           <>
             {!isHovering || readonly ? (
               <>
+                {hasDefault && (
+                  <div className="mr-2 flex items-center text-xs font-normal text-text-tertiary">
+                    <span className="shrink-0">
+                      {t(($) => $['nodes.start.defaultValue'], { ns: 'workflow' })}:
+                    </span>
+                    <span
+                      title={defaultText}
+                      data-testid="var-item-default-value"
+                      className="ml-1 max-w-[120px] truncate"
+                    >
+                      {defaultText}
+                    </span>
+                  </div>
+                )}
                 {payload.required && (
                   <div className="mr-2 text-xs font-normal text-text-tertiary">
                     {t(($) => $['nodes.start.required'], { ns: 'workflow' })}

--- a/web/app/components/workflow/nodes/start/components/var-item.tsx
+++ b/web/app/components/workflow/nodes/start/components/var-item.tsx
@@ -2,6 +2,7 @@
 import type { FC } from 'react'
 import type { InputVar, MoreInfo } from '@/app/components/workflow/types'
 import { cn } from '@langgenius/dify-ui/cn'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/tooltip'
 import { RiDeleteBinLine } from '@remixicon/react'
 import { useBoolean, useHover } from 'ahooks'
 import { noop } from 'es-toolkit/function'
@@ -63,57 +64,71 @@ const VarItem: FC<Props> = ({
     <div
       ref={ref}
       className={cn(
-        'flex h-8 cursor-pointer items-center justify-between rounded-lg border border-components-panel-border-subtle bg-components-panel-on-panel-item-bg px-2.5 shadow-xs hover:shadow-md',
+        'flex min-h-8 cursor-pointer items-start justify-between rounded-lg border border-components-panel-border-subtle bg-components-panel-on-panel-item-bg px-2.5 py-1 shadow-xs hover:shadow-md',
         className,
       )}
     >
-      <div className="flex w-0 grow items-center space-x-1">
-        <Variable02
-          className={cn('size-3.5 text-text-accent', canDrag && 'group-hover:opacity-0')}
-        />
-        <div
-          title={payload.variable}
-          className="max-w-[130px] shrink-0 truncate text-[13px] font-medium text-text-secondary"
-        >
-          {payload.variable}
-        </div>
-        {payload.label && (
-          <>
-            <div className="shrink-0 text-xs font-medium text-text-quaternary">·</div>
-            <div
-              title={payload.label as string}
-              className="max-w-[130px] truncate text-[13px] font-medium text-text-tertiary"
-            >
-              {payload.label as string}
-            </div>
-          </>
-        )}
-        {showLegacyBadge && (
-          <Badge
-            text="LEGACY"
-            className="shrink-0 border-text-accent-secondary text-text-accent-secondary"
+      <div className="flex w-0 grow flex-col gap-0.5">
+        {/* Identity line: variable name · label */}
+        <div className="flex h-6 min-w-0 items-center space-x-1">
+          <Variable02
+            className={cn('size-3.5 text-text-accent', canDrag && 'group-hover:opacity-0')}
           />
+          <div
+            title={payload.variable}
+            className="max-w-[130px] shrink-0 truncate text-[13px] font-medium text-text-secondary"
+          >
+            {payload.variable}
+          </div>
+          {payload.label && (
+            <>
+              <div className="shrink-0 text-xs font-medium text-text-quaternary">·</div>
+              <div
+                title={payload.label as string}
+                className="max-w-[130px] truncate text-[13px] font-medium text-text-tertiary"
+              >
+                {payload.label as string}
+              </div>
+            </>
+          )}
+          {showLegacyBadge && (
+            <Badge
+              text="LEGACY"
+              className="shrink-0 border-text-accent-secondary text-text-accent-secondary"
+            />
+          )}
+        </div>
+
+        {/* Default-value indicator: its own line beneath the name, left-aligned. The full
+            value is shown via the house Tooltip (portal-based) so it survives the row
+            re-render that hover triggers — a native `title` here disappears on hover. */}
+        {hasDefault && (
+          <div
+            data-testid="var-item-default"
+            className="flex min-w-0 items-center pl-[18px] text-xs font-normal text-text-tertiary"
+          >
+            <span className="shrink-0">
+              {t(($) => $['nodes.start.defaultValue'], { ns: 'workflow' })}:
+            </span>
+            <Tooltip>
+              <TooltipTrigger
+                data-testid="var-item-default-value"
+                render={<span />}
+                className="ml-1 min-w-0 cursor-default truncate"
+              >
+                {defaultText}
+              </TooltipTrigger>
+              <TooltipContent>{defaultText}</TooltipContent>
+            </Tooltip>
+          </div>
         )}
       </div>
-      <div className="ml-2 flex shrink-0 items-center">
+
+      <div className="ml-2 flex h-6 shrink-0 items-center">
         {rightContent || (
           <>
             {!isHovering || readonly ? (
               <>
-                {hasDefault && (
-                  <div className="mr-2 flex items-center text-xs font-normal text-text-tertiary">
-                    <span className="shrink-0">
-                      {t(($) => $['nodes.start.defaultValue'], { ns: 'workflow' })}:
-                    </span>
-                    <span
-                      title={defaultText}
-                      data-testid="var-item-default-value"
-                      className="ml-1 max-w-[120px] truncate"
-                    >
-                      {defaultText}
-                    </span>
-                  </div>
-                )}
                 {payload.required && (
                   <div className="mr-2 text-xs font-normal text-text-tertiary">
                     {t(($) => $['nodes.start.required'], { ns: 'workflow' })}

--- a/web/i18n/ar-TN/workflow.json
+++ b/web/i18n/ar-TN/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "اسم الموضوع",
   "nodes.questionClassifiers.topicPlaceholder": "اكتب اسم الموضوع الخاص بك",
   "nodes.start.builtInVar": "المتغيرات المدمجة",
+  "nodes.start.defaultValue": "افتراضي",
   "nodes.start.inputField": "حقل الإدخال",
   "nodes.start.noVarTip": "تعيين المدخلات التي يمكن استخدامها في سير العمل",
   "nodes.start.outputVars.files": "قائمة الملفات",

--- a/web/i18n/de-DE/workflow.json
+++ b/web/i18n/de-DE/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Themenname",
   "nodes.questionClassifiers.topicPlaceholder": "Geben Sie Ihren Themennamen ein",
   "nodes.start.builtInVar": "Eingebaute Variablen",
+  "nodes.start.defaultValue": "Standard",
   "nodes.start.inputField": "Eingabefeld",
   "nodes.start.noVarTip": "Legen Sie Eingaben fest, die im Workflow verwendet werden können",
   "nodes.start.outputVars.files": "Dateiliste",

--- a/web/i18n/en-US/workflow.json
+++ b/web/i18n/en-US/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Topic Name",
   "nodes.questionClassifiers.topicPlaceholder": "Write your topic name",
   "nodes.start.builtInVar": "Built-in Variables",
+  "nodes.start.defaultValue": "default",
   "nodes.start.inputField": "Input Field",
   "nodes.start.noVarTip": "Set inputs that can be used in the Workflow",
   "nodes.start.outputVars.files": "File list",

--- a/web/i18n/es-ES/workflow.json
+++ b/web/i18n/es-ES/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Nombre del tema",
   "nodes.questionClassifiers.topicPlaceholder": "Escribe el nombre de tu tema",
   "nodes.start.builtInVar": "Variables incorporadas",
+  "nodes.start.defaultValue": "predeterminado",
   "nodes.start.inputField": "Campo de entrada",
   "nodes.start.noVarTip": "Establece las entradas que se pueden utilizar en el flujo de trabajo",
   "nodes.start.outputVars.files": "Lista de archivos",

--- a/web/i18n/fa-IR/workflow.json
+++ b/web/i18n/fa-IR/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "نام موضوع",
   "nodes.questionClassifiers.topicPlaceholder": "نام موضوع را بنویسید",
   "nodes.start.builtInVar": "متغیرهای داخلی",
+  "nodes.start.defaultValue": "پیش‌فرض",
   "nodes.start.inputField": "فیلد ورودی",
   "nodes.start.noVarTip": "ورودی‌هایی که در گردش کار استفاده می‌شوند را تعریف کنید",
   "nodes.start.outputVars.files": "لیست فایل‌ها",

--- a/web/i18n/fr-FR/workflow.json
+++ b/web/i18n/fr-FR/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Nom du sujet",
   "nodes.questionClassifiers.topicPlaceholder": "Écrivez le nom de votre sujet",
   "nodes.start.builtInVar": "Variables intégrées",
+  "nodes.start.defaultValue": "par défaut",
   "nodes.start.inputField": "Champ de saisie",
   "nodes.start.noVarTip": "Définir les entrées qui peuvent être utilisées dans le flux de travail",
   "nodes.start.outputVars.files": "Liste de fichiers",

--- a/web/i18n/hi-IN/workflow.json
+++ b/web/i18n/hi-IN/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "विषय नाम",
   "nodes.questionClassifiers.topicPlaceholder": "अपना विषय नाम लिखें",
   "nodes.start.builtInVar": "निर्मित वेरिएबल्स",
+  "nodes.start.defaultValue": "डिफ़ॉल्ट",
   "nodes.start.inputField": "इनपुट फील्ड",
   "nodes.start.noVarTip": "वर्कफ्लो में उपयोग के लिए इनपुट्स सेट करें",
   "nodes.start.outputVars.files": "फ़ाइल सूची",

--- a/web/i18n/id-ID/workflow.json
+++ b/web/i18n/id-ID/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Nama Topik",
   "nodes.questionClassifiers.topicPlaceholder": "Tulis nama topik Anda",
   "nodes.start.builtInVar": "Variabel bawaan",
+  "nodes.start.defaultValue": "bawaan",
   "nodes.start.inputField": "Bidang Masukan",
   "nodes.start.noVarTip": "Atur input yang dapat digunakan dalam Alur Kerja",
   "nodes.start.outputVars.files": "Daftar file",

--- a/web/i18n/it-IT/workflow.json
+++ b/web/i18n/it-IT/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Nome Argomento",
   "nodes.questionClassifiers.topicPlaceholder": "Scrivi il nome del tuo argomento",
   "nodes.start.builtInVar": "Variabili Integrate",
+  "nodes.start.defaultValue": "predefinito",
   "nodes.start.inputField": "Campo di Input",
   "nodes.start.noVarTip": "Imposta gli input che possono essere utilizzati nel Flusso di lavoro",
   "nodes.start.outputVars.files": "Elenco file",

--- a/web/i18n/ja-JP/workflow.json
+++ b/web/i18n/ja-JP/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "トピック名",
   "nodes.questionClassifiers.topicPlaceholder": "トピック名を入力してください",
   "nodes.start.builtInVar": "組み込み変数",
+  "nodes.start.defaultValue": "デフォルト",
   "nodes.start.inputField": "入力フィールド",
   "nodes.start.noVarTip": "入力設定はワークフロー内で利用可能",
   "nodes.start.outputVars.files": "ファイル一覧",

--- a/web/i18n/ko-KR/workflow.json
+++ b/web/i18n/ko-KR/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "주제 이름",
   "nodes.questionClassifiers.topicPlaceholder": "주제 이름을 작성하세요",
   "nodes.start.builtInVar": "내장 변수",
+  "nodes.start.defaultValue": "기본값",
   "nodes.start.inputField": "입력 필드",
   "nodes.start.noVarTip": "워크플로우에서 사용할 입력을 설정하세요",
   "nodes.start.outputVars.files": "파일 목록",

--- a/web/i18n/nl-NL/workflow.json
+++ b/web/i18n/nl-NL/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Topic Name",
   "nodes.questionClassifiers.topicPlaceholder": "Write your topic name",
   "nodes.start.builtInVar": "Built-in Variables",
+  "nodes.start.defaultValue": "standaard",
   "nodes.start.inputField": "Input Field",
   "nodes.start.noVarTip": "Set inputs that can be used in the Workflow",
   "nodes.start.outputVars.files": "File list",

--- a/web/i18n/pl-PL/workflow.json
+++ b/web/i18n/pl-PL/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Nazwa tematu",
   "nodes.questionClassifiers.topicPlaceholder": "Napisz nazwę swojego tematu",
   "nodes.start.builtInVar": "Wbudowane zmienne",
+  "nodes.start.defaultValue": "domyślny",
   "nodes.start.inputField": "Pole wejściowe",
   "nodes.start.noVarTip": "Ustaw wejścia, które mogą być używane w przepływie pracy",
   "nodes.start.outputVars.files": "Lista plików",

--- a/web/i18n/pt-BR/workflow.json
+++ b/web/i18n/pt-BR/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Nome do tópico",
   "nodes.questionClassifiers.topicPlaceholder": "Escreva o nome do seu tópico",
   "nodes.start.builtInVar": "Variáveis integradas",
+  "nodes.start.defaultValue": "padrão",
   "nodes.start.inputField": "Campo de entrada",
   "nodes.start.noVarTip": "Defina as entradas que podem ser usadas no Fluxo de Trabalho",
   "nodes.start.outputVars.files": "Lista de arquivos",

--- a/web/i18n/ro-RO/workflow.json
+++ b/web/i18n/ro-RO/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Nume subiect",
   "nodes.questionClassifiers.topicPlaceholder": "Scrieți numele subiectului",
   "nodes.start.builtInVar": "Variabile integrate",
+  "nodes.start.defaultValue": "implicit",
   "nodes.start.inputField": "Câmp de intrare",
   "nodes.start.noVarTip": "Setați intrările care pot fi utilizate în fluxul de lucru",
   "nodes.start.outputVars.files": "Listă de fișiere",

--- a/web/i18n/ru-RU/workflow.json
+++ b/web/i18n/ru-RU/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Название темы",
   "nodes.questionClassifiers.topicPlaceholder": "Введите название вашей темы",
   "nodes.start.builtInVar": "Встроенные переменные",
+  "nodes.start.defaultValue": "по умолчанию",
   "nodes.start.inputField": "Поле ввода",
   "nodes.start.noVarTip": "Установите входные данные, которые можно использовать в рабочем процессе",
   "nodes.start.outputVars.files": "Список файлов",

--- a/web/i18n/sl-SI/workflow.json
+++ b/web/i18n/sl-SI/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Ime teme",
   "nodes.questionClassifiers.topicPlaceholder": "Napišite ime svoje teme",
   "nodes.start.builtInVar": "Vgrajene spremenljivke",
+  "nodes.start.defaultValue": "privzeto",
   "nodes.start.inputField": "Vnosno polje",
   "nodes.start.noVarTip": "Nastavite vhodne podatke, ki jih lahko uporabite v delovnem toku.",
   "nodes.start.outputVars.files": "Seznam datotek",

--- a/web/i18n/th-TH/workflow.json
+++ b/web/i18n/th-TH/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "ชื่อหัวข้อ",
   "nodes.questionClassifiers.topicPlaceholder": "เขียนชื่อหัวข้อของคุณ",
   "nodes.start.builtInVar": "ตัวแปรในตัว",
+  "nodes.start.defaultValue": "ค่าเริ่มต้น",
   "nodes.start.inputField": "ฟิลด์อินพุต",
   "nodes.start.noVarTip": "ตั้งค่าอินพุตที่สามารถใช้ในเวิร์กโฟลว์",
   "nodes.start.outputVars.files": "รายการไฟล์",

--- a/web/i18n/tr-TR/workflow.json
+++ b/web/i18n/tr-TR/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Konu Adı",
   "nodes.questionClassifiers.topicPlaceholder": "Konu adınızı yazın",
   "nodes.start.builtInVar": "Yerleşik Değişkenler",
+  "nodes.start.defaultValue": "varsayılan",
   "nodes.start.inputField": "Giriş Alanı",
   "nodes.start.noVarTip": "İş Akışında kullanılabilecek girişleri ayarlayın",
   "nodes.start.outputVars.files": "Dosya listesi",

--- a/web/i18n/uk-UA/workflow.json
+++ b/web/i18n/uk-UA/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Назва теми",
   "nodes.questionClassifiers.topicPlaceholder": "Напишіть назву вашої теми",
   "nodes.start.builtInVar": "Вбудовані змінні",
+  "nodes.start.defaultValue": "за замовчуванням",
   "nodes.start.inputField": "Поле введення",
   "nodes.start.noVarTip": "Встановіть вхідні дані, які можуть бути використані у робочому потоці",
   "nodes.start.outputVars.files": "Список файлів",

--- a/web/i18n/vi-VN/workflow.json
+++ b/web/i18n/vi-VN/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Tên chủ đề",
   "nodes.questionClassifiers.topicPlaceholder": "Viết tên chủ đề của bạn",
   "nodes.start.builtInVar": "Biến tích hợp sẵn",
+  "nodes.start.defaultValue": "mặc định",
   "nodes.start.inputField": "Trường đầu vào",
   "nodes.start.noVarTip": "Đặt các đầu vào có thể sử dụng trong Quy trình làm việc",
   "nodes.start.outputVars.files": "Danh sách tệp",

--- a/web/i18n/zh-Hans/workflow.json
+++ b/web/i18n/zh-Hans/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "主题内容",
   "nodes.questionClassifiers.topicPlaceholder": "在这里输入你的主题内容",
   "nodes.start.builtInVar": "内置变量",
+  "nodes.start.defaultValue": "默认",
   "nodes.start.inputField": "输入字段",
   "nodes.start.noVarTip": "设置的输入可在工作流程中使用",
   "nodes.start.outputVars.files": "文件列表",

--- a/web/i18n/zh-Hant/workflow.json
+++ b/web/i18n/zh-Hant/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "主題內容",
   "nodes.questionClassifiers.topicPlaceholder": "在這裡輸入你的主題內容",
   "nodes.start.builtInVar": "內置變數",
+  "nodes.start.defaultValue": "預設",
   "nodes.start.inputField": "輸入字段",
   "nodes.start.noVarTip": "設置的輸入可在工作流程中使用",
   "nodes.start.outputVars.files": "文件列表",


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #39563.

In the User Input (Start) node field list, a field's default value is now shown beneath the field name when one is set, so you can see at a glance which fields will fall back to a default at run time instead of opening each field's edit panel one at a time. This is a display-only change — defaults already apply correctly at run time; this just surfaces an existing property in the list.

Two problems with a first pass at this (found by browser-testing, not visible in unit tests) motivated the final shape:

1. **Layout** — the indicator first rendered inline in the row's right-hand metadata zone next to `required`. It now sits on its own line beneath the `{icon} name · label` identity line, left-aligned, in the row's persistent left column. `required` stays top-right. Single-line rows with no default keep their original height and don't shift on hover.

2. **Tooltip** — the value is truncated when long, with the full value on hover. The first pass used the native `title` attribute, which disappeared on hover: the metadata zone only renders while the row is *not* hovered, so hovering to read the tooltip flipped the row's hover state and unmounted the indicator. Moving the indicator into the persistent column fixes the unmount, and the tooltip now uses the house `@langgenius/dify-ui/tooltip` (portal-based), which survives the row re-render.

The nullish/empty guard is unchanged: `false` and `0` are shown; an unset or empty-string default shows nothing.

Tests assert **position** (beneath the name, not in the `required` zone) and **tooltip content** (full value on hover, trigger stays mounted) — not just presence, since presence-only tests missed both problems above.

`From Claude Code`

## Screenshots

**Before**
<img width="791" height="375" alt="2026-07-24_22-09-40" src="https://github.com/user-attachments/assets/073bd5fb-1860-4115-a050-9f4998b9dff8" />

**After**
<img width="824" height="444" alt="2026-07-24_22-11-36" src="https://github.com/user-attachments/assets/6ff73e5c-2570-4fc9-8eaf-9a0e912b0ab0" />

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods