### PR TITLE
refactor(web): migrate webapp email code fields

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -141,11 +141,6 @@
       "count": 1
     }
   },
-  "web/app/(shareLayout)/webapp-signin/components/mail-and-code-auth.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/(shareLayout)/webapp-signin/components/mail-and-password-auth.tsx": {
     "jsx_a11y/tabindex-no-positive": {
       "count": 3

--- a/web/app/(shareLayout)/webapp-signin/components/mail-and-code-auth.tsx
+++ b/web/app/(shareLayout)/webapp-signin/components/mail-and-code-auth.tsx
@@ -1,9 +1,10 @@
 import { Button } from '@langgenius/dify-ui/button'
+import { Field, FieldControl, FieldLabel } from '@langgenius/dify-ui/field'
+import { Form } from '@langgenius/dify-ui/form'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { resolveWebAppLoginRedirect } from '@/app/(shareLayout)/webapp-signin/login-redirect'
-import Input from '@/app/components/base/input'
 import { COUNT_DOWN_TIME_MS, useSetCountdownLeftTime } from '@/app/components/signin/storage'
 import { emailRegex } from '@/config'
 import { useLocale } from '@/context/i18n'
@@ -63,26 +64,23 @@ export default function MailAndCodeAuth() {
   }
 
   return (
-    <form
-      onSubmit={(event) => {
-        event.preventDefault()
+    <Form
+      onFormSubmit={() => {
         void handleGetEMailVerificationCode()
       }}
     >
-      <div className="mb-2">
-        <label htmlFor="email" className="my-2 system-md-semibold text-text-secondary">
+      <Field name="email" className="mb-2 block">
+        <FieldLabel className="my-2 py-0 system-md-semibold! text-text-secondary">
           {t(($) => $.email, { ns: 'login' })}
-        </label>
+        </FieldLabel>
         <div className="mt-1">
-          <Input
-            id="email"
-            name="email"
+          <FieldControl
             type="email"
             autoComplete="email"
             spellCheck={false}
             value={email}
             placeholder={t(($) => $.emailPlaceholder, { ns: 'login' }) as string}
-            onChange={(e) => setEmail(e.target.value)}
+            onValueChange={setEmail}
           />
         </div>
         <div className="mt-3">
@@ -96,7 +94,7 @@ export default function MailAndCodeAuth() {
             {t(($) => $['signup.verifyMail'], { ns: 'login' })}
           </Button>
         </div>
-      </div>
-    </form>
+      </Field>
+    </Form>
   )
 }


### PR DESCRIPTION
## Summary

Migrate the WebApp email-code form from the deprecated web Input to the documented Dify UI Form, Field, FieldLabel, and FieldControl composition.

## Behavior contract

- Dify UI owns the native form/field DOM contract and accessible label association.
- The WebApp feature continues to own email state, validation, code-request mutation, countdown, and redirect policy.
- The email field retains the metadata and Enter-submit behavior introduced by #40227.

## Scope

- One WebApp email-code component.
- One matching `no-restricted-imports` suppression entry removed with the repository prune command.

## Non-goals

- No shared form adapter migration.
- No auth-flow abstraction with the Console implementation.
- No check-code page changes.

## Verification

- `pnpm exec vp test run __tests__/embedded-user-id-auth.test.tsx` — 6/6 passed.
- `pnpm exec vp check 'app/(shareLayout)/webapp-signin/components/mail-and-code-auth.tsx'` — 0 warnings/errors.
- `node scripts/lint-a11y.mjs 'app/(shareLayout)/webapp-signin/components/mail-and-code-auth.tsx'` — passed.
- `pnpm lint:oxlint --prune-suppressions` removed only this component's restricted-import entry.
- `pnpm check` from the repository root — 0 errors; existing warning baseline unchanged.

## Visual regression review

Compared the parent legacy-Input branch and this branch in detached local worktrees with the same route, API fixture, viewport, and theme.

The first comparison caught the FieldLabel default typography overriding the existing label token; this PR now applies the repository's important typography override pattern. The final computed layouts matched exactly:

- Form: 400 x 104 px at the same coordinates.
- Label: 14 px / 20 px, weight 600, same 28 x 16.5 px box and coordinates.
- Input: 400 x 32 px, 7 x 12 px padding, 8 px radius, same coordinates.
- Button: 400 x 32 px, 0 x 14 px padding, 8 px radius, same coordinates.

No static alignment, centering, spacing, size, wrapping, or typography difference remains.

## Rollback

Revert this PR only to return to the legacy Input while keeping the correct native submit behavior from #40227.

## Stack

- Base: #40227
- Depends on: #40227
- Stack: #40229
