### PR TITLE
test(web): query plugin item actions by name

### DIFF
--- a/web/app/components/plugins/plugin-item/__tests__/action.spec.tsx
+++ b/web/app/components/plugins/plugin-item/__tests__/action.spec.tsx
@@ -140,8 +140,6 @@ const getDeleteButton = () => screen.getByRole('button', { name: 'plugin.action.
 
 // ==================== Tests ====================
 
-// Helper to find action buttons (real ActionButton component uses type="button")
-const getActionButtons = () => screen.getAllByRole('button')
 const queryActionButtons = () => screen.queryAllByRole('button')
 
 describe('Action Component', () => {
@@ -272,7 +270,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getDeleteButton())
 
       // Assert
       expect(screen.getByRole('heading', { name: 'plugin.action.delete' }))!.toBeInTheDocument()
@@ -289,7 +287,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getDeleteButton())
 
       // Assert
       // Assert
@@ -306,7 +304,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getDeleteButton())
       expect(screen.getByRole('heading', { name: 'plugin.action.delete' }))!.toBeInTheDocument()
 
       fireEvent.click(getDeleteCancelButton())
@@ -328,7 +326,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getDeleteButton())
       fireEvent.click(getDeleteConfirmButton())
 
       // Assert
@@ -350,7 +348,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getDeleteButton())
       fireEvent.click(getDeleteConfirmButton())
 
       // Assert
@@ -370,7 +368,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getDeleteButton())
       fireEvent.click(getDeleteConfirmButton())
 
       // Assert
@@ -392,7 +390,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getDeleteButton())
       fireEvent.click(getDeleteConfirmButton())
 
       // Assert
@@ -414,7 +412,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getDeleteButton())
       fireEvent.click(getDeleteConfirmButton())
 
       // Assert
@@ -441,7 +439,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getDeleteButton())
       fireEvent.click(getDeleteConfirmButton())
 
       // Assert - Loading state
@@ -474,7 +472,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getPluginInfoButton())
 
       // Assert
       // Assert
@@ -500,7 +498,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getPluginInfoButton())
       expect(screen.getByTestId('plugin-info-modal'))!.toBeInTheDocument()
 
       fireEvent.click(screen.getByTestId('close-plugin-info'))
@@ -559,7 +557,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getCheckForUpdatesButton())
 
       // Assert
       await waitFor(() => {
@@ -585,7 +583,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getCheckForUpdatesButton())
 
       // Assert
       await waitFor(() => {
@@ -604,7 +602,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getCheckForUpdatesButton())
 
       // Assert
       await waitFor(() => {
@@ -628,7 +626,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getCheckForUpdatesButton())
 
       // Assert - toast is called with the translated payload
       await waitFor(() => {
@@ -662,7 +660,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getCheckForUpdatesButton())
 
       // Assert
       await waitFor(() => {
@@ -702,7 +700,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getCheckForUpdatesButton())
 
       // Wait for modal to be called
       await waitFor(() => {
@@ -734,7 +732,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getCheckForUpdatesButton())
 
       // Assert
       await waitFor(() => {
@@ -763,7 +761,7 @@ describe('Action Component', () => {
 
       // Act
       const { rerender } = render(<Action {...props1} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getDeleteButton())
       fireEvent.click(getDeleteConfirmButton())
 
       await waitFor(() => {
@@ -772,7 +770,7 @@ describe('Action Component', () => {
 
       mockUninstallPlugin.mockClear()
       rerender(<Action {...props2} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getDeleteButton())
       fireEvent.click(getDeleteConfirmButton())
 
       await waitFor(() => {
@@ -800,7 +798,7 @@ describe('Action Component', () => {
 
       // Act
       const { rerender } = render(<Action {...props1} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getDeleteButton())
       fireEvent.click(getDeleteConfirmButton())
 
       await waitFor(() => {
@@ -809,7 +807,7 @@ describe('Action Component', () => {
       expect(onDelete2).not.toHaveBeenCalled()
 
       rerender(<Action {...props2} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getDeleteButton())
       fireEvent.click(getDeleteConfirmButton())
 
       await waitFor(() => {
@@ -838,7 +836,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getCheckForUpdatesButton())
 
       // Assert - Should use author and pluginName as fallback
       await waitFor(() => {
@@ -862,7 +860,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getDeleteButton())
       fireEvent.click(getDeleteConfirmButton())
 
       // The confirm button should be disabled during deletion
@@ -888,7 +886,7 @@ describe('Action Component', () => {
 
       // Act
       render(<Action {...props} />)
-      fireEvent.click(getActionButtons()[0]!)
+      fireEvent.click(getDeleteButton())
 
       // Assert
       // Assert

--- a/web/app/components/plugins/plugin-item/__tests__/action.spec.tsx
+++ b/web/app/components/plugins/plugin-item/__tests__/action.spec.tsx
@@ -133,6 +133,10 @@ const createActionProps = (overrides: Partial<ActionProps> = {}): ActionProps =>
 const getDeleteConfirmButton = () =>
   screen.getByRole('button', { name: /common\.operation\.confirm/ })
 const getDeleteCancelButton = () => screen.getByRole('button', { name: 'common.operation.cancel' })
+const getCheckForUpdatesButton = () =>
+  screen.getByRole('button', { name: 'plugin.action.checkForUpdates' })
+const getPluginInfoButton = () => screen.getByRole('button', { name: 'plugin.action.pluginInfo' })
+const getDeleteButton = () => screen.getByRole('button', { name: 'plugin.action.delete' })
 
 // ==================== Tests ====================
 
@@ -165,7 +169,7 @@ describe('Action Component', () => {
       render(<Action {...props} />)
 
       // Assert
-      expect(getActionButtons()).toHaveLength(1)
+      expect(getDeleteButton()).toBeInTheDocument()
     })
 
     it('should render fetch new version button when isShowFetchNewVersion is true', () => {
@@ -180,7 +184,7 @@ describe('Action Component', () => {
       render(<Action {...props} />)
 
       // Assert
-      expect(getActionButtons()).toHaveLength(1)
+      expect(getCheckForUpdatesButton()).toBeInTheDocument()
     })
 
     it('should render info button when isShowInfo is true', () => {
@@ -195,7 +199,7 @@ describe('Action Component', () => {
       render(<Action {...props} />)
 
       // Assert
-      expect(getActionButtons()).toHaveLength(1)
+      expect(getPluginInfoButton()).toBeInTheDocument()
     })
 
     it('should render all buttons when all flags are true', () => {
@@ -210,7 +214,9 @@ describe('Action Component', () => {
       render(<Action {...props} />)
 
       // Assert
-      expect(getActionButtons()).toHaveLength(3)
+      expect(getCheckForUpdatesButton()).toBeInTheDocument()
+      expect(getPluginInfoButton()).toBeInTheDocument()
+      expect(getDeleteButton()).toBeInTheDocument()
     })
 
     it('should render no buttons when all flags are false', () => {
@@ -241,16 +247,15 @@ describe('Action Component', () => {
       render(<Action {...props} />)
 
       // Assert
-      const buttons = getActionButtons()
-      await user.hover(buttons[0]!)
+      await user.hover(getCheckForUpdatesButton())
       expect(await screen.findByText('plugin.action.checkForUpdates'))!.toBeInTheDocument()
-      await user.unhover(buttons[0]!)
+      await user.unhover(getCheckForUpdatesButton())
 
-      await user.hover(buttons[1]!)
+      await user.hover(getPluginInfoButton())
       expect(await screen.findByText('plugin.action.pluginInfo'))!.toBeInTheDocument()
-      await user.unhover(buttons[1]!)
+      await user.unhover(getPluginInfoButton())
 
-      await user.hover(buttons[2]!)
+      await user.hover(getDeleteButton())
       expect(await screen.findByText('plugin.action.delete'))!.toBeInTheDocument()
     })
   })

--- a/web/app/components/plugins/plugin-item/action.tsx
+++ b/web/app/components/plugins/plugin-item/action.tsx
@@ -120,8 +120,11 @@ const Action: FC<Props> = ({
         <Tooltip>
           <TooltipTrigger
             render={
-              <ActionButton onClick={handleFetchNewVersion}>
-                <span className="i-ri-loop-left-line size-4 text-text-tertiary" />
+              <ActionButton
+                aria-label={t(($) => $[`${i18nPrefix}.checkForUpdates`], { ns: 'plugin' })}
+                onClick={handleFetchNewVersion}
+              >
+                <span aria-hidden className="i-ri-loop-left-line size-4 text-text-tertiary" />
               </ActionButton>
             }
           />
@@ -134,8 +137,11 @@ const Action: FC<Props> = ({
         <Tooltip>
           <TooltipTrigger
             render={
-              <ActionButton onClick={showPluginInfo}>
-                <span className="i-ri-information-2-line size-4 text-text-tertiary" />
+              <ActionButton
+                aria-label={t(($) => $[`${i18nPrefix}.pluginInfo`], { ns: 'plugin' })}
+                onClick={showPluginInfo}
+              >
+                <span aria-hidden className="i-ri-information-2-line size-4 text-text-tertiary" />
               </ActionButton>
             }
           />
@@ -149,10 +155,11 @@ const Action: FC<Props> = ({
           <TooltipTrigger
             render={
               <ActionButton
+                aria-label={t(($) => $[`${i18nPrefix}.delete`], { ns: 'plugin' })}
                 className="text-text-tertiary hover:bg-state-destructive-hover hover:text-text-destructive"
                 onClick={showDeleteConfirm}
               >
-                <span className="i-ri-delete-bin-line size-4" />
+                <span aria-hidden className="i-ri-delete-bin-line size-4" />
               </ActionButton>
             }
           />


### PR DESCRIPTION
## Summary

- Replace every remaining single-action positional locator in the plugin item action tests with a helper that queries the intended action by role and accessible name.
- Remove the generic getActionButtons helper so future tests cannot silently bind behavior to toolbar order.
- Keep absence checks on queryAllByRole because those assertions verify action visibility rather than one named action.

## Behavior contract

- Delete scenarios explicitly select Delete.
- Plugin information scenarios explicitly select Plugin info.
- Update scenarios explicitly select Check for updates.
- This PR changes no production behavior and depends on #40261, which introduces the accessible names used by these locators.

## Visual regression

This is a test-only PR. It has no production bundle, DOM, CSS, layout, interaction, or runtime visual effect.

## Validation

- pnpm exec vp check app/components/plugins/plugin-item/__tests__/action.spec.tsx (0 errors, 0 warnings)
- pnpm exec vp test run app/components/plugins/plugin-item/__tests__/action.spec.tsx (32/32)
- pnpm check (0 errors, 2059 existing warnings)
- git diff codex/a11y-plugin-item-actions --stat (1 test file; 25 insertions, 27 deletions)

From Codex