### PR TITLE
fix(web): make dataset menu items buttons

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -202,14 +202,6 @@
       "count": 4
     }
   },
-  "web/app/components/app-sidebar/dataset-info/menu-item.tsx": {
-    "jsx_a11y/click-events-have-key-events": {
-      "count": 1
-    },
-    "jsx_a11y/no-static-element-interactions": {
-      "count": 1
-    }
-  },
   "web/app/components/app/annotation/add-annotation-modal/edit-item/index.tsx": {
     "erasable-syntax-only/enums": {
       "count": 1

--- a/web/app/components/app-sidebar/dataset-info/__tests__/index.spec.tsx
+++ b/web/app/components/app-sidebar/dataset-info/__tests__/index.spec.tsx
@@ -236,37 +236,48 @@ describe('MenuItem', () => {
     it('should call handler when clicked', async () => {
       const user = userEvent.setup()
       const handleClick = vi.fn()
-      // Arrange
       render(<MenuItem name="Edit" Icon={TestEditIcon} handleClick={handleClick} />)
 
-      // Act
-      await user.click(screen.getByText('Edit'))
+      const menuItem = screen.getByRole('button', { name: 'Edit' })
+      expect(menuItem).toHaveAttribute('type', 'button')
+      await user.click(menuItem)
 
-      // Assert
       expect(handleClick).toHaveBeenCalledTimes(1)
     })
 
+    it('should support native keyboard activation', async () => {
+      const user = userEvent.setup()
+      const handleClick = vi.fn()
+      render(<MenuItem name="Edit" Icon={TestEditIcon} handleClick={handleClick} />)
+
+      const menuItem = screen.getByRole('button', { name: 'Edit' })
+      menuItem.focus()
+      await user.keyboard('{Enter}')
+      await user.keyboard(' ')
+
+      expect(handleClick).toHaveBeenCalledTimes(2)
+    })
+
     it('should stop propagation before invoking the handler', () => {
-      const parentClick = vi.fn()
       const handleClick = vi.fn()
 
-      render(
-        <div role="button" tabIndex={0} onClick={parentClick} onKeyDown={parentClick}>
-          <MenuItem name="Edit" Icon={TestEditIcon} handleClick={handleClick} />
-        </div>,
-      )
+      render(<MenuItem name="Edit" Icon={TestEditIcon} handleClick={handleClick} />)
+      const menuItem = screen.getByRole('button', { name: 'Edit' })
+      const event = createEvent.click(menuItem)
+      const stopPropagation = vi.spyOn(event, 'stopPropagation')
 
-      fireEvent.click(screen.getByText('Edit'))
+      fireEvent(menuItem, event)
 
       expect(handleClick).toHaveBeenCalledTimes(1)
-      expect(parentClick).not.toHaveBeenCalled()
+      expect(stopPropagation).toHaveBeenCalledTimes(1)
     })
 
     it('should prevent the default action when no click handler is provided', () => {
       render(<MenuItem name="Edit" Icon={TestEditIcon} />)
 
-      const event = createEvent.click(screen.getByText('Edit'))
-      fireEvent(screen.getByText('Edit'), event)
+      const menuItem = screen.getByRole('button', { name: 'Edit' })
+      const event = createEvent.click(menuItem)
+      fireEvent(menuItem, event)
 
       expect(event.defaultPrevented).toBe(true)
     })

--- a/web/app/components/app-sidebar/dataset-info/menu-item.tsx
+++ b/web/app/components/app-sidebar/dataset-info/menu-item.tsx
@@ -9,17 +9,18 @@ type MenuItemProps = {
 
 const MenuItem = ({ Icon, name, handleClick }: MenuItemProps) => {
   return (
-    <div
-      className="flex items-center gap-x-1 rounded-lg px-2 py-1.5 hover:bg-state-base-hover"
+    <button
+      type="button"
+      className="flex w-full items-center gap-x-1 rounded-lg px-2 py-1.5 text-left outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid"
       onClick={(e) => {
         e.preventDefault()
         e.stopPropagation()
         handleClick?.()
       }}
     >
-      <Icon className="size-4 text-text-tertiary" />
+      <Icon aria-hidden className="size-4 text-text-tertiary" />
       <span className="px-1 system-md-regular text-text-secondary">{name}</span>
-    </div>
+    </button>
   )
 }
 


### PR DESCRIPTION
## Summary

- replace Dataset Sidebar MenuItem clickable divs with native buttons
- preserve the stretched row layout, spacing, typography, and hover state
- keep visible menu text as the accessible name and hide decorative icons
- verify pointer, Enter, Space, preventDefault, and stopPropagation contracts
- remove the component's two obsolete accessibility suppressions

## Behavior contract

Each visible dataset menu action is a full-width button named by its translated text. Pointer click, Enter, and Space invoke the supplied action while preserving the existing preventDefault and stopPropagation behavior.

## Scope

- DatasetInfo MenuItem only
- its focused interaction tests in the existing DatasetInfo spec
- this component's click-events-have-key-events and no-static-element-interactions suppressions

## Non-goals

- no DropdownMenu ownership or open-state change
- no DatasetInfo permissions or action logic change
- no shared Button migration
- no adjacent menu or icon cleanup

## Verification

- red phase: four role-based MenuItem tests failed against the existing div while the other 17 DatasetInfo/Menu tests remained green
- pnpm exec vp test run app/components/app-sidebar/dataset-info/__tests__/index.spec.tsx (21/21)
- pnpm exec vp check app/components/app-sidebar/dataset-info/menu-item.tsx app/components/app-sidebar/dataset-info/__tests__/index.spec.tsx
- node scripts/lint-a11y.mjs app/components/app-sidebar/dataset-info/menu-item.tsx
- pnpm lint:oxlint --prune-suppressions; suppression diff removes only this component's two entries
- git diff --check

## Visual regression review

- original gap, padding, radius, typography, icon size/color, and hover background are retained
- w-full explicitly preserves the parent flex column's previous stretch behavior
- text-left locks the previous leading alignment
- project Preflight removes native button default border, background, margin, and padding
- the only intended visual addition is a non-layout-shifting keyboard focus ring

## Rollback

Revert this PR independently to restore the clickable div and its two suppressions. The parent import-only cleanup remains valid.

## Stack

Depends only on #40216. It is the behavior layer of stack #40218.
