### PR TITLE
fix(ui): align button spacing with design

### DIFF
--- a/packages/dify-ui/README.md
+++ b/packages/dify-ui/README.md
@@ -81,6 +81,11 @@ Utilities:
 
 ## Button loading and disabled contract
 
+`Button` owns the spacing between direct children. Regular (`medium`) and Large sizes use
+4px and 6px gaps. Small uses 3px for Primary and 4px for the other variants. Do not add icon
+margins or a standard `gap-*` at call sites; use a Button `className` override only for a
+documented layout exception.
+
 `Button` keeps normal `disabled` controls native-disabled by default so unavailable actions are removed from the keyboard focus order.
 
 When `loading` is true, `Button` defaults `focusableWhenDisabled` to true. Loading represents an action that has already been triggered and is temporarily pending, so the button remains focusable while Base UI still suppresses click, pointer, keyboard activation, and submit-button activation. Pass `focusableWhenDisabled={false}` only when a loading button should use native disabled behavior.

--- a/packages/dify-ui/src/button/index.stories.tsx
+++ b/packages/dify-ui/src/button/index.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import * as React from 'react'
 import { expect, fn } from 'storybook/test'
 import { Button, buttonVariants } from '.'
 
@@ -126,12 +125,19 @@ export const Destructive: Story = {
 export const WithIcon: Story = {
   args: {
     variant: 'primary',
-    children: (
-      <React.Fragment>
-        <span aria-hidden className="mr-1.5 i-ri-rocket-line size-4 shrink-0" />
-        Launch
-      </React.Fragment>
-    ),
+    size: 'medium',
+    children: 'Launch',
+  },
+  render: (args) => {
+    const iconSize =
+      args.size === 'small' ? 'size-3.5' : args.size === 'large' ? 'size-5' : 'size-4'
+
+    return (
+      <Button {...args}>
+        <span aria-hidden className={`i-ri-rocket-line shrink-0 ${iconSize}`} />
+        {args.children}
+      </Button>
+    )
   },
 }
 

--- a/packages/dify-ui/src/button/index.tsx
+++ b/packages/dify-ui/src/button/index.tsx
@@ -7,26 +7,26 @@ import { cva } from 'class-variance-authority'
 import { cn } from '../cn'
 
 const buttonVariants = cva(
-  'inline-flex cursor-pointer items-center justify-center whitespace-nowrap outline-hidden focus-visible:ring-2 focus-visible:ring-state-accent-solid data-disabled:cursor-not-allowed',
+  'inline-flex cursor-pointer items-center justify-center overflow-hidden whitespace-nowrap outline-hidden focus-visible:ring-2 focus-visible:ring-state-accent-solid data-disabled:cursor-not-allowed',
   {
     variants: {
       variant: {
         primary: [
-          'border-components-button-primary-border bg-components-button-primary-bg text-components-button-primary-text shadow-sm',
-          'hover:border-components-button-primary-border-hover hover:bg-components-button-primary-bg-hover',
-          'data-disabled:border-components-button-primary-border-disabled data-disabled:bg-components-button-primary-bg-disabled data-disabled:text-components-button-primary-text-disabled data-disabled:shadow-none',
+          'bg-components-button-primary-bg text-components-button-primary-text shadow-primary-button inset-ring-[0.5px] inset-ring-components-button-primary-border',
+          'hover:bg-components-button-primary-bg-hover hover:shadow-xs hover:shadow-shadow-shadow-3 hover:inset-ring-components-button-primary-border-hover',
+          'data-disabled:bg-components-button-primary-bg-disabled data-disabled:text-components-button-primary-text-disabled data-disabled:shadow-none data-disabled:inset-ring-components-button-primary-border-disabled',
         ],
         secondary: [
-          'border-[0.5px] shadow-xs backdrop-blur-[5px]',
+          'border-[0.5px] shadow-xs shadow-shadow-shadow-3 backdrop-blur-[5px]',
           'border-components-button-secondary-border bg-components-button-secondary-bg text-components-button-secondary-text',
           'hover:border-components-button-secondary-border-hover hover:bg-components-button-secondary-bg-hover',
-          'data-disabled:border-components-button-secondary-border-disabled data-disabled:bg-components-button-secondary-bg-disabled data-disabled:text-components-button-secondary-text-disabled data-disabled:backdrop-blur-xs',
+          'data-disabled:border-components-button-secondary-border-disabled data-disabled:bg-components-button-secondary-bg-disabled data-disabled:text-components-button-secondary-text-disabled data-disabled:shadow-none data-disabled:backdrop-blur-xs',
         ],
         'secondary-accent': [
-          'border-[0.5px] shadow-xs',
+          'border-[0.5px] shadow-xs shadow-shadow-shadow-3 backdrop-blur-[5px]',
           'border-components-button-secondary-border bg-components-button-secondary-bg text-components-button-secondary-accent-text',
           'hover:border-components-button-secondary-border-hover hover:bg-components-button-secondary-bg-hover',
-          'data-disabled:border-components-button-secondary-border-disabled data-disabled:bg-components-button-secondary-bg-disabled data-disabled:text-components-button-secondary-accent-text-disabled',
+          'data-disabled:border-components-button-secondary-border-disabled data-disabled:bg-components-button-secondary-bg-disabled data-disabled:text-components-button-secondary-accent-text-disabled data-disabled:shadow-none data-disabled:backdrop-blur-xs',
         ],
         tertiary: [
           'bg-components-button-tertiary-bg text-components-button-tertiary-text',
@@ -45,9 +45,9 @@ const buttonVariants = cva(
         ],
       },
       size: {
-        small: 'h-6 rounded-md px-2 text-xs font-medium',
-        medium: 'h-8 rounded-lg px-3.5 text-[13px] leading-4 font-medium',
-        large: 'h-9 rounded-[10px] px-4 text-sm font-semibold',
+        small: 'h-6 gap-1 rounded-md px-[9px] text-xs font-medium',
+        medium: 'h-8 gap-1 rounded-lg px-3.5 text-[13px] leading-4 font-medium',
+        large: 'h-9 gap-1.5 rounded-[10px] px-4 text-sm font-semibold',
       },
       tone: {
         default: '',
@@ -57,11 +57,16 @@ const buttonVariants = cva(
     compoundVariants: [
       {
         variant: 'primary',
+        size: 'small',
+        class: 'gap-[3px] px-2',
+      },
+      {
+        variant: 'primary',
         tone: 'destructive',
         class: [
-          'border-components-button-destructive-primary-border bg-components-button-destructive-primary-bg text-components-button-destructive-primary-text',
-          'hover:border-components-button-destructive-primary-border-hover hover:bg-components-button-destructive-primary-bg-hover',
-          'data-disabled:border-components-button-destructive-primary-border-disabled data-disabled:bg-components-button-destructive-primary-bg-disabled data-disabled:text-components-button-destructive-primary-text-disabled data-disabled:shadow-none',
+          'bg-components-button-destructive-primary-bg text-components-button-destructive-primary-text inset-ring-components-button-destructive-primary-border',
+          'hover:bg-components-button-destructive-primary-bg-hover hover:inset-ring-components-button-destructive-primary-border-hover',
+          'data-disabled:bg-components-button-destructive-primary-bg-disabled data-disabled:text-components-button-destructive-primary-text-disabled data-disabled:shadow-none data-disabled:inset-ring-components-button-destructive-primary-bg-disabled',
         ],
       },
       {
@@ -129,7 +134,7 @@ function Button({
       {children}
       {loading && (
         <i
-          className="ms-1 i-ri-loader-2-line size-3 animate-spin motion-reduce:animate-none"
+          className="i-ri-loader-2-line size-3 animate-spin motion-reduce:animate-none"
           aria-hidden="true"
         />
       )}

--- a/packages/dify-ui/src/button/index.tsx
+++ b/packages/dify-ui/src/button/index.tsx
@@ -73,7 +73,7 @@ const buttonVariants = cva(
         class: [
           'bg-components-button-destructive-secondary-bg text-components-button-destructive-secondary-text inset-ring-components-button-destructive-secondary-border',
           'hover:bg-components-button-destructive-secondary-bg-hover hover:inset-ring-components-button-destructive-secondary-border-hover',
-          'data-disabled:bg-components-button-destructive-secondary-bg-disabled data-disabled:text-components-button-destructive-secondary-text-disabled data-disabled:inset-ring-components-button-destructive-secondary-border-disabled',
+          'data-disabled:text-components-button-destructive-secondary-text-disabled',
         ],
       },
       {

--- a/packages/dify-ui/src/button/index.tsx
+++ b/packages/dify-ui/src/button/index.tsx
@@ -17,16 +17,14 @@ const buttonVariants = cva(
           'data-disabled:bg-components-button-primary-bg-disabled data-disabled:text-components-button-primary-text-disabled data-disabled:shadow-none data-disabled:inset-ring-components-button-primary-border-disabled',
         ],
         secondary: [
-          'border-[0.5px] shadow-xs shadow-shadow-shadow-3 backdrop-blur-[5px]',
-          'border-components-button-secondary-border bg-components-button-secondary-bg text-components-button-secondary-text',
-          'hover:border-components-button-secondary-border-hover hover:bg-components-button-secondary-bg-hover',
-          'data-disabled:border-components-button-secondary-border-disabled data-disabled:bg-components-button-secondary-bg-disabled data-disabled:text-components-button-secondary-text-disabled data-disabled:shadow-none data-disabled:backdrop-blur-xs',
+          'bg-components-button-secondary-bg text-components-button-secondary-text shadow-xs inset-ring-[0.5px] shadow-shadow-shadow-3 inset-ring-components-button-secondary-border backdrop-blur-[5px]',
+          'hover:bg-components-button-secondary-bg-hover hover:inset-ring-components-button-secondary-border-hover',
+          'data-disabled:bg-components-button-secondary-bg-disabled data-disabled:text-components-button-secondary-text-disabled data-disabled:shadow-none data-disabled:inset-ring-components-button-secondary-border-disabled data-disabled:backdrop-blur-xs',
         ],
         'secondary-accent': [
-          'border-[0.5px] shadow-xs shadow-shadow-shadow-3 backdrop-blur-[5px]',
-          'border-components-button-secondary-border bg-components-button-secondary-bg text-components-button-secondary-accent-text',
-          'hover:border-components-button-secondary-border-hover hover:bg-components-button-secondary-bg-hover',
-          'data-disabled:border-components-button-secondary-border-disabled data-disabled:bg-components-button-secondary-bg-disabled data-disabled:text-components-button-secondary-accent-text-disabled data-disabled:shadow-none data-disabled:backdrop-blur-xs',
+          'bg-components-button-secondary-bg text-components-button-secondary-accent-text shadow-xs inset-ring-[0.5px] shadow-shadow-shadow-3 inset-ring-components-button-secondary-border backdrop-blur-[5px]',
+          'hover:bg-components-button-secondary-bg-hover hover:inset-ring-components-button-secondary-border-hover',
+          'data-disabled:bg-components-button-secondary-bg-disabled data-disabled:text-components-button-secondary-accent-text-disabled data-disabled:shadow-none data-disabled:inset-ring-components-button-secondary-border-disabled data-disabled:backdrop-blur-xs',
         ],
         tertiary: [
           'bg-components-button-tertiary-bg text-components-button-tertiary-text',
@@ -73,9 +71,9 @@ const buttonVariants = cva(
         variant: 'secondary',
         tone: 'destructive',
         class: [
-          'border-components-button-destructive-secondary-border bg-components-button-destructive-secondary-bg text-components-button-destructive-secondary-text',
-          'hover:border-components-button-destructive-secondary-border-hover hover:bg-components-button-destructive-secondary-bg-hover',
-          'data-disabled:border-components-button-destructive-secondary-border-disabled data-disabled:bg-components-button-destructive-secondary-bg-disabled data-disabled:text-components-button-destructive-secondary-text-disabled',
+          'bg-components-button-destructive-secondary-bg text-components-button-destructive-secondary-text inset-ring-components-button-destructive-secondary-border',
+          'hover:bg-components-button-destructive-secondary-bg-hover hover:inset-ring-components-button-destructive-secondary-border-hover',
+          'data-disabled:bg-components-button-destructive-secondary-bg-disabled data-disabled:text-components-button-destructive-secondary-text-disabled data-disabled:inset-ring-components-button-destructive-secondary-border-disabled',
         ],
       },
       {

--- a/packages/dify-ui/src/styles/styles.css
+++ b/packages/dify-ui/src/styles/styles.css
@@ -66,6 +66,12 @@
 
   /* shadows */
   --shadow-xs: 0px 1px 2px 0px rgba(16, 24, 40, 0.05);
+  --shadow-primary-button:
+    0px 2px 2px -1px rgba(0, 0, 0, 0.12), 0px 1px 1px -1px rgba(0, 0, 0, 0.12),
+    0px 0px 0px 0.5px var(--color-shadow-shadow-10),
+    inset 0px -6px 12px -4px var(--color-shadow-shadow-5),
+    inset 0px 0px 1px 0px rgba(255, 255, 255, 0.16),
+    inset 0px 0.5px 0px 0px rgba(255, 255, 255, 0.08);
   --shadow-sm: 0px 1px 2px 0px rgba(16, 24, 40, 0.06), 0px 1px 3px 0px rgba(16, 24, 40, 0.1);
   --shadow-sm-no-bottom:
     0px -1px 2px 0px rgba(16, 24, 40, 0.06), 0px -1px 3px 0px rgba(16, 24, 40, 0.1);

--- a/web/app/(shareLayout)/webapp-signin/components/sso-auth.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/sso-auth.tsx
@@ -80,7 +80,7 @@ function SSOAuth({ protocol }: SSOAuthProps) {
       disabled={isLoading}
       className="w-full"
     >
-      <Lock01 className="mr-2 size-5 text-text-accent-light-mode-only" />
+      <Lock01 className="size-5 text-text-accent-light-mode-only" />
       <span className="truncate">{t(($) => $.withSSO, { ns: 'login' })}</span>
     </Button>
   )

--- a/web/app/account/(commonLayout)/header.tsx
+++ b/web/app/account/(commonLayout)/header.tsx
@@ -46,7 +46,7 @@ const Header = () => {
         </p>
       </div>
       <div className="flex shrink-0 items-center gap-3">
-        <Button className="gap-2 px-3 py-2 system-sm-medium" onClick={goToHome}>
+        <Button className="px-3 py-2 system-sm-medium" onClick={goToHome}>
           <span aria-hidden className="i-custom-vender-main-nav-home size-4" />
           <p>{t(($) => $['mainNav.home'], { ns: 'common' })}</p>
           <span aria-hidden className="i-ri-arrow-right-up-line size-4" />

--- a/web/app/components/app-sidebar/app-info/app-info-detail-panel.tsx
+++ b/web/app/components/app-sidebar/app-info/app-info-detail-panel.tsx
@@ -179,7 +179,7 @@ const AppInfoDetailPanel = ({
           <Button
             size="medium"
             variant="ghost"
-            className="gap-0.5"
+
             onClick={switchOperation.onClick}
           >
             {switchOperation.icon}

--- a/web/app/components/app-sidebar/app-info/app-operations.tsx
+++ b/web/app/components/app-sidebar/app-info/app-operations.tsx
@@ -128,7 +128,7 @@ const AppOperations = ({
             data-targetid={operation.id}
             size="small"
             variant="secondary"
-            className="gap-px focus-visible:ring-inset"
+            className="focus-visible:ring-inset"
             disabled={operation.disabled}
             loading={operation.loading}
             tabIndex={-1}
@@ -145,7 +145,7 @@ const AppOperations = ({
           id="more-measure"
           size="small"
           variant="secondary"
-          className="gap-px focus-visible:ring-inset"
+          className="focus-visible:ring-inset"
           tabIndex={-1}
         >
           <RiMoreLine className="size-3.5 text-components-button-secondary-text" />
@@ -161,7 +161,7 @@ const AppOperations = ({
             data-targetid={operation.id}
             size="small"
             variant="secondary"
-            className="gap-px focus-visible:ring-inset"
+            className="focus-visible:ring-inset"
             disabled={operation.disabled}
             loading={operation.loading}
             onClick={operation.onClick}
@@ -178,11 +178,7 @@ const AppOperations = ({
           <DropdownMenu open={showMore} onOpenChange={setShowMore}>
             <DropdownMenuTrigger
               render={
-                <Button
-                  size="small"
-                  variant="secondary"
-                  className="gap-px focus-visible:ring-inset"
-                />
+                <Button size="small" variant="secondary" className="focus-visible:ring-inset" />
               }
             >
               <>

--- a/web/app/components/app/annotation/batch-action.tsx
+++ b/web/app/components/app/annotation/batch-action.tsx
@@ -52,19 +52,14 @@ const BatchAction: FC<IBatchActionProps> = ({
           </span>
         </div>
         <Divider type="vertical" className="mx-0.5 h-3.5 bg-divider-regular" />
-        <Button
-          variant="ghost"
-          tone="destructive"
-          className="gap-x-0.5 px-3"
-          onClick={showDeleteConfirm}
-        >
+        <Button variant="ghost" tone="destructive" onClick={showDeleteConfirm}>
           <span aria-hidden className="i-ri-delete-bin-line size-4" />
-          <span className="px-0.5">{t(($) => $['operation.delete'], { ns: 'common' })}</span>
+          <span>{t(($) => $['operation.delete'], { ns: 'common' })}</span>
         </Button>
 
         <Divider type="vertical" className="mx-0.5 h-3.5 bg-divider-regular" />
-        <Button variant="ghost" className="px-3" onClick={() => onSelectedIdsChange([])}>
-          <span className="px-0.5">{t(($) => $['operation.cancel'], { ns: 'common' })}</span>
+        <Button variant="ghost" onClick={() => onSelectedIdsChange([])}>
+          <span>{t(($) => $['operation.cancel'], { ns: 'common' })}</span>
         </Button>
       </div>
       <AlertDialog open={isShowDeleteConfirm} onOpenChange={(open) => !open && hideDeleteConfirm()}>

--- a/web/app/components/app/annotation/header-opts/index.tsx
+++ b/web/app/components/app/annotation/header-opts/index.tsx
@@ -180,7 +180,7 @@ const HeaderOptions: FC<Props> = ({ appId, onAdd, onAdded, controlUpdateList }) 
   return (
     <div className="flex space-x-2">
       <Button variant="primary" onClick={() => setShowAddModal(true)}>
-        <span aria-hidden className="mr-0.5 i-ri-add-line size-4" />
+        <span aria-hidden className="i-ri-add-line size-4" />
         <div>{t(($) => $['table.header.addAnnotation'], { ns: 'appAnnotation' })}</div>
       </Button>
       <DropdownMenu

--- a/web/app/components/app/app-access-control/add-member-or-group-pop.tsx
+++ b/web/app/components/app/app-access-control/add-member-or-group-pop.tsx
@@ -319,11 +319,11 @@ function GroupItem({ group, subject }: GroupItemProps) {
         size="small"
         disabled={isChecked}
         variant="ghost-accent"
-        className="mr-1 flex shrink-0 items-center justify-between px-1.5 py-1"
+        className="mr-1 flex shrink-0 items-center justify-between py-1"
         onPointerDown={(event) => event.preventDefault()}
         onClick={handleExpandClick}
       >
-        <span className="px-0.75">
+        <span>
           {t(($) => $['accessControlDialog.operateGroupAndMember.expand'], { ns: 'app' })}
         </span>
         <RiArrowRightSLine className="size-4" aria-hidden="true" />

--- a/web/app/components/app/app-publisher/publish-with-multiple-model.tsx
+++ b/web/app/components/app/app-publisher/publish-with-multiple-model.tsx
@@ -65,7 +65,7 @@ const PublishWithMultipleModel: FC<PublishWithMultipleModelProps> = ({
       >
         <>
           {t(($) => $['operation.applyConfig'], { ns: 'appDebug' })}
-          <RiArrowDownSLine className="ml-0.5 size-3" />
+          <RiArrowDownSLine className="size-3" />
         </>
       </DropdownMenuTrigger>
       <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="w-[288px] p-1">

--- a/web/app/components/app/configuration/base/operation-button/index.tsx
+++ b/web/app/components/app/configuration/base/operation-button/index.tsx
@@ -21,7 +21,7 @@ export function OperationButton({
       {...buttonProps}
       variant="ghost"
       size="small"
-      className={cn('h-7 gap-1 px-3 text-text-secondary', className)}
+      className={cn('h-7 px-3 text-text-secondary', className)}
     >
       <span
         aria-hidden

--- a/web/app/components/app/configuration/base/warning-mask/formatting-changed.tsx
+++ b/web/app/components/app/configuration/base/warning-mask/formatting-changed.tsx
@@ -31,7 +31,7 @@ const FormattingChanged: FC<IFormattingChangedProps> = ({ onConfirm, onCancel })
       description={t(($) => $.formattingChangedText, { ns: 'appDebug' })}
       footer={
         <div className="flex space-x-2">
-          <Button variant="primary" className="flex space-x-2" onClick={onConfirm}>
+          <Button variant="primary" className="flex" onClick={onConfirm}>
             {icon}
             <span>{t(($) => $['operation.refresh'], { ns: 'common' })}</span>
           </Button>

--- a/web/app/components/app/configuration/config-prompt/index.tsx
+++ b/web/app/components/app/configuration/config-prompt/index.tsx
@@ -159,7 +159,7 @@ const Prompt: FC<IPromptProps> = ({
       {modelModeType === ModelModeType.chat &&
         (currentAdvancedPrompt as PromptItem[]).length < MAX_PROMPT_MESSAGE_LENGTH && (
           <Button onClick={handleAddMessage} className="mt-3 w-full">
-            <RiAddLine className="mr-2 size-4" />
+            <RiAddLine className="size-4" />
             <div>{t(($) => $['promptMode.operation.addMessage'], { ns: 'appDebug' })}</div>
           </Button>
         )}

--- a/web/app/components/app/configuration/config-vision/param-config.tsx
+++ b/web/app/components/app/configuration/config-vision/param-config.tsx
@@ -1,7 +1,6 @@
 'use client'
 import type { FC } from 'react'
 import { Button } from '@langgenius/dify-ui/button'
-import { cn } from '@langgenius/dify-ui/cn'
 import { Popover, PopoverContent, PopoverTrigger } from '@langgenius/dify-ui/popover'
 import { RiSettings2Line } from '@remixicon/react'
 import { memo, useState } from 'react'
@@ -16,9 +15,9 @@ const ParamsConfig: FC = () => {
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger
         render={
-          <Button variant="ghost" size="small" className={cn('')}>
+          <Button variant="ghost" size="small">
             <RiSettings2Line className="size-3.5" />
-            <div className="ml-1">{t(($) => $['voice.settings'], { ns: 'appDebug' })}</div>
+            <div>{t(($) => $['voice.settings'], { ns: 'appDebug' })}</div>
           </Button>
         }
       />

--- a/web/app/components/app/configuration/config/agent-setting-button.tsx
+++ b/web/app/components/app/configuration/config/agent-setting-button.tsx
@@ -32,7 +32,7 @@ const AgentSettingButton: FC<Props> = ({
         className="mr-2 shrink-0"
         disabled={disabled}
       >
-        <span className="mr-1 i-ri-settings-2-line size-4 text-text-tertiary" />
+        <span className="i-ri-settings-2-line size-4 text-text-tertiary" />
         {t(($) => $['agent.setting.name'], { ns: 'appDebug' })}
       </Button>
       {isShowAgentSetting && (

--- a/web/app/components/app/configuration/config/agent/agent-tools/index.tsx
+++ b/web/app/components/app/configuration/config/agent/agent-tools/index.tsx
@@ -366,7 +366,7 @@ const AgentTools: FC = () => {
                       }}
                     >
                       {t(($) => $.notAuthorized, { ns: 'tools' })}
-                      <StatusDot className="ml-2" status="warning" />
+                      <StatusDot status="warning" />
                     </Button>
                   )}
                 </div>

--- a/web/app/components/app/configuration/config/automatic/automatic-btn.tsx
+++ b/web/app/components/app/configuration/config/automatic/automatic-btn.tsx
@@ -13,8 +13,8 @@ const AutomaticBtn: FC<IAutomaticBtnProps> = ({ onClick }) => {
 
   return (
     <Button variant="secondary-accent" size="small" onClick={onClick}>
-      <RiSparklingFill className="mr-1 size-3.5" />
-      <span className="">{t(($) => $['operation.automatic'], { ns: 'appDebug' })}</span>
+      <RiSparklingFill className="size-3.5" />
+      <span>{t(($) => $['operation.automatic'], { ns: 'appDebug' })}</span>
     </Button>
   )
 }

--- a/web/app/components/app/configuration/config/automatic/get-automatic-res.tsx
+++ b/web/app/components/app/configuration/config/automatic/get-automatic-res.tsx
@@ -382,7 +382,7 @@ const GetAutomaticRes: FC<IGetAutomaticResProps> = ({
                   {t(($) => $[`${i18nPrefix}.dismiss`], { ns: 'appDebug' })}
                 </Button>
                 <Button
-                  className="flex space-x-1"
+                  className="flex"
                   variant="primary"
                   onClick={onGenerate}
                   disabled={isLoading}

--- a/web/app/components/app/configuration/config/code-generator/get-code-generator-res.tsx
+++ b/web/app/components/app/configuration/config/code-generator/get-code-generator-res.tsx
@@ -255,7 +255,7 @@ export const GetCodeGeneratorResModal: FC<IGetCodeGeneratorResProps> = ({
                   {t(($) => $[`${i18nPrefix}.dismiss`], { ns: 'appDebug' })}
                 </Button>
                 <Button
-                  className="flex space-x-1"
+                  className="flex"
                   variant="primary"
                   onClick={onGenerate}
                   disabled={isLoading}

--- a/web/app/components/app/configuration/configuration-view.tsx
+++ b/web/app/components/app/configuration/configuration-view.tsx
@@ -194,9 +194,7 @@ const ConfigurationView: FC<ConfigurationViewModel> = ({
                         className="mr-2 h-8! text-[13px]! font-medium"
                         onClick={onOpenDebugPanel}
                       >
-                        <span className="mr-1">
-                          {t(($) => $['operation.debugConfig'], { ns: 'appDebug' })}
-                        </span>
+                        <span>{t(($) => $['operation.debugConfig'], { ns: 'appDebug' })}</span>
                         <CodeBracketIcon className="size-4 text-text-tertiary" />
                       </Button>
                     )}

--- a/web/app/components/app/configuration/dataset-config/params-config/index.tsx
+++ b/web/app/components/app/configuration/dataset-config/params-config/index.tsx
@@ -113,7 +113,7 @@ const ParamsConfig = ({ disabled, selectedDatasets }: ParamsConfigProps) => {
         }}
         disabled={disabled}
       >
-        <RiEqualizer2Line className="mr-1 size-3.5" />
+        <RiEqualizer2Line className="size-3.5" />
         {t(($) => $.retrievalSettings, { ns: 'dataset' })}
       </Button>
       {rerankSettingModalOpen && (

--- a/web/app/components/app/configuration/debug/index.tsx
+++ b/web/app/components/app/configuration/debug/index.tsx
@@ -427,7 +427,7 @@ const Debug: FC<IDebug> = ({
                   }
                   disabled={multipleModelConfigs.length >= 4 || !canTestAndRun}
                 >
-                  <RiAddLine className="mr-1 size-3.5" />
+                  <RiAddLine className="size-3.5" />
                   {t(($) => $['modelProvider.addModel'], { ns: 'common' })}(
                   {multipleModelConfigs.length}
                   /4)

--- a/web/app/components/app/configuration/prompt-value-panel/index.tsx
+++ b/web/app/components/app/configuration/prompt-value-panel/index.tsx
@@ -293,7 +293,7 @@ const PromptValuePanel: FC<IPromptValuePanelProps> = ({
                       onClick={() => onSend?.()}
                       className="w-24"
                     >
-                      <RiPlayLargeFill className="mr-0.5 size-4 shrink-0" aria-hidden="true" />
+                      <RiPlayLargeFill className="size-4 shrink-0" aria-hidden="true" />
                       {t(($) => $['inputs.run'], { ns: 'appDebug' })}
                     </Button>
                   }
@@ -310,7 +310,7 @@ const PromptValuePanel: FC<IPromptValuePanelProps> = ({
                 onClick={() => onSend?.()}
                 className="w-24"
               >
-                <RiPlayLargeFill className="mr-0.5 size-4 shrink-0" aria-hidden="true" />
+                <RiPlayLargeFill className="size-4 shrink-0" aria-hidden="true" />
                 {t(($) => $['inputs.run'], { ns: 'appDebug' })}
               </Button>
             )}

--- a/web/app/components/app/create-app-dialog/app-card/index.tsx
+++ b/web/app/components/app/create-app-dialog/app-card/index.tsx
@@ -89,13 +89,13 @@ const AppCard = ({ app, canCreate, onCreate }: AppCardProps) => {
           >
             {canCreate && (
               <Button variant="primary" onClick={() => onCreate()}>
-                <PlusIcon className="mr-1 size-4" />
+                <PlusIcon className="size-4" />
                 <span className="text-xs">{t(($) => $['newApp.useTemplate'], { ns: 'app' })}</span>
               </Button>
             )}
             {canViewApp && (
               <Button onClick={handleShowTryAppPanel}>
-                <RiInformation2Line className="mr-1 size-4" />
+                <RiInformation2Line className="size-4" />
                 <span>{t(($) => $['appCard.try'], { ns: 'explore' })}</span>
               </Button>
             )}

--- a/web/app/components/app/create-app-dropdown.tsx
+++ b/web/app/components/app/create-app-dropdown.tsx
@@ -44,10 +44,10 @@ export function CreateAppDropdown({
             data-step-by-step-tour-target={stepByStepTourTarget}
             variant="primary"
             size="medium"
-            className="gap-0.5 px-2 whitespace-nowrap shadow-xs shadow-shadow-shadow-3"
+            className="px-2 whitespace-nowrap shadow-xs shadow-shadow-shadow-3"
           >
             <span aria-hidden className="i-ri-add-line size-4 shrink-0" />
-            <span className="pl-1">{t(($) => $['operation.create'], { ns: 'common' })}</span>
+            <span>{t(($) => $['operation.create'], { ns: 'common' })}</span>
             <span aria-hidden className="i-ri-arrow-down-s-line size-4 shrink-0" />
           </Button>
         }

--- a/web/app/components/app/create-app-modal/index.tsx
+++ b/web/app/components/app/create-app-modal/index.tsx
@@ -345,7 +345,7 @@ function CreateApp({ onClose, onSuccess, onCreateFromTemplate, defaultAppMode }:
                 <Button onClick={onClose}>{t(($) => $['newApp.Cancel'], { ns: 'app' })}</Button>
                 <Button
                   disabled={!canCreateApp || isAppsFull || !name}
-                  className="gap-1"
+
                   variant="primary"
                   onClick={handleCreateApp}
                 >

--- a/web/app/components/app/create-from-dsl-modal/index.tsx
+++ b/web/app/components/app/create-from-dsl-modal/index.tsx
@@ -334,7 +334,6 @@ function CreateFromDSLModal({
                   disabled={createDisabled}
                   loading={isImporting}
                   variant="primary"
-                  className="gap-1"
                 >
                   <span>{t(($) => $['newApp.Create'], { ns: 'app' })}</span>
                   <KbdGroup>

--- a/web/app/components/app/overview/apikey-info-panel/index.tsx
+++ b/web/app/components/app/overview/apikey-info-panel/index.tsx
@@ -67,11 +67,7 @@ const APIKeyInfoPanel: FC = () => {
           {t(($) => $[`apiKeyInfo.cloud.${'trial'}.description`], { ns: 'appOverview' })}
         </div>
       )}
-      <Button
-        variant="primary"
-        className="mt-2 space-x-2"
-        onClick={() => setSettingsDestination('provider')}
-      >
+      <Button variant="primary" className="mt-2" onClick={() => setSettingsDestination('provider')}>
         <div className="text-sm font-medium">
           {t(($) => $['apiKeyInfo.setAPIBtn'], { ns: 'appOverview' })}
         </div>

--- a/web/app/components/app/overview/app-card-sections.tsx
+++ b/web/app/components/app/overview/app-card-sections.tsx
@@ -373,7 +373,7 @@ export const AppCardOperations = ({
               show={disabled}
             >
               <Button
-                className="min-w-22 rounded-r-none border-0 px-0 py-0 shadow-none backdrop-blur-none hover:bg-components-button-secondary-bg"
+                className="min-w-22 rounded-r-none px-0 py-0 shadow-none inset-ring-0 backdrop-blur-none hover:bg-components-button-secondary-bg"
                 size="small"
                 variant="secondary"
                 onClick={onClick}
@@ -390,7 +390,7 @@ export const AppCardOperations = ({
             <div aria-hidden="true" className="h-6 w-px shrink-0 bg-divider-regular opacity-100" />
             <Button
               aria-label={launchConfigAction.label}
-              className="w-8 rounded-l-none border-0 p-0 shadow-none backdrop-blur-none hover:bg-components-button-secondary-bg-hover"
+              className="w-8 rounded-l-none p-0 shadow-none inset-ring-0 backdrop-blur-none hover:bg-components-button-secondary-bg-hover"
               size="small"
               variant="secondary"
               onClick={launchConfigAction.onClick}

--- a/web/app/components/app/overview/customize/index.tsx
+++ b/web/app/components/app/overview/customize/index.tsx
@@ -109,7 +109,7 @@ const CustomizeModal: FC<IShareLinkProps> = ({
                     />
                   }
                 >
-                  <GithubIcon className="mr-2 text-text-secondary" />
+                  <GithubIcon className="text-text-secondary" />
                   {t(($) => $[`${prefixCustomize}.way1.step1Operation`], { ns: 'appOverview' })}
                 </Button>
               </div>
@@ -136,7 +136,7 @@ const CustomizeModal: FC<IShareLinkProps> = ({
                     />
                   }
                 >
-                  <div className="mr-1.5 border-t-0 border-r-[7px] border-b-12 border-l-[7px] border-solid border-text-primary border-t-transparent border-r-transparent border-l-transparent"></div>
+                  <div className="border-t-0 border-r-[7px] border-b-12 border-l-[7px] border-solid border-text-primary border-t-transparent border-r-transparent border-l-transparent"></div>
                   <span>
                     {t(($) => $[`${prefixCustomize}.way1.step2Operation`], { ns: 'appOverview' })}
                   </span>
@@ -193,7 +193,7 @@ const CustomizeModal: FC<IShareLinkProps> = ({
               </span>
               <span
                 aria-hidden="true"
-                className="ml-1 i-heroicons-arrow-top-right-on-square size-4 shrink-0 text-text-secondary"
+                className="i-heroicons-arrow-top-right-on-square size-4 shrink-0 text-text-secondary"
               />
             </Button>
           </div>

--- a/web/app/components/app/switch-app-modal/index.tsx
+++ b/web/app/components/app/switch-app-modal/index.tsx
@@ -200,7 +200,7 @@ const SwitchAppModal = ({
                 {t(($) => $['newApp.Cancel'], { ns: 'app' })}
               </Button>
               <Button
-                className="border-red-700"
+                className="inset-ring-red-700"
                 disabled={isAppsFull || !name}
                 variant="primary"
                 tone="destructive"

--- a/web/app/components/app/text-generate/saved-items/no-data/index.tsx
+++ b/web/app/components/app/text-generate/saved-items/no-data/index.tsx
@@ -26,7 +26,7 @@ const NoData: FC<INoDataProps> = ({ onStartCreateContent }) => {
         {t(($) => $['generation.savedNoData.description'], { ns: 'share' })}
       </div>
       <Button variant="primary" className="mt-3" onClick={onStartCreateContent}>
-        <RiAddLine className="mr-1 size-4" />
+        <RiAddLine className="size-4" />
         <span>{t(($) => $['generation.savedNoData.startCreateContent'], { ns: 'share' })}</span>
       </Button>
     </div>

--- a/web/app/components/base/chat/chat-with-history/sidebar/index.tsx
+++ b/web/app/components/base/chat/chat-with-history/sidebar/index.tsx
@@ -123,7 +123,7 @@ const Sidebar = ({ isPanel }: Props) => {
           className="w-full justify-center"
           onClick={handleNewConversation}
         >
-          <span aria-hidden className="mr-1 i-ri-edit-box-line size-4" />
+          <span aria-hidden className="i-ri-edit-box-line size-4" />
           {t(($) => $['chat.newChat'], { ns: 'share' })}
         </Button>
       </div>

--- a/web/app/components/base/chat/chat/index.tsx
+++ b/web/app/components/base/chat/chat/index.tsx
@@ -270,7 +270,7 @@ const Chat: FC<ChatProps> = ({
             {!noStopResponding && isResponding && (
               <div data-testid="stop-responding-container" className="mb-2 flex justify-center">
                 <Button
-                  className="pointer-events-auto border-components-panel-border bg-components-panel-bg text-components-button-secondary-text"
+                  className="pointer-events-auto bg-components-panel-bg text-components-button-secondary-text inset-ring-components-panel-border"
                   onClick={onStopResponding}
                 >
                   <div className="i-custom-vender-solid-mediaAndDevices-stop-circle h-3.5 w-3.5" />

--- a/web/app/components/base/chat/chat/index.tsx
+++ b/web/app/components/base/chat/chat/index.tsx
@@ -273,7 +273,7 @@ const Chat: FC<ChatProps> = ({
                   className="pointer-events-auto border-components-panel-border bg-components-panel-bg text-components-button-secondary-text"
                   onClick={onStopResponding}
                 >
-                  <div className="mr-1.25 i-custom-vender-solid-mediaAndDevices-stop-circle h-3.5 w-3.5" />
+                  <div className="i-custom-vender-solid-mediaAndDevices-stop-circle h-3.5 w-3.5" />
                   <span className="text-xs font-normal">
                     {t(($) => $['operation.stopResponding'], { ns: 'appDebug' })}
                   </span>

--- a/web/app/components/base/features/new-feature-panel/annotation-reply/config-param-modal.tsx
+++ b/web/app/components/base/features/new-feature-panel/annotation-reply/config-param-modal.tsx
@@ -136,7 +136,6 @@ const ConfigParamModal: FC<Props> = ({
         <div className="mt-6 flex justify-end gap-2">
           <Button onClick={onHide}>{t(($) => $['operation.cancel'], { ns: 'common' })}</Button>
           <Button variant="primary" onClick={handleSave} loading={isLoading}>
-            <div></div>
             <div>
               {t(($) => $[`initSetup.${isInit ? 'confirmBtn' : 'configConfirmBtn'}`], {
                 ns: 'appAnnotation',

--- a/web/app/components/base/features/new-feature-panel/annotation-reply/index.tsx
+++ b/web/app/components/base/features/new-feature-panel/annotation-reply/index.tsx
@@ -123,7 +123,7 @@ const AnnotationReply = ({ disabled, onChange }: Props) => {
                     onClick={() => setIsShowAnnotationConfigInit(true)}
                     disabled={disabled}
                   >
-                    <RiEqualizer2Line className="mr-1 size-4" />
+                    <RiEqualizer2Line className="size-4" />
                     {t(($) => $['operation.params'], { ns: 'common' })}
                   </Button>
                   <Button
@@ -132,7 +132,7 @@ const AnnotationReply = ({ disabled, onChange }: Props) => {
                       router.push(`/app/${appId}/annotations`)
                     }}
                   >
-                    <RiExternalLinkLine className="mr-1 size-4" />
+                    <RiExternalLinkLine className="size-4" />
                     {t(($) => $['feature.annotation.cacheManagement'], { ns: 'appDebug' })}
                   </Button>
                 </div>

--- a/web/app/components/base/features/new-feature-panel/conversation-opener/index.tsx
+++ b/web/app/components/base/features/new-feature-panel/conversation-opener/index.tsx
@@ -111,7 +111,7 @@ const ConversationOpener = ({
             )}
             {isHovering && (
               <Button className="w-full" onClick={handleOpenOpeningModal} disabled={disabled}>
-                <RiEditLine className="mr-1 size-4" />
+                <RiEditLine className="size-4" />
                 {t(($) => $['openingStatement.writeOpener'], { ns: 'appDebug' })}
               </Button>
             )}

--- a/web/app/components/base/features/new-feature-panel/feature-bar.tsx
+++ b/web/app/components/base/features/new-feature-panel/feature-bar.tsx
@@ -212,7 +212,7 @@ const FeatureBar = ({
               size="small"
               onClick={() => onFeatureBarClick?.(true)}
             >
-              <div className="mx-1">{t(($) => $['feature.bar.manage'], { ns: 'appDebug' })}</div>
+              <div>{t(($) => $['feature.bar.manage'], { ns: 'appDebug' })}</div>
               <RiArrowRightLine className="size-3.5 text-text-accent" />
             </Button>
           )}

--- a/web/app/components/base/features/new-feature-panel/file-upload/index.tsx
+++ b/web/app/components/base/features/new-feature-panel/file-upload/index.tsx
@@ -93,7 +93,7 @@ const FileUpload = ({ disabled, onChange }: Props) => {
                 onChange={onChange}
               >
                 <Button className="w-full" disabled={disabled}>
-                  <RiEqualizer2Line className="mr-1 size-4" />
+                  <RiEqualizer2Line className="size-4" />
                   {t(($) => $['operation.settings'], { ns: 'common' })}
                 </Button>
               </SettingModal>

--- a/web/app/components/base/features/new-feature-panel/follow-up.tsx
+++ b/web/app/components/base/features/new-feature-panel/follow-up.tsx
@@ -97,7 +97,7 @@ const FollowUp = ({ disabled, onChange }: Props) => {
               )}
               {isHovering && (
                 <Button className="w-full" onClick={handleOpenSettingModal} disabled={disabled}>
-                  <RiEqualizer2Line className="mr-1 size-4" />
+                  <RiEqualizer2Line className="size-4" />
                   {t(($) => $['operation.settings'], { ns: 'common' })}
                 </Button>
               )}

--- a/web/app/components/base/features/new-feature-panel/image-upload/index.tsx
+++ b/web/app/components/base/features/new-feature-panel/image-upload/index.tsx
@@ -102,7 +102,7 @@ const FileUpload = ({ disabled, onChange }: Props) => {
                 onChange={onChange}
               >
                 <Button className="w-full" disabled={disabled}>
-                  <RiEqualizer2Line className="mr-1 size-4" />
+                  <RiEqualizer2Line className="size-4" />
                   {t(($) => $['operation.settings'], { ns: 'common' })}
                 </Button>
               </SettingModal>

--- a/web/app/components/base/features/new-feature-panel/moderation/index.tsx
+++ b/web/app/components/base/features/new-feature-panel/moderation/index.tsx
@@ -160,7 +160,7 @@ const Moderation = ({ disabled, onChange }: Props) => {
                 onClick={handleOpenModerationSettingModal}
                 disabled={disabled}
               >
-                <RiEqualizer2Line className="mr-1 size-4" />
+                <RiEqualizer2Line className="size-4" />
                 {t(($) => $['operation.settings'], { ns: 'common' })}
               </Button>
             )}

--- a/web/app/components/base/features/new-feature-panel/text-to-speech/index.tsx
+++ b/web/app/components/base/features/new-feature-panel/text-to-speech/index.tsx
@@ -105,7 +105,7 @@ const TextToSpeech = ({ disabled, onChange }: Props) => {
                 onChange={onChange}
               >
                 <Button className="w-full" disabled={disabled}>
-                  <RiEqualizer2Line className="mr-1 size-4" />
+                  <RiEqualizer2Line className="size-4" />
                   {t(($) => $['voice.voiceSettings.title'], { ns: 'appDebug' })}
                 </Button>
               </VoiceSettings>

--- a/web/app/components/base/file-uploader/file-from-link-or-local/index.tsx
+++ b/web/app/components/base/file-uploader/file-from-link-or-local/index.tsx
@@ -100,7 +100,7 @@ const FileFromLinkOrLocal = ({
           )}
           {showFromLocal && (
             <Button className="relative w-full" variant="secondary-accent" disabled={disabled}>
-              <RiUploadCloud2Line className="mr-1 size-4" />
+              <RiUploadCloud2Line className="size-4" />
               {t(($) => $['fileUploader.uploadFromComputer'], { ns: 'common' })}
               <FileInput fileConfig={fileConfig} />
             </Button>

--- a/web/app/components/base/file-uploader/file-uploader-in-attachment/index.tsx
+++ b/web/app/components/base/file-uploader/file-uploader-in-attachment/index.tsx
@@ -50,7 +50,7 @@ const FileUploaderInAttachment = ({ isDisabled, fileConfig }: FileUploaderInAtta
           disabled={!!(fileConfig.number_limits && files.length >= fileConfig.number_limits)}
         >
           <span className="shrink-0">{option.icon}</span>
-          <span className="ml-1 min-w-0 truncate">{option.label}</span>
+          <span className="min-w-0 truncate">{option.label}</span>
           {option.value === TransferMethod.local_file && <FileInput fileConfig={fileConfig} />}
         </Button>
       )

--- a/web/app/components/base/prompt-editor/plugins/hitl-input-block/input-field.tsx
+++ b/web/app/components/base/prompt-editor/plugins/hitl-input-block/input-field.tsx
@@ -346,9 +346,7 @@ const InputField: React.FC<InputFieldProps> = ({
             </Button>
           ) : (
             <Button className="flex" variant="primary" disabled={!nameValid} onClick={handleSave}>
-              <span className="mr-1">
-                {t(($) => $[`${i18nPrefix}.insert`], { ns: 'workflow' })}
-              </span>
+              <span>{t(($) => $[`${i18nPrefix}.insert`], { ns: 'workflow' })}</span>
               <KbdGroup>
                 {['Mod', 'Enter'].map((key) => (
                   <Kbd key={key} color="white">

--- a/web/app/components/billing/plan/index.tsx
+++ b/web/app/components/billing/plan/index.tsx
@@ -94,9 +94,9 @@ const PlanComp: FC<Props> = ({ loc }) => {
           <div className="flex shrink-0 items-center gap-1">
             {isCloudEdition && enableEducationPlan && (!isEducationAccount || isAboutToExpire) && (
               <Button variant="ghost" onClick={handleVerify} disabled={isPending}>
-                <span className="mr-1 i-ri-graduation-cap-line size-4" />
+                <span className="i-ri-graduation-cap-line size-4" />
                 {t(($) => $.toVerified, { ns: 'education' })}
-                {isPending && <Loading className="ml-1 animate-spin-slow" />}
+                {isPending && <Loading className="animate-spin-slow" />}
               </Button>
             )}
             {isCloudEdition &&
@@ -109,9 +109,9 @@ const PlanComp: FC<Props> = ({ loc }) => {
                   onClick={handleEducationDiscount}
                   disabled={isEducationDiscountLoading}
                 >
-                  <span className="mr-1 i-ri-graduation-cap-line size-4" />
+                  <span className="i-ri-graduation-cap-line size-4" />
                   {t(($) => $.useEducationDiscount, { ns: 'education' })}
-                  {isEducationDiscountLoading && <Loading className="ml-1 animate-spin-slow" />}
+                  {isEducationDiscountLoading && <Loading className="animate-spin-slow" />}
                 </Button>
               )}
             {isCloudEdition && !isEnterprisePlan && (

--- a/web/app/components/custom/custom-web-app-brand/components/chat-preview-card.tsx
+++ b/web/app/components/custom/custom-web-app-brand/components/chat-preview-card.tsx
@@ -34,7 +34,7 @@ const ChatPreviewCard = ({
         </div>
         <div className="shrink-0 px-4 py-3">
           <Button variant="secondary-accent" className="w-full justify-center">
-            <span className="mr-1 i-ri-edit-box-line size-4" />
+            <span className="i-ri-edit-box-line size-4" />
             <div className="p-1 opacity-20">
               <div className="h-2 w-23.5 rounded-xs bg-text-accent-light-mode-only"></div>
             </div>

--- a/web/app/components/custom/custom-web-app-brand/components/workflow-preview-card.tsx
+++ b/web/app/components/custom/custom-web-app-brand/components/workflow-preview-card.tsx
@@ -53,7 +53,7 @@ const WorkflowPreviewCard = ({
             <div className="h-2 w-10 rounded-xs bg-text-quaternary opacity-20"></div>
           </Button>
           <Button variant="primary" size="small" disabled>
-            <span className="mr-1 i-ri-play-large-line size-4" />
+            <span className="i-ri-play-large-line size-4" />
             <span>Execute</span>
           </Button>
         </div>

--- a/web/app/components/custom/custom-web-app-brand/index.tsx
+++ b/web/app/components/custom/custom-web-app-brand/index.tsx
@@ -69,7 +69,7 @@ const CustomWebAppBrand = () => {
           )}
           {!uploading && (
             <Button className="relative mr-2" disabled={uploadDisabled}>
-              <span className="mr-1 i-ri-image-add-line size-4" />
+              <span className="i-ri-image-add-line size-4" />
               {webappLogo || fileId
                 ? t(($) => $.change, { ns: 'custom' })
                 : t(($) => $.upload, { ns: 'custom' })}
@@ -88,7 +88,7 @@ const CustomWebAppBrand = () => {
           )}
           {uploading && (
             <Button className="relative mr-2" disabled={true}>
-              <span className="mr-1 i-ri-loader-2-line size-4 animate-spin" />
+              <span className="i-ri-loader-2-line size-4 animate-spin" />
               {t(($) => $.uploading, { ns: 'custom' })}
             </Button>
           )}

--- a/web/app/components/datasets/create-from-pipeline/create-options/create-from-dsl-modal/index.tsx
+++ b/web/app/components/datasets/create-from-pipeline/create-options/create-from-dsl-modal/index.tsx
@@ -72,12 +72,7 @@ const CreateFromDSLModal = ({
           </div>
           <div className="flex justify-end gap-x-2 p-6 pt-5">
             <Button onClick={onClose}>{t(($) => $['newApp.Cancel'], { ns: 'app' })}</Button>
-            <Button
-              disabled={buttonDisabled}
-              variant="primary"
-              onClick={handleCreateApp}
-              className="gap-1"
-            >
+            <Button disabled={buttonDisabled} variant="primary" onClick={handleCreateApp}>
               <span>{t(($) => $['newApp.import'], { ns: 'app' })}</span>
             </Button>
           </div>

--- a/web/app/components/datasets/create-from-pipeline/list/template-card/actions.tsx
+++ b/web/app/components/datasets/create-from-pipeline/list/template-card/actions.tsx
@@ -36,17 +36,13 @@ const Actions = ({
         isMoreOperationsOpen ? 'flex' : 'hidden group-hover:flex',
       )}
     >
-      <Button variant="primary" onClick={onApplyTemplate} className="grow gap-x-0.5">
+      <Button variant="primary" onClick={onApplyTemplate} className="grow">
         <span aria-hidden className="i-ri-add-line size-4" />
-        <span className="px-0.5">
-          {t(($) => $['operations.choose'], { ns: 'datasetPipeline' })}
-        </span>
+        <span>{t(($) => $['operations.choose'], { ns: 'datasetPipeline' })}</span>
       </Button>
-      <Button variant="secondary" onClick={handleShowTemplateDetails} className="grow gap-x-0.5">
+      <Button variant="secondary" onClick={handleShowTemplateDetails} className="grow">
         <span aria-hidden className="i-ri-arrow-right-up-line size-4" />
-        <span className="px-0.5">
-          {t(($) => $['operations.details'], { ns: 'datasetPipeline' })}
-        </span>
+        <span>{t(($) => $['operations.details'], { ns: 'datasetPipeline' })}</span>
       </Button>
       {showMoreOperations && (
         <DropdownMenu open={isMoreOperationsOpen} onOpenChange={setIsMoreOperationsOpen}>

--- a/web/app/components/datasets/create-from-pipeline/list/template-card/details/index.tsx
+++ b/web/app/components/datasets/create-from-pipeline/list/template-card/details/index.tsx
@@ -89,11 +89,9 @@ const Details = ({ id, type, onApplyTemplate, onClose }: DetailsProps) => {
           {pipelineTemplateInfo.description}
         </p>
         <div className="p-3">
-          <Button variant="primary" onClick={onApplyTemplate} className="w-full gap-x-0.5">
+          <Button variant="primary" onClick={onApplyTemplate} className="w-full">
             <RiAddLine className="size-4" />
-            <span className="px-0.5">
-              {t(($) => $['operations.useTemplate'], { ns: 'datasetPipeline' })}
-            </span>
+            <span>{t(($) => $['operations.useTemplate'], { ns: 'datasetPipeline' })}</span>
           </Button>
         </div>
         <div className="flex flex-col gap-y-1 px-4 py-2">

--- a/web/app/components/datasets/create/embedding-process/index.tsx
+++ b/web/app/components/datasets/create/embedding-process/index.tsx
@@ -57,13 +57,13 @@ const ActionButtons: FC<{
   return (
     <div className="mt-6 flex items-center gap-x-2 py-2">
       <Link href={apiReferenceUrl} target="_blank" rel="noopener noreferrer">
-        <Button className="w-fit gap-x-0.5 px-3">
+        <Button className="w-fit">
           <RiTerminalBoxLine className="size-4" />
-          <span className="px-0.5">Access the API</span>
+          <span>Access the API</span>
         </Button>
       </Link>
-      <Button className="w-fit gap-x-0.5 px-3" variant="primary" onClick={onNavToDocuments}>
-        <span className="px-0.5">{t(($) => $['stepThree.navTo'], { ns: 'datasetCreation' })}</span>
+      <Button className="w-fit" variant="primary" onClick={onNavToDocuments}>
+        <span>{t(($) => $['stepThree.navTo'], { ns: 'datasetCreation' })}</span>
         <RiArrowRightLine className="size-4 stroke-current stroke-1" />
       </Button>
     </div>

--- a/web/app/components/datasets/create/step-two/components/general-chunking-options.tsx
+++ b/web/app/components/datasets/create/step-two/components/general-chunking-options.tsx
@@ -117,7 +117,7 @@ export const GeneralChunkingOptions: FC<GeneralChunkingOptionsProps> = ({
       actions={
         <>
           <Button variant="secondary-accent" onClick={onPreview}>
-            <RiSearchEyeLine className="mr-0.5 size-4" />
+            <RiSearchEyeLine className="size-4" />
             {t(($) => $['stepTwo.previewChunk'], { ns: 'datasetCreation' })}
           </Button>
           <Button variant="ghost" onClick={onReset}>

--- a/web/app/components/datasets/create/step-two/components/parent-child-options.tsx
+++ b/web/app/components/datasets/create/step-two/components/parent-child-options.tsx
@@ -107,7 +107,7 @@ export const ParentChildOptions: FC<ParentChildOptionsProps> = ({
       actions={
         <>
           <Button variant="secondary-accent" onClick={onPreview}>
-            <RiSearchEyeLine className="mr-0.5 size-4" />
+            <RiSearchEyeLine className="size-4" />
             {t(($) => $['stepTwo.previewChunk'], { ns: 'datasetCreation' })}
           </Button>
           <Button variant="ghost" onClick={onReset}>

--- a/web/app/components/datasets/create/step-two/components/step-two-footer.tsx
+++ b/web/app/components/datasets/create/step-two/components/step-two-footer.tsx
@@ -26,7 +26,7 @@ export const StepTwoFooter: FC<StepTwoFooterProps> = ({
     return (
       <div className="mt-8 flex items-center py-2">
         <Button onClick={onPrevious}>
-          <RiArrowLeftLine className="mr-1 size-4" />
+          <RiArrowLeftLine className="size-4" />
           {t(($) => $['stepTwo.previousStep'], { ns: 'datasetCreation' })}
         </Button>
         <Button className="ml-auto" loading={isCreating} variant="primary" onClick={onCreate}>

--- a/web/app/components/datasets/create/website/base/header.tsx
+++ b/web/app/components/datasets/create/website/base/header.tsx
@@ -36,7 +36,7 @@ const Header = ({
         <Button
           variant="secondary"
           size="small"
-          className={cn(isInPipeline ? 'size-6 px-1' : 'gap-x-0.5 px-1.5')}
+          className={cn(isInPipeline ? 'size-6 px-1' : 'px-1.5')}
           onClick={onClickConfiguration}
         >
           <RiEqualizer2Line className="size-4" />

--- a/web/app/components/datasets/documents/components/documents-header.tsx
+++ b/web/app/components/datasets/documents/components/documents-header.tsx
@@ -191,7 +191,7 @@ const DocumentsHeader: FC<DocumentsHeaderProps> = ({
           )}
           {embeddingAvailable && canManageMetadata && (
             <Button variant="secondary" className="shrink-0" onClick={showEditMetadataModal}>
-              <span className="mr-1 i-ri-draft-line size-4" />
+              <span className="i-ri-draft-line size-4" />
               {t(($) => $['metadata.metadata'], { ns: 'dataset' })}
             </Button>
           )}
@@ -209,7 +209,7 @@ const DocumentsHeader: FC<DocumentsHeaderProps> = ({
           )}
           {embeddingAvailable && canAddDocument && (
             <Button variant="primary" onClick={onAddDocument} className="shrink-0">
-              <span className="mr-2 i-heroicons-plus-solid size-4 stroke-current" />
+              <span className="i-heroicons-plus-solid size-4 stroke-current" />
               {addButtonText}
             </Button>
           )}

--- a/web/app/components/datasets/documents/create-from-pipeline/actions/index.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/actions/index.tsx
@@ -68,13 +68,8 @@ const Actions = ({
             {t(($) => $['operation.cancel'], { ns: 'common' })}
           </Button>
         </Link>
-        <Button
-          disabled={disabled}
-          variant="primary"
-          onClick={handleNextStep}
-          className="gap-x-0.5"
-        >
-          <span className="px-0.5">{t(($) => $['stepOne.button'], { ns: 'datasetCreation' })}</span>
+        <Button disabled={disabled} variant="primary" onClick={handleNextStep}>
+          <span>{t(($) => $['stepOne.button'], { ns: 'datasetCreation' })}</span>
           <RiArrowRightLine className="size-4" />
         </Button>
       </div>

--- a/web/app/components/datasets/documents/create-from-pipeline/data-source/online-drive/file-list/list/empty-search-result.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/data-source/online-drive/file-list/list/empty-search-result.tsx
@@ -20,10 +20,8 @@ const EmptySearchResult = ({
       <div className="system-sm-regular text-text-secondary">
         {t(($) => $['onlineDrive.emptySearchResult'], { ns: 'datasetPipeline' })}
       </div>
-      <Button variant="secondary-accent" size="small" onClick={onResetKeywords} className="px-1.5">
-        <span className="px-0.75">
-          {t(($) => $['onlineDrive.resetKeywords'], { ns: 'datasetPipeline' })}
-        </span>
+      <Button variant="secondary-accent" size="small" onClick={onResetKeywords}>
+        <span>{t(($) => $['onlineDrive.resetKeywords'], { ns: 'datasetPipeline' })}</span>
       </Button>
     </div>
   )

--- a/web/app/components/datasets/documents/create-from-pipeline/data-source/website-crawl/base/options/index.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/data-source/website-crawl/base/options/index.tsx
@@ -89,10 +89,10 @@ const Options = ({ variables, step, runDisabled, onSubmit }: OptionsProps) => {
           onClick={form.handleSubmit}
           disabled={runDisabled || isRunning}
           loading={isRunning}
-          className="shrink-0 gap-x-0.5"
+          className="shrink-0"
         >
           <RiPlayLargeLine className="size-4" />
-          <span className="px-0.5">
+          <span>
             {!isRunning
               ? t(($) => $[`${I18N_PREFIX}.run`], { ns: 'datasetCreation' })
               : t(($) => $[`${I18N_PREFIX}.running`], { ns: 'datasetCreation' })}

--- a/web/app/components/datasets/documents/create-from-pipeline/process-documents/actions.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/process-documents/actions.tsx
@@ -14,11 +14,9 @@ const Actions = ({ onBack, runDisabled, onProcess }: ActionsProps) => {
 
   return (
     <div className="flex items-center justify-between">
-      <Button variant="secondary" onClick={onBack} className="gap-x-0.5">
+      <Button variant="secondary" onClick={onBack}>
         <RiArrowLeftLine className="size-4" />
-        <span className="px-0.5">
-          {t(($) => $['operations.dataSource'], { ns: 'datasetPipeline' })}
-        </span>
+        <span>{t(($) => $['operations.dataSource'], { ns: 'datasetPipeline' })}</span>
       </Button>
       <Button variant="primary" disabled={runDisabled} onClick={onProcess}>
         {t(($) => $['operations.saveAndProcess'], { ns: 'datasetPipeline' })}

--- a/web/app/components/datasets/documents/create-from-pipeline/process-documents/header.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/process-documents/header.tsx
@@ -21,16 +21,9 @@ const Header = ({ onReset, resetDisabled, previewDisabled, onPreview }: HeaderPr
       <Button variant="ghost" disabled={resetDisabled} onClick={onReset}>
         {t(($) => $['operation.reset'], { ns: 'common' })}
       </Button>
-      <Button
-        variant="secondary-accent"
-        onClick={onPreview}
-        className="gap-x-0.5"
-        disabled={previewDisabled}
-      >
+      <Button variant="secondary-accent" onClick={onPreview} disabled={previewDisabled}>
         <RiSearchEyeLine className="size-4" />
-        <span className="px-0.5">
-          {t(($) => $['addDocuments.stepTwo.previewChunks'], { ns: 'datasetPipeline' })}
-        </span>
+        <span>{t(($) => $['addDocuments.stepTwo.previewChunks'], { ns: 'datasetPipeline' })}</span>
       </Button>
     </div>
   )

--- a/web/app/components/datasets/documents/create-from-pipeline/processing/embedding-process/index.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/processing/embedding-process/index.tsx
@@ -240,15 +240,13 @@ const EmbeddingProcess = ({
       </div>
       <div className="mt-6 flex items-center gap-x-2 py-2">
         <Link href={apiReferenceUrl} target="_blank" rel="noopener noreferrer">
-          <Button className="w-fit gap-x-0.5 px-3">
+          <Button className="w-fit">
             <RiTerminalBoxLine className="size-4" />
-            <span className="px-0.5">Access the API</span>
+            <span>Access the API</span>
           </Button>
         </Link>
-        <Button className="w-fit gap-x-0.5 px-3" variant="primary" onClick={navToDocumentList}>
-          <span className="px-0.5">
-            {t(($) => $['stepThree.navTo'], { ns: 'datasetCreation' })}
-          </span>
+        <Button className="w-fit" variant="primary" onClick={navToDocumentList}>
+          <span>{t(($) => $['stepThree.navTo'], { ns: 'datasetCreation' })}</span>
           <RiArrowRightLine className="size-4 stroke-current stroke-1" />
         </Button>
       </div>

--- a/web/app/components/datasets/documents/detail/completed/common/batch-action.tsx
+++ b/web/app/components/datasets/documents/detail/completed/common/batch-action.tsx
@@ -85,72 +85,57 @@ const BatchAction: FC<IBatchActionProps> = ({
         </div>
         <Divider type="vertical" className="mx-0.5 h-3.5 bg-divider-regular" />
         {onBatchEnable && (
-          <Button variant="ghost" className="gap-x-0.5 px-3" onClick={onBatchEnable}>
+          <Button variant="ghost" onClick={onBatchEnable}>
             <RiCheckboxCircleLine className="size-4" />
-            <span className="px-0.5">{t(($) => $[`${i18nPrefix}.enable`], { ns: 'dataset' })}</span>
+            <span>{t(($) => $[`${i18nPrefix}.enable`], { ns: 'dataset' })}</span>
           </Button>
         )}
         {onBatchDisable && (
-          <Button variant="ghost" className="gap-x-0.5 px-3" onClick={onBatchDisable}>
+          <Button variant="ghost" onClick={onBatchDisable}>
             <RiCloseCircleLine className="size-4" />
-            <span className="px-0.5">
-              {t(($) => $[`${i18nPrefix}.disable`], { ns: 'dataset' })}
-            </span>
+            <span>{t(($) => $[`${i18nPrefix}.disable`], { ns: 'dataset' })}</span>
           </Button>
         )}
         {onEditMetadata && (
-          <Button variant="ghost" className="gap-x-0.5 px-3" onClick={onEditMetadata}>
+          <Button variant="ghost" onClick={onEditMetadata}>
             <RiDraftLine className="size-4" />
-            <span className="px-0.5">{t(($) => $['metadata.metadata'], { ns: 'dataset' })}</span>
+            <span>{t(($) => $['metadata.metadata'], { ns: 'dataset' })}</span>
           </Button>
         )}
         {onBatchSummary && isNonCloudEdition && (
-          <Button variant="ghost" className="gap-x-0.5 px-3" onClick={onBatchSummary}>
+          <Button variant="ghost" onClick={onBatchSummary}>
             <SearchLinesSparkle className="size-4" />
-            <span className="px-0.5">
-              {t(($) => $['list.action.summary'], { ns: 'datasetDocuments' })}
-            </span>
+            <span>{t(($) => $['list.action.summary'], { ns: 'datasetDocuments' })}</span>
           </Button>
         )}
         {onArchive && (
-          <Button variant="ghost" className="gap-x-0.5 px-3" onClick={onArchive}>
+          <Button variant="ghost" onClick={onArchive}>
             <RiArchive2Line className="size-4" />
-            <span className="px-0.5">
-              {t(($) => $[`${i18nPrefix}.archive`], { ns: 'dataset' })}
-            </span>
+            <span>{t(($) => $[`${i18nPrefix}.archive`], { ns: 'dataset' })}</span>
           </Button>
         )}
         {onBatchReIndex && (
-          <Button variant="ghost" className="gap-x-0.5 px-3" onClick={onBatchReIndex}>
+          <Button variant="ghost" onClick={onBatchReIndex}>
             <RiRefreshLine className="size-4" />
-            <span className="px-0.5">
-              {t(($) => $[`${i18nPrefix}.reIndex`], { ns: 'dataset' })}
-            </span>
+            <span>{t(($) => $[`${i18nPrefix}.reIndex`], { ns: 'dataset' })}</span>
           </Button>
         )}
         {onBatchDownload && (
-          <Button variant="ghost" className="gap-x-0.5 px-3" onClick={onBatchDownload}>
+          <Button variant="ghost" onClick={onBatchDownload}>
             <RiDownload2Line className="size-4" />
-            <span className="px-0.5">
-              {t(($) => $[`${i18nPrefix}.download`], { ns: 'dataset' })}
-            </span>
+            <span>{t(($) => $[`${i18nPrefix}.download`], { ns: 'dataset' })}</span>
           </Button>
         )}
         {onBatchDelete && (
-          <Button
-            variant="ghost"
-            tone="destructive"
-            className="gap-x-0.5 px-3"
-            onClick={showDeleteConfirm}
-          >
+          <Button variant="ghost" tone="destructive" onClick={showDeleteConfirm}>
             <RiDeleteBinLine className="size-4" />
-            <span className="px-0.5">{t(($) => $[`${i18nPrefix}.delete`], { ns: 'dataset' })}</span>
+            <span>{t(($) => $[`${i18nPrefix}.delete`], { ns: 'dataset' })}</span>
           </Button>
         )}
 
         <Divider type="vertical" className="mx-0.5 h-3.5 bg-divider-regular" />
-        <Button variant="ghost" className="px-3" onClick={onCancel}>
-          <span className="px-0.5">{t(($) => $[`${i18nPrefix}.cancel`], { ns: 'dataset' })}</span>
+        <Button variant="ghost" onClick={onCancel}>
+          <span>{t(($) => $[`${i18nPrefix}.cancel`], { ns: 'dataset' })}</span>
         </Button>
       </div>
       {onBatchDelete && (

--- a/web/app/components/datasets/documents/detail/completed/common/regeneration-modal.tsx
+++ b/web/app/components/datasets/documents/detail/completed/common/regeneration-modal.tsx
@@ -57,12 +57,7 @@ const RegeneratingContent: FC = React.memo(() => {
         </p>
       </div>
       <div className="flex justify-end pt-6">
-        <Button
-          variant="primary"
-          tone="destructive"
-          disabled
-          className="inline-flex items-center gap-x-0.5"
-        >
+        <Button variant="primary" tone="destructive" disabled className="inline-flex items-center">
           <RiLoader2Line className="size-4 animate-spin text-components-button-destructive-primary-text-disabled" />
           <span>{t(($) => $['operation.regenerate'], { ns: 'common' })}</span>
         </Button>

--- a/web/app/components/datasets/external-api/external-api-panel/index.tsx
+++ b/web/app/components/datasets/external-api/external-api-panel/index.tsx
@@ -80,7 +80,7 @@ const ExternalAPIPanel: React.FC<ExternalAPIPanelProps> = ({
           <div className="flex flex-col items-start justify-center gap-2 self-stretch px-4 py-3">
             <Button
               variant="primary"
-              className="flex items-center justify-center gap-0.5 px-3 py-2"
+              className="flex items-center justify-center px-3 py-2"
               onClick={handleOpenExternalAPIModal}
             >
               <RiAddLine className="size-4 text-components-button-primary-text" />

--- a/web/app/components/datasets/external-knowledge-base/create/ExternalApiSelection.tsx
+++ b/web/app/components/datasets/external-knowledge-base/create/ExternalApiSelection.tsx
@@ -84,7 +84,7 @@ const ExternalApiSelection: React.FC<ExternalApiSelectionProps> = ({
             }}
           />
         ) : (
-          <Button variant="tertiary" onClick={handleAddNewAPI} className="justify-start gap-0.5">
+          <Button variant="tertiary" onClick={handleAddNewAPI} className="justify-start">
             <RiAddLine className="size-4 text-text-tertiary" />
             <span className="system-sm-regular text-text-tertiary">
               {t(($) => $.noExternalKnowledge, { ns: 'dataset' })}

--- a/web/app/components/datasets/extra-info/service-api/card.tsx
+++ b/web/app/components/datasets/extra-info/service-api/card.tsx
@@ -56,21 +56,21 @@ const Card = ({ apiBaseUrl, onOpenSecretKeyModal, canManageSecretKey = false }: 
             <Button
               variant="ghost"
               size="small"
-              className="gap-x-px text-text-tertiary"
+              className="text-text-tertiary"
               disabled={!canManageSecretKey}
               onClick={onOpenSecretKeyModal}
             >
               <span className="i-ri-key-2-line size-3.5 shrink-0" />
-              <span className="px-0.75 system-xs-medium">
+              <span className="system-xs-medium">
                 {t(($) => $['serviceApi.card.apiKey'], { ns: 'dataset' })}
               </span>
             </Button>
           }
         />
         <Link href={apiReferenceUrl} target="_blank" rel="noopener noreferrer">
-          <Button variant="ghost" size="small" className="gap-x-px text-text-tertiary">
+          <Button variant="ghost" size="small" className="text-text-tertiary">
             <span className="i-ri-book-open-line size-3.5 shrink-0" />
-            <span className="px-0.75 system-xs-medium">
+            <span className="system-xs-medium">
               {t(($) => $['serviceApi.card.apiReference'], { ns: 'dataset' })}
             </span>
           </Button>

--- a/web/app/components/datasets/hit-testing/components/query-input/index.tsx
+++ b/web/app/components/datasets/hit-testing/components/query-input/index.tsx
@@ -232,7 +232,7 @@ const QueryInput = ({
         }
         className="w-22"
       >
-        <RiPlayCircleLine className="mr-1 size-4" />
+        <RiPlayCircleLine className="size-4" />
         {t(($) => $['input.testing'], { ns: 'datasetHitTesting' })}
       </Button>
     )
@@ -266,7 +266,7 @@ const QueryInput = ({
               onClick={() => setIsSettingsOpen(!isSettingsOpen)}
             >
               <RiEqualizer2Line className="size-3.5 text-components-button-secondary-text" />
-              <div className="flex items-center justify-center gap-1 px-0.75">
+              <div className="flex items-center justify-center gap-1">
                 <span className="system-xs-medium text-components-button-secondary-text">
                   {t(($) => $.settingTitle, { ns: 'datasetHitTesting' })}
                 </span>

--- a/web/app/components/datasets/list/header.tsx
+++ b/web/app/components/datasets/list/header.tsx
@@ -83,14 +83,14 @@ const DatasetListHeader = ({
             <Button
               variant="ghost"
               size="small"
-              className="gap-1 overflow-hidden px-1.5 text-text-tertiary"
+              className="overflow-hidden text-text-tertiary"
               onClick={onExternalApiClick}
             >
               <span
                 aria-hidden
                 className="i-custom-vender-solid-development-api-connection-mod size-3.5 shrink-0"
               />
-              <span className="px-0.5 system-xs-medium">
+              <span className="system-xs-medium">
                 {t(($) => $.externalAPIPanelTitle, { ns: 'dataset' })}
               </span>
             </Button>
@@ -134,13 +134,11 @@ const DatasetListHeader = ({
                   <Button
                     variant="primary"
                     size="medium"
-                    className="gap-0.5 px-2 shadow-xs"
+                    className="px-2 shadow-xs"
                     data-step-by-step-tour-target={stepByStepTourCreateMenuTarget}
                   >
                     <span aria-hidden className="i-ri-add-line size-4 shrink-0" />
-                    <span className="pl-1">
-                      {t(($) => $['operation.create'], { ns: 'common' })}
-                    </span>
+                    <span>{t(($) => $['operation.create'], { ns: 'common' })}</span>
                     <span aria-hidden className="i-ri-arrow-down-s-line size-4 shrink-0" />
                   </Button>
                 }

--- a/web/app/components/datasets/metadata/metadata-dataset/dataset-metadata-drawer.tsx
+++ b/web/app/components/datasets/metadata/metadata-dataset/dataset-metadata-drawer.tsx
@@ -241,7 +241,7 @@ const DatasetMetadataDrawer: FC<Props> = ({
                   setOpen={setOpen}
                   trigger={
                     <Button variant="primary" className="mt-3">
-                      <RiAddLine className="mr-1" />
+                      <RiAddLine />
                       {t(($) => $[`${i18nPrefix}.addMetaData`], { ns: 'dataset' })}
                     </Button>
                   }

--- a/web/app/components/datasets/metadata/metadata-document/index.tsx
+++ b/web/app/components/datasets/metadata/metadata-document/index.tsx
@@ -71,7 +71,7 @@ const MetadataDocument: FC<Props> = ({
                 </div>
               ) : (
                 <Button variant="ghost" size="small" onClick={startToEdit}>
-                  <span className="mr-1 i-ri-edit-line size-3.5 cursor-pointer text-text-tertiary" />
+                  <span className="i-ri-edit-line size-3.5 cursor-pointer text-text-tertiary" />
                   <div>{t(($) => $['operation.edit'], { ns: 'common' })}</div>
                 </Button>
               ))

--- a/web/app/components/datasets/metadata/metadata-document/no-data.tsx
+++ b/web/app/components/datasets/metadata/metadata-document/no-data.tsx
@@ -21,7 +21,7 @@ const NoData: FC<Props> = ({ onStart }) => {
       </div>
       <Button variant="primary" className="mt-2" onClick={onStart}>
         <div>{t(($) => $['metadata.documentMetadata.startLabeling'], { ns: 'dataset' })}</div>
-        <RiArrowRightLine className="ml-1 size-4" />
+        <RiArrowRightLine className="size-4" />
       </Button>
     </div>
   )

--- a/web/app/components/develop/secret-key/__tests__/secret-key-button.spec.tsx
+++ b/web/app/components/develop/secret-key/__tests__/secret-key-button.spec.tsx
@@ -169,48 +169,6 @@ describe('SecretKeyButton', () => {
     })
   })
 
-  describe('button styling', () => {
-    it('should have px-3 padding', () => {
-      render(<SecretKeyButton />)
-      const button = screen.getByRole('button')
-      expect(button.className).toContain('px-3')
-    })
-  })
-
-  describe('icon styling', () => {
-    it('should have icon container with flex layout', () => {
-      const { container } = render(<SecretKeyButton />)
-      const iconContainer = container.querySelector('.flex.items-center.justify-center')
-      expect(iconContainer)!.toBeInTheDocument()
-    })
-
-    it('should have correct icon dimensions', () => {
-      const { container } = render(<SecretKeyButton />)
-      const iconContainer = container.querySelector('.size-3\\.5')
-      expect(iconContainer)!.toBeInTheDocument()
-    })
-
-    it('should have tertiary text color on icon', () => {
-      const { container } = render(<SecretKeyButton />)
-      const icon = container.querySelector('.text-text-tertiary')
-      expect(icon)!.toBeInTheDocument()
-    })
-  })
-
-  describe('text styling', () => {
-    it('should have horizontal padding', () => {
-      render(<SecretKeyButton />)
-      const text = screen.getByText('appApi.apiKey')
-      expect(text.className).toContain('px-0.75')
-    })
-
-    it('should have tertiary text color', () => {
-      render(<SecretKeyButton />)
-      const text = screen.getByText('appApi.apiKey')
-      expect(text.className).toContain('text-text-tertiary')
-    })
-  })
-
   describe('modal props', () => {
     it('should pass isShow prop to modal', async () => {
       const user = userEvent.setup()

--- a/web/app/components/develop/secret-key/secret-key-button.tsx
+++ b/web/app/components/develop/secret-key/secret-key-button.tsx
@@ -32,7 +32,7 @@ const SecretKeyButton = ({
         <div className="flex size-3.5 items-center justify-center">
           <span className="i-ri-key-2-line size-3.5 text-text-tertiary" />
         </div>
-        <div className={`px-0.75 system-xs-medium text-text-tertiary ${textCls}`}>
+        <div className={`system-xs-medium text-text-tertiary ${textCls}`}>
           {t(($) => $.apiKey, { ns: 'appApi' })}
         </div>
       </Button>

--- a/web/app/components/develop/secret-key/secret-key-modal.tsx
+++ b/web/app/components/develop/secret-key/secret-key-modal.tsx
@@ -201,7 +201,7 @@ const SecretKeyModal = ({ isShow = false, appId, canManage, onClose }: ISecretKe
               onClick={onCreate}
               disabled={!currentWorkspace.id || !canManage}
             >
-              <span className="mr-1 i-heroicons-plus-20-solid flex size-4 shrink-0" />
+              <span className="i-heroicons-plus-20-solid flex size-4 shrink-0" />
               <div className="text-xs font-medium text-text-secondary">
                 {t(($) => $['apiKeyModal.createNewSecretKey'], { ns: 'appApi' })}
               </div>

--- a/web/app/components/explore/create-app-modal/index.tsx
+++ b/web/app/components/explore/create-app-modal/index.tsx
@@ -230,7 +230,7 @@ const CreateAppModal = ({
           <div className="flex flex-row-reverse">
             <Button
               disabled={(!isEditModal && isAppsFull) || !name.trim() || confirmDisabled}
-              className="ml-2 w-24 gap-1"
+              className="ml-2 w-24"
               variant="primary"
               onClick={handleSubmit}
             >

--- a/web/app/components/explore/try-app/app-info/index.tsx
+++ b/web/app/components/explore/try-app/app-info/index.tsx
@@ -129,7 +129,7 @@ const AppInfo: FC<Props> = ({
           data-step-by-step-tour-target={createButtonStepByStepTourTarget}
           onClick={onCreate}
         >
-          <span className="mr-1 i-ri-add-line size-4 shrink-0" />
+          <span className="i-ri-add-line size-4 shrink-0" />
           <span className="truncate">
             {t(($) => $['tryApp.createFromSampleApp'], { ns: 'explore' })}
           </span>

--- a/web/app/components/header/account-dropdown/compliance.tsx
+++ b/web/app/components/header/account-dropdown/compliance.tsx
@@ -59,10 +59,10 @@ function ComplianceDocActionVisual({
         disabled={isPending}
         loading={isPending}
         aria-hidden
-        className="pointer-events-none flex items-center gap-px"
+        className="pointer-events-none flex items-center"
       >
         <span className="i-ri-arrow-down-circle-line size-3.5 text-components-button-secondary-text-disabled" />
-        <span className="px-0.75 system-xs-medium text-components-button-secondary-text">
+        <span className="system-xs-medium text-components-button-secondary-text">
           {downloadText}
         </span>
       </Button>

--- a/web/app/components/header/account-setting/access-rules-page/access-rule-section.tsx
+++ b/web/app/components/header/account-setting/access-rules-page/access-rule-section.tsx
@@ -107,7 +107,7 @@ const AccessRuleSection = ({
         <div className="flex shrink-0 items-center gap-3">
           {canManage && (
             <Button variant="primary" size="medium" onClick={onCreate} disabled={isLoadingRules}>
-              <span className="mr-0.5 i-ri-add-line size-3.5" />
+              <span className="i-ri-add-line size-3.5" />
               <span>{t(($) => $['accessRule.newPermissionSet'], { ns: 'permission' })}</span>
             </Button>
           )}

--- a/web/app/components/header/account-setting/api-based-extension-page/index.tsx
+++ b/web/app/components/header/account-setting/api-based-extension-page/index.tsx
@@ -105,7 +105,7 @@ export function ApiBasedExtensionPage({ layout }: ApiBasedExtensionPageProps = {
     <div className="flex w-full items-center justify-between gap-2">
       <SearchInput className="w-50" value={keywords} onValueChange={setKeywords} />
       <Button variant="secondary" disabled={!canManage} onClick={handleOpenApiBasedExtensionModal}>
-        <span className="mr-1 i-ri-add-line size-4" aria-hidden="true" />
+        <span className="i-ri-add-line size-4" aria-hidden="true" />
         {t(($) => $['apiBasedExtension.add'], { ns: 'common' })}
       </Button>
     </div>

--- a/web/app/components/header/account-setting/api-based-extension-page/item.tsx
+++ b/web/app/components/header/account-setting/api-based-extension-page/item.tsx
@@ -57,11 +57,11 @@ export function Item({ apiBasedExtension, onEdit, canManage = true }: ItemProps)
       </div>
       <div className="pointer-events-none flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100">
         <Button disabled={!canManage} onClick={handleOpenApiBasedExtensionModal}>
-          <span className="mr-1 i-ri-edit-line size-4" aria-hidden="true" />
+          <span className="i-ri-edit-line size-4" aria-hidden="true" />
           {t(($) => $['operation.edit'], { ns: 'common' })}
         </Button>
         <Button disabled={!canManage} onClick={() => canManage && setShowDeleteConfirm(true)}>
-          <span className="mr-1 i-ri-delete-bin-line size-4" aria-hidden="true" />
+          <span className="i-ri-delete-bin-line size-4" aria-hidden="true" />
           {t(($) => $['operation.delete'], { ns: 'common' })}
         </Button>
       </div>

--- a/web/app/components/header/account-setting/members-page/invite-button.tsx
+++ b/web/app/components/header/account-setting/members-page/invite-button.tsx
@@ -26,7 +26,7 @@ const InviteButton = (props: InviteButtonProps) => {
   }
   return (
     <Button {...props} variant="primary">
-      <span aria-hidden="true" className="mr-1 i-ri-user-add-line size-4" />
+      <span aria-hidden="true" className="i-ri-user-add-line size-4" />
       {t(($) => $['members.invite'], { ns: 'common' })}
     </Button>
   )

--- a/web/app/components/header/account-setting/members-page/member-details-modal/index.tsx
+++ b/web/app/components/header/account-setting/members-page/member-details-modal/index.tsx
@@ -55,8 +55,8 @@ const MemberDetailsModal = ({
           defaultValue: 'Assigned Roles',
         })
   const assignActionIconClassName = allowMultipleRoles
-    ? 'mr-0.5 i-ri-add-line h-3.5 w-3.5'
-    : 'mr-0.5 i-ri-edit-line h-3.5 w-3.5'
+    ? 'i-ri-add-line h-3.5 w-3.5'
+    : 'i-ri-edit-line h-3.5 w-3.5'
   const assignActionLabel = allowMultipleRoles
     ? t(($) => $['members.memberDetails.assign'], {
         ns: 'common',

--- a/web/app/components/header/account-setting/model-provider-page/model-auth/add-custom-model.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-auth/add-custom-model.tsx
@@ -66,7 +66,7 @@ const AddCustomModel = ({
             disabled && 'cursor-not-allowed opacity-50',
           )}
         >
-          <span className="mr-1 i-ri-add-circle-fill size-3.5" />
+          <span className="i-ri-add-circle-fill size-3.5" />
           {t(($) => $['modelProvider.addModel'], { ns: 'common' })}
         </Button>
       )

--- a/web/app/components/header/account-setting/model-provider-page/model-auth/config-model.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-auth/config-model.tsx
@@ -42,18 +42,18 @@ const ConfigModel = ({
       {credentialRemoved && (
         <>
           {t(($) => $['modelProvider.auth.credentialRemoved'], { ns: 'common' })}
-          <StatusDot status="error" className="ml-2" />
+          <StatusDot status="error" />
         </>
       )}
       {!loadBalancingEnabled && !credentialRemoved && !loadBalancingInvalid && (
         <>
-          <RiEqualizer2Line className="mr-1 size-4" />
+          <RiEqualizer2Line className="size-4" />
           {t(($) => $['operation.config'], { ns: 'common' })}
         </>
       )}
       {loadBalancingEnabled && !credentialRemoved && !loadBalancingInvalid && (
         <>
-          <RiScales3Line className="mr-1 size-4" />
+          <RiScales3Line className="size-4" />
           {t(($) => $['modelProvider.auth.configLoadBalancing'], { ns: 'common' })}
         </>
       )}

--- a/web/app/components/header/account-setting/model-provider-page/model-auth/switch-credential-in-load-balancing.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-auth/switch-credential-in-load-balancing.tsx
@@ -60,13 +60,13 @@ const SwitchCredentialInLoadBalancing = ({
       <Button
         variant="secondary"
         className={cn(
-          'shrink-0 space-x-1',
+          'shrink-0',
           (authRemoved || unavailable) && 'text-components-button-destructive-secondary-text',
           (!canOpenCredentialMenu || (empty && !canCreateCredential)) &&
             'cursor-not-allowed opacity-50',
         )}
       >
-        {!empty && <StatusDot className="mr-2" status={color} />}
+        {!empty && <StatusDot status={color} />}
         {authRemoved && t(($) => $['modelProvider.auth.authRemoved'], { ns: 'common' })}
         {unavailable && t(($) => $['auth.credentialUnavailableInButton'], { ns: 'plugin' })}
         {empty &&
@@ -77,7 +77,7 @@ const SwitchCredentialInLoadBalancing = ({
           (!canCreateCredential || notAllowCustomCredential) &&
           t(($) => $['auth.credentialUnavailableInButton'], { ns: 'plugin' })}
         {!authRemoved && !unavailable && !empty && customModelCredential?.credential_name}
-        {currentCredential?.from_enterprise && <Badge className="ml-2">Enterprise</Badge>}
+        {currentCredential?.from_enterprise && <Badge>Enterprise</Badge>}
         <span className="i-ri-arrow-down-s-line size-4" />
       </Button>
     )

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/configuration-button.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/configuration-button.tsx
@@ -18,7 +18,7 @@ const ConfigurationButton = ({ modelProvider, handleOpenModal }: ConfigurationBu
         handleOpenModal(modelProvider, ConfigurationMethodEnum.predefinedModel, undefined)
       }}
     >
-      <div className="flex items-center justify-center gap-1 px-0.75">
+      <div className="flex items-center justify-center gap-1">
         {t(($) => $['nodes.agent.notAuthorized'], { ns: 'workflow' })}
       </div>
       <div className="flex h-3.5 w-3.5 items-center justify-center">

--- a/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/presets-parameter.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/model-parameter-modal/presets-parameter.tsx
@@ -57,7 +57,7 @@ function PresetsParameter({ onSelect, supportedParameterNames }: PresetsParamete
         }
       >
         {t(($) => $['modelProvider.loadPresets'], { ns: 'common' })}
-        <span className="ml-0.5 i-ri-arrow-down-s-line size-3.5" />
+        <span className="i-ri-arrow-down-s-line size-3.5" />
       </DropdownMenuTrigger>
       <DropdownMenuContent>
         {visiblePresetTones.map((tone) => (

--- a/web/app/components/header/account-setting/model-provider-page/provider-added-card/model-auth-dropdown/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/provider-added-card/model-auth-dropdown/index.tsx
@@ -37,7 +37,7 @@ function ModelAuthDropdown({
             variant={buttonConfig.variant}
             title={buttonConfig.text}
           >
-            <span className="mr-1 i-ri-equalizer-2-line size-3.5 shrink-0" />
+            <span className="i-ri-equalizer-2-line size-3.5 shrink-0" />
             <span className="min-w-0 truncate">{buttonConfig.text}</span>
           </Button>
         }

--- a/web/app/components/header/account-setting/model-provider-page/system-model-selector/index.tsx
+++ b/web/app/components/header/account-setting/model-provider-page/system-model-selector/index.tsx
@@ -166,9 +166,9 @@ const SystemModel: FC<SystemModelSelectorProps> = ({
         onClick={() => setOpen(true)}
       >
         {isLoading ? (
-          <span className="mr-0.5 i-ri-loader-2-line size-3.5 animate-spin" />
+          <span className="i-ri-loader-2-line size-3.5 animate-spin" />
         ) : (
-          <span className="mr-0.5 i-ri-brain-2-line size-3.5" />
+          <span className="i-ri-brain-2-line size-3.5" />
         )}
         {t(($) => $['modelProvider.systemModelSettings'], { ns: 'common' })}
       </Button>

--- a/web/app/components/header/account-setting/update-setting-dialog.tsx
+++ b/web/app/components/header/account-setting/update-setting-dialog.tsx
@@ -244,13 +244,9 @@ const UpdateSettingDialog = ({ category, disabled = false }: Props) => {
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogTrigger
         render={
-          <Button
-            variant="secondary"
-            className="h-8 gap-0.5 px-3 system-sm-medium"
-            disabled={disabled}
-          >
+          <Button variant="secondary" className="h-8 system-sm-medium" disabled={disabled}>
             <span aria-hidden className="i-custom-vender-system-auto-update-line size-4" />
-            <span className="px-0.5">{t(($) => $['autoUpdate.autoUpdate'], { ns: 'plugin' })}</span>
+            <span>{t(($) => $['autoUpdate.autoUpdate'], { ns: 'plugin' })}</span>
             {selectedStrategyLabel && (
               <span className="flex min-w-4 items-center justify-center rounded-[5px] border border-divider-deep bg-components-badge-bg-dimm px-1 py-0.5 system-2xs-medium-uppercase text-text-tertiary">
                 {selectedStrategyLabel}

--- a/web/app/components/header/account-setting/workflow-log-archives-page/index.tsx
+++ b/web/app/components/header/account-setting/workflow-log-archives-page/index.tsx
@@ -399,7 +399,7 @@ function WorkflowArchiveMonthRow({ archive }: { archive: WorkflowRunArchiveMonth
                 variant="secondary"
                 loading={isPreparing}
                 disabled={isPreparing}
-                className="gap-1 px-2"
+                className="px-2"
                 aria-label={buttonAriaLabel}
                 onClick={onAction}
               >

--- a/web/app/components/plugins/install-plugin/install-bundle/steps/install.tsx
+++ b/web/app/components/plugins/install-plugin/install-bundle/steps/install.tsx
@@ -230,7 +230,7 @@ const Install: FC<Props> = ({
             )}
             <Button
               variant="primary"
-              className="flex min-w-18 space-x-0.5"
+              className="flex min-w-18"
               disabled={
                 !canInstall ||
                 isInstalling ||

--- a/web/app/components/plugins/install-plugin/install-from-github/steps/loaded.tsx
+++ b/web/app/components/plugins/install-plugin/install-from-github/steps/loaded.tsx
@@ -164,7 +164,7 @@ const Loaded: React.FC<LoadedProps> = ({
         )}
         <Button
           variant="primary"
-          className="flex min-w-18 space-x-0.5"
+          className="flex min-w-18"
           onClick={handleInstall}
           disabled={isInstalling || isLoading}
         >

--- a/web/app/components/plugins/install-plugin/install-from-local-package/steps/install.tsx
+++ b/web/app/components/plugins/install-plugin/install-from-local-package/steps/install.tsx
@@ -156,7 +156,7 @@ const Installed: FC<Props> = ({
         )}
         <Button
           variant="primary"
-          className="flex min-w-18 space-x-0.5"
+          className="flex min-w-18"
           disabled={isInstalling || isLoading}
           onClick={handleInstall}
         >

--- a/web/app/components/plugins/install-plugin/install-from-marketplace/steps/install.tsx
+++ b/web/app/components/plugins/install-plugin/install-from-marketplace/steps/install.tsx
@@ -180,7 +180,7 @@ const Installed: FC<Props> = ({
         )}
         <Button
           variant="primary"
-          className="flex min-w-18 space-x-0.5"
+          className="flex min-w-18"
           disabled={isInstalling || isLoading || !canInstall}
           onClick={handleInstall}
         >

--- a/web/app/components/plugins/marketplace/list/card-wrapper.tsx
+++ b/web/app/components/plugins/marketplace/list/card-wrapper.tsx
@@ -86,11 +86,11 @@ const CardWrapperComponent = ({
               : t(($) => $['detailPanel.operation.install'], { ns: 'plugin' })}
           </Button>
           <Button
-            className="min-w-0 flex-1 gap-0.5 shadow-xs backdrop-blur-[5px]"
+            className="min-w-0 flex-1 shadow-xs backdrop-blur-[5px]"
             onClick={handleOpenMarketplaceDetail}
           >
             {t(($) => $['detailPanel.operation.detail'], { ns: 'plugin' })}
-            <span aria-hidden className="ml-1 i-ri-arrow-right-up-line size-4" />
+            <span aria-hidden className="i-ri-arrow-right-up-line size-4" />
           </Button>
         </div>
         {isShowInstallFromMarketplace && (

--- a/web/app/components/plugins/marketplace/search-box/trigger/marketplace.tsx
+++ b/web/app/components/plugins/marketplace/search-box/trigger/marketplace.tsx
@@ -49,7 +49,7 @@ function MarketplaceTrigger({
               !selectedTagsLength && 'data-popup-open:bg-state-base-hover',
             )}
           >
-            <span className="p-0.5">
+            <span className="py-0.5">
               <span
                 aria-hidden
                 className={cn(
@@ -58,7 +58,7 @@ function MarketplaceTrigger({
                 )}
               />
             </span>
-            <span className="flex items-center gap-x-1 p-1 system-sm-medium">
+            <span className="flex items-center gap-x-1 py-1 system-sm-medium">
               {!selectedTagsLength && <span>{t(($) => $.allTags, { ns: 'pluginTags' })}</span>}
               {!!selectedTagsLength && (
                 <span className="text-text-secondary">
@@ -76,7 +76,7 @@ function MarketplaceTrigger({
               )}
             </span>
             {!selectedTagsLength && (
-              <span className="p-0.5">
+              <span className="py-0.5">
                 <span
                   aria-hidden
                   className="i-ri-arrow-down-s-line block size-4 text-text-tertiary"

--- a/web/app/components/plugins/marketplace/search-box/trigger/tool-selector.tsx
+++ b/web/app/components/plugins/marketplace/search-box/trigger/tool-selector.tsx
@@ -50,7 +50,7 @@ function ToolSelectorTrigger({
               !selectedTagsLength && 'data-popup-open:bg-state-base-hover',
             )}
           >
-            <span className={cn('shrink-0', !!selectedTagsLength && 'p-0.5')}>
+            <span className={cn('shrink-0', !!selectedTagsLength && 'py-0.5 pl-0.5')}>
               <span
                 aria-hidden
                 className={cn(
@@ -60,7 +60,7 @@ function ToolSelectorTrigger({
               />
             </span>
             {!!selectedTagsLength && (
-              <span className="flex min-w-0 items-center gap-x-0.5 px-0.5 py-1 system-sm-medium">
+              <span className="flex min-w-0 items-center gap-x-0.5 py-1 system-sm-medium">
                 <span className="truncate text-text-secondary">
                   {tags
                     .map((tag) => tagsMap[tag]?.label)

--- a/web/app/components/plugins/plugin-auth/authorize/add-oauth-button.tsx
+++ b/web/app/components/plugins/plugin-auth/authorize/add-oauth-button.tsx
@@ -202,7 +202,7 @@ const AddOAuthButton = ({
             {is_oauth_custom_client_enabled && (
               <Badge
                 className={cn(
-                  'mr-0.5 ml-1',
+                  'mr-0.5',
                   buttonVariant === 'primary' &&
                     'border-text-primary-on-surface bg-components-badge-bg-dimm text-text-primary-on-surface',
                 )}
@@ -240,7 +240,7 @@ const AddOAuthButton = ({
           disabled={disabled}
           className="w-full"
         >
-          <span className="mr-0.5 i-ri-equalizer-2-line size-4" />
+          <span className="i-ri-equalizer-2-line size-4" />
           {t(($) => $['auth.setupOAuth'], { ns: 'plugin' })}
         </Button>
       )}

--- a/web/app/components/plugins/plugin-auth/authorized-in-data-source-node.tsx
+++ b/web/app/components/plugins/plugin-auth/authorized-in-data-source-node.tsx
@@ -17,7 +17,7 @@ const AuthorizedInDataSourceNode = ({
 
   return (
     <Button size="small" onClick={onJumpToDataSourcePage}>
-      <StatusDot className="mr-1.5" status="success" />
+      <StatusDot status="success" />
       {authorizationsNum > 1
         ? t(($) => $['auth.authorizations'], { ns: 'plugin' })
         : t(($) => $['auth.authorization'], { ns: 'plugin' })}

--- a/web/app/components/plugins/plugin-auth/authorized-in-node.tsx
+++ b/web/app/components/plugins/plugin-auth/authorized-in-node.tsx
@@ -76,7 +76,7 @@ const AuthorizedInNode = ({
           )}
           variant={defaultUnavailable || unavailable ? 'ghost' : 'secondary'}
         >
-          <StatusDot className="mr-1.5" status={color} />
+          <StatusDot status={color} />
           {label}
           {(unavailable || defaultUnavailable) && (
             <>

--- a/web/app/components/plugins/plugin-auth/authorized/index.tsx
+++ b/web/app/components/plugins/plugin-auth/authorized/index.tsx
@@ -218,10 +218,7 @@ const Authorized = ({
                 <Button
                   className={cn('w-full', state.open && 'bg-components-button-secondary-bg-hover')}
                 >
-                  <StatusDot
-                    className="mr-2"
-                    status={unavailableCredential ? 'disabled' : 'success'}
-                  />
+                  <StatusDot status={unavailableCredential ? 'disabled' : 'success'} />
                   {credentials.length}
                   &nbsp;
                   {credentials.length > 1
@@ -229,7 +226,7 @@ const Authorized = ({
                     : t(($) => $['auth.authorization'], { ns: 'plugin' })}
                   {!!unavailableCredentials.length &&
                     ` (${unavailableCredentials.length} ${t(($) => $['auth.unavailable'], { ns: 'plugin' })})`}
-                  <span className="ml-0.5 i-ri-arrow-down-s-line size-4" />
+                  <span className="i-ri-arrow-down-s-line size-4" />
                 </Button>
               )}
             </div>

--- a/web/app/components/plugins/plugin-auth/plugin-auth-in-agent.tsx
+++ b/web/app/components/plugins/plugin-auth/plugin-auth-in-agent.tsx
@@ -73,10 +73,10 @@ const PluginAuthInAgent = ({
             removed && 'text-text-destructive',
           )}
         >
-          <StatusDot className="mr-2" status={color} />
+          <StatusDot status={color} />
           {label}
           {unavailable && t(($) => $['auth.unavailable'], { ns: 'plugin' })}
-          <RiArrowDownSLine className="ml-0.5 size-4" />
+          <RiArrowDownSLine className="size-4" />
         </Button>
       )
     },

--- a/web/app/components/plugins/plugin-auth/plugin-auth-in-datasource-node.tsx
+++ b/web/app/components/plugins/plugin-auth/plugin-auth-in-datasource-node.tsx
@@ -20,7 +20,7 @@ const PluginAuthInDataSourceNode = ({
       {!isAuthorized && (
         <div className="px-4 pb-2">
           <Button className="w-full" variant="primary" onClick={onJumpToDataSourcePage}>
-            <RiAddLine className="mr-1 size-4" />
+            <RiAddLine className="size-4" />
             {t(($) => $['integrations.connect'], { ns: 'common' })}
           </Button>
         </div>

--- a/web/app/components/plugins/plugin-detail-panel/subscription-list/create/oauth-client.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/subscription-list/create/oauth-client.tsx
@@ -111,7 +111,7 @@ export const OAuthClientSettingsModal = ({
                     {oauthConfig?.redirect_uri}
                   </div>
                   <Button variant="secondary" size="small" onClick={handleCopyRedirectUri}>
-                    <span aria-hidden="true" className="mr-1 i-ri-clipboard-line h-3.5 w-3.5" />
+                    <span aria-hidden="true" className="i-ri-clipboard-line h-3.5 w-3.5" />
                     {t(($) => $['operation.copy'], { ns: 'common' })}
                   </Button>
                 </div>

--- a/web/app/components/plugins/plugin-detail-panel/tool-selector/components/tool-item.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/tool-selector/components/tool-item.tsx
@@ -177,7 +177,7 @@ export function ToolItem({
           render={
             <Button className="relative z-10" variant="secondary" size="small">
               {t(($) => $.notAuthorized, { ns: 'tools' })}
-              <StatusDot className="ml-2" status="warning" />
+              <StatusDot status="warning" />
             </Button>
           }
         />
@@ -187,7 +187,7 @@ export function ToolItem({
           render={
             <Button className="relative z-10" variant="secondary" size="small">
               {t(($) => $['auth.authRemoved'], { ns: 'plugin' })}
-              <StatusDot className="ml-2" status="error" />
+              <StatusDot status="error" />
             </Button>
           }
         />

--- a/web/app/components/plugins/plugin-detail-panel/tool-selector/components/tool-trigger.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/tool-selector/components/tool-trigger.tsx
@@ -42,7 +42,7 @@ export function ToolTrigger({
       )}
     >
       {value?.provider_name && provider && (
-        <div className="mr-1 shrink-0 rounded-lg border border-components-panel-border bg-components-panel-bg p-px">
+        <div className="shrink-0 rounded-lg border border-components-panel-border bg-components-panel-bg p-px">
           <BlockIcon className="size-4!" type={BlockEnum.Tool} toolIcon={provider.icon} />
         </div>
       )}
@@ -62,7 +62,7 @@ export function ToolTrigger({
         <span
           aria-hidden
           className={cn(
-            'ml-0.5 i-ri-equalizer-2-line size-4 shrink-0 text-text-quaternary group-hover:text-text-secondary',
+            'i-ri-equalizer-2-line size-4 shrink-0 text-text-quaternary group-hover:text-text-secondary',
             open && 'text-text-secondary',
           )}
         />
@@ -71,7 +71,7 @@ export function ToolTrigger({
         <span
           aria-hidden
           className={cn(
-            'ml-0.5 i-ri-arrow-down-s-line size-4 shrink-0 text-text-quaternary group-hover:text-text-secondary',
+            'i-ri-arrow-down-s-line size-4 shrink-0 text-text-quaternary group-hover:text-text-secondary',
             open && 'text-text-secondary',
           )}
         />

--- a/web/app/components/plugins/plugin-page/__tests__/install-plugin-dropdown.spec.tsx
+++ b/web/app/components/plugins/plugin-page/__tests__/install-plugin-dropdown.spec.tsx
@@ -84,18 +84,6 @@ describe('InstallPluginDropdown', () => {
     expect(screen.getByText('plugin.source.marketplace')).toBeInTheDocument()
     expect(screen.getByText('plugin.source.github')).toBeInTheDocument()
     expect(screen.getByText('plugin.source.local')).toBeInTheDocument()
-    expect(document.querySelector('.i-custom-vender-plugin-box-sparkle-fill')).toHaveClass(
-      'size-4',
-      'shrink-0',
-    )
-    expect(document.querySelector('.i-custom-vender-solid-general-github')).toHaveClass(
-      'size-4',
-      'shrink-0',
-    )
-    expect(document.querySelector('.i-custom-vender-solid-files-file-zip')).toHaveClass(
-      'size-4',
-      'shrink-0',
-    )
   })
 
   it('applies custom trigger label and presentation props', () => {
@@ -115,8 +103,8 @@ describe('InstallPluginDropdown', () => {
 
     expect(container.querySelector('.custom-root')).toBeInTheDocument()
     expect(trigger).toHaveTextContent('Install')
-    expect(screen.getByTestId('add-circle-fill-icon')).toHaveClass('size-4', 'shrink-0')
-    expect(screen.getByTestId('arrow-down-icon')).toHaveClass('ml-1', 'size-4')
+    expect(screen.getByTestId('add-circle-fill-icon')).toBeInTheDocument()
+    expect(screen.getByTestId('arrow-down-icon')).toBeInTheDocument()
     expect(trigger).toHaveClass('custom-trigger')
     expect(trigger).not.toHaveAttribute('data-popup-open')
 
@@ -128,7 +116,7 @@ describe('InstallPluginDropdown', () => {
   })
 
   it('can hide the trigger arrow for compact integrations placement', () => {
-    const { container } = render(
+    render(
       <InstallPluginDropdown
         onSwitchToMarketplaceTab={vi.fn()}
         triggerLabel="Install"
@@ -139,9 +127,8 @@ describe('InstallPluginDropdown', () => {
     const trigger = getTrigger('Install')
 
     expect(trigger).toHaveTextContent('Install')
-    expect(screen.getByTestId('add-circle-fill-icon')).toHaveClass('size-4', 'shrink-0')
+    expect(screen.getByTestId('add-circle-fill-icon')).toBeInTheDocument()
     expect(screen.queryByTestId('arrow-down-icon')).not.toBeInTheDocument()
-    expect(container.querySelector('.px-0\\.5')).toHaveClass('min-w-0', 'flex-1', 'text-left')
   })
 
   it('keeps the trigger visible but disabled when install is unavailable', () => {

--- a/web/app/components/plugins/plugin-page/empty/index.tsx
+++ b/web/app/components/plugins/plugin-page/empty/index.tsx
@@ -271,7 +271,7 @@ const Empty = ({
                       key={action}
                       variant="secondary"
                       title={text}
-                      className="h-8 w-full justify-start gap-x-0.5 px-3 py-2 system-sm-medium"
+                      className="h-8 w-full justify-start py-2 system-sm-medium"
                       onClick={() => {
                         if (action === 'local') fileInputRef.current?.click()
                         else if (action === 'marketplace')
@@ -284,7 +284,7 @@ const Empty = ({
                       ) : (
                         <Icon className="size-4 text-components-button-secondary-text" />
                       )}
-                      <span className="min-w-0 flex-1 truncate px-0.5 text-left">{text}</span>
+                      <span className="min-w-0 flex-1 truncate text-left">{text}</span>
                     </Button>
                   ),
                 )}

--- a/web/app/components/plugins/plugin-page/index.tsx
+++ b/web/app/components/plugins/plugin-page/index.tsx
@@ -207,7 +207,7 @@ const PluginPage = ({ plugins, marketplace }: PluginPageProps) => {
                   target="_blank"
                 >
                   <Button className="px-3" variant="secondary-accent">
-                    <RiBookOpenLine className="mr-1 size-4" />
+                    <RiBookOpenLine className="size-4" />
                     {t(($) => $.publishPlugins, { ns: 'plugin' })}
                   </Button>
                 </Link>

--- a/web/app/components/plugins/plugin-page/install-plugin-dropdown.tsx
+++ b/web/app/components/plugins/plugin-page/install-plugin-dropdown.tsx
@@ -175,10 +175,10 @@ const InstallPluginDropdown = ({
               )}
             >
               <RiAddCircleFill className="size-4 shrink-0" />
-              <span className={cn(showTriggerArrow ? 'pl-1' : 'min-w-0 flex-1 px-0.5 text-left')}>
+              <span className={cn(!showTriggerArrow && 'min-w-0 flex-1 text-left')}>
                 {buttonLabel}
               </span>
-              {showTriggerArrow && <RiArrowDownSLine className="ml-1 size-4" />}
+              {showTriggerArrow && <RiArrowDownSLine className="size-4" />}
             </Button>
           )}
         />

--- a/web/app/components/plugins/plugin-page/plugin-tasks/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/plugin-page/plugin-tasks/__tests__/index.spec.tsx
@@ -388,22 +388,12 @@ describe('TaskStatusIndicator Component', () => {
           totalPluginsLength={3}
         />,
       )
-      const trigger = document.getElementById('plugin-task-trigger')
-      expect(trigger)!.toHaveClass(
-        'border-components-panel-border-subtle',
-        'bg-components-panel-bg',
-      )
-      expect(screen.getByTestId('task-status-success-badge')).toHaveClass('text-text-success')
+      expect(screen.getByTestId('task-status-success-badge')).toBeInTheDocument()
     })
 
     it('should show error icon when failed', () => {
       render(<TaskStatusIndicator {...defaultProps} isFailed />)
-      const trigger = document.getElementById('plugin-task-trigger')
-      expect(trigger)!.toHaveClass(
-        'border-components-button-destructive-secondary-border-hover',
-        'bg-state-destructive-hover',
-      )
-      expect(screen.getByTestId('task-status-error-badge')).toHaveClass('text-text-destructive')
+      expect(screen.getByTestId('task-status-error-badge')).toBeInTheDocument()
     })
   })
 

--- a/web/app/components/plugins/plugin-page/plugin-tasks/components/task-status-indicator.tsx
+++ b/web/app/components/plugins/plugin-page/plugin-tasks/components/task-status-indicator.tsx
@@ -89,14 +89,14 @@ function TaskStatusIndicator({
             disabled={disabled}
             aria-label={tip}
             className={cn(
-              'relative size-8 overflow-visible rounded-lg border-[0.5px] border-components-panel-border-subtle bg-components-panel-bg p-2 shadow-none',
+              'relative size-8 overflow-visible rounded-lg bg-components-panel-bg p-2 shadow-none inset-ring-components-panel-border-subtle',
               'focus-visible:ring-2 focus-visible:ring-state-accent-solid',
               isClickable ? 'cursor-pointer' : 'cursor-default',
               showErrorStyle &&
-                'cursor-pointer border-components-button-destructive-secondary-border-hover bg-state-destructive-hover text-components-button-destructive-secondary-text shadow-xs shadow-shadow-shadow-3 backdrop-blur-[5px] hover:bg-state-destructive-hover-alt',
+                'cursor-pointer bg-state-destructive-hover text-components-button-destructive-secondary-text shadow-xs shadow-shadow-shadow-3 inset-ring-components-button-destructive-secondary-border-hover backdrop-blur-[5px] hover:bg-state-destructive-hover-alt',
               isOpen &&
                 !showErrorStyle &&
-                'border-components-button-secondary-border-hover bg-components-button-secondary-bg-hover shadow-xs shadow-shadow-shadow-3 backdrop-blur-[5px]',
+                'bg-components-button-secondary-bg-hover shadow-xs shadow-shadow-shadow-3 inset-ring-components-button-secondary-border-hover backdrop-blur-[5px]',
               isOpen && showErrorStyle && 'bg-state-destructive-hover-alt',
             )}
             id="plugin-task-trigger"

--- a/web/app/components/plugins/plugin-page/plugin-tasks/components/task-status-indicator.tsx
+++ b/web/app/components/plugins/plugin-page/plugin-tasks/components/task-status-indicator.tsx
@@ -89,7 +89,7 @@ function TaskStatusIndicator({
             disabled={disabled}
             aria-label={tip}
             className={cn(
-              'relative size-8 rounded-lg border-[0.5px] border-components-panel-border-subtle bg-components-panel-bg p-2 shadow-none',
+              'relative size-8 overflow-visible rounded-lg border-[0.5px] border-components-panel-border-subtle bg-components-panel-bg p-2 shadow-none',
               'focus-visible:ring-2 focus-visible:ring-state-accent-solid',
               isClickable ? 'cursor-pointer' : 'cursor-default',
               showErrorStyle &&

--- a/web/app/components/plugins/reference-setting-modal/auto-update-setting/plugins-picker.tsx
+++ b/web/app/components/plugins/reference-setting-modal/auto-update-setting/plugins-picker.tsx
@@ -91,7 +91,7 @@ const PluginsPicker: FC<Props> = ({ updateMode, value, onChange, integrationCate
 
       <ToolPicker
         trigger={
-          <Button className="h-6 w-full gap-1" size="small" variant="secondary-accent">
+          <Button className="h-6 w-full" size="small" variant="secondary-accent">
             <RiAddLine className="size-3.5" />
             {t(($) => $[`${i18nPrefix}.operation.select`], { ns: 'plugin' })}
           </Button>

--- a/web/app/components/rag-pipeline/components/panel/input-field/index.tsx
+++ b/web/app/components/rag-pipeline/components/panel/input-field/index.tsx
@@ -107,17 +107,12 @@ const InputFieldPanel = () => {
         <Button
           variant="ghost"
           size="small"
-          className={cn(
-            'shrink-0 gap-x-px px-1.5',
-            isPreviewing && 'bg-state-accent-active text-text-accent',
-          )}
+          className={cn('shrink-0', isPreviewing && 'bg-state-accent-active text-text-accent')}
           onClick={togglePreviewPanel}
           disabled={isEditing}
         >
           <RiEyeLine className="size-3.5" />
-          <span className="px-0.75">
-            {t(($) => $['operations.preview'], { ns: 'datasetPipeline' })}
-          </span>
+          <span>{t(($) => $['operations.preview'], { ns: 'datasetPipeline' })}</span>
         </Button>
         <Divider type="vertical" className="mx-1 h-3" />
         <button

--- a/web/app/components/rag-pipeline/components/panel/test-run/preparation/actions/index.tsx
+++ b/web/app/components/rag-pipeline/components/panel/test-run/preparation/actions/index.tsx
@@ -13,7 +13,7 @@ const Actions = ({ disabled, handleNextStep }: ActionsProps) => {
   return (
     <div className="flex justify-end p-4 pt-2">
       <Button disabled={disabled} variant="primary" onClick={handleNextStep}>
-        <span className="px-0.5">{t(($) => $['stepOne.button'], { ns: 'datasetCreation' })}</span>
+        <span>{t(($) => $['stepOne.button'], { ns: 'datasetCreation' })}</span>
       </Button>
     </div>
   )

--- a/web/app/components/rag-pipeline/components/rag-pipeline-header/input-field-button.tsx
+++ b/web/app/components/rag-pipeline/components/rag-pipeline-header/input-field-button.tsx
@@ -14,9 +14,9 @@ const InputFieldButton = () => {
   }, [setShowInputFieldPanel, setShowEnvPanel])
 
   return (
-    <Button variant="secondary" className="flex gap-x-0.5" onClick={handleClick}>
+    <Button variant="secondary" className="flex" onClick={handleClick}>
       <InputField className="size-4" />
-      <span className="px-0.5">{t(($) => $.inputField, { ns: 'datasetPipeline' })}</span>
+      <span>{t(($) => $.inputField, { ns: 'datasetPipeline' })}</span>
     </Button>
   )
 }

--- a/web/app/components/rag-pipeline/components/rag-pipeline-header/publisher/index.tsx
+++ b/web/app/components/rag-pipeline/components/rag-pipeline-header/publisher/index.tsx
@@ -104,7 +104,7 @@ const Publisher = () => {
           nativeButton
           render={
             <Button className="px-2" variant="primary" disabled={!canPipelineRelease}>
-              <span className="pl-1">{t(($) => $['common.publish'], { ns: 'workflow' })}</span>
+              <span>{t(($) => $['common.publish'], { ns: 'workflow' })}</span>
               <RiArrowDownSLine className="size-4" />
             </Button>
           }

--- a/web/app/components/rag-pipeline/components/rag-pipeline-header/publisher/popup.tsx
+++ b/web/app/components/rag-pipeline/components/rag-pipeline-header/publisher/popup.tsx
@@ -270,7 +270,7 @@ export function Popup({
             <RiPlayCircleLine className="mr-2 size-4" />
             {t(($) => $['common.goToAddDocuments'], { ns: 'pipeline' })}
           </div>
-          <RiArrowRightUpLine className="ml-2 size-4 shrink-0" />
+          <RiArrowRightUpLine className="size-4 shrink-0" />
         </Button>
         <Link href={apiReferenceUrl} target="_blank" rel="noopener noreferrer">
           <Button
@@ -282,7 +282,7 @@ export function Popup({
               <RiTerminalBoxLine className="mr-2 size-4" />
               {t(($) => $['common.accessAPIReference'], { ns: 'workflow' })}
             </div>
-            <RiArrowRightUpLine className="ml-2 size-4 shrink-0" />
+            <RiArrowRightUpLine className="size-4 shrink-0" />
           </Button>
         </Link>
         <Divider className="my-2" />

--- a/web/app/components/rag-pipeline/components/update-dsl-modal.tsx
+++ b/web/app/components/rag-pipeline/components/update-dsl-modal.tsx
@@ -63,7 +63,7 @@ const UpdateDSLModal = ({ onCancel, onBackup, onImport }: UpdateDSLModalProps) =
               <div className="flex items-start gap-1 self-stretch pt-1 pb-0.5">
                 <Button size="small" variant="secondary" className="relative" onClick={onBackup}>
                   <RiFileDownloadLine className="size-3.5 text-components-button-secondary-text" />
-                  <div className="flex items-center justify-center gap-1 px-0.75">
+                  <div className="flex items-center justify-center gap-1">
                     {t(($) => $['common.backupCurrentDraft'], { ns: 'workflow' })}
                   </div>
                 </Button>

--- a/web/app/components/share/text-generation/result/index.tsx
+++ b/web/app/components/share/text-generation/result/index.tsx
@@ -119,9 +119,9 @@ const Result: FC<IResultProps> = ({
         <div className={`mb-3 flex ${isPC ? 'justify-end' : 'justify-center'}`}>
           <Button variant="secondary" disabled={runState.isStopping} onClick={runState.handleStop}>
             {runState.isStopping ? (
-              <span aria-hidden className="mr-1.25 i-ri-loader-2-line h-3.5 w-3.5 animate-spin" />
+              <span aria-hidden className="i-ri-loader-2-line h-3.5 w-3.5 animate-spin" />
             ) : (
-              <span aria-hidden className="mr-1.25 i-ri-stop-circle-fill h-3.5 w-3.5" />
+              <span aria-hidden className="i-ri-stop-circle-fill h-3.5 w-3.5" />
             )}
             <span className="text-xs font-normal">
               {t(($) => $['operation.stopResponding'], { ns: 'appDebug' })}

--- a/web/app/components/share/text-generation/run-batch/index.tsx
+++ b/web/app/components/share/text-generation/run-batch/index.tsx
@@ -44,7 +44,7 @@ const RunBatch: FC<IRunBatchProps> = ({ vars, onSend, isAllFinished }) => {
           disabled={!isParsed || !isAllFinished}
         >
           <Icon
-            className={cn(!isAllFinished && 'animate-spin', 'mr-1 size-4 shrink-0')}
+            className={cn(!isAllFinished && 'animate-spin', 'size-4 shrink-0')}
             aria-hidden="true"
           />
           <span className="text-[13px] uppercase">

--- a/web/app/components/share/text-generation/run-batch/res-download/index.tsx
+++ b/web/app/components/share/text-generation/run-batch/res-download/index.tsx
@@ -1,7 +1,6 @@
 'use client'
 import type { FC } from 'react'
 import { Button } from '@langgenius/dify-ui/button'
-import { cn } from '@langgenius/dify-ui/cn'
 import { RiDownloadLine } from '@remixicon/react'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
@@ -34,7 +33,7 @@ const ResDownload: FC<IResDownloadProps> = ({ isMobile, values }) => {
         </ActionButton>
       )}
       {!isMobile && (
-        <Button className={cn('space-x-1')}>
+        <Button>
           <RiDownloadLine className="size-4" />
           <span>{t(($) => $['operation.download'], { ns: 'common' })}</span>
         </Button>

--- a/web/app/components/share/text-generation/run-once/index.tsx
+++ b/web/app/components/share/text-generation/run-once/index.tsx
@@ -311,18 +311,15 @@ const RunOnce: FC<IRunOnceProps> = ({
                 {isRunning ? (
                   <>
                     {runControl?.isStopping ? (
-                      <RiLoader2Line
-                        className="mr-1 size-4 shrink-0 animate-spin"
-                        aria-hidden="true"
-                      />
+                      <RiLoader2Line className="size-4 shrink-0 animate-spin" aria-hidden="true" />
                     ) : (
-                      <StopCircle className="mr-1 size-4 shrink-0" aria-hidden="true" />
+                      <StopCircle className="size-4 shrink-0" aria-hidden="true" />
                     )}
                     <span className="text-[13px]">{stopLabel}</span>
                   </>
                 ) : (
                   <>
-                    <RiPlayLargeLine className="mr-1 size-4 shrink-0" aria-hidden="true" />
+                    <RiPlayLargeLine className="size-4 shrink-0" aria-hidden="true" />
                     <span className="text-[13px]">
                       {t(($) => $['generation.run'], { ns: 'share' })}
                     </span>

--- a/web/app/components/snippet-list/components/snippet-create-button.tsx
+++ b/web/app/components/snippet-list/components/snippet-create-button.tsx
@@ -29,9 +29,9 @@ const SnippetCreateButton = () => {
         <PopoverTrigger
           render={
             <Button disabled={isSubmitting}>
-              <span aria-hidden className="mr-0.5 i-ri-add-line size-4" />
+              <span aria-hidden className="i-ri-add-line size-4" />
               <span>{t(($) => $.create)}</span>
-              <span aria-hidden className="ml-0.5 i-ri-arrow-down-s-line size-4" />
+              <span aria-hidden className="i-ri-arrow-down-s-line size-4" />
             </Button>
           }
         />

--- a/web/app/components/snippets/components/snippet-run-panel.tsx
+++ b/web/app/components/snippets/components/snippet-run-panel.tsx
@@ -232,7 +232,7 @@ const SnippetRunPanel = ({ fields }: SnippetRunPanelProps) => {
                 workflowRunningData?.resultText &&
                 typeof workflowRunningData.resultText === 'string' && (
                   <Button
-                    className="mb-4 ml-4 space-x-1"
+                    className="mb-4 ml-4"
                     onClick={() => {
                       copy(workflowRunningData?.resultText || '')
                       toast.success(t(($) => $['actionMsg.copySuccessfully'], { ns: 'common' }))

--- a/web/app/components/tools/edit-custom-collection-modal/get-schema.tsx
+++ b/web/app/components/tools/edit-custom-collection-modal/get-schema.tsx
@@ -45,7 +45,7 @@ const GetSchema: FC<Props> = ({ onChange }) => {
   return (
     <div className="flex w-56 justify-end gap-1">
       <DropdownMenu open={showImportFromUrl} onOpenChange={setShowImportFromUrl}>
-        <DropdownMenuTrigger render={<Button size="small" className="gap-1" />}>
+        <DropdownMenuTrigger render={<Button size="small" />}>
           <span className="i-ri-add-line size-3" aria-hidden />
           <span className="system-xs-medium text-text-secondary">
             {t(($) => $['createTool.importFromUrl'], { ns: 'tools' })}
@@ -74,7 +74,7 @@ const GetSchema: FC<Props> = ({ onChange }) => {
         </DropdownMenuContent>
       </DropdownMenu>
       <DropdownMenu open={showExamples} onOpenChange={setShowExamples}>
-        <DropdownMenuTrigger render={<Button size="small" className="gap-1" />}>
+        <DropdownMenuTrigger render={<Button size="small" />}>
           <span className="system-xs-medium text-text-secondary">
             {t(($) => $['createTool.examples'], { ns: 'tools' })}
           </span>

--- a/web/app/components/tools/mcp/create-card.tsx
+++ b/web/app/components/tools/mcp/create-card.tsx
@@ -45,7 +45,7 @@ export function NewMCPButton({ handleCreate }: Props) {
     <>
       <Button
         variant="secondary"
-        className="gap-0.5 px-3!"
+        className="px-3!"
         data-step-by-step-tour-target={STEP_BY_STEP_TOUR_TARGETS.integrationMcpAdd}
         onClick={() => setShowModal(true)}
         title={addMCPServerLabel}

--- a/web/app/components/tools/mcp/detail/content.tsx
+++ b/web/app/components/tools/mcp/detail/content.tsx
@@ -199,7 +199,7 @@ const MCPDetailContent: FC<Props> = ({
               onClick={handleAuthorize}
               disabled={!canManageMCP}
             >
-              <StatusDot className="mr-2" status="success" />
+              <StatusDot status="success" />
               {t(($) => $['auth.authorized'], { ns: 'tools' })}
             </Button>
           )}
@@ -215,7 +215,7 @@ const MCPDetailContent: FC<Props> = ({
           )}
           {isAuthorizing && (
             <Button variant="primary" className="w-full" disabled>
-              <span aria-hidden className="mr-1 i-ri-loader-2-line size-4 animate-spin" />
+              <span aria-hidden className="i-ri-loader-2-line size-4 animate-spin" />
               {t(($) => $['mcp.authorizing'], { ns: 'tools' })}
             </Button>
           )}
@@ -271,7 +271,7 @@ const MCPDetailContent: FC<Props> = ({
               </div>
               <div>
                 <Button size="small" onClick={showUpdateConfirm} disabled={!canManageMCP}>
-                  <span aria-hidden className="mr-1 i-ri-loop-left-line size-3.5" />
+                  <span aria-hidden className="i-ri-loop-left-line size-3.5" />
                   {t(($) => $['mcp.update'], { ns: 'tools' })}
                 </Button>
               </div>

--- a/web/app/components/tools/mcp/headers-input.tsx
+++ b/web/app/components/tools/mcp/headers-input.tsx
@@ -51,7 +51,7 @@ const HeadersInput = ({ headersItems, onChange, readonly = false, isMasked = fal
         </div>
         {!readonly && (
           <Button variant="secondary" size="small" onClick={handleAddItem} className="w-full">
-            <RiAddLine className="mr-1 size-4" />
+            <RiAddLine className="size-4" />
             {t(($) => $['mcp.modal.addHeader'], { ns: 'tools' })}
           </Button>
         )}
@@ -111,7 +111,7 @@ const HeadersInput = ({ headersItems, onChange, readonly = false, isMasked = fal
       </div>
       {!readonly && (
         <Button variant="secondary" size="small" onClick={handleAddItem} className="w-full">
-          <RiAddLine className="mr-1 size-4" />
+          <RiAddLine className="size-4" />
           {t(($) => $['mcp.modal.addHeader'], { ns: 'tools' })}
         </Button>
       )}

--- a/web/app/components/tools/provider/custom-create-card.tsx
+++ b/web/app/components/tools/provider/custom-create-card.tsx
@@ -53,7 +53,7 @@ export const NewCustomToolButton = ({ onRefreshData }: Props) => {
     <>
       <Button
         variant="secondary"
-        className="gap-0.5 px-3!"
+        className="px-3!"
         onClick={() => setIsShowEditCustomCollectionModal(true)}
         title={addSwaggerAPIAsToolLabel}
         aria-label={addSwaggerAPIAsToolLabel}

--- a/web/app/components/tools/provider/detail.tsx
+++ b/web/app/components/tools/provider/detail.tsx
@@ -318,7 +318,7 @@ const ProviderDetail = ({ collection, onHide, onRefreshData }: Props) => {
                     >
                       <span
                         aria-hidden
-                        className="mr-1 i-ri-equalizer-2-line size-4 text-components-button-secondary-text"
+                        className="i-ri-equalizer-2-line size-4 text-components-button-secondary-text"
                       />
                       <div className="system-sm-medium text-text-secondary">
                         {t(($) => $['createTool.editAction'], { ns: 'tools' })}
@@ -332,7 +332,7 @@ const ProviderDetail = ({ collection, onHide, onRefreshData }: Props) => {
                         <Button
                           nativeButton={false}
                           variant="primary"
-                          className={cn('my-3 h-8 min-w-0 flex-1 rounded-lg px-3 py-2')}
+                          className={cn('my-3 h-8 min-w-0 flex-1 rounded-lg py-2')}
                           render={
                             <a
                               href={`${basePath}/app/${(customCollection as WorkflowToolProviderResponse).workflow_app_id}/workflow`}
@@ -342,14 +342,14 @@ const ProviderDetail = ({ collection, onHide, onRefreshData }: Props) => {
                             />
                           }
                         >
-                          <span className="min-w-0 truncate px-0.5 system-sm-medium">
+                          <span className="min-w-0 truncate system-sm-medium">
                             {t(($) => $.openInStudio, { ns: 'tools' })}
                           </span>
                           <span aria-hidden className="i-ri-arrow-right-up-line size-4 shrink-0" />
                         </Button>
                         <Button
                           variant="secondary"
-                          className={cn('my-3 h-8 min-w-0 flex-1 rounded-lg px-3 py-2')}
+                          className={cn('my-3 h-8 min-w-0 flex-1 rounded-lg py-2')}
                           onClick={() => setWorkflowToolDrawerOpen(true)}
                           disabled={!canManageTools}
                         >
@@ -357,7 +357,7 @@ const ProviderDetail = ({ collection, onHide, onRefreshData }: Props) => {
                             aria-hidden
                             className="i-ri-equalizer-2-line size-4 shrink-0 text-components-button-secondary-text"
                           />
-                          <span className="min-w-0 truncate px-0.5 system-sm-medium text-components-button-secondary-text">
+                          <span className="min-w-0 truncate system-sm-medium text-components-button-secondary-text">
                             {t(($) => $['createTool.editAction'], { ns: 'tools' })}
                           </span>
                         </Button>
@@ -395,7 +395,7 @@ const ProviderDetail = ({ collection, onHide, onRefreshData }: Props) => {
                                   }}
                                   disabled={!canOpenCredentialSettings}
                                 >
-                                  <StatusDot className="mr-2" status="success" />
+                                  <StatusDot status="success" />
                                   {t(($) => $['auth.authorized'], { ns: 'tools' })}
                                 </Button>
                               )}

--- a/web/app/components/tools/workflow-tool/configure-button.tsx
+++ b/web/app/components/tools/workflow-tool/configure-button.tsx
@@ -76,7 +76,7 @@ const WorkflowToolConfigureButton = ({
               <div className="flex justify-between gap-x-2">
                 <Button size="small" className="w-35" onClick={onConfigure} disabled={disabled}>
                   {t(($) => $['common.configure'], { ns: 'workflow' })}
-                  {outdated && <StatusDot className="ml-1" status="warning" />}
+                  {outdated && <StatusDot status="warning" />}
                 </Button>
                 <Button
                   size="small"
@@ -85,7 +85,7 @@ const WorkflowToolConfigureButton = ({
                   disabled={disabled}
                 >
                   {t(($) => $['common.manageInTools'], { ns: 'workflow' })}
-                  <span className="ml-1 i-ri-arrow-right-up-line size-4" />
+                  <span className="i-ri-arrow-right-up-line size-4" />
                 </Button>
               </div>
               {outdated && (

--- a/web/app/components/workflow-app/components/workflow-header/features-trigger.tsx
+++ b/web/app/components/workflow-app/components/workflow-header/features-trigger.tsx
@@ -240,8 +240,8 @@ const FeaturesTrigger = () => {
       {isChatMode && (
         <Button
           className={cn(
-            'rounded-lg border border-transparent text-components-button-secondary-text',
-            theme === 'dark' && 'border-black/5 bg-white/10 backdrop-blur-xs',
+            'rounded-lg text-components-button-secondary-text inset-ring-1 inset-ring-transparent',
+            theme === 'dark' && 'bg-white/10 inset-ring-black/5 backdrop-blur-xs',
           )}
           onClick={handleShowFeatures}
         >

--- a/web/app/components/workflow-app/components/workflow-header/features-trigger.tsx
+++ b/web/app/components/workflow-app/components/workflow-header/features-trigger.tsx
@@ -245,7 +245,7 @@ const FeaturesTrigger = () => {
           )}
           onClick={handleShowFeatures}
         >
-          <span className="mr-1 i-ri-apps-2-add-line size-4 text-components-button-secondary-text" />
+          <span className="i-ri-apps-2-add-line size-4 text-components-button-secondary-text" />
           {t(($) => $['common.features'], { ns: 'workflow' })}
         </Button>
       )}

--- a/web/app/components/workflow/block-selector/featured-tools.tsx
+++ b/web/app/components/workflow/block-selector/featured-tools.tsx
@@ -193,7 +193,7 @@ const FeaturedTools = ({
           <Button
             variant="ghost"
             size="medium"
-            className="group mt-1 w-full justify-start gap-x-2 pr-2 pl-3 text-left text-text-tertiary hover:text-text-secondary focus-visible:ring-inset"
+            className="group mt-1 w-full justify-start pr-2 pl-3 text-left text-text-tertiary hover:text-text-secondary focus-visible:ring-inset"
             onClick={() => {
               setVisibleCount((count) => {
                 if (count >= maxAvailable) return INITIAL_VISIBLE_COUNT
@@ -202,7 +202,7 @@ const FeaturedTools = ({
               })
             }}
           >
-            <div className="flex items-center px-1 text-text-tertiary group-hover:text-text-secondary group-focus-visible:text-text-secondary">
+            <div className="flex items-center pl-1 text-text-tertiary group-hover:text-text-secondary group-focus-visible:text-text-secondary">
               <span
                 aria-hidden
                 className="i-ri-more-line size-4 group-hover:hidden group-focus-visible:hidden"

--- a/web/app/components/workflow/block-selector/featured-triggers.tsx
+++ b/web/app/components/workflow/block-selector/featured-triggers.tsx
@@ -191,7 +191,7 @@ const FeaturedTriggers = ({
           <Button
             variant="ghost"
             size="medium"
-            className="group mt-1 w-full justify-start gap-x-2 pr-2 pl-3 text-left text-text-tertiary hover:text-text-secondary focus-visible:ring-inset"
+            className="group mt-1 w-full justify-start pr-2 pl-3 text-left text-text-tertiary hover:text-text-secondary focus-visible:ring-inset"
             onClick={() => {
               setVisibleCount((count) => {
                 if (count >= maxAvailable) return INITIAL_VISIBLE_COUNT
@@ -200,7 +200,7 @@ const FeaturedTriggers = ({
               })
             }}
           >
-            <div className="flex items-center px-1 text-text-tertiary group-hover:text-text-secondary group-focus-visible:text-text-secondary">
+            <div className="flex items-center pl-1 text-text-tertiary group-hover:text-text-secondary group-focus-visible:text-text-secondary">
               <span
                 aria-hidden
                 className="i-ri-more-line size-4 group-hover:hidden group-focus-visible:hidden"

--- a/web/app/components/workflow/block-selector/rag-tool-recommendations/index.tsx
+++ b/web/app/components/workflow/block-selector/rag-tool-recommendations/index.tsx
@@ -102,10 +102,10 @@ export function RAGToolRecommendations({
               <Button
                 variant="ghost"
                 size="medium"
-                className="w-full justify-start gap-x-2 pr-2 pl-3 text-left focus-visible:ring-inset"
+                className="w-full justify-start pr-2 pl-3 text-left focus-visible:ring-inset"
                 onClick={onLoadMore}
               >
-                <div className="px-1">
+                <div className="pl-1">
                   <span
                     aria-hidden="true"
                     className="i-ri-more-line block size-4 text-text-tertiary"

--- a/web/app/components/workflow/block-selector/snippets/snippet-tags-filter.tsx
+++ b/web/app/components/workflow/block-selector/snippets/snippet-tags-filter.tsx
@@ -81,7 +81,7 @@ const SnippetTagsFilter = ({ embedded = false, value, onChange }: SnippetTagsFil
               aria-hidden="true"
             />
             {value.length > 0 && (
-              <span className="ml-1 system-xs-medium text-text-secondary">{value.length}</span>
+              <span className="system-xs-medium text-text-secondary">{value.length}</span>
             )}
           </Button>
         }

--- a/web/app/components/workflow/comment/mention-input.tsx
+++ b/web/app/components/workflow/comment/mention-input.tsx
@@ -619,9 +619,8 @@ const MentionInputInner = forwardRef<HTMLTextAreaElement, MentionInputProps>(
                   size="small"
                   disabled={loading || !value.trim()}
                   onClick={() => handleSubmit()}
-                  className="gap-1"
                 >
-                  {loading && <RiLoader2Line className="mr-1 size-3.5 animate-spin" />}
+                  {loading && <RiLoader2Line className="size-3.5 animate-spin" />}
                   <span>{t(($) => $['operation.save'], { ns: 'common' })}</span>
                   {!loading && <EnterKey className="size-4" />}
                 </Button>

--- a/web/app/components/workflow/header/header-in-restoring.tsx
+++ b/web/app/components/workflow/header/header-in-restoring.tsx
@@ -166,8 +166,8 @@ const HeaderInRestoring = ({ onRestoreSettled }: HeaderInRestoringProps) => {
           disabled={!canRestore}
           variant="primary"
           className={cn(
-            'rounded-lg border border-transparent',
-            theme === 'dark' && 'border-black/5 bg-white/10 backdrop-blur-xs',
+            'rounded-lg inset-ring-1 inset-ring-transparent',
+            theme === 'dark' && 'bg-white/10 inset-ring-black/5 backdrop-blur-xs',
           )}
         >
           {t(($) => $['common.restore'], { ns: 'workflow' })}
@@ -175,8 +175,8 @@ const HeaderInRestoring = ({ onRestoreSettled }: HeaderInRestoringProps) => {
         <Button
           onClick={handleCancelRestore}
           className={cn(
-            'rounded-lg border border-transparent text-components-button-secondary-accent-text',
-            theme === 'dark' && 'border-black/5 bg-white/10 backdrop-blur-xs',
+            'rounded-lg text-components-button-secondary-accent-text inset-ring-1 inset-ring-transparent',
+            theme === 'dark' && 'bg-white/10 inset-ring-black/5 backdrop-blur-xs',
           )}
         >
           <div className="flex items-center gap-x-0.5">

--- a/web/app/components/workflow/header/header-in-view-history.tsx
+++ b/web/app/components/workflow/header/header-in-view-history.tsx
@@ -32,7 +32,7 @@ const HeaderInHistory = ({ viewHistoryProps }: HeaderInHistoryProps) => {
         <ViewHistory {...viewHistoryProps} withText />
         <Divider type="vertical" className="mx-auto h-3.5" />
         <Button variant="primary" onClick={handleGoBackToEdit}>
-          <ArrowNarrowLeft className="mr-1 size-4" />
+          <ArrowNarrowLeft className="size-4" />
           {t(($) => $['common.goBackToEdit'], { ns: 'workflow' })}
         </Button>
       </div>

--- a/web/app/components/workflow/header/version-history-button.tsx
+++ b/web/app/components/workflow/header/version-history-button.tsx
@@ -42,8 +42,8 @@ export function VersionHistoryButton({ onClick }: VersionHistoryButtonProps) {
         render={
           <Button
             className={cn(
-              'rounded-lg border border-transparent p-2',
-              theme === 'dark' && 'border-black/5 bg-white/10 backdrop-blur-xs',
+              'rounded-lg p-2 inset-ring-1 inset-ring-transparent',
+              theme === 'dark' && 'bg-white/10 inset-ring-black/5 backdrop-blur-xs',
             )}
             onClick={onClick}
           >

--- a/web/app/components/workflow/nodes/_base/components/add-button.tsx
+++ b/web/app/components/workflow/nodes/_base/components/add-button.tsx
@@ -14,7 +14,7 @@ type Props = Readonly<{
 const AddButton: FC<Props> = ({ className, text, onClick }) => {
   return (
     <Button className={cn('w-full', className)} variant="tertiary" size="medium" onClick={onClick}>
-      <RiAddLine className="mr-1 size-3.5" />
+      <RiAddLine className="size-3.5" />
       <div>{text}</div>
     </Button>
   )

--- a/web/app/components/workflow/nodes/_base/components/before-run-form/index.tsx
+++ b/web/app/components/workflow/nodes/_base/components/before-run-form/index.tsx
@@ -134,7 +134,7 @@ const BeforeRunForm: FC<BeforeRunFormProps> = ({
               <Button
                 disabled={!isFileLoaded}
                 variant="primary"
-                className="w-0 grow space-x-2"
+                className="w-0 grow"
                 onClick={handleRunOrGenerateForm}
               >
                 <div>{t(($) => $[`${i18nPrefix}.startRun`], { ns: 'workflow' })}</div>
@@ -144,7 +144,7 @@ const BeforeRunForm: FC<BeforeRunFormProps> = ({
               <Button
                 disabled={!isFileLoaded}
                 variant="primary"
-                className="w-0 grow space-x-2"
+                className="w-0 grow"
                 onClick={handleRunOrGenerateForm}
               >
                 <div>{t(($) => $['nodes.humanInput.singleRun.button'], { ns: 'workflow' })}</div>

--- a/web/app/components/workflow/nodes/_base/components/install-plugin-button.tsx
+++ b/web/app/components/workflow/nodes/_base/components/install-plugin-button.tsx
@@ -100,9 +100,9 @@ export const InstallPluginButton = (props: InstallPluginButtonProps) => {
         ? t(($) => $['nodes.agent.pluginInstaller.install'], { ns: 'workflow' })
         : t(($) => $['nodes.agent.pluginInstaller.installing'], { ns: 'workflow' })}
       {!isLoading ? (
-        <span className="ml-1 i-ri-install-line size-3.5" />
+        <span className="i-ri-install-line size-3.5" />
       ) : (
-        <span className="ml-1 i-ri-loader-2-line size-3.5 animate-spin" />
+        <span className="i-ri-loader-2-line size-3.5 animate-spin" />
       )}
     </Button>
   )

--- a/web/app/components/workflow/nodes/_base/components/next-step/add.tsx
+++ b/web/app/components/workflow/nodes/_base/components/next-step/add.tsx
@@ -59,7 +59,7 @@ const Add = ({ nodeId, nodeData, sourceHandle, isParallel, isFailBranch }: AddPr
       size="large"
       className="bg-dropzone-bg hover:bg-dropzone-bg-hover relative w-full justify-start rounded-lg border border-dashed border-divider-regular px-2 text-xs text-text-placeholder data-popup-open:bg-components-dropzone-bg-alt!"
     >
-      <div className="mr-1.5 flex h-5 w-5 items-center justify-center rounded-[5px] bg-background-default-dimmed">
+      <div className="flex h-5 w-5 items-center justify-center rounded-[5px] bg-background-default-dimmed">
         <RiAddLine aria-hidden className="size-3" />
       </div>
       <div className="flex items-center uppercase">{tip}</div>

--- a/web/app/components/workflow/nodes/_base/components/workflow-panel/last-run/no-data.tsx
+++ b/web/app/components/workflow/nodes/_base/components/workflow-panel/last-run/no-data.tsx
@@ -21,7 +21,7 @@ const NoData: FC<Props> = ({ canSingleRun, onSingleRun }) => {
       </div>
       {canSingleRun && (
         <Button className="flex" size="small" onClick={onSingleRun}>
-          <RiPlayLine className="mr-1 size-3.5" />
+          <RiPlayLine className="size-3.5" />
           <div>{t(($) => $['debug.noData.runThisNode'], { ns: 'workflow' })}</div>
         </Button>
       )}

--- a/web/app/components/workflow/nodes/agent-v2/components/agent-output-variables/edit-card.tsx
+++ b/web/app/components/workflow/nodes/agent-v2/components/agent-output-variables/edit-card.tsx
@@ -198,7 +198,6 @@ export function OutputEditCard({
             variant="primary"
             disabled={confirmDisabled}
             aria-label={t(($) => $['nodes.agent.outputVars.confirm'], { ns: 'workflow' })}
-            className="gap-x-1"
           >
             {t(($) => $['nodes.agent.outputVars.confirm'], { ns: 'workflow' })}
             <ConfirmHotkeyHint />

--- a/web/app/components/workflow/nodes/agent-v2/components/agent-output-variables/index.tsx
+++ b/web/app/components/workflow/nodes/agent-v2/components/agent-output-variables/index.tsx
@@ -324,7 +324,7 @@ export function AgentOutputVariables({
               <Button
                 size="small"
                 variant="tertiary"
-                className="h-6 w-full gap-x-1 rounded-md bg-components-input-bg-normal text-text-secondary hover:bg-state-base-hover"
+                className="h-6 w-full rounded-md bg-components-input-bg-normal text-text-secondary hover:bg-state-base-hover"
                 onClick={handleNewOutput}
               >
                 <span aria-hidden="true" className="i-ri-add-line size-3.5" />

--- a/web/app/components/workflow/nodes/agent-v2/components/agent-roster-field.tsx
+++ b/web/app/components/workflow/nodes/agent-v2/components/agent-roster-field.tsx
@@ -257,7 +257,7 @@ function AgentRosterDrawer({
                     <Button
                       variant="secondary"
                       size="medium"
-                      className="min-w-0 flex-1 gap-1.5 px-3"
+                      className="min-w-0 flex-1 px-3"
                       loading={isCopyPending}
                       onClick={onMakeCopy}
                     >

--- a/web/app/components/workflow/nodes/agent-v2/components/edit-in-console-link.tsx
+++ b/web/app/components/workflow/nodes/agent-v2/components/edit-in-console-link.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next'
 import { getAgentDetailPath } from '@/features/agent-v2/agent-detail/routes'
 import Link from '@/next/link'
 
-const layoutClassName = 'min-w-0 flex-1 gap-1.5 px-3'
+const layoutClassName = 'min-w-0 flex-1 px-3'
 
 export function EditInConsoleLink({
   agentId,

--- a/web/app/components/workflow/nodes/data-source-empty/index.tsx
+++ b/web/app/components/workflow/nodes/data-source-empty/index.tsx
@@ -13,7 +13,7 @@ const DataSourceEmptyNode = ({ id, data }: NodeProps) => {
 
   const triggerElement = (
     <Button variant="primary" className="w-full">
-      <span aria-hidden className="mr-1 i-ri-add-line size-4" />
+      <span aria-hidden className="i-ri-add-line size-4" />
       {t(($) => $['nodes.dataSource.add'], { ns: 'workflow' })}
     </Button>
   )

--- a/web/app/components/workflow/nodes/human-input/components/delivery-method/method-item.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/delivery-method/method-item.tsx
@@ -182,7 +182,7 @@ const DeliveryMethodItem: FC<DeliveryMethodItemProps> = ({
               disabled={readonly}
             >
               {t(($) => $[`${i18nPrefix}.deliveryMethod.notConfigured`], { ns: 'workflow' })}
-              <StatusDot status="warning" className="ml-1" />
+              <StatusDot status="warning" />
             </Button>
           )}
         </div>

--- a/web/app/components/workflow/nodes/human-input/components/delivery-method/recipient/member-selector.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/delivery-method/recipient/member-selector.tsx
@@ -39,7 +39,7 @@ const MemberSelector: FC<Props> = ({ value, email, onSelect, list = [] }) => {
             className="w-full justify-between data-popup-open:bg-state-accent-hover"
             variant="ghost-accent"
           >
-            <RiContactsBookLine className="mr-1 size-4" />
+            <RiContactsBookLine className="size-4" />
             <div>
               {t(($) => $[`${i18nPrefix}.deliveryMethod.emailConfigure.memberSelector.trigger`], {
                 ns: 'workflow',

--- a/web/app/components/workflow/nodes/human-input/panel.tsx
+++ b/web/app/components/workflow/nodes/human-input/panel.tsx
@@ -127,7 +127,7 @@ const Panel: FC<NodePanelProps<HumanInputNodeType>> = ({ id, data }) => {
                 variant="ghost"
                 size="small"
                 className={cn(
-                  'flex items-center space-x-1 px-2',
+                  'flex items-center px-2',
                   isPreview && 'bg-state-accent-active text-text-accent',
                 )}
                 onClick={() => setIsPreview((isPreview) => !isPreview)}

--- a/web/app/components/workflow/nodes/if-else/components/condition-add.tsx
+++ b/web/app/components/workflow/nodes/if-else/components/condition-add.tsx
@@ -38,7 +38,7 @@ const ConditionAdd = ({
       <PopoverTrigger
         render={
           <Button size="small" className={className} disabled={disabled}>
-            <RiAddLine className="mr-1 size-3.5" />
+            <RiAddLine className="size-3.5" />
             {t(($) => $['nodes.ifElse.addCondition'], { ns: 'workflow' })}
           </Button>
         }

--- a/web/app/components/workflow/nodes/if-else/components/condition-list/condition-operator.tsx
+++ b/web/app/components/workflow/nodes/if-else/components/condition-list/condition-operator.tsx
@@ -62,7 +62,7 @@ const ConditionOperator = ({
         {selectedOption
           ? selectedOption.label
           : t(($) => $[`${i18nPrefix}.select`], { ns: 'workflow' })}
-        <RiArrowDownSLine className="ml-1 size-3.5" />
+        <RiArrowDownSLine className="size-3.5" />
       </DropdownMenuTrigger>
       <DropdownMenuContent
         placement="bottom-end"

--- a/web/app/components/workflow/nodes/if-else/components/condition-number-input.tsx
+++ b/web/app/components/workflow/nodes/if-else/components/condition-number-input.tsx
@@ -59,7 +59,7 @@ const ConditionNumberInput = ({
       <DropdownMenu open={numberVarTypeVisible} onOpenChange={setNumberVarTypeVisible}>
         <DropdownMenuTrigger render={<Button className="shrink-0" variant="ghost" size="small" />}>
           {capitalize(numberVarType)}
-          <RiArrowDownSLine className="ml-px size-3.5" />
+          <RiArrowDownSLine className="size-3.5" />
         </DropdownMenuTrigger>
         <DropdownMenuContent
           placement="bottom-start"

--- a/web/app/components/workflow/nodes/if-else/components/condition-wrap.tsx
+++ b/web/app/components/workflow/nodes/if-else/components/condition-wrap.tsx
@@ -188,7 +188,7 @@ const ConditionWrap: FC<Props> = ({
                       className="border-0 bg-transparent p-0 hover:bg-transparent focus-visible:bg-transparent [&>*:last-child]:hidden"
                     >
                       <Button size="small" disabled={readOnly}>
-                        <RiAddLine className="mr-1 size-3.5" />
+                        <RiAddLine className="size-3.5" />
                         {t(($) => $['nodes.ifElse.addSubVariable'], { ns: 'workflow' })}
                       </Button>
                     </SelectTrigger>
@@ -219,7 +219,7 @@ const ConditionWrap: FC<Props> = ({
                     onMouseEnter={() => setWillDeleteCaseId(item.case_id)}
                     onMouseLeave={() => setWillDeleteCaseId('')}
                   >
-                    <RiDeleteBinLine className="mr-1 size-3.5" />
+                    <RiDeleteBinLine className="size-3.5" />
                     {t(($) => $['operation.remove'], { ns: 'common' })}
                   </Button>
                 )}
@@ -235,7 +235,7 @@ const ConditionWrap: FC<Props> = ({
           disabled={readOnly}
           onClick={() => handleAddSubVariableCondition?.(caseId!, conditionId!)}
         >
-          <RiAddLine className="mr-1 size-3.5" />
+          <RiAddLine className="size-3.5" />
           {t(($) => $['nodes.ifElse.addSubVariable'], { ns: 'workflow' })}
         </Button>
       )}

--- a/web/app/components/workflow/nodes/if-else/panel.tsx
+++ b/web/app/components/workflow/nodes/if-else/panel.tsx
@@ -64,7 +64,7 @@ const Panel: FC<NodePanelProps<IfElseNodeType>> = ({ id, data }) => {
           onClick={() => handleAddCase()}
           disabled={readOnly}
         >
-          <RiAddLine className="mr-1 size-4" />
+          <RiAddLine className="size-4" />
           ELIF
         </Button>
       </div>

--- a/web/app/components/workflow/nodes/iteration/add-block.tsx
+++ b/web/app/components/workflow/nodes/iteration/add-block.tsx
@@ -42,7 +42,7 @@ const AddBlock = ({ iterationNodeData }: AddBlockProps) => {
       size="medium"
       className="relative data-popup-open:bg-components-button-secondary-bg-hover"
     >
-      <RiAddLine aria-hidden className="mr-1 size-4" />
+      <RiAddLine aria-hidden className="size-4" />
       {t(($) => $['common.addBlock'], { ns: 'workflow' })}
     </Button>
   )

--- a/web/app/components/workflow/nodes/knowledge-base/components/chunk-structure/index.tsx
+++ b/web/app/components/workflow/nodes/knowledge-base/components/chunk-structure/index.tsx
@@ -55,7 +55,7 @@ const ChunkStructure = ({
             readonly={readonly}
             trigger={
               <Button className="w-full" variant="secondary-accent">
-                <span className="mr-1 i-ri-add-line size-4" />
+                <span className="i-ri-add-line size-4" />
                 {t(($) => $['nodes.knowledgeBase.chooseChunkStructure'], { ns: 'workflow' })}
               </Button>
             }

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/condition-operator.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/condition-operator.tsx
@@ -55,7 +55,7 @@ const ConditionOperator = ({
             {selectedOption
               ? selectedOption.label
               : t(($) => $[`${i18nPrefix}.select`], { ns: 'workflow' })}
-            <RiArrowDownSLine className="ml-1 size-3.5" />
+            <RiArrowDownSLine className="size-3.5" />
           </Button>
         }
       />

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/condition-value-method.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/condition-list/condition-value-method.tsx
@@ -22,7 +22,7 @@ const ConditionValueMethod = ({
         render={
           <Button className="shrink-0" variant="ghost" size="small">
             {capitalize(valueMethod)}
-            <RiArrowDownSLine className="ml-px size-3.5" />
+            <RiArrowDownSLine className="size-3.5" />
           </Button>
         }
       />

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/metadata-trigger.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/metadata/metadata-trigger.tsx
@@ -40,9 +40,9 @@ const MetadataTrigger = ({
       <PopoverTrigger
         render={
           <Button variant="secondary-accent" size="small">
-            <RiFilter3Line className="mr-1 size-3.5" />
+            <RiFilter3Line className="size-3.5" />
             {t(($) => $['nodes.knowledgeRetrieval.metadata.panel.conditions'], { ns: 'workflow' })}
-            <div className="ml-1 flex items-center rounded-[5px] border border-divider-deep px-1 system-2xs-medium-uppercase text-text-tertiary">
+            <div className="flex items-center rounded-[5px] border border-divider-deep px-1 system-2xs-medium-uppercase text-text-tertiary">
               {metadataFilteringConditions?.conditions.length || 0}
             </div>
           </Button>

--- a/web/app/components/workflow/nodes/knowledge-retrieval/components/retrieval-config.tsx
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/components/retrieval-config.tsx
@@ -130,7 +130,7 @@ const RetrievalConfig: FC<Props> = ({
             disabled={readonly}
             className="data-popup-open:bg-components-button-ghost-bg-hover"
           >
-            <RiEqualizer2Line className="mr-1 size-3.5" />
+            <RiEqualizer2Line className="size-3.5" />
             {t(($) => $.retrievalSettings, { ns: 'dataset' })}
           </Button>
         }

--- a/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/json-schema-generator/generated-result.tsx
+++ b/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/json-schema-generator/generated-result.tsx
@@ -97,16 +97,12 @@ const GeneratedResult: FC<GeneratedResultProps> = ({
           </div>
           {/* Footer */}
           <div className="flex items-center justify-between p-4 pt-2">
-            <Button variant="secondary" className="flex items-center gap-x-0.5" onClick={onBack}>
+            <Button variant="secondary" className="flex items-center" onClick={onBack}>
               <RiArrowLeftLine className="size-4" />
               <span>{t(($) => $['nodes.llm.jsonSchema.back'], { ns: 'workflow' })}</span>
             </Button>
             <div className="flex items-center gap-x-2">
-              <Button
-                variant="secondary"
-                className="flex items-center gap-x-0.5"
-                onClick={onRegenerate}
-              >
+              <Button variant="secondary" className="flex items-center" onClick={onRegenerate}>
                 <RiSparklingLine className="size-4" />
                 <span>{t(($) => $['nodes.llm.jsonSchema.regenerate'], { ns: 'workflow' })}</span>
               </Button>

--- a/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/json-schema-generator/prompt-editor.tsx
+++ b/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/json-schema-generator/prompt-editor.tsx
@@ -105,7 +105,7 @@ const PromptEditor: FC<PromptEditorProps> = ({
         <Button variant="secondary" onClick={onClose}>
           {t(($) => $['operation.cancel'], { ns: 'common' })}
         </Button>
-        <Button variant="primary" className="flex items-center gap-x-0.5" onClick={onGenerate}>
+        <Button variant="primary" className="flex items-center" onClick={onGenerate}>
           <RiSparklingFill className="size-4" />
           <span>{t(($) => $['nodes.llm.jsonSchema.generate'], { ns: 'workflow' })}</span>
         </Button>

--- a/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/add-field.tsx
+++ b/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/add-field.tsx
@@ -24,13 +24,11 @@ const AddField = () => {
       <Button
         size="small"
         variant="secondary-accent"
-        className="flex items-center gap-x-px"
+        className="flex items-center"
         onClick={handleAddField}
       >
         <RiAddCircleFill className="size-3.5" />
-        <span className="px-0.75">
-          {t(($) => $['nodes.llm.jsonSchema.addField'], { ns: 'workflow' })}
-        </span>
+        <span>{t(($) => $['nodes.llm.jsonSchema.addField'], { ns: 'workflow' })}</span>
       </Button>
     </div>
   )

--- a/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/edit-card/advanced-actions.tsx
+++ b/web/app/components/workflow/nodes/llm/components/json-schema-config-modal/visual-editor/edit-card/advanced-actions.tsx
@@ -32,7 +32,7 @@ export function AdvancedActions({ isConfirmDisabled, onCancel, onConfirm }: Adva
         {t(($) => $['operation.cancel'], { ns: 'common' })}
       </Button>
       <Button
-        className="flex items-center gap-x-1"
+        className="flex items-center"
         disabled={isConfirmDisabled}
         size="small"
         variant="primary"

--- a/web/app/components/workflow/nodes/llm/components/structure-output.tsx
+++ b/web/app/components/workflow/nodes/llm/components/structure-output.tsx
@@ -37,7 +37,7 @@ export function StructureOutput({ className, value, onChange }: Props) {
           className="flex"
           onClick={() => setShowConfig(true)}
         >
-          <i className="mr-1 i-ri-edit-line size-3.5" aria-hidden="true" />
+          <i className="i-ri-edit-line size-3.5" aria-hidden="true" />
           <div className="system-xs-medium text-components-button-secondary-text">
             {t(($) => $['structOutput.configure'], { ns: 'app' })}
           </div>

--- a/web/app/components/workflow/nodes/loop/add-block.tsx
+++ b/web/app/components/workflow/nodes/loop/add-block.tsx
@@ -42,7 +42,7 @@ const AddBlock = ({ loopNodeData }: AddBlockProps) => {
       size="medium"
       className="relative data-popup-open:bg-components-button-secondary-bg-hover"
     >
-      <RiAddLine aria-hidden className="mr-1 size-4" />
+      <RiAddLine aria-hidden className="size-4" />
       {t(($) => $['common.addBlock'], { ns: 'workflow' })}
     </Button>
   )

--- a/web/app/components/workflow/nodes/loop/components/condition-add.tsx
+++ b/web/app/components/workflow/nodes/loop/components/condition-add.tsx
@@ -31,7 +31,7 @@ const ConditionAdd = ({ className, variables, onSelectVariable, disabled }: Cond
       <PopoverTrigger
         render={
           <Button size="small" className={className} disabled={disabled}>
-            <RiAddLine className="mr-1 size-3.5" />
+            <RiAddLine className="size-3.5" />
             {t(($) => $['nodes.ifElse.addCondition'], { ns: 'workflow' })}
           </Button>
         }

--- a/web/app/components/workflow/nodes/loop/components/condition-list/condition-operator.tsx
+++ b/web/app/components/workflow/nodes/loop/components/condition-list/condition-operator.tsx
@@ -62,7 +62,7 @@ const ConditionOperator = ({
         {selectedOption
           ? selectedOption.label
           : t(($) => $[`${i18nPrefix}.select`], { ns: 'workflow' })}
-        <RiArrowDownSLine className="ml-1 size-3.5" />
+        <RiArrowDownSLine className="size-3.5" />
       </DropdownMenuTrigger>
       <DropdownMenuContent
         placement="bottom-end"

--- a/web/app/components/workflow/nodes/loop/components/condition-number-input.tsx
+++ b/web/app/components/workflow/nodes/loop/components/condition-number-input.tsx
@@ -59,7 +59,7 @@ const ConditionNumberInput = ({
       <DropdownMenu open={numberVarTypeVisible} onOpenChange={setNumberVarTypeVisible}>
         <DropdownMenuTrigger render={<Button className="shrink-0" variant="ghost" size="small" />}>
           {capitalize(numberVarType)}
-          <RiArrowDownSLine className="ml-px size-3.5" />
+          <RiArrowDownSLine className="size-3.5" />
         </DropdownMenuTrigger>
         <DropdownMenuContent
           placement="bottom-start"

--- a/web/app/components/workflow/nodes/loop/components/condition-wrap.tsx
+++ b/web/app/components/workflow/nodes/loop/components/condition-wrap.tsx
@@ -141,7 +141,7 @@ const ConditionWrap: FC<Props> = ({
                   className="border-0 bg-transparent p-0 hover:bg-transparent focus-visible:bg-transparent [&>*:last-child]:hidden"
                 >
                   <Button size="small" disabled={readOnly}>
-                    <RiAddLine className="mr-1 size-3.5" />
+                    <RiAddLine className="size-3.5" />
                     {t(($) => $['nodes.ifElse.addSubVariable'], { ns: 'workflow' })}
                   </Button>
                 </SelectTrigger>

--- a/web/app/components/workflow/nodes/tool/components/tool-form/item.tsx
+++ b/web/app/components/workflow/nodes/tool/components/tool-form/item.tsx
@@ -110,7 +110,7 @@ const ToolFormItem: FC<Props> = ({
                 onClick={() => setIsShowSchema(true)}
                 className="px-1 system-xs-regular text-text-tertiary"
               >
-                <span aria-hidden className="mr-1 i-ri-braces-line size-3.5" />
+                <span aria-hidden className="i-ri-braces-line size-3.5" />
                 <span>JSON Schema</span>
               </Button>
             </>

--- a/web/app/components/workflow/nodes/trigger-plugin/components/trigger-form/item.tsx
+++ b/web/app/components/workflow/nodes/trigger-plugin/components/trigger-form/item.tsx
@@ -70,7 +70,7 @@ const TriggerFormItem: FC<Props> = ({
                 onClick={() => setIsShowSchema(true)}
                 className="px-1 system-xs-regular text-text-tertiary"
               >
-                <span aria-hidden className="mr-1 i-ri-braces-line size-3.5" />
+                <span aria-hidden className="i-ri-braces-line size-3.5" />
                 <span>JSON Schema</span>
               </Button>
             </>

--- a/web/app/components/workflow/panel/chat-variable-panel/components/array-bool-list.tsx
+++ b/web/app/components/workflow/panel/chat-variable-panel/components/array-bool-list.tsx
@@ -63,7 +63,7 @@ const ArrayValueList: FC<Props> = ({ className, list, onChange }) => {
         </div>
       ))}
       <Button variant="tertiary" className="w-full" onClick={handleItemAdd}>
-        <RiAddLine className="mr-1 size-4" />
+        <RiAddLine className="size-4" />
         <span>{t(($) => $['chatVariable.modal.addArrayValue'], { ns: 'workflow' })}</span>
       </Button>
     </div>

--- a/web/app/components/workflow/panel/chat-variable-panel/components/array-value-list.tsx
+++ b/web/app/components/workflow/panel/chat-variable-panel/components/array-value-list.tsx
@@ -66,7 +66,7 @@ const ArrayValueList: FC<Props> = ({ isString = true, list, onChange }) => {
         </div>
       ))}
       <Button variant="tertiary" className="w-full" onClick={handleItemAdd}>
-        <RiAddLine className="mr-1 size-4" />
+        <RiAddLine className="size-4" />
         <span>{t(($) => $['chatVariable.modal.addArrayValue'], { ns: 'workflow' })}</span>
       </Button>
     </div>

--- a/web/app/components/workflow/panel/chat-variable-panel/components/variable-modal-trigger.tsx
+++ b/web/app/components/workflow/panel/chat-variable-panel/components/variable-modal-trigger.tsx
@@ -31,7 +31,7 @@ const VariableModalTrigger = ({ open, setOpen, showTip, chatVar, onClose, onSave
       <PopoverTrigger
         render={
           <Button variant="primary">
-            <RiAddLine className="mr-1 size-4" />
+            <RiAddLine className="size-4" />
             <span className="system-sm-medium">
               {t(($) => $['chatVariable.button'], { ns: 'workflow' })}
             </span>

--- a/web/app/components/workflow/panel/chat-variable-panel/components/variable-modal.sections.tsx
+++ b/web/app/components/workflow/panel/chat-variable-panel/components/variable-modal.sections.tsx
@@ -124,9 +124,9 @@ export const ValueSection = ({
           onClick={() => onEditorChange(!editInJSON)}
         >
           {editInJSON ? (
-            <RiInputField className="mr-1 size-3.5" />
+            <RiInputField className="size-3.5" />
           ) : (
-            <RiDraftLine className="mr-1 size-3.5" />
+            <RiDraftLine className="size-3.5" />
           )}
           {t(editorToggleLabelSelectors[toggleLabelKey], { ns: 'workflow' })}
         </Button>

--- a/web/app/components/workflow/panel/env-panel/variable-trigger.tsx
+++ b/web/app/components/workflow/panel/env-panel/variable-trigger.tsx
@@ -30,7 +30,7 @@ const VariableTrigger = ({ open, setOpen, env, onClose, onSave }: Props) => {
       <PopoverTrigger
         render={
           <Button variant="primary">
-            <RiAddLine className="mr-1 size-4" />
+            <RiAddLine className="size-4" />
             <span className="system-sm-medium">
               {t(($) => $['env.envPanelButton'], { ns: 'workflow' })}
             </span>

--- a/web/app/components/workflow/panel/workflow-preview.tsx
+++ b/web/app/components/workflow/panel/workflow-preview.tsx
@@ -227,7 +227,7 @@ const WorkflowPreview = () => {
                 workflowRunningData?.resultText &&
                 typeof workflowRunningData?.resultText === 'string' && (
                   <Button
-                    className={cn('mb-4 ml-4 space-x-1')}
+                    className={cn('mb-4 ml-4')}
                     onClick={() => {
                       const content = workflowRunningData?.resultText
                       if (typeof content === 'string') copy(content)

--- a/web/app/components/workflow/run/agent-log/agent-log-nav.tsx
+++ b/web/app/components/workflow/run/agent-log/agent-log-nav.tsx
@@ -24,7 +24,7 @@ export function AgentLogNav({ agentOrToolLogItemStack, onShowAgentOrToolLog }: A
           onShowAgentOrToolLog()
         }}
       >
-        <span aria-hidden className="mr-1 i-ri-arrow-left-line size-3.5" />
+        <span aria-hidden className="i-ri-arrow-left-line size-3.5" />
         AGENT
       </Button>
       <div className="mx-0.5 shrink-0 system-xs-regular text-divider-deep">/</div>

--- a/web/app/components/workflow/run/iteration-log/iteration-log-trigger.tsx
+++ b/web/app/components/workflow/run/iteration-log/iteration-log-trigger.tsx
@@ -132,7 +132,7 @@ const IterationLogTrigger = ({
 
   return (
     <Button
-      className="flex w-full cursor-pointer items-center self-stretch rounded-lg border-none bg-components-button-tertiary-bg-hover px-3 py-2 hover:bg-components-button-tertiary-bg-hover"
+      className="flex w-full cursor-pointer items-center self-stretch rounded-lg bg-components-button-tertiary-bg-hover px-3 py-2 inset-ring-0 hover:bg-components-button-tertiary-bg-hover"
       onClick={handleOnShowIterationDetail}
     >
       {/* oxlint-disable-next-line hyoban/prefer-tailwind-icons */}

--- a/web/app/components/workflow/run/iteration-log/iteration-log-trigger.tsx
+++ b/web/app/components/workflow/run/iteration-log/iteration-log-trigger.tsx
@@ -132,7 +132,7 @@ const IterationLogTrigger = ({
 
   return (
     <Button
-      className="flex w-full cursor-pointer items-center gap-2 self-stretch rounded-lg border-none bg-components-button-tertiary-bg-hover px-3 py-2 hover:bg-components-button-tertiary-bg-hover"
+      className="flex w-full cursor-pointer items-center self-stretch rounded-lg border-none bg-components-button-tertiary-bg-hover px-3 py-2 hover:bg-components-button-tertiary-bg-hover"
       onClick={handleOnShowIterationDetail}
     >
       {/* oxlint-disable-next-line hyoban/prefer-tailwind-icons */}

--- a/web/app/components/workflow/run/loop-log/loop-log-trigger.tsx
+++ b/web/app/components/workflow/run/loop-log/loop-log-trigger.tsx
@@ -75,7 +75,7 @@ const LoopLogTrigger = ({ nodeInfo, allExecutions, onShowLoopResultList }: LoopL
 
   return (
     <Button
-      className="flex w-full cursor-pointer items-center self-stretch rounded-lg border-none bg-components-button-tertiary-bg-hover px-3 py-2 hover:bg-components-button-tertiary-bg-hover"
+      className="flex w-full cursor-pointer items-center self-stretch rounded-lg bg-components-button-tertiary-bg-hover px-3 py-2 inset-ring-0 hover:bg-components-button-tertiary-bg-hover"
       onClick={handleOnShowLoopDetail}
     >
       <Loop className="size-4 shrink-0 text-components-button-tertiary-text" />

--- a/web/app/components/workflow/run/loop-log/loop-log-trigger.tsx
+++ b/web/app/components/workflow/run/loop-log/loop-log-trigger.tsx
@@ -75,7 +75,7 @@ const LoopLogTrigger = ({ nodeInfo, allExecutions, onShowLoopResultList }: LoopL
 
   return (
     <Button
-      className="flex w-full cursor-pointer items-center gap-2 self-stretch rounded-lg border-none bg-components-button-tertiary-bg-hover px-3 py-2 hover:bg-components-button-tertiary-bg-hover"
+      className="flex w-full cursor-pointer items-center self-stretch rounded-lg border-none bg-components-button-tertiary-bg-hover px-3 py-2 hover:bg-components-button-tertiary-bg-hover"
       onClick={handleOnShowLoopDetail}
     >
       <Loop className="size-4 shrink-0 text-components-button-tertiary-text" />

--- a/web/app/components/workflow/update-dsl-modal.tsx
+++ b/web/app/components/workflow/update-dsl-modal.tsx
@@ -209,7 +209,7 @@ const UpdateDSLModal = ({ onCancel, onBackup, onImport }: UpdateDSLModalProps) =
               <div className="flex items-start gap-1 self-stretch pt-1 pb-0.5">
                 <Button size="small" variant="secondary" className="relative" onClick={onBackup}>
                   <RiFileDownloadLine className="size-3.5 text-components-button-secondary-text" />
-                  <div className="flex items-center justify-center gap-1 px-0.75">
+                  <div className="flex items-center justify-center gap-1">
                     {t(($) => $['common.backupCurrentDraft'], { ns: 'workflow' })}
                   </div>
                 </Button>

--- a/web/app/components/workflow/variable-inspect/listening.tsx
+++ b/web/app/components/workflow/variable-inspect/listening.tsx
@@ -215,7 +215,7 @@ const Listening: FC<ListeningProps> = ({ onStop, message }) => {
       )}
       <div>
         <Button size="medium" className="px-3" variant="primary" onClick={onStop}>
-          <StopCircle className="mr-1 size-4" />
+          <StopCircle className="size-4" />
           {t(($) => $['debug.variableInspect.listening.stopButton'], { ns: 'workflow' })}
         </Button>
       </div>

--- a/web/app/components/workflow/workflow-generator/index.tsx
+++ b/web/app/components/workflow/workflow-generator/index.tsx
@@ -638,18 +638,14 @@ function WorkflowGeneratorModal() {
                   // window where the user might want to bail (slow
                   // model, wrong instruction, etc.). Hidden when idle so
                   // the row stays focused on the primary action.
-                  <Button
-                    className="flex space-x-1"
-                    variant="secondary"
-                    onClick={onCancelGeneration}
-                  >
+                  <Button className="flex" variant="secondary" onClick={onCancelGeneration}>
                     <span className="text-xs font-semibold">
                       {t(($) => $['workflowGenerator.cancel'])}
                     </span>
                   </Button>
                 ) : (
                   <Button
-                    className="flex space-x-1"
+                    className="flex"
                     variant="primary"
                     onClick={onGenerate}
                     disabled={!model.name}

--- a/web/app/device/components/chooser.tsx
+++ b/web/app/device/components/chooser.tsx
@@ -39,12 +39,12 @@ const Chooser: FC<Props> = ({ userCode, ssoAvailable }) => {
 
   return (
     <div className="flex flex-col gap-3">
-      <Button variant="primary" size="large" className="w-full gap-2" onClick={onAccount}>
+      <Button variant="primary" size="large" className="w-full" onClick={onAccount}>
         <span className="i-ri-user-3-line h-4 w-4" />
         {t(($) => $['chooser.signInAccount'])}
       </Button>
       {ssoAvailable && (
-        <Button variant="secondary" size="large" className="w-full gap-2" onClick={onSSO}>
+        <Button variant="secondary" size="large" className="w-full" onClick={onSSO}>
           <span className="i-ri-shield-line h-4 w-4" />
           {t(($) => $['chooser.signInSSO'])}
         </Button>

--- a/web/app/education-apply/education-apply-page.tsx
+++ b/web/app/education-apply/education-apply-page.tsx
@@ -102,7 +102,7 @@ const EducationApplyAgeContent = () => {
   }
   const renderBackToDifyButton = () => (
     <Button variant="ghost-accent" onClick={handleReturnHome}>
-      <span className="mr-1 i-ri-arrow-left-line size-4" />
+      <span className="i-ri-arrow-left-line size-4" />
       {t(($) => $['applied.noPaymentPermission.returnHome'], { ns: 'education' })}
     </Button>
   )

--- a/web/app/education-apply/expire-notice-modal.tsx
+++ b/web/app/education-apply/expire-notice-modal.tsx
@@ -114,7 +114,7 @@ const ExpireNoticeModal: React.FC<Props> = ({ expireAt, expired, onClose }) => {
                   onClose()
                   setShowPricingModal()
                 }}
-                className="flex items-center space-x-1"
+                className="flex items-center"
               >
                 <SparklesSoftAccent className="size-4" />
                 <div className="text-components-button-secondary-accent-text">

--- a/web/app/signin/components/social-auth.tsx
+++ b/web/app/signin/components/social-auth.tsx
@@ -35,7 +35,7 @@ export default function SocialAuth(props: SocialAuthProps) {
         <a href={getOAuthLink('/oauth/login/github')}>
           <Button disabled={props.disabled} className="w-full">
             <>
-              <span className={cn(style.githubIcon, 'mr-2 size-5')} />
+              <span className={cn(style.githubIcon, 'size-5')} />
               <span className="truncate leading-normal">
                 {t(($) => $.withGitHub, { ns: 'login' })}
               </span>
@@ -47,7 +47,7 @@ export default function SocialAuth(props: SocialAuthProps) {
         <a href={getOAuthLink('/oauth/login/google')}>
           <Button disabled={props.disabled} className="w-full">
             <>
-              <span className={cn(style.googleIcon, 'mr-2 size-5')} />
+              <span className={cn(style.googleIcon, 'size-5')} />
               <span className="truncate leading-normal">
                 {t(($) => $.withGoogle, { ns: 'login' })}
               </span>

--- a/web/app/signin/components/sso-auth.tsx
+++ b/web/app/signin/components/sso-auth.tsx
@@ -64,7 +64,7 @@ const SSOAuth: FC<SSOAuthProps> = ({ protocol }) => {
       disabled={isLoading}
       className="w-full"
     >
-      <Lock01 className="mr-2 size-5 text-text-accent-light-mode-only" />
+      <Lock01 className="size-5 text-text-accent-light-mode-only" />
       <span className="truncate">{t(($) => $.withSSO, { ns: 'login' })}</span>
     </Button>
   )

--- a/web/features/agent-v2/agent-detail/access/components/agent-api-key-modal.tsx
+++ b/web/features/agent-v2/agent-detail/access/components/agent-api-key-modal.tsx
@@ -218,7 +218,7 @@ export function AgentApiKeyModal({
 
           <div className="mt-4 flex justify-start">
             <Button onClick={handleCreateApiKey} loading={isCreating}>
-              <span aria-hidden className="mr-1 i-heroicons-plus-20-solid size-4" />
+              <span aria-hidden className="i-heroicons-plus-20-solid size-4" />
               {t(($) => $['apiKeyModal.createNewSecretKey'])}
             </Button>
           </div>

--- a/web/features/agent-v2/agent-detail/access/components/service-api-access-card.tsx
+++ b/web/features/agent-v2/agent-detail/access/components/service-api-access-card.tsx
@@ -77,7 +77,7 @@ export function ServiceApiAccessCard({ agentId }: { agentId: string }) {
         <Button
           variant="secondary"
           size="medium"
-          className="gap-1.5 px-3"
+          className="px-3"
           disabled={isBusy || apiAccessQuery.isError}
           onClick={() => setApiKeyModalOpen(true)}
         >
@@ -101,7 +101,7 @@ export function ServiceApiAccessCard({ agentId }: { agentId: string }) {
           <Button
             variant="secondary"
             size="medium"
-            className="gap-1.5 px-3"
+            className="px-3"
             onClick={() => {
               void apiAccessQuery.refetch()
             }}

--- a/web/features/agent-v2/agent-detail/access/components/web-app-access-card.tsx
+++ b/web/features/agent-v2/agent-detail/access/components/web-app-access-card.tsx
@@ -232,7 +232,7 @@ export function WebAppAccessCard({
           {t(($) => $['agentDetail.access.webApp.actions.launch'])}
         </a>
       ) : (
-        <Button variant="secondary" size="medium" className="gap-1.5 px-3" disabled>
+        <Button variant="secondary" size="medium" className="px-3" disabled>
           <span aria-hidden className="i-ri-external-link-line size-4" />
           {t(($) => $['agentDetail.access.webApp.actions.launch'])}
         </Button>
@@ -240,7 +240,7 @@ export function WebAppAccessCard({
       <Button
         variant="secondary"
         size="medium"
-        className="gap-1.5 px-3"
+        className="px-3"
         disabled={!embeddedConfig}
         onClick={() => setShowEmbeddedModal(true)}
       >
@@ -250,7 +250,7 @@ export function WebAppAccessCard({
       <Button
         variant="secondary"
         size="medium"
-        className="gap-1.5 px-3"
+        className="px-3"
         disabled={!customizeConfig}
         onClick={() => setShowCustomizeModal(true)}
       >
@@ -260,7 +260,7 @@ export function WebAppAccessCard({
       <Button
         variant="secondary"
         size="medium"
-        className="gap-1.5 px-3"
+        className="px-3"
         disabled={!settingsAppInfo || updateSiteMutation.isPending}
         onClick={() => setShowSettingsModal(true)}
       >

--- a/web/features/agent-v2/agent-detail/access/components/web-app-access-control-button.tsx
+++ b/web/features/agent-v2/agent-detail/access/components/web-app-access-control-button.tsx
@@ -45,7 +45,7 @@ export function WebAppAccessControlButton({ agent }: { agent?: AgentAppDetailWit
       <Button
         variant="secondary"
         size="medium"
-        className="gap-1.5 px-3"
+        className="px-3"
         onClick={() => setShowAccessControl(true)}
       >
         <span aria-hidden className="i-ri-lock-2-line size-4" />

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/advanced/content-moderation.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/advanced/content-moderation.tsx
@@ -133,11 +133,11 @@ function AgentContentModerationSettingsContent() {
               <Button
                 size="small"
                 variant="ghost"
-                className="h-6 gap-0.5 px-1.5 py-1 text-text-tertiary"
+                className="h-6 py-1 text-text-tertiary"
                 onClick={() => openSettings()}
               >
                 <span className="i-ri-equalizer-2-line size-3.5" aria-hidden />
-                <span className="px-0.5 system-xs-medium">
+                <span className="system-xs-medium">
                   {t(($) => $['operation.settings'], { ns: 'common' })}
                 </span>
               </Button>

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/common/add-button.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/common/add-button.tsx
@@ -29,7 +29,7 @@ export function ConfigureSectionAddButton({
       aria-label={ariaLabel}
       variant="ghost"
       size="small"
-      className={cn('shrink-0 gap-1 px-2', className)}
+      className={cn('shrink-0 px-2', className)}
     >
       <span aria-hidden className="i-ri-add-line size-3.5" />
       <span>{t(($) => $['operation.add'])}</span>

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/memory.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/memory.tsx
@@ -105,7 +105,7 @@ export function MemorySettings({ isPending, memory }: MemorySettingsProps) {
             {t(($) => $['agentDetail.memorySettings.export.description'])}
           </p>
         </div>
-        <Button variant="secondary" size="small" disabled className="gap-1.5">
+        <Button variant="secondary" size="small" disabled>
           <span aria-hidden className="i-ri-download-line size-3.5" />
           {t(($) => $['agentDetail.memorySettings.export.download'])}
         </Button>

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/publish-bar/index.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/publish-bar/index.tsx
@@ -402,7 +402,7 @@ function PublishBarActions({
         variant="primary"
         disabled={!canPublish}
         loading={isPublishing}
-        className="h-8 gap-1 rounded-lg px-3"
+        className="h-8 rounded-lg px-3"
         onClick={onPublishRequest}
       >
         {actionIcon && <span aria-hidden className={`${actionIcon} size-4 shrink-0`} />}
@@ -467,7 +467,7 @@ function AgentVersionRestoreBar({
       <Button
         type="button"
         variant="secondary"
-        className="h-8 gap-1 rounded-lg px-3 text-text-accent"
+        className="h-8 rounded-lg px-3 text-text-accent"
         onClick={onExitVersions}
       >
         <span aria-hidden className="i-ri-arrow-go-back-line size-4 shrink-0" />

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/provider-tool/item.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/tools/provider-tool/item.tsx
@@ -94,7 +94,7 @@ function UnauthorizedCredentialStatus({
         className={cn('shrink-0', open && 'bg-components-button-secondary-bg-hover')}
       >
         {t(($) => $.notAuthorized, { ns: 'tools' })}
-        <StatusDot className="ml-2" status="warning" />
+        <StatusDot status="warning" />
       </Button>
     ),
     [t],

--- a/web/features/agent-v2/roster/components/create-agent-dialog.tsx
+++ b/web/features/agent-v2/roster/components/create-agent-dialog.tsx
@@ -97,9 +97,9 @@ export function CreateAgentDialog({ open, onOpenChange }: CreateAgentDialogProps
         disablePointerDismissal
       >
         {open === undefined && (
-          <DialogTrigger render={<Button variant="primary" className="h-8 gap-0.5 px-3" />}>
+          <DialogTrigger render={<Button variant="primary" className="h-8" />}>
             <span aria-hidden className="i-ri-add-line size-4" />
-            <span className="px-0.5 system-sm-medium">{t(($) => $['roster.createAgent'])}</span>
+            <span className="system-sm-medium">{t(($) => $['roster.createAgent'])}</span>
           </DialogTrigger>
         )}
         <DialogContent className="flex max-h-[calc(100dvh-2rem)] w-130 flex-col overflow-hidden! p-0!">

--- a/web/features/deployments/detail/access/permissions/access-subject-selector/subject-options.tsx
+++ b/web/features/deployments/detail/access/permissions/access-subject-selector/subject-options.tsx
@@ -136,11 +136,11 @@ function GroupItem({ group, subject, selectedGroups, onExpandGroup }: GroupItemP
         size="small"
         disabled={isChecked}
         variant="ghost-accent"
-        className="mr-1 flex shrink-0 items-center justify-between px-1.5 py-1"
+        className="mr-1 flex shrink-0 items-center justify-between py-1"
         onPointerDown={(event) => event.preventDefault()}
         onClick={() => onExpandGroup(group)}
       >
-        <span className="px-0.75">
+        <span>
           {t(($) => $['accessControlDialog.operateGroupAndMember.expand'], { ns: 'app' })}
         </span>
         <span className="i-ri-arrow-right-s-line size-4" aria-hidden="true" />

--- a/web/features/deployments/detail/api-tokens/api-keys/api-key-generate-menu.tsx
+++ b/web/features/deployments/detail/api-tokens/api-keys/api-key-generate-menu.tsx
@@ -4,7 +4,6 @@ import type { Environment } from '@dify/contracts/enterprise/types.gen'
 import type { ButtonProps } from '@langgenius/dify-ui/button'
 import type { FormEvent, ReactNode } from 'react'
 import { Button } from '@langgenius/dify-ui/button'
-import { cn } from '@langgenius/dify-ui/cn'
 import {
   Dialog,
   DialogCloseButton,
@@ -139,7 +138,7 @@ export function ApiKeyGenerateMenu({
       variant={triggerVariant}
       disabled={disabled}
       onClick={handleOpenCreateDialog}
-      className={cn('gap-1.5', triggerClassName)}
+      className={triggerClassName}
     >
       <span className="i-ri-add-line size-4" aria-hidden="true" />
       {t(($) => $['access.api.newKey'])}

--- a/web/features/deployments/detail/api-tokens/api-token-management/section.tsx
+++ b/web/features/deployments/detail/api-tokens/api-token-management/section.tsx
@@ -68,7 +68,7 @@ function DeveloperApiEndpoint({ apiUrl }: { apiUrl: string }) {
         value={apiUrl}
         className="min-w-0 flex-1"
       />
-      <Button variant="secondary" className="shrink-0 gap-1.5" onClick={() => setApiDocsOpen(true)}>
+      <Button variant="secondary" className="shrink-0" onClick={() => setApiDocsOpen(true)}>
         <span className="i-ri-file-list-3-line size-3.5" />
         {t(($) => $['access.api.docs'])}
       </Button>

--- a/web/features/deployments/detail/instances/header-actions/new-deployment-button.tsx
+++ b/web/features/deployments/detail/instances/header-actions/new-deployment-button.tsx
@@ -20,7 +20,7 @@ export function NewDeploymentButton() {
     <Button
       size="medium"
       variant="primary"
-      className="gap-1.5"
+
       disabled={!appInstanceId}
       onClick={() => {
         if (!appInstanceId) return

--- a/web/features/deployments/detail/overview/environment-status/environment-strip.tsx
+++ b/web/features/deployments/detail/overview/environment-status/environment-strip.tsx
@@ -82,7 +82,7 @@ function EnvironmentEmptyState({ canDeploy }: { canDeploy: boolean }) {
             type="button"
             variant="primary"
             size="medium"
-            className="gap-1.5"
+
             onClick={() => openDeployDrawer({ appInstanceId })}
           >
             <span className="i-ri-rocket-line size-4 shrink-0" aria-hidden="true" />

--- a/web/features/new-rag/new-knowledge-list.tsx
+++ b/web/features/new-rag/new-knowledge-list.tsx
@@ -107,14 +107,14 @@ export function NewKnowledgeList({
               <Button
                 variant="ghost"
                 size="small"
-                className="gap-1 overflow-hidden px-1.5 text-text-tertiary"
+                className="overflow-hidden text-text-tertiary"
                 onClick={() => setShowExternalApiPanel(true)}
               >
                 <span
                   aria-hidden
                   className="i-custom-vender-solid-development-api-connection-mod size-3.5 shrink-0"
                 />
-                <span className="px-0.5 system-xs-medium">{t(($) => $.externalAPIPanelTitle)}</span>
+                <span className="system-xs-medium">{t(($) => $.externalAPIPanelTitle)}</span>
               </Button>
             )}
             <ServiceApi apiBaseUrl={apiBaseInfo?.api_base_url ?? ''} />
@@ -139,10 +139,10 @@ export function NewKnowledgeList({
                 render={<Link href="/datasets/new/create" />}
                 variant="primary"
                 size="medium"
-                className="gap-0.5 px-2 shadow-xs"
+                className="px-2 shadow-xs"
               >
                 <span aria-hidden className="i-ri-add-line size-4 shrink-0" />
-                <span className="pl-1">{createLabel}</span>
+                <span>{createLabel}</span>
               </Button>
             </div>
           )}


### PR DESCRIPTION
## Summary

- make Dify UI Button own the spacing between direct children, using the size-specific values from the Figma Button component
- align Primary, Secondary, and Secondary Accent shadows, blur, disabled states, clipping, and inside strokes with the design tokens
- migrate Web Button consumers away from duplicated icon margins and `gap` / `space-x` overrides
- migrate consumer stroke overrides to the same `inset-ring-*` contract so borderless and custom-stroke Buttons do not retain or double the primitive stroke
- keep the existing public Button API unchanged

## Why

Icon-and-label spacing was owned by individual call sites, so omitted spacing rendered icons against labels while duplicated spacing produced inconsistent gaps. The primitive now owns this layout contract, and existing consumers have been migrated to avoid double spacing.

Primary, Secondary, and Secondary Accent strokes now use 0.5px inset rings. This matches Figma's inside-stroke geometry without changing intrinsic Button dimensions and keeps the normal stroke separate from the 2px `focus-visible` ring.

The migration also removes obsolete CSS utility assertions exposed by the spacing change while retaining behavior, state, and public presentation-prop coverage.

## Scope

- no new Button variants, icon slots, wrappers, or icon-only sizing API
- existing direct-child composition remains unchanged
- explicit Ghost Button borders used for dashed or input-like business layouts remain owned by those consumers

Closes #39984.