### PR TITLE
fix(web): reuse request-scoped query client during SSR

### DIFF
--- a/web/context/__tests__/query-client.spec.tsx
+++ b/web/context/__tests__/query-client.spec.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment node
+
+import { renderToString } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  isServer: true,
+  getQueryClientServer: vi.fn(),
+  makeQueryClient: vi.fn(),
+}))
+
+vi.mock('@/utils/client', () => ({
+  get isServer() {
+    return mocks.isServer
+  },
+  isClient: false,
+}))
+
+vi.mock('../query-client-server', () => ({
+  get getQueryClientServer() {
+    return mocks.getQueryClientServer
+  },
+  get makeQueryClient() {
+    return mocks.makeQueryClient
+  },
+}))
+
+describe('TanStackQueryProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    mocks.isServer = true
+    mocks.getQueryClientServer.mockReturnValue({})
+    mocks.makeQueryClient.mockReturnValue({})
+  })
+
+  it('reuses the request-scoped server query client during SSR', async () => {
+    const { TanStackQueryProvider } = await import('../query-client')
+
+    renderToString(
+      <TanStackQueryProvider>
+        <div>child</div>
+      </TanStackQueryProvider>,
+    )
+
+    expect(mocks.getQueryClientServer).toHaveBeenCalled()
+    expect(mocks.makeQueryClient).not.toHaveBeenCalled()
+  })
+})

--- a/web/context/query-client.tsx
+++ b/web/context/query-client.tsx
@@ -6,13 +6,13 @@ import { QueryClientProvider, QueryErrorResetBoundary } from '@tanstack/react-qu
 import { queryClientAtom } from 'jotai-tanstack-query'
 import { useHydrateAtoms } from 'jotai/react/utils'
 import { isServer } from '@/utils/client'
-import { makeQueryClient } from './query-client-server'
+import { getQueryClientServer, makeQueryClient } from './query-client-server'
 
 let browserQueryClient: QueryClient | undefined
 
 function getQueryClient() {
   if (isServer) {
-    return makeQueryClient()
+    return getQueryClientServer()
   }
   if (!browserQueryClient) browserQueryClient = makeQueryClient()
   return browserQueryClient


### PR DESCRIPTION
Fixes #39914

## Summary

- Reuse `getQueryClientServer()` inside `TanStackQueryProvider` during SSR instead of creating a fresh `QueryClient` per render.
- Let routes outside `(commonLayout)` such as `/signin` read the root layout's prefetched `system-features` cache instead of refetching through the browser-facing `/console/api` prefix on `http://localhost`.
- Add a regression test that asserts the provider uses the request-scoped server query client during SSR.

## Screenshots

N/A (SSR fetch-path change only).

## Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I ran focused frontend tests for the changed files.