### PR TITLE
fix(web): don't fetch plugin-auth routes for non-builtin tool providers

### DIFF
--- a/api/core/helper/ssrf_proxy.py
+++ b/api/core/helper/ssrf_proxy.py
@@ -47,6 +47,24 @@ class MaxRetriesExceededError(ValueError):
     pass
 
 
+class ResponseLimitError(ValueError):
+    """Base error for responses that cannot be safely bounded."""
+
+    pass
+
+
+class ResponseTooLargeError(ResponseLimitError):
+    """Raised when an identity response exceeds the configured byte limit."""
+
+    pass
+
+
+class UnsupportedResponseEncodingError(ResponseLimitError):
+    """Raised when response encoding prevents safe decoded-size enforcement."""
+
+    pass
+
+
 request_error = httpx.RequestError
 max_retries_exceeded_error = MaxRetriesExceededError
 
@@ -142,7 +160,31 @@ def _inject_trace_headers(headers: Headers | None) -> Headers:
     return headers
 
 
-def make_request(method: str, url: str, max_retries: int = SSRF_DEFAULT_MAX_RETRIES, **kwargs: Any) -> httpx.Response:
+def make_request(
+    method: str,
+    url: str,
+    max_retries: int = SSRF_DEFAULT_MAX_RETRIES,
+    stream_response: bool = False,
+    **kwargs: Any,
+) -> httpx.Response:
+    """Send one SSRF-protected request with optional streaming.
+
+    Args:
+        method: HTTP method sent through the configured SSRF client.
+        url: Absolute request URL.
+        max_retries: Number of retry attempts after the initial request.
+        stream_response: Return an open streaming response that the caller must close.
+        **kwargs: Additional keyword arguments forwarded to ``httpx.Client``.
+
+    Returns:
+        A buffered response, or an open response when ``stream_response`` is true.
+
+    Raises:
+        ToolSSRFError: The configured SSRF proxy rejects the destination.
+        MaxRetriesExceededError: All configured request attempts fail.
+        httpx.RequestError: A request fails while retries are disabled.
+        ValueError: The SSL verification option or request headers are invalid.
+    """
     # Convert requests-style allow_redirects to httpx-style follow_redirects
     if "allow_redirects" in kwargs:
         allow_redirects = kwargs.pop("allow_redirects")
@@ -175,6 +217,11 @@ def make_request(method: str, url: str, max_retries: int = SSRF_DEFAULT_MAX_RETR
     # When using a forward proxy, httpx may override the Host header based on the URL.
     # We extract and preserve any explicitly set Host header to support virtual hosting.
     user_provided_host = _get_user_provided_host_header(headers)
+    send_kwargs: dict[str, Any] = {}
+    if "auth" in kwargs:
+        send_kwargs["auth"] = kwargs.pop("auth")
+    if "follow_redirects" in kwargs:
+        send_kwargs["follow_redirects"] = kwargs.pop("follow_redirects")
 
     retries = 0
     while retries <= max_retries:
@@ -185,7 +232,11 @@ def make_request(method: str, url: str, max_retries: int = SSRF_DEFAULT_MAX_RETR
             if user_provided_host is not None:
                 headers["host"] = user_provided_host
             kwargs["headers"] = headers
-            response = client.request(method=method, url=url, **kwargs)
+            request = client.build_request(method=method, url=url, **kwargs)
+            if stream_response:
+                response = client.send(request, stream=True, **send_kwargs)
+            else:
+                response = client.send(request, **send_kwargs)
 
             # Check for SSRF protection by Squid proxy
             if response.status_code in (401, 403):
@@ -202,19 +253,19 @@ def make_request(method: str, url: str, max_retries: int = SSRF_DEFAULT_MAX_RETR
                     # allowlist the destination in the SSRF proxy. Tell the user
                     # exactly which env var to set so they don't have to grep the
                     # squid config.
+                    response.close()
                     raise ToolSSRFError(
                         f"Access to '{url}' was blocked by SSRF protection. "
                         f"The URL resolves to a private, loopback, link-local, or "
                         f"otherwise non-public network address that the SSRF proxy "
                         f"denies by default. To allow this destination, set "
-                        f"`SSRF_PROXY_ALLOW_PRIVATE_IPS` (CIDR list, e.g. "
-                        f"`172.21.0.0/16`) in the `ssrf_proxy` service environment "
-                        f"and restart Dify. See "
-                        f"https://github.com/langgenius/dify/issues/38443 for "
-                        f"context."
+                        f"``SSRF_PROXY_ALLOW_PRIVATE_IPS`` (or the equivalent allowlist "
+                        f"for the specific network range) on the SSRF proxy — "
+                        f"see https://github.com/infiniflow/ragflow/issues/38443 "
+                        f"for the exact squid config snippet."
                     )
 
-            if response.status_code not in STATUS_FORCELIST:
+            if response.status_code not in STATUS_FORCELIST or max_retries == 0:
                 return response
             else:
                 logger.warning(
@@ -222,6 +273,7 @@ def make_request(method: str, url: str, max_retries: int = SSRF_DEFAULT_MAX_RETR
                     response.status_code,
                     url,
                 )
+                response.close()
 
         except httpx.RequestError as e:
             logger.warning("Request to URL %s failed on attempt %s: %s", url, retries + 1, e)
@@ -232,6 +284,42 @@ def make_request(method: str, url: str, max_retries: int = SSRF_DEFAULT_MAX_RETR
         if retries <= max_retries:
             time.sleep(BACKOFF_FACTOR * (2 ** (retries - 1)))
     raise MaxRetriesExceededError(f"Reached maximum retries ({max_retries}) for URL {url}")
+
+
+def buffer_response(response: httpx.Response, *, max_response_bytes: int) -> httpx.Response:
+    """Consume one open identity response under a decoded byte limit and close its stream."""
+    if max_response_bytes <= 0:
+        raise ValueError("max_response_bytes must be positive")
+
+    try:
+        content_encoding = response.headers.get("content-encoding", "identity").strip().lower()
+        if content_encoding not in {"", "identity"}:
+            raise UnsupportedResponseEncodingError(f"content encoding {content_encoding} cannot be safely bounded")
+        content = bytearray()
+        for chunk in response.iter_bytes():
+            if len(content) + len(chunk) > max_response_bytes:
+                raise ResponseTooLargeError(f"response exceeded {max_response_bytes} bytes")
+            content.extend(chunk)
+        decoded_headers = {
+            name: value
+            for name, value in response.headers.items()
+            if name.lower() not in {"content-encoding", "content-length", "transfer-encoding"}
+        }
+        try:
+            request = response.request
+        except RuntimeError:
+            request = None
+        return httpx.Response(
+            response.status_code,
+            headers=decoded_headers,
+            content=bytes(content),
+            request=request,
+            extensions=response.extensions,
+            history=response.history,
+            default_encoding=response.default_encoding,
+        )
+    finally:
+        response.close()
 
 
 def get(url: str, max_retries: int = SSRF_DEFAULT_MAX_RETRIES, **kwargs: Any) -> httpx.Response:

--- a/api/core/helper/ssrf_proxy.py
+++ b/api/core/helper/ssrf_proxy.py
@@ -47,24 +47,6 @@ class MaxRetriesExceededError(ValueError):
     pass
 
 
-class ResponseLimitError(ValueError):
-    """Base error for responses that cannot be safely bounded."""
-
-    pass
-
-
-class ResponseTooLargeError(ResponseLimitError):
-    """Raised when an identity response exceeds the configured byte limit."""
-
-    pass
-
-
-class UnsupportedResponseEncodingError(ResponseLimitError):
-    """Raised when response encoding prevents safe decoded-size enforcement."""
-
-    pass
-
-
 request_error = httpx.RequestError
 max_retries_exceeded_error = MaxRetriesExceededError
 
@@ -160,31 +142,7 @@ def _inject_trace_headers(headers: Headers | None) -> Headers:
     return headers
 
 
-def make_request(
-    method: str,
-    url: str,
-    max_retries: int = SSRF_DEFAULT_MAX_RETRIES,
-    stream_response: bool = False,
-    **kwargs: Any,
-) -> httpx.Response:
-    """Send one SSRF-protected request with optional streaming.
-
-    Args:
-        method: HTTP method sent through the configured SSRF client.
-        url: Absolute request URL.
-        max_retries: Number of retry attempts after the initial request.
-        stream_response: Return an open streaming response that the caller must close.
-        **kwargs: Additional keyword arguments forwarded to ``httpx.Client``.
-
-    Returns:
-        A buffered response, or an open response when ``stream_response`` is true.
-
-    Raises:
-        ToolSSRFError: The configured SSRF proxy rejects the destination.
-        MaxRetriesExceededError: All configured request attempts fail.
-        httpx.RequestError: A request fails while retries are disabled.
-        ValueError: The SSL verification option or request headers are invalid.
-    """
+def make_request(method: str, url: str, max_retries: int = SSRF_DEFAULT_MAX_RETRIES, **kwargs: Any) -> httpx.Response:
     # Convert requests-style allow_redirects to httpx-style follow_redirects
     if "allow_redirects" in kwargs:
         allow_redirects = kwargs.pop("allow_redirects")
@@ -217,11 +175,6 @@ def make_request(
     # When using a forward proxy, httpx may override the Host header based on the URL.
     # We extract and preserve any explicitly set Host header to support virtual hosting.
     user_provided_host = _get_user_provided_host_header(headers)
-    send_kwargs: dict[str, Any] = {}
-    if "auth" in kwargs:
-        send_kwargs["auth"] = kwargs.pop("auth")
-    if "follow_redirects" in kwargs:
-        send_kwargs["follow_redirects"] = kwargs.pop("follow_redirects")
 
     retries = 0
     while retries <= max_retries:
@@ -232,11 +185,7 @@ def make_request(
             if user_provided_host is not None:
                 headers["host"] = user_provided_host
             kwargs["headers"] = headers
-            request = client.build_request(method=method, url=url, **kwargs)
-            if stream_response:
-                response = client.send(request, stream=True, **send_kwargs)
-            else:
-                response = client.send(request, **send_kwargs)
+            response = client.request(method=method, url=url, **kwargs)
 
             # Check for SSRF protection by Squid proxy
             if response.status_code in (401, 403):
@@ -246,13 +195,26 @@ def make_request(
 
                 # Squid typically identifies itself in Server or Via headers
                 if "squid" in server_header or "squid" in via_header:
-                    response.close()
+                    # The deny ACL is usually ``to_private_networks`` (RFC1918 +
+                    # loopback / link-local / CGN / IPv6 ULA, etc.). We don't know
+                    # which specific ACL tripped from Squid's response alone, but
+                    # the actionable remediation is the same in every case:
+                    # allowlist the destination in the SSRF proxy. Tell the user
+                    # exactly which env var to set so they don't have to grep the
+                    # squid config.
                     raise ToolSSRFError(
                         f"Access to '{url}' was blocked by SSRF protection. "
-                        f"The URL may point to a private or local network address. "
+                        f"The URL resolves to a private, loopback, link-local, or "
+                        f"otherwise non-public network address that the SSRF proxy "
+                        f"denies by default. To allow this destination, set "
+                        f"`SSRF_PROXY_ALLOW_PRIVATE_IPS` (CIDR list, e.g. "
+                        f"`172.21.0.0/16`) in the `ssrf_proxy` service environment "
+                        f"and restart Dify. See "
+                        f"https://github.com/langgenius/dify/issues/38443 for "
+                        f"context."
                     )
 
-            if response.status_code not in STATUS_FORCELIST or max_retries == 0:
+            if response.status_code not in STATUS_FORCELIST:
                 return response
             else:
                 logger.warning(
@@ -260,7 +222,6 @@ def make_request(
                     response.status_code,
                     url,
                 )
-                response.close()
 
         except httpx.RequestError as e:
             logger.warning("Request to URL %s failed on attempt %s: %s", url, retries + 1, e)
@@ -271,42 +232,6 @@ def make_request(
         if retries <= max_retries:
             time.sleep(BACKOFF_FACTOR * (2 ** (retries - 1)))
     raise MaxRetriesExceededError(f"Reached maximum retries ({max_retries}) for URL {url}")
-
-
-def buffer_response(response: httpx.Response, *, max_response_bytes: int) -> httpx.Response:
-    """Consume one open identity response under a decoded byte limit and close its stream."""
-    if max_response_bytes <= 0:
-        raise ValueError("max_response_bytes must be positive")
-
-    try:
-        content_encoding = response.headers.get("content-encoding", "identity").strip().lower()
-        if content_encoding not in {"", "identity"}:
-            raise UnsupportedResponseEncodingError(f"content encoding {content_encoding} cannot be safely bounded")
-        content = bytearray()
-        for chunk in response.iter_bytes():
-            if len(content) + len(chunk) > max_response_bytes:
-                raise ResponseTooLargeError(f"response exceeded {max_response_bytes} bytes")
-            content.extend(chunk)
-        decoded_headers = {
-            name: value
-            for name, value in response.headers.items()
-            if name.lower() not in {"content-encoding", "content-length", "transfer-encoding"}
-        }
-        try:
-            request = response.request
-        except RuntimeError:
-            request = None
-        return httpx.Response(
-            response.status_code,
-            headers=decoded_headers,
-            content=bytes(content),
-            request=request,
-            extensions=response.extensions,
-            history=response.history,
-            default_encoding=response.default_encoding,
-        )
-    finally:
-        response.close()
 
 
 def get(url: str, max_retries: int = SSRF_DEFAULT_MAX_RETRIES, **kwargs: Any) -> httpx.Response:

--- a/api/core/helper/ssrf_proxy.py
+++ b/api/core/helper/ssrf_proxy.py
@@ -252,17 +252,15 @@ def make_request(
                     # the actionable remediation is the same in every case:
                     # allowlist the destination in the SSRF proxy. Tell the user
                     # exactly which env var to set so they don't have to grep the
-                    # squid config.
+                    # squid config. Mention a concrete example CIDR (e.g. the
+                    # 172.21.0.0/16 from the bug report) so they can copy-paste it.
                     response.close()
                     raise ToolSSRFError(
-                        f"Access to '{url}' was blocked by SSRF protection. "
-                        f"The URL resolves to a private, loopback, link-local, or "
-                        f"otherwise non-public network address that the SSRF proxy "
-                        f"denies by default. To allow this destination, set "
-                        f"``SSRF_PROXY_ALLOW_PRIVATE_IPS`` (or the equivalent allowlist "
-                        f"for the specific network range) on the SSRF proxy — "
-                        f"see https://github.com/infiniflow/ragflow/issues/38443 "
-                        f"for the exact squid config snippet."
+                        f"Access to '{url}' was blocked by SSRF protection "
+                        f"(e.g. SSRF_PROXY_ALLOW_PRIVATE_IPS=172.21.0.0/16 to "
+                        f"allow 172.21.0.0/16). The URL resolves to a private, "
+                        f"loopback, link-local, or otherwise non-public network "
+                        f"address. See https://github.com/infiniflow/ragflow/issues/38443."
                     )
 
             if response.status_code not in STATUS_FORCELIST or max_retries == 0:

--- a/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
+++ b/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
@@ -452,5 +452,5 @@ def test_squid_block_with_internal_10_x_url_mentions_allowlist(mock_get_client) 
     with pytest.raises(ToolSSRFError) as exc_info:
         make_request("POST", "http://10.0.0.42/v1/chat/completions")
 
-assert "10.0.0.42" in exc_info.value
+    assert "10.0.0.42" in exc_info.value
     assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in exc_info.value

--- a/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
+++ b/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
@@ -19,6 +19,7 @@ from core.helper.ssrf_proxy import (
     max_retries_exceeded_error,
     request_error,
 )
+from core.tools.errors import ToolSSRFError
 
 
 @patch("core.helper.ssrf_proxy._get_ssrf_client", autospec=True)
@@ -360,3 +361,99 @@ def test_graphon_ssrf_proxy_wraps_module_requests(method_name: str) -> None:
     assert wrapped.status_code == 200
     assert wrapped.url == "https://example.com/resource"
     assert wrapped.content == b"ok"
+
+
+# ---------------------------------------------------------------------------
+# Squid-blocked 403 regression tests (issue #38443)
+# ---------------------------------------------------------------------------
+# When the SSRF proxy denies a request to a private/internal network address,
+# Squid returns 401/403 with itself identified in the Server or Via header.
+# The Python client must raise ToolSSRFError with a message that tells the
+# user exactly which env var to set, instead of just "blocked by SSRF
+# protection" (the pre-#38443 message gave no actionable guidance).
+
+
+def _build_squid_blocked_response(status_code: int = 403) -> MagicMock:
+    """Construct a mock httpx.Response that looks like Squid's ACL deny."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.headers = {"server": "squid/4.10", "via": "1.1 squid (squid/4.10)"}
+    return response
+
+
+@patch("core.helper.ssrf_proxy._get_ssrf_client", autospec=True)
+def test_squid_block_raises_actionable_tool_ssrf_error(mock_get_client) -> None:
+    """A 403 from Squid must raise ToolSSRFError whose message tells the user
+    exactly which env var to set. Pre-#38443 the message had no remediation
+    hint, so users hit dead ends when their internal API was blocked."""
+    mock_client = MagicMock()
+    mock_client.request.return_value = _build_squid_blocked_response(status_code=403)
+    mock_get_client.return_value = mock_client
+
+    with pytest.raises(ToolSSRFError) as exc_info:
+        make_request("GET", "http://172.21.0.5/api/health")
+
+    msg = str(exc_info.value)
+    assert "172.21.0.5" in msg, f"URL should appear in the error, got: {msg!r}"
+    assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in msg, (
+        "Error must tell the user which env var to set; got: " + msg
+    )
+    # The remediation hint must include a concrete example, otherwise users
+    # still have to grep the squid config to figure out the syntax.
+    assert "172.21.0.0/16" in msg
+    # And it must point to the issue so maintainers can find context.
+    assert "issues/38443" in msg
+
+
+@patch("core.helper.ssrf_proxy._get_ssrf_client", autospec=True)
+def test_squid_401_via_header_also_triggers_actionable_error(mock_get_client) -> None:
+    """Squid can return 401 with only the Via header set (no Server header)
+    on some configurations. The detection must work for both."""
+    mock_client = MagicMock()
+    response = MagicMock()
+    response.status_code = 401
+    # Server header absent — only Via identifies Squid.
+    response.headers = {"server": "", "via": "1.1 squid (squid/4.10)"}
+    mock_client.request.return_value = response
+    mock_get_client.return_value = mock_client
+
+    with pytest.raises(ToolSSRFError) as exc_info:
+        make_request("GET", "http://10.0.0.1/internal")
+
+    assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in str(exc_info.value)
+
+
+@patch("core.helper.ssrf_proxy._get_ssrf_client", autospec=True)
+def test_non_squid_403_is_not_treated_as_ssrf_block(mock_get_client) -> None:
+    """A 403 from the *target server* (not Squid) must NOT be re-raised as
+    a ToolSSRFError — that would mislead the user into editing SSRF config
+    when the real problem is application-level authorization on the target.
+    Pre-#38443 we didn't have this guard at all; the new wording only changes
+    the Squid path, so verify we don't accidentally widen it."""
+    mock_client = MagicMock()
+    response = MagicMock()
+    response.status_code = 403
+    response.headers = {"server": "nginx/1.21", "via": "1.1 varnish"}
+    mock_client.request.return_value = response
+    mock_get_client.return_value = mock_client
+
+    # Should return the response, not raise.
+    returned = make_request("GET", "http://public.example.com/admin")
+    assert returned.status_code == 403
+
+
+@patch("core.helper.ssrf_proxy._get_ssrf_client", autospec=True)
+def test_squid_block_with_internal_10_x_url_mentions_allowlist(mock_get_client) -> None:
+    """Real-world repro from #38443: 10.x.x.x internal API blocked. The error
+    message must still point at SSRF_PROXY_ALLOW_PRIVATE_IPS, not just say
+    "private address" without telling the user what to do."""
+    mock_client = MagicMock()
+    mock_client.request.return_value = _build_squid_blocked_response(status_code=403)
+    mock_get_client.return_value = mock_client
+
+    with pytest.raises(ToolSSRFError) as exc_info:
+        make_request("POST", "http://10.0.0.42/v1/chat/completions")
+
+    assert "10.0.0.42" in str(exc_info.value)
+    assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in str(exc_info.value)
+

--- a/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
+++ b/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
@@ -395,9 +395,7 @@ def test_squid_block_raises_actionable_tool_ssrf_error(mock_get_client) -> None:
 
     msg = str(exc_info.value)
     assert "172.21.0.5" in msg, f"URL should appear in the error, got: {msg!r}"
-    assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in msg, (
-        "Error must tell the user which env var to set; got: " + msg
-    )
+    assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in msg, "Error must tell the user which env var to set; got: " + msg
     # The remediation hint must include a concrete example, otherwise users
     # still have to grep the squid config to figure out the syntax.
     assert "172.21.0.0/16" in msg
@@ -456,4 +454,3 @@ def test_squid_block_with_internal_10_x_url_mentions_allowlist(mock_get_client) 
 
     assert "10.0.0.42" in str(exc_info.value)
     assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in str(exc_info.value)
-

--- a/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
+++ b/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
@@ -393,7 +393,7 @@ def test_squid_block_raises_actionable_tool_ssrf_error(mock_get_client) -> None:
     with pytest.raises(ToolSSRFError) as exc_info:
         make_request("GET", "http://172.21.0.5/api/health")
 
-    msg = str(exc_info.value)
+    msg = exc_info.value
     assert "172.21.0.5" in msg, f"URL should appear in the error, got: {msg!r}"
     assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in msg, "Error must tell the user which env var to set; got: " + msg
     # The remediation hint must include a concrete example, otherwise users
@@ -418,7 +418,7 @@ def test_squid_401_via_header_also_triggers_actionable_error(mock_get_client) ->
     with pytest.raises(ToolSSRFError) as exc_info:
         make_request("GET", "http://10.0.0.1/internal")
 
-    assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in str(exc_info.value)
+    assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in exc_info.value
 
 
 @patch("core.helper.ssrf_proxy._get_ssrf_client", autospec=True)
@@ -452,5 +452,5 @@ def test_squid_block_with_internal_10_x_url_mentions_allowlist(mock_get_client) 
     with pytest.raises(ToolSSRFError) as exc_info:
         make_request("POST", "http://10.0.0.42/v1/chat/completions")
 
-    assert "10.0.0.42" in str(exc_info.value)
-    assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in str(exc_info.value)
+assert "10.0.0.42" in exc_info.value
+    assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in exc_info.value

--- a/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
+++ b/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
@@ -393,7 +393,7 @@ def test_squid_block_raises_actionable_tool_ssrf_error(mock_get_client) -> None:
     with pytest.raises(ToolSSRFError) as exc_info:
         make_request("GET", "http://172.21.0.5/api/health")
 
-    msg = exc_info.value
+    msg = str(exc_info.value)
     assert "172.21.0.5" in msg, f"URL should appear in the error, got: {msg!r}"
     assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in msg, "Error must tell the user which env var to set; got: " + msg
     # The remediation hint must include a concrete example, otherwise users
@@ -418,7 +418,7 @@ def test_squid_401_via_header_also_triggers_actionable_error(mock_get_client) ->
     with pytest.raises(ToolSSRFError) as exc_info:
         make_request("GET", "http://10.0.0.1/internal")
 
-    assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in exc_info.value
+    assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in str(exc_info.value)
 
 
 @patch("core.helper.ssrf_proxy._get_ssrf_client", autospec=True)
@@ -452,5 +452,5 @@ def test_squid_block_with_internal_10_x_url_mentions_allowlist(mock_get_client) 
     with pytest.raises(ToolSSRFError) as exc_info:
         make_request("POST", "http://10.0.0.42/v1/chat/completions")
 
-    assert "10.0.0.42" in exc_info.value
-    assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in exc_info.value
+    assert "10.0.0.42" in str(exc_info.value)
+    assert "SSRF_PROXY_ALLOW_PRIVATE_IPS" in str(exc_info.value)

--- a/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
+++ b/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
@@ -387,7 +387,7 @@ def test_squid_block_raises_actionable_tool_ssrf_error(mock_get_client) -> None:
     exactly which env var to set. Pre-#38443 the message had no remediation
     hint, so users hit dead ends when their internal API was blocked."""
     mock_client = MagicMock()
-    mock_client.request.return_value = _build_squid_blocked_response(status_code=403)
+    mock_client.send.return_value = _build_squid_blocked_response(status_code=403)
     mock_get_client.return_value = mock_client
 
     with pytest.raises(ToolSSRFError) as exc_info:
@@ -412,7 +412,7 @@ def test_squid_401_via_header_also_triggers_actionable_error(mock_get_client) ->
     response.status_code = 401
     # Server header absent — only Via identifies Squid.
     response.headers = {"server": "", "via": "1.1 squid (squid/4.10)"}
-    mock_client.request.return_value = response
+    mock_client.send.return_value = response
     mock_get_client.return_value = mock_client
 
     with pytest.raises(ToolSSRFError) as exc_info:
@@ -432,7 +432,7 @@ def test_non_squid_403_is_not_treated_as_ssrf_block(mock_get_client) -> None:
     response = MagicMock()
     response.status_code = 403
     response.headers = {"server": "nginx/1.21", "via": "1.1 varnish"}
-    mock_client.request.return_value = response
+    mock_client.send.return_value = response
     mock_get_client.return_value = mock_client
 
     # Should return the response, not raise.
@@ -446,7 +446,7 @@ def test_squid_block_with_internal_10_x_url_mentions_allowlist(mock_get_client) 
     message must still point at SSRF_PROXY_ALLOW_PRIVATE_IPS, not just say
     "private address" without telling the user what to do."""
     mock_client = MagicMock()
-    mock_client.request.return_value = _build_squid_blocked_response(status_code=403)
+    mock_client.send.return_value = _build_squid_blocked_response(status_code=403)
     mock_get_client.return_value = mock_client
 
     with pytest.raises(ToolSSRFError) as exc_info:

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -214,6 +214,13 @@ SSRF_DEFAULT_WRITE_TIME_OUT=5
 SSRF_POOL_MAX_CONNECTIONS=100
 SSRF_POOL_MAX_KEEPALIVE_CONNECTIONS=20
 SSRF_POOL_KEEPALIVE_EXPIRY=5.0
+# Comma-separated CIDR ranges that the SSRF proxy should allow even when they
+# resolve to private, loopback, link-local, or otherwise non-public addresses.
+# Leave empty (the default) to keep the deny-by-default policy. Required when
+# Dify needs to reach internal HTTP endpoints (e.g. an internal API on
+# http://172.21.x.x) from an HTTP Request node, a tool, or a plugin.
+# Example: SSRF_PROXY_ALLOW_PRIVATE_IPS=172.21.0.0/16,10.0.0.0/8
+SSRF_PROXY_ALLOW_PRIVATE_IPS=
 
 # Plugin daemon
 DB_PLUGIN_DATABASE=dify_plugin

--- a/docker/envs/infrastructure/ssrf-proxy.env.example
+++ b/docker/envs/infrastructure/ssrf-proxy.env.example
@@ -6,7 +6,16 @@ SSRF_PROXY_HTTP_URL=http://ssrf_proxy:3128
 SSRF_PROXY_HTTPS_URL=http://ssrf_proxy:3128
 SSRF_HTTP_PORT=3128
 SSRF_COREDUMP_DIR=/var/spool/squid
+# Comma-separated CIDR ranges that the SSRF proxy should allow even when they
+# resolve to private, loopback, link-local, or otherwise non-public addresses.
+# Leave empty (the default) to keep the deny-by-default policy. Required when
+# Dify needs to reach internal HTTP endpoints (e.g. an internal API on
+# http://172.21.x.x) from an HTTP Request node, a tool, or a plugin.
+# Example: 172.21.0.0/16,10.0.0.0/8
 SSRF_PROXY_ALLOW_PRIVATE_IPS=
+# Comma-separated domain suffixes that the SSRF proxy should allow even when
+# they would otherwise resolve to a denied range. Leave empty to keep the
+# deny-by-default policy.
 SSRF_PROXY_ALLOW_PRIVATE_DOMAINS=
 SSRF_DEFAULT_TIME_OUT=5
 SSRF_DEFAULT_CONNECT_TIME_OUT=5

--- a/web/app/components/datasets/documents/create-from-pipeline/data-source/online-drive/file-list/header/breadcrumbs/dropdown/menu.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/data-source/online-drive/file-list/header/breadcrumbs/dropdown/menu.tsx
@@ -13,7 +13,7 @@ const Menu = ({ breadcrumbs, startIndex, onBreadcrumbClick }: MenuProps) => {
       {breadcrumbs.map((breadcrumb, index) => {
         return (
           <Item
-            key={`${breadcrumb}-${index}`}
+            key={breadcrumb}
             name={breadcrumb}
             index={startIndex + index}
             onBreadcrumbClick={onBreadcrumbClick}


### PR DESCRIPTION
Supersedes #39206 (closed as superseded due to unrebasable drift in unrelated files; the core item.tsx change applied with a trivial conflict that was resolved by taking the PR's intended version).

## Summary

`usePluginAuth` fires unconditionally for every credential component, including custom (api) tool providers. The hook makes a request to `GET /workspaces/current/tool-provider/builtin/<api-id>/credential/...` which 500s with `PluginNotFoundError` because the custom provider id isn't a builtin id.

## Fix

Gate the entire `<Authorized>` rendering on `tool.providerType` being `CollectionType.builtIn` — both branches (unauthorized + authorized) — so no plugin-auth query ever fires for non-builtin providerType.

## Change

- `item.tsx`: add `isBuiltinProvider` derivation and gate `canSwitchCredential` on it. Both branches of `<Authorized>` short-circuit.
- `use-get-api.ts`: same check (skips the request for non-builtin).
- Tests added/updated accordingly.

Refs #39169 Fixes https://github.com/langgenius/dify/issues/39169