### PR TITLE
refactor(api): isolate trial app usage writes

### DIFF
--- a/api/controllers/console/explore/trial.py
+++ b/api/controllers/console/explore/trial.py
@@ -96,7 +96,6 @@ from services.errors.message import (
     SuggestedQuestionsAfterAnswerDisabledError,
 )
 from services.message_service import MessageService
-from services.recommended_app_service import RecommendedAppService
 
 logger = logging.getLogger(__name__)
 
@@ -511,7 +510,7 @@ class TrialAppWorkflowRunApi(TrialAppResource):
                 invoke_from=InvokeFrom.EXPLORE,
                 streaming=True,
             )
-            RecommendedAppService.add_trial_app_record(app_id, user_id, session=session)
+            application_services().trial_app_usage.record(app_id=app_id, account_id=user_id)
             # response-contract:ignore compact_generate_response
             return helper.compact_generate_response(response)
         except ProviderTokenNotInitError as ex:
@@ -589,7 +588,7 @@ class TrialChatApi(TrialAppResource):
                 invoke_from=InvokeFrom.EXPLORE,
                 streaming=True,
             )
-            RecommendedAppService.add_trial_app_record(app_id, user_id, session=session)
+            application_services().trial_app_usage.record(app_id=app_id, account_id=user_id)
             # response-contract:ignore compact_generate_response
             return helper.compact_generate_response(response)
         except services.errors.conversation.ConversationNotExistsError:
@@ -675,7 +674,7 @@ class TrialChatAudioApi(TrialAppResource):
                 session=db.session(),
                 end_user=None,
             )
-            RecommendedAppService.add_trial_app_record(app_id, user_id, session=db.session())
+            application_services().trial_app_usage.record(app_id=app_id, account_id=user_id)
             return response
         except services.errors.app_model_config.AppModelConfigBrokenError:
             logger.exception("App model config broken.")
@@ -736,7 +735,7 @@ class TrialChatTextApi(TrialAppResource):
                 voice=voice,
                 message_ref=message_ref,
             )
-            RecommendedAppService.add_trial_app_record(app_id, user_id, session=db.session())
+            application_services().trial_app_usage.record(app_id=app_id, account_id=user_id)
             return response
         except services.errors.app_model_config.AppModelConfigBrokenError:
             logger.exception("App model config broken.")
@@ -794,7 +793,7 @@ class TrialCompletionApi(TrialAppResource):
                 streaming=streaming,
             )
 
-            RecommendedAppService.add_trial_app_record(app_id, user_id, session=session)
+            application_services().trial_app_usage.record(app_id=app_id, account_id=user_id)
             # response-contract:ignore compact_generate_response
             return helper.compact_generate_response(response)
         except services.errors.conversation.ConversationNotExistsError:

--- a/api/extensions/ext_application_services.py
+++ b/api/extensions/ext_application_services.py
@@ -23,6 +23,7 @@ from repositories.explore_banner_query_repository import ExploreBannerQueryRepos
 from repositories.installation_state_repository import InstallationStateRepository
 from repositories.tag_repository import TagRepository
 from repositories.trial_app_query_repository import TrialAppQueryRepository
+from repositories.trial_app_usage_repository import TrialAppUsageRepository
 from repositories.webapp_access_query_repository import WebAppAccessQueryRepository
 from repositories.workspace_member_query_repository import WorkspaceMemberQueryRepository
 from repositories.workspace_query_repository import WorkspaceQueryRepository
@@ -55,6 +56,7 @@ from services.schema_definition_service import SchemaDefinitionService
 from services.setup_adapters import RedisSetupLock, RegisterServiceAccountProvisioner
 from services.setup_service import SetupService
 from services.tag_application_service import TagApplicationService
