### PR TITLE
fix: update plugin download endpoint references from /download to /download-url

### DIFF
--- a/api/tests/unit_tests/core/helper/test_marketplace.py
+++ b/api/tests/unit_tests/core/helper/test_marketplace.py
@@ -17,7 +17,7 @@ from core.helper.marketplace import (
 def test_get_plugin_pkg_url_contains_unique_identifier() -> None:
     url = get_plugin_pkg_url("langgenius/openai:0.4.2@checksum")
 
-    assert "api/v1/plugins/download" in url
+    assert "api/v1/plugins/download-url" in url
     assert "unique_identifier=langgenius%2Fopenai%3A0.4.2%40checksum" in url
 
 

--- a/e2e/support/marketplace-plugins.ts
+++ b/e2e/support/marketplace-plugins.ts
@@ -100,7 +100,7 @@ const waitForPluginInstallTask = async (
 
 const getMarketplaceDownloadUrl = (pluginUniqueIdentifier: string) => {
   const url = new URL(
-    '/api/v1/plugins/download',
+    '/api/v1/plugins/download-url',
     process.env.E2E_MARKETPLACE_API_URL || defaultMarketplaceApiUrl,
   )
   url.searchParams.set('unique_identifier', pluginUniqueIdentifier)


### PR DESCRIPTION
## Summary

The marketplace plugin download endpoint was renamed from `/api/v1/plugins/download` to `/api/v1/plugins/download-url` in commit `69a16d83` (#39811), but the E2E seed helper and unit test still referenced the old path.

This PR updates:
- `e2e/support/marketplace-plugins.ts`: fix the fallback download URL
- `api/tests/unit_tests/core/helper/test_marketplace.py`: tighten the assertion to verify the exact new path

Previously the test used `assert "api/v1/plugins/download" in url` which passed because `"download-url"` contains the substring `"download"` — this would not catch a future rename.

## Changes

| File | Change |
|------|--------|
| `e2e/support/marketplace-plugins.ts:103` | `/api/v1/plugins/download` → `/api/v1/plugins/download-url` |
| `api/tests/unit_tests/core/helper/test_marketplace.py:20` | `"api/v1/plugins/download"` → `"api/v1/plugins/download-url"` |

## Test Plan

- [x] `git diff --check` clean
- [x] Unit test: `core.helper.marketplace.get_plugin_pkg_url` now returns URL with `/download-url` endpoint

## Real behavior proof

Behavior or issue addressed: After the fix, the E2E seed helper requests the correct `/api/v1/plugins/download-url` endpoint (matching the backend rename in #39811), and the unit test properly validates the new path without false-positive substring matching.

Real environment tested: Repository `langgenius/dify`, branch `fix/plugin-download-url-endpoint`, commit `802fe7042` (main), Python 3.12.

Exact steps or command run after this patch:
```shell
cd api && python3 -c "
from core.helper.marketplace import get_plugin_pkg_url
url = get_plugin_pkg_url('langgenius/openai:0.4.2@checksum')
print(f'URL: {url}')
assert 'api/v1/plugins/download-url' in url
assert 'unique_identifier=langgenius%2Fopenai%3A0.4.2%40checksum' in url
print('OK')
"
```

Evidence after fix:
```
URL: https://marketplace.dify.ai/api/v1/plugins/download-url?unique_identifier=langgenius%2Fopenai%3A0.4.2%40checksum
OK
```

Observed result after fix: `get_plugin_pkg_url()` now returns the correct `/api/v1/plugins/download-url` path. The unit test assertion now validates the exact renamed path instead of relying on substring matching.

What was not tested: E2E seed flow integration (requires full Dify setup with marketplace API); TypeScript compilation of the E2E helper file (requires full Node.js deps).

## Risk

Minimal — two single-line changes in test/E2E support files. No production code paths are modified. The production code (`api/core/helper/marketplace.py`) was already updated to use `/download-url` in #39811.

## Related Issue

Closes #39892