### PR TITLE
fix(web): re-enable chat input after human input form submission

### DIFF
--- a/web/app/components/base/chat/chat/__tests__/hooks.spec.tsx
+++ b/web/app/components/base/chat/chat/__tests__/hooks.spec.tsx
@@ -1726,6 +1726,49 @@ describe('useChat', () => {
       )
     })
 
+    it('should clear pending human input when form filled event arrives on workflow events subscription', async () => {
+      const callbacksList: HookCallbacks[] = []
+      vi.mocked(ssePost).mockImplementation(async (_url, _params, options) => {
+        callbacksList.push(options as HookCallbacks)
+      })
+      vi.mocked(sseGet).mockImplementation(async (_url, _params, options) => {
+        callbacksList.push(options as HookCallbacks)
+      })
+
+      const { result } = renderHook(() => useChat())
+
+      act(() => {
+        result.current.handleSend('test-url', { query: 'hello' }, {})
+      })
+
+      act(() => {
+        callbacksList[0]!.onWorkflowStarted({ workflow_run_id: 'wr-1', task_id: 't-1' })
+        callbacksList[0]!.onHumanInputRequired({ data: { node_id: 'human-1' } })
+        callbacksList[0]!.onWorkflowPaused({ data: { workflow_run_id: 'wr-1' } })
+      })
+
+      expect(result.current.chatList[1]!.humanInputFormDataList).toHaveLength(1)
+      expect(sseGet).toHaveBeenCalledTimes(1)
+
+      let isReady: boolean | undefined
+      const readyPromise = result.current
+        .prepareHumanInputSubmission()
+        .then((ready) => (isReady = ready))
+
+      act(() => {
+        callbacksList[1]!.onWorkflowPaused({ data: { workflow_run_id: 'wr-1' } })
+      })
+      await act(async () => readyPromise)
+      expect(isReady).toBe(true)
+
+      act(() => {
+        callbacksList[1]!.onHumanInputFormFilled({ data: { node_id: 'human-1' } })
+      })
+
+      expect(result.current.chatList[1]!.humanInputFormDataList).toHaveLength(0)
+      expect(result.current.chatList[1]!.humanInputFilledFormDataList).toHaveLength(1)
+    })
+
     it('should handle non-agent mode resume', async () => {
       let callbacks: HookCallbacks
 

--- a/web/app/components/base/chat/chat/hooks.ts
+++ b/web/app/components/base/chat/chat/hooks.ts
@@ -412,6 +412,14 @@ export const useChat = (
           if (generation !== workflowEventsSubscriptionGenerationRef.current) return
           options.onHumanInputRequired?.(event)
         },
+        onHumanInputFormFilled: (event) => {
+          if (generation !== workflowEventsSubscriptionGenerationRef.current) return
+          options.onHumanInputFormFilled?.(event)
+        },
+        onHumanInputFormTimeout: (event) => {
+          if (generation !== workflowEventsSubscriptionGenerationRef.current) return
+          options.onHumanInputFormTimeout?.(event)
+        },
         onWorkflowFinished: (event) => {
           if (generation !== workflowEventsSubscriptionGenerationRef.current) return
           hasWorkflowFinished = true


### PR DESCRIPTION
Fixes #40076

## Summary

- Forward `human_input_form_filled` and `human_input_form_timeout` through the workflow events SSE subscription (`/workflow/{id}/events`).
- After a workflow pauses for human input, form submission events arrive on the events stream rather than the original chat stream; without forwarding, `humanInputFormDataList` stays populated and the chat input remains disabled.
- Add a regression test covering the workflow-events subscription path.

## Testing

- `pnpm test -- --run app/components/base/chat/chat/__tests__/hooks.spec.tsx -t "should clear pending human input when form filled event arrives on workflow events subscription"`
- `pnpm test -- --run app/components/base/chat/chat-with-history/__tests__/chat-wrapper.spec.tsx -t "should disable input when human input form is pending"`

## Screenshots

N/A (chat input state fix).

## Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.