### PR TITLE
fix: gate service API, MCP and trigger surfaces on enterprise license

### DIFF
--- a/api/app_factory.py
+++ b/api/app_factory.py
@@ -1,10 +1,13 @@
 import logging
 import time
+from collections.abc import Callable
+from typing import NamedTuple
 
 import socketio
 from flask import request
 from opentelemetry.trace import get_current_span
 from opentelemetry.trace.span import INVALID_SPAN_ID, INVALID_TRACE_ID
+from werkzeug.exceptions import Forbidden, HTTPException, ServiceUnavailable
 
 from configs import dify_config
 from contexts.wrapper import RecyclableContextVar
@@ -42,6 +45,65 @@ _CONSOLE_EXEMPT_PREFIXES = (
     "/console/api/activate/check",
 )
 
+_WEBAPP_EXEMPT_PREFIXES = ("/api/system-features",)
+
+_INVALID_LICENSE_STATUSES = (LicenseStatus.INACTIVE, LicenseStatus.EXPIRED, LicenseStatus.LOST)
+
+# How long a webhook sender is told to wait before retrying. Long enough that a blocked
+# provider backs off rather than burning its retry budget while an admin renews the license.
+_LICENSE_RETRY_AFTER_SECONDS = 300
+
+
+def _session_surface_error(license_status: LicenseStatus | None) -> HTTPException:
+    """Console and webapp authenticate with cookies, so drop the browser session."""
+    if license_status is None:
+        return UnauthorizedAndForceLogout("Unable to verify enterprise license. Please contact your administrator.")
+    return UnauthorizedAndForceLogout(f"Enterprise license is {license_status}. Please contact your administrator.")
+
+
+def _bearer_surface_error(license_status: LicenseStatus | None) -> HTTPException:
+    """Service API authenticates with bearer tokens: forcing a logout is meaningless and
+    license state must not leak to external callers. Mirrors services.openapi.license_gate.
+    """
+    return Forbidden(description="license_required")
+
+
+def _retryable_surface_error(license_status: LicenseStatus | None) -> HTTPException:
+    """Inbound webhooks have no Dify-side replay, and their sender is a machine rather than
+    a person who could renew the license. Senders retry on 5xx but treat 4xx as permanent —
+    often disabling the subscription — so refuse in a way that survives a later renewal.
+    """
+    return ServiceUnavailable(description="license_required", retry_after=_LICENSE_RETRY_AFTER_SECONDS)
+
+
+class _LicenseGatedSurface(NamedTuple):
+    prefix: str
+    exempt_prefixes: tuple[str, ...]
+    build_error: Callable[[LicenseStatus | None], HTTPException]
+
+
+# Surfaces blocked while the enterprise license is invalid. Console and webapp exempt the
+# bootstrap endpoints their sign-in pages need; the app-invocation surfaces have no sign-in
+# page to bootstrap, so they are gated whole. Health probes live on /health, and the
+# dify-enterprise control plane on /inner/api, both outside every prefix here.
+_LICENSE_GATED_SURFACES = (
+    _LicenseGatedSurface("/console/api/", _CONSOLE_EXEMPT_PREFIXES, _session_surface_error),
+    _LicenseGatedSurface("/api/", _WEBAPP_EXEMPT_PREFIXES, _session_surface_error),
+    _LicenseGatedSurface("/v1", (), _bearer_surface_error),
+    _LicenseGatedSurface("/mcp", (), _bearer_surface_error),
+    _LicenseGatedSurface("/triggers", (), _retryable_surface_error),
+)
+
+
+def _match_license_gated_surface(path: str) -> _LicenseGatedSurface | None:
+    for surface in _LICENSE_GATED_SURFACES:
+        if not path.startswith(surface.prefix):
+            continue
+        if any(path.startswith(exempt) for exempt in surface.exempt_prefixes):
+            return None
+        return surface
+    return None
+
 
 # ----------------------------
 # Application Factory Function
@@ -62,38 +124,20 @@ def create_flask_app_with_configs() -> DifyApp:
         init_request_context()
         RecyclableContextVar.increment_thread_recycles()
 
-        # Enterprise license validation for API endpoints (both console and webapp)
-        # When license expires, block all API access except bootstrap endpoints needed
-        # for the frontend to load the license expiration page without infinite reloads.
+        # Enterprise license validation. An invalid license blocks the console, the webapp
+        # and the Service API; each surface reports it in its own auth dialect.
         if dify_config.ENTERPRISE_ENABLED:
-            is_console_api = request.path.startswith("/console/api/")
-            is_webapp_api = request.path.startswith("/api/")
+            surface = _match_license_gated_surface(request.path)
+            if surface is not None:
+                try:
+                    # Cached lookup — see EnterpriseService for TTL details
+                    license_status = EnterpriseService.get_cached_license_status()
+                except Exception:
+                    logger.exception("Failed to check enterprise license status")
+                    license_status = None
 
-            if is_console_api or is_webapp_api:
-                if is_console_api:
-                    is_exempt = any(request.path.startswith(p) for p in _CONSOLE_EXEMPT_PREFIXES)
-                else:  # webapp API
-                    is_exempt = request.path.startswith("/api/system-features")
-
-                if not is_exempt:
-                    try:
-                        # Check license status (cached — see EnterpriseService for TTL details)
-                        license_status = EnterpriseService.get_cached_license_status()
-                        if license_status in (LicenseStatus.INACTIVE, LicenseStatus.EXPIRED, LicenseStatus.LOST):
-                            raise UnauthorizedAndForceLogout(
-                                f"Enterprise license is {license_status}. Please contact your administrator."
-                            )
-                        if license_status is None:
-                            raise UnauthorizedAndForceLogout(
-                                "Unable to verify enterprise license. Please contact your administrator."
-                            )
-                    except UnauthorizedAndForceLogout:
-                        raise
-                    except Exception:
-                        logger.exception("Failed to check enterprise license status")
-                        raise UnauthorizedAndForceLogout(
-                            "Unable to verify enterprise license. Please contact your administrator."
-                        )
+                if license_status is None or license_status in _INVALID_LICENSE_STATUSES:
+                    raise surface.build_error(license_status)
 
     # add after request hook for injecting trace headers from OpenTelemetry span context
     # Only adds headers when OTEL is enabled and has valid context

--- a/api/app_factory.py
+++ b/api/app_factory.py
@@ -49,31 +49,21 @@ _WEBAPP_EXEMPT_PREFIXES = ("/api/system-features",)
 
 _INVALID_LICENSE_STATUSES = (LicenseStatus.INACTIVE, LicenseStatus.EXPIRED, LicenseStatus.LOST)
 
-# How long a webhook sender is told to wait before retrying. Long enough that a blocked
-# provider backs off rather than burning its retry budget while an admin renews the license.
-_LICENSE_RETRY_AFTER_SECONDS = 300
-
 
 def _session_surface_error(license_status: LicenseStatus | None) -> HTTPException:
-    """Console and webapp authenticate with cookies, so drop the browser session."""
     if license_status is None:
         return UnauthorizedAndForceLogout("Unable to verify enterprise license. Please contact your administrator.")
     return UnauthorizedAndForceLogout(f"Enterprise license is {license_status}. Please contact your administrator.")
 
 
 def _bearer_surface_error(license_status: LicenseStatus | None) -> HTTPException:
-    """Service API authenticates with bearer tokens: forcing a logout is meaningless and
-    license state must not leak to external callers. Mirrors services.openapi.license_gate.
-    """
+    """Token-authed: forcing a logout is meaningless and license state must not leak."""
     return Forbidden(description="license_required")
 
 
 def _retryable_surface_error(license_status: LicenseStatus | None) -> HTTPException:
-    """Inbound webhooks have no Dify-side replay, and their sender is a machine rather than
-    a person who could renew the license. Senders retry on 5xx but treat 4xx as permanent —
-    often disabling the subscription — so refuse in a way that survives a later renewal.
-    """
-    return ServiceUnavailable(description="license_required", retry_after=_LICENSE_RETRY_AFTER_SECONDS)
+    """Webhook senders retry on 5xx but treat 4xx as permanent, disabling the subscription."""
+    return ServiceUnavailable(description="license_required")
 
 
 class _LicenseGatedSurface(NamedTuple):
