### PR TITLE
refactor(web): use css icon for variable inspect close

### DIFF
--- a/web/app/components/workflow/variable-inspect/panel.tsx
+++ b/web/app/components/workflow/variable-inspect/panel.tsx
@@ -2,7 +2,6 @@ import type { FC } from 'react'
 import type { NodeProps } from '../types'
 import type { VarInInspect } from '@/types/workflow'
 import { cn } from '@langgenius/dify-ui/cn'
-import { RiCloseLine } from '@remixicon/react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import ActionButton from '@/app/components/base/action-button'
@@ -179,7 +178,7 @@ const Panel: FC = () => {
             aria-label={t(($) => $['operation.close'], { ns: 'common' })}
             onClick={() => setShowVariableInspectPanel(false)}
           >
-            <RiCloseLine className="size-4" />
+            <span aria-hidden className="i-ri-close-line size-4" />
           </ActionButton>
         </div>
         <div className="grow p-2">
@@ -200,7 +199,7 @@ const Panel: FC = () => {
             aria-label={t(($) => $['operation.close'], { ns: 'common' })}
             onClick={() => setShowVariableInspectPanel(false)}
           >
-            <RiCloseLine className="size-4" />
+            <span aria-hidden className="i-ri-close-line size-4" />
           </ActionButton>
         </div>
         <div className="grow p-2">


### PR DESCRIPTION
## Summary

- Replace both variable-inspect header Close icon React components with the equivalent Tailwind CSS icon class recommended by the repository lint rule.
- Remove the now-unused `@remixicon/react` import.
- Preserve the localized Close labels introduced by #40289.

## Dependency

Stacked on #40289 because both PRs intentionally touch the same conditional header branches. This implementation cleanup does not change the accessibility behavior contract.

## Behavior contract

Listening and Empty states keep the same ActionButtons, accessible names, click handlers, and store transition.

## Visual regression

This PR changes one icon implementation at two equivalent call sites.

- Both replacements use `i-ri-close-line`, the lint-recommended icon from the same Remix icon set.
- Both icons keep `size-4` (16 by 16 CSS pixels).
- ActionButton dimensions, centering, colors, hover/focus states, header spacing, and conditional layout are unchanged.
- Both CSS icons are explicitly decorative with `aria-hidden`.

Reviewer focus: compare the Close silhouette, centering, current-color rendering, hover/focus contrast, and light/dark appearance in both Listening and Empty states.

## Validation

- Focused Vitest: 3/3 tests passed
- Focused code check: the same 3 baseline errors and 0 warnings, exactly 2 warnings fewer than #40289
- Full `pnpm check`: 0 errors and 2057 existing warnings, exactly 2 fewer than #40289
- Standalone accessibility lint: only the same 2 pre-existing responsive-backdrop diagnostics
- Diff relative to #40289: 1 production file, 2 insertions and 3 deletions
- `git diff --check`: passed

## Rollback

Revert `8913fd4609`; #40289 remains fully functional and reviewable.

From Codex