### PR TITLE
refactor(web): use css icons in the tab filter story

### DIFF
--- a/web/app/components/base/tab-slider-new/index.stories.tsx
+++ b/web/app/components/base/tab-slider-new/index.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
-import { RiSparklingFill, RiTerminalBoxLine } from '@remixicon/react'
 import { useState } from 'react'
 import TabSliderNew from '.'
 
@@ -7,12 +6,14 @@ const OPTIONS = [
   {
     value: 'visual',
     text: 'Visual builder',
-    icon: <RiSparklingFill className="mr-2 size-4 text-primary-500" />,
+    icon: <span className="mr-2 i-ri-sparkling-fill size-4 text-primary-500" aria-hidden="true" />,
   },
   {
     value: 'code',
     text: 'Code',
-    icon: <RiTerminalBoxLine className="mr-2 size-4 text-text-tertiary" />,
+    icon: (
+      <span className="mr-2 i-ri-terminal-box-line size-4 text-text-tertiary" aria-hidden="true" />
+    ),
   },
 ]
 


### PR DESCRIPTION
## Summary

- replace two Remix React icons in the TabSliderNew story with the repository's recommended CSS icon classes
- mark the decorative story icons hidden from assistive technology
- remove the two focused icon warnings without touching production code

## Scope

Only `web/app/components/base/tab-slider-new/index.stories.tsx`.

This layer has no production bundle or runtime behavior change.

## Visual regression

Compared this story against #40243 with the same viewport and theme.

- both icons remain 16 × 16
- both icons retain the same x/y coordinates, 8 px right margin, and colors
- both item boxes and both text ranges remain unchanged
- the CSS masks use the corresponding Remix icon data recommended by the repository lint rule

## Verification

- `pnpm exec vp check app/components/base/tab-slider-new/index.stories.tsx` — 0 warnings/errors
- `pnpm check` — 0 errors; repository warning count decreases by 2
- `git diff --check`

## Stack

Base: #40243

This is the final, Storybook-only layer of stack #40245. It can be omitted or reverted without affecting the accessibility fix.
