### PR TITLE
fix(webapp): break infinite 404 loop on stale conversation IDs

### DIFF
--- a/web/app/components/base/chat/chat-with-history/hooks.tsx
+++ b/web/app/components/base/chat/chat-with-history/hooks.tsx
@@ -239,7 +239,11 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
         refetchOnReconnect: false,
       },
     )
-  const { data: appChatListData, isLoading: appChatListDataLoading } = useShareChatList(
+  const {
+    data: appChatListData,
+    isLoading: appChatListDataLoading,
+    error: appChatListError,
+  } = useShareChatList(
     {
       conversationId: chatShouldReloadKey,
       appSourceType,
@@ -251,6 +255,13 @@ export const useChatWithHistory = (installedAppInfo?: InstalledApp) => {
       refetchOnReconnect: false,
     },
   )
+  // If the stored conversation no longer exists on the backend, drop it from
+  // localStorage so the user starts fresh instead of seeing an error loop.
+  useEffect(() => {
+    if (appChatListError && (appChatListError as unknown as Response)?.status === 404 && appId) {
+      handleConversationIdInfoChange('')
+    }
+  }, [appChatListError, appId, handleConversationIdInfoChange])
   const invalidateShareConversations = useInvalidateShareConversations()
   const [clearChatList, setClearChatList] = useState(false)
   const [isResponding, setIsResponding] = useState(false)

--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -168,11 +168,22 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
       pinned: false,
       limit: 100,
     })
-  const { data: appChatListData, isLoading: appChatListDataLoading } = useShareChatList({
+  const {
+    data: appChatListData,
+    isLoading: appChatListDataLoading,
+    error: appChatListError,
+  } = useShareChatList({
     conversationId: chatShouldReloadKey,
     appSourceType,
     appId,
   })
+  // If the stored conversation no longer exists on the backend, drop it from
+  // localStorage so the user starts fresh instead of seeing an error loop.
+  useEffect(() => {
+    if (appChatListError && (appChatListError as unknown as Response)?.status === 404 && appId) {
+      handleConversationIdInfoChange('')
+    }
+  }, [appChatListError, appId, handleConversationIdInfoChange])
   const invalidateShareConversations = useInvalidateShareConversations()
   const [clearChatList, setClearChatList] = useState(false)
   const [isResponding, setIsResponding] = useState(false)

--- a/web/service/share.ts
+++ b/web/service/share.ts
@@ -222,6 +222,9 @@ export const fetchChatList = async (
 ) => {
   return getAction('get', appSourceType)(getUrl('messages', appSourceType, installedAppId), {
     params: { conversation_id: conversationId, limit: 20, last_id: '' },
+    // Silence the toast on every retry — the caller decides what to do
+    // with a 404 via the query error state.
+    silent: true,
   }) as any
 }
 

--- a/web/service/use-share.ts
+++ b/web/service/use-share.ts
@@ -132,6 +132,13 @@ export const useShareChatList = (params: ShareChatListParams, options: ShareQuer
     enabled: isEnabled,
     refetchOnReconnect,
     refetchOnWindowFocus,
+    // Stop retrying when the conversation no longer exists (stale id in
+    // localStorage); otherwise TanStack Query loops forever on the 404.
+    retry: (failureCount, error) => {
+      const status = (error as unknown as Response)?.status
+      if (status === 404) return false
+      return failureCount < 3
+    },
     // Always consider chat list data stale to ensure fresh data when switching
     // back to a conversation. This fixes issue where recent messages don't appear
     // until switching away and back again (GitHub issue #30378).


### PR DESCRIPTION
When a shared web app stores a conversation_id in localStorage that the backend later deletes (admin console, expiry, etc.), the frontend kept retrying GET /api/messages in an infinite 404 loop. TanStack Query's default retry policy treats every error as transient, so the stale id was retried forever — every couple of seconds plus on every window focus — with no way for the user to recover short of clearing browser storage. The "Reset conversation" button didn't help because it never touched the stored conversationIdInfo.

This fixes it in three small spots. fetchChatList now passes silent: true so the error toast doesn't fire on each retry while the loop is running. useShareChatList gets a retry predicate that stops immediately on HTTP 404, since a missing conversation is permanent, not transient. Both the embedded-chatbot and chat-with-history hooks watch the query error state and clear the stale conversationIdInfo entry on 404, so the UI falls back to starting a fresh conversation automatically.

The previous attempt at this (#34945) went stale with merge conflicts and never landed; the three fix points it targeted are all still absent on main. Closes #39484.