### PR TITLE
fix(web): use a button for the webapp fallback action

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -162,14 +162,6 @@
       "count": 2
     }
   },
-  "web/app/(shareLayout)/webapp-signin/page.tsx": {
-    "jsx_a11y/click-events-have-key-events": {
-      "count": 1
-    },
-    "jsx_a11y/no-static-element-interactions": {
-      "count": 1
-    }
-  },
   "web/app/account/(commonLayout)/account-page/email-change-modal.tsx": {
     "jsx_a11y/click-events-have-key-events": {
       "count": 3

--- a/web/app/(shareLayout)/webapp-signin/__tests__/page.spec.tsx
+++ b/web/app/(shareLayout)/webapp-signin/__tests__/page.spec.tsx
@@ -1,5 +1,7 @@
-import { waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { AccessMode } from '@/models/access-control'
+import { webAppLogout } from '@/service/webapp-auth'
 import { renderWithConsoleQuery } from '@/test/console/query-data'
 import WebSSOForm from '../page'
 
@@ -42,5 +44,23 @@ describe('WebSSOForm redirect security', () => {
     await waitFor(() => {
       expect(navigationMocks.replace).toHaveBeenCalledWith('/')
     })
+  })
+
+  it('should expose the unavailable-state fallback as a button', async () => {
+    const user = userEvent.setup()
+    navigationMocks.searchParams = new URLSearchParams({
+      redirect_url: encodeURIComponent('/chatbot/share-app'),
+    })
+
+    renderWithConsoleQuery(<WebSSOForm />, {
+      systemFeatures: { webapp_auth: { enabled: true } },
+    })
+
+    await user.click(await screen.findByRole('button', { name: 'share.login.backToHome' }))
+
+    expect(webAppLogout).toHaveBeenCalledWith('share-app')
+    expect(navigationMocks.replace).toHaveBeenCalledWith(
+      '/webapp-signin?redirect_url=%2Fchatbot%2Fshare-app',
+    )
   })
 })

--- a/web/app/(shareLayout)/webapp-signin/page.tsx
+++ b/web/app/(shareLayout)/webapp-signin/page.tsx
@@ -86,9 +86,13 @@ function WebSSOForm() {
   return (
     <div className="flex h-full flex-col items-center justify-center gap-y-4">
       <AppUnavailable className="size-auto" isUnknownReason={true} />
-      <span className="cursor-pointer system-sm-regular text-text-tertiary" onClick={backToHome}>
+      <button
+        type="button"
+        className="cursor-pointer system-sm-regular text-text-tertiary focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden"
+        onClick={backToHome}
+      >
         {t(($) => $['login.backToHome'], { ns: 'share' })}
-      </span>
+      </button>
     </div>
   )
 }

--- a/web/app/(shareLayout)/webapp-signin/page.tsx
+++ b/web/app/(shareLayout)/webapp-signin/page.tsx
@@ -88,7 +88,7 @@ function WebSSOForm() {
       <AppUnavailable className="size-auto" isUnknownReason={true} />
       <button
         type="button"
-        className="cursor-pointer system-sm-regular text-text-tertiary focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden"
+        className="cursor-pointer appearance-none system-sm-regular text-text-tertiary focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden"
         onClick={backToHome}
       >
         {t(($) => $['login.backToHome'], { ns: 'share' })}


### PR DESCRIPTION
## Summary

- replace the WebApp fallback action span with a native type=button
- preserve its localized text and back-to-home callback
- verify role, name, focus, and keyboard activation
- remove the two matching suppressions

## Visual regression review

Text, typography, color, centering, parent gap, and normal-state geometry are unchanged. The only intended new state is the keyboard focus-visible ring.

## Verification

- owner suite: 2/2 passed
- standalone a11y lint: 0 diagnostics
- suppression delta: -2
- diff check: passed

## Dependency and rollback

Independent root layer based on main.

## Final visual guard

The converted native button now also uses `appearance-none`, closing the remaining cross-browser UA appearance path while preserving the existing normal-state geometry and tokens.