### PR TITLE
fix(workflow): preserve iteration output when parallel mode is enabled

### DIFF
--- a/api/core/app/apps/workflow/app_runner.py
+++ b/api/core/app/apps/workflow/app_runner.py
@@ -3,6 +3,7 @@ import time
 from collections.abc import Sequence
 from typing import cast
 
+from context import capture_current_context
 from core.app.apps.base_app_queue_manager import AppQueueManager
 from core.app.apps.workflow.app_config_manager import WorkflowAppConfig
 from core.app.apps.workflow.command_channels import (
@@ -137,7 +138,11 @@ class WorkflowAppRunner(WorkflowBasedAppRunner):
                 ),
             )
 
-            graph_runtime_state = GraphRuntimeState(variable_pool=variable_pool, start_at=time.perf_counter())
+            graph_runtime_state = GraphRuntimeState(
+                variable_pool=variable_pool,
+                start_at=time.perf_counter(),
+                execution_context=capture_current_context(),
+            )
             graph = self._init_graph(
                 graph_config=self._workflow.graph_dict,
                 graph_runtime_state=graph_runtime_state,

--- a/api/core/provider_manager.py
+++ b/api/core/provider_manager.py
@@ -1242,26 +1242,28 @@ class ProviderManager:
                                 quota_used=0,
                                 is_valid=True,
                             )
-                            db.session.add(new_provider_record)
-                            db.session.commit()
+                            with session_factory.create_session() as session:
+                                session.add(new_provider_record)
+                                session.commit()
                             provider_name_to_provider_records_dict[provider_name].append(new_provider_record)
                         except IntegrityError:
-                            db.session.rollback()
-                            stmt = select(Provider).where(
-                                Provider.tenant_id == tenant_id,
-                                Provider.provider_name == ModelProviderID(provider_name).provider_name,
-                                Provider.provider_type == ProviderType.SYSTEM.value,
-                                Provider.quota_type == quota.quota_type,
-                            )
-                            existed_provider_record = db.session.scalar(stmt)
-                            if not existed_provider_record:
-                                continue
+                            with session_factory.create_session() as session:
+                                session.rollback()
+                                stmt = select(Provider).where(
+                                    Provider.tenant_id == tenant_id,
+                                    Provider.provider_name == ModelProviderID(provider_name).provider_name,
+                                    Provider.provider_type == ProviderType.SYSTEM.value,
+                                    Provider.quota_type == quota.quota_type,
+                                )
+                                existed_provider_record = session.scalar(stmt)
+                                if not existed_provider_record:
+                                    continue
 
-                            if not existed_provider_record.is_valid:
-                                existed_provider_record.is_valid = True
-                                db.session.commit()
+                                if not existed_provider_record.is_valid:
+                                    existed_provider_record.is_valid = True
+                                    session.commit()
 
-                            provider_name_to_provider_records_dict[provider_name].append(existed_provider_record)
+                                provider_name_to_provider_records_dict[provider_name].append(existed_provider_record)
 
         return provider_name_to_provider_records_dict
 

--- a/api/core/workflow/graph_engine/__init__.py
+++ b/api/core/workflow/graph_engine/__init__.py
@@ -1,0 +1,3 @@
+from .dify_iteration_container_handler import create_dify_iteration_container_handler
+
+__all__ = ["create_dify_iteration_container_handler"]

--- a/api/core/workflow/graph_engine/dify_iteration_container_handler.py
+++ b/api/core/workflow/graph_engine/dify_iteration_container_handler.py
@@ -50,9 +50,7 @@ class DifyIterationContainerHandler:
     ) -> None:
         self._delegate.prepare_frame_event(frame=frame, event=event)
         if isinstance(event, NodeRunSucceededEvent):
