### PR TITLE
fix(web): name external retrieval close action

### DIFF
--- a/web/app/components/datasets/hit-testing/__tests__/modify-external-retrieval-modal.spec.tsx
+++ b/web/app/components/datasets/hit-testing/__tests__/modify-external-retrieval-modal.spec.tsx
@@ -2,14 +2,6 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import ModifyExternalRetrievalModal from '../modify-external-retrieval-modal'
 
-vi.mock('@/app/components/base/action-button', () => ({
-  default: ({ children, onClick }: { children: React.ReactNode; onClick: () => void }) => (
-    <button data-testid="action-button" onClick={onClick}>
-      {children}
-    </button>
-  ),
-}))
-
 vi.mock('../../external-knowledge-base/create/RetrievalSettings', () => ({
   default: ({
     topK,
@@ -67,7 +59,7 @@ describe('ModifyExternalRetrievalModal', () => {
 
   it('should call onClose when close button clicked', () => {
     render(<ModifyExternalRetrievalModal {...defaultProps} />)
-    fireEvent.click(screen.getByTestId('action-button'))
+    fireEvent.click(screen.getByRole('button', { name: 'common.operation.close' }))
     expect(defaultProps.onClose).toHaveBeenCalled()
   })
 

--- a/web/app/components/datasets/hit-testing/modify-external-retrieval-modal.tsx
+++ b/web/app/components/datasets/hit-testing/modify-external-retrieval-modal.tsx
@@ -55,8 +55,12 @@ const ModifyExternalRetrievalModal: React.FC<ModifyExternalRetrievalModalProps> 
         <div className="grow system-xl-semibold text-text-primary">
           {t(($) => $.settingTitle, { ns: 'datasetHitTesting' })}
         </div>
-        <ActionButton className="ml-auto" onClick={onClose}>
-          <RiCloseLine className="size-4 shrink-0" />
+        <ActionButton
+          aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+          className="ml-auto"
+          onClick={onClose}
+        >
+          <RiCloseLine aria-hidden className="size-4 shrink-0" />
         </ActionButton>
       </div>
       <div className="flex flex-col items-start justify-center gap-4 self-stretch p-4 pt-2">


### PR DESCRIPTION
## Summary

- give the external retrieval settings close action a localized accessible name
- hide the close glyph from the accessibility tree
- remove the ActionButton test mock that replaced the real control with a data-testid
- exercise the real ActionButton through role and accessible name

## Ownership and scope

ModifyExternalRetrievalModal owns the close action and its behavior test. RetrievalSettings remains the business boundary in the test. This PR does not change retrieval fields, values, save behavior, the shared ActionButton primitive, or any Dify UI form contract.

## Visual regression review

This is an ARIA-only production change. The rendered ActionButton, classes, dimensions, glyph, visible text, and click path are unchanged.

Please verify:
- header title and close-action alignment in light and dark themes
- close glyph size and color
- close action hover, active, and focus-visible states
- no shift in retrieval settings or footer actions

## Validation

- focused Vitest: 10/10 passed
- standalone accessibility lint: 0 findings
- focused format/lint/type check: 0 errors, 1 existing icon warning
- full pnpm check: 0 errors, 2059 existing warnings
- git diff --check: passed

## Rollback

Revert this PR alone to restore the previous unnamed action and test mock. Retrieval state and save behavior are unaffected.