### PR TITLE
fix(api): include full end_date day in feedback export filter

### DIFF
--- a/api/services/feedback_service.py
+++ b/api/services/feedback_service.py
@@ -1,7 +1,7 @@
 import csv
 import io
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from flask import Response
 from sqlalchemy import or_, select
@@ -75,8 +75,9 @@ class FeedbackService:
 
         if end_date:
             try:
-                end_dt = datetime.strptime(end_date, "%Y-%m-%d")
-                stmt = stmt.where(MessageFeedback.created_at <= end_dt)
+                # Treat end_date as inclusive through 23:59:59 by using an exclusive next-day bound.
+                end_dt_exclusive = datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)
+                stmt = stmt.where(MessageFeedback.created_at < end_dt_exclusive)
             except ValueError:
                 raise ValueError(f"Invalid end_date format: {end_date}. Use YYYY-MM-DD")
 

--- a/api/tests/unit_tests/services/test_feedback_service.py
+++ b/api/tests/unit_tests/services/test_feedback_service.py
@@ -149,6 +149,25 @@ class TestFeedbackService:
         assert json_content["export_info"]["total_records"] == 1
         assert json_content["feedback_data"][0]["from_account_name"] == "Admin User"
 
+    def test_export_feedbacks_end_date_includes_entire_day(
+        self, sqlite_session: Session, sample_data: FeedbackSample
+    ) -> None:
+        feedback_day = sample_data["admin_feedback"].created_at.strftime("%Y-%m-%d")
+
+        result = FeedbackService.export_feedbacks(
+            app_id=APP_ID,
+            session=sqlite_session,
+            end_date=feedback_day,
+            format_type="json",
+        )
+
+        exported_ids = {
+            item["feedback_id"]
+            for item in json.loads(result.get_data(as_text=True))["feedback_data"]
+        }
+        assert str(sample_data["admin_feedback"].id) in exported_ids
+        assert str(sample_data["user_feedback"].id) in exported_ids
+
     def test_export_feedbacks_with_filters(self, sqlite_session: Session, sample_data: FeedbackSample) -> None:
         result = FeedbackService.export_feedbacks(
             app_id=APP_ID,

--- a/api/tests/unit_tests/services/test_feedback_service.py
+++ b/api/tests/unit_tests/services/test_feedback_service.py
@@ -161,10 +161,7 @@ class TestFeedbackService:
             format_type="json",
         )
 
-        exported_ids = {
-            item["feedback_id"]
-            for item in json.loads(result.get_data(as_text=True))["feedback_data"]
-        }
+        exported_ids = {item["feedback_id"] for item in json.loads(result.get_data(as_text=True))["feedback_data"]}
         assert str(sample_data["admin_feedback"].id) in exported_ids
         assert str(sample_data["user_feedback"].id) in exported_ids
 


### PR DESCRIPTION
Fixes #40050

## Summary

- Treat feedback export `end_date` as inclusive through the end of the specified day.
- Use an exclusive next-day upper bound (`created_at < end_date + 1 day`) instead of comparing against midnight at the start of the day.
- Add a regression test that exports feedback created later in the day when `end_date` matches that day.

## Screenshots

N/A (API-only behavior change).

## Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.