### PR TITLE
refactor(web): use css icon for generated result copy

### DIFF
--- a/web/app/components/app/configuration/config/automatic/result.tsx
+++ b/web/app/components/app/configuration/config/automatic/result.tsx
@@ -2,7 +2,6 @@
 import type { FC } from 'react'
 import type { GenRes } from '@/service/debug'
 import { Button } from '@langgenius/dify-ui/button'
-import { RiClipboardLine } from '@remixicon/react'
 import copy from 'copy-to-clipboard'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
@@ -60,7 +59,7 @@ const Result: FC<Props> = ({
               toast.success(t(($) => $['actionMsg.copySuccessfully'], { ns: 'common' }))
             }}
           >
-            <RiClipboardLine aria-hidden="true" className="size-4 text-text-secondary" />
+            <span aria-hidden className="i-ri-clipboard-line size-4 text-text-secondary" />
           </Button>
           <Button variant="primary" onClick={onApply}>
             {t(($) => $['generate.apply'], { ns: 'appDebug' })}


### PR DESCRIPTION
## Summary

- Replace the generated-result copy action Remix React SVG with the lint-recommended `i-ri-clipboard-line` CSS icon.
- Remove the now-unused `@remixicon/react` import.
- Preserve the accessible name and decorative icon contract introduced by #40259.

## Dependency

This PR is stacked on #40259 because both layers intentionally modify the same copy action. The parent owns accessibility semantics; this child owns only icon implementation.

## Behavior contract

- Copy still invokes the same clipboard and success-toast behavior.
- The button accessible name remains Copy.
- The icon remains decorative and exposes no separate accessibility node.

## Visual regression

This PR intentionally changes only the icon rendering implementation. The button element, padding, dimensions, color class, placement, handler, and surrounding layout are unchanged. The CSS icon uses the exact `i-ri-clipboard-line` mapping required by the repository lint rule and is already used by other 16px copy actions in the codebase.

Reviewer focus: compare the 16x16 clipboard silhouette, optical centering, color, button padding, and alignment with Apply in light and dark themes. No layout shift or ordinary-state difference is acceptable.

## Validation

- `pnpm exec vp check app/components/app/configuration/config/automatic/result.tsx app/components/app/configuration/config/automatic/__tests__/result.spec.tsx` (0 warnings, 0 errors; parent had 1 icon warning)
- `pnpm lint:a11y app/components/app/configuration/config/automatic/result.tsx` (0 diagnostics)
- `pnpm exec vp test run app/components/app/configuration/config/automatic/__tests__/result.spec.tsx` (3/3)
- `pnpm check` (0 errors, 2058 warnings; exactly one fewer than #40259)
- `git diff codex/a11y-generated-result-copy --stat` (1 production file; 1 insertion, 2 deletions)

From Codex