### PR TITLE
chore: pass session explicitly in ApiModeration

### DIFF
--- a/api/core/moderation/api/api.py
+++ b/api/core/moderation/api/api.py
@@ -2,6 +2,7 @@ from typing import Any, override
 
 from pydantic import BaseModel, Field
 from sqlalchemy import select
+from sqlalchemy.orm import scoped_session
 
 from core.extension.api_based_extension_requestor import APIBasedExtensionPoint, APIBasedExtensionRequestor
 from core.helper.encrypter import decrypt_token
@@ -40,7 +41,7 @@ class ApiModeration(Moderation):
         if not api_based_extension_id:
             raise ValueError("api_based_extension_id is required")
 
-        extension = cls._get_api_based_extension(tenant_id, api_based_extension_id)
+        extension = cls._get_api_based_extension(tenant_id, api_based_extension_id, db.session)
         if not extension:
             raise ValueError("API-based Extension not found. Please check it again.")
 
@@ -81,7 +82,9 @@ class ApiModeration(Moderation):
     def _get_config_by_requestor(self, extension_point: APIBasedExtensionPoint, params: dict[str, Any]):
         if self.config is None:
             raise ValueError("The config is not set.")
-        extension = self._get_api_based_extension(self.tenant_id, self.config.get("api_based_extension_id", ""))
+        extension = self._get_api_based_extension(
+            self.tenant_id, self.config.get("api_based_extension_id", ""), db.session
+        )
         if not extension:
             raise ValueError("API-based Extension not found. Please check it again.")
         requestor = APIBasedExtensionRequestor(extension.api_endpoint, decrypt_token(self.tenant_id, extension.api_key))
@@ -90,10 +93,12 @@ class ApiModeration(Moderation):
         return result
 
     @staticmethod
-    def _get_api_based_extension(tenant_id: str, api_based_extension_id: str) -> APIBasedExtension | None:
+    def _get_api_based_extension(
+        tenant_id: str, api_based_extension_id: str, session: scoped_session
+    ) -> APIBasedExtension | None:
         stmt = select(APIBasedExtension).where(
             APIBasedExtension.tenant_id == tenant_id, APIBasedExtension.id == api_based_extension_id
         )
-        extension = db.session.scalar(stmt)
+        extension = session.scalar(stmt)
 
         return extension

--- a/api/tests/unit_tests/core/moderation/api/test_api.py
+++ b/api/tests/unit_tests/core/moderation/api/test_api.py
@@ -4,20 +4,11 @@ import pytest
 from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
-import core.moderation.api.api as moderation_module
 from core.extension.api_based_extension_requestor import APIBasedExtensionPoint
 from core.moderation.api.api import ApiModeration, ModerationInputParams, ModerationOutputParams
 from core.moderation.base import ModerationAction, ModerationInputsResult, ModerationOutputsResult
+from extensions.ext_database import db
 from models.api_based_extension import APIBasedExtension
-
-
-class _DatabaseBinding:
-    """Expose the real SQLite session used by extension lookup."""
-
-    session: Session
-
-    def __init__(self, session: Session) -> None:
-        self.session = session
 
 
 class TestApiModeration:
@@ -61,7 +52,7 @@ class TestApiModeration:
     def test_validate_config_success(self, mock_get_extension, api_config):
         mock_get_extension.return_value = MagicMock(spec=APIBasedExtension)
         ApiModeration.validate_config("test-tenant-id", api_config)
-        mock_get_extension.assert_called_once_with("test-tenant-id", "test-extension-id")
+        mock_get_extension.assert_called_once_with("test-tenant-id", "test-extension-id", db.session)
 
     def test_validate_config_missing_extension_id(self):
         config = {
@@ -160,7 +151,7 @@ class TestApiModeration:
         result = api_moderation._get_config_by_requestor(APIBasedExtensionPoint.APP_MODERATION_INPUT, params)
 
         assert result == {"flagged": True}
-        mock_get_ext.assert_called_once_with("test-tenant-id", "test-extension-id")
+        mock_get_ext.assert_called_once_with("test-tenant-id", "test-extension-id", db.session)
         mock_decrypt.assert_called_once_with("test-tenant-id", "encrypted-key")
         mock_requestor_cls.assert_called_once_with("http://api.test", "decrypted-key")
         mock_requestor.request.assert_called_once_with(APIBasedExtensionPoint.APP_MODERATION_INPUT, params)
@@ -177,7 +168,7 @@ class TestApiModeration:
             api_moderation._get_config_by_requestor(APIBasedExtensionPoint.APP_MODERATION_INPUT, {})
 
     @pytest.mark.parametrize("sqlite_session", [(APIBasedExtension,)], indirect=True)
-    def test_get_api_based_extension(self, sqlite_session: Session, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_get_api_based_extension(self, sqlite_session: Session) -> None:
         target = APIBasedExtension(
             tenant_id="tenant-1",
             name="Target extension",
@@ -194,9 +185,8 @@ class TestApiModeration:
         other_tenant.id = "ext-2"
         sqlite_session.add_all((target, other_tenant))
         sqlite_session.commit()
-        monkeypatch.setattr(moderation_module, "db", _DatabaseBinding(sqlite_session))
 
-        result = ApiModeration._get_api_based_extension("tenant-1", "ext-1")
+        result = ApiModeration._get_api_based_extension("tenant-1", "ext-1", sqlite_session)
 
         assert result is target
-        assert ApiModeration._get_api_based_extension("tenant-1", "ext-2") is None
+        assert ApiModeration._get_api_based_extension("tenant-1", "ext-2", sqlite_session) is None


### PR DESCRIPTION
## Summary

For #37403 — make the DB session an explicit parameter in the moderation module, following the pattern from #37402.

- `ApiModeration._get_api_based_extension` now takes `session: scoped_session` and uses it for the query, instead of relying on the implicit global `db.session` inside the leaf function.
- Callers (`validate_config` and `_get_config_by_requestor`) pass `db.session` at the call site, so the session dependency of the leaf query is visible in the signature.
- The other moderation providers (`keywords`, `openai_moderation`) do not query the database, so the factory boundary and their signatures stay unchanged.
- No behavior change.

## Testing

- `uv run --project api pytest api/tests/unit_tests/core/moderation -q` → 208 passed
- `ruff check` / `ruff format --check` on touched files → pass
- `pyrefly check` on touched files → 0 errors

From CodeBuddy Code
