### PR TITLE
refactor(web): remove external API panel React.FC

### DIFF
--- a/web/app/components/datasets/external-api/external-api-panel/index.tsx
+++ b/web/app/components/datasets/external-api/external-api-panel/index.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@langgenius/dify-ui/button'
 import { cn } from '@langgenius/dify-ui/cn'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import ActionButton from '@/app/components/base/action-button'
 import Loading from '@/app/components/base/loading'
@@ -15,10 +14,7 @@ type ExternalAPIPanelProps = {
   onClose: () => void
 }
 
-const ExternalAPIPanel: React.FC<ExternalAPIPanelProps> = ({
-  canManageExternalKnowledgeApi,
-  onClose,
-}) => {
+const ExternalAPIPanel = ({ canManageExternalKnowledgeApi, onClose }: ExternalAPIPanelProps) => {
   const { t } = useTranslation()
   const docLink = useDocLink()
   const { setShowExternalKnowledgeAPIModal } = useModalContext()


### PR DESCRIPTION
## Summary

- type ExternalAPIPanel props directly on the function parameter
- remove the unused React namespace import and React.FC annotation
- preserve the component API, JSX, and runtime behavior

## Dependency

This cleanup is stacked on #40310 only because it edits the same component after the icon conversion. It has no accessibility or runtime dependency and remains a separate review layer.

## Visual regression review

This is a type-only refactor. The emitted JSX, classes, visible content, dimensions, interaction states, and accessibility tree are unchanged. A visual difference would be a regression.

## Validation

- focused Vitest: 14/14 passed
- standalone accessibility lint: 0 findings
- focused format/lint/type check: 0 findings
- full pnpm check: 0 errors, 2056 existing warnings
- git diff --check: passed

## Rollback

Revert this PR alone to restore React.FC without affecting either lower stack layer.