### PR TITLE
chore(api): remove unreachable match suppressions

### DIFF
--- a/api/core/app/apps/common/workflow_response_converter.py
+++ b/api/core/app/apps/common/workflow_response_converter.py
@@ -856,7 +856,9 @@ class WorkflowResponseConverter:
         return tuple(flattened_files)
 
     @classmethod
-    def _fetch_files_from_variable_value(cls, value: Union[dict, list, Segment]) -> Sequence[Mapping[str, Any]]:
+    def _fetch_files_from_variable_value(
+        cls, value: Union[dict, list, Segment, File, None]
+    ) -> Sequence[Mapping[str, Any]]:
         """
         Fetch files from variable value
         :param value: variable value
@@ -871,7 +873,6 @@ class WorkflowResponseConverter:
                 files.append(value.value.to_dict())
             case ArrayFileSegment():
                 files.extend([i.to_dict() for i in value.value])
-            # pyrefly: ignore [unreachable-match-case]
             case File():
                 files.append(value.to_dict())
             case list():

--- a/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
+++ b/api/core/app/task_pipeline/easy_ui_based_generate_task_pipeline.py
@@ -373,12 +373,11 @@ class EasyUIBasedGenerateTaskPipeline(BasedGenerateTaskPipeline[EasyUIAppGenerat
 
         delta_text = ""
         # EasyUI streams text only; structured multimodal chunks contribute their text parts.
-        for content in delta_content:
+        for content in cast(list[object], delta_content):
             logger.debug("The content type %s in LLM chunk delta message content.: %r", type(content), content)
             match content:
                 case TextPromptMessageContent():
                     delta_text += content.data
-                # pyrefly: ignore [unreachable-match-case]
                 case str():
                     delta_text += content
                 case _:

--- a/api/core/mcp/session/base_session.py
+++ b/api/core/mcp/session/base_session.py
@@ -135,7 +135,7 @@ class BaseSession[
     messages when entered.
     """
 
-    _response_streams: dict[RequestId, queue.Queue[JSONRPCResponse | JSONRPCError | HTTPStatusError]]
+    _response_streams: dict[RequestId, queue.Queue[JSONRPCResponse | JSONRPCError | HTTPStatusError | None]]
     _request_id: int
     _in_flight: dict[RequestId, RequestResponder[ReceiveRequestT, SendResultT]]
     _receive_request_type: type[ReceiveRequestT]
@@ -216,7 +216,7 @@ class BaseSession[
         request_id = self._request_id
         self._request_id = request_id + 1
 
-        response_queue: queue.Queue[JSONRPCResponse | JSONRPCError | HTTPStatusError] = queue.Queue()
+        response_queue: queue.Queue[JSONRPCResponse | JSONRPCError | HTTPStatusError | None] = queue.Queue()
         self._response_streams[request_id] = response_queue
 
         try:
@@ -241,7 +241,6 @@ class BaseSession[
                     continue
 
             match response_or_error:
-                # pyrefly: ignore [unreachable-match-case]
                 case None:
                     raise MCPConnectionError(
                         ErrorData(


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

- Widen the static types at the LLM-content, workflow-output, and MCP-response boundaries to reflect values the existing runtime paths already support.
- Remove the three `unreachable-match-case` Pyrefly suppressions without changing runtime behavior.

Fixes #39948

## Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs) — N/A; no user-facing behavior changed.
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. — N/A; this is a static-type correction with no new behavior, and the existing affected-path tests pass.
- [ ] I've updated the documentation accordingly. — N/A; no documentation change is required.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods — targeted Ruff, Pyrefly, and MyPy checks passed for all changed backend files; frontend is unaffected.

### Validation

- `uv run --project api --dev ruff format --check <changed files>`
- `uv run --project api --dev ruff check <changed files>`
- `./dev/pyrefly-check-local <changed files>`
- Targeted MyPy on all changed files
- `make test TARGET_TESTS='api/tests/unit_tests/core/app/apps/common/test_workflow_response_converter.py api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_based_generate_task_pipeline_core.py api/tests/unit_tests/core/mcp/session/test_base_session.py'` — 83 passed

From Codex
