### PR TITLE
fix(web): name annotation configuration action

### DIFF
--- a/web/app/components/app/annotation/__tests__/index.spec.tsx
+++ b/web/app/components/app/annotation/__tests__/index.spec.tsx
@@ -501,7 +501,9 @@ describe('Annotation', () => {
 
     expect(latestListProps.selectedIds).toEqual([])
 
-    const configButton = document.querySelector('.action-btn') as HTMLButtonElement
+    const configButton = screen.getByRole('button', {
+      name: 'appAnnotation.initSetup.configTitle',
+    })
     fireEvent.click(configButton)
     expect(await screen.findByTestId('config-modal')).toBeInTheDocument()
 

--- a/web/app/components/app/annotation/index.tsx
+++ b/web/app/components/app/annotation/index.tsx
@@ -202,8 +202,16 @@ const Annotation: FC<Props> = (props) => {
                   {annotationConfig?.enabled && (
                     <div className="flex items-center pr-1 pl-1.5">
                       <div className="mr-1 h-3.5 w-px shrink-0 bg-divider-subtle"></div>
-                      <ActionButton onClick={() => setIsShowEdit(true)}>
-                        <RiEqualizer2Line className="size-4 text-text-tertiary" />
+                      <ActionButton
+                        aria-label={t(($) => $['initSetup.configTitle'], {
+                          ns: 'appAnnotation',
+                        })}
+                        onClick={() => setIsShowEdit(true)}
+                      >
+                        <RiEqualizer2Line
+                          aria-hidden="true"
+                          className="size-4 text-text-tertiary"
+                        />
                       </ActionButton>
                     </div>
                   )}


### PR DESCRIPTION
## Summary

- Give the icon-only annotation reply setup action an explicit accessible name using the existing localized modal title.
- Hide the equalizer icon from the accessibility tree because the button now owns the semantics.
- Replace the owner test's CSS-class lookup with a role-and-name query.

## Behavior contract

- Assistive technology identifies the action as Annotation Reply Setup.
- Activating the action still opens the existing configuration modal.
- The existing save, close, selection, and annotation-list flows remain covered by the owner suite.

## Visual regression

No visual change is expected. This PR does not change elements, classes, styles, layout, node order, or event handlers; it only adds ARIA attributes and strengthens one test query.

The existing icon migration warning and the annotation owner's existing data-flow lint debt are intentionally left unchanged so they can be reviewed separately.

## Validation

- node scripts/lint-a11y.mjs app/components/app/annotation/index.tsx
- pnpm exec vp test run app/components/app/annotation/__tests__/index.spec.tsx (9/9)
- pnpm check (0 errors, 2059 existing warnings)

The narrow file-only lint command also reports six pre-existing baseline errors in the annotation owner; this PR introduces none of those diagnostics.

From Codex