### PR TITLE
fix(web): use a primary heading on the install page

### DIFF
--- a/web/app/install/installForm.spec.tsx
+++ b/web/app/install/installForm.spec.tsx
@@ -45,6 +45,7 @@ describe('InstallForm', () => {
     render(<InstallForm />)
 
     expect(await screen.findByLabelText('login.email')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('login.setAdminAccount')
     expect(screen.getByRole('button', { name: /login\.installBtn/ })).toBeInTheDocument()
   })
 

--- a/web/app/install/installForm.tsx
+++ b/web/app/install/installForm.tsx
@@ -105,9 +105,9 @@ const InstallForm = () => {
   ) : (
     <>
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
-        <h2 className="text-[32px] font-bold text-text-primary">
+        <h1 className="text-[32px] font-bold text-text-primary">
           {t(($) => $.setAdminAccount, { ns: 'login' })}
-        </h2>
+        </h1>
         <p className="mt-1 text-sm text-text-secondary">
           {t(($) => $.setAdminAccountDesc, { ns: 'login' })}
         </p>


### PR DESCRIPTION
## Summary

- expose the install page title as its primary h1
- query the title by heading level in the owner test

## Review boundary

Copy, class names, installation form, validation, submission, and layout are unchanged.

## Visual regression review

The title keeps the same classes and preflight removes native heading margins, so no visible delta is expected.

## Verification

- owner suite: 6/6 passed
- standalone a11y lint: 0 diagnostics
- diff check: passed

## Dependency and rollback

Independent root layer based on main.