### PR TITLE
refactor(web): remove annotation control React.FC

### DIFF
--- a/web/app/components/base/features/new-feature-panel/annotation-reply/annotation-ctrl-button.tsx
+++ b/web/app/components/base/features/new-feature-panel/annotation-reply/annotation-ctrl-button.tsx
@@ -1,9 +1,8 @@
 'use client'
-import type { FC } from 'react'
 import { toast } from '@langgenius/dify-ui/toast'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/tooltip'
 import { RiEditLine, RiFileEditLine } from '@remixicon/react'
-import * as React from 'react'
+import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import ActionButton from '@/app/components/base/action-button'
 import { useModalContext } from '@/context/modal-context'
@@ -19,7 +18,7 @@ type Props = Readonly<{
   onAdded: (annotationId: string, authorName: string) => void
   onEdit: () => void
 }>
-const AnnotationCtrlButton: FC<Props> = ({
+const AnnotationCtrlButton = ({
   cached,
   query,
   answer,
@@ -27,7 +26,7 @@ const AnnotationCtrlButton: FC<Props> = ({
   messageId,
   onAdded,
   onEdit,
-}) => {
+}: Props) => {
   const { t } = useTranslation()
   const { plan, enableBilling } = useProviderContext()
   const isAnnotationFull =
@@ -85,4 +84,4 @@ const AnnotationCtrlButton: FC<Props> = ({
     </>
   )
 }
-export default React.memo(AnnotationCtrlButton)
+export default memo(AnnotationCtrlButton)


### PR DESCRIPTION
## Summary

- Replace React.FC with an explicit Props annotation on the annotation reply control component.
- Replace the React namespace import with a named memo import.
- Preserve the existing memoized default export and all render behavior.

## Behavior contract

- Prop requirements remain exactly the same.
- Memoization remains exactly the same.
- This PR contains no accessibility, service, state, or test behavior change and depends on #40270 only because both PRs intentionally modify the same component in review order.

## Visual regression

No visual change is possible from this refactor. The JSX, DOM, classes, styles, layout, icons, ARIA attributes, and event handlers are unchanged relative to #40270.

## Validation

- pnpm exec vp check app/components/base/features/new-feature-panel/annotation-reply/annotation-ctrl-button.tsx (0 errors, 2 existing icon warnings)
- pnpm exec vp test run app/components/base/features/new-feature-panel/annotation-reply/__tests__/annotation-ctrl-button.spec.tsx (7/7)
- pnpm check (0 errors, 2059 existing warnings)
- git diff codex/a11y-annotation-actions --stat (1 production file; 4 insertions, 5 deletions)

From Codex