### PR TITLE
refactor(web): migrate the signup email field

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -5729,11 +5729,6 @@
       "count": 1
     }
   },
-  "web/app/signup/components/input-mail.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "web/app/signup/layout.tsx": {
     "typescript/no-explicit-any": {
       "count": 1

--- a/web/app/signup/components/input-mail.tsx
+++ b/web/app/signup/components/input-mail.tsx
@@ -1,11 +1,12 @@
 'use client'
 import type { MailSendResponse } from '@/service/use-common'
 import { Button } from '@langgenius/dify-ui/button'
+import { Field, FieldControl, FieldLabel } from '@langgenius/dify-ui/field'
+import { Form as DifyForm } from '@langgenius/dify-ui/form'
 import { toast } from '@langgenius/dify-ui/toast'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Input from '@/app/components/base/input'
 import Split from '@/app/signin/split'
 import { emailRegex } from '@/config'
 import { useLocale } from '@/context/i18n'
@@ -45,29 +46,26 @@ export default function Form({ onSuccess }: Props) {
   }, [email, locale, submitMail, t, isPending, onSuccess])
 
   return (
-    <form
-      onSubmit={(e) => {
-        e.preventDefault()
-        handleSubmit()
+    <DifyForm
+      onFormSubmit={() => {
+        void handleSubmit()
       }}
     >
-      <div className="mb-3">
-        <label htmlFor="email" className="my-2 system-md-semibold text-text-secondary">
+      <Field name="email" className="mb-3 block">
+        <FieldLabel className="my-2 py-0 system-md-semibold! text-text-secondary">
           {t(($) => $.email, { ns: 'login' })}
-        </label>
+        </FieldLabel>
         <div className="mt-1">
-          <Input
+          <FieldControl
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            id="email"
-            name="email"
+            onValueChange={setEmail}
             type="email"
             autoComplete="email"
             spellCheck={false}
             placeholder={t(($) => $.emailPlaceholder, { ns: 'login' }) || ''}
           />
         </div>
-      </div>
+      </Field>
       <div className="mb-2">
         <Button variant="primary" type="submit" disabled={isPending || !email} className="w-full">
           {t(($) => $['signup.verifyMail'], { ns: 'login' })}
@@ -107,6 +105,6 @@ export default function Form({ onSuccess }: Props) {
           </div>
         </>
       )}
-    </form>
+    </DifyForm>
   )
 }


### PR DESCRIPTION
## Summary

- migrate the signup email boundary from the restricted legacy input to Dify UI `Form`, `Field`, `FieldLabel`, and `FieldControl`
- preserve the existing submission, validation, request, redirect, and translation owners
- remove only the matching restricted-import suppression

## Ownership contract

- Dify UI `Form` owns the native submit event boundary
- Dify UI `Field` owns label/control association and control metadata
- the signup feature continues to own email state, validation, mutation state, and `onSuccess`
- no compatibility wrapper or cross-feature abstraction is introduced

## Scope

- `web/app/signup/components/input-mail.tsx`
- the matching `no-restricted-imports` suppression entry

The behavior test remains in the parent layer so this PR reviews only the primitive migration.

## Visual regression

Compared this branch against #40230 on `/signup` with the same system-features mock, locale, viewport, and theme. The form, label, input, and submit button match exactly for position, width, height, font size, line height, font weight, padding, border radius, and display.

Key geometry remained unchanged:

- form: 400 × 185 at (440, 340.898)
- label: 28 × 16.5, 14/20, weight 600
- input: 400 × 32, padding 7 × 12, radius 8
- submit button: 400 × 32, padding 0 × 14, radius 8

The only DOM delta in that comparison is the Dify UI generated input id and its matching label `for` value.

## Verification

- `pnpm exec vp test run app/signup/components/input-mail.spec.tsx` — 7/7
- `pnpm exec vp check app/signup/components/input-mail.tsx app/signup/components/input-mail.spec.tsx` — 0 warnings/errors
- `node scripts/lint-a11y.mjs app/signup/components/input-mail.tsx`
- `pnpm check` — 0 errors, existing warnings only

## Stack

Base: #40230

This PR is the second and final layer of stack #40232. It can be reviewed and reverted independently.
