### PR TITLE
revert(web): remove redundant slash picker intent tracking

### DIFF
--- a/web/app/components/base/prompt-editor/plugins/component-picker-block/__tests__/index.spec.tsx
+++ b/web/app/components/base/prompt-editor/plugins/component-picker-block/__tests__/index.spec.tsx
@@ -228,7 +228,6 @@ async function setEditorText(
   editor: LexicalEditor,
   text: string,
   selectEnd: boolean,
-  selectionOffset?: number,
 ): Promise<void> {
   await act(async () => {
     editor.update(() => {
@@ -238,26 +237,9 @@ async function setEditorText(
       const textNode = $createTextNode(text)
       paragraph.append(textNode)
       root.append(paragraph)
-      if (typeof selectionOffset === 'number') textNode.select(selectionOffset, selectionOffset)
-      else if (selectEnd) textNode.selectEnd()
+      if (selectEnd) textNode.selectEnd()
     })
   })
-}
-
-function markSlashTyped(editable: HTMLElement) {
-  editable.dispatchEvent(
-    new InputEvent('beforeinput', {
-      bubbles: true,
-      cancelable: true,
-      inputType: 'insertText',
-      data: '/',
-    }),
-  )
-}
-
-async function insertSlashTrigger(editor: LexicalEditor, editable: HTMLElement): Promise<void> {
-  markSlashTyped(editable)
-  await setEditorText(editor, '/', true)
 }
 
 function readEditorText(editor: LexicalEditor): string {
@@ -660,44 +642,6 @@ describe('ComponentPicker (component-picker-block/index.tsx)', () => {
     })
   })
 
