### PR TITLE
fix(dify-agent): keep tmux server alive without sessions

### DIFF
--- a/dify-agent-runtime/internal/server/tmux.go
+++ b/dify-agent-runtime/internal/server/tmux.go
@@ -21,7 +21,11 @@ func NewTmuxController(config *Config) *TmuxController {
 
 // StartServer ensures the tmux server is running.
 func (t *TmuxController) StartServer() error {
-	_, err := t.runTmux("start-server")
+	_, err := t.runTmux(
+		"start-server",
+		";",
+		"set-option", "-g", "exit-empty", "off",
+	)
 	return err
 }
 

--- a/dify-agent-runtime/internal/server/tmux_test.go
+++ b/dify-agent-runtime/internal/server/tmux_test.go
@@ -1,8 +1,90 @@
 package server
 
 import (
+	"os/exec"
+	"strings"
 	"testing"
 )
+
+func newTestTmuxController(t *testing.T) *TmuxController {
+	t.Helper()
+
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+
+	config := DefaultConfig()
+	config.RuntimeDir = t.TempDir()
+	controller := NewTmuxController(config)
+	t.Cleanup(func() {
+		_, _ = controller.runTmuxNoCheck("kill-server")
+	})
+
+	return controller
+}
+
+func assertTmuxServerRunning(t *testing.T, controller *TmuxController) {
+	t.Helper()
+
+	exitEmpty, err := controller.runTmux("show-options", "-gv", "exit-empty")
+	if err != nil {
+		t.Fatalf("tmux server is not running: %v", err)
+	}
+	if got := strings.TrimSpace(exitEmpty); got != "off" {
+		t.Fatalf("exit-empty = %q, want %q", got, "off")
+	}
+}
+
+func TestStartServerKeepsTmuxServerRunningWithoutSessions(t *testing.T) {
+	controller := newTestTmuxController(t)
+
+	if err := controller.StartServer(); err != nil {
+		t.Fatalf("StartServer() error = %v", err)
+	}
+
+	assertTmuxServerRunning(t, controller)
+
+	sessions, err := controller.ListSessions()
+	if err != nil {
+		t.Fatalf("ListSessions() error = %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Fatalf("ListSessions() = %v, want no sessions", sessions)
+	}
+}
+
+func TestTmuxServerRemainsRunningAfterLastSessionIsDeleted(t *testing.T) {
+	controller := newTestTmuxController(t)
+
+	if err := controller.StartServer(); err != nil {
+		t.Fatalf("StartServer() error = %v", err)
+	}
+
+	const jobID = "last-session"
+	sessionName := JobSessionName(jobID)
+	if _, err := controller.runTmux("new-session", "-d", "-s", sessionName); err != nil {
+		t.Fatalf("create tmux session: %v", err)
+	}
+
+	sessions, err := controller.ListSessions()
+	if err != nil {
+		t.Fatalf("ListSessions() before cleanup error = %v", err)
+	}
+	if !sessions[sessionName] {
+		t.Fatalf("ListSessions() = %v, want session %q", sessions, sessionName)
+	}
+
+	controller.CleanupSession(jobID)
+	assertTmuxServerRunning(t, controller)
+
+	sessions, err = controller.ListSessions()
+	if err != nil {
+		t.Fatalf("ListSessions() after cleanup error = %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Fatalf("ListSessions() after cleanup = %v, want no sessions", sessions)
+	}
+}
 
 func TestShellQuote(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Keep shellctl's dedicated tmux server alive when no job sessions exist by setting the global `exit-empty` option to `off` during server startup.
- Add real-tmux regression coverage for zero-session startup and deletion of the final session.
- Keep the change limited to normal tmux lifecycle ownership; no retry, recovery, healthcheck, or anchor-session behavior is added.

## Root cause

shellctl started its dedicated tmux server with the default `exit-empty=on`. Deleting the final job session therefore allowed tmux to exit and remove or recreate its shared socket. Concurrent job status checks could hit that lifecycle window and return `tmux_error (500)`.

## Impact

The tmux server and its socket now remain available across zero-session periods, preventing scheduled runs and context cleanup from failing when the final session is removed.

## Validation

- `go test ./...` from `dify-agent-runtime/`
- `git diff --check`
- Focused real-tmux lifecycle tests repeated during implementation review

## Screenshots

N/A — runtime-only changes.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

****This PR is made with gpt-5.6-sol (codex), while I'm responsible for all the changes.****