### PR TITLE
fix: prevent Safari from clipping the settings close button

### DIFF
--- a/packages/dify-ui/src/avatar/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/avatar/__tests__/index.spec.tsx
@@ -7,17 +7,6 @@ function stubImageLoader() {
 
   function TestImage(_width?: number, _height?: number): HTMLImageElement {
     const image = document.createElement('img')
-    Object.defineProperties(image, {
-      complete: {
-        configurable: true,
-        value: false,
-      },
-      src: {
-        configurable: true,
-        value: '',
-        writable: true,
-      },
-    })
     images.push(image)
     return image
   }

--- a/packages/dify-ui/src/avatar/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/avatar/__tests__/index.spec.tsx
@@ -7,6 +7,17 @@ function stubImageLoader() {
 
   function TestImage(_width?: number, _height?: number): HTMLImageElement {
     const image = document.createElement('img')
+    Object.defineProperties(image, {
+      complete: {
+        configurable: true,
+        value: false,
+      },
+      src: {
+        configurable: true,
+        value: '',
+        writable: true,
+      },
+    })
     images.push(image)
     return image
   }

--- a/web/app/components/header/account-setting/index.tsx
+++ b/web/app/components/header/account-setting/index.tsx
@@ -211,6 +211,18 @@ export default function AccountSetting({
 
   return (
     <MenuDialog show onClose={handleClose}>
+      <div className="fixed top-6 right-6 z-20 flex shrink-0 flex-col items-center">
+        <Button
+          variant="tertiary"
+          size="large"
+          className="px-2"
+          aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+          onClick={handleClose}
+        >
+          <span className="i-ri-close-line size-5" />
+        </Button>
+        <div className="mt-1 system-2xs-medium-uppercase text-text-tertiary">ESC</div>
+      </div>
       <div className="flex h-screen w-full max-w-full pl-0 sm:pl-[232px]">
         <div className="flex w-[44px] shrink-0 flex-col pr-6 pl-4 sm:w-[224px]">
           <div className="mt-6 mb-8 flex h-[38px] items-center px-3 title-2xl-semi-bold whitespace-nowrap text-text-primary">
@@ -274,18 +286,6 @@ export default function AccountSetting({
                     {activeItem?.description}
                   </div>
                 )}
-              </div>
-              <div className="fixed top-6 right-6 flex shrink-0 flex-col items-center">
-                <Button
-                  variant="tertiary"
-                  size="large"
-                  className="px-2"
-                  aria-label={t(($) => $['operation.close'], { ns: 'common' })}
-                  onClick={handleClose}
-                >
-                  <span className="i-ri-close-line size-5" />
-                </Button>
-                <div className="mt-1 system-2xs-medium-uppercase text-text-tertiary">ESC</div>
               </div>
             </div>
             <div className="max-w-full min-w-0 px-4 pt-6 sm:px-8">


### PR DESCRIPTION
## Summary

- Move the account settings Close/ESC controls outside the scroll area so Safari no longer clips them when tab content becomes scrollable.
- Preserve the existing click and Escape close behavior, verified by the focused account settings test suite.

Fixes SNP-584

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.