+from services.trial_app_usage import TrialAppUsageRecorder
 from services.web_app_runtime_query_service import WebAppRuntimeQueryService
 from services.webapp_access_query_service import (
     WebAppAccessQueryService,
@@ -105,6 +107,7 @@ class ApplicationServices:
     feature_queries: FeatureQueryService
     init_validation: InitValidationService
     recommended_app_queries: RecommendedAppQueryService
+    trial_app_usage: TrialAppUsageRecorder
     workspace_queries: WorkspaceQueryService
     workspace_member_queries: WorkspaceMemberQueryService
     tags: TagApplicationService
@@ -185,6 +188,7 @@ def build_application_services(
             trial_apps=TrialAppQueryRepository(session_factory=database_client),
             is_trial_enabled=RecommendedAppService.is_trial_app_enabled,
         ),
+        trial_app_usage=TrialAppUsageRepository(session_factory=database_client),
         workspace_queries=WorkspaceQueryService(
             workspaces=WorkspaceQueryRepository(
                 client=database_client,

--- a/api/repositories/trial_app_usage_repository.py
+++ b/api/repositories/trial_app_usage_repository.py
@@ -1,0 +1,28 @@
+"""Database repository for recommended trial app usage."""
+
+from typing import override
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+from models.model import AccountTrialAppRecord
+from services.trial_app_usage import TrialAppUsageRecorder
+
+
+class TrialAppUsageRepository(TrialAppUsageRecorder):
+    def __init__(self, session_factory: sessionmaker[Session]) -> None:
+        self._session_factory = session_factory
+
+    @override
+    def record(self, *, app_id: str, account_id: str) -> None:
+        """Increment usage without committing the caller's request transaction."""
+        with self._session_factory() as session, session.begin():
+            record = session.scalar(
+                select(AccountTrialAppRecord)
+                .where(AccountTrialAppRecord.app_id == app_id, AccountTrialAppRecord.account_id == account_id)
+                .limit(1)
+            )
+            if record is None:
+                session.add(AccountTrialAppRecord(app_id=app_id, account_id=account_id, count=1))
+            else:
+                record.count += 1

--- a/api/services/recommended_app_service.py
+++ b/api/services/recommended_app_service.py
@@ -3,12 +3,12 @@ from sqlalchemy.orm import Session
 
 from configs import dify_config
 from enums import DeploymentEdition
-from models.model import AccountTrialAppRecord, App
+from models.model import App
 from services.recommend_app.recommend_app_factory import RecommendAppRetrievalFactory
 
 
 class RecommendedAppService:
-    """Own recommended app runtime admission and trial usage writes."""
+    """Own recommended app runtime admission."""
 
     @staticmethod
     def is_trial_app_enabled() -> bool:
@@ -25,22 +25,3 @@ class RecommendedAppService:
             return None
 
         return session.scalar(select(App).where(App.id == app_id, App.status == "normal").limit(1))
-
-    @classmethod
-    def add_trial_app_record(cls, app_id: str, account_id: str, *, session: Session):
-        """
-        Add trial app record.
-        :param app_id: app id
-        :return:
-        """
-        account_trial_app_record = session.scalar(
-            select(AccountTrialAppRecord)
-            .where(AccountTrialAppRecord.app_id == app_id, AccountTrialAppRecord.account_id == account_id)
-            .limit(1)
-        )
-        if account_trial_app_record:
-            account_trial_app_record.count += 1
-            session.commit()
-        else:
-            session.add(AccountTrialAppRecord(app_id=app_id, count=1, account_id=account_id))
-            session.commit()

--- a/api/services/trial_app_usage.py
+++ b/api/services/trial_app_usage.py
@@ -1,0 +1,7 @@
+"""Port for recording recommended trial app usage."""
+
+from typing import Protocol
+
+
+class TrialAppUsageRecorder(Protocol):
+    def record(self, *, app_id: str, account_id: str) -> None: ...

--- a/api/tests/unit_tests/controllers/console/explore/test_trial.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_trial.py
@@ -68,6 +68,17 @@ def account() -> Account:
     return acc
 
 
+@pytest.fixture
+def trial_app_usage(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    usage = MagicMock()
+    monkeypatch.setattr(
+        module,
+        "application_services",
+        MagicMock(return_value=SimpleNamespace(trial_app_usage=usage)),
+    )
+    return usage
+
+
 def _app(*, app_id: str, mode: AppMode, tenant_id: str = "tenant-1") -> App:
     return App(
         id=app_id,
@@ -269,14 +280,19 @@ class TestTrialAppWorkflowRunApi(_UsesSQLiteSession):
                     _app(app_id="not-workflow", mode=AppMode.CHAT),
                 )
 
-    def test_success(self, app: Flask, trial_app_workflow: App, account: Account) -> None:
+    def test_success(
+        self,
+        app: Flask,
+        trial_app_workflow: App,
+        account: Account,
+        trial_app_usage: MagicMock,
+    ) -> None:
         api = module.TrialAppWorkflowRunApi()
         method = unwrap(api.post)
 
         with (
             app.test_request_context("/", json={"inputs": {}}),
             patch.object(module.AppGenerateService, "generate", return_value=MagicMock()),
-            patch.object(module.RecommendedAppService, "add_trial_app_record"),
         ):
             result = method(
                 api,
@@ -287,6 +303,7 @@ class TestTrialAppWorkflowRunApi(_UsesSQLiteSession):
             )
 
         assert result is not None
+        trial_app_usage.record.assert_called_once_with(app_id="a-workflow", account_id="u1")
 
     def test_workflow_provider_not_init(self, app: Flask, trial_app_workflow: App, account: Account) -> None:
         api = module.TrialAppWorkflowRunApi()
@@ -451,20 +468,26 @@ class TestTrialChatApi(_UsesSQLiteSession):
                     _app(app_id="not-chat", mode=AppMode.COMPLETION),
                 )
 
-    def test_success(self, app: Flask, trial_app_chat: App, account: Account) -> None:
+    def test_success(
+        self,
+        app: Flask,
+        trial_app_chat: App,
+        account: Account,
+        trial_app_usage: MagicMock,
+    ) -> None:
         api = module.TrialChatApi()
         method = unwrap(api.post)
 
         with (
             app.test_request_context("/", json={"inputs": {}, "query": "hi"}),
             patch.object(module.AppGenerateService, "generate", return_value=MagicMock()),
-            patch.object(module.RecommendedAppService, "add_trial_app_record"),
         ):
             result = method(
                 api, ChatRequest.model_validate(request.get_json()), self.sqlite_session, account, trial_app_chat
             )
 
         assert result is not None
+        trial_app_usage.record.assert_called_once_with(app_id="a-chat", account_id="u1")
 
     def test_chat_conversation_not_exists(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatApi()
@@ -652,14 +675,19 @@ class TestTrialCompletionApi(_UsesSQLiteSession):
                     _app(app_id="not-completion", mode=AppMode.CHAT),
                 )
 
-    def test_success(self, app: Flask, trial_app_completion: App, account: Account) -> None:
+    def test_success(
+        self,
+        app: Flask,
+        trial_app_completion: App,
+        account: Account,
+        trial_app_usage: MagicMock,
+    ) -> None:
         api = module.TrialCompletionApi()
         method = unwrap(api.post)
 
         with (
             app.test_request_context("/", json={"inputs": {}, "query": ""}),
             patch.object(module.AppGenerateService, "generate", return_value=MagicMock()),
-            patch.object(module.RecommendedAppService, "add_trial_app_record"),
         ):
             result = method(
                 api,
@@ -670,6 +698,7 @@ class TestTrialCompletionApi(_UsesSQLiteSession):
             )
 
         assert result is not None
+        trial_app_usage.record.assert_called_once_with(app_id="a-comp", account_id="u1")
 
     def test_completion_app_config_broken(self, app: Flask, trial_app_completion: App, account: Account) -> None:
         api = module.TrialCompletionApi()
@@ -919,7 +948,13 @@ class TestTrialAppParameterApi:
 
 
 class TestTrialChatAudioApi:
-    def test_success(self, app: Flask, trial_app_chat: App, account: Account) -> None:
+    def test_success(
+        self,
+        app: Flask,
+        trial_app_chat: App,
+        account: Account,
+        trial_app_usage: MagicMock,
+    ) -> None:
         api = module.TrialChatAudioApi()
         method = unwrap(api.post)
 
@@ -930,11 +965,11 @@ class TestTrialChatAudioApi:
                 "/", method="POST", data={"file": (file_data, "test.wav")}, content_type="multipart/form-data"
             ),
             patch.object(module.AudioService, "transcript_asr", return_value={"text": "hello"}),
-            patch.object(module.RecommendedAppService, "add_trial_app_record"),
         ):
             result = method(api, account, trial_app_chat)
 
         assert result == {"text": "hello"}
+        trial_app_usage.record.assert_called_once_with(app_id="a-chat", account_id="u1")
 
     def test_app_config_broken(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatAudioApi()
@@ -1140,22 +1175,34 @@ class TestTrialChatAudioApi:
 
 
 class TestTrialChatTextApi:
-    def test_success(self, app: Flask, trial_app_chat: App, account: Account) -> None:
+    def test_success(
+        self,
+        app: Flask,
+        trial_app_chat: App,
+        account: Account,
+        trial_app_usage: MagicMock,
+    ) -> None:
         api = module.TrialChatTextApi()
         method = unwrap(api.post)
 
         with (
             app.test_request_context("/", json={"text": "hello", "voice": "en-US"}),
             patch.object(module.AudioService, "transcript_tts", return_value={"audio": "base64_data"}),
-            patch.object(module.RecommendedAppService, "add_trial_app_record"),
         ):
             result = method(
                 api, TextToSpeechRequest.model_validate(request.get_json(silent=True) or {}), account, trial_app_chat
             )
 
         assert result == {"audio": "base64_data"}
+        trial_app_usage.record.assert_called_once_with(app_id="a-chat", account_id="u1")
 
-    def test_success_with_message_ref(self, app: Flask, trial_app_chat: App, account: Account) -> None:
+    def test_success_with_message_ref(
+        self,
+        app: Flask,
+        trial_app_chat: App,
+        account: Account,
+        trial_app_usage: MagicMock,
+    ) -> None:
         api = module.TrialChatTextApi()
         method = unwrap(api.post)
         transcript_tts = MagicMock(return_value={"audio": "base64_data"})
@@ -1164,7 +1211,6 @@ class TestTrialChatTextApi:
         with (
             app.test_request_context("/", json={"text": "hello", "message_id": "message-1"}),
             patch.object(module.AudioService, "transcript_tts", transcript_tts),
-            patch.object(module.RecommendedAppService, "add_trial_app_record"),
         ):
             result = method(
                 api, TextToSpeechRequest.model_validate(request.get_json(silent=True) or {}), account, trial_app_chat
@@ -1176,6 +1222,7 @@ class TestTrialChatTextApi:
             "message-1",
             account_id="u1",
         )
+        trial_app_usage.record.assert_called_once_with(app_id="a-chat", account_id="u1")
 
     def test_app_config_broken(self, app: Flask, trial_app_chat: App, account: Account) -> None:
         api = module.TrialChatTextApi()

--- a/api/tests/unit_tests/extensions/test_ext_application_services.py
+++ b/api/tests/unit_tests/extensions/test_ext_application_services.py
@@ -3,17 +3,19 @@
 import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import httpx
 import pytest
 from flask import Flask
 from pydantic import ValidationError
+from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
 
 from enums import DeploymentEdition, WebAppAccessMode
 from extensions import ext_application_services
 from extensions.ext_redis import RedisClientWrapper
-from models.model import DifySetup
+from models.model import AccountTrialAppRecord, DifySetup
 from repositories.account_activation_repository import SQLAlchemyAccountActivationRepository
 from repositories.account_repository import SQLAlchemyAccountRepository
 from services.account_activation_adapters import (
@@ -223,6 +225,31 @@ def test_build_application_services_wires_data_source_api_key_auth(
     )
 
     assert isinstance(services.data_source_api_key_auth, DataSourceApiKeyAuthService)
+
+
+def test_build_application_services_wires_trial_app_usage(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    services = ext_application_services.build_application_services(
+        database_client=sqlite_session_factory,
+        deployment_edition=DeploymentEdition.COMMUNITY,
+        initialization_password="",
+        redis=MagicMock(spec=RedisClientWrapper),
+    )
+    app_id = str(uuid4())
+    account_id = str(uuid4())
+
+    services.trial_app_usage.record(app_id=app_id, account_id=account_id)
+
+    with sqlite_session_factory() as session:
+        record = session.scalar(
+            select(AccountTrialAppRecord).where(
+                AccountTrialAppRecord.app_id == app_id,
+                AccountTrialAppRecord.account_id == account_id,
+            )
+        )
+    assert record is not None
+    assert record.count == 1
 
 
 def test_build_application_services_adapts_enterprise_webapp_access_mode(

--- a/api/tests/unit_tests/repositories/test_trial_app_usage_repository.py
+++ b/api/tests/unit_tests/repositories/test_trial_app_usage_repository.py
@@ -1,0 +1,53 @@
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+from models.model import AccountTrialAppRecord
+from repositories.trial_app_usage_repository import TrialAppUsageRepository
+
+
+def _record(
+    session_factory: sessionmaker[Session],
+    *,
+    app_id: str,
+    account_id: str,
+) -> AccountTrialAppRecord | None:
+    with session_factory() as session:
+        return session.scalar(
+            select(AccountTrialAppRecord).where(
+                AccountTrialAppRecord.app_id == app_id,
+                AccountTrialAppRecord.account_id == account_id,
+            )
+        )
+
+
+def test_record_increments_existing_usage(sqlite_session_factory: sessionmaker[Session]) -> None:
+    app_id = str(uuid.uuid4())
+    account_id = str(uuid.uuid4())
+    with sqlite_session_factory.begin() as session:
+        session.add(AccountTrialAppRecord(app_id=app_id, account_id=account_id, count=3))
+
+    TrialAppUsageRepository(sqlite_session_factory).record(app_id=app_id, account_id=account_id)
+
+    record = _record(sqlite_session_factory, app_id=app_id, account_id=account_id)
+    assert record is not None
+    assert record.count == 4
+
+
+def test_record_does_not_commit_caller_session(sqlite_session_factory: sessionmaker[Session]) -> None:
+    pending_app_id = str(uuid.uuid4())
+    usage_app_id = str(uuid.uuid4())
+    account_id = str(uuid.uuid4())
+
+    with sqlite_session_factory() as caller_session:
+        caller_session.add(AccountTrialAppRecord(app_id=pending_app_id, account_id=account_id, count=1))
+
+        TrialAppUsageRepository(sqlite_session_factory).record(app_id=usage_app_id, account_id=account_id)
+
+        caller_session.rollback()
+
+    assert _record(sqlite_session_factory, app_id=pending_app_id, account_id=account_id) is None
+    usage = _record(sqlite_session_factory, app_id=usage_app_id, account_id=account_id)
+    assert usage is not None
+    assert usage.count == 1

--- a/api/tests/unit_tests/services/test_recommended_app_service.py
+++ b/api/tests/unit_tests/services/test_recommended_app_service.py
@@ -5,11 +5,10 @@ from collections.abc import Callable
 from unittest.mock import MagicMock
 
 import pytest
-from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from enums import DeploymentEdition
-from models.model import AccountTrialAppRecord, App, AppMode
+from models.model import App, AppMode
 from services import recommended_app_service as service_module
 from services.recommended_app_service import RecommendedAppService
 
@@ -89,41 +88,3 @@ def test_get_app_returns_none_when_app_is_not_recommended(
 
     assert result is None
     retrieval.get_recommend_app_detail.assert_called_once_with(app.id, session=sqlite_session)
-
-
-def test_add_trial_app_record_increments_existing(sqlite_session: Session) -> None:
-    app_id = str(uuid.uuid4())
-    account_id = str(uuid.uuid4())
-    sqlite_session.add(AccountTrialAppRecord(app_id=app_id, account_id=account_id, count=3))
-    sqlite_session.commit()
-
-    RecommendedAppService.add_trial_app_record(app_id, account_id, session=sqlite_session)
-
-    sqlite_session.expire_all()
-    record = sqlite_session.scalar(
-        select(AccountTrialAppRecord).where(
-            AccountTrialAppRecord.app_id == app_id,
-            AccountTrialAppRecord.account_id == account_id,
-        )
-    )
-    assert record is not None
-    assert record.count == 4
-
-
-def test_add_trial_app_record_creates_new_record(sqlite_session: Session) -> None:
-    app_id = str(uuid.uuid4())
-    account_id = str(uuid.uuid4())
-
-    RecommendedAppService.add_trial_app_record(app_id, account_id, session=sqlite_session)
-
-    sqlite_session.expire_all()
-    record = sqlite_session.scalar(
-        select(AccountTrialAppRecord).where(
-            AccountTrialAppRecord.app_id == app_id,
-            AccountTrialAppRecord.account_id == account_id,
-        )
-    )
-    assert record is not None
-    assert record.app_id == app_id
-    assert record.account_id == account_id
-    assert record.count == 1


### PR DESCRIPTION
## Summary

Part of #39993. This is PR 2 of the Recommended App refactor stack and is based on #40207.

Move Recommended Trial App usage writes out of `RecommendedAppService` and give them an independent transaction boundary:

- five Trial execution handlers pass only `app_id` and `account_id`;
- `TrialAppUsageRecorder` defines the minimal framework-neutral capability port;
- `TrialAppUsageRepository` implements the port and owns its Session and transaction;
- the composition root binds the repository without a one-line forwarding service;
- the legacy `RecommendedAppService.add_trial_app_record()` path is removed.

## Why this layer

The previous implementation accepted the controller's request Session and called `commit()`. That could commit unrelated pending work owned by the request. The new repository commits only the usage record; a regression test verifies that caller-session pending data is still rolled back independently.

## Intentional boundaries

- Existing select-then-increment concurrency behavior is preserved; this PR does not introduce atomic quota reservation.
- Usage is still recorded only after generation, ASR, or TTS succeeds.
- Existing HTTP error mapping and response contracts are unchanged.
- Preview admission and the remaining catalog providers stay in later stack layers.

## Verification

- 112 focused unit tests passed.
- Ruff check and formatting passed.
- Pyrefly reported 0 diagnostics for changed production paths.
- Import-linter kept all 10 contracts.
- Response-contract lint and the controller SQLAlchemy/getattr guards passed.

From Codex
