### PR TITLE
chore: dep inject for model in explore apis

### DIFF
--- a/api/controllers/console/explore/audio.py
+++ b/api/controllers/console/explore/audio.py
@@ -20,6 +20,7 @@ from controllers.console.app.error import (
     UnsupportedAudioTypeError,
 )
 from controllers.console.explore.wraps import InstalledAppResource
+from controllers.console.wraps import model_validate
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from extensions.ext_database import db
 from graphon.model_runtime.errors.invoke import InvokeError
@@ -100,16 +101,15 @@ class ChatAudioApi(InstalledAppResource):
 class ChatTextApi(InstalledAppResource):
     @console_ns.expect(console_ns.models[TextToAudioPayload.__name__])
     @console_ns.response(200, "Success", console_ns.models[AudioBinaryResponse.__name__])
-    def post(self, installed_app: InstalledApp):
+    @model_validate(TextToAudioPayload)
+    def post(self, req_data: TextToAudioPayload, installed_app: InstalledApp):
         app_model = installed_app.app_with_session(session=db.session())
         if app_model is None:
             raise AppUnavailableError()
         try:
-            payload = TextToAudioPayload.model_validate(console_ns.payload or {})
-
-            message_id = payload.message_id
-            text = payload.text
-            voice = payload.voice
+            message_id = req_data.message_id
+            text = req_data.text
+            voice = req_data.voice
             message_ref = None
             if message_id:
                 current_user, _ = current_account_with_tenant()

