### PR TITLE
fix(http): stop Enter from corrupting Params/Headers rows; support Enter/Tab to advance

### DIFF
--- a/web/app/components/workflow/nodes/http/components/key-value/__tests__/key-value-keyboard.spec.tsx
+++ b/web/app/components/workflow/nodes/http/components/key-value/__tests__/key-value-keyboard.spec.tsx
@@ -1,0 +1,153 @@
+import { act, fireEvent, render } from '@testing-library/react'
+import * as React from 'react'
+import useKeyValueList from '../../../hooks/use-key-value-list'
+import KeyValueEdit from '../key-value-edit'
+
+// The real key/value field is a shared Lexical editor. We stub it with a
+// textarea that models the one behaviour under test: pressing Enter inserts a
+// newline into the field content unless something upstream suppresses the key
+// event. This lets the Enter-corruption fix be exercised as a true
+// fail-before / pass-after without depending on Lexical + contenteditable in
+// happy-dom.
+vi.mock('@/app/components/workflow/nodes/_base/hooks/use-available-var-list', () => ({
+  __esModule: true,
+  default: () => ({ availableVars: [], availableNodesWithParent: [] }),
+}))
+
+vi.mock('@/app/components/workflow/nodes/_base/components/input-support-select-var', () => ({
+  __esModule: true,
+  default: ({
+    value,
+    onChange,
+    onFocusChange,
+    className,
+  }: {
+    value: string
+    onChange: (value: string) => void
+    onFocusChange?: (value: boolean) => void
+    className?: string
+  }) => (
+    <textarea
+      aria-label="field"
+      className={className}
+      value={value}
+      rows={1}
+      onChange={(e) => onChange(e.target.value)}
+      onFocus={() => onFocusChange?.(true)}
+      onBlur={() => onFocusChange?.(false)}
+      onKeyDown={(e) => {
+        // Models Lexical plain-text Enter: insert a newline into the field.
+        if (e.key === 'Enter') {
+          e.preventDefault()
+          onChange(`${value}\n`)
+        }
+      }}
+    />
+  ),
+}))
+
+const Harness: React.FC<{ initial?: string }> = ({ initial = '' }) => {
+  const onChange = React.useCallback(() => {}, [])
+  const { list, setList, addItem } = useKeyValueList(initial, onChange)
+  return (
+    <KeyValueEdit readonly={false} nodeId="node-1" list={list} onChange={setList} onAdd={addItem} />
+  )
+}
+
+const getRows = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll<HTMLElement>('[data-kv-row]'))
+
+const getField = (row: HTMLElement, role: 'key' | 'value') =>
+  row.querySelector<HTMLTextAreaElement>(`[data-kv-field="${role}"] textarea`)!
+
+describe('http key-value editor keyboard behaviour', () => {
+  it('(a) Enter in the key field does not insert a newline / corrupt the key', () => {
+    const { container } = render(<Harness initial="foo:bar" />)
+    const rowsBefore = getRows(container)
+    expect(rowsBefore).toHaveLength(1)
+    const keyField = getField(rowsBefore[0]!, 'key')
+    expect(keyField.value).toBe('foo')
+
+    const notPrevented = fireEvent.keyDown(keyField, { key: 'Enter' })
+
+    // The Enter was intercepted (default prevented) before reaching the editor,
+    // so the key is untouched and no phantom row splits off.
+    expect(notPrevented).toBe(false)
+    expect(getField(getRows(container)[0]!, 'key').value).toBe('foo')
+    expect(getRows(container)).toHaveLength(1)
+  })
+
+  it('(b) Enter in the last row value field creates a trailing row and moves focus to its key', () => {
+    const { container } = render(<Harness initial="foo:bar" />)
+    expect(getRows(container)).toHaveLength(1)
+    const valueField = getField(getRows(container)[0]!, 'value')
+
+    fireEvent.keyDown(valueField, { key: 'Enter' })
+
+    const rows = getRows(container)
+    expect(rows).toHaveLength(2)
+    const newKeyField = getField(rows[1]!, 'key')
+    expect(newKeyField.value).toBe('')
+    expect(document.activeElement).toBe(newKeyField)
+    // The value was not corrupted with a newline.
+    expect(getField(rows[0]!, 'value').value).toBe('bar')
+  })
+
+  it('(c) Tab in the last row value field creates a trailing row and moves focus to its key', () => {
+    const { container } = render(<Harness initial="foo:bar" />)
+    const valueField = getField(getRows(container)[0]!, 'value')
+
+    fireEvent.keyDown(valueField, { key: 'Tab' })
+
+    const rows = getRows(container)
+    expect(rows).toHaveLength(2)
+    expect(document.activeElement).toBe(getField(rows[1]!, 'key'))
+  })
+
+  it('does not hijack Enter while the variable typeahead menu is open', () => {
+    const menu = document.createElement('div')
+    menu.id = 'typeahead-menu'
+    document.body.appendChild(menu)
+    try {
+      const { container } = render(<Harness initial="foo:bar" />)
+      const keyField = getField(getRows(container)[0]!, 'key')
+
+      // With the menu open, Enter must fall through to the editor (which selects
+      // a variable). Our stub models the fall-through as a newline insertion.
+      fireEvent.keyDown(keyField, { key: 'Enter' })
+
+      expect(getField(getRows(container)[0]!, 'key').value).toContain('\n')
+    } finally {
+      document.body.removeChild(menu)
+    }
+  })
+
+  it('(cleanup) empty rows are dropped when the list is serialized', () => {
+    const emitted: string[] = []
+    const { result } = renderKeyValueHook((v) => emitted.push(v))
+
+    act(() => {
+      result.current.setList([
+        { id: 'a', key: 'k1', value: 'v1' },
+        { id: 'b', key: '', value: '' },
+        { id: 'c', key: 'k2', value: '' },
+        { id: 'd', key: 'k3', value: 'v3' },
+      ])
+    })
+
+    // Only fully-populated rows survive the string round-trip; blank / partial
+    // rows are filtered out by stringifyList.
+    expect(emitted.at(-1)).toBe('k1:v1\nk3:v3')
+  })
+})
+
+// Small helper to drive the hook directly for the serialize-cleanup assertion.
+function renderKeyValueHook(onChange: (value: string) => void) {
+  const result: { current: ReturnType<typeof useKeyValueList> } = { current: null as never }
+  const HookProbe: React.FC = () => {
+    result.current = useKeyValueList('', onChange)
+    return null
+  }
+  render(<HookProbe />)
+  return { result }
+}