@@ -82,10 +72,8 @@ class _LicenseGatedSurface(NamedTuple):
     build_error: Callable[[LicenseStatus | None], HTTPException]
 
 
-# Surfaces blocked while the enterprise license is invalid. Console and webapp exempt the
-# bootstrap endpoints their sign-in pages need; the app-invocation surfaces have no sign-in
-# page to bootstrap, so they are gated whole. Health probes live on /health, and the
-# dify-enterprise control plane on /inner/api, both outside every prefix here.
+# /files (plugin-daemon data plane), /inner/api (enterprise control plane) and /health
+# stay ungated: blocking them breaks workflow execution or license recovery itself.
 _LICENSE_GATED_SURFACES = (
     _LicenseGatedSurface("/console/api/", _CONSOLE_EXEMPT_PREFIXES, _session_surface_error),
     _LicenseGatedSurface("/api/", _WEBAPP_EXEMPT_PREFIXES, _session_surface_error),
@@ -124,13 +112,10 @@ def create_flask_app_with_configs() -> DifyApp:
         init_request_context()
         RecyclableContextVar.increment_thread_recycles()
 
-        # Enterprise license validation. An invalid license blocks the console, the webapp
-        # and the Service API; each surface reports it in its own auth dialect.
         if dify_config.ENTERPRISE_ENABLED:
             surface = _match_license_gated_surface(request.path)
             if surface is not None:
                 try:
-                    # Cached lookup — see EnterpriseService for TTL details
                     license_status = EnterpriseService.get_cached_license_status()
                 except Exception:
                     logger.exception("Failed to check enterprise license status")

--- a/api/tests/unit_tests/test_app_factory.py
+++ b/api/tests/unit_tests/test_app_factory.py
@@ -1,0 +1,324 @@
+"""Enterprise license gating performed by the global ``before_request`` hook."""
+
+from unittest.mock import patch
+
+import pytest
+from flask import Blueprint, Flask
+from flask_restx import Resource
+
+from app_factory import create_flask_app_with_configs
+from libs.external_api import ExternalApi
+from services.feature_service import LicenseStatus
+
+INVALID_STATUSES = [LicenseStatus.INACTIVE, LicenseStatus.EXPIRED, LicenseStatus.LOST]
+VALID_STATUSES = [LicenseStatus.ACTIVE, LicenseStatus.EXPIRING]
+
+
+def _license(status: LicenseStatus | None):
+    return patch("app_factory.EnterpriseService.get_cached_license_status", return_value=status)
+
+
+def _enterprise(enabled: bool = True):
+    return patch("app_factory.dify_config.ENTERPRISE_ENABLED", enabled)
+
+
+@pytest.fixture
+def gated_app() -> Flask:
+    """App with one route per surface the license gate distinguishes."""
+    app = create_flask_app_with_configs()
+
+    @app.route("/v1/chat-messages", methods=["POST"])
+    def service_api_route():
+        return {"surface": "service_api"}
+
+    @app.route("/v1/")
+    def service_api_index_route():
+        return {"surface": "service_api_index"}
+
+    @app.route("/mcp/server/<server_code>/mcp", methods=["POST"])
+    def mcp_route(server_code: str):
+        return {"surface": "mcp", "server_code": server_code}
+
+    @app.route("/triggers/webhook/<webhook_id>", methods=["POST"])
+    def trigger_route(webhook_id: str):
+        return {"surface": "triggers", "webhook_id": webhook_id}
+
+    @app.route("/console/api/apps")
+    def console_route():
+        return {"surface": "console"}
+
+    @app.route("/console/api/login", methods=["POST"])
+    def console_bootstrap_route():
+        return {"surface": "console_bootstrap"}
+
+    @app.route("/api/messages")
+    def webapp_route():
+        return {"surface": "webapp"}
+
+    @app.route("/api/system-features")
+    def webapp_bootstrap_route():
+        return {"surface": "webapp_bootstrap"}
+
+    @app.route("/health")
+    def health_route():
+        return {"surface": "health"}
+
+    @app.route("/inner/api/rbac/check-access", methods=["POST"])
+    def inner_api_route():
+        return {"surface": "inner_api"}
+
+    @app.route("/files/upload/for-plugin", methods=["POST"])
+    def files_route():
+        return {"surface": "files"}
+
+    return app
+
+
+class TestServiceApiLicenseGate:
+    """/v1 is a bearer-token surface, so it is gated with an opaque 403."""
+
+    @pytest.mark.parametrize("status", INVALID_STATUSES)
+    def test_blocks_when_license_invalid(self, gated_app: Flask, status: LicenseStatus):
+        with _enterprise(), _license(status):
+            response = gated_app.test_client().post("/v1/chat-messages")
+
+        assert response.status_code == 403
+
+    def test_block_response_carries_machine_readable_marker(self, gated_app: Flask):
+        with _enterprise(), _license(LicenseStatus.EXPIRED):
+            response = gated_app.test_client().post("/v1/chat-messages")
+
+        assert b"license_required" in response.data
+
+    def test_block_response_does_not_leak_license_status(self, gated_app: Flask):
+        with _enterprise(), _license(LicenseStatus.EXPIRED):
+            response = gated_app.test_client().post("/v1/chat-messages")
+
+        assert b"expired" not in response.data.lower()
+
+    def test_blocks_when_license_status_unavailable(self, gated_app: Flask):
+        with _enterprise(), _license(None):
+            response = gated_app.test_client().post("/v1/chat-messages")
+
+        assert response.status_code == 403
+
+    def test_blocks_when_license_lookup_raises(self, gated_app: Flask):
+        lookup_failed = patch(
+            "app_factory.EnterpriseService.get_cached_license_status",
+            side_effect=RuntimeError("enterprise api unreachable"),
+        )
+        with _enterprise(), lookup_failed:
+            response = gated_app.test_client().post("/v1/chat-messages")
+
+        assert response.status_code == 403
+
+    def test_blocks_index_route(self, gated_app: Flask):
+        """/v1 has no sign-in page to bootstrap, so nothing on it is exempt."""
+        with _enterprise(), _license(LicenseStatus.EXPIRED):
+            response = gated_app.test_client().get("/v1/")
+
+        assert response.status_code == 403
+
+    @pytest.mark.parametrize("status", VALID_STATUSES)
+    def test_allows_when_license_valid(self, gated_app: Flask, status: LicenseStatus):
+        with _enterprise(), _license(status):
+            response = gated_app.test_client().post("/v1/chat-messages")
+
+        assert response.status_code == 200
+
+    def test_allows_unclassified_status(self, gated_app: Flask):
+        """LicenseStatus.NONE is not in the blocked set — parity with console/webapp."""
+        with _enterprise(), _license(LicenseStatus.NONE):
+            response = gated_app.test_client().post("/v1/chat-messages")
+
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize("status", INVALID_STATUSES)
+    def test_does_not_gate_community_edition(self, gated_app: Flask, status: LicenseStatus):
+        with _enterprise(False), _license(status):
+            response = gated_app.test_client().post("/v1/chat-messages")
+
+        assert response.status_code == 200
+
+
+class TestMcpLicenseGate:
+    """/mcp invokes apps for external MCP clients, so it is gated like the Service API."""
+
+    @pytest.mark.parametrize("status", INVALID_STATUSES)
+    def test_blocks_when_license_invalid(self, gated_app: Flask, status: LicenseStatus):
+        with _enterprise(), _license(status):
+            response = gated_app.test_client().post("/mcp/server/srv-code/mcp")
+
+        assert response.status_code == 403
+
+    def test_block_response_carries_machine_readable_marker(self, gated_app: Flask):
+        with _enterprise(), _license(LicenseStatus.EXPIRED):
+            response = gated_app.test_client().post("/mcp/server/srv-code/mcp")
+
+        assert b"license_required" in response.data
+
+    @pytest.mark.parametrize("status", VALID_STATUSES)
+    def test_allows_when_license_valid(self, gated_app: Flask, status: LicenseStatus):
+        with _enterprise(), _license(status):
+            response = gated_app.test_client().post("/mcp/server/srv-code/mcp")
+
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize("status", INVALID_STATUSES)
+    def test_does_not_gate_community_edition(self, gated_app: Flask, status: LicenseStatus):
+        with _enterprise(False), _license(status):
+            response = gated_app.test_client().post("/mcp/server/srv-code/mcp")
+
+        assert response.status_code == 200
+
+
+class TestTriggerLicenseGate:
+    """Inbound webhooks are refused so senders retry, rather than dropping events."""
+
+    @pytest.mark.parametrize("status", INVALID_STATUSES)
+    def test_blocks_when_license_invalid(self, gated_app: Flask, status: LicenseStatus):
+        with _enterprise(), _license(status):
+            response = gated_app.test_client().post("/triggers/webhook/hook-id")
+
+        assert response.status_code == 503
+
+    def test_block_response_advertises_retry_after(self, gated_app: Flask):
+        """Senders treat 4xx as permanent and 5xx as retryable — the header must survive."""
+        with _enterprise(), _license(LicenseStatus.EXPIRED):
+            response = gated_app.test_client().post("/triggers/webhook/hook-id")
+
+        assert response.headers["Retry-After"] == "300"
+
+    def test_block_response_carries_machine_readable_marker(self, gated_app: Flask):
+        with _enterprise(), _license(LicenseStatus.EXPIRED):
+            response = gated_app.test_client().post("/triggers/webhook/hook-id")
+
+        assert b"license_required" in response.data
+
+    @pytest.mark.parametrize("status", VALID_STATUSES)
+    def test_allows_when_license_valid(self, gated_app: Flask, status: LicenseStatus):
+        with _enterprise(), _license(status):
+            response = gated_app.test_client().post("/triggers/webhook/hook-id")
+
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize("status", INVALID_STATUSES)
+    def test_does_not_gate_community_edition(self, gated_app: Flask, status: LicenseStatus):
+        with _enterprise(False), _license(status):
+            response = gated_app.test_client().post("/triggers/webhook/hook-id")
+
+        assert response.status_code == 200
+
+
+class TestGateThroughRealErrorHandlers:
+    """The gate raises from before_request, so its errors must survive each blueprint's own
+    error handling: flask-restx for the Service API, plain Flask for triggers.
+    """
+
+    @pytest.fixture
+    def wired_app(self) -> Flask:
+        app = create_flask_app_with_configs()
+
+        service_api_bp = Blueprint("service_api_test", __name__, url_prefix="/v1")
+        api = ExternalApi(service_api_bp)
+
+        @api.route("/chat-messages")
+        class ChatMessages(Resource):
+            def post(self):
+                return {"surface": "service_api"}
+
+        app.register_blueprint(service_api_bp)
+
+        trigger_bp = Blueprint("trigger_test", __name__, url_prefix="/triggers")
+
+        @trigger_bp.route("/webhook/<webhook_id>", methods=["POST"])
+        def webhook_route(webhook_id: str):
+            return {"surface": "triggers"}
+
+        app.register_blueprint(trigger_bp)
+        return app
+
+    def test_service_api_block_is_json_with_license_marker(self, wired_app: Flask):
+        with _enterprise(), _license(LicenseStatus.EXPIRED):
+            response = wired_app.test_client().post("/v1/chat-messages")
+
+        assert response.status_code == 403
+        body = response.get_json()
+        assert body["message"] == "license_required"
+        assert body["status"] == 403
+
+    def test_service_api_block_does_not_clear_cookies(self, wired_app: Flask):
+        """Force-logout cookie clearing belongs to the cookie-authed surfaces only."""
+        with _enterprise(), _license(LicenseStatus.EXPIRED):
+            response = wired_app.test_client().post("/v1/chat-messages")
+
+        assert response.headers.getlist("Set-Cookie") == []
+
+    def test_trigger_block_keeps_retry_after_on_the_wire(self, wired_app: Flask):
+        with _enterprise(), _license(LicenseStatus.EXPIRED):
+            response = wired_app.test_client().post("/triggers/webhook/hook-id")
+
+        assert response.status_code == 503
+        assert response.headers["Retry-After"] == "300"
+
+    def test_surfaces_are_reachable_when_license_valid(self, wired_app: Flask):
+        with _enterprise(), _license(LicenseStatus.ACTIVE):
+            service_api = wired_app.test_client().post("/v1/chat-messages")
+            triggers = wired_app.test_client().post("/triggers/webhook/hook-id")
+
+        assert service_api.status_code == 200
+        assert triggers.status_code == 200
+
+
+class TestUngatedSurfaces:
+    """Surfaces that must stay reachable while the license is invalid."""
+
+    def test_inner_api_is_not_gated(self, gated_app: Flask):
+        """dify-enterprise control plane — gating it could block license recovery itself."""
+        with _enterprise(), _license(LicenseStatus.EXPIRED):
+            response = gated_app.test_client().post("/inner/api/rbac/check-access")
+
+        assert response.status_code == 200
+
+    def test_files_data_plane_is_not_gated(self, gated_app: Flask):
+        """Signed file URLs are fetched by the plugin daemon and by LLM vendors."""
+        with _enterprise(), _license(LicenseStatus.EXPIRED):
+            response = gated_app.test_client().post("/files/upload/for-plugin")
+
+        assert response.status_code == 200
+
+
+class TestSessionSurfaceLicenseGate:
+    """Console and webapp are cookie-authed, so they keep force-logout 401 semantics."""
+
+    @pytest.mark.parametrize("status", INVALID_STATUSES)
+    def test_blocks_console_with_force_logout(self, gated_app: Flask, status: LicenseStatus):
+        with _enterprise(), _license(status):
+            response = gated_app.test_client().get("/console/api/apps")
+
+        assert response.status_code == 401
+
+    @pytest.mark.parametrize("status", INVALID_STATUSES)
+    def test_blocks_webapp_with_force_logout(self, gated_app: Flask, status: LicenseStatus):
+        with _enterprise(), _license(status):
+            response = gated_app.test_client().get("/api/messages")
+
+        assert response.status_code == 401
+
+    def test_console_bootstrap_route_stays_reachable(self, gated_app: Flask):
+        with _enterprise(), _license(LicenseStatus.EXPIRED):
+            response = gated_app.test_client().post("/console/api/login")
+
+        assert response.status_code == 200
+
+    def test_webapp_bootstrap_route_stays_reachable(self, gated_app: Flask):
+        with _enterprise(), _license(LicenseStatus.EXPIRED):
+            response = gated_app.test_client().get("/api/system-features")
+
+        assert response.status_code == 200
+
+    def test_health_route_is_never_gated(self, gated_app: Flask):
+        with _enterprise(), _license(LicenseStatus.EXPIRED):
+            response = gated_app.test_client().get("/health")
+
+        assert response.status_code == 200

--- a/api/tests/unit_tests/test_app_factory.py
+++ b/api/tests/unit_tests/test_app_factory.py
@@ -36,11 +36,11 @@ def gated_app() -> Flask:
 
     @app.route("/mcp/server/<server_code>/mcp", methods=["POST"])
     def mcp_route(server_code: str):
-        return {"surface": "mcp", "server_code": server_code}
+        return {"surface": "mcp"}
 
     @app.route("/triggers/webhook/<webhook_id>", methods=["POST"])
     def trigger_route(webhook_id: str):
-        return {"surface": "triggers", "webhook_id": webhook_id}
+        return {"surface": "triggers"}
 
     @app.route("/console/api/apps")
     def console_route():

--- a/api/tests/unit_tests/test_app_factory.py
+++ b/api/tests/unit_tests/test_app_factory.py
@@ -24,7 +24,6 @@ def _enterprise(enabled: bool = True):
 
 @pytest.fixture
 def gated_app() -> Flask:
-    """App with one route per surface the license gate distinguishes."""
     app = create_flask_app_with_configs()
 
     @app.route("/v1/chat-messages", methods=["POST"])
@@ -182,13 +181,6 @@ class TestTriggerLicenseGate:
 
         assert response.status_code == 503
 
-    def test_block_response_advertises_retry_after(self, gated_app: Flask):
-        """Senders treat 4xx as permanent and 5xx as retryable — the header must survive."""
-        with _enterprise(), _license(LicenseStatus.EXPIRED):
-            response = gated_app.test_client().post("/triggers/webhook/hook-id")
-
-        assert response.headers["Retry-After"] == "300"
-
     def test_block_response_carries_machine_readable_marker(self, gated_app: Flask):
         with _enterprise(), _license(LicenseStatus.EXPIRED):
             response = gated_app.test_client().post("/triggers/webhook/hook-id")
@@ -211,9 +203,7 @@ class TestTriggerLicenseGate:
 
 
 class TestGateThroughRealErrorHandlers:
-    """The gate raises from before_request, so its errors must survive each blueprint's own
-    error handling: flask-restx for the Service API, plain Flask for triggers.
-    """
+    """Gate errors must survive each blueprint's error handling: flask-restx vs plain Flask."""
 
     @pytest.fixture
     def wired_app(self) -> Flask:
@@ -254,12 +244,12 @@ class TestGateThroughRealErrorHandlers:
 
         assert response.headers.getlist("Set-Cookie") == []
 
-    def test_trigger_block_keeps_retry_after_on_the_wire(self, wired_app: Flask):
+    def test_trigger_block_survives_plain_blueprint_handling(self, wired_app: Flask):
         with _enterprise(), _license(LicenseStatus.EXPIRED):
             response = wired_app.test_client().post("/triggers/webhook/hook-id")
 
         assert response.status_code == 503
-        assert response.headers["Retry-After"] == "300"
+        assert b"license_required" in response.data
 
     def test_surfaces_are_reachable_when_license_valid(self, wired_app: Flask):
         with _enterprise(), _license(LicenseStatus.ACTIVE):


### PR DESCRIPTION
## Summary

The global enterprise license gate in `api/app_factory.py` only covered the console (`/console/api`) and the webapp (`/api`). An expired license therefore left three surfaces fully usable:

- **`/v1`** — the Service API. `controllers/service_api/` had no license check anywhere, so every app integration kept running.
- **`/mcp`** — the MCP server surface, which invokes apps for external MCP clients exactly like `/v1`.
- **`/triggers`** — inbound webhooks, which keep firing workflows.

This replaces the two-branch check with a table of gated surfaces, each carrying its own exemption list and error dialect:

| Surface | On invalid license | Rationale |
|---|---|---|
| `/console/api/` | 401 + force-logout | unchanged (cookie-authed) |
| `/api/` (webapp) | 401 + force-logout | unchanged (cookie-authed) |
| `/v1` | 403 `license_required` | **new** |
| `/mcp` | 403 `license_required` | **new** |
| `/triggers` | 503 `license_required` | **new** |

`/v1` and `/mcp` follow the existing bearer-surface precedent in `services/openapi/license_gate.py` rather than the console's `UnauthorizedAndForceLogout`: forcing a logout is meaningless for token auth (there are no cookies to clear), and the opaque message avoids leaking license state to external callers.

`/triggers` deliberately differs. Its caller is a machine, not a person who can renew the license, and Dify does not replay dropped webhook events. Senders retry on 5xx but treat 4xx as permanent — Slack and others disable the subscription after repeated failures, which would require manual recreation even after the license is fixed. A 503 blocks execution while letting the subscription survive.

### Deliberately left ungated

- **`/files`** — this is the runtime data plane, not UI. The plugin daemon POSTs to `/files/upload/for-plugin` and fetches `/files/tools/...` over HTTP from a separate process, and with `MULTIMODAL_SEND_FORMAT=url` the model provider itself fetches signed `/files/...` URLs. Gating it would break workflow execution while adding no enforcement, since every entry point is already gated. The signatures are HMAC-scoped and short-lived (`FILES_ACCESS_TIMEOUT`, default 300s).
- **`/inner/api`** — the bidirectional control plane between Dify and dify-enterprise. Gating it risks blocking license recovery itself.
- **`/health`** — container health probes; gating would cause restart loops on expiry.

Console and webapp behaviour is unchanged: same blocked statuses, same messages, same bootstrap exemption lists, same degrade-to-401 path when the license lookup raises.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
