### PR TITLE
fix(ci): make web workflows reproducible

### DIFF
--- a/.github/actions/setup-web/action.yml
+++ b/.github/actions/setup-web/action.yml
@@ -11,6 +11,7 @@ runs:
     - name: Setup Vite+
       uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
       with:
+        version: 0.2.6
         node-version-file: .nvmrc
         cache: true
         run-install: true

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -15,7 +15,7 @@ permissions:
   statuses: write
 
 concurrency:
-  group: main-ci-${{ github.head_ref || github.run_id }}
+  group: main-ci-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -89,6 +89,7 @@ jobs:
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
               - '.nvmrc'
+              - '.github/workflows/main-ci.yml'
               - '.github/workflows/web-tests.yml'
               - '.github/actions/setup-web/**'
             e2e:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -8,7 +8,7 @@ on:
         type: string
 
 concurrency:
-  group: style-${{ github.head_ref || github.run_id }}
+  group: style-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -7,10 +7,6 @@ on:
         required: true
         type: string
 
-concurrency:
-  group: style-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.run_id }}
-  cancel-in-progress: true
-
 permissions:
   checks: write
   statuses: write

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -11,10 +11,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: web-e2e-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   test:
     name: Web Full-Stack E2E

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: web-e2e-${{ github.head_ref || github.run_id }}
+  group: web-e2e-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -9,10 +9,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: web-tests-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   test:
     name: Web Tests (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: web-tests-${{ github.head_ref || github.run_id }}
+  group: web-tests-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

- pin the Vite+ bootstrap version to the workspace's `0.2.6` catalog version
- make changes to `main-ci.yml` trigger Web Tests
- key Main CI concurrency by pull request number and merge queue runs by merge-group SHA
- keep cancellation ownership in the caller instead of duplicating it across reusable workflows

## Why

The pinned `setup-vp` action otherwise installs a floating `latest` Vite+ CLI, so CI tooling can change without a repository update. The Web path filter also omitted its caller workflow, and branch-name-only concurrency groups can collide across pull requests from different forks that use the same branch name. Reusable workflows run as part of their caller, so they do not need separate cancellation groups on top of Main CI's concurrency policy.

## Validation

- actionlint v1.7.12 on all changed workflows, ignoring only the repository's custom Depot runner labels
- YAML parse for the changed action and workflows
- verified the pinned Vite+ version matches `pnpm-workspace.yaml`
- `git diff --check`
