### PR TITLE
refactor(web): use css icon for agent log navigation

### DIFF
--- a/web/app/components/workflow/run/agent-log/agent-log-nav-more.tsx
+++ b/web/app/components/workflow/run/agent-log/agent-log-nav-more.tsx
@@ -6,7 +6,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@langgenius/dify-ui/dropdown-menu'
-import { RiMoreLine } from '@remixicon/react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -29,7 +28,7 @@ const AgentLogNavMore = ({ options, onShowAgentOrToolLog }: AgentLogNavMoreProps
           />
         }
       >
-        <RiMoreLine className="size-4" />
+        <span aria-hidden className="i-ri-more-line size-4" />
       </DropdownMenuTrigger>
       <DropdownMenuContent
         placement="bottom-start"


### PR DESCRIPTION
## Summary

- Replace the agent log navigation More icon React component with the equivalent Tailwind CSS icon class recommended by the repository lint rule.
- Remove the now-unused `@remixicon/react` import.
- Preserve the trigger name and semantic dropdown tests introduced by #40286.

## Dependency

Stacked on #40286 because both PRs intentionally touch the same trigger component. This implementation cleanup does not change the accessibility behavior contract.

## Behavior contract

The dropdown trigger keeps the same Button, localized accessible name, open state, menu primitive, placement, and selection callbacks.

## Visual regression

This PR changes one icon implementation and therefore keeps visual review explicit.

- The replacement uses `i-ri-more-line`, the lint-recommended icon from the same Remix icon set.
- The icon keeps `size-4` (16 by 16 CSS pixels).
- Button dimensions, centering, colors, hover/focus states, dropdown placement, and surrounding breadcrumb layout are unchanged.
- The CSS icon is explicitly decorative with `aria-hidden`.

Reviewer focus: compare the three-dot silhouette, centering, current-color rendering, hover/focus contrast, and light/dark appearance.

## Validation

- Focused Vitest: 2/2 tests passed
- Focused accessibility lint: 0 diagnostics
- Focused code check: 0 warnings and 0 errors, exactly 1 warning fewer than #40286
- Full `pnpm check`: 0 errors and 2058 existing warnings, exactly 1 fewer than #40286
- Diff relative to #40286: 1 production file, 1 insertion and 2 deletions
- `git diff --check`: passed

## Rollback

Revert `da8d42f835`; #40286 remains fully functional and reviewable.

From Codex