### PR TITLE
refactor(web): use css icon for version filter

### DIFF
--- a/web/app/components/workflow/panel/version-history-panel/filter/filter-item.tsx
+++ b/web/app/components/workflow/panel/version-history-panel/filter/filter-item.tsx
@@ -1,6 +1,5 @@
 import type { FC } from 'react'
 import type { WorkflowVersionFilterOptions } from '../../../types'
-import { RiCheckLine } from '@remixicon/react'
 import * as React from 'react'
 
 type FilterItemProps = {
@@ -23,7 +22,9 @@ const FilterItem: FC<FilterItemProps> = ({ item, isSelected = false, onClick }) 
       }}
     >
       <span className="flex-1 system-md-regular text-text-primary">{item.name}</span>
-      {isSelected && <RiCheckLine aria-hidden className="size-4 shrink-0 text-text-accent" />}
+      {isSelected && (
+        <span aria-hidden className="i-ri-check-line size-4 shrink-0 text-text-accent" />
+      )}
     </button>
   )
 }


### PR DESCRIPTION
## Summary

- replace the selected version-filter React SVG with its CSS icon
- keep the check decorative with `aria-hidden`
- remove the one exact icon lint warning

## Boundary

- one production component only
- no selection semantics, filter behavior, spacing, or tests changed

## Validation

- `pnpm --dir web exec vp test run app/components/workflow/panel/version-history-panel/filter/__tests__/filter-item.spec.tsx app/components/workflow/panel/version-history-panel/filter/__tests__/index.spec.tsx` — 4/4 passed
- `./node_modules/.bin/vp lint web/app/components/workflow/panel/version-history-panel/filter/filter-item.tsx web/app/components/workflow/panel/version-history-panel/filter/__tests__/filter-item.spec.tsx web/app/components/workflow/panel/version-history-panel/filter/__tests__/index.spec.tsx`
- `pnpm --dir web lint:a11y app/components/workflow/panel/version-history-panel/filter/filter-item.tsx`
- `pnpm check` — 0 errors, 2058 warnings, exactly 1 fewer than the parent
- `git diff --check`

## Visual regression review

- verify the check glyph shape matches the previous Remix icon
- verify it remains 16x16, non-shrinking, and uses the same accent color
- verify selected-row alignment and spacing are unchanged

## Stack

- depends on #40357
- this visual-only leaf can be reviewed or reverted independently

## Rollback

Revert commit `81f0d69c834405756dcd693ec9c8729cfdf23a8b`; the parent accessibility behavior remains intact.