### PR TITLE
refactor: replace manual model_validate with @model_validate in rag_pipeline controllers

### DIFF
--- a/api/controllers/console/datasets/rag_pipeline/datasource_auth.py
+++ b/api/controllers/console/datasets/rag_pipeline/datasource_auth.py
@@ -14,6 +14,7 @@ from controllers.console.wraps import (
     RBACResourceScope,
     account_initialization_required,
     edit_permission_required,
+    model_validate,
     rbac_permission_required,
     setup_required,
     with_current_tenant_id,
@@ -275,8 +276,8 @@ class DatasourceAuth(Resource):
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.CREDENTIAL_CREATE, resource_required=False)
     @with_current_tenant_id
-    def post(self, current_tenant_id: str, provider_id: str):
-        payload = DatasourceCredentialPayload.model_validate(console_ns.payload or {})
+    @model_validate(DatasourceCredentialPayload)
+    def post(self, req_data: DatasourceCredentialPayload, current_tenant_id: str, provider_id: str):
         datasource_provider_id = DatasourceProviderID(provider_id)
         datasource_provider_service = DatasourceProviderService()
 
@@ -284,8 +285,8 @@ class DatasourceAuth(Resource):
             datasource_provider_service.add_datasource_api_key_provider(
                 tenant_id=current_tenant_id,
                 provider_id=datasource_provider_id,
-                credentials=payload.credentials,
-                name=payload.name,
+                credentials=req_data.credentials,
+                name=req_data.name,
             )
         except CredentialsValidateFailedError as ex:
             raise ValueError(str(ex))
@@ -325,16 +326,16 @@ class DatasourceAuthDeleteApi(Resource):
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)
     @with_current_tenant_id
-    def post(self, current_tenant_id: str, provider_id: str):
+    @model_validate(DatasourceCredentialDeletePayload)
+    def post(self, req_data: DatasourceCredentialDeletePayload, current_tenant_id: str, provider_id: str):
         datasource_provider_id = DatasourceProviderID(provider_id)
         plugin_id = datasource_provider_id.plugin_id
         provider_name = datasource_provider_id.provider_name
 
-        payload = DatasourceCredentialDeletePayload.model_validate(console_ns.payload or {})
         datasource_provider_service = DatasourceProviderService()
         datasource_provider_service.remove_datasource_credentials(
             tenant_id=current_tenant_id,
-            auth_id=payload.credential_id,
+            auth_id=req_data.credential_id,
             provider=provider_name,
             plugin_id=plugin_id,
             session=db.session(),
@@ -354,18 +355,18 @@ class DatasourceAuthUpdateApi(Resource):
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)
     @with_current_tenant_id
-    def post(self, current_tenant_id: str, provider_id: str):
+    @model_validate(DatasourceCredentialUpdatePayload)
+    def post(self, req_data: DatasourceCredentialUpdatePayload, current_tenant_id: str, provider_id: str):
         datasource_provider_id = DatasourceProviderID(provider_id)
-        payload = DatasourceCredentialUpdatePayload.model_validate(console_ns.payload or {})
 
         datasource_provider_service = DatasourceProviderService()
         datasource_provider_service.update_datasource_credentials(
             tenant_id=current_tenant_id,
-            auth_id=payload.credential_id,
+            auth_id=req_data.credential_id,
             provider=datasource_provider_id.provider_name,
             plugin_id=datasource_provider_id.plugin_id,
-            credentials=payload.credentials or {},
-            name=payload.name,
+            credentials=req_data.credentials or {},
+            name=req_data.name,
         )
         return SimpleResultResponse(result="success").model_dump(mode="json"), 201
 
@@ -420,15 +421,15 @@ class DatasourceAuthOauthCustomClient(Resource):
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)
     @with_current_tenant_id
-    def post(self, current_tenant_id: str, provider_id: str):
-        payload = DatasourceCustomClientPayload.model_validate(console_ns.payload or {})
+    @model_validate(DatasourceCustomClientPayload)
+    def post(self, req_data: DatasourceCustomClientPayload, current_tenant_id: str, provider_id: str):
         datasource_provider_id = DatasourceProviderID(provider_id)
         datasource_provider_service = DatasourceProviderService()
         datasource_provider_service.setup_oauth_custom_client_params(
             tenant_id=current_tenant_id,
             datasource_provider_id=datasource_provider_id,
-            client_params=payload.client_params or {},
-            enabled=payload.enable_oauth_custom_client or False,
+            client_params=req_data.client_params or {},
+            enabled=req_data.enable_oauth_custom_client or False,
         )
         return SimpleResultResponse(result="success").model_dump(mode="json"), 200
 
@@ -457,14 +458,14 @@ class DatasourceAuthDefaultApi(Resource):
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)
     @with_current_tenant_id
-    def post(self, current_tenant_id: str, provider_id: str):
-        payload = DatasourceDefaultPayload.model_validate(console_ns.payload or {})
+    @model_validate(DatasourceDefaultPayload)
+    def post(self, req_data: DatasourceDefaultPayload, current_tenant_id: str, provider_id: str):
         datasource_provider_id = DatasourceProviderID(provider_id)
         datasource_provider_service = DatasourceProviderService()
         datasource_provider_service.set_default_datasource_provider(
             tenant_id=current_tenant_id,
             datasource_provider_id=datasource_provider_id,
-            credential_id=payload.id,
+            credential_id=req_data.id,
         )
         return SimpleResultResponse(result="success").model_dump(mode="json"), 200
 
@@ -479,14 +480,14 @@ class DatasourceUpdateProviderNameApi(Resource):
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.CREDENTIAL_MANAGE, resource_required=False)
     @with_current_tenant_id
-    def post(self, current_tenant_id: str, provider_id: str):
-        payload = DatasourceUpdateNamePayload.model_validate(console_ns.payload or {})
+    @model_validate(DatasourceUpdateNamePayload)
+    def post(self, req_data: DatasourceUpdateNamePayload, current_tenant_id: str, provider_id: str):
         datasource_provider_id = DatasourceProviderID(provider_id)
         datasource_provider_service = DatasourceProviderService()
         datasource_provider_service.update_datasource_provider_name(
             tenant_id=current_tenant_id,
             datasource_provider_id=datasource_provider_id,
-            name=payload.name,
-            credential_id=payload.credential_id,
+            name=req_data.name,
+            credential_id=req_data.credential_id,
         )
         return SimpleResultResponse(result="success").model_dump(mode="json"), 200

--- a/api/controllers/console/datasets/rag_pipeline/datasource_content_preview.py
+++ b/api/controllers/console/datasets/rag_pipeline/datasource_content_preview.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from controllers.common.schema import register_schema_models
 from controllers.console import console_ns
 from controllers.console.datasets.wraps import get_rag_pipeline
-from controllers.console.wraps import account_initialization_required, setup_required, with_current_user
+from controllers.console.wraps import account_initialization_required, model_validate, setup_required, with_current_user
 from extensions.ext_database import db
 from libs.login import login_required
 from models import Account
@@ -34,14 +34,14 @@ class DataSourceContentPreviewApi(Resource):
     @account_initialization_required
     @get_rag_pipeline
     @with_current_user
-    def post(self, current_user: Account, pipeline: Pipeline, node_id: str):
+    @model_validate(Parser)
+    def post(self, req_data: Parser, current_user: Account, pipeline: Pipeline, node_id: str):
         """
         Run datasource content preview
         """
-        args = Parser.model_validate(console_ns.payload)
 
-        inputs = args.inputs
-        datasource_type = args.datasource_type
+        inputs = req_data.inputs
+        datasource_type = req_data.datasource_type
         rag_pipeline_service = RagPipelineService(db.session())
         preview_content = rag_pipeline_service.run_datasource_node_preview(
             pipeline=pipeline,
@@ -50,6 +50,6 @@ class DataSourceContentPreviewApi(Resource):
             account=current_user,
             datasource_type=datasource_type,
             is_published=True,
-            credential_id=args.credential_id,
+            credential_id=req_data.credential_id,
         )
         return preview_content, 200

