### PR TITLE
fix(web): expose the voice recording timer

### DIFF
--- a/e2e/features/step-definitions/agent-v2/speech-to-text.steps.ts
+++ b/e2e/features/step-definitions/agent-v2/speech-to-text.steps.ts
@@ -50,10 +50,9 @@ When(
     const page = this.getPage()
     const agentId = getCurrentAgentId(this)
 
-    await expect(page.getByTestId('voice-input-timer')).toHaveText(
-      voiceInputTestMaterial.recordingDuration,
-      { timeout: 15_000 },
-    )
+    await expect(page.getByRole('timer')).toHaveText(voiceInputTestMaterial.recordingDuration, {
+      timeout: 15_000,
+    })
 
     const responsePromise = page.waitForResponse(
       (response) =>

--- a/web/app/components/base/voice-input/__tests__/index.spec.tsx
+++ b/web/app/components/base/voice-input/__tests__/index.spec.tsx
@@ -101,7 +101,7 @@ describe('VoiceInput', () => {
 
       expect(await screen.findByText('common.voiceInput.speaking')).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'common.voiceInput.stop' })).toBeInTheDocument()
-      expect(screen.getByTestId('voice-input-timer')).toHaveTextContent('00:00')
+      expect(screen.getByRole('timer')).toHaveTextContent('00:00')
       expect(getByteFrequencyData).toHaveBeenCalledTimes(1)
     })
 
@@ -301,7 +301,7 @@ describe('VoiceInput', () => {
 
       act(() => vi.advanceTimersByTime(1000))
 
-      expect(screen.getByTestId('voice-input-timer')).toHaveTextContent('00:01')
+      expect(screen.getByRole('timer')).toHaveTextContent('00:01')
     })
 
     it('should stop automatically at ten minutes', async () => {
@@ -312,7 +312,7 @@ describe('VoiceInput', () => {
       await act(async () => {})
 
       expect(recorderStop).toHaveBeenCalledTimes(1)
-      expect(screen.getByTestId('voice-input-timer')).toHaveTextContent('10:00')
+      expect(screen.getByRole('timer')).toHaveTextContent('10:00')
     })
   })
 })

--- a/web/app/components/base/voice-input/index.tsx
+++ b/web/app/components/base/voice-input/index.tsx
@@ -249,11 +249,11 @@ function VoiceInput({
           </button>
         )}
         <div
+          role="timer"
           className={cn(
             'w-11.25 pl-1 text-xs font-medium',
             duration > 500 ? 'text-text-destructive' : 'text-text-secondary',
           )}
-          data-testid="voice-input-timer"
         >
           {`${minutes}:${seconds}`}
         </div>


### PR DESCRIPTION
## Summary

Expose the elapsed voice-recording display as the standard ARIA timer role and migrate its component and Agent v2 E2E locators to that user-facing semantic contract.

This is an independent one-layer stack from `main`; it has no dependency on the Auth or Chat stacks.

## Behavior contract

- The visible elapsed time remains `MM:SS` through recording and conversion.
- Assistive technology and tests can identify the elapsed display as a timer.
- The owner-level test and Playwright step observe the same public role.
- The timer does not become a live announcement region and does not interrupt users every second.

## Scope

- Add `role="timer"` to the existing elapsed-time element.
- Remove `data-testid="voice-input-timer"` after migrating all four consumers: three RTL assertions and one Agent v2 Playwright locator.
- Keep the E2E wait and fixture-duration assertion unchanged.

## Non-goals

- No recording lifecycle, timer arithmetic, audio fixture, or speech-to-text behavior change.
- No new translation key or accessible-name policy.
- No Storybook cleanup.
- No visual style or layout change.

## Verification

- Red/green regression: after semantic locator migration, 3 of 15 component tests failed because no timer role existed; all passed after the production change.
- `cd web && pnpm exec vp test run app/components/base/voice-input/__tests__/index.spec.tsx` — 1 file, 15 tests passed.
- `cd web && pnpm lint:a11y app/components/base/voice-input/index.tsx` — passed.
- `cd web && pnpm exec vp check app/components/base/voice-input/index.tsx app/components/base/voice-input/__tests__/index.spec.tsx` — no warnings, lint errors, or type errors.
- `cd e2e && pnpm exec vp check --fix features/step-definitions/agent-v2/speech-to-text.steps.ts` — no warnings, lint errors, or type errors.
- `pnpm check` — passed; 8358 files formatted, 0 errors, existing repository warnings only.
- `git diff --check` — passed.

The full `@microphone @external-model` scenario was not run locally because it requires the dedicated fake-microphone and external-model runtime lane. The locator remains inside the existing web-first assertion and keeps its 15-second behavior timeout.

## Visual regression review

There is no visual delta. The element type, text, classes, width, padding, typography, color threshold, and layout position are unchanged; only its DOM role changes.

## Rollback

Revert this PR only. It has no schema, fixture, API, or shared component dependency.

- [x] Added a semantic product contract and migrated every known locator.
- [x] Kept the change atomic and independently revertible.
- [x] No documentation update is required.

From Codex
