### PR TITLE
refactor(web): remove external API modal React.FC

### DIFF
--- a/web/app/components/datasets/external-api/external-api-modal/index.tsx
+++ b/web/app/components/datasets/external-api/external-api-modal/index.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import type { CreateExternalAPIReq, FormSchema } from '../declarations'
 import {
   AlertDialog,
@@ -65,14 +64,14 @@ const emptyExternalAPIFormData: CreateExternalAPIReq = {
   },
 }
 
-const AddExternalAPIModal: FC<AddExternalAPIModalProps> = ({
+const AddExternalAPIModal = ({
   data,
   onSave,
   onCancel,
   datasetBindings,
   isEditMode,
   onEdit,
-}) => {
+}: AddExternalAPIModalProps) => {
   const { t } = useTranslation()
   const [loading, setLoading] = useState(false)
   const [showConfirm, setShowConfirm] = useState(false)


### PR DESCRIPTION
## Summary

- type AddExternalAPIModal props directly on the function parameter
- remove the FC type import and annotation
- preserve the component API, JSX, form ownership, and runtime behavior

## Dependency

This cleanup is stacked on #40314 only because it edits the same component after the icon conversion. It has no accessibility, form, or runtime dependency and remains a separate review layer.

## Visual regression review

This is a type-only refactor. The emitted JSX, classes, visible content, dimensions, interaction states, form behavior, and accessibility tree are unchanged. A visual difference would be a regression.

## Validation

- focused Vitest: 24/24 passed
- standalone accessibility lint: 0 findings
- focused format/lint/type check: 0 findings
- full pnpm check: 0 errors, 2055 existing warnings
- git diff --check: passed

## Rollback

Revert this PR alone to restore FC without affecting either lower stack layer.