### PR TITLE
fix: catch ValueError instead of bare except in account CLI commands

### DIFF
--- a/api/commands/account.py
+++ b/api/commands/account.py
@@ -33,7 +33,7 @@ def reset_password(email, new_password, password_confirm):
 
     try:
         valid_password(new_password)
-    except:
+    except ValueError:
         click.echo(click.style(f"Invalid password. Must match {password_pattern}", fg="red"))
         return
 
@@ -75,7 +75,7 @@ def reset_email(email, new_email, email_confirm):
 
     try:
         email_validate(normalized_new_email)
-    except:
+    except ValueError:
         click.echo(click.style(f"Invalid email: {new_email}", fg="red"))
         return
 

--- a/api/tests/unit_tests/commands/test_account_commands.py
+++ b/api/tests/unit_tests/commands/test_account_commands.py
@@ -1,0 +1,37 @@
+from unittest.mock import Mock
+
+from click.testing import CliRunner
+
+from commands.account import reset_email, reset_password
+
+
+def test_reset_password_does_not_swallow_keyboard_interrupt(monkeypatch):
+    monkeypatch.setattr(
+        "commands.account.AccountService.get_account_by_email_with_case_fallback",
+        Mock(return_value=Mock()),
+    )
+    monkeypatch.setattr("commands.account.valid_password", Mock(side_effect=KeyboardInterrupt))
+
+    result = CliRunner().invoke(
+        reset_password,
+        ["--email", "a@example.com", "--new-password", "whatever", "--password-confirm", "whatever"],
+    )
+
+    assert not isinstance(result.exception, SystemExit) or result.exception.code != 0
+    assert "Invalid password" not in result.output
+
+
+def test_reset_email_does_not_swallow_keyboard_interrupt(monkeypatch):
+    monkeypatch.setattr(
+        "commands.account.AccountService.get_account_by_email_with_case_fallback",
+        Mock(return_value=Mock()),
+    )
+    monkeypatch.setattr("commands.account.email_validate", Mock(side_effect=KeyboardInterrupt))
+
+    result = CliRunner().invoke(
+        reset_email,
+        ["--email", "a@example.com", "--new-email", "b@example.com", "--email-confirm", "b@example.com"],
+    )
+
+    assert not isinstance(result.exception, SystemExit) or result.exception.code != 0
+    assert "Invalid email" not in result.output

--- a/api/tests/unit_tests/commands/test_account_commands.py
+++ b/api/tests/unit_tests/commands/test_account_commands.py
@@ -1,11 +1,12 @@
 from unittest.mock import Mock
 
+import pytest
 from click.testing import CliRunner
 
 from commands.account import reset_email, reset_password
 
 
-def test_reset_password_does_not_swallow_keyboard_interrupt(monkeypatch):
+def test_reset_password_does_not_swallow_keyboard_interrupt(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "commands.account.AccountService.get_account_by_email_with_case_fallback",
         Mock(return_value=Mock()),
@@ -21,7 +22,7 @@ def test_reset_password_does_not_swallow_keyboard_interrupt(monkeypatch):
     assert "Invalid password" not in result.output
 
 
-def test_reset_email_does_not_swallow_keyboard_interrupt(monkeypatch):
+def test_reset_email_does_not_swallow_keyboard_interrupt(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "commands.account.AccountService.get_account_by_email_with_case_fallback",
         Mock(return_value=Mock()),


### PR DESCRIPTION
## Summary

`reset-password` and `reset-email` in `api/commands/account.py` wrap `valid_password`/`email_validate` in a bare `except:` block. Both validators only ever raise `ValueError` on invalid input, so the bare except unnecessarily catches everything else too, including `KeyboardInterrupt` and `SystemExit`. That makes the interactive CLI prompt unresponsive to Ctrl+C while it's waiting on these calls, since the interrupt gets swallowed and reported as an "Invalid password"/"Invalid email" message instead of stopping the command.

This narrows both `except:` clauses to `except ValueError:`, matching the exception the validators actually raise.

Fixes #40348

## Test plan

Added `api/tests/unit_tests/commands/test_account_commands.py` with a regression test for each command. Each test mocks the validator to raise `KeyboardInterrupt` and asserts it propagates out of the command instead of being swallowed into an "Invalid password"/"Invalid email" message.

Confirmed the tests fail against the pre-fix code (bare `except:`) and pass with the fix:

```
$ uv run --project api pytest --timeout 30 api/tests/unit_tests/commands/test_account_commands.py -v --no-cov
api/tests/unit_tests/commands/test_account_commands.py::test_reset_password_does_not_swallow_keyboard_interrupt PASSED
api/tests/unit_tests/commands/test_account_commands.py::test_reset_email_does_not_swallow_keyboard_interrupt PASSED
2 passed, 1 warning in 1.20s
```

Also ran the full `api/tests/unit_tests/commands/` suite (174 tests) to confirm no regressions, and `ruff format --diff` / `ruff check` on the changed files (both clean).

From Claude
