### PR TITLE
fix(ui): align select trigger focus ring

### DIFF
--- a/packages/dify-ui/src/select/index.tsx
+++ b/packages/dify-ui/src/select/index.tsx
@@ -35,7 +35,7 @@ const selectTriggerVariants = cva(
   [
     'group flex w-full items-center border-0 bg-components-input-bg-normal text-start text-components-input-text-filled outline-hidden',
     'hover:bg-state-base-hover-alt focus-visible:bg-state-base-hover-alt data-popup-open:bg-state-base-hover-alt',
-    'focus-visible:inset-ring-1 focus-visible:inset-ring-components-input-border-active',
+    'focus-visible:ring-2 focus-visible:ring-state-accent-solid',
     'data-placeholder:text-components-input-text-placeholder',
     'data-readonly:cursor-default data-readonly:bg-components-input-bg-normal data-readonly:hover:bg-components-input-bg-normal',
     'data-disabled:cursor-not-allowed data-disabled:bg-components-input-bg-disabled data-disabled:text-components-input-text-filled-disabled data-disabled:hover:bg-components-input-bg-disabled',

--- a/web/app/components/base/chip/index.tsx
+++ b/web/app/components/base/chip/index.tsx
@@ -66,7 +66,7 @@ function Chip<T extends ItemValue>({
         <SelectTrigger
           aria-label={triggerContent || t(($) => $['placeholder.select'], { ns: 'common' })}
           className={cn(
-            'h-auto min-h-8 w-fit max-w-full cursor-pointer items-center rounded-lg border-[0.5px] border-transparent bg-components-input-bg-normal px-2 py-1 hover:bg-state-base-hover-alt focus-visible:bg-state-base-hover-alt focus-visible:ring-2 focus-visible:ring-state-accent-solid data-popup-open:bg-state-base-hover-alt! data-popup-open:hover:bg-state-base-hover-alt [&>*:last-child]:hidden',
+            'h-auto min-h-8 w-fit max-w-full cursor-pointer items-center rounded-lg border-[0.5px] border-transparent bg-components-input-bg-normal px-2 py-1 hover:bg-state-base-hover-alt data-popup-open:bg-state-base-hover-alt! data-popup-open:hover:bg-state-base-hover-alt [&>*:last-child]:hidden',
             hasValue &&
               'border-components-button-secondary-border! bg-components-button-secondary-bg! pr-6 shadow-xs hover:border-components-button-secondary-border-hover hover:bg-components-button-secondary-bg-hover! data-popup-open:border-components-button-secondary-border-hover! data-popup-open:bg-components-button-secondary-bg-hover! data-popup-open:hover:border-components-button-secondary-border-hover data-popup-open:hover:bg-components-button-secondary-bg-hover!',
             className,

--- a/web/features/agent-v2/agent-detail/monitoring/page.tsx
+++ b/web/features/agent-v2/agent-detail/monitoring/page.tsx
@@ -211,7 +211,7 @@ function AgentMonitoringSourceFilter({
       <div className="relative w-fit max-w-full">
         <SelectTrigger
           aria-label={triggerLabel}
-          className="h-auto min-h-8 w-fit max-w-full min-w-53 cursor-pointer items-center rounded-lg border-[0.5px] border-components-button-secondary-border bg-components-button-secondary-bg px-2 py-1 pr-6 shadow-xs hover:border-components-button-secondary-border-hover hover:bg-components-button-secondary-bg-hover! focus-visible:bg-state-base-hover-alt focus-visible:ring-2 focus-visible:ring-state-accent-solid data-popup-open:border-components-button-secondary-border-hover! data-popup-open:bg-components-button-secondary-bg-hover! data-popup-open:hover:border-components-button-secondary-border-hover data-popup-open:hover:bg-components-button-secondary-bg-hover! [&>*:last-child]:hidden"
+          className="h-auto min-h-8 w-fit max-w-full min-w-53 cursor-pointer items-center rounded-lg border-[0.5px] border-components-button-secondary-border bg-components-button-secondary-bg px-2 py-1 pr-6 shadow-xs hover:border-components-button-secondary-border-hover hover:bg-components-button-secondary-bg-hover! data-popup-open:border-components-button-secondary-border-hover! data-popup-open:bg-components-button-secondary-bg-hover! data-popup-open:hover:border-components-button-secondary-border-hover data-popup-open:hover:bg-components-button-secondary-bg-hover! [&>*:last-child]:hidden"
         >
           <span className="flex min-w-0 grow items-center gap-1 text-left">
             <span className="flex min-w-0 grow items-center gap-1 px-1">


### PR DESCRIPTION
## What

- align the shared Dify UI `SelectTrigger` keyboard focus indicator with the blue 2px accent ring used by other interactive primitives
- remove redundant focus-visible overrides from the chip selector and Agent V2 monitoring source filter
- leave hover, open, disabled, and read-only state styling unchanged

## Why

`SelectTrigger` owned a gray 1px inset ring while two web consumers added a blue 2px outer ring. Because inset and outer ring utilities are separate CSS families, both could render together. Moving the focus-visible contract into the shared trigger makes keyboard focus consistent and prevents call sites from composing duplicate indicators.

## Impact

All `SelectTrigger` consumers now inherit the same keyboard-only focus ring. Mouse focus behavior and the existing non-focus states are unchanged.

## Checks

- `pnpm -C packages/dify-ui test --run src/select/__tests__/index.spec.tsx`
- `./node_modules/.bin/vp check packages/dify-ui/src/select/index.tsx web/app/components/base/chip/index.tsx web/features/agent-v2/agent-detail/monitoring/page.tsx`
- `TAILWIND_CANONICAL_CLASSES=true ./node_modules/.bin/vp lint packages/dify-ui/src/select/index.tsx web/app/components/base/chip/index.tsx web/features/agent-v2/agent-detail/monitoring/page.tsx`
- `pnpm check` (0 errors; existing baseline warnings only)
- `git diff --check`
