### PR TITLE
refactor(api): extract recommended app query service

### DIFF
--- a/api/.importlinter
+++ b/api/.importlinter
@@ -200,3 +200,21 @@ forbidden_modules =
     repositories
     sqlalchemy
     werkzeug
+
+[importlinter:contract:recommended-app-query-service-boundary]
+name = Recommended app query application service is framework and persistence neutral
+type = forbidden
+source_modules =
+    services.recommended_app_query_service
+forbidden_modules =
+    configs
+    controllers
+    extensions
+    flask
+    models
+    repositories
+    services.recommend_app
+    services.recommended_app_query_compat
+    services.recommended_app_service
+    sqlalchemy
+    werkzeug

--- a/api/controllers/console/explore/error.py
+++ b/api/controllers/console/explore/error.py
@@ -31,6 +31,12 @@ class AppAccessDeniedError(BaseHTTPException):
     code = 403
 
 
+class RecommendedAppNotFoundError(BaseHTTPException):
+    error_code = "recommended_app_not_found"
+    description = "Recommended app not found."
+    code = 404
+
+
 class TrialAppNotAllowed(BaseHTTPException):
     """*403* `Trial App Not Allowed`
 

--- a/api/controllers/console/explore/recommended_app.py
+++ b/api/controllers/console/explore/recommended_app.py
@@ -2,18 +2,18 @@ from typing import Any
 from uuid import UUID
 
 from flask_restx import Resource
-from pydantic import BaseModel, Field, RootModel, computed_field, field_validator
+from pydantic import BaseModel, Field, computed_field, field_validator
 
-from constants.languages import languages
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from controllers.console import console_ns
+from controllers.console.explore.error import RecommendedAppNotFoundError
 from controllers.console.wraps import account_initialization_required, model_validate, with_current_user
-from extensions.ext_database import db
+from extensions.ext_application_services import application_services
 from fields.base import ResponseModel
 from libs.helper import build_icon_url, dump_response
 from libs.login import login_required
 from models import Account
-from services.recommended_app_service import RecommendedAppService
+from services.recommended_app_query_service import RecommendedAppNotFoundError as RecommendedAppQueryNotFoundError
 
 
 class RecommendedAppsQuery(BaseModel):
@@ -79,10 +79,6 @@ class RecommendedAppDetailResponse(ResponseModel):
     can_trial: bool
 
 
-class RecommendedAppDetailNullableResponse(RootModel[RecommendedAppDetailResponse | None]):
-    pass
-
-
 register_schema_models(
     console_ns,
     RecommendedAppsQuery,
@@ -94,16 +90,7 @@ register_response_schema_models(
     RecommendedAppListResponse,
     LearnDifyAppListResponse,
     RecommendedAppDetailResponse,
-    RecommendedAppDetailNullableResponse,
 )
-
-
-def _resolve_language(language: str | None, user: Account) -> str:
-    if language and language in languages:
-        return language
-    if user.interface_language:
-        return user.interface_language
-    return languages[0]
 
 
 @console_ns.route("/explore/apps")
@@ -115,12 +102,12 @@ class RecommendedAppListApi(Resource):
     @with_current_user
     @model_validate(RecommendedAppsQuery)
     def get(self, req_data: RecommendedAppsQuery, current_user: Account):
-        # language args
-        language_prefix = _resolve_language(req_data.language, current_user)
-
         return dump_response(
             RecommendedAppListResponse,
-            RecommendedAppService.get_recommended_apps_and_categories(language_prefix, session=db.session()),
+            application_services().recommended_app_queries.list_recommended(
+                requested_language=req_data.language,
+                interface_language=current_user.interface_language,
+            ),
         )
 
 
@@ -133,19 +120,24 @@ class LearnDifyAppListApi(Resource):
     @with_current_user
     @model_validate(RecommendedAppsQuery)
     def get(self, req_data: RecommendedAppsQuery, current_user: Account):
-        language_prefix = _resolve_language(req_data.language, current_user)
-
         return dump_response(
             LearnDifyAppListResponse,
-            RecommendedAppService.get_learn_dify_apps(language_prefix, session=db.session()),
+            application_services().recommended_app_queries.list_learn_dify(
+                requested_language=req_data.language,
+                interface_language=current_user.interface_language,
+            ),
         )
 
 
 @console_ns.route("/explore/apps/<uuid:app_id>")
 class RecommendedAppApi(Resource):
-    @console_ns.response(200, "Success", console_ns.models[RecommendedAppDetailNullableResponse.__name__])
+    @console_ns.response(200, "Success", console_ns.models[RecommendedAppDetailResponse.__name__])
+    @console_ns.response(404, "Recommended app not found")
     @login_required
     @account_initialization_required
     def get(self, app_id: UUID):
-        result = RecommendedAppService.get_recommend_app_detail(str(app_id), session=db.session())
-        return RecommendedAppDetailNullableResponse.model_validate(result).model_dump(mode="json")
+        try:
+            result = application_services().recommended_app_queries.get_detail(str(app_id))
+        except RecommendedAppQueryNotFoundError:
+            raise RecommendedAppNotFoundError() from None
+        return dump_response(RecommendedAppDetailResponse, result)

--- a/api/extensions/ext_application_services.py
+++ b/api/extensions/ext_application_services.py
@@ -20,6 +20,7 @@ from repositories.app_definition_query_repository import AppDefinitionQueryRepos
 from repositories.data_source_api_key_auth_repository import SQLAlchemyDataSourceApiKeyAuthBindingRepository
 from repositories.explore_banner_query_repository import ExploreBannerQueryRepository
 from repositories.installation_state_repository import InstallationStateRepository
+from repositories.trial_app_query_repository import TrialAppQueryRepository
 from repositories.webapp_access_query_repository import WebAppAccessQueryRepository
 from repositories.workspace_member_query_repository import WorkspaceMemberQueryRepository
 from repositories.workspace_query_repository import WorkspaceQueryRepository
@@ -43,6 +44,9 @@ from services.feature_query_service import FeatureQueryService
 from services.feature_service import FeatureService
 from services.feature_service_gateway import FeatureServiceGateway
 from services.init_validation_service import InitValidationService
+from services.recommended_app_query_compat import LegacyRecommendedAppCatalogGateway
+from services.recommended_app_query_service import RecommendedAppQueryService
+from services.recommended_app_service import RecommendedAppService
 from services.schema_definition_service import SchemaDefinitionService
 from services.setup_adapters import RedisSetupLock, RegisterServiceAccountProvisioner
 from services.setup_service import SetupService
@@ -80,6 +84,7 @@ class ApplicationServices:
     setup: SetupService
     feature_queries: FeatureQueryService
     init_validation: InitValidationService
+    recommended_app_queries: RecommendedAppQueryService
     workspace_queries: WorkspaceQueryService
     workspace_member_queries: WorkspaceMemberQueryService
 
@@ -141,6 +146,11 @@ def build_application_services(
             state=installation_state,
             validation_required=(deployment_edition != DeploymentEdition.CLOUD and bool(initialization_password)),
             expected_password=initialization_password,
+        ),
+        recommended_app_queries=RecommendedAppQueryService(
+            catalog=LegacyRecommendedAppCatalogGateway(session_factory=database_client),
+            trial_apps=TrialAppQueryRepository(session_factory=database_client),
+            is_trial_enabled=RecommendedAppService.is_trial_app_enabled,
         ),
         workspace_queries=WorkspaceQueryService(
             workspaces=WorkspaceQueryRepository(

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -6525,7 +6525,8 @@ Check if dataset is in use
 
 | Code | Description | Schema |
 | ---- | ----------- | ------ |
-| 200 | Success | **application/json**: [RecommendedAppDetailNullableResponse](#recommendedappdetailnullableresponse)<br> |
+| 200 | Success | **application/json**: [RecommendedAppDetailResponse](#recommendedappdetailresponse)<br> |
+| 404 | Recommended app not found |  |
 
 ### [GET] /features
 **Get feature configuration for current tenant**
@@ -20704,12 +20705,6 @@ Whitelist scopes accepted by RBAC app and dataset access config APIs.
 | name | string |  | Yes |
 | permission_keys | [ string ] |  | No |
 | updated_at | integer |  | Yes |
-
-#### RecommendedAppDetailNullableResponse
-
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| RecommendedAppDetailNullableResponse | [RecommendedAppDetailResponse](#recommendedappdetailresponse) |  |  |
 
 #### RecommendedAppDetailResponse
 

--- a/api/repositories/trial_app_query_repository.py
+++ b/api/repositories/trial_app_query_repository.py
@@ -1,0 +1,23 @@
+"""Database repository for recommended app trial eligibility."""
+
+from collections.abc import Sequence, Set
+from typing import override
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+from models.model import TrialApp
+from services.recommended_app_query_service import TrialAppQuery
+
+
+class TrialAppQueryRepository(TrialAppQuery):
+    def __init__(self, session_factory: sessionmaker[Session]) -> None:
+        self._session_factory = session_factory
+
+    @override
+    def existing_ids(self, app_ids: Sequence[str]) -> Set[str]:
+        if not app_ids:
+            return frozenset()
+
+        with self._session_factory() as session:
+            return frozenset(session.scalars(select(TrialApp.app_id).where(TrialApp.app_id.in_(app_ids))).all())

--- a/api/services/recommend_app/database/database_retrieval.py
+++ b/api/services/recommend_app/database/database_retrieval.py
@@ -75,7 +75,7 @@ class DatabaseRecommendAppRetrieval(RecommendAppRetrievalBase):
         if len(recommended_apps) == 0:
             recommended_apps = cls._fetch_listed_recommended_apps(languages[0], session=session)
 
-        return cls._format_recommended_apps(recommended_apps, language)
+        return cls._format_recommended_apps(recommended_apps, language, session=session)
 
     @classmethod
     def fetch_learn_dify_apps_from_db(cls, language: str, *, session: Session) -> RecommendedAppsResultDict:
@@ -89,7 +89,7 @@ class DatabaseRecommendAppRetrieval(RecommendAppRetrievalBase):
         if len(recommended_apps) == 0 and language != languages[0]:
             recommended_apps = cls._fetch_listed_recommended_apps(languages[0], session=session, is_learn_dify=True)
 
-        return cls._format_recommended_apps(recommended_apps, language)
+        return cls._format_recommended_apps(recommended_apps, language, session=session)
 
     @classmethod
     def _fetch_listed_recommended_apps(
@@ -103,7 +103,11 @@ class DatabaseRecommendAppRetrieval(RecommendAppRetrievalBase):
 
     @classmethod
     def _format_recommended_apps(
-        cls, recommended_apps: list[RecommendedApp], language: str
+        cls,
+        recommended_apps: list[RecommendedApp],
+        language: str,
+        *,
+        session: Session,
     ) -> RecommendedAppsResultDict:
         """
         Serialize DB recommended app rows into the Explore list response shape.
@@ -115,18 +119,18 @@ class DatabaseRecommendAppRetrieval(RecommendAppRetrievalBase):
         categories = set()
         recommended_apps_result: list[RecommendedAppItemDict] = []
         for recommended_app in recommended_apps:
-            app = recommended_app.app
+            app = session.get(App, recommended_app.app_id)
             if not app or not app.is_public:
                 continue
 
-            site = app.site
+            site = app.site_with_session(session=session)
             if not site:
                 continue
 
             app_categories = recommended_app.categories or []
             recommended_app_result: RecommendedAppItemDict = {
                 "id": recommended_app.id,
-                "app": recommended_app.app,
+                "app": app,
                 "app_id": recommended_app.app_id,
                 "description": site.description,
                 "copyright": site.copyright,

--- a/api/services/recommended_app_query_compat.py
+++ b/api/services/recommended_app_query_compat.py
@@ -1,0 +1,186 @@
+"""Compatibility adapter for the existing recommended app retrieval stack."""
+
+from collections.abc import Mapping, Sequence
+from typing import cast, override
+
+from sqlalchemy.orm import Session, sessionmaker
+
+from configs import dify_config
+from models.model import App
+from services.recommend_app.recommend_app_factory import RecommendAppRetrievalFactory
+from services.recommended_app_query_service import (
+    RecommendedAppCatalogGateway,
+    RecommendedAppCatalogPage,
+    RecommendedAppDetailRecord,
+    RecommendedAppInfoRecord,
+    RecommendedAppRecord,
+)
+
+
+class LegacyRecommendedAppCatalogGateway(RecommendedAppCatalogGateway):
+    """Map the mixed dict/ORM retrieval results to persistence-neutral records."""
+
+    def __init__(self, session_factory: sessionmaker[Session]) -> None:
+        self._session_factory = session_factory
+
+    @override
+    def list_recommended(self, language: str) -> RecommendedAppCatalogPage:
+        retrieval = self._configured_retrieval()
+        with self._session_factory() as session:
+            result = retrieval.get_recommended_apps_and_categories(language, session=session)
+            return self._map_recommended_page(result)
+
+    @override
+    def list_builtin(self, language: str) -> RecommendedAppCatalogPage:
+        retrieval = RecommendAppRetrievalFactory.get_buildin_recommend_app_retrieval()
+        return self._map_page(retrieval.fetch_recommended_apps_from_builtin(language))
+
+    @override
+    def list_learn_dify(self, language: str) -> RecommendedAppCatalogPage:
+        retrieval = self._configured_retrieval()
+        with self._session_factory() as session:
+            result = retrieval.get_learn_dify_apps(language, session=session)
+            raw_apps = cast(Sequence[object], result["recommended_apps"])
+            return RecommendedAppCatalogPage(
+                recommended_apps=tuple(self._map_app(app) for app in raw_apps),
+                categories=(),
+            )
+
+    @override
+    def get_detail(self, app_id: str) -> RecommendedAppDetailRecord | None:
+        retrieval = self._configured_retrieval()
+        with self._session_factory() as session:
+            result = retrieval.get_recommend_app_detail(app_id, session=session)
+            if result is None:
+                return None
+            if not isinstance(result, Mapping):
+                raise TypeError("recommended app detail must be a mapping")
+            return self._map_detail(cast(Mapping[str, object], result))
+
+    @staticmethod
+    def _configured_retrieval():
+        retrieval_type = RecommendAppRetrievalFactory.get_recommend_app_factory(
+            dify_config.HOSTED_FETCH_APP_TEMPLATES_MODE
+        )
+        return retrieval_type()
+
+    @classmethod
+    def _map_page(cls, result: Mapping[str, object]) -> RecommendedAppCatalogPage:
+        raw_apps = cast(Sequence[object], result["recommended_apps"])
+        return RecommendedAppCatalogPage(
+            recommended_apps=tuple(cls._map_app(app) for app in raw_apps),
+            categories=cls._as_string_tuple(result["categories"], field="categories"),
+        )
+
+    @classmethod
+    def _map_recommended_page(cls, result: Mapping[str, object]) -> RecommendedAppCatalogPage:
+        if not result.get("recommended_apps"):
+            return RecommendedAppCatalogPage(recommended_apps=(), categories=())
+        return cls._map_page(result)
+
+    @classmethod
+    def _map_app(cls, source: object) -> RecommendedAppRecord:
+        if not isinstance(source, Mapping):
+            raise TypeError("recommended app must be a mapping")
+
+        source = cast(Mapping[str, object], source)
+        app_id = source["app_id"]
+        if not isinstance(app_id, str):
+            raise TypeError("app_id must be a string")
+        app_source = source.get("app")
+        if app_source is not None and not isinstance(app_source, (Mapping, App)):
+            raise TypeError("app must be a mapping or App")
+
+        return RecommendedAppRecord(
+            app=cls._map_app_info(cast(Mapping[str, object] | App | None, app_source)),
+            app_id=app_id,
+            description=cast(str | None, source.get("description")),
+            copyright=cast(str | None, source.get("copyright")),
+            privacy_policy=cast(str | None, source.get("privacy_policy")),
+            custom_disclaimer=cast(str | None, source.get("custom_disclaimer")),
+            categories=cls._as_string_tuple(source.get("categories", ()), field="categories"),
+            position=cast(int | None, source.get("position")),
+            is_listed=cast(bool | None, source.get("is_listed")),
+        )
+
+    @classmethod
+    def _map_app_info(cls, source: Mapping[str, object] | App | None) -> RecommendedAppInfoRecord | None:
+        if source is None:
+            return None
+
+        app_id: object
+        name: object
+        mode: object
+        icon: object
+        icon_type: object
+        icon_background: object
+        if isinstance(source, App):
+            app_id = source.id
+            name = source.name
+            mode = source.mode
+            icon = source.icon
+            icon_type = source.icon_type
+            icon_background = source.icon_background
+        else:
+            app_id = source["id"]
+            name = source.get("name")
+            mode = source.get("mode")
+            icon = source.get("icon")
+            icon_type = source.get("icon_type")
+            icon_background = source.get("icon_background")
+
+        if not isinstance(app_id, str):
+            raise TypeError("app.id must be a string")
+
+        return RecommendedAppInfoRecord(
+            id=app_id,
+            name=cast(str | None, name),
+            mode=cls._enum_string(mode, field="app.mode"),
+            icon=cast(str | None, icon),
+            icon_type=cls._enum_string(icon_type, field="app.icon_type"),
+            icon_background=cast(str | None, icon_background),
+        )
+
+    @classmethod
+    def _map_detail(cls, source: Mapping[str, object]) -> RecommendedAppDetailRecord:
+        app_id = source["id"]
+        name = source["name"]
+        export_data = source["export_data"]
+        if not isinstance(app_id, str):
+            raise TypeError("id must be a string")
+        if not isinstance(name, str):
+            raise TypeError("name must be a string")
+        if not isinstance(export_data, str):
+            raise TypeError("export_data must be a string")
+
+        mode = cls._enum_string(source["mode"], field="mode")
+        if mode is None:
+            raise TypeError("mode must be a string or string enum")
+
+        return RecommendedAppDetailRecord(
+            id=app_id,
+            name=name,
+            icon=cast(str | None, source.get("icon")),
+            icon_background=cast(str | None, source.get("icon_background")),
+            mode=mode,
+            export_data=export_data,
+        )
+
+    @staticmethod
+    def _as_string_tuple(value: object, *, field: str) -> tuple[str, ...]:
+        if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+            raise TypeError(f"{field} must be a sequence of strings")
+        items: list[str] = []
+        for item in value:
+            if not isinstance(item, str):
+                raise TypeError(f"{field} must contain only strings")
+            items.append(item)
+        return tuple(items)
+
+    @staticmethod
+    def _enum_string(value: object, *, field: str) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return str(value)
+        raise TypeError(f"{field} must be a string or string enum")

--- a/api/services/recommended_app_query_service.py
+++ b/api/services/recommended_app_query_service.py
@@ -1,0 +1,180 @@
+"""Application service for querying the recommended app catalog."""
+
+from collections.abc import Callable, Sequence, Set
+from typing import NamedTuple, Protocol
+
+from constants.languages import languages
+
+_BUILTIN_FALLBACK_LANGUAGE = "en-US"
+
+
+class RecommendedAppInfoRecord(NamedTuple):
+    id: str
+    name: str | None
+    mode: str | None
+    icon: str | None
+    icon_type: str | None
+    icon_background: str | None
+
+
+class RecommendedAppRecord(NamedTuple):
+    app: RecommendedAppInfoRecord | None
+    app_id: str
+    description: str | None
+    copyright: str | None
+    privacy_policy: str | None
+    custom_disclaimer: str | None
+    categories: tuple[str, ...]
+    position: int | None
+    is_listed: bool | None
+
+
+class RecommendedAppCatalogPage(NamedTuple):
+    recommended_apps: tuple[RecommendedAppRecord, ...]
+    categories: tuple[str, ...]
+
+
+class RecommendedAppDetailRecord(NamedTuple):
+    id: str
+    name: str
+    icon: str | None
+    icon_background: str | None
+    mode: str
+    export_data: str
+
+
+class RecommendedAppCatalogGateway(Protocol):
+    def list_recommended(self, language: str) -> RecommendedAppCatalogPage: ...
+
+    def list_builtin(self, language: str) -> RecommendedAppCatalogPage: ...
+
+    def list_learn_dify(self, language: str) -> RecommendedAppCatalogPage: ...
+
+    def get_detail(self, app_id: str) -> RecommendedAppDetailRecord | None: ...
+
+
+class TrialAppQuery(Protocol):
+    def existing_ids(self, app_ids: Sequence[str]) -> Set[str]: ...
+
+
+class RecommendedAppSummary(NamedTuple):
+    app: RecommendedAppInfoRecord | None
+    app_id: str
+    description: str | None
+    copyright: str | None
+    privacy_policy: str | None
+    custom_disclaimer: str | None
+    categories: tuple[str, ...]
+    position: int | None
+    is_listed: bool | None
+    can_trial: bool
+
+
+class RecommendedAppListResult(NamedTuple):
+    recommended_apps: tuple[RecommendedAppSummary, ...]
+    categories: tuple[str, ...]
+
+
+class LearnDifyAppListResult(NamedTuple):
+    recommended_apps: tuple[RecommendedAppSummary, ...]
+
+
+class RecommendedAppDetailSummary(NamedTuple):
+    id: str
+    name: str
+    icon: str | None
+    icon_background: str | None
+    mode: str
+    export_data: str
+    can_trial: bool
+
+
+class RecommendedAppNotFoundError(Exception):
+    pass
+
+
+class RecommendedAppQueryService:
+    def __init__(
+        self,
+        *,
+        catalog: RecommendedAppCatalogGateway,
+        trial_apps: TrialAppQuery,
+        is_trial_enabled: Callable[[], bool],
+    ) -> None:
+        self._catalog = catalog
+        self._trial_apps = trial_apps
+        self._is_trial_enabled = is_trial_enabled
+
+    def list_recommended(
+        self,
+        *,
+        requested_language: str | None,
+        interface_language: str | None,
+    ) -> RecommendedAppListResult:
+        language = self._resolve_language(requested_language, interface_language)
+        page = self._catalog.list_recommended(language)
+        if not page.recommended_apps:
+            page = self._catalog.list_builtin(_BUILTIN_FALLBACK_LANGUAGE)
+
+        return RecommendedAppListResult(
+            recommended_apps=self._with_trial_status(page.recommended_apps),
+            categories=page.categories,
+        )
+
+    def list_learn_dify(
+        self,
+        *,
+        requested_language: str | None,
+        interface_language: str | None,
+    ) -> LearnDifyAppListResult:
+        language = self._resolve_language(requested_language, interface_language)
+        page = self._catalog.list_learn_dify(language)
+        return LearnDifyAppListResult(recommended_apps=self._with_trial_status(page.recommended_apps))
+
+    def get_detail(self, app_id: str) -> RecommendedAppDetailSummary:
+        detail = self._catalog.get_detail(app_id)
+        if detail is None:
+            raise RecommendedAppNotFoundError
+
+        can_trial = False
+        if self._is_trial_enabled():
+            can_trial = detail.id in self._trial_apps.existing_ids((detail.id,))
+
+        return RecommendedAppDetailSummary(
+            id=detail.id,
+            name=detail.name,
+            icon=detail.icon,
+            icon_background=detail.icon_background,
+            mode=detail.mode,
+            export_data=detail.export_data,
+            can_trial=can_trial,
+        )
+
+    def _with_trial_status(self, apps: Sequence[RecommendedAppRecord]) -> tuple[RecommendedAppSummary, ...]:
+        trial_app_ids: Set[str] = set()
+        if self._is_trial_enabled():
+            trial_app_ids = self._trial_apps.existing_ids([app.app_id for app in apps])
+
+        return tuple(
+            RecommendedAppSummary(
+                app=app.app,
+                app_id=app.app_id,
+                description=app.description,
+                copyright=app.copyright,
+                privacy_policy=app.privacy_policy,
+                custom_disclaimer=app.custom_disclaimer,
+                categories=app.categories,
+                position=app.position,
+                is_listed=app.is_listed,
+                can_trial=app.app_id in trial_app_ids,
+            )
+            for app in apps
+        )
+
+    @staticmethod
+    def _resolve_language(requested_language: str | None, interface_language: str | None) -> str:
+        if requested_language and requested_language in languages:
+            return requested_language
+        if interface_language:
+            return interface_language
+        return languages[0]

--- a/api/services/recommended_app_service.py
+++ b/api/services/recommended_app_service.py
@@ -1,16 +1,14 @@
-from typing import Any
-
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from configs import dify_config
 from enums import DeploymentEdition
-from models.model import AccountTrialAppRecord, App, TrialApp
+from models.model import AccountTrialAppRecord, App
 from services.recommend_app.recommend_app_factory import RecommendAppRetrievalFactory
 
 
 class RecommendedAppService:
-    """Own recommended app retrieval and Cloud-only trial eligibility."""
+    """Own recommended app runtime admission and trial usage writes."""
 
     @staticmethod
     def is_trial_app_enabled() -> bool:
@@ -27,66 +25,6 @@ class RecommendedAppService:
             return None
 
         return session.scalar(select(App).where(App.id == app_id, App.status == "normal").limit(1))
-
-    @classmethod
-    def get_recommended_apps_and_categories(cls, language: str, *, session: Session):
-        """
-        Get recommended apps and categories.
-        :param language: language
-        :return:
-        """
-        mode = dify_config.HOSTED_FETCH_APP_TEMPLATES_MODE
-        retrieval_instance = RecommendAppRetrievalFactory.get_recommend_app_factory(mode)()
-        result = retrieval_instance.get_recommended_apps_and_categories(language, session=session)
-        if not result.get("recommended_apps"):
-            result = (
-                RecommendAppRetrievalFactory.get_buildin_recommend_app_retrieval().fetch_recommended_apps_from_builtin(
-                    "en-US"
-                )
-            )
-
-        apps = result["recommended_apps"]
-        trial_app_ids = (
-            cls._get_trial_app_ids(session, [app["app_id"] for app in apps]) if cls.is_trial_app_enabled() else set()
-        )
-        for app in apps:
-            app["can_trial"] = app["app_id"] in trial_app_ids
-        return result
-
-    @classmethod
-    def get_learn_dify_apps(cls, language: str, *, session: Session) -> dict[str, Any]:
-        """
-        Get recommended apps marked for the Learn Dify section.
-        :param language: language
-        :return:
-        """
-        mode = dify_config.HOSTED_FETCH_APP_TEMPLATES_MODE
-        retrieval_instance = RecommendAppRetrievalFactory.get_recommend_app_factory(mode)()
-        result = retrieval_instance.get_learn_dify_apps(language, session=session)
-
-        apps = result["recommended_apps"]
-        trial_app_ids = (
-            cls._get_trial_app_ids(session, [app["app_id"] for app in apps]) if cls.is_trial_app_enabled() else set()
-        )
-        for app in apps:
-            app["can_trial"] = app["app_id"] in trial_app_ids
-
-        return {"recommended_apps": apps}
-
-    @classmethod
-    def get_recommend_app_detail(cls, app_id: str, *, session: Session) -> dict[str, Any] | None:
-        """
-        Get recommend app detail.
-        :param app_id: app id
-        :return:
-        """
-        mode = dify_config.HOSTED_FETCH_APP_TEMPLATES_MODE
-        retrieval_instance = RecommendAppRetrievalFactory.get_recommend_app_factory(mode)()
-        result: dict[str, Any] | None = retrieval_instance.get_recommend_app_detail(app_id, session=session)
-        if result is None:
-            return None
-        result["can_trial"] = cls.is_trial_app_enabled() and cls._can_trial_app(session, result["id"])
-        return result
 
     @classmethod
     def add_trial_app_record(cls, app_id: str, account_id: str, *, session: Session):
@@ -106,14 +44,3 @@ class RecommendedAppService:
         else:
             session.add(AccountTrialAppRecord(app_id=app_id, count=1, account_id=account_id))
             session.commit()
-
-    @staticmethod
-    def _can_trial_app(session: Session, app_id: str) -> bool:
-        trial_app_model = session.scalar(select(TrialApp).where(TrialApp.app_id == app_id).limit(1))
-        return trial_app_model is not None
-
-    @staticmethod
-    def _get_trial_app_ids(session: Session, app_ids: list[str]) -> set[str]:
-        if not app_ids:
-            return set()
-        return set(session.scalars(select(TrialApp.app_id).where(TrialApp.app_id.in_(app_ids))).all())

--- a/api/tests/unit_tests/commands/test_generate_swagger_specs.py
+++ b/api/tests/unit_tests/commands/test_generate_swagger_specs.py
@@ -241,12 +241,11 @@ def test_generate_specs_include_console_contract_shapes_for_schema_migration(tmp
     assert app_list_item_schema["properties"]["can_trial"]["type"] == "boolean"
     assert "anyOf" not in app_list_item_schema["properties"]["can_trial"]
     assert "can_trial" in app_list_item_schema["required"]
-    app_detail_nullable_schema = schemas["RecommendedAppDetailNullableResponse"]
     assert _response_schema(paths["/explore/apps/{app_id}"]["get"])["$ref"] == (
-        "#/components/schemas/RecommendedAppDetailNullableResponse"
+        "#/components/schemas/RecommendedAppDetailResponse"
     )
-    assert {"$ref": "#/components/schemas/RecommendedAppDetailResponse"} in app_detail_nullable_schema["anyOf"]
-    assert {"type": "null"} in app_detail_nullable_schema["anyOf"]
+    assert "404" in paths["/explore/apps/{app_id}"]["get"]["responses"]
+    assert "RecommendedAppDetailNullableResponse" not in schemas
     assert schemas["RecommendedAppInfoResponse"]["properties"]["icon_url"]["readOnly"] is True
     assert schemas["InstalledAppInfoResponse"]["properties"]["icon_url"]["readOnly"] is True
     assert _response_schema(paths["/apps/{app_id}"]["get"])["$ref"] == "#/components/schemas/AppDetailWithSite"

--- a/api/tests/unit_tests/controllers/console/explore/test_recommended_app.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_recommended_app.py
@@ -1,14 +1,24 @@
 from inspect import unwrap
-from unittest.mock import ANY, patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
 from pydantic import ValidationError
 
 import controllers.console.explore.recommended_app as module
-from controllers.console.explore.recommended_app import RecommendedAppsQuery
 from models import Account
 from models.model import AppMode, IconType
+from services.recommended_app_query_service import (
+    LearnDifyAppListResult,
+    RecommendedAppDetailSummary,
+    RecommendedAppInfoRecord,
+    RecommendedAppListResult,
+    RecommendedAppSummary,
+)
+from services.recommended_app_query_service import (
+    RecommendedAppNotFoundError as RecommendedAppQueryNotFoundError,
+)
 
 
 def make_account(interface_language: str | None) -> Account:
@@ -19,133 +29,149 @@ def make_account(interface_language: str | None) -> Account:
 
 
 class TestRecommendedAppListApi:
-    def test_get_with_language_param(self, app: Flask):
+    def test_get_with_language_param(self, app: Flask) -> None:
         api = module.RecommendedAppListApi()
         method = unwrap(api.get)
 
-        result_data = {"recommended_apps": [], "categories": []}
+        queries = MagicMock()
+        queries.list_recommended.return_value = RecommendedAppListResult(recommended_apps=(), categories=())
 
         with (
             app.test_request_context("/", query_string={"language": "en-US"}),
             patch.object(
-                module.RecommendedAppService,
-                "get_recommended_apps_and_categories",
-                return_value=result_data,
-            ) as service_mock,
+                module,
+                "application_services",
+                return_value=SimpleNamespace(recommended_app_queries=queries),
+            ),
         ):
-            result = method(api, RecommendedAppsQuery(language="en-US"), make_account("fr-FR"))
+            result = method(api, module.RecommendedAppsQuery(language="en-US"), make_account("fr-FR"))
 
-        service_mock.assert_called_once_with("en-US", session=ANY)
-        assert result == result_data
+        queries.list_recommended.assert_called_once_with(
+            requested_language="en-US",
+            interface_language="fr-FR",
+        )
+        assert result == {"recommended_apps": [], "categories": []}
 
-    def test_get_fallback_to_user_language(self, app: Flask):
-        api = module.RecommendedAppListApi()
+
+class TestLearnDifyAppListApi:
+    def test_get_with_language_param(self, app: Flask) -> None:
+        api = module.LearnDifyAppListApi()
         method = unwrap(api.get)
 
-        result_data = {"recommended_apps": [], "categories": []}
+        queries = MagicMock()
+        queries.list_learn_dify.return_value = LearnDifyAppListResult(recommended_apps=())
 
         with (
-            app.test_request_context("/", query_string={"language": "invalid"}),
+            app.test_request_context("/", query_string={"language": "en-US"}),
             patch.object(
-                module.RecommendedAppService,
-                "get_recommended_apps_and_categories",
-                return_value=result_data,
-            ) as service_mock,
+                module,
+                "application_services",
+                return_value=SimpleNamespace(recommended_app_queries=queries),
+            ),
         ):
