### PR TITLE
docs: fix stale app_model param name in pipeline docstrings

### DIFF
--- a/api/core/app/apps/pipeline/pipeline_generator.py
+++ b/api/core/app/apps/pipeline/pipeline_generator.py
@@ -388,7 +388,7 @@ class PipelineGenerator(BaseAppGenerator):
         """
         Generate App response.
 
-        :param app_model: App
+        :param pipeline: Pipeline
         :param workflow: Workflow
         :param node_id: the node id
         :param user: account or end user
@@ -490,7 +490,7 @@ class PipelineGenerator(BaseAppGenerator):
         """
         Generate App response.
 
-        :param app_model: App
+        :param pipeline: Pipeline
         :param workflow: Workflow
         :param node_id: the node id
         :param user: account or end user

--- a/api/services/rag_pipeline/rag_pipeline.py
+++ b/api/services/rag_pipeline/rag_pipeline.py
@@ -1173,7 +1173,7 @@ class RagPipelineService:
         Get debug workflow run list
         Only return triggered_from == debugging
 
-        :param app_model: app model
+        :param pipeline: pipeline
         :param args: request args
         """
         limit = int(args.get("limit", 20))
@@ -1196,7 +1196,7 @@ class RagPipelineService:
         """
         Get workflow run detail
 
-        :param app_model: app model
+        :param pipeline: pipeline
         :param run_id: workflow run id
         """
         return self._workflow_run_repo.get_workflow_run_by_id(


### PR DESCRIPTION
# Summary

Four docstrings document a parameter named `app_model` that does not exist — the actual parameter is `pipeline`.

All four are the pipeline / RAG-pipeline counterparts of methods that also exist in the App flow. The docstring was carried over verbatim when the signature changed, so it still describes the App version's parameter.

The clearest evidence is that the two `PipelineGenerator` docstrings are **byte-identical** to their `WorkflowAppGenerator` counterparts, which genuinely do take `app_model: App`:

```python
# core/app/apps/workflow/app_generator.py:431 — correct as written
def single_iteration_generate(self, app_model: App, workflow: Workflow, ...):
    """
    Generate App response.

    :param app_model: App
    :param workflow: Workflow
```

```python
# core/app/apps/pipeline/pipeline_generator.py:377 — same docstring, different signature
def single_iteration_generate(self, pipeline: Pipeline, workflow: Workflow, ...):
    """
    Generate App response.

    :param app_model: App     # <-- no such parameter
    :param workflow: Workflow
```

| File | Method | Was | Now |
|---|---|---|---|
| `core/app/apps/pipeline/pipeline_generator.py:391` | `single_iteration_generate` | `:param app_model: App` | `:param pipeline: Pipeline` |
| `core/app/apps/pipeline/pipeline_generator.py:493` | `single_loop_generate` | `:param app_model: App` | `:param pipeline: Pipeline` |
| `api/services/rag_pipeline/rag_pipeline.py:1176` | `get_rag_pipeline_paginate_workflow_runs` | `:param app_model: app model` | `:param pipeline: pipeline` |
| `api/services/rag_pipeline/rag_pipeline.py:1199` | `get_rag_pipeline_workflow_run` | `:param app_model: app model` | `:param pipeline: pipeline` |

2 files, +4/-4. Docstrings only — no executable line changed.

## How I found these

I walked every function in `api/` with `ast` and diffed the documented `:param` / `Args:` names against the real signature. That surfaced 27 functions with documented-but-nonexistent parameters. This PR fixes only the 4 that share one root cause (stale `app_model` in a `pipeline` method), keeping the change to a single problem class.

After the change the same scan reports 23 — exactly these 4 resolved, nothing else touched.

## Verification

```
$ uv tool run ruff@0.15.12 format --check core/app/apps/pipeline/pipeline_generator.py services/rag_pipeline/rag_pipeline.py
2 files already formatted

$ uv tool run ruff@0.15.12 check core/app/apps/pipeline/pipeline_generator.py services/rag_pipeline/rag_pipeline.py
All checks passed!
```

No tests added: nothing executable changed, so there is no behavior to assert on.

## Notes for the reviewer

**The other 23 scan hits are deliberately out of scope.** They are a mix of genuinely different problems (e.g. `PipelineGenerator._generate` documents `workflow` where the parameter is `workflow_id`) and cases needing a judgment call I'd rather leave to you. Happy to open follow-ups if you want them; I kept this PR to one problem class on purpose.

# Screenshots

N/A — docstring-only change, nothing user-visible.

# Checklist

- [x] This change requires a documentation update, included: `N/A`
- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for this change (N/A — docstrings only, no behavior change)
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat` (`ruff` checks pass, see above)

---

I used an AI assistant (Claude Code) to help find and verify this change. I reviewed every line and ran the checks above myself.

From Claude Code
