### PR TITLE
fix(dify-agent): retry E2B Shellctl connects in transport

### DIFF
--- a/dify-agent/src/dify_agent/runtime_backend/e2b.py
+++ b/dify-agent/src/dify_agent/runtime_backend/e2b.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from e2b.connection_config import ApiParams
 
 E2B_MAX_ACTIVE_TIMEOUT_SECONDS = 60 * 60
+_SHELLCTL_CONNECT_RETRIES = 2
 
 
 class _E2BControlPlaneNotFoundError(RuntimeError):
@@ -306,6 +307,7 @@ class E2BExecutionBindingBackend:
             headers=headers,
             follow_redirects=True,
             timeout=httpx.Timeout(60.0),
+            transport=httpx.AsyncHTTPTransport(retries=_SHELLCTL_CONNECT_RETRIES),
         )
 
         def client_factory() -> ShellctlClientProtocol:

--- a/dify-agent/tests/local/dify_agent/runtime_backend/test_e2b.py
+++ b/dify-agent/tests/local/dify_agent/runtime_backend/test_e2b.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import cast
 
+import httpx2 as httpx
 import pytest
 
 from dify_agent.runtime_backend import (
@@ -254,3 +255,32 @@ async def test_e2b_checkpoint_uses_exact_source_runtime() -> None:
 
     assert snapshot_ref == "snapshot-source-1"
     assert source_sandbox.snapshots == 1
+
+
+@pytest.mark.anyio
+async def test_e2b_acquire_delegates_connect_retries_to_http_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    configured_retries: list[int] = []
+    transport = httpx.MockTransport(lambda _request: httpx.Response(500))
+
+    def create_transport(*, retries: int = 0) -> httpx.AsyncBaseTransport:
+        configured_retries.append(retries)
+        return transport
+
+    monkeypatch.setattr(httpx, "AsyncHTTPTransport", create_transport)
+    control = _ControlPlane()
+    sandbox = _Sandbox(sandbox_id="sandbox-1")
+    sandbox.files.paths.add("/home/dify/workspace")
+    control.sandboxes[sandbox.sandbox_id] = sandbox
+    backend = E2BExecutionBindingBackend(
+        control_plane=control,  # pyright: ignore[reportArgumentType]
+        template="prepared-template",
+        active_timeout_seconds=3600,
+    )
+
+    lease = await backend.acquire(sandbox.sandbox_id)
+
+    assert configured_retries == [2]
+    await backend.release(lease)
+    assert sandbox.pauses == [True]


### PR DESCRIPTION
## Summary

- retry transient E2B Shellctl connection failures in the HTTP transport
- keep retry policy scoped to the E2B data-plane client
- verify the configured transport retry count during Binding acquisition

## Root cause

An E2B Sandbox may be connectable through the control plane before its Shellctl endpoint is ready to accept a TCP/TLS connection. A first data-plane request can therefore fail with `ConnectError` or `ConnectTimeout` during resume startup.

Retrying the complete Shell adapter operation would re-enter the logical request and can expand its timeout. Connection readiness retries belong at the HTTP transport boundary instead.

## Implementation

- configure the E2B Shellctl `AsyncClient` with `AsyncHTTPTransport(retries=2)`
- preserve the existing Shell adapter behavior without adding an application-level retry loop
- rely on HTTPX transport semantics so only connection errors and connection timeouts are retried

## Impact

E2B Shellctl connections receive up to two additional connection attempts during transient startup races. Read failures, HTTP responses, and accepted Shell jobs are not retried.

Transport retries use per-connection timeouts; this change does not add a hard wall-clock deadline around the complete operation.

## Validation

- `make -C dify-agent check`
- Ruff format check for both changed files
- focused Python 3.12 E2B backend tests: 6 passed

## Scope

This PR changes only the E2B Runtime backend and its focused test. It contains no Config Layer changes and is independent of #39873.

From Codex