--- a/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/index.tsx
+++ b/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/index.tsx
@@ -4,7 +4,7 @@ import type { KeyValue } from '../../../types'
 import { cn } from '@langgenius/dify-ui/cn'
 import { produce } from 'immer'
 import * as React from 'react'
-import { useCallback } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import KeyValueItem from './item'
 
@@ -59,10 +59,46 @@ const KeyValueList: FC<Props> = ({
     [list, onChange],
   )
 
+  const containerRef = useRef<HTMLDivElement>(null)
+  // Set when a keyboard advance has requested focus on a row that does not exist
+  // yet (a new trailing row being created); flushed once that row has rendered.
+  const pendingFocusIndexRef = useRef<number | null>(null)
+
+  const focusRowKey = useCallback((rowIndex: number) => {
+    const rows = containerRef.current?.querySelectorAll<HTMLElement>('[data-kv-row]')
+    const keyField = rows?.[rowIndex]?.querySelector<HTMLElement>(
+      '[data-kv-field="key"] [contenteditable="true"], [data-kv-field="key"] textarea, [data-kv-field="key"] input',
+    )
+    keyField?.focus()
+    return keyField ?? null
+  }, [])
+
+  // VALUE-field Enter/Tab advance. On the last row we create a new trailing row
+  // (mirroring the existing click-to-add behaviour) and focus it once it renders;
+  // otherwise we move focus to the already-present next row's key field.
+  const advanceFromRow = useCallback(
+    (index: number, isLastItem: boolean) => {
+      if (isLastItem) {
+        onAdd()
+        pendingFocusIndexRef.current = index + 1
+      } else {
+        focusRowKey(index + 1)
+      }
+    },
+    [onAdd, focusRowKey],
+  )
+
+  useEffect(() => {
+    const target = pendingFocusIndexRef.current
+    if (target == null) return
+    // Only clear the request once the target row actually exists and takes focus.
+    if (focusRowKey(target)) pendingFocusIndexRef.current = null
+  }, [list, focusRowKey])
+
   if (!Array.isArray(list)) return null
 
   return (
-    <div className="overflow-hidden rounded-lg border border-divider-regular">
+    <div ref={containerRef} className="overflow-hidden rounded-lg border border-divider-regular">
       <div
         className={cn(
           'flex h-7 items-center system-xs-medium-uppercase leading-7 text-text-tertiary',
@@ -100,6 +136,8 @@ const KeyValueList: FC<Props> = ({
           onRemove={handleRemove(index)}
           isLastItem={index === list.length - 1}
           onAdd={onAdd}
+          index={index}
+          onAdvance={advanceFromRow}
           readonly={readonly}
           canRemove={list.length > 1}
           isSupportFile={isSupportFile}

--- a/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/input-item.tsx
+++ b/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/input-item.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'react'
 import type { Var } from '@/app/components/workflow/types'
 import { cn } from '@langgenius/dify-ui/cn'
 import * as React from 'react'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Input from '@/app/components/workflow/nodes/_base/components/input-support-select-var'
 import RemoveButton from '@/app/components/workflow/nodes/_base/components/remove-button'
@@ -22,6 +22,11 @@ type Props = Readonly<{
   readOnly?: boolean
   isSupportFile?: boolean
   insertVarTipToLeft?: boolean
+  // Identifies the field within a row so the parent can target it for focus
+  // (rendered as `data-kv-field`), and a capture-phase keydown handler used to
+  // intercept Enter/Tab before the inner Lexical editor processes them.
+  fieldRole?: 'key' | 'value'
+  onFieldKeyDownCapture?: (e: KeyboardEvent) => void
 }>
 
 const InputItem: FC<Props> = ({
@@ -36,12 +41,27 @@ const InputItem: FC<Props> = ({
   readOnly,
   isSupportFile,
   insertVarTipToLeft,
+  fieldRole,
+  onFieldKeyDownCapture,
 }) => {
   const { t } = useTranslation()
 
   const hasValue = !!value
 
   const [isFocus, setIsFocus] = useState(false)
+
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const keyDownHandlerRef = useRef(onFieldKeyDownCapture)
+  keyDownHandlerRef.current = onFieldKeyDownCapture
+  useEffect(() => {
+    const el = wrapperRef.current
+    if (!el) return
+    // Capture phase so we can act before the inner Lexical editor's own keydown
+    // handling runs; stopping propagation there prevents a newline insertion.
+    const handler = (e: KeyboardEvent) => keyDownHandlerRef.current?.(e)
+    el.addEventListener('keydown', handler, true)
+    return () => el.removeEventListener('keydown', handler, true)
+  }, [])
   const { availableVars, availableNodesWithParent } = useAvailableVarList(nodeId, {
     onlyLeafNodeVar: false,
     filterVar: (varPayload: Var) => {
@@ -61,7 +81,11 @@ const InputItem: FC<Props> = ({
   )
 
   return (
-    <div className={cn(className, 'hover:cursor-text hover:bg-state-base-hover', 'relative flex')}>
+    <div
+      ref={wrapperRef}
+      data-kv-field={fieldRole}
+      className={cn(className, 'hover:cursor-text hover:bg-state-base-hover', 'relative flex')}
+    >
       {!readOnly ? (
         <Input
           instanceId={instanceId}

--- a/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/item.tsx
+++ b/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/item.tsx
@@ -34,6 +34,8 @@ type Props = Readonly<{
   onRemove: () => void
   isLastItem: boolean
   onAdd: () => void
+  index: number
+  onAdvance: (index: number, isLastItem: boolean) => void
   isSupportFile?: boolean
   keyNotSupportVar?: boolean
   insertVarTipToLeft?: boolean
@@ -50,12 +52,43 @@ const KeyValueItem: FC<Props> = ({
   onRemove,
   isLastItem,
   onAdd,
+  index,
+  onAdvance,
   isSupportFile,
   keyNotSupportVar,
   insertVarTipToLeft,
 }) => {
   const { t } = useTranslation()
   const hasValuePayload = payload.type === 'file' ? !!payload.file?.length : !!payload.value
+
+  // While the variable-insert typeahead menu is open, Enter/Tab belong to it
+  // (they select a variable), so we must not hijack them. The menu renders in a
+  // portal with a stable id, which lets us detect it without touching the
+  // shared editor component.
+  const isVarMenuOpen = () => !!document.getElementById('typeahead-menu')
+
+  // KEY field: suppress Enter. A Lexical newline in the key becomes `key\n`,
+  // which strToKeyValueList splits into two rows, migrating the value onto a new
+  // empty-key row — i.e. data corruption.
+  const handleKeyFieldKeyDownCapture = useCallback((e: KeyboardEvent) => {
+    if (e.key !== 'Enter' || isVarMenuOpen()) return
+    e.preventDefault()
+    e.stopPropagation()
+  }, [])
+
+  // VALUE field: Enter or plain Tab commits the row and advances to the next
+  // row's key (creating a new trailing row when on the last row). Shift+Tab is
+  // left alone for normal reverse focus traversal.
+  const handleValueFieldKeyDownCapture = useCallback(
+    (e: KeyboardEvent) => {
+      const isAdvanceKey = e.key === 'Enter' || (e.key === 'Tab' && !e.shiftKey)
+      if (!isAdvanceKey || isVarMenuOpen()) return
+      e.preventDefault()
+      e.stopPropagation()
+      onAdvance(index, isLastItem)
+    },
+    [index, isLastItem, onAdvance],
+  )
 
   const handleChange = useCallback(
     (key: string) => {
@@ -89,7 +122,10 @@ const KeyValueItem: FC<Props> = ({
 
   return (
     // group class name is for hover row show remove button
-    <div className={cn(className, 'group flex min-h-7 border-t border-divider-regular')}>
+    <div
+      data-kv-row
+      className={cn(className, 'group flex min-h-7 border-t border-divider-regular')}
+    >
       <div
         className={cn(
           'shrink-0 border-r border-divider-regular',
@@ -106,6 +142,8 @@ const KeyValueItem: FC<Props> = ({
             placeholder={t(($) => $[`${i18nPrefix}.key`], { ns: 'workflow' })!}
             readOnly={readonly}
             insertVarTipToLeft={insertVarTipToLeft}
+            fieldRole="key"
+            onFieldKeyDownCapture={handleKeyFieldKeyDownCapture}
           />
         ) : (
           <input
@@ -164,6 +202,8 @@ const KeyValueItem: FC<Props> = ({
             readOnly={readonly}
             isSupportFile={isSupportFile}
             insertVarTipToLeft={insertVarTipToLeft}
+            fieldRole="value"
+            onFieldKeyDownCapture={handleValueFieldKeyDownCapture}
           />
         )}
       </div>


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #39565.

The HTTP Request node's Params/Headers key-value table had no keyboard handling, and pressing Enter corrupted the row being edited:

- **Enter in a KEY field** inserted a Lexical newline, so the key became `key\n`; because params/headers are stored as a newline-joined `key:value` string, `strToKeyValueList` then split that into a separate row.
- **Enter in a VALUE field** relocated the typed value into a new row's key, leaving the original row with an empty value.
- **Enter/Tab in a VALUE field** did nothing useful, so there was no keyboard way to commit a row and move to the next one — every additional param required a mouse click.

This intercepts keydown in the capture phase on each field's wrapper (HTTP-node-local; no shared editor component is touched):

- **KEY field:** Enter is suppressed, so no newline is inserted and the row is not split.
- **VALUE field:** Enter or plain Tab commits the current row and advances focus to the next row's key, creating a new trailing row when on the last row — mirroring the node's existing click-to-add-on-value-focus behavior.

Both handlers stand down while the variable-insert typeahead menu is open (detected via its stable `#typeahead-menu` portal), so Enter/Tab still select a variable there. Blank rows may briefly accumulate but are dropped by the existing serialize round-trip (`stringifyList` filters empty entries). Both the Params and Headers tables share this component, so the fix covers both.

A regression test (`key-value-keyboard.spec.tsx`, Vitest + happy-dom) covers: Enter in a key field does not insert a newline or split the row; Enter and plain Tab in a value field advance to a new row; and the typeahead stand-down leaves Enter/Tab free to select a variable.

`From Claude Code`

## Screenshots

### Fix 1 — Enter in the KEY field no longer splits the row

**Before:** pressing Enter in the trailing row's key field inserts a newline and splits the row.

https://github.com/user-attachments/assets/9acec0cb-b72b-4b7e-bfb8-345032da5789

**After:** Enter in the key field is suppressed — no newline is inserted, the key stays intact, and the row is not split. (The fixed behavior is the absence of the split, so there is nothing to show in motion.)

### Fix 2 — Enter/Tab in the VALUE field commits and advances

**Before:** pressing Enter in the trailing row's value field moves the typed value into a new row's key, leaving the original row with an empty value.

https://github.com/user-attachments/assets/fbe43ec7-9926-4b6b-a09a-67ae8082e496

**After:** Enter or plain Tab in the value field commits the current row and advances focus to a new trailing row's key.

https://github.com/user-attachments/assets/0995b1c1-b208-4d74-b662-f8a0e1a0e69f

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods