### PR TITLE
fix(api): validate installation scope for cached marketplace packages

### DIFF
--- a/api/core/plugin/plugin_service.py
+++ b/api/core/plugin/plugin_service.py
@@ -919,10 +919,8 @@ class PluginService:
 
         try:
             manager.fetch_plugin_manifest(tenant_id, new_plugin_unique_identifier)
-            # already downloaded, skip, and record install event
-            marketplace.record_install_plugin_event(new_plugin_unique_identifier)
         except Exception:
-            # plugin not installed, download and upload pkg
+            # plugin not downloaded yet, download and upload pkg
             pkg = download_plugin_pkg(new_plugin_unique_identifier)
             response = manager.upload_pkg(
                 tenant_id,
@@ -932,6 +930,11 @@ class PluginService:
 
             # check if the plugin is available to install
             PluginService._check_plugin_installation_scope(response.verification)
+        else:
+            # already downloaded, the cached pkg still has to satisfy the installation scope
+            decode_response = manager.decode_plugin_from_identifier(tenant_id, new_plugin_unique_identifier)
+            PluginService._check_plugin_installation_scope(decode_response.verification)
+            marketplace.record_install_plugin_event(new_plugin_unique_identifier)
 
         result = manager.upgrade_plugin(
             tenant_id,
@@ -1122,14 +1125,8 @@ class PluginService:
         for plugin_unique_identifier in plugin_unique_identifiers:
             try:
                 manager.fetch_plugin_manifest(tenant_id, plugin_unique_identifier)
-                plugin_decode_response = manager.decode_plugin_from_identifier(tenant_id, plugin_unique_identifier)
-                # check if the plugin is available to install
-                PluginService._check_plugin_installation_scope(plugin_decode_response.verification)
-                # already downloaded, skip
-                actual_plugin_unique_identifiers.append(plugin_unique_identifier)
-                metas.append({"plugin_unique_identifier": plugin_unique_identifier})
             except Exception:
-                # plugin not installed, download and upload pkg
+                # plugin not downloaded yet, download and upload pkg
                 pkg = download_plugin_pkg(plugin_unique_identifier)
                 response = manager.upload_pkg(
                     tenant_id,
@@ -1141,6 +1138,12 @@ class PluginService:
                 # use response plugin_unique_identifier
                 actual_plugin_unique_identifiers.append(response.unique_identifier)
                 metas.append({"plugin_unique_identifier": response.unique_identifier})
+            else:
+                # already downloaded, the cached pkg still has to satisfy the installation scope
+                plugin_decode_response = manager.decode_plugin_from_identifier(tenant_id, plugin_unique_identifier)
+                PluginService._check_plugin_installation_scope(plugin_decode_response.verification)
+                actual_plugin_unique_identifiers.append(plugin_unique_identifier)
+                metas.append({"plugin_unique_identifier": plugin_unique_identifier})
 
         result = manager.install_from_identifiers(
             tenant_id,

--- a/api/tests/unit_tests/services/plugin/test_plugin_service.py
+++ b/api/tests/unit_tests/services/plugin/test_plugin_service.py
@@ -16,6 +16,7 @@ from core.provider_manager import ProviderConfigurationCacheSource
 from graphon.model_runtime.entities.common_entities import I18nObject
 from graphon.model_runtime.entities.provider_entities import ConfigurateMethod, ProviderEntity
 from models.provider import Provider, ProviderCredential, ProviderType, TenantPreferredModelProvider
+from services.feature_service import PluginInstallationPermissionModel, PluginInstallationScope
 
 MODULE = "core.plugin.plugin_service"
 TENANT_ID = "11111111-1111-1111-1111-111111111111"
@@ -1018,11 +1019,15 @@ class TestPluginModelProviderCacheInvalidation:
             patch(f"{MODULE}.PluginService.invalidate_plugin_model_providers_cache") as invalidate_cache,
         ):
             mock_config.MARKETPLACE_ENABLED = True
-            feature_service.get_system_features.return_value = SimpleNamespace(
-                plugin_installation_permission=SimpleNamespace(restrict_to_marketplace_only=False)
+            feature_service.get_plugin_installation_permission.return_value = PluginInstallationPermissionModel(
+                restrict_to_marketplace_only=False,
+                plugin_installation_scope=PluginInstallationScope.ALL,
             )
             installer = installer_cls.return_value
             installer.fetch_plugin_manifest.return_value = MagicMock()
+            decode_response = MagicMock()
+            decode_response.verification = None
+            installer.decode_plugin_from_identifier.return_value = decode_response
             installer.upgrade_plugin.return_value = "task-id"
 
             from core.plugin.plugin_service import PluginService

--- a/api/tests/unit_tests/services/plugin/test_plugin_service_installation.py
+++ b/api/tests/unit_tests/services/plugin/test_plugin_service_installation.py
@@ -294,6 +294,71 @@ class TestUpgradePluginWithMarketplace:
         mock_download.assert_called_once_with("new-uid")
         installer.upload_pkg.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "scope",
+        [PluginInstallationScope.OFFICIAL_ONLY, PluginInstallationScope.OFFICIAL_AND_SPECIFIC_PARTNERS],
+    )
+    @patch("core.plugin.plugin_service.download_plugin_pkg")
+    @patch("core.plugin.plugin_service.marketplace")
+    @patch("core.plugin.plugin_service.FeatureService")
+    @patch("core.plugin.plugin_service.PluginInstaller")
+    @patch("core.plugin.plugin_service.dify_config")
+    def test_rejects_cached_pkg_outside_scope(
+        self, mock_config, mock_installer_cls, mock_fs, mock_marketplace, mock_download, scope
+    ):
+        mock_config.MARKETPLACE_ENABLED = True
+        mock_fs.get_plugin_installation_permission.return_value = _make_permission(scope=scope)
+        installer = mock_installer_cls.return_value
+        installer.fetch_plugin_manifest.return_value = MagicMock()
+        decode_resp = MagicMock()
+        decode_resp.verification.authorized_category = PluginVerification.AuthorizedCategory.Community
+        installer.decode_plugin_from_identifier.return_value = decode_resp
+
+        with pytest.raises(PluginInstallationForbiddenError):
+            PluginService.upgrade_plugin_with_marketplace("t1", "old-uid", "new-uid")
+
+        installer.upgrade_plugin.assert_not_called()
+        mock_marketplace.record_install_plugin_event.assert_not_called()
+        # the rejection must not fall through to the download branch and cache the pkg again
+        mock_download.assert_not_called()
+        installer.upload_pkg.assert_not_called()
+
+    @patch("core.plugin.plugin_service.FeatureService")
+    @patch("core.plugin.plugin_service.PluginInstaller")
+    @patch("core.plugin.plugin_service.dify_config")
+    def test_rejects_before_touching_daemon_when_scope_is_none(self, mock_config, mock_installer_cls, mock_fs):
+        mock_config.MARKETPLACE_ENABLED = True
+        mock_fs.get_plugin_installation_permission.return_value = _make_permission(scope=PluginInstallationScope.NONE)
+        installer = mock_installer_cls.return_value
+
+        with pytest.raises(PluginInstallationForbiddenError):
+            PluginService.upgrade_plugin_with_marketplace("t1", "old-uid", "new-uid")
+
+        installer.fetch_plugin_manifest.assert_not_called()
+        installer.upgrade_plugin.assert_not_called()
+
+    @patch("core.plugin.plugin_service.marketplace")
+    @patch("core.plugin.plugin_service.FeatureService")
+    @patch("core.plugin.plugin_service.PluginInstaller")
+    @patch("core.plugin.plugin_service.dify_config")
+    def test_allows_cached_official_pkg_under_official_only(
+        self, mock_config, mock_installer_cls, mock_fs, mock_marketplace
+    ):
+        mock_config.MARKETPLACE_ENABLED = True
+        mock_fs.get_plugin_installation_permission.return_value = _make_permission(
+            scope=PluginInstallationScope.OFFICIAL_ONLY
+        )
+        installer = mock_installer_cls.return_value
+        installer.fetch_plugin_manifest.return_value = MagicMock()
+        decode_resp = MagicMock()
+        decode_resp.verification.authorized_category = PluginVerification.AuthorizedCategory.Langgenius
+        installer.decode_plugin_from_identifier.return_value = decode_resp
+
+        PluginService.upgrade_plugin_with_marketplace("t1", "old-uid", "new-uid")
+
+        mock_marketplace.record_install_plugin_event.assert_called_once_with("new-uid")
+        installer.upgrade_plugin.assert_called_once()
+
 
 class TestUpgradePluginWithGithub:
     @patch("core.plugin.plugin_service.FeatureService")
@@ -373,6 +438,29 @@ class TestInstallFromMarketplacePkg:
         installer.install_from_identifiers.assert_called_once()
         call_args = installer.install_from_identifiers.call_args[0]
         assert call_args[1] == ["uid-1"]
+
+    @patch("core.plugin.plugin_service.download_plugin_pkg")
+    @patch("core.plugin.plugin_service.FeatureService")
+    @patch("core.plugin.plugin_service.PluginInstaller")
+    @patch("core.plugin.plugin_service.dify_config")
+    def test_rejects_cached_pkg_outside_scope(self, mock_config, mock_installer_cls, mock_fs, mock_download):
+        mock_config.MARKETPLACE_ENABLED = True
+        mock_fs.get_plugin_installation_permission.return_value = _make_permission(
+            scope=PluginInstallationScope.OFFICIAL_ONLY
+        )
+        installer = mock_installer_cls.return_value
+        installer.fetch_plugin_manifest.return_value = MagicMock()
+        decode_resp = MagicMock()
+        decode_resp.verification.authorized_category = PluginVerification.AuthorizedCategory.Community
+        installer.decode_plugin_from_identifier.return_value = decode_resp
+
+        with pytest.raises(PluginInstallationForbiddenError):
+            PluginService.install_from_marketplace_pkg("t1", ["uid-1"])
+
+        installer.install_from_identifiers.assert_not_called()
+        # the rejection must not fall through to the download branch and cache the pkg again
+        mock_download.assert_not_called()
+        installer.upload_pkg.assert_not_called()
 
 
 class TestUninstall:


### PR DESCRIPTION
## Summary

Under a restricted `Allowed Plugins` policy, clicking Install twice on an already-installed plugin upgrades it anyway — the policy is bypassed.

`upgrade_plugin_with_marketplace` ran no scope check at all when `fetch_plugin_manifest` found the package already cached in the plugin daemon:

```python
try:
    manager.fetch_plugin_manifest(...)        # cache hit -> no scope check whatsoever
    marketplace.record_install_plugin_event(...)
except Exception:
    pkg = download_plugin_pkg(...)
    response = manager.upload_pkg(...)        # side effect happens first
    PluginService._check_plugin_installation_scope(response.verification)
```

The first click takes `except`: the package is downloaded and uploaded to the daemon *before* the scope check rejects it, so it stays cached. The second click hits the cache, takes the unvalidated `try` branch, and upgrades. This reproduces on `OFFICIAL_ONLY` and `OFFICIAL_AND_SPECIFIC_PARTNERS`; `NONE` is already rejected up front by `_get_plugin_installation_permission` (#39669).

`install_from_marketplace_pkg` does validate its cached branch, but the check sits inside the same `try` that detects caching, so `PluginInstallationForbiddenError` is swallowed by `except Exception` and falls through to the download branch. The outcome is still a rejection, but every rejected install re-downloads and re-caches the package it just refused.

### Change

Both marketplace paths move the cached branch from `try` into `else`, and the upgrade path gains the missing `decode_plugin_from_identifier` + `_check_plugin_installation_scope`. `else` is load-bearing: exceptions raised there are not caught by the sibling `except`, so the policy error propagates instead of triggering a pointless re-download.

The plugin daemon exposes no endpoint to evict an uploaded package (`PluginInstaller` only has uninstall and install-task deletion), so a package cached by the pre-fix flow cannot be removed retroactively. Validating on every path makes such a leftover inert rather than a bypass.

Internal tracking: [EE-1842](https://linear.app/dify/issue/EE-1842).

## Test plan

Reverting only the source change while keeping the new tests reproduces the reported bug:

```
FAILED TestUpgradePluginWithMarketplace::test_rejects_cached_pkg_outside_scope[official_only]
    - DID NOT RAISE PluginInstallationForbiddenError
FAILED TestUpgradePluginWithMarketplace::test_rejects_cached_pkg_outside_scope[official_and_specific_partners]
    - DID NOT RAISE PluginInstallationForbiddenError
FAILED TestInstallFromMarketplacePkg::test_rejects_cached_pkg_outside_scope
    - Expected 'download_plugin_pkg' to not have been called. Called 1 times.
```

With the fix, `pytest api/tests/unit_tests/services/plugin/` is 138 passed.

New coverage: cached package under each restricted scope is rejected without re-downloading; `NONE` never reaches the daemon; a cached officially-signed package still upgrades under `OFFICIAL_ONLY`.

Also repaired a stale mock in `test_plugin_service.py` — the cache-invalidation test stubbed `FeatureService.get_system_features`, which the service stopped calling, so the now-reachable scope check saw a `MagicMock` scope and raised `policy is invalid`. It now stubs `get_plugin_installation_permission` with a real `PluginInstallationPermissionModel`.

`make lint` clean. `make type-check` doesn't complete in a nested worktree (pyrefly skips its include patterns) — this predates the change; per-file `dev/pyrefly-check-local api/core/plugin/plugin_service.py` and `mypy` on the changed file both pass.
