### PR TITLE
feat(web): show default values in User Input field list

### DIFF
--- a/web/app/components/workflow/nodes/start/components/__tests__/var-item.spec.tsx
+++ b/web/app/components/workflow/nodes/start/components/__tests__/var-item.spec.tsx
@@ -32,4 +32,36 @@ describe('StartVarItem', () => {
     fireEvent.click(screen.getByRole('button', { name: 'common.operation.remove' }))
     expect(handleRemove).toHaveBeenCalledTimes(1)
   })
+
+  it('shows the default value under the field name when one is set', () => {
+    render(
+      <VarItem
+        readonly
+        payload={createPayload({
+          default: 'langgenius/dify-official-plugins-and-extensions',
+          required: true,
+        })}
+      />,
+    )
+
+    const defaultLine = screen.getByTitle('langgenius/dify-official-plugins-and-extensions')
+    expect(defaultLine).toHaveTextContent(
+      'workflow.nodes.start.default: langgenius/dify-official-plugins-and-extensions',
+    )
+    expect(screen.getByText('workflow.nodes.start.required')).toBeInTheDocument()
+  })
+
+  it('hides the default line when no default value is set', () => {
+    render(<VarItem readonly payload={createPayload({ required: false })} />)
+
+    expect(screen.queryByText(/workflow\.nodes\.start\.default:/)).not.toBeInTheDocument()
+  })
+
+  it('shows boolean false defaults', () => {
+    render(
+      <VarItem readonly payload={createPayload({ type: InputVarType.checkbox, default: false })} />,
+    )
+
+    expect(screen.getByTitle('false')).toHaveTextContent('workflow.nodes.start.default: false')
+  })
 })

--- a/web/app/components/workflow/nodes/start/components/var-item.tsx
+++ b/web/app/components/workflow/nodes/start/components/var-item.tsx
@@ -52,40 +52,56 @@ const VarItem: FC<Props> = ({
     },
     [onChange, hideEditVarModal],
   )
+
+  const defaultValue = payload.default
+  const hasDefault = defaultValue !== undefined && defaultValue !== null && defaultValue !== ''
+  const defaultValueText = hasDefault ? String(defaultValue) : ''
+
   return (
     <div
       ref={ref}
       className={cn(
-        'flex h-8 cursor-pointer items-center justify-between rounded-lg border border-components-panel-border-subtle bg-components-panel-on-panel-item-bg px-2.5 shadow-xs hover:shadow-md',
+        'flex cursor-pointer items-center justify-between rounded-lg border border-components-panel-border-subtle bg-components-panel-on-panel-item-bg px-2.5 shadow-xs hover:shadow-md',
+        hasDefault ? 'min-h-8 py-1.5' : 'h-8',
         className,
       )}
     >
-      <div className="flex w-0 grow items-center space-x-1">
-        <Variable02
-          className={cn('size-3.5 text-text-accent', canDrag && 'group-hover:opacity-0')}
-        />
-        <div
-          title={payload.variable}
-          className="max-w-[130px] shrink-0 truncate text-[13px] font-medium text-text-secondary"
-        >
-          {payload.variable}
-        </div>
-        {payload.label && (
-          <>
-            <div className="shrink-0 text-xs font-medium text-text-quaternary">·</div>
-            <div
-              title={payload.label as string}
-              className="max-w-[130px] truncate text-[13px] font-medium text-text-tertiary"
-            >
-              {payload.label as string}
-            </div>
-          </>
-        )}
-        {showLegacyBadge && (
-          <Badge
-            text="LEGACY"
-            className="shrink-0 border-text-accent-secondary text-text-accent-secondary"
+      <div className="flex w-0 grow flex-col">
+        <div className="flex items-center space-x-1">
+          <Variable02
+            className={cn('size-3.5 shrink-0 text-text-accent', canDrag && 'group-hover:opacity-0')}
           />
+          <div
+            title={payload.variable}
+            className="max-w-[130px] shrink-0 truncate text-[13px] font-medium text-text-secondary"
+          >
+            {payload.variable}
+          </div>
+          {payload.label && (
+            <>
+              <div className="shrink-0 text-xs font-medium text-text-quaternary">·</div>
+              <div
+                title={payload.label as string}
+                className="max-w-[130px] truncate text-[13px] font-medium text-text-tertiary"
+              >
+                {payload.label as string}
+              </div>
+            </>
+          )}
+          {showLegacyBadge && (
+            <Badge
+              text="LEGACY"
+              className="shrink-0 border-text-accent-secondary text-text-accent-secondary"
+            />
+          )}
+        </div>
+        {hasDefault && (
+          <div
+            title={defaultValueText}
+            className="truncate pl-[18px] text-xs font-normal text-text-tertiary"
+          >
+            {t(($) => $['nodes.start.default'], { ns: 'workflow' })}: {defaultValueText}
+          </div>
         )}
       </div>
       <div className="ml-2 flex shrink-0 items-center">

--- a/web/i18n/ar-TN/workflow.json
+++ b/web/i18n/ar-TN/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "اسم الموضوع",
   "nodes.questionClassifiers.topicPlaceholder": "اكتب اسم الموضوع الخاص بك",
   "nodes.start.builtInVar": "المتغيرات المدمجة",
+  "nodes.start.default": "افتراضي",
   "nodes.start.inputField": "حقل الإدخال",
   "nodes.start.noVarTip": "تعيين المدخلات التي يمكن استخدامها في سير العمل",
   "nodes.start.outputVars.files": "قائمة الملفات",

--- a/web/i18n/de-DE/workflow.json
+++ b/web/i18n/de-DE/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Themenname",
   "nodes.questionClassifiers.topicPlaceholder": "Geben Sie Ihren Themennamen ein",
   "nodes.start.builtInVar": "Eingebaute Variablen",
+  "nodes.start.default": "Standard",
   "nodes.start.inputField": "Eingabefeld",
   "nodes.start.noVarTip": "Legen Sie Eingaben fest, die im Workflow verwendet werden können",
   "nodes.start.outputVars.files": "Dateiliste",

--- a/web/i18n/en-US/workflow.json
+++ b/web/i18n/en-US/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Topic Name",
   "nodes.questionClassifiers.topicPlaceholder": "Write your topic name",
   "nodes.start.builtInVar": "Built-in Variables",
+  "nodes.start.default": "default",
   "nodes.start.inputField": "Input Field",
   "nodes.start.noVarTip": "Set inputs that can be used in the Workflow",
   "nodes.start.outputVars.files": "File list",

--- a/web/i18n/es-ES/workflow.json
+++ b/web/i18n/es-ES/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Nombre del tema",
   "nodes.questionClassifiers.topicPlaceholder": "Escribe el nombre de tu tema",
   "nodes.start.builtInVar": "Variables incorporadas",
+  "nodes.start.default": "predeterminado",
   "nodes.start.inputField": "Campo de entrada",
   "nodes.start.noVarTip": "Establece las entradas que se pueden utilizar en el flujo de trabajo",
   "nodes.start.outputVars.files": "Lista de archivos",

--- a/web/i18n/fa-IR/workflow.json
+++ b/web/i18n/fa-IR/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "نام موضوع",
   "nodes.questionClassifiers.topicPlaceholder": "نام موضوع را بنویسید",
   "nodes.start.builtInVar": "متغیرهای داخلی",
+  "nodes.start.default": "پیش‌فرض",
   "nodes.start.inputField": "فیلد ورودی",
   "nodes.start.noVarTip": "ورودی‌هایی که در گردش کار استفاده می‌شوند را تعریف کنید",
   "nodes.start.outputVars.files": "لیست فایل‌ها",

--- a/web/i18n/fr-FR/workflow.json
+++ b/web/i18n/fr-FR/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Nom du sujet",
   "nodes.questionClassifiers.topicPlaceholder": "Écrivez le nom de votre sujet",
   "nodes.start.builtInVar": "Variables intégrées",
+  "nodes.start.default": "défaut",
   "nodes.start.inputField": "Champ de saisie",
   "nodes.start.noVarTip": "Définir les entrées qui peuvent être utilisées dans le flux de travail",
   "nodes.start.outputVars.files": "Liste de fichiers",

--- a/web/i18n/hi-IN/workflow.json
+++ b/web/i18n/hi-IN/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "विषय नाम",
   "nodes.questionClassifiers.topicPlaceholder": "अपना विषय नाम लिखें",
   "nodes.start.builtInVar": "निर्मित वेरिएबल्स",
+  "nodes.start.default": "डिफ़ॉल्ट",
   "nodes.start.inputField": "इनपुट फील्ड",
   "nodes.start.noVarTip": "वर्कफ्लो में उपयोग के लिए इनपुट्स सेट करें",
   "nodes.start.outputVars.files": "फ़ाइल सूची",

--- a/web/i18n/id-ID/workflow.json
+++ b/web/i18n/id-ID/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Nama Topik",
   "nodes.questionClassifiers.topicPlaceholder": "Tulis nama topik Anda",
   "nodes.start.builtInVar": "Variabel bawaan",
+  "nodes.start.default": "default",
   "nodes.start.inputField": "Bidang Masukan",
   "nodes.start.noVarTip": "Atur input yang dapat digunakan dalam Alur Kerja",
   "nodes.start.outputVars.files": "Daftar file",

--- a/web/i18n/it-IT/workflow.json
+++ b/web/i18n/it-IT/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Nome Argomento",
   "nodes.questionClassifiers.topicPlaceholder": "Scrivi il nome del tuo argomento",
   "nodes.start.builtInVar": "Variabili Integrate",
+  "nodes.start.default": "predefinito",
   "nodes.start.inputField": "Campo di Input",
   "nodes.start.noVarTip": "Imposta gli input che possono essere utilizzati nel Flusso di lavoro",
   "nodes.start.outputVars.files": "Elenco file",

--- a/web/i18n/ja-JP/workflow.json
+++ b/web/i18n/ja-JP/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "トピック名",
   "nodes.questionClassifiers.topicPlaceholder": "トピック名を入力してください",
   "nodes.start.builtInVar": "組み込み変数",
+  "nodes.start.default": "デフォルト",
   "nodes.start.inputField": "入力フィールド",
   "nodes.start.noVarTip": "入力設定はワークフロー内で利用可能",
   "nodes.start.outputVars.files": "ファイル一覧",

--- a/web/i18n/ko-KR/workflow.json
+++ b/web/i18n/ko-KR/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "주제 이름",
   "nodes.questionClassifiers.topicPlaceholder": "주제 이름을 작성하세요",
   "nodes.start.builtInVar": "내장 변수",
+  "nodes.start.default": "기본값",
   "nodes.start.inputField": "입력 필드",
   "nodes.start.noVarTip": "워크플로우에서 사용할 입력을 설정하세요",
   "nodes.start.outputVars.files": "파일 목록",

--- a/web/i18n/nl-NL/workflow.json
+++ b/web/i18n/nl-NL/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Topic Name",
   "nodes.questionClassifiers.topicPlaceholder": "Write your topic name",
   "nodes.start.builtInVar": "Built-in Variables",
+  "nodes.start.default": "standaard",
   "nodes.start.inputField": "Input Field",
   "nodes.start.noVarTip": "Set inputs that can be used in the Workflow",
   "nodes.start.outputVars.files": "File list",

--- a/web/i18n/pl-PL/workflow.json
+++ b/web/i18n/pl-PL/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Nazwa tematu",
   "nodes.questionClassifiers.topicPlaceholder": "Napisz nazwę swojego tematu",
   "nodes.start.builtInVar": "Wbudowane zmienne",
+  "nodes.start.default": "domyślne",
   "nodes.start.inputField": "Pole wejściowe",
   "nodes.start.noVarTip": "Ustaw wejścia, które mogą być używane w przepływie pracy",
   "nodes.start.outputVars.files": "Lista plików",

--- a/web/i18n/pt-BR/workflow.json
+++ b/web/i18n/pt-BR/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Nome do tópico",
   "nodes.questionClassifiers.topicPlaceholder": "Escreva o nome do seu tópico",
   "nodes.start.builtInVar": "Variáveis integradas",
+  "nodes.start.default": "padrão",
   "nodes.start.inputField": "Campo de entrada",
   "nodes.start.noVarTip": "Defina as entradas que podem ser usadas no Fluxo de Trabalho",
   "nodes.start.outputVars.files": "Lista de arquivos",

--- a/web/i18n/ro-RO/workflow.json
+++ b/web/i18n/ro-RO/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Nume subiect",
   "nodes.questionClassifiers.topicPlaceholder": "Scrieți numele subiectului",
   "nodes.start.builtInVar": "Variabile integrate",
+  "nodes.start.default": "implicit",
   "nodes.start.inputField": "Câmp de intrare",
   "nodes.start.noVarTip": "Setați intrările care pot fi utilizate în fluxul de lucru",
   "nodes.start.outputVars.files": "Listă de fișiere",

--- a/web/i18n/ru-RU/workflow.json
+++ b/web/i18n/ru-RU/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Название темы",
   "nodes.questionClassifiers.topicPlaceholder": "Введите название вашей темы",
   "nodes.start.builtInVar": "Встроенные переменные",
+  "nodes.start.default": "по умолчанию",
   "nodes.start.inputField": "Поле ввода",
   "nodes.start.noVarTip": "Установите входные данные, которые можно использовать в рабочем процессе",
   "nodes.start.outputVars.files": "Список файлов",

--- a/web/i18n/sl-SI/workflow.json
+++ b/web/i18n/sl-SI/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Ime teme",
   "nodes.questionClassifiers.topicPlaceholder": "Napišite ime svoje teme",
   "nodes.start.builtInVar": "Vgrajene spremenljivke",
+  "nodes.start.default": "privzeto",
   "nodes.start.inputField": "Vnosno polje",
   "nodes.start.noVarTip": "Nastavite vhodne podatke, ki jih lahko uporabite v delovnem toku.",
   "nodes.start.outputVars.files": "Seznam datotek",

--- a/web/i18n/th-TH/workflow.json
+++ b/web/i18n/th-TH/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "ชื่อหัวข้อ",
   "nodes.questionClassifiers.topicPlaceholder": "เขียนชื่อหัวข้อของคุณ",
   "nodes.start.builtInVar": "ตัวแปรในตัว",
+  "nodes.start.default": "ค่าเริ่มต้น",
   "nodes.start.inputField": "ฟิลด์อินพุต",
   "nodes.start.noVarTip": "ตั้งค่าอินพุตที่สามารถใช้ในเวิร์กโฟลว์",
   "nodes.start.outputVars.files": "รายการไฟล์",

--- a/web/i18n/tr-TR/workflow.json
+++ b/web/i18n/tr-TR/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Konu Adı",
   "nodes.questionClassifiers.topicPlaceholder": "Konu adınızı yazın",
   "nodes.start.builtInVar": "Yerleşik Değişkenler",
+  "nodes.start.default": "varsayılan",
   "nodes.start.inputField": "Giriş Alanı",
   "nodes.start.noVarTip": "İş Akışında kullanılabilecek girişleri ayarlayın",
   "nodes.start.outputVars.files": "Dosya listesi",

--- a/web/i18n/uk-UA/workflow.json
+++ b/web/i18n/uk-UA/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Назва теми",
   "nodes.questionClassifiers.topicPlaceholder": "Напишіть назву вашої теми",
   "nodes.start.builtInVar": "Вбудовані змінні",
+  "nodes.start.default": "за замовчуванням",
   "nodes.start.inputField": "Поле введення",
   "nodes.start.noVarTip": "Встановіть вхідні дані, які можуть бути використані у робочому потоці",
   "nodes.start.outputVars.files": "Список файлів",

--- a/web/i18n/vi-VN/workflow.json
+++ b/web/i18n/vi-VN/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "Tên chủ đề",
   "nodes.questionClassifiers.topicPlaceholder": "Viết tên chủ đề của bạn",
   "nodes.start.builtInVar": "Biến tích hợp sẵn",
+  "nodes.start.default": "mặc định",
   "nodes.start.inputField": "Trường đầu vào",
   "nodes.start.noVarTip": "Đặt các đầu vào có thể sử dụng trong Quy trình làm việc",
   "nodes.start.outputVars.files": "Danh sách tệp",

--- a/web/i18n/zh-Hans/workflow.json
+++ b/web/i18n/zh-Hans/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "主题内容",
   "nodes.questionClassifiers.topicPlaceholder": "在这里输入你的主题内容",
   "nodes.start.builtInVar": "内置变量",
+  "nodes.start.default": "默认",
   "nodes.start.inputField": "输入字段",
   "nodes.start.noVarTip": "设置的输入可在工作流程中使用",
   "nodes.start.outputVars.files": "文件列表",

--- a/web/i18n/zh-Hant/workflow.json
+++ b/web/i18n/zh-Hant/workflow.json
@@ -976,6 +976,7 @@
   "nodes.questionClassifiers.topicName": "主題內容",
   "nodes.questionClassifiers.topicPlaceholder": "在這裡輸入你的主題內容",
   "nodes.start.builtInVar": "內置變數",
+  "nodes.start.default": "預設",
   "nodes.start.inputField": "輸入字段",
   "nodes.start.noVarTip": "設置的輸入可在工作流程中使用",
   "nodes.start.outputVars.files": "文件列表",


### PR DESCRIPTION
## Summary
- Show each User Input (Start node) field default beneath the field name in the panel field list when one is set, truncated with ellipsis and the full value available on hover.
- Keep `required` on the right; leave the canvas Start node unchanged so node height stays the same.
- Add `nodes.start.default` i18n keys across locales and cover the display behavior in `var-item` tests.

Fixes #39563

## Test plan
- [ ] Open a workflow with a User Input / Start node that has several fields
- [ ] Set defaults on some fields and leave others unset
- [ ] Confirm fields with defaults show `default: ...` under the name in the Input Field list
- [ ] Confirm long defaults truncate and reveal the full value on hover
- [ ] Confirm fields without defaults show no default line
- [ ] Confirm `required` still appears on the right
- [ ] Confirm the canvas Start node does not show defaults
- [ ] Run `pnpm test -- run app/components/workflow/nodes/start/components/__tests__/var-item.spec.tsx` from `web/`
