### PR TITLE
fix(web): stop chunk length/overlap inputs collapsing to an unusable width in narrow containers

### DIFF
--- a/web/app/components/datasets/create/step-two/components/__tests__/general-chunking-options.spec.tsx
+++ b/web/app/components/datasets/create/step-two/components/__tests__/general-chunking-options.spec.tsx
@@ -198,16 +198,29 @@ describe('GeneralChunkingOptions', () => {
     })
   })
 
-  // Regression: langgenius/dify#39592 — the delimiter/max-length/overlap row
-  // must be allowed to wrap so the number fields reflow instead of collapsing
-  // in a narrow card. Fails before the fix (row was a non-wrapping `flex`).
+  // Regression: dify issue 39592 — the delimiter/max-length/overlap row must
+  // stack (one field per row) in a narrow card and sit three-across when wide,
+  // driven by a container query rather than the viewport. Fails before this
+  // change (row was flex-wrap; no @container ancestor).
   describe('#39592 narrow-container regression', () => {
-    it('lets the three-field row wrap on container width', () => {
+    it('stacks by default and becomes a row across the 552px container query', () => {
       render(<GeneralChunkingOptions {...defaultProps} />)
       const delimiterLabel = screen.getByText(`${ns}.stepTwo.separator`)
       const row = delimiterLabel.closest('.gap-3')
       expect(row).not.toBeNull()
-      expect(row!.className).toContain('flex-wrap')
+      // stacked by default (below threshold)
+      expect(row!.className).toContain('flex-col')
+      // three-across at/above the container threshold
+      expect(row!.className).toContain('@min-[552px]/chunkfields:flex-row')
+      // the previous flex-wrap approach is gone
+      expect(row!.className).not.toContain('flex-wrap')
+    })
+
+    it('marks an ancestor as the query container', () => {
+      render(<GeneralChunkingOptions {...defaultProps} />)
+      const delimiterLabel = screen.getByText(`${ns}.stepTwo.separator`)
+      const container = delimiterLabel.closest('[class*="@container/chunkfields"]')
+      expect(container).not.toBeNull()
     })
   })
 })

--- a/web/app/components/datasets/create/step-two/components/__tests__/general-chunking-options.spec.tsx
+++ b/web/app/components/datasets/create/step-two/components/__tests__/general-chunking-options.spec.tsx
@@ -197,4 +197,17 @@ describe('GeneralChunkingOptions', () => {
       expect(onSummaryIndexSettingChange).toHaveBeenCalledWith({ enable: true })
     })
   })
+
+  // Regression: langgenius/dify#39592 — the delimiter/max-length/overlap row
+  // must be allowed to wrap so the number fields reflow instead of collapsing
+  // in a narrow card. Fails before the fix (row was a non-wrapping `flex`).
+  describe('#39592 narrow-container regression', () => {
+    it('lets the three-field row wrap on container width', () => {
+      render(<GeneralChunkingOptions {...defaultProps} />)
+      const delimiterLabel = screen.getByText(`${ns}.stepTwo.separator`)
+      const row = delimiterLabel.closest('.gap-3')
+      expect(row).not.toBeNull()
+      expect(row!.className).toContain('flex-wrap')
+    })
+  })
 })

--- a/web/app/components/datasets/create/step-two/components/__tests__/inputs.spec.tsx
+++ b/web/app/components/datasets/create/step-two/components/__tests__/inputs.spec.tsx
@@ -136,3 +136,32 @@ describe('OverlapInput', () => {
     expect(onChange).toHaveBeenLastCalledWith(100)
   })
 })
