### PR TITLE
fix(web): name variable inspect close actions

### DIFF
--- a/web/app/components/workflow/variable-inspect/__tests__/panel.spec.tsx
+++ b/web/app/components/workflow/variable-inspect/__tests__/panel.spec.tsx
@@ -131,9 +131,10 @@ describe('VariableInspect Panel', () => {
   })
 
   it('should render the listening state and stop the workflow on demand', () => {
-    renderPanel({
+    const { store } = renderPanel({
       isListening: true,
       listeningTriggerType: BlockEnum.TriggerWebhook,
+      showVariableInspectPanel: true,
     })
 
     fireEvent.click(
@@ -144,6 +145,9 @@ describe('VariableInspect Panel', () => {
     expect(mockEmit).toHaveBeenCalledWith({
       type: EVENT_WORKFLOW_STOP,
     })
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.operation.close' }))
+    expect(store.getState().showVariableInspectPanel).toBe(false)
   })
 
   it('should render the empty state and close the panel from the header action', () => {
@@ -151,7 +155,7 @@ describe('VariableInspect Panel', () => {
       showVariableInspectPanel: true,
     })
 
-    fireEvent.click(screen.getAllByRole('button')[0]!)
+    fireEvent.click(screen.getByRole('button', { name: 'common.operation.close' }))
 
     expect(screen.getByText('workflow.debug.variableInspect.emptyTip'))!.toBeInTheDocument()
     expect(store.getState().showVariableInspectPanel).toBe(false)

--- a/web/app/components/workflow/variable-inspect/panel.tsx
+++ b/web/app/components/workflow/variable-inspect/panel.tsx
@@ -175,7 +175,10 @@ const Panel: FC = () => {
           <div className="system-sm-semibold-uppercase text-text-primary">
             {t(($) => $['debug.variableInspect.title'], { ns: 'workflow' })}
           </div>
-          <ActionButton onClick={() => setShowVariableInspectPanel(false)}>
+          <ActionButton
+            aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+            onClick={() => setShowVariableInspectPanel(false)}
+          >
             <RiCloseLine className="size-4" />
           </ActionButton>
         </div>
@@ -193,7 +196,10 @@ const Panel: FC = () => {
           <div className="system-sm-semibold-uppercase text-text-primary">
             {t(($) => $['debug.variableInspect.title'], { ns: 'workflow' })}
           </div>
-          <ActionButton onClick={() => setShowVariableInspectPanel(false)}>
+          <ActionButton
+            aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+            onClick={() => setShowVariableInspectPanel(false)}
+          >
             <RiCloseLine className="size-4" />
           </ActionButton>
         </div>


### PR DESCRIPTION
## Summary

- Give the Listening and Empty variable-inspect header Close buttons the existing localized Close label.
- Query both conditional branches by role and name instead of button position.
- Verify that closing either branch updates the variable-inspect panel store state.

## Dependency

Independent single-PR stack based on current `main` at `925ca49f21`.

## Behavior contract

Both existing ActionButtons keep the same click handler and continue to set `showVariableInspectPanel` to false. Assistive technology can now identify the icon-only action in either rendered branch.

The responsive left-panel backdrop and the existing workflow-stop event payload are separate contracts. Their three existing suppression entries remain unchanged.

## Visual regression

No visual change is expected: ActionButton type, classes, Close icons, dimensions, header layout, conditional rendering, and handlers are unchanged. The translation value is applied only through `aria-label`.

Reviewer focus: compare Listening and Empty headers in light and dark themes; rendered pixels should be identical.

## Validation

- Focused Vitest: 3/3 tests passed
- Full `pnpm check`: 0 errors and 2059 existing warnings
- Standalone accessibility lint: only the same 2 pre-existing responsive-backdrop diagnostics
- Focused code check: the same 3 baseline errors and 2 existing CSS icon warnings; no new diagnostic
- `git diff --check`: passed
- Scope: 1 production file and 1 same-owner test file, 14 insertions and 4 deletions

## Rollback

Revert `2886a37305`; panel behavior and visuals remain unchanged either way.

From Codex