### PR TITLE
refactor(web): remove stale header maximize state

### DIFF
--- a/web/app/components/header/header-wrapper.tsx
+++ b/web/app/components/header/header-wrapper.tsx
@@ -1,12 +1,8 @@
 'use client'
-import type { EventEmitterValue } from '@/context/event-emitter'
 import { cn } from '@langgenius/dify-ui/cn'
 import * as React from 'react'
-import { useState } from 'react'
-import { useEventEmitterContextContext } from '@/context/event-emitter'
 import { usePathname } from '@/next/navigation'
 import s from './index.module.css'
-import { useWorkflowCanvasMaximizeValue } from './storage'
 
 type HeaderWrapperProps = {
   children: React.ReactNode
@@ -15,21 +11,6 @@ type HeaderWrapperProps = {
 const HeaderWrapper = ({ children }: HeaderWrapperProps) => {
   const pathname = usePathname()
   const isBordered = ['/apps', '/snippets', '/datasets/create', '/tools'].includes(pathname)
-  const inWorkflowCanvas = pathname.endsWith('/workflow')
-  const isPipelineCanvas = pathname.endsWith('/pipeline')
-  const storedHideHeader = useWorkflowCanvasMaximizeValue()
-  const [eventHideHeader, setEventHideHeader] = useState<boolean | null>(null)
-  const hideHeader = eventHideHeader ?? storedHideHeader
-  const { eventEmitter } = useEventEmitterContextContext()
-
-  eventEmitter?.useSubscription((value: EventEmitterValue) => {
-    if (
-      typeof value === 'object' &&
-      value.type === 'workflow-canvas-maximize' &&
-      typeof value.payload === 'boolean'
-    )
-      setEventHideHeader(value.payload)
-  })
 
   return (
     <div
@@ -37,7 +18,6 @@ const HeaderWrapper = ({ children }: HeaderWrapperProps) => {
         'sticky top-0 right-0 left-0 z-30 flex min-h-14 shrink-0 grow-0 basis-auto flex-col',
         s.header,
         isBordered ? 'border-b border-divider-regular' : '',
-        hideHeader && (inWorkflowCanvas || isPipelineCanvas) && 'hidden',
       )}
     >
       {children}

--- a/web/app/components/header/storage.ts
+++ b/web/app/components/header/storage.ts
@@ -3,7 +3,4 @@ import { createLocalStorageState } from 'foxact/create-local-storage-state'
 const [useHideMaintenanceNotice, _useHideMaintenanceNoticeValue, _useSetHideMaintenanceNotice] =
   createLocalStorageState<string>('hide-maintenance-notice', '0', { raw: true })
 
-const [_useWorkflowCanvasMaximize, useWorkflowCanvasMaximizeValue, _useSetWorkflowCanvasMaximize] =
-  createLocalStorageState<boolean>('workflow-canvas-maximize', false)
-
-export { useHideMaintenanceNotice, useWorkflowCanvasMaximizeValue }
+export { useHideMaintenanceNotice }


### PR DESCRIPTION
## Summary

- remove the orphaned workflow canvas maximize subscription from HeaderWrapper
- delete the unwritten maximize localStorage state and route-specific hide branch
- keep maintenance notice persistence unchanged

## Tests

- vp test run app/components/header/__tests__/maintenance-notice.spec.tsx
- vp check web/app/components/header/header-wrapper.tsx web/app/components/header/storage.ts