### PR TITLE
fix(api): tighten RAGFlow external knowledge endpoint validation

### DIFF
--- a/api/services/external_knowledge_service.py
+++ b/api/services/external_knowledge_service.py
@@ -86,7 +86,7 @@ class ExternalDatasetService:
         if "api_key" not in settings or not settings["api_key"]:
             raise ValueError("api_key is required")
 
-        endpoint = f"{settings['endpoint']}/retrieval"
+        endpoint = f"{settings['endpoint'].rstrip('/')}/retrieval"
         api_key = settings["api_key"]
 
         parsed_url = urlparse(endpoint)
@@ -115,7 +115,7 @@ class ExternalDatasetService:
             raise ValueError(f"Bad Gateway: failed to connect to the endpoint: {endpoint}")
         if response.status_code == 404:
             raise ValueError(f"Not Found: failed to connect to the endpoint: {endpoint}")
-        if response.status_code == 403:
+        if response.status_code in {401, 403}:
             raise ValueError("Forbidden: Authorization failed with the provided api_key")
 
     @staticmethod
@@ -396,7 +396,7 @@ class ExternalDatasetService:
         try:
             response = ExternalDatasetService.process_external_api(
                 ExternalKnowledgeApiSetting(
-                    url=f"{settings.get('endpoint')}/retrieval",
+                    url=f"{settings.get('endpoint', '').rstrip('/')}/retrieval",
                     request_method="post",
                     headers=headers,
                     params=request_params,

--- a/api/tests/unit_tests/services/test_external_dataset_service.py
+++ b/api/tests/unit_tests/services/test_external_dataset_service.py
@@ -905,12 +905,73 @@ class TestExternalDatasetServiceCheckEndpoint:
         assert "CDEF" not in message
 
     @patch("services.external_knowledge_service.ssrf_proxy")
+    def test_check_endpoint_strips_trailing_slash_before_retrieval(
+        self, mock_proxy, factory: ExternalDatasetServiceTestDataFactory
+    ):
+        """Regression for #40028: trailing slashes must not produce a double-slash retrieval URL."""
+        settings = {"endpoint": "http://ragflow.example.com/api/v1/dify/", "api_key": "ragflow-test-key"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_proxy.post.return_value = mock_response
+
+        ExternalDatasetService.check_endpoint_and_api_key(settings)
+
+        assert mock_proxy.post.call_args[0][0] == "http://ragflow.example.com/api/v1/dify/retrieval"
+
+    @patch("services.external_knowledge_service.ssrf_proxy")
+    def test_check_endpoint_ragflow_wrong_base_returns_401(
+        self, mock_proxy, factory: ExternalDatasetServiceTestDataFactory
+    ):
+        """Regression for #40028: a generic /api/v1 base must not pass when it only returns 401."""
+        settings = {"endpoint": "http://ragflow.example.com/api/v1", "api_key": "ragflow-test-key"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_proxy.post.return_value = mock_response
+
+        with pytest.raises(ValueError, match="Forbidden.*Authorization failed"):
+            ExternalDatasetService.check_endpoint_and_api_key(settings)
+
+        call_args = mock_proxy.post.call_args
+        assert call_args[0][0] == "http://ragflow.example.com/api/v1/retrieval"
+
+    @patch("services.external_knowledge_service.ssrf_proxy")
+    def test_check_endpoint_ragflow_dify_base_accepts_argument_error(
+        self, mock_proxy, factory: ExternalDatasetServiceTestDataFactory
+    ):
+        """Regression for #40028: the documented /api/v1/dify base should pass when the provider
+        rejects the probe payload with a 400 argument error instead of dropping the connection."""
+        settings = {"endpoint": "http://ragflow.example.com/api/v1/dify", "api_key": "ragflow-test-key"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_proxy.post.return_value = mock_response
+
+        ExternalDatasetService.check_endpoint_and_api_key(settings)
+
+        call_args = mock_proxy.post.call_args
+        assert call_args[0][0] == "http://ragflow.example.com/api/v1/dify/retrieval"
+
+    @patch("services.external_knowledge_service.ssrf_proxy")
+    def test_check_endpoint_401_unauthorized(self, mock_proxy, factory: ExternalDatasetServiceTestDataFactory):
+        """Test validation fails with 401 Unauthorized (auth failure)."""
+        settings = {"endpoint": "https://api.example.com", "api_key": "wrong-key"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_proxy.post.return_value = mock_response
+
+        with pytest.raises(ValueError, match="Forbidden.*Authorization failed"):
+            ExternalDatasetService.check_endpoint_and_api_key(settings)
+
+    @patch("services.external_knowledge_service.ssrf_proxy")
     def test_check_endpoint_other_4xx_codes_pass(self, mock_proxy, factory: ExternalDatasetServiceTestDataFactory):
         """Test that other 4xx codes don't raise exceptions."""
         # Arrange
         settings = {"endpoint": "https://api.example.com", "api_key": "test-key"}
 
-        for status_code in [400, 401, 405, 429]:
+        for status_code in [400, 405, 429]:
             mock_response = MagicMock()
             mock_response.status_code = status_code
             mock_proxy.post.return_value = mock_response


### PR DESCRIPTION
Fixes #40028

## Summary

- Reject `401 Unauthorized` during external knowledge endpoint validation, matching the existing `403` auth-failure handling so generic `/api/v1` bases cannot pass with an unauthenticated response.
- Normalize trailing slashes before appending `/retrieval` to avoid `//retrieval` probe URLs when users enter the documented RAGFlow base (`/api/v1/dify/`).
- Apply the same trailing-slash normalization to live retrieval requests.
- Add regression tests for the RAGFlow `/api/v1` vs `/api/v1/dify` validation behavior.

## Screenshots

N/A (API-only behavior change).

## Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.