### PR TITLE
refactor(web): use css icons for chat settings

### DIFF
--- a/web/app/components/base/chat/chat-with-history/inputs-form/__tests__/view-form-dropdown.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/inputs-form/__tests__/view-form-dropdown.spec.tsx
@@ -66,17 +66,19 @@ describe('ViewFormDropdown', () => {
     // Initially, settings icon should be hidden (portal content)
     expect(screen.queryByText('share.chat.chatSettingsTitle')).not.toBeInTheDocument()
 
-    // Find trigger (ActionButton renders a button)
-    const trigger = screen.getByRole('button')
+    const trigger = screen.getByRole('button', { name: 'share.chat.viewChatSettings' })
     expect(trigger).toBeInTheDocument()
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
 
     // Open dropdown
     await user.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
     expect(screen.getByText('share.chat.chatSettingsTitle')).toBeInTheDocument()
     expect(screen.getByText('Test Label')).toBeInTheDocument()
 
     // Close dropdown
     await user.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
     expect(screen.queryByText('share.chat.chatSettingsTitle')).not.toBeInTheDocument()
   })
 
@@ -90,7 +92,7 @@ describe('ViewFormDropdown', () => {
 
     const user = userEvent.setup()
     render(<ViewFormDropdown />)
-    await user.click(screen.getByRole('button'))
+    await user.click(screen.getByRole('button', { name: 'share.chat.viewChatSettings' }))
 
     expect(screen.getByText('Text Form')).toBeInTheDocument()
     expect(screen.getByText('Num Form')).toBeInTheDocument()
@@ -99,7 +101,7 @@ describe('ViewFormDropdown', () => {
   it('applies correct state to ActionButton when open', async () => {
     const user = userEvent.setup()
     render(<ViewFormDropdown />)
-    const trigger = screen.getByRole('button')
+    const trigger = screen.getByRole('button', { name: 'share.chat.viewChatSettings' })
 
     // closed state
     expect(trigger).not.toHaveClass('action-btn-hover')

--- a/web/app/components/base/chat/chat-with-history/inputs-form/view-form-dropdown.tsx
+++ b/web/app/components/base/chat/chat-with-history/inputs-form/view-form-dropdown.tsx
@@ -13,10 +13,11 @@ const ViewFormDropdown = () => {
         render={(props, state) => (
           <ActionButton
             {...props}
+            aria-label={t(($) => $['chat.viewChatSettings'], { ns: 'share' })}
             size="l"
             state={state.open ? ActionButtonState.Hover : ActionButtonState.Default}
           >
-            <RiChatSettingsLine className="h-4.5 w-4.5" />
+            <RiChatSettingsLine aria-hidden="true" className="h-4.5 w-4.5" />
           </ActionButton>
         )}
       />

--- a/web/app/components/base/chat/chat-with-history/inputs-form/view-form-dropdown.tsx
+++ b/web/app/components/base/chat/chat-with-history/inputs-form/view-form-dropdown.tsx
@@ -1,9 +1,7 @@
 import { Popover, PopoverContent, PopoverTrigger } from '@langgenius/dify-ui/popover'
-import { RiChatSettingsLine } from '@remixicon/react'
 import { useTranslation } from 'react-i18next'
 import ActionButton, { ActionButtonState } from '@/app/components/base/action-button'
 import InputsFormContent from '@/app/components/base/chat/chat-with-history/inputs-form/content'
-import { Message3Fill } from '@/app/components/base/icons/src/public/other'
 
 const ViewFormDropdown = () => {
   const { t } = useTranslation()
@@ -17,7 +15,7 @@ const ViewFormDropdown = () => {
             size="l"
             state={state.open ? ActionButtonState.Hover : ActionButtonState.Default}
           >
-            <RiChatSettingsLine aria-hidden="true" className="h-4.5 w-4.5" />
+            <span aria-hidden className="i-ri-chat-settings-line h-4.5 w-4.5" />
           </ActionButton>
         )}
       />
@@ -29,7 +27,7 @@ const ViewFormDropdown = () => {
       >
         <div className="w-100 rounded-2xl border-[0.5px] border-components-panel-border bg-components-panel-bg shadow-lg backdrop-blur-xs">
           <div className="flex items-center gap-3 rounded-t-2xl border-b border-divider-subtle px-6 py-4">
-            <Message3Fill className="size-6 shrink-0" />
+            <div aria-hidden className="i-custom-public-other-message-3-fill size-6 shrink-0" />
             <div className="grow system-xl-semibold text-text-secondary">
               {t(($) => $['chat.chatSettingsTitle'], { ns: 'share' })}
             </div>

--- a/web/app/components/base/chat/embedded-chatbot/inputs-form/__tests__/view-form-dropdown.spec.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/inputs-form/__tests__/view-form-dropdown.spec.tsx
@@ -11,13 +11,16 @@ describe('ViewFormDropdown', () => {
     const user = userEvent.setup()
     render(<ViewFormDropdown />)
 
-    const trigger = screen.getByTestId('view-form-dropdown-trigger')
+    const trigger = screen.getByRole('button', { name: 'share.chat.viewChatSettings' })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
     expect(screen.queryByText('Form content')).not.toBeInTheDocument()
 
     await user.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
     expect(screen.getByText('Form content')).toBeInTheDocument()
 
     await user.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
     expect(screen.queryByText('Form content')).not.toBeInTheDocument()
   })
 })

--- a/web/app/components/base/chat/embedded-chatbot/inputs-form/view-form-dropdown.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/inputs-form/view-form-dropdown.tsx
@@ -17,11 +17,15 @@ const ViewFormDropdown = ({ iconColor }: Props) => {
         render={(props, state) => (
           <ActionButton
             {...props}
+            aria-label={t(($) => $['chat.viewChatSettings'], { ns: 'share' })}
             size="l"
             state={state.open ? ActionButtonState.Hover : ActionButtonState.Default}
             data-testid="view-form-dropdown-trigger"
           >
-            <div className={cn('i-ri-chat-settings-line h-4.5 w-4.5 shrink-0', iconColor)} />
+            <div
+              aria-hidden
+              className={cn('i-ri-chat-settings-line h-4.5 w-4.5 shrink-0', iconColor)}
+            />
           </ActionButton>
         )}
       />


### PR DESCRIPTION
## Summary

- replace the two decorative SVG components in the chat-with-history settings popover with matching CSS icons
- preserve the trigger glyph at 18px and the panel glyph at 24px
- remove the now-unused icon imports

## Boundary

This PR contains only visual-resource substitutions. The accessible name and state contract remain owned by #40341; the embedded chatbot already uses the matching CSS trigger icon.

## Validation

- focused lint — both icon-component warnings removed
- the two focused popover suites — 4 passed
- standalone a11y lint on both production components — passed
- `pnpm check` — 0 errors, 2057 warnings (exactly two fewer)
- `git diff --check` — passed

## Visual regression review

Compare the chat-settings glyph and filled message glyph shape, 18px/24px bounds, current-color rendering, alignment, shrink behavior, button box, panel spacing, hover/open states, and light/dark themes. No visual difference is intended; any mismatch is a regression.

## Stack

Depends on #40341. Final PR in stack #40343.