### PR TITLE
fix(web): restore webapp email code form submission

### DIFF
--- a/web/app/(shareLayout)/webapp-signin/components/__tests__/mail-and-code-auth.spec.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/__tests__/mail-and-code-auth.spec.tsx
@@ -1,0 +1,58 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MailAndCodeAuth from '../mail-and-code-auth'
+
+const pushMock = vi.fn()
+const replaceMock = vi.fn()
+const setCountdownLeftTimeMock = vi.fn()
+const sendWebAppEMailLoginCodeMock = vi.fn()
+const searchParams = new URLSearchParams({
+  redirect_url: encodeURIComponent('/chatbot/test-app'),
+})
+
+vi.mock('@/next/navigation', () => ({
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+  useSearchParams: () => searchParams,
+}))
+
+vi.mock('@/context/i18n', () => ({
+  useLocale: () => 'en-US',
+}))
+
+vi.mock('@/app/components/signin/storage', () => ({
+  COUNT_DOWN_TIME_MS: 60_000,
+  useSetCountdownLeftTime: () => setCountdownLeftTimeMock,
+}))
+
+vi.mock('@/service/common', () => ({
+  sendWebAppEMailLoginCode: (...args: unknown[]) => sendWebAppEMailLoginCodeMock(...args),
+}))
+
+describe('MailAndCodeAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    sendWebAppEMailLoginCodeMock.mockResolvedValue({ result: 'success', data: 'token-abc' })
+  })
+
+  it('submits from the email field through the native form', async () => {
+    const user = userEvent.setup()
+    render(<MailAndCodeAuth />)
+
+    const emailInput = screen.getByRole('textbox', { name: 'login.email' })
+    const submitButton = screen.getByRole('button', { name: 'login.signup.verifyMail' })
+
+    expect(emailInput).toHaveAttribute('name', 'email')
+    expect(emailInput).toHaveAttribute('autocomplete', 'email')
+    expect(emailInput).toHaveAttribute('spellcheck', 'false')
+    expect(submitButton).toHaveAttribute('type', 'submit')
+
+    await user.tab()
+    expect(emailInput).toHaveFocus()
+    await user.type(emailInput, 'user@example.com{Enter}')
+
+    await waitFor(() => {
+      expect(sendWebAppEMailLoginCodeMock).toHaveBeenCalledTimes(1)
+    })
+    expect(pushMock).toHaveBeenCalledWith(expect.stringContaining('/webapp-signin/check-code?'))
+  })
+})

--- a/web/app/(shareLayout)/webapp-signin/components/mail-and-code-auth.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/mail-and-code-auth.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@langgenius/dify-ui/button'
 import { toast } from '@langgenius/dify-ui/toast'
-import { noop } from 'es-toolkit/function'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { resolveWebAppLoginRedirect } from '@/app/(shareLayout)/webapp-signin/login-redirect'
@@ -64,8 +63,12 @@ export default function MailAndCodeAuth() {
   }
 
   return (
-    <form onSubmit={noop}>
-      <input type="text" className="hidden" />
+    <form
+      onSubmit={(event) => {
+        event.preventDefault()
+        void handleGetEMailVerificationCode()
+      }}
+    >
       <div className="mb-2">
         <label htmlFor="email" className="my-2 system-md-semibold text-text-secondary">
           {t(($) => $.email, { ns: 'login' })}
@@ -73,7 +76,10 @@ export default function MailAndCodeAuth() {
         <div className="mt-1">
           <Input
             id="email"
+            name="email"
             type="email"
+            autoComplete="email"
+            spellCheck={false}
             value={email}
             placeholder={t(($) => $.emailPlaceholder, { ns: 'login' }) as string}
             onChange={(e) => setEmail(e.target.value)}
@@ -81,11 +87,11 @@ export default function MailAndCodeAuth() {
         </div>
         <div className="mt-3">
           <Button
+            type="submit"
             loading={loading}
             disabled={loading || !email}
             variant="primary"
             className="w-full"
-            onClick={handleGetEMailVerificationCode}
           >
             {t(($) => $['signup.verifyMail'], { ns: 'login' })}
           </Button>


### PR DESCRIPTION
## Summary

- restore the native submit boundary for the WebApp email-code request
- give the email field stable name, email type, autocomplete, and spellcheck metadata
- make the verification action type=submit
- verify Enter reaches the existing validation, request, countdown, and redirect owner once

## Review boundary

The legacy Input, visible wrappers, classes, validation, request payload, countdown, and redirect behavior remain unchanged.

## Visual regression review

No visible element or style class changes. The only removed node was an empty display-none input.

## Verification

- focused owner test: passed
- standalone a11y lint: 0 diagnostics
- full static check: 0 errors
- diff check: passed

## Dependency and rollback

Independent root layer based on main. The deferred Dify UI input migration is not part of this delivery.