### PR TITLE
fix: reject trailing newlines in alphanumeric() validator (#39666)

### DIFF
--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -289,7 +289,11 @@ UUIDStr = Annotated[str, AfterValidator(_strict_uuid)]
 
 def alphanumeric(value: str):
     # check if the value is alphanumeric and underlined
-    if re.match(r"^[a-zA-Z0-9_]+$", value):
+    # Use re.fullmatch instead of re.match to reject trailing newlines.
+    # In Python, '$' matches at end-of-string OR just before a trailing newline,
+    # so re.match accepts "tool_name\n". re.fullmatch requires the entire
+    # string to match. Regression for #39666 (sibling of #39234 / #39548).
+    if re.fullmatch(r"^[a-zA-Z0-9_]+$", value):
         return value
 
     raise ValueError(f"{value} is not a valid alphanumeric value")

--- a/api/tests/unit_tests/libs/test_helper.py
+++ b/api/tests/unit_tests/libs/test_helper.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 import pytest
 
-from libs.helper import OptionalTimestampField, email, escape_like_pattern, extract_tenant_id
+from libs.helper import OptionalTimestampField, alphanumeric, email, escape_like_pattern, extract_tenant_id
 from models.account import Account
 from models.model import EndUser
 
@@ -153,3 +153,47 @@ class TestEmailValidator:
     def test_invalid_email_rejected(self):
         with pytest.raises(ValueError, match="not a valid email"):
             email("not-an-email")
+
+
+class TestAlphanumericValidator:
+    """Tests for the alphanumeric() validator — regression for #39666."""
+
+    def test_valid_alphanumeric_accepted(self):
+        assert alphanumeric("tool_name") == "tool_name"
+        assert alphanumeric("Tool123") == "Tool123"
+        assert alphanumeric("_underscore_start") == "_underscore_start"
+        assert alphanumeric("a") == "a"
+
+    def test_trailing_newline_rejected(self):
+        # re.match with $ accepts a trailing \n in Python; re.fullmatch does not.
+        # This was the pre-fix behaviour: alphanumeric("tool\n") returned "tool\n".
+        with pytest.raises(ValueError, match="not a valid alphanumeric value"):
+            alphanumeric("tool_name\n")
+
+    def test_trailing_carriage_return_rejected(self):
+        with pytest.raises(ValueError, match="not a valid alphanumeric value"):
+            alphanumeric("tool_name\r")
+
+    def test_trailing_crlf_rejected(self):
+        with pytest.raises(ValueError, match="not a valid alphanumeric value"):
+            alphanumeric("tool_name\r\n")
+
+    def test_leading_newline_rejected(self):
+        with pytest.raises(ValueError, match="not a valid alphanumeric value"):
+            alphanumeric("\ntool_name")
+
+    def test_embedded_whitespace_rejected(self):
+        with pytest.raises(ValueError, match="not a valid alphanumeric value"):
+            alphanumeric("tool name")
+
+    def test_empty_string_rejected(self):
+        with pytest.raises(ValueError, match="not a valid alphanumeric value"):
+            alphanumeric("")
+
+    def test_special_characters_rejected(self):
+        with pytest.raises(ValueError, match="not a valid alphanumeric value"):
+            alphanumeric("tool-name")
+        with pytest.raises(ValueError, match="not a valid alphanumeric value"):
+            alphanumeric("tool.name")
+        with pytest.raises(ValueError, match="not a valid alphanumeric value"):
+            alphanumeric("tool/name")


### PR DESCRIPTION
Fixes #39666.

## Summary

`alphanumeric()` in `api/libs/helper.py` used `re.match(r"^[a-zA-Z0-9_]+$", value)`. In Python, `$` matches at end-of-string OR just before a trailing newline, so values like `"tool_name\n"` slipped through the validator. The fix replaces `re.match` with `re.fullmatch`, matching the pattern established by the email validator fix in #39320 (closed my #39442 as duplicate) and the password validator fix in #39548.

## Why it matters

`alphanumeric` is the field validator on `WorkflowToolBasePayload.name` (`api/controllers/console/workspace/tool_providers.py:183`), shared by both `WorkflowToolCreatePayload` and `WorkflowToolUpdatePayload`. The tool name is stored in the database, rendered in the console UI, and used to look the tool up. A tool named `my_tool` and a tool named `my_tool\n` are distinct rows that look identical to a human reader — duplicate names that don't dedupe, plus the same log-injection / header-injection surface that the email fix closed.

## Changes

- `api/libs/helper.py:290` — `re.match` → `re.fullmatch` with a comment matching the style of the email fix at line 224.
- `api/tests/unit_tests/libs/test_helper.py` — new `TestAlphanumericValidator` class with 8 tests covering the happy path, trailing newline, trailing CR, trailing CRLF, leading newline, embedded whitespace, empty string, and special characters. Existing `TestEmailValidator` is the template.

## Verification

```
cd api
.venv/bin/python -m pytest tests/unit_tests/libs/test_helper.py -v
# 31 passed in 0.55s  (23 existing + 8 new)

.venv/bin/python -m ruff check libs/helper.py tests/unit_tests/libs/test_helper.py
# All checks passed!

.venv/bin/python -m ruff format --check libs/helper.py tests/unit_tests/libs/test_helper.py
# 2 files already formatted
```

Broader sweep to make sure nothing else regressed:

```
cd api
.venv/bin/python -m pytest tests/unit_tests/libs/ -q
# 601 passed, 16 warnings, 138 subtests passed in 13.00s

.venv/bin/python -m pytest tests/unit_tests/controllers/console/workspace/test_tool_providers.py -q
# 22 passed
```

## Scope

- One source line in `api/libs/helper.py` (plus a 4-line comment).
- One new test class in `api/tests/unit_tests/libs/test_helper.py`.
- No API change, no schema change, no migration. Existing rows are unaffected — a `name` ending in `\n` is invalid under both the old and new contract; nothing needs rewriting.

## Out of scope (noted in #39666)

The same `re.match`-with-trailing-newline pattern appears in two more files under `api/libs/`:

- `api/libs/custom_inputs.py:26` (`parse_time_duration`)
- `api/libs/time_parser.py:28` (time-parser helper)

Lower-impact than the `alphanumeric` case (the inputs are usually form-supplied; the validators don't gate a security surface as directly as `WorkflowToolBasePayload.name`). Happy to file follow-ups if maintainers want a sweep, but kept this PR scoped to the single highest-impact call site.
