### PR TITLE
fix(web): name agent log navigation menu

### DIFF
--- a/web/app/components/workflow/run/agent-log/__tests__/agent-log-nav-more.spec.tsx
+++ b/web/app/components/workflow/run/agent-log/__tests__/agent-log-nav-more.spec.tsx
@@ -28,8 +28,15 @@ describe('AgentLogNavMore', () => {
 
     render(<AgentLogNavMore options={[option]} onShowAgentOrToolLog={onShowAgentOrToolLog} />)
 
-    await user.click(screen.getByRole('button'))
-    await user.click(screen.getByText('Intermediate Tool'))
+    const menuButton = screen.getByRole('button', {
+      name: 'common.operation.more',
+      expanded: false,
+    })
+    await user.click(menuButton)
+    expect(
+      screen.getByRole('button', { name: 'common.operation.more', expanded: true }),
+    ).toBeInTheDocument()
+    await user.click(screen.getByRole('menuitem', { name: 'Intermediate Tool' }))
 
     expect(onShowAgentOrToolLog).toHaveBeenCalledWith(option)
   })

--- a/web/app/components/workflow/run/agent-log/__tests__/agent-log-nav.spec.tsx
+++ b/web/app/components/workflow/run/agent-log/__tests__/agent-log-nav.spec.tsx
@@ -38,8 +38,8 @@ describe('AgentLogNav', () => {
     await user.click(
       screen.getByRole('button', { name: /^workflow\.nodes\.agent\.strategy\.label$/ }),
     )
-    await user.click(screen.getAllByRole('button')[2]!)
-    await user.click(screen.getByText('Tool A'))
+    await user.click(screen.getByRole('button', { name: 'common.operation.more' }))
+    await user.click(screen.getByRole('menuitem', { name: 'Tool A' }))
 
     expect(onShowAgentOrToolLog.mock.calls[0]).toHaveLength(0)
     expect(onShowAgentOrToolLog).toHaveBeenNthCalledWith(2, stack[0])

--- a/web/app/components/workflow/run/agent-log/agent-log-nav-more.tsx
+++ b/web/app/components/workflow/run/agent-log/agent-log-nav-more.tsx
@@ -8,17 +8,27 @@ import {
 } from '@langgenius/dify-ui/dropdown-menu'
 import { RiMoreLine } from '@remixicon/react'
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 type AgentLogNavMoreProps = {
   options: AgentLogItemWithChildren[]
   onShowAgentOrToolLog: (detail?: AgentLogItemWithChildren) => void
 }
 const AgentLogNavMore = ({ options, onShowAgentOrToolLog }: AgentLogNavMoreProps) => {
+  const { t } = useTranslation()
   const [open, setOpen] = useState(false)
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger render={<Button className="size-6" variant="ghost-accent" />}>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            aria-label={t(($) => $['operation.more'], { ns: 'common' })}
+            className="size-6"
+            variant="ghost-accent"
+          />
+        }
+      >
         <RiMoreLine className="size-4" />
       </DropdownMenuTrigger>
       <DropdownMenuContent


### PR DESCRIPTION
## Summary

- Give the icon-only agent log breadcrumb menu trigger the existing localized More label.
- Query the trigger by role and name instead of its DOM position.
- Verify the real dropdown contract: closed trigger, open trigger, semantic menu item, and selected log entry.

## Dependency

Independent single-PR stack based on current `main` at `925ca49f21`.

## Behavior contract

The existing Dify UI dropdown primitive continues to own focus, keyboard handling, `aria-expanded`, menu roles, placement, and open state. This PR only supplies the trigger's missing accessible name and tests the primitive through its public semantics.

## Visual regression

No visual change is expected: DOM structure, Button classes and variant, More icon, dimensions, dropdown placement, menu content, and handlers are unchanged. The translation value is applied only through `aria-label`.

Reviewer focus: compare closed/open, hover, keyboard focus, and menu placement states; normal rendered pixels should be identical.

## Validation

- Focused Vitest: 2/2 tests passed
- Focused accessibility lint: 0 diagnostics
- Focused code check: 0 errors and 1 pre-existing CSS icon warning
- Full `pnpm check`: 0 errors and 2059 existing warnings
- `git diff --check`: passed
- Scope: 1 production file and 2 same-owner test files, 22 insertions and 5 deletions

## Rollback

Revert `2ccaf33cbc`; dropdown behavior and visuals remain unchanged either way.

From Codex