### PR TITLE
refactor(web): remove dead dataset operator context state

### DIFF
--- a/web/__mocks__/provider-context.ts
+++ b/web/__mocks__/provider-context.ts
@@ -18,7 +18,6 @@ export const baseProviderContextValue: ProviderContextState = {
   onPlanInfoChanged: noop,
   enableReplaceWebAppLogo: false,
   modelLoadBalancingEnabled: false,
-  datasetOperatorEnabled: false,
   enableEducationPlan: false,
   isEducationWorkspace: false,
   isEducationAccount: false,

--- a/web/app/components/app/overview/apikey-info-panel/__tests__/test-utils.tsx
+++ b/web/app/components/app/overview/apikey-info-panel/__tests__/test-utils.tsx
@@ -50,7 +50,6 @@ const defaultProviderContext = {
   onPlanInfoChanged: noop,
   enableReplaceWebAppLogo: false,
   modelLoadBalancingEnabled: false,
-  datasetOperatorEnabled: false,
   enableEducationPlan: false,
   isEducationWorkspace: false,
   isEducationAccount: false,

--- a/web/context/provider-context-provider.tsx
+++ b/web/context/provider-context-provider.tsx
@@ -72,7 +72,6 @@ export const ProviderContextProvider = ({ children }: ProviderContextProviderPro
   const [enableBilling, setEnableBilling] = useState(true)
   const [enableReplaceWebAppLogo, setEnableReplaceWebAppLogo] = useState(false)
   const [modelLoadBalancingEnabled, setModelLoadBalancingEnabled] = useState(false)
-  const [datasetOperatorEnabled, setDatasetOperatorEnabled] = useState(false)
   const [webappCopyrightEnabled, setWebappCopyrightEnabled] = useState(false)
   const [licenseLimit, setLicenseLimit] = useState({
     workspace_members: {
@@ -120,7 +119,6 @@ export const ProviderContextProvider = ({ children }: ProviderContextProviderPro
       }
 
       if (data.model_load_balancing_enabled) setModelLoadBalancingEnabled(true)
-      if (data.dataset_operator_enabled) setDatasetOperatorEnabled(true)
       if (data.webapp_copyright_enabled) setWebappCopyrightEnabled(true)
       setLicenseLimit({ workspace_members: resolveMemberInviteLimit(data) })
       if (data.is_allow_transfer_workspace)
@@ -207,7 +205,6 @@ export const ProviderContextProvider = ({ children }: ProviderContextProviderPro
         onPlanInfoChanged: fetchPlan,
         enableReplaceWebAppLogo,
         modelLoadBalancingEnabled,
-        datasetOperatorEnabled,
         enableEducationPlan,
         isEducationWorkspace,
         isEducationAccount: isEducationDataFetchedAfterMount

--- a/web/context/provider-context.ts
+++ b/web/context/provider-context.ts
@@ -27,7 +27,6 @@ export type ProviderContextState = {
   onPlanInfoChanged: () => void
   enableReplaceWebAppLogo: boolean
   modelLoadBalancingEnabled: boolean
-  datasetOperatorEnabled: boolean
   enableEducationPlan: boolean
   isEducationWorkspace: boolean
   isEducationAccount: boolean
@@ -61,7 +60,6 @@ export const baseProviderContextValue: ProviderContextState = {
   onPlanInfoChanged: noop,
   enableReplaceWebAppLogo: false,
   modelLoadBalancingEnabled: false,
-  datasetOperatorEnabled: false,
   enableEducationPlan: false,
   isEducationWorkspace: false,
   isEducationAccount: false,


### PR DESCRIPTION
## Summary
- remove the unused `datasetOperatorEnabled` field from `ProviderContextState` and its default value
- stop copying `dataset_operator_enabled` into local provider state that has no consumers
- remove the obsolete field from provider context test fixtures without changing the API contract

## Tests
- `vp check web/context/provider-context.ts web/context/provider-context-provider.tsx web/__mocks__/provider-context.ts web/app/components/app/overview/apikey-info-panel/__tests__/test-utils.tsx` (0 errors; 2 existing warnings)
- `vp test run app/components/app/overview/apikey-info-panel/__tests__` (2 files, 8 tests passed)
- `git diff --check`