### PR TITLE
fix(web): stop reporting workspace status

### DIFF
--- a/web/context/__tests__/console-bootstrap.spec.tsx
+++ b/web/context/__tests__/console-bootstrap.spec.tsx
@@ -552,7 +552,8 @@ describe('Console bootstrap', () => {
       })
       await waitFor(() => {
         expect(setUserId).toHaveBeenCalledWith('user@example.com')
-        expect(setUserProperties).toHaveBeenCalledWith(
+        const properties = vi.mocked(setUserProperties).mock.calls.at(-1)?.[0]
+        expect(properties).toEqual(
           expect.objectContaining({
             email: 'user@example.com',
             workspace_id: 'workspace-1',
@@ -560,6 +561,7 @@ describe('Console bootstrap', () => {
             workspace_role: 'editor',
           }),
         )
+        expect(properties).not.toHaveProperty('workspace_status')
         expect(flushRegistrationSuccess).toHaveBeenCalled()
       })
     })

--- a/web/context/amplitude-identity-sync.ts
+++ b/web/context/amplitude-identity-sync.ts
@@ -30,7 +30,6 @@ function buildAmplitudeProperties({
     properties.workspace_id = currentWorkspace.id
     properties.workspace_name = currentWorkspace.name
     properties.workspace_plan = currentWorkspace.plan
-    properties.workspace_status = currentWorkspace.status
     properties.workspace_role = currentWorkspace.role
   }
 


### PR DESCRIPTION
## Summary

- stop sending the redundant `workspace_status` Amplitude user property
- keep `workspace_id`, `workspace_name`, `workspace_plan`, and `workspace_role` unchanged
- assert at the console bootstrap boundary that identity synchronization omits `workspace_status`

## Why

This is a narrow follow-up to #39616. The current-workspace flow only exposes an accessible workspace and redirects or rejects archived workspaces, so `workspace_status` is effectively always `normal` in Cloud analytics and does not provide a meaningful segmentation dimension.

The change only affects future Identify updates. Existing historical events and user-profile values are intentionally left untouched.

## Validation

- `pnpm exec vp test run context/__tests__/console-bootstrap.spec.tsx` — 10 tests passed
- `pnpm exec vp check context/amplitude-identity-sync.ts context/__tests__/console-bootstrap.spec.tsx` — formatting, lint, and scoped type checks passed
- `pnpm lint:tss -- --force` — 6003 checks passed
- `git diff --check`