### PR TITLE
fix(web): align tour trigger DOM order

### DIFF
--- a/web/app/components/main-nav/__tests__/index.spec.tsx
+++ b/web/app/components/main-nav/__tests__/index.spec.tsx
@@ -655,6 +655,23 @@ describe('MainNav', () => {
     expect(helpButton.parentElement).toHaveClass('shrink-0', 'rounded-full', 'p-1')
   })
 
+  it('orders the Step-by-step Tour before the account and help actions', async () => {
+    localStorage.setItem(STEP_BY_STEP_TOUR_SHELL_MODE_STORAGE_KEY, 'collapsed')
+
+    renderMainNav()
+
+    const tourTrigger = await screen.findByRole('button', { name: 'Open step-by-step tour' })
+    const accountButton = screen.getByRole('button', { name: 'common.account.account' })
+    const helpButton = screen.getByRole('button', { name: 'common.mainNav.help.openMenu' })
+
+    expect(tourTrigger.compareDocumentPosition(accountButton)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    )
+    expect(accountButton.compareDocumentPosition(helpButton)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    )
+  })
+
   it('keeps the global navigation account section expanded on home routes', () => {
     localStorage.setItem(DETAIL_SIDEBAR_STORAGE_KEY, 'collapse')
     mockPathname = '/'

--- a/web/app/components/main-nav/__tests__/index.spec.tsx
+++ b/web/app/components/main-nav/__tests__/index.spec.tsx
@@ -667,9 +667,7 @@ describe('MainNav', () => {
     expect(tourTrigger.compareDocumentPosition(accountButton)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     )
-    expect(accountButton.compareDocumentPosition(helpButton)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    )
+    expect(accountButton.compareDocumentPosition(helpButton)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
   })
 
   it('keeps the global navigation account section expanded on home routes', () => {

--- a/web/app/components/main-nav/index.tsx
+++ b/web/app/components/main-nav/index.tsx
@@ -133,6 +133,7 @@ export function MainNav({ className }: MainNavProps) {
         )}
       </div>
       <div className="relative w-60 shrink-0">
+        <StepByStepTourMount className="absolute -top-7 left-2.5 h-8 w-[183px] overflow-visible" />
         <div className="flex w-60 items-center justify-between bg-gradient-to-b from-background-body-transparent to-background-body to-50% py-3 pr-1 pl-3 backdrop-blur-[2px]">
           <div className="flex min-w-0 items-center gap-1 overflow-hidden">
             <AccountSection />
@@ -141,7 +142,6 @@ export function MainNav({ className }: MainNavProps) {
             <HelpMenu />
           </div>
         </div>
-        <StepByStepTourMount className="absolute -top-7 left-2.5 h-8 w-[183px] overflow-visible" />
       </div>
     </aside>
   )


### PR DESCRIPTION
## Summary

- move the Step-by-step Tour mount before the account and help actions in MainNav
- add a regression test for the resulting DOM order

## Why

The tour trigger is visually positioned above the footer actions, but its DOM position followed the account and help buttons. This made the keyboard order diverge from the visual order.

## Validation

- `cd web && vp test run app/components/main-nav/__tests__/index.spec.tsx`
- `git diff --check`