### PR TITLE
fix(web): skip auth validation for local file datasource (#39856)

### DIFF
--- a/web/app/components/workflow/utils/__tests__/data-source.spec.ts
+++ b/web/app/components/workflow/utils/__tests__/data-source.spec.ts
@@ -69,9 +69,19 @@ describe('getDataSourceCheckParams', () => {
     ])
   })
 
-  it('should mark an unauthorized datasource as not authed', () => {
+  it('should not require authorization for a local file datasource', () => {
     const result = getDataSourceCheckParams(
       createDataSourceData(),
+      [createDataSourceCollection()],
+      'en_US',
+    )
+
+    expect(result.notAuthed).toBe(false)
+  })
+
+  it('should mark an unauthorized online datasource as not authed', () => {
+    const result = getDataSourceCheckParams(
+      createDataSourceData({ provider_type: 'online_document' }),
       [createDataSourceCollection()],
       'en_US',
     )
@@ -81,7 +91,7 @@ describe('getDataSourceCheckParams', () => {
 
   it('should mark as authed when is_authorized is true', () => {
     const result = getDataSourceCheckParams(
-      createDataSourceData(),
+      createDataSourceData({ provider_type: 'online_document' }),
       [createDataSourceCollection({ is_authorized: true })],
       'en_US',
     )

--- a/web/app/components/workflow/utils/data-source.ts
+++ b/web/app/components/workflow/utils/data-source.ts
@@ -1,13 +1,14 @@
 import type { DataSourceNodeType } from '../nodes/data-source/types'
 import type { InputVar, ToolWithProvider } from '../types'
 import { toolParametersToFormSchemas } from '@/app/components/tools/utils/to-form-schema'
+import { DataSourceClassification } from '../nodes/data-source/types'
 
 export const getDataSourceCheckParams = (
   toolData: DataSourceNodeType,
   dataSourceList: ToolWithProvider[],
   language: string,
 ) => {
-  const { plugin_id, datasource_name } = toolData
+  const { plugin_id, provider_type, datasource_name } = toolData
   const currentDataSource = dataSourceList.find((item) => item.plugin_id === plugin_id)
   const currentDataSourceItem = currentDataSource?.tools.find(
     (tool) => tool.name === datasource_name,
@@ -30,7 +31,10 @@ export const getDataSourceCheckParams = (
       })
       return formInputs
     })(),
-    notAuthed: !!currentDataSource?.allow_delete && !currentDataSource?.is_authorized,
+    notAuthed:
+      provider_type !== DataSourceClassification.localFile &&
+      !!currentDataSource?.allow_delete &&
+      !currentDataSource?.is_authorized,
     language,
   }
 }


### PR DESCRIPTION
## Summary

Cherry-picks `b4d93b02fd55f30224746fab64aa49c60c7e8ad8` onto `hotfix/1.16.1-fix.0`.

Skips plugin authorization validation for local file datasources while retaining it for online datasources.

## Validation

- `BASE_SHA=myori/hotfix/1.16.1-fix.0 HEAD_SHA=HEAD MAIN_REF=myori/main bash .github/scripts/check-hotfix-cherry-picks.sh` -> verified 1 PR commit includes cherry-pick provenance from main
- `cd web && pnpm test run app/components/workflow/utils/__tests__/data-source.spec.ts` -> 1 file, 7 tests passed
- `cd web && pnpm type-check` -> passed
- `git diff --check myori/hotfix/1.16.1-fix.0...HEAD` -> passed