### PR TITLE
fix(e2e): configure sandbox-reachable API URL

### DIFF
--- a/e2e/scripts/setup.ts
+++ b/e2e/scripts/setup.ts
@@ -31,7 +31,8 @@ import './env-register'
 
 const buildIdPath = path.join(webDir, '.next', 'BUILD_ID')
 const webBuildStampPath = path.join(webDir, '.next', 'e2e-web-build.sha256')
-const apiHost = '127.0.0.1'
+const apiLoopbackHost = '127.0.0.1'
+const apiBindHost = '0.0.0.0'
 const apiPort = 5001
 const agentBackendHost = '127.0.0.1'
 const agentBackendBindHost = '0.0.0.0'
@@ -42,6 +43,7 @@ const shellctlContainerName = process.env.E2E_SHELLCTL_CONTAINER_NAME || 'dify-a
 const shellctlImage = process.env.E2E_SHELLCTL_IMAGE || 'dify-agent-local-sandbox:e2e'
 const shellctlUrl = `http://${shellctlHost}:${shellctlPort}`
 const agentStubApiBaseUrl = `http://host.docker.internal:${agentBackendPort}/agent-stub`
+const sandboxFilesBaseUrl = `http://host.docker.internal:${apiPort}`
 const defaultPluginDaemonKey = 'lYkiYYT6owG+71oLerGzA7GXCgOT++6ovaezWAjpCjf+Sjc3ZtU+qUEi'
 const defaultInnerApiKeyForPlugin = 'QaHbTe77CtuXmsfyhR7+vRjI/+XbV1AaFy691iy+kGDv2Jvy0/eAh8Y1'
 const defaultAgentServerSecretKey = 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY'
@@ -104,7 +106,7 @@ function getAgentBackendBaseUrl() {
   return undefined
 }
 
-const getAgentBackendEnvironment = async () => {
+export const getAgentBackendEnvironment = async () => {
   const apiEnv = await getApiEnvironment()
   const redisPassword = process.env.REDIS_PASSWORD || apiEnv.REDIS_PASSWORD || 'difyai123456'
 
@@ -116,7 +118,9 @@ const getAgentBackendEnvironment = async () => {
       apiEnv.INNER_API_KEY_FOR_PLUGIN ||
       defaultInnerApiKeyForPlugin,
     DIFY_AGENT_INNER_API_URL:
-      process.env.DIFY_AGENT_INNER_API_URL || `http://${apiHost}:${apiPort}`,
+      process.env.DIFY_AGENT_INNER_API_URL || `http://${apiLoopbackHost}:${apiPort}`,
+    DIFY_AGENT_SANDBOX_FILES_BASE_URL:
+      process.env.DIFY_AGENT_SANDBOX_FILES_BASE_URL || sandboxFilesBaseUrl,
     DIFY_AGENT_SERVER_SECRET_KEY:
       process.env.DIFY_AGENT_SERVER_SECRET_KEY || defaultAgentServerSecretKey,
     DIFY_AGENT_STUB_API_BASE_URL: process.env.DIFY_AGENT_STUB_API_BASE_URL || agentStubApiBaseUrl,
@@ -304,12 +308,12 @@ export const startWeb = async () => {
 }
 
 export const startApi = async () => {
-  if (await isTcpPortReachable(apiHost, apiPort)) {
+  if (await isTcpPortReachable(apiLoopbackHost, apiPort)) {
     const listenerDescription = await getTcpPortListenerDescription(apiPort)
     const listenerMessage = listenerDescription ? `\n\nPort listener:\n${listenerDescription}` : ''
 
     throw new Error(
-      `Cannot start the E2E API server because ${apiHost}:${apiPort} is already in use.${listenerMessage}`,
+      `Cannot start the E2E API server because ${apiLoopbackHost}:${apiPort} is already in use.${listenerMessage}`,
     )
   }
 
@@ -332,7 +336,7 @@ export const startApi = async () => {
       'flask',
       'run',
       '--host',
-      apiHost,
+      apiBindHost,
       '--port',
       String(apiPort),
     ],

--- a/e2e/tests/managed-runtime-environment.test.ts
+++ b/e2e/tests/managed-runtime-environment.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getAgentBackendEnvironment } from '../scripts/setup'
+
+describe('managed runtime environment', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('uses separate host and Sandbox API addresses', async () => {
+    vi.stubEnv('DIFY_AGENT_INNER_API_URL', '')
+    vi.stubEnv('DIFY_AGENT_SANDBOX_FILES_BASE_URL', '')
+
+    await expect(getAgentBackendEnvironment()).resolves.toMatchObject({
+      DIFY_AGENT_INNER_API_URL: 'http://127.0.0.1:5001',
+      DIFY_AGENT_SANDBOX_FILES_BASE_URL: 'http://host.docker.internal:5001',
+    })
+  })
+
+  it('preserves an explicit Sandbox-reachable API address', async () => {
+    vi.stubEnv('DIFY_AGENT_SANDBOX_FILES_BASE_URL', 'https://dify.example.test/base')
+
+    await expect(getAgentBackendEnvironment()).resolves.toMatchObject({
+      DIFY_AGENT_SANDBOX_FILES_BASE_URL: 'https://dify.example.test/base',
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- pass the formal `DIFY_AGENT_SANDBOX_FILES_BASE_URL` setting to the managed Agent backend
- keep host-side inner API calls on loopback while giving Sandbox file transfers a Docker host-gateway URL
- bind the managed API server to `0.0.0.0` so the Sandbox container can reach the host without changing host-side probes
- cover the managed runtime defaults and the explicit deployment override at the environment owner

## Root cause

#39952 split Agent file URL audiences into the host-side `DIFY_AGENT_INNER_API_URL` control plane and the Sandbox-visible `DIFY_AGENT_SANDBOX_FILES_BASE_URL` data plane. Docker Compose was updated, but the managed E2E runtime still injected only the older Agent settings.

The post-merge external-runtime lane therefore started the Agent Stub with an inner API key and public Stub URL but without the required Sandbox files base URL. `ServerSettings` rejected the configuration before any Cucumber scenario started.

This change keeps the network owners explicit:

- Agent backend to API: `http://127.0.0.1:5001`
- Sandbox to signed `/files/*` endpoints: `http://host.docker.internal:5001`
- API bind address for container ingress: `0.0.0.0`

It does not add an E2E-specific alias or duplicate the setting in workflow YAML.

## Validation

- `vp run test:unit` — 10 files, 46 tests passed
- `vp check e2e` — formatting, lint, and type checks passed
- `git diff --check`
- constructed `dify_agent.server.settings.ServerSettings` with the managed runtime values

The credentialed post-merge external-runtime suite was not run locally because it owns a full E2E reset and external provider credentials; CI remains the integration proof for Docker host-gateway reachability.

Related failure: https://github.com/langgenius/dify/actions/runs/30919039854/job/92024738258