--- a/api/controllers/console/explore/completion.py
+++ b/api/controllers/console/explore/completion.py
@@ -20,7 +20,7 @@ from controllers.console.app.error import (
 from controllers.console.app.wraps import with_session
 from controllers.console.explore.error import NotChatAppError, NotCompletionAppError
 from controllers.console.explore.wraps import InstalledAppResource
-from controllers.console.wraps import with_current_user, with_current_user_id
+from controllers.console.wraps import model_validate, with_current_user, with_current_user_id
 from controllers.web.error import InvokeRateLimitError as InvokeRateLimitHttpError
 from core.app.entities.app_invoke_entities import InvokeFrom
 from core.errors.error import (
@@ -89,17 +89,23 @@ class CompletionApi(InstalledAppResource):
     @console_ns.response(200, "Success")
     @with_current_user
     @with_session
-    def post(self, session: Session, current_user: Account, installed_app: InstalledApp):
+    @model_validate(CompletionMessageExplorePayload)
+    def post(
+        self,
+        req_data: CompletionMessageExplorePayload,
+        session: Session,
+        current_user: Account,
+        installed_app: InstalledApp,
+    ):
         app_model = installed_app.app_with_session(session=session)
         if app_model is None:
             raise AppUnavailableError()
         if app_model.mode != AppMode.COMPLETION:
             raise NotCompletionAppError()
 
-        payload = CompletionMessageExplorePayload.model_validate(console_ns.payload or {})
-        args = payload.model_dump(exclude_none=True)
+        args = req_data.model_dump(exclude_none=True)
 
-        streaming = payload.response_mode == "streaming"
+        streaming = req_data.response_mode == "streaming"
         args["auto_generate_name"] = False
 
         installed_app.last_used_at = naive_utc_now()
@@ -173,7 +179,8 @@ class ChatApi(InstalledAppResource):
     @console_ns.response(200, "Success")
     @with_current_user
     @with_session
-    def post(self, session: Session, current_user: Account, installed_app: InstalledApp):
+    @model_validate(ChatMessagePayload)
+    def post(self, req_data: ChatMessagePayload, session: Session, current_user: Account, installed_app: InstalledApp):
         app_model = installed_app.app_with_session(session=session)
         if app_model is None:
             raise AppUnavailableError()
@@ -181,8 +188,7 @@ class ChatApi(InstalledAppResource):
         if app_mode not in {AppMode.CHAT, AppMode.AGENT_CHAT, AppMode.ADVANCED_CHAT}:
             raise NotChatAppError()
 
-        payload = ChatMessagePayload.model_validate(console_ns.payload or {})
-        args = payload.model_dump(exclude_none=True)
+        args = req_data.model_dump(exclude_none=True)
 
         args["auto_generate_name"] = False
 
@@ -191,10 +197,10 @@ class ChatApi(InstalledAppResource):
 
         try:
             # Eagerly validate conversation to avoid hanging on invalid conversation_id
-            if payload.conversation_id:
+            if req_data.conversation_id:
                 ConversationService.get_conversation(
                     app_model=app_model,
-                    conversation_id=payload.conversation_id,
+                    conversation_id=req_data.conversation_id,
                     user=current_user,
                     session=session,
                 )

--- a/api/controllers/console/explore/conversation.py
+++ b/api/controllers/console/explore/conversation.py
@@ -11,7 +11,7 @@ from controllers.common.schema import query_params_from_model, register_response
 from controllers.console.app.error import AppUnavailableError
 from controllers.console.explore.error import NotChatAppError
 from controllers.console.explore.wraps import InstalledAppResource
-from controllers.console.wraps import with_current_user
+from controllers.console.wraps import model_validate, with_current_user
 from core.app.entities.app_invoke_entities import InvokeFrom
 from extensions.ext_database import db
 from fields.conversation_fields import (
@@ -133,7 +133,8 @@ class ConversationRenameApi(InstalledAppResource):
     @console_ns.expect(console_ns.models[ConversationRenamePayload.__name__])
     @console_ns.response(200, "Conversation renamed successfully", console_ns.models[SimpleConversation.__name__])
     @with_current_user
-    def post(self, current_user: Account, installed_app: InstalledApp, c_id: UUID):
+    @model_validate(ConversationRenamePayload)
+    def post(self, req_data: ConversationRenamePayload, current_user: Account, installed_app: InstalledApp, c_id: UUID):
         app_model = installed_app.app_with_session(session=db.session())
         if app_model is None:
             raise AppUnavailableError()
@@ -143,12 +144,10 @@ class ConversationRenameApi(InstalledAppResource):
 
         conversation_id = str(c_id)
 
-        payload = ConversationRenamePayload.model_validate(console_ns.payload or {})
-
         try:
             session = db.session()
             conversation = ConversationService.rename(
-                app_model, conversation_id, current_user, payload.name, payload.auto_generate, session=session
+                app_model, conversation_id, current_user, req_data.name, req_data.auto_generate, session=session
             )
             return (
                 TypeAdapter(SimpleConversation)

--- a/api/controllers/console/explore/installed_app.py
+++ b/api/controllers/console/explore/installed_app.py
@@ -15,6 +15,7 @@ from controllers.console.explore.wraps import InstalledAppResource
 from controllers.console.wraps import (
     account_initialization_required,
     cloud_edition_billing_resource_check,
+    model_validate,
     with_current_tenant_id,
     with_current_user,
 )
@@ -195,16 +196,15 @@ class InstalledAppsListApi(Resource):
     @console_ns.expect(console_ns.models[InstalledAppCreatePayload.__name__])
     @console_ns.response(200, "Success", console_ns.models[SimpleMessageResponse.__name__])
     @with_current_tenant_id
-    def post(self, current_tenant_id: str):
-        payload = InstalledAppCreatePayload.model_validate(console_ns.payload or {})
-
+    @model_validate(InstalledAppCreatePayload)
+    def post(self, req_data: InstalledAppCreatePayload, current_tenant_id: str):
         recommended_app = db.session.scalar(
-            select(RecommendedApp).where(RecommendedApp.app_id == payload.app_id).limit(1)
+            select(RecommendedApp).where(RecommendedApp.app_id == req_data.app_id).limit(1)
         )
         if recommended_app is None:
             raise NotFound("Recommended app not found")
 
-        app = db.session.get(App, payload.app_id)
+        app = db.session.get(App, req_data.app_id)
 
         if app is None:
             raise NotFound("App entity not found")
@@ -214,7 +214,7 @@ class InstalledAppsListApi(Resource):
 
         installed_app = db.session.scalar(
             select(InstalledApp)
-            .where(and_(InstalledApp.app_id == payload.app_id, InstalledApp.tenant_id == current_tenant_id))
+            .where(and_(InstalledApp.app_id == req_data.app_id, InstalledApp.tenant_id == current_tenant_id))
             .limit(1)
         )
 
@@ -223,7 +223,7 @@ class InstalledAppsListApi(Resource):
             recommended_app.install_count += 1
 
             new_installed_app = InstalledApp(
-                app_id=payload.app_id,
+                app_id=req_data.app_id,
                 tenant_id=current_tenant_id,
                 app_owner_tenant_id=app.tenant_id,
                 is_pinned=False,
@@ -281,12 +281,11 @@ class InstalledAppApi(InstalledAppResource):
 
     @console_ns.response(200, "Success", console_ns.models[SimpleResultMessageResponse.__name__])
     @console_ns.expect(console_ns.models[InstalledAppUpdatePayload.__name__])
-    def patch(self, installed_app: InstalledApp):
-        payload = InstalledAppUpdatePayload.model_validate(console_ns.payload or {})
-
+    @model_validate(InstalledAppUpdatePayload)
+    def patch(self, req_data: InstalledAppUpdatePayload, installed_app: InstalledApp):
         commit_args = False
-        if payload.is_pinned is not None:
-            installed_app.is_pinned = payload.is_pinned
+        if req_data.is_pinned is not None:
+            installed_app.is_pinned = req_data.is_pinned
             commit_args = True
 
         if commit_args:

--- a/api/controllers/console/explore/message.py
+++ b/api/controllers/console/explore/message.py
@@ -24,7 +24,7 @@ from controllers.console.explore.error import (
     NotCompletionAppError,
 )
 from controllers.console.explore.wraps import InstalledAppResource
-from controllers.console.wraps import with_current_user
+from controllers.console.wraps import model_validate, with_current_user
 from core.app.entities.app_invoke_entities import InvokeFrom
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from extensions.ext_database import db
@@ -119,22 +119,23 @@ class MessageFeedbackApi(InstalledAppResource):
     @console_ns.expect(console_ns.models[MessageFeedbackPayload.__name__])
     @console_ns.response(200, "Feedback submitted successfully", console_ns.models[ResultResponse.__name__])
     @with_current_user
-    def post(self, current_user: Account, installed_app: InstalledApp, message_id: UUID):
+    @model_validate(MessageFeedbackPayload)
+    def post(
+        self, req_data: MessageFeedbackPayload, current_user: Account, installed_app: InstalledApp, message_id: UUID
+    ):
         app_model = installed_app.app_with_session(session=db.session())
         if app_model is None:
             raise AppUnavailableError()
 
         message_id_str = str(message_id)
 
-        payload = MessageFeedbackPayload.model_validate(console_ns.payload or {})
-
         try:
             MessageService.create_feedback(
                 app_model=app_model,
                 message_id=message_id_str,
                 user=current_user,
-                rating=FeedbackRating(payload.rating) if payload.rating else None,
-                content=payload.content,
+                rating=FeedbackRating(req_data.rating) if req_data.rating else None,
+                content=req_data.content,
                 session=db.session(),
             )
         except MessageNotExistsError:

--- a/api/controllers/console/explore/saved_message.py
+++ b/api/controllers/console/explore/saved_message.py
@@ -10,7 +10,7 @@ from controllers.console import console_ns
 from controllers.console.app.error import AppUnavailableError
 from controllers.console.explore.error import NotCompletionAppError
 from controllers.console.explore.wraps import InstalledAppResource
-from controllers.console.wraps import with_current_user
+from controllers.console.wraps import model_validate, with_current_user
 from extensions.ext_database import db
 from fields.conversation_fields import MessageResponseSource, ResultResponse
 from fields.message_fields import SavedMessageInfiniteScrollPagination, SavedMessageItem
@@ -55,17 +55,16 @@ class SavedMessageListApi(InstalledAppResource):
     @console_ns.expect(console_ns.models[SavedMessageCreatePayload.__name__])
     @console_ns.response(200, "Success", console_ns.models[ResultResponse.__name__])
     @with_current_user
-    def post(self, current_user: Account, installed_app: InstalledApp):
+    @model_validate(SavedMessageCreatePayload)
+    def post(self, req_data: SavedMessageCreatePayload, current_user: Account, installed_app: InstalledApp):
         app_model = installed_app.app_with_session(session=db.session())
         if app_model is None:
             raise AppUnavailableError()
         if app_model.mode != "completion":
             raise NotCompletionAppError()
 
-        payload = SavedMessageCreatePayload.model_validate(console_ns.payload or {})
-
         try:
-            SavedMessageService.save(app_model, current_user, str(payload.message_id), session=db.session())
+            SavedMessageService.save(app_model, current_user, str(req_data.message_id), session=db.session())
         except MessageNotExistsError:
             raise NotFound("Message Not Exists.")
 

--- a/api/tests/test_containers_integration_tests/controllers/console/explore/test_conversation.py
+++ b/api/tests/test_containers_integration_tests/controllers/console/explore/test_conversation.py
@@ -198,7 +198,13 @@ class TestConversationRenameApi:
                 return_value=conversation,
             ),
         ):
-            result = method(api, user, chat_app, "cid")
+            result = method(
+                api,
+                conversation_module.ConversationRenamePayload.model_validate({"name": "new"}),
+                user,
+                chat_app,
+                "cid",
+            )
 
         assert result["id"] == "cid"
 
@@ -215,7 +221,13 @@ class TestConversationRenameApi:
             ),
         ):
             with pytest.raises(NotFound):
-                method(api, user, chat_app, "cid")
+                method(
+                    api,
+                    conversation_module.ConversationRenamePayload.model_validate({"name": "new"}),
+                    user,
+                    chat_app,
+                    "cid",
+                )
 
 
 class TestConversationPinApi:

--- a/api/tests/unit_tests/controllers/console/explore/test_audio.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_audio.py
@@ -273,7 +273,10 @@ class TestChatTextApi:
             ),
             patch.object(audio_module.AudioService, "transcript_tts", transcript_tts),
         ):
-            resp = self.method(installed_app)
+            resp = self.method(
+                audio_module.TextToAudioPayload.model_validate({"message_id": "m1", "text": "hello", "voice": "v1"}),
+                installed_app,
+            )
 
         assert resp == {"audio": "ok"}
         assert transcript_tts.call_args.kwargs["message_ref"] == MessageRef(
@@ -295,7 +298,7 @@ class TestChatTextApi:
             ),
         ):
             with pytest.raises(ProviderNotInitializeError):
-                self.method(installed_app)
+                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)
 
     def test_model_not_supported(self, app: Flask, installed_app):
         with (
@@ -310,7 +313,7 @@ class TestChatTextApi:
             ),
         ):
             with pytest.raises(ProviderModelCurrentlyNotSupportError):
-                self.method(installed_app)
+                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)
 
     def test_invoke_error(self, app: Flask, installed_app):
         with (
@@ -325,7 +328,7 @@ class TestChatTextApi:
             ),
         ):
             with pytest.raises(CompletionRequestError):
-                self.method(installed_app)
+                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)
 
     def test_unknown_exception(self, app: Flask, installed_app):
         with (
@@ -340,7 +343,7 @@ class TestChatTextApi:
             ),
         ):
             with pytest.raises(InternalServerError):
-                self.method(installed_app)
+                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)
 
     def test_app_unavailable_tts(self, app: Flask, installed_app):
         with (
@@ -355,7 +358,7 @@ class TestChatTextApi:
             ),
         ):
             with pytest.raises(AppUnavailableError):
-                self.method(installed_app)
+                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)
 
     def test_no_audio_uploaded_tts(self, app: Flask, installed_app):
         with (
@@ -370,7 +373,7 @@ class TestChatTextApi:
             ),
         ):
             with pytest.raises(NoAudioUploadedError):
-                self.method(installed_app)
+                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)
 
     def test_audio_too_large_tts(self, app: Flask, installed_app):
         with (
@@ -385,7 +388,7 @@ class TestChatTextApi:
             ),
         ):
             with pytest.raises(AudioTooLargeError):
-                self.method(installed_app)
+                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)
 
     def test_unsupported_audio_type_tts(self, app: Flask, installed_app):
         with (
@@ -400,7 +403,7 @@ class TestChatTextApi:
             ),
         ):
             with pytest.raises(audio_module.UnsupportedAudioTypeError):
-                self.method(installed_app)
+                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)
 
     def test_provider_not_support_speech_to_text_tts(self, app: Flask, installed_app):
         with (
@@ -415,7 +418,7 @@ class TestChatTextApi:
             ),
         ):
             with pytest.raises(audio_module.ProviderNotSupportSpeechToTextError):
-                self.method(installed_app)
+                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)
 
     def test_quota_exceeded_tts(self, app: Flask, installed_app):
         with (
@@ -430,4 +433,4 @@ class TestChatTextApi:
             ),
         ):
             with pytest.raises(ProviderQuotaExceededError):
-                self.method(installed_app)
+                self.method(audio_module.TextToAudioPayload.model_validate({"text": "hi"}), installed_app)

--- a/api/tests/unit_tests/controllers/console/explore/test_completion.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_completion.py
@@ -57,7 +57,7 @@ def payload_patch(payload_data):
 
 
 class TestCompletionApi:
-    def test_post_success(self, app: Flask, completion_app, user, payload_patch):
+    def test_post_success(self, app: Flask, completion_app, user, payload_patch, payload_data):
         api = completion_module.CompletionApi()
         method = unwrap(api.post)
 
@@ -75,7 +75,13 @@ class TestCompletionApi:
                 return_value=("ok", 200),
             ),
         ):
-            result = method(api, MagicMock(), user, completion_app)
+            result = method(
+                api,
+                completion_module.CompletionMessageExplorePayload.model_validate(payload_data),
+                MagicMock(),
+                user,
+                completion_app,
+            )
 
         assert result == ("ok", 200)
 
@@ -86,9 +92,15 @@ class TestCompletionApi:
         installed_app = _installed_app(AppMode.CHAT)
 
         with pytest.raises(NotCompletionAppError):
-            method(api, MagicMock(), user, installed_app)
+            method(
+                api,
+                completion_module.CompletionMessageExplorePayload.model_validate({"inputs": {}, "query": "hi"}),
+                MagicMock(),
+                user,
+                installed_app,
+            )
 
-    def test_conversation_completed(self, app: Flask, completion_app, user, payload_patch):
+    def test_conversation_completed(self, app: Flask, completion_app, user, payload_patch, payload_data):
         api = completion_module.CompletionApi()
         method = unwrap(api.post)
 
@@ -102,9 +114,15 @@ class TestCompletionApi:
             ),
         ):
             with pytest.raises(ConversationCompletedError):
-                method(api, MagicMock(), user, completion_app)
+                method(
+                    api,
+                    completion_module.CompletionMessageExplorePayload.model_validate(payload_data),
+                    MagicMock(),
+                    user,
+                    completion_app,
+                )
 
-    def test_internal_error(self, app: Flask, completion_app, user, payload_patch):
+    def test_internal_error(self, app: Flask, completion_app, user, payload_patch, payload_data):
         api = completion_module.CompletionApi()
         method = unwrap(api.post)
 
@@ -118,9 +136,15 @@ class TestCompletionApi:
             ),
         ):
             with pytest.raises(InternalServerError):
-                method(api, MagicMock(), user, completion_app)
+                method(
+                    api,
+                    completion_module.CompletionMessageExplorePayload.model_validate(payload_data),
+                    MagicMock(),
+                    user,
+                    completion_app,
+                )
 
-    def test_conversation_not_exists(self, app: Flask, completion_app, user, payload_patch):
+    def test_conversation_not_exists(self, app: Flask, completion_app, user, payload_patch, payload_data):
         api = completion_module.CompletionApi()
         method = unwrap(api.post)
 
