### PR TITLE
refactor(web): simplify the dataset menu item

### DIFF
--- a/web/app/components/app-sidebar/dataset-info/menu-item.tsx
+++ b/web/app/components/app-sidebar/dataset-info/menu-item.tsx
@@ -1,5 +1,5 @@
 import type { RemixiconComponentType } from '@remixicon/react'
-import * as React from 'react'
+import { memo } from 'react'
 
 type MenuItemProps = {
   name: string
@@ -23,4 +23,4 @@ const MenuItem = ({ Icon, name, handleClick }: MenuItemProps) => {
   )
 }
 
-export default React.memo(MenuItem)
+export default memo(MenuItem)


### PR DESCRIPTION
## Summary

- replace the React namespace import with a named memo import in DatasetInfo MenuItem
- keep the rendered DOM, click handling, styles, tests, and lint suppressions unchanged

## Contract

This is an import-only cleanup. MenuItem rendering and behavior must remain identical.

## Scope

- Dataset Sidebar MenuItem only
- two equivalent import/export lines

## Non-goals

- no accessibility claim in this layer
- no DOM, event, or visual change
- no suppression cleanup
- no adjacent DatasetInfo components

## Verification

- pnpm exec vp test run app/components/app-sidebar/dataset-info/__tests__/index.spec.tsx (20/20)
- pnpm exec vp fmt --write app/components/app-sidebar/dataset-info/menu-item.tsx
- git diff --check

## Visual regression review

The JSX and class list are unchanged, so no visual change is intended.

## Rollback

Revert this PR independently to restore the React namespace import.

## Stack

This is the dependency-free cleanup layer. The following layer will make MenuItem a native button and remove its two accessibility suppressions.
