### PR TITLE
fix(web): hide citation measurement items from assistive tech

### DIFF
--- a/web/app/components/base/chat/chat/citation/__tests__/index.spec.tsx
+++ b/web/app/components/base/chat/chat/citation/__tests__/index.spec.tsx
@@ -96,7 +96,9 @@ describe('Citation', () => {
           ]}
         />,
       )
-      expect(screen.getAllByTestId('citation-measurement-item')).toHaveLength(2)
+      const measurementItems = screen.getAllByTestId('citation-measurement-item')
+      expect(measurementItems).toHaveLength(2)
+      measurementItems.forEach((item) => expect(item).toHaveAttribute('aria-hidden', 'true'))
     })
 
     it('should display the document name inside each measurement item', () => {

--- a/web/app/components/base/chat/chat/citation/index.tsx
+++ b/web/app/components/base/chat/chat/citation/index.tsx
@@ -86,6 +86,7 @@ const Citation: FC<CitationProps> = ({
         {resources.map((res, index) => (
           <div
             key={res.documentId}
+            aria-hidden
             data-testid="citation-measurement-item"
             className="absolute top-0 left-0 -z-10 mr-1 mb-1 h-7 w-auto max-w-60 pr-2 pl-7 text-xs whitespace-nowrap opacity-0"
             ref={(ele: HTMLDivElement | null) => {


### PR DESCRIPTION
## Summary

Hide citation measurement-only copies from the accessibility tree while preserving their DOM geometry and measurement locator.

This is a deliberately small owner-local layer in the Chat accessibility stack. The following layer handles the separate interactive citation toggle.

## Behavior contract

- One hidden measurement element remains rendered for each unique citation document.
- Measurement elements keep their text and `clientWidth` behavior for the existing layout calculation.
- Duplicate document names from those opacity-hidden elements are not exposed to assistive technology.

## Scope

- Add `aria-hidden` to the existing measurement elements.
- Retain `data-testid="citation-measurement-item"` because it represents a real geometry boundary used by the test harness.
- Add a focused assertion for the accessibility-tree boundary.

## Non-goals

- No citation layout algorithm change.
- No citation toggle change; that is the next stack layer.
- No refactor of the existing effect or measurement ownership.
- No test-id cleanup where geometry, rather than user interaction, is under test.

## Verification

- Red/green regression: the focused test failed before production code because the elements had no `aria-hidden`, then passed after the fix.
- `cd web && pnpm exec vp test run app/components/base/chat/chat/citation/__tests__/index.spec.tsx` — 1 file, 21 tests passed.
- `git diff --check` — passed.

The file-targeted lint command still reports three pre-existing baselined diagnostics in `citation/index.tsx`: two for the separate clickable toggle and one for the existing measurement effect. This layer adds no lint diagnostic. The next layer removes the two toggle diagnostics; the effect remains outside this PR's behavior contract.

## Visual regression review

There is no visual or layout delta: `aria-hidden` only changes accessibility-tree exposure. The element, text, classes, opacity, positioning, ref assignment, and `clientWidth` measurement remain unchanged.

## Rollback

Revert this PR only. The layout algorithm and public component API are unchanged.

- [x] Added a behavior-focused regression assertion.
- [x] Kept the change atomic and owner-local.
- [x] No documentation update is required.

From Codex
