### PR TITLE
fix(workflow): lazy-load Loro collaboration runtime

### DIFF
--- a/web/app/components/workflow/collaboration/core/__tests__/collaboration-manager.logs-and-events.spec.ts
+++ b/web/app/components/workflow/collaboration/core/__tests__/collaboration-manager.logs-and-events.spec.ts
@@ -6,6 +6,7 @@ import { LoroDoc } from 'loro-crdt'
 import { BlockEnum } from '@/app/components/workflow/types'
 import { CollaborationManager } from '../collaboration-manager'
 import { webSocketClient } from '../websocket-manager'
+import { attachCrdtRuntime } from './test-crdt-runtime'
 
 type ReactFlowStore = {
   getState: () => {
@@ -70,6 +71,7 @@ const createEdge = (id: string, source: string, target: string): Edge => ({
 
 const setupManagerWithDoc = () => {
   const manager = new CollaborationManager()
+  attachCrdtRuntime(manager)
   const doc = new LoroDoc()
   const internals = getManagerInternals(manager)
   internals.doc = doc

--- a/web/app/components/workflow/collaboration/core/__tests__/collaboration-manager.merge-behavior.test.ts
+++ b/web/app/components/workflow/collaboration/core/__tests__/collaboration-manager.merge-behavior.test.ts
@@ -3,6 +3,7 @@ import type { Node } from '@/app/components/workflow/types'
 import { LoroDoc } from 'loro-crdt/base64'
 import { BlockEnum } from '@/app/components/workflow/types'
 import { CollaborationManager } from '../collaboration-manager'
+import { attachCrdtRuntime } from './test-crdt-runtime'
 
 const NODE_ID = 'node-1'
 const LLM_NODE_ID = 'llm-node'
@@ -163,6 +164,7 @@ const getManagerInternals = (manager: CollaborationManager): CollaborationManage
 
 const getManager = (doc: LoroDoc) => {
   const manager = new CollaborationManager()
+  attachCrdtRuntime(manager)
   const internals = getManagerInternals(manager)
   internals.doc = doc
   internals.nodesMap = doc.getMap('nodes')

--- a/web/app/components/workflow/collaboration/core/__tests__/collaboration-manager.runtime-loading.spec.ts
+++ b/web/app/components/workflow/collaboration/core/__tests__/collaboration-manager.runtime-loading.spec.ts
@@ -1,0 +1,88 @@
+import type { Socket } from 'socket.io-client'
+
+const loroModuleState = vi.hoisted(() => ({ evaluations: 0 }))
+
+vi.mock('loro-crdt', async (importOriginal) => {
+  loroModuleState.evaluations += 1
+  return importOriginal()
+})
+
+const createMockSocket = (): Socket =>
+  ({
+    id: 'socket-runtime-loading',
+    connected: true,
+    emit: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  }) as unknown as Socket
+
+const loadCollaborationModules = async () => {
+  const [{ CollaborationManager }, { webSocketClient }] = await Promise.all([
+    import('../collaboration-manager'),
+    import('../websocket-manager'),
+  ])
+
+  return { CollaborationManager, webSocketClient }
+}
+
+describe('CollaborationManager CRDT runtime loading', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+    loroModuleState.evaluations = 0
+  })
+
+  it('does not evaluate Loro when the manager module is loaded', async () => {
+    const { CollaborationManager } = await loadCollaborationModules()
+    const manager = new CollaborationManager()
+
+    expect(loroModuleState.evaluations).toBe(0)
+    expect(manager.isConnected()).toBe(false)
+  })
+
+  it('does not create connection state when the runtime fails to load', async () => {
+    const { CollaborationManager, webSocketClient } = await loadCollaborationModules()
+    const manager = new CollaborationManager()
+    const runtimeError = new Error('runtime-load-failed')
+    const loadRuntimeSpy = vi
+      .spyOn(
+        manager as unknown as {
+          loadCrdtRuntime: () => Promise<(typeof import('../crdt-runtime'))['crdtRuntime']>
+        },
+        'loadCrdtRuntime',
+      )
+      .mockRejectedValue(runtimeError)
+    const connectSpy = vi.spyOn(webSocketClient, 'connect')
+
+    await expect(manager.connect('app-runtime-failure')).rejects.toBe(runtimeError)
+
+    expect(loadRuntimeSpy).toHaveBeenCalledTimes(1)
+    expect(connectSpy).not.toHaveBeenCalled()
+    expect(manager.isConnected()).toBe(false)
+  })
+
+  it('initializes one session for concurrent consumers of the same app', async () => {
+    const { CollaborationManager, webSocketClient } = await loadCollaborationModules()
+    const manager = new CollaborationManager()
+    const socket = createMockSocket()
+    const connectSpy = vi.spyOn(webSocketClient, 'connect').mockReturnValue(socket)
+    const disconnectSpy = vi
+      .spyOn(webSocketClient, 'disconnect')
+      .mockImplementation(() => undefined)
+
+    const [firstConnectionId, secondConnectionId] = await Promise.all([
+      manager.connect('app-concurrent'),
+      manager.connect('app-concurrent'),
+    ])
+
+    expect(firstConnectionId).not.toBe(secondConnectionId)
+    expect(connectSpy).toHaveBeenCalledTimes(1)
+    expect(loroModuleState.evaluations).toBe(1)
+
+    manager.disconnect(firstConnectionId)
+    expect(disconnectSpy).not.toHaveBeenCalled()
+
+    manager.disconnect(secondConnectionId)
+    expect(disconnectSpy).toHaveBeenCalledWith('app-concurrent')
+  })
+})

--- a/web/app/components/workflow/collaboration/core/__tests__/collaboration-manager.socket-and-subscriptions.spec.ts
+++ b/web/app/components/workflow/collaboration/core/__tests__/collaboration-manager.socket-and-subscriptions.spec.ts
@@ -13,6 +13,7 @@ import { LoroDoc, LoroMap } from 'loro-crdt'
 import { BlockEnum } from '@/app/components/workflow/types'
 import { CollaborationManager } from '../collaboration-manager'
 import { webSocketClient } from '../websocket-manager'
+import { attachCrdtRuntime } from './test-crdt-runtime'
 
 type ReactFlowStore = {
   getState: () => {
@@ -147,6 +148,7 @@ const createMockSocket = (id = 'socket-1'): MockSocket => {
 
 const setupManagerWithDoc = () => {
   const manager = new CollaborationManager()
+  attachCrdtRuntime(manager)
   const doc = new LoroDoc()
   const internals = getManagerInternals(manager)
   internals.doc = doc
@@ -1371,6 +1373,7 @@ describe('CollaborationManager socket and subscription behavior', () => {
 
   it('covers private guard branches for socket helpers and container migration', async () => {
     const manager = new CollaborationManager()
+    attachCrdtRuntime(manager)
     const internals = getManagerInternals(manager)
     const socket = createMockSocket('socket-private')
     const getSocketSpy = vi.spyOn(webSocketClient, 'getSocket').mockReturnValue(null)

--- a/web/app/components/workflow/collaboration/core/__tests__/collaboration-manager.test.ts
+++ b/web/app/components/workflow/collaboration/core/__tests__/collaboration-manager.test.ts
@@ -8,6 +8,7 @@ import { LoroDoc } from 'loro-crdt/base64'
 import { Position } from 'reactflow'
 import { CollaborationManager } from '@/app/components/workflow/collaboration/core/collaboration-manager'
 import { BlockEnum } from '@/app/components/workflow/types'
+import { attachCrdtRuntime } from './test-crdt-runtime'
 
 const NODE_ID = '1760342909316'
 
@@ -247,6 +248,7 @@ const setupManager = (): {
   internals: CollaborationManagerInternals
 } => {
   const manager = new CollaborationManager()
+  attachCrdtRuntime(manager)
   const doc = new LoroDoc()
   const internals = getManagerInternals(manager)
   internals.doc = doc

--- a/web/app/components/workflow/collaboration/core/__tests__/test-crdt-runtime.ts
+++ b/web/app/components/workflow/collaboration/core/__tests__/test-crdt-runtime.ts
@@ -1,0 +1,7 @@
+import type { CollaborationManager } from '../collaboration-manager'
+import { crdtRuntime } from '../crdt-runtime'
+
+export const attachCrdtRuntime = (manager: CollaborationManager): void => {
+  const internals = manager as unknown as { crdtRuntime: typeof crdtRuntime }
+  internals.crdtRuntime = crdtRuntime
+}

--- a/web/app/components/workflow/collaboration/core/collaboration-manager.ts
+++ b/web/app/components/workflow/collaboration/core/collaboration-manager.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import type { Value } from 'loro-crdt'
+import type { LoroDoc, LoroList, LoroMap, UndoManager, Value } from 'loro-crdt'
 import type { Socket } from 'socket.io-client'
 import type { CommonNodeType, Edge, Node } from '../../types'
 import type {
@@ -17,12 +17,13 @@ import type {
   WorkflowSyncRequest,
   WorkflowSyncResult,
 } from '../types/collaboration'
+import type { CRDTProvider } from './crdt-provider'
 import { cloneDeep } from 'es-toolkit/object'
 import { isEqual } from 'es-toolkit/predicate'
-import { LoroDoc, LoroList, LoroMap, UndoManager } from 'loro-crdt'
-import { CRDTProvider } from './crdt-provider'
 import { EventEmitter } from './event-emitter'
 import { emitWithAuthGuard, webSocketClient } from './websocket-manager'
+
+type CrdtRuntime = (typeof import('./crdt-runtime'))['crdtRuntime']
 
 type NodePanelPresenceEventData = {
   nodeId: string
@@ -154,6 +155,7 @@ const toUint8Array = (value: unknown): Uint8Array | null => {
 }
 
 export class CollaborationManager {
+  private crdtRuntime: CrdtRuntime | null = null
   private doc: LoroDoc | null = null
   private undoManager: UndoManager | null = null
   private provider: CRDTProvider | null = null
@@ -259,6 +261,8 @@ export class CollaborationManager {
   private getNodeContainer(nodeId: string): LoroMap<Record<string, Value>> {
     if (!this.nodesMap) throw new Error('Nodes map not initialized')
 
+    const { LoroMap } = this.getCrdtRuntime()
+
     let container = this.nodesMap.get(nodeId) as unknown
 
     const isMapContainer = (
@@ -292,6 +296,7 @@ export class CollaborationManager {
   private ensureDataContainer(
     nodeContainer: LoroMap<Record<string, Value>>,
   ): LoroMap<Record<string, Value>> {
+    const { LoroMap } = this.getCrdtRuntime()
     let dataContainer = nodeContainer.get('data') as unknown
 
     if (
@@ -309,6 +314,7 @@ export class CollaborationManager {
     nodeContainer: LoroMap<Record<string, Value>>,
     key: string,
   ): LoroList<unknown> {
+    const { LoroList } = this.getCrdtRuntime()
     const dataContainer = this.ensureDataContainer(nodeContainer)
     let list = dataContainer.get(key) as unknown
 
@@ -527,7 +533,18 @@ export class CollaborationManager {
     this.disconnect()
   }
 
+  private async loadCrdtRuntime(): Promise<CrdtRuntime> {
+    const { crdtRuntime } = await import('./crdt-runtime')
+    return crdtRuntime
+  }
+
+  private getCrdtRuntime(): CrdtRuntime {
+    if (!this.crdtRuntime) throw new Error('CRDT runtime not initialized')
+    return this.crdtRuntime
+  }
+
   private initializeCrdt(socket: Socket): void {
+    const { CRDTProvider, LoroDoc, UndoManager } = this.getCrdtRuntime()
     this.provider?.destroy()
     this.undoManager = null
     this.doc = new LoroDoc()
@@ -622,6 +639,8 @@ export class CollaborationManager {
   }
 
   async connect(appId: string, reactFlowStore?: ReactFlowStore): Promise<string> {
+    this.crdtRuntime ??= await this.loadCrdtRuntime()
+
     const connectionId = Math.random().toString(36).substring(2, 11)
 
     this.activeConnections.add(connectionId)

--- a/web/app/components/workflow/collaboration/core/crdt-runtime.ts
+++ b/web/app/components/workflow/collaboration/core/crdt-runtime.ts
@@ -1,0 +1,21 @@
+'use client'
+
+import { LoroDoc, LoroList, LoroMap, UndoManager } from 'loro-crdt'
+import { CRDTProvider } from './crdt-provider'
+
+/**
+ * Production code must load this module only through CollaborationManager.connect().
+ * Importing either Loro or CRDTProvider from the manager would evaluate Loro's browser WASM
+ * loader on pages that only reference the manager. CRDTProvider belongs here because it also
+ * imports loro-crdt at runtime.
+ *
+ * TODO: Move graph sync, snapshots, and undo/redo behind an opaque CrdtGraphRuntime interface
+ * so CollaborationManager no longer depends on Loro constructors or types.
+ */
+export const crdtRuntime = {
+  CRDTProvider,
+  LoroDoc,
+  LoroList,
+  LoroMap,
+  UndoManager,
+}


### PR DESCRIPTION
## Summary

- move all Loro runtime values and `CRDTProvider` behind a dedicated lazy CRDT runtime boundary
- load and cache that runtime before `CollaborationManager.connect()` creates any connection state or socket
- add regression coverage for manager-only imports, runtime load failures, and concurrent same-app consumers
- keep existing internal CRDT fixtures explicit without changing their behavior assertions

## Why

Importing `collaboration-manager` previously evaluated both `loro-crdt` and `CRDTProvider`. The browser entry of Loro 1.13.7 synchronously fetches and compiles its WASM during module evaluation, so pages that only referenced the manager could pay the Loro/WASM cost even when collaboration was disabled.

This change makes `connect()` the runtime activation boundary. Pages may still reference the existing manager APIs, but they do not evaluate Loro or request its WASM unless collaboration is enabled and a connection is actually started.

The runtime import happens before connection IDs, app state, or sockets are created, so a failed dynamic import leaves no partial collaboration session. The loaded runtime is cached on the manager and reused for reconnects.

## Scope

This PR fixes premature Loro loading on Home, TryApp, non-workflow pages, and workflows with collaboration disabled. It does not change collaboration ownership or behavior, and it does not replace Loro's synchronous browser WASM loader after collaboration is activated.

## Bundle verification

A production Next.js build succeeds. The Loro browser loader and WASM reference are isolated in a 75,419-byte dynamic chunk, and that chunk is absent from client route manifests.

## Screenshots

Not applicable; there are no UI changes.

## Checks

- `pnpm exec vp check --fix <8 changed files>`
- `pnpm exec vp test run app/components/workflow/collaboration/core/__tests__ app/components/workflow/collaboration/hooks/__tests__/use-collaboration.spec.ts app/components/workflow-app/components/__tests__/workflow-main.spec.tsx` (10 files, 102 tests)
- `pnpm lint:tss` (6006 passed)
- `pnpm check` (0 errors; existing repository warnings remain)
- `pnpm build`
- `git diff --check`
- independent full-diff review: no issues found

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran the relevant frontend checks and tests.

From Codex