### PR TITLE
fix(api): bound billing service HTTP timeouts (#39874)

### DIFF
--- a/api/services/billing_service.py
+++ b/api/services/billing_service.py
@@ -21,7 +21,10 @@ logger = logging.getLogger(__name__)
 
 _http_client: httpx.Client = get_pooled_http_client(
     "billing:default",
-    lambda: httpx.Client(limits=httpx.Limits(max_keepalive_connections=50, max_connections=100)),
+    lambda: httpx.Client(
+        timeout=httpx.Timeout(30.0, connect=5.0),
+        limits=httpx.Limits(max_keepalive_connections=50, max_connections=100),
+    ),
 )
 
 

--- a/api/tests/unit_tests/services/test_billing_service.py
+++ b/api/tests/unit_tests/services/test_billing_service.py
@@ -2055,3 +2055,17 @@ class TestBillingServiceSubscriptionInfoDataType:
 
         with pytest.raises(ValidationError):
             BillingService.get_info("tenant-type-test")
+
+
+def test_pooled_billing_client_carries_bounded_timeout() -> None:
+    """Regression for #39874: the pooled billing client must carry a
+    read/connect timeout so a stalled Stripe / cloud-billing proxy
+    fails fast instead of pinning a worker. Same shape as the
+    JinaReader / WaterCrawl hardening that landed in PR #39860 and #39824.
+    """
+    import services.billing_service as billing_service_module
+
+    client = billing_service_module._http_client
+    assert client.timeout is not None
+    assert client.timeout.read == 30.0
+    assert client.timeout.connect == 5.0


### PR DESCRIPTION
Fixes #39874.

## Summary

`_http_client` in `api/services/billing_service.py` was a pooled `httpx.Client` constructed with no `timeout=`, and the single call site at line 434 (`_http_client.request(method, url, ...)`) did not pass a per-call override either. A stalled Stripe / cloud-billing proxy could pin a worker indefinitely and surface as a 30-second-or-longer HTTP timeout to the console user. Added `httpx.Timeout(30.0, connect=5.0)` at client construction.

## Why it matters

Billing is a hard dependency for cloud-edition tenants. A request that blocks on the billing API surfaces as a long HTTP timeout to the console user, and the worker thread is tied up for the duration. On self-hosted deployments with a proxy in front of the billing endpoint, an internal-network partition can pin a worker indefinitely — there is no upper bound on the wait.

The fix is the same shape as the in-flight sibling PRs that apply the same hardening to other outbound HTTP clients:

- JinaReader / adaptive-crawl PR #39860 (issue #39859) — the same floor used here
- Notion #39832
- Firecrawl #39830
- WaterCrawl credential validation #39824
- WaterCrawl extractor (the original hardening in PR #37512)

## Changes

- `api/services/billing_service.py` — added `httpx.Timeout(30.0, connect=5.0)` to the constructor of the pooled `_http_client`. Same value as the prior hardening PRs.
- `api/tests/unit_tests/services/test_billing_service.py` — new `test_pooled_billing_client_carries_bounded_timeout` confirming `_http_client.timeout` is non-`None` with the documented read and connect bounds.

The single call site at line 434 inherits the bounded timeout automatically. The existing retry decorator at line 420 (`retry=retry_if_exception_type(httpx.RequestError)`) already covers transient failures; a `httpx.TimeoutException` raised by the bounded client triggers the same retry path and the existing exponential backoff.

## Verification

```
cd api
.venv/bin/python -m pytest tests/unit_tests/services/test_billing_service.py -q
# 107 passed, 3 warnings in 14.50s  (106 existing + 1 new)

.venv/bin/python -m ruff check services/billing_service.py tests/unit_tests/services/test_billing_service.py
# All checks passed!

.venv/bin/python -m ruff format --check services/billing_service.py tests/unit_tests/services/test_billing_service.py
# 2 files already formatted
```

Direct confirmation of the fix:

```
>>> from services.billing_service import _http_client
>>> _http_client.timeout
Timeout(connect=5.0, read=30.0, write=30.0, pool=30.0)
```

## Scope

- One source line change.
- One new test confirming the configured timeouts.
- No API change, no schema change, no migration. Default behaviour for a fast, healthy billing endpoint is unchanged.

## Out of scope

A wider sweep of `api/services/` for any remaining un-bounded outbound HTTP. The billing service is the only known un-bounded site at the module-load level after this fix; the remaining `httpx` users either pass a per-call `timeout=` or run through the SSRF proxy which has its own bounds.
