### PR TITLE
chore: dep inject for model in workflow run archive download

### DIFF
--- a/api/controllers/console/workflow_run_archive.py
+++ b/api/controllers/console/workflow_run_archive.py
@@ -13,6 +13,7 @@ from controllers.console.wraps import (
     account_initialization_required,
     cloud_edition_billing_enabled,
     cloud_edition_billing_paid_plan_required,
+    model_validate,
     only_edition_cloud,
     setup_required,
 )
@@ -144,16 +145,16 @@ class WorkflowRunArchiveDownloadsApi(Resource):
     @only_edition_cloud
     @cloud_edition_billing_enabled
     @cloud_edition_billing_paid_plan_required
-    def post(self):
+    @model_validate(WorkflowRunArchiveDownloadPayload)
+    def post(self, req_data: WorkflowRunArchiveDownloadPayload):
         tenant_id, account_id = _current_owner_or_admin_ids()
-        payload = WorkflowRunArchiveDownloadPayload.model_validate(console_ns.payload or {})
         try:
             task = create_workflow_run_archive_download_task(
                 db.session(),
                 tenant_id=tenant_id,
                 requested_by=account_id,
-                year=payload.year,
-                month=payload.month,
+                year=req_data.year,
+                month=req_data.month,
             )
         except WorkflowRunArchiveNotFoundError as exc:
             raise NotFound(str(exc)) from exc

--- a/api/tests/unit_tests/controllers/console/test_workflow_run_archive.py
+++ b/api/tests/unit_tests/controllers/console/test_workflow_run_archive.py
@@ -54,7 +54,7 @@ def test_current_owner_or_admin_ids_returns_current_ids_for_manager(
     ("method", "args"),
     [
         (WorkflowRunArchivesApi.get, ()),
-        (WorkflowRunArchiveDownloadsApi.post, ()),
+        (WorkflowRunArchiveDownloadsApi.post, (None,)),
         (WorkflowRunArchiveDownloadApi.get, ("download-1",)),
         (WorkflowRunArchiveDownloadFileApi.get, ("download-1",)),
     ],


### PR DESCRIPTION
## Summary

Replace manual `WorkflowRunArchiveDownloadPayload.model_validate(console_ns.payload or {})` with the `@model_validate` decorator introduced in #36750, injecting the validated payload as a method argument.

## How to Test

- [ ] Workflow run archive download POST endpoint still validates `WorkflowRunArchiveDownloadPayload` correctly
- [ ] Existing unit tests pass

## Screenshots

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes