### PR TITLE
refactor(web): remove human input preview React.FC

### DIFF
--- a/web/app/components/workflow/nodes/human-input/components/form-content-preview.tsx
+++ b/web/app/components/workflow/nodes/human-input/components/form-content-preview.tsx
@@ -1,5 +1,4 @@
 'use client'
-import type { FC } from 'react'
 import type { FormInputItem, UserAction } from '../types'
 import { Button } from '@langgenius/dify-ui/button'
 import * as React from 'react'
@@ -22,12 +21,12 @@ type FormContentPreviewProps = {
   onClose: () => void
 }
 
-const FormContentPreview: FC<FormContentPreviewProps> = ({
+const FormContentPreview = ({
   content,
   formInputs,
   userActions,
   onClose,
-}) => {
+}: FormContentPreviewProps) => {
   const { t } = useTranslation()
   const panelWidth = useStore((state) => state.panelWidth)
   const nodes = useNodes()


### PR DESCRIPTION
## Summary

- type FormContentPreview props directly on the function parameter
- remove the FC type import and annotation
- preserve the component API, JSX, preview behavior, and runtime output

## Dependency

This cleanup is stacked on #40321 only because it edits the same component after the semantic fix. It has no accessibility or runtime dependency and remains a separate review layer.

## Visual regression review

This is a type-only refactor. The emitted JSX, classes, visible content, panel geometry, interaction states, preview behavior, and accessibility tree are unchanged. A visual difference would be a regression.

## Validation

- focused Vitest: 3/3 passed
- standalone accessibility lint: 0 findings
- focused format/lint/type check: 0 findings
- full pnpm check: 0 errors, 2059 existing warnings
- git diff --check: passed

## Rollback

Revert this PR alone to restore React.FC without affecting the semantic fix in #40321.