### PR TITLE
fix(web): notify parent on MCP OAuth callback when opener is missing

### DIFF
--- a/web/app/oauth-callback/page.tsx
+++ b/web/app/oauth-callback/page.tsx
@@ -1,10 +1,32 @@
 'use client'
+import { useTranslation } from 'react-i18next'
 import { useOAuthCallback } from '@/hooks/use-oauth'
 
 const OAuthCallback = () => {
-  useOAuthCallback()
+  const { t } = useTranslation()
+  const { status, errorDescription } = useOAuthCallback()
 
-  return <div />
+  const isSuccess = status === 'success'
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background-body px-6">
+      <div className="flex max-w-md flex-col items-center gap-2 text-center">
+        <p
+          className={`system-lg-semibold ${isSuccess ? 'text-text-success' : 'text-text-destructive'}`}
+        >
+          {isSuccess
+            ? t(($) => $['modal.oauth.authorization.authSuccess'], { ns: 'pluginTrigger' })
+            : t(($) => $['modal.oauth.authorization.authFailed'], { ns: 'pluginTrigger' })}
+        </p>
+        {!isSuccess && errorDescription && (
+          <p className="system-sm-regular text-text-secondary">{errorDescription}</p>
+        )}
+        <p className="system-sm-regular text-text-tertiary">
+          {t(($) => $['modal.oauth.authorization.waitingJump'], { ns: 'pluginTrigger' })}
+        </p>
+      </div>
+    </div>
+  )
 }
 
 export default OAuthCallback

