### PR TITLE
refactor(web): use css icon for external retrieval close

### DIFF
--- a/web/app/components/datasets/hit-testing/modify-external-retrieval-modal.tsx
+++ b/web/app/components/datasets/hit-testing/modify-external-retrieval-modal.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@langgenius/dify-ui/button'
-import { RiCloseLine } from '@remixicon/react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import ActionButton from '@/app/components/base/action-button'
@@ -60,7 +59,7 @@ const ModifyExternalRetrievalModal: React.FC<ModifyExternalRetrievalModalProps> 
           className="ml-auto"
           onClick={onClose}
         >
-          <RiCloseLine aria-hidden className="size-4 shrink-0" />
+          <span aria-hidden className="i-ri-close-line size-4 shrink-0" />
         </ActionButton>
       </div>
       <div className="flex flex-col items-start justify-center gap-4 self-stretch p-4 pt-2">


### PR DESCRIPTION
## Summary

- replace the external retrieval close RemixIcon component with the equivalent CSS icon span
- keep the glyph decorative and preserve its 16px size and shrink behavior
- remove exactly one prefer-tailwind-icons warning

## Dependency

This PR is stacked on #40317 because it preserves the accessible close-action contract introduced there. It contains only the icon implementation change.

## Visual regression review

Please compare before and after in light and dark themes:
- close glyph shape and 16px dimensions
- header alignment and spacing
- ActionButton box geometry
- hover, active, and focus-visible states
- retrieval settings and footer layout

No text, event, accessible name, retrieval value, or component geometry is intentionally changed.

## Validation

- focused Vitest: 10/10 passed
- standalone accessibility lint: 0 findings
- focused format/lint/type check: 0 findings
- full pnpm check: 0 errors, 2058 existing warnings
- warning delta from parent: exactly -1
- git diff --check: passed

## Rollback

Revert this PR alone to restore the component icon. The semantic fix in #40317 remains intact.