### PR TITLE
test(rag): close temp file before encoding detection in test_helpers

### DIFF
--- a/api/tests/unit_tests/core/rag/extractor/test_helpers.py
+++ b/api/tests/unit_tests/core/rag/extractor/test_helpers.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 from types import SimpleNamespace
 
@@ -9,11 +10,14 @@ from core.rag.extractor.helpers import detect_file_encodings
 
 class TestHelpers:
     def test_detect_file_encodings(self) -> None:
-        with tempfile.NamedTemporaryFile(mode="w+t", suffix=".txt") as temp:
+        with tempfile.NamedTemporaryFile(mode="w+t", suffix=".txt", delete=False) as temp:
             temp.write("Shared data")
             temp.flush()
             temp_path = temp.name
+        try:
             encodings = detect_file_encodings(temp_path)
+        finally:
+            os.unlink(temp_path)
 
         assert len(encodings) == 1
         assert encodings[0].encoding in {"utf_8", "ascii"}


### PR DESCRIPTION
# test(rag): close temp file before encoding detection in test_helpers

Fixes #39891

## Summary

- Close the temporary file before calling `detect_file_encodings` in `test_detect_file_encodings` so the production helper can reopen the path on Windows.
- Clean up the file with `os.unlink` in a `finally` block.
- No production behavior changes.

## Root cause

The test writes into `tempfile.NamedTemporaryFile(mode="w+t")` and calls `detect_file_encodings(temp_path)` while the handle is still open. `charset_normalizer.from_path` reopens the path, which fails with `PermissionError` on Windows because an open `NamedTemporaryFile` cannot be reopened there (documented platform difference; Linux/macOS allow it, which is why CI is green).

## Validation

- Windows (Python 3.12): `test_detect_file_encodings` now passes.
- Backend: `test_helpers.py` passes on POSIX as well.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Codex

