### PR TITLE
fix(web): name plugin detail close action

### DIFF
--- a/web/app/components/plugins/plugin-detail-panel/detail-header/__tests__/index.spec.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/detail-header/__tests__/index.spec.tsx
@@ -45,10 +45,8 @@ vi.mock('@/utils/var', () => ({
 }))
 
 vi.mock('@/app/components/base/action-button', () => ({
-  default: ({ onClick, children }: { onClick?: () => void; children: React.ReactNode }) => (
-    <button data-testid="close-button" onClick={onClick}>
-      {children}
-    </button>
+  default: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
   ),
 }))
 
@@ -219,7 +217,7 @@ describe('DetailHeader', () => {
     render(<DetailHeader detail={createDetail()} onHide={onHide} onUpdate={vi.fn()} />)
 
     fireEvent.click(screen.getByText('plugin.detailPanel.operation.update'))
-    fireEvent.click(screen.getByTestId('close-button'))
+    fireEvent.click(screen.getByRole('button', { name: 'common.operation.close' }))
 
     expect(mockHandleUpdate).toHaveBeenCalledTimes(1)
     expect(onHide).toHaveBeenCalled()

--- a/web/app/components/plugins/plugin-detail-panel/detail-header/index.tsx
+++ b/web/app/components/plugins/plugin-detail-panel/detail-header/index.tsx
@@ -310,7 +310,10 @@ const DetailHeader = ({
               showCheckVersion={canUpdatePlugin}
               showRemove={canDeletePlugin}
             />
-            <ActionButton onClick={onHide}>
+            <ActionButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              onClick={onHide}
+            >
               <span aria-hidden className="i-ri-close-line size-4" />
             </ActionButton>
           </div>


### PR DESCRIPTION
## Summary

- Give the icon-only plugin detail panel close action the existing localized common.operation.close accessible name.
- Keep the close icon hidden from the accessibility tree because the button owns the action semantics.
- Make the owner test mock forward native button attributes and select Close by role and name instead of data-testid.

## Behavior contract

- Assistive technology identifies the detail panel action as Close.
- Activating Close still calls the existing onHide callback.
- Update and all other plugin detail header behavior remain unchanged.

## Visual regression

No visual change is expected. This PR does not change the rendered element, icon, classes, styles, layout, dimensions, node order, visibility, event handlers, or focus styling; it only adds an ARIA attribute.

## Validation

- pnpm exec vp check app/components/plugins/plugin-detail-panel/detail-header/index.tsx app/components/plugins/plugin-detail-panel/detail-header/__tests__/index.spec.tsx (0 errors, 1 pre-existing warning)
- node scripts/lint-a11y.mjs app/components/plugins/plugin-detail-panel/detail-header/index.tsx (0 errors)
- pnpm exec vp test run app/components/plugins/plugin-detail-panel/detail-header/__tests__/index.spec.tsx (2/2)
- pnpm check (0 errors, 2059 existing warnings)

From Codex