### PR TITLE
refactor(web): use css icon for human input delete

### DIFF
--- a/web/app/components/workflow/nodes/human-input/components/user-action.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/user-action.tsx
@@ -2,7 +2,6 @@ import type { FC } from 'react'
 import type { UserAction } from '../types'
 import { Button } from '@langgenius/dify-ui/button'
 import { toast } from '@langgenius/dify-ui/toast'
-import { RiDeleteBinLine } from '@remixicon/react'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import Input from '@/app/components/base/input'
@@ -107,7 +106,7 @@ const UserActionItem: FC<UserActionItemProps> = ({ data, onChange, onDelete, rea
           variant="tertiary"
           onClick={() => onDelete(data.id)}
         >
-          <RiDeleteBinLine className="size-4" />
+          <span aria-hidden className="i-ri-delete-bin-line size-4" />
         </Button>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Replace the Human Input delete action's Remix SVG component with the equivalent project CSS icon.
- Mark the decorative icon hidden from assistive technology.
- Remove the now-unused Remix icon import.

## Dependency

Depends only on #40293, which gives the existing delete button its accessible name. No other behavior or form changes are included.

## Behavior contract

The parent button remains the only interactive element and keeps the same accessible name, delete callback, row id argument, readonly rendering, classes, and dimensions. This child only changes how the decorative trash glyph is rendered.

## Visual regression

This layer is expected to be pixel-equivalent: the icon remains `size-4` inside the same `px-2` tertiary Button.

Reviewer checklist:

- Compare the editable Human Input row before and after in light and dark themes.
- Check default, hover, focus-visible, and pressed states.
- Confirm glyph family, 16px size, alignment, color inheritance, button box, and surrounding row layout are unchanged.
- Confirm readonly mode still removes the entire delete action.

## Validation

- Focused Vitest: 2/2 tests passed
- Focused accessibility lint: 0 diagnostics
- Focused code check: only the same pre-existing legacy Input restriction; the icon warning is removed
- Full `pnpm check`: 0 errors and 2058 warnings, exactly 1 fewer warning than the parent
- `git diff --check`: passed
- Scope against parent: 1 production file, 1 insertion and 2 deletions

## Rollback

Revert `467cb203df` to restore only the icon implementation; #40293's accessible name remains intact.

From Codex