### PR TITLE
fix(web): name human input delete action

### DIFF
--- a/web/app/components/workflow/nodes/human-input/components/__tests__/user-action.spec.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/__tests__/user-action.spec.tsx
@@ -122,7 +122,7 @@ describe('UserActionItem', () => {
       target: { value: '   ' },
     })
     fireEvent.click(screen.getByText('change-style'))
-    fireEvent.click(screen.getAllByRole('button')[1]!)
+    fireEvent.click(screen.getByRole('button', { name: 'operation.delete' }))
 
     expect(onChange).toHaveBeenNthCalledWith(1, expect.objectContaining({ id: '' }))
     expect(onChange).toHaveBeenNthCalledWith(
@@ -135,6 +135,6 @@ describe('UserActionItem', () => {
 
     expect(screen.getByTestId('nodes.humanInput.userActions.actionNamePlaceholder'))!.toBeDisabled()
     expect(screen.getByTestId('nodes.humanInput.userActions.buttonTextPlaceholder'))!.toBeDisabled()
-    expect(screen.getAllByRole('button')).toHaveLength(1)
+    expect(screen.queryByRole('button', { name: 'operation.delete' })).not.toBeInTheDocument()
   })
 })

--- a/web/app/components/workflow/nodes/human-input/components/user-action.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/user-action.tsx
@@ -101,7 +101,12 @@ const UserActionItem: FC<UserActionItemProps> = ({ data, onChange, onDelete, rea
         readonly={readonly}
       />
       {!readonly && (
-        <Button className="px-2" variant="tertiary" onClick={() => onDelete(data.id)}>
+        <Button
+          aria-label={t(($) => $['operation.delete'], { ns: 'common' })}
+          className="px-2"
+          variant="tertiary"
+          onClick={() => onDelete(data.id)}
+        >
           <RiDeleteBinLine className="size-4" />
         </Button>
       )}


### PR DESCRIPTION
## Summary

- Give the icon-only Human Input user-action Delete button the existing localized Delete label.
- Replace positional button lookup with a role-and-name query.
- Verify that readonly mode removes the named Delete action.

## Dependency

Independent single-PR stack based on current `main` at `925ca49f21`.

## Behavior contract

The existing Dify UI Button keeps the same delete callback, row id argument, conditional readonly rendering, classes, and icon. Assistive technology can now identify the action without relying on the trash icon or DOM order.

## Form boundary

This PR intentionally does not migrate the two adjacent legacy Input fields. Field naming, validation, and Dify UI Field composition are a separate form-owner contract and should not be mechanically bundled into an icon-button fix.

## Visual regression

No visual change is expected: Button variant, classes, dimensions, Delete icon, row layout, inputs, dropdown, conditional rendering, and handlers are unchanged. The translation value is applied only through `aria-label`.

Reviewer focus: compare editable and readonly rows in light and dark themes; rendered pixels should be identical.

## Validation

- Focused Vitest: 2/2 tests passed
- Focused accessibility lint: 0 diagnostics
- Focused code check: only the same legacy Input restriction and 1 existing CSS icon warning
- Full `pnpm check`: 0 errors and 2059 existing warnings
- `git diff --check`: passed
- Scope: 1 production file and 1 same-owner test file, 8 insertions and 3 deletions

## Rollback

Revert `f3d2c6bdf2`; delete behavior and visuals remain unchanged either way.

From Codex