### PR TITLE
refactor(web): use css icons for chat history header

### DIFF
--- a/web/app/components/base/chat/chat-with-history/header/index.tsx
+++ b/web/app/components/base/chat/chat-with-history/header/index.tsx
@@ -10,7 +10,6 @@ import {
 } from '@langgenius/dify-ui/alert-dialog'
 import { cn } from '@langgenius/dify-ui/cn'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/tooltip'
-import { RiEditBoxLine, RiLayoutRight2Line, RiResetLeftLine } from '@remixicon/react'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import ActionButton, { ActionButtonState } from '@/app/components/base/action-button'
@@ -95,7 +94,7 @@ const Header = () => {
             size="l"
             onClick={() => handleSidebarCollapse(false)}
           >
-            <RiLayoutRight2Line aria-hidden="true" className="h-4.5 w-4.5" />
+            <span aria-hidden className="i-ri-layout-right-2-line h-4.5 w-4.5" />
           </ActionButton>
           <div className="mr-1 shrink-0">
             <AppIcon
@@ -145,7 +144,7 @@ const Header = () => {
                       disabled={!currentConversationId || isResponding}
                       onClick={handleNewConversation}
                     >
-                      <RiEditBoxLine aria-hidden="true" className="h-4.5 w-4.5" />
+                      <span aria-hidden className="i-ri-edit-box-line h-4.5 w-4.5" />
                     </ActionButton>
                   </div>
                 }
@@ -164,7 +163,7 @@ const Header = () => {
                     size="l"
                     onClick={handleNewConversation}
                   >
-                    <RiResetLeftLine aria-hidden="true" className="h-4.5 w-4.5" />
+                    <span aria-hidden className="i-ri-reset-left-line h-4.5 w-4.5" />
                   </ActionButton>
                 }
               />


### PR DESCRIPTION
## Summary

- replace the header's expand-sidebar, new-chat, and reset-chat SVG components with matching CSS icons
- preserve all three glyphs at 18px
- remove the now-unused Remix icon import

## Boundary

This PR changes only the header's decorative icon resources. The five accessible names and behavior-focused test selectors remain owned by #40344; sidebar icons were already CSS icons.

## Validation

- focused lint — all three header icon warnings removed
- header and sidebar focused suites — 78 passed
- standalone a11y lint on both production components — passed
- `pnpm check` — 0 errors, 2056 warnings (exactly three fewer)
- `git diff --check` — passed

## Visual regression review

Compare all three glyph shapes and directions, 18px bounds, current-color rendering, centering, disabled appearance, tooltips, sidebar transition, hover/active states, and light/dark themes. No visual difference is intended; any mismatch is a regression.

## Stack

Depends on #40344. Final PR in stack #40346.