### PR TITLE
fix: hide log detail actions for legacy app logs

### DIFF
--- a/web/app/components/app/log/__tests__/list.spec.tsx
+++ b/web/app/components/app/log/__tests__/list.spec.tsx
@@ -97,12 +97,14 @@ vi.mock('@/app/components/base/copy-icon', () => ({
 vi.mock('@/app/components/app/text-generate/item', () => ({
   default: ({
     content,
+    hideLogAction,
     onFeedback,
   }: {
     content: string
+    hideLogAction?: boolean
     onFeedback: (value: { rating: string; content?: string }) => Promise<boolean>
   }) => (
-    <div data-testid="text-generation">
+    <div data-testid="text-generation" data-hide-log-action={String(hideLogAction)}>
       <div>{content}</div>
       <button onClick={() => void onFeedback({ rating: 'like', content: 'great' })}>
         completion-feedback
@@ -120,6 +122,7 @@ vi.mock('@/app/components/base/chat/chat', () => ({
     onAnnotationRemoved,
     switchSibling,
     hideLogModal,
+    showPromptLog,
   }: {
     chatList: Array<{ id: string }>
     onFeedback: (mid: string, value: { rating: string; content?: string }) => Promise<boolean>
@@ -134,8 +137,13 @@ vi.mock('@/app/components/base/chat/chat', () => ({
     onAnnotationRemoved: (index: number) => Promise<boolean>
     switchSibling: (siblingMessageId: string) => void
     hideLogModal?: boolean
+    showPromptLog?: boolean
   }) => (
-    <div data-testid="chat-panel" data-hide-log-modal={String(hideLogModal)}>
+    <div
+      data-testid="chat-panel"
+      data-hide-log-modal={String(hideLogModal)}
+      data-show-prompt-log={String(showPromptLog)}
+    >
       <div>{chatList.length}</div>
       <button onClick={() => void onFeedback('message-1', { rating: 'like', content: 'nice' })}>
         chat-feedback
@@ -416,6 +424,41 @@ describe('ConversationList', () => {
     })
   })
 
+  it.each([
+    ['chatbot', AppModeEnum.CHAT, 'false'],
+    ['agent', AppModeEnum.AGENT_CHAT, 'false'],
+    ['chatflow', AppModeEnum.ADVANCED_CHAT, 'true'],
+  ])('should expose run details only for %s conversation answers', async (_, mode, expected) => {
+    mockChatConversationDetail = {
+      id: 'conversation-1',
+      created_at: 1710000000,
+      model_config: {
+        model: 'gpt-4o',
+        configs: {
+          introduction: 'Hello there',
+        },
+        user_input_form: [],
+      },
+      message: {
+        inputs: {},
+      },
+    }
+    mockFetchChatMessages.mockResolvedValue({
+      data: [createChatMessage('message-1')],
+      has_more: false,
+    })
+
+    renderConversationList({
+      appDetail: { id: 'app-1', mode } as any,
+      searchParams: '?conversation_id=conversation-1',
+    })
+
+    expect(await screen.findByTestId('chat-panel')).toHaveAttribute(
+      'data-show-prompt-log',
+      expected,
+    )
+  })
+
   it('should mount agent log modals from the detail panel instead of the nested chat layout', async () => {
     mockChatConversationDetail = {
       id: 'conversation-1',
@@ -509,6 +552,7 @@ describe('ConversationList', () => {
     })
 
     expect(screen.getByTestId('var-panel')).toHaveTextContent('query:Question')
+    expect(screen.getByTestId('text-generation')).toHaveAttribute('data-hide-log-action', 'true')
     expect(screen.getByTestId('prompt-log-modal')).toBeInTheDocument()
 
     fireEvent.click(screen.getByText('completion-feedback'))

--- a/web/app/components/app/log/list.tsx
+++ b/web/app/components/app/log/list.tsx
@@ -515,6 +515,7 @@ function DetailPanel({ appDetail, detail, onClose, onFeedback }: IDetailPanel) {
               onRetry={noop}
               supportFeedback
               feedback={detail.message.feedbacks.find((item: any) => item.from_source === 'admin')}
+              hideLogAction
               onFeedback={(feedback) => onFeedback(detail.message.id, feedback)}
               isShowTextToSpeech
               siteInfo={null}
@@ -543,7 +544,7 @@ function DetailPanel({ appDetail, detail, onClose, onFeedback }: IDetailPanel) {
               onAnnotationRemoved={handleAnnotationRemoved}
               onFeedback={onFeedback}
               noChatInput
-              showPromptLog
+              showPromptLog={isAdvanced}
               hideProcessDetail
               hideLogModal
               chatContainerInnerClassName="px-3"
@@ -585,7 +586,7 @@ function DetailPanel({ appDetail, detail, onClose, onFeedback }: IDetailPanel) {
                 onAnnotationRemoved={handleAnnotationRemoved}
                 onFeedback={onFeedback}
                 noChatInput
-                showPromptLog
+                showPromptLog={isAdvanced}
                 hideProcessDetail
                 hideLogModal
                 chatContainerInnerClassName="px-3"

--- a/web/app/components/app/text-generate/item/__tests__/action-groups.spec.tsx
+++ b/web/app/components/app/text-generate/item/__tests__/action-groups.spec.tsx
@@ -105,6 +105,28 @@ describe('GenerationActionGroups', () => {
     ).toBeDisabled()
   })
 
+  it('should hide the log action when requested by the owning surface', () => {
+    render(
+      <GenerationActionGroups
+        appSourceType={AppSourceType.webApp}
+        content="hello world"
+        currentTab="DETAIL"
+        depth={1}
+        hideLogAction
+        isError={false}
+        isInWebApp={false}
+        messageId="msg-1"
+        onMoreLikeThis={mockOnMoreLikeThis}
+        onOpenLogModal={mockOnOpenLogModal}
+        onRetry={mockOnRetry}
+      />,
+    )
+
+    expect(
+      screen.queryByRole('button', { name: /(?:^|\.)operation\.log(?=$|:)/ }),
+    ).not.toBeInTheDocument()
+  })
+
   it('should stringify non-string content before copying', () => {
     render(
       <GenerationActionGroups

--- a/web/app/components/app/text-generate/item/action-groups.tsx
+++ b/web/app/components/app/text-generate/item/action-groups.tsx
@@ -26,6 +26,7 @@ type GenerationActionGroupsProps = {
   currentTab: string
   depth: number
   feedback?: FeedbackType
+  hideLogAction?: boolean
   isError: boolean
   isInWebApp: boolean
   isResponding?: boolean
@@ -49,6 +50,7 @@ const GenerationActionGroups: FC<GenerationActionGroupsProps> = ({
   currentTab,
   depth,
   feedback,
+  hideLogAction,
   isError,
   isInWebApp,
   isResponding,
@@ -71,18 +73,21 @@ const GenerationActionGroups: FC<GenerationActionGroupsProps> = ({
 
   return (
     <>
-      {!isInWebApp && appSourceType !== AppSourceTypeEnum.installedApp && !isResponding && (
-        <div className="ml-1 flex items-center gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs">
-          <ActionButton
-            aria-label={t(($) => $['operation.log'], { ns: 'common' })}
-            disabled={isError || !messageId}
-            title={t(($) => $['operation.log'], { ns: 'common' })}
-            onClick={onOpenLogModal}
-          >
-            <RiFileList3Line className="size-4" />
-          </ActionButton>
-        </div>
-      )}
+      {!hideLogAction &&
+        !isInWebApp &&
+        appSourceType !== AppSourceTypeEnum.installedApp &&
+        !isResponding && (
+          <div className="ml-1 flex items-center gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs">
+            <ActionButton
+              aria-label={t(($) => $['operation.log'], { ns: 'common' })}
+              disabled={isError || !messageId}
+              title={t(($) => $['operation.log'], { ns: 'common' })}
+              onClick={onOpenLogModal}
+            >
+              <RiFileList3Line className="size-4" />
+            </ActionButton>
+          </div>
+        )}
       <div className="ml-1 flex items-center gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs">
         {moreLikeThis && !isTryApp && (
           <ActionButton

--- a/web/app/components/app/text-generate/item/index.tsx
+++ b/web/app/components/app/text-generate/item/index.tsx
@@ -58,6 +58,7 @@ type IGenerationItemProps = {
   controlClearMoreLikeThis?: number
   supportFeedback?: boolean
   isShowTextToSpeech?: boolean
+  hideLogAction?: boolean
   hideProcessDetail?: boolean
   siteInfo: SiteInfo | null
   inSidePanel?: boolean
@@ -86,6 +87,7 @@ const GenerationItem: FC<IGenerationItemProps> = ({
   controlClearMoreLikeThis,
   supportFeedback,
   isShowTextToSpeech,
+  hideLogAction,
   hideProcessDetail,
   siteInfo,
   inSidePanel,
@@ -130,6 +132,7 @@ const GenerationItem: FC<IGenerationItemProps> = ({
     installedAppId,
     controlClearMoreLikeThis,
     isWorkflow,
+    hideLogAction,
     siteInfo,
     taskId,
   }
@@ -274,6 +277,7 @@ const GenerationItem: FC<IGenerationItemProps> = ({
                   currentTab={currentTab}
                   depth={depth}
                   feedback={feedback}
+                  hideLogAction={hideLogAction}
                   isError={isError}
                   isInWebApp={isInWebApp}
                   isResponding={isResponding}


### PR DESCRIPTION
## Summary

- Hide unavailable log detail actions from chatbot, agent, and completion app logs.
- Preserve run detail behavior for chatflow and workflow apps.
- Add regression coverage for each affected app mode.

Fixes SNP-616

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.