### PR TITLE
docs: fix broken anchor links in ar-SA and hi-IN READMEs

### DIFF
--- a/dify-agent-runtime/README.md
+++ b/dify-agent-runtime/README.md
@@ -41,7 +41,7 @@ docker build -f dify-agent-runtime/docker/Dockerfile \
   dify-agent-runtime/
 ```
 
-### Runing docker container
+### Running docker container
 
 ```
 docker run -d --name dify-agent-runtime \


### PR DESCRIPTION
docs/ar-SA/README.md: the quick-start-guide link used escaped
brackets (\[...\]), so it rendered as plain text instead of a link,
and its anchor didn't match the real heading. Unescaped it and
pointed it at the correct slug (#البداية-السريعة).

docs/hi-IN/README.md: the "community and us" link pointed at
#community--contact, but the real heading is bilingual
(## समुदाय और संपर्क (Community & contact)), so the real slug is
#समुदाय-और-संपर्क-community--contact.

Both slugs verified with github-slugger (the same library GitHub
uses to generate heading anchors).

Docs only, no functional changes.