### PR TITLE
fix(api): harden summary index consistency

### DIFF
--- a/api/commands/vector.py
+++ b/api/commands/vector.py
@@ -1,9 +1,12 @@
 import json
+from collections.abc import Sequence
 from typing import cast
 
 import click
 from flask import current_app
-from sqlalchemy import select
+from flask.cli import with_appcontext
+from sqlalchemy import select, update
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -11,18 +14,28 @@ from configs import dify_config
 from core.rag.datasource.vdb.vector_factory import Vector
 from core.rag.datasource.vdb.vector_type import VectorType
 from core.rag.index_processor.constant.built_in_field import BuiltInField
+from core.rag.index_processor.constant.doc_type import DocType
 from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
-from core.rag.models.document import ChildDocument, Document
+from core.rag.models.document import Document
 from extensions.ext_database import db
 from libs.pagination import paginate_query
-from models.dataset import Dataset, DatasetCollectionBinding, DatasetMetadata, DatasetMetadataBinding, DocumentSegment
+from models.dataset import (
+    ChildChunk,
+    Dataset,
+    DatasetCollectionBinding,
+    DatasetMetadata,
+    DatasetMetadataBinding,
+    DocumentSegment,
+    DocumentSegmentSummary,
+)
 from models.dataset import Document as DatasetDocument
-from models.enums import DatasetMetadataType, IndexingStatus, SegmentStatus
+from models.enums import DatasetMetadataType, IndexingStatus, SegmentStatus, SummaryStatus
 from models.model import App, AppAnnotationSetting, MessageAnnotation
 
 
 @click.command("vdb-migrate", help="Migrate vector db.")
 @click.option("--scope", default="all", prompt=False, help="The scope of vector database to migrate, Default is All.")
+@with_appcontext
 def vdb_migrate(scope: str):
     if scope in {"knowledge", "all"}:
         migrate_knowledge_vector_database()
@@ -102,8 +115,7 @@ def migrate_annotation_vector_database():
                         )
                         documents.append(document)
 
-                with Session(db.engine) as session:
-                    vector = Vector(dataset, attributes=["doc_id", "annotation_id", "app_id"], session=session)
+                vector = Vector(dataset, attributes=["doc_id", "annotation_id", "app_id"])
                 click.echo(f"Migrating annotations for app: {app.id}.")
 
                 try:
@@ -141,9 +153,150 @@ def migrate_annotation_vector_database():
     )
 
 
+def _collect_dataset_vector_documents(
+    dataset: Dataset,
+    *,
+    session: Session,
+) -> tuple[list[Document], int]:
+    """Snapshot the canonical vector payload while the read transaction is open."""
+    dataset_documents = session.scalars(
+        select(DatasetDocument).where(
+            DatasetDocument.tenant_id == dataset.tenant_id,
+            DatasetDocument.dataset_id == dataset.id,
+            DatasetDocument.indexing_status == IndexingStatus.COMPLETED,
+            DatasetDocument.enabled == True,
+            DatasetDocument.archived == False,
+        )
+    ).all()
+
+    documents: list[Document] = []
+    segments_count = 0
+    for dataset_document in dataset_documents:
+        segments = session.scalars(
+            select(DocumentSegment).where(
+                DocumentSegment.tenant_id == dataset.tenant_id,
+                DocumentSegment.document_id == dataset_document.id,
+                DocumentSegment.dataset_id == dataset.id,
+                DocumentSegment.status == SegmentStatus.COMPLETED,
+                DocumentSegment.enabled == True,
+            )
+        ).all()
+        segment_ids = [segment.id for segment in segments]
+        summaries = (
+            session.scalars(
+                select(DocumentSegmentSummary)
+                .where(
+                    DocumentSegmentSummary.dataset_id == dataset.id,
+                    DocumentSegmentSummary.document_id == dataset_document.id,
+                    DocumentSegmentSummary.chunk_id.in_(segment_ids),
+                )
+                .order_by(
+                    DocumentSegmentSummary.chunk_id,
+                    DocumentSegmentSummary.updated_at.desc(),
+                    DocumentSegmentSummary.id.desc(),
+                )
+            ).all()
+            if segment_ids
+            else []
+        )
+        canonical_summaries: dict[str, DocumentSegmentSummary] = {}
+        for summary_record in summaries:
+            canonical_summaries.setdefault(summary_record.chunk_id, summary_record)
+
+        for segment in segments:
+            base_metadata = {
+                "doc_id": segment.index_node_id,
+                "doc_hash": segment.index_node_hash,
+                "document_id": segment.document_id,
+                "dataset_id": segment.dataset_id,
+                "doc_type": DocType.TEXT,
+                "is_summary": False,
+            }
+            if dataset_document.doc_form == IndexStructureType.PARENT_CHILD_INDEX:
+                child_chunks = session.scalars(
+                    select(ChildChunk)
+                    .where(
+                        ChildChunk.tenant_id == dataset.tenant_id,
+                        ChildChunk.dataset_id == dataset.id,
+                        ChildChunk.document_id == dataset_document.id,
+                        ChildChunk.segment_id == segment.id,
+                    )
+                    .order_by(ChildChunk.position)
+                ).all()
+                for child_chunk in child_chunks:
+                    documents.append(
+                        Document(
+                            page_content=child_chunk.content,
+                            metadata={
+                                "doc_id": child_chunk.index_node_id,
+                                "doc_hash": child_chunk.index_node_hash,
+                                "document_id": segment.document_id,
+                                "dataset_id": segment.dataset_id,
+                                "doc_type": DocType.TEXT,
+                                "is_summary": False,
+                            },
+                        )
+                    )
+            elif segment.index_node_id:
+                documents.append(Document(page_content=segment.content, metadata=base_metadata))
+
+            summary = canonical_summaries.get(segment.id)
+            if (
+                summary is not None
+                and summary.status == SummaryStatus.COMPLETED
+                and summary.enabled
+                and summary.summary_content
+                and summary.summary_index_node_id
+            ):
+                documents.append(
+                    Document(
+                        page_content=summary.summary_content,
+                        metadata={
+                            "doc_id": summary.summary_index_node_id,
+                            "doc_hash": summary.summary_index_node_hash,
+                            "document_id": segment.document_id,
+                            "dataset_id": segment.dataset_id,
+                            "original_chunk_id": segment.id,
+                            "doc_type": DocType.TEXT,
+                            "is_summary": True,
+                        },
+                    )
+                )
+            segments_count += 1
+
+    return documents, segments_count
+
+
+def _vector_documents_signature(documents: Sequence[Document]) -> tuple[tuple[str, ...], ...]:
+    """Return a stable signature for detecting relational changes during vector I/O."""
+    return tuple(
+        sorted(
+            (
+                type(document).__name__,
+                document.page_content,
+                str(document.metadata.get("doc_id") or ""),
+                str(document.metadata.get("doc_hash") or ""),
+                str(document.metadata.get("document_id") or ""),
+                str(document.metadata.get("dataset_id") or ""),
+                str(document.metadata.get("original_chunk_id") or ""),
+                str(document.metadata.get("doc_type") or ""),
+                str(bool(document.metadata.get("is_summary"))),
+            )
+            for document in documents
+        )
+    )
+
+
 def migrate_knowledge_vector_database():
-    """
-    Migrate vector database data to target vector database.
+    """Migrate each high-quality dataset to the configured vector provider.
+
+    Relational payloads are copied inside short read transactions; vector I/O
+    never owns a database connection. Before activation, the payload is read
+    again in the activation transaction and the dataset pointer is compare-and-swap
+    updated together with every setting that selected the target collection or
+    embedding space. This detects changes committed during provider I/O.
+    Cross-store atomicity is impossible here, so operators must quiesce dataset
+    writes to eliminate the final concurrent-write window.
     """
     click.echo(click.style("Starting vector database migration.", fg="green"))
     create_count = 0
@@ -178,7 +331,7 @@ def migrate_knowledge_vector_database():
         VectorType.OCEANBASE,
     }
     page = 1
-    db_session = db.session()
+    session_maker = sessionmaker(db.engine, expire_on_commit=False)
     while True:
         try:
             stmt = (
@@ -186,9 +339,10 @@ def migrate_knowledge_vector_database():
                 .where(Dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY)
                 .order_by(Dataset.created_at.desc())
             )
-
-            datasets = paginate_query(stmt, page=page, per_page=50, max_per_page=50, session=db_session)
-            if not datasets.items:
+            with session_maker() as read_session:
+                dataset_page = paginate_query(stmt, page=page, per_page=50, max_per_page=50, session=read_session)
+                datasets = list(dataset_page.items)
+            if not datasets:
                 break
         except SQLAlchemyError:
             raise
@@ -201,6 +355,12 @@ def migrate_knowledge_vector_database():
             )
             try:
                 click.echo(f"Creating dataset vector database index: {dataset.id}")
+                source_index_struct = dataset.index_struct
+                source_provider = dataset.provider
+                source_indexing_technique = dataset.indexing_technique
+                source_embedding_model = dataset.embedding_model
+                source_embedding_model_provider = dataset.embedding_model_provider
+                source_collection_binding_id = dataset.collection_binding_id
                 if dataset.index_struct_dict:
                     if dataset.index_struct_dict["type"] == vector_type:
                         skipped_count = skipped_count + 1
@@ -211,11 +371,12 @@ def migrate_knowledge_vector_database():
                     collection_name = Dataset.gen_collection_name_by_id(dataset_id)
                 elif vector_type == VectorType.QDRANT:
                     if dataset.collection_binding_id:
-                        dataset_collection_binding = db.session.execute(
-                            select(DatasetCollectionBinding).where(
-                                DatasetCollectionBinding.id == dataset.collection_binding_id
+                        with session_maker() as read_session:
+                            dataset_collection_binding = read_session.scalar(
+                                select(DatasetCollectionBinding).where(
+                                    DatasetCollectionBinding.id == dataset.collection_binding_id
+                                )
                             )
-                        ).scalar_one_or_none()
                         if dataset_collection_binding:
                             collection_name = dataset_collection_binding.collection_name
                         else:
@@ -230,8 +391,12 @@ def migrate_knowledge_vector_database():
 
                 index_struct_dict = {"type": vector_type, "vector_store": {"class_prefix": collection_name}}
                 dataset.index_struct = json.dumps(index_struct_dict)
-                with Session(db.engine) as session:
-                    vector = Vector(dataset, session=session)
+                with session_maker() as read_session:
+                    documents, segments_count = _collect_dataset_vector_documents(dataset, session=read_session)
+                source_signature = _vector_documents_signature(documents)
+
+                # All relational state is now copied to plain RAG documents and the read transaction is closed.
+                vector = Vector(dataset)
                 click.echo(f"Migrating dataset {dataset.id}.")
 
                 try:
@@ -247,56 +412,6 @@ def migrate_knowledge_vector_database():
                     )
                     raise e
 
-                dataset_documents = db.session.scalars(
-                    select(DatasetDocument).where(
-                        DatasetDocument.dataset_id == dataset.id,
-                        DatasetDocument.indexing_status == IndexingStatus.COMPLETED,
-                        DatasetDocument.enabled == True,
-                        DatasetDocument.archived == False,
-                    )
-                ).all()
-
-                documents = []
-                segments_count = 0
-                for dataset_document in dataset_documents:
-                    segments = db.session.scalars(
-                        select(DocumentSegment).where(
-                            DocumentSegment.document_id == dataset_document.id,
-                            DocumentSegment.status == SegmentStatus.COMPLETED,
-                            DocumentSegment.enabled == True,
-                        )
-                    ).all()
-
-                    for segment in segments:
-                        document = Document(
-                            page_content=segment.content,
-                            metadata={
-                                "doc_id": segment.index_node_id,
-                                "doc_hash": segment.index_node_hash,
-                                "document_id": segment.document_id,
-                                "dataset_id": segment.dataset_id,
-                            },
-                        )
-                        if dataset_document.doc_form == IndexStructureType.PARENT_CHILD_INDEX:
-                            child_chunks = segment.get_child_chunks(session=db_session)
-                            if child_chunks:
-                                child_documents = []
-                                for child_chunk in child_chunks:
-                                    child_document = ChildDocument(
-                                        page_content=child_chunk.content,
-                                        metadata={
-                                            "doc_id": child_chunk.index_node_id,
-                                            "doc_hash": child_chunk.index_node_hash,
-                                            "document_id": segment.document_id,
-                                            "dataset_id": segment.dataset_id,
-                                        },
-                                    )
-                                    child_documents.append(child_document)
-                                document.children = child_documents
-
-                        documents.append(document)
-                        segments_count = segments_count + 1
-
                 if documents:
                     try:
                         click.echo(
@@ -306,23 +421,68 @@ def migrate_knowledge_vector_database():
                                 fg="green",
                             )
                         )
-                        all_child_documents = []
-                        for doc in documents:
-                            if doc.children:
-                                all_child_documents.extend(doc.children)
                         vector.create(documents)
-                        if all_child_documents:
-                            vector.create(all_child_documents)
                         click.echo(click.style(f"Created vector index for dataset {dataset.id}.", fg="green"))
                     except Exception as e:
                         click.echo(click.style(f"Failed to created vector index for dataset {dataset.id}.", fg="red"))
                         raise e
-                db.session.add(dataset)
-                db.session.commit()
+                source_index_condition = (
+                    Dataset.index_struct.is_(None)
+                    if source_index_struct is None
+                    else Dataset.index_struct == source_index_struct
+                )
+                source_embedding_model_condition = (
+                    Dataset.embedding_model.is_(None)
+                    if source_embedding_model is None
+                    else Dataset.embedding_model == source_embedding_model
+                )
+                source_embedding_model_provider_condition = (
+                    Dataset.embedding_model_provider.is_(None)
+                    if source_embedding_model_provider is None
+                    else Dataset.embedding_model_provider == source_embedding_model_provider
+                )
+                source_collection_binding_condition = (
+                    Dataset.collection_binding_id.is_(None)
+                    if source_collection_binding_id is None
+                    else Dataset.collection_binding_id == source_collection_binding_id
+                )
+                with session_maker.begin() as write_session:
+                    current_documents, current_segments_count = _collect_dataset_vector_documents(
+                        dataset, session=write_session
+                    )
+                    if (
+                        current_segments_count != segments_count
+                        or _vector_documents_signature(current_documents) != source_signature
+                    ):
+                        raise RuntimeError(
+                            f"Dataset {dataset.id} changed while its vector index was being migrated; "
+                            "the database pointer was not updated"
+                        )
+                    update_result = cast(
+                        CursorResult,
+                        write_session.execute(
+                            update(Dataset)
+                            .where(
+                                Dataset.id == dataset.id,
+                                Dataset.tenant_id == dataset.tenant_id,
+                                source_index_condition,
+                                Dataset.provider == source_provider,
+                                Dataset.indexing_technique == source_indexing_technique,
+                                source_embedding_model_condition,
+                                source_embedding_model_provider_condition,
+                                source_collection_binding_condition,
+                            )
+                            .values(index_struct=dataset.index_struct)
+                        ),
+                    )
+                    if update_result.rowcount != 1:
+                        raise RuntimeError(
+                            f"Dataset {dataset.id} vector configuration changed concurrently; "
+                            "the migration result was not activated"
+                        )
                 click.echo(f"Successfully migrated dataset {dataset.id}.")
                 create_count += 1
             except Exception as e:
-                db.session.rollback()
                 click.echo(click.style(f"Error creating dataset index: {e.__class__.__name__} {str(e)}", fg="red"))
                 continue
 

--- a/api/controllers/console/datasets/datasets_segments.py
+++ b/api/controllers/console/datasets/datasets_segments.py
@@ -44,6 +44,7 @@ from controllers.console.wraps import (
 from core.errors.error import LLMBadRequestError, ProviderTokenNotInitError
 from core.model_manager import ModelManager
 from core.rag.index_processor.constant.index_type import IndexTechniqueType
+from extensions.ext_database import db
 from extensions.ext_redis import redis_client
 from fields.base import ResponseModel
 from fields.segment_fields import (
@@ -325,6 +326,8 @@ class DatasetDocumentSegmentListApi(Resource):
             DatasetService.check_dataset_permission(dataset, current_user, session)
         except services.errors.account.NoPermissionError as e:
             raise Forbidden(str(e))
+        # Release the materialized console auth session before the service commits and publishes cleanup.
+        db.session.remove()
         SegmentService.delete_segments(segment_ids, document, dataset, session)
         return "", 204
 
@@ -393,6 +396,8 @@ class DatasetDocumentSegmentApi(Resource):
         if cache_result is not None:
             raise InvalidActionError("Document is being indexed, please try again later")
         try:
+            # Release the materialized console auth session before the service commits and publishes indexing work.
+            db.session.remove()
             SegmentService.update_segments_status(segment_ids, action, dataset, document, session)
         except Exception as e:
             raise InvalidActionError(str(e))
@@ -537,6 +542,10 @@ class DatasetDocumentSegmentUpdateApi(Resource):
         SegmentService.segment_create_args_validate(payload_dict, document)
 
         # Update segment (summary update with change detection is handled in SegmentService.update_segment)
+        # Console authentication uses Flask-SQLAlchemy's scoped session, while this handler uses the explicitly
+        # injected session. The account and tenant are materialized by this point, so release the auth session
+        # before update paths can call embedding or vector providers.
+        db.session.remove()
         segment = SegmentService.update_segment(
             SegmentUpdateArgs.model_validate(payload.model_dump(exclude_none=True)),
             segment,
@@ -595,6 +604,8 @@ class DatasetDocumentSegmentUpdateApi(Resource):
             raise Forbidden(str(e))
         segment_id_str = str(segment_id)
         _, segment = _get_segment_for_document(session, dataset, document, segment_id_str)
+        # Release the materialized console auth session before the service commits and publishes cleanup.
+        db.session.remove()
         SegmentService.delete_segment(segment, document, dataset, session)
         return "", 204
 
@@ -743,6 +754,8 @@ class ChildChunkAddApi(Resource):
         # validate args
         try:
             payload = ChildChunkCreatePayload.model_validate(console_ns.payload or {})
+            # Release the materialized console auth session before embedding and vector-provider I/O.
+            db.session.remove()
             child_chunk = SegmentService.create_child_chunk(payload.content, segment, document, dataset, session)
         except ChildChunkIndexingServiceError as e:
             raise ChildChunkIndexingError(str(e))
@@ -845,6 +858,7 @@ class ChildChunkAddApi(Resource):
         # validate args
         payload = ChildChunkBatchUpdatePayload.model_validate(console_ns.payload or {})
         try:
+            db.session.remove()
             child_chunks = SegmentService.update_child_chunks(payload.chunks, segment, document, dataset, session)
         except ChildChunkIndexingServiceError as e:
             raise ChildChunkIndexingError(str(e))
@@ -901,6 +915,7 @@ class ChildChunkUpdateApi(Resource):
         if not child_chunk:
             raise NotFound("Child chunk not found.")
         try:
+            db.session.remove()
             SegmentService.delete_child_chunk(child_chunk, dataset, session)
         except ChildChunkDeleteIndexServiceError as e:
             raise ChildChunkDeleteIndexError(str(e))
@@ -956,6 +971,7 @@ class ChildChunkUpdateApi(Resource):
         # validate args
         try:
             payload = ChildChunkUpdatePayload.model_validate(console_ns.payload or {})
+            db.session.remove()
             child_chunk = SegmentService.update_child_chunk(
                 payload.content, child_chunk, segment, document, dataset, session
             )

--- a/api/controllers/service_api/dataset/segment.py
+++ b/api/controllers/service_api/dataset/segment.py
@@ -26,6 +26,7 @@ from controllers.service_api.wraps import (
 from core.errors.error import LLMBadRequestError, ProviderTokenNotInitError
 from core.model_manager import ModelManager
 from core.rag.index_processor.constant.index_type import IndexTechniqueType
+from extensions.ext_database import db
 from fields.base import ResponseModel
 from fields.segment_fields import (
     ChildChunkDetailResponse,
@@ -377,6 +378,8 @@ class DatasetSegmentApi(DatasetApiResource):
             raise NotFound("Document not found.")
         segment_id_str = str(segment_id)
         _, segment = _get_segment_for_document(session, dataset, document, segment_id_str)
+        # Release the materialized dataset-token auth session before the service commits and publishes cleanup.
+        db.session.remove()
         SegmentService.delete_segment(segment, document, dataset, session)
         return "", 204
 
@@ -440,6 +443,10 @@ class DatasetSegmentApi(DatasetApiResource):
 
         payload = SegmentUpdatePayload.model_validate(service_api_ns.payload or {})
 
+        # Dataset-token authentication uses Flask-SQLAlchemy's scoped session, while this handler uses the
+        # explicitly injected session. The authenticated account and tenant are materialized by this point, so
+        # release the auth session before update paths can call embedding or vector providers.
+        db.session.remove()
         updated_segment = SegmentService.update_segment(payload.segment, segment, document, dataset, session)
         summary = SummaryIndexService.get_segment_summary(
             segment_id=updated_segment.id, dataset_id=dataset_id_str, session=session
@@ -586,6 +593,9 @@ class ChildChunkApi(DatasetApiResource):
         payload = ChildChunkCreatePayload.model_validate(service_api_ns.payload or {})
 
         try:
+            # Dataset-token authentication has materialized its scoped session. Release it before embedding and
+            # vector-provider I/O; the explicitly injected controller session remains the write owner.
+            db.session.remove()
             child_chunk = SegmentService.create_child_chunk(payload.content, segment, document, dataset, session)
         except ChildChunkIndexingServiceError as e:
             raise ChildChunkIndexingError(str(e))
@@ -726,6 +736,7 @@ class DatasetChildChunkApi(DatasetApiResource):
             raise NotFound("Child chunk not found.")
 
         try:
+            db.session.remove()
             SegmentService.delete_child_chunk(child_chunk, dataset, session)
         except ChildChunkDeleteIndexServiceError as e:
             raise ChildChunkDeleteIndexError(str(e))
@@ -799,6 +810,7 @@ class DatasetChildChunkApi(DatasetApiResource):
         payload = ChildChunkUpdatePayload.model_validate(service_api_ns.payload or {})
 
         try:
+            db.session.remove()
             child_chunk = SegmentService.update_child_chunk(
                 payload.content, child_chunk, segment, document, dataset, session
             )

--- a/api/core/app/apps/pipeline/pipeline_generator.py
+++ b/api/core/app/apps/pipeline/pipeline_generator.py
@@ -321,6 +321,15 @@ class PipelineGenerator(BaseAppGenerator):
             workflow = session.get(Workflow, workflow_id)
             if not workflow:
                 raise ValueError(f"Workflow not found: {workflow_id}")
+            # The worker and response pipeline use their own repository/node
+            # sessions. Release the caller's read transaction before either can
+            # block on provider I/O or stream events back to the client.
+            expire_on_commit = session.expire_on_commit
+            session.expire_on_commit = False
+            try:
+                session.commit()
+            finally:
+                session.expire_on_commit = expire_on_commit
             queue_manager = PipelineQueueManager(
                 task_id=application_generate_entity.task_id,
                 user_id=application_generate_entity.user_id,
@@ -625,19 +634,22 @@ class PipelineGenerator(BaseAppGenerator):
                     else:
                         # For internal calls, use the original user ID
                         system_user_id = application_generate_entity.user_id
-                    # workflow app
-                    runner = PipelineRunner(
-                        application_generate_entity=application_generate_entity,
-                        queue_manager=queue_manager,
-                        workflow_thread_pool_id=workflow_thread_pool_id,
-                        variable_loader=variable_loader,
-                        workflow=workflow,
-                        system_user_id=system_user_id,
-                        workflow_execution_repository=workflow_execution_repository,
-                        workflow_node_execution_repository=workflow_node_execution_repository,
-                    )
 
-                    runner.run()
+                # The loaded scalar fields remain usable after close. Pipeline nodes
+                # and repositories own any later SQL, so the worker must not retain
+                # this checkout during external work.
+                runner = PipelineRunner(
+                    application_generate_entity=application_generate_entity,
+                    queue_manager=queue_manager,
+                    workflow_thread_pool_id=workflow_thread_pool_id,
+                    variable_loader=variable_loader,
+                    workflow=workflow,
+                    system_user_id=system_user_id,
+                    workflow_execution_repository=workflow_execution_repository,
+                    workflow_node_execution_repository=workflow_node_execution_repository,
+                )
+
+                runner.run()
             except GenerateTaskStoppedError:
                 pass
             except InvokeAuthorizationError:

--- a/api/core/indexing_runner.py
+++ b/api/core/indexing_runner.py
@@ -114,6 +114,9 @@ class IndexingRunner:
                     current_user=current_user,
                     session=session,
                 )
+                # Account/transform lookups may own a transaction. Token counting can call the embedding provider.
+                if dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY:
+                    session.commit()
                 token_counts = calculate_segment_token_counts(dataset=dataset, documents=documents)
                 total_tokens = sum(token_counts)
                 # save segment
@@ -199,6 +202,9 @@ class IndexingRunner:
                 current_user=current_user,
                 session=session,
             )
+            # Account/transform lookups may own a transaction. Token counting can call the embedding provider.
+            if dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY:
+                session.commit()
             token_counts = calculate_segment_token_counts(dataset=dataset, documents=documents)
             total_tokens = sum(token_counts)
             # save segment

--- a/api/core/rag/datasource/retrieval_service.py
+++ b/api/core/rag/datasource/retrieval_service.py
@@ -34,8 +34,9 @@ from models.dataset import (
     SegmentAttachmentBinding,
 )
 from models.dataset import Document as DatasetDocument
+from models.enums import IndexingStatus, SummaryStatus
 from models.model import UploadFile
-from services.external_knowledge_service import ExternalDatasetService
+from services.external_knowledge_service import ExternalDatasetService, ResolvedExternalKnowledgeConfig
 
 
 class SegmentAttachmentResult(TypedDict):
@@ -175,28 +176,25 @@ class RetrievalService:
     @classmethod
     def external_retrieve(
         cls,
-        session: Session,
+        tenant_id: str,
         dataset_id: str,
         query: str,
+        resolved_config: ResolvedExternalKnowledgeConfig,
         external_retrieval_model: dict[str, Any] | None = None,
         metadata_filtering_conditions: dict[str, Any] | None = None,
     ):
-        stmt = select(Dataset).where(Dataset.id == dataset_id)
-        dataset = session.scalar(stmt)
-        if not dataset:
-            return []
         metadata_condition = (
             MetadataFilteringCondition.model_validate(metadata_filtering_conditions)
             if metadata_filtering_conditions
             else None
         )
         all_documents = ExternalDatasetService.fetch_external_knowledge_retrieval(
-            tenant_id=dataset.tenant_id,
+            tenant_id=tenant_id,
             dataset_id=dataset_id,
             query=query,
             external_retrieval_parameters=external_retrieval_model or {},
             metadata_condition=metadata_condition,
-            session=session,
+            resolved_config=resolved_config,
         )
         return all_documents
 
@@ -328,31 +326,30 @@ class RetrievalService:
                 embedding_score_threshold = (
                     0.0 if retrieval_method == RetrievalMethod.HYBRID_SEARCH else score_threshold
                 )
-                with Session(db.engine) as session:
-                    vector = Vector(dataset=dataset, session=session)
-                    if query_type == QueryType.TEXT_QUERY:
-                        documents.extend(
-                            vector.search_by_vector(
-                                query,
-                                search_type="similarity_score_threshold",
-                                top_k=top_k,
-                                score_threshold=embedding_score_threshold,
-                                filter={"group_id": [dataset.id]},
-                                document_ids_filter=document_ids_filter,
-                            )
+                vector = Vector(dataset=dataset)
+                if query_type == QueryType.TEXT_QUERY:
+                    documents.extend(
+                        vector.search_by_vector(
+                            query,
+                            search_type="similarity_score_threshold",
+                            top_k=top_k,
+                            score_threshold=embedding_score_threshold,
+                            filter={"group_id": [dataset.id]},
+                            document_ids_filter=document_ids_filter,
                         )
-                    if query_type == QueryType.IMAGE_QUERY:
-                        if not dataset.is_multimodal:
-                            return
-                        documents.extend(
-                            vector.search_by_file(
-                                file_id=query,
-                                top_k=top_k,
-                                score_threshold=embedding_score_threshold,
-                                filter={"group_id": [dataset.id]},
-                                document_ids_filter=document_ids_filter,
-                            )
+                    )
+                if query_type == QueryType.IMAGE_QUERY:
+                    if not dataset.is_multimodal:
+                        return
+                    documents.extend(
+                        vector.search_by_file(
+                            file_id=query,
+                            top_k=top_k,
+                            score_threshold=embedding_score_threshold,
+                            filter={"group_id": [dataset.id]},
+                            document_ids_filter=document_ids_filter,
                         )
+                    )
 
                 if documents:
                     if (
@@ -428,11 +425,13 @@ class RetrievalService:
                 if not dataset:
                     raise ValueError("dataset not found")
 
-                with Session(db.engine) as session:
-                    vector_processor = Vector(dataset=dataset, session=session)
+                vector_processor = Vector(dataset=dataset)
 
                 documents = vector_processor.search_by_full_text(
-                    cls.escape_query_for_search(query), top_k=top_k, document_ids_filter=document_ids_filter
+                    cls.escape_query_for_search(query),
+                    top_k=top_k,
+                    filter={"group_id": [dataset.id]},
+                    document_ids_filter=document_ids_filter,
                 )
                 if documents:
                     if (
@@ -469,7 +468,13 @@ class RetrievalService:
         return query.replace('"', '\\"')
 
     @classmethod
-    def format_retrieval_documents(cls, session: Session, documents: list[Document]) -> list[RetrievalSegments]:
+    def format_retrieval_documents(
+        cls,
+        session: Session,
+        documents: list[Document],
+        *,
+        allowed_dataset_ids: set[str],
+    ) -> list[RetrievalSegments]:
         """Format retrieval documents with optimized batch processing"""
         if not documents:
             return []
@@ -485,8 +490,24 @@ class RetrievalService:
                 doc.id: doc
                 for doc in session.scalars(
                     select(DatasetDocument)
-                    .where(DatasetDocument.id.in_(document_ids))
-                    .options(load_only(DatasetDocument.id, DatasetDocument.doc_form, DatasetDocument.dataset_id))
+                    .where(
+                        DatasetDocument.id.in_(document_ids),
+                        DatasetDocument.dataset_id.in_(allowed_dataset_ids),
+                        DatasetDocument.enabled.is_(True),
+                        DatasetDocument.archived.is_(False),
+                        DatasetDocument.indexing_status == IndexingStatus.COMPLETED,
+                    )
+                    .options(
+                        load_only(
+                            DatasetDocument.id,
+                            DatasetDocument.doc_form,
+                            DatasetDocument.dataset_id,
+                            DatasetDocument.tenant_id,
+                            DatasetDocument.enabled,
+                            DatasetDocument.archived,
+                            DatasetDocument.indexing_status,
+                        )
+                    )
                 ).all()
             }
 
@@ -495,8 +516,8 @@ class RetrievalService:
             child_index_node_ids = []
             index_node_ids = []
             doc_to_document_map = {}
-            summary_segment_ids = set()  # Track segments retrieved via summary
-            summary_score_map: dict[str, float] = {}  # Map original_chunk_id to summary score
+            summary_hit_scores: dict[tuple[str, str, str], float | None] = {}
+            summary_score_map: dict[str, float] = {}
 
             # First pass: collect all document IDs and identify summary documents
             for document in documents:
@@ -507,6 +528,17 @@ class RetrievalService:
                 dataset_document = dataset_documents[document_id]
                 if not dataset_document:
                     continue
+                if dataset_document.dataset_id not in allowed_dataset_ids:
+                    continue
+                if (
+                    not dataset_document.enabled
+                    or dataset_document.archived
+                    or dataset_document.indexing_status != IndexingStatus.COMPLETED
+                ):
+                    continue
+                vector_dataset_id = document.metadata.get("dataset_id")
+                if vector_dataset_id is None or str(vector_dataset_id) != dataset_document.dataset_id:
+                    continue
                 valid_dataset_documents[document_id] = dataset_document
 
                 doc_id = document.metadata.get("doc_id") or ""
@@ -515,25 +547,19 @@ class RetrievalService:
                 # Check if this is a summary document
                 is_summary = document.metadata.get("is_summary", False)
                 if is_summary:
-                    # For summary documents, find the original chunk via original_chunk_id
                     original_chunk_id = document.metadata.get("original_chunk_id")
-                    if original_chunk_id:
-                        summary_segment_ids.add(original_chunk_id)
-                        # Save summary's score for later use
-                        summary_score = document.metadata.get("score")
-                        if summary_score is not None:
+                    if original_chunk_id and doc_id:
+                        summary_score: float | None = None
+                        raw_summary_score = document.metadata.get("score")
+                        if raw_summary_score is not None:
                             try:
-                                summary_score_float = float(summary_score)
-                                # If the same segment has multiple summary hits, take the highest score
-                                if original_chunk_id not in summary_score_map:
-                                    summary_score_map[original_chunk_id] = summary_score_float
-                                else:
-                                    summary_score_map[original_chunk_id] = max(
-                                        summary_score_map[original_chunk_id], summary_score_float
-                                    )
+                                summary_score = float(raw_summary_score)
                             except (ValueError, TypeError):
-                                # Skip invalid score values
                                 pass
+                        summary_key = (dataset_document.dataset_id, original_chunk_id, doc_id)
+                        previous_score = summary_hit_scores.get(summary_key)
+                        if previous_score is None or (summary_score is not None and summary_score > previous_score):
+                            summary_hit_scores[summary_key] = summary_score
                     continue  # Skip adding to other lists for summary documents
 
                 if dataset_document.doc_form == IndexStructureType.PARENT_CHILD_INDEX:
@@ -547,6 +573,9 @@ class RetrievalService:
                     else:
                         index_node_ids.append(doc_id)
 
+            if not valid_dataset_documents:
+                return []
+
             image_doc_ids = [i for i in image_doc_ids if i]
             child_index_node_ids = [i for i in child_index_node_ids if i]
             index_node_ids = [i for i in index_node_ids if i]
@@ -558,8 +587,16 @@ class RetrievalService:
             child_chunk_map: dict[str, list[ChildChunk]] = {}
             doc_segment_map: dict[str, list[str]] = {}
             segment_summary_map: dict[str, str] = {}  # Map segment_id to summary content
+            summary_segment_ids: set[str] = set()
+            valid_dataset_ids = {document.dataset_id for document in valid_dataset_documents.values()}
+            valid_tenant_ids = {document.tenant_id for document in valid_dataset_documents.values()}
 
-            attachments = cls.get_segment_attachment_infos(image_doc_ids, session)
+            attachments = cls.get_segment_attachment_infos(
+                image_doc_ids,
+                session,
+                dataset_ids=valid_dataset_ids,
+                tenant_ids=valid_tenant_ids,
+            )
 
             for attachment in attachments:
                 segment_ids.append(attachment["segment_id"])
@@ -572,7 +609,10 @@ class RetrievalService:
                 else:
                     doc_segment_map[attachment["segment_id"]] = [attachment["attachment_id"]]
 
-            child_chunk_stmt = select(ChildChunk).where(ChildChunk.index_node_id.in_(child_index_node_ids))
+            child_chunk_stmt = select(ChildChunk).where(
+                ChildChunk.index_node_id.in_(child_index_node_ids),
+                ChildChunk.dataset_id.in_(valid_dataset_ids),
+            )
             child_index_nodes = session.execute(child_chunk_stmt).scalars().all()
 
             for i in child_index_nodes:
@@ -592,6 +632,7 @@ class RetrievalService:
                     DocumentSegment.enabled == True,
                     DocumentSegment.status == "completed",
                     DocumentSegment.index_node_id.in_(index_node_ids),
+                    DocumentSegment.dataset_id.in_(valid_dataset_ids),
                 )
                 index_node_segments = session.execute(document_segment_stmt).scalars().all()
                 for index_node_segment in index_node_segments:
@@ -603,19 +644,63 @@ class RetrievalService:
                     DocumentSegment.enabled == True,
                     DocumentSegment.status == "completed",
                     DocumentSegment.id.in_(segment_ids),
+                    DocumentSegment.dataset_id.in_(valid_dataset_ids),
                 )
                 segments = session.execute(document_segment_stmt).scalars().all()  # type: ignore
 
             if index_node_segments:
                 segments.extend(index_node_segments)
 
-            # Handle summary documents: query segments by original_chunk_id
+            # A vector-store hit is authoritative only while its node ID matches
+            # the current enabled summary pointer. This rejects old replacement
+            # vectors and vectors left behind by delayed cleanup.
+            if summary_hit_scores:
+                candidate_segment_ids = {key[1] for key in summary_hit_scores}
+                candidate_dataset_ids = {key[0] for key in summary_hit_scores}
+                summaries = session.scalars(
+                    select(DocumentSegmentSummary)
+                    .where(
+                        DocumentSegmentSummary.dataset_id.in_(candidate_dataset_ids),
+                        DocumentSegmentSummary.chunk_id.in_(candidate_segment_ids),
+                    )
+                    .order_by(
+                        DocumentSegmentSummary.dataset_id,
+                        DocumentSegmentSummary.chunk_id,
+                        DocumentSegmentSummary.updated_at.desc(),
+                        DocumentSegmentSummary.id.desc(),
+                    )
+                ).all()
+                canonical_summary_keys: set[tuple[str, str]] = set()
+                for summary in summaries:
+                    canonical_key = (summary.dataset_id, summary.chunk_id)
+                    if canonical_key in canonical_summary_keys:
+                        continue
+                    canonical_summary_keys.add(canonical_key)
+                    if summary.status != SummaryStatus.COMPLETED or not summary.enabled:
+                        continue
+                    summary_node_id = summary.summary_index_node_id
+                    if not summary_node_id or not summary.summary_content:
+                        continue
+                    summary_key = (summary.dataset_id, summary.chunk_id, summary_node_id)
+                    if summary_key not in summary_hit_scores:
+                        continue
+                    summary_segment_ids.add(summary.chunk_id)
+                    segment_summary_map[summary.chunk_id] = summary.summary_content
+                    summary_score = summary_hit_scores[summary_key]
+                    if summary_score is not None:
+                        summary_score_map[summary.chunk_id] = max(
+                            summary_score_map.get(summary.chunk_id, summary_score),
+                            summary_score,
+                        )
+
+            # Handle validated summary documents: query segments by original_chunk_id.
             if summary_segment_ids:
                 summary_segment_ids_list = list(summary_segment_ids)
                 summary_segment_stmt = select(DocumentSegment).where(
                     DocumentSegment.enabled == True,
                     DocumentSegment.status == "completed",
                     DocumentSegment.id.in_(summary_segment_ids_list),
+                    DocumentSegment.dataset_id.in_(valid_dataset_ids),
                 )
                 summary_segments = session.execute(summary_segment_stmt).scalars().all()  # type: ignore
                 segments.extend(summary_segments)
@@ -623,19 +708,6 @@ class RetrievalService:
                 for seg in summary_segments:
                     if seg.id not in segment_ids:
                         segment_ids.append(seg.id)
-
-            # Batch query summaries for segments retrieved via summary (only enabled summaries)
-            if summary_segment_ids:
-                summaries = session.scalars(
-                    select(DocumentSegmentSummary).where(
-                        DocumentSegmentSummary.chunk_id.in_(list(summary_segment_ids)),
-                        DocumentSegmentSummary.status == "completed",
-                        DocumentSegmentSummary.enabled.is_(True),  # Only retrieve enabled summaries
-                    )
-                ).all()
-                for summary in summaries:
-                    if summary.summary_content:
-                        segment_summary_map[summary.chunk_id] = summary.summary_content
 
             include_segment_ids = set()
             segment_child_map: dict[str, SegmentChildMapDetail] = {}
@@ -646,7 +718,12 @@ class RetrievalService:
                 attachment_infos: list[AttachmentInfoDict] = attachment_map.get(segment.id, [])
                 ds_dataset_document: DatasetDocument | None = valid_dataset_documents.get(segment.document_id)
 
-                if ds_dataset_document and ds_dataset_document.doc_form == IndexStructureType.PARENT_CHILD_INDEX:
+                # The vector hit is only a lookup hint. The segment's own
+                # document must still be one of the active rows validated above.
+                if ds_dataset_document is None:
+                    continue
+
+                if ds_dataset_document.doc_form == IndexStructureType.PARENT_CHILD_INDEX:
                     if segment.id not in include_segment_ids:
                         include_segment_ids.add(segment.id)
                         # Check if this segment was retrieved via summary
@@ -918,11 +995,22 @@ class RetrievalService:
     def get_segment_attachment_info(
         cls, dataset_id: str, tenant_id: str, attachment_id: str, session: Session
     ) -> SegmentAttachmentResult | None:
-        upload_file = session.scalar(select(UploadFile).where(UploadFile.id == attachment_id).limit(1))
+        upload_file = session.scalar(
+            select(UploadFile)
+            .where(
+                UploadFile.id == attachment_id,
+                UploadFile.tenant_id == tenant_id,
+            )
+            .limit(1)
+        )
         if upload_file:
             attachment_binding = session.scalar(
                 select(SegmentAttachmentBinding)
-                .where(SegmentAttachmentBinding.attachment_id == upload_file.id)
+                .where(
+                    SegmentAttachmentBinding.attachment_id == upload_file.id,
+                    SegmentAttachmentBinding.dataset_id == dataset_id,
+                    SegmentAttachmentBinding.tenant_id == tenant_id,
+                )
                 .limit(1)
             )
             if attachment_binding:
@@ -940,15 +1028,28 @@ class RetrievalService:
 
     @classmethod
     def get_segment_attachment_infos(
-        cls, attachment_ids: list[str], session: Session
+        cls,
+        attachment_ids: list[str],
+        session: Session,
+        *,
+        dataset_ids: set[str] | None = None,
+        tenant_ids: set[str] | None = None,
     ) -> list[SegmentAttachmentInfoResult]:
         attachment_infos: list[SegmentAttachmentInfoResult] = []
         granted_upload_file_ids: list[str] = []
-        upload_files = session.scalars(select(UploadFile).where(UploadFile.id.in_(attachment_ids))).all()
+        upload_file_filters = [UploadFile.id.in_(attachment_ids)]
+        if tenant_ids is not None:
+            upload_file_filters.append(UploadFile.tenant_id.in_(tenant_ids))
+        upload_files = session.scalars(select(UploadFile).where(*upload_file_filters)).all()
         if upload_files:
             upload_file_ids = [upload_file.id for upload_file in upload_files]
+            attachment_binding_filters = [SegmentAttachmentBinding.attachment_id.in_(upload_file_ids)]
+            if dataset_ids is not None:
+                attachment_binding_filters.append(SegmentAttachmentBinding.dataset_id.in_(dataset_ids))
+            if tenant_ids is not None:
+                attachment_binding_filters.append(SegmentAttachmentBinding.tenant_id.in_(tenant_ids))
             attachment_bindings = session.scalars(
-                select(SegmentAttachmentBinding).where(SegmentAttachmentBinding.attachment_id.in_(upload_file_ids))
+                select(SegmentAttachmentBinding).where(*attachment_binding_filters)
             ).all()
             attachment_binding_map = {binding.attachment_id: binding for binding in attachment_bindings}
 

--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -8,6 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from configs import dify_config
+from core.db.session_factory import session_factory
 from core.model_manager import ModelManager
 from core.rag.datasource.vdb.vector_backend_registry import get_vector_factory_class
 from core.rag.datasource.vdb.vector_base import BaseVector, VectorIndexStructDict
@@ -99,16 +100,23 @@ class _LazyEmbeddings(Embeddings):
 
 
 class Vector:
-    def __init__(self, dataset: Dataset, attributes: list | None = None, *, session: Session):
+    def __init__(
+        self,
+        dataset: Dataset,
+        attributes: list | None = None,
+        *,
+        session: Session | None = None,
+    ):
+        """Create a vector adapter without retaining database session state.
+
+        Callers may pass their session so an already-active transaction can
+        resolve whitelist routing without a second pool checkout. An idle caller
+        session is not started solely for this lookup; the short internal
+        session remains preferable in that case.
+        """
         if attributes is None:
-            # `is_summary` and `original_chunk_id` are stored on summary vectors
-            # by `SummaryIndexService` and read back by `RetrievalService` to
-            # route summary hits through their original parent chunks. They
-            # must be listed here so vector backends that use this list as an
-            # explicit return-properties projection (notably Weaviate) actually
-            # return those fields; without them, summary hits silently
-            # collapse into `is_summary = False` branches and the summary
-            # retrieval path is a no-op. See #34884.
+            # Summary retrieval needs both fields from backends that use an
+            # explicit return-property projection.
             attributes = [
                 "doc_id",
                 "dataset_id",
@@ -120,15 +128,17 @@ class Vector:
             ]
         self._dataset = dataset
         # Use a lazy proxy so cleanup paths (delete_by_ids / delete / text_exists)
-        # never transitively trigger billing API calls during ``Vector(dataset, session=...)``
+        # never transitively trigger billing API calls during ``Vector(dataset)``
         # construction. The real embedding model is materialized only when an
         # ``embed_*`` method is actually invoked (i.e. create / search paths).
         self._embeddings: Embeddings = _LazyEmbeddings(dataset)
         self._attributes = attributes
-        self._session = session
-        self._vector_processor = self._init_vector(session=session)
+        if session is not None and session.in_transaction():
+            self._vector_processor = self._init_vector(session=session)
+        else:
+            self._vector_processor = self._init_vector()
 
-    def _init_vector(self, *, session: Session) -> BaseVector:
+    def _init_vector(self, *, session: Session | None = None) -> BaseVector:
         vector_type = dify_config.VECTOR_STORE
 
         if self._dataset.index_struct_dict:
@@ -138,7 +148,11 @@ class Vector:
                 stmt = select(Whitelist).where(
                     Whitelist.tenant_id == self._dataset.tenant_id, Whitelist.category == "vector_db"
                 )
-                whitelist = session.scalars(stmt).one_or_none()
+                if session is None:
+                    with session_factory.create_session() as read_session:
+                        whitelist = read_session.scalars(stmt).one_or_none()
+                else:
+                    whitelist = session.scalars(stmt).one_or_none()
                 if whitelist:
                     vector_type = VectorType.TIDB_ON_QDRANT
 
@@ -192,20 +206,25 @@ class Vector:
                 batch_start = time.time()
                 logger.info("Processing batch %s/%s (%s files)", i // batch_size + 1, total_batches, len(batch))
 
-                # Batch query all upload files to avoid N+1 queries
-                attachment_ids = [doc.metadata["doc_id"] for doc in batch]
-                stmt = select(UploadFile).where(UploadFile.id.in_(attachment_ids))
-                upload_files = self._session.scalars(stmt).all()
-                upload_file_map = {str(f.id): f for f in upload_files}
+                # Fetch only the storage identifiers needed below. Tenant scoping prevents a document carrying an
+                # unrelated file UUID from reading another tenant's object.
+                attachment_ids = list(dict.fromkeys(str(doc.metadata["doc_id"]) for doc in batch))
+                stmt = select(UploadFile.id, UploadFile.key).where(
+                    UploadFile.id.in_(attachment_ids),
+                    UploadFile.tenant_id == self._dataset.tenant_id,
+                )
+                with session_factory.create_session() as read_session:
+                    upload_files = read_session.execute(stmt).all()
+                upload_file_map = {str(upload_file_id): storage_key for upload_file_id, storage_key in upload_files}
 
                 file_base64_list = []
                 real_batch = []
                 for document in batch:
-                    attachment_id = document.metadata["doc_id"]
+                    attachment_id = str(document.metadata["doc_id"])
                     doc_type = document.metadata["doc_type"]
-                    upload_file = upload_file_map.get(attachment_id)
-                    if upload_file:
-                        blob = storage.load_once(upload_file.key)
+                    storage_key = upload_file_map.get(attachment_id)
+                    if storage_key is not None:
+                        blob = storage.load_once(storage_key)
                         file_base64_str = base64.b64encode(blob).decode()
                         file_base64_list.append(
                             {
@@ -253,11 +272,16 @@ class Vector:
         return self._vector_processor.search_by_vector(query_vector, **kwargs)
 
     def search_by_file(self, file_id: str, **kwargs: Any) -> list[Document]:
-        upload_file: UploadFile | None = self._session.get(UploadFile, file_id)
+        stmt = select(UploadFile.key).where(
+            UploadFile.id == file_id,
+            UploadFile.tenant_id == self._dataset.tenant_id,
+        )
+        with session_factory.create_session() as read_session:
+            storage_key = read_session.scalar(stmt)
 
-        if not upload_file:
+        if storage_key is None:
             return []
-        blob = storage.load_once(upload_file.key)
+        blob = storage.load_once(storage_key)
         file_base64_str = base64.b64encode(blob).decode()
         multimodal_vector = self._embeddings.embed_multimodal_query(
             {

--- a/api/core/rag/index_processor/index_processor.py
+++ b/api/core/rag/index_processor/index_processor.py
@@ -9,7 +9,6 @@ from flask import current_app
 from sqlalchemy import delete, func, select, update
 from sqlalchemy.orm import Session
 
-from core.db.session_factory import session_factory
 from core.rag.index_processor.constant.index_type import IndexTechniqueType
 from core.rag.index_processor.index_processor_base import SummaryIndexSettingDict
 from core.workflow.nodes.knowledge_index.exc import KnowledgeIndexNodeError
@@ -86,7 +85,8 @@ class IndexProcessor:
         created_at_value = document.created_at
         if summary_index_setting is None:
             summary_index_setting = dataset.summary_index_setting
-        index_node_ids = []
+        index_node_ids: list[str] = []
+        segment_ids: list[str] = []
 
         index_processor = IndexProcessorFactory(dataset.chunk_structure).init_index_processor()
         if original_document_id:
@@ -99,14 +99,22 @@ class IndexProcessor:
             ).all()
             if segments:
                 index_node_ids = [segment.index_node_id for segment in segments if segment.index_node_id]
+                segment_ids = [segment.id for segment in segments]
 
         indexing_start_at = time.perf_counter()
         # The metadata reads above must not keep a transaction open across vector I/O.
         session.commit()
-        # delete from vector index
-        if index_node_ids:
+        # Summary cleanup is keyed by database segment IDs and must still run
+        # when indexing failed before an index_node_id was assigned.
+        if segment_ids:
             index_processor.clean(
-                dataset, index_node_ids, with_keywords=True, delete_child_chunks=True, session=session
+                dataset,
+                index_node_ids,
+                with_keywords=True,
+                delete_child_chunks=True,
+                delete_summaries=True,
+                segment_ids=segment_ids,
+                session=session,
             )
             session.commit()
             segment_delete_stmt = delete(DocumentSegment).where(
@@ -225,16 +233,14 @@ class IndexProcessor:
                 """Generate summary for a single chunk."""
                 if flask_app:
                     with flask_app.app_context():
-                        with session_factory.create_session() as worker_session:
-                            summary, _ = ParagraphIndexProcessor.generate_summary(
-                                tenant_id=tenant_id,
-                                text=preview_item.content if preview_item.content is not None else "",
-                                summary_index_setting=summary_index_setting,
-                                document_language=doc_language,
-                                session=worker_session,
-                            )
-                            if summary:
-                                preview_item.summary = summary
+                        summary, _ = ParagraphIndexProcessor.generate_summary(
+                            tenant_id=tenant_id,
+                            text=preview_item.content if preview_item.content is not None else "",
+                            summary_index_setting=summary_index_setting,
+                            document_language=doc_language,
+                        )
+                        if summary:
+                            preview_item.summary = summary
 
             # Generate summaries concurrently using ThreadPoolExecutor
             # Set a reasonable timeout to prevent hanging (60 seconds per chunk, max 5 minutes total)

--- a/api/core/rag/index_processor/index_processor_base.py
+++ b/api/core/rag/index_processor/index_processor_base.py
@@ -76,7 +76,8 @@ class BaseIndexProcessor(ABC):
             preview_texts: List of preview details to generate summaries for
             summary_index_setting: Summary index configuration
             doc_language: Optional document language to ensure summary is generated in the correct language
-            session: SQLAlchemy session used for summary image lookups
+            session: Caller-owned session reserved for processor-specific preview reads. Implementations must not
+                share it with worker threads or retain it across model I/O.
         """
         raise NotImplementedError
 

--- a/api/core/rag/index_processor/processor/paragraph_index_processor.py
+++ b/api/core/rag/index_processor/processor/paragraph_index_processor.py
@@ -29,7 +29,6 @@ from core.rag.index_processor.index_processor_base import BaseIndexProcessor, Su
 from core.rag.models.document import AttachmentDocument, Document, MultimodalGeneralStructureChunk
 from core.tools.utils.text_processing_utils import remove_leading_symbols
 from core.workflow.file_reference import build_file_reference
-from factories.file_factory import build_from_mapping
 from graphon.file import File, FileTransferMethod, FileType, file_manager
 from graphon.model_runtime.entities.llm_entities import LLMResult, LLMUsage
 from graphon.model_runtime.entities.message_entities import (
@@ -43,13 +42,12 @@ from graphon.model_runtime.entities.model_entities import ModelFeature, ModelTyp
 from libs import helper
 from models import UploadFile
 from models.account import Account
-from models.dataset import Dataset, DatasetProcessRule, DocumentSegment, SegmentAttachmentBinding
+from models.dataset import Dataset, DatasetProcessRule, SegmentAttachmentBinding
 from models.dataset import Document as DatasetDocument
 from services.account_service import AccountService
 from services.summary_index_service import SummaryIndexService
 
 logger = logging.getLogger(__name__)
-
 
 _file_access_controller = DatabaseFileAccessController()
 
@@ -139,7 +137,7 @@ class ParagraphIndexProcessor(BaseIndexProcessor):
         **kwargs,
     ) -> None:
         if dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY:
-            vector = Vector(dataset, session=session)
+            vector = Vector(dataset)
             vector.create(documents)
             if multimodal_documents and dataset.is_multimodal:
                 vector.create_multimodal(multimodal_documents)
@@ -162,34 +160,22 @@ class ParagraphIndexProcessor(BaseIndexProcessor):
         # Only delete summaries if explicitly requested (e.g., when segment is actually deleted)
         delete_summaries = kwargs.get("delete_summaries", False)
         if delete_summaries:
-            if node_ids:
-                # Find segments by index_node_id
-                segments = session.scalars(
-                    select(DocumentSegment).where(
-                        DocumentSegment.dataset_id == dataset.id,
-                        DocumentSegment.index_node_id.in_(node_ids),
-                    )
-                ).all()
-                segment_ids = [segment.id for segment in segments]
-                if segment_ids:
-                    SummaryIndexService.delete_summaries_for_segments(dataset, segment_ids, session=session)
-            else:
-                # Delete all summaries for the dataset
-                SummaryIndexService.delete_summaries_for_segments(dataset, None, session=session)
+            segment_ids = cast(list[str] | None, kwargs.get("segment_ids"))
+            if node_ids is not None and segment_ids is None:
+                raise ValueError("segment_ids are required for partial summary cleanup")
+            SummaryIndexService.delete_summaries_for_segments(dataset=dataset, segment_ids=segment_ids, session=session)
 
         if dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY:
-            vector = Vector(dataset, session=session)
-            if node_ids:
-                vector.delete_by_ids(node_ids)
-            else:
-                vector.delete()
+            if node_ids is None:
+                Vector(dataset).delete()
+            elif node_ids:
+                Vector(dataset).delete_by_ids(node_ids)
             with_keywords = False
         if with_keywords:
-            keyword = Keyword(dataset)
-            if node_ids:
-                keyword.delete_by_ids(node_ids, session)
-            else:
-                keyword.delete(session=session)
+            if node_ids is None:
+                Keyword(dataset).delete(session=session)
+            elif node_ids:
+                Keyword(dataset).delete_by_ids(node_ids, session)
 
     @override
     def index(self, dataset: Dataset, document: DatasetDocument, chunks: Any, session: Session) -> None:
@@ -236,6 +222,8 @@ class ParagraphIndexProcessor(BaseIndexProcessor):
                         all_multimodal_documents.append(file_document)
                     doc.attachments = attachments
                 else:
+                    # AccountService may commit and close its session while preparing a detached account.
+                    # Isolate that lifecycle from the caller's document-indexing transaction.
                     with session_factory.create_session() as account_session:
                         account = AccountService.load_user(document.created_by, account_session)
                     if not account:
@@ -245,6 +233,9 @@ class ParagraphIndexProcessor(BaseIndexProcessor):
                         all_multimodal_documents.extend(doc.attachments)
                 documents.append(doc)
         if documents:
+            # Attachment lookups above may own a read transaction. Token counting can call the embedding provider.
+            if dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY:
+                session.commit()
             token_counts = calculate_segment_token_counts(dataset=dataset, documents=documents)
             # save node to document segment
             doc_store = DatasetDocumentStore(dataset=dataset, user_id=document.created_by, document_id=document.id)
@@ -257,7 +248,7 @@ class ParagraphIndexProcessor(BaseIndexProcessor):
             )
             session.commit()
             if dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY:
-                vector = Vector(dataset, session=session)
+                vector = Vector(dataset)
                 vector.create(documents)
                 if all_multimodal_documents and dataset.is_multimodal:
                     vector.create_multimodal(all_multimodal_documents)
@@ -294,6 +285,9 @@ class ParagraphIndexProcessor(BaseIndexProcessor):
         For each segment, concurrently call generate_summary to generate a summary
         and write it to the summary attribute of PreviewDetail.
         In preview mode (indexing-estimate), if any summary generation fails, the method will raise an exception.
+
+        The interface session is intentionally not shared with workers. Vision-capable summaries own a short image
+        lookup session inside ``generate_summary`` and close it before storage or model I/O.
         """
         import concurrent.futures
 
@@ -311,25 +305,21 @@ class ParagraphIndexProcessor(BaseIndexProcessor):
             if flask_app:
                 # Ensure Flask app context in worker thread
                 with flask_app.app_context():
-                    with session_factory.create_session() as worker_session:
-                        summary, _ = self.generate_summary(
-                            tenant_id,
-                            preview.content,
-                            summary_index_setting,
-                            document_language=doc_language,
-                            session=worker_session,
-                        )
-                    preview.summary = summary
-            else:
-                # Fallback: try without app context (may fail)
-                with session_factory.create_session() as worker_session:
                     summary, _ = self.generate_summary(
                         tenant_id,
                         preview.content,
                         summary_index_setting,
                         document_language=doc_language,
-                        session=worker_session,
                     )
+                    preview.summary = summary
+            else:
+                # Fallback: try without app context (may fail)
+                summary, _ = self.generate_summary(
+                    tenant_id,
+                    preview.content,
+                    summary_index_setting,
+                    document_language=doc_language,
+                )
                 preview.summary = summary
 
         # Generate summaries concurrently using ThreadPoolExecutor
@@ -384,12 +374,13 @@ class ParagraphIndexProcessor(BaseIndexProcessor):
         summary_index_setting: SummaryIndexSettingDict | None = None,
         segment_id: str | None = None,
         document_language: str | None = None,
-        *,
-        session: Session,
     ) -> tuple[str, LLMUsage]:
         """
         Generate summary for the given text using ModelInstance.invoke_llm and the default or custom summary prompt,
         and supports vision models by including images from the segment attachments or text content.
+
+        Database access is limited to vision-image lookup and uses an internal, short-lived
+        session so callers do not hold or share a session across LLM I/O.
 
         Args:
             tenant_id: Tenant ID
@@ -398,8 +389,6 @@ class ParagraphIndexProcessor(BaseIndexProcessor):
             segment_id: Optional segment ID to fetch attachments from SegmentAttachmentBinding table
             document_language: Optional document language (e.g., "Chinese", "English")
                 to ensure summary is generated in the correct language
-            session: SQLAlchemy session used for summary image lookups
-
         Returns:
             Tuple of (summary_content, llm_usage) where llm_usage is LLMUsage object
         """
@@ -444,15 +433,14 @@ class ParagraphIndexProcessor(BaseIndexProcessor):
         # Extract images if model supports vision
         image_files = []
         if supports_vision:
-            # First, try to get images from SegmentAttachmentBinding (preferred method)
-            if segment_id:
-                image_files = ParagraphIndexProcessor._extract_images_from_segment_attachments(
-                    tenant_id, segment_id, session
-                )
+            with session_factory.create_session() as image_session:
+                if segment_id:
+                    image_files = ParagraphIndexProcessor._extract_images_from_segment_attachments(
+                        tenant_id, segment_id, image_session
+                    )
 
-            # If no images from attachments, fall back to extracting from text
-            if not image_files:
-                image_files = ParagraphIndexProcessor._extract_images_from_text(tenant_id, text, session)
+                if not image_files:
+                    image_files = ParagraphIndexProcessor._extract_images_from_text(tenant_id, text, image_session)
 
         # Build prompt messages
         prompt_messages = []
@@ -555,9 +543,11 @@ class ParagraphIndexProcessor(BaseIndexProcessor):
 
         # Get unique IDs for database query
         unique_upload_file_ids = list(set(upload_file_id_list))
-        upload_files = session.scalars(
-            select(UploadFile).where(UploadFile.id.in_(unique_upload_file_ids), UploadFile.tenant_id == tenant_id)
-        ).all()
+        upload_file_stmt = select(UploadFile).where(
+            UploadFile.id.in_(unique_upload_file_ids),
+            UploadFile.tenant_id == tenant_id,
+        )
+        upload_files = session.scalars(_file_access_controller.apply_upload_file_filters(upload_file_stmt)).all()
 
         # Create File objects from UploadFile records
         file_objects = []
@@ -566,17 +556,18 @@ class ParagraphIndexProcessor(BaseIndexProcessor):
             if not upload_file.mime_type or "image" not in upload_file.mime_type:
                 continue
 
-            mapping = {
-                "upload_file_id": upload_file.id,
-                "transfer_method": FileTransferMethod.LOCAL_FILE.value,
-                "type": FileType.IMAGE.value,
-            }
-
             try:
-                file_obj = build_from_mapping(
-                    mapping=mapping,
-                    tenant_id=tenant_id,
-                    access_controller=_file_access_controller,
+                file_obj = File(
+                    file_id=upload_file.id,
+                    filename=upload_file.name,
+                    extension="." + upload_file.extension,
+                    mime_type=upload_file.mime_type,
+                    file_type=FileType.IMAGE,
+                    transfer_method=FileTransferMethod.LOCAL_FILE,
+                    remote_url=upload_file.source_url,
+                    reference=build_file_reference(record_id=upload_file.id),
+                    size=upload_file.size,
+                    storage_key=upload_file.key,
                 )
                 file_objects.append(file_obj)
             except Exception as e:
@@ -601,20 +592,22 @@ class ParagraphIndexProcessor(BaseIndexProcessor):
         from sqlalchemy import select
 
         # Query attachments from SegmentAttachmentBinding table
-        attachments_with_bindings = session.execute(
-            select(SegmentAttachmentBinding, UploadFile)
-            .join(UploadFile, UploadFile.id == SegmentAttachmentBinding.attachment_id)
+        attachment_file_stmt = (
+            select(UploadFile)
+            .join(SegmentAttachmentBinding, UploadFile.id == SegmentAttachmentBinding.attachment_id)
             .where(
                 SegmentAttachmentBinding.segment_id == segment_id,
                 SegmentAttachmentBinding.tenant_id == tenant_id,
+                UploadFile.tenant_id == tenant_id,
             )
-        ).all()
+        )
+        upload_files = session.scalars(_file_access_controller.apply_upload_file_filters(attachment_file_stmt)).all()
 
-        if not attachments_with_bindings:
+        if not upload_files:
             return []
 
         file_objects = []
-        for _, upload_file in attachments_with_bindings:
+        for upload_file in upload_files:
             # Only process image files
             if not upload_file.mime_type or "image" not in upload_file.mime_type:
                 continue

--- a/api/core/rag/index_processor/processor/parent_child_index_processor.py
+++ b/api/core/rag/index_processor/processor/parent_child_index_processor.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import uuid
-from typing import Any, TypedDict, override
+from typing import Any, TypedDict, cast, override
 
 from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
@@ -144,7 +144,7 @@ class ParentChildIndexProcessor(BaseIndexProcessor):
         **kwargs,
     ) -> None:
         if dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY:
-            vector = Vector(dataset, session=session)
+            vector = Vector(dataset)
             for document in documents:
                 child_documents = document.children
                 if child_documents:
@@ -160,37 +160,46 @@ class ParentChildIndexProcessor(BaseIndexProcessor):
         self, dataset: Dataset, node_ids: list[str] | None, with_keywords: bool = True, *, session: Session, **kwargs
     ) -> None:
         # node_ids is segment's node_ids
+        segment_ids = cast(list[str] | None, kwargs.get("segment_ids"))
         # Note: Summary indexes are now disabled (not deleted) when segments are disabled.
         # This method is called for actual deletion scenarios (e.g., when segment is deleted).
         # For disable operations, disable_summaries_for_segments is called directly in the task.
         # Only delete summaries if explicitly requested (e.g., when segment is actually deleted)
         delete_summaries = kwargs.get("delete_summaries", False)
         if delete_summaries:
-            if node_ids:
-                # Find segments by index_node_id
-                segments = session.scalars(
-                    select(DocumentSegment).where(
-                        DocumentSegment.dataset_id == dataset.id,
-                        DocumentSegment.index_node_id.in_(node_ids),
-                    )
-                ).all()
-                segment_ids = [segment.id for segment in segments]
-                if segment_ids:
-                    SummaryIndexService.delete_summaries_for_segments(dataset, segment_ids, session=session)
-            else:
-                # Delete all summaries for the dataset
-                SummaryIndexService.delete_summaries_for_segments(dataset, None, session=session)
+            if node_ids is not None and segment_ids is None:
+                raise ValueError("segment_ids are required for partial summary cleanup")
+            SummaryIndexService.delete_summaries_for_segments(dataset=dataset, segment_ids=segment_ids, session=session)
 
         if dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY:
             delete_child_chunks = kwargs.get("delete_child_chunks") or False
             precomputed_child_node_ids = kwargs.get("precomputed_child_node_ids")
-            vector = Vector(dataset, session=session)
+            if node_ids is None:
+                Vector(dataset).delete()
 
-            if node_ids:
+                if delete_child_chunks:
+                    session.execute(
+                        delete(ChildChunk).where(
+                            ChildChunk.tenant_id == dataset.tenant_id, ChildChunk.dataset_id == dataset.id
+                        )
+                    )
+                    session.flush()
+            else:
                 # Use precomputed child_node_ids if available (to avoid race conditions)
                 if precomputed_child_node_ids is not None:
                     child_node_ids = precomputed_child_node_ids
-                else:
+                elif segment_ids:
+                    child_node_ids = [
+                        node_id
+                        for node_id in session.scalars(
+                            select(ChildChunk.index_node_id).where(
+                                ChildChunk.dataset_id == dataset.id,
+                                ChildChunk.segment_id.in_(segment_ids),
+                            )
+                        ).all()
+                        if node_id
+                    ]
+                elif node_ids:
                     # Fallback to original query (may fail if segments are already deleted)
                     rows = session.execute(
                         select(ChildChunk.index_node_id)
@@ -202,29 +211,30 @@ class ParentChildIndexProcessor(BaseIndexProcessor):
                         )
                     ).all()
                     child_node_ids = [row[0] for row in rows if row[0]]
+                else:
+                    child_node_ids = []
 
                 # Delete from vector index
                 if child_node_ids:
-                    vector.delete_by_ids(child_node_ids)
+                    Vector(dataset).delete_by_ids(child_node_ids)
 
                 # Delete from database
-                if delete_child_chunks and child_node_ids:
-                    session.execute(
-                        delete(ChildChunk).where(
-                            ChildChunk.dataset_id == dataset.id, ChildChunk.index_node_id.in_(child_node_ids)
-                        )
-                    )
-                    session.flush()
-            else:
-                vector.delete()
-
                 if delete_child_chunks:
-                    # Use existing compound index: (tenant_id, dataset_id, ...)
-                    session.execute(
-                        delete(ChildChunk).where(
-                            ChildChunk.tenant_id == dataset.tenant_id, ChildChunk.dataset_id == dataset.id
+                    if segment_ids:
+                        session.execute(
+                            delete(ChildChunk).where(
+                                ChildChunk.dataset_id == dataset.id,
+                                ChildChunk.segment_id.in_(segment_ids),
+                            )
                         )
-                    )
+                    elif child_node_ids:
+                        session.execute(
+                            delete(ChildChunk).where(
+                                ChildChunk.dataset_id == dataset.id, ChildChunk.index_node_id.in_(child_node_ids)
+                            )
+                        )
+                    else:
+                        return
                     session.flush()
 
     def _split_child_nodes(
@@ -305,6 +315,9 @@ class ParentChildIndexProcessor(BaseIndexProcessor):
                 doc.attachments = self._get_content_files(doc, current_user=account, session=session)
             documents.append(doc)
         if documents:
+            # Attachment lookups above may own a read transaction. Token counting can call the embedding provider.
+            if dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY:
+                session.commit()
             token_counts = calculate_segment_token_counts(dataset=dataset, documents=documents)
             # update document parent mode
             dataset_process_rule = DatasetProcessRule(
@@ -338,7 +351,7 @@ class ParentChildIndexProcessor(BaseIndexProcessor):
                         all_child_documents.extend(doc.children)
                     if doc.attachments:
                         all_multimodal_documents.extend(doc.attachments)
-                vector = Vector(dataset, session=session)
+                vector = Vector(dataset)
                 if all_child_documents:
                     vector.create(all_child_documents)
                 if all_multimodal_documents and dataset.is_multimodal:
@@ -393,25 +406,21 @@ class ParentChildIndexProcessor(BaseIndexProcessor):
             if flask_app:
                 # Ensure Flask app context in worker thread
                 with flask_app.app_context():
-                    with session_factory.create_session() as worker_session:
-                        summary, _ = ParagraphIndexProcessor.generate_summary(
-                            tenant_id=tenant_id,
-                            text=preview.content,
-                            summary_index_setting=summary_index_setting,
-                            document_language=doc_language,
-                            session=worker_session,
-                        )
-                    preview.summary = summary
-            else:
-                # Fallback: try without app context (may fail)
-                with session_factory.create_session() as worker_session:
                     summary, _ = ParagraphIndexProcessor.generate_summary(
                         tenant_id=tenant_id,
                         text=preview.content,
                         summary_index_setting=summary_index_setting,
                         document_language=doc_language,
-                        session=worker_session,
                     )
+                    preview.summary = summary
+            else:
+                # Fallback: try without app context (may fail)
+                summary, _ = ParagraphIndexProcessor.generate_summary(
+                    tenant_id=tenant_id,
+                    text=preview.content,
+                    summary_index_setting=summary_index_setting,
+                    document_language=doc_language,
+                )
                 preview.summary = summary
 
         # Generate summaries concurrently using ThreadPoolExecutor

--- a/api/core/rag/index_processor/processor/qa_index_processor.py
+++ b/api/core/rag/index_processor/processor/qa_index_processor.py
@@ -4,11 +4,10 @@ import logging
 import re
 import threading
 import uuid
-from typing import Any, TypedDict, override
+from typing import Any, TypedDict, cast, override
 
 import pandas as pd
 from flask import Flask, current_app
-from sqlalchemy import select
 from sqlalchemy.orm import Session
 from werkzeug.datastructures import FileStorage
 
@@ -27,7 +26,7 @@ from core.rag.models.document import AttachmentDocument, Document, QAStructureCh
 from core.tools.utils.text_processing_utils import remove_leading_symbols
 from libs import helper
 from models.account import Account
-from models.dataset import Dataset, DocumentSegment
+from models.dataset import Dataset
 from models.dataset import Document as DatasetDocument
 from services.summary_index_service import SummaryIndexService
 
@@ -154,7 +153,7 @@ class QAIndexProcessor(BaseIndexProcessor):
         **kwargs,
     ) -> None:
         if dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY:
-            vector = Vector(dataset, session=session)
+            vector = Vector(dataset)
             vector.create(documents)
             if multimodal_documents and dataset.is_multimodal:
                 vector.create_multimodal(multimodal_documents)
@@ -170,26 +169,15 @@ class QAIndexProcessor(BaseIndexProcessor):
         # Only delete summaries if explicitly requested (e.g., when segment is actually deleted)
         delete_summaries = kwargs.get("delete_summaries", False)
         if delete_summaries:
-            if node_ids:
-                # Find segments by index_node_id
-                segments = session.scalars(
-                    select(DocumentSegment).where(
-                        DocumentSegment.dataset_id == dataset.id,
-                        DocumentSegment.index_node_id.in_(node_ids),
-                    )
-                ).all()
-                segment_ids = [segment.id for segment in segments]
-                if segment_ids:
-                    SummaryIndexService.delete_summaries_for_segments(dataset, segment_ids, session=session)
-            else:
-                # Delete all summaries for the dataset
-                SummaryIndexService.delete_summaries_for_segments(dataset, None, session=session)
+            segment_ids = cast(list[str] | None, kwargs.get("segment_ids"))
+            if node_ids is not None and segment_ids is None:
+                raise ValueError("segment_ids are required for partial summary cleanup")
+            SummaryIndexService.delete_summaries_for_segments(dataset=dataset, segment_ids=segment_ids, session=session)
 
-        vector = Vector(dataset, session=session)
-        if node_ids:
-            vector.delete_by_ids(node_ids)
-        else:
-            vector.delete()
+        if node_ids is None:
+            Vector(dataset).delete()
+        elif node_ids:
+            Vector(dataset).delete_by_ids(node_ids)
 
     @override
     def index(self, dataset: Dataset, document: DatasetDocument, chunks: Any, session: Session) -> None:
@@ -206,6 +194,9 @@ class QAIndexProcessor(BaseIndexProcessor):
             doc = Document(page_content=qa_chunk.question, metadata=metadata)
             documents.append(doc)
         if documents:
+            # End any caller-owned read transaction before token counting can call the embedding provider.
+            if dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY:
+                session.commit()
             token_counts = calculate_segment_token_counts(dataset=dataset, documents=documents)
             # save node to document segment
             doc_store = DatasetDocumentStore(dataset=dataset, user_id=document.created_by, document_id=document.id)
@@ -217,7 +208,7 @@ class QAIndexProcessor(BaseIndexProcessor):
             )
             session.commit()
             if dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY:
-                vector = Vector(dataset, session=session)
+                vector = Vector(dataset)
                 vector.create(documents)
             else:
                 raise ValueError("Indexing technique must be high quality.")

--- a/api/core/rag/rerank/rerank_model.py
+++ b/api/core/rag/rerank/rerank_model.py
@@ -1,6 +1,7 @@
 import base64
 from typing import override
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from core.model_manager import ModelInstance, ModelManager
@@ -16,6 +17,12 @@ from models.model import UploadFile
 
 
 class RerankModelRunner(BaseRerankRunner):
+    """Run model reranking with short, tenant-scoped multimodal file reads.
+
+    Required upload-file keys are prefetched in one transaction. That
+    transaction is committed before storage or model-provider I/O begins.
+    """
+
     _session: Session
 
     def __init__(self, rerank_model_instance: ModelInstance, *, session: Session):
@@ -130,64 +137,78 @@ class RerankModelRunner(BaseRerankRunner):
         :param query_type: query type
         :return: rerank result
         """
-        docs: list[MultimodalRerankInput] = []
-        doc_ids = set()
-        unique_documents = []
+        if query_type == QueryType.TEXT_QUERY:
+            return self.fetch_text_rerank(query, documents, score_threshold, top_n)
+        if query_type != QueryType.IMAGE_QUERY:
+            raise ValueError(f"Query type {query_type} is not supported")
+
+        doc_ids: set[str] = set()
+        unique_candidates: list[Document] = []
+        image_file_ids: set[str] = set()
         for document in documents:
+            metadata = document.metadata or {}
             if (
                 document.provider == "dify"
-                and document.metadata is not None
-                and document.metadata["doc_id"] not in doc_ids
+                and metadata.get("doc_id") is not None
+                and str(metadata["doc_id"]) not in doc_ids
             ):
-                if document.metadata.get("doc_type") == DocType.IMAGE:
-                    upload_file = self._session.get(UploadFile, document.metadata["doc_id"])
-                    if upload_file:
-                        blob = storage.load_once(upload_file.key)
-                        document_file_base64 = base64.b64encode(blob).decode()
-                        docs.append(
-                            MultimodalRerankInput(
-                                content=document_file_base64,
-                                content_type=document.metadata["doc_type"],
-                            )
-                        )
-                else:
-                    docs.append(
-                        MultimodalRerankInput(
-                            content=document.page_content,
-                            content_type=document.metadata.get("doc_type") or DocType.TEXT,
-                        )
-                    )
-                doc_ids.add(document.metadata["doc_id"])
-                unique_documents.append(document)
+                doc_id = str(metadata["doc_id"])
+                doc_ids.add(doc_id)
+                unique_candidates.append(document)
+                if metadata.get("doc_type") == DocType.IMAGE:
+                    image_file_ids.add(doc_id)
             elif document.provider == "external":
-                if document not in unique_documents:
-                    docs.append(
-                        MultimodalRerankInput(
-                            content=document.page_content,
-                            content_type=document.metadata.get("doc_type") or DocType.TEXT,
-                        )
+                if document not in unique_candidates:
+                    unique_candidates.append(document)
+
+        tenant_id = self.rerank_model_instance.provider_model_bundle.configuration.tenant_id
+        upload_file_ids = [*image_file_ids, query]
+        upload_files = self._session.scalars(
+            select(UploadFile).where(
+                UploadFile.id.in_(upload_file_ids),
+                UploadFile.tenant_id == tenant_id,
+            )
+        ).all()
+        upload_keys = {upload_file.id: upload_file.key for upload_file in upload_files}
+        self._session.commit()
+
+        query_key = upload_keys.get(query)
+        if query_key is None:
+            raise ValueError(f"Upload file not found for query: {query}")
+
+        docs: list[MultimodalRerankInput] = []
+        unique_documents: list[Document] = []
+        for document in unique_candidates:
+            metadata = document.metadata or {}
+            if document.provider == "dify" and metadata.get("doc_type") == DocType.IMAGE:
+                image_key = upload_keys.get(str(metadata["doc_id"]))
+                if image_key is None:
+                    continue
+                blob = storage.load_once(image_key)
+                docs.append(
+                    MultimodalRerankInput(
+                        content=base64.b64encode(blob).decode(),
+                        content_type=DocType.IMAGE,
                     )
-                    unique_documents.append(document)
-
-        documents = unique_documents
-        if query_type == QueryType.TEXT_QUERY:
-            rerank_result, unique_documents = self.fetch_text_rerank(query, documents, score_threshold, top_n)
-            return rerank_result, unique_documents
-        elif query_type == QueryType.IMAGE_QUERY:
-            upload_file = self._session.get(UploadFile, query)
-            if upload_file:
-                blob = storage.load_once(upload_file.key)
-                file_query = base64.b64encode(blob).decode()
-                file_query_input = MultimodalRerankInput(
-                    content=file_query,
-                    content_type=DocType.IMAGE,
                 )
-                rerank_result = self.rerank_model_instance.invoke_multimodal_rerank(
-                    query=file_query_input, docs=docs, score_threshold=score_threshold, top_n=top_n
-                )
-                return rerank_result, unique_documents
             else:
-                raise ValueError(f"Upload file not found for query: {query}")
+                docs.append(
+                    MultimodalRerankInput(
+                        content=document.page_content,
+                        content_type=metadata.get("doc_type") or DocType.TEXT,
+                    )
+                )
+            unique_documents.append(document)
 
-        else:
-            raise ValueError(f"Query type {query_type} is not supported")
+        query_blob = storage.load_once(query_key)
+        file_query_input = MultimodalRerankInput(
+            content=base64.b64encode(query_blob).decode(),
+            content_type=DocType.IMAGE,
+        )
+        rerank_result = self.rerank_model_instance.invoke_multimodal_rerank(
+            query=file_query_input,
+            docs=docs,
+            score_threshold=score_threshold,
+            top_n=top_n,
+        )
+        return rerank_result, unique_documents

--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -6,11 +6,12 @@ import threading
 import time
 from collections import Counter, defaultdict
 from collections.abc import Generator, Mapping
+from dataclasses import dataclass
 from typing import Any, Union, cast
 
 from flask import Flask, current_app
 from sqlalchemy import and_, func, literal, or_, select, update
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import Session, load_only, sessionmaker
 
 from core.app.app_config.entities import (
     DatasetEntity,
@@ -86,7 +87,7 @@ from models.dataset import (
 from models.dataset import Document as DatasetDocument
 from models.dataset import Document as DocumentModel
 from models.enums import CreatorUserRole, DatasetQuerySource
-from services.external_knowledge_service import ExternalDatasetService
+from services.external_knowledge_service import ExternalDatasetService, ResolvedExternalKnowledgeConfig
 from services.feature_service import FeatureService
 
 default_retrieval_model: DefaultRetrievalModelDict = {
@@ -96,6 +97,24 @@ default_retrieval_model: DefaultRetrievalModelDict = {
     "top_k": 4,
     "score_threshold_enabled": False,
 }
+
+
+@dataclass(frozen=True)
+class _DatasetRetrievalConfig:
+    """Committed dataset values needed after the lookup session closes."""
+
+    id: str
+    tenant_id: str
+    name: str
+    provider: str
+    retrieval_model: dict[str, Any] | None
+    indexing_technique: IndexTechniqueType | None
+    external_knowledge_config: ResolvedExternalKnowledgeConfig | None
+
+    @property
+    def external_retrieval_model(self) -> dict[str, Any]:
+        return self.retrieval_model or {"top_k": 2, "score_threshold": 0.0}
+
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +166,6 @@ class DatasetRetrieval:
             query = request.query if request.query is not None else ""
 
             metadata_filter_document_ids, metadata_condition = self.get_metadata_filter_condition(
-                session=session,
                 dataset_ids=available_datasets_ids,
                 query=query,
                 tenant_id=request.tenant_id,
@@ -217,7 +235,6 @@ class DatasetRetrieval:
                 stop=stop,
             )
             all_documents = self.single_retrieve(
-                session,
                 request.app_id,
                 request.tenant_id,
                 request.user_id,
@@ -277,7 +294,11 @@ class DatasetRetrieval:
         # deal with dify documents
         if dify_documents:
             with Session(bind=session.get_bind()) as format_session:
-                records = RetrievalService.format_retrieval_documents(format_session, dify_documents)
+                records = RetrievalService.format_retrieval_documents(
+                    format_session,
+                    dify_documents,
+                    allowed_dataset_ids={dataset.id for dataset in available_datasets},
+                )
             dataset_ids = [i.segment.dataset_id for i in records]
             document_ids = [i.segment.document_id for i in records]
 
@@ -425,7 +446,6 @@ class DatasetRetrieval:
             inputs = {}
         available_datasets_ids = [dataset.id for dataset in available_datasets]
         metadata_filter_document_ids, metadata_condition = self.get_metadata_filter_condition(
-            session,
             available_datasets_ids,
             query,
             tenant_id,
@@ -440,7 +460,6 @@ class DatasetRetrieval:
         user_from = "account" if invoke_from in {InvokeFrom.EXPLORE, InvokeFrom.DEBUGGER} else "end_user"
         if retrieve_config.retrieve_strategy == DatasetRetrieveConfigEntity.RetrieveStrategy.SINGLE:
             all_documents = self.single_retrieve(
-                session,
                 app_id,
                 tenant_id,
                 user_id,
@@ -495,7 +514,11 @@ class DatasetRetrieval:
         # deal with dify documents
         if dify_documents:
             with Session(bind=session.get_bind()) as format_session:
-                records = RetrievalService.format_retrieval_documents(format_session, dify_documents)
+                records = RetrievalService.format_retrieval_documents(
+                    format_session,
+                    dify_documents,
+                    allowed_dataset_ids=set(available_datasets_ids),
+                )
             if records:
                 for record in records:
                     segment = record.segment
@@ -604,7 +627,6 @@ class DatasetRetrieval:
     @trace_span()
     def single_retrieve(
         self,
-        session: Session,
         app_id: str,
         tenant_id: str,
         user_id: str,
@@ -650,19 +672,19 @@ class DatasetRetrieval:
         self._record_usage(router_usage)
         timer = None
         if dataset_id:
-            # get retrieval model config
-            dataset_stmt = select(Dataset).where(Dataset.id == dataset_id)
-            selected_dataset = session.scalar(dataset_stmt)
+            selected_dataset = self._get_dataset_retrieval_config(dataset_id, tenant_id)
             if selected_dataset:
                 results = []
                 if selected_dataset.provider == "external":
+                    if selected_dataset.external_knowledge_config is None:
+                        raise RuntimeError("External knowledge configuration was not resolved")
                     external_documents = ExternalDatasetService.fetch_external_knowledge_retrieval(
-                        session=session,
                         tenant_id=selected_dataset.tenant_id,
                         dataset_id=dataset_id,
                         query=query,
-                        external_retrieval_parameters=selected_dataset.retrieval_model,
+                        external_retrieval_parameters=selected_dataset.external_retrieval_model,
                         metadata_condition=metadata_condition,
+                        resolved_config=selected_dataset.external_knowledge_config,
                     )
                     for external_document in external_documents:
                         document = Document(
@@ -739,6 +761,46 @@ class DatasetRetrieval:
 
                 return results
         return []
+
+    @staticmethod
+    def _get_dataset_retrieval_config(dataset_id: str, tenant_id: str) -> _DatasetRetrievalConfig | None:
+        """Copy retrieval configuration to plain values before provider or vector I/O."""
+        dataset_stmt = (
+            select(Dataset)
+            .where(Dataset.id == dataset_id, Dataset.tenant_id == tenant_id)
+            .options(
+                load_only(
+                    Dataset.id,
+                    Dataset.tenant_id,
+                    Dataset.name,
+                    Dataset.provider,
+                    Dataset.retrieval_model,
+                    Dataset.indexing_technique,
+                )
+            )
+        )
+        with session_factory.create_session() as read_session:
+            dataset = read_session.scalar(dataset_stmt)
+            if dataset is None:
+                return None
+            external_knowledge_config = (
+                ExternalDatasetService.resolve_external_knowledge_config(
+                    tenant_id=dataset.tenant_id,
+                    dataset_id=dataset.id,
+                    session=read_session,
+                )
+                if dataset.provider == "external"
+                else None
+            )
+            return _DatasetRetrievalConfig(
+                id=dataset.id,
+                tenant_id=dataset.tenant_id,
+                name=dataset.name,
+                provider=dataset.provider,
+                retrieval_model=dataset.retrieval_model,
+                indexing_technique=dataset.indexing_technique,
+                external_knowledge_config=external_knowledge_config,
+            )
 
     @trace_span()
     def multiple_retrieve(
@@ -1103,14 +1165,36 @@ class DatasetRetrieval:
             if not dataset:
                 return []
 
-            if dataset.provider == "external" and query:
-                external_documents = ExternalDatasetService.fetch_external_knowledge_retrieval(
+            selected_dataset_id = dataset.id
+            dataset_provider = dataset.provider
+            retrieval_model_value = dataset.retrieval_model
+            indexing_technique = dataset.indexing_technique
+            dataset_tenant_id = dataset.tenant_id if dataset_provider == "external" else None
+            dataset_name = dataset.name if dataset_provider == "external" else None
+            external_knowledge_config = None
+            if dataset_provider == "external" and query:
+                assert dataset_tenant_id is not None
+                external_knowledge_config = ExternalDatasetService.resolve_external_knowledge_config(
+                    tenant_id=dataset_tenant_id,
+                    dataset_id=selected_dataset_id,
                     session=session,
-                    tenant_id=dataset.tenant_id,
+                )
+            # Reuse this worker transaction for all database-backed retrieval configuration, then end it before
+            # provider, embedding, reranking, or vector I/O.
+            session.commit()
+
+            if dataset_provider == "external" and query:
+                if external_knowledge_config is None:
+                    raise RuntimeError("External knowledge configuration was not resolved")
+                if dataset_tenant_id is None or dataset_name is None:
+                    raise RuntimeError("External dataset values were not resolved")
+                external_documents = ExternalDatasetService.fetch_external_knowledge_retrieval(
+                    tenant_id=dataset_tenant_id,
                     dataset_id=dataset_id,
                     query=query,
-                    external_retrieval_parameters=dataset.retrieval_model,
+                    external_retrieval_parameters=retrieval_model_value,
                     metadata_condition=metadata_condition,
+                    resolved_config=external_knowledge_config,
                 )
                 for external_document in external_documents:
                     document = Document(
@@ -1122,21 +1206,21 @@ class DatasetRetrieval:
                         document.metadata["score"] = external_document.get("score")
                         document.metadata["title"] = external_document.get("title")
                         document.metadata["dataset_id"] = dataset_id
-                        document.metadata["dataset_name"] = dataset.name
+                        document.metadata["dataset_name"] = dataset_name
                     all_documents.append(document)
             else:
                 # get retrieval model , if the model is not setting , using default
                 retrieval_model: DefaultRetrievalModelDict = (
-                    cast(DefaultRetrievalModelDict, dataset.retrieval_model)
-                    if dataset.retrieval_model
+                    cast(DefaultRetrievalModelDict, retrieval_model_value)
+                    if retrieval_model_value
                     else default_retrieval_model
                 )
 
-                if dataset.indexing_technique == IndexTechniqueType.ECONOMY:
+                if indexing_technique == IndexTechniqueType.ECONOMY:
                     # use keyword table query
                     documents = RetrievalService.retrieve(
                         retrieval_method=RetrievalMethod.KEYWORD_SEARCH,
-                        dataset_id=dataset.id,
+                        dataset_id=selected_dataset_id,
                         query=query,
                         top_k=top_k,
                         document_ids_filter=document_ids_filter,
@@ -1148,7 +1232,7 @@ class DatasetRetrieval:
                         # retrieval source
                         documents = RetrievalService.retrieve(
                             retrieval_method=retrieval_model["search_method"],
-                            dataset_id=dataset.id,
+                            dataset_id=selected_dataset_id,
                             query=query,
                             top_k=retrieval_model.get("top_k") or 4,
                             score_threshold=retrieval_model.get("score_threshold", 0.0)
@@ -1425,7 +1509,6 @@ class DatasetRetrieval:
 
     def get_metadata_filter_condition(
         self,
-        session: Session,
         dataset_ids: list[str],
         query: str,
         tenant_id: str,
@@ -1435,7 +1518,7 @@ class DatasetRetrieval:
         metadata_filtering_conditions: MetadataFilteringCondition | None,
         inputs: dict[str, Any],
     ) -> tuple[dict[str, list[str]] | None, MetadataFilteringCondition | None]:
-        document_query = select(DatasetDocument).where(
+        document_query = select(DatasetDocument.dataset_id, DatasetDocument.id).where(
             DatasetDocument.dataset_id.in_(dataset_ids),
             DatasetDocument.indexing_status == "completed",
             DatasetDocument.enabled == True,
@@ -1447,7 +1530,7 @@ class DatasetRetrieval:
             return None, None
         elif metadata_filtering_mode == "automatic":
             automatic_metadata_filters = self._automatic_metadata_filter_func(
-                session, dataset_ids, query, tenant_id, user_id, metadata_model_config
+                dataset_ids, query, tenant_id, user_id, metadata_model_config
             )
             if automatic_metadata_filters:
                 conditions = []
@@ -1506,11 +1589,12 @@ class DatasetRetrieval:
                 document_query = document_query.where(and_(*filters))
             else:
                 document_query = document_query.where(or_(*filters))
-        documents = session.scalars(document_query).all()
+        with session_factory.create_session() as read_session:
+            document_refs = read_session.execute(document_query).all()
         # group by dataset_id
-        metadata_filter_document_ids = defaultdict(list) if documents else None  # type: ignore
-        for document in documents:
-            metadata_filter_document_ids[document.dataset_id].append(document.id)  # type: ignore
+        metadata_filter_document_ids = defaultdict(list) if document_refs else None  # type: ignore
+        for dataset_id, document_id in document_refs:
+            metadata_filter_document_ids[dataset_id].append(document_id)  # type: ignore
         return metadata_filter_document_ids, metadata_condition
 
     def _replace_metadata_filter_value(self, text: str, inputs: dict[str, Any]) -> str:
@@ -1529,7 +1613,6 @@ class DatasetRetrieval:
 
     def _automatic_metadata_filter_func(
         self,
-        session: Session,
         dataset_ids: list[str],
         query: str,
         tenant_id: str,
@@ -1537,9 +1620,10 @@ class DatasetRetrieval:
         metadata_model_config: ModelConfig,
     ) -> list[dict[str, Any]] | None:
         # get all metadata field
-        metadata_stmt = select(DatasetMetadata).where(DatasetMetadata.dataset_id.in_(dataset_ids))
-        metadata_fields = session.scalars(metadata_stmt).all()
-        all_metadata_fields = [metadata_field.name for metadata_field in metadata_fields]
+        metadata_stmt = select(DatasetMetadata.name).where(DatasetMetadata.dataset_id.in_(dataset_ids))
+        with session_factory.create_session() as read_session:
+            metadata_fields = read_session.scalars(metadata_stmt).all()
+        all_metadata_fields = list(metadata_fields)
         # get metadata model config
         if metadata_model_config is None:
             raise ValueError("metadata_model_config is required")

--- a/api/core/rag/summary_index/summary_index.py
+++ b/api/core/rag/summary_index/summary_index.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from core.db.session_factory import session_factory
 from core.rag.index_processor.constant.index_type import IndexTechniqueType
 from core.rag.index_processor.index_processor_base import SummaryIndexSettingDict
-from models.dataset import Dataset, Document, DocumentSegment, DocumentSegmentSummary
+from models.dataset import Dataset, Document, DocumentSegment
 from services.summary_index_service import SummaryIndexService
 from tasks.generate_summary_index_task import generate_summary_index_task
 
@@ -54,14 +54,14 @@ class SummaryIndex:
                 if not segment_ids:
                     return
 
-                existing_summaries = session.scalars(
-                    select(DocumentSegmentSummary).where(
-                        DocumentSegmentSummary.chunk_id.in_(segment_ids),
-                        DocumentSegmentSummary.dataset_id == dataset_id,
-                        DocumentSegmentSummary.status == "completed",
-                    )
-                ).all()
-                completed_summary_segment_ids = {i.chunk_id for i in existing_summaries}
+                existing_summaries = SummaryIndexService.get_segments_summaries(
+                    segment_ids,
+                    dataset_id,
+                    session=session,
+                )
+                completed_summary_segment_ids = {
+                    segment_id for segment_id, summary in existing_summaries.items() if summary.status == "completed"
+                }
                 # Preview mode should process segments that are MISSING completed summaries
                 pending_segment_ids = [sid for sid in segment_ids if sid not in completed_summary_segment_ids]
 

--- a/api/core/tools/utils/dataset_retriever/dataset_retriever_tool.py
+++ b/api/core/tools/utils/dataset_retriever/dataset_retriever_tool.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from core.app.app_config.entities import DatasetRetrieveConfigEntity, ModelConfig
+from core.db.session_factory import session_factory
 from core.rag.datasource.retrieval_service import DefaultRetrievalModelDict, RetrievalService
 from core.rag.entities import DocumentContext, RetrievalSourceMetadata
 from core.rag.index_processor.constant.index_type import IndexTechniqueType
@@ -59,7 +60,20 @@ class DatasetRetrieverTool(DatasetRetrieverBaseTool):
     @override
     def _run(self, session: Session, query: str) -> str:
         dataset_stmt = select(Dataset).where(Dataset.tenant_id == self.tenant_id, Dataset.id == self.dataset_id)
-        dataset = session.scalar(dataset_stmt)
+        # Workflow tools may be consumed inside an outer ``Session.begin()``.
+        # Keep the tool-owned session untouched so model/vector/provider I/O
+        # cannot retain that transaction's connection.
+        with session_factory.create_session() as read_session:
+            dataset = read_session.scalar(dataset_stmt)
+            external_knowledge_config = (
+                ExternalDatasetService.resolve_external_knowledge_config(
+                    tenant_id=dataset.tenant_id,
+                    dataset_id=dataset.id,
+                    session=read_session,
+                )
+                if dataset is not None and dataset.provider == "external"
+                else None
+            )
 
         if not dataset:
             return ""
@@ -67,7 +81,6 @@ class DatasetRetrieverTool(DatasetRetrieverBaseTool):
             hit_callback.on_query(query, dataset.id, session)
         dataset_retrieval = DatasetRetrieval()
         metadata_filter_document_ids, metadata_condition = dataset_retrieval.get_metadata_filter_condition(
-            session,
             [dataset.id],
             query,
             self.tenant_id,
@@ -82,14 +95,16 @@ class DatasetRetrieverTool(DatasetRetrieverBaseTool):
         else:
             document_ids_filter = None
         if dataset.provider == "external":
+            if external_knowledge_config is None:
+                raise RuntimeError("External knowledge configuration was not resolved")
             results: list[RetrievalDocument] = []
             external_documents = ExternalDatasetService.fetch_external_knowledge_retrieval(
-                session=session,
                 tenant_id=dataset.tenant_id,
                 dataset_id=dataset.id,
                 query=query,
                 external_retrieval_parameters=dataset.retrieval_model,
                 metadata_condition=metadata_condition,
+                resolved_config=external_knowledge_config,
             )
             for external_document in external_documents:
                 document = RetrievalDocument(
@@ -169,7 +184,11 @@ class DatasetRetrieverTool(DatasetRetrieverBaseTool):
                             document_score_list[item.metadata["doc_id"]] = item.metadata["score"]
                 document_context_list: list[DocumentContext] = []
                 with Session(bind=session.get_bind()) as format_session:
-                    records = RetrievalService.format_retrieval_documents(format_session, documents)
+                    records = RetrievalService.format_retrieval_documents(
+                        format_session,
+                        documents,
+                        allowed_dataset_ids={dataset.id},
+                    )
                 if records:
                     for record in records:
                         segment = record.segment

--- a/api/providers/vdb/vdb-qdrant/src/dify_vdb_qdrant/qdrant_vector.py
+++ b/api/providers/vdb/vdb-qdrant/src/dify_vdb_qdrant/qdrant_vector.py
@@ -21,13 +21,13 @@ from qdrant_client.local.qdrant_local import QdrantLocal
 from sqlalchemy import select
 
 from configs import dify_config
+from core.db.session_factory import session_factory
 from core.rag.datasource.vdb.field import Field
 from core.rag.datasource.vdb.vector_base import BaseVector, VectorIndexStructDict
 from core.rag.datasource.vdb.vector_factory import AbstractVectorFactory
 from core.rag.datasource.vdb.vector_type import VectorType
 from core.rag.embedding.embedding_base import Embeddings
 from core.rag.models.document import Document
-from extensions.ext_database import db
 from extensions.ext_redis import redis_client
 from models.dataset import Dataset, DatasetCollectionBinding
 
@@ -499,10 +499,13 @@ class QdrantVectorFactory(AbstractVectorFactory):
     @override
     def init_vector(self, dataset: Dataset, attributes: list, embeddings: Embeddings) -> QdrantVector:
         if dataset.collection_binding_id:
-            stmt = select(DatasetCollectionBinding).where(DatasetCollectionBinding.id == dataset.collection_binding_id)
-            dataset_collection_binding = db.session.scalars(stmt).one_or_none()
-            if dataset_collection_binding:
-                collection_name = dataset_collection_binding.collection_name
+            stmt = select(DatasetCollectionBinding.collection_name).where(
+                DatasetCollectionBinding.id == dataset.collection_binding_id
+            )
+            with session_factory.create_session() as session:
+                collection_name = session.scalar(stmt)
+            if collection_name:
+                collection_name = str(collection_name)
             else:
                 raise ValueError("Dataset Collection Bindings does not exist!")
         else:

--- a/api/providers/vdb/vdb-qdrant/tests/unit_tests/test_qdrant_vector.py
+++ b/api/providers/vdb/vdb-qdrant/tests/unit_tests/test_qdrant_vector.py
@@ -3,13 +3,45 @@ import os
 import sys
 import types
 from collections import UserDict
+from contextlib import nullcontext
 from types import SimpleNamespace
-from typing import override
+from typing import Any, override
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from core.rag.embedding.embedding_base import Embeddings
 from core.rag.models.document import Document
+from models.dataset import Dataset
+
+
+def _dataset() -> Dataset:
+    dataset = Dataset()
+    dataset.id = "dataset-1"
+    dataset.tenant_id = "tenant-1"
+    dataset.collection_binding_id = None
+    dataset.index_struct = None
+    return dataset
+
+
+class _UnusedEmbeddings(Embeddings):
+    """Concrete embedding dependency for factory tests that never request embeddings."""
+
+    @override
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        raise AssertionError("embed_documents should not be called")
+
+    @override
+    def embed_multimodal_documents(self, multimodel_documents: list[dict[str, Any]]) -> list[list[float]]:
+        raise AssertionError("embed_multimodal_documents should not be called")
+
+    @override
+    def embed_query(self, text: str) -> list[float]:
+        raise AssertionError("embed_query should not be called")
+
+    @override
+    def embed_multimodal_query(self, multimodel_document: dict[str, Any]) -> list[float]:
+        raise AssertionError("embed_multimodal_query should not be called")
 
 
 def _build_fake_qdrant_modules():
@@ -91,26 +123,30 @@ def _build_fake_qdrant_modules():
             super().__init__(**kwargs)
             self._load = MagicMock()
 
-    qdrant_client.QdrantClient = QdrantClient
-    qdrant_http_models.FilterSelector = FilterSelector
-    qdrant_http_models.HnswConfigDiff = HnswConfigDiff
-    qdrant_http_models.PayloadSchemaType = SimpleNamespace(KEYWORD="KEYWORD")
-    qdrant_http_models.TextIndexParams = TextIndexParams
-    qdrant_http_models.TextIndexType = SimpleNamespace(TEXT="TEXT")
-    qdrant_http_models.TokenizerType = SimpleNamespace(MULTILINGUAL="MULTILINGUAL")
-    qdrant_http_models.VectorParams = VectorParams
-    qdrant_http_models.Distance = _Distance()
-    qdrant_http_models.PointStruct = PointStruct
-    qdrant_http_models.Filter = Filter
-    qdrant_http_models.FieldCondition = FieldCondition
-    qdrant_http_models.MatchValue = MatchValue
-    qdrant_http_models.MatchAny = MatchAny
-    qdrant_http_models.MatchText = MatchText
-    qdrant_http_exceptions.UnexpectedResponse = UnexpectedResponseError
+    vars(qdrant_client).update({"QdrantClient": QdrantClient})
+    vars(qdrant_http_models).update(
+        {
+            "FilterSelector": FilterSelector,
+            "HnswConfigDiff": HnswConfigDiff,
+            "PayloadSchemaType": SimpleNamespace(KEYWORD="KEYWORD"),
+            "TextIndexParams": TextIndexParams,
+            "TextIndexType": SimpleNamespace(TEXT="TEXT"),
+            "TokenizerType": SimpleNamespace(MULTILINGUAL="MULTILINGUAL"),
+            "VectorParams": VectorParams,
+            "Distance": _Distance(),
+            "PointStruct": PointStruct,
+            "Filter": Filter,
+            "FieldCondition": FieldCondition,
+            "MatchValue": MatchValue,
+            "MatchAny": MatchAny,
+            "MatchText": MatchText,
+        }
+    )
+    vars(qdrant_http_exceptions).update({"UnexpectedResponse": UnexpectedResponseError})
 
-    qdrant_http.models = qdrant_http_models
-    qdrant_local_mod.QdrantLocal = QdrantLocal
-    qdrant_local_pkg.qdrant_local = qdrant_local_mod
+    vars(qdrant_http).update({"models": qdrant_http_models})
+    vars(qdrant_local_mod).update({"QdrantLocal": QdrantLocal})
+    vars(qdrant_local_pkg).update({"qdrant_local": qdrant_local_mod})
 
     return {
         "qdrant_client": qdrant_client,
@@ -292,13 +328,8 @@ def test_search_and_helper_methods(qdrant_module):
 
 def test_qdrant_factory_paths(qdrant_module, monkeypatch: pytest.MonkeyPatch):
     factory = qdrant_module.QdrantVectorFactory()
-    dataset = SimpleNamespace(
-        id="dataset-1",
-        tenant_id="tenant-1",
-        collection_binding_id=None,
-        index_struct_dict=None,
-        index_struct=None,
-    )
+    dataset = _dataset()
+    embeddings = _UnusedEmbeddings()
     monkeypatch.setattr(qdrant_module.Dataset, "gen_collection_name_by_id", lambda _id: "AUTO_COLLECTION")
     monkeypatch.setattr(qdrant_module, "current_app", SimpleNamespace(config=SimpleNamespace(root_path="/root")))
     monkeypatch.setattr(qdrant_module.dify_config, "QDRANT_URL", "http://localhost:6333")
@@ -309,22 +340,22 @@ def test_qdrant_factory_paths(qdrant_module, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(qdrant_module.dify_config, "QDRANT_REPLICATION_FACTOR", 1)
 
     with patch.object(qdrant_module, "QdrantVector", return_value="vector") as vector_cls:
-        result = factory.init_vector(dataset, attributes=[], embeddings=MagicMock())
+        result = factory.init_vector(dataset, attributes=[], embeddings=embeddings)
     assert result == "vector"
     assert vector_cls.call_args.kwargs["collection_name"] == "AUTO_COLLECTION"
     assert dataset.index_struct is not None
 
     # collection binding lookup path
     dataset.collection_binding_id = "binding-1"
-    dataset.index_struct_dict = {"vector_store": {"class_prefix": "existing"}}
-    monkeypatch.setattr(qdrant_module, "select", lambda _model: SimpleNamespace(where=lambda *_args: "stmt"))
-    qdrant_module.db.session.scalars = MagicMock(
-        return_value=SimpleNamespace(one_or_none=lambda: SimpleNamespace(collection_name="BOUND_COLLECTION"))
-    )
+    binding_session = MagicMock()
+    binding_session.scalar.return_value = "BOUND_COLLECTION"
+    create_session = MagicMock(return_value=nullcontext(binding_session))
+    monkeypatch.setattr(qdrant_module.session_factory, "create_session", create_session)
     with patch.object(qdrant_module, "QdrantVector", return_value="vector") as vector_cls:
-        factory.init_vector(dataset, attributes=[], embeddings=MagicMock())
+        factory.init_vector(dataset, attributes=[], embeddings=embeddings)
     assert vector_cls.call_args.kwargs["collection_name"] == "BOUND_COLLECTION"
+    create_session.assert_called_once_with()
 
-    qdrant_module.db.session.scalars = MagicMock(return_value=SimpleNamespace(one_or_none=lambda: None))
+    binding_session.scalar.return_value = None
     with pytest.raises(ValueError, match="Dataset Collection Bindings does not exist"):
-        factory.init_vector(dataset, attributes=[], embeddings=MagicMock())
+        factory.init_vector(dataset, attributes=[], embeddings=embeddings)

--- a/api/providers/vdb/vdb-tidb-on-qdrant/src/dify_vdb_tidb_on_qdrant/tidb_on_qdrant_vector.py
+++ b/api/providers/vdb/vdb-tidb-on-qdrant/src/dify_vdb_tidb_on_qdrant/tidb_on_qdrant_vector.py
@@ -3,6 +3,7 @@ import logging
 import os
 import uuid
 from collections.abc import Generator, Iterable, Sequence
+from dataclasses import dataclass
 from itertools import islice
 from typing import TYPE_CHECKING, Any, override
 
@@ -26,6 +27,7 @@ from qdrant_client.local.qdrant_local import QdrantLocal
 from sqlalchemy import select
 
 from configs import dify_config
+from core.db.session_factory import session_factory
 from core.rag.datasource.vdb.field import Field
 from core.rag.datasource.vdb.vector_base import BaseVector, VectorIndexStructDict
 from core.rag.datasource.vdb.vector_factory import AbstractVectorFactory
@@ -33,7 +35,6 @@ from core.rag.datasource.vdb.vector_type import VectorType
 from core.rag.embedding.embedding_base import Embeddings
 from core.rag.models.document import Document
 from dify_vdb_tidb_on_qdrant.tidb_service import TidbService
-from extensions.ext_database import db
 from extensions.ext_redis import redis_client
 from models.dataset import Dataset, TidbAuthBinding
 from models.enums import TidbAuthBindingStatus
@@ -80,6 +81,23 @@ class TidbConfig(BaseModel):
     api_url: str
     public_key: str
     private_key: str
+
+
+@dataclass(frozen=True)
+class _TidbBindingConfig:
+    cluster_id: str
+    account: str
+    password: str
+    qdrant_endpoint: str | None
+
+
+@dataclass(frozen=True)
+class _ProvisionedTidbCluster:
+    cluster_id: str
+    cluster_name: str
+    account: str
+    password: str
+    qdrant_endpoint: str | None
 
 
 class TidbOnQdrantVector(BaseVector):
@@ -431,38 +449,80 @@ class TidbOnQdrantVector(BaseVector):
 
 
 class TidbOnQdrantVectorFactory(AbstractVectorFactory):
+    @staticmethod
+    def _binding_config(binding: TidbAuthBinding) -> _TidbBindingConfig:
+        return _TidbBindingConfig(
+            cluster_id=binding.cluster_id,
+            account=binding.account,
+            password=binding.password,
+            qdrant_endpoint=binding.qdrant_endpoint,
+        )
+
+    @classmethod
+    def _load_tenant_binding(cls, tenant_id: str) -> _TidbBindingConfig | None:
+        with session_factory.create_session() as session:
+            binding = session.scalars(
+                select(TidbAuthBinding).where(TidbAuthBinding.tenant_id == tenant_id)
+            ).one_or_none()
+            return cls._binding_config(binding) if binding is not None else None
+
+    @staticmethod
+    def _provisioned_cluster(response: object, tenant_id: str) -> _ProvisionedTidbCluster:
+        if not isinstance(response, dict):
+            raise RuntimeError(f"TiDB provisioning returned an invalid cluster response for tenant {tenant_id}")
+
+        required_values: dict[str, str] = {}
+        for field_name in ("cluster_id", "cluster_name", "account", "password"):
+            field_value = response.get(field_name)
+            if not isinstance(field_value, str) or not field_value:
+                raise RuntimeError(f"TiDB provisioning returned an invalid cluster response for tenant {tenant_id}")
+            required_values[field_name] = field_value
+
+        qdrant_endpoint = response.get("qdrant_endpoint")
+        if qdrant_endpoint is not None and not isinstance(qdrant_endpoint, str):
+            raise RuntimeError(f"TiDB provisioning returned an invalid cluster response for tenant {tenant_id}")
+
+        return _ProvisionedTidbCluster(
+            cluster_id=required_values["cluster_id"],
+            cluster_name=required_values["cluster_name"],
+            account=required_values["account"],
+            password=required_values["password"],
+            qdrant_endpoint=qdrant_endpoint,
+        )
+
     @override
     def init_vector(self, dataset: Dataset, attributes: list, embeddings: Embeddings) -> TidbOnQdrantVector:
         logger.info("init_vector: tenant_id=%s, dataset_id=%s", dataset.tenant_id, dataset.id)
-        stmt = select(TidbAuthBinding).where(TidbAuthBinding.tenant_id == dataset.tenant_id)
-        tidb_auth_binding = db.session.scalars(stmt).one_or_none()
-        if not tidb_auth_binding:
+        binding_config = self._load_tenant_binding(dataset.tenant_id)
+        if binding_config is None:
             logger.info("No existing TidbAuthBinding for tenant %s, acquiring lock", dataset.tenant_id)
             with redis_client.lock("create_tidb_serverless_cluster_lock", timeout=900):
-                stmt = select(TidbAuthBinding).where(TidbAuthBinding.tenant_id == dataset.tenant_id)
-                tidb_auth_binding = db.session.scalars(stmt).one_or_none()
-                if tidb_auth_binding:
-                    logger.info("Found binding after lock: cluster_id=%s", tidb_auth_binding.cluster_id)
-                    TIDB_ON_QDRANT_API_KEY = f"{tidb_auth_binding.account}:{tidb_auth_binding.password}"
-
+                binding_config = self._load_tenant_binding(dataset.tenant_id)
+                if binding_config is not None:
+                    logger.info("Found binding after lock: cluster_id=%s", binding_config.cluster_id)
                 else:
-                    idle_tidb_auth_binding = db.session.scalar(
-                        select(TidbAuthBinding)
-                        .where(TidbAuthBinding.active == False, TidbAuthBinding.status == "ACTIVE")
-                        .limit(1)
-                    )
-                    if idle_tidb_auth_binding:
-                        logger.info(
-                            "Assigning idle cluster %s to tenant %s",
-                            idle_tidb_auth_binding.cluster_id,
-                            dataset.tenant_id,
+                    with session_factory.create_session() as session:
+                        idle_tidb_auth_binding = session.scalar(
+                            select(TidbAuthBinding)
+                            .where(TidbAuthBinding.active == False, TidbAuthBinding.status == "ACTIVE")
+                            .limit(1)
+                            .with_for_update()
                         )
-                        idle_tidb_auth_binding.active = True
-                        idle_tidb_auth_binding.tenant_id = dataset.tenant_id
-                        db.session.commit()
-                        tidb_auth_binding = idle_tidb_auth_binding
-                        TIDB_ON_QDRANT_API_KEY = f"{idle_tidb_auth_binding.account}:{idle_tidb_auth_binding.password}"
-                    else:
+                        if idle_tidb_auth_binding is not None:
+                            logger.info(
+                                "Assigning idle cluster %s to tenant %s",
+                                idle_tidb_auth_binding.cluster_id,
+                                dataset.tenant_id,
+                            )
+                            idle_tidb_auth_binding.active = True
+                            idle_tidb_auth_binding.tenant_id = dataset.tenant_id
+                            session.commit()
+                            binding_config = self._binding_config(idle_tidb_auth_binding)
+
+                    # Cluster provisioning is external I/O and must not retain
+                    # either the request-scoped session or the short binding
+                    # lookup transaction above.
+                    if binding_config is None:
                         logger.info("No idle clusters available, creating new cluster for tenant %s", dataset.tenant_id)
                         new_cluster = TidbService.create_tidb_serverless_cluster(
                             dify_config.TIDB_PROJECT_ID or "",
@@ -472,36 +532,46 @@ class TidbOnQdrantVectorFactory(AbstractVectorFactory):
                             dify_config.TIDB_PRIVATE_KEY or "",
                             dify_config.TIDB_REGION or "",
                         )
+                        if new_cluster is None:
+                            raise RuntimeError(
+                                f"TiDB provisioning did not return an active cluster for tenant {dataset.tenant_id}"
+                            )
+                        provisioned_cluster = self._provisioned_cluster(new_cluster, dataset.tenant_id)
                         logger.info(
                             "New cluster created: cluster_id=%s, qdrant_endpoint=%s",
-                            new_cluster["cluster_id"],
-                            new_cluster.get("qdrant_endpoint"),
+                            provisioned_cluster.cluster_id,
+                            provisioned_cluster.qdrant_endpoint,
                         )
                         new_tidb_auth_binding = TidbAuthBinding(
-                            cluster_id=new_cluster["cluster_id"],
-                            cluster_name=new_cluster["cluster_name"],
-                            account=new_cluster["account"],
-                            password=new_cluster["password"],
-                            qdrant_endpoint=new_cluster.get("qdrant_endpoint"),
+                            cluster_id=provisioned_cluster.cluster_id,
+                            cluster_name=provisioned_cluster.cluster_name,
+                            account=provisioned_cluster.account,
+                            password=provisioned_cluster.password,
+                            qdrant_endpoint=provisioned_cluster.qdrant_endpoint,
                             tenant_id=dataset.tenant_id,
                             active=True,
                             status=TidbAuthBindingStatus.ACTIVE,
                         )
-                        db.session.add(new_tidb_auth_binding)
-                        db.session.commit()
-                        tidb_auth_binding = new_tidb_auth_binding
-                        TIDB_ON_QDRANT_API_KEY = f"{new_tidb_auth_binding.account}:{new_tidb_auth_binding.password}"
+                        with session_factory.create_session() as session:
+                            session.add(new_tidb_auth_binding)
+                            session.commit()
+                        binding_config = _TidbBindingConfig(
+                            cluster_id=provisioned_cluster.cluster_id,
+                            account=provisioned_cluster.account,
+                            password=provisioned_cluster.password,
+                            qdrant_endpoint=provisioned_cluster.qdrant_endpoint,
+                        )
         else:
-            logger.info("Existing binding found: cluster_id=%s", tidb_auth_binding.cluster_id)
-            TIDB_ON_QDRANT_API_KEY = f"{tidb_auth_binding.account}:{tidb_auth_binding.password}"
+            logger.info("Existing binding found: cluster_id=%s", binding_config.cluster_id)
 
-        qdrant_url = (
-            (tidb_auth_binding.qdrant_endpoint if tidb_auth_binding else None) or dify_config.TIDB_ON_QDRANT_URL or ""
-        )
+        if binding_config is None:
+            raise RuntimeError(f"Failed to resolve TiDB binding for tenant {dataset.tenant_id}")
+        tidb_on_qdrant_api_key = f"{binding_config.account}:{binding_config.password}"
+        qdrant_url = binding_config.qdrant_endpoint or dify_config.TIDB_ON_QDRANT_URL or ""
         logger.info(
             "Using qdrant endpoint: %s (from_binding=%s, fallback_global=%s)",
             qdrant_url,
-            tidb_auth_binding.qdrant_endpoint if tidb_auth_binding else None,
+            binding_config.qdrant_endpoint,
             dify_config.TIDB_ON_QDRANT_URL,
         )
 
@@ -520,7 +590,7 @@ class TidbOnQdrantVectorFactory(AbstractVectorFactory):
             group_id=dataset.id,
             config=TidbOnQdrantConfig(
                 endpoint=qdrant_url,
-                api_key=TIDB_ON_QDRANT_API_KEY,
+                api_key=tidb_on_qdrant_api_key,
                 root_path=str(config.root_path),
                 timeout=dify_config.TIDB_ON_QDRANT_CLIENT_TIMEOUT,
                 grpc_port=dify_config.TIDB_ON_QDRANT_GRPC_PORT,

--- a/api/providers/vdb/vdb-tidb-on-qdrant/tests/unit_tests/test_tidb_on_qdrant_vector.py
+++ b/api/providers/vdb/vdb-tidb-on-qdrant/tests/unit_tests/test_tidb_on_qdrant_vector.py
@@ -1,13 +1,48 @@
-from unittest.mock import patch
+from contextlib import nullcontext
+from typing import Any, override
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
 from dify_vdb_tidb_on_qdrant.tidb_on_qdrant_vector import (
     TidbOnQdrantConfig,
     TidbOnQdrantVector,
+    TidbOnQdrantVectorFactory,
 )
+from dify_vdb_tidb_on_qdrant.tidb_service import TidbService
 from qdrant_client.http import models as rest
 from qdrant_client.http.exceptions import UnexpectedResponse
+
+from core.rag.embedding.embedding_base import Embeddings
+from models.dataset import Dataset, TidbAuthBinding
+from models.enums import TidbAuthBindingStatus
+
+
+def _dataset() -> Dataset:
+    dataset = Dataset()
+    dataset.id = "dataset-1"
+    dataset.tenant_id = "tenant-1"
+    return dataset
+
+
+class _UnusedEmbeddings(Embeddings):
+    """Concrete embedding dependency for factory tests that never request embeddings."""
+
+    @override
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        raise AssertionError("embed_documents should not be called")
+
+    @override
+    def embed_multimodal_documents(self, multimodel_documents: list[dict[str, Any]]) -> list[list[float]]:
+        raise AssertionError("embed_multimodal_documents should not be called")
+
+    @override
+    def embed_query(self, text: str) -> list[float]:
+        raise AssertionError("embed_query should not be called")
+
+    @override
+    def embed_multimodal_query(self, multimodel_document: dict[str, Any]) -> list[float]:
+        raise AssertionError("embed_multimodal_query should not be called")
 
 
 class TestTidbOnQdrantVectorDeleteByIds:
@@ -175,6 +210,31 @@ class TestTidbOnQdrantVectorDeleteByIds:
 
 
 class TestInitVectorEndpointSelection:
+    def test_load_tenant_binding_requires_unambiguous_cardinality(self):
+        binding = TidbAuthBinding(
+            tenant_id="tenant-1",
+            cluster_id="cluster-1",
+            cluster_name="cluster-name-1",
+            active=True,
+            status=TidbAuthBindingStatus.ACTIVE,
+            account="account-1",
+            password="password-1",
+            qdrant_endpoint="https://qdrant.example.com",
+        )
+        session = MagicMock()
+        session.scalars.return_value.one_or_none.return_value = binding
+
+        with patch(
+            "dify_vdb_tidb_on_qdrant.tidb_on_qdrant_vector.session_factory.create_session",
+            return_value=nullcontext(session),
+        ):
+            config = TidbOnQdrantVectorFactory._load_tenant_binding("tenant-1")
+
+        assert config is not None
+        assert config.cluster_id == binding.cluster_id
+        session.scalars.return_value.one_or_none.assert_called_once_with()
+        session.scalar.assert_not_called()
+
     """Test that init_vector selects the correct qdrant endpoint.
 
     We avoid importing the full module (which triggers Flask app context)
@@ -226,3 +286,43 @@ class TestInitVectorEndpointSelection:
         qdrant_url = binding_endpoint or global_url or ""
 
         assert qdrant_url == "https://qdrant-global.tidb.com"
+
+    def test_provisioning_without_an_active_cluster_raises_explicitly(self):
+        factory = TidbOnQdrantVectorFactory()
+        dataset = _dataset()
+        session = MagicMock()
+        session.scalar.return_value = None
+
+        with (
+            patch.object(factory, "_load_tenant_binding", return_value=None),
+            patch(
+                "dify_vdb_tidb_on_qdrant.tidb_on_qdrant_vector.session_factory.create_session",
+                return_value=nullcontext(session),
+            ),
+            patch("dify_vdb_tidb_on_qdrant.tidb_on_qdrant_vector.redis_client.lock", return_value=nullcontext()),
+            patch.object(TidbService, "create_tidb_serverless_cluster", return_value=None),
+            pytest.raises(RuntimeError, match="did not return an active cluster"),
+        ):
+            factory.init_vector(dataset, [], _UnusedEmbeddings())
+
+    def test_provisioning_with_malformed_cluster_response_raises_explicitly(self):
+        factory = TidbOnQdrantVectorFactory()
+        dataset = _dataset()
+        session = MagicMock()
+        session.scalar.return_value = None
+
+        with (
+            patch.object(factory, "_load_tenant_binding", return_value=None),
+            patch(
+                "dify_vdb_tidb_on_qdrant.tidb_on_qdrant_vector.session_factory.create_session",
+                return_value=nullcontext(session),
+            ),
+            patch("dify_vdb_tidb_on_qdrant.tidb_on_qdrant_vector.redis_client.lock", return_value=nullcontext()),
+            patch.object(
+                TidbService,
+                "create_tidb_serverless_cluster",
+                return_value={"cluster_id": "cluster-1"},
+            ),
+            pytest.raises(RuntimeError, match="invalid cluster response"),
+        ):
+            factory.init_vector(dataset, [], _UnusedEmbeddings())

--- a/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
@@ -11,7 +11,8 @@ import json
 import logging
 import threading
 import uuid as _uuid
-from typing import Any, override
+from itertools import batched
+from typing import Any, cast, override
 from urllib.parse import urlparse
 
 import weaviate
@@ -20,7 +21,8 @@ from pydantic import BaseModel, model_validator
 from weaviate.classes.data import DataObject
 from weaviate.classes.init import Auth
 from weaviate.classes.query import Filter, MetadataQuery
-from weaviate.exceptions import UnexpectedStatusCodeError, WeaviateQueryError
+from weaviate.collections.classes.filters import FilterReturn
+from weaviate.exceptions import WeaviateQueryError
 
 from configs import dify_config
 from core.rag.datasource.vdb.field import Field
@@ -34,8 +36,17 @@ from models.dataset import Dataset
 
 logger = logging.getLogger(__name__)
 
+_DELETE_BATCH_SIZE = 500
+_DOC_ID_UUID_NAMESPACE = _uuid.UUID("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
+
 _weaviate_client: weaviate.WeaviateClient | None = None
 _weaviate_client_lock = threading.Lock()
+
+
+def _normalize_result_vector(value: object) -> list[float] | None:
+    if not isinstance(value, list) or not all(isinstance(item, int | float) for item in value):
+        return None
+    return [float(item) for item in cast(list[int | float], value)]
 
 
 def _shutdown_weaviate_client() -> None:
@@ -228,8 +239,16 @@ class WeaviateVector(BaseVector):
                                 data_type=wc.DataType.TEXT,
                                 tokenization=tokenization,
                             ),
-                            wc.Property(name="document_id", data_type=wc.DataType.TEXT),
-                            wc.Property(name="doc_id", data_type=wc.DataType.TEXT),
+                            wc.Property(
+                                name="document_id",
+                                data_type=wc.DataType.TEXT,
+                                tokenization=wc.Tokenization.FIELD,
+                            ),
+                            wc.Property(
+                                name="doc_id",
+                                data_type=wc.DataType.TEXT,
+                                tokenization=wc.Tokenization.FIELD,
+                            ),
                             wc.Property(name="doc_type", data_type=wc.DataType.TEXT),
                             wc.Property(name="chunk_index", data_type=wc.DataType.INT),
                             wc.Property(name="is_summary", data_type=wc.DataType.BOOL),
@@ -259,9 +278,11 @@ class WeaviateVector(BaseVector):
 
         to_add = []
         if "document_id" not in existing:
-            to_add.append(wc.Property(name="document_id", data_type=wc.DataType.TEXT))
+            to_add.append(
+                wc.Property(name="document_id", data_type=wc.DataType.TEXT, tokenization=wc.Tokenization.FIELD)
+            )
         if "doc_id" not in existing:
-            to_add.append(wc.Property(name="doc_id", data_type=wc.DataType.TEXT))
+            to_add.append(wc.Property(name="doc_id", data_type=wc.DataType.TEXT, tokenization=wc.Tokenization.FIELD))
         if "doc_type" not in existing:
             to_add.append(wc.Property(name="doc_type", data_type=wc.DataType.TEXT))
         if "chunk_index" not in existing:
@@ -277,18 +298,50 @@ class WeaviateVector(BaseVector):
             except Exception as e:
                 logger.warning("Could not add property %s: %s", prop.name, e)
 
+    @staticmethod
+    def _exact_text_filter(property_name: str, values: list[str]) -> FilterReturn | None:
+        """Match complete TEXT-property values without token-overlap leakage."""
+        unique_values = list(dict.fromkeys(value for value in values if value))
+        if not unique_values:
+            return None
+
+        combined = Filter.by_property(property_name).equal(unique_values[0])
+        for value in unique_values[1:]:
+            combined |= Filter.by_property(property_name).equal(value)
+        return combined
+
+    @staticmethod
+    def _build_search_filter(kwargs: dict[str, Any]) -> FilterReturn | None:
+        """Filter optional document IDs; the selected collection already scopes the dataset."""
+        document_ids = [str(document_id) for document_id in kwargs.get("document_ids_filter") or []]
+        return WeaviateVector._exact_text_filter("document_id", document_ids)
+
+    @staticmethod
+    def _matches_search_scope(properties: dict[str, Any], kwargs: dict[str, Any]) -> bool:
+        """Reject document-ID false positives from legacy collections that use WORD tokenization."""
+        document_ids = {str(document_id) for document_id in kwargs.get("document_ids_filter") or []}
+        if document_ids and str(properties.get("document_id") or "") not in document_ids:
+            return False
+        return True
+
     @override
-    def _get_uuids(self, documents: list[Document]) -> list[str]:
+    def _get_uuids(self, texts: list[Document]) -> list[str]:
         """
-        Generates deterministic UUIDs for documents based on their content.
+        Generates deterministic UUIDs from each durable metadata ``doc_id``.
 
-        Uses UUID5 with URL namespace to ensure consistent IDs for identical content.
+        UUID-shaped handles are preserved. Other handles are namespaced into a
+        UUID so identity never depends on document content and identical chunks
+        cannot overwrite one another.
         """
-        URL_NAMESPACE = _uuid.UUID("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
-
         uuids = []
-        for doc in documents:
-            uuid_val = _uuid.uuid5(URL_NAMESPACE, doc.page_content)
+        for doc in texts:
+            doc_id = doc.metadata.get("doc_id")
+            if doc_id is None or str(doc_id) == "":
+                raise ValueError("Document must contain a doc_id")
+            try:
+                uuid_val = _uuid.UUID(str(doc_id))
+            except (TypeError, ValueError, AttributeError):
+                uuid_val = _uuid.uuid5(_DOC_ID_UUID_NAMESPACE, str(doc_id))
             uuids.append(str(uuid_val))
 
         return uuids
@@ -298,14 +351,16 @@ class WeaviateVector(BaseVector):
         """
         Adds documents with their embeddings to the collection.
 
-        Batches insertions for efficiency and returns the list of inserted object IDs.
+        Canonical object UUIDs are derived from ``doc_id``. Existing canonical
+        objects are replaced, new objects are inserted in a checked batch, and
+        legacy content-derived UUIDs are retired only after publication succeeds.
         """
         uuids = self._get_uuids(documents)
         texts = [d.page_content for d in documents]
         metadatas = [d.metadata for d in documents]
 
         col = self._client.collections.use(self._collection_name)
-        objs: list[DataObject] = []
+        objs: list[DataObject[dict[str, Any]]] = []
         ids_out: list[str] = []
 
         for i, text in enumerate(texts):
@@ -330,11 +385,104 @@ class WeaviateVector(BaseVector):
                 )
             )
 
-        with col.batch.dynamic() as batch:
-            for obj in objs:
-                batch.add_object(properties=obj.properties, uuid=obj.uuid, vector=obj.vector)
+        doc_ids = [str(metadata["doc_id"]) for metadata in metadatas if metadata.get("doc_id")]
+        existing_uuids = self._get_object_uuids_by_doc_id(col, doc_ids)
+        objects_to_insert: list[DataObject[dict[str, Any]]] = []
+        for obj, metadata in zip(objs, metadatas):
+            doc_id = str(metadata["doc_id"]) if metadata.get("doc_id") else None
+            object_uuid = obj.uuid
+            object_properties = obj.properties
+            if object_uuid is None or object_properties is None:
+                raise RuntimeError("Weaviate data object is missing its UUID or properties")
+            if doc_id is not None and str(object_uuid) in existing_uuids.get(doc_id, set()):
+                col.data.replace(uuid=object_uuid, properties=object_properties, vector=obj.vector)
+            else:
+                objects_to_insert.append(obj)
+
+        if objects_to_insert:
+            with col.batch.dynamic() as batch:
+                for obj in objects_to_insert:
+                    batch.add_object(properties=obj.properties, uuid=obj.uuid, vector=obj.vector)
+            self._raise_for_batch_failures(col)
+
+        # Query again after canonical publication so a retry or mixed-version
+        # deployment can also retire legacy objects created concurrently.
+        canonical_uuid_by_doc_id = {
+            str(metadata["doc_id"]): str(obj.uuid) for obj, metadata in zip(objs, metadatas) if metadata.get("doc_id")
+        }
+        published_uuids = self._get_object_uuids_by_doc_id(col, list(canonical_uuid_by_doc_id))
+        legacy_uuids: list[str] = []
+        for doc_id, canonical_uuid in canonical_uuid_by_doc_id.items():
+            for object_uuid in published_uuids.get(doc_id, set()):
+                if object_uuid != canonical_uuid:
+                    legacy_uuids.append(object_uuid)
+        self._delete_object_uuids(col, legacy_uuids)
 
         return ids_out
+
+    def _get_object_uuids_by_property(
+        self,
+        col: Any,
+        property_name: str,
+        values: list[str],
+    ) -> dict[str, set[str]]:
+        """Return object UUIDs after exact client-side validation for legacy WORD-tokenized fields."""
+        object_uuids: dict[str, set[str]] = {}
+        unique_values = list(dict.fromkeys(value for value in values if value))
+        for value_batch in batched(unique_values, _DELETE_BATCH_SIZE):
+            value_filter = self._exact_text_filter(property_name, list(value_batch))
+            if value_filter is None:
+                continue
+            offset = 0
+            while True:
+                result = col.query.fetch_objects(
+                    filters=value_filter,
+                    limit=_DELETE_BATCH_SIZE,
+                    offset=offset,
+                    return_properties=[property_name],
+                    include_vector=False,
+                )
+                objects = list(result.objects or [])
+                for obj in objects:
+                    value = (obj.properties or {}).get(property_name)
+                    if value is not None and str(value) in value_batch:
+                        object_uuids.setdefault(str(value), set()).add(str(obj.uuid))
+                if len(objects) < _DELETE_BATCH_SIZE:
+                    break
+                # Weaviate 1.27 rejects cursor (``after``) pagination when a
+                # filter is present. Keep the result set stable until every
+                # UUID has been collected, then retire legacy objects.
+                offset += len(objects)
+        return object_uuids
+
+    def _get_object_uuids_by_doc_id(self, col: Any, doc_ids: list[str]) -> dict[str, set[str]]:
+        """Return every object UUID grouped by durable ``doc_id``."""
+        return self._get_object_uuids_by_property(col, "doc_id", doc_ids)
+
+    def _delete_object_uuids(self, col: Any, object_uuids: list[str]) -> None:
+        unique_uuids = list(dict.fromkeys(object_uuids))
+        for uuid_batch in batched(unique_uuids, _DELETE_BATCH_SIZE):
+            self._delete_many_checked(col, Filter.by_id().contains_any(list(uuid_batch)))
+
+    def _raise_for_batch_failures(self, col: Any) -> None:
+        """Raise when Weaviate reports object-level batch insertion errors."""
+        failed_objects = list(col.batch.failed_objects)
+        if not failed_objects:
+            return
+
+        messages = [failed_object.message for failed_object in failed_objects[:3]]
+        details = "; ".join(messages)
+        raise RuntimeError(f"Weaviate failed to insert {len(failed_objects)} object(s): {details}")
+
+    def _delete_many_checked(self, col: Any, where: FilterReturn) -> None:
+        """Delete matching objects and surface Weaviate's partial failures."""
+        result = col.data.delete_many(where=where, verbose=True)
+        failed = result.failed
+        if failed > 0:
+            raise RuntimeError(
+                f"Weaviate failed to delete {failed} of {result.matches} matching object(s) "
+                f"from collection {self._collection_name}"
+            )
 
     def _is_uuid(self, val: str) -> bool:
         """Validates whether a string is a valid UUID format."""
@@ -351,7 +499,8 @@ class WeaviateVector(BaseVector):
             return
 
         col = self._client.collections.use(self._collection_name)
-        col.data.delete_many(where=Filter.by_property(key).equal(value))
+        object_uuids = self._get_object_uuids_by_property(col, key, [value]).get(value, set())
+        self._delete_object_uuids(col, list(object_uuids))
 
     @override
     def delete(self):
@@ -366,32 +515,28 @@ class WeaviateVector(BaseVector):
             return False
 
         col = self._client.collections.use(self._collection_name)
-        res = col.query.fetch_objects(
-            filters=Filter.by_property("doc_id").equal(id),
-            limit=1,
-            return_properties=["doc_id"],
-        )
-
-        return len(res.objects) > 0
+        return bool(self._get_object_uuids_by_doc_id(col, [id]).get(id))
 
     @override
     def delete_by_ids(self, ids: list[str]) -> None:
         """
-        Deletes objects by their UUID identifiers.
+        Deletes objects by their durable metadata ``doc_id`` values.
 
-        Silently ignores 404 errors for non-existent IDs.
+        Historical Weaviate objects used content-derived object UUIDs, while the
+        application persisted ``doc_id`` as the deletion handle. Property-based
+        deletion therefore supports both historical objects and new summaries
+        whose object UUID is the same as ``doc_id``.
         """
-        if not self._client.collections.exists(self._collection_name):
+        unique_ids = list(dict.fromkeys(identifier for identifier in ids if identifier))
+        if not unique_ids or not self._client.collections.exists(self._collection_name):
             return
 
         col = self._client.collections.use(self._collection_name)
-
-        for uid in ids:
-            try:
-                col.data.delete_by_id(uid)
-            except UnexpectedStatusCodeError as e:
-                if getattr(e, "status_code", None) != 404:
-                    raise
+        object_uuids = self._get_object_uuids_by_doc_id(col, unique_ids)
+        self._delete_object_uuids(
+            col,
+            [object_uuid for doc_id in unique_ids for object_uuid in object_uuids.get(doc_id, set())],
+        )
 
     @override
     def search_by_vector(self, query_vector: list[float], **kwargs: Any) -> list[Document]:
@@ -407,51 +552,65 @@ class WeaviateVector(BaseVector):
         col = self._client.collections.use(self._collection_name)
         props = list({*self._attributes, self._DOCUMENT_ID_PROPERTY, Field.TEXT_KEY.value})
 
-        where = None
-        doc_ids = kwargs.get("document_ids_filter") or []
-        if doc_ids:
-            where = Filter.by_property(self._DOCUMENT_ID_PROPERTY).contains_any(doc_ids)
+        where = self._build_search_filter(kwargs)
 
         top_k = int(kwargs.get("top_k", 4))
+        if top_k <= 0:
+            return []
         score_threshold = float(kwargs.get("score_threshold") or 0.0)
 
-        try:
-            res = col.query.near_vector(
-                near_vector=query_vector,
-                limit=top_k,
-                return_properties=props,
-                return_metadata=MetadataQuery(distance=True),
-                include_vector=False,
-                filters=where,
-                target_vector="default",
-            )
-        except WeaviateQueryError:
-            self._ensure_properties()
-            res = col.query.near_vector(
-                near_vector=query_vector,
-                limit=top_k,
-                return_properties=props,
-                return_metadata=MetadataQuery(distance=True),
-                include_vector=False,
-                filters=where,
-                target_vector="default",
-            )
-
         docs: list[Document] = []
-        for obj in res.objects:
-            properties = dict(obj.properties or {})
-            text = properties.pop(Field.TEXT_KEY.value, "")
-            if obj.metadata and obj.metadata.distance is not None:
-                distance = obj.metadata.distance
-            else:
-                distance = 1.0
-            score = 1.0 - distance
+        offset = 0
+        while len(docs) < top_k:
+            try:
+                res = col.query.near_vector(
+                    near_vector=query_vector,
+                    limit=top_k,
+                    offset=offset,
+                    return_properties=props,
+                    return_metadata=MetadataQuery(distance=True),
+                    include_vector=False,
+                    filters=where,
+                    target_vector="default",
+                )
+            except WeaviateQueryError:
+                self._ensure_properties()
+                res = col.query.near_vector(
+                    near_vector=query_vector,
+                    limit=top_k,
+                    offset=offset,
+                    return_properties=props,
+                    return_metadata=MetadataQuery(distance=True),
+                    include_vector=False,
+                    filters=where,
+                    target_vector="default",
+                )
 
-            if score > score_threshold:
+            objects = list(res.objects or [])
+            score_threshold_reached = False
+            for obj in objects:
+                properties = dict(obj.properties or {})
+                if obj.metadata and obj.metadata.distance is not None:
+                    distance = obj.metadata.distance
+                else:
+                    distance = 1.0
+                score = 1.0 - distance
+                if score <= score_threshold:
+                    score_threshold_reached = True
+                    break
+                if not self._matches_search_scope(properties, kwargs):
+                    continue
+                text_value = properties.pop(Field.TEXT_KEY.value, "")
+                text = text_value if isinstance(text_value, str) else str(text_value or "")
                 properties["score"] = score
                 docs.append(Document(page_content=text, metadata=properties))
+                if len(docs) == top_k:
+                    break
 
-        docs.sort(key=lambda d: d.metadata.get("score", 0.0), reverse=True)
+            if len(docs) == top_k or score_threshold_reached or len(objects) < top_k:
+                break
+            offset += len(objects)
+
         return docs
 
     @override
@@ -467,43 +626,57 @@ class WeaviateVector(BaseVector):
         col = self._client.collections.use(self._collection_name)
         props = list({*self._attributes, Field.TEXT_KEY.value})
 
-        where = None
-        doc_ids = kwargs.get("document_ids_filter") or []
-        if doc_ids:
-            where = Filter.by_property(self._DOCUMENT_ID_PROPERTY).contains_any(doc_ids)
+        where = self._build_search_filter(kwargs)
 
         top_k = int(kwargs.get("top_k", 4))
-
-        try:
-            res = col.query.bm25(
-                query=query,
-                query_properties=[Field.TEXT_KEY.value],
-                limit=top_k,
-                return_properties=props,
-                include_vector=True,
-                filters=where,
-            )
-        except WeaviateQueryError:
-            self._ensure_properties()
-            res = col.query.bm25(
-                query=query,
-                query_properties=[Field.TEXT_KEY.value],
-                limit=top_k,
-                return_properties=props,
-                include_vector=True,
-                filters=where,
-            )
+        if top_k <= 0:
+            return []
 
         docs: list[Document] = []
-        for obj in res.objects:
-            properties = dict(obj.properties or {})
-            text = properties.pop(Field.TEXT_KEY.value, "")
+        offset = 0
+        while len(docs) < top_k:
+            try:
+                res = col.query.bm25(
+                    query=query,
+                    query_properties=[Field.TEXT_KEY.value],
+                    limit=top_k,
+                    offset=offset,
+                    return_properties=props,
+                    include_vector=True,
+                    filters=where,
+                )
+            except WeaviateQueryError:
+                self._ensure_properties()
+                res = col.query.bm25(
+                    query=query,
+                    query_properties=[Field.TEXT_KEY.value],
+                    limit=top_k,
+                    offset=offset,
+                    return_properties=props,
+                    include_vector=True,
+                    filters=where,
+                )
 
-            vec = obj.vector
-            if isinstance(vec, dict):
-                vec = vec.get("default") or next(iter(vec.values()), None)
+            objects = list(res.objects or [])
+            for obj in objects:
+                properties = dict(obj.properties or {})
+                if not self._matches_search_scope(properties, kwargs):
+                    continue
+                text_value = properties.pop(Field.TEXT_KEY.value, "")
+                text = text_value if isinstance(text_value, str) else str(text_value or "")
 
-            docs.append(Document(page_content=text, vector=vec, metadata=properties))
+                raw_vector = obj.vector
+                if isinstance(raw_vector, dict):
+                    raw_vector = raw_vector.get("default") or next(iter(raw_vector.values()), None)
+                vector = _normalize_result_vector(raw_vector)
+
+                docs.append(Document(page_content=text, vector=vector, metadata=properties))
+                if len(docs) == top_k:
+                    break
+
+            if len(docs) == top_k or len(objects) < top_k:
+                break
+            offset += len(objects)
         return docs
 
     def _json_serializable(self, value: Any) -> Any:

--- a/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
@@ -1,4 +1,4 @@
-from typing import override
+from typing import Any, override
 
 """Unit tests for Weaviate vector database implementation.
 
@@ -12,14 +12,56 @@ Focuses on verifying that doc_type is properly handled in:
 import datetime
 import json
 import unittest
+import uuid
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from dify_vdb_weaviate import weaviate_vector as weaviate_vector_module
 from dify_vdb_weaviate.weaviate_vector import WeaviateConfig, WeaviateVector
+from weaviate.collections.classes.batch import BatchObject, DeleteManyReturn, ErrorObject
 
+from core.rag.embedding.embedding_base import Embeddings
 from core.rag.models.document import Document
+from models.dataset import Dataset
+
+
+def _dataset(dataset_id: str, *, collection_name: str | None = None) -> Dataset:
+    dataset = Dataset()
+    dataset.id = dataset_id
+    dataset.index_struct = (
+        json.dumps({"vector_store": {"class_prefix": collection_name}}) if collection_name is not None else None
+    )
+    return dataset
+
+
+def _delete_many_result(*, failed: int = 0, successful: int = 0, matches: int | None = None) -> DeleteManyReturn[None]:
+    return DeleteManyReturn(
+        failed=failed,
+        matches=failed + successful if matches is None else matches,
+        objects=None,
+        successful=successful,
+    )
+
+
+class _UnusedEmbeddings(Embeddings):
+    """Concrete embedding dependency for factory tests that never request embeddings."""
+
+    @override
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        raise AssertionError("embed_documents should not be called")
+
+    @override
+    def embed_multimodal_documents(self, multimodel_documents: list[dict[str, Any]]) -> list[list[float]]:
+        raise AssertionError("embed_multimodal_documents should not be called")
+
+    @override
+    def embed_query(self, text: str) -> list[float]:
+        raise AssertionError("embed_query should not be called")
+
+    @override
+    def embed_multimodal_query(self, multimodel_document: dict[str, Any]) -> list[float]:
+        raise AssertionError("embed_multimodal_query should not be called")
 
 
 class TestWeaviateVector(unittest.TestCase):
@@ -43,6 +85,60 @@ class TestWeaviateVector(unittest.TestCase):
     def test_config_requires_endpoint(self):
         with pytest.raises(ValueError, match="config WEAVIATE_ENDPOINT is required"):
             WeaviateConfig(endpoint="")
+
+    def test_result_vector_normalization_rejects_non_numeric_shapes(self):
+        assert weaviate_vector_module._normalize_result_vector([0.1, 2]) == [0.1, 2.0]
+        assert weaviate_vector_module._normalize_result_vector([[0.1]]) is None
+        assert weaviate_vector_module._normalize_result_vector("0.1") is None
+
+    def test_object_uuid_uses_metadata_doc_id_without_content_collision(self):
+        first_id = str(uuid.uuid4())
+        second_id = str(uuid.uuid4())
+        documents = [
+            Document(
+                page_content="identical content",
+                metadata={"doc_id": first_id},
+            ),
+            Document(
+                page_content="identical content",
+                metadata={"doc_id": second_id},
+            ),
+        ]
+
+        vector = WeaviateVector.__new__(WeaviateVector)
+
+        assert vector._get_uuids(documents) == [first_id, second_id]
+
+    def test_non_uuid_doc_id_has_stable_identity_independent_of_content(self):
+        vector = WeaviateVector.__new__(WeaviateVector)
+        first = Document(page_content="first", metadata={"doc_id": "external-handle"})
+        second = Document(page_content="second", metadata={"doc_id": "external-handle"})
+
+        assert vector._get_uuids([first]) == vector._get_uuids([second])
+
+    def test_document_identity_requires_durable_doc_id(self):
+        vector = WeaviateVector.__new__(WeaviateVector)
+
+        with pytest.raises(ValueError, match="must contain a doc_id"):
+            vector._get_uuids([Document(page_content="missing identity", metadata={})])
+
+    def test_build_search_filter_uses_exact_predicates_for_document_ids(self):
+        search_filter = WeaviateVector._build_search_filter(
+            {
+                "document_ids_filter": ["document-a", "document-b"],
+                "filter": {"group_id": ["dataset-a", "dataset-b"]},
+            }
+        )
+
+        assert search_filter is not None
+        conditions = vars(search_filter)["filters"]
+        assert [(condition.operator.value, condition.value) for condition in conditions] == [
+            ("Equal", "document-a"),
+            ("Equal", "document-b"),
+        ]
+
+    def test_build_search_filter_ignores_dataset_group_filter(self):
+        assert WeaviateVector._build_search_filter({"filter": {"group_id": ["dataset-a"]}}) is None
 
     @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
     def _create_weaviate_vector(self, mock_weaviate_module):
@@ -164,13 +260,13 @@ class TestWeaviateVector(unittest.TestCase):
         }
 
     def test_get_collection_name_uses_existing_class_prefix_and_appends_suffix(self):
-        dataset = SimpleNamespace(index_struct_dict={"vector_store": {"class_prefix": "ExistingCollection"}}, id="ds-1")
+        dataset = _dataset("ds-1", collection_name="ExistingCollection")
         wv = WeaviateVector.__new__(WeaviateVector)
 
         assert wv.get_collection_name(dataset) == "ExistingCollection_Node"
 
     def test_get_collection_name_generates_name_from_dataset_id(self):
-        dataset = SimpleNamespace(index_struct_dict=None, id="ds-2")
+        dataset = _dataset("ds-2")
         wv = WeaviateVector.__new__(WeaviateVector)
 
         with patch.object(weaviate_vector_module.Dataset, "gen_collection_name_by_id", return_value="Generated_Node"):
@@ -235,6 +331,7 @@ class TestWeaviateVector(unittest.TestCase):
         assert "doc_type" in property_names, (
             f"doc_type should be in collection schema properties, got: {property_names}"
         )
+        assert "dataset_id" not in property_names
 
     @patch("dify_vdb_weaviate.weaviate_vector.redis_client")
     def test_create_collection_returns_early_when_cache_key_exists(self, mock_redis):
@@ -291,6 +388,7 @@ class TestWeaviateVector(unittest.TestCase):
         # Simulate existing properties WITHOUT doc_type
         existing_props = [
             SimpleNamespace(name="text"),
+            SimpleNamespace(name="dataset_id"),
             SimpleNamespace(name="document_id"),
             SimpleNamespace(name="doc_id"),
             SimpleNamespace(name="chunk_index"),
@@ -332,7 +430,14 @@ class TestWeaviateVector(unittest.TestCase):
 
         add_calls = mock_col.config.add_property.call_args_list
         added_names = [call.args[0].name for call in add_calls]
-        assert added_names == ["document_id", "doc_id", "doc_type", "chunk_index", "is_summary", "original_chunk_id"]
+        assert added_names == [
+            "document_id",
+            "doc_id",
+            "doc_type",
+            "chunk_index",
+            "is_summary",
+            "original_chunk_id",
+        ]
 
     @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
     def test_ensure_properties_skips_existing_doc_type(self, mock_weaviate_module):
@@ -452,6 +557,7 @@ class TestWeaviateVector(unittest.TestCase):
         mock_obj = MagicMock()
         mock_obj.properties = {
             "text": "fallback distance result",
+            "dataset_id": "dataset-1",
             "document_id": "doc-1",
             "doc_id": "segment-1",
         }
@@ -469,13 +575,17 @@ class TestWeaviateVector(unittest.TestCase):
         docs = wv.search_by_vector(
             query_vector=[0.2] * 3,
             document_ids_filter=["doc-1"],
+            filter={"group_id": ["dataset-1"]},
             top_k=2,
             score_threshold=-1,
         )
 
         assert len(docs) == 1
         assert docs[0].metadata["score"] == 0.0
-        assert mock_col.query.near_vector.call_args.kwargs["filters"] is not None
+        search_filter = mock_col.query.near_vector.call_args.kwargs["filters"]
+        assert search_filter.target == "document_id"
+        assert search_filter.value == "doc-1"
+        assert search_filter.operator.value == "Equal"
 
     @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
     def test_search_by_vector_returns_empty_when_collection_is_missing(self, mock_weaviate_module):
@@ -491,6 +601,61 @@ class TestWeaviateVector(unittest.TestCase):
         )
 
         assert wv.search_by_vector(query_vector=[0.1] * 3) == []
+
+    @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
+    def test_search_by_vector_pages_past_legacy_token_filter_false_positive(self, mock_weaviate_module):
+        mock_client = MagicMock()
+        mock_client.is_ready.return_value = True
+        mock_weaviate_module.connect_to_custom.return_value = mock_client
+        mock_client.collections.exists.return_value = True
+        mock_col = MagicMock()
+        mock_client.collections.use.return_value = mock_col
+        mock_col.query.near_vector.side_effect = [
+            SimpleNamespace(
+                objects=[
+                    SimpleNamespace(
+                        properties={
+                            "text": "wrong but closest",
+                            "doc_id": "wrong",
+                            "document_id": "document-1-suffix",
+                            "dataset_id": "dataset-1",
+                        },
+                        metadata=SimpleNamespace(distance=0.01),
+                    )
+                ]
+            ),
+            SimpleNamespace(
+                objects=[
+                    SimpleNamespace(
+                        properties={
+                            "text": "right but second",
+                            "doc_id": "right",
+                            "document_id": "document-1",
+                            "dataset_id": "dataset-1",
+                        },
+                        metadata=SimpleNamespace(distance=0.02),
+                    )
+                ]
+            ),
+        ]
+
+        wv = WeaviateVector(
+            collection_name=self.collection_name,
+            config=self.config,
+            attributes=self.attributes,
+        )
+        docs = wv.search_by_vector(
+            [0.1, 0.2],
+            top_k=1,
+            score_threshold=0.0,
+            document_ids_filter=["document-1"],
+            filter={"group_id": ["dataset-1"]},
+        )
+
+        assert [document.metadata["doc_id"] for document in docs] == ["right"]
+        assert mock_col.query.near_vector.call_count == 2
+        assert mock_col.query.near_vector.call_args_list[0].kwargs["offset"] == 0
+        assert mock_col.query.near_vector.call_args_list[1].kwargs["offset"] == 1
 
     @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
     def test_search_by_vector_retries_on_weaviate_query_error(self, mock_weaviate_module):
@@ -594,7 +759,12 @@ class TestWeaviateVector(unittest.TestCase):
         mock_client.collections.use.return_value = mock_col
 
         mock_obj = MagicMock()
-        mock_obj.properties = {"text": "bm25 result", "doc_id": "segment-1"}
+        mock_obj.properties = {
+            "text": "bm25 result",
+            "dataset_id": "dataset-1",
+            "document_id": "doc-1",
+            "doc_id": "segment-1",
+        }
         mock_obj.vector = [0.3, 0.4]
 
         mock_result = MagicMock()
@@ -606,11 +776,17 @@ class TestWeaviateVector(unittest.TestCase):
             config=self.config,
             attributes=self.attributes,
         )
-        docs = wv.search_by_full_text(query="bm25", document_ids_filter=["doc-1"])
+        docs = wv.search_by_full_text(
+            query="bm25",
+            document_ids_filter=["doc-1"],
+            filter={"group_id": ["dataset-1"]},
+        )
 
         assert len(docs) == 1
         assert docs[0].vector == [0.3, 0.4]
-        assert mock_col.query.bm25.call_args.kwargs["filters"] is not None
+        search_filter = mock_col.query.bm25.call_args.kwargs["filters"]
+        assert search_filter.target == "document_id"
+        assert search_filter.value == "doc-1"
 
     @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
     def test_search_by_full_text_returns_empty_when_collection_is_missing(self, mock_weaviate_module):
@@ -626,6 +802,60 @@ class TestWeaviateVector(unittest.TestCase):
         )
 
         assert wv.search_by_full_text(query="missing") == []
+
+    @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
+    def test_search_by_full_text_pages_past_legacy_token_filter_false_positive(self, mock_weaviate_module):
+        mock_client = MagicMock()
+        mock_client.is_ready.return_value = True
+        mock_weaviate_module.connect_to_custom.return_value = mock_client
+        mock_client.collections.exists.return_value = True
+        mock_col = MagicMock()
+        mock_client.collections.use.return_value = mock_col
+        mock_col.query.bm25.side_effect = [
+            SimpleNamespace(
+                objects=[
+                    SimpleNamespace(
+                        properties={
+                            "text": "wrong but highest ranked",
+                            "doc_id": "wrong",
+                            "document_id": "document-1-suffix",
+                            "dataset_id": "dataset-1",
+                        },
+                        vector={"default": [0.1, 0.2]},
+                    )
+                ]
+            ),
+            SimpleNamespace(
+                objects=[
+                    SimpleNamespace(
+                        properties={
+                            "text": "right but second",
+                            "doc_id": "right",
+                            "document_id": "document-1",
+                            "dataset_id": "dataset-1",
+                        },
+                        vector={"default": [0.2, 0.3]},
+                    )
+                ]
+            ),
+        ]
+
+        wv = WeaviateVector(
+            collection_name=self.collection_name,
+            config=self.config,
+            attributes=self.attributes,
+        )
+        docs = wv.search_by_full_text(
+            "query",
+            top_k=1,
+            document_ids_filter=["document-1"],
+            filter={"group_id": ["dataset-1"]},
+        )
+
+        assert [document.metadata["doc_id"] for document in docs] == ["right"]
+        assert mock_col.query.bm25.call_count == 2
+        assert mock_col.query.bm25.call_args_list[0].kwargs["offset"] == 0
+        assert mock_col.query.bm25.call_args_list[1].kwargs["offset"] == 1
 
     @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
     def test_search_by_full_text_retries_on_weaviate_query_error(self, mock_weaviate_module):
@@ -753,6 +983,77 @@ class TestWeaviateVector(unittest.TestCase):
         assert call_kwargs.kwargs["vector"] is None
         assert call_kwargs.kwargs["properties"]["created_at"] == created_at.isoformat()
 
+    @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
+    def test_add_texts_raises_when_batch_reports_failed_objects(self, mock_weaviate_module):
+        mock_client = MagicMock()
+        mock_client.is_ready.return_value = True
+        mock_weaviate_module.connect_to_custom.return_value = mock_client
+        mock_col = MagicMock()
+        mock_client.collections.use.return_value = mock_col
+        mock_col.query.fetch_objects.return_value = SimpleNamespace(objects=[])
+
+        mock_batch = MagicMock()
+        mock_batch.__enter__ = MagicMock(return_value=mock_batch)
+        mock_batch.__exit__ = MagicMock(return_value=False)
+        mock_col.batch.dynamic.return_value = mock_batch
+        mock_col.batch.failed_objects = [
+            ErrorObject(
+                message="object rejected",
+                object_=BatchObject(collection=self.collection_name, index=0),
+            )
+        ]
+
+        doc = Document(page_content="text", metadata={"doc_id": "segment-1"})
+        wv = WeaviateVector(
+            collection_name=self.collection_name,
+            config=self.config,
+            attributes=self.attributes,
+        )
+
+        with pytest.raises(RuntimeError, match="object rejected"):
+            wv.add_texts(documents=[doc], embeddings=[[0.1]])
+
+    def test_add_texts_rejects_malformed_weaviate_data_object(self):
+        wv = WeaviateVector.__new__(WeaviateVector)
+        wv._collection_name = self.collection_name
+        wv._client = MagicMock()
+
+        with (
+            patch.object(
+                weaviate_vector_module,
+                "DataObject",
+                return_value=SimpleNamespace(uuid=None, properties={}),
+            ),
+            pytest.raises(RuntimeError, match="missing its UUID or properties"),
+        ):
+            wv.add_texts(
+                documents=[Document(page_content="text", metadata={"doc_id": "segment-1"})],
+                embeddings=[[0.1]],
+            )
+
+    def test_doc_id_lookup_paginates_with_filter_compatible_offset(self):
+        wv = WeaviateVector.__new__(WeaviateVector)
+        collection = MagicMock()
+        first = SimpleNamespace(uuid=uuid.uuid4(), properties={"doc_id": "segment-1"})
+        second = SimpleNamespace(uuid=uuid.uuid4(), properties={"doc_id": "segment-2"})
+        false_positive = SimpleNamespace(uuid=uuid.uuid4(), properties={"doc_id": "segment-3"})
+        collection.query.fetch_objects.side_effect = [
+            SimpleNamespace(objects=[first, second]),
+            SimpleNamespace(objects=[false_positive]),
+        ]
+
+        with patch.object(weaviate_vector_module, "_DELETE_BATCH_SIZE", 2):
+            result = wv._get_object_uuids_by_doc_id(collection, ["segment-1", "segment-2"])
+
+        assert result == {
+            "segment-1": {str(first.uuid)},
+            "segment-2": {str(second.uuid)},
+        }
+        assert collection.query.fetch_objects.call_count == 2
+        assert collection.query.fetch_objects.call_args_list[0].kwargs["offset"] == 0
+        assert collection.query.fetch_objects.call_args_list[1].kwargs["offset"] == 2
+        assert "after" not in collection.query.fetch_objects.call_args_list[1].kwargs
+
     def test_is_uuid_handles_invalid_values(self):
         wv = WeaviateVector.__new__(WeaviateVector)
 
@@ -777,9 +1078,35 @@ class TestWeaviateVector(unittest.TestCase):
         mock_col = MagicMock()
         wv._client.collections.use.return_value = mock_col
 
+        object_uuid = str(uuid.uuid4())
+        mock_col.query.fetch_objects.return_value = SimpleNamespace(
+            objects=[SimpleNamespace(uuid=object_uuid, properties={"doc_id": "segment-1"})]
+        )
+        mock_col.data.delete_many.return_value = _delete_many_result(successful=1)
+
         wv.delete_by_metadata_field("doc_id", "segment-1")
 
         mock_col.data.delete_many.assert_called_once()
+        delete_kwargs = mock_col.data.delete_many.call_args.kwargs
+        assert delete_kwargs["where"].target == "_id"
+        assert delete_kwargs["where"].value == [object_uuid]
+        assert delete_kwargs["verbose"] is True
+
+    def test_delete_by_metadata_field_raises_on_partial_failure(self):
+        wv = WeaviateVector.__new__(WeaviateVector)
+        wv._collection_name = self.collection_name
+        wv._client = MagicMock()
+        wv._client.collections.exists.return_value = True
+        mock_col = MagicMock()
+        wv._client.collections.use.return_value = mock_col
+        object_uuid = str(uuid.uuid4())
+        mock_col.query.fetch_objects.return_value = SimpleNamespace(
+            objects=[SimpleNamespace(uuid=object_uuid, properties={"doc_id": "segment-1"})]
+        )
+        mock_col.data.delete_many.return_value = _delete_many_result(failed=1, successful=1)
+
+        with pytest.raises(RuntimeError, match="failed to delete 1"):
+            wv.delete_by_metadata_field("doc_id", "segment-1")
 
     def test_delete_removes_collection_when_present(self):
         wv = WeaviateVector.__new__(WeaviateVector)
@@ -798,50 +1125,132 @@ class TestWeaviateVector(unittest.TestCase):
         wv._client.collections.exists.side_effect = [False, True]
         mock_col = MagicMock()
         wv._client.collections.use.return_value = mock_col
-        mock_col.query.fetch_objects.return_value = SimpleNamespace(objects=[SimpleNamespace()])
+        mock_col.query.fetch_objects.return_value = SimpleNamespace(
+            objects=[SimpleNamespace(uuid=uuid.uuid4(), properties={"doc_id": "segment-1"})]
+        )
 
         assert wv.text_exists("segment-1") is False
         assert wv.text_exists("segment-1") is True
 
-    def test_delete_by_ids_handles_missing_collections_and_404s(self):
-        class FakeUnexpectedStatusCodeError(Exception):
-            def __init__(self, status_code):
-                super().__init__(f"status={status_code}")
-                self.status_code = status_code
-
+    def test_delete_by_ids_deletes_by_metadata_for_legacy_and_current_objects(self):
         wv = WeaviateVector.__new__(WeaviateVector)
         wv._collection_name = self.collection_name
         wv._client = MagicMock()
         wv._client.collections.exists.side_effect = [False, True]
         mock_col = MagicMock()
         wv._client.collections.use.return_value = mock_col
-        mock_col.data.delete_by_id.side_effect = [FakeUnexpectedStatusCodeError(404), None]
+        legacy_uuid = str(uuid.uuid4())
+        current_uuid = str(uuid.uuid4())
+        mock_col.query.fetch_objects.return_value = SimpleNamespace(
+            objects=[
+                SimpleNamespace(uuid=legacy_uuid, properties={"doc_id": "legacy-id"}),
+                SimpleNamespace(uuid=current_uuid, properties={"doc_id": "current-id"}),
+            ]
+        )
+        mock_col.data.delete_many.return_value = _delete_many_result(successful=2)
 
-        with patch.object(weaviate_vector_module, "UnexpectedStatusCodeError", FakeUnexpectedStatusCodeError):
-            wv.delete_by_ids(["ignored"])
-            wv.delete_by_ids(["missing-id", "ok-id"])
+        wv.delete_by_ids(["ignored"])
+        wv.delete_by_ids(["legacy-id", "current-id"])
 
-        assert mock_col.data.delete_by_id.call_count == 2
+        mock_col.data.delete_many.assert_called_once()
+        delete_filter = mock_col.data.delete_many.call_args.kwargs["where"]
+        assert (delete_filter.target, delete_filter.operator.value, delete_filter.value) == (
+            "_id",
+            "ContainsAny",
+            [legacy_uuid, current_uuid],
+        )
+        assert mock_col.data.delete_many.call_args.kwargs["verbose"] is True
 
-    def test_delete_by_ids_reraises_non_404_errors(self):
-        class FakeUnexpectedStatusCodeError(Exception):
-            def __init__(self, status_code):
-                super().__init__(f"status={status_code}")
-                self.status_code = status_code
-
+    def test_delete_by_ids_raises_on_partial_failure(self):
         wv = WeaviateVector.__new__(WeaviateVector)
         wv._collection_name = self.collection_name
         wv._client = MagicMock()
         wv._client.collections.exists.return_value = True
         mock_col = MagicMock()
         wv._client.collections.use.return_value = mock_col
-        mock_col.data.delete_by_id.side_effect = FakeUnexpectedStatusCodeError(500)
+        object_uuid = str(uuid.uuid4())
+        mock_col.query.fetch_objects.return_value = SimpleNamespace(
+            objects=[SimpleNamespace(uuid=object_uuid, properties={"doc_id": "segment-1"})]
+        )
+        mock_col.data.delete_many.return_value = _delete_many_result(failed=1)
+
+        with pytest.raises(RuntimeError, match="failed to delete 1"):
+            wv.delete_by_ids(["segment-1"])
+
+    def test_delete_by_ids_skips_empty_input(self):
+        wv = WeaviateVector.__new__(WeaviateVector)
+        wv._collection_name = self.collection_name
+        wv._client = MagicMock()
+        wv._client.collections.exists.return_value = True
+
+        wv.delete_by_ids([])
+
+        wv._client.collections.exists.assert_not_called()
+
+    def test_delete_by_ids_deduplicates_and_batches(self):
+        wv = WeaviateVector.__new__(WeaviateVector)
+        wv._collection_name = self.collection_name
+        wv._client = MagicMock()
+        wv._client.collections.exists.return_value = True
+        mock_col = MagicMock()
+        wv._client.collections.use.return_value = mock_col
+        mock_col.data.delete_many.return_value = _delete_many_result(successful=2)
+        object_uuids = {
+            "node-1": {str(uuid.uuid4())},
+            "node-2": {str(uuid.uuid4())},
+            "node-3": {str(uuid.uuid4())},
+        }
 
         with (
-            patch.object(weaviate_vector_module, "UnexpectedStatusCodeError", FakeUnexpectedStatusCodeError),
-            pytest.raises(FakeUnexpectedStatusCodeError, match="status=500"),
+            patch.object(weaviate_vector_module, "_DELETE_BATCH_SIZE", 2),
+            patch.object(wv, "_get_object_uuids_by_doc_id", return_value=object_uuids),
         ):
-            wv.delete_by_ids(["bad-id"])
+            wv.delete_by_ids(["node-1", "node-2", "node-1", "node-3"])
+
+        filters = [mock_call.kwargs["where"] for mock_call in mock_col.data.delete_many.call_args_list]
+        assert filters[0].target == "_id"
+        assert filters[0].value == [*object_uuids["node-1"], *object_uuids["node-2"]]
+        assert filters[1].value == [*object_uuids["node-3"]]
+
+    @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
+    def test_add_texts_retires_legacy_content_uuid_after_canonical_insert(self, mock_weaviate_module):
+        mock_client = MagicMock()
+        mock_client.is_ready.return_value = True
+        mock_weaviate_module.connect_to_custom.return_value = mock_client
+        mock_col = MagicMock()
+        mock_client.collections.use.return_value = mock_col
+
+        doc_id = str(uuid.uuid4())
+        legacy_uuid = str(uuid.uuid4())
+        legacy_object = SimpleNamespace(uuid=legacy_uuid, properties={"doc_id": doc_id})
+        canonical_object = SimpleNamespace(uuid=doc_id, properties={"doc_id": doc_id})
+        mock_col.query.fetch_objects.side_effect = [
+            SimpleNamespace(objects=[legacy_object]),
+            SimpleNamespace(objects=[legacy_object, canonical_object]),
+        ]
+
+        mock_batch = MagicMock()
+        mock_batch.__enter__ = MagicMock(return_value=mock_batch)
+        mock_batch.__exit__ = MagicMock(return_value=False)
+        mock_col.batch.dynamic.return_value = mock_batch
+        mock_col.batch.failed_objects = []
+        mock_col.data.delete_many.return_value = _delete_many_result(successful=1)
+
+        wv = WeaviateVector(
+            collection_name=self.collection_name,
+            config=self.config,
+            attributes=self.attributes,
+        )
+        ids = wv.add_texts(
+            documents=[Document(page_content="replacement", metadata={"doc_id": doc_id})],
+            embeddings=[[0.1, 0.2]],
+        )
+
+        assert ids == [doc_id]
+        mock_batch.add_object.assert_called_once()
+        mock_col.data.delete_many.assert_called_once()
+        delete_filter = mock_col.data.delete_many.call_args.kwargs["where"]
+        assert (delete_filter.target, delete_filter.value) == ("_id", [legacy_uuid])
 
     def test_json_serializable_converts_datetime(self):
         wv = WeaviateVector.__new__(WeaviateVector)
@@ -863,21 +1272,15 @@ class TestVectorDefaultAttributes(unittest.TestCase):
         mock_get_embeddings.return_value = MagicMock()
         mock_init_vector.return_value = MagicMock()
 
-        mock_dataset = MagicMock()
-        mock_dataset.index_struct_dict = None
-
-        vector = Vector(dataset=mock_dataset, session=MagicMock())
+        vector = Vector(dataset=_dataset("dataset-1"))
 
         assert "doc_type" in vector._attributes, f"doc_type should be in default attributes, got: {vector._attributes}"
 
 
 class TestWeaviateVectorFactory(unittest.TestCase):
     def test_init_vector_uses_existing_dataset_index_struct(self):
-        dataset = SimpleNamespace(
-            id="dataset-1",
-            index_struct_dict={"vector_store": {"class_prefix": "ExistingCollection_Node"}},
-            index_struct=None,
-        )
+        dataset = _dataset("dataset-1", collection_name="ExistingCollection_Node")
+        original_index_struct = dataset.index_struct
         attributes = ["doc_id"]
 
         with (
@@ -888,7 +1291,7 @@ class TestWeaviateVectorFactory(unittest.TestCase):
             patch("dify_vdb_weaviate.weaviate_vector.WeaviateVector", return_value="vector") as mock_vector,
         ):
             factory = weaviate_vector_module.WeaviateVectorFactory()
-            result = factory.init_vector(dataset, attributes, MagicMock())
+            result = factory.init_vector(dataset, attributes, _UnusedEmbeddings())
 
         assert result == "vector"
         config = mock_vector.call_args.kwargs["config"]
@@ -898,10 +1301,10 @@ class TestWeaviateVectorFactory(unittest.TestCase):
         assert config.grpc_endpoint == "localhost:50051"
         assert config.api_key == "api-key"
         assert config.batch_size == 88
-        assert dataset.index_struct is None
+        assert dataset.index_struct == original_index_struct
 
     def test_init_vector_generates_collection_and_updates_index_struct(self):
-        dataset = SimpleNamespace(id="dataset-2", index_struct_dict=None, index_struct=None)
+        dataset = _dataset("dataset-2")
         attributes = ["doc_id", "doc_type"]
 
         with (
@@ -917,7 +1320,7 @@ class TestWeaviateVectorFactory(unittest.TestCase):
             patch("dify_vdb_weaviate.weaviate_vector.WeaviateVector", return_value="vector") as mock_vector,
         ):
             factory = weaviate_vector_module.WeaviateVectorFactory()
-            result = factory.init_vector(dataset, attributes, MagicMock())
+            result = factory.init_vector(dataset, attributes, _UnusedEmbeddings())
 
         assert result == "vector"
         assert mock_vector.call_args.kwargs["collection_name"] == "GeneratedCollection_Node"

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -10,6 +10,7 @@ from collections.abc import Sequence
 from typing import Annotated, Any, Literal, TypedDict, cast
 
 import sqlalchemy as sa
+from celery import Task
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 from redis.exceptions import LockNotOwnedError
 from sqlalchemy import ColumnElement, delete, exists, func, select, update
@@ -117,6 +118,19 @@ class ProcessRulesDict(TypedDict):
 class AutoDisableLogsDict(TypedDict):
     document_ids: list[str]
     count: int
+
+
+class DocumentStatusAsyncTask(TypedDict):
+    function: Task
+    args: list[str]
+
+
+class DocumentStatusUpdate(TypedDict):
+    document: Document
+    document_id: str
+    updates: dict[str, Any]
+    async_task: DocumentStatusAsyncTask | None
+    set_cache: bool
 
 
 class _EstimatePreProcessingRule(BaseModel):
@@ -3152,7 +3166,7 @@ class DocumentService:
         action: Literal["enable", "disable", "archive", "un_archive"],
         user,
         session: Session,
-    ):
+    ) -> None:
         """
         Batch update document status.
 
@@ -3174,7 +3188,7 @@ class DocumentService:
         if action not in valid_actions:
             raise ValueError(f"Invalid action: {action}. Must be one of {valid_actions}")
 
-        documents_to_update = []
+        documents_to_update: list[DocumentStatusUpdate] = []
 
         # First pass: validate all documents and prepare updates
         for document_id in document_ids:
@@ -3225,18 +3239,17 @@ class DocumentService:
                         task_func.delay(*task_args)
                 except Exception as e:
                     # Log the error but do not rollback the transaction
-                    logger.exception("Error executing async task for document %s", update_info["document"].id)
+                    logger.exception("Error executing async task for document %s", update_info["document_id"])
                     # don't raise the error immediately, but capture it for later
                     propagation_error = e
                 try:
                     # Set Redis cache if needed after successful commit
                     if update_info["set_cache"]:
-                        document = update_info["document"]
-                        indexing_cache_key = f"document_{document.id}_indexing"
+                        indexing_cache_key = f"document_{update_info['document_id']}_indexing"
                         redis_client.setex(indexing_cache_key, 600, 1)
                 except Exception:
                     # Log the error but do not rollback the transaction
-                    logger.exception("Error setting cache for document %s", update_info["document"].id)
+                    logger.exception("Error setting cache for document %s", update_info["document_id"])
             # Raise any propagation error after all updates
             if propagation_error:
                 raise propagation_error
@@ -3244,7 +3257,7 @@ class DocumentService:
     @staticmethod
     def _prepare_document_status_update(
         document: Document, action: Literal["enable", "disable", "archive", "un_archive"], user
-    ):
+    ) -> DocumentStatusUpdate | None:
         """Prepare document status update information.
 
         Args:
@@ -3270,20 +3283,22 @@ class DocumentService:
         return None
 
     @staticmethod
-    def _prepare_enable_update(document, now):
+    def _prepare_enable_update(document, now) -> DocumentStatusUpdate | None:
         """Prepare updates for enabling a document."""
         if document.enabled:
             return None
 
-        return {
+        update_info: DocumentStatusUpdate = {
             "document": document,
+            "document_id": document.id,
             "updates": {"enabled": True, "disabled_at": None, "disabled_by": None, "updated_at": now},
             "async_task": {"function": add_document_to_index_task, "args": [document.id]},
             "set_cache": True,
         }
+        return update_info
 
     @staticmethod
-    def _prepare_disable_update(document, user, now):
+    def _prepare_disable_update(document, user, now) -> DocumentStatusUpdate | None:
         """Prepare updates for disabling a document."""
         if not document.completed_at or document.indexing_status != IndexingStatus.COMPLETED:
             raise DocumentIndexingError(f"Document: {document.name} is not completed.")
@@ -3291,21 +3306,24 @@ class DocumentService:
         if not document.enabled:
             return None
 
-        return {
+        update_info: DocumentStatusUpdate = {
             "document": document,
+            "document_id": document.id,
             "updates": {"enabled": False, "disabled_at": now, "disabled_by": user.id, "updated_at": now},
             "async_task": {"function": remove_document_from_index_task, "args": [document.id]},
             "set_cache": True,
         }
+        return update_info
 
     @staticmethod
-    def _prepare_archive_update(document, user, now):
+    def _prepare_archive_update(document, user, now) -> DocumentStatusUpdate | None:
         """Prepare updates for archiving a document."""
         if document.archived:
             return None
 
-        update_info = {
+        update_info: DocumentStatusUpdate = {
             "document": document,
+            "document_id": document.id,
             "updates": {"archived": True, "archived_at": now, "archived_by": user.id, "updated_at": now},
             "async_task": None,
             "set_cache": False,
@@ -3319,13 +3337,14 @@ class DocumentService:
         return update_info
 
     @staticmethod
-    def _prepare_unarchive_update(document, now):
+    def _prepare_unarchive_update(document, now) -> DocumentStatusUpdate | None:
         """Prepare updates for unarchiving a document."""
         if not document.archived:
             return None
 
-        update_info = {
+        update_info: DocumentStatusUpdate = {
             "document": document,
+            "document_id": document.id,
             "updates": {"archived": False, "archived_at": None, "archived_by": None, "updated_at": now},
             "async_task": None,
             "set_cache": False,
@@ -3625,24 +3644,18 @@ class SegmentService:
                     # summary_index_setting is only needed for LLM generation, not for manual summary vectorization
                     # Vectorization uses dataset.embedding_model, which doesn't require summary_index_setting
                     if dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY:
-                        # Query existing summary from database
-                        from models.dataset import DocumentSegmentSummary
+                        from services.summary_index_service import SummaryIndexService
 
-                        existing_summary = session.scalar(
-                            select(DocumentSegmentSummary)
-                            .where(
-                                DocumentSegmentSummary.chunk_id == segment.id,
-                                DocumentSegmentSummary.dataset_id == dataset.id,
-                            )
-                            .limit(1)
+                        existing_summary = SummaryIndexService.get_segment_summary(
+                            segment.id,
+                            dataset.id,
+                            session=session,
                         )
 
                         # Check if summary has changed
                         existing_summary_content = existing_summary.summary_content if existing_summary else None
                         if existing_summary_content != args.summary:
                             # Summary has changed, update it
-                            from services.summary_index_service import SummaryIndexService
-
                             try:
                                 SummaryIndexService.update_summary_for_segment(
                                     segment,
@@ -3725,15 +3738,12 @@ class SegmentService:
                     VectorService.update_segment_vector(args.keywords, segment, dataset, session=session)
                 # Handle summary index when content changed
                 if dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY:
-                    from models.dataset import DocumentSegmentSummary
+                    from services.summary_index_service import SummaryIndexService
 
-                    existing_summary = session.scalar(
-                        select(DocumentSegmentSummary)
-                        .where(
-                            DocumentSegmentSummary.chunk_id == segment.id,
-                            DocumentSegmentSummary.dataset_id == dataset.id,
-                        )
-                        .limit(1)
+                    existing_summary = SummaryIndexService.get_segment_summary(
+                        segment.id,
+                        dataset.id,
+                        session=session,
                     )
 
                     if args.summary is None:
@@ -3745,8 +3755,6 @@ class SegmentService:
                             and dataset.summary_index_setting.get("enable") is True
                         ):
                             # Segment previously had summary, regenerate it with new content
-                            from services.summary_index_service import SummaryIndexService
-
                             try:
                                 SummaryIndexService.generate_and_vectorize_summary(
                                     segment,
@@ -3764,8 +3772,6 @@ class SegmentService:
                         existing_summary_content = existing_summary.summary_content if existing_summary else None
                         if existing_summary_content != args.summary:
                             # Summary has changed, use user-provided summary
-                            from services.summary_index_service import SummaryIndexService
-
                             try:
                                 SummaryIndexService.update_summary_for_segment(
                                     segment,
@@ -3785,8 +3791,6 @@ class SegmentService:
                                 and dataset.summary_index_setting
                                 and dataset.summary_index_setting.get("enable") is True
                             ):
-                                from services.summary_index_service import SummaryIndexService
-
                                 try:
                                     SummaryIndexService.generate_and_vectorize_summary(
                                         segment,
@@ -3817,31 +3821,32 @@ class SegmentService:
 
     @classmethod
     def delete_segment(cls, segment: DocumentSegment, document: Document, dataset: Dataset, session: Session):
+        """Delete one segment, then publish index cleanup using IDs captured before the commit.
+
+        RDBMS is authoritative here: the row deletion commits before broker I/O so a fast worker cannot remove
+        vectors for a segment whose deletion later rolls back. If publishing fails, stale index data is unreachable
+        through database-backed retrieval and can be reconciled by later cleanup.
+        """
         indexing_cache_key = f"segment_{segment.id}_delete_indexing"
         cache_result = redis_client.get(indexing_cache_key)
         if cache_result is not None:
             raise ValueError("Segment is deleting.")
 
-        # enabled segment need to delete index
-        if segment.enabled:
-            # send delete segment index task
-            redis_client.setex(indexing_cache_key, 600, 1)
-
-            # Get child chunk IDs before parent segment is deleted
-            child_node_ids = []
-            if segment.index_node_id:
-                child_node_ids = list(
-                    session.scalars(
-                        select(ChildChunk.index_node_id).where(
-                            ChildChunk.segment_id == segment.id,
-                            ChildChunk.dataset_id == dataset.id,
-                        )
-                    ).all()
+        # Actual deletion must remove summary rows even when the segment was
+        # already disabled or never received a vector node ID.
+        redis_client.setex(indexing_cache_key, 600, 1)
+        child_node_ids = [
+            node_id
+            for node_id in session.scalars(
+                select(ChildChunk.index_node_id).where(
+                    ChildChunk.segment_id == segment.id,
+                    ChildChunk.dataset_id == dataset.id,
                 )
-
-            delete_segment_from_index_task.delay(
-                [segment.index_node_id], dataset.id, document.id, [segment.id], child_node_ids
-            )
+            ).all()
+            if node_id
+        ]
+        index_node_ids = [segment.index_node_id] if segment.index_node_id else []
+        segment_id = segment.id
 
         session.delete(segment)
         # update document word count
@@ -3849,9 +3854,25 @@ class SegmentService:
         document.word_count -= segment.word_count
         session.add(document)
         session.commit()
+        try:
+            delete_segment_from_index_task.delay(
+                index_node_ids,
+                dataset.id,
+                document.id,
+                [segment_id],
+                child_node_ids,
+            )
+        except Exception:
+            cls._remove_orphaned_summary_rows_after_publish_failure(session, dataset.id, [segment_id])
+            raise
 
     @classmethod
     def delete_segments(cls, segment_ids: list, document: Document, dataset: Dataset, session: Session):
+        """Delete validated segments, then publish index cleanup after the relational commit.
+
+        Durable segment and vector IDs are captured first because the cleanup worker runs after the source rows no
+        longer exist. Keeping broker I/O after commit avoids holding a database connection across publication.
+        """
         assert current_user is not None
         # Check if segment_ids is not empty to avoid WHERE false condition
         if not segment_ids or len(segment_ids) == 0:
@@ -3868,29 +3889,21 @@ class SegmentService:
         if not segments_info:
             return
 
-        index_node_ids = [info[0] for info in segments_info]
+        index_node_ids = [info[0] for info in segments_info if info[0]]
         segment_db_ids = [info[1] for info in segments_info]
         total_words = sum(info[2] for info in segments_info if info[2] is not None)
 
         # Get child chunk IDs before parent segments are deleted
-        child_node_ids = []
-        if index_node_ids:
-            child_node_ids = [
-                nid
-                for nid in session.scalars(
-                    select(ChildChunk.index_node_id).where(
-                        ChildChunk.segment_id.in_(segment_db_ids),
-                        ChildChunk.dataset_id == dataset.id,
-                    )
-                ).all()
-                if nid
-            ]
-
-        # Start async cleanup with both parent and child node IDs
-        if index_node_ids or child_node_ids:
-            delete_segment_from_index_task.delay(
-                index_node_ids, dataset.id, document.id, segment_db_ids, child_node_ids
-            )
+        child_node_ids = [
+            node_id
+            for node_id in session.scalars(
+                select(ChildChunk.index_node_id).where(
+                    ChildChunk.segment_id.in_(segment_db_ids),
+                    ChildChunk.dataset_id == dataset.id,
+                )
+            ).all()
+            if node_id
+        ]
 
         if document.word_count is None:
             document.word_count = 0
@@ -3900,8 +3913,56 @@ class SegmentService:
         session.add(document)
 
         # Delete database records
-        session.execute(delete(DocumentSegment).where(DocumentSegment.id.in_(segment_ids)))
+        session.execute(
+            delete(DocumentSegment).where(
+                DocumentSegment.id.in_(segment_db_ids),
+                DocumentSegment.dataset_id == dataset.id,
+                DocumentSegment.document_id == document.id,
+                DocumentSegment.tenant_id == current_user.current_tenant_id,
+            )
+        )
         session.commit()
+        # Dispatch based on database segment IDs because summary cleanup does
+        # not depend on either parent or child vector IDs being present.
+        try:
+            delete_segment_from_index_task.delay(
+                index_node_ids,
+                dataset.id,
+                document.id,
+                segment_db_ids,
+                child_node_ids,
+            )
+        except Exception:
+            cls._remove_orphaned_summary_rows_after_publish_failure(session, dataset.id, segment_db_ids)
+            raise
+
+    @staticmethod
+    def _remove_orphaned_summary_rows_after_publish_failure(
+        session: Session,
+        dataset_id: str,
+        segment_ids: list[str],
+    ) -> None:
+        """Remove relational dependants when external cleanup cannot be enqueued.
+
+        Vector objects can be reconciled later and are rejected by database-backed retrieval once their segment is
+        gone. The remaining rows have no database cascade from ``document_segments`` and must not be left orphaned
+        solely because the broker was unavailable after the authoritative segment deletion committed.
+        """
+        try:
+            VectorService.delete_segment_relational_dependants(
+                session=session,
+                dataset_id=dataset_id,
+                segment_ids=segment_ids,
+            )
+            session.commit()
+        except Exception:
+            session.rollback()
+            logger.exception(
+                "Failed to remove orphaned relational rows after segment cleanup publish failure, "
+                "dataset_id=%s, segment_ids=%s",
+                dataset_id,
+                segment_ids,
+            )
 
     @classmethod
     def update_segments_status(

--- a/api/services/external_knowledge_service.py
+++ b/api/services/external_knowledge_service.py
@@ -1,10 +1,12 @@
 import json
 from copy import deepcopy
+from dataclasses import dataclass
 from typing import Any, cast
 from urllib.parse import urlparse
 
 import httpx
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
+from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.orm import Session
 
 from constants import HIDDEN_VALUE
@@ -25,6 +27,14 @@ from services.entities.external_knowledge_entities.external_knowledge_entities i
 )
 from services.errors.dataset import DatasetNameDuplicateError
 from services.errors.knowledge_retrieval import ExternalKnowledgeRetrievalError
+
+
+@dataclass(frozen=True)
+class ResolvedExternalKnowledgeConfig:
+    """Plain provider configuration that is safe to retain after its database transaction ends."""
+
+    settings_json: str
+    external_knowledge_id: str
 
 
 class ExternalDatasetService:
@@ -335,6 +345,47 @@ class ExternalDatasetService:
         return dataset
 
     @staticmethod
+    def resolve_external_knowledge_config(
+        tenant_id: str,
+        dataset_id: str,
+        *,
+        session: Session,
+    ) -> ResolvedExternalKnowledgeConfig:
+        """Resolve tenant-scoped provider configuration without finalizing the caller's transaction."""
+        try:
+            config_row = session.execute(
+                select(
+                    ExternalKnowledgeBindings.external_knowledge_id,
+                    ExternalKnowledgeApis.settings,
+                )
+                .select_from(ExternalKnowledgeBindings)
+                .outerjoin(
+                    ExternalKnowledgeApis,
+                    and_(
+                        ExternalKnowledgeApis.id == ExternalKnowledgeBindings.external_knowledge_api_id,
+                        ExternalKnowledgeApis.tenant_id == tenant_id,
+                    ),
+                )
+                .where(
+                    ExternalKnowledgeBindings.dataset_id == dataset_id,
+                    ExternalKnowledgeBindings.tenant_id == tenant_id,
+                )
+            ).one_or_none()
+        except MultipleResultsFound as error:
+            raise ExternalKnowledgeRetrievalError("multiple external knowledge bindings found") from error
+        if config_row is None:
+            raise ExternalKnowledgeRetrievalError("external knowledge binding not found")
+
+        external_knowledge_id, settings_json = config_row
+        if settings_json is None:
+            raise ExternalKnowledgeRetrievalError("external api template not found")
+
+        return ResolvedExternalKnowledgeConfig(
+            settings_json=settings_json,
+            external_knowledge_id=external_knowledge_id,
+        )
+
+    @staticmethod
     def fetch_external_knowledge_retrieval(
         tenant_id: str,
         dataset_id: str,
@@ -342,37 +393,16 @@ class ExternalDatasetService:
         external_retrieval_parameters: dict[str, Any],
         metadata_condition: MetadataFilteringCondition | None = None,
         *,
-        session: Session,
+        resolved_config: ResolvedExternalKnowledgeConfig,
     ):
         """Fetch retrieval records from an external knowledge provider.
 
-        Success requires a tenant-scoped binding plus API template and a ``200``
-        response body shaped like ``{"records": [...]}``. All dependency
-        failures, non-200 responses, and malformed success payloads must be
-        normalized to ``ExternalKnowledgeRetrievalError`` so callers—especially
-        the inner knowledge retrieval API—can consistently expose
-        ``502 external_knowledge_failed``.
+        ``resolved_config`` must be loaded with ``resolve_external_knowledge_config`` and the resolving transaction
+        must be ended before this method is called. This method performs no database access, so provider latency cannot
+        retain a connection. Non-200 responses and malformed success payloads are normalized to
+        ``ExternalKnowledgeRetrievalError``.
         """
-        external_knowledge_binding = session.scalar(
-            select(ExternalKnowledgeBindings)
-            .where(ExternalKnowledgeBindings.dataset_id == dataset_id, ExternalKnowledgeBindings.tenant_id == tenant_id)
-            .limit(1)
-        )
-        if not external_knowledge_binding:
-            raise ExternalKnowledgeRetrievalError("external knowledge binding not found")
-
-        external_knowledge_api = session.scalar(
-            select(ExternalKnowledgeApis)
-            .where(
-                ExternalKnowledgeApis.id == external_knowledge_binding.external_knowledge_api_id,
-                ExternalKnowledgeApis.tenant_id == tenant_id,
-            )
-            .limit(1)
-        )
-        if external_knowledge_api is None or external_knowledge_api.settings is None:
-            raise ExternalKnowledgeRetrievalError("external api template not found")
-
-        settings = json.loads(external_knowledge_api.settings)
+        settings = json.loads(resolved_config.settings_json)
         headers = {"Content-Type": "application/json"}
         if settings.get("api_key"):
             headers["Authorization"] = f"Bearer {settings.get('api_key')}"
@@ -384,7 +414,7 @@ class ExternalDatasetService:
                 "score_threshold": score_threshold,
             },
             "query": query,
-            "knowledge_id": external_knowledge_binding.external_knowledge_id,
+            "knowledge_id": resolved_config.external_knowledge_id,
             "metadata_condition": metadata_condition.model_dump() if metadata_condition else None,
         }
 

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -18,6 +18,7 @@ from models import Account
 from models.dataset import Dataset, DatasetQuery
 from models.dataset import Document as DatasetDocument
 from models.enums import CreatorUserRole, DatasetQuerySource
+from services.external_knowledge_service import ExternalDatasetService
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +131,6 @@ class HitTestingService:
             metadata_filtering_conditions = MetadataFilteringCondition.model_validate(metadata_filtering_conditions_raw)
 
             metadata_filter_document_ids, metadata_condition = dataset_retrieval.get_metadata_filter_condition(
-                session=session,
                 dataset_ids=[dataset.id],
                 query=query,
                 metadata_filtering_mode="manual",
@@ -143,7 +143,7 @@ class HitTestingService:
             if metadata_filter_document_ids:
                 document_ids_filter = metadata_filter_document_ids.get(dataset.id, [])
             if metadata_condition and not document_ids_filter:
-                return cls.compact_retrieve_response(query, [], session=session)
+                return cls.compact_retrieve_response(query, [], dataset_id=dataset.id, session=session)
         all_documents = RetrievalService.retrieve(
             retrieval_method=RetrievalMethod(
                 resolved_retrieval_model.get("search_method", RetrievalMethod.SEMANTIC_SEARCH)
@@ -185,7 +185,7 @@ class HitTestingService:
             session.add(dataset_query)
         session.commit()
 
-        return cls.compact_retrieve_response(query, all_documents, session=session)
+        return cls.compact_retrieve_response(query, all_documents, dataset_id=dataset.id, session=session)
 
     @classmethod
     def external_retrieve(
@@ -206,10 +206,22 @@ class HitTestingService:
 
         start = time.perf_counter()
 
-        all_documents = RetrievalService.external_retrieve(
+        dataset_id = dataset.id
+        tenant_id = dataset.tenant_id
+        account_id = account.id
+        resolved_config = ExternalDatasetService.resolve_external_knowledge_config(
+            tenant_id=tenant_id,
+            dataset_id=dataset_id,
             session=session,
-            dataset_id=dataset.id,
+        )
+        # Reuse the request transaction for permission, dataset, binding, and API-template reads, then end that entire
+        # read phase before HTTP. The audit write below safely starts a new transaction through SQLAlchemy autobegin.
+        session.commit()
+        all_documents = RetrievalService.external_retrieve(
+            tenant_id=tenant_id,
+            dataset_id=dataset_id,
             query=cls.escape_query_for_search(query),
+            resolved_config=resolved_config,
             external_retrieval_model=external_retrieval_model,
             metadata_filtering_conditions=metadata_filtering_conditions,
         )
@@ -218,12 +230,12 @@ class HitTestingService:
         logger.debug("External knowledge hit testing retrieve in %s seconds", end - start)
 
         dataset_query = DatasetQuery(
-            dataset_id=dataset.id,
+            dataset_id=dataset_id,
             content=query,
             source=DatasetQuerySource.HIT_TESTING,
             source_app_id=None,
             created_by_role=CreatorUserRole.ACCOUNT,
-            created_by=account.id,
+            created_by=account_id,
         )
 
         session.add(dataset_query)
@@ -233,10 +245,21 @@ class HitTestingService:
 
     @classmethod
     def compact_retrieve_response(
-        cls, query: str, documents: list[Document], *, session: Session
+        cls,
+        query: str,
+        documents: list[Document],
+        *,
+        dataset_id: str,
+        session: Session,
     ) -> RetrieveResponseDict:
+        # format_retrieval_documents possibly writes.
+        # Isolate formatter rollbacks and ORM state from the caller-owned transaction.
         with Session(bind=session.get_bind()) as format_session:
-            records = RetrievalService.format_retrieval_documents(format_session, documents)
+            records = RetrievalService.format_retrieval_documents(
+                format_session,
+                documents,
+                allowed_dataset_ids={dataset_id},
+            )
 
         return {
             "query": {

--- a/api/services/knowledge_retrieval_inner_service.py
+++ b/api/services/knowledge_retrieval_inner_service.py
@@ -62,6 +62,9 @@ class InnerKnowledgeRetrievalService:
         """
         self._validate_caller_app(tenant_id=request.caller.tenant_id, app_id=request.caller.app_id, session=session)
         self._validate_datasets(tenant_id=request.caller.tenant_id, dataset_ids=request.dataset_ids, session=session)
+        # The injected inner-API session contains validation reads only. Release
+        # that transaction before metadata/router model or provider I/O begins.
+        session.commit()
 
         rag = DatasetRetrieval()
         results = rag.knowledge_retrieval(session=session, request=self._to_rag_request(request))

--- a/api/services/summary_index_service.py
+++ b/api/services/summary_index_service.py
@@ -1,12 +1,20 @@
-"""Summary index service for generating and managing document segment summaries."""
+"""Summary index service for generating and managing document segment summaries.
+
+Summary vector publication is conditional on the source segment, summary row,
+and dataset vector configuration remaining unchanged. This prevents slow work
+from committing a pointer to a vector built with obsolete routing or embedding
+settings.
+"""
 
 import logging
 import time
 import uuid
-from datetime import UTC, datetime
-from typing import TypedDict, cast
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from itertools import batched
+from typing import Any, TypedDict, cast
 
-from sqlalchemy import select, update
+from sqlalchemy import select, union_all
 from sqlalchemy.orm import Session
 
 from core.db.session_factory import session_factory
@@ -19,11 +27,73 @@ from core.rag.models.document import Document
 from graphon.model_runtime.entities.llm_entities import LLMUsage
 from graphon.model_runtime.entities.model_entities import ModelType
 from libs import helper
-from models.dataset import Dataset, DocumentSegment, DocumentSegmentSummary
+from models.dataset import (
+    Dataset,
+    DocumentSegment,
+    DocumentSegmentSummary,
+)
 from models.dataset import Document as DatasetDocument
 from models.enums import SummaryStatus
 
 logger = logging.getLogger(__name__)
+
+_GENERATION_CLAIM_PREFIX = "__summary_generation_claim__:"
+_SUMMARY_GENERATION_CLAIM_TIMEOUT = timedelta(days=1)
+_SUMMARY_VECTOR_CLEANUP_BATCH_SIZE = 500
+
+
+class SummaryIndexConflictError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class SummaryGenerationClaim:
+    """Identifies one generation attempt and the segment content it summarizes."""
+
+    dataset_id: str
+    segment_id: str
+    summary_record_id: str
+    generation_token: str
+    source_content_hash: str
+    expected_summary_content: str | None = None
+    expected_status: SummaryStatus = SummaryStatus.GENERATING
+    expected_node_id: str | None = None
+    expected_enabled: bool = True
+    previous_error: str | None = None
+    had_active_publication: bool = False
+
+
+@dataclass(frozen=True)
+class _SummaryVectorDatasetState:
+    """Dataset fields that determine where and how a summary vector is built."""
+
+    tenant_id: str
+    indexing_technique: str | None
+    embedding_model_provider: str | None
+    embedding_model: str | None
+    index_struct: str | None
+    collection_binding_id: str | None
+
+
+@dataclass(frozen=True)
+class _SummaryVectorPublication:
+    dataset_id: str
+    segment_id: str
+    segment_content: str
+    summary_record_id: str
+    summary_content: str
+    old_node_id: str | None
+    new_node_id: str
+    summary_hash: str
+    expected_enabled: bool
+    expected_error: str | None
+    expected_generation_token: str | None
+    embedding_tokens: int
+    expected_dataset_state: _SummaryVectorDatasetState
+    expected_summary_content: str | None = None
+    expected_status: SummaryStatus = SummaryStatus.GENERATING
+    previous_error: str | None = None
+    had_active_publication: bool = False
 
 
 class SummaryEntryDict(TypedDict):
@@ -43,15 +113,745 @@ class DocumentSummaryStatusDetailDict(TypedDict):
 
 
 class SummaryIndexService:
-    """Service for generating and managing summary indexes."""
+    """Service for generating and managing summary indexes.
+
+    Generation stores a tagged per-attempt claim in the otherwise-unused error field. A completed row keeps its
+    published status and vector until the replacement succeeds, while status APIs interpret the claim as active work.
+    The claim has a 24-hour lease and its token is also the pending vector ID, allowing status reads and competing
+    mutations to reclaim abandoned work without a schema change. Every generated database write must still own its
+    unexpired claim so slow work cannot overwrite a newer manual edit or generation attempt.
+    """
+
+    @staticmethod
+    def _lock_segment_rows(session: Session, dataset_id: str, segment_ids: list[str] | None) -> None:
+        if segment_ids == []:
+            return
+
+        stmt = select(DocumentSegment.id).where(DocumentSegment.dataset_id == dataset_id)
+        if segment_ids is not None:
+            stmt = stmt.where(DocumentSegment.id.in_(sorted(set(segment_ids))))
+        session.execute(stmt.order_by(DocumentSegment.id).with_for_update()).all()
+
+    @staticmethod
+    def _publication_is_durable(publication: _SummaryVectorPublication) -> bool:
+        """Reconcile a commit whose client acknowledgement may have been lost."""
+        with session_factory.create_session() as session:
+            summary = session.scalar(
+                select(DocumentSegmentSummary).where(
+                    DocumentSegmentSummary.id == publication.summary_record_id,
+                    DocumentSegmentSummary.dataset_id == publication.dataset_id,
+                    DocumentSegmentSummary.chunk_id == publication.segment_id,
+                )
+            )
+            return bool(
+                summary
+                and summary.summary_index_node_id == publication.new_node_id
+                and summary.summary_index_node_hash == publication.summary_hash
+                and summary.summary_content == publication.summary_content
+                and summary.status == SummaryStatus.COMPLETED
+                and summary.error is None
+            )
+
+    @staticmethod
+    def _get_summary_record(
+        session: Session,
+        segment_id: str,
+        dataset_id: str,
+        *,
+        for_update: bool = False,
+    ) -> DocumentSegmentSummary | None:
+        stmt = (
+            select(DocumentSegmentSummary)
+            .where(
+                DocumentSegmentSummary.chunk_id == segment_id,
+                DocumentSegmentSummary.dataset_id == dataset_id,
+            )
+            .order_by(
+                DocumentSegmentSummary.updated_at.desc(),
+                DocumentSegmentSummary.id.desc(),
+            )
+            .limit(1)
+        )
+        if for_update:
+            stmt = stmt.with_for_update()
+        return session.scalar(stmt)
+
+    @staticmethod
+    def _get_segment_content(session: Session, dataset_id: str, segment_id: str) -> str | None:
+        return session.scalar(
+            select(DocumentSegment.content)
+            .where(
+                DocumentSegment.id == segment_id,
+                DocumentSegment.dataset_id == dataset_id,
+            )
+            .limit(1)
+        )
+
+    @staticmethod
+    def _summary_vector_dataset_state(dataset: Dataset) -> _SummaryVectorDatasetState:
+        return _SummaryVectorDatasetState(
+            tenant_id=dataset.tenant_id,
+            indexing_technique=str(dataset.indexing_technique) if dataset.indexing_technique is not None else None,
+            embedding_model_provider=dataset.embedding_model_provider,
+            embedding_model=dataset.embedding_model,
+            index_struct=dataset.index_struct,
+            collection_binding_id=dataset.collection_binding_id,
+        )
+
+    @staticmethod
+    def _get_publication_dataset(
+        session: Session,
+        publication: _SummaryVectorPublication,
+    ) -> Dataset:
+        """Lock and validate the vector-building dataset snapshot."""
+        dataset = session.get(Dataset, publication.dataset_id, with_for_update=True)
+        if dataset is None:
+            raise SummaryIndexConflictError(
+                f"Summary {publication.summary_record_id} dataset was deleted during vectorization"
+            )
+        if SummaryIndexService._summary_vector_dataset_state(dataset) != publication.expected_dataset_state:
+            raise SummaryIndexConflictError(
+                f"Summary {publication.summary_record_id} dataset configuration changed during vectorization"
+            )
+        return dataset
+
+    @staticmethod
+    def _publish_summary_vector(publication: _SummaryVectorPublication) -> datetime:
+        """Commit a vector pointer only if its database inputs are unchanged."""
+        with session_factory.create_session() as session:
+            SummaryIndexService._lock_segment_rows(session, publication.dataset_id, [publication.segment_id])
+            SummaryIndexService._get_publication_dataset(session, publication)
+            summary = session.scalar(
+                select(DocumentSegmentSummary)
+                .where(
+                    DocumentSegmentSummary.id == publication.summary_record_id,
+                    DocumentSegmentSummary.dataset_id == publication.dataset_id,
+                    DocumentSegmentSummary.chunk_id == publication.segment_id,
+                )
+                .with_for_update()
+            )
+            if summary is None:
+                replacement = SummaryIndexService._get_summary_record(
+                    session,
+                    publication.segment_id,
+                    publication.dataset_id,
+                    for_update=True,
+                )
+                if replacement is None:
+                    raise SummaryIndexConflictError(
+                        f"Summary {publication.summary_record_id} was deleted while segment "
+                        f"{publication.segment_id} was being vectorized"
+                    )
+                raise SummaryIndexConflictError(
+                    f"Summary {publication.summary_record_id} was replaced by {replacement.id} while segment "
+                    f"{publication.segment_id} was being vectorized"
+                )
+
+            source_changed = (
+                publication.expected_generation_token is not None
+                and SummaryIndexService._get_segment_content(
+                    session,
+                    publication.dataset_id,
+                    publication.segment_id,
+                )
+                != publication.segment_content
+            )
+            if (
+                summary.summary_index_node_id != publication.old_node_id
+                or summary.summary_content != publication.expected_summary_content
+                or summary.status != publication.expected_status
+                or summary.enabled != publication.expected_enabled
+                or summary.error != publication.expected_error
+                or (
+                    publication.expected_generation_token is not None
+                    and SummaryIndexService._generation_claim_is_stale(summary)
+                )
+                or source_changed
+                or not SummaryIndexService._segment_allows_summary(
+                    session,
+                    publication.dataset_id,
+                    publication.segment_id,
+                )
+            ):
+                raise SummaryIndexConflictError(f"Summary {publication.summary_record_id} vectorization was superseded")
+
+            updated_at = datetime.now(UTC).replace(tzinfo=None)
+            summary.summary_index_node_id = publication.new_node_id
+            summary.summary_index_node_hash = publication.summary_hash
+            summary.summary_content = publication.summary_content
+            summary.tokens = publication.embedding_tokens
+            summary.status = SummaryStatus.COMPLETED
+            summary.error = None
+            summary.updated_at = updated_at
+            session.add(summary)
+            session.commit()
+            return updated_at
+
+    @staticmethod
+    def _record_vectorization_failure(
+        publication: _SummaryVectorPublication,
+        error: Exception,
+        target: DocumentSegmentSummary,
+    ) -> None:
+        """Mark only the exact, unchanged summary row as failed."""
+        with session_factory.create_session() as session:
+            SummaryIndexService._lock_segment_rows(session, publication.dataset_id, [publication.segment_id])
+            try:
+                SummaryIndexService._get_publication_dataset(session, publication)
+            except SummaryIndexConflictError:
+                logger.info(
+                    "Skipped stale vectorization error for summary %s after dataset configuration changed",
+                    publication.summary_record_id,
+                )
+                return
+            summary = session.scalar(
+                select(DocumentSegmentSummary)
+                .where(
+                    DocumentSegmentSummary.id == publication.summary_record_id,
+                    DocumentSegmentSummary.dataset_id == publication.dataset_id,
+                    DocumentSegmentSummary.chunk_id == publication.segment_id,
+                )
+                .with_for_update()
+            )
+            if summary is None:
+                logger.info(
+                    "Skipped vectorization error for deleted summary %s",
+                    publication.summary_record_id,
+                )
+                return
+
+            source_changed = (
+                publication.expected_generation_token is not None
+                and SummaryIndexService._get_segment_content(
+                    session,
+                    publication.dataset_id,
+                    publication.segment_id,
+                )
+                != publication.segment_content
+            )
+            if (
+                summary.summary_index_node_id != publication.old_node_id
+                or summary.summary_content != publication.expected_summary_content
+                or summary.status != publication.expected_status
+                or summary.enabled != publication.expected_enabled
+                or summary.error != publication.expected_error
+                or source_changed
+            ):
+                logger.info(
+                    "Skipped stale vectorization error for summary %s",
+                    publication.summary_record_id,
+                )
+                return
+
+            if publication.had_active_publication:
+                summary.status = publication.expected_status
+                summary.error = publication.previous_error
+            else:
+                summary.status = SummaryStatus.ERROR
+                summary.error = f"Vectorization failed: {error}"
+            summary.updated_at = datetime.now(UTC).replace(tzinfo=None)
+            session.add(summary)
+            session.commit()
+            target.summary_content = summary.summary_content
+            target.summary_index_node_id = summary.summary_index_node_id
+            target.summary_index_node_hash = summary.summary_index_node_hash
+            target.tokens = summary.tokens
+            target.status = summary.status
+            target.error = summary.error
+            target.enabled = summary.enabled
+            target.updated_at = summary.updated_at
+
+    @staticmethod
+    def _apply_publication(
+        target: DocumentSegmentSummary,
+        publication: _SummaryVectorPublication,
+        updated_at: datetime,
+    ) -> None:
+        target.summary_index_node_id = publication.new_node_id
+        target.summary_index_node_hash = publication.summary_hash
+        target.summary_content = publication.summary_content
+        target.tokens = publication.embedding_tokens
+        target.status = SummaryStatus.COMPLETED
+        target.error = None
+        target.updated_at = updated_at
+
+    @staticmethod
+    def _is_transient_vector_error(error: Exception) -> bool:
+        if isinstance(error, ConnectionError):
+            return True
+        message = str(error).lower()
+        return any(
+            marker in message
+            for marker in (
+                "connection",
+                "disconnected",
+                "timeout",
+                "network",
+                "could not connect",
+                "server disconnected",
+                "weaviate",
+            )
+        )
+
+    @staticmethod
+    def _commit_caller_session_before_external_io(session: Session | None) -> None:
+        """Commit caller-owned work without expiring ORM state used by follow-up external I/O.
+
+        Flask-SQLAlchemy sessions expire loaded objects on commit. Summary generation/vectorization intentionally
+        commits before calling LLM/vector providers, but expired ``Dataset``/``DocumentSegment`` instances would lazy
+        refresh on first attribute access and hold a DB connection open across those provider calls.
+        """
+        if session is None:
+            return
+
+        session_with_expiration: Any = session
+        if not hasattr(session_with_expiration, "expire_on_commit") and callable(session):
+            session_with_expiration = session()
+
+        expire_on_commit = session_with_expiration.expire_on_commit
+        if not isinstance(expire_on_commit, bool):
+            session.commit()
+            return
+
+        session_with_expiration.expire_on_commit = False
+        try:
+            session.commit()
+        finally:
+            session_with_expiration.expire_on_commit = expire_on_commit
+
+    @staticmethod
+    def _embedding_token_count(dataset: Dataset, summary_content: str) -> int:
+        try:
+            model_manager = ModelManager.for_tenant(tenant_id=dataset.tenant_id)
+            embedding_model = model_manager.get_model_instance(
+                tenant_id=dataset.tenant_id,
+                provider=dataset.embedding_model_provider,
+                model_type=ModelType.TEXT_EMBEDDING,
+                model=dataset.embedding_model,
+            )
+            if embedding_model is None:
+                return 0
+            token_counts = embedding_model.get_text_embedding_num_tokens([summary_content])
+            token_count = token_counts[0] if token_counts else 0
+            return token_count if isinstance(token_count, int) else 0
+        except Exception as error:
+            logger.warning("Failed to calculate embedding tokens for summary: %s", error)
+            return 0
+
+    @staticmethod
+    def _generation_claim_marker(generation_token: str) -> str:
+        return f"{_GENERATION_CLAIM_PREFIX}{generation_token}"
+
+    @staticmethod
+    def _generation_token_from_error(error: str | None) -> str | None:
+        if not error or not error.startswith(_GENERATION_CLAIM_PREFIX):
+            return None
+        generation_token = error.removeprefix(_GENERATION_CLAIM_PREFIX)
+        return generation_token or None
+
+    @staticmethod
+    def _clear_generation_claim(summary_record: DocumentSegmentSummary) -> str | None:
+        generation_token = SummaryIndexService._generation_token_from_error(summary_record.error)
+        if generation_token is not None:
+            summary_record.error = None
+        return generation_token
+
+    @staticmethod
+    def _generation_claim_is_stale(summary_record: DocumentSegmentSummary) -> bool:
+        updated_at = summary_record.updated_at
+        if not isinstance(updated_at, datetime):
+            return False
+        if updated_at.tzinfo is not None:
+            updated_at = updated_at.astimezone(UTC).replace(tzinfo=None)
+        return updated_at <= datetime.now(UTC).replace(tzinfo=None) - _SUMMARY_GENERATION_CLAIM_TIMEOUT
+
+    @staticmethod
+    def _effective_summary_status(summary_record: DocumentSegmentSummary) -> SummaryStatus:
+        if SummaryIndexService._generation_token_from_error(summary_record.error) is not None:
+            if SummaryIndexService._generation_claim_is_stale(summary_record):
+                if SummaryIndexService._summary_has_active_publication(summary_record):
+                    return SummaryStatus.COMPLETED
+                return SummaryStatus.ERROR
+            return SummaryStatus.GENERATING
+        return SummaryStatus(summary_record.status)
+
+    @staticmethod
+    def _recover_stale_generation_claims(
+        dataset_id: str,
+        summaries: list[DocumentSegmentSummary],
+    ) -> None:
+        """Reclaim expired attempts already encountered by a status read.
+
+        The claim token is also the pending vector ID, so recovery can retire an
+        uncommitted vector without adding a database column or scanning the
+        summary table. Rows are rechecked under lock before their claims change.
+        """
+        stale_claims = {
+            summary.id: (
+                summary.chunk_id,
+                generation_token,
+            )
+            for summary in summaries
+            if (generation_token := SummaryIndexService._generation_token_from_error(summary.error)) is not None
+            and SummaryIndexService._generation_claim_is_stale(summary)
+        }
+        if not stale_claims:
+            return
+
+        retired_node_ids: list[str] = []
+        with session_factory.create_session() as session:
+            SummaryIndexService._lock_segment_rows(
+                session,
+                dataset_id,
+                [chunk_id for chunk_id, _generation_token in stale_claims.values()],
+            )
+            claimed_summaries = session.scalars(
+                select(DocumentSegmentSummary)
+                .where(
+                    DocumentSegmentSummary.id.in_(stale_claims),
+                    DocumentSegmentSummary.dataset_id == dataset_id,
+                )
+                .with_for_update()
+            ).all()
+            for summary in claimed_summaries:
+                expected_chunk_id, expected_generation_token = stale_claims[summary.id]
+                if (
+                    summary.chunk_id != expected_chunk_id
+                    or SummaryIndexService._generation_token_from_error(summary.error) != expected_generation_token
+                    or not SummaryIndexService._generation_claim_is_stale(summary)
+                ):
+                    continue
+
+                if SummaryIndexService._summary_has_active_publication(summary):
+                    summary.error = None
+                else:
+                    summary.status = SummaryStatus.ERROR
+                    summary.error = "Summary generation timed out"
+                retired_node_ids.append(expected_generation_token)
+                session.add(summary)
+
+            if retired_node_ids:
+                session.commit()
+
+        if retired_node_ids:
+            delete_unreferenced_summary_vectors(dataset_id, retired_node_ids)
+
+    @staticmethod
+    def _generation_claim_is_current(
+        session: Session,
+        summary_record: DocumentSegmentSummary,
+        claim: SummaryGenerationClaim,
+    ) -> bool:
+        if (
+            summary_record.id != claim.summary_record_id
+            or summary_record.dataset_id != claim.dataset_id
+            or summary_record.chunk_id != claim.segment_id
+            or SummaryIndexService._generation_token_from_error(summary_record.error) != claim.generation_token
+            or SummaryIndexService._generation_claim_is_stale(summary_record)
+        ):
+            return False
+
+        source_content = SummaryIndexService._get_segment_content(session, claim.dataset_id, claim.segment_id)
+        return source_content is not None and helper.generate_text_hash(source_content) == claim.source_content_hash
+
+    @staticmethod
+    def _generation_claim_token_is_current(
+        summary_record: DocumentSegmentSummary,
+        claim: SummaryGenerationClaim,
+    ) -> bool:
+        return (
+            summary_record.id == claim.summary_record_id
+            and summary_record.dataset_id == claim.dataset_id
+            and summary_record.chunk_id == claim.segment_id
+            and SummaryIndexService._generation_token_from_error(summary_record.error) == claim.generation_token
+        )
+
+    @staticmethod
+    def _summary_has_active_publication(summary_record: DocumentSegmentSummary) -> bool:
+        return bool(
+            summary_record.enabled
+            and summary_record.status == SummaryStatus.COMPLETED
+            and summary_record.summary_content
+            and summary_record.summary_index_node_id
+        )
+
+    @staticmethod
+    def _finish_claim_with_error(
+        summary_record: DocumentSegmentSummary,
+        claim: SummaryGenerationClaim,
+        error: str,
+    ) -> None:
+        """Restore the publication snapshot and expose an error only when no publication existed."""
+        summary_record.summary_content = claim.expected_summary_content
+        summary_record.summary_index_node_id = claim.expected_node_id
+        summary_record.enabled = claim.expected_enabled
+        if claim.had_active_publication:
+            summary_record.status = claim.expected_status
+            summary_record.error = claim.previous_error
+        else:
+            summary_record.status = SummaryStatus.ERROR
+            summary_record.error = error
+
+    @staticmethod
+    def _abandon_generation_claim(claim: SummaryGenerationClaim) -> None:
+        """Best-effort release of a still-owned claim after stale publication."""
+        try:
+            with session_factory.create_session() as session:
+                SummaryIndexService._lock_segment_rows(session, claim.dataset_id, [claim.segment_id])
+                summary_record = session.get(DocumentSegmentSummary, claim.summary_record_id, with_for_update=True)
+                if not summary_record or not SummaryIndexService._generation_claim_token_is_current(
+                    summary_record, claim
+                ):
+                    return
+
+                SummaryIndexService._finish_claim_with_error(
+                    summary_record,
+                    claim,
+                    "Summary generation was superseded before publication",
+                )
+                session.add(summary_record)
+                session.commit()
+        except Exception:
+            logger.warning(
+                "Failed to release generation claim %s for summary %s",
+                claim.generation_token,
+                claim.summary_record_id,
+                exc_info=True,
+            )
+
+    @staticmethod
+    def _summary_allowed_segment_ids(session: Session, dataset_id: str, segment_ids: list[str]) -> set[str]:
+        return set(
+            session.scalars(
+                select(DocumentSegment.id)
+                .join(DatasetDocument, DatasetDocument.id == DocumentSegment.document_id)
+                .where(
+                    DocumentSegment.id.in_(segment_ids),
+                    DocumentSegment.dataset_id == dataset_id,
+                    DocumentSegment.enabled.is_(True),
+                    DocumentSegment.status == "completed",
+                    DatasetDocument.dataset_id == dataset_id,
+                    DatasetDocument.enabled.is_(True),
+                    DatasetDocument.archived.is_(False),
+                    DatasetDocument.indexing_status == "completed",
+                )
+            ).all()
+        )
+
+    @staticmethod
+    def _segment_allows_summary(session: Session, dataset_id: str, segment_id: str) -> bool:
+        stmt = (
+            select(DocumentSegment.id)
+            .join(DatasetDocument, DatasetDocument.id == DocumentSegment.document_id)
+            .where(
+                DocumentSegment.id == segment_id,
+                DocumentSegment.dataset_id == dataset_id,
+                DocumentSegment.enabled.is_(True),
+                DocumentSegment.status == "completed",
+                DatasetDocument.dataset_id == dataset_id,
+                DatasetDocument.enabled.is_(True),
+                DatasetDocument.archived.is_(False),
+                DatasetDocument.indexing_status == "completed",
+            )
+        )
+        return session.execute(stmt).scalar_one_or_none() is not None
+
+    @staticmethod
+    def _reenable_summary_record(summary_record: DocumentSegmentSummary) -> None:
+        if summary_record.enabled:
+            return
+
+        summary_record.enabled = True
+        summary_record.disabled_at = None
+        summary_record.disabled_by = None
+
+    @staticmethod
+    def _mark_summary_generation_started(
+        segment: DocumentSegment,
+        dataset: Dataset,
+    ) -> SummaryGenerationClaim:
+        """Claim a summary row for one automatic generation attempt.
+
+        The caller must present the returned claim when saving generated content. A competing generation replaces the
+        marker, while a manual or administrative mutation clears it. The source-content comparison also rejects a
+        detached segment that was already stale when this method acquired the row lock.
+        """
+        superseded_generation_token: str | None = None
+        with session_factory.create_session() as session:
+            SummaryIndexService._lock_segment_rows(session, dataset.id, [segment.id])
+            if not SummaryIndexService._segment_allows_summary(session, dataset.id, segment.id):
+                raise SummaryIndexConflictError(f"Segment {segment.id} no longer accepts summaries")
+            source_content = SummaryIndexService._get_segment_content(session, dataset.id, segment.id)
+            if source_content is None or source_content != segment.content:
+                raise SummaryIndexConflictError(f"Segment {segment.id} changed before summary generation started")
+            summary_record = SummaryIndexService._get_summary_record(
+                session,
+                segment.id,
+                dataset.id,
+                for_update=True,
+            )
+
+            if not summary_record:
+                logger.warning("Summary record not found for segment %s, creating one", segment.id)
+                summary_record = DocumentSegmentSummary(
+                    dataset_id=dataset.id,
+                    document_id=segment.document_id,
+                    chunk_id=segment.id,
+                    summary_content="",
+                    status=SummaryStatus.GENERATING,
+                    enabled=True,
+                )
+                had_active_publication = False
+                previous_error = None
+            else:
+                had_active_publication = SummaryIndexService._summary_has_active_publication(summary_record)
+                superseded_generation_token = SummaryIndexService._generation_token_from_error(summary_record.error)
+                previous_error = None if superseded_generation_token is not None else summary_record.error
+                SummaryIndexService._reenable_summary_record(summary_record)
+
+            generation_token = str(uuid.uuid4())
+            if not had_active_publication:
+                summary_record.status = SummaryStatus.GENERATING
+            summary_record.error = SummaryIndexService._generation_claim_marker(generation_token)
+            session.add(summary_record)
+            claim = SummaryGenerationClaim(
+                dataset_id=dataset.id,
+                segment_id=segment.id,
+                summary_record_id=summary_record.id,
+                generation_token=generation_token,
+                source_content_hash=helper.generate_text_hash(source_content),
+                expected_summary_content=summary_record.summary_content,
+                expected_status=summary_record.status,
+                expected_node_id=summary_record.summary_index_node_id,
+                expected_enabled=summary_record.enabled,
+                previous_error=previous_error,
+                had_active_publication=had_active_publication,
+            )
+            session.commit()
+
+        if superseded_generation_token is not None:
+            delete_unreferenced_summary_vectors(dataset.id, [superseded_generation_token])
+        return claim
+
+    @staticmethod
+    def _save_summary_content(
+        segment: DocumentSegment,
+        dataset: Dataset,
+        summary_content: str,
+        *,
+        generation_claim: SummaryGenerationClaim | None = None,
+        status: SummaryStatus = SummaryStatus.GENERATING,
+    ) -> DocumentSegmentSummary:
+        """Stage claimed content or persist unclaimed content after locking its owner.
+
+        Claimed content remains detached until vector publication atomically replaces the prior database content.
+        It is rejected if another operation superseded or expired the claim. Calls without a claim persist immediately
+        and clear any prior generation claim.
+        """
+        superseded_generation_token: str | None = None
+        with session_factory.create_session() as session:
+            SummaryIndexService._lock_segment_rows(session, dataset.id, [segment.id])
+            if not SummaryIndexService._segment_allows_summary(session, dataset.id, segment.id):
+                raise SummaryIndexConflictError(f"Segment {segment.id} no longer accepts summaries")
+            if generation_claim:
+                if generation_claim.dataset_id != dataset.id or generation_claim.segment_id != segment.id:
+                    raise SummaryIndexConflictError("Summary generation claim does not match the target segment")
+                summary_record = session.get(
+                    DocumentSegmentSummary,
+                    generation_claim.summary_record_id,
+                    with_for_update=True,
+                )
+                if not summary_record:
+                    raise SummaryIndexConflictError(
+                        f"Summary {generation_claim.summary_record_id} was deleted while segment {segment.id} "
+                        "was being generated"
+                    )
+                if not SummaryIndexService._generation_claim_is_current(session, summary_record, generation_claim):
+                    raise SummaryIndexConflictError(
+                        f"Summary {generation_claim.summary_record_id} generation was superseded"
+                    )
+                staged_summary = DocumentSegmentSummary(
+                    dataset_id=summary_record.dataset_id,
+                    document_id=summary_record.document_id,
+                    chunk_id=summary_record.chunk_id,
+                    summary_content=summary_content,
+                    summary_index_node_id=summary_record.summary_index_node_id,
+                    summary_index_node_hash=summary_record.summary_index_node_hash,
+                    tokens=summary_record.tokens,
+                    status=status,
+                    error=summary_record.error,
+                    enabled=summary_record.enabled,
+                    disabled_at=summary_record.disabled_at,
+                    disabled_by=summary_record.disabled_by,
+                )
+                staged_summary.id = summary_record.id
+                staged_summary.created_at = summary_record.created_at
+                staged_summary.updated_at = summary_record.updated_at
+                return staged_summary
+            else:
+                summary_record = SummaryIndexService._get_summary_record(
+                    session,
+                    segment.id,
+                    dataset.id,
+                    for_update=True,
+                )
+
+            if not summary_record:
+                summary_record = DocumentSegmentSummary(
+                    dataset_id=dataset.id,
+                    document_id=segment.document_id,
+                    chunk_id=segment.id,
+                    summary_content=summary_content,
+                    status=status,
+                    enabled=True,
+                )
+            else:
+                summary_record.summary_content = summary_content
+                summary_record.status = status
+                superseded_generation_token = SummaryIndexService._clear_generation_claim(summary_record)
+                if superseded_generation_token is None:
+                    summary_record.error = None
+                SummaryIndexService._reenable_summary_record(summary_record)
+
+            session.add(summary_record)
+            session.commit()
+
+        if superseded_generation_token is not None:
+            delete_unreferenced_summary_vectors(dataset.id, [superseded_generation_token])
+        return summary_record
+
+    @staticmethod
+    def _enable_summary_record(
+        summary_record_id: str,
+        segment_id: str,
+        dataset_id: str,
+    ) -> bool:
+        superseded_generation_token: str | None = None
+        with session_factory.create_session() as session:
+            SummaryIndexService._lock_segment_rows(session, dataset_id, [segment_id])
+            summary_record = session.get(DocumentSegmentSummary, summary_record_id, with_for_update=True)
+            if (
+                not summary_record
+                or summary_record.dataset_id != dataset_id
+                or summary_record.chunk_id != segment_id
+                or not SummaryIndexService._segment_allows_summary(session, dataset_id, segment_id)
+            ):
+                return False
+
+            SummaryIndexService._reenable_summary_record(summary_record)
+            superseded_generation_token = SummaryIndexService._clear_generation_claim(summary_record)
+            session.add(summary_record)
+            session.commit()
+
+        if superseded_generation_token is not None:
+            delete_unreferenced_summary_vectors(dataset_id, [superseded_generation_token])
+        return True
 
     @staticmethod
     def generate_summary_for_segment(
         segment: DocumentSegment,
         dataset: Dataset,
         summary_index_setting: SummaryIndexSettingDict,
-        *,
-        session: Session,
     ) -> tuple[str, LLMUsage]:
         """
         Generate summary for a single segment.
@@ -60,9 +860,6 @@ class SummaryIndexService:
             segment: DocumentSegment to generate summary for
             dataset: Dataset containing the segment
             summary_index_setting: Summary index configuration
-
-        Keyword Args:
-            session: SQLAlchemy session used to load the segment's document.
 
         Returns:
             Tuple of (summary_content, llm_usage) where llm_usage is LLMUsage object
@@ -74,12 +871,13 @@ class SummaryIndexService:
         # Use lazy import to avoid circular import
         from core.rag.index_processor.processor.paragraph_index_processor import ParagraphIndexProcessor
 
-        # Get document language to ensure summary is generated in the correct language
-        # This is especially important for image-only chunks where text is empty or minimal
-        document_language = None
-        document = segment.get_document(session=session)
-        if document and document.doc_language:
-            document_language = document.doc_language
+        with session_factory.create_session() as session:
+            document_language = session.scalar(
+                select(DatasetDocument.doc_language).where(
+                    DatasetDocument.id == segment.document_id,
+                    DatasetDocument.dataset_id == dataset.id,
+                )
+            )
 
         summary_content, usage = ParagraphIndexProcessor.generate_summary(
             tenant_id=dataset.tenant_id,
@@ -87,7 +885,6 @@ class SummaryIndexService:
             summary_index_setting=summary_index_setting,
             segment_id=segment.id,
             document_language=document_language,
-            session=session,
         )
 
         if not summary_content:
@@ -101,12 +898,11 @@ class SummaryIndexService:
         dataset: Dataset,
         summary_content: str,
         status: SummaryStatus = SummaryStatus.GENERATING,
-        *,
-        session: Session,
     ) -> DocumentSegmentSummary:
         """
         Create or update a DocumentSegmentSummary record.
         If a summary record already exists for this segment, it will be updated instead of creating a new one.
+        The write is committed before returning so follow-up vectorization can run without a dirty DB session.
 
         Args:
             segment: DocumentSegment to create summary for
@@ -114,48 +910,15 @@ class SummaryIndexService:
             summary_content: Generated summary content
             status: Summary status (default: SummaryStatus.GENERATING)
 
-        Keyword Args:
-            session: SQLAlchemy session used for the summary record.
-
         Returns:
             Created or updated DocumentSegmentSummary instance
         """
-        # Check if summary record already exists
-        existing_summary = session.scalar(
-            select(DocumentSegmentSummary)
-            .where(
-                DocumentSegmentSummary.chunk_id == segment.id,
-                DocumentSegmentSummary.dataset_id == dataset.id,
-            )
-            .limit(1)
+        return SummaryIndexService._save_summary_content(
+            segment=segment,
+            dataset=dataset,
+            summary_content=summary_content,
+            status=status,
         )
-
-        if existing_summary:
-            # Update existing record
-            existing_summary.summary_content = summary_content
-            existing_summary.status = status
-            existing_summary.error = None  # Clear any previous errors
-            # Re-enable if it was disabled
-            if not existing_summary.enabled:
-                existing_summary.enabled = True
-                existing_summary.disabled_at = None
-                existing_summary.disabled_by = None
-            session.add(existing_summary)
-            session.flush()
-            return existing_summary
-        else:
-            # Create new record (enabled by default)
-            summary_record = DocumentSegmentSummary(
-                dataset_id=dataset.id,
-                document_id=segment.document_id,
-                chunk_id=segment.id,
-                summary_content=summary_content,
-                status=status,
-                enabled=True,  # Explicitly set enabled to True
-            )
-            session.add(summary_record)
-            session.flush()
-            return summary_record
 
     @staticmethod
     def vectorize_summary(
@@ -163,16 +926,13 @@ class SummaryIndexService:
         segment: DocumentSegment,
         dataset: Dataset,
         session: Session | None = None,
+        *,
+        generation_claim: SummaryGenerationClaim | None = None,
     ) -> None:
-        """
-        Vectorize summary and store in vector database.
+        """Publish a replacement summary vector, then retire the previous vector.
 
-        Args:
-            summary_record: DocumentSegmentSummary record
-            segment: Original DocumentSegment
-            dataset: Dataset containing the segment
-            session: Optional SQLAlchemy session. If provided, uses this session instead of creating a new one.
-                    If not provided, creates a new session and commits automatically.
+        A supplied session is committed before external I/O; publication uses a
+        fresh transaction and rejects any intervening summary or segment change.
         """
         if dataset.indexing_technique != IndexTechniqueType.HIGH_QUALITY:
             logger.warning(
@@ -180,391 +940,172 @@ class SummaryIndexService:
                 dataset.id,
             )
             return
+        SummaryIndexService._commit_caller_session_before_external_io(session)
 
-        # Get summary_record_id for later session queries
-        summary_record_id = summary_record.id
-        # Save the original session parameter for use in error handling
-        original_session = session
-
-        def create_vector() -> Vector:
-            if original_session is not None:
-                return Vector(dataset, session=original_session)
-            with session_factory.create_session() as vector_session:
-                return Vector(dataset, session=vector_session)
-
-        logger.debug(
-            "Starting vectorization for segment %s, summary_record_id=%s, using_provided_session=%s",
-            segment.id,
-            summary_record_id,
-            original_session is not None,
-        )
-
-        # Reuse existing index_node_id if available (like segment does), otherwise generate new one
-        old_summary_node_id = summary_record.summary_index_node_id
-        if old_summary_node_id:
-            # Reuse existing index_node_id (like segment behavior)
-            summary_index_node_id = old_summary_node_id
-            logger.debug("Reusing existing index_node_id %s for segment %s", summary_index_node_id, segment.id)
-        else:
-            # Generate new index node ID only for new summaries
-            summary_index_node_id = str(uuid.uuid4())
-            logger.debug("Generated new index_node_id %s for segment %s", summary_index_node_id, segment.id)
-
-        # Always regenerate hash (in case summary content changed)
         summary_content = summary_record.summary_content
         if not summary_content or not summary_content.strip():
             raise ValueError(f"Summary content is empty for segment {segment.id}, cannot vectorize")
-        summary_hash = helper.generate_text_hash(summary_content)
 
-        # Delete old vector only if we're reusing the same index_node_id (to overwrite)
-        # If index_node_id changed, the old vector should have been deleted elsewhere
-        if old_summary_node_id and old_summary_node_id == summary_index_node_id:
-            try:
-                vector = create_vector()
-                vector.delete_by_ids([old_summary_node_id])
-            except Exception as e:
-                logger.warning(
-                    "Failed to delete old summary vector for segment %s: %s. Continuing with new vectorization.",
-                    segment.id,
-                    str(e),
-                )
+        if generation_claim is not None and (
+            generation_claim.dataset_id != dataset.id
+            or generation_claim.segment_id != segment.id
+            or generation_claim.summary_record_id != summary_record.id
+        ):
+            raise SummaryIndexConflictError("Summary generation claim does not match the vectorization target")
 
-        # Calculate embedding tokens for summary (for logging and statistics)
-        embedding_tokens = 0
-        try:
-            model_manager = ModelManager.for_tenant(tenant_id=dataset.tenant_id)
-            embedding_model = model_manager.get_model_instance(
-                tenant_id=dataset.tenant_id,
-                provider=dataset.embedding_model_provider,
-                model_type=ModelType.TEXT_EMBEDDING,
-                model=dataset.embedding_model,
-            )
-            if embedding_model:
-                tokens_list = embedding_model.get_text_embedding_num_tokens([summary_content])
-                raw_embedding_tokens = tokens_list[0] if tokens_list else 0
-                embedding_tokens = raw_embedding_tokens if isinstance(raw_embedding_tokens, int) else 0
-        except Exception as e:
-            logger.warning("Failed to calculate embedding tokens for summary: %s", str(e))
-
-        # Create document with summary content and metadata
+        publication = _SummaryVectorPublication(
+            dataset_id=dataset.id,
+            segment_id=segment.id,
+            segment_content=segment.content,
+            summary_record_id=summary_record.id,
+            summary_content=summary_content,
+            old_node_id=(
+                generation_claim.expected_node_id
+                if generation_claim is not None
+                else summary_record.summary_index_node_id
+            ),
+            new_node_id=generation_claim.generation_token if generation_claim is not None else str(uuid.uuid4()),
+            summary_hash=helper.generate_text_hash(summary_content),
+            expected_enabled=(
+                generation_claim.expected_enabled if generation_claim is not None else summary_record.enabled
+            ),
+            expected_error=(
+                SummaryIndexService._generation_claim_marker(generation_claim.generation_token)
+                if generation_claim is not None
+                else summary_record.error
+            ),
+            expected_generation_token=(
+                generation_claim.generation_token
+                if generation_claim is not None
+                else SummaryIndexService._generation_token_from_error(summary_record.error)
+            ),
+            embedding_tokens=SummaryIndexService._embedding_token_count(dataset, summary_content),
+            expected_dataset_state=SummaryIndexService._summary_vector_dataset_state(dataset),
+            expected_summary_content=(
+                generation_claim.expected_summary_content
+                if generation_claim is not None
+                else summary_record.summary_content
+            ),
+            expected_status=(
+                generation_claim.expected_status if generation_claim is not None else summary_record.status
+            ),
+            previous_error=generation_claim.previous_error if generation_claim is not None else summary_record.error,
+            had_active_publication=(
+                generation_claim.had_active_publication
+                if generation_claim is not None
+                else SummaryIndexService._summary_has_active_publication(summary_record)
+            ),
+        )
         summary_document = Document(
             page_content=summary_content,
             metadata={
-                "doc_id": summary_index_node_id,
-                "doc_hash": summary_hash,
+                "doc_id": publication.new_node_id,
+                "doc_hash": publication.summary_hash,
                 "dataset_id": dataset.id,
                 "document_id": segment.document_id,
-                "original_chunk_id": segment.id,  # Key: link to original chunk
+                "original_chunk_id": segment.id,
                 "doc_type": DocType.TEXT,
-                "is_summary": True,  # Identifier for summary documents
+                "is_summary": True,
             },
         )
 
-        # Vectorize and store with retry mechanism for connection errors
-        max_retries = 3
-        retry_delay = 2.0
-
-        for attempt in range(max_retries):
+        max_attempts = 3
+        vector: Vector | None = None
+        vector_was_added = False
+        for attempt in range(max_attempts):
             try:
-                logger.debug(
-                    "Attempting to vectorize summary for segment %s (attempt %s/%s)",
-                    segment.id,
-                    attempt + 1,
-                    max_retries,
-                )
-                vector = create_vector()
-                # Use duplicate_check=False to ensure re-vectorization even if old vector still exists
-                # The old vector should have been deleted above, but if deletion failed,
-                # we still want to re-vectorize (upsert will overwrite)
+                vector = Vector(dataset)
                 vector.add_texts([summary_document], duplicate_check=False)
-                logger.debug(
-                    "Successfully added summary vector to database for segment %s (attempt %s/%s)",
-                    segment.id,
-                    attempt + 1,
-                    max_retries,
-                )
+                vector_was_added = True
+                updated_at = SummaryIndexService._publish_summary_vector(publication)
+            except Exception as error:
+                transient = SummaryIndexService._is_transient_vector_error(error)
+                reconciliation_failed = False
+                durable = False
+                if vector_was_added:
+                    try:
+                        durable = SummaryIndexService._publication_is_durable(publication)
+                    except Exception:
+                        reconciliation_failed = True
+                        logger.warning(
+                            "Could not reconcile summary publication %s for segment %s",
+                            publication.new_node_id,
+                            segment.id,
+                            exc_info=True,
+                        )
 
-                # Log embedding token usage
-                if embedding_tokens > 0:
-                    logger.info(
-                        "Summary embedding for segment %s used %s tokens",
-                        segment.id,
-                        embedding_tokens,
+                if durable:
+                    SummaryIndexService._apply_publication(
+                        summary_record,
+                        publication,
+                        datetime.now(UTC).replace(tzinfo=None),
                     )
-
-                # Success - update summary record with index node info
-                # Use provided session if available, otherwise create a new one
-                use_provided_session = session is not None
-                if not use_provided_session:
-                    logger.debug("Creating new session for vectorization of segment %s", segment.id)
-                    session_context = session_factory.create_session()
-                    session = session_context.__enter__()
-                else:
-                    logger.debug("Using provided session for vectorization of segment %s", segment.id)
-                    session_context = None  # Don't use context manager for provided session
-
-                # At this point, session is guaranteed to be not None
-                # Type narrowing: session is definitely not None after the if/else above
-                if session is None:
-                    raise RuntimeError("Session should not be None at this point")
-
-                try:
-                    # Declare summary_record_in_session variable
-                    summary_record_in_session: DocumentSegmentSummary | None
-
-                    # If using provided session, merge the summary_record into it
-                    if use_provided_session:
-                        # Merge the summary_record into the provided session
-                        logger.debug(
-                            "Merging summary_record (id=%s) into provided session for segment %s",
-                            summary_record_id,
-                            segment.id,
-                        )
-                        summary_record_in_session = session.merge(summary_record)
-                        logger.debug(
-                            "Successfully merged summary_record for segment %s, merged_id=%s",
-                            segment.id,
-                            summary_record_in_session.id,
-                        )
-                    else:
-                        # Query the summary record in the new session
-                        logger.debug(
-                            "Querying summary_record by id=%s for segment %s in new session",
-                            summary_record_id,
-                            segment.id,
-                        )
-                        summary_record_in_session = session.scalar(
-                            select(DocumentSegmentSummary)
-                            .where(DocumentSegmentSummary.id == summary_record_id)
-                            .limit(1)
-                        )
-
-                        if not summary_record_in_session:
-                            # Record not found - try to find by chunk_id and dataset_id instead
-                            logger.debug(
-                                "Summary record not found by id=%s, trying chunk_id=%s and dataset_id=%s "
-                                "for segment %s",
-                                summary_record_id,
-                                segment.id,
-                                dataset.id,
-                                segment.id,
-                            )
-                            summary_record_in_session = session.scalar(
-                                select(DocumentSegmentSummary)
-                                .where(
-                                    DocumentSegmentSummary.chunk_id == segment.id,
-                                    DocumentSegmentSummary.dataset_id == dataset.id,
-                                )
-                                .limit(1)
-                            )
-
-                            if not summary_record_in_session:
-                                # Still not found - create a new one using the parameter data
-                                logger.warning(
-                                    "Summary record not found in database for segment %s (id=%s), creating new one. "
-                                    "This may indicate a session isolation issue.",
-                                    segment.id,
-                                    summary_record_id,
-                                )
-                                summary_record_in_session = DocumentSegmentSummary(
-                                    dataset_id=dataset.id,
-                                    document_id=segment.document_id,
-                                    chunk_id=segment.id,
-                                    summary_content=summary_content,
-                                    summary_index_node_id=summary_index_node_id,
-                                    summary_index_node_hash=summary_hash,
-                                    tokens=embedding_tokens,
-                                    status=SummaryStatus.COMPLETED,
-                                    enabled=True,
-                                )
-                                if summary_record_in_session is None:
-                                    raise RuntimeError("summary_record_in_session should not be None at this point")
-                                summary_record_in_session.id = summary_record_id
-                                session.add(summary_record_in_session)
-                                logger.info(
-                                    "Created new summary record (id=%s) for segment %s after vectorization",
-                                    summary_record_id,
-                                    segment.id,
-                                )
-                            else:
-                                # Found by chunk_id - update it
-                                logger.info(
-                                    "Found summary record for segment %s by chunk_id "
-                                    "(id mismatch: expected %s, found %s). "
-                                    "This may indicate the record was created in a different session.",
-                                    segment.id,
-                                    summary_record_id,
-                                    summary_record_in_session.id,
-                                )
-                        else:
-                            logger.debug(
-                                "Found summary_record (id=%s) for segment %s in new session",
-                                summary_record_id,
-                                segment.id,
-                            )
-
-                        # At this point, summary_record_in_session is guaranteed to be not None
-                        if summary_record_in_session is None:
-                            raise RuntimeError("summary_record_in_session should not be None at this point")
-
-                    # Update all fields including summary_content
-                    # Always use the summary_content from the parameter (which is the latest from outer session)
-                    # rather than relying on what's in the database, in case outer session hasn't committed yet
-                    summary_record_in_session.summary_index_node_id = summary_index_node_id
-                    summary_record_in_session.summary_index_node_hash = summary_hash
-                    summary_record_in_session.tokens = embedding_tokens  # Save embedding tokens
-                    summary_record_in_session.status = SummaryStatus.COMPLETED
-                    # Ensure summary_content is preserved (use the latest from summary_record parameter)
-                    # This is critical: use the parameter value, not the database value
-                    summary_record_in_session.summary_content = summary_content
-                    # Explicitly update updated_at to ensure it's refreshed even if other fields haven't changed
-                    summary_record_in_session.updated_at = datetime.now(UTC).replace(tzinfo=None)
-                    session.add(summary_record_in_session)
-
-                    # Only commit if we created the session ourselves
-                    if not use_provided_session:
-                        logger.debug("Committing session for segment %s (self-created session)", segment.id)
-                        session.commit()
-                        logger.debug("Successfully committed session for segment %s", segment.id)
-                    else:
-                        # When using provided session, flush to ensure changes are written to database
-                        # This prevents refresh() from overwriting our changes
-                        logger.debug(
-                            "Flushing session for segment %s (using provided session, caller will commit)",
-                            segment.id,
-                        )
-                        session.flush()
-                        logger.debug("Successfully flushed session for segment %s", segment.id)
-                    # If using provided session, let the caller handle commit
-
+                    if publication.old_node_id:
+                        delete_unreferenced_summary_vectors(dataset.id, [publication.old_node_id])
                     logger.info(
-                        "Successfully vectorized summary for segment %s, index_node_id=%s, index_node_hash=%s, "
-                        "tokens=%s, summary_record_id=%s, use_provided_session=%s",
+                        "Reconciled summary vector %s for segment %s after %s",
+                        publication.new_node_id,
                         segment.id,
-                        summary_index_node_id,
-                        summary_hash,
-                        embedding_tokens,
-                        summary_record_in_session.id,
-                        use_provided_session,
+                        type(error).__name__,
                     )
-                    # Update the original object for consistency
-                    summary_record.summary_index_node_id = summary_index_node_id
-                    summary_record.summary_index_node_hash = summary_hash
-                    summary_record.tokens = embedding_tokens
-                    summary_record.status = SummaryStatus.COMPLETED
-                    summary_record.summary_content = summary_content
-                    if summary_record_in_session.updated_at:
-                        summary_record.updated_at = summary_record_in_session.updated_at
-                finally:
-                    # Only close session if we created it ourselves
-                    if not use_provided_session and session_context:
-                        session_context.__exit__(None, None, None)
-                # Success, exit function
-                return
+                    return
 
-            except (ConnectionError, Exception) as e:
-                error_str = str(e).lower()
-                # Check if it's a connection-related error that might be transient
-                is_connection_error = any(
-                    keyword in error_str
-                    for keyword in [
-                        "connection",
-                        "disconnected",
-                        "timeout",
-                        "network",
-                        "could not connect",
-                        "server disconnected",
-                        "weaviate",
-                    ]
-                )
+                if isinstance(error, SummaryIndexConflictError):
+                    if reconciliation_failed:
+                        raise
+                    if vector_was_added and vector is not None:
+                        try:
+                            vector.delete_by_ids([publication.new_node_id])
+                        except Exception:
+                            logger.warning(
+                                "Failed to compensate summary vector %s",
+                                publication.new_node_id,
+                                exc_info=True,
+                            )
+                    raise
 
-                if is_connection_error and attempt < max_retries - 1:
-                    # Retry for connection errors
-                    wait_time = retry_delay * (2**attempt)  # Exponential backoff
+                if transient and attempt < max_attempts - 1:
+                    wait_time = 2.0 * (2**attempt)
                     logger.warning(
-                        "Vectorization attempt %s/%s failed for segment %s (connection error): %s. "
-                        "Retrying in %.1f seconds...",
+                        "Summary vectorization attempt %s/%s failed for segment %s: %s; retrying in %.1fs",
                         attempt + 1,
-                        max_retries,
+                        max_attempts,
                         segment.id,
-                        str(e),
+                        error,
                         wait_time,
                     )
                     time.sleep(wait_time)
                     continue
-                else:
-                    # Final attempt failed or non-connection error - log and update status
-                    logger.error(
-                        "Failed to vectorize summary for segment %s after %s attempts: %s. "
-                        "summary_record_id=%s, index_node_id=%s, use_provided_session=%s",
-                        segment.id,
-                        attempt + 1,
-                        str(e),
-                        summary_record_id,
-                        summary_index_node_id,
-                        session is not None,
-                        exc_info=True,
-                    )
-                    # Update error status in session
-                    # Use the original_session saved at function start (the function parameter)
-                    logger.debug(
-                        "Updating error status for segment %s, summary_record_id=%s, has_original_session=%s",
-                        segment.id,
-                        summary_record_id,
-                        original_session is not None,
-                    )
-                    # Always create a new session for error handling to avoid issues with closed sessions
-                    # Even if original_session was provided, we create a new one for safety
-                    with session_factory.create_session() as error_session:
-                        # Try to find the record by id first
-                        # Note: Using assignment only (no type annotation) to avoid redeclaration error
-                        summary_record_in_session = error_session.scalar(
-                            select(DocumentSegmentSummary)
-                            .where(DocumentSegmentSummary.id == summary_record_id)
-                            .limit(1)
-                        )
-                        if not summary_record_in_session:
-                            # Try to find by chunk_id and dataset_id
-                            logger.debug(
-                                "Summary record not found by id=%s, trying chunk_id=%s and dataset_id=%s "
-                                "for segment %s",
-                                summary_record_id,
-                                segment.id,
-                                dataset.id,
-                                segment.id,
-                            )
-                            summary_record_in_session = error_session.scalar(
-                                select(DocumentSegmentSummary)
-                                .where(
-                                    DocumentSegmentSummary.chunk_id == segment.id,
-                                    DocumentSegmentSummary.dataset_id == dataset.id,
-                                )
-                                .limit(1)
-                            )
 
-                        if summary_record_in_session:
-                            summary_record_in_session.status = SummaryStatus.ERROR
-                            summary_record_in_session.error = f"Vectorization failed: {str(e)}"
-                            summary_record_in_session.updated_at = datetime.now(UTC).replace(tzinfo=None)
-                            error_session.add(summary_record_in_session)
-                            error_session.commit()
-                            logger.info(
-                                "Updated error status in new session for segment %s, record_id=%s",
-                                segment.id,
-                                summary_record_in_session.id,
-                            )
-                            # Update the original object for consistency
-                            summary_record.status = SummaryStatus.ERROR
-                            summary_record.error = summary_record_in_session.error
-                            summary_record.updated_at = summary_record_in_session.updated_at
-                        else:
-                            logger.warning(
-                                "Could not update error status: summary record not found for segment %s (id=%s). "
-                                "This may indicate a session isolation issue.",
-                                segment.id,
-                                summary_record_id,
-                            )
-                    raise
+                logger.error(
+                    "Summary vectorization failed for segment %s after %s attempts",
+                    segment.id,
+                    attempt + 1,
+                    exc_info=True,
+                )
+                if vector_was_added and not reconciliation_failed and vector is not None:
+                    try:
+                        vector.delete_by_ids([publication.new_node_id])
+                    except Exception:
+                        logger.warning(
+                            "Failed to compensate unpublished summary vector %s",
+                            publication.new_node_id,
+                            exc_info=True,
+                        )
+                if not (vector_was_added and reconciliation_failed):
+                    SummaryIndexService._record_vectorization_failure(publication, error, summary_record)
+                raise
+            else:
+                SummaryIndexService._apply_publication(summary_record, publication, updated_at)
+                if publication.old_node_id:
+                    delete_unreferenced_summary_vectors(dataset.id, [publication.old_node_id])
+                logger.info(
+                    "Vectorized summary %s for segment %s with %s embedding tokens",
+                    publication.summary_record_id,
+                    segment.id,
+                    publication.embedding_tokens,
+                )
+                return
 
     @staticmethod
     def batch_create_summary_records(
@@ -585,23 +1126,42 @@ class SummaryIndexService:
         if not segment_ids:
             return
 
+        superseded_generation_tokens: list[str] = []
         with session_factory.create_session() as session:
+            SummaryIndexService._lock_segment_rows(session, dataset.id, segment_ids)
+            allowed_segment_ids = SummaryIndexService._summary_allowed_segment_ids(session, dataset.id, segment_ids)
             # Query existing summary records
             existing_summaries = session.scalars(
-                select(DocumentSegmentSummary).where(
+                select(DocumentSegmentSummary)
+                .where(
                     DocumentSegmentSummary.chunk_id.in_(segment_ids),
                     DocumentSegmentSummary.dataset_id == dataset.id,
                 )
+                .order_by(
+                    DocumentSegmentSummary.chunk_id,
+                    DocumentSegmentSummary.updated_at.desc(),
+                    DocumentSegmentSummary.id.desc(),
+                )
             ).all()
-            existing_summary_map = {summary.chunk_id: summary for summary in existing_summaries}
+            existing_summary_map: dict[str, DocumentSegmentSummary] = {}
+            for summary in existing_summaries:
+                existing_summary_map.setdefault(summary.chunk_id, summary)
 
             # Create or update records
             for segment in segments:
+                if segment.id not in allowed_segment_ids:
+                    continue
                 existing_summary = existing_summary_map.get(segment.id)
                 if existing_summary:
+                    if SummaryIndexService._summary_has_active_publication(existing_summary):
+                        continue
                     # Update existing record
                     existing_summary.status = status
-                    existing_summary.error = None  # Clear any previous errors
+                    superseded_generation_token = SummaryIndexService._clear_generation_claim(existing_summary)
+                    if superseded_generation_token is not None:
+                        superseded_generation_tokens.append(superseded_generation_token)
+                    else:
+                        existing_summary.error = None
                     if not existing_summary.enabled:
                         existing_summary.enabled = True
                         existing_summary.disabled_at = None
@@ -622,14 +1182,18 @@ class SummaryIndexService:
             # Commit the batch created records
             session.commit()
 
+        if superseded_generation_tokens:
+            delete_unreferenced_summary_vectors(dataset.id, superseded_generation_tokens)
+
     @staticmethod
     def update_summary_record_error(
         segment: DocumentSegment,
         dataset: Dataset,
         error: str,
+        *,
+        generation_claim: SummaryGenerationClaim | None = None,
     ) -> None:
-        """
-        Update summary record with error status.
+        """Update a summary record with an error if the originating generation still owns it.
 
         Args:
             segment: DocumentSegment
@@ -637,18 +1201,29 @@ class SummaryIndexService:
             error: Error message
         """
         with session_factory.create_session() as session:
-            summary_record = session.scalar(
-                select(DocumentSegmentSummary)
-                .where(
-                    DocumentSegmentSummary.chunk_id == segment.id,
-                    DocumentSegmentSummary.dataset_id == dataset.id,
-                )
-                .limit(1)
+            SummaryIndexService._lock_segment_rows(session, dataset.id, [segment.id])
+            summary_record = SummaryIndexService._get_summary_record(
+                session,
+                segment.id,
+                dataset.id,
+                for_update=True,
             )
 
             if summary_record:
-                summary_record.status = SummaryStatus.ERROR
-                summary_record.error = error
+                if generation_claim:
+                    if not SummaryIndexService._generation_claim_token_is_current(summary_record, generation_claim):
+                        logger.info("Skipped stale summary generation error for segment %s", segment.id)
+                        return
+                    source_content = SummaryIndexService._get_segment_content(session, dataset.id, segment.id)
+                    source_is_current = (
+                        source_content is not None
+                        and helper.generate_text_hash(source_content) == generation_claim.source_content_hash
+                    )
+                    claim_error = error if source_is_current else "Summary generation was superseded by a source change"
+                    SummaryIndexService._finish_claim_with_error(summary_record, generation_claim, claim_error)
+                else:
+                    summary_record.status = SummaryStatus.ERROR
+                    summary_record.error = error
                 session.add(summary_record)
                 session.commit()
             else:
@@ -660,19 +1235,16 @@ class SummaryIndexService:
         dataset: Dataset,
         summary_index_setting: SummaryIndexSettingDict,
         *,
-        session: Session,
+        session: Session | None = None,
     ) -> DocumentSegmentSummary:
         """
         Generate summary for a segment and vectorize it.
-        Assumes summary record already exists (created by batch_create_summary_records).
+        Caller state is committed before service-owned LLM/vector work.
 
         Args:
             segment: DocumentSegment to generate summary for
             dataset: Dataset containing the segment
             summary_index_setting: Summary index configuration
-
-        Keyword Args:
-            session: SQLAlchemy session used for summary record updates.
 
         Returns:
             Created DocumentSegmentSummary instance
@@ -680,48 +1252,22 @@ class SummaryIndexService:
         Raises:
             ValueError: If summary generation fails
         """
+        SummaryIndexService._commit_caller_session_before_external_io(session)
+        generation_claim = SummaryIndexService._mark_summary_generation_started(segment, dataset)
+        summary_record: DocumentSegmentSummary | None = None
+
         try:
-            # Get or refresh summary record in this session
-            summary_record_in_session = session.scalar(
-                select(DocumentSegmentSummary)
-                .where(
-                    DocumentSegmentSummary.chunk_id == segment.id,
-                    DocumentSegmentSummary.dataset_id == dataset.id,
-                )
-                .limit(1)
-            )
-
-            if not summary_record_in_session:
-                # If not found, create one
-                logger.warning("Summary record not found for segment %s, creating one", segment.id)
-                summary_record_in_session = DocumentSegmentSummary(
-                    dataset_id=dataset.id,
-                    document_id=segment.document_id,
-                    chunk_id=segment.id,
-                    summary_content="",
-                    status=SummaryStatus.GENERATING,
-                    enabled=True,
-                )
-                session.add(summary_record_in_session)
-                session.flush()
-
-            # Update status to "generating"
-            summary_record_in_session.status = SummaryStatus.GENERATING
-            summary_record_in_session.error = None
-            session.add(summary_record_in_session)
-            # Persist GENERATING and release the write transaction before LLM I/O.
-            session.commit()
-
-            # Generate summary (returns summary_content and llm_usage)
             summary_content, llm_usage = SummaryIndexService.generate_summary_for_segment(
-                segment, dataset, summary_index_setting, session=session
+                segment, dataset, summary_index_setting
             )
 
-            # Update summary content
-            summary_record_in_session.summary_content = summary_content
-            session.add(summary_record_in_session)
-            # Flush to ensure summary_content is saved before vectorize_summary queries it
-            session.flush()
+            summary_record = SummaryIndexService._save_summary_content(
+                segment=segment,
+                dataset=dataset,
+                summary_content=summary_content,
+                generation_claim=generation_claim,
+                status=SummaryStatus.GENERATING,
+            )
 
             # Log LLM usage for summary generation
             if llm_usage and llm_usage.total_tokens > 0:
@@ -733,30 +1279,26 @@ class SummaryIndexService:
                     llm_usage.completion_tokens,
                 )
 
-            SummaryIndexService.vectorize_summary(summary_record_in_session, segment, dataset, session=session)
-            # vectorize_summary mutates status and token fields; refresh before returning the ORM object.
-            session.refresh(summary_record_in_session)
-            session.commit()
+            SummaryIndexService.vectorize_summary(
+                summary_record,
+                segment,
+                dataset,
+                generation_claim=generation_claim,
+            )
             logger.info("Successfully generated and vectorized summary for segment %s", segment.id)
-            return summary_record_in_session
-
+            return summary_record
+        except SummaryIndexConflictError:
+            logger.info("Summary generation for segment %s was superseded", segment.id)
+            SummaryIndexService._abandon_generation_claim(generation_claim)
+            raise
         except Exception as e:
             logger.exception("Failed to generate summary for segment %s", segment.id)
-            session.rollback()
-            # Update summary record with error status
-            summary_record_in_session = session.scalar(
-                select(DocumentSegmentSummary)
-                .where(
-                    DocumentSegmentSummary.chunk_id == segment.id,
-                    DocumentSegmentSummary.dataset_id == dataset.id,
-                )
-                .limit(1)
+            SummaryIndexService.update_summary_record_error(
+                segment=segment,
+                dataset=dataset,
+                error=str(e),
+                generation_claim=generation_claim,
             )
-            if summary_record_in_session:
-                summary_record_in_session.status = SummaryStatus.ERROR
-                summary_record_in_session.error = str(e)
-                session.add(summary_record_in_session)
-                session.commit()
             raise
 
     @staticmethod
@@ -764,6 +1306,7 @@ class SummaryIndexService:
         dataset: Dataset,
         document: DatasetDocument,
         summary_index_setting: SummaryIndexSettingDict,
+        session: Session | None = None,
         segment_ids: list[str] | None = None,
         only_parent_chunks: bool = False,
     ) -> list[DocumentSegmentSummary]:
@@ -806,7 +1349,7 @@ class SummaryIndexService:
             only_parent_chunks,
         )
 
-        with session_factory.create_session() as session:
+        def _load_segments(query_session: Session) -> list[DocumentSegment]:
             # Query segments (only enabled segments)
             stmt = select(DocumentSegment).where(
                 DocumentSegment.dataset_id == dataset.id,
@@ -818,60 +1361,51 @@ class SummaryIndexService:
             if segment_ids:
                 stmt = stmt.where(DocumentSegment.id.in_(segment_ids))
 
-            segments = list(session.scalars(stmt).all())
+            return list(query_session.scalars(stmt).all())
 
-            if not segments:
-                logger.info("No segments found for document %s", document.id)
-                return []
+        if session is None:
+            with session_factory.create_session() as query_session:
+                segments = _load_segments(query_session)
+        else:
+            segments = _load_segments(session)
+            SummaryIndexService._commit_caller_session_before_external_io(session)
 
-            # Batch create summary records with "not_started" status before processing
-            # This ensures all records exist upfront, allowing status tracking
-            SummaryIndexService.batch_create_summary_records(
-                segments=segments,
-                dataset=dataset,
-                status=SummaryStatus.NOT_STARTED,
-            )
+        if not segments:
+            logger.info("No segments found for document %s", document.id)
+            return []
 
-            summary_records = []
+        SummaryIndexService.batch_create_summary_records(
+            segments=segments,
+            dataset=dataset,
+            status=SummaryStatus.NOT_STARTED,
+        )
 
-            for segment in segments:
-                # For parent-child mode, only process parent chunks
-                # In parent-child mode, all DocumentSegments are parent chunks,
-                # so we process all of them. Child chunks are stored in ChildChunk table
-                # and are not DocumentSegments, so they won't be in the segments list.
-                # This check is mainly for clarity and future-proofing.
-                if only_parent_chunks:
-                    # In parent-child mode, all segments in the query are parent chunks
-                    # Child chunks are not DocumentSegments, so they won't appear here
-                    # We can process all segments
-                    pass
+        summary_records = []
 
-                try:
-                    summary_record = SummaryIndexService.generate_and_vectorize_summary(
-                        segment, dataset, summary_index_setting, session=session
-                    )
-                    summary_records.append(summary_record)
-                except Exception as e:
-                    logger.exception("Failed to generate summary for segment %s", segment.id)
-                    # Update summary record with error status
-                    SummaryIndexService.update_summary_record_error(
-                        segment=segment,
-                        dataset=dataset,
-                        error=str(e),
-                    )
-                    # Continue with other segments
-                    continue
+        for segment in segments:
+            try:
+                summary_record = SummaryIndexService.generate_and_vectorize_summary(
+                    segment, dataset, summary_index_setting
+                )
+                summary_records.append(summary_record)
+            except SummaryIndexConflictError:
+                logger.info("Summary generation for segment %s was superseded", segment.id)
+                continue
+            except Exception:
+                logger.exception("Failed to generate summary for segment %s", segment.id)
+                continue
 
-            logger.info(
-                "Completed summary generation for document %s: %s summaries generated and vectorized",
-                document.id,
-                len(summary_records),
-            )
-            return summary_records
+        logger.info(
+            "Completed summary generation for document %s: %s summaries generated and vectorized",
+            document.id,
+            len(summary_records),
+        )
+        return summary_records
 
     @staticmethod
     def disable_summaries_for_segments(
         dataset: Dataset,
+        session: Session | None = None,
         segment_ids: list[str] | None = None,
         disabled_by: str | None = None,
     ) -> None:
@@ -886,19 +1420,25 @@ class SummaryIndexService:
         """
         from libs.datetime_utils import naive_utc_now
 
-        with session_factory.create_session() as session:
+        if segment_ids == []:
+            return
+
+        def _disable_with_session(write_session: Session) -> list[str]:
+            SummaryIndexService._lock_segment_rows(write_session, dataset.id, segment_ids)
             stmt = select(DocumentSegmentSummary).where(
                 DocumentSegmentSummary.dataset_id == dataset.id,
                 DocumentSegmentSummary.enabled.is_(True),  # Only disable enabled summaries
             )
 
-            if segment_ids:
+            if segment_ids is not None:
                 stmt = stmt.where(DocumentSegmentSummary.chunk_id.in_(segment_ids))
 
-            summaries = session.scalars(stmt).all()
+            summaries = write_session.scalars(
+                stmt.order_by(DocumentSegmentSummary.chunk_id, DocumentSegmentSummary.id).with_for_update()
+            ).all()
 
             if not summaries:
-                return
+                return []
 
             logger.info(
                 "Disabling %s summary records for dataset %s, segment_ids: %s",
@@ -907,29 +1447,41 @@ class SummaryIndexService:
                 len(segment_ids) if segment_ids else "all",
             )
 
-            # Remove from vector database (but keep records)
-            if dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY:
-                summary_node_ids = [s.summary_index_node_id for s in summaries if s.summary_index_node_id]
-                if summary_node_ids:
-                    try:
-                        vector = Vector(dataset, session=session)
-                        vector.delete_by_ids(summary_node_ids)
-                    except Exception as e:
-                        logger.warning("Failed to remove summary vectors: %s", str(e))
-
             # Disable summary records (don't delete)
+            summary_node_ids = [node_id for summary in summaries if (node_id := summary.summary_index_node_id)]
             now = naive_utc_now()
-            session.execute(
-                update(DocumentSegmentSummary)
-                .where(DocumentSegmentSummary.id.in_(s.id for s in summaries))
-                .values(enabled=False, disabled_at=now, disabled_by=disabled_by)
-            )
-            session.commit()
+            for summary in summaries:
+                summary.enabled = False
+                summary.disabled_at = now
+                summary.disabled_by = disabled_by
+                generation_token = SummaryIndexService._clear_generation_claim(summary)
+                if generation_token is not None:
+                    summary_node_ids.append(generation_token)
+                write_session.add(summary)
             logger.info("Disabled %s summary records for dataset %s", len(summaries), dataset.id)
+            return summary_node_ids
+
+        if session is None:
+            with session_factory.create_session() as write_session:
+                summary_node_ids = _disable_with_session(write_session)
+                write_session.commit()
+        else:
+            try:
+                with session.begin_nested():
+                    summary_node_ids = _disable_with_session(session)
+            except Exception:
+                if not session.is_active:
+                    session.rollback()
+                raise
+            SummaryIndexService._commit_caller_session_before_external_io(session)
+
+        if summary_node_ids:
+            delete_unreferenced_summary_vectors(dataset.id, summary_node_ids)
 
     @staticmethod
     def enable_summaries_for_segments(
         dataset: Dataset,
+        session: Session | None = None,
         segment_ids: list[str] | None = None,
     ) -> None:
         """
@@ -945,19 +1497,26 @@ class SummaryIndexService:
             segment_ids: List of segment IDs to enable summaries for. If None, enable all.
         """
         # Only enable summary index for high_quality indexing technique
+        if segment_ids == []:
+            return
         if dataset.indexing_technique != IndexTechniqueType.HIGH_QUALITY:
             return
 
-        with session_factory.create_session() as session:
-            stmt = select(DocumentSegmentSummary).where(
-                DocumentSegmentSummary.dataset_id == dataset.id,
-                DocumentSegmentSummary.enabled.is_(False),  # Only enable disabled summaries
-            )
+        summary_segment_pairs: list[tuple[DocumentSegmentSummary, DocumentSegment]] = []
 
-            if segment_ids:
+        def _collect_candidates(query_session: Session) -> None:
+            stmt = select(DocumentSegmentSummary).where(DocumentSegmentSummary.dataset_id == dataset.id)
+
+            if segment_ids is not None:
                 stmt = stmt.where(DocumentSegmentSummary.chunk_id.in_(segment_ids))
 
-            summaries = session.scalars(stmt).all()
+            summaries = query_session.scalars(
+                stmt.order_by(
+                    DocumentSegmentSummary.chunk_id,
+                    DocumentSegmentSummary.updated_at.desc(),
+                    DocumentSegmentSummary.id.desc(),
+                )
+            ).all()
 
             if not summaries:
                 return
@@ -970,54 +1529,67 @@ class SummaryIndexService:
             )
 
             # Re-vectorize and re-add to vector database
-            enabled_count = 0
+            seen_chunk_ids: set[str] = set()
+            candidate_summaries: list[DocumentSegmentSummary] = []
             for summary in summaries:
-                # Get the original segment
-                segment = session.scalar(
-                    select(DocumentSegment)
-                    .where(
-                        DocumentSegment.id == summary.chunk_id,
+                if summary.chunk_id in seen_chunk_ids:
+                    continue
+                seen_chunk_ids.add(summary.chunk_id)
+                if summary.enabled:
+                    continue
+                if summary.summary_content:
+                    candidate_summaries.append(summary)
+
+            if not candidate_summaries:
+                return
+
+            candidate_segment_ids = [summary.chunk_id for summary in candidate_summaries]
+            segments_by_id = {
+                segment.id: segment
+                for segment in query_session.scalars(
+                    select(DocumentSegment).where(
+                        DocumentSegment.id.in_(candidate_segment_ids),
                         DocumentSegment.dataset_id == dataset.id,
                     )
-                    .limit(1)
-                )
+                ).all()
+            }
 
+            for summary in candidate_summaries:
+                segment = segments_by_id.get(summary.chunk_id)
                 # Summary.enabled stays in sync with chunk.enabled,
                 # only enable summary if the associated chunk is enabled.
                 if not segment or not segment.enabled or segment.status != "completed":
                     continue
 
-                if not summary.summary_content:
-                    continue
+                summary_segment_pairs.append((summary, segment))
 
-                try:
-                    # Re-vectorize summary (this will update status and tokens in its own session)
-                    # Pass the session to vectorize_summary to avoid session isolation issues
-                    SummaryIndexService.vectorize_summary(summary, segment, dataset, session=session)
+        if session is None:
+            with session_factory.create_session() as query_session:
+                _collect_candidates(query_session)
+        else:
+            _collect_candidates(session)
+            SummaryIndexService._commit_caller_session_before_external_io(session)
 
-                    # Refresh the object from database to get the updated status and tokens from vectorize_summary
-                    session.refresh(summary)
-
-                    # Enable summary record
-                    summary.enabled = True
-                    summary.disabled_at = None
-                    summary.disabled_by = None
-                    session.add(summary)
+        enabled_count = 0
+        for summary, segment in summary_segment_pairs:
+            try:
+                SummaryIndexService.vectorize_summary(summary, segment, dataset)
+                if SummaryIndexService._enable_summary_record(summary.id, segment.id, dataset.id):
                     enabled_count += 1
-                except Exception:
-                    logger.exception("Failed to re-vectorize summary %s", summary.id)
-                    # Keep it disabled if vectorization fails
-                    continue
+                elif summary.summary_index_node_id:
+                    delete_unreferenced_summary_vectors(dataset.id, [summary.summary_index_node_id])
+            except Exception:
+                logger.exception("Failed to re-vectorize summary %s", summary.id)
+                continue
 
-            session.commit()
-            logger.info("Enabled %s summary records for dataset %s", enabled_count, dataset.id)
+        logger.info("Enabled %s summary records for dataset %s", enabled_count, dataset.id)
 
     @staticmethod
     def delete_summaries_for_segments(
         dataset: Dataset,
         segment_ids: list[str] | None = None,
         *,
-        session: Session,
+        session: Session | None = None,
     ) -> None:
         """
         Delete summary records and vectors for segments (used only for actual deletion scenarios).
@@ -1026,30 +1598,52 @@ class SummaryIndexService:
         Args:
             dataset: Dataset containing the segments
             segment_ids: List of segment IDs to delete summaries for. If None, delete all.
+
         """
-        stmt = select(DocumentSegmentSummary).where(DocumentSegmentSummary.dataset_id == dataset.id)
-
-        if segment_ids:
-            stmt = stmt.where(DocumentSegmentSummary.chunk_id.in_(segment_ids))
-
-        summaries = session.scalars(stmt).all()
-
-        if not summaries:
+        if segment_ids == []:
             return
 
-            # Delete from vector database
-        if dataset.indexing_technique == IndexTechniqueType.HIGH_QUALITY:
-            summary_node_ids = [s.summary_index_node_id for s in summaries if s.summary_index_node_id]
-            if summary_node_ids:
-                vector = Vector(dataset, session=session)
-                vector.delete_by_ids(summary_node_ids)
+        def _delete_with_session(write_session: Session) -> list[str]:
+            SummaryIndexService._lock_segment_rows(write_session, dataset.id, segment_ids)
+            stmt = select(DocumentSegmentSummary).where(DocumentSegmentSummary.dataset_id == dataset.id)
 
-            # Delete summary records
-        for summary in summaries:
-            session.delete(summary)
+            if segment_ids is not None:
+                stmt = stmt.where(DocumentSegmentSummary.chunk_id.in_(segment_ids))
 
-        session.flush()
-        logger.info("Deleted %s summary records for dataset %s", len(summaries), dataset.id)
+            summaries = write_session.scalars(
+                stmt.order_by(DocumentSegmentSummary.chunk_id, DocumentSegmentSummary.id).with_for_update()
+            ).all()
+
+            if not summaries:
+                return []
+
+            summary_node_ids = [node_id for summary in summaries if (node_id := summary.summary_index_node_id)]
+            summary_count = len(summaries)
+            for summary in summaries:
+                generation_token = SummaryIndexService._generation_token_from_error(summary.error)
+                if generation_token is not None:
+                    summary_node_ids.append(generation_token)
+                write_session.delete(summary)
+
+            logger.info("Deleted %s summary records for dataset %s", summary_count, dataset.id)
+            return summary_node_ids
+
+        if session is None:
+            with session_factory.create_session() as write_session:
+                summary_node_ids = _delete_with_session(write_session)
+                write_session.commit()
+        else:
+            try:
+                with session.begin_nested():
+                    summary_node_ids = _delete_with_session(session)
+            except Exception:
+                if not session.is_active:
+                    session.rollback()
+                raise
+            SummaryIndexService._commit_caller_session_before_external_io(session)
+
+        if summary_node_ids:
+            delete_unreferenced_summary_vectors(dataset.id, summary_node_ids)
 
     @staticmethod
     def update_summary_for_segment(
@@ -1057,7 +1651,7 @@ class SummaryIndexService:
         dataset: Dataset,
         summary_content: str,
         *,
-        session: Session,
+        session: Session | None = None,
     ) -> DocumentSegmentSummary | None:
         """
         Update summary for a segment and re-vectorize it.
@@ -1067,11 +1661,9 @@ class SummaryIndexService:
             dataset: Dataset containing the segment
             summary_content: New summary content
 
-        Keyword Args:
-            session: SQLAlchemy session used for summary record updates.
-
         Returns:
-            Updated DocumentSegmentSummary instance, or None if indexing technique is not high_quality
+            The published summary state, or an error record when no prior publication exists.
+            Returns None if indexing technique is not high_quality.
         """
         # Only update summary index for high_quality indexing technique
         if dataset.indexing_technique != IndexTechniqueType.HIGH_QUALITY:
@@ -1081,119 +1673,106 @@ class SummaryIndexService:
         # summary_index_setting is only needed for LLM generation, not for manual summary vectorization
         # Vectorization uses dataset.embedding_model, which doesn't require summary_index_setting
 
-        # Skip qa_model documents
-        document = segment.get_document(session=session)
-        if document and document.doc_form == "qa_model":
+        def _load_doc_form(query_session: Session) -> str | None:
+            return query_session.scalar(
+                select(DatasetDocument.doc_form).where(
+                    DatasetDocument.id == segment.document_id,
+                    DatasetDocument.dataset_id == dataset.id,
+                )
+            )
+
+        if session is None:
+            with session_factory.create_session() as query_session:
+                doc_form = _load_doc_form(query_session)
+        else:
+            doc_form = _load_doc_form(session)
+        if doc_form == "qa_model":
             return None
 
-        try:
-            summary_record = session.scalar(
-                select(DocumentSegmentSummary)
-                .where(
-                    DocumentSegmentSummary.chunk_id == segment.id,
-                    DocumentSegmentSummary.dataset_id == dataset.id,
-                )
-                .limit(1)
-            )
+        if not summary_content or not summary_content.strip():
 
-            # Check if summary_content is empty (whitespace-only strings are considered empty)
-            if not summary_content or not summary_content.strip():
-                # If summary is empty, only delete existing summary vector and record
+            def _delete_with_session(write_session: Session) -> tuple[bool, list[str]]:
+                SummaryIndexService._lock_segment_rows(write_session, dataset.id, [segment.id])
+                summary_record = SummaryIndexService._get_summary_record(
+                    write_session,
+                    segment.id,
+                    dataset.id,
+                    for_update=True,
+                )
+
                 if summary_record:
-                    # Delete old vector if exists
-                    old_summary_node_id = summary_record.summary_index_node_id
-                    if old_summary_node_id:
-                        try:
-                            vector = Vector(dataset, session=session)
-                            vector.delete_by_ids([old_summary_node_id])
-                        except Exception as e:
-                            logger.warning(
-                                "Failed to delete old summary vector for segment %s: %s",
-                                segment.id,
-                                str(e),
-                            )
-
-                    # Delete summary record since summary is empty
-                    session.delete(summary_record)
-                    session.commit()
-                    logger.info("Deleted summary for segment %s (empty content provided)", segment.id)
-                    return None
-                else:
-                    # No existing summary record, nothing to do
-                    logger.info("No summary record found for segment %s, nothing to delete", segment.id)
-                    return None
-
-            if summary_record:
-                # Update existing summary
-                old_summary_node_id = summary_record.summary_index_node_id
-
-                # Update summary content
-                summary_record.summary_content = summary_content
-                summary_record.status = SummaryStatus.GENERATING
-                summary_record.error = None  # Clear any previous errors
-                session.add(summary_record)
-                # Flush to ensure summary_content is saved before vectorize_summary queries it
-                session.flush()
-
-                # Delete old vector if exists (before vectorization)
-                if old_summary_node_id:
-                    try:
-                        vector = Vector(dataset, session=session)
-                        vector.delete_by_ids([old_summary_node_id])
-                    except Exception as e:
-                        logger.warning(
-                            "Failed to delete old summary vector for segment %s: %s",
-                            segment.id,
-                            str(e),
+                    node_ids = [
+                        node_id
+                        for node_id in (
+                            summary_record.summary_index_node_id,
+                            SummaryIndexService._generation_token_from_error(summary_record.error),
                         )
+                        if node_id is not None
+                    ]
+                    write_session.delete(summary_record)
+                    return True, node_ids
+                return False, []
+
+            if session is None:
+                with session_factory.create_session() as write_session:
+                    summary_deleted, retired_node_ids = _delete_with_session(write_session)
+                    write_session.commit()
             else:
-                # Create new summary record if doesn't exist
-                summary_record = SummaryIndexService.create_summary_record(
-                    segment,
-                    dataset,
-                    summary_content,
-                    status=SummaryStatus.GENERATING,
-                    session=session,
-                )
+                try:
+                    with session.begin_nested():
+                        summary_deleted, retired_node_ids = _delete_with_session(session)
+                except Exception:
+                    if not session.is_active:
+                        session.rollback()
+                    raise
+                SummaryIndexService._commit_caller_session_before_external_io(session)
 
-            try:
-                # Vectorization must finish here so the manual summary is searchable immediately.
-                SummaryIndexService.vectorize_summary(summary_record, segment, dataset, session=session)
-                session.refresh(summary_record)
-                session.commit()
-                logger.info("Successfully updated and re-vectorized summary for segment %s", segment.id)
-                return summary_record
-            except Exception as e:
-                # If vectorization fails, update status to error in current session.
-                # Return the record with error status so callers can still finish segment updates.
-                if not session.is_active:
-                    session.rollback()
-                summary_record.summary_content = summary_content
-                summary_record.status = SummaryStatus.ERROR
-                summary_record.error = f"Vectorization failed: {str(e)}"
-                session.add(summary_record)
-                session.commit()
-                logger.exception("Failed to vectorize summary for segment %s", segment.id)
-                return summary_record
+            if retired_node_ids:
+                delete_unreferenced_summary_vectors(dataset.id, retired_node_ids)
 
-        except Exception as e:
-            logger.exception("Failed to update summary for segment %s", segment.id)
-            session.rollback()
-            # Update summary record with error status if it exists
-            summary_record = session.scalar(
-                select(DocumentSegmentSummary)
-                .where(
-                    DocumentSegmentSummary.chunk_id == segment.id,
-                    DocumentSegmentSummary.dataset_id == dataset.id,
-                )
-                .limit(1)
+            if summary_deleted:
+                logger.info("Deleted summary for segment %s (empty content provided)", segment.id)
+            else:
+                logger.info("No summary record found for segment %s, nothing to delete", segment.id)
+            return None
+
+        SummaryIndexService._commit_caller_session_before_external_io(session)
+
+        generation_claim = SummaryIndexService._mark_summary_generation_started(segment, dataset)
+        summary_record: DocumentSegmentSummary | None = None
+        try:
+            summary_record = SummaryIndexService._save_summary_content(
+                segment=segment,
+                dataset=dataset,
+                summary_content=summary_content,
+                generation_claim=generation_claim,
+                status=SummaryStatus.GENERATING,
             )
-            if summary_record:
-                summary_record.status = SummaryStatus.ERROR
-                summary_record.error = str(e)
-                session.add(summary_record)
-                session.commit()
+            SummaryIndexService.vectorize_summary(
+                summary_record,
+                segment,
+                dataset,
+                generation_claim=generation_claim,
+            )
+            logger.info("Successfully updated and re-vectorized summary for segment %s", segment.id)
+            return summary_record
+        except SummaryIndexConflictError:
+            logger.info("Summary update for segment %s was superseded", segment.id)
+            SummaryIndexService._abandon_generation_claim(generation_claim)
             raise
+        except Exception as e:
+            logger.exception("Failed to vectorize summary for segment %s", segment.id)
+            error = f"Vectorization failed: {str(e)}"
+            SummaryIndexService.update_summary_record_error(
+                segment=segment,
+                dataset=dataset,
+                error=error,
+                generation_claim=generation_claim,
+            )
+            if summary_record is None:
+                raise
+            SummaryIndexService._finish_claim_with_error(summary_record, generation_claim, error)
+            return summary_record
 
     @staticmethod
     def get_segment_summary(
@@ -1215,15 +1794,19 @@ class SummaryIndexService:
         Returns:
             DocumentSegmentSummary instance if found, None otherwise
         """
-        return session.scalar(
+        summary = session.scalar(
             select(DocumentSegmentSummary)
             .where(
                 DocumentSegmentSummary.chunk_id == segment_id,
                 DocumentSegmentSummary.dataset_id == dataset_id,
-                DocumentSegmentSummary.enabled.is_(True),
+            )
+            .order_by(
+                DocumentSegmentSummary.updated_at.desc(),
+                DocumentSegmentSummary.id.desc(),
             )
             .limit(1)
         )
+        return summary if summary and summary.enabled else None
 
     @staticmethod
     def get_segments_summaries(
@@ -1249,13 +1832,21 @@ class SummaryIndexService:
             return {}
 
         summaries = session.scalars(
-            select(DocumentSegmentSummary).where(
+            select(DocumentSegmentSummary)
+            .where(
                 DocumentSegmentSummary.chunk_id.in_(segment_ids),
                 DocumentSegmentSummary.dataset_id == dataset_id,
-                DocumentSegmentSummary.enabled.is_(True),
+            )
+            .order_by(
+                DocumentSegmentSummary.chunk_id,
+                DocumentSegmentSummary.updated_at.desc(),
+                DocumentSegmentSummary.id.desc(),
             )
         ).all()
-        return {summary.chunk_id: summary for summary in summaries}
+        canonical_summaries: dict[str, DocumentSegmentSummary] = {}
+        for summary in summaries:
+            canonical_summaries.setdefault(summary.chunk_id, summary)
+        return {chunk_id: summary for chunk_id, summary in canonical_summaries.items() if summary.enabled}
 
     @staticmethod
     def get_document_summaries(
@@ -1279,16 +1870,27 @@ class SummaryIndexService:
         Returns:
             List of DocumentSegmentSummary instances (only enabled summaries)
         """
+        if segment_ids == []:
+            return []
+
         stmt = select(DocumentSegmentSummary).where(
             DocumentSegmentSummary.document_id == document_id,
             DocumentSegmentSummary.dataset_id == dataset_id,
-            DocumentSegmentSummary.enabled.is_(True),
         )
-
-        if segment_ids:
+        if segment_ids is not None:
             stmt = stmt.where(DocumentSegmentSummary.chunk_id.in_(segment_ids))
 
-        return list(session.scalars(stmt).all())
+        summaries = session.scalars(
+            stmt.order_by(
+                DocumentSegmentSummary.chunk_id,
+                DocumentSegmentSummary.updated_at.desc(),
+                DocumentSegmentSummary.id.desc(),
+            )
+        ).all()
+        canonical_summaries: dict[str, DocumentSegmentSummary] = {}
+        for summary in summaries:
+            canonical_summaries.setdefault(summary.chunk_id, summary)
+        return [summary for summary in canonical_summaries.values() if summary.enabled]
 
     @staticmethod
     def get_document_summary_index_status(
@@ -1328,7 +1930,10 @@ class SummaryIndexService:
 
         # Get all summary records for these segments
         summaries = SummaryIndexService.get_segments_summaries(segment_ids, dataset_id, session=session)
-        summary_status_map = {chunk_id: summary.status for chunk_id, summary in summaries.items()}
+        SummaryIndexService._recover_stale_generation_claims(dataset_id, list(summaries.values()))
+        summary_status_map = {
+            chunk_id: SummaryIndexService._effective_summary_status(summary) for chunk_id, summary in summaries.items()
+        }
 
         # Check if there are any "not_started" or "generating" status summaries
         has_pending_summaries = any(
@@ -1384,7 +1989,10 @@ class SummaryIndexService:
         # Get all summary records for these segments
         all_segment_ids = [seg.id for seg in segments]
         summaries = SummaryIndexService.get_segments_summaries(all_segment_ids, dataset_id, session=session)
-        summary_status_map = {chunk_id: summary.status for chunk_id, summary in summaries.items()}
+        SummaryIndexService._recover_stale_generation_claims(dataset_id, list(summaries.values()))
+        summary_status_map = {
+            chunk_id: SummaryIndexService._effective_summary_status(summary) for chunk_id, summary in summaries.items()
+        }
 
         # Calculate summary_index_status for each document
         result: dict[str, str | None] = {}
@@ -1463,6 +2071,7 @@ class SummaryIndexService:
                 segment_ids=segment_ids,
                 session=session,
             )
+            SummaryIndexService._recover_stale_generation_claims(dataset_id, summaries)
 
         # Create a mapping of chunk_id to summary
         summary_map = {summary.chunk_id: summary for summary in summaries}
@@ -1479,19 +2088,23 @@ class SummaryIndexService:
         for segment in segments:
             summary = summary_map.get(segment.id)
             if summary:
-                status = SummaryStatus(summary.status)
+                status = SummaryIndexService._effective_summary_status(summary)
                 status_counts[status] = status_counts.get(status, 0) + 1
                 summary_list.append(
                     {
                         "segment_id": segment.id,
                         "segment_position": segment.position,
-                        "status": summary.status,
+                        "status": status,
                         "summary_preview": (
                             summary.summary_content[:100] + "..."
                             if summary.summary_content and len(summary.summary_content) > 100
                             else summary.summary_content
                         ),
-                        "error": summary.error,
+                        "error": (
+                            None
+                            if SummaryIndexService._generation_token_from_error(summary.error) is not None
+                            else summary.error
+                        ),
                         "created_at": int(summary.created_at.timestamp()) if summary.created_at else None,
                         "updated_at": int(summary.updated_at.timestamp()) if summary.updated_at else None,
                     }
@@ -1514,4 +2127,56 @@ class SummaryIndexService:
             total_segments=total_segments,
             summary_status=cast(dict[str, int], status_counts),
             summaries=summary_list,
+        )
+
+
+def delete_unreferenced_summary_vectors(dataset_id: str, node_ids: list[str]) -> None:
+    """Best-effort deletion of summary vectors that have no active database owner.
+
+    Database references are checked before vector-store I/O. A failed deletion can leave an unreachable vector, but
+    the cleanup never intentionally deletes a vector still owned by an enabled summary or document segment.
+    """
+    unique_node_ids = list(dict.fromkeys(node_id for node_id in node_ids if node_id))
+    if not unique_node_ids:
+        return
+
+    try:
+        with session_factory.create_session() as session:
+            dataset = session.get(Dataset, dataset_id)
+            if dataset is None:
+                logger.warning("Skipping summary vector cleanup because dataset %s no longer exists", dataset_id)
+                return
+
+            referenced_node_ids: set[str] = set()
+            for node_id_batch in batched(unique_node_ids, _SUMMARY_VECTOR_CLEANUP_BATCH_SIZE):
+                referenced_node_ids.update(
+                    node_id
+                    for node_id in session.scalars(
+                        union_all(
+                            select(DocumentSegmentSummary.summary_index_node_id).where(
+                                DocumentSegmentSummary.dataset_id == dataset_id,
+                                DocumentSegmentSummary.summary_index_node_id.in_(node_id_batch),
+                                DocumentSegmentSummary.enabled.is_(True),
+                            ),
+                            select(DocumentSegment.index_node_id).where(
+                                DocumentSegment.dataset_id == dataset_id,
+                                DocumentSegment.index_node_id.in_(node_id_batch),
+                            ),
+                        )
+                    ).all()
+                    if node_id is not None
+                )
+
+        deletable_node_ids = [node_id for node_id in unique_node_ids if node_id not in referenced_node_ids]
+        if not deletable_node_ids:
+            return
+
+        vector = Vector(dataset)
+        for node_id_batch in batched(deletable_node_ids, _SUMMARY_VECTOR_CLEANUP_BATCH_SIZE):
+            vector.delete_by_ids(list(node_id_batch))
+    except Exception:
+        logger.warning(
+            "Summary vector cleanup failed for dataset %s; unreachable vectors may remain",
+            dataset_id,
+            exc_info=True,
         )

--- a/api/services/vector_service.py
+++ b/api/services/vector_service.py
@@ -14,7 +14,14 @@ from core.rag.index_processor.index_processor_factory import IndexProcessorFacto
 from core.rag.models.document import AttachmentDocument, Document
 from graphon.model_runtime.entities.model_entities import ModelType
 from models import UploadFile
-from models.dataset import ChildChunk, Dataset, DatasetProcessRule, DocumentSegment, SegmentAttachmentBinding
+from models.dataset import (
+    ChildChunk,
+    Dataset,
+    DatasetProcessRule,
+    DocumentSegment,
+    DocumentSegmentSummary,
+    SegmentAttachmentBinding,
+)
 from models.dataset import Document as DatasetDocument
 from models.enums import SegmentType
 
@@ -369,3 +376,50 @@ class VectorService:
             logger.exception("Failed to update multimodal vector for segment %s", segment.id)
             session.rollback()
             raise
+
+    @staticmethod
+    def delete_segment_index_artifacts(
+        *,
+        session: Session,
+        dataset_id: str,
+        segment_ids: list[str] | None,
+    ) -> None:
+        """Delete summary and child-chunk rows for segments or an entire dataset.
+
+        The caller owns the transaction so cleanup can participate in either a
+        task fallback or a service-level publication failure path.
+        """
+        if segment_ids == []:
+            return
+
+        summary_delete_stmt = delete(DocumentSegmentSummary).where(DocumentSegmentSummary.dataset_id == dataset_id)
+        child_chunk_delete_stmt = delete(ChildChunk).where(ChildChunk.dataset_id == dataset_id)
+        if segment_ids is not None:
+            summary_delete_stmt = summary_delete_stmt.where(DocumentSegmentSummary.chunk_id.in_(segment_ids))
+            child_chunk_delete_stmt = child_chunk_delete_stmt.where(ChildChunk.segment_id.in_(segment_ids))
+
+        session.execute(summary_delete_stmt)
+        session.execute(child_chunk_delete_stmt)
+
+    @staticmethod
+    def delete_segment_relational_dependants(
+        *,
+        session: Session,
+        dataset_id: str,
+        segment_ids: list[str],
+    ) -> None:
+        """Delete every relational row that depends on removed segments."""
+        if not segment_ids:
+            return
+
+        VectorService.delete_segment_index_artifacts(
+            session=session,
+            dataset_id=dataset_id,
+            segment_ids=segment_ids,
+        )
+        session.execute(
+            delete(SegmentAttachmentBinding).where(
+                SegmentAttachmentBinding.dataset_id == dataset_id,
+                SegmentAttachmentBinding.segment_id.in_(segment_ids),
+            )
+        )

--- a/api/tasks/add_document_to_index_task.py
+++ b/api/tasks/add_document_to_index_task.py
@@ -52,6 +52,7 @@ def add_document_to_index_task(dataset_document_id: str):
                 select(DocumentSegment)
                 .where(
                     DocumentSegment.document_id == dataset_document.id,
+                    DocumentSegment.dataset_id == dataset_document.dataset_id,
                     DocumentSegment.status == SegmentStatus.COMPLETED,
                 )
                 .order_by(DocumentSegment.position.asc())
@@ -103,6 +104,7 @@ def add_document_to_index_task(dataset_document_id: str):
 
             index_type = dataset.get_doc_form(session=session)
             index_processor = IndexProcessorFactory(index_type).init_index_processor()
+            session.commit()
             index_processor.load(dataset, documents, multimodal_documents=multimodal_documents, session=session)
 
             # delete auto disable log
@@ -113,7 +115,10 @@ def add_document_to_index_task(dataset_document_id: str):
             # update segment to enable
             session.execute(
                 update(DocumentSegment)
-                .where(DocumentSegment.document_id == dataset_document.id)
+                .where(
+                    DocumentSegment.document_id == dataset_document.id,
+                    DocumentSegment.dataset_id == dataset_document.dataset_id,
+                )
                 .values(enabled=True, disabled_at=None, disabled_by=None, updated_at=naive_utc_now())
             )
             session.commit()

--- a/api/tasks/annotation/add_annotation_to_index_task.py
+++ b/api/tasks/annotation/add_annotation_to_index_task.py
@@ -48,8 +48,7 @@ def add_annotation_to_index_task(
         document = Document(
             page_content=question, metadata={"annotation_id": annotation_id, "app_id": app_id, "doc_id": annotation_id}
         )
-        with session_factory.create_session() as session:
-            vector = Vector(dataset, attributes=["doc_id", "annotation_id", "app_id"], session=session)
+        vector = Vector(dataset, attributes=["doc_id", "annotation_id", "app_id"])
         vector.create([document], duplicate_check=True)
 
         end_at = time.perf_counter()

--- a/api/tasks/annotation/delete_annotation_index_task.py
+++ b/api/tasks/annotation/delete_annotation_index_task.py
@@ -34,8 +34,7 @@ def delete_annotation_index_task(annotation_id: str, app_id: str, tenant_id: str
         )
 
         try:
-            with session_factory.create_session() as session:
-                vector = Vector(dataset, attributes=["doc_id", "annotation_id", "app_id"], session=session)
+            vector = Vector(dataset, attributes=["doc_id", "annotation_id", "app_id"])
             vector.delete_by_metadata_field("annotation_id", annotation_id)
         except Exception:
             logger.exception("Delete annotation index failed when annotation deleted.")

--- a/api/tasks/annotation/update_annotation_to_index_task.py
+++ b/api/tasks/annotation/update_annotation_to_index_task.py
@@ -49,8 +49,7 @@ def update_annotation_to_index_task(
         document = Document(
             page_content=question, metadata={"annotation_id": annotation_id, "app_id": app_id, "doc_id": annotation_id}
         )
-        with session_factory.create_session() as session:
-            vector = Vector(dataset, attributes=["doc_id", "annotation_id", "app_id"], session=session)
+        vector = Vector(dataset, attributes=["doc_id", "annotation_id", "app_id"])
         vector.delete_by_metadata_field("annotation_id", annotation_id)
         vector.add_texts([document])
         end_at = time.perf_counter()

--- a/api/tasks/batch_clean_document_task.py
+++ b/api/tasks/batch_clean_document_task.py
@@ -13,6 +13,7 @@ from core.tools.utils.web_reader_tool import get_image_upload_file_ids
 from extensions.ext_storage import storage
 from models.dataset import Dataset, DatasetMetadataBinding, DocumentSegment
 from models.model import UploadFile
+from services.vector_service import VectorService
 from tasks.refresh_billing_vector_space_task import schedule_billing_vector_space_refresh
 
 logger = logging.getLogger(__name__)
@@ -47,13 +48,22 @@ def batch_clean_document_task(
     segment_ids: list[str] = []
     total_image_upload_file_ids: list[str] = []
     dataset_tenant_id: str | None = None
+    vector_cleanup_succeeded = False
 
     try:
         # ============ Step 1: Query segment and file data (short read-only transaction) ============
         with session_factory.create_session() as session:
+            dataset = session.scalar(select(Dataset).where(Dataset.id == dataset_id).limit(1))
+            if not dataset:
+                logger.warning("Dataset not found for document cleanup, dataset_id: %s", dataset_id)
+                return
+            dataset_tenant_id = dataset.tenant_id
             # Get segments info
             segments = session.scalars(
-                select(DocumentSegment).where(DocumentSegment.document_id.in_(document_ids))
+                select(DocumentSegment).where(
+                    DocumentSegment.document_id.in_(document_ids),
+                    DocumentSegment.dataset_id == dataset_id,
+                )
             ).all()
 
             if segments:
@@ -68,34 +78,45 @@ def batch_clean_document_task(
             # Query storage keys for image files
             if total_image_upload_file_ids:
                 image_files = session.scalars(
-                    select(UploadFile).where(UploadFile.id.in_(total_image_upload_file_ids))
+                    select(UploadFile).where(
+                        UploadFile.id.in_(total_image_upload_file_ids),
+                        UploadFile.tenant_id == dataset_tenant_id,
+                    )
                 ).all()
                 storage_keys_to_delete.extend([f.key for f in image_files if f and f.key])
 
             # Query storage keys for document files
             if file_ids:
-                files = session.scalars(select(UploadFile).where(UploadFile.id.in_(file_ids))).all()
+                files = session.scalars(
+                    select(UploadFile).where(
+                        UploadFile.id.in_(file_ids),
+                        UploadFile.tenant_id == dataset_tenant_id,
+                    )
+                ).all()
                 storage_keys_to_delete.extend([f.key for f in files if f and f.key])
 
         # ============ Step 2: Clean vector index (external service, fresh session for dataset) ============
-        if index_node_ids:
+        if index_node_ids or segment_ids:
             try:
                 # Fetch dataset in a fresh session to avoid DetachedInstanceError
-                with session_factory.create_session() as session, session.begin():
+                with session_factory.create_session() as session:
                     dataset = session.scalar(select(Dataset).where(Dataset.id == dataset_id).limit(1))
                     if not dataset:
                         logger.warning("Dataset not found for vector index cleanup, dataset_id: %s", dataset_id)
                     else:
                         index_processor = IndexProcessorFactory(doc_form).init_index_processor()
+                        session.commit()
                         index_processor.clean(
                             dataset,
                             index_node_ids,
                             with_keywords=True,
                             delete_child_chunks=True,
                             delete_summaries=True,
+                            segment_ids=segment_ids,
                             session=session,
                         )
-                        dataset_tenant_id = dataset.tenant_id
+                        session.commit()
+                        vector_cleanup_succeeded = True
             except Exception:
                 logger.exception(
                     "Failed to clean vector index for dataset_id: %s, document_ids: %s, index_node_ids count: %d",
@@ -134,7 +155,10 @@ def batch_clean_document_task(
                 batch = total_image_upload_file_ids[i : i + BATCH_SIZE]
                 try:
                     with session_factory.create_session() as session:
-                        stmt = delete(UploadFile).where(UploadFile.id.in_(batch))
+                        stmt = delete(UploadFile).where(
+                            UploadFile.id.in_(batch),
+                            UploadFile.tenant_id == dataset_tenant_id,
+                        )
                         session.execute(stmt)
                         session.commit()
                 except Exception:
@@ -161,7 +185,16 @@ def batch_clean_document_task(
                 batch = segment_ids[i : i + BATCH_SIZE]
                 try:
                     with session_factory.create_session() as session:
-                        segment_delete_stmt = delete(DocumentSegment).where(DocumentSegment.id.in_(batch))
+                        segment_delete_stmt = delete(DocumentSegment).where(
+                            DocumentSegment.id.in_(batch),
+                            DocumentSegment.dataset_id == dataset_id,
+                        )
+                        # In case index_processor.clean didn't clean fully
+                        VectorService.delete_segment_index_artifacts(
+                            session=session,
+                            dataset_id=dataset_id,
+                            segment_ids=batch,
+                        )
                         session.execute(segment_delete_stmt)
                         session.commit()
                 except Exception:
@@ -185,7 +218,10 @@ def batch_clean_document_task(
         if file_ids:
             try:
                 with session_factory.create_session() as session:
-                    stmt = delete(UploadFile).where(UploadFile.id.in_(file_ids))
+                    stmt = delete(UploadFile).where(
+                        UploadFile.id.in_(file_ids),
+                        UploadFile.tenant_id == dataset_tenant_id,
+                    )
                     session.execute(stmt)
                     session.commit()
             except Exception:
@@ -211,7 +247,7 @@ def batch_clean_document_task(
                 dataset_id,
             )
 
-        if dataset_tenant_id is not None:
+        if vector_cleanup_succeeded and dataset_tenant_id is not None:
             schedule_billing_vector_space_refresh(dataset_tenant_id)
 
         end_at = time.perf_counter()

--- a/api/tasks/clean_dataset_task.py
+++ b/api/tasks/clean_dataset_task.py
@@ -3,7 +3,7 @@ import time
 
 import click
 from celery import shared_task
-from sqlalchemy import delete, select
+from sqlalchemy import and_, delete, select
 
 from core.db.session_factory import session_factory
 from core.rag.index_processor.index_processor_factory import IndexProcessorFactory
@@ -24,6 +24,7 @@ from models.dataset import (
 )
 from models.model import UploadFile
 from models.workflow import Workflow
+from services.vector_service import VectorService
 from tasks.refresh_billing_vector_space_task import schedule_billing_vector_space_refresh
 
 logger = logging.getLogger(__name__)
@@ -54,6 +55,7 @@ def clean_dataset_task(
     logger.info(click.style(f"Start clean dataset when dataset deleted: {dataset_id}", fg="green"))
     start_at = time.perf_counter()
     vector_cleanup_succeeded = False
+    storage_file_keys: list[str] = []
 
     with session_factory.create_session() as session:
         try:
@@ -69,7 +71,13 @@ def clean_dataset_task(
             # Use JOIN to fetch attachments with bindings in a single query
             attachments_with_bindings = session.execute(
                 select(SegmentAttachmentBinding, UploadFile)
-                .join(UploadFile, UploadFile.id == SegmentAttachmentBinding.attachment_id)
+                .outerjoin(
+                    UploadFile,
+                    and_(
+                        UploadFile.id == SegmentAttachmentBinding.attachment_id,
+                        UploadFile.tenant_id == tenant_id,
+                    ),
+                )
                 .where(
                     SegmentAttachmentBinding.tenant_id == tenant_id,
                     SegmentAttachmentBinding.dataset_id == dataset_id,
@@ -90,19 +98,31 @@ def clean_dataset_task(
                     )
                 )
 
+            # Release the read transaction before contacting the vector backend.
+            session.commit()
+
             # Add exception handling around IndexProcessorFactory.clean() to prevent single point of failure
             # This ensures Document/Segment deletion can continue even if vector database cleanup fails
             try:
                 index_processor = IndexProcessorFactory(doc_form).init_index_processor()
                 index_processor.clean(dataset, None, with_keywords=True, delete_child_chunks=True, session=session)
+                session.commit()
                 vector_cleanup_succeeded = True
                 logger.info(click.style(f"Successfully cleaned vector database for dataset: {dataset_id}", fg="green"))
             except Exception:
+                session.rollback()
                 logger.exception(click.style(f"Failed to clean vector database for dataset {dataset_id}", fg="red"))
                 # Continue with document and segment deletion even if vector cleanup fails
                 logger.info(
                     click.style(f"Continuing with document and segment deletion for dataset: {dataset_id}", fg="yellow")
                 )
+
+            # In case index_processor.clean didn't clean fully
+            VectorService.delete_segment_index_artifacts(
+                session=session,
+                dataset_id=dataset_id,
+                segment_ids=None,
+            )
 
             if documents is None or len(documents) == 0:
                 logger.info(click.style(f"No documents found for dataset: {dataset_id}", fg="green"))
@@ -112,42 +132,41 @@ def clean_dataset_task(
                 for document in documents:
                     session.delete(document)
 
-                segment_ids = [segment.id for segment in segments]
-                for segment in segments:
-                    image_upload_file_ids = get_image_upload_file_ids(segment.content)
-                    image_files = session.scalars(
-                        select(UploadFile).where(UploadFile.id.in_(image_upload_file_ids))
-                    ).all()
-                    for image_file in image_files:
-                        if image_file is None:
-                            continue
-                        try:
-                            storage.delete(image_file.key)
-                        except Exception:
-                            logger.exception(
-                                "Delete image_files failed when storage deleted, \
-                                              image_upload_file_is: %s",
-                                image_file.id,
-                            )
-                    stmt = delete(UploadFile).where(UploadFile.id.in_(image_upload_file_ids))
-                    session.execute(stmt)
+            segment_ids = [segment.id for segment in segments]
+            for segment in segments:
+                image_upload_file_ids = get_image_upload_file_ids(segment.content)
+                image_files = session.scalars(
+                    select(UploadFile).where(
+                        UploadFile.id.in_(image_upload_file_ids),
+                        UploadFile.tenant_id == tenant_id,
+                    )
+                ).all()
+                storage_file_keys.extend(image_file.key for image_file in image_files)
+                stmt = delete(UploadFile).where(
+                    UploadFile.id.in_(image_upload_file_ids),
+                    UploadFile.tenant_id == tenant_id,
+                )
+                session.execute(stmt)
 
-                segment_delete_stmt = delete(DocumentSegment).where(DocumentSegment.id.in_(segment_ids))
+            if segment_ids:
+                segment_delete_stmt = delete(DocumentSegment).where(
+                    DocumentSegment.id.in_(segment_ids),
+                    DocumentSegment.dataset_id == dataset_id,
+                )
                 session.execute(segment_delete_stmt)
             # delete segment attachments
             if attachments_with_bindings:
-                attachment_ids = [attachment_file.id for _, attachment_file in attachments_with_bindings]
+                attachment_ids = [binding.attachment_id for binding, _ in attachments_with_bindings]
                 binding_ids = [binding.id for binding, _ in attachments_with_bindings]
-                for binding, attachment_file in attachments_with_bindings:
-                    try:
-                        storage.delete(attachment_file.key)
-                    except Exception:
-                        logger.exception(
-                            "Delete attachment_file failed when storage deleted, \
-                                            attachment_file_id: %s",
-                            binding.attachment_id,
-                        )
-                attachment_file_delete_stmt = delete(UploadFile).where(UploadFile.id.in_(attachment_ids))
+                storage_file_keys.extend(
+                    attachment_file.key
+                    for _, attachment_file in attachments_with_bindings
+                    if attachment_file is not None
+                )
+                attachment_file_delete_stmt = delete(UploadFile).where(
+                    UploadFile.id.in_(attachment_ids),
+                    UploadFile.tenant_id == tenant_id,
+                )
                 session.execute(attachment_file_delete_stmt)
 
                 binding_delete_stmt = delete(SegmentAttachmentBinding).where(
@@ -181,14 +200,31 @@ def clean_dataset_task(
                             if data_source_info and "upload_file_id" in data_source_info:
                                 file_id = data_source_info["upload_file_id"]
                                 file_ids.append(file_id)
-                files = session.scalars(select(UploadFile).where(UploadFile.id.in_(file_ids))).all()
-                for file in files:
-                    storage.delete(file.key)
+                files = session.scalars(
+                    select(UploadFile).where(
+                        UploadFile.id.in_(file_ids),
+                        UploadFile.tenant_id == tenant_id,
+                    )
+                ).all()
+                storage_file_keys.extend(file.key for file in files)
 
-                file_delete_stmt = delete(UploadFile).where(UploadFile.id.in_(file_ids))
+                file_delete_stmt = delete(UploadFile).where(
+                    UploadFile.id.in_(file_ids),
+                    UploadFile.tenant_id == tenant_id,
+                )
                 session.execute(file_delete_stmt)
 
             session.commit()
+            # Do this after DB commits because dangling reference in DB is less
+            # acceptable than uncleaned storaged files (?)
+            for storage_file_key in dict.fromkeys(storage_file_keys):
+                try:
+                    storage.delete(storage_file_key)
+                except Exception:
+                    logger.exception(
+                        "Delete file failed when dataset deleted, storage_file_key: %s",
+                        storage_file_key,
+                    )
             if vector_cleanup_succeeded:
                 schedule_billing_vector_space_refresh(dataset.tenant_id)
             end_at = time.perf_counter()

--- a/api/tasks/clean_document_task.py
+++ b/api/tasks/clean_document_task.py
@@ -3,7 +3,7 @@ import time
 
 import click
 from celery import shared_task
-from sqlalchemy import delete, select
+from sqlalchemy import and_, delete, select
 
 from core.db.session_factory import session_factory
 from core.rag.index_processor.index_processor_factory import IndexProcessorFactory
@@ -11,6 +11,7 @@ from core.tools.utils.web_reader_tool import get_image_upload_file_ids
 from extensions.ext_storage import storage
 from models.dataset import Dataset, DatasetMetadataBinding, DocumentSegment, SegmentAttachmentBinding
 from models.model import UploadFile
+from services.vector_service import VectorService
 from tasks.refresh_billing_vector_space_task import schedule_billing_vector_space_refresh
 
 logger = logging.getLogger(__name__)
@@ -34,7 +35,7 @@ def clean_document_task(
     """
     logger.info(click.style(f"Start clean document when document deleted: {document_id}", fg="green"))
     start_at = time.perf_counter()
-    total_attachment_files = []
+    total_attachment_files: list[str] = []
     vector_cleanup_succeeded = False
 
     with session_factory.create_session() as session:
@@ -45,11 +46,22 @@ def clean_document_task(
                 raise Exception("Document has no dataset")
 
             dataset_tenant_id = dataset.tenant_id
-            segments = session.scalars(select(DocumentSegment).where(DocumentSegment.document_id == document_id)).all()
+            segments = session.scalars(
+                select(DocumentSegment).where(
+                    DocumentSegment.document_id == document_id,
+                    DocumentSegment.dataset_id == dataset_id,
+                )
+            ).all()
             # Use JOIN to fetch attachments with bindings in a single query
             attachments_with_bindings = session.execute(
                 select(SegmentAttachmentBinding, UploadFile)
-                .join(UploadFile, UploadFile.id == SegmentAttachmentBinding.attachment_id)
+                .outerjoin(
+                    UploadFile,
+                    and_(
+                        UploadFile.id == SegmentAttachmentBinding.attachment_id,
+                        UploadFile.tenant_id == dataset.tenant_id,
+                    ),
+                )
                 .where(
                     SegmentAttachmentBinding.tenant_id == dataset.tenant_id,
                     SegmentAttachmentBinding.dataset_id == dataset_id,
@@ -57,18 +69,22 @@ def clean_document_task(
                 )
             ).all()
 
-            attachment_ids = [attachment_file.id for _, attachment_file in attachments_with_bindings]
+            attachment_ids = [binding.attachment_id for binding, _ in attachments_with_bindings]
             binding_ids = [binding.id for binding, _ in attachments_with_bindings]
-            total_attachment_files.extend([attachment_file.key for _, attachment_file in attachments_with_bindings])
+            total_attachment_files.extend(
+                attachment_file.key for _, attachment_file in attachments_with_bindings if attachment_file is not None
+            )
 
             index_node_ids = [segment.index_node_id for segment in segments if segment.index_node_id]
+            segment_ids = [segment.id for segment in segments]
             segment_contents = [segment.content for segment in segments]
         except Exception:
             logger.exception("Cleaned document when document deleted failed")
             return
 
-    # check segment is exist
-    if index_node_ids:
+    # Summary/child cleanup is keyed by segment ID and must still run for
+    # partially indexed segments that never received a primary vector node ID.
+    if index_node_ids or segment_ids:
         # Wrap vector / keyword index cleanup in try/except so that a transient
         # failure here (e.g. billing API hiccup propagated via FeatureService when
         # ModelManager is initialized inside ``Vector(dataset)``) does not abort
@@ -79,40 +95,61 @@ def clean_document_task(
         # the vector backend or one of its transitive dependencies was unhappy.
         try:
             index_processor = IndexProcessorFactory(doc_form).init_index_processor()
-            with session_factory.create_session() as session, session.begin():
+            with session_factory.create_session() as session:
                 dataset = session.scalar(select(Dataset).where(Dataset.id == dataset_id).limit(1))
                 if dataset:
+                    session.commit()
                     index_processor.clean(
                         dataset,
                         index_node_ids,
                         with_keywords=True,
                         delete_child_chunks=True,
                         delete_summaries=True,
+                        segment_ids=segment_ids,
                         session=session,
                     )
+                    session.commit()
                     vector_cleanup_succeeded = True
         except Exception:
             logger.exception(
                 "Failed to clean vector / keyword index in clean_document_task, "
                 "document_id=%s, dataset_id=%s, index_node_ids_count=%d. "
-                "Continuing with PG / storage cleanup; vector orphans can be reaped later.",
+                "Continuing with PG / storage cleanup; stale external index objects may remain.",
                 document_id,
                 dataset_id,
                 len(index_node_ids),
             )
 
-    total_image_files = []
+    total_image_files: list[str] = []
     with session_factory.create_session() as session, session.begin():
         for segment_content in segment_contents:
             image_upload_file_ids = get_image_upload_file_ids(segment_content)
-            image_files = session.scalars(select(UploadFile).where(UploadFile.id.in_(image_upload_file_ids))).all()
+            image_files = session.scalars(
+                select(UploadFile).where(
+                    UploadFile.id.in_(image_upload_file_ids),
+                    UploadFile.tenant_id == dataset_tenant_id,
+                )
+            ).all()
             total_image_files.extend([image_file.key for image_file in image_files])
-            image_file_delete_stmt = delete(UploadFile).where(UploadFile.id.in_(image_upload_file_ids))
+            image_file_delete_stmt = delete(UploadFile).where(
+                UploadFile.id.in_(image_upload_file_ids),
+                UploadFile.tenant_id == dataset_tenant_id,
+            )
             session.execute(image_file_delete_stmt)
 
     with session_factory.create_session() as session, session.begin():
-        segment_delete_stmt = delete(DocumentSegment).where(DocumentSegment.document_id == document_id)
-        session.execute(segment_delete_stmt)
+        # In case index_preprocessor.clean misses these
+        VectorService.delete_segment_index_artifacts(
+            session=session,
+            dataset_id=dataset_id,
+            segment_ids=segment_ids,
+        )
+        session.execute(
+            delete(DocumentSegment).where(
+                DocumentSegment.document_id == document_id,
+                DocumentSegment.dataset_id == dataset_id,
+            )
+        )
 
     for image_file_key in total_image_files:
         try:
@@ -124,20 +161,34 @@ def clean_document_task(
                 image_file_key,
             )
 
+    document_file_key: str | None = None
     with session_factory.create_session() as session, session.begin():
         if file_id:
-            file = session.scalar(select(UploadFile).where(UploadFile.id == file_id).limit(1))
+            file = session.scalar(
+                select(UploadFile)
+                .where(
+                    UploadFile.id == file_id,
+                    UploadFile.tenant_id == dataset_tenant_id,
+                )
+                .limit(1)
+            )
             if file:
-                try:
-                    storage.delete(file.key)
-                except Exception:
-                    logger.exception("Delete file failed when document deleted, file_id: %s", file_id)
+                document_file_key = file.key
                 session.delete(file)
+
+    if document_file_key:
+        try:
+            storage.delete(document_file_key)
+        except Exception:
+            logger.exception("Delete file failed when document deleted, file_id: %s", file_id)
 
     with session_factory.create_session() as session, session.begin():
         # delete segment attachments
         if attachment_ids:
-            attachment_file_delete_stmt = delete(UploadFile).where(UploadFile.id.in_(attachment_ids))
+            attachment_file_delete_stmt = delete(UploadFile).where(
+                UploadFile.id.in_(attachment_ids),
+                UploadFile.tenant_id == dataset_tenant_id,
+            )
             session.execute(attachment_file_delete_stmt)
 
         if binding_ids:

--- a/api/tasks/clean_notion_document_task.py
+++ b/api/tasks/clean_notion_document_task.py
@@ -8,6 +8,7 @@ from sqlalchemy import delete, select
 from core.db.session_factory import session_factory
 from core.rag.index_processor.index_processor_factory import IndexProcessorFactory
 from models.dataset import Dataset, Document, DocumentSegment
+from services.vector_service import VectorService
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,12 @@ def clean_notion_document_task(document_ids: list[str], dataset_id: str):
     """
     logger.info(click.style(f"Start clean document when import form notion document deleted: {dataset_id}", fg="green"))
     start_at = time.perf_counter()
-    total_index_node_ids = []
+    if not document_ids:
+        logger.info("No Notion documents selected for cleanup in dataset %s", dataset_id)
+        return
+
+    total_index_node_ids: list[str] = []
+    total_segment_ids: list[str] = []
 
     with session_factory.create_session() as session, session.begin():
         dataset = session.scalar(select(Dataset).where(Dataset.id == dataset_id).limit(1))
@@ -31,14 +37,21 @@ def clean_notion_document_task(document_ids: list[str], dataset_id: str):
         if not dataset:
             raise Exception("Document has no dataset")
         index_type = dataset.get_doc_form(session=session)
-        index_processor = IndexProcessorFactory(index_type).init_index_processor()
 
-        document_delete_stmt = delete(Document).where(Document.id.in_(document_ids))
+        segments = session.scalars(
+            select(DocumentSegment).where(
+                DocumentSegment.document_id.in_(document_ids),
+                DocumentSegment.dataset_id == dataset_id,
+            )
+        ).all()
+        total_index_node_ids.extend(segment.index_node_id for segment in segments if segment.index_node_id)
+        total_segment_ids.extend(segment.id for segment in segments)
+        document_delete_stmt = delete(Document).where(
+            Document.id.in_(document_ids),
+            Document.dataset_id == dataset_id,
+            Document.tenant_id == dataset.tenant_id,
+        )
         session.execute(document_delete_stmt)
-
-        for document_id in document_ids:
-            segments = session.scalars(select(DocumentSegment).where(DocumentSegment.document_id == document_id)).all()
-            total_index_node_ids.extend([segment.index_node_id for segment in segments if segment.index_node_id])
 
     # Wrap vector / keyword index cleanup in try/except so that a transient
     # failure here (e.g. billing API hiccup propagated via FeatureService when
@@ -47,31 +60,45 @@ def clean_notion_document_task(document_ids: list[str], dataset_id: str):
     # The Document rows are hard-deleted in the previous session block, so any
     # exception escaping this task would produce orphans that no later request
     # can reference back. Mirrors the pattern in ``clean_dataset_task``.
-    try:
-        with session_factory.create_session() as session, session.begin():
-            dataset = session.scalar(select(Dataset).where(Dataset.id == dataset_id).limit(1))
-            if dataset:
-                index_processor.clean(
-                    dataset,
-                    total_index_node_ids,
-                    with_keywords=True,
-                    delete_child_chunks=True,
-                    delete_summaries=True,
-                    session=session,
-                )
-    except Exception:
-        logger.exception(
-            "Failed to clean vector / keyword index in clean_notion_document_task, "
-            "dataset_id=%s, document_ids=%s, index_node_ids_count=%d. "
-            "Continuing with segment deletion; vector orphans can be reaped later.",
-            dataset_id,
-            document_ids,
-            len(total_index_node_ids),
-        )
+    if total_index_node_ids or total_segment_ids:
+        try:
+            index_processor = IndexProcessorFactory(index_type).init_index_processor()
+            with session_factory.create_session() as session:
+                cleanup_dataset = session.scalar(select(Dataset).where(Dataset.id == dataset_id).limit(1))
+                if cleanup_dataset:
+                    session.commit()
+                    index_processor.clean(
+                        cleanup_dataset,
+                        total_index_node_ids,
+                        with_keywords=True,
+                        delete_child_chunks=True,
+                        delete_summaries=True,
+                        segment_ids=total_segment_ids,
+                        session=session,
+                    )
+                    session.commit()
+        except Exception:
+            logger.exception(
+                "Failed to clean vector / keyword index in clean_notion_document_task, "
+                "dataset_id=%s, document_ids=%s, index_node_ids_count=%d. "
+                "Continuing with segment deletion; stale external index objects may remain.",
+                dataset_id,
+                document_ids,
+                len(total_index_node_ids),
+            )
 
     with session_factory.create_session() as session, session.begin():
-        segment_delete_stmt = delete(DocumentSegment).where(DocumentSegment.document_id.in_(document_ids))
-        session.execute(segment_delete_stmt)
+        VectorService.delete_segment_index_artifacts(
+            session=session,
+            dataset_id=dataset_id,
+            segment_ids=total_segment_ids,
+        )
+        session.execute(
+            delete(DocumentSegment).where(
+                DocumentSegment.document_id.in_(document_ids),
+                DocumentSegment.dataset_id == dataset_id,
+            )
+        )
 
     end_at = time.perf_counter()
     logger.info(

--- a/api/tasks/delete_segment_from_index_task.py
+++ b/api/tasks/delete_segment_from_index_task.py
@@ -9,6 +9,7 @@ from core.db.session_factory import session_factory
 from core.rag.index_processor.index_processor_factory import IndexProcessorFactory
 from models.dataset import Dataset, Document, SegmentAttachmentBinding
 from models.model import UploadFile
+from services.vector_service import VectorService
 
 logger = logging.getLogger(__name__)
 
@@ -22,8 +23,10 @@ def delete_segment_from_index_task(
     :param index_node_ids:
     :param dataset_id:
     :param document_id:
+    :param segment_ids:
+    :param child_node_ids:
 
-    Usage: delete_segment_from_index_task.delay(index_node_ids, dataset_id, document_id)
+    Usage: delete_segment_from_index_task.delay(index_node_ids, dataset_id, document_id, segment_ids, child_node_ids)
     """
     logger.info(click.style("Start delete segment from index", fg="green"))
     start_at = time.perf_counter()
@@ -32,45 +35,67 @@ def delete_segment_from_index_task(
             dataset = session.scalar(select(Dataset).where(Dataset.id == dataset_id).limit(1))
             if not dataset:
                 logging.warning("Dataset %s not found, skipping index cleanup", dataset_id)
+                VectorService.delete_segment_relational_dependants(
+                    session=session,
+                    dataset_id=dataset_id,
+                    segment_ids=segment_ids,
+                )
+                session.commit()
                 return
 
-            dataset_document = session.scalar(select(Document).where(Document.id == document_id).limit(1))
+            dataset_document = session.scalar(
+                select(Document)
+                .where(
+                    Document.id == document_id,
+                    Document.dataset_id == dataset_id,
+                )
+                .limit(1)
+            )
             if not dataset_document:
+                logging.warning("Document %s not found, skipping external index cleanup", document_id)
+                VectorService.delete_segment_relational_dependants(
+                    session=session,
+                    dataset_id=dataset_id,
+                    segment_ids=segment_ids,
+                )
+                session.commit()
                 return
 
-            if (
-                not dataset_document.enabled
-                or dataset_document.archived
-                or dataset_document.indexing_status != "completed"
-            ):
-                logging.info("Document not in valid state for index operations, skipping")
-                return
             doc_form = dataset_document.doc_form
 
-            # Proceed with index cleanup using the index_node_ids directly
-            # For actual deletion, we should delete summaries (not just disable them)
+            # Deletion cleanup is driven by durable IDs and must not depend on
+            # the document's current indexing state. The segment row has
+            # already been removed by the caller at this point.
             index_processor = IndexProcessorFactory(doc_form).init_index_processor()
+            session.commit()
             index_processor.clean(
                 dataset,
                 index_node_ids,
                 with_keywords=True,
                 delete_child_chunks=True,
                 precomputed_child_node_ids=child_node_ids,
-                delete_summaries=True,  # Actually delete summaries when segment is deleted,
+                delete_summaries=True,  # Actually delete summaries when segment is deleted
+                segment_ids=segment_ids,
                 session=session,
             )
             session.commit()
             if dataset.is_multimodal:
                 # delete segment attachment binding
                 segment_attachment_bindings = session.scalars(
-                    select(SegmentAttachmentBinding).where(SegmentAttachmentBinding.segment_id.in_(segment_ids))
+                    select(SegmentAttachmentBinding).where(
+                        SegmentAttachmentBinding.segment_id.in_(segment_ids),
+                        SegmentAttachmentBinding.tenant_id == dataset.tenant_id,
+                        SegmentAttachmentBinding.dataset_id == dataset.id,
+                        SegmentAttachmentBinding.document_id == dataset_document.id,
+                    )
                 ).all()
                 if segment_attachment_bindings:
                     attachment_ids = [binding.attachment_id for binding in segment_attachment_bindings]
+                    segment_attachment_bind_ids = [binding.id for binding in segment_attachment_bindings]
+                    session.commit()
                     index_processor.clean(
                         session=session, dataset=dataset, node_ids=attachment_ids, with_keywords=False
                     )
-                    segment_attachment_bind_ids = [i.id for i in segment_attachment_bindings]
 
                     for i in range(0, len(segment_attachment_bind_ids), 1000):
                         segment_attachment_bind_delete_stmt = delete(SegmentAttachmentBinding).where(
@@ -79,7 +104,12 @@ def delete_segment_from_index_task(
                         session.execute(segment_attachment_bind_delete_stmt)
 
                     # delete upload file
-                    session.execute(delete(UploadFile).where(UploadFile.id.in_(attachment_ids)))
+                    session.execute(
+                        delete(UploadFile).where(
+                            UploadFile.id.in_(attachment_ids),
+                            UploadFile.tenant_id == dataset.tenant_id,
+                        )
+                    )
                     session.commit()
 
             end_at = time.perf_counter()
@@ -87,3 +117,13 @@ def delete_segment_from_index_task(
         except Exception:
             session.rollback()
             logger.exception("delete segment from index failed")
+            try:
+                VectorService.delete_segment_relational_dependants(
+                    session=session,
+                    dataset_id=dataset_id,
+                    segment_ids=segment_ids,
+                )
+                session.commit()
+            except Exception:
+                session.rollback()
+                logger.exception("Failed to remove relational rows after segment index cleanup failed")

--- a/api/tasks/disable_segment_from_index_task.py
+++ b/api/tasks/disable_segment_from_index_task.py
@@ -60,16 +60,18 @@ def disable_segment_from_index_task(segment_id: str):
 
             index_type = dataset_document.doc_form
             index_processor = IndexProcessorFactory(index_type).init_index_processor()
-            assert segment.index_node_id
-            index_processor.clean(dataset, [segment.index_node_id], session=session)
             session.commit()
+            if segment.index_node_id:
+                index_processor.clean(dataset, [segment.index_node_id], session=session)
 
             # Disable summary index for this segment
             from services.summary_index_service import SummaryIndexService
 
             try:
+                session.commit()
                 SummaryIndexService.disable_summaries_for_segments(
                     dataset=dataset,
+                    session=session,
                     segment_ids=[segment.id],
                     disabled_by=segment.disabled_by,
                 )

--- a/api/tasks/disable_segments_from_index_task.py
+++ b/api/tasks/disable_segments_from_index_task.py
@@ -64,10 +64,10 @@ def disable_segments_from_index_task(segment_ids: list, dataset_id: str, documen
                 if segment_attachment_bindings:
                     attachment_ids = [binding.attachment_id for binding in segment_attachment_bindings]
                     index_node_ids.extend(attachment_ids)
+            session.commit()
             index_processor.clean(
                 dataset, index_node_ids, with_keywords=True, delete_child_chunks=False, session=session
             )
-            session.commit()
 
             # Disable summary indexes for these segments
             from services.summary_index_service import SummaryIndexService
@@ -76,8 +76,10 @@ def disable_segments_from_index_task(segment_ids: list, dataset_id: str, documen
             try:
                 # Get disabled_by from first segment (they should all have the same disabled_by)
                 disabled_by = segments[0].disabled_by if segments else None
+                session.commit()
                 SummaryIndexService.disable_summaries_for_segments(
                     dataset=dataset,
+                    session=session,
                     segment_ids=segment_ids_list,
                     disabled_by=disabled_by,
                 )

--- a/api/tasks/document_indexing_sync_task.py
+++ b/api/tasks/document_indexing_sync_task.py
@@ -68,8 +68,14 @@ def document_indexing_sync_task(dataset_id: str, document_id: str):
         tenant_id = document.tenant_id
         index_type = document.doc_form
 
-        segments = session.scalars(select(DocumentSegment).where(DocumentSegment.document_id == document_id)).all()
+        segments = session.scalars(
+            select(DocumentSegment).where(
+                DocumentSegment.document_id == document_id,
+                DocumentSegment.dataset_id == dataset_id,
+            )
+        ).all()
         index_node_ids = [segment.index_node_id for segment in segments if segment.index_node_id]
+        segment_ids = [segment.id for segment in segments]
 
     # Get credentials from datasource provider
     datasource_provider_service = DatasourceProviderService()
@@ -130,6 +136,8 @@ def document_indexing_sync_task(dataset_id: str, document_id: str):
                         index_node_ids,
                         with_keywords=True,
                         delete_child_chunks=True,
+                        delete_summaries=True,
+                        segment_ids=segment_ids,
                         session=session,
                     )
                     session.commit()
@@ -149,7 +157,10 @@ def document_indexing_sync_task(dataset_id: str, document_id: str):
             document.indexing_status = IndexingStatus.PARSING
             document.processing_started_at = naive_utc_now()
 
-            segment_delete_stmt = delete(DocumentSegment).where(DocumentSegment.document_id == document_id)
+            segment_delete_stmt = delete(DocumentSegment).where(
+                DocumentSegment.document_id == document_id,
+                DocumentSegment.dataset_id == dataset_id,
+            )
             session.execute(segment_delete_stmt)
             # Make the source update and segment deletion visible before extraction.
             session.commit()

--- a/api/tasks/document_indexing_update_task.py
+++ b/api/tasks/document_indexing_update_task.py
@@ -48,20 +48,28 @@ def document_indexing_update_task(dataset_id: str, document_id: str):
                 return
 
             index_type = document.doc_form
-            segments = session.scalars(select(DocumentSegment).where(DocumentSegment.document_id == document_id)).all()
+            segments = session.scalars(
+                select(DocumentSegment).where(
+                    DocumentSegment.document_id == document_id,
+                    DocumentSegment.dataset_id == dataset_id,
+                )
+            ).all()
             index_node_ids = [segment.index_node_id for segment in segments if segment.index_node_id]
+            segment_ids = [segment.id for segment in segments]
             # Persist the parsing status before vector cleanup and extraction.
             session.commit()
 
             clean_success = False
             try:
                 index_processor = IndexProcessorFactory(index_type).init_index_processor()
-                if index_node_ids:
+                if segment_ids:
                     index_processor.clean(
                         dataset,
                         index_node_ids,
                         with_keywords=True,
                         delete_child_chunks=True,
+                        delete_summaries=True,
+                        segment_ids=segment_ids,
                         session=session,
                     )
                     end_at = time.perf_counter()
@@ -88,7 +96,10 @@ def document_indexing_update_task(dataset_id: str, document_id: str):
                 session.commit()
 
             if clean_success:
-                segment_delete_stmt = delete(DocumentSegment).where(DocumentSegment.document_id == document_id)
+                segment_delete_stmt = delete(DocumentSegment).where(
+                    DocumentSegment.document_id == document_id,
+                    DocumentSegment.dataset_id == dataset_id,
+                )
                 session.execute(segment_delete_stmt)
                 session.commit()
 

--- a/api/tasks/duplicate_document_indexing_task.py
+++ b/api/tasks/duplicate_document_indexing_task.py
@@ -135,10 +135,14 @@ def _duplicate_document_indexing_task(dataset_id: str, document_ids: Sequence[st
                 index_processor = IndexProcessorFactory(index_type).init_index_processor()
 
                 segments = session.scalars(
-                    select(DocumentSegment).where(DocumentSegment.document_id == document.id)
+                    select(DocumentSegment).where(
+                        DocumentSegment.document_id == document.id,
+                        DocumentSegment.dataset_id == dataset.id,
+                    )
                 ).all()
                 if segments:
                     index_node_ids = [segment.index_node_id for segment in segments if segment.index_node_id]
+                    segment_ids = [segment.id for segment in segments]
 
                     # delete from vector index
                     index_processor.clean(
@@ -146,12 +150,16 @@ def _duplicate_document_indexing_task(dataset_id: str, document_ids: Sequence[st
                         index_node_ids,
                         with_keywords=True,
                         delete_child_chunks=True,
+                        delete_summaries=True,
+                        segment_ids=segment_ids,
                         session=session,
                     )
 
-                    segment_ids = [segment.id for segment in segments]
                     if segment_ids:
-                        segment_delete_stmt = delete(DocumentSegment).where(DocumentSegment.id.in_(segment_ids))
+                        segment_delete_stmt = delete(DocumentSegment).where(
+                            DocumentSegment.id.in_(segment_ids),
+                            DocumentSegment.dataset_id == dataset.id,
+                        )
                         session.execute(segment_delete_stmt)
                     session.commit()
 

--- a/api/tasks/enable_segment_to_index_task.py
+++ b/api/tasks/enable_segment_to_index_task.py
@@ -106,15 +106,17 @@ def enable_segment_to_index_task(segment_id: str):
                     )
 
             # save vector index
-            index_processor.load(dataset, [document], multimodal_documents=multimodel_documents, session=session)
             session.commit()
+            index_processor.load(dataset, [document], multimodal_documents=multimodel_documents, session=session)
 
             # Enable summary index for this segment
             from services.summary_index_service import SummaryIndexService
 
             try:
+                session.commit()
                 SummaryIndexService.enable_summaries_for_segments(
                     dataset=dataset,
+                    session=session,
                     segment_ids=[segment.id],
                 )
             except Exception as e:

--- a/api/tasks/enable_segments_to_index_task.py
+++ b/api/tasks/enable_segments_to_index_task.py
@@ -104,17 +104,18 @@ def enable_segments_to_index_task(segment_ids: list, dataset_id: str, document_i
                         )
                 documents.append(document)
             # save vector index
-            index_processor.load(dataset, documents, multimodal_documents=multimodal_documents, session=session)
-
             session.commit()
+            index_processor.load(dataset, documents, multimodal_documents=multimodal_documents, session=session)
 
             # Enable summary indexes for these segments
             from services.summary_index_service import SummaryIndexService
 
             segment_ids_list = [segment.id for segment in segments]
             try:
+                session.commit()
                 SummaryIndexService.enable_summaries_for_segments(
                     dataset=dataset,
+                    session=session,
                     segment_ids=segment_ids_list,
                 )
             except Exception as e:

--- a/api/tasks/generate_summary_index_task.py
+++ b/api/tasks/generate_summary_index_task.py
@@ -45,7 +45,14 @@ def generate_summary_index_task(dataset_id: str, document_id: str, segment_ids: 
                 logger.error(click.style(f"Dataset not found: {dataset_id}", fg="red"))
                 return
 
-            document = session.scalar(select(DatasetDocument).where(DatasetDocument.id == document_id).limit(1))
+            document = session.scalar(
+                select(DatasetDocument)
+                .where(
+                    DatasetDocument.id == document_id,
+                    DatasetDocument.dataset_id == dataset_id,
+                )
+                .limit(1)
+            )
             if not document:
                 logger.error(click.style(f"Document not found: {document_id}", fg="red"))
                 return
@@ -85,23 +92,22 @@ def generate_summary_index_task(dataset_id: str, document_id: str, segment_ids: 
             # Determine if only parent chunks should be processed
             only_parent_chunks = dataset.chunk_structure == "parent_child_index"
 
-            # Generate summaries
-            summary_records = SummaryIndexService.generate_summaries_for_document(
-                dataset=dataset,
-                document=document,
-                summary_index_setting=summary_index_setting,
-                segment_ids=segment_ids,
-                only_parent_chunks=only_parent_chunks,
-            )
+        summary_records = SummaryIndexService.generate_summaries_for_document(
+            dataset=dataset,
+            document=document,
+            summary_index_setting=summary_index_setting,
+            segment_ids=segment_ids,
+            only_parent_chunks=only_parent_chunks,
+        )
 
-            end_at = time.perf_counter()
-            logger.info(
-                click.style(
-                    f"Summary index generation completed for document {document_id}: "
-                    f"{len(summary_records)} summaries generated, latency: {end_at - start_at}",
-                    fg="green",
-                )
+        end_at = time.perf_counter()
+        logger.info(
+            click.style(
+                f"Summary index generation completed for document {document_id}: "
+                f"{len(summary_records)} summaries generated, latency: {end_at - start_at}",
+                fg="green",
             )
+        )
 
     except Exception as e:
         logger.exception("Failed to generate summary index for document %s", document_id)

--- a/api/tasks/regenerate_summary_index_task.py
+++ b/api/tasks/regenerate_summary_index_task.py
@@ -6,14 +6,14 @@ from collections import defaultdict
 
 import click
 from celery import shared_task
-from sqlalchemy import or_, select
+from sqlalchemy import select
 
 from core.db.session_factory import session_factory
 from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
 from models.dataset import Dataset, DocumentSegment, DocumentSegmentSummary
 from models.dataset import Document as DatasetDocument
 from models.enums import SummaryStatus
-from services.summary_index_service import SummaryIndexService
+from services.summary_index_service import SummaryIndexConflictError, SummaryIndexService
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +85,7 @@ def regenerate_summary_index_task(
                 # For embedding_model change: directly query all segments with existing summaries
                 # Don't require document indexing_status == "completed"
                 # Include summaries with status "completed" or "error" (if they have content)
-                segments_with_summaries = session.execute(
+                summary_candidates = session.execute(
                     select(DocumentSegment, DocumentSegmentSummary)
                     .join(
                         DocumentSegmentSummary,
@@ -100,18 +100,27 @@ def regenerate_summary_index_task(
                         DocumentSegment.status == "completed",  # Segment must be completed
                         DocumentSegment.enabled == True,
                         DocumentSegmentSummary.dataset_id == dataset_id,
-                        DocumentSegmentSummary.summary_content.isnot(None),  # Must have summary content
-                        # Include completed summaries or error summaries (with content)
-                        or_(
-                            DocumentSegmentSummary.status == SummaryStatus.COMPLETED,
-                            DocumentSegmentSummary.status == SummaryStatus.ERROR,
-                        ),
                         DatasetDocument.enabled == True,  # Document must be enabled
                         DatasetDocument.archived == False,  # Document must not be archived
                         DatasetDocument.doc_form != IndexStructureType.QA_INDEX,  # Skip qa_model documents
                     )
-                    .order_by(DocumentSegment.document_id.asc(), DocumentSegment.position.asc())
+                    .order_by(
+                        DocumentSegment.document_id.asc(),
+                        DocumentSegment.position.asc(),
+                        DocumentSegmentSummary.updated_at.desc(),
+                        DocumentSegmentSummary.id.desc(),
+                    )
                 ).all()
+                canonical_candidates: dict[str, tuple[DocumentSegment, DocumentSegmentSummary]] = {}
+                for segment, summary_record in summary_candidates:
+                    canonical_candidates.setdefault(segment.id, (segment, summary_record))
+                segments_with_summaries = [
+                    (segment, summary_record)
+                    for segment, summary_record in canonical_candidates.values()
+                    if summary_record.enabled
+                    and summary_record.summary_content
+                    and summary_record.status in (SummaryStatus.COMPLETED, SummaryStatus.ERROR)
+                ]
 
                 if not segments_with_summaries:
                     logger.info(
@@ -138,6 +147,8 @@ def regenerate_summary_index_task(
                     len(segments_by_document),
                 )
 
+                session.commit()
+
                 for document_id, segment_summary_pairs in segments_by_document.items():
                     logger.info(
                         "Re-vectorizing summaries for %s segments in document %s",
@@ -147,25 +158,12 @@ def regenerate_summary_index_task(
 
                     for segment, summary_record in segment_summary_pairs:
                         try:
-                            # Delete old vector
-                            if summary_record.summary_index_node_id:
-                                try:
-                                    from core.rag.datasource.vdb.vector_factory import Vector
-
-                                    vector = Vector(dataset, session=session)
-                                    vector.delete_by_ids([summary_record.summary_index_node_id])
-                                except Exception as e:
-                                    logger.warning(
-                                        "Failed to delete old summary vector for segment %s: %s",
-                                        segment.id,
-                                        str(e),
-                                    )
-
-                            # Re-vectorize with new embedding model
-                            SummaryIndexService.vectorize_summary(summary_record, segment, dataset, session=session)
-                            session.commit()
+                            SummaryIndexService.vectorize_summary(summary_record, segment, dataset)
                             total_segments_processed += 1
 
+                        except SummaryIndexConflictError:
+                            logger.info("Summary re-vectorization for segment %s was superseded", segment.id)
+                            continue
                         except Exception as e:
                             logger.error(
                                 "Failed to re-vectorize summary for segment %s: %s",
@@ -174,11 +172,6 @@ def regenerate_summary_index_task(
                                 exc_info=True,
                             )
                             total_segments_failed += 1
-                            # Update summary record with error status
-                            summary_record.status = SummaryStatus.ERROR
-                            summary_record.error = f"Re-vectorization failed: {str(e)}"
-                            session.add(summary_record)
-                            session.commit()
                             continue
 
             else:
@@ -215,7 +208,7 @@ def regenerate_summary_index_task(
 
                     try:
                         # Get all segments with existing summaries
-                        segments = session.scalars(
+                        segment_candidates = session.scalars(
                             select(DocumentSegment)
                             .join(
                                 DocumentSegmentSummary,
@@ -230,6 +223,7 @@ def regenerate_summary_index_task(
                             )
                             .order_by(DocumentSegment.position.asc())
                         ).all()
+                        segments = list({segment.id: segment for segment in segment_candidates}.values())
 
                         if not segments:
                             continue
@@ -241,28 +235,29 @@ def regenerate_summary_index_task(
                         )
 
                         for segment in segments:
-                            existing_summary_record: DocumentSegmentSummary | None = None
                             try:
-                                # Get existing summary record
-                                existing_summary_record = session.scalar(
-                                    select(DocumentSegmentSummary)
-                                    .where(
-                                        DocumentSegmentSummary.chunk_id == segment.id,
-                                        DocumentSegmentSummary.dataset_id == dataset_id,
-                                    )
-                                    .limit(1)
+                                existing_summary_record = SummaryIndexService.get_segment_summary(
+                                    segment.id,
+                                    dataset_id,
+                                    session=session,
                                 )
 
                                 if not existing_summary_record:
                                     logger.warning("Summary record not found for segment %s, skipping", segment.id)
                                     continue
 
+                                session.commit()
                                 # Regenerate both summary content and vectors (for summary_model change)
                                 SummaryIndexService.generate_and_vectorize_summary(
-                                    segment, dataset, summary_index_setting, session=session
+                                    segment,
+                                    dataset,
+                                    summary_index_setting,
                                 )
                                 total_segments_processed += 1
 
+                            except SummaryIndexConflictError:
+                                logger.info("Summary regeneration for segment %s was superseded", segment.id)
+                                continue
                             except Exception as e:
                                 logger.error(
                                     "Failed to regenerate summary for segment %s: %s",
@@ -271,12 +266,6 @@ def regenerate_summary_index_task(
                                     exc_info=True,
                                 )
                                 total_segments_failed += 1
-                                # Update summary record with error status
-                                if existing_summary_record is not None:
-                                    existing_summary_record.status = SummaryStatus.ERROR
-                                    existing_summary_record.error = f"Regeneration failed: {str(e)}"
-                                    session.add(existing_summary_record)
-                                    session.commit()
                                 continue
 
                     except Exception as e:

--- a/api/tasks/remove_document_from_index_task.py
+++ b/api/tasks/remove_document_from_index_task.py
@@ -45,7 +45,12 @@ def remove_document_from_index_task(document_id: str):
 
             index_processor = IndexProcessorFactory(document.doc_form).init_index_processor()
 
-            segments = session.scalars(select(DocumentSegment).where(DocumentSegment.document_id == document.id)).all()
+            segments = session.scalars(
+                select(DocumentSegment).where(
+                    DocumentSegment.document_id == document.id,
+                    DocumentSegment.dataset_id == document.dataset_id,
+                )
+            ).all()
 
             # Disable summary indexes for all segments in this document
             from services.summary_index_service import SummaryIndexService
@@ -53,8 +58,10 @@ def remove_document_from_index_task(document_id: str):
             segment_ids_list = [segment.id for segment in segments]
             if segment_ids_list:
                 try:
+                    session.commit()
                     SummaryIndexService.disable_summaries_for_segments(
                         dataset=dataset,
+                        session=session,
                         segment_ids=segment_ids_list,
                         disabled_by=document.disabled_by,
                     )
@@ -76,7 +83,10 @@ def remove_document_from_index_task(document_id: str):
             # update segment to disable
             session.execute(
                 update(DocumentSegment)
-                .where(DocumentSegment.document_id == document.id)
+                .where(
+                    DocumentSegment.document_id == document.id,
+                    DocumentSegment.dataset_id == document.dataset_id,
+                )
                 .values(
                     enabled=False,
                     disabled_at=naive_utc_now(),

--- a/api/tasks/retry_document_indexing_task.py
+++ b/api/tasks/retry_document_indexing_task.py
@@ -83,22 +83,31 @@ def retry_document_indexing_task(dataset_id: str, document_ids: list[str], user_
                     index_processor = IndexProcessorFactory(document.doc_form).init_index_processor()
 
                     segments = session.scalars(
-                        select(DocumentSegment).where(DocumentSegment.document_id == document_id)
+                        select(DocumentSegment).where(
+                            DocumentSegment.document_id == document_id,
+                            DocumentSegment.dataset_id == dataset.id,
+                        )
                     ).all()
                     if segments:
                         index_node_ids = [segment.index_node_id for segment in segments if segment.index_node_id]
+                        segment_ids = [segment.id for segment in segments]
                         # delete from vector index
                         index_processor.clean(
                             dataset,
                             index_node_ids,
                             with_keywords=True,
                             delete_child_chunks=True,
+                            delete_summaries=True,
+                            segment_ids=segment_ids,
                             session=session,
                         )
 
                     segment_ids = [segment.id for segment in segments]
                     if segment_ids:
-                        segment_delete_stmt = delete(DocumentSegment).where(DocumentSegment.id.in_(segment_ids))
+                        segment_delete_stmt = delete(DocumentSegment).where(
+                            DocumentSegment.id.in_(segment_ids),
+                            DocumentSegment.dataset_id == dataset.id,
+                        )
                         session.execute(segment_delete_stmt)
                     session.commit()
 

--- a/api/tasks/sync_website_document_indexing_task.py
+++ b/api/tasks/sync_website_document_indexing_task.py
@@ -69,17 +69,32 @@ def sync_website_document_indexing_task(dataset_id: str, document_id: str):
             # clean old data
             index_processor = IndexProcessorFactory(document.doc_form).init_index_processor()
 
-            segments = session.scalars(select(DocumentSegment).where(DocumentSegment.document_id == document_id)).all()
+            segments = session.scalars(
+                select(DocumentSegment).where(
+                    DocumentSegment.document_id == document_id,
+                    DocumentSegment.dataset_id == dataset_id,
+                )
+            ).all()
             if segments:
                 index_node_ids = [segment.index_node_id for segment in segments if segment.index_node_id]
+                segment_ids = [segment.id for segment in segments]
                 # delete from vector index
                 index_processor.clean(
-                    dataset, index_node_ids, with_keywords=True, delete_child_chunks=True, session=session
+                    dataset,
+                    index_node_ids,
+                    with_keywords=True,
+                    delete_child_chunks=True,
+                    delete_summaries=True,
+                    segment_ids=segment_ids,
+                    session=session,
                 )
 
             segment_ids = [segment.id for segment in segments]
             if segment_ids:
-                segment_delete_stmt = delete(DocumentSegment).where(DocumentSegment.id.in_(segment_ids))
+                segment_delete_stmt = delete(DocumentSegment).where(
+                    DocumentSegment.id.in_(segment_ids),
+                    DocumentSegment.dataset_id == dataset_id,
+                )
                 session.execute(segment_delete_stmt)
             session.commit()
 

--- a/api/tests/test_containers_integration_tests/services/test_hit_testing_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_hit_testing_service.py
@@ -13,9 +13,10 @@ from sqlalchemy.orm import Session
 from core.rag.embedding.retrieval import RetrievalSegments
 from core.rag.models.document import Document
 from core.rag.retrieval.retrieval_methods import RetrievalMethod
-from models.dataset import Dataset, DatasetQuery, DocumentSegment
+from models.dataset import Dataset, DatasetQuery, DocumentSegment, ExternalKnowledgeApis, ExternalKnowledgeBindings
 from models.dataset import Document as DatasetDocument
 from models.enums import DataSourceType, DocumentCreatedFrom, SegmentStatus
+from services.external_knowledge_service import ResolvedExternalKnowledgeConfig
 from services.hit_testing_service import HitTestingService
 
 
@@ -167,7 +168,12 @@ class TestHitTestingService:
         mock_format.return_value = [mock_record]
 
         response = _RetrieveResponse.model_validate(
-            HitTestingService.compact_retrieve_response(query, [mock_doc], session=db_session_with_containers)
+            HitTestingService.compact_retrieve_response(
+                query,
+                [mock_doc],
+                dataset_id="dataset-1",
+                session=db_session_with_containers,
+            )
         )
 
         assert response.query.content == query
@@ -217,7 +223,36 @@ class TestHitTestingService:
         account_id = str(uuid4())
         account = MagicMock()
         account.id = account_id
-        mock_ext_retrieve.return_value = [{"content": "ext content", "score": 1.0}]
+
+        def retrieve_external(**_kwargs: object) -> list[dict[str, object]]:
+            assert not db_session_with_containers.in_transaction()
+            return [{"content": "ext content", "score": 1.0}]
+
+        mock_ext_retrieve.side_effect = retrieve_external
+        dataset_id = dataset.id
+        tenant_id = dataset.tenant_id
+        settings_json = json.dumps({"endpoint": "https://api.example.com", "api_key": "test-key"})
+        external_api = ExternalKnowledgeApis(
+            name="test-api",
+            description="test API",
+            tenant_id=tenant_id,
+            settings=settings_json,
+            created_by=account_id,
+            updated_by=account_id,
+        )
+        db_session_with_containers.add(external_api)
+        db_session_with_containers.flush()
+        external_knowledge_id = "external-knowledge-1"
+        db_session_with_containers.add(
+            ExternalKnowledgeBindings(
+                tenant_id=tenant_id,
+                external_knowledge_api_id=external_api.id,
+                dataset_id=dataset_id,
+                external_knowledge_id=external_knowledge_id,
+                created_by=account_id,
+            )
+        )
+        db_session_with_containers.commit()
 
         before_count = db_session_with_containers.scalar(select(func.count()).select_from(DatasetQuery)) or 0
 
@@ -235,9 +270,13 @@ class TestHitTestingService:
         assert response.query.content == 'test "query"'
         assert response.records[0].content == "ext content"
         mock_ext_retrieve.assert_called_once_with(
-            session=db_session_with_containers,
-            dataset_id=dataset.id,
+            tenant_id=tenant_id,
+            dataset_id=dataset_id,
             query='test \\"query\\"',
+            resolved_config=ResolvedExternalKnowledgeConfig(
+                settings_json=settings_json,
+                external_knowledge_id=external_knowledge_id,
+            ),
             external_retrieval_model={"model": "test"},
             metadata_filtering_conditions={"key": "val"},
         )

--- a/api/tests/test_containers_integration_tests/tasks/test_clean_dataset_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_clean_dataset_task.py
@@ -827,11 +827,12 @@ class TestCleanDatasetTask:
         document = self._create_test_document(db_session_with_containers, account, tenant, dataset)
         segment = self._create_test_segment(db_session_with_containers, account, tenant, dataset, document)
         upload_file = self._create_test_upload_file(db_session_with_containers, account, tenant)
+        upload_file_id = upload_file.id
 
         # Update document with file reference
         import json
 
-        document.data_source_info = json.dumps({"upload_file_id": upload_file.id})
+        document.data_source_info = json.dumps({"upload_file_id": upload_file_id})
         db_session_with_containers.commit()
 
         # Mock storage to raise exceptions
@@ -856,12 +857,12 @@ class TestCleanDatasetTask:
         # Note: When storage operations fail, the upload file may not be deleted
         # This demonstrates that the cleanup process continues even with storage errors
         remaining_files = db_session_with_containers.scalars(
-            select(UploadFile).where(UploadFile.id == upload_file.id)
+            select(UploadFile).where(UploadFile.id == upload_file_id)
         ).all()
         # The upload file should still be deleted from the database even if storage cleanup fails
         # However, this depends on the specific implementation of clean_dataset_task
         if len(remaining_files) > 0:
-            print(f"Warning: Upload file {upload_file.id} was not deleted despite storage failure")
+            print(f"Warning: Upload file {upload_file_id} was not deleted despite storage failure")
             print("This demonstrates that the cleanup process continues even with storage errors")
         # We don't assert here as the behavior depends on the specific implementation
 

--- a/api/tests/test_containers_integration_tests/tasks/test_clean_notion_document_task.py
+++ b/api/tests/test_containers_integration_tests/tasks/test_clean_notion_document_task.py
@@ -7,6 +7,7 @@ containers to ensure proper cleanup of Notion documents, segments, and vector in
 
 import json
 import uuid
+from collections.abc import Generator
 from unittest.mock import Mock, patch
 
 import pytest
@@ -34,7 +35,7 @@ class TestCleanNotionDocumentTask:
     """Integration tests for clean_notion_document_task using testcontainers."""
 
     @pytest.fixture
-    def mock_external_service_dependencies(self):
+    def mock_external_service_dependencies(self) -> Generator[dict[str, Mock], None, None]:
         """Mock setup for external service dependencies."""
         with (
             patch("services.account_service.FeatureService") as mock_account_feature_service,
@@ -47,14 +48,14 @@ class TestCleanNotionDocumentTask:
             }
 
     @pytest.fixture
-    def mock_index_processor(self):
+    def mock_index_processor(self) -> Mock:
         """Mock IndexProcessor for testing."""
         mock_processor = Mock()
         mock_processor.clean = Mock()
         return mock_processor
 
     @pytest.fixture
-    def mock_index_processor_factory(self, mock_index_processor):
+    def mock_index_processor_factory(self, mock_index_processor: Mock) -> Generator[Mock, None, None]:
         """Mock IndexProcessorFactory for testing."""
         # Mock the actual IndexProcessorFactory class
         with patch("tasks.clean_notion_document_task.IndexProcessorFactory") as mock_factory:
@@ -71,8 +72,11 @@ class TestCleanNotionDocumentTask:
             yield mock_factory
 
     def test_clean_notion_document_task_success(
-        self, db_session_with_containers: Session, mock_index_processor_factory, mock_external_service_dependencies
-    ):
+        self,
+        db_session_with_containers: Session,
+        mock_index_processor_factory: Mock,
+        mock_external_service_dependencies: dict[str, Mock],
+    ) -> None:
         """
         Test successful cleanup of Notion documents with proper database operations.
 
@@ -94,6 +98,7 @@ class TestCleanNotionDocumentTask:
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company(), session=db_session_with_containers)
         tenant = account.current_tenant
+        assert tenant is not None
 
         # Create dataset
         dataset = Dataset(
@@ -176,8 +181,11 @@ class TestCleanNotionDocumentTask:
         # 5. The task completes without errors
 
     def test_clean_notion_document_task_dataset_not_found(
-        self, db_session_with_containers: Session, mock_index_processor_factory, mock_external_service_dependencies
-    ):
+        self,
+        db_session_with_containers: Session,
+        mock_index_processor_factory: Mock,
+        mock_external_service_dependencies: dict[str, Mock],
+    ) -> None:
         """
         Test cleanup task behavior when dataset is not found.
 
@@ -195,55 +203,12 @@ class TestCleanNotionDocumentTask:
         # Verify that the index processor factory was not used
         mock_index_processor_factory.return_value.init_index_processor.assert_not_called()
 
-    def test_clean_notion_document_task_empty_document_list(
-        self, db_session_with_containers: Session, mock_index_processor_factory, mock_external_service_dependencies
-    ):
-        """
-        Test cleanup task behavior with empty document list.
-
-        This test verifies that the task handles empty document lists gracefully
-        without attempting to process or delete anything.
-        """
-        fake = Faker()
-
-        # Create test data
-        account = AccountService.create_account(
-            email=fake.email(),
-            name=fake.name(),
-            interface_language="en-US",
-            password=generate_valid_password(fake),
-            session=db_session_with_containers,
-        )
-        TenantService.create_owner_tenant_if_not_exist(account, name=fake.company(), session=db_session_with_containers)
-        tenant = account.current_tenant
-
-        # Create dataset
-        dataset = Dataset(
-            id=str(uuid.uuid4()),
-            tenant_id=tenant.id,
-            name=fake.company(),
-            description=fake.text(max_nb_chars=100),
-            data_source_type=DataSourceType.NOTION_IMPORT,
-            created_by=account.id,
-        )
-        db_session_with_containers.add(dataset)
-        db_session_with_containers.commit()
-
-        # Execute cleanup task with empty document list
-        clean_notion_document_task([], dataset.id)
-
-        # Verify that the index processor was called once with empty node list
-        mock_processor = mock_index_processor_factory.return_value.init_index_processor.return_value
-        assert mock_processor.clean.call_count == 1
-        args, kwargs = mock_processor.clean.call_args
-        # args: (dataset, total_index_node_ids)
-        assert isinstance(args[0], Dataset)
-        assert args[1] == []
-        assert kwargs["session"] is not None
-
     def test_clean_notion_document_task_with_different_index_types(
-        self, db_session_with_containers: Session, mock_index_processor_factory, mock_external_service_dependencies
-    ):
+        self,
+        db_session_with_containers: Session,
+        mock_index_processor_factory: Mock,
+        mock_external_service_dependencies: dict[str, Mock],
+    ) -> None:
         """
         Test cleanup task with different dataset index types.
 
@@ -262,6 +227,7 @@ class TestCleanNotionDocumentTask:
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company(), session=db_session_with_containers)
         tenant = account.current_tenant
+        assert tenant is not None
 
         # Test different index types
         # Note: Only testing text_model to avoid dependency on external services
@@ -330,8 +296,11 @@ class TestCleanNotionDocumentTask:
             mock_index_processor_factory.reset_mock()
 
     def test_clean_notion_document_task_with_segments_no_index_node_ids(
-        self, db_session_with_containers: Session, mock_index_processor_factory, mock_external_service_dependencies
-    ):
+        self,
+        db_session_with_containers: Session,
+        mock_index_processor_factory: Mock,
+        mock_external_service_dependencies: dict[str, Mock],
+    ) -> None:
         """
         Test cleanup task with segments that have no index_node_ids.
 
@@ -350,6 +319,7 @@ class TestCleanNotionDocumentTask:
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company(), session=db_session_with_containers)
         tenant = account.current_tenant
+        assert tenant is not None
 
         # Create dataset
         dataset = Dataset(
@@ -413,8 +383,11 @@ class TestCleanNotionDocumentTask:
         # are properly deleted from the database.
 
     def test_clean_notion_document_task_partial_document_cleanup(
-        self, db_session_with_containers: Session, mock_index_processor_factory, mock_external_service_dependencies
-    ):
+        self,
+        db_session_with_containers: Session,
+        mock_index_processor_factory: Mock,
+        mock_external_service_dependencies: dict[str, Mock],
+    ) -> None:
         """
         Test cleanup task with partial document cleanup scenario.
 
@@ -433,6 +406,7 @@ class TestCleanNotionDocumentTask:
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company(), session=db_session_with_containers)
         tenant = account.current_tenant
+        assert tenant is not None
 
         # Create dataset
         dataset = Dataset(
@@ -515,8 +489,11 @@ class TestCleanNotionDocumentTask:
         # The database operations work correctly, isolating only the specified documents.
 
     def test_clean_notion_document_task_with_mixed_segment_statuses(
-        self, db_session_with_containers: Session, mock_index_processor_factory, mock_external_service_dependencies
-    ):
+        self,
+        db_session_with_containers: Session,
+        mock_index_processor_factory: Mock,
+        mock_external_service_dependencies: dict[str, Mock],
+    ) -> None:
         """
         Test cleanup task with segments in different statuses.
 
@@ -535,6 +512,7 @@ class TestCleanNotionDocumentTask:
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company(), session=db_session_with_containers)
         tenant = account.current_tenant
+        assert tenant is not None
 
         # Create dataset
         dataset = Dataset(
@@ -605,8 +583,11 @@ class TestCleanNotionDocumentTask:
         # IndexProcessor verification would require more sophisticated mocking.
 
     def test_clean_notion_document_task_continues_when_index_processor_fails(
-        self, db_session_with_containers: Session, mock_index_processor_factory, mock_external_service_dependencies
-    ):
+        self,
+        db_session_with_containers: Session,
+        mock_index_processor_factory: Mock,
+        mock_external_service_dependencies: dict[str, Mock],
+    ) -> None:
         """
         Index processor failure (e.g. transient billing API error propagated via
         ``FeatureService`` when ``Vector(dataset)`` lazily resolves the embedding
@@ -636,6 +617,7 @@ class TestCleanNotionDocumentTask:
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company(), session=db_session_with_containers)
         tenant = account.current_tenant
+        assert tenant is not None
 
         # Create dataset
         dataset = Dataset(
@@ -709,8 +691,11 @@ class TestCleanNotionDocumentTask:
         assert _count_segments(db_session_with_containers, DocumentSegment.document_id == document.id) == 0
 
     def test_clean_notion_document_task_with_large_number_of_documents(
-        self, db_session_with_containers: Session, mock_index_processor_factory, mock_external_service_dependencies
-    ):
+        self,
+        db_session_with_containers: Session,
+        mock_index_processor_factory: Mock,
+        mock_external_service_dependencies: dict[str, Mock],
+    ) -> None:
         """
         Test cleanup task with a large number of documents and segments.
 
@@ -729,6 +714,7 @@ class TestCleanNotionDocumentTask:
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company(), session=db_session_with_containers)
         tenant = account.current_tenant
+        assert tenant is not None
 
         # Create dataset
         dataset = Dataset(
@@ -744,6 +730,7 @@ class TestCleanNotionDocumentTask:
 
         # Create a large number of documents
         num_documents = 50
+        num_segments_per_doc = 5
         documents = []
         all_segments = []
         all_index_node_ids = []
@@ -770,7 +757,6 @@ class TestCleanNotionDocumentTask:
             documents.append(document)
             assert tenant
             # Create multiple segments for each document
-            num_segments_per_doc = 5
             for j in range(num_segments_per_doc):
                 segment = DocumentSegment(
                     tenant_id=tenant.id,
@@ -808,8 +794,11 @@ class TestCleanNotionDocumentTask:
         # The database efficiently handles large-scale deletions.
 
     def test_clean_notion_document_task_with_documents_from_different_tenants(
-        self, db_session_with_containers: Session, mock_index_processor_factory, mock_external_service_dependencies
-    ):
+        self,
+        db_session_with_containers: Session,
+        mock_index_processor_factory: Mock,
+        mock_external_service_dependencies: dict[str, Mock],
+    ) -> None:
         """
         Test cleanup task with documents from different tenants.
 
@@ -835,6 +824,7 @@ class TestCleanNotionDocumentTask:
                 account, name=fake.company(), session=db_session_with_containers
             )
             tenant = account.current_tenant
+            assert tenant is not None
             accounts.append(account)
             tenants.append(tenant)
 
@@ -856,10 +846,10 @@ class TestCleanNotionDocumentTask:
         all_segments = []
         all_index_node_ids = []
 
-        for i, (dataset, account) in enumerate(zip(datasets, accounts)):
+        for i, (dataset, account, tenant) in enumerate(zip(datasets, accounts, tenants)):
             document = Document(
                 id=str(uuid.uuid4()),
-                tenant_id=account.current_tenant.id,
+                tenant_id=tenant.id,
                 dataset_id=dataset.id,
                 position=0,
                 data_source_type=DataSourceType.NOTION_IMPORT,
@@ -880,7 +870,7 @@ class TestCleanNotionDocumentTask:
             # Create segments for each document
             for j in range(3):
                 segment = DocumentSegment(
-                    tenant_id=account.current_tenant.id,
+                    tenant_id=tenant.id,
                     dataset_id=dataset.id,
                     document_id=document.id,
                     position=j,
@@ -924,8 +914,11 @@ class TestCleanNotionDocumentTask:
         # Only documents from the target dataset are affected, maintaining tenant separation.
 
     def test_clean_notion_document_task_with_documents_in_different_states(
-        self, db_session_with_containers: Session, mock_index_processor_factory, mock_external_service_dependencies
-    ):
+        self,
+        db_session_with_containers: Session,
+        mock_index_processor_factory: Mock,
+        mock_external_service_dependencies: dict[str, Mock],
+    ) -> None:
         """
         Test cleanup task with documents in different indexing states.
 
@@ -944,6 +937,7 @@ class TestCleanNotionDocumentTask:
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company(), session=db_session_with_containers)
         tenant = account.current_tenant
+        assert tenant is not None
 
         # Create dataset
         dataset = Dataset(
@@ -1030,8 +1024,11 @@ class TestCleanNotionDocumentTask:
         # All documents are deleted regardless of their indexing status.
 
     def test_clean_notion_document_task_with_documents_having_metadata(
-        self, db_session_with_containers: Session, mock_index_processor_factory, mock_external_service_dependencies
-    ):
+        self,
+        db_session_with_containers: Session,
+        mock_index_processor_factory: Mock,
+        mock_external_service_dependencies: dict[str, Mock],
+    ) -> None:
         """
         Test cleanup task with documents that have rich metadata.
 
@@ -1050,6 +1047,7 @@ class TestCleanNotionDocumentTask:
         )
         TenantService.create_owner_tenant_if_not_exist(account, name=fake.company(), session=db_session_with_containers)
         tenant = account.current_tenant
+        assert tenant is not None
 
         # Create dataset with built-in fields enabled
         dataset = Dataset(

--- a/api/tests/unit_tests/commands/test_vector.py
+++ b/api/tests/unit_tests/commands/test_vector.py
@@ -1,0 +1,468 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from commands import vector as vector_command
+from core.rag.datasource.vdb.vector_type import VectorType
+from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
+from core.rag.models.document import Document as VectorDocument
+from models.dataset import (
+    ChildChunk,
+    Dataset,
+    DatasetCollectionBinding,
+    DocumentSegment,
+    DocumentSegmentSummary,
+)
+from models.dataset import Document as DatasetDocument
+from models.enums import (
+    CollectionBindingType,
+    DataSourceType,
+    DocumentCreatedFrom,
+    IndexingStatus,
+    SegmentStatus,
+    SummaryStatus,
+)
+from models.model import App, AppAnnotationSetting, MessageAnnotation
+
+
+def _dataset() -> Dataset:
+    dataset = Dataset(
+        tenant_id=str(uuid.uuid4()),
+        name="vector migration dataset",
+        description="",
+        provider="vendor",
+        permission="only_me",
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        indexing_technique=IndexTechniqueType.HIGH_QUALITY,
+        created_by=str(uuid.uuid4()),
+        embedding_model="embedding",
+        embedding_model_provider="provider",
+        chunk_structure=IndexStructureType.PARAGRAPH_INDEX,
+    )
+    dataset.id = str(uuid.uuid4())
+    return dataset
+
+
+def _document(dataset: Dataset, *, position: int, doc_form: str) -> DatasetDocument:
+    document = DatasetDocument(
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        position=position,
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        batch=f"batch-{position}",
+        name=f"document-{position}.txt",
+        created_from=DocumentCreatedFrom.WEB,
+        created_by=dataset.created_by,
+        enabled=True,
+        archived=False,
+        indexing_status=IndexingStatus.COMPLETED,
+        doc_form=doc_form,
+        word_count=10,
+        tokens=10,
+    )
+    document.id = str(uuid.uuid4())
+    return document
+
+
+def _segment(dataset: Dataset, document: DatasetDocument, *, position: int) -> DocumentSegment:
+    segment = DocumentSegment(
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        document_id=document.id,
+        position=position,
+        content=f"parent content {position}",
+        word_count=3,
+        tokens=3,
+        created_by=dataset.created_by,
+        status=SegmentStatus.COMPLETED,
+        enabled=True,
+    )
+    segment.id = str(uuid.uuid4())
+    segment.index_node_id = str(uuid.uuid4())
+    segment.index_node_hash = f"parent-hash-{position}"
+    return segment
+
+
+def _summary(dataset: Dataset, document: DatasetDocument, segment: DocumentSegment) -> DocumentSegmentSummary:
+    return DocumentSegmentSummary(
+        dataset_id=dataset.id,
+        document_id=document.id,
+        chunk_id=segment.id,
+        summary_content=f"summary for {segment.content}",
+        summary_index_node_id=str(uuid.uuid4()),
+        summary_index_node_hash=f"summary-hash-{segment.position}",
+        status=SummaryStatus.COMPLETED,
+        enabled=True,
+    )
+
+
+class _ScalarResult:
+    def __init__(self, values: Sequence[object]) -> None:
+        self._values = values
+
+    def all(self) -> list[object]:
+        return list(self._values)
+
+
+class _QueuedReadSession:
+    def __init__(self, results: Sequence[Sequence[object]]) -> None:
+        self._results = iter(results)
+
+    def scalars(self, _statement: object) -> _ScalarResult:
+        return _ScalarResult(next(self._results))
+
+
+def test_collect_dataset_vector_documents_preserves_summaries_and_parent_child_shape() -> None:
+    dataset = _dataset()
+    paragraph_document = _document(dataset, position=1, doc_form=IndexStructureType.PARAGRAPH_INDEX)
+    parent_document = _document(dataset, position=2, doc_form=IndexStructureType.PARENT_CHILD_INDEX)
+    paragraph_segment = _segment(dataset, paragraph_document, position=1)
+    parent_segment = _segment(dataset, parent_document, position=1)
+    paragraph_summary = _summary(dataset, paragraph_document, paragraph_segment)
+    parent_summary = _summary(dataset, parent_document, parent_segment)
+    child = ChildChunk(
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        document_id=parent_document.id,
+        segment_id=parent_segment.id,
+        position=1,
+        content="real child content",
+        word_count=3,
+        created_by=dataset.created_by,
+        index_node_id=str(uuid.uuid4()),
+        index_node_hash="child-hash",
+    )
+    session = _QueuedReadSession(
+        [
+            [paragraph_document, parent_document],
+            [paragraph_segment],
+            [paragraph_summary],
+            [parent_segment],
+            [parent_summary],
+            [child],
+        ]
+    )
+
+    documents, segment_count = vector_command._collect_dataset_vector_documents(
+        dataset,
+        session=session,  # type: ignore[arg-type]
+    )
+
+    assert segment_count == 2
+    assert {document.metadata["doc_id"] for document in documents} == {
+        paragraph_segment.index_node_id,
+        paragraph_summary.summary_index_node_id,
+        child.index_node_id,
+        parent_summary.summary_index_node_id,
+    }
+    assert parent_segment.index_node_id not in {document.metadata["doc_id"] for document in documents}
+    assert {document.metadata["original_chunk_id"] for document in documents if document.metadata["is_summary"]} == {
+        paragraph_segment.id,
+        parent_segment.id,
+    }
+
+
+@dataclass(frozen=True)
+class _Page:
+    items: list[Dataset]
+
+
+class _TrackedSessionContext:
+    def __init__(self, tracker: _ConnectionTracker, session: MagicMock) -> None:
+        self._tracker = tracker
+        self._session = session
+
+    def __enter__(self) -> MagicMock:
+        self._tracker.active += 1
+        return self._session
+
+    def __exit__(self, _exc_type: object, _exc: object, _tb: object) -> None:
+        self._tracker.active -= 1
+
+
+class _ConnectionTracker:
+    def __init__(self) -> None:
+        self.active = 0
+        self.read_scalar_result: object | None = None
+        self.write_session = MagicMock()
+
+    def read(self) -> _TrackedSessionContext:
+        session = MagicMock()
+        session.scalar.return_value = self.read_scalar_result
+        return _TrackedSessionContext(self, session)
+
+    def write(self) -> _TrackedSessionContext:
+        return _TrackedSessionContext(self, self.write_session)
+
+
+class _TrackedSessionMaker:
+    def __init__(self, tracker: _ConnectionTracker) -> None:
+        self._tracker = tracker
+
+    def __call__(self) -> _TrackedSessionContext:
+        return self._tracker.read()
+
+    def begin(self) -> _TrackedSessionContext:
+        return self._tracker.write()
+
+
+def test_knowledge_migration_closes_read_transaction_before_vector_io() -> None:
+    dataset = _dataset()
+    tracker = _ConnectionTracker()
+    tracker.write_session.execute.return_value.rowcount = 1
+    vector = MagicMock()
+    document = VectorDocument(
+        page_content="snapshot",
+        metadata={
+            "doc_id": str(uuid.uuid4()),
+            "document_id": str(uuid.uuid4()),
+            "dataset_id": dataset.id,
+        },
+    )
+
+    def create_vector(detached_dataset: Dataset) -> MagicMock:
+        assert tracker.active == 0
+        assert detached_dataset.index_struct_dict is not None
+        return vector
+
+    with (
+        patch.object(vector_command, "db", MagicMock(engine=object())),
+        patch.object(
+            vector_command,
+            "sessionmaker",
+            return_value=_TrackedSessionMaker(tracker),
+        ),
+        patch.object(
+            vector_command,
+            "paginate_query",
+            side_effect=[_Page([dataset]), _Page([])],
+        ),
+        patch.object(
+            vector_command,
+            "_collect_dataset_vector_documents",
+            return_value=([document], 1),
+        ),
+        patch.object(vector_command, "Vector", side_effect=create_vector) as vector_factory,
+        patch.object(vector_command.dify_config, "VECTOR_STORE", VectorType.WEAVIATE),
+    ):
+        vector_command.migrate_knowledge_vector_database()
+
+    vector_factory.assert_called_once_with(dataset)
+    vector.delete.assert_called_once_with()
+    vector.create.assert_called_once_with([document])
+    tracker.write_session.execute.assert_called_once()
+    assert tracker.active == 0
+
+
+def test_knowledge_migration_does_not_activate_snapshot_changed_during_vector_io(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    dataset = _dataset()
+    tracker = _ConnectionTracker()
+    vector = MagicMock()
+    original_document = VectorDocument(
+        page_content="original snapshot",
+        metadata={"doc_id": str(uuid.uuid4()), "dataset_id": dataset.id},
+    )
+    changed_document = VectorDocument(
+        page_content="concurrent update",
+        metadata={"doc_id": original_document.metadata["doc_id"], "dataset_id": dataset.id},
+    )
+
+    with (
+        patch.object(vector_command, "db", MagicMock(engine=object())),
+        patch.object(vector_command, "sessionmaker", return_value=_TrackedSessionMaker(tracker)),
+        patch.object(vector_command, "paginate_query", side_effect=[_Page([dataset]), _Page([])]),
+        patch.object(
+            vector_command,
+            "_collect_dataset_vector_documents",
+            side_effect=[([original_document], 1), ([changed_document], 1)],
+        ),
+        patch.object(vector_command, "Vector", return_value=vector),
+        patch.object(vector_command.dify_config, "VECTOR_STORE", VectorType.WEAVIATE),
+    ):
+        vector_command.migrate_knowledge_vector_database()
+
+    vector.create.assert_called_once_with([original_document])
+    tracker.write_session.execute.assert_not_called()
+    assert "changed while its vector index was being migrated" in capsys.readouterr().out
+    assert tracker.active == 0
+
+
+def test_knowledge_migration_does_not_overwrite_concurrently_changed_vector_configuration(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    dataset = _dataset()
+    tracker = _ConnectionTracker()
+    tracker.write_session.execute.return_value.rowcount = 0
+    vector = MagicMock()
+    document = VectorDocument(
+        page_content="stable snapshot",
+        metadata={"doc_id": str(uuid.uuid4()), "dataset_id": dataset.id},
+    )
+
+    with (
+        patch.object(vector_command, "db", MagicMock(engine=object())),
+        patch.object(vector_command, "sessionmaker", return_value=_TrackedSessionMaker(tracker)),
+        patch.object(vector_command, "paginate_query", side_effect=[_Page([dataset]), _Page([])]),
+        patch.object(vector_command, "_collect_dataset_vector_documents", return_value=([document], 1)),
+        patch.object(vector_command, "Vector", return_value=vector),
+        patch.object(vector_command.dify_config, "VECTOR_STORE", VectorType.WEAVIATE),
+    ):
+        vector_command.migrate_knowledge_vector_database()
+
+    vector.create.assert_called_once_with([document])
+    tracker.write_session.execute.assert_called_once()
+    assert "vector configuration changed concurrently" in capsys.readouterr().out
+    assert tracker.active == 0
+
+
+def test_knowledge_migration_compare_and_swap_guards_embedding_configuration(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    dataset = _dataset()
+    tracker = _ConnectionTracker()
+    vector = MagicMock()
+    document = VectorDocument(
+        page_content="stable snapshot",
+        metadata={"doc_id": str(uuid.uuid4()), "dataset_id": dataset.id},
+    )
+
+    def execute(statement: object) -> MagicMock:
+        # Simulate the database accepting the activation unless the command
+        # includes the embedding configuration in its compare-and-swap.
+        statement_text = str(statement)
+        guards_embedding_configuration = (
+            "datasets.embedding_model =" in statement_text and "datasets.embedding_model_provider =" in statement_text
+        )
+        result = MagicMock()
+        result.rowcount = 0 if guards_embedding_configuration else 1
+        return result
+
+    tracker.write_session.execute.side_effect = execute
+
+    with (
+        patch.object(vector_command, "db", MagicMock(engine=object())),
+        patch.object(vector_command, "sessionmaker", return_value=_TrackedSessionMaker(tracker)),
+        patch.object(vector_command, "paginate_query", side_effect=[_Page([dataset]), _Page([])]),
+        patch.object(vector_command, "_collect_dataset_vector_documents", return_value=([document], 1)),
+        patch.object(vector_command, "Vector", return_value=vector),
+        patch.object(vector_command.dify_config, "VECTOR_STORE", VectorType.WEAVIATE),
+    ):
+        vector_command.migrate_knowledge_vector_database()
+
+    vector.create.assert_called_once_with([document])
+    assert "vector configuration changed concurrently" in capsys.readouterr().out
+    assert tracker.active == 0
+
+
+def test_knowledge_migration_resolves_qdrant_binding_without_holding_connection_during_vector_io() -> None:
+    dataset = _dataset()
+    dataset.collection_binding_id = str(uuid.uuid4())
+    binding = DatasetCollectionBinding(
+        provider_name="provider",
+        model_name="embedding",
+        type=CollectionBindingType.DATASET,
+        collection_name="bound-collection",
+    )
+    tracker = _ConnectionTracker()
+    tracker.read_scalar_result = binding
+    tracker.write_session.execute.return_value.rowcount = 1
+    vector = MagicMock()
+    document = VectorDocument(
+        page_content="stable snapshot",
+        metadata={"doc_id": str(uuid.uuid4()), "dataset_id": dataset.id},
+    )
+
+    def create_vector(detached_dataset: Dataset) -> MagicMock:
+        assert tracker.active == 0
+        assert detached_dataset.index_struct_dict == {
+            "type": VectorType.QDRANT,
+            "vector_store": {"class_prefix": binding.collection_name},
+        }
+        return vector
+
+    with (
+        patch.object(vector_command, "db", MagicMock(engine=object())),
+        patch.object(vector_command, "sessionmaker", return_value=_TrackedSessionMaker(tracker)),
+        patch.object(vector_command, "paginate_query", side_effect=[_Page([dataset]), _Page([])]),
+        patch.object(vector_command, "_collect_dataset_vector_documents", return_value=([document], 1)),
+        patch.object(vector_command, "Vector", side_effect=create_vector),
+        patch.object(vector_command.dify_config, "VECTOR_STORE", VectorType.QDRANT),
+    ):
+        vector_command.migrate_knowledge_vector_database()
+
+    vector.delete.assert_called_once_with()
+    vector.create.assert_called_once_with([document])
+    assert tracker.active == 0
+
+
+class _SequencedSessionMaker:
+    def __init__(self, sessions: Sequence[MagicMock], tracker: _ConnectionTracker) -> None:
+        self._sessions = iter(sessions)
+        self._tracker = tracker
+
+    def begin(self) -> _TrackedSessionContext:
+        session = next(self._sessions)
+        return _TrackedSessionContext(self._tracker, session)
+
+
+def test_annotation_migration_closes_database_transaction_before_vector_io() -> None:
+    tenant_id = str(uuid.uuid4())
+    app = App(id=str(uuid.uuid4()), tenant_id=tenant_id, status="normal")
+    binding = DatasetCollectionBinding(
+        provider_name="provider",
+        model_name="embedding",
+        type=CollectionBindingType.ANNOTATION,
+        collection_name="annotation-collection",
+    )
+    setting = AppAnnotationSetting(
+        app_id=app.id,
+        score_threshold=0.8,
+        collection_binding_id=binding.id,
+        created_user_id=str(uuid.uuid4()),
+        updated_user_id=str(uuid.uuid4()),
+    )
+    annotation = MessageAnnotation(
+        app_id=app.id,
+        question="How does migration work?",
+        content="Safely.",
+        account_id=str(uuid.uuid4()),
+    )
+    first_page_session = MagicMock()
+    first_page_session.scalars.return_value.all.return_value = [app]
+    detail_session = MagicMock()
+    detail_session.scalar.side_effect = [setting, binding]
+    detail_session.scalars.return_value.all.return_value = [annotation]
+    final_page_session = MagicMock()
+    final_page_session.scalars.return_value.all.return_value = list[App]()
+    tracker = _ConnectionTracker()
+    session_maker = _SequencedSessionMaker(
+        [first_page_session, detail_session, final_page_session],
+        tracker,
+    )
+    vector = MagicMock()
+
+    def create_vector(dataset: Dataset, *, attributes: list[str]) -> MagicMock:
+        assert tracker.active == 0
+        assert dataset.id == app.id
+        assert attributes == ["doc_id", "annotation_id", "app_id"]
+        return vector
+
+    with (
+        patch.object(vector_command, "db", MagicMock(engine=object())),
+        patch.object(vector_command, "sessionmaker", return_value=session_maker),
+        patch.object(vector_command, "Vector", side_effect=create_vector),
+    ):
+        vector_command.migrate_annotation_vector_database()
+
+    vector.delete.assert_called_once_with()
+    created_documents = vector.create.call_args.args[0]
+    assert len(created_documents) == 1
+    assert created_documents[0].metadata["annotation_id"] == annotation.id
+    assert tracker.active == 0

--- a/api/tests/unit_tests/controllers/console/datasets/test_datasets_segments.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_datasets_segments.py
@@ -25,8 +25,8 @@ from core.errors.error import LLMBadRequestError, ProviderTokenNotInitError
 from core.rag.index_processor.constant.index_type import IndexStructureType
 from fields.segment_fields import segment_response_with_summary, segment_responses_with_summaries
 from libs.datetime_utils import naive_utc_now
-from models.dataset import ChildChunk, DocumentSegment
-from models.enums import SegmentStatus, SegmentType
+from models.dataset import ChildChunk, Dataset, Document, DocumentSegment
+from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus, SegmentType
 from models.model import UploadFile
 from services.errors.chunk import ChildChunkDeleteIndexError as ChildChunkDeleteIndexServiceError
 from services.errors.chunk import ChildChunkIndexingError as ChildChunkIndexingServiceError
@@ -53,6 +53,34 @@ def _segment():
     segment.updated_at = naive_utc_now()
     segment.updated_by = "u1"
     return segment
+
+
+def _dataset() -> Dataset:
+    return Dataset(
+        id="ds-1",
+        tenant_id="tenant-1",
+        name="Dataset",
+        created_by="u1",
+        indexing_technique="high_quality",
+    )
+
+
+def _document(dataset: Dataset) -> Document:
+    return Document(
+        id="doc-1",
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        position=1,
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        batch="batch-1",
+        name="document.txt",
+        created_from=DocumentCreatedFrom.WEB,
+        created_by="u1",
+        indexing_status=IndexingStatus.COMPLETED,
+        enabled=True,
+        archived=False,
+        doc_form=IndexStructureType.PARAGRAPH_INDEX,
+    )
 
 
 def _child_chunk():
@@ -230,10 +258,12 @@ class TestDatasetDocumentSegmentApi:
                 "controllers.console.datasets.datasets_segments.SegmentService.update_segments_status",
                 return_value=None,
             ),
+            patch("controllers.console.datasets.datasets_segments.db.session.remove") as remove_auth_session,
         ):
             response, status = method(api, MagicMock(), "tenant-1", user, "ds-1", "doc-1", "enable")
         assert status == 200
         assert response["result"] == "success"
+        remove_auth_session.assert_called_once_with()
 
     def test_patch_document_indexing_in_progress(self, app: Flask):
         api = DatasetDocumentSegmentApi()
@@ -439,10 +469,12 @@ class TestDatasetDocumentSegmentUpdateApi:
                 "controllers.console.datasets.datasets_segments.SummaryIndexService.get_segment_summary",
                 return_value=None,
             ),
+            patch("controllers.console.datasets.datasets_segments.db.session.remove") as mock_remove_auth_session,
         ):
             response, status = method(api, session, "tenant-1", user, "ds-1", "doc-1", "seg-1")
         assert status == 200
         assert "data" in response
+        mock_remove_auth_session.assert_called_once_with()
 
     def test_patch_document_outside_dataset_is_not_found(self, app: Flask):
         api = DatasetDocumentSegmentUpdateApi()
@@ -734,10 +766,12 @@ class TestChildChunkAddApi:
                 "controllers.console.datasets.datasets_segments.SegmentService.create_child_chunk",
                 return_value=child_chunk,
             ),
+            patch("controllers.console.datasets.datasets_segments.db.session.remove") as remove_auth_session,
         ):
             response, status = method(api, MagicMock(), "tenant-1", user, "ds-1", "doc-1", "seg-1")
         assert status == 200
         assert response["data"]["id"] == "cc-1"
+        remove_auth_session.assert_called_once_with()
 
     def test_post_child_chunk_indexing_error(self, app: Flask):
         api = ChildChunkAddApi()
@@ -767,6 +801,45 @@ class TestChildChunkAddApi:
         ):
             with pytest.raises(ChildChunkIndexingError):
                 method(api, MagicMock(), "tenant-1", user, "ds-1", "doc-1", "seg-1")
+
+    def test_patch_releases_auth_session_before_batch_vector_io(self, app: Flask):
+        api = ChildChunkAddApi()
+        method = unwrap(api.patch)
+        payload = {"chunks": [{"id": "cc-1", "content": "updated child"}]}
+        user = MagicMock(is_dataset_editor=True)
+        dataset = _dataset()
+        document = _document(dataset)
+        segment = _segment()
+        child_chunk = _child_chunk()
+        child_chunk.content = "updated child"
+        with (
+            app.test_request_context("/", json=payload),
+            patch.object(type(console_ns), "payload", payload),
+            patch("controllers.console.datasets.datasets_segments.DatasetService.get_dataset", return_value=dataset),
+            patch("controllers.console.datasets.datasets_segments.DocumentService.get_document", return_value=document),
+            patch(
+                "controllers.console.datasets.datasets_segments.SegmentService.get_segment_by_ref",
+                return_value=segment,
+            ),
+            patch(
+                "controllers.console.datasets.datasets_segments.DatasetService.check_dataset_model_setting",
+                return_value=None,
+            ),
+            patch(
+                "controllers.console.datasets.datasets_segments.DatasetService.check_dataset_permission",
+                return_value=None,
+            ),
+            patch(
+                "controllers.console.datasets.datasets_segments.SegmentService.update_child_chunks",
+                return_value=[child_chunk],
+            ),
+            patch("controllers.console.datasets.datasets_segments.db.session.remove") as remove_auth_session,
+        ):
+            response, status = method(api, MagicMock(), "tenant-1", user, "ds-1", "doc-1", "seg-1")
+
+        assert status == 200
+        assert response["data"][0]["content"] == "updated child"
+        remove_auth_session.assert_called_once_with()
 
     def test_post_permission_denied(self, app: Flask):
         api = ChildChunkAddApi()
@@ -819,10 +892,55 @@ class TestChildChunkUpdateApi:
             patch(
                 "controllers.console.datasets.datasets_segments.SegmentService.delete_child_chunk", return_value=None
             ),
+            patch("controllers.console.datasets.datasets_segments.db.session.remove") as remove_auth_session,
         ):
             response, status = method(api, MagicMock(), "tenant-1", user, "ds-1", "doc-1", "seg-1", "cc-1")
         assert status == 204
         assert response == ""
+        remove_auth_session.assert_called_once_with()
+
+    def test_patch_success_releases_auth_session_before_vector_io(self, app: Flask):
+        api = ChildChunkUpdateApi()
+        method = unwrap(api.patch)
+        payload = {"content": "updated child"}
+        user = MagicMock(is_dataset_editor=True)
+        dataset = _dataset()
+        document = _document(dataset)
+        segment = _segment()
+        child_chunk = _child_chunk()
+        child_chunk.content = payload["content"]
+        with (
+            app.test_request_context("/", json=payload),
+            patch.object(type(console_ns), "payload", payload),
+            patch("controllers.console.datasets.datasets_segments.DatasetService.get_dataset", return_value=dataset),
+            patch("controllers.console.datasets.datasets_segments.DocumentService.get_document", return_value=document),
+            patch(
+                "controllers.console.datasets.datasets_segments.SegmentService.get_segment_by_ref",
+                return_value=segment,
+            ),
+            patch(
+                "controllers.console.datasets.datasets_segments.SegmentService.get_child_chunk_by_segment_ref",
+                return_value=child_chunk,
+            ),
+            patch(
+                "controllers.console.datasets.datasets_segments.DatasetService.check_dataset_model_setting",
+                return_value=None,
+            ),
+            patch(
+                "controllers.console.datasets.datasets_segments.DatasetService.check_dataset_permission",
+                return_value=None,
+            ),
+            patch(
+                "controllers.console.datasets.datasets_segments.SegmentService.update_child_chunk",
+                return_value=child_chunk,
+            ),
+            patch("controllers.console.datasets.datasets_segments.db.session.remove") as remove_auth_session,
+        ):
+            response, status = method(api, MagicMock(), "tenant-1", user, "ds-1", "doc-1", "seg-1", "cc-1")
+
+        assert status == 200
+        assert response["data"]["content"] == "updated child"
+        remove_auth_session.assert_called_once_with()
 
     def test_delete_child_chunk_index_error(self, app: Flask):
         api = ChildChunkUpdateApi()

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_segment.py
@@ -37,7 +37,7 @@ from controllers.service_api.dataset.segment import (
 from core.rag.index_processor.constant.index_type import IndexStructureType
 from libs.datetime_utils import naive_utc_now
 from models.dataset import ChildChunk, Dataset, Document, DocumentSegment
-from models.enums import IndexingStatus, SegmentType
+from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus, SegmentType
 from services.dataset_service import DocumentService, SegmentService
 
 
@@ -110,15 +110,32 @@ def _child_chunk() -> ChildChunk:
 
 def _document_for_dataset(
     dataset: Dataset, document_id: str = "doc-id", doc_form: str = IndexStructureType.PARAGRAPH_INDEX
-):
-    document = Mock()
-    document.id = document_id
-    document.dataset_id = dataset.id
-    document.tenant_id = dataset.tenant_id
-    document.indexing_status = "completed"
-    document.enabled = True
-    document.doc_form = doc_form
-    return document
+) -> Document:
+    return Document(
+        id=document_id,
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        position=1,
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        batch="batch-1",
+        name="document.txt",
+        created_from=DocumentCreatedFrom.WEB,
+        created_by="account-1",
+        indexing_status=IndexingStatus.COMPLETED,
+        enabled=True,
+        archived=False,
+        doc_form=doc_form,
+    )
+
+
+def _dataset_for_tenant(tenant_id: str) -> Dataset:
+    return Dataset(
+        id=str(uuid.uuid4()),
+        tenant_id=tenant_id,
+        name="Dataset",
+        created_by="account-1",
+        indexing_technique="high_quality",
+    )
 
 
 class TestSegmentCreatePayload:
@@ -1207,9 +1224,12 @@ class TestDatasetSegmentApiDelete:
         mock_seg_svc.delete_segment.return_value = None
 
         # Act
-        with app.test_request_context(
-            f"/datasets/{mock_dataset.id}/documents/doc-id/segments/{mock_segment.id}",
-            method="DELETE",
+        with (
+            app.test_request_context(
+                f"/datasets/{mock_dataset.id}/documents/doc-id/segments/{mock_segment.id}",
+                method="DELETE",
+            ),
+            patch("controllers.service_api.dataset.segment.db.session.remove") as mock_remove_auth_session,
         ):
             api = DatasetSegmentApi()
             delete = inspect.unwrap(api.delete)
@@ -1224,6 +1244,7 @@ class TestDatasetSegmentApiDelete:
 
         # Assert
         assert response == ("", 204)
+        mock_remove_auth_session.assert_called_once_with()
         mock_seg_svc.delete_segment.assert_called_once_with(
             mock_segment, mock_doc, mock_dataset, session_factory.session
         )
@@ -1415,11 +1436,14 @@ class TestDatasetSegmentApiUpdate:
         mock_get_summary.return_value = None
         mock_dump_segment.return_value = _segment_response_dict()
 
-        with app.test_request_context(
-            f"/datasets/{mock_dataset.id}/documents/doc-id/segments/{mock_segment.id}",
-            method="POST",
-            json={"segment": {"content": "updated content"}},
-            headers={"Authorization": "Bearer test_token"},
+        with (
+            app.test_request_context(
+                f"/datasets/{mock_dataset.id}/documents/doc-id/segments/{mock_segment.id}",
+                method="POST",
+                json={"segment": {"content": "updated content"}},
+                headers={"Authorization": "Bearer test_token"},
+            ),
+            patch("controllers.service_api.dataset.segment.db.session.remove") as mock_remove_auth_session,
         ):
             api = DatasetSegmentApi()
             response, status = api.post(
@@ -1431,6 +1455,7 @@ class TestDatasetSegmentApiUpdate:
 
         assert status == 200
         assert "data" in response
+        mock_remove_auth_session.assert_called_once_with()
         mock_seg_svc.update_segment.assert_called_once()
         mock_dump_segment.assert_called_once_with(updated, None, session=session_factory.session)
 
@@ -1912,11 +1937,14 @@ class TestChildChunkApiPost:
         mock_child = _child_chunk()
         mock_seg_svc.create_child_chunk.return_value = mock_child
 
-        with app.test_request_context(
-            f"/datasets/{mock_dataset.id}/documents/doc-id/segments/seg-id/child_chunks",
-            method="POST",
-            json={"content": "child chunk content"},
-            headers={"Authorization": "Bearer test_token"},
+        with (
+            app.test_request_context(
+                f"/datasets/{mock_dataset.id}/documents/doc-id/segments/seg-id/child_chunks",
+                method="POST",
+                json={"content": "child chunk content"},
+                headers={"Authorization": "Bearer test_token"},
+            ),
+            patch("controllers.service_api.dataset.segment.db.session.remove") as mock_remove_auth_session,
         ):
             api = ChildChunkApi()
             response, status = api.post(
@@ -1928,6 +1956,7 @@ class TestChildChunkApiPost:
 
         assert status == 200
         assert "data" in response
+        mock_remove_auth_session.assert_called_once_with()
 
     @patch("controllers.service_api.dataset.segment.current_account_with_tenant")
     @patch("controllers.common.session.session_factory", new_callable=_session_factory_mock)
@@ -2046,9 +2075,12 @@ class TestDatasetChildChunkApiDelete:
         mock_seg_svc.get_child_chunk_by_segment_ref.return_value = mock_child
         mock_seg_svc.delete_child_chunk.return_value = None
 
-        with app.test_request_context(
-            f"/datasets/{mock_dataset.id}/documents/doc-id/segments/{segment_id}/child_chunks/{child_chunk_id}",
-            method="DELETE",
+        with (
+            app.test_request_context(
+                f"/datasets/{mock_dataset.id}/documents/doc-id/segments/{segment_id}/child_chunks/{child_chunk_id}",
+                method="DELETE",
+            ),
+            patch("controllers.service_api.dataset.segment.db.session.remove") as mock_remove_auth_session,
         ):
             api = DatasetChildChunkApi()
             delete = inspect.unwrap(api.delete)
@@ -2063,7 +2095,79 @@ class TestDatasetChildChunkApiDelete:
             )
 
         assert response == ("", 204)
+        mock_remove_auth_session.assert_called_once_with()
         mock_seg_svc.delete_child_chunk.assert_called_once()
+
+    @patch("controllers.service_api.dataset.segment.SegmentService")
+    @patch("controllers.service_api.dataset.segment.DocumentService")
+    @patch("controllers.service_api.dataset.segment.current_account_with_tenant")
+    @patch("controllers.common.session.session_factory", new_callable=_session_factory_mock)
+    @patch("controllers.service_api.wraps.FeatureService")
+    @patch("controllers.service_api.wraps.validate_and_get_api_token")
+    def test_update_child_chunk_releases_auth_session_before_vector_io(
+        self,
+        mock_validate_token,
+        mock_feature_svc,
+        session_factory,
+        mock_account_fn,
+        mock_doc_svc,
+        mock_seg_svc,
+        app: Flask,
+        mock_tenant,
+    ):
+        TestChildChunkApiPost._setup_billing_mocks(mock_validate_token, mock_feature_svc, mock_tenant.id)
+        mock_account_fn.return_value = (Mock(), mock_tenant.id)
+        dataset = _dataset_for_tenant(mock_tenant.id)
+        document = _document_for_dataset(dataset)
+        session_factory.session.scalar.return_value = dataset
+        mock_doc_svc.get_document.return_value = document
+        segment_id = str(uuid.uuid4())
+        child_chunk_id = str(uuid.uuid4())
+        segment = DocumentSegment(
+            tenant_id=dataset.tenant_id,
+            dataset_id=dataset.id,
+            document_id=document.id,
+            position=1,
+            content="parent content",
+            word_count=2,
+            tokens=2,
+            created_by="account-1",
+            status=SegmentStatus.COMPLETED,
+        )
+        segment.id = segment_id
+        mock_seg_svc.get_segment_by_ref.return_value = segment
+        child_chunk = _child_chunk()
+        child_chunk.id = child_chunk_id
+        child_chunk.segment_id = segment_id
+        child_chunk.dataset_id = dataset.id
+        child_chunk.document_id = document.id
+        child_chunk.tenant_id = dataset.tenant_id
+        child_chunk.content = "updated child content"
+        mock_seg_svc.get_child_chunk_by_segment_ref.return_value = child_chunk
+        mock_seg_svc.update_child_chunk.return_value = child_chunk
+
+        with (
+            app.test_request_context(
+                f"/datasets/{dataset.id}/documents/doc-id/segments/{segment_id}/child_chunks/{child_chunk_id}",
+                method="PATCH",
+                json={"content": "updated child content"},
+                headers={"Authorization": "Bearer test_token"},
+            ),
+            patch("controllers.service_api.dataset.segment.db.session.remove") as mock_remove_auth_session,
+        ):
+            api = DatasetChildChunkApi()
+            response, status = api.patch(
+                tenant_id=mock_tenant.id,
+                dataset_id=dataset.id,
+                document_id="doc-id",
+                segment_id=segment_id,
+                child_chunk_id=child_chunk_id,
+            )
+
+        assert status == 200
+        assert response["data"]["content"] == "updated child content"
+        mock_remove_auth_session.assert_called_once_with()
+        mock_seg_svc.update_child_chunk.assert_called_once()
 
     @patch("controllers.service_api.dataset.segment.SegmentService")
     @patch("controllers.service_api.dataset.segment.DocumentService")

--- a/api/tests/unit_tests/core/app/apps/pipeline/test_pipeline_generator.py
+++ b/api/tests/unit_tests/core/app/apps/pipeline/test_pipeline_generator.py
@@ -373,11 +373,19 @@ def test_generate_worker_sets_system_user_id_for_external_call(generator, mocker
         user_id="user",
     )
 
-    session = DummySession()
+    events: list[str] = []
+
+    class TrackedSession(DummySession):
+        def __exit__(self, exc_type, exc, tb):
+            events.append("session-close")
+            return False
+
+    session = TrackedSession()
     session.scalar.side_effect = [MagicMock(), MagicMock(session_id="session")]
     _patch_session(mocker, session)
 
     runner_instance = MagicMock()
+    runner_instance.run.side_effect = lambda: events.append("runner")
     mocker.patch.object(module, "PipelineRunner", return_value=runner_instance)
 
     generator._generate_worker(
@@ -391,6 +399,7 @@ def test_generate_worker_sets_system_user_id_for_external_call(generator, mocker
     )
 
     assert module.PipelineRunner.call_args.kwargs["system_user_id"] == "session"
+    assert events == ["session-close", "runner"]
 
 
 def test_generate_raises_when_workflow_not_found(generator, mocker: MockerFixture):
@@ -427,8 +436,11 @@ def test_generate_success_returns_converted(generator, mocker: MockerFixture):
     mocker.patch.object(module, "preserve_flask_contexts", _dummy_preserve)
 
     workflow = MagicMock(id="wf", tenant_id="tenant", app_id="pipe", graph_dict={})
+    events: list[str] = []
     session = MagicMock()
     session.get.return_value = workflow
+    session.expire_on_commit = True
+    session.commit.side_effect = lambda: events.append(f"commit-expire={session.expire_on_commit}")
     mocker.patch.object(module.db, "session", session)
 
     queue_manager = MagicMock()
@@ -436,6 +448,7 @@ def test_generate_success_returns_converted(generator, mocker: MockerFixture):
 
     worker_thread = MagicMock()
     worker_thread.is_alive.return_value = False
+    worker_thread.start.side_effect = lambda: events.append("worker-start")
     mocker.patch.object(module.threading, "Thread", return_value=worker_thread)
 
     mocker.patch.object(generator, "_get_draft_var_saver_factory", return_value=MagicMock())
@@ -463,6 +476,8 @@ def test_generate_success_returns_converted(generator, mocker: MockerFixture):
 
     assert result == "converted"
     worker_thread.join.assert_called_once_with(timeout=300)
+    assert events == ["commit-expire=False", "worker-start"]
+    assert session.expire_on_commit is True
 
 
 def test_single_iteration_generate_validates_inputs(generator, mocker: MockerFixture):

--- a/api/tests/unit_tests/core/rag/datasource/test_datasource_retrieval.py
+++ b/api/tests/unit_tests/core/rag/datasource/test_datasource_retrieval.py
@@ -13,7 +13,10 @@ from core.rag.index_processor.constant.query_type import QueryType
 from core.rag.models.document import Document
 from core.rag.rerank.rerank_type import RerankMode
 from core.rag.retrieval.retrieval_methods import RetrievalMethod
-from models.dataset import Dataset
+from models.dataset import ChildChunk, Dataset, DocumentSegment, DocumentSegmentSummary
+from models.dataset import Document as DatasetDocument
+from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus, SummaryStatus
+from services.external_knowledge_service import ResolvedExternalKnowledgeConfig
 
 
 def create_mock_document(
@@ -232,13 +235,16 @@ class TestRetrievalServiceInternals:
         mock_validate.return_value = "validated-condition"
         expected_documents = [create_mock_document("external-doc", "external-1", 0.8, provider="external")]
         mock_fetch.return_value = expected_documents
-        session = MagicMock()
-        session.scalar.return_value = SimpleNamespace(tenant_id="tenant-1")
+        resolved_config = ResolvedExternalKnowledgeConfig(
+            settings_json='{"endpoint": "https://api.example.com"}',
+            external_knowledge_id="knowledge-1",
+        )
 
         results = RetrievalService.external_retrieve(
-            session=session,
+            tenant_id="tenant-1",
             dataset_id="dataset-1",
             query="test query",
+            resolved_config=resolved_config,
             external_retrieval_model={"top_k": 3},
             metadata_filtering_conditions={"field": "source", "operator": "contains", "value": "manual"},
         )
@@ -251,16 +257,8 @@ class TestRetrievalServiceInternals:
             query="test query",
             external_retrieval_parameters={"top_k": 3},
             metadata_condition="validated-condition",
-            session=session,
+            resolved_config=resolved_config,
         )
-
-    def test_external_retrieve_returns_empty_when_dataset_not_found(self):
-        session = MagicMock()
-        session.scalar.return_value = None
-
-        results = RetrievalService.external_retrieve(session=session, dataset_id="missing", query="q")
-
-        assert results == []
 
     @patch("core.rag.datasource.retrieval_service.Session")
     def test_get_dataset_queries_by_id(self, mock_session_class):
@@ -385,7 +383,7 @@ class TestRetrievalServiceInternals:
 
         assert len(all_documents) == 1
         assert exceptions == []
-        mock_vector_class.assert_called_once_with(dataset=internal_dataset, session=vector_session)
+        mock_vector_class.assert_called_once_with(dataset=internal_dataset)
         vector_instance.search_by_vector.assert_called_once()
 
     @patch("core.rag.datasource.retrieval_service.Vector")
@@ -634,7 +632,12 @@ class TestRetrievalServiceInternals:
 
         assert len(all_documents) == 1
         assert exceptions == []
-        vector_instance.search_by_full_text.assert_called_once()
+        vector_instance.search_by_full_text.assert_called_once_with(
+            'query \\"x\\"',
+            top_k=4,
+            filter={"group_id": [internal_dataset.id]},
+            document_ids_filter=None,
+        )
 
     @patch("core.rag.datasource.retrieval_service.DataPostProcessor")
     @patch("core.rag.datasource.retrieval_service.Vector")
@@ -731,26 +734,128 @@ class TestRetrievalServiceInternals:
         assert exceptions == ["fulltext failed"]
 
     def test_format_retrieval_documents_with_empty_input_returns_empty_list(self):
-        assert RetrievalService.format_retrieval_documents(MagicMock(), []) == []
+        assert RetrievalService.format_retrieval_documents(MagicMock(), [], allowed_dataset_ids=set()) == []
 
     def test_format_retrieval_documents_without_document_id_returns_empty_list(self):
         documents = [Document(page_content="content", metadata={"doc_id": "doc-1", "score": 0.4}, provider="dify")]
 
-        assert RetrievalService.format_retrieval_documents(MagicMock(), documents) == []
+        assert (
+            RetrievalService.format_retrieval_documents(
+                MagicMock(),
+                documents,
+                allowed_dataset_ids=set(),
+            )
+            == []
+        )
+
+    @pytest.mark.parametrize(
+        ("enabled", "archived", "indexing_status"),
+        [
+            (False, False, "completed"),
+            (True, True, "completed"),
+            (True, False, "error"),
+        ],
+    )
+    def test_format_retrieval_documents_rejects_hits_for_inactive_documents(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        enabled: bool,
+        archived: bool,
+        indexing_status: str,
+    ):
+        dataset_document = SimpleNamespace(
+            id="document-id",
+            tenant_id="tenant-id",
+            dataset_id="dataset-id",
+            doc_form=IndexStructureType.PARAGRAPH_INDEX,
+            enabled=enabled,
+            archived=archived,
+            indexing_status=indexing_status,
+        )
+        segment = SimpleNamespace(
+            id="segment-id",
+            document_id=dataset_document.id,
+            index_node_id="index-node-id",
+        )
+        fake_session = _FakeSession(
+            execute_payloads=[[], [segment]],
+            scalars_payloads=[[dataset_document], []],
+        )
+        vector_hit = Document(
+            page_content="stale vector content",
+            metadata={
+                "dataset_id": dataset_document.dataset_id,
+                "document_id": dataset_document.id,
+                "doc_id": segment.index_node_id,
+                "score": 1.0,
+            },
+            provider="dify",
+        )
+        monkeypatch.setattr(retrieval_service_module, "RetrievalSegments", _SimpleRetrievalSegment)
+
+        result = RetrievalService.format_retrieval_documents(
+            fake_session,
+            [vector_hit],
+            allowed_dataset_ids={dataset_document.dataset_id},
+        )
+
+        assert result == []
 
     def test_format_retrieval_documents_with_parent_child_summary_and_attachments(
         self, monkeypatch: pytest.MonkeyPatch
     ):
-        dataset_doc_parent = SimpleNamespace(
-            id="doc-parent",
-            doc_form=IndexStructureType.PARENT_CHILD_INDEX,
-            dataset_id="dataset-id",
+        def dataset_document(document_id: str, doc_form: IndexStructureType) -> DatasetDocument:
+            document = DatasetDocument(
+                tenant_id="tenant-id",
+                dataset_id="dataset-id",
+                position=1,
+                data_source_type=DataSourceType.UPLOAD_FILE,
+                batch="batch-id",
+                name=f"{document_id}.txt",
+                created_from=DocumentCreatedFrom.API,
+                created_by="creator-id",
+                doc_metadata={},
+                doc_form=doc_form,
+                indexing_status=IndexingStatus.COMPLETED,
+                enabled=True,
+                archived=False,
+            )
+            document.id = document_id
+            return document
+
+        def segment(
+            segment_id: str,
+            document_id: str,
+            index_node_id: str,
+        ) -> DocumentSegment:
+            result = DocumentSegment(
+                tenant_id="tenant-id",
+                dataset_id="dataset-id",
+                document_id=document_id,
+                position=1,
+                content=f"content for {segment_id}",
+                word_count=3,
+                tokens=3,
+                created_by="creator-id",
+                index_node_id=index_node_id,
+                index_node_hash=f"hash-{segment_id}",
+                status=SegmentStatus.COMPLETED,
+                enabled=True,
+            )
+            result.id = segment_id
+            return result
+
+        dataset_doc_parent = dataset_document(
+            "doc-parent",
+            IndexStructureType.PARENT_CHILD_INDEX,
         )
-        dataset_doc_text = SimpleNamespace(id="doc-text", doc_form="paragraph", dataset_id="dataset-id")
-        dataset_doc_parent_summary = SimpleNamespace(
-            id="doc-parent-summary",
-            doc_form=IndexStructureType.PARENT_CHILD_INDEX,
-            dataset_id="dataset-id",
+        dataset_doc_text = dataset_document(
+            "doc-text",
+            IndexStructureType.PARAGRAPH_INDEX,
+        )
+        dataset_doc_parent_summary = dataset_document(
+            "doc-parent-summary",
+            IndexStructureType.PARENT_CHILD_INDEX,
         )
 
         monkeypatch.setattr(retrieval_service_module, "RetrievalChildChunk", _SimpleRetrievalChildChunk)
@@ -831,22 +936,74 @@ class TestRetrievalServiceInternals:
                 },
                 provider="dify",
             ),
+            Document(
+                page_content="disabled durable summary",
+                metadata={
+                    "document_id": "doc-text",
+                    "doc_id": "summary-disabled-node",
+                    "is_summary": True,
+                    "original_chunk_id": "segment-disabled-summary",
+                    "score": "0.99",
+                },
+                provider="dify",
+            ),
+            Document(
+                page_content="summary missing durable pointer",
+                metadata={
+                    "document_id": "doc-text",
+                    "doc_id": "summary-missing-pointer-node",
+                    "is_summary": True,
+                    "original_chunk_id": "segment-missing-pointer",
+                    "score": "0.98",
+                },
+                provider="dify",
+            ),
+            Document(
+                page_content="stale summary without current vector hit",
+                metadata={
+                    "document_id": "doc-text",
+                    "doc_id": "summary-stale-only-node",
+                    "is_summary": True,
+                    "original_chunk_id": "segment-current-pointer-not-hit",
+                    "score": "0.97",
+                },
+                provider="dify",
+            ),
         ]
-
-        child_chunk = SimpleNamespace(
-            id="child-chunk-1",
-            segment_id="segment-parent",
-            index_node_id="child-node-1",
-            content="child details",
-            position=2,
+        for input_document in input_documents:
+            input_document.metadata["dataset_id"] = "dataset-id"
+        input_documents.append(
+            Document(
+                page_content="cross-dataset vector hit",
+                metadata={
+                    "document_id": "doc-text",
+                    "doc_id": "foreign-index-node",
+                    "dataset_id": "foreign-dataset-id",
+                    "score": 1.0,
+                },
+                provider="dify",
+            )
         )
-        segment_parent = SimpleNamespace(id="segment-parent", document_id="doc-parent", index_node_id="parent-node")
-        segment_text = SimpleNamespace(id="segment-text", document_id="doc-text", index_node_id="index-node-1")
-        segment_summary = SimpleNamespace(id="segment-summary", document_id="doc-text", index_node_id="summary-node")
-        segment_parent_summary = SimpleNamespace(
-            id="segment-parent-summary",
-            document_id="doc-parent-summary",
-            index_node_id="summary-parent-node",
+
+        child_chunk = ChildChunk(
+            tenant_id="tenant-id",
+            dataset_id="dataset-id",
+            document_id="doc-parent",
+            segment_id="segment-parent",
+            position=2,
+            content="child details",
+            word_count=2,
+            created_by="creator-id",
+            index_node_id="child-node-1",
+        )
+        child_chunk.id = "child-chunk-1"
+        segment_parent = segment("segment-parent", "doc-parent", "parent-node")
+        segment_text = segment("segment-text", "doc-text", "index-node-1")
+        segment_summary = segment("segment-summary", "doc-text", "summary-node")
+        segment_parent_summary = segment(
+            "segment-parent-summary",
+            "doc-parent-summary",
+            "summary-parent-node",
         )
 
         fake_session = _FakeSession(
@@ -859,15 +1016,67 @@ class TestRetrievalServiceInternals:
             scalars_payloads=[
                 [dataset_doc_parent, dataset_doc_text, dataset_doc_parent_summary],
                 [
-                    SimpleNamespace(chunk_id="segment-summary", summary_content="summary for text"),
-                    SimpleNamespace(chunk_id="segment-parent-summary", summary_content="summary for parent"),
+                    DocumentSegmentSummary(
+                        dataset_id=dataset_doc_text.dataset_id,
+                        document_id=dataset_doc_text.id,
+                        chunk_id="segment-summary",
+                        summary_index_node_id="summary-node-1",
+                        summary_content="summary for text",
+                        status=SummaryStatus.COMPLETED,
+                        enabled=True,
+                    ),
+                    DocumentSegmentSummary(
+                        dataset_id=dataset_doc_text.dataset_id,
+                        document_id=dataset_doc_text.id,
+                        chunk_id="segment-summary",
+                        summary_index_node_id="summary-node-2",
+                        summary_content="older duplicate summary",
+                        status=SummaryStatus.COMPLETED,
+                        enabled=True,
+                    ),
+                    DocumentSegmentSummary(
+                        dataset_id=dataset_doc_parent_summary.dataset_id,
+                        document_id=dataset_doc_parent_summary.id,
+                        chunk_id="segment-parent-summary",
+                        summary_index_node_id="summary-parent-valid",
+                        summary_content="summary for parent",
+                        status=SummaryStatus.COMPLETED,
+                        enabled=True,
+                    ),
+                    DocumentSegmentSummary(
+                        dataset_id=dataset_doc_text.dataset_id,
+                        document_id=dataset_doc_text.id,
+                        chunk_id="segment-disabled-summary",
+                        summary_index_node_id="summary-disabled-node",
+                        summary_content="disabled summary",
+                        status=SummaryStatus.COMPLETED,
+                        enabled=False,
+                    ),
+                    DocumentSegmentSummary(
+                        dataset_id=dataset_doc_text.dataset_id,
+                        document_id=dataset_doc_text.id,
+                        chunk_id="segment-missing-pointer",
+                        summary_index_node_id=None,
+                        summary_content="summary missing pointer",
+                        status=SummaryStatus.COMPLETED,
+                        enabled=True,
+                    ),
+                    DocumentSegmentSummary(
+                        dataset_id=dataset_doc_text.dataset_id,
+                        document_id=dataset_doc_text.id,
+                        chunk_id="segment-current-pointer-not-hit",
+                        summary_index_node_id="summary-current-node",
+                        summary_content="current summary",
+                        status=SummaryStatus.COMPLETED,
+                        enabled=True,
+                    ),
                 ],
             ],
         )
         monkeypatch.setattr(
             RetrievalService,
             "get_segment_attachment_infos",
-            lambda attachment_ids, session: [
+            lambda attachment_ids, session, **_: [
                 {
                     "attachment_id": "attach-node-1",
                     "attachment_info": {
@@ -895,11 +1104,17 @@ class TestRetrievalServiceInternals:
             ],
         )
 
-        result = RetrievalService.format_retrieval_documents(fake_session, input_documents)
+        result = RetrievalService.format_retrieval_documents(
+            fake_session,
+            input_documents,
+            allowed_dataset_ids={"dataset-id"},
+        )
 
         assert len(result) == 4
         result_by_segment_id = {item.segment.id: item for item in result}
-        assert result_by_segment_id["segment-summary"].score == pytest.approx(0.95)
+        # The higher-scoring summary-node-2 is stale and must not override the
+        # current durable pointer summary-node-1.
+        assert result_by_segment_id["segment-summary"].score == pytest.approx(0.9)
         assert result_by_segment_id["segment-summary"].summary == "summary for text"
         assert result_by_segment_id["segment-parent"].score == pytest.approx(0.8)
         assert result_by_segment_id["segment-parent"].files is not None
@@ -916,7 +1131,11 @@ class TestRetrievalServiceInternals:
         documents = [Document(page_content="content", metadata={"document_id": "doc-1"}, provider="dify")]
 
         with pytest.raises(RuntimeError, match="db error"):
-            RetrievalService.format_retrieval_documents(session, documents)
+            RetrievalService.format_retrieval_documents(
+                session,
+                documents,
+                allowed_dataset_ids={"dataset-id"},
+            )
 
         session.rollback.assert_called_once()
 

--- a/api/tests/unit_tests/core/rag/datasource/test_retrieval_attachment_access.py
+++ b/api/tests/unit_tests/core/rag/datasource/test_retrieval_attachment_access.py
@@ -20,13 +20,14 @@ from core.app.file_access import (
 )
 from core.rag.datasource.retrieval_service import RetrievalService
 from core.rag.embedding.retrieval import RetrievalSegments
+from core.rag.index_processor.constant.index_type import IndexStructureType
 from core.rag.models.document import Document as RagDocument
 from core.rag.retrieval import dataset_retrieval as dataset_retrieval_module
 from core.rag.retrieval.dataset_retrieval import DatasetRetrieval
 from core.workflow.nodes.knowledge_retrieval.retrieval import KnowledgeRetrievalRequest
 from extensions.storage.storage_type import StorageType
 from models import UploadFile
-from models.dataset import Dataset, DocumentSegment, SegmentAttachmentBinding
+from models.dataset import ChildChunk, Dataset, DocumentSegment, SegmentAttachmentBinding
 from models.dataset import Document as DatasetDocument
 from models.enums import CreatorUserRole, DataSourceType, DocumentCreatedFrom, SegmentStatus
 
@@ -101,6 +102,153 @@ def test_segment_attachment_lookup_grants_returned_upload_files_to_current_scope
     assert "upload_files.id IN" in whereclause
 
 
+@pytest.mark.parametrize("sqlite_session", [(UploadFile, SegmentAttachmentBinding)], indirect=True)
+def test_segment_attachment_lookup_rejects_cross_tenant_and_cross_dataset_rows(sqlite_session: Session) -> None:
+    tenant_id = str(uuid4())
+    dataset_id = str(uuid4())
+    foreign_tenant_id = str(uuid4())
+    foreign_dataset_id = str(uuid4())
+    user_id = str(uuid4())
+
+    local_file = UploadFile(
+        tenant_id=tenant_id,
+        storage_type=StorageType.LOCAL,
+        key="uploads/local.png",
+        name="local.png",
+        size=10,
+        extension="png",
+        mime_type="image/png",
+        created_by_role=CreatorUserRole.END_USER,
+        created_by=user_id,
+        created_at=datetime.now(UTC),
+        used=False,
+    )
+    foreign_file = UploadFile(
+        tenant_id=foreign_tenant_id,
+        storage_type=StorageType.LOCAL,
+        key="uploads/foreign.png",
+        name="foreign.png",
+        size=20,
+        extension="png",
+        mime_type="image/png",
+        created_by_role=CreatorUserRole.END_USER,
+        created_by=user_id,
+        created_at=datetime.now(UTC),
+        used=False,
+    )
+    local_binding = SegmentAttachmentBinding(
+        tenant_id=tenant_id,
+        dataset_id=dataset_id,
+        document_id=str(uuid4()),
+        segment_id=str(uuid4()),
+        attachment_id=local_file.id,
+    )
+    foreign_binding = SegmentAttachmentBinding(
+        tenant_id=foreign_tenant_id,
+        dataset_id=foreign_dataset_id,
+        document_id=str(uuid4()),
+        segment_id=str(uuid4()),
+        attachment_id=foreign_file.id,
+    )
+    sqlite_session.add_all([local_file, foreign_file, local_binding, foreign_binding])
+    sqlite_session.commit()
+
+    assert (
+        RetrievalService.get_segment_attachment_info(
+            dataset_id,
+            tenant_id,
+            foreign_file.id,
+            sqlite_session,
+        )
+        is None
+    )
+
+    results = RetrievalService.get_segment_attachment_infos(
+        [local_file.id, foreign_file.id],
+        sqlite_session,
+        dataset_ids={dataset_id},
+        tenant_ids={tenant_id},
+    )
+
+    assert [result["attachment_id"] for result in results] == [local_file.id]
+
+
+@pytest.mark.parametrize(
+    "sqlite_session",
+    [(Dataset, DatasetDocument, DocumentSegment, ChildChunk, UploadFile, SegmentAttachmentBinding)],
+    indirect=True,
+)
+def test_format_retrieval_documents_enforces_vector_and_authorized_dataset_scope(sqlite_session: Session) -> None:
+    local_dataset_id = str(uuid4())
+    foreign_dataset_id = str(uuid4())
+    foreign_tenant_id = str(uuid4())
+    creator_id = str(uuid4())
+    foreign_dataset = Dataset(
+        tenant_id=foreign_tenant_id,
+        name="Foreign dataset",
+        created_by=creator_id,
+    )
+    foreign_dataset.id = foreign_dataset_id
+    foreign_document = DatasetDocument(
+        tenant_id=foreign_tenant_id,
+        dataset_id=foreign_dataset_id,
+        position=1,
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        batch="foreign-batch",
+        name="Foreign document",
+        created_from=DocumentCreatedFrom.API,
+        created_by=creator_id,
+        doc_metadata={},
+        doc_form=IndexStructureType.PARAGRAPH_INDEX,
+    )
+    foreign_document.id = str(uuid4())
+    foreign_segment = DocumentSegment(
+        tenant_id=foreign_tenant_id,
+        dataset_id=foreign_dataset_id,
+        document_id=foreign_document.id,
+        position=1,
+        content="foreign content",
+        word_count=2,
+        tokens=2,
+        created_by=creator_id,
+        index_node_id=str(uuid4()),
+        index_node_hash="foreign-hash",
+        hit_count=1,
+        status=SegmentStatus.COMPLETED,
+        enabled=True,
+    )
+    sqlite_session.add_all([foreign_dataset, foreign_document, foreign_segment])
+    sqlite_session.commit()
+
+    poisoned_vector_hit = RagDocument(
+        page_content=foreign_segment.content,
+        metadata={
+            "dataset_id": local_dataset_id,
+            "document_id": foreign_document.id,
+            "doc_id": foreign_segment.index_node_id,
+            "score": 0.99,
+        },
+    )
+    consistently_forged_vector_hit = RagDocument(
+        page_content=foreign_segment.content,
+        metadata={
+            "dataset_id": foreign_dataset_id,
+            "document_id": foreign_document.id,
+            "doc_id": foreign_segment.index_node_id,
+            "score": 0.99,
+        },
+    )
+
+    assert (
+        RetrievalService.format_retrieval_documents(
+            sqlite_session,
+            [poisoned_vector_hit, consistently_forged_vector_hit],
+            allowed_dataset_ids={local_dataset_id},
+        )
+        == []
+    )
+
+
 @pytest.mark.parametrize("sqlite_session", [(Dataset, DatasetDocument, DocumentSegment)], indirect=True)
 def test_knowledge_retrieval_grants_returned_segments_to_current_scope(
     monkeypatch: pytest.MonkeyPatch,
@@ -152,7 +300,11 @@ def test_knowledge_retrieval_grants_returned_segments_to_current_scope(
         "multiple_retrieve",
         lambda **kwargs: [RagDocument(page_content="segment content", provider="dify")],
     )
-    monkeypatch.setattr(RetrievalService, "format_retrieval_documents", lambda _session, documents: [record])
+    monkeypatch.setattr(
+        RetrievalService,
+        "format_retrieval_documents",
+        lambda _session, documents, **_: [record],
+    )
     factory = sessionmaker(bind=sqlite_engine, expire_on_commit=False)
     monkeypatch.setattr(dataset_retrieval_module.session_factory, "create_session", factory)
     scope = FileAccessScope(

--- a/api/tests/unit_tests/core/rag/datasource/vdb/test_vector_factory.py
+++ b/api/tests/unit_tests/core/rag/datasource/vdb/test_vector_factory.py
@@ -1,12 +1,28 @@
 import base64
+import json
 import sys
 import types
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
 from core.rag.models.document import Document
+from models.dataset import Dataset
+
+
+def _dataset(*, vector_type: str | None = None) -> Dataset:
+    dataset = Dataset(
+        tenant_id="tenant-1",
+        name="Vector factory test dataset",
+        created_by="creator-id",
+        embedding_model_provider="openai",
+        embedding_model="text-embedding-3-small",
+    )
+    dataset.id = "dataset-1"
+    if vector_type is not None:
+        dataset.index_struct = json.dumps({"type": vector_type})
+    return dataset
 
 
 def _register_fake_factory_module(monkeypatch: pytest.MonkeyPatch, module_path: str, class_name: str):
@@ -146,16 +162,12 @@ def test_get_vector_factory_entry_point_overrides_builtin(vector_factory_module,
 
 
 def test_vector_init_uses_default_and_custom_attributes(vector_factory_module):
-    dataset = SimpleNamespace(id="dataset-1")
-    session = MagicMock()
+    dataset = _dataset()
 
     with patch.object(vector_factory_module.Vector, "_init_vector", return_value="processor") as init_vector:
-        default_vector = vector_factory_module.Vector(dataset, session=session)
-        custom_vector = vector_factory_module.Vector(dataset, attributes=["doc_id"], session=session)
+        default_vector = vector_factory_module.Vector(dataset)
+        custom_vector = vector_factory_module.Vector(dataset, attributes=["doc_id"])
 
-    # `is_summary` and `original_chunk_id` must be in the default return-properties
-    # projection so summary index retrieval works on backends that honor the list
-    # as an explicit projection (e.g. Weaviate). See #34884.
     assert default_vector._attributes == [
         "doc_id",
         "dataset_id",
@@ -166,19 +178,66 @@ def test_vector_init_uses_default_and_custom_attributes(vector_factory_module):
         "original_chunk_id",
     ]
     assert custom_vector._attributes == ["doc_id"]
-    # ``_embeddings`` is now a lazy proxy that defers materializing the real
-    # embedding model until ``embed_*`` is invoked, so cleanup paths never
-    # trigger billing/feature-service calls during ``Vector(dataset, session=...)``
-    # construction. See ``_LazyEmbeddings``.
     assert isinstance(default_vector._embeddings, vector_factory_module._LazyEmbeddings)
-    assert default_vector._session is session
-    assert custom_vector._session is session
+    assert "_session" not in default_vector.__dict__
+    assert "_session" not in custom_vector.__dict__
     assert default_vector._vector_processor == "processor"
-    assert [call.kwargs["session"] for call in init_vector.call_args_list] == [session, session]
+    assert init_vector.call_args_list == [call(), call()]
+
+
+def test_vector_init_reuses_supplied_session_for_backend_resolution(vector_factory_module):
+    dataset = _dataset()
+    session = MagicMock()
+
+    with patch.object(vector_factory_module.Vector, "_init_vector", return_value="processor") as init_vector:
+        vector = vector_factory_module.Vector(dataset, session=session)
+
+    assert vector._vector_processor == "processor"
+    assert "_session" not in vector.__dict__
+    init_vector.assert_called_once_with(session=session)
+
+
+def test_vector_init_does_not_start_idle_caller_session(vector_factory_module):
+    dataset = _dataset()
+    session = MagicMock()
+    session.in_transaction.return_value = False
+
+    with patch.object(vector_factory_module.Vector, "_init_vector", return_value="processor") as init_vector:
+        vector_factory_module.Vector(dataset, session=session)
+
+    init_vector.assert_called_once_with()
+
+
+def test_vector_init_uses_short_internal_session_for_whitelist_routing(vector_factory_module):
+    dataset = _dataset()
+    read_session = MagicMock()
+    read_session.scalars.return_value.one_or_none.return_value = MagicMock()
+    read_context = MagicMock()
+    read_context.__enter__.return_value = read_session
+    read_context.__exit__.return_value = None
+    factory = MagicMock()
+    factory.init_vector.return_value = "processor"
+
+    with (
+        patch.object(vector_factory_module.dify_config, "VECTOR_STORE", vector_factory_module.VectorType.CHROMA),
+        patch.object(vector_factory_module.dify_config, "VECTOR_STORE_WHITELIST_ENABLE", True),
+        patch.object(
+            vector_factory_module.session_factory, "create_session", return_value=read_context
+        ) as create_session,
+        patch.object(vector_factory_module.Vector, "get_vector_factory", return_value=lambda: factory),
+    ):
+        vector = vector_factory_module.Vector(dataset)
+
+    assert vector._vector_processor == "processor"
+    create_session.assert_called_once_with()
+    read_session.scalars.assert_called_once()
+    statement = read_session.scalars.call_args.args[0]
+    assert "whitelists.tenant_id = :tenant_id_1" in str(statement)
+    factory.init_vector.assert_called_once()
 
 
 def test_lazy_embeddings_defer_real_load_until_first_embed_call(vector_factory_module, monkeypatch: pytest.MonkeyPatch):
-    """``Vector(dataset, session=...)`` must not transitively call ``ModelManager`` during
+    """``Vector(dataset)`` must not transitively call ``ModelManager`` during
     construction. The real embedding model should only be materialized on the
     first ``embed_*`` call (i.e. create / search paths) so cleanup paths
     (``delete_by_ids`` / ``delete``) remain resilient to billing-API failures.
@@ -186,11 +245,7 @@ def test_lazy_embeddings_defer_real_load_until_first_embed_call(vector_factory_m
     for_tenant_mock = MagicMock(side_effect=AssertionError("ModelManager.for_tenant must not be called eagerly"))
     monkeypatch.setattr(vector_factory_module.ModelManager, "for_tenant", for_tenant_mock)
 
-    dataset = SimpleNamespace(
-        tenant_id="tenant-1",
-        embedding_model_provider="openai",
-        embedding_model="text-embedding-3-small",
-    )
+    dataset = _dataset()
 
     proxy = vector_factory_module._LazyEmbeddings(dataset)
 
@@ -235,9 +290,7 @@ def test_init_vector_prefers_dataset_index_struct(vector_factory_module, monkeyp
     )
 
     vector = vector_factory_module.Vector.__new__(vector_factory_module.Vector)
-    vector._dataset = SimpleNamespace(
-        index_struct_dict={"type": vector_factory_module.VectorType.UPSTASH}, tenant_id="tenant-1"
-    )
+    vector._dataset = _dataset(vector_type=vector_factory_module.VectorType.UPSTASH)
     vector._attributes = ["doc_id"]
     vector._embeddings = "embeddings"
 
@@ -272,7 +325,7 @@ def test_init_vector_uses_whitelist_override(vector_factory_module, monkeypatch:
     )
 
     vector = vector_factory_module.Vector.__new__(vector_factory_module.Vector)
-    vector._dataset = SimpleNamespace(index_struct_dict=None, tenant_id="tenant-1")
+    vector._dataset = _dataset()
     vector._attributes = ["doc_id"]
     vector._embeddings = "embeddings"
 
@@ -288,7 +341,7 @@ def test_init_vector_raises_when_vector_store_missing(vector_factory_module, mon
     monkeypatch.setattr(vector_factory_module.dify_config, "VECTOR_STORE_WHITELIST_ENABLE", False)
 
     vector = vector_factory_module.Vector.__new__(vector_factory_module.Vector)
-    vector._dataset = SimpleNamespace(index_struct_dict=None, tenant_id="tenant-1")
+    vector._dataset = _dataset()
     vector._attributes = []
     vector._embeddings = "embeddings"
 
@@ -349,31 +402,59 @@ def test_create_skips_empty_text_documents_before_embedding(vector_factory_modul
 
 def test_create_multimodal_filters_missing_uploads(vector_factory_module, monkeypatch: pytest.MonkeyPatch):
     class _Field:
+        def __init__(self, name):
+            self.name = name
+
         def in_(self, value):
-            return value
+            observed["attachment_ids"] = value
+            return f"{self.name}-in"
 
         def __eq__(self, value):
-            return value
+            observed["tenant_id"] = value
+            return f"{self.name}-eq"
 
     vector = vector_factory_module.Vector.__new__(vector_factory_module.Vector)
+    vector._dataset = _dataset()
     vector._embeddings = MagicMock()
     vector._embeddings.embed_multimodal_documents.return_value = [[0.1, 0.2]]
     vector._vector_processor = MagicMock()
     session = MagicMock()
-    vector._session = session
-    session.scalars.return_value = SimpleNamespace(all=lambda: [SimpleNamespace(id="f-1", key="k-1")])
+    session.__enter__.return_value = session
+    session.execute.return_value.all.return_value = [("f-1", "k-1")]
+    monkeypatch.setattr(vector_factory_module.session_factory, "create_session", lambda: session)
 
-    monkeypatch.setattr(vector_factory_module, "UploadFile", SimpleNamespace(id=_Field()))
-    monkeypatch.setattr(vector_factory_module, "select", lambda _model: SimpleNamespace(where=lambda *_args: "stmt"))
+    observed = {}
+    id_field = _Field("id")
+    key_field = _Field("key")
+    tenant_field = _Field("tenant")
+
+    def fake_select(*columns):
+        observed["columns"] = columns
+        return SimpleNamespace(where=lambda *predicates: observed.update(predicates=predicates) or "stmt")
+
+    monkeypatch.setattr(
+        vector_factory_module,
+        "UploadFile",
+        SimpleNamespace(id=id_field, key=key_field, tenant_id=tenant_field),
+    )
+    monkeypatch.setattr(vector_factory_module, "select", fake_select)
     monkeypatch.setattr(vector_factory_module.storage, "load_once", MagicMock(return_value=b"abc"))
 
     docs = [
         Document(page_content="file-1", metadata={"doc_id": "f-1", "doc_type": "image"}),
         Document(page_content="file-2", metadata={"doc_id": "f-2", "doc_type": "image"}),
+        Document(page_content="file-2-duplicate", metadata={"doc_id": "f-2", "doc_type": "image"}),
     ]
 
     vector.create_multimodal(file_documents=docs, request_id="r-1")
 
+    assert observed == {
+        "columns": (id_field, key_field),
+        "attachment_ids": ["f-1", "f-2"],
+        "tenant_id": "tenant-1",
+        "predicates": ("id-in", "tenant-eq"),
+    }
+    session.execute.assert_called_once_with("stmt")
     file_base64 = base64.b64encode(b"abc").decode()
     vector._embeddings.embed_multimodal_documents.assert_called_once_with(
         [{"content": file_base64, "content_type": "image", "file_id": "f-1"}]
@@ -483,18 +564,49 @@ def test_vector_delegation_methods(vector_factory_module):
 
 
 def test_search_by_file_handles_missing_and_existing_upload(vector_factory_module, monkeypatch: pytest.MonkeyPatch):
+    class _Field:
+        def __init__(self, name):
+            self.name = name
+
+        def __eq__(self, value):
+            observed[self.name] = value
+            return f"{self.name}-eq"
+
     vector = vector_factory_module.Vector.__new__(vector_factory_module.Vector)
+    vector._dataset = _dataset()
     vector._embeddings = MagicMock()
     vector._vector_processor = MagicMock()
 
     session = MagicMock()
-    session.get.return_value = None
-    vector._session = session
+    session.__enter__.return_value = session
+    session.scalar.side_effect = [None, "blob-key"]
+    monkeypatch.setattr(vector_factory_module.session_factory, "create_session", lambda: session)
+
+    observed = {}
+    id_field = _Field("file_id")
+    key_field = _Field("key")
+    tenant_field = _Field("tenant_id")
+
+    def fake_select(*columns):
+        observed["columns"] = columns
+        return SimpleNamespace(where=lambda *predicates: observed.update(predicates=predicates) or "stmt")
+
+    monkeypatch.setattr(
+        vector_factory_module,
+        "UploadFile",
+        SimpleNamespace(id=id_field, key=key_field, tenant_id=tenant_field),
+    )
+    monkeypatch.setattr(vector_factory_module, "select", fake_select)
 
     assert vector.search_by_file("file-1") == []
-    session.get.assert_called_once_with(vector_factory_module.UploadFile, "file-1")
+    assert observed == {
+        "columns": (key_field,),
+        "file_id": "file-1",
+        "tenant_id": "tenant-1",
+        "predicates": ("file_id-eq", "tenant_id-eq"),
+    }
+    session.scalar.assert_called_once_with("stmt")
 
-    session.get.return_value = SimpleNamespace(key="blob-key")
     monkeypatch.setattr(vector_factory_module.storage, "load_once", MagicMock(return_value=b"file-bytes"))
     vector._embeddings.embed_multimodal_query.return_value = [0.3, 0.4]
     vector._vector_processor.search_by_vector.return_value = ["hit"]
@@ -502,7 +614,9 @@ def test_search_by_file_handles_missing_and_existing_upload(vector_factory_modul
     result = vector.search_by_file("file-2", top_k=2)
 
     assert result == ["hit"]
-    session.get.assert_called_with(vector_factory_module.UploadFile, "file-2")
+    assert observed["file_id"] == "file-2"
+    assert observed["tenant_id"] == "tenant-1"
+    session.scalar.assert_called_with("stmt")
     payload = vector._embeddings.embed_multimodal_query.call_args.args[0]
     assert payload["content_type"] == vector_factory_module.DocType.IMAGE
     assert payload["file_id"] == "file-2"
@@ -536,11 +650,7 @@ def test_get_embeddings_builds_cache_embedding(vector_factory_module, monkeypatc
     monkeypatch.setattr(vector_factory_module, "CacheEmbedding", MagicMock(return_value="cached-embedding"))
 
     vector = vector_factory_module.Vector.__new__(vector_factory_module.Vector)
-    vector._dataset = SimpleNamespace(
-        tenant_id="tenant-1",
-        embedding_model_provider="openai",
-        embedding_model="text-embedding-3-small",
-    )
+    vector._dataset = _dataset()
 
     result = vector._get_embeddings()
 

--- a/api/tests/unit_tests/core/rag/indexing/processor/test_paragraph_index_processor.py
+++ b/api/tests/unit_tests/core/rag/indexing/processor/test_paragraph_index_processor.py
@@ -1,18 +1,49 @@
 import logging
 from contextlib import nullcontext
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+from core.app.entities.app_invoke_entities import InvokeFrom, UserFrom
+from core.app.file_access import FileAccessScope, bind_file_access_scope
 from core.entities.knowledge_entities import PreviewDetail
 from core.rag.index_processor.constant.index_type import IndexTechniqueType
 from core.rag.index_processor.processor.paragraph_index_processor import ParagraphIndexProcessor
 from core.rag.models.document import AttachmentDocument, Document
+from extensions.storage.storage_type import StorageType
 from graphon.model_runtime.entities.llm_entities import LLMResult, LLMUsage
 from graphon.model_runtime.entities.message_entities import AssistantPromptMessage, ImagePromptMessageContent
 from graphon.model_runtime.entities.model_entities import ModelFeature
+from models.enums import CreatorUserRole
+from models.model import UploadFile
+
+
+def _upload_file(
+    file_id: str,
+    *,
+    name: str = "image.png",
+    extension: str = "png",
+    mime_type: str = "image/png",
+    key: str = "key",
+) -> UploadFile:
+    upload_file = UploadFile(
+        tenant_id="tenant-1",
+        storage_type=StorageType.LOCAL,
+        key=key,
+        name=name,
+        size=1,
+        extension=extension,
+        mime_type=mime_type,
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by="00000000-0000-0000-0000-000000000001",
+        created_at=datetime.now(UTC).replace(tzinfo=None),
+        used=False,
+    )
+    upload_file.id = file_id
+    return upload_file
 
 
 class TestParagraphIndexProcessor:
@@ -180,7 +211,7 @@ class TestParagraphIndexProcessor:
             patch("core.rag.index_processor.processor.paragraph_index_processor.Keyword") as mock_keyword_cls,
         ):
             processor.load(dataset, docs, multimodal_documents=multimodal_docs, session=session)
-        mock_vector_cls.assert_called_once_with(dataset, session=session)
+        mock_vector_cls.assert_called_once_with(dataset)
         vector = mock_vector_cls.return_value
         vector.create.assert_called_once_with(docs)
         vector.create_multimodal.assert_called_once_with(multimodal_docs)
@@ -224,9 +255,9 @@ class TestParagraphIndexProcessor:
             patch("core.rag.index_processor.processor.paragraph_index_processor.Vector") as mock_vector_cls,
         ):
             vector = mock_vector_cls.return_value
-            processor.clean(dataset, ["node-1"], delete_summaries=True, session=session)
+            processor.clean(dataset, ["node-1"], delete_summaries=True, segment_ids=["seg-1"], session=session)
 
-        mock_summary.assert_called_once_with(dataset, ["seg-1"], session=session)
+        mock_summary.assert_called_once_with(dataset=dataset, segment_ids=["seg-1"], session=session)
         vector.delete_by_ids.assert_called_once_with(["node-1"])
 
     def test_clean_economy_deletes_summaries_and_keywords(
@@ -243,7 +274,7 @@ class TestParagraphIndexProcessor:
         ):
             processor.clean(dataset, None, delete_summaries=True, session=session)
 
-        mock_summary.assert_called_once_with(dataset, None, session=session)
+        mock_summary.assert_called_once_with(dataset=dataset, segment_ids=None, session=session)
         mock_keyword_cls.return_value.delete.assert_called_once()
 
     def test_clean_deletes_keywords_by_ids(self, processor: ParagraphIndexProcessor, dataset: Mock) -> None:
@@ -253,6 +284,37 @@ class TestParagraphIndexProcessor:
             processor.clean(dataset, ["node-2"], with_keywords=True, session=session)
 
         mock_keyword_cls.return_value.delete_by_ids.assert_called_once_with(["node-2"], session)
+
+    def test_clean_empty_partial_selection_does_not_delete_vector_index(
+        self, processor: ParagraphIndexProcessor, dataset: Mock
+    ) -> None:
+        session = Mock()
+        with (
+            patch(
+                "core.rag.index_processor.processor.paragraph_index_processor.SummaryIndexService.delete_summaries_for_segments"
+            ) as mock_summary,
+            patch("core.rag.index_processor.processor.paragraph_index_processor.Vector") as mock_vector_cls,
+        ):
+            processor.clean(dataset, [], delete_summaries=True, segment_ids=[], session=session)
+
+        mock_summary.assert_called_once_with(dataset=dataset, segment_ids=[], session=session)
+        mock_vector_cls.assert_not_called()
+
+    def test_clean_rejects_partial_summary_cleanup_without_durable_segment_ids(
+        self, processor: ParagraphIndexProcessor, dataset: Mock
+    ) -> None:
+        with pytest.raises(ValueError, match="segment_ids are required"):
+            processor.clean(dataset, ["node-1"], delete_summaries=True, session=Mock())
+
+    def test_clean_empty_partial_selection_does_not_delete_keyword_index(
+        self, processor: ParagraphIndexProcessor, dataset: Mock
+    ) -> None:
+        dataset.indexing_technique = IndexTechniqueType.ECONOMY
+        session = Mock()
+        with patch("core.rag.index_processor.processor.paragraph_index_processor.Keyword") as mock_keyword_cls:
+            processor.clean(dataset, [], with_keywords=True, session=session)
+
+        mock_keyword_cls.assert_not_called()
 
     def test_index_list_chunks_high_quality(
         self, processor: ParagraphIndexProcessor, dataset: Mock, dataset_document: Mock
@@ -281,7 +343,7 @@ class TestParagraphIndexProcessor:
             mock_vector_cls.return_value.create.side_effect = lambda _documents: phase_events.append("vector")
             processor.index(dataset, dataset_document, ["chunk-1", "chunk-2"], session)
 
-        assert phase_events == ["count", "store", "commit", "vector"]
+        assert phase_events == ["commit", "count", "store", "commit", "vector"]
         documents = mock_token_counter.call_args.kwargs["documents"]
         assert [document.page_content for document in documents] == ["chunk-1", "chunk-2"]
         mock_token_counter.assert_called_once_with(dataset=dataset, documents=documents)
@@ -291,7 +353,7 @@ class TestParagraphIndexProcessor:
             token_counts=[11, 22],
             save_child=False,
         )
-        mock_vector_cls.assert_called_once_with(dataset, session=session)
+        mock_vector_cls.assert_called_once_with(dataset)
         mock_vector_cls.return_value.create.assert_called_once()
         mock_vector_cls.return_value.create_multimodal.assert_called_once()
 
@@ -404,27 +466,15 @@ class TestParagraphIndexProcessor:
     def test_generate_summary_preview_success_and_failure(self, processor: ParagraphIndexProcessor) -> None:
         preview_items = [PreviewDetail(content="chunk-1"), PreviewDetail(content="chunk-2")]
         session = Mock()
-        worker_sessions = [Mock(), Mock()]
 
-        with (
-            patch(
-                "core.rag.index_processor.processor.paragraph_index_processor.session_factory.create_session",
-                side_effect=[nullcontext(worker_session) for worker_session in worker_sessions],
-            ) as create_session,
-            patch.object(
-                processor, "generate_summary", return_value=("summary", LLMUsage.empty_usage())
-            ) as mock_generate_summary,
-        ):
+        with patch.object(
+            processor, "generate_summary", return_value=("summary", LLMUsage.empty_usage())
+        ) as mock_generate_summary:
             result = processor.generate_summary_preview(
                 "tenant-1", preview_items, {"enable": True}, doc_language="English", session=session
             )
         assert all(item.summary == "summary" for item in result)
-        call_sessions = [call.kwargs["session"] for call in mock_generate_summary.call_args_list]
-        assert create_session.call_count == len(preview_items)
-        assert all(call_session is not session for call_session in call_sessions)
-        assert {id(call_session) for call_session in call_sessions} == {
-            id(worker_session) for worker_session in worker_sessions
-        }
+        assert all("session" not in call.kwargs for call in mock_generate_summary.call_args_list)
 
         with patch.object(processor, "generate_summary", side_effect=RuntimeError("summary failed")):
             with pytest.raises(ValueError, match="Failed to generate summaries"):
@@ -462,10 +512,10 @@ class TestParagraphIndexProcessor:
 
     def test_generate_summary_validates_input(self) -> None:
         with pytest.raises(ValueError, match="must be enabled"):
-            ParagraphIndexProcessor.generate_summary("tenant-1", "text", {"enable": False}, session=Mock())
+            ParagraphIndexProcessor.generate_summary("tenant-1", "text", {"enable": False})
 
         with pytest.raises(ValueError, match="model_name and model_provider_name"):
-            ParagraphIndexProcessor.generate_summary("tenant-1", "text", {"enable": True}, session=Mock())
+            ParagraphIndexProcessor.generate_summary("tenant-1", "text", {"enable": True})
 
     def test_generate_summary_text_only_flow(self, caplog: pytest.LogCaptureFixture) -> None:
         model_instance = Mock()
@@ -495,7 +545,6 @@ class TestParagraphIndexProcessor:
                     "text content",
                     {"enable": True, "model_name": "model-a", "model_provider_name": "provider-a"},
                     document_language="English",
-                    session=Mock(),
                 )
 
         assert summary == "text summary"
@@ -504,14 +553,34 @@ class TestParagraphIndexProcessor:
         assert any("Failed to deduct quota for summary generation" in record.message for record in caplog.records)
 
     def test_generate_summary_handles_vision_and_image_conversion(self) -> None:
+        events: list[str] = []
         model_instance = Mock()
         model_instance.credentials = {"k": "v"}
         model_instance.model_type_instance.get_model_schema.return_value = SimpleNamespace(
             features=[ModelFeature.VISION]
         )
-        model_instance.invoke_llm.return_value = self._llm_result("vision summary")
         image_file = SimpleNamespace()
         image_content = ImagePromptMessageContent(format="url", mime_type="image/png", url="http://example.com/a.png")
+        image_session = Mock()
+        image_session_context = MagicMock()
+        image_session_context.__enter__.side_effect = lambda: events.append("open") or image_session
+        image_session_context.__exit__.side_effect = lambda *_args: events.append("close")
+
+        def extract_images(*_args):
+            events.append("lookup")
+            return [image_file]
+
+        def convert_image(*_args, **_kwargs):
+            assert events[-1] == "close"
+            events.append("storage")
+            return image_content
+
+        def invoke_llm(**_kwargs):
+            assert "close" in events
+            events.append("llm")
+            return self._llm_result("vision summary")
+
+        model_instance.invoke_llm.side_effect = invoke_llm
 
         with (
             patch(
@@ -522,14 +591,20 @@ class TestParagraphIndexProcessor:
                 return_value=model_instance,
             ),
             patch.object(
-                ParagraphIndexProcessor, "_extract_images_from_segment_attachments", return_value=[image_file]
+                ParagraphIndexProcessor,
+                "_extract_images_from_segment_attachments",
+                side_effect=extract_images,
             ),
             patch.object(ParagraphIndexProcessor, "_extract_images_from_text", return_value=[]) as mock_extract_text,
             patch(
                 "core.rag.index_processor.processor.paragraph_index_processor.file_manager.to_prompt_message_content",
-                return_value=image_content,
+                side_effect=convert_image,
             ),
             patch("core.rag.index_processor.processor.paragraph_index_processor.deduct_llm_quota"),
+            patch(
+                "core.rag.index_processor.processor.paragraph_index_processor.session_factory.create_session",
+                return_value=image_session_context,
+            ),
         ):
             mock_provider_manager.return_value.get_provider_model_bundle.return_value = Mock()
             summary, _ = ParagraphIndexProcessor.generate_summary(
@@ -537,10 +612,10 @@ class TestParagraphIndexProcessor:
                 "text content",
                 {"enable": True, "model_name": "model-a", "model_provider_name": "provider-a"},
                 segment_id="seg-1",
-                session=Mock(),
             )
 
         assert summary == "vision summary"
+        assert events == ["open", "lookup", "close", "storage", "llm"]
         mock_extract_text.assert_not_called()
 
     def test_generate_summary_fallbacks_for_prompt_and_result_types(self, caplog: pytest.LogCaptureFixture) -> None:
@@ -570,6 +645,7 @@ class TestParagraphIndexProcessor:
                 "core.rag.index_processor.processor.paragraph_index_processor.file_manager.to_prompt_message_content",
                 side_effect=RuntimeError("bad image"),
             ),
+            patch("core.rag.index_processor.processor.paragraph_index_processor.session_factory.create_session"),
         ):
             mock_provider_manager.return_value.get_provider_model_bundle.return_value = Mock()
             with pytest.raises(ValueError, match="Expected LLMResult"):
@@ -580,7 +656,6 @@ class TestParagraphIndexProcessor:
                         "tenant-1",
                         "text content",
                         {"enable": True, "model_name": "model-a", "model_provider_name": "provider-a"},
-                        session=Mock(),
                     )
 
         assert sum(1 for r in caplog.records if r.levelno == logging.WARNING) == 1
@@ -594,42 +669,23 @@ class TestParagraphIndexProcessor:
             "![img2](/files/22222222-2222-2222-2222-222222222222/file-preview) "
             "![tool](/files/tools/33333333-3333-3333-3333-333333333333.png)"
         )
-        image_upload = SimpleNamespace(
-            id="11111111-1111-1111-1111-111111111111",
-            tenant_id="tenant-1",
-            name="image.png",
-            mime_type="image/png",
-            extension="png",
-            source_url="",
-            size=1,
-            key="key",
-        )
-        non_image_upload = SimpleNamespace(
-            id="22222222-2222-2222-2222-222222222222",
-            tenant_id="tenant-1",
+        image_upload = _upload_file("11111111-1111-1111-1111-111111111111")
+        non_image_upload = _upload_file(
+            "22222222-2222-2222-2222-222222222222",
             name="file.txt",
-            mime_type="text/plain",
             extension="txt",
-            source_url="",
-            size=1,
-            key="key",
+            mime_type="text/plain",
         )
         scalars_result = Mock()
         scalars_result.all.return_value = [image_upload, non_image_upload]
         session = Mock()
         session.scalars.return_value = scalars_result
 
-        with (
-            patch(
-                "core.rag.index_processor.processor.paragraph_index_processor.build_from_mapping",
-                return_value=SimpleNamespace(id="file-1"),
-            ) as mock_builder,
-            caplog.at_level(logging.WARNING, logger="core.rag.index_processor.processor.paragraph_index_processor"),
-        ):
+        with caplog.at_level(logging.WARNING, logger="core.rag.index_processor.processor.paragraph_index_processor"):
             files = ParagraphIndexProcessor._extract_images_from_text("tenant-1", text, session)
 
         assert len(files) == 1
-        assert mock_builder.call_count == 1
+        assert files[0].id == image_upload.id
         assert not any(record.levelno == logging.WARNING for record in caplog.records)
 
     def test_extract_images_from_text_returns_empty_when_no_matches(self) -> None:
@@ -639,18 +695,27 @@ class TestParagraphIndexProcessor:
         session.scalars.return_value = scalars_result
         assert ParagraphIndexProcessor._extract_images_from_text("tenant-1", "no images here", session) == []
 
+    def test_extract_images_from_text_preserves_end_user_file_scope(self) -> None:
+        text = "![img](/files/11111111-1111-1111-1111-111111111111/image-preview)"
+        session = Mock()
+        session.scalars.return_value.all.return_value = []
+        scope = FileAccessScope(
+            tenant_id="tenant-1",
+            user_id="end-user-1",
+            user_from=UserFrom.END_USER,
+            invoke_from=InvokeFrom.WEB_APP,
+        )
+
+        with bind_file_access_scope(scope):
+            ParagraphIndexProcessor._extract_images_from_text("tenant-1", text, session)
+
+        statement_sql = str(session.scalars.call_args.args[0].whereclause)
+        assert "upload_files.created_by_role" in statement_sql
+        assert "upload_files.created_by" in statement_sql
+
     def test_extract_images_from_text_logs_when_build_fails(self, caplog: pytest.LogCaptureFixture) -> None:
         text = "![img](/files/11111111-1111-1111-1111-111111111111/image-preview)"
-        image_upload = SimpleNamespace(
-            id="11111111-1111-1111-1111-111111111111",
-            tenant_id="tenant-1",
-            name="image.png",
-            mime_type="image/png",
-            extension="png",
-            source_url="",
-            size=1,
-            key="key",
-        )
+        image_upload = _upload_file("11111111-1111-1111-1111-111111111111")
         scalars_result = Mock()
         scalars_result.all.return_value = [image_upload]
         session = Mock()
@@ -658,7 +723,7 @@ class TestParagraphIndexProcessor:
 
         with (
             patch(
-                "core.rag.index_processor.processor.paragraph_index_processor.build_from_mapping",
+                "core.rag.index_processor.processor.paragraph_index_processor.File",
                 side_effect=RuntimeError("build failed"),
             ),
             caplog.at_level(logging.WARNING, logger="core.rag.index_processor.processor.paragraph_index_processor"),
@@ -669,50 +734,52 @@ class TestParagraphIndexProcessor:
         assert sum(1 for r in caplog.records if r.levelno == logging.WARNING) == 1
 
     def test_extract_images_from_segment_attachments(self, caplog: pytest.LogCaptureFixture) -> None:
-        image_upload = SimpleNamespace(
-            id="file-1",
-            name="image",
-            extension="png",
-            mime_type="image/png",
-            source_url="",
-            size=1,
-            key="k1",
-        )
-        bad_upload = SimpleNamespace(
-            id="file-2",
-            name="broken",
-            extension=None,
-            mime_type="image/png",
-            source_url="",
-            size=1,
-            key="k2",
-        )
-        non_image_upload = SimpleNamespace(
-            id="file-3",
+        image_upload = _upload_file("file-1", name="image", key="k1")
+        bad_upload = _upload_file("file-2", name="broken", key="k2")
+        bad_upload.extension = None  # type: ignore[assignment]
+        non_image_upload = _upload_file(
+            "file-3",
             name="text",
             extension="txt",
             mime_type="text/plain",
-            source_url="",
-            size=1,
             key="k3",
         )
-        execute_result = Mock()
-        execute_result.all.return_value = [(None, image_upload), (None, bad_upload), (None, non_image_upload)]
+        scalars_result = Mock()
+        scalars_result.all.return_value = [image_upload, bad_upload, non_image_upload]
         session = Mock()
-        session.execute.return_value = execute_result
+        session.scalars.return_value = scalars_result
 
         with caplog.at_level(logging.WARNING, logger="core.rag.index_processor.processor.paragraph_index_processor"):
             files = ParagraphIndexProcessor._extract_images_from_segment_attachments("tenant-1", "seg-1", session)
 
         assert len(files) == 1
         assert sum(1 for r in caplog.records if r.levelno == logging.WARNING) == 1
+        statement = session.scalars.call_args.args[0]
+        assert "upload_files.tenant_id" in str(statement)
 
     def test_extract_images_from_segment_attachments_empty(self) -> None:
-        execute_result = Mock()
-        execute_result.all.return_value = []
+        scalars_result = Mock()
+        scalars_result.all.return_value = []
         session = Mock()
-        session.execute.return_value = execute_result
+        session.scalars.return_value = scalars_result
 
         empty_files = ParagraphIndexProcessor._extract_images_from_segment_attachments("tenant-1", "seg-1", session)
 
         assert empty_files == []
+
+    def test_extract_images_from_segment_attachments_preserves_end_user_file_scope(self) -> None:
+        session = Mock()
+        session.scalars.return_value.all.return_value = []
+        scope = FileAccessScope(
+            tenant_id="tenant-1",
+            user_id="end-user-1",
+            user_from=UserFrom.END_USER,
+            invoke_from=InvokeFrom.WEB_APP,
+        )
+
+        with bind_file_access_scope(scope):
+            ParagraphIndexProcessor._extract_images_from_segment_attachments("tenant-1", "seg-1", session)
+
+        statement_sql = str(session.scalars.call_args.args[0].whereclause)
+        assert "upload_files.created_by_role" in statement_sql
+        assert "upload_files.created_by" in statement_sql

--- a/api/tests/unit_tests/core/rag/indexing/processor/test_parent_child_index_processor.py
+++ b/api/tests/unit_tests/core/rag/indexing/processor/test_parent_child_index_processor.py
@@ -211,7 +211,7 @@ class TestParentChildIndexProcessor:
             vector = mock_vector_cls.return_value
             processor.load(dataset, [parent_doc], multimodal_documents=multimodal_docs, session=session)
 
-        mock_vector_cls.assert_called_once_with(dataset, session=session)
+        mock_vector_cls.assert_called_once_with(dataset)
         assert vector.create.call_count == 1
         formatted_docs = vector.create.call_args[0][0]
         assert len(formatted_docs) == 2
@@ -266,6 +266,63 @@ class TestParentChildIndexProcessor:
         session.execute.assert_called()
         session.flush.assert_called_once()
 
+    def test_clean_empty_partial_selection_does_not_delete_dataset(
+        self, processor: ParentChildIndexProcessor, dataset: Mock
+    ) -> None:
+        session = Mock()
+
+        with patch("core.rag.index_processor.processor.parent_child_index_processor.Vector") as mock_vector_cls:
+            processor.clean(
+                dataset,
+                [],
+                delete_child_chunks=True,
+                precomputed_child_node_ids=[],
+                session=session,
+            )
+
+        mock_vector_cls.assert_not_called()
+        session.execute.assert_not_called()
+        session.commit.assert_not_called()
+
+    def test_clean_rejects_partial_summary_cleanup_without_durable_segment_ids(
+        self, processor: ParentChildIndexProcessor, dataset: Mock
+    ) -> None:
+        with pytest.raises(ValueError, match="segment_ids are required"):
+            processor.clean(dataset, ["node-1"], delete_summaries=True, session=Mock())
+
+    def test_clean_no_node_or_segment_ids_is_a_partial_noop(
+        self, processor: ParentChildIndexProcessor, dataset: Mock
+    ) -> None:
+        session = Mock()
+        with patch("core.rag.index_processor.processor.parent_child_index_processor.Vector") as vector_cls:
+            processor.clean(dataset, [], delete_child_chunks=False, session=session)
+
+        vector_cls.assert_not_called()
+        session.execute.assert_not_called()
+
+    def test_clean_uses_segment_ids_when_parent_has_no_vector_id(
+        self, processor: ParentChildIndexProcessor, dataset: Mock
+    ) -> None:
+        session = MagicMock()
+        session.scalars.return_value.all.return_value = ["child-1", None, "child-2"]
+
+        with patch("core.rag.index_processor.processor.parent_child_index_processor.Vector") as mock_vector_cls:
+            processor.clean(
+                dataset,
+                [],
+                delete_child_chunks=True,
+                segment_ids=["segment-1"],
+                session=session,
+            )
+
+        mock_vector_cls.assert_called_once_with(dataset)
+        mock_vector_cls.return_value.delete_by_ids.assert_called_once_with(["child-1", "child-2"])
+        child_lookup = session.scalars.call_args.args[0]
+        child_delete = session.execute.call_args.args[0]
+        assert any("segment-1" in value for value in child_lookup.compile().params.values() if isinstance(value, list))
+        assert any("segment-1" in value for value in child_delete.compile().params.values() if isinstance(value, list))
+        session.flush.assert_called_once()
+
     def test_clean_deletes_summaries_when_requested(self, processor: ParentChildIndexProcessor, dataset: Mock) -> None:
         scalars_result = Mock()
         scalars_result.all.return_value = [SimpleNamespace(id="seg-1")]
@@ -281,9 +338,16 @@ class TestParentChildIndexProcessor:
             ) as mock_summary,
             patch("core.rag.index_processor.processor.parent_child_index_processor.Vector"),
         ):
-            processor.clean(dataset, ["node-1"], delete_summaries=True, precomputed_child_node_ids=[], session=session)
+            processor.clean(
+                dataset,
+                ["node-1"],
+                delete_summaries=True,
+                precomputed_child_node_ids=[],
+                segment_ids=["seg-1"],
+                session=session,
+            )
 
-        mock_summary.assert_called_once_with(dataset, ["seg-1"], session=session)
+        mock_summary.assert_called_once_with(dataset=dataset, segment_ids=["seg-1"], session=session)
 
     def test_clean_deletes_all_summaries_when_node_ids_missing(
         self, processor: ParentChildIndexProcessor, dataset: Mock
@@ -297,7 +361,7 @@ class TestParentChildIndexProcessor:
             session = MagicMock()
             processor.clean(dataset, None, delete_summaries=True, session=session)
 
-        mock_summary.assert_called_once_with(dataset, None, session=session)
+        mock_summary.assert_called_once_with(dataset=dataset, segment_ids=None, session=session)
 
     def test_split_child_nodes_requires_subchunk_segmentation(self, processor: ParentChildIndexProcessor) -> None:
         rules = Rule(subchunk_segmentation=None)
@@ -372,7 +436,7 @@ class TestParentChildIndexProcessor:
             mock_vector_cls.return_value.create.side_effect = lambda _documents: phase_events.append("vector")
             processor.index(dataset, dataset_document, {"parent_child_chunks": []}, session)
 
-        assert phase_events == ["count", "store", "commit", "vector"]
+        assert phase_events == ["commit", "count", "store", "commit", "vector"]
         assert dataset_document.dataset_process_rule_id == "rule-1"
         session.add.assert_called_once_with(dataset_rule)
         session.flush.assert_called_once()
@@ -385,7 +449,7 @@ class TestParentChildIndexProcessor:
             token_counts=[11],
             save_child=True,
         )
-        mock_vector_cls.assert_called_once_with(dataset, session=session)
+        mock_vector_cls.assert_called_once_with(dataset)
         assert mock_vector_cls.return_value.create.call_count == 1
         mock_vector_cls.return_value.create_multimodal.assert_called_once()
 
@@ -481,29 +545,17 @@ class TestParentChildIndexProcessor:
     def test_generate_summary_preview_sets_summaries(self, processor: ParentChildIndexProcessor) -> None:
         preview_texts = [PreviewDetail(content="chunk-1"), PreviewDetail(content="chunk-2")]
         session = MagicMock()
-        worker_sessions = [MagicMock(), MagicMock()]
 
-        with (
-            patch(
-                "core.rag.index_processor.processor.parent_child_index_processor.session_factory.create_session",
-                side_effect=[nullcontext(worker_session) for worker_session in worker_sessions],
-            ) as create_session,
-            patch(
-                "core.rag.index_processor.processor.paragraph_index_processor.ParagraphIndexProcessor.generate_summary",
-                return_value=("summary", None),
-            ) as mock_generate_summary,
-        ):
+        with patch(
+            "core.rag.index_processor.processor.paragraph_index_processor.ParagraphIndexProcessor.generate_summary",
+            return_value=("summary", None),
+        ) as mock_generate_summary:
             result = processor.generate_summary_preview(
                 "tenant-1", preview_texts, {"enable": True}, doc_language="English", session=session
             )
 
         assert all(item.summary == "summary" for item in result)
-        call_sessions = [call.kwargs["session"] for call in mock_generate_summary.call_args_list]
-        assert create_session.call_count == len(preview_texts)
-        assert all(call_session is not session for call_session in call_sessions)
-        assert {id(call_session) for call_session in call_sessions} == {
-            id(worker_session) for worker_session in worker_sessions
-        }
+        assert all("session" not in call.kwargs for call in mock_generate_summary.call_args_list)
 
     def test_generate_summary_preview_raises_when_worker_fails(self, processor: ParentChildIndexProcessor) -> None:
         preview_texts = [PreviewDetail(content="chunk-1")]

--- a/api/tests/unit_tests/core/rag/indexing/processor/test_qa_index_processor.py
+++ b/api/tests/unit_tests/core/rag/indexing/processor/test_qa_index_processor.py
@@ -221,7 +221,7 @@ class TestQAIndexProcessor:
             vector = mock_vector_cls.return_value
             processor.load(dataset, docs, multimodal_documents=multimodal_docs, session=session)
 
-        mock_vector_cls.assert_called_once_with(dataset, session=session)
+        mock_vector_cls.assert_called_once_with(dataset)
         vector.create.assert_called_once_with(docs)
         vector.create_multimodal.assert_called_once_with(multimodal_docs)
 
@@ -251,9 +251,9 @@ class TestQAIndexProcessor:
             patch("core.rag.index_processor.processor.qa_index_processor.Vector") as mock_vector_cls,
         ):
             vector = mock_vector_cls.return_value
-            processor.clean(dataset, ["node-1"], delete_summaries=True, session=mock_session)
+            processor.clean(dataset, ["node-1"], delete_summaries=True, segment_ids=["seg-1"], session=mock_session)
 
-        mock_summary.assert_called_once_with(dataset, ["seg-1"], session=mock_session)
+        mock_summary.assert_called_once_with(dataset=dataset, segment_ids=["seg-1"], session=mock_session)
         vector.delete_by_ids.assert_called_once_with(["node-1"])
 
     def test_clean_handles_dataset_wide_cleanup(self, processor: QAIndexProcessor, dataset: Mock) -> None:
@@ -267,8 +267,29 @@ class TestQAIndexProcessor:
             vector = mock_vector_cls.return_value
             processor.clean(dataset, None, delete_summaries=True, session=session)
 
-        mock_summary.assert_called_once_with(dataset, None, session=session)
+        mock_summary.assert_called_once_with(dataset=dataset, segment_ids=None, session=session)
         vector.delete.assert_called_once()
+
+    def test_clean_empty_partial_selection_does_not_delete_vector_index(
+        self, processor: QAIndexProcessor, dataset: Mock
+    ) -> None:
+        session = Mock()
+        with (
+            patch(
+                "core.rag.index_processor.processor.qa_index_processor.SummaryIndexService.delete_summaries_for_segments"
+            ) as mock_summary,
+            patch("core.rag.index_processor.processor.qa_index_processor.Vector") as mock_vector_cls,
+        ):
+            processor.clean(dataset, [], delete_summaries=True, segment_ids=[], session=session)
+
+        mock_summary.assert_called_once_with(dataset=dataset, segment_ids=[], session=session)
+        mock_vector_cls.assert_not_called()
+
+    def test_clean_rejects_partial_summary_cleanup_without_durable_segment_ids(
+        self, processor: QAIndexProcessor, dataset: Mock
+    ) -> None:
+        with pytest.raises(ValueError, match="segment_ids are required"):
+            processor.clean(dataset, ["node-1"], delete_summaries=True, session=Mock())
 
     def test_index_adds_documents_and_vectors_for_high_quality(
         self, processor: QAIndexProcessor, dataset: Mock, dataset_document: Mock
@@ -302,7 +323,7 @@ class TestQAIndexProcessor:
             mock_vector_cls.return_value.create.side_effect = lambda _documents: phase_events.append("vector")
             processor.index(dataset, dataset_document, {"qa_chunks": []}, session)
 
-        assert phase_events == ["count", "store", "commit", "vector"]
+        assert phase_events == ["commit", "count", "store", "commit", "vector"]
         documents = mock_token_counter.call_args.kwargs["documents"]
         assert [document.page_content for document in documents] == ["Q1", "Q2"]
         mock_token_counter.assert_called_once_with(dataset=dataset, documents=documents)

--- a/api/tests/unit_tests/core/rag/indexing/test_index_processor.py
+++ b/api/tests/unit_tests/core/rag/indexing/test_index_processor.py
@@ -6,7 +6,65 @@ from unittest.mock import MagicMock, patch
 from core.rag.index_processor.constant.index_type import IndexTechniqueType
 from core.rag.index_processor.index_processor import IndexProcessor
 from core.workflow.nodes.knowledge_index.protocols import Preview, PreviewItem
-from models.dataset import Dataset, Document
+from models.dataset import Dataset, Document, DocumentSegment
+from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
+
+
+def _dataset() -> Dataset:
+    dataset = Dataset(
+        id="dataset-1",
+        tenant_id="tenant-1",
+        name="Dataset",
+        description="",
+        provider="vendor",
+        permission="only_me",
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        indexing_technique=IndexTechniqueType.HIGH_QUALITY,
+        created_by="00000000-0000-0000-0000-000000000001",
+        chunk_structure="text_model",
+    )
+    dataset.summary_index_setting = None
+    return dataset
+
+
+def _document(document_id: str = "doc-1") -> Document:
+    document = Document(
+        id=document_id,
+        tenant_id="tenant-1",
+        dataset_id="dataset-1",
+        position=1,
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        batch="batch-1",
+        name="Document",
+        created_from=DocumentCreatedFrom.WEB,
+        created_by="00000000-0000-0000-0000-000000000001",
+        indexing_status=IndexingStatus.COMPLETED,
+        enabled=True,
+        archived=False,
+        doc_form="text_model",
+        word_count=0,
+        tokens=0,
+        need_summary=False,
+    )
+    document.created_at = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC)
+    return document
+
+
+def _segment(index_node_id: str | None) -> DocumentSegment:
+    segment = DocumentSegment(
+        tenant_id="tenant-1",
+        dataset_id="dataset-1",
+        document_id="original-doc",
+        position=1,
+        content="old content",
+        word_count=2,
+        tokens=2,
+        created_by="00000000-0000-0000-0000-000000000001",
+        index_node_id=index_node_id,
+        status=SegmentStatus.COMPLETED,
+    )
+    segment.id = "segment-1"
+    return segment
 
 
 class TestIndexProcessor:
@@ -23,23 +81,8 @@ class TestIndexProcessor:
         assert preview.qa_preview[0].answer == "A1"
 
     def test_index_and_clean_ends_transactions_around_index_io(self) -> None:
-        document = SimpleNamespace(
-            id="document-1",
-            name="Document",
-            created_at=datetime.datetime(2026, 1, 1),
-            indexing_latency=None,
-            indexing_status=None,
-            completed_at=None,
-            word_count=0,
-            need_summary=False,
-        )
-        dataset = SimpleNamespace(
-            id="dataset-1",
-            tenant_id="tenant-1",
-            name="Dataset",
-            chunk_structure="text_model",
-            summary_index_setting=None,
-        )
+        document = _document("document-1")
+        dataset = _dataset()
         session = MagicMock()
         session.scalar.side_effect = [dataset, document, 3]
         phase_events: list[str] = []
@@ -62,21 +105,9 @@ class TestIndexProcessor:
         assert phase_events == ["commit", "index", "commit"]
 
     def test_index_and_clean_scopes_replacement_queries_to_dataset_owner(self) -> None:
-        dataset = SimpleNamespace(
-            id="dataset-1",
-            tenant_id="tenant-1",
-            name="Dataset",
-            summary_index_setting=None,
-            chunk_structure="text_model",
-        )
-        document = SimpleNamespace(
-            id="doc-1",
-            tenant_id="tenant-1",
-            dataset_id="dataset-1",
-            name="Document",
-            created_at=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC),
-        )
-        segment = SimpleNamespace(index_node_id="node-1")
+        dataset = _dataset()
+        document = _document()
+        segment = _segment("node-1")
         session = MagicMock()
 
         def resolve_owner(statement):
@@ -123,9 +154,50 @@ class TestIndexProcessor:
             ["node-1"],
             with_keywords=True,
             delete_child_chunks=True,
+            delete_summaries=True,
+            segment_ids=["segment-1"],
             session=session,
         )
         index_backend.index.assert_called_once_with(dataset, document, {}, session)
+
+    def test_index_and_clean_removes_summaries_when_replaced_segments_have_no_vector_ids(self) -> None:
+        dataset = _dataset()
+        document = _document()
+        segment = _segment(None)
+        session = MagicMock()
+
+        def resolve_owner(statement):
+            entity = statement.column_descriptions[0]["entity"]
+            if entity is Dataset:
+                return dataset
+            if entity is Document:
+                return document
+            return 0
+
+        session.scalar.side_effect = resolve_owner
+        session.scalars.return_value.all.return_value = [segment]
+
+        with patch("core.rag.index_processor.index_processor.IndexProcessorFactory") as index_processor_factory:
+            index_backend = index_processor_factory.return_value.init_index_processor.return_value
+            IndexProcessor().index_and_clean(
+                dataset_id="dataset-1",
+                document_id="doc-1",
+                original_document_id="original-doc",
+                chunks={},
+                batch="batch-1",
+                session=session,
+            )
+
+        index_backend.clean.assert_called_once_with(
+            dataset,
+            [],
+            with_keywords=True,
+            delete_child_chunks=True,
+            delete_summaries=True,
+            segment_ids=["segment-1"],
+            session=session,
+        )
+        assert any("DELETE FROM document_segments" in str(call.args[0]) for call in session.execute.call_args_list)
 
     def test_get_preview_output_scopes_document_to_dataset_owner(self) -> None:
         dataset = SimpleNamespace(
@@ -167,7 +239,7 @@ class TestIndexProcessor:
         assert {"doc-1", "dataset-1", "tenant-1"} <= set(document_statement.compile().params.values())
         assert result is expected_preview
 
-    def test_preview_summary_workers_use_independent_sessions(self) -> None:
+    def test_preview_summary_releases_caller_session_before_workers(self) -> None:
         caller_session = MagicMock()
         phase_events: list[str] = []
         caller_session.commit.side_effect = lambda: phase_events.append("commit")
@@ -176,7 +248,6 @@ class TestIndexProcessor:
             summary_index_setting={"enable": True},
             tenant_id="tenant-1",
         )
-        worker_sessions = [MagicMock(), MagicMock()]
         preview = Preview(
             chunk_structure="text_model",
             total_segments=2,
@@ -184,11 +255,12 @@ class TestIndexProcessor:
         )
         flask_app = SimpleNamespace(app_context=lambda: nullcontext())
         processor = IndexProcessor()
-        worker_contexts = iter(nullcontext(worker_session) for worker_session in worker_sessions)
 
-        def create_worker_session():
-            phase_events.append("worker")
-            return next(worker_contexts)
+        def generate_summary_side_effect(**_kwargs: object) -> tuple[str, None]:
+            assert phase_events
+            assert phase_events[0] == "commit"
+            phase_events.append("summary")
+            return "summary", None
 
         with (
             patch.object(processor, "format_preview", return_value=preview),
@@ -197,13 +269,9 @@ class TestIndexProcessor:
                 SimpleNamespace(_get_current_object=lambda: flask_app),
             ),
             patch(
-                "core.rag.index_processor.index_processor.session_factory.create_session",
-                side_effect=create_worker_session,
-            ),
-            patch(
                 "core.rag.index_processor.index_processor.ParagraphIndexProcessor.generate_summary",
-                return_value=("summary", None),
-            ) as generate_summary,
+                side_effect=generate_summary_side_effect,
+            ) as generate_summary_mock,
         ):
             result = processor.get_preview_output(
                 chunks=[],
@@ -215,9 +283,6 @@ class TestIndexProcessor:
             )
 
         assert all(item.summary == "summary" for item in result.preview)
-        assert phase_events == ["commit", "worker", "worker"]
-        call_sessions = [call.kwargs["session"] for call in generate_summary.call_args_list]
-        assert all(call_session is not caller_session for call_session in call_sessions)
-        assert all(
-            any(call_session is worker_session for worker_session in worker_sessions) for call_session in call_sessions
-        )
+        assert phase_events == ["commit", "summary", "summary"]
+        assert all("session" not in call.kwargs for call in generate_summary_mock.call_args_list)
+        assert {call.kwargs["text"] for call in generate_summary_mock.call_args_list} == {"chunk-1", "chunk-2"}

--- a/api/tests/unit_tests/core/rag/indexing/test_indexing_runner.py
+++ b/api/tests/unit_tests/core/rag/indexing/test_indexing_runner.py
@@ -1000,6 +1000,7 @@ class TestIndexingRunnerRun:
 
     def test_run_counts_each_transformed_document_once(self, mock_dependencies, sample_dataset_documents):
         runner = IndexingRunner()
+        phase_events: list[str] = []
         dataset_document = sample_dataset_documents[0]
         dataset = Mock(spec=Dataset)
         dataset.id = dataset_document.dataset_id
@@ -1016,6 +1017,7 @@ class TestIndexingRunnerRun:
             Account: current_user,
         }
         mock_dependencies["session"].get.side_effect = lambda model, _: model_dispatch.get(model)
+        mock_dependencies["session"].commit.side_effect = lambda: phase_events.append("commit")
         process_rule = Mock(spec=DatasetProcessRule)
         process_rule.to_dict.return_value = {"mode": "automatic", "rules": {}}
         mock_dependencies["session"].scalar.return_value = process_rule
@@ -1027,11 +1029,12 @@ class TestIndexingRunnerRun:
             patch.object(runner, "_load") as load,
             patch(
                 "core.indexing_runner.calculate_segment_token_counts",
-                return_value=[11, 22],
+                side_effect=lambda **_kwargs: phase_events.append("count") or [11, 22],
             ) as calculate_token_counts,
         ):
             runner.run([dataset_document], mock_dependencies["session"])
 
+        assert phase_events == ["commit", "commit", "count", "commit"]
         calculate_token_counts.assert_called_once_with(dataset=dataset, documents=transformed_documents)
         load_segments.assert_called_once_with(
             session=mock_dependencies["session"],
@@ -1046,6 +1049,7 @@ class TestIndexingRunnerRun:
         self, mock_dependencies, sample_dataset_documents
     ):
         runner = IndexingRunner()
+        phase_events: list[str] = []
         dataset_document = sample_dataset_documents[0]
         dataset_document.created_by = "user-1"
         dataset = Mock(spec=Dataset)
@@ -1063,6 +1067,7 @@ class TestIndexingRunnerRun:
             Account: current_user,
         }
         mock_dependencies["session"].get.side_effect = lambda model, _: model_dispatch.get(model)
+        mock_dependencies["session"].commit.side_effect = lambda: phase_events.append("commit")
         mock_dependencies["session"].scalars.return_value.all.return_value = []
         process_rule = Mock(spec=DatasetProcessRule)
         process_rule.to_dict.return_value = {"mode": "automatic", "rules": {}}
@@ -1075,11 +1080,12 @@ class TestIndexingRunnerRun:
             patch.object(runner, "_load") as load,
             patch(
                 "core.indexing_runner.calculate_segment_token_counts",
-                return_value=[11, 22],
+                side_effect=lambda **_kwargs: phase_events.append("count") or [11, 22],
             ) as calculate_token_counts,
         ):
             runner.run_in_splitting_status(dataset_document, mock_dependencies["session"])
 
+        assert phase_events == ["commit", "commit", "commit", "count", "commit"]
         calculate_token_counts.assert_called_once_with(dataset=dataset, documents=transformed_documents)
         load_segments.assert_called_once_with(
             session=mock_dependencies["session"],

--- a/api/tests/unit_tests/core/rag/rerank/test_reranker.py
+++ b/api/tests/unit_tests/core/rag/rerank/test_reranker.py
@@ -12,8 +12,8 @@ All tests use mocking to avoid external dependencies and ensure fast, reliable e
 Tests follow the Arrange-Act-Assert pattern for clarity.
 """
 
+from datetime import UTC, datetime
 from operator import itemgetter
-from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -28,7 +28,28 @@ from core.rag.rerank.rerank_factory import RerankRunnerFactory
 from core.rag.rerank.rerank_model import RerankModelRunner
 from core.rag.rerank.rerank_type import RerankMode
 from core.rag.rerank.weight_rerank import WeightRerankRunner
+from extensions.storage.storage_type import StorageType
 from graphon.model_runtime.entities.rerank_entities import RerankDocument, RerankResult
+from models.enums import CreatorUserRole
+from models.model import UploadFile
+
+
+def _upload_file(file_id: str, key: str, tenant_id: str = "test-tenant-id") -> UploadFile:
+    upload_file = UploadFile(
+        tenant_id=tenant_id,
+        storage_type=StorageType.LOCAL,
+        key=key,
+        name=f"{file_id}.png",
+        size=10,
+        extension="png",
+        mime_type="image/png",
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by="00000000-0000-0000-0000-000000000001",
+        created_at=datetime.now(UTC).replace(tzinfo=None),
+        used=False,
+    )
+    upload_file.id = file_id
+    return upload_file
 
 
 def create_mock_model_instance() -> ModelInstance:
@@ -467,7 +488,7 @@ class TestRerankModelRunnerMultimodal:
         assert len(result) == 1
         assert result[0].metadata["score"] == 0.88
 
-    def test_fetch_multimodal_rerank_builds_docs_and_calls_text_rerank(self, rerank_runner):
+    def test_fetch_multimodal_rerank_text_query_avoids_image_io(self, rerank_runner):
         image_doc = Document(
             page_content="image-content",
             metadata={"doc_id": "img-1", "doc_type": DocType.IMAGE},
@@ -486,7 +507,6 @@ class TestRerankModelRunnerMultimodal:
         rerank_result = RerankResult(model="rerank-model", docs=[])
 
         with (
-            patch.object(rerank_runner._session, "get", return_value=SimpleNamespace(key="image-key")),
             patch("core.rag.rerank.rerank_model.storage.load_once", return_value=b"image-bytes") as mock_load_once,
             patch.object(
                 rerank_runner,
@@ -502,9 +522,10 @@ class TestRerankModelRunnerMultimodal:
 
         assert result == rerank_result
         assert len(unique_documents) == 3
-        mock_load_once.assert_called_once_with("image-key")
+        mock_load_once.assert_not_called()
+        rerank_runner._session.scalars.assert_not_called()
         text_rerank_call_args = mock_text_rerank.call_args.args
-        assert len(text_rerank_call_args[1]) == 3
+        assert text_rerank_call_args[1] == [image_doc, text_doc, external_doc, external_doc]
 
     def test_fetch_multimodal_rerank_skips_missing_image_upload(self, rerank_runner):
         image_doc = Document(
@@ -514,14 +535,11 @@ class TestRerankModelRunnerMultimodal:
         )
         rerank_result = RerankResult(model="rerank-model", docs=[])
 
-        with (
-            patch.object(rerank_runner._session, "get", return_value=None),
-            patch.object(
-                rerank_runner,
-                "fetch_text_rerank",
-                return_value=(rerank_result, [image_doc]),
-            ) as mock_text_rerank,
-        ):
+        with patch.object(
+            rerank_runner,
+            "fetch_text_rerank",
+            return_value=(rerank_result, [image_doc]),
+        ) as mock_text_rerank:
             result, unique_documents = rerank_runner.fetch_multimodal_rerank(
                 query="python",
                 documents=[image_doc],
@@ -532,6 +550,41 @@ class TestRerankModelRunnerMultimodal:
         assert unique_documents == [image_doc]
         docs_arg = mock_text_rerank.call_args.args[1]
         assert len(docs_arg) == 1
+
+    def test_fetch_multimodal_image_query_keeps_unique_external_and_skips_missing_dify_image(
+        self, rerank_runner: RerankModelRunner, mock_model_instance
+    ):
+        missing_image = Document(
+            page_content="missing image",
+            metadata={"doc_id": "missing-image-id", "doc_type": DocType.IMAGE},
+            provider="dify",
+        )
+        external = Document(
+            page_content="external text",
+            metadata={"doc_type": DocType.TEXT},
+            provider="external",
+        )
+        rerank_runner._session.scalars.return_value.all.return_value = [
+            _upload_file("query-image-id", "query-image-key"),
+        ]
+        rerank_result = RerankResult(
+            model="rerank-model",
+            docs=[RerankDocument(index=0, text="external text", score=0.8)],
+        )
+        mock_model_instance.invoke_multimodal_rerank.return_value = rerank_result
+
+        with patch("core.rag.rerank.rerank_model.storage.load_once", return_value=b"query-image"):
+            result, unique_documents = rerank_runner.fetch_multimodal_rerank(
+                query="query-image-id",
+                documents=[missing_image, external, external],
+                query_type=QueryType.IMAGE_QUERY,
+            )
+
+        assert result == rerank_result
+        assert unique_documents == [external]
+        assert mock_model_instance.invoke_multimodal_rerank.call_args.kwargs["docs"] == [
+            {"content": "external text", "content_type": DocType.TEXT}
+        ]
 
     def test_fetch_multimodal_rerank_image_query_invokes_multimodal_model(
         self, rerank_runner: RerankModelRunner, mock_model_instance
@@ -548,7 +601,9 @@ class TestRerankModelRunnerMultimodal:
         mock_model_instance.invoke_multimodal_rerank.return_value = rerank_result
 
         session = MagicMock()
-        session.get.return_value = SimpleNamespace(key="query-image-key")
+        session.scalars.return_value.all.return_value = [
+            _upload_file("query-upload-id", "query-image-key"),
+        ]
         with (
             patch.object(rerank_runner, "_session", session),
             patch("core.rag.rerank.rerank_model.storage.load_once", return_value=b"query-image-bytes"),
@@ -567,15 +622,63 @@ class TestRerankModelRunnerMultimodal:
         assert invoke_kwargs["query"]["content_type"] == DocType.IMAGE
         assert invoke_kwargs["docs"][0]["content"] == "text-content"
         assert "user" not in invoke_kwargs
+        session.commit.assert_called_once()
+
+        statement = session.scalars.call_args.args[0]
+        statement_params = statement.compile().params.values()
+        assert "test-tenant-id" in statement_params
+        assert any(
+            isinstance(param, list) and "query-upload-id" in param for param in statement.compile().params.values()
+        )
 
     def test_fetch_multimodal_rerank_raises_when_query_image_not_found(self, rerank_runner):
-        with patch.object(rerank_runner._session, "get", return_value=None):
-            with pytest.raises(ValueError, match="Upload file not found for query"):
-                rerank_runner.fetch_multimodal_rerank(
-                    query="missing-upload-id",
-                    documents=[],
-                    query_type=QueryType.IMAGE_QUERY,
-                )
+        rerank_runner._session.scalars.return_value.all.return_value = []
+
+        with pytest.raises(ValueError, match="Upload file not found for query"):
+            rerank_runner.fetch_multimodal_rerank(
+                query="missing-upload-id",
+                documents=[],
+                query_type=QueryType.IMAGE_QUERY,
+            )
+
+    def test_fetch_multimodal_rerank_closes_read_transaction_before_external_io(
+        self, rerank_runner: RerankModelRunner, mock_model_instance
+    ):
+        image_doc = Document(
+            page_content="image-content",
+            metadata={"doc_id": "document-image-id", "doc_type": DocType.IMAGE},
+            provider="dify",
+        )
+        text_doc = Document(
+            page_content="text-content",
+            metadata={"doc_id": "text-id", "doc_type": DocType.TEXT},
+            provider="dify",
+        )
+        events: list[str] = []
+        rerank_runner._session.scalars.return_value.all.return_value = [
+            _upload_file("document-image-id", "document-image-key"),
+            _upload_file("query-image-id", "query-image-key"),
+        ]
+        rerank_runner._session.commit.side_effect = lambda: events.append("commit")
+        mock_model_instance.invoke_multimodal_rerank.side_effect = lambda **_kwargs: (
+            events.append("provider")
+            or RerankResult(
+                model="rerank-model",
+                docs=[RerankDocument(index=0, text="image-content", score=0.8)],
+            )
+        )
+
+        with patch(
+            "core.rag.rerank.rerank_model.storage.load_once",
+            side_effect=lambda _key: events.append("storage") or b"image-bytes",
+        ):
+            rerank_runner.fetch_multimodal_rerank(
+                query="query-image-id",
+                documents=[image_doc, text_doc],
+                query_type=QueryType.IMAGE_QUERY,
+            )
+
+        assert events == ["commit", "storage", "storage", "provider"]
 
     def test_fetch_multimodal_rerank_rejects_unsupported_query_type(self, rerank_runner):
         with pytest.raises(ValueError, match="is not supported"):

--- a/api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py
+++ b/api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py
@@ -1,3 +1,4 @@
+import inspect
 import threading
 from collections.abc import Generator
 from contextlib import contextmanager, nullcontext
@@ -27,7 +28,7 @@ from core.rag.data_post_processor.data_post_processor import WeightsDict
 from core.rag.datasource.retrieval_service import RetrievalService
 from core.rag.entities import Condition as AppCondition
 from core.rag.index_processor.constant.doc_type import DocType
-from core.rag.index_processor.constant.index_type import IndexStructureType
+from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
 from core.rag.models.document import Document
 from core.rag.rerank.rerank_type import RerankMode
 from core.rag.retrieval.dataset_retrieval import DatasetRetrieval
@@ -37,7 +38,8 @@ from core.workflow.nodes.knowledge_retrieval.retrieval import KnowledgeRetrieval
 from graphon.model_runtime.entities.llm_entities import LLMUsage
 from graphon.model_runtime.entities.model_entities import ModelFeature
 from models.dataset import Dataset
-from models.enums import CreatorUserRole
+from models.enums import CreatorUserRole, DataSourceType
+from services.external_knowledge_service import ResolvedExternalKnowledgeConfig
 
 # ==================== Helper Functions ====================
 
@@ -91,6 +93,20 @@ def _dataset(**values: object) -> Dataset:
     return cast(Dataset, SimpleNamespace(**values))
 
 
+class _ExpireAfterCommitDataset(SimpleNamespace):
+    """Fail if retrieval code touches ORM-like attributes after its transaction ends."""
+
+    _expired = False
+
+    def expire(self) -> None:
+        self._expired = True
+
+    def __getattribute__(self, name: str) -> object:
+        if not name.startswith("_") and object.__getattribute__(self, "_expired"):
+            raise AssertionError(f"post-commit dataset access would refresh expired attribute {name!r}")
+        return super().__getattribute__(name)
+
+
 def _metadata_condition() -> AppMetadataFilteringCondition:
     return AppMetadataFilteringCondition(logical_operator="and", conditions=[])
 
@@ -101,6 +117,7 @@ def _patched_retriever_session():
     session_ctx = MagicMock()
     session_ctx.__enter__.return_value = session
     session_ctx.__exit__.return_value = None
+    session.context_manager = session_ctx
     with patch("core.rag.retrieval.dataset_retrieval.session_factory.create_session", return_value=session_ctx):
         yield session
 
@@ -4209,7 +4226,6 @@ class TestDatasetRetrievalAdditionalHelpers:
             assert "stop" not in config.parameters
 
     def test_automatic_metadata_filter_func(self, retrieval: DatasetRetrieval) -> None:
-        metadata_field = SimpleNamespace(name="author")
         model_instance = Mock()
         model_instance.invoke_llm.return_value = iter([Mock()])
         model_config = ModelConfigWithCredentialsEntity.model_construct(
@@ -4224,17 +4240,17 @@ class TestDatasetRetrievalAdditionalHelpers:
         )
         usage = LLMUsage.from_metadata({"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2})
         session_scalars = Mock()
-        session_scalars.all.return_value = [metadata_field]
-        session = MagicMock()
-        session.scalars.return_value = session_scalars
+        session_scalars.all.return_value = ["author"]
 
         with (
+            _patched_retriever_session() as read_session,
             patch.object(retrieval, "_fetch_model_config", return_value=(model_instance, model_config)),
             patch.object(retrieval, "_get_prompt_template", return_value=(["prompt"], [])),
             patch.object(retrieval, "_handle_invoke_result", return_value=('{"metadata_map":[]}', usage)),
             patch("core.rag.retrieval.dataset_retrieval.parse_and_check_json_markdown") as mock_parse,
             patch.object(retrieval, "_record_usage") as mock_record_usage,
         ):
+            read_session.scalars.return_value = session_scalars
             mock_parse.return_value = {
                 "metadata_map": [
                     {
@@ -4250,7 +4266,6 @@ class TestDatasetRetrievalAdditionalHelpers:
                 ]
             }
             result = retrieval._automatic_metadata_filter_func(
-                session,
                 dataset_ids=["d1"],
                 query="python",
                 tenant_id="tenant-1",
@@ -4260,13 +4275,16 @@ class TestDatasetRetrievalAdditionalHelpers:
 
         assert result == [{"metadata_name": "author", "value": "Alice", "condition": "contains"}]
         mock_record_usage.assert_called_once_with(usage)
+        metadata_statement = read_session.scalars.call_args.args[0]
+        assert [column.key for column in metadata_statement.selected_columns] == ["name"]
 
         with (
+            _patched_retriever_session() as read_session,
             patch.object(retrieval, "_fetch_model_config", side_effect=RuntimeError("boom")),
         ):
+            read_session.scalars.return_value = session_scalars
             with pytest.raises(RuntimeError, match="boom"):
                 retrieval._automatic_metadata_filter_func(
-                    session,
                     dataset_ids=["d1"],
                     query="python",
                     tenant_id="tenant-1",
@@ -4275,13 +4293,10 @@ class TestDatasetRetrievalAdditionalHelpers:
                 )
 
     def test_get_metadata_filter_condition(self, retrieval: DatasetRetrieval) -> None:
-        scalars_result = Mock()
-        scalars_result.all.return_value = [SimpleNamespace(dataset_id="d1", id="doc-1")]
-        session = MagicMock()
-        session.scalars.return_value = scalars_result
+        execute_result = Mock()
+        execute_result.all.return_value = [("d1", "doc-1")]
 
         mapping, condition = retrieval.get_metadata_filter_condition(
-            session,
             dataset_ids=["d1"],
             query="python",
             tenant_id="tenant-1",
@@ -4296,10 +4311,11 @@ class TestDatasetRetrievalAdditionalHelpers:
 
         automatic_filters = [{"condition": "contains", "metadata_name": "author", "value": "Alice"}]
         with (
+            _patched_retriever_session() as read_session,
             patch.object(retrieval, "_automatic_metadata_filter_func", return_value=automatic_filters),
         ):
+            read_session.execute.return_value = execute_result
             mapping, condition = retrieval.get_metadata_filter_condition(
-                session,
                 dataset_ids=["d1"],
                 query="python",
                 tenant_id="tenant-1",
@@ -4317,26 +4333,28 @@ class TestDatasetRetrievalAdditionalHelpers:
             logical_operator="and",
             conditions=[AppCondition(name="author", comparison_operator="contains", value="{{name}}")],
         )
-        mapping, condition = retrieval.get_metadata_filter_condition(
-            session,
-            dataset_ids=["d1"],
-            query="python",
-            tenant_id="tenant-1",
-            user_id="u1",
-            metadata_filtering_mode="manual",
-            metadata_model_config=AppModelConfig(provider="openai", name="gpt", mode="chat"),
-            metadata_filtering_conditions=manual_conditions,
-            inputs={"name": "Alice"},
-        )
+        with _patched_retriever_session() as read_session:
+            read_session.execute.return_value = execute_result
+            mapping, condition = retrieval.get_metadata_filter_condition(
+                dataset_ids=["d1"],
+                query="python",
+                tenant_id="tenant-1",
+                user_id="u1",
+                metadata_filtering_mode="manual",
+                metadata_model_config=AppModelConfig(provider="openai", name="gpt", mode="chat"),
+                metadata_filtering_conditions=manual_conditions,
+                inputs={"name": "Alice"},
+            )
         assert mapping == {"d1": ["doc-1"]}
         assert condition is not None
         assert condition.conditions
         first_condition = condition.conditions[0]
         assert first_condition.value == "Alice"
+        document_statement = read_session.execute.call_args.args[0]
+        assert [column.key for column in document_statement.selected_columns] == ["dataset_id", "id"]
 
         with pytest.raises(ValueError, match="Invalid metadata filtering mode"):
             retrieval.get_metadata_filter_condition(
-                session,
                 dataset_ids=["d1"],
                 query="python",
                 tenant_id="tenant-1",
@@ -4661,7 +4679,12 @@ class TestRetrieveCoverage:
 
         mock_model_manager.assert_called_once_with(tenant_id="tenant-1", user_id="user-1")
         mock_single_retrieve.assert_called_once()
-        assert mock_single_retrieve.call_args.args[9] == PlanningStrategy.ROUTER
+        single_retrieve_args = inspect.signature(DatasetRetrieval.single_retrieve).bind(
+            retrieval,
+            *mock_single_retrieve.call_args.args,
+            **mock_single_retrieve.call_args.kwargs,
+        )
+        assert single_retrieve_args.arguments["planning_strategy"] == PlanningStrategy.ROUTER
         assert model_config.provider_model_bundle is bound_bundle
         assert model_config.credentials == {"api_key": "secret"}
         assert model_config.model_schema is bound_schema
@@ -4826,6 +4849,148 @@ class TestSingleAndMultipleRetrieveCoverage:
     def retrieval(self) -> DatasetRetrieval:
         return DatasetRetrieval()
 
+    def test_dataset_retrieval_config_is_tenant_scoped_plain_snapshot(self, retrieval: DatasetRetrieval) -> None:
+        dataset = _dataset(
+            id="ds-1",
+            name="Dataset",
+            provider="dify",
+            tenant_id="tenant-1",
+            retrieval_model={"top_k": 2},
+            indexing_technique="high_quality",
+        )
+
+        with _patched_retriever_session() as read_session:
+            read_session.scalar.return_value = dataset
+            config = retrieval._get_dataset_retrieval_config("ds-1", "tenant-1")
+
+        assert config is not None
+        assert config.id == "ds-1"
+        assert config.tenant_id == "tenant-1"
+        statement = read_session.scalar.call_args.args[0]
+        compiled_statement = str(statement)
+        assert "datasets.description" not in compiled_statement
+        assert "datasets.id = :id_1" in compiled_statement
+        assert "datasets.tenant_id = :tenant_id_1" in compiled_statement
+
+    def test_dataset_retrieval_config_returns_none_for_unknown_tenant_dataset(
+        self, retrieval: DatasetRetrieval
+    ) -> None:
+        with _patched_retriever_session() as read_session:
+            read_session.scalar.return_value = None
+            config = retrieval._get_dataset_retrieval_config("missing", "tenant-1")
+
+        assert config is None
+
+    def test_single_retrieve_rejects_external_dataset_without_resolved_config(
+        self, retrieval: DatasetRetrieval
+    ) -> None:
+        dataset = _dataset(
+            id="external-1",
+            name="External",
+            description="external dataset",
+            provider="external",
+            tenant_id="tenant-1",
+            retrieval_model={"top_k": 2},
+            indexing_technique="high_quality",
+        )
+        with (
+            _patched_retriever_session() as read_session,
+            patch("core.rag.retrieval.dataset_retrieval.ReactMultiDatasetRouter") as router,
+            patch(
+                "core.rag.retrieval.dataset_retrieval.ExternalDatasetService.resolve_external_knowledge_config",
+                return_value=None,
+            ),
+        ):
+            read_session.scalar.return_value = dataset
+            router.return_value.invoke.return_value = ("external-1", LLMUsage.empty_usage())
+            with pytest.raises(RuntimeError, match="configuration was not resolved"):
+                retrieval.single_retrieve(
+                    app_id="app-1",
+                    tenant_id="tenant-1",
+                    user_id="user-1",
+                    user_from="workflow",
+                    query="python",
+                    available_datasets=[dataset],
+                    model_instance=Mock(),
+                    model_config=Mock(),
+                    planning_strategy=PlanningStrategy.REACT_ROUTER,
+                )
+
+    def test_worker_retriever_rejects_external_dataset_without_resolved_config(
+        self, retrieval: DatasetRetrieval
+    ) -> None:
+        dataset = _dataset(
+            id="external-1",
+            name="External",
+            provider="external",
+            tenant_id="tenant-1",
+            retrieval_model={"top_k": 2},
+            indexing_technique="high_quality",
+        )
+        session = MagicMock()
+        session.scalar.return_value = dataset
+
+        with (
+            patch(
+                "core.rag.retrieval.dataset_retrieval.ExternalDatasetService.resolve_external_knowledge_config",
+                return_value=None,
+            ),
+            pytest.raises(RuntimeError, match="configuration was not resolved"),
+        ):
+            retrieval._retriever(
+                Flask(__name__),
+                session,
+                "external-1",
+                "query",
+                2,
+                [],
+            )
+
+        session.commit.assert_called_once_with()
+
+    def test_worker_retriever_rejects_incomplete_external_dataset_snapshot(self, retrieval: DatasetRetrieval) -> None:
+        dataset = Dataset(
+            id="external-1",
+            tenant_id="tenant-1",
+            name="External",
+            description="external dataset",
+            provider="external",
+            data_source_type=DataSourceType.UPLOAD_FILE,
+            indexing_technique=IndexTechniqueType.HIGH_QUALITY,
+            created_by=str(uuid4()),
+            retrieval_model={"top_k": 2},
+        )
+        # Exercise the defensive boundary for a corrupt row without replacing the ORM entity with a mock.
+        dataset.name = None  # type: ignore[assignment]
+        session = MagicMock()
+        session.scalar.return_value = dataset
+        resolved_config = ResolvedExternalKnowledgeConfig(
+            settings_json='{"endpoint": "https://api.example.com"}',
+            external_knowledge_id="knowledge-1",
+        )
+
+        with (
+            patch(
+                "core.rag.retrieval.dataset_retrieval.ExternalDatasetService.resolve_external_knowledge_config",
+                return_value=resolved_config,
+            ),
+            patch(
+                "core.rag.retrieval.dataset_retrieval.ExternalDatasetService.fetch_external_knowledge_retrieval"
+            ) as external_retrieve,
+            pytest.raises(RuntimeError, match="values were not resolved"),
+        ):
+            retrieval._retriever(
+                Flask(__name__),
+                session,
+                dataset.id,
+                "query",
+                2,
+                [],
+            )
+
+        session.commit.assert_called_once_with()
+        external_retrieve.assert_not_called()
+
     def test_single_retrieve_external_path(self, retrieval: DatasetRetrieval) -> None:
         dataset = _dataset(
             id="ds-1",
@@ -4833,15 +4998,22 @@ class TestSingleAndMultipleRetrieveCoverage:
             description=None,
             provider="external",
             tenant_id="tenant-1",
-            retrieval_model={"top_k": 2},
+            retrieval_model=None,
             indexing_technique="high_quality",
+        )
+        resolved_config = ResolvedExternalKnowledgeConfig(
+            settings_json='{"endpoint": "https://api.example.com"}',
+            external_knowledge_id="knowledge-1",
         )
         app = Flask(__name__)
         usage = LLMUsage.from_metadata({"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2})
-        session = MagicMock()
-        session.scalar.return_value = dataset
         with app.app_context():
             with (
+                _patched_retriever_session() as read_session,
+                patch(
+                    "core.rag.retrieval.dataset_retrieval.ExternalDatasetService.resolve_external_knowledge_config",
+                    return_value=resolved_config,
+                ),
                 patch("core.rag.retrieval.dataset_retrieval.ReactMultiDatasetRouter") as mock_router_cls,
                 patch(
                     "core.rag.retrieval.dataset_retrieval.ExternalDatasetService.fetch_external_knowledge_retrieval"
@@ -4850,12 +5022,15 @@ class TestSingleAndMultipleRetrieveCoverage:
                 patch.object(retrieval, "_on_retrieval_end") as mock_end,
                 patch.object(retrieval, "_on_query"),
             ):
+                read_session.scalar.return_value = dataset
                 mock_router_cls.return_value.invoke.return_value = ("ds-1", usage)
-                mock_external.return_value = [
-                    {"content": "ext result", "metadata": {"k": "v"}, "score": 0.9, "title": "Ext Doc"}
-                ]
+
+                def fetch_external(**_kwargs):
+                    assert read_session.context_manager.__exit__.called
+                    return [{"content": "ext result", "metadata": {"k": "v"}, "score": 0.9, "title": "Ext Doc"}]
+
+                mock_external.side_effect = fetch_external
                 result = retrieval.single_retrieve(
-                    session,
                     app_id="app-1",
                     tenant_id="tenant-1",
                     user_id="user-1",
@@ -4870,6 +5045,11 @@ class TestSingleAndMultipleRetrieveCoverage:
 
         assert len(result) == 1
         assert result[0].provider == "external"
+        assert mock_external.call_args.kwargs["external_retrieval_parameters"] == {
+            "top_k": 2,
+            "score_threshold": 0.0,
+        }
+        assert mock_external.call_args.kwargs["resolved_config"] is resolved_config
         mock_end.assert_called_once()
         assert retrieval.llm_usage.total_tokens == 2
 
@@ -4895,10 +5075,9 @@ class TestSingleAndMultipleRetrieveCoverage:
         app = Flask(__name__)
         usage = LLMUsage.from_metadata({"prompt_tokens": 1, "completion_tokens": 0, "total_tokens": 1})
         result_doc = _doc(provider="dify", score=0.7, dataset_id="ds-1", document_id="doc-1", doc_id="node-1")
-        session = MagicMock()
-        session.scalar.return_value = dataset
         with app.app_context():
             with (
+                _patched_retriever_session() as read_session,
                 patch("core.rag.retrieval.dataset_retrieval.FunctionCallMultiDatasetRouter") as mock_router_cls,
                 patch(
                     "core.rag.retrieval.dataset_retrieval.RetrievalService.retrieve", return_value=[result_doc]
@@ -4907,9 +5086,9 @@ class TestSingleAndMultipleRetrieveCoverage:
                 patch.object(retrieval, "_on_retrieval_end"),
                 patch.object(retrieval, "_on_query"),
             ):
+                read_session.scalar.return_value = dataset
                 mock_router_cls.return_value.invoke.return_value = ("ds-1", usage)
                 results = retrieval.single_retrieve(
-                    session,
                     app_id="app-1",
                     tenant_id="tenant-1",
                     user_id="user-1",
@@ -4931,7 +5110,6 @@ class TestSingleAndMultipleRetrieveCoverage:
         with patch("core.rag.retrieval.dataset_retrieval.ReactMultiDatasetRouter") as mock_router_cls:
             mock_router_cls.return_value.invoke.return_value = (None, LLMUsage.empty_usage())
             results = retrieval.single_retrieve(
-                MagicMock(),
                 app_id="app-1",
                 tenant_id="tenant-1",
                 user_id="user-1",
@@ -4957,13 +5135,12 @@ class TestSingleAndMultipleRetrieveCoverage:
             retrieval_model={"top_k": 2, "search_method": "semantic_search", "reranking_enable": False},
         )
         with (
+            _patched_retriever_session() as read_session,
             patch("core.rag.retrieval.dataset_retrieval.ReactMultiDatasetRouter") as mock_router_cls,
         ):
-            session = MagicMock()
-            session.scalar.return_value = dataset
+            read_session.scalar.return_value = dataset
             mock_router_cls.return_value.invoke.return_value = ("ds-1", LLMUsage.empty_usage())
             no_filter = retrieval.single_retrieve(
-                session,
                 app_id="app-1",
                 tenant_id="tenant-1",
                 user_id="user-1",
@@ -4977,7 +5154,6 @@ class TestSingleAndMultipleRetrieveCoverage:
                 metadata_condition=_metadata_condition(),
             )
             missing_doc_ids = retrieval.single_retrieve(
-                session,
                 app_id="app-1",
                 tenant_id="tenant-1",
                 user_id="user-1",
@@ -5248,7 +5424,7 @@ class TestInternalHooksCoverage:
             == []
         )
 
-        external_dataset = SimpleNamespace(
+        external_dataset = _ExpireAfterCommitDataset(
             id="ext-ds",
             name="External",
             provider="external",
@@ -5256,14 +5432,28 @@ class TestInternalHooksCoverage:
             retrieval_model={"top_k": 2},
             indexing_technique="high_quality",
         )
+        resolved_config = ResolvedExternalKnowledgeConfig(
+            settings_json='{"endpoint": "https://api.example.com"}',
+            external_knowledge_id="knowledge-1",
+        )
         with (
+            patch(
+                "core.rag.retrieval.dataset_retrieval.ExternalDatasetService.resolve_external_knowledge_config",
+                return_value=resolved_config,
+            ),
             patch(
                 "core.rag.retrieval.dataset_retrieval.ExternalDatasetService.fetch_external_knowledge_retrieval"
             ) as mock_external,
         ):
             session = MagicMock()
             session.scalar.return_value = external_dataset
-            mock_external.return_value = [{"content": "e", "metadata": {}, "score": 0.8, "title": "Ext"}]
+            session.commit.side_effect = external_dataset.expire
+
+            def fetch_external(**_kwargs):
+                session.commit.assert_called_once_with()
+                return [{"content": "e", "metadata": {}, "score": 0.8, "title": "Ext"}]
+
+            mock_external.side_effect = fetch_external
             retrieval._retriever(
                 flask_app=flask_app,  # type: ignore[arg-type]
                 session=session,
@@ -5272,6 +5462,7 @@ class TestInternalHooksCoverage:
                 top_k=1,
                 all_documents=all_documents,
             )
+            assert mock_external.call_args.kwargs["resolved_config"] is resolved_config
 
         economy_dataset = SimpleNamespace(
             id="eco-ds",
@@ -5418,11 +5609,10 @@ class TestInternalHooksCoverage:
         assert len(ranked) == 1
         assert ranked[0].metadata.get("score") == 0.0
 
-        with patch("core.rag.retrieval.dataset_retrieval.db.session.scalars") as mock_scalars:
-            mock_scalars.return_value.all.return_value = []
+        with _patched_retriever_session() as read_session:
+            read_session.scalars.return_value.all.return_value = []
             with pytest.raises(ValueError):
                 retrieval._automatic_metadata_filter_func(
-                    MagicMock(),
                     dataset_ids=["d1"],
                     query="python",
                     tenant_id="tenant-1",
@@ -5431,19 +5621,19 @@ class TestInternalHooksCoverage:
                 )
 
         session_scalars = Mock()
-        session_scalars.all.return_value = [SimpleNamespace(name="author")]
+        session_scalars.all.return_value = ["author"]
         with (
-            patch("core.rag.retrieval.dataset_retrieval.db.session.scalars", return_value=session_scalars),
+            _patched_retriever_session() as read_session,
             patch.object(retrieval, "_fetch_model_config", return_value=(Mock(), Mock())),
             patch.object(retrieval, "_get_prompt_template", return_value=(["prompt"], [])),
             patch.object(retrieval, "_record_usage"),
         ):
+            read_session.scalars.return_value = session_scalars
             model_instance = Mock()
             model_instance.invoke_llm.side_effect = RuntimeError("nope")
             with patch.object(retrieval, "_fetch_model_config", return_value=(model_instance, Mock())):
                 assert (
                     retrieval._automatic_metadata_filter_func(
-                        MagicMock(),
                         dataset_ids=["d1"],
                         query="python",
                         tenant_id="tenant-1",

--- a/api/tests/unit_tests/core/rag/summary_index/test_summary_index.py
+++ b/api/tests/unit_tests/core/rag/summary_index/test_summary_index.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
+from core.rag.summary_index.summary_index import SummaryIndex
+from models.dataset import Dataset, DocumentSegment, DocumentSegmentSummary
+from models.dataset import Document as DatasetDocument
+from models.enums import (
+    DataSourceType,
+    DocumentCreatedFrom,
+    IndexingStatus,
+    SegmentStatus,
+    SummaryStatus,
+)
+
+
+def test_preview_skips_segments_with_concrete_completed_summaries() -> None:
+    tenant_id = str(uuid.uuid4())
+    account_id = str(uuid.uuid4())
+    dataset = Dataset(
+        tenant_id=tenant_id,
+        name="preview dataset",
+        created_by=account_id,
+        indexing_technique=IndexTechniqueType.HIGH_QUALITY,
+        summary_index_setting={"enable": True},
+    )
+    dataset.id = str(uuid.uuid4())
+    document = DatasetDocument(
+        tenant_id=tenant_id,
+        dataset_id=dataset.id,
+        position=1,
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        batch="preview-batch",
+        name="preview.txt",
+        created_from=DocumentCreatedFrom.WEB,
+        created_by=account_id,
+        enabled=True,
+        archived=False,
+        indexing_status=IndexingStatus.COMPLETED,
+        doc_form=IndexStructureType.PARAGRAPH_INDEX,
+        word_count=2,
+        tokens=2,
+    )
+    document.id = str(uuid.uuid4())
+    segment = DocumentSegment(
+        tenant_id=tenant_id,
+        dataset_id=dataset.id,
+        document_id=document.id,
+        position=1,
+        content="preview content",
+        word_count=2,
+        tokens=2,
+        created_by=account_id,
+        status=SegmentStatus.COMPLETED,
+        enabled=True,
+    )
+    segment.id = str(uuid.uuid4())
+    summary = DocumentSegmentSummary(
+        dataset_id=dataset.id,
+        document_id=document.id,
+        chunk_id=segment.id,
+        summary_content="completed preview summary",
+        status=SummaryStatus.COMPLETED,
+        enabled=True,
+    )
+
+    session = MagicMock()
+    session.scalar.side_effect = [dataset, document]
+    session.scalars.return_value.all.return_value = [segment]
+    session_context = MagicMock()
+    session_context.__enter__.return_value = session
+    session_context.__exit__.return_value = None
+
+    with (
+        patch(
+            "core.rag.summary_index.summary_index.session_factory.create_session",
+            return_value=session_context,
+        ),
+        patch(
+            "core.rag.summary_index.summary_index.SummaryIndexService.get_segments_summaries",
+            return_value={segment.id: summary},
+        ) as get_summaries,
+        patch("core.rag.summary_index.summary_index.generate_summary_index_task.delay") as publish_task,
+    ):
+        SummaryIndex().generate_and_vectorize_summary(
+            dataset.id,
+            document.id,
+            is_preview=True,
+        )
+
+    get_summaries.assert_called_once_with([segment.id], dataset.id, session=session)
+    publish_task.assert_not_called()

--- a/api/tests/unit_tests/core/tools/utils/test_misc_utils_extra.py
+++ b/api/tests/unit_tests/core/tools/utils/test_misc_utils_extra.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from contextlib import nullcontext
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from yaml import YAMLError
@@ -18,10 +18,21 @@ from core.tools.utils.dataset_retriever.dataset_retriever_tool import DatasetRet
 from core.tools.utils.text_processing_utils import remove_leading_symbols
 from core.tools.utils.uuid_utils import is_valid_uuid
 from core.tools.utils.yaml_utils import _load_yaml_file, load_yaml_file_cached
+from models.dataset import Dataset
+from services.external_knowledge_service import ResolvedExternalKnowledgeConfig
 
 
 def _retrieve_config() -> DatasetRetrieveConfigEntity:
     return DatasetRetrieveConfigEntity(retrieve_strategy=DatasetRetrieveConfigEntity.RetrieveStrategy.SINGLE)
+
+
+def _read_session_context(dataset):
+    read_session = Mock()
+    read_session.scalar.return_value = dataset
+    read_context = MagicMock()
+    read_context.__enter__.return_value = read_session
+    read_context.__exit__.return_value = None
+    return read_session, read_context
 
 
 class _FakeFlaskApp:
@@ -136,7 +147,11 @@ def test_single_dataset_retriever_external_run_returns_content_and_resources():
         {"logical_operator": "and"},
     )
     session = Mock()
-    session.scalar.return_value = dataset
+    read_session, read_context = _read_session_context(dataset)
+    resolved_config = ResolvedExternalKnowledgeConfig(
+        settings_json='{"endpoint": "https://api.example.com"}',
+        external_knowledge_id="knowledge-1",
+    )
     external_documents = [
         {"content": "first", "metadata": {"document_id": "doc-a"}, "score": 0.9, "title": "Doc A"},
         {"content": "second", "metadata": {"document_id": "doc-b"}, "score": 0.8, "title": "Doc B"},
@@ -152,13 +167,27 @@ def test_single_dataset_retriever_external_run_returns_content_and_resources():
         inputs={"x": 1},
     )
 
-    with patch.object(single_retriever_module, "DatasetRetrieval", return_value=dataset_retrieval):
-        with patch.object(
+    with (
+        patch.object(single_retriever_module.session_factory, "create_session", return_value=read_context),
+        patch.object(single_retriever_module, "DatasetRetrieval", return_value=dataset_retrieval),
+        patch.object(
+            single_retriever_module.ExternalDatasetService,
+            "resolve_external_knowledge_config",
+            return_value=resolved_config,
+        ) as resolve_mock,
+        patch.object(
             single_retriever_module.ExternalDatasetService,
             "fetch_external_knowledge_retrieval",
-            return_value=external_documents,
-        ) as fetch_mock:
-            result = tool.run(session=session, query="hello")
+        ) as fetch_mock,
+    ):
+
+        def fetch_external(**_kwargs):
+            assert read_context.__exit__.called
+            session.scalar.assert_not_called()
+            return external_documents
+
+        fetch_mock.side_effect = fetch_external
+        result = tool.run(session=session, query="hello")
 
     assert result == "first\nsecond"
     assert callback.queries == [("hello", "dataset-1")]
@@ -166,8 +195,46 @@ def test_single_dataset_retriever_external_run_returns_content_and_resources():
     resource_info = callback.resources
     assert [item.position for item in resource_info] == [1, 2]
     assert resource_info[0].dataset_id == "dataset-1"
+    resolve_mock.assert_called_once_with(
+        tenant_id="tenant-1",
+        dataset_id="dataset-1",
+        session=read_session,
+    )
     fetch_mock.assert_called_once()
-    assert fetch_mock.call_args.kwargs["session"] is session
+    assert fetch_mock.call_args.kwargs["resolved_config"] is resolved_config
+
+
+def test_single_dataset_retriever_rejects_missing_external_configuration():
+    dataset = Dataset(
+        tenant_id="tenant-1",
+        name="External Knowledge",
+        created_by="account-1",
+        provider="external",
+        indexing_technique="high_quality",
+        retrieval_model={},
+    )
+    dataset.id = "dataset-1"
+    _, read_context = _read_session_context(dataset)
+    tool = SingleDatasetRetrieverTool(
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        retrieve_config=_retrieve_config(),
+        return_resource=False,
+        retriever_from="dev",
+        hit_callbacks=[],
+        inputs={},
+    )
+
+    with (
+        patch.object(single_retriever_module.session_factory, "create_session", return_value=read_context),
+        patch.object(
+            single_retriever_module.ExternalDatasetService,
+            "resolve_external_knowledge_config",
+            return_value=None,
+        ),
+        pytest.raises(RuntimeError, match="configuration was not resolved"),
+    ):
+        tool.run(session=Mock(), query="hello")
 
 
 def test_single_dataset_retriever_returns_empty_when_metadata_filter_finds_no_documents():
@@ -182,7 +249,7 @@ def test_single_dataset_retriever_returns_empty_when_metadata_filter_finds_no_do
     dataset_retrieval = Mock()
     dataset_retrieval.get_metadata_filter_condition.return_value = ({"dataset-1": []}, {"logical_operator": "and"})
     session = Mock()
-    session.scalar.return_value = dataset
+    _, read_context = _read_session_context(dataset)
 
     tool = SingleDatasetRetrieverTool(
         tenant_id="tenant-1",
@@ -194,9 +261,12 @@ def test_single_dataset_retriever_returns_empty_when_metadata_filter_finds_no_do
         inputs={},
     )
 
-    with patch.object(single_retriever_module, "DatasetRetrieval", return_value=dataset_retrieval):
-        with patch.object(single_retriever_module.RetrievalService, "retrieve") as retrieve_mock:
-            result = tool.run(session=session, query="hello")
+    with (
+        patch.object(single_retriever_module.session_factory, "create_session", return_value=read_context),
+        patch.object(single_retriever_module, "DatasetRetrieval", return_value=dataset_retrieval),
+        patch.object(single_retriever_module.RetrievalService, "retrieve") as retrieve_mock,
+    ):
+        result = tool.run(session=session, query="hello")
 
     assert result == ""
     retrieve_mock.assert_not_called()
@@ -261,8 +331,9 @@ def test_single_dataset_retriever_non_economy_run_sorts_context_and_resources():
         id="doc-high", name="Document High", data_source_type="notion", doc_metadata={"lang": "fr"}
     )
     session = Mock()
-    session.scalar.side_effect = [dataset, lookup_doc_low, lookup_doc_high]
+    session.scalar.side_effect = [lookup_doc_low, lookup_doc_high]
     session.get.return_value = dataset
+    _, read_context = _read_session_context(dataset)
 
     tool = SingleDatasetRetrieverTool(
         tenant_id="tenant-1",
@@ -275,14 +346,17 @@ def test_single_dataset_retriever_non_economy_run_sorts_context_and_resources():
         top_k=2,
     )
 
-    with patch.object(single_retriever_module, "DatasetRetrieval", return_value=dataset_retrieval):
-        with patch.object(single_retriever_module.RetrievalService, "retrieve", return_value=documents):
-            with patch.object(
-                single_retriever_module.RetrievalService,
-                "format_retrieval_documents",
-                return_value=records,
-            ):
-                result = tool.run(session=session, query="hello")
+    with (
+        patch.object(single_retriever_module.session_factory, "create_session", return_value=read_context),
+        patch.object(single_retriever_module, "DatasetRetrieval", return_value=dataset_retrieval),
+        patch.object(single_retriever_module.RetrievalService, "retrieve", return_value=documents),
+        patch.object(
+            single_retriever_module.RetrievalService,
+            "format_retrieval_documents",
+            return_value=records,
+        ),
+    ):
+        result = tool.run(session=session, query="hello")
 
     assert result == "signed high\nsummary low\nquestion:signed low answer:low answer"
     assert callback.documents == documents

--- a/api/tests/unit_tests/services/hit_service.py
+++ b/api/tests/unit_tests/services/hit_service.py
@@ -11,13 +11,14 @@ from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.orm import Session
 
 from core.rag.models.document import Document
 from core.rag.retrieval.retrieval_methods import RetrievalMethod
 from models import Account
 from models.dataset import Dataset, DatasetQuery
+from services.external_knowledge_service import ResolvedExternalKnowledgeConfig
 from services.hit_testing_service import HitTestingService
 
 pytestmark = [
@@ -417,15 +418,33 @@ class TestHitTestingServiceExternalRetrieve:
             {"content": "External doc 1", "title": "Title 1", "score": 0.95, "metadata": {"key": "value"}},
             {"content": "External doc 2", "title": "Title 2", "score": 0.85, "metadata": {}},
         ]
+        resolved_config = ResolvedExternalKnowledgeConfig(
+            settings_json='{"endpoint": "https://api.example.com"}',
+            external_knowledge_id="knowledge-1",
+        )
 
         with (
+            patch(
+                "services.hit_testing_service.ExternalDatasetService.resolve_external_knowledge_config",
+                autospec=True,
+            ) as mock_resolve,
             patch(
                 "services.hit_testing_service.RetrievalService.external_retrieve", autospec=True
             ) as mock_external_retrieve,
             patch("services.hit_testing_service.time.perf_counter", autospec=True) as mock_perf_counter,
         ):
             mock_perf_counter.side_effect = [0.0, 0.1]
-            mock_external_retrieve.return_value = external_documents
+
+            def resolve_config(**_kwargs):
+                sqlite_session.execute(text("SELECT 1"))
+                return resolved_config
+
+            def retrieve_external(**_kwargs):
+                assert not sqlite_session.in_transaction()
+                return external_documents
+
+            mock_resolve.side_effect = resolve_config
+            mock_external_retrieve.side_effect = retrieve_external
 
             # Act
             result = HitTestingService.external_retrieve(
@@ -446,6 +465,7 @@ class TestHitTestingServiceExternalRetrieve:
             mock_external_retrieve.assert_called_once()
             # Verify query was escaped
             assert mock_external_retrieve.call_args[1]["query"] == 'test query with \\"quotes\\"'
+            assert mock_external_retrieve.call_args.kwargs["resolved_config"] is resolved_config
             query_log = sqlite_session.scalar(select(DatasetQuery))
             assert query_log is not None
             assert query_log.dataset_id == dataset.id
@@ -491,8 +511,16 @@ class TestHitTestingServiceExternalRetrieve:
         metadata_filtering_conditions = {"category": "test"}
 
         external_documents = [{"content": "Doc 1", "title": "Title", "score": 0.9, "metadata": {}}]
+        resolved_config = ResolvedExternalKnowledgeConfig(
+            settings_json='{"endpoint": "https://api.example.com"}',
+            external_knowledge_id="knowledge-1",
+        )
 
         with (
+            patch(
+                "services.hit_testing_service.ExternalDatasetService.resolve_external_knowledge_config",
+                return_value=resolved_config,
+            ),
             patch(
                 "services.hit_testing_service.RetrievalService.external_retrieve", autospec=True
             ) as mock_external_retrieve,
@@ -530,8 +558,16 @@ class TestHitTestingServiceExternalRetrieve:
         query = "test query"
         external_retrieval_model = {}
         metadata_filtering_conditions = {}
+        resolved_config = ResolvedExternalKnowledgeConfig(
+            settings_json='{"endpoint": "https://api.example.com"}',
+            external_knowledge_id="knowledge-1",
+        )
 
         with (
+            patch(
+                "services.hit_testing_service.ExternalDatasetService.resolve_external_knowledge_config",
+                return_value=resolved_config,
+            ),
             patch(
                 "services.hit_testing_service.RetrievalService.external_retrieve", autospec=True
             ) as mock_external_retrieve,
@@ -588,7 +624,12 @@ class TestHitTestingServiceCompactRetrieveResponse:
             mock_format.return_value = mock_records
 
             # Act
-            result = HitTestingService.compact_retrieve_response(query, documents, session=sqlite_session)
+            result = HitTestingService.compact_retrieve_response(
+                query,
+                documents,
+                dataset_id="dataset-1",
+                session=sqlite_session,
+            )
 
             # Assert
             assert result["query"]["content"] == query
@@ -599,6 +640,7 @@ class TestHitTestingServiceCompactRetrieveResponse:
             assert mock_format.call_args.args[0] is not sqlite_session
             assert mock_format.call_args.args[0].get_bind() is sqlite_session.get_bind()
             assert mock_format.call_args.args[1] == documents
+            assert mock_format.call_args.kwargs["allowed_dataset_ids"] == {"dataset-1"}
 
     def test_compact_retrieve_response_empty_documents(self, sqlite_session: Session):
         """
@@ -617,7 +659,12 @@ class TestHitTestingServiceCompactRetrieveResponse:
             mock_format.return_value = []
 
             # Act
-            result = HitTestingService.compact_retrieve_response(query, documents, session=sqlite_session)
+            result = HitTestingService.compact_retrieve_response(
+                query,
+                documents,
+                dataset_id="dataset-1",
+                session=sqlite_session,
+            )
 
             # Assert
             assert result["query"]["content"] == query
@@ -626,6 +673,7 @@ class TestHitTestingServiceCompactRetrieveResponse:
             assert mock_format.call_args.args[0] is not sqlite_session
             assert mock_format.call_args.args[0].get_bind() is sqlite_session.get_bind()
             assert mock_format.call_args.args[1] == documents
+            assert mock_format.call_args.kwargs["allowed_dataset_ids"] == {"dataset-1"}
 
 
 class TestHitTestingServiceCompactExternalRetrieveResponse:

--- a/api/tests/unit_tests/services/test_dataset_service_segment.py
+++ b/api/tests/unit_tests/services/test_dataset_service_segment.py
@@ -1,5 +1,9 @@
 """Unit tests for SegmentService behaviors in dataset_service."""
 
+from core.rag.index_processor.constant.index_type import IndexTechniqueType
+from models import Tenant
+from models.dataset import Dataset, Document, DocumentSegment, DocumentSegmentSummary
+from models.enums import DataSourceType, DocumentCreatedFrom, SegmentStatus, SummaryStatus
 from services.dataset_ref_service import DatasetRef, DatasetRefService, DocumentRef, SegmentRef
 
 from .dataset_service_test_helpers import (
@@ -8,7 +12,6 @@ from .dataset_service_test_helpers import (
     ChildChunkDeleteIndexError,
     ChildChunkIndexingError,
     ChildChunkUpdateArgs,
-    DocumentSegment,
     IndexStructureType,
     MagicMock,
     ModelType,
@@ -24,6 +27,82 @@ from .dataset_service_test_helpers import (
     patch,
     pytest,
 )
+
+
+def _concrete_dataset() -> Dataset:
+    return Dataset(
+        id="dataset-1",
+        tenant_id="tenant-1",
+        name="Dataset",
+        description="",
+        provider="vendor",
+        permission="only_me",
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        indexing_technique=IndexTechniqueType.ECONOMY,
+        created_by="00000000-0000-0000-0000-000000000001",
+    )
+
+
+def _concrete_document(dataset: Dataset, *, word_count: int) -> Document:
+    return Document(
+        id="doc-1",
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        position=1,
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        batch="batch-1",
+        name="Document",
+        created_from=DocumentCreatedFrom.WEB,
+        created_by="00000000-0000-0000-0000-000000000001",
+        indexing_status="completed",
+        enabled=True,
+        archived=False,
+        doc_form="text_model",
+        word_count=word_count,
+    )
+
+
+def _concrete_segment(
+    dataset: Dataset,
+    document: Document,
+    *,
+    enabled: bool,
+    index_node_id: str | None,
+) -> DocumentSegment:
+    segment = DocumentSegment(
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        document_id=document.id,
+        position=1,
+        content="segment content",
+        word_count=4,
+        tokens=2,
+        created_by="00000000-0000-0000-0000-000000000001",
+        enabled=enabled,
+        index_node_id=index_node_id,
+        status=SegmentStatus.COMPLETED,
+    )
+    segment.id = "segment-1"
+    return segment
+
+
+def _summary(summary_content: str) -> DocumentSegmentSummary:
+    return DocumentSegmentSummary(
+        dataset_id="dataset-1",
+        document_id="doc-1",
+        chunk_id="segment-1",
+        summary_content=summary_content,
+        status=SummaryStatus.COMPLETED,
+        enabled=True,
+    )
+
+
+def _concrete_account() -> Account:
+    account = Account(name="Owner", email="owner@example.com")
+    tenant = Tenant(name="Tenant")
+    tenant.id = "tenant-1"
+    account._current_tenant = tenant
+    return account
 
 
 def _make_segment_ref(segment_id: str = "segment-1"):
@@ -687,7 +766,7 @@ class TestSegmentServiceMutations:
         dataset = _make_dataset(indexing_technique="high_quality")
         refreshed_segment = SimpleNamespace(id=segment.id)
         processing_rule = SimpleNamespace(id=document.dataset_process_rule_id)
-        existing_summary = SimpleNamespace(summary_content="old summary")
+        existing_summary = _summary("old summary")
         embedding_model_instance = object()
         args = SegmentUpdateArgs(
             content="same content",
@@ -731,7 +810,7 @@ class TestSegmentServiceMutations:
         dataset = _make_dataset(indexing_technique="high_quality")
         dataset.summary_index_setting = {"enable": True}
         refreshed_segment = SimpleNamespace(id=segment.id)
-        existing_summary = SimpleNamespace(summary_content="old summary")
+        existing_summary = _summary("old summary")
         embedding_model = MagicMock()
         embedding_model.get_text_embedding_num_tokens.return_value = [9]
         args = SegmentUpdateArgs(content="new content", keywords=["kw-1"])
@@ -770,7 +849,7 @@ class TestSegmentServiceMutations:
         dataset = _make_dataset(indexing_technique="high_quality")
         dataset.summary_index_setting = {"enable": True}
         refreshed_segment = SimpleNamespace(id=segment.id)
-        existing_summary = SimpleNamespace(summary_content="same summary")
+        existing_summary = _summary("same summary")
         embedding_model = MagicMock()
         embedding_model.get_text_embedding_num_tokens.return_value = [7]
         args = SegmentUpdateArgs(content="new text", summary="same summary")
@@ -838,6 +917,56 @@ class TestSegmentServiceMutations:
             with pytest.raises(ValueError, match="Segment is deleting"):
                 SegmentService.delete_segment(segment, document, dataset, MagicMock())
 
+    def test_delete_disabled_segment_still_dispatches_summary_cleanup(self):
+        session = MagicMock()
+        dataset = _concrete_dataset()
+        document = _concrete_document(dataset, word_count=10)
+        segment = _concrete_segment(dataset, document, enabled=False, index_node_id=None)
+        side_effect_order: list[str] = []
+
+        with (
+            patch("services.dataset_service.redis_client") as mock_redis,
+            patch("services.dataset_service.delete_segment_from_index_task") as delete_task,
+        ):
+            mock_redis.get.return_value = None
+            session.scalars.return_value.all.return_value = []
+            session.commit.side_effect = lambda: side_effect_order.append("commit")
+            delete_task.delay.side_effect = lambda *_args: side_effect_order.append("publish")
+
+            SegmentService.delete_segment(segment, document, dataset, session)
+
+        mock_redis.setex.assert_called_once_with(f"segment_{segment.id}_delete_indexing", 600, 1)
+        delete_task.delay.assert_called_once_with([], dataset.id, document.id, [segment.id], [])
+        session.delete.assert_called_once_with(segment)
+        assert side_effect_order == ["commit", "publish"]
+
+    def test_delete_segment_publish_failure_removes_relational_dependants(self):
+        session = MagicMock()
+        dataset = _concrete_dataset()
+        document = _concrete_document(dataset, word_count=10)
+        segment = _concrete_segment(dataset, document, enabled=True, index_node_id="node-1")
+
+        with (
+            patch("services.dataset_service.redis_client") as mock_redis,
+            patch("services.dataset_service.delete_segment_from_index_task") as delete_task,
+        ):
+            mock_redis.get.return_value = None
+            session.scalars.return_value.all.return_value = []
+            delete_task.delay.side_effect = RuntimeError("broker unavailable")
+
+            with pytest.raises(RuntimeError, match="broker unavailable"):
+                SegmentService.delete_segment(segment, document, dataset, session)
+
+        assert session.commit.call_count == 2
+        delete_statements = [
+            str(call.args[0].compile(compile_kwargs={"literal_binds": True})) for call in session.execute.call_args_list
+        ]
+        summary_delete_sql = next(sql for sql in delete_statements if "DELETE FROM document_segment_summaries" in sql)
+        assert f"document_segment_summaries.dataset_id = '{dataset.id}'" in summary_delete_sql
+        assert f"document_segment_summaries.chunk_id IN ('{segment.id}')" in summary_delete_sql
+        assert any("DELETE FROM child_chunks" in sql for sql in delete_statements)
+        assert any("DELETE FROM segment_attachment_bindings" in sql for sql in delete_statements)
+
     def test_delete_segments_removes_records_and_clamps_document_word_count(self):
         session = MagicMock()
         dataset = _make_dataset()
@@ -870,6 +999,94 @@ class TestSegmentServiceMutations:
             ["child-1"],
         )
         session.commit.assert_called()
+
+    def test_delete_segments_dispatches_cleanup_without_vector_ids(self):
+        session = MagicMock()
+        dataset = _concrete_dataset()
+        document = _concrete_document(dataset, word_count=3)
+        current_user = _concrete_account()
+        side_effect_order: list[str] = []
+
+        with (
+            patch("services.dataset_service.current_user", current_user),
+            patch("services.dataset_service.delete_segment_from_index_task") as delete_task,
+        ):
+            execute_result = MagicMock()
+            execute_result.all.return_value = [(None, "segment-1", 2)]
+            session.execute.return_value = execute_result
+            session.scalars.return_value.all.return_value = []
+            session.commit.side_effect = lambda: side_effect_order.append("commit")
+            delete_task.delay.side_effect = lambda *_args: side_effect_order.append("publish")
+
+            SegmentService.delete_segments(["segment-1"], document, dataset, session)
+
+        delete_task.delay.assert_called_once_with([], dataset.id, document.id, ["segment-1"], [])
+        assert side_effect_order == ["commit", "publish"]
+
+    def test_delete_segments_publish_failure_removes_relational_dependants(self):
+        session = MagicMock()
+        dataset = _concrete_dataset()
+        document = _concrete_document(dataset, word_count=3)
+        current_user = _concrete_account()
+        segment_rows = MagicMock()
+        segment_rows.all.return_value = [(None, "segment-1", 2)]
+        session.execute.return_value = segment_rows
+        session.scalars.return_value.all.return_value = []
+
+        with (
+            patch("services.dataset_service.current_user", current_user),
+            patch("services.dataset_service.delete_segment_from_index_task") as delete_task,
+        ):
+            delete_task.delay.side_effect = RuntimeError("broker unavailable")
+            with pytest.raises(RuntimeError, match="broker unavailable"):
+                SegmentService.delete_segments(["segment-1"], document, dataset, session)
+
+        assert session.commit.call_count == 2
+        delete_statements = [
+            str(call.args[0].compile(compile_kwargs={"literal_binds": True})) for call in session.execute.call_args_list
+        ]
+        summary_delete_sql = next(sql for sql in delete_statements if "DELETE FROM document_segment_summaries" in sql)
+        assert f"document_segment_summaries.dataset_id = '{dataset.id}'" in summary_delete_sql
+        assert "document_segment_summaries.chunk_id IN ('segment-1')" in summary_delete_sql
+        assert any("DELETE FROM child_chunks" in sql for sql in delete_statements)
+        assert any("DELETE FROM segment_attachment_bindings" in sql for sql in delete_statements)
+
+    def test_publish_failure_summary_cleanup_rolls_back_without_hiding_broker_error(self):
+        session = MagicMock()
+        session.execute.side_effect = RuntimeError("database unavailable")
+
+        SegmentService._remove_orphaned_summary_rows_after_publish_failure(
+            session,
+            "dataset-1",
+            ["segment-1"],
+        )
+
+        session.rollback.assert_called_once_with()
+
+    def test_delete_segments_mutates_only_rows_validated_by_the_ownership_query(self, account_context):
+        session = MagicMock()
+        dataset = _concrete_dataset()
+        document = _concrete_document(dataset, word_count=3)
+        execute_result = MagicMock()
+        execute_result.all.return_value = [("node-1", "segment-1", 2)]
+        session.execute.return_value = execute_result
+        session.scalars.return_value.all.return_value = []
+
+        with patch("services.dataset_service.delete_segment_from_index_task"):
+            SegmentService.delete_segments(
+                ["segment-1", "foreign-segment"],
+                document,
+                dataset,
+                session,
+            )
+
+        delete_statement = session.execute.call_args_list[-1].args[0]
+        sql = str(delete_statement.compile(compile_kwargs={"literal_binds": True}))
+        assert "document_segments.id IN ('segment-1')" in sql
+        assert "foreign-segment" not in sql
+        assert f"document_segments.dataset_id = '{dataset.id}'" in sql
+        assert f"document_segments.document_id = '{document.id}'" in sql
+        assert "document_segments.tenant_id = 'tenant-1'" in sql
 
     def test_update_segments_status_enables_only_segments_without_indexing_cache(self):
         session = MagicMock()
@@ -1055,7 +1272,7 @@ class TestSegmentServiceAdditionalRegenerationBranches:
         dataset.embedding_model_provider = None
         refreshed_segment = SimpleNamespace(id=segment.id)
         processing_rule = SimpleNamespace(id=document.dataset_process_rule_id)
-        existing_summary = SimpleNamespace(summary_content="old summary")
+        existing_summary = _summary("old summary")
         embedding_model_instance = object()
 
         with (

--- a/api/tests/unit_tests/services/test_external_dataset_service.py
+++ b/api/tests/unit_tests/services/test_external_dataset_service.py
@@ -12,6 +12,7 @@ from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from sqlalchemy.exc import MultipleResultsFound
 
 from constants import HIDDEN_VALUE
 from models.dataset import Dataset, ExternalKnowledgeApis, ExternalKnowledgeBindings
@@ -22,7 +23,20 @@ from services.entities.external_knowledge_entities.external_knowledge_entities i
 )
 from services.errors.dataset import DatasetNameDuplicateError
 from services.errors.knowledge_retrieval import ExternalKnowledgeRetrievalError
-from services.external_knowledge_service import ExternalDatasetService
+from services.external_knowledge_service import ExternalDatasetService, ResolvedExternalKnowledgeConfig
+
+
+def resolved_external_config(
+    settings: dict[str, Any] | None = None,
+    external_knowledge_id: str = "knowledge-123",
+) -> ResolvedExternalKnowledgeConfig:
+    return ResolvedExternalKnowledgeConfig(
+        settings_json=json.dumps(
+            settings or {"endpoint": "https://api.example.com", "api_key": "test-key-123"},
+            ensure_ascii=False,
+        ),
+        external_knowledge_id=external_knowledge_id,
+    )
 
 
 class ExternalDatasetServiceTestDataFactory:
@@ -1652,13 +1666,6 @@ class TestExternalDatasetServiceFetchRetrieval:
         dataset_id = "dataset-123"
         query = "test query for retrieval"
 
-        binding = factory.create_external_knowledge_binding_mock(
-            dataset_id=dataset_id, external_knowledge_api_id="api-123"
-        )
-        api = factory.create_external_knowledge_api_mock(api_id="api-123")
-
-        mock_db.session.scalar.side_effect = [binding, api]
-
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
@@ -1677,7 +1684,7 @@ class TestExternalDatasetServiceFetchRetrieval:
             dataset_id,
             query,
             external_retrieval_parameters,
-            session=mock_db.session,
+            resolved_config=resolved_external_config(),
         )
 
         # Assert
@@ -1685,18 +1692,51 @@ class TestExternalDatasetServiceFetchRetrieval:
         assert result[0]["content"] == "result 1"
         assert result[1]["score"] == 0.8
 
+    def test_resolve_external_knowledge_config_uses_one_tenant_scoped_query(self):
+        session = MagicMock()
+        session.execute.return_value.one_or_none.return_value = (
+            "knowledge-123",
+            '{"endpoint": "https://api.example.com", "api_key": "secret"}',
+        )
+
+        resolved_config = ExternalDatasetService.resolve_external_knowledge_config(
+            "tenant-123",
+            "dataset-123",
+            session=session,
+        )
+
+        assert resolved_config.external_knowledge_id == "knowledge-123"
+        assert resolved_config.settings_json == '{"endpoint": "https://api.example.com", "api_key": "secret"}'
+        session.execute.assert_called_once()
+        statement = str(session.execute.call_args.args[0])
+        assert "external_knowledge_bindings.tenant_id" in statement
+        assert "external_knowledge_apis.tenant_id" in statement
+
+    def test_resolve_external_knowledge_config_rejects_ambiguous_bindings(self):
+        session = MagicMock()
+        session.execute.return_value.one_or_none.side_effect = MultipleResultsFound()
+
+        with pytest.raises(ExternalKnowledgeRetrievalError, match="multiple external knowledge bindings"):
+            ExternalDatasetService.resolve_external_knowledge_config(
+                "tenant-123",
+                "dataset-123",
+                session=session,
+            )
+
     @patch("services.external_knowledge_service.db")
     def test_fetch_external_knowledge_retrieval_binding_not_found_error(
         self, mock_db, factory: ExternalDatasetServiceTestDataFactory
     ):
         """Test error when external knowledge binding is not found."""
         # Arrange
-        mock_db.session.scalar.return_value = None
+        mock_db.session.execute.return_value.one_or_none.return_value = None
 
         # Act & Assert
         with pytest.raises(ExternalKnowledgeRetrievalError, match="external knowledge binding not found"):
-            ExternalDatasetService.fetch_external_knowledge_retrieval(
-                "tenant-123", "dataset-123", "query", {}, session=mock_db.session
+            ExternalDatasetService.resolve_external_knowledge_config(
+                "tenant-123",
+                "dataset-123",
+                session=mock_db.session,
             )
 
     @patch("services.external_knowledge_service.db")
@@ -1705,13 +1745,14 @@ class TestExternalDatasetServiceFetchRetrieval:
     ):
         """Test error when a binding points to an API template outside the dataset tenant."""
         # Arrange
-        binding = factory.create_external_knowledge_binding_mock()
-        mock_db.session.scalar.side_effect = [binding, None]
+        mock_db.session.execute.return_value.one_or_none.return_value = ("knowledge-123", None)
 
         # Act & Assert
         with pytest.raises(ExternalKnowledgeRetrievalError, match="external api template not found"):
-            ExternalDatasetService.fetch_external_knowledge_retrieval(
-                "tenant-123", "dataset-123", "query", {}, session=mock_db.session
+            ExternalDatasetService.resolve_external_knowledge_config(
+                "tenant-123",
+                "dataset-123",
+                session=mock_db.session,
             )
 
     @patch("services.external_knowledge_service.ExternalDatasetService.process_external_api")
@@ -1721,11 +1762,6 @@ class TestExternalDatasetServiceFetchRetrieval:
     ):
         """Test retrieval with empty results."""
         # Arrange
-        binding = factory.create_external_knowledge_binding_mock()
-        api = factory.create_external_knowledge_api_mock()
-
-        mock_db.session.scalar.side_effect = [binding, api]
-
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {"records": []}
@@ -1737,7 +1773,7 @@ class TestExternalDatasetServiceFetchRetrieval:
             "dataset-123",
             "query",
             {"top_k": 5},
-            session=mock_db.session,
+            resolved_config=resolved_external_config(),
         )
 
         # Assert
@@ -1750,11 +1786,6 @@ class TestExternalDatasetServiceFetchRetrieval:
     ):
         """Test retrieval with score threshold enabled."""
         # Arrange
-        binding = factory.create_external_knowledge_binding_mock()
-        api = factory.create_external_knowledge_api_mock()
-
-        mock_db.session.scalar.side_effect = [binding, api]
-
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {"records": [{"content": "high score result"}]}
@@ -1772,7 +1803,7 @@ class TestExternalDatasetServiceFetchRetrieval:
             "dataset-123",
             "query",
             external_retrieval_parameters,
-            session=mock_db.session,
+            resolved_config=resolved_external_config(),
         )
 
         # Assert
@@ -1788,11 +1819,6 @@ class TestExternalDatasetServiceFetchRetrieval:
     ):
         """Test that non-200 status code raises Exception with response text."""
         # Arrange
-        binding = factory.create_external_knowledge_binding_mock()
-        api = factory.create_external_knowledge_api_mock()
-
-        mock_db.session.scalar.side_effect = [binding, api]
-
         mock_response = MagicMock()
         mock_response.status_code = 500
         mock_response.text = "Internal Server Error: Database connection failed"
@@ -1805,7 +1831,7 @@ class TestExternalDatasetServiceFetchRetrieval:
                 "dataset-123",
                 "query",
                 {"top_k": 5},
-                session=mock_db.session,
+                resolved_config=resolved_external_config(),
             )
 
     @pytest.mark.parametrize(
@@ -1831,13 +1857,6 @@ class TestExternalDatasetServiceFetchRetrieval:
         tenant_id = "tenant-123"
         dataset_id = "dataset-123"
 
-        binding = factory.create_external_knowledge_binding_mock(
-            dataset_id=dataset_id, external_knowledge_api_id="api-123"
-        )
-        api = factory.create_external_knowledge_api_mock(api_id="api-123")
-
-        mock_db.session.scalar.side_effect = [binding, api]
-
         mock_response = MagicMock()
         mock_response.status_code = status_code
         mock_response.text = error_message
@@ -1846,7 +1865,11 @@ class TestExternalDatasetServiceFetchRetrieval:
         # Act & Assert
         with pytest.raises(ExternalKnowledgeRetrievalError, match=re.escape(error_message)):
             ExternalDatasetService.fetch_external_knowledge_retrieval(
-                tenant_id, dataset_id, "query", {"top_k": 5}, session=mock_db.session
+                tenant_id,
+                dataset_id,
+                "query",
+                {"top_k": 5},
+                resolved_config=resolved_external_config(),
             )
 
     @patch("services.external_knowledge_service.ExternalDatasetService.process_external_api")
@@ -1856,11 +1879,6 @@ class TestExternalDatasetServiceFetchRetrieval:
     ):
         """Test exception with empty response text."""
         # Arrange
-        binding = factory.create_external_knowledge_binding_mock()
-        api = factory.create_external_knowledge_api_mock()
-
-        mock_db.session.scalar.side_effect = [binding, api]
-
         mock_response = MagicMock()
         mock_response.status_code = 503
         mock_response.text = ""
@@ -1873,18 +1891,13 @@ class TestExternalDatasetServiceFetchRetrieval:
                 "dataset-123",
                 "query",
                 {"top_k": 5},
-                session=mock_db.session,
+                resolved_config=resolved_external_config(),
             )
 
     @patch("services.external_knowledge_service.ExternalDatasetService.process_external_api")
     @patch("services.external_knowledge_service.db")
     def test_fetch_external_knowledge_retrieval_invalid_json_response(self, mock_db, mock_process, factory):
         """Test malformed JSON success responses are normalized to external retrieval errors."""
-        binding = factory.create_external_knowledge_binding_mock()
-        api = factory.create_external_knowledge_api_mock()
-
-        mock_db.session.scalar.side_effect = [binding, api]
-
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.side_effect = json.JSONDecodeError("Expecting value", "", 0)
@@ -1896,18 +1909,13 @@ class TestExternalDatasetServiceFetchRetrieval:
                 "dataset-123",
                 "query",
                 {"top_k": 5},
-                session=mock_db.session,
+                resolved_config=resolved_external_config(),
             )
 
     @patch("services.external_knowledge_service.ExternalDatasetService.process_external_api")
     @patch("services.external_knowledge_service.db")
     def test_fetch_external_knowledge_retrieval_invalid_success_payload_shape(self, mock_db, mock_process, factory):
         """Test malformed success payload shapes are normalized to external retrieval errors."""
-        binding = factory.create_external_knowledge_binding_mock()
-        api = factory.create_external_knowledge_api_mock()
-
-        mock_db.session.scalar.side_effect = [binding, api]
-
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = ["not-a-dict"]
@@ -1919,18 +1927,13 @@ class TestExternalDatasetServiceFetchRetrieval:
                 "dataset-123",
                 "query",
                 {"top_k": 5},
-                session=mock_db.session,
+                resolved_config=resolved_external_config(),
             )
 
     @patch("services.external_knowledge_service.ExternalDatasetService.process_external_api")
     @patch("services.external_knowledge_service.db")
     def test_fetch_external_knowledge_retrieval_invalid_records_shape(self, mock_db, mock_process, factory):
         """Test non-list records payloads are normalized to external retrieval errors."""
-        binding = factory.create_external_knowledge_binding_mock()
-        api = factory.create_external_knowledge_api_mock()
-
-        mock_db.session.scalar.side_effect = [binding, api]
-
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {"records": {"unexpected": "shape"}}
@@ -1942,17 +1945,13 @@ class TestExternalDatasetServiceFetchRetrieval:
                 "dataset-123",
                 "query",
                 {"top_k": 5},
-                session=mock_db.session,
+                resolved_config=resolved_external_config(),
             )
 
     @patch("services.external_knowledge_service.ExternalDatasetService.process_external_api")
     @patch("services.external_knowledge_service.db")
     def test_fetch_external_knowledge_retrieval_wraps_transport_errors(self, mock_db, mock_process, factory):
         """Test transport/runtime failures are normalized to external retrieval errors."""
-        binding = factory.create_external_knowledge_binding_mock()
-        api = factory.create_external_knowledge_api_mock()
-
-        mock_db.session.scalar.side_effect = [binding, api]
         mock_process.side_effect = RuntimeError("connection reset by peer")
 
         with pytest.raises(ExternalKnowledgeRetrievalError, match="connection reset by peer"):
@@ -1961,5 +1960,5 @@ class TestExternalDatasetServiceFetchRetrieval:
                 "dataset-123",
                 "query",
                 {"top_k": 5},
-                session=mock_db.session,
+                resolved_config=resolved_external_config(),
             )

--- a/api/tests/unit_tests/services/test_knowledge_retrieval_inner_service.py
+++ b/api/tests/unit_tests/services/test_knowledge_retrieval_inner_service.py
@@ -175,7 +175,7 @@ class TestInnerKnowledgeRetrievalService:
         assert response.results[0].title == "FAQ.md"
         assert response.usage.currency == "USD"
         assert rag.knowledge_retrieval.call_args.kwargs["session"] is sqlite_session
-        assert sqlite_session.in_transaction()
+        assert not sqlite_session.in_transaction()
 
     @pytest.mark.parametrize("sqlite_session", [(App, Dataset)], indirect=True)
     @patch("services.knowledge_retrieval_inner_service.DatasetRetrieval")
@@ -233,7 +233,7 @@ class TestInnerKnowledgeRetrievalService:
         assert rag_request.metadata_filtering_mode == "automatic"
         assert rag_request.metadata_model_config is not None
         assert rag_request.metadata_model_config.provider == "openai"
-        assert sqlite_session.in_transaction()
+        assert not sqlite_session.in_transaction()
 
     @pytest.mark.parametrize("sqlite_session", [(App, Dataset)], indirect=True)
     def test_retrieve_raises_when_app_missing(self, sqlite_session: Session):

--- a/api/tests/unit_tests/services/test_summary_index_service.py
+++ b/api/tests/unit_tests/services/test_summary_index_service.py
@@ -5,20 +5,20 @@ from __future__ import annotations
 import logging
 import sys
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from typing import cast
+from unittest.mock import ANY, MagicMock, call
 
 import pytest
-from sqlalchemy import create_engine, select
-from sqlalchemy.exc import SAWarning
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy import Table, create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
 
 import services.summary_index_service as summary_module
 from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
-from models.dataset import DocumentSegmentSummary
-from models.enums import SegmentStatus, SummaryStatus
-from services.summary_index_service import SummaryIndexService
+from models.dataset import Dataset, DocumentSegment, DocumentSegmentSummary
+from models.enums import DataSourceType, SegmentStatus, SummaryStatus
+from services.summary_index_service import SummaryGenerationClaim, SummaryIndexService
 
 
 @dataclass(frozen=True)
@@ -39,6 +39,8 @@ def _dataset(*, indexing_technique: str = IndexTechniqueType.HIGH_QUALITY) -> Ma
     dataset.indexing_technique = indexing_technique
     dataset.embedding_model_provider = "openai"
     dataset.embedding_model = "text-embedding"
+    dataset.index_struct = '{"type":"weaviate","vector_store":{"class_prefix":"dataset-1"}}'
+    dataset.collection_binding_id = None
     return dataset
 
 
@@ -56,10 +58,8 @@ def _segment(*, has_document: bool = True) -> MagicMock:
         doc.doc_language = "en"
         doc.doc_form = IndexStructureType.PARAGRAPH_INDEX
         segment.document = doc
-        segment.get_document.return_value = doc
     else:
         segment.document = None
-        segment.get_document.return_value = None
     return segment
 
 
@@ -77,10 +77,501 @@ def _summary_record(*, summary_content: str = "summary", node_id: str | None = N
     record.error = None
     record.enabled = True
     record.created_at = datetime(2024, 1, 1, tzinfo=UTC)
-    record.updated_at = datetime(2024, 1, 1, tzinfo=UTC)
+    record.updated_at = datetime.now(UTC)
     record.disabled_at = None
     record.disabled_by = None
     return record
+
+
+def _concrete_dataset(*, indexing_technique: str = IndexTechniqueType.HIGH_QUALITY) -> Dataset:
+    return Dataset(
+        id="dataset-1",
+        tenant_id="tenant-1",
+        name="dataset",
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        indexing_technique=indexing_technique,
+        created_by="user-1",
+        embedding_model_provider="openai",
+        embedding_model="text-embedding",
+    )
+
+
+def _concrete_segment() -> DocumentSegment:
+    segment = DocumentSegment(
+        tenant_id="tenant-1",
+        dataset_id="dataset-1",
+        document_id="doc-1",
+        position=1,
+        content="manual segment content",
+        word_count=3,
+        tokens=3,
+        created_by="user-1",
+        status=SegmentStatus.COMPLETED,
+    )
+    segment.id = "seg-1"
+    return segment
+
+
+def _concrete_summary_record(*, summary_content: str = "summary") -> DocumentSegmentSummary:
+    summary = DocumentSegmentSummary(
+        dataset_id="dataset-1",
+        document_id="doc-1",
+        chunk_id="seg-1",
+        summary_content=summary_content,
+        status=SummaryStatus.GENERATING,
+        enabled=True,
+    )
+    summary.id = "sum-1"
+    return summary
+
+
+def test_delete_unreferenced_summary_vectors_preserves_current_pointer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = _concrete_dataset()
+    session = MagicMock()
+    session.get.return_value = dataset
+    session.scalars.return_value.all.return_value = ["current-node"]
+    vector_class = MagicMock()
+    monkeypatch.setattr(summary_module, "Vector", vector_class)
+    monkeypatch.setattr(
+        summary_module.session_factory,
+        "create_session",
+        MagicMock(return_value=_SessionContext(session)),
+    )
+
+    summary_module.delete_unreferenced_summary_vectors(dataset.id, ["current-node"])
+
+    vector_class.assert_not_called()
+
+
+def test_delete_unreferenced_summary_vectors_deduplicates_deletable_nodes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = _concrete_dataset()
+    session = MagicMock()
+    session.get.return_value = dataset
+    session.scalars.return_value.all.return_value = []
+    vector = MagicMock()
+    monkeypatch.setattr(summary_module, "Vector", MagicMock(return_value=vector))
+    monkeypatch.setattr(
+        summary_module.session_factory,
+        "create_session",
+        MagicMock(return_value=_SessionContext(session)),
+    )
+
+    summary_module.delete_unreferenced_summary_vectors(dataset.id, ["old-node", "", "old-node"])
+
+    vector.delete_by_ids.assert_called_once_with(["old-node"])
+
+
+def test_delete_unreferenced_summary_vectors_batches_queries_and_deletes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = _concrete_dataset()
+    session = MagicMock()
+    session.get.return_value = dataset
+    first_scalar_result = MagicMock()
+    first_scalar_result.all.return_value = []
+    second_scalar_result = MagicMock()
+    second_scalar_result.all.return_value = []
+    session.scalars.side_effect = [first_scalar_result, second_scalar_result]
+    vector = MagicMock()
+    monkeypatch.setattr(summary_module, "_SUMMARY_VECTOR_CLEANUP_BATCH_SIZE", 2)
+    monkeypatch.setattr(summary_module, "Vector", MagicMock(return_value=vector))
+    monkeypatch.setattr(
+        summary_module.session_factory,
+        "create_session",
+        MagicMock(return_value=_SessionContext(session)),
+    )
+
+    summary_module.delete_unreferenced_summary_vectors(dataset.id, ["node-1", "node-2", "node-3"])
+
+    assert session.scalars.call_count == 2
+    assert vector.delete_by_ids.call_args_list == [
+        call(["node-1", "node-2"]),
+        call(["node-3"]),
+    ]
+
+
+def test_delete_unreferenced_summary_vectors_is_best_effort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = _concrete_dataset()
+    session = MagicMock()
+    session.get.return_value = dataset
+    session.scalars.return_value.all.return_value = []
+    vector = MagicMock()
+    vector.delete_by_ids.side_effect = ConnectionError("unavailable")
+    monkeypatch.setattr(summary_module, "Vector", MagicMock(return_value=vector))
+    monkeypatch.setattr(
+        summary_module.session_factory,
+        "create_session",
+        MagicMock(return_value=_SessionContext(session)),
+    )
+
+    summary_module.delete_unreferenced_summary_vectors(dataset.id, ["old-node"])
+
+    vector.delete_by_ids.assert_called_once_with(["old-node"])
+
+
+class _CommitTrackingSession:
+    expire_on_commit: bool
+    commit_expire_on_commit_values: list[bool]
+
+    def __init__(self) -> None:
+        self.expire_on_commit = True
+        self.commit_expire_on_commit_values = []
+
+    def scalar(self, _stmt: object) -> str:
+        return IndexStructureType.PARAGRAPH_INDEX
+
+    def commit(self) -> None:
+        self.commit_expire_on_commit_values.append(self.expire_on_commit)
+
+
+class _ScopedCommitTrackingSession:
+    current_session: _CommitTrackingSession
+
+    def __init__(self) -> None:
+        self.current_session = _CommitTrackingSession()
+
+    def __call__(self) -> _CommitTrackingSession:
+        return self.current_session
+
+    def scalar(self, stmt: object) -> str:
+        return self.current_session.scalar(stmt)
+
+    def commit(self) -> None:
+        self.current_session.commit()
+
+
+def _generation_claim(
+    *,
+    generation_token: str = "generation-1",
+    source_content: str = "hello world",
+) -> SummaryGenerationClaim:
+    return SummaryGenerationClaim(
+        dataset_id="dataset-1",
+        segment_id="seg-1",
+        summary_record_id="sum-1",
+        generation_token=generation_token,
+        source_content_hash=summary_module.helper.generate_text_hash(source_content),
+    )
+
+
+def _claim_summary(
+    summary: DocumentSegmentSummary,
+    segment: DocumentSegment,
+    *,
+    generation_token: str = "generation-1",
+) -> SummaryGenerationClaim:
+    previous_error = summary.error
+    had_active_publication = SummaryIndexService._summary_has_active_publication(summary)
+    if not had_active_publication:
+        summary.status = SummaryStatus.GENERATING
+    summary.error = SummaryIndexService._generation_claim_marker(generation_token)
+    return SummaryGenerationClaim(
+        dataset_id=summary.dataset_id,
+        segment_id=summary.chunk_id,
+        summary_record_id=summary.id,
+        generation_token=generation_token,
+        source_content_hash=summary_module.helper.generate_text_hash(segment.content),
+        expected_summary_content=summary.summary_content,
+        expected_status=summary.status,
+        expected_node_id=summary.summary_index_node_id,
+        expected_enabled=summary.enabled,
+        previous_error=previous_error,
+        had_active_publication=had_active_publication,
+    )
+
+
+def test_mark_generation_preserves_active_publication(monkeypatch: pytest.MonkeyPatch) -> None:
+    dataset = _concrete_dataset()
+    segment = _concrete_segment()
+    summary = _concrete_summary_record(summary_content="active summary")
+    summary.status = SummaryStatus.COMPLETED
+    summary.summary_index_node_id = "active-node"
+    summary.summary_index_node_hash = "active-hash"
+    session = MagicMock()
+
+    monkeypatch.setattr(
+        summary_module.session_factory,
+        "create_session",
+        MagicMock(return_value=_SessionContext(session)),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+    monkeypatch.setattr(SummaryIndexService, "_segment_allows_summary", MagicMock(return_value=True))
+    monkeypatch.setattr(SummaryIndexService, "_get_segment_content", MagicMock(return_value=segment.content))
+    monkeypatch.setattr(SummaryIndexService, "_get_summary_record", MagicMock(return_value=summary))
+
+    claim = SummaryIndexService._mark_summary_generation_started(segment, dataset)
+
+    assert summary.status == SummaryStatus.COMPLETED
+    assert summary.summary_content == "active summary"
+    assert summary.summary_index_node_id == "active-node"
+    assert summary.error == SummaryIndexService._generation_claim_marker(claim.generation_token)
+    assert SummaryIndexService._effective_summary_status(summary) == SummaryStatus.GENERATING
+    session.commit.assert_called_once_with()
+
+
+def test_mark_generation_discards_and_cleans_superseded_claim(monkeypatch: pytest.MonkeyPatch) -> None:
+    dataset = _concrete_dataset()
+    segment = _concrete_segment()
+    summary = _concrete_summary_record(summary_content="active summary")
+    summary.status = SummaryStatus.COMPLETED
+    summary.summary_index_node_id = "active-node"
+    summary.error = SummaryIndexService._generation_claim_marker("superseded-token")
+    session = MagicMock()
+    cleanup = MagicMock()
+
+    monkeypatch.setattr(
+        summary_module.session_factory,
+        "create_session",
+        MagicMock(return_value=_SessionContext(session)),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+    monkeypatch.setattr(SummaryIndexService, "_segment_allows_summary", MagicMock(return_value=True))
+    monkeypatch.setattr(SummaryIndexService, "_get_segment_content", MagicMock(return_value=segment.content))
+    monkeypatch.setattr(SummaryIndexService, "_get_summary_record", MagicMock(return_value=summary))
+    monkeypatch.setattr(summary_module, "delete_unreferenced_summary_vectors", cleanup)
+
+    claim = SummaryIndexService._mark_summary_generation_started(segment, dataset)
+
+    assert claim.previous_error is None
+    assert summary.error == SummaryIndexService._generation_claim_marker(claim.generation_token)
+    cleanup.assert_called_once_with(dataset.id, ["superseded-token"])
+
+
+def test_stale_completed_claim_reports_completed_publication() -> None:
+    summary = _concrete_summary_record(summary_content="active summary")
+    summary.status = SummaryStatus.COMPLETED
+    summary.summary_index_node_id = "active-node"
+    summary.error = SummaryIndexService._generation_claim_marker("abandoned-token")
+    summary.updated_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=2)
+
+    assert SummaryIndexService._effective_summary_status(summary) == SummaryStatus.COMPLETED
+
+
+def test_recover_stale_generation_claim_restores_publication_and_cleans_vector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = _concrete_dataset()
+    summary = _concrete_summary_record(summary_content="active summary")
+    summary.status = SummaryStatus.COMPLETED
+    summary.summary_index_node_id = "active-node"
+    summary.error = SummaryIndexService._generation_claim_marker("abandoned-node")
+    summary.updated_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=2)
+    session = MagicMock()
+    session.scalars.return_value.all.return_value = [summary]
+    cleanup = MagicMock()
+
+    monkeypatch.setattr(
+        summary_module.session_factory,
+        "create_session",
+        MagicMock(return_value=_SessionContext(session)),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+    monkeypatch.setattr(summary_module, "delete_unreferenced_summary_vectors", cleanup)
+
+    SummaryIndexService._recover_stale_generation_claims(dataset.id, [summary])
+
+    assert summary.status == SummaryStatus.COMPLETED
+    assert summary.error is None
+    session.commit.assert_called_once_with()
+    cleanup.assert_called_once_with(dataset.id, ["abandoned-node"])
+
+
+def test_save_claim_stages_content_without_mutating_active_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    dataset = _concrete_dataset()
+    segment = _concrete_segment()
+    active_summary = _concrete_summary_record(summary_content="active summary")
+    active_summary.status = SummaryStatus.COMPLETED
+    active_summary.summary_index_node_id = "active-node"
+    active_summary.summary_index_node_hash = "active-hash"
+    claim = _claim_summary(active_summary, segment)
+    session = MagicMock()
+    session.get.return_value = active_summary
+
+    monkeypatch.setattr(
+        summary_module.session_factory,
+        "create_session",
+        MagicMock(return_value=_SessionContext(session)),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+    monkeypatch.setattr(SummaryIndexService, "_segment_allows_summary", MagicMock(return_value=True))
+    monkeypatch.setattr(SummaryIndexService, "_get_segment_content", MagicMock(return_value=segment.content))
+
+    staged_summary = SummaryIndexService._save_summary_content(
+        segment,
+        dataset,
+        "replacement summary",
+        generation_claim=claim,
+    )
+
+    assert staged_summary is not active_summary
+    assert staged_summary.summary_content == "replacement summary"
+    assert staged_summary.summary_index_node_id == "active-node"
+    assert active_summary.summary_content == "active summary"
+    assert active_summary.status == SummaryStatus.COMPLETED
+    assert active_summary.summary_index_node_id == "active-node"
+    session.commit.assert_not_called()
+
+
+def test_claimed_error_restores_active_publication(monkeypatch: pytest.MonkeyPatch) -> None:
+    dataset = _concrete_dataset()
+    segment = _concrete_segment()
+    active_summary = _concrete_summary_record(summary_content="active summary")
+    active_summary.status = SummaryStatus.COMPLETED
+    active_summary.summary_index_node_id = "active-node"
+    active_summary.summary_index_node_hash = "active-hash"
+    claim = _claim_summary(active_summary, segment)
+    session = MagicMock()
+
+    monkeypatch.setattr(
+        summary_module.session_factory,
+        "create_session",
+        MagicMock(return_value=_SessionContext(session)),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+    monkeypatch.setattr(SummaryIndexService, "_get_summary_record", MagicMock(return_value=active_summary))
+    monkeypatch.setattr(SummaryIndexService, "_get_segment_content", MagicMock(return_value=segment.content))
+
+    SummaryIndexService.update_summary_record_error(
+        segment,
+        dataset,
+        "replacement failed",
+        generation_claim=claim,
+    )
+
+    assert active_summary.status == SummaryStatus.COMPLETED
+    assert active_summary.error is None
+    assert active_summary.summary_content == "active summary"
+    assert active_summary.summary_index_node_id == "active-node"
+    session.commit.assert_called_once_with()
+
+
+def test_claimed_error_releases_active_publication_after_source_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    dataset = _concrete_dataset()
+    segment = _concrete_segment()
+    active_summary = _concrete_summary_record(summary_content="active summary")
+    active_summary.status = SummaryStatus.COMPLETED
+    active_summary.summary_index_node_id = "active-node"
+    active_summary.summary_index_node_hash = "active-hash"
+    claim = _claim_summary(active_summary, segment)
+    session = MagicMock()
+
+    monkeypatch.setattr(
+        summary_module.session_factory,
+        "create_session",
+        MagicMock(return_value=_SessionContext(session)),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+    monkeypatch.setattr(SummaryIndexService, "_get_summary_record", MagicMock(return_value=active_summary))
+    monkeypatch.setattr(SummaryIndexService, "_get_segment_content", MagicMock(return_value="changed source"))
+
+    SummaryIndexService.update_summary_record_error(
+        segment,
+        dataset,
+        "provider failed",
+        generation_claim=claim,
+    )
+
+    assert active_summary.status == SummaryStatus.COMPLETED
+    assert active_summary.error is None
+    assert active_summary.summary_content == "active summary"
+    assert active_summary.summary_index_node_id == "active-node"
+    session.commit.assert_called_once_with()
+
+
+def test_batch_create_summary_records_preserves_active_publication(monkeypatch: pytest.MonkeyPatch) -> None:
+    dataset = _concrete_dataset()
+    segment = _concrete_segment()
+    summary = _concrete_summary_record(summary_content="active summary")
+    summary.status = SummaryStatus.COMPLETED
+    summary.summary_index_node_id = "active-node"
+    summary.summary_index_node_hash = "active-hash"
+    session = MagicMock()
+    allowed_ids_result = MagicMock()
+    allowed_ids_result.all.return_value = [segment.id]
+    existing_summaries_result = MagicMock()
+    existing_summaries_result.all.return_value = [summary]
+    session.scalars.side_effect = [allowed_ids_result, existing_summaries_result]
+
+    monkeypatch.setattr(
+        summary_module.session_factory,
+        "create_session",
+        MagicMock(return_value=_SessionContext(session)),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+
+    SummaryIndexService.batch_create_summary_records([segment], dataset, status=SummaryStatus.NOT_STARTED)
+
+    assert summary.status == SummaryStatus.COMPLETED
+    assert summary.summary_content == "active summary"
+    assert summary.summary_index_node_id == "active-node"
+    session.commit.assert_called_once_with()
+
+
+def test_generate_conflict_abandons_owned_claim(monkeypatch: pytest.MonkeyPatch) -> None:
+    dataset = _concrete_dataset()
+    segment = _concrete_segment()
+    claim = _generation_claim()
+    staged_summary = _concrete_summary_record(summary_content="replacement")
+    conflict = summary_module.SummaryIndexConflictError("dataset configuration changed")
+    abandon_claim = MagicMock()
+
+    monkeypatch.setattr(SummaryIndexService, "_mark_summary_generation_started", MagicMock(return_value=claim))
+    monkeypatch.setattr(
+        SummaryIndexService,
+        "generate_summary_for_segment",
+        MagicMock(return_value=("replacement", MagicMock(total_tokens=0))),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_save_summary_content", MagicMock(return_value=staged_summary))
+    monkeypatch.setattr(SummaryIndexService, "vectorize_summary", MagicMock(side_effect=conflict))
+    monkeypatch.setattr(SummaryIndexService, "_abandon_generation_claim", abandon_claim, raising=False)
+
+    with pytest.raises(summary_module.SummaryIndexConflictError, match="dataset configuration changed"):
+        SummaryIndexService.generate_and_vectorize_summary(segment, dataset, {"enable": True})
+
+    abandon_claim.assert_called_once_with(claim)
+
+
+def test_claimed_vector_uses_recoverable_generation_token_as_node_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    dataset = _concrete_dataset()
+    segment = _concrete_segment()
+    active_summary = _concrete_summary_record(summary_content="active summary")
+    active_summary.status = SummaryStatus.COMPLETED
+    active_summary.summary_index_node_id = "active-node"
+    claim = _claim_summary(active_summary, segment, generation_token="recoverable-node")
+    staged_summary = _concrete_summary_record(summary_content="replacement summary")
+    staged_summary.summary_index_node_id = "active-node"
+    vector = MagicMock()
+    publications: list[summary_module._SummaryVectorPublication] = []
+
+    monkeypatch.setattr(summary_module, "Vector", MagicMock(return_value=vector))
+    monkeypatch.setattr(summary_module, "delete_unreferenced_summary_vectors", MagicMock())
+    monkeypatch.setattr(SummaryIndexService, "_embedding_token_count", MagicMock(return_value=0))
+
+    def publish(publication: summary_module._SummaryVectorPublication) -> datetime:
+        publications.append(publication)
+        return datetime.now(UTC).replace(tzinfo=None)
+
+    monkeypatch.setattr(SummaryIndexService, "_publish_summary_vector", publish)
+
+    SummaryIndexService.vectorize_summary(
+        staged_summary,
+        segment,
+        dataset,
+        generation_claim=claim,
+    )
+
+    assert publications[0].new_node_id == claim.generation_token
+    assert vector.add_texts.call_args.args[0][0].metadata["doc_id"] == claim.generation_token
+
+
+def _allow_current_publication_dataset(monkeypatch: pytest.MonkeyPatch, dataset: Dataset | MagicMock) -> None:
+    monkeypatch.setattr(SummaryIndexService, "_get_publication_dataset", MagicMock(return_value=dataset))
 
 
 def test_generate_summary_for_segment_passes_document_language(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -100,17 +591,21 @@ def test_generate_summary_for_segment_passes_document_language(monkeypatch: pyte
 
     segment = _segment(has_document=True)
     dataset = _dataset()
-    session = MagicMock()
+    language_session = MagicMock()
+    language_session.scalar.return_value = "en"
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(language_session))),
+    )
 
-    content, got_usage = SummaryIndexService.generate_summary_for_segment(segment, dataset, {"a": 1}, session=session)
+    content, got_usage = SummaryIndexService.generate_summary_for_segment(segment, dataset, {"enable": True})
     assert content == "sum"
     assert got_usage is usage
 
     paragraph_module.ParagraphIndexProcessor.generate_summary.assert_called_once()
     _, kwargs = paragraph_module.ParagraphIndexProcessor.generate_summary.call_args
     assert kwargs["document_language"] == "en"
-    assert kwargs["session"] is session
-    segment.get_document.assert_called_once_with(session=session)
 
 
 def test_generate_summary_for_segment_raises_when_empty(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -122,12 +617,19 @@ def test_generate_summary_for_segment_raises_when_empty(monkeypatch: pytest.Monk
         "core.rag.index_processor.processor.paragraph_index_processor",
         paragraph_module,
     )
+    language_session = MagicMock()
+    language_session.scalar.return_value = None
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(language_session))),
+    )
 
     with pytest.raises(ValueError, match="Generated summary is empty"):
-        SummaryIndexService.generate_summary_for_segment(_segment(), _dataset(), {"a": 1}, session=MagicMock())
+        SummaryIndexService.generate_summary_for_segment(_segment(), _dataset(), {"enable": True})
 
 
-def test_create_summary_record_updates_existing_and_reenables() -> None:
+def test_create_summary_record_updates_existing_and_reenables(monkeypatch: pytest.MonkeyPatch) -> None:
     existing = _summary_record(summary_content="old", node_id="n1")
     existing.enabled = False
     existing.disabled_at = datetime(2024, 1, 1)
@@ -135,37 +637,146 @@ def test_create_summary_record_updates_existing_and_reenables() -> None:
 
     session = MagicMock(name="session")
     session.scalar.return_value = existing
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
 
     segment = _segment()
     dataset = _dataset()
 
-    result = SummaryIndexService.create_summary_record(
-        segment, dataset, "new", status=SummaryStatus.GENERATING, session=session
-    )
+    result = SummaryIndexService.create_summary_record(segment, dataset, "new", status=SummaryStatus.GENERATING)
     assert result is existing
-    assert existing.summary_content == "new"
-    assert existing.status == SummaryStatus.GENERATING
-    assert existing.enabled is True
-    assert existing.disabled_at is None
-    assert existing.disabled_by is None
-    assert existing.error is None
+    assert result.summary_content == "new"
+    assert result.status == SummaryStatus.GENERATING
+    assert result.enabled
+    assert result.disabled_at is None
+    assert result.disabled_by is None
+    assert result.error is None
     session.add.assert_called_once_with(existing)
-    session.flush.assert_called_once()
+    session.commit.assert_called_once()
 
 
-def test_create_summary_record_creates_new() -> None:
+def test_create_summary_record_creates_new(monkeypatch: pytest.MonkeyPatch) -> None:
     session = MagicMock(name="session")
     session.scalar.return_value = None
-
-    record = SummaryIndexService.create_summary_record(
-        _segment(), _dataset(), "new", status=SummaryStatus.GENERATING, session=session
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
     )
+
+    record = SummaryIndexService.create_summary_record(_segment(), _dataset(), "new", status=SummaryStatus.GENERATING)
     assert record.dataset_id == "dataset-1"
     assert record.chunk_id == "seg-1"
     assert record.summary_content == "new"
     assert record.enabled is True
     session.add.assert_called_once()
-    session.flush.assert_called_once()
+    session.commit.assert_called_once()
+
+
+def test_save_summary_content_does_not_replace_missing_claimed_record(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = MagicMock()
+    session.get.return_value = None
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
+
+    with pytest.raises(summary_module.SummaryIndexConflictError, match="was deleted"):
+        SummaryIndexService._save_summary_content(
+            _segment(),
+            _dataset(),
+            "summary",
+            generation_claim=SummaryGenerationClaim(
+                dataset_id="dataset-1",
+                segment_id="seg-1",
+                summary_record_id="missing-summary",
+                generation_token="generation-1",
+                source_content_hash=summary_module.helper.generate_text_hash("hello world"),
+            ),
+        )
+
+    session.add.assert_not_called()
+    session.commit.assert_not_called()
+
+
+def test_save_summary_content_rejects_superseded_generation_claim(monkeypatch: pytest.MonkeyPatch) -> None:
+    record = _summary_record(summary_content="manual")
+    record.error = SummaryIndexService._generation_claim_marker("generation-2")
+    session = MagicMock()
+    session.get.return_value = record
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
+
+    with pytest.raises(summary_module.SummaryIndexConflictError, match="generation was superseded"):
+        SummaryIndexService._save_summary_content(
+            _segment(),
+            _dataset(),
+            "stale generated summary",
+            generation_claim=_generation_claim(),
+        )
+
+    assert record.summary_content == "manual"
+    session.add.assert_not_called()
+    session.commit.assert_not_called()
+
+
+def test_save_summary_content_rejects_changed_source_segment(monkeypatch: pytest.MonkeyPatch) -> None:
+    record = _summary_record(summary_content="old")
+    record.error = SummaryIndexService._generation_claim_marker("generation-1")
+    session = MagicMock()
+    session.get.return_value = record
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_get_segment_content", MagicMock(return_value="edited content"))
+
+    with pytest.raises(summary_module.SummaryIndexConflictError, match="generation was superseded"):
+        SummaryIndexService._save_summary_content(
+            _segment(),
+            _dataset(),
+            "stale generated summary",
+            generation_claim=_generation_claim(),
+        )
+
+    assert record.summary_content == "old"
+    session.add.assert_not_called()
+    session.commit.assert_not_called()
+
+
+def test_save_summary_content_rejects_claim_for_another_segment(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = MagicMock()
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
+
+    with pytest.raises(summary_module.SummaryIndexConflictError, match="does not match the target segment"):
+        SummaryIndexService._save_summary_content(
+            _segment(),
+            _dataset(),
+            "generated summary",
+            generation_claim=SummaryGenerationClaim(
+                dataset_id="dataset-1",
+                segment_id="another-segment",
+                summary_record_id="sum-1",
+                generation_token="generation-1",
+                source_content_hash=summary_module.helper.generate_text_hash("hello world"),
+            ),
+        )
+
+    session.get.assert_not_called()
+    session.add.assert_not_called()
+    session.commit.assert_not_called()
 
 
 def test_vectorize_summary_skips_non_high_quality(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -183,6 +794,7 @@ def test_vectorize_summary_raises_for_blank_content() -> None:
 
 def test_vectorize_summary_retries_connection_errors_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
     dataset = _dataset()
+    _allow_current_publication_dataset(monkeypatch, dataset)
     segment = _segment()
     summary = _summary_record(summary_content="sum", node_id=None)
 
@@ -201,59 +813,424 @@ def test_vectorize_summary_retries_connection_errors_then_succeeds(monkeypatch: 
 
     session = MagicMock(name="provided_session")
     merged = _summary_record(summary_content="sum")
-    session.merge.return_value = merged
+    final_session = MagicMock()
+    final_session.scalar.return_value = merged
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(final_session))),
+    )
     monkeypatch.setattr(summary_module.time, "sleep", MagicMock())
 
     SummaryIndexService.vectorize_summary(summary, segment, dataset, session=session)
 
     assert vector_instance.add_texts.call_count == 2
     summary_module.time.sleep.assert_called_once()  # type: ignore[attr-defined]
-    session.flush.assert_called_once()
+    session.commit.assert_called_once()
+    final_session.commit.assert_called_once()
     assert summary.status == SummaryStatus.COMPLETED
     assert summary.summary_index_node_id == "uuid-1"
     assert summary.summary_index_node_hash == "hash-1"
     assert summary.tokens == 5
 
 
-def test_vectorize_summary_without_session_creates_record_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_vectorize_summary_publishes_before_retiring_old_vector(monkeypatch: pytest.MonkeyPatch) -> None:
     dataset = _dataset()
+    _allow_current_publication_dataset(monkeypatch, dataset)
+    segment = _segment()
+    summary = _summary_record(summary_content="sum", node_id="old-node")
+    stored_summary = _summary_record(summary_content="sum", node_id="old-node")
+    events: list[str] = []
+
+    monkeypatch.setattr(summary_module.uuid, "uuid4", MagicMock(return_value="uuid-1"))
+    monkeypatch.setattr(summary_module.helper, "generate_text_hash", MagicMock(return_value="hash-1"))
+    monkeypatch.setattr(
+        summary_module.ModelManager,
+        "for_tenant",
+        MagicMock(return_value=MagicMock(get_model_instance=MagicMock(return_value=None))),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+    monkeypatch.setattr(SummaryIndexService, "_segment_allows_summary", MagicMock(return_value=True))
+
+    vector = MagicMock()
+    vector.add_texts.side_effect = lambda *_args, **_kwargs: events.append("add")
+    monkeypatch.setattr(summary_module, "Vector", MagicMock(return_value=vector))
+    cleanup = MagicMock(side_effect=lambda *_args: events.append("cleanup"))
+    monkeypatch.setattr(summary_module, "delete_unreferenced_summary_vectors", cleanup)
+
+    session = MagicMock()
+    session.scalar.return_value = stored_summary
+    session.commit.side_effect = lambda: events.append("commit")
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
+
+    SummaryIndexService.vectorize_summary(summary, segment, dataset)
+
+    assert events == ["add", "commit", "cleanup"]
+    assert stored_summary.summary_index_node_id == "uuid-1"
+    cleanup.assert_called_once_with(dataset.id, ["old-node"])
+
+
+def test_publish_summary_vector_rejects_changed_dataset_embedding_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stored_summary = _summary_record(summary_content="sum", node_id="old-node")
+    publication = summary_module._SummaryVectorPublication(
+        dataset_id="dataset-1",
+        segment_id="seg-1",
+        segment_content="hello world",
+        summary_record_id="sum-1",
+        summary_content="sum",
+        old_node_id="old-node",
+        new_node_id="new-node",
+        summary_hash="hash-1",
+        expected_enabled=True,
+        expected_error=None,
+        expected_generation_token=None,
+        embedding_tokens=3,
+        expected_dataset_state=SummaryIndexService._summary_vector_dataset_state(_dataset()),
+    )
+    current_dataset = _dataset()
+    current_dataset.embedding_model = "new-embedding-model"
+    session = MagicMock()
+    session.get.return_value = current_dataset
+    session.scalar.return_value = stored_summary
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+    monkeypatch.setattr(SummaryIndexService, "_segment_allows_summary", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
+
+    with pytest.raises(summary_module.SummaryIndexConflictError, match="dataset configuration changed"):
+        SummaryIndexService._publish_summary_vector(publication)
+
+    session.commit.assert_not_called()
+    assert stored_summary.summary_index_node_id == "old-node"
+
+
+def test_publish_summary_vector_rejects_expired_generation_claim(monkeypatch: pytest.MonkeyPatch) -> None:
+    stored_summary = _summary_record(summary_content="active summary", node_id="old-node")
+    stored_summary.status = SummaryStatus.COMPLETED
+    stored_summary.error = SummaryIndexService._generation_claim_marker("expired-node")
+    stored_summary.updated_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=2)
+    publication = summary_module._SummaryVectorPublication(
+        dataset_id="dataset-1",
+        segment_id="seg-1",
+        segment_content="hello world",
+        summary_record_id="sum-1",
+        summary_content="replacement summary",
+        old_node_id="old-node",
+        new_node_id="expired-node",
+        summary_hash="hash-1",
+        expected_enabled=True,
+        expected_error=stored_summary.error,
+        expected_generation_token="expired-node",
+        embedding_tokens=3,
+        expected_dataset_state=SummaryIndexService._summary_vector_dataset_state(_dataset()),
+        expected_summary_content="active summary",
+        expected_status=SummaryStatus.COMPLETED,
+        had_active_publication=True,
+    )
+    session = MagicMock()
+    session.scalar.return_value = stored_summary
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+    monkeypatch.setattr(SummaryIndexService, "_get_publication_dataset", MagicMock(return_value=_dataset()))
+    monkeypatch.setattr(SummaryIndexService, "_get_segment_content", MagicMock(return_value="hello world"))
+    monkeypatch.setattr(SummaryIndexService, "_segment_allows_summary", MagicMock(return_value=True))
+
+    with pytest.raises(summary_module.SummaryIndexConflictError, match="superseded"):
+        SummaryIndexService._publish_summary_vector(publication)
+
+    session.commit.assert_not_called()
+
+
+def test_publish_summary_vector_rejects_deleted_dataset(monkeypatch: pytest.MonkeyPatch) -> None:
+    stored_summary = _summary_record(summary_content="sum", node_id="old-node")
+    publication = summary_module._SummaryVectorPublication(
+        dataset_id="dataset-1",
+        segment_id="seg-1",
+        segment_content="hello world",
+        summary_record_id="sum-1",
+        summary_content="sum",
+        old_node_id="old-node",
+        new_node_id="new-node",
+        summary_hash="hash-1",
+        expected_enabled=True,
+        expected_error=None,
+        expected_generation_token=None,
+        embedding_tokens=3,
+        expected_dataset_state=SummaryIndexService._summary_vector_dataset_state(_dataset()),
+    )
+    session = MagicMock()
+    session.get.return_value = None
+    session.scalar.return_value = stored_summary
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+    monkeypatch.setattr(SummaryIndexService, "_segment_allows_summary", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
+
+    with pytest.raises(summary_module.SummaryIndexConflictError, match="dataset was deleted"):
+        SummaryIndexService._publish_summary_vector(publication)
+
+    session.commit.assert_not_called()
+    assert stored_summary.summary_index_node_id == "old-node"
+
+
+def test_vectorize_summary_reconciles_commit_ack_loss_without_deleting_durable_vector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = _dataset()
+    _allow_current_publication_dataset(monkeypatch, dataset)
+    segment = _segment()
+    summary = _summary_record(summary_content="sum", node_id="old-node")
+    stored_summary = _summary_record(summary_content="sum", node_id="old-node")
+
+    monkeypatch.setattr(summary_module.uuid, "uuid4", MagicMock(return_value="new-node"))
+    monkeypatch.setattr(summary_module.helper, "generate_text_hash", MagicMock(return_value="hash-1"))
+    monkeypatch.setattr(
+        summary_module.ModelManager,
+        "for_tenant",
+        MagicMock(return_value=MagicMock(get_model_instance=MagicMock(return_value=None))),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+    monkeypatch.setattr(SummaryIndexService, "_segment_allows_summary", MagicMock(return_value=True))
+    monkeypatch.setattr(SummaryIndexService, "_get_segment_content", MagicMock(return_value=segment.content))
+    cleanup_after_commit = MagicMock()
+    monkeypatch.setattr(summary_module, "delete_unreferenced_summary_vectors", cleanup_after_commit)
+
+    vector = MagicMock()
+    monkeypatch.setattr(summary_module, "Vector", MagicMock(return_value=vector))
+
+    publish_session = MagicMock()
+    publish_session.scalar.return_value = stored_summary
+    publish_session.commit.side_effect = ConnectionError("connection lost after server commit")
+    reconcile_session = MagicMock()
+    reconcile_session.scalar.return_value = stored_summary
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(
+            create_session=MagicMock(
+                side_effect=[
+                    _SessionContext(publish_session),
+                    _SessionContext(reconcile_session),
+                ]
+            )
+        ),
+    )
+
+    SummaryIndexService.vectorize_summary(summary, segment, dataset)
+
+    assert stored_summary.summary_index_node_id == "new-node"
+    assert stored_summary.status == SummaryStatus.COMPLETED
+    assert summary.summary_index_node_id == "new-node"
+    assert call(["new-node"]) not in vector.delete_by_ids.call_args_list
+    cleanup_after_commit.assert_called_once_with(dataset.id, ["old-node"])
+
+
+def test_vectorize_summary_old_vector_cleanup_failure_is_non_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
+    dataset = _dataset()
+    _allow_current_publication_dataset(monkeypatch, dataset)
+    segment = _segment()
+    summary = _summary_record(summary_content="sum", node_id="old-node")
+    stored_summary = _summary_record(summary_content="sum", node_id="old-node")
+
+    monkeypatch.setattr(summary_module.uuid, "uuid4", MagicMock(return_value="uuid-1"))
+    monkeypatch.setattr(summary_module.helper, "generate_text_hash", MagicMock(return_value="hash-1"))
+    monkeypatch.setattr(
+        summary_module.ModelManager,
+        "for_tenant",
+        MagicMock(return_value=MagicMock(get_model_instance=MagicMock(return_value=None))),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+    monkeypatch.setattr(SummaryIndexService, "_segment_allows_summary", MagicMock(return_value=True))
+
+    vector = MagicMock()
+    vector.delete_by_ids.side_effect = RuntimeError("cleanup failed")
+    monkeypatch.setattr(summary_module, "Vector", MagicMock(return_value=vector))
+
+    session = MagicMock()
+    session.scalar.return_value = stored_summary
+    session.get.return_value = dataset
+    session.scalars.return_value.all.return_value = []
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
+
+    SummaryIndexService.vectorize_summary(summary, segment, dataset)
+
+    session.commit.assert_called_once()
+    assert stored_summary.status == SummaryStatus.COMPLETED
+    assert stored_summary.summary_index_node_id == "uuid-1"
+    assert summary.status == SummaryStatus.COMPLETED
+
+
+def test_vectorize_summary_does_not_recreate_record_deleted_during_vectorization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = _dataset()
+    _allow_current_publication_dataset(monkeypatch, dataset)
     segment = _segment()
     summary = _summary_record(summary_content="sum", node_id="old-node")
 
+    monkeypatch.setattr(summary_module.uuid, "uuid4", MagicMock(return_value="uuid-1"))
     monkeypatch.setattr(summary_module.helper, "generate_text_hash", MagicMock(return_value="hash-1"))
 
-    # Force deletion branch to run and swallow delete failures.
-    vector_for_delete = MagicMock()
-    vector_for_delete.delete_by_ids.side_effect = RuntimeError("delete failed")
-    vector_for_add = MagicMock()
-    vector_for_add.add_texts.return_value = None
-    vector_cls = MagicMock(side_effect=[vector_for_delete, vector_for_add])
-    monkeypatch.setattr(summary_module, "Vector", vector_cls)
+    vector = MagicMock()
+    monkeypatch.setattr(summary_module, "Vector", MagicMock(return_value=vector))
 
     model_manager = MagicMock()
     model_manager.get_model_instance.side_effect = RuntimeError("no model")
     monkeypatch.setattr(summary_module.ModelManager, "for_tenant", MagicMock(return_value=model_manager))
 
-    # New session used after vectorization succeeds (record not found by id nor chunk_id).
     session = MagicMock(name="session")
-    session.scalar.side_effect = [None, None]
+    session.scalar.side_effect = [None, None, None]
 
     create_session_mock = MagicMock(return_value=_SessionContext(session))
     monkeypatch.setattr(summary_module, "session_factory", SimpleNamespace(create_session=create_session_mock))
 
-    SummaryIndexService.vectorize_summary(summary, segment, dataset, session=None)
+    with pytest.raises(summary_module.SummaryIndexConflictError, match="was deleted"):
+        SummaryIndexService.vectorize_summary(summary, segment, dataset, session=None)
 
-    # Vector initialization and the record update both obtain local sessions.
-    create_session_mock.assert_called()
-    assert all(call.kwargs["session"] is session for call in vector_cls.call_args_list)
-    session.add.assert_called()
-    session.commit.assert_called_once()
-    assert summary.status == SummaryStatus.COMPLETED
-    assert summary.summary_index_node_id == "old-node"  # reused
+    assert create_session_mock.call_count == 2
+    session.add.assert_not_called()
+    session.commit.assert_not_called()
+    vector.delete_by_ids.assert_called_once_with(["uuid-1"])
+    assert summary.status == SummaryStatus.GENERATING
+    assert summary.summary_index_node_id == "old-node"
+
+
+def test_vectorize_summary_rejects_newer_generation_after_vector_publish(monkeypatch: pytest.MonkeyPatch) -> None:
+    dataset = _dataset()
+    _allow_current_publication_dataset(monkeypatch, dataset)
+    segment = _segment()
+    summary = _summary_record(summary_content="sum", node_id="old-node")
+    summary.error = SummaryIndexService._generation_claim_marker("generation-1")
+    stored_summary = _summary_record(summary_content="sum", node_id="old-node")
+    stored_summary.error = SummaryIndexService._generation_claim_marker("generation-2")
+
+    monkeypatch.setattr(summary_module.uuid, "uuid4", MagicMock(return_value="new-node"))
+    monkeypatch.setattr(summary_module.helper, "generate_text_hash", MagicMock(return_value="hash-1"))
+    monkeypatch.setattr(
+        summary_module.ModelManager,
+        "for_tenant",
+        MagicMock(return_value=MagicMock(get_model_instance=MagicMock(return_value=None))),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+
+    vector = MagicMock()
+    monkeypatch.setattr(summary_module, "Vector", MagicMock(return_value=vector))
+
+    session = MagicMock()
+    session.scalar.return_value = stored_summary
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
+
+    with pytest.raises(summary_module.SummaryIndexConflictError, match="vectorization was superseded"):
+        SummaryIndexService.vectorize_summary(summary, segment, dataset)
+
+    vector.add_texts.assert_called_once()
+    vector.delete_by_ids.assert_called_once_with(["new-node"])
+    session.commit.assert_not_called()
+    assert stored_summary.summary_index_node_id == "old-node"
+    assert stored_summary.error == SummaryIndexService._generation_claim_marker("generation-2")
+
+
+def test_vectorize_summary_preserves_conflict_when_compensating_vector_delete_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    dataset = _dataset()
+    _allow_current_publication_dataset(monkeypatch, dataset)
+    segment = _segment()
+    summary = _summary_record(summary_content="sum", node_id="old-node")
+    summary.error = SummaryIndexService._generation_claim_marker("generation-1")
+    stored_summary = _summary_record(summary_content="sum", node_id="old-node")
+    stored_summary.error = SummaryIndexService._generation_claim_marker("generation-2")
+
+    monkeypatch.setattr(summary_module.uuid, "uuid4", MagicMock(return_value="new-node"))
+    monkeypatch.setattr(summary_module.helper, "generate_text_hash", MagicMock(return_value="hash-1"))
+    monkeypatch.setattr(
+        summary_module.ModelManager,
+        "for_tenant",
+        MagicMock(return_value=MagicMock(get_model_instance=MagicMock(return_value=None))),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+
+    vector = MagicMock()
+    vector.delete_by_ids.side_effect = RuntimeError("vector cleanup unavailable")
+    monkeypatch.setattr(summary_module, "Vector", MagicMock(return_value=vector))
+
+    session = MagicMock()
+    session.scalar.return_value = stored_summary
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
+
+    with (
+        caplog.at_level("WARNING"),
+        pytest.raises(summary_module.SummaryIndexConflictError, match="vectorization was superseded"),
+    ):
+        SummaryIndexService.vectorize_summary(summary, segment, dataset)
+
+    vector.delete_by_ids.assert_called_once_with(["new-node"])
+    assert "Failed to compensate summary vector new-node" in caplog.text
+    assert stored_summary.summary_index_node_id == "old-node"
+
+
+def test_vectorize_summary_compensates_unpublished_vector_after_terminal_database_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = _dataset()
+    segment = _segment()
+    summary = _summary_record(summary_content="sum", node_id="old-node")
+
+    monkeypatch.setattr(summary_module.uuid, "uuid4", MagicMock(return_value="new-node"))
+    monkeypatch.setattr(summary_module.helper, "generate_text_hash", MagicMock(return_value="hash-1"))
+    monkeypatch.setattr(SummaryIndexService, "_embedding_token_count", MagicMock(return_value=3))
+    monkeypatch.setattr(
+        SummaryIndexService,
+        "_publish_summary_vector",
+        MagicMock(side_effect=RuntimeError("database constraint failure")),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_publication_is_durable", MagicMock(return_value=False))
+    record_failure = MagicMock()
+    monkeypatch.setattr(SummaryIndexService, "_record_vectorization_failure", record_failure)
+
+    vector = MagicMock()
+    monkeypatch.setattr(summary_module, "Vector", MagicMock(return_value=vector))
+
+    with pytest.raises(RuntimeError, match="database constraint failure"):
+        SummaryIndexService.vectorize_summary(summary, segment, dataset)
+
+    vector.add_texts.assert_called_once()
+    vector.delete_by_ids.assert_called_once_with(["new-node"])
+    record_failure.assert_called_once()
 
 
 def test_vectorize_summary_final_failure_updates_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
     dataset = _dataset()
+    _allow_current_publication_dataset(monkeypatch, dataset)
     segment = _segment()
     summary = _summary_record(summary_content="sum", node_id=None)
 
@@ -280,6 +1257,42 @@ def test_vectorize_summary_final_failure_updates_error_status(monkeypatch: pytes
     error_session.commit.assert_called_once()
 
 
+def test_vectorize_summary_failure_does_not_mark_newer_generation_as_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = _dataset()
+    _allow_current_publication_dataset(monkeypatch, dataset)
+    segment = _segment()
+    summary = _summary_record(summary_content="sum", node_id=None)
+    summary.error = SummaryIndexService._generation_claim_marker("generation-1")
+    stored_summary = _summary_record(summary_content="sum", node_id=None)
+    stored_summary.error = SummaryIndexService._generation_claim_marker("generation-2")
+
+    monkeypatch.setattr(summary_module.uuid, "uuid4", MagicMock(return_value="new-node"))
+    monkeypatch.setattr(summary_module.helper, "generate_text_hash", MagicMock(return_value="hash-1"))
+    monkeypatch.setattr(summary_module.time, "sleep", MagicMock())
+    monkeypatch.setattr(
+        summary_module,
+        "Vector",
+        MagicMock(return_value=MagicMock(add_texts=MagicMock(side_effect=RuntimeError("boom")))),
+    )
+
+    error_session = MagicMock()
+    error_session.scalar.return_value = stored_summary
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(error_session))),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        SummaryIndexService.vectorize_summary(summary, segment, dataset)
+
+    assert stored_summary.status == SummaryStatus.GENERATING
+    assert stored_summary.error == SummaryIndexService._generation_claim_marker("generation-2")
+    error_session.commit.assert_not_called()
+
+
 def test_batch_create_summary_records_no_segments_noop(monkeypatch: pytest.MonkeyPatch) -> None:
     create_session_mock = MagicMock()
     monkeypatch.setattr(summary_module, "session_factory", SimpleNamespace(create_session=create_session_mock))
@@ -297,19 +1310,25 @@ def test_batch_create_summary_records_creates_and_updates(monkeypatch: pytest.Mo
     existing = _summary_record()
     existing.chunk_id = "seg-2"
     existing.enabled = False
+    existing.error = SummaryIndexService._generation_claim_marker("in-flight-generation")
 
     session = MagicMock()
-    session.scalars.return_value.all.return_value = [existing]
+    session.scalars.side_effect = [SimpleNamespace(all=lambda: [s1.id, s2.id]), SimpleNamespace(all=lambda: [existing])]
+    cleanup = MagicMock()
 
     monkeypatch.setattr(
         summary_module,
         "session_factory",
         SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
     )
+    monkeypatch.setattr(summary_module, "delete_unreferenced_summary_vectors", cleanup)
 
     SummaryIndexService.batch_create_summary_records([s1, s2], dataset, status=SummaryStatus.NOT_STARTED)
     session.commit.assert_called_once()
-    assert existing.enabled is True
+    updated_summary = cast(DocumentSegmentSummary, session.add.call_args.args[0])
+    assert updated_summary.enabled
+    assert updated_summary.error is None
+    cleanup.assert_called_once_with(dataset.id, ["in-flight-generation"])
 
 
 def test_update_summary_record_error_updates_when_exists(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -331,6 +1350,33 @@ def test_update_summary_record_error_updates_when_exists(monkeypatch: pytest.Mon
     session.commit.assert_called_once()
 
 
+def test_update_summary_record_error_does_not_overwrite_newer_generation(monkeypatch: pytest.MonkeyPatch) -> None:
+    dataset = _dataset()
+    segment = _segment()
+    record = _summary_record()
+    record.error = SummaryIndexService._generation_claim_marker("generation-2")
+
+    session = MagicMock()
+    session.scalar.return_value = record
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
+
+    SummaryIndexService.update_summary_record_error(
+        segment,
+        dataset,
+        "stale error",
+        generation_claim=_generation_claim(generation_token="generation-1"),
+    )
+
+    assert record.status == SummaryStatus.GENERATING
+    assert record.error == SummaryIndexService._generation_claim_marker("generation-2")
+    session.add.assert_not_called()
+    session.commit.assert_not_called()
+
+
 def test_generate_and_vectorize_summary_success(monkeypatch: pytest.MonkeyPatch) -> None:
     dataset = _dataset()
     segment = _segment()
@@ -338,20 +1384,138 @@ def test_generate_and_vectorize_summary_success(monkeypatch: pytest.MonkeyPatch)
 
     session = MagicMock()
     session.scalar.return_value = record
-    phase_events: list[str] = []
-    session.commit.side_effect = lambda: phase_events.append("commit")
-
-    generate_summary = MagicMock(
-        side_effect=lambda *_args, **_kwargs: phase_events.append("generate") or ("sum", MagicMock(total_tokens=0))
+    session.get.return_value = record
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
     )
-    monkeypatch.setattr(SummaryIndexService, "generate_summary_for_segment", generate_summary)
-    vectorize_summary = MagicMock(side_effect=lambda *_args, **_kwargs: phase_events.append("vectorize"))
-    monkeypatch.setattr(SummaryIndexService, "vectorize_summary", vectorize_summary)
+    monkeypatch.setattr(SummaryIndexService, "_get_segment_content", MagicMock(return_value=segment.content))
+    monkeypatch.setattr(
+        SummaryIndexService, "generate_summary_for_segment", MagicMock(return_value=("sum", MagicMock(total_tokens=0)))
+    )
+    vectorize_mock = MagicMock(return_value=None)
+    monkeypatch.setattr(SummaryIndexService, "vectorize_summary", vectorize_mock)
 
-    out = SummaryIndexService.generate_and_vectorize_summary(segment, dataset, {"enable": True}, session=session)
-    assert out is record
-    session.refresh.assert_called_once_with(record)
-    assert phase_events == ["commit", "generate", "vectorize", "commit"]
+    out = SummaryIndexService.generate_and_vectorize_summary(segment, dataset, {"enable": True})
+    assert out is not record
+    assert out.summary_content == "sum"
+    vectorize_mock.assert_called_once_with(out, segment, dataset, generation_claim=ANY)
+    session.commit.assert_called_once_with()
+
+
+def test_generate_and_vectorize_summary_releases_service_sessions_before_external_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    record = _summary_record(summary_content="old")
+    active_contexts = 0
+
+    class _TrackedContext:
+        def __init__(self) -> None:
+            self.session = MagicMock()
+            self.session.scalar.return_value = record
+            self.session.get.return_value = record
+
+        def __enter__(self) -> MagicMock:
+            nonlocal active_contexts
+            active_contexts += 1
+            return self.session
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            nonlocal active_contexts
+            active_contexts -= 1
+
+    def create_session() -> _TrackedContext:
+        return _TrackedContext()
+
+    monkeypatch.setattr(summary_module, "session_factory", SimpleNamespace(create_session=create_session))
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+    monkeypatch.setattr(SummaryIndexService, "_segment_allows_summary", MagicMock(return_value=True))
+    monkeypatch.setattr(SummaryIndexService, "_get_segment_content", MagicMock(return_value="hello world"))
+
+    external_calls: list[str] = []
+    caller_session = MagicMock()
+
+    def assert_clean_boundary(name: str) -> None:
+        assert caller_session.commit.called
+        assert active_contexts == 0
+        external_calls.append(name)
+
+    monkeypatch.setattr(
+        SummaryIndexService,
+        "generate_summary_for_segment",
+        lambda *_args, **_kwargs: (assert_clean_boundary("llm") or "sum", MagicMock(total_tokens=0)),
+    )
+    monkeypatch.setattr(
+        SummaryIndexService,
+        "vectorize_summary",
+        lambda *_args, **_kwargs: assert_clean_boundary("vector"),
+    )
+
+    SummaryIndexService.generate_and_vectorize_summary(_segment(), _dataset(), {"enable": True}, session=caller_session)
+
+    assert external_calls == ["llm", "vector"]
+    caller_session.commit.assert_called_once()
+
+
+def test_generation_claim_rejects_interleaved_manual_and_older_generated_writes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stored_summary = _summary_record(summary_content="old summary")
+
+    def create_session() -> _SessionContext:
+        session = MagicMock()
+        session.scalar.return_value = stored_summary
+        session.get.return_value = stored_summary
+        return _SessionContext(session)
+
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=create_session),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+    monkeypatch.setattr(SummaryIndexService, "_segment_allows_summary", MagicMock(return_value=True))
+    monkeypatch.setattr(SummaryIndexService, "_get_segment_content", MagicMock(return_value="hello world"))
+
+    dataset = _dataset()
+    segment = _segment()
+
+    stale_claim = SummaryIndexService._mark_summary_generation_started(segment, dataset)
+    SummaryIndexService._save_summary_content(segment, dataset, "manual summary")
+
+    with pytest.raises(summary_module.SummaryIndexConflictError, match="generation was superseded"):
+        SummaryIndexService._save_summary_content(
+            segment,
+            dataset,
+            "stale generated summary",
+            generation_claim=stale_claim,
+        )
+
+    assert stored_summary.summary_content == "manual summary"
+    assert stored_summary.error is None
+
+    staged_summary: DocumentSegmentSummary | None = None
+    for attempt in range(200):
+        older_claim = SummaryIndexService._mark_summary_generation_started(segment, dataset)
+        newer_claim = SummaryIndexService._mark_summary_generation_started(segment, dataset)
+        with pytest.raises(summary_module.SummaryIndexConflictError, match="generation was superseded"):
+            SummaryIndexService._save_summary_content(
+                segment,
+                dataset,
+                f"older generated summary {attempt}",
+                generation_claim=older_claim,
+            )
+        staged_summary = SummaryIndexService._save_summary_content(
+            segment,
+            dataset,
+            f"newer generated summary {attempt}",
+            generation_claim=newer_claim,
+        )
+
+    assert staged_summary is not None
+    assert staged_summary.summary_content == "newer generated summary 199"
+    assert stored_summary.summary_content == "manual summary"
 
 
 def test_generate_and_vectorize_summary_vectorize_failure_sets_error(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -361,64 +1525,27 @@ def test_generate_and_vectorize_summary_vectorize_failure_sets_error(monkeypatch
 
     session = MagicMock()
     session.scalar.return_value = record
-
+    session.get.return_value = record
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_get_segment_content", MagicMock(return_value=segment.content))
     monkeypatch.setattr(
         SummaryIndexService, "generate_summary_for_segment", MagicMock(return_value=("sum", MagicMock(total_tokens=0)))
     )
     monkeypatch.setattr(SummaryIndexService, "vectorize_summary", MagicMock(side_effect=RuntimeError("boom")))
 
     with pytest.raises(RuntimeError, match="boom"):
-        SummaryIndexService.generate_and_vectorize_summary(segment, dataset, {"enable": True}, session=session)
+        SummaryIndexService.generate_and_vectorize_summary(segment, dataset, {"enable": True})
     assert record.status == SummaryStatus.ERROR
-    # Outer exception handler overwrites the error with the raw exception message.
     assert record.error == "boom"
-    session.rollback.assert_called_once()
 
 
-def test_generate_and_vectorize_summary_rolls_back_failed_transaction_before_recording_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_vectorize_summary_rejects_replacement_record_found_by_chunk_id(monkeypatch: pytest.MonkeyPatch) -> None:
     dataset = _dataset()
-    segment = _segment()
-    record = _summary_record(summary_content="")
-    session = MagicMock()
-    rolled_back = False
-    scalar_calls = 0
-
-    def scalar(*_args, **_kwargs):
-        nonlocal scalar_calls
-        scalar_calls += 1
-        if scalar_calls > 1 and not rolled_back:
-            raise PendingRollbackError("rollback required")
-        return record
-
-    def rollback() -> None:
-        nonlocal rolled_back
-        rolled_back = True
-
-    session.scalar.side_effect = scalar
-    session.rollback.side_effect = rollback
-    session.flush.side_effect = RuntimeError("flush failed")
-    monkeypatch.setattr(
-        SummaryIndexService,
-        "generate_summary_for_segment",
-        MagicMock(return_value=("sum", MagicMock(total_tokens=0))),
-    )
-    vectorize_summary = MagicMock()
-    monkeypatch.setattr(SummaryIndexService, "vectorize_summary", vectorize_summary)
-
-    with pytest.raises(RuntimeError, match="flush failed"):
-        SummaryIndexService.generate_and_vectorize_summary(segment, dataset, {"enable": True}, session=session)
-
-    assert rolled_back is True
-    assert record.status == SummaryStatus.ERROR
-    assert record.error == "flush failed"
-    vectorize_summary.assert_not_called()
-    assert session.commit.call_count == 2
-
-
-def test_vectorize_summary_updates_existing_record_found_by_chunk_id(monkeypatch: pytest.MonkeyPatch) -> None:
-    dataset = _dataset()
+    _allow_current_publication_dataset(monkeypatch, dataset)
     segment = _segment()
     summary = _summary_record(summary_content="sum", node_id=None)
 
@@ -444,13 +1571,15 @@ def test_vectorize_summary_updates_existing_record_found_by_chunk_id(monkeypatch
         SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
     )
 
-    SummaryIndexService.vectorize_summary(summary, segment, dataset, session=None)
-    session.commit.assert_called_once()
-    assert existing.summary_index_node_id == "uuid-1"
+    with pytest.raises(summary_module.SummaryIndexConflictError, match="was replaced"):
+        SummaryIndexService.vectorize_summary(summary, segment, dataset, session=None)
+    session.commit.assert_not_called()
+    assert existing.summary_index_node_id == "old-node"
 
 
 def test_vectorize_summary_updates_existing_record_found_by_id(monkeypatch: pytest.MonkeyPatch) -> None:
     dataset = _dataset()
+    _allow_current_publication_dataset(monkeypatch, dataset)
     segment = _segment()
     summary = _summary_record(summary_content="sum", node_id=None)
 
@@ -465,7 +1594,7 @@ def test_vectorize_summary_updates_existing_record_found_by_id(monkeypatch: pyte
         MagicMock(return_value=MagicMock(get_model_instance=MagicMock(return_value=None))),
     )
 
-    existing = _summary_record(summary_content="old", node_id="old-node")
+    existing = _summary_record(summary_content="sum", node_id=None)
     session = MagicMock(name="session")
     session.scalar.return_value = existing  # hit by id
     monkeypatch.setattr(
@@ -479,80 +1608,7 @@ def test_vectorize_summary_updates_existing_record_found_by_id(monkeypatch: pyte
     assert existing.summary_index_node_hash == "hash-1"
 
 
-def test_vectorize_summary_session_enter_returns_none_triggers_runtime_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    dataset = _dataset()
-    segment = _segment()
-    summary = _summary_record(summary_content="sum", node_id=None)
-
-    monkeypatch.setattr(summary_module.uuid, "uuid4", MagicMock(return_value="uuid-1"))
-    monkeypatch.setattr(summary_module.helper, "generate_text_hash", MagicMock(return_value="hash-1"))
-    monkeypatch.setattr(
-        summary_module, "Vector", MagicMock(return_value=MagicMock(add_texts=MagicMock(return_value=None)))
-    )
-    monkeypatch.setattr(
-        summary_module.ModelManager,
-        "for_tenant",
-        MagicMock(return_value=MagicMock(get_model_instance=MagicMock(return_value=None))),
-    )
-
-    class _BadContext:
-        def __enter__(self):
-            return None
-
-        def __exit__(self, exc_type, exc, tb) -> None:
-            return None
-
-    error_session = MagicMock()
-    error_session.scalar.return_value = summary
-
-    vector_session = MagicMock()
-    create_session_mock = MagicMock(
-        side_effect=[_SessionContext(vector_session), _BadContext(), _SessionContext(error_session)]
-    )
-    monkeypatch.setattr(summary_module, "session_factory", SimpleNamespace(create_session=create_session_mock))
-
-    with pytest.raises(RuntimeError, match="Session should not be None"):
-        SummaryIndexService.vectorize_summary(summary, segment, dataset, session=None)
-
-
-def test_vectorize_summary_created_record_becomes_none_triggers_guard(monkeypatch: pytest.MonkeyPatch) -> None:
-    dataset = _dataset()
-    segment = _segment()
-    summary = _summary_record(summary_content="sum", node_id=None)
-
-    monkeypatch.setattr(summary_module.uuid, "uuid4", MagicMock(return_value="uuid-1"))
-    monkeypatch.setattr(summary_module.helper, "generate_text_hash", MagicMock(return_value="hash-1"))
-    monkeypatch.setattr(
-        summary_module, "Vector", MagicMock(return_value=MagicMock(add_texts=MagicMock(return_value=None)))
-    )
-    monkeypatch.setattr(
-        summary_module.ModelManager,
-        "for_tenant",
-        MagicMock(return_value=MagicMock(get_model_instance=MagicMock(return_value=None))),
-    )
-
-    session = MagicMock()
-    session.scalar.side_effect = [None, None]  # miss by id and chunk_id
-
-    error_session = MagicMock()
-    error_session.scalar.return_value = summary
-
-    vector_session = MagicMock()
-    create_session_mock = MagicMock(
-        side_effect=[_SessionContext(vector_session), _SessionContext(session), _SessionContext(error_session)]
-    )
-    monkeypatch.setattr(summary_module, "session_factory", SimpleNamespace(create_session=create_session_mock))
-
-    # Force the created record to be None so the "should not be None" guard triggers.
-    # Also mock select() so SQLAlchemy doesn't validate the mocked DocumentSegmentSummary as a real column clause.
-    monkeypatch.setattr(summary_module, "select", MagicMock(return_value=MagicMock()))
-    monkeypatch.setattr(summary_module, "DocumentSegmentSummary", MagicMock(return_value=None))
-
-    with pytest.raises(RuntimeError, match="summary_record_in_session should not be None"):
-        SummaryIndexService.vectorize_summary(summary, segment, dataset, session=None)
-
-
-def test_vectorize_summary_error_handler_tries_chunk_id_lookup_and_can_warn_not_found(
+def test_vectorize_summary_failure_does_not_mark_a_deleted_row(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     dataset = _dataset()
@@ -569,7 +1625,7 @@ def test_vectorize_summary_error_handler_tries_chunk_id_lookup_and_can_warn_not_
     )
 
     error_session = MagicMock(name="error_session")
-    error_session.scalar.side_effect = [None, None]  # not found by id, not found by chunk_id
+    error_session.scalar.return_value = None
 
     monkeypatch.setattr(
         summary_module,
@@ -580,7 +1636,6 @@ def test_vectorize_summary_error_handler_tries_chunk_id_lookup_and_can_warn_not_
     with pytest.raises(RuntimeError, match="boom"):
         SummaryIndexService.vectorize_summary(summary, segment, dataset, session=None)
 
-    # No record -> no commit in error session.
     error_session.commit.assert_not_called()
 
 
@@ -593,6 +1648,7 @@ def test_update_summary_record_error_warns_when_missing(
 
     session = MagicMock()
     session.scalar.return_value = None
+    session.get.return_value = None
     monkeypatch.setattr(
         summary_module,
         "session_factory",
@@ -611,14 +1667,24 @@ def test_generate_and_vectorize_summary_creates_missing_record_and_logs_usage(
     dataset = _dataset()
     segment = _segment()
 
-    session = MagicMock()
-    session.scalar.return_value = None
+    mark_session = MagicMock()
+    mark_session.scalar.return_value = None
+    save_session = MagicMock()
+    save_session.get.side_effect = lambda *_args, **_kwargs: mark_session.add.call_args.args[0]
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(
+            create_session=MagicMock(side_effect=[_SessionContext(mark_session), _SessionContext(save_session)])
+        ),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_get_segment_content", MagicMock(return_value=segment.content))
     usage = MagicMock(total_tokens=4, prompt_tokens=1, completion_tokens=3)
     monkeypatch.setattr(SummaryIndexService, "generate_summary_for_segment", MagicMock(return_value=("sum", usage)))
     monkeypatch.setattr(SummaryIndexService, "vectorize_summary", MagicMock(return_value=None))
 
     with caplog.at_level(logging.INFO, logger="services.summary_index_service"):
-        result = SummaryIndexService.generate_and_vectorize_summary(segment, dataset, {"enable": True}, session=session)
+        result = SummaryIndexService.generate_and_vectorize_summary(segment, dataset, {"enable": True})
         assert result.status in {SummaryStatus.GENERATING, SummaryStatus.COMPLETED}
         assert any(r.levelno >= logging.INFO for r in caplog.records)
 
@@ -666,7 +1732,7 @@ def test_generate_summaries_for_document_runs_and_handles_errors(monkeypatch: py
 
     records = SummaryIndexService.generate_summaries_for_document(dataset, document, {"enable": True})
     assert len(records) == 1
-    update_err_mock.assert_called_once()
+    update_err_mock.assert_not_called()
 
 
 def test_generate_summaries_for_document_no_segments_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -710,16 +1776,19 @@ def test_generate_summaries_for_document_applies_segment_ids_and_only_parent_chu
         dataset,
         document,
         {"enable": True},
+        session=session,
         segment_ids=[seg.id],
         only_parent_chunks=True,
     )
     session.scalars.assert_called()
+    session.commit.assert_called_once()
 
 
-def test_disable_summaries_for_segments_updates_sqlite_records() -> None:
-    dataset = SimpleNamespace(id="dataset-1", indexing_technique=IndexTechniqueType.ECONOMY)
+def test_disable_summaries_for_segments_updates_sqlite_records(monkeypatch: pytest.MonkeyPatch) -> None:
+    dataset = _concrete_dataset(indexing_technique=IndexTechniqueType.ECONOMY)
     engine = create_engine("sqlite+pysqlite:///:memory:")
-    DocumentSegmentSummary.__table__.create(engine)
+    summary_table = cast(Table, DocumentSegmentSummary.__table__)
+    summary_table.create(engine)
     summary_rows = [
         {
             "id": "sum-1",
@@ -728,6 +1797,7 @@ def test_disable_summaries_for_segments_updates_sqlite_records() -> None:
             "chunk_id": "seg-1",
             "summary_content": "s",
             "summary_index_node_id": "n1",
+            "error": SummaryIndexService._generation_claim_marker("generation-1"),
             "status": SummaryStatus.COMPLETED,
             "enabled": True,
         },
@@ -735,20 +1805,28 @@ def test_disable_summaries_for_segments_updates_sqlite_records() -> None:
             "id": "sum-2",
             "dataset_id": dataset.id,
             "document_id": "doc-1",
-            "chunk_id": "seg-1",
+            "chunk_id": "seg-2",
             "summary_content": "s",
             "summary_index_node_id": None,
+            "error": SummaryIndexService._generation_claim_marker("generation-2"),
             "status": SummaryStatus.COMPLETED,
             "enabled": True,
         },
     ]
     with engine.begin() as connection:
-        connection.execute(DocumentSegmentSummary.__table__.insert(), summary_rows)
+        connection.execute(summary_table.insert(), summary_rows)
 
     session_maker = sessionmaker(bind=engine, expire_on_commit=False)
     summary_module.session_factory.configure(engine, expire_on_commit=False)
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+    cleanup = MagicMock()
+    monkeypatch.setattr(summary_module, "delete_unreferenced_summary_vectors", cleanup)
 
-    SummaryIndexService.disable_summaries_for_segments(dataset, segment_ids=["seg-1"], disabled_by="u")
+    SummaryIndexService.disable_summaries_for_segments(
+        dataset,
+        segment_ids=["seg-1", "seg-2"],
+        disabled_by="u",
+    )
 
     with session_maker() as session:
         summaries = session.scalars(select(DocumentSegmentSummary).order_by(DocumentSegmentSummary.id)).all()
@@ -758,10 +1836,12 @@ def test_disable_summaries_for_segments_updates_sqlite_records() -> None:
         ("sum-2", False, "u"),
     ]
     assert all(summary.disabled_at is not None for summary in summaries)
+    assert all(summary.error is None for summary in summaries)
+    cleanup.assert_called_once_with(dataset.id, ["n1", "generation-1", "generation-2"])
 
 
 def test_disable_summaries_for_segments_no_summaries_noop(monkeypatch: pytest.MonkeyPatch) -> None:
-    dataset = _dataset()
+    dataset = _dataset(indexing_technique=IndexTechniqueType.ECONOMY)
     session = MagicMock()
     session.scalars.return_value.all.return_value = []
     monkeypatch.setattr(
@@ -773,17 +1853,62 @@ def test_disable_summaries_for_segments_no_summaries_noop(monkeypatch: pytest.Mo
         sys.modules, "libs.datetime_utils", SimpleNamespace(naive_utc_now=MagicMock(return_value=datetime(2024, 1, 1)))
     )
     SummaryIndexService.disable_summaries_for_segments(dataset)
-    session.commit.assert_not_called()
+    session.commit.assert_called_once()
+
+
+def test_disable_summaries_commits_caller_transaction_before_vector_cleanup(monkeypatch: pytest.MonkeyPatch) -> None:
+    dataset = _dataset()
+    summary = _summary_record(node_id="node-1")
+    session = MagicMock()
+    events: list[str] = []
+    rows = MagicMock()
+    rows.all.return_value = [summary]
+    session.scalars.side_effect = lambda *_args: events.append("summary-lock") or rows
+    session.commit.side_effect = lambda: events.append("commit")
+    cleanup = MagicMock(side_effect=lambda *_args: events.append("cleanup"))
+    monkeypatch.setattr(summary_module, "delete_unreferenced_summary_vectors", cleanup)
+    monkeypatch.setattr(
+        SummaryIndexService, "_lock_segment_rows", MagicMock(side_effect=lambda *_args: events.append("parent-lock"))
+    )
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(side_effect=AssertionError("nested session"))),
+    )
+
+    SummaryIndexService.disable_summaries_for_segments(dataset, session=session, segment_ids=[summary.chunk_id])
+
+    assert events == ["parent-lock", "summary-lock", "commit", "cleanup"]
+    session.begin_nested.assert_called_once_with()
+    cleanup.assert_called_once_with(dataset.id, ["node-1"])
 
 
 def test_enable_summaries_for_segments_skips_non_high_quality() -> None:
     SummaryIndexService.enable_summaries_for_segments(_dataset(indexing_technique=IndexTechniqueType.ECONOMY))
 
 
+def test_enable_summary_record_rechecks_current_segment_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    summary = _summary_record()
+    summary.enabled = False
+    session = MagicMock()
+    session.get.return_value = summary
+    session.execute.return_value.scalar_one_or_none.return_value = None
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
+
+    assert SummaryIndexService._enable_summary_record(summary.id, summary.chunk_id, summary.dataset_id) is False
+    session.add.assert_not_called()
+    session.commit.assert_not_called()
+
+
 def test_enable_summaries_for_segments_revectorizes_and_enables(monkeypatch: pytest.MonkeyPatch) -> None:
     dataset = _dataset()
     summary = _summary_record(summary_content="sum", node_id="n1")
     summary.enabled = False
+    summary.error = SummaryIndexService._generation_claim_marker("in-flight-generation")
 
     segment = _segment()
     segment.id = summary.chunk_id
@@ -791,8 +1916,12 @@ def test_enable_summaries_for_segments_revectorizes_and_enables(monkeypatch: pyt
     segment.status = SegmentStatus.COMPLETED
 
     session = MagicMock()
-    session.scalars.return_value.all.return_value = [summary]
-    session.scalar.return_value = segment
+    summaries_result = MagicMock()
+    summaries_result.all.return_value = [summary]
+    segments_result = MagicMock()
+    segments_result.all.return_value = [segment]
+    session.scalars.side_effect = [summaries_result, segments_result]
+    session.get.return_value = summary
 
     monkeypatch.setattr(
         summary_module,
@@ -800,12 +1929,47 @@ def test_enable_summaries_for_segments_revectorizes_and_enables(monkeypatch: pyt
         SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
     )
     vec_mock = MagicMock()
+    cleanup = MagicMock()
     monkeypatch.setattr(SummaryIndexService, "vectorize_summary", vec_mock)
+    monkeypatch.setattr(summary_module, "delete_unreferenced_summary_vectors", cleanup)
 
-    SummaryIndexService.enable_summaries_for_segments(dataset, segment_ids=[summary.chunk_id])
-    vec_mock.assert_called_once()
-    assert summary.enabled is True
-    session.commit.assert_called_once()
+    SummaryIndexService.enable_summaries_for_segments(dataset, session=session, segment_ids=[summary.chunk_id])
+    vec_mock.assert_called_once_with(summary, segment, dataset)
+    enabled_summary = cast(DocumentSegmentSummary, session.add.call_args.args[0])
+    assert enabled_summary.enabled
+    assert enabled_summary.error is None
+    assert session.commit.call_count == 2
+    cleanup.assert_called_once_with(dataset.id, ["in-flight-generation"])
+
+
+def test_enable_summaries_for_segments_retires_vector_when_final_enable_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = _dataset()
+    summary = _summary_record(summary_content="sum", node_id="old-node")
+    summary.enabled = False
+    segment = _segment()
+    segment.id = summary.chunk_id
+    segment.enabled = True
+    segment.status = SegmentStatus.COMPLETED
+    session = MagicMock()
+    summaries_result = MagicMock()
+    summaries_result.all.return_value = [summary]
+    segments_result = MagicMock()
+    segments_result.all.return_value = [segment]
+    session.scalars.side_effect = [summaries_result, segments_result]
+
+    def publish_replacement(*_args) -> None:
+        summary.summary_index_node_id = "new-node"
+
+    cleanup = MagicMock()
+    monkeypatch.setattr(SummaryIndexService, "vectorize_summary", publish_replacement)
+    monkeypatch.setattr(SummaryIndexService, "_enable_summary_record", MagicMock(return_value=False))
+    monkeypatch.setattr(summary_module, "delete_unreferenced_summary_vectors", cleanup)
+
+    SummaryIndexService.enable_summaries_for_segments(dataset, session=session, segment_ids=[summary.chunk_id])
+
+    cleanup.assert_called_once_with(dataset.id, ["new-node"])
 
 
 def test_enable_summaries_for_segments_no_summaries_noop(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -828,22 +1992,29 @@ def test_enable_summaries_for_segments_skips_segment_or_content_and_handles_vect
     dataset = _dataset()
     summary1 = _summary_record(summary_content="sum", node_id="n1")
     summary1.enabled = False
+    summary1.chunk_id = "seg-1"
     summary2 = _summary_record(summary_content="", node_id="n2")
     summary2.enabled = False
+    summary2.chunk_id = "seg-2"
     summary3 = _summary_record(summary_content="sum3", node_id="n3")
     summary3.enabled = False
+    summary3.chunk_id = "seg-3"
 
     bad_segment = _segment()
     bad_segment.enabled = False
     bad_segment.status = SegmentStatus.COMPLETED
 
     good_segment = _segment()
+    good_segment.id = "seg-3"
     good_segment.enabled = True
     good_segment.status = SegmentStatus.COMPLETED
 
     session = MagicMock()
-    session.scalars.return_value.all.return_value = [summary1, summary2, summary3]
-    session.scalar.side_effect = [bad_segment, good_segment, good_segment]
+    summaries_result = MagicMock()
+    summaries_result.all.return_value = [summary1, summary2, summary3]
+    segments_result = MagicMock()
+    segments_result.all.return_value = [bad_segment, good_segment]
+    session.scalars.side_effect = [summaries_result, segments_result]
 
     monkeypatch.setattr(
         summary_module,
@@ -856,39 +2027,63 @@ def test_enable_summaries_for_segments_skips_segment_or_content_and_handles_vect
     with caplog.at_level(logging.ERROR, logger="services.summary_index_service"):
         SummaryIndexService.enable_summaries_for_segments(dataset)
         assert any(r.levelno >= logging.ERROR for r in caplog.records)
-    session.commit.assert_called_once()
+    session.commit.assert_not_called()
 
 
 def test_delete_summaries_for_segments_deletes_vectors_and_records(monkeypatch: pytest.MonkeyPatch) -> None:
     dataset = _dataset()
     summary = _summary_record(summary_content="sum", node_id="n1")
+    summary.error = SummaryIndexService._generation_claim_marker("pending-node")
 
     session = MagicMock()
     session.scalars.return_value.all.return_value = [summary]
+    events: list[str] = []
+    session.delete.side_effect = lambda *_args: events.append("delete-row")
+    session.commit.side_effect = lambda: events.append("commit")
 
-    vector_instance = MagicMock()
-    monkeypatch.setattr(summary_module, "Vector", MagicMock(return_value=vector_instance))
+    cleanup = MagicMock(side_effect=lambda *_args: events.append("cleanup"))
+    monkeypatch.setattr(summary_module, "delete_unreferenced_summary_vectors", cleanup)
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(side_effect=AssertionError("nested session"))),
+    )
 
     SummaryIndexService.delete_summaries_for_segments(dataset, segment_ids=[summary.chunk_id], session=session)
-    vector_instance.delete_by_ids.assert_called_once_with(["n1"])
     session.delete.assert_called_once_with(summary)
-    session.flush.assert_called_once()
+    session.commit.assert_called_once()
+    cleanup.assert_called_once_with(dataset.id, ["n1", "pending-node"])
+    assert events == ["delete-row", "commit", "cleanup"]
 
 
 def test_delete_summaries_for_segments_no_summaries_noop(monkeypatch: pytest.MonkeyPatch) -> None:
-    dataset = _dataset()
+    dataset = _dataset(indexing_technique=IndexTechniqueType.ECONOMY)
     session = MagicMock()
     session.scalars.return_value.all.return_value = []
-    SummaryIndexService.delete_summaries_for_segments(dataset, session=session)
-    session.flush.assert_not_called()
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
+    SummaryIndexService.delete_summaries_for_segments(dataset)
+    session.commit.assert_called_once()
 
 
-def test_update_summary_for_segment_skip_conditions() -> None:
+def test_update_summary_for_segment_skip_conditions(monkeypatch: pytest.MonkeyPatch) -> None:
     session = MagicMock()
+    session.scalar.return_value = IndexStructureType.QA_INDEX
     economy_dataset = _dataset(indexing_technique=IndexTechniqueType.ECONOMY)
     assert SummaryIndexService.update_summary_for_segment(_segment(), economy_dataset, "x", session=session) is None
     seg = _segment(has_document=True)
-    seg.get_document.return_value.doc_form = IndexStructureType.QA_INDEX
+    seg.document.doc_form = IndexStructureType.QA_INDEX
+    query_session = MagicMock()
+    query_session.scalar.return_value = IndexStructureType.QA_INDEX
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(query_session))),
+    )
     assert SummaryIndexService.update_summary_for_segment(seg, _dataset(), "x", session=session) is None
 
 
@@ -896,21 +2091,31 @@ def test_update_summary_for_segment_empty_content_deletes_existing(monkeypatch: 
     dataset = _dataset()
     segment = _segment()
     record = _summary_record(summary_content="old", node_id="n1")
+    record.error = SummaryIndexService._generation_claim_marker("pending-node")
 
     session = MagicMock()
     session.scalar.return_value = record
+    events: list[str] = []
+    session.delete.side_effect = lambda *_args: events.append("delete-row")
+    session.commit.side_effect = lambda: events.append("commit")
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(side_effect=AssertionError("nested session"))),
+    )
 
-    vector_instance = MagicMock()
-    monkeypatch.setattr(summary_module, "Vector", MagicMock(return_value=vector_instance))
+    cleanup = MagicMock(side_effect=lambda *_args: events.append("cleanup"))
+    monkeypatch.setattr(summary_module, "delete_unreferenced_summary_vectors", cleanup)
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
     assert SummaryIndexService.update_summary_for_segment(segment, dataset, "   ", session=session) is None
-    vector_instance.delete_by_ids.assert_called_once_with(["n1"])
     session.delete.assert_called_once_with(record)
     session.commit.assert_called_once()
+    cleanup.assert_called_once_with(dataset.id, ["n1", "pending-node"])
+    assert events == ["delete-row", "commit", "cleanup"]
 
 
-def test_update_summary_for_segment_empty_content_delete_vector_warns(
+def test_update_summary_for_segment_empty_content_cleanup_failure_is_deferred(
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     dataset = _dataset()
     segment = _segment()
@@ -918,13 +2123,20 @@ def test_update_summary_for_segment_empty_content_delete_vector_warns(
 
     session = MagicMock()
     session.scalar.return_value = record
-    vector_instance = MagicMock()
-    vector_instance.delete_by_ids.side_effect = RuntimeError("boom")
-    monkeypatch.setattr(summary_module, "Vector", MagicMock(return_value=vector_instance))
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
 
-    with caplog.at_level(logging.WARNING, logger="services.summary_index_service"):
-        assert SummaryIndexService.update_summary_for_segment(segment, dataset, "", session=session) is None
-        assert any(r.levelno >= logging.WARNING for r in caplog.records)
+    cleanup = MagicMock()
+    monkeypatch.setattr(summary_module, "delete_unreferenced_summary_vectors", cleanup)
+
+    assert SummaryIndexService.update_summary_for_segment(segment, dataset, "", session=session) is None
+    session.begin_nested.assert_called_once_with()
+    session.rollback.assert_not_called()
+    session.commit.assert_called_once()
+    cleanup.assert_called_once_with(dataset.id, ["n1"])
 
 
 def test_update_summary_for_segment_empty_content_no_record_noop(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -933,47 +2145,67 @@ def test_update_summary_for_segment_empty_content_no_record_noop(monkeypatch: py
 
     session = MagicMock()
     session.scalar.return_value = None
-    assert SummaryIndexService.update_summary_for_segment(segment, dataset, "   ", session=session) is None
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
+    monkeypatch.setattr(summary_module, "Vector", MagicMock(return_value=MagicMock()))
+    assert SummaryIndexService.update_summary_for_segment(segment, dataset, "   ") is None
 
 
 def test_update_summary_for_segment_updates_existing_and_vectorizes(monkeypatch: pytest.MonkeyPatch) -> None:
     dataset = _dataset()
     segment = _segment()
-    record = _summary_record(summary_content="old", node_id="n1")
+    staged_record = _summary_record(summary_content="new summary", node_id="n1")
+    claim = _generation_claim()
+    events: list[str] = []
+    caller_session = _CommitTrackingSession()
 
-    session = MagicMock()
-    session.scalar.return_value = record
+    monkeypatch.setattr(SummaryIndexService, "_mark_summary_generation_started", MagicMock(return_value=claim))
+    monkeypatch.setattr(SummaryIndexService, "_save_summary_content", MagicMock(return_value=staged_record))
 
-    vector_instance = MagicMock()
-    monkeypatch.setattr(summary_module, "Vector", MagicMock(return_value=vector_instance))
-    vectorize_mock = MagicMock()
+    def vectorize_summary(*args, **kwargs):
+        events.append("vector")
+
+    vectorize_mock = MagicMock(side_effect=vectorize_summary)
     monkeypatch.setattr(SummaryIndexService, "vectorize_summary", vectorize_mock)
 
-    out = SummaryIndexService.update_summary_for_segment(segment, dataset, "new summary", session=session)
-    assert out is record
-    vectorize_mock.assert_called_once()
-    session.refresh.assert_called_once_with(record)
-    session.commit.assert_called()
+    out = SummaryIndexService.update_summary_for_segment(
+        segment,
+        dataset,
+        "new summary",
+        session=cast(Session, caller_session),
+    )
+    assert out is staged_record
+    vectorize_mock.assert_called_once_with(staged_record, segment, dataset, generation_claim=claim)
+    assert events == ["vector"]
 
 
-def test_update_summary_for_segment_existing_vector_delete_warns(
+def test_update_summary_for_segment_existing_vector_delete_is_left_to_vectorize_summary(
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     dataset = _dataset()
     segment = _segment()
     record = _summary_record(summary_content="old", node_id="n1")
-
-    session = MagicMock()
-    session.scalar.return_value = record
+    staged_record = _summary_record(summary_content="new", node_id="n1")
+    claim = _generation_claim()
     vector_instance = MagicMock()
-    vector_instance.delete_by_ids.side_effect = RuntimeError("boom")
+    caller_session = _CommitTrackingSession()
     monkeypatch.setattr(summary_module, "Vector", MagicMock(return_value=vector_instance))
-    monkeypatch.setattr(SummaryIndexService, "vectorize_summary", MagicMock(return_value=None))
+    monkeypatch.setattr(SummaryIndexService, "_mark_summary_generation_started", MagicMock(return_value=claim))
+    monkeypatch.setattr(SummaryIndexService, "_save_summary_content", MagicMock(return_value=staged_record))
+    vectorize_mock = MagicMock(return_value=None)
+    monkeypatch.setattr(SummaryIndexService, "vectorize_summary", vectorize_mock)
 
-    with caplog.at_level(logging.WARNING, logger="services.summary_index_service"):
-        SummaryIndexService.update_summary_for_segment(segment, dataset, "new", session=session)
-        assert any(r.levelno >= logging.WARNING for r in caplog.records)
+    SummaryIndexService.update_summary_for_segment(
+        segment,
+        dataset,
+        "new",
+        session=cast(Session, caller_session),
+    )
+    vector_instance.delete_by_ids.assert_not_called()
+    vectorize_mock.assert_called_once_with(staged_record, segment, dataset, generation_claim=claim)
 
 
 def test_update_summary_for_segment_existing_vectorize_failure_returns_error_record(
@@ -981,96 +2213,105 @@ def test_update_summary_for_segment_existing_vectorize_failure_returns_error_rec
 ) -> None:
     dataset = _dataset()
     segment = _segment()
-    record = _summary_record(summary_content="old", node_id="n1")
-
-    session = MagicMock(is_active=True)
-    session.scalar.return_value = record
+    staged_record = _summary_record(summary_content="new", node_id="n1")
+    claim = _generation_claim()
+    caller_session = _CommitTrackingSession()
+    monkeypatch.setattr(SummaryIndexService, "_mark_summary_generation_started", MagicMock(return_value=claim))
+    monkeypatch.setattr(SummaryIndexService, "_save_summary_content", MagicMock(return_value=staged_record))
+    monkeypatch.setattr(SummaryIndexService, "update_summary_record_error", MagicMock())
     monkeypatch.setattr(SummaryIndexService, "vectorize_summary", MagicMock(side_effect=RuntimeError("boom")))
 
-    out = SummaryIndexService.update_summary_for_segment(segment, dataset, "new", session=session)
-
-    assert out is record
-    assert out.summary_content == "new"
+    out = SummaryIndexService.update_summary_for_segment(
+        segment,
+        dataset,
+        "new",
+        session=cast(Session, caller_session),
+    )
+    assert out is staged_record
     assert out.status == SummaryStatus.ERROR
     assert "Vectorization failed" in (out.error or "")
-    session.rollback.assert_not_called()
-    session.add.assert_called_with(record)
-    session.commit.assert_called_once()
 
 
-def test_update_summary_for_segment_failed_flush_persists_new_content(monkeypatch: pytest.MonkeyPatch) -> None:
-    engine = create_engine("sqlite+pysqlite:///:memory:")
-    DocumentSegmentSummary.__table__.create(engine)
-    session_maker = sessionmaker(bind=engine, expire_on_commit=False)
+def test_update_summary_for_segment_vectorize_failure_preserves_active_publication(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = _concrete_dataset()
+    segment = _concrete_segment()
+    published_summary = _concrete_summary_record(summary_content="published summary")
+    published_summary.status = SummaryStatus.COMPLETED
+    published_summary.summary_index_node_id = "published-node"
+    published_summary.summary_index_node_hash = "published-hash"
+    published_summary.tokens = 3
+    claim = _claim_summary(published_summary, segment)
+    staged_summary = _concrete_summary_record(summary_content="replacement summary")
+    staged_summary.summary_index_node_id = published_summary.summary_index_node_id
+    staged_summary.summary_index_node_hash = published_summary.summary_index_node_hash
+    staged_summary.tokens = published_summary.tokens
+    staged_summary.error = SummaryIndexService._generation_claim_marker(claim.generation_token)
+    caller_session = _CommitTrackingSession()
 
-    with session_maker() as session:
-        record = DocumentSegmentSummary(
-            dataset_id="dataset-1",
-            document_id="doc-1",
-            chunk_id="seg-1",
-            summary_content="old",
-            status=SummaryStatus.COMPLETED,
-        )
-        record.id = "sum-1"
-        session.add(record)
-        session.commit()
+    monkeypatch.setattr(SummaryIndexService, "_mark_summary_generation_started", MagicMock(return_value=claim))
+    monkeypatch.setattr(SummaryIndexService, "_save_summary_content", MagicMock(return_value=staged_summary))
+    monkeypatch.setattr(SummaryIndexService, "update_summary_record_error", MagicMock())
+    monkeypatch.setattr(SummaryIndexService, "vectorize_summary", MagicMock(side_effect=RuntimeError("boom")))
 
-        def fail_flush(*_args, **_kwargs) -> None:
-            duplicate = DocumentSegmentSummary(
-                dataset_id="dataset-1",
-                document_id="doc-1",
-                chunk_id="seg-2",
-                summary_content="duplicate",
-            )
-            duplicate.id = record.id
-            session.add(duplicate)
-            session.flush()
+    result = SummaryIndexService.update_summary_for_segment(
+        segment,
+        dataset,
+        "replacement summary",
+        session=cast(Session, caller_session),
+    )
 
-        segment = _segment()
-        segment.get_document.return_value = SimpleNamespace(doc_form=IndexStructureType.PARAGRAPH_INDEX)
-        monkeypatch.setattr(SummaryIndexService, "vectorize_summary", fail_flush)
-
-        with pytest.warns(SAWarning, match="conflicts with persistent instance"):
-            out = SummaryIndexService.update_summary_for_segment(segment, _dataset(), "new", session=session)
-        session.expire_all()
-        persisted = session.get(DocumentSegmentSummary, record.id)
-
-        assert out is record
-        assert persisted is not None
-        assert persisted.summary_content == "new"
-        assert persisted.status == SummaryStatus.ERROR
+    assert result is staged_summary
+    assert result.status == SummaryStatus.COMPLETED
+    assert result.error is None
+    assert result.summary_content == "published summary"
+    assert result.summary_index_node_id == "published-node"
 
 
 def test_update_summary_for_segment_new_record_success(monkeypatch: pytest.MonkeyPatch) -> None:
     dataset = _dataset()
     segment = _segment()
-
-    session = MagicMock()
-    session.scalar.return_value = None
-    created = _summary_record(summary_content="new", node_id=None)
-    monkeypatch.setattr(SummaryIndexService, "create_summary_record", MagicMock(return_value=created))
+    staged_record = _summary_record(summary_content="new")
+    claim = _generation_claim()
+    caller_session = _CommitTrackingSession()
+    monkeypatch.setattr(SummaryIndexService, "_mark_summary_generation_started", MagicMock(return_value=claim))
+    monkeypatch.setattr(SummaryIndexService, "_save_summary_content", MagicMock(return_value=staged_record))
     monkeypatch.setattr(SummaryIndexService, "vectorize_summary", MagicMock(return_value=None))
 
-    out = SummaryIndexService.update_summary_for_segment(segment, dataset, "new", session=session)
-    assert out is created
-    session.refresh.assert_called()
-    session.commit.assert_called()
+    out = SummaryIndexService.update_summary_for_segment(
+        segment,
+        dataset,
+        "new",
+        session=cast(Session, caller_session),
+    )
+    assert out is staged_record
 
 
-def test_update_summary_for_segment_outer_exception_sets_error_and_reraises(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_update_summary_for_segment_save_conflict_abandons_claim(monkeypatch: pytest.MonkeyPatch) -> None:
     dataset = _dataset()
     segment = _segment()
-    record = _summary_record(summary_content="old", node_id="n1")
+    claim = _generation_claim()
+    abandon_claim = MagicMock()
+    query_session = MagicMock()
+    query_session.scalar.return_value = IndexStructureType.PARAGRAPH_INDEX
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(query_session))),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_mark_summary_generation_started", MagicMock(return_value=claim))
+    monkeypatch.setattr(
+        SummaryIndexService,
+        "_save_summary_content",
+        MagicMock(side_effect=summary_module.SummaryIndexConflictError("source changed")),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_abandon_generation_claim", abandon_claim)
 
-    session = MagicMock()
-    session.scalar.return_value = record
-    session.flush.side_effect = RuntimeError("flush boom")
-    with pytest.raises(RuntimeError, match="flush boom"):
-        SummaryIndexService.update_summary_for_segment(segment, dataset, "new", session=session)
-    assert record.status == SummaryStatus.ERROR
-    assert record.error == "flush boom"
-    session.rollback.assert_called_once()
-    session.commit.assert_called()
+    with pytest.raises(summary_module.SummaryIndexConflictError, match="source changed"):
+        SummaryIndexService.update_summary_for_segment(segment, dataset, "new")
+
+    abandon_claim.assert_called_once_with(claim)
 
 
 def test_get_segment_summary_and_document_summaries() -> None:
@@ -1097,6 +2338,34 @@ def test_get_segments_summaries_non_empty() -> None:
     assert set(out.keys()) == {"seg-1", "seg-2"}
 
 
+def test_summary_reads_do_not_fall_back_to_an_older_enabled_duplicate() -> None:
+    canonical_disabled = _summary_record(summary_content="new")
+    canonical_disabled.enabled = False
+    older_enabled = _summary_record(summary_content="old")
+    session = MagicMock()
+    session.scalar.return_value = canonical_disabled
+    session.scalars.return_value.all.return_value = [canonical_disabled, older_enabled]
+
+    assert SummaryIndexService.get_segment_summary("seg-1", "dataset-1", session=session) is None
+    assert SummaryIndexService.get_segments_summaries(["seg-1"], "dataset-1", session=session) == {}
+    assert SummaryIndexService.get_document_summaries("doc-1", "dataset-1", session=session) == []
+
+
+def test_get_document_summaries_empty_segment_selection_is_empty() -> None:
+    session = MagicMock()
+
+    assert (
+        SummaryIndexService.get_document_summaries(
+            "doc-1",
+            "dataset-1",
+            segment_ids=[],
+            session=session,
+        )
+        == []
+    )
+    session.scalars.assert_not_called()
+
+
 def test_get_document_summary_index_status_no_segments_returns_none() -> None:
     session = MagicMock()
     session.scalars.return_value.all.return_value = []
@@ -1112,12 +2381,14 @@ def test_get_documents_summary_index_status_empty_input() -> None:
 
 
 def test_get_documents_summary_index_status_no_pending_sets_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    completed_summary = _concrete_summary_record()
+    completed_summary.status = SummaryStatus.COMPLETED
     session = MagicMock()
-    session.execute.return_value.all.return_value = [SimpleNamespace(id="seg-1", document_id="doc-1")]
+    session.execute.return_value.all.return_value = [_concrete_segment()]
     monkeypatch.setattr(
         SummaryIndexService,
         "get_segments_summaries",
-        MagicMock(return_value={"seg-1": SimpleNamespace(status=SummaryStatus.COMPLETED)}),
+        MagicMock(return_value={"seg-1": completed_summary}),
     )
     result = SummaryIndexService.get_documents_summary_index_status(["doc-1"], "dataset-1", "tenant-1", session=session)
     assert result["doc-1"] is None
@@ -1129,19 +2400,24 @@ def test_update_summary_for_segment_creates_new_and_vectorize_fails_returns_erro
     dataset = _dataset()
     segment = _segment()
 
-    session = MagicMock(is_active=False)
-    session.scalar.return_value = None
+    staged_record = _summary_record(summary_content="new")
+    claim = _generation_claim()
+    caller_session = _CommitTrackingSession()
+    monkeypatch.setattr(SummaryIndexService, "_mark_summary_generation_started", MagicMock(return_value=claim))
+    monkeypatch.setattr(SummaryIndexService, "_save_summary_content", MagicMock(return_value=staged_record))
+    monkeypatch.setattr(SummaryIndexService, "update_summary_record_error", MagicMock())
+    vectorize_mock = MagicMock(side_effect=RuntimeError("boom"))
+    monkeypatch.setattr(SummaryIndexService, "vectorize_summary", vectorize_mock)
 
-    created = _summary_record(summary_content="new", node_id=None)
-    monkeypatch.setattr(SummaryIndexService, "create_summary_record", MagicMock(return_value=created))
-    monkeypatch.setattr(SummaryIndexService, "vectorize_summary", MagicMock(side_effect=RuntimeError("boom")))
-
-    out = SummaryIndexService.update_summary_for_segment(segment, dataset, "new", session=session)
+    out = SummaryIndexService.update_summary_for_segment(
+        segment,
+        dataset,
+        "new",
+        session=cast(Session, caller_session),
+    )
+    assert out is not None
     assert out.status == SummaryStatus.ERROR
     assert "Vectorization failed" in (out.error or "")
-    session.rollback.assert_called_once()
-    session.add.assert_called_with(created)
-    session.commit.assert_called_once()
 
 
 def test_get_segments_summaries_empty_list() -> None:
@@ -1149,14 +2425,18 @@ def test_get_segments_summaries_empty_list() -> None:
 
 
 def test_get_document_summary_index_status_and_documents_status(monkeypatch: pytest.MonkeyPatch) -> None:
-    seg_row = SimpleNamespace(id="seg-1", document_id="doc-1")
+    segment = _concrete_segment()
+    generating_summary = _concrete_summary_record()
+    generating_summary.status = SummaryStatus.GENERATING
+    not_started_summary = _concrete_summary_record()
+    not_started_summary.status = SummaryStatus.NOT_STARTED
     session = MagicMock()
     session.scalars.return_value.all.return_value = ["seg-1"]  # get_document_summary_index_status returns IDs
 
     monkeypatch.setattr(
         SummaryIndexService,
         "get_segments_summaries",
-        MagicMock(return_value={"seg-1": SimpleNamespace(status=SummaryStatus.GENERATING)}),
+        MagicMock(return_value={"seg-1": generating_summary}),
     )
     assert (
         SummaryIndexService.get_document_summary_index_status("doc-1", "dataset-1", "tenant-1", session=session)
@@ -1165,11 +2445,11 @@ def test_get_document_summary_index_status_and_documents_status(monkeypatch: pyt
 
     # Multiple docs
     session2 = MagicMock()
-    session2.execute.return_value.all.return_value = [seg_row]  # get_documents_summary_index_status uses execute
+    session2.execute.return_value.all.return_value = [segment]  # get_documents_summary_index_status uses execute
     monkeypatch.setattr(
         SummaryIndexService,
         "get_segments_summaries",
-        MagicMock(return_value={"seg-1": SimpleNamespace(status=SummaryStatus.NOT_STARTED)}),
+        MagicMock(return_value={"seg-1": not_started_summary}),
     )
     result = SummaryIndexService.get_documents_summary_index_status(
         ["doc-1", "doc-2"], "dataset-1", "tenant-1", session=session2
@@ -1202,5 +2482,327 @@ def test_get_document_summary_status_detail_counts_and_previews(monkeypatch: pyt
     assert detail["total_segments"] == 2
     assert detail["summary_status"]["completed"] == 1
     assert detail["summary_status"]["not_started"] == 1
-    assert detail["summaries"][0]["summary_preview"].endswith("...")
+    summary_preview = detail["summaries"][0]["summary_preview"]
+    assert summary_preview is not None
+    assert summary_preview.endswith("...")
     assert detail["summaries"][1]["status"] == "not_started"
+
+
+def test_get_document_summary_status_detail_hides_internal_generation_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    segment = _segment()
+    summary = _summary_record()
+    summary.status = SummaryStatus.COMPLETED
+    summary.summary_index_node_id = "active-node"
+    summary.error = SummaryIndexService._generation_claim_marker("generation-1")
+
+    segment_service = SimpleNamespace(get_segments_by_document_and_dataset=MagicMock(return_value=[segment]))
+    monkeypatch.setitem(sys.modules, "services.dataset_service", SimpleNamespace(SegmentService=segment_service))
+    monkeypatch.setattr(SummaryIndexService, "get_document_summaries", MagicMock(return_value=[summary]))
+
+    detail = SummaryIndexService.get_document_summary_status_detail("doc-1", "dataset-1", MagicMock())
+
+    assert detail["summaries"][0]["status"] == SummaryStatus.GENERATING
+    assert detail["summaries"][0]["error"] is None
+
+
+def test_lock_segment_rows_empty_selection_is_noop() -> None:
+    session = MagicMock()
+
+    SummaryIndexService._lock_segment_rows(session, "dataset-1", [])
+
+    session.execute.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("allows_summary", "source_content", "message"),
+    [
+        (False, "hello world", "no longer accepts summaries"),
+        (True, "changed content", "changed before summary generation started"),
+    ],
+)
+def test_mark_summary_generation_rejects_stale_segment_state(
+    monkeypatch: pytest.MonkeyPatch,
+    allows_summary: bool,
+    source_content: str,
+    message: str,
+) -> None:
+    session = MagicMock()
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+    monkeypatch.setattr(SummaryIndexService, "_segment_allows_summary", MagicMock(return_value=allows_summary))
+    monkeypatch.setattr(SummaryIndexService, "_get_segment_content", MagicMock(return_value=source_content))
+
+    with pytest.raises(summary_module.SummaryIndexConflictError, match=message):
+        SummaryIndexService._mark_summary_generation_started(_segment(), _dataset())
+
+    session.add.assert_not_called()
+    session.commit.assert_not_called()
+
+
+def test_save_summary_content_rejects_segment_that_became_ineligible(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = MagicMock()
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+    monkeypatch.setattr(SummaryIndexService, "_segment_allows_summary", MagicMock(return_value=False))
+
+    with pytest.raises(summary_module.SummaryIndexConflictError, match="no longer accepts summaries"):
+        SummaryIndexService._save_summary_content(_segment(), _dataset(), "summary")
+
+    session.add.assert_not_called()
+    session.commit.assert_not_called()
+
+
+def test_batch_create_summary_records_skips_ineligible_segments(monkeypatch: pytest.MonkeyPatch) -> None:
+    allowed = _segment()
+    disallowed = _segment()
+    disallowed.id = "seg-disallowed"
+    session = MagicMock()
+    session.scalars.return_value.all.return_value = []
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=MagicMock(return_value=_SessionContext(session))),
+    )
+    monkeypatch.setattr(SummaryIndexService, "_lock_segment_rows", MagicMock())
+    monkeypatch.setattr(
+        SummaryIndexService,
+        "_summary_allowed_segment_ids",
+        MagicMock(return_value={allowed.id}),
+    )
+
+    SummaryIndexService.batch_create_summary_records([allowed, disallowed], _dataset())
+
+    assert session.add.call_count == 1
+    assert session.add.call_args.args[0].chunk_id == allowed.id
+    session.commit.assert_called_once_with()
+
+
+def test_generation_failure_before_vectorization_updates_claimed_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    claim = _generation_claim()
+    update_error = MagicMock()
+    monkeypatch.setattr(SummaryIndexService, "_mark_summary_generation_started", MagicMock(return_value=claim))
+    monkeypatch.setattr(
+        SummaryIndexService,
+        "generate_summary_for_segment",
+        MagicMock(side_effect=RuntimeError("llm unavailable")),
+    )
+    monkeypatch.setattr(SummaryIndexService, "update_summary_record_error", update_error)
+
+    segment = _segment()
+    dataset = _dataset()
+    with pytest.raises(RuntimeError, match="llm unavailable"):
+        SummaryIndexService.generate_and_vectorize_summary(segment, dataset, {"enable": True})
+
+    update_error.assert_called_once_with(
+        segment=segment,
+        dataset=dataset,
+        error="llm unavailable",
+        generation_claim=claim,
+    )
+
+
+def test_empty_summary_mutation_selections_do_not_open_transactions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    create_session = MagicMock(side_effect=AssertionError("no session expected"))
+    monkeypatch.setattr(
+        summary_module,
+        "session_factory",
+        SimpleNamespace(create_session=create_session),
+    )
+    dataset = _dataset()
+
+    SummaryIndexService.disable_summaries_for_segments(dataset, segment_ids=[])
+    SummaryIndexService.enable_summaries_for_segments(dataset, segment_ids=[])
+    SummaryIndexService.delete_summaries_for_segments(dataset, segment_ids=[])
+
+    create_session.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        SummaryIndexService.disable_summaries_for_segments,
+        SummaryIndexService.delete_summaries_for_segments,
+    ],
+)
+def test_caller_owned_summary_mutation_rolls_back_nested_transaction_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    operation,
+) -> None:
+    dataset = _dataset()
+    session = MagicMock()
+    session.is_active = False
+    nested = MagicMock()
+    nested.__enter__.side_effect = RuntimeError("savepoint failed")
+    session.begin_nested.return_value = nested
+
+    with pytest.raises(RuntimeError, match="savepoint failed"):
+        operation(dataset, segment_ids=["seg-1"], session=session)
+
+    session.rollback.assert_called_once_with()
+    session.refresh.assert_not_called()
+    session.commit.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        SummaryIndexService.disable_summaries_for_segments,
+        SummaryIndexService.delete_summaries_for_segments,
+    ],
+)
+def test_caller_owned_summary_mutation_preserves_active_outer_transaction(
+    operation,
+) -> None:
+    dataset = _dataset()
+    session = MagicMock()
+    session.is_active = True
+    nested = MagicMock()
+    nested.__enter__.side_effect = RuntimeError("savepoint failed")
+    session.begin_nested.return_value = nested
+
+    with pytest.raises(RuntimeError, match="savepoint failed"):
+        operation(dataset, segment_ids=["seg-1"], session=session)
+
+    session.rollback.assert_not_called()
+    session.commit.assert_not_called()
+
+
+def test_enable_summaries_skips_duplicate_and_already_enabled_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    disabled = _summary_record(summary_content="summary")
+    disabled.enabled = False
+    duplicate = _summary_record(summary_content="older duplicate")
+    duplicate.enabled = False
+    already_enabled = _summary_record(summary_content="enabled")
+    already_enabled.chunk_id = "seg-enabled"
+    already_enabled.enabled = True
+    segment = _segment()
+
+    session = MagicMock()
+    summaries_result = MagicMock()
+    summaries_result.all.return_value = [disabled, duplicate, already_enabled]
+    segments_result = MagicMock()
+    segments_result.all.return_value = [segment]
+    session.scalars.side_effect = [summaries_result, segments_result]
+    vectorize_summary = MagicMock()
+    monkeypatch.setattr(SummaryIndexService, "vectorize_summary", vectorize_summary)
+    monkeypatch.setattr(SummaryIndexService, "_enable_summary_record", MagicMock(return_value=True))
+
+    SummaryIndexService.enable_summaries_for_segments(
+        _dataset(),
+        session=session,
+        segment_ids=[disabled.chunk_id, already_enabled.chunk_id],
+    )
+
+    vectorize_summary.assert_called_once_with(disabled, segment, ANY)
+    session.scalar.assert_not_called()
+
+
+def test_empty_manual_summary_rolls_back_nested_transaction_failure() -> None:
+    dataset = _dataset()
+    session = MagicMock()
+    session.is_active = False
+    session.scalar.return_value = IndexStructureType.PARAGRAPH_INDEX
+    nested = MagicMock()
+    nested.__enter__.side_effect = RuntimeError("savepoint failed")
+    session.begin_nested.return_value = nested
+
+    with pytest.raises(RuntimeError, match="savepoint failed"):
+        SummaryIndexService.update_summary_for_segment(
+            _segment(),
+            dataset,
+            "",
+            session=session,
+        )
+
+    session.rollback.assert_called_once_with()
+    session.refresh.assert_not_called()
+    session.commit.assert_not_called()
+
+
+def test_manual_summary_conflict_is_logged_and_reraised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conflict = summary_module.SummaryIndexConflictError("superseded")
+    claim = _generation_claim()
+    abandon_claim = MagicMock()
+    monkeypatch.setattr(SummaryIndexService, "_mark_summary_generation_started", MagicMock(return_value=claim))
+    monkeypatch.setattr(SummaryIndexService, "_save_summary_content", MagicMock(return_value=_summary_record()))
+    monkeypatch.setattr(SummaryIndexService, "vectorize_summary", MagicMock(side_effect=conflict))
+    monkeypatch.setattr(SummaryIndexService, "_abandon_generation_claim", abandon_claim)
+    session = MagicMock()
+    session.scalar.return_value = IndexStructureType.PARAGRAPH_INDEX
+
+    with pytest.raises(summary_module.SummaryIndexConflictError, match="superseded"):
+        SummaryIndexService.update_summary_for_segment(
+            _segment(),
+            _dataset(),
+            "manual",
+            session=session,
+        )
+
+    abandon_claim.assert_called_once_with(claim)
+
+
+def test_update_summary_for_segment_commits_without_expiring_loaded_instances(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = _concrete_dataset()
+    segment = _concrete_segment()
+    summary_record = _concrete_summary_record(summary_content="manual summary")
+    claim = _generation_claim()
+    caller_session = _ScopedCommitTrackingSession()
+    vectorized: list[tuple[DocumentSegmentSummary, DocumentSegment, Dataset, SummaryGenerationClaim]] = []
+
+    def save_summary_content(
+        *,
+        segment: DocumentSegment,
+        dataset: Dataset,
+        summary_content: str,
+        status: SummaryStatus = SummaryStatus.GENERATING,
+        generation_claim: SummaryGenerationClaim | None = None,
+    ) -> DocumentSegmentSummary:
+        assert summary_content == "manual summary"
+        assert status == SummaryStatus.GENERATING
+        assert generation_claim is claim
+        assert isinstance(segment, DocumentSegment)
+        assert isinstance(dataset, Dataset)
+        return summary_record
+
+    def vectorize_summary(
+        summary_record: DocumentSegmentSummary,
+        segment: DocumentSegment,
+        dataset: Dataset,
+        *,
+        generation_claim: SummaryGenerationClaim,
+    ) -> None:
+        vectorized.append((summary_record, segment, dataset, generation_claim))
+
+    monkeypatch.setattr(SummaryIndexService, "_mark_summary_generation_started", MagicMock(return_value=claim))
+    monkeypatch.setattr(SummaryIndexService, "_save_summary_content", save_summary_content)
+    monkeypatch.setattr(SummaryIndexService, "vectorize_summary", vectorize_summary)
+
+    result = SummaryIndexService.update_summary_for_segment(
+        segment,
+        dataset,
+        "manual summary",
+        session=cast(Session, caller_session),
+    )
+
+    assert result is summary_record
+    assert vectorized == [(summary_record, segment, dataset, claim)]
+    assert caller_session.current_session.commit_expire_on_commit_values == [False]
+    assert caller_session.current_session.expire_on_commit is True

--- a/api/tests/unit_tests/tasks/test_batch_clean_document_task.py
+++ b/api/tests/unit_tests/tasks/test_batch_clean_document_task.py
@@ -1,12 +1,37 @@
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
+from core.rag.index_processor.constant.index_type import IndexTechniqueType
+from extensions.storage.storage_type import StorageType
+from models.dataset import Dataset, DocumentSegment
+from models.enums import CreatorUserRole, SegmentStatus
+from models.model import UploadFile
 from tasks.batch_clean_document_task import batch_clean_document_task
 
 
-def _setup_cleanup_dependencies():
+def _setup_cleanup_dependencies(*, index_node_id: str | None = "node-1"):
     session = MagicMock()
-    segment = MagicMock(id="segment-1", index_node_id="node-1", content="content")
-    dataset = MagicMock(id="dataset-1", tenant_id="tenant-1")
+    segment = DocumentSegment(
+        tenant_id="tenant-1",
+        dataset_id="dataset-1",
+        document_id="document-1",
+        position=1,
+        content="content",
+        word_count=1,
+        tokens=1,
+        created_by="creator-1",
+        index_node_id=index_node_id,
+        status=SegmentStatus.COMPLETED,
+        enabled=True,
+    )
+    segment.id = "segment-1"
+    dataset = Dataset(
+        tenant_id="tenant-1",
+        name="Cleanup dataset",
+        created_by="creator-1",
+        indexing_technique=IndexTechniqueType.HIGH_QUALITY,
+    )
+    dataset.id = "dataset-1"
     session.scalars.return_value.all.return_value = [segment]
     session.scalar.return_value = dataset
 
@@ -37,7 +62,7 @@ def test_successful_vector_cleanup_schedules_billing_refresh():
 
 
 def test_failed_vector_cleanup_does_not_schedule_billing_refresh():
-    _, context_manager = _setup_cleanup_dependencies()
+    session, context_manager = _setup_cleanup_dependencies()
 
     with (
         patch("tasks.batch_clean_document_task.session_factory.create_session", return_value=context_manager),
@@ -55,4 +80,94 @@ def test_failed_vector_cleanup_does_not_schedule_billing_refresh():
             file_ids=[],
         )
 
+    assert any("DELETE FROM document_segment_summaries" in str(call.args[0]) for call in session.execute.call_args_list)
+    assert any("DELETE FROM child_chunks" in str(call.args[0]) for call in session.execute.call_args_list)
     schedule_refresh.assert_not_called()
+
+
+def test_segment_without_primary_node_id_still_runs_summary_cleanup():
+    _, context_manager = _setup_cleanup_dependencies(index_node_id=None)
+
+    with (
+        patch("tasks.batch_clean_document_task.session_factory.create_session", return_value=context_manager),
+        patch("tasks.batch_clean_document_task.get_image_upload_file_ids", return_value=[]),
+        patch("tasks.batch_clean_document_task.IndexProcessorFactory") as processor_factory,
+        patch("tasks.batch_clean_document_task.schedule_billing_vector_space_refresh"),
+    ):
+        batch_clean_document_task(
+            document_ids=["document-1"],
+            dataset_id="dataset-1",
+            doc_form="paragraph",
+            file_ids=[],
+        )
+
+    processor = processor_factory.return_value.init_index_processor.return_value
+    processor.clean.assert_called_once()
+    args, kwargs = processor.clean.call_args
+    assert args[1] == []
+    assert kwargs["segment_ids"] == ["segment-1"]
+    assert kwargs["delete_summaries"] is True
+
+
+def test_missing_dataset_is_a_scoped_noop():
+    session = MagicMock()
+    session.scalar.return_value = None
+    context_manager = MagicMock()
+    context_manager.__enter__.return_value = session
+
+    with (
+        patch("tasks.batch_clean_document_task.session_factory.create_session", return_value=context_manager),
+        patch("tasks.batch_clean_document_task.IndexProcessorFactory") as processor_factory,
+    ):
+        batch_clean_document_task(
+            document_ids=["document-1"],
+            dataset_id="missing-dataset",
+            doc_form="paragraph",
+            file_ids=[],
+        )
+
+    processor_factory.assert_not_called()
+    session.scalars.assert_not_called()
+
+
+def test_image_upload_rows_are_tenant_scoped_and_deleted():
+    session, context_manager = _setup_cleanup_dependencies()
+    image_file = UploadFile(
+        tenant_id="tenant-1",
+        storage_type=StorageType.LOCAL,
+        key="image-key",
+        name="image.png",
+        size=10,
+        extension="png",
+        mime_type="image/png",
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by="creator-1",
+        created_at=datetime.now(UTC).replace(tzinfo=None),
+        used=True,
+    )
+    segment_result = MagicMock()
+    segment_result.all.return_value = session.scalars.return_value.all.return_value
+    image_result = MagicMock()
+    image_result.all.return_value = [image_file]
+    session.scalars.side_effect = [segment_result, image_result]
+
+    with (
+        patch("tasks.batch_clean_document_task.session_factory.create_session", return_value=context_manager),
+        patch("tasks.batch_clean_document_task.get_image_upload_file_ids", return_value=[image_file.id]),
+        patch("tasks.batch_clean_document_task.IndexProcessorFactory"),
+        patch("tasks.batch_clean_document_task.storage") as storage,
+        patch("tasks.batch_clean_document_task.schedule_billing_vector_space_refresh"),
+    ):
+        batch_clean_document_task(
+            document_ids=["document-1"],
+            dataset_id="dataset-1",
+            doc_form="paragraph",
+            file_ids=[],
+        )
+
+    executed_statements = [str(call.args[0]) for call in session.execute.call_args_list]
+    assert any("DELETE FROM upload_files" in statement for statement in executed_statements)
+    assert all(
+        "upload_files.tenant_id" in statement for statement in executed_statements if "upload_files" in statement
+    )
+    storage.delete.assert_called_once_with(image_file.key)

--- a/api/tests/unit_tests/tasks/test_clean_dataset_task.py
+++ b/api/tests/unit_tests/tasks/test_clean_dataset_task.py
@@ -12,12 +12,16 @@ This module tests the dataset cleanup task functionality including:
 """
 
 import uuid
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
-from models.enums import DataSourceType
+from extensions.storage.storage_type import StorageType
+from models.dataset import DocumentSegment, SegmentAttachmentBinding
+from models.enums import CreatorUserRole, SegmentStatus
+from models.model import UploadFile
 from tasks.clean_dataset_task import clean_dataset_task
 
 # ============================================================================
@@ -105,35 +109,32 @@ def mock_get_image_upload_file_ids():
         yield mock_func
 
 
-@pytest.fixture
-def mock_document():
-    """Create a mock Document object."""
-    doc = MagicMock()
-    doc.id = str(uuid.uuid4())
-    doc.tenant_id = str(uuid.uuid4())
-    doc.dataset_id = str(uuid.uuid4())
-    doc.data_source_type = DataSourceType.UPLOAD_FILE
-    doc.data_source_info = '{"upload_file_id": "test-file-id"}'
-    doc.data_source_info_dict = {"upload_file_id": "test-file-id"}
-    return doc
-
-
-@pytest.fixture
-def mock_segment():
-    """Create a mock DocumentSegment object."""
-    segment = MagicMock()
-    segment.id = str(uuid.uuid4())
-    segment.content = "Test segment content"
-    return segment
-
-
-@pytest.fixture
-def mock_upload_file():
-    """Create a mock UploadFile object."""
-    upload_file = MagicMock()
-    upload_file.id = str(uuid.uuid4())
-    upload_file.key = f"test_files/{uuid.uuid4()}.txt"
-    return upload_file
+def _attachment(
+    *,
+    tenant_id: str,
+    dataset_id: str,
+) -> tuple[SegmentAttachmentBinding, UploadFile]:
+    attachment_file = UploadFile(
+        tenant_id=tenant_id,
+        storage_type=StorageType.LOCAL,
+        key=f"attachments/{uuid.uuid4()}.pdf",
+        name="attachment.pdf",
+        size=10,
+        extension="pdf",
+        mime_type="application/pdf",
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by="00000000-0000-0000-0000-000000000001",
+        created_at=datetime.now(UTC).replace(tzinfo=None),
+        used=True,
+    )
+    binding = SegmentAttachmentBinding(
+        tenant_id=tenant_id,
+        dataset_id=dataset_id,
+        document_id=str(uuid.uuid4()),
+        segment_id=str(uuid.uuid4()),
+        attachment_id=attachment_file.id,
+    )
+    return binding, attachment_file
 
 
 # ============================================================================
@@ -225,9 +226,9 @@ class TestPipelineAndWorkflowDeletion:
             pipeline_id=pipeline_id,
         )
 
-        # Assert - verify execute was called for delete operations
-        # 1 attachment JOIN query + 5 base deletes + 2 pipeline/workflow deletes = 8
-        assert mock_db_session.session.execute.call_count >= 8
+        executed_sql = [str(call.args[0]) for call in mock_db_session.session.execute.call_args_list]
+        assert any("DELETE FROM pipelines" in sql for sql in executed_sql)
+        assert any("DELETE FROM workflows" in sql for sql in executed_sql)
 
     def test_clean_dataset_task_without_pipeline_id(
         self,
@@ -256,9 +257,11 @@ class TestPipelineAndWorkflowDeletion:
             pipeline_id=None,
         )
 
-        # Assert - verify execute was called for delete operations
-        # 1 attachment JOIN query + 5 base deletes = 6
-        assert mock_db_session.session.execute.call_count == 6
+        executed_sql = [str(call.args[0]) for call in mock_db_session.session.execute.call_args_list]
+        assert not any("DELETE FROM pipelines" in sql for sql in executed_sql)
+        assert not any("DELETE FROM workflows" in sql for sql in executed_sql)
+        assert any("DELETE FROM document_segment_summaries" in sql for sql in executed_sql)
+        assert any("DELETE FROM child_chunks" in sql for sql in executed_sql)
 
 
 # ============================================================================
@@ -292,15 +295,10 @@ class TestSegmentAttachmentCleanup:
         - Binding records are deleted from database
         """
         # Arrange
-        mock_binding = MagicMock()
-        mock_binding.attachment_id = str(uuid.uuid4())
-
-        mock_attachment_file = MagicMock()
-        mock_attachment_file.id = mock_binding.attachment_id
-        mock_attachment_file.key = f"attachments/{uuid.uuid4()}.pdf"
+        binding, attachment_file = _attachment(tenant_id=tenant_id, dataset_id=dataset_id)
 
         # Setup execute to return attachment with binding
-        mock_db_session.session.execute.return_value.all.return_value = [(mock_binding, mock_attachment_file)]
+        mock_db_session.session.execute.return_value.all.return_value = [(binding, attachment_file)]
 
         # Act
         clean_dataset_task(
@@ -313,7 +311,7 @@ class TestSegmentAttachmentCleanup:
         )
 
         # Assert
-        mock_storage.delete.assert_called_with(mock_attachment_file.key)
+        mock_storage.delete.assert_called_with(attachment_file.key)
         # Attachment file and binding are deleted in batch; verify DELETEs were issued
         execute_sqls = [" ".join(str(c[0][0]).split()) for c in mock_db_session.session.execute.call_args_list]
         assert any("DELETE FROM upload_files" in sql for sql in execute_sqls)
@@ -337,14 +335,9 @@ class TestSegmentAttachmentCleanup:
         - Attachment file and binding are still deleted from database
         """
         # Arrange
-        mock_binding = MagicMock()
-        mock_binding.attachment_id = str(uuid.uuid4())
+        binding, attachment_file = _attachment(tenant_id=tenant_id, dataset_id=dataset_id)
 
-        mock_attachment_file = MagicMock()
-        mock_attachment_file.id = mock_binding.attachment_id
-        mock_attachment_file.key = f"attachments/{uuid.uuid4()}.pdf"
-
-        mock_db_session.session.execute.return_value.all.return_value = [(mock_binding, mock_attachment_file)]
+        mock_db_session.session.execute.return_value.all.return_value = [(binding, attachment_file)]
         mock_storage.delete.side_effect = Exception("Storage error")
 
         # Act
@@ -487,4 +480,55 @@ class TestIndexProcessorParameters:
                 doc_form=IndexStructureType.PARAGRAPH_INDEX,
             )
 
+        assert any(
+            "DELETE FROM child_chunks" in str(call.args[0]) for call in mock_db_session.session.execute.call_args_list
+        )
         schedule_refresh.assert_not_called()
+
+    def test_cleanup_removes_segments_when_documents_were_already_deleted(
+        self,
+        dataset_id: str,
+        tenant_id: str,
+        collection_binding_id: str,
+        mock_db_session,
+        mock_storage,
+        mock_index_processor_factory,
+        mock_get_image_upload_file_ids,
+    ):
+        segment = DocumentSegment(
+            tenant_id=tenant_id,
+            dataset_id=dataset_id,
+            document_id=str(uuid.uuid4()),
+            position=1,
+            content="Test segment content",
+            word_count=2,
+            tokens=2,
+            created_by="00000000-0000-0000-0000-000000000001",
+            status=SegmentStatus.COMPLETED,
+        )
+        segment.id = str(uuid.uuid4())
+        document_result = MagicMock()
+        document_result.all.return_value = []
+        segment_result = MagicMock()
+        segment_result.all.return_value = [segment]
+        empty_result = MagicMock()
+        empty_result.all.return_value = []
+        mock_db_session.session.scalars.side_effect = [
+            document_result,
+            segment_result,
+            empty_result,
+        ]
+
+        clean_dataset_task(
+            dataset_id=dataset_id,
+            tenant_id=tenant_id,
+            indexing_technique=IndexTechniqueType.HIGH_QUALITY,
+            index_struct='{"type": "paragraph"}',
+            collection_binding_id=collection_binding_id,
+            doc_form=IndexStructureType.PARAGRAPH_INDEX,
+        )
+
+        assert any(
+            "DELETE FROM document_segments" in str(call.args[0])
+            for call in mock_db_session.session.execute.call_args_list
+        )

--- a/api/tests/unit_tests/tasks/test_clean_document_task.py
+++ b/api/tests/unit_tests/tasks/test_clean_document_task.py
@@ -6,6 +6,7 @@ starts from the production incident shape: the caller has already deleted the
 """
 
 import uuid
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,6 +14,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 import tasks.clean_document_task as clean_document_task_module
+from extensions.storage.storage_type import StorageType
 from models.dataset import (
     Dataset,
     DatasetMetadataBinding,
@@ -20,7 +22,7 @@ from models.dataset import (
     DocumentSegment,
     SegmentAttachmentBinding,
 )
-from models.enums import DataSourceType, DocumentCreatedFrom
+from models.enums import CreatorUserRole, DataSourceType, DocumentCreatedFrom
 from models.model import UploadFile
 from tasks.clean_document_task import clean_document_task
 
@@ -201,6 +203,22 @@ def _assert_relational_cleanup(
     assert remaining_binding_document_ids == {other_document_id}
 
 
+def _upload_file(*, tenant_id: str, key: str) -> UploadFile:
+    return UploadFile(
+        tenant_id=tenant_id,
+        storage_type=StorageType.LOCAL,
+        key=key,
+        name=f"{key}.bin",
+        size=10,
+        extension="bin",
+        mime_type="application/octet-stream",
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by="creator-1",
+        created_at=datetime.now(UTC).replace(tzinfo=None),
+        used=True,
+    )
+
+
 class TestVectorCleanupResilience:
     """Vector/index failures must not abort relational cleanup."""
 
@@ -280,6 +298,7 @@ class TestVectorCleanupResilience:
             "with_keywords": True,
             "delete_child_chunks": True,
             "delete_summaries": True,
+            "segment_ids": ["seg-1"],
         }
         _assert_relational_cleanup(
             sqlite_session,
@@ -288,6 +307,49 @@ class TestVectorCleanupResilience:
             survivor_segment_id=survivor_segment_id,
         )
         schedule_refresh.assert_called_once_with(tenant_id)
+
+    def test_segment_without_primary_node_id_still_runs_summary_cleanup(
+        self,
+        document_id: str,
+        dataset_id: str,
+        tenant_id: str,
+        sqlite_session: Session,
+        bind_task_sessions: None,
+        mock_storage,
+        mock_index_processor_factory,
+    ) -> None:
+        segment_id = "seg-with-summary-only"
+        other_document_id, survivor_segment_id = _persist_deleted_document_state(
+            sqlite_session,
+            document_id=document_id,
+            dataset_id=dataset_id,
+            tenant_id=tenant_id,
+            target_segment_ids=[segment_id],
+        )
+        segment = sqlite_session.get(DocumentSegment, segment_id)
+        assert segment is not None
+        segment.index_node_id = None
+        sqlite_session.commit()
+
+        with patch("tasks.clean_document_task.schedule_billing_vector_space_refresh"):
+            clean_document_task(
+                document_id=document_id,
+                dataset_id=dataset_id,
+                doc_form="paragraph",
+                file_id=None,
+            )
+
+        mock_index_processor_factory["processor"].clean.assert_called_once()
+        args, kwargs = mock_index_processor_factory["processor"].clean.call_args
+        assert args[1] == []
+        assert kwargs["segment_ids"] == [segment_id]
+        assert kwargs["delete_summaries"] is True
+        _assert_relational_cleanup(
+            sqlite_session,
+            document_id=document_id,
+            other_document_id=other_document_id,
+            survivor_segment_id=survivor_segment_id,
+        )
 
     def test_no_segments_skips_vector_cleanup(
         self,
@@ -324,3 +386,78 @@ class TestVectorCleanupResilience:
             survivor_segment_id=survivor_segment_id,
         )
         schedule_refresh.assert_not_called()
+
+    def test_document_and_attachment_cleanup_is_tenant_scoped_when_storage_fails(
+        self,
+        document_id: str,
+        dataset_id: str,
+        tenant_id: str,
+        sqlite_session: Session,
+        bind_task_sessions: None,
+        mock_storage,
+        mock_index_processor_factory,
+    ) -> None:
+        other_document_id, survivor_segment_id = _persist_deleted_document_state(
+            sqlite_session,
+            document_id=document_id,
+            dataset_id=dataset_id,
+            tenant_id=tenant_id,
+            target_segment_ids=[],
+        )
+        foreign_tenant_id = str(uuid.uuid4())
+        attachment_file = _upload_file(tenant_id=tenant_id, key="attachment-key")
+        document_file = _upload_file(tenant_id=tenant_id, key="document-key")
+        foreign_file = _upload_file(tenant_id=foreign_tenant_id, key="foreign-key")
+        target_binding = SegmentAttachmentBinding(
+            tenant_id=tenant_id,
+            dataset_id=dataset_id,
+            document_id=document_id,
+            segment_id="segment-1",
+            attachment_id=attachment_file.id,
+        )
+        foreign_binding = SegmentAttachmentBinding(
+            tenant_id=foreign_tenant_id,
+            dataset_id=dataset_id,
+            document_id=document_id,
+            segment_id="segment-1",
+            attachment_id=foreign_file.id,
+        )
+        document_file_id = document_file.id
+        attachment_file_id = attachment_file.id
+        foreign_file_id = foreign_file.id
+        target_binding_id = target_binding.id
+        foreign_binding_id = foreign_binding.id
+        expected_storage_keys = [document_file.key, attachment_file.key]
+        sqlite_session.add_all(
+            [
+                attachment_file,
+                document_file,
+                foreign_file,
+                target_binding,
+                foreign_binding,
+            ]
+        )
+        sqlite_session.commit()
+        mock_storage.delete.side_effect = RuntimeError("storage unavailable")
+
+        clean_document_task(
+            document_id=document_id,
+            dataset_id=dataset_id,
+            doc_form="paragraph",
+            file_id=document_file_id,
+        )
+
+        mock_index_processor_factory["factory_cls"].assert_not_called()
+        assert [call.args[0] for call in mock_storage.delete.call_args_list] == expected_storage_keys
+        sqlite_session.expire_all()
+        assert sqlite_session.get(UploadFile, document_file_id) is None
+        assert sqlite_session.get(UploadFile, attachment_file_id) is None
+        assert sqlite_session.get(UploadFile, foreign_file_id) is not None
+        assert sqlite_session.get(SegmentAttachmentBinding, target_binding_id) is None
+        assert sqlite_session.get(SegmentAttachmentBinding, foreign_binding_id) is not None
+        _assert_relational_cleanup(
+            sqlite_session,
+            document_id=document_id,
+            other_document_id=other_document_id,
+            survivor_segment_id=survivor_segment_id,
+        )

--- a/api/tests/unit_tests/tasks/test_clean_notion_document_task.py
+++ b/api/tests/unit_tests/tasks/test_clean_notion_document_task.py
@@ -1,0 +1,132 @@
+"""Unit tests for the Notion document cleanup task."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import tasks.clean_notion_document_task as task_module
+from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
+from models.dataset import Dataset, DocumentSegment
+from models.enums import SegmentStatus
+
+
+def _dataset() -> Dataset:
+    return Dataset(
+        id="dataset-1",
+        tenant_id="tenant-1",
+        name="Notion dataset",
+        created_by="creator-1",
+        indexing_technique=IndexTechniqueType.HIGH_QUALITY,
+        chunk_structure=IndexStructureType.PARAGRAPH_INDEX,
+    )
+
+
+def _segment(dataset: Dataset) -> DocumentSegment:
+    segment = DocumentSegment(
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        document_id="document-1",
+        position=1,
+        content="notion content",
+        word_count=2,
+        tokens=2,
+        created_by=dataset.created_by,
+        index_node_id=None,
+        status=SegmentStatus.COMPLETED,
+    )
+    segment.id = "segment-1"
+    return segment
+
+
+def test_empty_document_list_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    create_session = MagicMock()
+    index_processor_factory = MagicMock()
+    monkeypatch.setattr(task_module.session_factory, "create_session", create_session)
+    monkeypatch.setattr(task_module, "IndexProcessorFactory", index_processor_factory)
+
+    task_module.clean_notion_document_task.run([], "dataset-1")
+
+    create_session.assert_not_called()
+    index_processor_factory.assert_not_called()
+
+
+def test_segments_without_index_node_ids_use_scoped_cleanup(monkeypatch: pytest.MonkeyPatch) -> None:
+    dataset = _dataset()
+    segment = _segment(dataset)
+
+    read_session = MagicMock()
+    read_session.scalar.return_value = dataset
+    read_session.scalars.return_value.all.return_value = [segment]
+    cleanup_session = MagicMock()
+    cleanup_session.scalar.return_value = dataset
+    delete_session = MagicMock()
+
+    session_contexts = []
+    for session in (read_session, cleanup_session, delete_session):
+        context = MagicMock()
+        context.__enter__.return_value = session
+        session_contexts.append(context)
+
+    create_session = MagicMock(side_effect=session_contexts)
+    monkeypatch.setattr(task_module.session_factory, "create_session", create_session)
+
+    index_processor = MagicMock()
+    index_processor_factory = MagicMock()
+    index_processor_factory.return_value.init_index_processor.return_value = index_processor
+    monkeypatch.setattr(task_module, "IndexProcessorFactory", index_processor_factory)
+
+    task_module.clean_notion_document_task.run(["document-1"], dataset.id)
+
+    index_processor.clean.assert_called_once_with(
+        dataset,
+        [],
+        with_keywords=True,
+        delete_child_chunks=True,
+        delete_summaries=True,
+        segment_ids=[segment.id],
+        session=cleanup_session,
+    )
+    assert cleanup_session.commit.call_count == 2
+    assert any(
+        "DELETE FROM document_segment_summaries" in str(call.args[0]) for call in delete_session.execute.call_args_list
+    )
+    assert any("DELETE FROM child_chunks" in str(call.args[0]) for call in delete_session.execute.call_args_list)
+
+
+def test_vector_cleanup_failure_still_removes_relational_summary_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    dataset = _dataset()
+    segment = _segment(dataset)
+    segment.index_node_id = "node-1"
+
+    read_session = MagicMock()
+    read_session.scalar.return_value = dataset
+    read_session.scalars.return_value.all.return_value = [segment]
+    cleanup_session = MagicMock()
+    cleanup_session.scalar.return_value = dataset
+    delete_session = MagicMock()
+
+    session_contexts = []
+    for session in (read_session, cleanup_session, delete_session):
+        context = MagicMock()
+        context.__enter__.return_value = session
+        session_contexts.append(context)
+    monkeypatch.setattr(
+        task_module.session_factory,
+        "create_session",
+        MagicMock(side_effect=session_contexts),
+    )
+
+    index_processor = MagicMock()
+    index_processor.clean.side_effect = RuntimeError("vector provider unavailable")
+    index_processor_factory = MagicMock()
+    index_processor_factory.return_value.init_index_processor.return_value = index_processor
+    monkeypatch.setattr(task_module, "IndexProcessorFactory", index_processor_factory)
+
+    task_module.clean_notion_document_task.run([segment.document_id], dataset.id)
+
+    index_processor.clean.assert_called_once()
+    cleanup_session.rollback.assert_not_called()
+    assert any(
+        "DELETE FROM document_segment_summaries" in str(call.args[0]) for call in delete_session.execute.call_args_list
+    )
+    assert any("DELETE FROM child_chunks" in str(call.args[0]) for call in delete_session.execute.call_args_list)

--- a/api/tests/unit_tests/tasks/test_document_indexing_sync_task.py
+++ b/api/tests/unit_tests/tasks/test_document_indexing_sync_task.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from core.db import session_factory as session_factory_module
 from core.rag.index_processor.constant.index_type import IndexStructureType
 from models.dataset import Dataset, Document, DocumentSegment
-from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus
+from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
 from tasks.document_indexing_sync_task import document_indexing_sync_task
 
 pytestmark = pytest.mark.parametrize(
@@ -111,6 +111,26 @@ def document(
     sqlite_session.add(document)
     sqlite_session.commit()
     return document
+
+
+@pytest.fixture
+def segment(sqlite_session: Session, dataset: Dataset, document: Document) -> DocumentSegment:
+    """Persist the old segment whose primary and summary vectors must be removed."""
+    segment = DocumentSegment(
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        document_id=document.id,
+        position=1,
+        content="Old Notion content",
+        word_count=3,
+        tokens=3,
+        created_by=document.created_by,
+        index_node_id="node-1",
+        status=SegmentStatus.COMPLETED,
+    )
+    sqlite_session.add(segment)
+    sqlite_session.commit()
+    return segment
 
 
 @pytest.fixture(autouse=True)
@@ -240,11 +260,14 @@ class TestDataSourceInfoSerialization:
     def test_data_source_info_serialized_as_json_string(
         self,
         document: Document,
+        segment: DocumentSegment,
         sqlite_session: Session,
         dataset_id: str,
         document_id: str,
     ):
         """data_source_info must be serialized with json.dumps before DB write."""
+        segment_id = segment.id
+        index_node_id = segment.index_node_id
         with (
             patch("tasks.document_indexing_sync_task.DatasourceProviderService") as mock_service_class,
             patch("tasks.document_indexing_sync_task.NotionExtractor") as mock_extractor_class,
@@ -281,3 +304,10 @@ class TestDataSourceInfoSerialization:
             assert parsed["last_edited_time"] == "2024-02-01T00:00:00Z"
             assert stored_document.indexing_status == IndexingStatus.PARSING
             assert stored_document.processing_started_at is not None
+            cleanup_args, cleanup_kwargs = mock_ip.clean.call_args
+            assert cleanup_args[0].id == dataset_id
+            assert cleanup_args[1] == [index_node_id]
+            assert cleanup_kwargs["delete_summaries"] is True
+            assert cleanup_kwargs["segment_ids"] == [segment_id]
+            assert cleanup_kwargs["session"] is not None
+            assert sqlite_session.get(DocumentSegment, segment_id) is None

--- a/api/tests/unit_tests/tasks/test_document_indexing_update_task.py
+++ b/api/tests/unit_tests/tasks/test_document_indexing_update_task.py
@@ -11,12 +11,13 @@ regenerated under the same conditions as during initial creation:
 """
 
 from contextlib import nullcontext
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
 from core.indexing_runner import DocumentIsPausedError
+from models.dataset import Dataset, Document, DocumentSegment
+from models.enums import DataSourceType, DocumentCreatedFrom, SegmentStatus
 from tasks.document_indexing_update_task import document_indexing_update_task
 
 
@@ -42,32 +43,57 @@ def _make_dataset_and_documents(
     doc_form: str = "text_model",
     need_summary: bool = True,
 ):
-    """Create mock dataset and document objects.
+    """Create concrete detached ORM dataset and document objects.
 
     Returns (dataset, doc_for_session1, doc_for_session3).
 
     session1 doc: before IndexingRunner runs (status irrelevant for summary).
     session3 doc: re-queried after IndexingRunner completes — normally COMPLETED.
     """
-    dataset = SimpleNamespace(
+    dataset = Dataset(
         id=dataset_id,
+        tenant_id="tenant-1",
+        name="Dataset",
+        description="",
+        provider="vendor",
+        permission="only_me",
+        data_source_type=DataSourceType.UPLOAD_FILE,
         indexing_technique=indexing_technique,
+        created_by="00000000-0000-0000-0000-000000000001",
         summary_index_setting=summary_index_setting,
     )
-    doc_s1 = SimpleNamespace(
+    doc_s1 = Document(
         id=document_id,
+        tenant_id="tenant-1",
         dataset_id=dataset_id,
+        position=1,
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        batch="batch-1",
+        name="Document",
+        created_from=DocumentCreatedFrom.WEB,
+        created_by="00000000-0000-0000-0000-000000000001",
         indexing_status="waiting",
         doc_form=doc_form,
         need_summary=need_summary,
+        enabled=True,
+        archived=False,
     )
     # After IndexingRunner.run the document status is COMPLETED in the DB
-    doc_s3 = SimpleNamespace(
+    doc_s3 = Document(
         id=document_id,
+        tenant_id="tenant-1",
         dataset_id=dataset_id,
+        position=1,
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        batch="batch-1",
+        name="Document",
+        created_from=DocumentCreatedFrom.WEB,
+        created_by="00000000-0000-0000-0000-000000000001",
         indexing_status="completed",
         doc_form=doc_form,
         need_summary=need_summary,
+        enabled=True,
+        archived=False,
     )
     return dataset, doc_s1, doc_s3
 
@@ -417,9 +443,16 @@ class TestUpdateTaskSummaryGeneration:
         session1.scalars.return_value = MagicMock(all=MagicMock(return_value=[]))
 
         # Document still in error status after indexing
-        doc_s3_error = SimpleNamespace(
+        doc_s3_error = Document(
             id="doc-1",
-            dataset_id="ds-1",
+            tenant_id=dataset.tenant_id,
+            dataset_id=dataset.id,
+            position=1,
+            data_source_type=DataSourceType.UPLOAD_FILE,
+            batch="batch-1",
+            name="Document",
+            created_from=DocumentCreatedFrom.WEB,
+            created_by="00000000-0000-0000-0000-000000000001",
             indexing_status="error",
             doc_form="text_model",
             need_summary=True,
@@ -490,7 +523,19 @@ class TestUpdateTaskSummaryGeneration:
 
         session1 = _session_with_begin()
         session1.scalar.side_effect = [doc_s1, dataset]
-        seg = SimpleNamespace(index_node_id="node-1")
+        seg = DocumentSegment(
+            tenant_id="tenant-1",
+            dataset_id=dataset.id,
+            document_id=doc_s1.id,
+            position=1,
+            content="segment content",
+            word_count=2,
+            tokens=2,
+            created_by="00000000-0000-0000-0000-000000000001",
+            index_node_id="node-1",
+            status=SegmentStatus.COMPLETED,
+        )
+        seg.id = "segment-1"
         session1.scalars.return_value = MagicMock(all=MagicMock(return_value=[seg]))
 
         session3 = MagicMock()
@@ -518,3 +563,64 @@ class TestUpdateTaskSummaryGeneration:
         document_indexing_update_task("ds-1", "doc-1")
 
         delay_mock.assert_called_once_with("ds-1", "doc-1", None)
+        processor.clean.assert_called_once_with(
+            dataset,
+            ["node-1"],
+            with_keywords=True,
+            delete_child_chunks=True,
+            delete_summaries=True,
+            segment_ids=["segment-1"],
+            session=session1,
+        )
+
+    def test_should_clean_summaries_when_segment_has_no_vector_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Summary cleanup is keyed by segment IDs, even before a vector ID was assigned."""
+        dataset, doc_s1, doc_s3 = _make_dataset_and_documents(
+            summary_index_setting={"enable": True},
+        )
+
+        session1 = _session_with_begin()
+        session1.scalar.side_effect = [doc_s1, dataset]
+        segment = DocumentSegment(
+            tenant_id="tenant-1",
+            dataset_id=dataset.id,
+            document_id=doc_s1.id,
+            position=1,
+            content="segment content",
+            word_count=2,
+            tokens=2,
+            created_by="00000000-0000-0000-0000-000000000001",
+            index_node_id=None,
+            status=SegmentStatus.COMPLETED,
+        )
+        segment.id = "segment-1"
+        session1.scalars.return_value = MagicMock(all=MagicMock(return_value=[segment]))
+
+        session3 = MagicMock()
+        session3.scalar.side_effect = [doc_s3, dataset]
+
+        runner = MagicMock()
+        processor = MagicMock()
+        _patch_all(
+            monkeypatch,
+            sessions=[_SessionContext(session1), _SessionContext(session3)],
+            runner=runner,
+            processor=processor,
+        )
+        monkeypatch.setattr(
+            "tasks.document_indexing_update_task.generate_summary_index_task.delay",
+            MagicMock(),
+        )
+
+        document_indexing_update_task("ds-1", "doc-1")
+
+        processor.clean.assert_called_once_with(
+            dataset,
+            [],
+            with_keywords=True,
+            delete_child_chunks=True,
+            delete_summaries=True,
+            segment_ids=["segment-1"],
+            session=session1,
+        )
+        assert any("DELETE FROM document_segments" in str(call.args[0]) for call in session1.execute.call_args_list)

--- a/api/tests/unit_tests/tasks/test_duplicate_document_indexing_task.py
+++ b/api/tests/unit_tests/tasks/test_duplicate_document_indexing_task.py
@@ -1,17 +1,61 @@
 """Unit tests for queue/wrapper behaviors in duplicate document indexing tasks (non-database logic)."""
 
 import uuid
+from contextlib import nullcontext
 from unittest.mock import Mock, patch
 
 import pytest
 
+from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
 from core.rag.pipeline.queue import TenantIsolatedTaskQueue
+from models.dataset import Dataset, Document, DocumentSegment
+from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
+from services.feature_service import FeatureModel
 from tasks.duplicate_document_indexing_task import (
+    _duplicate_document_indexing_task,
     _duplicate_document_indexing_task_with_tenant_queue,
     duplicate_document_indexing_task,
     normal_duplicate_document_indexing_task,
     priority_duplicate_document_indexing_task,
 )
+
+
+def _cleanup_rows() -> tuple[Dataset, Document, DocumentSegment]:
+    dataset = Dataset(
+        id="dataset-1",
+        tenant_id="tenant-1",
+        name="Dataset",
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        indexing_technique=IndexTechniqueType.HIGH_QUALITY,
+        created_by="account-1",
+    )
+    document = Document(
+        id="document-1",
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        position=1,
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        batch="batch-1",
+        name="Document",
+        created_from=DocumentCreatedFrom.WEB,
+        created_by="account-1",
+        indexing_status=IndexingStatus.ERROR,
+        doc_form=IndexStructureType.PARAGRAPH_INDEX,
+    )
+    segment = DocumentSegment(
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        document_id=document.id,
+        position=1,
+        content="old content",
+        word_count=2,
+        tokens=2,
+        created_by="account-1",
+        index_node_id="node-1",
+        status=SegmentStatus.COMPLETED,
+    )
+    segment.id = "segment-1"
+    return dataset, document, segment
 
 
 @pytest.fixture
@@ -51,6 +95,46 @@ class TestDuplicateDocumentIndexingTask:
 
         # Assert
         mock_core_func.assert_called_once_with(dataset_id, document_ids)
+
+    def test_core_cleanup_deletes_summary_vectors_with_dataset_scope(self) -> None:
+        dataset, document, segment = _cleanup_rows()
+        session = Mock()
+        session.scalar.return_value = dataset
+        document_rows = Mock()
+        document_rows.all.return_value = [document]
+        segment_rows = Mock()
+        segment_rows.all.return_value = [segment]
+        session.scalars.side_effect = [document_rows, segment_rows]
+        processor = Mock()
+
+        with (
+            patch(
+                "tasks.duplicate_document_indexing_task.session_factory.create_session",
+                return_value=nullcontext(session),
+            ),
+            patch(
+                "tasks.duplicate_document_indexing_task.FeatureService.get_features",
+                return_value=FeatureModel(),
+            ),
+            patch("tasks.duplicate_document_indexing_task.IndexProcessorFactory") as processor_factory,
+            patch("tasks.duplicate_document_indexing_task.IndexingRunner"),
+        ):
+            processor_factory.return_value.init_index_processor.return_value = processor
+            _duplicate_document_indexing_task(dataset.id, [document.id])
+
+        processor.clean.assert_called_once_with(
+            dataset,
+            [segment.index_node_id],
+            with_keywords=True,
+            delete_child_chunks=True,
+            delete_summaries=True,
+            segment_ids=[segment.id],
+            session=session,
+        )
+        segment_queries = [str(call.args[0]) for call in session.scalars.call_args_list]
+        delete_queries = [str(call.args[0]) for call in session.execute.call_args_list]
+        assert "document_segments.dataset_id" in segment_queries[1]
+        assert "document_segments.dataset_id" in delete_queries[0]
 
     @patch("tasks.duplicate_document_indexing_task._duplicate_document_indexing_task", autospec=True)
     def test_duplicate_document_indexing_task_with_empty_document_ids(self, mock_core_func, dataset_id):

--- a/api/tests/unit_tests/tasks/test_enable_segment_index_tasks.py
+++ b/api/tests/unit_tests/tasks/test_enable_segment_index_tasks.py
@@ -1,35 +1,72 @@
 from contextlib import nullcontext
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from core.rag.index_processor.constant.index_type import IndexStructureType
-from models.enums import IndexingStatus, SegmentStatus
+from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
+from models.dataset import Dataset, Document, DocumentSegment
+from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
 from tasks.enable_segment_to_index_task import enable_segment_to_index_task
 from tasks.enable_segments_to_index_task import enable_segments_to_index_task
 
 
-def test_enable_segment_commits_index_rows_after_loading() -> None:
-    dataset = SimpleNamespace(id="dataset-1", is_multimodal=False)
-    document = SimpleNamespace(
+def _dataset() -> Dataset:
+    return Dataset(
+        id="dataset-1",
+        tenant_id="tenant-1",
+        name="Dataset",
+        description="",
+        provider="vendor",
+        permission="only_me",
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        indexing_technique=IndexTechniqueType.HIGH_QUALITY,
+        created_by="00000000-0000-0000-0000-000000000001",
+        is_multimodal=False,
+    )
+
+
+def _document(dataset: Dataset) -> Document:
+    return Document(
         id="document-1",
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        position=1,
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        batch="batch-1",
+        name="Document",
+        created_from=DocumentCreatedFrom.WEB,
+        created_by="00000000-0000-0000-0000-000000000001",
+        indexing_status=IndexingStatus.COMPLETED,
         enabled=True,
         archived=False,
-        indexing_status=IndexingStatus.COMPLETED,
         doc_form=IndexStructureType.PARAGRAPH_INDEX,
     )
-    segment = SimpleNamespace(
-        id="segment-1",
-        status=SegmentStatus.COMPLETED,
+
+
+def _segment(dataset: Dataset, document: Document) -> DocumentSegment:
+    segment = DocumentSegment(
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        document_id=document.id,
+        position=1,
         content="content",
+        word_count=1,
+        tokens=1,
+        created_by="00000000-0000-0000-0000-000000000001",
         index_node_id="node-1",
         index_node_hash="hash-1",
-        document_id=document.id,
-        dataset_id=dataset.id,
-        get_dataset=MagicMock(return_value=dataset),
-        get_document=MagicMock(return_value=document),
+        status=SegmentStatus.COMPLETED,
+        enabled=True,
     )
+    segment.id = "segment-1"
+    return segment
+
+
+def test_enable_segment_commits_index_rows_after_loading() -> None:
+    dataset = _dataset()
+    document = _document(dataset)
+    segment = _segment(dataset, document)
     session = MagicMock()
     session.scalar.return_value = segment
+    session.get.side_effect = lambda model, _identifier: dataset if model is Dataset else document
     phase_events: list[str] = []
     session.commit.side_effect = lambda: phase_events.append("commit")
     index_processor = MagicMock()
@@ -48,41 +85,29 @@ def test_enable_segment_commits_index_rows_after_loading() -> None:
         processor_factory.return_value.init_index_processor.return_value = index_processor
         enable_segment_to_index_task.run(segment.id)
 
-    assert phase_events == ["load", "commit", "summary"]
+    assert phase_events == ["commit", "load", "commit", "summary"]
+    enable_summaries.assert_called_once_with(dataset=dataset, session=session, segment_ids=[segment.id])
 
 
 def test_enable_segment_rolls_back_before_error_compensation() -> None:
-    dataset = SimpleNamespace(id="dataset-1", is_multimodal=False)
-    document = SimpleNamespace(
-        id="document-1",
-        enabled=True,
-        archived=False,
-        indexing_status=IndexingStatus.COMPLETED,
-        doc_form=IndexStructureType.PARAGRAPH_INDEX,
-    )
-    segment = SimpleNamespace(
-        id="segment-1",
-        status=SegmentStatus.COMPLETED,
-        content="content",
-        index_node_id="node-1",
-        index_node_hash="hash-1",
-        document_id=document.id,
-        dataset_id=dataset.id,
-        enabled=True,
-        disabled_at=None,
-        error=None,
-        get_dataset=MagicMock(return_value=dataset),
-        get_document=MagicMock(return_value=document),
-    )
+    dataset = _dataset()
+    document = _document(dataset)
+    segment = _segment(dataset, document)
     phase_events: list[str] = []
     session = MagicMock()
     session.scalar.return_value = segment
+    session.get.side_effect = lambda model, _identifier: dataset if model is Dataset else document
     session.rollback.side_effect = lambda: phase_events.append("rollback")
 
+    commit_count = 0
+
     def commit() -> None:
-        assert segment.enabled is False
-        assert segment.status == SegmentStatus.ERROR
-        assert segment.error == "load failed"
+        nonlocal commit_count
+        commit_count += 1
+        if commit_count == 2:
+            assert segment.enabled is False
+            assert segment.status == SegmentStatus.ERROR
+            assert segment.error == "load failed"
         phase_events.append("commit")
 
     session.commit.side_effect = commit
@@ -103,27 +128,14 @@ def test_enable_segment_rolls_back_before_error_compensation() -> None:
         processor_factory.return_value.init_index_processor.return_value = index_processor
         enable_segment_to_index_task.run(segment.id)
 
-    assert phase_events == ["load", "rollback", "commit"]
+    assert phase_events == ["commit", "load", "rollback", "commit"]
     enable_summaries.assert_not_called()
 
 
 def test_enable_segments_commits_index_rows_after_loading() -> None:
-    dataset = SimpleNamespace(id="dataset-1", is_multimodal=False)
-    document = SimpleNamespace(
-        id="document-1",
-        enabled=True,
-        archived=False,
-        indexing_status="completed",
-        doc_form=IndexStructureType.PARAGRAPH_INDEX,
-    )
-    segment = SimpleNamespace(
-        id="segment-1",
-        content="content",
-        index_node_id="node-1",
-        index_node_hash="hash-1",
-        document_id=document.id,
-        dataset_id=dataset.id,
-    )
+    dataset = _dataset()
+    document = _document(dataset)
+    segment = _segment(dataset, document)
     session = MagicMock()
     session.scalar.side_effect = [dataset, document]
     session.scalars.return_value.all.return_value = [segment]
@@ -145,26 +157,14 @@ def test_enable_segments_commits_index_rows_after_loading() -> None:
         processor_factory.return_value.init_index_processor.return_value = index_processor
         enable_segments_to_index_task.run([segment.id], dataset.id, document.id)
 
-    assert phase_events == ["load", "commit", "summary"]
+    assert phase_events == ["commit", "load", "commit", "summary"]
+    enable_summaries.assert_called_once_with(dataset=dataset, session=session, segment_ids=[segment.id])
 
 
 def test_enable_segments_rolls_back_before_error_compensation() -> None:
-    dataset = SimpleNamespace(id="dataset-1", is_multimodal=False)
-    document = SimpleNamespace(
-        id="document-1",
-        enabled=True,
-        archived=False,
-        indexing_status="completed",
-        doc_form=IndexStructureType.PARAGRAPH_INDEX,
-    )
-    segment = SimpleNamespace(
-        id="segment-1",
-        content="content",
-        index_node_id="node-1",
-        index_node_hash="hash-1",
-        document_id=document.id,
-        dataset_id=dataset.id,
-    )
+    dataset = _dataset()
+    document = _document(dataset)
+    segment = _segment(dataset, document)
     phase_events: list[str] = []
     session = MagicMock()
     session.scalar.side_effect = [dataset, document]
@@ -189,5 +189,5 @@ def test_enable_segments_rolls_back_before_error_compensation() -> None:
         processor_factory.return_value.init_index_processor.return_value = index_processor
         enable_segments_to_index_task.run([segment.id], dataset.id, document.id)
 
-    assert phase_events == ["load", "rollback", "compensate", "commit"]
+    assert phase_events == ["commit", "load", "rollback", "compensate", "commit"]
     enable_summaries.assert_not_called()

--- a/api/tests/unit_tests/tasks/test_generate_summary_index_task.py
+++ b/api/tests/unit_tests/tasks/test_generate_summary_index_task.py
@@ -1,0 +1,84 @@
+"""Unit tests for the summary-index generation task session lifecycle."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import tasks.generate_summary_index_task as task_module
+from core.rag.index_processor.constant.index_type import IndexTechniqueType
+from models.dataset import Dataset, Document
+from models.enums import DataSourceType, DocumentCreatedFrom
+
+
+class _TrackedSessionContext:
+    def __init__(self, session: MagicMock) -> None:
+        self.session = session
+        self.active = False
+        self.exited = False
+
+    def __enter__(self) -> MagicMock:
+        self.active = True
+        return self.session
+
+    def __exit__(self, _exc_type: object, _exc: object, _tb: object) -> None:
+        self.active = False
+        self.exited = True
+
+
+def test_generate_summary_index_task_releases_loader_session_before_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = Dataset(
+        id="dataset-1",
+        tenant_id="tenant-1",
+        name="Dataset",
+        description="",
+        provider="vendor",
+        permission="only_me",
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        indexing_technique=IndexTechniqueType.HIGH_QUALITY,
+        created_by="00000000-0000-0000-0000-000000000001",
+        summary_index_setting={"enable": True},
+        chunk_structure="text_model",
+    )
+    document = Document(
+        id="document-1",
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        position=1,
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        batch="batch-1",
+        name="Document",
+        created_from=DocumentCreatedFrom.WEB,
+        created_by="00000000-0000-0000-0000-000000000001",
+        need_summary=True,
+    )
+    loader_session = MagicMock()
+    loader_statements: list[object] = []
+
+    def scalar(statement: object) -> Dataset | Document:
+        loader_statements.append(statement)
+        return [dataset, document][len(loader_statements) - 1]
+
+    loader_session.scalar.side_effect = scalar
+    loader_context = _TrackedSessionContext(loader_session)
+    monkeypatch.setattr(task_module.session_factory, "create_session", MagicMock(return_value=loader_context))
+
+    observed: dict[str, object] = {}
+
+    def generate_summaries_for_document(**kwargs: object) -> list[object]:
+        observed["loader_active"] = loader_context.active
+        observed["session"] = kwargs.get("session")
+        return []
+
+    monkeypatch.setattr(
+        task_module.SummaryIndexService,
+        "generate_summaries_for_document",
+        generate_summaries_for_document,
+    )
+
+    task_module.generate_summary_index_task.run("dataset-1", "document-1")
+
+    assert loader_context.exited is True
+    assert observed == {"loader_active": False, "session": None}
+    assert "documents.dataset_id =" in str(loader_statements[1])

--- a/api/tests/unit_tests/tasks/test_regenerate_summary_index_task.py
+++ b/api/tests/unit_tests/tasks/test_regenerate_summary_index_task.py
@@ -1,0 +1,238 @@
+"""Regression tests for regenerate-summary task transaction rollover."""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+import tasks.regenerate_summary_index_task as task_module
+from core.rag.datasource.vdb import vector_factory
+from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
+from models.dataset import Dataset, DocumentSegment, DocumentSegmentSummary
+from models.dataset import Document as DatasetDocument
+from models.enums import SummaryStatus
+
+
+class _Rows:
+    def __init__(self, rows: list[object]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[object]:
+        return self._rows
+
+
+def _dataset() -> Dataset:
+    dataset = Dataset()
+    dataset.id = "dataset-1"
+    dataset.indexing_technique = IndexTechniqueType.HIGH_QUALITY
+    dataset.summary_index_setting = {"enable": True, "model_name": "summary-model"}
+    return dataset
+
+
+def _document() -> DatasetDocument:
+    document = DatasetDocument()
+    document.id = "document-1"
+    document.doc_form = IndexStructureType.PARAGRAPH_INDEX
+    return document
+
+
+def _segment() -> DocumentSegment:
+    segment = DocumentSegment(
+        tenant_id="tenant-1",
+        dataset_id="dataset-1",
+        document_id="document-1",
+        position=1,
+        content="segment content",
+        word_count=2,
+        tokens=2,
+        created_by="account-1",
+    )
+    segment.id = "segment-1"
+    return segment
+
+
+def _summary(*, enabled: bool = True) -> DocumentSegmentSummary:
+    summary = DocumentSegmentSummary(
+        dataset_id="dataset-1",
+        document_id="document-1",
+        chunk_id="segment-1",
+        summary_index_node_id="old-node",
+        summary_content="summary",
+        status=SummaryStatus.COMPLETED,
+        enabled=enabled,
+    )
+    summary.id = "summary-1"
+    return summary
+
+
+class _TrackedSessionContext:
+    def __init__(self, session: MagicMock) -> None:
+        self.session = session
+        self.active = False
+        self.transaction_active = False
+
+    def __enter__(self) -> MagicMock:
+        self.active = True
+        return self.session
+
+    def __exit__(self, _exc_type: object, _exc: object, _tb: object) -> None:
+        self.active = False
+        self.transaction_active = False
+
+    def query(self, result: object) -> object:
+        self.transaction_active = True
+        return result
+
+
+def test_revectorization_rolls_over_loader_transaction_before_external_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = _dataset()
+    segment = _segment()
+    summary = _summary()
+    session = MagicMock()
+    context = _TrackedSessionContext(session)
+    session.scalar.side_effect = lambda *_args: context.query(dataset)
+    session.execute.side_effect = lambda *_args: context.query(_Rows([(segment, summary)]))
+    session.in_transaction.side_effect = lambda: context.transaction_active
+    session.commit.side_effect = lambda: setattr(context, "transaction_active", False)
+    monkeypatch.setattr(task_module.session_factory, "create_session", MagicMock(return_value=context))
+
+    callback_state: list[tuple[bool, bool]] = []
+
+    def vectorize(*_args: object) -> None:
+        callback_state.append((context.active, session.in_transaction()))
+        raise RuntimeError("external vectorization failed")
+
+    vectorize_mock = MagicMock(side_effect=vectorize)
+    monkeypatch.setattr(task_module.SummaryIndexService, "vectorize_summary", vectorize_mock)
+    vector_cls = MagicMock()
+    monkeypatch.setattr(vector_factory, "Vector", vector_cls)
+
+    task_module.regenerate_summary_index_task.run("dataset-1", regenerate_vectors_only=True)
+
+    vectorize_mock.assert_called_once_with(summary, segment, dataset)
+    assert callback_state == [(True, False)]
+    session.commit.assert_called_once()
+    session.add.assert_not_called()
+    vector_cls.assert_not_called()
+
+
+def test_revectorization_does_not_use_an_older_enabled_duplicate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = _dataset()
+    segment = _segment()
+    canonical_disabled = _summary(enabled=False)
+    canonical_disabled.id = "summary-new"
+    canonical_disabled.summary_content = "new"
+    older_enabled = _summary()
+    older_enabled.id = "summary-old"
+    older_enabled.summary_content = "old"
+    session = MagicMock()
+    context = _TrackedSessionContext(session)
+    session.scalar.side_effect = lambda *_args: context.query(dataset)
+    executed_statements: list[object] = []
+
+    def execute(statement: object) -> object:
+        executed_statements.append(statement)
+        return context.query(_Rows([(segment, canonical_disabled), (segment, older_enabled)]))
+
+    session.execute.side_effect = execute
+    monkeypatch.setattr(task_module.session_factory, "create_session", MagicMock(return_value=context))
+    vectorize_mock = MagicMock()
+    monkeypatch.setattr(task_module.SummaryIndexService, "vectorize_summary", vectorize_mock)
+
+    task_module.regenerate_summary_index_task.run("dataset-1", regenerate_vectors_only=True)
+
+    vectorize_mock.assert_not_called()
+    statement_sql = str(executed_statements[0])
+    assert "document_segment_summaries.updated_at DESC" in statement_sql
+    assert "document_segment_summaries.id DESC" in statement_sql
+
+
+def test_regeneration_rolls_over_lookup_transaction_before_external_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = _dataset()
+    setting = dataset.summary_index_setting
+    assert setting is not None
+    document = _document()
+    segment = _segment()
+    summary = _summary()
+    session = MagicMock()
+    context = _TrackedSessionContext(session)
+    scalar_results = iter([dataset, summary])
+    session.scalar.side_effect = lambda *_args: context.query(next(scalar_results))
+    scalar_batches = iter([[document], [segment]])
+    session.scalars.side_effect = lambda *_args: context.query(_Rows(next(scalar_batches)))
+    session.in_transaction.side_effect = lambda: context.transaction_active
+    session.commit.side_effect = lambda: setattr(context, "transaction_active", False)
+    monkeypatch.setattr(task_module.session_factory, "create_session", MagicMock(return_value=context))
+
+    callback_state: list[tuple[bool, bool]] = []
+
+    def generate(*_args: object) -> None:
+        callback_state.append((context.active, session.in_transaction()))
+        raise RuntimeError("external generation failed")
+
+    generate_mock = MagicMock(side_effect=generate)
+    monkeypatch.setattr(task_module.SummaryIndexService, "generate_and_vectorize_summary", generate_mock)
+
+    task_module.regenerate_summary_index_task.run("dataset-1")
+
+    generate_mock.assert_called_once_with(segment, dataset, setting)
+    assert callback_state == [(True, False)]
+    session.commit.assert_called_once()
+    session.add.assert_not_called()
+
+
+def test_revectorization_treats_concurrent_supersession_as_benign(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    dataset = _dataset()
+    segment = _segment()
+    summary = _summary()
+    session = MagicMock()
+    context = _TrackedSessionContext(session)
+    session.scalar.side_effect = lambda *_args: context.query(dataset)
+    session.execute.side_effect = lambda *_args: context.query(_Rows([(segment, summary)]))
+    monkeypatch.setattr(task_module.session_factory, "create_session", MagicMock(return_value=context))
+    vectorize_mock = MagicMock(side_effect=task_module.SummaryIndexConflictError("superseded"))
+    monkeypatch.setattr(task_module.SummaryIndexService, "vectorize_summary", vectorize_mock)
+
+    with caplog.at_level(logging.INFO, logger=task_module.__name__):
+        task_module.regenerate_summary_index_task.run("dataset-1", regenerate_vectors_only=True)
+
+    vectorize_mock.assert_called_once_with(summary, segment, dataset)
+    assert "Summary re-vectorization for segment segment-1 was superseded" in caplog.text
+    assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
+
+
+def test_regeneration_treats_concurrent_supersession_as_benign(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    dataset = _dataset()
+    document = _document()
+    segment = _segment()
+    summary = _summary()
+    session = MagicMock()
+    context = _TrackedSessionContext(session)
+    scalar_results = iter([dataset, summary])
+    session.scalar.side_effect = lambda *_args: context.query(next(scalar_results))
+    scalar_batches = iter([[document], [segment]])
+    session.scalars.side_effect = lambda *_args: context.query(_Rows(next(scalar_batches)))
+    session.in_transaction.side_effect = lambda: context.transaction_active
+    session.commit.side_effect = lambda: setattr(context, "transaction_active", False)
+    monkeypatch.setattr(task_module.session_factory, "create_session", MagicMock(return_value=context))
+    generate_mock = MagicMock(side_effect=task_module.SummaryIndexConflictError("superseded"))
+    monkeypatch.setattr(task_module.SummaryIndexService, "generate_and_vectorize_summary", generate_mock)
+
+    with caplog.at_level(logging.INFO, logger=task_module.__name__):
+        task_module.regenerate_summary_index_task.run("dataset-1")
+
+    generate_mock.assert_called_once_with(segment, dataset, dataset.summary_index_setting)
+    assert "Summary regeneration for segment segment-1 was superseded" in caplog.text
+    assert not [record for record in caplog.records if record.levelno >= logging.ERROR]

--- a/api/tests/unit_tests/tasks/test_reindex_summary_cleanup_tasks.py
+++ b/api/tests/unit_tests/tasks/test_reindex_summary_cleanup_tasks.py
@@ -1,0 +1,144 @@
+"""Regression tests for summary cleanup in document reindex tasks."""
+
+from contextlib import nullcontext
+from unittest.mock import Mock, patch
+
+from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
+from models import Account, Tenant
+from models.dataset import Dataset, Document, DocumentSegment
+from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
+from services.feature_service import FeatureModel
+from tasks.retry_document_indexing_task import retry_document_indexing_task
+from tasks.sync_website_document_indexing_task import sync_website_document_indexing_task
+
+
+def _cleanup_rows() -> tuple[Dataset, Document, DocumentSegment]:
+    dataset = Dataset(
+        id="dataset-1",
+        tenant_id="tenant-1",
+        name="Dataset",
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        indexing_technique=IndexTechniqueType.HIGH_QUALITY,
+        created_by="account-1",
+    )
+    document = Document(
+        id="document-1",
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        position=1,
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        batch="batch-1",
+        name="Document",
+        created_from=DocumentCreatedFrom.WEB,
+        created_by="account-1",
+        indexing_status=IndexingStatus.ERROR,
+        doc_form=IndexStructureType.PARAGRAPH_INDEX,
+    )
+    segment = DocumentSegment(
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        document_id=document.id,
+        position=1,
+        content="old content",
+        word_count=2,
+        tokens=2,
+        created_by="account-1",
+        index_node_id="node-1",
+        status=SegmentStatus.COMPLETED,
+    )
+    segment.id = "segment-1"
+    return dataset, document, segment
+
+
+def _assert_scoped_summary_cleanup(
+    *,
+    processor: Mock,
+    session: Mock,
+    dataset: Dataset,
+    segment: DocumentSegment,
+) -> None:
+    processor.clean.assert_called_once_with(
+        dataset,
+        [segment.index_node_id],
+        with_keywords=True,
+        delete_child_chunks=True,
+        delete_summaries=True,
+        segment_ids=[segment.id],
+        session=session,
+    )
+    segment_queries = [str(call.args[0]) for call in session.scalars.call_args_list]
+    delete_queries = [str(call.args[0]) for call in session.execute.call_args_list]
+    assert "document_segments.dataset_id" in segment_queries[-1]
+    assert "document_segments.dataset_id" in delete_queries[0]
+
+
+def test_retry_document_cleanup_deletes_summary_vectors_with_dataset_scope() -> None:
+    dataset, document, segment = _cleanup_rows()
+    user = Account(name="User", email="user@example.com")
+    user.id = "account-1"
+    tenant = Tenant(name="Tenant")
+    tenant.id = dataset.tenant_id
+
+    session = Mock()
+    session.scalar.side_effect = [dataset, user, tenant, document]
+    segment_rows = Mock()
+    segment_rows.all.return_value = [segment]
+    session.scalars.return_value = segment_rows
+    processor = Mock()
+
+    with (
+        patch(
+            "tasks.retry_document_indexing_task.session_factory.create_session",
+            return_value=nullcontext(session),
+        ),
+        patch(
+            "tasks.retry_document_indexing_task.FeatureService.get_features",
+            return_value=FeatureModel(),
+        ),
+        patch.object(Account, "set_current_tenant_with_session", autospec=True),
+        patch("tasks.retry_document_indexing_task.IndexProcessorFactory") as processor_factory,
+        patch("tasks.retry_document_indexing_task.IndexingRunner"),
+        patch("tasks.retry_document_indexing_task.redis_client"),
+    ):
+        processor_factory.return_value.init_index_processor.return_value = processor
+        retry_document_indexing_task.run(dataset.id, [document.id], user.id)
+
+    _assert_scoped_summary_cleanup(
+        processor=processor,
+        session=session,
+        dataset=dataset,
+        segment=segment,
+    )
+
+
+def test_website_sync_cleanup_deletes_summary_vectors_with_dataset_scope() -> None:
+    dataset, document, segment = _cleanup_rows()
+    session = Mock()
+    session.scalar.side_effect = [dataset, document]
+    segment_rows = Mock()
+    segment_rows.all.return_value = [segment]
+    session.scalars.return_value = segment_rows
+    processor = Mock()
+
+    with (
+        patch(
+            "tasks.sync_website_document_indexing_task.session_factory.create_session",
+            return_value=nullcontext(session),
+        ),
+        patch(
+            "tasks.sync_website_document_indexing_task.FeatureService.get_features",
+            return_value=FeatureModel(),
+        ),
+        patch("tasks.sync_website_document_indexing_task.IndexProcessorFactory") as processor_factory,
+        patch("tasks.sync_website_document_indexing_task.IndexingRunner"),
+        patch("tasks.sync_website_document_indexing_task.redis_client"),
+    ):
+        processor_factory.return_value.init_index_processor.return_value = processor
+        sync_website_document_indexing_task.run(dataset.id, document.id)
+
+    _assert_scoped_summary_cleanup(
+        processor=processor,
+        session=session,
+        dataset=dataset,
+        segment=segment,
+    )

--- a/api/tests/unit_tests/tasks/test_segment_index_cleanup_tasks.py
+++ b/api/tests/unit_tests/tasks/test_segment_index_cleanup_tasks.py
@@ -1,26 +1,74 @@
 from contextlib import nullcontext
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from models.enums import SegmentStatus
+from core.rag.index_processor.constant.index_type import IndexStructureType, IndexTechniqueType
+from models.dataset import Dataset, Document, DocumentSegment, SegmentAttachmentBinding
+from models.enums import DataSourceType, DocumentCreatedFrom, IndexingStatus, SegmentStatus
 from tasks.delete_segment_from_index_task import delete_segment_from_index_task
 from tasks.disable_segment_from_index_task import disable_segment_from_index_task
 from tasks.disable_segments_from_index_task import disable_segments_from_index_task
+from tasks.remove_document_from_index_task import remove_document_from_index_task
+
+
+def _dataset(*, is_multimodal: bool = False) -> Dataset:
+    return Dataset(
+        id="dataset-1",
+        tenant_id="tenant-1",
+        name="Dataset",
+        description="",
+        provider="vendor",
+        permission="only_me",
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        indexing_technique=IndexTechniqueType.HIGH_QUALITY,
+        created_by="00000000-0000-0000-0000-000000000001",
+        is_multimodal=is_multimodal,
+    )
+
+
+def _document(dataset: Dataset, *, enabled: bool = True) -> Document:
+    return Document(
+        id="document-1",
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        position=1,
+        data_source_type=DataSourceType.UPLOAD_FILE,
+        batch="batch-1",
+        name="Document",
+        created_from=DocumentCreatedFrom.WEB,
+        created_by="00000000-0000-0000-0000-000000000001",
+        indexing_status=IndexingStatus.COMPLETED,
+        enabled=enabled,
+        archived=False,
+        doc_form=IndexStructureType.PARAGRAPH_INDEX,
+        disabled_by="00000000-0000-0000-0000-000000000002",
+    )
+
+
+def _segment(dataset: Dataset, document: Document, *, index_node_id: str = "node-1") -> DocumentSegment:
+    segment = DocumentSegment(
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        document_id=document.id,
+        position=1,
+        content="content",
+        word_count=1,
+        tokens=1,
+        created_by="00000000-0000-0000-0000-000000000001",
+        index_node_id=index_node_id,
+        status=SegmentStatus.COMPLETED,
+        disabled_by="00000000-0000-0000-0000-000000000002",
+    )
+    segment.id = "segment-1"
+    return segment
 
 
 def test_disable_segment_commits_index_cleanup() -> None:
-    dataset = SimpleNamespace(id="dataset-1")
-    document = SimpleNamespace(enabled=True, archived=False, indexing_status="completed", doc_form="text_model")
-    segment = SimpleNamespace(
-        id="segment-1",
-        status=SegmentStatus.COMPLETED,
-        index_node_id="node-1",
-        disabled_by="user-1",
-        get_dataset=MagicMock(return_value=dataset),
-        get_document=MagicMock(return_value=document),
-    )
+    dataset = _dataset()
+    document = _document(dataset)
+    segment = _segment(dataset, document)
     session = MagicMock()
     session.scalar.return_value = segment
+    session.get.side_effect = lambda model, _identifier: dataset if model is Dataset else document
     phase_events: list[str] = []
     session.commit.side_effect = lambda: phase_events.append("commit")
     processor = MagicMock()
@@ -41,19 +89,53 @@ def test_disable_segment_commits_index_cleanup() -> None:
         processor_factory.return_value.init_index_processor.return_value = processor
         disable_segment_from_index_task.run(segment.id)
 
-    assert phase_events == ["clean", "commit", "summary"]
+    assert phase_events == ["commit", "clean", "commit", "summary"]
+    disable_summaries.assert_called_once_with(
+        dataset=dataset,
+        session=session,
+        segment_ids=[segment.id],
+        disabled_by=segment.disabled_by,
+    )
+
+
+def test_disable_segment_without_primary_vector_still_disables_summary() -> None:
+    dataset = _dataset()
+    document = _document(dataset)
+    segment = _segment(dataset, document, index_node_id="")
+    segment.index_node_id = None
+    session = MagicMock()
+    session.scalar.return_value = segment
+    session.get.side_effect = lambda model, _identifier: dataset if model is Dataset else document
+    processor = MagicMock()
+    disable_summaries = MagicMock()
+
+    with (
+        patch(
+            "tasks.disable_segment_from_index_task.session_factory.create_session", return_value=nullcontext(session)
+        ),
+        patch("tasks.disable_segment_from_index_task.IndexProcessorFactory") as processor_factory,
+        patch(
+            "services.summary_index_service.SummaryIndexService.disable_summaries_for_segments",
+            disable_summaries,
+        ),
+        patch("tasks.disable_segment_from_index_task.redis_client.delete"),
+    ):
+        processor_factory.return_value.init_index_processor.return_value = processor
+        disable_segment_from_index_task.run(segment.id)
+
+    processor.clean.assert_not_called()
+    disable_summaries.assert_called_once_with(
+        dataset=dataset,
+        session=session,
+        segment_ids=[segment.id],
+        disabled_by=segment.disabled_by,
+    )
 
 
 def test_disable_segments_commits_index_cleanup() -> None:
-    dataset = SimpleNamespace(id="dataset-1", is_multimodal=False)
-    document = SimpleNamespace(
-        id="document-1",
-        enabled=True,
-        archived=False,
-        indexing_status="completed",
-        doc_form="text_model",
-    )
-    segment = SimpleNamespace(id="segment-1", index_node_id="node-1", disabled_by="user-1")
+    dataset = _dataset()
+    document = _document(dataset)
+    segment = _segment(dataset, document)
     session = MagicMock()
     session.scalar.side_effect = [dataset, document]
     session.scalars.return_value.all.return_value = [segment]
@@ -77,18 +159,18 @@ def test_disable_segments_commits_index_cleanup() -> None:
         processor_factory.return_value.init_index_processor.return_value = processor
         disable_segments_from_index_task.run([segment.id], dataset.id, document.id)
 
-    assert phase_events == ["clean", "commit", "summary"]
+    assert phase_events == ["commit", "clean", "commit", "summary"]
+    disable_summaries.assert_called_once_with(
+        dataset=dataset,
+        session=session,
+        segment_ids=[segment.id],
+        disabled_by=segment.disabled_by,
+    )
 
 
 def test_delete_segment_commits_index_cleanup_without_attachments() -> None:
-    dataset = SimpleNamespace(id="dataset-1", is_multimodal=False)
-    document = SimpleNamespace(
-        id="document-1",
-        enabled=True,
-        archived=False,
-        indexing_status="completed",
-        doc_form="text_model",
-    )
+    dataset = _dataset()
+    document = _document(dataset)
     session = MagicMock()
     session.scalar.side_effect = [dataset, document]
     phase_events: list[str] = []
@@ -103,4 +185,181 @@ def test_delete_segment_commits_index_cleanup_without_attachments() -> None:
         processor_factory.return_value.init_index_processor.return_value = processor
         delete_segment_from_index_task.run(["node-1"], dataset.id, document.id, ["segment-1"])
 
-    assert phase_events == ["clean", "commit"]
+    assert phase_events == ["commit", "clean", "commit"]
+
+
+def test_delete_segment_cleans_deleted_ids_for_inactive_document() -> None:
+    """Actual deletion must not leave summaries because a document is disabled."""
+    dataset = _dataset()
+    document = _document(dataset, enabled=False)
+    session = MagicMock()
+    session.scalar.side_effect = [dataset, document]
+    processor = MagicMock()
+
+    with (
+        patch("tasks.delete_segment_from_index_task.session_factory.create_session", return_value=nullcontext(session)),
+        patch("tasks.delete_segment_from_index_task.IndexProcessorFactory") as processor_factory,
+    ):
+        processor_factory.return_value.init_index_processor.return_value = processor
+        delete_segment_from_index_task.run([], dataset.id, document.id, ["segment-1"])
+
+    processor.clean.assert_called_once_with(
+        dataset,
+        [],
+        with_keywords=True,
+        delete_child_chunks=True,
+        precomputed_child_node_ids=None,
+        delete_summaries=True,
+        segment_ids=["segment-1"],
+        session=session,
+    )
+
+
+def test_delete_segment_removes_relational_dependants_when_document_is_already_gone() -> None:
+    dataset = _dataset()
+    session = MagicMock()
+    session.scalar.side_effect = [dataset, None]
+
+    with (
+        patch("tasks.delete_segment_from_index_task.session_factory.create_session", return_value=nullcontext(session)),
+        patch("tasks.delete_segment_from_index_task.IndexProcessorFactory") as processor_factory,
+    ):
+        delete_segment_from_index_task.run([], dataset.id, "missing-document", ["segment-1"])
+
+    processor_factory.assert_not_called()
+    delete_statements = [str(call.args[0]) for call in session.execute.call_args_list]
+    assert any("DELETE FROM document_segment_summaries" in sql for sql in delete_statements)
+    assert any("DELETE FROM child_chunks" in sql for sql in delete_statements)
+    assert any("DELETE FROM segment_attachment_bindings" in sql for sql in delete_statements)
+
+
+def test_delete_segment_removes_relational_dependants_when_index_cleanup_fails() -> None:
+    dataset = _dataset()
+    document = _document(dataset)
+    session = MagicMock()
+    session.scalar.side_effect = [dataset, document]
+    processor = MagicMock()
+    processor.clean.side_effect = RuntimeError("vector backend unavailable")
+
+    with (
+        patch("tasks.delete_segment_from_index_task.session_factory.create_session", return_value=nullcontext(session)),
+        patch("tasks.delete_segment_from_index_task.IndexProcessorFactory") as processor_factory,
+    ):
+        processor_factory.return_value.init_index_processor.return_value = processor
+        delete_segment_from_index_task.run([], dataset.id, document.id, ["segment-1"])
+
+    delete_statements = [str(call.args[0]) for call in session.execute.call_args_list]
+    assert any("DELETE FROM document_segment_summaries" in sql for sql in delete_statements)
+    assert any("DELETE FROM child_chunks" in sql for sql in delete_statements)
+    assert any("DELETE FROM segment_attachment_bindings" in sql for sql in delete_statements)
+    assert session.rollback.call_count == 1
+    assert session.commit.call_count == 2
+
+
+def test_delete_segment_cleanup_failure_does_not_escape_when_relational_fallback_also_fails() -> None:
+    dataset = _dataset()
+    document = _document(dataset)
+    session = MagicMock()
+    session.scalar.side_effect = [dataset, document]
+    session.execute.side_effect = RuntimeError("database cleanup unavailable")
+    processor = MagicMock()
+    processor.clean.side_effect = RuntimeError("vector backend unavailable")
+
+    with (
+        patch("tasks.delete_segment_from_index_task.session_factory.create_session", return_value=nullcontext(session)),
+        patch("tasks.delete_segment_from_index_task.IndexProcessorFactory") as processor_factory,
+    ):
+        processor_factory.return_value.init_index_processor.return_value = processor
+        delete_segment_from_index_task.run([], dataset.id, document.id, ["segment-1"])
+
+    session.execute.assert_called_once()
+    assert session.rollback.call_count == 2
+    assert session.commit.call_count == 1
+
+
+def test_delete_segment_rolls_over_attachment_lookup_before_cleanup() -> None:
+    dataset = _dataset(is_multimodal=True)
+    document = _document(dataset)
+    binding = SegmentAttachmentBinding(
+        tenant_id=dataset.tenant_id,
+        dataset_id=dataset.id,
+        document_id=document.id,
+        segment_id="segment-1",
+        attachment_id="attachment-1",
+    )
+    binding.id = "binding-1"
+    session = MagicMock()
+    transaction_active = False
+
+    def scalar(*_args: object) -> object:
+        nonlocal transaction_active
+        transaction_active = True
+        return dataset if session.scalar.call_count == 1 else document
+
+    def scalars(*_args: object) -> MagicMock:
+        nonlocal transaction_active
+        transaction_active = True
+        return MagicMock(all=MagicMock(return_value=[binding]))
+
+    def commit() -> None:
+        nonlocal transaction_active
+        transaction_active = False
+
+    session.scalar.side_effect = scalar
+    session.scalars.side_effect = scalars
+    session.commit.side_effect = commit
+    processor = MagicMock()
+    cleanup_transaction_states: list[bool] = []
+    processor.clean.side_effect = lambda *_args, **_kwargs: cleanup_transaction_states.append(transaction_active)
+
+    with (
+        patch("tasks.delete_segment_from_index_task.session_factory.create_session", return_value=nullcontext(session)),
+        patch("tasks.delete_segment_from_index_task.IndexProcessorFactory") as processor_factory,
+    ):
+        processor_factory.return_value.init_index_processor.return_value = processor
+        delete_segment_from_index_task.run(["node-1"], dataset.id, document.id, ["segment-1"])
+
+    assert cleanup_transaction_states == [False, False]
+    assert processor.clean.call_count == 2
+
+
+def test_remove_document_commits_before_summary_and_index_cleanup() -> None:
+    dataset = _dataset()
+    document = _document(dataset)
+    segment = _segment(dataset, document)
+    session = MagicMock()
+    session.scalar.return_value = document
+    session.scalars.return_value.all.return_value = [segment]
+    session.get.return_value = dataset
+    phase_events: list[str] = []
+    session.commit.side_effect = lambda: phase_events.append("commit")
+    processor = MagicMock()
+    processor.clean.side_effect = lambda *_args, **_kwargs: phase_events.append("clean")
+
+    def disable_summaries(**_kwargs: object) -> None:
+        phase_events.append("summary")
+        session.commit()
+
+    disable_summaries_mock = MagicMock(side_effect=disable_summaries)
+    with (
+        patch(
+            "tasks.remove_document_from_index_task.session_factory.create_session",
+            return_value=nullcontext(session),
+        ),
+        patch("tasks.remove_document_from_index_task.IndexProcessorFactory") as processor_factory,
+        patch(
+            "services.summary_index_service.SummaryIndexService.disable_summaries_for_segments",
+            disable_summaries_mock,
+        ),
+        patch("tasks.remove_document_from_index_task.redis_client.delete"),
+    ):
+        processor_factory.return_value.init_index_processor.return_value = processor
+        remove_document_from_index_task.run(document.id)
+
+    assert phase_events == ["commit", "summary", "commit", "clean", "commit"]
+    disable_summaries_mock.assert_called_once_with(
+        dataset=dataset,
+        session=session,
+        segment_ids=[segment.id],
+        disabled_by=document.disabled_by,
+    )


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Added concurrency-safe summary generation claims, atomic vector publication, stale-claim recovery, and orphaned-vector cleanup. (TODO: full optimistic lock not implemented because I want to prevent DDL/migratino)
- Preserved existing summaries during regeneration and improved failure, enable, disable, and deletion handling.
- Validated retrieval results against allowed datasets and canonical summary records, with safer deduplication and score merging.
- Removed long-lived database sessions around LLM, embedding, storage, and vector-provider operations.
- Hardened Qdrant and TiDB binding initialization, plus Weaviate upserts, pagination, deletion, legacy cleanup, and batch error handling.
- Made vector migration include summaries and detect concurrent dataset or configuration changes before activation.
- Improved segment/document cleanup so summary, child-chunk, and attachment rows remain consistent after partial failures.
- Added extensive tests for summary concurrency, retrieval scoping, migration, vector backends, transactions, and cleanup tasks.


## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
