### PR TITLE
fix: preserve UTF-8 byte size for text uploads

### DIFF
--- a/api/services/file_service.py
+++ b/api/services/file_service.py
@@ -170,9 +170,10 @@ class FileService:
         # user uuid as file name
         file_uuid = str(uuid.uuid4())
         file_key = "upload_files/" + tenant_id + "/" + file_uuid + ".txt"
+        content = text.encode("utf-8")
 
         # save file to storage
-        storage.save(file_key, text.encode("utf-8"))
+        storage.save(file_key, content)
 
         # save file to db
         upload_file = UploadFile(
@@ -180,7 +181,7 @@ class FileService:
             storage_type=StorageType(dify_config.STORAGE_TYPE),
             key=file_key,
             name=text_name,
-            size=len(text),
+            size=len(content),
             extension="txt",
             mime_type="text/plain",
             created_by=user_id,

--- a/api/tests/unit_tests/services/test_file_service.py
+++ b/api/tests/unit_tests/services/test_file_service.py
@@ -112,6 +112,20 @@ class TestFileService:
         assert persisted is not None
         assert persisted.hash == result.hash
 
+    @pytest.mark.parametrize("text", ["ASCII text", "包含多字节 UTF-8 文本 🚀"])
+    def test_upload_text_uses_utf8_byte_length(self, text: str, file_service: FileService):
+        with patch("services.file_service.storage") as mock_storage:
+            result = file_service.upload_text(
+                text=text,
+                text_name="test.txt",
+                user_id="user_id",
+                tenant_id="tenant_id",
+            )
+
+        expected_content = text.encode("utf-8")
+        assert result.size == len(expected_content)
+        mock_storage.save.assert_called_once_with(result.key, expected_content)
+
     def test_upload_file_uses_explicit_resource_tenant(self, file_service: FileService):
         user = MagicMock(spec=Account)
         user.id = "user-id"


### PR DESCRIPTION
## Summary

- Fix text upload metadata to store the UTF-8 byte length.
- Add regression coverage for ASCII and multibyte UTF-8 text.
- Do not include a historical data migration in this PR.

## Root cause

`FileService.upload_text()` stored `text.encode("utf-8")` but recorded `len(text)` as the file size. For non-ASCII text, this is the Unicode character count rather than the number of stored bytes. The download endpoint uses this value as `Content-Length`, which can truncate the response.

This changes the implementation to encode the text once, save those bytes, and use `len(content)` for `UploadFile.size`.

## Validation

- `uv run --project api --no-default-groups --group dev pytest api/tests/unit_tests/services/test_file_service.py -k upload_text_uses_utf8_byte_length`
  - 2 passed
- `ruff check` passed for the changed files.
- `ruff format --check` passed for the changed files.

Fixes #40032