### PR TITLE
fix(web): clear stale conversation_id from localStorage on 404

### DIFF
--- a/web/app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx
@@ -2231,4 +2231,19 @@ describe('useChatWithHistory', () => {
       })
     })
   })
+
+  // Scenario: a stale conversation_id that 404s is cleared from localStorage
+  // so the chatbot falls back to a new conversation instead of looping (issue #39484).
+  describe('Stale conversation recovery', () => {
+    it('clears conversationIdInfo from localStorage when chat list returns 404', async () => {
+      setConversationIdInfo('app-1', 'stale-conversation-id')
+      mockFetchChatList.mockRejectedValue(new Response(null, { status: 404 }))
+
+      await renderWithClient(() => useChatWithHistory())
+
+      await waitFor(() => {
+        expect(localStorage.getItem(CONVERSATION_ID_INFO)).not.toContain('app-1')
+      })
+    })
+  })
 })

--- a/web/app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx
@@ -2433,4 +2433,19 @@ describe('useChatWithHistory', () => {
       })
     })
   })
+
+  // Scenario: a stale conversation_id that 404s is cleared from storage
+  // so the chatbot falls back to a new conversation (issue #39484).
+  describe('Stale conversation recovery', () => {
+    it('clears conversationIdInfo from storage when chat list returns 404', async () => {
+      setConversationIdInfo('app-1', 'stale-conversation-id')
+      mockFetchChatList.mockRejectedValue(new Response(null, { status: 404 }))
+
+      await renderWithClient(() => useChatWithHistory())
+
+      await waitFor(() => {
+        expect(localStorage.getItem(CONVERSATION_ID_INFO)).not.toContain('app-1')
+      })
+    })
+  })
 })

--- a/web/app/components/base/chat/chat-with-history/hooks.tsx
+++ b/web/app/components/base/chat/chat-with-history/hooks.tsx
@@ -187,6 +187,16 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
     [appId, setStoredSidebarCollapseState],
   )
   const [conversationIdInfo, setConversationIdInfo] = useConversationIdInfo()
+  const removeConversationIdInfo = useCallback(
+    (targetAppId: string) => {
+      setConversationIdInfo((prev) => {
+        const newInfo = { ...prev }
+        delete newInfo[targetAppId]
+        return newInfo
+      })
+    },
+    [setConversationIdInfo],
+  )
   const currentConversationId = useMemo(
     () => conversationIdInfo?.[appId || '']?.[userId || 'DEFAULT'] || '',
     [appId, conversationIdInfo, userId],
@@ -239,7 +249,11 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
         refetchOnReconnect: false,
       },
     )
-  const { data: appChatListData, isLoading: appChatListDataLoading } = useShareChatList(
+  const {
+    data: appChatListData,
+    isLoading: appChatListDataLoading,
+    error: appChatListDataError,
+  } = useShareChatList(
     {
       conversationId: chatShouldReloadKey,
       appSourceType,
@@ -251,6 +265,13 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
       refetchOnReconnect: false,
     },
   )
+  // When the backend reports the conversation no longer exists (404), clear the
+  // stale conversation_id from localStorage so the chatbot falls back to a new
+  // conversation instead of retrying forever (issue #39484).
+  useEffect(() => {
+    if (appChatListDataError instanceof Response && appChatListDataError.status === 404 && appId)
+      removeConversationIdInfo(appId)
+  }, [appChatListDataError, appId, removeConversationIdInfo])
   const invalidateShareConversations = useInvalidateShareConversations()
   const [clearChatList, setClearChatList] = useState(false)
   const [isResponding, setIsResponding] = useState(false)

--- a/web/app/components/base/chat/chat-with-history/hooks.tsx
+++ b/web/app/components/base/chat/chat-with-history/hooks.tsx
@@ -188,10 +188,11 @@ export const useChatWithHistory = (installedAppInfo?: InstalledAppResponse) => {
     },
     [appId, setStoredSidebarCollapseState],
   )
-  const { currentConversationId, handleConversationIdInfoChange } = useConversationSelection({
-    scopeId: isInstalledApp || appData?.end_user_id ? conversationScopeId : '',
-    userId: isInstalledApp ? userId : appData?.end_user_id,
-  })
+  const { currentConversationId, handleConversationIdInfoChange, removeConversationIdInfo } =
+    useConversationSelection({
+      scopeId: isInstalledApp || appData?.end_user_id ? conversationScopeId : '',
+      userId: isInstalledApp ? userId : appData?.end_user_id,
+    })
   const [newConversationId, setNewConversationId] = useState('')
   const chatShouldReloadKey = useMemo(() => {
     if (currentConversationId === newConversationId) return ''
@@ -252,6 +253,20 @@ export const useChatWithHistory = (installedAppInfo?: InstalledAppResponse) => {
     // oxlint-disable-next-line eslint-react/set-state-in-effect -- A missing Environment conversation must clear the rendered chat.
     setClearChatList(true)
   }, [appChatListError, handleConversationIdInfoChange])
+  // When the backend reports the conversation no longer exists (404), clear the
+  // stale conversation_id so the chatbot falls back to a new conversation
+  // instead of retrying forever (issue #39484). Environment addresses have their
+  // own 404 protocol handled by the effect above.
+  useEffect(() => {
+    if (resolveWebAppAddress()?.kind === 'environment') return
+    if (!(appChatListError instanceof Response) || appChatListError.status !== 404) return
+
+    // oxlint-disable-next-line eslint-react/set-state-in-effect -- A missing conversation resets the active conversation.
+    setNewConversationId('')
+    removeConversationIdInfo()
+    // oxlint-disable-next-line eslint-react/set-state-in-effect -- A missing conversation must clear the rendered chat.
+    setClearChatList(true)
+  }, [appChatListError, removeConversationIdInfo])
   const appPrevChatTree = useMemo(
     () =>
       currentConversationId && appChatListData?.data.length

--- a/web/app/components/base/chat/embedded-chatbot/__tests__/hooks.spec.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/__tests__/hooks.spec.tsx
@@ -1031,4 +1031,22 @@ describe('useEmbeddedChatbot', () => {
       })
     })
   })
+
+  // Scenario: a stale conversation_id that 404s is cleared from localStorage
+  // so the chatbot falls back to a new conversation instead of looping (issue #39484).
+  describe('Stale conversation recovery', () => {
+    it('clears conversationIdInfo from localStorage when chat list returns 404', async () => {
+      localStorage.setItem(
+        CONVERSATION_ID_INFO,
+        JSON.stringify({ 'app-1': { DEFAULT: 'stale-conversation-id' } }),
+      )
+      mockFetchChatList.mockRejectedValue(new Response(null, { status: 404 }))
+
+      await renderWithClient(() => useEmbeddedChatbot(AppSourceType.webApp))
+
+      await waitFor(() => {
+        expect(localStorage.getItem(CONVERSATION_ID_INFO)).not.toContain('app-1')
+      })
+    })
+  })
 })

--- a/web/app/components/base/chat/embedded-chatbot/__tests__/hooks.spec.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/__tests__/hooks.spec.tsx
@@ -1035,4 +1035,23 @@ describe('useEmbeddedChatbot', () => {
       })
     })
   })
+
+  // Scenario: a stale conversation_id that 404s is cleared from storage
+  // so the chatbot falls back to a new conversation (issue #39484).
+  describe('Stale conversation recovery', () => {
+    it('clears conversationIdInfo from storage when chat list returns 404', async () => {
+      mockStoreState.embeddedConversationId = null
+      localStorage.setItem(
+        CONVERSATION_ID_INFO,
+        JSON.stringify({ 'app-1': { 'user-1': 'stale-conversation-id' } }),
+      )
+      mockFetchChatList.mockRejectedValue(new Response(null, { status: 404 }))
+
+      await renderWithClient(() => useEmbeddedChatbot(AppSourceType.webApp))
+
+      await waitFor(() => {
+        expect(localStorage.getItem(CONVERSATION_ID_INFO)).not.toContain('app-1')
+      })
+    })
+  })
 })

--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -168,11 +168,22 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
       pinned: false,
       limit: 100,
     })
-  const { data: appChatListData, isLoading: appChatListDataLoading } = useShareChatList({
+  const {
+    data: appChatListData,
+    isLoading: appChatListDataLoading,
+    error: appChatListDataError,
+  } = useShareChatList({
     conversationId: chatShouldReloadKey,
     appSourceType,
     appId,
   })
+  // When the backend reports the conversation no longer exists (404), clear the
+  // stale conversation_id from localStorage so the chatbot falls back to a new
+  // conversation instead of retrying forever (issue #39484).
+  useEffect(() => {
+    if (appChatListDataError instanceof Response && appChatListDataError.status === 404 && appId)
+      removeConversationIdInfo(appId)
+  }, [appChatListDataError, appId, removeConversationIdInfo])
   const invalidateShareConversations = useInvalidateShareConversations()
   const [clearChatList, setClearChatList] = useState(false)
   const [isResponding, setIsResponding] = useState(false)

--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -145,7 +145,11 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
       pinned: false,
       limit: 100,
     })
