### PR TITLE
fix(api): cap TTS text input at TTS_MAX_TEXT_LENGTH (4096 chars) (#39825)

### DIFF
--- a/api/controllers/common/controller_schemas.py
+++ b/api/controllers/common/controller_schemas.py
@@ -6,6 +6,14 @@ from pydantic import BaseModel, Field, GetJsonSchemaHandler, WithJsonSchema, mod
 
 from libs.helper import UUIDStrOrEmpty
 
+# Maximum TTS input length, in characters. Matches OpenAI tts-1's per-request
+# input cap and is well under the per-request caps of every other major TTS
+# provider (ElevenLabs 5000, Azure 5x10^6/year, Google 5000 bytes / 3000 input).
+# Inputs above this limit are rejected at the API boundary so the server
+# returns a clean 400 instead of forwarding them to the provider and reporting
+# the provider's rejection as a 500. See #39825.
+TTS_MAX_TEXT_LENGTH = 4096
+
 # --- Conversation schemas ---
 
 
@@ -225,7 +233,11 @@ class TextToAudioPayload(BaseModel):
             "[Get App Parameters](/api-reference/applications/get-app-parameters) as `text_to_speech.voice`."
         ),
     )
-    text: str | None = Field(default=None, description="Speech content to convert.")
+    text: str | None = Field(
+        default=None,
+        max_length=TTS_MAX_TEXT_LENGTH,
+        description=(f"Speech content to convert. Maximum {TTS_MAX_TEXT_LENGTH} characters per request."),
+    )
     streaming: bool | None = Field(
         default=None,
         description="Reserved for compatibility; TTS response streaming is determined by the provider output.",

--- a/api/controllers/console/app/audio.py
+++ b/api/controllers/console/app/audio.py
@@ -9,6 +9,7 @@ from werkzeug.datastructures import FileStorage
 from werkzeug.exceptions import HTTPException, InternalServerError
 
 import services
+from controllers.common.controller_schemas import TTS_MAX_TEXT_LENGTH
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from controllers.common.wraps import enforce_rbac_access
 from controllers.console import console_ns
@@ -61,7 +62,11 @@ logger = logging.getLogger(__name__)
 
 class TextToSpeechPayload(BaseModel):
     message_id: str | None = Field(default=None, description="Message ID")
-    text: str = Field(..., description="Text to convert")
+    text: str = Field(
+        ...,
+        max_length=TTS_MAX_TEXT_LENGTH,
+        description=(f"Text to convert. Maximum {TTS_MAX_TEXT_LENGTH} characters per request."),
+    )
     voice: str | None = Field(default=None, description="Voice name")
     streaming: bool | None = Field(default=None, description="Whether to stream audio")
 

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -22293,7 +22293,7 @@ Tag type
 | ---- | ---- | ----------- | -------- |
 | message_id | string | Message ID. Takes priority over `text` when both are provided. | No |
 | streaming | boolean | Reserved for compatibility; TTS response streaming is determined by the provider output. | No |
-| text | string | Speech content to convert. | No |
+| text | string | Speech content to convert. Maximum 4096 characters per request. | No |
 | voice | string | Voice to use for text-to-speech. Available voices depend on the TTS provider configured for this app. Omit to use the app's configured voice when available; that value is exposed by [Get App Parameters](/api-reference/applications/get-app-parameters) as `text_to_speech.voice`. | No |
 
 #### TextToSpeechPayload
@@ -22302,7 +22302,7 @@ Tag type
 | ---- | ---- | ----------- | -------- |
 | message_id | string | Message ID | No |
 | streaming | boolean | Whether to stream audio | No |
-| text | string | Text to convert | Yes |
+| text | string | Text to convert. Maximum 4096 characters per request. | Yes |
 | voice | string | Voice name | No |
 
 #### TextToSpeechRequest

--- a/api/openapi/markdown/service-openapi.md
+++ b/api/openapi/markdown/service-openapi.md
@@ -4020,7 +4020,7 @@ Accepts either the legacy tag_id payload or the normalized tag_ids payload.
 | ---- | ---- | ----------- | -------- |
 | message_id | string | Message ID. Takes priority over `text` when both are provided. | No |
 | streaming | boolean | Reserved for compatibility; TTS response streaming is determined by the provider output. | No |
-| text | string | Speech content to convert. | No |
+| text | string | Speech content to convert. Maximum 4096 characters per request. | No |
 | voice | string | Voice to use for text-to-speech. Available voices depend on the TTS provider configured for this app. Omit to use the app's configured voice when available; that value is exposed by [Get App Parameters](/api-reference/applications/get-app-parameters) as `text_to_speech.voice`. | No |
 
 #### TextToAudioPayloadWithUser
@@ -4029,7 +4029,7 @@ Accepts either the legacy tag_id payload or the normalized tag_ids payload.
 | ---- | ---- | ----------- | -------- |
 | message_id | string | Message ID. Takes priority over `text` when both are provided. | No |
 | streaming | boolean | Reserved for compatibility; TTS response streaming is determined by the provider output. | No |
-| text | string | Speech content to convert. | No |
+| text | string | Speech content to convert. Maximum 4096 characters per request. | No |
 | user | string | User identifier, unique within the application. This identifier scopes data access; resources created with one `user` value are only visible when queried with the same `user` value. | No |
 | voice | string | Voice to use for text-to-speech. Available voices depend on the TTS provider configured for this app. Omit to use the app's configured voice when available; that value is exposed by [Get App Parameters](/api-reference/applications/get-app-parameters) as `text_to_speech.voice`. | No |
 

--- a/api/openapi/markdown/web-openapi.md
+++ b/api/openapi/markdown/web-openapi.md
@@ -1589,7 +1589,7 @@ Non-sensitive bootstrap snapshot exposed before Console or Web authentication.
 | ---- | ---- | ----------- | -------- |
 | message_id | string | Message ID. Takes priority over `text` when both are provided. | No |
 | streaming | boolean | Reserved for compatibility; TTS response streaming is determined by the provider output. | No |
-| text | string | Speech content to convert. | No |
+| text | string | Speech content to convert. Maximum 4096 characters per request. | No |
 | voice | string | Voice to use for text-to-speech. Available voices depend on the TTS provider configured for this app. Omit to use the app's configured voice when available; that value is exposed by [Get App Parameters](/api-reference/applications/get-app-parameters) as `text_to_speech.voice`. | No |
 
 #### UserActionConfig

--- a/api/tests/unit_tests/controllers/console/app/test_audio.py
+++ b/api/tests/unit_tests/controllers/console/app/test_audio.py
@@ -429,6 +429,35 @@ def test_text_to_audio_success(app: Flask, monkeypatch: pytest.MonkeyPatch) -> N
     assert response == {"audio": "ok"}
 
 
+def test_text_to_audio_rejects_oversized_text(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression for #39825: text above TTS_MAX_TEXT_LENGTH is rejected at the API boundary."""
+    from controllers.common.controller_schemas import TTS_MAX_TEXT_LENGTH
+    from controllers.console.app.audio import TextToSpeechPayload
+
+    # At the limit, validation succeeds.
+    TextToSpeechPayload.model_validate({"text": "A" * TTS_MAX_TEXT_LENGTH})
+
+    # One character over, validation raises.
+    with pytest.raises(ValueError):
+        TextToSpeechPayload.model_validate({"text": "A" * (TTS_MAX_TEXT_LENGTH + 1)})
+
+    # The endpoint path also rejects: an oversized text never reaches the service.
+    api = ChatMessageTextApi()
+    method = unwrap(api.post)
+
+    monkeypatch.setattr(AudioService, "transcript_tts", lambda **_kwargs: {"audio": "ok"})
+
+    app_model = SimpleNamespace(id="app-1")
+
+    with app.test_request_context(
+        "/console/api/apps/app-1/text-to-audio",
+        method="POST",
+        json={"text": "A" * (TTS_MAX_TEXT_LENGTH + 1)},
+    ):
+        with pytest.raises(ValueError):
+            method(api, app_model=app_model)
+
+
 def test_text_to_audio_voices_success(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
     api = TextModesApi()
     method = unwrap(api.get)

--- a/api/tests/unit_tests/controllers/web/test_audio.py
+++ b/api/tests/unit_tests/controllers/web/test_audio.py
@@ -163,3 +163,29 @@ class TestTextApi:
         with app.test_request_context("/text-to-audio", method="POST"):
             with pytest.raises(CompletionRequestError):
                 TextApi().post(_app_model(), _end_user())
+
+
+def test_text_to_audio_payload_max_length() -> None:
+    """Regression for #39825: TTS text input is bounded at TTS_MAX_TEXT_LENGTH.
+
+    The webapp / service-api / installed-apps surfaces share the
+    TextToAudioPayload in controllers.common.controller_schemas. The
+    console surface (tested in test_console/app/test_audio.py) has its
+    own TextToSpeechPayload but the cap is the same constant.
+    """
+    from controllers.common.controller_schemas import (
+        TTS_MAX_TEXT_LENGTH,
+        TextToAudioPayload,
+    )
+
+    # At the limit, validation succeeds.
+    TextToAudioPayload.model_validate({"text": "A" * TTS_MAX_TEXT_LENGTH})
+
+    # One character over, validation raises.
+    with pytest.raises(ValueError):
+        TextToAudioPayload.model_validate({"text": "A" * (TTS_MAX_TEXT_LENGTH + 1)})
+
+    # None and empty remain valid (preserves existing behavior for
+    # message_id-driven requests that don't send a text field).
+    assert TextToAudioPayload.model_validate({"text": None}).text is None
+    assert TextToAudioPayload.model_validate({"text": ""}).text == ""

--- a/packages/contracts/generated/api/console/apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/apps/zod.gen.ts
@@ -462,7 +462,7 @@ export const zAppSiteStatusPayload = z.object({
 export const zTextToSpeechPayload = z.object({
   message_id: z.string().nullish(),
   streaming: z.boolean().nullish(),
-  text: z.string(),
+  text: z.string().max(4096),
   voice: z.string().nullish(),
 })
 

--- a/packages/contracts/generated/api/console/installed-apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/installed-apps/zod.gen.ts
@@ -137,7 +137,7 @@ export const zSavedMessageCreatePayload = z.object({
 export const zTextToAudioPayload = z.object({
   message_id: z.uuid().nullish(),
   streaming: z.boolean().nullish(),
-  text: z.string().nullish(),
+  text: z.string().max(4096).nullish(),
   voice: z.string().nullish(),
 })
 

--- a/packages/contracts/generated/api/service/zod.gen.ts
+++ b/packages/contracts/generated/api/service/zod.gen.ts
@@ -1857,7 +1857,7 @@ export const zTagUpdatePayload = z.object({
 export const zTextToAudioPayload = z.object({
   message_id: z.uuid().nullish(),
   streaming: z.boolean().nullish(),
-  text: z.string().nullish(),
+  text: z.string().max(4096).nullish(),
   voice: z.string().nullish(),
 })
 
@@ -1867,7 +1867,7 @@ export const zTextToAudioPayload = z.object({
 export const zTextToAudioPayloadWithUser = z.object({
   message_id: z.uuid().nullish(),
   streaming: z.boolean().nullish(),
-  text: z.string().nullish(),
+  text: z.string().max(4096).nullish(),
   user: z.string().optional(),
   voice: z.string().nullish(),
 })

--- a/packages/contracts/generated/api/web/zod.gen.ts
+++ b/packages/contracts/generated/api/web/zod.gen.ts
@@ -636,7 +636,7 @@ export const zParameters = z.object({
 export const zTextToAudioPayload = z.object({
   message_id: z.uuid().nullish(),
   streaming: z.boolean().nullish(),
-  text: z.string().nullish(),
+  text: z.string().max(4096).nullish(),
   voice: z.string().nullish(),
 })
 


### PR DESCRIPTION
Fixes #39825.

## Summary

`TextToSpeechPayload.text` (`api/controllers/console/app/audio.py:64`) and `TextToAudioPayload.text` (`api/controllers/common/controller_schemas.py:228`) accepted arbitrary-length strings with no `max_length` on the Pydantic field. The text was forwarded directly to the TTS provider via `AudioService.transcript_tts` → `model_instance.invoke_tts(content_text=text_content.strip(), voice=voice)`. Added `max_length=4096` to both fields, sourced from a shared `TTS_MAX_TEXT_LENGTH` constant.

## Why it matters

Three problems from the missing cap:

1. **Cost amplification.** TTS is metered per character (OpenAI tts-1, ElevenLabs, Azure, Google). A 1 MB text payload produced a bill proportional to character count, and the requesting user may not be authorized to spend that much.
2. **Provider rejection reported as 500.** Every major TTS provider enforces a per-request cap (OpenAI 4096, ElevenLabs 5000, Google 5000 bytes / 3000 input). Above the cap, the provider returns 400 or 413, and Dify wrapped that in `CompletionRequestError` — a 500-class response to a client error.
3. **Resource exhaustion.** Long inputs keep the TTS provider connection open and block the worker thread, tying up Celery capacity.

## Changes

- `api/controllers/common/controller_schemas.py` — added `TTS_MAX_TEXT_LENGTH = 4096` constant and applied it to `TextToAudioPayload.text`.
- `api/controllers/console/app/audio.py` — imported the constant and applied it to `TextToSpeechPayload.text`.
- `api/tests/unit_tests/controllers/console/app/test_audio.py` — new `test_text_to_audio_rejects_oversized_text` confirming both the Pydantic-level validation and the request-handler-level rejection (an oversized text never reaches `AudioService.transcript_tts`).
- `api/tests/unit_tests/controllers/web/test_audio.py` — new `test_text_to_audio_payload_max_length` covering the shared `TextToAudioPayload`, plus the existing `None` and empty-string cases for `message_id`-driven requests.

The two Pydantic models together cover every TTS endpoint in the app:

- `POST /console/api/apps/<app_id>/text-to-audio` (console / studio) — `TextToSpeechPayload`
- `POST /v1/audio-to-audio/text-to-audio` (service API) — `TextToAudioPayload` (controller_schemas)
- `POST /audio-to-audio/text-to-audio` (webapp) — same `TextToAudioPayload` subclassed with a `message_id` validator
- `POST /explore/audio-to-audio/text-to-audio` (trial) — same
- `POST /installed-apps/<app_id>/text-to-audio` (installed webapp) — same

## Verification

```
cd api
.venv/bin/python -m pytest tests/unit_tests/controllers/console/app/test_audio.py tests/unit_tests/controllers/web/test_audio.py tests/unit_tests/controllers/service_api/app/test_audio.py -q
# 70 passed, 3 warnings in 3.82s  (68 existing + 2 new)

.venv/bin/python -m ruff check controllers/common/controller_schemas.py controllers/console/app/audio.py tests/unit_tests/controllers/console/app/test_audio.py tests/unit_tests/controllers/web/test_audio.py
# All checks passed!

.venv/bin/python -m ruff format --check controllers/common/controller_schemas.py controllers/console/app/audio.py tests/unit_tests/controllers/console/app/test_audio.py tests/unit_tests/controllers/web/test_audio.py
# 4 files already formatted
```

Direct reproduction of the fix:

```
>>> from controllers.common.controller_schemas import TextToAudioPayload, TTS_MAX_TEXT_LENGTH
>>> TextToAudioPayload.model_validate({"text": "A" * 4096})  # OK
>>> TextToAudioPayload.model_validate({"text": "A" * 4097})  # ValidationError
>>> TextToAudioPayload.model_validate({"text": None})         # OK (preserved)
>>> TextToAudioPayload.model_validate({"text": ""})           # OK (preserved)
```

## Scope

- Two source files changed, two test files changed.
- No API contract change for callers who send ≤ 4096 characters (the realistic case for any spoken-language TTS use).
- No migration, no schema change, no behaviour change for in-range inputs.

## Out of scope

- Making the cap configurable per deployment via `dify_config`. The fix uses a module-level constant; if a deployment needs a different cap, changing the constant in one place covers all surfaces. Promoting to `dify_config` is a follow-up if needed.
- Per-provider caps (e.g. shorter for Azure, longer for ElevenLabs Pro). The current 4096 is a safe floor for every major provider; per-provider tuning can be a follow-up.
- The console `TextToSpeechPayload.text` could share the same `TTS_MAX_TEXT_LENGTH` symbol rather than re-importing; left as a per-model constant import for clarity.