--- a/api/controllers/console/datasets/rag_pipeline/rag_pipeline.py
+++ b/api/controllers/console/datasets/rag_pipeline/rag_pipeline.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Any
 
-from flask import request
 from flask_restx import Resource
 from pydantic import BaseModel, Field
 from sqlalchemy import select
@@ -21,6 +20,7 @@ from controllers.console.wraps import (
     account_initialization_required,
     enterprise_license_required,
     knowledge_pipeline_publish_enabled,
+    model_validate,
     setup_required,
     with_current_tenant_id,
     with_current_user,
@@ -104,12 +104,17 @@ class PipelineTemplateListApi(Resource):
     @enterprise_license_required
     @with_current_tenant_id
     @with_session
-    def get(self, session: Session, current_tenant_id: str) -> JsonResponseWithStatus:
-        query = PipelineTemplateListQuery.model_validate(request.args.to_dict(flat=True))
+    @model_validate(PipelineTemplateListQuery)
+    def get(
+        self,
+        req_data: PipelineTemplateListQuery,
+        session: Session,
+        current_tenant_id: str,
+    ) -> JsonResponseWithStatus:
         # get pipeline templates
         pipeline_templates = RagPipelineService.get_pipeline_templates(
-            type=query.type,
-            language=query.language,
+            type=req_data.type,
+            language=req_data.language,
             current_tenant_id=current_tenant_id,
             session=session,
         )
@@ -125,11 +130,11 @@ class PipelineTemplateDetailApi(Resource):
     @account_initialization_required
     @enterprise_license_required
     @with_session
-    def get(self, session: Session, template_id: str) -> JsonResponseWithStatus:
-        query = PipelineTemplateDetailQuery.model_validate(request.args.to_dict(flat=True))
+    @model_validate(PipelineTemplateDetailQuery)
+    def get(self, req_data: PipelineTemplateDetailQuery, session: Session, template_id: str) -> JsonResponseWithStatus:
         pipeline_template = RagPipelineService.get_pipeline_template_detail(
             template_id,
-            type=query.type,
+            type=req_data.type,
             session=session,
         )
         if pipeline_template is None:
@@ -147,9 +152,15 @@ class CustomizedPipelineTemplateApi(Resource):
     @enterprise_license_required
     @with_current_user
     @with_current_tenant_id
-    def patch(self, current_tenant_id: str, current_user: Account, template_id: str) -> tuple[str, int]:
-        payload = CustomizedPipelineTemplatePayload.model_validate(console_ns.payload or {})
-        pipeline_template_info = PipelineTemplateInfoEntity.model_validate(payload.model_dump())
+    @model_validate(CustomizedPipelineTemplatePayload)
+    def patch(
+        self,
+        req_data: CustomizedPipelineTemplatePayload,
+        current_tenant_id: str,
+        current_user: Account,
+        template_id: str,
+    ) -> tuple[str, int]:
+        pipeline_template_info = PipelineTemplateInfoEntity.model_validate(req_data.model_dump())
         RagPipelineService.update_customized_pipeline_template(
             template_id, pipeline_template_info, current_user, current_tenant_id, session=db.session()
         )
@@ -192,10 +203,16 @@ class PublishCustomizedPipelineTemplateApi(Resource):
     @knowledge_pipeline_publish_enabled
     @with_current_user
     @with_current_tenant_id
-    def post(self, current_tenant_id: str, current_user: Account, pipeline_id: str) -> tuple[str, int]:
-        payload = CustomizedPipelineTemplatePayload.model_validate(console_ns.payload or {})
+    @model_validate(CustomizedPipelineTemplatePayload)
+    def post(
+        self,
+        req_data: CustomizedPipelineTemplatePayload,
+        current_tenant_id: str,
+        current_user: Account,
+        pipeline_id: str,
+    ) -> tuple[str, int]:
         rag_pipeline_service = RagPipelineService(db.session())
         rag_pipeline_service.publish_customized_pipeline_template(
-            pipeline_id, payload.model_dump(), current_user, current_tenant_id, session=db.session()
+            pipeline_id, req_data.model_dump(), current_user, current_tenant_id, session=db.session()
         )
         return "", 204

--- a/api/controllers/console/datasets/rag_pipeline/rag_pipeline_datasets.py
+++ b/api/controllers/console/datasets/rag_pipeline/rag_pipeline_datasets.py
@@ -10,6 +10,7 @@ from controllers.console.datasets.rag_pipeline.rag_pipeline_import import RagPip
 from controllers.console.wraps import (
     account_initialization_required,
     cloud_edition_billing_rate_limit_check,
+    model_validate,
     setup_required,
     with_current_tenant_id,
     with_current_user,
@@ -47,8 +48,13 @@ class CreateRagPipelineDatasetApi(Resource):
     @cloud_edition_billing_rate_limit_check("knowledge")
     @with_current_user
     @with_current_tenant_id
-    def post(self, current_tenant_id: str, current_user: Account) -> JsonResponseWithStatus:
-        payload = RagPipelineDatasetImportPayload.model_validate(console_ns.payload or {})
+    @model_validate(RagPipelineDatasetImportPayload)
+    def post(
+        self,
+        req_data: RagPipelineDatasetImportPayload,
+        current_tenant_id: str,
+        current_user: Account,
+    ) -> JsonResponseWithStatus:
         # The role of the current user in the ta table must be admin, owner, or editor, or dataset_operator
         if not current_user.is_dataset_editor:
             raise Forbidden()
@@ -62,7 +68,7 @@ class CreateRagPipelineDatasetApi(Resource):
             ),
             permission=DatasetPermissionEnum.ONLY_ME,
             partial_member_list=None,
-            yaml_content=payload.yaml_content,
+            yaml_content=req_data.yaml_content,
         )
         try:
             rag_pipeline_dsl_service = RagPipelineDslService(db.session())

--- a/api/controllers/console/datasets/rag_pipeline/rag_pipeline_draft_variable.py
+++ b/api/controllers/console/datasets/rag_pipeline/rag_pipeline_draft_variable.py
@@ -4,7 +4,7 @@ from functools import wraps
 from typing import Any, Concatenate, NoReturn
 from uuid import UUID
 
-from flask import Response, request
+from flask import Response
 from flask_restx import Resource, marshal, marshal_with
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import sessionmaker
@@ -24,7 +24,7 @@ from controllers.console.app.workflow_draft_variable import (
     workflow_draft_variable_model,
 )
 from controllers.console.datasets.wraps import get_rag_pipeline
-from controllers.console.wraps import account_initialization_required, setup_required, with_current_user
+from controllers.console.wraps import account_initialization_required, model_validate, setup_required, with_current_user
 from core.app.file_access import DatabaseFileAccessController
 from core.workflow.llm_environment_variable import LLMEnvironmentVariable, environment_variable_value_type
 from core.workflow.variable_prefixes import CONVERSATION_VARIABLE_NODE_ID, SYSTEM_VARIABLE_NODE_ID
@@ -92,11 +92,11 @@ class RagPipelineVariableCollectionApi(Resource):
     )
     @_api_prerequisite
     @marshal_with(workflow_draft_variable_list_without_value_model)
-    def get(self, current_user: Account, pipeline: Pipeline):
+    @model_validate(PaginationQuery)
+    def get(self, req_data: PaginationQuery, current_user: Account, pipeline: Pipeline):
         """
         Get draft workflow
         """
-        query = PaginationQuery.model_validate(request.args.to_dict())
 
         # fetch draft workflow by app_model
         rag_pipeline_service = RagPipelineService(db.session())
@@ -111,8 +111,8 @@ class RagPipelineVariableCollectionApi(Resource):
             )
         workflow_vars = draft_var_srv.list_variables_without_values(
             app_id=pipeline.id,
-            page=query.page,
-            limit=query.limit,
+            page=req_data.page,
+            limit=req_data.limit,
             user_id=current_user.id,
         )
 
@@ -196,7 +196,14 @@ class RagPipelineVariableApi(Resource):
     @_api_prerequisite
     @marshal_with(workflow_draft_variable_model)
     @console_ns.expect(console_ns.models[WorkflowDraftVariablePatchPayload.__name__])
-    def patch(self, _current_user: Account, pipeline: Pipeline, variable_id: UUID):
+    @model_validate(WorkflowDraftVariablePatchPayload)
+    def patch(
+        self,
+        req_data: WorkflowDraftVariablePatchPayload,
+        _current_user: Account,
+        pipeline: Pipeline,
+        variable_id: UUID,
+    ):
         # Request payload for file types:
         #
         # Local File:
@@ -221,8 +228,7 @@ class RagPipelineVariableApi(Resource):
         draft_var_srv = WorkflowDraftVariableService(
             session=db.session(),
         )
-        payload = WorkflowDraftVariablePatchPayload.model_validate(console_ns.payload or {})
-        args = payload.model_dump(exclude_none=True)
+        args = req_data.model_dump(exclude_none=True)
 
         variable_id_str = str(variable_id)
         variable = draft_var_srv.get_variable(variable_id=variable_id_str)

--- a/api/controllers/console/datasets/rag_pipeline/rag_pipeline_import.py
+++ b/api/controllers/console/datasets/rag_pipeline/rag_pipeline_import.py
@@ -1,4 +1,3 @@
-from flask import request
 from flask_restx import Resource
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
@@ -17,6 +16,7 @@ from controllers.console.wraps import (
     RBACResourceScope,
     account_initialization_required,
     edit_permission_required,
+    model_validate,
     rbac_permission_required,
     setup_required,
     with_current_user,
@@ -85,9 +85,9 @@ class RagPipelineImportApi(Resource):
         RBACResourceScope.DATASET, RBACPermission.DATASET_CREATE_AND_MANAGEMENT, resource_required=False
     )
     @with_current_user
-    def post(self, current_user: Account) -> JsonResponseWithStatus:
+    @model_validate(RagPipelineImportPayload)
+    def post(self, req_data: RagPipelineImportPayload, current_user: Account) -> JsonResponseWithStatus:
         # Check user role first
-        payload = RagPipelineImportPayload.model_validate(console_ns.payload or {})
 
         # Use a plain Session so that caught exceptions inside the service
         # (which return FAILED status instead of re-raising) do not leave the
@@ -98,11 +98,11 @@ class RagPipelineImportApi(Resource):
             account = current_user
             result = import_service.import_rag_pipeline(
                 account=account,
-                import_mode=payload.mode,
-                yaml_content=payload.yaml_content,
-                yaml_url=payload.yaml_url,
-                pipeline_id=payload.pipeline_id,
-                dataset_name=payload.name,
+                import_mode=req_data.mode,
+                yaml_content=req_data.yaml_content,
+                yaml_url=req_data.yaml_url,
+                pipeline_id=req_data.pipeline_id,
+                dataset_name=req_data.name,
             )
             if result.status == ImportStatus.FAILED:
                 session.rollback()
@@ -179,14 +179,14 @@ class RagPipelineExportApi(Resource):
     @account_initialization_required
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_IMPORT_EXPORT_DSL)
-    def get(self, pipeline: Pipeline) -> JsonResponseWithStatus:
+    @model_validate(IncludeSecretQuery)
+    def get(self, req_data: IncludeSecretQuery, pipeline: Pipeline) -> JsonResponseWithStatus:
         # Add include_secret params
-        query = IncludeSecretQuery.model_validate(request.args.to_dict())
 
         with Session(db.engine, expire_on_commit=False) as session:
             export_service = RagPipelineDslService(session)
             result = export_service.export_rag_pipeline_dsl(
-                pipeline=pipeline, include_secret=query.include_secret == "true"
+                pipeline=pipeline, include_secret=req_data.include_secret == "true"
             )
 
         return dump_response(SimpleDataResponse, {"data": result}), 200

--- a/api/controllers/console/datasets/rag_pipeline/rag_pipeline_workflow.py
+++ b/api/controllers/console/datasets/rag_pipeline/rag_pipeline_workflow.py
@@ -33,6 +33,7 @@ from controllers.console.wraps import (
     RBACResourceScope,
     account_initialization_required,
     edit_permission_required,
+    model_validate,
     rbac_permission_required,
     setup_required,
     with_current_tenant_id,
@@ -274,12 +275,12 @@ class RagPipelineDraftRunIterationNodeApi(Resource):
     @get_rag_pipeline
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_EDIT)
-    def post(self, current_user: Account, pipeline: Pipeline, node_id: str):
+    @model_validate(NodeRunPayload)
+    def post(self, req_data: NodeRunPayload, current_user: Account, pipeline: Pipeline, node_id: str):
         """
         Run draft workflow iteration node
         """
-        payload = NodeRunPayload.model_validate(console_ns.payload or {})
-        args = payload.model_dump(exclude_none=True)
+        args = req_data.model_dump(exclude_none=True)
 
         try:
             response = PipelineGenerateService.generate_single_iteration(
@@ -309,12 +310,12 @@ class RagPipelineDraftRunLoopNodeApi(Resource):
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_EDIT)
     @with_current_user
     @get_rag_pipeline
-    def post(self, current_user: Account, pipeline: Pipeline, node_id: str):
+    @model_validate(NodeRunPayload)
+    def post(self, req_data: NodeRunPayload, current_user: Account, pipeline: Pipeline, node_id: str):
         """
         Run draft workflow loop node
         """
-        payload = NodeRunPayload.model_validate(console_ns.payload or {})
-        args = payload.model_dump(exclude_none=True)
+        args = req_data.model_dump(exclude_none=True)
 
         try:
             response = PipelineGenerateService.generate_single_loop(
@@ -344,13 +345,13 @@ class DraftRagPipelineRunApi(Resource):
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_EDIT)
     @with_current_user
     @with_session
-    def post(self, session: Session, current_user: Account, pipeline_id: UUID):
+    @model_validate(DraftWorkflowRunPayload)
+    def post(self, req_data: DraftWorkflowRunPayload, session: Session, current_user: Account, pipeline_id: UUID):
         """
         Run draft workflow
         """
         pipeline = load_rag_pipeline(session, str(pipeline_id))
-        payload = DraftWorkflowRunPayload.model_validate(console_ns.payload or {})
-        args = payload.model_dump()
+        args = req_data.model_dump()
 
         try:
             response = PipelineGenerateService.generate(
@@ -378,14 +379,14 @@ class PublishedRagPipelineRunApi(Resource):
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_EDIT)
     @with_current_user
     @with_session
-    def post(self, session: Session, current_user: Account, pipeline_id: UUID):
+    @model_validate(PublishedWorkflowRunPayload)
+    def post(self, req_data: PublishedWorkflowRunPayload, session: Session, current_user: Account, pipeline_id: UUID):
         """
         Run published workflow
         """
         pipeline = load_rag_pipeline(session, str(pipeline_id))
-        payload = PublishedWorkflowRunPayload.model_validate(console_ns.payload or {})
-        args = payload.model_dump(exclude_none=True)
-        streaming = payload.response_mode == "streaming"
+        args = req_data.model_dump(exclude_none=True)
+        streaming = req_data.response_mode == "streaming"
 
         try:
             response = PipelineGenerateService.generate(
@@ -393,7 +394,7 @@ class PublishedRagPipelineRunApi(Resource):
                 pipeline=pipeline,
                 user=current_user,
                 args=args,
-                invoke_from=InvokeFrom.DEBUGGER if payload.is_preview else InvokeFrom.PUBLISHED_PIPELINE,
+                invoke_from=InvokeFrom.DEBUGGER if req_data.is_preview else InvokeFrom.PUBLISHED_PIPELINE,
                 streaming=streaming,
             )
 
@@ -413,11 +414,11 @@ class RagPipelinePublishedDatasourceNodeRunApi(Resource):
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_EDIT)
     @with_current_user
     @get_rag_pipeline
