### PR TITLE
fix(web): name the webapp password visibility action

### DIFF
--- a/web/app/(shareLayout)/webapp-signin/components/__tests__/mail-and-password-auth.spec.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/__tests__/mail-and-password-auth.spec.tsx
@@ -83,4 +83,18 @@ describe('MailAndPasswordAuth', () => {
     )
     expect(screen.getByRole('link', { name: 'login.forget' })).toBeInTheDocument()
   })
+
+  it('names the password visibility action for its current state', async () => {
+    const user = userEvent.setup()
+    render(<MailAndPasswordAuth isEmailSetup />)
+
+    const passwordInput = screen.getByLabelText('login.password')
+    expect(passwordInput).toHaveAttribute('type', 'password')
+
+    await user.click(screen.getByRole('button', { name: 'login.showPassword' }))
+    expect(passwordInput).toHaveAttribute('type', 'text')
+
+    await user.click(screen.getByRole('button', { name: 'login.hidePassword' }))
+    expect(passwordInput).toHaveAttribute('type', 'password')
+  })
 })

--- a/web/app/(shareLayout)/webapp-signin/components/mail-and-password-auth.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/mail-and-password-auth.tsx
@@ -148,8 +148,15 @@ export default function MailAndPasswordAuth({ isEmailSetup }: MailAndPasswordAut
             placeholder={t(($) => $.passwordPlaceholder, { ns: 'login' }) || ''}
           />
           <div className="absolute inset-y-0 right-0 flex items-center">
-            <Button type="button" variant="ghost" onClick={() => setShowPassword(!showPassword)}>
-              {showPassword ? '👀' : '😝'}
+            <Button
+              type="button"
+              variant="ghost"
+              aria-label={t(($) => $[showPassword ? 'hidePassword' : 'showPassword'], {
+                ns: 'login',
+              })}
+              onClick={() => setShowPassword(!showPassword)}
+            >
+              <span aria-hidden="true">{showPassword ? '👀' : '😝'}</span>
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- name the existing password visibility button with the localized Show password or Hide password action
- hide the existing emoji glyph from the accessibility tree so it does not override the button name
- verify the name and input type through both visibility states

## Review boundary

This layer changes no visible glyph, class, spacing, size, padding, position, form behavior, or translation. The existing emoji presentation remains byte-for-byte text content inside an aria-hidden span.

## Behavior contract

The control remains type=button. Activating it changes the password input from password to text and back without submitting the form; its accessible name always describes the next action.

## Verification

- owner suite: 3/3 passed
- standalone a11y lint: 0 diagnostics
- diff check: passed

## Dependency and rollback

Depends on #40223 because the semantic test shares the same owner spec and exact Dify UI field label. Revert this layer independently to remove only the accessible action name.