### PR TITLE
refactor(web): derive system feature enums from schemas

### DIFF
--- a/web/app/(shareLayout)/webapp-signin/normalForm.tsx
+++ b/web/app/(shareLayout)/webapp-signin/normalForm.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { zLicenseStatus } from '@dify/contracts/api/console/system-features/zod.gen'
 import { cn } from '@langgenius/dify-ui/cn'
 import { RiContractLine, RiDoorLockLine, RiErrorWarningFill } from '@remixicon/react'
 import { useSuspenseQuery } from '@tanstack/react-query'
@@ -7,7 +8,6 @@ import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Loading from '@/app/components/base/loading'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
-import { LicenseStatus } from '@/features/system-features/constants'
 import Link from '@/next/link'
 import MailAndCodeAuth from './components/mail-and-code-auth'
 import MailAndPasswordAuth from './components/mail-and-password-auth'
@@ -57,7 +57,7 @@ const NormalForm = () => {
       </div>
     )
   }
-  if (systemFeatures.license?.status === LicenseStatus.LOST) {
+  if (systemFeatures.license?.status === zLicenseStatus.enum.lost) {
     return (
       <div className="mx-auto mt-8 w-full">
         <div className="relative">
@@ -77,7 +77,7 @@ const NormalForm = () => {
       </div>
     )
   }
-  if (systemFeatures.license?.status === LicenseStatus.EXPIRED) {
+  if (systemFeatures.license?.status === zLicenseStatus.enum.expired) {
     return (
       <div className="mx-auto mt-8 w-full">
         <div className="relative">
@@ -97,7 +97,7 @@ const NormalForm = () => {
       </div>
     )
   }
-  if (systemFeatures.license?.status === LicenseStatus.INACTIVE) {
+  if (systemFeatures.license?.status === zLicenseStatus.enum.inactive) {
     return (
       <div className="mx-auto mt-8 w-full">
         <div className="relative">

--- a/web/app/components/header/license-env/__tests__/index.spec.tsx
+++ b/web/app/components/header/license-env/__tests__/index.spec.tsx
@@ -1,6 +1,6 @@
+import { zLicenseStatus } from '@dify/contracts/api/console/system-features/zod.gen'
 import { screen } from '@testing-library/react'
 import dayjs from 'dayjs'
-import { LicenseStatus } from '@/features/system-features/constants'
 import { consoleQuery } from '@/service/client'
 import {
   createConsoleQueryClient,
@@ -44,27 +44,27 @@ describe('LicenseNav', () => {
   })
 
   it('should render Enterprise badge when license status is ACTIVE', () => {
-    renderLicenseNav({ status: LicenseStatus.ACTIVE })
+    renderLicenseNav({ status: zLicenseStatus.enum.active })
     expect(screen.getByText('Enterprise')).toBeInTheDocument()
   })
 
   it('should render singular expiring message when license expires in 0 days', () => {
     const expiredAt = dayjs().add(2, 'hours').toISOString()
-    renderLicenseNav({ status: LicenseStatus.EXPIRING, expired_at: expiredAt })
+    renderLicenseNav({ status: zLicenseStatus.enum.expiring, expired_at: expiredAt })
     expect(screen.getByText(/license\.expiring/)).toBeInTheDocument()
     expect(screen.getByText(/count":0/)).toBeInTheDocument()
   })
 
   it('should render singular expiring message when license expires in 1 day', () => {
     const tomorrow = dayjs().add(1, 'day').add(1, 'hour').toISOString()
-    renderLicenseNav({ status: LicenseStatus.EXPIRING, expired_at: tomorrow })
+    renderLicenseNav({ status: zLicenseStatus.enum.expiring, expired_at: tomorrow })
     expect(screen.getByText(/license\.expiring/)).toBeInTheDocument()
     expect(screen.getByText(/count":1/)).toBeInTheDocument()
   })
 
   it('should render plural expiring message when license expires in 5 days', () => {
     const fiveDaysLater = dayjs().add(5, 'day').add(1, 'hour').toISOString()
-    renderLicenseNav({ status: LicenseStatus.EXPIRING, expired_at: fiveDaysLater })
+    renderLicenseNav({ status: zLicenseStatus.enum.expiring, expired_at: fiveDaysLater })
     expect(screen.getByText(/license\.expiring_plural/)).toBeInTheDocument()
     expect(screen.getByText(/count":5/)).toBeInTheDocument()
   })

--- a/web/app/components/header/license-env/index.tsx
+++ b/web/app/components/header/license-env/index.tsx
@@ -1,9 +1,9 @@
 'use client'
 
+import { zLicenseStatus } from '@dify/contracts/api/console/system-features/zod.gen'
 import { useQuery } from '@tanstack/react-query'
 import dayjs from 'dayjs'
 import { useTranslation } from 'react-i18next'
-import { LicenseStatus } from '@/features/system-features/constants'
 import { consoleQuery } from '@/service/client'
 import PremiumBadge from '../../base/premium-badge'
 
@@ -11,7 +11,7 @@ function LicenseNav() {
   const { t } = useTranslation()
   const { data: license } = useQuery(consoleQuery.systemFeatures.license.get.queryOptions())
 
-  if (license?.status === LicenseStatus.EXPIRING) {
+  if (license?.status === zLicenseStatus.enum.expiring) {
     const count = dayjs(license.expired_at).diff(dayjs(), 'days')
     return (
       <PremiumBadge color="orange" className="select-none">
@@ -34,7 +34,7 @@ function LicenseNav() {
       </PremiumBadge>
     )
   }
-  if (license?.status === LicenseStatus.ACTIVE) {
+  if (license?.status === zLicenseStatus.enum.active) {
     return (
       <PremiumBadge color="indigo" className="select-none">
         <span className="px-1 system-xs-medium">Enterprise</span>

--- a/web/app/components/main-nav/components/__tests__/workspace-card.spec.tsx
+++ b/web/app/components/main-nav/components/__tests__/workspace-card.spec.tsx
@@ -2,13 +2,13 @@ import type { PostWorkspacesCurrentResponse } from '@dify/contracts/api/console/
 import type { ModalContextState } from '@/context/modal-context'
 import type { ProviderContextState } from '@/context/provider-context'
 import type { IWorkspace } from '@/models/common'
+import { zLicenseStatus } from '@dify/contracts/api/console/system-features/zod.gen'
 import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Plan } from '@/app/components/billing/type'
 import { ACCOUNT_SETTING_TAB } from '@/app/components/header/account-setting/constants'
 import { useModalContext } from '@/context/modal-context'
 import { useProviderContext } from '@/context/provider-context'
-import { LicenseStatus } from '@/features/system-features/constants'
 import { consoleQuery } from '@/service/client'
 import {
   createConsoleQueryClient,
@@ -321,7 +321,7 @@ describe('WorkspaceCard', () => {
         deployment_edition: 'ENTERPRISE',
       },
       systemFeaturesLicense: {
-        status: LicenseStatus.ACTIVE,
+        status: zLicenseStatus.enum.active,
       },
     })
 

--- a/web/app/components/plugins/install-plugin/hooks/__tests__/use-install-plugin-limit.spec.ts
+++ b/web/app/components/plugins/install-plugin/hooks/__tests__/use-install-plugin-limit.spec.ts
@@ -1,6 +1,6 @@
 import type { PluginInstallationScope } from '@dify/contracts/api/console/system-features/types.gen'
+import { zPluginInstallationScope } from '@dify/contracts/api/console/system-features/zod.gen'
 import { describe, expect, it } from 'vitest'
-import { InstallationScope } from '@/features/system-features/constants'
 import { renderHookWithConsoleQuery as renderHook } from '@/test/console/query-data'
 import { pluginInstallLimit } from '../use-install-plugin-limit'
 
@@ -26,25 +26,25 @@ function makeSystemFeatures(
 
 describe('pluginInstallLimit', () => {
   it('should allow all plugins when scope is ALL', () => {
-    const features = makeSystemFeatures(InstallationScope.ALL)
+    const features = makeSystemFeatures(zPluginInstallationScope.enum.all)
 
     expect(pluginInstallLimit(basePlugin, features).canInstall).toBe(true)
   })
 
   it('should deny all plugins when scope is NONE', () => {
-    const features = makeSystemFeatures(InstallationScope.NONE)
+    const features = makeSystemFeatures(zPluginInstallationScope.enum.none)
 
     expect(pluginInstallLimit(basePlugin, features).canInstall).toBe(false)
   })
 
   it('should allow langgenius plugins when scope is OFFICIAL_ONLY', () => {
-    const features = makeSystemFeatures(InstallationScope.OFFICIAL_ONLY)
+    const features = makeSystemFeatures(zPluginInstallationScope.enum.official_only)
 
     expect(pluginInstallLimit(basePlugin, features).canInstall).toBe(true)
   })
 
   it('should deny non-official plugins when scope is OFFICIAL_ONLY', () => {
-    const features = makeSystemFeatures(InstallationScope.OFFICIAL_ONLY)
+    const features = makeSystemFeatures(zPluginInstallationScope.enum.official_only)
     const plugin = {
       ...basePlugin,
       verification: { authorized_category: 'community' as const },
@@ -54,7 +54,9 @@ describe('pluginInstallLimit', () => {
   })
 
   it('should allow partner plugins when scope is OFFICIAL_AND_PARTNER', () => {
-    const features = makeSystemFeatures(InstallationScope.OFFICIAL_AND_PARTNER)
+    const features = makeSystemFeatures(
+      zPluginInstallationScope.enum.official_and_specific_partners,
+    )
     const plugin = {
       ...basePlugin,
       verification: { authorized_category: 'partner' as const },
@@ -64,27 +66,27 @@ describe('pluginInstallLimit', () => {
   })
 
   it('should deny github plugins when restrict_to_marketplace_only is true', () => {
-    const features = makeSystemFeatures(InstallationScope.ALL, true)
+    const features = makeSystemFeatures(zPluginInstallationScope.enum.all, true)
     const plugin = { ...basePlugin, from: 'github' as const } satisfies PluginInstallCandidate
 
     expect(pluginInstallLimit(plugin, features).canInstall).toBe(false)
   })
 
   it('should deny package plugins when restrict_to_marketplace_only is true', () => {
-    const features = makeSystemFeatures(InstallationScope.ALL, true)
+    const features = makeSystemFeatures(zPluginInstallationScope.enum.all, true)
     const plugin = { ...basePlugin, from: 'package' as const } satisfies PluginInstallCandidate
 
     expect(pluginInstallLimit(plugin, features).canInstall).toBe(false)
   })
 
   it('should allow marketplace plugins even when restrict_to_marketplace_only is true', () => {
-    const features = makeSystemFeatures(InstallationScope.ALL, true)
+    const features = makeSystemFeatures(zPluginInstallationScope.enum.all, true)
 
     expect(pluginInstallLimit(basePlugin, features).canInstall).toBe(true)
   })
 
   it('should default to langgenius when no verification info', () => {
-    const features = makeSystemFeatures(InstallationScope.OFFICIAL_ONLY)
+    const features = makeSystemFeatures(zPluginInstallationScope.enum.official_only)
     const plugin = { from: 'marketplace' as const } satisfies PluginInstallCandidate
 
     expect(pluginInstallLimit(plugin, features).canInstall).toBe(true)

--- a/web/app/components/plugins/install-plugin/hooks/use-install-plugin-limit.tsx
+++ b/web/app/components/plugins/install-plugin/hooks/use-install-plugin-limit.tsx
@@ -3,9 +3,9 @@ import type {
   PluginBundleDependencyType,
   PluginVerification,
 } from '@dify/contracts/api/console/workspaces/types.gen'
+import { zPluginInstallationScope } from '@dify/contracts/api/console/system-features/zod.gen'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
-import { InstallationScope } from '@/features/system-features/constants'
 
 type PluginInstallCandidate = {
   from: PluginBundleDependencyType
@@ -32,13 +32,13 @@ export function pluginInstallLimit(
   const scope = permission.plugin_installation_scope
 
   switch (scope) {
-    case InstallationScope.ALL:
+    case zPluginInstallationScope.enum.all:
       return { canInstall: true }
-    case InstallationScope.NONE:
+    case zPluginInstallationScope.enum.none:
       return { canInstall: false }
-    case InstallationScope.OFFICIAL_ONLY:
+    case zPluginInstallationScope.enum.official_only:
       return { canInstall: authorizedCategory === 'langgenius' }
-    case InstallationScope.OFFICIAL_AND_PARTNER:
+    case zPluginInstallationScope.enum.official_and_specific_partners:
       return {
         canInstall: authorizedCategory === 'langgenius' || authorizedCategory === 'partner',
       }

--- a/web/app/components/plugins/plugin-page/empty/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/plugin-page/empty/__tests__/index.spec.tsx
@@ -1,13 +1,13 @@
 import type { GetSystemFeaturesResponse } from '@dify/contracts/api/console/system-features/types.gen'
 import type { ReactElement } from 'react'
 import type { FilterState } from '../../filter-management'
+import { zPluginInstallationScope } from '@dify/contracts/api/console/system-features/zod.gen'
 import { act, fireEvent, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   getStepByStepTourTargetSelector,
   STEP_BY_STEP_TOUR_TARGETS,
 } from '@/app/components/step-by-step-tour/target-registry'
-import { InstallationScope } from '@/features/system-features/constants'
 import { renderWithConsoleQuery } from '@/test/console/query-data'
 // ==================== Imports (after mocks) ====================
 import Empty from '../index'
@@ -99,7 +99,7 @@ const resetMockState = () => {
   mockState.systemFeatures = {
     enable_marketplace: true,
     plugin_installation_permission: {
-      plugin_installation_scope: InstallationScope.ALL,
+      plugin_installation_scope: zPluginInstallationScope.enum.all,
       restrict_to_marketplace_only: false,
     },
   }
@@ -328,7 +328,7 @@ describe('Empty Component', () => {
       setMockSystemFeatures({
         enable_marketplace: true,
         plugin_installation_permission: {
-          plugin_installation_scope: InstallationScope.ALL,
+          plugin_installation_scope: zPluginInstallationScope.enum.all,
           restrict_to_marketplace_only: false,
         },
       })
@@ -356,7 +356,7 @@ describe('Empty Component', () => {
       setMockSystemFeatures({
         enable_marketplace: true,
         plugin_installation_permission: {
-          plugin_installation_scope: InstallationScope.ALL,
+          plugin_installation_scope: zPluginInstallationScope.enum.all,
           restrict_to_marketplace_only: true,
         },
       })
@@ -378,7 +378,7 @@ describe('Empty Component', () => {
       setMockSystemFeatures({
         enable_marketplace: false,
         plugin_installation_permission: {
-          plugin_installation_scope: InstallationScope.ALL,
+          plugin_installation_scope: zPluginInstallationScope.enum.all,
           restrict_to_marketplace_only: false,
         },
       })
@@ -400,7 +400,7 @@ describe('Empty Component', () => {
       setMockSystemFeatures({
         enable_marketplace: false,
         plugin_installation_permission: {
-          plugin_installation_scope: InstallationScope.ALL,
+          plugin_installation_scope: zPluginInstallationScope.enum.all,
           restrict_to_marketplace_only: true,
         },
       })
@@ -611,7 +611,7 @@ describe('Empty Component', () => {
       setMockSystemFeatures({
         enable_marketplace: true,
         plugin_installation_permission: {
-          plugin_installation_scope: InstallationScope.ALL,
+          plugin_installation_scope: zPluginInstallationScope.enum.all,
           restrict_to_marketplace_only: false,
         },
       })
@@ -625,7 +625,7 @@ describe('Empty Component', () => {
       setMockSystemFeatures({
         enable_marketplace: true,
         plugin_installation_permission: {
-          plugin_installation_scope: InstallationScope.ALL,
+          plugin_installation_scope: zPluginInstallationScope.enum.all,
           restrict_to_marketplace_only: true,
         },
       })

--- a/web/app/signin/normal-form.tsx
+++ b/web/app/signin/normal-form.tsx
@@ -1,3 +1,4 @@
+import { zLicenseStatus } from '@dify/contracts/api/console/system-features/zod.gen'
 import { cn } from '@langgenius/dify-ui/cn'
 import { toast } from '@langgenius/dify-ui/toast'
 import { RiContractLine, RiDoorLockLine, RiErrorWarningFill } from '@remixicon/react'
@@ -6,7 +7,6 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { isLegacyBase401, userProfileQueryOptions } from '@/features/account-profile/client'
 import { systemFeaturesQueryOptions } from '@/features/system-features/client'
-import { LicenseStatus } from '@/features/system-features/constants'
 import Link from '@/next/link'
 import { useRouter, useSearchParams } from '@/next/navigation'
 import { invitationCheck } from '@/service/common'
@@ -119,7 +119,7 @@ function NormalForm() {
       </div>
     )
   }
-  if (systemFeatures.license?.status === LicenseStatus.LOST) {
+  if (systemFeatures.license?.status === zLicenseStatus.enum.lost) {
     return (
       <div className="mx-auto mt-8 w-full">
         <div className="relative">
@@ -139,7 +139,7 @@ function NormalForm() {
       </div>
     )
   }
-  if (systemFeatures.license?.status === LicenseStatus.EXPIRED) {
+  if (systemFeatures.license?.status === zLicenseStatus.enum.expired) {
     return (
       <div className="mx-auto mt-8 w-full">
         <div className="relative">
@@ -159,7 +159,7 @@ function NormalForm() {
       </div>
     )
   }
-  if (systemFeatures.license?.status === LicenseStatus.INACTIVE) {
+  if (systemFeatures.license?.status === zLicenseStatus.enum.inactive) {
     return (
       <div className="mx-auto mt-8 w-full">
         <div className="relative">

--- a/web/features/system-features/constants.ts
+++ b/web/features/system-features/constants.ts
@@ -1,26 +1,5 @@
-import type { GetSystemFeaturesResponse } from '@dify/contracts/api/console/system-features/types.gen'
-
 export const SSOProtocol = {
   SAML: 'saml',
   OIDC: 'oidc',
   OAuth2: 'oauth2',
 } as const
-
-export const LicenseStatus = {
-  NONE: 'none',
-  INACTIVE: 'inactive',
-  ACTIVE: 'active',
-  EXPIRING: 'expiring',
-  EXPIRED: 'expired',
-  LOST: 'lost',
-} as const satisfies Record<string, GetSystemFeaturesResponse['license']['status']>
-
-export const InstallationScope = {
-  ALL: 'all',
-  NONE: 'none',
-  OFFICIAL_ONLY: 'official_only',
-  OFFICIAL_AND_PARTNER: 'official_and_specific_partners',
-} as const satisfies Record<
-  string,
-  GetSystemFeaturesResponse['plugin_installation_permission']['plugin_installation_scope']
->

--- a/web/test/console/system-features.ts
+++ b/web/test/console/system-features.ts
@@ -2,7 +2,10 @@ import type {
   GetSystemFeaturesLicenseResponse,
   GetSystemFeaturesResponse,
 } from '@dify/contracts/api/console/system-features/types.gen'
-import { InstallationScope, LicenseStatus } from '@/features/system-features/constants'
+import {
+  zLicenseStatus,
+  zPluginInstallationScope,
+} from '@dify/contracts/api/console/system-features/zod.gen'
 
 export type DeepPartial<T> =
   T extends Array<infer U>
@@ -25,7 +28,7 @@ const baseSystemFeatures = {
   is_email_setup: false,
   enable_change_email: true,
   license: {
-    status: LicenseStatus.NONE,
+    status: zLicenseStatus.enum.none,
   },
   branding: {
     enabled: false,
@@ -45,7 +48,7 @@ const baseSystemFeatures = {
     allow_public_access: true,
   },
   plugin_installation_permission: {
-    plugin_installation_scope: InstallationScope.ALL,
+    plugin_installation_scope: zPluginInstallationScope.enum.all,
     restrict_to_marketplace_only: false,
   },
   rbac_enabled: false,
@@ -57,7 +60,7 @@ const baseSystemFeatures = {
 } satisfies GetSystemFeaturesResponse
 
 const baseSystemFeaturesLicense = {
-  status: LicenseStatus.NONE,
+  status: zLicenseStatus.enum.none,
   expired_at: '',
   workspaces: {
     enabled: false,


### PR DESCRIPTION
## Summary

- replace the handwritten license status values with the generated `zLicenseStatus` schema
- replace the handwritten plugin installation scope values with the generated `zPluginInstallationScope` schema
- remove those duplicated values from the System Features constants module while keeping the still-handwritten SSO protocol values

## Why

The backend OpenAPI contract already generates runtime Zod enums for these fields. Consuming those schemas directly keeps the frontend literals aligned with the API contract and preserves exhaustive TypeScript checking for plugin installation scopes.

This PR does not enable transport-level response parsing yet; it establishes the generated runtime schemas as the single source for enum values so response validation can be added at the request boundary separately.

## Impact

No intended behavior change. License-state rendering, plugin installation policy decisions, and test fixtures use the same wire values as before.

## Validation

- `pnpm check` (0 errors)
- focused Vitest suite: 5 files, 73 tests passed
- `git diff --check`
