### PR TITLE
refactor(web): remove human input action React.FC

### DIFF
--- a/web/app/components/workflow/nodes/human-input/components/user-action.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/user-action.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import type { UserAction } from '../types'
 import { Button } from '@langgenius/dify-ui/button'
 import { toast } from '@langgenius/dify-ui/toast'
@@ -18,7 +17,7 @@ type UserActionItemProps = {
   readonly?: boolean
 }
 
-const UserActionItem: FC<UserActionItemProps> = ({ data, onChange, onDelete, readonly }) => {
+const UserActionItem = ({ data, onChange, onDelete, readonly }: UserActionItemProps) => {
   const { t } = useTranslation()
 
   const handleIDChange = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Summary

- Replace the Human Input user-action component's `React.FC` annotation with an explicit props parameter type.
- Remove the now-unused `FC` type import.
- Keep the React namespace import because the change handlers still use `React.ChangeEvent`.

## Dependency

Depends only on #40294 because it is a separate optional cleanup on the same component. It does not change or extend the accessible-name fix in #40293.

## Behavior contract

Type ownership moves from `React.FC<UserActionItemProps>` to the function parameter. Runtime output, props, children behavior, callbacks, conditional rendering, form inputs, translations, and icon implementation are identical.

## Visual regression

No JSX, classes, styles, assets, or runtime branches change. A visual difference is not possible from this type-only refactor; the Human Input row should render exactly as #40294.

## Validation

- Focused Vitest: 2/2 tests passed
- Focused accessibility lint: 0 diagnostics
- Focused code check: only the same pre-existing legacy Input restriction
- Full `pnpm check`: 0 errors and 2058 warnings, unchanged from the parent
- `git diff --check`: passed
- Scope against parent: 1 production file, 1 insertion and 2 deletions

## Rollback

Revert `c1532dcb04` to restore only the component typing style.

From Codex