### PR TITLE
revert(dify-agent): restore per-item config materialization

### DIFF
--- a/dify-agent/src/dify_agent/layers/config/layer.py
+++ b/dify-agent/src/dify_agent/layers/config/layer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json
+import asyncio
 import shlex
 from dataclasses import dataclass
 from typing import ClassVar
@@ -194,101 +194,71 @@ class DifyConfigLayer(PlainLayer[DifyConfigDeps, DifyConfigLayerConfig, DifyConf
         if not self.config.mentioned_skill_names and not self.config.mentioned_file_names:
             return
 
-        if names := self.config.mentioned_skill_names:
-            output = await self._run_mentioned_pull(
-                script=self._build_shell_skill_pull_script(names),
-                target_kind="skill",
-            )
-            self.runtime_state.pulled_skill_outputs = _parse_skill_pull_outputs(output, names)
+        tasks = [
+            *(self._pull_mentioned_skill(name) for name in self.config.mentioned_skill_names),
+            *(self._pull_mentioned_file(name) for name in self.config.mentioned_file_names),
+        ]
+        await asyncio.gather(*tasks)
 
-        if names := self.config.mentioned_file_names:
-            output = await self._run_mentioned_pull(
-                script=self._build_shell_file_pull_script(names),
-                target_kind="file",
-            )
-            self.runtime_state.pulled_file_outputs = _parse_file_pull_outputs(output, names)
-
-    async def _run_mentioned_pull(self, *, script: str, target_kind: str) -> str:
+    async def _pull_mentioned_skill(self, name: str) -> None:
         result = await self.deps.shell.run_remote_script(
-            script,
+            self._build_shell_skill_pull_script(name),
             inject_agent_stub_env=True,
         )
         if result.exit_code != 0:
             raise DifyConfigLayerError(
-                f"config mentioned {target_kind} pull failed in shell: "
+                "config mentioned skill pull failed in shell: "
                 f"{result.status} exit_code={result.exit_code}\n{result.output}"
             )
         if not result.output_complete:
             reason = result.incomplete_reason or "unknown"
             raise DifyConfigLayerError(
-                f"config mentioned {target_kind} pull output was incomplete before the payload finished: {reason}"
+                f"config mentioned skill pull output was incomplete before the payload finished: {reason}"
             )
         output = result.output.strip()
         if not output:
-            raise DifyConfigLayerError(f"missing pull output for mentioned config {target_kind}s")
-        return output
-
-    def _build_shell_skill_pull_script(self, names: list[str]) -> str:
-        targets = " ".join(shlex.quote(name) for name in names)
-        return f"set -eu\ndify-agent config skills pull --json {targets}"
-
-    def _build_shell_file_pull_script(self, names: list[str]) -> str:
-        targets = " ".join(shlex.quote(name) for name in names)
-        return f"set -eu\ndify-agent config files pull --json {targets}"
-
-
-def _parse_skill_pull_outputs(output: str, expected_names: list[str]) -> dict[str, str]:
-    items = _parse_pull_items(output, target_kind="skill")
-    parsed: dict[str, str] = {}
-    for name in expected_names:
-        item = items.get(name)
-        if item is None:
             raise DifyConfigLayerError(f"missing pull output for mentioned config skill {name}")
-        directory_path = item.get("directory_path")
-        skill_md = item.get("skill_md")
-        if not isinstance(directory_path, str) or not directory_path:
-            raise DifyConfigLayerError(f"invalid directory path in pull output for mentioned config skill {name}")
-        if not isinstance(skill_md, str):
-            raise DifyConfigLayerError(f"invalid skill content in pull output for mentioned config skill {name}")
-        parsed[name] = f"{directory_path}\n{skill_md}".strip()
-    return parsed
+        self.runtime_state.pulled_skill_outputs = {
+            **self.runtime_state.pulled_skill_outputs,
+            name: output,
+        }
 
-
-def _parse_file_pull_outputs(output: str, expected_names: list[str]) -> dict[str, str]:
-    items = _parse_pull_items(output, target_kind="file")
-    parsed: dict[str, str] = {}
-    for name in expected_names:
-        item = items.get(name)
-        if item is None:
+    async def _pull_mentioned_file(self, name: str) -> None:
+        result = await self.deps.shell.run_remote_script(
+            self._build_shell_file_pull_script(name),
+            inject_agent_stub_env=True,
+        )
+        if result.exit_code != 0:
+            raise DifyConfigLayerError(
+                "config mentioned file pull failed in shell: "
+                f"{result.status} exit_code={result.exit_code}\n{result.output}"
+            )
+        if not result.output_complete:
+            reason = result.incomplete_reason or "unknown"
+            raise DifyConfigLayerError(
+                f"config mentioned file pull output was incomplete before the payload finished: {reason}"
+            )
+        output = result.output.strip()
+        if not output:
             raise DifyConfigLayerError(f"missing pull output for mentioned config file {name}")
-        path = item.get("path")
-        if not isinstance(path, str) or not path:
-            raise DifyConfigLayerError(f"invalid path in pull output for mentioned config file {name}")
-        parsed[name] = path
-    return parsed
+        self.runtime_state.pulled_file_outputs = {
+            **self.runtime_state.pulled_file_outputs,
+            name: output,
+        }
 
+    def _build_shell_skill_pull_script(self, name: str) -> str:
+        lines = [
+            "set -eu",
+            f"dify-agent config skills pull {shlex.quote(name)}",
+        ]
+        return "\n".join(lines)
 
-def _parse_pull_items(output: str, *, target_kind: str) -> dict[str, dict[str, object]]:
-    try:
-        payload: object = json.loads(output)
-    except json.JSONDecodeError as exc:
-        raise DifyConfigLayerError(f"invalid JSON pull output for mentioned config {target_kind}s") from exc
-    if not isinstance(payload, dict):
-        raise DifyConfigLayerError(f"invalid pull output for mentioned config {target_kind}s")
-    raw_items = payload.get("items")
-    if not isinstance(raw_items, list):
-        raise DifyConfigLayerError(f"missing items in pull output for mentioned config {target_kind}s")
-
-    items: dict[str, dict[str, object]] = {}
-    for raw_item in raw_items:
-        if not isinstance(raw_item, dict):
-            raise DifyConfigLayerError(f"invalid item in pull output for mentioned config {target_kind}s")
-        item = {str(key): value for key, value in raw_item.items()}
-        name = item.get("name")
-        if not isinstance(name, str) or not name:
-            raise DifyConfigLayerError(f"missing item name in pull output for mentioned config {target_kind}s")
-        items[name] = item
-    return items
+    def _build_shell_file_pull_script(self, name: str) -> str:
+        lines = [
+            "set -eu",
+            f"dify-agent config files pull {shlex.quote(name)}",
+        ]
+        return "\n".join(lines)
 
 
 def _format_command_output(command: str, output: str) -> str:

--- a/dify-agent/tests/local/dify_agent/layers/config/test_layer.py
+++ b/dify-agent/tests/local/dify_agent/layers/config/test_layer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json
+import asyncio
 from typing import Literal
 
 import pytest
@@ -62,40 +62,32 @@ def _remote_result(
     )
 
 
-def _skill_pull_output(*names: str, include_skill: bool = True) -> str:
-    items = []
-    if include_skill:
-        items = [
-            {
-                "name": name,
-                "archive_path": f"/workspace/.dify_conf/skills/{name}.zip",
-                "directory_path": f"/workspace/.dify_conf/skills/{name}",
-                "skill_md": "# Alpha\nUse it.\n",
-            }
-            for name in names or ("alpha",)
-        ]
-    return json.dumps({"items": items})
+def _skill_pull_output(*, include_skill: bool = True) -> str:
+    if not include_skill:
+        return ""
+    return "/workspace/.dify_conf/skills/alpha\n# Alpha\nUse it.\n"
 
 
-def _file_pull_output(*names: str, include_file: bool = True) -> str:
-    items = []
-    if include_file:
-        items = [{"name": name, "path": f"/workspace/.dify_conf/files/{name}"} for name in names or ("guide.txt",)]
-    return json.dumps({"items": items})
+def _file_pull_output(*, include_file: bool = True) -> str:
+    if not include_file:
+        return ""
+    return "/workspace/.dify_conf/files/guide.txt\n"
 
 
 def test_build_shell_pull_scripts_include_targets() -> None:
     layer = _build_layer()
 
-    skill_script = layer._build_shell_skill_pull_script(["alpha", "skill with space"])
-    file_script = layer._build_shell_file_pull_script(["guide.txt", "file with space.txt"])
+    skill_script = layer._build_shell_skill_pull_script("alpha")
+    file_script = layer._build_shell_file_pull_script("guide.txt")
 
-    assert skill_script == "set -eu\ndify-agent config skills pull --json alpha 'skill with space'"
-    assert file_script == "set -eu\ndify-agent config files pull --json guide.txt 'file with space.txt'"
+    assert skill_script == "set -eu\ndify-agent config skills pull alpha"
+    assert "__DIFY_CONFIG_SKILLS_BEGIN__" not in skill_script
+    assert file_script == "set -eu\ndify-agent config files pull guide.txt"
+    assert "__DIFY_CONFIG_FILES_BEGIN__" not in file_script
 
 
 @pytest.mark.anyio
-async def test_on_context_create_computes_runtime_fields_and_pulls_mentioned_assets_in_batches(
+async def test_on_context_create_computes_runtime_fields_and_pulls_mentioned_assets_in_parallel(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     layer = _build_layer()
@@ -112,6 +104,7 @@ async def test_on_context_create_computes_runtime_fields_and_pulls_mentioned_ass
         captured_scripts.append(script)
         active_commands += 1
         max_active_commands = max(max_active_commands, active_commands)
+        await asyncio.sleep(0)
         active_commands -= 1
         if "skills pull" in script:
             return _remote_result(_skill_pull_output())
@@ -123,11 +116,11 @@ async def test_on_context_create_computes_runtime_fields_and_pulls_mentioned_ass
 
     await layer.on_context_create()
 
-    assert max_active_commands == 1
+    assert max_active_commands > 1
     assert len(captured_scripts) == 2
-    assert captured_scripts == [
-        "set -eu\ndify-agent config skills pull --json alpha",
-        "set -eu\ndify-agent config files pull --json guide.txt",
+    assert sorted(captured_scripts) == [
+        "set -eu\ndify-agent config files pull guide.txt",
+        "set -eu\ndify-agent config skills pull alpha",
     ]
     assert layer.runtime_state.pulled_skill_outputs == {"alpha": "/workspace/.dify_conf/skills/alpha\n# Alpha\nUse it."}
     assert layer.runtime_state.pulled_file_outputs == {"guide.txt": "/workspace/.dify_conf/files/guide.txt"}
@@ -145,39 +138,6 @@ async def test_on_context_create_computes_runtime_fields_and_pulls_mentioned_ass
         "$ dify-agent file download --help"
     )
     assert _AGENT_FILE_UPLOAD_REPLY_HINT in suffix_prompt
-
-
-@pytest.mark.anyio
-async def test_on_context_create_batches_all_mentioned_assets_into_two_serial_jobs(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    layer = _build_layer()
-    layer.config = layer.config.model_copy(
-        update={
-            "mentioned_skill_names": [f"skill-{index}" for index in range(4)],
-            "mentioned_file_names": [f"file-{index}.txt" for index in range(4)],
-        }
-    )
-    captured_scripts: list[str] = []
-
-    async def fake_run_remote_script(self, script: str, *, inject_agent_stub_env: bool = False, timeout: float = 10.0):
-        del self, timeout
-        assert inject_agent_stub_env is True
-        captured_scripts.append(script)
-        if "skills pull" in script:
-            return _remote_result(_skill_pull_output(*(f"skill-{index}" for index in range(4))))
-        return _remote_result(_file_pull_output(*(f"file-{index}.txt" for index in range(4))))
-
-    monkeypatch.setattr(DifyShellLayer, "run_remote_script", fake_run_remote_script)
-
-    await layer.on_context_create()
-
-    assert captured_scripts == [
-        "set -eu\ndify-agent config skills pull --json skill-0 skill-1 skill-2 skill-3",
-        "set -eu\ndify-agent config files pull --json file-0.txt file-1.txt file-2.txt file-3.txt",
-    ]
-    assert set(layer.runtime_state.pulled_skill_outputs) == {f"skill-{index}" for index in range(4)}
-    assert set(layer.runtime_state.pulled_file_outputs) == {f"file-{index}.txt" for index in range(4)}
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- revert #39873 and restore per-item Config materialization
- keep this production change separate from benchmark data-path validation
- re-evaluate Config and File behavior with content-level checks before reintroducing an optimization

## Validation

- `UV_PYTHON=3.12.13 uv run --project dify-agent --extra server pytest dify-agent/tests/local/dify_agent/layers/config/test_layer.py -q` (6 passed)
- `make -C dify-agent check` (passed)
- `make -C dify-agent typecheck` (blocked by 75 pre-existing repository-wide errors outside this revert)
- `make -C dify-agent test` (blocked during collection by existing duplicate test module names)

## Scope

This PR only reverts the production Config-layer changes from #39873. Benchmark Config/File data-path validation will remain in the benchmark PR.