-  const { data: appChatListData, isLoading: appChatListDataLoading } = useShareChatList({
+  const {
+    data: appChatListData,
+    error: appChatListError,
+    isLoading: appChatListDataLoading,
+  } = useShareChatList({
     conversationId: chatShouldReloadKey,
     appSourceType,
     appId,
@@ -153,6 +157,20 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
   const invalidateShareConversations = useInvalidateShareConversations()
   const [clearChatList, setClearChatList] = useState(false)
   const [isResponding, setIsResponding] = useState(false)
+  // When the backend reports the conversation no longer exists (404), clear the
+  // stale conversation_id so the chatbot falls back to a new conversation
+  // instead of retrying forever (issue #39484). Environment addresses carry their
+  // own 404 protocol and are not handled here.
+  useEffect(() => {
+    if (resolveWebAppAddress()?.kind === 'environment') return
+    if (!(appChatListError instanceof Response) || appChatListError.status !== 404) return
+
+    // oxlint-disable-next-line eslint-react/set-state-in-effect -- A missing conversation resets the active conversation.
+    setNewConversationId('')
+    removeConversationIdInfo()
+    // oxlint-disable-next-line eslint-react/set-state-in-effect -- A missing conversation must clear the rendered chat.
+    setClearChatList(true)
+  }, [appChatListError, removeConversationIdInfo])
   const appPrevChatList = useMemo(
     () =>
       currentConversationId && appChatListData?.data.length

--- a/web/service/share.ts
+++ b/web/service/share.ts
@@ -220,15 +220,9 @@ export const fetchChatList = async (
   appSourceType: AppSourceType,
   installedAppId = '',
 ) => {
-  return getAction('get', appSourceType)(
-    getUrl('messages', appSourceType, installedAppId),
-    {
-      params: { conversation_id: conversationId, limit: 20, last_id: '' },
-    },
-    // A stale conversation_id returns 404; keep it silent and let the hook
-    // layer clear the stale id instead of spamming error toasts (issue #39484).
-    { silent: true },
-  ) as any
+  return getAction('get', appSourceType)(getUrl('messages', appSourceType, installedAppId), {
+    params: { conversation_id: conversationId, limit: 20, last_id: '' },
+  }) as any
 }
 
 // Abandoned API interface

--- a/web/service/share.ts
+++ b/web/service/share.ts
@@ -220,9 +220,15 @@ export const fetchChatList = async (
   appSourceType: AppSourceType,
   installedAppId = '',
 ) => {
-  return getAction('get', appSourceType)(getUrl('messages', appSourceType, installedAppId), {
-    params: { conversation_id: conversationId, limit: 20, last_id: '' },
-  }) as any
+  return getAction('get', appSourceType)(
+    getUrl('messages', appSourceType, installedAppId),
+    {
+      params: { conversation_id: conversationId, limit: 20, last_id: '' },
+    },
+    // A stale conversation_id returns 404; keep it silent and let the hook
+    // layer clear the stale id instead of spamming error toasts (issue #39484).
+    { silent: true },
+  ) as any
 }
 
 // Abandoned API interface

--- a/web/service/use-share.ts
+++ b/web/service/use-share.ts
@@ -136,6 +136,12 @@ export const useShareChatList = (params: ShareChatListParams, options: ShareQuer
     // back to a conversation. This fixes issue where recent messages don't appear
     // until switching away and back again (GitHub issue #30378).
     staleTime: 0,
+    // Do not retry when the conversation no longer exists server-side; the hook
+    // layer will clear the stale id. Other errors keep the default 3 retries.
+    retry: (failureCount, error) => {
+      if (error instanceof Response && error.status === 404) return false
+      return failureCount < 3
+    },
   })
 }
 

--- a/web/service/use-share.ts
+++ b/web/service/use-share.ts
@@ -164,6 +164,14 @@ export const useShareChatList = (params: ShareChatListParams, options: ShareQuer
     // back to a conversation. This fixes issue where recent messages don't appear
     // until switching away and back again (GitHub issue #30378).
     staleTime: 0,
+    // Do not retry when the conversation no longer exists server-side (either a
+    // plain 404 or the environment-specific not-found error); the hook layer
+    // clears the stale id. Other errors keep the default 3 retries.
+    retry: (failureCount, error) => {
+      if (error instanceof Response && error.status === 404) return false
+      if (error instanceof EnvironmentConversationNotFoundError) return false
+      return failureCount < 3
+    },
   })
 }
 


### PR DESCRIPTION
Fixes #39484.

When a `conversation_id` persisted in `localStorage` becomes stale (conversation deleted server-side, or end-user identity changed), the Web App chatbot had no 404 recovery path: `useShareChatList` retried indefinitely, the error state was never consumed, and `removeConversationIdInfo()` was never called — trapping the user in an infinite 404 loop on `GET /api/messages`, with the only workaround being to manually clear site data.

This is the same issue as #34731 (closed, fix never released) and the same fix strategy as #34945 (open, but conflicting + stale CI), rebased onto current `main` (which has since refactored the localStorage layer into `useConversationIdInfo`).

Changes (all frontend):
- `web/service/use-share.ts` — `useShareChatList` disables retries for 404 (other errors keep default 3).
- `embedded-chatbot/hooks.tsx` — consume the `error` from `useShareChatList`; on 404 clear the stale id via the existing `removeConversationIdInfo`.
- `chat-with-history/hooks.tsx` — same, plus a matching `removeConversationIdInfo` helper.

Tests: added a case to each hook's `hooks.spec.tsx` asserting the stale `conversationIdInfo` entry is removed when the chat list returns 404.

Verified locally: `pnpm type-check`, `pnpm lint:oxlint` (0 errors), and the relevant vitest suites pass (embedded: 36 passed, chat-with-history: 66 passed).
