### PR TITLE
chore: dep inject for model in datasets document and web human input …

### DIFF
--- a/api/controllers/console/datasets/datasets_document.py
+++ b/api/controllers/console/datasets/datasets_document.py
@@ -21,7 +21,7 @@ from controllers.common.fields import SimpleResultMessageResponse, SimpleResultR
 from controllers.common.schema import register_response_schema_models, register_schema_models
 from controllers.common.session import with_session
 from controllers.console import console_ns
-from controllers.console.wraps import RBACPermission, RBACResourceScope, rbac_permission_required
+from controllers.console.wraps import RBACPermission, RBACResourceScope, model_validate, rbac_permission_required
 from core.entities.knowledge_entities import IndexingEstimate
 from core.errors.error import (
     LLMBadRequestError,
@@ -1267,12 +1267,19 @@ class DocumentMetadataApi(DocumentResource):
     @with_current_tenant_id
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_EDIT)
     @with_session
-    def put(self, session: Session, current_tenant_id: str, current_user: Account, dataset_id: UUID, document_id: UUID):
+    @model_validate(DocumentMetadataUpdatePayload)
+    def put(
+        self,
+        req_data: DocumentMetadataUpdatePayload,
+        session: Session,
+        current_tenant_id: str,
+        current_user: Account,
+        dataset_id: UUID,
+        document_id: UUID,
+    ):
         dataset_id_str = str(dataset_id)
         document_id_str = str(document_id)
         document = self.get_document(session, dataset_id_str, document_id_str, current_user, current_tenant_id)
-
-        req_data = DocumentMetadataUpdatePayload.model_validate(request.get_json() or {})
 
         doc_type = req_data.doc_type
         doc_metadata = req_data.doc_metadata

--- a/api/controllers/web/human_input_form.py
+++ b/api/controllers/web/human_input_form.py
@@ -16,6 +16,7 @@ from configs import dify_config
 from controllers.common.errors import NotFoundError
 from controllers.common.human_input import HumanInputFormSubmitPayload, stringify_form_default_values
 from controllers.common.schema import register_response_schema_models, register_schema_models
+from controllers.console.wraps import model_validate
 from controllers.web import web_ns
 from controllers.web.error import WebFormRateLimitExceededError
 from controllers.web.site import WebAppSiteResponse
@@ -235,7 +236,8 @@ class HumanInputFormApi(Resource):
         "Form submitted successfully",
         web_ns.models[HumanInputFormSubmitResponse.__name__],
     )
-    def post(self, form_token: str):
+    @model_validate(HumanInputFormSubmitPayload)
+    def post(self, payload: HumanInputFormSubmitPayload, form_token: str):
         """
         Submit human input form by token.
 
@@ -249,8 +251,6 @@ class HumanInputFormApi(Resource):
             "action": "Approve"
         }
         """
-        payload = HumanInputFormSubmitPayload.model_validate(request.get_json())
-
         ip_address = extract_remote_ip(request)
         if _FORM_SUBMIT_RATE_LIMITER.is_rate_limited(ip_address):
             raise WebFormRateLimitExceededError()

--- a/api/tests/unit_tests/controllers/console/datasets/test_datasets_document.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_datasets_document.py
@@ -21,6 +21,7 @@ from controllers.console.datasets.datasets_document import (
     DocumentIndexingEstimateApi,
     DocumentIndexingStatusApi,
     DocumentMetadataApi,
+    DocumentMetadataUpdatePayload,
     DocumentPipelineExecutionLogApi,
     DocumentProcessingApi,
     DocumentRenameApi,
@@ -631,15 +632,16 @@ class TestDocumentMetadataApi:
         payload = {"doc_type": "invoice", "doc_metadata": {"amount": 10, "invalid": "x"}}
         schema = {"amount": int}
         session = MagicMock()
+        req_data = DocumentMetadataUpdatePayload.model_validate(payload)
         with (
-            app.test_request_context("/", json=payload),
+            app.test_request_context("/"),
             patch.object(api, "get_document", return_value=doc),
             patch(
                 "controllers.console.datasets.datasets_document.DocumentService.DOCUMENT_METADATA_SCHEMA",
                 {"invoice": schema},
             ),
         ):
-            method(api, session, tenant_id, user, "ds-1", "doc-1")
+            method(api, req_data, session, tenant_id, user, "ds-1", "doc-1")
         assert doc.doc_metadata == {"amount": 10}
 
     def test_put_success(self, app: Flask, patch_tenant):
@@ -649,32 +651,35 @@ class TestDocumentMetadataApi:
         document = MagicMock()
         payload = {"doc_type": "others", "doc_metadata": {"a": 1}}
         session = MagicMock()
+        req_data = DocumentMetadataUpdatePayload.model_validate(payload)
         with (
-            app.test_request_context("/", json=payload),
+            app.test_request_context("/"),
             patch.object(api, "get_document", return_value=document),
             patch(
                 "controllers.console.datasets.datasets_document.DocumentService.DOCUMENT_METADATA_SCHEMA",
                 {"others": {}},
             ),
         ):
-            response, status = method(api, session, tenant_id, user, "ds-1", "doc-1")
+            response, status = method(api, req_data, session, tenant_id, user, "ds-1", "doc-1")
         assert status == 200
 
     def test_put_invalid_payload(self, app: Flask, patch_tenant):
         api = DocumentMetadataApi()
         method = unwrap(api.put)
         user, tenant_id = patch_tenant
-        with app.test_request_context("/", json={}), patch.object(api, "get_document", return_value=MagicMock()):
+        req_data = DocumentMetadataUpdatePayload.model_validate({})
+        with app.test_request_context("/"), patch.object(api, "get_document", return_value=MagicMock()):
             with pytest.raises(ValueError):
-                method(api, MagicMock(), tenant_id, user, "ds-1", "doc-1")
+                method(api, req_data, MagicMock(), tenant_id, user, "ds-1", "doc-1")
 
     def test_put_invalid_doc_type(self, app: Flask, patch_tenant):
         api = DocumentMetadataApi()
         method = unwrap(api.put)
         user, tenant_id = patch_tenant
         payload = {"doc_type": "invalid", "doc_metadata": {}}
+        req_data = DocumentMetadataUpdatePayload.model_validate(payload)
         with (
-            app.test_request_context("/", json=payload),
+            app.test_request_context("/"),
             patch.object(api, "get_document", return_value=MagicMock()),
             patch(
                 "controllers.console.datasets.datasets_document.DocumentService.DOCUMENT_METADATA_SCHEMA",
@@ -682,7 +687,7 @@ class TestDocumentMetadataApi:
             ),
         ):
             with pytest.raises(ValueError):
-                method(api, MagicMock(), tenant_id, user, "ds-1", "doc-1")
+                method(api, req_data, MagicMock(), tenant_id, user, "ds-1", "doc-1")
 
 
 class TestDocumentStatusApi:

--- a/api/tests/unit_tests/controllers/console/datasets/test_datasets_document.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_datasets_document.py
@@ -1434,15 +1434,16 @@ class TestDocumentListAdvancedCases:
         payload = {"doc_type": "contract", "doc_metadata": {"amount": 5000, "currency": "USD", "invalid_field": "x"}}
         schema = {"amount": int, "currency": str}
         session = MagicMock()
+        req_data = DocumentMetadataUpdatePayload.model_validate(payload)
         with (
-            app.test_request_context("/", json=payload),
+            app.test_request_context("/"),
             patch.object(api, "get_document", return_value=doc),
             patch(
                 "controllers.console.datasets.datasets_document.DocumentService.DOCUMENT_METADATA_SCHEMA",
                 {"contract": schema},
             ),
         ):
-            response, status = method(api, session, tenant_id, user, "ds-1", "doc-1")
+            response, status = method(api, req_data, session, tenant_id, user, "ds-1", "doc-1")
             assert status == 200
             assert doc.doc_metadata == {"amount": 5000, "currency": "USD"}
 


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our `https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md`
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

#36659

Replace manual `DocumentMetadataUpdatePayload.model_validate(request.get_json() or {})` and `HumanInputFormSubmitPayload.model_validate(request.get_json())` with the `@model_validate` decorator introduced in #36750, injecting the validated payload as a method argument.

## Screenshots

N/A — backend-only refactoring, no UI changes.

## Checklist

- [ ] This change requires a documentation update, included: `https://github.com/langgenius/dify-docs`
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods