### PR TITLE
fix(tts): sniff actual audio format for Content-Type instead of hardcoding audio/mpeg

### DIFF
--- a/api/core/helper/audio_format.py
+++ b/api/core/helper/audio_format.py
@@ -1,0 +1,71 @@
+"""Audio format helpers for sniffing the real MIME type of TTS streams.
+
+TTS providers return raw ``bytes`` chunks with no accompanying content-type,
+so the HTTP layer cannot know upfront whether the stream is MP3, WAV, OGG, etc.
+Some providers (e.g. Tongyi ``qwen-tts``) emit WAV/PCM even when the HTTP
+response was advertised as ``audio/mpeg``, which browsers refuse to play.
+
+``detect_audio_content_type`` peeks at the leading magic bytes of the first
+chunk and returns the matching MIME type, defaulting to ``audio/mpeg`` when the
+signature is unknown so that MP3-producing providers keep working unchanged.
+"""
+
+from collections.abc import Generator, Iterable
+
+# Minimum bytes needed to disambiguate the supported audio formats.
+_MIN_MAGIC_BYTES = 12
+
+
+def _sniff_content_type(first_chunk: bytes) -> str:
+    """Return the MIME type implied by *first_chunk*'s magic bytes.
+
+    Falls back to ``audio/mpeg`` when the signature is not recognised, matching
+    the historical behaviour for MP3-only providers.
+    """
+    if len(first_chunk) >= 4 and first_chunk[:4] == b"RIFF" and first_chunk[8:12] == b"WAVE":
+        return "audio/wav"
+    if len(first_chunk) >= 4 and first_chunk[:4] == b"OggS":
+        return "audio/ogg"
+    if len(first_chunk) >= 2 and first_chunk[0] == 0xFF and (first_chunk[1] & 0xE0) == 0xE0:
+        # MP3 frame sync (11 set bits).
+        return "audio/mpeg"
+    if len(first_chunk) >= 3 and first_chunk[:3] == b"ID3":
+        # MP3 with an in-band ID3 metadata header.
+        return "audio/mpeg"
+    return "audio/mpeg"
+
+
+def detect_audio_content_type(
+    audio_stream: Iterable[bytes],
+) -> tuple[Generator[bytes], str]:
+    """Detect the content type of an audio byte stream by peeking at its head.
+
+    Consumes only the first chunk (or accumulates up to ``_MIN_MAGIC_BYTES``
+    bytes across small chunks) so the rest of the stream can be yielded to the
+    caller without re-fetching from the provider.
+
+    Returns a generator that replays the sniffed bytes followed by the remainder
+    of *audio_stream*, plus the detected MIME content type.
+    """
+    iterator = iter(audio_stream)
+    buffered = bytearray()
+    content_type = "audio/mpeg"
+
+    for chunk in iterator:
+        if not chunk:
+            continue
+        buffered.extend(chunk)
+        if len(buffered) >= _MIN_MAGIC_BYTES:
+            content_type = _sniff_content_type(bytes(buffered))
+            break
+    else:
+        # Stream ended before we had enough bytes; sniff what we have.
+        if buffered:
+            content_type = _sniff_content_type(bytes(buffered))
+
+    def _replay() -> Generator[bytes]:
+        if buffered:
+            yield bytes(buffered)
+        yield from iterator
+
+    return _replay(), content_type

--- a/api/services/audio_service.py
+++ b/api/services/audio_service.py
@@ -11,6 +11,7 @@ from werkzeug.datastructures import FileStorage
 
 from constants import AUDIO_EXTENSIONS
 from core.app.apps.agent_app.app_feature_projection import merge_agent_app_features
+from core.helper.audio_format import detect_audio_content_type
 from core.model_manager import ModelManager
 from graphon.model_runtime.entities.model_entities import ModelType
 from models.agent_config_entities import AgentSoulConfig
@@ -223,16 +224,27 @@ class AudioService:
 
             else:
                 response = invoke_tts(text_content=message.answer, app_model=app_model, voice=voice, is_draft=is_draft)
-                if isinstance(response, Generator):
-                    return Response(stream_with_context(response), content_type="audio/mpeg")  # type: ignore
-                return response
+                return cls._build_tts_response(response)
         else:
             if text is None:
                 raise ValueError("Text is required")
             response = invoke_tts(text_content=text, app_model=app_model, voice=voice, is_draft=is_draft)
-            if isinstance(response, Generator):
-                return Response(stream_with_context(response), content_type="audio/mpeg")  # type: ignore
+            return cls._build_tts_response(response)
+
+    @staticmethod
+    def _build_tts_response(response: Generator[bytes] | object) -> Response | object:
+        """Wrap a TTS model response in a Flask ``Response`` with the right content type.
+
+        Streaming TTS responses are sniffed for their actual audio format so the
+        ``Content-Type`` header matches the bytes (e.g. ``audio/wav`` for providers
+        that return WAV instead of MP3). Non-streaming responses are returned
+        unchanged, preserving the prior behaviour for providers that return a
+        single blob.
+        """
+        if not isinstance(response, Generator):
             return response
