### PR TITLE
chore: dep inject for model in notification dismiss

### DIFF
--- a/api/controllers/console/notification.py
+++ b/api/controllers/console/notification.py
@@ -1,7 +1,6 @@
 from collections.abc import Mapping
 from typing import TypedDict
 
-from flask import request
 from flask_restx import Resource
 from pydantic import BaseModel, Field
 
@@ -10,6 +9,7 @@ from controllers.common.schema import register_response_schema_models, register_
 from controllers.console import console_ns
 from controllers.console.wraps import (
     account_initialization_required,
+    model_validate,
     only_edition_cloud,
     setup_required,
     with_current_user,
@@ -141,8 +141,8 @@ class NotificationDismissApi(Resource):
     @only_edition_cloud
     @console_ns.expect(console_ns.models[DismissNotificationPayload.__name__])
     @console_ns.response(200, "Success", console_ns.models[SimpleResultResponse.__name__])
-    def post(self, current_user: Account):
-        payload = DismissNotificationPayload.model_validate(request.get_json())
+    @model_validate(DismissNotificationPayload)
+    def post(self, payload: DismissNotificationPayload, current_user: Account):
         BillingService.dismiss_notification(
             notification_id=payload.notification_id,
             account_id=str(current_user.id),


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our `https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md`
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

#36659

Replace manual `DismissNotificationPayload.model_validate(request.get_json())` with the `@model_validate` decorator introduced in #36750, injecting the validated payload as a method argument.

## Screenshots

N/A — backend-only refactoring, no UI changes.

## Checklist

- [ ] This change requires a documentation update, included: `https://github.com/langgenius/dify-docs`
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods