### PR TITLE
refactor(web): use css icons for MCP headers

### DIFF
--- a/web/app/components/tools/mcp/headers-input.tsx
+++ b/web/app/components/tools/mcp/headers-input.tsx
@@ -2,7 +2,6 @@
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
 import { Input } from '@langgenius/dify-ui/input'
-import { RiAddLine, RiDeleteBinLine } from '@remixicon/react'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { v4 as uuid } from 'uuid'
@@ -51,7 +50,7 @@ const HeadersInput = ({ headersItems, onChange, readonly = false, isMasked = fal
         </div>
         {!readonly && (
           <Button variant="secondary" size="small" onClick={handleAddItem} className="w-full">
-            <RiAddLine className="size-4" />
+            <span aria-hidden className="i-ri-add-line size-4" />
             {t(($) => $['mcp.modal.addHeader'], { ns: 'tools' })}
           </Button>
         )}
@@ -108,7 +107,7 @@ const HeadersInput = ({ headersItems, onChange, readonly = false, isMasked = fal
                   onClick={() => handleRemoveItem(index)}
                   className="mr-2"
                 >
-                  <RiDeleteBinLine aria-hidden className="size-4 text-text-destructive" />
+                  <span aria-hidden className="i-ri-delete-bin-line size-4 text-text-destructive" />
                 </ActionButton>
               )}
             </div>
@@ -117,7 +116,7 @@ const HeadersInput = ({ headersItems, onChange, readonly = false, isMasked = fal
       </div>
       {!readonly && (
         <Button variant="secondary" size="small" onClick={handleAddItem} className="w-full">
-          <RiAddLine className="size-4" />
+          <span aria-hidden className="i-ri-add-line size-4" />
           {t(($) => $['mcp.modal.addHeader'], { ns: 'tools' })}
         </Button>
       )}


### PR DESCRIPTION
## Summary

- Replace the MCP header Add and Delete Remix SVG components with the equivalent project CSS icons.
- Keep all three glyphs decorative.
- Remove the now-unused Remix icon import.

## Dependency

Depends only on #40300. This is an optional visual-implementation cleanup and does not change the field or action semantics.

## Behavior contract

Buttons, accessible names, values, callbacks, readonly conditions, classes, dimensions, and row structure are unchanged. Only the decorative glyph implementation changes.

## Visual regression

This layer is expected to be pixel-equivalent: both Add glyphs and the Delete glyph retain the same Remix icon names, `size-4`, color inheritance, and parent button layout.

Reviewer checklist:

- Compare empty and populated header editors in light and dark themes.
- Check Add and Delete default, hover, focus-visible, and pressed states.
- Confirm 16px glyph size, shape, alignment, color, button box, row height, and surrounding spacing are unchanged.
- Confirm readonly mode still removes Add and Delete controls exactly as before.

## Validation

- Focused Vitest: 24/24 tests passed
- Focused accessibility lint: 0 diagnostics
- Focused code check: 0 errors and 0 warnings
- Full `pnpm check`: 0 errors and 2056 warnings, exactly 3 fewer warnings than the parent
- `git diff --check`: passed
- Scope against parent: 1 production file, 3 insertions and 4 deletions

## Rollback

Revert `8d509e8d82` to restore only the icon implementation.

From Codex