### PR TITLE
fix(vdb): correct malformed metadata-filter SQL in Relyt and AnalyticDB

### DIFF
--- a/api/providers/vdb/vdb-analyticdb/src/dify_vdb_analyticdb/analyticdb_vector_sql.py
+++ b/api/providers/vdb/vdb-analyticdb/src/dify_vdb_analyticdb/analyticdb_vector_sql.py
@@ -212,7 +212,7 @@ class AnalyticdbVectorBySql:
         if not isinstance(top_k, int) or top_k <= 0:
             raise ValueError("top_k must be a positive integer")
         document_ids_filter = kwargs.get("document_ids_filter")
-        where_clause = "WHERE 1=1"
+        where_clause = "WHERE 1=1 "
         if document_ids_filter:
             document_ids = ", ".join(f"'{id}'" for id in document_ids_filter)
             where_clause += f"AND metadata_->>'document_id' IN ({document_ids})"

--- a/api/providers/vdb/vdb-analyticdb/tests/unit_tests/test_analyticdb_vector_sql.py
+++ b/api/providers/vdb/vdb-analyticdb/tests/unit_tests/test_analyticdb_vector_sql.py
@@ -227,6 +227,26 @@ def test_search_by_vector_returns_documents_above_threshold():
     assert docs[0].metadata["score"] == 0.8
 
 
+def test_search_by_vector_where_clause_separates_and_predicate():
+    """Regression for #39476: WHERE 1=1 must be followed by a space before AND."""
+    vector = AnalyticdbVectorBySql.__new__(AnalyticdbVectorBySql)
+    vector.table_name = "dify.collection"
+    cursor = MagicMock()
+    cursor.__iter__.return_value = iter([])
+
+    @contextmanager
+    def _cursor_context():
+        yield cursor
+
+    vector._get_cursor = _cursor_context
+
+    vector.search_by_vector([0.1, 0.2], top_k=2, document_ids_filter=["doc-1", "doc-2"])
+
+    sql = cursor.execute.call_args.args[0]
+    assert "WHERE 1=1 AND metadata_->>'document_id' IN ('doc-1', 'doc-2')" in sql
+    assert "WHERE 1=1AND" not in sql
+
+
 @pytest.mark.parametrize("invalid_top_k", [0, "x", -1])
 def test_search_by_full_text_validates_top_k(invalid_top_k):
     vector = AnalyticdbVectorBySql.__new__(AnalyticdbVectorBySql)

--- a/api/providers/vdb/vdb-relyt/src/dify_vdb_relyt/relyt_vector.py
+++ b/api/providers/vdb/vdb-relyt/src/dify_vdb_relyt/relyt_vector.py
@@ -255,9 +255,9 @@ class RelytVector(BaseVector):
         filter_condition = ""
         if filter is not None:
             conditions = [
-                f"metadata->>'{key!r}' in ({', '.join(map(repr, value))})"
+                f"metadata->>'{key}' in ({', '.join(map(repr, value))})"
                 if len(value) > 1
-                else f"metadata->>'{key!r}' = {value[0]!r}"
+                else f"metadata->>'{key}' = {value[0]!r}"
                 for key, value in filter.items()
             ]
             filter_condition = f"WHERE {' AND '.join(conditions)}"

--- a/api/providers/vdb/vdb-relyt/tests/unit_tests/test_relyt_vector.py
+++ b/api/providers/vdb/vdb-relyt/tests/unit_tests/test_relyt_vector.py
@@ -266,6 +266,31 @@ def test_similarity_search_with_score_by_vector(relyt_module):
     assert similarities[0][0].page_content == "doc-a"
 
 
+def test_similarity_search_metadata_filter_sql_quotes_key_once(relyt_module):
+    """Regression for #39476: metadata keys must not be double-quoted via !r."""
+    vector = relyt_module.RelytVector.__new__(relyt_module.RelytVector)
+    vector._collection_name = "collection_1"
+    vector.client = MagicMock()
+    vector.embedding_dimension = 3
+    conn = MagicMock()
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = None
+    conn.execute.return_value.fetchall.return_value = []
+    vector.client.connect.return_value = conn
+
+    vector.similarity_search_with_score_by_vector(
+        [0.1, 0.2],
+        k=2,
+        filter={"document_id": ["d-1"], "source": ["a", "b"]},
+    )
+
+    sql = conn.execute.call_args.args[0].text
+    assert "metadata->>'document_id' = 'd-1'" in sql
+    assert "metadata->>'source' in ('a', 'b')" in sql
+    assert "metadata->>''document_id''" not in sql
+    assert "metadata->>''source''" not in sql
+
+
 # 7. search_by_vector filters by score and ids
 def test_search_by_vector_filters_by_score_and_ids(relyt_module):
     vector = relyt_module.RelytVector.__new__(relyt_module.RelytVector)


### PR DESCRIPTION
## Summary

Fixes two related SQL construction bugs that break every metadata-filtered vector search on Relyt and AnalyticDB.

- **Relyt:** `metadata->>'{key!r}'` double-quoted JSONB keys (e.g. `metadata->>''document_id''`), which is invalid SQL. Drop the `!r` so keys render as `metadata->>'document_id'`.
- **AnalyticDB:** `WHERE 1=1` was concatenated directly with `AND ...`, producing `WHERE 1=1AND ...`. PostgreSQL 15+ rejects that. Add a trailing space after `WHERE 1=1`.
- Add unit regression tests that assert the generated SQL for both providers.

Fixes #39476

## Screenshots

Not applicable (SQL construction / unit-test change only).

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran the relevant backend unit tests for the Relyt and AnalyticDB providers (49 passed, including the new regressions)
