### PR TITLE
fix(feedback): include the full end date in exports

### DIFF
--- a/api/services/feedback_service.py
+++ b/api/services/feedback_service.py
@@ -1,7 +1,7 @@
 import csv
 import io
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from flask import Response
 from sqlalchemy import or_, select
@@ -75,8 +75,8 @@ class FeedbackService:
 
         if end_date:
             try:
-                end_dt = datetime.strptime(end_date, "%Y-%m-%d")
-                stmt = stmt.where(MessageFeedback.created_at <= end_dt)
+                end_dt = datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)
+                stmt = stmt.where(MessageFeedback.created_at < end_dt)
             except ValueError:
                 raise ValueError(f"Invalid end_date format: {end_date}. Use YYYY-MM-DD")
 

--- a/api/tests/integration_tests/controllers/console/app/test_feedback_export_api.py
+++ b/api/tests/integration_tests/controllers/console/app/test_feedback_export_api.py
@@ -299,6 +299,23 @@ class TestFeedbackExportApi:
             format_type="csv",
         )
 
+    def test_feedback_export_end_date_includes_the_full_day(self):
+        session = mock.Mock()
+        session.execute.return_value.all.return_value = []
+
+        FeedbackService.export_feedbacks(
+            str(uuid.uuid4()),
+            session=session,
+            end_date="2024-12-31",
+            format_type="json",
+        )
+
+        statement = session.execute.call_args.args[0]
+        compiled = str(statement.compile(compile_kwargs={"literal_binds": True}))
+
+        assert "2025-01-01 00:00:00" in compiled
+        assert "2024-12-31 00:00:00" not in compiled
+
     def test_feedback_export_invalid_date_format(
         self, test_client: FlaskClient, auth_header, monkeypatch: pytest.MonkeyPatch, mock_app_model, mock_account
     ):


### PR DESCRIPTION
## Summary

- Make the `end_date` filter include the entire selected calendar day by using the next midnight as an exclusive upper bound.
- Add a regression test that compiles the generated statement and verifies the boundary.

Fixes #40050

OpenJobs listing: 70a9a0fd-82d3-41b2-b92d-a8509998d6b5 (https://openjobs.bot/jobs/70a9a0fd-82d3-41b2-b92d-a8509998d6b5)

## Testing

- Python compileall passed for the changed service and test.
- Full project pytest collection was not runnable in this environment because Flask/project dependencies are not installed.
- The regression assertion checks that the upper bound is 2025-01-01 00:00:00 rather than 2024-12-31 00:00:00.

## Checklist

- [x] Linked issue: Fixes #40050
- [x] Scope limited to the feedback service and focused integration regression test.
- [x] Regression coverage added.
- [x] Self-review completed.

From Codex