### PR TITLE
fix(api): accumulate truncated flag in _truncate_array

### DIFF
--- a/api/services/variable_truncator.py
+++ b/api/services/variable_truncator.py
@@ -301,7 +301,7 @@ class VariableTruncator(BaseTruncator):
                 raise UnknownTypeError(f"got unknown type {type(item)} in array truncation")
             truncated_value.append(part_result.value)
             used_size += part_result.value_size
-            truncated = part_result.truncated
+            truncated = truncated or part_result.truncated
         return _PartResult(truncated_value, used_size, truncated)
 
     @classmethod

--- a/api/tests/unit_tests/services/test_variable_truncator.py
+++ b/api/tests/unit_tests/services/test_variable_truncator.py
@@ -238,6 +238,13 @@ class TestArrayTruncation:
         for item in result.value:
             assert isinstance(item, dict)
 
+    def test_array_truncation_flag_accumulation(self, small_truncator: VariableTruncator):
+        """Test that truncated flag stays True when an early element is truncated but a later element is not."""
+        mixed_array: list[object] = ["very long string " * 5, 42]
+        result = small_truncator._truncate_array(mixed_array, 50)
+
+        assert result.truncated is True
+
 
 class TestObjectTruncation:
     """Test object truncation functionality."""


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #39773

`_truncate_array` in `api/services/variable_truncator.py` uses a direct assignment (`truncated = part_result.truncated`) at line 304, which **overwrites** the truncation flag on every loop iteration. If an early array element is truncated but a later one fits within budget, the method incorrectly returns `truncated = False`.

The other two methods in the same file accumulate the flag correctly:
- `truncate_variable_mapping` (line 136): `is_truncated = is_truncated or part_result.truncated`
- `_truncate_object` (lines 383-384): `if value_result.truncated: truncated = True`

This PR applies the same accumulating pattern to `_truncate_array` and adds a targeted unit test.

### Changes
- **`api/services/variable_truncator.py`**: Changed `truncated = part_result.truncated` → `truncated = truncated or part_result.truncated`
- **`api/tests/unit_tests/services/test_variable_truncator.py`**: Added `test_array_truncation_flag_accumulation` to verify the flag stays `True` when an early element is truncated but a later one is not

## Screenshots

N/A — backend-only logic fix, no UI changes.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
