### PR TITLE
fix(web): preserve Chatflow drafts across navigation

### DIFF
--- a/web/__tests__/base/chat-flow.test.tsx
+++ b/web/__tests__/base/chat-flow.test.tsx
@@ -46,8 +46,10 @@ const mockAppData = {
 
 const defaultHookReturn: HookReturn = {
   isInstalledApp: false,
+  isUserIdResolved: true,
   appId: 'test-app-id',
   currentConversationId: '',
+  chatInputDraftKey: undefined,
   currentConversationItem: undefined,
   handleConversationIdInfoChange: vi.fn(),
   appData: mockAppData,

--- a/web/app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx
@@ -299,6 +299,71 @@ describe('useChatWithHistory', () => {
 
   // Scenario: conversation id updates persist to localStorage.
   describe('Conversation id persistence', () => {
+    it('should wait for user identity resolution before creating a chat input draft key', async () => {
+      const { getProcessedSystemVariablesFromUrlParams } = await import('../../utils')
+      let resolveUserId: ((value: { user_id: string }) => void) | undefined
+      vi.mocked(getProcessedSystemVariablesFromUrlParams).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveUserId = resolve
+          }),
+      )
+      mockFetchConversations.mockResolvedValue(createConversationData())
+      mockFetchChatList.mockResolvedValue({ data: [] })
+
+      const { result } = await renderWithClient(() => useChatWithHistory())
+
+      expect(result!.current.chatInputDraftKey).toBeUndefined()
+
+      await act(async () => {
+        resolveUserId?.({ user_id: 'user-1' })
+      })
+
+      await waitFor(() => {
+        expect(result!.current.chatInputDraftKey).toBe(
+          `chat-input-draft:${JSON.stringify([
+            AppSourceType.webApp,
+            'app-1',
+            'user-1',
+            'conversation-1',
+          ])}`,
+        )
+      })
+    })
+
+    it('should scope the chat input draft to the current application, user, and conversation', async () => {
+      mockFetchConversations.mockResolvedValue(createConversationData())
+      mockFetchChatList.mockResolvedValue({ data: [] })
+
+      const { result } = await renderWithClient(() => useChatWithHistory())
+
+      await waitFor(() => {
+        expect(result!.current.chatInputDraftKey).toBe(
+          `chat-input-draft:${JSON.stringify([
+            AppSourceType.webApp,
+            'app-1',
+            'user-1',
+            'conversation-1',
+          ])}`,
+        )
+      })
+
+      act(() => {
+        result!.current.handleChangeConversation('conversation-2')
+      })
+
+      await waitFor(() => {
+        expect(result!.current.chatInputDraftKey).toBe(
+          `chat-input-draft:${JSON.stringify([
+            AppSourceType.webApp,
+            'app-1',
+            'user-1',
+            'conversation-2',
+          ])}`,
+        )
+      })
+    })
+
     it('should store new conversation id in localStorage after completion', async () => {
       // Arrange
       const listData = createConversationData({

--- a/web/app/components/base/chat/chat-with-history/chat-wrapper.tsx
+++ b/web/app/components/base/chat/chat-with-history/chat-wrapper.tsx
@@ -35,6 +35,7 @@ const ChatWrapper = () => {
     appParams,
     appPrevChatTree,
     currentConversationId,
+    chatInputDraftKey,
     currentConversationItem,
     currentConversationInputs,
     inputsForms,
@@ -460,6 +461,7 @@ const ChatWrapper = () => {
         switchSibling={doSwitchSibling}
         inputDisabled={inputDisabled}
         sidebarCollapseState={sidebarCollapseState}
+        chatInputDraftKey={chatInputDraftKey}
         renderAgentContent={renderAgentContent}
         questionIcon={
           initUserVariables?.avatar_url ? (

--- a/web/app/components/base/chat/chat-with-history/context.ts
+++ b/web/app/components/base/chat/chat-with-history/context.ts
@@ -34,7 +34,9 @@ export type ChatWithHistoryContextValue = {
   chatShouldReloadKey: string
   isMobile: boolean
   isInstalledApp: boolean
+  isUserIdResolved?: boolean
   appId?: string
+  chatInputDraftKey?: string
   handleFeedback: (messageId: string, feedback: Feedback) => void
   currentChatInstanceRef: RefObject<{ handleStop: () => void }>
   themeBuilder?: ThemeBuilder
@@ -76,6 +78,7 @@ export const ChatWithHistoryContext = createContext<ChatWithHistoryContextValue>
   chatShouldReloadKey: '',
   isMobile: false,
   isInstalledApp: false,
+  isUserIdResolved: true,
   handleFeedback: noop,
   currentChatInstanceRef: { current: { handleStop: noop } },
   sidebarCollapseState: false,

--- a/web/app/components/base/chat/chat-with-history/hooks.tsx
+++ b/web/app/components/base/chat/chat-with-history/hooks.tsx
@@ -166,10 +166,22 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
   }, [isInstalledApp, installedAppInfo, appInfo])
   const appId = useMemo(() => appData?.app_id, [appData])
   const [userId, setUserId] = useState<string>()
+  const [isUserIdResolved, setIsUserIdResolved] = useState(false)
   useEffect(() => {
-    getProcessedSystemVariablesFromUrlParams().then(({ user_id }) => {
-      setUserId(user_id)
-    })
+    let isActive = true
+
+    getProcessedSystemVariablesFromUrlParams()
+      .then(({ user_id }) => {
+        if (isActive) setUserId(user_id)
+      })
+      .catch(noop)
+      .finally(() => {
+        if (isActive) setIsUserIdResolved(true)
+      })
+
+    return () => {
+      isActive = false
+    }
   }, [])
   useEffect(() => {
     const setLocaleFromProps = async () => {
@@ -191,6 +203,16 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
     () => conversationIdInfo?.[appId || '']?.[userId || 'DEFAULT'] || '',
     [appId, conversationIdInfo, userId],
   )
+  const chatInputDraftKey = useMemo(() => {
+    if (!appId || !isUserIdResolved) return undefined
+
+    return `chat-input-draft:${JSON.stringify([
+      appSourceType,
+      appId,
+      userId || 'DEFAULT',
+      currentConversationId || 'NEW',
+    ])}`
+  }, [appId, appSourceType, currentConversationId, isUserIdResolved, userId])
   const handleConversationIdInfoChange = useCallback(
     (changeConversationId: string) => {
       if (appId) {
@@ -603,7 +625,9 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
   return {
     isInstalledApp,
     appId,
+    isUserIdResolved,
     currentConversationId,
+    chatInputDraftKey,
     currentConversationItem,
     handleConversationIdInfoChange,
     appData,

--- a/web/app/components/base/chat/chat-with-history/index.tsx
+++ b/web/app/components/base/chat/chat-with-history/index.tsx
@@ -23,6 +23,7 @@ const ChatWithHistory: FC<ChatWithHistoryProps> = ({ className }) => {
     appData,
     appChatListDataLoading,
     chatShouldReloadKey,
+    isUserIdResolved = true,
     isMobile,
     themeBuilder,
     sidebarCollapseState,
@@ -78,8 +79,8 @@ const ChatWithHistory: FC<ChatWithHistoryProps> = ({ className }) => {
           )}
         >
           {!isMobile && <Header />}
-          {appChatListDataLoading && <Loading type="app" />}
-          {!appChatListDataLoading && <ChatWrapper key={chatShouldReloadKey} />}
+          {(appChatListDataLoading || !isUserIdResolved) && <Loading type="app" />}
+          {!appChatListDataLoading && isUserIdResolved && <ChatWrapper key={chatShouldReloadKey} />}
         </div>
       </div>
     </div>
@@ -108,6 +109,7 @@ const ChatWithHistoryWrap: FC<ChatWithHistoryWrapProps> = ({
     appMeta,
     appChatListDataLoading,
     currentConversationId,
+    chatInputDraftKey,
     currentConversationItem,
     appPrevChatTree,
     pinnedConversationList,
@@ -127,6 +129,7 @@ const ChatWithHistoryWrap: FC<ChatWithHistoryWrapProps> = ({
     handleNewConversationCompleted,
     chatShouldReloadKey,
     isInstalledApp,
+    isUserIdResolved,
     appId,
     handleFeedback,
     currentChatInstanceRef,
@@ -150,6 +153,7 @@ const ChatWithHistoryWrap: FC<ChatWithHistoryWrapProps> = ({
         appMeta,
         appChatListDataLoading,
         currentConversationId,
+        chatInputDraftKey,
         currentConversationItem,
         appPrevChatTree,
         pinnedConversationList,
@@ -170,6 +174,7 @@ const ChatWithHistoryWrap: FC<ChatWithHistoryWrapProps> = ({
         chatShouldReloadKey,
         isMobile,
         isInstalledApp,
+        isUserIdResolved,
         appId,
         handleFeedback,
         currentChatInstanceRef,

--- a/web/app/components/base/chat/chat/chat-input-area/__tests__/index.spec.tsx
+++ b/web/app/components/base/chat/chat/chat-input-area/__tests__/index.spec.tsx
@@ -326,6 +326,125 @@ describe('ChatInputArea', () => {
 
   // -------------------------------------------------------------------------
   describe('User Interaction', () => {
+    it('should restore an unsent draft after the composer remounts', async () => {
+      const draftKey = 'chat-input-draft-persistence'
+      const user = userEvent.setup({ delay: null })
+      sessionStorage.removeItem(draftKey)
+
+      const view = render(<ChatInputArea visionConfig={mockVisionConfig} draftKey={draftKey} />)
+      await user.type(getTextarea()!, 'Keep this draft')
+      view.unmount()
+
+      const restoredView = render(
+        <ChatInputArea visionConfig={mockVisionConfig} draftKey={draftKey} />,
+      )
+      expect(getTextarea()!).toHaveValue('Keep this draft')
+
+      restoredView.unmount()
+      sessionStorage.removeItem(draftKey)
+    })
+
+    it('should persist the latest draft after typing settles or the page is hidden', () => {
+      const draftKey = 'chat-input-draft-pagehide'
+      sessionStorage.removeItem(draftKey)
+      vi.useFakeTimers()
+
+      try {
+        const view = render(<ChatInputArea visionConfig={mockVisionConfig} draftKey={draftKey} />)
+        const textarea = getTextarea()!
+
+        fireEvent.change(textarea, { target: { value: 'First draft' } })
+        act(() => vi.advanceTimersByTime(300))
+        expect(sessionStorage.getItem(draftKey)).toBe('First draft')
+
+        fireEvent.change(textarea, { target: { value: 'Latest draft' } })
+        window.dispatchEvent(new Event('pagehide'))
+        expect(sessionStorage.getItem(draftKey)).toBe('Latest draft')
+
+        view.unmount()
+      } finally {
+        sessionStorage.removeItem(draftKey)
+        vi.useRealTimers()
+      }
+    })
+
+    it('should keep drafts isolated between conversations', async () => {
+      const user = userEvent.setup({ delay: null })
+      const firstDraftKey = 'chat-input-draft-conversation-a'
+      const secondDraftKey = 'chat-input-draft-conversation-b'
+      sessionStorage.removeItem(firstDraftKey)
+      sessionStorage.removeItem(secondDraftKey)
+
+      const firstView = render(
+        <ChatInputArea visionConfig={mockVisionConfig} draftKey={firstDraftKey} />,
+      )
+      await user.type(getTextarea()!, 'Draft for conversation A')
+      firstView.unmount()
+
+      const secondView = render(
+        <ChatInputArea visionConfig={mockVisionConfig} draftKey={secondDraftKey} />,
+      )
+      await user.type(getTextarea()!, 'Draft for conversation B')
+      secondView.unmount()
+
+      const restoredFirstView = render(
+        <ChatInputArea visionConfig={mockVisionConfig} draftKey={firstDraftKey} />,
+      )
+      expect(getTextarea()!).toHaveValue('Draft for conversation A')
+      restoredFirstView.unmount()
+
+      const restoredSecondView = render(
+        <ChatInputArea visionConfig={mockVisionConfig} draftKey={secondDraftKey} />,
+      )
+      expect(getTextarea()!).toHaveValue('Draft for conversation B')
+      restoredSecondView.unmount()
+
+      sessionStorage.removeItem(firstDraftKey)
+      sessionStorage.removeItem(secondDraftKey)
+    })
+
+    it('should keep a draft when an asynchronous send is rejected', async () => {
+      const draftKey = 'chat-input-draft-rejected-send'
+      const user = userEvent.setup({ delay: null })
+      const onSend = vi.fn().mockResolvedValue(false)
+      sessionStorage.removeItem(draftKey)
+
+      const view = render(
+        <ChatInputArea visionConfig={mockVisionConfig} draftKey={draftKey} onSend={onSend} />,
+      )
+      await user.type(getTextarea()!, 'Retry this draft')
+      await user.click(screen.getByRole('button', { name: 'common.operation.send' }))
+      await waitFor(() => expect(onSend).toHaveBeenCalled())
+      view.unmount()
+
+      const restoredView = render(
+        <ChatInputArea visionConfig={mockVisionConfig} draftKey={draftKey} />,
+      )
+      expect(getTextarea()!).toHaveValue('Retry this draft')
+
+      restoredView.unmount()
+      sessionStorage.removeItem(draftKey)
+    })
+
+    it('should clear the persisted draft after a message is accepted', async () => {
+      const draftKey = 'chat-input-draft-cleared-after-send'
+      const user = userEvent.setup({ delay: null })
+      const onSend = vi.fn()
+      sessionStorage.setItem(draftKey, 'Send this draft')
+
+      const view = render(
+        <ChatInputArea visionConfig={mockVisionConfig} draftKey={draftKey} onSend={onSend} />,
+      )
+      await user.click(screen.getByRole('button', { name: 'common.operation.send' }))
+      expect(onSend).toHaveBeenCalledWith('Send this draft', [])
+      view.unmount()
+
+      render(<ChatInputArea visionConfig={mockVisionConfig} draftKey={draftKey} />)
+      expect(getTextarea()!).toHaveValue('')
+
+      sessionStorage.removeItem(draftKey)
+    })
+
     it('should update textarea value as the user types', async () => {
       const user = userEvent.setup({ delay: null })
       render(<ChatInputArea visionConfig={mockVisionConfig} />)

--- a/web/app/components/base/chat/chat/chat-input-area/index.tsx
+++ b/web/app/components/base/chat/chat/chat-input-area/index.tsx
@@ -8,9 +8,10 @@ import { cn } from '@langgenius/dify-ui/cn'
 import { toast } from '@langgenius/dify-ui/toast'
 import { noop } from 'es-toolkit/function'
 import { decode } from 'html-entities'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Textarea from 'react-textarea-autosize'
+import { getChatInputDraft, setChatInputDraft } from '@/app/components/base/chat/storage'
 import FeatureBar from '@/app/components/base/features/new-feature-panel/feature-bar'
 import { FileListInChatInput } from '@/app/components/base/file-uploader'
 import { useFile } from '@/app/components/base/file-uploader/hooks'
@@ -23,6 +24,8 @@ import { useTextAreaHeight } from './hooks'
 import Operation from './operation'
 
 type SendAcceptance = void | boolean | Promise<void | boolean>
+
+const DRAFT_PERSISTENCE_DELAY = 300
 
 function isMicrophonePermissionDenied(error: unknown) {
   return error instanceof DOMException && error.name === 'NotAllowedError'
@@ -52,6 +55,7 @@ type ChatInputAreaProps = {
   footerNotice?: ReactNode
   footerNoticeTooltip?: ReactNode
   autoFocus?: boolean
+  draftKey?: string
   /**
    * Controls whether pressing Enter sends the message.
    * - true (default): Enter sends, Shift+Enter inserts newline
@@ -84,6 +88,7 @@ const ChatInputArea = ({
   footerNotice,
   footerNoticeTooltip,
   autoFocus = true,
+  draftKey,
   sendOnEnter = true,
 }: ChatInputAreaProps) => {
   const { t } = useTranslation()
@@ -95,7 +100,9 @@ const ChatInputArea = ({
     handleTextareaResize,
     isMultipleLine,
   } = useTextAreaHeight()
-  const [query, setQuery] = useState('')
+  const [query, setQuery] = useState(() => getChatInputDraft(draftKey))
+  const queryRef = useRef(query)
+  const draftPersistenceTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const canSend = !!query.trim()
   const [showVoiceInput, setShowVoiceInput] = useState(false)
   const filesStore = useFileStore()
@@ -111,25 +118,62 @@ const ChatInputArea = ({
   const historyRef = useRef([''])
   const [currentIndex, setCurrentIndex] = useState(-1)
   const isComposingRef = useRef(false)
-  const queryRef = useRef('')
   const voiceInputRef = useRef<HTMLDivElement>(null)
   const voiceInputReturnFocusRef = useRef<HTMLElement | null>(null)
   const voiceInputCompletedRef = useRef(false)
+  const clearDraftPersistenceTimer = useCallback(() => {
+    if (draftPersistenceTimerRef.current === undefined) return
+
+    clearTimeout(draftPersistenceTimerRef.current)
+    draftPersistenceTimerRef.current = undefined
+  }, [])
+  const persistDraft = useCallback(
+    (draft: string) => {
+      clearDraftPersistenceTimer()
+      setChatInputDraft(draftKey, draft)
+    },
+    [clearDraftPersistenceTimer, draftKey],
+  )
+  const scheduleDraftPersistence = useCallback(
+    (draft: string) => {
+      clearDraftPersistenceTimer()
+      if (!draftKey) return
+
+      draftPersistenceTimerRef.current = setTimeout(() => {
+        draftPersistenceTimerRef.current = undefined
+        setChatInputDraft(draftKey, draft)
+      }, DRAFT_PERSISTENCE_DELAY)
+    },
+    [clearDraftPersistenceTimer, draftKey],
+  )
   const handleQueryChange = useCallback(
     (value: string) => {
       queryRef.current = value
       setQuery(value)
+      scheduleDraftPersistence(value)
       setTimeout(handleTextareaResize, 0)
     },
-    [handleTextareaResize],
+    [handleTextareaResize, scheduleDraftPersistence],
   )
+  useEffect(() => {
+    const handlePageHide = () => persistDraft(queryRef.current)
+    window.addEventListener('pagehide', handlePageHide)
+
+    return () => {
+      window.removeEventListener('pagehide', handlePageHide)
+      persistDraft(queryRef.current)
+    }
+  }, [persistDraft])
   const resetAcceptedMessage = useCallback(
     (acceptedQuery: string, acceptedFiles: ReturnType<typeof filesStore.getState>['files']) => {
       const { files, setFiles } = filesStore.getState()
-      if (queryRef.current === acceptedQuery) handleQueryChange('')
+      if (queryRef.current === acceptedQuery) {
+        handleQueryChange('')
+        persistDraft('')
+      }
       if (files === acceptedFiles) setFiles([])
     },
-    [filesStore, handleQueryChange],
+    [filesStore, handleQueryChange, persistDraft],
   )
   const handleSend = () => {
     if (!canSend) return

--- a/web/app/components/base/chat/chat/index.tsx
+++ b/web/app/components/base/chat/chat/index.tsx
@@ -81,6 +81,7 @@ export type ChatProps = {
   sendOnEnter?: boolean
   speechToTextTarget?: SpeechToTextTarget
   onBeforeSpeechToText?: () => Promise<unknown>
+  chatInputDraftKey?: string
   renderAgentContent?: (props: {
     item: ChatItem
     responding?: boolean
@@ -142,6 +143,7 @@ const Chat: FC<ChatProps> = ({
   sendOnEnter,
   speechToTextTarget,
   onBeforeSpeechToText,
+  chatInputDraftKey,
   renderAgentContent,
   onHumanInputFormSubmit,
   getHumanInputNodeData,
@@ -283,6 +285,7 @@ const Chat: FC<ChatProps> = ({
             {hasTryToAsk && <TryToAsk suggestedQuestions={suggestedQuestions} onSend={onSend} />}
             {!noChatInput && (
               <ChatInputArea
+                key={chatInputDraftKey}
                 botName={inputPlaceholderBotName || appData?.site?.title || 'Bot'}
                 customPlaceholder={inputPlaceholder ?? appData?.site?.input_placeholder}
                 disabled={inputDisabled}
@@ -295,6 +298,7 @@ const Chat: FC<ChatProps> = ({
                 speechToTextConfig={config?.speech_to_text}
                 speechToTextTarget={speechToTextTarget}
                 onBeforeSpeechToText={onBeforeSpeechToText}
+                draftKey={chatInputDraftKey}
                 onSend={onSend}
                 inputs={inputs}
                 inputsForm={inputsForm}

--- a/web/app/components/base/chat/storage.ts
+++ b/web/app/components/base/chat/storage.ts
@@ -1,6 +1,40 @@
 import { createLocalStorageState } from 'foxact/create-local-storage-state'
 import { CONVERSATION_ID_INFO } from './constants'
 
+const getSessionStorage = (): Storage | null => {
+  try {
+    if (typeof window === 'undefined') return null
+    return window.sessionStorage
+  } catch {
+    return null
+  }
+}
+
+export const getChatInputDraft = (draftKey?: string) => {
+  if (!draftKey) return ''
+
+  const storage = getSessionStorage()
+  if (!storage) return ''
+
+  try {
+    return storage.getItem(draftKey) || ''
+  } catch {
+    return ''
+  }
+}
+
+export const setChatInputDraft = (draftKey: string | undefined, draft: string) => {
+  if (!draftKey) return
+
+  const storage = getSessionStorage()
+  if (!storage) return
+
+  try {
+    if (draft) storage.setItem(draftKey, draft)
+    else storage.removeItem(draftKey)
+  } catch {}
+}
+
 const [useConversationIdInfo, _useConversationIdInfoValue, _useSetConversationIdInfo] =
   createLocalStorageState<Record<string, Record<string, string>>>(CONVERSATION_ID_INFO, {})
 


### PR DESCRIPTION
## Summary

- Preserve unsent text in the published Chatflow composer across route changes.
- Scope drafts to the app source, app, end user, and conversation.
- Persist settled input and page-hide state, clear a draft after an accepted send, and wait for end-user identity resolution before mounting the composer.

This resolves the unsent-composer portion of #38555. Recovering an in-progress execution needs a separate resumable event-stream contract and remains out of scope.

## Screenshots

N/A. This is state-preservation behavior covered by automated tests.

## Tests

- pnpm test run app/components/base/chat/chat/chat-input-area/__tests__/index.spec.tsx app/components/base/chat/chat-with-history/__tests__/hooks.spec.tsx app/components/base/chat/chat-with-history/__tests__/chat-wrapper.spec.tsx __tests__/base/chat-flow.test.tsx
- pnpm type-check
- pnpm exec vp check for the changed frontend files

## Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I added a test for each introduced behavior and kept the change atomic.
- [x] No documentation update is required for this internal state-preservation fix.