### PR TITLE
test: migrate core app sessions to SQLite

### DIFF
--- a/api/tests/unit_tests/core/agent/test_cot_agent_runner.py
+++ b/api/tests/unit_tests/core/agent/test_cot_agent_runner.py
@@ -344,9 +344,20 @@ class TestRun:
         message = MagicMock()
         message.id = "msg-id"
         events: list[str] = []
-        session = MagicMock()
-        session.commit.side_effect = lambda: events.append("commit")
-        session.close.side_effect = lambda: events.append("close")
+        session = runner.session
+        original_close = session.close
+        original_commit = session.commit
+
+        def close_session() -> None:
+            events.append("close")
+            original_close()
+
+        def commit_session() -> None:
+            events.append("commit")
+            original_commit()
+
+        mocker.patch.object(session, "close", side_effect=close_session)
+        mocker.patch.object(session, "commit", side_effect=commit_session)
 
         def provider_chunks():
             events.append("first-chunk")

--- a/api/tests/unit_tests/core/agent/test_fc_agent_runner.py
+++ b/api/tests/unit_tests/core/agent/test_fc_agent_runner.py
@@ -1,5 +1,6 @@
 import json
 from collections.abc import Iterator
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -20,6 +21,8 @@ from graphon.model_runtime.entities.message_entities import (
     TextPromptMessageContent,
     UserPromptMessage,
 )
+from models.enums import CreatorUserRole
+from models.model import StorageType, UploadFile
 
 # ==============================
 # Dummy Helper Classes
@@ -333,23 +336,37 @@ class TestBuildDatasetToolImageContents:
         )
         build_reference = mocker.patch("core.agent.fc_agent_runner.build_file_reference", return_value="file-ref")
 
-        upload_file = MagicMock()
+        upload_file = UploadFile(
+            tenant_id="00000000-0000-0000-0000-000000000001",
+            storage_type=StorageType.LOCAL,
+            key="image_files/chart.png",
+            name="chart.png",
+            size=123,
+            extension="png",
+            mime_type="image/png",
+            created_by_role=CreatorUserRole.ACCOUNT,
+            created_by="00000000-0000-0000-0000-000000000002",
+            created_at=datetime.now(UTC),
+            used=True,
+        )
         upload_file.id = "890985e9-c2f1-484e-bc7b-62010a337e6d"
-        upload_file.name = "chart.png"
-        upload_file.extension = "png"
-        upload_file.mime_type = "image/png"
-        upload_file.source_url = ""
-        upload_file.size = 123
-        upload_file.key = "image_files/chart.png"
-
-        non_image_file = MagicMock()
+        non_image_file = UploadFile(
+            tenant_id=upload_file.tenant_id,
+            storage_type=StorageType.LOCAL,
+            key="files/report.pdf",
+            name="report.pdf",
+            size=10,
+            extension="pdf",
+            mime_type="application/pdf",
+            created_by_role=CreatorUserRole.ACCOUNT,
+            created_by=upload_file.created_by,
+            created_at=datetime.now(UTC),
+            used=True,
+        )
         non_image_file.id = "11111111-1111-1111-1111-111111111111"
-        non_image_file.mime_type = "application/pdf"
-
-        scalars_result = MagicMock()
-        scalars_result.all.return_value = [upload_file, non_image_file]
-        session = MagicMock()
-        session.scalars.return_value = scalars_result
+        session = runner.session
+        session.add_all([upload_file, non_image_file])
+        session.commit()
 
         response = (
             "![image](http://localhost:5001/files/890985e9-c2f1-484e-bc7b-62010a337e6d/file-preview?sign=1)\n"
@@ -392,13 +409,24 @@ class TestRunMethod:
         queue_calls = runner.queue_manager.publish.call_args_list
         assert any(call.args and call.args[0].__class__.__name__ == "QueueMessageEndEvent" for call in queue_calls)
 
-    def test_run_streaming_branch(self, runner: FunctionCallAgentRunner):
+    def test_run_streaming_branch(self, runner: FunctionCallAgentRunner, mocker: MockerFixture):
         message = MagicMock(id="m1")
         runner.stream_tool_call = True
         events: list[str] = []
-        session = MagicMock()
-        session.commit.side_effect = lambda: events.append("commit")
-        session.close.side_effect = lambda: events.append("close")
+        session = runner.session
+        original_commit = session.commit
+        original_close = session.close
+
+        def commit_session() -> None:
+            events.append("commit")
+            original_commit()
+
+        def close_session() -> None:
+            events.append("close")
+            original_close()
+
+        mocker.patch.object(session, "commit", side_effect=commit_session)
+        mocker.patch.object(session, "close", side_effect=close_session)
 
         content = [TextPromptMessageContent(data="hi")]
         chunk = DummyChunk(message=DummyMessage(content=content), usage=build_usage())

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_generator.py
@@ -119,9 +119,7 @@ class TestAdvancedChatAppGeneratorInternals:
             workflow_id="workflow-id",
         )
 
-    def test_generate_loads_conversation_and_files(
-        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
-    ):
+    def test_generate_loads_conversation_and_files(self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session):
         generator = AdvancedChatAppGenerator()
         app_config = self._build_app_config()
 
@@ -210,9 +208,7 @@ class TestAdvancedChatAppGeneratorInternals:
         assert build_files_called["called"] is True
         assert get_conversation.call_args.kwargs["session"] is session
 
-    def test_resume_delegates_to_generate(
-        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
-    ):
+    def test_resume_delegates_to_generate(self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session):
         generator = AdvancedChatAppGenerator()
         existing_trace_manager = SimpleNamespace(app_id="existing-app", user_id="existing-user")
         application_generate_entity = AdvancedChatAppGenerateEntity.model_construct(
@@ -325,9 +321,7 @@ class TestAdvancedChatAppGeneratorInternals:
         assert captured["application_generate_entity"].single_iteration_run.node_id == "node-1"
         assert captured["application_generate_entity"].extras["trace_session_id"] == "session-1"
 
-    def test_single_loop_generate_builds_debug_task(
-        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
-    ):
+    def test_single_loop_generate_builds_debug_task(self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session):
         generator = AdvancedChatAppGenerator()
         app_config = self._build_app_config()
         captured: dict[str, object] = {}
@@ -1165,9 +1159,7 @@ class TestAdvancedChatAppGeneratorInternals:
 
         assert queue_manager.publish_error.called
 
-    def test_generate_debugger_enables_retrieve_source(
-        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
-    ):
+    def test_generate_debugger_enables_retrieve_source(self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session):
         generator = AdvancedChatAppGenerator()
 
         app_config = WorkflowUIBasedAppConfig(
@@ -1402,9 +1394,7 @@ class TestAdvancedChatAppGeneratorResume:
         assert trace_manager.app_id == "app-id"
         assert trace_manager.user_id == "session-id"
 
-    def test_resume_preserves_existing_trace_manager(
-        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
-    ):
+    def test_resume_preserves_existing_trace_manager(self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session):
         generator = AdvancedChatAppGenerator()
         existing_trace_manager = SimpleNamespace(app_id="existing-app", user_id="existing-user")
         application_generate_entity = AdvancedChatAppGenerateEntity.model_construct(

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_generator.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from pydantic import BaseModel, ValidationError
+from sqlalchemy.orm import Session
 
 from constants import UUID_NIL
 from core.app.app_config.entities import AppAdditionalFeatures, WorkflowUIBasedAppConfig
@@ -25,7 +26,7 @@ from models.model import AppMode
 
 
 class TestAdvancedChatAppGeneratorValidation:
-    def test_generate_requires_query(self):
+    def test_generate_requires_query(self, unbound_session: Session):
         generator = AdvancedChatAppGenerator()
 
         with pytest.raises(ValueError, match="query is required"):
@@ -37,10 +38,10 @@ class TestAdvancedChatAppGeneratorValidation:
                 invoke_from=InvokeFrom.WEB_APP,
                 workflow_run_id="run-id",
                 streaming=False,
-                session=MagicMock(),
+                session=unbound_session,
             )
 
-    def test_generate_requires_string_query(self):
+    def test_generate_requires_string_query(self, unbound_session: Session):
         generator = AdvancedChatAppGenerator()
 
         with pytest.raises(ValueError, match="query must be a string"):
@@ -52,10 +53,10 @@ class TestAdvancedChatAppGeneratorValidation:
                 invoke_from=InvokeFrom.WEB_APP,
                 workflow_run_id="run-id",
                 streaming=False,
-                session=MagicMock(),
+                session=unbound_session,
             )
 
-    def test_single_iteration_generate_validates_args(self):
+    def test_single_iteration_generate_validates_args(self, unbound_session: Session):
         generator = AdvancedChatAppGenerator()
 
         with pytest.raises(ValueError, match="node_id is required"):
@@ -66,7 +67,7 @@ class TestAdvancedChatAppGeneratorValidation:
                 user=SimpleNamespace(),
                 args={"inputs": {}},
                 streaming=False,
-                session=MagicMock(),
+                session=unbound_session,
             )
 
         with pytest.raises(ValueError, match="inputs is required"):
@@ -77,10 +78,10 @@ class TestAdvancedChatAppGeneratorValidation:
                 user=SimpleNamespace(),
                 args={},
                 streaming=False,
-                session=MagicMock(),
+                session=unbound_session,
             )
 
-    def test_single_loop_generate_validates_args(self):
+    def test_single_loop_generate_validates_args(self, unbound_session: Session):
         generator = AdvancedChatAppGenerator()
 
         with pytest.raises(ValueError, match="node_id is required"):
@@ -91,7 +92,7 @@ class TestAdvancedChatAppGeneratorValidation:
                 user=SimpleNamespace(),
                 args=SimpleNamespace(inputs={}),
                 streaming=False,
-                session=MagicMock(),
+                session=unbound_session,
             )
 
         with pytest.raises(ValueError, match="inputs is required"):
@@ -102,7 +103,7 @@ class TestAdvancedChatAppGeneratorValidation:
                 user=SimpleNamespace(),
                 args=SimpleNamespace(inputs=None),
                 streaming=False,
-                session=MagicMock(),
+                session=unbound_session,
             )
 
 
@@ -118,7 +119,9 @@ class TestAdvancedChatAppGeneratorInternals:
             workflow_id="workflow-id",
         )
 
-    def test_generate_loads_conversation_and_files(self, monkeypatch: pytest.MonkeyPatch):
+    def test_generate_loads_conversation_and_files(
+        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
+    ):
         generator = AdvancedChatAppGenerator()
         app_config = self._build_app_config()
 
@@ -126,7 +129,7 @@ class TestAdvancedChatAppGeneratorInternals:
         built_files: list[object] = []
         build_files_called = {"called": False}
         captured: dict[str, object] = {}
-        session = MagicMock()
+        session = unbound_session
         get_conversation = MagicMock(return_value=conversation)
 
         monkeypatch.setattr(
@@ -207,7 +210,9 @@ class TestAdvancedChatAppGeneratorInternals:
         assert build_files_called["called"] is True
         assert get_conversation.call_args.kwargs["session"] is session
 
-    def test_resume_delegates_to_generate(self, monkeypatch: pytest.MonkeyPatch):
+    def test_resume_delegates_to_generate(
+        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
+    ):
         generator = AdvancedChatAppGenerator()
         existing_trace_manager = SimpleNamespace(app_id="existing-app", user_id="existing-user")
         application_generate_entity = AdvancedChatAppGenerateEntity.model_construct(
@@ -241,7 +246,7 @@ class TestAdvancedChatAppGeneratorInternals:
             user=SimpleNamespace(id="end-user-id", session_id="session-id"),
             conversation=SimpleNamespace(id="conversation-id"),
             message=SimpleNamespace(id="message-id"),
-            session=MagicMock(),
+            session=unbound_session,
             application_generate_entity=application_generate_entity,
             workflow_execution_repository=SimpleNamespace(),
             workflow_node_execution_repository=SimpleNamespace(),
@@ -254,7 +259,9 @@ class TestAdvancedChatAppGeneratorInternals:
         assert captured_entity.trace_manager is existing_trace_manager
         assert captured_graph_runtime_state is not None
 
-    def test_single_iteration_generate_builds_debug_task(self, monkeypatch: pytest.MonkeyPatch):
+    def test_single_iteration_generate_builds_debug_task(
+        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
+    ):
         generator = AdvancedChatAppGenerator()
         app_config = self._build_app_config()
         captured: dict[str, object] = {}
@@ -262,7 +269,7 @@ class TestAdvancedChatAppGeneratorInternals:
         draft_sessions: list[object] = []
         var_loader = SimpleNamespace(loader="draft")
         workflow = SimpleNamespace(id="workflow-id")
-        session = MagicMock()
+        session = unbound_session
 
         monkeypatch.setattr(
             "core.app.apps.advanced_chat.app_generator.AdvancedChatAppConfigManager.get_app_config",
@@ -318,7 +325,9 @@ class TestAdvancedChatAppGeneratorInternals:
         assert captured["application_generate_entity"].single_iteration_run.node_id == "node-1"
         assert captured["application_generate_entity"].extras["trace_session_id"] == "session-1"
 
-    def test_single_loop_generate_builds_debug_task(self, monkeypatch: pytest.MonkeyPatch):
+    def test_single_loop_generate_builds_debug_task(
+        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
+    ):
         generator = AdvancedChatAppGenerator()
         app_config = self._build_app_config()
         captured: dict[str, object] = {}
@@ -326,7 +335,7 @@ class TestAdvancedChatAppGeneratorInternals:
         draft_sessions: list[object] = []
         var_loader = SimpleNamespace(loader="draft")
         workflow = SimpleNamespace(id="workflow-id")
-        session = MagicMock()
+        session = unbound_session
 
         monkeypatch.setattr(
             "core.app.apps.advanced_chat.app_generator.AdvancedChatAppConfigManager.get_app_config",
@@ -1156,7 +1165,9 @@ class TestAdvancedChatAppGeneratorInternals:
 
         assert queue_manager.publish_error.called
 
-    def test_generate_debugger_enables_retrieve_source(self, monkeypatch: pytest.MonkeyPatch):
+    def test_generate_debugger_enables_retrieve_source(
+        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
+    ):
         generator = AdvancedChatAppGenerator()
 
         app_config = WorkflowUIBasedAppConfig(
@@ -1229,14 +1240,16 @@ class TestAdvancedChatAppGeneratorInternals:
             invoke_from=InvokeFrom.DEBUGGER,
             workflow_run_id="run-id",
             streaming=False,
-            session=MagicMock(),
+            session=unbound_session,
         )
 
         assert result == {"ok": True}
         assert app_config.additional_features.show_retrieve_source is True
         assert captured["application_generate_entity"].query == "hello"
 
-    def test_generate_service_api_sets_parent_message_id(self, monkeypatch: pytest.MonkeyPatch):
+    def test_generate_service_api_sets_parent_message_id(
+        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
+    ):
         generator = AdvancedChatAppGenerator()
 
         app_config = WorkflowUIBasedAppConfig(
@@ -1309,7 +1322,7 @@ class TestAdvancedChatAppGeneratorInternals:
             invoke_from=InvokeFrom.SERVICE_API,
             workflow_run_id="run-id",
             streaming=False,
-            session=MagicMock(),
+            session=unbound_session,
         )
 
         assert captured["application_generate_entity"].parent_message_id == UUID_NIL
@@ -1327,7 +1340,9 @@ class TestAdvancedChatAppGeneratorResume:
             workflow_id="workflow-id",
         )
 
-    def test_resume_restores_trace_manager_when_missing(self, monkeypatch: pytest.MonkeyPatch):
+    def test_resume_restores_trace_manager_when_missing(
+        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
+    ):
         generator = AdvancedChatAppGenerator()
         application_generate_entity = AdvancedChatAppGenerateEntity.model_construct(
             task_id="task",
@@ -1373,7 +1388,7 @@ class TestAdvancedChatAppGeneratorResume:
             user=SimpleNamespace(id="end-user-id", session_id="session-id"),
             conversation=SimpleNamespace(id="conversation-id"),
             message=SimpleNamespace(id="message-id"),
-            session=MagicMock(),
+            session=unbound_session,
             application_generate_entity=application_generate_entity,
             workflow_execution_repository=SimpleNamespace(),
             workflow_node_execution_repository=SimpleNamespace(),
@@ -1387,7 +1402,9 @@ class TestAdvancedChatAppGeneratorResume:
         assert trace_manager.app_id == "app-id"
         assert trace_manager.user_id == "session-id"
 
-    def test_resume_preserves_existing_trace_manager(self, monkeypatch: pytest.MonkeyPatch):
+    def test_resume_preserves_existing_trace_manager(
+        self, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
+    ):
         generator = AdvancedChatAppGenerator()
         existing_trace_manager = SimpleNamespace(app_id="existing-app", user_id="existing-user")
         application_generate_entity = AdvancedChatAppGenerateEntity.model_construct(
@@ -1421,7 +1438,7 @@ class TestAdvancedChatAppGeneratorResume:
             user=SimpleNamespace(id="end-user-id", session_id="session-id"),
             conversation=SimpleNamespace(id="conversation-id"),
             message=SimpleNamespace(id="message-id"),
-            session=MagicMock(),
+            session=unbound_session,
             application_generate_entity=application_generate_entity,
             workflow_execution_repository=SimpleNamespace(),
             workflow_node_execution_repository=SimpleNamespace(),

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_runner_input_moderation.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_runner_input_moderation.py
@@ -1,13 +1,18 @@
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
 
 import core.app.apps.advanced_chat.app_runner as module
 from core.app.apps.advanced_chat.app_runner import AdvancedChatAppRunner
 from core.app.entities.app_invoke_entities import AdvancedChatAppGenerateEntity, InvokeFrom
 from core.app.entities.queue_entities import QueueAnnotationReplyEvent, QueueStopEvent
 from core.moderation.base import ModerationError
+from models.model import App, AppMode, IconType
 
 MINIMAL_GRAPH = {
     "nodes": [
@@ -24,10 +29,11 @@ MINIMAL_GRAPH = {
 
 
 @pytest.fixture
-def build_runner():
+def build_runner(sqlite_session: Session):
     """Construct a minimal AdvancedChatAppRunner with heavy dependencies mocked."""
     app_id = str(uuid4())
     workflow_id = str(uuid4())
+    tenant_id = str(uuid4())
 
     # Mocks for constructor args
     mock_queue_manager = MagicMock()
@@ -41,7 +47,7 @@ def build_runner():
 
     mock_workflow = MagicMock()
     mock_workflow.id = workflow_id
-    mock_workflow.tenant_id = str(uuid4())
+    mock_workflow.tenant_id = tenant_id
     mock_workflow.app_id = app_id
     mock_workflow.type = "chat"
     mock_workflow.graph_dict = MINIMAL_GRAPH
@@ -50,7 +56,22 @@ def build_runner():
     mock_app_config = MagicMock()
     mock_app_config.app_id = app_id
     mock_app_config.workflow_id = workflow_id
-    mock_app_config.tenant_id = str(uuid4())
+    mock_app_config.tenant_id = tenant_id
+
+    sqlite_session.add(
+        App(
+            id=app_id,
+            tenant_id=tenant_id,
+            name="Advanced chat app",
+            mode=AppMode.ADVANCED_CHAT,
+            icon_type=IconType.EMOJI,
+            icon="chat",
+            icon_background="#ffffff",
+            enable_site=False,
+            enable_api=False,
+        )
+    )
+    sqlite_session.commit()
 
     gen = MagicMock(spec=AdvancedChatAppGenerateEntity)
     gen.app_config = mock_app_config
@@ -86,24 +107,8 @@ def build_runner():
 
 def _patch_common_run_deps(runner: AdvancedChatAppRunner):
     """Context manager that patches common heavy deps used by run()."""
-    # create_session() returns a context manager whose body yields a session that
-    # supports both scalar() (app record lookup) and begin()/scalars().all()
-    # (conversation variable initialization).
-    mock_session = MagicMock()
-    mock_session.scalar.return_value = MagicMock()
-    mock_session.scalars.return_value.all.return_value = []
-
-    session_context = MagicMock()
-    session_context.__enter__.return_value = mock_session
-    session_context.__exit__.return_value = False
-    mock_session.begin.return_value.__enter__.return_value = mock_session
-    mock_session.begin.return_value.__exit__.return_value = False
-
     return patch.multiple(
         "core.app.apps.advanced_chat.app_runner",
-        create_session=MagicMock(return_value=session_context),
-        select=MagicMock(),
-        session_factory=MagicMock(get_session_maker=MagicMock(return_value=MagicMock())),
         RedisChannel=MagicMock(),
         redis_client=MagicMock(),
         WorkflowEntry=MagicMock(**{"return_value.run.return_value": iter([])}),
@@ -192,15 +197,15 @@ def test_run_returns_early_when_direct_output_via_handle_input_moderation(build_
         mock_init_graph.assert_not_called()
 
 
-def test_run_publishes_annotation_after_commit(build_runner):
+def test_run_publishes_annotation_after_commit(build_runner, sqlite_engine: Engine):
     runner = build_runner
     events: list[str] = []
-    session = MagicMock()
-    session.scalar.return_value = MagicMock()
-    session.commit.side_effect = lambda: events.append("commit")
-    session_context = MagicMock()
-    session_context.__enter__.return_value = session
-    session_context.__exit__.return_value = False
+
+    def record_commit(session: Session) -> None:
+        if session.get_bind() is sqlite_engine:
+            events.append("commit")
+
+    event.listen(Session, "after_commit", record_commit)
     annotation_reply = MagicMock(id="annotation-1", content="annotated answer")
 
     def publish(event):
@@ -209,7 +214,6 @@ def test_run_publishes_annotation_after_commit(build_runner):
 
     with (
         _patch_common_run_deps(runner),
-        patch.object(module, "create_session", return_value=session_context),
         patch.object(
             runner,
             "handle_input_moderation",
@@ -220,19 +224,22 @@ def test_run_publishes_annotation_after_commit(build_runner):
         patch.object(runner, "_complete_with_stream_output"),
     ):
         runner.run()
+    event.remove(Session, "after_commit", record_commit)
 
     assert events == ["commit", "publish"]
 
 
-def test_run_closes_scoped_session_before_workflow_run(build_runner):
+def test_run_closes_scoped_session_before_workflow_run(
+    build_runner, sqlite_session_factory: sessionmaker[Session]
+):
     runner = build_runner
     events = []
 
-    mock_session = MagicMock()
-    mock_session.scalar.return_value = MagicMock()
-    session_context = MagicMock()
-    session_context.__enter__.return_value = mock_session
-    session_context.__exit__.side_effect = lambda exc_type, exc, tb: events.append("close") or False
+    @contextmanager
+    def observed_session():
+        with sqlite_session_factory() as session:
+            yield session
+        events.append("close")
 
     workflow_entry = MagicMock()
 
@@ -243,8 +250,7 @@ def test_run_closes_scoped_session_before_workflow_run(build_runner):
     workflow_entry.run.side_effect = run_workflow
 
     with (
-        patch.object(module, "create_session", return_value=session_context),
-        patch.object(module, "session_factory", MagicMock(get_session_maker=MagicMock(return_value=MagicMock()))),
+        patch.object(module, "create_session", observed_session),
         patch.object(module, "RedisChannel"),
         patch.object(module, "redis_client"),
         patch.object(module, "WorkflowEntry", return_value=workflow_entry),

--- a/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_runner_input_moderation.py
+++ b/api/tests/unit_tests/core/app/apps/advanced_chat/test_app_runner_input_moderation.py
@@ -229,9 +229,7 @@ def test_run_publishes_annotation_after_commit(build_runner, sqlite_engine: Engi
     assert events == ["commit", "publish"]
 
 
-def test_run_closes_scoped_session_before_workflow_run(
-    build_runner, sqlite_session_factory: sessionmaker[Session]
-):
+def test_run_closes_scoped_session_before_workflow_run(build_runner, sqlite_session_factory: sessionmaker[Session]):
     runner = build_runner
     events = []
 

--- a/api/tests/unit_tests/core/app/apps/agent_chat/test_agent_chat_app_runner.py
+++ b/api/tests/unit_tests/core/app/apps/agent_chat/test_agent_chat_app_runner.py
@@ -80,9 +80,7 @@ def _patch_create_session(mocker: MockerFixture, sqlite_session_factory: session
 
 
 class TestAgentChatAppRunnerRun:
-    def test_run_app_not_found(
-        self, runner: AgentChatAppRunner, mocker: MockerFixture, sqlite_session: Session
-    ):
+    def test_run_app_not_found(self, runner: AgentChatAppRunner, mocker: MockerFixture, sqlite_session: Session):
         app_config = mocker.MagicMock(app_id="app1", tenant_id="tenant", agent=mocker.MagicMock())
         generate_entity = mocker.MagicMock(app_config=app_config, inputs={}, query="q", files=[], stream=True)
 
@@ -175,9 +173,7 @@ class TestAgentChatAppRunnerRun:
 
         runner.run(generate_entity, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), sqlite_session)
 
-    def test_run_model_schema_missing(
-        self, runner: AgentChatAppRunner, mocker: MockerFixture, sqlite_session: Session
-    ):
+    def test_run_model_schema_missing(self, runner: AgentChatAppRunner, mocker: MockerFixture, sqlite_session: Session):
         app_record = mocker.MagicMock(id="app1", tenant_id="tenant")
         app_config = mocker.MagicMock(app_id="app1", tenant_id="tenant", prompt_template=mocker.MagicMock())
         app_config.agent = AgentEntity(provider="p", model="m", strategy=AgentEntity.Strategy.CHAIN_OF_THOUGHT)
@@ -425,9 +421,7 @@ class TestAgentChatAppRunnerRun:
                 sqlite_session,
             )
 
-    def test_run_message_not_found(
-        self, runner: AgentChatAppRunner, mocker: MockerFixture, sqlite_session: Session
-    ):
+    def test_run_message_not_found(self, runner: AgentChatAppRunner, mocker: MockerFixture, sqlite_session: Session):
         app_record = mocker.MagicMock(id="app1", tenant_id="tenant")
         app_config = mocker.MagicMock(app_id="app1", tenant_id="tenant", prompt_template=mocker.MagicMock())
         app_config.agent = AgentEntity(provider="p", model="m", strategy=AgentEntity.Strategy.FUNCTION_CALLING)

--- a/api/tests/unit_tests/core/app/apps/agent_chat/test_agent_chat_app_runner.py
+++ b/api/tests/unit_tests/core/app/apps/agent_chat/test_agent_chat_app_runner.py
@@ -1,41 +1,102 @@
+from datetime import datetime
+
 import pytest
 from pytest_mock import MockerFixture
+from sqlalchemy import event
+from sqlalchemy.orm import Session, sessionmaker
 
 from core.agent.entities import AgentEntity
 from core.app.apps.agent_chat.app_runner import AgentChatAppRunner
+from core.app.entities.app_invoke_entities import InvokeFrom
 from core.moderation.base import ModerationError
 from graphon.model_runtime.entities.llm_entities import LLMMode
 from graphon.model_runtime.entities.model_entities import ModelFeature, ModelPropertyKey
+from models.enums import ConversationFromSource
+from models.model import App, AppMode, Conversation, Message
 
 
 @pytest.fixture
-def runner():
+def runner(sqlite_session: Session):
+    app = App(
+        id="app1",
+        tenant_id="tenant",
+        name="Agent chat app",
+        description="",
+        mode=AppMode.AGENT_CHAT,
+        enable_site=False,
+        enable_api=False,
+    )
+    conversation = Conversation(
+        id="conv",
+        app_id=app.id,
+        app_model_config_id=None,
+        model_provider=None,
+        override_model_configs=None,
+        model_id=None,
+        mode=AppMode.AGENT_CHAT,
+        name="Conversation",
+        inputs={},
+        introduction="",
+        system_instruction="",
+        system_instruction_tokens=0,
+        status="normal",
+        invoke_from=InvokeFrom.SERVICE_API,
+        from_source=ConversationFromSource.API,
+        from_end_user_id=None,
+        from_account_id="user",
+    )
+    message = Message(
+        id="msg",
+        app_id=app.id,
+        conversation_id=conversation.id,
+        inputs={},
+        query="q",
+        message={},
+        message_tokens=0,
+        message_unit_price=0,
+        message_price_unit=0,
+        answer="",
+        answer_tokens=0,
+        answer_unit_price=0,
+        answer_price_unit=0,
+        provider_response_latency=0,
+        total_price=0,
+        currency="USD",
+        invoke_from=InvokeFrom.SERVICE_API,
+        from_source=ConversationFromSource.API,
+        from_end_user_id=None,
+        from_account_id="user",
+        app_mode=AppMode.AGENT_CHAT,
+        created_at=datetime(2025, 1, 1),
+    )
+    sqlite_session.add_all([app, conversation, message])
+    sqlite_session.commit()
     return AgentChatAppRunner()
 
 
-def patch_create_session(mocker: MockerFixture, *, return_value=None, side_effect=None):
-    session = mocker.MagicMock()
-    if side_effect is not None:
-        session.scalar.side_effect = side_effect
-    else:
-        session.scalar.return_value = return_value
-    session_context = mocker.MagicMock()
-    session_context.__enter__.return_value = session
-    mocker.patch("core.app.apps.agent_chat.app_runner.create_session", return_value=session_context)
-    return session
+@pytest.fixture(autouse=True)
+def _patch_create_session(mocker: MockerFixture, sqlite_session_factory: sessionmaker[Session]) -> None:
+    mocker.patch("core.app.apps.agent_chat.app_runner.create_session", side_effect=sqlite_session_factory)
 
 
 class TestAgentChatAppRunnerRun:
-    def test_run_app_not_found(self, runner: AgentChatAppRunner, mocker: MockerFixture):
+    def test_run_app_not_found(
+        self, runner: AgentChatAppRunner, mocker: MockerFixture, sqlite_session: Session
+    ):
         app_config = mocker.MagicMock(app_id="app1", tenant_id="tenant", agent=mocker.MagicMock())
         generate_entity = mocker.MagicMock(app_config=app_config, inputs={}, query="q", files=[], stream=True)
 
-        patch_create_session(mocker, return_value=None)
+        app = sqlite_session.get(App, "app1")
+        assert app is not None
+        sqlite_session.delete(app)
+        sqlite_session.commit()
 
         with pytest.raises(ValueError):
-            runner.run(generate_entity, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock())
+            runner.run(generate_entity, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), sqlite_session)
 
-    def test_run_moderation_error_direct_output(self, runner: AgentChatAppRunner, mocker: MockerFixture):
+    def test_run_moderation_error_direct_output(
+        self, runner: AgentChatAppRunner, mocker: MockerFixture, sqlite_session: Session
+    ):
         app_record = mocker.MagicMock(id="app1", tenant_id="tenant")
         app_config = mocker.MagicMock(app_id="app1", tenant_id="tenant", prompt_template=mocker.MagicMock())
         app_config.agent = mocker.MagicMock()
@@ -49,16 +110,17 @@ class TestAgentChatAppRunnerRun:
             conversation_id=None,
         )
 
-        patch_create_session(mocker, return_value=app_record)
         mocker.patch.object(runner, "organize_prompt_messages", return_value=([], None))
         mocker.patch.object(runner, "moderation_for_inputs", side_effect=ModerationError("bad"))
         mocker.patch.object(runner, "direct_output")
 
-        runner.run(generate_entity, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock())
+        runner.run(generate_entity, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), sqlite_session)
 
         runner.direct_output.assert_called_once()
 
-    def test_run_annotation_reply_short_circuits(self, runner: AgentChatAppRunner, mocker: MockerFixture):
+    def test_run_annotation_reply_short_circuits(
+        self, runner: AgentChatAppRunner, mocker: MockerFixture, sqlite_session: Session
+    ):
         app_record = mocker.MagicMock(id="app1", tenant_id="tenant")
         app_config = mocker.MagicMock(app_id="app1", tenant_id="tenant", prompt_template=mocker.MagicMock())
         app_config.agent = mocker.MagicMock()
@@ -74,7 +136,6 @@ class TestAgentChatAppRunnerRun:
             invoke_from=mocker.MagicMock(),
         )
 
-        patch_create_session(mocker, return_value=app_record)
         mocker.patch.object(runner, "organize_prompt_messages", return_value=([], None))
         mocker.patch.object(runner, "moderation_for_inputs", return_value=(None, {}, "q"))
         annotation = mocker.MagicMock(id="anno", content="answer")
@@ -82,14 +143,16 @@ class TestAgentChatAppRunnerRun:
         mocker.patch.object(runner, "direct_output")
 
         queue_manager = mocker.MagicMock()
-        write_session = mocker.MagicMock()
+        write_session = sqlite_session
         runner.run(generate_entity, queue_manager, mocker.MagicMock(), mocker.MagicMock(), write_session)
 
         queue_manager.publish.assert_called_once()
         assert annotation_query.call_args.kwargs["session"] is write_session
         runner.direct_output.assert_called_once()
 
-    def test_run_hosting_moderation_short_circuits(self, runner: AgentChatAppRunner, mocker: MockerFixture):
+    def test_run_hosting_moderation_short_circuits(
+        self, runner: AgentChatAppRunner, mocker: MockerFixture, sqlite_session: Session
+    ):
         app_record = mocker.MagicMock(id="app1", tenant_id="tenant")
         app_config = mocker.MagicMock(app_id="app1", tenant_id="tenant", prompt_template=mocker.MagicMock())
         app_config.agent = mocker.MagicMock()
@@ -105,159 +168,15 @@ class TestAgentChatAppRunnerRun:
             user_id="user",
         )
 
-        patch_create_session(mocker, return_value=app_record)
         mocker.patch.object(runner, "organize_prompt_messages", return_value=([], None))
         mocker.patch.object(runner, "moderation_for_inputs", return_value=(None, {}, "q"))
         mocker.patch.object(runner, "query_app_annotations_to_reply", return_value=None)
         mocker.patch.object(runner, "check_hosting_moderation", return_value=True)
 
-        runner.run(generate_entity, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock())
+        runner.run(generate_entity, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), sqlite_session)
 
-    def test_run_model_schema_missing(self, runner: AgentChatAppRunner, mocker: MockerFixture):
-        app_record = mocker.MagicMock(id="app1", tenant_id="tenant")
-        app_config = mocker.MagicMock(app_id="app1", tenant_id="tenant", prompt_template=mocker.MagicMock())
-        app_config.agent = AgentEntity(provider="p", model="m", strategy=AgentEntity.Strategy.CHAIN_OF_THOUGHT)
-
-        generate_entity = mocker.MagicMock(
-            app_config=app_config,
-            inputs={},
-            query="q",
-            files=[],
-            stream=True,
-            model_conf=mocker.MagicMock(
-                provider_model_bundle=mocker.MagicMock(),
-                model="m",
-                provider="p",
-                credentials={"k": "v"},
-            ),
-            conversation_id="conv",
-            invoke_from=mocker.MagicMock(),
-            user_id="user",
-        )
-
-        patch_create_session(mocker, return_value=app_record)
-        mocker.patch.object(runner, "organize_prompt_messages", return_value=([], None))
-        mocker.patch.object(runner, "moderation_for_inputs", return_value=(None, {}, "q"))
-        mocker.patch.object(runner, "query_app_annotations_to_reply", return_value=None)
-        mocker.patch.object(runner, "check_hosting_moderation", return_value=False)
-
-        llm_instance = mocker.MagicMock()
-        llm_instance.model_type_instance.get_model_schema.return_value = None
-        mocker.patch("core.app.apps.agent_chat.app_runner.ModelInstance", return_value=llm_instance)
-
-        with pytest.raises(ValueError):
-            runner.run(generate_entity, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock())
-
-    @pytest.mark.parametrize(
-        ("mode", "expected_runner"),
-        [
-            (LLMMode.CHAT, "CotChatAgentRunner"),
-            (LLMMode.COMPLETION, "CotCompletionAgentRunner"),
-        ],
-    )
-    def test_run_chain_of_thought_modes(self, runner: AgentChatAppRunner, mocker: MockerFixture, mode, expected_runner):
-        app_record = mocker.MagicMock(id="app1", tenant_id="tenant")
-        app_config = mocker.MagicMock(app_id="app1", tenant_id="tenant", prompt_template=mocker.MagicMock())
-        app_config.agent = AgentEntity(provider="p", model="m", strategy=AgentEntity.Strategy.CHAIN_OF_THOUGHT)
-
-        generate_entity = mocker.MagicMock(
-            app_config=app_config,
-            inputs={},
-            query="q",
-            files=[],
-            stream=True,
-            model_conf=mocker.MagicMock(
-                provider_model_bundle=mocker.MagicMock(),
-                model="m",
-                provider="p",
-                credentials={"k": "v"},
-            ),
-            conversation_id="conv",
-            invoke_from=mocker.MagicMock(),
-            user_id="user",
-        )
-
-        patch_create_session(mocker, return_value=app_record)
-        mocker.patch.object(runner, "organize_prompt_messages", return_value=([], None))
-        mocker.patch.object(runner, "moderation_for_inputs", return_value=(None, {}, "q"))
-        mocker.patch.object(runner, "query_app_annotations_to_reply", return_value=None)
-        mocker.patch.object(runner, "check_hosting_moderation", return_value=False)
-
-        model_schema = mocker.MagicMock()
-        model_schema.features = []
-        model_schema.model_properties = {ModelPropertyKey.MODE: mode}
-
-        llm_instance = mocker.MagicMock()
-        llm_instance.model_type_instance.get_model_schema.return_value = model_schema
-        mocker.patch("core.app.apps.agent_chat.app_runner.ModelInstance", return_value=llm_instance)
-
-        conversation = mocker.MagicMock(id="conv")
-        message = mocker.MagicMock(id="msg")
-        patch_create_session(mocker, side_effect=[app_record, conversation, message])
-
-        runner_cls = mocker.MagicMock()
-        mocker.patch(f"core.app.apps.agent_chat.app_runner.{expected_runner}", runner_cls)
-
-        runner_instance = mocker.MagicMock()
-        runner_cls.return_value = runner_instance
-        events: list[str] = []
-        runner_instance.run.side_effect = lambda **_kwargs: events.append("agent-run") or []
-        mocker.patch.object(runner, "_handle_invoke_result")
-        session = mocker.MagicMock()
-        session.commit.side_effect = lambda: events.append("commit")
-        session.close.side_effect = lambda: events.append("close")
-
-        runner.run(generate_entity, mocker.MagicMock(), conversation, message, session)
-
-        assert events == ["commit", "close", "commit", "close", "agent-run"]
-        runner_instance.run.assert_called_once()
-        runner._handle_invoke_result.assert_called_once()
-
-    def test_run_invalid_llm_mode_raises(self, runner: AgentChatAppRunner, mocker: MockerFixture):
-        app_record = mocker.MagicMock(id="app1", tenant_id="tenant")
-        app_config = mocker.MagicMock(app_id="app1", tenant_id="tenant", prompt_template=mocker.MagicMock())
-        app_config.agent = AgentEntity(provider="p", model="m", strategy=AgentEntity.Strategy.CHAIN_OF_THOUGHT)
-
-        generate_entity = mocker.MagicMock(
-            app_config=app_config,
-            inputs={},
-            query="q",
-            files=[],
-            stream=True,
-            model_conf=mocker.MagicMock(
-                provider_model_bundle=mocker.MagicMock(),
-                model="m",
-                provider="p",
-                credentials={"k": "v"},
-            ),
-            conversation_id="conv",
-            invoke_from=mocker.MagicMock(),
-            user_id="user",
-        )
-
-        patch_create_session(mocker, return_value=app_record)
-        mocker.patch.object(runner, "organize_prompt_messages", return_value=([], None))
-        mocker.patch.object(runner, "moderation_for_inputs", return_value=(None, {}, "q"))
-        mocker.patch.object(runner, "query_app_annotations_to_reply", return_value=None)
-        mocker.patch.object(runner, "check_hosting_moderation", return_value=False)
-
-        model_schema = mocker.MagicMock()
-        model_schema.features = []
-        model_schema.model_properties = {ModelPropertyKey.MODE: "invalid"}
-
-        llm_instance = mocker.MagicMock()
-        llm_instance.model_type_instance.get_model_schema.return_value = model_schema
-        mocker.patch("core.app.apps.agent_chat.app_runner.ModelInstance", return_value=llm_instance)
-
-        conversation = mocker.MagicMock(id="conv")
-        message = mocker.MagicMock(id="msg")
-        patch_create_session(mocker, side_effect=[app_record, conversation, message])
-
-        with pytest.raises(ValueError):
-            runner.run(generate_entity, mocker.MagicMock(), conversation, message, mocker.MagicMock())
-
-    def test_run_function_calling_strategy_selected_by_features(
-        self, runner: AgentChatAppRunner, mocker: MockerFixture
+    def test_run_model_schema_missing(
+        self, runner: AgentChatAppRunner, mocker: MockerFixture, sqlite_session: Session
     ):
         app_record = mocker.MagicMock(id="app1", tenant_id="tenant")
         app_config = mocker.MagicMock(app_id="app1", tenant_id="tenant", prompt_template=mocker.MagicMock())
@@ -280,7 +199,161 @@ class TestAgentChatAppRunnerRun:
             user_id="user",
         )
 
-        patch_create_session(mocker, return_value=app_record)
+        mocker.patch.object(runner, "organize_prompt_messages", return_value=([], None))
+        mocker.patch.object(runner, "moderation_for_inputs", return_value=(None, {}, "q"))
+        mocker.patch.object(runner, "query_app_annotations_to_reply", return_value=None)
+        mocker.patch.object(runner, "check_hosting_moderation", return_value=False)
+
+        llm_instance = mocker.MagicMock()
+        llm_instance.model_type_instance.get_model_schema.return_value = None
+        mocker.patch("core.app.apps.agent_chat.app_runner.ModelInstance", return_value=llm_instance)
+
+        with pytest.raises(ValueError):
+            runner.run(generate_entity, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), sqlite_session)
+
+    @pytest.mark.parametrize(
+        ("mode", "expected_runner"),
+        [
+            (LLMMode.CHAT, "CotChatAgentRunner"),
+            (LLMMode.COMPLETION, "CotCompletionAgentRunner"),
+        ],
+    )
+    def test_run_chain_of_thought_modes(
+        self,
+        runner: AgentChatAppRunner,
+        mocker: MockerFixture,
+        mode,
+        expected_runner,
+        sqlite_session: Session,
+    ):
+        app_record = mocker.MagicMock(id="app1", tenant_id="tenant")
+        app_config = mocker.MagicMock(app_id="app1", tenant_id="tenant", prompt_template=mocker.MagicMock())
+        app_config.agent = AgentEntity(provider="p", model="m", strategy=AgentEntity.Strategy.CHAIN_OF_THOUGHT)
+
+        generate_entity = mocker.MagicMock(
+            app_config=app_config,
+            inputs={},
+            query="q",
+            files=[],
+            stream=True,
+            model_conf=mocker.MagicMock(
+                provider_model_bundle=mocker.MagicMock(),
+                model="m",
+                provider="p",
+                credentials={"k": "v"},
+            ),
+            conversation_id="conv",
+            invoke_from=mocker.MagicMock(),
+            user_id="user",
+        )
+
+        mocker.patch.object(runner, "organize_prompt_messages", return_value=([], None))
+        mocker.patch.object(runner, "moderation_for_inputs", return_value=(None, {}, "q"))
+        mocker.patch.object(runner, "query_app_annotations_to_reply", return_value=None)
+        mocker.patch.object(runner, "check_hosting_moderation", return_value=False)
+
+        model_schema = mocker.MagicMock()
+        model_schema.features = []
+        model_schema.model_properties = {ModelPropertyKey.MODE: mode}
+
+        llm_instance = mocker.MagicMock()
+        llm_instance.model_type_instance.get_model_schema.return_value = model_schema
+        mocker.patch("core.app.apps.agent_chat.app_runner.ModelInstance", return_value=llm_instance)
+
+        conversation = mocker.MagicMock(id="conv")
+        message = mocker.MagicMock(id="msg")
+
+        runner_cls = mocker.MagicMock()
+        mocker.patch(f"core.app.apps.agent_chat.app_runner.{expected_runner}", runner_cls)
+
+        runner_instance = mocker.MagicMock()
+        runner_cls.return_value = runner_instance
+        events: list[str] = []
+        runner_instance.run.side_effect = lambda **_kwargs: events.append("agent-run") or []
+        mocker.patch.object(runner, "_handle_invoke_result")
+        session = sqlite_session
+        event.listen(session, "after_commit", lambda _session: events.append("commit"))
+        original_close = session.close
+
+        def close_session() -> None:
+            events.append("close")
+            original_close()
+
+        session.close = close_session
+
+        runner.run(generate_entity, mocker.MagicMock(), conversation, message, session)
+
+        assert events == ["commit", "close", "commit", "close", "agent-run"]
+        runner_instance.run.assert_called_once()
+        runner._handle_invoke_result.assert_called_once()
+
+    def test_run_invalid_llm_mode_raises(
+        self, runner: AgentChatAppRunner, mocker: MockerFixture, sqlite_session: Session
+    ):
+        app_record = mocker.MagicMock(id="app1", tenant_id="tenant")
+        app_config = mocker.MagicMock(app_id="app1", tenant_id="tenant", prompt_template=mocker.MagicMock())
+        app_config.agent = AgentEntity(provider="p", model="m", strategy=AgentEntity.Strategy.CHAIN_OF_THOUGHT)
+
+        generate_entity = mocker.MagicMock(
+            app_config=app_config,
+            inputs={},
+            query="q",
+            files=[],
+            stream=True,
+            model_conf=mocker.MagicMock(
+                provider_model_bundle=mocker.MagicMock(),
+                model="m",
+                provider="p",
+                credentials={"k": "v"},
+            ),
+            conversation_id="conv",
+            invoke_from=mocker.MagicMock(),
+            user_id="user",
+        )
+
+        mocker.patch.object(runner, "organize_prompt_messages", return_value=([], None))
+        mocker.patch.object(runner, "moderation_for_inputs", return_value=(None, {}, "q"))
+        mocker.patch.object(runner, "query_app_annotations_to_reply", return_value=None)
+        mocker.patch.object(runner, "check_hosting_moderation", return_value=False)
+
+        model_schema = mocker.MagicMock()
+        model_schema.features = []
+        model_schema.model_properties = {ModelPropertyKey.MODE: "invalid"}
+
+        llm_instance = mocker.MagicMock()
+        llm_instance.model_type_instance.get_model_schema.return_value = model_schema
+        mocker.patch("core.app.apps.agent_chat.app_runner.ModelInstance", return_value=llm_instance)
+
+        conversation = mocker.MagicMock(id="conv")
+        message = mocker.MagicMock(id="msg")
+
+        with pytest.raises(ValueError):
+            runner.run(generate_entity, mocker.MagicMock(), conversation, message, sqlite_session)
+
+    def test_run_function_calling_strategy_selected_by_features(
+        self, runner: AgentChatAppRunner, mocker: MockerFixture, sqlite_session: Session
+    ):
+        app_record = mocker.MagicMock(id="app1", tenant_id="tenant")
+        app_config = mocker.MagicMock(app_id="app1", tenant_id="tenant", prompt_template=mocker.MagicMock())
+        app_config.agent = AgentEntity(provider="p", model="m", strategy=AgentEntity.Strategy.CHAIN_OF_THOUGHT)
+
+        generate_entity = mocker.MagicMock(
+            app_config=app_config,
+            inputs={},
+            query="q",
+            files=[],
+            stream=True,
+            model_conf=mocker.MagicMock(
+                provider_model_bundle=mocker.MagicMock(),
+                model="m",
+                provider="p",
+                credentials={"k": "v"},
+            ),
+            conversation_id="conv",
+            invoke_from=mocker.MagicMock(),
+            user_id="user",
+        )
+
         mocker.patch.object(runner, "organize_prompt_messages", return_value=([], None))
         mocker.patch.object(runner, "moderation_for_inputs", return_value=(None, {}, "q"))
         mocker.patch.object(runner, "query_app_annotations_to_reply", return_value=None)
@@ -296,7 +369,6 @@ class TestAgentChatAppRunnerRun:
 
         conversation = mocker.MagicMock(id="conv")
         message = mocker.MagicMock(id="msg")
-        patch_create_session(mocker, side_effect=[app_record, conversation, message])
 
         runner_cls = mocker.MagicMock()
         mocker.patch("core.app.apps.agent_chat.app_runner.FunctionCallAgentRunner", runner_cls)
@@ -306,12 +378,14 @@ class TestAgentChatAppRunnerRun:
         runner_instance.run.return_value = []
         mocker.patch.object(runner, "_handle_invoke_result")
 
-        runner.run(generate_entity, mocker.MagicMock(), conversation, message, mocker.MagicMock())
+        runner.run(generate_entity, mocker.MagicMock(), conversation, message, sqlite_session)
 
         assert app_config.agent.strategy == AgentEntity.Strategy.FUNCTION_CALLING
         runner_instance.run.assert_called_once()
 
-    def test_run_conversation_not_found(self, runner: AgentChatAppRunner, mocker: MockerFixture):
+    def test_run_conversation_not_found(
+        self, runner: AgentChatAppRunner, mocker: MockerFixture, sqlite_session: Session
+    ):
         app_record = mocker.MagicMock(id="app1", tenant_id="tenant")
         app_config = mocker.MagicMock(app_id="app1", tenant_id="tenant", prompt_template=mocker.MagicMock())
         app_config.agent = AgentEntity(provider="p", model="m", strategy=AgentEntity.Strategy.FUNCTION_CALLING)
@@ -333,7 +407,10 @@ class TestAgentChatAppRunnerRun:
             user_id="user",
         )
 
-        patch_create_session(mocker, side_effect=[app_record, None])
+        conversation_record = sqlite_session.get(Conversation, "conv")
+        assert conversation_record is not None
+        sqlite_session.delete(conversation_record)
+        sqlite_session.commit()
         mocker.patch.object(runner, "organize_prompt_messages", return_value=([], None))
         mocker.patch.object(runner, "moderation_for_inputs", return_value=(None, {}, "q"))
         mocker.patch.object(runner, "query_app_annotations_to_reply", return_value=None)
@@ -345,10 +422,12 @@ class TestAgentChatAppRunnerRun:
                 mocker.MagicMock(),
                 mocker.MagicMock(id="conv"),
                 mocker.MagicMock(id="msg"),
-                mocker.MagicMock(),
+                sqlite_session,
             )
 
-    def test_run_message_not_found(self, runner: AgentChatAppRunner, mocker: MockerFixture):
+    def test_run_message_not_found(
+        self, runner: AgentChatAppRunner, mocker: MockerFixture, sqlite_session: Session
+    ):
         app_record = mocker.MagicMock(id="app1", tenant_id="tenant")
         app_config = mocker.MagicMock(app_id="app1", tenant_id="tenant", prompt_template=mocker.MagicMock())
         app_config.agent = AgentEntity(provider="p", model="m", strategy=AgentEntity.Strategy.FUNCTION_CALLING)
@@ -370,7 +449,10 @@ class TestAgentChatAppRunnerRun:
             user_id="user",
         )
 
-        patch_create_session(mocker, side_effect=[app_record, mocker.MagicMock(id="conv"), None])
+        message_record = sqlite_session.get(Message, "msg")
+        assert message_record is not None
+        sqlite_session.delete(message_record)
+        sqlite_session.commit()
         mocker.patch.object(runner, "organize_prompt_messages", return_value=([], None))
         mocker.patch.object(runner, "moderation_for_inputs", return_value=(None, {}, "q"))
         mocker.patch.object(runner, "query_app_annotations_to_reply", return_value=None)
@@ -382,10 +464,12 @@ class TestAgentChatAppRunnerRun:
                 mocker.MagicMock(),
                 mocker.MagicMock(id="conv"),
                 mocker.MagicMock(id="msg"),
-                mocker.MagicMock(),
+                sqlite_session,
             )
 
-    def test_run_invalid_agent_strategy_raises(self, runner: AgentChatAppRunner, mocker: MockerFixture):
+    def test_run_invalid_agent_strategy_raises(
+        self, runner: AgentChatAppRunner, mocker: MockerFixture, sqlite_session: Session
+    ):
         app_record = mocker.MagicMock(id="app1", tenant_id="tenant")
         app_config = mocker.MagicMock(app_id="app1", tenant_id="tenant", prompt_template=mocker.MagicMock())
         app_config.agent = mocker.MagicMock(strategy="invalid", provider="p", model="m")
@@ -407,7 +491,6 @@ class TestAgentChatAppRunnerRun:
             user_id="user",
         )
 
-        patch_create_session(mocker, return_value=app_record)
         mocker.patch.object(runner, "organize_prompt_messages", return_value=([], None))
         mocker.patch.object(runner, "moderation_for_inputs", return_value=(None, {}, "q"))
         mocker.patch.object(runner, "query_app_annotations_to_reply", return_value=None)
@@ -423,7 +506,6 @@ class TestAgentChatAppRunnerRun:
 
         conversation = mocker.MagicMock(id="conv")
         message = mocker.MagicMock(id="msg")
-        patch_create_session(mocker, side_effect=[app_record, conversation, message])
 
         with pytest.raises(ValueError):
-            runner.run(generate_entity, mocker.MagicMock(), conversation, message, mocker.MagicMock())
+            runner.run(generate_entity, mocker.MagicMock(), conversation, message, sqlite_session)

--- a/api/tests/unit_tests/core/app/apps/chat/test_app_config_manager.py
+++ b/api/tests/unit_tests/core/app/apps/chat/test_app_config_manager.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from sqlalchemy.orm import Session
+
 from core.app.app_config.entities import EasyUIBasedAppModelConfigFrom, ModelConfigEntity, PromptTemplateEntity
 from core.app.apps.chat.app_config_manager import ChatAppConfigManager
 from models.model import AppMode
@@ -76,7 +78,7 @@ class TestChatAppConfigManager:
 
         app_model_config.to_dict.assert_called_once_with(annotation_reply=annotation_reply)
 
-    def test_config_validate_filters_related_keys(self):
+    def test_config_validate_filters_related_keys(self, unbound_session: Session):
         config = {"extra": 1}
 
         def _add_key(key, value):
@@ -133,7 +135,7 @@ class TestChatAppConfigManager:
                 side_effect=_add_key("sensitive_word_avoidance", 11),
             ),
         ):
-            filtered = ChatAppConfigManager.config_validate(session=MagicMock(), tenant_id="t1", config=config)
+            filtered = ChatAppConfigManager.config_validate(session=unbound_session, tenant_id="t1", config=config)
 
         assert filtered["model"] == 1
         assert filtered["inputs"] == 2

--- a/api/tests/unit_tests/core/app/apps/chat/test_app_generator_and_runner.py
+++ b/api/tests/unit_tests/core/app/apps/chat/test_app_generator_and_runner.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import ANY, MagicMock, Mock, patch
 
 import pytest
+from sqlalchemy.orm import Session, sessionmaker
 
 from core.app.apps.chat.app_generator import ChatAppGenerator
 from core.app.apps.chat.app_runner import ChatAppRunner
@@ -11,7 +12,7 @@ from core.app.entities.app_invoke_entities import InvokeFrom
 from core.app.entities.queue_entities import QueueAnnotationReplyEvent
 from core.moderation.base import ModerationError
 from graphon.model_runtime.errors.invoke import InvokeAuthorizationError
-from models.model import AppMode
+from models.model import App, AppMode, IconType
 
 
 class DummyGenerateEntity:
@@ -31,24 +32,39 @@ class DummyQueueManager:
 
 
 @contextmanager
-def patched_create_session(*, return_value=None, side_effect=None):
-    session = MagicMock()
-    if side_effect is not None:
-        session.scalar.side_effect = side_effect
-    else:
-        session.scalar.return_value = return_value
-    session_context = MagicMock()
-    session_context.__enter__.return_value = session
-    with patch("core.app.apps.chat.app_runner.create_session", return_value=session_context):
-        yield session
+def patched_create_session(session_factory: sessionmaker[Session]):
+    @contextmanager
+    def create_session():
+        with session_factory() as session:
+            yield session
+
+    with patch("core.app.apps.chat.app_runner.create_session", create_session):
+        yield
+
+
+def _persist_app(session: Session) -> App:
+    app = App(
+        id="app-1",
+        tenant_id="tenant-1",
+        name="Chat app",
+        mode=AppMode.CHAT,
+        icon_type=IconType.EMOJI,
+        icon="chat",
+        icon_background="#ffffff",
+        enable_site=False,
+        enable_api=True,
+    )
+    session.add(app)
+    session.commit()
+    return app
 
 
 class TestChatAppGenerator:
-    def test_generate_requires_query(self):
+    def test_generate_requires_query(self, unbound_session: Session):
         generator = ChatAppGenerator()
         with pytest.raises(ValueError):
             generator.generate(
-                session=MagicMock(),
+                session=unbound_session,
                 app_model=SimpleNamespace(),
                 user=SimpleNamespace(),
                 args={"inputs": {}},
@@ -56,11 +72,11 @@ class TestChatAppGenerator:
                 streaming=False,
             )
 
-    def test_generate_rejects_non_string_query(self):
+    def test_generate_rejects_non_string_query(self, unbound_session: Session):
         generator = ChatAppGenerator()
         with pytest.raises(ValueError):
             generator.generate(
-                session=MagicMock(),
+                session=unbound_session,
                 app_model=SimpleNamespace(),
                 user=SimpleNamespace(),
                 args={"query": 1, "inputs": {}},
@@ -68,11 +84,10 @@ class TestChatAppGenerator:
                 streaming=False,
             )
 
-    def test_generate_debugger_overrides_model_config(self):
+    def test_generate_debugger_overrides_model_config(self, unbound_session: Session):
         generator = ChatAppGenerator()
         app_model = SimpleNamespace(id="app-1", tenant_id="tenant-1")
         user = SimpleNamespace(id="user-1", session_id="session-1")
-        session = MagicMock()
         args = {
             "query": "hi",
             "inputs": {},
@@ -116,19 +131,20 @@ class TestChatAppGenerator:
             patch("core.app.apps.chat.app_generator.threading.Thread") as mock_thread,
         ):
             mock_thread.return_value.start.return_value = None
-            result = generator.generate(app_model, user, args, InvokeFrom.DEBUGGER, streaming=False, session=session)
+            result = generator.generate(
+                app_model, user, args, InvokeFrom.DEBUGGER, streaming=False, session=unbound_session
+            )
 
         assert result == {"ok": True}
-        assert get_conversation.call_args.kwargs["session"] is session
+        assert get_conversation.call_args.kwargs["session"] is unbound_session
         assert generate_entity.call_args.kwargs["extras"]["trace_session_id"] == "session-1"
 
-    def test_generate_uses_session_for_annotation_reply(self):
+    def test_generate_uses_session_for_annotation_reply(self, unbound_session: Session):
         generator = ChatAppGenerator()
         app_model = SimpleNamespace(id="app-1", tenant_id="tenant-1")
         app_model_config = MagicMock(id="config-1", app_id="app-1")
         annotation_reply = {"enabled": False}
         user = SimpleNamespace(id="user-1", session_id="session-1")
-        session = MagicMock()
 
         with (
             patch.object(ChatAppGenerator, "_get_app_model_config", return_value=app_model_config),
@@ -148,14 +164,14 @@ class TestChatAppGenerator:
                     user,
                     {"query": "hi", "inputs": {}},
                     InvokeFrom.WEB_APP,
-                    session=session,
+                    session=unbound_session,
                 )
 
-        load_annotation_reply_config.assert_called_once_with(session, "app-1")
+        load_annotation_reply_config.assert_called_once_with(unbound_session, "app-1")
         app_model_config.to_dict.assert_called_once_with(annotation_reply=annotation_reply)
         assert get_app_config.call_args.kwargs["annotation_reply"] is annotation_reply
 
-    def test_generate_rejects_model_config_override_for_non_debugger(self):
+    def test_generate_rejects_model_config_override_for_non_debugger(self, unbound_session: Session):
         generator = ChatAppGenerator()
         with pytest.raises(ValueError):
             with (
@@ -164,7 +180,7 @@ class TestChatAppGenerator:
                 ),
             ):
                 generator.generate(
-                    session=MagicMock(),
+                    session=unbound_session,
                     app_model=SimpleNamespace(tenant_id="t1", id="a1", mode=AppMode.CHAT.value),
                     user=SimpleNamespace(id="u1", session_id="s1"),
                     args={"query": "hi", "inputs": {}, "model_config": {"foo": "bar"}},
@@ -172,7 +188,7 @@ class TestChatAppGenerator:
                     streaming=False,
                 )
 
-    def test_generate_worker_handles_exceptions(self):
+    def test_generate_worker_handles_exceptions(self, unbound_session_factory: sessionmaker[Session]):
         generator = ChatAppGenerator()
         queue_manager = DummyQueueManager()
         entity = DummyGenerateEntity(task_id="t1", user_id="u1")
@@ -181,10 +197,12 @@ class TestChatAppGenerator:
             patch.object(ChatAppGenerator, "_get_conversation", return_value=SimpleNamespace()),
             patch.object(ChatAppGenerator, "_get_message", return_value=SimpleNamespace()),
             patch("core.app.apps.chat.app_generator.ChatAppRunner.run", side_effect=InvokeAuthorizationError()),
-            patch("core.app.apps.chat.app_generator.session_factory.create_session") as create_session,
+            patch(
+                "core.app.apps.chat.app_generator.session_factory",
+                SimpleNamespace(create_session=unbound_session_factory),
+            ),
             patch("core.app.apps.chat.app_generator.db.session.close"),
         ):
-            create_session.return_value.__enter__.return_value = MagicMock()
             generator._generate_worker(
                 flask_app=Mock(app_context=Mock(return_value=Mock(__enter__=Mock(), __exit__=Mock()))),
                 application_generate_entity=entity,
@@ -199,10 +217,12 @@ class TestChatAppGenerator:
             patch.object(ChatAppGenerator, "_get_conversation", return_value=SimpleNamespace()),
             patch.object(ChatAppGenerator, "_get_message", return_value=SimpleNamespace()),
             patch("core.app.apps.chat.app_generator.ChatAppRunner.run", side_effect=GenerateTaskStoppedError()),
-            patch("core.app.apps.chat.app_generator.session_factory.create_session") as create_session,
+            patch(
+                "core.app.apps.chat.app_generator.session_factory",
+                SimpleNamespace(create_session=unbound_session_factory),
+            ),
             patch("core.app.apps.chat.app_generator.db.session.close"),
         ):
-            create_session.return_value.__enter__.return_value = MagicMock()
             generator._generate_worker(
                 flask_app=Mock(app_context=Mock(return_value=Mock(__enter__=Mock(), __exit__=Mock()))),
                 application_generate_entity=entity,
@@ -213,7 +233,9 @@ class TestChatAppGenerator:
 
 
 class TestChatAppRunner:
-    def test_run_raises_when_app_missing(self):
+    def test_run_raises_when_app_missing(
+        self, sqlite_session_factory: sessionmaker[Session], unbound_session: Session
+    ):
         runner = ChatAppRunner()
         app_config = SimpleNamespace(
             app_id="app-1", tenant_id="tenant-1", prompt_template=None, external_data_variables=[]
@@ -231,13 +253,20 @@ class TestChatAppRunner:
             invoke_from=InvokeFrom.SERVICE_API,
         )
 
-        with patched_create_session(return_value=None):
+        with patched_create_session(sqlite_session_factory):
             with pytest.raises(ValueError):
                 runner.run(
-                    app_generate_entity, DummyQueueManager(), SimpleNamespace(), SimpleNamespace(id="m1"), MagicMock()
+                    app_generate_entity,
+                    DummyQueueManager(),
+                    SimpleNamespace(),
+                    SimpleNamespace(id="m1"),
+                    unbound_session,
                 )
 
-    def test_run_moderation_error_direct_output(self):
+    def test_run_moderation_error_direct_output(
+        self, sqlite_session: Session, sqlite_session_factory: sessionmaker[Session]
+    ):
+        _persist_app(sqlite_session)
         runner = ChatAppRunner()
         app_config = SimpleNamespace(
             app_id="app-1",
@@ -261,18 +290,25 @@ class TestChatAppRunner:
         )
 
         with (
-            patched_create_session(return_value=SimpleNamespace(id="app-1", tenant_id="tenant-1")),
+            patched_create_session(sqlite_session_factory),
             patch.object(ChatAppRunner, "organize_prompt_messages", return_value=([], [])),
             patch.object(ChatAppRunner, "moderation_for_inputs", side_effect=ModerationError("blocked")),
             patch.object(ChatAppRunner, "direct_output") as mock_direct,
         ):
             runner.run(
-                app_generate_entity, DummyQueueManager(), SimpleNamespace(), SimpleNamespace(id="m1"), MagicMock()
+                app_generate_entity,
+                DummyQueueManager(),
+                SimpleNamespace(),
+                SimpleNamespace(id="m1"),
+                sqlite_session,
             )
 
         mock_direct.assert_called_once()
 
-    def test_run_annotation_reply_short_circuits(self):
+    def test_run_annotation_reply_short_circuits(
+        self, sqlite_session: Session, sqlite_session_factory: sessionmaker[Session]
+    ):
+        _persist_app(sqlite_session)
         runner = ChatAppRunner()
         app_config = SimpleNamespace(
             app_id="app-1",
@@ -298,21 +334,25 @@ class TestChatAppRunner:
         annotation = SimpleNamespace(id="ann-1", content="answer")
 
         with (
-            patched_create_session(return_value=SimpleNamespace(id="app-1", tenant_id="tenant-1")),
+            patched_create_session(sqlite_session_factory),
             patch.object(ChatAppRunner, "organize_prompt_messages", return_value=([], [])),
             patch.object(ChatAppRunner, "moderation_for_inputs", return_value=(None, {}, "hi")),
             patch.object(ChatAppRunner, "query_app_annotations_to_reply", return_value=annotation) as annotation_query,
             patch.object(ChatAppRunner, "direct_output") as mock_direct,
         ):
             queue_manager = DummyQueueManager()
-            write_session = MagicMock()
-            runner.run(app_generate_entity, queue_manager, SimpleNamespace(), SimpleNamespace(id="m1"), write_session)
+            runner.run(
+                app_generate_entity, queue_manager, SimpleNamespace(), SimpleNamespace(id="m1"), sqlite_session
+            )
 
         assert any(isinstance(item[0], QueueAnnotationReplyEvent) for item in queue_manager.published)
-        assert annotation_query.call_args.kwargs["session"] is write_session
+        assert annotation_query.call_args.kwargs["session"] is sqlite_session
         mock_direct.assert_called_once()
 
-    def test_run_returns_when_hosting_moderation_blocks(self):
+    def test_run_returns_when_hosting_moderation_blocks(
+        self, sqlite_session: Session, sqlite_session_factory: sessionmaker[Session]
+    ):
+        _persist_app(sqlite_session)
         runner = ChatAppRunner()
         app_config = SimpleNamespace(
             app_id="app-1",
@@ -336,17 +376,24 @@ class TestChatAppRunner:
         )
 
         with (
-            patched_create_session(return_value=SimpleNamespace(id="app-1", tenant_id="tenant-1")),
+            patched_create_session(sqlite_session_factory),
             patch.object(ChatAppRunner, "organize_prompt_messages", return_value=([], [])),
             patch.object(ChatAppRunner, "moderation_for_inputs", return_value=(None, {}, "hi")),
             patch.object(ChatAppRunner, "query_app_annotations_to_reply", return_value=None),
             patch.object(ChatAppRunner, "check_hosting_moderation", return_value=True),
         ):
             runner.run(
-                app_generate_entity, DummyQueueManager(), SimpleNamespace(), SimpleNamespace(id="m1"), MagicMock()
+                app_generate_entity,
+                DummyQueueManager(),
+                SimpleNamespace(),
+                SimpleNamespace(id="m1"),
+                sqlite_session,
             )
 
-    def test_run_closes_explicit_session_before_stream_consumption(self):
+    def test_run_closes_explicit_session_before_stream_consumption(
+        self, sqlite_session: Session, sqlite_session_factory: sessionmaker[Session]
+    ):
+        _persist_app(sqlite_session)
         runner = ChatAppRunner()
         app_config = SimpleNamespace(
             app_id="app-1",
@@ -372,9 +419,8 @@ class TestChatAppRunner:
         events = []
         queue_manager = DummyQueueManager()
         model_instance = MagicMock()
-        session = MagicMock()
-        session.commit.side_effect = lambda: events.append("commit")
-        session.close.side_effect = lambda: events.append("close")
+        original_commit = sqlite_session.commit
+        original_close = sqlite_session.close
 
         def invoke_stream():
             events.append("first-chunk")
@@ -385,7 +431,7 @@ class TestChatAppRunner:
             return invoke_stream()
 
         with (
-            patched_create_session(return_value=SimpleNamespace(id="app-1", tenant_id="tenant-1")),
+            patched_create_session(sqlite_session_factory),
             patch.object(ChatAppRunner, "organize_prompt_messages", return_value=([], [])),
             patch.object(ChatAppRunner, "moderation_for_inputs", return_value=(None, {}, "hi")),
             patch.object(ChatAppRunner, "query_app_annotations_to_reply", return_value=None),
@@ -397,9 +443,17 @@ class TestChatAppRunner:
                 side_effect=lambda invoke_result, **kwargs: list(invoke_result),
             ) as mock_handle,
             patch("core.app.apps.chat.app_runner.ModelInstance", return_value=model_instance),
+            patch.object(
+                sqlite_session, "commit", side_effect=lambda: (events.append("commit"), original_commit())[1]
+            ),
+            patch.object(
+                sqlite_session, "close", side_effect=lambda: (events.append("close"), original_close())[1]
+            ),
         ):
             model_instance.invoke_llm.side_effect = invoke_llm
-            runner.run(app_generate_entity, queue_manager, SimpleNamespace(), SimpleNamespace(id="m1"), session)
+            runner.run(
+                app_generate_entity, queue_manager, SimpleNamespace(), SimpleNamespace(id="m1"), sqlite_session
+            )
 
         assert events == ["commit", "close", "commit", "close", "invoke", "first-chunk"]
         mock_handle.assert_called_once_with(

--- a/api/tests/unit_tests/core/app/apps/chat/test_app_generator_and_runner.py
+++ b/api/tests/unit_tests/core/app/apps/chat/test_app_generator_and_runner.py
@@ -233,9 +233,7 @@ class TestChatAppGenerator:
 
 
 class TestChatAppRunner:
-    def test_run_raises_when_app_missing(
-        self, sqlite_session_factory: sessionmaker[Session], unbound_session: Session
-    ):
+    def test_run_raises_when_app_missing(self, sqlite_session_factory: sessionmaker[Session], unbound_session: Session):
         runner = ChatAppRunner()
         app_config = SimpleNamespace(
             app_id="app-1", tenant_id="tenant-1", prompt_template=None, external_data_variables=[]
@@ -341,9 +339,7 @@ class TestChatAppRunner:
             patch.object(ChatAppRunner, "direct_output") as mock_direct,
         ):
             queue_manager = DummyQueueManager()
-            runner.run(
-                app_generate_entity, queue_manager, SimpleNamespace(), SimpleNamespace(id="m1"), sqlite_session
-            )
+            runner.run(app_generate_entity, queue_manager, SimpleNamespace(), SimpleNamespace(id="m1"), sqlite_session)
 
         assert any(isinstance(item[0], QueueAnnotationReplyEvent) for item in queue_manager.published)
         assert annotation_query.call_args.kwargs["session"] is sqlite_session
@@ -443,17 +439,11 @@ class TestChatAppRunner:
                 side_effect=lambda invoke_result, **kwargs: list(invoke_result),
             ) as mock_handle,
             patch("core.app.apps.chat.app_runner.ModelInstance", return_value=model_instance),
-            patch.object(
-                sqlite_session, "commit", side_effect=lambda: (events.append("commit"), original_commit())[1]
-            ),
-            patch.object(
-                sqlite_session, "close", side_effect=lambda: (events.append("close"), original_close())[1]
-            ),
+            patch.object(sqlite_session, "commit", side_effect=lambda: (events.append("commit"), original_commit())[1]),
+            patch.object(sqlite_session, "close", side_effect=lambda: (events.append("close"), original_close())[1]),
         ):
             model_instance.invoke_llm.side_effect = invoke_llm
-            runner.run(
-                app_generate_entity, queue_manager, SimpleNamespace(), SimpleNamespace(id="m1"), sqlite_session
-            )
+            runner.run(app_generate_entity, queue_manager, SimpleNamespace(), SimpleNamespace(id="m1"), sqlite_session)
 
         assert events == ["commit", "close", "commit", "close", "invoke", "first-chunk"]
         mock_handle.assert_called_once_with(

--- a/api/tests/unit_tests/core/app/apps/completion/test_app_runner.py
+++ b/api/tests/unit_tests/core/app/apps/completion/test_app_runner.py
@@ -1,14 +1,18 @@
-from contextlib import contextmanager
 from types import SimpleNamespace
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import ANY, MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
+from sqlalchemy.orm import Session
 
 import core.app.apps.completion.app_runner as module
 from core.app.apps.completion.app_runner import CompletionAppRunner
 from core.moderation.base import ModerationError
 from graphon.model_runtime.entities.message_entities import ImagePromptMessageContent
+from models.model import App, AppMode, IconType
+
+APP_ID = "00000000-0000-0000-0000-000000000001"
+TENANT_ID = "00000000-0000-0000-0000-000000000002"
 
 
 @pytest.fixture
@@ -18,8 +22,8 @@ def runner():
 
 def _build_app_config(dataset=None, external_tools=None, additional_features=None):
     app_config = MagicMock()
-    app_config.app_id = "app1"
-    app_config.tenant_id = "tenant"
+    app_config.app_id = APP_ID
+    app_config.tenant_id = TENANT_ID
     app_config.prompt_template = MagicMock()
     app_config.dataset = dataset
     app_config.external_data_variables = external_tools or []
@@ -48,27 +52,33 @@ def _build_generate_entity(app_config, file_upload_config=None):
     )
 
 
-@contextmanager
-def patched_create_session(*, return_value=None):
-    session = MagicMock()
-    session.scalar.return_value = return_value
-    session_context = MagicMock()
-    session_context.__enter__.return_value = session
-    with patch.object(module, "create_session", return_value=session_context):
-        yield session
+def _persist_app(session: Session) -> App:
+    app = App(
+        id=APP_ID,
+        tenant_id=TENANT_ID,
+        name="Completion app",
+        mode=AppMode.COMPLETION,
+        icon_type=IconType.EMOJI,
+        icon="chat",
+        icon_background="#ffffff",
+        enable_site=False,
+        enable_api=False,
+    )
+    session.add(app)
+    session.commit()
+    return app
 
 
 class TestCompletionAppRunner:
-    def test_run_app_not_found(self, runner, mocker: MockerFixture):
+    def test_run_app_not_found(self, runner, mocker: MockerFixture, sqlite_session: Session):
         app_config = _build_app_config()
         app_generate_entity = _build_generate_entity(app_config)
 
-        with patched_create_session(return_value=None):
-            with pytest.raises(ValueError):
-                runner.run(app_generate_entity, MagicMock(), MagicMock(), MagicMock())
+        with pytest.raises(ValueError):
+            runner.run(app_generate_entity, MagicMock(), MagicMock(), sqlite_session)
 
-    def test_run_moderation_error_outputs_direct(self, runner, mocker: MockerFixture):
-        app_record = MagicMock(id="app1", tenant_id="tenant")
+    def test_run_moderation_error_outputs_direct(self, runner, mocker: MockerFixture, sqlite_session: Session):
+        _persist_app(sqlite_session)
 
         app_config = _build_app_config()
         app_generate_entity = _build_generate_entity(app_config)
@@ -78,14 +88,13 @@ class TestCompletionAppRunner:
         runner.direct_output = MagicMock()
         runner._handle_invoke_result = MagicMock()
 
-        with patched_create_session(return_value=app_record):
-            runner.run(app_generate_entity, MagicMock(), MagicMock(id="msg"), MagicMock())
+        runner.run(app_generate_entity, MagicMock(), MagicMock(id="msg"), sqlite_session)
 
         runner.direct_output.assert_called_once()
         runner._handle_invoke_result.assert_not_called()
 
-    def test_run_hosting_moderation_stops(self, runner, mocker: MockerFixture):
-        app_record = MagicMock(id="app1", tenant_id="tenant")
+    def test_run_hosting_moderation_stops(self, runner, mocker: MockerFixture, sqlite_session: Session):
+        _persist_app(sqlite_session)
 
         app_config = _build_app_config()
         app_generate_entity = _build_generate_entity(app_config)
@@ -95,13 +104,12 @@ class TestCompletionAppRunner:
         runner.check_hosting_moderation = MagicMock(return_value=True)
         runner._handle_invoke_result = MagicMock()
 
-        with patched_create_session(return_value=app_record):
-            runner.run(app_generate_entity, MagicMock(), MagicMock(id="msg"), MagicMock())
+        runner.run(app_generate_entity, MagicMock(), MagicMock(id="msg"), sqlite_session)
 
         runner._handle_invoke_result.assert_not_called()
 
-    def test_run_dataset_and_external_tools_flow(self, runner, mocker: MockerFixture):
-        app_record = MagicMock(id="app1", tenant_id="tenant")
+    def test_run_dataset_and_external_tools_flow(self, runner, mocker: MockerFixture, sqlite_session: Session):
+        _persist_app(sqlite_session)
 
         retrieve_config = MagicMock(query_variable="qvar")
         dataset_config = MagicMock(dataset_ids=["ds"], retrieve_config=retrieve_config)
@@ -132,23 +140,35 @@ class TestCompletionAppRunner:
         model_instance.invoke_llm.return_value = "invoke_result"
         mocker.patch.object(module, "ModelInstance", return_value=model_instance)
 
-        with patched_create_session(return_value=app_record):
-            runner.run(app_generate_entity, MagicMock(), MagicMock(id="msg", tenant_id="tenant"), MagicMock())
+        runner.run(app_generate_entity, MagicMock(), MagicMock(id="msg", tenant_id=TENANT_ID), sqlite_session)
 
         dataset_retrieval.retrieve.assert_called_once()
         assert dataset_retrieval.retrieve.call_args.kwargs["query"] == "query_from_input"
         runner._handle_invoke_result.assert_called_once()
 
-    def test_run_closes_explicit_session_before_stream_consumption(self, runner, mocker: MockerFixture):
-        app_record = MagicMock(id="app1", tenant_id="tenant")
+    def test_run_closes_explicit_session_before_stream_consumption(
+        self, runner, mocker: MockerFixture, sqlite_session: Session
+    ):
+        _persist_app(sqlite_session)
         app_config = _build_app_config()
         app_generate_entity = _build_generate_entity(app_config)
         queue_manager = MagicMock()
 
         events = []
-        session = MagicMock()
-        session.commit.side_effect = lambda: events.append("commit")
-        session.close.side_effect = lambda: events.append("close")
+        session = sqlite_session
+        original_commit = session.commit
+        original_close = session.close
+
+        def commit_session() -> None:
+            events.append("commit")
+            original_commit()
+
+        def close_session() -> None:
+            events.append("close")
+            original_close()
+
+        mocker.patch.object(session, "commit", side_effect=commit_session)
+        mocker.patch.object(session, "close", side_effect=close_session)
         runner.organize_prompt_messages = MagicMock(return_value=([], None))
         runner.moderation_for_inputs = MagicMock(return_value=(None, app_generate_entity.inputs, "query"))
         runner.check_hosting_moderation = MagicMock(return_value=False)
@@ -168,8 +188,7 @@ class TestCompletionAppRunner:
         model_instance.invoke_llm.side_effect = invoke_llm
         mocker.patch.object(module, "ModelInstance", return_value=model_instance)
 
-        with patched_create_session(return_value=app_record):
-            runner.run(app_generate_entity, queue_manager, MagicMock(id="msg"), session)
+        runner.run(app_generate_entity, queue_manager, MagicMock(id="msg"), session)
 
         assert events == ["commit", "close", "invoke", "first-chunk"]
         runner._handle_invoke_result.assert_called_once_with(
@@ -178,11 +197,11 @@ class TestCompletionAppRunner:
             stream=True,
             message_id="msg",
             user_id="user",
-            tenant_id="tenant",
+            tenant_id=TENANT_ID,
         )
 
-    def test_run_uses_low_image_detail_default(self, runner, mocker: MockerFixture):
-        app_record = MagicMock(id="app1", tenant_id="tenant")
+    def test_run_uses_low_image_detail_default(self, runner, mocker: MockerFixture, sqlite_session: Session):
+        _persist_app(sqlite_session)
 
         app_config = _build_app_config()
         app_generate_entity = _build_generate_entity(app_config, file_upload_config=None)
@@ -191,8 +210,7 @@ class TestCompletionAppRunner:
         runner.moderation_for_inputs = MagicMock(return_value=(None, app_generate_entity.inputs, "query"))
         runner.check_hosting_moderation = MagicMock(return_value=True)
 
-        with patched_create_session(return_value=app_record):
-            runner.run(app_generate_entity, MagicMock(), MagicMock(id="msg"), MagicMock())
+        runner.run(app_generate_entity, MagicMock(), MagicMock(id="msg"), sqlite_session)
 
         assert (
             runner.organize_prompt_messages.call_args.kwargs["image_detail_config"]

--- a/api/tests/unit_tests/core/app/apps/pipeline/test_pipeline_generator.py
+++ b/api/tests/unit_tests/core/app/apps/pipeline/test_pipeline_generator.py
@@ -4,12 +4,24 @@ from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 from pytest_mock import MockerFixture
+from sqlalchemy import select
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
 import core.app.apps.pipeline.pipeline_generator as module
 from core.app.apps.exc import GenerateTaskStoppedError
 from core.app.entities.app_invoke_entities import InvokeFrom
 from core.datasource.entities.datasource_entities import DatasourceProviderType
-from models.enums import DataSourceType
+from models.dataset import Document, DocumentPipelineExecutionLog
+from models.enums import DataSourceType, EndUserType
+from models.model import EndUser
+from models.workflow import Workflow, WorkflowType
+
+TENANT_ID = "00000000-0000-0000-0000-000000000001"
+PIPELINE_ID = "00000000-0000-0000-0000-000000000002"
+DATASET_ID = "00000000-0000-0000-0000-000000000003"
+WORKFLOW_ID = "00000000-0000-0000-0000-000000000004"
+USER_ID = "00000000-0000-0000-0000-000000000005"
 
 
 class FakeRagPipelineGenerateEntity(SimpleNamespace):
@@ -24,9 +36,10 @@ class FakeRagPipelineGenerateEntity(SimpleNamespace):
 
 
 @pytest.fixture
-def generator(mocker: MockerFixture):
+def generator(mocker: MockerFixture, sqlite_engine: Engine):
     gen = module.PipelineGenerator()
 
+    _patch_sqlite_engine(mocker, sqlite_engine)
     mocker.patch.object(module, "RagPipelineGenerateEntity", FakeRagPipelineGenerateEntity)
     mocker.patch.object(module, "RagPipelineInvokeEntity", side_effect=lambda **kwargs: kwargs)
     mocker.patch.object(module.contexts, "plugin_tool_providers", SimpleNamespace(set=MagicMock()))
@@ -37,27 +50,27 @@ def generator(mocker: MockerFixture):
 
 def _build_pipeline_dataset():
     return SimpleNamespace(
-        id="ds",
+        id=DATASET_ID,
         name="dataset",
         description="desc",
-        chunk_structure="chunk",
+        chunk_structure="text_model",
         built_in_field_enabled=True,
-        tenant_id="tenant",
+        tenant_id=TENANT_ID,
     )
 
 
 def _build_pipeline():
-    pipeline = MagicMock(tenant_id="tenant", id="pipe")
+    pipeline = MagicMock(tenant_id=TENANT_ID, id=PIPELINE_ID)
     pipeline.retrieve_dataset.return_value = _build_pipeline_dataset()
     return pipeline
 
 
 def _build_workflow():
-    return MagicMock(id="wf", graph_dict={"nodes": [], "edges": []}, tenant_id="tenant")
+    return MagicMock(id=WORKFLOW_ID, graph_dict={"nodes": [], "edges": []}, tenant_id=TENANT_ID)
 
 
 def _build_user():
-    return MagicMock(id="user", name="User", session_id="session")
+    return SimpleNamespace(id=USER_ID, name="User", session_id="session")
 
 
 def _build_args():
@@ -69,39 +82,53 @@ def _build_args():
     }
 
 
-def _patch_session(mocker, session):
-    mocker.patch.object(module, "Session", return_value=session)
-    mocker.patch.object(type(module.db), "engine", new_callable=PropertyMock, return_value=MagicMock())
+def _patch_sqlite_engine(mocker: MockerFixture, sqlite_engine: Engine) -> None:
+    mocker.patch.object(type(module.db), "engine", new_callable=PropertyMock, return_value=sqlite_engine)
+
+
+def _patch_db_session(
+    mocker: MockerFixture, sqlite_session_factory: sessionmaker[Session]
+) -> scoped_session[Session]:
+    session_proxy = scoped_session(sqlite_session_factory)
+    mocker.patch.object(module.db, "session", session_proxy)
+    return session_proxy
+
+
+def _persist_worker_records(session: Session) -> None:
+    workflow = Workflow(
+        id=WORKFLOW_ID,
+        tenant_id=TENANT_ID,
+        app_id=PIPELINE_ID,
+        type=WorkflowType.RAG_PIPELINE,
+        version=Workflow.VERSION_DRAFT,
+        graph="{}",
+        _features="{}",
+        created_by=USER_ID,
+    )
+    end_user = EndUser(
+        id=USER_ID,
+        tenant_id=TENANT_ID,
+        app_id=PIPELINE_ID,
+        type=EndUserType.BROWSER,
+        session_id="session",
+        name="User",
+        is_anonymous=True,
+    )
+    session.add_all([workflow, end_user])
+    session.commit()
 
 
 def _dummy_preserve(*args, **kwargs):
     return contextlib.nullcontext()
 
 
-class DummySession:
-    def __init__(self):
-        self.scalar = MagicMock()
-        self.add = MagicMock()
-        self.flush = MagicMock()
-        self.commit = MagicMock()
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        return False
-
-
-def test_generate_dataset_missing(generator, mocker: MockerFixture):
+def test_generate_dataset_missing(generator, sqlite_session: Session):
     pipeline = _build_pipeline()
     pipeline.retrieve_dataset.return_value = None
 
-    session = DummySession()
-    _patch_session(mocker, session)
-
     with pytest.raises(ValueError):
         generator.generate(
-            session=session,
+            session=sqlite_session,
             pipeline=pipeline,
             workflow=_build_workflow(),
             user=_build_user(),
@@ -111,12 +138,9 @@ def test_generate_dataset_missing(generator, mocker: MockerFixture):
         )
 
 
-def test_generate_debugger_calls_generate(generator, mocker: MockerFixture):
+def test_generate_debugger_calls_generate(generator, mocker: MockerFixture, sqlite_session: Session):
     pipeline = _build_pipeline()
     workflow = _build_workflow()
-
-    session = DummySession()
-    _patch_session(mocker, session)
 
     mocker.patch.object(
         generator,
@@ -144,7 +168,7 @@ def test_generate_debugger_calls_generate(generator, mocker: MockerFixture):
     mocker.patch.object(generator, "_generate", return_value={"result": "ok"})
 
     result = generator.generate(
-        session=session,
+        session=sqlite_session,
         pipeline=pipeline,
         workflow=workflow,
         user=_build_user(),
@@ -156,12 +180,11 @@ def test_generate_debugger_calls_generate(generator, mocker: MockerFixture):
     assert result == {"result": "ok"}
 
 
-def test_generate_published_pipeline_creates_documents_and_delay(generator, mocker: MockerFixture):
+def test_generate_published_pipeline_creates_documents_and_delay(
+    generator, mocker: MockerFixture, sqlite_session: Session
+):
     pipeline = _build_pipeline()
     workflow = _build_workflow()
-
-    session = DummySession()
-    _patch_session(mocker, session)
 
     datasource_info_list = [{"name": "file1"}, {"name": "file2"}]
 
@@ -182,30 +205,6 @@ def test_generate_published_pipeline_creates_documents_and_delay(generator, mock
     get_features = mocker.patch("services.feature_service.FeatureService.get_features", return_value=features)
     check_limits = mocker.patch("services.dataset_service.DocumentService.check_document_creation_limits")
 
-    document1 = SimpleNamespace(
-        id="doc1",
-        position=1,
-        data_source_type=DatasourceProviderType.LOCAL_FILE,
-        data_source_info="{}",
-        name="file1",
-        indexing_status="",
-        error=None,
-        enabled=True,
-    )
-    document2 = SimpleNamespace(
-        id="doc2",
-        position=2,
-        data_source_type=DatasourceProviderType.LOCAL_FILE,
-        data_source_info="{}",
-        name="file2",
-        indexing_status="",
-        error=None,
-        enabled=True,
-    )
-    mocker.patch.object(generator, "_build_document", side_effect=[document1, document2])
-
-    mocker.patch.object(module, "DocumentPipelineExecutionLog", return_value=MagicMock())
-
     mocker.patch.object(
         module.DifyCoreRepositoryFactory,
         "create_workflow_execution_repository",
@@ -221,7 +220,7 @@ def test_generate_published_pipeline_creates_documents_and_delay(generator, mock
     mocker.patch.object(module, "RagPipelineTaskProxy", return_value=task_proxy)
 
     result = generator.generate(
-        session=session,
+        session=sqlite_session,
         pipeline=pipeline,
         workflow=workflow,
         user=_build_user(),
@@ -233,18 +232,23 @@ def test_generate_published_pipeline_creates_documents_and_delay(generator, mock
     assert result["batch"]
     assert len(result["documents"]) == 2
     check_limits.assert_called_once_with(len(datasource_info_list), features)
-    session.flush.assert_called_once_with()
-    session.commit.assert_called_once_with()
+    persisted_documents = sqlite_session.scalars(
+        select(Document).where(Document.dataset_id == DATASET_ID).order_by(Document.position)
+    ).all()
+    assert [document.name for document in persisted_documents] == ["file1", "file2"]
+    persisted_logs = sqlite_session.scalars(
+        select(DocumentPipelineExecutionLog).where(DocumentPipelineExecutionLog.pipeline_id == PIPELINE_ID)
+    ).all()
+    assert {log.document_id for log in persisted_logs} == {document.id for document in persisted_documents}
     task_proxy.delay.assert_called_once()
-    get_features.assert_called_once_with("tenant")
+    get_features.assert_called_once_with(TENANT_ID)
 
 
-def test_generate_published_pipeline_rejects_when_document_creation_limits_exceeded(generator, mocker: MockerFixture):
+def test_generate_published_pipeline_rejects_when_document_creation_limits_exceeded(
+    generator, mocker: MockerFixture, sqlite_session: Session
+):
     pipeline = _build_pipeline()
     workflow = _build_workflow()
-
-    session = DummySession()
-    _patch_session(mocker, session)
 
     datasource_info_list = [{"name": "file1"}, {"name": "file2"}]
     mocker.patch.object(
@@ -267,7 +271,7 @@ def test_generate_published_pipeline_rejects_when_document_creation_limits_excee
 
     with pytest.raises(ValueError, match="document limit exceeded"):
         generator.generate(
-            session=session,
+            session=sqlite_session,
             pipeline=pipeline,
             workflow=workflow,
             user=_build_user(),
@@ -277,15 +281,12 @@ def test_generate_published_pipeline_rejects_when_document_creation_limits_excee
         )
 
     check_limits.assert_called_once_with(len(datasource_info_list), features)
-    session.add.assert_not_called()
+    assert sqlite_session.scalars(select(Document)).all() == []
 
 
-def test_generate_is_retry_calls_generate(generator, mocker: MockerFixture):
+def test_generate_is_retry_calls_generate(generator, mocker: MockerFixture, sqlite_session: Session):
     pipeline = _build_pipeline()
     workflow = _build_workflow()
-
-    session = DummySession()
-    _patch_session(mocker, session)
 
     mocker.patch.object(
         generator,
@@ -316,7 +317,7 @@ def test_generate_is_retry_calls_generate(generator, mocker: MockerFixture):
     args["original_document_id"] = "document-1"
 
     result = generator.generate(
-        session=session,
+        session=sqlite_session,
         pipeline=pipeline,
         workflow=workflow,
         user=_build_user(),
@@ -332,22 +333,25 @@ def test_generate_is_retry_calls_generate(generator, mocker: MockerFixture):
     assert application_generate_entity.original_document_id is None
 
 
-def test_generate_worker_handles_errors(generator, mocker: MockerFixture):
+def test_generate_worker_handles_errors(
+    generator,
+    mocker: MockerFixture,
+    sqlite_session: Session,
+    sqlite_engine: Engine,
+    sqlite_session_factory: sessionmaker[Session],
+):
     flask_app = MagicMock()
     flask_app.app_context.return_value = contextlib.nullcontext()
     mocker.patch.object(module, "preserve_flask_contexts", _dummy_preserve)
-    mocker.patch.object(module.db, "session", MagicMock(close=MagicMock()))
-    mocker.patch.object(type(module.db), "engine", new_callable=PropertyMock, return_value=MagicMock())
+    _persist_worker_records(sqlite_session)
+    _patch_sqlite_engine(mocker, sqlite_engine)
+    _patch_db_session(mocker, sqlite_session_factory)
 
     application_generate_entity = FakeRagPipelineGenerateEntity(
-        app_config=SimpleNamespace(tenant_id="tenant", app_id="pipe", workflow_id="wf"),
+        app_config=SimpleNamespace(tenant_id=TENANT_ID, app_id=PIPELINE_ID, workflow_id=WORKFLOW_ID),
         invoke_from=InvokeFrom.WEB_APP,
-        user_id="user",
+        user_id=USER_ID,
     )
-
-    session = DummySession()
-    session.scalar.side_effect = [MagicMock(), MagicMock(session_id="session")]
-    _patch_session(mocker, session)
 
     runner_instance = MagicMock()
     runner_instance.run.side_effect = ValueError("bad")
@@ -367,22 +371,25 @@ def test_generate_worker_handles_errors(generator, mocker: MockerFixture):
     queue_manager.publish_error.assert_called_once()
 
 
-def test_generate_worker_sets_system_user_id_for_external_call(generator, mocker: MockerFixture):
+def test_generate_worker_sets_system_user_id_for_external_call(
+    generator,
+    mocker: MockerFixture,
+    sqlite_session: Session,
+    sqlite_engine: Engine,
+    sqlite_session_factory: sessionmaker[Session],
+):
     flask_app = MagicMock()
     flask_app.app_context.return_value = contextlib.nullcontext()
     mocker.patch.object(module, "preserve_flask_contexts", _dummy_preserve)
-    mocker.patch.object(module.db, "session", MagicMock(close=MagicMock()))
-    mocker.patch.object(type(module.db), "engine", new_callable=PropertyMock, return_value=MagicMock())
+    _persist_worker_records(sqlite_session)
+    _patch_sqlite_engine(mocker, sqlite_engine)
+    _patch_db_session(mocker, sqlite_session_factory)
 
     application_generate_entity = FakeRagPipelineGenerateEntity(
-        app_config=SimpleNamespace(tenant_id="tenant", app_id="pipe", workflow_id="wf"),
+        app_config=SimpleNamespace(tenant_id=TENANT_ID, app_id=PIPELINE_ID, workflow_id=WORKFLOW_ID),
         invoke_from=InvokeFrom.WEB_APP,
-        user_id="user",
+        user_id=USER_ID,
     )
-
-    session = DummySession()
-    session.scalar.side_effect = [MagicMock(), MagicMock(session_id="session")]
-    _patch_session(mocker, session)
 
     runner_instance = MagicMock()
     mocker.patch.object(module, "PipelineRunner", return_value=runner_instance)
@@ -400,13 +407,13 @@ def test_generate_worker_sets_system_user_id_for_external_call(generator, mocker
     assert module.PipelineRunner.call_args.kwargs["system_user_id"] == "session"
 
 
-def test_generate_raises_when_workflow_not_found(generator, mocker: MockerFixture):
+def test_generate_raises_when_workflow_not_found(
+    generator, mocker: MockerFixture, sqlite_session: Session
+):
     flask_app = MagicMock()
     mocker.patch.object(module, "preserve_flask_contexts", _dummy_preserve)
 
-    session = MagicMock()
-    session.get.return_value = None
-    mocker.patch.object(module.db, "session", session)
+    session = sqlite_session
 
     with pytest.raises(ValueError):
         generator._generate(
@@ -429,14 +436,23 @@ def test_generate_raises_when_workflow_not_found(generator, mocker: MockerFixtur
         )
 
 
-def test_generate_success_returns_converted(generator, mocker: MockerFixture):
+def test_generate_success_returns_converted(generator, mocker: MockerFixture, sqlite_session: Session):
     flask_app = MagicMock()
     mocker.patch.object(module, "preserve_flask_contexts", _dummy_preserve)
 
-    workflow = MagicMock(id="wf", tenant_id="tenant", app_id="pipe", graph_dict={})
-    session = MagicMock()
-    session.get.return_value = workflow
-    mocker.patch.object(module.db, "session", session)
+    workflow = Workflow(
+        id="00000000-0000-0000-0000-000000000001",
+        tenant_id="00000000-0000-0000-0000-000000000002",
+        app_id="00000000-0000-0000-0000-000000000003",
+        type=WorkflowType.RAG_PIPELINE,
+        version=Workflow.VERSION_DRAFT,
+        graph="{}",
+        _features="{}",
+        created_by="00000000-0000-0000-0000-000000000004",
+    )
+    sqlite_session.add(workflow)
+    sqlite_session.commit()
+    session = sqlite_session
 
     queue_manager = MagicMock()
     mocker.patch.object(module, "PipelineQueueManager", return_value=queue_manager)
@@ -454,7 +470,7 @@ def test_generate_success_returns_converted(generator, mocker: MockerFixture):
         flask_app=flask_app,
         context=contextlib.nullcontext(),
         pipeline=_build_pipeline(),
-        workflow_id="wf",
+        workflow_id=workflow.id,
         user=_build_user(),
         application_generate_entity=FakeRagPipelineGenerateEntity(
             task_id="t",
@@ -472,10 +488,10 @@ def test_generate_success_returns_converted(generator, mocker: MockerFixture):
     worker_thread.join.assert_called_once_with(timeout=300)
 
 
-def test_single_iteration_generate_validates_inputs(generator, mocker: MockerFixture):
+def test_single_iteration_generate_validates_inputs(generator, sqlite_session: Session):
     with pytest.raises(ValueError):
         generator.single_iteration_generate(
-            _build_pipeline(), _build_workflow(), "", _build_user(), {}, session=DummySession()
+            _build_pipeline(), _build_workflow(), "", _build_user(), {}, session=sqlite_session
         )
 
     with pytest.raises(ValueError):
@@ -485,16 +501,13 @@ def test_single_iteration_generate_validates_inputs(generator, mocker: MockerFix
             "node",
             _build_user(),
             {"inputs": None},
-            session=DummySession(),
+            session=sqlite_session,
         )
 
 
-def test_single_iteration_generate_dataset_required(generator, mocker: MockerFixture):
+def test_single_iteration_generate_dataset_required(generator, sqlite_session: Session):
     pipeline = _build_pipeline()
     pipeline.retrieve_dataset.return_value = None
-
-    session = DummySession()
-    _patch_session(mocker, session)
 
     with pytest.raises(ValueError):
         generator.single_iteration_generate(
@@ -503,15 +516,17 @@ def test_single_iteration_generate_dataset_required(generator, mocker: MockerFix
             "node",
             _build_user(),
             {"inputs": {"a": 1}},
-            session=session,
+            session=sqlite_session,
         )
 
 
-def test_single_iteration_generate_success(generator, mocker: MockerFixture):
+def test_single_iteration_generate_success(
+    generator,
+    mocker: MockerFixture,
+    sqlite_session: Session,
+    sqlite_session_factory: sessionmaker[Session],
+):
     pipeline = _build_pipeline()
-
-    session = DummySession()
-    _patch_session(mocker, session)
 
     mocker.patch.object(
         module.PipelineConfigManager,
@@ -528,7 +543,7 @@ def test_single_iteration_generate_success(generator, mocker: MockerFixture):
         "create_workflow_node_execution_repository",
         return_value=MagicMock(),
     )
-    mocker.patch.object(module.db, "session", MagicMock(return_value=MagicMock()))
+    _patch_db_session(mocker, sqlite_session_factory)
 
     mocker.patch.object(module, "WorkflowDraftVariableService", return_value=MagicMock())
     mocker.patch.object(module, "DraftVarLoader", return_value=MagicMock())
@@ -542,17 +557,19 @@ def test_single_iteration_generate_success(generator, mocker: MockerFixture):
         _build_user(),
         {"inputs": {"a": 1}},
         streaming=False,
-        session=session,
+        session=sqlite_session,
     )
 
     assert result == {"ok": True}
 
 
-def test_single_loop_generate_success(generator, mocker: MockerFixture):
+def test_single_loop_generate_success(
+    generator,
+    mocker: MockerFixture,
+    sqlite_session: Session,
+    sqlite_session_factory: sessionmaker[Session],
+):
     pipeline = _build_pipeline()
-
-    session = DummySession()
-    _patch_session(mocker, session)
 
     mocker.patch.object(
         module.PipelineConfigManager,
@@ -569,7 +586,7 @@ def test_single_loop_generate_success(generator, mocker: MockerFixture):
         "create_workflow_node_execution_repository",
         return_value=MagicMock(),
     )
-    mocker.patch.object(module.db, "session", MagicMock(return_value=MagicMock()))
+    _patch_db_session(mocker, sqlite_session_factory)
 
     mocker.patch.object(module, "WorkflowDraftVariableService", return_value=MagicMock())
     mocker.patch.object(module, "DraftVarLoader", return_value=MagicMock())
@@ -583,7 +600,7 @@ def test_single_loop_generate_success(generator, mocker: MockerFixture):
         _build_user(),
         {"inputs": {"a": 1}},
         streaming=False,
-        session=session,
+        session=sqlite_session,
     )
 
     assert result == {"ok": True}

--- a/api/tests/unit_tests/core/app/apps/pipeline/test_pipeline_generator.py
+++ b/api/tests/unit_tests/core/app/apps/pipeline/test_pipeline_generator.py
@@ -86,9 +86,7 @@ def _patch_sqlite_engine(mocker: MockerFixture, sqlite_engine: Engine) -> None:
     mocker.patch.object(type(module.db), "engine", new_callable=PropertyMock, return_value=sqlite_engine)
 
 
-def _patch_db_session(
-    mocker: MockerFixture, sqlite_session_factory: sessionmaker[Session]
-) -> scoped_session[Session]:
+def _patch_db_session(mocker: MockerFixture, sqlite_session_factory: sessionmaker[Session]) -> scoped_session[Session]:
     session_proxy = scoped_session(sqlite_session_factory)
     mocker.patch.object(module.db, "session", session_proxy)
     return session_proxy
@@ -407,9 +405,7 @@ def test_generate_worker_sets_system_user_id_for_external_call(
     assert module.PipelineRunner.call_args.kwargs["system_user_id"] == "session"
 
 
-def test_generate_raises_when_workflow_not_found(
-    generator, mocker: MockerFixture, sqlite_session: Session
-):
+def test_generate_raises_when_workflow_not_found(generator, mocker: MockerFixture, sqlite_session: Session):
     flask_app = MagicMock()
     mocker.patch.object(module, "preserve_flask_contexts", _dummy_preserve)
 

--- a/api/tests/unit_tests/core/app/apps/test_advanced_chat_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/test_advanced_chat_app_generator.py
@@ -4,16 +4,17 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
 from core.app.app_config.entities import AppAdditionalFeatures, WorkflowUIBasedAppConfig
-from core.app.apps import message_based_app_generator
 from core.app.apps.advanced_chat.app_generator import AdvancedChatAppGenerator
 from core.app.entities.app_invoke_entities import AdvancedChatAppGenerateEntity, InvokeFrom
 from core.app.task_pipeline import message_cycle_manager
 from core.app.task_pipeline.message_cycle_manager import MessageCycleManager
 from core.ops.ops_trace_manager import TraceQueueManager
 from models.enums import ConversationFromSource
-from models.model import AppMode, Conversation, Message
+from models.model import AppMode, Conversation
 from services.errors.conversation import ConversationNotExistsError
 
 
@@ -46,25 +47,7 @@ def _make_generate_entity(app_config: WorkflowUIBasedAppConfig) -> AdvancedChatA
     )
 
 
-@pytest.fixture(autouse=True)
-def mock_db_session(monkeypatch: pytest.MonkeyPatch):
-    session = MagicMock()
-
-    def refresh_side_effect(obj):
-        if isinstance(obj, Conversation) and obj.id is None:
-            obj.id = "generated-conversation-id"
-        if isinstance(obj, Message) and obj.id is None:
-            obj.id = "generated-message-id"
-
-    session.refresh.side_effect = refresh_side_effect
-    session.add.return_value = None
-    session.commit.return_value = None
-
-    monkeypatch.setattr(message_based_app_generator, "db", SimpleNamespace(session=session))
-    return session
-
-
-def test_init_generate_records_sets_conversation_metadata(mock_db_session):
+def test_init_generate_records_sets_conversation_metadata(sqlite_session: Session):
     app_config = _make_app_config()
     entity = _make_generate_entity(app_config)
 
@@ -73,15 +56,15 @@ def test_init_generate_records_sets_conversation_metadata(mock_db_session):
     conversation, _ = generator._init_generate_records(
         entity,
         conversation=None,
-        session=mock_db_session,
+        session=sqlite_session,
     )
 
-    assert entity.conversation_id == "generated-conversation-id"
-    assert conversation.id == "generated-conversation-id"
+    assert entity.conversation_id == conversation.id
+    assert conversation.id is not None
     assert entity.is_new_conversation is True
 
 
-def test_init_generate_records_marks_existing_conversation(mock_db_session):
+def test_init_generate_records_marks_existing_conversation(sqlite_session: Session):
     app_config = _make_app_config()
     entity = _make_generate_entity(app_config)
 
@@ -104,13 +87,15 @@ def test_init_generate_records_marks_existing_conversation(mock_db_session):
         from_account_id=None,
     )
     existing_conversation.id = "existing-conversation-id"
+    sqlite_session.add(existing_conversation)
+    sqlite_session.flush()
 
     generator = AdvancedChatAppGenerator()
 
     conversation, _ = generator._init_generate_records(
         entity,
         conversation=existing_conversation,
-        session=mock_db_session,
+        session=sqlite_session,
     )
 
     assert entity.conversation_id == "existing-conversation-id"
@@ -118,7 +103,12 @@ def test_init_generate_records_marks_existing_conversation(mock_db_session):
     assert entity.is_new_conversation is False
 
 
-def test_generate_falls_back_to_new_conversation_when_conversation_missing(monkeypatch: pytest.MonkeyPatch):
+def test_generate_falls_back_to_new_conversation_when_conversation_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_engine: Engine,
+    sqlite_session: Session,
+    sqlite_session_factory: sessionmaker[Session],
+):
     app_config = _make_app_config()
     workflow = SimpleNamespace(
         features_dict={},
@@ -144,9 +134,10 @@ def test_generate_falls_back_to_new_conversation_when_conversation_missing(monke
         "core.app.apps.advanced_chat.app_generator.AdvancedChatAppConfigManager.get_app_config",
         lambda **_kwargs: app_config,
     )
+    db_session = scoped_session(sqlite_session_factory)
     monkeypatch.setattr(
         "core.app.apps.advanced_chat.app_generator.db",
-        SimpleNamespace(engine=object(), session=lambda: MagicMock()),
+        SimpleNamespace(engine=sqlite_engine, session=db_session),
     )
     trace_manager = object.__new__(TraceQueueManager)
     monkeypatch.setattr(
@@ -163,7 +154,7 @@ def test_generate_falls_back_to_new_conversation_when_conversation_missing(monke
     )
 
     captured: dict[str, object] = {}
-    session = MagicMock()
+    session = sqlite_session
 
     def fake_generate(self, **kwargs):
         captured.update(kwargs)
@@ -188,6 +179,7 @@ def test_generate_falls_back_to_new_conversation_when_conversation_missing(monke
     application_generate_entity = captured["application_generate_entity"]
     assert isinstance(application_generate_entity, AdvancedChatAppGenerateEntity)
     assert application_generate_entity.conversation_id is None
+    db_session.remove()
 
 
 def test_message_cycle_manager_uses_new_conversation_flag(monkeypatch: pytest.MonkeyPatch):

--- a/api/tests/unit_tests/core/app/apps/test_message_based_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/test_message_based_app_generator.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
 
 import pytest
+from sqlalchemy.orm import Session
 
 from core.app.app_config.entities import (
     AppAdditionalFeatures,
@@ -12,11 +12,10 @@ from core.app.app_config.entities import (
     ModelConfigEntity,
     PromptTemplateEntity,
 )
-from core.app.apps import message_based_app_generator
 from core.app.apps.exc import GenerateTaskStoppedError
 from core.app.apps.message_based_app_generator import MessageBasedAppGenerator
 from core.app.entities.app_invoke_entities import ChatAppGenerateEntity, InvokeFrom
-from models.model import AppMode, Conversation, Message
+from models.model import AppMode
 from services.errors.app_model_config import AppModelConfigBrokenError
 
 
@@ -84,25 +83,7 @@ def _make_chat_generate_entity(app_config: EasyUIBasedAppConfig) -> ChatAppGener
     )
 
 
-@pytest.fixture(autouse=True)
-def mock_db_session(monkeypatch: pytest.MonkeyPatch):
-    session = MagicMock()
-
-    def refresh_side_effect(obj):
-        if isinstance(obj, Conversation) and obj.id is None:
-            obj.id = "generated-conversation-id"
-        if isinstance(obj, Message) and obj.id is None:
-            obj.id = "generated-message-id"
-
-    session.refresh.side_effect = refresh_side_effect
-    session.add.return_value = None
-    session.commit.return_value = None
-
-    monkeypatch.setattr(message_based_app_generator, "db", SimpleNamespace(session=session))
-    return session
-
-
-def test_init_generate_records_skips_conversation_fields_for_non_conversation_entity(mock_db_session):
+def test_init_generate_records_skips_conversation_fields_for_non_conversation_entity(sqlite_session: Session):
     app_config = _make_app_config(AppMode.COMPLETION)
     entity = DummyCompletionGenerateEntity(app_config=app_config)
 
@@ -111,16 +92,16 @@ def test_init_generate_records_skips_conversation_fields_for_non_conversation_en
     conversation, message = generator._init_generate_records(
         entity,
         conversation=None,
-        session=mock_db_session,
+        session=sqlite_session,
     )
 
-    assert conversation.id == "generated-conversation-id"
-    assert message.id == "generated-message-id"
+    assert conversation.id is not None
+    assert message.id is not None
     assert hasattr(entity, "conversation_id") is False
     assert hasattr(entity, "is_new_conversation") is False
 
 
-def test_init_generate_records_sets_conversation_fields_for_chat_entity(mock_db_session):
+def test_init_generate_records_sets_conversation_fields_for_chat_entity(sqlite_session: Session):
     app_config = _make_app_config(AppMode.CHAT)
     entity = _make_chat_generate_entity(app_config)
 
@@ -129,12 +110,12 @@ def test_init_generate_records_sets_conversation_fields_for_chat_entity(mock_db_
     conversation, _ = generator._init_generate_records(
         entity,
         conversation=None,
-        session=mock_db_session,
+        session=sqlite_session,
     )
 
-    assert entity.conversation_id == "generated-conversation-id"
+    assert entity.conversation_id == conversation.id
     assert entity.is_new_conversation is True
-    assert conversation.id == "generated-conversation-id"
+    assert conversation.id is not None
 
 
 class TestMessageBasedAppGeneratorExtras:
@@ -163,17 +144,15 @@ class TestMessageBasedAppGeneratorExtras:
                 stream=False,
             )
 
-    def test_get_app_model_config_requires_valid_config(self):
+    def test_get_app_model_config_requires_valid_config(self, sqlite_session: Session):
         generator = MessageBasedAppGenerator()
         app_model = SimpleNamespace(id="app", app_model_config_id=None, app_model_config=None)
-        session = MagicMock()
+        session = sqlite_session
 
         with pytest.raises(AppModelConfigBrokenError):
             generator._get_app_model_config(app_model, conversation=None, session=session)
 
         conversation = SimpleNamespace(app_model_config_id="missing-id")
-        session.scalar.return_value = None
-
         with pytest.raises(AppModelConfigBrokenError):
             generator._get_app_model_config(
                 app_model=SimpleNamespace(id="app"),

--- a/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_based_generate_task_pipeline.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_based_generate_task_pipeline.py
@@ -1,7 +1,10 @@
+from collections.abc import Iterator
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
+from sqlalchemy import Engine, event
+from sqlalchemy.orm import Session
 
 from core.app.apps.base_app_queue_manager import AppQueueManager
 from core.app.entities.app_invoke_entities import ChatAppGenerateEntity
@@ -31,15 +34,17 @@ from graphon.model_runtime.entities.message_entities import TextPromptMessageCon
 from models.model import AppMode
 
 
-def _patch_stream_session():
-    session = Mock()
-    session_cm = Mock()
-    session_cm.__enter__ = Mock(return_value=session)
-    session_cm.__exit__ = Mock(return_value=False)
-    return session, patch(
-        "core.app.task_pipeline.easy_ui_based_generate_task_pipeline.session_factory.create_session",
-        return_value=session_cm,
-    )
+@pytest.fixture
+def committed_sessions(sqlite_engine: Engine) -> Iterator[list[Session]]:
+    sessions: list[Session] = []
+
+    def record_commit(session: Session) -> None:
+        if session.get_bind() is sqlite_engine:
+            sessions.append(session)
+
+    event.listen(Session, "after_commit", record_commit)
+    yield sessions
+    event.remove(Session, "after_commit", record_commit)
 
 
 class TestEasyUIBasedGenerateTaskPipelineProcessStreamResponse:
@@ -245,7 +250,7 @@ class TestEasyUIBasedGenerateTaskPipelineProcessStreamResponse:
             answer="Agent response", message_id="test-message-id"
         )
 
-    def test_message_end_event(self, pipeline, mock_message_cycle_manager, mock_task_state):
+    def test_message_end_event(self, pipeline, mock_message_cycle_manager, mock_task_state, committed_sessions):
         """Test handling of message end events."""
         # Setup
         llm_result = Mock(spec=RuntimeLLMResult)
@@ -262,19 +267,17 @@ class TestEasyUIBasedGenerateTaskPipelineProcessStreamResponse:
         pipeline._save_message = Mock()
         pipeline._message_end_to_stream_response = Mock(return_value=Mock(spec=MessageEndStreamResponse))
 
-        session, patch_session = _patch_stream_session()
-        with patch_session:
-            # Execute
-            responses = list(pipeline._process_stream_response(publisher=None, trace_manager=None))
+        responses = list(pipeline._process_stream_response(publisher=None, trace_manager=None))
 
         # Assert
         assert len(responses) == 1
         assert mock_task_state.llm_result == llm_result
-        pipeline._save_message.assert_called_once_with(session=session, trace_manager=None)
-        session.commit.assert_called_once()
+        session = pipeline._save_message.call_args.kwargs["session"]
+        assert isinstance(session, Session)
+        assert committed_sessions == [session]
         pipeline._message_end_to_stream_response.assert_called_once()
 
-    def test_error_event(self, pipeline):
+    def test_error_event(self, pipeline, committed_sessions):
         """Test handling of error events."""
         # Setup
         error_event = Mock(spec=QueueErrorEvent)
@@ -287,15 +290,14 @@ class TestEasyUIBasedGenerateTaskPipelineProcessStreamResponse:
         pipeline.handle_error = Mock(return_value=Exception("Test error"))
         pipeline.error_to_stream_response = Mock(return_value=Mock(spec=ErrorStreamResponse))
 
-        session, patch_session = _patch_stream_session()
-        with patch_session:
-            # Execute
-            responses = list(pipeline._process_stream_response(publisher=None, trace_manager=None))
+        responses = list(pipeline._process_stream_response(publisher=None, trace_manager=None))
 
         # Assert
         assert len(responses) == 1
+        session = pipeline.handle_error.call_args.kwargs["session"]
+        assert isinstance(session, Session)
+        assert committed_sessions == [session]
         pipeline.handle_error.assert_called_once_with(event=error_event, session=session, message_id="test-message-id")
-        session.commit.assert_called_once()
         pipeline.error_to_stream_response.assert_called_once()
 
     def test_ping_event(self, pipeline):
@@ -358,7 +360,7 @@ class TestEasyUIBasedGenerateTaskPipelineProcessStreamResponse:
         publisher.publish.assert_any_call(mock_queue_message)
         publisher.publish.assert_any_call(None)
 
-    def test_trace_manager_passed_to_save_message(self, pipeline):
+    def test_trace_manager_passed_to_save_message(self, pipeline, committed_sessions):
         """Test that trace manager is passed to _save_message."""
         # Setup
         trace_manager = Mock(spec=TraceQueueManager)
@@ -373,14 +375,13 @@ class TestEasyUIBasedGenerateTaskPipelineProcessStreamResponse:
         pipeline._save_message = Mock()
         pipeline._message_end_to_stream_response = Mock(return_value=Mock(spec=MessageEndStreamResponse))
 
-        session, patch_session = _patch_stream_session()
-        with patch_session:
-            # Execute
-            list(pipeline._process_stream_response(publisher=None, trace_manager=trace_manager))
+        list(pipeline._process_stream_response(publisher=None, trace_manager=trace_manager))
 
         # Assert
+        session = pipeline._save_message.call_args.kwargs["session"]
+        assert isinstance(session, Session)
+        assert committed_sessions == [session]
         pipeline._save_message.assert_called_once_with(session=session, trace_manager=trace_manager)
-        session.commit.assert_called_once()
 
     def test_multiple_events_sequence(self, pipeline, mock_message_cycle_manager, mock_task_state):
         """Test handling multiple events in sequence."""

--- a/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_based_generate_task_pipeline_core.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_easy_ui_based_generate_task_pipeline_core.py
@@ -7,6 +7,7 @@ from typing import cast
 from unittest.mock import Mock
 
 import pytest
+from sqlalchemy.orm import Session
 
 from core.app.app_config.entities import (
     AppAdditionalFeatures,
@@ -56,7 +57,7 @@ from extensions.storage.storage_type import StorageType
 from graphon.file import FileTransferMethod, FileType
 from graphon.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk, LLMResultChunkDelta, LLMUsage
 from graphon.model_runtime.entities.message_entities import AssistantPromptMessage, TextPromptMessageContent
-from models.enums import CreatorUserRole
+from models.enums import ConversationFromSource, CreatorUserRole
 from models.model import AppMode, Conversation, Message, MessageAgentThought, MessageFile, UploadFile
 
 
@@ -136,14 +137,52 @@ def _unknown_queue_message() -> MessageQueueMessage:
 
 
 def _make_conversation(app_mode: AppMode) -> Conversation:
-    conversation = Conversation()
+    conversation = Conversation(
+        app_id="app",
+        app_model_config_id=None,
+        model_provider=None,
+        override_model_configs=None,
+        model_id=None,
+        mode=app_mode,
+        name="conversation",
+        inputs={},
+        introduction="",
+        system_instruction="",
+        system_instruction_tokens=0,
+        status="normal",
+        invoke_from=InvokeFrom.WEB_APP,
+        from_source=ConversationFromSource.API,
+        from_end_user_id="user",
+        from_account_id=None,
+    )
     conversation.id = "conv"
     conversation.mode = app_mode
     return conversation
 
 
 def _make_message() -> Message:
-    message = Message()
+    message = Message(
+        app_id="app",
+        conversation_id="conv",
+        inputs={},
+        query="query",
+        message="",
+        message_tokens=0,
+        message_unit_price=0,
+        message_price_unit=0,
+        answer="",
+        answer_tokens=0,
+        answer_unit_price=0,
+        answer_price_unit=0,
+        provider_response_latency=0,
+        total_price=0,
+        currency="USD",
+        invoke_from=InvokeFrom.WEB_APP,
+        from_source=ConversationFromSource.API,
+        from_end_user_id="user",
+        from_account_id=None,
+        app_mode=AppMode.CHAT,
+    )
     message.id = "msg"
     message.created_at = datetime.now(UTC)
     return message
@@ -1173,7 +1212,9 @@ class TestEasyUiBasedGenerateTaskPipeline:
 
         assert list(pipeline._process_stream_response(publisher=None)) == []
 
-    def test_save_message_persists_fields_and_emits_trace(self, monkeypatch: pytest.MonkeyPatch):
+    def test_save_message_persists_fields_and_emits_trace(
+        self, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+    ):
         conversation = _make_conversation(AppMode.CHAT)
         message = _make_message()
         application_generate_entity = _make_entity(ChatAppGenerateEntity, AppMode.CHAT)
@@ -1195,8 +1236,9 @@ class TestEasyUiBasedGenerateTaskPipeline:
 
         message_obj = _make_message()
         conversation_obj = _make_conversation(AppMode.CHAT)
-        session = Mock()
-        session.scalar.side_effect = [message_obj, conversation_obj]
+        session = sqlite_session
+        session.add_all([conversation_obj, message_obj])
+        session.flush()
         trace_manager_double = _TraceManagerDouble()
         trace_manager = cast(TraceQueueManager, trace_manager_double)
         sent_payloads: list[tuple[tuple[object, ...], dict[str, object]]] = []
@@ -1234,7 +1276,7 @@ class TestEasyUiBasedGenerateTaskPipeline:
         assert trace_task.kwargs["trace_session_id"] == "session-1"
         assert len(sent_payloads) == 1
 
-    def test_save_message_raises_when_message_not_found(self):
+    def test_save_message_raises_when_message_not_found(self, sqlite_session: Session):
         conversation = _make_conversation(AppMode.CHAT)
         message = _make_message()
         pipeline = EasyUIBasedGenerateTaskPipeline(
@@ -1244,13 +1286,12 @@ class TestEasyUiBasedGenerateTaskPipeline:
             message=message,
             stream=False,
         )
-        session = Mock()
-        session.scalar.return_value = None
+        session = sqlite_session
 
         with pytest.raises(ValueError, match="message msg not found"):
             pipeline._save_message(session=session)
 
-    def test_save_message_raises_when_conversation_not_found(self):
+    def test_save_message_raises_when_conversation_not_found(self, sqlite_session: Session):
         conversation = _make_conversation(AppMode.CHAT)
         message = _make_message()
         pipeline = EasyUIBasedGenerateTaskPipeline(
@@ -1260,8 +1301,9 @@ class TestEasyUiBasedGenerateTaskPipeline:
             message=message,
             stream=False,
         )
-        session = Mock()
-        session.scalar.side_effect = [_make_message(), None]
+        session = sqlite_session
+        session.add(_make_message())
+        session.flush()
 
         with pytest.raises(ValueError, match="Conversation conv not found"):
             pipeline._save_message(session=session)

--- a/api/tests/unit_tests/core/app/task_pipeline/test_message_cycle_manager_optimization.py
+++ b/api/tests/unit_tests/core/app/task_pipeline/test_message_cycle_manager_optimization.py
@@ -418,7 +418,7 @@ class TestMessageCycleManagerOptimization:
         assert conversation.name == (long_query[:47] + "...")
         assert any(record.levelno == logging.ERROR for record in caplog.records)
 
-    def test_handle_annotation_reply_sets_metadata(self, message_cycle_manager):
+    def test_handle_annotation_reply_sets_metadata(self, message_cycle_manager, unbound_session: Session):
         """Populate task metadata from annotation reply events.
 
         Args: message_cycle_manager with TaskStateMetadata and a mocked AppAnnotationService.
@@ -431,7 +431,7 @@ class TestMessageCycleManagerOptimization:
             id="ann-1",
             account_id="acct-1",
         )
-        session = Mock()
+        session = unbound_session
 
         with (
             patch("core.app.task_pipeline.message_cycle_manager.AppAnnotationService") as mock_service,


### PR DESCRIPTION
## What changed

- replace mocked SQLAlchemy sessions in core agent and app runner/generator tests with isolated SQLite fixtures
- persist real apps, workflows, conversations, messages, end users, upload files, and related tenant-owned records
- bind task-owned and module-level session factories to the shared SQLite engine
- verify commit ordering, rollback paths, and database state while leaving model providers and other external boundaries mocked

## Why

Mocked Session chains bypass real ORM loading, ownership predicates, and transaction semantics. SQLite-backed tests exercise those contracts without changing production behavior.

## Impact

Test-only change. Production APIs, schema, and runtime behavior are unchanged.

## Validation

- Ruff passed for all 14 changed test files
- Pytest passed for all 14 changed test files (240 passed)
