### PR TITLE
fix(agent): preserve plugin-declared model parameters through Agent Soul

### DIFF
--- a/api/clients/agent_backend/request_builder.py
+++ b/api/clients/agent_backend/request_builder.py
@@ -159,8 +159,12 @@ class AgentBackendModelConfig(BaseModel):
 # ``DifyPluginLLMLayerConfig.model_settings`` is pydantic_ai's ``ModelSettings``
 # TypedDict (closed: unknown keys are rejected, explicit ``None`` values fail the
 # per-field type checks). Agent Soul model settings carry a wider, nullable shape
-# (``stop`` / ``response_format`` plus null-padded fields), so the layer config
-# only receives the keys the runtime contract accepts.
+# (``stop`` / ``response_format`` plus null-padded fields, plus arbitrary
+# plugin-declared parameters such as Qwen's ``enable_thinking``), so the layer
+# config only receives the keys the runtime contract accepts directly; anything
+# else is forwarded through ``extra_body``, the TypedDict's own escape hatch for
+# provider-specific parameters (see
+# ``dify_agent.adapters.llm.model._map_model_settings_to_parameters``).
 _AGENT_MODEL_SETTINGS_PASSTHROUGH_KEYS = (
     "temperature",
     "top_p",
@@ -168,6 +172,7 @@ _AGENT_MODEL_SETTINGS_PASSTHROUGH_KEYS = (
     "frequency_penalty",
     "max_tokens",
 )
+_AGENT_MODEL_SETTINGS_KNOWN_KEYS = frozenset({*_AGENT_MODEL_SETTINGS_PASSTHROUGH_KEYS, "stop", "response_format"})
 
 
 def _agent_model_settings(settings: Mapping[str, JsonValue]) -> dict[str, JsonValue] | None:
@@ -177,6 +182,15 @@ def _agent_model_settings(settings: Mapping[str, JsonValue]) -> dict[str, JsonVa
     stop = settings.get("stop")
     if isinstance(stop, list) and stop:
         sanitized["stop_sequences"] = stop
+
+    extra_body: dict[str, JsonValue] = {
+        key: value
+        for key, value in settings.items()
+        if key not in _AGENT_MODEL_SETTINGS_KNOWN_KEYS and value is not None
+    }
+    if extra_body:
+        sanitized["extra_body"] = extra_body
+
     return sanitized or None
 
 

--- a/api/models/agent_config_entities.py
+++ b/api/models/agent_config_entities.py
@@ -527,8 +527,14 @@ class AgentModelResponseFormatConfig(AgentFlexibleConfig):
     type: str | None = Field(default=None, max_length=64)
 
 
-class AgentSoulModelSettings(BaseModel):
-    model_config = ConfigDict(extra="ignore")
+class AgentSoulModelSettings(AgentFlexibleConfig):
+    """Model parameters for the Agent Soul model.
+
+    Model plugins can declare arbitrary parameters via ``parameter_rules``
+    (e.g. Qwen/Tongyi's ``enable_thinking``) beyond the common OpenAI-style
+    fields typed below, so extra keys must round-trip through persistence
+    rather than being dropped.
+    """
 
     temperature: float | None = None
     top_p: float | None = None

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -14923,6 +14923,13 @@ Reference to model credentials resolved only at runtime.
 
 #### AgentSoulModelSettings
 
+Model parameters for the Agent Soul model.
+
+Model plugins can declare arbitrary parameters via ``parameter_rules``
+(e.g. Qwen/Tongyi's ``enable_thinking``) beyond the common OpenAI-style
+fields typed below, so extra keys must round-trip through persistence
+rather than being dropped.
+
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | frequency_penalty | number |  | No |

--- a/api/tests/unit_tests/clients/agent_backend/test_request_builder.py
+++ b/api/tests/unit_tests/clients/agent_backend/test_request_builder.py
@@ -119,6 +119,29 @@ def test_request_builder_separates_agent_soul_and_workflow_job_prompt():
     assert dumped["composition"]["layers"][2]["config"]["user"] == "Summarize the report."
 
 
+def test_request_builder_forwards_plugin_specific_model_settings_via_extra_body():
+    run_input = _run_input().model_copy(
+        update={
+            "model": AgentBackendModelConfig(
+                plugin_id="langgenius/tongyi",
+                model_provider="tongyi",
+                model="qwen-plus-latest",
+                credentials={"api_key": "secret-key"},
+                model_settings={"temperature": 0.7, "enable_thinking": True, "thinking_budget": 4096},
+            )
+        }
+    )
+
+    request = AgentBackendRunRequestBuilder().build_for_workflow_node(run_input)
+    layers = {layer.name: layer for layer in request.composition.layers}
+    model_config = cast(DifyPluginLLMLayerConfig, layers[DIFY_AGENT_MODEL_LAYER_ID].config)
+
+    assert model_config.model_settings == {
+        "temperature": 0.7,
+        "extra_body": {"enable_thinking": True, "thinking_budget": 4096},
+    }
+
+
 @pytest.mark.parametrize("agent_config_version_kind", ["snapshot", "draft"])
 def test_agent_app_request_builder_keeps_agent_soul_prompt_for_snapshot_and_draft(
     agent_config_version_kind: str,

--- a/api/tests/unit_tests/models/test_agent_config_entities.py
+++ b/api/tests/unit_tests/models/test_agent_config_entities.py
@@ -2,11 +2,28 @@ import pytest
 
 from core.workflow.file_reference import build_file_reference
 from models.agent_config_entities import (
+    AgentSoulModelSettings,
     DeclaredArrayItem,
     DeclaredOutputChildConfig,
     DeclaredOutputConfig,
     DeclaredOutputType,
 )
+
+
+def test_agent_soul_model_settings_preserves_plugin_declared_parameters() -> None:
+    settings = AgentSoulModelSettings.model_validate(
+        {
+            "temperature": 0.7,
+            "enable_thinking": True,
+            "thinking_budget": 4096,
+        }
+    )
+
+    dumped = settings.model_dump(mode="json", exclude_none=True)
+
+    assert dumped["temperature"] == 0.7
+    assert dumped["enable_thinking"] is True
+    assert dumped["thinking_budget"] == 4096
 
 
 def test_file_default_value_accepts_canonical_reference_mapping() -> None:

--- a/packages/contracts/generated/api/console/agent/types.gen.ts
+++ b/packages/contracts/generated/api/console/agent/types.gen.ts
@@ -1586,6 +1586,7 @@ export type AgentSoulModelSettings = {
   stop?: Array<string> | null
   temperature?: number | null
   top_p?: number | null
+  [key: string]: unknown
 }
 
 export type AgentSandboxProviderConfig = {

--- a/packages/contracts/generated/api/console/agent/zod.gen.ts
+++ b/packages/contracts/generated/api/console/agent/zod.gen.ts
@@ -2037,6 +2037,13 @@ export const zAgentModelResponseFormatConfig = z.object({
 
 /**
  * AgentSoulModelSettings
+ *
+ * Model parameters for the Agent Soul model.
+ *
+ * Model plugins can declare arbitrary parameters via ``parameter_rules``
+ * (e.g. Qwen/Tongyi's ``enable_thinking``) beyond the common OpenAI-style
+ * fields typed below, so extra keys must round-trip through persistence
+ * rather than being dropped.
  */
 export const zAgentSoulModelSettings = z.object({
   frequency_penalty: z.number().nullish(),

--- a/packages/contracts/generated/api/console/apps/types.gen.ts
+++ b/packages/contracts/generated/api/console/apps/types.gen.ts
@@ -2846,6 +2846,7 @@ export type AgentSoulModelSettings = {
   stop?: Array<string> | null
   temperature?: number | null
   top_p?: number | null
+  [key: string]: unknown
 }
 
 export type AgentSandboxProviderConfig = {

--- a/packages/contracts/generated/api/console/apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/apps/zod.gen.ts
@@ -3643,6 +3643,13 @@ export const zAgentModelResponseFormatConfig = z.object({
 
 /**
  * AgentSoulModelSettings
+ *
+ * Model parameters for the Agent Soul model.
+ *
+ * Model plugins can declare arbitrary parameters via ``parameter_rules``
+ * (e.g. Qwen/Tongyi's ``enable_thinking``) beyond the common OpenAI-style
+ * fields typed below, so extra keys must round-trip through persistence
+ * rather than being dropped.
  */
 export const zAgentSoulModelSettings = z.object({
   frequency_penalty: z.number().nullish(),

--- a/packages/contracts/generated/api/console/snippets/types.gen.ts
+++ b/packages/contracts/generated/api/console/snippets/types.gen.ts
@@ -924,6 +924,7 @@ export type AgentSoulModelSettings = {
   stop?: Array<string> | null
   temperature?: number | null
   top_p?: number | null
+  [key: string]: unknown
 }
 
 export type AgentSandboxProviderConfig = {

--- a/packages/contracts/generated/api/console/snippets/zod.gen.ts
+++ b/packages/contracts/generated/api/console/snippets/zod.gen.ts
@@ -1155,6 +1155,13 @@ export const zAgentModelResponseFormatConfig = z.object({
 
 /**
  * AgentSoulModelSettings
+ *
+ * Model parameters for the Agent Soul model.
+ *
+ * Model plugins can declare arbitrary parameters via ``parameter_rules``
+ * (e.g. Qwen/Tongyi's ``enable_thinking``) beyond the common OpenAI-style
+ * fields typed below, so extra keys must round-trip through persistence
+ * rather than being dropped.
  */
 export const zAgentSoulModelSettings = z.object({
   frequency_penalty: z.number().nullish(),


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

Fixes #40144.

`AgentSoulModelSettings` used `extra="ignore"`, so any model parameter beyond
the 7 typed OpenAI-style fields (e.g. Qwen/Tongyi's `enable_thinking`) was
silently dropped when an Agent app's `model_settings` was validated during
save/publish. On reload, the parameter panel treated the missing key as "off".

Even for a config that briefly held the parameter in memory, the runtime
request path applied a second, narrower whitelist (`_agent_model_settings()`
in `api/clients/agent_backend/request_builder.py`) that forwarded only 5 keys
plus `stop`, so the parameter never reached the model plugin either — the
feature never actually took effect, not just a display bug.

### Fix

1. `api/models/agent_config_entities.py`: `AgentSoulModelSettings` now inherits
   `AgentFlexibleConfig` (`extra="allow"`), matching the pattern already used
   by sibling config models in this file (`AgentModelResponseFormatConfig`,
   `AgentHumanToolConfig`, etc.), so plugin-declared parameters survive the
   save/publish round trip.
2. `api/clients/agent_backend/request_builder.py`: `_agent_model_settings()`
   now forwards any key outside the known set into `extra_body`. This is not
   an ad-hoc addition — `DifyPluginLLMLayerConfig.model_settings` is
   `pydantic_ai`'s `ModelSettings` TypedDict, which is closed and *raises* a
   `ValidationError` for unknown top-level keys (confirmed locally), so
   passing arbitrary keys through directly is not an option. `extra_body` is
   that TypedDict's own escape hatch for provider-specific parameters, and
   `dify_agent`'s `_map_model_settings_to_parameters()` already merges it into
   the final request sent to the plugin — this change just stops discarding
   the data before it reaches that merge.

Scope note: this only widens the persistence + forwarding paths as described
in the issue. It does not touch `response_format`, which is a separate,
pre-existing gap outside this issue's report.

## Testing

Added a persistence round-trip test and a runtime-forwarding test, and
verified both fail without the fix (reverted the two source files locally,
confirmed the exact failures below, then restored the fix):

```
FAILED tests/unit_tests/models/test_agent_config_entities.py::test_agent_soul_model_settings_preserves_plugin_declared_parameters - KeyError: 'enable_thinking'
FAILED tests/unit_tests/clients/agent_backend/test_request_builder.py::test_request_builder_forwards_plugin_specific_model_settings_via_extra_body - AssertionError: assert {'temperature': 0.7} == {'extra_body'...erature': 0.7}
```

With the fix applied:

```
$ uv run pytest tests/unit_tests/models/test_agent_config_entities.py tests/unit_tests/clients/agent_backend/test_request_builder.py -q
34 passed in 1.42s

$ uv run pytest tests/unit_tests -k "agent" -q
1562 passed, 15432 deselected in 127.00s

$ uv run ruff check clients/agent_backend/request_builder.py models/agent_config_entities.py
All checks passed!

$ uv run ruff format --check clients/agent_backend/request_builder.py models/agent_config_entities.py
2 files already formatted

$ uv run mypy --exclude-gitignore --exclude '(^|/)conftest\.py$' --exclude 'tests/' \
    --exclude 'migrations/' --exclude 'dev/generate_swagger_specs.py' \
    --exclude 'dev/generate_fastopenapi_specs.py' --check-untyped-defs \
    --disable-error-code=import-untyped models/agent_config_entities.py clients/agent_backend/request_builder.py
Success: no issues found in 2 source files
```

Also confirmed the underlying pydantic_ai constraint directly:

```python
>>> DifyPluginLLMLayerConfig(plugin_id='p', model_provider='mp', model='m',
...     model_settings={'temperature': 0.5, 'enable_thinking': True})
ValidationError: 1 validation error for DifyPluginLLMLayerConfig
model_settings.enable_thinking
  Extra inputs are not permitted [type=extra_forbidden, input_value=True, input_type=bool]
```

## Screenshots

| Before | After |
| ------ | ----- |
| N/A (backend data-persistence bug) | N/A (backend data-persistence bug) |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran the backend equivalent of `make lint && make type-check` (`ruff check`, `ruff format --check`, `mypy`) on the changed files; this PR has no frontend changes, so `pnpm exec vp staged` was not applicable

From Claude Code
