### PR TITLE
chore: dep inject for model in agent app sandbox upload

### DIFF
--- a/api/controllers/console/app/agent_app_sandbox.py
+++ b/api/controllers/console/app/agent_app_sandbox.py
@@ -11,7 +11,6 @@ from typing import Literal
 from uuid import UUID
 
 from dify_agent.client import DifyAgentClientError, DifyAgentHTTPError, DifyAgentTimeoutError
-from flask import request
 from flask_restx import Resource
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
@@ -28,6 +27,7 @@ from controllers.console.agent.app_helpers import resolve_agent_runtime_app_mode
 from controllers.console.app.wraps import get_app_model
 from controllers.console.wraps import (
     account_initialization_required,
+    model_validate,
     setup_required,
     with_current_tenant_id,
     with_current_user,
@@ -242,18 +242,25 @@ class AgentAppSandboxUploadResource(Resource):
     @with_current_tenant_id
     @with_current_user
     @with_session(write=False)
-    def post(self, session: Session, current_user: Account, tenant_id: str, agent_id: UUID):
+    @model_validate(AgentSandboxUploadPayload)
+    def post(
+        self,
+        req_data: AgentSandboxUploadPayload,
+        session: Session,
+        current_user: Account,
+        tenant_id: str,
+        agent_id: UUID,
+    ):
         app_model = resolve_agent_runtime_app_model(session=session, tenant_id=tenant_id, agent_id=agent_id)
-        payload = AgentSandboxUploadPayload.model_validate(request.get_json(silent=True) or {})
         try:
             result = AgentAppSandboxService().upload_file(
                 tenant_id=tenant_id,
                 app_id=app_model.id,
                 agent_id=str(agent_id),
-                caller_type=payload.caller_type,
-                caller_id=payload.caller_id,
+                caller_type=req_data.caller_type,
+                caller_id=req_data.caller_id,
                 account_id=current_user.id,
-                path=payload.path,
+                path=req_data.path,
             )
         except Exception as exc:
             return _handle(exc)
@@ -345,16 +352,23 @@ class WorkflowAgentSandboxUploadResource(Resource):
     @account_initialization_required
     @get_app_model(mode=[AppMode.ADVANCED_CHAT, AppMode.WORKFLOW])
     @with_current_tenant_id
-    def post(self, tenant_id: str, app_model: App, workflow_run_id: UUID, node_id: str):
-        payload = WorkflowAgentSandboxUploadPayload.model_validate(request.get_json(silent=True) or {})
+    @model_validate(WorkflowAgentSandboxUploadPayload)
+    def post(
+        self,
+        req_data: WorkflowAgentSandboxUploadPayload,
+        tenant_id: str,
+        app_model: App,
+        workflow_run_id: UUID,
+        node_id: str,
+    ):
         try:
             result = WorkflowAgentSandboxService().upload_file(
                 tenant_id=tenant_id,
                 app_id=app_model.id,
                 workflow_run_id=str(workflow_run_id),
                 node_id=node_id,
-                node_execution_id=payload.node_execution_id,
-                path=payload.path,
+                node_execution_id=req_data.node_execution_id,
+                path=req_data.path,
                 session=db.session(),
             )
         except Exception as exc:

--- a/api/tests/unit_tests/controllers/console/app/test_agent_app_sandbox.py
+++ b/api/tests/unit_tests/controllers/console/app/test_agent_app_sandbox.py
@@ -172,22 +172,16 @@ def test_agent_app_sandbox_resources_proxy_service(monkeypatch: pytest.MonkeyPat
         "query_params_from_request",
         lambda model: SimpleNamespace(caller_type="build_draft", caller_id="build-1", path="sub/report.txt"),
     )
-    monkeypatch.setattr(
-        module,
-        "request",
-        SimpleNamespace(
-            get_json=lambda silent=True: {
-                "caller_type": "build_draft",
-                "caller_id": "build-1",
-                "path": "report.txt",
-            }
-        ),
-    )
 
     info = unwrap(module.AgentAppSandboxInfoResource.get)(object(), session, account, "tenant-1", "agent-1")
     listing = unwrap(module.AgentAppSandboxListResource.get)(object(), session, account, "tenant-1", "agent-1")
     preview = unwrap(module.AgentAppSandboxReadResource.get)(object(), session, account, "tenant-1", "agent-1")
-    upload = unwrap(module.AgentAppSandboxUploadResource.post)(object(), session, account, "tenant-1", "agent-1")
+    req_data = module.AgentSandboxUploadPayload.model_validate(
+        {"caller_type": "build_draft", "caller_id": "build-1", "path": "report.txt"}
+    )
+    upload = unwrap(module.AgentAppSandboxUploadResource.post)(
+        object(), req_data, session, account, "tenant-1", "agent-1"
+    )
 
     assert info == {"workspace_cwd": "."}
     assert listing["path"] == "sub/report.txt"
@@ -240,11 +234,6 @@ def test_workflow_agent_sandbox_resources_proxy_service(monkeypatch: pytest.Monk
         "query_params_from_request",
         lambda model: SimpleNamespace(node_execution_id="execution-1", path="out.txt"),
     )
-    monkeypatch.setattr(
-        module,
-        "request",
-        SimpleNamespace(get_json=lambda silent=True: {"node_execution_id": "execution-1", "path": "upload.txt"}),
-    )
     app_model = _app_model()
 
     listing = unwrap(module.WorkflowAgentSandboxListResource.get)(
@@ -253,8 +242,11 @@ def test_workflow_agent_sandbox_resources_proxy_service(monkeypatch: pytest.Monk
     preview = unwrap(module.WorkflowAgentSandboxReadResource.get)(
         object(), "tenant-1", app_model, "run-1", "agent-node"
     )
+    req_data = module.WorkflowAgentSandboxUploadPayload.model_validate(
+        {"node_execution_id": "execution-1", "path": "upload.txt"}
+    )
     upload = unwrap(module.WorkflowAgentSandboxUploadResource.post)(
-        object(), "tenant-1", app_model, "run-1", "agent-node"
+        object(), req_data, "tenant-1", app_model, "run-1", "agent-node"
     )
 
     assert listing["path"] == "out.txt"


### PR DESCRIPTION
## Summary

#36659

Replace manual AgentSandboxUploadPayload.model_validate(request.get_json(silent=True) or {}) and WorkflowAgentSandboxUploadPayload.model_validate(request.get_json(silent=True) or {}) with the @model_validate decorator introduced in #36750, injecting the validated payload as a method argument.

## Screenshots

N/A — backend-only refactoring, no UI changes.

## Checklist

- [ ] This change requires a documentation update, included: https://github.com/langgenius/dify-docs
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran make lint && make type-check (backend) and cd web && pnpm exec vp staged (frontend) to appease the lint gods