### PR TITLE
fix(ci): switch Playwright jobs to Azure Ubuntu mirror

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Switch Ubuntu mirror
+        run: |
+          sudo sed -i 's|http://us-east-1.ec2.archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+          sudo apt-get update
+
       - name: Setup web dependencies
         uses: ./.github/actions/setup-web
 

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -101,6 +101,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Switch Ubuntu mirror
+        run: |
+          sudo sed -i 's|http://us-east-1.ec2.archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+          sudo apt-get update
+
       - name: Setup web environment
         uses: ./.github/actions/setup-web
 
@@ -134,6 +139,11 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Switch Ubuntu mirror
+        run: |
+          sudo sed -i 's|http://us-east-1.ec2.archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+          sudo apt-get update
 
       - name: Setup web environment
         uses: ./.github/actions/setup-web


### PR DESCRIPTION
## Summary

- switch the Ubuntu archive mirror to Azure before dependency installation in Web Full-Stack E2E
- apply the same mirror configuration to the dify-ui Browser Mode and Storybook jobs
- keep Playwright browser commands and shared setup actions unchanged

## Root cause

Playwright's `--with-deps` installation invokes APT before downloading browser binaries. Depot runners have been timing out while retrieving packages from Ubuntu's unstable AWS archive mirror.

## Impact

The affected Playwright jobs use Azure's Ubuntu archive mirror for system dependencies, avoiding the AWS archive mirror failures reported by Depot.

## Validation

- `vp fmt .github/workflows/web-e2e.yml .github/workflows/web-tests.yml --check`
- parsed both workflow files with Ruby YAML
- `git diff --check`