### PR TITLE
fix(workflow): keep a Code node output variable when a name transits another row's

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/variable/__tests__/output-var-list.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/__tests__/output-var-list.spec.tsx
@@ -1,5 +1,6 @@
 import type { OutputVar } from '../../../../code/types'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
 import OutputVarList from '../output-var-list'
 
 vi.mock('../var-type-picker', () => ({
@@ -104,6 +105,101 @@ describe('OutputVarList', () => {
       // var_1 must survive because index 0 still uses it
       expect(afterSecond.var_1).toBeDefined()
       expect(afterSecond.var_2).toBeDefined()
+    })
+  })
+
+  describe('typing a name that another row already holds', () => {
+    // The component is controlled, so a multi-keystroke test has to feed each change back the way
+    // the owning hook does. This mirrors use-output-var-list's handleVarsChange: outputs are
+    // replaced, the changed row is pointed at the new key, and a rename is announced to the nodes
+    // referencing the old name.
+    const renderControlled = (outputs: OutputVar, outputKeyOrders: string[]) => {
+      const state = { outputs, outputKeyOrders }
+      const announcedRenames: Array<{ oldName: string; newName: string }> = []
+
+      const Harness = () => {
+        const [currentOutputs, setCurrentOutputs] = useState(outputs)
+        const [currentOrders, setCurrentOrders] = useState(outputKeyOrders)
+
+        return (
+          <OutputVarList
+            readonly={false}
+            outputs={currentOutputs}
+            outputKeyOrders={currentOrders}
+            onChange={(newOutputs, changedIndex, newKey) => {
+              const nextOrders =
+                changedIndex === undefined
+                  ? currentOrders
+                  : currentOrders.map((key, i) => (i === changedIndex ? newKey! : key))
+
+              if (newKey && changedIndex !== undefined)
+                announcedRenames.push({ oldName: currentOrders[changedIndex]!, newName: newKey })
+
+              state.outputs = newOutputs
+              state.outputKeyOrders = nextOrders
+              setCurrentOutputs(newOutputs)
+              setCurrentOrders(nextOrders)
+            }}
+            onRemove={vi.fn()}
+          />
+        )
+      }
+
+      render(<Harness />)
+      const nameInputAt = (index: number) => screen.getAllByRole('textbox')[index]!
+      return { state, announcedRenames, nameInputAt }
+    }
+
+    const twoRows = () => createOutputs({ a: 'array[object]', var_2: 'string' })
+
+    it('should keep the first row declared type when a later row transits its name', () => {
+      const afterTransit = collectRenameResult(twoRows(), ['a', 'var_2'], 1, 'a')
+
+      // The row being edited is not the row whose type this is. Committing the collision would
+      // overwrite the array[object] declaration with the string one.
+      expect(afterTransit.a).toEqual({ type: 'array[object]', children: null })
+      expect(afterTransit.var_2).toEqual({ type: 'string', children: null })
+    })
+
+    it('should not give a row another row type when typing past its name', () => {
+      const { state, nameInputAt } = renderControlled(twoRows(), ['a', 'var_2'])
+
+      fireEvent.change(nameInputAt(1), { target: { value: 'a' } })
+      fireEvent.change(nameInputAt(1), { target: { value: 'ab' } })
+
+      expect(state.outputs.a).toEqual({ type: 'array[object]', children: null })
+      expect(state.outputs.ab).toEqual({ type: 'string', children: null })
+      // The row moved off var_2 in one committed step, so nothing is left behind unreachable.
+      expect(state.outputs.var_2).toBeUndefined()
+      expect(Object.keys(state.outputs)).toHaveLength(2)
+      expect(state.outputKeyOrders).toEqual(['a', 'ab'])
+    })
+
+    it('should not announce a rename while the typed name collides', () => {
+      const { announcedRenames, nameInputAt } = renderControlled(twoRows(), ['a', 'var_2'])
+
+      fireEvent.change(nameInputAt(1), { target: { value: 'a' } })
+
+      // Renames are matched by name, so announcing this one would later repoint the first row's
+      // references onto this row.
+      expect(announcedRenames).toEqual([])
+
+      fireEvent.change(nameInputAt(1), { target: { value: 'ab' } })
+
+      expect(announcedRenames).toEqual([{ oldName: 'var_2', newName: 'ab' }])
+    })
+
+    it('should restore the committed name when the field is left while the name collides', () => {
+      const { state, nameInputAt } = renderControlled(twoRows(), ['a', 'var_2'])
+
+      fireEvent.change(nameInputAt(1), { target: { value: 'a' } })
+      expect(nameInputAt(1)).toHaveValue('a')
+
+      fireEvent.blur(nameInputAt(1))
+
+      expect(nameInputAt(1)).toHaveValue('var_2')
+      expect(state.outputs.var_2).toEqual({ type: 'string', children: null })
+      expect(state.outputKeyOrders).toEqual(['a', 'var_2'])
     })
   })
 

--- a/web/app/components/workflow/nodes/_base/components/variable/__tests__/output-var-list.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/__tests__/output-var-list.spec.tsx
@@ -29,7 +29,8 @@ describe('OutputVarList', () => {
   }
 
   // Render the component and trigger a rename at the given index.
-  // Returns the newOutputs passed to onChange.
+  // Returns the outputs after the rename: the payload passed to onChange, or the outputs
+  // unchanged when the rename was not committed.
   const collectRenameResult = (
     outputs: OutputVar,
     outputKeyOrders: string[],
@@ -53,7 +54,7 @@ describe('OutputVarList', () => {
     const inputs = screen.getAllByRole('textbox')
     fireEvent.change(inputs[renameIndex]!, { target: { value: newName } })
 
-    return captured!
+    return captured ?? outputs
   }
 
   beforeEach(() => {
@@ -84,12 +85,14 @@ describe('OutputVarList', () => {
       expect(newOutputs.var_1).toEqual({ type: 'string', children: null })
     })
 
-    it('should keep outputs key alive when duplicate is renamed back to unique name', () => {
+    it('should keep both entries alive when a name transits an existing one and is then made unique', () => {
       // Step 1: rename var_2 -> var_1 (creates duplicate)
       const outputs = createOutputs({ var_1: 'string', var_2: 'number' })
       const afterFirst = collectRenameResult(outputs, ['var_1', 'var_2'], 1, 'var_1')
 
-      expect(afterFirst.var_2).toBeUndefined()
+      // outputs is keyed by name, so committing this rename would overwrite var_1's entry with
+      // var_2's. The rename is held until the name is unique, so var_2 keeps its own entry.
+      expect(afterFirst.var_2).toBeDefined()
       expect(afterFirst.var_1).toBeDefined()
 
       // Clean up first render before the second to avoid DOM collision

--- a/web/app/components/workflow/nodes/_base/components/variable/output-var-list.tsx
+++ b/web/app/components/workflow/nodes/_base/components/variable/output-var-list.tsx
@@ -6,7 +6,7 @@ import { toast } from '@langgenius/dify-ui/toast'
 import { useDebounceFn } from 'ahooks'
 import { produce } from 'immer'
 import * as React from 'react'
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Input from '@/app/components/base/input'
 import { checkKeys, replaceSpaceWithUnderscoreInVarNameInput } from '@/utils/var'
@@ -23,6 +23,11 @@ type Props = Readonly<{
 
 const OutputVarList: FC<Props> = ({ readonly, outputs, outputKeyOrders, onChange, onRemove }) => {
   const { t } = useTranslation()
+
+  // The name being typed into a row while it collides with another row's name. `outputs` is keyed
+  // by variable name, so it cannot hold two rows sharing one name; committing a colliding rename
+  // would overwrite the other row's entry. Only one input can be focused, so one draft is enough.
+  const [draftName, setDraftName] = useState<{ index: number; name: string } | null>(null)
 
   const list = outputKeyOrders.map((key) => {
     return {
@@ -58,11 +63,18 @@ const OutputVarList: FC<Props> = ({ readonly, outputs, outputKeyOrders, onChange
         replaceSpaceWithUnderscoreInVarNameInput(e.target)
         const newKey = e.target.value
 
-        validateVarInput(
-          list.filter((_, itemIndex) => itemIndex !== index),
-          newKey,
-        )
+        const otherVars = list.filter((_, itemIndex) => itemIndex !== index)
+        validateVarInput(otherVars, newKey)
 
+        // Hold a colliding name locally instead of writing it. Typing stays unrestricted, but
+        // `outputs` keeps this row on its current key, so neither entry is overwritten and no
+        // rename is propagated to the nodes referencing either variable.
+        if (otherVars.some((item) => item.variable === newKey)) {
+          setDraftName({ index, name: newKey })
+          return
+        }
+
+        setDraftName(null)
         const newOutputs = produce(outputs, (draft) => {
           draft[newKey] = draft[oldKey]!
           // Only delete old key if no other entry shares this name
@@ -73,6 +85,14 @@ const OutputVarList: FC<Props> = ({ readonly, outputs, outputKeyOrders, onChange
     },
     [list, onChange, outputs, validateVarInput],
   )
+
+  const handleVarNameBlur = useCallback((index: number) => {
+    return () => {
+      // A draft only outlives a keystroke while it collides, so leaving the field discards it
+      // and the input falls back to the name the row still holds in `outputs`.
+      setDraftName((current) => (current?.index === index ? null : current))
+    }
+  }, [])
 
   const handleVarTypeChange = useCallback(
     (index: number) => {
@@ -102,8 +122,9 @@ const OutputVarList: FC<Props> = ({ readonly, outputs, outputKeyOrders, onChange
         <div className="flex items-center space-x-1" key={index}>
           <Input
             readOnly={readonly}
-            value={item.variable}
+            value={draftName?.index === index ? draftName.name : item.variable}
             onChange={handleVarNameChange(index)}
+            onBlur={handleVarNameBlur(index)}
             wrapperClassName="grow"
           />
           <VarTypePicker


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #40126

A Code node output variable loses its declared type when another row's name is typed through it. `outputs` is a `Record<name, {type, children}>` and rows are positional via `outputKeyOrders`, so the object cannot represent two rows sharing a name. In `handleVarNameChange`, `draft[newKey] = draft[oldKey]` runs unconditionally, so a name that collides with another row overwrites that row's entry with the editing row's. A row declared `array[object]` becomes `string`, and the loss reaches the exported DSL. The name check beside it is debounced 500ms and only raises a toast, so the message arrives after the entry it describes is gone.

**The fix holds the in-progress name in local component state while it collides, and commits the rename into `outputs` only once the name is unique.** Typing is never blocked — the input renders the draft, so any string is reachable, including one that transits an existing name. Only the write is deferred. While a draft is held the row keeps its own key, so neither entry is overwritten.

Deferring the write has a second effect worth naming. `handleVarsChange` calls `handleOutVarRenameChange`, which matches downstream variable references **by name**. Committing a colliding rename therefore made the *next* keystroke repoint the other row's consumers onto this row. Holding the rename until the name is unique means that never fires on a transient collision. This is a reading of the code rather than something reproduced in a browser; it is covered by a test.

Leaving the field while the name still collides discards the draft and the input falls back to the name the row holds in `outputs`, so no partial name is committed.

**Alternatives considered and rejected.**

Skipping only the write while still reporting the rename leaves `outputKeyOrders[index]` pointing at the other row's key. The next keystroke then reads that key as the old name and copies the other row's entry onto the new name, stranding the original entry under a key no row points at — quieter corruption rather than none.

Blocking the keystroke outright is not available either. A synchronous guard that returned before the write was replaced by the current debounced validator in #23300, which addressed per-keystroke toast spam reported in #23297. Restoring that guard would reintroduce the spam, and on a controlled input it also freezes the field: a user with a row named `a` could never type `ab`. This PR takes the other half of what #23297's reporter proposed — commit on blur / when the name resolves — so the validation stays debounced and the write stops being destructive. Credit to @MatriQ for proposing that shape.

#31170 (open) reworks the same function into a boolean gate, and it is worth being precise about what that gate covers. `validateVarInput` there returns `false` only when `checkKeys` fails; the duplicate-name branch raises the toast and then falls through to `return true`, so `if (!validateVarInput(...)) return` does not fire on a collision and the `produce` block still runs. That matches what the PR is for — it fixes #31169, the 30-character limit. The two changes are independent and don't conflict.

Re-keying `outputs` by a stable row id would remove the constraint at the root, but it changes a stored shape and needs a migration, so it is left to maintainers.

**Compatibility.** The `produce` block is unchanged; only when it runs changed. A workflow in which no duplicate is typed loads and saves exactly as before, and no stored shape or DSL changes. Toast behaviour and its 500ms debounce are untouched — this fixes data loss, not messaging. Existing workflows already collapsed by this defect still load: the case where `outputKeyOrders` holds the same name twice is covered by a pre-existing test that still passes.

**Prior art.** #34555 reported the deletion side of the same keyed-object constraint and #34604 guarded deletion in both `handleVarNameChange` and `handleRemoveVariable`. That guard is untouched here and still does its job; this PR adds the matching guard on the write. Credit to @JunQingKiret and @fatelei — the constraint is stated precisely in #34604's description and that description is what made this straightforward to locate.

**Tests.** Four new tests, all failing before the fix: the reported case (row 1 `array[object]`, row 2 typed to transit its name, row 1's type must survive); typing past the collision `a` → `ab`, asserting the new row does not inherit the first row's type and that nothing is stranded under an unreferenced key; that no rename is announced while the name collides; and the blur-while-colliding behaviour. Two of them drive the component through a small harness that feeds each change back the way `useOutputVarList` does, because a second keystroke otherwise reads stale props and cannot reach the state a user reaches.

**Two changes to the existing test file, called out so they are not a surprise in review.** Both are in commit 2 of 3, separate from the fix and from the new tests.

1. `output-var-list.spec.tsx` contained an assertion that the entry being renamed away from is `undefined` afterwards. That is the state this PR prevents, so the assertion is inverted and the test renamed to describe what it now pins. It is a separate commit for reviewability.
2. In the same commit, the file's render helper ended `return captured!` — the `onChange` payload with a non-null assertion. A rename that is not committed produces no `onChange`, so it now returns `captured ?? outputs` and its contract reads "the outputs after the rename". The two other tests using it always commit, so they are unaffected and were green throughout.

Every other assertion in the file is unchanged. Suite results: `output-var-list.spec.tsx` 12/12 with the fix and 7/12 on `main` — the five failures are exactly the four new tests plus the inverted assertion. The wider `web/app/components/workflow/nodes/` suite is 1128/1128, 261 files.

## Screenshots

**Before**

https://github.com/user-attachments/assets/e695dbc8-dfdb-4dab-94f2-951217a674a7

---

**After**

https://github.com/user-attachments/assets/73feb260-288b-4146-8e47-ccb8ca2f18ad

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods — frontend only, no backend file is changed; `vp check` on both changed files reports 0 errors and 1 warning, and that warning (`key={index}`) is pre-existing on `main`

From Claude Code