### PR TITLE
docs: Broken Grafana link in Turkish README (placeholder text instead of URL)

### DIFF
--- a/dify-agent-runtime/README.md
+++ b/dify-agent-runtime/README.md
@@ -41,7 +41,7 @@ docker build -f dify-agent-runtime/docker/Dockerfile \
   dify-agent-runtime/
 ```
 
-### Runing docker container
+### Running docker container
 
 ```
 docker run -d --name dify-agent-runtime \

--- a/docs/tr-TR/README.md
+++ b/docs/tr-TR/README.md
@@ -132,7 +132,7 @@ Yapılandırmayı özelleştirmeniz gerekiyorsa, lütfen [.env.example](../../do
 
 Uygulamalar, kiracılar, mesajlar ve daha fazlasının granularitesinde metrikleri izlemek için Dify'nin PostgreSQL veritabanını veri kaynağı olarak kullanarak panoyu Grafana'ya aktarın.
 
-- [@bowenliang123 tarafından Grafana Panosu](%E9%93%BE%E6%8E%A5)
+- [@bowenliang123 tarafından Grafana Panosu](https://github.com/bowenliang123/dify-grafana-dashboard)
 
 ### Kubernetes ile Dağıtım
 


### PR DESCRIPTION
In `docs/tr-TR/README.md`, the Grafana Dashboard link points to
leftover placeholder text ("链接", percent-encoded as %E9%93%BE%E6%8E%A5)
instead of a real URL.

README.md and docs/zh-CN/README.md both correctly link to:
https://github.com/bowenliang123/dify-grafana-dashboard

Happy to submit a one-line fix PR.