### PR TITLE
refactor(web): simplify the member selector component

### DIFF
--- a/web/app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx
+++ b/web/app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx
@@ -1,8 +1,6 @@
 'use client'
-import type { FC } from 'react'
 import { Avatar } from '@langgenius/dify-ui/avatar'
 import { Popover, PopoverContent, PopoverTrigger } from '@langgenius/dify-ui/popover'
-import * as React from 'react'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Input from '@/app/components/base/input'
@@ -14,7 +12,7 @@ type Props = Readonly<{
   exclude?: string[]
 }>
 
-const MemberSelector: FC<Props> = ({ value, onSelect, exclude = [] }) => {
+function MemberSelector({ value, onSelect, exclude = [] }: Props) {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
   const [searchValue, setSearchValue] = useState('')


### PR DESCRIPTION
## Summary

Simplify the transfer-ownership MemberSelector declaration before the separate accessibility change: use a typed function declaration instead of `React.FC` and remove the redundant React namespace import.

This is the bottom layer of an independent Account settings stack from `main`.

## Contract

- Component props, rendering, state ownership, imports with runtime effects, and exported API remain unchanged.
- No DOM, styling, event, query, or translation behavior changes.
- The following stack layer can focus only on interactive semantics.

## Scope

- Remove the `FC` type import.
- Remove the unused React namespace import.
- Type the existing function parameter directly with `Props`.

## Non-goals

- No interactive element change.
- No legacy Input migration. The remaining `no-restricted-imports` suppression belongs to the deprecated web Input import and requires a separate Dify UI standalone-input contract review.
- No suppression change in this PR.

## Verification

- `cd web && pnpm exec vp test run app/components/header/account-setting/members-page/transfer-ownership-modal/__tests__/member-selector.spec.tsx` — 1 file, 12 tests passed.
- `git diff --check` — passed.

## Visual regression review

There is no DOM or class diff, so no visual or layout change is possible from this layer.

## Rollback

Revert this PR only. The following accessibility layer can be reviewed separately against either declaration style if needed.

- [x] Kept non-accessibility cleanup separate from semantic changes.
- [x] No documentation update is required.

From Codex
