### PR TITLE
fix(api): stop echoing the raw api_key in the 403 error message (#39888)

### DIFF
--- a/api/services/external_knowledge_service.py
+++ b/api/services/external_knowledge_service.py
@@ -114,7 +114,7 @@ class ExternalDatasetService:
         if response.status_code == 404:
             raise ValueError(f"Not Found: failed to connect to the endpoint: {endpoint}")
         if response.status_code == 403:
-            raise ValueError(f"Forbidden: Authorization failed with api_key: {api_key}")
+            raise ValueError("Forbidden: Authorization failed with the provided api_key")
 
     @staticmethod
     def get_external_knowledge_api(

--- a/api/tests/unit_tests/services/test_external_dataset_service.py
+++ b/api/tests/unit_tests/services/test_external_dataset_service.py
@@ -784,6 +784,43 @@ class TestExternalDatasetServiceCheckEndpoint:
             ExternalDatasetService.check_endpoint_and_api_key(settings)
 
     @patch("services.external_knowledge_service.ssrf_proxy")
+    def test_check_endpoint_403_message_does_not_echo_api_key(
+        self, mock_proxy, factory: ExternalDatasetServiceTestDataFactory
+    ):
+        """Regression for #39888: the 403 error message must not contain the raw api_key.
+
+        Before the fix, `external_knowledge_service.py:117` interpolated
+        `api_key` into the `ValueError` message, so the credential round-tripped
+        in the application log (via `current_app.logger.exception` in
+        `api/libs/external_api.py:94`) and in the 400 response body
+        (`{"code": "invalid_param", "message": str(e), ...}`). The 403 status
+        from the upstream provider was the only signal that the key was bad;
+        echoing it back is just a plaintext credential leak.
+        """
+        # Arrange -- a real-looking key with a prefix that would be a high-signal
+        # substring to grep for in logs.
+        api_key = "sk-abcdefghijklmnop1234567890ABCDEF"
+        settings = {"endpoint": "https://api.example.com", "api_key": api_key}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_proxy.post.return_value = mock_response
+
+        # Act
+        with pytest.raises(ValueError) as exc_info:
+            ExternalDatasetService.check_endpoint_and_api_key(settings)
+
+        # Assert -- the message names the failure but does not include the key.
+        message = str(exc_info.value)
+        assert "Forbidden" in message
+        assert "Authorization failed" in message
+        assert api_key not in message
+        # Belt-and-braces: also check the prefix and a 6-char tail to catch
+        # regressions that only echo part of the key.
+        assert "sk-abcdef" not in message
+        assert "CDEF" not in message
+
+    @patch("services.external_knowledge_service.ssrf_proxy")
     def test_check_endpoint_other_4xx_codes_pass(self, mock_proxy, factory: ExternalDatasetServiceTestDataFactory):
         """Test that other 4xx codes don't raise exceptions."""
         # Arrange


### PR DESCRIPTION
## Summary

Stops echoing the raw `api_key` in the 403 error message from `ExternalDatasetService.check_endpoint_and_api_key`. The bug: a 403 from the upstream provider raised `ValueError(f"Forbidden: Authorization failed with api_key: {api_key}")`, and the same exception was then logged by `current_app.logger.exception` and returned verbatim in the 400 response body by the console API's handler. The credential therefore round-tripped in plaintext through application logs (anyone with log access) and through the HTTP response (the tenant who submitted the key, plus anyone the response was forwarded to).

This is a credential-leak fix. The same function already uses static messages for the other validations (`api_key is required`); only the 403 path interpolated the value.

## Changes

- `api/services/external_knowledge_service.py:117` -- replace the f-string `ValueError(f"Forbidden: Authorization failed with api_key: {api_key}")` with a static message `ValueError("Forbidden: Authorization failed with the provided api_key")`. One-line source change, no behavior change for the caller (the error still raises on 403; the message still tells the operator the key was rejected).
- `api/tests/unit_tests/services/test_external_dataset_service.py` -- new test `test_check_endpoint_403_message_does_not_echo_api_key` in the existing `TestExternalDatasetServiceCheckEndpoint` class. Asserts the full api_key value, a 10-char prefix, and a 4-char tail are all absent from the raised message. The existing `test_check_endpoint_403_forbidden` only matched `Forbidden.*Authorization failed`, which is satisfied by both the old and the new message; the new test is what catches this specific bug.

## Test plan

```
$ api/.venv/bin/python -m pytest api/tests/unit_tests/services/test_external_dataset_service.py
110 passed in 25.75s
```

Negative-control run (source change reverted, fix absent):
```
$ git stash push api/services/external_knowledge_service.py
$ api/.venv/bin/python -m pytest api/tests/unit_tests/services/test_external_dataset_service.py::TestExternalDatasetServiceCheckEndpoint::test_check_endpoint_403_message_does_not_echo_api_key
FAILED ... AssertionError: 'sk-abcdefghijklmnop1234567890ABCDEF' is contained here:
  Forbidden: Authorization failed with api_key: sk-abcdefghijklmnop1234567890ABCDEF
$ git stash pop
```

The new test fails on the old code with the credential visible in the assertion error, and passes on the new code. So the test is genuinely the one catching this bug, not a tautology.

Lint, format, and type checks:
```
$ api/.venv/bin/python -m ruff check api/services/external_knowledge_service.py api/tests/unit_tests/services/test_external_dataset_service.py
All checks passed!
$ api/.venv/bin/python -m ruff format --check <same files>
2 files already formatted
$ api/.venv/bin/python -m mypy --check-untyped-defs --disable-error-code=import-untyped api/services/external_knowledge_service.py
Success: no issues found in 1 source file
```

(14 pre-existing mypy errors in the test file at lines 1288, 1519, 1580-1581, etc. are in code I didn't touch -- the existing test code, not the new test method.)

## Risk

Very low. The error still raises on 403 with a message that names the failure ("Authorization failed with the provided api_key"). The only behavior change is that the credential no longer appears in the message. No callers parse the message to extract the key (verified by reading the call sites: the exception is caught in `api/libs/external_api.py:94` and passed to `str(e)` for logging and response body). If a caller was depending on parsing the key out of the error, they would have to be reconstructing the credential from the error, which is the bug we're fixing.

Sentry is not affected: `ValueError` is in `ignore_errors` in `api/extensions/ext_sentry.py:38`, so the key was never sent to Sentry. The leak was local to the application log stream and the HTTP response body.

## Out of scope

A wider audit of other places where the same anti-pattern might exist (raw credential in error message, log line, or response body) is left for a follow-up issue if maintainers want a sweep. The grep would be: any `f"...{api_key}..."`, `f"...{password}..."`, or `f"...{token}..."` in error / exception / log strings.

Fixes #39888