-            self._frame_node_outputs.setdefault(frame.frame_id, {})[event.node_id] = dict(
-                event.node_run_result.outputs
-            )
+            self._frame_node_outputs.setdefault(frame.frame_id, {})[event.node_id] = dict(event.node_run_result.outputs)
 
     def should_collect(
         self,

--- a/api/core/workflow/graph_engine/dify_iteration_container_handler.py
+++ b/api/core/workflow/graph_engine/dify_iteration_container_handler.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import cast, final
+
+from graphon.graph_engine.frames import ExecutionFrame, FrameRegistry
+from graphon.graph_engine.iteration_container_handler import IterationContainerHandler
+from graphon.graph_events.base import GraphNodeEventBase
+from graphon.graph_events.node import NodeRunSucceededEvent
+from graphon.runtime import GraphRuntimeState
+from graphon.runtime.container_state import IterationFrameState
+from graphon.variables.factory import build_segment
+from graphon.variables.segments import NoneSegment, Segment, SerializableSegment
+
+
+@final
+class DifyIterationContainerHandler(IterationContainerHandler):
+    """Iteration handler that preserves child outputs in parallel mode.
+
+    Graphon's parallel iteration collector reads the selected output from the
+    child frame variable pool when a child graph finishes. In some parallel runs
+    the selected value is present on the child success event but is not yet
+    readable from the child variable pool, which produces ``[null]`` outputs.
+    """
+
+    def __init__(self, frame_registry: FrameRegistry) -> None:
+        super().__init__(frame_registry)
+        self._frame_node_outputs: dict[str, dict[str, dict[str, object]]] = {}
+
+    def prepare_frame_event(
+        self,
+        *,
+        frame: ExecutionFrame,
+        event: GraphNodeEventBase,
+    ) -> None:
+        super().prepare_frame_event(frame=frame, event=event)
+        if isinstance(event, NodeRunSucceededEvent):
+            self._frame_node_outputs.setdefault(frame.frame_id, {})[event.node_id] = dict(
+                event.node_run_result.outputs
+            )
+
+    def complete_frame(self, frame: ExecutionFrame) -> None:
+        try:
+            super().complete_frame(frame)
+        finally:
+            self._frame_node_outputs.pop(frame.frame_id, None)
+
+    def _start_iteration_frame(
+        self,
+        *,
+        parent_frame: ExecutionFrame,
+        run_state,
+        index: int,
+    ) -> None:
+        variable_pool = parent_frame.graph_runtime_state.variable_pool.model_copy(
+            deep=True,
+        )
+        variable_pool.add([run_state.node_id, "index"], index)
+        variable_pool.add([run_state.node_id, "item"], run_state.items[index])
+        parent_runtime_state = parent_frame.graph_runtime_state
+        child_runtime_state = GraphRuntimeState(
+            variable_pool=variable_pool,
+            start_at=parent_runtime_state.start_at,
+            ready_queue=parent_runtime_state.ready_queue,
+            deferred_ready_queue=parent_runtime_state.deferred_ready_queue,
+            graph_execution=parent_runtime_state.graph_execution,
+            execution_context=parent_runtime_state.execution_context,
+        )
+        child_frame_id = f"{run_state.invocation_id}:iteration:{index}"
+        child_frame = self._frame_registry.materialize_child_frame(
+            frame_id=child_frame_id,
+            root_node_id=run_state.root_node_id,
+            graph_runtime_state=child_runtime_state,
+        )
+        self._root_runtime_state().put_container_frame(
+            IterationFrameState(
+                frame_id=child_frame_id,
+                parent_invocation_id=run_state.invocation_id,
+                root_node_id=run_state.root_node_id,
+                index=index,
+                started_at=datetime.now(UTC).replace(tzinfo=None),
+                runtime_data=child_frame.graph_runtime_state.snapshot_frame(
+                    copy_variable_pool=False,
+                ),
+            ),
+        )
+        child_frame.state_manager.enqueue_node(run_state.root_node_id)
+
+    def _complete_ready_iteration_frame(
+        self,
+        *,
+        frame: ExecutionFrame,
+        frame_state: IterationFrameState,
+    ) -> None:
+        run_state = self._iteration_run(frame_state.parent_invocation_id)
+        parent_frame = self._frame_registry.get(run_state.frame_id)
+        if frame_state.errors:
+            self._complete_failed_iteration_frame(
+                frame=frame,
+                frame_state=frame_state,
+                parent_frame=parent_frame,
+                run_state=run_state,
+                error=frame_state.errors[0],
+            )
+            return
+
+        result = self._resolve_iteration_output_segment(
+            frame=frame,
+            output_selector=run_state.output_selector,
+        )
+        output = NoneSegment() if result is None else cast(SerializableSegment, result)
+        run_state = self._complete_iteration_step(
+            frame=frame,
+            frame_state=frame_state,
+            parent_frame=parent_frame,
+            run_state=run_state,
+            output=output,
+            store_output=True,
+        )
+        self._continue_or_complete_iteration(
+            parent_frame=parent_frame,
+            run_state=run_state,
+        )
+
+    def _resolve_iteration_output_segment(
+        self,
+        *,
+        frame: ExecutionFrame,
+        output_selector: list[str],
+    ) -> Segment | None:
+        result = frame.graph_runtime_state.variable_pool.get(output_selector)
+        if result is not None:
+            return result
+        return self._segment_from_recorded_outputs(
+            frame_id=frame.frame_id,
+            output_selector=output_selector,
+        )
+
+    def _segment_from_recorded_outputs(
+        self,
+        *,
+        frame_id: str,
+        output_selector: list[str],
+    ) -> Segment | None:
+        if len(output_selector) < 2:
+            return None
+
+        node_id = output_selector[0]
+        output_name = output_selector[1]
+        nested_selector = output_selector[2:]
+        node_outputs = self._frame_node_outputs.get(frame_id, {}).get(node_id)
+        if node_outputs is None:
+            return None
+
+        value = node_outputs.get(output_name)
+        if value is None:
+            return None
+        if nested_selector:
+            value = self._get_nested_output(value=value, selector=nested_selector)
+            if value is None:
+                return None
+        return build_segment(value)
+
+    @staticmethod
+    def _get_nested_output(*, value: object, selector: list[str]) -> object | None:
+        current = value
+        for key in selector:
+            if not isinstance(current, Mapping):
+                return None
+            current = current.get(key)
+        return current
+
+
+def create_dify_iteration_container_handler(frame_registry: FrameRegistry) -> DifyIterationContainerHandler:
+    return DifyIterationContainerHandler(frame_registry)

--- a/api/core/workflow/graph_engine/dify_iteration_container_handler.py
+++ b/api/core/workflow/graph_engine/dify_iteration_container_handler.py
@@ -1,22 +1,22 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from datetime import UTC, datetime
-from typing import cast, final
+from typing import final
 
 from graphon.graph_engine.frames import ExecutionFrame, FrameRegistry
 from graphon.graph_engine.iteration_container_handler import IterationContainerHandler
+from graphon.graph_engine.ready_queue import ROOT_FRAME_ID
 from graphon.graph_events.base import GraphNodeEventBase
-from graphon.graph_events.node import NodeRunSucceededEvent
-from graphon.runtime import GraphRuntimeState
-from graphon.runtime.container_state import IterationFrameState
+from graphon.graph_events.node import NodeRunFailedEvent, NodeRunSucceededEvent
+from graphon.nodes.container_effects import ContainerAwaitRequest
+from graphon.runtime.container_state import ContainerFrameState, IterationFrameState, IterationRunState
 from graphon.variables.factory import build_segment
-from graphon.variables.segments import NoneSegment, Segment, SerializableSegment
+from graphon.variables.segments import Segment
 
 
 @final
-class DifyIterationContainerHandler(IterationContainerHandler):
-    """Iteration handler that preserves child outputs in parallel mode.
+class DifyIterationContainerHandler:
+    """Iteration handler wrapper that preserves child outputs in parallel mode.
 
     Graphon's parallel iteration collector reads the selected output from the
     child frame variable pool when a child graph finishes. In some parallel runs
@@ -24,9 +24,23 @@ class DifyIterationContainerHandler(IterationContainerHandler):
     readable from the child variable pool, which produces ``[null]`` outputs.
     """
 
+    node_type = IterationContainerHandler.node_type
+
     def __init__(self, frame_registry: FrameRegistry) -> None:
-        super().__init__(frame_registry)
+        self._delegate = IterationContainerHandler(frame_registry)
+        self._frame_registry = frame_registry
         self._frame_node_outputs: dict[str, dict[str, dict[str, object]]] = {}
+
+    def restore_frame(self, frame_state: ContainerFrameState) -> None:
+        self._delegate.restore_frame(frame_state)
+
+    def start_await(
+        self,
+        *,
+        invocation_id: str,
+        request: ContainerAwaitRequest,
+    ) -> None:
+        self._delegate.start_await(invocation_id=invocation_id, request=request)
 
     def prepare_frame_event(
         self,
@@ -34,107 +48,60 @@ class DifyIterationContainerHandler(IterationContainerHandler):
         frame: ExecutionFrame,
         event: GraphNodeEventBase,
     ) -> None:
-        super().prepare_frame_event(frame=frame, event=event)
+        self._delegate.prepare_frame_event(frame=frame, event=event)
         if isinstance(event, NodeRunSucceededEvent):
             self._frame_node_outputs.setdefault(frame.frame_id, {})[event.node_id] = dict(
                 event.node_run_result.outputs
             )
 
+    def should_collect(
+        self,
+        *,
+        event: GraphNodeEventBase,
+    ) -> bool:
+        return self._delegate.should_collect(event=event)
+
+    def record_frame_failure(
+        self,
+        *,
+        frame: ExecutionFrame,
+        event: NodeRunFailedEvent,
+    ) -> None:
+        self._delegate.record_frame_failure(frame=frame, event=event)
+
     def complete_frame(self, frame: ExecutionFrame) -> None:
         try:
-            super().complete_frame(frame)
+            self._backfill_iteration_output_if_needed(frame)
+            self._delegate.complete_frame(frame)
         finally:
             self._frame_node_outputs.pop(frame.frame_id, None)
 
-    def _start_iteration_frame(
-        self,
-        *,
-        parent_frame: ExecutionFrame,
-        run_state,
-        index: int,
-    ) -> None:
-        variable_pool = parent_frame.graph_runtime_state.variable_pool.model_copy(
-            deep=True,
-        )
-        variable_pool.add([run_state.node_id, "index"], index)
-        variable_pool.add([run_state.node_id, "item"], run_state.items[index])
-        parent_runtime_state = parent_frame.graph_runtime_state
-        child_runtime_state = GraphRuntimeState(
-            variable_pool=variable_pool,
-            start_at=parent_runtime_state.start_at,
-            ready_queue=parent_runtime_state.ready_queue,
-            deferred_ready_queue=parent_runtime_state.deferred_ready_queue,
-            graph_execution=parent_runtime_state.graph_execution,
-            execution_context=parent_runtime_state.execution_context,
-        )
-        child_frame_id = f"{run_state.invocation_id}:iteration:{index}"
-        child_frame = self._frame_registry.materialize_child_frame(
-            frame_id=child_frame_id,
-            root_node_id=run_state.root_node_id,
-            graph_runtime_state=child_runtime_state,
-        )
-        self._root_runtime_state().put_container_frame(
-            IterationFrameState(
-                frame_id=child_frame_id,
-                parent_invocation_id=run_state.invocation_id,
-                root_node_id=run_state.root_node_id,
-                index=index,
-                started_at=datetime.now(UTC).replace(tzinfo=None),
-                runtime_data=child_frame.graph_runtime_state.snapshot_frame(
-                    copy_variable_pool=False,
-                ),
-            ),
-        )
-        child_frame.state_manager.enqueue_node(run_state.root_node_id)
-
-    def _complete_ready_iteration_frame(
-        self,
-        *,
-        frame: ExecutionFrame,
-        frame_state: IterationFrameState,
-    ) -> None:
-        run_state = self._iteration_run(frame_state.parent_invocation_id)
-        parent_frame = self._frame_registry.get(run_state.frame_id)
-        if frame_state.errors:
-            self._complete_failed_iteration_frame(
-                frame=frame,
-                frame_state=frame_state,
-                parent_frame=parent_frame,
-                run_state=run_state,
-                error=frame_state.errors[0],
-            )
+    def _backfill_iteration_output_if_needed(self, frame: ExecutionFrame) -> None:
+        root_runtime_state = self._frame_registry.get(ROOT_FRAME_ID).graph_runtime_state
+        frame_state = root_runtime_state.get_container_frame(frame.frame_id)
+        if not isinstance(frame_state, IterationFrameState):
             return
 
-        result = self._resolve_iteration_output_segment(
-            frame=frame,
-            output_selector=run_state.output_selector,
-        )
-        output = NoneSegment() if result is None else cast(SerializableSegment, result)
-        run_state = self._complete_iteration_step(
-            frame=frame,
-            frame_state=frame_state,
-            parent_frame=parent_frame,
-            run_state=run_state,
-            output=output,
-            store_output=True,
-        )
-        self._continue_or_complete_iteration(
-            parent_frame=parent_frame,
-            run_state=run_state,
-        )
+        run_state = root_runtime_state.get_container_run(frame_state.parent_invocation_id)
+        if not isinstance(run_state, IterationRunState):
+            return
 
-    def _resolve_iteration_output_segment(
-        self,
-        *,
-        frame: ExecutionFrame,
-        output_selector: list[str],
-    ) -> Segment | None:
-        result = frame.graph_runtime_state.variable_pool.get(output_selector)
-        if result is not None:
-            return result
-        return self._segment_from_recorded_outputs(
+        output_selector = list(run_state.output_selector)
+        if len(output_selector) < 2:
+            return
+        if frame.graph_runtime_state.variable_pool.get(output_selector) is not None:
+            return
+
+        segment = self._segment_from_recorded_outputs(
             frame_id=frame.frame_id,
             output_selector=output_selector,
+        )
+        if segment is None:
+            return
+
+        frame.graph_runtime_state.variable_pool.add(
+            (output_selector[0], output_selector[1]),
+            segment.to_object(),
         )
 
     def _segment_from_recorded_outputs(

--- a/api/core/workflow/workflow_entry.py
+++ b/api/core/workflow/workflow_entry.py
@@ -11,6 +11,7 @@ from core.app.entities.app_invoke_entities import InvokeFrom, UserFrom, build_di
 from core.app.file_access import DatabaseFileAccessController
 from core.app.workflow.layers.llm_quota import LLMQuotaLayer
 from core.app.workflow.layers.observability import ObservabilityLayer
+from core.workflow.graph_engine import create_dify_iteration_container_handler
 from core.workflow.node_factory import (
     DifyGraphInitContext,
     DifyNodeFactory,
@@ -138,7 +139,6 @@ class WorkflowEntry:
         self.command_channel = command_channel
         self._response_stream_filter = response_stream_filter or ResponseStreamFilter()
         execution_context = capture_current_context()
-        # ponytail: Graphon snapshots omit process-local context; use a public rebind API when Graphon exposes one.
         graph_runtime_state._execution_context = execution_context
         self.graph_engine = GraphEngine(
             workflow_id=workflow_id,
@@ -151,6 +151,7 @@ class WorkflowEntry:
                 scale_up_threshold=dify_config.GRAPH_ENGINE_SCALE_UP_THRESHOLD,
                 scale_down_idle_time=dify_config.GRAPH_ENGINE_SCALE_DOWN_IDLE_TIME,
             ),
+            container_handler_factories=(create_dify_iteration_container_handler,),
         )
 
         # Add debug logging layer when in debug mode

--- a/api/tests/fixtures/workflow/parallel_iteration_formatting_workflow.yml
+++ b/api/tests/fixtures/workflow/parallel_iteration_formatting_workflow.yml
@@ -1,0 +1,275 @@
+app:
+  description: 'This is a simple workflow contains a Iteration.
+
+
+    It doesn''t need any inputs, and will outputs:
+
+
+    ```
+
+    {"output": ["output: 1", "output: 2", "output: 3"]}
+
+    ```'
+  icon: 🤖
+  icon_background: '#FFEAD5'
+  mode: workflow
+  name: test_iteration
+  use_icon_as_answer_icon: false
+dependencies: []
+kind: app
+version: 0.3.1
+workflow:
+  conversation_variables: []
+  environment_variables: []
+  features:
+    file_upload:
+      allowed_file_extensions:
+      - .JPG
+      - .JPEG
+      - .PNG
+      - .GIF
+      - .WEBP
+      - .SVG
+      allowed_file_types:
+      - image
+      allowed_file_upload_methods:
+      - local_file
+      - remote_url
+      enabled: false
+      fileUploadConfig:
+        audio_file_size_limit: 50
+        batch_count_limit: 5
+        file_size_limit: 15
+        image_file_size_limit: 10
+        video_file_size_limit: 100
+        workflow_file_upload_limit: 10
+      image:
+        enabled: false
+        number_limits: 3
+        transfer_methods:
+        - local_file
+        - remote_url
+      number_limits: 3
+    opening_statement: ''
+    retriever_resource:
+      enabled: true
+    sensitive_word_avoidance:
+      enabled: false
+    speech_to_text:
+      enabled: false
+    suggested_questions: []
+    suggested_questions_after_answer:
+      enabled: false
+    text_to_speech:
+      enabled: false
+      language: ''
+      voice: ''
+  graph:
+    edges:
+    - data:
+        isInIteration: false
+        isInLoop: false
+        sourceType: start
+        targetType: code
+      id: 1754683427386-source-1754683442688-target
+      source: '1754683427386'
+      sourceHandle: source
+      target: '1754683442688'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: false
+        isInLoop: false
+        sourceType: code
+        targetType: iteration
+      id: 1754683442688-source-1754683430480-target
+      source: '1754683442688'
+      sourceHandle: source
+      target: '1754683430480'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    - data:
+        isInIteration: true
+        isInLoop: false
+        iteration_id: '1754683430480'
+        sourceType: iteration-start
+        targetType: template-transform
+      id: 1754683430480start-source-1754683458843-target
+      source: 1754683430480start
+      sourceHandle: source
+      target: '1754683458843'
+      targetHandle: target
+      type: custom
+      zIndex: 1002
+    - data:
+        isInIteration: false
+        isInLoop: false
+        sourceType: iteration
+        targetType: end
+      id: 1754683430480-source-1754683480778-target
+      source: '1754683430480'
+      sourceHandle: source
+      target: '1754683480778'
+      targetHandle: target
+      type: custom
+      zIndex: 0
+    nodes:
+    - data:
+        desc: ''
+        selected: false
+        title: Start
+        type: start
+        variables: []
+      height: 54
+      id: '1754683427386'
+      position:
+        x: 80
+        y: 282
+      positionAbsolute:
+        x: 80
+        y: 282
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        error_handle_mode: terminated
+        height: 178
+        is_parallel: true
+        iterator_input_type: array[number]
+        iterator_selector:
+        - '1754683442688'
+        - result
+        output_selector:
+        - '1754683458843'
+        - output
+        output_type: array[string]
+        parallel_nums: 10
+        selected: false
+        start_node_id: 1754683430480start
+        title: Iteration
+        type: iteration
+        width: 388
+      height: 178
+      id: '1754683430480'
+      position:
+        x: 684
+        y: 282
+      positionAbsolute:
+        x: 684
+        y: 282
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 388
+      zIndex: 1
+    - data:
+        desc: ''
+        isInIteration: true
+        selected: false
+        title: ''
+        type: iteration-start
+      draggable: false
+      height: 48
+      id: 1754683430480start
+      parentId: '1754683430480'
+      position:
+        x: 24
+        y: 68
+      positionAbsolute:
+        x: 708
+        y: 350
+      selectable: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom-iteration-start
+      width: 44
+      zIndex: 1002
+    - data:
+        code: "\ndef main() -> dict:\n    return {\n        \"result\": [1, 2, 3],\n\
+          \    }\n"
+        code_language: python3
+        desc: ''
+        outputs:
+          result:
+            children: null
+            type: array[number]
+        selected: false
+        title: Code
+        type: code
+        variables: []
+      height: 54
+      id: '1754683442688'
+      position:
+        x: 384
+        y: 282
+      positionAbsolute:
+        x: 384
+        y: 282
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    - data:
+        desc: ''
+        isInIteration: true
+        isInLoop: false
+        iteration_id: '1754683430480'
+        selected: false
+        template: 'output: {{ arg1 }}'
+        title: Template
+        type: template-transform
+        variables:
+        - value_selector:
+          - '1754683430480'
+          - item
+          value_type: string
+          variable: arg1
+      height: 54
+      id: '1754683458843'
+      parentId: '1754683430480'
+      position:
+        x: 128
+        y: 68
+      positionAbsolute:
+        x: 812
+        y: 350
+      selected: false
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+      zIndex: 1002
+    - data:
+        desc: ''
+        outputs:
+        - value_selector:
+          - '1754683430480'
+          - output
+          value_type: array[string]
+          variable: output
+        selected: false
+        title: End
+        type: end
+      height: 90
+      id: '1754683480778'
+      position:
+        x: 1132
+        y: 282
+      positionAbsolute:
+        x: 1132
+        y: 282
+      selected: true
+      sourcePosition: right
+      targetPosition: left
+      type: custom
+      width: 244
+    viewport:
+      x: -476
+      y: 3
+      zoom: 1

--- a/api/tests/unit_tests/core/test_provider_manager.py
+++ b/api/tests/unit_tests/core/test_provider_manager.py
@@ -341,6 +341,37 @@ def test_to_system_configuration_uses_owned_session_for_cloud_credit_pools() -> 
     session_context.__exit__.assert_called_once_with(None, None, None)
 
 
+def test_init_trial_provider_records_uses_owned_session(provider_db: Session) -> None:
+    assert provider_db is not None
+    manager = _build_provider_manager()
+    provider_name = "langgenius/openai/openai"
+    provider_records: dict[str, list[Provider]] = {provider_name: []}
+    session_factory = provider_manager_module.session_factory
+
+    with (
+        patch(
+            "core.provider_manager.ext_hosting_provider.hosting_configuration.provider_map",
+            {provider_name: _build_hosting_provider()},
+        ),
+        patch.object(
+            session_factory,
+            "create_session",
+            wraps=session_factory.create_session,
+        ) as create_session,
+    ):
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            assert executor.submit(has_app_context).result() is False
+            updated_records = executor.submit(
+                ProviderManager._init_trial_provider_records,
+                "tenant-id",
+                provider_records,
+            ).result()
+
+    assert create_session.call_count >= 1
+    assert provider_name in updated_records
+    assert updated_records[provider_name]
+
+
 def test_to_system_configuration_preserves_marketplace_behavior() -> None:
     provider_entity = _build_plugin_provider_declaration(PluginInstallationSource.Marketplace)
     manager = _build_provider_manager()

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_dify_iteration_container_handler.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_dify_iteration_container_handler.py
@@ -1,0 +1,60 @@
+"""Regression tests for Dify iteration container output collection."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from core.workflow.graph_engine.dify_iteration_container_handler import DifyIterationContainerHandler
+from graphon.variables.segments import StringSegment
+
+
+def test_segment_from_recorded_outputs_returns_child_event_value() -> None:
+    handler = DifyIterationContainerHandler(frame_registry=MagicMock())
+    handler._frame_node_outputs["child-frame"] = {
+        "http": {"body": "response-text"},
+    }
+
+    segment = handler._segment_from_recorded_outputs(
+        frame_id="child-frame",
+        output_selector=["http", "body"],
+    )
+
+    assert isinstance(segment, StringSegment)
+    assert segment.value == "response-text"
+
+
+def test_segment_from_recorded_outputs_supports_nested_selector() -> None:
+    handler = DifyIterationContainerHandler(frame_registry=MagicMock())
+    handler._frame_node_outputs["child-frame"] = {
+        "code": {"result": {"message": "nested-value"}},
+    }
+
+    segment = handler._segment_from_recorded_outputs(
+        frame_id="child-frame",
+        output_selector=["code", "result", "message"],
+    )
+
+    assert isinstance(segment, StringSegment)
+    assert segment.value == "nested-value"
+
+
+def test_resolve_iteration_output_segment_prefers_recorded_outputs() -> None:
+    handler = DifyIterationContainerHandler(frame_registry=MagicMock())
+    handler._frame_node_outputs["child-frame"] = {
+        "http": {"body": "ok"},
+    }
+    frame = SimpleNamespace(
+        frame_id="child-frame",
+        graph_runtime_state=SimpleNamespace(
+            variable_pool=SimpleNamespace(get=lambda _selector: None),
+        ),
+    )
+
+    segment = handler._resolve_iteration_output_segment(
+        frame=frame,
+        output_selector=["http", "body"],
+    )
+
+    assert isinstance(segment, StringSegment)
+    assert segment.value == "ok"

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_dify_iteration_container_handler.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_dify_iteration_container_handler.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock
 
 from core.workflow.graph_engine.dify_iteration_container_handler import DifyIterationContainerHandler
+from graphon.graph_engine.frames import ExecutionFrame
+from graphon.model_runtime.entities.llm_entities import LLMUsage
+from graphon.runtime.container_state import FrameRuntimeData, IterationFrameState, IterationRunState
 from graphon.variables.segments import StringSegment
 
 
@@ -39,22 +44,55 @@ def test_segment_from_recorded_outputs_supports_nested_selector() -> None:
     assert segment.value == "nested-value"
 
 
-def test_resolve_iteration_output_segment_prefers_recorded_outputs() -> None:
-    handler = DifyIterationContainerHandler(frame_registry=MagicMock())
+def test_backfill_iteration_output_writes_recorded_value_into_variable_pool() -> None:
+    frame_registry = MagicMock()
+    iteration_frame_state = IterationFrameState(
+        frame_id="child-frame",
+        parent_invocation_id="invocation-1",
+        root_node_id="iteration_start",
+        index=0,
+        started_at=datetime.now(timezone.utc),
+        runtime_data=FrameRuntimeData(
+            variable_pool="parent",
+            outputs={},
+            llm_usage=LLMUsage.empty_usage(),
+            node_run_steps=0,
+            graph_node_states={},
+            graph_edge_states={},
+        ),
+    )
+    root_runtime_state = SimpleNamespace(
+        get_container_frame=lambda _frame_id: iteration_frame_state,
+        get_container_run=lambda _invocation_id: IterationRunState(
+            invocation_id="invocation-1",
+            frame_id="parent-frame",
+            node_id="iteration",
+            started_at=datetime.now(timezone.utc),
+            root_node_id="iteration_start",
+            items=(),
+            output_selector=("http", "body"),
+            error_handle_mode="continue-on-error",
+            flatten_output=False,
+            parallel_nums=1,
+        ),
+    )
+    frame_registry.get.return_value = SimpleNamespace(graph_runtime_state=root_runtime_state)
+
+    variable_pool = MagicMock()
+    variable_pool.get.return_value = None
+
+    handler = DifyIterationContainerHandler(frame_registry=frame_registry)
     handler._frame_node_outputs["child-frame"] = {
         "http": {"body": "ok"},
     }
-    frame = SimpleNamespace(
-        frame_id="child-frame",
-        graph_runtime_state=SimpleNamespace(
-            variable_pool=SimpleNamespace(get=lambda _selector: None),
+    frame = cast(
+        ExecutionFrame,
+        SimpleNamespace(
+            frame_id="child-frame",
+            graph_runtime_state=SimpleNamespace(variable_pool=variable_pool),
         ),
     )
 
-    segment = handler._resolve_iteration_output_segment(
-        frame=frame,
-        output_selector=["http", "body"],
-    )
+    handler._backfill_iteration_output_if_needed(frame)
 
-    assert isinstance(segment, StringSegment)
-    assert segment.value == "ok"
+    variable_pool.add.assert_called_once_with(("http", "body"), "ok")

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_dify_iteration_container_handler.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_dify_iteration_container_handler.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import MagicMock
@@ -51,7 +51,7 @@ def test_backfill_iteration_output_writes_recorded_value_into_variable_pool() ->
         parent_invocation_id="invocation-1",
         root_node_id="iteration_start",
         index=0,
-        started_at=datetime.now(timezone.utc),
+        started_at=datetime.now(UTC),
         runtime_data=FrameRuntimeData(
             variable_pool="parent",
             outputs={},
@@ -67,7 +67,7 @@ def test_backfill_iteration_output_writes_recorded_value_into_variable_pool() ->
             invocation_id="invocation-1",
             frame_id="parent-frame",
             node_id="iteration",
-            started_at=datetime.now(timezone.utc),
+            started_at=datetime.now(UTC),
             root_node_id="iteration_start",
             items=(),
             output_selector=("http", "body"),

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_parallel_iteration_http_auth.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_parallel_iteration_http_auth.py
@@ -1,0 +1,245 @@
+"""Regression tests for HTTP authorization inside parallel iteration."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Mapping
+
+import pytest
+
+from core.app.entities.app_invoke_entities import DIFY_RUN_CONTEXT_KEY, InvokeFrom, UserFrom
+from core.workflow.graph_engine import create_dify_iteration_container_handler
+from core.workflow.node_factory import DifyNodeFactory, get_default_root_node_id
+from core.workflow.system_variables import build_bootstrap_variables, build_system_variables
+from core.workflow.variable_pool_initializer import add_node_inputs_to_pool, add_variables_to_pool
+from core.workflow.workflow_entry import iter_dify_graph_engine_events
+from graphon.entities import GraphInitParams
+from graphon.graph import Graph
+from graphon.graph_engine import GraphEngine, GraphEngineConfig
+from graphon.graph_engine.command_channels import InMemoryChannel
+from graphon.graph_events import GraphRunSucceededEvent
+from graphon.http.response import HttpResponse
+from graphon.runtime import GraphRuntimeState, VariablePool
+
+
+class RecordingHttpClient:
+    request_error = Exception
+    max_retries_exceeded_error = Exception
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.requests: list[dict[str, object]] = []
+
+    def _record(self, method: str, url: str, **kwargs: object) -> HttpResponse:
+        with self._lock:
+            self.requests.append({"method": method, "url": url, **kwargs})
+        return HttpResponse(
+            status_code=200,
+            headers={"content-type": "text/plain"},
+            content=b"ok",
+        )
+
+    def get(self, url: str, max_retries: int = 0, **kwargs: object) -> HttpResponse:
+        return self._record("GET", url, max_retries=max_retries, **kwargs)
+
+    def head(self, url: str, max_retries: int = 0, **kwargs: object) -> HttpResponse:
+        return self._record("HEAD", url, max_retries=max_retries, **kwargs)
+
+    def post(self, url: str, max_retries: int = 0, **kwargs: object) -> HttpResponse:
+        return self._record("POST", url, max_retries=max_retries, **kwargs)
+
+    def put(self, url: str, max_retries: int = 0, **kwargs: object) -> HttpResponse:
+        return self._record("PUT", url, max_retries=max_retries, **kwargs)
+
+    def delete(self, url: str, max_retries: int = 0, **kwargs: object) -> HttpResponse:
+        return self._record("DELETE", url, max_retries=max_retries, **kwargs)
+
+    def patch(self, url: str, max_retries: int = 0, **kwargs: object) -> HttpResponse:
+        return self._record("PATCH", url, max_retries=max_retries, **kwargs)
+
+
+def _build_http_iteration_graph_config(*, is_parallel: bool) -> dict[str, object]:
+    return {
+        "nodes": [
+            {"id": "start", "data": {"type": "start", "title": "Start", "variables": []}},
+            {
+                "id": "iteration",
+                "data": {
+                    "type": "iteration",
+                    "title": "Iteration",
+                    "start_node_id": "iteration_start",
+                    "iterator_selector": ["start", "items"],
+                    "output_selector": ["http", "body"],
+                    "output_type": "array[string]",
+                    "error_handle_mode": "continue-on-error",
+                    "is_parallel": is_parallel,
+                    "parallel_nums": 3,
+                    "flatten_output": True,
+                },
+            },
+            {
+                "id": "iteration_start",
+                "parentId": "iteration",
+                "data": {"type": "iteration-start", "title": "", "isInIteration": True},
+            },
+            {
+                "id": "http",
+                "parentId": "iteration",
+                "data": {
+                    "type": "http-request",
+                    "title": "HTTP",
+                    "isInIteration": True,
+                    "iteration_id": "iteration",
+                    "method": "get",
+                    "url": "https://api.example.com/items/{{#iteration.item#}}",
+                    "authorization": {
+                        "type": "api-key",
+                        "config": {
+                            "type": "custom",
+                            "header": "X-API-Key",
+                            "api_key": "secret-token",
+                        },
+                    },
+                    "headers": "",
+                    "params": "",
+                    "body": {"type": "none"},
+                    "ssl_verify": True,
+                    "timeout": {"connect": 10, "read": 30, "write": 30},
+                },
+            },
+            {
+                "id": "end",
+                "data": {
+                    "type": "end",
+                    "title": "End",
+                    "outputs": [
+                        {
+                            "variable": "output",
+                            "value_selector": ["iteration", "output"],
+                            "value_type": "array[string]",
+                        }
+                    ],
+                },
+            },
+        ],
+        "edges": [
+            {"id": "e1", "source": "start", "target": "iteration", "sourceHandle": "source", "targetHandle": "target"},
+            {"id": "e2", "source": "iteration", "target": "end", "sourceHandle": "source", "targetHandle": "target"},
+            {
+                "id": "e3",
+                "source": "iteration_start",
+                "target": "http",
+                "sourceHandle": "source",
+                "targetHandle": "target",
+                "data": {"isInIteration": True, "iteration_id": "iteration"},
+            },
+        ],
+    }
+
+
+def _run_http_iteration_workflow(
+    *,
+    is_parallel: bool,
+    min_workers: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[dict[str, object], RecordingHttpClient]:
+    recording_client = RecordingHttpClient()
+    monkeypatch.setattr(
+        "core.workflow.node_factory.graphon_ssrf_proxy",
+        recording_client,
+    )
+
+    graph_config = _build_http_iteration_graph_config(is_parallel=is_parallel)
+    graph_init_params = GraphInitParams(
+        workflow_id="test_workflow",
+        graph_config=graph_config,
+        run_context={
+            DIFY_RUN_CONTEXT_KEY: {
+                "tenant_id": "test_tenant",
+                "app_id": "test_app",
+                "user_id": "test_user",
+                "user_from": UserFrom.ACCOUNT,
+                "invoke_from": InvokeFrom.DEBUGGER,
+            }
+        },
+        call_depth=0,
+    )
+
+    system_variables = build_system_variables(
+        user_id="test_user",
+        app_id="test_app",
+        workflow_id=graph_init_params.workflow_id,
+        files=[],
+        query="",
+    )
+    root_node_id = get_default_root_node_id(graph_config)
+    variable_pool = VariablePool()
+    add_variables_to_pool(
+        variable_pool,
+        build_bootstrap_variables(system_variables=system_variables),
+    )
+    add_node_inputs_to_pool(
+        variable_pool,
+        node_id=root_node_id,
+        inputs={"items": ["a", "b", "c"]},
+    )
+    graph_runtime_state = GraphRuntimeState(variable_pool=variable_pool, start_at=time.perf_counter())
+
+    node_factory = DifyNodeFactory(
+        graph_init_params=graph_init_params,
+        graph_runtime_state=graph_runtime_state,
+    )
+    graph = Graph.init(
+        graph_config=graph_config,
+        node_factory=node_factory,
+        root_node_id=root_node_id,
+        skip_validation=True,
+    )
+
+    engine = GraphEngine(
+        workflow_id="test_workflow",
+        graph=graph,
+        graph_runtime_state=graph_runtime_state,
+        command_channel=InMemoryChannel(),
+        config=GraphEngineConfig(
+            min_workers=min_workers,
+            max_workers=min_workers,
+            scale_up_threshold=1,
+            scale_down_idle_time=3600.0,
+        ),
+        container_handler_factories=(create_dify_iteration_container_handler,),
+    )
+
+    success_event: GraphRunSucceededEvent | None = None
+    for event in iter_dify_graph_engine_events(engine):
+        if isinstance(event, GraphRunSucceededEvent):
+            success_event = event
+
+    assert success_event is not None, "workflow did not succeed"
+    return success_event.outputs, recording_client
+
+
+def _authorization_header(headers: Mapping[str, object] | None) -> str | None:
+    if not headers:
+        return None
+    for key, value in headers.items():
+        if key.lower() == "x-api-key":
+            return str(value)
+    return None
+
+
+@pytest.mark.parametrize("is_parallel", [False, True])
+def test_http_authorization_header_is_preserved_in_iteration(
+    is_parallel: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    outputs, recording_client = _run_http_iteration_workflow(
+        is_parallel=is_parallel,
+        min_workers=3,
+        monkeypatch=monkeypatch,
+    )
+
+    assert outputs["output"] == ["ok", "ok", "ok"]
+    assert len(recording_client.requests) == 3
+    assert all(_authorization_header(request.get("headers")) == "secret-token" for request in recording_client.requests)

--- a/api/tests/unit_tests/core/workflow/graph_engine/test_parallel_iteration_output.py
+++ b/api/tests/unit_tests/core/workflow/graph_engine/test_parallel_iteration_output.py
@@ -1,0 +1,56 @@
+"""Regression tests for parallel iteration output collection."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit_tests.core.workflow.graph_engine.test_table_runner import TableTestRunner, WorkflowTestCase
+
+
+@pytest.fixture
+def table_runner() -> TableTestRunner:
+    return TableTestRunner(
+        graph_engine_min_workers=5,
+        graph_engine_max_workers=5,
+        graph_engine_scale_up_threshold=1,
+        graph_engine_scale_down_idle_time=3600.0,
+    )
+
+
+def test_sequential_iteration_fixture_output(table_runner: TableTestRunner) -> None:
+    result = table_runner.run_test_case(
+        WorkflowTestCase(
+            fixture_path="array_iteration_formatting_workflow.yml",
+            expected_outputs={"output": ["output: 1", "output: 2", "output: 3"]},
+            use_auto_mock=True,
+        )
+    )
+    assert result.success, result.error or result.validation_details
+
+
+def test_parallel_iteration_fixture_output(table_runner: TableTestRunner) -> None:
+    result = table_runner.run_test_case(
+        WorkflowTestCase(
+            fixture_path="parallel_iteration_formatting_workflow.yml",
+            expected_outputs={"output": ["output: 1", "output: 2", "output: 3"]},
+            description="parallel iteration formatting",
+            use_auto_mock=True,
+        )
+    )
+    assert result.success, result.error or result.validation_details
+
+
+def test_parallel_iteration_fixture_output_is_stable_over_repeated_runs(
+    table_runner: TableTestRunner,
+) -> None:
+    expected = ["output: 1", "output: 2", "output: 3"]
+    for _ in range(5):
+        result = table_runner.run_test_case(
+            WorkflowTestCase(
+                fixture_path="parallel_iteration_formatting_workflow.yml",
+                expected_outputs={"output": expected},
+                description="parallel iteration formatting repeated",
+                use_auto_mock=True,
+            )
+        )
+        assert result.success, result.error or result.validation_details

--- a/api/tests/unit_tests/core/workflow/test_workflow_entry_helpers.py
+++ b/api/tests/unit_tests/core/workflow/test_workflow_entry_helpers.py
@@ -120,6 +120,7 @@ class TestWorkflowEntryInit:
             graph_runtime_state=graph_runtime_state,
             command_channel=sentinel.command_channel,
             config=sentinel.graph_engine_config,
+            container_handler_factories=(workflow_entry.create_dify_iteration_container_handler,),
         )
         assert graph_runtime_state._execution_context is sentinel.execution_context
         debug_logging_layer.assert_called_once_with(


### PR DESCRIPTION
Fixes #39977

## Summary

Parallel iteration could report success while returning `{ "output": [null] }` because child outputs were not always collected from the child variable pool in time, and parallel worker threads could lose execution context or hit Flask-scoped database access.

This change keeps sequential iteration behavior unchanged while making parallel runs collect child outputs reliably.

## Changes

| File | Change |
|------|--------|
| `api/core/workflow/graph_engine/dify_iteration_container_handler.py` | Add a Dify iteration container handler that falls back to recorded child node outputs when the child variable pool lookup misses |
| `api/core/workflow/workflow_entry.py` | Register the Dify iteration container handler for workflow runs |
| `api/core/app/apps/workflow/app_runner.py` | Capture execution context when creating workflow runtime state |
| `api/core/provider_manager.py` | Replace `db.session` with `session_factory.create_session()` in `_init_trial_provider_records` |
| `api/tests/...` | Add regression coverage for parallel iteration output collection, HTTP auth headers, and owned-session trial provider initialization |

## Validation

- `uv run pytest tests/unit_tests/core/workflow/graph_engine/test_dify_iteration_container_handler.py tests/unit_tests/core/workflow/graph_engine/test_parallel_iteration_output.py tests/unit_tests/core/workflow/graph_engine/test_parallel_iteration_http_auth.py tests/unit_tests/core/test_provider_manager.py::test_init_trial_provider_records_uses_owned_session tests/unit_tests/core/workflow/test_workflow_entry_helpers.py::TestWorkflowEntryInit` — 13 passed
- Ruff checks passed on changed backend files