### PR TITLE
refactor(web): remove variable inspect panel React.FC

### DIFF
--- a/web/app/components/workflow/variable-inspect/panel.tsx
+++ b/web/app/components/workflow/variable-inspect/panel.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import type { NodeProps } from '../types'
 import type { VarInInspect } from '@/types/workflow'
 import { cn } from '@langgenius/dify-ui/cn'
@@ -25,7 +24,7 @@ export type currentVarType = {
   nodeData: NodeProps['data']
 }
 
-const Panel: FC = () => {
+const Panel = () => {
   const { t } = useTranslation()
 
   const bottomPanelWidth = useStore((s) => s.bottomPanelWidth)


### PR DESCRIPTION
## Summary

- Remove the unnecessary `React.FC` annotation from the no-props variable inspect Panel component.
- Remove the now-unused React type import.
- Preserve the component export and every render branch.

## Dependency

Stacked on #40290 only because all three PRs intentionally touch the same component in review order. This type cleanup has no accessibility or icon behavior dependency.

## Behavior contract

The component still accepts no props and renders the same Listening, Empty, and split-panel branches. State, effects, event handlers, store selectors, ARIA attributes, JSX, and memoization behavior are unchanged.

## Visual regression

No visual change is possible from this diff: JSX, DOM, classes, styles, layout, icons, and rendered attributes are unchanged relative to #40290.

Reviewer focus: confirm the diff is limited to the `FC` type import and component annotation.

## Validation

- Focused Vitest: 3/3 tests passed
- Focused code check: the same 3 baseline errors and 0 warnings as #40290
- Full `pnpm check`: 0 errors and 2057 existing warnings
- Diff relative to #40290: 1 production file, 1 insertion and 2 deletions
- `git diff --check`: passed

## Rollback

Revert `4db77fb0ac`; #40289 and #40290 remain fully functional and reviewable.

From Codex