### PR TITLE
fix(app): respect WORKFLOW_MAX_EXECUTION_TIME in workflow queue managers

### DIFF
--- a/api/core/app/apps/base_app_queue_manager.py
+++ b/api/core/app/apps/base_app_queue_manager.py
@@ -56,13 +56,17 @@ class AppQueueManager(ABC):
         self._abort_sent = threading.Event()
         self._lifecycle_lock = threading.Lock()
 
+    @property
+    def _listen_timeout(self) -> int:
+        return dify_config.APP_MAX_EXECUTION_TIME
+
     def listen(self):
         """
         Listen to queue
         :return:
         """
-        # wait for APP_MAX_EXECUTION_TIME seconds to stop listen
-        listen_timeout = dify_config.APP_MAX_EXECUTION_TIME
+        # wait for configured execution time seconds to stop listen
+        listen_timeout = self._listen_timeout
         start_time = time.monotonic()
         last_ping_time: int | float = 0
         try:

--- a/api/core/app/apps/message_based_app_queue_manager.py
+++ b/api/core/app/apps/message_based_app_queue_manager.py
@@ -1,5 +1,6 @@
 from typing import override
 
+from configs import dify_config
 from core.app.apps.base_app_queue_manager import AppQueueManager, PublishFrom
 from core.app.apps.exc import GenerateTaskStoppedError
 from core.app.entities.app_invoke_entities import InvokeFrom
@@ -23,6 +24,13 @@ class MessageBasedAppQueueManager(AppQueueManager):
         self._conversation_id = str(conversation_id)
         self._app_mode = app_mode
         self._message_id = str(message_id)
+
+    @property
+    @override
+    def _listen_timeout(self) -> int:
+        if self._app_mode == AppMode.ADVANCED_CHAT.value:
+            return dify_config.WORKFLOW_MAX_EXECUTION_TIME
+        return dify_config.APP_MAX_EXECUTION_TIME
 
     @override
     def _publish(self, event: AppQueueEvent, pub_from: PublishFrom):

--- a/api/core/app/apps/pipeline/pipeline_queue_manager.py
+++ b/api/core/app/apps/pipeline/pipeline_queue_manager.py
@@ -1,5 +1,6 @@
 from typing import override
 
+from configs import dify_config
 from core.app.apps.base_app_queue_manager import AppQueueManager, PublishFrom
 from core.app.apps.exc import GenerateTaskStoppedError
 from core.app.entities.app_invoke_entities import InvokeFrom
@@ -20,6 +21,11 @@ class PipelineQueueManager(AppQueueManager):
         super().__init__(task_id, user_id, invoke_from)
 
         self._app_mode = app_mode
+
+    @property
+    @override
+    def _listen_timeout(self) -> int:
+        return dify_config.WORKFLOW_MAX_EXECUTION_TIME
 
     @override
     def _publish(self, event: AppQueueEvent, pub_from: PublishFrom) -> None:

--- a/api/core/app/apps/workflow/app_queue_manager.py
+++ b/api/core/app/apps/workflow/app_queue_manager.py
@@ -1,5 +1,6 @@
 from typing import override
 
+from configs import dify_config
 from core.app.apps.base_app_queue_manager import AppQueueManager, PublishFrom
 from core.app.entities.app_invoke_entities import InvokeFrom
 from core.app.entities.queue_entities import (
@@ -19,6 +20,11 @@ class WorkflowAppQueueManager(AppQueueManager):
         super().__init__(task_id, user_id, invoke_from)
 
         self._app_mode = app_mode
+
+    @property
+    @override
+    def _listen_timeout(self) -> int:
+        return dify_config.WORKFLOW_MAX_EXECUTION_TIME
 
     @override
     def _publish(self, event: AppQueueEvent, pub_from: PublishFrom):

--- a/api/tests/unit_tests/core/app/apps/pipeline/test_pipeline_queue_manager.py
+++ b/api/tests/unit_tests/core/app/apps/pipeline/test_pipeline_queue_manager.py
@@ -56,3 +56,9 @@ def test_publish_non_stop_event_no_stop_listen(mocker: MockerFixture):
     non_stop_event = mocker.MagicMock(spec=module.AppQueueEvent)
     manager._publish(non_stop_event, PublishFrom.TASK_PIPELINE)
     manager.stop_listen.assert_not_called()
+
+
+def test_pipeline_queue_manager_uses_workflow_max_execution_time(mocker: MockerFixture):
+    manager = PipelineQueueManager(task_id="t", user_id="u", invoke_from=InvokeFrom.WEB_APP, app_mode="rag")
+    mocker.patch.object(module.dify_config, "WORKFLOW_MAX_EXECUTION_TIME", 3600)
+    assert manager._listen_timeout == 3600

--- a/api/tests/unit_tests/core/app/apps/workflow/test_app_queue_manager.py
+++ b/api/tests/unit_tests/core/app/apps/workflow/test_app_queue_manager.py
@@ -59,11 +59,21 @@ class TestWorkflowAppQueueManager:
                 reason="Client response stream closed before app execution completed",
             )
 
+    def test_workflow_app_queue_manager_uses_workflow_max_execution_time(self):
+        manager = WorkflowAppQueueManager(
+            task_id="task",
+            user_id="user",
+            invoke_from=InvokeFrom.DEBUGGER,
+            app_mode="workflow",
+        )
+        with patch("core.app.apps.workflow.app_queue_manager.dify_config.WORKFLOW_MAX_EXECUTION_TIME", 3600):
+            assert manager._listen_timeout == 3600
+
     def test_execution_timeout_aborts_graph_before_stop_event(self):
         with (
             patch("core.app.apps.base_app_queue_manager.redis_client") as redis_client,
             patch("core.app.apps.base_app_queue_manager.GraphEngineManager") as graph_engine_manager,
-            patch("core.app.apps.base_app_queue_manager.dify_config.APP_MAX_EXECUTION_TIME", 0),
+            patch("core.app.apps.workflow.app_queue_manager.dify_config.WORKFLOW_MAX_EXECUTION_TIME", 0),
         ):
             redis_client.get.return_value = None
             manager = WorkflowAppQueueManager(


### PR DESCRIPTION
## Fixes Issue

Fixes #39602

## Summary

`WORKFLOW_MAX_EXECUTION_TIME` was not being respected during workflow execution because `AppQueueManager.listen()` in `api/core/app/apps/base_app_queue_manager.py` hardcoded `listen_timeout = dify_config.APP_MAX_EXECUTION_TIME` (defaulting to 1200 seconds).

Even though `WORKFLOW_MAX_EXECUTION_TIME` was passed into GraphEngine's `ExecutionLimitsLayer`, the queue manager prematurely aborted execution at 1200 seconds when `APP_MAX_EXECUTION_TIME` was reached.

## Changes Made

1. Introduced property `_listen_timeout` on `AppQueueManager` returning `APP_MAX_EXECUTION_TIME` by default.
2. Overrode `_listen_timeout` in `WorkflowAppQueueManager` and `PipelineQueueManager` to return `dify_config.WORKFLOW_MAX_EXECUTION_TIME`.
3. Overrode `_listen_timeout` in `MessageBasedAppQueueManager` for `ADVANCED_CHAT` mode to return `dify_config.WORKFLOW_MAX_EXECUTION_TIME`.
4. Added unit test cases verifying `_listen_timeout` resolution for workflow queue managers.

## Verification

Ran unit tests across queue managers:
- `tests/unit_tests/core/app/apps/workflow/test_app_queue_manager.py`
- `tests/unit_tests/core/app/apps/pipeline/test_pipeline_queue_manager.py`
- `tests/unit_tests/core/app/apps/test_base_app_queue_manager.py`
- `tests/unit_tests/core/app/apps/test_message_based_app_queue_manager.py`

Result: 21 passed.