### PR TITLE
fix(web): name human input preview close

### DIFF
--- a/web/app/components/workflow/nodes/human-input/components/__tests__/form-content-preview.spec.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/__tests__/form-content-preview.spec.tsx
@@ -22,15 +22,6 @@ vi.mock('@/app/components/workflow/store/workflow/use-nodes', () => ({
   default: () => mockUseNodes(),
 }))
 
-vi.mock('@/app/components/base/action-button', () => ({
-  __esModule: true,
-  default: ({ children, onClick }: { children?: ReactNode; onClick?: () => void }) => (
-    <button type="button" aria-label="close-preview" onClick={onClick}>
-      {children}
-    </button>
-  ),
-}))
-
 vi.mock('@/app/components/base/badge', () => ({
   __esModule: true,
   default: ({ children }: { children?: ReactNode }) => <div data-testid="badge">{children}</div>,
@@ -140,7 +131,7 @@ describe('FormContentPreview', () => {
       <FormContentPreview content="content" formInputs={[]} userActions={[]} onClose={onClose} />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'close-preview' }))
+    fireEvent.click(screen.getByRole('button', { name: 'operation.close' }))
 
     expect(onClose).toHaveBeenCalledTimes(1)
   })

--- a/web/app/components/workflow/nodes/human-input/components/form-content-preview.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/form-content-preview.tsx
@@ -69,8 +69,11 @@ const FormContentPreview: FC<FormContentPreviewProps> = ({
         <Badge uppercase className="border-text-accent-secondary text-text-accent-secondary">
           {t(($) => $[`${i18nPrefix}.formContent.preview`], { ns: 'workflow' })}
         </Badge>
-        <ActionButton onClick={onClose}>
-          <span className="i-ri-close-line size-5 text-text-tertiary" />
+        <ActionButton
+          aria-label={t(($) => $['operation.close'], { ns: 'common' })}
+          onClick={onClose}
+        >
+          <span aria-hidden className="i-ri-close-line size-5 text-text-tertiary" />
         </ActionButton>
       </div>
       <div className="max-h-[calc(100vh-167px)] overflow-y-auto px-4">


### PR DESCRIPTION
## Summary

- give the human input form preview close action a localized accessible name
- hide the existing CSS close glyph from the accessibility tree
- remove the ActionButton test mock that fabricated a close-preview label
- exercise the real ActionButton through role and accessible name

## Ownership and scope

FormContentPreview owns the close action and its behavior test. This PR does not change Markdown rendering, workflow node lookup, form input previews, user action buttons, panel positioning, or the shared ActionButton primitive.

## Visual regression review

This is an ARIA-only production change. The rendered ActionButton, CSS icon, classes, dimensions, visible content, panel geometry, and click path are unchanged.

Please verify:
- preview badge and close-action alignment
- 20px close glyph size and tertiary color in light and dark themes
- close action hover, active, and focus-visible states
- no shift in Markdown content, action buttons, or panel position

## Validation

- focused Vitest: 3/3 passed
- standalone accessibility lint: 0 findings
- focused format/lint/type check: 0 findings
- full pnpm check: 0 errors, 2059 existing warnings
- git diff --check: passed

## Rollback

Revert this PR alone to restore the previous unnamed action and fabricated test label. Preview content and workflow behavior are unaffected.