### PR TITLE
fix(web): only open slash variable picker when / is typed (#39755)

### DIFF
--- a/web/app/components/base/prompt-editor/plugins/component-picker-block/__tests__/index.spec.tsx
+++ b/web/app/components/base/prompt-editor/plugins/component-picker-block/__tests__/index.spec.tsx
@@ -228,6 +228,7 @@ async function setEditorText(
   editor: LexicalEditor,
   text: string,
   selectEnd: boolean,
+  selectionOffset?: number,
 ): Promise<void> {
   await act(async () => {
     editor.update(() => {
@@ -237,9 +238,26 @@ async function setEditorText(
       const textNode = $createTextNode(text)
       paragraph.append(textNode)
       root.append(paragraph)
-      if (selectEnd) textNode.selectEnd()
+      if (typeof selectionOffset === 'number') textNode.select(selectionOffset, selectionOffset)
+      else if (selectEnd) textNode.selectEnd()
     })
   })
+}
+
+function markSlashTyped(editable: HTMLElement) {
+  editable.dispatchEvent(
+    new InputEvent('beforeinput', {
+      bubbles: true,
+      cancelable: true,
+      inputType: 'insertText',
+      data: '/',
+    }),
+  )
+}
+
+async function insertSlashTrigger(editor: LexicalEditor, editable: HTMLElement): Promise<void> {
+  markSlashTyped(editable)
+  await setEditorText(editor, '/', true)
 }
 
 function readEditorText(editor: LexicalEditor): string {
@@ -642,6 +660,44 @@ describe('ComponentPicker (component-picker-block/index.tsx)', () => {
     })
   })
 
+  it('opens the slash menu when the user types / but not when clicking after an existing slash', async () => {
+    const captures: Captures = { editor: null, eventEmitter: null }
+    const urlPrompt = 'Use https://dict.youdao.com/dictvoice?audio=word&type=0'
+
+    render(
+      <MinimalEditor
+        triggerString="/"
+        workflowVariableBlock={makeWorkflowVariableBlock({}, [
+          makeWorkflowVarNode('node-1', 'Node 1', [makeWorkflowNodeVar('output', VarType.string)]),
+        ])}
+        agentOutputBlock={{
+          show: true,
+          outputs: [],
+          onChange: vi.fn(),
+        }}
+        captures={captures}
+      />,
+    )
+
+    const editor = await waitForEditor(captures)
+    const editable = screen.getByTestId(CONTENT_EDITABLE_TEST_ID)
+
+    await insertSlashTrigger(editor, editable)
+    await flushNextTick()
+
+    expect(await screen.findByText('output')).toBeInTheDocument()
+
+    await setEditorText(editor, urlPrompt, false, urlPrompt.indexOf('://') + 2)
+    await flushNextTick()
+
+    fireEvent.pointerDown(editable)
+    fireEvent.click(editable)
+    await flushNextTick()
+
+    expect(screen.queryByText('output')).not.toBeInTheDocument()
+    expect(screen.queryByText('workflow.nodes.agent.outputVars.newOutput')).not.toBeInTheDocument()
+  })
+
   it('clears slash trigger state after creating an agent output from the footer action', async () => {
     const captures: Captures = { editor: null, eventEmitter: null }
 
@@ -662,8 +718,9 @@ describe('ComponentPicker (component-picker-block/index.tsx)', () => {
 
     const editor = await waitForEditor(captures)
     const dispatchSpy = vi.spyOn(editor, 'dispatchCommand')
+    const editable = screen.getByTestId(CONTENT_EDITABLE_TEST_ID)
 
-    await setEditorText(editor, '/', true)
+    await insertSlashTrigger(editor, editable)
     await flushNextTick()
 
     const newOutputAction = await screen.findByText('workflow.nodes.agent.outputVars.newOutput')
@@ -677,7 +734,6 @@ describe('ComponentPicker (component-picker-block/index.tsx)', () => {
       ).not.toBeInTheDocument()
     })
 
-    const editable = screen.getByTestId(CONTENT_EDITABLE_TEST_ID)
     fireEvent.focus(editable)
 
     await flushNextTick()
@@ -1028,7 +1084,8 @@ describe('ComponentPicker (component-picker-block/index.tsx)', () => {
       )
 
       const editor = await waitForEditor(captures)
-      await setEditorText(editor, '/', true)
+      const editable = screen.getByTestId(CONTENT_EDITABLE_TEST_ID)
+      await insertSlashTrigger(editor, editable)
       expect(await screen.findByText('payload')).toBeInTheDocument()
 
       vi.useFakeTimers()

--- a/web/app/components/base/prompt-editor/plugins/component-picker-block/index.tsx
+++ b/web/app/components/base/prompt-editor/plugins/component-picker-block/index.tsx
@@ -83,6 +83,7 @@ const ComponentPicker = ({
   })
   const [editor] = useLexicalComposerContext()
   const triggerMatchRef = useRef<MenuTextMatch | null>(null)
+  const slashTypedRef = useRef(false)
   const baseCheckForTriggerMatch = useBasicTypeaheadTriggerMatch(triggerString, {
     minLength: 0,
     maxLength: 75,
@@ -90,10 +91,22 @@ const ComponentPicker = ({
   const checkForTriggerMatch = useCallback(
     (text: string, editor: LexicalEditor) => {
       const match = baseCheckForTriggerMatch(text, editor)
+      if (
+        match &&
+        triggerString === '/' &&
+        match.matchingString.length === 0 &&
+        !slashTypedRef.current
+      ) {
+        triggerMatchRef.current = null
+        return null
+      }
+      if (match && triggerString === '/' && match.matchingString.length === 0)
+        slashTypedRef.current = false
+
       triggerMatchRef.current = match
       return match
     },
-    [baseCheckForTriggerMatch],
+    [baseCheckForTriggerMatch, triggerString],
   )
 
   const [queryString, setQueryString] = useState<string | null>(null)
@@ -139,7 +152,27 @@ const ComponentPicker = ({
       if (blurTimerRef.current) clearTimeout(blurTimerRef.current)
       unregister()
     }
-  }, [editor, clearBlurTimer])
+  }, [editor, clearBlurTimer, triggerString])
+
+  useEffect(() => {
+    const rootElement = editor.getRootElement()
+    if (!rootElement || triggerString !== '/') return
+
+    const handleBeforeInput = (event: InputEvent) => {
+      if (event.inputType === 'insertText' && event.data === '/') slashTypedRef.current = true
+    }
+
+    const handlePointerDown = () => {
+      slashTypedRef.current = false
+    }
+
+    rootElement.addEventListener('beforeinput', handleBeforeInput)
+    rootElement.addEventListener('pointerdown', handlePointerDown)
+    return () => {
+      rootElement.removeEventListener('beforeinput', handleBeforeInput)
+      rootElement.removeEventListener('pointerdown', handlePointerDown)
+    }
+  }, [editor, triggerString])
 
   eventEmitter?.useSubscription((v: EventEmitterValue) => {
     if (


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Open the workflow slash variable picker only when the user inserts `/` via text input
- Ignore caret placement on existing `/` characters in prompt content (for example URLs)
- Track slash intent with `beforeinput` and clear it on pointer clicks so re-clicking an old slash does not reopen the menu
- Add regression coverage for typed `/` vs clicking after an existing slash in URL text

Fixes #39755

## Root cause

`ComponentPickerBlock` used `useBasicTypeaheadTriggerMatch` with `minLength: 0` for the `/` trigger. That matches any caret position immediately after an existing slash, so clicking inside URL text like `https://...` reopened the variable picker even though the user did not type `/`.

## Impact

Workflow Agent prompt editing no longer opens the variable picker when users click inside existing prompt text that happens to contain `/`. Typing `/` still opens the picker as before, including when filtering with additional characters after the slash.

## Screenshots

| Before | After |
|--------|-------|
| N/A — interaction fix verified with unit tests | N/A — interaction fix verified with unit tests |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran targeted frontend unit tests for the changed prompt-editor picker path.

## Validation

```bash
cd web && pnpm exec vp test run app/components/base/prompt-editor/plugins/component-picker-block/__tests__/index.spec.tsx
```

- 20 passed (including regression test for typing `/` vs clicking after an existing slash)