### PR TITLE
fix(security): block direct owner role assignment via update-role endpoint

### DIFF
--- a/api/controllers/console/workspace/members.py
+++ b/api/controllers/console/workspace/members.py
@@ -402,6 +402,15 @@ class MemberUpdateRoleApi(Resource):
 
         if not TenantAccountRole.is_valid_role(new_role):
             return {"code": "invalid-role", "message": "Invalid role"}, HTTPStatus.BAD_REQUEST
+        # Ownership transfer must go through the dedicated email-verified workflow
+        # (send-email → verify-code → /owner-transfer). Allowing direct assignment
+        # here bypasses CSRF protection and, in RBAC mode, lets any user with
+        # workspace.role.manage escalate themselves or a peer to owner.
+        if new_role == TenantAccountRole.OWNER:
+            return {
+                "code": "invalid-role",
+                "message": "Cannot directly assign owner role. Use the owner transfer workflow.",
+            }, HTTPStatus.BAD_REQUEST
         if not current_user.current_tenant:
             raise ValueError("No current tenant")
         if not _is_role_enabled(new_role, current_user.current_tenant.id):

--- a/api/tests/unit_tests/controllers/console/workspace/test_members.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_members.py
@@ -1,7 +1,7 @@
 from contextlib import nullcontext
 from inspect import unwrap
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from flask import Flask
@@ -542,6 +542,34 @@ class TestMemberUpdateRoleApi:
             result, status = method(api, MagicMock(), "id")
 
         assert status == 400
+
+    def test_update_owner_role_returns_bad_request(self, app: Flask):
+        """Security regression: PUT update-role with role='owner' must be rejected.
+
+        Direct owner assignment via this endpoint bypasses the mandatory
+        email-verification ownership-transfer workflow and, in RBAC mode,
+        allows any user with workspace.role.manage to escalate themselves
+        or a peer to owner without being the current workspace owner.
+        TenantService.update_member_role must never be called.
+        """
+        api = MemberUpdateRoleApi()
+        method = unwrap(api.put)
+
+        update_mock = Mock()
+        payload = {"role": "owner"}
+
+        with (
+            app.test_request_context("/", json=payload),
+            patch(
+                "controllers.console.workspace.members.TenantService.update_member_role",
+                update_mock,
+            ),
+        ):
+            result, status = method(api, MagicMock(), "member-id")
+
+        assert status == 400
+        assert result["code"] == "invalid-role"
+        update_mock.assert_not_called()
 
 
 class TestDatasetOperatorMemberListApi:


### PR DESCRIPTION
## Summary

`PUT /console/api/workspaces/current/members/{member_id}/update-role` accepted `{"role": "owner"}` because `TenantAccountRole.is_valid_role("owner")` returns `True`. This created two privilege-escalation paths that bypass the mandatory email-verification ownership-transfer workflow.

Fixes: owner role assignment bypass in `MemberUpdateRoleApi`

---

## Vulnerability Analysis

### Attack Path 1 — Non-RBAC mode (MEDIUM)

A workspace **owner** could silently transfer ownership to any member in a single unauthenticated-session request by POSTing to the general `update-role` endpoint instead of the intended 3-step flow:

```
# Intended (requires email verification):
POST /members/send-owner-transfer-confirm-email  → receives code by email
POST /members/owner-transfer-check               → verifies code, gets token
POST /members/{id}/owner-transfer                → transfers with token

# Bypass (no verification):
PUT /members/{id}/update-role   {"role": "owner"}   → immediate transfer ✅
```

This bypasses CSRF protection and the accidental-transfer safeguard built into the email-verification flow.

### Attack Path 2 — RBAC mode (HIGH)

In RBAC mode, `check_member_permission()` for the `"update"` action only checks that the caller holds the `workspace.role.manage` permission key. It does **not** require the caller to be the current workspace owner. Combined with `update_member_role()`'s ADMIN-only guard (which does not fire for non-ADMIN DB roles in RBAC mode), any user with `workspace.role.manage` can:

```bash
curl -X PUT /console/api/workspaces/current/members/{victim_id}/update-role \
  -H "Authorization: Bearer <attacker_token>" \
  -d '{"role": "owner"}'
# → HTTP 200, attacker is now owner
```

This is a full privilege escalation: a delegated role-manager who is not the workspace owner can steal workspace ownership.

---

## Root Cause

`api/controllers/console/workspace/members.py` — `MemberUpdateRoleApi.put()`:

```python
# Before fix — "owner" passes is_valid_role() and flows into update_member_role()
if not TenantAccountRole.is_valid_role(new_role):          # True for "owner"
    return {"code": "invalid-role", ...}, 400
# ... no owner-role guard ...
TenantService.update_member_role(tenant, member, new_role, ...)  # executes!
```

Note: the **openapi** controller (`controllers/openapi/_models.py`) already has this correct — its `MemberRoleUpdatePayload` uses a Pydantic `Literal` that excludes `"owner"`. The **console** controller's `MemberRoleUpdatePayload` uses plain `role: str` and lacked this guard.

---

## Fix

One targeted guard added in `MemberUpdateRoleApi.put()`, immediately after the `is_valid_role` check:

```python
# Ownership transfer must go through the dedicated email-verified workflow.
if new_role == TenantAccountRole.OWNER:
    return {
        "code": "invalid-role",
        "message": "Cannot directly assign owner role. Use the owner transfer workflow.",
    }, HTTPStatus.BAD_REQUEST
```

The legitimate `OwnerTransfer` endpoint (which already requires `@is_allow_transfer_owner`, ownership verification, and a time-limited email token) continues to call `update_member_role(..., "owner", ...)` unchanged — that path is unaffected.

---

## Changed Files

| File | Change |
|---|---|
| `api/controllers/console/workspace/members.py` | Added owner-role guard in `MemberUpdateRoleApi.put()` |
| `api/tests/unit_tests/controllers/console/workspace/test_members.py` | Added `test_update_owner_role_returns_bad_request` regression test |

---

## Regression Test

`TestMemberUpdateRoleApi.test_update_owner_role_returns_bad_request`:

- Calls `MemberUpdateRoleApi.put()` with `{"role": "owner"}`
- Asserts HTTP 400 with `code == "invalid-role"`  
- Asserts `TenantService.update_member_role` is **never called** (no ownership change occurs)

The test uses the same `unwrap()` + `patch()` pattern as all other unit tests in this file, requires no DB or network, and runs in the existing unit-test suite.

---

## Adversarial Review

**Can the bypass be reproduced after this fix?**

- `PUT /update-role {"role": "owner"}` → 400 `invalid-role` ✅ blocked
- `PUT /update-role {"role": "OWNER"}` → `is_valid_role("OWNER")` returns `False` (enum is lowercase) → 400 `invalid-role` ✅ blocked  
- Using the `/owner-transfer` endpoint → still requires email token + `@is_allow_transfer_owner` ✅ unaffected

**Are there similar patterns elsewhere?**  
The openapi controller (`controllers/openapi/_models.py`) already rejects `"owner"` at the Pydantic layer. No other role-update endpoint accepts free-form role strings without an owner check.
