### PR TITLE
fix: prevent the model selector footer from covering options

### DIFF
--- a/web/app/components/header/account-setting/index.tsx
+++ b/web/app/components/header/account-setting/index.tsx
@@ -211,6 +211,18 @@ export default function AccountSetting({
 
   return (
     <MenuDialog show onClose={handleClose}>
+      <div className="fixed top-6 right-6 z-20 flex shrink-0 flex-col items-center">
+        <Button
+          variant="tertiary"
+          size="large"
+          className="px-2"
+          aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+          onClick={handleClose}
+        >
+          <span className="i-ri-close-line size-5" />
+        </Button>
+        <div className="mt-1 system-2xs-medium-uppercase text-text-tertiary">ESC</div>
+      </div>
       <div className="flex h-screen w-full max-w-full pl-0 sm:pl-[232px]">
         <div className="flex w-[44px] shrink-0 flex-col pr-6 pl-4 sm:w-[224px]">
           <div className="mt-6 mb-8 flex h-[38px] items-center px-3 title-2xl-semi-bold whitespace-nowrap text-text-primary">
@@ -274,18 +286,6 @@ export default function AccountSetting({
                     {activeItem?.description}
                   </div>
                 )}
-              </div>
-              <div className="fixed top-6 right-6 flex shrink-0 flex-col items-center">
-                <Button
-                  variant="tertiary"
-                  size="large"
-                  className="px-2"
-                  aria-label={t(($) => $['operation.close'], { ns: 'common' })}
-                  onClick={handleClose}
-                >
-                  <span className="i-ri-close-line size-5" />
-                </Button>
-                <div className="mt-1 system-2xs-medium-uppercase text-text-tertiary">ESC</div>
               </div>
             </div>
             <div className="max-w-full min-w-0 px-4 pt-6 sm:px-8">

--- a/web/app/components/header/account-setting/index.tsx
+++ b/web/app/components/header/account-setting/index.tsx
@@ -211,18 +211,6 @@ export default function AccountSetting({
 
   return (
     <MenuDialog show onClose={handleClose}>
-      <div className="fixed top-6 right-6 z-20 flex shrink-0 flex-col items-center">
-        <Button
-          variant="tertiary"
-          size="large"
-          className="px-2"
-          aria-label={t(($) => $['operation.close'], { ns: 'common' })}
-          onClick={handleClose}
-        >
-          <span className="i-ri-close-line size-5" />
-        </Button>
-        <div className="mt-1 system-2xs-medium-uppercase text-text-tertiary">ESC</div>
-      </div>
       <div className="flex h-screen w-full max-w-full pl-0 sm:pl-[232px]">
         <div className="flex w-[44px] shrink-0 flex-col pr-6 pl-4 sm:w-[224px]">
           <div className="mt-6 mb-8 flex h-[38px] items-center px-3 title-2xl-semi-bold whitespace-nowrap text-text-primary">
@@ -286,6 +274,18 @@ export default function AccountSetting({
                     {activeItem?.description}
                   </div>
                 )}
+              </div>
+              <div className="fixed top-6 right-6 flex shrink-0 flex-col items-center">
+                <Button
+                  variant="tertiary"
+                  size="large"
+                  className="px-2"
+                  aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+                  onClick={handleClose}
+                >
+                  <span className="i-ri-close-line size-5" />
+                </Button>
+                <div className="mt-1 system-2xs-medium-uppercase text-text-tertiary">ESC</div>
               </div>
             </div>
             <div className="max-w-full min-w-0 px-4 pt-6 sm:px-8">

--- a/web/app/components/header/account-setting/model-provider-page/model-selector/popup.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-selector/popup.tsx
@@ -272,8 +272,10 @@ function Popup({
   return (
     <ModelSelectorPopupFrame>
       <ModelSelectorSearchHeader inputValue={inputValue} onInputValueChange={onInputValueChange} />
-      {showCreditsExhaustedAlert && <CreditsExhaustedAlert hasApiKeyFallback={hasApiKeyFallback} />}
       <ModelSelectorScrollBody label={t(($) => $['modelProvider.models'], { ns: 'common' })}>
+        {showCreditsExhaustedAlert && (
+          <CreditsExhaustedAlert hasApiKeyFallback={hasApiKeyFallback} />
+        )}
         <ComboboxList className="max-h-none overflow-visible p-0">
           <div className="pb-1">
             {filteredModelList.map((model) => (


### PR DESCRIPTION
## Summary

- Keep the exhausted-credit alert inside the model selector scroll region so it no longer reduces the visible option space.
- Prevent the final model options from overlapping the provider settings footer, restoring scroll and keyboard access to the bottom of the list.

Fixes SNP-585

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.