### PR TITLE
refactor(web): migrate webapp password fields to dify ui

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -138,11 +138,6 @@
       "count": 1
     }
   },
-  "web/app/(shareLayout)/webapp-signin/components/mail-and-password-auth.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/(shareLayout)/webapp-signin/normalForm.tsx": {
     "jsx_a11y/click-events-have-key-events": {
       "count": 2

--- a/web/app/(shareLayout)/webapp-signin/components/__tests__/mail-and-password-auth.spec.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/__tests__/mail-and-password-auth.spec.tsx
@@ -73,4 +73,14 @@ describe('MailAndPasswordAuth', () => {
       expect(webAppLoginMock).toHaveBeenCalledTimes(1)
     })
   })
+
+  it('keeps the password field name separate from the recovery link', () => {
+    render(<MailAndPasswordAuth isEmailSetup />)
+
+    expect(screen.getByLabelText('login.password', { exact: true })).toHaveAttribute(
+      'name',
+      'password',
+    )
+    expect(screen.getByRole('link', { name: 'login.forget' })).toBeInTheDocument()
+  })
 })

--- a/web/app/(shareLayout)/webapp-signin/components/mail-and-password-auth.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/mail-and-password-auth.tsx
@@ -1,10 +1,11 @@
 'use client'
 import { Button } from '@langgenius/dify-ui/button'
+import { Field, FieldControl, FieldLabel } from '@langgenius/dify-ui/field'
+import { Form } from '@langgenius/dify-ui/form'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { resolveWebAppLoginRedirect } from '@/app/(shareLayout)/webapp-signin/login-redirect'
-import Input from '@/app/components/base/input'
 import { emailRegex } from '@/config'
 import { useLocale } from '@/context/i18n'
 import { useWebAppStore } from '@/context/web-app-context'
@@ -100,21 +101,19 @@ export default function MailAndPasswordAuth({ isEmailSetup }: MailAndPasswordAut
   }
 
   return (
-    <form
-      onSubmit={(event) => {
-        event.preventDefault()
+    <Form
+      onFormSubmit={() => {
         void handleEmailPasswordLogin()
       }}
     >
-      <div className="mb-3">
-        <label htmlFor="email" className="my-2 system-md-semibold text-text-secondary">
+      <Field name="email" className="mb-3 block">
+        <FieldLabel className="my-2 py-0 system-md-semibold text-text-secondary">
           {t(($) => $.email, { ns: 'login' })}
-        </label>
+        </FieldLabel>
         <div className="mt-1">
-          <Input
-            name="email"
+          <FieldControl
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            onValueChange={setEmail}
             id="email"
             type="email"
             autoComplete="email"
@@ -122,13 +121,13 @@ export default function MailAndPasswordAuth({ isEmailSetup }: MailAndPasswordAut
             placeholder={t(($) => $.emailPlaceholder, { ns: 'login' }) || ''}
           />
         </div>
-      </div>
+      </Field>
 
-      <div className="mb-3">
-        <label htmlFor="password" className="my-2 flex items-center justify-between">
-          <span className="system-md-semibold text-text-secondary">
+      <Field name="password" className="mb-3 block">
+        <div className="my-2 flex items-center justify-between">
+          <FieldLabel className="py-0 system-md-semibold text-text-secondary">
             {t(($) => $.password, { ns: 'login' })}
-          </span>
+          </FieldLabel>
           <Link
             href={`/webapp-reset-password?${searchParams.toString()}`}
             className={`system-xs-regular ${isEmailSetup ? 'text-components-button-secondary-accent-text' : 'pointer-events-none text-components-button-secondary-accent-text-disabled'}`}
@@ -137,12 +136,11 @@ export default function MailAndPasswordAuth({ isEmailSetup }: MailAndPasswordAut
           >
             {t(($) => $.forget, { ns: 'login' })}
           </Link>
-        </label>
+        </div>
         <div className="relative mt-1">
-          <Input
-            name="password"
+          <FieldControl
             value={password}
-            onChange={(e) => setPassword(e.target.value)}
+            onValueChange={setPassword}
             id="password"
             type={showPassword ? 'text' : 'password'}
             autoComplete="current-password"
@@ -155,7 +153,7 @@ export default function MailAndPasswordAuth({ isEmailSetup }: MailAndPasswordAut
             </Button>
           </div>
         </div>
-      </div>
+      </Field>
 
       <div className="mb-2">
         <Button
@@ -167,6 +165,6 @@ export default function MailAndPasswordAuth({ isEmailSetup }: MailAndPasswordAut
           {t(($) => $.signBtn, { ns: 'login' })}
         </Button>
       </div>
-    </form>
+    </Form>
   )
 }

--- a/web/app/(shareLayout)/webapp-signin/components/mail-and-password-auth.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/mail-and-password-auth.tsx
@@ -107,7 +107,7 @@ export default function MailAndPasswordAuth({ isEmailSetup }: MailAndPasswordAut
       }}
     >
       <Field name="email" className="mb-3 block">
-        <FieldLabel className="my-2 py-0 system-md-semibold text-text-secondary">
+        <FieldLabel className="my-2 py-0 text-sm leading-5 font-semibold text-text-secondary">
           {t(($) => $.email, { ns: 'login' })}
         </FieldLabel>
         <div className="mt-1">
@@ -125,7 +125,7 @@ export default function MailAndPasswordAuth({ isEmailSetup }: MailAndPasswordAut
 
       <Field name="password" className="mb-3 block">
         <div className="my-2 flex items-center justify-between">
-          <FieldLabel className="py-0 system-md-semibold text-text-secondary">
+          <FieldLabel className="py-0 text-sm leading-5 font-semibold text-text-secondary">
             {t(($) => $.password, { ns: 'login' })}
           </FieldLabel>
           <Link


### PR DESCRIPTION
## Summary

- replace the deprecated Web Input with the documented Dify UI Form, Field, FieldLabel, and FieldControl composition
- keep authentication state, validation, token, redirect, and submit ownership in the feature
- give the password control the exact field label only; the recovery link remains a separate link
- remove the one legacy-import suppression

## Review boundary

This is the primitive-composition layer only. It does not change submission behavior, password visibility behavior, translations, validation, errors, or redirects.

## Visual regression review

The existing block, margin, relative-positioning, and action wrappers remain. FieldControl medium uses the same normal-state radius, padding, typography, color, border, hover, and focus tokens as the legacy regular Input. The emoji visibility action is unchanged in this layer.

## Verification

- owner suite: 2/2 passed, including an exact password-label assertion that fails on the legacy wrapper label
- standalone a11y lint: 0 diagnostics
- full static check: 0 errors
- suppression delta: -1

## Dependency and rollback

Depends only on #40222 because it reuses that layer's owner test and native submit boundary. #40225 adds the visibility-action name. Revert this layer to restore the legacy Input without reverting the parent submit fix.