### PR TITLE
fix(web): expose workflow parallel toggle state

### DIFF
--- a/web/app/components/workflow/run/__tests__/tracing-panel.spec.tsx
+++ b/web/app/components/workflow/run/__tests__/tracing-panel.spec.tsx
@@ -135,11 +135,23 @@ describe('TracingPanel', () => {
 
     fireEvent.mouseLeave(hoverTarget)
 
-    fireEvent.click(screen.getAllByRole('button')[0]!)
+    const parallelToggle = screen.getByRole('button', {
+      name: 'Parallel Group',
+      expanded: true,
+    })
+    expect(parallelToggle).toHaveAttribute('aria-controls', 'parallel-1-children')
+
+    fireEvent.click(parallelToggle)
+    expect(
+      screen.getByRole('button', { name: 'Parallel Group', expanded: false }),
+    ).toBeInTheDocument()
     expect(
       container.querySelector('[data-parallel-id="parallel-1"] > div:last-child'),
     )!.toHaveClass('hidden')
-    fireEvent.click(screen.getAllByRole('button')[0]!)
+    fireEvent.click(parallelToggle)
+    expect(
+      screen.getByRole('button', { name: 'Parallel Group', expanded: true }),
+    ).toBeInTheDocument()
     expect(
       container.querySelector('[data-parallel-id="parallel-1"] > div:last-child'),
     ).not.toHaveClass('hidden')

--- a/web/app/components/workflow/run/tracing-panel.tsx
+++ b/web/app/components/workflow/run/tracing-panel.tsx
@@ -90,6 +90,9 @@ const TracingPanel: FC<TracingPanelProps> = ({
           <div className="mb-1 flex items-center">
             <button
               type="button"
+              aria-controls={`${node.id}-children`}
+              aria-expanded={!isCollapsed}
+              aria-label={parallelDetail.parallelTitle}
               onClick={() => toggleCollapse(node.id)}
               className={cn(
                 'mr-2 transition-colors',
@@ -115,7 +118,10 @@ const TracingPanel: FC<TracingPanelProps> = ({
               }}
             ></div>
           </div>
-          <div className={`relative pl-2 ${isCollapsed ? 'hidden' : ''}`}>
+          <div
+            id={`${node.id}-children`}
+            className={`relative pl-2 ${isCollapsed ? 'hidden' : ''}`}
+          >
             <div
               className={cn(
                 'absolute top-0 bottom-0 left-1.25 w-0.5',


### PR DESCRIPTION
## Summary

- Give the icon-only parallel trace toggle a stable accessible name from its visible parallel title.
- Expose the expanded state and the controlled child region with `aria-expanded` and `aria-controls`.
- Replace positional button queries with role, name, and expanded-state assertions.

## Dependency

Independent single-PR stack based on current `origin/main` at `925ca49f21`.

## Behavior contract

The existing native button keeps the same click and keyboard behavior. Assistive technology can now identify which parallel group the button controls and whether that group is expanded.

The outer tracing wrapper still uses click propagation control. Its two existing jsx-a11y baseline entries are unrelated to this toggle contract and remain unchanged.

## Visual regression

No visual change is expected: element types, DOM nesting, classes, icon classes, dimensions, hover styling, collapsed layout, and event handlers are unchanged.

Reviewer focus: compare expanded/collapsed and hover/non-hover states in light and dark themes; the rendered pixels should be identical.

## Validation

- Focused Vitest: 3/3 tests passed
- Full `pnpm check`: 0 errors, 2059 existing warnings
- Standalone accessibility lint: only the same 2 pre-existing tracing-wrapper diagnostics; no toggle diagnostic
- `git diff --check`: passed
- Scope: 1 production file and 1 same-owner test file, 21 insertions and 3 deletions

From Codex