### PR TITLE
perf: optimize app log api elapse, not call getattr

### DIFF
--- a/api/services/workflow_app_service.py
+++ b/api/services/workflow_app_service.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any, TypedDict
 
 from sqlalchemy import and_, func, or_, select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, load_only
 
 from core.plugin.plugin_service import PluginService
 from graphon.enums import WorkflowExecutionStatus
@@ -26,9 +26,19 @@ class LogView:
     - Proxies all other attributes to the underlying `WorkflowAppLog`
     """
 
-    def __init__(self, log: WorkflowAppLog, details: LogViewDetails | None):
+    def __init__(
+        self,
+        log: WorkflowAppLog,
+        details: LogViewDetails | None,
+        workflow_run: WorkflowRun | None = None,
+        created_by_account: Account | None = None,
+        created_by_end_user: EndUser | None = None,
+    ):
         self.log = log
         self.details_ = details
+        self.workflow_run = workflow_run
+        self.created_by_account = created_by_account
+        self.created_by_end_user = created_by_end_user
 
     @property
     def details(self) -> LogViewDetails | None:
@@ -168,14 +178,76 @@ class WorkflowAppService:
         # wrapper moved to module scope as `LogView`
 
         # Execute query and get items
+        logs: list[WorkflowAppLog]
+        details_by_log_id: dict[str, LogViewDetails]
         if detail:
             rows = session.execute(offset_stmt).all()
-            items = [
-                LogView(log, {"trigger_metadata": self.handle_trigger_metadata(app_model.tenant_id, meta_val)})
+            logs = [log for log, _meta_val in rows]
+            details_by_log_id = {
+                log.id: {"trigger_metadata": self.handle_trigger_metadata(app_model.tenant_id, meta_val)}
                 for log, meta_val in rows
-            ]
+            }
         else:
-            items = [LogView(log, None) for log in session.scalars(offset_stmt).all()]
+            logs = list(session.scalars(offset_stmt).all())
+            details_by_log_id = {}
+
+        workflow_run_ids = {log.workflow_run_id for log in logs if log.workflow_run_id}
+        workflow_runs_by_id: dict[str, WorkflowRun] = {}
+        if workflow_run_ids:
+            workflow_runs_by_id = {
+                workflow_run.id: workflow_run
+                for workflow_run in session.scalars(
+                    select(WorkflowRun)
+                    .options(
+                        load_only(
+                            WorkflowRun.id,
+                            WorkflowRun.version,
+                            WorkflowRun.status,
+                            WorkflowRun.triggered_from,
+                            WorkflowRun.error,
+                            WorkflowRun.elapsed_time,
+                            WorkflowRun.total_tokens,
+                            WorkflowRun.total_steps,
+                            WorkflowRun.created_at,
+                            WorkflowRun.finished_at,
+                            WorkflowRun.exceptions_count,
+                        )
+                    )
+                    .where(WorkflowRun.id.in_(workflow_run_ids))
+                ).all()
+            }
+
+        account_ids = {
+            log.created_by for log in logs if CreatorUserRole(log.created_by_role) == CreatorUserRole.ACCOUNT
+        }
+        end_user_ids = {
+            log.created_by for log in logs if CreatorUserRole(log.created_by_role) == CreatorUserRole.END_USER
+        }
+
+        accounts_by_id: dict[str, Account] = {}
+        if account_ids:
+            accounts_by_id = {
+                account.id: account
+                for account in session.scalars(select(Account).where(Account.id.in_(account_ids))).all()
+            }
+
+        end_users_by_id: dict[str, EndUser] = {}
+        if end_user_ids:
+            end_users_by_id = {
+                end_user.id: end_user
+                for end_user in session.scalars(select(EndUser).where(EndUser.id.in_(end_user_ids))).all()
+            }
+
+        items = [
+            LogView(
+                log,
+                details_by_log_id.get(log.id),
+                workflow_run=workflow_runs_by_id.get(log.workflow_run_id),
+                created_by_account=accounts_by_id.get(log.created_by),
+                created_by_end_user=end_users_by_id.get(log.created_by),
+            )
+            for log in logs
+        ]
         return {
             "page": page,
             "limit": limit,

--- a/api/tests/unit_tests/controllers/service_api/app/test_workflow.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_workflow.py
@@ -23,6 +23,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from flask import Flask
+from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 from werkzeug.exceptions import BadRequest, NotFound
@@ -382,6 +383,40 @@ class TestWorkflowAppService:
         assert result["total"] == 1
         assert result["has_more"] is False
         assert [item.id for item in result["data"]] == [log.id]
+
+    @pytest.mark.parametrize("sqlite_session", [(WorkflowAppLog, WorkflowRun)], indirect=True)
+    def test_get_paginate_workflow_app_logs_preloads_lightweight_workflow_runs(
+        self, sqlite_session: Session, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Log list rows should not resolve workflow runs through the per-row model property."""
+        workflow_run = _make_workflow_run(run_id="log-run-1")
+        log = _make_workflow_app_log(workflow_run_id=workflow_run.id)
+        sqlite_session.add_all([workflow_run, log])
+        sqlite_session.commit()
+        sqlite_session.expunge_all()
+
+        def fail_workflow_run_property(_self):
+            raise AssertionError("WorkflowAppLog.workflow_run property should not be used for log list rows")
+
+        monkeypatch.setattr(WorkflowAppLog, "workflow_run", property(fail_workflow_run_property))
+
+        service = WorkflowAppService()
+        result = service.get_paginate_workflow_app_logs(
+            session=sqlite_session,
+            app_model=_make_app_model(),
+            keyword=None,
+            status=None,
+            created_at_before=None,
+            created_at_after=None,
+            page=1,
+            limit=20,
+            created_by_end_user_session_id=None,
+            created_by_account=None,
+        )
+
+        item = result["data"][0]
+        assert item.workflow_run.id == "log-run-1"
+        assert {"graph", "inputs", "outputs"}.issubset(sa_inspect(item.workflow_run).unloaded)
 
 
 class TestWorkflowExecutionStatus:


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #40036, not call getattr, do not call

```
@property
def workflow_run(self):
        if self.workflow_run_id:
            from sqlalchemy.orm import sessionmaker

            from repositories.factory import DifyAPIRepositoryFactory

            session_maker = sessionmaker(bind=db.engine, expire_on_commit=False)
            repo = DifyAPIRepositoryFactory.create_api_workflow_run_repository(session_maker)
            return repo.get_workflow_run_by_id_without_tenant(run_id=self.workflow_run_id)

        return None
```

## Screenshots

| Before | After |
|--------|-------|
| ... | ... |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
