### PR TITLE
refactor(web): remove external retrieval React.FC

### DIFF
--- a/web/app/components/datasets/hit-testing/modify-external-retrieval-modal.tsx
+++ b/web/app/components/datasets/hit-testing/modify-external-retrieval-modal.tsx
@@ -16,13 +16,13 @@ type ModifyExternalRetrievalModalProps = {
   initialScoreThresholdEnabled: boolean
 }
 
-const ModifyExternalRetrievalModal: React.FC<ModifyExternalRetrievalModalProps> = ({
+const ModifyExternalRetrievalModal = ({
   onClose,
   onSave,
   initialTopK,
   initialScoreThreshold,
   initialScoreThresholdEnabled,
-}) => {
+}: ModifyExternalRetrievalModalProps) => {
   const { t } = useTranslation()
   const [topK, setTopK] = useState(initialTopK)
   const [scoreThreshold, setScoreThreshold] = useState(initialScoreThreshold)


### PR DESCRIPTION
## Summary

- type ModifyExternalRetrievalModal props directly on the function parameter
- remove the React.FC annotation
- preserve the component API, JSX, retrieval state, and runtime behavior

## Dependency

This cleanup is stacked on #40318 only because it edits the same component after the icon conversion. It has no accessibility, form, or runtime dependency and remains a separate review layer.

## Visual regression review

This is a type-only refactor. The emitted JSX, classes, visible content, dimensions, interaction states, retrieval behavior, and accessibility tree are unchanged. A visual difference would be a regression.

## Validation

- focused Vitest: 10/10 passed
- standalone accessibility lint: 0 findings
- focused format/lint/type check: 0 findings
- full pnpm check: 0 errors, 2058 existing warnings
- git diff --check: passed

## Rollback

Revert this PR alone to restore React.FC without affecting either lower stack layer.