### PR TITLE
fix(web): enforce frame ancestors on protected routes

### DIFF
--- a/web/__tests__/proxy-frame-options.spec.ts
+++ b/web/__tests__/proxy-frame-options.spec.ts
@@ -1,7 +1,27 @@
-import { describe, expect, it } from 'vitest'
-import { canEmbedPath } from '@/proxy'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { canEmbedPath, proxy } from '@/proxy'
+
+const mockEnv = vi.hoisted(() => ({
+  NEXT_PUBLIC_ALLOW_EMBED: false,
+  NEXT_PUBLIC_CSP_WHITELIST: 'https://example.com',
+}))
+
+vi.mock('@/env', () => ({
+  env: mockEnv,
+}))
+
+const createRequest = (url: string) =>
+  ({
+    headers: new Headers(),
+    nextUrl: new URL(url),
+  }) as Parameters<typeof proxy>[0]
 
 describe('proxy frame options', () => {
+  afterEach(() => {
+    mockEnv.NEXT_PUBLIC_ALLOW_EMBED = false
+    vi.unstubAllEnvs()
+  })
+
   it('should allow embedded share routes', () => {
     expect(canEmbedPath('/chatbot/token')).toBe(true)
     expect(canEmbedPath('/workflow/token')).toBe(true)
@@ -11,10 +31,42 @@ describe('proxy frame options', () => {
   })
 
   it('should deny non-embedded console routes by default', () => {
+    expect(canEmbedPath('/chatty')).toBe(false)
+    expect(canEmbedPath('/workflowish')).toBe(false)
+    expect(canEmbedPath('/completionist')).toBe(false)
+    expect(canEmbedPath('/webapp-signing')).toBe(false)
     expect(canEmbedPath('/agents')).toBe(false)
     expect(canEmbedPath('/agent-settings')).toBe(false)
     expect(canEmbedPath('/agentic')).toBe(false)
     expect(canEmbedPath('/agents/agent-1/access')).toBe(false)
     expect(canEmbedPath('/apps')).toBe(false)
+  })
+
+  it('should enforce frame ancestors on protected document routes', () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const response = proxy(createRequest('https://cloud.dify.ai/device'))
+    const contentSecurityPolicy = response.headers.get('content-security-policy')
+
+    expect(response.headers.get('x-frame-options')).toBe('DENY')
+    expect(contentSecurityPolicy).toContain("script-src 'self'")
+    expect(contentSecurityPolicy).toContain("frame-ancestors 'none'")
+  })
+
+  it('should keep published app routes embeddable', () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const response = proxy(createRequest('https://udify.app/chat/test-token'))
+    const contentSecurityPolicy = response.headers.get('content-security-policy')
+
+    expect(response.headers.get('x-frame-options')).toBeNull()
+    expect(contentSecurityPolicy).toContain("script-src 'self'")
+    expect(contentSecurityPolicy).not.toContain('frame-ancestors')
+  })
+
+  it('should protect device routes when global embedding is enabled', () => {
+    mockEnv.NEXT_PUBLIC_ALLOW_EMBED = true
+    const response = proxy(createRequest('https://cloud.dify.ai/device/code'))
+
+    expect(response.headers.get('x-frame-options')).toBe('DENY')
+    expect(response.headers.get('content-security-policy')).toContain("frame-ancestors 'none'")
   })
 })

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -40,17 +40,6 @@ const nextConfig: NextConfig = {
       },
     ]
   },
-  // Deny framing on device-flow routes — no trusted embedder exists.
-  async headers() {
-    const antiFrame = [
-      { key: 'X-Frame-Options', value: 'DENY' },
-      { key: 'Content-Security-Policy', value: "frame-ancestors 'none'" },
-    ]
-    return [
-      { source: '/device', headers: antiFrame },
-      { source: '/device/:path*', headers: antiFrame },
-    ]
-  },
   output: 'standalone',
   compiler: {
     removeConsole: isDev ? false : { exclude: ['warn', 'error'] },

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -9,20 +9,39 @@ const NECESSARY_DOMAIN =
   '*.sentry.io http://localhost:* http://127.0.0.1:* https://analytics.google.com googletagmanager.com *.googletagmanager.com https://www.google-analytics.com https://cdn-cookieyes.com https://ungh.cc https://api2.amplitude.com *.amplitude.com'
 const CURRENT_PATHNAME_HEADER = 'x-dify-pathname'
 const CURRENT_SEARCH_HEADER = 'x-dify-search'
-const EMBEDDABLE_PATH_PREFIXES = ['/chat', '/workflow', '/completion', '/webapp-signin']
-const EMBEDDABLE_PATH_SEGMENTS = ['/agent']
+const EMBEDDABLE_PATH_SEGMENTS = [
+  '/agent',
+  '/chat',
+  '/chatbot',
+  '/completion',
+  '/webapp-signin',
+  '/workflow',
+]
+const NON_EMBEDDABLE_PATH_SEGMENTS = ['/device']
+const FRAME_ANCESTORS_NONE = "frame-ancestors 'none';"
+
+const matchesPathSegment = (pathname: string, segments: string[]) =>
+  segments.some((segment) => pathname === segment || pathname.startsWith(`${segment}/`))
 
 export const canEmbedPath = (pathname: string) =>
-  EMBEDDABLE_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix)) ||
-  EMBEDDABLE_PATH_SEGMENTS.some(
-    (segment) => pathname === segment || pathname.startsWith(`${segment}/`),
-  )
+  matchesPathSegment(pathname, EMBEDDABLE_PATH_SEGMENTS)
 
-const wrapResponseWithXFrameOptions = (response: NextResponse, pathname: string) => {
-  // prevent clickjacking: https://owasp.org/www-community/attacks/Clickjacking
-  // Chatbot page should be allowed to be embedded in iframe. It's a feature
-  if (env.NEXT_PUBLIC_ALLOW_EMBED !== true && !canEmbedPath(pathname))
+const wrapResponseWithFrameProtection = (response: NextResponse, pathname: string) => {
+  // Published app routes are intentionally embeddable; all other routes default to clickjacking protection.
+  const preventEmbedding =
+    matchesPathSegment(pathname, NON_EMBEDDABLE_PATH_SEGMENTS) ||
+    (env.NEXT_PUBLIC_ALLOW_EMBED !== true && !canEmbedPath(pathname))
+
+  if (preventEmbedding) {
     response.headers.set('X-Frame-Options', 'DENY')
+    const contentSecurityPolicy = response.headers.get('Content-Security-Policy')
+    response.headers.set(
+      'Content-Security-Policy',
+      contentSecurityPolicy
+        ? `${contentSecurityPolicy} ${FRAME_ANCESTORS_NONE}`
+        : FRAME_ANCESTORS_NONE,
+    )
+  }
 
   return response
 }
@@ -40,7 +59,7 @@ export function proxy(request: NextRequest) {
         headers: requestHeaders,
       },
     })
-    return wrapResponseWithXFrameOptions(response, pathname)
+    return wrapResponseWithFrameProtection(response, pathname)
   }
 
   const whiteList = `${env.NEXT_PUBLIC_CSP_WHITELIST} ${NECESSARY_DOMAIN}`
@@ -78,7 +97,7 @@ export function proxy(request: NextRequest) {
 
   response.headers.set('Content-Security-Policy', contentSecurityPolicyHeaderValue)
 
-  return wrapResponseWithXFrameOptions(response, pathname)
+  return wrapResponseWithFrameProtection(response, pathname)
 }
 
 export const config = {


### PR DESCRIPTION
## Summary

- make the Next.js Proxy the application-side owner of anti-framing response headers
- add `frame-ancestors 'none'` alongside the existing `X-Frame-Options: DENY` compatibility header
- match published app routes by complete path segment so lookalike paths such as `/chatty` and `/workflowish` remain protected
- preserve the invariant that `/device` cannot be embedded even when global embedding is enabled

## Root cause

The device-flow anti-framing policy was split between `next.config.ts` and the Proxy. When the Proxy emitted the full CSP, it replaced the device-specific CSP. Published app routes also used prefix matching, which classified unrelated lookalike paths as embeddable.

## Impact

Console, authentication, device-flow, and other non-published routes now receive an enforced `frame-ancestors 'none'` directive. Published app routes remain embeddable by product contract.

## Validation

- `vp test run __tests__/proxy-frame-options.spec.ts`
- `vp check web/proxy.ts web/next.config.ts web/__tests__/proxy-frame-options.spec.ts`
- `pnpm --dir web lint:tss`
- `pnpm check` (0 errors; existing repository warnings only)
- `pnpm --dir web build`
- standalone production response-header smoke checks for `/device`, `/signin`, published app routes, and prefix-collision routes

The production build completed successfully. Static generation logged expected connection-refused messages because the local API was not running.

## Linear

Related to [SNP-595](https://linear.app/dify/issue/SNP-595/补齐-frame-ancestors-与-frame-src-的嵌入边界).

This PR intentionally covers only the inbound `frame-ancestors` boundary. The outbound `frame-src` consumer audit remains in SNP-595, so this PR does not auto-close the issue.