### PR TITLE
fix(api): silence opentelemetry.context error reports to Sentry on cloud

### DIFF
--- a/api/extensions/ext_sentry.py
+++ b/api/extensions/ext_sentry.py
@@ -7,6 +7,7 @@ def init_app(app: DifyApp):
         import sentry_sdk
         from sentry_sdk.integrations.celery import CeleryIntegration
         from sentry_sdk.integrations.flask import FlaskIntegration
+        from sentry_sdk.integrations.logging import ignore_logger
         from werkzeug.exceptions import HTTPException
 
         from graphon.model_runtime.errors.invoke import InvokeRateLimitError
@@ -45,3 +46,12 @@ def init_app(app: DifyApp):
             release=f"dify-{dify_config.project.version}-{dify_config.COMMIT_SHA}",
             before_send=before_send,
         )
+
+        if dify_config.BILLING_ENABLED:
+            # Cloud only. `opentelemetry.context.detach()` catches its own failures and reports
+            # them through `logger.exception`, so a double-detach surfaces as an error event
+            # rather than as a raised exception. Under gevent this can fire about once per
+            # workflow run, which is enough volume to crowd real errors out of the issue stream.
+            # Self-hosted deployments rarely see enough of it to be worth silencing, and the
+            # records still reach the normal logging handlers either way.
+            ignore_logger("opentelemetry.context")


### PR DESCRIPTION
## Summary

`opentelemetry.context.detach()` catches its own failures and reports them through `logger.exception` rather than letting them propagate:

```python
def detach(token):
    try:
        _RUNTIME_CONTEXT.detach(token)
    except Exception:
        logger.exception("Failed to detach context")
```

So a double-detach never surfaces as a raised exception — it is delivered straight to Sentry as a handled error event by the logging integration. Under gevent this fires about once per workflow run, which is enough volume to crowd genuine errors out of the issue stream.

This PR does not change the detach behaviour itself. It only stops the reports from being sent to Sentry, by registering the logger with `sentry_sdk`'s `ignore_logger` when billing is enabled.

Scope of the change:

- **Self-hosted is unaffected.** `BILLING_ENABLED` defaults to `False`, so nothing changes unless a deployment explicitly opts in. The same gate is already used elsewhere in the codebase to separate cloud-only behaviour (`tasks/delete_account_task.py`, `tasks/refresh_billing_vector_space_task.py`, `core/indexing_runner.py`).
- **Only that one logger name.** `sentry_sdk` matches ignored loggers with `fnmatch`, and the pattern contains no wildcards, so child and sibling loggers (`opentelemetry.context.contextvars_context`, `opentelemetry.trace`, `opentelemetry`) are untouched.
- **Nothing is lost from logs.** `ignore_logger` only affects the Sentry logging integration. Records still reach the standard logging handlers, so stdout-based log pipelines keep every line.

`opentelemetry.context` emits exactly two messages in the whole module — the detach failure above, and a startup-time `"Failed to load context: %s, fallback to %s"` that only fires when the configured context entry point cannot be loaded. The latter is still visible in normal logs, and a failure there breaks tracing globally in ways that are obvious without Sentry.

Related: #36809, #25673, #18496 — the underlying double-detach has been reported several times. This PR is not a fix for it.

## Screenshots

Not applicable — no user-facing change.

## Checklist

- [x] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs) — not required, no new configuration option is introduced.
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
