### PR TITLE
fix(dify-ui): improve select and status dot accessibility

### DIFF
--- a/packages/dify-ui/src/select/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/select/__tests__/index.spec.tsx
@@ -1,4 +1,5 @@
-import type * as React from 'react'
+import * as React from 'react'
+import { page } from 'vite-plus/test/browser'
 import { render } from 'vitest-browser-react'
 import {
   Select,
@@ -32,21 +33,7 @@ const renderOpenSelect = ({
       <SelectTrigger aria-label="city select" {...triggerProps}>
         <SelectValue />
       </SelectTrigger>
-      <SelectContent
-        positionerProps={{
-          role: 'group',
-          'aria-label': 'select positioner',
-        }}
-        popupProps={{
-          role: 'dialog',
-          'aria-label': 'select popup',
-        }}
-        listProps={{
-          role: 'listbox',
-          'aria-label': 'select list',
-        }}
-        {...contentProps}
-      >
+      <SelectContent {...contentProps}>
         <SelectItem value="seattle">
           <SelectItemText>Seattle</SelectItemText>
           <SelectItemIndicator />
@@ -69,7 +56,7 @@ describe('Select wrappers', () => {
             <SelectTrigger aria-label="city select">
               <SelectValue />
             </SelectTrigger>
-            <SelectContent listProps={{ role: 'listbox', 'aria-label': 'select list' }}>
+            <SelectContent>
               <SelectItem value="seattle">
                 <SelectItemText>Seattle</SelectItemText>
                 <SelectItemIndicator />
@@ -165,13 +152,93 @@ describe('Select wrappers', () => {
   })
 
   describe('SelectContent', () => {
+    it('should keep long options inside a narrow viewport', async () => {
+      const popupRef = React.createRef<HTMLDivElement>()
+      const originalViewport = {
+        height: window.innerHeight,
+        width: window.innerWidth,
+      }
+
+      await page.viewport(320, 568)
+
+      try {
+        const screen = await render(
+          <div style={{ width: '100vw' }}>
+            <Select open defaultValue="english">
+              <SelectTrigger aria-label="deployment target">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent popupProps={{ ref: popupRef }}>
+                <SelectItem value="english">
+                  <SelectItemText>
+                    Production deployment with a long provider and region identifier
+                  </SelectItemText>
+                </SelectItem>
+                <SelectItem value="chinese">
+                  <SelectItemText>生产环境中的超长模型服务供应商和区域标识名称</SelectItemText>
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>,
+        )
+
+        await expect.element(screen.getByRole('listbox')).toBeVisible()
+        await vi.waitFor(() => {
+          const viewportWidth = document.documentElement.clientWidth
+          const popupBounds = popupRef.current?.getBoundingClientRect()
+
+          expect(popupBounds).toBeDefined()
+          expect(viewportWidth).toBe(320)
+          expect(popupBounds?.left).toBeGreaterThanOrEqual(0)
+          expect(popupBounds?.right).toBeLessThanOrEqual(viewportWidth)
+          expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(viewportWidth)
+        })
+      } finally {
+        await page.viewport(originalViewport.width, originalViewport.height)
+      }
+    })
+
+    it('should preserve an explicit popup width when the viewport has enough space', async () => {
+      const popupRef = React.createRef<HTMLDivElement>()
+      const originalViewport = {
+        height: window.innerHeight,
+        width: window.innerWidth,
+      }
+
+      await page.viewport(800, 600)
+
+      try {
+        const screen = await render(
+          <div style={{ width: '256px' }}>
+            <Select open defaultValue="stable">
+              <SelectTrigger aria-label="package version">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent popupClassName="w-[512px]" popupProps={{ ref: popupRef }}>
+                <SelectItem value="stable">
+                  <SelectItemText>Stable package version</SelectItemText>
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>,
+        )
+
+        await expect.element(screen.getByRole('listbox')).toBeVisible()
+        await vi.waitFor(() => {
+          expect(popupRef.current?.getBoundingClientRect().width).toBe(512)
+        })
+      } finally {
+        await page.viewport(originalViewport.width, originalViewport.height)
+      }
+    })
+
     it('should render SelectGroupLabel for grouped options without naming the trigger', async () => {
       const screen = await renderWithSafeViewport(
         <Select open defaultValue="seattle">
           <SelectTrigger aria-label="city select">
             <SelectValue />
           </SelectTrigger>
-          <SelectContent listProps={{ role: 'listbox', 'aria-label': 'select list' }}>
+          <SelectContent>
             <SelectGroup>
               <SelectGroupLabel className="custom-label">Popular cities</SelectGroupLabel>
               <SelectItem value="seattle">
@@ -190,36 +257,44 @@ describe('Select wrappers', () => {
     })
 
     it('should use positioning attributes when placement is not provided', async () => {
-      const screen = await renderOpenSelect()
+      const positionerRef = React.createRef<HTMLDivElement>()
 
-      await expect
-        .element(screen.getByRole('group', { name: 'select positioner' }))
-        .toHaveAttribute('data-side', 'bottom')
-      await expect
-        .element(screen.getByRole('group', { name: 'select positioner' }))
-        .toHaveAttribute('data-align', 'start')
+      await renderOpenSelect({
+        contentProps: {
+          positionerProps: { ref: positionerRef },
+        },
+      })
+
+      await vi.waitFor(() => {
+        expect(positionerRef.current).toHaveAttribute('data-side', 'bottom')
+        expect(positionerRef.current).toHaveAttribute('data-align', 'start')
+      })
     })
 
     it('should preserve positioning attributes when placement props are provided', async () => {
-      const screen = await renderOpenSelect({
+      const positionerRef = React.createRef<HTMLDivElement>()
+
+      await renderOpenSelect({
         contentProps: {
           placement: 'top-end',
           sideOffset: 12,
           alignOffset: 6,
+          positionerProps: { ref: positionerRef },
         },
       })
 
-      await expect
-        .element(screen.getByRole('group', { name: 'select positioner' }))
-        .toHaveAttribute('data-side', 'top')
-      await expect
-        .element(screen.getByRole('group', { name: 'select positioner' }))
-        .toHaveAttribute('data-align', 'end')
+      await vi.waitFor(() => {
+        expect(positionerRef.current).toHaveAttribute('data-side', 'top')
+        expect(positionerRef.current).toHaveAttribute('data-align', 'end')
+      })
     })
 
     it('should forward passthrough props to positioner popup and list when passthrough props are provided', async () => {
       const onPopupClick = vi.fn()
       const onListFocus = vi.fn()
+      const positionerRef = React.createRef<HTMLDivElement>()
+      const popupRef = React.createRef<HTMLDivElement>()
+      const listRef = React.createRef<HTMLDivElement>()
 
       const screen = await render(
         <Select open defaultValue="seattle">
@@ -228,20 +303,18 @@ describe('Select wrappers', () => {
           </SelectTrigger>
           <SelectContent
             positionerProps={{
-              role: 'group',
-              'aria-label': 'select positioner',
               id: 'select-positioner',
+              ref: positionerRef,
             }}
             popupProps={{
-              role: 'dialog',
-              'aria-label': 'select popup',
               id: 'select-popup',
+              ref: popupRef,
               onClick: onPopupClick,
             }}
             listProps={{
-              role: 'listbox',
               'aria-label': 'select list',
               id: 'select-list',
+              ref: listRef,
               onFocus: onListFocus,
             }}
           >
@@ -253,22 +326,15 @@ describe('Select wrappers', () => {
         </Select>,
       )
 
-      await screen.getByRole('dialog', { name: 'select popup' }).click()
-      screen
-        .getByRole('listbox', { name: 'select list' })
-        .element()
-        .dispatchEvent(
-          new FocusEvent('focusin', {
-            bubbles: true,
-          }),
-        )
+      popupRef.current?.click()
+      listRef.current?.dispatchEvent(
+        new FocusEvent('focusin', {
+          bubbles: true,
+        }),
+      )
 
-      await expect
-        .element(screen.getByRole('group', { name: 'select positioner' }))
-        .toHaveAttribute('id', 'select-positioner')
-      await expect
-        .element(screen.getByRole('dialog', { name: 'select popup' }))
-        .toHaveAttribute('id', 'select-popup')
+      expect(positionerRef.current).toHaveAttribute('id', 'select-positioner')
+      expect(popupRef.current).toHaveAttribute('id', 'select-popup')
       await expect
         .element(screen.getByRole('listbox', { name: 'select list' }))
         .toHaveAttribute('id', 'select-list')
@@ -284,7 +350,7 @@ describe('Select wrappers', () => {
           <SelectTrigger aria-label="city select">
             <SelectValue />
           </SelectTrigger>
-          <SelectContent listProps={{ role: 'listbox', 'aria-label': 'select list' }}>
+          <SelectContent>
             <SelectItem value="seattle">
               <SelectItemText>Seattle</SelectItemText>
               <SelectItemIndicator />
@@ -308,7 +374,7 @@ describe('Select wrappers', () => {
           <SelectTrigger aria-label="custom select">
             <SelectValue />
           </SelectTrigger>
-          <SelectContent listProps={{ role: 'listbox', 'aria-label': 'select list' }}>
+          <SelectContent>
             <SelectItem value="a" className="gap-2">
               <SelectItemText>Custom Item</SelectItemText>
             </SelectItem>

--- a/packages/dify-ui/src/select/index.tsx
+++ b/packages/dify-ui/src/select/index.tsx
@@ -168,7 +168,7 @@ function SelectContent({
       >
         <BaseSelect.Popup
           className={cn(
-            'min-w-(--anchor-width) rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg',
+            'max-w-(--available-width) min-w-[min(var(--anchor-width),var(--available-width))] overflow-hidden rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg outline-hidden',
             floatingPopupAnimationClassName,
             popupClassName,
           )}

--- a/packages/dify-ui/src/status-dot/__tests__/index.spec.tsx
+++ b/packages/dify-ui/src/status-dot/__tests__/index.spec.tsx
@@ -1,17 +1,33 @@
 import { render } from 'vitest-browser-react'
-import { StatusDot } from '../index'
+import { StatusDot, StatusDotSkeleton } from '../index'
 
 describe('StatusDot', () => {
-  it('is hidden from assistive tech by default', async () => {
-    const screen = await render(<StatusDot data-testid="dot" />)
+  it('hides the visual indicator and its loading placeholder from assistive technology', async () => {
+    const screen = await render(
+      <>
+        <StatusDot data-testid="dot" />
+        <StatusDotSkeleton data-testid="skeleton" />
+      </>,
+    )
 
     await expect.element(screen.getByTestId('dot')).toHaveAttribute('aria-hidden', 'true')
+    await expect.element(screen.getByTestId('skeleton')).toHaveAttribute('aria-hidden', 'true')
   })
 
-  it('keeps an explicit accessible label visible to assistive tech', async () => {
-    const screen = await render(<StatusDot aria-label="Active" data-testid="dot" />)
+  it('does not allow consumers to override the decorative contract', async () => {
+    const screen = await render(
+      <>
+        {/* @ts-expect-error StatusDot is always decorative */}
+        <StatusDot aria-hidden={false} data-testid="dot" />
+        {/* @ts-expect-error Status semantics belong to the surrounding component */}
+        <StatusDot aria-label="Active" data-testid="labelled-dot" />
+        {/* @ts-expect-error StatusDotSkeleton is always decorative */}
+        <StatusDotSkeleton aria-hidden={false} data-testid="skeleton" />
+      </>,
+    )
 
-    await expect.element(screen.getByTestId('dot')).toHaveAttribute('aria-label', 'Active')
-    await expect.element(screen.getByTestId('dot')).not.toHaveAttribute('aria-hidden')
+    await expect.element(screen.getByTestId('dot')).toHaveAttribute('aria-hidden', 'true')
+    await expect.element(screen.getByTestId('labelled-dot')).toHaveAttribute('aria-hidden', 'true')
+    await expect.element(screen.getByTestId('skeleton')).toHaveAttribute('aria-hidden', 'true')
   })
 })

--- a/packages/dify-ui/src/status-dot/index.stories.tsx
+++ b/packages/dify-ui/src/status-dot/index.stories.tsx
@@ -16,7 +16,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Status Dot primitive from the Dify Design Kit. Use it for compact visual status indicators; provide an accessible label only when the dot is the sole status representation.',
+          'Decorative Status Dot primitive from the Dify Design Kit. Pair it with visible status text owned by the surrounding component; the dot itself stays hidden from assistive technology.',
       },
     },
   },

--- a/packages/dify-ui/src/status-dot/index.tsx
+++ b/packages/dify-ui/src/status-dot/index.tsx
@@ -50,54 +50,41 @@ type StatusDotVariants = VariantProps<typeof statusDotVariants>
 type StatusDotStatus = NonNullable<StatusDotVariants['status']>
 type StatusDotSize = NonNullable<StatusDotVariants['size']>
 
-type StatusDotProps = Omit<React.ComponentProps<'span'>, 'children'> & {
+type DecorativeSpanProps = Omit<
+  React.ComponentProps<'span'>,
+  'children' | 'role' | 'tabIndex' | keyof React.AriaAttributes
+> & {
+  [Key in keyof React.AriaAttributes]?: never
+} & {
+  role?: never
+  tabIndex?: never
+}
+
+type StatusDotProps = DecorativeSpanProps & {
   status?: StatusDotStatus
   size?: StatusDotSize
 }
 
-type StatusDotSkeletonProps = Omit<React.ComponentProps<'span'>, 'children'> & {
+type StatusDotSkeletonProps = DecorativeSpanProps & {
   size?: StatusDotSize
 }
 
-function StatusDot({
-  className,
-  status = 'success',
-  size = 'medium',
-  'aria-hidden': ariaHidden,
-  'aria-label': ariaLabel,
-  'aria-labelledby': ariaLabelledBy,
-  ...props
-}: StatusDotProps) {
-  const hidden = ariaHidden ?? (ariaLabel || ariaLabelledBy ? undefined : true)
-
+function StatusDot({ className, status = 'success', size = 'medium', ...props }: StatusDotProps) {
   return (
     <span
-      className={cn(statusDotVariants({ status, size }), className)}
-      aria-hidden={hidden}
-      aria-label={ariaLabel}
-      aria-labelledby={ariaLabelledBy}
       {...props}
+      className={cn(statusDotVariants({ status, size }), className)}
+      aria-hidden="true"
     />
   )
 }
 
-function StatusDotSkeleton({
-  className,
-  size = 'medium',
-  'aria-hidden': ariaHidden,
-  'aria-label': ariaLabel,
-  'aria-labelledby': ariaLabelledBy,
-  ...props
-}: StatusDotSkeletonProps) {
-  const hidden = ariaHidden ?? (ariaLabel || ariaLabelledBy ? undefined : true)
-
+function StatusDotSkeleton({ className, size = 'medium', ...props }: StatusDotSkeletonProps) {
   return (
     <span
-      className={cn(statusDotSkeletonVariants({ size }), className)}
-      aria-hidden={hidden}
-      aria-label={ariaLabel}
-      aria-labelledby={ariaLabelledBy}
       {...props}
+      className={cn(statusDotSkeletonVariants({ size }), className)}
+      aria-hidden="true"
     />
   )
 }


### PR DESCRIPTION
## Summary

- constrain Select popups to Base UI's runtime `--available-width` while preserving the trigger-width default and explicit consumer widths
- keep StatusDot and StatusDotSkeleton consistently decorative and prevent consumers from overriding that contract with ARIA, role, or tabIndex props
- replace test-only ARIA roles with ref-based DOM access and add real-browser narrow viewport coverage

## Root cause

Select only enforced `min-width: var(--anchor-width)`. When a full-width trigger or a long option exceeded the space available to Base UI's positioner, CSS min-width won over the viewport boundary and the popup could overflow a 320px viewport.

StatusDot was visually intended to be decorative, but its public span props allowed consumers to attach conflicting accessibility semantics. The surrounding component should own the readable status instead.

## Implementation details

The Select popup now uses Base UI's positioning variables:

- `max-width: var(--available-width)`
- `min-width: min(var(--anchor-width), var(--available-width))`

This preserves the existing minimum trigger width whenever space is available and only shrinks at a viewport boundary. Existing Web consumers were audited: explicit widths such as the plugin install flow's 512px popup remain intact, and no Web migration is required. The two existing `listProps` consumers still have valid needs for a listbox label and an IntersectionObserver root.

StatusDot now renders `aria-hidden="true"` after forwarded DOM props and narrows its TypeScript API so ARIA attributes, `role`, and `tabIndex` cannot contradict the decorative primitive contract. Storybook documentation now directs consumers to provide status text in the surrounding component.

## Validation

- `vp check packages/dify-ui`
- `pnpm -C packages/dify-ui test` — 35 files, 223 tests passed
- `pnpm -C packages/dify-ui test:storybook` — 35 files, 199 tests passed
- targeted `vp check` for 119 Web Select/StatusDot consumer files — 0 errors
- `git diff --check`

Browser Mode tests verify both a 320px viewport with long English and Chinese options and an explicit 512px popup in an 800px viewport.