### PR TITLE
fix(agent): enforce idempotency_key during create-run admission

### DIFF
--- a/dify-agent/src/dify_agent/runtime/run_scheduler.py
+++ b/dify-agent/src/dify_agent/runtime/run_scheduler.py
@@ -7,13 +7,18 @@ status and event streams, but there is no Redis job queue or cross-process
 handoff. If the process crashes, currently active runs are lost until an external
 operator marks or retries them.
 Create-run requests are accepted once the scheduler is not stopping and storage
-can persist the run record. Request-shaped execution failures are left to
+can persist the run record. Requests carrying an ``idempotency_key`` are
+deduplicated during admission so an exact replay within the storage retention
+window returns the original run instead of scheduling duplicate work.
+Request-shaped execution failures are left to
 ``AgentRunRunner`` so bad compositions, ``on_exit`` policies, prompts,
 structured-output schemas, or session snapshots become asynchronous
 ``run_failed`` outcomes instead of synchronous HTTP rejections.
 """
 
 import asyncio
+import hashlib
+import json
 import logging
 from collections.abc import Callable
 from typing import Protocol
@@ -43,6 +48,14 @@ class RunStore(RunEventSink, Protocol):
 
     async def create_run(self) -> RunRecord:
         """Persist a new run record and return it with status ``running``."""
+        ...
+
+    async def create_run_idempotent(self, *, idempotency_key: str, request_fingerprint: str) -> tuple[RunRecord, bool]:
+        """Persist a run record unless the idempotency key already claims one."""
+        ...
+
+    async def get_run(self, run_id: str) -> RunRecord:
+        """Return the latest persisted run record."""
         ...
 
     async def wait_for_cancellation(self, run_id: str) -> bool:
@@ -112,12 +125,23 @@ class RunScheduler:
         The returned record is already ``running``. The background task is removed
         from ``active_tasks`` when it finishes, regardless of success or failure.
         Request-shaped runtime failures are intentionally deferred to the runner so
-        callers can observe them through the normal event/status stream.
+        callers can observe them through the normal event/status stream. When the
+        request carries an ``idempotency_key``, admission is deduplicated by the
+        store: an exact replay returns the original run record without starting a
+        second background task.
         """
         async with self._lifecycle_lock:
             if self.stopping:
                 raise SchedulerStoppingError("run scheduler is shutting down")
-            record = await self.store.create_run()
+            if request.idempotency_key is None:
+                record = await self.store.create_run()
+            else:
+                record, created = await self.store.create_run_idempotent(
+                    idempotency_key=request.idempotency_key,
+                    request_fingerprint=_create_run_fingerprint(request),
+                )
+                if not created:
+                    return record
             task = asyncio.create_task(self._run_record(record, request), name=f"dify-agent-run-{record.run_id}")
             self.active_tasks[record.run_id] = task
             task.add_done_callback(lambda _task, run_id=record.run_id: self._discard_active_run(run_id))
@@ -253,6 +277,13 @@ class RunScheduler:
             _ = await emit_run_failed(self.store, run_id=run_id, error=message, reason="shutdown")
         except Exception:
             logger.exception("failed to mark cancelled run failed", extra={"run_id": run_id})
+
+
+def _create_run_fingerprint(request: CreateRunRequest) -> str:
+    """Stable digest of the normalized create-run payload, excluding the key itself."""
+    payload = request.model_dump(mode="json", exclude={"idempotency_key"})
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
 
 
 __all__ = ["RunCancellationConflictError", "RunScheduler", "SchedulerStoppingError"]

--- a/dify-agent/src/dify_agent/runtime/run_scheduler.py
+++ b/dify-agent/src/dify_agent/runtime/run_scheduler.py
@@ -6,13 +6,18 @@ task registry. Redis remains the durable source for status and event streams, bu
 there is no Redis job queue or cross-process handoff. If the process crashes,
 currently active runs are lost until an external operator marks or retries them.
 Create-run requests are accepted once the scheduler is not stopping and storage
-can persist the run record. Request-shaped execution failures are left to
+can persist the run record. Requests carrying an ``idempotency_key`` are
+deduplicated during admission so an exact replay within the storage retention
+window returns the original run instead of scheduling duplicate work.
+Request-shaped execution failures are left to
 ``AgentRunRunner`` so bad compositions, ``on_exit`` policies, prompts,
 structured-output schemas, or session snapshots become asynchronous
 ``run_failed`` outcomes instead of synchronous HTTP rejections.
 """
 
 import asyncio
+import hashlib
+import json
 import logging
 from collections.abc import Callable
 from typing import Protocol
@@ -42,6 +47,10 @@ class RunStore(RunEventSink, Protocol):
 
     async def create_run(self) -> RunRecord:
         """Persist a new run record and return it with status ``running``."""
+        ...
+
+    async def create_run_idempotent(self, *, idempotency_key: str, request_fingerprint: str) -> tuple[RunRecord, bool]:
+        """Persist a run record unless the idempotency key already claims one."""
         ...
 
     async def get_run(self, run_id: str) -> RunRecord:
@@ -108,12 +117,23 @@ class RunScheduler:
         The returned record is already ``running``. The background task is removed
         from ``active_tasks`` when it finishes, regardless of success or failure.
         Request-shaped runtime failures are intentionally deferred to the runner so
-        callers can observe them through the normal event/status stream.
+        callers can observe them through the normal event/status stream. When the
+        request carries an ``idempotency_key``, admission is deduplicated by the
+        store: an exact replay returns the original run record without starting a
+        second background task.
         """
         async with self._lifecycle_lock:
             if self.stopping:
                 raise SchedulerStoppingError("run scheduler is shutting down")
