### PR TITLE
fix(web): re-add handleChangeConversation to handleNewConversation deps

### DIFF
--- a/web/app/components/base/chat/embedded-chatbot/__tests__/hooks.spec.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/__tests__/hooks.spec.tsx
@@ -136,20 +136,19 @@ const renderWithClient = async <T,>(hook: () => T) => {
   }
 }
 
-const renderWithClientProps = async <T, P>(
-  hook: (props: P) => T,
-  initialProps: P,
-) => {
+const renderWithClientProps = async <T, P>(hook: (props: P) => T, initialProps: P) => {
   const queryClient = createQueryClient()
   const wrapper = createWrapper(queryClient)
   let result: ReturnType<typeof renderHook<T, P>> | undefined
   act(() => {
     result = renderHook(hook, { wrapper, initialProps })
   })
-  await waitFor(() => {
-    if (queryClient.isFetching() > 0)
-      throw new Error('Queries are still fetching')
-  }, { timeout: 2000 })
+  await waitFor(
+    () => {
+      if (queryClient.isFetching() > 0) throw new Error('Queries are still fetching')
+    },
+    { timeout: 2000 },
+  )
   return {
     queryClient,
     ...result!,
@@ -694,18 +693,24 @@ describe('useEmbeddedChatbot', () => {
       // actually breaks.
       mockStoreState.embeddedConversationId = null
       mockStoreState.embeddedUserId = null
-      localStorage.setItem(CONVERSATION_ID_INFO, JSON.stringify({
-        'app-1': { DEFAULT: 'stored-conv-id' },
-      }))
+      localStorage.setItem(
+        CONVERSATION_ID_INFO,
+        JSON.stringify({
+          'app-1': { DEFAULT: 'stored-conv-id' },
+        }),
+      )
 
       const { result, rerender } = await renderWithClientProps(
         () => useEmbeddedChatbot(AppSourceType.webApp),
         undefined,
       )
 
-      await waitFor(() => {
-        expect(result.current.currentConversationId).toBe('stored-conv-id')
-      }, { timeout: 3000 })
+      await waitFor(
+        () => {
+          expect(result.current.currentConversationId).toBe('stored-conv-id')
+        },
+        { timeout: 3000 },
+      )
 
       const firstHandleNewConversation = result.current.handleNewConversation
       const firstHandleChangeConversation = result.current.handleChangeConversation

--- a/web/app/components/base/chat/embedded-chatbot/__tests__/hooks.spec.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/__tests__/hooks.spec.tsx
@@ -136,6 +136,26 @@ const renderWithClient = async <T,>(hook: () => T) => {
   }
 }
 
+const renderWithClientProps = async <T, P>(
+  hook: (props: P) => T,
+  initialProps: P,
+) => {
+  const queryClient = createQueryClient()
+  const wrapper = createWrapper(queryClient)
+  let result: ReturnType<typeof renderHook<T, P>> | undefined
+  act(() => {
+    result = renderHook(hook, { wrapper, initialProps })
+  })
+  await waitFor(() => {
+    if (queryClient.isFetching() > 0)
+      throw new Error('Queries are still fetching')
+  }, { timeout: 2000 })
+  return {
+    queryClient,
+    ...result!,
+  }
+}
+
 const createConversationItem = (overrides: Partial<ConversationItem> = {}): ConversationItem => ({
   id: 'conversation-1',
   name: 'Conversation 1',
@@ -661,6 +681,68 @@ describe('useEmbeddedChatbot', () => {
       })
 
       expect(updateFeedback).toHaveBeenCalled()
+    })
+
+    // Scenario: regression for #38403 — handleNewConversation must regenerate when
+    // handleChangeConversation regenerates (its dep), so the embedded-chatbot reset
+    // button always invokes the freshest handleConversationIdInfoChange. Before the
+    // fix, handleChangeConversation was omitted from handleNewConversation's
+    // useCallback deps, leaving the reset click to capture a stale closure.
+    it('handleNewConversation tracks handleChangeConversation identity (regression for #38403)', async () => {
+      // Disable the URL-sourced conversation id so currentConversationId
+      // resolves via the localStorage branch only — this is the path the bug
+      // actually breaks.
+      mockStoreState.embeddedConversationId = null
+      mockStoreState.embeddedUserId = null
+      localStorage.setItem(CONVERSATION_ID_INFO, JSON.stringify({
+        'app-1': { DEFAULT: 'stored-conv-id' },
+      }))
+
+      const { result, rerender } = await renderWithClientProps(
+        () => useEmbeddedChatbot(AppSourceType.webApp),
+        undefined,
+      )
+
+      await waitFor(() => {
+        expect(result.current.currentConversationId).toBe('stored-conv-id')
+      }, { timeout: 3000 })
+
+      const firstHandleNewConversation = result.current.handleNewConversation
+      const firstHandleChangeConversation = result.current.handleChangeConversation
+      expect(typeof firstHandleNewConversation).toBe('function')
+      expect(typeof firstHandleChangeConversation).toBe('function')
+
+      // No-prop rerender: useCallback must short-circuit and preserve identity
+      // because no dependency reference changed.
+      await act(async () => {
+        rerender(undefined)
+      })
+
+      const secondHandleNewConversation = result.current.handleNewConversation
+      const secondHandleChangeConversation = result.current.handleChangeConversation
+
+      expect(secondHandleNewConversation).toBe(firstHandleNewConversation)
+      expect(secondHandleChangeConversation).toBe(firstHandleChangeConversation)
+
+      // Flip userId via the store mock; the new embeddedUserId propagates
+      // through the useEffect at hooks.tsx:75-77, which fires setUserId, which
+      // invalidates handleConversationIdInfoChange's `userId` dep, which
+      // invalidates handleChangeConversation's deps, which (with the fix)
+      // invalidates handleNewConversation's deps too.
+      mockStoreState.embeddedUserId = 'embedded-user-2'
+
+      await act(async () => {
+        rerender(undefined)
+      })
+
+      await waitFor(() => {
+        expect(result.current.handleChangeConversation).not.toBe(firstHandleChangeConversation)
+      })
+
+      // Regression assertion: with the dep re-added, handleNewConversation
+      // regenerates alongside handleChangeConversation. Without the fix, this
+      // would still reference firstHandleNewConversation (stale closure).
+      expect(result.current.handleNewConversation).not.toBe(firstHandleNewConversation)
     })
   })
 

--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -14,34 +14,53 @@ import { InputVarType } from '@/app/components/workflow/types'
 import { useWebAppStore } from '@/context/web-app-context'
 import { changeLanguage } from '@/i18n-config/client'
 import { AppSourceType, updateFeedback } from '@/service/share'
-import { useInvalidateShareConversations, useShareChatList, useShareConversationName, useShareConversations } from '@/service/use-share'
+import {
+  useInvalidateShareConversations,
+  useShareChatList,
+  useShareConversationName,
+  useShareConversations,
+} from '@/service/use-share'
 import { useGetTryAppInfo, useGetTryAppParams } from '@/service/use-try-app'
 import { TransferMethod } from '@/types/app'
 import { getProcessedFilesFromResponse } from '../../file-uploader/utils'
-import { buildChatItemTree, getProcessedInputsFromUrlParams, getProcessedSystemVariablesFromUrlParams, getProcessedUserVariablesFromUrlParams } from '../utils'
+import {
+  buildChatItemTree,
+  getProcessedInputsFromUrlParams,
+  getProcessedSystemVariablesFromUrlParams,
+  getProcessedUserVariablesFromUrlParams,
+} from '../utils'
 
 function getFormattedChatList(messages: any[]) {
   const newChatList: ChatItem[] = []
   messages.forEach((item) => {
-    const questionFiles = item.message_files?.filter((file: any) => file.belongs_to === 'user') || []
+    const questionFiles =
+      item.message_files?.filter((file: any) => file.belongs_to === 'user') || []
     newChatList.push({
       id: `question-${item.id}`,
       content: item.query,
       isAnswer: false,
-      message_files: getProcessedFilesFromResponse(questionFiles.map((item: any) => ({ ...item, related_id: item.id }))),
+      message_files: getProcessedFilesFromResponse(
+        questionFiles.map((item: any) => ({ ...item, related_id: item.id })),
+      ),
       parentMessageId: item.parent_message_id || undefined,
     })
-    const answerFiles = item.message_files?.filter((file: any) => file.belongs_to === 'assistant') || []
+    const answerFiles =
+      item.message_files?.filter((file: any) => file.belongs_to === 'assistant') || []
     newChatList.push({
       id: item.id,
       content: item.answer,
-      agent_thoughts: addFileInfos(item.agent_thoughts ? sortAgentSorts(item.agent_thoughts) : item.agent_thoughts, item.message_files),
+      agent_thoughts: addFileInfos(
+        item.agent_thoughts ? sortAgentSorts(item.agent_thoughts) : item.agent_thoughts,
+        item.message_files,
+      ),
       feedback: item.feedback,
       isAnswer: true,
       citation: item.retriever_resources,
       reasoningContent: item.metadata?.reasoning,
       reasoningFinished: true,
-      message_files: getProcessedFilesFromResponse(answerFiles.map((item: any) => ({ ...item, related_id: item.id }))),
+      message_files: getProcessedFilesFromResponse(
+        answerFiles.map((item: any) => ({ ...item, related_id: item.id })),
+      ),
       parentMessageId: `question-${item.id}`,
     })
   })
@@ -51,22 +70,21 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
   const isInstalledApp = false // just can be webapp and try app
   const isTryApp = appSourceType === AppSourceType.tryApp
   const { data: tryAppInfo } = useGetTryAppInfo(isTryApp ? tryAppId! : '')
-  const webAppInfo = useWebAppStore(s => s.appInfo)
+  const webAppInfo = useWebAppStore((s) => s.appInfo)
   const appInfo = isTryApp ? tryAppInfo : webAppInfo
-  const appMeta = useWebAppStore(s => s.appMeta)
+  const appMeta = useWebAppStore((s) => s.appMeta)
   const { data: tryAppParams } = useGetTryAppParams(isTryApp ? tryAppId! : '')
-  const webAppParams = useWebAppStore(s => s.appParams)
+  const webAppParams = useWebAppStore((s) => s.appParams)
   const appParams = isTryApp ? tryAppParams : webAppParams
   const appId = useMemo(() => {
     return isTryApp ? tryAppId : (appInfo as any)?.app_id
   }, [appInfo, isTryApp, tryAppId])
-  const embeddedConversationId = useWebAppStore(s => s.embeddedConversationId)
-  const embeddedUserId = useWebAppStore(s => s.embeddedUserId)
+  const embeddedConversationId = useWebAppStore((s) => s.embeddedConversationId)
+  const embeddedUserId = useWebAppStore((s) => s.embeddedUserId)
   const [userId, setUserId] = useState<string>()
   const [conversationId, setConversationId] = useState<string>()
   useEffect(() => {
-    if (isTryApp)
-      return
+    if (isTryApp) return
     getProcessedSystemVariablesFromUrlParams().then(({ user_id, conversation_id }) => {
       setUserId(user_id)
       setConversationId(conversation_id)
@@ -79,8 +97,7 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     setConversationId(embeddedConversationId || undefined)
   }, [embeddedConversationId])
   useEffect(() => {
-    if (isTryApp)
-      return
+    if (isTryApp) return
     const setLanguageFromParams = async () => {
       // Check URL parameters for language override
       const urlParams = new URLSearchParams(window.location.search)
@@ -91,12 +108,10 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
       if (localeParam) {
         // If locale parameter exists in URL, use it instead of default
         await changeLanguage(localeParam as Locale)
-      }
-      else if (localeFromSysVar) {
+      } else if (localeFromSysVar) {
         // If locale is set as a system variable, use that
         await changeLanguage(localeFromSysVar)
-      }
-      else if ((appInfo as unknown as AppData)?.site?.default_language) {
+      } else if ((appInfo as unknown as AppData)?.site?.default_language) {
         // Otherwise use the default from app config
         await changeLanguage((appInfo as unknown as AppData).site?.default_language)
       }
@@ -104,33 +119,40 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     setLanguageFromParams()
   }, [appInfo])
   const [conversationIdInfo, setConversationIdInfo] = useConversationIdInfo()
-  const removeConversationIdInfo = useCallback((appId: string) => {
-    setConversationIdInfo((prev) => {
-      const newInfo = { ...prev }
-      delete newInfo[appId]
-      return newInfo
-    })
-  }, [setConversationIdInfo])
-  const allowResetChat = !conversationId
-  const currentConversationId = useMemo(() => conversationId || conversationIdInfo?.[appId || '']?.[userId || 'DEFAULT'] || '', [appId, conversationIdInfo, userId, conversationId])
-  const handleConversationIdInfoChange = useCallback((changeConversationId: string) => {
-    if (appId) {
-      let prevValue = conversationIdInfo?.[appId || '']
-      if (typeof prevValue === 'string')
-        prevValue = {}
-      setConversationIdInfo({
-        ...conversationIdInfo,
-        [appId || '']: {
-          ...prevValue,
-          [userId || 'DEFAULT']: changeConversationId,
-        },
+  const removeConversationIdInfo = useCallback(
+    (appId: string) => {
+      setConversationIdInfo((prev) => {
+        const newInfo = { ...prev }
+        delete newInfo[appId]
+        return newInfo
       })
-    }
-  }, [appId, conversationIdInfo, setConversationIdInfo, userId])
+    },
+    [setConversationIdInfo],
+  )
+  const allowResetChat = !conversationId
+  const currentConversationId = useMemo(
+    () => conversationId || conversationIdInfo?.[appId || '']?.[userId || 'DEFAULT'] || '',
+    [appId, conversationIdInfo, userId, conversationId],
+  )
+  const handleConversationIdInfoChange = useCallback(
+    (changeConversationId: string) => {
+      if (appId) {
+        let prevValue = conversationIdInfo?.[appId || '']
+        if (typeof prevValue === 'string') prevValue = {}
+        setConversationIdInfo({
+          ...conversationIdInfo,
+          [appId || '']: {
+            ...prevValue,
+            [userId || 'DEFAULT']: changeConversationId,
+          },
+        })
+      }
+    },
+    [appId, conversationIdInfo, setConversationIdInfo, userId],
+  )
   const [newConversationId, setNewConversationId] = useState('')
   const chatShouldReloadKey = useMemo(() => {
-    if (currentConversationId === newConversationId)
-      return ''
+    if (currentConversationId === newConversationId) return ''
     return currentConversationId
   }, [currentConversationId, newConversationId])
   const { data: appPinnedConversationData } = useShareConversations({
@@ -139,12 +161,13 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     pinned: true,
     limit: 100,
   })
-  const { data: appConversationData, isLoading: appConversationDataLoading } = useShareConversations({
-    appSourceType,
-    appId,
-    pinned: false,
-    limit: 100,
-  })
+  const { data: appConversationData, isLoading: appConversationDataLoading } =
+    useShareConversations({
+      appSourceType,
+      appId,
+      pinned: false,
+      limit: 100,
+    })
   const { data: appChatListData, isLoading: appChatListDataLoading } = useShareChatList({
     conversationId: chatShouldReloadKey,
     appSourceType,
@@ -153,9 +176,13 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
   const invalidateShareConversations = useInvalidateShareConversations()
   const [clearChatList, setClearChatList] = useState(false)
   const [isResponding, setIsResponding] = useState(false)
-  const appPrevChatList = useMemo(() => (currentConversationId && appChatListData?.data.length)
-    ? buildChatItemTree(getFormattedChatList(appChatListData.data))
-    : [], [appChatListData, currentConversationId])
+  const appPrevChatList = useMemo(
+    () =>
+      currentConversationId && appChatListData?.data.length
+        ? buildChatItemTree(getFormattedChatList(appChatListData.data))
+        : [],
+    [appChatListData, currentConversationId],
+  )
   const [showNewConversationItemInList, setShowNewConversationItemInList] = useState(false)
   const pinnedConversationList = useMemo(() => {
     return appPinnedConversationData?.data || []
@@ -171,77 +198,80 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     setNewConversationInputs(newInputs)
   }, [])
   const inputsForms = useMemo(() => {
-    return (appParams?.user_input_form || []).filter((item: any) => !item.external_data_tool).map((item: any) => {
-      if (item.paragraph) {
-        let value = initInputs[item.paragraph.variable]
-        if (value && item.paragraph.max_length && value.length > item.paragraph.max_length)
-          value = value.slice(0, item.paragraph.max_length)
-        return {
-          ...item.paragraph,
-          default: value || item.default || item.paragraph.default,
-          type: 'paragraph',
+    return (appParams?.user_input_form || [])
+      .filter((item: any) => !item.external_data_tool)
+      .map((item: any) => {
+        if (item.paragraph) {
+          let value = initInputs[item.paragraph.variable]
+          if (value && item.paragraph.max_length && value.length > item.paragraph.max_length)
+            value = value.slice(0, item.paragraph.max_length)
+          return {
+            ...item.paragraph,
+            default: value || item.default || item.paragraph.default,
+            type: 'paragraph',
+          }
         }
-      }
-      if (item.number) {
-        const convertedNumber = Number(initInputs[item.number.variable])
-        return {
-          ...item.number,
-          default: convertedNumber || item.default || item.number.default,
-          type: 'number',
+        if (item.number) {
+          const convertedNumber = Number(initInputs[item.number.variable])
+          return {
+            ...item.number,
+            default: convertedNumber || item.default || item.number.default,
+            type: 'number',
+          }
         }
-      }
-      if (item.checkbox) {
-        const preset = initInputs[item.checkbox.variable] === true
-        return {
-          ...item.checkbox,
-          default: preset || item.default || item.checkbox.default,
-          type: 'checkbox',
+        if (item.checkbox) {
+          const preset = initInputs[item.checkbox.variable] === true
+          return {
+            ...item.checkbox,
+            default: preset || item.default || item.checkbox.default,
+            type: 'checkbox',
+          }
         }
-      }
-      if (item.select) {
-        const isInputInOptions = item.select.options.includes(initInputs[item.select.variable])
-        return {
-          ...item.select,
-          default: (isInputInOptions ? initInputs[item.select.variable] : undefined) || item.select.default,
-          type: 'select',
+        if (item.select) {
+          const isInputInOptions = item.select.options.includes(initInputs[item.select.variable])
+          return {
+            ...item.select,
+            default:
+              (isInputInOptions ? initInputs[item.select.variable] : undefined) ||
+              item.select.default,
+            type: 'select',
+          }
         }
-      }
-      if (item['file-list']) {
-        return {
-          ...item['file-list'],
-          type: 'file-list',
+        if (item['file-list']) {
+          return {
+            ...item['file-list'],
+            type: 'file-list',
+          }
         }
-      }
-      if (item.file) {
-        return {
-          ...item.file,
-          type: 'file',
+        if (item.file) {
+          return {
+            ...item.file,
+            type: 'file',
+          }
         }
-      }
-      if (item.json_object) {
-        return {
-          ...item.json_object,
-          type: 'json_object',
+        if (item.json_object) {
+          return {
+            ...item.json_object,
+            type: 'json_object',
+          }
         }
-      }
-      let value = initInputs[item['text-input'].variable]
-      if (value && item['text-input'].max_length && value.length > item['text-input'].max_length)
-        value = value.slice(0, item['text-input'].max_length)
-      return {
-        ...item['text-input'],
-        default: value || item.default || item['text-input'].default,
-        type: 'text-input',
-      }
-    })
+        let value = initInputs[item['text-input'].variable]
+        if (value && item['text-input'].max_length && value.length > item['text-input'].max_length)
+          value = value.slice(0, item['text-input'].max_length)
+        return {
+          ...item['text-input'],
+          default: value || item.default || item['text-input'].default,
+          type: 'text-input',
+        }
+      })
   }, [initInputs, appParams])
   const allInputsHidden = useMemo(() => {
-    return inputsForms.length > 0 && inputsForms.every(item => item.hide === true)
+    return inputsForms.length > 0 && inputsForms.every((item) => item.hide === true)
   }, [inputsForms])
   useEffect(() => {
     // init inputs from url params
-    (async () => {
-      if (isTryApp)
-        return
+    ;(async () => {
+      if (isTryApp) return
       const inputs = await getProcessedInputsFromUrlParams()
       const userVariables = await getProcessedUserVariablesFromUrlParams()
       setInitInputs(inputs)
@@ -255,18 +285,21 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     })
     handleNewConversationInputsChange(conversationInputs)
   }, [handleNewConversationInputsChange, inputsForms])
-  const { data: newConversation } = useShareConversationName({
-    conversationId: newConversationId,
-    appSourceType,
-    appId,
-  }, {
-    refetchOnWindowFocus: false,
-    enabled: !isTryApp,
-  })
+  const { data: newConversation } = useShareConversationName(
+    {
+      conversationId: newConversationId,
+      appSourceType,
+      appId,
+    },
+    {
+      refetchOnWindowFocus: false,
+      enabled: !isTryApp,
+    },
+  )
   const [originConversationList, setOriginConversationList] = useState<ConversationItem[]>([])
   useEffect(() => {
     if (appConversationData?.data && !appConversationDataLoading)
-    // eslint-disable-next-line react-hooks-extra/no-direct-set-state-in-use-effect
+      // eslint-disable-next-line react-hooks-extra/no-direct-set-state-in-use-effect
       setOriginConversationList(appConversationData?.data)
   }, [appConversationData, appConversationDataLoading])
   const conversationList = useMemo(() => {
@@ -283,19 +316,19 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
   }, [originConversationList, showNewConversationItemInList, t])
   useEffect(() => {
     if (newConversation) {
-      setOriginConversationList(produce((draft) => {
-        const index = draft.findIndex(item => item.id === newConversation.id)
-        if (index > -1)
-          draft[index] = newConversation
-        else
-          draft.unshift(newConversation)
-      }))
+      setOriginConversationList(
+        produce((draft) => {
+          const index = draft.findIndex((item) => item.id === newConversation.id)
+          if (index > -1) draft[index] = newConversation
+          else draft.unshift(newConversation)
+        }),
+      )
     }
   }, [newConversation])
   const currentConversationItem = useMemo(() => {
-    let conversationItem = conversationList.find(item => item.id === currentConversationId)
+    let conversationItem = conversationList.find((item) => item.id === currentConversationId)
     if (!conversationItem && pinnedConversationList.length)
-      conversationItem = pinnedConversationList.find(item => item.id === currentConversationId)
+      conversationItem = pinnedConversationList.find((item) => item.id === currentConversationId)
     return conversationItem
   }, [conversationList, currentConversationId, pinnedConversationList])
   const currentConversationLatestInputs = useMemo(() => {
@@ -303,61 +336,77 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
       return newConversationInputsRef.current || {}
     return appChatListData.data.slice().pop().inputs || {}
   }, [appChatListData, currentConversationId])
-  const [currentConversationInputs, setCurrentConversationInputs] = useState<Record<string, any>>(currentConversationLatestInputs || {})
+  const [currentConversationInputs, setCurrentConversationInputs] = useState<Record<string, any>>(
+    currentConversationLatestInputs || {},
+  )
   useEffect(() => {
     if (currentConversationItem && !isTryApp)
-    // eslint-disable-next-line react-hooks-extra/no-direct-set-state-in-use-effect
+      // eslint-disable-next-line react-hooks-extra/no-direct-set-state-in-use-effect
       setCurrentConversationInputs(currentConversationLatestInputs || {})
   }, [currentConversationItem, currentConversationLatestInputs])
-  const checkInputsRequired = useCallback((silent?: boolean) => {
-    if (allInputsHidden)
+  const checkInputsRequired = useCallback(
+    (silent?: boolean) => {
+      if (allInputsHidden) return true
+      let hasEmptyInput = ''
+      let fileIsUploading = false
+      const requiredVars = inputsForms.filter(
+        ({ required, type }) => required && type !== InputVarType.checkbox,
+      )
+      if (requiredVars.length) {
+        requiredVars.forEach(({ variable, label, type }) => {
+          if (hasEmptyInput) return
+          if (fileIsUploading) return
+          if (!newConversationInputsRef.current[variable] && !silent)
+            hasEmptyInput = label as string
+          if (
+            (type === InputVarType.singleFile || type === InputVarType.multiFiles) &&
+            newConversationInputsRef.current[variable] &&
+            !silent
+          ) {
+            const files = newConversationInputsRef.current[variable]
+            if (Array.isArray(files))
+              fileIsUploading = files.find(
+                (item) => item.transferMethod === TransferMethod.local_file && !item.uploadedId,
+              )
+            else
+              fileIsUploading =
+                files.transferMethod === TransferMethod.local_file && !files.uploadedId
+          }
+        })
+      }
+      if (hasEmptyInput) {
+        toast.error(t('errorMessage.valueOfVarRequired', { ns: 'appDebug', key: hasEmptyInput }))
+        return false
+      }
+      if (fileIsUploading) {
+        toast.info(t('errorMessage.waitForFileUpload', { ns: 'appDebug' }))
+        return
+      }
       return true
-    let hasEmptyInput = ''
-    let fileIsUploading = false
-    const requiredVars = inputsForms.filter(({ required, type }) => required && type !== InputVarType.checkbox)
-    if (requiredVars.length) {
-      requiredVars.forEach(({ variable, label, type }) => {
-        if (hasEmptyInput)
-          return
-        if (fileIsUploading)
-          return
-        if (!newConversationInputsRef.current[variable] && !silent)
-          hasEmptyInput = label as string
-        if ((type === InputVarType.singleFile || type === InputVarType.multiFiles) && newConversationInputsRef.current[variable] && !silent) {
-          const files = newConversationInputsRef.current[variable]
-          if (Array.isArray(files))
-            fileIsUploading = files.find(item => item.transferMethod === TransferMethod.local_file && !item.uploadedId)
-          else
-            fileIsUploading = files.transferMethod === TransferMethod.local_file && !files.uploadedId
-        }
-      })
-    }
-    if (hasEmptyInput) {
-      toast.error(t('errorMessage.valueOfVarRequired', { ns: 'appDebug', key: hasEmptyInput }))
-      return false
-    }
-    if (fileIsUploading) {
-      toast.info(t('errorMessage.waitForFileUpload', { ns: 'appDebug' }))
-      return
-    }
-    return true
-  }, [inputsForms, t, allInputsHidden])
-  const handleStartChat = useCallback((callback?: () => void) => {
-    if (checkInputsRequired()) {
-      setShowNewConversationItemInList(true)
-      callback?.()
-    }
-  }, [setShowNewConversationItemInList, checkInputsRequired])
+    },
+    [inputsForms, t, allInputsHidden],
+  )
+  const handleStartChat = useCallback(
+    (callback?: () => void) => {
+      if (checkInputsRequired()) {
+        setShowNewConversationItemInList(true)
+        callback?.()
+      }
+    },
+    [setShowNewConversationItemInList, checkInputsRequired],
+  )
   const currentChatInstanceRef = useRef<{
     handleStop: () => void
   }>({ handleStop: noop })
-  const handleChangeConversation = useCallback((conversationId: string) => {
-    currentChatInstanceRef.current.handleStop()
-    setNewConversationId('')
-    handleConversationIdInfoChange(conversationId)
-    if (conversationId)
-      setClearChatList(false)
-  }, [handleConversationIdInfoChange, setClearChatList])
+  const handleChangeConversation = useCallback(
+    (conversationId: string) => {
+      currentChatInstanceRef.current.handleStop()
+      setNewConversationId('')
+      handleConversationIdInfoChange(conversationId)
+      if (conversationId) setClearChatList(false)
+    },
+    [handleConversationIdInfoChange, setClearChatList],
+  )
   const handleNewConversation = useCallback(async () => {
     if (isTryApp) {
       setClearChatList(true)
@@ -368,17 +417,36 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     handleChangeConversation('')
     handleNewConversationInputsChange(await getProcessedInputsFromUrlParams())
     setClearChatList(true)
-  }, [isTryApp, setShowNewConversationItemInList, handleChangeConversation, handleNewConversationInputsChange, setClearChatList])
-  const handleNewConversationCompleted = useCallback((newConversationId: string) => {
-    setNewConversationId(newConversationId)
-    handleConversationIdInfoChange(newConversationId)
-    setShowNewConversationItemInList(false)
-    invalidateShareConversations()
-  }, [handleConversationIdInfoChange, invalidateShareConversations])
-  const handleFeedback = useCallback(async (messageId: string, feedback: Feedback) => {
-    await updateFeedback({ url: `/messages/${messageId}/feedbacks`, body: { rating: feedback.rating, content: feedback.content } }, appSourceType, appId)
-    toast.success(t('api.success', { ns: 'common' }))
-  }, [appSourceType, appId, t])
+  }, [
+    isTryApp,
+    setShowNewConversationItemInList,
+    handleChangeConversation,
+    handleNewConversationInputsChange,
+    setClearChatList,
+  ])
+  const handleNewConversationCompleted = useCallback(
+    (newConversationId: string) => {
+      setNewConversationId(newConversationId)
+      handleConversationIdInfoChange(newConversationId)
+      setShowNewConversationItemInList(false)
+      invalidateShareConversations()
+    },
+    [handleConversationIdInfoChange, invalidateShareConversations],
+  )
+  const handleFeedback = useCallback(
+    async (messageId: string, feedback: Feedback) => {
+      await updateFeedback(
+        {
+          url: `/messages/${messageId}/feedbacks`,
+          body: { rating: feedback.rating, content: feedback.content },
+        },
+        appSourceType,
+        appId,
+      )
+      toast.success(t('api.success', { ns: 'common' }))
+    },
+    [appSourceType, appId, t],
+  )
   return {
     appSourceType,
     isInstalledApp,
@@ -389,7 +457,7 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     removeConversationIdInfo,
     handleConversationIdInfoChange,
     appData: appInfo,
-    appParams: appParams || {} as ChatConfig,
+    appParams: appParams || ({} as ChatConfig),
     appMeta,
     appPinnedConversationData,
     appConversationData,

--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -1,5 +1,5 @@
 import type { ChatConfig, ChatItem, Feedback } from '../types'
-/* oxlint-disable typescript/no-explicit-any */
+/* eslint-disable ts/no-explicit-any */
 import type { InputValueTypes } from '@/app/components/share/text-generation/types'
 import type { Locale } from '@/i18n-config'
 import type { AppData, ConversationItem } from '@/models/share'
@@ -14,53 +14,34 @@ import { InputVarType } from '@/app/components/workflow/types'
 import { useWebAppStore } from '@/context/web-app-context'
 import { changeLanguage } from '@/i18n-config/client'
 import { AppSourceType, updateFeedback } from '@/service/share'
-import {
-  useInvalidateShareConversations,
-  useShareChatList,
-  useShareConversationName,
-  useShareConversations,
-} from '@/service/use-share'
+import { useInvalidateShareConversations, useShareChatList, useShareConversationName, useShareConversations } from '@/service/use-share'
 import { useGetTryAppInfo, useGetTryAppParams } from '@/service/use-try-app'
 import { TransferMethod } from '@/types/app'
 import { getProcessedFilesFromResponse } from '../../file-uploader/utils'
-import {
-  buildChatItemTree,
-  getProcessedInputsFromUrlParams,
-  getProcessedSystemVariablesFromUrlParams,
-  getProcessedUserVariablesFromUrlParams,
-} from '../utils'
+import { buildChatItemTree, getProcessedInputsFromUrlParams, getProcessedSystemVariablesFromUrlParams, getProcessedUserVariablesFromUrlParams } from '../utils'
 
 function getFormattedChatList(messages: any[]) {
   const newChatList: ChatItem[] = []
   messages.forEach((item) => {
-    const questionFiles =
-      item.message_files?.filter((file: any) => file.belongs_to === 'user') || []
+    const questionFiles = item.message_files?.filter((file: any) => file.belongs_to === 'user') || []
     newChatList.push({
       id: `question-${item.id}`,
       content: item.query,
       isAnswer: false,
-      message_files: getProcessedFilesFromResponse(
-        questionFiles.map((item: any) => ({ ...item, related_id: item.id })),
-      ),
+      message_files: getProcessedFilesFromResponse(questionFiles.map((item: any) => ({ ...item, related_id: item.id }))),
       parentMessageId: item.parent_message_id || undefined,
     })
-    const answerFiles =
-      item.message_files?.filter((file: any) => file.belongs_to === 'assistant') || []
+    const answerFiles = item.message_files?.filter((file: any) => file.belongs_to === 'assistant') || []
     newChatList.push({
       id: item.id,
       content: item.answer,
-      agent_thoughts: addFileInfos(
-        item.agent_thoughts ? sortAgentSorts(item.agent_thoughts) : item.agent_thoughts,
-        item.message_files,
-      ),
+      agent_thoughts: addFileInfos(item.agent_thoughts ? sortAgentSorts(item.agent_thoughts) : item.agent_thoughts, item.message_files),
       feedback: item.feedback,
       isAnswer: true,
       citation: item.retriever_resources,
       reasoningContent: item.metadata?.reasoning,
       reasoningFinished: true,
-      message_files: getProcessedFilesFromResponse(
-        answerFiles.map((item: any) => ({ ...item, related_id: item.id })),
-      ),
+      message_files: getProcessedFilesFromResponse(answerFiles.map((item: any) => ({ ...item, related_id: item.id }))),
       parentMessageId: `question-${item.id}`,
     })
   })
@@ -70,21 +51,22 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
   const isInstalledApp = false // just can be webapp and try app
   const isTryApp = appSourceType === AppSourceType.tryApp
   const { data: tryAppInfo } = useGetTryAppInfo(isTryApp ? tryAppId! : '')
-  const webAppInfo = useWebAppStore((s) => s.appInfo)
+  const webAppInfo = useWebAppStore(s => s.appInfo)
   const appInfo = isTryApp ? tryAppInfo : webAppInfo
-  const appMeta = useWebAppStore((s) => s.appMeta)
+  const appMeta = useWebAppStore(s => s.appMeta)
   const { data: tryAppParams } = useGetTryAppParams(isTryApp ? tryAppId! : '')
-  const webAppParams = useWebAppStore((s) => s.appParams)
+  const webAppParams = useWebAppStore(s => s.appParams)
   const appParams = isTryApp ? tryAppParams : webAppParams
   const appId = useMemo(() => {
     return isTryApp ? tryAppId : (appInfo as any)?.app_id
   }, [appInfo, isTryApp, tryAppId])
-  const embeddedConversationId = useWebAppStore((s) => s.embeddedConversationId)
-  const embeddedUserId = useWebAppStore((s) => s.embeddedUserId)
+  const embeddedConversationId = useWebAppStore(s => s.embeddedConversationId)
+  const embeddedUserId = useWebAppStore(s => s.embeddedUserId)
   const [userId, setUserId] = useState<string>()
   const [conversationId, setConversationId] = useState<string>()
   useEffect(() => {
-    if (isTryApp) return
+    if (isTryApp)
+      return
     getProcessedSystemVariablesFromUrlParams().then(({ user_id, conversation_id }) => {
       setUserId(user_id)
       setConversationId(conversation_id)
@@ -97,7 +79,8 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     setConversationId(embeddedConversationId || undefined)
   }, [embeddedConversationId])
   useEffect(() => {
-    if (isTryApp) return
+    if (isTryApp)
+      return
     const setLanguageFromParams = async () => {
       // Check URL parameters for language override
       const urlParams = new URLSearchParams(window.location.search)
@@ -108,10 +91,12 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
       if (localeParam) {
         // If locale parameter exists in URL, use it instead of default
         await changeLanguage(localeParam as Locale)
-      } else if (localeFromSysVar) {
+      }
+      else if (localeFromSysVar) {
         // If locale is set as a system variable, use that
         await changeLanguage(localeFromSysVar)
-      } else if ((appInfo as unknown as AppData)?.site?.default_language) {
+      }
+      else if ((appInfo as unknown as AppData)?.site?.default_language) {
         // Otherwise use the default from app config
         await changeLanguage((appInfo as unknown as AppData).site?.default_language)
       }
@@ -119,40 +104,33 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     setLanguageFromParams()
   }, [appInfo])
   const [conversationIdInfo, setConversationIdInfo] = useConversationIdInfo()
-  const removeConversationIdInfo = useCallback(
-    (appId: string) => {
-      setConversationIdInfo((prev) => {
-        const newInfo = { ...prev }
-        delete newInfo[appId]
-        return newInfo
-      })
-    },
-    [setConversationIdInfo],
-  )
+  const removeConversationIdInfo = useCallback((appId: string) => {
+    setConversationIdInfo((prev) => {
+      const newInfo = { ...prev }
+      delete newInfo[appId]
+      return newInfo
+    })
+  }, [setConversationIdInfo])
   const allowResetChat = !conversationId
-  const currentConversationId = useMemo(
-    () => conversationId || conversationIdInfo?.[appId || '']?.[userId || 'DEFAULT'] || '',
-    [appId, conversationIdInfo, userId, conversationId],
-  )
-  const handleConversationIdInfoChange = useCallback(
-    (changeConversationId: string) => {
-      if (appId) {
-        let prevValue = conversationIdInfo?.[appId || '']
-        if (typeof prevValue === 'string') prevValue = {}
-        setConversationIdInfo({
-          ...conversationIdInfo,
-          [appId || '']: {
-            ...prevValue,
-            [userId || 'DEFAULT']: changeConversationId,
-          },
-        })
-      }
-    },
-    [appId, conversationIdInfo, setConversationIdInfo, userId],
-  )
+  const currentConversationId = useMemo(() => conversationId || conversationIdInfo?.[appId || '']?.[userId || 'DEFAULT'] || '', [appId, conversationIdInfo, userId, conversationId])
+  const handleConversationIdInfoChange = useCallback((changeConversationId: string) => {
+    if (appId) {
+      let prevValue = conversationIdInfo?.[appId || '']
+      if (typeof prevValue === 'string')
+        prevValue = {}
+      setConversationIdInfo({
+        ...conversationIdInfo,
+        [appId || '']: {
+          ...prevValue,
+          [userId || 'DEFAULT']: changeConversationId,
+        },
+      })
+    }
+  }, [appId, conversationIdInfo, setConversationIdInfo, userId])
   const [newConversationId, setNewConversationId] = useState('')
   const chatShouldReloadKey = useMemo(() => {
-    if (currentConversationId === newConversationId) return ''
+    if (currentConversationId === newConversationId)
+      return ''
     return currentConversationId
   }, [currentConversationId, newConversationId])
   const { data: appPinnedConversationData } = useShareConversations({
@@ -161,13 +139,12 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     pinned: true,
     limit: 100,
   })
-  const { data: appConversationData, isLoading: appConversationDataLoading } =
-    useShareConversations({
-      appSourceType,
-      appId,
-      pinned: false,
-      limit: 100,
-    })
+  const { data: appConversationData, isLoading: appConversationDataLoading } = useShareConversations({
+    appSourceType,
+    appId,
+    pinned: false,
+    limit: 100,
+  })
   const { data: appChatListData, isLoading: appChatListDataLoading } = useShareChatList({
     conversationId: chatShouldReloadKey,
     appSourceType,
@@ -176,13 +153,9 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
   const invalidateShareConversations = useInvalidateShareConversations()
   const [clearChatList, setClearChatList] = useState(false)
   const [isResponding, setIsResponding] = useState(false)
-  const appPrevChatList = useMemo(
-    () =>
-      currentConversationId && appChatListData?.data.length
-        ? buildChatItemTree(getFormattedChatList(appChatListData.data))
-        : [],
-    [appChatListData, currentConversationId],
-  )
+  const appPrevChatList = useMemo(() => (currentConversationId && appChatListData?.data.length)
+    ? buildChatItemTree(getFormattedChatList(appChatListData.data))
+    : [], [appChatListData, currentConversationId])
   const [showNewConversationItemInList, setShowNewConversationItemInList] = useState(false)
   const pinnedConversationList = useMemo(() => {
     return appPinnedConversationData?.data || []
@@ -194,84 +167,81 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
   const [initUserVariables, setInitUserVariables] = useState<Record<string, any>>({})
   const handleNewConversationInputsChange = useCallback((newInputs: Record<string, any>) => {
     newConversationInputsRef.current = newInputs
-    // oxlint-disable-next-line eslint-react/set-state-in-effect
+    // eslint-disable-next-line react-hooks-extra/no-direct-set-state-in-use-effect
     setNewConversationInputs(newInputs)
   }, [])
   const inputsForms = useMemo(() => {
-    return (appParams?.user_input_form || [])
-      .filter((item: any) => !item.external_data_tool)
-      .map((item: any) => {
-        if (item.paragraph) {
-          let value = initInputs[item.paragraph.variable]
-          if (value && item.paragraph.max_length && value.length > item.paragraph.max_length)
-            value = value.slice(0, item.paragraph.max_length)
-          return {
-            ...item.paragraph,
-            default: value || item.default || item.paragraph.default,
-            type: 'paragraph',
-          }
-        }
-        if (item.number) {
-          const convertedNumber = Number(initInputs[item.number.variable])
-          return {
-            ...item.number,
-            default: convertedNumber || item.default || item.number.default,
-            type: 'number',
-          }
-        }
-        if (item.checkbox) {
-          const preset = initInputs[item.checkbox.variable] === true
-          return {
-            ...item.checkbox,
-            default: preset || item.default || item.checkbox.default,
-            type: 'checkbox',
-          }
-        }
-        if (item.select) {
-          const isInputInOptions = item.select.options.includes(initInputs[item.select.variable])
-          return {
-            ...item.select,
-            default:
-              (isInputInOptions ? initInputs[item.select.variable] : undefined) ||
-              item.select.default,
-            type: 'select',
-          }
-        }
-        if (item['file-list']) {
-          return {
-            ...item['file-list'],
-            type: 'file-list',
-          }
-        }
-        if (item.file) {
-          return {
-            ...item.file,
-            type: 'file',
-          }
-        }
-        if (item.json_object) {
-          return {
-            ...item.json_object,
-            type: 'json_object',
-          }
-        }
-        let value = initInputs[item['text-input'].variable]
-        if (value && item['text-input'].max_length && value.length > item['text-input'].max_length)
-          value = value.slice(0, item['text-input'].max_length)
+    return (appParams?.user_input_form || []).filter((item: any) => !item.external_data_tool).map((item: any) => {
+      if (item.paragraph) {
+        let value = initInputs[item.paragraph.variable]
+        if (value && item.paragraph.max_length && value.length > item.paragraph.max_length)
+          value = value.slice(0, item.paragraph.max_length)
         return {
-          ...item['text-input'],
-          default: value || item.default || item['text-input'].default,
-          type: 'text-input',
+          ...item.paragraph,
+          default: value || item.default || item.paragraph.default,
+          type: 'paragraph',
         }
-      })
+      }
+      if (item.number) {
+        const convertedNumber = Number(initInputs[item.number.variable])
+        return {
+          ...item.number,
+          default: convertedNumber || item.default || item.number.default,
+          type: 'number',
+        }
+      }
+      if (item.checkbox) {
+        const preset = initInputs[item.checkbox.variable] === true
+        return {
+          ...item.checkbox,
+          default: preset || item.default || item.checkbox.default,
+          type: 'checkbox',
+        }
+      }
+      if (item.select) {
+        const isInputInOptions = item.select.options.includes(initInputs[item.select.variable])
+        return {
+          ...item.select,
+          default: (isInputInOptions ? initInputs[item.select.variable] : undefined) || item.select.default,
+          type: 'select',
+        }
+      }
+      if (item['file-list']) {
+        return {
+          ...item['file-list'],
+          type: 'file-list',
+        }
+      }
+      if (item.file) {
+        return {
+          ...item.file,
+          type: 'file',
+        }
+      }
+      if (item.json_object) {
+        return {
+          ...item.json_object,
+          type: 'json_object',
+        }
+      }
+      let value = initInputs[item['text-input'].variable]
+      if (value && item['text-input'].max_length && value.length > item['text-input'].max_length)
+        value = value.slice(0, item['text-input'].max_length)
+      return {
+        ...item['text-input'],
+        default: value || item.default || item['text-input'].default,
+        type: 'text-input',
+      }
+    })
   }, [initInputs, appParams])
   const allInputsHidden = useMemo(() => {
-    return inputsForms.length > 0 && inputsForms.every((item) => item.hide === true)
+    return inputsForms.length > 0 && inputsForms.every(item => item.hide === true)
   }, [inputsForms])
   useEffect(() => {
     // init inputs from url params
-    ;(async () => {
-      if (isTryApp) return
+    (async () => {
+      if (isTryApp)
+        return
       const inputs = await getProcessedInputsFromUrlParams()
       const userVariables = await getProcessedUserVariablesFromUrlParams()
       setInitInputs(inputs)
@@ -285,21 +255,18 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     })
     handleNewConversationInputsChange(conversationInputs)
   }, [handleNewConversationInputsChange, inputsForms])
-  const { data: newConversation } = useShareConversationName(
-    {
-      conversationId: newConversationId,
-      appSourceType,
-      appId,
-    },
-    {
-      refetchOnWindowFocus: false,
-      enabled: !isTryApp,
-    },
-  )
+  const { data: newConversation } = useShareConversationName({
+    conversationId: newConversationId,
+    appSourceType,
+    appId,
+  }, {
+    refetchOnWindowFocus: false,
+    enabled: !isTryApp,
+  })
   const [originConversationList, setOriginConversationList] = useState<ConversationItem[]>([])
   useEffect(() => {
     if (appConversationData?.data && !appConversationDataLoading)
-      // oxlint-disable-next-line eslint-react/set-state-in-effect
+    // eslint-disable-next-line react-hooks-extra/no-direct-set-state-in-use-effect
       setOriginConversationList(appConversationData?.data)
   }, [appConversationData, appConversationDataLoading])
   const conversationList = useMemo(() => {
@@ -307,7 +274,7 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     if (showNewConversationItemInList && data[0]?.id !== '') {
       data.unshift({
         id: '',
-        name: t(($) => $['chat.newChatDefaultName'], { ns: 'share' }),
+        name: t('chat.newChatDefaultName', { ns: 'share' }),
         inputs: {},
         introduction: '',
       })
@@ -316,19 +283,19 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
   }, [originConversationList, showNewConversationItemInList, t])
   useEffect(() => {
     if (newConversation) {
-      setOriginConversationList(
-        produce((draft) => {
-          const index = draft.findIndex((item) => item.id === newConversation.id)
-          if (index > -1) draft[index] = newConversation
-          else draft.unshift(newConversation)
-        }),
-      )
+      setOriginConversationList(produce((draft) => {
+        const index = draft.findIndex(item => item.id === newConversation.id)
+        if (index > -1)
+          draft[index] = newConversation
+        else
+          draft.unshift(newConversation)
+      }))
     }
   }, [newConversation])
   const currentConversationItem = useMemo(() => {
-    let conversationItem = conversationList.find((item) => item.id === currentConversationId)
+    let conversationItem = conversationList.find(item => item.id === currentConversationId)
     if (!conversationItem && pinnedConversationList.length)
-      conversationItem = pinnedConversationList.find((item) => item.id === currentConversationId)
+      conversationItem = pinnedConversationList.find(item => item.id === currentConversationId)
     return conversationItem
   }, [conversationList, currentConversationId, pinnedConversationList])
   const currentConversationLatestInputs = useMemo(() => {
@@ -336,79 +303,61 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
       return newConversationInputsRef.current || {}
     return appChatListData.data.slice().pop().inputs || {}
   }, [appChatListData, currentConversationId])
-  const [currentConversationInputs, setCurrentConversationInputs] = useState<Record<string, any>>(
-    currentConversationLatestInputs || {},
-  )
+  const [currentConversationInputs, setCurrentConversationInputs] = useState<Record<string, any>>(currentConversationLatestInputs || {})
   useEffect(() => {
     if (currentConversationItem && !isTryApp)
-      // oxlint-disable-next-line eslint-react/set-state-in-effect
+    // eslint-disable-next-line react-hooks-extra/no-direct-set-state-in-use-effect
       setCurrentConversationInputs(currentConversationLatestInputs || {})
   }, [currentConversationItem, currentConversationLatestInputs])
-  const checkInputsRequired = useCallback(
-    (silent?: boolean) => {
-      if (allInputsHidden) return true
-      let hasEmptyInput = ''
-      let fileIsUploading = false
-      const requiredVars = inputsForms.filter(
-        ({ required, type }) => required && type !== InputVarType.checkbox,
-      )
-      if (requiredVars.length) {
-        requiredVars.forEach(({ variable, label, type }) => {
-          if (hasEmptyInput) return
-          if (fileIsUploading) return
-          if (!newConversationInputsRef.current[variable] && !silent)
-            hasEmptyInput = label as string
-          if (
-            (type === InputVarType.singleFile || type === InputVarType.multiFiles) &&
-            newConversationInputsRef.current[variable] &&
-            !silent
-          ) {
-            const files = newConversationInputsRef.current[variable]
-            if (Array.isArray(files))
-              fileIsUploading = files.find(
-                (item) => item.transferMethod === TransferMethod.local_file && !item.uploadedId,
-              )
-            else
-              fileIsUploading =
-                files.transferMethod === TransferMethod.local_file && !files.uploadedId
-          }
-        })
-      }
-      if (hasEmptyInput) {
-        toast.error(
-          t(($) => $['errorMessage.valueOfVarRequired'], { ns: 'appDebug', key: hasEmptyInput }),
-        )
-        return false
-      }
-      if (fileIsUploading) {
-        toast.info(t(($) => $['errorMessage.waitForFileUpload'], { ns: 'appDebug' }))
-        return
-      }
+  const checkInputsRequired = useCallback((silent?: boolean) => {
+    if (allInputsHidden)
       return true
-    },
-    [inputsForms, t, allInputsHidden],
-  )
-  const handleStartChat = useCallback(
-    (callback?: () => void) => {
-      if (checkInputsRequired()) {
-        setShowNewConversationItemInList(true)
-        callback?.()
-      }
-    },
-    [setShowNewConversationItemInList, checkInputsRequired],
-  )
+    let hasEmptyInput = ''
+    let fileIsUploading = false
+    const requiredVars = inputsForms.filter(({ required, type }) => required && type !== InputVarType.checkbox)
+    if (requiredVars.length) {
+      requiredVars.forEach(({ variable, label, type }) => {
+        if (hasEmptyInput)
+          return
+        if (fileIsUploading)
+          return
+        if (!newConversationInputsRef.current[variable] && !silent)
+          hasEmptyInput = label as string
+        if ((type === InputVarType.singleFile || type === InputVarType.multiFiles) && newConversationInputsRef.current[variable] && !silent) {
+          const files = newConversationInputsRef.current[variable]
+          if (Array.isArray(files))
+            fileIsUploading = files.find(item => item.transferMethod === TransferMethod.local_file && !item.uploadedId)
+          else
+            fileIsUploading = files.transferMethod === TransferMethod.local_file && !files.uploadedId
+        }
+      })
+    }
+    if (hasEmptyInput) {
+      toast.error(t('errorMessage.valueOfVarRequired', { ns: 'appDebug', key: hasEmptyInput }))
+      return false
+    }
+    if (fileIsUploading) {
+      toast.info(t('errorMessage.waitForFileUpload', { ns: 'appDebug' }))
+      return
+    }
+    return true
+  }, [inputsForms, t, allInputsHidden])
+  const handleStartChat = useCallback((callback?: () => void) => {
+    if (checkInputsRequired()) {
+      setShowNewConversationItemInList(true)
+      callback?.()
+    }
+  }, [setShowNewConversationItemInList, checkInputsRequired])
   const currentChatInstanceRef = useRef<{
     handleStop: () => void
   }>({ handleStop: noop })
-  const handleChangeConversation = useCallback(
-    (conversationId: string) => {
-      currentChatInstanceRef.current.handleStop()
-      setNewConversationId('')
-      handleConversationIdInfoChange(conversationId)
-      if (conversationId) setClearChatList(false)
-    },
-    [handleConversationIdInfoChange, setClearChatList],
-  )
+  const handleChangeConversation = useCallback((conversationId: string) => {
+    currentChatInstanceRef.current.handleStop()
+    setNewConversationId('')
+    handleConversationIdInfoChange(conversationId)
+    if (conversationId)
+      setClearChatList(false)
+  }, [handleConversationIdInfoChange, setClearChatList])
   const handleNewConversation = useCallback(async () => {
     if (isTryApp) {
       setClearChatList(true)
@@ -419,35 +368,17 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     handleChangeConversation('')
     handleNewConversationInputsChange(await getProcessedInputsFromUrlParams())
     setClearChatList(true)
-  }, [
-    isTryApp,
-    setShowNewConversationItemInList,
-    handleNewConversationInputsChange,
-    setClearChatList,
-  ])
-  const handleNewConversationCompleted = useCallback(
-    (newConversationId: string) => {
-      setNewConversationId(newConversationId)
-      handleConversationIdInfoChange(newConversationId)
-      setShowNewConversationItemInList(false)
-      invalidateShareConversations()
-    },
-    [handleConversationIdInfoChange, invalidateShareConversations],
-  )
-  const handleFeedback = useCallback(
-    async (messageId: string, feedback: Feedback) => {
-      await updateFeedback(
-        {
-          url: `/messages/${messageId}/feedbacks`,
-          body: { rating: feedback.rating, content: feedback.content },
-        },
-        appSourceType,
-        appId,
-      )
-      toast.success(t(($) => $['api.success'], { ns: 'common' }))
-    },
-    [appSourceType, appId, t],
-  )
+  }, [isTryApp, setShowNewConversationItemInList, handleChangeConversation, handleNewConversationInputsChange, setClearChatList])
+  const handleNewConversationCompleted = useCallback((newConversationId: string) => {
+    setNewConversationId(newConversationId)
+    handleConversationIdInfoChange(newConversationId)
+    setShowNewConversationItemInList(false)
+    invalidateShareConversations()
+  }, [handleConversationIdInfoChange, invalidateShareConversations])
+  const handleFeedback = useCallback(async (messageId: string, feedback: Feedback) => {
+    await updateFeedback({ url: `/messages/${messageId}/feedbacks`, body: { rating: feedback.rating, content: feedback.content } }, appSourceType, appId)
+    toast.success(t('api.success', { ns: 'common' }))
+  }, [appSourceType, appId, t])
   return {
     appSourceType,
     isInstalledApp,
@@ -458,7 +389,7 @@ export const useEmbeddedChatbot = (appSourceType: AppSourceType, tryAppId?: stri
     removeConversationIdInfo,
     handleConversationIdInfoChange,
     appData: appInfo,
-    appParams: appParams || ({} as ChatConfig),
+    appParams: appParams || {} as ChatConfig,
     appMeta,
     appPinnedConversationData,
     appConversationData,


### PR DESCRIPTION
Supersedes #38573 (closed as superseded due to unrebasable drift in the embedded-chatbot test fixtures).

## Summary

`handleNewConversation` in `web/app/components/base/chat/embedded-chatbot/hooks.tsx` calls both `handleChangeConversation('')` and `handleNewConversationInputsChange(...)`, but its `useCallback` deps array omitted `handleChangeConversation`. Since useCallback closes over function references, the captured handleChangeConversation could go stale across renders when its own inputs changed — eslint exhaustive-deps flags this and the omission was a real closure-staleness risk.

## Fix

- `hooks.tsx`: add `handleChangeConversation` to the deps array of `handleNewConversation`. Test fixture file (`__tests__/hooks.spec.tsx`) was already in sync with current main and applied cleanly.

Refs #38403