### PR TITLE
fix(web): name workflow debug actions

### DIFF
--- a/web/app/components/workflow/panel/debug-and-preview/__tests__/debug-and-preview.spec.tsx
+++ b/web/app/components/workflow/panel/debug-and-preview/__tests__/debug-and-preview.spec.tsx
@@ -1,0 +1,95 @@
+import type { Ref } from 'react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useImperativeHandle } from 'react'
+import { renderWorkflowComponent } from '@/app/components/workflow/__tests__/workflow-test-env'
+import DebugAndPreview from '../index'
+
+const mockHandleRestart = vi.fn()
+const mockHandleNodeCancelRunningStatus = vi.fn()
+const mockHandleEdgeCancelRunningStatus = vi.fn()
+
+vi.mock('reactflow', () => ({
+  useNodes: () => [
+    {
+      data: {
+        type: 'start',
+        variables: [{ label: 'Topic', variable: 'topic' }],
+      },
+      id: 'start',
+    },
+  ],
+}))
+
+vi.mock('../../../hooks/use-workflow-panel-interactions', () => ({
+  useWorkflowInteractions: () => ({
+    handleCancelDebugAndPreviewPanel: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../hooks/use-nodes-interactions-without-sync', () => ({
+  useNodesInteractionsWithoutSync: () => ({
+    handleNodeCancelRunningStatus: mockHandleNodeCancelRunningStatus,
+  }),
+}))
+
+vi.mock('../../../hooks/use-edges-interactions-without-sync', () => ({
+  useEdgesInteractionsWithoutSync: () => ({
+    handleEdgeCancelRunningStatus: mockHandleEdgeCancelRunningStatus,
+  }),
+}))
+
+vi.mock('../../../nodes/_base/hooks/use-resize-panel', () => ({
+  useResizePanel: () => ({
+    containerRef: vi.fn(),
+    triggerRef: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../persistence/local-storage-options', () => ({
+  useSetDebugPreviewPanelWidth: () => vi.fn(),
+}))
+
+vi.mock('../chat-wrapper', () => ({
+  default: function MockChatWrapper({ ref }: { ref: Ref<{ handleRestart: () => void }> }) {
+    useImperativeHandle(ref, () => ({ handleRestart: mockHandleRestart }))
+    return <div>Chat</div>
+  },
+}))
+
+describe('DebugAndPreview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('exposes and invokes the restart action by name', async () => {
+    const user = userEvent.setup()
+    renderWorkflowComponent(<DebugAndPreview />, {
+      initialStoreState: {
+        previewPanelWidth: 400,
+      },
+    })
+
+    await user.click(screen.getByRole('button', { name: /operation\.refresh/ }))
+
+    expect(mockHandleNodeCancelRunningStatus).toHaveBeenCalledTimes(1)
+    expect(mockHandleEdgeCancelRunningStatus).toHaveBeenCalledTimes(1)
+    expect(mockHandleRestart).toHaveBeenCalledTimes(1)
+  })
+
+  it('exposes the user input field toggle state by name', async () => {
+    const user = userEvent.setup()
+    renderWorkflowComponent(<DebugAndPreview />, {
+      initialStoreState: {
+        previewPanelWidth: 400,
+      },
+    })
+    const toggle = screen.getByRole('button', { name: /panel\.userInputField/ })
+
+    expect(toggle).toHaveAttribute('aria-pressed', 'true')
+
+    await user.click(toggle)
+
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+  })
+})

--- a/web/app/components/workflow/panel/debug-and-preview/index.tsx
+++ b/web/app/components/workflow/panel/debug-and-preview/index.tsx
@@ -33,6 +33,8 @@ const DebugAndPreview = () => {
   const startNode = nodes.find((node) => node.data.type === BlockEnum.Start)
   const variables = startNode?.data.variables || []
   const visibleVariables = variables
+  const restartLabel = t(($) => $['operation.refresh'], { ns: 'common' })
+  const userInputFieldLabel = t(($) => $['panel.userInputField'], { ns: 'workflow' })
 
   const [showConversationVariableModal, setShowConversationVariableModal] = useState(false)
 
@@ -94,12 +96,12 @@ const DebugAndPreview = () => {
             <Tooltip>
               <TooltipTrigger
                 render={
-                  <ActionButton onClick={() => handleRestartChat()}>
-                    <RefreshCcw01 className="size-4" />
+                  <ActionButton aria-label={restartLabel} onClick={() => handleRestartChat()}>
+                    <RefreshCcw01 aria-hidden="true" className="size-4" />
                   </ActionButton>
                 }
               />
-              <TooltipContent>{t(($) => $['operation.refresh'], { ns: 'common' })}</TooltipContent>
+              <TooltipContent>{restartLabel}</TooltipContent>
             </Tooltip>
             {visibleVariables.length > 0 && (
               <div className="relative">
@@ -107,16 +109,16 @@ const DebugAndPreview = () => {
                   <TooltipTrigger
                     render={
                       <ActionButton
+                        aria-label={userInputFieldLabel}
+                        aria-pressed={expanded}
                         state={expanded ? ActionButtonState.Active : undefined}
                         onClick={() => setExpanded(!expanded)}
                       >
-                        <RiEqualizer2Line className="size-4" />
+                        <RiEqualizer2Line aria-hidden="true" className="size-4" />
                       </ActionButton>
                     }
                   />
-                  <TooltipContent>
-                    {t(($) => $['panel.userInputField'], { ns: 'workflow' })}
-                  </TooltipContent>
+                  <TooltipContent>{userInputFieldLabel}</TooltipContent>
                 </Tooltip>
                 {expanded && (
                   <div className="absolute right-1.25 -bottom-4.25 z-10 h-3 w-3 rotate-45 border-t-[0.5px] border-l-[0.5px] border-components-panel-border-subtle bg-components-panel-on-panel-item-bg" />


### PR DESCRIPTION
## Summary

- Give the existing Restart and User Input Field action buttons accessible names from their existing tooltip copy.
- Expose the User Input Field toggle state with `aria-pressed`.
- Hide the icon SVGs from the accessibility tree and cover both actions through role-and-name queries.

## Behavior contract

- Restart still cancels the current node and edge running states before restarting chat.
- The User Input Field control still starts expanded and toggles the same local state.
- The close control is intentionally excluded because it is still a clickable `div` and requires a separate semantic-element change.
- No suppression entry changes are included.

## Visual regression

No visual change is expected. This PR does not replace elements or change DOM nesting, classes, styles, dimensions, layout, tooltip copy, or event handlers. The added ARIA attributes do not participate in layout or paint.

Reviewer focus: verify the Restart and User Input Field buttons retain their current size, alignment, active styling, tooltip placement, and icon rendering in both expanded and collapsed states.

## Validation

- `pnpm exec vp check app/components/workflow/panel/debug-and-preview/__tests__/debug-and-preview.spec.tsx` (0 warnings, 0 errors)
- `pnpm exec vp test run app/components/workflow/panel/debug-and-preview/__tests__/debug-and-preview.spec.tsx` (2/2)
- `pnpm check` (0 errors, 2059 existing warnings)
- `git diff --check`

Focused lint on the production file still reports the two existing accessibility errors on the excluded close `div`; this PR does not add or suppress either error.

From Codex