### PR TITLE
refactor(web): keep copy id events on the button

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -4890,22 +4890,6 @@
       "count": 5
     }
   },
-  "web/app/components/workflow/nodes/tool/components/__tests__/copy-id.spec.tsx": {
-    "jsx_a11y/click-events-have-key-events": {
-      "count": 1
-    },
-    "jsx_a11y/no-static-element-interactions": {
-      "count": 1
-    }
-  },
-  "web/app/components/workflow/nodes/tool/components/copy-id.tsx": {
-    "jsx_a11y/click-events-have-key-events": {
-      "count": 1
-    },
-    "jsx_a11y/no-static-element-interactions": {
-      "count": 1
-    }
-  },
   "web/app/components/workflow/nodes/tool/components/mixed-variable-text-input/index.tsx": {
     "typescript/no-explicit-any": {
       "count": 1

--- a/web/app/components/workflow/nodes/tool/components/__tests__/copy-id.spec.tsx
+++ b/web/app/components/workflow/nodes/tool/components/__tests__/copy-id.spec.tsx
@@ -39,15 +39,20 @@ describe('tool/copy-id', () => {
     expect(trigger).toHaveAccessibleName('appOverview.overview.appInfo.embedded.copy')
   })
 
-  it('should stop click propagation from the outer wrapper', () => {
+  it('should stop click propagation from the copy button', () => {
     const handleParentClick = vi.fn()
-    const { container } = render(
-      <div onClick={handleParentClick}>
-        <CopyId content="tool-123" />
-      </div>,
-    )
+    render(<CopyId content="tool-123" />)
+    document.body.addEventListener('click', handleParentClick)
 
-    fireEvent.click(container.querySelector('.inline-flex') as HTMLElement)
+    act(() => {
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: 'appOverview.overview.appInfo.embedded.copy',
+        }),
+      )
+      vi.advanceTimersByTime(100)
+    })
+    document.body.removeEventListener('click', handleParentClick)
 
     expect(handleParentClick).not.toHaveBeenCalled()
   })

--- a/web/app/components/workflow/nodes/tool/components/copy-id.tsx
+++ b/web/app/components/workflow/nodes/tool/components/copy-id.tsx
@@ -30,11 +30,7 @@ const CopyFeedbackNew = ({ content }: Props) => {
       : t(($) => $[`${prefixEmbedded}.copy`], { ns: 'appOverview' })) || ''
 
   return (
-    <div
-      className="inline-flex w-full pb-0.5"
-      onClick={(e) => e.stopPropagation()}
-      onMouseLeave={onMouseLeave}
-    >
+    <div className="inline-flex w-full pb-0.5" onMouseLeave={onMouseLeave}>
       <Tooltip>
         <TooltipTrigger
           render={
@@ -42,7 +38,10 @@ const CopyFeedbackNew = ({ content }: Props) => {
               type="button"
               aria-label={tooltip}
               className="group/copy flex w-full items-center gap-0.5 text-left"
-              onClick={onClickCopy}
+              onClick={(event) => {
+                event.stopPropagation()
+                onClickCopy()
+              }}
             >
               <span className="w-0 grow cursor-pointer truncate system-2xs-regular text-text-quaternary group-hover:text-text-tertiary">
                 {content}


### PR DESCRIPTION
## Summary

- Move click propagation ownership from the non-interactive layout wrapper to the existing, named copy button.
- Exercise the public button role and accessible name in the propagation test instead of querying a CSS wrapper.
- Prune the four exact `jsx-a11y` suppressions that are no longer needed across production code and its test.

## Behavior contract

- Activating the copy button still copies the tool ID and updates the existing copied feedback.
- A copy-button activation does not trigger an ancestor click action.
- The outer wrapper owns layout and mouse-leave feedback only.
- The wrapper's 2 px bottom padding is no longer treated as an interaction surface.

## Visual regression review

No element tag, class, style, node order, text, or icon changed. This PR only moves an event handler and updates its test, so default, hover, and copied-state geometry remain unchanged.

## Validation

- Red: the focused accessibility lint reported `click-events-have-key-events` and `no-static-element-interactions` on the wrapper before the refactor.
- `pnpm exec vp check app/components/workflow/nodes/tool/components/copy-id.tsx app/components/workflow/nodes/tool/components/__tests__/copy-id.spec.tsx`
- `node scripts/lint-a11y.mjs app/components/workflow/nodes/tool/components/copy-id.tsx`
- `pnpm exec vp test run app/components/workflow/nodes/tool/components/__tests__/copy-id.spec.tsx` (2/2)
- `pnpm check` (0 errors; 2059 existing warnings)

From Codex