### PR TITLE
fix(account): stop sharing one additional_data dict across token calls

### DIFF
--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -895,10 +895,11 @@ class AccountService:
         email: str,
         account: Account | None = None,
         code: str | None = None,
-        additional_data: dict[str, Any] = {},
+        additional_data: dict[str, Any] | None = None,
     ):
         if not code:
             code = "".join([str(secrets.randbelow(exclusive_upper_bound=10)) for _ in range(6)])
+        additional_data = {**additional_data} if additional_data else {}
         additional_data["code"] = code
         token = TokenManager.generate_token(
             account=account, email=email, token_type="reset_password", additional_data=additional_data
@@ -910,10 +911,11 @@ class AccountService:
         cls,
         email: str,
         code: str | None = None,
-        additional_data: dict[str, Any] = {},
+        additional_data: dict[str, Any] | None = None,
     ):
         if not code:
             code = "".join([str(secrets.randbelow(exclusive_upper_bound=10)) for _ in range(6)])
+        additional_data = {**additional_data} if additional_data else {}
         additional_data["code"] = code
         token = TokenManager.generate_token(email=email, token_type="email_register", additional_data=additional_data)
         return code, token
@@ -938,10 +940,11 @@ class AccountService:
         email: str,
         account: Account | None = None,
         code: str | None = None,
-        additional_data: dict[str, Any] = {},
+        additional_data: dict[str, Any] | None = None,
     ):
         if not code:
             code = "".join([str(secrets.randbelow(exclusive_upper_bound=10)) for _ in range(6)])
+        additional_data = {**additional_data} if additional_data else {}
         additional_data["code"] = code
         token = TokenManager.generate_token(
             account=account, email=email, token_type="owner_transfer", additional_data=additional_data

--- a/api/tests/unit_tests/services/test_account_service.py
+++ b/api/tests/unit_tests/services/test_account_service.py
@@ -1,4 +1,6 @@
+import inspect
 import json
+import threading
 from collections.abc import Iterator, Sequence
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
@@ -2876,3 +2878,74 @@ class TestIsEmailSendIpLimit:
             patch.object(dify_config, "EMAIL_SEND_IP_LIMIT_PER_MINUTE", 60),
         ):
             assert AccountService.is_email_send_ip_limit("1.2.3.4") is False
+
+
+class TestTokenGenerationAdditionalData:
+    """The code-carrying token generators must not share one dict across calls."""
+
+    _GENERATORS = (
+        "generate_reset_password_token",
+        "generate_email_register_token",
+        "generate_owner_transfer_token",
+    )
+
+    @pytest.mark.parametrize("method_name", _GENERATORS)
+    def test_additional_data_default_is_not_mutable(self, method_name: str) -> None:
+        """The default must not be a dict the function then writes the code into."""
+        parameter = inspect.signature(getattr(AccountService, method_name)).parameters["additional_data"]
+        assert parameter.default is None
+
+    @pytest.mark.parametrize("method_name", _GENERATORS)
+    def test_caller_dict_is_not_mutated(self, method_name: str) -> None:
+        """A dict passed in by the caller must come back without the code in it."""
+        generate = getattr(AccountService, method_name)
+        caller_data = {"invite_id": "abc"}
+
+        with patch("services.account_service.TokenManager.generate_token", return_value="token") as mock_generate:
+            code, _ = generate("user@example.com", additional_data=caller_data)
+
+        assert caller_data == {"invite_id": "abc"}
+        assert mock_generate.call_args.kwargs["additional_data"] == {"invite_id": "abc", "code": code}
+
+    @pytest.mark.parametrize("method_name", _GENERATORS)
+    def test_concurrent_calls_keep_their_own_code(self, method_name: str) -> None:
+        """Two overlapping calls must each store the code they returned to their caller.
+
+        The generators run under gevent workers, so a second greenlet can write to a
+        shared default dict between the first one's write and TokenManager reading it.
+        """
+        generate = getattr(AccountService, method_name)
+        first_entered = threading.Event()
+        second_wrote = threading.Event()
+        stored: dict[str, str] = {}
+
+        def fake_generate_token(
+            *,
+            email: str,
+            additional_data: dict[str, str] | None = None,
+            **_: object,
+        ) -> str:
+            if email == "first@example.com":
+                first_entered.set()
+                second_wrote.wait(timeout=5)
+            else:
+                second_wrote.set()
+            assert additional_data is not None
+            stored[email] = additional_data["code"]
+            return "token"
+
+        returned: dict[str, str] = {}
+
+        def call(email: str) -> None:
+            returned[email] = generate(email)[0]
+
+        with patch("services.account_service.TokenManager.generate_token", fake_generate_token):
+            first = threading.Thread(target=call, args=("first@example.com",))
+            second = threading.Thread(target=call, args=("second@example.com",))
+            first.start()
+            first_entered.wait(timeout=5)
+            second.start()
+            first.join(timeout=5)
+            second.join(timeout=5)
+
+        assert stored == returned


### PR DESCRIPTION
Fixes #39815

Three token generators in `api/services/account_service.py` share one mutable default and then write into it:

```python
def generate_reset_password_token(..., additional_data: dict[str, Any] = {}):
    additional_data["code"] = code                      # writes into the default

def generate_email_register_token(..., additional_data: dict[str, Any] = {}):
    additional_data["code"] = code

def generate_owner_transfer_token(..., additional_data: dict[str, Any] = {}):
    additional_data["code"] = code
```

This PR changes all three to `dict[str, Any] | None = None` and copies the caller's dict:

```python
additional_data = {**additional_data} if additional_data else {}
```

## What this fixes

**Reachable today: the caller's dict is mutated.** Every call writes `code` into whatever dict was passed in. All four production call sites pass a fresh literal that is discarded immediately, so nothing observable goes wrong right now, but the function silently modifies its argument and nothing says so.

**Latent: the shared default collapses concurrent calls.** When the default is used, two overlapping calls write into the same object, and the caller can be told one code while the token is minted with another:

```
default dict before any call: {}
after alice's call:           {'code': '909393'}
after bob's call:             {'code': '844774'}
-> same dict object reused:   True

codes returned to callers:       alice -> 251573,  bob -> 787541
code the token was minted with:  alice -> 787541
```

No production caller reaches that today. Verified on `main`, the callers are:

| generator | call site | argument |
|---|---|---|
| reset_password | `controllers/console/auth/forgot_password.py` | `{"phase": "reset"}` |
| reset_password | `controllers/web/forgot_password.py` | `{"phase": "reset"}` |
| email_register | `controllers/console/auth/email_register.py` | `{"phase": "register"}` |
| owner_transfer | `controllers/console/workspace/members.py` | `{}` |

so this is a latent trap rather than a live incident, and it should be merged on that basis rather than as a security fix.

## Why the latent argument is stronger than usual here

`api/.ruff.toml` selects all of `B` (line 14) but lists `B006`, `mutable-argument-default`, in `ignore` (line 72). So this pattern has no lint backstop in this repo, and it has already been copy-pasted into three functions. The next code-carrying generator added without an explicit `additional_data` argument inherits it, and the symptom would be a user occasionally receiving a code that does not work while someone else's token carries it. That is a bad thing to learn about from a support ticket.

## Tests

`api/tests/unit_tests/services/test_account_service.py`, parametrized over all three generators:

- the default is not a mutable dict (`inspect.signature(...).default is None`)
- a caller-supplied dict comes back without `code` written into it
- two interleaved calls each keep their own code

The concurrency test uses `threading` rather than gevent. The bug only needs the two calls to interleave between reading and writing the shared dict, which threads reproduce deterministically, so modelling the production worker type is not necessary here.

