### PR TITLE
fix(web): name OAuth redirect copy action

### DIFF
--- a/web/app/components/plugins/plugin-auth/authorize/__tests__/add-oauth-button.spec.tsx
+++ b/web/app/components/plugins/plugin-auth/authorize/__tests__/add-oauth-button.spec.tsx
@@ -1,6 +1,6 @@
 import type { OAuthClientSettingsProps } from '../oauth-client-settings'
 import type { FormSchema } from '@/app/components/base/form/types'
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import * as React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AuthCategory } from '../../types'
@@ -248,7 +248,7 @@ describe('AddOAuthButton', () => {
     })
     expect(screen.getByText('https://redirect.example.com')).toBeInTheDocument()
 
-    fireEvent.click(within(screen.getByTestId('oauth-schema-label-client_id')).getByRole('button'))
+    fireEvent.click(screen.getByRole('button', { name: 'common.operation.copy' }))
 
     expect(mockWriteText).toHaveBeenCalledWith('https://redirect.example.com')
   })

--- a/web/app/components/plugins/plugin-auth/authorize/add-oauth-button.tsx
+++ b/web/app/components/plugins/plugin-auth/authorize/add-oauth-button.tsx
@@ -101,12 +101,13 @@ const AddOAuthButton = ({
                 <div className="flex w-full py-0.5 system-sm-medium">
                   <div className="w-0 grow wrap-break-word break-all">{redirect_uri}</div>
                   <ActionButton
+                    aria-label={t(($) => $['operation.copy'], { ns: 'common' })}
                     className="shrink-0"
                     onClick={() => {
                       navigator.clipboard.writeText(redirect_uri || '')
                     }}
                   >
-                    <span className="i-ri-clipboard-line size-4" />
+                    <span aria-hidden className="i-ri-clipboard-line size-4" />
                   </ActionButton>
                 </div>
               )}


### PR DESCRIPTION
## Summary

- Give the icon-only OAuth redirect URI copy action the existing localized Copy name.
- Mark the clipboard glyph decorative.
- Replace the test's schema-container plus unnamed-button lookup with role and name.

## Dependency

Independent single-layer stack based on current `main` at `925ca49f21`.

## Behavior contract

The existing ActionButton keeps the same redirect URI, Clipboard API call, callback timing, schema label placement, classes, dimensions, and CSS icon. The action is now identifiable without first locating its test container or relying on an unnamed button.

## Form boundary

This PR does not alter the OAuth form schema, labels, values, validation, modal state, or Dify UI field composition. The copy action is an adjacent button-owned semantic contract.

## Visual regression

No visual change is expected. The production diff only adds `aria-label` and `aria-hidden`; elements, class names, icon class, spacing, redirect text wrapping, and handlers are unchanged.

Reviewer focus: compare the OAuth Client Settings redirect URI row in light and dark themes, including default, hover, focus-visible, and click states. Static pixels and layout should be identical.

## Validation

- Focused Vitest: 9/9 tests passed
- Focused accessibility lint: 0 diagnostics
- Focused code check: 0 errors and 0 warnings
- Full `pnpm check`: 0 errors and 2059 existing warnings
- `git diff --check`: passed
- Scope: 1 production file and 1 same-owner test file, 4 insertions and 3 deletions

## Rollback

Revert `0aaf617a5b`; copy behavior and visuals remain unchanged either way.

From Codex