+        sniffed_stream, content_type = detect_audio_content_type(response)
+        return Response(stream_with_context(sniffed_stream), content_type=content_type)  # type: ignore
 
     @classmethod
     def transcript_tts_voices(cls, tenant_id: str, language: str):

--- a/api/tests/unit_tests/core/helper/test_audio_format.py
+++ b/api/tests/unit_tests/core/helper/test_audio_format.py
@@ -1,0 +1,85 @@
+from core.helper.audio_format import detect_audio_content_type
+
+
+def _wav_header() -> bytes:
+    return b"RIFF\x24\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00"
+
+
+def _mp3_frame_header() -> bytes:
+    # 0xFF 0xFB = MPEG-1 Layer III, no CRC
+    return b"\xff\xfb\x90\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+
+
+def _mp3_id3_header() -> bytes:
+    return b"ID3\x03\x00\x00\x00\x00\x00\x00"
+
+
+def _ogg_header() -> bytes:
+    return b"OggS\x00\x02\x00\x00\x00\x00\x00\x00"
+
+
+def test_detect_wav_content_type() -> None:
+    stream = iter([_wav_header(), b"audio data chunk"])
+    replay, content_type = detect_audio_content_type(stream)
+    assert content_type == "audio/wav"
+    chunks = list(replay)
+    assert b"".join(chunks) == _wav_header() + b"audio data chunk"
+
+
+def test_detect_mp3_frame_sync_content_type() -> None:
+    stream = iter([_mp3_frame_header(), b"more mp3 data"])
+    replay, content_type = detect_audio_content_type(stream)
+    assert content_type == "audio/mpeg"
+    chunks = list(replay)
+    assert b"".join(chunks) == _mp3_frame_header() + b"more mp3 data"
+
+
+def test_detect_mp3_id3_content_type() -> None:
+    stream = iter([_mp3_id3_header(), b"mp3 body"])
+    replay, content_type = detect_audio_content_type(stream)
+    assert content_type == "audio/mpeg"
+    chunks = list(replay)
+    assert _mp3_id3_header() in b"".join(chunks)
+
+
+def test_detect_ogg_content_type() -> None:
+    stream = iter([_ogg_header(), b"ogg data"])
+    replay, content_type = detect_audio_content_type(stream)
+    assert content_type == "audio/ogg"
+
+
+def test_unknown_format_defaults_to_mpeg() -> None:
+    stream = iter([b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b", b"rest"])
+    replay, content_type = detect_audio_content_type(stream)
+    assert content_type == "audio/mpeg"
+
+
+def test_small_chunks_are_accumulated() -> None:
+    """The helper should accumulate small chunks until it has enough magic bytes."""
+    header = _wav_header()
+    # Split the WAV header into 2-byte chunks.
+    chunks = [header[i : i + 2] for i in range(0, len(header), 2)]
+    chunks.append(b"payload")
+    stream = iter(chunks)
+    replay, content_type = detect_audio_content_type(stream)
+    assert content_type == "audio/wav"
+    rebuilt = b"".join(replay)
+    assert header + b"payload" in rebuilt
+
+
+def test_empty_stream() -> None:
+    replay, content_type = detect_audio_content_type(iter([]))
+    assert content_type == "audio/mpeg"
+    assert list(replay) == []
+
+
+def test_replay_preserves_all_data() -> None:
+    """No data should be lost — the full stream must be reconstructable."""
+    data = [_wav_header(), b"chunk1", b"", b"chunk2"]
+    stream = iter(data)
+    replay, content_type = detect_audio_content_type(stream)
+    assert content_type == "audio/wav"
+    rebuilt = b"".join(replay)
+    assert _wav_header() in rebuilt
+    assert b"chunk1" in rebuilt
+    assert b"chunk2" in rebuilt

--- a/web/app/components/base/audio-btn/__tests__/audio.spec.ts
+++ b/web/app/components/base/audio-btn/__tests__/audio.spec.ts
@@ -38,6 +38,9 @@ type Reader = {
 
 type AudioResponse = {
   status: number
+  headers: {
+    get: (name: string) => string | null
+  }
   body: {
     getReader: () => Reader
   }
@@ -195,7 +198,11 @@ const setMediaSourceSupport = (options: { mediaSource: boolean; managedMediaSour
   })
 }
 
-const makeAudioResponse = (status: number, reads: ReaderResult[]): AudioResponse => {
+const makeAudioResponse = (
+  status: number,
+  reads: ReaderResult[],
+  contentType = 'audio/mpeg',
+): AudioResponse => {
   const read = vi.fn<() => Promise<ReaderResult>>()
   reads.forEach((result) => {
     read.mockResolvedValueOnce(result)
@@ -203,6 +210,12 @@ const makeAudioResponse = (status: number, reads: ReaderResult[]): AudioResponse
 
   return {
     status,
+    headers: {
+      get: (name: string) => {
+        if (name.toLowerCase() === 'content-type') return contentType
+        return null
+      },
+    },
     body: {
       getReader: () => ({ read }),
     },
@@ -1043,6 +1056,34 @@ describe('AudioPlayer', () => {
       expect(audio!.pause).toHaveBeenCalledTimes(1)
       expect(audioContext!.close).toHaveBeenCalledTimes(1)
       expect(globalThis.URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+    })
+
+    it('should use WAV content type from response header instead of default audio/mpeg', async () => {
+      mockTextToAudioStream.mockResolvedValue(
+        makeAudioResponse(
+          200,
+          [
+            { value: new Uint8Array([1, 2]), done: false },
+            { value: new Uint8Array([3, 4]), done: true },
+          ],
+          'audio/wav',
+        ),
+      )
+
+      const player = new AudioPlayer('/text-to-audio', true, 'msg-1', 'hello', 'en-US', null)
+      player.playAudio()
+      const mediaSource = testState.mediaSources[0]
+
+      // Wait for the async loadAudio to process the response (which sets the
+      // content type from the header), then fire sourceopen so the source buffer
+      // is created with the detected WAV type.
+      await waitFor(() => {
+        expect(mockTextToAudioStream).toHaveBeenCalledTimes(1)
+      })
+      await Promise.resolve()
+      mediaSource!.emit('sourceopen')
+
+      expect(mediaSource!.addSourceBuffer).toHaveBeenCalledWith('audio/wav')
     })
   })
 })

--- a/web/app/components/base/audio-btn/audio.ts
+++ b/web/app/components/base/audio-btn/audio.ts
@@ -28,6 +28,7 @@ export default class AudioPlayer {
   private playbackPending = false
   private playWhenReady = false
   private sourceOpenListener?: () => void
+  private currentContentType = AUDIO_CONTENT_TYPE
   constructor(
     streamUrl: string,
     isPublic: boolean,
@@ -71,10 +72,11 @@ export default class AudioPlayer {
   }
 
   private listenMediaSource(contentType: string) {
+    this.currentContentType = contentType
     this.sourceOpenListener = () => {
       if (this.destroyed || this.sourceBuffer) return
       try {
-        this.sourceBuffer = this.mediaSource?.addSourceBuffer(contentType)
+        this.sourceBuffer = this.mediaSource?.addSourceBuffer(this.currentContentType)
         this.sourceBuffer?.addEventListener('updateend', this.flushBuffers)
         this.flushBuffers()
       } catch {
@@ -85,6 +87,15 @@ export default class AudioPlayer {
       }
     }
     this.mediaSource?.addEventListener('sourceopen', this.sourceOpenListener)
+  }
+
+  private updateContentType(contentType: string) {
+    if (this.destroyed || this.sourceBuffer || contentType === this.currentContentType) return
+    const supports = Boolean(
+      (window.ManagedMediaSource || window.MediaSource)?.isTypeSupported?.(contentType),
+    )
+    if (!supports) return
+    this.currentContentType = contentType
   }
 
   private flushBuffers = () => {
@@ -224,6 +235,12 @@ export default class AudioPlayer {
         this.callback?.('error')
         return
       }
+      // Honor the Content-Type advertised by the backend; some TTS providers
+      // (e.g. Tongyi qwen-tts) return WAV/PCM data, and playing it as MP3 fails.
+      const responseContentType =
+        audioResponse.headers.get('Content-Type') || audioResponse.headers.get('content-type')
+      const detectedType = responseContentType?.split(';')[0]?.trim()
+      if (detectedType) this.updateContentType(detectedType)
       if (!audioResponse.body) throw new Error('Audio response body is missing')
       const reader = audioResponse.body.getReader()
       while (true) {
@@ -334,7 +351,7 @@ export default class AudioPlayer {
       return
     }
 
-    const audioBlob = new Blob(this.cacheBuffers, { type: AUDIO_CONTENT_TYPE })
+    const audioBlob = new Blob(this.cacheBuffers, { type: this.currentContentType })
     this.cacheBuffers = []
     this.releaseObjectUrl()
     this.objectUrl = URL.createObjectURL(audioBlob)


### PR DESCRIPTION
TTS providers like Tongyi qwen-tts return WAV/PCM data, but the streaming response was always advertised as audio/mpeg regardless of the actual bytes. Browsers refuse to play the mismatched data (NotSupportedError in Chrome/Edge, MediaSource type-not-supported in Firefox), so TTS audio is completely broken for these providers.

The backend now peeks at the first chunk of the TTS stream to detect the real format via magic bytes (RIFF....WAVE → audio/wav, OggS → audio/ogg, MP3 frame-sync/ID3 → audio/mpeg) and sets the matching Content-Type header on the Flask Response. The frontend reads the advertised Content-Type and configures the MediaSource source buffer accordingly, falling back to audio/mpeg when the header is absent or the detected format is not supported by the browser. This keeps MP3-producing providers working unchanged while fixing WAV providers like Tongyi.

Added unit tests for the format detection helper (WAV, MP3, OGG, unknown) and a frontend test verifying that a response with audio/wav Content-Type produces a WAV source buffer.

Fixes #39434