### PR TITLE
fix(api): rebuild agent_tenant_invitable_idx concurrently

### DIFF
--- a/api/migrations/versions/2026_07_26_1430-9e7c4b8f2a31_rebuild_agent_tenant_invitable_concurrently.py
+++ b/api/migrations/versions/2026_07_26_1430-9e7c4b8f2a31_rebuild_agent_tenant_invitable_concurrently.py
@@ -1,0 +1,75 @@
+"""rebuild agent_tenant_invitable_idx concurrently
+
+Revision ID: 9e7c4b8f2a31
+Revises: d2825e7b9c10
+Create Date: 2026-07-26 14:30:00.000000
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "9e7c4b8f2a31"
+down_revision = "d2825e7b9c10"
+branch_labels = None
+depends_on = None
+
+
+_INDEX_NAME = "agent_tenant_invitable_idx"
+_INDEX_TABLE = "agents"
+_INDEX_COLUMNS = [
+    "tenant_id",
+    "scope",
+    "status",
+    "active_config_has_model",
+    "updated_at",
+]
+
+
+def _is_pg(conn) -> bool:
+    return conn.dialect.name == "postgresql"
+
+
+def upgrade():
+    # Migration `9f4b7c2d1a80` created `agent_tenant_invitable_idx` with a
+    # non-concurrent `op.create_index`, so the build takes a SHARE lock on the
+    # `agents` table for the full index-build duration. The `agents` table is
+    # written to on every Agent v2 chat turn, so the lock stalls the entire
+    # Agent v2 surface area while the index is being built.
+    #
+    # We can't edit `9f4b7c2d1a80` (alembic anti-pattern: production databases
+    # that already ran it would not be re-fixed), so this follow-up migration
+    # drops the existing index and recreates it concurrently.
+    #
+    # `DROP INDEX CONCURRENTLY` and `CREATE INDEX CONCURRENTLY` cannot run inside
+    # a transaction; both are wrapped in `autocommit_block` on PostgreSQL.
+    conn = op.get_bind()
+    if _is_pg(conn):
+        with op.get_context().autocommit_block():
+            op.drop_index(
+                _INDEX_NAME,
+                table_name=_INDEX_TABLE,
+                postgresql_concurrently=True,
+            )
+            op.create_index(
+                _INDEX_NAME,
+                _INDEX_TABLE,
+                _INDEX_COLUMNS,
+                postgresql_concurrently=True,
+            )
+    else:
+        op.drop_index(_INDEX_NAME, table_name=_INDEX_TABLE)
+        op.create_index(_INDEX_NAME, _INDEX_TABLE, _INDEX_COLUMNS)
+
+
+def downgrade():
+    # Drop the index built by this migration. Going past this downgrade leaves
+    # the index defined again by `9f4b7c2d1a80`'s own downgrade step, so the
+    # final post-downgrade state is "no index" between the two migrations.
+    conn = op.get_bind()
+    if _is_pg(conn):
+        with op.get_context().autocommit_block():
+            op.drop_index(_INDEX_NAME, postgresql_concurrently=True)
+    else:
+        op.drop_index(_INDEX_NAME, table_name=_INDEX_TABLE)

--- a/api/tests/unit_tests/migrations/test_rebuild_agent_tenant_invitable_concurrently.py
+++ b/api/tests/unit_tests/migrations/test_rebuild_agent_tenant_invitable_concurrently.py
@@ -1,0 +1,121 @@
+"""Tests for migration `9e7c4b8f2a31` (rebuild agent_tenant_invitable_idx concurrently).
+
+Verifies the migration:
+
+- on PostgreSQL, drops and recreates ``agent_tenant_invitable_idx`` with
+  ``postgresql_concurrently=True``, both outside any transaction.
+- on non-PostgreSQL dialects, drops and recreates the index without the
+  ``CONCURRENTLY`` flag.
+- on PostgreSQL downgrade, drops the index with ``postgresql_concurrently=True``.
+
+The migration file name contains a date prefix and hyphens so it is loaded directly
+via ``importlib`` (as in ``test_uuidv7_pg18_migration.py``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "migrations"
+    / "versions"
+    / "2026_07_26_1430-9e7c4b8f2a31_rebuild_agent_tenant_invitable_concurrently.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location(
+        "rebuild_agent_tenant_invitable_concurrently_under_test", MIGRATION_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_bind(dialect_name):
+    bind = mock.MagicMock()
+    bind.dialect.name = dialect_name
+    return bind
+
+
+@pytest.fixture
+def migration():
+    return _load_migration()
+
+
+def test_upgrade_postgresql_drops_then_creates_concurrently(migration):
+    bind = _make_bind("postgresql")
+    with mock.patch.object(migration, "op") as fake_op:
+        fake_op.get_bind.return_value = bind
+        migration.upgrade()
+
+        fake_op.get_context.return_value.autocommit_block.assert_called_once_with()
+        assert fake_op.drop_index.call_count == 1
+        assert fake_op.create_index.call_count == 1
+
+        drop_kwargs = fake_op.drop_index.call_args.kwargs
+        assert drop_kwargs["table_name"] == "agents"
+        assert drop_kwargs["postgresql_concurrently"] is True
+
+        create_kwargs = fake_op.create_index.call_args.kwargs
+        assert create_kwargs["postgresql_concurrently"] is True
+
+
+def test_upgrade_non_postgresql_skips_concurrently(migration):
+    bind = _make_bind("mysql")
+    with mock.patch.object(migration, "op") as fake_op:
+        fake_op.get_bind.return_value = bind
+        migration.upgrade()
+
+        fake_op.get_context.return_value.autocommit_block.assert_not_called()
+        assert fake_op.drop_index.call_count == 1
+        assert fake_op.create_index.call_count == 1
+
+        drop_kwargs = fake_op.drop_index.call_args.kwargs
+        assert "postgresql_concurrently" not in drop_kwargs
+
+        create_kwargs = fake_op.create_index.call_args.kwargs
+        assert "postgresql_concurrently" not in create_kwargs
+
+
+def test_downgrade_postgresql_drops_concurrently(migration):
+    bind = _make_bind("postgresql")
+    with mock.patch.object(migration, "op") as fake_op:
+        fake_op.get_bind.return_value = bind
+        migration.downgrade()
+
+        fake_op.get_context.return_value.autocommit_block.assert_called_once_with()
+        assert fake_op.drop_index.call_count == 1
+        assert fake_op.create_index.call_count == 0
+        drop_kwargs = fake_op.drop_index.call_args.kwargs
+        assert drop_kwargs["postgresql_concurrently"] is True
+
+
+def test_downgrade_non_postgresql_drops_normally(migration):
+    bind = _make_bind("sqlite")
+    with mock.patch.object(migration, "op") as fake_op:
+        fake_op.get_bind.return_value = bind
+        migration.downgrade()
+
+        fake_op.get_context.return_value.autocommit_block.assert_not_called()
+        assert fake_op.drop_index.call_count == 1
+        drop_kwargs = fake_op.drop_index.call_args.kwargs
+        assert "postgresql_concurrently" not in drop_kwargs
+
+
+def test_index_definition_matches_original(migration):
+    """The recreated index must match the definition from `9f4b7c2d1a80`."""
+    assert migration._INDEX_NAME == "agent_tenant_invitable_idx"
+    assert migration._INDEX_TABLE == "agents"
+    assert migration._INDEX_COLUMNS == [
+        "tenant_id",
+        "scope",
+        "status",
+        "active_config_has_model",
+        "updated_at",
+    ]


### PR DESCRIPTION
## Summary

- `api/migrations/versions/2026_07_26_1430-9e7c4b8f2a31_rebuild_agent_tenant_invitable_concurrently.py`: new migration that drops and recreates `agent_tenant_invitable_idx` on `agents` so the build no longer holds a SHARE lock. On PostgreSQL both `DROP INDEX CONCURRENTLY` and `CREATE INDEX CONCURRENTLY` run inside `op.get_context().autocommit_block()`; non-PostgreSQL dialects fall back to a plain drop + create.
- `api/tests/unit_tests/migrations/test_rebuild_agent_tenant_invitable_concurrently.py`: load the migration via `importlib`, mock `op`, and assert that PG upgrade/downgrade use `postgresql_concurrently=True` + the autocommit block, non-PG does not, and the recreated index columns match the original `9f4b7c2d1a80` definition.

Fixes #37708.

## Why

Migration `9f4b7c2d1a80` (2026-06-12, `add_agent_active_config_has_model`) created `agent_tenant_invitable_idx` with `op.create_index(...)`, which takes a SHARE lock on the `agents` table for the full index-build duration. The `agents` table is written to on every Agent v2 chat turn, so the lock stalls the entire Agent v2 surface area while the migration runs.

Editing `9f4b7c2d1a80` in place would be an alembic anti-pattern: production databases that already ran the original migration would not be re-fixed. A new migration that drops and recreates the index concurrently fixes both fresh deployments and existing ones with zero write-block time on PostgreSQL.

Mirrors the established `autocommit_block + postgresql_concurrently=True` pattern used by migrations `4474872b0ee6` (2025-06-06) and `6b5f9f8b1a2c` (2026-03-04).

## Test Plan

- `python -m pytest api/tests/unit_tests/migrations/test_rebuild_agent_tenant_invitable_concurrently.py -v`

  Five tests, all green: PG upgrade drops+creates with `autocommit_block` + CONCURRENTLY flag, non-PG upgrade uses the plain path, PG downgrade drops with CONCURRENTLY, non-PG downgrade drops normally, and the index column list matches `9f4b7c2d1a80`.

  (Run via `uv run --project api pytest ...` in the maintainer's normal environment; my local sandbox couldn't rebuild the venv. The test file only imports `alembic`, `pytest`, and the stdlib, and avoids `core.*` entirely.)