### PR TITLE
fix(http): stop Enter from corrupting Params/Headers rows in HTTP Request node

### DIFF
--- a/web/app/components/base/prompt-editor/plugins/component-picker-block/index.tsx
+++ b/web/app/components/base/prompt-editor/plugins/component-picker-block/index.tsx
@@ -245,6 +245,7 @@ const ComponentPicker = ({
             <div className="size-0" data-prompt-editor-typeahead-menu>
               <div
                 className="w-65 rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-1 shadow-lg"
+                data-visible={isPositioned ? 'true' : 'false'}
                 style={{
                   ...floatingStyles,
                   visibility: isPositioned ? 'visible' : 'hidden',

--- a/web/app/components/base/prompt-editor/plugins/component-picker-block/index.tsx
+++ b/web/app/components/base/prompt-editor/plugins/component-picker-block/index.tsx
@@ -242,7 +242,7 @@ const ComponentPicker = ({
             // The `LexicalMenu` will try to calculate the position of the floating menu based on the first child.
             // Since we use floating ui, we need to wrap it with a div to prevent the position calculation being affected.
             // See https://github.com/facebook/lexical/blob/ac97dfa9e14a73ea2d6934ff566282d7f758e8bb/packages/lexical-react/src/shared/LexicalMenu.ts#L493
-            <div className="size-0">
+            <div className="size-0" data-prompt-editor-typeahead-menu>
               <div
                 className="w-65 rounded-lg border-[0.5px] border-components-panel-border bg-components-panel-bg-blur p-1 shadow-lg"
                 style={{

--- a/web/app/components/workflow/nodes/_base/components/__tests__/input-support-select-var.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/components/__tests__/input-support-select-var.spec.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import Editor from '../input-support-select-var'
+
+vi.mock('@/app/components/base/prompt-editor', () => ({
+  __esModule: true,
+  default: ({ value }: { value: string }) => (
+    <div data-testid="prompt-editor">
+      <input data-testid="editor-input" defaultValue={value} />
+    </div>
+  ),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (cb: (k: { $: Record<string, string> }) => string) => cb({ $: {} }),
+  }),
+}))
+
+vi.mock('@langgenius/dify-ui/cn', () => ({
+  cn: (...args: unknown[]) => String(args.filter(Boolean).join(' ')),
+}))
+
+vi.mock('@langgenius/dify-ui/tooltip', () => ({
+  Tooltip: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  TooltipContent: () => null,
+  TooltipTrigger: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/app/components/base/icons/src/vender/solid/development', () => ({
+  Variable02: () => null,
+}))
+
+vi.mock('@/app/components/workflow/store', () => ({
+  useStore: () => null,
+}))
+
+const wrap = (overrides: Record<string, unknown> = {}) =>
+  render((<Editor value="open" onChange={() => {}} {...overrides} />) as ReactNode)
+
+describe('input-support-select-var singleLine Enter handling', () => {
+  it('commits on Enter when singleLine and no typeahead menu is open', async () => {
+    const user = userEvent.setup()
+    const onCommit = vi.fn()
+
+    wrap({ singleLine: true, onCommit })
+
+    const input = screen.getByTestId('editor-input')
+    await user.click(input)
+    await user.keyboard('{Enter}')
+
+    expect(onCommit).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not commit on Enter while the typeahead menu is visible', async () => {
+    const user = userEvent.setup()
+    const onCommit = vi.fn()
+
+    // Simulate an open typeahead menu rendered by the component-picker-block plugin.
+    document.body.innerHTML =
+      '<div data-prompt-editor-typeahead-menu><div data-visible="true"></div></div>'
+
+    wrap({ singleLine: true, onCommit })
+
+    const input = screen.getByTestId('editor-input')
+    await user.click(input)
+    await user.keyboard('{Enter}')
+
+    expect(onCommit).not.toHaveBeenCalled()
+  })
+
+  it('does not commit on Enter when singleLine is disabled', async () => {
+    const user = userEvent.setup()
+    const onCommit = vi.fn()
+
+    wrap({ onCommit })
+
+    const input = screen.getByTestId('editor-input')
+    await user.click(input)
+    await user.keyboard('{Enter}')
+
+    expect(onCommit).not.toHaveBeenCalled()
+  })
+})

--- a/web/app/components/workflow/nodes/_base/components/input-support-select-var.tsx
+++ b/web/app/components/workflow/nodes/_base/components/input-support-select-var.tsx
@@ -58,7 +58,7 @@ const Editor: FC<Props> = ({
   const pipelineId = useStore((s) => s.pipelineId)
   const setShowInputFieldPanel = useStore((s) => s.setShowInputFieldPanel)
 
-  const handleKeyDown = useCallback(
+  const handleKeyDownCapture = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
       if (!singleLine || e.key !== 'Enter') return
       // When the variable-insert menu is open, Enter must select the highlighted
@@ -69,7 +69,15 @@ const Editor: FC<Props> = ({
         '[data-prompt-editor-typeahead-menu] > div[data-visible="true"]',
       )
       if (menuOpen) return
+      // Capture phase is required here: Lexical registers a native keydown
+      // listener directly on the contentEditable, which runs before React's
+      // delegated (bubble-phase) synthetic handlers on Chromium and inserts the
+      // paragraph synchronously — too late for a bubble-phase preventDefault.
+      // Intercepting in the capture phase stops the event before it ever
+      // reaches Lexical, so no newline is inserted. WebKit happened to order
+      // the handlers differently, which is why this only misbehaved on Chromium.
       e.preventDefault()
+      e.stopPropagation()
       onCommit?.()
     },
     [singleLine, onCommit],
@@ -79,7 +87,7 @@ const Editor: FC<Props> = ({
     <div
       className={cn(className, 'relative min-h-8')}
       role="presentation"
-      onKeyDown={handleKeyDown}
+      onKeyDownCapture={handleKeyDownCapture}
     >
       <>
         <PromptEditor

--- a/web/app/components/workflow/nodes/_base/components/input-support-select-var.tsx
+++ b/web/app/components/workflow/nodes/_base/components/input-support-select-var.tsx
@@ -74,7 +74,11 @@ const Editor: FC<Props> = ({
   )
 
   return (
-    <div className={cn(className, 'relative min-h-8')} onKeyDown={handleKeyDown}>
+    <div
+      className={cn(className, 'relative min-h-8')}
+      role="presentation"
+      onKeyDown={handleKeyDown}
+    >
       <>
         <PromptEditor
           instanceId={instanceId}

--- a/web/app/components/workflow/nodes/_base/components/input-support-select-var.tsx
+++ b/web/app/components/workflow/nodes/_base/components/input-support-select-var.tsx
@@ -6,7 +6,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/too
 import { useBoolean } from 'ahooks'
 import { noop } from 'es-toolkit/function'
 import * as React from 'react'
-import { useEffect } from 'react'
+import { useCallback, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Variable02 } from '@/app/components/base/icons/src/vender/solid/development'
 import PromptEditor from '@/app/components/base/prompt-editor'
@@ -24,6 +24,8 @@ type Props = Readonly<{
   onFocusChange?: (value: boolean) => void
   readOnly?: boolean
   justVar?: boolean
+  singleLine?: boolean
+  onCommit?: () => void
   nodesOutputVars?: NodeOutPutVar[]
   availableNodes?: Node[]
   insertVarTipToLeft?: boolean
@@ -42,6 +44,8 @@ const Editor: FC<Props> = ({
   nodesOutputVars,
   availableNodes = [],
   insertVarTipToLeft,
+  singleLine = false,
+  onCommit,
 }) => {
   const { t } = useTranslation()
 
@@ -54,8 +58,23 @@ const Editor: FC<Props> = ({
   const pipelineId = useStore((s) => s.pipelineId)
   const setShowInputFieldPanel = useStore((s) => s.setShowInputFieldPanel)
 
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!singleLine || e.key !== 'Enter') return
+      // When the variable-insert menu is open, Enter must select the highlighted
+      // variable — let the editor handle it.
+      const menuOpen = document.querySelector(
+        '[data-prompt-editor-typeahead-menu] > div:not([style*="visibility: hidden"])',
+      )
+      if (menuOpen) return
+      e.preventDefault()
+      onCommit?.()
+    },
+    [singleLine, onCommit],
+  )
+
   return (
-    <div className={cn(className, 'relative min-h-8')}>
+    <div className={cn(className, 'relative min-h-8')} onKeyDown={handleKeyDown}>
       <>
         <PromptEditor
           instanceId={instanceId}

--- a/web/app/components/workflow/nodes/_base/components/input-support-select-var.tsx
+++ b/web/app/components/workflow/nodes/_base/components/input-support-select-var.tsx
@@ -62,9 +62,11 @@ const Editor: FC<Props> = ({
     (e: React.KeyboardEvent<HTMLDivElement>) => {
       if (!singleLine || e.key !== 'Enter') return
       // When the variable-insert menu is open, Enter must select the highlighted
-      // variable — let the editor handle it.
+      // variable — let the editor handle it. The menu exposes its open state as
+      // a data attribute (set from isPositioned) instead of relying on the
+      // inline visibility style, so the check survives styling changes.
       const menuOpen = document.querySelector(
-        '[data-prompt-editor-typeahead-menu] > div:not([style*="visibility: hidden"])',
+        '[data-prompt-editor-typeahead-menu] > div[data-visible="true"]',
       )
       if (menuOpen) return
       e.preventDefault()

--- a/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/__tests__/input-item.spec.tsx
+++ b/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/__tests__/input-item.spec.tsx
@@ -1,0 +1,98 @@
+import type { ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import InputItem from '../input-item'
+
+vi.mock('@/app/components/workflow/nodes/_base/components/input-support-select-var', () => ({
+  __esModule: true,
+  default: ({
+    value,
+    onChange,
+    singleLine,
+    onCommit,
+  }: {
+    value: string
+    onChange: (v: string) => void
+    singleLine?: boolean
+    onCommit?: () => void
+  }) => (
+    <div data-testid="editor" data-singleline={singleLine ? 'true' : 'false'}>
+      <input
+        data-testid="editor-input"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (singleLine && e.key === 'Enter') {
+            e.preventDefault()
+            onCommit?.()
+          }
+        }}
+      />
+    </div>
+  ),
+}))
+
+vi.mock('@/app/components/workflow/nodes/_base/components/remove-button', () => ({
+  __esModule: true,
+  default: ({ onClick }: { onClick?: () => void }) => (
+    <button type="button" data-testid="remove" onClick={onClick}>
+      remove
+    </button>
+  ),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (cb: (k: { $: Record<string, string> }) => string) => cb({ $: {} }),
+  }),
+}))
+
+vi.mock('@langgenius/dify-ui/cn', () => ({
+  cn: (...args: unknown[]) => String(args.filter(Boolean).join(' ')),
+}))
+
+vi.mock('@/app/components/workflow/nodes/_base/hooks/use-available-var-list', () => ({
+  __esModule: true,
+  default: () => ({ availableVars: [], availableNodesWithParent: [] }),
+}))
+
+const wrap = (overrides: Record<string, unknown> = {}) =>
+  render(
+    (
+      <InputItem nodeId="n1" value="open" onChange={() => {}} hasRemove={false} {...overrides} />
+    ) as ReactNode,
+  )
+
+describe('http/key-value InputItem singleLine commit', () => {
+  it('enables singleLine mode and invokes onCommit when the editor signals Enter', async () => {
+    const user = userEvent.setup()
+    const onCommit = vi.fn()
+
+    wrap({ singleLine: true, onCommit })
+
+    const editor = screen.getByTestId('editor')
+    expect(editor).toHaveAttribute('data-singleline', 'true')
+
+    const input = screen.getByTestId('editor-input')
+    await user.click(input)
+    await user.keyboard('{Enter}')
+
+    expect(onCommit).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call onCommit when singleLine is not enabled', async () => {
+    const user = userEvent.setup()
+    const onCommit = vi.fn()
+
+    wrap({ onCommit })
+
+    const editor = screen.getByTestId('editor')
+    expect(editor).toHaveAttribute('data-singleline', 'false')
+
+    const input = screen.getByTestId('editor-input')
+    await user.click(input)
+    await user.keyboard('{Enter}')
+
+    expect(onCommit).not.toHaveBeenCalled()
+  })
+})

--- a/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/input-item.tsx
+++ b/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/input-item.tsx
@@ -21,6 +21,8 @@ type Props = Readonly<{
   placeholder?: string
   readOnly?: boolean
   isSupportFile?: boolean
+  singleLine?: boolean
+  onCommit?: () => void
   insertVarTipToLeft?: boolean
 }>
 
@@ -35,6 +37,8 @@ const InputItem: FC<Props> = ({
   placeholder,
   readOnly,
   isSupportFile,
+  singleLine,
+  onCommit,
   insertVarTipToLeft,
 }) => {
   const { t } = useTranslation()
@@ -78,6 +82,8 @@ const InputItem: FC<Props> = ({
           placeholder={t(($) => $['nodes.http.insertVarPlaceholder'], { ns: 'workflow' })!}
           placeholderClassName="leading-[21px]!"
           insertVarTipToLeft={insertVarTipToLeft}
+          singleLine={singleLine}
+          onCommit={onCommit}
         />
       ) : (
         <div className="h-full w-full pl-0.5 leading-4.5">

--- a/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/item.tsx
+++ b/web/app/components/workflow/nodes/http/components/key-value/key-value-edit/item.tsx
@@ -103,6 +103,7 @@ const KeyValueItem: FC<Props> = ({
             placeholder={t(($) => $[`${i18nPrefix}.key`], { ns: 'workflow' })!}
             readOnly={readonly}
             insertVarTipToLeft={insertVarTipToLeft}
+            singleLine
           />
         ) : (
           <input
@@ -161,6 +162,8 @@ const KeyValueItem: FC<Props> = ({
             readOnly={readonly}
             isSupportFile={isSupportFile}
             insertVarTipToLeft={insertVarTipToLeft}
+            singleLine
+            onCommit={handleValueContainerClick}
           />
         )}
       </div>


### PR DESCRIPTION
On the HTTP Request node, the Params and Headers tables store their rows as a newline-joined "key:value" string, but each field is rendered with the multi-line PromptEditor. Pressing Enter while focused on a key or value inserted a literal newline, which the list<->string round-trip (strToKeyValueList splits on newline) then re-read as a row boundary. The result was that Enter split the row and relocated the value you had just typed into the next row's key, leaving the original row with an empty value. This is #39565 (and the same newline-joined-string root cause behind #39551 / #38860).

This adds a singleLine flag to the variable-aware input used by the key/value table. In single-line mode Enter is intercepted before it reaches the editor so no newline is inserted, unless the variable-insert menu is currently open, in which case Enter still selects the highlighted variable as before. On the value field, Enter also appends a new trailing row so params can be added from the keyboard. The menu-open state is detected via a data attribute on the typeahead portal.

Verified with tsc, the http and prompt-editor vitest suites (683 tests), and added a component test for the single-line commit behavior. I deliberately kept the scope to preventing the newline corruption and the value-field "add row" affordance; full Tab-to-next-row focus management felt out of scope and risky to bundle here.
