### PR TITLE
fix(web): expose chat variable tips state

### DIFF
--- a/web/app/components/workflow/panel/chat-variable-panel/__tests__/index.spec.tsx
+++ b/web/app/components/workflow/panel/chat-variable-panel/__tests__/index.spec.tsx
@@ -201,10 +201,18 @@ describe('ChatVariablePanel', () => {
 
     expect(screen.getByText('workflow.chatVariable.panelDescription')).toBeInTheDocument()
 
-    const toggleTipButton = screen.getByRole('button', { name: 'TIPS', expanded: true })
+    const toggleTipButton = screen.getByRole('button', {
+      name: 'workflow.chatVariable.tips',
+      expanded: true,
+    })
     await user.click(toggleTipButton)
     expect(screen.queryByText('workflow.chatVariable.panelDescription')).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'TIPS', expanded: false })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', {
+        name: 'workflow.chatVariable.tips',
+        expanded: false,
+      }),
+    ).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'common.operation.close' }))
 

--- a/web/app/components/workflow/panel/chat-variable-panel/__tests__/index.spec.tsx
+++ b/web/app/components/workflow/panel/chat-variable-panel/__tests__/index.spec.tsx
@@ -201,9 +201,10 @@ describe('ChatVariablePanel', () => {
 
     expect(screen.getByText('workflow.chatVariable.panelDescription')).toBeInTheDocument()
 
-    const toggleTipButton = screen.getAllByRole('button')[0]!
+    const toggleTipButton = screen.getByRole('button', { name: 'TIPS', expanded: true })
     await user.click(toggleTipButton)
     expect(screen.queryByText('workflow.chatVariable.panelDescription')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'TIPS', expanded: false })).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'common.operation.close' }))
 

