### PR TITLE
fix(web): name the chat settings trigger

### DIFF
--- a/web/app/components/base/chat/embedded-chatbot/inputs-form/__tests__/view-form-dropdown.spec.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/inputs-form/__tests__/view-form-dropdown.spec.tsx
@@ -11,13 +11,16 @@ describe('ViewFormDropdown', () => {
     const user = userEvent.setup()
     render(<ViewFormDropdown />)
 
-    const trigger = screen.getByTestId('view-form-dropdown-trigger')
+    const trigger = screen.getByRole('button', { name: 'share.chat.viewChatSettings' })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
     expect(screen.queryByText('Form content')).not.toBeInTheDocument()
 
     await user.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
     expect(screen.getByText('Form content')).toBeInTheDocument()
 
     await user.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
     expect(screen.queryByText('Form content')).not.toBeInTheDocument()
   })
 })

--- a/web/app/components/base/chat/embedded-chatbot/inputs-form/view-form-dropdown.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/inputs-form/view-form-dropdown.tsx
@@ -19,9 +19,12 @@ const ViewFormDropdown = ({ iconColor }: Props) => {
             {...props}
             size="l"
             state={state.open ? ActionButtonState.Hover : ActionButtonState.Default}
-            data-testid="view-form-dropdown-trigger"
+            aria-label={t(($) => $['chat.viewChatSettings'], { ns: 'share' })}
           >
-            <div className={cn('i-ri-chat-settings-line h-4.5 w-4.5 shrink-0', iconColor)} />
+            <span
+              aria-hidden
+              className={cn('i-ri-chat-settings-line h-4.5 w-4.5 shrink-0', iconColor)}
+            />
           </ActionButton>
         )}
       />


### PR DESCRIPTION
## Summary

Give the embedded chat settings icon button an accessible name and migrate its test away from `data-testid`.

This is the bottom PR in the Chat accessibility stack and targets `main`.

## Behavioral contract

- The icon-only trigger is named by the existing localized View chat settings action.
- The icon is decorative and does not contribute to the accessible name.
- The trigger remains a native ActionButton and exposes its open state through `aria-expanded`.
- The owner test locates the control by role and name and verifies closed, open, and closed-again states.

## Scope

- One production component and its existing owner test.
- One trigger `data-testid` removed after the semantic locator became available.
- One commit: `b250d73cbd`.

## HTML validity

The icon wrapper changes from `div` to `span`, keeping the button content within the phrasing-content model. The icon utility supplies the same inline-block geometry and all size/color classes are unchanged.

## Non-goals

- No global `data-testid` policy or deletion.
- The unused content test hook remains for a dedicated test-hygiene audit.
- No Popover primitive, layout, form, or CSS icon refactor.

## Suppression status

No suppression is changed because this missing-name case is not currently covered by the repository jsx-a11y baseline rules. The targeted standalone a11y lint is clean, while the semantic test supplies the missing regression gate.

## Verification

- Red before implementation: the test found an unnamed button and could not query View chat settings by role/name.
- `pnpm --dir web exec vitest run app/components/base/chat/embedded-chatbot/inputs-form/__tests__/view-form-dropdown.spec.tsx`
  - 1 file, 1 test passed.
- `pnpm --dir web lint:a11y app/components/base/chat/embedded-chatbot/inputs-form/view-form-dropdown.tsx`
  - 0 diagnostics.
- `vp check --fix <two changed files>`
  - 0 errors and 0 warnings.
- `git diff --check`
  - passed.

## Visual regression review

- ActionButton, size, state, icon utility, dimensions, shrink behavior, and optional color class are unchanged.
- `aria-label` and `aria-hidden` do not affect layout or paint.
- The icon wrapper keeps the same generated icon display and exact class list.
- No focus, hover, active, spacing, typography, or responsive class changed.

Reviewer check: this PR should have no visual CSS delta.

## Rollback

Revert `b250d73cbd`; the production semantics and semantic locator roll back together.

From Codex