### PR TITLE
fix(web-api): restrict public HITL form tokens

### DIFF
--- a/api/controllers/web/human_input_form.py
+++ b/api/controllers/web/human_input_form.py
@@ -19,6 +19,7 @@ from controllers.common.schema import register_response_schema_models, register_
 from controllers.web import web_ns
 from controllers.web.error import WebFormRateLimitExceededError
 from controllers.web.site import WebAppSiteResponse
+from core.workflow.human_input_policy import HumanInputSurface, is_recipient_type_allowed_for_surface
 from core.workflow.nodes.human_input.entities import FormInputConfig, UserActionConfig
 from extensions.ext_database import db
 from fields.base import ResponseModel
@@ -184,11 +185,9 @@ class HumanInputFormApi(Resource):
         _FORM_ACCESS_RATE_LIMITER.increment_rate_limit(ip_address)
 
         service = HumanInputService(db.engine)
-        # TODO(QuantumGhost): forbid submission for form tokens
-        # that are only for console.
         form = service.get_form_by_token(form_token)
 
-        if form is None:
+        if form is None or not is_recipient_type_allowed_for_surface(form.recipient_type, HumanInputSurface.WEB):
             raise NotFoundError("Form not found")
 
         service.ensure_form_active(form)
@@ -258,12 +257,11 @@ class HumanInputFormApi(Resource):
 
         service = HumanInputService(db.engine)
         form = service.get_form_by_token(form_token)
-        if form is None:
+        if form is None or not is_recipient_type_allowed_for_surface(form.recipient_type, HumanInputSurface.WEB):
             raise NotFoundError("Form not found")
 
-        if (recipient_type := form.recipient_type) is None:
-            logger.warning("Recipient type is None for form, form_id=%", form.id)
-            raise AssertionError("Recipient type is None")
+        recipient_type = form.recipient_type
+        assert recipient_type is not None
 
         try:
             service.submit_form_by_token(

--- a/api/core/workflow/human_input_policy.py
+++ b/api/core/workflow/human_input_policy.py
@@ -20,14 +20,16 @@ class HumanInputSurface(StrEnum):
     SERVICE_API = "service_api"
     CONSOLE = "console"
     OPENAPI = "openapi"
+    WEB = "web"
 
 
-# SERVICE_API and OPENAPI are intentionally narrower than CONSOLE: token callers
+# Token-facing API surfaces are intentionally narrower than CONSOLE: callers
 # should only be able to act on end-user web forms, not internal console flows.
 ALLOWED_RECIPIENT_TYPES_BY_SURFACE: dict[HumanInputSurface, frozenset[RecipientType]] = {
     HumanInputSurface.SERVICE_API: frozenset({RecipientType.STANDALONE_WEB_APP}),
     HumanInputSurface.CONSOLE: frozenset({RecipientType.CONSOLE, RecipientType.BACKSTAGE}),
     HumanInputSurface.OPENAPI: frozenset({RecipientType.STANDALONE_WEB_APP}),
+    HumanInputSurface.WEB: frozenset({RecipientType.STANDALONE_WEB_APP}),
 }
 
 # A single HITL form can have multiple recipient records; this shared priority

--- a/api/services/human_input_file_upload_service.py
+++ b/api/services/human_input_file_upload_service.py
@@ -8,6 +8,7 @@ from sqlalchemy import Engine, select
 from sqlalchemy.orm import Session, selectinload, sessionmaker
 
 from configs import dify_config
+from core.workflow.human_input_policy import HumanInputSurface, is_recipient_type_allowed_for_surface
 from core.workflow.nodes.human_input.enums import HumanInputFormKind, HumanInputFormStatus
 from libs.datetime_utils import ensure_naive_utc, naive_utc_now
 from models.account import Account, Tenant
@@ -79,7 +80,11 @@ class HumanInputFileUploadService:
                 .where(HumanInputFormRecipient.access_token == form_token)
                 .limit(1)
             )
-            if recipient_model is None or recipient_model.form is None:
+            if (
+                recipient_model is None
+                or recipient_model.form is None
+                or not is_recipient_type_allowed_for_surface(recipient_model.recipient_type, HumanInputSurface.WEB)
+            ):
                 raise FormNotFoundError()
 
             form = recipient_model.form

