### PR TITLE
fix(web): refresh all workflow variable blocks after nodes map update

### DIFF
--- a/web/app/components/base/prompt-editor/plugins/workflow-variable-block/__tests__/component.spec.tsx
+++ b/web/app/components/base/prompt-editor/plugins/workflow-variable-block/__tests__/component.spec.tsx
@@ -517,7 +517,7 @@ describe('WorkflowVariableBlockComponent', () => {
     )
   })
 
-  it('should apply workflow node map updates through command handler', () => {
+  it('should apply workflow node map updates without stopping other variable blocks', () => {
     render(
       <WorkflowVariableBlockComponent
         nodeKey="k"
@@ -545,7 +545,7 @@ describe('WorkflowVariableBlockComponent', () => {
       })
     })
 
-    expect(result).toBe(true)
+    expect(result).toBe(false)
   })
 
   it('should mark non-special variable invalid when source key is missing in availableVariables', () => {

--- a/web/app/components/base/prompt-editor/plugins/workflow-variable-block/component.tsx
+++ b/web/app/components/base/prompt-editor/plugins/workflow-variable-block/component.tsx
@@ -89,7 +89,7 @@ const WorkflowVariableBlockComponent = ({
         (payload: UpdateWorkflowNodesMapPayload) => {
           setLocalWorkflowNodesMap(payload.workflowNodesMap)
           setLocalAvailableVariables(payload.availableVariables)
-          return true
+          return false
         },
         COMMAND_PRIORITY_EDITOR,
       ),


### PR DESCRIPTION
Fixes #40041

## Summary

- Return `false` from each workflow variable block's `UPDATE_WORKFLOW_NODES_MAP` command handler so Lexical continues dispatching to later blocks.
- Prevent plugin tool output variables inserted after the first block from staying marked invalid after a page refresh.
- Update the component test to assert the command handler does not stop propagation.

## Screenshots

N/A (workflow editor validation state only).

## Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I ran focused frontend tests for the changed files.