### PR TITLE
fix(web): name the chat history settings trigger

### DIFF
--- a/web/app/components/base/chat/chat-with-history/inputs-form/__tests__/view-form-dropdown.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/inputs-form/__tests__/view-form-dropdown.spec.tsx
@@ -67,7 +67,7 @@ describe('ViewFormDropdown', () => {
     expect(screen.queryByText('share.chat.chatSettingsTitle')).not.toBeInTheDocument()
 
     // Find trigger (ActionButton renders a button)
-    const trigger = screen.getByRole('button')
+    const trigger = screen.getByRole('button', { name: 'share.chat.chatSettingsTitle' })
     expect(trigger).toBeInTheDocument()
 
     // Open dropdown
@@ -90,7 +90,7 @@ describe('ViewFormDropdown', () => {
 
     const user = userEvent.setup()
     render(<ViewFormDropdown />)
-    await user.click(screen.getByRole('button'))
+    await user.click(screen.getByRole('button', { name: 'share.chat.chatSettingsTitle' }))
 
     expect(screen.getByText('Text Form')).toBeInTheDocument()
     expect(screen.getByText('Num Form')).toBeInTheDocument()
@@ -99,7 +99,7 @@ describe('ViewFormDropdown', () => {
   it('applies correct state to ActionButton when open', async () => {
     const user = userEvent.setup()
     render(<ViewFormDropdown />)
-    const trigger = screen.getByRole('button')
+    const trigger = screen.getByRole('button', { name: 'share.chat.chatSettingsTitle' })
 
     // closed state
     expect(trigger).not.toHaveClass('action-btn-hover')

--- a/web/app/components/base/chat/chat-with-history/inputs-form/view-form-dropdown.tsx
+++ b/web/app/components/base/chat/chat-with-history/inputs-form/view-form-dropdown.tsx
@@ -13,10 +13,11 @@ const ViewFormDropdown = () => {
         render={(props, state) => (
           <ActionButton
             {...props}
+            aria-label={t(($) => $['chat.chatSettingsTitle'], { ns: 'share' })}
             size="l"
             state={state.open ? ActionButtonState.Hover : ActionButtonState.Default}
           >
-            <RiChatSettingsLine className="h-4.5 w-4.5" />
+            <RiChatSettingsLine aria-hidden="true" className="h-4.5 w-4.5" />
           </ActionButton>
         )}
       />


### PR DESCRIPTION
## Summary

- give the chat-history settings icon button the existing translated settings title as its accessible name
- mark the trigger icon decorative
- tighten the component tests from an unnamed button query to role + name

## Behavior contract

- Dify UI Popover continues to own trigger state, focus, and disclosure behavior
- ActionButton continues to own the visual button contract
- the visible popover title and trigger name share the same existing translation key
- no test id is introduced; behavior is located through the accessible role and name

## Scope

Only the chat-with-history `ViewFormDropdown` implementation and its focused test.

The embedded-chat implementation is a separate owner already covered by #40199; this PR does not depend on or modify that implementation.

## Test evidence

The updated tests failed first because the existing trigger had button role but an empty accessible name. After the production change, all 3 tests pass while continuing to cover open, close, multiple form items, and visual action state.

## Visual regression

The production diff only adds `aria-label` and `aria-hidden` attributes. Elements, class names, styles, dimensions, order, pointer behavior, and open-state rendering are unchanged.

The two existing icon migration warnings are deliberately not folded into this PR because that would require a separate visual validation boundary.

## Verification

- `pnpm exec vp test run app/components/base/chat/chat-with-history/inputs-form/__tests__/view-form-dropdown.spec.tsx` — 3/3
- targeted `vp check` — 0 errors
- `node scripts/lint-a11y.mjs app/components/base/chat/chat-with-history/inputs-form/view-form-dropdown.tsx`
- `pnpm check` — 0 errors, existing warnings only
- `git diff --check`

## Stack

Base: `main`

This is a single-layer, independently reviewable and revertible PR.
