### PR TITLE
fix(web): name plugin credential actions

### DIFF
--- a/web/app/components/plugins/plugin-auth/authorized/__tests__/item.spec.tsx
+++ b/web/app/components/plugins/plugin-auth/authorized/__tests__/item.spec.tsx
@@ -191,8 +191,7 @@ describe('Item Component', () => {
       )
 
       const enterRenameMode = () => {
-        const firstButton = result.container.querySelectorAll('button')[0] as HTMLElement
-        fireEvent.click(firstButton)
+        fireEvent.click(screen.getByRole('button', { name: 'common.operation.rename' }))
       }
 
       return { ...result, onRename, enterRenameMode }
@@ -337,7 +336,7 @@ describe('Item Component', () => {
         credentials: { api_key: 'secret' },
       })
 
-      const { container } = render(
+      render(
         <Item
           credential={credential}
           onEdit={onEdit}
@@ -348,10 +347,7 @@ describe('Item Component', () => {
         />,
       )
 
-      const editButton = container
-        .querySelector('.i-ri-equalizer-2-line')
-        ?.closest('button') as HTMLElement
-      fireEvent.click(editButton)
+      fireEvent.click(screen.getByRole('button', { name: 'common.operation.edit' }))
       expect(onEdit).toHaveBeenCalledWith('edit-test-id', {
         api_key: 'secret',
         __name__: 'Edit Test',
@@ -403,7 +399,7 @@ describe('Item Component', () => {
       const onDelete = vi.fn()
       const credential = createCredential({ id: 'delete-test-id' })
 
-      const { container } = render(
+      render(
         <Item
           credential={credential}
           onDelete={onDelete}
@@ -414,10 +410,7 @@ describe('Item Component', () => {
         />,
       )
 
-      const deleteButton = container
-        .querySelector('.i-ri-delete-bin-line')
-        ?.closest('button') as HTMLElement
-      fireEvent.click(deleteButton)
+      fireEvent.click(screen.getByRole('button', { name: 'common.operation.delete' }))
       expect(onDelete).toHaveBeenCalledWith('delete-test-id')
     })
 
@@ -521,7 +514,7 @@ describe('Item Component', () => {
       const onDelete = vi.fn()
       const credential = createCredential()
 
-      const { container } = render(
+      render(
         <Item
           credential={credential}
           onItemClick={onItemClick}
@@ -533,10 +526,7 @@ describe('Item Component', () => {
         />,
       )
 
-      const deleteButton = container
-        .querySelector('.i-ri-delete-bin-line')
-        ?.closest('button') as HTMLElement
-      fireEvent.click(deleteButton)
+      fireEvent.click(screen.getByRole('button', { name: 'common.operation.delete' }))
       expect(onDelete).toHaveBeenCalled()
     })
   })

--- a/web/app/components/plugins/plugin-auth/authorized/item.tsx
+++ b/web/app/components/plugins/plugin-auth/authorized/item.tsx
@@ -177,6 +177,7 @@ const Item = ({
                 <TooltipTrigger
                   render={
                     <ActionButton
+                      aria-label={t(($) => $['operation.rename'], { ns: 'common' })}
                       disabled={disabled || !canManageCredential}
                       onClick={(e) => {
                         e.stopPropagation()
@@ -184,7 +185,7 @@ const Item = ({
                         setRenameValue(credential.name)
                       }}
                     >
-                      <span className="i-ri-edit-line size-4 text-text-tertiary" />
+                      <span aria-hidden className="i-ri-edit-line size-4 text-text-tertiary" />
                     </ActionButton>
                   }
                 />
@@ -200,6 +201,7 @@ const Item = ({
                 <TooltipTrigger
                   render={
                     <ActionButton
+                      aria-label={t(($) => $['operation.edit'], { ns: 'common' })}
                       disabled={disabled || !canManageCredential}
                       onClick={(e) => {
                         e.stopPropagation()
@@ -210,7 +212,10 @@ const Item = ({
                         })
                       }}
                     >
-                      <span className="i-ri-equalizer-2-line size-4 text-text-tertiary" />
+                      <span
+                        aria-hidden
+                        className="i-ri-equalizer-2-line size-4 text-text-tertiary"
+                      />
                     </ActionButton>
                   }
                 />
@@ -222,6 +227,7 @@ const Item = ({
               <TooltipTrigger
                 render={
                   <ActionButton
+                    aria-label={t(($) => $['operation.delete'], { ns: 'common' })}
                     className="hover:bg-transparent"
                     disabled={disabled || !canManageCredential}
                     onClick={(e) => {
@@ -229,7 +235,10 @@ const Item = ({
                       onDelete?.(credential.id)
                     }}
                   >
-                    <span className="i-ri-delete-bin-line size-4 text-text-tertiary hover:text-text-destructive" />
+                    <span
+                      aria-hidden
+                      className="i-ri-delete-bin-line size-4 text-text-tertiary hover:text-text-destructive"
+                    />
                   </ActionButton>
                 }
               />


### PR DESCRIPTION
## Summary

- Give the plugin credential Rename, Edit, and Delete icon buttons the accessible names already shown in their tooltips.
- Hide each CSS icon from the accessibility tree because its button now owns the action semantics.
- Make the owner tests activate those actions by role and name instead of button order or icon class.

## Behavior contract

- Rename enters the existing inline rename flow.
- Edit passes the same credential values to the existing edit callback.
- Delete passes the same credential id to the existing delete callback and still stops row-click propagation.
- Permission, enterprise, borrowed-credential, disabled, and OAuth visibility rules remain unchanged.

## Scope boundary

This PR intentionally does not change the clickable credential row or the inline rename input. The row keyboard model and the Dify UI field/form migration are separate higher-risk owner changes.

## Visual regression

No visual change is expected. This PR does not change elements, classes, styles, layout, dimensions, hover visibility, node order, event handlers, or focus styling; it only adds ARIA attributes.

## Validation

- pnpm exec vp check app/components/plugins/plugin-auth/authorized/__tests__/item.spec.tsx (0 errors, 0 warnings)
- pnpm exec vp test run app/components/plugins/plugin-auth/authorized/__tests__/item.spec.tsx (37/37)
- pnpm check (0 errors, 2059 existing warnings)
- Focused production lint exposes 3 pre-existing owner errors: deprecated Input import plus the clickable credential row missing role and keyboard handling.
- node scripts/lint-a11y.mjs confirms only the same 2 pre-existing clickable-row accessibility errors.

From Codex