### PR TITLE
fix(agent): preserve completed thought elapsed time

### DIFF
--- a/api/core/workflow/nodes/agent/message_transformer.py
+++ b/api/core/workflow/nodes/agent/message_transformer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from collections.abc import Generator, Mapping
 from typing import Any, cast
 
@@ -29,6 +30,24 @@ from services.tools.builtin_tools_manage_service import BuiltinToolManageService
 from .exceptions import AgentNodeError, AgentVariableTypeError, ToolFileNotFoundError
 
 _file_access_controller = DatabaseFileAccessController()
+
+
+def _is_positive_elapsed_time(value: Any) -> bool:
+    return isinstance(value, int | float) and not isinstance(value, bool) and math.isfinite(value) and value > 0
+
+
+def _merge_agent_log_metadata(
+    previous_metadata: Mapping[str, Any] | None,
+    new_metadata: Mapping[str, Any] | None,
+) -> Mapping[str, Any]:
+    merged_metadata = dict(new_metadata or {})
+    previous_elapsed_time = (previous_metadata or {}).get("elapsed_time")
+    new_elapsed_time = merged_metadata.get("elapsed_time")
+
+    if _is_positive_elapsed_time(previous_elapsed_time) and not _is_positive_elapsed_time(new_elapsed_time):
+        merged_metadata["elapsed_time"] = previous_elapsed_time
+
+    return merged_metadata
 
 
 class AgentMessageTransformer:
@@ -241,7 +260,7 @@ class AgentMessageTransformer:
                         log.status = agent_log.status
                         log.error = agent_log.error
                         log.label = agent_log.label
-                        log.metadata = agent_log.metadata
+                        log.metadata = _merge_agent_log_metadata(log.metadata, agent_log.metadata)
                         break
                 else:
                     agent_logs.append(agent_log)

--- a/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py
@@ -1,8 +1,12 @@
 from unittest.mock import patch
 
+import pytest
+
+from core.tools.entities.tool_entities import ToolInvokeMessage
 from core.tools.utils.message_transformer import ToolFileMessageTransformer
 from core.workflow.nodes.agent.message_transformer import AgentMessageTransformer
-from graphon.enums import BuiltinNodeTypes
+from graphon.enums import BuiltinNodeTypes, WorkflowNodeExecutionMetadataKey
+from graphon.node_events import StreamCompletedEvent
 
 
 def test_transform_passes_conversation_id_to_tool_file_message_transformer() -> None:
@@ -31,3 +35,196 @@ def test_transform_passes_conversation_id_to_tool_file_message_transformer() -> 
         tenant_id="tenant-id",
         conversation_id="conversation-id",
     )
