### PR TITLE
fix(e2e): align marketplace plugin download URL

### DIFF
--- a/e2e/support/marketplace-plugins.ts
+++ b/e2e/support/marketplace-plugins.ts
@@ -100,7 +100,7 @@ const waitForPluginInstallTask = async (
 
 const getMarketplaceDownloadUrl = (pluginUniqueIdentifier: string) => {
   const url = new URL(
-    '/api/v1/plugins/download',
+    '/api/v1/plugins/download-url',
     process.env.E2E_MARKETPLACE_API_URL || defaultMarketplaceApiUrl,
   )
   url.searchParams.set('unique_identifier', pluginUniqueIdentifier)

--- a/e2e/tests/marketplace-plugins.test.ts
+++ b/e2e/tests/marketplace-plugins.test.ts
@@ -58,13 +58,16 @@ describe('bootstrapMarketplacePlugins', () => {
 
   it('uses generated package upload when the API process cannot download from Marketplace', async () => {
     vi.stubEnv('E2E_TEST_MARKETPLACE_PLUGIN_IDS', '')
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('plugin-package'))
+    vi.stubEnv('E2E_MARKETPLACE_API_URL', 'https://marketplace.test')
+    const marketplaceFetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('plugin-package'))
     const { consoleClient, installPackage, uploadPackage } = createMarketplaceConsoleClient(
       new ORPCError('INTERNAL_SERVER_ERROR', {
         data: {
           body: {
             message:
-              'Reached maximum retries (3) for URL https://marketplace.test/plugins/download',
+              'Reached maximum retries (3) for URL https://marketplace.test/api/v1/plugins/download-url',
           },
         },
         status: 500,
@@ -73,6 +76,10 @@ describe('bootstrapMarketplacePlugins', () => {
     const result = await bootstrapTestPlugin(consoleClient)
 
     expect(result.status).toBe('verified')
+    expect(marketplaceFetch).toHaveBeenCalledOnce()
+    expect(marketplaceFetch).toHaveBeenCalledWith(
+      'https://marketplace.test/api/v1/plugins/download-url?unique_identifier=langgenius%2Ftest%3A1.0.0%40marketplace',
+    )
     expect(uploadPackage).toHaveBeenCalledWith({
       body: { pkg: expect.any(File) },
     })


### PR DESCRIPTION
## Summary

- align the E2E Marketplace package fallback with the current `/api/v1/plugins/download-url` endpoint
- verify the request preserves the complete checksum-bearing `unique_identifier`
- keep the external binary download as the existing centralized protocol adapter

## Why

The API download owner moved from `/api/v1/plugins/download` to `/api/v1/plugins/download-url` in #39811, but the Agent V2 E2E seed fallback retained the old route. The old endpoint remains compatible today, but the fallback no longer matched the production download path.

This does not add an oRPC wrapper: generated Console operations already own plugin lookup, upload, installation, and task polling, while the Marketplace download is an external binary and redirect boundary.

## Validation

- `pnpm -C e2e exec vitest run tests/marketplace-plugins.test.ts`
- `pnpm -C e2e type-check`
- `vp check e2e`
- `git diff --check`