### PR TITLE
chore: dep inject for model in api based extension

### DIFF
--- a/api/controllers/console/extension.py
+++ b/api/controllers/console/extension.py
@@ -17,7 +17,7 @@ from services.code_based_extension_service import CodeBasedExtensionService
 
 from ..common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from . import console_ns
-from .wraps import account_initialization_required, setup_required, with_current_tenant_id
+from .wraps import account_initialization_required, model_validate, setup_required, with_current_tenant_id
 
 
 class CodeBasedExtensionQuery(BaseModel):
@@ -123,14 +123,13 @@ class APIBasedExtensionAPI(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    def post(self, current_tenant_id: str):
-        payload = APIBasedExtensionPayload.model_validate(console_ns.payload or {})
-
+    @model_validate(APIBasedExtensionPayload)
+    def post(self, req_data: APIBasedExtensionPayload, current_tenant_id: str):
         extension_data = APIBasedExtension(
             tenant_id=current_tenant_id,
-            name=payload.name,
-            api_endpoint=payload.api_endpoint,
-            api_key=payload.api_key,
+            name=req_data.name,
+            api_endpoint=req_data.api_endpoint,
+            api_key=req_data.api_key,
         )
 
         extension = APIBasedExtensionService.save(extension_data, session=db.session())
@@ -138,7 +137,7 @@ class APIBasedExtensionAPI(Resource):
             id=extension.id,
             name=extension.name,
             api_endpoint=extension.api_endpoint,
-            api_key=payload.api_key,
+            api_key=req_data.api_key,
             created_at=to_timestamp(extension.created_at),
         ).model_dump(mode="json"), 201
 
@@ -172,22 +171,22 @@ class APIBasedExtensionDetailAPI(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    def post(self, current_tenant_id: str, id: UUID):
+    @model_validate(APIBasedExtensionPayload)
+    def post(self, req_data: APIBasedExtensionPayload, current_tenant_id: str, id: UUID):
         api_based_extension_id = str(id)
 
         extension_data_from_db = APIBasedExtensionService.get_with_tenant_id(
             current_tenant_id, api_based_extension_id, session=db.session()
         )
 
-        payload = APIBasedExtensionPayload.model_validate(console_ns.payload or {})
         api_key_for_response = extension_data_from_db.api_key
 
-        extension_data_from_db.name = payload.name
-        extension_data_from_db.api_endpoint = payload.api_endpoint
+        extension_data_from_db.name = req_data.name
+        extension_data_from_db.api_endpoint = req_data.api_endpoint
 
-        if payload.api_key != HIDDEN_VALUE:
-            extension_data_from_db.api_key = payload.api_key
-            api_key_for_response = payload.api_key
+        if req_data.api_key != HIDDEN_VALUE:
+            extension_data_from_db.api_key = req_data.api_key
+            api_key_for_response = req_data.api_key
 
         APIBasedExtensionService.save(extension_data_from_db, session=db.session())
         return APIBasedExtensionResponse(


### PR DESCRIPTION
## Summary

#36659

Replace manual APIBasedExtensionPayload.model_validate(console_ns.payload or {}) with the @model_validate decorator introduced in #36750, injecting the validated payload as a method argument.

## Screenshots

N/A — backend-only refactoring, no UI changes.

## Checklist

- [ ] This change requires a documentation update, included: https://github.com/langgenius/dify-docs
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran make lint && make type-check (backend) and cd web && pnpm exec vp staged (frontend) to appease the lint gods