### PR TITLE
refactor: avoid state updates in breakpoint effect

### DIFF
--- a/web/hooks/use-breakpoints.ts
+++ b/web/hooks/use-breakpoints.ts
@@ -1,5 +1,5 @@
 'use client'
-import * as React from 'react'
+import { useSyncExternalStore } from 'react'
 
 export const MediaType = {
   mobile: 'mobile',
@@ -9,21 +9,24 @@ export const MediaType = {
 
 type MediaTypeValue = (typeof MediaType)[keyof typeof MediaType]
 
+const subscribeToViewport = (onStoreChange: () => void) => {
+  window.addEventListener('resize', onStoreChange)
+  return () => window.removeEventListener('resize', onStoreChange)
+}
+
+const getViewportWidth = () => globalThis.innerWidth
+const getServerViewportWidth = () => 1024
+
 const useBreakpoints = (): MediaTypeValue => {
-  const [width, setWidth] = React.useState(globalThis.innerWidth)
-  const media = (() => {
-    if (width <= 640) return MediaType.mobile
-    if (width <= 768) return MediaType.tablet
-    return MediaType.pc
-  })()
+  const width = useSyncExternalStore(
+    subscribeToViewport,
+    getViewportWidth,
+    getServerViewportWidth,
+  )
 
-  React.useEffect(() => {
-    const handleWindowResize = () => setWidth(window.innerWidth)
-    window.addEventListener('resize', handleWindowResize)
-    return () => window.removeEventListener('resize', handleWindowResize)
-  }, [])
-
-  return media
+  if (width <= 640) return MediaType.mobile
+  if (width <= 768) return MediaType.tablet
+  return MediaType.pc
 }
 
 export default useBreakpoints

--- a/web/hooks/use-breakpoints.ts
+++ b/web/hooks/use-breakpoints.ts
@@ -18,11 +18,7 @@ const getViewportWidth = () => globalThis.innerWidth
 const getServerViewportWidth = () => 1024
 
 const useBreakpoints = (): MediaTypeValue => {
-  const width = useSyncExternalStore(
-    subscribeToViewport,
-    getViewportWidth,
-    getServerViewportWidth,
-  )
+  const width = useSyncExternalStore(subscribeToViewport, getViewportWidth, getServerViewportWidth)
 
   if (width <= 640) return MediaType.mobile
   if (width <= 768) return MediaType.tablet


### PR DESCRIPTION
Closes #25194

## Summary
- replace the resize useEffect and local state with useSyncExternalStore
- keep viewport changes subscribed through the browser resize event
- provide a stable server snapshot for SSR

## Verification
- source-level check confirms the breakpoint hook no longer calls a state setter from useEffect
- frontend automated checks could not run because node_modules is not installed in this checkout