### PR TITLE
fix(web): make the citation toggle a button

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -852,12 +852,6 @@
   "web/app/components/base/chat/chat/citation/index.tsx": {
     "eslint-react/set-state-in-effect": {
       "count": 1
-    },
-    "jsx_a11y/click-events-have-key-events": {
-      "count": 1
-    },
-    "jsx_a11y/no-static-element-interactions": {
-      "count": 1
     }
   },
   "web/app/components/base/chat/chat/hooks.ts": {

--- a/web/app/components/base/chat/chat/citation/__tests__/index.spec.tsx
+++ b/web/app/components/base/chat/chat/citation/__tests__/index.spec.tsx
@@ -226,7 +226,7 @@ describe('Citation', () => {
         />,
       )
       expect(screen.getAllByTestId('popup')).toHaveLength(3)
-      expect(screen.queryByTestId('citation-more-toggle')).not.toBeInTheDocument()
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
     })
   })
 
@@ -246,7 +246,11 @@ describe('Citation', () => {
           ]}
         />,
       )
-      expect(screen.getByTestId('citation-more-toggle')).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', {
+          name: 'share.chat.expand common.chat.citation.title',
+        }),
+      ).toHaveAttribute('aria-expanded', 'false')
     })
   })
 
@@ -268,7 +272,11 @@ describe('Citation', () => {
           ]}
         />,
       )
-      expect(screen.getByTestId('citation-more-toggle')).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', {
+          name: 'share.chat.expand common.chat.citation.title',
+        }),
+      ).toHaveAttribute('aria-expanded', 'false')
       expect(screen.getAllByTestId('popup')).toHaveLength(2)
     })
   })
@@ -290,42 +298,74 @@ describe('Citation', () => {
           ]}
         />,
       )
-      return screen.getByTestId('citation-more-toggle')
+      return screen.getByRole('button', {
+        name: 'share.chat.expand common.chat.citation.title',
+      })
     }
 
     it('should show the overflow count label matching /+\\s*\\d+/ on the more-toggle in collapsed state', () => {
-      renderOverflowScenario()
-      expect(screen.getByTestId('citation-more-toggle').textContent).toMatch(/^\+\s*\d+$/)
+      const toggle = renderOverflowScenario()
+      expect(toggle).toHaveAttribute('aria-expanded', 'false')
+      expect(toggle.textContent).toMatch(/^\+\s*\d+$/)
     })
 
-    it('should display the collapse icon div after clicking more-toggle to expand', async () => {
+    it('should expose the expanded state and collapse action after clicking more-toggle', async () => {
       const user = userEvent.setup()
-      renderOverflowScenario()
+      const toggle = renderOverflowScenario()
 
-      await user.click(screen.getByTestId('citation-more-toggle'))
+      await user.click(toggle)
 
-      expect(document.querySelector('.i-ri-arrow-down-s-line')).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', {
+          name: 'share.chat.collapse common.chat.citation.title',
+        }),
+      ).toHaveAttribute('aria-expanded', 'true')
     })
 
     it('should return to the count label after clicking the toggle a second time to collapse', async () => {
       const user = userEvent.setup()
-      renderOverflowScenario()
+      const toggle = renderOverflowScenario()
 
-      await user.click(screen.getByTestId('citation-more-toggle'))
-      await user.click(screen.getByTestId('citation-more-toggle'))
+      await user.click(toggle)
+      await user.click(
+        screen.getByRole('button', {
+          name: 'share.chat.collapse common.chat.citation.title',
+        }),
+      )
 
-      expect(screen.getByTestId('citation-more-toggle').textContent).toMatch(/^\+\s*\d+$/)
+      expect(
+        screen.getByRole('button', {
+          name: 'share.chat.expand common.chat.citation.title',
+        }).textContent,
+      ).toMatch(/^\+\s*\d+$/)
     })
 
     it('should show all resource popups after expanding via the more-toggle', async () => {
       const user = userEvent.setup()
-      renderOverflowScenario()
+      const toggle = renderOverflowScenario()
 
-      await user.click(screen.getByTestId('citation-more-toggle'))
+      await user.click(toggle)
 
       await waitFor(() => {
         expect(screen.getAllByTestId('popup')).toHaveLength(3)
       })
+    })
+
+    it.each([
+      ['Enter', '{Enter}'],
+      ['Space', ' '],
+    ])('should expand with the %s key', async (_, key) => {
+      const user = userEvent.setup()
+      const toggle = renderOverflowScenario()
+
+      toggle.focus()
+      await user.keyboard(key)
+
+      expect(
+        screen.getByRole('button', {
+          name: 'share.chat.collapse common.chat.citation.title',
+        }),
+      ).toHaveAttribute('aria-expanded', 'true')
     })
   })
 
@@ -335,7 +375,7 @@ describe('Citation', () => {
       setupContainer()
       render(<Citation data={[makeCitationItem()]} />)
       expect(screen.getAllByTestId('citation-measurement-item')).toHaveLength(1)
-      expect(screen.queryByTestId('citation-more-toggle')).not.toBeInTheDocument()
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
     })
 
     it('should handle all citations sharing one document_id as a single resource', () => {

--- a/web/app/components/base/chat/chat/citation/index.tsx
+++ b/web/app/components/base/chat/chat/citation/index.tsx
@@ -112,7 +112,7 @@ const Citation: FC<CitationProps> = ({
             type="button"
             aria-expanded={showMore}
             aria-label={citationToggleLabel}
-            className="flex h-7 cursor-pointer items-center rounded-lg bg-components-panel-bg px-2 system-xs-medium text-text-tertiary focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden"
+            className="flex h-7 cursor-pointer appearance-none items-center rounded-lg bg-components-panel-bg px-2 system-xs-medium text-text-tertiary focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden"
             onClick={() => setShowMore((v) => !v)}
           >
             {!showMore ? (

--- a/web/app/components/base/chat/chat/citation/index.tsx
+++ b/web/app/components/base/chat/chat/citation/index.tsx
@@ -72,6 +72,12 @@ const Citation: FC<CitationProps> = ({
   }, [])
 
   const resourcesLength = resources.length
+  const citationTitle = t(($) => $['chat.citation.title'], { ns: 'common' })
+  const citationToggleLabel = `${
+    showMore
+      ? t(($) => $['chat.collapse'], { ns: 'share' })
+      : t(($) => $['chat.expand'], { ns: 'share' })
+  } ${citationTitle}`
 
   return (
     <div className="mt-3 -mb-1">
@@ -79,7 +85,7 @@ const Citation: FC<CitationProps> = ({
         data-testid="citation-title"
         className="mb-2 flex items-center system-xs-medium text-text-tertiary"
       >
-        {t(($) => $['chat.citation.title'], { ns: 'common' })}
+        {citationTitle}
         <div className="ml-2 h-px grow bg-divider-regular" />
       </div>
       <div className="relative flex flex-wrap">
@@ -102,17 +108,22 @@ const Citation: FC<CitationProps> = ({
           </div>
         ))}
         {limitNumberInOneLine < resourcesLength && (
-          <div
-            data-testid="citation-more-toggle"
-            className="flex h-7 cursor-pointer items-center rounded-lg bg-components-panel-bg px-2 system-xs-medium text-text-tertiary"
+          <button
+            type="button"
+            aria-expanded={showMore}
+            aria-label={citationToggleLabel}
+            className="flex h-7 cursor-pointer items-center rounded-lg bg-components-panel-bg px-2 system-xs-medium text-text-tertiary focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden"
             onClick={() => setShowMore((v) => !v)}
           >
             {!showMore ? (
               `+ ${resourcesLength - limitNumberInOneLine}`
             ) : (
-              <div className="i-ri-arrow-down-s-line size-4 rotate-180 text-text-tertiary" />
+              <span
+                aria-hidden
+                className="i-ri-arrow-down-s-line size-4 rotate-180 text-text-tertiary"
+              />
             )}
-          </div>
+          </button>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Make the citation overflow control a native button with a localized action name and explicit expanded state.

This layer follows the measurement-only accessibility boundary in #40203. The two changes share the Citation owner but remain independently reviewable and revertible.

## Behavior contract

- The overflow control is absent when every citation fits.
- Pointer click, Enter, and Space expand the same set of resources.
- The accessible name changes between Expand citations and Collapse citations.
- `aria-expanded` matches whether all citation resources are shown.
- The collapse arrow remains decorative.

## Scope

- Replace the clickable `div` with `button type="button"`.
- Keep the existing height, padding, flex alignment, background, radius, typography, and text color classes.
- Add the project-standard `focus-visible` ring.
- Remove the interaction `data-testid` and migrate tests to role, localized name, expanded state, pointer behavior, Enter, and Space.
- Remove exactly the two resolved jsx-a11y suppressions while retaining the unrelated existing effect suppression.

## Non-goals

- No citation measurement algorithm or effect refactor.
- No Popup behavior change.
- No shared disclosure abstraction.
- No `React.FC` or unrelated icon cleanup.

## Verification

- Red/green regression: 8 semantic assertions failed before the production change because no button role existed.
- `cd web && pnpm exec vp test run app/components/base/chat/chat/citation/__tests__/index.spec.tsx` — 1 file, 23 tests passed.
- `cd web && pnpm lint:a11y app/components/base/chat/chat/citation/index.tsx` — passed.
- `cd web && pnpm exec vp fmt app/components/base/chat/chat/citation/index.tsx app/components/base/chat/chat/citation/__tests__/index.spec.tsx --check` — passed.
- `pnpm lint:oxlint --prune-suppressions` — passed; only the two resolved toggle diagnostics were removed from this file.
- `git diff --check` — passed.

The file keeps one pre-existing `set-state-in-effect` suppression. It is a separate measurement-ownership refactor and is not required for this interaction contract.

## Visual regression review

The new button retains the old control's complete normal-state class list: `flex`, `h-7`, horizontal padding, center alignment, radius, background, typography, and color. Repository preflight removes native button border/background defaults and resets margin and padding before utility classes apply. The visible count and arrow are unchanged. The only intended visual delta is the standard ring in `:focus-visible`.

Reviewer checks:

- Compare the `+ N` control width, height, text alignment, background, and baseline before/after.
- Compare the expanded arrow size and centering.
- Confirm no native border or extra padding appears in pointer-only states.
- Confirm the ring appears only with keyboard focus.

## Rollback

Revert this PR only. #40203 can remain because its measurement-tree boundary is independent.

- [x] Added behavior-focused semantic tests.
- [x] Kept the change atomic and owner-local.
- [x] No documentation update is required.

From Codex

## Final visual guard

The converted native button now also uses `appearance-none`, closing the remaining cross-browser UA appearance path while preserving the existing normal-state geometry and tokens.