--- a/web/app/components/workflow/panel/chat-variable-panel/index.tsx
+++ b/web/app/components/workflow/panel/chat-variable-panel/index.tsx
@@ -212,7 +212,7 @@ const ChatVariablePanel = () => {
         {t(($) => $['chatVariable.panelTitle'], { ns: 'workflow' })}
         <div className="flex items-center gap-1">
           <ActionButton
-            aria-label="TIPS"
+            aria-label={t(($) => $['chatVariable.tips'], { ns: 'workflow' })}
             aria-expanded={showTip}
             state={showTip ? ActionButtonState.Active : undefined}
             onClick={() => setShowTip(!showTip)}

--- a/web/app/components/workflow/panel/chat-variable-panel/index.tsx
+++ b/web/app/components/workflow/panel/chat-variable-panel/index.tsx
@@ -212,10 +212,12 @@ const ChatVariablePanel = () => {
         {t(($) => $['chatVariable.panelTitle'], { ns: 'workflow' })}
         <div className="flex items-center gap-1">
           <ActionButton
+            aria-label="TIPS"
+            aria-expanded={showTip}
             state={showTip ? ActionButtonState.Active : undefined}
             onClick={() => setShowTip(!showTip)}
           >
-            <RiBookOpenLine className="size-4" />
+            <RiBookOpenLine aria-hidden="true" className="size-4" />
           </ActionButton>
           <button
             type="button"

--- a/web/i18n/ar-TN/workflow.json
+++ b/web/i18n/ar-TN/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "تستخدم متغيرات المحادثة لتخزين المعلومات التفاعلية التي يحتاج LLM إلى تذكرها، بما في ذلك سجل المحادثة والملفات التي تم تحميلها وتفضيلات المستخدم. هم للقراءة والكتابة. ",
   "chatVariable.panelTitle": "متغيرات المحادثة",
   "chatVariable.storedContent": "المحتوى المخزن",
+  "chatVariable.tips": "نصائح",
   "chatVariable.updatedAt": "تم التحديث في ",
   "collaboration.historyAction.generic": "قام متعاون بعملية تراجع/إعادة",
   "comments.actions.addComment": "أضف تعليقًا",

--- a/web/i18n/de-DE/workflow.json
+++ b/web/i18n/de-DE/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "Gesprächsvariablen werden verwendet, um interaktive Informationen zu speichern, die das LLM benötigt, einschließlich Gesprächsverlauf, hochgeladene Dateien und Benutzereinstellungen. Sie sind les- und schreibbar.",
   "chatVariable.panelTitle": "Gesprächsvariablen",
   "chatVariable.storedContent": "Gespeicherter Inhalt",
+  "chatVariable.tips": "Tipps",
   "chatVariable.updatedAt": "Aktualisiert am ",
   "collaboration.historyAction.generic": "Ein Mitbearbeiter hat Rückgängig/Wiederholen ausgeführt",
   "comments.actions.addComment": "Kommentar hinzufügen",

--- a/web/i18n/en-US/workflow.json
+++ b/web/i18n/en-US/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "Conversation Variables are used to store interactive information that LLM needs to remember, including conversation history, uploaded files, user preferences. They are read-write. ",
   "chatVariable.panelTitle": "Conversation Variables",
   "chatVariable.storedContent": "Stored content",
+  "chatVariable.tips": "Tips",
   "chatVariable.updatedAt": "Updated at ",
   "collaboration.historyAction.generic": "A collaborator performed an undo/redo action",
   "comments.actions.addComment": "Add Comment",

--- a/web/i18n/es-ES/workflow.json
+++ b/web/i18n/es-ES/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "Las Variables de Conversación se utilizan para almacenar información interactiva que el LLM necesita recordar, incluyendo el historial de conversación, archivos subidos y preferencias del usuario. Son de lectura y escritura.",
   "chatVariable.panelTitle": "Variables de Conversación",
   "chatVariable.storedContent": "Contenido almacenado",
+  "chatVariable.tips": "Consejos",
   "chatVariable.updatedAt": "Actualizado el ",
   "collaboration.historyAction.generic": "Un colaborador realizó deshacer/rehacer",
   "comments.actions.addComment": "Añadir un comentario",

--- a/web/i18n/fa-IR/workflow.json
+++ b/web/i18n/fa-IR/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "متغیرهای مکالمه برای ذخیره اطلاعات تعاملی که LLM باید به خاطر بسپارد (مانند تاریخچه مکالمه، فایل‌های آپلودشده و ترجیحات کاربر) استفاده می‌شوند. این متغیرها قابل خواندن و نوشتن هستند.",
   "chatVariable.panelTitle": "متغیرهای مکالمه",
   "chatVariable.storedContent": "محتوای ذخیره‌شده",
+  "chatVariable.tips": "نکات",
   "chatVariable.updatedAt": "به‌روزرسانی شده در ",
   "collaboration.historyAction.generic": "یک همکار عملیات برگرداندن/انجام مجدد را انجام داد",
   "comments.actions.addComment": "افزودن دیدگاه",

--- a/web/i18n/fr-FR/workflow.json
+++ b/web/i18n/fr-FR/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "Les Variables de Conversation sont utilisées pour stocker des informations interactives dont le LLM a besoin de se souvenir, y compris l'historique des conversations, les fichiers téléchargés et les préférences de l'utilisateur. Elles sont en lecture-écriture.",
   "chatVariable.panelTitle": "Variables de Conversation",
   "chatVariable.storedContent": "Contenu stocké",
+  "chatVariable.tips": "Conseils",
   "chatVariable.updatedAt": "Mis à jour le ",
   "collaboration.historyAction.generic": "Un collaborateur a effectué une annulation/une réexécution",
   "comments.actions.addComment": "Ajouter un commentaire",

--- a/web/i18n/hi-IN/workflow.json
+++ b/web/i18n/hi-IN/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "वार्तालाप चर का उपयोग इंटरैक्टिव जानकारी संग्रहित करने के लिए किया जाता है जिसे LLM को याद रखने की आवश्यकता होती है, जिसमें वार्तालाप इतिहास, अपलोड की गई फाइलें, उपयोगकर्ता प्राथमिकताएं शामिल हैं। वे पठनीय और लेखनीय हैं।",
   "chatVariable.panelTitle": "वार्तालाप चर",
   "chatVariable.storedContent": "संग्रहीत सामग्री",
+  "chatVariable.tips": "सुझाव",
   "chatVariable.updatedAt": "अपडेट किया गया ",
   "collaboration.historyAction.generic": "एक सहयोगी ने Undo/Redo किया",
   "comments.actions.addComment": "टिप्पणी जोड़ें",

--- a/web/i18n/id-ID/workflow.json
+++ b/web/i18n/id-ID/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "Variabel Percakapan digunakan untuk menyimpan informasi interaktif yang perlu diingat LLM, termasuk riwayat percakapan, file yang diunggah, preferensi pengguna. Mereka dibaca-tulis.",
   "chatVariable.panelTitle": "Variabel Percakapan",
   "chatVariable.storedContent": "Konten yang disimpan",
+  "chatVariable.tips": "Tips",
   "chatVariable.updatedAt": "Diperbarui pada",
   "collaboration.historyAction.generic": "Seorang kolaborator melakukan urungkan/ulang",
   "comments.actions.addComment": "Tambahkan komentar",

--- a/web/i18n/it-IT/workflow.json
+++ b/web/i18n/it-IT/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "Le Variabili di Conversazione sono utilizzate per memorizzare informazioni interattive che il LLM deve ricordare, inclusi la cronologia delle conversazioni, i file caricati e le preferenze dell'utente. Sono in lettura e scrittura.",
   "chatVariable.panelTitle": "Variabili di Conversazione",
   "chatVariable.storedContent": "Contenuto memorizzato",
+  "chatVariable.tips": "Suggerimenti",
   "chatVariable.updatedAt": "Aggiornato il ",
   "collaboration.historyAction.generic": "Un collaboratore ha eseguito annulla/ripristina",
   "comments.actions.addComment": "Aggiungi un commento",

--- a/web/i18n/ja-JP/workflow.json
+++ b/web/i18n/ja-JP/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "対話情報を保存・管理（会話履歴/ファイル/ユーザー設定など）。書き換えができます。",
   "chatVariable.panelTitle": "会話変数",
   "chatVariable.storedContent": "保存内容",
+  "chatVariable.tips": "ヒント",
   "chatVariable.updatedAt": "最終更新：",
   "collaboration.historyAction.generic": "共同編集者が元に戻す/やり直しを実行しました",
   "comments.actions.addComment": "コメントを追加",

--- a/web/i18n/ko-KR/workflow.json
+++ b/web/i18n/ko-KR/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "대화 변수는 LLM 이 기억해야 할 대화 기록, 업로드된 파일, 사용자 선호도 등의 상호작용 정보를 저장하는 데 사용됩니다. 이들은 읽기 및 쓰기가 가능합니다.",
   "chatVariable.panelTitle": "대화 변수",
   "chatVariable.storedContent": "저장된 내용",
+  "chatVariable.tips": "팁",
   "chatVariable.updatedAt": "업데이트 시간: ",
   "collaboration.historyAction.generic": "공동 작업자가 실행 취소/다시 실행을 수행했습니다",
   "comments.actions.addComment": "댓글 추가",

--- a/web/i18n/lo-LA/workflow.json
+++ b/web/i18n/lo-LA/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "ຕົວປ່ຽນການສົນທະນາໃຊ້ເພື່ອເກັບຂໍ້ມູນທີ່ LLM ຕ້ອງຈົດຈຳ ເຊັ່ນ ປະຫວັດການສົນທະນາ, ໄຟລ໌ທີ່ອັບໂຫຼດ, ຄວາມມັກຂອງຜູ້ໃຊ້. ຕົວປ່ຽນເຫຼົ່ານີ້ສາມາດອ່ານ ແລະ ຂຽນໄດ້.",
   "chatVariable.panelTitle": "ຕົວປ່ຽນການສົນທະນາ",
   "chatVariable.storedContent": "ເນື້ອໃນທີ່ເກັບໄວ້",
+  "chatVariable.tips": "ຄຳແນະນຳ",
   "chatVariable.updatedAt": "ອັບເດດເມື່ອ ",
   "collaboration.historyAction.generic": "ຜູ້ຮ່ວມງານໄດ້ເຮັດການ Undo/Redo",
   "comments.actions.addComment": "ເພີ່ມຄຳເຫັນ",

--- a/web/i18n/nl-NL/workflow.json
+++ b/web/i18n/nl-NL/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "Conversation Variables are used to store interactive information that LLM needs to remember, including conversation history, uploaded files, user preferences. They are read-write. ",
   "chatVariable.panelTitle": "Conversation Variables",
   "chatVariable.storedContent": "Stored content",
+  "chatVariable.tips": "Tips",
   "chatVariable.updatedAt": "Updated at ",
   "collaboration.historyAction.generic": "Een medewerker heeft een ongedaan maken/opnieuw uitvoeren-actie uitgevoerd",
   "comments.actions.addComment": "Voeg een reactie toe",

--- a/web/i18n/pl-PL/workflow.json
+++ b/web/i18n/pl-PL/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "Zmienne Konwersacji służą do przechowywania interaktywnych informacji, które LLM musi pamiętać, w tym historii konwersacji, przesłanych plików, preferencji użytkownika. Są one do odczytu i zapisu.",
   "chatVariable.panelTitle": "Zmienne Konwersacji",
   "chatVariable.storedContent": "Przechowywana zawartość",
+  "chatVariable.tips": "Wskazówki",
   "chatVariable.updatedAt": "Zaktualizowano ",
   "collaboration.historyAction.generic": "Współpracownik wykonał cofnięcie/ponowienie",
   "comments.actions.addComment": "Dodaj komentarz",

--- a/web/i18n/pt-BR/workflow.json
+++ b/web/i18n/pt-BR/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "As Variáveis de Conversação são usadas para armazenar informações interativas que o LLM precisa lembrar, incluindo histórico de conversas, arquivos carregados, preferências do usuário. Elas são de leitura e escrita.",
   "chatVariable.panelTitle": "Variáveis de Conversação",
   "chatVariable.storedContent": "Conteúdo armazenado",
+  "chatVariable.tips": "Dicas",
   "chatVariable.updatedAt": "Atualizado em ",
   "collaboration.historyAction.generic": "Um colaborador realizou desfazer/refazer",
   "comments.actions.addComment": "Adicionar comentário",

--- a/web/i18n/ro-RO/workflow.json
+++ b/web/i18n/ro-RO/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "Variabilele de Conversație sunt utilizate pentru a stoca informații interactive pe care LLM trebuie să le rețină, inclusiv istoricul conversației, fișiere încărcate, preferințele utilizatorului. Acestea sunt citibile și inscriptibile.",
   "chatVariable.panelTitle": "Variabile de Conversație",
   "chatVariable.storedContent": "Conținut stocat",
+  "chatVariable.tips": "Sfaturi",
   "chatVariable.updatedAt": "Actualizat la ",
   "collaboration.historyAction.generic": "Un colaborator a efectuat anulare/refacere",
   "comments.actions.addComment": "Adaugă un comentariu",

--- a/web/i18n/ru-RU/workflow.json
+++ b/web/i18n/ru-RU/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "Переменные разговора используются для хранения интерактивной информации, которую LLM необходимо запомнить, включая историю разговоров, загруженные файлы, пользовательские настройки. Они доступны для чтения и записи. ",
   "chatVariable.panelTitle": "Переменные разговора",
   "chatVariable.storedContent": "Сохраненный контент",
+  "chatVariable.tips": "Советы",
   "chatVariable.updatedAt": "Обновлено в ",
   "collaboration.historyAction.generic": "Участник выполнил отмену/повтор",
   "comments.actions.addComment": "Добавить комментарий",

--- a/web/i18n/sl-SI/workflow.json
+++ b/web/i18n/sl-SI/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "Spremenljivke pogovora se uporabljajo za shranjevanje interaktivnih informacij, ki se jih LLM mora zapomniti, vključno z zgodovino pogovorov, naloženimi datotekami in uporabnikovimi nastavitvami. So branje-in-pisanje.",
   "chatVariable.panelTitle": "Pogovor Spremenljivke",
   "chatVariable.storedContent": "Shranjena vsebina",
+  "chatVariable.tips": "Nasveti",
   "chatVariable.updatedAt": "Posodobljeno ob",
   "collaboration.historyAction.generic": "Sodelavec je izvedel razveljavitev/ponovitev",
   "comments.actions.addComment": "Dodaj komentar",

--- a/web/i18n/th-TH/workflow.json
+++ b/web/i18n/th-TH/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "ตัวแปรการสนทนาใช้เพื่อจัดเก็บข้อมูลแบบโต้ตอบที่ LLM จําเป็นต้องจดจํา รวมถึงประวัติการสนทนา ไฟล์ที่อัปโหลด การตั้งค่าของผู้ใช้ พวกเขาอ่าน-เขียน",
   "chatVariable.panelTitle": "ตัวแปรการสนทนา",
   "chatVariable.storedContent": "เนื้อหาที่เก็บไว้",
+  "chatVariable.tips": "เคล็ดลับ",
   "chatVariable.updatedAt": "อัพเดทเมื่อ",
   "collaboration.historyAction.generic": "ผู้ร่วมงานได้ทำการยกเลิก/ทำซ้ำ",
   "comments.actions.addComment": "เพิ่มความคิดเห็น",

--- a/web/i18n/tr-TR/workflow.json
+++ b/web/i18n/tr-TR/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "Konuşma Değişkenleri, LLM'nin hatırlaması gereken interaktif bilgileri (konuşma geçmişi, yüklenen dosyalar, kullanıcı tercihleri dahil) depolamak için kullanılır. Bunlar okunabilir ve yazılabilirdir.",
   "chatVariable.panelTitle": "Konuşma Değişkenleri",
   "chatVariable.storedContent": "Depolanan içerik",
+  "chatVariable.tips": "İpuçları",
   "chatVariable.updatedAt": "Güncellenme zamanı: ",
   "collaboration.historyAction.generic": "Bir işbirlikçi geri alma/yeniden yapma gerçekleştirdi",
   "comments.actions.addComment": "Yorum ekle",

--- a/web/i18n/uk-UA/workflow.json
+++ b/web/i18n/uk-UA/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "Змінні розмови використовуються для зберігання інтерактивної інформації, яку LLM повинен пам'ятати, включаючи історію розмови, завантажені файли, вподобання користувача. Вони доступні для читання та запису.",
   "chatVariable.panelTitle": "Змінні розмови",
   "chatVariable.storedContent": "Збережений вміст",
+  "chatVariable.tips": "Поради",
   "chatVariable.updatedAt": "Оновлено ",
   "collaboration.historyAction.generic": "Співавтор виконав скасування/повторення",
   "comments.actions.addComment": "Додати коментар",

--- a/web/i18n/vi-VN/workflow.json
+++ b/web/i18n/vi-VN/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "Biến Hội Thoại được sử dụng để lưu trữ thông tin tương tác mà LLM cần ghi nhớ, bao gồm lịch sử hội thoại, tệp đã tải lên, tùy chọn người dùng. Chúng có thể đọc và ghi được.",
   "chatVariable.panelTitle": "Biến Hội Thoại",
   "chatVariable.storedContent": "Nội dung đã lưu",
+  "chatVariable.tips": "Mẹo",
   "chatVariable.updatedAt": "Cập nhật lúc ",
   "collaboration.historyAction.generic": "Một cộng tác viên đã thực hiện hoàn tác/làm lại",
   "comments.actions.addComment": "Thêm bình luận",

--- a/web/i18n/zh-Hans/workflow.json
+++ b/web/i18n/zh-Hans/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "会话变量用于存储 LLM 需要的上下文信息，如用户偏好、对话历史等。它是可读写的。",
   "chatVariable.panelTitle": "会话变量",
   "chatVariable.storedContent": "存储内容",
+  "chatVariable.tips": "提示",
   "chatVariable.updatedAt": "更新时间 ",
   "collaboration.historyAction.generic": "协作者执行了撤销/重做操作",
   "comments.actions.addComment": "添加评论",

--- a/web/i18n/zh-Hant/workflow.json
+++ b/web/i18n/zh-Hant/workflow.json
@@ -114,6 +114,7 @@
   "chatVariable.panelDescription": "對話變數用於儲存 LLM 需要記住的互動資訊，包括對話歷史、上傳的檔案、使用者偏好等。這些變數可讀寫。",
   "chatVariable.panelTitle": "對話變數",
   "chatVariable.storedContent": "已儲存內容",
+  "chatVariable.tips": "提示",
   "chatVariable.updatedAt": "更新於 ",
   "collaboration.historyAction.generic": "協作者執行了復原/重做操作",
   "comments.actions.addComment": "新增評論",


### PR DESCRIPTION
## Summary

- give the existing tips disclosure the stable accessible name `TIPS`
- expose its open state with `aria-expanded`
- hide the decorative book glyph from the accessibility tree
- assert the real name and expanded state before and after activation

## Dependency

Stacked on #40333 because both layers update the same owner test and header. This layer does not depend on the close action at runtime and remains a single semantic contract.

## Validation

- `pnpm --dir web exec vp test run app/components/workflow/panel/chat-variable-panel/__tests__/index.spec.tsx` — 4/4 passed
- `pnpm --dir web lint:a11y 'app/components/workflow/panel/chat-variable-panel/index.tsx'` — passed
- `pnpm check` — 0 errors / 2059 existing warnings
- `git diff --check` — passed
- the strengthened name/expanded assertion failed against the old unnamed control before the production change

## Visual regression review

Expected visual delta: none.

Please verify:

- the book button keeps the same 24×24 ActionButton box and 16×16 glyph
- active, hover, collapsed, expanded, light-mode, and dark-mode visuals are unchanged
- showing or hiding the tips area preserves the existing panel layout transition and spacing
- the close control remains aligned with the tips control

Only ARIA attributes were added; the existing `ActionButtonState.Active` remains the sole visual-state owner.

## Rollback

Revert this PR without reverting #40333. The close action remains valid independently.