### PR TITLE
fix(web): expose SVG preview toggle state

### DIFF
--- a/web/app/components/base/svg/__tests__/index.spec.tsx
+++ b/web/app/components/base/svg/__tests__/index.spec.tsx
@@ -3,14 +3,18 @@ import userEvent from '@testing-library/user-event'
 import SVGBtn from '..'
 
 describe('SVGBtn', () => {
-  it('toggles SVG mode when clicked', async () => {
+  it('exposes and toggles the SVG preview state', async () => {
     const user = userEvent.setup()
     const setIsSVG = vi.fn()
-    render(<SVGBtn isSVG={false} setIsSVG={setIsSVG} />)
+    const { rerender } = render(<SVGBtn isSVG={false} setIsSVG={setIsSVG} />)
 
-    await user.click(screen.getByRole('button'))
+    await user.click(screen.getByRole('button', { name: 'SVG', pressed: false }))
 
     expect(setIsSVG).toHaveBeenCalledOnce()
     expect(setIsSVG.mock.calls[0]![0](false)).toBe(true)
+
+    rerender(<SVGBtn isSVG setIsSVG={setIsSVG} />)
+
+    expect(screen.getByRole('button', { name: 'SVG', pressed: true })).toBeInTheDocument()
   })
 })

--- a/web/app/components/base/svg/index.tsx
+++ b/web/app/components/base/svg/index.tsx
@@ -11,11 +11,13 @@ type ISVGBtnProps = {
 const SVGBtn = ({ isSVG, setIsSVG }: ISVGBtnProps) => {
   return (
     <ActionButton
+      aria-label="SVG"
+      aria-pressed={isSVG}
       onClick={() => {
         setIsSVG((prevIsSVG) => !prevIsSVG)
       }}
     >
-      <div className={cn('size-4', isSVG ? s.svgIconed : s.svgIcon)}></div>
+      <span aria-hidden="true" className={cn('block size-4', isSVG ? s.svgIconed : s.svgIcon)} />
     </ActionButton>
   )
 }


### PR DESCRIPTION
## Summary

- give the SVG preview toggle the stable accessible name `SVG`
- expose the current preview mode through `aria-pressed`
- use valid phrasing content inside the button while preserving the icon box
- strengthen the existing test to query the real role, name, and pressed state

## Ownership and scope

This PR changes only the shared SVG preview toggle. It does not change Markdown rendering, SVG sanitization, the copy action, CSS modules, or consumer state ownership. There is no dependency on another accessibility PR.

## Validation

- `pnpm --dir web exec vp test run app/components/base/svg/__tests__/index.spec.tsx` — 1/1 passed
- `pnpm --dir web lint:a11y 'app/components/base/svg/index.tsx'` — passed
- `pnpm check` — 0 errors / 2059 existing warnings
- `git diff --check` — passed
- the strengthened role/name/pressed assertion failed against the old unnamed button before the production change

## Visual regression review

Expected visual delta: none.

Please verify:

- the ActionButton remains the same size and alignment in SVG code-block headers
- both inactive and active SVG glyphs keep the same 16×16 background image, position, and color
- hover, active, dark-mode, and surrounding copy-button spacing are unchanged
- switching between source and rendered preview does not move the header controls

The former `div` was block-level. Its replacement is explicitly `block size-4`, so the box model is preserved; the ARIA attributes do not affect layout or paint.

## Rollback

Revert this PR alone. It has no downstream code dependency.