### PR TITLE
fix(api): stop echoing the api_key value in the external knowledge 403 error

### DIFF
--- a/api/services/external_knowledge_service.py
+++ b/api/services/external_knowledge_service.py
@@ -114,7 +114,7 @@ class ExternalDatasetService:
         if response.status_code == 404:
             raise ValueError(f"Not Found: failed to connect to the endpoint: {endpoint}")
         if response.status_code == 403:
-            raise ValueError(f"Forbidden: Authorization failed with api_key: {api_key}")
+            raise ValueError("Forbidden: Authorization failed with the provided api_key")
 
     @staticmethod
     def get_external_knowledge_api(

--- a/api/tests/unit_tests/services/test_external_dataset_service.py
+++ b/api/tests/unit_tests/services/test_external_dataset_service.py
@@ -784,6 +784,26 @@ class TestExternalDatasetServiceCheckEndpoint:
             ExternalDatasetService.check_endpoint_and_api_key(settings)
 
     @patch("services.external_knowledge_service.ssrf_proxy")
+    def test_check_endpoint_403_forbidden_does_not_leak_api_key(
+        self, mock_proxy, factory: ExternalDatasetServiceTestDataFactory
+    ):
+        """The 403 error message must describe the auth failure without
+        echoing the api_key value into logs and HTTP responses."""
+        # Arrange
+        settings = {"endpoint": "https://api.example.com", "api_key": "sk-sensitive-key-12345"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_proxy.post.return_value = mock_response
+
+        # Act & Assert
+        with pytest.raises(ValueError, match="Forbidden.*Authorization failed") as exc_info:
+            ExternalDatasetService.check_endpoint_and_api_key(settings)
+
+        # The error message must NOT contain the raw api_key value
+        assert "sk-sensitive-key-12345" not in str(exc_info.value)
+
+    @patch("services.external_knowledge_service.ssrf_proxy")
     def test_check_endpoint_other_4xx_codes_pass(self, mock_proxy, factory: ExternalDatasetServiceTestDataFactory):
         """Test that other 4xx codes don't raise exceptions."""
         # Arrange


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

The external knowledge API validation probe at `check_endpoint_and_api_key` interpolates the raw `api_key` value into the `ValueError` message on a 403 response (`api/services/external_knowledge_service.py:117`). Because the exception is not wrapped by the caller, it reaches the console API's `handle_value_error` (`api/libs/external_api.py:92-97`), which (a) logs the full message via `current_app.logger.exception`, and (b) returns it verbatim to the caller in a 400 body (`{"code": "invalid_param", "message": str(e), "status": 400}`). The credential therefore lands in application logs and in the API response itself. (Sentry is unaffected: this project explicitly ignores `ValueError` in `extensions/ext_sentry.py`.)

Stop interpolating the key, keeping the auth-failure signal intact. This matches the other validations in the same file (`api_key is required` at lines 57, 85, and 270), which never echo the value.

Fixes #39888

## Screenshots

Backend error-message change with no UI surface; the behaviour change is covered by the regression test.

| Before | After |
|--------|-------|
| `400 {"code": "invalid_param", "message": "Forbidden: Authorization failed with api_key: sk-live-key-value"}` — key returned to the caller and written to application logs | `400 {"code": "invalid_param", "message": "Forbidden: Authorization failed with the provided api_key"}` — key is never echoed |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

**On the absence of a private advisory:** I did not use the private advisory channel on purpose: there is nothing to disclose beyond log/observability hygiene. The tenant who submits the key already knows its value; the issue is limited to the credential being written to application logs and echoed in the 400 response to that same tenant. Sentry explicitly ignores `ValueError` in this project, so it never reaches the error-tracking pipeline. I have classified it accordingly — happy to move this to a private advisory if you read it differently.

## Test evidence

New regression test `test_check_endpoint_403_forbidden_does_not_leak_api_key` in `api/tests/unit_tests/services/test_external_dataset_service.py` (same class and mocking pattern as the existing `test_check_endpoint_403_forbidden`).

Without the fix (current `main`):

```text
>       assert "sk-sensitive-key-12345" not in str(exc_info.value)
E       AssertionError: assert 'sk-sensitive-key-12345' not in 'Forbidden: ...ve-key-12345'
E         'sk-sensitive-key-12345' is contained here:
E           Forbidden: Authorization failed with api_key: sk-sensitive-key-12345
FAILED test_external_dataset_service.py::TestExternalDatasetServiceCheckEndpoint::test_check_endpoint_403_forbidden_does_not_leak_api_key
```

With the fix applied:

```text
test_external_dataset_service.py::TestExternalDatasetServiceCheckEndpoint::test_check_endpoint_403_forbidden PASSED
test_external_dataset_service.py::TestExternalDatasetServiceCheckEndpoint::test_check_endpoint_403_forbidden_does_not_leak_api_key PASSED
======================= 110 passed, 5 warnings in 9.49s =======================
```

(The full test file passes, 110/110, including the pre-existing `test_check_endpoint_403_forbidden`, whose `Forbidden.*Authorization failed` match still holds.)

Assisted-by: AI tooling (implementation and verification reviewed line by line; I understand and stand by the change).
