### PR TITLE
refactor(web): use css icons for external API panel

### DIFF
--- a/web/app/components/datasets/external-api/external-api-panel/index.tsx
+++ b/web/app/components/datasets/external-api/external-api-panel/index.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
-import { RiAddLine, RiBookOpenLine, RiCloseLine } from '@remixicon/react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
@@ -64,7 +63,7 @@ const ExternalAPIPanel: React.FC<ExternalAPIPanelProps> = ({
               href={docLink('/use-dify/knowledge/external-knowledge-api')}
               target="_blank"
             >
-              <RiBookOpenLine className="size-3 text-text-accent" />
+              <span aria-hidden className="i-ri-book-open-line size-3 text-text-accent" />
               <div className="grow body-xs-regular text-text-accent">
                 {t(($) => $.externalAPIPanelDocumentation, { ns: 'dataset' })}
               </div>
@@ -75,7 +74,7 @@ const ExternalAPIPanel: React.FC<ExternalAPIPanelProps> = ({
               aria-label={t(($) => $['operation.close'], { ns: 'common' })}
               onClick={() => onClose()}
             >
-              <RiCloseLine aria-hidden className="size-4 text-text-tertiary" />
+              <span aria-hidden className="i-ri-close-line size-4 text-text-tertiary" />
             </ActionButton>
           </div>
         </div>
@@ -86,7 +85,10 @@ const ExternalAPIPanel: React.FC<ExternalAPIPanelProps> = ({
               className="flex items-center justify-center px-3 py-2"
               onClick={handleOpenExternalAPIModal}
             >
-              <RiAddLine className="size-4 text-components-button-primary-text" />
+              <span
+                aria-hidden
+                className="i-ri-add-line size-4 text-components-button-primary-text"
+              />
               <div className="system-sm-medium text-components-button-primary-text">
                 {t(($) => $.createExternalAPI, { ns: 'dataset' })}
               </div>


### PR DESCRIPTION
## Summary

- replace the External API panel documentation, close, and add RemixIcon components with equivalent CSS icon spans
- keep all glyphs decorative while preserving existing size and color classes
- remove exactly three prefer-tailwind-icons warnings

## Dependency

This PR is stacked on #40309 because it preserves the accessible close-action contract introduced there. It contains only icon implementation changes.

## Visual regression review

Please compare before and after in light and dark themes:
- documentation, close, and add glyph shapes
- 12px documentation icon and 16px close/add icon dimensions
- accent, tertiary, and primary-button icon colors
- inline alignment, gaps, and button box geometry
- close action hover, active, and focus-visible states
- panel header and create-button layout

No text, event, accessibility name, or component geometry is intentionally changed.

## Validation

- focused Vitest: 14/14 passed
- standalone accessibility lint: 0 findings
- focused format/lint/type check: 0 findings
- full pnpm check: 0 errors, 2056 existing warnings
- warning delta from parent: exactly -3
- git diff --check: passed

## Rollback

Revert this PR alone to restore the component icons. The semantic fix in #40309 remains intact.