### PR TITLE
docs: correct in-app /audio-to-text API reference to match implementation

### DIFF
--- a/api/controllers/service_api/app/audio.py
+++ b/api/controllers/service_api/app/audio.py
@@ -55,6 +55,7 @@ class AudioApi(Resource):
         responses={
             200: "Successfully converted audio to text.",
             400: (
+                "- `no_audio_uploaded` : No audio file was provided in the request.\n"
                 "- `speech_to_text_disabled` : Speech-to-text is disabled for this app.\n"
                 "- `provider_not_support_speech_to_text` : Model provider does not support speech-to-text.\n"
                 "- `provider_not_initialize` : No valid model provider credentials found.\n"

--- a/api/controllers/service_api/app/audio.py
+++ b/api/controllers/service_api/app/audio.py
@@ -55,12 +55,9 @@ class AudioApi(Resource):
         responses={
             200: "Successfully converted audio to text.",
             400: (
-                "- `app_unavailable` : App unavailable or misconfigured.\n"
                 "- `speech_to_text_disabled` : Speech-to-text is disabled for this app.\n"
                 "- `provider_not_support_speech_to_text` : Model provider does not support speech-to-text.\n"
                 "- `provider_not_initialize` : No valid model provider credentials found.\n"
-                "- `provider_quota_exceeded` : Model provider quota exhausted.\n"
-                "- `model_currently_not_support` : Current model does not support this operation.\n"
                 "- `completion_request_error` : Speech recognition request failed."
             ),
             413: "`audio_too_large` : Audio file size exceeded the limit.",

--- a/api/openapi/markdown/service-openapi.md
+++ b/api/openapi/markdown/service-openapi.md
@@ -278,7 +278,7 @@ Convert audio file to text. Supported MIME types: `audio/mp3`, `audio/mpga`, `au
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
 | 200 | Successfully converted audio to text. | **application/json**: [AudioTranscriptResponse](#audiotranscriptresponse)<br> |
-| 400 | - `app_unavailable` : App unavailable or misconfigured. - `speech_to_text_disabled` : Speech-to-text is disabled for this app. - `provider_not_support_speech_to_text` : Model provider does not support speech-to-text. - `provider_not_initialize` : No valid model provider credentials found. - `provider_quota_exceeded` : Model provider quota exhausted. - `model_currently_not_support` : Current model does not support this operation. - `completion_request_error` : Speech recognition request failed. |  |
+| 400 | - `no_audio_uploaded` : No audio file was provided in the request. - `speech_to_text_disabled` : Speech-to-text is disabled for this app. - `provider_not_support_speech_to_text` : Model provider does not support speech-to-text. - `provider_not_initialize` : No valid model provider credentials found. - `completion_request_error` : Speech recognition request failed. |  |
 | 401 | Unauthorized - invalid API token |  |
 | 403 | Forbidden - token scope, app, dataset, or workspace access denied |  |
 | 413 | `audio_too_large` : Audio file size exceeded the limit. |  |

--- a/web/app/components/develop/template/template_advanced_chat.en.mdx
+++ b/web/app/components/develop/template/template_advanced_chat.en.mdx
@@ -1799,8 +1799,8 @@ Chat applications support session persistence, allowing previous chat history to
     <Properties>
       <Property name='file' type='file' key='file'>
         Audio file.
-        Supported formats: `['mp3', 'mp4', 'mpeg', 'mpga', 'm4a', 'wav', 'webm']`
-        File size limit: 15MB
+        Supported formats: `['mp3', 'm4a', 'wav', 'amr', 'mpga']`
+        File size limit: 30MB
       </Property>
       <Property name='user' type='string' key='user'>
       User identifier, defined by the developer's rules, must be unique within the application.
@@ -1819,7 +1819,7 @@ Chat applications support session persistence, allowing previous chat history to
       label="/audio-to-text"
       targetCode={`curl -X POST '${props.appDetail.api_base_url}/audio-to-text' \\
 --header 'Authorization: Bearer {api_key}' \\
---form 'file=@localfile;type=audio/[mp3|mp4|mpeg|mpga|m4a|wav|webm]'`}
+--form 'file=@localfile;type=audio/[mp3|m4a|wav|amr|mpga]'`}
     />
 
     <CodeGroup title="Response">

--- a/web/app/components/develop/template/template_advanced_chat.ja.mdx
+++ b/web/app/components/develop/template/template_advanced_chat.ja.mdx
@@ -1799,8 +1799,8 @@ import { WorkflowVersionApiUpgradeNotice } from '../workflow-version-api-upgrade
     <Properties>
       <Property name='file' type='file' key='file'>
         オーディオファイル。
-        サポートされている形式：`['mp3', 'mp4', 'mpeg', 'mpga', 'm4a', 'wav', 'webm']`
-        ファイルサイズ制限：15MB
+        サポートされている形式：`['mp3', 'm4a', 'wav', 'amr', 'mpga']`
+        ファイルサイズ制限：30MB
       </Property>
       <Property name='user' type='string' key='user'>
       ユーザー識別子、開発者のルールによって定義され、アプリケーション内で一意でなければなりません。
@@ -1819,7 +1819,7 @@ import { WorkflowVersionApiUpgradeNotice } from '../workflow-version-api-upgrade
       label="/audio-to-text"
       targetCode={`curl -X POST '${props.appDetail.api_base_url}/audio-to-text' \\
 --header 'Authorization: Bearer {api_key}' \\
---form 'file=@localfile;type=audio/[mp3|mp4|mpeg|mpga|m4a|wav|webm]'`}
+--form 'file=@localfile;type=audio/[mp3|m4a|wav|amr|mpga]'`}
     />
 
     <CodeGroup title="応答">

--- a/web/app/components/develop/template/template_advanced_chat.zh.mdx
+++ b/web/app/components/develop/template/template_advanced_chat.zh.mdx
@@ -1822,8 +1822,8 @@ import { WorkflowVersionApiUpgradeNotice } from '../workflow-version-api-upgrade
     <Properties>
       <Property name='file' type='file' key='file'>
         语音文件。
-        支持格式：`['mp3', 'mp4', 'mpeg', 'mpga', 'm4a', 'wav', 'webm']`
-        文件大小限制：15MB
+        支持格式：`['mp3', 'm4a', 'wav', 'amr', 'mpga']`
+        文件大小限制：30MB
       </Property>
       <Property name='user' type='string' key='user'>
         用户标识，由开发者定义规则，需保证用户标识在应用内唯一。
@@ -1841,7 +1841,7 @@ import { WorkflowVersionApiUpgradeNotice } from '../workflow-version-api-upgrade
       label="/audio-to-text"
       targetCode={`curl -X POST '${props.appDetail.api_base_url}/audio-to-text' \\
 --header 'Authorization: Bearer {api_key}' \\
---form 'file=@localfile;type=audio/[mp3|mp4|mpeg|mpga|m4a|wav|webm]'`}
+--form 'file=@localfile;type=audio/[mp3|m4a|wav|amr|mpga]'`}
     />
 
     <CodeGroup title="Response">

--- a/web/app/components/develop/template/template_chat.en.mdx
+++ b/web/app/components/develop/template/template_chat.en.mdx
@@ -1323,8 +1323,8 @@ Chat applications support session persistence, allowing previous chat history to
     <Properties>
       <Property name='file' type='file' key='file'>
         Audio file.
-        Supported formats: `['mp3', 'mp4', 'mpeg', 'mpga', 'm4a', 'wav', 'webm']`
-        File size limit: 15MB
+        Supported formats: `['mp3', 'm4a', 'wav', 'amr', 'mpga']`
+        File size limit: 30MB
       </Property>
       <Property name='user' type='string' key='user'>
       User identifier, defined by the developer's rules, must be unique within the application.
@@ -1343,7 +1343,7 @@ Chat applications support session persistence, allowing previous chat history to
       label="/audio-to-text"
       targetCode={`curl -X POST '${props.appDetail.api_base_url}/audio-to-text' \\
 --header 'Authorization: Bearer {api_key}' \\
---form 'file=@localfile;type=audio/[mp3|mp4|mpeg|mpga|m4a|wav|webm]'`}
+--form 'file=@localfile;type=audio/[mp3|m4a|wav|amr|mpga]'`}
     />
 
     <CodeGroup title="Response">

--- a/web/app/components/develop/template/template_chat.ja.mdx
+++ b/web/app/components/develop/template/template_chat.ja.mdx
@@ -1317,8 +1317,8 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
     <Properties>
       <Property name='file' type='file' key='file'>
         オーディオファイル。
-        サポートされている形式：`['mp3', 'mp4', 'mpeg', 'mpga', 'm4a', 'wav', 'webm']`
-        ファイルサイズ制限：15MB
+        サポートされている形式：`['mp3', 'm4a', 'wav', 'amr', 'mpga']`
+        ファイルサイズ制限：30MB
       </Property>
       <Property name='user' type='string' key='user'>
       ユーザー識別子、開発者のルールで定義され、アプリケーション内で一意でなければなりません。
@@ -1337,7 +1337,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
       label="/audio-to-text"
       targetCode={`curl -X POST '${props.appDetail.api_base_url}/audio-to-text' \\
 --header 'Authorization: Bearer {api_key}' \\
---form 'file=@localfile;type=audio/[mp3|mp4|mpeg|mpga|m4a|wav|webm]'`}
+--form 'file=@localfile;type=audio/[mp3|m4a|wav|amr|mpga]'`}
     />
 
     <CodeGroup title="応答">

--- a/web/app/components/develop/template/template_chat.zh.mdx
+++ b/web/app/components/develop/template/template_chat.zh.mdx
@@ -1325,8 +1325,8 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
     <Properties>
       <Property name='file' type='file' key='file'>
         语音文件。
-        支持格式：`['mp3', 'mp4', 'mpeg', 'mpga', 'm4a', 'wav', 'webm']`
-        文件大小限制：15MB
+        支持格式：`['mp3', 'm4a', 'wav', 'amr', 'mpga']`
+        文件大小限制：30MB
       </Property>
       <Property name='user' type='string' key='user'>
         用户标识，由开发者定义规则，需保证用户标识在应用内唯一。
@@ -1344,7 +1344,7 @@ import { Row, Col, Properties, Property, Heading, SubProperty } from '../md.tsx'
       label="/audio-to-text"
       targetCode={`curl -X POST '${props.appDetail.api_base_url}/audio-to-text' \\
 --header 'Authorization: Bearer {api_key}' \\
---form 'file=@localfile;type=audio/[mp3|mp4|mpeg|mpga|m4a|wav|webm]`}
+--form 'file=@localfile;type=audio/[mp3|m4a|wav|amr|mpga]`}
     />
 
     <CodeGroup title="Response">


### PR DESCRIPTION
## Summary

The in-app API reference for `/audio-to-text` describes an endpoint that does not exist. This
corrects the documentation to match the implementation; no behaviour changes.

Three drifts, all visible in App → API Access → *Audio to text*:

1. **Format list.** The templates advertise `['mp3', 'mp4', 'mpeg', 'mpga', 'm4a', 'wav', 'webm']`.
   `api/constants/__init__.py` declares `_AUDIO_EXTENSION_BASE = ("mp3", "m4a", "wav", "amr",
   "mpga")`, and `AudioService._invoke_speech_to_text` rejects anything outside it with
   `unsupported_audio_type` (415). So `mp4`, `mpeg` and `webm` are advertised but rejected, and
   `amr` is accepted but undocumented.
2. **Size limit.** The templates say `15MB`. `api/services/audio_service.py` sets `FILE_SIZE = 30`,
   so uploads between 15 MB and 30 MB succeed while the docs say they should not.
3. **Unreachable error codes.** The `/audio-to-text` docstring lists `app_unavailable`,
   `provider_quota_exceeded` and `model_currently_not_support` under 400. Nothing reachable from
   this endpoint raises the mapped exceptions: `AppModelConfigBrokenError` is raised only in
   `core/app/apps/message_based_app_generator.py`; `QuotaExceededError` and
   `ModelCurrentlyNotSupportError` only in `core/app/llm/quota.py`, `services/credit_pool_service.py`
   and the easy-UI `ModelConfigConverter`, none of which is on the `AudioService.transcript_asr`
   call graph. (`services/quota_service.py` also raises a `QuotaExceededError`, but that is
   `services.errors.app`'s class, not the `core.errors.error` one this controller catches.)

**One addition beyond the three drifts #39928 reports.** While walking the raise sites for point 3 I
found the same block is missing a code it *does* return: `no_audio_uploaded` (400). `AudioApi.post`
reads `request.files.get("file")`, which is `None` when the form field is absent; `transcript_asr`
forwards it untouched; `_invoke_speech_to_text` opens with `if file is None: raise
NoAudioUploadedServiceError()` (`api/services/audio_service.py:131`), and the controller maps that to
`NoAudioUploadedError`, `error_code = "no_audio_uploaded"`, `code = 400`. That behaviour is
deliberate — #39322 changed `request.files["file"]` to `request.files.get("file")` in this handler
specifically so a missing file returns 400 rather than 500. A reachable code missing from the list is
the same documentation drift as an unreachable code being present, so it is added here rather than
left for a follow-up.

The format list and size are corrected in all six develop templates — en, ja and zh for both
`template_chat` and `template_advanced_chat` — in **both** places each file states them: the
`Supported formats` line and the `curl` example below it. Changes to the ja and zh files are values
only; no translated prose was altered. The three unreachable codes are removed from the
`/audio-to-text` 400 block and `no_audio_uploaded` is added to it.

The second 400 block in `api/controllers/service_api/app/audio.py` belongs to `/text-to-audio`
(`class TextApi`), a different endpoint on a different service method. Its error codes were not
traced and it is deliberately left unchanged — this PR is scoped to `/audio-to-text`.

**Whether `/audio-to-text` should accept `mp4`, `mpeg` or `webm` is a separate product question and
is deliberately not addressed here.** This PR does not touch `AUDIO_EXTENSIONS`, `FILE_SIZE`, or any
handler. It only makes the documentation describe what ships today. If the endpoint should accept
more formats, that is a behaviour change worth its own issue.

The analysis in #39928 is what made this straightforward — the reporter traced the drift to the
constants and to the exception raise sites, and the file list there was the starting point for this
change. I verified each claim against `main` independently before editing, including walking every
`raise` site of the three exceptions.

The reference docs on docs.dify.ai were already corrected in langgenius/dify-docs#903; this is the
two in-repo surfaces only.

Fixes #39928

From Claude Code

## Screenshots

| Before | After |
|--------|-------|
| `Supported formats: ['mp3', 'mp4', 'mpeg', 'mpga', 'm4a', 'wav', 'webm']` / `File size limit: 15MB` | `Supported formats: ['mp3', 'm4a', 'wav', 'amr', 'mpga']` / `File size limit: 30MB` |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods