### PR TITLE
perf(web): skip unauthenticated SSR console prefetch

### DIFF
--- a/web/app/(commonLayout)/__tests__/hydration-boundary.spec.tsx
+++ b/web/app/(commonLayout)/__tests__/hydration-boundary.spec.tsx
@@ -18,6 +18,8 @@ const mocks = vi.hoisted(() => ({
   headers: vi.fn(),
   resolveServerConsoleApiUrl: vi.fn(),
   basePath: '',
+  accessTokenCookieName: 'access_token',
+  refreshTokenCookieName: 'refresh_token',
 }))
 
 vi.mock('@/context/query-client-server', async (importOriginal) => {
@@ -41,6 +43,11 @@ vi.mock('@/utils/var', () => ({
   get basePath() {
     return mocks.basePath
   },
+}))
+
+vi.mock('@/config', () => ({
+  ACCESS_TOKEN_COOKIE_NAME: () => mocks.accessTokenCookieName,
+  REFRESH_TOKEN_COOKIE_NAME: () => mocks.refreshTokenCookieName,
 }))
 
 vi.mock('@/features/account-profile/server', () => ({
@@ -76,6 +83,8 @@ describe('CommonLayoutHydrationBoundary', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.basePath = ''
+    mocks.accessTokenCookieName = 'access_token'
+    mocks.refreshTokenCookieName = 'refresh_token'
     mocks.rootQueryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     mocks.headers.mockResolvedValue(
       new Headers({
@@ -107,7 +116,7 @@ describe('CommonLayoutHydrationBoundary', () => {
       dataset: { default_permission_keys: [], overrides: [] },
     })
     mocks.getServerConsoleClientContext.mockResolvedValue({
-      cookie: 'session=abc',
+      cookie: 'access_token=abc; csrf_token=csrf-token',
       csrfToken: 'csrf-token',
     })
     mocks.workspaceQueryOptions.mockReturnValue({
@@ -142,7 +151,7 @@ describe('CommonLayoutHydrationBoundary', () => {
     expect(mocks.getServerConsoleClientContext).toHaveBeenCalledTimes(1)
     expect(mocks.workspaceQueryOptions).toHaveBeenCalledWith({
       context: {
-        cookie: 'session=abc',
+        cookie: 'access_token=abc; csrf_token=csrf-token',
         csrfToken: 'csrf-token',
       },
       retry: false,
@@ -150,12 +159,72 @@ describe('CommonLayoutHydrationBoundary', () => {
     expect(mocks.workspaceQueryFn).toHaveBeenCalledTimes(1)
     expect(mocks.permissionQueryOptions).toHaveBeenCalledWith({
       context: {
-        cookie: 'session=abc',
+        cookie: 'access_token=abc; csrf_token=csrf-token',
         csrfToken: 'csrf-token',
       },
       retry: false,
     })
     expect(mocks.permissionQueryFn).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    ['plain', 'access_token'],
+    ['__Host-', '__Host-access_token'],
+  ])(
+    'should keep the API-driven validation path when the %s access token cookie exists',
+    async (_, cookieName) => {
+      mocks.accessTokenCookieName = cookieName
+      mocks.getServerConsoleClientContext.mockResolvedValue({
+        cookie: `${cookieName}=abc; locale=en-US`,
+      })
+      const { CommonLayoutHydrationBoundary } = await import('../hydration-boundary')
+
+      await CommonLayoutHydrationBoundary({ children: null })
+
+      expect(mocks.profileQueryFn).toHaveBeenCalledTimes(1)
+      expect(mocks.workspaceQueryFn).toHaveBeenCalledTimes(1)
+      expect(mocks.permissionQueryFn).toHaveBeenCalledTimes(1)
+      expect(mocks.redirect).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each([
+    ['plain', 'refresh_token'],
+    ['__Host-', '__Host-refresh_token'],
+  ])(
+    'should redirect to auth refresh without prefetching when only the %s refresh token cookie exists',
+    async (_, cookieName) => {
+      mocks.refreshTokenCookieName = cookieName
+      mocks.getServerConsoleClientContext.mockResolvedValue({
+        cookie: `${cookieName}=old-refresh; locale=en-US`,
+      })
+      const { CommonLayoutHydrationBoundary } = await import('../hydration-boundary')
+
+      await expect(CommonLayoutHydrationBoundary({ children: null })).rejects.toThrow(
+        'NEXT_REDIRECT',
+      )
+
+      expect(mocks.redirect).toHaveBeenCalledWith(
+        '/auth/refresh?redirect_url=%2Fapps%3Ftag%3Dworkflow',
+      )
+      expect(mocks.profileQueryFn).not.toHaveBeenCalled()
+      expect(mocks.workspaceQueryFn).not.toHaveBeenCalled()
+      expect(mocks.permissionQueryFn).not.toHaveBeenCalled()
+    },
+  )
+
+  it('should redirect to signin without prefetching when no auth cookie exists', async () => {
+    mocks.getServerConsoleClientContext.mockResolvedValue({
+      cookie: 'locale=en-US',
+    })
+    const { CommonLayoutHydrationBoundary } = await import('../hydration-boundary')
+
+    await expect(CommonLayoutHydrationBoundary({ children: null })).rejects.toThrow('NEXT_REDIRECT')
+
+    expect(mocks.redirect).toHaveBeenCalledWith('/signin?redirect_url=%2Fapps%3Ftag%3Dworkflow')
+    expect(mocks.profileQueryFn).not.toHaveBeenCalled()
+    expect(mocks.workspaceQueryFn).not.toHaveBeenCalled()
+    expect(mocks.permissionQueryFn).not.toHaveBeenCalled()
   })
 
   it('should dehydrate only Common-owned queries', async () => {

--- a/web/app/(commonLayout)/hydration-boundary.tsx
+++ b/web/app/(commonLayout)/hydration-boundary.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query'
+import { ACCESS_TOKEN_COOKIE_NAME, REFRESH_TOKEN_COOKIE_NAME } from '@/config'
 import { makeQueryClient } from '@/context/query-client-server'
 import { serverUserProfileQueryOptions } from '@/features/account-profile/server'
 import { headers } from '@/next/headers'
@@ -9,11 +10,13 @@ import {
   resolveServerConsoleApiUrl,
   serverConsoleQuery,
 } from '@/service/server'
+import { hasRequestCookie } from '@/utils/request-cookie'
 
 const CURRENT_PATHNAME_HEADER = 'x-dify-pathname'
 const CURRENT_SEARCH_HEADER = 'x-dify-search'
 const ACCOUNT_PROFILE_PATH = '/account/profile'
 const AUTH_REFRESH_PATH = '/auth/refresh'
+const SIGNIN_PATH = '/signin'
 
 type ConsoleErrorPayload = {
   code?: string
@@ -43,6 +46,11 @@ const redirectToAuthRefresh = async () => {
   redirect(`${AUTH_REFRESH_PATH}?redirect_url=${encodeURIComponent(currentPath)}`)
 }
 
+const redirectToSignin = async () => {
+  const currentPath = await getCurrentPath()
+  redirect(`${SIGNIN_PATH}?redirect_url=${encodeURIComponent(currentPath)}`)
+}
+
 const handleProfileError = async (error: unknown) => {
   if (!(error instanceof Response)) throw error
 
@@ -61,6 +69,14 @@ export async function CommonLayoutHydrationBoundary({ children }: { children: Re
   if (accountProfileUrl) {
     try {
       const context = await getServerConsoleClientContext()
+      const hasAccessToken = hasRequestCookie(context.cookie, ACCESS_TOKEN_COOKIE_NAME())
+
+      if (!hasAccessToken) {
+        if (hasRequestCookie(context.cookie, REFRESH_TOKEN_COOKIE_NAME()))
+          await redirectToAuthRefresh()
+
+        await redirectToSignin()
+      }
 
       await Promise.all([
         queryClient.fetchQuery(serverUserProfileQueryOptions()),

--- a/web/app/auth/refresh/__tests__/route.spec.ts
+++ b/web/app/auth/refresh/__tests__/route.spec.ts
@@ -4,12 +4,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   basePath: '',
+  refreshTokenCookieName: 'refresh_token',
 }))
 
 vi.mock('@/config', () => ({
   API_PREFIX: 'http://localhost:5001/console/api',
+  ACCESS_TOKEN_COOKIE_NAME: () => 'access_token',
   CSRF_COOKIE_NAME: () => 'csrf_token',
   CSRF_HEADER_NAME: 'X-CSRF-Token',
+  REFRESH_TOKEN_COOKIE_NAME: () => mocks.refreshTokenCookieName,
 }))
 
 vi.mock('server-only', () => ({}))
@@ -48,6 +51,7 @@ describe('auth refresh route', () => {
     vi.resetModules()
     vi.unstubAllGlobals()
     mocks.basePath = ''
+    mocks.refreshTokenCookieName = 'refresh_token'
   })
 
   it('should refresh cookies and redirect back to the requested path', async () => {
@@ -88,6 +92,41 @@ describe('auth refresh route', () => {
       'access_token=new-access; Path=/; HttpOnly',
       'refresh_token=new-refresh; Path=/; HttpOnly',
     ])
+  })
+
+  it.each([
+    ['plain', 'refresh_token'],
+    ['__Host-', '__Host-refresh_token'],
+  ])('should call refresh-token when the %s refresh token cookie exists', async (_, cookieName) => {
+    mocks.refreshTokenCookieName = cookieName
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { GET } = await import('../route')
+
+    const response = await GET(
+      createRequest(
+        'http://localhost:3000/auth/refresh?redirect_url=%2Fapps',
+        `${cookieName}=old-refresh; locale=en-US`,
+      ),
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(response.status).toBe(303)
+    expect(response.headers.get('location')).toBe('/apps')
+  })
+
+  it('should redirect to signin without calling refresh-token when only unrelated cookies exist', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const { GET } = await import('../route')
+
+    const response = await GET(
+      createRequest('http://localhost:3000/auth/refresh?redirect_url=%2Fapps', 'locale=en-US'),
+    )
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(response.status).toBe(303)
+    expect(response.headers.get('location')).toBe('/signin?redirect_url=%2Fapps')
   })
 
   it('should redirect to signin when refresh token is rejected', async () => {

--- a/web/app/auth/refresh/route.ts
+++ b/web/app/auth/refresh/route.ts
@@ -1,6 +1,8 @@
 import type { LoginRedirectTarget } from '@/utils/login-redirect'
+import { REFRESH_TOKEN_COOKIE_NAME } from '@/config'
 import { resolveServerConsoleApiUrl } from '@/service/server'
 import { getServerLoginFallback, resolveLoginRedirectTarget } from '@/utils/login-redirect'
+import { hasRequestCookie } from '@/utils/request-cookie'
 import { basePath } from '@/utils/var'
 
 const REFRESH_TOKEN_PATH = '/refresh-token'
@@ -92,7 +94,8 @@ export async function GET(request: Request) {
   const refreshUrl = resolveServerConsoleApiUrl(REFRESH_TOKEN_PATH)
   const cookie = request.headers.get('cookie')
 
-  if (!refreshUrl || !cookie) return createSigninRedirectResponse(redirectTarget)
+  if (!refreshUrl || !cookie || !hasRequestCookie(cookie, REFRESH_TOKEN_COOKIE_NAME()))
+    return createSigninRedirectResponse(redirectTarget)
 
   try {
     const response = await fetch(refreshUrl, {

--- a/web/config/index.ts
+++ b/web/config/index.ts
@@ -94,12 +94,17 @@ export const SOCKET_URL = getStringConfig(env.NEXT_PUBLIC_SOCKET_URL, 'ws://loca
 
 export const BATCH_CONCURRENCY = env.NEXT_PUBLIC_BATCH_CONCURRENCY
 
-export const CSRF_COOKIE_NAME = () => {
-  if (COOKIE_DOMAIN) return 'csrf_token'
+const AUTH_COOKIE_NAME = (cookieName: string) => {
+  if (COOKIE_DOMAIN) return cookieName
   const isSecure = API_PREFIX.startsWith('https://')
-  return isSecure ? '__Host-csrf_token' : 'csrf_token'
+  return isSecure ? `__Host-${cookieName}` : cookieName
+}
+export const CSRF_COOKIE_NAME = () => {
+  return AUTH_COOKIE_NAME('csrf_token')
 }
 export const CSRF_HEADER_NAME = 'X-CSRF-Token'
+export const ACCESS_TOKEN_COOKIE_NAME = () => AUTH_COOKIE_NAME('access_token')
+export const REFRESH_TOKEN_COOKIE_NAME = () => AUTH_COOKIE_NAME('refresh_token')
 export const ACCESS_TOKEN_LOCAL_STORAGE_NAME = 'access_token'
 export const PASSPORT_LOCAL_STORAGE_NAME = (appCode: string) => `passport-${appCode}`
 export const PASSPORT_HEADER_NAME = 'X-App-Passport'

--- a/web/utils/request-cookie.ts
+++ b/web/utils/request-cookie.ts
@@ -1,0 +1,2 @@
+export const hasRequestCookie = (cookieHeader: string | undefined, cookieName: string) =>
+  Boolean(cookieHeader?.split(';').some((cookie) => cookie.trim().split('=', 1)[0] === cookieName))


### PR DESCRIPTION
## Summary

- skip the three SSR console API prefetches when the request has no access-token cookie
- route refresh-only requests directly through `/auth/refresh`, while requests without auth cookies go directly to sign-in
- avoid calling `/console/api/refresh-token` when the request only contains unrelated cookies
- keep the existing API-driven validation path whenever an access-token cookie is present

Closes #39610.

## Validation

- `NODE_ENV=test pnpm --dir web exec vp test run 'app/(commonLayout)/__tests__/hydration-boundary.spec.tsx' app/auth/refresh/__tests__/route.spec.ts` — 43 passed
- `NODE_ENV=test pnpm --dir web exec vp test run service/__tests__/server.spec.ts features/account-profile/__tests__/server.spec.ts config/__tests__/server.spec.ts` — 9 passed
- changed-file `vp check` — passed with no warnings, lint errors, or type errors
- `pnpm --dir web lint:tss` — 6000 passed
- `git diff --check` — passed
- independent candidate review — PASS
- independent patch review — PASS

The regression tests were also applied independently to the current upstream base without the production changes: 4 intended failures reproduced, then all 43 focused tests passed with this patch.

## Duplicate Check

Checked immediately before publication against upstream `main` at `f68cabe2267295fbfb10341ea53f31b65f0a97c5`.

- issue #39610 remains open, unassigned, and has no implementation claim or contribution-lock label
- no active PR was found by issue number, `CommonLayoutHydrationBoundary`, auth-cookie SSR, or refresh-token/hydration-boundary searches
- related merged PRs #39308, #38570, and #36818 address different hydration/base-path/auth-boot behavior and do not implement this cookie short-circuit

## Browser / Playwright

Not run. This change only selects server-side redirect/fetch branches and does not alter browser layout or interaction behavior; focused Vitest coverage deterministically verifies redirects and that the relevant fetch/prefetch calls do or do not occur.
