### PR TITLE
refactor(web): simplify the tool category filter component

### DIFF
--- a/web/app/components/base/tab-slider-new/index.tsx
+++ b/web/app/components/base/tab-slider-new/index.tsx
@@ -1,10 +1,10 @@
-import type { FC } from 'react'
+import type { ReactNode } from 'react'
 import { cn } from '@langgenius/dify-ui/cn'
 
 type Option = {
   value: string
   text: string
-  icon?: React.ReactNode
+  icon?: ReactNode
 }
 type TabSliderProps = {
   className?: string
@@ -12,7 +12,7 @@ type TabSliderProps = {
   onChange: (v: string) => void
   options: Option[]
 }
-const TabSliderNew: FC<TabSliderProps> = ({ className, value, onChange, options }) => {
+function TabSliderNew({ className, value, onChange, options }: TabSliderProps) {
   return (
     <div data-testid="tab-slider-new" className={cn(className, 'relative flex')}>
       {options.map((option) => (


### PR DESCRIPTION
## Summary

- replace the legacy `React.FC` declaration with a named function
- import `ReactNode` directly for the option icon type
- keep the tool category filter's public behavior and rendered DOM unchanged

## Scope

Only `web/app/components/base/tab-slider-new/index.tsx`.

This is a mechanical preparation layer. It does not change props, classes, handlers, test ids, or output.

## Verification

- `pnpm exec vp test run app/components/base/tab-slider-new/__tests__/index.spec.tsx` — 1/1
- `pnpm check` — 0 errors, existing warnings only
- `git diff --check`

## Visual regression

None: the generated JSX and class names are unchanged.

## Stack

Base: `main`

Child: #40243 adds the semantic filter behavior. Review and revert this PR independently; if reverting the complete stack, start from the top child.
