### PR TITLE
fix(web): name external API card actions

### DIFF
--- a/web/app/components/datasets/external-api/external-api-panel/index.tsx
+++ b/web/app/components/datasets/external-api/external-api-panel/index.tsx
@@ -94,11 +94,12 @@ const ExternalAPIPanel: React.FC<ExternalAPIPanelProps> = ({
           {isLoading ? (
             <Loading />
           ) : (
-            externalKnowledgeApiList.map((api) => (
+            externalKnowledgeApiList.map((api, index) => (
               <ExternalKnowledgeAPICard
                 key={api.id}
                 api={api}
                 canManageExternalKnowledgeApi={canManageExternalKnowledgeApi}
+                position={index + 1}
               />
             ))
           )}

--- a/web/app/components/datasets/external-api/external-knowledge-api-card/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/external-api/external-knowledge-api-card/__tests__/index.spec.tsx
@@ -88,17 +88,20 @@ describe('ExternalKnowledgeAPICard', () => {
     })
 
     it('should render edit and delete buttons', () => {
-      const { container } = render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const buttons = container.querySelectorAll('button')
-      expect(buttons.length).toBe(2)
+      render(<ExternalKnowledgeAPICard {...defaultProps} />)
+      expect(screen.getByRole('button', { name: 'common.operation.edit' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'common.operation.delete' })).toBeInTheDocument()
     })
 
     it('should hide edit and delete buttons when external knowledge API management is unavailable', () => {
-      const { container } = render(
-        <ExternalKnowledgeAPICard {...defaultProps} canManageExternalKnowledgeApi={false} />,
-      )
+      render(<ExternalKnowledgeAPICard {...defaultProps} canManageExternalKnowledgeApi={false} />)
 
-      expect(container.querySelectorAll('button').length).toBe(0)
+      expect(
+        screen.queryByRole('button', { name: 'common.operation.edit' }),
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'common.operation.delete' }),
+      ).not.toBeInTheDocument()
     })
 
     it('should render API connection icon', () => {
@@ -125,9 +128,8 @@ describe('ExternalKnowledgeAPICard', () => {
       }
       vi.mocked(fetchExternalAPI).mockResolvedValue(mockResponse)
 
-      const { container } = render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const buttons = container.querySelectorAll('button')
-      const editButton = buttons[0]
+      render(<ExternalKnowledgeAPICard {...defaultProps} />)
+      const editButton = screen.getByRole('button', { name: 'common.operation.edit' })
 
       fireEvent.click(editButton!)
 
@@ -153,9 +155,8 @@ describe('ExternalKnowledgeAPICard', () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       vi.mocked(fetchExternalAPI).mockRejectedValue(new Error('Fetch failed'))
 
-      const { container } = render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const buttons = container.querySelectorAll('button')
-      const editButton = buttons[0]
+      render(<ExternalKnowledgeAPICard {...defaultProps} />)
+      const editButton = screen.getByRole('button', { name: 'common.operation.edit' })
 
       fireEvent.click(editButton!)
 
@@ -185,8 +186,8 @@ describe('ExternalKnowledgeAPICard', () => {
       }
       vi.mocked(fetchExternalAPI).mockResolvedValue(mockResponse)
 
-      const { container } = render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const editButton = container.querySelectorAll('button')[0]
+      render(<ExternalKnowledgeAPICard {...defaultProps} />)
+      const editButton = screen.getByRole('button', { name: 'common.operation.edit' })
 
       fireEvent.click(editButton!)
 
@@ -234,8 +235,8 @@ describe('ExternalKnowledgeAPICard', () => {
       }
       vi.mocked(fetchExternalAPI).mockResolvedValue(mockResponse)
 
-      const { container } = render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const editButton = container.querySelectorAll('button')[0]
+      render(<ExternalKnowledgeAPICard {...defaultProps} />)
+      const editButton = screen.getByRole('button', { name: 'common.operation.edit' })
 
       fireEvent.click(editButton!)
 
@@ -254,9 +255,8 @@ describe('ExternalKnowledgeAPICard', () => {
     it('should check usage and show confirm dialog when delete button is clicked', async () => {
       vi.mocked(checkUsageExternalAPI).mockResolvedValue({ is_using: false, count: 0 })
 
-      const { container } = render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const buttons = container.querySelectorAll('button')
-      const deleteButton = buttons[1]
+      render(<ExternalKnowledgeAPICard {...defaultProps} />)
+      const deleteButton = screen.getByRole('button', { name: 'common.operation.delete' })
 
       fireEvent.click(deleteButton!)
 
@@ -273,8 +273,8 @@ describe('ExternalKnowledgeAPICard', () => {
     it('should show usage count in confirm dialog when API is in use', async () => {
       vi.mocked(checkUsageExternalAPI).mockResolvedValue({ is_using: true, count: 3 })
 
-      const { container } = render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const deleteButton = container.querySelectorAll('button')[1]
+      render(<ExternalKnowledgeAPICard {...defaultProps} />)
+      const deleteButton = screen.getByRole('button', { name: 'common.operation.delete' })
 
       fireEvent.click(deleteButton!)
 
@@ -287,8 +287,8 @@ describe('ExternalKnowledgeAPICard', () => {
       vi.mocked(checkUsageExternalAPI).mockResolvedValue({ is_using: false, count: 0 })
       vi.mocked(deleteExternalAPI).mockResolvedValue({ result: 'success' })
 
-      const { container } = render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const deleteButton = container.querySelectorAll('button')[1]
+      render(<ExternalKnowledgeAPICard {...defaultProps} />)
+      const deleteButton = screen.getByRole('button', { name: 'common.operation.delete' })
 
       fireEvent.click(deleteButton!)
 
@@ -310,8 +310,8 @@ describe('ExternalKnowledgeAPICard', () => {
     it('should close confirm dialog when cancel is clicked', async () => {
       vi.mocked(checkUsageExternalAPI).mockResolvedValue({ is_using: false, count: 0 })
 
-      const { container } = render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const deleteButton = container.querySelectorAll('button')[1]
+      render(<ExternalKnowledgeAPICard {...defaultProps} />)
+      const deleteButton = screen.getByRole('button', { name: 'common.operation.delete' })
 
       fireEvent.click(deleteButton!)
 
@@ -332,8 +332,8 @@ describe('ExternalKnowledgeAPICard', () => {
       vi.mocked(checkUsageExternalAPI).mockResolvedValue({ is_using: false, count: 0 })
       vi.mocked(deleteExternalAPI).mockRejectedValue(new Error('Delete failed'))
 
-      const { container } = render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const deleteButton = container.querySelectorAll('button')[1]
+      render(<ExternalKnowledgeAPICard {...defaultProps} />)
+      const deleteButton = screen.getByRole('button', { name: 'common.operation.delete' })
 
       fireEvent.click(deleteButton!)
 
@@ -358,8 +358,8 @@ describe('ExternalKnowledgeAPICard', () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       vi.mocked(checkUsageExternalAPI).mockRejectedValue(new Error('Check failed'))
 
-      const { container } = render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const deleteButton = container.querySelectorAll('button')[1]
+      render(<ExternalKnowledgeAPICard {...defaultProps} />)
+      const deleteButton = screen.getByRole('button', { name: 'common.operation.delete' })
 
       fireEvent.click(deleteButton!)
 
@@ -394,8 +394,8 @@ describe('ExternalKnowledgeAPICard', () => {
       vi.mocked(checkUsageExternalAPI).mockResolvedValue({ is_using: false, count: 0 })
       vi.mocked(deleteExternalAPI).mockResolvedValue({ result: 'error' })
 
-      const { container } = render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const deleteButton = container.querySelectorAll('button')[1]
+      render(<ExternalKnowledgeAPICard {...defaultProps} />)
+      const deleteButton = screen.getByRole('button', { name: 'common.operation.delete' })
 
       fireEvent.click(deleteButton!)
 

--- a/web/app/components/datasets/external-api/external-knowledge-api-card/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/external-api/external-knowledge-api-card/__tests__/index.spec.tsx
@@ -70,7 +70,13 @@ describe('ExternalKnowledgeAPICard', () => {
   const defaultProps = {
     api: mockApi,
     canManageExternalKnowledgeApi: true,
+    position: 1,
   }
+
+  const editButtonName =
+    'common.operation.edit Test External API https://api.example.com/knowledge 1'
+  const deleteButtonName =
+    'common.operation.delete Test External API https://api.example.com/knowledge 1'
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -88,20 +94,41 @@ describe('ExternalKnowledgeAPICard', () => {
     })
 
     it('should render edit and delete buttons', () => {
-      render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      expect(screen.getByRole('button', { name: 'common.operation.edit' })).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: 'common.operation.delete' })).toBeInTheDocument()
+      const duplicateApi = {
+        ...mockApi,
+        id: 'api-456',
+      }
+
+      render(
+        <>
+          <ExternalKnowledgeAPICard {...defaultProps} />
+          <ExternalKnowledgeAPICard
+            api={duplicateApi}
+            canManageExternalKnowledgeApi={true}
+            position={2}
+          />
+        </>,
+      )
+
+      expect(screen.getByRole('button', { name: editButtonName })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: deleteButtonName })).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', {
+          name: 'common.operation.edit Test External API https://api.example.com/knowledge 2',
+        }),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', {
+          name: 'common.operation.delete Test External API https://api.example.com/knowledge 2',
+        }),
+      ).toBeInTheDocument()
     })
 
     it('should hide edit and delete buttons when external knowledge API management is unavailable', () => {
       render(<ExternalKnowledgeAPICard {...defaultProps} canManageExternalKnowledgeApi={false} />)
 
-      expect(
-        screen.queryByRole('button', { name: 'common.operation.edit' }),
-      ).not.toBeInTheDocument()
-      expect(
-        screen.queryByRole('button', { name: 'common.operation.delete' }),
-      ).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: editButtonName })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: deleteButtonName })).not.toBeInTheDocument()
     })
 
     it('should render API connection icon', () => {
@@ -129,7 +156,7 @@ describe('ExternalKnowledgeAPICard', () => {
       vi.mocked(fetchExternalAPI).mockResolvedValue(mockResponse)
 
       render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const editButton = screen.getByRole('button', { name: 'common.operation.edit' })
+      const editButton = screen.getByRole('button', { name: editButtonName })
 
       fireEvent.click(editButton!)
 
@@ -156,7 +183,7 @@ describe('ExternalKnowledgeAPICard', () => {
       vi.mocked(fetchExternalAPI).mockRejectedValue(new Error('Fetch failed'))
 
       render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const editButton = screen.getByRole('button', { name: 'common.operation.edit' })
+      const editButton = screen.getByRole('button', { name: editButtonName })
 
       fireEvent.click(editButton!)
 
@@ -187,7 +214,7 @@ describe('ExternalKnowledgeAPICard', () => {
       vi.mocked(fetchExternalAPI).mockResolvedValue(mockResponse)
 
       render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const editButton = screen.getByRole('button', { name: 'common.operation.edit' })
+      const editButton = screen.getByRole('button', { name: editButtonName })
 
       fireEvent.click(editButton!)
 
@@ -236,7 +263,7 @@ describe('ExternalKnowledgeAPICard', () => {
       vi.mocked(fetchExternalAPI).mockResolvedValue(mockResponse)
 
       render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const editButton = screen.getByRole('button', { name: 'common.operation.edit' })
+      const editButton = screen.getByRole('button', { name: editButtonName })
 
       fireEvent.click(editButton!)
 
@@ -256,7 +283,7 @@ describe('ExternalKnowledgeAPICard', () => {
       vi.mocked(checkUsageExternalAPI).mockResolvedValue({ is_using: false, count: 0 })
 
       render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const deleteButton = screen.getByRole('button', { name: 'common.operation.delete' })
+      const deleteButton = screen.getByRole('button', { name: deleteButtonName })
 
       fireEvent.click(deleteButton!)
 
@@ -274,7 +301,7 @@ describe('ExternalKnowledgeAPICard', () => {
       vi.mocked(checkUsageExternalAPI).mockResolvedValue({ is_using: true, count: 3 })
 
       render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const deleteButton = screen.getByRole('button', { name: 'common.operation.delete' })
+      const deleteButton = screen.getByRole('button', { name: deleteButtonName })
 
       fireEvent.click(deleteButton!)
 
@@ -288,7 +315,7 @@ describe('ExternalKnowledgeAPICard', () => {
       vi.mocked(deleteExternalAPI).mockResolvedValue({ result: 'success' })
 
       render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const deleteButton = screen.getByRole('button', { name: 'common.operation.delete' })
+      const deleteButton = screen.getByRole('button', { name: deleteButtonName })
 
       fireEvent.click(deleteButton!)
 
@@ -311,7 +338,7 @@ describe('ExternalKnowledgeAPICard', () => {
       vi.mocked(checkUsageExternalAPI).mockResolvedValue({ is_using: false, count: 0 })
 
       render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const deleteButton = screen.getByRole('button', { name: 'common.operation.delete' })
+      const deleteButton = screen.getByRole('button', { name: deleteButtonName })
 
       fireEvent.click(deleteButton!)
 
@@ -333,7 +360,7 @@ describe('ExternalKnowledgeAPICard', () => {
       vi.mocked(deleteExternalAPI).mockRejectedValue(new Error('Delete failed'))
 
       render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const deleteButton = screen.getByRole('button', { name: 'common.operation.delete' })
+      const deleteButton = screen.getByRole('button', { name: deleteButtonName })
 
       fireEvent.click(deleteButton!)
 
@@ -359,7 +386,7 @@ describe('ExternalKnowledgeAPICard', () => {
       vi.mocked(checkUsageExternalAPI).mockRejectedValue(new Error('Check failed'))
 
       render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const deleteButton = screen.getByRole('button', { name: 'common.operation.delete' })
+      const deleteButton = screen.getByRole('button', { name: deleteButtonName })
 
       fireEvent.click(deleteButton!)
 
@@ -384,6 +411,7 @@ describe('ExternalKnowledgeAPICard', () => {
         <ExternalKnowledgeAPICard
           api={apiWithEmptyEndpoint}
           canManageExternalKnowledgeApi={true}
+          position={1}
         />,
       )
       expect(screen.getByText('Test External API'))!.toBeInTheDocument()
@@ -395,7 +423,7 @@ describe('ExternalKnowledgeAPICard', () => {
       vi.mocked(deleteExternalAPI).mockResolvedValue({ result: 'error' })
 
       render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const deleteButton = screen.getByRole('button', { name: 'common.operation.delete' })
+      const deleteButton = screen.getByRole('button', { name: deleteButtonName })
 
       fireEvent.click(deleteButton!)
 

--- a/web/app/components/datasets/external-api/external-knowledge-api-card/index.tsx
+++ b/web/app/components/datasets/external-api/external-knowledge-api-card/index.tsx
@@ -28,11 +28,13 @@ import {
 type ExternalKnowledgeAPICardProps = {
   api: ExternalKnowledgeApiResponse
   canManageExternalKnowledgeApi: boolean
+  position: number
 }
 
 const ExternalKnowledgeAPICard: React.FC<ExternalKnowledgeAPICardProps> = ({
   api,
   canManageExternalKnowledgeApi,
+  position,
 }) => {
   const { setShowExternalKnowledgeAPIModal } = useModalContext()
   const [showConfirm, setShowConfirm] = useState(false)
@@ -133,7 +135,7 @@ const ExternalKnowledgeAPICard: React.FC<ExternalKnowledgeAPICardProps> = ({
         {canManageExternalKnowledgeApi && (
           <div className="flex items-start gap-1">
             <ActionButton
-              aria-label={t(($) => $['operation.edit'], { ns: 'common' })}
+              aria-label={`${t(($) => $['operation.edit'], { ns: 'common' })} ${api.name} ${endpoint} ${position}`}
               onClick={handleEditClick}
             >
               <RiEditLine
@@ -142,7 +144,7 @@ const ExternalKnowledgeAPICard: React.FC<ExternalKnowledgeAPICardProps> = ({
               />
             </ActionButton>
             <ActionButton
-              aria-label={t(($) => $['operation.delete'], { ns: 'common' })}
+              aria-label={`${t(($) => $['operation.delete'], { ns: 'common' })} ${api.name} ${endpoint} ${position}`}
               className="hover:bg-state-destructive-hover"
               onClick={handleDeleteClick}
               onMouseEnter={() => setIsHovered(true)}

--- a/web/app/components/datasets/external-api/external-knowledge-api-card/index.tsx
+++ b/web/app/components/datasets/external-api/external-knowledge-api-card/index.tsx
@@ -132,16 +132,26 @@ const ExternalKnowledgeAPICard: React.FC<ExternalKnowledgeAPICardProps> = ({
         </div>
         {canManageExternalKnowledgeApi && (
           <div className="flex items-start gap-1">
-            <ActionButton onClick={handleEditClick}>
-              <RiEditLine className="size-4 text-text-tertiary hover:text-text-secondary" />
+            <ActionButton
+              aria-label={t(($) => $['operation.edit'], { ns: 'common' })}
+              onClick={handleEditClick}
+            >
+              <RiEditLine
+                aria-hidden
+                className="size-4 text-text-tertiary hover:text-text-secondary"
+              />
             </ActionButton>
             <ActionButton
+              aria-label={t(($) => $['operation.delete'], { ns: 'common' })}
               className="hover:bg-state-destructive-hover"
               onClick={handleDeleteClick}
               onMouseEnter={() => setIsHovered(true)}
               onMouseLeave={() => setIsHovered(false)}
             >
-              <RiDeleteBinLine className="size-4 text-text-tertiary hover:text-text-destructive" />
+              <RiDeleteBinLine
+                aria-hidden
+                className="size-4 text-text-tertiary hover:text-text-destructive"
+              />
             </ActionButton>
           </div>
         )}


### PR DESCRIPTION
## Summary

- name the External Knowledge API card Edit and Delete actions with existing localized strings
- mark both action glyphs decorative
- query both actions by role and name in permission and interaction tests

## Review boundary

Fetch, modal, usage check, confirmation, deletion, invalidation, permission, handlers, node order, classes, dimensions, hover styles, and Remix icons are unchanged.

## Visual regression review

Production changes are ARIA-only, so normal, hover, focus, light, and dark pixels must be unchanged.

## Verification

- owner suite: 17/17 passed
- standalone a11y lint: 0 diagnostics
- full static check: 0 errors
- diff check: passed

## Dependency and rollback

Independent root layer. Revert it to remove the names and semantic locators together.