### PR TITLE
fix(web): show API errors when agent publishing fails

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/__tests__/use-agent-configure-sync.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/__tests__/use-agent-configure-sync.spec.tsx
@@ -975,11 +975,45 @@ describe('useAgentConfigureSync', () => {
       })
     })
 
-    await expect(result.current.publishDraft()).rejects.toThrow(
-      'Failed to save agent composer draft.',
-    )
+    await expect(result.current.publishDraft()).rejects.toThrow('save failed')
 
     expect(publishAgentMutationFn).not.toHaveBeenCalled()
+    expect(toastMock.error).toHaveBeenCalledWith('save failed')
+  })
+
+  it('should show the API error message when publishing fails', async () => {
+    const responseError = new Response(
+      JSON.stringify({
+        code: 'invalid_model_credentials',
+        message: 'Model credential validation failed',
+        status: 400,
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        status: 400,
+        statusText: 'Bad Request',
+      },
+    )
+    publishAgentMutationFn.mockRejectedValueOnce(responseError)
+    const { result } = renderUseAgentConfigureSync({
+      currentModel: configuredModel,
+    })
+
+    await expect(result.current.publishDraft()).rejects.toBe(responseError)
+
+    expect(toastMock.error).toHaveBeenCalledWith('Model credential validation failed')
+  })
+
+  it('should show the default error when publish rejection has no message', async () => {
+    publishAgentMutationFn.mockRejectedValueOnce({ code: 'publish_failed' })
+    const { result } = renderUseAgentConfigureSync({
+      currentModel: configuredModel,
+    })
+
+    await expect(result.current.publishDraft()).rejects.toEqual({ code: 'publish_failed' })
+
     expect(toastMock.error).toHaveBeenCalledWith('common.api.actionFailed')
   })
 
@@ -1249,6 +1283,7 @@ describe('useAgentConfigureSync', () => {
 
     expect(result.current.isPublishing).toBe(false)
     expect(toastMock.error).toHaveBeenCalledTimes(1)
+    expect(toastMock.error).toHaveBeenCalledWith('publish failed')
     expect(composerPutMutationFn).toHaveBeenCalledTimes(2)
     expect(composerPutMutationFn).toHaveBeenLastCalledWith(
       expect.objectContaining({

--- a/web/features/agent-v2/agent-detail/configure/use-agent-configure-sync.ts
+++ b/web/features/agent-v2/agent-detail/configure/use-agent-configure-sync.ts
@@ -135,9 +135,10 @@ export function useAgentConfigureSync({
             agent_soul: configSnapshot,
           },
         })
-      } catch {
+      } catch (error) {
         // Autosave is silent and keeps the local draft intact; explicit commands must stop at this boundary.
         if (!silent) {
+          if (publish) throw error
           throw new Error('Failed to save agent composer draft.')
         }
 
@@ -378,7 +379,20 @@ export function useAgentConfigureSync({
       })
       toast.success(tCommon(($) => $['api.actionSuccess']))
     } catch (error) {
-      toast.error(tCommon(($) => $['api.actionFailed']))
+      let errorData: unknown = error
+      if (error instanceof Response) {
+        try {
+          errorData = await error.clone().json()
+        } catch {}
+      }
+      toast.error(
+        errorData &&
+          typeof errorData === 'object' &&
+          'message' in errorData &&
+          typeof errorData.message === 'string'
+          ? errorData.message
+          : tCommon(($) => $['api.actionFailed']),
+      )
       throw error
     } finally {
       publishInFlightRef.current = false


### PR DESCRIPTION
## Summary

- surface the backend error message when Agent V2 publishing fails
- preserve publish-time draft-save errors so the publish handler can display them
- fall back to the existing generic action-failed message when the response has no string `message`
- add regression coverage for failed draft saves, HTTP error responses, fallback errors, and failed-publish autosave recovery

Fix DIFY-2849.
## Root cause

The generated request path rejects failed publish requests with a `Response`, while the publish handler only displayed a fixed generic error. The response body was never parsed, so its backend-provided `message` could not reach the toast.

## Impact

Users now see the actionable backend error returned by the Agent publish API instead of only “Action failed.”

## Validation

- `pnpm exec vp test run features/agent-v2/agent-detail/configure/__tests__/use-agent-configure-sync.spec.tsx` (32 tests passed)
- scoped Vite+ format, lint, and type checks for the two changed files
- `git diff --check`

