### PR TITLE
fix(web): name external API modal close

### DIFF
--- a/web/app/components/datasets/external-api/external-api-modal/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/external-api/external-api-modal/__tests__/index.spec.tsx
@@ -74,9 +74,7 @@ describe('AddExternalAPIModal', () => {
 
     it('should render close button', () => {
       render(<AddExternalAPIModal {...defaultProps} />)
-      // Close button is rendered in a portal
-      const closeButton = document.body.querySelector('.action-btn')
-      expect(closeButton)!.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'common.operation.close' })).toBeInTheDocument()
     })
   })
 
@@ -388,9 +386,7 @@ describe('AddExternalAPIModal', () => {
       const onCancel = vi.fn()
       render(<AddExternalAPIModal {...defaultProps} onCancel={onCancel} />)
 
-      // Close button is rendered in a portal
-      const closeButton = document.body.querySelector('.action-btn')!
-      fireEvent.click(closeButton)
+      fireEvent.click(screen.getByRole('button', { name: 'common.operation.close' }))
 
       expect(onCancel).toHaveBeenCalledTimes(1)
     })

--- a/web/app/components/datasets/external-api/external-api-modal/index.tsx
+++ b/web/app/components/datasets/external-api/external-api-modal/index.tsx
@@ -184,8 +184,12 @@ const AddExternalAPIModal: FC<AddExternalAPIModalProps> = ({
               </div>
             )}
           </div>
-          <ActionButton className="absolute top-5 right-5" onClick={onCancel}>
-            <RiCloseLine className="h-4.5 w-4.5 shrink-0 text-text-tertiary" />
+          <ActionButton
+            aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+            className="absolute top-5 right-5"
+            onClick={onCancel}
+          >
+            <RiCloseLine aria-hidden className="h-4.5 w-4.5 shrink-0 text-text-tertiary" />
           </ActionButton>
           <Form
             value={formData}


### PR DESCRIPTION
## Summary

- give the External API modal close action a localized accessible name
- hide the close glyph from the accessibility tree
- query the close action by role and name instead of portal CSS internals

## Ownership and scope

The External API modal owns the close action and its behavior test. This PR does not change the shared ActionButton primitive or the modal form owner. Dify UI Form and field semantics, validation, save/edit behavior, confirmation flow, and dialog dismissal behavior are unchanged.

## Visual regression review

This is an ARIA-only production change. The rendered element, classes, dimensions, glyph, visible text, and click path are unchanged.

Please verify:
- modal title and close-action alignment in create and edit modes
- close glyph size and color in light and dark themes
- close action hover, active, and focus-visible states
- no shift in the form, action footer, or encryption notice

## Validation

- focused Vitest: 24/24 passed
- standalone accessibility lint: 0 findings
- focused format/lint/type check: 0 errors, 4 existing icon warnings
- full pnpm check: 0 errors, 2059 existing warnings
- git diff --check: passed

## Rollback

Revert this PR alone to remove the accessible name and semantic test migration. No shared primitive or form behavior depends on it.