### PR TITLE
fix(api): use constant-time HMAC compare for signed file URLs

### DIFF
--- a/api/core/app/workflow/file_runtime.py
+++ b/api/core/app/workflow/file_runtime.py
@@ -150,7 +150,8 @@ class DifyWorkflowFileRuntime(WorkflowFileRuntimeProtocol):
     ) -> bool:
         payload = f"{preview_kind}-preview|{file_id}|{timestamp}|{nonce}"
         recalculated = hmac.new(self._secret_key(), payload.encode(), hashlib.sha256).digest()
-        if sign != base64.urlsafe_b64encode(recalculated).decode():
+        expected = base64.urlsafe_b64encode(recalculated).decode()
+        if not hmac.compare_digest(sign, expected):
             return False
         return int(time.time()) - int(timestamp) <= dify_config.FILES_ACCESS_TIMEOUT
 

--- a/api/core/tools/signature.py
+++ b/api/core/tools/signature.py
@@ -80,8 +80,8 @@ def verify_tool_file_signature(file_id: str, timestamp: str, nonce: str, sign: s
     recalculated_sign = hmac.new(_secret_key(), data_to_sign.encode(), hashlib.sha256).digest()
     recalculated_encoded_sign = base64.urlsafe_b64encode(recalculated_sign).decode()
 
-    # verify signature
-    if sign != recalculated_encoded_sign:
+    # verify signature (constant-time; matches remote_fetcher)
+    if not hmac.compare_digest(sign, recalculated_encoded_sign):
         return False
 
     current_time = int(time.time())
@@ -154,7 +154,7 @@ def verify_plugin_file_signature(
     recalculated_sign = hmac.new(_secret_key(), data_to_sign.encode(), hashlib.sha256).digest()
     recalculated_encoded_sign = base64.urlsafe_b64encode(recalculated_sign).decode()
 
-    if sign != recalculated_encoded_sign:
+    if not hmac.compare_digest(sign, recalculated_encoded_sign):
         return False
 
     current_time = int(time.time())


### PR DESCRIPTION
## Summary
- `verify_tool_file_signature`, `verify_plugin_file_signature`, and workflow `verify_preview_signature` compared HMAC digests with `!=`.
- `remote_fetcher._verify_signed_file_url` already uses `hmac.compare_digest`.
- Switch the remaining signed-URL verifiers to `hmac.compare_digest` for constant-time comparison.

Sibling of open hardening work (#33766 / #39523) but covers different call sites (tool/plugin/preview URLs).

## Test plan
- [x] `python3 -m py_compile` on touched modules
- [ ] Existing unit tests in `api/tests/unit_tests/core/tools/test_signature.py` (roundtrip / reject invalid / reject expired)


Made with [Cursor](https://cursor.com)