### PR TITLE
chore(api): fix typos in config description and comment

### DIFF
--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -870,7 +870,7 @@ class WorkflowVariableTruncationConfig(BaseSettings):
     )
     WORKFLOW_VARIABLE_TRUNCATION_STRING_LENGTH: PositiveInt = Field(
         100000,
-        description="maximum length for string to trigger tuncation, measure in number of characters",
+        description="maximum length for string to trigger truncation, measure in number of characters",
     )
     WORKFLOW_VARIABLE_TRUNCATION_ARRAY_LENGTH: PositiveInt = Field(
         1000,

--- a/api/controllers/console/human_input_form.py
+++ b/api/controllers/console/human_input_form.py
@@ -137,7 +137,7 @@ class ConsoleHumanInputFormApi(Resource):
         self._ensure_console_access(form, current_tenant_id)
         self._ensure_console_recipient_type(form)
         recipient_type = form.recipient_type
-        # The type checker is not smart enought to validate the following invariant.
+        # The type checker is not smart enough to validate the following invariant.
         # So we need to assert it manually.
         assert recipient_type is not None, "recipient_type cannot be None here."
 


### PR DESCRIPTION
## Summary

- Correct `tuncation` to `truncation` in the workflow variable truncation configuration description.
- Correct `enought` to `enough` in a console human-input form comment.
- This typo-only change does not alter control flow, configuration values, or functional behavior. No issue is linked under the pull request template's typo exemption.

Validation completed:

- `git diff --check`
- `.venv\Scripts\ruff.exe format --check api/configs/feature/__init__.py api/controllers/console/human_input_form.py`
- `.venv\Scripts\ruff.exe check api/configs/feature/__init__.py api/controllers/console/human_input_form.py`
- `.venv\Scripts\codespell.exe api/configs/feature/__init__.py api/controllers/console/human_input_form.py`
- `.venv\Scripts\python.exe` AST parsing for both changed files

Tests were not added because the changes only correct spelling in descriptive metadata and a comment, with no executable behavior change.

## Screenshots

Not applicable; this change does not affect the UI.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Codex
