### PR TITLE
fix(web): name saved item actions

### DIFF
--- a/web/app/components/app/text-generate/saved-items/__tests__/index.spec.tsx
+++ b/web/app/components/app/text-generate/saved-items/__tests__/index.spec.tsx
@@ -37,27 +37,22 @@ describe('SavedItems', () => {
     expect(markdownElement)!.toBeInTheDocument()
     expect(screen.getByText('11 common.unit.char'))!.toBeInTheDocument()
 
-    const actionArea = container.querySelector('[class*="bg-components-actionbar-bg"]')
-    const actionButtons = actionArea?.querySelectorAll('button') ?? []
-    expect(actionButtons.length).toBeGreaterThanOrEqual(3)
+    expect(screen.getByRole('button', { name: 'common.operation.copy' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'common.operation.delete' })).toBeInTheDocument()
   })
 
   it('copies content and notifies, and triggers remove callback', () => {
     const handleRemove = vi.fn()
-    const { container } = render(<SavedItems {...baseProps} onRemove={handleRemove} />)
+    render(<SavedItems {...baseProps} onRemove={handleRemove} />)
 
-    const actionArea = container.querySelector('[class*="bg-components-actionbar-bg"]')
-    const actionButtons = actionArea?.querySelectorAll('button') ?? []
-    expect(actionButtons.length).toBeGreaterThanOrEqual(3)
+    const copyButton = screen.getByRole('button', { name: 'common.operation.copy' })
+    const deleteButton = screen.getByRole('button', { name: 'common.operation.delete' })
 
-    const copyButton = actionButtons[1]
-    const deleteButton = actionButtons[2]
-
-    fireEvent.click(copyButton!)
+    fireEvent.click(copyButton)
     expect(mockCopy).toHaveBeenCalledWith('hello world')
     expect(toastSuccessSpy).toHaveBeenCalledWith('common.actionMsg.copySuccessfully')
 
-    fireEvent.click(deleteButton!)
+    fireEvent.click(deleteButton)
     expect(handleRemove).toHaveBeenCalledWith('1')
   })
 })

--- a/web/app/components/app/text-generate/saved-items/index.tsx
+++ b/web/app/components/app/text-generate/saved-items/index.tsx
@@ -49,19 +49,21 @@ const SavedItems: FC<ISavedItemsProps> = ({
                 <div className="ml-1 flex items-center gap-0.5 rounded-[10px] border-[0.5px] border-components-actionbar-border bg-components-actionbar-bg p-0.5 shadow-md backdrop-blur-xs">
                   {isShowTextToSpeech && <NewAudioButton value={answer} />}
                   <ActionButton
+                    aria-label={t(($) => $['operation.copy'], { ns: 'common' })}
                     onClick={() => {
                       copy(answer)
                       toast.success(t(($) => $['actionMsg.copySuccessfully'], { ns: 'common' }))
                     }}
                   >
-                    <RiClipboardLine className="size-4" />
+                    <RiClipboardLine aria-hidden="true" className="size-4" />
                   </ActionButton>
                   <ActionButton
+                    aria-label={t(($) => $['operation.delete'], { ns: 'common' })}
                     onClick={() => {
                       onRemove(id)
                     }}
                   >
-                    <RiDeleteBinLine className="size-4" />
+                    <RiDeleteBinLine aria-hidden="true" className="size-4" />
                   </ActionButton>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

- Give the saved text copy and delete icon buttons explicit accessible names.
- Hide their Remix icons from the accessibility tree because the buttons now own the semantics.
- Replace CSS-class and DOM-order test lookups with role-and-name queries.

## Behavior contract

- Assistive technology identifies the saved-item actions as Copy and Delete.
- Copy still writes the answer and shows the existing success toast.
- Delete still invokes the owner callback with the saved item ID.
- The text-to-speech action remains independent and unchanged.

## Visual regression

No visual change is expected. This PR does not change elements, classes, styles, layout, node order, or event handlers; it only adds ARIA attributes and strengthens test queries.

The two existing prefer-tailwind-icons warnings are intentionally left unchanged so icon implementation can be reviewed separately.

## Validation

- pnpm exec vp check app/components/app/text-generate/saved-items/index.tsx app/components/app/text-generate/saved-items/__tests__/index.spec.tsx (0 errors, 2 existing icon warnings)
- node scripts/lint-a11y.mjs app/components/app/text-generate/saved-items/index.tsx
- pnpm exec vp test run app/components/app/text-generate/saved-items/__tests__/index.spec.tsx (2/2)
- pnpm check (0 errors, 2059 existing warnings)

From Codex