### PR TITLE
refactor(api): separate listener-segment completion from execution terminal state

### DIFF
--- a/api/core/app/apps/base_app_queue_manager.py
+++ b/api/core/app/apps/base_app_queue_manager.py
@@ -52,7 +52,10 @@ class AppQueueManager(ABC):
         self._graph_runtime_state: GraphRuntimeState | None = None
         self._stopped_cache: TTLCache[tuple, bool] = TTLCache(maxsize=1, ttl=1)
         self._cache_lock = threading.Lock()
-        self._execution_terminal = threading.Event()
+        # Listener-segment completion is independent of execution completion. A producer marks
+        # the segment complete after publishing its terminal event; the cleanup path in listen()
+        # only aborts the underlying execution when the segment was NOT completed.
+        self._listener_segment_completed = threading.Event()
         self._abort_sent = threading.Event()
         self._lifecycle_lock = threading.Lock()
 
@@ -79,7 +82,7 @@ class AppQueueManager(ABC):
                     elapsed_time = time.monotonic() - start_time
                     timed_out = elapsed_time >= listen_timeout
                     manually_stopped = self._is_stopped()
-                    if not self._execution_terminal.is_set() and (timed_out or manually_stopped):
+                    if not self._listener_segment_completed.is_set() and (timed_out or manually_stopped):
                         reason = (
                             f"App execution exceeded {listen_timeout} seconds" if timed_out else "App task was stopped"
                         )
@@ -94,24 +97,41 @@ class AppQueueManager(ABC):
                         self.publish(QueuePingEvent(), PublishFrom.TASK_PIPELINE)
                         last_ping_time = elapsed_time // 10
         finally:
-            if not self._execution_terminal.is_set():
+            if not self._listener_segment_completed.is_set():
                 self._abort_execution("Client response stream closed before app execution completed")
             self._graph_runtime_state = None  # Release reference once consumers finish or close the generator.
 
-    def stop_listen(self, *, execution_terminal: bool = False):
+    def complete_listener_segment(self) -> None:
         """
-        Stop listen to queue
-        :return:
+        Mark the current response-listener segment as completed by the producer.
+
+        Producers call this after publishing a terminal event (succeeded, failed, paused, etc.).
+        Closing the listener under this state means the underlying execution may still be live
+        (a paused workflow can resume), so the cleanup path in listen() does NOT abort it.
+
+        Contrast with stop_listen(), which signals that the consumer detached unexpectedly
+        and lets the cleanup path cancel the underlying execution.
         """
-        if execution_terminal:
-            self._execution_terminal.set()
+        self._listener_segment_completed.set()
+        self._clear_task_belong_cache()
+        self._q.put(None)
+
+    def stop_listen(self) -> None:
+        """
+        Stop listen to queue.
+
+        Use this when the consumer (response generator) has closed without the producer
+        completing the listener segment. The cleanup path in listen() will then abort the
+        underlying execution exactly once. For the producer-completed path, call
+        complete_listener_segment() instead.
+        """
         self._clear_task_belong_cache()
         self._q.put(None)
 
     def _abort_execution(self, reason: str) -> None:
         """Propagate response timeout/disconnect to legacy and GraphEngine runners."""
         with self._lifecycle_lock:
-            if self._execution_terminal.is_set() or self._abort_sent.is_set():
+            if self._listener_segment_completed.is_set() or self._abort_sent.is_set():
                 return
             self._abort_sent.set()
 

--- a/api/core/app/apps/message_based_app_queue_manager.py
+++ b/api/core/app/apps/message_based_app_queue_manager.py
@@ -45,7 +45,7 @@ class MessageBasedAppQueueManager(AppQueueManager):
         if isinstance(
             event, QueueStopEvent | QueueErrorEvent | QueueMessageEndEvent | QueueAdvancedChatMessageEndEvent
         ):
-            self.stop_listen(execution_terminal=True)
+            self.complete_listener_segment()
 
         if pub_from == PublishFrom.APPLICATION_MANAGER and self._is_stopped():
             if self._app_mode == AppMode.ADVANCED_CHAT.value:

--- a/api/core/app/apps/pipeline/pipeline_queue_manager.py
+++ b/api/core/app/apps/pipeline/pipeline_queue_manager.py
@@ -42,7 +42,7 @@ class PipelineQueueManager(AppQueueManager):
             | QueueWorkflowFailedEvent
             | QueueWorkflowPartialSuccessEvent,
         ):
-            self.stop_listen(execution_terminal=True)
+            self.complete_listener_segment()
 
         if pub_from == PublishFrom.APPLICATION_MANAGER and self._is_stopped():
             raise GenerateTaskStoppedError()

--- a/api/core/app/apps/workflow/app_queue_manager.py
+++ b/api/core/app/apps/workflow/app_queue_manager.py
@@ -48,4 +48,4 @@ class WorkflowAppQueueManager(AppQueueManager):
             | QueueWorkflowPausedEvent
             | QueueWorkflowPartialSuccessEvent,
         ):
