### PR TITLE
fix(web): name code generator action

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/__tests__/code-generator-button.spec.tsx
+++ b/web/app/components/workflow/nodes/_base/components/__tests__/code-generator-button.spec.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CodeLanguage } from '@/app/components/workflow/nodes/code/types'
+import CodeGenerateBtn from '../code-generator-button'
+
+vi.mock('@/app/components/app/configuration/config/code-generator/get-code-generator-res', () => ({
+  GetCodeGeneratorResModal: () => <div role="dialog" aria-label="code generator" />,
+}))
+
+vi.mock('@/app/components/workflow/hooks-store', () => ({
+  useHooksStore: (selector: (state: { configsMap: { flowId: string } }) => unknown) =>
+    selector({ configsMap: { flowId: 'flow-1' } }),
+}))
+
+describe('CodeGenerateBtn', () => {
+  it('should open the code generator from the named action', async () => {
+    const user = userEvent.setup()
+    render(<CodeGenerateBtn nodeId="node-1" codeLanguages={CodeLanguage.python3} />)
+
+    await user.click(screen.getByRole('button', { name: 'appDebug.operation.automatic' }))
+
+    expect(screen.getByRole('dialog', { name: 'code generator' })).toBeInTheDocument()
+  })
+})

--- a/web/app/components/workflow/nodes/_base/components/code-generator-button.tsx
+++ b/web/app/components/workflow/nodes/_base/components/code-generator-button.tsx
@@ -5,6 +5,7 @@ import type { GenRes } from '@/service/debug'
 import { cn } from '@langgenius/dify-ui/cn'
 import * as React from 'react'
 import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { GetCodeGeneratorResModal } from '@/app/components/app/configuration/config/code-generator/get-code-generator-res'
 import { ActionButton } from '@/app/components/base/action-button'
 import { Generator } from '@/app/components/base/icons/src/vender/other'
@@ -26,6 +27,7 @@ const CodeGenerateBtn: FC<Props> = ({
   codeLanguages,
   onGenerated,
 }) => {
+  const { t } = useTranslation()
   const [showAutomatic, setShowAutomatic] = useState(false)
   const handleAutomaticRes = useCallback(
     (res: GenRes) => {
@@ -38,8 +40,12 @@ const CodeGenerateBtn: FC<Props> = ({
 
   return (
     <div className={cn(className)}>
-      <ActionButton className="hover:bg-[#155EFF]/8" onClick={() => setShowAutomatic(true)}>
-        <Generator className="size-4 text-primary-600" />
+      <ActionButton
+        aria-label={t(($) => $['operation.automatic'], { ns: 'appDebug' })}
+        className="hover:bg-[#155EFF]/8"
+        onClick={() => setShowAutomatic(true)}
+      >
+        <Generator aria-hidden className="size-4 text-primary-600" />
       </ActionButton>
       {showAutomatic && (
         <GetCodeGeneratorResModal


### PR DESCRIPTION
## Summary

- give the workflow code generator action a localized accessible name
- hide the generator glyph from the accessibility tree
- add a behavior test that finds the real ActionButton by name and opens the generator dialog

## Ownership and scope

CodeGenerateBtn owns the action and the transition that opens GetCodeGeneratorResModal. The test keeps the ActionButton and state transition real while mocking the modal and workflow store as external boundaries. Code generation requests, modal contents, editor values, and shared primitives are unchanged.

## Visual regression review

This is an ARIA-only production change. The rendered ActionButton, classes, dimensions, glyph, color, and click path are unchanged.

Please verify:
- 16px generator glyph shape, primary color, and alignment
- ActionButton box geometry
- hover, active, and focus-visible states
- no shift in the surrounding code editor controls

## Validation

- regression proof: the new semantic test failed against the unnamed baseline
- focused Vitest: 1/1 passed after the fix
- standalone accessibility lint: 0 findings
- focused format/lint/type check: 0 errors, 1 existing icon warning
- full pnpm check: 0 errors, 2059 existing warnings
- git diff --check: passed

## Rollback

Revert this PR alone to remove the accessible name and its behavior test. Code generation behavior and modal implementation are unaffected.