### PR TITLE
refactor(web): remove generated result React.FC

### DIFF
--- a/web/app/components/app/configuration/config/automatic/result.tsx
+++ b/web/app/components/app/configuration/config/automatic/result.tsx
@@ -1,9 +1,8 @@
 'use client'
-import type { FC } from 'react'
 import type { GenRes } from '@/service/debug'
 import { Button } from '@langgenius/dify-ui/button'
 import copy from 'copy-to-clipboard'
-import * as React from 'react'
+import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from '@/app/components/app/configuration/toast'
 import CodeEditor from '@/app/components/workflow/nodes/llm/components/json-schema-config-modal/code-editor'
@@ -24,7 +23,7 @@ type Props = Readonly<{
   generatorType: GeneratorType
 }>
 
-const Result: FC<Props> = ({
+const Result = ({
   isBasicMode,
   nodeId,
   current,
@@ -33,7 +32,7 @@ const Result: FC<Props> = ({
   versions,
   onApply,
   generatorType,
-}) => {
+}: Props) => {
   const { t } = useTranslation()
   const isGeneratorPrompt = generatorType === GeneratorType.prompt
 
@@ -94,4 +93,4 @@ const Result: FC<Props> = ({
     </div>
   )
 }
-export default React.memo(Result)
+export default memo(Result)


### PR DESCRIPTION
## Summary

- Replace `React.FC` with an explicit `Props` annotation on the generated result component.
- Replace the React namespace import with the named `memo` import.
- Preserve the memoized export and every render path.

## Dependency

This PR is stacked on #40279 only because all three PRs intentionally touch the same component in review order. It has no accessibility or icon behavior dependency.

## Behavior contract

The component accepts the same props and remains memoized. There are no state, service, event-handler, or test changes.

## Visual regression

No visual change is expected: JSX, DOM, classes, styles, layout, icons, ARIA attributes, and handlers are unchanged relative to #40279.

Reviewer focus: confirm the diff is limited to the React import, explicit props annotation, and memo export.

## Validation

- Focused `vp check`: 0 warnings, 0 errors
- Focused accessibility lint: 0 diagnostics
- Focused Vitest: 3/3 tests passed
- Full `pnpm check`: 0 errors, 2058 existing warnings
- Diff relative to #40279: 1 production file, 4 insertions, 5 deletions

From Codex