-            self.stop_listen(execution_terminal=True)
+            self.complete_listener_segment()

--- a/api/tests/unit_tests/core/app/apps/pipeline/test_pipeline_queue_manager.py
+++ b/api/tests/unit_tests/core/app/apps/pipeline/test_pipeline_queue_manager.py
@@ -20,19 +20,19 @@ from graphon.model_runtime.entities.llm_entities import LLMResult
 def test_publish_sets_stop_listen_and_raises_on_stopped(mocker: MockerFixture):
     manager = PipelineQueueManager(task_id="t", user_id="u", invoke_from=InvokeFrom.WEB_APP, app_mode="rag")
     manager._q = mocker.MagicMock()
-    manager.stop_listen = mocker.MagicMock()
+    manager.complete_listener_segment = mocker.MagicMock()
     manager._is_stopped = mocker.MagicMock(return_value=True)
 
     with pytest.raises(GenerateTaskStoppedError):
         manager._publish(QueueStopEvent(stopped_by=QueueStopEvent.StopBy.USER_MANUAL), PublishFrom.APPLICATION_MANAGER)
 
-    manager.stop_listen.assert_called_once()
+    manager.complete_listener_segment.assert_called_once()
 
 
 def test_publish_stop_events_trigger_stop_listen(mocker: MockerFixture):
     manager = PipelineQueueManager(task_id="t", user_id="u", invoke_from=InvokeFrom.WEB_APP, app_mode="rag")
     manager._q = mocker.MagicMock()
-    manager.stop_listen = mocker.MagicMock()
+    manager.complete_listener_segment = mocker.MagicMock()
     manager._is_stopped = mocker.MagicMock(return_value=False)
 
     for event in [
@@ -42,17 +42,17 @@ def test_publish_stop_events_trigger_stop_listen(mocker: MockerFixture):
         QueueWorkflowFailedEvent(error="failed", exceptions_count=1),
         QueueWorkflowPartialSuccessEvent(exceptions_count=1),
     ]:
-        manager.stop_listen.reset_mock()
+        manager.complete_listener_segment.reset_mock()
         manager._publish(event, PublishFrom.TASK_PIPELINE)
-        manager.stop_listen.assert_called_once()
+        manager.complete_listener_segment.assert_called_once()
 
 
 def test_publish_non_stop_event_no_stop_listen(mocker: MockerFixture):
     manager = PipelineQueueManager(task_id="t", user_id="u", invoke_from=InvokeFrom.WEB_APP, app_mode="rag")
     manager._q = mocker.MagicMock()
-    manager.stop_listen = mocker.MagicMock()
+    manager.complete_listener_segment = mocker.MagicMock()
     manager._is_stopped = mocker.MagicMock(return_value=False)
 
     non_stop_event = mocker.MagicMock(spec=module.AppQueueEvent)
     manager._publish(non_stop_event, PublishFrom.TASK_PIPELINE)
-    manager.stop_listen.assert_not_called()
+    manager.complete_listener_segment.assert_not_called()

--- a/api/tests/unit_tests/core/app/apps/test_base_app_queue_manager.py
+++ b/api/tests/unit_tests/core/app/apps/test_base_app_queue_manager.py
@@ -81,6 +81,31 @@ class TestBaseAppQueueManager:
                 reason="Client response stream closed before app execution completed",
             )
 
+    def test_complete_listener_segment_sets_event_and_closes_queue(self):
+        with patch("core.app.apps.base_app_queue_manager.redis_client") as mock_redis:
+            mock_redis.setex.return_value = True
+            mock_redis.get.return_value = None
+            manager = DummyQueueManager(task_id="t1", user_id="u1", invoke_from=InvokeFrom.SERVICE_API)
+
+            assert manager._listener_segment_completed.is_set() is False
+            manager.complete_listener_segment()
+            assert manager._listener_segment_completed.is_set() is True
+            assert manager._q.get_nowait() is None
+
+    def test_listen_after_complete_listener_segment_does_not_abort(self):
+        with (
+            patch("core.app.apps.base_app_queue_manager.redis_client") as mock_redis,
+            patch("core.app.apps.base_app_queue_manager.GraphEngineManager") as graph_engine_manager,
+        ):
+            mock_redis.setex.return_value = True
+            mock_redis.get.return_value = None
+            manager = DummyQueueManager(task_id="t1", user_id="u1", invoke_from=InvokeFrom.SERVICE_API)
+
+            manager.complete_listener_segment()
+            assert list(manager.listen()) == []
+
+            graph_engine_manager.return_value.send_stop_command.assert_not_called()
+
     def test_abort_execution_is_idempotent_when_graph_stop_command_fails(self, caplog):
         with (
             patch("core.app.apps.base_app_queue_manager.redis_client") as mock_redis,

--- a/api/tests/unit_tests/core/app/apps/test_message_based_app_queue_manager.py
+++ b/api/tests/unit_tests/core/app/apps/test_message_based_app_queue_manager.py
@@ -22,11 +22,11 @@ class TestMessageBasedAppQueueManager:
                 message_id="m1",
             )
 
-        manager.stop_listen = Mock()
+        manager.complete_listener_segment = Mock()
         manager._is_stopped = Mock(return_value=False)
 
         manager._publish(QueueStopEvent(stopped_by=QueueStopEvent.StopBy.USER_MANUAL), Mock())
-        manager.stop_listen.assert_called_once()
+        manager.complete_listener_segment.assert_called_once()
 
     def test_publish_raises_when_stopped(self):
         with patch("core.app.apps.base_app_queue_manager.redis_client") as mock_redis:
@@ -58,7 +58,7 @@ class TestMessageBasedAppQueueManager:
             )
 
         manager._is_stopped = Mock(return_value=False)
-        manager.stop_listen = Mock()
+        manager.complete_listener_segment = Mock()
 
         manager._publish(QueueMessageEndEvent(), PublishFrom.TASK_PIPELINE)
 

--- a/api/tests/unit_tests/core/app/apps/workflow/test_app_queue_manager.py
+++ b/api/tests/unit_tests/core/app/apps/workflow/test_app_queue_manager.py
@@ -24,11 +24,11 @@ class TestWorkflowAppQueueManager:
 
         with (
             patch.object(manager, "_is_stopped", return_value=True) as is_stopped,
-            patch.object(manager, "stop_listen") as stop_listen,
+            patch.object(manager, "complete_listener_segment") as complete_listener_segment,
         ):
             manager._publish(QueueMessageEndEvent(llm_result=None), PublishFrom.APPLICATION_MANAGER)
 
-        stop_listen.assert_called_once()
+        complete_listener_segment.assert_called_once()
         is_stopped.assert_not_called()
 
     def test_publish_non_stop_event_does_not_raise(self):


### PR DESCRIPTION
## What

Refactor `AppQueueManager` so the response-listener lifecycle is explicit and decoupled from the underlying workflow execution terminal state. Resolves #39782.

## Why

`stop_listen(*, execution_terminal=False)` conflated two independent lifecycles:

1. the response-listener segment, and
2. the workflow execution.

A paused workflow ends its current listener segment but stays `PAUSED` and resumable, so calling the terminal form on `QueueWorkflowPausedEvent` was semantically false but required to suppress the cleanup-path abort. That hidden cross-module invariant produced #39448 and forced #39485 to patch the symptom by adding the pause event to the terminal allowlist. Any new resumable execution state would have to be added to the same allowlist, and omitting one would silently turn normal control flow into destructive distributed cancellation.

Modelling the listener lifecycle directly removes the invariant: a producer that completes its segment marks the listener done, and the cleanup path in `listen()` only aborts when the segment was NOT completed by the producer.

## Changes

- `AppQueueManager._execution_terminal` -> `_listener_segment_completed`. The cleanup path in `listen()` and the early-out in `_abort_execution()` now test the renamed event.
- New method `AppQueueManager.complete_listener_segment()` — producer-completed path. Sets the event, clears the task-belong cache, puts the queue sentinel.
- `AppQueueManager.stop_listen()` — consumer-detached path only. The boolean parameter is removed. The cleanup path aborts the underlying execution exactly once when this method was the only call.
- 3 production call sites (`WorkflowAppQueueManager`, `MessageBasedAppQueueManager`, `PipelineQueueManager`) call `complete_listener_segment()` after publishing a terminal event.
- Concise docstrings on both methods document the new contract and the contrast between the two paths.

## Acceptance criteria

- [x] Workflow pause ends the current listener segment without sending a GraphEngine abort command.
- [x] Successful / partial-success / failed / errored / explicitly stopped executions close the listener normally without a duplicate abort.
- [x] Consumer close before producer completion cancels the execution exactly once.
- [x] Timeout and manual-stop behavior unchanged.
- [x] Advanced Chat pause handling unchanged; its stream still ends only after message-specific completion processing.
- [x] Names and docstrings distinguish listener completion from workflow execution terminality.

## Testing

- 556 unit tests under `tests/unit_tests/core/app/apps/` pass.
- 2 new tests in `test_base_app_queue_manager.py` assert `complete_listener_segment()` sets the event and that a completed-segment `listen()` does not abort.
- `ruff check` and `ruff format --check` clean on all 8 files.
- `pyrefly check api/core/app/` clean.

## Out of scope

A later change may inject an execution-cancellation port so `AppQueueManager` no longer needs to know about both the legacy Redis stop flag and the GraphEngine command channel. Not required for this bounded lifecycle refactor.
