### PR TITLE
fix(web): make the scroll-to-node action a button

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -3760,14 +3760,6 @@
       "count": 2
     }
   },
-  "web/app/components/workflow/header/scroll-to-selected-node-button.tsx": {
-    "jsx_a11y/click-events-have-key-events": {
-      "count": 1
-    },
-    "jsx_a11y/no-static-element-interactions": {
-      "count": 1
-    }
-  },
   "web/app/components/workflow/header/test-run-menu.tsx": {
     "erasable-syntax-only/enums": {
       "count": 1

--- a/web/app/components/workflow/header/__tests__/scroll-to-selected-node-button.spec.tsx
+++ b/web/app/components/workflow/header/__tests__/scroll-to-selected-node-button.spec.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { createNode } from '../../__tests__/fixtures'
 import { resetReactFlowMockState, rfState } from '../../__tests__/reactflow-mock-state'
 import ScrollToSelectedNodeButton from '../scroll-to-selected-node-button'
@@ -32,7 +33,8 @@ describe('ScrollToSelectedNodeButton', () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it('should render the action and scroll to the selected node when clicked', () => {
+  it('should render a button and scroll to the selected node when clicked', async () => {
+    const user = userEvent.setup()
     rfState.nodes = [
       createNode({
         id: 'node-1',
@@ -46,9 +48,36 @@ describe('ScrollToSelectedNodeButton', () => {
 
     render(<ScrollToSelectedNodeButton />)
 
-    fireEvent.click(screen.getByText('workflow.panel.scrollToSelectedNode'))
+    const button = screen.getByRole('button', {
+      name: 'workflow.panel.scrollToSelectedNode',
+    })
+    expect(button).toHaveAttribute('type', 'button')
+
+    await user.click(button)
 
     expect(mockScrollToWorkflowNode).toHaveBeenCalledWith('node-2')
     expect(mockScrollToWorkflowNode).toHaveBeenCalledTimes(1)
+  })
+
+  it('should support native keyboard activation', async () => {
+    const user = userEvent.setup()
+    rfState.nodes = [
+      createNode({
+        id: 'node-2',
+        data: { selected: true },
+      }),
+    ]
+
+    render(<ScrollToSelectedNodeButton />)
+
+    const button = screen.getByRole('button', {
+      name: 'workflow.panel.scrollToSelectedNode',
+    })
+    button.focus()
+    await user.keyboard('{Enter}')
+    await user.keyboard(' ')
+
+    expect(mockScrollToWorkflowNode).toHaveBeenNthCalledWith(1, 'node-2')
+    expect(mockScrollToWorkflowNode).toHaveBeenNthCalledWith(2, 'node-2')
   })
 })

--- a/web/app/components/workflow/header/scroll-to-selected-node-button.tsx
+++ b/web/app/components/workflow/header/scroll-to-selected-node-button.tsx
@@ -13,14 +13,15 @@ const ScrollToSelectedNodeButton: FC = () => {
   if (!selectedNode) return null
 
   return (
-    <div
+    <button
+      type="button"
       className={cn(
-        'flex h-6 cursor-pointer items-center justify-center rounded-md border-[0.5px] border-effects-highlight bg-components-actionbar-bg px-3 system-xs-medium whitespace-nowrap text-text-tertiary shadow-lg backdrop-blur-xs transition-colors duration-200 hover:text-text-accent',
+        'flex h-6 cursor-pointer items-center justify-center rounded-md border-[0.5px] border-effects-highlight bg-components-actionbar-bg px-3 system-xs-medium whitespace-nowrap text-text-tertiary shadow-lg backdrop-blur-xs transition-colors duration-200 hover:text-text-accent focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden',
       )}
       onClick={() => scrollToWorkflowNode(selectedNode.id)}
     >
       {t(($) => $['panel.scrollToSelectedNode'], { ns: 'workflow' })}
-    </div>
+    </button>
   )
 }
 

--- a/web/app/components/workflow/header/scroll-to-selected-node-button.tsx
+++ b/web/app/components/workflow/header/scroll-to-selected-node-button.tsx
@@ -16,7 +16,7 @@ const ScrollToSelectedNodeButton: FC = () => {
     <button
       type="button"
       className={cn(
-        'flex h-6 cursor-pointer items-center justify-center rounded-md border-[0.5px] border-effects-highlight bg-components-actionbar-bg px-3 system-xs-medium whitespace-nowrap text-text-tertiary shadow-lg backdrop-blur-xs transition-colors duration-200 hover:text-text-accent focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden',
+        'flex h-6 cursor-pointer appearance-none items-center justify-center rounded-md border-[0.5px] border-effects-highlight bg-components-actionbar-bg px-3 system-xs-medium whitespace-nowrap text-text-tertiary shadow-lg backdrop-blur-xs transition-colors duration-200 hover:text-text-accent focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden',
       )}
       onClick={() => scrollToWorkflowNode(selectedNode.id)}
     >


### PR DESCRIPTION
## Summary

- replace the Workflow Header scroll-to-selected-node container with a native type=button
- verify role, name, click, Enter, and Space behavior
- remove the two matching suppressions

## Review boundary

Node selection, scroll ownership, conditional rendering, text, and adjacent header actions are unchanged.

## Visual regression review

The existing 24px height, flex alignment, padding, border, radius, background, shadow, typography, and hover classes remain. The only intended new state is the keyboard focus-visible ring.

## Verification

- owner suite: 3/3 passed
- standalone a11y lint: 0 diagnostics
- suppression delta: -2
- diff check: passed

## Dependency and rollback

Independent root layer based on main; the former type-only prerequisite is closed.

## Final visual guard

The converted native button now also uses `appearance-none`, closing the remaining cross-browser UA appearance path while preserving the existing normal-state geometry and tokens.