### PR TITLE
fix: align build and preview chat layouts

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/components/preview/build-chat.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/preview/build-chat.tsx
@@ -38,7 +38,7 @@ function AgentBuildChatEmptyState({
 
   return (
     <>
-      <div className="dify-blue-glass-surface relative flex h-12.5 w-12 items-center justify-center rounded-xl p-2">
+      <div className="dify-blue-glass-surface relative flex h-14 w-14.5 items-center justify-center rounded-xl p-2">
         <div className="absolute inset-x-px inset-y-0.5 grid grid-cols-[repeat(8,4px)] grid-rows-[repeat(8,4px)] gap-0.5 opacity-25">
           {buildIconGridCells.map((cell) => (
             <span

--- a/web/features/agent-v2/agent-detail/configure/components/preview/chat-session.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/preview/chat-session.tsx
@@ -181,7 +181,7 @@ export function AgentPreviewChatSession({
   )
 
   return (
-    <div className="relative flex h-full min-h-0 flex-col overflow-hidden">
+    <div className="relative mx-auto flex h-full min-h-0 w-full max-w-150 flex-col overflow-hidden">
       <div className="min-h-0 flex-1">
         <AgentPreviewChatConversation
           key={conversationSessionKey}
@@ -220,18 +220,21 @@ export function AgentPreviewChatSession({
         <div
           className={cn(
             isEmptyChat
-              ? 'flex w-full max-w-150 flex-col items-start p-3 text-left'
+              ? 'flex w-full max-w-150 flex-col items-start text-left'
               : 'pointer-events-none relative w-full',
           )}
         >
-          {isEmptyChat &&
-            renderEmptyState({
-              agentIcon,
-              agentIconBackground,
-              agentIconType,
-              agentName,
-              showUnconfiguredNotice,
-            })}
+          {isEmptyChat && (
+            <div className="w-full p-3 pb-0">
+              {renderEmptyState({
+                agentIcon,
+                agentIconBackground,
+                agentIconType,
+                agentName,
+                showUnconfiguredNotice,
+              })}
+            </div>
+          )}
           <div className={cn(isEmptyChat && 'pointer-events-auto mt-5 w-full')}>
             {chatInputNode}
           </div>


### PR DESCRIPTION
## Summary

- Center Build and Preview chat sessions within a shared 600px maximum width.
- Separate the empty-state information padding from the full-width chat input while preserving a 20px gap.

Fixes DIFY-2860

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.