### PR TITLE
fix(web): name the snippet info menu trigger

### DIFF
--- a/web/app/components/app-sidebar/snippet-info/__tests__/dropdown.spec.tsx
+++ b/web/app/components/app-sidebar/snippet-info/__tests__/dropdown.spec.tsx
@@ -133,7 +133,7 @@ describe('SnippetInfoDropdown', () => {
     it('should render the dropdown trigger button', () => {
       render(<SnippetInfoDropdown snippet={mockSnippet} />)
 
-      expect(screen.getByRole('button')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'common.operation.more' })).toBeInTheDocument()
     })
 
     it('should render nothing without snippet create or management permission', () => {
@@ -149,7 +149,7 @@ describe('SnippetInfoDropdown', () => {
       mockWorkspacePermissionKeys = ['snippets.create_and_modify']
 
       const { unmount } = render(<SnippetInfoDropdown snippet={mockSnippet} />)
-      await user.click(screen.getByRole('button'))
+      await user.click(screen.getByRole('button', { name: 'common.operation.more' }))
 
       expect(screen.getByText('snippet.menu.editInfo')).toBeInTheDocument()
       expect(screen.getByText('snippet.menu.exportSnippet')).toBeInTheDocument()
@@ -158,7 +158,7 @@ describe('SnippetInfoDropdown', () => {
       unmount()
       mockWorkspacePermissionKeys = ['snippets.management']
       render(<SnippetInfoDropdown snippet={mockSnippet} />)
-      await user.click(screen.getByRole('button'))
+      await user.click(screen.getByRole('button', { name: 'common.operation.more' }))
 
       expect(screen.queryByText('snippet.menu.editInfo')).not.toBeInTheDocument()
       expect(screen.queryByText('snippet.menu.exportSnippet')).not.toBeInTheDocument()
@@ -177,7 +177,7 @@ describe('SnippetInfoDropdown', () => {
       )
 
       render(<SnippetInfoDropdown snippet={mockSnippet} />)
-      await user.click(screen.getByRole('button'))
+      await user.click(screen.getByRole('button', { name: 'common.operation.more' }))
       await user.click(screen.getByText('snippet.menu.editInfo'))
 
       expect(screen.getByTestId('create-snippet-dialog')).toBeInTheDocument()
@@ -216,7 +216,7 @@ describe('SnippetInfoDropdown', () => {
 
       render(<SnippetInfoDropdown snippet={mockSnippet} />)
 
-      await user.click(screen.getByRole('button'))
+      await user.click(screen.getByRole('button', { name: 'common.operation.more' }))
       await user.click(screen.getByText('snippet.menu.exportSnippet'))
 
       await waitFor(() => {
@@ -236,7 +236,7 @@ describe('SnippetInfoDropdown', () => {
 
       render(<SnippetInfoDropdown snippet={mockSnippet} />)
 
-      await user.click(screen.getByRole('button'))
+      await user.click(screen.getByRole('button', { name: 'common.operation.more' }))
       await user.click(screen.getByText('snippet.menu.exportSnippet'))
 
       await waitFor(() => {
@@ -257,7 +257,7 @@ describe('SnippetInfoDropdown', () => {
 
       render(<SnippetInfoDropdown snippet={mockSnippet} />)
 
-      await user.click(screen.getByRole('button'))
+      await user.click(screen.getByRole('button', { name: 'common.operation.more' }))
       await user.click(screen.getByText('snippet.menu.deleteSnippet'))
 
       expect(screen.getByText('snippet.deleteConfirmTitle')).toBeInTheDocument()

--- a/web/app/components/app-sidebar/snippet-info/dropdown.tsx
+++ b/web/app/components/app-sidebar/snippet-info/dropdown.tsx
@@ -126,7 +126,10 @@ const SnippetInfoDropdown = ({ snippet }: SnippetInfoDropdownProps) => {
   return (
     <>
       <DropdownMenu open={open} onOpenChange={setOpen}>
-        <DropdownMenuTrigger className="action-btn action-btn-m size-6 rounded-md text-text-tertiary data-popup-open:bg-state-base-hover data-popup-open:text-text-secondary">
+        <DropdownMenuTrigger
+          aria-label={t(($) => $['operation.more'], { ns: 'common' })}
+          className="action-btn action-btn-m size-6 rounded-md text-text-tertiary data-popup-open:bg-state-base-hover data-popup-open:text-text-secondary"
+        >
           <span aria-hidden className="i-ri-more-fill size-4" />
         </DropdownMenuTrigger>
         <DropdownMenuContent placement="bottom-end" sideOffset={4} popupClassName="w-[180px] p-1">


### PR DESCRIPTION
## Summary

- Give the snippet sidebar overflow trigger the established translated `common.operation.more` accessible name.
- Exercise every edit, export, and delete flow through the named trigger instead of an anonymous button query.

## Behavior contract

- Assistive technology exposes the icon-only trigger as the More action.
- Existing permission filtering and edit, export, and delete behavior remain unchanged.
- The label matches the snippet card, dataset sidebar, MCP detail, and other existing overflow-menu contracts.

## Visual regression review

This is an ARIA-only production change. No element tag, class, style, icon, node order, popup placement, or interaction state changed, so no visual delta is expected.

## Validation

- `pnpm exec vp check app/components/app-sidebar/snippet-info/dropdown.tsx app/components/app-sidebar/snippet-info/__tests__/dropdown.spec.tsx`
- `node scripts/lint-a11y.mjs app/components/app-sidebar/snippet-info/dropdown.tsx`
- `pnpm exec vp test run app/components/app-sidebar/snippet-info/__tests__/dropdown.spec.tsx` (7/7)
- `pnpm check` (0 errors; 2059 existing warnings)

From Codex