### PR TITLE
fix(rag): add bounded timeout to Firecrawl extractor requests

### DIFF
--- a/api/core/rag/extractor/firecrawl/firecrawl_app.py
+++ b/api/core/rag/extractor/firecrawl/firecrawl_app.py
@@ -6,6 +6,10 @@ import httpx
 
 from extensions.ext_storage import storage
 
+# Bounded connect/read timeout so a slow or hanging Firecrawl endpoint cannot
+# block extraction indefinitely (mirrors the WaterCrawl extractor client).
+_REQUEST_TIMEOUT = httpx.Timeout(30.0, connect=5.0)
+
 
 class FirecrawlDocumentData(TypedDict):
     title: str | None
@@ -176,7 +180,7 @@ class FirecrawlApp:
     def _post_request(self, url, data, headers, retries=3, backoff_factor=0.5) -> httpx.Response:
         response: httpx.Response | None = None
         for attempt in range(retries):
-            response = httpx.post(url, headers=headers, json=data)
+            response = httpx.post(url, headers=headers, json=data, timeout=_REQUEST_TIMEOUT)
             if response.status_code == 502:
                 time.sleep(backoff_factor * (2**attempt))
             else:
@@ -187,7 +191,7 @@ class FirecrawlApp:
     def _get_request(self, url, headers, retries=3, backoff_factor=0.5) -> httpx.Response:
         response: httpx.Response | None = None
         for attempt in range(retries):
-            response = httpx.get(url, headers=headers)
+            response = httpx.get(url, headers=headers, timeout=_REQUEST_TIMEOUT)
             if response.status_code == 502:
                 time.sleep(backoff_factor * (2**attempt))
             else:

--- a/api/tests/unit_tests/core/rag/extractor/firecrawl/test_firecrawl.py
+++ b/api/tests/unit_tests/core/rag/extractor/firecrawl/test_firecrawl.py
@@ -35,6 +35,18 @@ class TestFirecrawlApp:
         }
         assert app._build_url("/v2/crawl") == "https://custom.firecrawl.dev/v2/crawl"
 
+    def test_requests_use_bounded_timeout(self, mocker: MockerFixture):
+        """Outbound requests must carry a bounded timeout so a hanging endpoint cannot block extraction."""
+        app = FirecrawlApp(api_key="fc-key", base_url="https://custom.firecrawl.dev")
+        mock_post = mocker.patch("httpx.post", return_value=_response(200, {"id": "job-1"}))
+        mock_get = mocker.patch("httpx.get", return_value=_response(200, {"status": "completed"}))
+
+        app._post_request("https://custom.firecrawl.dev/v1/crawl", {}, app._prepare_headers())
+        app._get_request("https://custom.firecrawl.dev/v1/crawl/job-1", app._prepare_headers())
+
+        assert mock_post.call_args.kwargs["timeout"] == firecrawl_module._REQUEST_TIMEOUT
+        assert mock_get.call_args.kwargs["timeout"] == firecrawl_module._REQUEST_TIMEOUT
+
     def test_scrape_url_success(self, mocker: MockerFixture):
         app = FirecrawlApp(api_key="fc-key", base_url="https://custom.firecrawl.dev")
         mocker.patch(


### PR DESCRIPTION
## Summary

The Firecrawl extractor issued `httpx.post` / `httpx.get` without any timeout in `FirecrawlApp._post_request` and `_get_request`, so a slow or unresponsive Firecrawl endpoint could block extraction indefinitely (the surrounding 502-retry loop never runs because the first request never returns).

This applies the same hardening already present in the WaterCrawl extractor client (`httpx.Timeout(30.0, connect=5.0)`, added after #37512) to the Firecrawl extractor:

- `api/core/rag/extractor/firecrawl/firecrawl_app.py`: add module-level `_REQUEST_TIMEOUT = httpx.Timeout(30.0, connect=5.0)` and pass it to both request helpers
- `api/tests/unit_tests/core/rag/extractor/firecrawl/test_firecrawl.py`: regression test asserting both helpers carry the bounded timeout

Note this is distinct from #37521, which covered the Firecrawl **auth provider**; the extractor path was not covered by that fix.

Verified locally: `pytest tests/unit_tests/core/rag/extractor/firecrawl/test_firecrawl.py` → 32 passed; `make lint` and `make type-check` clean.

Fixes #39830

## Screenshots

N/A — backend-only change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Claude Code
