### PR TITLE
chore: Broken docker-compose.yaml link in Hindi README (missing slash)

### DIFF
--- a/dify-agent-runtime/README.md
+++ b/dify-agent-runtime/README.md
@@ -41,7 +41,7 @@ docker build -f dify-agent-runtime/docker/Dockerfile \
   dify-agent-runtime/
 ```
 
-### Runing docker container
+### Running docker container
 
 ```
 docker run -d --name dify-agent-runtime \

--- a/docs/hi-IN/README.md
+++ b/docs/hi-IN/README.md
@@ -75,7 +75,7 @@ Dify एक मुक्त-स्रोत प्लेटफ़ॉर्म �
 
 <br/>
 
-Dify सर्वर शुरू करने का सबसे आसान तरीका [Docker Compose](../..docker/docker-compose.yaml) के माध्यम से है। नीचे दिए गए कमांड्स से Dify चलाने से पहले, सुनिश्चित करें कि आपकी मशीन पर [Docker] (https://docs.docker.com/get-docker/) और [Docker Compose] (https://docs.docker.com/compose/install/) इंस्टॉल हैं।:
+Dify सर्वर शुरू करने का सबसे आसान तरीका [Docker Compose](../../docker/docker-compose.yaml) के माध्यम से है। नीचे दिए गए कमांड्स से Dify चलाने से पहले, सुनिश्चित करें कि आपकी मशीन पर [Docker] (https://docs.docker.com/get-docker/) और [Docker Compose] (https://docs.docker.com/compose/install/) इंस्टॉल हैं।:
 
 ```bash
 cd dify


### PR DESCRIPTION
In `docs/hi-IN/README.md`, the Docker Compose link is
`../..docker/docker-compose.yaml` — missing a "/" between the
relative-path segment and "docker", so the link is broken.

Should be `../../docker/docker-compose.yaml`, matching the pattern
already used correctly in docs/ja-JP, docs/ko-KR, and docs/de-DE
READMEs.

Happy to submit a one-line fix PR.