--- a/api/tests/unit_tests/controllers/web/test_human_input_form.py
+++ b/api/tests/unit_tests/controllers/web/test_human_input_form.py
@@ -120,7 +120,7 @@ def test_get_form_includes_site(monkeypatch: pytest.MonkeyPatch, app: Flask, dat
             self.app_id = app_model.id
             self.tenant_id = app_model.tenant_id
             self.expiration_time = expiration
-            self.recipient_type = RecipientType.BACKSTAGE
+            self.recipient_type = RecipientType.STANDALONE_WEB_APP
 
         def get_definition(self):
             return _FakeDefinition()
@@ -323,99 +323,24 @@ def test_create_upload_token_returns_token_and_form_expiration(
     limiter_mock.increment_rate_limit.assert_called_once_with("203.0.113.10")
 
 
-def test_get_form_allows_backstage_token(monkeypatch: pytest.MonkeyPatch, app: Flask, database_session: Session):
-    """GET returns form payload for backstage token."""
+def test_get_form_rejects_backstage_token(monkeypatch: pytest.MonkeyPatch, app: Flask, sqlite_engine: Engine):
+    """GET hides forms whose tokens belong to an internal console surface."""
 
-    expiration_time = datetime(2099, 1, 2, tzinfo=UTC)
-    _, app_model, _ = _persist_app_site(database_session)
-
-    class _FakeDefinition:
-        def model_dump(self, mode: str | None = None):
-            return {
-                "form_content": "Raw content",
-                "rendered_content": "Rendered",
-                "inputs": [],
-                "default_values": {},
-                "user_actions": [],
-            }
-
-    class _FakeForm:
-        def __init__(self, expiration: datetime):
-            self.workflow_run_id = None
-            self.app_id = app_model.id
-            self.tenant_id = app_model.tenant_id
-            self.expiration_time = expiration
-
-        def get_definition(self):
-            return _FakeDefinition()
-
-    form = _FakeForm(expiration_time)
+    form = SimpleNamespace(recipient_type=RecipientType.BACKSTAGE)
     limiter_mock = MagicMock()
     limiter_mock.is_rate_limited.return_value = False
     monkeypatch.setattr(human_input_module, "_FORM_ACCESS_RATE_LIMITER", limiter_mock)
     monkeypatch.setattr(human_input_module, "extract_remote_ip", lambda req: "203.0.113.10")
     service_mock = MagicMock()
     service_mock.get_form_by_token.return_value = form
-    service_mock.resolve_form_inputs.return_value = []
     monkeypatch.setattr(human_input_module, "HumanInputService", lambda engine: service_mock)
-
-    monkeypatch.setattr(
-        site_module.FeatureService,
-        "get_features",
-        lambda tenant_id, **_kwargs: FeatureModel(can_replace_logo=True, webapp_copyright_enabled=True),
-    )
+    monkeypatch.setattr(human_input_module, "db", SimpleNamespace(engine=sqlite_engine))
 
     with app.test_request_context("/api/form/human_input/token-1", method="GET"):
-        response = HumanInputFormApi().get("token-1")
+        with pytest.raises(human_input_module.NotFoundError):
+            HumanInputFormApi().get("token-1")
 
-    body = response
-    assert set(body.keys()) == {
-        "site",
-        "form_content",
-        "inputs",
-        "resolved_default_values",
-        "user_actions",
-        "expiration_time",
-    }
-    assert body["form_content"] == "Rendered"
-    assert body["inputs"] == []
-    assert body["resolved_default_values"] == {}
-    assert body["user_actions"] == []
-    assert body["expiration_time"] == int(expiration_time.timestamp())
-    assert body["site"] == {
-        "app_id": app_model.id,
-        "mode": "chat",
-        "end_user_id": None,
-        "enable_site": True,
-        "site": {
-            "title": "My Site",
-            "chat_color_theme": "light",
-            "chat_color_theme_inverted": False,
-            "icon_type": "emoji",
-            "icon": "robot",
-            "icon_background": "#fff",
-            "icon_url": None,
-            "description": "desc",
-            "copyright": None,
-            "privacy_policy": None,
-            "input_placeholder": "Ask the app",
-            "custom_disclaimer": "",
-            "default_language": "en",
-            "prompt_public": False,
-            "show_workflow_steps": True,
-            "use_icon_as_answer_icon": False,
-        },
-        "model_config": None,
-        "plan": "basic",
-        "can_replace_logo": True,
-        "custom_config": {
-            "remove_webapp_brand": True,
-            "replace_webapp_logo": None,
-        },
-    }
-    service_mock.get_form_by_token.assert_called_once_with("token-1")
-    limiter_mock.is_rate_limited.assert_called_once_with("203.0.113.10")
-    limiter_mock.increment_rate_limit.assert_called_once_with("203.0.113.10")
+    service_mock.ensure_form_active.assert_not_called()
 
 
 def test_get_form_raises_forbidden_when_site_missing(
@@ -442,6 +367,7 @@ def test_get_form_raises_forbidden_when_site_missing(
             self.app_id = app_model.id
             self.tenant_id = app_model.tenant_id
             self.expiration_time = expiration
+            self.recipient_type = RecipientType.STANDALONE_WEB_APP
 
         def get_definition(self):
             return _FakeDefinition()
@@ -462,13 +388,10 @@ def test_get_form_raises_forbidden_when_site_missing(
     limiter_mock.increment_rate_limit.assert_called_once_with("203.0.113.10")
 
 
-def test_submit_form_accepts_backstage_token(monkeypatch: pytest.MonkeyPatch, app: Flask, sqlite_engine: Engine):
-    """POST forwards backstage submissions to the service."""
+def test_submit_form_rejects_backstage_token(monkeypatch: pytest.MonkeyPatch, app: Flask, sqlite_engine: Engine):
+    """POST hides forms whose tokens belong to an internal console surface."""
 
-    class _FakeForm:
-        recipient_type = RecipientType.BACKSTAGE
-
-    form = _FakeForm()
+    form = SimpleNamespace(recipient_type=RecipientType.BACKSTAGE)
     limiter_mock = MagicMock()
     limiter_mock.is_rate_limited.return_value = False
     monkeypatch.setattr(human_input_module, "_FORM_SUBMIT_RATE_LIMITER", limiter_mock)
@@ -483,19 +406,10 @@ def test_submit_form_accepts_backstage_token(monkeypatch: pytest.MonkeyPatch, ap
         method="POST",
         json={"inputs": {"content": "ok"}, "action": "approve"},
     ):
-        response, status = HumanInputFormApi().post("token-1")
+        with pytest.raises(human_input_module.NotFoundError):
+            HumanInputFormApi().post("token-1")
 
-    assert status == 200
-    assert response == {}
-    service_mock.submit_form_by_token.assert_called_once_with(
-        recipient_type=RecipientType.BACKSTAGE,
-        form_token="token-1",
-        selected_action_id="approve",
-        form_data={"content": "ok"},
-        submission_end_user_id=None,
-    )
-    limiter_mock.is_rate_limited.assert_called_once_with("203.0.113.10")
-    limiter_mock.increment_rate_limit.assert_called_once_with("203.0.113.10")
+    service_mock.submit_form_by_token.assert_not_called()
 
 
 def test_submit_form_rate_limited(monkeypatch: pytest.MonkeyPatch, app: Flask):
@@ -546,7 +460,7 @@ def test_get_form_rate_limited(monkeypatch: pytest.MonkeyPatch, app: Flask):
 
 def test_get_form_raises_expired(monkeypatch: pytest.MonkeyPatch, app: Flask, sqlite_engine: Engine):
     class _FakeForm:
-        pass
+        recipient_type = RecipientType.STANDALONE_WEB_APP
 
     form = _FakeForm()
     limiter_mock = MagicMock()

--- a/api/tests/unit_tests/services/test_human_input_file_upload_service.py
+++ b/api/tests/unit_tests/services/test_human_input_file_upload_service.py
@@ -21,6 +21,7 @@ from models.human_input import (
     HumanInputFormRecipient,
     HumanInputFormUploadFile,
     HumanInputFormUploadToken,
+    RecipientType,
 )
 from models.model import App, AppMode, EndUser
 from models.workflow import WorkflowRun, WorkflowType
@@ -73,6 +74,7 @@ def _create_waiting_form(
     *,
     created_by_role: CreatorUserRole = CreatorUserRole.ACCOUNT,
     form_kind: HumanInputFormKind = HumanInputFormKind.RUNTIME,
+    recipient_type: RecipientType = RecipientType.STANDALONE_WEB_APP,
 ) -> tuple[str, str, str]:
     form_id = "00000000-0000-0000-0000-000000000001"
     recipient_id = "00000000-0000-0000-0000-000000000002"
@@ -176,8 +178,8 @@ def _create_waiting_form(
                 id=recipient_id,
                 form_id=form_id,
                 delivery_id="00000000-0000-0000-0000-000000000003",
-                recipient_type="standalone_web_app",
-                recipient_payload='{"TYPE": "standalone_web_app"}',
+                recipient_type=recipient_type.value,
+                recipient_payload=f'{{"TYPE": "{recipient_type.value}"}}',
                 access_token="form-token-1",
             )
         )
@@ -192,6 +194,13 @@ def _create_service(
         session_maker,
         workflow_run_repository=workflow_run_repository or MagicMock(),
     )
+
+
+def test_issue_upload_token_rejects_backstage_recipient(session_maker) -> None:
+    _create_waiting_form(session_maker, recipient_type=RecipientType.BACKSTAGE)
+
+    with pytest.raises(service_module.FormNotFoundError):
+        _create_service(session_maker).issue_upload_token("form-token-1")
 
 
 def test_issue_upload_token_persists_token_without_technical_end_user(


### PR DESCRIPTION
## Summary
- add the public web surface to the shared HITL recipient policy
- return form-not-found for console/backstage tokens on public GET and POST endpoints
- prevent console/backstage form tokens from issuing public upload tokens
- add regression coverage for all three paths

## Test plan
- `uv run --project api pytest api/tests/unit_tests/controllers/web/test_human_input_form.py api/tests/unit_tests/services/test_human_input_file_upload_service.py -q`
- `uv run --project api ruff check api/controllers/web/human_input_form.py api/core/workflow/human_input_policy.py api/services/human_input_file_upload_service.py api/tests/unit_tests/controllers/web/test_human_input_form.py api/tests/unit_tests/services/test_human_input_file_upload_service.py`

Closes #39302