### PR TITLE
fix(api): use plain Session in MCP controller to avoid closed transac…

### DIFF
--- a/api/controllers/mcp/mcp.py
+++ b/api/controllers/mcp/mcp.py
@@ -83,21 +83,17 @@ class MCPAppApi(Resource):
                 return self._protocol_version_error_response(request_id, header_value)
 
         with Session(db.engine, expire_on_commit=False) as session:
-            try:
-                # Get MCP server and app
-                mcp_server, app = self._get_mcp_server_and_app(server_code, session)
-                self._validate_server_status(mcp_server)
-                # Get user input form
-                user_input_form = self._get_user_input_form(app)
-                # Handle notification vs request differently
-                response = self._process_mcp_message(
-                    mcp_request, request_id, app, mcp_server, user_input_form, session, protocol_version
-                )
-                session.commit()
-                return response
-            except Exception:
-                session.rollback()
-                raise
+            # Get MCP server and app
+            mcp_server, app = self._get_mcp_server_and_app(server_code, session)
+            self._validate_server_status(mcp_server)
+            # Get user input form
+            user_input_form = self._get_user_input_form(app)
+            # Handle notification vs request differently
+            response = self._process_mcp_message(
+                mcp_request, request_id, app, mcp_server, user_input_form, session, protocol_version
+            )
+            session.commit()
+            return response
 
     def _protocol_version_error_response(
         self, request_id: Union[int, str] | None, header_value: str | None

--- a/api/controllers/mcp/mcp.py
+++ b/api/controllers/mcp/mcp.py
@@ -4,7 +4,7 @@ from flask import Response, request
 from flask_restx import Resource
 from pydantic import BaseModel, Field, RootModel, ValidationError
 from sqlalchemy import select
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import Session
 
 from controllers.common.schema import register_response_schema_models, register_schema_model
 from controllers.mcp import mcp_ns
@@ -82,18 +82,22 @@ class MCPAppApi(Resource):
             else:
                 return self._protocol_version_error_response(request_id, header_value)
 
-        with sessionmaker(db.engine, expire_on_commit=False).begin() as session:
-            # Get MCP server and app
-            mcp_server, app = self._get_mcp_server_and_app(server_code, session)
-            self._validate_server_status(mcp_server)
-
-            # Get user input form
-            user_input_form = self._get_user_input_form(app)
-
-            # Handle notification vs request differently
-            return self._process_mcp_message(
-                mcp_request, request_id, app, mcp_server, user_input_form, session, protocol_version
-            )
+        with Session(db.engine, expire_on_commit=False) as session:
+            try:
+                # Get MCP server and app
+                mcp_server, app = self._get_mcp_server_and_app(server_code, session)
+                self._validate_server_status(mcp_server)
+                # Get user input form
+                user_input_form = self._get_user_input_form(app)
+                # Handle notification vs request differently
+                response = self._process_mcp_message(
+                    mcp_request, request_id, app, mcp_server, user_input_form, session, protocol_version
+                )
+                session.commit()
+                return response
+            except Exception:
+                session.rollback()
+                raise
 
     def _protocol_version_error_response(
         self, request_id: Union[int, str] | None, header_value: str | None
@@ -235,16 +239,15 @@ class MCPAppApi(Resource):
             except ValidationError as e:
                 raise MCPRequestError(mcp_types.INVALID_PARAMS, f"Invalid MCP request: {str(e)}")
 
-    def _retrieve_end_user(self, tenant_id: str, mcp_server_id: str) -> EndUser | None:
+    def _retrieve_end_user(self, tenant_id: str, mcp_server_id: str, session: Session) -> EndUser | None:
         """Get end user - manages its own database session"""
-        with sessionmaker(db.engine, expire_on_commit=False).begin() as session:
-            return session.scalar(
-                select(EndUser)
-                .where(
-                    EndUser.tenant_id == tenant_id, EndUser.session_id == mcp_server_id, EndUser.type == EndUserType.MCP
-                )
-                .limit(1)
-            )
+        return session.scalar(
+            select(EndUser)
+            .where(EndUser.tenant_id == tenant_id)
+            .where(EndUser.session_id == mcp_server_id)
+            .where(EndUser.type == EndUserType.MCP)
+            .limit(1)
+        )
 
     def _create_end_user(
         self, client_name: str, tenant_id: str, app_id: str, mcp_server_id: str, session: Session
@@ -273,7 +276,7 @@ class MCPAppApi(Resource):
         protocol_version: str,
     ) -> mcp_types.JSONRPCResponse | mcp_types.JSONRPCError | None:
         """Handle MCP request and return response"""
-        end_user = self._retrieve_end_user(mcp_server.tenant_id, mcp_server.id)
+        end_user = self._retrieve_end_user(mcp_server.tenant_id, mcp_server.id, session)
 
         if not end_user and isinstance(mcp_request.root, mcp_types.InitializeRequest):
             client_info = mcp_request.root.params.clientInfo


### PR DESCRIPTION
…tion

MCP tools/call wraps AppGenerateService in sessionmaker().begin(), but generation paths commit internally, causing InvalidRequestError.

## Summary

- Fix MCP `tools/call` failing with `Can't operate on closed transaction inside context manager` on 1.16.x
- Replace `sessionmaker(...).begin()` with plain `Session` + explicit commit/rollback in `api/controllers/mcp/mcp.py`
- Reuse caller session in `_retrieve_end_user` to avoid nested transactions
fixes #39787 

## Root cause
Outer `sessionmaker().begin()` conflicts with internal `session.commit()` in Advanced Chat / Workflow generation (same class of bug as #39191  / #36392 ).

## Test plan
- [ ] Publish Advanced Chat / Workflow as MCP server
- [ ] `initialize` / `tools/list` succeed
- [ ] `tools/call` succeeds (no -32603 / InvalidRequestError)
- [ ] Verified on self-hosted 1.16.1 before this PR
