### PR TITLE
fix(agent): normalize null LogMessage metadata in Agent V2 tool client

### DIFF
--- a/dify-agent/src/dify_agent/layers/dify_plugin/tool_client.py
+++ b/dify-agent/src/dify_agent/layers/dify_plugin/tool_client.py
@@ -96,6 +96,15 @@ class DifyPluginToolInvokeMessage(BaseModel):
         data: Mapping[str, object] = Field(default_factory=dict)
         metadata: Mapping[str, object] = Field(default_factory=dict)
 
+        @field_validator("metadata", mode="before")
+        @classmethod
+        def _normalize_metadata(cls, value: object) -> object:
+            # The plugin SDK's ``create_log_message`` defaults ``metadata`` to
+            # None, which the daemon serializes as ``metadata: null``. Mirror the
+            # canonical core model (ToolInvokeMessage.LogMessage) and coerce that
+            # null back to an empty mapping so the message union still resolves.
+            return value or {}
+
     class MessageType(StrEnum):
         TEXT = "text"
         IMAGE = "image"

--- a/dify-agent/tests/local/dify_agent/layers/dify_plugin/test_tool_client.py
+++ b/dify-agent/tests/local/dify_agent/layers/dify_plugin/test_tool_client.py
@@ -1,0 +1,59 @@
+"""Regression tests for DifyPluginToolInvokeMessage validation.
+
+Agent V2 talks to the plugin daemon through its own copy of the tool-stream
+message model. A tool that emits an operation log via the plugin SDK's
+``create_log_message`` leaves ``metadata`` unset, and the daemon serializes it
+onto the wire as ``metadata: null``. The canonical core model
+(``core.tools.entities.tool_entities.ToolInvokeMessage.LogMessage``) normalizes
+that null to ``{}``; Agent V2's copy must do the same, otherwise every such log
+message collapses the whole ``message`` union and the tool invocation fails with
+``N validation errors for DifyPluginToolInvokeMessage``.
+
+See langgenius/dify-official-plugins#3512.
+"""
+
+from __future__ import annotations
+
+from dify_agent.layers.dify_plugin.tool_client import DifyPluginToolInvokeMessage
+
+
+def test_log_message_with_null_metadata_normalizes_to_empty_dict() -> None:
+    """A LogMessage whose ``metadata`` is null must validate, not raise.
+
+    This is the exact wire shape produced when a plugin tool calls
+    ``create_log_message(label=..., data=..., status=...)`` without passing
+    ``metadata`` (the SDK default), e.g. the Google Calendar tool.
+    """
+    message = DifyPluginToolInvokeMessage.model_validate(
+        {
+            "type": "log",
+            "message": {
+                "id": "log-1",
+                "label": "Search Events Operation",
+                "status": "success",
+                "data": {"calendar_id": "primary"},
+                "metadata": None,
+            },
+        }
+    )
+
+    assert isinstance(message.message, DifyPluginToolInvokeMessage.LogMessage)
+    assert message.message.metadata == {}
+
+
+def test_log_message_with_omitted_metadata_still_validates() -> None:
+    """Omitting ``metadata`` entirely must also validate to an empty dict."""
+    message = DifyPluginToolInvokeMessage.model_validate(
+        {
+            "type": "log",
+            "message": {
+                "id": "log-2",
+                "label": "Fetching Top Stories",
+                "status": "success",
+                "data": {"limit": 10},
+            },
+        }
+    )
+
+    assert isinstance(message.message, DifyPluginToolInvokeMessage.LogMessage)
+    assert message.message.metadata == {}


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Reported in: langgenius/dify-official-plugins#3512
(cross-repo — GitHub won't auto-close across repositories, so that issue will need closing by hand once this merges.)

Calling any plugin tool from the new Agent (`/agents`) fails with `tool parameters validation error: 11 validation errors for DifyPluginToolInvokeMessage`. The same tool works from chatbot and workflow agent modes.

Agent V2 lives in the in-repo `dify-agent` package and validates plugin-daemon tool-stream messages against **its own private copy** of the message model. That copy never received the `null → {}` normalizer for `LogMessage.metadata` that #26890 added to the canonical core model. So any tool emitting `create_log_message()` without metadata serializes as `metadata: null`, fails the `LogMessage` branch, and — with no other branch matching — collapses the whole union into 11 errors. The older paths work because they validate against core's `ToolInvokeMessage`.

This adds a before-validator to the `dify-agent` copy mirroring core's `_normalize_metadata`, plus a regression test.

Not plugin-specific: `create_log_message` defaults `metadata=None` SDK-wide, and 31 files across 7 providers do the same. Google Calendar is not an outlier — this reproduces with the Hacker News tool, which needs no credentials.

**Verification.** Unit: `model_validate({…metadata: None})` fails with the 11 errors before and passes after. `test_tool_client.py` 2 passed, full `dify_plugin` layer suite 31 passed. End-to-end on self-hosted 1.16.0, Agent V2 + Hacker News tool, "What are the top stories on Hacker News right now?":

- **Before** — `get_top_stories` fails, the agent retries, it fails again, and it falls back to calling the HN API directly from its sandbox. The tool is broken but a user may never notice, because the agent silently routes around it.
- **After** — `get_top_stories` succeeds on the first call, no fallback needed.

Root `make lint` and `make type-check` both exit 0. Note that `dify-agent`'s own `make typecheck` reports 155 basedpyright errors, but these are pre-existing and environmental — the target omits the `server` extra, so fastapi/grpc/pydantic imports don't resolve. The changed file appears in zero of them, and reverting it to base yields the identical 155-error set, so this change adds none.

Worth flagging separately: both #26890 and #31450 had to be hand-re-derived into this second copy of the model, and the metadata one was missed. The duplication itself seems likely to keep producing this class of bug — but deduplicating the models is an architectural call, so I've kept this PR to restoring parity.

`From Claude Code`

## Screenshots

**Before**
two failed get_top_stories, then Ran commands / shell_wait

<img width="1280" height="1203" alt="3512-before" src="https://github.com/user-attachments/assets/8af5c23a-7701-4e64-9e50-8bf55abce684" />

---

**After**
one successful get_top_stories

<img width="1280" height="1203" alt="3512-after" src="https://github.com/user-attachments/assets/b11532f0-6918-4f82-bbc4-7914f3985899" />

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods