### PR TITLE
fix(api): validate installation scope for cached marketplace packages (#39935)

### DIFF
--- a/api/services/plugin/plugin_service.py
+++ b/api/services/plugin/plugin_service.py
@@ -293,10 +293,8 @@ class PluginService:
 
         try:
             manager.fetch_plugin_manifest(tenant_id, new_plugin_unique_identifier)
-            # already downloaded, skip, and record install event
-            marketplace.record_install_plugin_event(new_plugin_unique_identifier)
         except Exception:
-            # plugin not installed, download and upload pkg
+            # plugin not downloaded yet, download and upload pkg
             pkg = download_plugin_pkg(new_plugin_unique_identifier)
             response = manager.upload_pkg(
                 tenant_id,
@@ -306,6 +304,11 @@ class PluginService:
 
             # check if the plugin is available to install
             PluginService._check_plugin_installation_scope(response.verification)
+        else:
+            # already downloaded, the cached pkg still has to satisfy the installation scope
+            decode_response = manager.decode_plugin_from_identifier(tenant_id, new_plugin_unique_identifier)
+            PluginService._check_plugin_installation_scope(decode_response.verification)
+            marketplace.record_install_plugin_event(new_plugin_unique_identifier)
 
         return manager.upgrade_plugin(
             tenant_id,
@@ -485,14 +488,8 @@ class PluginService:
         for plugin_unique_identifier in plugin_unique_identifiers:
             try:
                 manager.fetch_plugin_manifest(tenant_id, plugin_unique_identifier)
-                plugin_decode_response = manager.decode_plugin_from_identifier(tenant_id, plugin_unique_identifier)
-                # check if the plugin is available to install
-                PluginService._check_plugin_installation_scope(plugin_decode_response.verification)
-                # already downloaded, skip
-                actual_plugin_unique_identifiers.append(plugin_unique_identifier)
-                metas.append({"plugin_unique_identifier": plugin_unique_identifier})
             except Exception:
-                # plugin not installed, download and upload pkg
+                # plugin not downloaded yet, download and upload pkg
                 pkg = download_plugin_pkg(plugin_unique_identifier)
                 response = manager.upload_pkg(
                     tenant_id,
@@ -504,6 +501,12 @@ class PluginService:
                 # use response plugin_unique_identifier
                 actual_plugin_unique_identifiers.append(response.unique_identifier)
                 metas.append({"plugin_unique_identifier": response.unique_identifier})
+            else:
+                # already downloaded, the cached pkg still has to satisfy the installation scope
+                plugin_decode_response = manager.decode_plugin_from_identifier(tenant_id, plugin_unique_identifier)
+                PluginService._check_plugin_installation_scope(plugin_decode_response.verification)
+                actual_plugin_unique_identifiers.append(plugin_unique_identifier)
+                metas.append({"plugin_unique_identifier": plugin_unique_identifier})
 
         return manager.install_from_identifiers(
             tenant_id,

--- a/api/tests/unit_tests/services/plugin/test_plugin_service.py
+++ b/api/tests/unit_tests/services/plugin/test_plugin_service.py
@@ -239,6 +239,59 @@ class TestUpgradePluginWithMarketplace:
         mock_download.assert_called_once_with("new-uid")
         installer.upload_pkg.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "scope",
+        [
+            PluginInstallationScope.NONE,
+            PluginInstallationScope.OFFICIAL_ONLY,
+            PluginInstallationScope.OFFICIAL_AND_SPECIFIC_PARTNERS,
+        ],
+    )
+    @patch("services.plugin.plugin_service.download_plugin_pkg")
+    @patch("services.plugin.plugin_service.marketplace")
+    @patch("services.plugin.plugin_service.FeatureService")
+    @patch("services.plugin.plugin_service.PluginInstaller")
+    @patch("services.plugin.plugin_service.dify_config")
+    def test_rejects_cached_pkg_outside_scope(
+        self, mock_config, mock_installer_cls, mock_fs, mock_marketplace, mock_download, scope
+    ):
+        mock_config.MARKETPLACE_ENABLED = True
+        mock_fs.get_system_features.return_value = make_features(scope=scope)
+        installer = mock_installer_cls.return_value
+        installer.fetch_plugin_manifest.return_value = MagicMock()
+        decode_resp = MagicMock()
+        decode_resp.verification.authorized_category = PluginVerification.AuthorizedCategory.Community
+        installer.decode_plugin_from_identifier.return_value = decode_resp
+
+        with pytest.raises(PluginInstallationForbiddenError):
+            PluginService.upgrade_plugin_with_marketplace("t1", "old-uid", "new-uid")
+
+        installer.upgrade_plugin.assert_not_called()
+        mock_marketplace.record_install_plugin_event.assert_not_called()
+        # the rejection must not fall through to the download branch and cache the pkg again
+        mock_download.assert_not_called()
+        installer.upload_pkg.assert_not_called()
+
+    @patch("services.plugin.plugin_service.marketplace")
+    @patch("services.plugin.plugin_service.FeatureService")
+    @patch("services.plugin.plugin_service.PluginInstaller")
+    @patch("services.plugin.plugin_service.dify_config")
+    def test_allows_cached_official_pkg_under_official_only(
+        self, mock_config, mock_installer_cls, mock_fs, mock_marketplace
+    ):
+        mock_config.MARKETPLACE_ENABLED = True
+        mock_fs.get_system_features.return_value = make_features(scope=PluginInstallationScope.OFFICIAL_ONLY)
+        installer = mock_installer_cls.return_value
+        installer.fetch_plugin_manifest.return_value = MagicMock()
+        decode_resp = MagicMock()
+        decode_resp.verification.authorized_category = PluginVerification.AuthorizedCategory.Langgenius
+        installer.decode_plugin_from_identifier.return_value = decode_resp
+
+        PluginService.upgrade_plugin_with_marketplace("t1", "old-uid", "new-uid")
+
+        mock_marketplace.record_install_plugin_event.assert_called_once_with("new-uid")
+        installer.upgrade_plugin.assert_called_once()
+
 
 class TestUpgradePluginWithGithub:
     @patch("services.plugin.plugin_service.FeatureService")
@@ -318,6 +371,27 @@ class TestInstallFromMarketplacePkg:
         installer.install_from_identifiers.assert_called_once()
         call_args = installer.install_from_identifiers.call_args[0]
         assert call_args[1] == ["uid-1"]  # uses original uid
+
+    @patch("services.plugin.plugin_service.download_plugin_pkg")
+    @patch("services.plugin.plugin_service.FeatureService")
+    @patch("services.plugin.plugin_service.PluginInstaller")
+    @patch("services.plugin.plugin_service.dify_config")
+    def test_rejects_cached_pkg_outside_scope(self, mock_config, mock_installer_cls, mock_fs, mock_download):
+        mock_config.MARKETPLACE_ENABLED = True
+        mock_fs.get_system_features.return_value = make_features(scope=PluginInstallationScope.OFFICIAL_ONLY)
+        installer = mock_installer_cls.return_value
+        installer.fetch_plugin_manifest.return_value = MagicMock()
+        decode_resp = MagicMock()
+        decode_resp.verification.authorized_category = PluginVerification.AuthorizedCategory.Community
+        installer.decode_plugin_from_identifier.return_value = decode_resp
+
+        with pytest.raises(PluginInstallationForbiddenError):
+            PluginService.install_from_marketplace_pkg("t1", ["uid-1"])
+
+        installer.install_from_identifiers.assert_not_called()
+        # the rejection must not fall through to the download branch and cache the pkg again
+        mock_download.assert_not_called()
+        installer.upload_pkg.assert_not_called()
 
 
 class TestUninstall:


### PR DESCRIPTION
## Summary

Cherry-pick of #39935 (`1b7a132afa`) to `lts/1.13.x`.

### Conflict resolution

Applied manually — cherry-pick can't apply the diff verbatim because `api/core/plugin/plugin_service.py` doesn't exist on this branch. Main's file moved from `api/services/plugin/plugin_service.py` to `api/core/plugin/plugin_service.py` in #36449 (not in this branch's history), and this branch's `FeatureService` exposes `get_system_features().plugin_installation_permission` rather than main's `get_plugin_installation_permission()`. Same restructure (already-downloaded branch moves from `try` into `else`, gains the missing scope check) applied at this branch's line numbers against its `FeatureService` shape. Diffstat is otherwise the same shape as upstream.

### Verification

```
pytest tests/unit_tests/services/plugin/ -> 67 passed
```

Reverting only the source change while keeping the new tests reproduces the reported bug (all three restricted scopes, including `NONE`, plus the swallowed-exception re-download in `install_from_marketplace_pkg`):

```
FAILED TestUpgradePluginWithMarketplace::test_rejects_cached_pkg_outside_scope[none] - DID NOT RAISE
FAILED TestUpgradePluginWithMarketplace::test_rejects_cached_pkg_outside_scope[official_only] - DID NOT RAISE
FAILED TestUpgradePluginWithMarketplace::test_rejects_cached_pkg_outside_scope[official_and_specific_partners] - DID NOT RAISE
FAILED TestInstallFromMarketplacePkg::test_rejects_cached_pkg_outside_scope - download_plugin_pkg called 1 times
```

`ruff check` / `ruff format --check` clean. Ran `.github/scripts/check-hotfix-cherry-picks.sh` (fetched from `origin/main`) locally against this commit — passes.

Internal tracking: EE-1842.
