### PR TITLE
chore(api): consolidate chained .where() calls into single calls

### DIFF
--- a/api/controllers/mcp/mcp.py
+++ b/api/controllers/mcp/mcp.py
@@ -240,9 +240,9 @@ class MCPAppApi(Resource):
         with sessionmaker(db.engine, expire_on_commit=False).begin() as session:
             return session.scalar(
                 select(EndUser)
-                .where(EndUser.tenant_id == tenant_id)
-                .where(EndUser.session_id == mcp_server_id)
-                .where(EndUser.type == EndUserType.MCP)
+                .where(
+                    EndUser.tenant_id == tenant_id, EndUser.session_id == mcp_server_id, EndUser.type == EndUserType.MCP
+                )
                 .limit(1)
             )
 

--- a/api/controllers/service_api/wraps.py
+++ b/api/controllers/service_api/wraps.py
@@ -322,11 +322,12 @@ def validate_dataset_token[R](view: Callable[..., R]) -> Callable[..., R]:
                 raise Forbidden("Dataset api access is not enabled.")
 
         tenant_account_join = db.session.execute(
-            select(Tenant, TenantAccountJoin)
-            .where(Tenant.id == api_token.tenant_id)
-            .where(TenantAccountJoin.tenant_id == Tenant.id)
-            .where(TenantAccountJoin.role.in_(["owner"]))
-            .where(Tenant.status == TenantStatus.NORMAL)
+            select(Tenant, TenantAccountJoin).where(
+                Tenant.id == api_token.tenant_id,
+                TenantAccountJoin.tenant_id == Tenant.id,
+                TenantAccountJoin.role.in_(["owner"]),
+                Tenant.status == TenantStatus.NORMAL,
+            )
         ).one_or_none()  # TODO: only owner information is required, so only one is returned.
         if tenant_account_join:
             tenant, ta = tenant_account_join

--- a/api/core/app/task_pipeline/message_cycle_manager.py
+++ b/api/core/app/task_pipeline/message_cycle_manager.py
@@ -66,11 +66,7 @@ class MessageCycleManager:
         # Use SQLAlchemy 2.x style session.scalar(select(...))
         with session_factory.create_session() as session:
             message_file = session.scalar(
-                select(MessageFile)
-                .where(
-                    MessageFile.message_id == message_id,
-                )
-                .where(MessageFile.belongs_to == "assistant")
+                select(MessageFile).where(MessageFile.message_id == message_id, MessageFile.belongs_to == "assistant")
             )
 
         if message_file:

--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -2003,8 +2003,11 @@ class DatasetRetrieval:
             results = session.scalars(
                 select(Dataset)
                 .outerjoin(subquery, Dataset.id == subquery.c.dataset_id)
-                .where(Dataset.tenant_id == tenant_id, Dataset.id.in_(dataset_ids))
-                .where((subquery.c.available_document_count > 0) | (Dataset.provider == "external"))
+                .where(
+                    Dataset.tenant_id == tenant_id,
+                    Dataset.id.in_(dataset_ids),
+                    (subquery.c.available_document_count > 0) | (Dataset.provider == "external"),
+                )
             ).all()
 
         available_datasets = []

--- a/api/extensions/ext_login.py
+++ b/api/extensions/ext_login.py
@@ -72,10 +72,11 @@ def _load_user_from_request(request_from_flask_login: Request, session: Session)
             workspace_id = request.headers.get("X-WORKSPACE-ID")
             if workspace_id:
                 tenant_account_join = session.execute(
-                    select(Tenant, TenantAccountJoin)
-                    .where(Tenant.id == workspace_id)
-                    .where(TenantAccountJoin.tenant_id == Tenant.id)
-                    .where(TenantAccountJoin.role == "owner")
+                    select(Tenant, TenantAccountJoin).where(
+                        Tenant.id == workspace_id,
+                        TenantAccountJoin.tenant_id == Tenant.id,
+                        TenantAccountJoin.role == "owner",
+                    )
                 ).one_or_none()
                 if tenant_account_join:
                     tenant, ta = tenant_account_join

--- a/api/models/account.py
+++ b/api/models/account.py
@@ -165,11 +165,8 @@ class Account(UserMixin, TypeBase):
 
     def set_tenant_id_with_session(self, tenant_id: str, *, session: Session) -> None:
         """Set the current tenant by id using the caller-owned session."""
-        query = (
-            select(Tenant, TenantAccountJoin)
-            .where(Tenant.id == tenant_id)
-            .where(TenantAccountJoin.tenant_id == Tenant.id)
-            .where(TenantAccountJoin.account_id == self.id)
+        query = select(Tenant, TenantAccountJoin).where(
+            Tenant.id == tenant_id, TenantAccountJoin.tenant_id == Tenant.id, TenantAccountJoin.account_id == self.id
         )
         tenant_account_join = session.execute(query).first()
         if not tenant_account_join:

--- a/api/services/account_service.py
+++ b/api/services/account_service.py
@@ -1624,8 +1624,7 @@ class TenantService:
             select(Account, TenantAccountJoin.role)
             .select_from(Account)
             .join(TenantAccountJoin, Account.id == TenantAccountJoin.account_id)
-            .where(TenantAccountJoin.tenant_id == tenant.id)
-            .where(TenantAccountJoin.role == "dataset_operator")
+            .where(TenantAccountJoin.tenant_id == tenant.id, TenantAccountJoin.role == "dataset_operator")
         )
 
         # Initialize an empty list to store the updated accounts

