### PR TITLE
fix(web): name chat settings triggers

### DIFF
--- a/web/app/components/base/chat/chat-with-history/inputs-form/__tests__/view-form-dropdown.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/inputs-form/__tests__/view-form-dropdown.spec.tsx
@@ -66,17 +66,19 @@ describe('ViewFormDropdown', () => {
     // Initially, settings icon should be hidden (portal content)
     expect(screen.queryByText('share.chat.chatSettingsTitle')).not.toBeInTheDocument()
 
-    // Find trigger (ActionButton renders a button)
-    const trigger = screen.getByRole('button')
+    const trigger = screen.getByRole('button', { name: 'share.chat.viewChatSettings' })
     expect(trigger).toBeInTheDocument()
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
 
     // Open dropdown
     await user.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
     expect(screen.getByText('share.chat.chatSettingsTitle')).toBeInTheDocument()
     expect(screen.getByText('Test Label')).toBeInTheDocument()
 
     // Close dropdown
     await user.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
     expect(screen.queryByText('share.chat.chatSettingsTitle')).not.toBeInTheDocument()
   })
 
@@ -90,7 +92,7 @@ describe('ViewFormDropdown', () => {
 
     const user = userEvent.setup()
     render(<ViewFormDropdown />)
-    await user.click(screen.getByRole('button'))
+    await user.click(screen.getByRole('button', { name: 'share.chat.viewChatSettings' }))
 
     expect(screen.getByText('Text Form')).toBeInTheDocument()
     expect(screen.getByText('Num Form')).toBeInTheDocument()
@@ -99,7 +101,7 @@ describe('ViewFormDropdown', () => {
   it('applies correct state to ActionButton when open', async () => {
     const user = userEvent.setup()
     render(<ViewFormDropdown />)
-    const trigger = screen.getByRole('button')
+    const trigger = screen.getByRole('button', { name: 'share.chat.viewChatSettings' })
 
     // closed state
     expect(trigger).not.toHaveClass('action-btn-hover')

--- a/web/app/components/base/chat/chat-with-history/inputs-form/view-form-dropdown.tsx
+++ b/web/app/components/base/chat/chat-with-history/inputs-form/view-form-dropdown.tsx
@@ -13,10 +13,11 @@ const ViewFormDropdown = () => {
         render={(props, state) => (
           <ActionButton
             {...props}
+            aria-label={t(($) => $['chat.viewChatSettings'], { ns: 'share' })}
             size="l"
             state={state.open ? ActionButtonState.Hover : ActionButtonState.Default}
           >
-            <RiChatSettingsLine className="h-4.5 w-4.5" />
+            <RiChatSettingsLine aria-hidden="true" className="h-4.5 w-4.5" />
           </ActionButton>
         )}
       />

--- a/web/app/components/base/chat/embedded-chatbot/inputs-form/__tests__/view-form-dropdown.spec.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/inputs-form/__tests__/view-form-dropdown.spec.tsx
@@ -11,13 +11,16 @@ describe('ViewFormDropdown', () => {
     const user = userEvent.setup()
     render(<ViewFormDropdown />)
 
-    const trigger = screen.getByTestId('view-form-dropdown-trigger')
+    const trigger = screen.getByRole('button', { name: 'share.chat.viewChatSettings' })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
     expect(screen.queryByText('Form content')).not.toBeInTheDocument()
 
     await user.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
     expect(screen.getByText('Form content')).toBeInTheDocument()
 
     await user.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
     expect(screen.queryByText('Form content')).not.toBeInTheDocument()
   })
 })

--- a/web/app/components/base/chat/embedded-chatbot/inputs-form/view-form-dropdown.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/inputs-form/view-form-dropdown.tsx
@@ -17,11 +17,14 @@ const ViewFormDropdown = ({ iconColor }: Props) => {
         render={(props, state) => (
           <ActionButton
             {...props}
+            aria-label={t(($) => $['chat.viewChatSettings'], { ns: 'share' })}
             size="l"
             state={state.open ? ActionButtonState.Hover : ActionButtonState.Default}
-            data-testid="view-form-dropdown-trigger"
           >
-            <div className={cn('i-ri-chat-settings-line h-4.5 w-4.5 shrink-0', iconColor)} />
+            <span
+              aria-hidden
+              className={cn('i-ri-chat-settings-line h-4.5 w-4.5 shrink-0', iconColor)}
+            />
           </ActionButton>
         )}
       />


### PR DESCRIPTION
## Summary

- give both ViewFormDropdown triggers the existing localized View chat settings name
- hide each glyph from the accessibility tree
- query both chat surfaces by role and accessible name
- verify the Base UI popover transition through aria-expanded
- keep the ActionButton content model valid with an inline span

## Review boundary

This is one duplicated user-facing contract across chat-with-history and embedded-chatbot. Form fields, validation, submission, popover ownership, handlers, classes, and layout are unchanged. The unused test id removed from the touched trigger is not replaced.

## Verification

- two owner suites: 4/4 passed
- standalone a11y lint on both production files: 0 diagnostics
- full static check: 0 errors
- diff check: passed

## Visual regression review

Only ARIA attributes and an inline div-to-span content-model correction change in production. Geometry, icons, alignment, placement, hover, and open states remain unchanged.

## Dependency and rollback

Independent root layer and sole owner of these two trigger names.