### PR TITLE
fix(web): make the member selector keyboard accessible

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -2822,12 +2822,6 @@
     }
   },
   "web/app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx": {
-    "jsx_a11y/click-events-have-key-events": {
-      "count": 1
-    },
-    "jsx_a11y/no-static-element-interactions": {
-      "count": 1
-    },
     "no-restricted-imports": {
       "count": 1
     }

--- a/web/app/components/header/account-setting/members-page/transfer-ownership-modal/__tests__/member-selector.spec.tsx
+++ b/web/app/components/header/account-setting/members-page/transfer-ownership-modal/__tests__/member-selector.spec.tsx
@@ -12,6 +12,16 @@ const mockAccounts = [
   { id: '3', name: 'Bob Wilson', email: 'bob@example.com', avatar_url: '' },
 ]
 
+const getTrigger = () =>
+  screen.getByRole('button', {
+    name: 'common.members.transferModal.transferPlaceholder',
+  })
+
+const getMemberButtons = () =>
+  screen.getAllByRole('button', {
+    name: /@example\.com/,
+  })
+
 describe('MemberSelector', () => {
   const mockOnSelect = vi.fn()
 
@@ -24,22 +34,25 @@ describe('MemberSelector', () => {
 
   it('should render placeholder when no value is selected', () => {
     render(<MemberSelector onSelect={mockOnSelect} />)
-    expect(screen.getByText(/members\.transferModal\.transferPlaceholder/i)).toBeInTheDocument()
+    expect(getTrigger()).toHaveAttribute('aria-expanded', 'false')
   })
 
   it('should render selected member info', () => {
     render(<MemberSelector value="1" onSelect={mockOnSelect} />)
-    expect(screen.getByText('John Doe')).toBeInTheDocument()
-    expect(screen.getByText('john@example.com')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', {
+        name: /John Doe.*john@example\.com/,
+      }),
+    ).toBeInTheDocument()
   })
 
   it('should open dropdown and show filtered list on click', async () => {
     const user = userEvent.setup()
     render(<MemberSelector onSelect={mockOnSelect} exclude={['1']} />)
 
-    await user.click(screen.getByTestId('member-selector-trigger'))
+    await user.click(getTrigger())
 
-    const items = screen.getAllByTestId('member-selector-item')
+    const items = getMemberButtons()
     expect(items).toHaveLength(2) // Jane and Bob (John excluded)
     expect(screen.queryByText('John Doe')).not.toBeInTheDocument()
     expect(screen.getByText('Jane Smith')).toBeInTheDocument()
@@ -49,10 +62,10 @@ describe('MemberSelector', () => {
     const user = userEvent.setup()
     render(<MemberSelector onSelect={mockOnSelect} />)
 
-    await user.click(screen.getByTestId('member-selector-trigger'))
+    await user.click(getTrigger())
     await user.type(screen.getByRole('textbox', { name: 'common.operation.search' }), 'Jane')
 
-    const items = screen.getAllByTestId('member-selector-item')
+    const items = getMemberButtons()
     expect(items).toHaveLength(1)
     expect(screen.getByText('Jane Smith')).toBeInTheDocument()
     expect(screen.queryByText('Bob Wilson')).not.toBeInTheDocument()
@@ -62,8 +75,8 @@ describe('MemberSelector', () => {
     const user = userEvent.setup()
     render(<MemberSelector onSelect={mockOnSelect} />)
 
-    await user.click(screen.getByTestId('member-selector-trigger'))
-    await user.click(screen.getByText('Jane Smith'))
+    await user.click(getTrigger())
+    await user.click(screen.getByRole('button', { name: /Jane Smith.*jane@example\.com/ }))
 
     expect(mockOnSelect).toHaveBeenCalledWith('2')
     await waitFor(() => {
@@ -77,10 +90,10 @@ describe('MemberSelector', () => {
     const user = userEvent.setup()
     render(<MemberSelector onSelect={mockOnSelect} />)
 
-    await user.click(screen.getByTestId('member-selector-trigger'))
+    await user.click(getTrigger())
     await user.type(screen.getByRole('textbox', { name: 'common.operation.search' }), 'john@')
 
-    const items = screen.getAllByTestId('member-selector-item')
+    const items = getMemberButtons()
     expect(items).toHaveLength(1)
     expect(screen.getByText('John Doe')).toBeInTheDocument()
     expect(screen.queryByText('Jane Smith')).not.toBeInTheDocument()
@@ -89,7 +102,7 @@ describe('MemberSelector', () => {
   it('should show placeholder when value does not match any account', () => {
     render(<MemberSelector value="nonexistent-id" onSelect={mockOnSelect} />)
 
-    expect(screen.getByText(/members\.transferModal\.transferPlaceholder/i)).toBeInTheDocument()
+    expect(getTrigger()).toBeInTheDocument()
   })
 
   it('should handle missing data gracefully', () => {
@@ -97,7 +110,7 @@ describe('MemberSelector', () => {
       typeof useMembers
     >)
     render(<MemberSelector onSelect={mockOnSelect} />)
-    expect(screen.getByText(/members\.transferModal\.transferPlaceholder/i)).toBeInTheDocument()
+    expect(getTrigger()).toBeInTheDocument()
   })
 
   it('should filter by email when account name is empty', async () => {
@@ -112,34 +125,35 @@ describe('MemberSelector', () => {
     } as unknown as ReturnType<typeof useMembers>)
     render(<MemberSelector onSelect={mockOnSelect} />)
 
-    await user.click(screen.getByTestId('member-selector-trigger'))
+    await user.click(getTrigger())
     await user.type(screen.getByRole('textbox', { name: 'common.operation.search' }), 'noname@')
 
-    const items = screen.getAllByTestId('member-selector-item')
+    const items = getMemberButtons()
     expect(items).toHaveLength(1)
   })
 
-  it('should apply hover background class when dropdown is open', async () => {
+  it('should expose the expanded state while the dropdown is open', async () => {
     const user = userEvent.setup()
     render(<MemberSelector onSelect={mockOnSelect} />)
 
-    const trigger = screen.getByTestId('member-selector-trigger')
+    const trigger = getTrigger()
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
     await user.click(trigger)
 
-    expect(trigger).toHaveAttribute('data-popup-open')
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
   })
 
   it('should not match account when neither name nor email contains search value', async () => {
     const user = userEvent.setup()
     render(<MemberSelector onSelect={mockOnSelect} />)
 
-    await user.click(screen.getByTestId('member-selector-trigger'))
+    await user.click(getTrigger())
     await user.type(
       screen.getByRole('textbox', { name: 'common.operation.search' }),
       'xyz-no-match-xyz',
     )
 
-    expect(screen.queryByTestId('member-selector-item')).not.toBeInTheDocument()
+    expect(screen.queryAllByRole('button', { name: /@example\.com/ })).toHaveLength(0)
   })
 
   it('should fall back to empty string for account with undefined email when searching', async () => {
@@ -153,10 +167,42 @@ describe('MemberSelector', () => {
     } as unknown as ReturnType<typeof useMembers>)
     render(<MemberSelector onSelect={mockOnSelect} />)
 
-    await user.click(screen.getByTestId('member-selector-trigger'))
+    await user.click(getTrigger())
     await user.type(screen.getByRole('textbox', { name: 'common.operation.search' }), 'john')
 
-    const items = screen.getAllByTestId('member-selector-item')
-    expect(items).toHaveLength(1)
+    expect(screen.getByRole('button', { name: /John/ })).toBeInTheDocument()
+  })
+
+  it.each([
+    ['Enter', '{Enter}'],
+    ['Space', ' '],
+  ])('should open the dropdown with the %s key', async (_, key) => {
+    const user = userEvent.setup()
+    render(<MemberSelector onSelect={mockOnSelect} />)
+
+    const trigger = getTrigger()
+    trigger.focus()
+    await user.keyboard(key)
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    expect(getMemberButtons()).toHaveLength(3)
+  })
+
+  it.each([
+    ['Enter', '{Enter}'],
+    ['Space', ' '],
+  ])('should select a member with the %s key', async (_, key) => {
+    const user = userEvent.setup()
+    render(<MemberSelector onSelect={mockOnSelect} />)
+
+    await user.click(getTrigger())
+    const jane = screen.getByRole('button', { name: /Jane Smith.*jane@example\.com/ })
+    jane.focus()
+    await user.keyboard(key)
+
+    expect(mockOnSelect).toHaveBeenCalledWith('2')
+    expect(
+      screen.queryByRole('textbox', { name: 'common.operation.search' }),
+    ).not.toBeInTheDocument()
   })
 })

--- a/web/app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx
+++ b/web/app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx
@@ -46,28 +46,33 @@ const MemberSelector: FC<Props> = ({ value, onSelect, exclude = [] }) => {
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger
         render={
-          <div
-            data-testid="member-selector-trigger"
-            className="group flex cursor-pointer items-center gap-1.5 rounded-lg bg-components-input-bg-normal px-2 py-1 hover:bg-state-base-hover-alt data-popup-open:bg-state-base-hover-alt"
-          >
-            {!currentValue && (
-              <div className="grow p-1 system-sm-regular text-components-input-text-placeholder">
-                {t(($) => $['members.transferModal.transferPlaceholder'], { ns: 'common' })}
-              </div>
-            )}
-            {currentValue && (
-              <>
-                <Avatar avatar={currentValue.avatar_url} size="sm" name={currentValue.name} />
-                <div className="grow truncate system-sm-medium text-text-secondary">
-                  {currentValue.name}
-                </div>
-                <div className="system-xs-regular text-text-quaternary">{currentValue.email}</div>
-              </>
-            )}
-            <div className="i-ri-arrow-down-s-line size-4 text-text-quaternary group-hover:text-text-secondary group-data-popup-open:text-text-secondary" />
-          </div>
+          <button
+            type="button"
+            className="group flex cursor-pointer items-center gap-1.5 rounded-lg bg-components-input-bg-normal px-2 py-1 text-start outline-hidden hover:bg-state-base-hover-alt focus-visible:ring-2 focus-visible:ring-state-accent-solid data-popup-open:bg-state-base-hover-alt"
+          />
         }
-      />
+      >
+        {!currentValue && (
+          <span className="grow p-1 system-sm-regular text-components-input-text-placeholder">
+            {t(($) => $['members.transferModal.transferPlaceholder'], { ns: 'common' })}
+          </span>
+        )}
+        {currentValue && (
+          <>
+            <span aria-hidden>
+              <Avatar avatar={currentValue.avatar_url} size="sm" name={currentValue.name} />
+            </span>
+            <span className="grow truncate system-sm-medium text-text-secondary">
+              {currentValue.name}
+            </span>
+            <span className="system-xs-regular text-text-quaternary">{currentValue.email}</span>
+          </>
+        )}
+        <span
+          aria-hidden
+          className="i-ri-arrow-down-s-line size-4 text-text-quaternary group-hover:text-text-secondary group-data-popup-open:text-text-secondary"
+        />
+      </PopoverTrigger>
       <PopoverContent
         placement="bottom"
         sideOffset={4}
@@ -84,21 +89,23 @@ const MemberSelector: FC<Props> = ({ value, onSelect, exclude = [] }) => {
           </div>
           <div className="p-1">
             {filteredList.map((account) => (
-              <div
+              <button
+                type="button"
                 key={account.id}
-                data-testid="member-selector-item"
-                className="flex cursor-pointer items-center gap-2 rounded-lg py-1 pr-3 pl-2 hover:bg-state-base-hover"
+                className="flex w-full cursor-pointer items-center gap-2 rounded-lg py-1 pr-3 pl-2 text-start outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid"
                 onClick={() => {
                   onSelect(account.id)
                   setOpen(false)
                 }}
               >
-                <Avatar avatar={account.avatar_url} size="sm" name={account.name} />
-                <div className="grow truncate system-sm-medium text-text-secondary">
+                <span aria-hidden>
+                  <Avatar avatar={account.avatar_url} size="sm" name={account.name} />
+                </span>
+                <span className="grow truncate system-sm-medium text-text-secondary">
                   {account.name}
-                </div>
-                <div className="system-xs-regular text-text-quaternary">{account.email}</div>
-              </div>
+                </span>
+                <span className="system-xs-regular text-text-quaternary">{account.email}</span>
+              </button>
             ))}
           </div>
         </div>

--- a/web/app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx
+++ b/web/app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx
@@ -48,7 +48,7 @@ const MemberSelector: FC<Props> = ({ value, onSelect, exclude = [] }) => {
         render={
           <button
             type="button"
-            className="group flex cursor-pointer items-center gap-1.5 rounded-lg bg-components-input-bg-normal px-2 py-1 text-start outline-hidden hover:bg-state-base-hover-alt focus-visible:ring-2 focus-visible:ring-state-accent-solid data-popup-open:bg-state-base-hover-alt"
+            className="group flex cursor-pointer appearance-none items-center gap-1.5 rounded-lg bg-components-input-bg-normal px-2 py-1 text-start outline-hidden hover:bg-state-base-hover-alt focus-visible:ring-2 focus-visible:ring-state-accent-solid data-popup-open:bg-state-base-hover-alt"
           />
         }
       >
@@ -92,7 +92,7 @@ const MemberSelector: FC<Props> = ({ value, onSelect, exclude = [] }) => {
               <button
                 type="button"
                 key={account.id}
-                className="flex w-full cursor-pointer items-center gap-2 rounded-lg py-1 pr-3 pl-2 text-start outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid"
+                className="flex w-full cursor-pointer appearance-none items-center gap-2 rounded-lg py-1 pr-3 pl-2 text-start outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid"
                 onClick={() => {
                   onSelect(account.id)
                   setOpen(false)


### PR DESCRIPTION
## Summary

Make the transfer-ownership MemberSelector's popover trigger and member choices native buttons with user-facing names, expanded state, and keyboard behavior.

This is the semantic layer above #40206. The declaration cleanup stays separate so this diff contains only DOM, behavior tests, and matching suppression removal.

## Behavior contract

- The closed trigger is a named button with `aria-haspopup="dialog"` and `aria-expanded="false"`.
- Pointer click, Enter, and Space open the same Base UI Popover.
- Each visible member is a named button; pointer click, Enter, and Space select the same member and close the popup.
- The trigger exposes the selected member name and email when a value exists.
- Search and exclusion behavior remain unchanged.
- Decorative avatars and arrows do not duplicate the button names.

## Scope

- Follow the Dify UI/Base UI documented trigger contract by rendering a real `button type="button"` through `PopoverTrigger.render`.
- Replace clickable member `div` elements with `button type="button"`.
- Replace invalid `div` descendants inside buttons with phrasing-content `span` elements.
- Explicitly preserve left text alignment and full-width member rows.
- Add only the project-standard keyboard `focus-visible` ring.
- Remove trigger/item test ids and migrate tests to role, name, expanded state, click, Enter, Space, filtering, and selection outcomes.
- Remove exactly the two resolved jsx-a11y suppressions.

## Non-goals

- No search-field or Dify UI Input migration. The remaining `no-restricted-imports` suppression identifies the deprecated legacy Input and is reserved for a separate form-boundary layer.
- No member-query or transfer workflow change.
- No listbox/combobox abstraction; this remains a searchable popover dialog containing explicit member action buttons.
- No shared Popover or Avatar change.

## Verification

- Red/green regression: all 16 semantic tests failed before the production change because no button role existed; Base UI also emitted its native-button contract warning. After the change, all 16 pass and the warning is gone.
- `cd web && pnpm exec vp test run app/components/header/account-setting/members-page/transfer-ownership-modal/__tests__/member-selector.spec.tsx` — 1 file, 16 tests passed.
- `cd web && pnpm lint:a11y app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx` — passed.
- `cd web && pnpm exec vp fmt app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx app/components/header/account-setting/members-page/transfer-ownership-modal/__tests__/member-selector.spec.tsx --check` — passed.
- `pnpm lint:oxlint --prune-suppressions` — passed; only the two resolved jsx-a11y diagnostics were removed and the deprecated Input diagnostic remains.
- `git diff --check` — passed.

## Visual regression review

The trigger keeps its complete existing flex, gap, radius, background, padding, hover, and popup-open classes. `text-start` explicitly prevents the native button default from centering the placeholder or selected member text. Member rows keep their flex/gap/radius/padding/hover classes; `w-full` matches the old block-level row width and `text-start` preserves name/email alignment. Repository preflight removes native border, background, margin, and padding defaults before utilities apply. The only intended visual delta is the keyboard focus ring.

Reviewer checks:

- Compare placeholder and selected-member alignment, trigger height, padding, and arrow position.
- Compare every member row's full width, avatar/name/email spacing, and left alignment.
- Confirm there is no native border or extra background in pointer-only states.
- Confirm focus rings appear only for keyboard focus.

## Rollback

Revert this PR only. #40206 is declaration-only and can remain independently.

- [x] Added behavior-focused semantic tests for pointer and keyboard paths.
- [x] Kept the form Input migration out of this PR.
- [x] No documentation update is required.

From Codex

## Final visual guard

The converted native button now also uses `appearance-none`, closing the remaining cross-browser UA appearance path while preserving the existing normal-state geometry and tokens.