+
+
+def _log_message(
+    *,
+    message_id: str,
+    status: ToolInvokeMessage.LogMessage.LogStatus,
+    metadata: dict[str, object] | None,
+) -> ToolInvokeMessage:
+    return ToolInvokeMessage(
+        type=ToolInvokeMessage.MessageType.LOG,
+        message=ToolInvokeMessage.LogMessage(
+            id=message_id,
+            label=f"label-{message_id}",
+            status=status,
+            data={"message_id": message_id, "status": status.value},
+            metadata=metadata,
+        ),
+    )
+
+
+def _agent_logs_from_transform(messages: list[ToolInvokeMessage]):
+    transformer = AgentMessageTransformer()
+
+    with patch.object(ToolFileMessageTransformer, "transform_tool_invoke_messages", return_value=iter(messages)):
+        events = list(
+            transformer.transform(
+                messages=iter(()),
+                tool_info={},
+                parameters_for_log={},
+                user_id="user-id",
+                tenant_id="tenant-id",
+                conversation_id="conversation-id",
+                node_type=BuiltinNodeTypes.AGENT,
+                node_id="node-id",
+                node_execution_id="execution-id",
+            )
+        )
+
+    completed_event = events[-1]
+    assert isinstance(completed_event, StreamCompletedEvent)
+    return completed_event.node_run_result.metadata[WorkflowNodeExecutionMetadataKey.AGENT_LOG]
+
+
+@pytest.mark.parametrize("final_metadata", [{"elapsed_time": 0}, {}])
+def test_transform_keeps_existing_positive_elapsed_time_when_final_log_has_zero_or_missing(
+    final_metadata: dict[str, object],
+) -> None:
+    agent_logs = _agent_logs_from_transform(
+        [
+            _log_message(
+                message_id="thought-1",
+                status=ToolInvokeMessage.LogMessage.LogStatus.START,
+                metadata={"elapsed_time": 1.25},
+            ),
+            _log_message(
+                message_id="thought-1",
+                status=ToolInvokeMessage.LogMessage.LogStatus.SUCCESS,
+                metadata=final_metadata,
+            ),
+        ]
+    )
+
+    assert len(agent_logs) == 1
+    assert agent_logs[0].metadata["elapsed_time"] == 1.25
+
+
+def test_transform_updates_elapsed_time_when_new_log_has_positive_value() -> None:
+    agent_logs = _agent_logs_from_transform(
+        [
+            _log_message(
+                message_id="thought-1",
+                status=ToolInvokeMessage.LogMessage.LogStatus.START,
+                metadata={"elapsed_time": 1.25},
+            ),
+            _log_message(
+                message_id="thought-1",
+                status=ToolInvokeMessage.LogMessage.LogStatus.SUCCESS,
+                metadata={"elapsed_time": 1.5},
+            ),
+        ]
+    )
+
+    assert len(agent_logs) == 1
+    assert agent_logs[0].metadata["elapsed_time"] == 1.5
+
+
+def test_transform_does_not_preserve_positive_infinity_elapsed_time() -> None:
+    agent_logs = _agent_logs_from_transform(
+        [
+            _log_message(
+                message_id="thought-1",
+                status=ToolInvokeMessage.LogMessage.LogStatus.START,
+                metadata={"elapsed_time": float("inf")},
+            ),
+            _log_message(
+                message_id="thought-1",
+                status=ToolInvokeMessage.LogMessage.LogStatus.SUCCESS,
+                metadata={"elapsed_time": 0},
+            ),
+        ]
+    )
+
+    assert len(agent_logs) == 1
+    assert agent_logs[0].metadata["elapsed_time"] == 0
+
+
+def test_transform_does_not_update_elapsed_time_to_positive_infinity() -> None:
+    agent_logs = _agent_logs_from_transform(
+        [
+            _log_message(
+                message_id="thought-1",
+                status=ToolInvokeMessage.LogMessage.LogStatus.START,
+                metadata={"elapsed_time": 1.25},
+            ),
+            _log_message(
+                message_id="thought-1",
+                status=ToolInvokeMessage.LogMessage.LogStatus.SUCCESS,
+                metadata={"elapsed_time": float("inf")},
+            ),
+        ]
+    )
+
+    assert len(agent_logs) == 1
+    assert agent_logs[0].metadata["elapsed_time"] == 1.25
+
+
+def test_transform_does_not_treat_bool_elapsed_time_as_positive_value() -> None:
+    agent_logs = _agent_logs_from_transform(
+        [
+            _log_message(
+                message_id="thought-1",
+                status=ToolInvokeMessage.LogMessage.LogStatus.START,
+                metadata={"elapsed_time": True},
+            ),
+            _log_message(
+                message_id="thought-1",
+                status=ToolInvokeMessage.LogMessage.LogStatus.SUCCESS,
+                metadata={"elapsed_time": 0},
+            ),
+        ]
+    )
+
+    assert len(agent_logs) == 1
+    assert agent_logs[0].metadata["elapsed_time"] == 0
+
+
+@pytest.mark.parametrize("metadata", [{"elapsed_time": 0}, {}])
+def test_transform_preserves_zero_or_missing_elapsed_time_when_no_positive_value_was_seen(
+    metadata: dict[str, object],
+) -> None:
+    agent_logs = _agent_logs_from_transform(
+        [
+            _log_message(
+                message_id="thought-1",
+                status=ToolInvokeMessage.LogMessage.LogStatus.START,
+                metadata=metadata,
+            ),
+            _log_message(
+                message_id="thought-1",
+                status=ToolInvokeMessage.LogMessage.LogStatus.SUCCESS,
+                metadata=metadata,
+            ),
+        ]
+    )
+
+    assert len(agent_logs) == 1
+    assert agent_logs[0].metadata == metadata
+
+
+def test_transform_elapsed_time_merge_is_scoped_to_message_id() -> None:
+    agent_logs = _agent_logs_from_transform(
+        [
+            _log_message(
+                message_id="thought-1",
+                status=ToolInvokeMessage.LogMessage.LogStatus.START,
+                metadata={"elapsed_time": 1.25},
+            ),
+            _log_message(
+                message_id="thought-2",
+                status=ToolInvokeMessage.LogMessage.LogStatus.SUCCESS,
+                metadata={"elapsed_time": 0},
+            ),
+            _log_message(
+                message_id="thought-1",
+                status=ToolInvokeMessage.LogMessage.LogStatus.SUCCESS,
+                metadata={},
+            ),
+        ]
+    )
+
+    logs_by_id = {log.message_id: log for log in agent_logs}
+    assert logs_by_id["thought-1"].metadata["elapsed_time"] == 1.25
+    assert logs_by_id["thought-2"].metadata["elapsed_time"] == 0


### PR DESCRIPTION
## Summary

- preserve a previously observed positive, finite Agent Thought `elapsed_time` when the final log for the same `message_id` reports `0` or omits the field
- continue accepting later positive, finite elapsed-time updates while rejecting booleans and non-finite values as authoritative durations
- add focused regression coverage for zero, missing, updated, non-finite, boolean, and distinct-message cases

Closes #39757.

## Validation

- Baseline regression: `4 failed, 6 passed` against the unpatched implementation
- `PYTHONDONTWRITEBYTECODE=1 uv run --project api pytest -p no:cacheprovider -o addopts='' api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py -q` (`10 passed`)
- `uv run --project api --dev ruff check api/core/workflow/nodes/agent/message_transformer.py api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py`
- `uv run --project api --dev ruff format --check api/core/workflow/nodes/agent/message_transformer.py api/tests/unit_tests/core/workflow/nodes/agent/test_message_transformer.py`
- `git diff --check`

## Duplicate Check

Checked the live issue timeline, open and closed pull requests by issue number, affected symbols, paths, and behavior, plus the current canonical `main` at `72c20daa61adb2448caa02f7d4e807af35f6a84e`. No equivalent active fix, merged fix, public implementation claim, assignment, or contribution lock was found. PRs #35301, #35574, and #35932 concern different UI or behavior boundaries.

## Browser / Playwright

Not run. The regression is isolated to backend Agent log aggregation and is deterministically covered by unit tests. A full browser reproduction requires a configured Dify service, model/Agent plugin, and workflow; no frontend code is changed.
