### PR TITLE
fix(api): parse Content-Disposition for remote file link uploads

### DIFF
--- a/api/controllers/common/helpers.py
+++ b/api/controllers/common/helpers.py
@@ -2,7 +2,6 @@ import contextlib
 import mimetypes
 import os
 import platform
-import re
 import urllib.parse
 import warnings
 from uuid import uuid4
@@ -27,6 +26,8 @@ except ImportError:
     magic = None  # type: ignore[assignment]
 
 from pydantic import BaseModel
+
+from factories.file_factory.remote import extract_filename
 
 
 class FileInfo(BaseModel):
@@ -56,19 +57,7 @@ def decode_remote_url(url: str, query_string: bytes | str = b"") -> str:
 
 def guess_file_info_from_response(response: httpx.Response):
     url = str(response.url)
-    # Try to extract filename from URL
-    parsed_url = urllib.parse.urlparse(url)
-    url_path = parsed_url.path
-    # Decode percent-encoded characters in the path segment
-    filename = urllib.parse.unquote(os.path.basename(url_path))
-
-    # If filename couldn't be extracted, use Content-Disposition header
-    if not filename:
-        content_disposition = response.headers.get("Content-Disposition")
-        if content_disposition:
-            filename_match = re.search(r'filename="?(.+)"?', content_disposition)
-            if filename_match:
-                filename = filename_match.group(1)
+    filename = extract_filename(url, response.headers.get("Content-Disposition"))
 
     # If still no filename, generate a unique one
     if not filename:

--- a/api/factories/file_factory/remote.py
+++ b/api/factories/file_factory/remote.py
@@ -84,7 +84,7 @@ def get_remote_file_info(url: str) -> tuple[str, str, int]:
     resp = remote_fetcher.make_request("HEAD", url, follow_redirects=True)
     if resp.status_code == httpx.codes.OK:
         content_disposition = resp.headers.get("Content-Disposition")
-        extracted_filename = extract_filename(url_path, content_disposition)
+        extracted_filename = extract_filename(url, content_disposition)
         if extracted_filename:
             filename = extracted_filename
             mime_type = _guess_mime_type(filename)

--- a/api/tests/unit_tests/controllers/common/test_helpers.py
+++ b/api/tests/unit_tests/controllers/common/test_helpers.py
@@ -21,6 +21,22 @@ def make_response(
 
 
 class TestGuessFileInfoFromResponse:
+    def test_filename_from_content_disposition_when_url_has_no_extension(self):
+        headers = {
+            "Content-Disposition": 'attachment; filename="report.docx"',
+            "Content-Type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        }
+        response = make_response(
+            url="https://test.domain.com/weaver/FileDownload?fileid=sdfsdfsfds",
+            headers=headers,
+            content=b"doc",
+        )
+
+        info = guess_file_info_from_response(response)
+
+        assert info.filename == "report.docx"
+        assert info.extension == ".docx"
+
     def test_filename_from_url(self):
         response = make_response(
             url="https://example.com/test.pdf",


### PR DESCRIPTION
Fixes #40059

## Summary

- Reuse the shared `extract_filename` helper when resolving remote upload metadata so paste-file-link uploads can recover the filename from `Content-Disposition`.
- Pass the full remote URL into `get_remote_file_info` filename extraction for query-only download links.
- Add a regression test for a `FileDownload?fileid=...` URL that only exposes the real filename in response headers.

## Screenshots

N/A (API-only behavior change).

## Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.