### PR TITLE
refactor(web): use css icon for assigner add

### DIFF
--- a/web/app/components/workflow/nodes/assigner/panel.tsx
+++ b/web/app/components/workflow/nodes/assigner/panel.tsx
@@ -1,7 +1,6 @@
 import type { FC } from 'react'
 import type { AssignerNodeType } from './types'
 import type { NodePanelProps } from '@/app/components/workflow/types'
-import { RiAddLine } from '@remixicon/react'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import ActionButton from '@/app/components/base/action-button'
@@ -42,7 +41,7 @@ const Panel: FC<NodePanelProps<AssignerNodeType>> = ({ id, data }) => {
             aria-label={t(($) => $['operation.add'], { ns: 'common' })}
             onClick={handleAddOperation}
           >
-            <RiAddLine aria-hidden="true" className="size-4 shrink-0 text-text-tertiary" />
+            <span aria-hidden="true" className="i-ri-add-line size-4 shrink-0 text-text-tertiary" />
           </ActionButton>
         </div>
         <VarList


### PR DESCRIPTION
## Summary

- replace the single decorative Remix add glyph with its matching CSS icon
- preserve the exact 16px size, shrink behavior, and tertiary text color
- remove the now-unused icon import

## Boundary

This is an owner-local visual-resource cleanup only. The accessible name remains owned by #40337, and the React component typing cleanup remains in the next PR.

## Validation

- focused lint — the one icon-component warning is removed
- `pnpm --dir web exec vp test run app/components/workflow/nodes/assigner/__tests__/panel.spec.tsx` — 1 passed
- `pnpm --dir web lint:a11y app/components/workflow/nodes/assigner/panel.tsx` — passed
- `pnpm check` — 0 errors, 2058 warnings (exactly one fewer)
- `git diff --check` — passed

## Visual regression review

Compare the add glyph shape, 16px bounds, tertiary color, centering, shrink behavior, button box, and hover/active/light/dark states. No visual difference is intended; any mismatch is a regression.

## Stack

Depends on #40337. Second PR in stack #40340.