### PR TITLE
fix(ext-socketio): pass TCP keepalive options to the Socket.IO Redis manager (#39812)

### DIFF
--- a/api/extensions/ext_socketio.py
+++ b/api/extensions/ext_socketio.py
@@ -1,4 +1,6 @@
+import socket
 import ssl
+import sys
 from typing import Any, cast
 from urllib.parse import urlparse
 
@@ -19,6 +21,25 @@ def _get_ssl_cert_reqs() -> ssl.VerifyMode:
     return cert_reqs_map.get(dify_config.REDIS_SSL_CERT_REQS, ssl.CERT_NONE)
 
 
+def _build_keepalive_options() -> dict[int, int]:
+    """Build the platform-specific TCP keepalive option set.
+
+    Mirrors the logic in ``extensions.ext_redis._get_connection_health_params``
+    so the Socket.IO Redis pub/sub connection gets the same idle-connection
+    probes as the regular Redis clients. Without these, cloud LBs and K8s
+    services silently close the idle pub/sub connection and the client only
+    notices on the next health check (issue #39812).
+    """
+    options: dict[int, int] = {}
+    if sys.platform == "linux":
+        options[socket.TCP_KEEPIDLE] = dify_config.REDIS_KEEPALIVE_IDLE
+        options[socket.TCP_KEEPINTVL] = dify_config.REDIS_KEEPALIVE_INTERVAL
+        options[socket.TCP_KEEPCNT] = dify_config.REDIS_KEEPALIVE_COUNT
+    elif sys.platform == "darwin":
+        options[socket.TCP_KEEPALIVE] = dify_config.REDIS_KEEPALIVE_IDLE
+    return options
+
+
 def _build_redis_options(redis_url: str) -> dict[str, Any]:
     """Build Redis options for Socket.IO's cross-process pub/sub manager.
 
@@ -26,12 +47,23 @@ def _build_redis_options(redis_url: str) -> dict[str, Any]:
     blocking ``pubsub.listen()`` loop that idles indefinitely between messages;
     applying a read timeout there causes a reconnect storm (issue #39423).
     ``socket_connect_timeout`` still guards connection establishment.
+
+    Note: TCP keepalive probes are added so cloud LBs / K8s services do not
+    silently close the idle pub/sub connection (issue #39812). The same
+    ``dify_config.REDIS_KEEPALIVE*`` values are already used by the regular
+    Redis clients via ``extensions.ext_redis._get_connection_health_params``.
     """
     options: dict[str, Any] = {
         "socket_connect_timeout": dify_config.REDIS_SOCKET_CONNECT_TIMEOUT,
         "health_check_interval": dify_config.REDIS_HEALTH_CHECK_INTERVAL,
         "protocol": dify_config.REDIS_SERIALIZATION_PROTOCOL,
     }
+
+    if dify_config.REDIS_KEEPALIVE:
+        options["socket_keepalive"] = dify_config.REDIS_KEEPALIVE
+        keepalive_options = _build_keepalive_options()
+        if keepalive_options:
+            options["socket_keepalive_options"] = keepalive_options
 
     if dify_config.REDIS_MAX_CONNECTIONS:
         options["max_connections"] = dify_config.REDIS_MAX_CONNECTIONS

--- a/api/tests/unit_tests/extensions/test_ext_socketio.py
+++ b/api/tests/unit_tests/extensions/test_ext_socketio.py
@@ -1,4 +1,6 @@
+import socket
 import ssl
+import sys
 
 import socketio
 
@@ -43,3 +45,70 @@ def test_build_redis_options_omits_socket_timeout(monkeypatch) -> None:
 
     assert "socket_timeout" not in options
     assert "socket_connect_timeout" in options
+
+
+def test_build_redis_options_omits_keepalive_when_disabled(monkeypatch) -> None:
+    # When REDIS_KEEPALIVE is False (the default), the Socket.IO Redis
+    # options must not include keepalive keys. opt-in only.
+    monkeypatch.setattr(ext_socketio.dify_config, "REDIS_KEEPALIVE", False)
+
+    options = ext_socketio._build_redis_options("redis://redis.example.com:6380/3")
+
+    assert "socket_keepalive" not in options
+    assert "socket_keepalive_options" not in options
+
+
+def test_build_keepalive_options_returns_platform_specific_dict(monkeypatch) -> None:
+    # Regression for #39812: when REDIS_KEEPALIVE is enabled, the Socket.IO
+    # pub/sub connection gets the same TCP keepalive probes as the regular
+    # Redis clients via extensions.ext_redis._get_connection_health_params.
+    # Without these, cloud LBs and K8s services silently close the idle
+    # pub/sub connection and the client only notices on the next health
+    # check, leading to "Cannot receive from redis... retrying in 1 secs"
+    # log spam every 30-60s.
+    # This test runs on whatever platform the CI runs on, and only asserts
+    # the high-level shape (dict, non-empty on linux/darwin) so the
+    # platform-specific constants (TCP_KEEPIDLE on linux, TCP_KEEPALIVE on
+    # darwin) stay where they belong. The actual production code under
+    # test follows the same ext_redis.py contract.
+    monkeypatch.setattr(ext_socketio.dify_config, "REDIS_KEEPALIVE_IDLE", 30)
+    monkeypatch.setattr(ext_socketio.dify_config, "REDIS_KEEPALIVE_INTERVAL", 10)
+    monkeypatch.setattr(ext_socketio.dify_config, "REDIS_KEEPALIVE_COUNT", 10)
+    monkeypatch.setattr(ext_socketio.sys, "platform", sys.platform)
+
+    options = ext_socketio._build_keepalive_options()
+
+    assert isinstance(options, dict)
+    # On linux: TCP_KEEPIDLE / TCP_KEEPINTVL / TCP_KEEPCNT are set.
+    # On darwin: TCP_KEEPALIVE is set.
+    # On other platforms (windows, etc.): empty dict -- keepalive is opt-in
+    # and not configured for those platforms, same as ext_redis.py.
+    if sys.platform == "linux":
+        assert options[socket.TCP_KEEPIDLE] == 30
+        assert options[socket.TCP_KEEPINTVL] == 10
+        assert options[socket.TCP_KEEPCNT] == 10
+    elif sys.platform == "darwin":
+        assert options[socket.TCP_KEEPALIVE] == 30
+    else:
+        assert options == {}
+
+
+def test_build_redis_options_includes_keepalive_when_enabled(monkeypatch) -> None:
+    # High-level check that socket_keepalive is wired into _build_redis_options
+    # when the REDIS_KEEPALIVE flag is on. The platform-specific option
+    # values are covered by test_build_keepalive_options_returns_platform_specific_dict.
+    monkeypatch.setattr(ext_socketio.dify_config, "REDIS_KEEPALIVE", True)
+    monkeypatch.setattr(ext_socketio.dify_config, "REDIS_KEEPALIVE_IDLE", 30)
+    monkeypatch.setattr(ext_socketio.dify_config, "REDIS_KEEPALIVE_INTERVAL", 10)
+    monkeypatch.setattr(ext_socketio.dify_config, "REDIS_KEEPALIVE_COUNT", 10)
+    monkeypatch.setattr(ext_socketio.sys, "platform", sys.platform)
+
+    options = ext_socketio._build_redis_options("redis://redis.example.com:6380/3")
+
+    assert options["socket_keepalive"] is True
+    # socket_keepalive_options is a non-empty dict on linux and darwin
+    # (the two platforms we configure keepalive for); empty on other
+    # platforms, in which case _build_redis_options should NOT include the
+    # key at all so we don't pass an empty dict to redis-py.
+    if sys.platform in ("linux", "darwin"):
+        assert options["socket_keepalive_options"]


### PR DESCRIPTION
## Summary

Adds TCP keepalive probes to the Socket.IO Redis pub/sub connection in `extensions/ext_socketio.py`. After PR #39587 removed `socket_timeout` to fix a reconnect storm (issue #39423), the pub/sub connection was left as a purely idle TCP socket with no keepalive probes. Cloud LBs, K8s services, and Redis proxies silently close idle connections, and the Redis client only notices on the next health check or when `pubsub.listen()` fails -- producing the "Cannot receive from redis... retrying in 1 secs" log spam every 30-60s reported in #39812.

The regular Redis clients in `extensions/ext_redis.py` already wire `socket_keepalive` and `socket_keepalive_options` via `_get_connection_health_params()`, using the same `dify_config.REDIS_KEEPALIVE*` values. This PR brings the Socket.IO manager in line with that contract.

## Changes

- `api/extensions/ext_socketio.py` -- extract a small `_build_keepalive_options()` helper that returns the platform-specific option set (linux: `TCP_KEEPIDLE` / `TCP_KEEPINTVL` / `TCP_KEEPCNT`, darwin: `TCP_KEEPALIVE`, other: empty), mirroring `_get_connection_health_params()` in `ext_redis.py`. Wire `socket_keepalive` and `socket_keepalive_options` into `_build_redis_options()` behind the existing `dify_config.REDIS_KEEPALIVE` opt-in flag (default `False`). The `socket_timeout` omission is preserved with the existing comment explaining why.
- `api/tests/unit_tests/extensions/test_ext_socketio.py` -- three new tests next to the existing `test_build_redis_options_*` cases:
  - `test_build_redis_options_omits_keepalive_when_disabled` -- `REDIS_KEEPALIVE=False` (the default) means no keepalive keys in the options dict.
  - `test_build_keepalive_options_returns_platform_specific_dict` -- on linux returns `{TCP_KEEPIDLE, TCP_KEEPINTVL, TCP_KEEPCNT}` with the configured idle / interval / count values, on darwin returns `{TCP_KEEPALIVE}`, on other platforms returns `{}` (same contract as `ext_redis.py`).
  - `test_build_redis_options_includes_keepalive_when_enabled` -- end-to-end: `socket_keepalive=True` and `socket_keepalive_options` is a non-empty dict on linux / darwin when `REDIS_KEEPALIVE=True`.

## Test plan

```
$ api/.venv/bin/python -m pytest api/tests/unit_tests/extensions/test_ext_socketio.py
7 passed in 19.78s
```

Verified the new tests catch the bug: with the source change reverted via `git stash`, both new keepalive tests fail (`AttributeError: module 'extensions.ext_socketio' has no attribute 'sys'`, because `_build_keepalive_options` doesn't exist and `_build_redis_options` doesn't include `socket_keepalive`).

Lint, format, and type checks:
```
$ api/.venv/bin/python -m ruff check api/extensions/ext_socketio.py api/tests/unit_tests/extensions/test_ext_socketio.py
All checks passed!
$ api/.venv/bin/python -m ruff format --check <same files>
2 files already formatted
$ api/.venv/bin/python -m mypy --check-untyped-defs --disable-error-code=import-untyped api/extensions/ext_socketio.py
Success: no issues found in 1 source file
```

## Risk

Very low. The change is opt-in: `REDIS_KEEPALIVE` defaults to `False` (per `api/configs/middleware/cache/redis_config.py:156`), so users who haven't configured it see no behavior change at all. The added `socket_keepalive` / `socket_keepalive_options` only flow to redis-py when the flag is on, and they only affect idle-connection probe behavior, not request/response semantics.

The `socket_timeout` omission is preserved with the original comment explaining why the pub/sub `listen()` loop needs no read timeout (otherwise a per-message idle would trigger the same reconnect storm this whole family of fixes is trying to avoid).

## Out of scope

A wider audit of other internal clients (e.g. plugin runtime, scheduler) that may also have un-bounded idle Redis connections is left for a follow-up if maintainers want a sweep. The grep is straightforward: any other `Redis*` / `ConnectionPool` construction that doesn't pass `socket_keepalive` from `dify_config.REDIS_KEEPALIVE*`.

Fixes #39812
