### PR TITLE
refactor(web): use css icon for prompt generator

### DIFF
--- a/web/app/components/workflow/nodes/llm/components/prompt-generator-btn.tsx
+++ b/web/app/components/workflow/nodes/llm/components/prompt-generator-btn.tsx
@@ -8,7 +8,6 @@ import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import GetAutomaticResModal from '@/app/components/app/configuration/config/automatic/get-automatic-res'
 import { ActionButton } from '@/app/components/base/action-button'
-import { Generator } from '@/app/components/base/icons/src/vender/other'
 import { AppModeEnum } from '@/types/app'
 import { useHooksStore } from '../../../hooks-store'
 
@@ -45,7 +44,7 @@ const PromptGeneratorBtn: FC<Props> = ({
         className="hover:bg-[#155EFF]/8"
         onClick={() => setShowAutomatic(true)}
       >
-        <Generator aria-hidden className="size-4 text-primary-600" />
+        <span aria-hidden className="i-custom-vender-other-generator size-4 text-primary-600" />
       </ActionButton>
       {showAutomatic && (
         <GetAutomaticResModal


### PR DESCRIPTION
## Summary

- replace the prompt generator SVG component with the equivalent CSS icon span
- keep the glyph decorative and preserve its 16px size and primary color
- remove exactly one prefer-tailwind-icons warning

## Dependency

This PR is stacked on #40328 because it preserves the named generator action and its behavior test. It contains only the icon implementation change.

## Visual regression review

Please compare before and after:
- generator glyph shape and 16px dimensions
- primary color in light and dark themes
- inline alignment and ActionButton box geometry
- hover, active, and focus-visible states
- surrounding prompt editor layout

No text, event, accessible name, modal state, or component geometry is intentionally changed.

## Validation

- focused Vitest: 1/1 passed
- standalone accessibility lint: 0 findings
- focused format/lint/type check: 0 findings
- full pnpm check: 0 errors, 2058 existing warnings
- warning delta from parent: exactly -1
- git diff --check: passed

## Rollback

Revert this PR alone to restore the SVG component. The semantic fix and behavior test in #40328 remain intact.