### PR TITLE
fix(web): name workflow version history action

### DIFF
--- a/web/app/components/workflow/header/__tests__/version-history-button.spec.tsx
+++ b/web/app/components/workflow/header/__tests__/version-history-button.spec.tsx
@@ -41,7 +41,7 @@ describe('VersionHistoryButton', () => {
     const onClick = vi.fn()
     render(<VersionHistoryButton onClick={onClick} />)
 
-    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByRole('button', { name: 'workflow.common.versionHistory' }))
 
     expect(onClick).toHaveBeenCalledTimes(1)
   })
@@ -64,7 +64,7 @@ describe('VersionHistoryButton', () => {
     const user = userEvent.setup()
     render(<VersionHistoryButton onClick={vi.fn()} />)
 
-    await user.hover(screen.getByRole('button'))
+    await user.hover(screen.getByRole('button', { name: 'workflow.common.versionHistory' }))
 
     expect(await screen.findByText('workflow.common.versionHistory')).toBeInTheDocument()
   })

--- a/web/app/components/workflow/header/version-history-button.tsx
+++ b/web/app/components/workflow/header/version-history-button.tsx
@@ -25,6 +25,8 @@ function PopupContent() {
 
 export function VersionHistoryButton({ onClick }: VersionHistoryButtonProps) {
   const { theme } = useTheme()
+  const { t } = useTranslation()
+  const label = t(($) => $['common.versionHistory'], { ns: 'workflow' })
 
   useHotkey(
     VERSION_HISTORY_HOTKEY,
@@ -41,13 +43,17 @@ export function VersionHistoryButton({ onClick }: VersionHistoryButtonProps) {
       <TooltipTrigger
         render={
           <Button
+            aria-label={label}
             className={cn(
               'rounded-lg p-2 inset-ring-1 inset-ring-transparent',
               theme === 'dark' && 'bg-white/10 inset-ring-black/5 backdrop-blur-xs',
             )}
             onClick={onClick}
           >
-            <span className="i-ri-history-line size-4 text-components-button-secondary-text" />
+            <span
+              aria-hidden
+              className="i-ri-history-line size-4 text-components-button-secondary-text"
+            />
           </Button>
         }
       />


### PR DESCRIPTION
## Summary

- Give the existing workflow Version History icon button an accessible name from its existing tooltip copy.
- Hide the CSS history icon from the accessibility tree.
- Query the action by role and name in its owner tests.

## Behavior contract

- Clicking Version History still invokes the same callback once.
- The existing Mod+Shift+H hotkey registration and input-ignore policy are unchanged.
- Hover still opens the same tooltip content.

## Visual regression

No visual change is possible from this patch. The Button element, DOM nesting, classes, styles, dimensions, theme branch, tooltip content, event handler, and CSS icon rendering are unchanged. `aria-label` and `aria-hidden` do not participate in layout or paint.

Reviewer focus: verify light and dark button background, padding, icon centering, tooltip placement, and hotkey badge remain identical.

## Validation

- `pnpm exec vp check app/components/workflow/header/version-history-button.tsx app/components/workflow/header/__tests__/version-history-button.spec.tsx` (0 warnings, 0 errors)
- `pnpm lint:a11y app/components/workflow/header/version-history-button.tsx` (0 diagnostics)
- `pnpm exec vp test run app/components/workflow/header/__tests__/version-history-button.spec.tsx` (3/3)
- `pnpm check` (0 errors, 2059 existing warnings)
- `git diff --check`

From Codex