### PR TITLE
fix(web): expose debug toolbar semantics

### DIFF
--- a/web/app/components/app/configuration/debug/__tests__/index.spec.tsx
+++ b/web/app/components/app/configuration/debug/__tests__/index.spec.tsx
@@ -158,14 +158,12 @@ vi.mock('@/app/components/app/text-generate/item', () => ({
 vi.mock('@/app/components/base/action-button', () => ({
   default: ({
     children,
-    onClick,
     state,
-  }: {
-    children: React.ReactNode
-    onClick?: () => void
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
     state?: string
   }) => (
-    <button type="button" data-testid="action-button" data-state={state} onClick={onClick}>
+    <button type="button" data-testid="action-button" data-state={state} {...props}>
       {children}
     </button>
   ),
@@ -581,7 +579,7 @@ describe('Debug', () => {
 
       expect(screen.getByTestId('debug-with-single-model'))!.toBeInTheDocument()
 
-      fireEvent.click(screen.getAllByTestId('action-button')[0]!)
+      fireEvent.click(screen.getByRole('button', { name: 'common.operation.refresh' }))
       expect(mockState.mockHandleRestart).toHaveBeenCalledTimes(1)
     })
 
@@ -607,7 +605,14 @@ describe('Debug', () => {
       })
 
       expect(screen.getByTestId('chat-user-input'))!.toBeInTheDocument()
-      fireEvent.click(screen.getAllByTestId('action-button')[1]!)
+      const inputPanelButton = screen.getByRole('button', {
+        name: 'workflow.panel.userInputField',
+      })
+      expect(inputPanelButton).toHaveAttribute('aria-expanded', 'true')
+
+      fireEvent.click(inputPanelButton)
+
+      expect(inputPanelButton).toHaveAttribute('aria-expanded', 'false')
       expect(screen.queryByTestId('chat-user-input')).not.toBeInTheDocument()
     })
 
@@ -619,7 +624,7 @@ describe('Debug', () => {
         },
       })
 
-      fireEvent.click(screen.getAllByTestId('action-button')[0]!)
+      fireEvent.click(screen.getByRole('button', { name: 'common.operation.refresh' }))
       expect(mockState.mockHandleRestart).toHaveBeenCalledTimes(1)
     })
 
@@ -631,7 +636,9 @@ describe('Debug', () => {
         },
       })
 
-      expect(screen.queryByTestId('action-button')).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'common.operation.refresh' }),
+      ).not.toBeInTheDocument()
     })
 
     it('should show formatting confirmation and handle cancel', () => {

--- a/web/app/components/app/configuration/debug/index.tsx
+++ b/web/app/components/app/configuration/debug/index.tsx
@@ -442,8 +442,11 @@ const Debug: FC<IDebug> = ({
                   <Tooltip>
                     <TooltipTrigger
                       render={
-                        <ActionButton onClick={clearConversation}>
-                          <RefreshCcw01 className="size-4" />
+                        <ActionButton
+                          aria-label={t(($) => $['operation.refresh'], { ns: 'common' })}
+                          onClick={clearConversation}
+                        >
+                          <RefreshCcw01 aria-hidden="true" className="size-4" />
                         </ActionButton>
                       }
                     />
@@ -459,11 +462,13 @@ const Debug: FC<IDebug> = ({
                       <TooltipTrigger
                         render={
                           <ActionButton
+                            aria-expanded={expanded}
+                            aria-label={t(($) => $['panel.userInputField'], { ns: 'workflow' })}
                             state={expanded ? ActionButtonState.Active : undefined}
                             disabled={!canTestAndRun}
                             onClick={() => setExpanded(!expanded)}
                           >
-                            <RiEqualizer2Line className="size-4" />
+                            <RiEqualizer2Line aria-hidden="true" className="size-4" />
                           </ActionButton>
                         }
                       />


### PR DESCRIPTION
## Summary

- Give the debug toolbar restart and user-input-panel actions explicit accessible names using their existing tooltip translations.
- Expose the user-input panel toggle state through aria-expanded.
- Hide decorative toolbar icons from the accessibility tree.
- Make the ActionButton test double forward native button attributes, then replace index-based test-id queries with role, name, and state assertions.

## Behavior contract

- Assistive technology identifies the toolbar actions as Restart and User Input Field.
- Restart still resets the single-model conversation and remains available for readonly apps with test/run permission.
- The user-input action reports its expanded or collapsed state and still shows or hides the existing input panel.
- Permission-gated absence remains covered.

## Visual regression

No visual change is expected. This PR does not change elements, classes, styles, layout, node order, tooltip content, or event handlers; it only adds ARIA attributes and strengthens the owner test boundary.

The existing icon migration warnings and debug owner's existing data-flow lint debt are intentionally left unchanged for separate review.

## Validation

- node scripts/lint-a11y.mjs app/components/app/configuration/debug/index.tsx
- pnpm exec vp test run app/components/app/configuration/debug/__tests__/index.spec.tsx (28/28)
- pnpm check (0 errors, 2059 existing warnings)

The narrow file-only lint command also reports thirteen pre-existing baseline errors across this large owner and its test; this PR introduces none of those diagnostics.

From Codex