### PR TITLE
test(e2e): align Agent tool credential states

### DIFF
--- a/e2e/features/step-definitions/agent-v2/agent-edit.steps.ts
+++ b/e2e/features/step-definitions/agent-v2/agent-edit.steps.ts
@@ -247,11 +247,12 @@ Then('I should see the Agent v2 tool state fixture tools', async function (this:
   const toolsSection = page.getByRole('region', { name: 'Tools' })
 
   await expect(toolsSection).toBeVisible({ timeout: 30_000 })
-  await expect(
-    toolsSection.getByRole('button', { exact: true, name: 'Not authorized' }),
-  ).toHaveCount(2)
 
-  const { action: jsonReplaceAction, tool: jsonTool } = await expectProviderToolActionVisible(
+  const {
+    action: jsonReplaceAction,
+    provider: jsonProvider,
+    tool: jsonTool,
+  } = await expectProviderToolActionVisible(
     toolsSection,
     agentBuilderPreseededResources.jsonReplaceTool,
   )
@@ -269,10 +270,16 @@ Then('I should see the Agent v2 tool state fixture tools', async function (this:
     }),
   ).toBeVisible()
 
-  await expectProviderToolActionVisible(
+  const { provider: tavilyProvider } = await expectProviderToolActionVisible(
     toolsSection,
     agentBuilderPreseededResources.tavilySearchTool,
   )
+  await expect(
+    tavilyProvider.locator('..').getByRole('button', { exact: true, name: 'Not authorized' }),
+  ).toBeVisible()
+  await expect(
+    jsonProvider.locator('..').getByRole('button', { exact: true, name: 'Not authorized' }),
+  ).toHaveCount(0)
 })
 
 Then('I should see the Agent v2 dual retrieval fixture settings', async function (this: DifyWorld) {

--- a/e2e/features/step-definitions/agent-v2/configure-helpers.ts
+++ b/e2e/features/step-definitions/agent-v2/configure-helpers.ts
@@ -276,7 +276,7 @@ export const expectProviderToolActionVisible = async (
   const action = toolsSection.getByText(tool.actionName, { exact: true })
   await expect(action).toBeVisible()
 
-  return { action, tool }
+  return { action, provider, tool }
 }
 
 export const openAgentKnowledgeRetrievalDialog = async (


### PR DESCRIPTION
## Summary

- scope the Agent v2 tool-state assertions to their individual provider rows
- verify that Tavily shows the user-visible `Not authorized` state
- verify that JSON Process, which requires no credentials, does not show an authorization warning
- expose the provider locator from the shared visibility helper for provider-owned assertions

## Root cause

The post-merge E2E still expected two global `Not authorized` buttons. After #39680 made installed provider metadata available to the Agent tool list, the UI correctly resolved JSON Process as a no-credential tool and hid its stale authorization warning. Tavily remains unauthorized. The count-based assertion no longer matched the product's credential-state contract and failed deterministically with `Expected: 2 / Received: 1`.

This is a stale E2E expectation, not a flaky test or a product regression.

## User impact

Post-merge E2E now protects the actual user-visible behavior per tool instead of coupling unrelated providers through a global badge count.

## Validation

- `E2E_START_AGENT_BACKEND=0 pnpm -C e2e e2e -- --tags '@tool-states-agent'` — 1 scenario, 9 steps passed
- `vp check e2e` — formatting, lint, and type checks passed
- `pnpm -C e2e test:unit` — 8 files, 36 tests passed
- `pnpm -C web test --run features/agent-v2/agent-detail/configure/components/orchestrate/tools/__tests__/index.spec.tsx` — 1 file, 15 tests passed