### PR TITLE
docs: fix typos in api comments and prompt example

### DIFF
--- a/api/core/llm_generator/prompts.py
+++ b/api/core/llm_generator/prompts.py
@@ -254,7 +254,7 @@ Your task is to convert simple user descriptions into properly formatted JSON Sc
 }
 
 ### Example 4:
-**User Input:** I need album schema, the ablum has songs, and each song has name, duration, and artist.
+**User Input:** I need album schema, the album has songs, and each song has name, duration, and artist.
 **JSON Schema Output:**
 {
     "type": "object",
@@ -273,7 +273,7 @@ Your task is to convert simple user descriptions into properly formatted JSON Sc
                     "duration": {
                         "type": "string"
                     },
-                    "aritst": {
+                    "artist": {
                         "type": "string"
                     }
                 },
@@ -281,7 +281,7 @@ Your task is to convert simple user descriptions into properly formatted JSON Sc
                     "name",
                     "id",
                     "duration",
-                    "aritst"
+                    "artist"
                 ]
             }
         }

--- a/api/core/workflow/nodes/human_input/pause_reason.py
+++ b/api/core/workflow/nodes/human_input/pause_reason.py
@@ -15,8 +15,8 @@ class DifyHITLEventType(StrEnum):
 
     """
 
-    # Ideally this should be a string constaint. However, we cannot put
-    # string constant into Literal type cosntructor. We have to warp it as a
+    # Ideally this should be a string constraint. However, we cannot put
+    # string constant into Literal type constructor. We have to wrap it as a
     # string enumeration.
     HUMAN_INPUT_REQUIRED = PauseReasonType.LEGACY_HUMAN_INPUT_REQUIRED.value
 

--- a/api/tasks/delete_conversation_task.py
+++ b/api/tasks/delete_conversation_task.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 @shared_task(queue="conversation")
 def delete_conversation_related_data(conversation_id: str):
     """
-    Delete related data conversation in correct order from datatbase to respect foreign key constraints
+    Delete related data conversation in correct order from database to respect foreign key constraints
 
     Args:
         conversation_id: conversation Id


### PR DESCRIPTION
## Summary

Spelling fixes in three `api/` files. Comments, docstrings and prompt text only — no behavior change.

**1. `api/core/llm_generator/prompts.py` — misspelled key in a few-shot example**

In `SYSTEM_STRUCTURED_OUTPUT_GENERATE`, Example 4's user input asks for `artist`, but the expected JSON Schema output spells the property `aritst` (lines 276 and 284). Since this is a few-shot example the model imitates, it teaches the LLM to emit a misspelled property name when a user asks for an album schema. Also `ablum` → `album` in the same example's user input (line 257).

**2. `api/core/workflow/nodes/human_input/pause_reason.py`** (lines 18–19)

`constaint` → `constraint`, `cosntructor` → `constructor`, `warp` → `wrap`.

**3. `api/tasks/delete_conversation_task.py`** (line 20)

`datatbase` → `database` in the docstring.

3 files, +6/-6.

## Screenshots

N/A — no user-facing UI change.

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs) — N/A, internal comments only.
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!) — this is a typo-only PR, so per the template no prior issue is opened. Happy to file one if you'd prefer.
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. — no test added: nothing executable changed. `aritst` appears nowhere else in the repo (verified with code search), so no test or caller reads that key; it only exists inside this prompt string.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

On the lint gate: `web/` is untouched, so no frontend check was needed. For the backend I ran `ruff` 0.15.12 (the version pinned in `api/pyproject.toml`) rather than the full `make lint`, since that target also runs `lint-imports` and `dotenv-linter` over the whole tree:

```
$ ruff format --check api/core/llm_generator/prompts.py \
    api/core/workflow/nodes/human_input/pause_reason.py \
    api/tasks/delete_conversation_task.py
3 files already formatted

$ ruff check <same 3 files>
error[I001][*]: Import block is un-sorted or un-formatted
  --> tasks/delete_conversation_task.py:1:1
Found 1 error.
```

That `I001` is **pre-existing and not from this PR** — I confirmed it reproduces on the unmodified file (`git stash` → same error). My diff in that file is one word inside a docstring. I left it alone rather than bundling an unrelated import reorder into a typo fix; let me know if you'd rather I include it.

Also verified `codespell` is clean on all three files after the change, and all three still parse (`ast.parse`).

From Claude Code
