### PR TITLE
refactor: replace manual model_validate with @model_validate in app core controllers

### DIFF
--- a/api/controllers/console/app/app.py
+++ b/api/controllers/console/app/app.py
@@ -4,7 +4,6 @@ from collections.abc import Sequence
 from datetime import datetime
 from typing import Any, Literal
 
-from flask import request
 from flask_restx import Resource
 from pydantic import AliasChoices, BaseModel, Field, ValidationInfo, computed_field, field_validator, model_validator
 from sqlalchemy import select
@@ -33,6 +32,7 @@ from controllers.console.wraps import (
     edit_permission_required,
     enterprise_license_required,
     is_admin_or_owner_required,
+    model_validate,
     rbac_permission_required,
     setup_required,
     with_current_tenant_id,
@@ -697,16 +697,16 @@ class AppListApi(Resource):
     @with_current_user
     @with_current_tenant_id
     @with_session
-    def post(self, session: Session, current_tenant_id: str, current_user: Account):
+    @model_validate(CreateAppPayload)
+    def post(self, req_data: CreateAppPayload, session: Session, current_tenant_id: str, current_user: Account):
         """Create app"""
-        args = CreateAppPayload.model_validate(console_ns.payload)
         params = CreateAppParams(
-            name=args.name,
-            description=args.description,
-            mode=args.mode,
-            icon_type=args.icon_type,
-            icon=args.icon,
-            icon_background=args.icon_background,
+            name=req_data.name,
+            description=req_data.description,
+            mode=req_data.mode,
+            icon_type=req_data.icon_type,
+            icon=req_data.icon,
+            icon_background=req_data.icon_background,
         )
 
         app_service = AppService()
@@ -908,20 +908,20 @@ class AppApi(Resource):
     @agent_manage_required_for_agent_app
     @with_session
     @get_app_model(mode=None)
-    def put(self, session: Session, app_model: App):
+    @model_validate(UpdateAppPayload)
+    def put(self, req_data: UpdateAppPayload, session: Session, app_model: App):
         """Update app"""
-        args = UpdateAppPayload.model_validate(console_ns.payload)
 
         app_service = AppService()
 
         args_dict: AppService.ArgsDict = {
-            "name": args.name,
-            "description": args.description or "",
-            "icon_type": args.icon_type,
-            "icon": args.icon or "",
-            "icon_background": args.icon_background or "",
-            "use_icon_as_answer_icon": args.use_icon_as_answer_icon or False,
-            "max_active_requests": args.max_active_requests or 0,
+            "name": req_data.name,
+            "description": req_data.description or "",
+            "icon_type": req_data.icon_type,
+            "icon": req_data.icon or "",
+            "icon_background": req_data.icon_background or "",
+            "use_icon_as_answer_icon": req_data.use_icon_as_answer_icon or False,
+            "max_active_requests": req_data.max_active_requests or 0,
         }
         app_model = app_service.update_app(app_model, args_dict, session=session)
         return AppDetailWithSite.model_validate(
@@ -969,10 +969,10 @@ class AppCopyApi(Resource):
     @with_current_user
     @with_current_tenant_id
     @get_app_model(mode=None)
-    def post(self, current_tenant_id: str, current_user: Account, app_model: App):
+    @model_validate(CopyAppPayload)
+    def post(self, req_data: CopyAppPayload, current_tenant_id: str, current_user: Account, app_model: App):
         """Copy app"""
         # The role of the current user in the ta table must be admin, owner, or editor
-        args = CopyAppPayload.model_validate(console_ns.payload or {})
 
         with Session(db.engine, expire_on_commit=False) as session:
             import_service = AppDslService(session)
@@ -982,11 +982,11 @@ class AppCopyApi(Resource):
                     account=current_user,
                     import_mode=ImportMode.YAML_CONTENT,
                     yaml_content=yaml_content,
-                    name=args.name,
-                    description=args.description,
-                    icon_type=args.icon_type,
-                    icon=args.icon,
-                    icon_background=args.icon_background,
+                    name=req_data.name,
+                    description=req_data.description,
+                    icon_type=req_data.icon_type,
+                    icon=req_data.icon,
+                    icon_background=req_data.icon_background,
                 )
             except NoPermissionError as e:
                 raise Forbidden(str(e))
@@ -1045,16 +1045,16 @@ class AppExportApi(Resource):
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_IMPORT_EXPORT_DSL)
     @agent_manage_required_for_agent_app
     @get_app_model
-    def get(self, app_model: App):
+    @model_validate(AppExportQuery)
+    def get(self, req_data: AppExportQuery, app_model: App):
         """Export app"""
-        args = AppExportQuery.model_validate(request.args.to_dict(flat=True))
 
         response = AppExportResponse(
             data=AppDslService.export_dsl(
                 app_model=app_model,
                 session=db.session(),
-                include_secret=args.include_secret,
-                workflow_id=args.workflow_id,
+                include_secret=req_data.include_secret,
+                workflow_id=req_data.workflow_id,
             )
         )
         return response.model_dump(mode="json")
@@ -1102,11 +1102,11 @@ class AppNameApi(Resource):
     @agent_manage_required_for_agent_app
     @with_session
     @get_app_model(mode=None)
-    def post(self, session: Session, app_model: App):
-        args = AppNamePayload.model_validate(console_ns.payload)
+    @model_validate(AppNamePayload)
+    def post(self, req_data: AppNamePayload, session: Session, app_model: App):
 
         app_service = AppService()
