### PR TITLE
refactor(web): derive supported locale types from config

### DIFF
--- a/web/i18n-config/index.ts
+++ b/web/i18n-config/index.ts
@@ -1,11 +1,11 @@
-import type { Locale } from '@/i18n-config/language'
+import type { Locale, SupportedLocale } from '@/i18n-config/language'
 import Cookies from 'js-cookie'
 import { LOCALE_COOKIE_NAME } from '@/config'
 import { changeLanguage } from '@/i18n-config/client'
 import { LanguagesSupported } from '@/i18n-config/language'
 
 export const i18n = {
-  defaultLocale: 'en-US',
+  defaultLocale: 'en-US' satisfies SupportedLocale,
   locales: LanguagesSupported,
 } as const
 

--- a/web/i18n-config/language.ts
+++ b/web/i18n-config/language.ts
@@ -1,21 +1,25 @@
 import type { DocLanguage } from '@/types/doc-paths'
 import data from './languages'
 
-export type I18nText = Record<(typeof LanguagesSupported)[number], string>
-
 export const languages = data.languages
 
-// for compatibility
-export type Locale = 'ja_JP' | 'zh_Hans' | 'en_US' | (typeof languages)[number]['value']
+type SupportedLanguage = Extract<(typeof languages)[number], { supported: true }>
+export type SupportedLocale = SupportedLanguage['value']
 
-export const LanguagesSupported: Locale[] = languages
-  .filter((item) => item.supported)
+// Plugin and model metadata still use underscore-separated locale keys.
+export type LegacyLocale = 'ja_JP' | 'zh_Hans' | 'en_US'
+export type Locale = LegacyLocale | (typeof languages)[number]['value']
+
+export type I18nText = Record<Locale, string>
+
+export const LanguagesSupported: SupportedLocale[] = languages
+  .filter((item): item is SupportedLanguage => item.supported)
   .map((item) => item.value)
 
-export const getLanguage = (locale: Locale): Locale => {
-  if (['zh-Hans', 'ja-JP'].includes(locale)) return locale.replace('-', '_') as Locale
+export const getLanguage = (locale: Locale): LegacyLocale => {
+  if (['zh-Hans', 'ja-JP'].includes(locale)) return locale.replace('-', '_') as LegacyLocale
 
-  return LanguagesSupported[0]!.replace('-', '_') as Locale
+  return LanguagesSupported[0]!.replace('-', '_') as LegacyLocale
 }
 
 const DOC_LANGUAGE: Record<string, DocLanguage | undefined> = {

--- a/web/i18n-config/load-resource.ts
+++ b/web/i18n-config/load-resource.ts
@@ -1,5 +1,5 @@
 import type { ResourceKey } from 'i18next'
-import type { Locale } from './language'
+import type { Locale, SupportedLocale } from './language'
 import type { Namespace, NamespaceInFileName } from './resources'
 import { kebabCase } from 'es-toolkit/string'
 import { LanguagesSupported } from './language'
@@ -18,7 +18,7 @@ const defaultLocale = 'en-US' satisfies Locale
 
 const normalizeLocale = (locale: Locale): Locale => {
   const normalized = legacyLocaleMap[locale] ?? locale
-  if (LanguagesSupported.includes(normalized)) return normalized
+  if (LanguagesSupported.includes(normalized as SupportedLocale)) return normalized
 
   return defaultLocale
 }

--- a/web/i18n-config/server.ts
+++ b/web/i18n-config/server.ts
@@ -1,5 +1,6 @@
 import type { i18n as I18nInstance, Resource, ResourceLanguage } from 'i18next'
 import type { Locale } from '.'
+import type { SupportedLocale } from './language'
 import type { Namespace, NamespaceInFileName } from './resources'
 import { match } from '@formatjs/intl-localematcher'
 import { camelCase } from 'es-toolkit/string'
@@ -15,7 +16,7 @@ import { loadI18nResource } from './load-resource'
 import { namespacesInFileName } from './resources'
 import { getInitOptions } from './settings'
 
-const [getLocaleCache, setLocaleCache] = serverOnlyContext<Locale | null>(null)
+const [getLocaleCache, setLocaleCache] = serverOnlyContext<SupportedLocale | null>(null)
 const [getI18nInstance, setI18nInstance] = serverOnlyContext<I18nInstance | null>(null)
 
 const getOrCreateI18next = async (lng: Locale) => {
@@ -49,11 +50,11 @@ export async function getTranslation<T extends Namespace>(lng: Locale, ns?: T) {
   }
 }
 
-export const getLocaleOnServer = async (): Promise<Locale> => {
+export const getLocaleOnServer = async (): Promise<SupportedLocale> => {
   const cached = getLocaleCache()
   if (cached) return cached
 
-  const locales: string[] = i18n.locales
+  const locales = i18n.locales
 
   let languages: string[] | undefined
   // get locale from cookie
@@ -77,7 +78,8 @@ export const getLocaleOnServer = async (): Promise<Locale> => {
     languages = [i18n.defaultLocale]
 
   // match locale
-  const matchedLocale = match(languages, locales, i18n.defaultLocale) as Locale
+  // intl-localematcher returns an available locale or the default, but types it as string.
+  const matchedLocale = match(languages, locales, i18n.defaultLocale) as SupportedLocale
   setLocaleCache(matchedLocale)
   return matchedLocale
 }


### PR DESCRIPTION
## Summary

- derive `SupportedLocale` from the `supported: true` language configuration
- name the underscore-separated metadata compatibility boundary as `LegacyLocale`
- keep the broader `Locale` contract for configured and legacy inputs
- narrow server locale matching, caching, and return types to `SupportedLocale`
- verify the default locale with `satisfies SupportedLocale`

## Why

`i18n.locales` was widened to `Locale[]`, then widened again to `string[]` in the server matcher. That allowed legacy metadata keys such as `en_US` to appear in the type of a value that can only come from the enabled locale configuration.

The matcher still returns `string` in the dependency's public type, so the remaining assertion is kept at that external boundary after both the available locales and default locale have been checked as `SupportedLocale`.

## Runtime impact

None. This change only adjusts TypeScript types, predicates, assertions, and comments. Transpiling every changed file before and after the patch produced identical JavaScript.

## Validation

- `vp check web/i18n-config/index.ts web/i18n-config/language.ts web/i18n-config/load-resource.ts web/i18n-config/server.ts`
- `vp check web` — 0 errors; 2,114 existing warnings
- transpiled JavaScript comparison for all four changed files
- `git diff --check`