### PR TITLE
fix(web): name chat header actions

### DIFF
--- a/web/app/components/base/chat/chat-with-history/header/__tests__/index.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/header/__tests__/index.spec.tsx
@@ -87,14 +87,11 @@ describe('Header Component', () => {
   })
 
   describe('Interactions', () => {
-    it('should handle new conversation', async () => {
+    it('should handle reset chat', async () => {
       const handleNewConversation = vi.fn()
       setup({ handleNewConversation, sidebarCollapseState: true, currentConversationId: 'conv-1' })
 
-      const buttons = screen.getAllByRole('button')
-      // Sidebar, NewChat, ResetChat (3)
-      const resetChatBtn = buttons[buttons.length - 1]
-      await userEvent.click(resetChatBtn!)
+      await userEvent.click(screen.getByRole('button', { name: 'share.chat.resetChat' }))
 
       expect(handleNewConversation).toHaveBeenCalled()
     })
@@ -340,9 +337,7 @@ describe('Header Component', () => {
         currentConversationId: 'conv-1',
       })
 
-      const buttons = screen.getAllByRole('button')
-      // Sidebar, NewChat, ResetChat (3)
-      const newChatBtn = buttons[1]
+      const newChatBtn = screen.getByRole('button', { name: 'share.chat.newChatTip' })
       expect(newChatBtn)!.toBeDisabled()
     })
 
@@ -353,9 +348,7 @@ describe('Header Component', () => {
         currentConversationId: '',
       })
 
-      const buttons = screen.getAllByRole('button')
-      // Sidebar, NewChat (2)
-      const newChatBtn = buttons[1]
+      const newChatBtn = screen.getByRole('button', { name: 'share.chat.newChatTip' })
       expect(newChatBtn)!.toBeDisabled()
     })
 

--- a/web/app/components/base/chat/chat-with-history/header/index.tsx
+++ b/web/app/components/base/chat/chat-with-history/header/index.tsx
@@ -134,6 +134,7 @@ const Header = () => {
                 render={
                   <div>
                     <ActionButton
+                      aria-label={t(($) => $['chat.newChatTip'], { ns: 'share' })}
                       size="l"
                       state={
                         !currentConversationId || isResponding
@@ -143,7 +144,7 @@ const Header = () => {
                       disabled={!currentConversationId || isResponding}
                       onClick={handleNewConversation}
                     >
-                      <RiEditBoxLine className="h-4.5 w-4.5" />
+                      <RiEditBoxLine aria-hidden className="h-4.5 w-4.5" />
                     </ActionButton>
                   </div>
                 }
@@ -157,8 +158,12 @@ const Header = () => {
             <Tooltip>
               <TooltipTrigger
                 render={
-                  <ActionButton size="l" onClick={handleNewConversation}>
-                    <RiResetLeftLine className="h-4.5 w-4.5" />
+                  <ActionButton
+                    aria-label={t(($) => $['chat.resetChat'], { ns: 'share' })}
+                    size="l"
+                    onClick={handleNewConversation}
+                  >
+                    <RiResetLeftLine aria-hidden className="h-4.5 w-4.5" />
                   </ActionButton>
                 }
               />


### PR DESCRIPTION
## Summary

- Give the chat header New chat and Reset chat icon buttons the accessible names already shown in their tooltips.
- Hide the Remix icons from the accessibility tree because their buttons now own the action semantics.
- Query the reset action and New chat disabled states by role and name instead of toolbar position.

## Behavior contract

- New chat exposes share.chat.newChatTip and preserves its existing disabled rules for no current conversation and active response generation.
- Reset chat exposes share.chat.resetChat and continues to call the existing new-conversation handler.
- The sidebar expand action is intentionally excluded because its opacity and focusability require a separate interaction review.

## Visual regression

No visual change is expected. This PR does not change elements, classes, styles, layout, dimensions, tooltip content, visibility, event handlers, or focus styling; it only adds ARIA attributes. Icon-to-CSS migration is intentionally separate.

## Validation

- pnpm exec vp check app/components/base/chat/chat-with-history/header/__tests__/index.spec.tsx (0 errors, 0 warnings)
- node scripts/lint-a11y.mjs app/components/base/chat/chat-with-history/header/index.tsx
- pnpm exec vp test run app/components/base/chat/chat-with-history/header/__tests__/index.spec.tsx (21/21)
- pnpm check (0 errors, 2059 existing warnings)
- Focused production lint exposes only 2 pre-existing as-any errors and 3 existing icon migration warnings.

From Codex