### PR TITLE
fix: block deletion of referenced workflows

### DIFF
--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -77,6 +77,7 @@ from services.entities.knowledge_entities.knowledge_entities import (
     WeightVectorSetting,
 )
 from services.errors.account import NoPermissionError
+from services.errors.app import WorkflowReferencedError
 from services.feature_service import FeatureService
 from tasks.initialize_created_app_rbac_access_task import initialize_created_app_rbac_access_task
 
@@ -934,6 +935,7 @@ class AppApi(Resource):
     @console_ns.doc(description="Delete application")
     @console_ns.doc(params={"app_id": "Application ID"})
     @console_ns.response(204, "App deleted successfully")
+    @console_ns.response(400, "Workflow is referenced by published workflows")
     @console_ns.response(403, "Insufficient permissions")
     @setup_required
     @login_required
@@ -946,7 +948,10 @@ class AppApi(Resource):
     def delete(self, session: Session, app_model: App):
         """Delete app"""
         app_service = AppService()
-        app_service.delete_app(app_model, session=session)
+        try:
+            app_service.delete_app(app_model, session=session)
+        except WorkflowReferencedError as exc:
+            raise BadRequest(str(exc)) from exc
 
         return "", 204
 

--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -16,6 +16,7 @@ from constants.model_template import default_app_templates
 from core.agent.entities import AgentToolEntity
 from core.errors.error import LLMBadRequestError, ProviderTokenNotInitError
 from core.model_manager import ModelManager
+from core.tools.entities.tool_entities import ToolProviderType
 from core.tools.tool_manager import ToolManager
 from core.tools.utils.configuration import ToolParameterConfigurationManager
 from events.app_event import app_was_created, app_was_deleted, app_was_updated
@@ -29,14 +30,18 @@ from models import Account, AppStar
 from models.agent import (
     APP_BACKED_AGENT_SOURCES,
     Agent,
+    AgentConfigSnapshot,
     AgentIconType,
     AgentScope,
     AgentStatus,
     AgentWorkingResourceStatus,
     AgentWorkspaceBinding,
+    WorkflowAgentBindingType,
+    WorkflowAgentNodeBinding,
 )
+from models.agent_config_entities import AgentSoulConfig
 from models.model import App, AppMode, AppModelConfig, IconType, Site, load_annotation_reply_config
-from models.tools import ApiToolProvider
+from models.tools import ApiToolProvider, WorkflowToolProvider
 from models.workflow import Workflow
 from services.agent.errors import AgentNameConflictError
 from services.agent.home_snapshot_service import AgentHomeSnapshotService
@@ -45,6 +50,7 @@ from services.agent.workspace_service import AgentWorkspaceService
 from services.billing_service import BillingService
 from services.enterprise import rbac_service as enterprise_rbac_service
 from services.enterprise.enterprise_service import EnterpriseService
+from services.errors.app import WorkflowReferencedError
 from services.feature_service import FeatureService
 from services.openapi.visibility import apply_openapi_gate, is_openapi_visible
 from services.tag_service import TagService
@@ -954,11 +960,170 @@ class AppService:
 
         return app
 
+    @staticmethod
+    def _extract_workflow_tool_provider_ids(graph: dict[str, Any]) -> set[str]:
+        nodes = graph.get("nodes")
+        if not isinstance(nodes, list):
+            raise TypeError("workflow graph nodes must be a list")
+
+        provider_ids: set[str] = set()
+        for node in nodes:
+            if not isinstance(node, dict):
+                raise TypeError("workflow graph nodes must be objects")
+            data = node.get("data")
+            if not isinstance(data, dict):
+                raise TypeError("workflow graph node data must be an object")
+
+            tool_configs: list[dict[str, Any]] = []
+            if data.get("type") == "tool":
+                tool_configs.append(data)
+            elif data.get("type") == "agent":
+                legacy_tools = data.get("tools")
+                if isinstance(legacy_tools, list):
+                    tool_configs.extend(config for config in legacy_tools if isinstance(config, dict))
+
+                agent_parameters = data.get("agent_parameters")
+                if isinstance(agent_parameters, dict):
+                    tools_parameter = agent_parameters.get("tools")
+                    if isinstance(tools_parameter, dict):
+                        tools_value = tools_parameter.get("value")
+                        if isinstance(tools_value, list):
+                            tool_configs.extend(config for config in tools_value if isinstance(config, dict))
+
+            for config in tool_configs:
+                provider_type = str(config.get("provider_type") or config.get("type") or "").lower()
+                if provider_type not in {"workflow", "workflow_tool"}:
+                    continue
+                provider_id = config.get("provider_id") or config.get("provider_name") or config.get("provider")
+                if provider_id:
+                    provider_ids.add(str(provider_id))
+
+        return provider_ids
+
+    @staticmethod
+    def _get_referencing_published_workflow_ids(app: App, *, session: Session) -> list[str]:
+        if app.mode not in {AppMode.ADVANCED_CHAT, AppMode.WORKFLOW}:
+            return []
+
+        provider_id = session.scalar(
+            select(WorkflowToolProvider.id)
+            .where(
+                WorkflowToolProvider.tenant_id == app.tenant_id,
+                WorkflowToolProvider.app_id == app.id,
+            )
+            .limit(1)
+        )
+        if provider_id is None:
+            return []
+
+        candidate_workflows = session.scalars(
+            select(Workflow).where(
+                Workflow.tenant_id == app.tenant_id,
+                Workflow.app_id != app.id,
+                Workflow.version != Workflow.VERSION_DRAFT,
+                Workflow.graph.contains(provider_id),
+            )
+        ).all()
+
+        referencing_workflow_ids: set[str] = set()
+        for workflow in candidate_workflows:
+            try:
+                graph = workflow.graph_dict
+                if not isinstance(graph, dict):
+                    raise TypeError("workflow graph must be an object")
+                discovered_provider_ids = AppService._extract_workflow_tool_provider_ids(graph)
+            except (AttributeError, TypeError, ValueError):
+                logger.warning(
+                    "Blocking deletion of workflow app %s because published workflow %s has an invalid graph "
+                    "containing its workflow tool provider ID",
+                    app.id,
+                    workflow.id,
+                )
+                referencing_workflow_ids.add(workflow.id)
+                continue
+
+            if provider_id in discovered_provider_ids:
+                referencing_workflow_ids.add(workflow.id)
+
+        snapshot_text = sa.type_coerce(AgentConfigSnapshot.config_snapshot, sa.Text())
+        snapshot_candidates = session.execute(
+            select(
+                Workflow.id,
+                snapshot_text.label("config_snapshot"),
+            )
+            .select_from(Workflow)
+            .join(
+                WorkflowAgentNodeBinding,
+                sa.and_(
+                    WorkflowAgentNodeBinding.tenant_id == Workflow.tenant_id,
+                    WorkflowAgentNodeBinding.app_id == Workflow.app_id,
+                    WorkflowAgentNodeBinding.workflow_id == Workflow.id,
+                    WorkflowAgentNodeBinding.workflow_version == Workflow.version,
+                ),
+            )
+            .join(
+                Agent,
+                sa.and_(
+                    Agent.tenant_id == WorkflowAgentNodeBinding.tenant_id,
+                    Agent.id == WorkflowAgentNodeBinding.agent_id,
+                ),
+            )
+            .join(
+                AgentConfigSnapshot,
+                sa.and_(
+                    AgentConfigSnapshot.tenant_id == WorkflowAgentNodeBinding.tenant_id,
+                    AgentConfigSnapshot.agent_id == Agent.id,
+                    sa.or_(
+                        AgentConfigSnapshot.id == WorkflowAgentNodeBinding.current_snapshot_id,
+                        sa.and_(
+                            WorkflowAgentNodeBinding.binding_type == WorkflowAgentBindingType.ROSTER_AGENT,
+                            AgentConfigSnapshot.id == Agent.active_config_snapshot_id,
+                        ),
+                    ),
+                ),
+            )
+            .where(
+                Workflow.tenant_id == app.tenant_id,
+                Workflow.app_id != app.id,
+                Workflow.version != Workflow.VERSION_DRAFT,
+                snapshot_text.contains(provider_id),
+            )
+        ).all()
+        for workflow_id, config_snapshot in snapshot_candidates:
+            try:
+                agent_soul = AgentSoulConfig.model_validate_json(config_snapshot)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Blocking deletion of workflow app %s because published workflow %s has an invalid Agent "
+                    "snapshot containing its workflow tool provider ID",
+                    app.id,
+                    workflow_id,
+                )
+                referencing_workflow_ids.add(workflow_id)
+                continue
+
+            if any(
+                tool.provider_type == ToolProviderType.WORKFLOW and tool.provider_id == provider_id
+                for tool in agent_soul.tools.dify_tools
+            ):
+                referencing_workflow_ids.add(workflow_id)
+
+        return sorted(referencing_workflow_ids)
+
     def delete_app(self, app: App, *, session: Session) -> None:
         """
         Delete app
         :param app: App instance
         """
+        referencing_workflow_ids = self._get_referencing_published_workflow_ids(app, session=session)
+        if referencing_workflow_ids:
+            reference_count = len(referencing_workflow_ids)
+            workflow_label = "workflow" if reference_count == 1 else "workflows"
+            raise WorkflowReferencedError(
+                f"Cannot delete workflow because it is referenced by {reference_count} published {workflow_label}. "
+                "Remove the references before deleting it."
+            )
+
         app_was_deleted.send(app)
 
         backing_agent = self._get_backing_agent_for_update(app, session=session)

--- a/api/services/errors/app.py
+++ b/api/services/errors/app.py
@@ -38,3 +38,9 @@ class TriggerNodeLimitExceededError(ValueError):
             f"Trigger node count ({count}) exceeds the limit ({limit}) for your subscription plan. "
             f"Please upgrade your plan or reduce the number of trigger nodes."
         )
+
+
+class WorkflowReferencedError(ValueError):
+    """Raised when a workflow app is referenced by published workflows."""
+
+    pass

--- a/api/tests/unit_tests/controllers/console/app/test_app_apis.py
+++ b/api/tests/unit_tests/controllers/console/app/test_app_apis.py
@@ -206,6 +206,29 @@ class TestCompletionEndpoints:
 
 
 class TestAppEndpoints:
+    def test_app_delete_maps_published_workflow_reference_to_bad_request(
+        self,
+        app: Flask,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        api = app_module.AppApi()
+        method = unwrap(api.delete)
+        app_service = MagicMock()
+        app_service.delete_app.side_effect = app_module.WorkflowReferencedError(
+            "Cannot delete workflow because it is referenced by 1 published workflow."
+        )
+        monkeypatch.setattr(app_module, "AppService", lambda: app_service)
+        session = MagicMock(spec=Session)
+        app_model = _make_app()
+
+        with (
+            app.test_request_context(f"/console/api/apps/{APP_ID}", method="DELETE"),
+            pytest.raises(BadRequest, match="referenced by 1 published workflow"),
+        ):
+            method(api, session, app_model=app_model)
+
+        app_service.delete_app.assert_called_once_with(app_model, session=session)
+
     def test_app_put_should_preserve_icon_type_when_payload_omits_it(self, app: Flask, monkeypatch: pytest.MonkeyPatch):
         api = app_module.AppApi()
         method = unwrap(api.put)

--- a/api/tests/unit_tests/services/test_app_service.py
+++ b/api/tests/unit_tests/services/test_app_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Callable
 from datetime import datetime
 from types import SimpleNamespace
@@ -12,12 +13,31 @@ from sqlalchemy import event
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from core.tools.entities.tool_entities import ToolProviderType
 from graphon.model_runtime.entities.model_entities import ModelType
 from models import Account
+from models.agent import (
+    Agent,
+    AgentConfigSnapshot,
+    AgentKind,
+    AgentScope,
+    AgentSource,
+    AgentStatus,
+    WorkflowAgentBindingType,
+    WorkflowAgentNodeBinding,
+)
+from models.agent_config_entities import (
+    AgentSoulConfig,
+    AgentSoulDifyToolConfig,
+    AgentSoulToolsConfig,
+    WorkflowNodeJobConfig,
+)
 from models.model import App, AppMode, AppModelConfig, IconType
-from models.workflow import Workflow
+from models.tools import WorkflowToolProvider
+from models.workflow import Workflow, WorkflowType
 from services.agent.errors import AgentNameConflictError
 from services.app_service import AppListParams, AppService, CreateAppParams
+from services.errors.app import WorkflowReferencedError
 
 
 class TestCreateAppTransactionBoundary:
@@ -700,6 +720,7 @@ class TestAgentAppType:
         with (
             patch("services.app_service.db") as mock_db,
             patch("services.app_service.current_user", SimpleNamespace(id="account-2")),
+            patch.object(AppService, "_get_referencing_published_workflow_ids", return_value=[]),
             patch("services.app_service.AgentWorkspaceService.retire_all_for_app", return_value=["workspace-1"]),
             patch("services.app_service.WorkflowAgentRetirementService.retire_unowned") as retire_unowned,
             patch("services.app_service.enqueue_agent_resource_collection") as enqueue_collection,
@@ -715,3 +736,311 @@ class TestAgentAppType:
 
         retire_unowned.assert_not_called()
         enqueue_collection.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "sqlite_session",
+    [(App, Workflow, WorkflowToolProvider, Agent, WorkflowAgentNodeBinding, AgentConfigSnapshot)],
+    indirect=True,
+)
+class TestDeleteWorkflowAppReferences:
+    @staticmethod
+    def _create_app(*, app_id: str, tenant_id: str = "tenant-1", name: str | None = None) -> App:
+        return App(
+            id=app_id,
+            tenant_id=tenant_id,
+            name=name or app_id,
+            description="",
+            mode=AppMode.WORKFLOW,
+            enable_site=True,
+            enable_api=True,
+            max_active_requests=0,
+        )
+
+    @staticmethod
+    def _create_workflow(
+        *,
+        workflow_id: str,
+        app_id: str,
+        graph: dict[str, object],
+        tenant_id: str = "tenant-1",
+        version: str = "v1",
+    ) -> Workflow:
+        return Workflow(
+            id=workflow_id,
+            tenant_id=tenant_id,
+            app_id=app_id,
+            type=WorkflowType.WORKFLOW,
+            version=version,
+            graph=json.dumps(graph),
+            features=json.dumps({}),
+            created_by="user-1",
+            environment_variables=[],
+            conversation_variables=[],
+            rag_pipeline_variables=[],
+        )
+
+    @staticmethod
+    def _create_provider(*, app_id: str, tenant_id: str = "tenant-1") -> WorkflowToolProvider:
+        provider = WorkflowToolProvider(
+            name=f"tool-{app_id}",
+            label="Workflow Tool",
+            icon="icon.svg",
+            app_id=app_id,
+            version="v1",
+            user_id="user-1",
+            tenant_id=tenant_id,
+            description="Test provider",
+            parameter_configuration="[]",
+        )
+        provider.id = str(uuid4())
+        return provider
+
+    @pytest.mark.parametrize("reference_shape", ["tool", "agent-tools", "agent-parameters"])
+    def test_delete_app_is_blocked_before_side_effects_when_published_workflow_references_it(
+        self,
+        sqlite_session: Session,
+        reference_shape: str,
+    ):
+        target_app = self._create_app(app_id="target-app")
+        consumer_app = self._create_app(app_id="consumer-app")
+        provider = self._create_provider(app_id=target_app.id)
+
+        if reference_shape == "tool":
+            node_data: dict[str, object] = {
+                "type": "tool",
+                "provider_type": "workflow",
+                "provider_id": provider.id,
+            }
+        elif reference_shape == "agent-tools":
+            node_data = {
+                "type": "agent",
+                "tools": [
+                    {
+                        "provider_type": "workflow",
+                        "provider_id": provider.id,
+                    }
+                ],
+            }
+        else:
+            node_data = {
+                "type": "agent",
+                "tools": [],
+                "agent_parameters": {
+                    "tools": {
+                        "value": [
+                            {
+                                "type": "workflow",
+                                "provider_name": provider.id,
+                            }
+                        ]
+                    }
+                },
+            }
+
+        consumer_workflow = self._create_workflow(
+            workflow_id="consumer-workflow",
+            app_id=consumer_app.id,
+            graph={"nodes": [{"id": "node-1", "data": node_data}], "edges": []},
+        )
+        consumer_app.workflow_id = consumer_workflow.id
+        sqlite_session.add_all([target_app, consumer_app, provider, consumer_workflow])
+        sqlite_session.commit()
+
+        with (
+            patch("services.app_service.app_was_deleted.send") as app_deleted_signal,
+            pytest.raises(WorkflowReferencedError, match="referenced by 1 published workflow"),
+        ):
+            AppService().delete_app(target_app, session=sqlite_session)
+
+        app_deleted_signal.assert_not_called()
+        assert sqlite_session.get(App, target_app.id) is not None
+
+    def test_draft_workflow_reference_does_not_block_deletion(self, sqlite_session: Session):
+        target_app = self._create_app(app_id="target-app")
+        consumer_app = self._create_app(app_id="consumer-app")
+        provider = self._create_provider(app_id=target_app.id)
+        draft_workflow = self._create_workflow(
+            workflow_id="consumer-draft",
+            app_id=consumer_app.id,
+            version=Workflow.VERSION_DRAFT,
+            graph={
+                "nodes": [
+                    {
+                        "id": "tool-node",
+                        "data": {
+                            "type": "tool",
+                            "provider_type": "workflow",
+                            "provider_id": provider.id,
+                        },
+                    }
+                ],
+                "edges": [],
+            },
+        )
+        sqlite_session.add_all([target_app, consumer_app, provider, draft_workflow])
+        sqlite_session.commit()
+
+        referencing_ids = AppService._get_referencing_published_workflow_ids(target_app, session=sqlite_session)
+
+        assert referencing_ids == []
+
+    def test_historical_published_workflow_reference_blocks_deletion(self, sqlite_session: Session):
+        target_app = self._create_app(app_id="target-app")
+        consumer_app = self._create_app(app_id="consumer-app")
+        provider = self._create_provider(app_id=target_app.id)
+        historical_workflow = self._create_workflow(
+            workflow_id="consumer-history",
+            app_id=consumer_app.id,
+            version="v1",
+            graph={
+                "nodes": [
+                    {
+                        "id": "tool-node",
+                        "data": {
+                            "type": "tool",
+                            "provider_type": "workflow",
+                            "provider_id": provider.id,
+                        },
+                    }
+                ],
+                "edges": [],
+            },
+        )
+        current_workflow = self._create_workflow(
+            workflow_id="consumer-current",
+            app_id=consumer_app.id,
+            version="v2",
+            graph={"nodes": [], "edges": []},
+        )
+        consumer_app.workflow_id = current_workflow.id
+        sqlite_session.add_all([target_app, consumer_app, provider, historical_workflow, current_workflow])
+        sqlite_session.commit()
+
+        referencing_ids = AppService._get_referencing_published_workflow_ids(target_app, session=sqlite_session)
+
+        assert referencing_ids == [historical_workflow.id]
+
+    @pytest.mark.parametrize(
+        ("binding_type", "active_snapshot_references", "bound_snapshot_references"),
+        [
+            (WorkflowAgentBindingType.ROSTER_AGENT, True, False),
+            (WorkflowAgentBindingType.ROSTER_AGENT, False, True),
+            (WorkflowAgentBindingType.INLINE_AGENT, False, True),
+        ],
+    )
+    def test_agent_v2_snapshot_reference_counts_as_published_workflow_reference(
+        self,
+        sqlite_session: Session,
+        binding_type: WorkflowAgentBindingType,
+        active_snapshot_references: bool,
+        bound_snapshot_references: bool,
+    ):
+        target_app = self._create_app(app_id="target-app")
+        consumer_app = self._create_app(app_id="consumer-app")
+        provider = self._create_provider(app_id=target_app.id)
+        published_workflow = self._create_workflow(
+            workflow_id="consumer-workflow",
+            app_id=consumer_app.id,
+            graph={"nodes": [{"id": "agent-node", "data": {"type": "agent", "version": "2"}}], "edges": []},
+        )
+        consumer_app.workflow_id = published_workflow.id
+        referenced_snapshot = AgentConfigSnapshot(
+            tenant_id=consumer_app.tenant_id,
+            agent_id="agent-1",
+            version=2,
+            config_snapshot=AgentSoulConfig(
+                tools=AgentSoulToolsConfig(
+                    dify_tools=[
+                        AgentSoulDifyToolConfig(
+                            provider_type=ToolProviderType.WORKFLOW,
+                            provider_id=provider.id,
+                            credential_type="unauthorized",
+                        )
+                    ]
+                )
+            ),
+            created_by="user-1",
+        )
+        referenced_snapshot.id = str(uuid4())
+        stale_snapshot = AgentConfigSnapshot(
+            tenant_id=consumer_app.tenant_id,
+            agent_id="agent-1",
+            version=1,
+            config_snapshot=AgentSoulConfig(),
+            created_by="user-1",
+        )
+        stale_snapshot.id = str(uuid4())
+        agent = Agent(
+            id="agent-1",
+            tenant_id=consumer_app.tenant_id,
+            name="Agent",
+            description="",
+            role="",
+            agent_kind=AgentKind.DIFY_AGENT,
+            scope=(
+                AgentScope.ROSTER if binding_type == WorkflowAgentBindingType.ROSTER_AGENT else AgentScope.WORKFLOW_ONLY
+            ),
+            source=AgentSource.ROSTER
+            if binding_type == WorkflowAgentBindingType.ROSTER_AGENT
+            else AgentSource.WORKFLOW,
+            status=AgentStatus.ACTIVE,
+            active_config_snapshot_id=(referenced_snapshot.id if active_snapshot_references else stale_snapshot.id),
+        )
+        binding = WorkflowAgentNodeBinding(
+            tenant_id=consumer_app.tenant_id,
+            app_id=consumer_app.id,
+            workflow_id=published_workflow.id,
+            workflow_version=published_workflow.version,
+            node_id="agent-node",
+            binding_type=binding_type,
+            agent_id="agent-1",
+            current_snapshot_id=(referenced_snapshot.id if bound_snapshot_references else stale_snapshot.id),
+            node_job_config=WorkflowNodeJobConfig(),
+            created_by="user-1",
+            updated_by="user-1",
+        )
+        sqlite_session.add_all(
+            [
+                target_app,
+                consumer_app,
+                provider,
+                published_workflow,
+                agent,
+                referenced_snapshot,
+                stale_snapshot,
+                binding,
+            ]
+        )
+        sqlite_session.commit()
+
+        referencing_ids = AppService._get_referencing_published_workflow_ids(target_app, session=sqlite_session)
+
+        assert referencing_ids == [published_workflow.id]
+
+    def test_provider_id_in_unrelated_node_does_not_count_as_reference(self, sqlite_session: Session):
+        target_app = self._create_app(app_id="target-app")
+        consumer_app = self._create_app(app_id="consumer-app")
+        provider = self._create_provider(app_id=target_app.id)
+        published_workflow = self._create_workflow(
+            workflow_id="consumer-workflow",
+            app_id=consumer_app.id,
+            graph={
+                "nodes": [
+                    {
+                        "id": "llm-node",
+                        "data": {
+                            "type": "llm",
+                            "title": provider.id,
+                        },
+                    }
+                ],
+                "edges": [],
+            },
+        )
+        sqlite_session.add_all([target_app, consumer_app, provider, published_workflow])
+        sqlite_session.commit()
+
+        referencing_ids = AppService._get_referencing_published_workflow_ids(target_app, session=sqlite_session)
+
+        assert referencing_ids == []


### PR DESCRIPTION
## Summary

- block workflow/chatflow app deletion when its workflow tool provider is still referenced by any published workflow version
- validate direct tool nodes, legacy and current Agent tool configurations, and Agent v2 bound/active snapshots
- return a clear HTTP 400 before any deletion side effects and report the number of referencing workflows

Fixes #39140

## Screenshots

Not applicable (backend validation only).

## Validation

- `pytest ...::TestDeleteWorkflowAppReferences ...::test_app_delete_maps_published_workflow_reference_to_bad_request` — 10 passed
- existing app deletion and deletion-signal regressions — 4 passed
- Ruff format/check — passed
- Pyrefly on changed backend files — 0 errors

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] Documentation is not required for this backend deletion guard.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods