### PR TITLE
fix(web): name dataset configuration actions

### DIFF
--- a/web/app/components/app/configuration/dataset-config/card-item/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/dataset-config/card-item/__tests__/index.spec.tsx
@@ -151,7 +151,14 @@ describe('dataset-config/card-item', () => {
     renderItem(dataset)
 
     const card = screen.getByText(dataset.name).closest('.group') as HTMLElement
-    const actionButtons = within(card).getAllByRole('button', { hidden: true })
+    const editButton = within(card).getByRole('button', {
+      name: 'common.operation.edit',
+      hidden: true,
+    })
+    const removeButton = within(card).getByRole('button', {
+      name: 'common.operation.remove',
+      hidden: true,
+    })
 
     expect(screen.getByText(dataset.name))!.toBeInTheDocument()
     expect(
@@ -160,7 +167,8 @@ describe('dataset-config/card-item', () => {
       ),
     )!.toBeInTheDocument()
     expect(screen.getByText('dataset.externalTag'))!.toBeInTheDocument()
-    expect(actionButtons).toHaveLength(2)
+    expect(editButton).toBeInTheDocument()
+    expect(removeButton).toBeInTheDocument()
   })
 
   it('should open settings drawer from edit action and close after saving', async () => {
@@ -169,8 +177,11 @@ describe('dataset-config/card-item', () => {
     const { onSave } = renderItem(dataset)
 
     const card = screen.getByText(dataset.name).closest('.group') as HTMLElement
-    const [editButton] = within(card).getAllByRole('button', { hidden: true })
-    await user.click(editButton!)
+    const editButton = within(card).getByRole('button', {
+      name: 'common.operation.edit',
+      hidden: true,
+    })
+    await user.click(editButton)
 
     expect(await screen.findByText('Mock settings modal'))!.toBeInTheDocument()
     fireEvent.click(await screen.findByText('Save changes'))
@@ -189,8 +200,10 @@ describe('dataset-config/card-item', () => {
     const { onRemove } = renderItem(dataset)
 
     const card = screen.getByText(dataset.name).closest('.group') as HTMLElement
-    const buttons = within(card).getAllByRole('button', { hidden: true })
-    const deleteButton = buttons.at(-1)!
+    const deleteButton = within(card).getByRole('button', {
+      name: 'common.operation.remove',
+      hidden: true,
+    })
 
     expect(deleteButton.className).not.toContain('action-btn-destructive')
 
@@ -225,8 +238,11 @@ describe('dataset-config/card-item', () => {
     renderItem(dataset)
 
     const card = screen.getByText(dataset.name).closest('.group') as HTMLElement
-    const [editButton] = within(card).getAllByRole('button', { hidden: true })
-    await user.click(editButton!)
+    const editButton = within(card).getByRole('button', {
+      name: 'common.operation.edit',
+      hidden: true,
+    })
+    await user.click(editButton)
     expect(screen.getByText('Mock settings modal'))!.toBeInTheDocument()
 
     const overlay = [...document.querySelectorAll('[class]')].find(

--- a/web/app/components/app/configuration/dataset-config/card-item/index.tsx
+++ b/web/app/components/app/configuration/dataset-config/card-item/index.tsx
@@ -74,22 +74,25 @@ const Item: FC<ItemProps> = ({ config, onSave, onRemove, readonly = false, edita
       <div className="ml-2 hidden shrink-0 items-center space-x-1 group-hover:flex">
         {editable && !readonly && (
           <ActionButton
+            aria-label={t(($) => $['operation.edit'], { ns: 'common' })}
             onClick={(e) => {
               e.stopPropagation()
               setShowSettingsModal(true)
             }}
           >
-            <RiEditLine className="size-4 shrink-0 text-text-tertiary" />
+            <RiEditLine aria-hidden="true" className="size-4 shrink-0 text-text-tertiary" />
           </ActionButton>
         )}
         {!readonly && (
           <ActionButton
+            aria-label={t(($) => $['operation.remove'], { ns: 'common' })}
             onClick={() => onRemove(config.id)}
             state={isDeleting ? ActionButtonState.Destructive : ActionButtonState.Default}
             onMouseEnter={() => setIsDeleting(true)}
             onMouseLeave={() => setIsDeleting(false)}
           >
             <RiDeleteBinLine
+              aria-hidden="true"
               className={cn(
                 'size-4 shrink-0 text-text-tertiary',
                 isDeleting && 'text-text-destructive',


### PR DESCRIPTION
## Summary

- Give the dataset configuration card edit and remove actions explicit accessible names.
- Hide the Remix icons from the accessibility tree because the button names now own the semantics.
- Query the actions by role and accessible name in the owner tests instead of relying on DOM order.

## Behavior contract

- Assistive technology identifies the two icon-only actions as Edit and Remove.
- Editing still opens the settings drawer, saving still closes it, and the mobile overlay behavior remains covered.
- Removing still invokes the existing callback, including the existing destructive hover state.

## Visual regression

No visual change is expected. This PR does not change elements, classes, styles, layout, node order, or event handlers; it only adds ARIA attributes and strengthens test queries.

The two existing prefer-tailwind-icons warnings in this component are intentionally left unchanged so an icon implementation migration can be reviewed separately.

## Validation

- pnpm exec vp check web/app/components/app/configuration/dataset-config/card-item/index.tsx web/app/components/app/configuration/dataset-config/card-item/__tests__/index.spec.tsx
- node scripts/lint-a11y.mjs web/app/components/app/configuration/dataset-config/card-item/index.tsx
- pnpm exec vp test run web/app/components/app/configuration/dataset-config/card-item/__tests__/index.spec.tsx (5/5)
- pnpm check (0 errors, 2059 existing warnings)

From Codex