### PR TITLE
refactor(web): use css icons in image previewer

### DIFF
--- a/web/app/components/datasets/common/image-previewer/index.tsx
+++ b/web/app/components/datasets/common/image-previewer/index.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@langgenius/dify-ui/button'
 import { Dialog, DialogContent } from '@langgenius/dify-ui/dialog'
 import { Kbd } from '@langgenius/dify-ui/kbd'
-import { RiArrowLeftLine, RiArrowRightLine, RiCloseLine, RiRefreshLine } from '@remixicon/react'
 import { formatForDisplay, useHotkey } from '@tanstack/react-hotkeys'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -166,7 +165,7 @@ const ImagePreviewer = ({ images, initialIndex = 0, onClose }: ImagePreviewerPro
             className="size-9 rounded-[10px] p-0"
             size="large"
           >
-            <RiCloseLine className="size-5" />
+            <span aria-hidden className="i-ri-close-line size-5" />
           </Button>
           <Kbd>{formatForDisplay('Escape')}</Kbd>
         </div>
@@ -181,7 +180,7 @@ const ImagePreviewer = ({ images, initialIndex = 0, onClose }: ImagePreviewerPro
               className="size-9 rounded-full p-0"
               size="large"
             >
-              <RiRefreshLine className="size-5" />
+              <span aria-hidden className="i-ri-refresh-line size-5" />
             </Button>
           </div>
         )}
@@ -209,7 +208,7 @@ const ImagePreviewer = ({ images, initialIndex = 0, onClose }: ImagePreviewerPro
           disabled={currentIndex === 0}
           size="large"
         >
-          <RiArrowLeftLine className="size-5" />
+          <span aria-hidden className="i-ri-arrow-left-line size-5" />
         </Button>
         <Button
           variant="secondary"
@@ -219,7 +218,7 @@ const ImagePreviewer = ({ images, initialIndex = 0, onClose }: ImagePreviewerPro
           disabled={currentIndex === images.length - 1}
           size="large"
         >
-          <RiArrowRightLine className="size-5" />
+          <span aria-hidden className="i-ri-arrow-right-line size-5" />
         </Button>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary

- Replace the image previewer's four Remix React icon components with the equivalent Tailwind CSS icon classes recommended by the repository lint rule.
- Remove the now-unused `@remixicon/react` import.
- Preserve the accessible names introduced by #40283.

## Dependency

Stacked on #40283 because both PRs intentionally touch the same component in review order. This implementation cleanup does not change or extend the accessibility behavior contract.

## Behavior contract

Close, Retry, Previous, and Next keep the same Button variants, handlers, disabled states, hotkeys, and localized `aria-label` values.

## Visual regression

This PR has a narrow visual review surface but is not claimed to be pixel-proven by tests.

- Each replacement uses the lint-recommended icon from the same Remix icon set.
- Every icon keeps `size-5` (20 by 20 CSS pixels).
- Button classes, centering, dimensions, colors, hover states, disabled states, and surrounding layout are unchanged.
- Each CSS icon is explicitly decorative with `aria-hidden`.

Reviewer focus: compare close, refresh, left-arrow, and right-arrow silhouettes; confirm centering, current-color rendering, hover/disabled contrast, and light/dark appearance.

## Validation

- Focused Vitest: 8/8 tests passed
- Focused accessibility lint: 0 diagnostics
- Focused code check: 0 errors and 2 pre-existing warnings, exactly 4 fewer than #40283
- Full `pnpm check`: 0 errors and 2055 existing warnings, exactly 4 fewer than #40283
- Diff relative to #40283: 1 production file, 4 insertions and 5 deletions
- `git diff --check`: passed

## Rollback

Revert `1561e90de4`; #40283 remains fully functional and reviewable.

From Codex