### PR TITLE
fix(api): reserve batch document retries atomically

### DIFF
--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -2099,18 +2099,27 @@ class DocumentService:
 
     @staticmethod
     def retry_document(dataset_id: str, documents: list[Document], session: Session):
-        for document in documents:
-            # add retry flag
-            retry_indexing_cache_key = f"document_{document.id}_is_retried"
-            cache_result = redis_client.get(retry_indexing_cache_key)
-            if cache_result is not None:
-                raise ValueError("Document is being retried, please try again later")
-            # retry document indexing
-            document.indexing_status = IndexingStatus.WAITING
-            session.add(document)
-            session.commit()
+        # Reserve every document before changing any state. Committing one
+        # document as waiting and then finding the next one already retried
+        # would leave the first in waiting with no task ever dispatched.
+        claimed_keys: list[str] = []
+        try:
+            for document in documents:
+                retry_indexing_cache_key = f"document_{document.id}_is_retried"
+                if not redis_client.set(retry_indexing_cache_key, 1, ex=600, nx=True):
+                    raise ValueError("Document is being retried, please try again later")
+                claimed_keys.append(retry_indexing_cache_key)
 
-            redis_client.setex(retry_indexing_cache_key, 600, 1)
+            for document in documents:
+                document.indexing_status = IndexingStatus.WAITING
+                session.add(document)
+            session.commit()
+        except Exception:
+            if claimed_keys:
+                redis_client.delete(*claimed_keys)
+            session.rollback()
+            raise
+
         # trigger async task
         document_ids = [document.id for document in documents]
         if not current_user or not current_user.id:

--- a/api/tests/unit_tests/services/test_dataset_service_document.py
+++ b/api/tests/unit_tests/services/test_dataset_service_document.py
@@ -219,10 +219,53 @@ class TestDocumentServiceMutations:
         session = MagicMock()
 
         with patch("services.dataset_service.redis_client") as mock_redis:
-            mock_redis.get.return_value = "1"
+            # the atomic claim loses the race
+            mock_redis.set.return_value = None
 
             with pytest.raises(ValueError, match="being retried"):
                 DocumentService.retry_document("dataset-1", [document], session)
+
+        session.rollback.assert_called_once()
+        session.commit.assert_not_called()
+
+    def test_retry_document_rolls_back_claims_and_status_when_a_later_document_is_retried(self):
+        first = DatasetServiceUnitDataFactory.create_document_mock(document_id="doc-1")
+        second = DatasetServiceUnitDataFactory.create_document_mock(document_id="doc-2")
+        session = MagicMock()
+
+        with patch("services.dataset_service.redis_client") as mock_redis:
+            # doc-1 claims fine, doc-2 is already being retried
+            mock_redis.set.side_effect = [True, None]
+
+            with pytest.raises(ValueError, match="being retried"):
+                DocumentService.retry_document("dataset-1", [first, second], session)
+
+        # doc-1's flag is released and nothing was committed as waiting
+        mock_redis.delete.assert_called_once_with("document_doc-1_is_retried")
+        session.rollback.assert_called_once()
+        session.commit.assert_not_called()
+        assert first.indexing_status != "waiting"
+
+    def test_retry_document_commits_all_and_dispatches_when_batch_is_free(self):
+        first = DatasetServiceUnitDataFactory.create_document_mock(document_id="doc-1")
+        second = DatasetServiceUnitDataFactory.create_document_mock(document_id="doc-2")
+        session = MagicMock()
+
+        with (
+            patch("services.dataset_service.redis_client") as mock_redis,
+            patch("services.dataset_service.retry_document_indexing_task") as retry_task,
+            patch("services.dataset_service.current_user") as mock_user,
+        ):
+            mock_redis.set.return_value = True
+            mock_user.id = "user-1"
+
+            DocumentService.retry_document("dataset-1", [first, second], session)
+
+        assert first.indexing_status == "waiting"
+        assert second.indexing_status == "waiting"
+        session.commit.assert_called_once()
+        mock_redis.delete.assert_not_called()
+        retry_task.delay.assert_called_once_with("dataset-1", ["doc-1", "doc-2"], "user-1")
 
     def test_sync_website_document_raises_when_sync_flag_exists(self):
         document = DatasetServiceUnitDataFactory.create_document_mock(document_id="doc-1")


### PR DESCRIPTION
Fixes #39975.

`retry_document` committed each document as `waiting` one at a time and only then checked the next document's retry flag. A batch where a later document was already being retried raised mid-loop and left the earlier documents in `waiting` with no indexing task ever dispatched, since the task goes out only after the loop. The flag check itself was a separate GET followed by SETEX, so two concurrent retry requests for the same document could both pass.

The method now claims every flag atomically with SET NX up front, commits all statuses in one transaction, and releases the claimed flags plus rolls back on any failure, so a partially-retryable batch changes nothing at all.

## Verification

Three unit tests in `test_dataset_service_document.py`: a lost atomic claim rejects without any commit, a mid-batch claim failure releases the earlier claim and leaves the first document untouched, and a free batch commits all documents once and dispatches the task. Full file: 80 passed with the repo conftest.

From Kimi Code
