### PR TITLE
refactor(web): use css icons for tool detail

### DIFF
--- a/web/app/components/base/chat/chat/answer/tool-detail.tsx
+++ b/web/app/components/base/chat/chat/answer/tool-detail.tsx
@@ -1,6 +1,5 @@
 import type { ToolInfoInThought } from '../type'
 import { cn } from '@langgenius/dify-ui/cn'
-import { RiArrowDownSLine, RiArrowRightSLine, RiHammerFill, RiLoader2Line } from '@remixicon/react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -30,12 +29,14 @@ const ToolDetail = ({ payload }: ToolDetailProps) => {
         )}
         onClick={() => setExpand(!expand)}
       >
-        {isFinished && <RiHammerFill aria-hidden="true" className="mr-1 size-3.5" />}
-        {!isFinished && <RiLoader2Line aria-hidden="true" className="mr-1 size-3.5 animate-spin" />}
+        {isFinished && <span aria-hidden className="mr-1 i-ri-hammer-fill size-3.5" />}
+        {!isFinished && (
+          <span aria-hidden className="mr-1 i-ri-loader-2-line size-3.5 animate-spin" />
+        )}
         {t(($) => $[`thought.${isFinished ? 'used' : 'using'}`], { ns: 'tools' })}
         <span className="mx-1 text-text-secondary">{toolLabel}</span>
-        {!expand && <RiArrowRightSLine aria-hidden="true" className="size-4" />}
-        {expand && <RiArrowDownSLine aria-hidden="true" className="ml-auto size-4" />}
+        {!expand && <span aria-hidden className="i-ri-arrow-right-s-line size-4" />}
+        {expand && <span aria-hidden className="ml-auto i-ri-arrow-down-s-line size-4" />}
       </button>
       {expand && (
         <>


### PR DESCRIPTION
## Summary

- replace the Tool Detail hammer, loader, collapsed arrow, and expanded arrow SVG components with matching CSS icons
- preserve the 14px status glyphs, 16px arrows, margins, auto alignment, and loader spin
- remove the now-unused Remix icon import

## Boundary

This PR changes only decorative icon resources. Native disclosure semantics, valid button content, state assertions, and suppression pruning remain owned by #40349.

## Validation

- focused lint — all four icon warnings removed
- focused owner suite — 4 passed
- standalone a11y lint — 0 diagnostics
- `pnpm check` — 0 errors, 2055 warnings (exactly four fewer)
- `git diff --check` — passed

## Visual regression review

Compare hammer and loader shapes, 14px bounds, loader rotation, 16px arrow shapes/directions, margins, right alignment when expanded, current-color rendering, header geometry, and light/dark states. No visual difference is intended; any mismatch is a regression.

## Stack

Depends on #40349. Final PR in stack #40351.