### PR TITLE
fix(agent): expose feedback in agent logs

### DIFF
--- a/api/fields/agent_fields.py
+++ b/api/fields/agent_fields.py
@@ -171,6 +171,12 @@ class AgentLogConversationItemResponse(ResponseModel):
         return to_timestamp(value)
 
 
+class AgentLogFeedbackResponse(ResponseModel):
+    rating: Literal["like", "dislike"]
+    content: str | None = None
+    from_source: Literal["user", "admin"]
+
+
 class AgentLogMessageItemResponse(ResponseModel):
     id: str
     message_id: str
@@ -181,6 +187,8 @@ class AgentLogMessageItemResponse(ResponseModel):
     error: str | None = None
     from_end_user_id: str | None = None
     from_account_id: str | None = None
+    feedback_enabled: bool = False
+    feedbacks: list[AgentLogFeedbackResponse] = Field(default_factory=list)
     message_tokens: int
     answer_tokens: int
     total_tokens: int

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -14399,6 +14399,14 @@ section may be empty, which is how callers express "no knowledge layer".
 | updated_at | integer |  | No |
 | user_rate | number |  | No |
 
+#### AgentLogFeedbackResponse
+
+| Name | Type | Description | Required |
+| ---- | ---- | ----------- | -------- |
+| content | string |  | No |
+| from_source | string, <br>**Available values:** "admin", "user" | *Enum:* `"admin"`, `"user"` | Yes |
+| rating | string, <br>**Available values:** "dislike", "like" | *Enum:* `"dislike"`, `"like"` | Yes |
+
 #### AgentLogListResponse
 
 | Name | Type | Description | Required |
@@ -14419,6 +14427,8 @@ section may be empty, which is how callers express "no knowledge layer".
 | created_at | integer |  | No |
 | currency | string |  | Yes |
 | error | string |  | No |
+| feedback_enabled | boolean |  | No |
+| feedbacks | [ [AgentLogFeedbackResponse](#agentlogfeedbackresponse) ] |  | No |
 | from_account_id | string |  | No |
 | from_end_user_id | string |  | No |
 | id | string |  | Yes |

--- a/api/services/agent/observability_service.py
+++ b/api/services/agent/observability_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
@@ -17,8 +17,8 @@ from core.app.entities.app_invoke_entities import InvokeFrom
 from graphon.enums import WorkflowNodeExecutionStatus
 from libs.helper import convert_datetime_to_date, escape_like_pattern, to_timestamp
 from models.agent import WorkflowAgentNodeBinding
-from models.enums import CreatorUserRole, MessageStatus
-from models.model import App, Conversation, Message
+from models.enums import CreatorUserRole, FeedbackFromSource, FeedbackRating, MessageStatus
+from models.model import App, Conversation, Message, MessageFeedback
 from models.workflow import WorkflowNodeExecutionModel, WorkflowRun, WorkflowType
 
 
@@ -138,7 +138,12 @@ class AgentObservabilityService:
         return int(message.message_tokens or 0) + int(message.answer_tokens or 0)
 
     @classmethod
-    def serialize_log_message(cls, message: Message, conversation: Conversation | None = None) -> dict[str, Any]:
+    def serialize_log_message(
+        cls,
+        message: Message,
+        conversation: Conversation | None = None,
+        feedbacks: Sequence[MessageFeedback] = (),
+    ) -> dict[str, Any]:
         invoke_from = message.invoke_from.value if message.invoke_from else None
         return {
             "id": message.id,
@@ -153,6 +158,8 @@ class AgentObservabilityService:
             "from_source": message.from_source.value if message.from_source else None,
             "from_end_user_id": message.from_end_user_id,
             "from_account_id": message.from_account_id,
+            "feedback_enabled": True,
+            "feedbacks": [cls._serialize_message_feedback(feedback) for feedback in feedbacks],
             "message_tokens": int(message.message_tokens or 0),
             "answer_tokens": int(message.answer_tokens or 0),
             "total_tokens": cls._total_tokens(message),
@@ -201,14 +208,19 @@ class AgentObservabilityService:
         rows: list[dict[str, Any]] = []
         for source_filter in source_filters:
             if source_filter.kind in {"all", "webapp"}:
+                messages = self._list_webapp_messages(
+                    app=app,
+                    conversation_id=conversation_id,
+                    params=params,
+                    source_filter=source_filter,
+                )
+                feedbacks_by_message = self._list_message_feedbacks(app=app, messages=messages)
                 rows.extend(
-                    self.serialize_log_message(message)
-                    for message in self._list_webapp_messages(
-                        app=app,
-                        conversation_id=conversation_id,
-                        params=params,
-                        source_filter=source_filter,
+                    self.serialize_log_message(
+                        message,
+                        feedbacks=feedbacks_by_message.get(message.id, ()),
                     )
+                    for message in messages
                 )
             if source_filter.kind in {"all", "workflow"}:
                 rows.extend(
@@ -270,6 +282,10 @@ class AgentObservabilityService:
         )
         stmt = self._apply_observability_filters(stmt, params=params, source_filter=source_filter)
         rows = list(self._session.execute(stmt).all())
+        feedback_rates = self._list_conversation_feedback_rates(
+            app=app,
+            conversation_ids=[row[0].id for row in rows],
+        )
         return [
             self._serialize_conversation_log(
                 conversation=row[0],
@@ -279,6 +295,8 @@ class AgentObservabilityService:
                 source=self._serialize_webapp_source(app),
                 created_at=row.created_at,
                 updated_at=row.updated_at,
+                user_rate=feedback_rates.get(row[0].id, {}).get("user_rate"),
+                operation_rate=feedback_rates.get(row[0].id, {}).get("operation_rate"),
             )
             for row in rows
         ]
@@ -349,6 +367,62 @@ class AgentObservabilityService:
         stmt = select(Message).where(Message.app_id == app.id, Message.conversation_id == conversation_id)
         stmt = self._apply_message_filters(stmt, params=params, source_filter=source_filter)
         return list(self._session.scalars(stmt.order_by(Message.created_at.desc(), Message.id.desc())).all())
+
+    def _list_message_feedbacks(self, *, app: App, messages: Sequence[Message]) -> dict[str, list[MessageFeedback]]:
+        message_ids = [message.id for message in messages]
+        if not message_ids:
+            return {}
+
+        stmt = (
+            select(MessageFeedback)
+            .where(
+                MessageFeedback.app_id == app.id,
+                MessageFeedback.message_id.in_(message_ids),
+                MessageFeedback.from_source.in_((FeedbackFromSource.USER, FeedbackFromSource.ADMIN)),
+            )
+            .order_by(MessageFeedback.created_at.asc(), MessageFeedback.id.asc())
+        )
+        feedbacks_by_message: dict[str, list[MessageFeedback]] = {}
+        for feedback in self._session.scalars(stmt).all():
+            feedbacks_by_message.setdefault(feedback.message_id, []).append(feedback)
+        return feedbacks_by_message
+
+    def _list_conversation_feedback_rates(
+        self, *, app: App, conversation_ids: Sequence[str]
+    ) -> dict[str, dict[str, float]]:
+        if not conversation_ids:
+            return {}
+
+        stmt = (
+            select(
+                MessageFeedback.conversation_id,
+                MessageFeedback.from_source,
+                func.sum(sa.case((MessageFeedback.rating == FeedbackRating.LIKE, 1), else_=0)).label("like_count"),
+                func.count(MessageFeedback.id).label("total_count"),
+            )
+            .where(
+                MessageFeedback.app_id == app.id,
+                MessageFeedback.conversation_id.in_(conversation_ids),
+                MessageFeedback.from_source.in_((FeedbackFromSource.USER, FeedbackFromSource.ADMIN)),
+            )
+            .group_by(MessageFeedback.conversation_id, MessageFeedback.from_source)
+        )
+        rates: dict[str, dict[str, float]] = {}
+        for row in self._session.execute(stmt).all():
+            rate = self._positive_feedback_rate(like_count=row.like_count, total_count=row.total_count)
+            if rate is None:
+                continue
+            source = self._enum_value(row.from_source)
+            rate_key = "user_rate" if source == FeedbackFromSource.USER.value else "operation_rate"
+            rates.setdefault(row.conversation_id, {})[rate_key] = rate
+        return rates
+
+    @staticmethod
+    def _positive_feedback_rate(*, like_count: int | None, total_count: int | None) -> float | None:
+        total = int(total_count or 0)
+        if total == 0:
+            return None
+        return int(like_count or 0) / total
 
     def _list_workflow_messages(
         self,
@@ -547,6 +621,8 @@ class AgentObservabilityService:
         source: dict[str, Any],
         created_at: datetime | None,
         updated_at: datetime | None,
+        user_rate: float | None,
+        operation_rate: float | None,
     ) -> dict[str, Any]:
         return {
             "id": conversation.id,
@@ -554,8 +630,8 @@ class AgentObservabilityService:
             "title": conversation.name,
             "end_user_id": conversation.from_end_user_id,
             "message_count": int(message_count or 0),
-            "user_rate": None,
-            "operation_rate": None,
+            "user_rate": user_rate,
+            "operation_rate": operation_rate,
             "unread": conversation.read_at is None,
             "source": source,
             "status": cls._conversation_status(paused_count=paused_count, failed_count=failed_count),
@@ -622,6 +698,8 @@ class AgentObservabilityService:
             "from_account_id": (
                 node_execution.created_by if created_by_role == CreatorUserRole.ACCOUNT.value else None
             ),
+            "feedback_enabled": False,
+            "feedbacks": [],
             "message_tokens": prompt_tokens,
             "answer_tokens": completion_tokens,
             "total_tokens": total_tokens,
@@ -630,6 +708,14 @@ class AgentObservabilityService:
             "latency": float(usage.get("latency") or node_execution.elapsed_time or 0),
             "created_at": to_timestamp(node_execution.created_at),
             "updated_at": to_timestamp(node_execution.finished_at or node_execution.created_at),
+        }
+
+    @classmethod
+    def _serialize_message_feedback(cls, feedback: MessageFeedback) -> dict[str, Any]:
+        return {
+            "rating": cls._enum_value(feedback.rating),
+            "content": feedback.content,
+            "from_source": cls._enum_value(feedback.from_source),
         }
 
     @staticmethod

--- a/api/tests/unit_tests/services/agent/test_agent_observability_service.py
+++ b/api/tests/unit_tests/services/agent/test_agent_observability_service.py
@@ -309,6 +309,60 @@ def test_list_log_messages_merges_deduplicates_and_sorts_sources(monkeypatch: py
     }
 
 
+def test_list_webapp_conversation_logs_includes_feedback_rates(monkeypatch: pytest.MonkeyPatch) -> None:
+    timestamp = datetime(2026, 7, 23, 7, 0, 19, tzinfo=UTC)
+    conversation = SimpleNamespace(
+        id="conversation-1",
+        name="Feedback conversation",
+        from_end_user_id="end-user-1",
+        read_at=None,
+    )
+
+    class FakeRow:
+        message_count = 2
+        paused_count = 0
+        failed_count = 0
+        created_at = timestamp
+        updated_at = timestamp
+
+        def __getitem__(self, index: int) -> SimpleNamespace:
+            if index != 0:
+                raise IndexError(index)
+            return conversation
+
+    class FakeResult:
+        def all(self) -> list[FakeRow]:
+            return [FakeRow()]
+
+    class FakeSession:
+        def execute(self, stmt: object) -> FakeResult:
+            str(stmt)
+            return FakeResult()
+
+    app = SimpleNamespace(
+        id="app-1",
+        name="Agent WebApp",
+        icon_type=None,
+        icon=None,
+        icon_background=None,
+    )
+    service = AgentObservabilityService(FakeSession())
+    monkeypatch.setattr(
+        service,
+        "_list_conversation_feedback_rates",
+        lambda **kwargs: {"conversation-1": {"user_rate": 0.5, "operation_rate": 1.0}},
+    )
+
+    rows = service._list_webapp_conversation_logs(
+        app=app,  # type: ignore[arg-type]
+        params=AgentLogQueryParams(),
+        source_filter=AgentObservabilityService.resolve_source_filter("webapp"),
+    )
+
+    assert rows[0]["user_rate"] == 0.5
+    assert rows[0]["operation_rate"] == 1.0
+
+
 def test_list_workflow_logs_uses_node_executions_without_messages() -> None:
     created_at = datetime(2026, 7, 23, 7, 0, 19, tzinfo=UTC)
     node_execution = SimpleNamespace(
@@ -767,6 +821,12 @@ def test_list_conversation_feedback_rates_maps_user_and_admin_sources() -> None:
                     from_source=FeedbackFromSource.ADMIN,
                     like_count=1,
                     total_count=1,
+                ),
+                SimpleNamespace(
+                    conversation_id="conversation-without-ratings",
+                    from_source=FeedbackFromSource.USER,
+                    like_count=0,
+                    total_count=0,
                 ),
             ]
 

--- a/api/tests/unit_tests/services/agent/test_agent_observability_service.py
+++ b/api/tests/unit_tests/services/agent/test_agent_observability_service.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import Protocol
 
 import pytest
 
@@ -710,6 +711,45 @@ def test_positive_feedback_rate_uses_rated_messages_as_denominator() -> None:
     assert AgentObservabilityService._positive_feedback_rate(like_count=2, total_count=4) == 0.5
     assert AgentObservabilityService._positive_feedback_rate(like_count=0, total_count=1) == 0
     assert AgentObservabilityService._positive_feedback_rate(like_count=None, total_count=0) is None
+
+
+def test_list_message_feedbacks_groups_feedbacks_by_message() -> None:
+    feedbacks = [
+        SimpleNamespace(message_id="message-1"),
+        SimpleNamespace(message_id="message-1"),
+        SimpleNamespace(message_id="message-2"),
+    ]
+
+    class Compilable(Protocol):
+        def compile(self) -> object: ...
+
+    class FakeScalarResult:
+        def all(self) -> list[SimpleNamespace]:
+            return feedbacks
+
+    class FakeSession:
+        def __init__(self) -> None:
+            self.scalar_calls = 0
+
+        def scalars(self, stmt: Compilable) -> FakeScalarResult:
+            stmt.compile()
+            self.scalar_calls += 1
+            return FakeScalarResult()
+
+    session = FakeSession()
+    service = AgentObservabilityService(session)  # type: ignore[arg-type]
+
+    grouped_feedbacks = service._list_message_feedbacks(
+        app=SimpleNamespace(id="app-1"),  # type: ignore[arg-type]
+        messages=[SimpleNamespace(id="message-1"), SimpleNamespace(id="message-2")],  # type: ignore[list-item]
+    )
+
+    assert grouped_feedbacks == {
+        "message-1": feedbacks[:2],
+        "message-2": feedbacks[2:],
+    }
+    assert service._list_message_feedbacks(app=SimpleNamespace(id="app-1"), messages=[]) == {}  # type: ignore[arg-type]
+    assert session.scalar_calls == 1
 
 
 def test_list_conversation_feedback_rates_maps_user_and_admin_sources() -> None:

--- a/api/tests/unit_tests/services/agent/test_agent_observability_service.py
+++ b/api/tests/unit_tests/services/agent/test_agent_observability_service.py
@@ -6,7 +6,13 @@ import pytest
 
 from core.app.entities.app_invoke_entities import InvokeFrom
 from graphon.enums import WorkflowNodeExecutionStatus
-from models.enums import ConversationFromSource, CreatorUserRole, MessageStatus
+from models.enums import (
+    ConversationFromSource,
+    CreatorUserRole,
+    FeedbackFromSource,
+    FeedbackRating,
+    MessageStatus,
+)
 from services.agent import observability_service as observability_service_module
 from services.agent.observability_service import AgentLogQueryParams, AgentObservabilityService
 
@@ -278,7 +284,8 @@ def test_list_log_messages_merges_deduplicates_and_sorts_sources(monkeypatch: py
         {"id": "workflow-only", "created_at": 20, "updated_at": 10},
     ]
     monkeypatch.setattr(service, "_list_webapp_messages", lambda **kwargs: [webapp_message])
-    monkeypatch.setattr(service, "serialize_log_message", lambda message: webapp_row)
+    monkeypatch.setattr(service, "_list_message_feedbacks", lambda **kwargs: {})
+    monkeypatch.setattr(service, "serialize_log_message", lambda message, feedbacks=(): webapp_row)
     monkeypatch.setattr(service, "_list_workflow_messages", lambda **kwargs: workflow_rows)
 
     payload = service.list_log_messages(
@@ -551,8 +558,24 @@ def test_serialize_log_message_returns_frontend_log_shape() -> None:
         updated_at=updated_at,
     )
     conversation = SimpleNamespace(name="Debug conversation")
+    feedbacks = [
+        SimpleNamespace(
+            rating=FeedbackRating.LIKE,
+            content="Useful",
+            from_source=FeedbackFromSource.USER,
+        ),
+        SimpleNamespace(
+            rating=FeedbackRating.DISLIKE,
+            content="Needs more detail",
+            from_source=FeedbackFromSource.ADMIN,
+        ),
+    ]
 
-    payload = AgentObservabilityService.serialize_log_message(message, conversation)  # type: ignore[arg-type]
+    payload = AgentObservabilityService.serialize_log_message(  # type: ignore[arg-type]
+        message,
+        conversation,
+        feedbacks,
+    )
 
     assert payload == {
         "id": "message-1",
@@ -567,6 +590,11 @@ def test_serialize_log_message_returns_frontend_log_shape() -> None:
         "from_source": "console",
         "from_end_user_id": None,
         "from_account_id": "account-1",
+        "feedback_enabled": True,
+        "feedbacks": [
+            {"rating": "like", "content": "Useful", "from_source": "user"},
+            {"rating": "dislike", "content": "Needs more detail", "from_source": "admin"},
+        ],
         "message_tokens": 3,
         "answer_tokens": 4,
         "total_tokens": 7,
@@ -615,6 +643,8 @@ def test_serialize_workflow_node_message_returns_frontend_log_shape() -> None:
         "error": None,
         "from_end_user_id": "end-user-1",
         "from_account_id": None,
+        "feedback_enabled": False,
+        "feedbacks": [],
         "message_tokens": 10,
         "answer_tokens": 5,
         "total_tokens": 15,
@@ -674,6 +704,52 @@ def test_serialize_workflow_node_message_handles_sparse_runtime_data() -> None:
     assert payload["currency"] == ""
     assert payload["latency"] == 2.0
     assert payload["updated_at"] == int(created_at.timestamp())
+
+
+def test_positive_feedback_rate_uses_rated_messages_as_denominator() -> None:
+    assert AgentObservabilityService._positive_feedback_rate(like_count=2, total_count=4) == 0.5
+    assert AgentObservabilityService._positive_feedback_rate(like_count=0, total_count=1) == 0
+    assert AgentObservabilityService._positive_feedback_rate(like_count=None, total_count=0) is None
+
+
+def test_list_conversation_feedback_rates_maps_user_and_admin_sources() -> None:
+    class FakeResult:
+        def all(self):
+            return [
+                SimpleNamespace(
+                    conversation_id="conversation-1",
+                    from_source=FeedbackFromSource.USER,
+                    like_count=2,
+                    total_count=4,
+                ),
+                SimpleNamespace(
+                    conversation_id="conversation-1",
+                    from_source=FeedbackFromSource.ADMIN,
+                    like_count=1,
+                    total_count=1,
+                ),
+            ]
+
+    class FakeSession:
+        def execute(self, stmt):
+            stmt.compile()
+            return FakeResult()
+
+    service = AgentObservabilityService(FakeSession())
+
+    rates = service._list_conversation_feedback_rates(
+        app=SimpleNamespace(id="app-1"),  # type: ignore[arg-type]
+        conversation_ids=["conversation-1"],
+    )
+
+    assert rates == {"conversation-1": {"user_rate": 0.5, "operation_rate": 1.0}}
+    assert (
+        service._list_conversation_feedback_rates(
+            app=SimpleNamespace(id="app-1"),  # type: ignore[arg-type]
+            conversation_ids=[],
+        )
+        == {}
+    )
 
 
 def test_workflow_node_serialization_helpers_handle_invalid_values() -> None:

--- a/packages/contracts/generated/api/console/agent/types.gen.ts
+++ b/packages/contracts/generated/api/console/agent/types.gen.ts
@@ -933,6 +933,8 @@ export type AgentLogMessageItemResponse = {
   created_at?: number | null
   currency: string
   error?: string | null
+  feedback_enabled?: boolean
+  feedbacks?: Array<AgentLogFeedbackResponse>
   from_account_id?: string | null
   from_end_user_id?: string | null
   id: string
@@ -1357,6 +1359,12 @@ export type AgentSuggestedQuestionsAfterAnswerModelConfig = {
   name: string
   provider: string
   [key: string]: unknown
+}
+
+export type AgentLogFeedbackResponse = {
+  content?: string | null
+  from_source: 'admin' | 'user'
+  rating: 'dislike' | 'like'
 }
 
 export type SimpleAccount = {

--- a/packages/contracts/generated/api/console/agent/zod.gen.ts
+++ b/packages/contracts/generated/api/console/agent/zod.gen.ts
@@ -832,40 +832,6 @@ export const zAgentLogListResponse = z.object({
   total: z.int(),
 })
 
-/**
- * AgentLogMessageItemResponse
- */
-export const zAgentLogMessageItemResponse = z.object({
-  answer: z.string(),
-  answer_tokens: z.int(),
-  conversation_id: z.string(),
-  created_at: z.int().nullish(),
-  currency: z.string(),
-  error: z.string().nullish(),
-  from_account_id: z.string().nullish(),
-  from_end_user_id: z.string().nullish(),
-  id: z.string(),
-  latency: z.number(),
-  message_id: z.string(),
-  message_tokens: z.int(),
-  query: z.string(),
-  status: z.string(),
-  total_price: z.string(),
-  total_tokens: z.int(),
-  updated_at: z.int().nullish(),
-})
-
-/**
- * AgentLogMessageListResponse
- */
-export const zAgentLogMessageListResponse = z.object({
-  data: z.array(zAgentLogMessageItemResponse),
-  has_more: z.boolean(),
-  limit: z.int(),
-  page: z.int(),
-  total: z.int(),
-})
-
 export const zJsonValue = z
   .union([
     z.string(),
@@ -1363,6 +1329,51 @@ export const zAgentSuggestedQuestionsAfterAnswerFeatureConfig = z.object({
   enabled: z.boolean().optional().default(false),
   model: zAgentSuggestedQuestionsAfterAnswerModelConfig.nullish(),
   prompt: z.string().nullish(),
+})
+
+/**
+ * AgentLogFeedbackResponse
+ */
+export const zAgentLogFeedbackResponse = z.object({
+  content: z.string().nullish(),
+  from_source: z.enum(['admin', 'user']),
+  rating: z.enum(['dislike', 'like']),
+})
+
+/**
+ * AgentLogMessageItemResponse
+ */
+export const zAgentLogMessageItemResponse = z.object({
+  answer: z.string(),
+  answer_tokens: z.int(),
+  conversation_id: z.string(),
+  created_at: z.int().nullish(),
+  currency: z.string(),
+  error: z.string().nullish(),
+  feedback_enabled: z.boolean().optional().default(false),
+  feedbacks: z.array(zAgentLogFeedbackResponse).optional(),
+  from_account_id: z.string().nullish(),
+  from_end_user_id: z.string().nullish(),
+  id: z.string(),
+  latency: z.number(),
+  message_id: z.string(),
+  message_tokens: z.int(),
+  query: z.string(),
+  status: z.string(),
+  total_price: z.string(),
+  total_tokens: z.int(),
+  updated_at: z.int().nullish(),
+})
+
+/**
+ * AgentLogMessageListResponse
+ */
+export const zAgentLogMessageListResponse = z.object({
+  data: z.array(zAgentLogMessageItemResponse),
+  has_more: z.boolean(),
+  limit: z.int(),
+  page: z.int(),
+  total: z.int(),
 })
 
 /**

--- a/web/features/agent-v2/agent-detail/logs/__tests__/log-detail-panel.spec.tsx
+++ b/web/features/agent-v2/agent-detail/logs/__tests__/log-detail-panel.spec.tsx
@@ -1,0 +1,223 @@
+import type {
+  AgentLogConversationItemResponse,
+  AgentLogMessageListResponse,
+} from '@dify/contracts/api/console/agent/types.gen'
+import type { FeedbackFunc, IChatItem } from '@/app/components/base/chat/chat/type'
+import { QueryClient } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClientTestProvider } from '@/test/console/query-provider'
+import { AgentLogDetailPanel } from '../components/log-detail-panel'
+
+const mocks = vi.hoisted(() => ({
+  chatProps: vi.fn(),
+  feedbackMutationFn: vi.fn(),
+  messagesQueryFn: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}))
+
+vi.mock('@/app/components/base/chat/chat', () => ({
+  default: ({
+    chatList,
+    config,
+    onFeedback,
+  }: {
+    chatList: IChatItem[]
+    config?: { supportFeedback?: boolean }
+    onFeedback?: FeedbackFunc
+  }) => {
+    mocks.chatProps({ chatList, config, onFeedback })
+    return (
+      <button
+        onClick={() => void onFeedback?.('message-1', { rating: 'like' })}
+      >
+        submit-feedback
+      </button>
+    )
+  },
+}))
+
+vi.mock('@langgenius/dify-ui/toast', () => ({
+  toast: {
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+  },
+}))
+
+vi.mock('@/hooks/use-timestamp', () => ({
+  default: () => ({
+    formatTime: (value: number) => `formatted-${value}`,
+  }),
+}))
+
+vi.mock('@/service/client', () => ({
+  consoleQuery: {
+    agent: {
+      byAgentId: {
+        feedbacks: {
+          post: {
+            mutationOptions: () => ({ mutationFn: mocks.feedbackMutationFn }),
+          },
+        },
+        logs: {
+          get: {
+            key: () => ['agent-logs'],
+          },
+          byConversationId: {
+            messages: {
+              get: {
+                key: () => ['agent-log-messages'],
+                queryOptions: ({ input }: { input: unknown }) => ({
+                  queryFn: () => mocks.messagesQueryFn(input),
+                  queryKey: ['agent-log-messages', input],
+                }),
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}))
+
+const webappLog: AgentLogConversationItemResponse = {
+  conversation_id: 'conversation-1',
+  id: 'conversation-1',
+  message_count: 1,
+  source: {
+    app_id: 'app-1',
+    app_name: 'Agent WebApp',
+    id: 'webapp:app-1',
+    type: 'webapp',
+  },
+  status: 'success',
+  title: 'Feedback conversation',
+  unread: false,
+}
+
+const workflowLog: AgentLogConversationItemResponse = {
+  ...webappLog,
+  conversation_id: 'execution-1',
+  id: 'execution-1',
+  source: {
+    app_id: 'workflow-app-1',
+    app_name: 'Workflow App',
+    id: 'workflow:workflow-app-1:workflow-1:v1:node-1',
+    node_id: 'node-1',
+    type: 'workflow',
+    workflow_id: 'workflow-1',
+    workflow_version: 'v1',
+  },
+}
+
+const webappMessages: AgentLogMessageListResponse = {
+  data: [
+    {
+      answer: 'Answer',
+      answer_tokens: 4,
+      conversation_id: 'conversation-1',
+      currency: 'USD',
+      feedback_enabled: true,
+      feedbacks: [
+        { content: 'Helpful', from_source: 'user', rating: 'like' },
+        { content: 'Needs work', from_source: 'admin', rating: 'dislike' },
+      ],
+      id: 'message-1',
+      latency: 1.25,
+      message_id: 'message-1',
+      message_tokens: 3,
+      query: 'Question',
+      status: 'success',
+      total_price: '0.001',
+      total_tokens: 7,
+    },
+  ],
+  has_more: false,
+  limit: 100,
+  page: 1,
+  total: 1,
+}
+
+function renderPanel(log: AgentLogConversationItemResponse, messages: AgentLogMessageListResponse) {
+  mocks.messagesQueryFn.mockResolvedValue(messages)
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue()
+
+  render(
+    <QueryClientTestProvider queryClient={queryClient}>
+      <AgentLogDetailPanel agentId="agent-1" log={log} onClose={vi.fn()} />
+    </QueryClientTestProvider>,
+  )
+
+  return { invalidateQueries }
+}
+
+describe('AgentLogDetailPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.feedbackMutationFn.mockResolvedValue({ result: 'success' })
+  })
+
+  it('maps user and admin feedback and submits operator feedback for webapp messages', async () => {
+    const user = userEvent.setup()
+    const { invalidateQueries } = renderPanel(webappLog, webappMessages)
+
+    await screen.findByRole('button', { name: 'submit-feedback' })
+    expect(mocks.chatProps).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({ supportFeedback: true }),
+        chatList: expect.arrayContaining([
+          expect.objectContaining({
+            adminFeedback: { content: 'Needs work', from_source: 'admin', rating: 'dislike' },
+            feedback: { content: 'Helpful', from_source: 'user', rating: 'like' },
+            feedbackDisabled: false,
+            id: 'message-1',
+          }),
+        ]),
+      }),
+    )
+
+    await user.click(screen.getByRole('button', { name: 'submit-feedback' }))
+
+    await waitFor(() => {
+      expect(mocks.feedbackMutationFn.mock.calls[0]?.[0]).toEqual({
+        body: {
+          content: undefined,
+          message_id: 'message-1',
+          rating: 'like',
+        },
+        params: { agent_id: 'agent-1' },
+      })
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['agent-logs'] })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['agent-log-messages'] })
+    expect(mocks.toastSuccess).toHaveBeenCalled()
+  })
+
+  it('keeps feedback disabled for workflow execution messages', async () => {
+    renderPanel(workflowLog, {
+      ...webappMessages,
+      data: [
+        {
+          ...webappMessages.data[0]!,
+          conversation_id: 'execution-1',
+          feedback_enabled: false,
+          feedbacks: [],
+        },
+      ],
+    })
+
+    await screen.findByRole('button', { name: 'submit-feedback' })
+    expect(mocks.chatProps).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({ supportFeedback: false }),
+        chatList: expect.arrayContaining([
+          expect.objectContaining({ feedbackDisabled: true, id: 'message-1' }),
+        ]),
+      }),
+    )
+  })
+})

--- a/web/features/agent-v2/agent-detail/logs/__tests__/log-detail-panel.spec.tsx
+++ b/web/features/agent-v2/agent-detail/logs/__tests__/log-detail-panel.spec.tsx
@@ -29,9 +29,7 @@ vi.mock('@/app/components/base/chat/chat', () => ({
   }) => {
     mocks.chatProps({ chatList, config, onFeedback })
     return (
-      <button
-        onClick={() => void onFeedback?.('message-1', { rating: 'like' })}
-      >
+      <button onClick={() => void onFeedback?.('message-1', { rating: 'like' })}>
         submit-feedback
       </button>
     )

--- a/web/features/agent-v2/agent-detail/logs/__tests__/log-detail-panel.spec.tsx
+++ b/web/features/agent-v2/agent-detail/logs/__tests__/log-detail-panel.spec.tsx
@@ -195,6 +195,18 @@ describe('AgentLogDetailPanel', () => {
     expect(mocks.toastSuccess).toHaveBeenCalled()
   })
 
+  it('reports operator feedback failures without refreshing log queries', async () => {
+    const user = userEvent.setup()
+    mocks.feedbackMutationFn.mockRejectedValue(new Error('feedback request failed'))
+    const { invalidateQueries } = renderPanel(webappLog, webappMessages)
+
+    await user.click(await screen.findByRole('button', { name: 'submit-feedback' }))
+
+    await waitFor(() => expect(mocks.toastError).toHaveBeenCalled())
+    expect(invalidateQueries).not.toHaveBeenCalled()
+    expect(mocks.toastSuccess).not.toHaveBeenCalled()
+  })
+
   it('keeps feedback disabled for workflow execution messages', async () => {
     renderPanel(workflowLog, {
       ...webappMessages,

--- a/web/features/agent-v2/agent-detail/logs/__tests__/page.spec.tsx
+++ b/web/features/agent-v2/agent-detail/logs/__tests__/page.spec.tsx
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   logsQueryFn: vi.fn(),
   logSourcesQueryFn: vi.fn(),
   messagesQueryFn: vi.fn(),
+  feedbackMutationFn: vi.fn(),
   logsQueryOptions: vi.fn((input: AgentLogsQueryInput) => ({
     queryKey: ['agent-logs', input],
     queryFn: () => mocks.logsQueryFn(input),
@@ -34,6 +35,9 @@ const mocks = vi.hoisted(() => ({
   messagesQueryOptions: vi.fn((input: AgentLogsQueryInput) => ({
     queryKey: ['agent-log-messages', input],
     queryFn: () => mocks.messagesQueryFn(input),
+  })),
+  feedbackMutationOptions: vi.fn(() => ({
+    mutationFn: mocks.feedbackMutationFn,
   })),
 }))
 
@@ -57,6 +61,11 @@ vi.mock('@/service/client', () => ({
     },
     agent: {
       byAgentId: {
+        feedbacks: {
+          post: {
+            mutationOptions: mocks.feedbackMutationOptions,
+          },
+        },
         logSources: {
           get: {
             queryOptions: mocks.logSourcesQueryOptions,
@@ -64,11 +73,13 @@ vi.mock('@/service/client', () => ({
         },
         logs: {
           get: {
+            key: () => ['agent-logs'],
             queryOptions: mocks.logsQueryOptions,
           },
           byConversationId: {
             messages: {
               get: {
+                key: () => ['agent-log-messages'],
                 queryOptions: mocks.messagesQueryOptions,
               },
             },
@@ -202,6 +213,8 @@ const messagesResponse: AgentLogMessageListResponse = {
       error: null,
       from_account_id: null,
       from_end_user_id: 'end-user-1',
+      feedback_enabled: true,
+      feedbacks: [],
       id: 'message-1',
       latency: 1.234,
       message_id: 'message-1',
@@ -255,6 +268,7 @@ describe('AgentLogsPage', () => {
     mocks.logsQueryFn.mockResolvedValue(emptyLogsResponse)
     mocks.logSourcesQueryFn.mockResolvedValue(logSourcesResponse)
     mocks.messagesQueryFn.mockResolvedValue(messagesResponse)
+    mocks.feedbackMutationFn.mockResolvedValue({ result: 'success' })
   })
 
   describe('Query contract', () => {

--- a/web/features/agent-v2/agent-detail/logs/components/log-detail-panel.tsx
+++ b/web/features/agent-v2/agent-detail/logs/components/log-detail-panel.tsx
@@ -2,10 +2,11 @@ import type {
   AgentLogConversationItemResponse,
   AgentLogMessageItemResponse,
 } from '@dify/contracts/api/console/agent/types.gen'
-import type { IChatItem } from '@/app/components/base/chat/chat/type'
+import type { FeedbackType, IChatItem } from '@/app/components/base/chat/chat/type'
+import type { ChatConfig } from '@/app/components/base/chat/types'
+import { toast } from '@langgenius/dify-ui/toast'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/tooltip'
-import { skipToken, useQuery } from '@tanstack/react-query'
-import { noop } from 'es-toolkit/function'
+import { skipToken, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import ActionButton from '@/app/components/base/action-button'
 import Chat from '@/app/components/base/chat/chat'
@@ -26,6 +27,10 @@ export function AgentLogDetailPanel({
   const { t } = useTranslation()
   const { t: tAgentV2 } = useTranslation('agentV2')
   const { formatTime } = useTimestamp()
+  const queryClient = useQueryClient()
+  const feedbackMutation = useMutation(
+    consoleQuery.agent.byAgentId.feedbacks.post.mutationOptions(),
+  )
   const messagesQuery = useQuery(
     consoleQuery.agent.byAgentId.logs.byConversationId.messages.get.queryOptions({
       input: log
@@ -56,6 +61,32 @@ export function AgentLogDetailPanel({
         messages: messagesQuery.data?.data ?? [],
       })
     : []
+  const handleFeedback = async (messageId: string, feedback: FeedbackType) => {
+    try {
+      await feedbackMutation.mutateAsync({
+        params: { agent_id: agentId },
+        body: {
+          message_id: messageId,
+          rating: feedback.rating,
+          content: feedback.content,
+        },
+      })
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: consoleQuery.agent.byAgentId.logs.get.key(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: consoleQuery.agent.byAgentId.logs.byConversationId.messages.get.key(),
+        }),
+      ])
+      toast.success(t(($) => $['actionMsg.modifiedSuccessfully'], { ns: 'common' }))
+      return true
+    }
+    catch {
+      toast.error(t(($) => $['actionMsg.modifiedUnsuccessfully'], { ns: 'common' }))
+      return false
+    }
+  }
 
   return (
     <div className="flex h-full flex-col rounded-xl border-[0.5px] border-components-panel-border">
@@ -113,12 +144,18 @@ export function AgentLogDetailPanel({
         {messagesQuery.isSuccess && chatList.length > 0 && (
           <div className="mb-4 pt-4">
             <Chat
+              config={
+                {
+                  supportAnnotation: true,
+                  supportFeedback: log?.source?.type === 'webapp',
+                } as ChatConfig
+              }
               chatList={chatList}
               noChatInput
               hideProcessDetail
               hideLogModal
               chatContainerInnerClassName="px-3"
-              onFeedback={noop}
+              onFeedback={handleFeedback}
             />
           </div>
         )}
@@ -139,6 +176,8 @@ function formatAgentLogMessages({
   const chatList: IChatItem[] = []
 
   messages.forEach((message) => {
+    const userFeedback = message.feedbacks?.find(feedback => feedback.from_source === 'user')
+    const adminFeedback = message.feedbacks?.find(feedback => feedback.from_source === 'admin')
     chatList.push({
       id: `question-${message.id}`,
       content: message.query,
@@ -149,7 +188,9 @@ function formatAgentLogMessages({
       id: message.id,
       content: message.answer || message.error || '',
       conversationId,
-      feedbackDisabled: true,
+      feedback: userFeedback,
+      adminFeedback,
+      feedbackDisabled: !message.feedback_enabled,
       input: {
         inputs: {
           query: message.query,

--- a/web/features/agent-v2/agent-detail/logs/components/log-detail-panel.tsx
+++ b/web/features/agent-v2/agent-detail/logs/components/log-detail-panel.tsx
@@ -81,8 +81,7 @@ export function AgentLogDetailPanel({
       ])
       toast.success(t(($) => $['actionMsg.modifiedSuccessfully'], { ns: 'common' }))
       return true
-    }
-    catch {
+    } catch {
       toast.error(t(($) => $['actionMsg.modifiedUnsuccessfully'], { ns: 'common' }))
       return false
     }
@@ -176,8 +175,8 @@ function formatAgentLogMessages({
   const chatList: IChatItem[] = []
 
   messages.forEach((message) => {
-    const userFeedback = message.feedbacks?.find(feedback => feedback.from_source === 'user')
-    const adminFeedback = message.feedbacks?.find(feedback => feedback.from_source === 'admin')
+    const userFeedback = message.feedbacks?.find((feedback) => feedback.from_source === 'user')
+    const adminFeedback = message.feedbacks?.find((feedback) => feedback.from_source === 'admin')
     chatList.push({
       id: `question-${message.id}`,
       content: message.query,


### PR DESCRIPTION
## Summary

- compute WebApp Agent Log user/admin positive-feedback rates from message feedbacks
- return message-level user/admin feedback in Agent Log detail responses without N+1 queries
- enable operator feedback controls for WebApp logs while keeping Workflow execution logs read-only

## Validation

- `uv run --group dev pytest tests/unit_tests/services/agent/test_agent_observability_service.py` (27 passed)
- targeted Agent Logs Vitest suite (8 passed)
- frontend TypeScript type-check and targeted lint
- Ruff, Pyrefly (changed backend files), and response-contract lint
- deployed revision `a223bd854e` to `deploy/agent` and verified on dev: existing WebApp user feedback reports `user_rate=1.0`; admin feedback create/remove updates and clears `operation_rate`; Workflow logs remain non-rateable

Linear: https://linear.app/dify/issue/DIFY-2854/agent-的-log-好像不正确记录-user-rate