--- a/web/hooks/use-oauth.spec.ts
+++ b/web/hooks/use-oauth.spec.ts
@@ -1,0 +1,332 @@
+import { act, renderHook } from '@testing-library/react'
+import {
+  buildOAuthCallbackMessage,
+  notifyOAuthBroadcast,
+  notifyOAuthCallback,
+  notifyOAuthOpener,
+  OAUTH_CALLBACK_MESSAGE_TYPE,
+  openOAuthPopup,
+  parseOAuthCallbackParams,
+  useOAuthCallback,
+} from './use-oauth'
+
+describe('parseOAuthCallbackParams', () => {
+  it('returns success when subscription_id is present', () => {
+    expect(parseOAuthCallbackParams('?subscription_id=sub-123')).toEqual({
+      success: true,
+      subscriptionId: 'sub-123',
+      error: null,
+      errorDescription: null,
+    })
+  })
+
+  it('returns error when error query param is present', () => {
+    expect(
+      parseOAuthCallbackParams('?error=access_denied&error_description=User%20denied'),
+    ).toEqual({
+      success: false,
+      subscriptionId: null,
+      error: 'access_denied',
+      errorDescription: 'User denied',
+    })
+  })
+
+  it('returns success when no params are present', () => {
+    expect(parseOAuthCallbackParams('')).toEqual({
+      success: true,
+      subscriptionId: null,
+      error: null,
+      errorDescription: null,
+    })
+  })
+})
+
+describe('buildOAuthCallbackMessage', () => {
+  it('builds subscription success payload', () => {
+    expect(buildOAuthCallbackMessage('?subscription_id=sub-123')).toEqual({
+      type: OAUTH_CALLBACK_MESSAGE_TYPE,
+      success: true,
+      subscriptionId: 'sub-123',
+    })
+  })
+
+  it('builds error payload', () => {
+    expect(buildOAuthCallbackMessage('?error=access_denied&error_description=Denied')).toEqual({
+      type: OAUTH_CALLBACK_MESSAGE_TYPE,
+      success: false,
+      error: 'access_denied',
+      errorDescription: 'Denied',
+    })
+  })
+
+  it('builds default success payload', () => {
+    expect(buildOAuthCallbackMessage('')).toEqual({
+      type: OAUTH_CALLBACK_MESSAGE_TYPE,
+    })
+  })
+})
+
+describe('notifyOAuthOpener', () => {
+  const originalOpener = window.opener
+
+  afterEach(() => {
+    Object.defineProperty(window, 'opener', {
+      configurable: true,
+      value: originalOpener,
+    })
+  })
+
+  it('posts message to opener when available', () => {
+    const postMessage = vi.fn()
+    Object.defineProperty(window, 'opener', {
+      configurable: true,
+      value: { origin: 'https://console.example.com', postMessage },
+    })
+
+    const message = buildOAuthCallbackMessage('')
+    const notified = notifyOAuthOpener(message)
+
+    expect(notified).toBe(true)
+    expect(postMessage).toHaveBeenCalledWith(message, 'https://console.example.com')
+  })
+
+  it('returns false when opener is missing', () => {
+    Object.defineProperty(window, 'opener', {
+      configurable: true,
+      value: null,
+    })
+
+    expect(notifyOAuthOpener(buildOAuthCallbackMessage(''))).toBe(false)
+  })
+})
+
+describe('notifyOAuthBroadcast', () => {
+  it('posts message through BroadcastChannel', () => {
+    const postMessage = vi.fn()
+    const close = vi.fn()
+    class BroadcastChannelMock {
+      name: string
+
+      constructor(name: string) {
+        this.name = name
+      }
+
+      postMessage = postMessage
+      close = close
+    }
+    vi.stubGlobal('BroadcastChannel', BroadcastChannelMock)
+
+    const message = buildOAuthCallbackMessage('')
+    notifyOAuthBroadcast(message)
+
+    expect(postMessage).toHaveBeenCalledWith(message)
+    expect(close).toHaveBeenCalled()
+
+    vi.unstubAllGlobals()
+  })
+})
+
+describe('notifyOAuthCallback', () => {
+  const originalOpener = window.opener
+
+  afterEach(() => {
+    Object.defineProperty(window, 'opener', {
+      configurable: true,
+      value: originalOpener,
+    })
+    vi.unstubAllGlobals()
+  })
+
+  it('notifies opener and broadcast channel', () => {
+    const postMessage = vi.fn()
+    Object.defineProperty(window, 'opener', {
+      configurable: true,
+      value: { origin: 'https://console.example.com', postMessage },
+    })
+
+    const broadcastPostMessage = vi.fn()
+    const broadcastClose = vi.fn()
+    class BroadcastChannelMock {
+      name: string
+
+      constructor(name: string) {
+        this.name = name
+      }
+
+      postMessage = broadcastPostMessage
+      close = broadcastClose
+    }
+    vi.stubGlobal('BroadcastChannel', BroadcastChannelMock)
+
+    const message = buildOAuthCallbackMessage('?subscription_id=sub-123')
+    notifyOAuthCallback(message)
+
+    expect(postMessage).toHaveBeenCalledWith(message, 'https://console.example.com')
+    expect(broadcastPostMessage).toHaveBeenCalledWith(message)
+    expect(broadcastClose).toHaveBeenCalled()
+  })
+})
+
+describe('useOAuthCallback', () => {
+  const originalClose = window.close
+  const originalLocation = window.location
+
+  beforeEach(() => {
+    window.close = vi.fn()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { search: '' },
+    })
+    Object.defineProperty(window, 'opener', {
+      configurable: true,
+      value: null,
+    })
+    vi.stubGlobal(
+      'BroadcastChannel',
+      class {
+        postMessage = vi.fn()
+        close = vi.fn()
+      },
+    )
+  })
+
+  afterEach(() => {
+    window.close = originalClose
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    })
+    vi.unstubAllGlobals()
+  })
+
+  it('notifies parent, sets success status, and closes window', () => {
+    const { result } = renderHook(() => useOAuthCallback())
+
+    expect(result.current.status).toBe('success')
+    expect(result.current.errorDescription).toBeNull()
+    expect(window.close).toHaveBeenCalled()
+  })
+
+  it('sets error status when callback includes error params', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { search: '?error=access_denied&error_description=Denied' },
+    })
+
+    const { result } = renderHook(() => useOAuthCallback())
+
+    expect(result.current.status).toBe('error')
+    expect(result.current.errorDescription).toBe('Denied')
+    expect(window.close).toHaveBeenCalled()
+  })
+})
+
+describe('openOAuthPopup', () => {
+  const originalOpen = window.open
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    window.open = originalOpen
+    vi.unstubAllGlobals()
+  })
+
+  it('invokes callback from window message event', () => {
+    const callback = vi.fn()
+    const popup = { closed: false }
+    window.open = vi.fn(() => popup as Window)
+
+    openOAuthPopup('https://oauth.example.com/authorize', callback)
+
+    const message = buildOAuthCallbackMessage('')
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', { data: message }))
+    })
+
+    expect(callback).toHaveBeenCalledWith(message)
+  })
+
+  it('invokes callback from BroadcastChannel when opener is unavailable', () => {
+    const callback = vi.fn()
+    const popup = { closed: false }
+    window.open = vi.fn(() => popup as Window)
+
+    let channelHandler: ((event: MessageEvent) => void) | undefined
+    class BroadcastChannelMock {
+      private messageHandler?: (event: MessageEvent) => void
+
+      set onmessage(handler: (event: MessageEvent) => void) {
+        this.messageHandler = handler
+        channelHandler = handler
+      }
+
+      get onmessage() {
+        return this.messageHandler ?? (() => {})
+      }
+
+      close = vi.fn()
+    }
+    vi.stubGlobal('BroadcastChannel', BroadcastChannelMock)
+
+    openOAuthPopup('https://oauth.example.com/authorize', callback)
+
+    const message = buildOAuthCallbackMessage('')
+    act(() => {
+      channelHandler?.(new MessageEvent('message', { data: message }))
+    })
+
+    expect(callback).toHaveBeenCalledWith(message)
+  })
+
+  it('deduplicates callback when both message and broadcast fire', () => {
+    const callback = vi.fn()
+    const popup = { closed: false }
+    window.open = vi.fn(() => popup as Window)
+
+    let channelHandler: ((event: MessageEvent) => void) | undefined
+    class BroadcastChannelMock {
+      private messageHandler?: (event: MessageEvent) => void
+
+      set onmessage(handler: (event: MessageEvent) => void) {
+        this.messageHandler = handler
+        channelHandler = handler
+      }
+
+      get onmessage() {
+        return this.messageHandler ?? (() => {})
+      }
+
+      close = vi.fn()
+    }
+    vi.stubGlobal('BroadcastChannel', BroadcastChannelMock)
+
+    openOAuthPopup('https://oauth.example.com/authorize', callback)
+
+    const message = buildOAuthCallbackMessage('')
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', { data: message }))
+      channelHandler?.(new MessageEvent('message', { data: message }))
+    })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('invokes callback when popup is closed without message', () => {
+    const callback = vi.fn()
+    const popup = { closed: false }
+    window.open = vi.fn(() => popup as Window)
+
+    openOAuthPopup('https://oauth.example.com/authorize', callback)
+
+    popup.closed = true
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    expect(callback).toHaveBeenCalledWith(undefined)
+  })
+})

--- a/web/hooks/use-oauth.ts
+++ b/web/hooks/use-oauth.ts
@@ -1,51 +1,128 @@
 'use client'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { validateRedirectUrl } from '@/utils/urlValidation'
 
-export const useOAuthCallback = () => {
-  useEffect(() => {
-    const urlParams = new URLSearchParams(window.location.search)
-    const subscriptionId = urlParams.get('subscription_id')
-    const error = urlParams.get('error')
-    const errorDescription = urlParams.get('error_description')
+export const OAUTH_CALLBACK_MESSAGE_TYPE = 'oauth_callback'
+export const OAUTH_CALLBACK_CHANNEL_NAME = 'dify-oauth-callback'
 
-    if (window.opener) {
-      // Use window.opener.origin instead of '*' for security
-      const targetOrigin = window.opener?.origin || '*'
-
-      if (subscriptionId) {
-        window.opener.postMessage(
-          {
-            type: 'oauth_callback',
-            success: true,
-            subscriptionId,
-          },
-          targetOrigin,
-        )
-      } else if (error) {
-        window.opener.postMessage(
-          {
-            type: 'oauth_callback',
-            success: false,
-            error,
-            errorDescription,
-          },
-          targetOrigin,
-        )
-      } else {
-        window.opener.postMessage(
-          {
-            type: 'oauth_callback',
-          },
-          targetOrigin,
-        )
-      }
-      window.close()
-    }
-  }, [])
+export type OAuthCallbackData = {
+  type: typeof OAUTH_CALLBACK_MESSAGE_TYPE
+  success?: boolean
+  subscriptionId?: string | null
+  error?: string | null
+  errorDescription?: string | null
 }
 
-export const openOAuthPopup = (url: string, callback: (data?: any) => void) => {
+export type OAuthCallbackStatus = 'success' | 'error'
+
+type ParsedOAuthCallbackParams = {
+  success: boolean
+  subscriptionId: string | null
+  error: string | null
+  errorDescription: string | null
+}
+
+export const parseOAuthCallbackParams = (search: string): ParsedOAuthCallbackParams => {
+  const urlParams = new URLSearchParams(search)
+  const subscriptionId = urlParams.get('subscription_id')
+  const error = urlParams.get('error')
+  const errorDescription = urlParams.get('error_description')
+
+  if (subscriptionId) {
+    return {
+      success: true,
+      subscriptionId,
+      error: null,
+      errorDescription: null,
+    }
+  }
+
+  if (error) {
+    return {
+      success: false,
+      subscriptionId: null,
+      error,
+      errorDescription,
+    }
+  }
+
+  return {
+    success: true,
+    subscriptionId: null,
+    error: null,
+    errorDescription: null,
+  }
+}
+
+export const buildOAuthCallbackMessage = (search: string): OAuthCallbackData => {
+  const parsed = parseOAuthCallbackParams(search)
+
+  if (parsed.subscriptionId) {
+    return {
+      type: OAUTH_CALLBACK_MESSAGE_TYPE,
+      success: true,
+      subscriptionId: parsed.subscriptionId,
+    }
+  }
+
+  if (parsed.error) {
+    return {
+      type: OAUTH_CALLBACK_MESSAGE_TYPE,
+      success: false,
+      error: parsed.error,
+      errorDescription: parsed.errorDescription,
+    }
+  }
+
+  return {
+    type: OAUTH_CALLBACK_MESSAGE_TYPE,
+  }
+}
+
+export const notifyOAuthOpener = (message: OAuthCallbackData): boolean => {
+  if (!window.opener) return false
+
+  try {
+    const targetOrigin = window.opener.origin || '*'
+    window.opener.postMessage(message, targetOrigin)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export const notifyOAuthBroadcast = (message: OAuthCallbackData): void => {
+  if (typeof BroadcastChannel === 'undefined') return
+
+  const channel = new BroadcastChannel(OAUTH_CALLBACK_CHANNEL_NAME)
+  channel.postMessage(message)
+  channel.close()
+}
+
+export const notifyOAuthCallback = (message: OAuthCallbackData): void => {
+  notifyOAuthOpener(message)
+  notifyOAuthBroadcast(message)
+}
+
+export const useOAuthCallback = () => {
+  const [{ status, errorDescription }] = useState(() => {
+    const parsed = parseOAuthCallbackParams(window.location.search)
+
+    return {
+      status: (parsed.success ? 'success' : 'error') as OAuthCallbackStatus,
+      errorDescription: parsed.errorDescription,
+    }
+  })
+
+  useEffect(() => {
+    notifyOAuthCallback(buildOAuthCallbackMessage(window.location.search))
+    window.close()
+  }, [])
+
+  return { status, errorDescription }
+}
+
+export const openOAuthPopup = (url: string, callback: (data?: OAuthCallbackData) => void) => {
   const width = 600
   const height = 600
   const left = window.screenX + (window.outerWidth - width) / 2
@@ -58,22 +135,39 @@ export const openOAuthPopup = (url: string, callback: (data?: any) => void) => {
     `width=${width},height=${height},left=${left},top=${top},scrollbars=yes`,
   )
 
-  const handleMessage = (event: MessageEvent) => {
-    if (event.data?.type === 'oauth_callback') {
-      window.removeEventListener('message', handleMessage)
-      callback(event.data)
+  let completed = false
+  let checkClosed: ReturnType<typeof setInterval> | undefined
+  let channel: BroadcastChannel | null = null
+
+  function finish(data?: OAuthCallbackData) {
+    if (completed) return
+
+    completed = true
+    window.removeEventListener('message', handleMessage)
+    if (channel) {
+      channel.close()
+      channel = null
+    }
+    if (checkClosed) clearInterval(checkClosed)
+
+    callback(data)
+  }
+
+  function handleMessage(event: MessageEvent) {
+    if (event.data?.type === OAUTH_CALLBACK_MESSAGE_TYPE) finish(event.data)
+  }
+
+  if (typeof BroadcastChannel !== 'undefined') {
+    channel = new BroadcastChannel(OAUTH_CALLBACK_CHANNEL_NAME)
+    channel.onmessage = (event: MessageEvent<OAuthCallbackData>) => {
+      if (event.data?.type === OAUTH_CALLBACK_MESSAGE_TYPE) finish(event.data)
     }
   }
 
   window.addEventListener('message', handleMessage)
 
-  // Fallback for window close detection
-  const checkClosed = setInterval(() => {
-    if (popup?.closed) {
-      clearInterval(checkClosed)
-      window.removeEventListener('message', handleMessage)
-      callback()
-    }
+  checkClosed = setInterval(() => {
+    if (popup?.closed) finish()
   }, 1000)
 
   return popup


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #39752

After MCP OAuth authorization completes, the backend redirects to `/oauth-callback`. The callback page previously rendered an empty `<div />` and only notified the parent console window when `window.opener` was available. After cross-origin OAuth redirects (e.g. Notion MCP), browsers can drop the opener reference, leaving users on a blank page and preventing the console from refreshing authorization state.

This change:
- Adds a `BroadcastChannel` fallback so the parent window still receives the OAuth completion event when `window.opener` is missing
- Deduplicates popup callbacks when both `postMessage` and `BroadcastChannel` fire
- Shows success/error feedback on the callback page instead of a blank screen
- Adds unit tests covering param parsing, notification paths, and popup callback delivery

## Root cause

`useOAuthCallback` gated all parent notification and window closing behind `if (window.opener)`. When the opener reference is lost during the OAuth redirect chain, the hook did nothing and the page rendered an empty container.

## Impact

- MCP OAuth authorization (and other flows using `openOAuthPopup` / `/oauth-callback`) now reliably notify the console even when `window.opener` is unavailable
- Users see authorization success/failure feedback if the popup cannot auto-close
- No backend or API contract changes

## Screenshots

| Before | After |
|--------|-------|
| Blank page after OAuth callback | Success/error message with auto-close attempt |

N/A for automated VM validation — requires live OAuth provider redirect.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

## Validation

```bash
cd web && pnpm exec vp test run hooks/use-oauth.spec.ts
# 16 passed

cd web && pnpm exec vp test run app/components/tools/mcp/detail/__tests__/content.spec.tsx
# 44 passed (existing MCP auth tests still pass)
```