### PR TITLE
fix(web): name the embedded chat settings trigger

### DIFF
--- a/web/app/components/base/chat/embedded-chatbot/inputs-form/__tests__/view-form-dropdown.spec.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/inputs-form/__tests__/view-form-dropdown.spec.tsx
@@ -11,7 +11,7 @@ describe('ViewFormDropdown', () => {
     const user = userEvent.setup()
     render(<ViewFormDropdown />)
 
-    const trigger = screen.getByTestId('view-form-dropdown-trigger')
+    const trigger = screen.getByRole('button', { name: 'share.chat.chatSettingsTitle' })
     expect(screen.queryByText('Form content')).not.toBeInTheDocument()
 
     await user.click(trigger)

--- a/web/app/components/base/chat/embedded-chatbot/inputs-form/view-form-dropdown.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/inputs-form/view-form-dropdown.tsx
@@ -17,11 +17,15 @@ const ViewFormDropdown = ({ iconColor }: Props) => {
         render={(props, state) => (
           <ActionButton
             {...props}
+            aria-label={t(($) => $['chat.chatSettingsTitle'], { ns: 'share' })}
             size="l"
             state={state.open ? ActionButtonState.Hover : ActionButtonState.Default}
             data-testid="view-form-dropdown-trigger"
           >
-            <div className={cn('i-ri-chat-settings-line h-4.5 w-4.5 shrink-0', iconColor)} />
+            <div
+              aria-hidden="true"
+              className={cn('i-ri-chat-settings-line h-4.5 w-4.5 shrink-0', iconColor)}
+            />
           </ActionButton>
         )}
       />


### PR DESCRIPTION
## Summary

- Give the embedded chat settings trigger the same translated accessible name shown in its panel heading.
- Mark the CSS chat-settings icon as decorative.
- Exercise the trigger through its public button role and accessible name instead of relying on `data-testid`.

## Behavior contract

- Assistive technology exposes the icon-only trigger as the chat settings action.
- Pointer activation still opens and closes the existing popover.
- The existing test ID remains available; this PR changes the test contract without treating test IDs as accessibility defects.

## Visual regression review

This is an ARIA-only change. No element tag, class, style, text node, node order, popover geometry, or interaction state changed, so no visual delta is expected.

## Validation

- `pnpm exec vp check app/components/base/chat/embedded-chatbot/inputs-form/view-form-dropdown.tsx app/components/base/chat/embedded-chatbot/inputs-form/__tests__/view-form-dropdown.spec.tsx`
- `node scripts/lint-a11y.mjs app/components/base/chat/embedded-chatbot/inputs-form/view-form-dropdown.tsx`
- `pnpm exec vp test run app/components/base/chat/embedded-chatbot/inputs-form/__tests__/view-form-dropdown.spec.tsx` (1/1)
- `pnpm check` (0 errors; 2059 existing warnings)

From Codex