### PR TITLE
refactor(web): remove external API card React.FC

### DIFF
--- a/web/app/components/datasets/external-api/external-knowledge-api-card/index.tsx
+++ b/web/app/components/datasets/external-api/external-knowledge-api-card/index.tsx
@@ -10,7 +10,6 @@ import {
   AlertDialogTitle,
 } from '@langgenius/dify-ui/alert-dialog'
 import { useQueryClient } from '@tanstack/react-query'
-import * as React from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import ActionButton from '@/app/components/base/action-button'
@@ -28,10 +27,10 @@ type ExternalKnowledgeAPICardProps = {
   canManageExternalKnowledgeApi: boolean
 }
 
-const ExternalKnowledgeAPICard: React.FC<ExternalKnowledgeAPICardProps> = ({
+const ExternalKnowledgeAPICard = ({
   api,
   canManageExternalKnowledgeApi,
-}) => {
+}: ExternalKnowledgeAPICardProps) => {
   const { setShowExternalKnowledgeAPIModal } = useModalContext()
   const [showConfirm, setShowConfirm] = useState(false)
   const [isHovered, setIsHovered] = useState(false)


### PR DESCRIPTION
## Summary

- Replace the External Knowledge API card's `React.FC` annotation with an explicit props parameter type.
- Remove the now-unused React namespace import.

## Dependency

Depends only on #40306 because it is a separate optional cleanup on the same component. It does not change the semantic or icon contracts.

## Behavior contract

Runtime output, props, callbacks, state, data fetching, mutations, dialogs, JSX, classes, icons, and conditional rendering are identical. Only TypeScript component typing changes.

## Visual regression

No JSX, classes, styles, assets, or runtime branches change. A visual difference is not possible from this type-only refactor; the card should render exactly as #40306.

## Validation

- Focused Vitest: 16/16 behavior tests passed
- Focused accessibility lint: 0 diagnostics
- Focused code check: 0 errors and 0 warnings
- Full `pnpm check`: 0 errors and 2056 warnings, unchanged from the parent
- `git diff --check`: passed
- Scope against parent: 1 production file, 2 insertions and 3 deletions

## Rollback

Revert `4e4b65efe1` to restore only the component typing style.

From Codex