### PR TITLE
test(e2e): align duplicate Agent publish state

### DIFF
--- a/e2e/features/agent-v2/agent-edit.feature
+++ b/e2e/features/agent-v2/agent-edit.feature
@@ -17,7 +17,7 @@ Feature: Agent v2 Agent Edit page
     And the Agent Builder preseeded Agent "E2E New Agent Builder Full Config" includes the core fixture configuration
     And the preseeded Agent v2 "E2E New Agent Builder Full Config" has been published via API
     When I duplicate the preseeded Agent v2 "E2E New Agent Builder Full Config" from the Agent Roster
-    Then the duplicated Agent v2 should inherit the full-config fixture from "E2E New Agent Builder Full Config"
+    Then the duplicated Agent v2 should inherit the full-config fixture from "E2E New Agent Builder Full Config" without inheriting its publication state
     When I open the Agent v2 configure page
     And I fill the Agent v2 prompt editor with the updated E2E prompt
     Then the Agent v2 configuration should be saved automatically

--- a/e2e/features/step-definitions/agent-v2/agent-edit.steps.ts
+++ b/e2e/features/step-definitions/agent-v2/agent-edit.steps.ts
@@ -179,7 +179,7 @@ Then('I should see the Agent v2 full-config fixture sections', async function (t
 })
 
 Then(
-  'the duplicated Agent v2 should inherit the full-config fixture from {string}',
+  'the duplicated Agent v2 should inherit the full-config fixture from {string} without inheriting its publication state',
   async function (this: DifyWorld, agentName: string) {
     const sourceAgent = getPreseededAgent(this, agentName)
     const duplicatedAgentId = getCurrentAgentId(this)
@@ -198,7 +198,8 @@ Then(
 
     expect(duplicatedDetail.id).toBe(duplicatedAgentId)
     expect(duplicatedDetail.name).toBe(this.lastCreatedAgentName)
-    expect(duplicatedSnapshot.activeConfigIsPublished).toBe(sourceSnapshot.activeConfigIsPublished)
+    expect(sourceSnapshot.activeConfigIsPublished).toBe(true)
+    expect(duplicatedSnapshot.activeConfigIsPublished).toBe(false)
     expect(duplicatedSnapshot.model).toEqual({
       name: stableModel.name,
       provider: stableModel.provider,


### PR DESCRIPTION
## Summary

- clarify that duplicated Agents inherit configuration without inheriting publication state
- assert the published source and unpublished duplicate states independently

## Why

PR #40105 intentionally gives each duplicated Agent a new publication history, but the prepared E2E scenario still expected the duplicate to inherit the source publication state.

## Validation

- reproduced the focused prepared scenario failure before the change
- passed the same focused scenario after the change: 1 scenario, 16 steps
- `git diff --check`