-            record = await self.store.create_run()
+            if request.idempotency_key is None:
+                record = await self.store.create_run()
+            else:
+                record, created = await self.store.create_run_idempotent(
+                    idempotency_key=request.idempotency_key,
+                    request_fingerprint=_create_run_fingerprint(request),
+                )
+                if not created:
+                    return record
             task = asyncio.create_task(self._run_record(record, request), name=f"dify-agent-run-{record.run_id}")
             self.active_tasks[record.run_id] = task
             task.add_done_callback(lambda _task, run_id=record.run_id: self._discard_active_run(run_id))
@@ -209,6 +229,13 @@ class RunScheduler:
             await self.store.update_status(run_id, "failed", message)
         except Exception:
             logger.exception("failed to mark cancelled run failed", extra={"run_id": run_id})
+
+
+def _create_run_fingerprint(request: CreateRunRequest) -> str:
+    """Stable digest of the normalized create-run payload, excluding the key itself."""
+    payload = request.model_dump(mode="json", exclude={"idempotency_key"})
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
 
 
 __all__ = ["RunCancellationConflictError", "RunScheduler", "SchedulerStoppingError"]

--- a/dify-agent/src/dify_agent/server/routes/runs.py
+++ b/dify-agent/src/dify_agent/server/routes/runs.py
@@ -26,7 +26,7 @@ from dify_agent.protocol.schemas import (
 )
 from dify_agent.runtime.run_scheduler import RunCancellationConflictError, RunScheduler, SchedulerStoppingError
 from dify_agent.server.sse import sse_event_stream
