### PR TITLE
fix(dify-ui): honor instant popup transitions

### DIFF
--- a/packages/dify-ui/src/overlay-shared.ts
+++ b/packages/dify-ui/src/overlay-shared.ts
@@ -11,7 +11,7 @@ export const floatingSeparatorClassName = 'my-1 h-px bg-divider-subtle'
 export const menuPopupClassName =
   'max-h-(--available-height) overflow-y-auto overflow-x-hidden rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur py-1 text-sm text-text-secondary shadow-lg outline-hidden focus:outline-hidden focus-visible:outline-hidden backdrop-blur-[5px]'
 export const floatingPopupAnimationClassName =
-  'origin-(--transform-origin) transition-[transform,scale,opacity] data-ending-style:scale-95 data-starting-style:scale-95 data-ending-style:opacity-0 data-starting-style:opacity-0 motion-reduce:transition-none'
+  'origin-(--transform-origin) transition-[transform,scale,opacity] data-ending-style:scale-95 data-starting-style:scale-95 data-ending-style:opacity-0 data-starting-style:opacity-0 data-instant:transition-none motion-reduce:transition-none'
 export const modalBackdropClassName =
   'absolute inset-0 z-50 bg-background-overlay transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 motion-reduce:transition-none'
 export const modalPopupAnimationClassName =

--- a/packages/dify-ui/src/popover/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/popover/__tests__/index.spec.tsx
@@ -1,4 +1,5 @@
 import type * as React from 'react'
+import { userEvent } from 'vite-plus/test/browser'
 import { render } from 'vitest-browser-react'
 import { Popover, PopoverContent, PopoverTrigger } from '..'
 
@@ -6,6 +7,43 @@ const renderWithSafeViewport = (ui: React.ReactNode) =>
   render(<div style={{ minHeight: '100vh', minWidth: '100vw', padding: '240px' }}>{ui}</div>)
 
 describe('PopoverContent', () => {
+  describe('Animation', () => {
+    it('should restore focus without waiting for an instant close transition', async () => {
+      const animationSettings = globalThis as typeof globalThis & {
+        BASE_UI_ANIMATIONS_DISABLED: boolean
+      }
+      const animationsDisabled = animationSettings.BASE_UI_ANIMATIONS_DISABLED
+      animationSettings.BASE_UI_ANIMATIONS_DISABLED = false
+
+      try {
+        const screen = await renderWithSafeViewport(
+          <Popover>
+            <PopoverTrigger>Open</PopoverTrigger>
+            <PopoverContent
+              popupClassName="duration-[30s]"
+              popupProps={{ role: 'dialog', 'aria-label': 'popover content' }}
+            >
+              <button type="button">Focusable content</button>
+            </PopoverContent>
+          </Popover>,
+        )
+
+        const trigger = screen.getByRole('button', { name: 'Open' })
+        await trigger.click()
+
+        const focusableContent = screen.getByRole('button', { name: 'Focusable content' })
+        focusableContent.element().focus()
+        await expect.element(focusableContent).toHaveFocus()
+
+        await userEvent.keyboard('{Escape}')
+
+        await expect.element(trigger).toHaveFocus()
+      } finally {
+        animationSettings.BASE_UI_ANIMATIONS_DISABLED = animationsDisabled
+      }
+    })
+  })
+
   describe('Placement', () => {
     it('should use bottom placement and default offsets when placement props are not provided', async () => {
       const screen = await renderWithSafeViewport(


### PR DESCRIPTION
## Summary

- honor Base UI's `data-instant` state in the shared floating popup animation
- skip exit transitions when Base UI requires an instant dismissal, preventing transient focus-visible feedback inside a closing popup
- add a Browser Mode regression test that verifies Escape restores focus without waiting for a long exit transition

## Root cause

Base UI marks dismissals such as Escape with `data-instant`, but the shared Dify UI floating popup animation did not consume that state. The popup therefore remained mounted for its exit transition while focus restoration was delayed, allowing the newly keyboard-driven `:focus-visible` state to appear on the focused popup element during closing.

## Impact

Normal animated open and close interactions are unchanged. Floating popup primitives that receive Base UI's `data-instant` state now dismiss immediately, keeping visual presence, interactivity, and focus restoration synchronized.

## Validation

- `pnpm --filter @langgenius/dify-ui test --run src/popover/__tests__/index.spec.tsx`
- full Dify UI unit suite: 216 tests passed
- Dify UI Storybook suite: 195 tests passed
- `pnpm --filter @langgenius/dify-ui type-check`
- `vp check packages/dify-ui/src/overlay-shared.ts packages/dify-ui/src/popover/__tests__/index.spec.tsx`
- regression test repeated 10 times without retries or failures