### PR TITLE
fix(web): name image previewer actions

### DIFF
--- a/web/app/components/datasets/common/image-previewer/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/common/image-previewer/__tests__/index.spec.tsx
@@ -32,15 +32,11 @@ const images = [
 
 const successfulResponse = () => new Response(new Blob(['test'], { type: 'image/png' }))
 
-const getPreviewButtons = () => {
-  const [closeButton, previousButton, nextButton] = screen.getAllByRole('button')
-
-  expect(closeButton).toBeInTheDocument()
-  expect(previousButton).toBeInTheDocument()
-  expect(nextButton).toBeInTheDocument()
-
-  return { closeButton: closeButton!, previousButton: previousButton!, nextButton: nextButton! }
-}
+const getPreviewButtons = () => ({
+  closeButton: screen.getByRole('button', { name: 'common.operation.close' }),
+  previousButton: screen.getByRole('button', { name: 'common.pagination.previous' }),
+  nextButton: screen.getByRole('button', { name: 'common.pagination.next' }),
+})
 
 describe('ImagePreviewer', () => {
   beforeEach(() => {
@@ -137,10 +133,9 @@ describe('ImagePreviewer', () => {
     render(<ImagePreviewer images={images} onClose={vi.fn()} />)
 
     expect(await screen.findByText(/Failed to load image/)).toHaveTextContent(images[0]!.url)
-    const [, retryButton] = screen.getAllByRole('button')
-    expect(retryButton).toBeInTheDocument()
+    const retryButton = screen.getByRole('button', { name: 'common.operation.retry' })
 
-    await user.click(retryButton!)
+    await user.click(retryButton)
 
     expect(await screen.findByRole('img', { name: 'image1.png' })).toBeInTheDocument()
     expect(mockFetch).toHaveBeenCalledTimes(4)

--- a/web/app/components/datasets/common/image-previewer/index.tsx
+++ b/web/app/components/datasets/common/image-previewer/index.tsx
@@ -4,6 +4,7 @@ import { Kbd } from '@langgenius/dify-ui/kbd'
 import { RiArrowLeftLine, RiArrowRightLine, RiCloseLine, RiRefreshLine } from '@remixicon/react'
 import { formatForDisplay, useHotkey } from '@tanstack/react-hotkeys'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import Loading from '@/app/components/base/loading'
 import { formatFileSize } from '@/utils/format'
 
@@ -29,6 +30,7 @@ type ImagePreviewerProps = {
 }
 
 const ImagePreviewer = ({ images, initialIndex = 0, onClose }: ImagePreviewerProps) => {
+  const { t } = useTranslation()
   const [currentIndex, setCurrentIndex] = useState(initialIndex)
   const [cachedImages, setCachedImages] = useState<Record<string, CachedImage>>(() => {
     return images.reduce(
@@ -159,6 +161,7 @@ const ImagePreviewer = ({ images, initialIndex = 0, onClose }: ImagePreviewerPro
         <div className="absolute top-6 right-6 z-10 flex cursor-pointer flex-col items-center gap-y-1">
           <Button
             variant="tertiary"
+            aria-label={t(($) => $['operation.close'], { ns: 'common' })}
             onClick={onClose}
             className="size-9 rounded-[10px] p-0"
             size="large"
@@ -173,6 +176,7 @@ const ImagePreviewer = ({ images, initialIndex = 0, onClose }: ImagePreviewerPro
             <span>{`Failed to load image: ${currentImage!.url}. Please try again.`}</span>
             <Button
               variant="secondary"
+              aria-label={t(($) => $['operation.retry'], { ns: 'common' })}
               onClick={() => retryImage(currentImage!)}
               className="size-9 rounded-full p-0"
               size="large"
@@ -199,6 +203,7 @@ const ImagePreviewer = ({ images, initialIndex = 0, onClose }: ImagePreviewerPro
         )}
         <Button
           variant="secondary"
+          aria-label={t(($) => $['pagination.previous'], { ns: 'common' })}
           onClick={prevImage}
           className="absolute top-1/2 left-8 z-10 size-9 -translate-y-1/2 rounded-full p-0"
           disabled={currentIndex === 0}
@@ -208,6 +213,7 @@ const ImagePreviewer = ({ images, initialIndex = 0, onClose }: ImagePreviewerPro
         </Button>
         <Button
           variant="secondary"
+          aria-label={t(($) => $['pagination.next'], { ns: 'common' })}
           onClick={nextImage}
           className="absolute top-1/2 right-8 z-10 size-9 -translate-y-1/2 rounded-full p-0"
           disabled={currentIndex === images.length - 1}


### PR DESCRIPTION
## Summary

- Give the image previewer's Close, Retry, Previous, and Next icon buttons localized accessible names.
- Reuse existing common translation keys; no copy or locale files are added.
- Replace DOM-order button queries with role-and-name queries in the same owner test suite.

## Dependency

Independent single-PR stack based on current `main` at `925ca49f21`.

## Behavior contract

The existing native buttons keep their click behavior, disabled boundaries, ArrowLeft/ArrowRight hotkeys, image loading, retry, and dialog close behavior. Assistive technology can now identify each control without relying on its icon or DOM position.

## Visual regression

No visual change is expected: DOM nesting, Button variants and sizes, classes, Remix icons, dimensions, Kbd hint, image layout, loading state, and handlers are unchanged. The new translation values are applied only through `aria-label`.

Reviewer focus: compare loaded, loading, error, first-image, middle-image, and last-image states; rendered pixels should be identical in light and dark themes.

## Validation

- Focused Vitest: 8/8 tests passed
- Focused accessibility lint: 0 diagnostics
- Focused code check: 0 errors and 6 pre-existing warnings
- Full `pnpm check`: 0 errors and 2059 existing warnings
- `git diff --check`: passed
- Scope: 1 production file and 1 same-owner test file, 13 insertions and 12 deletions

## Rollback

Revert `31f27e9fcd`; the action behavior and visuals remain unchanged either way.

From Codex