-    def post(self, current_user: Account, pipeline: Pipeline, node_id: str):
+    @model_validate(DatasourceNodeRunPayload)
+    def post(self, req_data: DatasourceNodeRunPayload, current_user: Account, pipeline: Pipeline, node_id: str):
         """
         Run rag pipeline datasource
         """
-        payload = DatasourceNodeRunPayload.model_validate(console_ns.payload or {})
 
         rag_pipeline_service = RagPipelineService(db.session())
         return helper.compact_generate_response(
@@ -425,11 +426,11 @@ class RagPipelinePublishedDatasourceNodeRunApi(Resource):
                 rag_pipeline_service.run_datasource_workflow_node(
                     pipeline=pipeline,
                     node_id=node_id,
-                    user_inputs=payload.inputs,
+                    user_inputs=req_data.inputs,
                     account=current_user,
-                    datasource_type=payload.datasource_type,
+                    datasource_type=req_data.datasource_type,
                     is_published=False,
-                    credential_id=payload.credential_id,
+                    credential_id=req_data.credential_id,
                 )
             )
         )
@@ -446,11 +447,11 @@ class RagPipelineDraftDatasourceNodeRunApi(Resource):
     @account_initialization_required
     @with_current_user
     @get_rag_pipeline
-    def post(self, current_user: Account, pipeline: Pipeline, node_id: str):
+    @model_validate(DatasourceNodeRunPayload)
+    def post(self, req_data: DatasourceNodeRunPayload, current_user: Account, pipeline: Pipeline, node_id: str):
         """
         Run rag pipeline datasource
         """
-        payload = DatasourceNodeRunPayload.model_validate(console_ns.payload or {})
 
         rag_pipeline_service = RagPipelineService(db.session())
         return helper.compact_generate_response(
@@ -458,11 +459,11 @@ class RagPipelineDraftDatasourceNodeRunApi(Resource):
                 rag_pipeline_service.run_datasource_workflow_node(
                     pipeline=pipeline,
                     node_id=node_id,
-                    user_inputs=payload.inputs,
+                    user_inputs=req_data.inputs,
                     account=current_user,
-                    datasource_type=payload.datasource_type,
+                    datasource_type=req_data.datasource_type,
                     is_published=False,
-                    credential_id=payload.credential_id,
+                    credential_id=req_data.credential_id,
                 )
             )
         )
@@ -483,12 +484,12 @@ class RagPipelineDraftNodeRunApi(Resource):
     @account_initialization_required
     @with_current_user
     @get_rag_pipeline
-    def post(self, current_user: Account, pipeline: Pipeline, node_id: str):
+    @model_validate(NodeRunRequiredPayload)
+    def post(self, req_data: NodeRunRequiredPayload, current_user: Account, pipeline: Pipeline, node_id: str):
         """
         Run draft workflow node
         """
-        payload = NodeRunRequiredPayload.model_validate(console_ns.payload or {})
-        inputs = payload.inputs
+        inputs = req_data.inputs
 
         rag_pipeline_service = RagPipelineService(db.session())
         workflow_node_execution = rag_pipeline_service.run_draft_workflow_node(
@@ -617,16 +618,16 @@ class DefaultRagPipelineBlockConfigApi(Resource):
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_EDIT)
     @get_rag_pipeline
-    def get(self, pipeline: Pipeline, block_type: str):
+    @model_validate(DefaultBlockConfigQuery)
+    def get(self, req_data: DefaultBlockConfigQuery, pipeline: Pipeline, block_type: str):
         """
         Get default block config
         """
-        query = DefaultBlockConfigQuery.model_validate(request.args.to_dict())
 
         filters = None
-        if query.q:
+        if req_data.q:
             try:
-                filters = json.loads(query.q)
+                filters = json.loads(req_data.q)
             except json.JSONDecodeError:
                 raise ValueError("Invalid filters")
 
@@ -651,16 +652,16 @@ class PublishedAllRagPipelineApi(Resource):
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_EDIT)
     @with_current_user
     @get_rag_pipeline
-    def get(self, current_user: Account, pipeline: Pipeline):
+    @model_validate(WorkflowListQuery)
+    def get(self, req_data: WorkflowListQuery, current_user: Account, pipeline: Pipeline):
         """
         Get published workflows
         """
-        query = WorkflowListQuery.model_validate(request.args.to_dict())
 
-        page = query.page
-        limit = query.limit
-        user_id = query.user_id
-        named_only = query.named_only
+        page = req_data.page
+        limit = req_data.limit
+        user_id = req_data.user_id
+        named_only = req_data.named_only
 
         if user_id:
             if user_id != current_user.id:
@@ -733,12 +734,12 @@ class RagPipelineByIdApi(Resource):
     @with_current_user
     @get_rag_pipeline
     @console_ns.expect(console_ns.models[WorkflowUpdatePayload.__name__])
-    def patch(self, current_user: Account, pipeline: Pipeline, workflow_id: str):
+    @model_validate(WorkflowUpdatePayload)
+    def patch(self, req_data: WorkflowUpdatePayload, current_user: Account, pipeline: Pipeline, workflow_id: str):
         """
         Update workflow attributes
         """
-        payload = WorkflowUpdatePayload.model_validate(console_ns.payload or {})
-        update_data = payload.model_dump(exclude_unset=True)
+        update_data = req_data.model_dump(exclude_unset=True)
 
         if not update_data:
             return {"message": "No valid fields to update"}, 400
@@ -803,12 +804,12 @@ class PublishedRagPipelineSecondStepApi(Resource):
     @get_rag_pipeline
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_EDIT)
-    def get(self, pipeline: Pipeline):
+    @model_validate(NodeIdQuery)
+    def get(self, req_data: NodeIdQuery, pipeline: Pipeline):
         """
         Get second step parameters of rag pipeline
         """
-        query = NodeIdQuery.model_validate(request.args.to_dict())
-        node_id = query.node_id
+        node_id = req_data.node_id
         rag_pipeline_service = RagPipelineService(db.session())
         variables = rag_pipeline_service.get_second_step_parameters(pipeline=pipeline, node_id=node_id, is_draft=False)
         return {
@@ -826,12 +827,12 @@ class PublishedRagPipelineFirstStepApi(Resource):
     @get_rag_pipeline
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_EDIT)
-    def get(self, pipeline: Pipeline):
+    @model_validate(NodeIdQuery)
+    def get(self, req_data: NodeIdQuery, pipeline: Pipeline):
         """
         Get first step parameters of rag pipeline
         """
-        query = NodeIdQuery.model_validate(request.args.to_dict())
-        node_id = query.node_id
+        node_id = req_data.node_id
         rag_pipeline_service = RagPipelineService(db.session())
         variables = rag_pipeline_service.get_first_step_parameters(pipeline=pipeline, node_id=node_id, is_draft=False)
         return {
@@ -849,12 +850,12 @@ class DraftRagPipelineFirstStepApi(Resource):
     @get_rag_pipeline
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_EDIT)
-    def get(self, pipeline: Pipeline):
+    @model_validate(NodeIdQuery)
+    def get(self, req_data: NodeIdQuery, pipeline: Pipeline):
         """
         Get first step parameters of rag pipeline
         """
-        query = NodeIdQuery.model_validate(request.args.to_dict())
-        node_id = query.node_id
+        node_id = req_data.node_id
         rag_pipeline_service = RagPipelineService(db.session())
         variables = rag_pipeline_service.get_first_step_parameters(pipeline=pipeline, node_id=node_id, is_draft=True)
         return {
@@ -872,12 +873,12 @@ class DraftRagPipelineSecondStepApi(Resource):
     @get_rag_pipeline
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_EDIT)
-    def get(self, pipeline: Pipeline):
+    @model_validate(NodeIdQuery)
+    def get(self, req_data: NodeIdQuery, pipeline: Pipeline):
         """
         Get second step parameters of rag pipeline
         """
-        query = NodeIdQuery.model_validate(request.args.to_dict())
-        node_id = query.node_id
+        node_id = req_data.node_id
 
         rag_pipeline_service = RagPipelineService(db.session())
         variables = rag_pipeline_service.get_second_step_parameters(pipeline=pipeline, node_id=node_id, is_draft=True)
@@ -1045,11 +1046,12 @@ class RagPipelineDatasourceVariableApi(Resource):
     @get_rag_pipeline
     @edit_permission_required
     @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_EDIT)
-    def post(self, current_user: Account, pipeline: Pipeline):
+    @model_validate(DatasourceVariablesPayload)
+    def post(self, req_data: DatasourceVariablesPayload, current_user: Account, pipeline: Pipeline):
         """
         Set datasource variables
         """
-        args = DatasourceVariablesPayload.model_validate(console_ns.payload or {}).model_dump()
+        args = req_data.model_dump()
 
         rag_pipeline_service = RagPipelineService(db.session())
         workflow_node_execution = rag_pipeline_service.set_datasource_variables(
@@ -1071,9 +1073,11 @@ class RagPipelineRecommendedPluginApi(Resource):
     @account_initialization_required
     @with_current_user
     @with_current_tenant_id
-    def get(self, current_tenant_id: str, current_user: Account):
-        query = RagPipelineRecommendedPluginQuery.model_validate(request.args.to_dict())
+    @model_validate(RagPipelineRecommendedPluginQuery)
+    def get(self, req_data: RagPipelineRecommendedPluginQuery, current_tenant_id: str, current_user: Account):
 
         rag_pipeline_service = RagPipelineService(db.session())
-        recommended_plugins = rag_pipeline_service.get_recommended_plugins(query.type, current_user, current_tenant_id)
+        recommended_plugins = rag_pipeline_service.get_recommended_plugins(
+            req_data.type, current_user, current_tenant_id
+        )
         return recommended_plugins

--- a/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_datasource_auth.py
+++ b/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_datasource_auth.py
@@ -14,9 +14,15 @@ from controllers.console.datasets.rag_pipeline.datasource_auth import (
     DatasourceAuthListApi,
     DatasourceAuthOauthCustomClient,
     DatasourceAuthUpdateApi,
+    DatasourceCredentialDeletePayload,
+    DatasourceCredentialPayload,
+    DatasourceCredentialUpdatePayload,
+    DatasourceCustomClientPayload,
+    DatasourceDefaultPayload,
     DatasourceHardCodeAuthListApi,
     DatasourceOAuthCallback,
     DatasourcePluginOAuthAuthorizationUrl,
+    DatasourceUpdateNamePayload,
     DatasourceUpdateProviderNameApi,
 )
 from core.plugin.impl.oauth import OAuthHandler
@@ -405,7 +411,8 @@ class TestDatasourceAuth:
                 return_value=None,
             ) as add_api_key_provider,
         ):
-            response, status = method(api, "tenant-1", _PROVIDER_ID)
+            req_data = DatasourceCredentialPayload.model_validate(payload)
+            response, status = method(api, req_data, "tenant-1", _PROVIDER_ID)
 
         assert response == _success_response()
         assert status == 200
@@ -431,7 +438,7 @@ class TestDatasourceAuth:
             ),
         ):
             with pytest.raises(ValueError):
-                method(api, "tenant-1", "notion")
+                method(api, DatasourceCredentialPayload.model_validate(payload), "tenant-1", "notion")
 
     def test_get_success(self, app: Flask):
         api = DatasourceAuth()
@@ -462,7 +469,7 @@ class TestDatasourceAuth:
             patch.object(type(console_ns), "payload", payload),
         ):
             with pytest.raises(ValueError):
-                method(api, "tenant-1", "notion")
+                method(api, DatasourceCredentialPayload.model_validate(payload), "tenant-1", "notion")
 
     def test_get_empty_list(self, app: Flask):
         api = DatasourceAuth()
@@ -499,7 +506,8 @@ class TestDatasourceAuthDeleteApi:
                 return_value=None,
             ) as remove_datasource_credentials,
         ):
-            response, status = method(api, "tenant-1", _PROVIDER_ID)
+            req_data = DatasourceCredentialDeletePayload.model_validate(payload)
+            response, status = method(api, req_data, "tenant-1", _PROVIDER_ID)
 
         assert response == _success_response()
         assert status == 200
@@ -522,7 +530,7 @@ class TestDatasourceAuthDeleteApi:
             patch.object(type(console_ns), "payload", payload),
         ):
             with pytest.raises(ValueError):
-                method(api, "tenant-1", "notion")
+                method(api, DatasourceCredentialDeletePayload.model_validate(payload), "tenant-1", "notion")
 
 
 class TestDatasourceAuthUpdateApi:
@@ -545,7 +553,8 @@ class TestDatasourceAuthUpdateApi:
                 return_value=None,
             ) as update_datasource_credentials,
         ):
-            response, status = method(api, "tenant-1", _PROVIDER_ID)
+            req_data = DatasourceCredentialUpdatePayload.model_validate(payload)
+            response, status = method(api, req_data, "tenant-1", _PROVIDER_ID)
 
         assert response == _success_response()
         assert status == 201
@@ -573,7 +582,8 @@ class TestDatasourceAuthUpdateApi:
                 return_value=None,
             ) as update_mock,
         ):
-            response, status = method(api, "tenant-1", "notion")
+            req_data = DatasourceCredentialUpdatePayload.model_validate(payload)
+            response, status = method(api, req_data, "tenant-1", "notion")
 
         assert response == _success_response()
         update_mock.assert_called_once()
@@ -595,7 +605,8 @@ class TestDatasourceAuthUpdateApi:
                 return_value=None,
             ),
         ):
-            response, status = method(api, "tenant-1", "notion")
+            req_data = DatasourceCredentialUpdatePayload.model_validate(payload)
+            response, status = method(api, req_data, "tenant-1", "notion")
 
         assert response == _success_response()
         assert status == 201
@@ -615,7 +626,8 @@ class TestDatasourceAuthUpdateApi:
                 return_value=None,
             ) as update_mock,
         ):
-            response, status = method(api, "tenant-1", "notion")
+            req_data = DatasourceCredentialUpdatePayload.model_validate(payload)
+            response, status = method(api, req_data, "tenant-1", "notion")
 
         assert response == _success_response()
         update_mock.assert_called_once()
@@ -716,7 +728,8 @@ class TestDatasourceAuthOauthCustomClient:
                 return_value=None,
             ) as setup_custom_client,
         ):
-            response, status = method(api, "tenant-1", _PROVIDER_ID)
+            req_data = DatasourceCustomClientPayload.model_validate(payload)
+            response, status = method(api, req_data, "tenant-1", _PROVIDER_ID)
 
         assert response == _success_response()
         assert status == 200
@@ -760,7 +773,8 @@ class TestDatasourceAuthOauthCustomClient:
                 return_value=None,
             ),
         ):
-            response, status = method(api, "tenant-1", "notion")
+            req_data = DatasourceCustomClientPayload.model_validate(payload)
+            response, status = method(api, req_data, "tenant-1", "notion")
 
         assert response == _success_response()
         assert status == 200
@@ -783,7 +797,8 @@ class TestDatasourceAuthOauthCustomClient:
                 return_value=None,
             ) as setup_mock,
         ):
-            response, status = method(api, "tenant-1", "notion")
+            req_data = DatasourceCustomClientPayload.model_validate(payload)
+            response, status = method(api, req_data, "tenant-1", "notion")
 
         assert response == _success_response()
         setup_mock.assert_called_once()
@@ -808,7 +823,8 @@ class TestDatasourceAuthDefaultApi:
                 return_value=None,
             ) as set_default_datasource_provider,
         ):
-            response, status = method(api, "tenant-1", _PROVIDER_ID)
+            req_data = DatasourceDefaultPayload.model_validate(payload)
+            response, status = method(api, req_data, "tenant-1", _PROVIDER_ID)
 
         assert response == _success_response()
         assert status == 200
