### PR TITLE
fix(web): name the plugin debug trigger

### DIFF
--- a/web/app/components/plugins/plugin-page/__tests__/debug-info.spec.tsx
+++ b/web/app/components/plugins/plugin-page/__tests__/debug-info.spec.tsx
@@ -49,7 +49,7 @@ describe('DebugInfo', () => {
   it('renders a disabled trigger when debug info is unavailable', () => {
     render(<DebugInfo />)
 
-    const trigger = screen.getByRole('button')
+    const trigger = screen.getByRole('button', { name: 'plugin.debugInfo.title' })
     expect(trigger).toBeDisabled()
   })
 
@@ -63,7 +63,7 @@ describe('DebugInfo', () => {
     const user = userEvent.setup()
     render(<DebugInfo />)
 
-    const trigger = screen.getByRole('button')
+    const trigger = screen.getByRole('button', { name: 'plugin.debugInfo.title' })
     expect(trigger).toBeEnabled()
 
     // Popover is closed initially — content not rendered yet

--- a/web/app/components/plugins/plugin-page/debug-info.tsx
+++ b/web/app/components/plugins/plugin-page/debug-info.tsx
@@ -29,6 +29,7 @@ function DebugInfo({
   const { t } = useTranslation()
   const docLink = useDocLink()
   const { data: info, isLoading } = useDebugKey()
+  const title = t(($) => $[`${i18nPrefix}.title`], { ns: 'plugin' })
   const trigger = triggerContent ?? <span aria-hidden className="i-ri-bug-line size-4" />
   const triggerClassNames = cn(
     !triggerClassName && 'size-full p-2 text-components-button-secondary-text',
@@ -42,7 +43,7 @@ function DebugInfo({
 
   if (!info) {
     return (
-      <Button variant={triggerVariant} className={triggerClassNames} disabled>
+      <Button variant={triggerVariant} className={triggerClassNames} aria-label={title} disabled>
         {trigger}
       </Button>
     )
@@ -52,7 +53,7 @@ function DebugInfo({
     <Popover>
       <PopoverTrigger
         render={
-          <Button variant={triggerVariant} className={triggerClassNames}>
+          <Button variant={triggerVariant} className={triggerClassNames} aria-label={title}>
             {trigger}
           </Button>
         }
@@ -62,7 +63,7 @@ function DebugInfo({
         popupClassName="border-0 bg-transparent p-0 shadow-none"
       >
         <PluginSidecarPanel
-          title={t(($) => $[`${i18nPrefix}.title`], { ns: 'plugin' })}
+          title={title}
           footer={
             <div className="flex w-full shrink-0 flex-col items-start">
               <div className="flex w-full shrink-0 items-center justify-end gap-2 px-4 pt-2 pb-4">


### PR DESCRIPTION
## Summary

- Reuse the plugin debug panel title as the accessible name of both the available and unavailable debug triggers.
- Exercise the enabled and disabled states through the public button role and accessible name.
- Keep the sidebar consumer and default icon trigger on one shared label contract.

## Behavior contract

- The default bug-icon button is announced as the plugin debug action.
- The unavailable state remains disabled while retaining its accessible name.
- The available state opens the same popover and exposes the same title, port, masked key, and documentation link.

## Visual regression review

This is an ARIA-only rendered change plus reuse of the existing title string. No tag, class, style, icon, visible text, node order, popover geometry, or state styling changed, so no visual delta is expected.

## Validation

- `pnpm exec vp check app/components/plugins/plugin-page/debug-info.tsx app/components/plugins/plugin-page/__tests__/debug-info.spec.tsx`
- `node scripts/lint-a11y.mjs app/components/plugins/plugin-page/debug-info.tsx`
- `pnpm exec vp test run app/components/plugins/plugin-page/__tests__/debug-info.spec.tsx` (3/3)
- `pnpm check` (0 errors; 2059 existing warnings)

From Codex