### PR TITLE
fix(web): name assigner add operation

### DIFF
--- a/web/app/components/workflow/nodes/assigner/__tests__/panel.spec.tsx
+++ b/web/app/components/workflow/nodes/assigner/__tests__/panel.spec.tsx
@@ -105,7 +105,7 @@ describe('assigner/panel', () => {
       }),
     )
 
-    await user.click(screen.getAllByRole('button')[0]!)
+    await user.click(screen.getByRole('button', { name: 'common.operation.add' }))
 
     expect(mockUseHandleAddOperationItem).toHaveBeenCalledWith(createData().items)
     expect(handleOperationListChanges).toHaveBeenCalledWith([

--- a/web/app/components/workflow/nodes/assigner/panel.tsx
+++ b/web/app/components/workflow/nodes/assigner/panel.tsx
@@ -38,8 +38,11 @@ const Panel: FC<NodePanelProps<AssignerNodeType>> = ({ id, data }) => {
           <div className="flex grow flex-col items-start justify-center system-sm-semibold-uppercase text-text-secondary">
             {t(($) => $[`${i18nPrefix}.variables`], { ns: 'workflow' })}
           </div>
-          <ActionButton onClick={handleAddOperation}>
-            <RiAddLine className="size-4 shrink-0 text-text-tertiary" />
+          <ActionButton
+            aria-label={t(($) => $['operation.add'], { ns: 'common' })}
+            onClick={handleAddOperation}
+          >
+            <RiAddLine aria-hidden="true" className="size-4 shrink-0 text-text-tertiary" />
           </ActionButton>
         </div>
         <VarList


### PR DESCRIPTION
## Summary

- give the existing assigner Add action its localized accessible name
- hide the glyph from the accessibility tree
- replace the positional test query with role and name

## Review boundary

Form submission, validation, fields, event handling, elements, classes, and layout are unchanged.

## Verification

- owner suite: 1/1 passed
- standalone a11y lint: 0 diagnostics
- full static check: 0 errors
- diff check: passed

## Visual regression and dependency

Production changes are ARIA-only, so normal pixels remain identical. This is an independent root layer; former icon and typing cleanup children are closed.