### PR TITLE
fix(web): name generated result copy action

### DIFF
--- a/web/app/components/app/configuration/config/automatic/__tests__/result.spec.tsx
+++ b/web/app/components/app/configuration/config/automatic/__tests__/result.spec.tsx
@@ -83,7 +83,7 @@ describe('Result', () => {
     expect(screen.getByTestId('prompt-res'))!.toHaveTextContent('generated output')
 
     fireEvent.click(screen.getByTestId('version-selector'))
-    fireEvent.click(screen.getAllByRole('button')[1]!)
+    fireEvent.click(screen.getByRole('button', { name: 'common.operation.copy' }))
     fireEvent.click(screen.getByText(/(?:^|\.)generate\.apply(?=$|:)/))
 
     expect(mockSetCurrentVersionIndex).toHaveBeenCalledWith(1)

--- a/web/app/components/app/configuration/config/automatic/result.tsx
+++ b/web/app/components/app/configuration/config/automatic/result.tsx
@@ -53,13 +53,14 @@ const Result: FC<Props> = ({
         </div>
         <div className="flex items-center space-x-2">
           <Button
+            aria-label={t(($) => $['operation.copy'], { ns: 'common' })}
             className="px-2"
             onClick={() => {
               copy(current.modified)
               toast.success(t(($) => $['actionMsg.copySuccessfully'], { ns: 'common' }))
             }}
           >
-            <RiClipboardLine className="size-4 text-text-secondary" />
+            <RiClipboardLine aria-hidden="true" className="size-4 text-text-secondary" />
           </Button>
           <Button variant="primary" onClick={onApply}>
             {t(($) => $['generate.apply'], { ns: 'appDebug' })}


### PR DESCRIPTION
## Summary

- Give the icon-only generated-result copy button an explicit accessible name.
- Hide the clipboard icon from the accessibility tree because the button now owns the semantics.
- Replace the owner test's positional button query with a role-and-name query.

## Behavior contract

- Assistive technology identifies the action as Copy.
- Activating it still copies the current generated result and shows the existing success toast.
- Version selection and Apply behavior remain covered and unchanged.

## Visual regression

No visual change is expected. This PR does not change elements, classes, styles, layout, node order, or event handlers; it only adds ARIA attributes and strengthens one test query.

The existing prefer-tailwind-icons warning is intentionally left unchanged so icon implementation can be reviewed separately.

## Validation

- pnpm exec vp check app/components/app/configuration/config/automatic/result.tsx app/components/app/configuration/config/automatic/__tests__/result.spec.tsx (0 errors, 1 existing icon warning)
- node scripts/lint-a11y.mjs app/components/app/configuration/config/automatic/result.tsx
- pnpm exec vp test run app/components/app/configuration/config/automatic/__tests__/result.spec.tsx (3/3)
- pnpm check (0 errors, 2059 existing warnings)

From Codex