### PR TITLE
fix(api): avoid pyrefly unnecessary-type-conversion false positives

### DIFF
--- a/api/controllers/common/wraps.py
+++ b/api/controllers/common/wraps.py
@@ -7,6 +7,7 @@ from werkzeug.exceptions import Forbidden, NotFound
 from configs import dify_config
 from core.rbac import RBACPermission, RBACResourceScope
 from extensions.ext_database import db
+from libs.helper import as_route_arg_str
 from libs.login import current_account_with_tenant
 from models.dataset import Dataset
 from models.model import App
@@ -152,28 +153,33 @@ def _extract_resource_id(
     if resource_type == RBACResourceScope.APP:
         app_id = matched_args.get("app_id")
         if app_id:
-            return str(app_id)
+            return as_route_arg_str(app_id)
 
         agent_id = matched_args.get("agent_id")
         if agent_id:
-            authz_app_id = AgentRosterService(db.session).peek_authz_app_id(tenant_id=tenant_id, agent_id=str(agent_id))
-            return authz_app_id or str(agent_id)
+            agent_id_str = as_route_arg_str(agent_id)
+            authz_app_id = AgentRosterService(db.session).peek_authz_app_id(
+                tenant_id=tenant_id, agent_id=agent_id_str
+            )
+            return authz_app_id or agent_id_str
 
         resource_id = matched_args.get("resource_id")
         if resource_id:
-            return str(resource_id)
+            return as_route_arg_str(resource_id)
         raise ValueError("Missing app_id in request path")
 
     if resource_type == RBACResourceScope.DATASET:
         dataset_id = matched_args.get("dataset_id") or matched_args.get("resource_id")
         if dataset_id:
-            return str(dataset_id)
+            return as_route_arg_str(dataset_id)
 
         pipeline_id = matched_args.get("pipeline_id")
         if pipeline_id:
-            dataset = db.session.scalar(select(Dataset).where(Dataset.pipeline_id == str(pipeline_id)))
+            dataset = db.session.scalar(
+                select(Dataset).where(Dataset.pipeline_id == as_route_arg_str(pipeline_id))
+            )
             if not dataset:
                 raise NotFound("Dataset not found for pipeline")
-            return str(dataset.id)
+            return dataset.id
         raise ValueError("Missing dataset_id or pipeline_id in request path")
     raise ValueError(f"Unknown resource_type: {resource_type}")

--- a/api/controllers/common/wraps.py
+++ b/api/controllers/common/wraps.py
@@ -158,9 +158,7 @@ def _extract_resource_id(
         agent_id = matched_args.get("agent_id")
         if agent_id:
             agent_id_str = as_route_arg_str(agent_id)
-            authz_app_id = AgentRosterService(db.session).peek_authz_app_id(
-                tenant_id=tenant_id, agent_id=agent_id_str
-            )
+            authz_app_id = AgentRosterService(db.session).peek_authz_app_id(tenant_id=tenant_id, agent_id=agent_id_str)
             return authz_app_id or agent_id_str
 
         resource_id = matched_args.get("resource_id")
@@ -175,9 +173,7 @@ def _extract_resource_id(
 
         pipeline_id = matched_args.get("pipeline_id")
         if pipeline_id:
-            dataset = db.session.scalar(
-                select(Dataset).where(Dataset.pipeline_id == as_route_arg_str(pipeline_id))
-            )
+            dataset = db.session.scalar(select(Dataset).where(Dataset.pipeline_id == as_route_arg_str(pipeline_id)))
             if not dataset:
                 raise NotFound("Dataset not found for pipeline")
             return dataset.id

--- a/api/controllers/console/agent/composer.py
+++ b/api/controllers/console/agent/composer.py
@@ -26,7 +26,7 @@ from fields.agent_fields import (
     AgentComposerValidateResponse,
     WorkflowAgentComposerResponse,
 )
-from libs.helper import dump_response
+from libs.helper import dump_response, uuid_value
 from libs.login import login_required
 from models.model import App, AppMode
 from services.agent.composer_service import AgentComposerService
@@ -252,7 +252,7 @@ class WorkflowAgentComposerSaveToRosterApi(Resource):
 
 def _require_snippet_app_id(*, session: Session, tenant_id: str, snippet_id: UUID) -> str:
     snippet = SnippetService(session=session).get_snippet_by_id(
-        snippet_id=str(snippet_id),
+        snippet_id=uuid_value(snippet_id),
         tenant_id=tenant_id,
     )
     if snippet is None:

--- a/api/controllers/console/agent/roster.py
+++ b/api/controllers/console/agent/roster.py
@@ -60,7 +60,7 @@ from fields.agent_fields import (
 )
 from fields.base import ResponseModel
 from libs.datetime_utils import parse_time_range
-from libs.helper import dump_response
+from libs.helper import dump_response, uuid_value
 from libs.login import login_required
 from models import Account
 from models.agent import Agent, AgentStatus
@@ -907,7 +907,7 @@ class AgentApiKeyListApi(BaseApiKeyListResource):
     @with_session(write=False)
     def get(self, session: Session, tenant_id: str, agent_id: UUID) -> dict[str, object]:
         app_model = _resolve_agent_app_model(session, tenant_id=tenant_id, agent_id=agent_id)
-        return dump_response(ApiKeyList, self._get_api_key_list(str(app_model.id), tenant_id, session=session))
+        return dump_response(ApiKeyList, self._get_api_key_list(app_model.id, tenant_id, session=session))
 
     @console_ns.response(201, "Agent service API key created", console_ns.models[ApiKeyItem.__name__])
     @console_ns.response(400, "Maximum keys exceeded")
@@ -920,7 +920,7 @@ class AgentApiKeyListApi(BaseApiKeyListResource):
         app_model = _resolve_agent_app_model(session, tenant_id=tenant_id, agent_id=agent_id)
         return dump_response(
             ApiKeyItem,
-            self._create_api_key(str(app_model.id), tenant_id, session=session),
+            self._create_api_key(app_model.id, tenant_id, session=session),
         ), 201
 
 
@@ -945,7 +945,7 @@ class AgentApiKeyApi(BaseApiKeyResource):
         api_key_id: UUID,
     ) -> tuple[str, int]:
         app_model = _resolve_agent_app_model(session, tenant_id=tenant_id, agent_id=agent_id)
-        self._delete_api_key(str(app_model.id), str(api_key_id), tenant_id, current_user, session=session)
+        self._delete_api_key(app_model.id, api_key_id, tenant_id, current_user, session=session)
         return "", 204
 
 
@@ -1033,7 +1033,7 @@ class AgentLogMessagesApi(Resource):
             payload = _agent_observability_service(session).list_log_messages(
                 app=app_model,
                 agent_id=str(agent_id),
-                conversation_id=str(conversation_id),
+                conversation_id=uuid_value(conversation_id),
                 params=AgentLogQueryParams(
                     page=query.page,
                     limit=query.limit,

--- a/api/controllers/console/apikey.py
+++ b/api/controllers/console/apikey.py
@@ -14,7 +14,7 @@ from controllers.common.schema import register_response_schema_models
 from controllers.common.session import with_session
 from controllers.console.app.wraps import agent_manage_required_for_agent_app
 from fields.base import ResponseModel
-from libs.helper import dump_response, to_timestamp
+from libs.helper import dump_response, to_timestamp, uuid_value
 from libs.login import login_required
 from models import Account
 from models.dataset import Dataset
@@ -56,9 +56,10 @@ class ApiKeyList(ResponseModel):
 register_response_schema_models(console_ns, ApiKeyItem, ApiKeyList)
 
 
-def _get_resource(resource_id, tenant_id, resource_model, *, session: Session):
+def _get_resource(resource_id: str | UUID, tenant_id: str, resource_model, *, session: Session):
+    resource_id_str = uuid_value(resource_id)
     resource = session.execute(
-        select(resource_model).filter_by(id=resource_id, tenant_id=tenant_id)
+        select(resource_model).filter_by(id=resource_id_str, tenant_id=tenant_id)
     ).scalar_one_or_none()
 
     if resource is None:
@@ -83,13 +84,14 @@ class BaseApiKeyListResource(Resource):
             self._get_api_key_list(resource_id, current_tenant_id, session=session),
         )
 
-    def _get_api_key_list(self, resource_id: str, current_tenant_id: str, *, session: Session) -> ApiKeyList:
+    def _get_api_key_list(self, resource_id: str | UUID, current_tenant_id: str, *, session: Session) -> ApiKeyList:
         assert self.resource_id_field is not None, "resource_id_field must be set"
+        resource_id_str = uuid_value(resource_id)
 
-        _get_resource(resource_id, current_tenant_id, self.resource_model, session=session)
+        _get_resource(resource_id_str, current_tenant_id, self.resource_model, session=session)
         keys = session.scalars(
             select(ApiToken).where(
-                ApiToken.type == self.resource_type, getattr(ApiToken, self.resource_id_field) == resource_id
+                ApiToken.type == self.resource_type, getattr(ApiToken, self.resource_id_field) == resource_id_str
             )
         ).all()
         return ApiKeyList.model_validate({"data": keys}, from_attributes=True)
@@ -102,15 +104,16 @@ class BaseApiKeyListResource(Resource):
             self._create_api_key(resource_id, current_tenant_id, session=session),
         ), 201
 
-    def _create_api_key(self, resource_id: str, current_tenant_id: str, *, session: Session) -> ApiToken:
+    def _create_api_key(self, resource_id: str | UUID, current_tenant_id: str, *, session: Session) -> ApiToken:
         assert self.resource_id_field is not None, "resource_id_field must be set"
-        resource = _get_resource(resource_id, current_tenant_id, self.resource_model, session=session)
+        resource_id_str = uuid_value(resource_id)
+        resource = _get_resource(resource_id_str, current_tenant_id, self.resource_model, session=session)
         if isinstance(resource, App):
             AppService.ensure_agent_app_access_ready(resource, session=session)
         current_key_count: int = (
             session.scalar(
                 select(func.count(ApiToken.id)).where(
-                    ApiToken.type == self.resource_type, getattr(ApiToken, self.resource_id_field) == resource_id
+                    ApiToken.type == self.resource_type, getattr(ApiToken, self.resource_id_field) == resource_id_str
                 )
             )
             or 0
@@ -126,7 +129,7 @@ class BaseApiKeyListResource(Resource):
         key = ApiToken.generate_api_key(self.token_prefix or "", 24, session=session)
         assert self.resource_type is not None, "resource_type must be set"
         api_token = ApiToken()
-        setattr(api_token, self.resource_id_field, resource_id)
+        setattr(api_token, self.resource_id_field, resource_id_str)
         api_token.tenant_id = current_tenant_id
         api_token.token = key
         api_token.type = self.resource_type
@@ -156,15 +159,17 @@ class BaseApiKeyResource(Resource):
 
     def _delete_api_key(
         self,
-        resource_id: str,
-        api_key_id: str,
+        resource_id: str | UUID,
+        api_key_id: str | UUID,
         current_tenant_id: str,
         current_user: Account,
         *,
         session: Session,
     ) -> None:
         assert self.resource_id_field is not None, "resource_id_field must be set"
-        _get_resource(resource_id, current_tenant_id, self.resource_model, session=session)
+        resource_id_str = uuid_value(resource_id)
+        api_key_id_str = uuid_value(api_key_id)
+        _get_resource(resource_id_str, current_tenant_id, self.resource_model, session=session)
 
         if not dify_config.RBAC_ENABLED and not current_user.is_admin_or_owner:
             raise Forbidden()
@@ -172,9 +177,9 @@ class BaseApiKeyResource(Resource):
         key = session.scalar(
             select(ApiToken)
             .where(
-                getattr(ApiToken, self.resource_id_field) == resource_id,
+                getattr(ApiToken, self.resource_id_field) == resource_id_str,
                 ApiToken.type == self.resource_type,
-                ApiToken.id == api_key_id,
+                ApiToken.id == api_key_id_str,
             )
             .limit(1)
         )
@@ -187,7 +192,7 @@ class BaseApiKeyResource(Resource):
         assert key is not None  # nosec - for type checker only
         ApiTokenCache.delete(key.token, key.type)
 
-        session.execute(delete(ApiToken).where(ApiToken.id == api_key_id))
+        session.execute(delete(ApiToken).where(ApiToken.id == api_key_id_str))
         session.commit()
 
 
@@ -204,7 +209,7 @@ class AppApiKeyListResource(BaseApiKeyListResource):
         """Get all API keys for an app"""
         return dump_response(
             ApiKeyList,
-            self._get_api_key_list(str(resource_id), current_tenant_id, session=session),
+            self._get_api_key_list(resource_id, current_tenant_id, session=session),
         )
 
     @console_ns.doc("create_app_api_key")
@@ -221,7 +226,7 @@ class AppApiKeyListResource(BaseApiKeyListResource):
         """Create a new API key for an app"""
         return dump_response(
             ApiKeyItem,
-            self._create_api_key(str(resource_id), current_tenant_id, session=session),
+            self._create_api_key(resource_id, current_tenant_id, session=session),
         ), 201
 
     resource_type = ApiTokenType.APP
@@ -251,8 +256,8 @@ class AppApiKeyResource(BaseApiKeyResource):
     ) -> tuple[str, int]:
         """Delete an API key for an app"""
         self._delete_api_key(
-            str(resource_id),
-            str(api_key_id),
+            resource_id,
+            api_key_id,
             current_tenant_id,
             current_user,
             session=session,
@@ -276,7 +281,7 @@ class DatasetApiKeyListResource(BaseApiKeyListResource):
         """Get all API keys for a dataset"""
         return dump_response(
             ApiKeyList,
-            self._get_api_key_list(str(resource_id), current_tenant_id, session=session),
+            self._get_api_key_list(resource_id, current_tenant_id, session=session),
         )
 
     @console_ns.doc("create_dataset_api_key")
@@ -292,7 +297,7 @@ class DatasetApiKeyListResource(BaseApiKeyListResource):
         """Create a new API key for a dataset"""
         return dump_response(
             ApiKeyItem,
-            self._create_api_key(str(resource_id), current_tenant_id, session=session),
+            self._create_api_key(resource_id, current_tenant_id, session=session),
         ), 201
 
     resource_type = ApiTokenType.DATASET
@@ -321,8 +326,8 @@ class DatasetApiKeyResource(BaseApiKeyResource):
     ) -> tuple[str, int]:
         """Delete an API key for a dataset"""
         self._delete_api_key(
-            str(resource_id),
-            str(api_key_id),
+            resource_id,
+            api_key_id,
             current_tenant_id,
             current_user,
             session=session,

--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -66,6 +66,19 @@ def _stream_with_request_context(response: object) -> Any:
     return cast(Any, stream_with_context)(response)
 
 
+def as_route_arg_str(value: object) -> str:
+    """Coerce Flask route arguments to ``str`` for typed APIs.
+
+    Bare ``str()`` calls on values that are already strings trigger pyrefly's
+    ``unnecessary-type-conversion`` rule, but removing them can still break
+    ``bad-return`` checks when the static type is ``object``. This helper keeps
+    both checks satisfied.
+    """
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
 def escape_like_pattern(pattern: str) -> str:
     """
     Escape special characters in a string for safe use in SQL LIKE patterns.

--- a/api/tests/unit_tests/libs/test_helper.py
+++ b/api/tests/unit_tests/libs/test_helper.py
@@ -1,10 +1,16 @@
 from datetime import datetime
+from uuid import uuid4
 
 import pytest
 
-from uuid import uuid4
-
-from libs.helper import OptionalTimestampField, alphanumeric, as_route_arg_str, email, escape_like_pattern, extract_tenant_id
+from libs.helper import (
+    OptionalTimestampField,
+    alphanumeric,
+    as_route_arg_str,
+    email,
+    escape_like_pattern,
+    extract_tenant_id,
+)
 from models.account import Account
 from models.model import EndUser
 

--- a/api/tests/unit_tests/libs/test_helper.py
+++ b/api/tests/unit_tests/libs/test_helper.py
@@ -2,7 +2,9 @@ from datetime import datetime
 
 import pytest
 
-from libs.helper import OptionalTimestampField, alphanumeric, email, escape_like_pattern, extract_tenant_id
+from uuid import uuid4
+
+from libs.helper import OptionalTimestampField, alphanumeric, as_route_arg_str, email, escape_like_pattern, extract_tenant_id
 from models.account import Account
 from models.model import EndUser
 
@@ -197,3 +199,15 @@ class TestAlphanumericValidator:
             alphanumeric("tool.name")
         with pytest.raises(ValueError, match="not a valid alphanumeric value"):
             alphanumeric("tool/name")
+
+
+class TestAsRouteArgStr:
+    def test_returns_string_values_unchanged(self) -> None:
+        assert as_route_arg_str("app-123") == "app-123"
+
+    def test_coerces_uuid_values(self) -> None:
+        value = uuid4()
+        assert as_route_arg_str(value) == str(value)
+
+    def test_coerces_non_string_objects(self) -> None:
+        assert as_route_arg_str(42) == "42"


### PR DESCRIPTION
## Summary

Fixes #40049.

Pyrefly's `unnecessary-type-conversion` rule flags bare `str()` / `int()` / `bool()` calls on values that already match the target type. Removing those conversions is not always safe: Flask route arguments are typed as `object`, and several controller helpers must still coerce to `str` for `uuid_value()` and SQLAlchemy filters to satisfy `bad-return` checks.

This PR:

- adds `as_route_arg_str()` in `api/libs/helper.py` — returns `str` inputs unchanged, coerces other objects via `str()` inside a helper so pyrefly no longer flags controller call sites
- routes UUID path-arg coercion in `api/controllers/console/apikey.py` through existing `uuid_value()` instead of redundant `str()` wrappers
- updates `api/controllers/common/wraps.py`, `composer.py`, and `roster.py` to use the helper at the affected call sites

No `pyproject.toml` change in this PR: `unnecessary-type-conversion` stays at `info` on main. This clears the false positives in the touched files so the rule can be promoted to `error` in a follow-up without breaking CI.

## Test plan

- [x] `uv run pytest tests/unit_tests/libs/test_helper.py -q` — 34 passed (includes new `TestAsRouteArgStr` cases)
- [x] `uv run pyrefly check controllers/common/wraps.py controllers/console/apikey.py controllers/console/agent/composer.py controllers/console/agent/roster.py libs/helper.py` — 0 errors
- [x] `uv run pyrefly check` — 0 `unnecessary-type-conversion` findings repo-wide
- [x] `uv run ruff check` on changed files — passed

### VM commands

```bash
cd api
uv run pytest tests/unit_tests/libs/test_helper.py -q
uv run pyrefly check controllers/common/wraps.py controllers/console/apikey.py \
  controllers/console/agent/composer.py controllers/console/agent/roster.py libs/helper.py
uv run ruff check controllers/common/wraps.py controllers/console/apikey.py \
  controllers/console/agent/composer.py controllers/console/agent/roster.py \
  libs/helper.py tests/unit_tests/libs/test_helper.py
```

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods