### PR TITLE
fix(cli): decouple release script tests from the live compat window

### DIFF
--- a/cli/scripts/release-naming.mjs
+++ b/cli/scripts/release-naming.mjs
@@ -114,9 +114,15 @@ function die(msg) {
   process.exit(1)
 }
 
+// Tests point this at a fixture manifest so their assertions stay fixed while
+// the real version and compat window move with every release. The name is
+// mirrored in test/fixtures/pkg-manifest.ts rather than imported from here,
+// because this file's shebang breaks the Windows test runner.
+const PKG_PATH_ENV = 'DIFYCTL_PKG_PATH'
+
 function loadPkg() {
-  const pkgUrl = new URL('../package.json', import.meta.url)
-  const pkg = JSON.parse(readFileSync(pkgUrl, 'utf8'))
+  const pkgPath = process.env[PKG_PATH_ENV] || new URL('../package.json', import.meta.url)
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
   if (!pkg.difyctl?.release) die('cli/package.json missing difyctl.release')
   return {
     version: pkg.version,

--- a/cli/scripts/release-naming.test.ts
+++ b/cli/scripts/release-naming.test.ts
@@ -1,12 +1,19 @@
 import { execFileSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { FIXTURE_COMPAT, pkgManifestEnv } from '../test/fixtures/pkg-manifest'
 
 const SCRIPT = fileURLToPath(new URL('./release-naming.mjs', import.meta.url))
 
-function run(args: string[]): { code: number; stdout: string; stderr: string } {
+function run(
+  args: string[],
+  env: Record<string, string> = {},
+): { code: number; stdout: string; stderr: string } {
   try {
-    const stdout = execFileSync('node', [SCRIPT, ...args], { encoding: 'utf8' })
+    const stdout = execFileSync('node', [SCRIPT, ...args], {
+      encoding: 'utf8',
+      env: { ...process.env, ...env },
+    })
     return { code: 0, stdout, stderr: '' }
   } catch (e) {
     const err = e as { status?: number; stdout?: string; stderr?: string }
@@ -14,45 +21,50 @@ function run(args: string[]): { code: number; stdout: string; stderr: string } {
   }
 }
 
-describe('release-naming compat-check (compat 1.16.0..1.16.0)', () => {
+describe('release-naming compat-check', () => {
+  const { minDify, maxDify } = FIXTURE_COMPAT // 2.0.0 .. 2.5.0
+  const pkgEnv = pkgManifestEnv()
+  const compatCheck = (difyVersion?: string) =>
+    run(difyVersion === undefined ? ['compat-check'] : ['compat-check', difyVersion], pkgEnv).code
+
   it('accepts a version inside the window', () => {
-    expect(run(['compat-check', '1.16.0']).code).toBe(0)
+    expect(compatCheck('2.3.0')).toBe(0)
   })
 
   it('accepts the inclusive lower bound', () => {
-    expect(run(['compat-check', '1.16.0']).code).toBe(0)
+    expect(compatCheck(minDify)).toBe(0)
   })
 
   it('accepts the inclusive upper bound', () => {
-    expect(run(['compat-check', '1.16.0']).code).toBe(0)
+    expect(compatCheck(maxDify)).toBe(0)
   })
 
   it('accepts a v-prefixed tag', () => {
-    expect(run(['compat-check', 'v1.16.0']).code).toBe(0)
+    expect(compatCheck('v2.3.0')).toBe(0)
   })
 
   it('rejects a version below the lower bound', () => {
-    expect(run(['compat-check', '1.15.9']).code).not.toBe(0)
+    expect(compatCheck('1.9.9')).not.toBe(0)
   })
 
   it('rejects a version above the upper bound', () => {
-    expect(run(['compat-check', '1.16.1']).code).not.toBe(0)
+    expect(compatCheck('2.5.1')).not.toBe(0)
   })
 
-  it('treats a prerelease of the bound as below it (1.16.0-rc1 < 1.16.0)', () => {
-    expect(run(['compat-check', '1.16.0-rc1']).code).not.toBe(0)
+  it('treats a prerelease of the lower bound as below it', () => {
+    expect(compatCheck(`${minDify}-rc1`)).not.toBe(0)
   })
 
-  it('ignores build metadata on the bound (1.16.0+build == 1.16.0)', () => {
-    expect(run(['compat-check', '1.16.0+build123']).code).toBe(0)
+  it('ignores build metadata on the bound', () => {
+    expect(compatCheck(`${maxDify}+build123`)).toBe(0)
   })
 
-  it('ignores build metadata when out of range (1.16.1+build still rejected)', () => {
-    expect(run(['compat-check', '1.16.1+build123']).code).not.toBe(0)
+  it('ignores build metadata when out of range', () => {
+    expect(compatCheck('2.5.1+build123')).not.toBe(0)
   })
 
   it('requires a version argument', () => {
-    expect(run(['compat-check']).code).not.toBe(0)
+    expect(compatCheck()).not.toBe(0)
   })
 })
 
@@ -66,6 +78,14 @@ describe('release-naming github-env', () => {
     const { stdout } = run(['github-env'])
     for (const key of ['version', 'channel', 'prerelease', 'minDify', 'maxDify', 'tagPrefix'])
       expect(stdout).toMatch(new RegExp(`^${key}=`, 'm'))
+  })
+
+  // The only assertion against the live manifest: the window must exist and be
+  // well-formed, whatever release it currently points at.
+  it('emits a well-formed compat window from the real cli/package.json', () => {
+    const { stdout } = run(['github-env'])
+    expect(stdout).toMatch(/^minDify=\d+\.\d+\.\d+$/m)
+    expect(stdout).toMatch(/^maxDify=\d+\.\d+\.\d+$/m)
   })
 })
 

--- a/cli/scripts/release-r2-edge.test.ts
+++ b/cli/scripts/release-r2-edge.test.ts
@@ -4,14 +4,20 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { FIXTURE_COMPAT, pkgManifestEnv } from '../test/fixtures/pkg-manifest'
 
 const SCRIPT = fileURLToPath(new URL('./release-r2-edge.mjs', import.meta.url))
+
+const PKG_ENV = pkgManifestEnv()
 
 function run(args: string[]): { code: number; stdout: string; stderr: string } {
   try {
     return {
       code: 0,
-      stdout: execFileSync('node', [SCRIPT, ...args], { encoding: 'utf8' }),
+      stdout: execFileSync('node', [SCRIPT, ...args], {
+        encoding: 'utf8',
+        env: { ...process.env, ...PKG_ENV },
+      }),
       stderr: '',
     }
   } catch (e) {
@@ -108,7 +114,7 @@ describe('release-r2-edge manifest', () => {
 
   it('carries the compat window from package.json', () => {
     const { json } = buildManifest()
-    expect(json.compat).toEqual({ minDify: '1.16.0', maxDify: '1.16.0' })
+    expect(json.compat).toEqual(FIXTURE_COMPAT)
   })
 
   it('lists all 5 targets with asset name + sha256 from the checksums file', () => {

--- a/cli/test/fixtures/pkg-manifest.ts
+++ b/cli/test/fixtures/pkg-manifest.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// Mirrors PKG_PATH_ENV in scripts/release-naming.mjs, which cannot be imported
+// here: its shebang breaks the Windows test runner. Divergence is self-
+// reporting, not silent — the script would fall back to the real
+// cli/package.json and every fixture-window assertion would fail.
+const PKG_PATH_ENV = 'DIFYCTL_PKG_PATH'
+
+// release-naming.mjs and release-r2-edge.mjs read their data from
+// cli/package.json. Tests spawn them against this fixture instead, so
+// assertions can name exact versions without tracking the live release.
+
+// Deliberately far from any real Dify version, and min != max so "inside the
+// window" is a case distinct from either bound.
+export const FIXTURE_COMPAT = { minDify: '2.0.0', maxDify: '2.5.0' }
+
+export const FIXTURE_TARGET_IDS = [
+  'linux-x64',
+  'linux-arm64',
+  'darwin-x64',
+  'darwin-arm64',
+  'windows-x64',
+] as const
+
+const FIXTURE_RELEASE = {
+  tagPrefix: 'difyctl-v',
+  binName: 'difyctl',
+  checksumsSuffix: '-checksums.txt',
+  targets: FIXTURE_TARGET_IDS.map((id) => ({
+    id,
+    bunTarget: `bun-${id}`,
+    exe: id.startsWith('windows'),
+  })),
+}
+
+export type PkgManifestOverrides = {
+  version?: string
+  channel?: string
+  compat?: { minDify: string; maxDify: string }
+}
+
+// Returns the env additions that point a spawned script at the fixture.
+export function pkgManifestEnv(overrides: PkgManifestOverrides = {}): Record<string, string> {
+  const manifest = {
+    version: overrides.version ?? '0.2.0-alpha',
+    difyctl: {
+      channel: overrides.channel ?? 'alpha',
+      compat: overrides.compat ?? FIXTURE_COMPAT,
+      release: FIXTURE_RELEASE,
+    },
+  }
+  const path = join(mkdtempSync(join(tmpdir(), 'difyctl-pkg-')), 'package.json')
+  writeFileSync(path, JSON.stringify(manifest))
+  return { [PKG_PATH_ENV]: path }
+}


### PR DESCRIPTION
## Summary

`cli/scripts/release-naming.test.ts` and `cli/scripts/release-r2-edge.test.ts` asserted against the live compat window in `cli/package.json`, so every Dify release bump inverts eight assertions and breaks CLI CI.

This is currently blocking #39653 (bump to 1.16.1) — `compat-check 1.16.0` now exits 1 (`expected 1 to be +0`) and `compat-check 1.16.1` now exits 0 (`expected +0 not to be +0`), on both `macos-latest` and `depot-ubuntu-24.04`.

### Why the tests read the live manifest at all

`loadPkg()` resolved `cli/package.json` relative to the script with no override, and the tests spawn the script as a subprocess — so the real file was the only reachable input. Hardcoding the current window was the only way to match it.

### Changes

- `release-naming.mjs`: `loadPkg()` honours a `DIFYCTL_PKG_PATH` override, defaulting to `cli/package.json` as before. This is the seam the tests were missing.
- `cli/test/fixtures/pkg-manifest.ts`: writes a temp manifest with a fixed `2.0.0..2.5.0` window and points a spawned script at it.
- Both test files run against that fixture, so no assertion depends on where the real window sits.
- One test still asserts the real `cli/package.json` emits a well-formed window — the live check, kept isolated.

Distinct bounds also restore coverage the live window could not express. With `min == max == 1.16.0`, `accepts a version inside the window` was a byte-for-byte duplicate of the lower-bound case, and a `minDify`/`maxDify` mix-up in the emitted manifest was undetectable.

## Verification

Reproduced by applying #39653's compat bump on top of `main`: 8 failed / 27 passed, matching CI exactly. With this change the same bump is green, and so is the unbumped tree — the suite no longer cares where the window sits.

Mutation-checked the manifest test by swapping `maxDify` for `minDify` in `release-r2-edge.mjs`:

```
AssertionError: expected { minDify: '2.0.0', maxDify: '2.0.0' }
              to deeply equal { minDify: '2.0.0', maxDify: '2.5.0' }
```

That mutation passed silently under the old single-valued window.

- `pnpm test` (cli): 1247 passed, 26 skipped, 0 failed
- `vp check cli`: 348 files formatted, no lint or type errors

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs) — n/a, test-only
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