-  it('opens the slash menu when the user types / but not when clicking after an existing slash', async () => {
-    const captures: Captures = { editor: null, eventEmitter: null }
-    const urlPrompt = 'Use https://dict.youdao.com/dictvoice?audio=word&type=0'
-
-    render(
-      <MinimalEditor
-        triggerString="/"
-        workflowVariableBlock={makeWorkflowVariableBlock({}, [
-          makeWorkflowVarNode('node-1', 'Node 1', [makeWorkflowNodeVar('output', VarType.string)]),
-        ])}
-        agentOutputBlock={{
-          show: true,
-          outputs: [],
-          onChange: vi.fn(),
-        }}
-        captures={captures}
-      />,
-    )
-
-    const editor = await waitForEditor(captures)
-    const editable = screen.getByTestId(CONTENT_EDITABLE_TEST_ID)
-
-    await insertSlashTrigger(editor, editable)
-    await flushNextTick()
-
-    expect(await screen.findByText('output')).toBeInTheDocument()
-
-    await setEditorText(editor, urlPrompt, false, urlPrompt.indexOf('://') + 2)
-    await flushNextTick()
-
-    fireEvent.pointerDown(editable)
-    fireEvent.click(editable)
-    await flushNextTick()
-
-    expect(screen.queryByText('output')).not.toBeInTheDocument()
-    expect(screen.queryByText('workflow.nodes.agent.outputVars.newOutput')).not.toBeInTheDocument()
-  })
-
   it('clears slash trigger state after creating an agent output from the footer action', async () => {
     const captures: Captures = { editor: null, eventEmitter: null }
 
@@ -718,9 +662,8 @@ describe('ComponentPicker (component-picker-block/index.tsx)', () => {
 
     const editor = await waitForEditor(captures)
     const dispatchSpy = vi.spyOn(editor, 'dispatchCommand')
-    const editable = screen.getByTestId(CONTENT_EDITABLE_TEST_ID)
 
-    await insertSlashTrigger(editor, editable)
+    await setEditorText(editor, '/', true)
     await flushNextTick()
 
     const newOutputAction = await screen.findByText('workflow.nodes.agent.outputVars.newOutput')
@@ -734,6 +677,7 @@ describe('ComponentPicker (component-picker-block/index.tsx)', () => {
       ).not.toBeInTheDocument()
     })
 
+    const editable = screen.getByTestId(CONTENT_EDITABLE_TEST_ID)
     fireEvent.focus(editable)
 
     await flushNextTick()
@@ -1084,8 +1028,7 @@ describe('ComponentPicker (component-picker-block/index.tsx)', () => {
       )
 
       const editor = await waitForEditor(captures)
-      const editable = screen.getByTestId(CONTENT_EDITABLE_TEST_ID)
-      await insertSlashTrigger(editor, editable)
+      await setEditorText(editor, '/', true)
       expect(await screen.findByText('payload')).toBeInTheDocument()
 
       vi.useFakeTimers()

--- a/web/app/components/base/prompt-editor/plugins/component-picker-block/index.tsx
+++ b/web/app/components/base/prompt-editor/plugins/component-picker-block/index.tsx
@@ -83,7 +83,6 @@ const ComponentPicker = ({
   })
   const [editor] = useLexicalComposerContext()
   const triggerMatchRef = useRef<MenuTextMatch | null>(null)
-  const slashTypedRef = useRef(false)
   const baseCheckForTriggerMatch = useBasicTypeaheadTriggerMatch(triggerString, {
     minLength: 0,
     maxLength: 75,
@@ -92,22 +91,10 @@ const ComponentPicker = ({
   const checkForTriggerMatch = useCallback(
     (text: string, editor: LexicalEditor) => {
       const match = baseCheckForTriggerMatch(text, editor)
-      if (
-        match &&
-        triggerString === '/' &&
-        match.matchingString.length === 0 &&
-        !slashTypedRef.current
-      ) {
-        triggerMatchRef.current = null
-        return null
-      }
-      if (match && triggerString === '/' && match.matchingString.length === 0)
-        slashTypedRef.current = false
-
       triggerMatchRef.current = match
       return match
     },
-    [baseCheckForTriggerMatch, triggerString],
+    [baseCheckForTriggerMatch],
   )
 
   const [queryString, setQueryString] = useState<string | null>(null)
@@ -153,27 +140,7 @@ const ComponentPicker = ({
       if (blurTimerRef.current) clearTimeout(blurTimerRef.current)
       unregister()
     }
-  }, [editor, clearBlurTimer, triggerString])
-
-  useEffect(() => {
-    const rootElement = editor.getRootElement()
-    if (!rootElement || triggerString !== '/') return
-
-    const handleBeforeInput = (event: InputEvent) => {
-      if (event.inputType === 'insertText' && event.data === '/') slashTypedRef.current = true
-    }
-
-    const handlePointerDown = () => {
-      slashTypedRef.current = false
-    }
-
-    rootElement.addEventListener('beforeinput', handleBeforeInput)
-    rootElement.addEventListener('pointerdown', handlePointerDown)
-    return () => {
-      rootElement.removeEventListener('beforeinput', handleBeforeInput)
-      rootElement.removeEventListener('pointerdown', handlePointerDown)
-    }
-  }, [editor, triggerString])
+  }, [editor, clearBlurTimer])
 
   eventEmitter?.useSubscription((v: EventEmitterValue) => {
     if (


### PR DESCRIPTION
## Summary

- revert the redundant slash-intent tracking introduced by #39761
- keep the trigger-boundary behavior already shipped in #39768
- restore reliable slash picker opening when users type `/` after the editor loses and regains focus

## Why

#39755 had already been fixed by #39768 before #39761 was merged. The existing boundary matcher prevents URL and path separators from reopening the picker while preserving valid slash commands at the beginning of text or after whitespace.

#39761 added a second `beforeinput`-based intent gate on top of that completed fix. The extra gate is redundant and introduced a regression in the Agent Task editor: after focus changes, typing `/` can insert the character without opening the picker. The regression is visible in post-merge E2E runs [31078775162](https://github.com/langgenius/dify/actions/runs/31078775162) and [31082547409](https://github.com/langgenius/dify/actions/runs/31082547409).

This reverts only #39761. The `requireTriggerBoundary` protection and its URL, path, cursor-position, and spacing coverage from #39768 remain intact.

## Validation

- `vp test run app/components/base/prompt-editor/__tests__/hooks.spec.tsx app/components/base/prompt-editor/plugins/component-picker-block/__tests__/index.spec.tsx features/agent-v2/agent-detail/configure/components/__tests__/agent-prompt-editor.spec.tsx` — 68 tests passed
- `vp check web/app/components/base/prompt-editor/plugins/component-picker-block/index.tsx web/app/components/base/prompt-editor/plugins/component-picker-block/__tests__/index.spec.tsx`
- `git diff --check origin/main...HEAD`