+
+// Regression: langgenius/dify#39592 — below ~1351px viewport (a ~440px card)
+// the number inputs collapsed to a 32px, unusable sliver. The input's own
+// min-width is the belt to the row's flex-wrap braces (the wrap lives on the
+// row in general-chunking-options). jsdom has no layout engine, so we cannot
+// assert pixel widths here; we assert the structural classes that prevent the
+// collapse. These fail before the fix and pass after.
+describe('#39592 narrow-container regression (structural)', () => {
+  it('gives the MaxLength input a min-width so it can never collapse to a sliver', () => {
+    render(<MaxLengthInput onChange={vi.fn()} />)
+    const input = screen.getByRole('textbox')
+    expect(input.className).toContain('min-w-[64px]')
+  })
+
+  it('gives the OverlapInput input a min-width too', () => {
+    render(<OverlapInput onChange={vi.fn()} />)
+    const input = screen.getByRole('textbox')
+    expect(input.className).toContain('min-w-[64px]')
+  })
+
+  it('gives each field a flex-basis (not flex-1) so the row can wrap on container width', () => {
+    render(<MaxLengthInput onChange={vi.fn()} />)
+    const field = screen.getByRole('textbox').closest('.space-y-2')
+    expect(field).not.toBeNull()
+    expect(field!.className).toContain('basis-[176px]')
+    // must not carry the old flex-1 that forced a single non-wrapping row
+    expect(field!.className).not.toContain('flex-1')
+  })
+})

--- a/web/app/components/datasets/create/step-two/components/__tests__/inputs.spec.tsx
+++ b/web/app/components/datasets/create/step-two/components/__tests__/inputs.spec.tsx
@@ -137,31 +137,37 @@ describe('OverlapInput', () => {
   })
 })
 
