### PR TITLE
chore: dep inject for model in workspace snippets, load balancing, and endpoint

### DIFF
--- a/api/controllers/console/workspace/endpoint.py
+++ b/api/controllers/console/workspace/endpoint.py
@@ -23,6 +23,7 @@ from controllers.console.wraps import (
     RBACResourceScope,
     account_initialization_required,
     is_admin_or_owner_required,
+    model_validate,
     rbac_permission_required,
     setup_required,
     with_current_tenant_id,
@@ -166,43 +167,38 @@ register_response_schema_models(
 )
 
 
-def _create_endpoint(tenant_id: str, user_id: str) -> bool:
+def _create_endpoint(tenant_id: str, user_id: str, req_data: EndpointCreatePayload) -> bool:
     """Create a plugin endpoint for the injected workspace and user."""
-    args = EndpointCreatePayload.model_validate(console_ns.payload)
-
     try:
         return EndpointService.create_endpoint(
             tenant_id=tenant_id,
             user_id=user_id,
-            plugin_unique_identifier=args.plugin_unique_identifier,
-            name=args.name,
-            settings=args.settings,
+            plugin_unique_identifier=req_data.plugin_unique_identifier,
+            name=req_data.name,
+            settings=req_data.settings,
         )
     except PluginPermissionDeniedError as e:
         raise ValueError(e.description) from e
 
 
-def _update_endpoint(tenant_id: str, user_id: str, endpoint_id: str) -> bool:
+def _update_endpoint(tenant_id: str, user_id: str, endpoint_id: str, req_data: EndpointUpdatePayload) -> bool:
     """Update a plugin endpoint identified by the canonical path parameter."""
-    args = EndpointUpdatePayload.model_validate(console_ns.payload)
-
     return EndpointService.update_endpoint(
         tenant_id=tenant_id,
         user_id=user_id,
         endpoint_id=endpoint_id,
-        name=args.name,
-        settings=args.settings,
+        name=req_data.name,
+        settings=req_data.settings,
     )
 
 
-def _legacy_update_endpoint(tenant_id: str, user_id: str) -> bool:
-    args = LegacyEndpointUpdatePayload.model_validate(console_ns.payload)
+def _legacy_update_endpoint(tenant_id: str, user_id: str, req_data: LegacyEndpointUpdatePayload) -> bool:
     return EndpointService.update_endpoint(
         tenant_id=tenant_id,
         user_id=user_id,
-        endpoint_id=args.endpoint_id,
-        name=args.name,
-        settings=args.settings,
+        endpoint_id=req_data.endpoint_id,
+        name=req_data.name,
+        settings=req_data.settings,
     )
 
 
@@ -215,15 +211,13 @@ def _delete_endpoint(tenant_id: str, user_id: str, endpoint_id: str) -> bool:
     )
 
 
-def _delete_endpoint_from_payload(tenant_id: str, user_id: str) -> bool:
-    args = EndpointIdPayload.model_validate(console_ns.payload)
-    return _delete_endpoint(tenant_id=tenant_id, user_id=user_id, endpoint_id=args.endpoint_id)
+def _delete_endpoint_from_payload(tenant_id: str, user_id: str, req_data: EndpointIdPayload) -> bool:
+    return _delete_endpoint(tenant_id=tenant_id, user_id=user_id, endpoint_id=req_data.endpoint_id)
 
 
-def _set_endpoint_enabled(tenant_id: str, user_id: str, *, enabled: bool) -> bool:
-    args = EndpointIdPayload.model_validate(console_ns.payload)
+def _set_endpoint_enabled(tenant_id: str, user_id: str, req_data: EndpointIdPayload, *, enabled: bool) -> bool:
     action = EndpointService.enable_endpoint if enabled else EndpointService.disable_endpoint
-    return action(tenant_id=tenant_id, user_id=user_id, endpoint_id=args.endpoint_id)
+    return action(tenant_id=tenant_id, user_id=user_id, endpoint_id=req_data.endpoint_id)
 
 
 @console_ns.route("/workspaces/current/endpoints")
@@ -246,8 +240,11 @@ class EndpointCollectionApi(Resource):
     @account_initialization_required
     @with_current_user_id
     @with_current_tenant_id
-    def post(self, tenant_id: str, user_id: str):
-        return SuccessResponse(success=_create_endpoint(tenant_id=tenant_id, user_id=user_id)).model_dump(mode="json")
+    @model_validate(EndpointCreatePayload)
+    def post(self, req_data: EndpointCreatePayload, tenant_id: str, user_id: str):
+        return SuccessResponse(
+            success=_create_endpoint(tenant_id=tenant_id, user_id=user_id, req_data=req_data)
+        ).model_dump(mode="json")
 
 
 @console_ns.route("/workspaces/current/endpoints/create")
@@ -275,8 +272,11 @@ class DeprecatedEndpointCreateApi(Resource):
     @account_initialization_required
     @with_current_user_id
     @with_current_tenant_id
-    def post(self, tenant_id: str, user_id: str):
-        return SuccessResponse(success=_create_endpoint(tenant_id=tenant_id, user_id=user_id)).model_dump(mode="json")
+    @model_validate(EndpointCreatePayload)
+    def post(self, req_data: EndpointCreatePayload, tenant_id: str, user_id: str):
+        return SuccessResponse(
+            success=_create_endpoint(tenant_id=tenant_id, user_id=user_id, req_data=req_data)
+        ).model_dump(mode="json")
 
 
 @console_ns.route("/workspaces/current/endpoints/list")
@@ -378,9 +378,10 @@ class EndpointItemApi(Resource):
     @account_initialization_required
     @with_current_user_id
     @with_current_tenant_id
-    def patch(self, tenant_id: str, user_id: str, id: str):
+    @model_validate(EndpointUpdatePayload)
+    def patch(self, req_data: EndpointUpdatePayload, tenant_id: str, user_id: str, id: str):
         return SuccessResponse(
-            success=_update_endpoint(tenant_id=tenant_id, user_id=user_id, endpoint_id=id)
+            success=_update_endpoint(tenant_id=tenant_id, user_id=user_id, endpoint_id=id, req_data=req_data)
         ).model_dump(mode="json")
 
 
@@ -410,10 +411,11 @@ class DeprecatedEndpointDeleteApi(Resource):
     @account_initialization_required
     @with_current_user_id
     @with_current_tenant_id
-    def post(self, tenant_id: str, user_id: str):
-        return SuccessResponse(success=_delete_endpoint_from_payload(tenant_id=tenant_id, user_id=user_id)).model_dump(
-            mode="json"
-        )
+    @model_validate(EndpointIdPayload)
+    def post(self, req_data: EndpointIdPayload, tenant_id: str, user_id: str):
+        return SuccessResponse(
+            success=_delete_endpoint_from_payload(tenant_id=tenant_id, user_id=user_id, req_data=req_data)
+        ).model_dump(mode="json")
 
 
 @console_ns.route("/workspaces/current/endpoints/update")
@@ -442,10 +444,11 @@ class DeprecatedEndpointUpdateApi(Resource):
     @account_initialization_required
     @with_current_user_id
     @with_current_tenant_id
-    def post(self, tenant_id: str, user_id: str):
-        return SuccessResponse(success=_legacy_update_endpoint(tenant_id=tenant_id, user_id=user_id)).model_dump(
-            mode="json"
-        )
+    @model_validate(LegacyEndpointUpdatePayload)
+    def post(self, req_data: LegacyEndpointUpdatePayload, tenant_id: str, user_id: str):
+        return SuccessResponse(
+            success=_legacy_update_endpoint(tenant_id=tenant_id, user_id=user_id, req_data=req_data)
+        ).model_dump(mode="json")
 
 
 @console_ns.route("/workspaces/current/endpoints/enable")
@@ -466,9 +469,10 @@ class EndpointEnableApi(Resource):
     @account_initialization_required
     @with_current_user_id
     @with_current_tenant_id
-    def post(self, tenant_id: str, user_id: str):
+    @model_validate(EndpointIdPayload)
+    def post(self, req_data: EndpointIdPayload, tenant_id: str, user_id: str):
         return SuccessResponse(
-            success=_set_endpoint_enabled(tenant_id=tenant_id, user_id=user_id, enabled=True)
+            success=_set_endpoint_enabled(tenant_id=tenant_id, user_id=user_id, req_data=req_data, enabled=True)
         ).model_dump(mode="json")
 
 
@@ -490,7 +494,8 @@ class EndpointDisableApi(Resource):
     @account_initialization_required
     @with_current_user_id
     @with_current_tenant_id
-    def post(self, tenant_id: str, user_id: str):
+    @model_validate(EndpointIdPayload)
+    def post(self, req_data: EndpointIdPayload, tenant_id: str, user_id: str):
         return SuccessResponse(
-            success=_set_endpoint_enabled(tenant_id=tenant_id, user_id=user_id, enabled=False)
+            success=_set_endpoint_enabled(tenant_id=tenant_id, user_id=user_id, req_data=req_data, enabled=False)
         ).model_dump(mode="json")

--- a/api/controllers/console/workspace/load_balancing_config.py
+++ b/api/controllers/console/workspace/load_balancing_config.py
@@ -6,6 +6,7 @@ from controllers.common.schema import register_response_schema_models, register_
 from controllers.console import console_ns
 from controllers.console.wraps import (
     account_initialization_required,
+    model_validate,
     setup_required,
     with_current_tenant_id,
     with_current_user,
@@ -49,13 +50,14 @@ class LoadBalancingCredentialsValidateApi(Resource):
     @account_initialization_required
     @with_current_user
     @with_current_tenant_id
-    def post(self, current_tenant_id: str, current_user: Account, provider: str):
+    @model_validate(LoadBalancingCredentialPayload)
+    def post(
+        self, req_data: LoadBalancingCredentialPayload, current_tenant_id: str, current_user: Account, provider: str
+    ):
         if not TenantAccountRole.is_privileged_role(current_user.current_role):
             raise Forbidden()
 
         tenant_id = current_tenant_id
-
-        payload = LoadBalancingCredentialPayload.model_validate(console_ns.payload or {})
 
         # validate model load balancing credentials
         model_load_balancing_service = ModelLoadBalancingService()
@@ -67,9 +69,9 @@ class LoadBalancingCredentialsValidateApi(Resource):
             model_load_balancing_service.validate_load_balancing_credentials(
                 tenant_id=tenant_id,
                 provider=provider,
-                model=payload.model,
-                model_type=payload.model_type,
-                credentials=payload.credentials,
+                model=req_data.model,
+                model_type=req_data.model_type,
+                credentials=req_data.credentials,
                 session=db.session(),
             )
         except CredentialsValidateFailedError as ex:
@@ -99,13 +101,19 @@ class LoadBalancingConfigCredentialsValidateApi(Resource):
     @account_initialization_required
     @with_current_user
     @with_current_tenant_id
-    def post(self, current_tenant_id: str, current_user: Account, provider: str, config_id: str):
+    @model_validate(LoadBalancingCredentialPayload)
+    def post(
+        self,
+        req_data: LoadBalancingCredentialPayload,
+        current_tenant_id: str,
+        current_user: Account,
+        provider: str,
+        config_id: str,
+    ):
         if not TenantAccountRole.is_privileged_role(current_user.current_role):
             raise Forbidden()
 
         tenant_id = current_tenant_id
-
-        payload = LoadBalancingCredentialPayload.model_validate(console_ns.payload or {})
 
         # validate model load balancing config credentials
         model_load_balancing_service = ModelLoadBalancingService()
@@ -117,9 +125,9 @@ class LoadBalancingConfigCredentialsValidateApi(Resource):
             model_load_balancing_service.validate_load_balancing_credentials(
                 tenant_id=tenant_id,
                 provider=provider,
-                model=payload.model,
-                model_type=payload.model_type,
-                credentials=payload.credentials,
+                model=req_data.model,
+                model_type=req_data.model_type,
+                credentials=req_data.credentials,
                 session=db.session(),
                 config_id=config_id,
             )

--- a/api/controllers/console/workspace/snippets.py
+++ b/api/controllers/console/workspace/snippets.py
@@ -27,6 +27,7 @@ from controllers.console.wraps import (
     RBACResourceScope,
     account_initialization_required,
     edit_permission_required,
+    model_validate,
     rbac_permission_required,
     setup_required,
     with_current_tenant_id,
@@ -151,27 +152,26 @@ class CustomizedSnippetsApi(Resource):
     )
     @with_current_user
     @with_current_tenant_id
-    def post(self, current_tenant_id: str, current_user: Account):
+    @model_validate(CreateSnippetPayload)
+    def post(self, req_data: CreateSnippetPayload, current_tenant_id: str, current_user: Account):
         """Create a new customized snippet."""
-        payload = CreateSnippetPayload.model_validate(console_ns.payload or {})
-
         try:
-            snippet_type = SnippetType(payload.type)
+            snippet_type = SnippetType(req_data.type)
         except ValueError:
             snippet_type = SnippetType.NODE
 
         try:
-            if payload.graph is not None:
-                SnippetService.validate_snippet_graph_forbidden_nodes(payload.graph)
+            if req_data.graph is not None:
+                SnippetService.validate_snippet_graph_forbidden_nodes(req_data.graph)
 
             snippet_service = _snippet_service()
             snippet = snippet_service.create_snippet(
                 tenant_id=current_tenant_id,
-                name=payload.name,
-                description=payload.description,
+                name=req_data.name,
+                description=req_data.description,
                 snippet_type=snippet_type,
-                icon_info=payload.icon_info.model_dump() if payload.icon_info else None,
-                input_fields=[f.model_dump() for f in payload.input_fields] if payload.input_fields else None,
+                icon_info=req_data.icon_info.model_dump() if req_data.icon_info else None,
+                input_fields=[f.model_dump() for f in req_data.input_fields] if req_data.input_fields else None,
                 account=current_user,
             )
         except ValueError as e:
@@ -216,7 +216,8 @@ class CustomizedSnippetDetailApi(Resource):
     )
     @with_current_user
     @with_current_tenant_id
-    def patch(self, current_tenant_id: str, current_user: Account, snippet_id: str):
+    @model_validate(UpdateSnippetPayload)
+    def patch(self, req_data: UpdateSnippetPayload, current_tenant_id: str, current_user: Account, snippet_id: str):
         """Update customized snippet."""
         snippet_service = _snippet_service()
         snippet = snippet_service.get_snippet_by_id(
@@ -227,11 +228,10 @@ class CustomizedSnippetDetailApi(Resource):
         if not snippet:
             raise NotFound("Snippet not found")
 
-        payload = UpdateSnippetPayload.model_validate(console_ns.payload or {})
-        update_data = payload.model_dump(exclude_unset=True)
+        update_data = req_data.model_dump(exclude_unset=True)
 
         if "icon_info" in update_data and update_data["icon_info"] is not None:
-            update_data["icon_info"] = payload.icon_info.model_dump() if payload.icon_info else None
+            update_data["icon_info"] = req_data.icon_info.model_dump() if req_data.icon_info else None
 
         if not update_data:
             return {"message": "No valid fields to update"}, 400
@@ -349,19 +349,18 @@ class CustomizedSnippetImportApi(Resource):
     )
     @with_current_user
     @with_session
-    def post(self, session: Session, current_user: Account):
+    @model_validate(SnippetImportPayload)
+    def post(self, req_data: SnippetImportPayload, session: Session, current_user: Account):
         """Import snippet from DSL."""
-        payload = SnippetImportPayload.model_validate(console_ns.payload or {})
-
         import_service = SnippetDslService(session)
         result = import_service.import_snippet(
             account=current_user,
-            import_mode=payload.mode,
-            yaml_content=payload.yaml_content,
-            yaml_url=payload.yaml_url,
-            snippet_id=payload.snippet_id,
-            name=payload.name,
-            description=payload.description,
+            import_mode=req_data.mode,
+            yaml_content=req_data.yaml_content,
+            yaml_url=req_data.yaml_url,
+            snippet_id=req_data.snippet_id,
+            name=req_data.name,
+            description=req_data.description,
         )
 
         # Return appropriate status code based on result

--- a/api/tests/unit_tests/controllers/console/workspace/test_endpoint.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_endpoint.py
@@ -11,11 +11,15 @@ from controllers.console.workspace.endpoint import (
     DeprecatedEndpointDeleteApi,
     DeprecatedEndpointUpdateApi,
     EndpointCollectionApi,
+    EndpointCreatePayload,
     EndpointDisableApi,
     EndpointEnableApi,
+    EndpointIdPayload,
     EndpointItemApi,
     EndpointListApi,
     EndpointListForSinglePluginApi,
+    EndpointUpdatePayload,
+    LegacyEndpointUpdatePayload,
 )
 from core.entities.provider_entities import ProviderConfig, ProviderConfigType
 from core.plugin.entities.endpoint import EndpointEntityWithInstance, EndpointProviderDeclaration
@@ -60,12 +64,13 @@ class TestEndpointCollectionApi:
             "name": "endpoint",
             "settings": {"a": 1},
         }
+        req_data = EndpointCreatePayload(**payload)
 
         with (
             app.test_request_context("/", json=payload),
             patch("controllers.console.workspace.endpoint.EndpointService.create_endpoint", return_value=True),
         ):
-            result = method(api, "t1", "u1")
+            result = method(api, req_data, "t1", "u1")
 
         assert result["success"] is True
 
@@ -78,6 +83,7 @@ class TestEndpointCollectionApi:
             "name": "endpoint",
             "settings": {},
         }
+        req_data = EndpointCreatePayload(**payload)
 
         with (
             app.test_request_context("/", json=payload),
@@ -87,7 +93,7 @@ class TestEndpointCollectionApi:
             ),
         ):
             with pytest.raises(ValueError):
-                method(api, "t1", "u1")
+                method(api, req_data, "t1", "u1")
 
     def test_create_validation_error(self, app: Flask):
         api = EndpointCollectionApi()
@@ -103,7 +109,7 @@ class TestEndpointCollectionApi:
             app.test_request_context("/", json=payload),
         ):
             with pytest.raises(ValueError):
-                method(api, "t1", "u1")
+                method(api, EndpointCreatePayload(**payload), "t1", "u1")
 
 
 class TestDeprecatedEndpointCreateApi:
@@ -116,12 +122,13 @@ class TestDeprecatedEndpointCreateApi:
             "name": "endpoint",
             "settings": {"a": 1},
         }
+        req_data = EndpointCreatePayload(**payload)
 
         with (
             app.test_request_context("/", json=payload),
             patch("controllers.console.workspace.endpoint.EndpointService.create_endpoint", return_value=True),
         ):
-            result = method(api, "t1", "u1")
+            result = method(api, req_data, "t1", "u1")
 
         assert result["success"] is True
 
@@ -242,6 +249,7 @@ class TestEndpointItemApi:
             "name": "new-name",
             "settings": {"x": 1},
         }
+        req_data = EndpointUpdatePayload(**payload)
 
         with (
             app.test_request_context("/", method="PATCH", json=payload),
@@ -250,7 +258,7 @@ class TestEndpointItemApi:
                 return_value=True,
             ) as mock_update,
         ):
-            result = method(api, "t1", "u1", "e1")
+            result = method(api, req_data, "t1", "u1", "e1")
 
         assert result["success"] is True
         mock_update.assert_called_once_with(
@@ -271,7 +279,7 @@ class TestEndpointItemApi:
             app.test_request_context("/", method="PATCH", json=payload),
         ):
             with pytest.raises(ValueError):
-                method(api, "t1", "u1", "e1")
+                method(api, EndpointUpdatePayload(**payload), "t1", "u1", "e1")
 
     def test_update_service_failure(self, app: Flask):
         api = EndpointItemApi()
@@ -281,12 +289,13 @@ class TestEndpointItemApi:
             "name": "n",
             "settings": {},
         }
+        req_data = EndpointUpdatePayload(**payload)
 
         with (
             app.test_request_context("/", method="PATCH", json=payload),
             patch("controllers.console.workspace.endpoint.EndpointService.update_endpoint", return_value=False),
         ):
-            result = method(api, "t1", "u1", "e1")
+            result = method(api, req_data, "t1", "u1", "e1")
 
         assert result["success"] is False
 
@@ -297,12 +306,13 @@ class TestDeprecatedEndpointDeleteApi:
         method = inspect.unwrap(api.post)
 
         payload = {"endpoint_id": "e1"}
+        req_data = EndpointIdPayload(**payload)
 
         with (
             app.test_request_context("/", json=payload),
             patch("controllers.console.workspace.endpoint.EndpointService.delete_endpoint", return_value=True),
         ):
-            result = method(api, "t1", "u1")
+            result = method(api, req_data, "t1", "u1")
 
         assert result["success"] is True
 
@@ -314,19 +324,20 @@ class TestDeprecatedEndpointDeleteApi:
             app.test_request_context("/", json={}),
         ):
             with pytest.raises(ValueError):
-                method(api, "t1", "u1")
+                method(api, EndpointIdPayload(), "t1", "u1")
 
     def test_delete_service_failure(self, app: Flask):
         api = DeprecatedEndpointDeleteApi()
         method = inspect.unwrap(api.post)
 
         payload = {"endpoint_id": "e1"}
+        req_data = EndpointIdPayload(**payload)
 
         with (
             app.test_request_context("/", json=payload),
             patch("controllers.console.workspace.endpoint.EndpointService.delete_endpoint", return_value=False),
         ):
-            result = method(api, "t1", "u1")
+            result = method(api, req_data, "t1", "u1")
 
         assert result["success"] is False
 
@@ -341,12 +352,13 @@ class TestDeprecatedEndpointUpdateApi:
             "name": "new-name",
             "settings": {"x": 1},
         }
+        req_data = LegacyEndpointUpdatePayload(**payload)
 
         with (
             app.test_request_context("/", json=payload),
             patch("controllers.console.workspace.endpoint.EndpointService.update_endpoint", return_value=True),
         ):
-            result = method(api, "t1", "u1")
+            result = method(api, req_data, "t1", "u1")
 
         assert result["success"] is True
 
@@ -360,7 +372,7 @@ class TestDeprecatedEndpointUpdateApi:
             app.test_request_context("/", json=payload),
         ):
             with pytest.raises(ValueError):
-                method(api, "t1", "u1")
+                method(api, LegacyEndpointUpdatePayload(**payload), "t1", "u1")
 
     def test_update_service_failure(self, app: Flask):
         api = DeprecatedEndpointUpdateApi()
@@ -371,12 +383,13 @@ class TestDeprecatedEndpointUpdateApi:
             "name": "n",
             "settings": {},
         }
+        req_data = LegacyEndpointUpdatePayload(**payload)
 
         with (
             app.test_request_context("/", json=payload),
             patch("controllers.console.workspace.endpoint.EndpointService.update_endpoint", return_value=False),
         ):
-            result = method(api, "t1", "u1")
+            result = method(api, req_data, "t1", "u1")
 
         assert result["success"] is False
 
@@ -417,12 +430,13 @@ class TestEndpointEnableApi:
         method = inspect.unwrap(api.post)
 
         payload = {"endpoint_id": "e1"}
+        req_data = EndpointIdPayload(**payload)
 
         with (
             app.test_request_context("/", json=payload),
             patch("controllers.console.workspace.endpoint.EndpointService.enable_endpoint", return_value=True),
         ):
-            result = method(api, "t1", "u1")
+            result = method(api, req_data, "t1", "u1")
 
         assert result["success"] is True
 
@@ -434,19 +448,20 @@ class TestEndpointEnableApi:
             app.test_request_context("/", json={}),
         ):
             with pytest.raises(ValueError):
-                method(api, "t1", "u1")
+                method(api, EndpointIdPayload(), "t1", "u1")
 
     def test_enable_service_failure(self, app: Flask):
         api = EndpointEnableApi()
         method = inspect.unwrap(api.post)
 
         payload = {"endpoint_id": "e1"}
+        req_data = EndpointIdPayload(**payload)
 
         with (
             app.test_request_context("/", json=payload),
             patch("controllers.console.workspace.endpoint.EndpointService.enable_endpoint", return_value=False),
         ):
-            result = method(api, "t1", "u1")
+            result = method(api, req_data, "t1", "u1")
 
         assert result["success"] is False
 
@@ -457,12 +472,13 @@ class TestEndpointDisableApi:
         method = inspect.unwrap(api.post)
 
         payload = {"endpoint_id": "e1"}
+        req_data = EndpointIdPayload(**payload)
 
         with (
             app.test_request_context("/", json=payload),
             patch("controllers.console.workspace.endpoint.EndpointService.disable_endpoint", return_value=True),
         ):
-            result = method(api, "t1", "u1")
+            result = method(api, req_data, "t1", "u1")
 
         assert result["success"] is True
 
@@ -474,4 +490,4 @@ class TestEndpointDisableApi:
             app.test_request_context("/", json={}),
         ):
             with pytest.raises(ValueError):
-                method(api, "t1", "u1")
+                method(api, EndpointIdPayload(), "t1", "u1")

--- a/api/tests/unit_tests/controllers/console/workspace/test_snippets.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_snippets.py
@@ -154,19 +154,14 @@ def test_create_snippet_defaults_unknown_type_and_returns_created(app: Flask, mo
     snippet = _snippet()
     create_snippet = Mock(return_value=snippet)
     monkeypatch.setattr(snippets_module.SnippetService, "create_snippet", create_snippet)
-    monkeypatch.setattr(
-        snippets_module.CreateSnippetPayload,
-        "model_validate",
-        Mock(
-            return_value=SimpleNamespace(
-                name="Snippet",
-                type="unknown",
-                description="Description",
-                graph=None,
-                icon_info=None,
-                input_fields=[],
-            )
-        ),
+
+    req_data = SimpleNamespace(
+        name="Snippet",
+        type="unknown",
+        description="Description",
+        graph=None,
+        icon_info=None,
+        input_fields=[],
     )
 
     api = snippets_module.CustomizedSnippetsApi()
@@ -177,7 +172,7 @@ def test_create_snippet_defaults_unknown_type_and_returns_created(app: Flask, mo
         method="POST",
         json={"name": "Snippet", "type": "node", "description": "Description"},
     ):
-        response, status_code = handler(api, "tenant-1", user)
+        response, status_code = handler(api, req_data, "tenant-1", user)
 
     assert status_code == 201
     assert response["id"] == "snippet-1"
@@ -189,6 +184,17 @@ def test_create_snippet_rejects_forbidden_nodes(app: Flask, monkeypatch: pytest.
     user = _account("account-1")
     create_snippet = Mock()
     monkeypatch.setattr(snippets_module.SnippetService, "create_snippet", create_snippet)
+
+    req_data = snippets_module.CreateSnippetPayload(
+        name="snippet with invalid node",
+        type="node",
+        graph={
+            "nodes": [
+                {"id": "knowledge-1", "data": {"type": "knowledge-retrieval"}},
+            ],
+            "edges": [],
+        },
+    )
 
     api = snippets_module.CustomizedSnippetsApi()
     handler = unwrap(api.post)
@@ -207,7 +213,7 @@ def test_create_snippet_rejects_forbidden_nodes(app: Flask, monkeypatch: pytest.
             },
         },
     ):
-        response, status_code = handler(api, "tenant-1", user)
+        response, status_code = handler(api, req_data, "tenant-1", user)
 
     assert status_code == 400
     assert "knowledge-retrieval" in response["message"]
@@ -245,6 +251,8 @@ def test_patch_snippet_returns_400_for_empty_payload(app: Flask, monkeypatch: py
     user = _account("user-1")
     monkeypatch.setattr(snippets_module.SnippetService, "get_snippet_by_id", Mock(return_value=snippet))
 
+    req_data = snippets_module.UpdateSnippetPayload()
+
     api = snippets_module.CustomizedSnippetDetailApi()
     handler = unwrap(api.patch)
 
@@ -253,7 +261,7 @@ def test_patch_snippet_returns_400_for_empty_payload(app: Flask, monkeypatch: py
         method="PATCH",
         json={},
     ):
-        response, status_code = handler(api, "tenant-1", user, snippet_id="snippet-1")
+        response, status_code = handler(api, req_data, "tenant-1", user, snippet_id="snippet-1")
 
     assert status_code == 400
     assert response == {"message": "No valid fields to update"}
@@ -275,6 +283,8 @@ def test_patch_snippet_updates_and_commits(app: Flask, monkeypatch: pytest.Monke
     monkeypatch.setattr(snippets_module, "Session", SessionContext)
     monkeypatch.setattr(snippets_module, "db", SimpleNamespace(engine=object()))
 
+    req_data = snippets_module.UpdateSnippetPayload(name="New", icon_info={"icon": "star"})
+
     api = snippets_module.CustomizedSnippetDetailApi()
     handler = unwrap(api.patch)
 
@@ -283,7 +293,7 @@ def test_patch_snippet_updates_and_commits(app: Flask, monkeypatch: pytest.Monke
         method="PATCH",
         json={"name": "New", "icon_info": {"icon": "star"}},
     ):
-        response, status_code = handler(api, "tenant-1", user, snippet_id="snippet-1")
+        response, status_code = handler(api, req_data, "tenant-1", user, snippet_id="snippet-1")
 
     assert status_code == 200
     assert response["id"] == "snippet-1"
@@ -378,6 +388,8 @@ def test_import_snippet_returns_202_for_pending_confirmation(app: Flask, monkeyp
         Mock(return_value=SimpleNamespace(import_snippet=import_snippet)),
     )
 
+    req_data = snippets_module.SnippetImportPayload(mode="yaml-content", yaml_content="kind: snippet")
+
     api = snippets_module.CustomizedSnippetImportApi()
     handler = unwrap(api.post)
 
@@ -386,7 +398,7 @@ def test_import_snippet_returns_202_for_pending_confirmation(app: Flask, monkeyp
         method="POST",
         json={"mode": "yaml-content", "yaml_content": "kind: snippet"},
     ):
-        response, status_code = handler(api, session, user)
+        response, status_code = handler(api, req_data, session, user)
 
     assert status_code == 202
     assert response["status"] == ImportStatus.PENDING.value
@@ -413,6 +425,8 @@ def test_import_snippet_returns_400_for_failed_import(app: Flask, monkeypatch: p
         Mock(return_value=SimpleNamespace(import_snippet=import_snippet)),
     )
 
+    req_data = snippets_module.SnippetImportPayload(mode="yaml-content", yaml_content="kind: snippet")
+
     api = snippets_module.CustomizedSnippetImportApi()
     handler = unwrap(api.post)
 
@@ -421,7 +435,7 @@ def test_import_snippet_returns_400_for_failed_import(app: Flask, monkeypatch: p
         method="POST",
         json={"mode": "yaml-content", "yaml_content": "kind: snippet"},
     ):
-        response, status_code = handler(api, session, user)
+        response, status_code = handler(api, req_data, session, user)
 
     assert status_code == 400
     assert response["error"] == "Invalid DSL"


### PR DESCRIPTION
## Description

Replace manual `*.model_validate(console_ns.payload or {})` with the `@model_validate` decorator introduced in #36750, injecting the validated payload as a method argument.

### Files changed

**`api/controllers/console/workspace/snippets.py`** (3 methods)
- `CustomizedSnippetsApi.post` - replaced manual model_validate with `@model_validate(CreateSnippetPayload)`, injected `req_data` parameter.
- `CustomizedSnippetDetailApi.patch` - replaced manual model_validate with `@model_validate(UpdateSnippetPayload)`, injected `req_data` parameter.
- `CustomizedSnippetImportApi.post` - replaced manual model_validate with `@model_validate(SnippetImportPayload)`, injected `req_data` parameter.

**`api/controllers/console/workspace/load_balancing_config.py`** (2 methods)
- `LoadBalancingCredentialsValidateApi.post` - replaced manual model_validate with `@model_validate(LoadBalancingCredentialPayload)`, injected `req_data` parameter.
- `LoadBalancingConfigCredentialsValidateApi.post` - same refactoring as above.

**`api/controllers/console/workspace/endpoint.py`** (5 helper functions + 7 Resource methods)
- Refactored standalone helper functions (`_create_endpoint`, `_update_endpoint`, `_legacy_update_endpoint`, `_delete_endpoint_from_payload`, `_set_endpoint_enabled`) to accept the validated payload as a `req_data` parameter instead of calling `model_validate(console_ns.payload)` internally.
- Added `@model_validate` decorator to the 7 Resource methods that call these helpers, passing `req_data` through to the helpers.

### Test updates
- `test_snippets.py` - updated tests that use `unwrap()` to pass `req_data` as the first argument after `api`.
- `test_endpoint.py` - updated tests that use `inspect.unwrap()` to pass `req_data` as the first argument after `api`; validation-error tests now construct the payload inline within `pytest.raises()`.
- `test_load_balancing_config.py` - no changes needed (tests call methods directly without `unwrap()`).

Related issue: #36659

## Screenshots

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes