### PR TITLE
fix(api): end_date filter in feedback export excludes the entire end date

### DIFF
--- a/api/services/feedback_service.py
+++ b/api/services/feedback_service.py
@@ -1,7 +1,7 @@
 import csv
 import io
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from flask import Response
 from sqlalchemy import or_, select
@@ -75,8 +75,8 @@ class FeedbackService:
 
         if end_date:
             try:
-                end_dt = datetime.strptime(end_date, "%Y-%m-%d")
-                stmt = stmt.where(MessageFeedback.created_at <= end_dt)
+                end_dt = datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)
+                stmt = stmt.where(MessageFeedback.created_at < end_dt)
             except ValueError:
                 raise ValueError(f"Invalid end_date format: {end_date}. Use YYYY-MM-DD")
 

--- a/api/tests/unit_tests/services/test_feedback_service.py
+++ b/api/tests/unit_tests/services/test_feedback_service.py
@@ -242,3 +242,23 @@ class TestFeedbackService:
         dislike_feedback = next(item for item in feedback_data if item["feedback_rating_raw"] == "dislike")
         assert like_feedback["feedback_rating"] == "👍"
         assert dislike_feedback["feedback_rating"] == "👎"
+
+
+class TestEndDateBoundary:
+    """Verify that end_date includes feedback from the entire day (fix for #40050)."""
+
+    def test_end_date_includes_entire_day(self):
+        from datetime import timedelta
+
+        end_date = "2026-08-05"
+        end_dt = datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)
+
+        assert end_dt == datetime(2026, 8, 6, 0, 0, 0)
+        assert datetime(2026, 8, 5, 14, 30, 0) < end_dt
+        assert datetime(2026, 8, 5, 23, 59, 59) < end_dt
+        assert not (datetime(2026, 8, 6, 0, 0, 1) < end_dt)
+
+    def test_start_date_includes_midnight(self):
+        start_dt = datetime.strptime("2026-08-01", "%Y-%m-%d")
+        assert start_dt == datetime(2026, 8, 1, 0, 0, 0)
+        assert datetime(2026, 8, 1, 0, 0, 0) >= start_dt


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #40050

The `end_date` filter in the feedback export API (`FeedbackService.export_feedbacks`) silently excludes virtually all feedback from the specified end date.

**Root cause:** `datetime.strptime("2026-08-05", "%Y-%m-%d")` produces `datetime(2026, 8, 5, 0, 0, 0)` — midnight at the *start* of the day. The filter `created_at <= end_dt` then only includes feedback created at exactly midnight, dropping the entire day's data.

**Fix:** Add `timedelta(days=1)` to shift the boundary to the start of the next day, and use strict `<` instead of `<=`:
```python
# Before (broken):
end_dt = datetime.strptime(end_date, "%Y-%m-%d")
stmt = stmt.where(MessageFeedback.created_at <= end_dt)

# After (fixed):
end_dt = datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)
stmt = stmt.where(MessageFeedback.created_at < end_dt)
