### PR TITLE
fix(agent): read suggested-questions config from app_model_config for Agent apps

### DIFF
--- a/api/services/message_service.py
+++ b/api/services/message_service.py
@@ -301,6 +301,18 @@ class MessageService:
                 suggested_questions_after_answer_config = cast(
                     SuggestedQuestionsAfterAnswerConfig, suggested_questions_after_answer
                 )
+        elif app_model.mode == AppMode.AGENT:
+            # Agent Apps store presentation features on the App's own
+            # app_model_config (written by AgentAppFeatureConfigService), not on
+            # the conversation — Agent conversations carry neither
+            # override_model_configs nor app_model_config_id.
+            app_model_config = app_model.app_model_config_with_session(session=session)
+            if not app_model_config:
+                raise ValueError("did not find app model config")
+
+            suggested_questions_after_answer_config = app_model_config.suggested_questions_after_answer_dict
+            if suggested_questions_after_answer_config.get("enabled", False) is False:
+                raise SuggestedQuestionsAfterAnswerDisabledError()
         else:
             if not conversation.override_model_configs:
                 app_model_config = session.scalar(


### PR DESCRIPTION
GET /messages/{message_id}/suggested returns 400 "Suggested Questions Is Disabled." for Agent Apps even when the feature is turned on. The root cause is in MessageService.get_suggested_questions_after_answer: only ADVANCED_CHAT has an explicit branch, so AppMode.AGENT falls into the legacy else path that reads the feature flag from conversation.app_model_config_id / override_model_configs. Agent conversations are created with both fields empty (their presentation features live on the App's own app_model_config via AgentAppFeatureConfigService), so the lookup misses the config and the feature reports as disabled.

This adds a dedicated AppMode.AGENT branch that resolves the flag from app_model.app_model_config_with_session and applies the same enabled/disabled guard as the existing paths. No behavior change for CHAT, AGENT_CHAT, or ADVANCED_CHAT.

Closes #39681.