### PR TITLE
fix(api): allow empty tools selector after agent tools are removed

### DIFF
--- a/api/core/plugin/entities/parameters.py
+++ b/api/core/plugin/entities/parameters.py
@@ -202,7 +202,9 @@ def init_frontend_parameter(rule: PluginParameter, type: StrEnum, value: Any):
     init frontend parameter by rule
     """
     parameter_value = value
-    if not parameter_value and parameter_value != 0:
+    # Empty list is a valid tools selector value (e.g. all tools removed from an agent).
+    # Skip the missing-value check so required tools params do not raise on [].
+    if not parameter_value and parameter_value != 0 and type != PluginParameterType.TOOLS_SELECTOR:
         # get default value
         parameter_value = rule.default
         if not parameter_value and rule.required:

--- a/api/tests/unit_tests/core/plugin/test_plugin_entities.py
+++ b/api/tests/unit_tests/core/plugin/test_plugin_entities.py
@@ -265,6 +265,13 @@ class TestPluginParameterEntities:
         with pytest.raises(ValueError, match="not found in tool config"):
             init_frontend_parameter(required_rule, PluginParameterType.STRING, None)
 
+    def test_init_frontend_parameter_allows_empty_tools_selector(self):
+        """Empty tools list is valid after all tools are removed from an agent node."""
+        tools_rule = PluginParameter(name="tools", label=self._label(), required=True, default=None)
+
+        assert init_frontend_parameter(tools_rule, PluginParameterType.TOOLS_SELECTOR, []) == []
+        assert init_frontend_parameter(tools_rule, PluginParameterType.TOOLS_SELECTOR, None) is None
+
 
 class TestPluginDaemonEntities:
     def test_credential_type_helpers(self):


### PR DESCRIPTION
## Summary
- Restores `TOOLS_SELECTOR` empty-list handling in `init_frontend_parameter` so an agent node can run after all tools are deleted (empty `[]` is no longer treated as a missing required param).
- Adds a regression test covering empty/`None` tools selector values.
- Fixes #39612 (regression of #15829 lost during a later refactor).

## Test plan
- [x] `make test TARGET_TESTS=./api/tests/unit_tests/core/plugin/test_plugin_entities.py` (58 passed)
- [ ] Create workflow: start → agent → end, add a code tool, run successfully
- [ ] Delete the tool from the agent node and run again — should succeed without `tool parameter tools not found in tool config`


Made with [Cursor](https://cursor.com)