### PR TITLE
fix(webapp): abort workflow stream on human input pause

### DIFF
--- a/web/app/components/share/text-generation/result/__tests__/workflow-stream-handlers.spec.ts
+++ b/web/app/components/share/text-generation/result/__tests__/workflow-stream-handlers.spec.ts
@@ -382,7 +382,13 @@ describe('createWorkflowStreamHandlers', () => {
     vi.clearAllMocks()
   })
 
-  const setupHandlers = (overrides: { isPublicAPI?: boolean; isTimedOut?: () => boolean } = {}) => {
+  const setupHandlers = (
+    overrides: {
+      abortControllerRef?: { current: AbortController | null }
+      isPublicAPI?: boolean
+      isTimedOut?: () => boolean
+    } = {},
+  ) => {
     let completionRes = ''
     let currentTaskId: string | null = null
     let isStopping = false
@@ -415,6 +421,7 @@ describe('createWorkflowStreamHandlers', () => {
     const markEnded = vi.fn()
 
     const handlers = createWorkflowStreamHandlers({
+      abortControllerRef: overrides.abortControllerRef,
       getCompletionRes: () => completionRes,
       getWorkflowProcessData: () => workflowProcessData,
       isPublicAPI: overrides.isPublicAPI ?? false,
@@ -1021,5 +1028,89 @@ describe('createWorkflowStreamHandlers', () => {
     })
 
     expect(circularOutputSetup.setCompletionRes).toHaveBeenCalledWith('[object Object]')
+  })
+
+  it('should abort the active workflow stream before opening resume SSE on pause', () => {
+    const abortControllerRef = { current: null as AbortController | null }
+    const setup = setupHandlers({ isPublicAPI: true, abortControllerRef })
+    const handlers = setup.handlers as Required<
+      Pick<IOtherOptions, 'getAbortController' | 'onWorkflowPaused'>
+    >
+    const initialAbortController = new AbortController()
+    const abortSpy = vi.spyOn(initialAbortController, 'abort')
+
+    act(() => {
+      handlers.getAbortController(initialAbortController)
+      handlers.onWorkflowPaused({
+        task_id: 'task-1',
+        workflow_run_id: 'run-1',
+        event: 'workflow_paused',
+        data: {
+          outputs: {},
+          paused_nodes: [],
+          reasons: [],
+          workflow_run_id: 'run-1',
+        },
+      })
+    })
+
+    expect(abortSpy).toHaveBeenCalledTimes(1)
+    expect(abortControllerRef.current).toBeNull()
+    expect(sseGetMock).toHaveBeenCalledWith(
+      '/workflow/run-1/events',
+      {},
+      expect.objectContaining({ isPublicAPI: true }),
+    )
+  })
+
+  it('should ignore stale stopped events from the initial stream after pause', () => {
+    const setup = setupHandlers()
+    const handlers = setup.handlers as Required<
+      Pick<IOtherOptions, 'onWorkflowPaused' | 'onWorkflowFinished'>
+    >
+
+    act(() => {
+      handlers.onWorkflowPaused({
+        task_id: 'task-1',
+        workflow_run_id: 'run-1',
+        event: 'workflow_paused',
+        data: {
+          outputs: {},
+          paused_nodes: [],
+          reasons: [],
+          workflow_run_id: 'run-1',
+        },
+      })
+      handlers.onWorkflowFinished({
+        task_id: 'task-1',
+        workflow_run_id: 'run-1',
+        event: 'workflow_finished',
+        data: {
+          id: 'run-1',
+          workflow_id: 'wf-1',
+          status: WorkflowRunningStatus.Stopped,
+          outputs: null,
+          error: '',
+          elapsed_time: 0,
+          total_tokens: 0,
+          total_steps: 0,
+          created_at: 0,
+          created_by: {
+            id: 'user-1',
+            name: 'User',
+            email: 'user@example.com',
+          },
+          finished_at: 0,
+        },
+      })
+    })
+
+    expect(setup.workflowProcessData()).toEqual(
+      expect.objectContaining({
+        status: WorkflowRunningStatus.Paused,
+      }),
+    )
+    expect(setup.onCompleted).not.toHaveBeenCalled()
+    expect(setup.setRespondingFalse).not.toHaveBeenCalled()
   })
 })

--- a/web/app/components/share/text-generation/result/hooks/use-result-sender.ts
+++ b/web/app/components/share/text-generation/result/hooks/use-result-sender.ts
@@ -119,6 +119,7 @@ export const useResultSender = ({
 
     if (isWorkflow) {
       const otherOptions = createWorkflowStreamHandlers({
+        abortControllerRef: runState.abortControllerRef,
         getCompletionRes: runState.getCompletionRes,
         getWorkflowProcessData: runState.getWorkflowProcessData,
         isPublicAPI: appSourceType === AppSourceType.webApp,

--- a/web/app/components/share/text-generation/result/workflow-stream-handlers.ts
+++ b/web/app/components/share/text-generation/result/workflow-stream-handlers.ts
@@ -1,4 +1,4 @@
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react'
 import type { TextGenerationTranslate } from '../types'
 import type { WorkflowProcess } from '@/app/components/base/chat/types'
 import type { IOtherOptions } from '@/service/base'
@@ -15,6 +15,7 @@ import { sseGet } from '@/service/base'
 
 type Notify = (payload: { type: 'error' | 'warning'; message: string }) => void
 type CreateWorkflowStreamHandlersParams = {
+  abortControllerRef?: MutableRefObject<AbortController | null>
   getCompletionRes: () => string
   getWorkflowProcessData: () => WorkflowProcess | undefined
   isPublicAPI: boolean
@@ -262,6 +263,7 @@ const serializeWorkflowOutputs = (outputs: WorkflowFinishedResponse['data']['out
 }
 
 export const createWorkflowStreamHandlers = ({
+  abortControllerRef,
   getCompletionRes,
   getWorkflowProcessData,
   isPublicAPI,
@@ -280,6 +282,20 @@ export const createWorkflowStreamHandlers = ({
   taskId,
 }: CreateWorkflowStreamHandlersParams): IOtherOptions => {
   let tempMessageId = ''
+  let workflowEventsAbortController: AbortController | null = null
+  let isResumeStreamActive = false
+
+  const setActiveAbortController = (abortController: AbortController) => {
+    workflowEventsAbortController = abortController
+    if (abortControllerRef) abortControllerRef.current = abortController
+  }
+
+  const abortActiveWorkflowStream = () => {
+    const activeController = workflowEventsAbortController ?? abortControllerRef?.current ?? null
+    activeController?.abort()
+    workflowEventsAbortController = null
+    if (abortControllerRef) abortControllerRef.current = null
+  }
 
   const finishWithFailure = () => {
     setRespondingFalse()
@@ -298,6 +314,7 @@ export const createWorkflowStreamHandlers = ({
 
   const otherOptions: IOtherOptions = {
     isPublicAPI,
+    getAbortController: setActiveAbortController,
     onWorkflowStarted: ({ workflow_run_id, task_id }) => {
       const workflowProcessData = getWorkflowProcessData()
       if (workflowProcessData?.tracing.length) {
@@ -342,6 +359,13 @@ export const createWorkflowStreamHandlers = ({
     },
     onWorkflowFinished: ({ data }) => {
       const workflowStatus = data.status as WorkflowRunningStatus | undefined
+      if (
+        isResumeStreamActive &&
+        workflowStatus === WorkflowRunningStatus.Stopped &&
+        getWorkflowProcessData()?.status === WorkflowRunningStatus.Paused
+      )
+        return
+
       if (isTimedOut()) {
         const finishedStatus =
           workflowStatus === WorkflowRunningStatus.Stopped
@@ -420,6 +444,8 @@ export const createWorkflowStreamHandlers = ({
     },
     onWorkflowPaused: ({ data }) => {
       tempMessageId = data.workflow_run_id
+      isResumeStreamActive = true
+      abortActiveWorkflowStream()
       // WebApp workflows must keep using the public API namespace after pause/resume.
       void sseGet(`/workflow/${data.workflow_run_id}/events`, {}, otherOptions)
       setWorkflowProcessData(applyWorkflowPaused(getWorkflowProcessData()))


### PR DESCRIPTION
## Summary

Fixes #39686

When a WebApp workflow pauses for human input, the initial `sendWorkflowMessage` POST stream stayed open while a resume SSE (`/workflow/{id}/events`) was opened. Both streams could deliver conflicting events — the aborted POST stream often emitted `workflow_finished` with `Stopped` status, causing the UI to show "Stopped by user" even though the worker completed successfully.

This change:
- Tracks the active workflow stream via `getAbortController`
- Aborts the active stream before opening the resume SSE on `workflow_paused`
- Ignores stale `Stopped` events from the initial stream while the workflow is paused

## Screenshots

| Before | After |
|--------|-------|
| UI shows "Stopped by user" after human input resume | Workflow completes and UI shows success |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods