### PR TITLE
fix(web): name chat history controls

### DIFF
--- a/web/app/components/base/chat/chat-with-history/header/__tests__/index.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/header/__tests__/index.spec.tsx
@@ -91,10 +91,8 @@ describe('Header Component', () => {
       const handleNewConversation = vi.fn()
       setup({ handleNewConversation, sidebarCollapseState: true, currentConversationId: 'conv-1' })
 
-      const buttons = screen.getAllByRole('button')
-      // Sidebar, NewChat, ResetChat (3)
-      const resetChatBtn = buttons[buttons.length - 1]
-      await userEvent.click(resetChatBtn!)
+      const resetChatBtn = screen.getByRole('button', { name: 'share.chat.resetChat' })
+      await userEvent.click(resetChatBtn)
 
       expect(handleNewConversation).toHaveBeenCalled()
     })
@@ -103,9 +101,8 @@ describe('Header Component', () => {
       const handleSidebarCollapse = vi.fn()
       setup({ handleSidebarCollapse, sidebarCollapseState: true })
 
-      const buttons = screen.getAllByRole('button')
-      const sidebarBtn = buttons[0]
-      await userEvent.click(sidebarBtn!)
+      const sidebarBtn = screen.getByRole('button', { name: 'layout.sidebar.expandSidebar' })
+      await userEvent.click(sidebarBtn)
 
       expect(handleSidebarCollapse).toHaveBeenCalledWith(false)
     })
@@ -340,10 +337,8 @@ describe('Header Component', () => {
         currentConversationId: 'conv-1',
       })
 
-      const buttons = screen.getAllByRole('button')
-      // Sidebar, NewChat, ResetChat (3)
-      const newChatBtn = buttons[1]
-      expect(newChatBtn)!.toBeDisabled()
+      const newChatBtn = screen.getByRole('button', { name: 'share.chat.newChatTip' })
+      expect(newChatBtn).toBeDisabled()
     })
 
     it('should handle New Chat button state when currentConversationId is missing and isResponding is false', () => {
@@ -353,10 +348,8 @@ describe('Header Component', () => {
         currentConversationId: '',
       })
 
-      const buttons = screen.getAllByRole('button')
-      // Sidebar, NewChat (2)
-      const newChatBtn = buttons[1]
-      expect(newChatBtn)!.toBeDisabled()
+      const newChatBtn = screen.getByRole('button', { name: 'share.chat.newChatTip' })
+      expect(newChatBtn).toBeDisabled()
     })
 
     it('should not render operation menu if conversation id is missing', () => {

--- a/web/app/components/base/chat/chat-with-history/header/index.tsx
+++ b/web/app/components/base/chat/chat-with-history/header/index.tsx
@@ -90,11 +90,12 @@ const Header = () => {
           )}
         >
           <ActionButton
+            aria-label={t(($) => $['sidebar.expandSidebar'], { ns: 'layout' })}
             className={cn(!isSidebarCollapsed && 'cursor-default')}
             size="l"
             onClick={() => handleSidebarCollapse(false)}
           >
-            <RiLayoutRight2Line className="h-4.5 w-4.5" />
+            <RiLayoutRight2Line aria-hidden="true" className="h-4.5 w-4.5" />
           </ActionButton>
           <div className="mr-1 shrink-0">
             <AppIcon
@@ -134,6 +135,7 @@ const Header = () => {
                 render={
                   <div>
                     <ActionButton
+                      aria-label={t(($) => $['chat.newChatTip'], { ns: 'share' })}
                       size="l"
                       state={
                         !currentConversationId || isResponding
@@ -143,7 +145,7 @@ const Header = () => {
                       disabled={!currentConversationId || isResponding}
                       onClick={handleNewConversation}
                     >
-                      <RiEditBoxLine className="h-4.5 w-4.5" />
+                      <RiEditBoxLine aria-hidden="true" className="h-4.5 w-4.5" />
                     </ActionButton>
                   </div>
                 }
@@ -157,8 +159,12 @@ const Header = () => {
             <Tooltip>
               <TooltipTrigger
                 render={
-                  <ActionButton size="l" onClick={handleNewConversation}>
-                    <RiResetLeftLine className="h-4.5 w-4.5" />
+                  <ActionButton
+                    aria-label={t(($) => $['chat.resetChat'], { ns: 'share' })}
+                    size="l"
+                    onClick={handleNewConversation}
+                  >
+                    <RiResetLeftLine aria-hidden="true" className="h-4.5 w-4.5" />
                   </ActionButton>
                 }
               />

--- a/web/app/components/base/chat/chat-with-history/sidebar/__tests__/index.spec.tsx
+++ b/web/app/components/base/chat/chat-with-history/sidebar/__tests__/index.spec.tsx
@@ -170,7 +170,9 @@ describe('Sidebar Index', () => {
 
       render(<Sidebar />)
       const header = screen.getByText('Test App').parentElement as HTMLElement
-      const collapseButton = within(header).getByRole('button')
+      const collapseButton = within(header).getByRole('button', {
+        name: 'layout.sidebar.collapseSidebar',
+      })
       expect(collapseButton).toBeInTheDocument()
 
       await user.click(collapseButton)
@@ -187,7 +189,9 @@ describe('Sidebar Index', () => {
 
       render(<Sidebar />)
       const header = screen.getByText('Test App').parentElement as HTMLElement
-      const expandButton = within(header).getByRole('button')
+      const expandButton = within(header).getByRole('button', {
+        name: 'layout.sidebar.expandSidebar',
+      })
       expect(expandButton).toBeInTheDocument()
 
       await user.click(expandButton)

--- a/web/app/components/base/chat/chat-with-history/sidebar/index.tsx
+++ b/web/app/components/base/chat/chat-with-history/sidebar/index.tsx
@@ -106,12 +106,20 @@ const Sidebar = ({ isPanel }: Props) => {
           {appData?.site.title}
         </div>
         {!isMobile && isSidebarCollapsed && (
-          <ActionButton size="l" onClick={() => handleSidebarCollapse(false)}>
+          <ActionButton
+            aria-label={t(($) => $['sidebar.expandSidebar'], { ns: 'layout' })}
+            size="l"
+            onClick={() => handleSidebarCollapse(false)}
+          >
             <span aria-hidden className="i-ri-expand-right-line h-4.5 w-4.5" />
           </ActionButton>
         )}
         {!isMobile && !isSidebarCollapsed && (
-          <ActionButton size="l" onClick={() => handleSidebarCollapse(true)}>
+          <ActionButton
+            aria-label={t(($) => $['sidebar.collapseSidebar'], { ns: 'layout' })}
+            size="l"
+            onClick={() => handleSidebarCollapse(true)}
+          >
             <span aria-hidden className="i-ri-layout-left-2-line h-4.5 w-4.5" />
           </ActionButton>
         )}


### PR DESCRIPTION
## Summary

- name chat-history actions for sidebar expansion, new chat, reset, expand, and collapse
- hide decorative header glyphs
- replace positional button queries with role-and-name interactions

## Review boundary

Callbacks, disabled logic, tooltips, sidebar transitions, visibility lifecycle, elements, classes, and layout are unchanged.

## Verification

- header and sidebar suites: 78/78 passed
- standalone a11y lint: 0 diagnostics
- full static check: 0 errors
- diff check: passed

## Visual regression and dependency

Production changes are ARIA-only, so normal pixels remain identical. This is an independent root layer; the former React typing cleanup is closed.