### PR TITLE
fix(api): reject trailing newlines in is_valid_trace_id and GenericProviderID (#39880)

### DIFF
--- a/api/core/helper/trace_id_helper.py
+++ b/api/core/helper/trace_id_helper.py
@@ -22,7 +22,11 @@ def is_valid_trace_id(trace_id: str) -> bool:
 
     Requirements: 1-128 characters, only letters, numbers, '-', and '_'.
     """
-    return bool(re.match(r"^[a-zA-Z0-9\-_]{1,128}$", trace_id))
+    # Use re.fullmatch instead of re.match to reject trailing newlines.
+    # Python's '$' matches at end-of-string OR just before a trailing newline,
+    # so re.match accepts "abc123\n". re.fullmatch requires the whole string
+    # to match. Regression for #39880 (sibling of #39234 / #39548 / #39666 / #39730).
+    return bool(re.fullmatch(r"[a-zA-Z0-9\-_]{1,128}", trace_id))
 
 
 def get_external_trace_id(request: Any) -> str | None:

--- a/api/models/provider_ids.py
+++ b/api/models/provider_ids.py
@@ -24,9 +24,13 @@ class GenericProviderID:
         if not value:
             raise NotFound("plugin not found, please add plugin")
         # check if the value is a valid plugin id with format: $organization/$plugin_name/$provider_name
-        if not re.match(r"^[a-z0-9_-]+\/[a-z0-9_-]+\/[a-z0-9_-]+$", value):
+        # Use re.fullmatch instead of re.match to reject trailing newlines.
+        # Python's '$' matches at end-of-string OR just before a trailing newline,
+        # so re.match accepts "google\n". re.fullmatch requires the whole string
+        # to match. Regression for #39880 (sibling of #39234 / #39548 / #39666 / #39730).
+        if not re.fullmatch(r"[a-z0-9_-]+/[a-z0-9_-]+/[a-z0-9_-]+", value):
             # check if matches [a-z0-9_-]+, if yes, append with langgenius/$value/$value
-            if re.match(r"^[a-z0-9_-]+$", value):
+            if re.fullmatch(r"[a-z0-9_-]+", value):
                 value = f"langgenius/{value}/{value}"
             else:
                 raise ValueError(f"Invalid plugin id {value}")

--- a/api/tests/unit_tests/core/helper/test_trace_id_helper.py
+++ b/api/tests/unit_tests/core/helper/test_trace_id_helper.py
@@ -118,6 +118,15 @@ class TestTraceIdHelper:
             ("abc!@#", False),
             ("空格", False),
             ("with space", False),
+            # Trailing newlines and other whitespace must be rejected so the
+            # value is safe to embed in log lines and the traceparent header.
+            # Regression for #39880 (sibling of #39234 / #39548 / #39666 / #39730).
+            ("abc123\n", False),
+            ("abc123\r", False),
+            ("abc123\r\n", False),
+            ("abc123\nfoo", False),
+            ("\nabc123", False),
+            ("abc 123", False),
         ],
     )
     def test_is_valid_trace_id(self, trace_id, expected):
@@ -164,6 +173,18 @@ class TestTraceIdHelper:
     )
     def test_get_external_trace_id_invalid(self, req):
         """Should return None for invalid or missing trace_id"""
+        assert get_external_trace_id(req) is None
+
+    @pytest.mark.parametrize(
+        "req",
+        [
+            DummyRequest(headers={"X-Trace-Id": "abc123\n"}),
+            DummyRequest(args={"trace_id": "abc123\n"}),
+            DummyRequest(is_json=True, json={"trace_id": "abc123\nfoo"}),
+        ],
+    )
+    def test_get_external_trace_id_rejects_trailing_newline(self, req):
+        """Trailing-newline trace_id is rejected at every entry point. Regression for #39880."""
         assert get_external_trace_id(req) is None
 
     @pytest.mark.parametrize(

--- a/api/tests/unit_tests/models/test_provider_ids.py
+++ b/api/tests/unit_tests/models/test_provider_ids.py
@@ -1,0 +1,74 @@
+import pytest
+from werkzeug.exceptions import NotFound
+
+from models.provider_ids import GenericProviderID
+
+
+class TestGenericProviderID:
+    def test_valid_three_segment_id(self) -> None:
+        pid = GenericProviderID("org1/plug1/prov1")
+
+        assert pid.organization == "org1"
+        assert pid.plugin_name == "plug1"
+        assert pid.provider_name == "prov1"
+        assert pid.is_hardcoded is False
+        assert pid.is_langgenius() is False
+        assert pid.plugin_id == "org1/plug1"
+        assert str(pid) == "org1/plug1/prov1"
+        assert pid.to_string() == "org1/plug1/prov1"
+
+    def test_single_segment_id_is_prefixed_with_langgenius(self) -> None:
+        pid = GenericProviderID("google")
+
+        assert pid.organization == "langgenius"
+        assert pid.plugin_name == "google"
+        assert pid.provider_name == "google"
+        assert pid.is_langgenius() is True
+        assert pid.plugin_id == "langgenius/google"
+
+    def test_hardcoded_flag_is_preserved(self) -> None:
+        pid = GenericProviderID("org1/plug1/prov1", is_hardcoded=True)
+        assert pid.is_hardcoded is True
+
+    def test_empty_value_raises_not_found(self) -> None:
+        with pytest.raises(NotFound):
+            GenericProviderID("")
+
+    def test_invalid_value_raises_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            GenericProviderID("Org1/Plug1/Prov1")  # uppercase
+
+        with pytest.raises(ValueError):
+            GenericProviderID("org/plug")  # only two segments, no fall-through match
+
+        with pytest.raises(ValueError):
+            GenericProviderID("org/plug/prov/extra")  # four segments
+
+    def test_value_with_dot_raises_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            GenericProviderID("org.name/plug/prov")
+
+    def test_trailing_newline_in_three_segment_id_is_rejected(self) -> None:
+        # Regression for #39880 (sibling of #39234 / #39548 / #39666 / #39730).
+        # Without re.fullmatch, Python's `$` matches just before the trailing
+        # newline, so the value is accepted and the newline survives into
+        # self.organization.
+        with pytest.raises(ValueError):
+            GenericProviderID("org1/plug1/prov1\n")
+
+        with pytest.raises(ValueError):
+            GenericProviderID("org1/plug1/prov1\r")
+
+        with pytest.raises(ValueError):
+            GenericProviderID("org1/plug1/prov1\r\n")
+
+    def test_trailing_newline_in_single_segment_id_is_rejected(self) -> None:
+        # This is the actual bypass the old re.match had: "google\n" matched
+        # the single-segment pattern (because `$` matched before `\n`), the
+        # constructor rewrote it as "langgenius/google\n/google\n", and the
+        # embedded newline survived into self.organization / plugin_id.
+        with pytest.raises(ValueError):
+            GenericProviderID("google\n")
+
+        with pytest.raises(ValueError):
+            GenericProviderID("google\r\n")


### PR DESCRIPTION
## Summary

Replaces `re.match` with `re.fullmatch` in two security-sensitive string parsers, closing a trailing-newline bypass that has the same shape as the email / password / alphanumeric / time_duration fixes in #39320, #39666, #39548, and #39730.

- `is_valid_trace_id` in `api/core/helper/trace_id_helper.py:25` -- the trace id is read from header / query / JSON body and then propagated to OpenTelemetry context, log extras, and a generated `traceparent` header. A body of `{"trace_id": "abc123\nfoo"}` was being accepted.
- `GenericProviderID.__init__` in `api/models/provider_ids.py:23,27,29` -- the parser for plugin / model / tool / datasource / trigger provider ids. The single-segment fall-through was rewriting `value` as `langgenius/{value}/{value}` and then splitting on `/`, so a value of `google\n` was accepted with the newline surviving into `self.organization` and bypassing `is_langgenius()`. Provider ids flow into plugin install URLs, package-manager lookups, and DB primary keys.

In Python, `$` in a regex matches at end-of-string OR just before a final newline, so the old `re.match(r"^...$", value)` accepted values with a trailing `\n`, `\r`, or `\r\n`. `re.fullmatch` requires the whole string to match, which closes the bypass.

## Changes

- `api/core/helper/trace_id_helper.py` -- `re.match(r"^[a-zA-Z0-9\-_]{1,128}$", trace_id)` -> `re.fullmatch(r"[a-zA-Z0-9\-_]{1,128}", trace_id)`. `^` and `$` dropped (redundant with `fullmatch`).
- `api/models/provider_ids.py` -- two `re.match` -> `re.fullmatch` swaps in `GenericProviderID.__init__`. `^` / `$` and the escaped `/` in the character class dropped for the same reason.
- `api/tests/unit_tests/core/helper/test_trace_id_helper.py` -- 6 new parametrize cases for `test_is_valid_trace_id` (trailing `\n`, trailing `\r`, trailing `\r\n`, embedded `\n`, leading `\n`, embedded space), plus a new `test_get_external_trace_id_rejects_trailing_newline` covering header / args / JSON-body rejection end-to-end.
- `api/tests/unit_tests/models/test_provider_ids.py` (new) -- `TestGenericProviderID` with 8 tests: valid 3-segment, valid single-segment (gets `langgenius/` prefixed), hardcoded flag, empty value, invalid value, dot in value, trailing newline in 3-segment, trailing newline in single-segment (the actual bypass). No test file existed for `models/provider_ids.py` before.

## Test plan

```
$ api/.venv/bin/python -m pytest api/tests/unit_tests/core/helper/test_trace_id_helper.py api/tests/unit_tests/models/test_provider_ids.py
55 passed in 22.65s
```

Broader sweep (no regressions):
```
$ api/.venv/bin/python -m pytest api/tests/unit_tests/core/helper/test_trace_id_helper.py api/tests/unit_tests/models/
428 passed in 32.10s
```

Lint, format, and type checks:
```
$ api/.venv/bin/python -m ruff check api/core/helper/trace_id_helper.py api/models/provider_ids.py api/tests/unit_tests/core/helper/test_trace_id_helper.py api/tests/unit_tests/models/test_provider_ids.py
All checks passed!
$ api/.venv/bin/python -m ruff format --check <same files>
4 files already formatted
$ ./dev/pyrefly-check-local api/core/helper/trace_id_helper.py api/models/provider_ids.py
(no output -- no errors)
$ api/.venv/bin/python -m mypy --check-untyped-defs --disable-error-code=import-untyped <source + tests>
Success: no issues found in 4 source files
```

## Out of scope

The same trailing-newline shape exists in `api/providers/vdb/vdb-oceanbase/src/dify_vdb_oceanbase/oceanbase_vector.py:325,461` (VDB-internal key / doc_id validators). Lower-impact -- internal surface, not user-facing auth / identifier fields. The same fix applies. Filed the trace_id_helper / provider_ids pair here, and noted the OceanBase pair in the issue's out-of-scope section for a follow-up PR if maintainers want it.

Fixes #39880
