### PR TITLE
refactor(api): move license expiry notice flag onto license detail

### DIFF
--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -18926,6 +18926,7 @@ Enum class for large language model mode.
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | expired_at | string |  | Yes |
+| license_expiry_notice_enabled | boolean |  | Yes |
 | seats | [LicenseLimitationModel](#licenselimitationmodel) |  | Yes |
 | status | [LicenseStatus](#licensestatus) |  | Yes |
 | workspaces | [LicenseLimitationModel](#licenselimitationmodel) |  | Yes |
@@ -22276,7 +22277,6 @@ Non-sensitive bootstrap snapshot exposed before Console or Web authentication.
 | enable_email_password_login | boolean, <br>**Default:** true |  | Yes |
 | enable_explore_banner | boolean |  | Yes |
 | enable_learn_app | boolean, <br>**Default:** true |  | Yes |
-| enable_license_expiry_notice | boolean, <br>**Default:** true |  | Yes |
 | enable_marketplace | boolean |  | Yes |
 | enable_social_oauth_login | boolean |  | Yes |
 | enable_step_by_step_tour | boolean |  | Yes |

--- a/api/openapi/markdown/web-openapi.md
+++ b/api/openapi/markdown/web-openapi.md
@@ -1566,7 +1566,6 @@ Non-sensitive bootstrap snapshot exposed before Console or Web authentication.
 | enable_email_password_login | boolean, <br>**Default:** true |  | Yes |
 | enable_explore_banner | boolean |  | Yes |
 | enable_learn_app | boolean, <br>**Default:** true |  | Yes |
-| enable_license_expiry_notice | boolean, <br>**Default:** true |  | Yes |
 | enable_marketplace | boolean |  | Yes |
 | enable_social_oauth_login | boolean |  | Yes |
 | enable_step_by_step_tour | boolean |  | Yes |

--- a/api/services/entities/feature_entities.py
+++ b/api/services/entities/feature_entities.py
@@ -89,6 +89,7 @@ class LicenseModel(LicenseStatusModel):
     expired_at: str = ""
     workspaces: LicenseLimitationModel = LicenseLimitationModel(enabled=False, size=0, limit=0)
     seats: LicenseLimitationModel = LicenseLimitationModel(enabled=False, size=0, limit=0)
+    license_expiry_notice_enabled: bool = False
 
 
 class BrandingModel(FeatureResponseModel):
@@ -197,4 +198,3 @@ class SystemFeatureModel(FeatureResponseModel):
     enable_step_by_step_tour: bool = False
     rbac_enabled: bool = False
     knowledge_fs_enabled: bool = False
-    enable_license_expiry_notice: bool = True

--- a/api/services/feature_service.py
+++ b/api/services/feature_service.py
@@ -151,9 +151,12 @@ class FeatureService:
         Non-enterprise deployments have no license, so an unconstrained default
         (unlimited seats/workspaces) is returned.
         """
-        if not dify_config.ENTERPRISE_ENABLED:
-            return feature_entities.LicenseModel()
-        return cls._build_license(EnterpriseService.get_info())
+        if dify_config.ENTERPRISE_ENABLED:
+            license_model = cls._build_license(EnterpriseService.get_info())
+            license_model.license_expiry_notice_enabled = dify_config.ENABLE_LICENSE_EXPIRY_NOTICE
+        else:
+            license_model = feature_entities.LicenseModel()
+        return license_model
 
     @staticmethod
     def is_explore_banner_enabled() -> bool:
@@ -173,7 +176,6 @@ class FeatureService:
         system_features.webapp_auth.allow_public_access = dify_config.WEBAPP_PUBLIC_ACCESS_ENABLED
         system_features.enable_step_by_step_tour = dify_config.ENABLE_STEP_BY_STEP_TOUR
         system_features.knowledge_fs_enabled = dify_config.KNOWLEDGE_FS_ENABLED
-        system_features.enable_license_expiry_notice = dify_config.ENABLE_LICENSE_EXPIRY_NOTICE
 
     @classmethod
     def _fulfill_trial_models_from_env(cls) -> list[str]:

--- a/api/tests/unit_tests/services/test_feature_service_license_expiry_notice.py
+++ b/api/tests/unit_tests/services/test_feature_service_license_expiry_notice.py
@@ -1,21 +1,45 @@
 import pytest
 
-from enums.deployment_edition import DeploymentEdition
 from services import feature_service as feature_service_module
-from services.entities.feature_entities import SystemFeatureModel
+from services.entities.feature_entities import LicenseModel, LicenseStatus
 from services.feature_service import FeatureService
 
+_ENTERPRISE_INFO = {"License": {"status": LicenseStatus.EXPIRING, "expiredAt": "2026-12-31"}}
 
-def test_system_feature_model_defaults_enable_license_expiry_notice() -> None:
-    system_features = SystemFeatureModel(deployment_edition=DeploymentEdition.COMMUNITY)
 
-    assert system_features.enable_license_expiry_notice is True
+def test_license_model_defaults_license_expiry_notice_disabled() -> None:
+    """Without a license there is no expiry to announce, so the notice is off unless enabled explicitly."""
+    assert LicenseModel().license_expiry_notice_enabled is False
 
 
 @pytest.mark.parametrize("enabled", [True, False])
-def test_get_system_features_reads_enable_license_expiry_notice(monkeypatch: pytest.MonkeyPatch, enabled: bool) -> None:
+def test_get_license_non_enterprise_ignores_expiry_notice_config(
+    monkeypatch: pytest.MonkeyPatch, enabled: bool
+) -> None:
+    """Non-enterprise deployments have no license, so the env toggle never turns the notice on."""
     monkeypatch.setattr(feature_service_module.dify_config, "ENABLE_LICENSE_EXPIRY_NOTICE", enabled)
+    monkeypatch.setattr("services.feature_service.dify_config.ENTERPRISE_ENABLED", False)
 
-    result = FeatureService.get_system_features()
+    result = FeatureService.get_license()
 
-    assert result.enable_license_expiry_notice is enabled
+    assert result.license_expiry_notice_enabled is False
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_get_license_enterprise_reads_license_expiry_notice_enabled(
+    monkeypatch: pytest.MonkeyPatch, enabled: bool
+) -> None:
+    """The enterprise-sourced license carries the env-resolved notice flag alongside its real status."""
+    monkeypatch.setattr(feature_service_module.dify_config, "ENABLE_LICENSE_EXPIRY_NOTICE", enabled)
+    monkeypatch.setattr("services.feature_service.dify_config.ENTERPRISE_ENABLED", True)
+    monkeypatch.setattr(
+        feature_service_module.EnterpriseService,
+        "get_info",
+        staticmethod(lambda: _ENTERPRISE_INFO),
+    )
+
+    result = FeatureService.get_license()
+
+    assert result.status == LicenseStatus.EXPIRING
+    assert result.expired_at == "2026-12-31"
+    assert result.license_expiry_notice_enabled is enabled

--- a/packages/contracts/generated/api/console/system-features/types.gen.ts
+++ b/packages/contracts/generated/api/console/system-features/types.gen.ts
@@ -15,7 +15,6 @@ export type SystemFeatureModel = {
   enable_email_password_login: boolean
   enable_explore_banner: boolean
   enable_learn_app: boolean
-  enable_license_expiry_notice: boolean
   enable_marketplace: boolean
   enable_social_oauth_login: boolean
   enable_step_by_step_tour: boolean
@@ -32,6 +31,7 @@ export type SystemFeatureModel = {
 
 export type LicenseModel = {
   expired_at: string
+  license_expiry_notice_enabled: boolean
   seats: LicenseLimitationModel
   status: LicenseStatus
   workspaces: LicenseLimitationModel

--- a/packages/contracts/generated/api/console/system-features/zod.gen.ts
+++ b/packages/contracts/generated/api/console/system-features/zod.gen.ts
@@ -48,6 +48,7 @@ export const zLicenseStatus = z.enum(['active', 'expired', 'expiring', 'inactive
  */
 export const zLicenseModel = z.object({
   expired_at: z.string().default(''),
+  license_expiry_notice_enabled: z.boolean().default(false),
   seats: zLicenseLimitationModel.default({
     enabled: false,
     limit: 0,
@@ -127,7 +128,6 @@ export const zSystemFeatureModel = z.object({
   enable_email_password_login: z.boolean().default(true),
   enable_explore_banner: z.boolean().default(false),
   enable_learn_app: z.boolean().default(true),
-  enable_license_expiry_notice: z.boolean().default(true),
   enable_marketplace: z.boolean().default(false),
   enable_social_oauth_login: z.boolean().default(false),
   enable_step_by_step_tour: z.boolean().default(false),

--- a/packages/contracts/generated/api/web/types.gen.ts
+++ b/packages/contracts/generated/api/web/types.gen.ts
@@ -520,7 +520,6 @@ export type SystemFeatureModel = {
   enable_email_password_login: boolean
   enable_explore_banner: boolean
   enable_learn_app: boolean
-  enable_license_expiry_notice: boolean
   enable_marketplace: boolean
   enable_social_oauth_login: boolean
   enable_step_by_step_tour: boolean

--- a/packages/contracts/generated/api/web/zod.gen.ts
+++ b/packages/contracts/generated/api/web/zod.gen.ts
@@ -788,7 +788,6 @@ export const zSystemFeatureModel = z.object({
   enable_email_password_login: z.boolean().default(true),
   enable_explore_banner: z.boolean().default(false),
   enable_learn_app: z.boolean().default(true),
-  enable_license_expiry_notice: z.boolean().default(true),
   enable_marketplace: z.boolean().default(false),
   enable_social_oauth_login: z.boolean().default(false),
   enable_step_by_step_tour: z.boolean().default(false),

--- a/web/app/components/header/license-badge/__tests__/index.spec.tsx
+++ b/web/app/components/header/license-badge/__tests__/index.spec.tsx
@@ -1,4 +1,3 @@
-import type { ConsoleQueryTestOptions } from '@/test/console/query-data'
 import { zLicenseStatus } from '@dify/contracts/api/console/system-features/zod.gen'
 import { screen } from '@testing-library/react'
 import dayjs from 'dayjs'
@@ -12,7 +11,6 @@ import LicenseBadge from '../index'
 
 const renderLicenseBadge = (
   license?: Parameters<typeof seedSystemFeaturesLicense>[1],
-  systemFeatures?: ConsoleQueryTestOptions['systemFeatures'],
 ) => {
   const queryClient = createConsoleQueryClient()
   if (license) seedSystemFeaturesLicense(queryClient, license)
@@ -22,7 +20,7 @@ const renderLicenseBadge = (
       queryFn: () => new Promise(() => {}),
     })
   }
-  return renderWithConsoleQuery(<LicenseBadge />, { queryClient, systemFeatures })
+  return renderWithConsoleQuery(<LicenseBadge />, { queryClient })
 }
 
 describe('LicenseBadge', () => {
@@ -54,40 +52,53 @@ describe('LicenseBadge', () => {
 
   it('should render singular expiring message when license expires in 0 days', () => {
     const expiredAt = dayjs().add(2, 'hours').toISOString()
-    renderLicenseBadge({ status: zLicenseStatus.enum.expiring, expired_at: expiredAt })
+    renderLicenseBadge({
+      status: zLicenseStatus.enum.expiring,
+      expired_at: expiredAt,
+      license_expiry_notice_enabled: true,
+    })
     expect(screen.getByText(/license\.expiring/)).toBeInTheDocument()
     expect(screen.getByText(/count":0/)).toBeInTheDocument()
   })
 
   it('should render singular expiring message when license expires in 1 day', () => {
     const tomorrow = dayjs().add(1, 'day').add(1, 'hour').toISOString()
-    renderLicenseBadge({ status: zLicenseStatus.enum.expiring, expired_at: tomorrow })
+    renderLicenseBadge({
+      status: zLicenseStatus.enum.expiring,
+      expired_at: tomorrow,
+      license_expiry_notice_enabled: true,
+    })
     expect(screen.getByText(/license\.expiring/)).toBeInTheDocument()
     expect(screen.getByText(/count":1/)).toBeInTheDocument()
   })
 
   it('should render plural expiring message when license expires in 5 days', () => {
     const fiveDaysLater = dayjs().add(5, 'day').add(1, 'hour').toISOString()
-    renderLicenseBadge({ status: zLicenseStatus.enum.expiring, expired_at: fiveDaysLater })
+    renderLicenseBadge({
+      status: zLicenseStatus.enum.expiring,
+      expired_at: fiveDaysLater,
+      license_expiry_notice_enabled: true,
+    })
     expect(screen.getByText(/license\.expiring_plural/)).toBeInTheDocument()
     expect(screen.getByText(/count":5/)).toBeInTheDocument()
   })
 
   it('should fall back to the Enterprise badge when the expiry notice is disabled', () => {
     const fiveDaysLater = dayjs().add(5, 'day').add(1, 'hour').toISOString()
-    renderLicenseBadge(
-      { status: zLicenseStatus.enum.expiring, expired_at: fiveDaysLater },
-      { enable_license_expiry_notice: false },
-    )
+    renderLicenseBadge({
+      status: zLicenseStatus.enum.expiring,
+      expired_at: fiveDaysLater,
+      license_expiry_notice_enabled: false,
+    })
     expect(screen.queryByText(/license\.expiring/)).not.toBeInTheDocument()
     expect(screen.getByText('Enterprise')).toBeInTheDocument()
   })
 
   it('should keep rendering the Enterprise badge for an active license when the expiry notice is disabled', () => {
-    renderLicenseBadge(
-      { status: zLicenseStatus.enum.active },
-      { enable_license_expiry_notice: false },
-    )
+    renderLicenseBadge({
+      status: zLicenseStatus.enum.active,
+      license_expiry_notice_enabled: false,
+    })
     expect(screen.getByText('Enterprise')).toBeInTheDocument()
   })
 })

--- a/web/app/components/header/license-badge/__tests__/index.spec.tsx
+++ b/web/app/components/header/license-badge/__tests__/index.spec.tsx
@@ -9,9 +9,7 @@ import {
 } from '@/test/console/query-data'
 import LicenseBadge from '../index'
 
-const renderLicenseBadge = (
-  license?: Parameters<typeof seedSystemFeaturesLicense>[1],
-) => {
+const renderLicenseBadge = (license?: Parameters<typeof seedSystemFeaturesLicense>[1]) => {
   const queryClient = createConsoleQueryClient()
   if (license) seedSystemFeaturesLicense(queryClient, license)
   else {

--- a/web/app/components/header/license-badge/index.tsx
+++ b/web/app/components/header/license-badge/index.tsx
@@ -1,23 +1,18 @@
 'use client'
 
 import { zLicenseStatus } from '@dify/contracts/api/console/system-features/zod.gen'
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import dayjs from 'dayjs'
 import { useTranslation } from 'react-i18next'
-import { systemFeaturesQueryOptions } from '@/features/system-features/client'
 import { consoleQuery } from '@/service/client'
 import PremiumBadge from '../../base/premium-badge'
 
 function LicenseBadge() {
   const { t } = useTranslation()
   const { data: license } = useQuery(consoleQuery.systemFeatures.license.get.queryOptions())
-  const { data: expiryNoticeEnabled } = useSuspenseQuery({
-    ...systemFeaturesQueryOptions(),
-    select: ({ enable_license_expiry_notice }) => enable_license_expiry_notice,
-  })
   const isExpiring = license?.status === zLicenseStatus.enum.expiring
 
-  if (isExpiring && expiryNoticeEnabled) {
+  if (isExpiring && license.license_expiry_notice_enabled) {
     const count = dayjs(license.expired_at).diff(dayjs(), 'days')
     return (
       <PremiumBadge color="orange" className="select-none">

--- a/web/test/console/system-features.ts
+++ b/web/test/console/system-features.ts
@@ -57,11 +57,11 @@ const baseSystemFeatures = {
   enable_learn_app: true,
   enable_step_by_step_tour: false,
   knowledge_fs_enabled: false,
-  enable_license_expiry_notice: true,
 } satisfies GetSystemFeaturesResponse
 
 const baseSystemFeaturesLicense = {
   status: zLicenseStatus.enum.none,
+  license_expiry_notice_enabled: false,
   expired_at: '',
   workspaces: {
     enabled: false,


### PR DESCRIPTION
## Summary

Follow-up to review feedback on #39972 (merged). That PR added `enable_license_expiry_notice` as a top-level field on the unauthenticated `/system-features` payload. This moves it onto the authenticated `/system-features/license` response — next to the `status` and `expired_at` it actually governs — and renames it to `license_expiry_notice_enabled`.

| | Before | After |
| --- | --- | --- |
| Model | `SystemFeatureModel` | `LicenseModel` |
| Endpoint | `GET /console/api/system-features` (unauthenticated) | `GET /console/api/system-features/license` (authenticated) |
| Field | `enable_license_expiry_notice` | `license_expiry_notice_enabled` |

**Frontend.** The badge already queried `/system-features/license` for `status` and `expired_at`, so it now reads the flag off that same response and drops its separate system-features query — one fewer request, and the `useSuspenseQuery` plus `systemFeaturesQueryOptions` import go with it.

**Defaults.** `LicenseModel.license_expiry_notice_enabled` defaults to `False`: with no license there is no expiry to announce. Only the enterprise path resolves it from `ENABLE_LICENSE_EXPIRY_NOTICE`, whose own default stays `True` — so enterprise behavior is unchanged from #39972 and the badge still shows by default.

Display-only; no enforcement path is touched. `ENABLE_LICENSE_EXPIRY_NOTICE` is unchanged, so no deployment config changes are needed.

Two consequences worth flagging for review:

- The flag is no longer in the webapp (`/api`) contract, because `/system-features/license` is console-only. Nothing in the webapp consumed it.
- It is now behind authentication. Fine for a console header badge, which only renders for signed-in users, but it is no longer readable pre-login the way it was on `/system-features`.

Generated contracts and OpenAPI markdown were regenerated with `pnpm gen-api-contract` and `dev/generate_swagger_markdown_docs.py`, not hand-edited.

## Screenshots

No visual change. With default config on an enterprise deployment the badge renders exactly as on `main`; the toggle's off-state behavior — falling back to the indigo `Enterprise` badge — is unchanged and covered by tests.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

### Verification

| Check | Result |
| --- | --- |
| `pytest` feature tests (4 files) | 18 passed |
| `dev/lint_response_contracts.py --fail-on-mismatch` | 476 valid, 0 mismatch |
| `mypy` (via `make type-check`) | Success: no issues found in 1665 source files |
| `ruff check` / `ruff format` | All checks passed |
| `cd web && pnpm type-check` | clean |
| `cd web && pnpm test app/components/header` | 113 files, 1113 tests passed |

Two caveats on the lint checklist item, since they could not run locally: `pnpm exec vp staged` reports `No "staged" config found in vite.config.ts`, and the pyrefly half of `make type-check` exits 1 with `No Python files matched pattern` for test directories that its own `project-excludes` excludes. Neither touches this diff — no pyrefly or vite config is modified here — and the mypy half passes clean.

Backend tests added: default is disabled, the enterprise path reads the env toggle, and the non-enterprise path ignores it (parameterized both ways). Frontend badge tests now name the flag explicitly rather than relying on a fixture default.
