### PR TITLE
test(web): rely on the plugin loading status

### DIFF
--- a/web/app/components/plugins/plugin-page/__tests__/plugins-panel.spec.tsx
+++ b/web/app/components/plugins/plugin-page/__tests__/plugins-panel.spec.tsx
@@ -312,10 +312,9 @@ describe('PluginsPanel', () => {
 
     render(<PluginsPanel />)
 
-    const loadingState = screen.getByRole('status')
+    const loadingState = screen.getByRole('status', { name: 'common.loading' })
 
     expect(loadingState).toHaveClass('px-12')
-    expect(screen.getAllByTestId('plugin-card-skeleton')).toHaveLength(6)
   })
 
   it('uses compact skeleton spacing while an integrations plugin category is pending', () => {
@@ -329,10 +328,9 @@ describe('PluginsPanel', () => {
 
     render(<PluginsPanel contentInset="compact" fixedCategory={PluginCategoryEnum.tool} />)
 
-    const loadingState = screen.getByRole('status')
+    const loadingState = screen.getByRole('status', { name: 'common.loading' })
 
     expect(loadingState).toHaveClass('px-6', 'max-w-[1600px]')
-    expect(screen.getAllByTestId('plugin-card-skeleton')).toHaveLength(6)
   })
 
   it('uses default content inset for the standalone plugins page', () => {

--- a/web/app/components/plugins/plugin-page/plugin-list-skeleton.tsx
+++ b/web/app/components/plugins/plugin-page/plugin-list-skeleton.tsx
@@ -4,10 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { SkeletonContainer, SkeletonPoint, SkeletonRectangle } from '@/app/components/base/skeleton'
 
 const PluginCardSkeleton = () => (
-  <div
-    data-testid="plugin-card-skeleton"
-    className="relative overflow-hidden rounded-xl border-[1.5px] border-background-section-burn bg-background-section-burn p-1"
-  >
+  <div className="relative overflow-hidden rounded-xl border-[1.5px] border-background-section-burn bg-background-section-burn p-1">
     <div className="relative rounded-xl border-[0.5px] border-components-panel-border bg-components-panel-on-panel-item-bg p-4 pb-3 shadow-xs">
       <div className="flex">
         <SkeletonRectangle className="size-10 shrink-0 animate-pulse rounded-xl" />


### PR DESCRIPTION
## Summary

- remove per-card data-testid attributes from the plugin list skeleton
- stop asserting the internal six-card placeholder count
- query the existing loading status through its common.loading accessible name
- keep skeleton rendering and spacing unchanged

## Contract

While installed plugins are loading, PluginsPanel exposes one named status. The focused tests continue to protect default and compact spacing without depending on the number or markup of internal visual placeholders.

## Scope

- PluginListSkeleton child test hooks
- two loading-spacing assertions in PluginsPanel tests

## Non-goals

- no skeleton count, layout, animation, or visual change
- no PluginsPanel loading policy change
- no global data-testid cleanup
- no suppression change

## Verification

- pnpm exec vp test run app/components/plugins/plugin-page/__tests__/plugins-panel.spec.tsx (34/34)
- pnpm exec vp check app/components/plugins/plugin-page/plugin-list-skeleton.tsx app/components/plugins/plugin-page/__tests__/plugins-panel.spec.tsx
- git diff --check

## Visual regression review

The six-card Array rendering and every class are unchanged. Only non-visual data-testid attributes and implementation-detail assertions are removed.

## Rollback

Revert this PR independently to restore the child test hooks and exact-count assertions.

## Stack

Independent one-layer stack based on main.
