### PR TITLE
fix(web): name conversation menu triggers

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -806,14 +806,6 @@
       "count": 3
     }
   },
-  "web/app/components/base/chat/chat-with-history/sidebar/__tests__/operation.spec.tsx": {
-    "jsx_a11y/click-events-have-key-events": {
-      "count": 2
-    },
-    "jsx_a11y/no-static-element-interactions": {
-      "count": 2
-    }
-  },
   "web/app/components/base/chat/chat-with-history/sidebar/item.tsx": {
     "jsx_a11y/click-events-have-key-events": {
       "count": 2

--- a/web/app/components/base/chat/chat-with-history/sidebar/__tests__/operation.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/sidebar/__tests__/operation.spec.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import Operation from '../operation'
 
 describe('Operation', () => {
+  const getTrigger = () => screen.getByRole('button', { name: 'common.operation.more' })
   const defaultProps = {
     isActive: false,
     isItemHovering: false,
@@ -22,14 +23,14 @@ describe('Operation', () => {
 
   it('should render more icon button', () => {
     render(<Operation {...defaultProps} />)
-    expect(screen.getByRole('button')).toBeInTheDocument()
+    expect(getTrigger()).toBeInTheDocument()
   })
 
   it('should toggle dropdown when clicked', async () => {
     const user = userEvent.setup()
     render(<Operation {...defaultProps} isItemHovering={true} />)
 
-    const trigger = screen.getByRole('button')
+    const trigger = getTrigger()
     await user.click(trigger)
 
     expect(screen.getByText('explore.sidebar.action.pin')).toBeInTheDocument()
@@ -37,14 +38,14 @@ describe('Operation', () => {
 
   it('should apply active state to ActionButton', () => {
     render(<Operation {...defaultProps} isActive={true} />)
-    expect(screen.getByRole('button')).toBeInTheDocument()
+    expect(getTrigger()).toBeInTheDocument()
   })
 
   it('should call togglePin when pin/unpin is clicked', async () => {
     const user = userEvent.setup()
     render(<Operation {...defaultProps} />)
 
-    await user.click(screen.getByRole('button'))
+    await user.click(getTrigger())
     await user.click(screen.getByText('explore.sidebar.action.pin'))
 
     expect(defaultProps.togglePin).toHaveBeenCalled()
@@ -54,7 +55,7 @@ describe('Operation', () => {
     const user = userEvent.setup()
     render(<Operation {...defaultProps} isPinned={true} />)
 
-    await user.click(screen.getByRole('button'))
+    await user.click(getTrigger())
     expect(screen.getByText('explore.sidebar.action.unpin')).toBeInTheDocument()
   })
 
@@ -62,7 +63,7 @@ describe('Operation', () => {
     const user = userEvent.setup()
     render(<Operation {...defaultProps} />)
 
-    await user.click(screen.getByRole('button'))
+    await user.click(getTrigger())
     await user.click(screen.getByText('explore.sidebar.action.rename'))
 
     await waitFor(() => {
@@ -74,7 +75,7 @@ describe('Operation', () => {
     const user = userEvent.setup()
     render(<Operation {...defaultProps} />)
 
-    await user.click(screen.getByRole('button'))
+    await user.click(getTrigger())
     await user.click(screen.getByText('explore.sidebar.action.delete'))
 
     await waitFor(() => {
@@ -86,7 +87,7 @@ describe('Operation', () => {
     const user = userEvent.setup()
     render(<Operation {...defaultProps} isShowRenameConversation={false} />)
 
-    await user.click(screen.getByRole('button'))
+    await user.click(getTrigger())
     expect(screen.queryByText('explore.sidebar.action.rename')).not.toBeInTheDocument()
   })
 
@@ -94,7 +95,7 @@ describe('Operation', () => {
     const user = userEvent.setup()
     render(<Operation {...defaultProps} isShowRenameConversation={false} isShowDelete={false} />)
 
-    await user.click(screen.getByRole('button'))
+    await user.click(getTrigger())
     expect(screen.queryByText('explore.sidebar.action.rename')).not.toBeInTheDocument()
     expect(screen.queryByText('explore.sidebar.action.delete')).not.toBeInTheDocument()
   })
@@ -103,7 +104,7 @@ describe('Operation', () => {
     const user = userEvent.setup()
     render(<Operation {...defaultProps} isItemHovering={true} />)
 
-    await user.click(screen.getByRole('button'))
+    await user.click(getTrigger())
 
     expect(screen.getByText('explore.sidebar.action.pin')).toBeInTheDocument()
   })
@@ -112,7 +113,7 @@ describe('Operation', () => {
     const user = userEvent.setup()
     const { rerender } = render(<Operation {...defaultProps} isItemHovering={true} />)
 
-    await user.click(screen.getByRole('button'))
+    await user.click(getTrigger())
     expect(screen.getByText('explore.sidebar.action.pin')).toBeInTheDocument()
 
     rerender(<Operation {...defaultProps} isItemHovering={false} />)
@@ -125,7 +126,7 @@ describe('Operation', () => {
   it('should keep the trigger mounted while visually hidden', () => {
     render(<Operation {...defaultProps} isItemHovering={false} />)
 
-    const trigger = screen.getByRole('button')
+    const trigger = getTrigger()
     expect(trigger).toHaveClass('pointer-events-none')
     expect(trigger).toHaveClass('opacity-0')
   })
@@ -134,7 +135,7 @@ describe('Operation', () => {
     const user = userEvent.setup()
     render(<Operation {...defaultProps} onRenameConversation={undefined} />)
 
-    await user.click(screen.getByRole('button'))
+    await user.click(getTrigger())
     await user.click(screen.getByText('explore.sidebar.action.rename'))
 
     await waitFor(() => {
@@ -146,13 +147,11 @@ describe('Operation', () => {
     const user = userEvent.setup()
     const parentClick = vi.fn()
 
-    render(
-      <div onClick={parentClick}>
-        <Operation {...defaultProps} />
-      </div>,
-    )
+    render(<Operation {...defaultProps} />)
+    document.body.addEventListener('click', parentClick)
 
-    await user.click(screen.getByRole('button'))
+    await user.click(getTrigger())
+    document.body.removeEventListener('click', parentClick)
 
     expect(parentClick).not.toHaveBeenCalled()
   })
@@ -161,14 +160,12 @@ describe('Operation', () => {
     const user = userEvent.setup()
     const parentClick = vi.fn()
 
-    render(
-      <div onClick={parentClick}>
-        <Operation {...defaultProps} isItemHovering={true} />
-      </div>,
-    )
+    render(<Operation {...defaultProps} isItemHovering={true} />)
+    document.body.addEventListener('click', parentClick)
 
-    await user.click(screen.getByRole('button'))
+    await user.click(getTrigger())
     await user.click(screen.getByRole('menu'))
+    document.body.removeEventListener('click', parentClick)
 
     expect(parentClick).not.toHaveBeenCalled()
   })

--- a/web/app/components/base/chat/chat-with-history/sidebar/operation.tsx
+++ b/web/app/components/base/chat/chat-with-history/sidebar/operation.tsx
@@ -51,6 +51,7 @@ const Operation: FC<Props> = ({
         render={(props, state) => (
           <ActionButton
             {...props}
+            aria-label={t(($) => $['operation.more'], { ns: 'common' })}
             className={cn(
               isItemHovering || state.open
                 ? 'pointer-events-auto opacity-100'


### PR DESCRIPTION
## Summary

- Give each chat-history conversation overflow trigger the established translated `common.operation.more` accessible name.
- Exercise all pin, unpin, rename, delete, visibility, hover, and propagation flows through the named trigger.
- Replace clickable-div propagation fixtures with a real ancestor event observer.
- Prune the four exact `jsx-a11y` suppressions that the old test fixtures required.

## Behavior contract

- The visually conditional overflow action remains mounted and is announced as More.
- Existing menu visibility, active styling, pin, rename, delete, and deferred callbacks remain unchanged.
- Trigger and popup clicks remain isolated from the conversation-row ancestor.
- This PR does not change the separate conversation item semantics or their remaining suppressions.

## Visual regression review

The production change adds only `aria-label`. No tag, class, style, icon, node order, hover visibility, popup geometry, or interaction state changed, so no visual delta is expected.

## Validation

- `pnpm exec vp check app/components/base/chat/chat-with-history/sidebar/__tests__/operation.spec.tsx`
- `node scripts/lint-a11y.mjs app/components/base/chat/chat-with-history/sidebar/operation.tsx`
- `pnpm exec vp test run app/components/base/chat/chat-with-history/sidebar/__tests__/operation.spec.tsx` (15/15)
- `pnpm check` (0 errors; 2059 existing warnings)

From Codex