### PR TITLE
fix(web): stop logging expected 401s from anonymous SSR console requests

### DIFF
--- a/web/service/__tests__/server.spec.ts
+++ b/web/service/__tests__/server.spec.ts
@@ -102,4 +102,50 @@ describe('server console oRPC client', () => {
     expect(request.headers.get('cookie')).toBe('access_token=abc; csrf_token=csrf-token')
     expect(request.headers.get('X-CSRF-Token')).toBe('csrf-token')
   })
+
+  it('should not log expected 401 Unauthorized responses from anonymous SSR requests', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ code: 'unauthorized', message: 'Unauthorized' }), {
+        status: 401,
+        headers: {
+          'content-type': 'application/json',
+        },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { getServerConsoleClientContext, serverConsoleClient } = await import('../server')
+
+    await expect(
+      serverConsoleClient.systemFeatures.get(undefined, {
+        context: await getServerConsoleClientContext(),
+      }),
+    ).rejects.toThrow()
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('should still log unexpected non-401 errors from SSR requests', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ code: 'internal_server_error', message: 'boom' }), {
+        status: 500,
+        headers: {
+          'content-type': 'application/json',
+        },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { getServerConsoleClientContext, serverConsoleClient } = await import('../server')
+
+    await expect(
+      serverConsoleClient.systemFeatures.get(undefined, {
+        context: await getServerConsoleClientContext(),
+      }),
+    ).rejects.toThrow()
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
+    consoleErrorSpy.mockRestore()
+  })
 })

--- a/web/service/server.ts
+++ b/web/service/server.ts
@@ -2,7 +2,7 @@ import type { consoleRouterContract } from '@dify/contracts/api/console/router.g
 import type { ClientLink } from '@orpc/client'
 import type { AnyContractRouter, ContractRouterClient } from '@orpc/contract'
 import type { JsonifiedClient } from '@orpc/openapi-client'
-import { createORPCClient, onError } from '@orpc/client'
+import { createORPCClient, onError, ORPCError } from '@orpc/client'
 import { OpenAPILink } from '@orpc/openapi-client/fetch'
 import { createTanstackQueryUtils } from '@orpc/tanstack-query'
 import { cache } from 'react'
@@ -78,6 +78,10 @@ function createServerConsoleOpenAPILink(contract: AnyContractRouter): ServerCons
     },
     interceptors: [
       onError((error) => {
+        // Anonymous SSR requests (e.g. public pages, health probes) are expected to hit
+        // this 401 — it's handled by callers, so logging it just spams the container output.
+        if (error instanceof ORPCError && error.status === 401) return
+
         console.error(error)
       }),
     ],


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #39719

Every page under `(commonLayout)` prefetches account/workspace data server-side through `serverConsoleClient` (`web/service/server.ts`) before the user's session is known. For anonymous visitors this SSR prefetch legitimately gets a `401 Unauthorized` from the API, which `CommonLayoutHydrationBoundary` (`web/app/(commonLayout)/hydration-boundary.tsx`) already handles gracefully (redirect to `/signin` or `/install`).

However, the oRPC `onError` interceptor used by the server console client unconditionally called `console.error(error)` for *every* request error, including these expected 401s. Because this SSR fetch runs inside the `web` container's Node process, every anonymous page load (or load-balancer health probe) produced an "Unauthorized" error line in the container logs — exactly what's reported in the issue, and confirmed as "expected/handled but noisy" by the `@dosu` bot's own investigation on the issue thread.

This PR makes the interceptor skip logging only for `ORPCError`s with `status === 401` (the case that's already handled by callers), while still logging any other unexpected error so real failures aren't silenced.

## Changes

- `web/service/server.ts`: skip `console.error` in the server console oRPC client's `onError` interceptor when the error is an `ORPCError` with `status === 401`.
- `web/service/__tests__/server.spec.ts`: added a regression test proving 401 responses are no longer logged, and a companion test proving other error statuses (e.g. 500) are still logged.

## Test plan

Ran the added tests against the pre-fix code (`git checkout HEAD~1 -- web/service/server.ts`) to confirm they fail without the change:

```
❯ service/__tests__/server.spec.ts (5 tests | 1 failed)
  × should not log expected 401 Unauthorized responses from anonymous SSR requests
AssertionError: expected "error" to not be called at all, but actually been called 1 times
```

With the fix restored:

```
$ pnpm vp test -- service/__tests__/server.spec.ts service/client.spec.ts
 Test Files  2 passed (2)
      Tests  37 passed (37)
```

Full `service/` suite:

```
$ pnpm vp test -- service/
 Test Files  23 passed (23)
      Tests  138 passed (138)
```

Static checks:

```
$ pnpm exec vp check service/server.ts service/__tests__/server.spec.ts
pass: All 2 files are correctly formatted
pass: Found no warnings, lint errors, or type errors in 2 files
```

## Screenshots

Not applicable — this is a server-side logging fix with no UI change.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Claude
