### PR TITLE
chore: dep inject for model in onboarding step by step tour

### DIFF
--- a/api/controllers/console/onboarding.py
+++ b/api/controllers/console/onboarding.py
@@ -21,7 +21,13 @@ from models import Account
 from services.step_by_step_tour_service import StepByStepTourPatch, StepByStepTourService
 
 from . import console_ns
-from .wraps import account_initialization_required, setup_required, with_current_tenant_id, with_current_user
+from .wraps import (
+    account_initialization_required,
+    model_validate,
+    setup_required,
+    with_current_tenant_id,
+    with_current_user,
+)
 
 StepByStepTourAction = Literal[
     "skip",
@@ -92,9 +98,9 @@ class StepByStepTourStateApi(Resource):
     @account_initialization_required
     @with_current_user
     @with_current_tenant_id
-    def patch(self, current_tenant_id: str, current_user: Account):
-        payload = StepByStepTourStatePatchPayload.model_validate(console_ns.payload or {})
-        patch = cast(StepByStepTourPatch, payload.model_dump(exclude_unset=True, exclude_none=True))
+    @model_validate(StepByStepTourStatePatchPayload)
+    def patch(self, req_data: StepByStepTourStatePatchPayload, current_tenant_id: str, current_user: Account):
+        patch = cast(StepByStepTourPatch, req_data.model_dump(exclude_unset=True, exclude_none=True))
         return dump_response(
             StepByStepTourStateResponse,
             StepByStepTourService.patch_state(

--- a/api/tests/unit_tests/controllers/console/test_onboarding.py
+++ b/api/tests/unit_tests/controllers/console/test_onboarding.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from inspect import unwrap
-from unittest.mock import Mock, PropertyMock, patch
+from unittest.mock import Mock
 
 import pytest
 from flask import Flask
 from pydantic import ValidationError
 
-from controllers.console import console_ns
 from controllers.console.onboarding import (
     StepByStepTourStateApi,
     StepByStepTourStatePatchPayload,
@@ -69,13 +68,13 @@ def test_patch_step_by_step_tour_state_passes_action_payload(
     method = unwrap(api.patch)
     payload = {"action": "complete_task", "task_id": "studio"}
 
+    req_data = StepByStepTourStatePatchPayload.model_validate(payload)
     with app.test_request_context(
         "/console/api/onboarding/step-by-step-tour/state",
         method="PATCH",
         json=payload,
     ):
-        with patch.object(type(console_ns), "payload", new_callable=PropertyMock, return_value=payload):
-            result = method(api, "workspace-1", _account())
+        result = method(api, req_data, "workspace-1", _account())
 
     assert result["completed_task_ids"] == ["home"]
     patch_state.assert_called_once()


### PR DESCRIPTION
## Summary

#36659

Replace manual StepByStepTourStatePatchPayload.model_validate(console_ns.payload or {}) with the @model_validate decorator introduced in #36750, injecting the validated payload as a method argument.

## Screenshots

N/A — backend-only refactoring, no UI changes.

## Checklist

- [ ] This change requires a documentation update, included: https://github.com/langgenius/dify-docs
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran make lint && make type-check (backend) and cd web && pnpm exec vp staged (frontend) to appease the lint gods