### PR TITLE
fix: preserve workflow stream client errors

### DIFF
--- a/api/core/app/apps/base_app_generate_response_converter.py
+++ b/api/core/app/apps/base_app_generate_response_converter.py
@@ -10,6 +10,7 @@ from core.app.entities.app_invoke_entities import InvokeFrom
 from core.app.entities.task_entities import AppBlockingResponse, AppStreamResponse
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from graphon.model_runtime.errors.invoke import InvokeError, InvokeRateLimitError
+from libs.exception import BaseHTTPException
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +118,13 @@ class AppGenerateResponseConverter[TBlockingResponse: AppBlockingResponse](ABC):
         :param e: exception
         :return:
         """
+        if isinstance(e, BaseHTTPException) and e.code is not None and 400 <= e.code < 500:
+            return {
+                "code": e.error_code,
+                "message": e.description or str(e),
+                "status": e.code,
+            }
+
         error_responses: dict[type[Exception], dict[str, JsonValue]] = {
             ValueError: {"code": "invalid_param", "status": 400},
             ProviderTokenNotInitError: {"code": "provider_not_initialize", "status": 400},

--- a/api/core/app/apps/base_app_generate_response_converter.py
+++ b/api/core/app/apps/base_app_generate_response_converter.py
@@ -10,7 +10,6 @@ from core.app.entities.app_invoke_entities import InvokeFrom
 from core.app.entities.task_entities import AppBlockingResponse, AppStreamResponse
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from graphon.model_runtime.errors.invoke import InvokeError, InvokeRateLimitError
-from libs.exception import BaseHTTPException
 
 logger = logging.getLogger(__name__)
 
@@ -118,13 +117,6 @@ class AppGenerateResponseConverter[TBlockingResponse: AppBlockingResponse](ABC):
         :param e: exception
         :return:
         """
-        if isinstance(e, BaseHTTPException) and e.code is not None and 400 <= e.code < 500:
-            return {
-                "code": e.error_code,
-                "message": e.description or str(e),
-                "status": e.code,
-            }
-
         error_responses: dict[type[Exception], dict[str, JsonValue]] = {
             ValueError: {"code": "invalid_param", "status": 400},
             ProviderTokenNotInitError: {"code": "provider_not_initialize", "status": 400},

--- a/api/core/app/apps/base_app_queue_manager.py
+++ b/api/core/app/apps/base_app_queue_manager.py
@@ -132,7 +132,7 @@ class AppQueueManager(ABC):
                 "Failed to clear task belong cache for task %s (key: %s)", self._task_id, self._task_belong_cache_key
             )
 
-    def publish_error(self, e, pub_from: PublishFrom) -> None:
+    def publish_error(self, e: Exception, pub_from: PublishFrom) -> None:
         """
         Publish error
         :param e: error

--- a/api/core/app/entities/queue_entities.py
+++ b/api/core/app/entities/queue_entities.py
@@ -472,7 +472,7 @@ class QueueErrorEvent(AppQueueEvent):
     """
 
     event: QueueEvent = QueueEvent.ERROR
-    error: Any = None
+    error: Exception
 
 
 class QueuePingEvent(AppQueueEvent):

