### PR TITLE
refactor(web): remove assigner panel React.FC

### DIFF
--- a/web/app/components/workflow/nodes/assigner/panel.tsx
+++ b/web/app/components/workflow/nodes/assigner/panel.tsx
@@ -1,7 +1,6 @@
-import type { FC } from 'react'
 import type { AssignerNodeType } from './types'
 import type { NodePanelProps } from '@/app/components/workflow/types'
-import * as React from 'react'
+import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import ActionButton from '@/app/components/base/action-button'
 import VarList from './components/var-list'
@@ -10,7 +9,7 @@ import useConfig from './use-config'
 
 const i18nPrefix = 'nodes.assigner'
 
-const Panel: FC<NodePanelProps<AssignerNodeType>> = ({ id, data }) => {
+const Panel = ({ id, data }: NodePanelProps<AssignerNodeType>) => {
   const { t } = useTranslation()
   const handleAddOperationItem = useHandleAddOperationItem()
   const {
@@ -64,4 +63,4 @@ const Panel: FC<NodePanelProps<AssignerNodeType>> = ({ id, data }) => {
   )
 }
 
-export default React.memo(Panel)
+export default memo(Panel)


### PR DESCRIPTION
## Summary

- type the assigner panel parameter directly instead of using `React.FC`
- import `memo` directly instead of retaining the React namespace
- leave the rendered tree and runtime behavior unchanged

## Boundary

This PR is deliberately isolated from the semantic fix and CSS icon conversion. It changes only the component declaration and import shape.

## Validation

- `pnpm --dir web exec vp test run app/components/workflow/nodes/assigner/__tests__/panel.spec.tsx` — 1 passed
- `pnpm --dir web lint:a11y app/components/workflow/nodes/assigner/panel.tsx` — passed
- focused lint — passed
- `pnpm check` — 0 errors, 2058 warnings
- `git diff --check` — passed

## Visual regression review

The runtime output should be byte-for-byte equivalent at the component boundary. Any DOM, interaction, layout, or visual difference is a regression.

## Stack

Depends on #40338. Final PR in stack #40340.