@@ -828,7 +844,7 @@ class TestDatasourceAuthDefaultApi:
             patch.object(type(console_ns), "payload", payload),
         ):
             with pytest.raises(ValueError):
-                method(api, "tenant-1", "notion")
+                method(api, DatasourceDefaultPayload.model_validate(payload), "tenant-1", "notion")
 
 
 class TestDatasourceUpdateProviderNameApi:
@@ -847,7 +863,8 @@ class TestDatasourceUpdateProviderNameApi:
                 return_value=None,
             ) as update_datasource_provider_name,
         ):
-            response, status = method(api, "tenant-1", _PROVIDER_ID)
+            req_data = DatasourceUpdateNamePayload.model_validate(payload)
+            response, status = method(api, req_data, "tenant-1", _PROVIDER_ID)
 
         assert response == _success_response()
         assert status == 200
@@ -871,7 +888,7 @@ class TestDatasourceUpdateProviderNameApi:
             patch.object(type(console_ns), "payload", payload),
         ):
             with pytest.raises(ValueError):
-                method(api, "tenant-1", "notion")
+                method(api, DatasourceUpdateNamePayload.model_validate(payload), "tenant-1", "notion")
 
     def test_update_name_missing_credential_id(self, app: Flask):
         api = DatasourceUpdateProviderNameApi()
@@ -884,4 +901,4 @@ class TestDatasourceUpdateProviderNameApi:
             patch.object(type(console_ns), "payload", payload),
         ):
             with pytest.raises(ValueError):
-                method(api, "tenant-1", "notion")
+                method(api, DatasourceUpdateNamePayload.model_validate(payload), "tenant-1", "notion")

--- a/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_datasource_content_preview.py
+++ b/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_datasource_content_preview.py
@@ -7,6 +7,7 @@ from flask import Flask
 from controllers.console import console_ns
 from controllers.console.datasets.rag_pipeline.datasource_content_preview import (
     DataSourceContentPreviewApi,
+    Parser,
 )
 from models import Account
 from models.dataset import Pipeline
@@ -49,7 +50,8 @@ class TestDataSourceContentPreviewApi:
                 return_value=service_instance,
             ),
         ):
-            response, status = method(api, account, pipeline, node_id)
+            req_data = Parser.model_validate(payload)
+            response, status = method(api, req_data, account, pipeline, node_id)
 
         service_instance.run_datasource_node_preview.assert_called_once_with(
             pipeline=pipeline,
@@ -80,7 +82,7 @@ class TestDataSourceContentPreviewApi:
             patch.object(type(console_ns), "payload", payload),
         ):
             with pytest.raises(ValueError):
-                method(api, account, pipeline, "node-1")
+                method(api, Parser.model_validate(payload), account, pipeline, "node-1")
 
     def test_post_without_credential_id(self, app: Flask):
         api = DataSourceContentPreviewApi()
@@ -106,7 +108,8 @@ class TestDataSourceContentPreviewApi:
                 return_value=service_instance,
             ),
         ):
-            response, status = method(api, account, pipeline, "node-1")
+            req_data = Parser.model_validate(payload)
+            response, status = method(api, req_data, account, pipeline, "node-1")
 
         service_instance.run_datasource_node_preview.assert_called_once()
         assert status == 200

--- a/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline.py
+++ b/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline.py
@@ -15,8 +15,11 @@ from controllers.console import console_ns
 from controllers.console.datasets.rag_pipeline import rag_pipeline as module
 from controllers.console.datasets.rag_pipeline.rag_pipeline import (
     CustomizedPipelineTemplateApi,
+    CustomizedPipelineTemplatePayload,
     PipelineTemplateDetailApi,
+    PipelineTemplateDetailQuery,
     PipelineTemplateListApi,
+    PipelineTemplateListQuery,
     PublishCustomizedPipelineTemplateApi,
 )
 from models.account import Account
@@ -90,7 +93,7 @@ class TestPipelineTemplateListApi:
             app.test_request_context("/rag/pipeline/templates"),
             patch.object(module.RagPipelineService, "get_pipeline_templates", side_effect=get_pipeline_templates),
         ):
-            response, status = method(api, session, tenant_id)
+            response, status = method(api, PipelineTemplateListQuery(), session, tenant_id)
 
         assert status == 200
         assert service_calls == [("built-in", "en-US", tenant_id)]
@@ -120,7 +123,9 @@ class TestPipelineTemplateListApi:
             app.test_request_context("/rag/pipeline/templates?type=customized&language=ja-JP"),
             patch.object(module.RagPipelineService, "get_pipeline_templates", side_effect=get_pipeline_templates),
         ):
-            response, status = method(api, session, tenant_id)
+            response, status = method(
+                api, PipelineTemplateListQuery(type="customized", language="ja-JP"), session, tenant_id
+            )
 
         assert status == 200
         assert response == {"pipeline_templates": []}
@@ -147,7 +152,7 @@ class TestPipelineTemplateDetailApi:
                 side_effect=get_pipeline_template_detail,
             ),
         ):
-            response, status = method(api, session, "template-1")
+            response, status = method(api, PipelineTemplateDetailQuery(type="customized"), session, "template-1")
 
         assert status == 200
         assert response == {**_template_detail(), "created_by": None}
@@ -170,7 +175,7 @@ class TestPipelineTemplateDetailApi:
             ),
             pytest.raises(NotFound),
         ):
-            method(api, session, "missing")
+            method(api, PipelineTemplateDetailQuery(), session, "missing")
 
 
 class TestCustomizedPipelineTemplateApi:
@@ -198,7 +203,9 @@ class TestCustomizedPipelineTemplateApi:
             patch.object(type(console_ns), "payload", new_callable=PropertyMock, return_value=payload),
             patch.object(module.RagPipelineService, "update_customized_pipeline_template", side_effect=update_template),
         ):
-            response, status = method(api, tenant_id, account, "template-1")
+            response, status = method(
+                api, CustomizedPipelineTemplatePayload.model_validate(payload), tenant_id, account, "template-1"
+            )
 
         assert (response, status) == ("", 204)
         assert len(service_calls) == 1
@@ -242,7 +249,9 @@ class TestCustomizedPipelineTemplateApi:
             patch.object(type(console_ns), "payload", new_callable=PropertyMock, return_value=payload),
             patch.object(module.RagPipelineService, "update_customized_pipeline_template", side_effect=update_template),
         ):
-            response, status = method(api, tenant_id, account, "template-1")
+            response, status = method(
+                api, CustomizedPipelineTemplatePayload.model_validate(payload), tenant_id, account, "template-1"
+            )
 
         assert (response, status) == ("", 204)
         assert len(service_calls) == 1
@@ -349,7 +358,9 @@ class TestPublishCustomizedPipelineTemplateApi:
             patch.object(type(console_ns), "payload", new_callable=PropertyMock, return_value=payload),
             patch.object(module, "RagPipelineService", Service),
         ):
-            response, status = method(api, tenant_id, account, "pipeline-1")
+            response, status = method(
+                api, CustomizedPipelineTemplatePayload.model_validate(payload), tenant_id, account, "pipeline-1"
+            )
 
         assert (response, status) == ("", 204)
         assert service_calls == [("pipeline-1", payload, account, tenant_id)]
@@ -386,7 +397,9 @@ class TestPublishCustomizedPipelineTemplateApi:
             patch.object(type(console_ns), "payload", new_callable=PropertyMock, return_value=payload),
             patch.object(module, "RagPipelineService", Service),
         ):
-            response, status = method(api, tenant_id, account, "pipeline-1")
+            response, status = method(
+                api, CustomizedPipelineTemplatePayload.model_validate(payload), tenant_id, account, "pipeline-1"
+            )
 
         assert (response, status) == ("", 204)
         assert service_calls == [

--- a/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_datasets.py
+++ b/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_datasets.py
@@ -15,6 +15,7 @@ from controllers.console.datasets.error import DatasetNameDuplicateError
 from controllers.console.datasets.rag_pipeline.rag_pipeline_datasets import (
     CreateEmptyRagPipelineDatasetApi,
     CreateRagPipelineDatasetApi,
+    RagPipelineDatasetImportPayload,
 )
 from services.entities.dsl_entities import ImportStatus
 
@@ -50,7 +51,7 @@ class TestCreateRagPipelineDatasetApi:
                 return_value=mock_service,
             ),
         ):
-            response, status = method(api, "tenant-1", user)
+            response, status = method(api, RagPipelineDatasetImportPayload.model_validate(payload), "tenant-1", user)
 
         assert status == 201
         assert response == {
@@ -75,7 +76,7 @@ class TestCreateRagPipelineDatasetApi:
             patch.object(type(console_ns), "payload", payload),
         ):
             with pytest.raises(Forbidden):
-                method(api, "tenant-1", user)
+                method(api, RagPipelineDatasetImportPayload.model_validate(payload), "tenant-1", user)
 
     def test_post_dataset_name_duplicate(self, app: Flask) -> None:
         api = CreateRagPipelineDatasetApi()
@@ -96,7 +97,7 @@ class TestCreateRagPipelineDatasetApi:
             ),
         ):
             with pytest.raises(DatasetNameDuplicateError):
-                method(api, "tenant-1", user)
+                method(api, RagPipelineDatasetImportPayload.model_validate(payload), "tenant-1", user)
 
     def test_post_invalid_payload(self, app: Flask) -> None:
         api = CreateRagPipelineDatasetApi()
@@ -110,7 +111,7 @@ class TestCreateRagPipelineDatasetApi:
             patch.object(type(console_ns), "payload", payload),
         ):
             with pytest.raises(ValueError):
-                method(api, "tenant-1", user)
+                method(api, RagPipelineDatasetImportPayload.model_validate(payload), "tenant-1", user)
 
 
 class TestCreateEmptyRagPipelineDatasetApi:

--- a/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_draft_variable.py
+++ b/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_draft_variable.py
@@ -8,12 +8,14 @@ from controllers.common.errors import InvalidArgumentError, NotFoundError
 from controllers.console import console_ns
 from controllers.console.app.error import DraftWorkflowNotExist
 from controllers.console.datasets.rag_pipeline.rag_pipeline_draft_variable import (
+    PaginationQuery,
     RagPipelineEnvironmentVariableCollectionApi,
     RagPipelineNodeVariableCollectionApi,
     RagPipelineSystemVariableCollectionApi,
     RagPipelineVariableApi,
     RagPipelineVariableCollectionApi,
     RagPipelineVariableResetApi,
+    WorkflowDraftVariablePatchPayload,
 )
 from core.workflow.llm_environment_variable import LLMEnvironmentVariable
 from core.workflow.variable_prefixes import SYSTEM_VARIABLE_NODE_ID
@@ -72,7 +74,7 @@ class TestRagPipelineVariableCollectionApi:
                 return_value=draft_srv,
             ),
         ):
-            result = method(api, editor_user, pipeline)
+            result = method(api, PaginationQuery(page=1, limit=10), editor_user, pipeline)
 
         assert result is var_list
         draft_srv.list_variables_without_values.assert_called_once_with(
@@ -100,7 +102,7 @@ class TestRagPipelineVariableCollectionApi:
             ),
         ):
             with pytest.raises(DraftWorkflowNotExist):
-                method(api, editor_user, pipeline)
+                method(api, PaginationQuery(), editor_user, pipeline)
 
     def test_delete_variables_success(self, app: Flask, fake_db, editor_user):
         api = RagPipelineVariableCollectionApi()
@@ -198,7 +200,7 @@ class TestRagPipelineVariableApi:
             ),
         ):
             with pytest.raises(InvalidArgumentError):
-                method(api, editor_user, pipeline, "v1")
+                method(api, WorkflowDraftVariablePatchPayload.model_validate(payload), editor_user, pipeline, "v1")
 
     def test_delete_variable_success(self, app: Flask, fake_db, editor_user):
         api = RagPipelineVariableApi()

--- a/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_import.py
+++ b/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_import.py
@@ -11,10 +11,12 @@ from flask import Flask
 
 from controllers.console import console_ns
 from controllers.console.datasets.rag_pipeline.rag_pipeline_import import (
+    IncludeSecretQuery,
     RagPipelineExportApi,
     RagPipelineImportApi,
     RagPipelineImportCheckDependenciesApi,
     RagPipelineImportConfirmApi,
+    RagPipelineImportPayload,
 )
 from core.plugin.entities.plugin import PluginDependency, PluginDependencyType
 from models.dataset import Pipeline
@@ -67,7 +69,7 @@ class TestRagPipelineImportApi:
                 return_value=service,
             ),
         ):
-            response, status = method(api, user)
+            response, status = method(api, RagPipelineImportPayload(mode="create"), user)
 
         assert status == 200
         assert response == {
@@ -105,7 +107,7 @@ class TestRagPipelineImportApi:
                 return_value=service,
             ),
         ):
-            response, status = method(api, user)
+            response, status = method(api, RagPipelineImportPayload(mode="create"), user)
 
         assert status == 400
         assert response["status"] == "failed"
@@ -139,7 +141,7 @@ class TestRagPipelineImportApi:
                 return_value=service,
             ),
         ):
-            response, status = method(api, user)
+            response, status = method(api, RagPipelineImportPayload(mode="create"), user)
 
         assert status == 202
         assert response["status"] == "pending"
@@ -287,7 +289,7 @@ class TestRagPipelineExportApi:
                 return_value=service,
             ),
         ):
-            response, status = method(api, pipeline)
+            response, status = method(api, IncludeSecretQuery(), pipeline)
 
         assert status == 200
         assert response == {"data": "yaml: data"}

--- a/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_workflow.py
+++ b/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_workflow.py
@@ -16,6 +16,14 @@ from sqlalchemy.orm import Session
 from werkzeug.exceptions import Forbidden
 
 from controllers.console.datasets.rag_pipeline import rag_pipeline_workflow as module
+from controllers.console.datasets.rag_pipeline.rag_pipeline_workflow import (
+    DraftWorkflowRunPayload,
+    NodeIdQuery,
+    PublishedWorkflowRunPayload,
+    RagPipelineRecommendedPluginQuery,
+    WorkflowListQuery,
+    WorkflowUpdatePayload,
+)
 from controllers.web.error import InvokeRateLimitError as InvokeRateLimitHttpError
 from models.account import Account, TenantAccountRole
 from models.dataset import Pipeline
@@ -133,7 +141,9 @@ def test_published_rag_pipeline_workflows_serialize_items_before_session_closes(
         method="GET",
         query_string={"page": 1, "limit": 10, "user_id": "", "named_only": "false"},
     ):
-        response = handler(api, _account(), pipeline=pipeline)
+        response = handler(
+            api, WorkflowListQuery(page=1, limit=10, user_id="", named_only=False), _account(), pipeline=pipeline
+        )
 
     assert response["items"][0]["id"] == DEFAULT_WORKFLOW_ID
     assert response["page"] == 1
@@ -157,6 +167,7 @@ def test_rag_pipeline_workflow_patch_serializes_response_model(
     ):
         response = handler(
             api,
+            WorkflowUpdatePayload.model_validate(payload),
             _account(),
             pipeline=_pipeline(),
             workflow_id=DEFAULT_WORKFLOW_ID,
@@ -198,7 +209,7 @@ def test_draft_rag_pipeline_second_step_parameters_serializes_variables(database
         database_app.test_request_context("/?node_id=node-1"),
         patch.object(RagPipelineService, "get_second_step_parameters", return_value=variables),
     ):
-        response = handler(api, _pipeline())
+        response = handler(api, NodeIdQuery(node_id="node-1"), _pipeline())
 
     assert response["variables"] == variables
 
@@ -215,7 +226,7 @@ def test_rag_pipeline_recommended_plugins_serializes_known_envelope(database_app
         database_app.test_request_context("/?type=tool"),
         patch.object(RagPipelineService, "get_recommended_plugins", return_value=recommended_plugins),
     ):
-        response = handler(api, DEFAULT_WORKFLOW_TENANT_ID, _account())
+        response = handler(api, RagPipelineRecommendedPluginQuery(type="tool"), DEFAULT_WORKFLOW_TENANT_ID, _account())
 
     assert response == recommended_plugins
 
@@ -270,7 +281,12 @@ def test_rag_pipeline_run_uses_sqlite_session(
         patch.object(module.PipelineGenerateService, "generate", return_value=MagicMock()) as generate,
         patch.object(module.helper, "compact_generate_response", return_value={"ok": True}),
     ):
-        response = handler(api, session, _account(), pipeline.id)
+        req_data = (
+            DraftWorkflowRunPayload.model_validate(payload)
+            if api_type is module.DraftRagPipelineRunApi
+            else PublishedWorkflowRunPayload.model_validate(payload)
+        )
+        response = handler(api, req_data, session, _account(), pipeline.id)
 
     assert response == {"ok": True}
     load_pipeline.assert_called_once_with(session, pipeline.id)
@@ -293,6 +309,11 @@ def test_rag_pipeline_run_translates_rate_limit(
     api = api_type()
     handler = unwrap_all(api.post)
     pipeline = _pipeline()
+    req_data = (
+        DraftWorkflowRunPayload.model_validate(payload)
+        if api_type is module.DraftRagPipelineRunApi
+        else PublishedWorkflowRunPayload.model_validate(payload)
+    )
 
     with (
         Session(sqlite_engine) as session,
@@ -301,4 +322,4 @@ def test_rag_pipeline_run_translates_rate_limit(
         patch.object(module.PipelineGenerateService, "generate", side_effect=InvokeRateLimitError("limit")),
         pytest.raises(InvokeRateLimitHttpError),
     ):
-        handler(api, session, _account(), pipeline.id)
+        handler(api, req_data, session, _account(), pipeline.id)

--- a/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_workflow_apis.py
+++ b/api/tests/unit_tests/controllers/console/datasets/rag_pipeline/test_rag_pipeline_workflow_apis.py
@@ -22,8 +22,12 @@ import services
 from controllers.console.app.error import DraftWorkflowNotExist, DraftWorkflowNotSync
 from controllers.console.datasets.rag_pipeline import rag_pipeline_workflow as workflow_controller
 from controllers.console.datasets.rag_pipeline.rag_pipeline_workflow import (
+    DatasourceVariablesPayload,
+    DefaultBlockConfigQuery,
     DefaultRagPipelineBlockConfigApi,
     DraftRagPipelineApi,
+    NodeRunPayload,
+    NodeRunRequiredPayload,
     PublishedAllRagPipelineApi,
     PublishedRagPipelineApi,
     RagPipelineByIdApi,
@@ -33,9 +37,12 @@ from controllers.console.datasets.rag_pipeline.rag_pipeline_workflow import (
     RagPipelineDraftRunLoopNodeApi,
     RagPipelineDraftWorkflowRestoreApi,
     RagPipelineRecommendedPluginApi,
+    RagPipelineRecommendedPluginQuery,
     RagPipelineTaskStopApi,
     RagPipelineWorkflowLastRunApi,
     RagPipelineWorkflowRunNodeExecutionListApi,
+    WorkflowListQuery,
+    WorkflowUpdatePayload,
 )
 from graphon.enums import WorkflowNodeExecutionStatus
 from libs.datetime_utils import naive_utc_now
@@ -418,7 +425,7 @@ class TestDraftRunNodes:
                 return_value={"ok": True},
             ),
         ):
-            result = method(api, user, pipeline, "node")
+            result = method(api, NodeRunPayload(), user, pipeline, "node")
             assert result == {"ok": True}
 
     def test_iteration_node_conversation_not_exists(self, app: Flask) -> None:
@@ -436,7 +443,7 @@ class TestDraftRunNodes:
             ),
         ):
             with pytest.raises(NotFound):
-                method(api, user, pipeline, "node")
+                method(api, NodeRunPayload(), user, pipeline, "node")
 
     def test_loop_node_success(self, app: Flask) -> None:
         api = RagPipelineDraftRunLoopNodeApi()
@@ -456,7 +463,7 @@ class TestDraftRunNodes:
                 return_value={"ok": True},
             ),
         ):
-            assert method(api, user, pipeline, "node") == {"ok": True}
+            assert method(api, NodeRunPayload(), user, pipeline, "node") == {"ok": True}
 
 
 class TestDraftNodeRun:
@@ -478,7 +485,7 @@ class TestDraftNodeRun:
             ),
         ):
             with pytest.raises(ValueError):
-                method(api, user, pipeline, "node")
+                method(api, NodeRunRequiredPayload(inputs={}), user, pipeline, "node")
 
 
 class TestPublishedPipelineApis:
@@ -551,7 +558,7 @@ class TestMiscApis:
                 return_value=service,
             ),
         ):
-            result = method(api, tenant_id, user)
+            result = method(api, RagPipelineRecommendedPluginQuery(type="all"), tenant_id, user)
             assert result == recommended_plugins
             service.get_recommended_plugins.assert_called_once_with("all", user, tenant_id)
 
@@ -573,7 +580,7 @@ class TestDefaultBlockConfigApi:
                 return_value=service,
             ),
         ):
-            result = method(api, pipeline, "llm")
+            result = method(api, DefaultBlockConfigQuery(q="{}"), pipeline, "llm")
             assert result == {"k": "v"}
 
     def test_get_block_config_invalid_json(self, app: Flask) -> None:
@@ -584,7 +591,7 @@ class TestDefaultBlockConfigApi:
 
         with app.test_request_context("/?q=bad-json"):
             with pytest.raises(ValueError):
-                method(api, pipeline, "llm")
+                method(api, DefaultBlockConfigQuery(q="bad-json"), pipeline, "llm")
 
 
 class TestPublishedAllRagPipelineApi:
@@ -605,7 +612,7 @@ class TestPublishedAllRagPipelineApi:
                 return_value=service,
             ),
         ):
-            result = method(api, user, pipeline)
+            result = method(api, WorkflowListQuery(), user, pipeline)
 
         assert result["items"][0]["id"] == "w1"
         assert result["items"][0]["graph"] == {"nodes": [], "edges": []}
@@ -622,7 +629,7 @@ class TestPublishedAllRagPipelineApi:
             app.test_request_context("/?user_id=u2"),
         ):
             with pytest.raises(Forbidden):
-                method(api, user, pipeline)
+                method(api, WorkflowListQuery(user_id="u2"), user, pipeline)
 
 
 class TestRagPipelineByIdApi:
@@ -647,7 +654,7 @@ class TestRagPipelineByIdApi:
                 return_value=service,
             ),
         ):
-            result = method(api, user, pipeline, "w1")
+            result = method(api, WorkflowUpdatePayload.model_validate(payload), user, pipeline, "w1")
 
         assert result["id"] == "w1"
         assert result["marked_name"] == "test"
@@ -661,7 +668,7 @@ class TestRagPipelineByIdApi:
         user = make_account()
 
         with app.test_request_context("/", json={}):
-            result, status = method(api, user, pipeline, "w1")
+            result, status = method(api, WorkflowUpdatePayload(), user, pipeline, "w1")
             assert status == 400
 
     def test_delete_success(self, app: Flask) -> None:
@@ -797,6 +804,6 @@ class TestRagPipelineDatasourceVariableApi:
                 return_value=service,
             ),
         ):
-            result = method(api, user, pipeline)
+            result = method(api, DatasourceVariablesPayload.model_validate(payload), user, pipeline)
             assert result["node_id"] == "n1"
             assert result["process_data"] == {}


### PR DESCRIPTION
Replace manual model_validate(request.get_json()) calls with the @model_validate decorator in rag_pipeline controller files.