### PR TITLE
fix(matrixone): generate ids for every document

### DIFF
--- a/api/providers/vdb/vdb-matrixone/src/dify_vdb_matrixone/matrixone_vector.py
+++ b/api/providers/vdb/vdb-matrixone/src/dify_vdb_matrixone/matrixone_vector.py
@@ -119,9 +119,8 @@ class MatrixoneVector(BaseVector):
         assert self.client is not None
         ids = []
         for doc in documents:
-            if doc.metadata is not None:
-                doc_id = doc.metadata.get("doc_id", str(uuid.uuid4()))
-                ids.append(doc_id)
+            doc_id = doc.metadata.get("doc_id") if doc.metadata else None
+            ids.append(str(doc_id or uuid.uuid4()))
         self.client.insert(
             texts=[doc.page_content for doc in documents],
             embeddings=embeddings,

--- a/api/providers/vdb/vdb-matrixone/tests/unit_tests/test_matrixone_vector.py
+++ b/api/providers/vdb/vdb-matrixone/tests/unit_tests/test_matrixone_vector.py
@@ -168,7 +168,8 @@ def test_get_client_handles_full_text_index_creation_error(matrixone_module, mon
 def test_add_texts_generates_ids_and_inserts(matrixone_module, monkeypatch: pytest.MonkeyPatch):
     vector = matrixone_module.MatrixoneVector("collection_1", _valid_config(matrixone_module))
     vector.client = MagicMock()
-    monkeypatch.setattr(matrixone_module.uuid, "uuid4", lambda: "generated-uuid")
+    generated_ids = iter(["generated-id-b", "generated-id-c"])
+    monkeypatch.setattr(matrixone_module.uuid, "uuid4", lambda: next(generated_ids))
     docs = [
         Document(page_content="a", metadata={"doc_id": "doc-a", "document_id": "d-1"}),
         Document(page_content="b", metadata={"document_id": "d-2"}),
@@ -177,18 +178,15 @@ def test_add_texts_generates_ids_and_inserts(matrixone_module, monkeypatch: pyte
 
     ids = vector.add_texts(docs, [[0.1], [0.2], [0.3]])
 
-    # For current prod code, only docs with metadata get ids, so only two ids
-    assert ids == ["doc-a", "generated-uuid"]
+    assert ids == ["doc-a", "generated-id-b", "generated-id-c"]
     vector.client.insert.assert_called_once()
     insert_kwargs = vector.client.insert.call_args.kwargs
-    # All lists passed to insert should be the same length
     texts = insert_kwargs["texts"]
     embeddings = insert_kwargs["embeddings"]
     metadatas = insert_kwargs["metadatas"]
     ids_insert = insert_kwargs["ids"]
-    assert len(texts) == len(embeddings) == len(metadatas) == len(docs)
-    # ids may be shorter than docs for current prod code, but should match number of docs with metadata
-    assert ids_insert == ["doc-a", "generated-uuid"]
+    assert len(ids_insert) == len(texts) == len(embeddings) == len(metadatas) == len(docs)
+    assert ids_insert == ids
 
 
 def test_delete_and_metadata_methods(matrixone_module):


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #39732

- Generate one ID for every document passed to MatrixOne, including documents with missing metadata.
- Preserve existing `doc_id` values and generate a UUID when `doc_id` or metadata is missing.
- Keep IDs aligned with texts, embeddings, and metadata during insertion.
- Extend unit test coverage for documents with explicit IDs, missing IDs, and missing metadata.

## Screenshots

Not applicable.

## Testing

- Added focused regression coverage for MatrixOne document ID generation.
- `python3 -m py_compile` for the changed Python files.
- `git diff --check`.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods