### PR TITLE
test(web): query notion loading by status

### DIFF
--- a/web/app/components/base/notion-page-selector/__tests__/base.spec.tsx
+++ b/web/app/components/base/notion-page-selector/__tests__/base.spec.tsx
@@ -121,7 +121,7 @@ describe('NotionPageSelector Base', () => {
 
     render(<NotionPageSelector credentialList={mockCredentialList} onSelect={vi.fn()} />)
 
-    expect(screen.getByTestId('notion-page-selector-loading')).toBeInTheDocument()
+    expect(screen.getByRole('status', { name: 'appApi.loading' })).toBeInTheDocument()
   })
 
   it('should render connector and open settings when fetch fails', async () => {
@@ -334,7 +334,7 @@ describe('NotionPageSelector Base', () => {
       isError: false,
     } as unknown as ReturnType<typeof usePreImportNotionPages>)
     render(<NotionPageSelector credentialList={mockCredentialList} onSelect={vi.fn()} />)
-    expect(screen.getByTestId('notion-page-selector-loading')).toBeInTheDocument()
+    expect(screen.getByRole('status', { name: 'appApi.loading' })).toBeInTheDocument()
   })
 
   it('should handle credential with empty id', () => {

--- a/web/app/components/base/notion-page-selector/base.tsx
+++ b/web/app/components/base/notion-page-selector/base.tsx
@@ -194,10 +194,7 @@ const NotionPageSelector = ({
         </div>
         <div className="overflow-hidden rounded-b-xl">
           {isFetchingNotionPages ? (
-            <div
-              className="flex h-74 items-center justify-center"
-              data-testid="notion-page-selector-loading"
-            >
+            <div className="flex h-74 items-center justify-center">
               <Loading />
             </div>
           ) : (


### PR DESCRIPTION
## Summary

- remove the redundant Notion page loading data-testid
- query the shared Loading component through its existing status role and accessible name
- keep the loading layout and behavior unchanged

## Contract

When Notion pages are fetching, the selector exposes one status named appApi.loading. Tests depend on that public semantic contract instead of an owner-local DOM hook.

## Scope

- NotionPageSelector loading wrapper
- two focused loading assertions in its existing spec

## Non-goals

- no Loading component change
- no Notion fetching, credential, or selection behavior change
- no global data-testid cleanup
- no suppression change

## Verification

- pnpm exec vp test run app/components/base/notion-page-selector/__tests__/base.spec.tsx (17/17)
- pnpm exec vp check app/components/base/notion-page-selector/base.tsx app/components/base/notion-page-selector/__tests__/base.spec.tsx (0 errors; one pre-existing use-state warning)
- git diff --check

## Visual regression review

The loading wrapper element and its h-74 flex centering classes are unchanged. Removing data-testid has no visual or layout effect.

## Rollback

Revert this PR independently to restore the test hook and its two test queries.

## Stack

Independent one-layer stack based on main.