--- a/api/core/app/task_pipeline/based_generate_task_pipeline.py
+++ b/api/core/app/task_pipeline/based_generate_task_pipeline.py
@@ -19,6 +19,7 @@ from core.app.entities.task_entities import (
 from core.errors.error import QuotaExceededError
 from core.moderation.output_moderation import ModerationRule, OutputModeration
 from graphon.model_runtime.errors.invoke import InvokeAuthorizationError, InvokeError
+from libs.exception import BaseHTTPException
 from models.enums import MessageStatus
 from models.model import Message
 
@@ -47,7 +48,9 @@ class BasedGenerateTaskPipeline[AppGenerateEntityT: AppGenerateEntity]:
         self.output_moderation_handler = self._init_output_moderation()
         self.stream = stream
 
-    def handle_error(self, *, event: QueueErrorEvent, session: Session | None = None, message_id: str = ""):
+    def handle_error(
+        self, *, event: QueueErrorEvent, session: Session | None = None, message_id: str = ""
+    ) -> Exception:
         logger.debug("error: %s", event.error)
         e = event.error
         err: Exception
@@ -55,6 +58,8 @@ class BasedGenerateTaskPipeline[AppGenerateEntityT: AppGenerateEntity]:
         match e:
             case InvokeAuthorizationError():
                 err = InvokeAuthorizationError("Incorrect API key provided")
+            case BaseHTTPException() if e.code is not None and 400 <= e.code < 500:
+                err = e
             case InvokeError() | ValueError() | AgentBackendError():
                 err = e
             case _:

--- a/api/core/app/task_pipeline/based_generate_task_pipeline.py
+++ b/api/core/app/task_pipeline/based_generate_task_pipeline.py
@@ -3,6 +3,7 @@ import time
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
+from werkzeug.exceptions import HTTPException
 
 from clients.agent_backend.errors import AgentBackendError
 from core.app.apps.base_app_queue_manager import AppQueueManager
@@ -19,7 +20,6 @@ from core.app.entities.task_entities import (
 from core.errors.error import QuotaExceededError
 from core.moderation.output_moderation import ModerationRule, OutputModeration
 from graphon.model_runtime.errors.invoke import InvokeAuthorizationError, InvokeError
-from libs.exception import BaseHTTPException
 from models.enums import MessageStatus
 from models.model import Message
 
@@ -58,13 +58,14 @@ class BasedGenerateTaskPipeline[AppGenerateEntityT: AppGenerateEntity]:
         match e:
             case InvokeAuthorizationError():
                 err = InvokeAuthorizationError("Incorrect API key provided")
-            case BaseHTTPException() if e.code is not None and 400 <= e.code < 500:
-                err = e
+            case HTTPException() if e.code is not None and 400 <= e.code < 500:
+                err = ValueError(e.description)
             case InvokeError() | ValueError() | AgentBackendError():
                 err = e
+            case HTTPException():
+                err = Exception(e.description)
             case _:
-                description = getattr(e, "description", None)
-                err = Exception(description if description is not None else str(e))
+                err = Exception(str(e))
 
         if not message_id or not session:
             return err

--- a/api/tasks/app_generate/workflow_execute_task.py
+++ b/api/tasks/app_generate/workflow_execute_task.py
@@ -311,32 +311,41 @@ def _publish_failed_workflow_terminal_events(exc: Exception, exec_params: AppExe
     topic.publish(json.dumps(finished_payload.model_dump(mode="json"), ensure_ascii=False).encode())
 
 
-def _get_event_name(event: str | Mapping[str, Any] | BaseModel) -> str | None:
+def _get_event_data(event: str | Mapping[str, Any] | BaseModel) -> Mapping[str, Any] | None:
+    """Expose event, task_id, and message fields while retaining legacy BaseModel compatibility."""
     if isinstance(event, BaseModel):
-        # Temporary compatibility for legacy BaseModel stream events; remove after confirming generators always emit
-        # str / Mapping responses.
-        event_name = getattr(event, "event", None)
-    elif isinstance(event, Mapping):
-        event_name = event.get("event")
-    else:
-        return None
+        # Remove this compatibility path after all generators are confirmed to emit only str or Mapping responses.
+        return event.model_dump()
+    if isinstance(event, Mapping):
+        return event
+    return None
 
+
+def _get_event_name(event: str | Mapping[str, Any] | BaseModel) -> str | None:
+    event_data = _get_event_data(event)
+    if event_data is None:
+        return None
+    event_name = event_data.get("event")
     if event_name is None:
         return None
     return str(event_name)
 
 
 def _get_task_id(event: str | Mapping[str, Any] | BaseModel) -> str | None:
-    if isinstance(event, BaseModel):
-        # Temporary compatibility for legacy BaseModel stream events; remove after confirming generators always emit
-        # str / Mapping responses.
-        task_id = getattr(event, "task_id", None)
-    elif isinstance(event, Mapping):
-        task_id = event.get("task_id")
-    else:
+    event_data = _get_event_data(event)
+    if event_data is None:
         return None
+    task_id = event_data.get("task_id")
 
     return task_id if isinstance(task_id, str) and task_id else None
+
+
+def _get_error_message(event: str | Mapping[str, Any] | BaseModel) -> str | None:
+    event_data = _get_event_data(event)
+    if event_data is None:
+        return None
+    message = event_data.get("message")
+    return message if isinstance(message, str) and message else None
 
 
 def _publish_streaming_response(
@@ -406,6 +415,7 @@ def _publish_streaming_response(
     started_published = False
     terminal_published = False
     last_task_id = normalized_workflow_run_id
+    stream_error_message: str | None = None
 
     try:
         for event in response_stream:
@@ -429,6 +439,8 @@ def _publish_streaming_response(
                 started_published = True
             elif event_name in terminal_events:
                 terminal_published = True
+            elif event_name == "error":
+                stream_error_message = _get_error_message(event) or stream_error_message
     except Exception as exc:
         if not terminal_published:
             logger.exception(
@@ -448,7 +460,7 @@ def _publish_streaming_response(
             normalized_workflow_run_id,
         )
         _publish_failed_terminal_event(
-            error_message=unexpected_stream_end_message,
+            error_message=stream_error_message or unexpected_stream_end_message,
             task_id=last_task_id,
             publish_started=not started_published,
         )

--- a/api/tests/unit_tests/core/app/apps/workflow/test_generate_task_pipeline_core.py
+++ b/api/tests/unit_tests/core/app/apps/workflow/test_generate_task_pipeline_core.py
@@ -817,7 +817,7 @@ class TestWorkflowGenerateTaskPipeline:
                 SimpleNamespace(event=QueueWorkflowStartedEvent()),
                 SimpleNamespace(event=QueueTextChunkEvent(text="hello")),
                 SimpleNamespace(event=QueuePingEvent()),
-                SimpleNamespace(event=QueueErrorEvent(error="e")),
+                SimpleNamespace(event=QueueErrorEvent(error=RuntimeError("e"))),
             ]
         )
         pipeline._handle_workflow_started_event = lambda event, **kwargs: iter(["started"])

--- a/api/tests/unit_tests/core/app/task_pipeline/test_based_generate_task_pipeline.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_based_generate_task_pipeline.py
@@ -12,8 +12,21 @@ from core.app.entities.queue_entities import QueueErrorEvent
 from core.app.task_pipeline.based_generate_task_pipeline import BasedGenerateTaskPipeline
 from core.errors.error import QuotaExceededError
 from graphon.model_runtime.errors.invoke import InvokeAuthorizationError, InvokeError, InvokeRateLimitError
+from libs.exception import BaseHTTPException
 from models.enums import ConversationFromSource, MessageStatus
 from models.model import AppMode, Message
+
+
+class _InvalidWorkflowError(BaseHTTPException):
+    error_code = "invalid_workflow"
+    description = "The workflow configuration is invalid."
+    code = 400
+
+
+class _InternalWorkflowError(BaseHTTPException):
+    error_code = "internal_workflow_error"
+    description = "Sensitive internal workflow details."
+    code = 500
 
 
 def _persist_message(session: Session, *, message_id: str) -> Message:
@@ -95,6 +108,21 @@ class TestBasedGenerateTaskPipeline:
         assert "Knowledge retrieval failed" in str(err)
         assert "agent_run_id=run-1" in str(err)
 
+    def test_handle_error_preserves_client_http_error(self, pipeline):
+        event = QueueErrorEvent(error=_InvalidWorkflowError())
+
+        err = pipeline.handle_error(event=event)
+
+        assert err is event.error
+
+    def test_handle_error_wraps_server_http_error(self, pipeline):
+        event = QueueErrorEvent(error=_InternalWorkflowError())
+
+        err = pipeline.handle_error(event=event)
+
+        assert err is not event.error
+        assert type(err) is Exception
+
     @pytest.mark.parametrize("sqlite_session", [(Message,)], indirect=True)
     def test_handle_error_updates_message_when_found(self, pipeline, sqlite_session: Session):
         event = QueueErrorEvent(error=ValueError("oops"))
@@ -149,6 +177,24 @@ class TestBasedGenerateTaskPipeline:
             "code": "completion_request_error",
             "status": 400,
             "message": "Knowledge retrieval failed (agent_run_id=run-1)",
+        }
+
+    def test_stream_converter_maps_client_http_error(self):
+        data = AppGenerateResponseConverter._error_to_stream_response(_InvalidWorkflowError())
+
+        assert data == {
+            "code": "invalid_workflow",
+            "status": 400,
+            "message": "The workflow configuration is invalid.",
+        }
+
+    def test_stream_converter_masks_server_http_error(self):
+        data = AppGenerateResponseConverter._error_to_stream_response(_InternalWorkflowError())
+
+        assert data == {
+            "code": "internal_server_error",
+            "status": 500,
+            "message": "Internal Server Error, please contact support.",
         }
 
     def test_handle_output_moderation_when_flagged(self, pipeline):

--- a/api/tests/unit_tests/core/app/task_pipeline/test_based_generate_task_pipeline.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_based_generate_task_pipeline.py
@@ -118,6 +118,15 @@ class TestBasedGenerateTaskPipeline:
         assert type(err) is Exception
         assert str(err) == "Sensitive internal workflow details."
 
+    def test_handle_error_wraps_unexpected_error(self, pipeline):
+        event = QueueErrorEvent(error=RuntimeError("unexpected error"))
+
+        err = pipeline.handle_error(event=event)
+
+        assert err is not event.error
+        assert type(err) is Exception
+        assert str(err) == "unexpected error"
+
     @pytest.mark.parametrize("sqlite_session", [(Message,)], indirect=True)
     def test_handle_error_updates_message_when_found(self, pipeline, sqlite_session: Session):
         event = QueueErrorEvent(error=ValueError("oops"))

--- a/api/tests/unit_tests/core/app/task_pipeline/test_based_generate_task_pipeline.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_based_generate_task_pipeline.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 
 import pytest
 from sqlalchemy.orm import Session
+from werkzeug.exceptions import InternalServerError, NotFound
 
 from clients.agent_backend.errors import AgentBackendRunFailedError
 from core.app.apps.base_app_generate_response_converter import AppGenerateResponseConverter
@@ -12,21 +13,8 @@ from core.app.entities.queue_entities import QueueErrorEvent
 from core.app.task_pipeline.based_generate_task_pipeline import BasedGenerateTaskPipeline
 from core.errors.error import QuotaExceededError
 from graphon.model_runtime.errors.invoke import InvokeAuthorizationError, InvokeError, InvokeRateLimitError
-from libs.exception import BaseHTTPException
 from models.enums import ConversationFromSource, MessageStatus
 from models.model import AppMode, Message
-
-
-class _InvalidWorkflowError(BaseHTTPException):
-    error_code = "invalid_workflow"
-    description = "The workflow configuration is invalid."
-    code = 400
-
-
-class _InternalWorkflowError(BaseHTTPException):
-    error_code = "internal_workflow_error"
-    description = "Sensitive internal workflow details."
-    code = 500
 
 
 def _persist_message(session: Session, *, message_id: str) -> Message:
@@ -108,20 +96,27 @@ class TestBasedGenerateTaskPipeline:
         assert "Knowledge retrieval failed" in str(err)
         assert "agent_run_id=run-1" in str(err)
 
-    def test_handle_error_preserves_client_http_error(self, pipeline):
-        event = QueueErrorEvent(error=_InvalidWorkflowError())
+    def test_handle_error_maps_client_http_error_to_invalid_param(self, pipeline):
+        event = QueueErrorEvent(error=NotFound("plugin not found, please add plugin"))
 
         err = pipeline.handle_error(event=event)
+        data = AppGenerateResponseConverter._error_to_stream_response(err)
 
-        assert err is event.error
+        assert type(err) is ValueError
+        assert data == {
+            "code": "invalid_param",
+            "status": 400,
+            "message": "plugin not found, please add plugin",
+        }
 
     def test_handle_error_wraps_server_http_error(self, pipeline):
-        event = QueueErrorEvent(error=_InternalWorkflowError())
+        event = QueueErrorEvent(error=InternalServerError("Sensitive internal workflow details."))
 
         err = pipeline.handle_error(event=event)
 
         assert err is not event.error
         assert type(err) is Exception
+        assert str(err) == "Sensitive internal workflow details."
 
     @pytest.mark.parametrize("sqlite_session", [(Message,)], indirect=True)
     def test_handle_error_updates_message_when_found(self, pipeline, sqlite_session: Session):
@@ -177,24 +172,6 @@ class TestBasedGenerateTaskPipeline:
             "code": "completion_request_error",
             "status": 400,
             "message": "Knowledge retrieval failed (agent_run_id=run-1)",
-        }
-
-    def test_stream_converter_maps_client_http_error(self):
-        data = AppGenerateResponseConverter._error_to_stream_response(_InvalidWorkflowError())
-
-        assert data == {
-            "code": "invalid_workflow",
-            "status": 400,
-            "message": "The workflow configuration is invalid.",
-        }
-
-    def test_stream_converter_masks_server_http_error(self):
-        data = AppGenerateResponseConverter._error_to_stream_response(_InternalWorkflowError())
-
-        assert data == {
-            "code": "internal_server_error",
-            "status": 500,
-            "message": "Internal Server Error, please contact support.",
         }
 
     def test_handle_output_moderation_when_flagged(self, pipeline):

--- a/api/tests/unit_tests/tasks/test_workflow_execute_task.py
+++ b/api/tests/unit_tests/tasks/test_workflow_execute_task.py
@@ -486,6 +486,41 @@ def test_publish_streaming_response_publishes_failed_terminal_on_exhaustion_with
     assert "ended without a terminal event" in caplog.text
 
 
+def test_publish_streaming_response_uses_stream_error_message_for_failed_terminal(mock_topic: MagicMock):
+    response_stream = iter(
+        [
+            {
+                "event": "workflow_started",
+                "task_id": "task-id",
+                "workflow_run_id": "workflow-run-id",
+                "data": {"id": "workflow-run-id", "workflow_id": "workflow-id", "inputs": {}, "created_at": 1},
+            },
+            {
+                "event": "error",
+                "workflow_run_id": "workflow-run-id",
+                "code": "invalid_workflow",
+                "message": "The workflow configuration is invalid.",
+                "status": 400,
+            },
+        ]
+    )
+
+    _publish_streaming_response(
+        response_stream,
+        "workflow-run-id",
+        app_mode=AppMode.ADVANCED_CHAT,
+        workflow_id="workflow-id",
+        inputs={},
+        started_reason=WorkflowStartReason.INITIAL,
+    )
+
+    payloads = _published_payloads(mock_topic)
+    assert [payload["event"] for payload in payloads] == ["workflow_started", "error", "workflow_finished"]
+    assert payloads[1]["status"] == 400
+    assert payloads[2]["data"]["status"] == WorkflowExecutionStatus.FAILED
+    assert payloads[2]["data"]["error"] == "The workflow configuration is invalid."
+
+
 def test_publish_streaming_response_does_not_publish_synthetic_failure_after_terminal_event(mock_topic: MagicMock):
     response_stream = iter(
         [

--- a/api/tests/unit_tests/tasks/test_workflow_execute_task.py
+++ b/api/tests/unit_tests/tasks/test_workflow_execute_task.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import json
 import logging
 import uuid
+from collections.abc import Generator, Mapping
 from contextlib import nullcontext
 from datetime import datetime
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -487,26 +489,23 @@ def test_publish_streaming_response_publishes_failed_terminal_on_exhaustion_with
 
 
 def test_publish_streaming_response_uses_stream_error_message_for_failed_terminal(mock_topic: MagicMock):
-    response_stream = iter(
-        [
-            {
-                "event": "workflow_started",
-                "task_id": "task-id",
-                "workflow_run_id": "workflow-run-id",
-                "data": {"id": "workflow-run-id", "workflow_id": "workflow-id", "inputs": {}, "created_at": 1},
-            },
-            {
-                "event": "error",
-                "workflow_run_id": "workflow-run-id",
-                "code": "invalid_workflow",
-                "message": "The workflow configuration is invalid.",
-                "status": 400,
-            },
-        ]
-    )
+    def response_stream() -> Generator[str | Mapping[str, Any] | BaseModel, None, None]:
+        yield {
+            "event": "workflow_started",
+            "task_id": "task-id",
+            "workflow_run_id": "workflow-run-id",
+            "data": {"id": "workflow-run-id", "workflow_id": "workflow-id", "inputs": {}, "created_at": 1},
+        }
+        yield {
+            "event": "error",
+            "workflow_run_id": "workflow-run-id",
+            "code": "invalid_workflow",
+            "message": "The workflow configuration is invalid.",
+            "status": 400,
+        }
 
     _publish_streaming_response(
-        response_stream,
+        response_stream(),
         "workflow-run-id",
         app_mode=AppMode.ADVANCED_CHAT,
         workflow_id="workflow-id",
@@ -515,10 +514,21 @@ def test_publish_streaming_response_uses_stream_error_message_for_failed_termina
     )
 
     payloads = _published_payloads(mock_topic)
-    assert [payload["event"] for payload in payloads] == ["workflow_started", "error", "workflow_finished"]
-    assert payloads[1]["status"] == 400
-    assert payloads[2]["data"]["status"] == WorkflowExecutionStatus.FAILED
-    assert payloads[2]["data"]["error"] == "The workflow configuration is invalid."
+    assert len(payloads) == 3
+    started_payload, error_payload, finished_payload = payloads
+    assert isinstance(started_payload, dict)
+    assert isinstance(error_payload, dict)
+    assert isinstance(finished_payload, dict)
+    assert [started_payload["event"], error_payload["event"], finished_payload["event"]] == [
+        "workflow_started",
+        "error",
+        "workflow_finished",
+    ]
+    assert error_payload["status"] == 400
+    finished_data = finished_payload["data"]
+    assert isinstance(finished_data, dict)
+    assert finished_data["status"] == WorkflowExecutionStatus.FAILED
+    assert finished_data["error"] == "The workflow configuration is invalid."
 
 
 def test_publish_streaming_response_does_not_publish_synthetic_failure_after_terminal_event(mock_topic: MagicMock):

--- a/api/tests/unit_tests/tasks/test_workflow_execute_task.py
+++ b/api/tests/unit_tests/tasks/test_workflow_execute_task.py
@@ -37,6 +37,7 @@ from tasks.app_generate.workflow_execute_task import (
 class _StreamEventModel(BaseModel):
     event: object | None = None
     task_id: object | None = None
+    message: object | None = None
 
 
 def _build_advanced_chat_generate_entity(conversation_id: str | None) -> AdvancedChatAppGenerateEntity:
@@ -247,6 +248,21 @@ def test_get_event_name(event: object, expected: str | None):
 )
 def test_get_task_id(event: object, expected: str | None):
     assert workflow_execute_task_module._get_task_id(event) == expected
+
+
+@pytest.mark.parametrize(
+    ("event", "expected"),
+    [
+        ({"message": "workflow error"}, "workflow error"),
+        (_StreamEventModel(message="workflow error"), "workflow error"),
+        ({"message": ""}, None),
+        ({"message": 123}, None),
+        ({}, None),
+        ("workflow error", None),
+    ],
+)
+def test_get_error_message(event: str | Mapping[str, object] | BaseModel, expected: str | None):
+    assert workflow_execute_task_module._get_error_message(event) == expected
 
 
 @pytest.fixture
@@ -502,6 +518,13 @@ def test_publish_streaming_response_uses_stream_error_message_for_failed_termina
             "message": "The workflow configuration is invalid.",
             "status": 400,
         }
+        yield {
+            "event": "error",
+            "workflow_run_id": "workflow-run-id",
+            "code": "invalid_workflow",
+            "message": "",
+            "status": 400,
+        }
 
     _publish_streaming_response(
         response_stream(),
@@ -513,13 +536,20 @@ def test_publish_streaming_response_uses_stream_error_message_for_failed_termina
     )
 
     payloads = _published_payloads(mock_topic)
-    assert len(payloads) == 3
-    started_payload, error_payload, finished_payload = payloads
+    assert len(payloads) == 4
+    started_payload, error_payload, empty_error_payload, finished_payload = payloads
     assert isinstance(started_payload, dict)
     assert isinstance(error_payload, dict)
+    assert isinstance(empty_error_payload, dict)
     assert isinstance(finished_payload, dict)
-    assert [started_payload["event"], error_payload["event"], finished_payload["event"]] == [
+    assert [
+        started_payload["event"],
+        error_payload["event"],
+        empty_error_payload["event"],
+        finished_payload["event"],
+    ] == [
         "workflow_started",
+        "error",
         "error",
         "workflow_finished",
     ]

--- a/api/tests/unit_tests/tasks/test_workflow_execute_task.py
+++ b/api/tests/unit_tests/tasks/test_workflow_execute_task.py
@@ -8,7 +8,6 @@ from contextlib import nullcontext
 from datetime import datetime
 from decimal import Decimal
 from types import SimpleNamespace
-from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -489,7 +488,7 @@ def test_publish_streaming_response_publishes_failed_terminal_on_exhaustion_with
 
 
 def test_publish_streaming_response_uses_stream_error_message_for_failed_terminal(mock_topic: MagicMock):
-    def response_stream() -> Generator[str | Mapping[str, Any] | BaseModel, None, None]:
+    def response_stream() -> Generator[str | Mapping[str, object] | BaseModel, None, None]:
         yield {
             "event": "workflow_started",
             "task_id": "task-id",


### PR DESCRIPTION
## Summary

- Normalize 4xx HTTP errors raised while initializing workflow nodes into the existing `invalid_param` SSE response, preserving the actionable message.
- Reuse the sanitized stream error in synthetic `workflow_finished` events instead of reporting a missing terminal event.

Related: SNP-586

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This does not apply to typos!)
- [x] I have added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I have updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods