### PR TITLE
refactor(web): use css icons for external API card

### DIFF
--- a/web/app/components/datasets/external-api/external-knowledge-api-card/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/external-api/external-knowledge-api-card/__tests__/index.spec.tsx
@@ -103,12 +103,6 @@ describe('ExternalKnowledgeAPICard', () => {
         screen.queryByRole('button', { name: 'common.operation.delete' }),
       ).not.toBeInTheDocument()
     })
-
-    it('should render API connection icon', () => {
-      const { container } = render(<ExternalKnowledgeAPICard {...defaultProps} />)
-      const icon = container.querySelector('svg')
-      expect(icon)!.toBeInTheDocument()
-    })
   })
 
   describe('User Interactions - Edit', () => {

--- a/web/app/components/datasets/external-api/external-knowledge-api-card/index.tsx
+++ b/web/app/components/datasets/external-api/external-knowledge-api-card/index.tsx
@@ -9,13 +9,11 @@ import {
   AlertDialogDescription,
   AlertDialogTitle,
 } from '@langgenius/dify-ui/alert-dialog'
-import { RiDeleteBinLine, RiEditLine } from '@remixicon/react'
 import { useQueryClient } from '@tanstack/react-query'
 import * as React from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import ActionButton from '@/app/components/base/action-button'
-import { ApiConnectionMod } from '@/app/components/base/icons/src/vender/solid/development'
 import { useModalContext } from '@/context/modal-context'
 import { consoleQuery } from '@/service/client'
 import {
@@ -125,7 +123,10 @@ const ExternalKnowledgeAPICard: React.FC<ExternalKnowledgeAPICardProps> = ({
       >
         <div className="flex grow flex-col items-start justify-center gap-1.5 py-1">
           <div className="flex items-center gap-1 self-stretch text-text-secondary">
-            <ApiConnectionMod className="size-4" />
+            <span
+              aria-hidden
+              className="i-custom-vender-solid-development-api-connection-mod size-4"
+            />
             <div className="system-sm-medium">{api.name}</div>
           </div>
           <div className="self-stretch system-xs-regular text-text-tertiary">{endpoint}</div>
@@ -136,9 +137,9 @@ const ExternalKnowledgeAPICard: React.FC<ExternalKnowledgeAPICardProps> = ({
               aria-label={t(($) => $['operation.edit'], { ns: 'common' })}
               onClick={handleEditClick}
             >
-              <RiEditLine
+              <span
                 aria-hidden
-                className="size-4 text-text-tertiary hover:text-text-secondary"
+                className="i-ri-edit-line size-4 text-text-tertiary hover:text-text-secondary"
               />
             </ActionButton>
             <ActionButton
@@ -148,9 +149,9 @@ const ExternalKnowledgeAPICard: React.FC<ExternalKnowledgeAPICardProps> = ({
               onMouseEnter={() => setIsHovered(true)}
               onMouseLeave={() => setIsHovered(false)}
             >
-              <RiDeleteBinLine
+              <span
                 aria-hidden
-                className="size-4 text-text-tertiary hover:text-text-destructive"
+                className="i-ri-delete-bin-line size-4 text-text-tertiary hover:text-text-destructive"
               />
             </ActionButton>
           </div>


### PR DESCRIPTION
## Summary

- Replace the API connection, Edit, and Delete SVG components with the equivalent project CSS icons.
- Preserve decorative semantics for all three glyphs.
- Delete the test that asserted only that some SVG existed.

## Dependency

Depends only on #40305. This is an optional visual-implementation cleanup above the completed semantic and test contracts.

## Test boundary

The removed test inspected an implementation detail and could not verify icon identity, alignment, color, or behavior. The remaining 16 tests cover the card's public rendering, permissions, edit flow, delete flow, confirmations, invalidation, and errors; visual equivalence is reviewed explicitly below.

## Visual regression

This layer is expected to be pixel-equivalent: the three CSS classes map to the same project icon names and retain the same `size-4` and text-color classes.

Reviewer checklist:

- Compare manageable and read-only cards in light and dark themes.
- Check API connection, Edit, and Delete glyph shape, 16px size, alignment, color, and surrounding spacing.
- Check Edit/Delete default, hover, focus-visible, and destructive hover states.
- Confirm card height, border, background, name, endpoint, and confirmation flow are unchanged.

## Validation

- Focused Vitest: 16/16 behavior tests passed
- Focused accessibility lint: 0 diagnostics
- Focused code check: 0 errors and 0 warnings
- Full `pnpm check`: 0 errors and 2056 warnings, exactly 3 fewer warnings than the parent
- `git diff --check`: passed
- Scope against parent: 1 production file and 1 test file, 8 insertions and 13 deletions

## Rollback

Revert `3092b775b8` to restore only the icon implementation and SVG-trivia test.

From Codex