### PR TITLE
chore: dep inject for model in explore workflow run

### DIFF
--- a/api/controllers/console/explore/workflow.py
+++ b/api/controllers/console/explore/workflow.py
@@ -15,7 +15,7 @@ from controllers.console.app.error import (
 from controllers.console.app.wraps import with_session
 from controllers.console.explore.error import NotWorkflowAppError
 from controllers.console.explore.wraps import InstalledAppResource
-from controllers.console.wraps import with_current_user
+from controllers.console.wraps import model_validate, with_current_user
 from controllers.web.error import InvokeRateLimitError as InvokeRateLimitHttpError
 from core.app.apps.base_app_queue_manager import AppQueueManager
 from core.app.entities.app_invoke_entities import InvokeFrom
@@ -47,7 +47,14 @@ class InstalledAppWorkflowRunApi(InstalledAppResource):
     @console_ns.response(200, "Success")
     @with_current_user
     @with_session
-    def post(self, session: Session, current_user: Account, installed_app: InstalledApp):
+    @model_validate(WorkflowRunPayload)
+    def post(
+        self,
+        req_data: WorkflowRunPayload,
+        session: Session,
+        current_user: Account,
+        installed_app: InstalledApp,
+    ):
         """
         Run workflow
         """
@@ -58,8 +65,7 @@ class InstalledAppWorkflowRunApi(InstalledAppResource):
         if app_mode != AppMode.WORKFLOW:
             raise NotWorkflowAppError()
 
-        payload = WorkflowRunPayload.model_validate(console_ns.payload or {})
-        args = payload.model_dump(exclude_none=True)
+        args = req_data.model_dump(exclude_none=True)
         try:
             response = AppGenerateService.generate(
                 session=session,

--- a/api/tests/unit_tests/controllers/console/explore/test_workflow.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_workflow.py
@@ -5,6 +5,7 @@ import pytest
 from flask import Flask
 from werkzeug.exceptions import InternalServerError
 
+from controllers.common.controller_schemas import WorkflowRunPayload
 from controllers.console.explore.error import NotWorkflowAppError
 from controllers.console.explore.workflow import (
     InstalledAppWorkflowRunApi,
@@ -62,11 +63,18 @@ class TestInstalledAppWorkflowRunApi:
 
         with app.test_request_context("/"):
             with pytest.raises(NotWorkflowAppError):
-                method(api, MagicMock(), MagicMock(), non_workflow_installed_app)
+                method(
+                    api,
+                    WorkflowRunPayload.model_validate({"inputs": {}}),
+                    MagicMock(),
+                    MagicMock(),
+                    non_workflow_installed_app,
+                )
 
     def test_success(self, app: Flask, installed_workflow_app, user, payload):
         api = InstalledAppWorkflowRunApi()
         method = unwrap(api.post)
+        req_data = WorkflowRunPayload.model_validate(payload)
 
         with (
             app.test_request_context("/", json=payload),
@@ -75,7 +83,7 @@ class TestInstalledAppWorkflowRunApi:
                 return_value=MagicMock(),
             ) as generate_mock,
         ):
-            result = method(api, MagicMock(), user, installed_workflow_app)
+            result = method(api, req_data, MagicMock(), user, installed_workflow_app)
 
             generate_mock.assert_called_once()
             assert generate_mock.call_args.kwargs["user"] is user
@@ -84,6 +92,7 @@ class TestInstalledAppWorkflowRunApi:
     def test_rate_limit_error(self, app: Flask, installed_workflow_app, user, payload):
         api = InstalledAppWorkflowRunApi()
         method = unwrap(api.post)
+        req_data = WorkflowRunPayload.model_validate(payload)
 
         with (
             app.test_request_context("/", json=payload),
@@ -93,11 +102,12 @@ class TestInstalledAppWorkflowRunApi:
             ),
         ):
             with pytest.raises(InvokeRateLimitHttpError):
-                method(api, MagicMock(), user, installed_workflow_app)
+                method(api, req_data, MagicMock(), user, installed_workflow_app)
 
     def test_unexpected_exception(self, app: Flask, installed_workflow_app, user, payload):
         api = InstalledAppWorkflowRunApi()
         method = unwrap(api.post)
+        req_data = WorkflowRunPayload.model_validate(payload)
 
         with (
             app.test_request_context("/", json=payload),
@@ -107,7 +117,7 @@ class TestInstalledAppWorkflowRunApi:
             ),
         ):
             with pytest.raises(InternalServerError):
-                method(api, MagicMock(), user, installed_workflow_app)
+                method(api, req_data, MagicMock(), user, installed_workflow_app)
 
 
 class TestInstalledAppWorkflowTaskStopApi:


### PR DESCRIPTION
## Summary

Replace manual `WorkflowRunPayload.model_validate(console_ns.payload or {})` with the `@model_validate` decorator introduced in #36750, injecting the validated payload as a method argument.

## How to Test

- [ ] Explore workflow run POST endpoint still validates `WorkflowRunPayload` correctly
- [ ] Existing unit tests pass

## Screenshots

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes