### PR TITLE
feat: label agent conversation reset action on hover

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/components/preview/__tests__/header.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/preview/__tests__/header.spec.tsx
@@ -76,6 +76,22 @@ describe('AgentPreviewHeader', () => {
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
   })
 
+  it.each(['build', 'preview'] as const)(
+    'should show the start-fresh tooltip on hover in %s mode',
+    async (mode) => {
+      const user = userEvent.setup()
+      renderHeader({ mode })
+
+      await user.hover(
+        screen.getByRole('button', { name: 'agentV2.agentDetail.configure.preview.restart' }),
+      )
+
+      expect(
+        await screen.findByText('agentV2.agentDetail.configure.preview.restart'),
+      ).toBeInTheDocument()
+    },
+  )
+
   it('should not emit refresh when the restart button is disabled', async () => {
     const user = userEvent.setup()
     const onRefresh = vi.fn()

--- a/web/features/agent-v2/agent-detail/configure/components/preview/header.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/preview/header.tsx
@@ -6,6 +6,7 @@ import {
   SegmentedControlDivider,
   SegmentedControlItem,
 } from '@langgenius/dify-ui/segmented-control'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/tooltip'
 import { useTranslation } from 'react-i18next'
 import { useDocLink } from '@/context/i18n'
 import { AgentConfigureClearSessionConfirmDialog } from '../confirm-clear-session-dialog'
@@ -138,6 +139,7 @@ export function AgentPreviewHeader({
   const previewTipBody = t(($) => $['agentDetail.configure.rightPanel.previewTipBody'])
   const previewDisabledTip = t(($) => $['agentDetail.configure.rightPanel.previewDisabledTip'])
   const learnMoreLabel = t(($) => $['agentDetail.configure.rightPanel.learnMore'])
+  const restartLabel = t(($) => $['agentDetail.configure.preview.restart'])
   const modeTip = `${buildLabel}. ${buildTipBody} ${learnMoreLabel} ${previewLabel}. ${previewTipBody}`
   const restartButton = (
     <button
@@ -145,7 +147,7 @@ export function AgentPreviewHeader({
       disabled={refreshDisabled}
       onClick={mode === 'preview' ? onRefresh : undefined}
       className="flex size-6 items-center justify-center rounded-md p-0.5 text-text-tertiary hover:bg-state-base-hover hover:text-text-secondary focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
-      aria-label={t(($) => $['agentDetail.configure.preview.restart'])}
+      aria-label={restartLabel}
     >
       <span aria-hidden className="i-custom-vender-other-replay-line size-4" />
     </button>
@@ -202,13 +204,22 @@ export function AgentPreviewHeader({
       </div>
       <div className="flex shrink-0 items-center">
         <div className="flex items-center gap-2">
-          {mode === 'preview' ? (
-            restartButton
-          ) : (
-            <AgentConfigureClearSessionConfirmDialog onConfirm={onRefresh}>
-              {restartButton}
-            </AgentConfigureClearSessionConfirmDialog>
-          )}
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <span className="inline-flex">
+                  {mode === 'preview' ? (
+                    restartButton
+                  ) : (
+                    <AgentConfigureClearSessionConfirmDialog onConfirm={onRefresh}>
+                      {restartButton}
+                    </AgentConfigureClearSessionConfirmDialog>
+                  )}
+                </span>
+              }
+            />
+            <TooltipContent>{restartLabel}</TooltipContent>
+          </Tooltip>
           {mode === 'build' && showWorkingDirectoryAction && (
             <button
               type="button"

--- a/web/i18n/ar-TN/agent-v-2.json
+++ b/web/i18n/ar-TN/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "معاينة {{name}}",
   "agentDetail.configure.preview.endUserAuth": "مصادقة المستخدم النهائي",
   "agentDetail.configure.preview.inputPlaceholder": "إرسال رسالة إلى {{name}}",
-  "agentDetail.configure.preview.restart": "إعادة تشغيل المعاينة",
+  "agentDetail.configure.preview.restart": "ابدأ من جديد",
   "agentDetail.configure.preview.sandboxNotice": "يعمل Agent داخل صندوق رمل Linux.",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "بالنسبة إلى إصدار Dify Community Edition، يعمل كل Agent من Agents الخاصة بك في بيئة صندوق رمل Linux 7.0.0-10060-aws داخل Docker لديك. تعديلاتك على البيئة عبر Build Chats مستمرة.",
   "agentDetail.configure.preview.title": "معاينة",

--- a/web/i18n/de-DE/agent-v-2.json
+++ b/web/i18n/de-DE/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "{{name}} in der Vorschau anzeigen",
   "agentDetail.configure.preview.endUserAuth": "Endbenutzer-Authentifizierung",
   "agentDetail.configure.preview.inputPlaceholder": "Nachricht an {{name}}",
-  "agentDetail.configure.preview.restart": "Vorschau neu starten",
+  "agentDetail.configure.preview.restart": "Neu beginnen",
   "agentDetail.configure.preview.sandboxNotice": "Der Agent läuft in einer Linux-Sandbox.",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "In der Dify Community Edition läuft jeder deiner Agents in einer Linux 7.0.0-10060-aws-Sandbox-Umgebung innerhalb deines Docker. Änderungen an der Umgebung über Build Chats bleiben erhalten.",
   "agentDetail.configure.preview.title": "Vorschau",

--- a/web/i18n/en-US/agent-v-2.json
+++ b/web/i18n/en-US/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "Preview {{name}}",
   "agentDetail.configure.preview.endUserAuth": "End-user authentication",
   "agentDetail.configure.preview.inputPlaceholder": "Message {{name}}",
-  "agentDetail.configure.preview.restart": "Restart preview",
+  "agentDetail.configure.preview.restart": "Start fresh",
   "agentDetail.configure.preview.sandboxNotice": "Agent runs in a Linux sandbox.",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "For Dify Community Edition, each of your agents runs in a Linux 7.0.0-10060-aws sandbox environment within your docker. Your edits to the environment via Build Chats are persistent.",
   "agentDetail.configure.preview.title": "Preview",

--- a/web/i18n/es-ES/agent-v-2.json
+++ b/web/i18n/es-ES/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "Vista previa de {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Autenticación de usuario final",
   "agentDetail.configure.preview.inputPlaceholder": "Enviar mensaje a {{name}}",
-  "agentDetail.configure.preview.restart": "Reiniciar vista previa",
+  "agentDetail.configure.preview.restart": "Empezar de nuevo",
   "agentDetail.configure.preview.sandboxNotice": "El agente se ejecuta en un sandbox de Linux.",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "En Dify Community Edition, cada uno de tus agentes se ejecuta en un entorno sandbox Linux 7.0.0-10060-aws dentro de tu Docker. Tus cambios en el entorno mediante Build Chats son persistentes.",
   "agentDetail.configure.preview.title": "Vista previa",

--- a/web/i18n/fa-IR/agent-v-2.json
+++ b/web/i18n/fa-IR/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "پیش‌نمایش {{name}}",
   "agentDetail.configure.preview.endUserAuth": "احراز هویت کاربر نهایی",
   "agentDetail.configure.preview.inputPlaceholder": "ارسال پیام به {{name}}",
-  "agentDetail.configure.preview.restart": "راه‌اندازی مجدد پیش‌نمایش",
+  "agentDetail.configure.preview.restart": "شروع تازه",
   "agentDetail.configure.preview.sandboxNotice": "Agent در یک سندباکس لینوکس اجرا می‌شود.",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "در Dify Community Edition، هر یک از Agentهای شما در یک محیط سندباکس Linux 7.0.0-10060-aws داخل Docker شما اجرا می‌شود. ویرایش‌های شما روی محیط از طریق Build Chats پایدار می‌ماند.",
   "agentDetail.configure.preview.title": "پیش‌نمایش",

--- a/web/i18n/fr-FR/agent-v-2.json
+++ b/web/i18n/fr-FR/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "Aperçu de {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Authentification de l’utilisateur final",
   "agentDetail.configure.preview.inputPlaceholder": "Envoyer un message à {{name}}",
-  "agentDetail.configure.preview.restart": "Redémarrer l’aperçu",
+  "agentDetail.configure.preview.restart": "Recommencer",
   "agentDetail.configure.preview.sandboxNotice": "L’agent s’exécute dans un bac à sable Linux.",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "Dans Dify Community Edition, chacun de vos agents s’exécute dans un environnement bac à sable Linux 7.0.0-10060-aws au sein de votre Docker. Les modifications apportées à l’environnement via Build Chats sont persistantes.",
   "agentDetail.configure.preview.title": "Aperçu",

--- a/web/i18n/hi-IN/agent-v-2.json
+++ b/web/i18n/hi-IN/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "{{name}} का पूर्वावलोकन",
   "agentDetail.configure.preview.endUserAuth": "अंतिम-उपयोगकर्ता प्रमाणीकरण",
   "agentDetail.configure.preview.inputPlaceholder": "{{name}} को संदेश भेजें",
-  "agentDetail.configure.preview.restart": "पूर्वावलोकन पुनः आरंभ करें",
+  "agentDetail.configure.preview.restart": "नए सिरे से शुरू करें",
   "agentDetail.configure.preview.sandboxNotice": "Agent Linux सैंडबॉक्स में चलता है.",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "Dify Community Edition में, आपके हर Agent आपके Docker के अंदर Linux 7.0.0-10060-aws सैंडबॉक्स वातावरण में चलता है. Build Chats के ज़रिए वातावरण में किए गए आपके बदलाव स्थायी रहते हैं.",
   "agentDetail.configure.preview.title": "पूर्वावलोकन",

--- a/web/i18n/id-ID/agent-v-2.json
+++ b/web/i18n/id-ID/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "Pratinjau {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Autentikasi pengguna akhir",
   "agentDetail.configure.preview.inputPlaceholder": "Kirim pesan ke {{name}}",
-  "agentDetail.configure.preview.restart": "Mulai ulang pratinjau",
+  "agentDetail.configure.preview.restart": "Mulai dari awal",
   "agentDetail.configure.preview.sandboxNotice": "Agent berjalan di sandbox Linux.",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "Di Dify Community Edition, setiap Agent Anda berjalan di lingkungan sandbox Linux 7.0.0-10060-aws di dalam Docker Anda. Perubahan yang Anda buat pada lingkungan melalui Build Chats bersifat persisten.",
   "agentDetail.configure.preview.title": "Pratinjau",

--- a/web/i18n/it-IT/agent-v-2.json
+++ b/web/i18n/it-IT/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "Anteprima di {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Autenticazione utente finale",
   "agentDetail.configure.preview.inputPlaceholder": "Invia un messaggio a {{name}}",
-  "agentDetail.configure.preview.restart": "Riavvia anteprima",
+  "agentDetail.configure.preview.restart": "Ricomincia",
   "agentDetail.configure.preview.sandboxNotice": "L'agent viene eseguito in una sandbox Linux.",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "In Dify Community Edition, ciascuno dei tuoi agent viene eseguito in un ambiente sandbox Linux 7.0.0-10060-aws all’interno del tuo Docker. Le modifiche all’ambiente tramite Build Chats sono persistenti.",
   "agentDetail.configure.preview.title": "Anteprima",

--- a/web/i18n/ja-JP/agent-v-2.json
+++ b/web/i18n/ja-JP/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "{{name}} をプレビュー",
   "agentDetail.configure.preview.endUserAuth": "エンドユーザー認証",
   "agentDetail.configure.preview.inputPlaceholder": "{{name}} にメッセージを送信",
-  "agentDetail.configure.preview.restart": "プレビューを再開",
+  "agentDetail.configure.preview.restart": "新しく始める",
   "agentDetail.configure.preview.sandboxNotice": "Agent は Linux サンドボックスで実行されます。",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "Dify Community Edition では、各 Agent は Docker 内の Linux 7.0.0-10060-aws サンドボックス環境で実行されます。Build Chats で行った環境への編集は永続化されます。",
   "agentDetail.configure.preview.title": "プレビュー",

--- a/web/i18n/ko-KR/agent-v-2.json
+++ b/web/i18n/ko-KR/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "{{name}} 미리보기",
   "agentDetail.configure.preview.endUserAuth": "최종 사용자 인증",
   "agentDetail.configure.preview.inputPlaceholder": "{{name}}에게 메시지 보내기",
-  "agentDetail.configure.preview.restart": "미리보기 다시 시작",
+  "agentDetail.configure.preview.restart": "새로 시작",
   "agentDetail.configure.preview.sandboxNotice": "Agent는 Linux 샌드박스에서 실행됩니다.",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "Dify Community Edition에서는 각 Agent가 Docker 내부의 Linux 7.0.0-10060-aws 샌드박스 환경에서 실행됩니다. Build Chats를 통해 환경에 적용한 변경 사항은 유지됩니다.",
   "agentDetail.configure.preview.title": "미리보기",

--- a/web/i18n/nl-NL/agent-v-2.json
+++ b/web/i18n/nl-NL/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "Voorbeeld van {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Authenticatie eindgebruiker",
   "agentDetail.configure.preview.inputPlaceholder": "Bericht sturen naar {{name}}",
-  "agentDetail.configure.preview.restart": "Voorbeeld opnieuw starten",
+  "agentDetail.configure.preview.restart": "Opnieuw beginnen",
   "agentDetail.configure.preview.sandboxNotice": "De agent wordt uitgevoerd in een Linux-sandbox.",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "In Dify Community Edition draait elk van je agents in een Linux 7.0.0-10060-aws-sandboxomgeving binnen je Docker. Je wijzigingen aan de omgeving via Build Chats blijven behouden.",
   "agentDetail.configure.preview.title": "Voorbeeld",

--- a/web/i18n/pl-PL/agent-v-2.json
+++ b/web/i18n/pl-PL/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "Podgląd {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Uwierzytelnianie użytkownika końcowego",
   "agentDetail.configure.preview.inputPlaceholder": "Wyślij wiadomość do {{name}}",
-  "agentDetail.configure.preview.restart": "Uruchom podgląd ponownie",
+  "agentDetail.configure.preview.restart": "Zacznij od nowa",
   "agentDetail.configure.preview.sandboxNotice": "Agent działa w piaskownicy Linux.",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "W Dify Community Edition każdy z Twoich agentów działa w środowisku piaskownicy Linux 7.0.0-10060-aws w Twoim Dockerze. Zmiany środowiska wprowadzone przez Build Chats są trwałe.",
   "agentDetail.configure.preview.title": "Podgląd",

--- a/web/i18n/pt-BR/agent-v-2.json
+++ b/web/i18n/pt-BR/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "Pré-visualizar {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Autenticação do usuário final",
   "agentDetail.configure.preview.inputPlaceholder": "Enviar mensagem para {{name}}",
-  "agentDetail.configure.preview.restart": "Reiniciar pré-visualização",
+  "agentDetail.configure.preview.restart": "Começar de novo",
   "agentDetail.configure.preview.sandboxNotice": "O agente é executado em uma sandbox Linux.",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "No Dify Community Edition, cada um dos seus agents é executado em um ambiente sandbox Linux 7.0.0-10060-aws dentro do seu Docker. Suas edições no ambiente via Build Chats são persistentes.",
   "agentDetail.configure.preview.title": "Pré-visualização",

--- a/web/i18n/ro-RO/agent-v-2.json
+++ b/web/i18n/ro-RO/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "Previzualizează {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Autentificare utilizator final",
   "agentDetail.configure.preview.inputPlaceholder": "Trimite mesaj către {{name}}",
-  "agentDetail.configure.preview.restart": "Reporniți previzualizarea",
+  "agentDetail.configure.preview.restart": "Începe din nou",
   "agentDetail.configure.preview.sandboxNotice": "Agentul rulează într-un sandbox Linux.",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "În Dify Community Edition, fiecare dintre agenții tăi rulează într-un mediu sandbox Linux 7.0.0-10060-aws în Dockerul tău. Modificările aduse mediului prin Build Chats sunt persistente.",
   "agentDetail.configure.preview.title": "Previzualizare",

--- a/web/i18n/ru-RU/agent-v-2.json
+++ b/web/i18n/ru-RU/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "Предпросмотр {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Аутентификация конечного пользователя",
   "agentDetail.configure.preview.inputPlaceholder": "Написать {{name}}",
-  "agentDetail.configure.preview.restart": "Перезапустить предпросмотр",
+  "agentDetail.configure.preview.restart": "Начать заново",
   "agentDetail.configure.preview.sandboxNotice": "Agent работает в песочнице Linux.",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "В Dify Community Edition каждый ваш Agent работает в среде песочницы Linux 7.0.0-10060-aws внутри вашего Docker. Изменения среды через Build Chats сохраняются.",
   "agentDetail.configure.preview.title": "Предпросмотр",

--- a/web/i18n/sl-SI/agent-v-2.json
+++ b/web/i18n/sl-SI/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "Predogled {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Preverjanje pristnosti končnega uporabnika",
   "agentDetail.configure.preview.inputPlaceholder": "Pošlji sporočilo za {{name}}",
-  "agentDetail.configure.preview.restart": "Znova zaženi predogled",
+  "agentDetail.configure.preview.restart": "Začni znova",
   "agentDetail.configure.preview.sandboxNotice": "Agent se izvaja v peskovniku Linux.",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "V Dify Community Edition vsak vaš Agent teče v peskovniškem okolju Linux 7.0.0-10060-aws znotraj vašega Dockerja. Spremembe okolja prek Build Chats so trajne.",
   "agentDetail.configure.preview.title": "Predogled",

--- a/web/i18n/th-TH/agent-v-2.json
+++ b/web/i18n/th-TH/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "แสดงตัวอย่าง {{name}}",
   "agentDetail.configure.preview.endUserAuth": "การยืนยันตัวตนของผู้ใช้ปลายทาง",
   "agentDetail.configure.preview.inputPlaceholder": "ส่งข้อความถึง {{name}}",
-  "agentDetail.configure.preview.restart": "เริ่มการแสดงตัวอย่างใหม่",
+  "agentDetail.configure.preview.restart": "เริ่มใหม่",
   "agentDetail.configure.preview.sandboxNotice": "Agent ทำงานในแซนด์บ็อกซ์ Linux",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "สำหรับ Dify Community Edition Agent แต่ละตัวของคุณจะทำงานในสภาพแวดล้อมแซนด์บ็อกซ์ Linux 7.0.0-10060-aws ภายใน Docker ของคุณ การแก้ไขสภาพแวดล้อมผ่าน Build Chats จะคงอยู่ถาวร",
   "agentDetail.configure.preview.title": "แสดงตัวอย่าง",

--- a/web/i18n/tr-TR/agent-v-2.json
+++ b/web/i18n/tr-TR/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "{{name}} önizlemesi",
   "agentDetail.configure.preview.endUserAuth": "Son kullanıcı kimlik doğrulaması",
   "agentDetail.configure.preview.inputPlaceholder": "{{name}} ile mesajlaş",
-  "agentDetail.configure.preview.restart": "Önizlemeyi yeniden başlat",
+  "agentDetail.configure.preview.restart": "Baştan başla",
   "agentDetail.configure.preview.sandboxNotice": "Agent bir Linux korumalı alanında çalışır.",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "Dify Community Edition’da, agent’larınızın her biri Docker’ınız içinde Linux 7.0.0-10060-aws korumalı alan ortamında çalışır. Build Chats üzerinden ortamda yaptığınız düzenlemeler kalıcıdır.",
   "agentDetail.configure.preview.title": "Önizleme",

--- a/web/i18n/uk-UA/agent-v-2.json
+++ b/web/i18n/uk-UA/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "Перегляд {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Автентифікація кінцевого користувача",
   "agentDetail.configure.preview.inputPlaceholder": "Надіслати повідомлення {{name}}",
-  "agentDetail.configure.preview.restart": "Перезапустити перегляд",
+  "agentDetail.configure.preview.restart": "Почати заново",
   "agentDetail.configure.preview.sandboxNotice": "Agent працює в пісочниці Linux.",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "У Dify Community Edition кожен ваш Agent працює в середовищі пісочниці Linux 7.0.0-10060-aws у вашому Docker. Зміни середовища через Build Chats зберігаються.",
   "agentDetail.configure.preview.title": "Перегляд",

--- a/web/i18n/vi-VN/agent-v-2.json
+++ b/web/i18n/vi-VN/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "Xem trước {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Xác thực người dùng cuối",
   "agentDetail.configure.preview.inputPlaceholder": "Nhắn cho {{name}}",
-  "agentDetail.configure.preview.restart": "Khởi động lại bản xem trước",
+  "agentDetail.configure.preview.restart": "Bắt đầu mới",
   "agentDetail.configure.preview.sandboxNotice": "Agent chạy trong sandbox Linux.",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "Trong Dify Community Edition, mỗi Agent của bạn chạy trong môi trường sandbox Linux 7.0.0-10060-aws bên trong Docker của bạn. Các chỉnh sửa môi trường qua Build Chats sẽ được lưu giữ.",
   "agentDetail.configure.preview.title": "Xem trước",

--- a/web/i18n/zh-Hans/agent-v-2.json
+++ b/web/i18n/zh-Hans/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "预览 {{name}}",
   "agentDetail.configure.preview.endUserAuth": "终端用户认证",
   "agentDetail.configure.preview.inputPlaceholder": "向 {{name}} 发送消息",
-  "agentDetail.configure.preview.restart": "重新开始预览",
+  "agentDetail.configure.preview.restart": "开启新对话",
   "agentDetail.configure.preview.sandboxNotice": "Agent 运行在 Linux 沙盒中。",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "在 Dify Community Edition 中，每个 Agent 都运行在你 Docker 内的 Linux 7.0.0-10060-aws 沙盒环境中。你通过 Build Chats 对环境所做的编辑会持久保留。",
   "agentDetail.configure.preview.title": "预览",

--- a/web/i18n/zh-Hant/agent-v-2.json
+++ b/web/i18n/zh-Hant/agent-v-2.json
@@ -157,7 +157,7 @@
   "agentDetail.configure.preview.empty.title": "預覽 {{name}}",
   "agentDetail.configure.preview.endUserAuth": "終端使用者驗證",
   "agentDetail.configure.preview.inputPlaceholder": "傳訊息給 {{name}}",
-  "agentDetail.configure.preview.restart": "重新開始預覽",
+  "agentDetail.configure.preview.restart": "開啟新對話",
   "agentDetail.configure.preview.sandboxNotice": "Agent 執行於 Linux 沙盒中。",
   "agentDetail.configure.preview.sandboxNoticeTooltip": "在 Dify Community Edition 中，每個 Agent 都執行於你 Docker 內的 Linux 7.0.0-10060-aws 沙盒環境。你透過 Build Chats 對環境所做的編輯會持久保留。",
   "agentDetail.configure.preview.title": "預覽",


### PR DESCRIPTION
## Summary

- Add a localized “Start fresh” tooltip to the Agent V2 conversation reset action in Preview and Build modes.
- Update all 23 Agent V2 locales and cover tooltip behavior in both modes.

Implements DIFY-2846

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.