### PR TITLE
refactor(web): remove duplicate dataset title update

### DIFF
--- a/web/app/components/datasets/list/__tests__/datasets.spec.tsx
+++ b/web/app/components/datasets/list/__tests__/datasets.spec.tsx
@@ -1,6 +1,6 @@
 import type { DataSet, DataSetListResponse } from '@/models/datasets'
 import type { useDatasetList } from '@/service/knowledge/use-dataset'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { IndexingType } from '@/app/components/datasets/create/step-two'
 import { STEP_BY_STEP_TOUR_TARGETS } from '@/app/components/step-by-step-tour/target-registry'
@@ -185,7 +185,6 @@ describe('Datasets', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     intersectionObserverCallback = null
-    document.title = ''
     vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
   })
 
@@ -246,15 +245,6 @@ describe('Datasets', () => {
       render(<Datasets {...defaultProps} />)
       const anchor = document.querySelector('.h-0')
       expect(anchor).toBeInTheDocument()
-    })
-  })
-
-  describe('Document Title', () => {
-    it('should set document title on mount', async () => {
-      render(<Datasets {...defaultProps} />)
-      await waitFor(() => {
-        expect(document.title).toContain('dataset.knowledge')
-      })
     })
   })
 

--- a/web/app/components/datasets/list/datasets.tsx
+++ b/web/app/components/datasets/list/datasets.tsx
@@ -48,10 +48,6 @@ const Datasets = ({
     !isFetchingNextPage && (isLoading || (isPlaceholderData && isFetching && datasets.length === 0))
 
   useEffect(() => {
-    document.title = `${t(($) => $.knowledge, { ns: 'dataset' })} - Dify`
-  }, [t])
-
-  useEffect(() => {
     if (anchorRef.current) {
       observerRef.current = new IntersectionObserver(
         (entries) => {


### PR DESCRIPTION
## Summary

- remove the dataset list child component's direct `document.title` update
- keep document title ownership in the existing dataset list entrypoint
- remove the child-level test that encoded the duplicate ownership

## Why

The dataset list entrypoint already updates the document title through `useDocumentTitle`, including custom branding. The child list component repeated that side effect with a hard-coded `Dify` suffix, creating two competing owners for the same global browser state.

## Validation

- `vp test run app/components/datasets/list/__tests__/datasets.spec.tsx` (23 tests passed)
- `vp test run app/components/datasets/list/__tests__` (58 tests passed)
- `vp check web/app/components/datasets/list/datasets.tsx web/app/components/datasets/list/__tests__/datasets.spec.tsx`
- `git diff --check`

The repository-wide `vp check` remains blocked by an existing formatting issue in `packages/dify-ui/src/dialog/index.tsx` on `main`; this PR does not modify that file.