### PR TITLE
fix(web): make dataset sidebar menu items buttons

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -202,14 +202,6 @@
       "count": 4
     }
   },
-  "web/app/components/app-sidebar/dataset-info/menu-item.tsx": {
-    "jsx_a11y/click-events-have-key-events": {
-      "count": 1
-    },
-    "jsx_a11y/no-static-element-interactions": {
-      "count": 1
-    }
-  },
   "web/app/components/app/annotation/add-annotation-modal/edit-item/index.tsx": {
     "erasable-syntax-only/enums": {
       "count": 1

--- a/web/app/components/app-sidebar/dataset-info/__tests__/index.spec.tsx
+++ b/web/app/components/app-sidebar/dataset-info/__tests__/index.spec.tsx
@@ -240,33 +240,47 @@ describe('MenuItem', () => {
       render(<MenuItem name="Edit" Icon={TestEditIcon} handleClick={handleClick} />)
 
       // Act
-      await user.click(screen.getByText('Edit'))
+      await user.click(screen.getByRole('button', { name: 'Edit' }))
 
       // Assert
       expect(handleClick).toHaveBeenCalledTimes(1)
     })
 
-    it('should stop propagation before invoking the handler', () => {
-      const parentClick = vi.fn()
+    it.each([
+      ['Enter', '{Enter}'],
+      ['Space', ' '],
+    ])('should be reachable and activate with %s', async (_, key) => {
+      const user = userEvent.setup()
       const handleClick = vi.fn()
+      render(<MenuItem name="Edit" Icon={TestEditIcon} handleClick={handleClick} />)
 
-      render(
-        <div role="button" tabIndex={0} onClick={parentClick} onKeyDown={parentClick}>
-          <MenuItem name="Edit" Icon={TestEditIcon} handleClick={handleClick} />
-        </div>,
-      )
+      await user.tab()
+      expect(screen.getByRole('button', { name: 'Edit' })).toHaveFocus()
 
-      fireEvent.click(screen.getByText('Edit'))
+      await user.keyboard(key)
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('should stop propagation before invoking the handler', () => {
+      const handleClick = vi.fn()
+      render(<MenuItem name="Edit" Icon={TestEditIcon} handleClick={handleClick} />)
+
+      const menuItem = screen.getByRole('button', { name: 'Edit' })
+      const event = createEvent.click(menuItem)
+      const stopPropagation = vi.spyOn(event, 'stopPropagation')
+
+      fireEvent(menuItem, event)
 
       expect(handleClick).toHaveBeenCalledTimes(1)
-      expect(parentClick).not.toHaveBeenCalled()
+      expect(stopPropagation).toHaveBeenCalledTimes(1)
     })
 
     it('should prevent the default action when no click handler is provided', () => {
       render(<MenuItem name="Edit" Icon={TestEditIcon} />)
 
-      const event = createEvent.click(screen.getByText('Edit'))
-      fireEvent(screen.getByText('Edit'), event)
+      const menuItem = screen.getByRole('button', { name: 'Edit' })
+      const event = createEvent.click(menuItem)
+      fireEvent(menuItem, event)
 
       expect(event.defaultPrevented).toBe(true)
     })

--- a/web/app/components/app-sidebar/dataset-info/menu-item.tsx
+++ b/web/app/components/app-sidebar/dataset-info/menu-item.tsx
@@ -11,7 +11,7 @@ const MenuItem = ({ Icon, name, handleClick }: MenuItemProps) => {
   return (
     <button
       type="button"
-      className="flex items-center gap-x-1 rounded-lg px-2 py-1.5 text-start outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid"
+      className="flex appearance-none items-center gap-x-1 rounded-lg px-2 py-1.5 text-start outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid"
       onClick={(e) => {
         e.preventDefault()
         e.stopPropagation()

--- a/web/app/components/app-sidebar/dataset-info/menu-item.tsx
+++ b/web/app/components/app-sidebar/dataset-info/menu-item.tsx
@@ -9,17 +9,18 @@ type MenuItemProps = {
 
 const MenuItem = ({ Icon, name, handleClick }: MenuItemProps) => {
   return (
-    <div
-      className="flex items-center gap-x-1 rounded-lg px-2 py-1.5 hover:bg-state-base-hover"
+    <button
+      type="button"
+      className="flex items-center gap-x-1 rounded-lg px-2 py-1.5 text-start outline-hidden hover:bg-state-base-hover focus-visible:ring-2 focus-visible:ring-state-accent-solid"
       onClick={(e) => {
         e.preventDefault()
         e.stopPropagation()
         handleClick?.()
       }}
     >
-      <Icon className="size-4 text-text-tertiary" />
+      <Icon aria-hidden className="size-4 text-text-tertiary" />
       <span className="px-1 system-md-regular text-text-secondary">{name}</span>
-    </div>
+    </button>
   )
 }
 


### PR DESCRIPTION
## Summary

- Render dataset sidebar actions as native `button type="button"` elements.
- Preserve the existing pointer behavior, default prevention, and propagation boundary.
- Query the public role and accessible name in tests, and cover Tab focus plus Enter activation.
- Prune the exact two obsolete `jsx-a11y` suppressions for this component.

## Behavior contract

- Every visible dataset sidebar menu item is exposed as a named button.
- Pointer click and Enter activation invoke the supplied action once.
- Activating an item does not trigger an ancestor action.
- The item remains safe when rendered inside a form because its type is explicitly `button`.

## Visual regression review

A temporary Storybook comparison rendered the previous div and the new button under the same production CSS. It was removed before commit.

- Item geometry: 192 x 32 px for both
- Padding: 6 x 8 px for both
- Icon geometry: 16 x 16 px with identical relative coordinates
- Text geometry: 32.88 x 20 px with identical relative coordinates
- Hover background: `rgba(200, 206, 218, 0.2)` for both
- `text-start` explicitly normalizes the button alignment to the previous div and avoids UA-centered text

The only intended new visual state is the browser focus indicator during keyboard navigation.

## Validation

- `pnpm exec vp check app/components/app-sidebar/dataset-info/menu-item.tsx app/components/app-sidebar/dataset-info/__tests__/index.spec.tsx`
- `node scripts/lint-a11y.mjs app/components/app-sidebar/dataset-info/menu-item.tsx`
- `pnpm exec vp test run app/components/app-sidebar/dataset-info/__tests__/index.spec.tsx` (22/22)
- `pnpm check` (0 errors; 2059 existing warnings)


## Final visual guard

The converted native button now also uses `appearance-none`, closing the remaining cross-browser UA appearance path while preserving the existing normal-state geometry and tokens.

From Codex