### PR TITLE
fix(web): allow duplicate Output node variables on mutually exclusive branches

### DIFF
--- a/web/app/components/workflow/hooks/__tests__/use-checklist.spec.ts
+++ b/web/app/components/workflow/hooks/__tests__/use-checklist.spec.ts
@@ -567,6 +567,47 @@ describe('useChecklist', () => {
     ).toBe(true)
   })
 
+  it('should allow duplicate output variables on end nodes behind exclusive branches', () => {
+    mockNodesMap[BlockEnum.IfElse] = {
+      checkValid: () => ({ errorMessage: '' }),
+      metaData: { isStart: false, isRequired: false },
+    }
+
+    const startNode = createNode({ id: 'start', data: { type: BlockEnum.Start, title: 'Start' } })
+    const ifElseNode = createNode({
+      id: 'if-else',
+      data: { type: BlockEnum.IfElse, title: 'If/Else' },
+    })
+    const firstEndNode = createNode({
+      id: 'end-1',
+      data: {
+        type: BlockEnum.End,
+        title: 'Output 1',
+        outputs: [{ variable: 'workflow_id', value_selector: ['sys', 'workflow_id'] }],
+      },
+    })
+    const secondEndNode = createNode({
+      id: 'end-2',
+      data: {
+        type: BlockEnum.End,
+        title: 'Output 2',
+        outputs: [{ variable: 'workflow_id', value_selector: ['sys', 'workflow_id'] }],
+      },
+    })
+
+    const edges = [
+      createEdge({ source: 'start', target: 'if-else' }),
+      createEdge({ source: 'if-else', target: 'end-1', sourceHandle: 'true' }),
+      createEdge({ source: 'if-else', target: 'end-2', sourceHandle: 'false' }),
+    ]
+
+    const { result } = renderWorkflowHook(() =>
+      useChecklist([startNode, ifElseNode, firstEndNode, secondEndNode], edges),
+    )
+
+    expect(result.current).toEqual([])
+  })
+
   it('should sync checklist items to the workflow store without render phase update warnings', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     try {

--- a/web/app/components/workflow/hooks/__tests__/use-checklist.spec.ts
+++ b/web/app/components/workflow/hooks/__tests__/use-checklist.spec.ts
@@ -608,6 +608,59 @@ describe('useChecklist', () => {
     expect(result.current).toEqual([])
   })
 
+  it('should report conflicting output types on exclusive branches', () => {
+    mockNodesMap[BlockEnum.IfElse] = {
+      checkValid: () => ({ errorMessage: '' }),
+      metaData: { isStart: false, isRequired: false },
+    }
+
+    const startNode = createNode({ id: 'start', data: { type: BlockEnum.Start, title: 'Start' } })
+    const ifElseNode = createNode({
+      id: 'if-else',
+      data: { type: BlockEnum.IfElse, title: 'If/Else' },
+    })
+    const firstEndNode = createNode({
+      id: 'end-1',
+      data: {
+        type: BlockEnum.End,
+        title: 'Output 1',
+        outputs: [{ variable: 'result', value_type: 'string', value_selector: ['sys', 'result'] }],
+      },
+    })
+    const secondEndNode = createNode({
+      id: 'end-2',
+      data: {
+        type: BlockEnum.End,
+        title: 'Output 2',
+        outputs: [{ variable: 'result', value_type: 'object', value_selector: ['sys', 'result'] }],
+      },
+    })
+
+    const edges = [
+      createEdge({ source: 'start', target: 'if-else' }),
+      createEdge({ source: 'if-else', target: 'end-1', sourceHandle: 'true' }),
+      createEdge({ source: 'if-else', target: 'end-2', sourceHandle: 'false' }),
+    ]
+
+    const { result } = renderWorkflowHook(() =>
+      useChecklist([startNode, ifElseNode, firstEndNode, secondEndNode], edges),
+    )
+
+    const secondWarning = result.current.find((item: ChecklistItem) => item.id === 'end-2')
+    const firstWarning = result.current.find((item: ChecklistItem) => item.id === 'end-1')
+
+    expect(
+      firstWarning?.errorMessages.some((message) =>
+        message.includes('conflictingOutputVariableTypes'),
+      ),
+    ).toBe(true)
+    expect(
+      secondWarning?.errorMessages.some((message) =>
+        message.includes('conflictingOutputVariableTypes'),
+      ),
+    ).toBe(true)
+  })
+
   it('should sync checklist items to the workflow store without render phase update warnings', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     try {

--- a/web/app/components/workflow/hooks/use-checklist.ts
+++ b/web/app/components/workflow/hooks/use-checklist.ts
@@ -61,7 +61,7 @@ import {
   getToolCheckParams,
   getValidTreeNodes,
 } from '../utils'
-import { getDuplicateEndOutputVariables } from '../utils/end-output-conflicts'
+import { getEndOutputConflicts } from '../utils/end-output-conflicts'
 import { extractPluginId } from '../utils/plugin'
 import { isNodePluginMissing } from '../utils/plugin-install-check'
 import { getTriggerCheckParams } from '../utils/trigger'
@@ -109,14 +109,20 @@ const getDuplicateEndOutputMessages = (
 ) => {
   const nodeMessages = new Map<string, string[]>()
 
-  getDuplicateEndOutputVariables(
+  getEndOutputConflicts(
     nodes.filter((node) => node.type === CUSTOM_NODE),
     edges,
-  ).forEach((variables, nodeId) => {
+  ).forEach((conflicts, nodeId) => {
     nodeMessages.set(
       nodeId,
-      variables.map((variable) =>
-        t(($) => $['errorMsg.duplicateOutputVariable'], { ns: 'workflow', variable }),
+      conflicts.map(({ variable, kind, types }) =>
+        kind === 'conflictingTypes'
+          ? t(($) => $['errorMsg.conflictingOutputVariableTypes'], {
+              ns: 'workflow',
+              variable,
+              types: (types ?? []).join(', '),
+            })
+          : t(($) => $['errorMsg.duplicateOutputVariable'], { ns: 'workflow', variable }),
       ),
     )
   })

--- a/web/app/components/workflow/hooks/use-checklist.ts
+++ b/web/app/components/workflow/hooks/use-checklist.ts
@@ -61,6 +61,7 @@ import {
   getToolCheckParams,
   getValidTreeNodes,
 } from '../utils'
+import { getDuplicateEndOutputVariables } from '../utils/end-output-conflicts'
 import { extractPluginId } from '../utils/plugin'
 import { isNodePluginMissing } from '../utils/plugin-install-check'
 import { getTriggerCheckParams } from '../utils/trigger'
@@ -103,33 +104,21 @@ const START_NODE_TYPES: BlockEnum[] = [
 
 const getDuplicateEndOutputMessages = (
   nodes: Node[],
+  edges: Edge[],
   t: ReturnType<typeof useTranslation>['t'],
 ) => {
-  const variableOccurrences = new Map<string, string[]>()
-
-  nodes.forEach((node) => {
-    if (node.type !== CUSTOM_NODE || node.data.type !== BlockEnum.End) return
-
-    const outputs = (node.data as { outputs?: Array<{ variable?: string }> }).outputs || []
-    outputs.forEach((output) => {
-      const variable = output.variable?.trim()
-      if (!variable) return
-
-      const occurrences = variableOccurrences.get(variable) || []
-      occurrences.push(node.id)
-      variableOccurrences.set(variable, occurrences)
-    })
-  })
-
   const nodeMessages = new Map<string, string[]>()
-  variableOccurrences.forEach((nodeIds, variable) => {
-    if (nodeIds.length <= 1) return
 
-    Array.from(new Set(nodeIds)).forEach((nodeId) => {
-      const messages = nodeMessages.get(nodeId) || []
-      messages.push(t(($) => $['errorMsg.duplicateOutputVariable'], { ns: 'workflow', variable }))
-      nodeMessages.set(nodeId, messages)
-    })
+  getDuplicateEndOutputVariables(
+    nodes.filter((node) => node.type === CUSTOM_NODE),
+    edges,
+  ).forEach((variables, nodeId) => {
+    nodeMessages.set(
+      nodeId,
+      variables.map((variable) =>
+        t(($) => $['errorMsg.duplicateOutputVariable'], { ns: 'workflow', variable }),
+      ),
+    )
   })
 
   return nodeMessages
@@ -287,7 +276,7 @@ export const useChecklist = (nodes: Node[], edges: Edge[], options?: { flowType?
   const needWarningNodes = useMemo<ChecklistItem[]>(() => {
     const list: ChecklistItem[] = []
     const filteredNodes = nodes.filter((node) => node.type === CUSTOM_NODE)
-    const duplicateEndOutputMessages = getDuplicateEndOutputMessages(filteredNodes, t)
+    const duplicateEndOutputMessages = getDuplicateEndOutputMessages(filteredNodes, edges, t)
     const { validNodes } = getValidTreeNodes(filteredNodes, edges)
     const installedPluginIds = new Set(modelProviders.map((p) => extractPluginId(p.provider)))
 
@@ -576,7 +565,7 @@ export const useChecklistBeforePublish = () => {
     const { dataSourceList } = workflowStore.getState()
     const nodes = getNodes()
     const filteredNodes = nodes.filter((node) => node.type === CUSTOM_NODE)
-    const duplicateEndOutputMessages = getDuplicateEndOutputMessages(filteredNodes, t)
+    const duplicateEndOutputMessages = getDuplicateEndOutputMessages(filteredNodes, edges, t)
     const { validNodes, maxDepth } = getValidTreeNodes(filteredNodes, edges)
 
     if (maxDepth > MAX_TREE_DEPTH) {

--- a/web/app/components/workflow/utils/__tests__/end-output-conflicts.spec.ts
+++ b/web/app/components/workflow/utils/__tests__/end-output-conflicts.spec.ts
@@ -1,0 +1,322 @@
+import type { Edge, Node } from '../../types'
+import { createEdge, createNode, resetFixtureCounters } from '../../__tests__/fixtures'
+import { BlockEnum } from '../../types'
+import { getDuplicateEndOutputVariables } from '../end-output-conflicts'
+
+beforeEach(() => {
+  resetFixtureCounters()
+})
+
+const start = (id = 'start') => createNode({ id, data: { type: BlockEnum.Start, title: 'Start' } })
+
+const ifElse = (id: string) =>
+  createNode({ id, data: { type: BlockEnum.IfElse, title: 'If/Else' } })
+
+const end = (id: string, variables: string[]) =>
+  createNode({
+    id,
+    data: {
+      type: BlockEnum.End,
+      title: id,
+      outputs: variables.map((variable) => ({ variable, value_selector: ['sys', variable] })),
+    },
+  })
+
+const link = (source: string, target: string, sourceHandle?: string) =>
+  createEdge({ source, target, ...(sourceHandle ? { sourceHandle } : {}) })
+
+const conflictsOf = (nodes: Node[], edges: Edge[]) =>
+  Object.fromEntries(getDuplicateEndOutputVariables(nodes, edges))
+
+describe('getDuplicateEndOutputVariables', () => {
+  it('should report nothing when output variable names are unique', () => {
+    const nodes = [start(), end('end-1', ['a']), end('end-2', ['b'])]
+    const edges = [link('start', 'end-1'), link('start', 'end-2')]
+
+    expect(conflictsOf(nodes, edges)).toEqual({})
+  })
+
+  it('should report Output nodes that run in parallel and share a variable name', () => {
+    const nodes = [start(), end('end-1', ['result']), end('end-2', ['result'])]
+    const edges = [link('start', 'end-1'), link('start', 'end-2')]
+
+    expect(conflictsOf(nodes, edges)).toEqual({
+      'end-1': ['result'],
+      'end-2': ['result'],
+    })
+  })
+
+  it('should allow the same variable name on both sides of an if/else', () => {
+    const nodes = [start(), ifElse('branch'), end('end-1', ['result']), end('end-2', ['result'])]
+    const edges = [
+      link('start', 'branch'),
+      link('branch', 'end-1', 'true'),
+      link('branch', 'end-2', 'false'),
+    ]
+
+    expect(conflictsOf(nodes, edges)).toEqual({})
+  })
+
+  it('should allow the same variable name across a success and a fail branch', () => {
+    const nodes = [
+      start(),
+      createNode({ id: 'llm', data: { type: BlockEnum.LLM, title: 'LLM' } }),
+      end('end-1', ['result']),
+      end('end-2', ['result']),
+    ]
+    const edges = [
+      link('start', 'llm'),
+      link('llm', 'end-1', 'source'),
+      link('llm', 'end-2', 'fail-branch'),
+    ]
+
+    expect(conflictsOf(nodes, edges)).toEqual({})
+  })
+
+  it('should allow the same variable name when several classifier classes merge into one Output node', () => {
+    const nodes = [
+      start(),
+      createNode({ id: 'classifier', data: { type: BlockEnum.QuestionClassifier, title: 'Q' } }),
+      end('end-1', ['result']),
+      end('end-2', ['result']),
+    ]
+    const edges = [
+      link('start', 'classifier'),
+      link('classifier', 'end-1', 'class-1'),
+      link('classifier', 'end-1', 'class-2'),
+      link('classifier', 'end-2', 'class-3'),
+    ]
+
+    expect(conflictsOf(nodes, edges)).toEqual({})
+  })
+
+  it('should report a conflict when one Output node bypasses the branch entirely', () => {
+    const nodes = [start(), ifElse('branch'), end('end-1', ['result']), end('end-2', ['result'])]
+    const edges = [link('start', 'branch'), link('branch', 'end-1', 'true'), link('start', 'end-2')]
+
+    expect(conflictsOf(nodes, edges)).toEqual({
+      'end-1': ['result'],
+      'end-2': ['result'],
+    })
+  })
+
+  it('should allow the same variable name on Output nodes reached through nested branches', () => {
+    const nodes = [
+      start(),
+      ifElse('outer'),
+      ifElse('inner'),
+      end('end-1', ['result']),
+      end('end-2', ['result']),
+      end('end-3', ['result']),
+    ]
+    const edges = [
+      link('start', 'outer'),
+      link('outer', 'inner', 'true'),
+      link('inner', 'end-1', 'true'),
+      link('inner', 'end-2', 'false'),
+      link('outer', 'end-3', 'false'),
+    ]
+
+    expect(conflictsOf(nodes, edges)).toEqual({})
+  })
+
+  it('should allow the same variable name on Output nodes behind a chain of if/else nodes', () => {
+    const nodes = [
+      start(),
+      ifElse('first'),
+      ifElse('second'),
+      end('end-1', ['result']),
+      end('end-2', ['result']),
+      end('end-3', ['result']),
+    ]
+    const edges = [
+      link('start', 'first'),
+      link('first', 'end-1', 'true'),
+      link('first', 'second', 'false'),
+      link('second', 'end-2', 'true'),
+      link('second', 'end-3', 'false'),
+    ]
+
+    expect(conflictsOf(nodes, edges)).toEqual({})
+  })
+
+  it('should allow the same variable name across a human input action and its timeout', () => {
+    const nodes = [
+      start(),
+      createNode({ id: 'human', data: { type: BlockEnum.HumanInput, title: 'Human Input' } }),
+      end('end-1', ['result']),
+      end('end-2', ['result']),
+    ]
+    const edges = [
+      link('start', 'human'),
+      link('human', 'end-1', 'action-approve'),
+      link('human', 'end-2', '__timeout'),
+    ]
+
+    expect(conflictsOf(nodes, edges)).toEqual({})
+  })
+
+  it('should allow the same variable name when Output nodes share a fallback Output node', () => {
+    // `ok` needs first=true and second=true, while `err` is reached from either failure path, so the
+    // two can still never run together.
+    const nodes = [
+      start(),
+      ifElse('first'),
+      ifElse('second'),
+      end('ok', ['result']),
+      end('err', ['result']),
+    ]
+    const edges = [
+      link('start', 'first'),
+      link('first', 'second', 'true'),
+      link('first', 'err', 'false'),
+      link('second', 'ok', 'true'),
+      link('second', 'err', 'false'),
+    ]
+
+    expect(conflictsOf(nodes, edges)).toEqual({})
+  })
+
+  it('should allow the same variable name when a fail branch joins an if/else failure path', () => {
+    const nodes = [
+      start(),
+      createNode({ id: 'llm', data: { type: BlockEnum.LLM, title: 'LLM' } }),
+      ifElse('branch'),
+      end('ok', ['result']),
+      end('err', ['result']),
+    ]
+    const edges = [
+      link('start', 'llm'),
+      link('llm', 'branch', 'source'),
+      link('llm', 'err', 'fail-branch'),
+      link('branch', 'ok', 'true'),
+      link('branch', 'err', 'false'),
+    ]
+
+    expect(conflictsOf(nodes, edges)).toEqual({})
+  })
+
+  it('should ignore the temporary edges added while highlighting variable dependencies', () => {
+    const nodes = [start(), ifElse('branch'), end('end-1', ['result']), end('end-2', ['result'])]
+    const edges = [
+      link('start', 'branch'),
+      link('branch', 'end-1', 'true'),
+      link('branch', 'end-2', 'false'),
+      createEdge({
+        source: 'start',
+        target: 'end-1',
+        sourceHandle: 'source_tmp',
+        data: { _isTemp: true },
+      }),
+      createEdge({
+        source: 'start',
+        target: 'end-2',
+        sourceHandle: 'source_tmp',
+        data: { _isTemp: true },
+      }),
+    ]
+
+    expect(conflictsOf(nodes, edges)).toEqual({})
+  })
+
+  it('should allow the same variable name on Output nodes belonging to different entry nodes', () => {
+    const nodes = [
+      start('start-a'),
+      createNode({ id: 'start-b', data: { type: BlockEnum.TriggerWebhook, title: 'Webhook' } }),
+      end('end-1', ['result']),
+      end('end-2', ['result']),
+    ]
+    const edges = [link('start-a', 'end-1'), link('start-b', 'end-2')]
+
+    expect(conflictsOf(nodes, edges)).toEqual({})
+  })
+
+  it('should report a variable declared twice by the same Output node', () => {
+    const nodes = [start(), end('end-1', ['result', 'result'])]
+    const edges = [link('start', 'end-1')]
+
+    expect(conflictsOf(nodes, edges)).toEqual({ 'end-1': ['result'] })
+  })
+
+  it('should ignore blank variable names', () => {
+    const nodes = [start(), end('end-1', ['', '  ']), end('end-2', ['', '  '])]
+    const edges = [link('start', 'end-1'), link('start', 'end-2')]
+
+    expect(conflictsOf(nodes, edges)).toEqual({})
+  })
+
+  it('should report only the variable names that actually collide', () => {
+    const nodes = [start(), end('end-1', ['shared', 'only-a']), end('end-2', ['shared', 'only-b'])]
+    const edges = [link('start', 'end-1'), link('start', 'end-2')]
+
+    expect(conflictsOf(nodes, edges)).toEqual({
+      'end-1': ['shared'],
+      'end-2': ['shared'],
+    })
+  })
+
+  it('should compare Output nodes only within their own scope', () => {
+    const nodes = [
+      start(),
+      createNode({ id: 'loop', data: { type: BlockEnum.Loop, title: 'Loop' } }),
+      end('end-1', ['result']),
+      createNode({
+        id: 'end-2',
+        parentId: 'loop',
+        data: {
+          type: BlockEnum.End,
+          title: 'end-2',
+          outputs: [{ variable: 'result', value_selector: ['sys', 'result'] }],
+        },
+      }),
+    ]
+    const edges = [link('start', 'loop'), link('loop', 'end-1')]
+
+    expect(conflictsOf(nodes, edges)).toEqual({})
+  })
+
+  it('should terminate and report a conflict when the graph contains a cycle', () => {
+    const nodes = [
+      start(),
+      createNode({ id: 'a', data: { type: BlockEnum.Code, title: 'A' } }),
+      createNode({ id: 'b', data: { type: BlockEnum.Code, title: 'B' } }),
+      end('end-1', ['result']),
+      end('end-2', ['result']),
+    ]
+    const edges = [
+      link('start', 'a'),
+      link('a', 'b'),
+      link('b', 'a'),
+      link('a', 'end-1'),
+      link('b', 'end-2'),
+    ]
+
+    expect(conflictsOf(nodes, edges)).toEqual({
+      'end-1': ['result'],
+      'end-2': ['result'],
+    })
+  })
+
+  it('should report a conflict for Output nodes that are not connected to an entry node', () => {
+    const nodes = [start(), end('end-1', ['result']), end('end-2', ['result'])]
+
+    expect(conflictsOf(nodes, [])).toEqual({
+      'end-1': ['result'],
+      'end-2': ['result'],
+    })
+  })
+
+  it('should not treat a dangling Output node as its own entry point in a flow without a start node', () => {
+    const nodes = [
+      createNode({ id: 'data-source', data: { type: BlockEnum.DataSource, title: 'Source' } }),
+      end('end-1', ['result']),
+      end('end-2', ['result']),
+    ]
+    const edges = [link('data-source', 'end-1')]
+
+    expect(conflictsOf(nodes, edges)).toEqual({
+      'end-1': ['result'],
+      'end-2': ['result'],
+    })
+  })
+})

--- a/web/app/components/workflow/utils/__tests__/end-output-conflicts.spec.ts
+++ b/web/app/components/workflow/utils/__tests__/end-output-conflicts.spec.ts
@@ -1,7 +1,7 @@
 import type { Edge, Node } from '../../types'
 import { createEdge, createNode, resetFixtureCounters } from '../../__tests__/fixtures'
-import { BlockEnum } from '../../types'
-import { getDuplicateEndOutputVariables } from '../end-output-conflicts'
+import { BlockEnum, VarType } from '../../types'
+import { getEndOutputConflicts } from '../end-output-conflicts'
 
 beforeEach(() => {
   resetFixtureCounters()
@@ -22,13 +22,46 @@ const end = (id: string, variables: string[]) =>
     },
   })
 
+const typedEnd = (id: string, outputs: [string, VarType][]) =>
+  createNode({
+    id,
+    data: {
+      type: BlockEnum.End,
+      title: id,
+      outputs: outputs.map(([variable, valueType]) => ({
+        variable,
+        value_type: valueType,
+        value_selector: ['sys', variable],
+      })),
+    },
+  })
+
 const link = (source: string, target: string, sourceHandle?: string) =>
   createEdge({ source, target, ...(sourceHandle ? { sourceHandle } : {}) })
 
+/** Conflicting variable names per Output node, ignoring the kind. */
 const conflictsOf = (nodes: Node[], edges: Edge[]) =>
-  Object.fromEntries(getDuplicateEndOutputVariables(nodes, edges))
+  Object.fromEntries(
+    [...getEndOutputConflicts(nodes, edges)].map(([nodeId, conflicts]) => [
+      nodeId,
+      conflicts.map((conflict) => conflict.variable),
+    ]),
+  )
 
-describe('getDuplicateEndOutputVariables', () => {
+const detailedConflictsOf = (nodes: Node[], edges: Edge[]) =>
+  Object.fromEntries(getEndOutputConflicts(nodes, edges))
+
+/** `start → if/else`, with each branch ending in its own Output node. */
+const exclusiveBranches = (first: Node, second: Node) => ({
+  nodes: [start(), ifElse('branch'), first, second],
+  edges: [
+    link('start', 'branch'),
+    link('branch', first.id, 'true'),
+    link('branch', second.id, 'false'),
+  ],
+})
+
+describe('getEndOutputConflicts', () => {
   it('should report nothing when output variable names are unique', () => {
     const nodes = [start(), end('end-1', ['a']), end('end-2', ['b'])]
     const edges = [link('start', 'end-1'), link('start', 'end-2')]
@@ -229,6 +262,59 @@ describe('getDuplicateEndOutputVariables', () => {
     const edges = [link('start-a', 'end-1'), link('start-b', 'end-2')]
 
     expect(conflictsOf(nodes, edges)).toEqual({})
+  })
+
+  it('should report conflicting types when exclusive branches declare the same name as string and object', () => {
+    const { nodes, edges } = exclusiveBranches(
+      typedEnd('end-1', [['result', VarType.string]]),
+      typedEnd('end-2', [['result', VarType.object]]),
+    )
+
+    expect(detailedConflictsOf(nodes, edges)).toEqual({
+      'end-1': [{ variable: 'result', kind: 'conflictingTypes', types: ['object', 'string'] }],
+      'end-2': [{ variable: 'result', kind: 'conflictingTypes', types: ['object', 'string'] }],
+    })
+  })
+
+  it('should allow exclusive branches to reuse a name when the declared types match', () => {
+    const { nodes, edges } = exclusiveBranches(
+      typedEnd('end-1', [['result', VarType.string]]),
+      typedEnd('end-2', [['result', VarType.string]]),
+    )
+
+    expect(detailedConflictsOf(nodes, edges)).toEqual({})
+  })
+
+  it('should treat any as compatible with every declared type', () => {
+    const { nodes, edges } = exclusiveBranches(
+      typedEnd('end-1', [['result', VarType.any]]),
+      typedEnd('end-2', [['result', VarType.object]]),
+    )
+
+    expect(detailedConflictsOf(nodes, edges)).toEqual({})
+  })
+
+  it('should not claim a type conflict when one side has no declared type', () => {
+    const { nodes, edges } = exclusiveBranches(
+      end('end-1', ['result']),
+      typedEnd('end-2', [['result', VarType.object]]),
+    )
+
+    expect(detailedConflictsOf(nodes, edges)).toEqual({})
+  })
+
+  it('should report the lost value rather than the type when the Output nodes also run together', () => {
+    const nodes = [
+      start(),
+      typedEnd('end-1', [['result', VarType.string]]),
+      typedEnd('end-2', [['result', VarType.object]]),
+    ]
+    const edges = [link('start', 'end-1'), link('start', 'end-2')]
+
+    expect(detailedConflictsOf(nodes, edges)).toEqual({
+      'end-1': [{ variable: 'result', kind: 'duplicateName' }],
+      'end-2': [{ variable: 'result', kind: 'duplicateName' }],
+    })
   })
 
   it('should report a variable declared twice by the same Output node', () => {

--- a/web/app/components/workflow/utils/end-output-conflicts.ts
+++ b/web/app/components/workflow/utils/end-output-conflicts.ts
@@ -1,0 +1,262 @@
+import type { Edge, Node } from '../types'
+import { BlockEnum } from '../types'
+
+/**
+ * Detects Output (End) nodes that declare the same output variable name *and* can run in the same
+ * execution. Two such nodes silently overwrite each other's value, so the editor warns about them.
+ *
+ * Output nodes sitting on mutually exclusive branches are not a conflict: a single run only ever
+ * reaches one of them, so reusing a variable name there is legitimate and must not block publishing.
+ */
+
+/** ReactFlow omits `sourceHandle` on nodes with a single output; the graph treats that as 'source'. */
+const DEFAULT_SOURCE_HANDLE = 'source'
+
+/** Pseudo branch standing for "which entry node started this run". */
+const ENTRY_BRANCH_ID = '__entry__'
+
+/**
+ * Upper bound on the branch combinations tracked per node. A graph busy enough to exceed it falls back
+ * to "may run together", which keeps the warning rather than dropping a real conflict.
+ */
+const MAX_PATH_CONDITIONS = 64
+
+const ENTRY_NODE_TYPES: BlockEnum[] = [
+  BlockEnum.Start,
+  BlockEnum.TriggerSchedule,
+  BlockEnum.TriggerWebhook,
+  BlockEnum.TriggerPlugin,
+]
+
+type EndOutput = { variable?: string }
+
+/** Branch decisions that must hold for a node to run: branch node id -> handle taken. */
+type PathCondition = Map<string, string>
+
+type NodeReachability = {
+  /** Path conditions this node can be reached under, keyed by a canonical form for de-duplication. */
+  conditions: Map<string, PathCondition>
+  /** True when the node has more path conditions than are tracked, so nothing can be proven about it. */
+  overflow: boolean
+}
+
+type ScopeGraph = {
+  entryIds: string[]
+  outgoing: Map<string, { handle: string; target: string }[]>
+  /** Nodes whose outgoing edges use more than one handle, so only one of them is taken per run. */
+  branchIds: Set<string>
+}
+
+const getScopeId = (node: Node) => node.parentId ?? ''
+
+const buildScopeGraph = (nodes: Node[], edges: Edge[]): ScopeGraph => {
+  const nodeIds = nodes.map((node) => node.id)
+  const inScope = new Set(nodeIds)
+  const outgoing = new Map<string, { handle: string; target: string }[]>()
+  const incomingCount = new Map<string, number>()
+
+  nodeIds.forEach((id) => {
+    outgoing.set(id, [])
+    incomingCount.set(id, 0)
+  })
+
+  edges.forEach((edge) => {
+    // Temporary edges are injected while highlighting variable dependencies and are not real paths.
+    if (edge.data?._isTemp) return
+    if (!inScope.has(edge.source) || !inScope.has(edge.target)) return
+
+    outgoing.get(edge.source)!.push({
+      handle: edge.sourceHandle || DEFAULT_SOURCE_HANDLE,
+      target: edge.target,
+    })
+    incomingCount.set(edge.target, incomingCount.get(edge.target)! + 1)
+  })
+
+  const branchIds = new Set(
+    nodeIds.filter((id) => new Set(outgoing.get(id)!.map((edge) => edge.handle)).size > 1),
+  )
+
+  // Nested scopes (Iteration / Loop children) and pipelines have no Start node, so fall back to the
+  // roots of the scope. An Output node is never an entry point, even when nothing is wired into it.
+  const typedEntryIds = nodes
+    .filter((node) => ENTRY_NODE_TYPES.includes(node.data.type))
+    .map((node) => node.id)
+  const entryIds = typedEntryIds.length
+    ? typedEntryIds
+    : nodes
+        .filter((node) => node.data.type !== BlockEnum.End && incomingCount.get(node.id) === 0)
+        .map((node) => node.id)
+
+  return { entryIds, outgoing, branchIds }
+}
+
+const getConditionKey = (condition: PathCondition) =>
+  [...condition]
+    .map(([branchId, handle]) => `${branchId}=${handle}`)
+    .sort()
+    .join('&')
+
+/**
+ * Collects, for every node, the branch decisions that lead to it. Conditions accumulate along edges
+ * and are de-duplicated, so the fixpoint iteration terminates even on cyclic graphs (Loop nodes).
+ */
+const getReachability = (graph: ScopeGraph) => {
+  const reachability = new Map<string, NodeReachability>()
+
+  const ensure = (id: string) => {
+    let node = reachability.get(id)
+    if (!node) {
+      node = { conditions: new Map<string, PathCondition>(), overflow: false }
+      reachability.set(id, node)
+    }
+    return node
+  }
+
+  const queue: string[] = []
+  graph.entryIds.forEach((id) => {
+    const condition: PathCondition = new Map([[ENTRY_BRANCH_ID, id]])
+    ensure(id).conditions.set(getConditionKey(condition), condition)
+    queue.push(id)
+  })
+
+  while (queue.length) {
+    const currentId = queue.shift()!
+    const current = ensure(currentId)
+    const isBranch = graph.branchIds.has(currentId)
+    const conditions = [...current.conditions.values()]
+
+    graph.outgoing.get(currentId)!.forEach(({ handle, target }) => {
+      const next = ensure(target)
+      let changed = false
+
+      if (current.overflow && !next.overflow) {
+        next.overflow = true
+        changed = true
+      }
+
+      conditions.forEach((condition) => {
+        const extended = new Map(condition)
+        if (isBranch) {
+          const taken = extended.get(currentId)
+          if (taken === undefined) extended.set(currentId, handle)
+          // A cycle can route back through the same branch on another handle, which means the branch
+          // may take both over one run and therefore constrains nothing.
+          else if (taken !== handle) extended.delete(currentId)
+        }
+
+        const key = getConditionKey(extended)
+        if (next.conditions.has(key)) return
+
+        if (next.conditions.size >= MAX_PATH_CONDITIONS) {
+          if (!next.overflow) {
+            next.overflow = true
+            changed = true
+          }
+          return
+        }
+
+        next.conditions.set(key, extended)
+        changed = true
+      })
+
+      if (changed) queue.push(target)
+    })
+  }
+
+  return reachability
+}
+
+/** Two conditions are compatible when they never require different handles of the same branch. */
+const areConditionsCompatible = (a: PathCondition, b: PathCondition) => {
+  const [smaller, larger] = a.size <= b.size ? [a, b] : [b, a]
+
+  for (const [branchId, handle] of smaller) {
+    const other = larger.get(branchId)
+    if (other !== undefined && other !== handle) return false
+  }
+
+  return true
+}
+
+/**
+ * True unless every way of reaching one node contradicts every way of reaching the other. Unreachable
+ * or untracked nodes also return true: without a proof of exclusivity we keep the warning.
+ */
+const canRunTogether = (reachability: Map<string, NodeReachability>, aId: string, bId: string) => {
+  const a = reachability.get(aId)
+  const b = reachability.get(bId)
+
+  if (!a || !b || a.overflow || b.overflow) return true
+  if (!a.conditions.size || !b.conditions.size) return true
+
+  for (const conditionA of a.conditions.values()) {
+    for (const conditionB of b.conditions.values()) {
+      if (areConditionsCompatible(conditionA, conditionB)) return true
+    }
+  }
+
+  return false
+}
+
+/**
+ * Returns the conflicting output variable names per Output node id. A name conflicts when the same
+ * Output node declares it twice, or when another Output node that may run in the same execution
+ * declares it too.
+ */
+export const getDuplicateEndOutputVariables = (nodes: Node[], edges: Edge[]) => {
+  const conflicts = new Map<string, string[]>()
+  const endNodes = nodes.filter((node) => node.data.type === BlockEnum.End)
+  if (endNodes.length === 0) return conflicts
+
+  const scopeIds = new Set(endNodes.map(getScopeId))
+
+  scopeIds.forEach((scopeId) => {
+    // variable name -> Output node id -> how many times that node declares it
+    const occurrences = new Map<string, Map<string, number>>()
+
+    endNodes
+      .filter((node) => getScopeId(node) === scopeId)
+      .forEach((node) => {
+        const outputs = (node.data as { outputs?: EndOutput[] }).outputs || []
+        outputs.forEach((output) => {
+          const variable = output.variable?.trim()
+          if (!variable) return
+
+          const byNode = occurrences.get(variable) ?? new Map<string, number>()
+          byNode.set(node.id, (byNode.get(node.id) ?? 0) + 1)
+          occurrences.set(variable, byNode)
+        })
+      })
+
+    const hasRepeatedName = [...occurrences.values()].some(
+      (byNode) => byNode.size > 1 || [...byNode.values()].some((count) => count > 1),
+    )
+    // Keep the common case free of graph analysis: no repeated name means nothing to reconcile.
+    if (!hasRepeatedName) return
+
+    const reachability = getReachability(
+      buildScopeGraph(
+        nodes.filter((node) => getScopeId(node) === scopeId),
+        edges,
+      ),
+    )
+
+    occurrences.forEach((byNode, variable) => {
+      const nodeIds = [...byNode.keys()]
+
+      nodeIds.forEach((nodeId) => {
+        const declaredTwice = (byNode.get(nodeId) ?? 0) > 1
+        const collidesWithSibling = nodeIds.some(
+          (otherId) => otherId !== nodeId && canRunTogether(reachability, nodeId, otherId),
+        )
+        if (!declaredTwice && !collidesWithSibling) return
+
+        const variables = conflicts.get(nodeId) ?? []
+        if (!variables.includes(variable)) variables.push(variable)
+        conflicts.set(nodeId, variables)
+      })
+    })
+  })
+
+  return conflicts
+}

--- a/web/app/components/workflow/utils/end-output-conflicts.ts
+++ b/web/app/components/workflow/utils/end-output-conflicts.ts
@@ -1,12 +1,21 @@
 import type { Edge, Node } from '../types'
-import { BlockEnum } from '../types'
+import { BlockEnum, VarType } from '../types'
 
 /**
- * Detects Output (End) nodes that declare the same output variable name *and* can run in the same
- * execution. Two such nodes silently overwrite each other's value, so the editor warns about them.
+ * Detects Output (End) node output variables that clash.
  *
- * Output nodes sitting on mutually exclusive branches are not a conflict: a single run only ever
- * reaches one of them, so reusing a variable name there is legitimate and must not block publishing.
+ * Two kinds of clash exist, because the workflow-level output is keyed by variable name only:
+ *
+ * - `duplicateName` — two Output nodes that can run in the same execution declare the same name, so
+ *   one value silently overwrites the other.
+ * - `conflictingTypes` — Output nodes on mutually exclusive branches reuse a name but declare
+ *   different types. Only one of them ever runs, so no value is lost, but the published output schema
+ *   keeps a single definition per name
+ *   (`WorkflowToolConfigurationUtils.get_workflow_graph_output` lets the later Output node win), so a
+ *   branch could return a value that does not match the schema consumers were given.
+ *
+ * Reusing a name across mutually exclusive branches with a matching type is legitimate and must not
+ * block publishing.
  */
 
 /** ReactFlow omits `sourceHandle` on nodes with a single output; the graph treats that as 'source'. */
@@ -28,7 +37,14 @@ const ENTRY_NODE_TYPES: BlockEnum[] = [
   BlockEnum.TriggerPlugin,
 ]
 
-type EndOutput = { variable?: string }
+type EndOutput = { variable?: string; value_type?: VarType }
+
+export type EndOutputConflict = {
+  variable: string
+  kind: 'duplicateName' | 'conflictingTypes'
+  /** The clashing declared types, only set for `conflictingTypes`. */
+  types?: VarType[]
+}
 
 /** Branch decisions that must hold for a node to run: branch node id -> handle taken. */
 type PathCondition = Map<string, string>
@@ -46,6 +62,8 @@ type ScopeGraph = {
   /** Nodes whose outgoing edges use more than one handle, so only one of them is taken per run. */
   branchIds: Set<string>
 }
+
+type OutputOccurrence = { nodeId: string; valueType?: VarType }
 
 const getScopeId = (node: Node) => node.parentId ?? ''
 
@@ -199,20 +217,27 @@ const canRunTogether = (reachability: Map<string, NodeReachability>, aId: string
 }
 
 /**
- * Returns the conflicting output variable names per Output node id. A name conflicts when the same
- * Output node declares it twice, or when another Output node that may run in the same execution
- * declares it too.
+ * Mirrors `filterVar` / `filterVarByType`: `any` matches everything. A missing type — a graph saved
+ * before the editor recorded it, or a reference it could not resolve — cannot prove a clash either.
  */
-export const getDuplicateEndOutputVariables = (nodes: Node[], edges: Edge[]) => {
-  const conflicts = new Map<string, string[]>()
+const areOutputTypesCompatible = (a?: VarType, b?: VarType) => {
+  if (!a || !b) return true
+  if (a === VarType.any || b === VarType.any) return true
+  return a === b
+}
+
+/**
+ * Returns the clashing output variables per Output node id. See `EndOutputConflict` for the two kinds.
+ */
+export const getEndOutputConflicts = (nodes: Node[], edges: Edge[]) => {
+  const conflicts = new Map<string, EndOutputConflict[]>()
   const endNodes = nodes.filter((node) => node.data.type === BlockEnum.End)
   if (endNodes.length === 0) return conflicts
 
   const scopeIds = new Set(endNodes.map(getScopeId))
 
   scopeIds.forEach((scopeId) => {
-    // variable name -> Output node id -> how many times that node declares it
-    const occurrences = new Map<string, Map<string, number>>()
+    const occurrences = new Map<string, OutputOccurrence[]>()
 
     endNodes
       .filter((node) => getScopeId(node) === scopeId)
@@ -222,17 +247,15 @@ export const getDuplicateEndOutputVariables = (nodes: Node[], edges: Edge[]) => 
           const variable = output.variable?.trim()
           if (!variable) return
 
-          const byNode = occurrences.get(variable) ?? new Map<string, number>()
-          byNode.set(node.id, (byNode.get(node.id) ?? 0) + 1)
-          occurrences.set(variable, byNode)
+          const entries = occurrences.get(variable) ?? []
+          entries.push({ nodeId: node.id, valueType: output.value_type })
+          occurrences.set(variable, entries)
         })
       })
 
-    const hasRepeatedName = [...occurrences.values()].some(
-      (byNode) => byNode.size > 1 || [...byNode.values()].some((count) => count > 1),
-    )
+    const repeated = [...occurrences.values()].some((entries) => entries.length > 1)
     // Keep the common case free of graph analysis: no repeated name means nothing to reconcile.
-    if (!hasRepeatedName) return
+    if (!repeated) return
 
     const reachability = getReachability(
       buildScopeGraph(
@@ -241,19 +264,43 @@ export const getDuplicateEndOutputVariables = (nodes: Node[], edges: Edge[]) => 
       ),
     )
 
-    occurrences.forEach((byNode, variable) => {
-      const nodeIds = [...byNode.keys()]
+    occurrences.forEach((entries, variable) => {
+      const nodeIds = [...new Set(entries.map((entry) => entry.nodeId))]
 
       nodeIds.forEach((nodeId) => {
-        const declaredTwice = (byNode.get(nodeId) ?? 0) > 1
-        const collidesWithSibling = nodeIds.some(
-          (otherId) => otherId !== nodeId && canRunTogether(reachability, nodeId, otherId),
-        )
-        if (!declaredTwice && !collidesWithSibling) return
+        const own = entries.filter((entry) => entry.nodeId === nodeId)
+        // The same Output node declaring a name twice always collides with itself.
+        let duplicateName = own.length > 1
+        const clashingTypes = new Set<VarType>()
 
-        const variables = conflicts.get(nodeId) ?? []
-        if (!variables.includes(variable)) variables.push(variable)
-        conflicts.set(nodeId, variables)
+        nodeIds.forEach((otherId) => {
+          if (otherId === nodeId) return
+
+          if (canRunTogether(reachability, nodeId, otherId)) {
+            duplicateName = true
+            return
+          }
+
+          entries
+            .filter((entry) => entry.nodeId === otherId)
+            .forEach((other) => {
+              own.forEach((mine) => {
+                if (areOutputTypesCompatible(mine.valueType, other.valueType)) return
+                clashingTypes.add(mine.valueType!)
+                clashingTypes.add(other.valueType!)
+              })
+            })
+        })
+
+        // A lost value is the more serious problem, so it wins when both apply.
+        const conflict: EndOutputConflict | undefined = duplicateName
+          ? { variable, kind: 'duplicateName' }
+          : clashingTypes.size
+            ? { variable, kind: 'conflictingTypes', types: [...clashingTypes].sort() }
+            : undefined
+        if (!conflict) return
+
+        conflicts.set(nodeId, [...(conflicts.get(nodeId) ?? []), conflict])
       })
     })
   })

--- a/web/i18n/en-US/workflow.json
+++ b/web/i18n/en-US/workflow.json
@@ -362,6 +362,7 @@
   "error.startNodeRequired": "Please add a start node first before {{operation}}",
   "errorMsg.authRequired": "Authorization is required",
   "errorMsg.configureModel": "Configure a model",
+  "errorMsg.conflictingOutputVariableTypes": "Output node variable \"{{variable}}\" is declared as {{types}} on branches that never run together. Output nodes reusing a variable name must declare the same type, because the published output keeps one definition per name.",
   "errorMsg.duplicateOutputVariable": "Duplicate Output node variable \"{{variable}}\". Output node variable names must be unique.",
   "errorMsg.fieldRequired": "{{field}} is required",
   "errorMsg.fields.code": "Code",

--- a/web/i18n/zh-Hans/workflow.json
+++ b/web/i18n/zh-Hans/workflow.json
@@ -362,6 +362,7 @@
   "error.startNodeRequired": "请先添加开始节点，然后再{{operation}}",
   "errorMsg.authRequired": "请先授权",
   "errorMsg.configureModel": "请配置模型",
+  "errorMsg.conflictingOutputVariableTypes": "输出节点变量“{{variable}}”在互斥分支上被声明为 {{types}}。复用同一变量名的输出节点必须声明相同类型，因为发布后的输出对每个名称只保留一份定义。",
   "errorMsg.duplicateOutputVariable": "输出节点变量“{{variable}}”重复。输出节点变量名必须唯一。",
   "errorMsg.fieldRequired": "{{field}} 不能为空",
   "errorMsg.fields.code": "代码",


### PR DESCRIPTION
## Summary

Output (End) nodes on mutually exclusive branches may reuse the same output variable name.

Since v1.15.0 (#35511) the editor rejects **any** two Output nodes that share an output variable name.
The check exists for a good reason — per #35510 item 3, two Output nodes that both emit the same name
silently overwrite each other — but it ignores graph topology. A workflow whose `true` and `false`
branches each end in their own Output node therefore cannot be published, even though only one of those
Output nodes can ever run.

This makes the check branch-aware instead of removing it: a duplicate is reported only when the two
Output nodes can actually run in the same execution.

Worth noting that the backend already treats same-named outputs as one variable —
`WorkflowToolConfigurationUtils.get_workflow_graph_output` collapses them, with *"Later end nodes
override duplicated variable definitions."* For mutually exclusive branches that is exactly the schema a
user wants: a single `result` regardless of which branch ran. Nothing server-side rejects the duplicate,
so the editor was the only thing blocking it.

Fixes #38440

Credit to @EvanYao826, who diagnosed this in #38488 and correctly identified
`getDuplicateEndOutputMessages` as the cause. That PR removes the check outright, which also drops the
protection for Output nodes on parallel branches (#35510 item 3) and for a variable declared twice
inside one Output node; this takes the narrower route instead.

## How it works

Exclusive branching is already visible in the graph: edges leaving one node through **distinct
`sourceHandle`s** are alternatives, whereas several edges leaving the **same** handle are a parallel
fan-out where every target runs. That covers every branching node in the editor without a node-type
allow-list — If/Else (`true` / case ids / `false`), Question Classifier (class ids), error handling
(`source` vs `fail-branch`) and Human Input (action ids vs `__timeout`).

`getDuplicateEndOutputVariables` walks the graph from its entry nodes and records, for each node, the
sets of branch decisions that lead to it (`branch node -> handle taken`). Two Output nodes are mutually
exclusive when every way of reaching one contradicts every way of reaching the other. Tracking whole
decision sets rather than one branch at a time matters, because failure branches often merge into a
single shared error Output node — checking branches independently reports a false positive there.

Details:

- Sets are de-duplicated and the walk runs to a fixpoint, so cyclic graphs terminate. A node exceeding
  the tracked combination limit falls back to "may run together", keeping the warning rather than
  dropping a real conflict.
- The choice of entry node is modelled as one more branch, so Output nodes belonging to different
  triggers do not collide.
- Temporary edges (`data._isTemp`, injected by `handleNodeSelect` while highlighting a node's variable
  dependencies) are skipped. They use a `source_tmp` handle and would otherwise invent paths that bypass
  real branches, making the warning appear and disappear as nodes are selected.
- When no variable name is repeated at all, no graph analysis runs, so the common case stays cheap
  inside the existing `useMemo`.

Preserved behaviour: Output nodes on parallel branches sharing a name are still reported, a single Output
node declaring the same name twice is still reported, and blank names are still ignored.

## Screenshots

No visual change — this is validation logic, so the only observable difference is that a workflow which
previously refused to publish now publishes. The failing state is captured in #38440. Repro and
verification steps below instead.

## How to verify

1. Create a workflow: `Start → If/Else`, with the `true` branch going to one Output node and the `false`
   branch to another.
2. Give both Output nodes an output variable with the **same** name, e.g. `result`.
3. Before: publishing fails with *Duplicate Output node variable "result"...*, and the workflow cannot be
   test-run either, since `useWorkflowRunValidation` gates on the same checklist.
4. After: publishing and running both succeed.
5. Still reported, as before: pointing `Start` at two Output nodes directly (a parallel fan-out, where
   both run) with the same variable name, and a single Output node declaring the same name twice.

## Changes

- **`web/app/components/workflow/utils/end-output-conflicts.ts`** (new): pure
  `getDuplicateEndOutputVariables(nodes, edges)` returning the conflicting variable names per Output
  node id.
- **`web/app/components/workflow/hooks/use-checklist.ts`**: `getDuplicateEndOutputMessages` delegates to
  that helper and only maps results to i18n messages; both call sites pass `edges`.
- **`web/app/components/workflow/utils/__tests__/end-output-conflicts.spec.ts`** (new): 20 unit tests —
  if/else, success vs `fail-branch`, Human Input timeout, several classifier classes merging into one
  Output node, a shared fallback Output node behind nested branches, if/else chains, branch bypass,
  multiple entry nodes, `parentId` scopes, cyclic graphs, temporary edges, disconnected Output nodes,
  blank names, partial name overlap.
- **`web/app/components/workflow/hooks/__tests__/use-checklist.spec.ts`**: added a checklist-level test
  for the #38440 topology. The existing `should detect duplicate output variables across end nodes` test
  is **unchanged** and still passes, since its graph is a parallel fan-out.

One thing left for maintainers to decide: `errorMsg.duplicateOutputVariable` still reads *"Output node
variable names must be unique."* That is accurate whenever the warning now fires, but it slightly
overstates the rule. I left the copy alone rather than machine-translate a reworded string into 22
locales — happy to update it if you tell me the wording you want.

## Checklist

- [x] This change requires a documentation update: no
- [x] I understand that this PR may be closed in case there was no previous discussion or issues.
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a
      single atomic change.
- [ ] I've updated the documentation accordingly. (not applicable)
- [x] Frontend-only change. `pnpm exec vp staged` is clean; note it has to run from the repo root, since
      the `staged` config lives in the root `vite.config.ts` rather than `web/`. Also ran
      `vp test app/components/workflow` (600 files / 3145 tests, all passing).

From Claude Code
