### PR TITLE
fix: prevent empty tenant_id on upload_files INSERT via variable offloading

### DIFF
--- a/api/services/file_service.py
+++ b/api/services/file_service.py
@@ -86,15 +86,17 @@ class FileService:
         file_uuid = str(uuid.uuid4())
 
         resource_tenant_id = tenant_id if tenant_id is not None else extract_tenant_id(user)
+        if not resource_tenant_id:
+            raise ValueError("tenant_id cannot be empty")
 
-        file_key = "upload_files/" + (resource_tenant_id or "") + "/" + file_uuid + "." + extension
+        file_key = "upload_files/" + resource_tenant_id + "/" + file_uuid + "." + extension
 
         # save file to storage
         storage.save(file_key, content)
 
         # save file to db
         upload_file = UploadFile(
-            tenant_id=resource_tenant_id or "",
+            tenant_id=resource_tenant_id,
             storage_type=StorageType(dify_config.STORAGE_TYPE),
             key=file_key,
             name=filename,

--- a/api/services/workflow_draft_variable_service.py
+++ b/api/services/workflow_draft_variable_service.py
@@ -1091,13 +1091,15 @@ class DraftVariableSaver:
         assert isinstance(bind, Engine)
         file_srv = FileService(bind)
 
+        tenant_id = self._resolve_app_tenant_id()
+
         upload_file = file_srv.upload_file(
             filename=filename,
             content=original_content_serialized.encode(),
             mimetype=content_type,
             user=self._user,
+            tenant_id=tenant_id,
         )
-        assert self._user.current_tenant_id
         # Create WorkflowDraftVariableFile record
         variable_file = WorkflowDraftVariableFile(
             upload_file_id=upload_file.id,
@@ -1105,7 +1107,7 @@ class DraftVariableSaver:
             length=original_length,
             value_type=value_seg.value_type,
             app_id=self._app_id,
-            tenant_id=self._user.current_tenant_id,
+            tenant_id=tenant_id,
             user_id=self._user.id,
         )
         variable_file.id = str(uuidv7())


### PR DESCRIPTION
Description:
## Summary
Closes #39627

Fixes an issue where workflow variable offloading creates `upload_files` records
with an empty `tenant_id`, causing a PostgreSQL UUID cast error.

## Root Cause

`DraftVariableSaver._try_offload_large_variable()` calls `FileService.upload_file()`
without passing `tenant_id`. In the streaming (Celery task) execution path,
`user._current_tenant` is not loaded, so `extract_tenant_id(user)` returns `None`,
and the `or ""` fallback in `file_service.py` produces an empty string that
PostgreSQL rejects when casting to UUID.

## Changes

1. **`api/services/workflow_draft_variable_service.py`**: Use the existing
   `_resolve_app_tenant_id()` method to resolve `tenant_id` from the app and pass
   it explicitly to both `FileService.upload_file()` and `WorkflowDraftVariableFile`.

2. **`api/services/file_service.py`**: Replace the silent `resource_tenant_id or ""`
   fallback with an explicit `ValueError` when `tenant_id` cannot be determined.

## How to Test

1. Create a workflow with a document-extractor node
2. Upload a PDF whose extracted text exceeds `WORKFLOW_VARIABLE_TRUNCATION_STRING_LENGTH` (100,000 characters)
3. Run the workflow and verify the variable offloading completes successfully