-from dify_agent.storage.redis_run_store import RedisRunStore, RunNotFoundError
+from dify_agent.storage.redis_run_store import IdempotencyConflictError, RedisRunStore, RunNotFoundError
 
 
 def create_runs_router(
@@ -50,6 +50,8 @@ def create_runs_router(
             record = await scheduler.create_run(request)
         except SchedulerStoppingError as exc:
             raise HTTPException(status_code=503, detail="run scheduler is shutting down") from exc
+        except IdempotencyConflictError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
         return CreateRunResponse(run_id=record.run_id, status=record.status)
 
     @router.get("/{run_id}", response_model=RunStatusResponse)

--- a/dify-agent/src/dify_agent/server/routes/runs.py
+++ b/dify-agent/src/dify_agent/server/routes/runs.py
@@ -27,7 +27,7 @@ from dify_agent.protocol.schemas import (
 )
 from dify_agent.runtime.run_scheduler import RunCancellationConflictError, RunScheduler, SchedulerStoppingError
 from dify_agent.server.sse import sse_event_stream
-from dify_agent.storage.redis_run_store import RedisRunStore, RunNotFoundError
+from dify_agent.storage.redis_run_store import IdempotencyConflictError, RedisRunStore, RunNotFoundError
 
 
 def create_runs_router(
@@ -54,6 +54,8 @@ def create_runs_router(
             record = await scheduler.create_run(request)
         except SchedulerStoppingError as exc:
             raise HTTPException(status_code=503, detail="run scheduler is shutting down") from exc
+        except IdempotencyConflictError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
         return CreateRunResponse(run_id=record.run_id, status=record.status)
 
     @router.get("/{run_id}", response_model=RunStatusResponse)

--- a/dify-agent/src/dify_agent/storage/redis_keys.py
+++ b/dify-agent/src/dify_agent/storage/redis_keys.py
@@ -11,4 +11,9 @@ def run_events_key(prefix: str, run_id: str) -> str:
     return f"{prefix}:runs:{run_id}:events"
 
 
-__all__ = ["run_events_key", "run_record_key"]
+def run_idempotency_key(prefix: str, key_digest: str) -> str:
+    """Return the Redis string key claiming one create-run idempotency key digest."""
+    return f"{prefix}:idempotency:{key_digest}"
+
+
+__all__ = ["run_events_key", "run_idempotency_key", "run_record_key"]

--- a/dify-agent/src/dify_agent/storage/redis_run_store.py
+++ b/dify-agent/src/dify_agent/storage/redis_run_store.py
@@ -6,10 +6,14 @@ beginning for polling and SSE. Records and streams share one retention window
 that is refreshed when status or event data is written. Execution is scheduled
 in-process by ``dify_agent.runtime.run_scheduler``; Redis is not a job queue, and
 create-run payloads are never persisted because layer config may include
-sensitive runtime configuration.
+sensitive runtime configuration. Create-run idempotency claims only persist the
+key digest, the request fingerprint digest, and the claimed run id.
 """
 
+import hashlib
+import json
 from collections.abc import AsyncIterator, Awaitable
+
 from typing import cast
 
 from redis.asyncio import Redis
@@ -24,7 +28,7 @@ from dify_agent.runtime.event_sink import (
 )
 from dify_agent.server.schemas import RunRecord, new_run_id
 from dify_agent.server.settings import DEFAULT_RUN_RETENTION_SECONDS
-from dify_agent.storage.redis_keys import run_events_key, run_record_key
+from dify_agent.storage.redis_keys import run_events_key, run_idempotency_key, run_record_key
 
 _TERMINAL_RUN_EVENT_TYPES = {"run_succeeded", "run_failed", "run_cancelled"}
 
@@ -66,6 +70,10 @@ return {1, ARGV[1], event_id}
 """
 
 
+class IdempotencyConflictError(RuntimeError):
+    """Raised when an idempotency key is reused with a different create-run request."""
+
+
 class RedisRunStore(RunEventSink):
     """Async Redis implementation for run records and event logs.
 
@@ -104,6 +112,46 @@ class RedisRunStore(RunEventSink):
             ex=self.run_retention_seconds,
         )
         return record
+
+    async def create_run_idempotent(self, *, idempotency_key: str, request_fingerprint: str) -> tuple[RunRecord, bool]:
+        """Persist a run record unless ``idempotency_key`` already claims one.
+
+        Returns ``(record, created)``. The claim is an atomic ``SET NX`` keyed by
+        the digest of ``idempotency_key`` so concurrent create requests reaching
+        different server processes with the same Redis prefix deduplicate onto
+        one run. When the key was already claimed with the same
+        ``request_fingerprint``, the freshly created duplicate record is removed
+        and the original run record is returned with ``created`` false. Reusing
+        the key with a different fingerprint raises ``IdempotencyConflictError``.
+        Only digests and the run id are persisted, never the create-run payload.
+        """
+        record = await self.create_run()
+        claim_key = run_idempotency_key(self.prefix, _idempotency_digest(idempotency_key))
+        claim_value = json.dumps({"run_id": record.run_id, "fingerprint": request_fingerprint}, separators=(",", ":"))
+        claimed = await self.redis.set(claim_key, claim_value, ex=self.run_retention_seconds, nx=True)
+        if claimed:
+            return record, True
+
+        raw_claim = await self.redis.get(claim_key)
+        if isinstance(raw_claim, bytes):
+            raw_claim = raw_claim.decode()
+        existing_claim = cast(dict[str, str] | None, json.loads(raw_claim)) if raw_claim else None
+        if existing_claim is not None and existing_claim.get("fingerprint") == request_fingerprint:
+            try:
+                original = await self.get_run(existing_claim["run_id"])
+            except RunNotFoundError:
+                original = None
+            if original is not None:
+                await self.redis.delete(run_record_key(self.prefix, record.run_id))
+                return original, False
+        elif existing_claim is not None:
+            await self.redis.delete(run_record_key(self.prefix, record.run_id))
+            raise IdempotencyConflictError("idempotency key was already used with a different create-run request")
+
+        # The claim expired between SET NX and GET, or the original run record is
+        # already gone: take over the key for the freshly created record.
+        await self.redis.set(claim_key, claim_value, ex=self.run_retention_seconds)
+        return record, True
 
     async def get_run(self, run_id: str) -> RunRecord:
         """Return one run record or raise ``RunNotFoundError``."""
@@ -240,4 +288,9 @@ def _decode_redis_text(value: object) -> str:
     return value.decode() if isinstance(value, bytes) else str(value)
 
 
-__all__ = ["DEFAULT_RUN_RETENTION_SECONDS", "RedisRunStore", "RunNotFoundError"]
+def _idempotency_digest(idempotency_key: str) -> str:
+    """Hash the caller-supplied key so arbitrary values stay valid Redis keys."""
+    return hashlib.sha256(idempotency_key.encode()).hexdigest()
+
+
+__all__ = ["DEFAULT_RUN_RETENTION_SECONDS", "IdempotencyConflictError", "RedisRunStore", "RunNotFoundError"]

--- a/dify-agent/src/dify_agent/storage/redis_run_store.py
+++ b/dify-agent/src/dify_agent/storage/redis_run_store.py
@@ -6,9 +6,12 @@ beginning for polling and SSE. Records and streams share one retention window
 that is refreshed when status or event data is written. Execution is scheduled
 in-process by ``dify_agent.runtime.run_scheduler``; Redis is not a job queue, and
 create-run payloads are never persisted because layer config may include model
-credentials.
+credentials. Create-run idempotency claims only persist the key digest, the
+request fingerprint digest, and the claimed run id.
 """
 
+import hashlib
+import json
 from collections.abc import AsyncIterator
 from typing import cast
 
@@ -18,11 +21,15 @@ from dify_agent.protocol.schemas import RUN_EVENT_ADAPTER, RunEvent, RunEventsRe
 from dify_agent.runtime.event_sink import RunEventSink
 from dify_agent.server.schemas import RunRecord, new_run_id
 from dify_agent.server.settings import DEFAULT_RUN_RETENTION_SECONDS
-from dify_agent.storage.redis_keys import run_events_key, run_record_key
+from dify_agent.storage.redis_keys import run_events_key, run_idempotency_key, run_record_key
 
 
 class RunNotFoundError(LookupError):
     """Raised when a requested run record does not exist."""
+
+
+class IdempotencyConflictError(RuntimeError):
+    """Raised when an idempotency key is reused with a different create-run request."""
 
 
 class RedisRunStore(RunEventSink):
@@ -63,6 +70,46 @@ class RedisRunStore(RunEventSink):
             ex=self.run_retention_seconds,
         )
         return record
+
+    async def create_run_idempotent(self, *, idempotency_key: str, request_fingerprint: str) -> tuple[RunRecord, bool]:
+        """Persist a run record unless ``idempotency_key`` already claims one.
+
+        Returns ``(record, created)``. The claim is an atomic ``SET NX`` keyed by
+        the digest of ``idempotency_key`` so concurrent create requests reaching
+        different server processes with the same Redis prefix deduplicate onto
+        one run. When the key was already claimed with the same
+        ``request_fingerprint``, the freshly created duplicate record is removed
+        and the original run record is returned with ``created`` false. Reusing
+        the key with a different fingerprint raises ``IdempotencyConflictError``.
+        Only digests and the run id are persisted, never the create-run payload.
+        """
+        record = await self.create_run()
+        claim_key = run_idempotency_key(self.prefix, _idempotency_digest(idempotency_key))
+        claim_value = json.dumps({"run_id": record.run_id, "fingerprint": request_fingerprint}, separators=(",", ":"))
+        claimed = await self.redis.set(claim_key, claim_value, ex=self.run_retention_seconds, nx=True)
+        if claimed:
+            return record, True
+
+        raw_claim = await self.redis.get(claim_key)
+        if isinstance(raw_claim, bytes):
+            raw_claim = raw_claim.decode()
+        existing_claim = cast(dict[str, str] | None, json.loads(raw_claim)) if raw_claim else None
+        if existing_claim is not None and existing_claim.get("fingerprint") == request_fingerprint:
+            try:
+                original = await self.get_run(existing_claim["run_id"])
+            except RunNotFoundError:
+                original = None
+            if original is not None:
+                await self.redis.delete(run_record_key(self.prefix, record.run_id))
+                return original, False
+        elif existing_claim is not None:
+            await self.redis.delete(run_record_key(self.prefix, record.run_id))
+            raise IdempotencyConflictError("idempotency key was already used with a different create-run request")
+
+        # The claim expired between SET NX and GET, or the original run record is
+        # already gone: take over the key for the freshly created record.
+        await self.redis.set(claim_key, claim_value, ex=self.run_retention_seconds)
+        return record, True
 
     async def get_run(self, run_id: str) -> RunRecord:
         """Return one run record or raise ``RunNotFoundError``."""
@@ -140,4 +187,9 @@ class RedisRunStore(RunEventSink):
         return event.model_copy(update={"id": event_id, "run_id": run_id})
 
 
-__all__ = ["DEFAULT_RUN_RETENTION_SECONDS", "RedisRunStore", "RunNotFoundError"]
+def _idempotency_digest(idempotency_key: str) -> str:
+    """Hash the caller-supplied key so arbitrary values stay valid Redis keys."""
+    return hashlib.sha256(idempotency_key.encode()).hexdigest()
+
+
+__all__ = ["DEFAULT_RUN_RETENTION_SECONDS", "IdempotencyConflictError", "RedisRunStore", "RunNotFoundError"]

--- a/dify-agent/tests/local/dify_agent/runtime/test_run_scheduler.py
+++ b/dify-agent/tests/local/dify_agent/runtime/test_run_scheduler.py
@@ -31,6 +31,7 @@ from dify_agent.runtime.event_sink import (
 from dify_agent.runtime.run_scheduler import RunCancellationConflictError, RunScheduler, SchedulerStoppingError
 from dify_agent.runtime.runner import AgentRunRunner
 from dify_agent.server.schemas import RunRecord
+from dify_agent.storage.redis_run_store import IdempotencyConflictError
 
 
 def _request(
@@ -95,6 +96,7 @@ class FakeStore:
     errors: dict[str, str | None]
     error_types: dict[str, RunFailureType | None]
     terminal_changes: dict[str, asyncio.Event]
+    claims: dict[str, tuple[str, str]]
 
     def __init__(self) -> None:
         self.records = {}
@@ -103,6 +105,7 @@ class FakeStore:
         self.errors = {}
         self.error_types = {}
         self.terminal_changes = {}
+        self.claims = {}
 
     async def create_run(self) -> RunRecord:
         run_id = f"run-{len(self.records) + 1}"
@@ -111,6 +114,17 @@ class FakeStore:
         self.statuses[run_id] = "running"
         self.terminal_changes[run_id] = asyncio.Event()
         return record
+
+    async def create_run_idempotent(self, *, idempotency_key: str, request_fingerprint: str) -> tuple[RunRecord, bool]:
+        claim = self.claims.get(idempotency_key)
+        if claim is None:
+            record = await self.create_run()
+            self.claims[idempotency_key] = (record.run_id, request_fingerprint)
+            return record, True
+        run_id, fingerprint = claim
+        if fingerprint != request_fingerprint:
+            raise IdempotencyConflictError("idempotency key was already used with a different create-run request")
+        return await self.get_run(run_id), False
 
     async def append_event(self, event: NonTerminalRunEvent) -> str:
         event_id = str(len(self.events[event.run_id]) + 1)
@@ -954,5 +968,101 @@ def test_shutdown_waits_for_in_flight_create_to_register_before_cancelling() -> 
 
             with pytest.raises(SchedulerStoppingError):
                 await scheduler.create_run(_request())
+
+    asyncio.run(scenario())
+
+
+def test_create_run_replay_with_same_idempotency_key_returns_original_without_new_task() -> None:
+    async def scenario() -> None:
+        store = FakeStore()
+        started = asyncio.Event()
+        release = asyncio.Event()
+        async with httpx.AsyncClient() as client:
+            scheduler = RunScheduler(
+                store=store,
+                plugin_daemon_http_client=client,
+                dify_api_http_client=client,
+                runner_factory=lambda _record, _request: ControlledRunner(started=started, release=release),
+            )
+            request = _request().model_copy(update={"idempotency_key": "key-1"})
+
+            first = await scheduler.create_run(request)
+            await asyncio.wait_for(started.wait(), timeout=1)
+            replay = await scheduler.create_run(request)
+
+            assert replay.run_id == first.run_id
+            assert replay.status == "running"
+            assert list(scheduler.active_tasks) == [first.run_id]
+            assert len(store.records) == 1
+            _ = release.set()
+            await asyncio.wait_for(scheduler.active_tasks[first.run_id], timeout=1)
+
+    asyncio.run(scenario())
+
+
+def test_create_run_replay_normalizes_request_before_fingerprinting() -> None:
+    async def scenario() -> None:
+        store = FakeStore()
+        release = asyncio.Event()
+        async with httpx.AsyncClient() as client:
+            scheduler = RunScheduler(
+                store=store,
+                plugin_daemon_http_client=client,
+                dify_api_http_client=client,
+                runner_factory=lambda _record, _request: ControlledRunner(started=asyncio.Event(), release=release),
+            )
+            first = await scheduler.create_run(
+                _request().model_copy(update={"idempotency_key": "key-1", "metadata": {"a": 1, "b": 2}})
+            )
+            replay = await scheduler.create_run(
+                _request().model_copy(update={"idempotency_key": "key-1", "metadata": {"b": 2, "a": 1}})
+            )
+
+            assert replay.run_id == first.run_id
+            assert len(store.records) == 1
+            _ = release.set()
+
+    asyncio.run(scenario())
+
+
+def test_create_run_rejects_same_idempotency_key_with_different_request() -> None:
+    async def scenario() -> None:
+        store = FakeStore()
+        release = asyncio.Event()
+        async with httpx.AsyncClient() as client:
+            scheduler = RunScheduler(
+                store=store,
+                plugin_daemon_http_client=client,
+                dify_api_http_client=client,
+                runner_factory=lambda _record, _request: ControlledRunner(started=asyncio.Event(), release=release),
+            )
+            _ = await scheduler.create_run(_request().model_copy(update={"idempotency_key": "key-1"}))
+
+            with pytest.raises(IdempotencyConflictError, match="different create-run request"):
+                _ = await scheduler.create_run(_request("other").model_copy(update={"idempotency_key": "key-1"}))
+
+            assert len(store.records) == 1
+            _ = release.set()
+
+    asyncio.run(scenario())
+
+
+def test_create_run_with_different_idempotency_keys_schedules_separate_runs() -> None:
+    async def scenario() -> None:
+        store = FakeStore()
+        release = asyncio.Event()
+        async with httpx.AsyncClient() as client:
+            scheduler = RunScheduler(
+                store=store,
+                plugin_daemon_http_client=client,
+                dify_api_http_client=client,
+                runner_factory=lambda _record, _request: ControlledRunner(started=asyncio.Event(), release=release),
+            )
+            first = await scheduler.create_run(_request().model_copy(update={"idempotency_key": "key-1"}))
+            second = await scheduler.create_run(_request().model_copy(update={"idempotency_key": "key-2"}))
+
+            assert first.run_id != second.run_id
+            assert len(store.records) == 2
+            _ = release.set()
 
     asyncio.run(scenario())

--- a/dify-agent/tests/local/dify_agent/runtime/test_run_scheduler.py
+++ b/dify-agent/tests/local/dify_agent/runtime/test_run_scheduler.py
@@ -20,6 +20,7 @@ from dify_agent.protocol.schemas import (
 )
 from dify_agent.runtime.run_scheduler import RunCancellationConflictError, RunScheduler, SchedulerStoppingError
 from dify_agent.server.schemas import RunRecord
+from dify_agent.storage.redis_run_store import IdempotencyConflictError
 
 
 def _request(
@@ -60,12 +61,14 @@ class FakeStore:
     events: dict[str, list[RunEvent]]
     statuses: dict[str, RunStatus]
     errors: dict[str, str | None]
+    claims: dict[str, tuple[str, str]]
 
     def __init__(self) -> None:
         self.records = {}
         self.events = defaultdict(list)
         self.statuses = {}
         self.errors = {}
+        self.claims = {}
 
     async def create_run(self) -> RunRecord:
         run_id = f"run-{len(self.records) + 1}"
@@ -73,6 +76,17 @@ class FakeStore:
         self.records[run_id] = record
         self.statuses[run_id] = "running"
         return record
+
+    async def create_run_idempotent(self, *, idempotency_key: str, request_fingerprint: str) -> tuple[RunRecord, bool]:
+        claim = self.claims.get(idempotency_key)
+        if claim is None:
+            record = await self.create_run()
+            self.claims[idempotency_key] = (record.run_id, request_fingerprint)
+            return record, True
+        run_id, fingerprint = claim
+        if fingerprint != request_fingerprint:
+            raise IdempotencyConflictError("idempotency key was already used with a different create-run request")
+        return await self.get_run(run_id), False
 
     async def append_event(self, event: RunEvent) -> str:
         event_id = str(len(self.events[event.run_id]) + 1)
@@ -417,5 +431,101 @@ def test_shutdown_waits_for_in_flight_create_to_register_before_cancelling() -> 
 
             with pytest.raises(SchedulerStoppingError):
                 await scheduler.create_run(_request())
+
+    asyncio.run(scenario())
+
+
+def test_create_run_replay_with_same_idempotency_key_returns_original_without_new_task() -> None:
+    async def scenario() -> None:
+        store = FakeStore()
+        started = asyncio.Event()
+        release = asyncio.Event()
+        async with httpx.AsyncClient() as client:
+            scheduler = RunScheduler(
+                store=store,
+                plugin_daemon_http_client=client,
+                dify_api_http_client=client,
+                runner_factory=lambda _record, _request: ControlledRunner(started=started, release=release),
+            )
+            request = _request().model_copy(update={"idempotency_key": "key-1"})
+
+            first = await scheduler.create_run(request)
+            await asyncio.wait_for(started.wait(), timeout=1)
+            replay = await scheduler.create_run(request)
+
+            assert replay.run_id == first.run_id
+            assert replay.status == "running"
+            assert list(scheduler.active_tasks) == [first.run_id]
+            assert len(store.records) == 1
+            _ = release.set()
+            await asyncio.wait_for(scheduler.active_tasks[first.run_id], timeout=1)
+
+    asyncio.run(scenario())
+
+
+def test_create_run_replay_normalizes_request_before_fingerprinting() -> None:
+    async def scenario() -> None:
+        store = FakeStore()
+        release = asyncio.Event()
+        async with httpx.AsyncClient() as client:
+            scheduler = RunScheduler(
+                store=store,
+                plugin_daemon_http_client=client,
+                dify_api_http_client=client,
+                runner_factory=lambda _record, _request: ControlledRunner(started=asyncio.Event(), release=release),
+            )
+            first = await scheduler.create_run(
+                _request().model_copy(update={"idempotency_key": "key-1", "metadata": {"a": 1, "b": 2}})
+            )
+            replay = await scheduler.create_run(
+                _request().model_copy(update={"idempotency_key": "key-1", "metadata": {"b": 2, "a": 1}})
+            )
+
+            assert replay.run_id == first.run_id
+            assert len(store.records) == 1
+            _ = release.set()
+
+    asyncio.run(scenario())
+
+
+def test_create_run_rejects_same_idempotency_key_with_different_request() -> None:
+    async def scenario() -> None:
+        store = FakeStore()
+        release = asyncio.Event()
+        async with httpx.AsyncClient() as client:
+            scheduler = RunScheduler(
+                store=store,
+                plugin_daemon_http_client=client,
+                dify_api_http_client=client,
+                runner_factory=lambda _record, _request: ControlledRunner(started=asyncio.Event(), release=release),
+            )
+            _ = await scheduler.create_run(_request().model_copy(update={"idempotency_key": "key-1"}))
+
+            with pytest.raises(IdempotencyConflictError, match="different create-run request"):
+                _ = await scheduler.create_run(_request("other").model_copy(update={"idempotency_key": "key-1"}))
+
+            assert len(store.records) == 1
+            _ = release.set()
+
+    asyncio.run(scenario())
+
+
+def test_create_run_with_different_idempotency_keys_schedules_separate_runs() -> None:
+    async def scenario() -> None:
+        store = FakeStore()
+        release = asyncio.Event()
+        async with httpx.AsyncClient() as client:
+            scheduler = RunScheduler(
+                store=store,
+                plugin_daemon_http_client=client,
+                dify_api_http_client=client,
+                runner_factory=lambda _record, _request: ControlledRunner(started=asyncio.Event(), release=release),
+            )
+            first = await scheduler.create_run(_request().model_copy(update={"idempotency_key": "key-1"}))
+            second = await scheduler.create_run(_request().model_copy(update={"idempotency_key": "key-2"}))
+
+            assert first.run_id != second.run_id
+            assert len(store.records) == 2
+            _ = release.set()
 
     asyncio.run(scenario())

--- a/dify-agent/tests/local/dify_agent/server/test_runs_routes.py
+++ b/dify-agent/tests/local/dify_agent/server/test_runs_routes.py
@@ -4,7 +4,7 @@ from dify_agent.protocol import CancelRunResponse, DIFY_AGENT_MODEL_LAYER_ID, Ru
 from dify_agent.runtime.run_scheduler import RunCancellationConflictError, SchedulerStoppingError
 from dify_agent.server.routes.runs import create_runs_router
 from dify_agent.server.schemas import RunRecord
-from dify_agent.storage.redis_run_store import RunNotFoundError
+from dify_agent.storage.redis_run_store import IdempotencyConflictError, RunNotFoundError
 
 
 class FakeScheduler:
@@ -312,3 +312,32 @@ def test_create_run_does_not_map_infrastructure_failure_to_422() -> None:
     )
 
     assert response.status_code == 500
+
+
+def test_create_run_maps_idempotency_conflict_to_409() -> None:
+    from fastapi import FastAPI
+
+    class ConflictingScheduler:
+        async def create_run(self, request: object) -> RunRecord:
+            del request
+            raise IdempotencyConflictError("idempotency key was already used with a different create-run request")
+
+    app = FastAPI()
+    app.include_router(
+        create_runs_router(lambda: FakeStore(), lambda: ConflictingScheduler())  # pyright: ignore[reportArgumentType]
+    )
+    client = TestClient(app)
+
+    response = client.post(
+        "/runs",
+        json={
+            "composition": {
+                "schema_version": 1,
+                "layers": [{"name": "prompt", "type": "plain.prompt", "config": {"user": "hello"}}],
+            },
+            "idempotency_key": "key-1",
+        },
+    )
+
+    assert response.status_code == 409
+    assert "different create-run request" in response.json()["detail"]

--- a/dify-agent/tests/local/dify_agent/server/test_runs_routes.py
+++ b/dify-agent/tests/local/dify_agent/server/test_runs_routes.py
@@ -4,6 +4,7 @@ from dify_agent.protocol import CancelRunResponse, DIFY_AGENT_MODEL_LAYER_ID
 from dify_agent.runtime.run_scheduler import RunCancellationConflictError, SchedulerStoppingError
 from dify_agent.server.routes.runs import create_runs_router
 from dify_agent.server.schemas import RunRecord
+from dify_agent.storage.redis_run_store import IdempotencyConflictError
 
 
 class FakeScheduler:
@@ -268,3 +269,32 @@ def test_create_run_does_not_map_infrastructure_failure_to_422() -> None:
     )
 
     assert response.status_code == 500
+
+
+def test_create_run_maps_idempotency_conflict_to_409() -> None:
+    from fastapi import FastAPI
+
+    class ConflictingScheduler:
+        async def create_run(self, request: object) -> RunRecord:
+            del request
+            raise IdempotencyConflictError("idempotency key was already used with a different create-run request")
+
+    app = FastAPI()
+    app.include_router(
+        create_runs_router(lambda: FakeStore(), lambda: ConflictingScheduler())  # pyright: ignore[reportArgumentType]
+    )
+    client = TestClient(app)
+
+    response = client.post(
+        "/runs",
+        json={
+            "composition": {
+                "schema_version": 1,
+                "layers": [{"name": "prompt", "type": "plain.prompt", "config": {"user": "hello"}}],
+            },
+            "idempotency_key": "key-1",
+        },
+    )
+
+    assert response.status_code == 409
+    assert "different create-run request" in response.json()["detail"]

--- a/dify-agent/tests/local/dify_agent/storage/test_redis_run_store.py
+++ b/dify-agent/tests/local/dify_agent/storage/test_redis_run_store.py
@@ -1,6 +1,7 @@
 import asyncio
-from collections.abc import Mapping
+import hashlib
 import json
+from collections.abc import Mapping
 from typing import cast
 
 import pytest
@@ -20,7 +21,12 @@ from dify_agent.protocol.schemas import (
     RunSucceededEventData,
 )
 from dify_agent.runtime.event_sink import RunFinalizationResult
-from dify_agent.storage.redis_run_store import DEFAULT_RUN_RETENTION_SECONDS, RedisRunStore, RunNotFoundError
+from dify_agent.storage.redis_run_store import (
+    DEFAULT_RUN_RETENTION_SECONDS,
+    IdempotencyConflictError,
+    RedisRunStore,
+    RunNotFoundError,
+)
 
 
 class FakeRedis:
@@ -34,13 +40,20 @@ class FakeRedis:
         self.streams = {}
         self.stream_changed = asyncio.Event()
 
-    async def set(self, key: str, value: object, *, ex: int | None = None) -> None:
-        self.commands.append(("set", key, value, ex))
+    async def set(self, key: str, value: object, *, ex: int | None = None, nx: bool = False) -> bool | None:
+        self.commands.append(("set", key, value, ex, nx))
+        if nx and key in self.values:
+            return None
         self.values[key] = value
+        return True
 
     async def get(self, key: str) -> object | None:
         self.commands.append(("get", key))
         return self.values.get(key)
+
+    async def delete(self, key: str) -> int:
+        self.commands.append(("delete", key))
+        return 1 if self.values.pop(key, None) is not None else 0
 
     async def xadd(self, key: str, fields: Mapping[str, object]) -> str:
         self.commands.append(("xadd", key, dict(fields)))
@@ -593,3 +606,57 @@ def test_iter_events_ends_after_live_terminal_event(terminal_type: str) -> None:
         return event.type
 
     assert asyncio.run(scenario()) == terminal_type
+
+
+def test_create_run_idempotent_claims_key_and_returns_new_record() -> None:
+    redis = FakeRedis()
+    store = RedisRunStore(redis, prefix="test", run_retention_seconds=60)  # pyright: ignore[reportArgumentType]
+
+    record, created = asyncio.run(store.create_run_idempotent(idempotency_key="key-1", request_fingerprint="fp-1"))
+
+    assert created is True
+    assert record.status == "running"
+    claim_entries = [(key, value) for key, value in redis.values.items() if key.startswith("test:idempotency:")]
+    assert claim_entries == [
+        (
+            f"test:idempotency:{hashlib.sha256(b'key-1').hexdigest()}",
+            json.dumps({"run_id": record.run_id, "fingerprint": "fp-1"}, separators=(",", ":")),
+        )
+    ]
+    set_commands = [
+        command for command in redis.commands if command[0] == "set" and str(command[1]).startswith("test:idempotency:")
+    ]
+    assert set_commands[0][3] == 60
+    assert set_commands[0][4] is True
+
+
+def test_create_run_idempotent_replay_returns_original_record_without_duplicate() -> None:
+    redis = FakeRedis()
+    store = RedisRunStore(redis, prefix="test", run_retention_seconds=60)  # pyright: ignore[reportArgumentType]
+
+    async def scenario() -> tuple[str, str, bool]:
+        first, first_created = await store.create_run_idempotent(idempotency_key="key-1", request_fingerprint="fp-1")
+        replay, replay_created = await store.create_run_idempotent(idempotency_key="key-1", request_fingerprint="fp-1")
+        assert first_created is True
+        return first.run_id, replay.run_id, replay_created
+
+    first_run_id, replay_run_id, replay_created = asyncio.run(scenario())
+
+    assert replay_created is False
+    assert replay_run_id == first_run_id
+    assert [key for key in redis.values if key.startswith("test:runs:")] == [f"test:runs:{first_run_id}:record"]
+
+
+def test_create_run_idempotent_conflict_raises_and_removes_duplicate_record() -> None:
+    redis = FakeRedis()
+    store = RedisRunStore(redis, prefix="test", run_retention_seconds=60)  # pyright: ignore[reportArgumentType]
+
+    async def scenario() -> str:
+        first, _ = await store.create_run_idempotent(idempotency_key="key-1", request_fingerprint="fp-1")
+        with pytest.raises(IdempotencyConflictError):
+            _ = await store.create_run_idempotent(idempotency_key="key-1", request_fingerprint="fp-2")
+        return first.run_id
+
+    run_id = asyncio.run(scenario())
+
+    assert [key for key in redis.values if key.startswith("test:runs:")] == [f"test:runs:{run_id}:record"]

--- a/dify-agent/tests/local/dify_agent/storage/test_redis_run_store.py
+++ b/dify-agent/tests/local/dify_agent/storage/test_redis_run_store.py
@@ -1,13 +1,20 @@
 import asyncio
+import hashlib
+import json
 from collections.abc import Mapping
 from typing import cast
 
+import pytest
 from pydantic import JsonValue
 
 from agenton.compositor import CompositorSessionSnapshot, LayerSessionSnapshot
 from agenton.layers import LifecycleState
 from dify_agent.protocol.schemas import RunStartedEvent, RunSucceededEvent, RunSucceededEventData
-from dify_agent.storage.redis_run_store import DEFAULT_RUN_RETENTION_SECONDS, RedisRunStore
+from dify_agent.storage.redis_run_store import (
+    DEFAULT_RUN_RETENTION_SECONDS,
+    IdempotencyConflictError,
+    RedisRunStore,
+)
 
 
 class FakeRedis:
@@ -20,13 +27,20 @@ class FakeRedis:
         self.values = {}
         self.streams = {}
 
-    async def set(self, key: str, value: object, *, ex: int | None = None) -> None:
-        self.commands.append(("set", key, value, ex))
+    async def set(self, key: str, value: object, *, ex: int | None = None, nx: bool = False) -> bool | None:
+        self.commands.append(("set", key, value, ex, nx))
+        if nx and key in self.values:
+            return None
         self.values[key] = value
+        return True
 
     async def get(self, key: str) -> object | None:
         self.commands.append(("get", key))
         return self.values.get(key)
+
+    async def delete(self, key: str) -> int:
+        self.commands.append(("delete", key))
+        return 1 if self.values.pop(key, None) is not None else 0
 
     async def xadd(self, key: str, fields: Mapping[str, object]) -> str:
         self.commands.append(("xadd", key, dict(fields)))
@@ -184,3 +198,57 @@ def test_get_events_round_trips_run_succeeded_output_and_session_snapshot() -> N
     assert decoded.id == event_id
     assert decoded.data.output == output
     assert decoded.data.session_snapshot == session_snapshot
+
+
+def test_create_run_idempotent_claims_key_and_returns_new_record() -> None:
+    redis = FakeRedis()
+    store = RedisRunStore(redis, prefix="test", run_retention_seconds=60)  # pyright: ignore[reportArgumentType]
+
+    record, created = asyncio.run(store.create_run_idempotent(idempotency_key="key-1", request_fingerprint="fp-1"))
+
+    assert created is True
+    assert record.status == "running"
+    claim_entries = [(key, value) for key, value in redis.values.items() if key.startswith("test:idempotency:")]
+    assert claim_entries == [
+        (
+            f"test:idempotency:{hashlib.sha256(b'key-1').hexdigest()}",
+            json.dumps({"run_id": record.run_id, "fingerprint": "fp-1"}, separators=(",", ":")),
+        )
+    ]
+    set_commands = [
+        command for command in redis.commands if command[0] == "set" and str(command[1]).startswith("test:idempotency:")
+    ]
+    assert set_commands[0][3] == 60
+    assert set_commands[0][4] is True
+
+
+def test_create_run_idempotent_replay_returns_original_record_without_duplicate() -> None:
+    redis = FakeRedis()
+    store = RedisRunStore(redis, prefix="test", run_retention_seconds=60)  # pyright: ignore[reportArgumentType]
+
+    async def scenario() -> tuple[str, str, bool]:
+        first, first_created = await store.create_run_idempotent(idempotency_key="key-1", request_fingerprint="fp-1")
+        replay, replay_created = await store.create_run_idempotent(idempotency_key="key-1", request_fingerprint="fp-1")
+        assert first_created is True
+        return first.run_id, replay.run_id, replay_created
+
+    first_run_id, replay_run_id, replay_created = asyncio.run(scenario())
+
+    assert replay_created is False
+    assert replay_run_id == first_run_id
+    assert [key for key in redis.values if key.startswith("test:runs:")] == [f"test:runs:{first_run_id}:record"]
+
+
+def test_create_run_idempotent_conflict_raises_and_removes_duplicate_record() -> None:
+    redis = FakeRedis()
+    store = RedisRunStore(redis, prefix="test", run_retention_seconds=60)  # pyright: ignore[reportArgumentType]
+
+    async def scenario() -> str:
+        first, _ = await store.create_run_idempotent(idempotency_key="key-1", request_fingerprint="fp-1")
+        with pytest.raises(IdempotencyConflictError):
+            _ = await store.create_run_idempotent(idempotency_key="key-1", request_fingerprint="fp-2")
+        return first.run_id
+
+    run_id = asyncio.run(scenario())
+
+    assert [key for key in redis.values if key.startswith("test:runs:")] == [f"test:runs:{run_id}:record"]


### PR DESCRIPTION
## Summary

Fixes #39685

The standalone dify-agent run server accepted `CreateRunRequest.idempotency_key` but never used it during run admission: `RunScheduler.create_run()` always persisted a new run record and started another background task, so client retries (and concurrent duplicate requests hitting different server processes sharing the same Redis prefix) repeated model invocations and tool side effects.

## Changes

- `RedisRunStore.create_run_idempotent()`: claims the idempotency key behind an atomic `SET NX` (TTL = run retention window), keyed by the key digest. Only the request fingerprint digest and the claimed run id are persisted — never the create-run payload, which may carry model credentials. A stale claim whose original run record is already gone is taken over by the fresh run.
- `RunScheduler.create_run()`: when the request carries an `idempotency_key`, computes a stable fingerprint over the normalized request (excluding the key itself) and deduplicates admission. An exact replay within the retention window returns the original run id and current status without scheduling a second task.
- `POST /runs`: reusing the key with a different normalized request returns HTTP 409.
- Requests without an idempotency key keep the existing behavior.
- Regression tests for the store claim/replay/conflict paths, scheduler dedup (including fingerprint normalization of semantically equal payloads), and the 409 route mapping.

## Testing

- `pytest tests` — 649 passed; the 2 failures in `test_run_scheduler.py` and the 4 collection errors from duplicate test-module basenames also reproduce on a clean `main` checkout and are unrelated to this change.
- `ruff check`, `ruff format --check`, and `basedpyright --level error` are clean on the touched files.
