### PR TITLE
refactor(web): simplify the scroll-to-node action

### DIFF
--- a/web/app/components/workflow/header/scroll-to-selected-node-button.tsx
+++ b/web/app/components/workflow/header/scroll-to-selected-node-button.tsx
@@ -1,11 +1,10 @@
-import type { FC } from 'react'
 import type { CommonNodeType } from '../types'
 import { cn } from '@langgenius/dify-ui/cn'
 import { useTranslation } from 'react-i18next'
 import { useNodes } from 'reactflow'
 import { scrollToWorkflowNode } from '../utils/node-navigation'
 
-const ScrollToSelectedNodeButton: FC = () => {
+const ScrollToSelectedNodeButton = () => {
   const { t } = useTranslation()
   const nodes = useNodes<CommonNodeType>()
   const selectedNode = nodes.find((node) => node.data.selected)


### PR DESCRIPTION
## Summary

- remove the React.FC annotation from ScrollToSelectedNodeButton
- keep the rendered DOM, event handling, styles, tests, and lint suppressions unchanged

## Contract

This is a type-only cleanup. It must not change whether the action renders, how the selected node is found, or how clicking scrolls the canvas.

## Scope

- one Workflow Header component
- one import removal and one declaration simplification

## Non-goals

- no accessibility claim in this layer
- no DOM or styling change
- no suppression cleanup
- no adjacent workflow header refactor

## Verification

- pnpm exec vp test run app/components/workflow/header/__tests__/scroll-to-selected-node-button.spec.tsx (2/2)
- pnpm exec vp fmt --write app/components/workflow/header/scroll-to-selected-node-button.tsx
- git diff --check

## Visual regression review

The JSX and class list are byte-for-byte unchanged, so no visual change is intended.

## Rollback

Revert this PR independently to restore the React.FC annotation.

## Stack

This is the dependency-free cleanup layer. The following layer will replace the existing clickable div with a native button and remove its two accessibility suppressions.
