### PR TITLE
fix(mcp): prefer streamable-http and catch transport errors on fallback

### DIFF
--- a/api/core/mcp/mcp_client.py
+++ b/api/core/mcp/mcp_client.py
@@ -6,11 +6,12 @@ from types import TracebackType
 from typing import Any
 from urllib.parse import urlparse
 
+import httpx
 from flask import has_request_context, request
 
 from core.mcp.client.sse_client import sse_client
 from core.mcp.client.streamable_client import streamablehttp_client
-from core.mcp.error import MCPConnectionError
+from core.mcp.error import MCPAuthError, MCPConnectionError
 from core.mcp.session.client_session import ClientSession
 from core.mcp.types import CallToolResult, Tool
 
@@ -58,7 +59,7 @@ class MCPClient:
     def _initialize(
         self,
     ):
-        """Initialize the client with fallback to SSE if streamable connection fails"""
+        """Initialize the client, preferring streamable-http when the URL path is ambiguous."""
         connection_methods: dict[str, Callable[..., AbstractContextManager[Any]]] = {
             "mcp": streamablehttp_client,
             "sse": sse_client,
@@ -72,11 +73,19 @@ class MCPClient:
             self.connect_server(client_factory, method_name)
         else:
             try:
-                logger.debug("Not supported method %s found in URL path, trying default 'mcp' method.", method_name)
-                self.connect_server(sse_client, "sse")
-            except (MCPConnectionError, ValueError):
-                logger.debug("MCP connection failed with 'sse', falling back to 'mcp' method.")
+                logger.debug(
+                    "Not supported method %s found in URL path, trying streamable-http first.",
+                    method_name,
+                )
                 self.connect_server(streamablehttp_client, "mcp")
+            except MCPAuthError:
+                raise
+            except (MCPConnectionError, ValueError, httpx.TransportError) as error:
+                logger.debug(
+                    "MCP connection failed with streamable-http, falling back to 'sse' method: %s",
+                    error,
+                )
+                self.connect_server(sse_client, "sse")
 
     def connect_server(self, client_factory: Callable[..., AbstractContextManager[Any]], method_name: str) -> None:
         """

--- a/api/tests/unit_tests/core/mcp/test_mcp_client.py
+++ b/api/tests/unit_tests/core/mcp/test_mcp_client.py
@@ -4,6 +4,7 @@ from contextlib import ExitStack
 from types import TracebackType
 from unittest.mock import MagicMock, Mock, patch
 
+import httpx
 import pytest
 from sqlalchemy.orm import Session
 
@@ -158,37 +159,11 @@ class TestMCPClient:
     @patch("core.mcp.mcp_client.sse_client")
     @patch("core.mcp.mcp_client.streamablehttp_client")
     @patch("core.mcp.mcp_client.ClientSession")
-    def test_initialize_with_unknown_method_fallback_to_sse(
+    def test_initialize_with_unknown_method_fallback_to_streamable_http(
         self, mock_client_session, mock_streamable_client, mock_sse_client
     ):
-        """Test initialization with unknown method falls back to SSE."""
+        """Test initialization with unknown method tries streamable-http first."""
         # Setup mocks
-        mock_read_stream = Mock()
-        mock_write_stream = Mock()
-        mock_sse_client.return_value.__enter__.return_value = (mock_read_stream, mock_write_stream)
-
-        mock_session = Mock()
-        mock_client_session.return_value.__enter__.return_value = mock_session
-
-        client = MCPClient(server_url="http://test.example.com/unknown")
-        client._initialize()
-
-        # Verify SSE client was tried
-        mock_sse_client.assert_called_once()
-        mock_streamable_client.assert_not_called()
-
-        # Verify session was created
-        assert client._session == mock_session
-
-    @patch("core.mcp.mcp_client.sse_client")
-    @patch("core.mcp.mcp_client.streamablehttp_client")
-    @patch("core.mcp.mcp_client.ClientSession")
-    def test_initialize_fallback_from_sse_to_mcp(self, mock_client_session, mock_streamable_client, mock_sse_client):
-        """Test initialization falls back from SSE to MCP on connection error."""
-        # Setup SSE to fail
-        mock_sse_client.side_effect = MCPConnectionError("SSE connection failed")
-
-        # Setup MCP to succeed
         mock_read_stream = Mock()
         mock_write_stream = Mock()
         mock_client_context = Mock()
@@ -204,12 +179,103 @@ class TestMCPClient:
         client = MCPClient(server_url="http://test.example.com/unknown")
         client._initialize()
 
-        # Verify both were tried
-        mock_sse_client.assert_called_once()
+        # Verify streamable-http client was tried first
         mock_streamable_client.assert_called_once()
+        mock_sse_client.assert_not_called()
 
-        # Verify session was created with MCP
+        # Verify session was created
         assert client._session == mock_session
+
+    @patch("core.mcp.mcp_client.sse_client")
+    @patch("core.mcp.mcp_client.streamablehttp_client")
+    @patch("core.mcp.mcp_client.ClientSession")
+    def test_initialize_fallback_from_streamable_http_to_sse(
+        self, mock_client_session, mock_streamable_client, mock_sse_client
+    ):
+        """Test initialization falls back from streamable-http to SSE on connection error."""
+        # Setup streamable-http to fail
+        mock_streamable_client.side_effect = MCPConnectionError("streamable-http connection failed")
+
+        # Setup SSE to succeed
+        mock_read_stream = Mock()
+        mock_write_stream = Mock()
+        mock_sse_client.return_value.__enter__.return_value = (mock_read_stream, mock_write_stream)
+
+        mock_session = Mock()
+        mock_client_session.return_value.__enter__.return_value = mock_session
+
+        client = MCPClient(server_url="http://test.example.com/unknown")
+        client._initialize()
+
+        # Verify both were tried
+        mock_streamable_client.assert_called_once()
+        mock_sse_client.assert_called_once()
+
+        # Verify session was created with SSE
+        assert client._session == mock_session
+
+    @patch("core.mcp.mcp_client.sse_client")
+    @patch("core.mcp.mcp_client.streamablehttp_client")
+    @patch("core.mcp.mcp_client.ClientSession")
+    def test_initialize_fallback_on_httpx_timeout(self, mock_client_session, mock_streamable_client, mock_sse_client):
+        """Test initialization falls back from streamable-http to SSE on httpx.ReadTimeout."""
+        mock_streamable_client.side_effect = httpx.ReadTimeout("timed out")
+
+        mock_read_stream = Mock()
+        mock_write_stream = Mock()
+        mock_sse_client.return_value.__enter__.return_value = (mock_read_stream, mock_write_stream)
+
+        mock_session = Mock()
+        mock_client_session.return_value.__enter__.return_value = mock_session
+
+        client = MCPClient(server_url="http://test.example.com/unknown")
+        client._initialize()
+
+        mock_streamable_client.assert_called_once()
+        mock_sse_client.assert_called_once()
+        assert client._session == mock_session
+
+    @patch("core.mcp.mcp_client.sse_client")
+    @patch("core.mcp.mcp_client.streamablehttp_client")
+    @patch("core.mcp.mcp_client.ClientSession")
+    def test_initialize_fallback_on_httpx_remote_protocol_error(
+        self, mock_client_session, mock_streamable_client, mock_sse_client
+    ):
+        """Test initialization falls back from streamable-http to SSE on httpx.RemoteProtocolError."""
+        mock_streamable_client.side_effect = httpx.RemoteProtocolError(
+            "Server disconnected without sending a response."
+        )
+
+        mock_read_stream = Mock()
+        mock_write_stream = Mock()
+        mock_sse_client.return_value.__enter__.return_value = (mock_read_stream, mock_write_stream)
+
+        mock_session = Mock()
+        mock_client_session.return_value.__enter__.return_value = mock_session
+
+        client = MCPClient(server_url="https://n8n.example.com/share/v1/mcp/share-id")
+        client._initialize()
+
+        mock_streamable_client.assert_called_once()
+        mock_sse_client.assert_called_once()
+        assert client._session == mock_session
+
+    @patch("core.mcp.mcp_client.sse_client")
+    @patch("core.mcp.mcp_client.streamablehttp_client")
+    @patch("core.mcp.mcp_client.ClientSession")
+    def test_initialize_does_not_retry_sse_on_auth_error(
+        self, mock_client_session, mock_streamable_client, mock_sse_client
+    ):
+        """Auth failures from streamable-http must not be retried over SSE."""
+        mock_streamable_client.side_effect = MCPAuthError("Authentication failed")
+
+        client = MCPClient(server_url="http://test.example.com/unknown")
+
+        with pytest.raises(MCPAuthError):
+            client._initialize()
+
+        mock_streamable_client.assert_called_once()
+        mock_sse_client.assert_not_called()
 
     @patch("core.mcp.mcp_client.streamablehttp_client")
     @patch("core.mcp.mcp_client.ClientSession")


### PR DESCRIPTION
Fixes #40001

## Summary

Self-hosted MCP authorization failed with `httpx.RemoteProtocolError: Server disconnected without sending a response` when the server URL path did not end with `/mcp` or `/sse`. Dify tried the SSE transport first and did not fall back because `httpx` transport errors were not caught.

This change prefers streamable-http for ambiguous URLs (the MCP default transport) and falls back to SSE only when the streamable-http connection fails with recoverable transport errors.

## Changes

| File | Change |
|------|--------|
| `api/core/mcp/mcp_client.py` | Try streamable-http first for unknown URL paths; catch `httpx.TransportError` during fallback; re-raise `MCPAuthError` without retrying another transport |
| `api/tests/unit_tests/core/mcp/test_mcp_client.py` | Update fallback tests and add coverage for `ReadTimeout`, `RemoteProtocolError`, and auth-error propagation |

## Validation

- `uv run pytest tests/unit_tests/core/mcp/test_mcp_client.py` — 38 passed
- Ruff checks passed on changed files