### PR TITLE
perf(web): lazy-load Home creation modals

### DIFF
--- a/web/app/components/explore/app-list/index.tsx
+++ b/web/app/components/explore/app-list/index.tsx
@@ -15,10 +15,8 @@ import { useQueryState } from 'nuqs'
 import * as React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import DSLConfirmModal from '@/app/components/app/create-from-dsl-modal/dsl-confirm-modal'
 import AppCard from '@/app/components/explore/app-card'
 import { Banner } from '@/app/components/explore/banner/banner'
-import CreateAppModal from '@/app/components/explore/create-app-modal'
 import {
   getStepByStepTourPermissionVariant,
   trackStepByStepTourEvent,
@@ -50,6 +48,11 @@ import { ExploreHomeSkeleton } from './loading-skeletons'
 import s from './style.module.css'
 
 const TryApp = dynamic(() => import('../try-app'), { ssr: false })
+const CreateAppModal = dynamic(() => import('../create-app-modal'), { ssr: false })
+const DSLConfirmModal = dynamic(
+  () => import('@/app/components/app/create-from-dsl-modal/dsl-confirm-modal'),
+  { ssr: false },
+)
 
 type ExploreAppListData = {
   categories: string[]


### PR DESCRIPTION
## Summary

- lazy-load the Home app creation modal
- lazy-load the DSL version confirmation modal
- preserve the existing Home creation state and user flows

## Why

Both modals are optional surfaces rendered only after the user enters an app creation flow, but static imports pulled them into the Home route's eager module graph.

## Validation

- `vp test run app/components/explore/app-list/__tests__/index.spec.tsx` (35 tests)
- `vp check web/app/components/explore/app-list/index.tsx`
- `pnpm check`
- `pnpm build`

Fixes SNP-583