### PR TITLE
fix(api): align marketplace download-url references in unit test and e2e helpers

### DIFF
--- a/api/tests/unit_tests/core/helper/test_marketplace.py
+++ b/api/tests/unit_tests/core/helper/test_marketplace.py
@@ -17,7 +17,8 @@ from core.helper.marketplace import (
 def test_get_plugin_pkg_url_contains_unique_identifier() -> None:
     url = get_plugin_pkg_url("langgenius/openai:0.4.2@checksum")
 
-    assert "api/v1/plugins/download" in url
+    assert "api/v1/plugins/download-url" in url
+    assert "api/v1/plugins/download?" not in url
     assert "unique_identifier=langgenius%2Fopenai%3A0.4.2%40checksum" in url
 
 

--- a/e2e/support/marketplace-plugins.ts
+++ b/e2e/support/marketplace-plugins.ts
@@ -100,7 +100,7 @@ const waitForPluginInstallTask = async (
 
 const getMarketplaceDownloadUrl = (pluginUniqueIdentifier: string) => {
   const url = new URL(
-    '/api/v1/plugins/download',
+    '/api/v1/plugins/download-url',
     process.env.E2E_MARKETPLACE_API_URL || defaultMarketplaceApiUrl,
   )
   url.searchParams.set('unique_identifier', pluginUniqueIdentifier)

--- a/e2e/tests/marketplace-plugins.test.ts
+++ b/e2e/tests/marketplace-plugins.test.ts
@@ -64,7 +64,7 @@ describe('bootstrapMarketplacePlugins', () => {
         data: {
           body: {
             message:
-              'Reached maximum retries (3) for URL https://marketplace.test/plugins/download',
+              'Reached maximum retries (3) for URL https://marketplace.test/plugins/download-url',
           },
         },
         status: 500,


### PR DESCRIPTION
# fix(api): align marketplace download-url references in unit test and e2e helpers

Fixes #39892

## Summary

- Assert the exact renamed endpoint in `test_get_plugin_pkg_url_contains_unique_identifier` and add a negative assertion for the old path.
- Update the E2E marketplace seed helper to download from `/api/v1/plugins/download-url`.
- Update the E2E test fixture message to the new URL; the fallback matcher still matches both old and new error text.

## Root cause

PR #39811 renamed the backend marketplace download URL from `/api/v1/plugins/download` to `/api/v1/plugins/download-url` but did not update the E2E seed helper or the backend unit test. The unit test kept passing only because the new path contains the old path as a substring.

## Validation

- Backend: `test_marketplace.py` passes and now pins the exact path.
- E2E: `marketplace-plugins.test.ts` still exercises the fallback branch with the updated fixture.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From Codex