--- a/api/services/annotation_service.py
+++ b/api/services/annotation_service.py
@@ -230,12 +230,12 @@ class AppAnnotationService:
             escaped_keyword = escape_like_pattern(keyword)
             stmt = (
                 select(MessageAnnotation)
-                .where(MessageAnnotation.app_id == app_id)
                 .where(
+                    MessageAnnotation.app_id == app_id,
                     or_(
                         MessageAnnotation.question.ilike(f"%{escaped_keyword}%", escape="\\"),
                         MessageAnnotation.content.ilike(f"%{escaped_keyword}%", escape="\\"),
-                    )
+                    ),
                 )
                 .order_by(MessageAnnotation.created_at.desc(), MessageAnnotation.id.desc())
             )

--- a/api/services/conversation_service.py
+++ b/api/services/conversation_service.py
@@ -256,8 +256,7 @@ class ConversationService:
 
         stmt = (
             select(ConversationVariable)
-            .where(ConversationVariable.app_id == app_model.id)
-            .where(ConversationVariable.conversation_id == conversation.id)
+            .where(ConversationVariable.app_id == app_model.id, ConversationVariable.conversation_id == conversation.id)
             .order_by(ConversationVariable.created_at)
         )
 
@@ -342,11 +341,10 @@ class ConversationService:
         conversation = cls.get_conversation(app_model, conversation_id, user, session=session)
 
         # Get the existing conversation variable
-        stmt = (
-            select(ConversationVariable)
-            .where(ConversationVariable.app_id == app_model.id)
-            .where(ConversationVariable.conversation_id == conversation.id)
-            .where(ConversationVariable.id == variable_id)
+        stmt = select(ConversationVariable).where(
+            ConversationVariable.app_id == app_model.id,
+            ConversationVariable.conversation_id == conversation.id,
+            ConversationVariable.id == variable_id,
         )
 
         existing_variable = session.scalar(stmt)

--- a/api/tests/test_containers_integration_tests/repositories/test_sqlalchemy_workflow_trigger_log_repository.py
+++ b/api/tests/test_containers_integration_tests/repositories/test_sqlalchemy_workflow_trigger_log_repository.py
@@ -125,8 +125,7 @@ def test_delete_by_run_ids_empty_short_circuits(db_session_with_containers: Sess
         remaining_count = db_session_with_containers.scalar(
             select(func.count())
             .select_from(WorkflowTriggerLog)
-            .where(WorkflowTriggerLog.tenant_id == tenant_id)
-            .where(WorkflowTriggerLog.workflow_run_id == run_id)
+            .where(WorkflowTriggerLog.tenant_id == tenant_id, WorkflowTriggerLog.workflow_run_id == run_id)
         )
         assert remaining_count == 1
     finally:


### PR DESCRIPTION
fixes #39818

Consolidates chained `.where(A).where(B)` into a single `.where(A, B)`. SQLAlchemy's `.where()` takes multiple positional criteria and ANDs them, so the two forms are equivalent, and the single-call style is already used elsewhere in the codebase.

17 sites across 10 files.

## Verified rather than assumed

`.where()` accepting varargs is documented behavior, but the equivalence is the whole basis of this PR, so I checked it against real SQLAlchemy instead of trusting the docs:

```python
chained = select(T).where(T.a == "x").where(T.b == "y")
merged  = select(T).where(T.a == "x", T.b == "y")
str(chained) == str(merged)          # True

# the annotation_service.py shape, where one criterion is an or_()
c2 = select(T).where(T.a == "x").where(or_(T.b == "y", T.b == "z"))
m2 = select(T).where(T.a == "x", or_(T.b == "y", T.b == "z"))
str(c2) == str(m2)                   # True
# SELECT ... WHERE t.a = :a_1 AND (t.b = :b_1 OR t.b = :b_2)
```

Byte-identical SQL in both shapes, including the `or_()` one, which was the only site where the outcome was not obvious by inspection.

## One site the issue did not list

The `ast-grep` output in the issue misses `api/core/rag/retrieval/dataset_retrieval.py:2006`. It is included here.

I located the sites with a paren-matching scan rather than a regex, so chains separated by nested calls or multi-line arguments could not hide, and re-ran the scan afterwards to confirm zero chained sites remain under `api/`.

## Formatting

Merging by hand left some awkward layout, so I ran the repo's own formatter (`ruff 0.15.12`, `api/.ruff.toml`). It reformatted exactly the 10 touched files and left the other 3189 unchanged. `ruff check .` passes.

The most visible reflow is `message_cycle_manager.py`, where the merged call now fits on one line within the 120-char limit:

```python
select(MessageFile).where(MessageFile.message_id == message_id, MessageFile.belongs_to == "assistant")
```

## Tests

No tests added or changed: this is a pure refactor with no observable behavior change, per the contributing guide's "add or update tests when the change affects observable behavior or carries meaningful regression risk". Existing coverage over these queries is unaffected, and the equivalence check above is the substantive verification.

For transparency about what I ran locally: every touched file parses, `ruff format` and `ruff check` are clean, and the SQL equivalence is demonstrated above. I did not complete a local `make test` run, so I am relying on CI for the full suite.
