### PR TITLE
fix(web): force render dialog backdrop and use dialog description in education verify modal

### DIFF
--- a/web/app/education-apply/verify-state-modal.tsx
+++ b/web/app/education-apply/verify-state-modal.tsx
@@ -51,7 +51,7 @@ function Confirm({
         <div className="shadows-shadow-lg flex max-w-full flex-col items-start rounded-2xl border-[0.5px] border-solid border-components-panel-border bg-components-panel-bg">
           <div className="flex flex-col items-start gap-2 self-stretch px-6 pt-6 pb-4">
             <DialogTitle className="title-2xl-semi-bold text-text-primary">{title}</DialogTitle>
-            {content && (
+            {content != null && (
               <DialogDescription className="w-full system-md-regular text-text-tertiary">
                 {content}
               </DialogDescription>

--- a/web/app/education-apply/verify-state-modal.tsx
+++ b/web/app/education-apply/verify-state-modal.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@langgenius/dify-ui/button'
-import { Dialog, DialogContent, DialogTitle } from '@langgenius/dify-ui/dialog'
-import { RiExternalLinkLine } from '@remixicon/react'
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@langgenius/dify-ui/dialog'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDocLink } from '@/context/i18n'
@@ -45,11 +44,18 @@ function Confirm({
       }}
       disablePointerDismissal={!maskClosable}
     >
-      <DialogContent className="w-full max-w-[481px]! overflow-hidden! border-none bg-transparent p-0! shadow-none">
+      <DialogContent
+        backdropProps={{ forceRender: true }}
+        className="w-full max-w-120.25 overflow-hidden border-none bg-transparent p-0 shadow-none"
+      >
         <div className="shadows-shadow-lg flex max-w-full flex-col items-start rounded-2xl border-[0.5px] border-solid border-components-panel-border bg-components-panel-bg">
           <div className="flex flex-col items-start gap-2 self-stretch px-6 pt-6 pb-4">
             <DialogTitle className="title-2xl-semi-bold text-text-primary">{title}</DialogTitle>
-            <div className="w-full system-md-regular text-text-tertiary">{content}</div>
+            {content && (
+              <DialogDescription className="w-full system-md-regular text-text-tertiary">
+                {content}
+              </DialogDescription>
+            )}
           </div>
           {email && (
             <div className="w-full space-y-1 px-6 py-3">
@@ -70,11 +76,11 @@ function Confirm({
                     href={eduDocLink}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="cursor-pointer system-xs-regular text-text-accent"
+                    className="inline-flex cursor-pointer items-center gap-1 system-xs-regular text-text-accent outline-hidden focus-visible:ring-2 focus-visible:ring-state-accent-solid"
                   >
                     {t(($) => $.learn, { ns: 'education' })}
+                    <span className="i-ri-external-link-line size-3 text-text-accent"></span>
                   </a>
-                  <RiExternalLinkLine className="size-3 text-text-accent" />
                 </>
               )}
             </div>


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- If this PR was created by an automated agent, add `From <Tool Name>` as the final line of the description. Example: `From Codex`. -->

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
