### PR TITLE
refactor(web): migrate the member search input

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -2821,11 +2821,6 @@
       "count": 2
     }
   },
-  "web/app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/components/header/account-setting/model-provider-page/declarations.ts": {
     "erasable-syntax-only/enums": {
       "count": 11

--- a/web/app/components/header/account-setting/members-page/transfer-ownership-modal/__tests__/member-selector.spec.tsx
+++ b/web/app/components/header/account-setting/members-page/transfer-ownership-modal/__tests__/member-selector.spec.tsx
@@ -63,7 +63,11 @@ describe('MemberSelector', () => {
     render(<MemberSelector onSelect={mockOnSelect} />)
 
     await user.click(getTrigger())
-    await user.type(screen.getByRole('textbox', { name: 'common.operation.search' }), 'Jane')
+    const searchInput = screen.getByRole('searchbox', { name: 'common.operation.search' })
+    expect(searchInput).toHaveAttribute('name', 'query')
+    expect(searchInput).toHaveAttribute('autocomplete', 'off')
+    expect(searchInput).toHaveAttribute('enterkeyhint', 'search')
+    await user.type(searchInput, 'Jane')
 
     const items = getMemberButtons()
     expect(items).toHaveLength(1)
@@ -81,7 +85,7 @@ describe('MemberSelector', () => {
     expect(mockOnSelect).toHaveBeenCalledWith('2')
     await waitFor(() => {
       expect(
-        screen.queryByRole('textbox', { name: 'common.operation.search' }),
+        screen.queryByRole('searchbox', { name: 'common.operation.search' }),
       ).not.toBeInTheDocument()
     })
   })
@@ -91,7 +95,7 @@ describe('MemberSelector', () => {
     render(<MemberSelector onSelect={mockOnSelect} />)
 
     await user.click(getTrigger())
-    await user.type(screen.getByRole('textbox', { name: 'common.operation.search' }), 'john@')
+    await user.type(screen.getByRole('searchbox', { name: 'common.operation.search' }), 'john@')
 
     const items = getMemberButtons()
     expect(items).toHaveLength(1)
@@ -126,7 +130,7 @@ describe('MemberSelector', () => {
     render(<MemberSelector onSelect={mockOnSelect} />)
 
     await user.click(getTrigger())
-    await user.type(screen.getByRole('textbox', { name: 'common.operation.search' }), 'noname@')
+    await user.type(screen.getByRole('searchbox', { name: 'common.operation.search' }), 'noname@')
 
     const items = getMemberButtons()
     expect(items).toHaveLength(1)
@@ -149,7 +153,7 @@ describe('MemberSelector', () => {
 
     await user.click(getTrigger())
     await user.type(
-      screen.getByRole('textbox', { name: 'common.operation.search' }),
+      screen.getByRole('searchbox', { name: 'common.operation.search' }),
       'xyz-no-match-xyz',
     )
 
@@ -168,7 +172,7 @@ describe('MemberSelector', () => {
     render(<MemberSelector onSelect={mockOnSelect} />)
 
     await user.click(getTrigger())
-    await user.type(screen.getByRole('textbox', { name: 'common.operation.search' }), 'john')
+    await user.type(screen.getByRole('searchbox', { name: 'common.operation.search' }), 'john')
 
     expect(screen.getByRole('button', { name: /John/ })).toBeInTheDocument()
   })
@@ -202,7 +206,7 @@ describe('MemberSelector', () => {
 
     expect(mockOnSelect).toHaveBeenCalledWith('2')
     expect(
-      screen.queryByRole('textbox', { name: 'common.operation.search' }),
+      screen.queryByRole('searchbox', { name: 'common.operation.search' }),
     ).not.toBeInTheDocument()
   })
 })

--- a/web/app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx
+++ b/web/app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx
@@ -1,9 +1,9 @@
 'use client'
 import { Avatar } from '@langgenius/dify-ui/avatar'
+import { Input } from '@langgenius/dify-ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@langgenius/dify-ui/popover'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import { useMembers } from '@/service/use-common'
 
 type Props = Readonly<{
@@ -78,12 +78,22 @@ function MemberSelector({ value, onSelect, exclude = [] }: Props) {
       >
         <div className="min-w-93 rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-bg-blur shadow-lg backdrop-blur-xs">
           <div className="p-2 pb-1">
-            <Input
-              showLeftIcon
-              aria-label={t(($) => $['operation.search'], { ns: 'common' })}
-              value={searchValue}
-              onChange={(e) => setSearchValue(e.target.value)}
-            />
+            <div className="relative w-full">
+              <span
+                aria-hidden
+                className="pointer-events-none absolute top-1/2 left-2 i-ri-search-line size-4 -translate-y-1/2 text-components-input-text-placeholder"
+              />
+              <Input
+                type="search"
+                name="query"
+                autoComplete="off"
+                enterKeyHint="search"
+                aria-label={t(($) => $['operation.search'], { ns: 'common' })}
+                className="pl-6.5 [&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none"
+                value={searchValue}
+                onValueChange={setSearchValue}
+              />
+            </div>
           </div>
           <div className="p-1">
             {filteredList.map((account) => (


### PR DESCRIPTION
## Summary

- replace the deprecated legacy Input with the Dify UI Input primitive
- keep the search icon composition local to MemberSelector so the existing 26px leading inset and no-clear behavior stay unchanged
- expose the control as a named searchbox and migrate behavior tests to semantic queries
- prune the remaining MemberSelector lint suppression

## Behavior contract

The member filter remains a controlled, non-submitting search control. It is exposed as a searchbox named Search, uses query as its form-field name, disables autocomplete, and requests a search enter key on supporting virtual keyboards.

## Scope

- Account Settings transfer-ownership MemberSelector only
- Dify UI Input dependency migration
- search semantics and focused tests
- one obsolete no-restricted-imports suppression

## Non-goals

- no shared SearchInput migration; that component changes the leading inset and adds a clear action
- no transfer workflow or filtering behavior changes
- no form-wide Field migration
- no unrelated legacy Input cleanup

## Verification

- pnpm exec vp test run app/components/header/account-setting/members-page/transfer-ownership-modal/__tests__/member-selector.spec.tsx (16/16)
- pnpm exec vp check app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx app/components/header/account-setting/members-page/transfer-ownership-modal/__tests__/member-selector.spec.tsx
- node scripts/lint-a11y.mjs app/components/header/account-setting/members-page/transfer-ownership-modal/member-selector.tsx
- pnpm lint:oxlint --prune-suppressions; suppression diff removes only this file's no-restricted-imports entry
- git diff --check

## Visual regression review

- same 16px search icon and left-2 absolute position
- same 26px leading input padding
- same medium size, typography, radius, colors, and hover/focus tokens
- browser search decoration and cancel control are explicitly hidden
- no layout or visible-content change is intended

## Rollback

Revert this PR independently to restore the legacy Input import and its suppression. The parent PRs remain valid.

## Stack

Depends on #40209, which depends on #40206. This layer is intentionally limited to the search input migration.
