### PR TITLE
fix(web): reuse request-scoped query client during SSR

### DIFF
--- a/web/app/__tests__/get-query-client.spec.ts
+++ b/web/app/__tests__/get-query-client.spec.ts
@@ -1,7 +1,49 @@
 import { dehydrate } from '@tanstack/react-query'
 import { getQueryClient } from '../get-query-client'
 
+const mocks = vi.hoisted(() => ({
+  isServer: false,
+}))
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>()
+  return {
+    ...actual,
+    cache: <T extends (...args: never[]) => unknown>(fn: T) => {
+      let cached: ReturnType<T> | undefined
+      return ((...args: Parameters<T>) => {
+        if (cached === undefined) cached = fn(...args) as ReturnType<T>
+        return cached
+      }) as T
+    },
+  }
+})
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>()
+  return {
+    ...actual,
+    environmentManager: {
+      ...actual.environmentManager,
+      isServer: () => mocks.isServer,
+    },
+  }
+})
+
 describe('getQueryClient', () => {
+  beforeEach(() => {
+    mocks.isServer = false
+  })
+
+  it('reuses the same query client during SSR within a request', () => {
+    mocks.isServer = true
+
+    const first = getQueryClient()
+    const second = getQueryClient()
+
+    expect(second).toBe(first)
+  })
+
   it('includes pending queries in dehydrated state', async () => {
     const queryClient = getQueryClient()
     const queryKey = ['pending-dehydration']

--- a/web/app/get-query-client.ts
+++ b/web/app/get-query-client.ts
@@ -1,4 +1,5 @@
 import { defaultShouldDehydrateQuery, environmentManager, QueryClient } from '@tanstack/react-query'
+import { cache } from 'react'
 
 const STALE_TIME = 1000 * 60 * 5
 
@@ -17,10 +18,12 @@ function makeQueryClient() {
   })
 }
 
+const getServerQueryClient = cache(makeQueryClient)
+
 let browserQueryClient: QueryClient | undefined
 
 export function getQueryClient() {
-  if (environmentManager.isServer()) return makeQueryClient()
+  if (environmentManager.isServer()) return getServerQueryClient()
   if (!browserQueryClient) browserQueryClient = makeQueryClient()
   return browserQueryClient
 }


### PR DESCRIPTION
Fixes #39914

## Summary

- Cache the server-side `QueryClient` in `get-query-client.ts` so `TanStackQueryProvider` and `getSystemFeaturesQueryClient()` share the same request-scoped instance during SSR.
- Let routes outside `(commonLayout)` such as `/signin` read the root layout's prefetched `system-features` cache instead of refetching through the browser-facing `/console/api` prefix on `http://localhost`.
- Add a regression test that asserts repeated server-side `getQueryClient()` calls return the same instance.

## Screenshots

N/A (SSR fetch-path change only).

## Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I ran focused frontend tests for the changed files.