### PR TITLE
fix(web): name external API panel close

### DIFF
--- a/web/app/components/datasets/external-api/external-api-panel/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/external-api/external-api-panel/__tests__/index.spec.tsx
@@ -105,10 +105,8 @@ describe('ExternalAPIPanel', () => {
     })
 
     it('should render close button', () => {
-      const { container } = render(<ExternalAPIPanel {...defaultProps} />)
-      const closeButton =
-        container.querySelector('[class*="action-button"]') || screen.getAllByRole('button')[0]
-      expect(closeButton)!.toBeInTheDocument()
+      render(<ExternalAPIPanel {...defaultProps} />)
+      expect(screen.getByRole('button', { name: 'common.operation.close' })).toBeInTheDocument()
     })
   })
 
@@ -171,11 +169,7 @@ describe('ExternalAPIPanel', () => {
     it('should call onClose when close button is clicked', () => {
       const onClose = vi.fn()
       render(<ExternalAPIPanel canManageExternalKnowledgeApi={true} onClose={onClose} />)
-      // Find the close button (ActionButton with close icon)
-      const buttons = screen.getAllByRole('button')
-      const closeButton =
-        buttons.find((btn) => btn.querySelector('svg[class*="ri-close"]')) || buttons[0]
-      fireEvent.click(closeButton!)
+      fireEvent.click(screen.getByRole('button', { name: 'common.operation.close' }))
       expect(onClose).toHaveBeenCalledTimes(1)
     })
 

--- a/web/app/components/datasets/external-api/external-api-panel/index.tsx
+++ b/web/app/components/datasets/external-api/external-api-panel/index.tsx
@@ -71,8 +71,11 @@ const ExternalAPIPanel: React.FC<ExternalAPIPanelProps> = ({
             </a>
           </div>
           <div className="flex items-center">
-            <ActionButton onClick={() => onClose()}>
-              <RiCloseLine className="size-4 text-text-tertiary" />
+            <ActionButton
+              aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+              onClick={() => onClose()}
+            >
+              <RiCloseLine aria-hidden className="size-4 text-text-tertiary" />
             </ActionButton>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- give the External API panel close action a localized accessible name
- hide the close glyph from the accessibility tree
- query the close action by role and name instead of button position or SVG internals

## Ownership and scope

The External API panel owns this action and its behavior test. This PR does not change the shared ActionButton primitive, form behavior, layout, styling, or event flow. It is the semantic root of the stack.

## Visual regression review

This is an ARIA-only production change. The rendered element, classes, dimensions, glyph, visible text, and click path are unchanged.

Please verify:
- panel header layout in light and dark themes
- close glyph size, color, and alignment
- close action hover, active, and focus-visible states
- no shift in the documentation link or panel content

## Validation

- focused Vitest: 14/14 passed
- standalone accessibility lint: 0 findings
- focused format/lint/type check: 0 findings
- full pnpm check: 0 errors, 2059 existing warnings
- git diff --check: passed

## Rollback

Revert this PR alone to remove the accessible name and the matching semantic test migration. No shared primitive or downstream behavior depends on it.