### PR TITLE
feat(api): cache remote recommended app template fetches

### DIFF
--- a/api/configs/feature/hosted_service/__init__.py
+++ b/api/configs/feature/hosted_service/__init__.py
@@ -451,6 +451,12 @@ class HostedFetchAppTemplateConfig(BaseSettings):
         default="https://tmpl.dify.ai",
     )
 
+    HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL: int = Field(
+        description="TTL in seconds for caching remote app template HTTP responses. 0 disables caching.",
+        default=600,
+        ge=0,
+    )
+
 
 class HostedFetchPipelineTemplateConfig(BaseSettings):
     """

--- a/api/services/recommend_app/remote/remote_retrieval.py
+++ b/api/services/recommend_app/remote/remote_retrieval.py
@@ -1,7 +1,9 @@
 import logging
+import threading
 from typing import Any, override
 
 import httpx
+from cachetools import TTLCache
 from flask import has_request_context, request
 from sqlalchemy.orm import Session
 
@@ -13,6 +15,11 @@ from services.recommend_app.recommend_app_type import RecommendAppType
 
 logger = logging.getLogger(__name__)
 
+_REMOTE_FETCH_CACHE_MAXSIZE = 64
+_remote_fetch_cache: TTLCache[tuple[str, str], dict[str, Any]] | None = None
+_remote_fetch_cache_ttl: int | None = None
+_remote_fetch_cache_lock = threading.Lock()
+
 
 def _current_origin_headers() -> dict[str, str]:
     origin = request.headers.get("Origin") if has_request_context() else None
@@ -23,6 +30,61 @@ def _current_origin_headers() -> dict[str, str]:
     if not isinstance(console_web_url, str) or not console_web_url:
         return {}
     return {"Origin": console_web_url}
+
+
+def _remote_fetch_cache_key(url: str, headers: dict[str, str]) -> tuple[str, str]:
+    return url, headers.get("Origin", "")
+
+
+def _hosted_fetch_cache_ttl() -> int:
+    ttl = dify_config.HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL
+    if isinstance(ttl, int) and not isinstance(ttl, bool):
+        return ttl
+    return 600
+
+
+def _get_remote_fetch_cache() -> TTLCache[tuple[str, str], dict[str, Any]] | None:
+    ttl = _hosted_fetch_cache_ttl()
+    if ttl <= 0:
+        return None
+
+    global _remote_fetch_cache, _remote_fetch_cache_ttl
+    if _remote_fetch_cache is None or _remote_fetch_cache_ttl != ttl:
+        with _remote_fetch_cache_lock:
+            if _remote_fetch_cache is None or _remote_fetch_cache_ttl != ttl:
+                _remote_fetch_cache = TTLCache(maxsize=_REMOTE_FETCH_CACHE_MAXSIZE, ttl=ttl)
+                _remote_fetch_cache_ttl = ttl
+    return _remote_fetch_cache
+
+
+def clear_remote_fetch_cache() -> None:
+    """Reset the in-memory remote fetch cache (used by tests)."""
+    global _remote_fetch_cache, _remote_fetch_cache_ttl
+    with _remote_fetch_cache_lock:
+        _remote_fetch_cache = None
+        _remote_fetch_cache_ttl = None
+
+
+def _fetch_remote_payload(url: str) -> tuple[int, dict[str, Any] | None]:
+    headers = _current_origin_headers()
+    cache_key = _remote_fetch_cache_key(url, headers)
+    cache = _get_remote_fetch_cache()
+    if cache is not None:
+        with _remote_fetch_cache_lock:
+            cached = cache.get(cache_key)
+            if cached is not None:
+                return 200, cached
+
+    response = httpx.get(url, headers=headers, timeout=httpx.Timeout(10.0, connect=3.0))
+    status_code = response.status_code
+    if status_code != 200:
+        return status_code, None
+
+    result: dict[str, Any] = response.json()
+    if cache is not None:
+        with _remote_fetch_cache_lock:
+            cache[cache_key] = result
+    return status_code, result
 
 
 class RemoteRecommendAppRetrieval(RecommendAppRetrievalBase):
@@ -75,10 +137,9 @@ class RemoteRecommendAppRetrieval(RecommendAppRetrievalBase):
         """
         domain = dify_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN
         url = f"{domain}/apps/{app_id}"
-        response = httpx.get(url, headers=_current_origin_headers(), timeout=httpx.Timeout(10.0, connect=3.0))
-        if response.status_code != 200:
+        status_code, data = _fetch_remote_payload(url)
+        if status_code != 200:
             return None
-        data: dict[str, Any] = response.json()
         return data
 
     @classmethod
@@ -90,11 +151,10 @@ class RemoteRecommendAppRetrieval(RecommendAppRetrievalBase):
         """
         domain = dify_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN
         url = f"{domain}/apps?language={language}"
-        response = httpx.get(url, headers=_current_origin_headers(), timeout=httpx.Timeout(10.0, connect=3.0))
-        if response.status_code != 200:
-            raise ValueError(f"fetch recommended apps failed, status code: {response.status_code}")
+        status_code, result = _fetch_remote_payload(url)
+        if status_code != 200:
+            raise ValueError(f"fetch recommended apps failed, status code: {status_code}")
 
-        result: dict[str, Any] = response.json()
         return result
 
     @classmethod
@@ -106,9 +166,8 @@ class RemoteRecommendAppRetrieval(RecommendAppRetrievalBase):
         """
         domain = dify_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN
         url = f"{domain}/apps/learn-dify?language={language}"
-        response = httpx.get(url, headers=_current_origin_headers(), timeout=httpx.Timeout(10.0, connect=3.0))
-        if response.status_code != 200:
-            raise ValueError(f"fetch learn dify apps failed, status code: {response.status_code}")
+        status_code, result = _fetch_remote_payload(url)
+        if status_code != 200:
+            raise ValueError(f"fetch learn dify apps failed, status code: {status_code}")
 
-        result: dict[str, Any] = response.json()
         return result

--- a/api/tests/unit_tests/services/recommend_app/test_remote_retrieval.py
+++ b/api/tests/unit_tests/services/recommend_app/test_remote_retrieval.py
@@ -7,7 +7,14 @@ from sqlalchemy import Engine
 from sqlalchemy.orm import Session
 
 from services.recommend_app.recommend_app_type import RecommendAppType
-from services.recommend_app.remote.remote_retrieval import RemoteRecommendAppRetrieval
+from services.recommend_app.remote.remote_retrieval import RemoteRecommendAppRetrieval, clear_remote_fetch_cache
+
+
+@pytest.fixture(autouse=True)
+def _clear_remote_fetch_cache_between_tests():
+    clear_remote_fetch_cache()
+    yield
+    clear_remote_fetch_cache()
 
 
 @pytest.fixture
@@ -249,3 +256,63 @@ class TestFetchFromDifyOfficial:
 
         with pytest.raises(ValueError, match="fetch learn dify apps failed"):
             RemoteRecommendAppRetrieval.fetch_learn_dify_apps_from_dify_official("en-US")
+
+    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
+    @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
+    def test_apps_uses_cache_for_repeated_requests(self, mock_get, mock_config):
+        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
+        mock_config.HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL = 600
+        mock_response = MagicMock(status_code=200)
+        mock_response.json.return_value = {"recommended_apps": [{"id": "app-1"}]}
+        mock_get.return_value = mock_response
+
+        first = RemoteRecommendAppRetrieval.fetch_recommended_apps_from_dify_official("en-US")
+        second = RemoteRecommendAppRetrieval.fetch_recommended_apps_from_dify_official("en-US")
+
+        assert first == second == {"recommended_apps": [{"id": "app-1"}]}
+        mock_get.assert_called_once()
+
+    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
+    @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
+    def test_apps_does_not_cache_failed_responses(self, mock_get, mock_config):
+        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
+        mock_config.HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL = 600
+        mock_get.return_value = MagicMock(status_code=500)
+
+        with pytest.raises(ValueError, match="fetch recommended apps failed"):
+            RemoteRecommendAppRetrieval.fetch_recommended_apps_from_dify_official("en-US")
+        with pytest.raises(ValueError, match="fetch recommended apps failed"):
+            RemoteRecommendAppRetrieval.fetch_recommended_apps_from_dify_official("en-US")
+
+        assert mock_get.call_count == 2
+
+    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
+    @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
+    def test_apps_skips_cache_when_ttl_disabled(self, mock_get, mock_config):
+        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
+        mock_config.HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL = 0
+        mock_response = MagicMock(status_code=200)
+        mock_response.json.return_value = {"recommended_apps": []}
+        mock_get.return_value = mock_response
+
+        RemoteRecommendAppRetrieval.fetch_recommended_apps_from_dify_official("en-US")
+        RemoteRecommendAppRetrieval.fetch_recommended_apps_from_dify_official("en-US")
+
+        assert mock_get.call_count == 2
+
+    @patch("services.recommend_app.remote.remote_retrieval.dify_config")
+    @patch("services.recommend_app.remote.remote_retrieval.httpx.get")
+    def test_apps_cache_isolated_by_origin_header(self, mock_get, mock_config):
+        mock_config.HOSTED_FETCH_APP_TEMPLATES_REMOTE_DOMAIN = "https://example.com"
+        mock_config.HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL = 600
+        mock_response = MagicMock(status_code=200)
+        mock_response.json.return_value = {"recommended_apps": []}
+        mock_get.return_value = mock_response
+
+        flask_app = Flask(__name__)
+        with flask_app.test_request_context(headers={"Origin": "https://cloud-a.example.com"}):
+            RemoteRecommendAppRetrieval.fetch_recommended_apps_from_dify_official("en-US")
+        with flask_app.test_request_context(headers={"Origin": "https://cloud-b.example.com"}):
+            RemoteRecommendAppRetrieval.fetch_recommended_apps_from_dify_official("en-US")
+
+        assert mock_get.call_count == 2


### PR DESCRIPTION
## Summary

Fixes #40129.

`HOSTED_FETCH_APP_TEMPLATES_MODE=remote` previously called `https://tmpl.dify.ai` via bare `httpx.get()` on every Explore / Learn Dify request with no caching. On slow or blocked networks this blocked SSR for up to the 10s timeout before falling back to builtin data.

This PR adds an in-memory TTL cache around remote template fetches in `RemoteRecommendAppRetrieval`:

- caches successful `200` JSON responses for `apps`, `apps/{id}`, and `apps/learn-dify` endpoints
- cache key: request URL + `Origin` header (matches existing origin-forwarding behavior)
- TTL configurable via `HOSTED_FETCH_APP_TEMPLATES_CACHE_TTL` (default **600** seconds; **0** disables caching)
- failed / non-200 responses are **not** cached

## Test plan

- [x] `uv run pytest tests/unit_tests/services/recommend_app/test_remote_retrieval.py -q` — 22 passed
- [x] New coverage: repeated calls hit cache once, failures not cached, TTL=0 disables cache, separate origins get separate cache entries
- [x] `uv run ruff check` on changed files — passed

### VM commands

```bash
cd api
uv run pytest tests/unit_tests/services/recommend_app/test_remote_retrieval.py -q
uv run ruff check services/recommend_app/remote/remote_retrieval.py \
  configs/feature/hosted_service/__init__.py \
  tests/unit_tests/services/recommend_app/test_remote_retrieval.py
```

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods