### PR TITLE
fix(workflow): fall back after initial collaboration failure

### DIFF
--- a/web/app/components/workflow-app/components/__tests__/workflow-main.spec.tsx
+++ b/web/app/components/workflow-app/components/__tests__/workflow-main.spec.tsx
@@ -20,6 +20,7 @@ const mockOnGraphReadyChange = vi.hoisted(() => vi.fn())
 const mockRefreshGraphSynchronously = vi.hoisted(() => vi.fn())
 const mockReplaceGraphFromReactFlow = vi.hoisted(() => vi.fn())
 const mockCanPersistLocalGraph = vi.hoisted(() => vi.fn())
+const mockCanUseLocalDraftFallback = vi.hoisted(() => vi.fn())
 const mockIsGraphReloadCurrent = vi.hoisted(() => vi.fn())
 const mockRetryGraphReload = vi.hoisted(() => vi.fn())
 
@@ -66,6 +67,7 @@ const collaborationRuntime = vi.hoisted(() => ({
   cursors: {} as Record<string, { x: number; y: number; userId: string; timestamp: number }>,
   isConnected: false,
   isEnabled: false,
+  connectionError: null as string | null,
 }))
 
 const collaborationListeners = vi.hoisted(() => ({
@@ -138,6 +140,7 @@ vi.mock('@/app/components/workflow/collaboration/hooks/use-collaboration', () =>
     cursors: collaborationRuntime.cursors,
     isConnected: collaborationRuntime.isConnected,
     isEnabled: collaborationRuntime.isEnabled,
+    connectionError: collaborationRuntime.connectionError,
   }),
 }))
 
@@ -183,6 +186,7 @@ vi.mock('@/app/components/workflow/collaboration/core/collaboration-manager', ()
     refreshGraphSynchronously: mockRefreshGraphSynchronously,
     replaceGraphFromReactFlow: mockReplaceGraphFromReactFlow,
     canPersistLocalGraph: mockCanPersistLocalGraph,
+    canUseLocalDraftFallback: mockCanUseLocalDraftFallback,
     isGraphReloadCurrent: mockIsGraphReloadCurrent,
     retryGraphReload: mockRetryGraphReload,
   },
@@ -431,6 +435,7 @@ describe('WorkflowMain', () => {
     collaborationRuntime.cursors = {}
     collaborationRuntime.isConnected = false
     collaborationRuntime.isEnabled = false
+    collaborationRuntime.connectionError = null
     collaborationListeners.varsAndFeaturesUpdate = null
     collaborationListeners.workflowUpdate = null
     collaborationListeners.syncRequest = null
@@ -438,6 +443,7 @@ describe('WorkflowMain', () => {
     collaborationListeners.graphReadyChange = null
     mockFetchWorkflowDraft.mockReset()
     mockCanPersistLocalGraph.mockReturnValue(true)
+    mockCanUseLocalDraftFallback.mockReturnValue(false)
     mockIsGraphReloadCurrent.mockReturnValue(true)
     mockReplaceGraphFromReactFlow.mockReturnValue(true)
     hookFns.doSyncWorkflowDraft.mockResolvedValue({ hash: 'saved-hash', updatedAt: 2 })
@@ -570,6 +576,31 @@ describe('WorkflowMain', () => {
 
     act(() => collaborationListeners.graphReadyChange?.(true))
     expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('uses the local draft when the initial collaboration connection fails', () => {
+    collaborationRuntime.isEnabled = true
+    collaborationRuntime.connectionError = 'websocket error'
+    mockCanUseLocalDraftFallback.mockReturnValue(true)
+
+    render(<WorkflowMain nodes={[]} edges={[]} viewport={{ x: 0, y: 0, zoom: 1 }} />)
+
+    act(() => collaborationListeners.graphReadyChange?.(false))
+
+    expect(screen.queryByTestId('collaboration-graph-loading')).not.toBeInTheDocument()
+    expect(screen.getByTestId('workflow-inner-context')).toBeInTheDocument()
+  })
+
+  it('keeps blocking after an established collaboration session disconnects', () => {
+    collaborationRuntime.isEnabled = true
+    collaborationRuntime.connectionError = 'transport close'
+    mockCanUseLocalDraftFallback.mockReturnValue(false)
+
+    render(<WorkflowMain nodes={[]} edges={[]} viewport={{ x: 0, y: 0, zoom: 1 }} />)
+
+    act(() => collaborationListeners.graphReadyChange?.(false))
+
+    expect(screen.getByRole('status')).toHaveTextContent('workflow.common.syncingData')
   })
 
   it('subscribes collaboration listeners and handles sync/workflow update callbacks', async () => {

--- a/web/app/components/workflow-app/components/workflow-main.tsx
+++ b/web/app/components/workflow-app/components/workflow-main.tsx
@@ -73,6 +73,7 @@ const WorkflowMain = ({ nodes, edges, viewport }: WorkflowMainProps) => {
     onlineUsers,
     cursors,
     isConnected,
+    connectionError,
     isEnabled: isCollaborationEnabled,
   } = useCollaboration(appId || '', reactFlowStore)
   const myUserId = useMemo(
@@ -427,6 +428,7 @@ const WorkflowMain = ({ nodes, edges, viewport }: WorkflowMainProps) => {
         <WorkflowChildren />
       </WorkflowWithInnerContext>
       {isCollaborationEnabled &&
+        !(connectionError && collaborationManager.canUseLocalDraftFallback()) &&
         (collaborationGraphState.appId !== appId || !collaborationGraphState.isReady) && (
           <div
             data-testid="collaboration-graph-loading"

--- a/web/app/components/workflow/collaboration/hooks/__tests__/use-collaboration.spec.ts
+++ b/web/app/components/workflow/collaboration/hooks/__tests__/use-collaboration.spec.ts
@@ -169,4 +169,26 @@ describe('useCollaboration', () => {
     result.current.startCursorTracking({ current: document.createElement('div') })
     expect(mockStartTracking).not.toHaveBeenCalled()
   })
+
+  it('exposes an initial connection error and clears it after reconnecting', async () => {
+    const { result } = renderHookWithConsoleQuery(() => useCollaboration('app-1'), {
+      systemFeatures: { enable_collaboration_mode: true },
+    })
+
+    await waitFor(() => {
+      expect(onStateChangeCallback).not.toBeNull()
+    })
+
+    onStateChangeCallback?.({ isConnected: false, error: 'websocket error' })
+
+    await waitFor(() => {
+      expect(result.current.connectionError).toBe('websocket error')
+    })
+
+    onStateChangeCallback?.({ isConnected: true })
+
+    await waitFor(() => {
+      expect(result.current.connectionError).toBeNull()
+    })
+  })
 })

--- a/web/app/components/workflow/collaboration/hooks/use-collaboration.ts
+++ b/web/app/components/workflow/collaboration/hooks/use-collaboration.ts
@@ -13,6 +13,7 @@ import { CursorService } from '../services/cursor-service'
 
 type CollaborationViewState = {
   isConnected: boolean
+  connectionError: string | null
   onlineUsers: OnlineUser[]
   cursors: Record<string, CursorPosition>
   nodePanelPresence: NodePanelPresenceMap
@@ -23,6 +24,7 @@ type ReactFlowStore = NonNullable<Parameters<typeof collaborationManager.connect
 
 const initialState: CollaborationViewState = {
   isConnected: false,
+  connectionError: null,
   onlineUsers: [],
   cursors: {},
   nodePanelPresence: {},
@@ -76,7 +78,14 @@ export function useCollaboration(appId: string, reactFlowStore?: ReactFlowStore)
 
         if (newState.isConnected === undefined) return
 
-        setState((prev) => ({ ...prev, isConnected: newState.isConnected ?? prev.isConnected }))
+        setState((prev) => ({
+          ...prev,
+          isConnected: newState.isConnected ?? prev.isConnected,
+          connectionError:
+            newState.isConnected === true
+              ? null
+              : (newState.error ?? newState.disconnectReason ?? prev.connectionError),
+        }))
       },
     )
 
@@ -145,6 +154,7 @@ export function useCollaboration(appId: string, reactFlowStore?: ReactFlowStore)
 
   const result = {
     isConnected: state.isConnected || false,
+    connectionError: state.connectionError,
     onlineUsers: state.onlineUsers || [],
     cursors: state.cursors || {},
     nodePanelPresence: state.nodePanelPresence || {},


### PR DESCRIPTION
## Summary

Addresses the indefinite workflow-editor loading state reported in #39694 when the collaboration WebSocket cannot establish its first connection.

The collaboration manager already distinguishes two safety states:

- before any successful collaboration connection, the HTTP-loaded local draft is a valid fallback;
- after a collaboration session has been established, disconnects must recover through CRDT synchronization before edits resume.

`WorkflowMain` ignored that distinction and always rendered the full-canvas “Synchronizing data” blocker whenever the collaborative graph was not ready. A startup `connect_error` therefore left the editor permanently blocked even though `canUseLocalDraftFallback()` was true.

This change exposes the connection error from `useCollaboration` and suppresses the blocker only when both the error exists and the manager explicitly permits the local-draft fallback. Reconnection clears the error. Established-session disconnects remain blocked.

## Validation

- WorkflowMain + collaboration hook behavior: **17 passed**.
- TSSLint: **6003 passed**.
- Targeted Vite+ format/lint/type checks: **0 errors** (one pre-existing ref-name warning).
- `git diff --check`: **passed**.
- The repository-wide `pnpm check` cannot be used as a clean gate in this Windows checkout because it reports CRLF formatting differences across 8,263 unchanged files; all four changed files pass the same targeted check.

## Scope

This restores the editor's intended local-draft startup fallback. It does not hide or claim to repair an incorrectly deployed collaboration WebSocket endpoint; after a previously successful collaborative session disconnects, the safety blocker remains active.