-        app_model = app_service.update_app_name(app_model, args.name, session=session)
+        app_model = app_service.update_app_name(app_model, req_data.name, session=session)
         return AppDetail.model_validate(
             app_model,
             from_attributes=True,
@@ -1130,15 +1130,15 @@ class AppIconApi(Resource):
     @agent_manage_required_for_agent_app
     @with_session
     @get_app_model(mode=None)
-    def post(self, session: Session, app_model: App):
-        args = AppIconPayload.model_validate(console_ns.payload or {})
+    @model_validate(AppIconPayload)
+    def post(self, req_data: AppIconPayload, session: Session, app_model: App):
 
         app_service = AppService()
         app_model = app_service.update_app_icon(
             app_model,
-            args.icon or "",
-            args.icon_background or "",
-            args.icon_type,
+            req_data.icon or "",
+            req_data.icon_background or "",
+            req_data.icon_type,
             session=session,
         )
         return AppDetail.model_validate(
@@ -1164,11 +1164,11 @@ class AppSiteStatus(Resource):
     @agent_manage_required_for_agent_app
     @with_session
     @get_app_model(mode=None)
-    def post(self, session: Session, app_model: App):
-        args = AppSiteStatusPayload.model_validate(console_ns.payload)
+    @model_validate(AppSiteStatusPayload)
+    def post(self, req_data: AppSiteStatusPayload, session: Session, app_model: App):
 
         app_service = AppService()
-        app_model = app_service.update_app_site_status(app_model, args.enable_site, session=session)
+        app_model = app_service.update_app_site_status(app_model, req_data.enable_site, session=session)
         return AppDetail.model_validate(
             app_model,
             from_attributes=True,
@@ -1192,11 +1192,11 @@ class AppApiStatus(Resource):
     @agent_manage_required_for_agent_app
     @with_session
     @get_app_model(mode=None)
-    def post(self, session: Session, app_model: App):
-        args = AppApiStatusPayload.model_validate(console_ns.payload)
+    @model_validate(AppApiStatusPayload)
+    def post(self, req_data: AppApiStatusPayload, session: Session, app_model: App):
 
         app_service = AppService()
-        app_model = app_service.update_app_api_status(app_model, args.enable_api, session=session)
+        app_model = app_service.update_app_api_status(app_model, req_data.enable_api, session=session)
         return AppDetail.model_validate(
             app_model,
             from_attributes=True,
@@ -1242,14 +1242,14 @@ class AppTraceApi(Resource):
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_TRACING_CONFIG)
     @get_app_model
-    def post(self, app_model: App):
+    @model_validate(AppTracePayload)
+    def post(self, req_data: AppTracePayload, app_model: App):
         # add app trace
-        args = AppTracePayload.model_validate(console_ns.payload)
 
         OpsTraceManager.update_app_tracing_config(
             app_id=app_model.id,
-            enabled=args.enabled,
-            tracing_provider=args.tracing_provider,
+            enabled=req_data.enabled,
+            tracing_provider=req_data.tracing_provider,
         )
 
         return SimpleResultResponse(result="success").model_dump(mode="json")

--- a/api/controllers/console/app/completion.py
+++ b/api/controllers/console/app/completion.py
@@ -29,6 +29,7 @@ from controllers.console.wraps import (
     RBACResourceScope,
     account_initialization_required,
     edit_permission_required,
+    model_validate,
     rbac_permission_required,
     setup_required,
     with_current_tenant_id,
@@ -160,11 +161,11 @@ class CompletionMessageApi(Resource):
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_TEST_AND_RUN)
     @with_session
     @get_app_model(mode=AppMode.COMPLETION)
-    def post(self, session: Session, current_user: Account, app_model: App):
-        args_model = CompletionMessagePayload.model_validate(console_ns.payload)
-        args = args_model.model_dump(exclude_none=True, by_alias=True)
+    @model_validate(CompletionMessagePayload)
+    def post(self, req_data: CompletionMessagePayload, session: Session, current_user: Account, app_model: App):
+        args = req_data.model_dump(exclude_none=True, by_alias=True)
 
-        streaming = args_model.response_mode != "blocking"
+        streaming = req_data.response_mode != "blocking"
         args["auto_generate_name"] = False
 
         try:

--- a/api/controllers/console/app/conversation.py
+++ b/api/controllers/console/app/conversation.py
@@ -2,7 +2,7 @@ from typing import Literal
 from uuid import UUID
 
 import sqlalchemy as sa
-from flask import abort, request
+from flask import abort
 from flask_restx import Resource
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import func, or_
@@ -18,6 +18,7 @@ from controllers.console.wraps import (
     RBACResourceScope,
     account_initialization_required,
     edit_permission_required,
+    model_validate,
     rbac_permission_required,
     setup_required,
     with_current_user,
@@ -108,17 +109,17 @@ class CompletionConversationApi(Resource):
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_VIEW_LAYOUT)
     @with_session(write=False)
     @get_app_model(mode=AppMode.COMPLETION)
-    def get(self, session: Session, current_user: Account, app_model: App):
-        args = CompletionConversationQuery.model_validate(request.args.to_dict(flat=True))
+    @model_validate(CompletionConversationQuery)
+    def get(self, req_data: CompletionConversationQuery, session: Session, current_user: Account, app_model: App):
 
         query = sa.select(Conversation).where(
             Conversation.app_id == app_model.id, Conversation.mode == "completion", Conversation.is_deleted.is_(False)
         )
 
-        if args.keyword:
+        if req_data.keyword:
             from libs.helper import escape_like_pattern
 
-            escaped_keyword = escape_like_pattern(args.keyword)
+            escaped_keyword = escape_like_pattern(req_data.keyword)
             query = query.join(Message, Message.conversation_id == Conversation.id).where(
                 or_(
                     Message.query.ilike(f"%{escaped_keyword}%", escape="\\"),
@@ -130,7 +131,7 @@ class CompletionConversationApi(Resource):
         assert account.timezone is not None
 
         try:
-            start_datetime_utc, end_datetime_utc = parse_time_range(args.start, args.end, account.timezone)
+            start_datetime_utc, end_datetime_utc = parse_time_range(req_data.start, req_data.end, account.timezone)
         except ValueError as e:
             abort(400, description=str(e))
 
@@ -142,7 +143,7 @@ class CompletionConversationApi(Resource):
             query = query.where(Conversation.created_at < end_datetime_utc)
 
         # FIXME, the type ignore in this file
-        if args.annotation_status == "annotated":
+        if req_data.annotation_status == "annotated":
             query = (
                 query.options(selectinload(Conversation.message_annotations))  # type: ignore[arg-type]
                 .join(  # type: ignore
@@ -150,7 +151,7 @@ class CompletionConversationApi(Resource):
                 )
                 .group_by(Conversation.id)
             )
-        elif args.annotation_status == "not_annotated":
+        elif req_data.annotation_status == "not_annotated":
             query = (
                 query.outerjoin(MessageAnnotation, MessageAnnotation.conversation_id == Conversation.id)
                 .group_by(Conversation.id)
@@ -159,7 +160,7 @@ class CompletionConversationApi(Resource):
 
         query = query.order_by(Conversation.created_at.desc())
 
-        conversations = paginate_query(query, session=session, page=args.page, per_page=args.limit)
+        conversations = paginate_query(query, session=session, page=req_data.page, per_page=req_data.limit)
 
         return dump_response(
             ConversationPaginationResponse,
@@ -238,8 +239,8 @@ class ChatConversationApi(Resource):
     @rbac_permission_required(RBACResourceScope.APP, RBACPermission.APP_VIEW_LAYOUT)
     @with_session(write=False)
     @get_app_model(mode=[AppMode.CHAT, AppMode.AGENT_CHAT, AppMode.ADVANCED_CHAT, AppMode.AGENT])
-    def get(self, session: Session, current_user: Account, app_model: App):
-        args = ChatConversationQuery.model_validate(request.args.to_dict(flat=True))
+    @model_validate(ChatConversationQuery)
+    def get(self, req_data: ChatConversationQuery, session: Session, current_user: Account, app_model: App):
 
         subquery = (
             sa.select(Conversation.id.label("conversation_id"), EndUser.session_id.label("from_end_user_session_id"))
@@ -249,10 +250,10 @@ class ChatConversationApi(Resource):
 
         query = sa.select(Conversation).where(Conversation.app_id == app_model.id, Conversation.is_deleted.is_(False))
 
-        if args.keyword:
+        if req_data.keyword:
             from libs.helper import escape_like_pattern
 
-            escaped_keyword = escape_like_pattern(args.keyword)
+            escaped_keyword = escape_like_pattern(req_data.keyword)
             keyword_filter = f"%{escaped_keyword}%"
             query = (
                 query.join(
@@ -276,12 +277,12 @@ class ChatConversationApi(Resource):
         assert account.timezone is not None
 
         try:
-            start_datetime_utc, end_datetime_utc = parse_time_range(args.start, args.end, account.timezone)
+            start_datetime_utc, end_datetime_utc = parse_time_range(req_data.start, req_data.end, account.timezone)
         except ValueError as e:
             abort(400, description=str(e))
 
         if start_datetime_utc:
-            match args.sort_by:
+            match req_data.sort_by:
                 case "updated_at" | "-updated_at":
                     query = query.where(Conversation.updated_at >= start_datetime_utc)
                 case "created_at" | "-created_at" | _:
@@ -289,13 +290,13 @@ class ChatConversationApi(Resource):
 
         if end_datetime_utc:
             end_datetime_utc = end_datetime_utc.replace(second=59)
-            match args.sort_by:
+            match req_data.sort_by:
                 case "updated_at" | "-updated_at":
                     query = query.where(Conversation.updated_at <= end_datetime_utc)
                 case "created_at" | "-created_at" | _:
                     query = query.where(Conversation.created_at <= end_datetime_utc)
 
-        match args.annotation_status:
+        match req_data.annotation_status:
             case "annotated":
                 query = (
                     query.options(selectinload(Conversation.message_annotations))  # type: ignore[arg-type]
@@ -316,7 +317,7 @@ class ChatConversationApi(Resource):
         if app_model.mode == AppMode.ADVANCED_CHAT:
             query = query.where(Conversation.invoke_from != InvokeFrom.DEBUGGER)
 
-        match args.sort_by:
+        match req_data.sort_by:
             case "created_at":
                 query = query.order_by(Conversation.created_at.asc())
             case "-created_at":
@@ -328,7 +329,7 @@ class ChatConversationApi(Resource):
             case _:
                 query = query.order_by(Conversation.created_at.desc())
 
-        conversations = paginate_query(query, session=session, page=args.page, per_page=args.limit)
+        conversations = paginate_query(query, session=session, page=req_data.page, per_page=req_data.limit)
 
         return dump_response(
             ConversationWithSummaryPaginationResponse,

--- a/api/controllers/console/app/generator.py
+++ b/api/controllers/console/app/generator.py
@@ -17,7 +17,12 @@ from controllers.console.app.error import (
     ProviderQuotaExceededError,
 )
 from controllers.console.app.wraps import with_session
-from controllers.console.wraps import account_initialization_required, setup_required, with_current_tenant_id
+from controllers.console.wraps import (
+    account_initialization_required,
+    model_validate,
+    setup_required,
+    with_current_tenant_id,
+)
 from core.app.app_config.entities import ModelConfig
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from core.helper.code_executor.code_node_provider import CodeNodeProvider
@@ -238,11 +243,11 @@ class RuleGenerateApi(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    def post(self, current_tenant_id: str):
-        args = RuleGeneratePayload.model_validate(console_ns.payload)
+    @model_validate(RuleGeneratePayload)
+    def post(self, req_data: RuleGeneratePayload, current_tenant_id: str):
 
         try:
-            rules = LLMGenerator.generate_rule_config(tenant_id=current_tenant_id, args=args)
+            rules = LLMGenerator.generate_rule_config(tenant_id=current_tenant_id, args=req_data)
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)
         except QuotaExceededError:
@@ -267,13 +272,13 @@ class RuleCodeGenerateApi(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    def post(self, current_tenant_id: str):
-        args = RuleCodeGeneratePayload.model_validate(console_ns.payload)
+    @model_validate(RuleCodeGeneratePayload)
+    def post(self, req_data: RuleCodeGeneratePayload, current_tenant_id: str):
 
         try:
             code_result = LLMGenerator.generate_code(
                 tenant_id=current_tenant_id,
-                args=args,
+                args=req_data,
             )
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)
@@ -299,13 +304,13 @@ class RuleStructuredOutputGenerateApi(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    def post(self, current_tenant_id: str):
-        args = RuleStructuredOutputPayload.model_validate(console_ns.payload)
+    @model_validate(RuleStructuredOutputPayload)
+    def post(self, req_data: RuleStructuredOutputPayload, current_tenant_id: str):
 
         try:
             structured_output = LLMGenerator.generate_structured_output(
                 tenant_id=current_tenant_id,
-                args=args,
+                args=req_data,
             )
         except ProviderTokenNotInitError as ex:
             raise ProviderNotInitializeError(ex.description)
@@ -332,36 +337,36 @@ class InstructionGenerateApi(Resource):
     @account_initialization_required
     @with_current_tenant_id
     @with_session(write=False)
-    def post(self, session: Session, current_tenant_id: str):
-        args = InstructionGeneratePayload.model_validate(console_ns.payload)
+    @model_validate(InstructionGeneratePayload)
+    def post(self, req_data: InstructionGeneratePayload, session: Session, current_tenant_id: str):
         providers: list[type[CodeNodeProvider]] = [Python3CodeProvider, JavascriptCodeProvider]
         code_provider: type[CodeNodeProvider] | None = next(
-            (p for p in providers if p.is_accept_language(args.language)), None
+            (p for p in providers if p.is_accept_language(req_data.language)), None
         )
         code_template = code_provider.get_default_code() if code_provider else ""
         try:
             # Generate from nothing for a workflow node
-            if (args.current in (code_template, "")) and args.node_id != "":
+            if (req_data.current in (code_template, "")) and req_data.node_id != "":
                 app = session.scalar(
-                    select(App).where(App.id == args.flow_id, App.tenant_id == current_tenant_id).limit(1)
+                    select(App).where(App.id == req_data.flow_id, App.tenant_id == current_tenant_id).limit(1)
                 )
                 if not app:
-                    return {"error": f"app {args.flow_id} not found"}, 400
+                    return {"error": f"app {req_data.flow_id} not found"}, 400
                 workflow = WorkflowService().get_draft_workflow(app_model=app, session=session)
                 if not workflow:
-                    return {"error": f"workflow {args.flow_id} not found"}, 400
+                    return {"error": f"workflow {req_data.flow_id} not found"}, 400
                 nodes: Sequence = workflow.graph_dict["nodes"]
-                node = [node for node in nodes if node["id"] == args.node_id]
+                node = [node for node in nodes if node["id"] == req_data.node_id]
                 if len(node) == 0:
-                    return {"error": f"node {args.node_id} not found"}, 400
+                    return {"error": f"node {req_data.node_id} not found"}, 400
                 node_type = node[0]["data"]["type"]
                 match node_type:
                     case "llm":
                         return LLMGenerator.generate_rule_config(
                             current_tenant_id,
                             args=RuleGeneratePayload(
-                                instruction=args.instruction,
-                                model_config=args.model_config_data,
+                                instruction=req_data.instruction,
+                                model_config=req_data.model_config_data,
                                 no_variable=True,
                             ),
                         )
@@ -369,8 +374,8 @@ class InstructionGenerateApi(Resource):
                         return LLMGenerator.generate_rule_config(
                             current_tenant_id,
                             args=RuleGeneratePayload(
-                                instruction=args.instruction,
-                                model_config=args.model_config_data,
+                                instruction=req_data.instruction,
+                                model_config=req_data.model_config_data,
                                 no_variable=True,
                             ),
                         )
@@ -378,31 +383,31 @@ class InstructionGenerateApi(Resource):
                         return LLMGenerator.generate_code(
                             tenant_id=current_tenant_id,
                             args=RuleCodeGeneratePayload(
-                                instruction=args.instruction,
-                                model_config=args.model_config_data,
-                                code_language=args.language,
+                                instruction=req_data.instruction,
+                                model_config=req_data.model_config_data,
+                                code_language=req_data.language,
                             ),
                         )
                     case _:
                         return {"error": f"invalid node type: {node_type}"}
-            if args.node_id == "" and args.current != "":  # For legacy app without a workflow
+            if req_data.node_id == "" and req_data.current != "":  # For legacy app without a workflow
                 return LLMGenerator.instruction_modify_legacy(
                     tenant_id=current_tenant_id,
-                    flow_id=args.flow_id,
-                    current=args.current,
-                    instruction=args.instruction,
-                    model_config=args.model_config_data,
-                    ideal_output=args.ideal_output,
+                    flow_id=req_data.flow_id,
+                    current=req_data.current,
+                    instruction=req_data.instruction,
+                    model_config=req_data.model_config_data,
+                    ideal_output=req_data.ideal_output,
                 )
-            if args.node_id != "" and args.current != "":  # For workflow node
+            if req_data.node_id != "" and req_data.current != "":  # For workflow node
                 return LLMGenerator.instruction_modify_workflow(
                     tenant_id=current_tenant_id,
-                    flow_id=args.flow_id,
-                    node_id=args.node_id,
-                    current=args.current,
-                    instruction=args.instruction,
-                    model_config=args.model_config_data,
-                    ideal_output=args.ideal_output,
+                    flow_id=req_data.flow_id,
+                    node_id=req_data.node_id,
+                    current=req_data.current,
+                    instruction=req_data.instruction,
+                    model_config=req_data.model_config_data,
+                    ideal_output=req_data.ideal_output,
                     workflow_service=WorkflowService(),
                 )
             return {"error": "incompatible parameters"}, 400
@@ -426,9 +431,9 @@ class InstructionGenerationTemplateApi(Resource):
     @setup_required
     @login_required
     @account_initialization_required
-    def post(self):
-        args = InstructionTemplatePayload.model_validate(console_ns.payload)
-        match args.type:
+    @model_validate(InstructionTemplatePayload)
+    def post(self, req_data: InstructionTemplatePayload):
+        match req_data.type:
             case "prompt":
                 from core.llm_generator.prompts import INSTRUCTION_GENERATE_TEMPLATE_PROMPT
 
@@ -438,7 +443,7 @@ class InstructionGenerationTemplateApi(Resource):
 
                 return {"data": INSTRUCTION_GENERATE_TEMPLATE_CODE}
             case _:
-                raise ValueError(f"Invalid type: {args.type}")
+                raise ValueError(f"Invalid type: {req_data.type}")
 
 
 def _workflow_instruction_guard(args: WorkflowGeneratePayload) -> tuple[dict, int] | None:
@@ -492,24 +497,24 @@ class WorkflowGenerateApi(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    def post(self, current_tenant_id: str):
-        args = WorkflowGeneratePayload.model_validate(console_ns.payload)
+    @model_validate(WorkflowGeneratePayload)
+    def post(self, req_data: WorkflowGeneratePayload, current_tenant_id: str):
 
         # Reject empty / over-length instructions at the boundary (shared with
         # the streaming endpoint) before spending a planner+builder roundtrip.
-        guard = _workflow_instruction_guard(args)
+        guard = _workflow_instruction_guard(req_data)
         if guard is not None:
             return guard
 
         try:
             result = WorkflowGeneratorService.generate_workflow_graph(
                 tenant_id=current_tenant_id,
-                mode=args.mode,
-                instruction=args.instruction,
-                model_config=args.model_config_data,
-                ideal_output=args.ideal_output,
-                current_graph=args.current_graph.model_dump(by_alias=True, exclude_none=True)
-                if args.current_graph
+                mode=req_data.mode,
+                instruction=req_data.instruction,
+                model_config=req_data.model_config_data,
+                ideal_output=req_data.ideal_output,
+                current_graph=req_data.current_graph.model_dump(by_alias=True, exclude_none=True)
+                if req_data.current_graph
                 else None,
             )
         except ProviderTokenNotInitError as ex:
@@ -547,13 +552,13 @@ class WorkflowInstructionSuggestionsApi(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    def post(self, current_tenant_id: str):
-        args = WorkflowInstructionSuggestionsPayload.model_validate(console_ns.payload)
+    @model_validate(WorkflowInstructionSuggestionsPayload)
+    def post(self, req_data: WorkflowInstructionSuggestionsPayload, current_tenant_id: str):
         suggestions = LLMGenerator.generate_workflow_instruction_suggestions(
             tenant_id=current_tenant_id,
-            mode=args.mode,
-            language=args.language,
-            count=args.count,
+            mode=req_data.mode,
+            language=req_data.language,
+            count=req_data.count,
         )
         return dump_response(WorkflowInstructionSuggestionsResponse, {"suggestions": suggestions})
 
@@ -583,12 +588,12 @@ class WorkflowGenerateStreamApi(Resource):
     @login_required
     @account_initialization_required
     @with_current_tenant_id
-    def post(self, current_tenant_id: str):
-        args = WorkflowGeneratePayload.model_validate(console_ns.payload)
+    @model_validate(WorkflowGeneratePayload)
+    def post(self, req_data: WorkflowGeneratePayload, current_tenant_id: str):
 
         # Same boundary guards as the blocking endpoint — return a normal 400
         # JSON for these BEFORE opening the stream.
-        guard = _workflow_instruction_guard(args)
+        guard = _workflow_instruction_guard(req_data)
         if guard is not None:
             return guard
 
@@ -596,12 +601,14 @@ class WorkflowGenerateStreamApi(Resource):
             try:
                 for event_name, payload in WorkflowGeneratorService.generate_workflow_graph_stream(
                     tenant_id=current_tenant_id,
-                    mode=args.mode,
-                    instruction=args.instruction,
-                    model_config=args.model_config_data,
-                    ideal_output=args.ideal_output,
+                    mode=req_data.mode,
+                    instruction=req_data.instruction,
+                    model_config=req_data.model_config_data,
+                    ideal_output=req_data.ideal_output,
                     current_graph=(
-                        args.current_graph.model_dump(by_alias=True, exclude_none=True) if args.current_graph else None
+                        req_data.current_graph.model_dump(by_alias=True, exclude_none=True)
+                        if req_data.current_graph
+                        else None
                     ),
                 ):
                     body = {"event": event_name, **payload}

--- a/api/tests/unit_tests/controllers/console/app/test_app_apis.py
+++ b/api/tests/unit_tests/controllers/console/app/test_app_apis.py
@@ -59,6 +59,7 @@ from controllers.console.app.workflow import AdvancedChatWorkflowRunPayload, Syn
 from controllers.console.app.workflow_app_log import WorkflowAppLogQuery
 from controllers.console.app.workflow_draft_variable import (
     EnvironmentVariableUpdatePayload,
+    WorkflowDraftVariableListQuery,
     WorkflowDraftVariableUpdatePayload,
 )
 from controllers.console.app.workflow_statistic import WorkflowStatisticQuery
@@ -144,7 +145,13 @@ class TestCompletionEndpoints:
             Session(sqlite_engine) as session,
             app.test_request_context("/", json={"inputs": {}, "model_config": {}, "query": "hi"}),
         ):
-            resp = method(api, session, _make_account(), app_model=MagicMock(id=APP_ID))
+            resp = method(
+                api,
+                CompletionMessagePayload(inputs={}, model_config={}, query="hi"),
+                session,
+                _make_account(),
+                app_model=MagicMock(id=APP_ID),
+            )
 
         assert resp == {"result": {"text": "ok"}}
 
@@ -167,7 +174,13 @@ class TestCompletionEndpoints:
             app.test_request_context("/", json={"inputs": {}, "model_config": {}, "query": "hi"}),
             pytest.raises(NotFound),
         ):
-            method(api, session, _make_account(), app_model=MagicMock(id=APP_ID))
+            method(
+                api,
+                CompletionMessagePayload(inputs={}, model_config={}, query="hi"),
+                session,
+                _make_account(),
+                app_model=MagicMock(id=APP_ID),
+            )
 
     def test_completion_api_provider_not_initialized(
         self, app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_engine: Engine
@@ -186,7 +199,13 @@ class TestCompletionEndpoints:
             app.test_request_context("/", json={"inputs": {}, "model_config": {}, "query": "hi"}),
             pytest.raises(completion_module.ProviderNotInitializeError),
         ):
-            method(api, session, _make_account(), app_model=MagicMock(id=APP_ID))
+            method(
+                api,
+                CompletionMessagePayload(inputs={}, model_config={}, query="hi"),
+                session,
+                _make_account(),
+                app_model=MagicMock(id=APP_ID),
+            )
 
     def test_completion_api_quota_exceeded(
         self, app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_engine: Engine
@@ -205,7 +224,13 @@ class TestCompletionEndpoints:
             app.test_request_context("/", json={"inputs": {}, "model_config": {}, "query": "hi"}),
             pytest.raises(completion_module.ProviderQuotaExceededError),
         ):
-            method(api, session, _make_account(), app_model=MagicMock(id=APP_ID))
+            method(
+                api,
+                CompletionMessagePayload(inputs={}, model_config={}, query="hi"),
+                session,
+                _make_account(),
+                app_model=MagicMock(id=APP_ID),
+            )
 
 
 class TestAppEndpoints:
@@ -232,7 +257,17 @@ class TestAppEndpoints:
             app.test_request_context("/console/api/apps/app-1", method="PUT", json=payload),
             patch.object(type(console_ns), "payload", payload),
         ):
-            response = method(api, unbound_session, app_model=_make_app(icon_type=app_module.IconType.EMOJI))
+            response = method(
+                api,
+                app_module.UpdateAppPayload(
+                    name="Updated App",
+                    description="Updated description",
+                    icon="🤖",
+                    icon_background="#FFFFFF",
+                ),
+                unbound_session,
+                app_model=_make_app(icon_type=app_module.IconType.EMOJI),
+            )
 
         assert response == {"id": "app-1"}
         assert app_service.update_app.call_args.args[1]["icon_type"] is None
@@ -271,7 +306,16 @@ class TestAppEndpoints:
             app.test_request_context("/console/api/apps/app-1/icon", method="POST", json=payload),
             patch.object(type(console_ns), "payload", payload),
         ):
-            response = method(api, unbound_session, app_model=_make_app())
+            response = method(
+                api,
+                app_module.AppIconPayload(
+                    icon="https://example.com/icon.png",
+                    icon_type=app_module.IconType.IMAGE,
+                    icon_background="#FFFFFF",
+                ),
+                unbound_session,
+                app_model=_make_app(),
+            )
 
         assert response == {"id": "app-1"}
         assert app_service.update_app_icon.call_args.args[1:] == (
@@ -301,7 +345,7 @@ class TestOpsTraceEndpoints:
         )
 
         with app.test_request_context("/?tracing_provider=langfuse"):
-            result = method(api, app_model=MagicMock(id="app-1"))
+            result = method(api, TraceProviderQuery(tracing_provider="langfuse"), MagicMock(id="app-1"))
 
         assert result == {"has_not_configured": True}
 
@@ -320,7 +364,11 @@ class TestOpsTraceEndpoints:
             json={"tracing_provider": "langfuse", "tracing_config": {"api_key": "k"}},
         ):
             with pytest.raises(BadRequest):
-                method(api, app_model=MagicMock(id="app-1"))
+                method(
+                    api,
+                    TraceConfigPayload(tracing_provider="langfuse", tracing_config={"api_key": "k"}),
+                    MagicMock(id="app-1"),
+                )
 
     def test_trace_app_config_delete_not_found(self, app: Flask, monkeypatch: pytest.MonkeyPatch):
         api = ops_trace_module.TraceAppConfigApi()
@@ -334,7 +382,7 @@ class TestOpsTraceEndpoints:
 
         with app.test_request_context("/?tracing_provider=langfuse"):
             with pytest.raises(BadRequest):
-                method(api, app_model=MagicMock(id="app-1"))
+                method(api, TraceProviderQuery(tracing_provider="langfuse"), MagicMock(id="app-1"))
 
 
 class TestSiteEndpoints:
@@ -374,7 +422,13 @@ class TestSiteEndpoints:
         site = self._add_site(db.session)
 
         with database_app.test_request_context("/", json={"title": "My Site", "input_placeholder": "Ask me anything"}):
-            result = method(api, db.session, _make_account(), app_model=_make_app())
+            result = method(
+                api,
+                AppSiteUpdatePayload(title="My Site", input_placeholder="Ask me anything"),
+                db.session,
+                _make_account(),
+                app_model=_make_app(),
+            )
 
         db.session.refresh(site)
         assert isinstance(result, dict)
@@ -441,7 +495,7 @@ class TestWorkflowAppLogEndpoints:
         )
 
         with database_app.test_request_context("/?page=1&limit=20"):
-            result = method(api, app_model=_make_app("app-1"))
+            result = method(api, WorkflowAppLogQuery(page=1, limit=20), app_model=_make_app("app-1"))
 
         assert result == {"page": 1, "limit": 20, "total": 0, "has_more": False, "data": []}
 
@@ -471,7 +525,12 @@ class TestWorkflowDraftVariableEndpoints:
         monkeypatch.setattr(workflow_draft_variable_module, "WorkflowService", DummyWorkflowService)
 
         with database_app.test_request_context("/?page=1&limit=20"):
-            result = method(api, _make_account(), app_model=_make_app("app-1"))
+            result = method(
+                api,
+                WorkflowDraftVariableListQuery(page=1, limit=20),
+                _make_account(),
+                app_model=_make_app("app-1"),
+            )
 
         assert result == {"items": [], "total": 0}
 
@@ -524,7 +583,16 @@ class TestWorkflowDraftVariableEndpoints:
                 "deleted_environment_variable_ids": ["env-b"],
             },
         ):
-            result = method(api, _make_account(), app_model=_make_app())
+            result = method(
+                api,
+                EnvironmentVariableUpdatePayload(
+                    environment_variables=[{"id": "env-a", "name": "a", "value_type": "string", "value": "new-a"}],
+                    patch=True,
+                    deleted_environment_variable_ids=["env-b"],
+                ),
+                _make_account(),
+                app_model=_make_app(),
+            )
 
         assert result == {"result": "success"}
         assert [(variable.id, variable.value) for variable in captured["environment_variables"]] == [("env-a", "new-a")]
@@ -570,7 +638,7 @@ class TestWorkflowStatisticEndpoints:
         with database_app.test_request_context("/"):
             account = _make_account()
             account.timezone = "UTC"
-            response = method(api, account, app_model=_make_app("app-1", tenant_id="t1"))
+            response = method(api, WorkflowStatisticQuery(), account, app_model=_make_app("app-1", tenant_id="t1"))
 
         assert response.get_json() == {"data": [{"date": "2024-01-01"}]}
 
@@ -600,7 +668,7 @@ class TestWorkflowStatisticEndpoints:
         with database_app.test_request_context("/"):
             account = _make_account()
             account.timezone = "UTC"
-            response = method(api, account, app_model=_make_app("app-1", tenant_id="t1"))
+            response = method(api, WorkflowStatisticQuery(), account, app_model=_make_app("app-1", tenant_id="t1"))
 
         assert response.get_json() == {"data": [{"date": "2024-01-02"}]}
 
@@ -630,7 +698,7 @@ class TestWorkflowTriggerEndpoints:
         db.session.commit()
 
         with database_app.test_request_context("/?node_id=node-1"):
-            result = method(api, app_model=_make_app())
+            result = method(api, Parser(node_id="node-1"), app_model=_make_app())
 
         assert isinstance(result, dict)
         assert {"id", "webhook_id", "webhook_url", "webhook_debug_url", "node_id", "created_at"} <= set(result.keys())

--- a/api/tests/unit_tests/controllers/console/app/test_app_apis.py
+++ b/api/tests/unit_tests/controllers/console/app/test_app_apis.py
@@ -59,7 +59,6 @@ from controllers.console.app.workflow import AdvancedChatWorkflowRunPayload, Syn
 from controllers.console.app.workflow_app_log import WorkflowAppLogQuery
 from controllers.console.app.workflow_draft_variable import (
     EnvironmentVariableUpdatePayload,
-    WorkflowDraftVariableListQuery,
     WorkflowDraftVariableUpdatePayload,
 )
 from controllers.console.app.workflow_statistic import WorkflowStatisticQuery
@@ -345,7 +344,7 @@ class TestOpsTraceEndpoints:
         )
 
         with app.test_request_context("/?tracing_provider=langfuse"):
-            result = method(api, TraceProviderQuery(tracing_provider="langfuse"), MagicMock(id="app-1"))
+            result = method(api, app_model=MagicMock(id="app-1"))
 
         assert result == {"has_not_configured": True}
 
@@ -364,11 +363,7 @@ class TestOpsTraceEndpoints:
             json={"tracing_provider": "langfuse", "tracing_config": {"api_key": "k"}},
         ):
             with pytest.raises(BadRequest):
-                method(
-                    api,
-                    TraceConfigPayload(tracing_provider="langfuse", tracing_config={"api_key": "k"}),
-                    MagicMock(id="app-1"),
-                )
+                method(api, app_model=MagicMock(id="app-1"))
 
     def test_trace_app_config_delete_not_found(self, app: Flask, monkeypatch: pytest.MonkeyPatch):
         api = ops_trace_module.TraceAppConfigApi()
@@ -382,7 +377,7 @@ class TestOpsTraceEndpoints:
 
         with app.test_request_context("/?tracing_provider=langfuse"):
             with pytest.raises(BadRequest):
-                method(api, TraceProviderQuery(tracing_provider="langfuse"), MagicMock(id="app-1"))
+                method(api, app_model=MagicMock(id="app-1"))
 
 
 class TestSiteEndpoints:
@@ -422,13 +417,7 @@ class TestSiteEndpoints:
         site = self._add_site(db.session)
 
         with database_app.test_request_context("/", json={"title": "My Site", "input_placeholder": "Ask me anything"}):
-            result = method(
-                api,
-                AppSiteUpdatePayload(title="My Site", input_placeholder="Ask me anything"),
-                db.session,
-                _make_account(),
-                app_model=_make_app(),
-            )
+            result = method(api, db.session, _make_account(), app_model=_make_app())
 
         db.session.refresh(site)
         assert isinstance(result, dict)
@@ -495,7 +484,7 @@ class TestWorkflowAppLogEndpoints:
         )
 
         with database_app.test_request_context("/?page=1&limit=20"):
-            result = method(api, WorkflowAppLogQuery(page=1, limit=20), app_model=_make_app("app-1"))
+            result = method(api, app_model=_make_app("app-1"))
 
         assert result == {"page": 1, "limit": 20, "total": 0, "has_more": False, "data": []}
 
@@ -525,12 +514,7 @@ class TestWorkflowDraftVariableEndpoints:
         monkeypatch.setattr(workflow_draft_variable_module, "WorkflowService", DummyWorkflowService)
 
         with database_app.test_request_context("/?page=1&limit=20"):
-            result = method(
-                api,
-                WorkflowDraftVariableListQuery(page=1, limit=20),
-                _make_account(),
-                app_model=_make_app("app-1"),
-            )
+            result = method(api, _make_account(), app_model=_make_app("app-1"))
 
         assert result == {"items": [], "total": 0}
 
@@ -583,16 +567,7 @@ class TestWorkflowDraftVariableEndpoints:
                 "deleted_environment_variable_ids": ["env-b"],
             },
         ):
-            result = method(
-                api,
-                EnvironmentVariableUpdatePayload(
-                    environment_variables=[{"id": "env-a", "name": "a", "value_type": "string", "value": "new-a"}],
-                    patch=True,
-                    deleted_environment_variable_ids=["env-b"],
-                ),
-                _make_account(),
-                app_model=_make_app(),
-            )
+            result = method(api, _make_account(), app_model=_make_app())
 
         assert result == {"result": "success"}
         assert [(variable.id, variable.value) for variable in captured["environment_variables"]] == [("env-a", "new-a")]
@@ -638,7 +613,7 @@ class TestWorkflowStatisticEndpoints:
         with database_app.test_request_context("/"):
             account = _make_account()
             account.timezone = "UTC"
-            response = method(api, WorkflowStatisticQuery(), account, app_model=_make_app("app-1", tenant_id="t1"))
+            response = method(api, account, app_model=_make_app("app-1", tenant_id="t1"))
 
         assert response.get_json() == {"data": [{"date": "2024-01-01"}]}
 
@@ -668,7 +643,7 @@ class TestWorkflowStatisticEndpoints:
         with database_app.test_request_context("/"):
             account = _make_account()
             account.timezone = "UTC"
-            response = method(api, WorkflowStatisticQuery(), account, app_model=_make_app("app-1", tenant_id="t1"))
+            response = method(api, account, app_model=_make_app("app-1", tenant_id="t1"))
 
         assert response.get_json() == {"data": [{"date": "2024-01-02"}]}
 
@@ -698,7 +673,7 @@ class TestWorkflowTriggerEndpoints:
         db.session.commit()
 
         with database_app.test_request_context("/?node_id=node-1"):
-            result = method(api, Parser(node_id="node-1"), app_model=_make_app())
+            result = method(api, app_model=_make_app())
 
         assert isinstance(result, dict)
         assert {"id", "webhook_id", "webhook_url", "webhook_debug_url", "node_id", "created_at"} <= set(result.keys())

--- a/api/tests/unit_tests/controllers/console/app/test_app_response_models.py
+++ b/api/tests/unit_tests/controllers/console/app/test_app_response_models.py
@@ -331,19 +331,11 @@ def test_app_list_query_accepts_single_repeated_tag_id(app_module):
     assert query.tag_ids == [tag_id]
 
 
-def test_create_app_endpoint_rejects_agent_mode(app_module, monkeypatch: pytest.MonkeyPatch, unbound_session: Session):
-    payload = {"name": "Iris", "mode": "agent", "description": "Agent app"}
-    app_service = MagicMock()
-    monkeypatch.setattr(app_module, "AppService", lambda: app_service)
-
-    app_module.console_ns.payload = payload
-    try:
-        with pytest.raises(ValidationError):
-            _unwrap(app_module.AppListApi().post)(unbound_session, "tenant-1", SimpleNamespace(id="account-1"))
-    finally:
-        app_module.console_ns.payload = None
-
-    app_service.create_app.assert_not_called()
+def test_create_app_endpoint_rejects_agent_mode(app_module):
+    with pytest.raises(ValidationError):
+        app_module.CreateAppPayload.model_validate(
+            {"name": "Iris", "mode": "agent", "description": "Agent app"}
+        )
 
 
 def test_app_partial_serialization_uses_aliases(app_models):
@@ -650,7 +642,17 @@ def test_app_create_api_attaches_permission_keys(app, app_module, unbound_sessio
                 replace_whitelist,
             )
 
-            resp, status = method(app_module.AppListApi(), unbound_session, "tenant-1", SimpleNamespace(id="acct-1"))
+            resp, status = method(
+                app_module.AppListApi(),
+                app_module.CreateAppPayload(
+                    name="Created App",
+                    description="Summary",
+                    mode="advanced-chat",
+                ),
+                unbound_session,
+                "tenant-1",
+                SimpleNamespace(id="acct-1"),
+            )
 
     assert status == 201
     assert resp["permission_keys"] == ["app.acl.view_layout", "app.acl.edit"]
@@ -1076,6 +1078,7 @@ def test_app_copy_api_attaches_permission_keys(app, app_module, sqlite_session: 
 
             resp, status = method(
                 app_module.AppCopyApi(),
+                app_module.CopyAppPayload(),
                 "tenant-1",
                 SimpleNamespace(id="acct-1"),
                 app_model=SimpleNamespace(id="app-original"),

--- a/api/tests/unit_tests/controllers/console/app/test_app_response_models.py
+++ b/api/tests/unit_tests/controllers/console/app/test_app_response_models.py
@@ -333,9 +333,7 @@ def test_app_list_query_accepts_single_repeated_tag_id(app_module):
 
 def test_create_app_endpoint_rejects_agent_mode(app_module):
     with pytest.raises(ValidationError):
-        app_module.CreateAppPayload.model_validate(
-            {"name": "Iris", "mode": "agent", "description": "Agent app"}
-        )
+        app_module.CreateAppPayload.model_validate({"name": "Iris", "mode": "agent", "description": "Agent app"})
 
 
 def test_app_partial_serialization_uses_aliases(app_models):

--- a/api/tests/unit_tests/controllers/console/app/test_conversation_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_conversation_api.py
@@ -58,7 +58,13 @@ def test_completion_conversation_list_returns_paginated_result(
     paginate_result.items = []
     monkeypatch.setattr(conversation_module, "paginate_query", lambda *_args, **_kwargs: paginate_result)
     with app.test_request_context("/console/api/apps/app-1/completion-conversations", method="GET"):
-        response = method(api, unbound_session, account, app_model=SimpleNamespace(id="app-1"))
+        response = method(
+            api,
+            conversation_module.CompletionConversationQuery(),
+            unbound_session,
+            account,
+            app_model=SimpleNamespace(id="app-1"),
+        )
     assert response == {"page": 1, "limit": 20, "total": 0, "has_more": False, "data": []}
 
 
@@ -77,7 +83,13 @@ def test_completion_conversation_list_invalid_time_range(
         "/console/api/apps/app-1/completion-conversations", method="GET", query_string={"start": "bad"}
     ):
         with pytest.raises(BadRequest):
-            method(api, unbound_session, account, app_model=SimpleNamespace(id="app-1"))
+            method(
+                api,
+                conversation_module.CompletionConversationQuery(),
+                unbound_session,
+                account,
+                app_model=SimpleNamespace(id="app-1"),
+            )
 
 
 def test_chat_conversation_list_advanced_chat_calls_paginate(
@@ -96,7 +108,11 @@ def test_chat_conversation_list_advanced_chat_calls_paginate(
     monkeypatch.setattr(conversation_module, "paginate_query", lambda *_args, **_kwargs: paginate_result)
     with app.test_request_context("/console/api/apps/app-1/chat-conversations", method="GET"):
         response = method(
-            api, unbound_session, account, app_model=SimpleNamespace(id="app-1", mode=AppMode.ADVANCED_CHAT)
+            api,
+            conversation_module.ChatConversationQuery(),
+            unbound_session,
+            account,
+            app_model=SimpleNamespace(id="app-1", mode=AppMode.ADVANCED_CHAT),
         )
     assert response == {"page": 1, "limit": 20, "total": 0, "has_more": False, "data": []}
 

--- a/api/tests/unit_tests/controllers/console/app/test_generator_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_generator_api.py
@@ -6,11 +6,19 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
-from flask import Flask
+from flask import Flask, request
 from sqlalchemy.orm import Session
 
 from controllers.console.app import generator as generator_module
 from controllers.console.app.error import ProviderNotInitializeError
+from controllers.console.app.generator import (
+    InstructionGeneratePayload,
+    InstructionTemplatePayload,
+    RuleCodeGeneratePayload,
+    RuleGeneratePayload,
+    WorkflowGeneratePayload,
+    WorkflowInstructionSuggestionsPayload,
+)
 from core.errors.error import ProviderTokenNotInitError
 from models.model import App, AppMode
 
@@ -61,7 +69,7 @@ def test_rule_generate_success(app: Flask, monkeypatch: pytest.MonkeyPatch) -> N
         method="POST",
         json={"instruction": "do it", "model_config": _model_config_payload()},
     ):
-        response = method(api, "t1")
+        response = method(api, RuleGeneratePayload.model_validate(request.get_json()), "t1")
 
     assert response == {"rules": []}
 
@@ -81,7 +89,7 @@ def test_rule_code_generate_maps_token_error(app: Flask, monkeypatch: pytest.Mon
         json={"instruction": "do it", "model_config": _model_config_payload()},
     ):
         with pytest.raises(ProviderNotInitializeError):
-            method(api, "t1")
+            method(api, RuleCodeGeneratePayload.model_validate(request.get_json()), "t1")
 
 
 @pytest.mark.parametrize("sqlite_session", [(App,)], indirect=True)
@@ -100,7 +108,9 @@ def test_instruction_generate_app_not_found(app: Flask, sqlite_session: Session)
             "model_config": _model_config_payload(),
         },
     ):
-        response, status = method(api, sqlite_session, "t1")
+        response, status = method(
+            api, InstructionGeneratePayload.model_validate(request.get_json()), sqlite_session, "t1"
+        )
 
     assert status == 400
     assert response["error"] == "app app-1 not found"
@@ -127,7 +137,9 @@ def test_instruction_generate_workflow_not_found(
             "model_config": _model_config_payload(),
         },
     ):
-        response, status = method(api, sqlite_session, "t1")
+        response, status = method(
+            api, InstructionGeneratePayload.model_validate(request.get_json()), sqlite_session, "t1"
+        )
 
     assert status == 400
     assert response["error"] == "workflow app-1 not found"
@@ -155,7 +167,9 @@ def test_instruction_generate_node_missing(
             "model_config": _model_config_payload(),
         },
     ):
-        response, status = method(api, sqlite_session, "t1")
+        response, status = method(
+            api, InstructionGeneratePayload.model_validate(request.get_json()), sqlite_session, "t1"
+        )
 
     assert status == 400
     assert response["error"] == "node node-1 not found"
@@ -188,7 +202,7 @@ def test_instruction_generate_code_node(app: Flask, monkeypatch: pytest.MonkeyPa
             "model_config": _model_config_payload(),
         },
     ):
-        response = method(api, sqlite_session, "t1")
+        response = method(api, InstructionGeneratePayload.model_validate(request.get_json()), sqlite_session, "t1")
 
     assert response == {"code": "x"}
     assert workflow_service.app_model is app_model
@@ -218,7 +232,7 @@ def test_instruction_generate_legacy_modify(
             "model_config": _model_config_payload(),
         },
     ):
-        response = method(api, sqlite_session, "t1")
+        response = method(api, InstructionGeneratePayload.model_validate(request.get_json()), sqlite_session, "t1")
 
     assert response == {"instruction": "ok"}
 
@@ -238,7 +252,9 @@ def test_instruction_generate_incompatible_params(app: Flask, sqlite_session: Se
             "model_config": _model_config_payload(),
         },
     ):
-        response, status = method(api, sqlite_session, "t1")
+        response, status = method(
+            api, InstructionGeneratePayload.model_validate(request.get_json()), sqlite_session, "t1"
+        )
 
     assert status == 400
     assert response["error"] == "incompatible parameters"
@@ -253,7 +269,7 @@ def test_instruction_template_prompt(app: Flask) -> None:
         method="POST",
         json={"type": "prompt"},
     ):
-        response = method(api)
+        response = method(api, InstructionTemplatePayload.model_validate(request.get_json()))
 
     assert "data" in response
 
@@ -268,7 +284,7 @@ def test_instruction_template_invalid_type(app: Flask) -> None:
         json={"type": "unknown"},
     ):
         with pytest.raises(ValueError):
-            method(api)
+            method(api, InstructionTemplatePayload.model_validate(request.get_json()))
 
 
 # ─ /workflow-generate ─────────────────────────────────────────────────────────
@@ -331,7 +347,7 @@ def test_workflow_generate_returns_service_result(app: Flask, monkeypatch: pytes
         method="POST",
         json=_workflow_generate_payload(),
     ):
-        response = method(api, "t1")
+        response = method(api, WorkflowGeneratePayload.model_validate(request.get_json()), "t1")
 
     assert response == expected
 
@@ -361,7 +377,7 @@ def test_workflow_generate_maps_provider_token_error(app: Flask, monkeypatch: py
         json=_workflow_generate_payload(),
     ):
         with pytest.raises(ProviderNotInitializeError):
-            method(api, "t1")
+            method(api, WorkflowGeneratePayload.model_validate(request.get_json()), "t1")
 
 
 def test_workflow_generate_maps_quota_error(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -379,7 +395,7 @@ def test_workflow_generate_maps_quota_error(app: Flask, monkeypatch: pytest.Monk
         json=_workflow_generate_payload(),
     ):
         with pytest.raises(ProviderQuotaExceededError):
-            method(api, "t1")
+            method(api, WorkflowGeneratePayload.model_validate(request.get_json()), "t1")
 
 
 def test_workflow_generate_maps_model_not_support_error(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -397,7 +413,7 @@ def test_workflow_generate_maps_model_not_support_error(app: Flask, monkeypatch:
         json=_workflow_generate_payload(),
     ):
         with pytest.raises(ProviderModelCurrentlyNotSupportError):
-            method(api, "t1")
+            method(api, WorkflowGeneratePayload.model_validate(request.get_json()), "t1")
 
 
 def test_workflow_generate_maps_invoke_error(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -415,7 +431,7 @@ def test_workflow_generate_maps_invoke_error(app: Flask, monkeypatch: pytest.Mon
         json=_workflow_generate_payload(),
     ):
         with pytest.raises(CompletionRequestError):
-            method(api, "t1")
+            method(api, WorkflowGeneratePayload.model_validate(request.get_json()), "t1")
 
 
 def test_workflow_generate_accepts_advanced_chat_mode(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -442,7 +458,7 @@ def test_workflow_generate_accepts_advanced_chat_mode(app: Flask, monkeypatch: p
         method="POST",
         json=payload,
     ):
-        method(api, "t1")
+        method(api, WorkflowGeneratePayload.model_validate(request.get_json()), "t1")
 
     assert captured["mode"] == "advanced-chat"
     assert captured["instruction"] == "Summarize a URL"
@@ -474,7 +490,7 @@ def test_workflow_generate_forwards_current_graph_for_refine(app: Flask, monkeyp
         method="POST",
         json=payload,
     ):
-        method(api, "t1")
+        method(api, WorkflowGeneratePayload.model_validate(request.get_json()), "t1")
 
     assert captured["current_graph"] == graph
 
@@ -501,7 +517,7 @@ def test_workflow_generate_current_graph_defaults_to_none(app: Flask, monkeypatc
         method="POST",
         json=_workflow_generate_payload(),
     ):
-        method(api, "t1")
+        method(api, WorkflowGeneratePayload.model_validate(request.get_json()), "t1")
 
     assert captured["current_graph"] is None
 
@@ -528,7 +544,7 @@ def test_workflow_generate_accepts_auto_mode(app: Flask, monkeypatch: pytest.Mon
     payload = _workflow_generate_payload()
     payload["mode"] = "auto"
     with app.test_request_context("/console/api/workflow-generate", method="POST", json=payload):
-        response = method(api, "t1")
+        response = method(api, WorkflowGeneratePayload.model_validate(request.get_json()), "t1")
 
     assert captured["mode"] == "auto"
     assert response["mode"] == "advanced-chat"
@@ -608,7 +624,7 @@ def test_workflow_instruction_suggestions_route_returns_list(app: Flask, monkeyp
         method="POST",
         json={"mode": "workflow", "language": "French", "count": 3},
     ):
-        response = method(api, "t1")
+        response = method(api, WorkflowInstructionSuggestionsPayload.model_validate(request.get_json()), "t1")
 
     assert response == {"suggestions": ["Summarize a URL", "Translate text"]}
     assert captured["mode"] == "workflow"
@@ -632,7 +648,7 @@ def test_workflow_instruction_suggestions_route_empty_is_valid_200(app: Flask, m
         method="POST",
         json={"mode": "advanced-chat"},
     ):
-        response = method(api, "t1")
+        response = method(api, WorkflowInstructionSuggestionsPayload.model_validate(request.get_json()), "t1")
 
     assert response == {"suggestions": []}
 
@@ -667,7 +683,7 @@ def test_workflow_generate_stream_emits_plan_then_result(app: Flask, monkeypatch
         method="POST",
         json=_workflow_generate_payload(),
     ):
-        response = method(api, "t1")
+        response = method(api, WorkflowGeneratePayload.model_validate(request.get_json()), "t1")
         assert response.mimetype == "text/event-stream"
         frames = _read_sse_frames(response)
 
@@ -694,7 +710,7 @@ def test_workflow_generate_stream_provider_error_emits_result_event(
         method="POST",
         json=_workflow_generate_payload(),
     ):
-        response = method(api, "t1")
+        response = method(api, WorkflowGeneratePayload.model_validate(request.get_json()), "t1")
         frames = _read_sse_frames(response)
 
     assert len(frames) == 1
@@ -711,7 +727,7 @@ def test_workflow_generate_stream_rejects_empty_instruction(app: Flask, monkeypa
     payload = _workflow_generate_payload()
     payload["instruction"] = "   "
     with app.test_request_context("/console/api/workflow-generate/stream", method="POST", json=payload):
-        response, status = method(api, "t1")
+        response, status = method(api, WorkflowGeneratePayload.model_validate(request.get_json()), "t1")
 
     assert status == 400
     assert response["errors"][0]["code"] == "EMPTY_INSTRUCTION"

--- a/api/tests/unit_tests/controllers/console/app/test_generator_api_missing.py
+++ b/api/tests/unit_tests/controllers/console/app/test_generator_api_missing.py
@@ -1,8 +1,14 @@
 import pytest
-from flask import Flask
+from flask import Flask, request
 from sqlalchemy.orm import Session
 
 from controllers.console.app import generator as generator_module
+from controllers.console.app.generator import (
+    InstructionGeneratePayload,
+    RuleCodeGeneratePayload,
+    RuleGeneratePayload,
+    RuleStructuredOutputPayload,
+)
 from core.errors.error import ModelCurrentlyNotSupportError, ProviderTokenNotInitError, QuotaExceededError
 from graphon.model_runtime.errors.invoke import InvokeError
 
@@ -47,7 +53,7 @@ def test_rule_generate_exceptions(app: Flask, monkeypatch: pytest.MonkeyPatch) -
             json={"instruction": "do it", "model_config": _model_config_payload()},
         ):
             with pytest.raises(expected_exception):
-                method(api, "t1")
+                method(api, RuleGeneratePayload.model_validate(request.get_json()), "t1")
 
 
 def test_rule_code_generate_exceptions(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -73,7 +79,7 @@ def test_rule_code_generate_exceptions(app: Flask, monkeypatch: pytest.MonkeyPat
             json={"instruction": "do it", "model_config": _model_config_payload()},
         ):
             with pytest.raises(expected_exception):
-                method(api, "t1")
+                method(api, RuleCodeGeneratePayload.model_validate(request.get_json()), "t1")
 
 
 def test_structured_output_generate_exceptions(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -100,7 +106,7 @@ def test_structured_output_generate_exceptions(app: Flask, monkeypatch: pytest.M
             json={"instruction": "do it", "model_config": _model_config_payload()},
         ):
             with pytest.raises(expected_exception):
-                method(api, "t1")
+                method(api, RuleStructuredOutputPayload.model_validate(request.get_json()), "t1")
 
 
 @pytest.mark.parametrize("sqlite_session", [()], indirect=True)
@@ -138,4 +144,4 @@ def test_instruction_generate_exceptions(
             },
         ):
             with pytest.raises(expected_exception):
-                method(api, sqlite_session, "t1")
+                method(api, InstructionGeneratePayload.model_validate(request.get_json()), sqlite_session, "t1")


### PR DESCRIPTION
Replace manual model_validate(request.get_json()) calls with the @model_validate decorator in app core controller files.