### PR TITLE
fix(auth): add bounded timeout to WaterCrawl credential validation

### DIFF
--- a/api/services/auth/watercrawl/watercrawl.py
+++ b/api/services/auth/watercrawl/watercrawl.py
@@ -6,6 +6,10 @@ import httpx
 
 from services.auth.api_key_auth_base import ApiKeyAuthBase, AuthCredentials
 
+# Explicit bounded timeout for credential-validation requests so a slow or
+# hanging WaterCrawl endpoint cannot block the worker indefinitely.
+_CREDENTIAL_TIMEOUT = httpx.Timeout(10.0)
+
 
 class WatercrawlAuth(ApiKeyAuthBase):
     def __init__(self, credentials: AuthCredentials):
@@ -33,7 +37,7 @@ class WatercrawlAuth(ApiKeyAuthBase):
         return {"Content-Type": "application/json", "X-API-KEY": self.api_key}
 
     def _get_request(self, url, headers):
-        return httpx.get(url, headers=headers)
+        return httpx.get(url, headers=headers, timeout=_CREDENTIAL_TIMEOUT)
 
     def _handle_error(self, response):
         if response.status_code in {402, 409, 500}:

--- a/api/tests/unit_tests/services/auth/test_watercrawl_auth.py
+++ b/api/tests/unit_tests/services/auth/test_watercrawl_auth.py
@@ -77,6 +77,7 @@ class TestWatercrawlAuth:
         mock_get.assert_called_once_with(
             "https://app.watercrawl.dev/api/v1/core/crawl-requests/",
             headers={"Content-Type": "application/json", "X-API-KEY": "test_api_key_123"},
+            timeout=httpx.Timeout(10.0),
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

WaterCrawl credential validation issued `httpx.get(url, headers=headers)` without any timeout, so a slow or unresponsive WaterCrawl endpoint could block the worker indefinitely during credential validation.

This applies the same hardening already present in the sibling auth providers — Firecrawl auth uses `_CREDENTIAL_TIMEOUT = httpx.Timeout(10.0)` and Jina auth uses a pooled client built with `httpx.Timeout(10.0)` (#37524) — to the WaterCrawl provider:

- `api/services/auth/watercrawl/watercrawl.py`: add module-level `_CREDENTIAL_TIMEOUT = httpx.Timeout(10.0)` and pass it to the validation request
- `api/tests/unit_tests/services/auth/test_watercrawl_auth.py`: assert the bounded timeout is applied

Verified locally: `pytest tests/unit_tests/services/auth/test_watercrawl_auth.py` → 27 passed; `make lint` and `make type-check` clean.

Fixes #39823

## Screenshots

N/A — backend-only change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Claude Code