-            result = method(api, RecommendedAppsQuery(), make_account("fr-FR"))
+            result = method(api, module.RecommendedAppsQuery(language="en-US"), make_account("fr-FR"))
 
-        service_mock.assert_called_once_with("fr-FR", session=ANY)
-        assert result == result_data
+        queries.list_learn_dify.assert_called_once_with(
+            requested_language="en-US",
+            interface_language="fr-FR",
+        )
+        assert result == {"recommended_apps": []}
 
-    def test_get_fallback_to_default_language(self, app: Flask):
-        api = module.RecommendedAppListApi()
+
+class TestRecommendedAppApi:
+    def test_get_success(self, app: Flask) -> None:
+        api = module.RecommendedAppApi()
         method = unwrap(api.get)
 
-        result_data = {"recommended_apps": [], "categories": []}
+        queries = MagicMock()
+        queries.get_detail.return_value = RecommendedAppDetailSummary(
+            id="app1",
+            name="App",
+            icon=None,
+            icon_background=None,
+            mode="chat",
+            export_data="{}",
+            can_trial=False,
+        )
 
         with (
             app.test_request_context("/"),
             patch.object(
-                module.RecommendedAppService,
-                "get_recommended_apps_and_categories",
-                return_value=result_data,
-            ) as service_mock,
+                module,
+                "application_services",
+                return_value=SimpleNamespace(recommended_app_queries=queries),
+            ),
         ):
-            result = method(api, RecommendedAppsQuery(), make_account(None))
+            result = method(api, "11111111-1111-1111-1111-111111111111")
 
-        service_mock.assert_called_once_with(module.languages[0], session=ANY)
-        assert result == result_data
-
-
-class TestLearnDifyAppListApi:
-    def test_get_with_language_param(self, app: Flask):
-        api = module.LearnDifyAppListApi()
-        method = unwrap(api.get)
-
-        result_data = {"recommended_apps": []}
-
-        with (
-            app.test_request_context("/", query_string={"language": "en-US"}),
-            patch.object(
-                module.RecommendedAppService,
-                "get_learn_dify_apps",
-                return_value=result_data,
-            ) as service_mock,
-        ):
-            result = method(api, RecommendedAppsQuery(language="en-US"), make_account("fr-FR"))
-
-        service_mock.assert_called_once_with("en-US", session=ANY)
-        assert result == result_data
-
-    def test_get_fallback_to_user_language(self, app: Flask):
-        api = module.LearnDifyAppListApi()
-        method = unwrap(api.get)
-
-        result_data = {"recommended_apps": []}
-
-        with (
-            app.test_request_context("/", query_string={"language": "invalid"}),
-            patch.object(
-                module.RecommendedAppService,
-                "get_learn_dify_apps",
-                return_value=result_data,
-            ) as service_mock,
-        ):
-            result = method(api, RecommendedAppsQuery(), make_account("fr-FR"))
-
-        service_mock.assert_called_once_with("fr-FR", session=ANY)
-        assert result == result_data
-
-
-class TestRecommendedAppApi:
-    def test_get_success(self, app: Flask):
-        api = module.RecommendedAppApi()
-        method = unwrap(api.get)
-
-        result_data = {
+        queries.get_detail.assert_called_once_with("11111111-1111-1111-1111-111111111111")
+        assert result == {
             "id": "app1",
             "name": "App",
+            "icon": None,
+            "icon_background": None,
             "mode": "chat",
             "export_data": "{}",
             "can_trial": False,
         }
 
+    def test_get_missing_raises_stable_not_found_error(self, app: Flask) -> None:
+        api = module.RecommendedAppApi()
+        method = unwrap(api.get)
+        queries = MagicMock()
+        queries.get_detail.side_effect = RecommendedAppQueryNotFoundError
+
         with (
             app.test_request_context("/"),
             patch.object(
-                module.RecommendedAppService,
-                "get_recommend_app_detail",
-                return_value=result_data,
-            ) as service_mock,
+                module,
+                "application_services",
+                return_value=SimpleNamespace(recommended_app_queries=queries),
+            ),
         ):
-            result = method(api, "11111111-1111-1111-1111-111111111111")
+            with pytest.raises(module.RecommendedAppNotFoundError) as exc_info:
+                method(api, "11111111-1111-1111-1111-111111111111")
 
-        service_mock.assert_called_once_with("11111111-1111-1111-1111-111111111111", session=ANY)
-        assert result == {**result_data, "icon": None, "icon_background": None}
+        assert exc_info.value.data == {
+            "code": "recommended_app_not_found",
+            "message": "Recommended app not found.",
+            "status": 404,
+        }
 
 
 class TestRecommendedAppResponseModels:
-    def test_recommended_app_info_response_computes_icon_url(self):
+    def test_query_service_records_serialize_through_controller_contract(self) -> None:
+        result = RecommendedAppListResult(
+            recommended_apps=(
+                RecommendedAppSummary(
+                    app=RecommendedAppInfoRecord(
+                        id="app-1",
+                        name="App",
+                        mode="chat",
+                        icon=None,
+                        icon_type=None,
+                        icon_background=None,
+                    ),
+                    app_id="app-1",
+                    description=None,
+                    copyright=None,
+                    privacy_policy=None,
+                    custom_disclaimer=None,
+                    categories=("Workflow",),
+                    position=1,
+                    is_listed=True,
+                    can_trial=False,
+                ),
+            ),
+            categories=("Workflow",),
+        )
+
+        response = module.dump_response(module.RecommendedAppListResponse, result)
+
+        assert response["recommended_apps"][0]["app"]["id"] == "app-1"
+        assert response["recommended_apps"][0]["categories"] == ["Workflow"]
+
+    def test_recommended_app_info_response_computes_icon_url(self) -> None:
         with patch.object(module, "build_icon_url", return_value="https://signed/icon.png"):
             payload = module.RecommendedAppInfoResponse.model_validate(
                 {
@@ -160,7 +186,7 @@ class TestRecommendedAppResponseModels:
 
         assert payload["icon_url"] == "https://signed/icon.png"
 
-    def test_recommended_app_list_response_serialization(self):
+    def test_recommended_app_list_response_serialization(self) -> None:
         response = module.RecommendedAppListResponse.model_validate(
             {
                 "recommended_apps": [
@@ -189,7 +215,7 @@ class TestRecommendedAppResponseModels:
         assert response["recommended_apps"][0]["categories"] == ["cat", "other"]
         assert response["categories"] == ["cat"]
 
-    def test_learn_dify_app_list_response_serialization(self):
+    def test_learn_dify_app_list_response_serialization(self) -> None:
         response = module.LearnDifyAppListResponse.model_validate(
             {
                 "recommended_apps": [
@@ -216,6 +242,6 @@ class TestRecommendedAppResponseModels:
         assert response["recommended_apps"][0]["app_id"] == "app-1"
         assert response["recommended_apps"][0]["categories"] == ["Workflow"]
 
-    def test_recommended_app_response_requires_can_trial(self):
+    def test_recommended_app_response_requires_can_trial(self) -> None:
         with pytest.raises(ValidationError):
             module.RecommendedAppResponse.model_validate({"app_id": "app-1"})

--- a/api/tests/unit_tests/repositories/test_trial_app_query_repository.py
+++ b/api/tests/unit_tests/repositories/test_trial_app_query_repository.py
@@ -1,0 +1,28 @@
+import uuid
+from unittest.mock import MagicMock
+
+from sqlalchemy.orm import Session, sessionmaker
+
+from models.model import TrialApp
+from repositories.trial_app_query_repository import TrialAppQueryRepository
+
+
+def test_existing_ids_returns_only_trial_apps(sqlite_session_factory: sessionmaker[Session]) -> None:
+    eligible_id = str(uuid.uuid4())
+    other_id = str(uuid.uuid4())
+    with sqlite_session_factory() as session:
+        session.add(TrialApp(app_id=eligible_id, tenant_id=str(uuid.uuid4())))
+        session.commit()
+
+    result = TrialAppQueryRepository(sqlite_session_factory).existing_ids([eligible_id, other_id])
+
+    assert result == frozenset({eligible_id})
+
+
+def test_existing_ids_skips_session_for_empty_input() -> None:
+    session_factory = MagicMock(spec=sessionmaker)
+
+    result = TrialAppQueryRepository(session_factory).existing_ids([])
+
+    assert result == frozenset()
+    session_factory.assert_not_called()

--- a/api/tests/unit_tests/services/recommend_app/test_database_retrieval.py
+++ b/api/tests/unit_tests/services/recommend_app/test_database_retrieval.py
@@ -1,10 +1,13 @@
 """Unit tests for database recommendation retrieval delegation."""
 
-from unittest.mock import patch
+import uuid
+from unittest.mock import MagicMock, patch
 
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
+from models import model as model_module
+from models.model import App, AppMode, RecommendedApp, Site
 from services.recommend_app.database.database_retrieval import DatabaseRecommendAppRetrieval
 from services.recommend_app.recommend_app_type import RecommendAppType
 
@@ -40,3 +43,50 @@ class TestDatabaseRecommendAppRetrieval:
 
         mock_fetch.assert_called_once_with("app-1", session=session)
         assert result == {"id": "app-1"}
+
+    def test_fetch_recommended_apps_uses_only_injected_session(self, sqlite_session: Session) -> None:
+        app = App(
+            id=str(uuid.uuid4()),
+            tenant_id=str(uuid.uuid4()),
+            name="Recommended App",
+            description="description",
+            mode=AppMode.CHAT,
+            icon_type=None,
+            icon=None,
+            icon_background=None,
+            enable_site=True,
+            enable_api=True,
+            is_public=True,
+            max_active_requests=None,
+        )
+        site = Site(
+            app_id=app.id,
+            title="Recommended App",
+            description="site description",
+            default_language="en-US",
+            customize_token_strategy="uuid",
+        )
+        recommended = RecommendedApp(
+            app_id=app.id,
+            description={},
+            copyright="copyright",
+            privacy_policy="privacy",
+            category="Workflow",
+            categories=["Workflow"],
+            language="en-US",
+        )
+        sqlite_session.add_all([app, site, recommended])
+        sqlite_session.commit()
+        global_session = MagicMock()
+        global_session.scalar.side_effect = AssertionError("database retrieval must use the injected session")
+
+        with patch.object(model_module.db, "session", global_session):
+            result = DatabaseRecommendAppRetrieval.fetch_recommended_apps_from_db(
+                "en-US",
+                session=sqlite_session,
+            )
+
+        assert result["recommended_apps"][0]["app"] is app
+        assert result["recommended_apps"][0]["description"] == "site description"
+        assert result["categories"] == ["Workflow"]
+        global_session.scalar.assert_not_called()

--- a/api/tests/unit_tests/services/test_recommended_app_query_compat.py
+++ b/api/tests/unit_tests/services/test_recommended_app_query_compat.py
@@ -1,0 +1,247 @@
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
+from models.model import App, AppMode, IconType
+from services import recommended_app_query_compat as compat_module
+from services.recommended_app_query_compat import LegacyRecommendedAppCatalogGateway
+from services.recommended_app_query_service import (
+    RecommendedAppCatalogPage,
+    RecommendedAppDetailRecord,
+    RecommendedAppInfoRecord,
+    RecommendedAppRecord,
+)
+
+
+@pytest.fixture
+def gateway_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[LegacyRecommendedAppCatalogGateway, MagicMock, MagicMock, MagicMock]:
+    session = MagicMock(spec=Session)
+    session_factory = MagicMock(spec=sessionmaker)
+    session_factory.return_value.__enter__.return_value = session
+    retrieval = MagicMock()
+    retrieval_type = MagicMock(return_value=retrieval)
+    get_factory = MagicMock(return_value=retrieval_type)
+    monkeypatch.setattr(compat_module.dify_config, "HOSTED_FETCH_APP_TEMPLATES_MODE", "remote")
+    monkeypatch.setattr(
+        compat_module.RecommendAppRetrievalFactory,
+        "get_recommend_app_factory",
+        get_factory,
+    )
+    return LegacyRecommendedAppCatalogGateway(session_factory), session, retrieval, get_factory
+
+
+@pytest.mark.parametrize("app_source_kind", ["mapping", "orm"])
+def test_list_recommended_selects_configured_retrieval_and_maps_mixed_results(
+    app_source_kind: str,
+    gateway_dependencies: tuple[LegacyRecommendedAppCatalogGateway, MagicMock, MagicMock, MagicMock],
+) -> None:
+    gateway, session, retrieval, get_factory = gateway_dependencies
+    app = App(
+        tenant_id="tenant-1",
+        name="App",
+        mode=AppMode.CHAT,
+        icon_type=IconType.IMAGE,
+        icon="icon.png",
+        icon_background="#fff",
+        enable_site=True,
+        enable_api=True,
+    )
+    app.id = "app-1"
+    app_source: object = app
+    if app_source_kind == "mapping":
+        app_source = {
+            "id": "app-1",
+            "name": "App",
+            "mode": "chat",
+            "icon": "icon.png",
+            "icon_type": "image",
+            "icon_background": "#fff",
+        }
+    retrieval.get_recommended_apps_and_categories.return_value = {
+        "recommended_apps": [
+            {
+                "app": app_source,
+                "app_id": "app-1",
+                "description": "description",
+                "copyright": None,
+                "privacy_policy": None,
+                "categories": ["Workflow"],
+                "position": 1,
+                "is_listed": True,
+            }
+        ],
+        "categories": ["Workflow"],
+    }
+
+    result = gateway.list_recommended("en-US")
+
+    assert result == RecommendedAppCatalogPage(
+        recommended_apps=(
+            RecommendedAppRecord(
+                app=RecommendedAppInfoRecord(
+                    id="app-1",
+                    name="App",
+                    mode="chat",
+                    icon="icon.png",
+                    icon_type="image",
+                    icon_background="#fff",
+                ),
+                app_id="app-1",
+                description="description",
+                copyright=None,
+                privacy_policy=None,
+                custom_disclaimer=None,
+                categories=("Workflow",),
+                position=1,
+                is_listed=True,
+            ),
+        ),
+        categories=("Workflow",),
+    )
+    get_factory.assert_called_once_with("remote")
+    retrieval.get_recommended_apps_and_categories.assert_called_once_with("en-US", session=session)
+
+
+def test_list_builtin_uses_builtin_source(
+    monkeypatch: pytest.MonkeyPatch,
+    gateway_dependencies: tuple[LegacyRecommendedAppCatalogGateway, MagicMock, MagicMock, MagicMock],
+) -> None:
+    gateway, _, _, _ = gateway_dependencies
+    builtin = MagicMock()
+    builtin_result: dict[str, object] = {"recommended_apps": [], "categories": []}
+    builtin.fetch_recommended_apps_from_builtin.return_value = builtin_result
+    get_builtin = MagicMock(return_value=builtin)
+    monkeypatch.setattr(
+        compat_module.RecommendAppRetrievalFactory,
+        "get_buildin_recommend_app_retrieval",
+        get_builtin,
+    )
+
+    result = gateway.list_builtin("en-US")
+
+    assert result == RecommendedAppCatalogPage(recommended_apps=(), categories=())
+    builtin.fetch_recommended_apps_from_builtin.assert_called_once_with("en-US")
+
+
+def test_list_learn_dify_delegates_to_configured_retrieval(
+    gateway_dependencies: tuple[LegacyRecommendedAppCatalogGateway, MagicMock, MagicMock, MagicMock],
+) -> None:
+    gateway, session, retrieval, _ = gateway_dependencies
+    learn_dify_result: dict[str, object] = {"recommended_apps": [], "categories": ["ignored"]}
+    retrieval.get_learn_dify_apps.return_value = learn_dify_result
+
+    result = gateway.list_learn_dify("fr-FR")
+
+    assert result.categories == ()
+    retrieval.get_learn_dify_apps.assert_called_once_with("fr-FR", session=session)
+
+
+def test_list_recommended_maps_none_apps_to_empty_page(
+    gateway_dependencies: tuple[LegacyRecommendedAppCatalogGateway, MagicMock, MagicMock, MagicMock],
+) -> None:
+    gateway, _, retrieval, _ = gateway_dependencies
+    retrieval.get_recommended_apps_and_categories.return_value = {
+        "recommended_apps": None,
+        "categories": ["ignored"],
+    }
+
+    assert gateway.list_recommended("en-US") == RecommendedAppCatalogPage(recommended_apps=(), categories=())
+
+
+def test_list_recommended_rejects_missing_categories_for_nonempty_page(
+    gateway_dependencies: tuple[LegacyRecommendedAppCatalogGateway, MagicMock, MagicMock, MagicMock],
+) -> None:
+    gateway, _, retrieval, _ = gateway_dependencies
+    retrieval.get_recommended_apps_and_categories.return_value = {
+        "recommended_apps": [{"app_id": "app-1", "app": None}],
+    }
+
+    with pytest.raises(KeyError, match="categories"):
+        gateway.list_recommended("en-US")
+
+
+@pytest.mark.parametrize("categories", ["Agent", b"Agent", ["Agent", 1]])
+def test_list_recommended_rejects_malformed_categories(
+    categories: object,
+    gateway_dependencies: tuple[LegacyRecommendedAppCatalogGateway, MagicMock, MagicMock, MagicMock],
+) -> None:
+    gateway, _, retrieval, _ = gateway_dependencies
+    retrieval.get_recommended_apps_and_categories.return_value = {
+        "recommended_apps": [{"app_id": "app-1", "app": None, "categories": list[str]()}],
+        "categories": categories,
+    }
+
+    with pytest.raises(TypeError, match="categories must"):
+        gateway.list_recommended("en-US")
+
+
+def test_list_recommended_rejects_malformed_app_categories(
+    gateway_dependencies: tuple[LegacyRecommendedAppCatalogGateway, MagicMock, MagicMock, MagicMock],
+) -> None:
+    gateway, _, retrieval, _ = gateway_dependencies
+    retrieval.get_recommended_apps_and_categories.return_value = {
+        "recommended_apps": [{"app_id": "app-1", "app": None, "categories": "Agent"}],
+        "categories": ["Agent"],
+    }
+
+    with pytest.raises(TypeError, match="categories must"):
+        gateway.list_recommended("en-US")
+
+
+def test_get_detail_maps_result_and_preserves_nullable_contract(
+    gateway_dependencies: tuple[LegacyRecommendedAppCatalogGateway, MagicMock, MagicMock, MagicMock],
+) -> None:
+    gateway, session, retrieval, _ = gateway_dependencies
+    retrieval.get_recommend_app_detail.side_effect = [
+        {
+            "id": "app-1",
+            "name": "App",
+            "icon": None,
+            "icon_background": None,
+            "mode": AppMode.CHAT,
+            "export_data": "{}",
+        },
+        None,
+    ]
+
+    assert gateway.get_detail("app-1") == RecommendedAppDetailRecord(
+        id="app-1",
+        name="App",
+        icon=None,
+        icon_background=None,
+        mode="chat",
+        export_data="{}",
+    )
+    assert gateway.get_detail("missing") is None
+    assert retrieval.get_recommend_app_detail.call_args_list[0].args == ("app-1",)
+    assert retrieval.get_recommend_app_detail.call_args_list[0].kwargs == {"session": session}
+
+
+def test_get_detail_rejects_arbitrary_enum_like_object(
+    gateway_dependencies: tuple[LegacyRecommendedAppCatalogGateway, MagicMock, MagicMock, MagicMock],
+) -> None:
+    gateway, _, retrieval, _ = gateway_dependencies
+    retrieval.get_recommend_app_detail.return_value = {
+        "id": "app-1",
+        "name": "App",
+        "icon": None,
+        "icon_background": None,
+        "mode": object(),
+        "export_data": "{}",
+    }
+
+    with pytest.raises(TypeError, match="mode must be a string or string enum"):
+        gateway.get_detail("app-1")
+
+
+def test_get_detail_rejects_non_mapping_result(
+    gateway_dependencies: tuple[LegacyRecommendedAppCatalogGateway, MagicMock, MagicMock, MagicMock],
+) -> None:
+    gateway, _, retrieval, _ = gateway_dependencies
+    retrieval.get_recommend_app_detail.return_value = object()
+
+    with pytest.raises(TypeError, match="recommended app detail must be a mapping"):
+        gateway.get_detail("app-1")

--- a/api/tests/unit_tests/services/test_recommended_app_query_service.py
+++ b/api/tests/unit_tests/services/test_recommended_app_query_service.py
@@ -1,0 +1,195 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from constants.languages import languages
+from services.recommended_app_query_service import (
+    RecommendedAppCatalogPage,
+    RecommendedAppDetailRecord,
+    RecommendedAppInfoRecord,
+    RecommendedAppNotFoundError,
+    RecommendedAppQueryService,
+    RecommendedAppRecord,
+)
+
+
+def _app(app_id: str) -> RecommendedAppRecord:
+    return RecommendedAppRecord(
+        app=RecommendedAppInfoRecord(
+            id=app_id,
+            name=f"App {app_id}",
+            mode="chat",
+            icon="icon.png",
+            icon_type="image",
+            icon_background="#fff",
+        ),
+        app_id=app_id,
+        description="description",
+        copyright=None,
+        privacy_policy=None,
+        custom_disclaimer=None,
+        categories=("Workflow",),
+        position=1,
+        is_listed=True,
+    )
+
+
+def _page(*app_ids: str, categories: tuple[str, ...] = ("Workflow",)) -> RecommendedAppCatalogPage:
+    return RecommendedAppCatalogPage(
+        recommended_apps=tuple(_app(app_id) for app_id in app_ids),
+        categories=categories,
+    )
+
+
+def _service(
+    *,
+    catalog: MagicMock,
+    trial_apps: MagicMock | None = None,
+    trial_enabled: MagicMock | None = None,
+) -> tuple[RecommendedAppQueryService, MagicMock, MagicMock]:
+    trial_apps = trial_apps or MagicMock()
+    trial_enabled = trial_enabled or MagicMock(return_value=False)
+    return (
+        RecommendedAppQueryService(
+            catalog=catalog,
+            trial_apps=trial_apps,
+            is_trial_enabled=trial_enabled,
+        ),
+        trial_apps,
+        trial_enabled,
+    )
+
+
+@pytest.mark.parametrize(
+    ("requested_language", "interface_language", "expected"),
+    [
+        ("en-US", "fr-FR", "en-US"),
+        ("invalid", "fr-FR", "fr-FR"),
+        (None, "custom-language", "custom-language"),
+        (None, None, languages[0]),
+    ],
+)
+def test_list_recommended_resolves_language(
+    requested_language: str | None,
+    interface_language: str | None,
+    expected: str,
+) -> None:
+    catalog = MagicMock()
+    catalog.list_recommended.return_value = _page("app-1")
+    service, _, _ = _service(catalog=catalog)
+
+    service.list_recommended(
+        requested_language=requested_language,
+        interface_language=interface_language,
+    )
+
+    catalog.list_recommended.assert_called_once_with(expected)
+
+
+def test_list_recommended_falls_back_to_builtin_en_us_when_empty() -> None:
+    catalog = MagicMock()
+    catalog.list_recommended.return_value = _page(categories=("remote",))
+    catalog.list_builtin.return_value = _page("builtin-app", categories=("builtin",))
+    service, _, _ = _service(catalog=catalog)
+
+    result = service.list_recommended(requested_language="ja-JP", interface_language=None)
+
+    catalog.list_builtin.assert_called_once_with("en-US")
+    assert [app.app_id for app in result.recommended_apps] == ["builtin-app"]
+    assert result.categories == ("builtin",)
+
+
+def test_list_recommended_disables_upstream_trial_without_querying_trial_apps() -> None:
+    catalog = MagicMock()
+    catalog.list_recommended.return_value = _page("app-1")
+    service, trial_apps, _ = _service(catalog=catalog)
+
+    result = service.list_recommended(requested_language="en-US", interface_language=None)
+
+    assert result.recommended_apps[0].can_trial is False
+    trial_apps.existing_ids.assert_not_called()
+
+
+def test_list_recommended_enriches_trial_status_in_one_bulk_query() -> None:
+    catalog = MagicMock()
+    catalog.list_recommended.return_value = _page("app-1", "app-2")
+    trial_apps = MagicMock()
+    trial_apps.existing_ids.return_value = frozenset({"app-1"})
+    service, _, _ = _service(
+        catalog=catalog,
+        trial_apps=trial_apps,
+        trial_enabled=MagicMock(return_value=True),
+    )
+
+    result = service.list_recommended(requested_language="en-US", interface_language=None)
+
+    assert [app.can_trial for app in result.recommended_apps] == [True, False]
+    trial_apps.existing_ids.assert_called_once_with(["app-1", "app-2"])
+
+
+def test_list_learn_dify_does_not_apply_general_builtin_fallback_or_return_categories() -> None:
+    catalog = MagicMock()
+    catalog.list_learn_dify.return_value = _page(categories=("ignored",))
+    service, _, _ = _service(catalog=catalog)
+
+    result = service.list_learn_dify(requested_language="invalid", interface_language="fr-FR")
+
+    catalog.list_learn_dify.assert_called_once_with("fr-FR")
+    catalog.list_builtin.assert_not_called()
+    assert result.recommended_apps == ()
+    assert not hasattr(result, "categories")
+
+
+def test_get_detail_raises_not_found_before_reading_trial_policy() -> None:
+    catalog = MagicMock()
+    catalog.get_detail.return_value = None
+    trial_enabled = MagicMock(side_effect=AssertionError("missing detail must not inspect trial policy"))
+    service, trial_apps, _ = _service(catalog=catalog, trial_enabled=trial_enabled)
+
+    with pytest.raises(RecommendedAppNotFoundError):
+        service.get_detail("missing")
+    trial_enabled.assert_not_called()
+    trial_apps.existing_ids.assert_not_called()
+
+
+def test_get_detail_does_not_query_trial_apps_when_disabled() -> None:
+    catalog = MagicMock()
+    catalog.get_detail.return_value = RecommendedAppDetailRecord(
+        id="catalog-app-id",
+        name="App",
+        icon=None,
+        icon_background=None,
+        mode="chat",
+        export_data="{}",
+    )
+    service, trial_apps, _ = _service(catalog=catalog)
+
+    result = service.get_detail("route-app-id")
+
+    assert result.can_trial is False
+    trial_apps.existing_ids.assert_not_called()
+
+
+@pytest.mark.parametrize(("existing_ids", "expected"), [(frozenset({"catalog-app-id"}), True), (frozenset(), False)])
+def test_get_detail_uses_catalog_result_id_for_trial_status(existing_ids: frozenset[str], expected: bool) -> None:
+    catalog = MagicMock()
+    catalog.get_detail.return_value = RecommendedAppDetailRecord(
+        id="catalog-app-id",
+        name="App",
+        icon=None,
+        icon_background=None,
+        mode="chat",
+        export_data="{}",
+    )
+    trial_apps = MagicMock()
+    trial_apps.existing_ids.return_value = existing_ids
+    service, _, _ = _service(
+        catalog=catalog,
+        trial_apps=trial_apps,
+        trial_enabled=MagicMock(return_value=True),
+    )
+
+    result = service.get_detail("route-app-id")
+
+    assert result.can_trial is expected
+    trial_apps.existing_ids.assert_called_once_with(("catalog-app-id",))

--- a/api/tests/unit_tests/services/test_recommended_app_service.py
+++ b/api/tests/unit_tests/services/test_recommended_app_service.py
@@ -1,61 +1,22 @@
-"""Unit tests for recommended app orchestration and SQLite-backed trial state."""
-
-from __future__ import annotations
+"""Unit tests for the remaining recommended app command/runtime service."""
 
 import uuid
 from collections.abc import Callable
-from typing import TypedDict, Unpack, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from enums import DeploymentEdition
-from models.model import AccountTrialAppRecord, App, AppMode, TrialApp
+from models.model import AccountTrialAppRecord, App, AppMode
 from services import recommended_app_service as service_module
 from services.recommended_app_service import RecommendedAppService
-
-pytestmark = pytest.mark.parametrize(
-    "sqlite_session",
-    [(TrialApp, AccountTrialAppRecord, App)],
-    indirect=True,
-)
 
 
 @pytest.fixture(autouse=True)
 def _recommended_app_config(config_overrides: Callable[..., None]) -> None:
-    config_overrides(
-        HOSTED_FETCH_APP_TEMPLATES_MODE="remote",
-        DEPLOYMENT_EDITION=DeploymentEdition.COMMUNITY,
-        ENABLE_TRIAL_APP=True,
-    )
-
-
-class RecommendedAppPayload(TypedDict, total=False):
-    id: str
-    app_id: str
-    name: str
-    description: str
-    category: str
-    icon: str
-    model_config: object
-    workflows: list[str]
-    tools: list[str]
-    can_trial: bool
-
-
-class AppsResponse(TypedDict):
-    recommended_apps: list[RecommendedAppPayload] | None
-    categories: list[str]
-
-
-class AppDetailKwargs(TypedDict, total=False):
-    category: str
-    icon: str
-    model_config: object
-    workflows: list[str]
-    tools: list[str]
+    config_overrides(HOSTED_FETCH_APP_TEMPLATES_MODE="remote")
 
 
 @pytest.mark.parametrize(
@@ -69,7 +30,6 @@ class AppDetailKwargs(TypedDict, total=False):
 )
 def test_trial_app_policy_is_cloud_only(
     config_overrides: Callable[..., None],
-    sqlite_session: Session,
     edition: DeploymentEdition,
     feature_enabled: bool,
     expected: bool,
@@ -77,85 +37,6 @@ def test_trial_app_policy_is_cloud_only(
     config_overrides(DEPLOYMENT_EDITION=edition, ENABLE_TRIAL_APP=feature_enabled)
 
     assert RecommendedAppService.is_trial_app_enabled() is expected
-
-
-# ── Helpers ────────────────────────────────────────────────────────────
-
-
-def _apps_response(
-    recommended_apps: list[RecommendedAppPayload] | None = None,
-    categories: list[str] | None = None,
-) -> AppsResponse:
-    if recommended_apps is None:
-        recommended_apps = [
-            {"app_id": "app-1", "name": "Test App 1", "description": "d1", "category": "productivity"},
-            {"app_id": "app-2", "name": "Test App 2", "description": "d2", "category": "communication"},
-        ]
-    if categories is None:
-        categories = ["productivity", "communication", "utilities"]
-    return {"recommended_apps": recommended_apps, "categories": categories}
-
-
-def _app_detail(
-    app_id: str = "app-123",
-    name: str = "Test App",
-    description: str = "Test description",
-    **kwargs: Unpack[AppDetailKwargs],
-) -> RecommendedAppPayload:
-    detail = RecommendedAppPayload(
-        id=app_id,
-        name=name,
-        description=description,
-        category=kwargs.get("category", "productivity"),
-        icon=kwargs.get("icon", "🚀"),
-        model_config=kwargs.get("model_config", {}),
-    )
-    detail.update(**kwargs)
-    return detail
-
-
-def _mock_factory_for_apps(
-    monkeypatch: pytest.MonkeyPatch,
-    *,
-    mode: str,
-    result: AppsResponse,
-    fallback_result: AppsResponse | None = None,
-) -> tuple[MagicMock, MagicMock]:
-    retrieval_instance = MagicMock()
-    retrieval_instance.get_recommended_apps_and_categories.return_value = result
-    retrieval_factory = MagicMock(return_value=retrieval_instance)
-    monkeypatch.setattr(service_module.dify_config, "HOSTED_FETCH_APP_TEMPLATES_MODE", mode, raising=False)
-    monkeypatch.setattr(
-        service_module.RecommendAppRetrievalFactory,
-        "get_recommend_app_factory",
-        MagicMock(return_value=retrieval_factory),
-    )
-    builtin_instance = MagicMock()
-    if fallback_result is not None:
-        builtin_instance.fetch_recommended_apps_from_builtin.return_value = fallback_result
-    monkeypatch.setattr(
-        service_module.RecommendAppRetrievalFactory,
-        "get_buildin_recommend_app_retrieval",
-        MagicMock(return_value=builtin_instance),
-    )
-    return retrieval_instance, builtin_instance
-
-
-def _mock_factory_for_app_detail(
-    monkeypatch: pytest.MonkeyPatch,
-    *,
-    result: RecommendedAppPayload | None,
-) -> MagicMock:
-    retrieval_instance = MagicMock()
-    retrieval_instance.get_recommend_app_detail.return_value = result
-    retrieval_factory = MagicMock(return_value=retrieval_instance)
-    monkeypatch.setattr(service_module.dify_config, "HOSTED_FETCH_APP_TEMPLATES_MODE", "remote", raising=False)
-    monkeypatch.setattr(
-        service_module.RecommendAppRetrievalFactory,
-        "get_recommend_app_factory",
-        MagicMock(return_value=retrieval_factory),
-    )
-    return retrieval_instance
 
 
 def _persist_app(session: Session, *, name: str) -> App:
@@ -172,391 +53,77 @@ def _persist_app(session: Session, *, name: str) -> App:
     return app
 
 
-# ── Pure logic tests: get_recommended_apps_and_categories ──────────────
+def _configure_recommended_detail(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    result: dict[str, str] | None,
+) -> MagicMock:
+    retrieval = MagicMock()
+    retrieval.get_recommend_app_detail.return_value = result
+    retrieval_type = MagicMock(return_value=retrieval)
+    monkeypatch.setattr(
+        service_module.RecommendAppRetrievalFactory,
+        "get_recommend_app_factory",
+        MagicMock(return_value=retrieval_type),
+    )
+    return retrieval
 
 
-class TestRecommendedAppServiceGetApps:
-    @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    def test_success_with_apps(self, mock_factory_class: MagicMock, sqlite_session: Session) -> None:
-        expected = _apps_response()
+def test_get_app_returns_normal_recommended_app(monkeypatch: pytest.MonkeyPatch, sqlite_session: Session) -> None:
+    app = _persist_app(sqlite_session, name="Recommended App")
+    retrieval = _configure_recommended_detail(monkeypatch, result={"id": app.id})
 
-        mock_instance = MagicMock()
-        mock_instance.get_recommended_apps_and_categories.return_value = expected
-        mock_factory = MagicMock(return_value=mock_instance)
-        mock_factory_class.get_recommend_app_factory.return_value = mock_factory
+    result = RecommendedAppService.get_app(app.id, session=sqlite_session)
 
-        result = RecommendedAppService.get_recommended_apps_and_categories("en-US", session=sqlite_session)
+    assert result is app
+    retrieval.get_recommend_app_detail.assert_called_once_with(app.id, session=sqlite_session)
 
-        assert result == expected
-        assert len(result["recommended_apps"]) == 2
-        assert len(result["categories"]) == 3
-        mock_factory_class.get_recommend_app_factory.assert_called_once_with("remote")
-        mock_instance.get_recommended_apps_and_categories.assert_called_once_with("en-US", session=sqlite_session)
 
-    @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    def test_fallback_to_builtin_when_empty(self, mock_factory_class: MagicMock, sqlite_session: Session) -> None:
-        empty_response = AppsResponse(recommended_apps=[], categories=[])
-        builtin_response = _apps_response(
-            recommended_apps=[{"app_id": "builtin-1", "name": "Builtin App", "category": "default"}]
+def test_get_app_returns_none_when_app_is_not_recommended(
+    monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+) -> None:
+    app = _persist_app(sqlite_session, name="Private App")
+    retrieval = _configure_recommended_detail(monkeypatch, result=None)
+
+    result = RecommendedAppService.get_app(app.id, session=sqlite_session)
+
+    assert result is None
+    retrieval.get_recommend_app_detail.assert_called_once_with(app.id, session=sqlite_session)
+
+
+def test_add_trial_app_record_increments_existing(sqlite_session: Session) -> None:
+    app_id = str(uuid.uuid4())
+    account_id = str(uuid.uuid4())
+    sqlite_session.add(AccountTrialAppRecord(app_id=app_id, account_id=account_id, count=3))
+    sqlite_session.commit()
+
+    RecommendedAppService.add_trial_app_record(app_id, account_id, session=sqlite_session)
+
+    sqlite_session.expire_all()
+    record = sqlite_session.scalar(
+        select(AccountTrialAppRecord).where(
+            AccountTrialAppRecord.app_id == app_id,
+            AccountTrialAppRecord.account_id == account_id,
         )
-
-        mock_remote_instance = MagicMock()
-        mock_remote_instance.get_recommended_apps_and_categories.return_value = empty_response
-        mock_factory_class.get_recommend_app_factory.return_value = MagicMock(return_value=mock_remote_instance)
-
-        mock_builtin_instance = MagicMock()
-        mock_builtin_instance.fetch_recommended_apps_from_builtin.return_value = builtin_response
-        mock_factory_class.get_buildin_recommend_app_retrieval.return_value = mock_builtin_instance
-
-        result = RecommendedAppService.get_recommended_apps_and_categories("zh-CN", session=sqlite_session)
-
-        assert result == builtin_response
-        assert result["recommended_apps"][0]["app_id"] == "builtin-1"
-        mock_builtin_instance.fetch_recommended_apps_from_builtin.assert_called_once_with("en-US")
-
-    @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    def test_fallback_when_none_recommended_apps(
-        self,
-        mock_factory_class: MagicMock,
-        sqlite_session: Session,
-        config_overrides: Callable[..., None],
-    ) -> None:
-        config_overrides(HOSTED_FETCH_APP_TEMPLATES_MODE="db")
-        none_response = AppsResponse(recommended_apps=None, categories=["test"])
-        builtin_response = _apps_response()
-
-        mock_db_instance = MagicMock()
-        mock_db_instance.get_recommended_apps_and_categories.return_value = none_response
-        mock_factory_class.get_recommend_app_factory.return_value = MagicMock(return_value=mock_db_instance)
-
-        mock_builtin_instance = MagicMock()
-        mock_builtin_instance.fetch_recommended_apps_from_builtin.return_value = builtin_response
-        mock_factory_class.get_buildin_recommend_app_retrieval.return_value = mock_builtin_instance
-
-        result = RecommendedAppService.get_recommended_apps_and_categories("en-US", session=sqlite_session)
-
-        assert result == builtin_response
-        mock_builtin_instance.fetch_recommended_apps_from_builtin.assert_called_once()
-
-    @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    def test_different_languages(
-        self,
-        mock_factory_class: MagicMock,
-        sqlite_session: Session,
-        config_overrides: Callable[..., None],
-    ) -> None:
-        config_overrides(HOSTED_FETCH_APP_TEMPLATES_MODE="builtin")
-
-        for language in ["en-US", "zh-CN", "ja-JP", "fr-FR"]:
-            lang_response = _apps_response(
-                recommended_apps=[{"app_id": f"app-{language}", "name": f"App {language}", "category": "test"}]
-            )
-            mock_instance = MagicMock()
-            mock_instance.get_recommended_apps_and_categories.return_value = lang_response
-            mock_factory_class.get_recommend_app_factory.return_value = MagicMock(return_value=mock_instance)
-
-            result = RecommendedAppService.get_recommended_apps_and_categories(language, session=sqlite_session)
-
-            assert result["recommended_apps"][0]["app_id"] == f"app-{language}"
-            mock_instance.get_recommended_apps_and_categories.assert_called_with(language, session=sqlite_session)
-
-    @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    def test_uses_correct_factory_mode(
-        self,
-        mock_factory_class: MagicMock,
-        sqlite_session: Session,
-        config_overrides: Callable[..., None],
-    ) -> None:
-        for mode in ["remote", "builtin", "db"]:
-            config_overrides(HOSTED_FETCH_APP_TEMPLATES_MODE=mode)
-            response = _apps_response()
-            mock_instance = MagicMock()
-            mock_instance.get_recommended_apps_and_categories.return_value = response
-            mock_factory_class.get_recommend_app_factory.return_value = MagicMock(return_value=mock_instance)
-
-            RecommendedAppService.get_recommended_apps_and_categories("en-US", session=sqlite_session)
-
-            mock_factory_class.get_recommend_app_factory.assert_called_with(mode)
+    )
+    assert record is not None
+    assert record.count == 4
 
 
-# ── Database-backed tests: get_app ─────────────────────────────────────
+def test_add_trial_app_record_creates_new_record(sqlite_session: Session) -> None:
+    app_id = str(uuid.uuid4())
+    account_id = str(uuid.uuid4())
 
+    RecommendedAppService.add_trial_app_record(app_id, account_id, session=sqlite_session)
 
-class TestRecommendedAppServiceGetApp:
-    def test_returns_normal_recommended_app(self, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session) -> None:
-        app = _persist_app(sqlite_session, name="Recommended App")
-
-        retrieval_instance = _mock_factory_for_app_detail(
-            monkeypatch,
-            result=RecommendedAppPayload(id=app.id),
+    sqlite_session.expire_all()
+    record = sqlite_session.scalar(
+        select(AccountTrialAppRecord).where(
+            AccountTrialAppRecord.app_id == app_id,
+            AccountTrialAppRecord.account_id == account_id,
         )
-        trial_policy = MagicMock(side_effect=AssertionError("get_app must not inspect trial policy"))
-        monkeypatch.setattr(RecommendedAppService, "is_trial_app_enabled", trial_policy)
-
-        result = RecommendedAppService.get_app(app.id, session=sqlite_session)
-
-        assert result is app
-        retrieval_instance.get_recommend_app_detail.assert_called_once_with(app.id, session=sqlite_session)
-        trial_policy.assert_not_called()
-
-    def test_returns_none_when_app_is_not_recommended(
-        self, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
-    ) -> None:
-        app = _persist_app(sqlite_session, name="Private App")
-
-        retrieval_instance = _mock_factory_for_app_detail(monkeypatch, result=None)
-
-        result = RecommendedAppService.get_app(app.id, session=sqlite_session)
-
-        assert result is None
-        retrieval_instance.get_recommend_app_detail.assert_called_once_with(app.id, session=sqlite_session)
-
-
-# ── Pure logic tests: get_recommend_app_detail ─────────────────────────
-
-
-class TestRecommendedAppServiceGetDetail:
-    @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    def test_returns_retrieval_detail_when_trial_disabled(
-        self,
-        mock_factory_class: MagicMock,
-        sqlite_session: Session,
-    ) -> None:
-        cases: list[tuple[str, RecommendedAppPayload]] = [
-            (
-                "complex-app",
-                _app_detail(
-                    app_id="complex-app",
-                    name="Complex App",
-                    model_config={
-                        "provider": "openai",
-                        "model": "gpt-4",
-                        "parameters": {"temperature": 0.7, "max_tokens": 2000, "top_p": 1.0},
-                    },
-                    workflows=["workflow-1", "workflow-2"],
-                    tools=["tool-1", "tool-2", "tool-3"],
-                ),
-            ),
-            ("app-empty", RecommendedAppPayload()),
-        ]
-
-        for app_id, expected in cases:
-            mock_instance = MagicMock()
-            mock_instance.get_recommend_app_detail.return_value = expected
-            mock_factory_class.get_recommend_app_factory.return_value = MagicMock(return_value=mock_instance)
-
-            result = RecommendedAppService.get_recommend_app_detail(app_id, session=sqlite_session)
-
-            assert result is not None
-            assert result["can_trial"] is False
-            mock_instance.get_recommend_app_detail.assert_called_once_with(app_id, session=sqlite_session)
-
-    @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    def test_different_modes(
-        self,
-        mock_factory_class: MagicMock,
-        sqlite_session: Session,
-        config_overrides: Callable[..., None],
-    ) -> None:
-        for mode in ["remote", "builtin", "db"]:
-            config_overrides(HOSTED_FETCH_APP_TEMPLATES_MODE=mode)
-            detail = _app_detail(app_id="test-app", name=f"App from {mode}")
-            mock_instance = MagicMock()
-            mock_instance.get_recommend_app_detail.return_value = detail
-            mock_factory_class.get_recommend_app_factory.return_value = MagicMock(return_value=mock_instance)
-
-            result = RecommendedAppService.get_recommend_app_detail("test-app", session=sqlite_session)
-
-            assert result is not None
-            mock_instance.get_recommend_app_detail.assert_called_with("test-app", session=sqlite_session)
-            mock_factory_class.get_recommend_app_factory.assert_called_with(mode)
-
-
-# ── Pure logic tests: get_learn_dify_apps ──────────────────────────────
-
-
-class TestRecommendedAppServiceGetLearnDifyApps:
-    @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    def test_uses_configured_retrieval_source(
-        self,
-        mock_factory_class: MagicMock,
-        sqlite_session: Session,
-    ) -> None:
-        expected_app = RecommendedAppPayload(app_id="app-1", category="Workflow")
-        mock_instance = MagicMock()
-        mock_instance.get_learn_dify_apps.return_value = {
-            "recommended_apps": [expected_app],
-            "categories": ["Workflow"],
-        }
-        mock_factory_class.get_recommend_app_factory.return_value = MagicMock(return_value=mock_instance)
-
-        result = RecommendedAppService.get_learn_dify_apps("en-US", session=sqlite_session)
-
-        assert result == {"recommended_apps": [{**expected_app, "can_trial": False}]}
-        mock_factory_class.get_recommend_app_factory.assert_called_once_with("remote")
-        mock_instance.get_learn_dify_apps.assert_called_once_with("en-US", session=sqlite_session)
-
-    def test_sets_can_trial_when_trial_feature_enabled(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        sqlite_session: Session,
-        config_overrides: Callable[..., None],
-    ) -> None:
-        config_overrides(HOSTED_FETCH_APP_TEMPLATES_MODE="db")
-        app = RecommendedAppPayload(app_id="app-1", category="Workflow")
-        mock_retrieval_instance = MagicMock()
-        mock_retrieval_instance.get_learn_dify_apps.return_value = {
-            "recommended_apps": [app],
-            "categories": ["Workflow"],
-        }
-        mock_retrieval_factory = MagicMock(return_value=mock_retrieval_instance)
-        monkeypatch.setattr(
-            service_module.RecommendAppRetrievalFactory,
-            "get_recommend_app_factory",
-            MagicMock(return_value=mock_retrieval_factory),
-        )
-        monkeypatch.setattr(RecommendedAppService, "is_trial_app_enabled", MagicMock(return_value=True))
-        trial_app_ids = MagicMock(return_value={"app-1"})
-        monkeypatch.setattr(RecommendedAppService, "_get_trial_app_ids", trial_app_ids)
-
-        result = RecommendedAppService.get_learn_dify_apps("en-US", session=sqlite_session)
-
-        assert result["recommended_apps"][0]["can_trial"] is True
-        trial_app_ids.assert_called_once_with(sqlite_session, ["app-1"])
-
-
-# ── Integration tests: trial app features (real DB) ────────────────────
-
-
-class TestRecommendedAppServiceTrialFeatures:
-    def test_get_apps_should_not_query_trial_table_when_disabled(
-        self, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
-    ) -> None:
-        upstream_result = AppsResponse(
-            recommended_apps=[RecommendedAppPayload(app_id="app-1", can_trial=True)], categories=["all"]
-        )
-        retrieval_instance, builtin_instance = _mock_factory_for_apps(
-            monkeypatch, mode="remote", result=upstream_result
-        )
-        monkeypatch.setattr(RecommendedAppService, "is_trial_app_enabled", MagicMock(return_value=False))
-        trial_app_ids = MagicMock(side_effect=AssertionError("disabled trial must not query TrialApp"))
-        monkeypatch.setattr(RecommendedAppService, "_get_trial_app_ids", trial_app_ids)
-
-        result = RecommendedAppService.get_recommended_apps_and_categories("en-US", session=sqlite_session)
-
-        assert result["recommended_apps"][0]["can_trial"] is False
-        trial_app_ids.assert_not_called()
-        retrieval_instance.get_recommended_apps_and_categories.assert_called_once_with("en-US", session=sqlite_session)
-        builtin_instance.fetch_recommended_apps_from_builtin.assert_not_called()
-
-    def test_get_apps_should_enrich_can_trial_when_enabled(
-        self, sqlite_session: Session, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        app_id_1 = str(uuid.uuid4())
-        app_id_2 = str(uuid.uuid4())
-        tenant_id = str(uuid.uuid4())
-
-        # app_id_1 has a TrialApp record; app_id_2 does not
-        sqlite_session.add(TrialApp(app_id=app_id_1, tenant_id=tenant_id))
-        sqlite_session.commit()
-
-        remote_result = AppsResponse(recommended_apps=[], categories=[])
-        fallback_result = AppsResponse(
-            recommended_apps=[RecommendedAppPayload(app_id=app_id_1), RecommendedAppPayload(app_id=app_id_2)],
-            categories=["all"],
-        )
-        _, builtin_instance = _mock_factory_for_apps(
-            monkeypatch, mode="remote", result=remote_result, fallback_result=fallback_result
-        )
-        monkeypatch.setattr(RecommendedAppService, "is_trial_app_enabled", MagicMock(return_value=True))
-
-        result = RecommendedAppService.get_recommended_apps_and_categories("ja-JP", session=sqlite_session)
-
-        builtin_instance.fetch_recommended_apps_from_builtin.assert_called_once_with("en-US")
-        assert result["recommended_apps"][0]["can_trial"] is True
-        assert result["recommended_apps"][1]["can_trial"] is False
-
-    @pytest.mark.parametrize("has_trial_app", [True, False])
-    def test_get_detail_should_set_can_trial_when_enabled(
-        self,
-        sqlite_session: Session,
-        monkeypatch: pytest.MonkeyPatch,
-        has_trial_app: bool,
-    ) -> None:
-        app_id = str(uuid.uuid4())
-        tenant_id = str(uuid.uuid4())
-
-        if has_trial_app:
-            sqlite_session.add(TrialApp(app_id=app_id, tenant_id=tenant_id))
-            sqlite_session.commit()
-
-        detail = RecommendedAppPayload(id=app_id, name="Test App")
-        retrieval_instance = MagicMock()
-        retrieval_instance.get_recommend_app_detail.return_value = detail
-        retrieval_factory = MagicMock(return_value=retrieval_instance)
-        monkeypatch.setattr(service_module.dify_config, "HOSTED_FETCH_APP_TEMPLATES_MODE", "remote", raising=False)
-        monkeypatch.setattr(
-            service_module.RecommendAppRetrievalFactory,
-            "get_recommend_app_factory",
-            MagicMock(return_value=retrieval_factory),
-        )
-        monkeypatch.setattr(RecommendedAppService, "is_trial_app_enabled", MagicMock(return_value=True))
-
-        result = RecommendedAppService.get_recommend_app_detail(app_id, session=sqlite_session)
-        assert result is not None
-        detail_result = cast(RecommendedAppPayload, result)
-
-        assert detail_result["id"] == app_id
-        assert detail_result["can_trial"] is has_trial_app
-
-    @patch("services.recommended_app_service.RecommendAppRetrievalFactory", autospec=True)
-    def test_get_detail_returns_none_before_reading_trial_flag(
-        self,
-        mock_factory_class: MagicMock,
-        sqlite_session: Session,
-    ) -> None:
-        mock_instance = MagicMock()
-        mock_instance.get_recommend_app_detail.return_value = None
-        mock_factory_class.get_recommend_app_factory.return_value = MagicMock(return_value=mock_instance)
-        trial_policy = MagicMock(side_effect=AssertionError("missing app must not inspect trial policy"))
-        with patch.object(RecommendedAppService, "is_trial_app_enabled", trial_policy):
-            result = RecommendedAppService.get_recommend_app_detail("nonexistent", session=sqlite_session)
-
-        assert result is None
-        mock_instance.get_recommend_app_detail.assert_called_once_with("nonexistent", session=sqlite_session)
-        trial_policy.assert_not_called()
-
-    def test_add_trial_app_record_increments_count_for_existing(self, sqlite_session: Session) -> None:
-        app_id = str(uuid.uuid4())
-        account_id = str(uuid.uuid4())
-
-        sqlite_session.add(AccountTrialAppRecord(app_id=app_id, account_id=account_id, count=3))
-        sqlite_session.commit()
-
-        RecommendedAppService.add_trial_app_record(app_id, account_id, session=sqlite_session)
-
-        sqlite_session.expire_all()
-        record = sqlite_session.scalar(
-            select(AccountTrialAppRecord)
-            .where(AccountTrialAppRecord.app_id == app_id, AccountTrialAppRecord.account_id == account_id)
-            .limit(1)
-        )
-        assert record is not None
-        assert record.count == 4
-
-    def test_add_trial_app_record_creates_new_record(self, sqlite_session: Session) -> None:
-        app_id = str(uuid.uuid4())
-        account_id = str(uuid.uuid4())
-
-        RecommendedAppService.add_trial_app_record(app_id, account_id, session=sqlite_session)
-
-        sqlite_session.expire_all()
-        record = sqlite_session.scalar(
-            select(AccountTrialAppRecord)
-            .where(AccountTrialAppRecord.app_id == app_id, AccountTrialAppRecord.account_id == account_id)
-            .limit(1)
-        )
-        assert record is not None
-        assert record.app_id == app_id
-        assert record.account_id == account_id
-        assert record.count == 1
+    )
+    assert record is not None
+    assert record.app_id == app_id
+    assert record.account_id == account_id
+    assert record.count == 1

--- a/packages/contracts/generated/api/console/explore/types.gen.ts
+++ b/packages/contracts/generated/api/console/explore/types.gen.ts
@@ -13,7 +13,15 @@ export type LearnDifyAppListResponse = {
   recommended_apps: Array<RecommendedAppResponse>
 }
 
-export type RecommendedAppDetailNullableResponse = RecommendedAppDetailResponse | null
+export type RecommendedAppDetailResponse = {
+  can_trial: boolean
+  export_data: string
+  icon?: string | null
+  icon_background?: string | null
+  id: string
+  mode: string
+  name: string
+}
 
 export type BannerListResponse = Array<BannerResponse>
 
@@ -28,16 +36,6 @@ export type RecommendedAppResponse = {
   is_listed?: boolean | null
   position?: number | null
   privacy_policy?: string | null
-}
-
-export type RecommendedAppDetailResponse = {
-  can_trial: boolean
-  export_data: string
-  icon?: string | null
-  icon_background?: string | null
-  id: string
-  mode: string
-  name: string
 }
 
 export type BannerResponse = {
@@ -139,8 +137,12 @@ export type GetExploreAppsByAppIdData = {
   url: '/explore/apps/{app_id}'
 }
 
+export type GetExploreAppsByAppIdErrors = {
+  404: unknown
+}
+
 export type GetExploreAppsByAppIdResponses = {
-  200: RecommendedAppDetailNullableResponse
+  200: RecommendedAppDetailResponse
 }
 
 export type GetExploreAppsByAppIdResponse =

--- a/packages/contracts/generated/api/console/explore/zod.gen.ts
+++ b/packages/contracts/generated/api/console/explore/zod.gen.ts
@@ -16,11 +16,6 @@ export const zRecommendedAppDetailResponse = z.object({
 })
 
 /**
- * RecommendedAppDetailNullableResponse
- */
-export const zRecommendedAppDetailNullableResponse = zRecommendedAppDetailResponse.nullable()
-
-/**
  * RecommendedAppInfoResponse
  */
 export const zRecommendedAppInfoResponse = z.object({
@@ -166,7 +161,7 @@ export const zGetExploreAppsByAppIdPath = z.object({
 /**
  * Success
  */
-export const zGetExploreAppsByAppIdResponse = zRecommendedAppDetailNullableResponse
+export const zGetExploreAppsByAppIdResponse = zRecommendedAppDetailResponse
 
 export const zGetExploreBannersQuery = z.object({
   language: z.string().optional().default('en-US'),

--- a/web/features/home/home-content/home-content.tsx
+++ b/web/features/home/home-content/home-content.tsx
@@ -349,7 +349,6 @@ export function HomeContent() {
           input: { params: { app_id: appId } },
         }),
       )
-      if (!appDetail) throw new Error('Recommended app not found')
 
       const { export_data, mode } = appDetail
       currentCreateAppModeRef.current = mode

--- a/web/service/explore.ts
+++ b/web/service/explore.ts
@@ -128,7 +128,6 @@ export const fetchAppDetail = async (id: string): Promise<ExploreAppDetailRespon
   const response = await consoleClient.explore.apps.byAppId.get({
     params: { app_id: id },
   })
-  if (!response) throw new Error('Recommended app not found')
   return normalizeAppDetail(response)
 }
 


### PR DESCRIPTION
## Summary

Part of #39993. This is PR 1 of the Recommended App refactor stack.

Extract the Recommended App read capability behind a framework- and persistence-neutral query service:

- list recommended and Learn Dify apps through typed records;
- enrich results with trial eligibility through a repository-owned read session;
- keep controllers limited to request data, scalar IDs, HTTP error translation, and `dump_response`;
- return a stable `recommended_app_not_found` 404 for a missing detail instead of `200 null`;
- regenerate OpenAPI, TypeScript, and Zod contracts and remove frontend hard-coded English fallback errors.

## Why this layer

The previous controllers consumed mixed dictionaries and ORM objects from the legacy retrieval stack and passed request Sessions through the read path. This layer defines one stable Recommended App query capability while keeping provider migration separate.

## Intentional boundaries

- `LegacyRecommendedAppCatalogGateway` temporarily adapts the existing builtin, remote, and database retrieval implementations. The final catalog adapters are introduced later in this stack.
- Database retrieval still owns its existing DSL export and Redis behavior; this PR does not redesign that provider.
- Controllers still use `with_current_user` for interface language because locale is not yet part of the stable request context.
- Trial usage writes and preview admission remain separate downstream capabilities.
- The global error envelope is unchanged; this PR only stabilizes the semantic error code for a missing Recommended App.

## Verification

- 68 focused API unit tests passed.
- 33 focused web tests passed.
- Contracts TypeScript type-check passed.
- Ruff, Pyrefly, import-linter, response-contract lint, and the controller SQLAlchemy/getattr guards passed.

From Codex
