### PR TITLE
fix(web): name snippet stop action

### DIFF
--- a/web/app/components/snippets/components/snippet-header/__tests__/run-mode.spec.tsx
+++ b/web/app/components/snippets/components/snippet-header/__tests__/run-mode.spec.tsx
@@ -74,7 +74,9 @@ describe('RunMode', () => {
 
     expect(screen.getByRole('button', { name: /workflow\.common\.running/i })).toBeDisabled()
 
-    await user.click(screen.getAllByRole('button')[1]!)
+    await user.click(
+      screen.getByRole('button', { name: /workflow\.debug\.variableInspect\.trigger\.stop/i }),
+    )
 
     expect(workflowHookMocks.handleStopRun).toHaveBeenCalledWith('task-1')
 
@@ -109,7 +111,9 @@ describe('RunMode', () => {
       },
     })
 
-    await user.click(screen.getAllByRole('button')[1]!)
+    await user.click(
+      screen.getByRole('button', { name: /workflow\.debug\.variableInspect\.trigger\.stop/i }),
+    )
 
     expect(workflowHookMocks.handleStopRun).toHaveBeenCalledWith('')
   })

--- a/web/app/components/snippets/components/snippet-header/run-mode.tsx
+++ b/web/app/components/snippets/components/snippet-header/run-mode.tsx
@@ -62,6 +62,7 @@ const RunMode = ({ text }: RunModeProps) => {
       {isRunning && (
         <button
           type="button"
+          aria-label={t(($) => $['debug.variableInspect.trigger.stop'], { ns: 'workflow' })}
           className="flex size-7 items-center justify-center rounded-r-md bg-state-accent-active"
           onClick={handleStop}
         >


### PR DESCRIPTION
## Summary

- Give the snippet RunMode stop icon button the same accessible name already used by the full workflow RunMode owner.
- Replace two positional second-button queries with role-and-name queries.

## Behavior contract

- Stop remains available only while a snippet workflow is running.
- Activating Stop still passes the current task id, including the existing empty-id fallback.
- Workflow stop events still call the same handler independently of the button.

## Visual regression

No visual change is possible from this patch. The button element, DOM nesting, classes, styles, dimensions, running-state branch, handler, and CSS icon are unchanged. The added `aria-label` does not participate in layout or paint.

Reviewer focus: verify the split Run/Stop control width, stop icon centering, rounded right edge, active background, and disabled Running control remain identical.

## Validation

- `pnpm exec vp check app/components/snippets/components/snippet-header/run-mode.tsx app/components/snippets/components/snippet-header/__tests__/run-mode.spec.tsx` (0 warnings, 0 errors)
- `pnpm lint:a11y app/components/snippets/components/snippet-header/run-mode.tsx` (0 diagnostics)
- `pnpm exec vp test run app/components/snippets/components/snippet-header/__tests__/run-mode.spec.tsx` (4/4)
- `pnpm check` (0 errors, 2059 existing warnings)
- `git diff --check`

From Codex