### PR TITLE
test(web): query collaboration loading by status

### DIFF
--- a/web/app/components/workflow-app/components/__tests__/workflow-main.spec.tsx
+++ b/web/app/components/workflow-app/components/__tests__/workflow-main.spec.tsx
@@ -581,7 +581,7 @@ describe('WorkflowMain', () => {
 
     render(<WorkflowMain nodes={[]} edges={[]} viewport={{ x: 0, y: 0, zoom: 1 }} />)
 
-    expect(screen.queryByTestId('collaboration-graph-loading')).not.toBeInTheDocument()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
 
     act(() => collaborationListeners.graphReadyChange?.(false))
     expect(screen.getByRole('status')).toHaveTextContent('workflow.common.syncingData')

--- a/web/app/components/workflow-app/components/workflow-main.tsx
+++ b/web/app/components/workflow-app/components/workflow-main.tsx
@@ -534,10 +534,7 @@ const WorkflowMain = ({ nodes, edges, viewport }: WorkflowMainProps) => {
       </WorkflowWithInnerContext>
       {isCollaborationEnabled &&
         (collaborationGraphState.appId !== appId || !collaborationGraphState.isReady) && (
-          <div
-            data-testid="collaboration-graph-loading"
-            className="absolute inset-0 z-50 flex cursor-wait items-center justify-center"
-          >
+          <div className="absolute inset-0 z-50 flex cursor-wait items-center justify-center">
             <div
               role="status"
               aria-live="polite"


### PR DESCRIPTION
## Summary

- remove the redundant collaboration graph loading data-testid
- use the existing status role for the complete not-ready to syncing to ready transition test
- keep the overlay layout and collaboration state machine unchanged

## Contract

The collaboration loading status is absent while the graph is initially ready, appears with the syncing message when graph readiness becomes false, and disappears when readiness returns.

## Scope

- WorkflowMain collaboration loading overlay
- one existing state-transition assertion

## Non-goals

- no collaboration runtime or graph-ready logic change
- no overlay styling, spinner, live-region, or text change
- no global data-testid cleanup
- no suppression change

## Verification

- pnpm exec vp test run app/components/workflow-app/components/__tests__/workflow-main.spec.tsx (19/19)
- pnpm exec vp check app/components/workflow-app/components/workflow-main.tsx app/components/workflow-app/components/__tests__/workflow-main.spec.tsx
- git diff --check

## Visual regression review

The absolute overlay wrapper and all of its classes are unchanged. Removing data-testid has no visual or layout effect.

## Rollback

Revert this PR independently to restore the overlay test hook and initial query.

## Stack

Independent one-layer stack based on main.
