### PR TITLE
fix(web): make tool provider cards buttons

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -3616,14 +3616,6 @@
       "count": 1
     }
   },
-  "web/app/components/tools/provider/tool-item.tsx": {
-    "jsx_a11y/click-events-have-key-events": {
-      "count": 1
-    },
-    "jsx_a11y/no-static-element-interactions": {
-      "count": 1
-    }
-  },
   "web/app/components/tools/setting/build-in/config-credentials.tsx": {
     "typescript/no-explicit-any": {
       "count": 3

--- a/web/app/components/tools/provider/__tests__/tool-item.spec.tsx
+++ b/web/app/components/tools/provider/__tests__/tool-item.spec.tsx
@@ -1,5 +1,6 @@
 import type { Collection, Tool } from '../../types'
 import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import ToolItem from '../tool-item'
 
@@ -38,10 +39,11 @@ const tool = {
 } as Tool
 
 describe('ToolItem', () => {
-  it('opens and closes tool details', () => {
+  it('opens and closes tool details', async () => {
+    const user = userEvent.setup()
     render(<ToolItem collection={collection} tool={tool} isBuiltIn isModel={false} />)
 
-    fireEvent.click(screen.getByText('Tool label'))
+    await user.click(screen.getByRole('button', { name: /Tool label/ }))
     expect(screen.getByTestId('tool-detail')).toBeInTheDocument()
     expect(screen.getByTestId('tool-detail')).toHaveAttribute(
       'data-show-readonly-setting-details',
@@ -52,10 +54,22 @@ describe('ToolItem', () => {
     expect(screen.queryByTestId('tool-detail')).not.toBeInTheDocument()
   })
 
+  it('is reachable and opens tool details from the keyboard', async () => {
+    const user = userEvent.setup()
+    render(<ToolItem collection={collection} tool={tool} isBuiltIn isModel={false} />)
+
+    await user.tab()
+    expect(screen.getByRole('button', { name: /Tool label/ })).toHaveFocus()
+
+    await user.keyboard('{Enter}')
+    expect(screen.getByTestId('tool-detail')).toBeInTheDocument()
+  })
+
   it('does not open tool details when disabled', () => {
     render(<ToolItem collection={collection} tool={tool} isBuiltIn isModel={false} disabled />)
 
-    fireEvent.click(screen.getByText('Tool label'))
+    expect(screen.getByRole('button', { name: /Tool label/ })).toBeDisabled()
+    fireEvent.click(screen.getByRole('button', { name: /Tool label/ }))
 
     expect(screen.queryByTestId('tool-detail')).not.toBeInTheDocument()
   })

--- a/web/app/components/tools/provider/tool-item.tsx
+++ b/web/app/components/tools/provider/tool-item.tsx
@@ -22,9 +22,11 @@ const ToolItem = ({ disabled, collection, tool, isBuiltIn, isModel }: Props) => 
 
   return (
     <>
-      <div
+      <button
+        type="button"
+        disabled={disabled}
         className={cn(
-          'bg-components-panel-item-bg cursor-pointer rounded-xl border-[0.5px] border-components-panel-border-subtle px-4 py-3 shadow-xs hover:bg-components-panel-on-panel-item-bg-hover',
+          'bg-components-panel-item-bg w-full cursor-pointer rounded-xl border-[0.5px] border-components-panel-border-subtle px-4 py-3 text-start shadow-xs hover:bg-components-panel-on-panel-item-bg-hover',
           disabled && 'cursor-not-allowed! opacity-50',
         )}
         onClick={() => !disabled && setShowDetail(true)}
@@ -36,7 +38,7 @@ const ToolItem = ({ disabled, collection, tool, isBuiltIn, isModel }: Props) => 
         >
           {tool.description[language]}
         </div>
-      </div>
+      </button>
       {showDetail && (
         <SettingBuiltInTool
           showBackButton


### PR DESCRIPTION
## Summary

- Render each tool provider card as a native `button type="button"`.
- Map the existing disabled presentation to the native `disabled` state.
- Preserve the block-card geometry with explicit `w-full text-start`.
- Cover public button semantics, keyboard activation, and disabled behavior in the owner test.
- Prune the exact two obsolete `jsx-a11y` suppressions.

## Behavior contract

- A tool card is reachable by Tab and opens its read-only details with pointer or Enter activation.
- A disabled card is exposed as disabled, is skipped by browser activation, and does not open details.
- Closing the detail view keeps the existing behavior.

## Visual regression review

A temporary Storybook comparison rendered the previous div and the new button under the same production CSS. It was removed before commit.

- Card geometry: 320 x 63 px for both
- Padding: 12 x 16 px for both
- Border: 0.5 px with 12 px radius for both
- Title and description geometry: identical relative coordinates and dimensions
- Text alignment: `start` for both
- Hover background: `rgb(249, 250, 251)` for both
- Disabled state: opacity 0.5 and `cursor: not-allowed` for both

The only intended new visual state is the browser focus indicator during keyboard navigation.

## Validation

- `pnpm exec vp check app/components/tools/provider/tool-item.tsx app/components/tools/provider/__tests__/tool-item.spec.tsx`
- `node scripts/lint-a11y.mjs app/components/tools/provider/tool-item.tsx`
- `pnpm exec vp test run app/components/tools/provider/__tests__/tool-item.spec.tsx` (3/3)
- `pnpm check` (0 errors; 2059 existing warnings)

From Codex