### PR TITLE
fix: build absolute plugin OAuth redirect_uri when CONSOLE_API_URL is empty

### DIFF
--- a/api/services/datasource_provider_service.py
+++ b/api/services/datasource_provider_service.py
@@ -21,6 +21,7 @@ from core.plugin.plugin_service import PluginService
 from core.tools.utils.encryption import ProviderConfigCache, ProviderConfigEncrypter, create_provider_encrypter
 from extensions.ext_database import db
 from extensions.ext_redis import redis_client
+from flask import request
 from graphon.model_runtime.entities.provider_entities import FormType
 from models.oauth import DatasourceOauthParamConfig, DatasourceOauthTenantParamConfig, DatasourceProvider
 from models.provider_ids import DatasourceProviderID
@@ -42,6 +43,19 @@ def get_current_user():
     if not isinstance(user_object, (Account, EndUser)):
         raise TypeError(f"current_user must be Account or EndUser, got {type(user_object).__name__}")
     return current_user
+
+
+def _build_plugin_oauth_redirect_uri(datasource_provider_id: DatasourceProviderID) -> str:
+    """Build the plugin OAuth callback URL.
+
+    Falls back to the current request host when CONSOLE_API_URL is not set, so the callback
+    is an absolute URL instead of a relative path, which OAuth providers like Notion reject
+    with "Missing or invalid redirect_uri".
+    """
+    base_url = dify_config.CONSOLE_API_URL
+    if not base_url:
+        base_url = request.host_url.rstrip("/")
+    return f"{base_url}/console/api/oauth/plugin/{datasource_provider_id}/datasource/callback"
 
 
 class DatasourceProviderService:
@@ -89,9 +103,7 @@ class DatasourceProviderService:
             plugin_id=plugin_id,
             provider=provider,
         )
-        redirect_uri = (
-            f"{dify_config.CONSOLE_API_URL}/console/api/oauth/plugin/{datasource_provider_id}/datasource/callback"
-        )
+        redirect_uri = _build_plugin_oauth_redirect_uri(datasource_provider_id)
         system_credentials = self.get_oauth_client(tenant_id, datasource_provider_id)
         try:
             refreshed_credentials = OAuthHandler().refresh_credentials(
@@ -897,9 +909,7 @@ class DatasourceProviderService:
                 plugin_id=datasource.plugin_id,
                 session=session,
             )
-            redirect_uri = (
-                f"{dify_config.CONSOLE_API_URL}/console/api/oauth/plugin/{datasource_provider_id}/datasource/callback"
-            )
+            redirect_uri = _build_plugin_oauth_redirect_uri(datasource_provider_id)
             datasource_credentials.append(
                 {
                     "provider": datasource.provider,
@@ -962,9 +972,7 @@ class DatasourceProviderService:
                     plugin_id=datasource.plugin_id,
                     session=session,
                 )
-                redirect_uri = "{}/console/api/oauth/plugin/{}/datasource/callback".format(
-                    dify_config.CONSOLE_API_URL, datasource_provider_id
-                )
+                redirect_uri = _build_plugin_oauth_redirect_uri(datasource_provider_id)
                 datasource_credentials.append(
                     {
                         "provider": datasource.provider,


### PR DESCRIPTION
## Summary

When `CONSOLE_API_URL` is not set in the deployment (e.g. empty in `docker/.env`), the plugin OAuth callback URL is built as a **relative path** like `/console/api/oauth/plugin/.../callback`. OAuth providers such as Notion require an absolute URL and reject the flow with `Missing or invalid redirect_uri`.

This PR introduces `_build_plugin_oauth_redirect_uri()` which falls back to the current request host when `CONSOLE_API_URL` is empty, so the callback is always an absolute URL.

## Why

Repro: local Dify deployment (docker, nginx on 8080), Notion datasource plugin. `docker/.env` had `CONSOLE_API_URL=` (empty). Clicking "Save & Authorize" produced an authorize URL with `redirect_uri=%2Fconsole%2Fapi%2Foauth%2Fplugin%2F...` (relative), and Notion returned `Missing or invalid redirect_uri`.

Also tracked in https://github.com/langgenius/dify/issues/21355 (closed without a solution).

## Changes

- Add `_build_plugin_oauth_redirect_uri()` helper: uses `CONSOLE_API_URL` when set, otherwise falls back to `request.host_url`
- Replace all three inline `redirect_uri` constructions in `datasource_provider_service.py` with the helper

## Verification

- `python -m py_compile` passes
- With `CONSOLE_API_URL=` empty: authorize URL now carries `redirect_uri=http://localhost:8080/console/api/oauth/plugin/...` (absolute) and the Notion OAuth flow completes end-to-end (authorize → callback → token exchange)

🤖 Generated with [Claude Code](https://claude.com/claude-code)