### PR TITLE
fix(workflow): align block icon vector sizes

### DIFF
--- a/web/app/components/workflow/block-icon.tsx
+++ b/web/app/components/workflow/block-icon.tsx
@@ -31,16 +31,23 @@ import {
 import { API_PREFIX } from '@/config'
 import { BlockEnum } from './types'
 
+type BlockIconSize = 'xs' | 'sm' | 'md'
+
 type BlockIconProps = {
   type: BlockEnum
-  size?: string
+  size?: BlockIconSize
   className?: string
   toolIcon?: string | { content: string; background: string }
 }
-const ICON_CONTAINER_CLASSNAME_SIZE_MAP: Record<string, string> = {
+const ICON_CONTAINER_CLASSNAME_SIZE_MAP: Record<BlockIconSize, string> = {
   xs: 'w-4 h-4 rounded-[5px] shadow-xs',
   sm: 'w-5 h-5 rounded-md shadow-xs',
   md: 'w-6 h-6 rounded-lg shadow-md',
+}
+const ICON_CLASSNAME_SIZE_MAP: Record<BlockIconSize, string> = {
+  xs: 'size-3',
+  sm: 'size-3.5',
+  md: 'size-4',
 }
 
 const DEFAULT_ICON_MAP: Record<BlockEnum, React.ComponentType<{ className: string }>> = {
@@ -144,7 +151,7 @@ const BlockIcon: FC<BlockIconProps> = ({ type, size = 'sm', className, toolIcon 
       >
         <span
           aria-hidden
-          className={cn('i-custom-vender-workflow-user-input', size === 'xs' ? 'size-4' : 'size-4')}
+          className={cn('i-custom-vender-workflow-user-input', ICON_CLASSNAME_SIZE_MAP[size])}
         />
       </div>
     )
@@ -163,7 +170,7 @@ const BlockIcon: FC<BlockIconProps> = ({ type, size = 'sm', className, toolIcon 
           aria-hidden
           className={cn(
             'i-custom-vender-workflow-start-placeholder text-text-primary opacity-30',
-            size === 'xs' ? 'size-3' : 'size-3.5',
+            ICON_CLASSNAME_SIZE_MAP[size],
           )}
         />
       </div>
@@ -180,17 +187,7 @@ const BlockIcon: FC<BlockIconProps> = ({ type, size = 'sm', className, toolIcon 
         className,
       )}
     >
-      {showDefaultIcon &&
-        getIcon(
-          type,
-          type === BlockEnum.TriggerSchedule || type === BlockEnum.TriggerWebhook
-            ? size === 'xs'
-              ? 'w-4 h-4'
-              : 'w-4.5 h-4.5'
-            : size === 'xs'
-              ? 'w-3 h-3'
-              : 'w-3.5 h-3.5',
-        )}
+      {showDefaultIcon && getIcon(type, ICON_CLASSNAME_SIZE_MAP[size])}
       {!showDefaultIcon && (
         <>
           {typeof resolvedToolIcon === 'string' ? (


### PR DESCRIPTION
## Summary

- Align built-in workflow block icon vectors to the shared 12 / 14 / 16 px size contract for 16 / 20 / 24 px containers.
- Apply the rule consistently to User Input, Schedule Trigger, Webhook Trigger, and other built-in workflow icons.
- Preserve plugin-provided icon images and existing container styling.

## Screenshots

| Before | After |
|--------|-------|
| Not captured — component-level vector sizing adjustment | Matched to the Dify Design Kit size contract |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran the staged frontend check and focused workflow icon tests.

## Validation

- `vp staged`
- `vitest run app/components/workflow/__tests__/block-icon.spec.tsx`

From Codex