### PR TITLE
fix(collaboration): remove redis pubsub socket_timeout

### DIFF
--- a/api/extensions/ext_socketio.py
+++ b/api/extensions/ext_socketio.py
@@ -22,7 +22,6 @@ def _get_ssl_cert_reqs() -> ssl.VerifyMode:
 def _build_redis_options(redis_url: str) -> dict[str, Any]:
     """Build Redis options for Socket.IO's cross-process pub/sub manager."""
     options: dict[str, Any] = {
-        "socket_timeout": dify_config.REDIS_SOCKET_TIMEOUT,
         "socket_connect_timeout": dify_config.REDIS_SOCKET_CONNECT_TIMEOUT,
         "health_check_interval": dify_config.REDIS_HEALTH_CHECK_INTERVAL,
         "protocol": dify_config.REDIS_SERIALIZATION_PROTOCOL,

--- a/api/tests/unit_tests/extensions/test_ext_socketio.py
+++ b/api/tests/unit_tests/extensions/test_ext_socketio.py
@@ -19,6 +19,17 @@ def test_create_socketio_client_manager_uses_pubsub_url_and_prefixed_channel(mon
     assert manager.channel == "tenant-a:socketio"
 
 
+def test_build_redis_options_does_not_set_socket_timeout_for_pubsub_listener(monkeypatch) -> None:
+   
+    monkeypatch.setattr(ext_socketio.dify_config, "REDIS_SOCKET_TIMEOUT", 5.0)
+
+    options = ext_socketio._build_redis_options("redis://redis.example.com:6379/0")
+
+    assert "socket_timeout" not in options
+    assert "socket_connect_timeout" in options
+    assert "health_check_interval" in options
+
+
 def test_build_redis_options_includes_tls_options_for_rediss(monkeypatch) -> None:
     monkeypatch.setattr(ext_socketio.dify_config, "REDIS_SSL_CERT_REQS", "CERT_REQUIRED")
     monkeypatch.setattr(ext_socketio.dify_config, "REDIS_SSL_CA_CERTS", "/ca.pem")


### PR DESCRIPTION
## Summary

Fixes #39745.

`socket_timeout` was applied to the long-lived `pubsub.listen()` connection used by the Socket.IO Redis manager (the connection that streams collaboration/room events between server instances). A `socket_timeout` on this kind of blocking, long-lived listen connection causes Redis to periodically force-close it once the timeout elapses, even though the connection is healthy and simply idle between events. This produced repeated forced reconnects (`Cannot receive from redis... retrying in N secs` in the logs) and dropped collaboration events in flight during the reconnect window — leaving the workflow editor stuck on **"Syncing data"** indefinitely for collaborators.

This PR removes `socket_timeout` from that connection's options. `socket_connect_timeout` and `health_check_interval` remain in place and are sufficient to detect and recover genuinely dead connections — they just don't force-close a healthy idle listener the way `socket_timeout` does.

### Verification

Verified manually with a local Docker build (`--profile collaboration`): the Redis reconnect spam in the logs is gone, and the workflow editor loads and syncs normally for collaborators instead of hanging on "Syncing data".

### Files changed

- `api/extensions/ext_socketio.py` — removed `socket_timeout` from the pubsub connection's Redis client options

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods