### PR TITLE
fix(rag): close downloaded temp file before reopening it in WordExtractor

### DIFF
--- a/api/core/rag/extractor/word_extractor.py
+++ b/api/core/rag/extractor/word_extractor.py
@@ -3,7 +3,6 @@
 Supports local file paths and remote URLs downloaded through the unified remote-file fetcher.
 """
 
-import inspect
 import logging
 import mimetypes
 import os
@@ -66,13 +65,15 @@ class WordExtractor(BaseExtractor):
 
             self.web_path = self.file_path
             # TODO: use a better way to handle the file
-            self.temp_file = tempfile.NamedTemporaryFile()  # noqa SIM115
+            temp_file = tempfile.NamedTemporaryFile(delete=False)  # noqa SIM115
             try:
-                self.temp_file.write(response.content)
-                self.temp_file.flush()
+                temp_file.write(response.content)
+                temp_file.flush()
             finally:
+                temp_file.close()
                 response.close()
-            self.file_path = self.temp_file.name
+            self.temp_file_path = temp_file.name
+            self.file_path = self.temp_file_path
         elif not os.path.isfile(self.file_path):
             raise ValueError(f"File path {self.file_path} is not a valid file or url")
 
@@ -82,16 +83,14 @@ class WordExtractor(BaseExtractor):
             return
 
         self._closed = True
-        temp_file = getattr(self, "temp_file", None)
-        if temp_file is None:
+        temp_file_path = getattr(self, "temp_file_path", None)
+        if temp_file_path is None:
             return
 
         try:
-            close_result = temp_file.close()
-            if inspect.isawaitable(close_result):
-                close_awaitable = getattr(close_result, "close", None)
-                if callable(close_awaitable):
-                    close_awaitable()
+            os.unlink(temp_file_path)
+        except FileNotFoundError:
+            pass
         except Exception:
             logger.debug("Failed to cleanup downloaded word temp file", exc_info=True)
 

--- a/api/tests/unit_tests/core/rag/extractor/test_word_extractor.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_word_extractor.py
@@ -5,7 +5,6 @@ import logging
 import os
 import tempfile
 from collections import UserDict
-from collections.abc import Generator
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Protocol, cast, override
@@ -108,7 +107,7 @@ def test_init_downloads_via_remote_fetcher(monkeypatch: pytest.MonkeyPatch):
         assert extractor.file_path != extractor.web_path
         assert Path(extractor.file_path).read_bytes() == docx_bytes
     finally:
-        extractor.temp_file.close()
+        extractor.close()
 
 
 @pytest.mark.parametrize("inject_session", [False, True])
@@ -415,49 +414,37 @@ def test_init_expands_home_path_and_invalid_local_path(monkeypatch, tmp_path: Pa
         WordExtractor("not-a-file", "tenant", "user")
 
 
-def test_close_closes_temp_file():
+def test_close_removes_temp_file(tmp_path: Path):
     extractor = object.__new__(WordExtractor)
     extractor._closed = False
-    extractor.temp_file = MagicMock()
+    path = tmp_path / "downloaded.docx"
+    path.write_bytes(b"content")
+    extractor.temp_file_path = str(path)
 
     extractor.close()
 
-    extractor.temp_file.close.assert_called_once()
+    assert not path.exists()
 
 
-def test_close_is_idempotent():
+def test_close_is_idempotent(monkeypatch: pytest.MonkeyPatch):
     extractor = object.__new__(WordExtractor)
     extractor._closed = False
-    extractor.temp_file = MagicMock()
+    extractor.temp_file_path = "tmp.docx"
+    unlink = MagicMock()
+    monkeypatch.setattr(we.os, "unlink", unlink)
 
     extractor.close()
     extractor.close()
 
-    extractor.temp_file.close.assert_called_once()
+    unlink.assert_called_once_with("tmp.docx")
 
 
-def test_close_closes_awaitable_close_result():
-    class FakeAwaitable:
-        closed: bool = False
-
-        def __await__(self) -> Generator[None, None, None]:
-            if False:
-                yield None
-            return None
-
-        def close(self) -> None:
-            self.closed = True
-
+def test_close_tolerates_missing_temp_file():
     extractor = object.__new__(WordExtractor)
     extractor._closed = False
-    extractor.temp_file = MagicMock()
-    close_result = FakeAwaitable()
-    extractor.temp_file.close = MagicMock(return_value=close_result)
+    extractor.temp_file_path = "missing.docx"
 
     extractor.close()
-
-    assert close_result.closed is True
-    extractor.temp_file.close.assert_called_once()
 
 
 def test_extract_images_handles_invalid_external_cases(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
# fix(rag): close downloaded temp file before reopening it in WordExtractor

Fixes #39889

## Summary

- Close the `NamedTemporaryFile` handle immediately after writing the remote response so the path can be reopened on Windows.
- Keep only the temp path on the instance and unlink it in `close()`; `close()` stays idempotent and tolerates a missing file.
- Update the extractor unit tests to cover path-based cleanup (unlink, idempotency, missing-file tolerance) instead of handle closing.

## Root cause

`WordExtractor.__init__` downloads a remote `.docx` into `tempfile.NamedTemporaryFile()` and keeps the handle open. `extract()` reopens `self.file_path` through python-docx. On Windows, an open `NamedTemporaryFile` cannot be reopened by another handle (`PermissionError`, surfaced as `PackageNotFoundError`), so remote .docx extraction is broken on Windows. On Linux/macOS reopening works, which is why CI did not catch it.

## Validation

- Windows (Python 3.12): `test_init_downloads_via_remote_fetcher` now passes; `WordExtractor(url).extract()` returns parsed documents.
- Backend: related `test_word_extractor.py` cases pass on Windows; unchanged behavior on POSIX.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Codex

