### PR TITLE
fix(web): replace foxact useIsClient in signin countdown

### DIFF
--- a/web/app/components/signin/countdown.tsx
+++ b/web/app/components/signin/countdown.tsx
@@ -1,7 +1,6 @@
 'use client'
 import { useCountDown } from 'ahooks'
-import { useIsClient } from 'foxact/use-is-client'
-import { Suspense, useEffect, useState } from 'react'
+import { Suspense, useEffect, useState, useSyncExternalStore } from 'react'
 import { useTranslation } from 'react-i18next'
 import { COUNT_DOWN_TIME_MS, useCountdownLeftTimeValue, useSetCountdownLeftTime } from './storage'
 
@@ -9,8 +8,17 @@ type CountdownProps = {
   onResend?: () => void
 }
 
+const subscribeHydrationState = () => () => {}
+
+const useIsHydrated = () =>
+  useSyncExternalStore(
+    subscribeHydrationState,
+    () => true,
+    () => false,
+  )
+
 export default function Countdown({ onResend }: CountdownProps) {
-  const isClient = useIsClient()
+  const isClient = useIsHydrated()
 
   if (!isClient) return <CountdownFallback />
 


### PR DESCRIPTION
## Summary

Fixes #38237.

The sign-in `Countdown` component used `useIsClient` from `foxact`, which relies on postMessage-based client detection. On some mobile browsers and WebViews this triggers React hydration errors on `/signin/check-code`, blocking email verification login.

Replaces foxact with `useSyncExternalStore` hydration detection — the same pattern already used in `app-icon` and other Dify web components. Server render and first client paint use `CountdownFallback`; the timer mounts after hydration without postMessage.

## Test plan

- [x] `pnpm vitest run app/components/signin/__tests__/countdown.spec.tsx` (4 passed)
- [x] Hydration regression test `restores the stored time after hydrating server markup` passes