### PR TITLE
fix(agent-v2): accept composer UI ids on manual metadata filter conditions

### DIFF
--- a/api/core/workflow/nodes/agent_v2/runtime_request_builder.py
+++ b/api/core/workflow/nodes/agent_v2/runtime_request_builder.py
@@ -836,7 +836,12 @@ def _knowledge_metadata_filtering_config(
     return DifyKnowledgeMetadataFilteringConfig(
         mode=metadata_filtering.mode,
         model_config=_knowledge_model_config(metadata_filtering.metadata_model_config),
-        conditions=cast(Any, metadata_filtering.conditions.model_dump(mode="json"))
+        conditions=cast(
+            Any,
+            metadata_filtering.conditions.model_dump(
+                mode="json", exclude={"conditions": {"__all__": {"id", "metadata_id"}}}
+            ),
+        )
         if metadata_filtering.conditions is not None
         else None,
     )

--- a/api/models/agent_config_entities.py
+++ b/api/models/agent_config_entities.py
@@ -420,8 +420,19 @@ class AgentKnowledgeRetrievalConfig(BaseModel):
 
 
 class AgentKnowledgeMetadataCondition(BaseModel):
+    """One manual metadata filter clause.
+
+    ``id`` and ``metadata_id`` are UI-only bookkeeping the composer sends on
+    every save (a stable row key and a reference to the selected metadata
+    field). They are persisted here for round-tripping the composer's draft
+    state but are stripped before building the Agent runtime request, whose
+    DTO only accepts ``name``/``comparison_operator``/``value``.
+    """
+
     model_config = ConfigDict(extra="forbid")
 
+    id: str | None = None
+    metadata_id: str | None = None
     name: str = Field(min_length=1, max_length=255)
     comparison_operator: SupportedComparisonOperator
     value: ConditionValue = None

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -14302,9 +14302,19 @@ the current roster/workflow APIs scoped to Dify Agent.
 
 #### AgentKnowledgeMetadataCondition
 
+One manual metadata filter clause.
+
+``id`` and ``metadata_id`` are UI-only bookkeeping the composer sends on
+every save (a stable row key and a reference to the selected metadata
+field). They are persisted here for round-tripping the composer's draft
+state but are stripped before building the Agent runtime request, whose
+DTO only accepts ``name``/``comparison_operator``/``value``.
+
 | Name | Type | Description | Required |
 | ---- | ---- | ----------- | -------- |
 | comparison_operator | string, <br>**Available values:** "<", "=", ">", "after", "before", "contains", "empty", "end with", "in", "is", "is not", "not contains", "not empty", "not in", "start with", "≠", "≤", "≥" | *Enum:* `"<"`, `"="`, `">"`, `"after"`, `"before"`, `"contains"`, `"empty"`, `"end with"`, `"in"`, `"is"`, `"is not"`, `"not contains"`, `"not empty"`, `"not in"`, `"start with"`, `"≠"`, `"≤"`, `"≥"` | Yes |
+| id | string |  | No |
+| metadata_id | string |  | No |
 | name | string |  | Yes |
 | value | string<br>[ string ]<br>number |  | No |
 

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_runtime_request_builder.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_runtime_request_builder.py
@@ -744,7 +744,13 @@ def test_build_maps_agent_soul_knowledge_to_knowledge_layer_config():
                                 "conditions": {
                                     "logical_operator": "and",
                                     "conditions": [
-                                        {"name": "category", "comparison_operator": "contains", "value": "auth"}
+                                        {
+                                            "id": "cond-1",
+                                            "metadata_id": "meta-1",
+                                            "name": "category",
+                                            "comparison_operator": "contains",
+                                            "value": "auth",
+                                        }
                                     ],
                                 },
                             },

--- a/api/tests/unit_tests/services/agent/test_agent_composer_entities.py
+++ b/api/tests/unit_tests/services/agent/test_agent_composer_entities.py
@@ -365,6 +365,51 @@ def test_knowledge_runtime_requirements_block_publish_but_not_draft_save(knowled
         ComposerConfigValidator.validate_publish_payload(publish_payload)
 
 
+def test_manual_metadata_filtering_condition_accepts_composer_ui_identifiers():
+    """The composer's condition editor always sends ``id`` (list row key) and
+    ``metadata_id`` (selected metadata field reference) alongside every
+    condition. Rejecting them as unknown fields broke every save of a manual
+    metadata filter (see GH issue #40169)."""
+    payload = ComposerSavePayload.model_validate(
+        {
+            "variant": ComposerVariant.AGENT_APP,
+            "save_strategy": ComposerSaveStrategy.SAVE_TO_CURRENT_VERSION,
+            "agent_soul": {
+                "knowledge": {
+                    "sets": [
+                        {
+                            "id": "support",
+                            "name": "Support KB",
+                            "datasets": [{"id": "dataset-1"}],
+                            "query": {"mode": "generated_query"},
+                            "retrieval": {"mode": "multiple", "top_k": 4},
+                            "metadata_filtering": {
+                                "mode": "manual",
+                                "conditions": {
+                                    "logical_operator": "and",
+                                    "conditions": [
+                                        {
+                                            "id": "b149eceb-191a-40a2-9f11-61cf21ebd147",
+                                            "metadata_id": "ad6cf326-eadf-46e8-a2d5-9cb892d2cc84",
+                                            "name": "category",
+                                            "comparison_operator": "is",
+                                            "value": "auth",
+                                        }
+                                    ],
+                                },
+                            },
+                        },
+                    ]
+                }
+            },
+        }
+    )
+
+    condition = payload.agent_soul.knowledge.sets[0].metadata_filtering.conditions.conditions[0]
+    assert condition.id == "b149eceb-191a-40a2-9f11-61cf21ebd147"
+    assert condition.metadata_id == "ad6cf326-eadf-46e8-a2d5-9cb892d2cc84"
+
+
 def test_agent_soul_model_config_is_first_class_without_credentials():
     config = AgentSoulConfig(
         model=AgentSoulModelConfig(

--- a/packages/contracts/generated/api/console/agent/types.gen.ts
+++ b/packages/contracts/generated/api/console/agent/types.gen.ts
@@ -1882,6 +1882,8 @@ export type AgentKnowledgeMetadataCondition = {
     | '≠'
     | '≤'
     | '≥'
+  id?: string | null
+  metadata_id?: string | null
   name: string
   value?: string | Array<string> | number | null
 }

--- a/packages/contracts/generated/api/console/agent/zod.gen.ts
+++ b/packages/contracts/generated/api/console/agent/zod.gen.ts
@@ -2357,6 +2357,14 @@ export const zAgentKnowledgeRetrievalConfig = z.object({
 
 /**
  * AgentKnowledgeMetadataCondition
+ *
+ * One manual metadata filter clause.
+ *
+ * ``id`` and ``metadata_id`` are UI-only bookkeeping the composer sends on
+ * every save (a stable row key and a reference to the selected metadata
+ * field). They are persisted here for round-tripping the composer's draft
+ * state but are stripped before building the Agent runtime request, whose
+ * DTO only accepts ``name``/``comparison_operator``/``value``.
  */
 export const zAgentKnowledgeMetadataCondition = z.object({
   comparison_operator: z.enum([
@@ -2379,6 +2387,8 @@ export const zAgentKnowledgeMetadataCondition = z.object({
     '≤',
     '≥',
   ]),
+  id: z.string().nullish(),
+  metadata_id: z.string().nullish(),
   name: z.string().min(1).max(255),
   value: z.union([z.string(), z.array(z.string()), z.number()]).nullish(),
 })

--- a/packages/contracts/generated/api/console/apps/types.gen.ts
+++ b/packages/contracts/generated/api/console/apps/types.gen.ts
@@ -3097,6 +3097,8 @@ export type AgentKnowledgeMetadataCondition = {
     | '≠'
     | '≤'
     | '≥'
+  id?: string | null
+  metadata_id?: string | null
   name: string
   value?: string | Array<string> | number | null
 }

--- a/packages/contracts/generated/api/console/apps/zod.gen.ts
+++ b/packages/contracts/generated/api/console/apps/zod.gen.ts
@@ -4048,6 +4048,14 @@ export const zMessageInfiniteScrollPaginationResponse = z.object({
 
 /**
  * AgentKnowledgeMetadataCondition
+ *
+ * One manual metadata filter clause.
+ *
+ * ``id`` and ``metadata_id`` are UI-only bookkeeping the composer sends on
+ * every save (a stable row key and a reference to the selected metadata
+ * field). They are persisted here for round-tripping the composer's draft
+ * state but are stripped before building the Agent runtime request, whose
+ * DTO only accepts ``name``/``comparison_operator``/``value``.
  */
 export const zAgentKnowledgeMetadataCondition = z.object({
   comparison_operator: z.enum([
@@ -4070,6 +4078,8 @@ export const zAgentKnowledgeMetadataCondition = z.object({
     '≤',
     '≥',
   ]),
+  id: z.string().nullish(),
+  metadata_id: z.string().nullish(),
   name: z.string().min(1).max(255),
   value: z.union([z.string(), z.array(z.string()), z.number()]).nullish(),
 })

--- a/packages/contracts/generated/api/console/snippets/types.gen.ts
+++ b/packages/contracts/generated/api/console/snippets/types.gen.ts
@@ -1130,6 +1130,8 @@ export type AgentKnowledgeMetadataCondition = {
     | '≠'
     | '≤'
     | '≥'
+  id?: string | null
+  metadata_id?: string | null
   name: string
   value?: string | Array<string> | number | null
 }

--- a/packages/contracts/generated/api/console/snippets/zod.gen.ts
+++ b/packages/contracts/generated/api/console/snippets/zod.gen.ts
@@ -1439,6 +1439,14 @@ export const zAgentKnowledgeRetrievalConfig = z.object({
 
 /**
  * AgentKnowledgeMetadataCondition
+ *
+ * One manual metadata filter clause.
+ *
+ * ``id`` and ``metadata_id`` are UI-only bookkeeping the composer sends on
+ * every save (a stable row key and a reference to the selected metadata
+ * field). They are persisted here for round-tripping the composer's draft
+ * state but are stripped before building the Agent runtime request, whose
+ * DTO only accepts ``name``/``comparison_operator``/``value``.
  */
 export const zAgentKnowledgeMetadataCondition = z.object({
   comparison_operator: z.enum([
@@ -1461,6 +1469,8 @@ export const zAgentKnowledgeMetadataCondition = z.object({
     '≤',
     '≥',
   ]),
+  id: z.string().nullish(),
+  metadata_id: z.string().nullish(),
   name: z.string().min(1).max(255),
   value: z.union([z.string(), z.array(z.string()), z.number()]).nullish(),
 })


### PR DESCRIPTION
## Summary

Fixes #40169.

Saving an Agent v2 knowledge set with a manual metadata filtering
condition always failed with:

```
{
    "code": "invalid_param",
    "message": "2 validation errors for ComposerSavePayload\nagent_soul.knowledge.sets.1.metadata_filtering.conditions.conditions.0.id\n  Extra inputs are not permitted [type=extra_forbidden, ...]\nagent_soul.knowledge.sets.1.metadata_filtering.conditions.conditions.0.metadata_id\n  Extra inputs are not permitted [type=extra_forbidden, ...]",
    "status": 400
}
```

The composer's condition editor (`web/.../orchestrate/knowledge/dialog.tsx`,
reusing the shared `MetadataFilteringCondition` type from the workflow
knowledge-retrieval node) always sends `id` (a stable row key) and
`metadata_id` (a reference to the selected metadata field) alongside
every condition. The backend's `AgentKnowledgeMetadataCondition`
(`api/models/agent_config_entities.py`) declared `extra="forbid"` and
only accepted `name` / `comparison_operator` / `value`, so every save
of a manual metadata filter was rejected.

### Fix

- `AgentKnowledgeMetadataCondition` now accepts and persists `id` and
  `metadata_id` so the composer round-trips its draft state correctly.
- `runtime_request_builder.py`'s `_knowledge_metadata_filtering_config`
  now strips `id`/`metadata_id` before mapping to the Agent runtime
  request, since `DifyKnowledgeMetadataCondition` in `dify-agent`
  intentionally keeps `extra="forbid"` with only the three original
  fields.

## Test plan

- Added `test_manual_metadata_filtering_condition_accepts_composer_ui_identifiers`
  in `api/tests/unit_tests/services/agent/test_agent_composer_entities.py`,
  reproducing the exact payload shape from the issue.
- Extended `test_build_maps_agent_soul_knowledge_to_knowledge_layer_config`
  in `api/tests/unit_tests/core/workflow/nodes/agent_v2/test_runtime_request_builder.py`
  to include `id`/`metadata_id` on an input condition and assert they
  are stripped from the mapped Agent runtime request.
- Verified both new/changed assertions fail without the fix (checked
  out the pre-fix source with `git checkout HEAD~1 -- <file>`) with the
  same `extra_forbidden` errors as the issue, then confirmed they pass
  after restoring the fix:

  ```
  $ uv run --project api python -m pytest -o addopts="" \
      api/tests/unit_tests/services/agent/test_agent_composer_entities.py \
      api/tests/unit_tests/core/workflow/nodes/agent_v2/test_runtime_request_builder.py -q
  ...
  69 passed, 1 warning in 1.82s
  ```

- Ran the full agent v2 unit test suite:

  ```
  $ uv run --project api python -m pytest -o addopts="" \
      api/tests/unit_tests/services/agent/ \
      api/tests/unit_tests/core/workflow/nodes/agent_v2/ -q
  ...
  635 passed, 2 warnings in 11.56s
  ```

- `uv run --project api --dev ruff format --check` and
  `ruff check` on all changed files: clean.
- `uv --directory api run mypy --exclude-gitignore --exclude '(^|/)conftest\.py$' --exclude 'tests/' --exclude 'migrations/' --check-untyped-defs --disable-error-code=import-untyped models/agent_config_entities.py core/workflow/nodes/agent_v2/runtime_request_builder.py`:
  `Success: no issues found in 2 source files`.

From Claude Code
