### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Build and test powerful AI workflows on a visual canvas, leveraging all the foll
 **2. Comprehensive model support**:
 Seamless integration with hundreds of proprietary / open-source LLMs from dozens of inference providers and self-hosted solutions, covering GPT, Mistral, Llama3, and any OpenAI API-compatible models. A full list of supported model providers can be found [here](https://docs.dify.ai/getting-started/readme/model-providers).
 
+> **Note:** The same OpenAI API-compatible pattern works with multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.
+
 ![providers-v5](https://github.com/langgenius/dify/assets/13230914/5a17bdbe-097a-4100-8363-40255b70f6e3)
 
 **3. Prompt IDE**:


### PR DESCRIPTION
## Summary

The README already highlights support for any OpenAI API-compatible models.

This PR adds a one-line note that the same pattern works with multi-model gateways when you are not self-hosting, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] README renders
- [ ] Existing provider list unchanged
- [ ] Note is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>