-// Regression: langgenius/dify#39592 — below ~1351px viewport (a ~440px card)
-// the number inputs collapsed to a 32px, unusable sliver. The input's own
-// min-width is the belt to the row's flex-wrap braces (the wrap lives on the
-// row in general-chunking-options). jsdom has no layout engine, so we cannot
-// assert pixel widths here; we assert the structural classes that prevent the
-// collapse. These fail before the fix and pass after.
+// Regression: dify issue 39592 — in a narrow card the number inputs collapsed
+// to a 32px, unusable sliver. The fix reflows on the container (a
+// @container/chunkfields ancestor, see general-chunking-options): below 552px
+// each field stacks and is capped at max-w-[288px] so the input reads as a form
+// field; at/above 552px it restores flex-1 (three across, pixel-identical to
+// stock). The input keeps a min-width floor as the belt against re-collapse.
+// jsdom has no layout engine, so we cannot assert pixel widths — we assert the
+// structural classes. These fail before this change and pass after.
 describe('#39592 narrow-container regression (structural)', () => {
-  it('gives the MaxLength input a min-width so it can never collapse to a sliver', () => {
+  it('gives the MaxLength input a min-width floor so it can never collapse to a sliver', () => {
     render(<MaxLengthInput onChange={vi.fn()} />)
     const input = screen.getByRole('textbox')
     expect(input.className).toContain('min-w-[64px]')
   })
 
-  it('gives the OverlapInput input a min-width too', () => {
+  it('gives the OverlapInput input a min-width floor too', () => {
     render(<OverlapInput onChange={vi.fn()} />)
     const input = screen.getByRole('textbox')
     expect(input.className).toContain('min-w-[64px]')
   })
 
-  it('gives each field a flex-basis (not flex-1) so the row can wrap on container width', () => {
+  it('caps each field width when stacked and restores flex-1 across the 552px container query', () => {
     render(<MaxLengthInput onChange={vi.fn()} />)
     const field = screen.getByRole('textbox').closest('.space-y-2')
     expect(field).not.toBeNull()
-    expect(field!.className).toContain('basis-[176px]')
-    // must not carry the old flex-1 that forced a single non-wrapping row
-    expect(field!.className).not.toContain('flex-1')
+    // stacked (default / below threshold): constrained width, no stretch
+    expect(field!.className).toContain('max-w-[288px]')
+    // three-across (at/above threshold): restore flex-1 and drop the cap
+    expect(field!.className).toContain('@min-[552px]/chunkfields:flex-1')
+    expect(field!.className).toContain('@min-[552px]/chunkfields:max-w-none')
+    // the previous flex-wrap approach is gone
+    expect(field!.className).not.toContain('basis-[176px]')
   })
 })

--- a/web/app/components/datasets/create/step-two/components/general-chunking-options.tsx
+++ b/web/app/components/datasets/create/step-two/components/general-chunking-options.tsx
@@ -128,7 +128,7 @@ export const GeneralChunkingOptions: FC<GeneralChunkingOptionsProps> = ({
       noHighlight={isInUpload && isNotUploadInEmptyDataset}
     >
       <div className="flex flex-col gap-y-4">
-        <div className="flex gap-3">
+        <div className="flex flex-wrap gap-3">
           <DelimiterInput
             value={segmentIdentifier}
             onChange={(e) => onSegmentIdentifierChange(e.target.value)}

--- a/web/app/components/datasets/create/step-two/components/general-chunking-options.tsx
+++ b/web/app/components/datasets/create/step-two/components/general-chunking-options.tsx
@@ -127,8 +127,10 @@ export const GeneralChunkingOptions: FC<GeneralChunkingOptionsProps> = ({
       }
       noHighlight={isInUpload && isNotUploadInEmptyDataset}
     >
-      <div className="flex flex-col gap-y-4">
-        <div className="flex flex-wrap gap-3">
+      <div className="@container/chunkfields flex flex-col gap-y-4">
+        {/* Container query, not a viewport breakpoint: three across at/above a
+            552px container, stacked one-per-row below (see inputs.tsx FormField). */}
+        <div className="flex flex-col gap-3 @min-[552px]/chunkfields:flex-row">
           <DelimiterInput
             value={segmentIdentifier}
             onChange={(e) => onSegmentIdentifierChange(e.target.value)}

--- a/web/app/components/datasets/create/step-two/components/inputs.tsx
+++ b/web/app/components/datasets/create/step-two/components/inputs.tsx
@@ -5,6 +5,7 @@ import type {
 } from '@langgenius/dify-ui/number-field'
 import type { FC, PropsWithChildren, ReactNode } from 'react'
 import type { InputProps } from '@/app/components/base/input'
+import { cn } from '@langgenius/dify-ui/cn'
 import {
   NumberField,
   NumberFieldControls,
@@ -30,7 +31,11 @@ const TextLabel: FC<PropsWithChildren> = (props) => {
 
 const FormField: FC<PropsWithChildren<{ label: ReactNode }>> = (props) => {
   return (
-    <div className="flex-1 space-y-2">
+    // grow + a 176px basis (not flex-1) so the row can wrap on real container
+    // width, not a viewport breakpoint: three columns fit down to ~552px, then
+    // reflow to two, then one. When three fit, equal basis + equal grow resolve
+    // to the same widths as the previous flex-1, so the wide layout is unchanged.
+    <div className="grow basis-[176px] space-y-2">
       <TextLabel>{props.label}</TextLabel>
       {props.children}
     </div>
@@ -142,7 +147,10 @@ function CompoundNumberInput({
           {...inputProps}
           aria-label={label}
           size={size}
-          className={className}
+          // min-w-[64px] overrides the component's default min-w-0 so the input
+          // can never collapse to an unusable sliver, even in an unforeseen
+          // container; belt to the row's flex-wrap braces.
+          className={cn('min-w-[64px]', className)}
           onBlur={onBlur}
         />
         {Boolean(unit) && <NumberFieldUnit size={size}>{unit}</NumberFieldUnit>}

--- a/web/app/components/datasets/create/step-two/components/inputs.tsx
+++ b/web/app/components/datasets/create/step-two/components/inputs.tsx
@@ -31,11 +31,12 @@ const TextLabel: FC<PropsWithChildren> = (props) => {
 
 const FormField: FC<PropsWithChildren<{ label: ReactNode }>> = (props) => {
   return (
-    // grow + a 176px basis (not flex-1) so the row can wrap on real container
-    // width, not a viewport breakpoint: three columns fit down to ~552px, then
-    // reflow to two, then one. When three fit, equal basis + equal grow resolve
-    // to the same widths as the previous flex-1, so the wide layout is unchanged.
-    <div className="grow basis-[176px] space-y-2">
+    // Reflow on the container (a @container/chunkfields ancestor), not the
+    // viewport. Below 552px the fields stack one per row, each capped at
+    // max-w-[288px] so the input reads as a form field, not a full-bleed bar.
+    // At/above 552px this restores flex-1 with no cap, so three columns resolve
+    // to (container - gaps)/3 — pixel-identical to the stock flex-1 layout.
+    <div className="max-w-[288px] space-y-2 @min-[552px]/chunkfields:max-w-none @min-[552px]/chunkfields:flex-1">
       <TextLabel>{props.label}</TextLabel>
       {props.children}
     </div>


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #39592.

In Knowledge → Create Knowledge Base → Text Segmentation & Cleaning → General, the "Maximum chunk length" and "Chunk overlap" inputs become completely unusable below a certain window width — no cursor on click, no typing, and the value doesn't render.

**This is not Cloud-specific.** It reproduces on stock self-hosted 1.16.0 (Docker), so the `cloud` label on the issue is misleading.

**Diagnosis.** The inputs are not `disabled` or `readonly`, `pointer-events` is `auto`, and nothing overlaps them — `elementFromPoint` at the field's centre returns the input itself. Measured at a 1280px viewport:

```
{"w":32,"h":36,"x":401.92,"y":228.5}
class="w-0 min-w-0 flex-1 …"  value="4,000"  placeholder="≤ 4000"
```

**The input is 32px wide.** Three `flex-1` columns in a ~440px card leave ~139px each; after the `characters` unit (~68px), the increment/decrement controls (~20px) and padding, ~32px remains. `w-0 min-w-0` lets the input take it. The value and placeholder are present — there's simply no room to render or click them. It reads as "unclickable" because most of the visible field box is the unit label, which isn't focusable.

**The fix.** A container query — the constraint is the container's width, not the viewport, so a media query would be wrong the moment the preview pane or sidebar changes. Above a 552px container the row is three across, unchanged; below it the three fields stack one per row, each capped at `max-w-[288px]` so they read as form fields rather than full-bleed bars. The input also gets `min-w-[64px]` so it can never collapse again in a container nobody anticipated.

Tailwind v4 container queries are already used in this repo (`@container/banner` in `explore/banner/`), so this follows existing precedent rather than introducing a pattern.

**The wide layout is provably unchanged** — new vs stock input width at four container sizes: 274px@1152, 144@760, 90@600, 74@552. Identical at every one; `@min-[552px]/chunkfields:flex-1` restores exactly `(container − gaps)/3`.

Three structural regression tests fail on the old source and pass after; 39 pass total. Lint: zero new findings against the pristine baseline.

The stacking behaviour is a layout choice rather than strictly part of the defect — happy to reduce this to just the `min-w-[64px]` floor if you'd prefer the smaller change, though at these container widths one row can only fit three fields by truncating the `characters` unit.

`From Claude Code`

## Screenshots

**Before**
Both fields empty and untypeable at 1280px

https://github.com/user-attachments/assets/dc56fab4-8231-4494-b674-20eea96d1d08

All fields focusable and typeable at 1440px

https://github.com/user-attachments/assets/ed26108d-e26c-42e6-8443-4ea7bac7c440

---

**After**
Three stacked fields, values visible and typeable at 1280px

https://github.com/user-attachments/assets/d2b05a88-476b-48b6-b745-403031c95484

Three unstacked fields, values visible and typeable at 1440px

https://github.com/user-attachments/assets/e05b2fcf-d6da-4fdd-94df-16750d602e30

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods