### PR TITLE
fix(web): name prompt generator action

### DIFF
--- a/web/app/components/workflow/nodes/llm/components/__tests__/prompt-generator-btn.spec.tsx
+++ b/web/app/components/workflow/nodes/llm/components/__tests__/prompt-generator-btn.spec.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import PromptGeneratorBtn from '../prompt-generator-btn'
+
+vi.mock('@/app/components/app/configuration/config/automatic/get-automatic-res', () => ({
+  default: () => <div role="dialog" aria-label="prompt generator" />,
+}))
+
+vi.mock('@/app/components/workflow/hooks-store', () => ({
+  useHooksStore: (selector: (state: { configsMap: { flowId: string } }) => unknown) =>
+    selector({ configsMap: { flowId: 'flow-1' } }),
+}))
+
+describe('PromptGeneratorBtn', () => {
+  it('should open the prompt generator from the named action', async () => {
+    const user = userEvent.setup()
+    render(<PromptGeneratorBtn nodeId="node-1" />)
+
+    await user.click(screen.getByRole('button', { name: 'appDebug.operation.automatic' }))
+
+    expect(screen.getByRole('dialog', { name: 'prompt generator' })).toBeInTheDocument()
+  })
+})

--- a/web/app/components/workflow/nodes/llm/components/prompt-generator-btn.tsx
+++ b/web/app/components/workflow/nodes/llm/components/prompt-generator-btn.tsx
@@ -5,6 +5,7 @@ import type { GenRes } from '@/service/debug'
 import { cn } from '@langgenius/dify-ui/cn'
 import * as React from 'react'
 import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import GetAutomaticResModal from '@/app/components/app/configuration/config/automatic/get-automatic-res'
 import { ActionButton } from '@/app/components/base/action-button'
 import { Generator } from '@/app/components/base/icons/src/vender/other'
@@ -27,6 +28,7 @@ const PromptGeneratorBtn: FC<Props> = ({
   editorId,
   currentPrompt,
 }) => {
+  const { t } = useTranslation()
   const [showAutomatic, setShowAutomatic] = useState(false)
   const handleAutomaticRes = useCallback(
     (res: GenRes) => {
@@ -38,8 +40,12 @@ const PromptGeneratorBtn: FC<Props> = ({
   const configsMap = useHooksStore((s) => s.configsMap)
   return (
     <div className={cn(className)}>
-      <ActionButton className="hover:bg-[#155EFF]/8" onClick={() => setShowAutomatic(true)}>
-        <Generator className="size-4 text-primary-600" />
+      <ActionButton
+        aria-label={t(($) => $['operation.automatic'], { ns: 'appDebug' })}
+        className="hover:bg-[#155EFF]/8"
+        onClick={() => setShowAutomatic(true)}
+      >
+        <Generator aria-hidden className="size-4 text-primary-600" />
       </ActionButton>
       {showAutomatic && (
         <GetAutomaticResModal


### PR DESCRIPTION
## Summary

- give the workflow prompt generator action a localized accessible name
- hide the generator glyph from the accessibility tree
- add a behavior test that finds the real ActionButton by name and opens the generator dialog

## Ownership and scope

PromptGeneratorBtn owns the action and the transition that opens GetAutomaticResModal. The test keeps the ActionButton and state transition real while mocking the modal and workflow store as external boundaries. Prompt generation requests, modal contents, editor values, and shared primitives are unchanged.

## Visual regression review

This is an ARIA-only production change. The rendered ActionButton, classes, dimensions, glyph, color, and click path are unchanged.

Please verify:
- 16px generator glyph shape, primary color, and alignment
- ActionButton box geometry
- hover, active, and focus-visible states
- no shift in the surrounding prompt editor controls

## Validation

- regression proof: the new semantic test failed against the unnamed baseline
- focused Vitest: 1/1 passed after the fix
- standalone accessibility lint: 0 findings
- focused format/lint/type check: 0 errors, 1 existing icon warning
- full pnpm check: 0 errors, 2059 existing warnings
- git diff --check: passed

## Rollback

Revert this PR alone to remove the accessible name and its behavior test. Prompt generation behavior and modal implementation are unaffected.