### PR TITLE
refactor(web): remove code generator React.FC

### DIFF
--- a/web/app/components/workflow/nodes/_base/components/code-generator-button.tsx
+++ b/web/app/components/workflow/nodes/_base/components/code-generator-button.tsx
@@ -1,5 +1,4 @@
 'use client'
-import type { FC } from 'react'
 import type { CodeLanguage } from '../../code/types'
 import type { GenRes } from '@/service/debug'
 import { cn } from '@langgenius/dify-ui/cn'
@@ -19,13 +18,7 @@ type Props = Readonly<{
   codeLanguages: CodeLanguage
 }>
 
-const CodeGenerateBtn: FC<Props> = ({
-  nodeId,
-  currentCode,
-  className,
-  codeLanguages,
-  onGenerated,
-}) => {
+const CodeGenerateBtn = ({ nodeId, currentCode, className, codeLanguages, onGenerated }: Props) => {
   const { t } = useTranslation()
   const [showAutomatic, setShowAutomatic] = useState(false)
   const handleAutomaticRes = useCallback(


### PR DESCRIPTION
## Summary

- type CodeGenerateBtn props directly on the function parameter
- remove the FC type import and annotation
- preserve the component API, JSX, state transition, and runtime behavior

## Dependency

This cleanup is stacked on #40325 only because it edits the same component after the icon conversion. It has no accessibility or runtime dependency and remains a separate review layer.

## Visual regression review

This is a type-only refactor. The emitted JSX, classes, visible content, interaction states, modal behavior, and accessibility tree are unchanged. A visual difference would be a regression.

## Validation

- focused Vitest: 1/1 passed
- standalone accessibility lint: 0 findings
- focused format/lint/type check: 0 findings
- full pnpm check: 0 errors, 2058 existing warnings
- git diff --check: passed

## Rollback

Revert this PR alone to restore React.FC without affecting either lower stack layer.