### PR TITLE
fix(ci): harden Playwright browser installs

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -50,9 +50,17 @@ jobs:
         working-directory: ./e2e
         run: vp run test:unit
 
-      - name: Install Playwright browser
+      - name: Install Playwright browsers for core E2E
+        if: ${{ !inputs.run-external-runtime }}
+        timeout-minutes: 15
         working-directory: ./e2e
-        run: vp run e2e:install
+        run: vp run e2e:install:ci
+
+      - name: Install Chromium for external runtime E2E
+        if: ${{ inputs.run-external-runtime }}
+        timeout-minutes: 15
+        working-directory: ./e2e
+        run: vp run e2e:install:ci:chromium
 
       - name: Run isolated source-api and built-web Cucumber E2E tests
         if: ${{ !inputs.run-external-runtime }}

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -91,6 +91,7 @@ jobs:
   dify-ui-test:
     name: dify-ui Tests
     runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 20
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     defaults:
@@ -108,7 +109,8 @@ jobs:
         uses: ./.github/actions/setup-web
 
       - name: Install Chromium for Browser Mode
-        run: vp exec playwright install --with-deps chromium
+        timeout-minutes: 15
+        run: vp exec playwright install --with-deps --only-shell chromium
 
       - name: Run dify-ui tests
         run: vp test run --project unit --coverage --silent=passed-only
@@ -125,6 +127,7 @@ jobs:
   dify-ui-storybook-test:
     name: dify-ui Storybook Tests
     runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 20
     defaults:
       run:
         shell: bash
@@ -140,7 +143,8 @@ jobs:
         uses: ./.github/actions/setup-web
 
       - name: Install Chromium for Browser Mode
-        run: vp exec playwright install --with-deps chromium
+        timeout-minutes: 15
+        run: vp exec playwright install --with-deps --only-shell chromium
 
       - name: Run dify-ui Storybook tests
         run: vp run test:storybook

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -10,6 +10,8 @@
     "e2e:full:headed": "tsx ./scripts/run-cucumber.ts --full --headed",
     "e2e:headed": "tsx ./scripts/run-cucumber.ts --headed",
     "e2e:install": "playwright install --with-deps chromium webkit",
+    "e2e:install:ci": "playwright install --with-deps --only-shell chromium webkit",
+    "e2e:install:ci:chromium": "playwright install --with-deps --only-shell chromium",
     "e2e:middleware:down": "tsx ./scripts/setup.ts middleware-down",
     "e2e:middleware:up": "tsx ./scripts/setup.ts middleware-up",
     "e2e:post-merge": "tsx ./scripts/run-post-merge.ts",


### PR DESCRIPTION
## Summary

- add CI-only Playwright install commands that keep local headed browser installs unchanged
- install Chromium and WebKit for core E2E, but only Chromium for external-runtime E2E
- install only Chromium Headless Shell in headless CI jobs
- bound Playwright install steps to 15 minutes and Dify UI browser jobs to 20 minutes

## Why

Web-related CI currently installs Chromium in three isolated jobs and also installs WebKit for external-runtime E2E even though that lane only runs Chromium. When browser or system dependency downloads degrade, the duplicated unbounded work turns a download incident into long-lived runners and delayed required checks.

## Validation

- `vp check e2e`
- `vp run --filter dify-e2e test:unit` (46 tests passed)
- Playwright `install --dry-run` for both CI browser sets
- actionlint v1.7.12 on the changed workflows, ignoring only the repository's custom Depot runner labels
- JSON parse and `git diff --check`