@@ -134,9 +158,15 @@ class TestCompletionApi:
             ),
         ):
             with pytest.raises(completion_module.NotFound):
-                method(api, MagicMock(), user, completion_app)
+                method(
+                    api,
+                    completion_module.CompletionMessageExplorePayload.model_validate(payload_data),
+                    MagicMock(),
+                    user,
+                    completion_app,
+                )
 
-    def test_app_unavailable(self, app: Flask, completion_app, user, payload_patch):
+    def test_app_unavailable(self, app: Flask, completion_app, user, payload_patch, payload_data):
         api = completion_module.CompletionApi()
         method = unwrap(api.post)
 
@@ -150,9 +180,15 @@ class TestCompletionApi:
             ),
         ):
             with pytest.raises(completion_module.AppUnavailableError):
-                method(api, MagicMock(), user, completion_app)
+                method(
+                    api,
+                    completion_module.CompletionMessageExplorePayload.model_validate(payload_data),
+                    MagicMock(),
+                    user,
+                    completion_app,
+                )
 
-    def test_provider_not_initialized(self, app: Flask, completion_app, user, payload_patch):
+    def test_provider_not_initialized(self, app: Flask, completion_app, user, payload_patch, payload_data):
         api = completion_module.CompletionApi()
         method = unwrap(api.post)
 
@@ -166,9 +202,15 @@ class TestCompletionApi:
             ),
         ):
             with pytest.raises(completion_module.ProviderNotInitializeError):
-                method(api, MagicMock(), user, completion_app)
+                method(
+                    api,
+                    completion_module.CompletionMessageExplorePayload.model_validate(payload_data),
+                    MagicMock(),
+                    user,
+                    completion_app,
+                )
 
-    def test_quota_exceeded(self, app: Flask, completion_app, user, payload_patch):
+    def test_quota_exceeded(self, app: Flask, completion_app, user, payload_patch, payload_data):
         api = completion_module.CompletionApi()
         method = unwrap(api.post)
 
@@ -182,9 +224,15 @@ class TestCompletionApi:
             ),
         ):
             with pytest.raises(completion_module.ProviderQuotaExceededError):
-                method(api, MagicMock(), user, completion_app)
+                method(
+                    api,
+                    completion_module.CompletionMessageExplorePayload.model_validate(payload_data),
+                    MagicMock(),
+                    user,
+                    completion_app,
+                )
 
-    def test_model_not_supported(self, app: Flask, completion_app, user, payload_patch):
+    def test_model_not_supported(self, app: Flask, completion_app, user, payload_patch, payload_data):
         api = completion_module.CompletionApi()
         method = unwrap(api.post)
 
@@ -198,9 +246,15 @@ class TestCompletionApi:
             ),
         ):
             with pytest.raises(completion_module.ProviderModelCurrentlyNotSupportError):
-                method(api, MagicMock(), user, completion_app)
+                method(
+                    api,
+                    completion_module.CompletionMessageExplorePayload.model_validate(payload_data),
+                    MagicMock(),
+                    user,
+                    completion_app,
+                )
 
-    def test_invoke_error(self, app: Flask, completion_app, user, payload_patch):
+    def test_invoke_error(self, app: Flask, completion_app, user, payload_patch, payload_data):
         api = completion_module.CompletionApi()
         method = unwrap(api.post)
 
@@ -214,7 +268,13 @@ class TestCompletionApi:
             ),
         ):
             with pytest.raises(completion_module.CompletionRequestError):
-                method(api, MagicMock(), user, completion_app)
+                method(
+                    api,
+                    completion_module.CompletionMessageExplorePayload.model_validate(payload_data),
+                    MagicMock(),
+                    user,
+                    completion_app,
+                )
 
 
 class TestCompletionStopApi:
@@ -239,7 +299,7 @@ class TestCompletionStopApi:
 
 
 class TestChatApi:
-    def test_post_success(self, app: Flask, chat_app, user, payload_patch):
+    def test_post_success(self, app: Flask, chat_app, user, payload_patch, payload_data):
         api = completion_module.ChatApi()
         method = unwrap(api.post)
 
@@ -257,7 +317,9 @@ class TestChatApi:
                 return_value=("ok", 200),
             ),
         ):
-            result = method(api, MagicMock(), user, chat_app)
+            result = method(
+                api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+            )
 
         assert result == ("ok", 200)
 
@@ -268,9 +330,15 @@ class TestChatApi:
         installed_app = _installed_app(AppMode.COMPLETION)
 
         with pytest.raises(NotChatAppError):
-            method(api, MagicMock(), user, installed_app)
+            method(
+                api,
+                completion_module.ChatMessagePayload.model_validate({"inputs": {}, "query": "hi"}),
+                MagicMock(),
+                user,
+                installed_app,
+            )
 
-    def test_rate_limit_error(self, app: Flask, chat_app, user, payload_patch):
+    def test_rate_limit_error(self, app: Flask, chat_app, user, payload_patch, payload_data):
         api = completion_module.ChatApi()
         method = unwrap(api.post)
 
@@ -284,9 +352,11 @@ class TestChatApi:
             ),
         ):
             with pytest.raises(InvokeRateLimitHttpError):
-                method(api, MagicMock(), user, chat_app)
+                method(
+                    api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+                )
 
-    def test_conversation_completed_chat(self, app: Flask, chat_app, user, payload_patch):
+    def test_conversation_completed_chat(self, app: Flask, chat_app, user, payload_patch, payload_data):
         api = completion_module.ChatApi()
         method = unwrap(api.post)
 
@@ -300,9 +370,11 @@ class TestChatApi:
             ),
         ):
             with pytest.raises(ConversationCompletedError):
-                method(api, MagicMock(), user, chat_app)
+                method(
+                    api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+                )
 
-    def test_conversation_not_exists_chat(self, app: Flask, chat_app, user, payload_patch):
+    def test_conversation_not_exists_chat(self, app: Flask, chat_app, user, payload_patch, payload_data):
         api = completion_module.ChatApi()
         method = unwrap(api.post)
 
@@ -316,7 +388,9 @@ class TestChatApi:
             ),
         ):
             with pytest.raises(completion_module.NotFound):
-                method(api, MagicMock(), user, chat_app)
+                method(
+                    api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+                )
 
     def test_invalid_conversation_id_fails_fast_as_not_found(self, app: Flask, chat_app, user) -> None:
         # A nonexistent conversation_id must fail fast as 404, before the streaming
@@ -349,13 +423,21 @@ class TestChatApi:
             patch.object(completion_module.AppGenerateService, "generate", generate_mock),
         ):
             with pytest.raises(completion_module.NotFound):
-                method(api, session, user, chat_app)
+                method(
+                    api,
+                    completion_module.ChatMessagePayload.model_validate(
+                        {"inputs": {}, "query": "hi", "conversation_id": conversation_id}
+                    ),
+                    session,
+                    user,
+                    chat_app,
+                )
 
         # The lookup must run before generation, so the generator is never started.
         generate_mock.assert_not_called()
         assert get_conversation_mock.call_args.kwargs["session"] is session
 
-    def test_app_unavailable_chat(self, app: Flask, chat_app, user, payload_patch):
+    def test_app_unavailable_chat(self, app: Flask, chat_app, user, payload_patch, payload_data):
         api = completion_module.ChatApi()
         method = unwrap(api.post)
 
@@ -369,9 +451,11 @@ class TestChatApi:
             ),
         ):
             with pytest.raises(completion_module.AppUnavailableError):
-                method(api, MagicMock(), user, chat_app)
+                method(
+                    api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+                )
 
-    def test_provider_not_initialized_chat(self, app: Flask, chat_app, user, payload_patch):
+    def test_provider_not_initialized_chat(self, app: Flask, chat_app, user, payload_patch, payload_data):
         api = completion_module.ChatApi()
         method = unwrap(api.post)
 
@@ -385,9 +469,11 @@ class TestChatApi:
             ),
         ):
             with pytest.raises(completion_module.ProviderNotInitializeError):
-                method(api, MagicMock(), user, chat_app)
+                method(
+                    api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+                )
 
-    def test_quota_exceeded_chat(self, app: Flask, chat_app, user, payload_patch):
+    def test_quota_exceeded_chat(self, app: Flask, chat_app, user, payload_patch, payload_data):
         api = completion_module.ChatApi()
         method = unwrap(api.post)
 
@@ -401,9 +487,11 @@ class TestChatApi:
             ),
         ):
             with pytest.raises(completion_module.ProviderQuotaExceededError):
-                method(api, MagicMock(), user, chat_app)
+                method(
+                    api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+                )
 
-    def test_model_not_supported_chat(self, app: Flask, chat_app, user, payload_patch):
+    def test_model_not_supported_chat(self, app: Flask, chat_app, user, payload_patch, payload_data):
         api = completion_module.ChatApi()
         method = unwrap(api.post)
 
@@ -417,9 +505,11 @@ class TestChatApi:
             ),
         ):
             with pytest.raises(completion_module.ProviderModelCurrentlyNotSupportError):
-                method(api, MagicMock(), user, chat_app)
+                method(
+                    api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+                )
 
-    def test_invoke_error_chat(self, app: Flask, chat_app, user, payload_patch):
+    def test_invoke_error_chat(self, app: Flask, chat_app, user, payload_patch, payload_data):
         api = completion_module.ChatApi()
         method = unwrap(api.post)
 
@@ -433,9 +523,11 @@ class TestChatApi:
             ),
         ):
             with pytest.raises(completion_module.CompletionRequestError):
-                method(api, MagicMock(), user, chat_app)
+                method(
+                    api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+                )
 
-    def test_internal_error_chat(self, app: Flask, chat_app, user, payload_patch):
+    def test_internal_error_chat(self, app: Flask, chat_app, user, payload_patch, payload_data):
         api = completion_module.ChatApi()
         method = unwrap(api.post)
 
@@ -449,7 +541,9 @@ class TestChatApi:
             ),
         ):
             with pytest.raises(InternalServerError):
-                method(api, MagicMock(), user, chat_app)
+                method(
+                    api, completion_module.ChatMessagePayload.model_validate(payload_data), MagicMock(), user, chat_app
+                )
 
 
 class TestChatStopApi:

--- a/api/tests/unit_tests/controllers/console/explore/test_installed_app.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_installed_app.py
@@ -960,7 +960,9 @@ def test_sqlite_patch_persists_pin_and_noop_payload(
         patch.object(module.db, "session", database),
     ):
         assert (
-            unwrap(api.patch)(api, module.InstalledAppUpdatePayload.model_validate({"is_pinned": True}), installed)["result"]
+            unwrap(api.patch)(api, module.InstalledAppUpdatePayload.model_validate({"is_pinned": True}), installed)[
+                "result"
+            ]
             == "success"
         )
     database.expire_all()
@@ -973,4 +975,7 @@ def test_sqlite_patch_persists_pin_and_noop_payload(
         payload_patch({}),
         patch.object(module.db, "session", database),
     ):
-        assert unwrap(api.patch)(api, module.InstalledAppUpdatePayload.model_validate({}), installed)["result"] == "success"
+        assert (
+            unwrap(api.patch)(api, module.InstalledAppUpdatePayload.model_validate({}), installed)["result"]
+            == "success"
+        )

--- a/api/tests/unit_tests/controllers/console/explore/test_installed_app.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_installed_app.py
@@ -548,7 +548,7 @@ class TestInstalledAppsCreateApi:
             payload_patch({"app_id": "a1"}),
             patch.object(module.db, "session", session),
         ):
-            result = method(api, tenant_id)
+            result = method(api, module.InstalledAppCreatePayload.model_validate({"app_id": "a1"}), tenant_id)
 
         assert result == {"message": "App installed successfully"}
         assert recommended.install_count == 1
@@ -566,7 +566,7 @@ class TestInstalledAppsCreateApi:
             patch.object(module.db, "session", session),
         ):
             with pytest.raises(NotFound):
-                method(api, tenant_id)
+                method(api, module.InstalledAppCreatePayload.model_validate({"app_id": "a1"}), tenant_id)
 
     def test_post_app_not_public(self, app: Flask, tenant_id: str, payload_patch: PayloadPatch) -> None:
         api = module.InstalledAppsListApi()
@@ -587,7 +587,7 @@ class TestInstalledAppsCreateApi:
             patch.object(module.db, "session", session),
         ):
             with pytest.raises(Forbidden):
-                method(api, tenant_id)
+                method(api, module.InstalledAppCreatePayload.model_validate({"app_id": "a1"}), tenant_id)
 
 
 class TestInstalledAppApi:
@@ -665,7 +665,7 @@ class TestInstalledAppApi:
             payload_patch({"is_pinned": True}),
             patch.object(module.db, "session"),
         ):
-            result = method(installed_app)
+            result = method(api, module.InstalledAppUpdatePayload.model_validate({"is_pinned": True}), installed_app)
 
         assert installed_app.is_pinned is True
         assert result["result"] == "success"
@@ -675,7 +675,7 @@ class TestInstalledAppApi:
         method = unwrap(api.patch)
 
         with app.test_request_context("/", json={}), payload_patch({}), patch.object(module.db, "session"):
-            result = method(installed_app)
+            result = method(api, module.InstalledAppUpdatePayload.model_validate({}), installed_app)
 
         assert result["result"] == "success"
 
@@ -869,7 +869,9 @@ def test_sqlite_post_installs_public_recommended_app_and_is_idempotent(
             payload_patch({"app_id": app_model.id}),
             patch.object(module.db, "session", database),
         ):
-            assert method(api, tenant_id) == {"message": "App installed successfully"}
+            assert method(
+                api, module.InstalledAppCreatePayload.model_validate({"app_id": app_model.id}), tenant_id
+            ) == {"message": "App installed successfully"}
 
     # End the request-scoped session so this assertion only observes committed data.
     bind = database.get_bind()
@@ -899,7 +901,7 @@ def test_sqlite_post_enforces_recommendation_and_public_state(
         patch.object(module.db, "session", database),
         pytest.raises(NotFound),
     ):
-        method(api, tenant_id)
+        method(api, module.InstalledAppCreatePayload.model_validate({"app_id": "missing"}), tenant_id)
 
     private_app = _persist_app(database, app_id="private", public=False)
     database.add(
@@ -918,7 +920,7 @@ def test_sqlite_post_enforces_recommendation_and_public_state(
         patch.object(module.db, "session", database),
         pytest.raises(Forbidden),
     ):
-        method(api, tenant_id)
+        method(api, module.InstalledAppCreatePayload.model_validate({"app_id": private_app.id}), tenant_id)
 
 
 def test_sqlite_delete_removes_foreign_installed_app_and_rejects_owned_app(
@@ -957,7 +959,10 @@ def test_sqlite_patch_persists_pin_and_noop_payload(
         payload_patch({"is_pinned": True}),
         patch.object(module.db, "session", database),
     ):
-        assert unwrap(api.patch)(installed)["result"] == "success"
+        assert (
+            unwrap(api.patch)(api, module.InstalledAppUpdatePayload.model_validate({"is_pinned": True}), installed)["result"]
+            == "success"
+        )
     database.expire_all()
     persisted_installed_app = database.get(InstalledApp, installed.id)
     assert persisted_installed_app is not None
@@ -968,4 +973,4 @@ def test_sqlite_patch_persists_pin_and_noop_payload(
         payload_patch({}),
         patch.object(module.db, "session", database),
     ):
-        assert unwrap(api.patch)(installed)["result"] == "success"
+        assert unwrap(api.patch)(api, module.InstalledAppUpdatePayload.model_validate({}), installed)["result"] == "success"

--- a/api/tests/unit_tests/controllers/console/explore/test_message.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_message.py
@@ -160,7 +160,9 @@ class TestMessageFeedbackApi:
                 "create_feedback",
             ),
         ):
-            result = method(MagicMock(), installed_app, "mid")
+            result = method(
+                module.MessageFeedbackPayload.model_validate({"rating": "like"}), MagicMock(), installed_app, "mid"
+            )
 
         assert result["result"] == "success"
 
@@ -179,7 +181,7 @@ class TestMessageFeedbackApi:
             ),
         ):
             with pytest.raises(NotFound):
-                method(MagicMock(), installed_app, "mid")
+                method(module.MessageFeedbackPayload.model_validate({}), MagicMock(), installed_app, "mid")
 
 
 class TestMessageMoreLikeThisApi:

--- a/api/tests/unit_tests/controllers/console/explore/test_saved_message.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_saved_message.py
@@ -100,7 +100,7 @@ class TestSavedMessageListApi:
             payload_patch(payload),
             patch.object(module.SavedMessageService, "save") as save_mock,
         ):
-            result = method(api, current_user, installed_app)
+            result = method(api, module.SavedMessageCreatePayload.model_validate(payload), current_user, installed_app)
 
         save_mock.assert_called_once()
         assert save_mock.call_args.args[1] is current_user
@@ -124,7 +124,7 @@ class TestSavedMessageListApi:
             ),
         ):
             with pytest.raises(NotFound):
-                method(api, MagicMock(), installed_app)
+                method(api, module.SavedMessageCreatePayload.model_validate(payload), MagicMock(), installed_app)
 
 
 class TestSavedMessageApi:


### PR DESCRIPTION
## Description

Replace manual `*.model_validate(console_ns.payload or {})` with the `@model_validate` decorator introduced in #36750, injecting the validated payload as a method argument.

### Files changed

**Controller files:**

- `api/controllers/console/explore/saved_message.py` - `SavedMessageListApi.post`: replaced `SavedMessageCreatePayload.model_validate(console_ns.payload or {})` with `@model_validate(SavedMessageCreatePayload)`
- `api/controllers/console/explore/conversation.py` - `ConversationRenameApi.post`: replaced `ConversationRenamePayload.model_validate(console_ns.payload or {})` with `@model_validate(ConversationRenamePayload)`
- `api/controllers/console/explore/message.py` - `MessageFeedbackApi.post`: replaced `MessageFeedbackPayload.model_validate(console_ns.payload or {})` with `@model_validate(MessageFeedbackPayload)`
- `api/controllers/console/explore/audio.py` - `ChatTextApi.post`: replaced `TextToAudioPayload.model_validate(console_ns.payload or {})` with `@model_validate(TextToAudioPayload)`
- `api/controllers/console/explore/completion.py` - `CompletionApi.post` and `ChatApi.post`: replaced `CompletionMessageExplorePayload.model_validate(...)` and `ChatMessagePayload.model_validate(...)` with `@model_validate` decorators
- `api/controllers/console/explore/installed_app.py` - `InstalledAppsListApi.post` and `InstalledAppApi.patch`: replaced `InstalledAppCreatePayload.model_validate(...)` and `InstalledAppUpdatePayload.model_validate(...)` with `@model_validate` decorators

**Test files:**

- `api/tests/unit_tests/controllers/console/explore/test_saved_message.py` - Updated `unwrap()` calls to pass validated payload as first arg
- `api/tests/unit_tests/controllers/console/explore/test_message.py` - Updated calls to pass validated payload as first arg
- `api/tests/unit_tests/controllers/console/explore/test_audio.py` - Updated `ChatTextApi` test calls to pass validated payload as first arg
- `api/tests/unit_tests/controllers/console/explore/test_completion.py` - Updated `CompletionApi` and `ChatApi` test calls to pass validated payloads as first arg
- `api/tests/unit_tests/controllers/console/explore/test_installed_app.py` - Updated `InstalledAppsListApi.post` and `InstalledAppApi.patch` test calls to pass validated payloads as first arg

Related issue: #36659

## Screenshots

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes