### PR TITLE
fix(web): name annotation reply actions

### DIFF
--- a/web/app/components/base/features/new-feature-panel/annotation-reply/__tests__/annotation-ctrl-button.spec.tsx
+++ b/web/app/components/base/features/new-feature-panel/annotation-reply/__tests__/annotation-ctrl-button.spec.tsx
@@ -60,7 +60,9 @@ describe('AnnotationCtrlButton', () => {
       />,
     )
 
-    expect(screen.getByRole('button')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'appDebug.feature.annotation.edit' }),
+    ).toBeInTheDocument()
   })
 
   it('should call onEdit when edit button is clicked', () => {
@@ -76,7 +78,7 @@ describe('AnnotationCtrlButton', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByRole('button', { name: 'appDebug.feature.annotation.edit' }))
 
     expect(onEdit).toHaveBeenCalled()
   })
@@ -93,7 +95,9 @@ describe('AnnotationCtrlButton', () => {
       />,
     )
 
-    expect(screen.getByRole('button')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'appDebug.feature.annotation.add' }),
+    ).toBeInTheDocument()
   })
 
   it('should not render any button when not cached and no answer', () => {
@@ -125,7 +129,7 @@ describe('AnnotationCtrlButton', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByRole('button', { name: 'appDebug.feature.annotation.add' }))
 
     await waitFor(() => {
       expect(mockAddAnnotation).toHaveBeenCalledWith('test-app', {
@@ -151,7 +155,7 @@ describe('AnnotationCtrlButton', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByRole('button', { name: 'appDebug.feature.annotation.add' }))
 
     expect(mockSetShowAnnotationFullModal).toHaveBeenCalled()
     expect(mockAddAnnotation).not.toHaveBeenCalled()
@@ -176,7 +180,7 @@ describe('AnnotationCtrlButton', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByRole('button', { name: 'appDebug.feature.annotation.add' }))
 
     await waitFor(() => {
       expect(onAdded).toHaveBeenCalledWith('annotation-2', '')

--- a/web/app/components/base/features/new-feature-panel/annotation-reply/annotation-ctrl-button.tsx
+++ b/web/app/components/base/features/new-feature-panel/annotation-reply/annotation-ctrl-button.tsx
@@ -52,8 +52,11 @@ const AnnotationCtrlButton: FC<Props> = ({
         <Tooltip>
           <TooltipTrigger
             render={
-              <ActionButton onClick={onEdit}>
-                <RiEditLine className="size-4" />
+              <ActionButton
+                aria-label={t(($) => $['feature.annotation.edit'], { ns: 'appDebug' })}
+                onClick={onEdit}
+              >
+                <RiEditLine aria-hidden className="size-4" />
               </ActionButton>
             }
           />
@@ -66,8 +69,11 @@ const AnnotationCtrlButton: FC<Props> = ({
         <Tooltip>
           <TooltipTrigger
             render={
-              <ActionButton onClick={handleAdd}>
-                <RiFileEditLine className="size-4" />
+              <ActionButton
+                aria-label={t(($) => $['feature.annotation.add'], { ns: 'appDebug' })}
+                onClick={handleAdd}
+              >
+                <RiFileEditLine aria-hidden className="size-4" />
               </ActionButton>
             }
           />


### PR DESCRIPTION
## Summary

- Give the annotation reply Edit and Add icon buttons the accessible names already shown in their tooltips.
- Hide the Remix icons from the accessibility tree because their buttons now own the action semantics.
- Query every owner-test action by role and name instead of relying on the only button in the render.

## Behavior contract

- Cached annotations expose Edit and preserve the existing onEdit callback.
- Uncached answers expose Add and preserve annotation creation, usage-limit modal, success notification, author fallback, and onAdded behavior.
- Empty answers still render no Add action.

## Visual regression

No visual change is expected. This PR does not change elements, classes, styles, layout, dimensions, tooltip content, visibility, event handlers, or focus styling; it only adds ARIA attributes. React.FC cleanup and icon-to-CSS migration are intentionally separate.

## Validation

- pnpm exec vp check app/components/base/features/new-feature-panel/annotation-reply/annotation-ctrl-button.tsx app/components/base/features/new-feature-panel/annotation-reply/__tests__/annotation-ctrl-button.spec.tsx (0 errors, 2 existing icon warnings)
- node scripts/lint-a11y.mjs app/components/base/features/new-feature-panel/annotation-reply/annotation-ctrl-button.tsx
- pnpm exec vp test run app/components/base/features/new-feature-panel/annotation-reply/__tests__/annotation-ctrl-button.spec.tsx (7/7)
- pnpm check (0 errors, 2059 existing warnings)

From Codex