### PR TITLE
fix(web): name MCP header fields

### DIFF
--- a/web/app/components/tools/mcp/__tests__/headers-input.spec.tsx
+++ b/web/app/components/tools/mcp/__tests__/headers-input.spec.tsx
@@ -48,6 +48,10 @@ describe('HeadersInput', () => {
 
     it('should render header items', () => {
       render(<HeadersInput {...defaultProps} headersItems={headersItems} />)
+      expect(screen.getAllByRole('textbox', { name: 'tools.mcp.modal.headerKey' })).toHaveLength(2)
+      expect(screen.getAllByRole('textbox', { name: 'tools.mcp.modal.headerValue' })).toHaveLength(
+        2,
+      )
       expect(screen.getByDisplayValue('Authorization')).toBeInTheDocument()
       expect(screen.getByDisplayValue('Bearer token123')).toBeInTheDocument()
       expect(screen.getByDisplayValue('Content-Type')).toBeInTheDocument()
@@ -105,7 +109,7 @@ describe('HeadersInput', () => {
       const onChange = vi.fn()
       render(<HeadersInput {...defaultProps} headersItems={headersItems} onChange={onChange} />)
 
-      const keyInput = screen.getByDisplayValue('Header1')
+      const keyInput = screen.getByRole('textbox', { name: 'tools.mcp.modal.headerKey' })
       fireEvent.change(keyInput, { target: { value: 'NewHeader' } })
 
       expect(onChange).toHaveBeenCalledWith([{ id: '1', key: 'NewHeader', value: 'Value1' }])
@@ -115,7 +119,7 @@ describe('HeadersInput', () => {
       const onChange = vi.fn()
       render(<HeadersInput {...defaultProps} headersItems={headersItems} onChange={onChange} />)
 
-      const valueInput = screen.getByDisplayValue('Value1')
+      const valueInput = screen.getByRole('textbox', { name: 'tools.mcp.modal.headerValue' })
       fireEvent.change(valueInput, { target: { value: 'NewValue' } })
 
       expect(onChange).toHaveBeenCalledWith([{ id: '1', key: 'Header1', value: 'NewValue' }])
@@ -166,7 +170,9 @@ describe('HeadersInput', () => {
       const onChange = vi.fn()
       render(<HeadersInput {...defaultProps} headersItems={headersItems} onChange={onChange} />)
 
-      const header2Input = screen.getByDisplayValue('Header2')
+      const header2Input = screen.getAllByRole('textbox', {
+        name: 'tools.mcp.modal.headerKey',
+      })[1]!
       fireEvent.change(header2Input, { target: { value: 'UpdatedHeader2' } })
 
       expect(onChange).toHaveBeenCalledWith([
@@ -199,8 +205,8 @@ describe('HeadersInput', () => {
     it('should make inputs readonly when readonly is true', () => {
       render(<HeadersInput {...defaultProps} headersItems={headersItems} readonly={true} />)
 
-      const keyInput = screen.getByDisplayValue('ReadOnly')
-      const valueInput = screen.getByDisplayValue('Value')
+      const keyInput = screen.getByRole('textbox', { name: 'tools.mcp.modal.headerKey' })
+      const valueInput = screen.getByRole('textbox', { name: 'tools.mcp.modal.headerValue' })
 
       expect(keyInput).toHaveAttribute('readonly')
       expect(valueInput).toHaveAttribute('readonly')
@@ -209,8 +215,8 @@ describe('HeadersInput', () => {
     it('should not make inputs readonly when readonly is false', () => {
       render(<HeadersInput {...defaultProps} headersItems={headersItems} readonly={false} />)
 
-      const keyInput = screen.getByDisplayValue('ReadOnly')
-      const valueInput = screen.getByDisplayValue('Value')
+      const keyInput = screen.getByRole('textbox', { name: 'tools.mcp.modal.headerKey' })
+      const valueInput = screen.getByRole('textbox', { name: 'tools.mcp.modal.headerValue' })
 
       expect(keyInput).not.toHaveAttribute('readonly')
       expect(valueInput).not.toHaveAttribute('readonly')
@@ -222,8 +228,10 @@ describe('HeadersInput', () => {
       const headersItems = [{ id: '1', key: '', value: '' }]
       render(<HeadersInput {...defaultProps} headersItems={headersItems} />)
 
-      const inputs = screen.getAllByRole('textbox')
-      expect(inputs.length).toBe(2)
+      expect(screen.getByRole('textbox', { name: 'tools.mcp.modal.headerKey' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('textbox', { name: 'tools.mcp.modal.headerValue' }),
+      ).toBeInTheDocument()
     })
 
     it('should handle special characters in header key', () => {

--- a/web/app/components/tools/mcp/headers-input.tsx
+++ b/web/app/components/tools/mcp/headers-input.tsx
@@ -85,6 +85,7 @@ const HeadersInput = ({ headersItems, onChange, readonly = false, isMasked = fal
           >
             <div className="w-1/2 border-r border-divider-regular">
               <Input
+                aria-label={t(($) => $['mcp.modal.headerKey'], { ns: 'tools' })}
                 value={item.key}
                 onChange={(e) => handleItemChange(index, 'key', e.target.value)}
                 placeholder={t(($) => $['mcp.modal.headerKeyPlaceholder'], { ns: 'tools' })}
@@ -94,6 +95,7 @@ const HeadersInput = ({ headersItems, onChange, readonly = false, isMasked = fal
             </div>
             <div className="flex w-1/2 items-center">
               <Input
+                aria-label={t(($) => $['mcp.modal.headerValue'], { ns: 'tools' })}
                 value={item.value}
                 onChange={(e) => handleItemChange(index, 'value', e.target.value)}
                 placeholder={t(($) => $['mcp.modal.headerValuePlaceholder'], { ns: 'tools' })}


### PR DESCRIPTION
## Summary

- Give every MCP header key and value Input the existing localized column name.
- Query the final textbox DOM by role and accessible name in the same-owner tests.
- Keep values, placeholders, readonly behavior, and list ownership unchanged.

## Dependency

Independent root of stack #40302, based on current `main` at `925ca49f21`.

## Dify UI boundary

The component already uses the standalone Dify UI Input primitive. This layer intentionally does not introduce Field layout or move state into a form abstraction: the repeated header list owns values and readonly behavior, while it has no per-field validation or error contract. The existing visible Header Key and Header Value column names are reused directly on the final input DOM.

## Behavior contract

Input elements, values, change handlers, placeholders, readonly flags, classes, row ids, add/remove behavior, and parent modal state are unchanged. Assistive technology can now distinguish the two textbox columns without relying on placeholders or current values.

## Visual regression

No visual change is expected. The production diff only adds two `aria-label` attributes; DOM structure, components, classes, dimensions, values, icons, and handlers are unchanged.

Reviewer focus: compare empty, populated, masked, and readonly header rows in light and dark themes. Static pixels and layout should be identical.

## Validation

- Focused Vitest: 24/24 tests passed
- Focused accessibility lint: 0 diagnostics
- Focused code check: 0 errors and 3 existing icon warnings
- Full `pnpm check`: 0 errors and 2059 existing warnings
- `git diff --check`: passed
- Scope: 1 production file and 1 same-owner test file, 19 insertions and 9 deletions

## Rollback

Revert `d574585b20`; runtime behavior and visuals remain unchanged either way.

From Codex