### PR TITLE
fix(mcp): include file-list variables in tools/list inputSchema

### DIFF
--- a/api/core/mcp/server/streamable_http.py
+++ b/api/core/mcp/server/streamable_http.py
@@ -316,6 +316,20 @@ def process_streaming_response(response: RateLimitGenerator) -> str:
     return answer
 
 
+def _file_object_parameter_schema() -> dict[str, Any]:
+    """Single-file value shape for MCP tool inputSchema."""
+    return {
+        "type": "object",
+        "properties": {
+            "type": {"type": "string"},
+            "transfer_method": {"type": "string"},
+            "url": {"type": "string"},
+            "upload_file_id": {"type": "string"},
+        },
+        "additionalProperties": True,
+    }
+
+
 def process_mapping_response(app: App, response: Mapping) -> str:
     """Process mapping response based on app mode"""
     match app.mode:
@@ -336,11 +350,7 @@ def convert_input_form_to_parameters(
     required = []
 
     for item in user_input_form:
-        if item.type in (
-            VariableEntityType.FILE,
-            VariableEntityType.FILE_LIST,
-            VariableEntityType.EXTERNAL_DATA_TOOL,
-        ):
+        if item.type == VariableEntityType.EXTERNAL_DATA_TOOL:
             continue
         parameters[item.variable] = {}
         if item.required:
@@ -358,6 +368,15 @@ def convert_input_form_to_parameters(
             parameters[item.variable]["type"] = "number"
         elif item.type == VariableEntityType.CHECKBOX:
             parameters[item.variable]["type"] = "boolean"
+        elif item.type == VariableEntityType.FILE:
+            parameters[item.variable] = _file_object_parameter_schema()
+            parameters[item.variable]["description"] = description
+        elif item.type == VariableEntityType.FILE_LIST:
+            parameters[item.variable] = {
+                "type": "array",
+                "items": _file_object_parameter_schema(),
+                "description": description,
+            }
         elif item.type == VariableEntityType.JSON_OBJECT:
             parameters[item.variable]["type"] = "object"
             if item.json_schema:

--- a/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
+++ b/api/tests/unit_tests/core/mcp/server/test_streamable_http.py
@@ -638,6 +638,13 @@ class TestUtilityFunctions:
                 required=False,
             ),
             VariableEntity(
+                type=VariableEntityType.FILE_LIST,
+                variable="attachments",
+                description="File list upload",
+                label="Attachments",
+                required=True,
+            ),
+            VariableEntity(
                 type=VariableEntityType.CHECKBOX,
                 variable="enabled",
                 description="Enable flag",
@@ -672,6 +679,8 @@ class TestUtilityFunctions:
             "name": "Enter your name",
             "category": "Select category",
             "count": "Enter count",
+            "upload": "Upload a file",
+            "attachments": "Upload files",
             "enabled": "Enable flag",
             "config": "Config object",
             "schema_config": "Config with schema",
@@ -691,8 +700,17 @@ class TestUtilityFunctions:
         assert "count" in parameters
         assert parameters["count"]["type"] == "number"
 
-        # FILE type is skipped entirely via `continue` — key should not exist
-        assert "upload" not in parameters
+        # FILE maps to an object with upload metadata fields
+        assert parameters["upload"]["type"] == "object"
+        assert parameters["upload"]["description"] == "Upload a file"
+        assert parameters["upload"]["additionalProperties"] is True
+        assert "upload_file_id" in parameters["upload"]["properties"]
+
+        # FILE_LIST maps to an array of file objects
+        assert parameters["attachments"]["type"] == "array"
+        assert parameters["attachments"]["description"] == "Upload files"
+        assert parameters["attachments"]["items"]["type"] == "object"
+        assert "upload_file_id" in parameters["attachments"]["items"]["properties"]
 
         # CHECKBOX maps to boolean
         assert parameters["enabled"]["type"] == "boolean"
@@ -714,7 +732,74 @@ class TestUtilityFunctions:
         assert "name" in required
         assert "count" in required
         assert "config" in required
+        assert "attachments" in required
         assert "category" not in required
+        assert "upload" not in required
+
+    def test_handle_list_tools_includes_file_list_input_for_workflow(self):
+        """Regression for #39727: file-list workflow inputs appear in tools/list inputSchema."""
+        user_input_form = [
+            VariableEntity(
+                type=VariableEntityType.FILE_LIST,
+                variable="documents",
+                description="Documents to process",
+                label="Documents",
+                required=True,
+            ),
+        ]
+        parameters_dict = {"documents": "Upload one or more documents"}
+
+        result = handle_list_tools(
+            "extract_docs",
+            AppMode.WORKFLOW,
+            user_input_form,
+            "Extract document content",
+            parameters_dict,
+        )
+
+        input_schema = result.tools[0].inputSchema
+        assert input_schema["properties"]["documents"] == {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "type": {"type": "string"},
+                    "transfer_method": {"type": "string"},
+                    "url": {"type": "string"},
+                    "upload_file_id": {"type": "string"},
+                },
+                "additionalProperties": True,
+            },
+            "description": "Upload one or more documents",
+        }
+        assert input_schema["required"] == ["documents"]
+
+    def test_build_parameter_schema_workflow_mode_includes_file_list(self):
+        """Workflow MCP schema should expose file-list variables alongside other inputs."""
+        schema = build_parameter_schema(
+            AppMode.WORKFLOW,
+            [
+                VariableEntity(
+                    type=VariableEntityType.TEXT_INPUT,
+                    variable="prompt",
+                    description="Prompt",
+                    label="Prompt",
+                    required=False,
+                ),
+                VariableEntity(
+                    type=VariableEntityType.FILE_LIST,
+                    variable="documents",
+                    description="Documents",
+                    label="Documents",
+                    required=True,
+                ),
+            ],
+            {"documents": "Upload documents"},
+        )
+
+        assert schema["properties"]["documents"]["type"] == "array"
+        assert schema["properties"]["documents"]["items"]["type"] == "object"
+        assert schema["required"] == ["documents"]
 
     # Note: _get_request_id function has been removed as request_id is now passed as parameter
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Include `FILE` and `FILE_LIST` workflow input variables in MCP `tools/list` `inputSchema`
- Map `FILE` to a file object schema (`type`, `transfer_method`, `url`, `upload_file_id`)
- Map `FILE_LIST` to an array of those file objects
- Align the schema shape with the existing OpenAPI input schema in `controllers/openapi/_input_schema.py`
- Add regression coverage for workflow `tools/list` and `build_parameter_schema` with file-list inputs

Fixes #39727

## Root cause

`convert_input_form_to_parameters()` in `api/core/mcp/server/streamable_http.py` skipped `FILE` and `FILE_LIST` types entirely. When a workflow with a File List (`array[file]`) input was published as an MCP server, `tools/list` omitted that parameter from `inputSchema` even though other input variables appeared correctly.

## Impact

MCP clients can now discover file-list inputs when listing tools for workflow apps published as MCP servers, instead of receiving an incomplete schema that drops `array[file]` parameters.

## Screenshots

| Before | After |
|--------|-------|
| N/A — backend-only change | N/A — backend-only change |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran targeted backend unit tests for the changed MCP schema path.

## Validation

```bash
cd api && uv run pytest tests/unit_tests/core/mcp/server/test_streamable_http.py -q -o addopts=
```

- 54 passed (including new regression tests for workflow `tools/list` and `build_parameter_schema` with file-list inputs)
