### PR TITLE
refactor(web): use css icons for PDF preview

### DIFF
--- a/web/app/components/base/file-uploader/pdf-preview.tsx
+++ b/web/app/components/base/file-uploader/pdf-preview.tsx
@@ -1,7 +1,6 @@
 import type { FC } from 'react'
 import { Dialog, DialogContent } from '@langgenius/dify-ui/dialog'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@langgenius/dify-ui/tooltip'
-import { RiCloseLine, RiZoomInLine, RiZoomOutLine } from '@remixicon/react'
 import { useHotkey } from '@tanstack/react-hotkeys'
 import { noop } from 'es-toolkit/function'
 import { useState } from 'react'
@@ -101,7 +100,7 @@ const PdfPreview: FC<PdfPreviewProps> = ({ url, onCancel }) => {
                 className="absolute top-6 right-24 flex size-8 cursor-pointer items-center justify-center rounded-lg"
                 onClick={zoomOut}
               >
-                <RiZoomOutLine className="size-4 text-gray-500" />
+                <span aria-hidden className="i-ri-zoom-out-line size-4 text-gray-500" />
               </button>
             }
           />
@@ -116,7 +115,7 @@ const PdfPreview: FC<PdfPreviewProps> = ({ url, onCancel }) => {
                 className="absolute top-6 right-16 flex size-8 cursor-pointer items-center justify-center rounded-lg"
                 onClick={zoomIn}
               >
-                <RiZoomInLine className="size-4 text-gray-500" />
+                <span aria-hidden className="i-ri-zoom-in-line size-4 text-gray-500" />
               </button>
             }
           />
@@ -131,7 +130,7 @@ const PdfPreview: FC<PdfPreviewProps> = ({ url, onCancel }) => {
                 className="absolute top-6 right-6 flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg bg-white/8 backdrop-blur-[2px]"
                 onClick={onCancel}
               >
-                <RiCloseLine className="size-4 text-gray-500" />
+                <span aria-hidden className="i-ri-close-line size-4 text-gray-500" />
               </button>
             }
           />


### PR DESCRIPTION
## Summary

- replace the PDF preview zoom-out, zoom-in, and close React SVGs with CSS icons
- keep all three glyphs decorative with `aria-hidden`
- remove the three exact icon lint warnings without changing control semantics

## Boundary

- one production component only
- no dialog containment, zoom math, hotkeys, callbacks, positions, button labels, or tests changed

## Validation

- `pnpm --dir web exec vp test run app/components/base/file-uploader/__tests__/pdf-preview.spec.tsx` — 10/10 passed
- `./node_modules/.bin/vp lint web/app/components/base/file-uploader/pdf-preview.tsx web/app/components/base/file-uploader/__tests__/pdf-preview.spec.tsx`
- `pnpm --dir web lint:a11y app/components/base/file-uploader/pdf-preview.tsx`
- `pnpm check` — 0 errors, 2056 warnings, exactly 3 fewer than the parent
- `git diff --check`

## Visual regression review

- compare the zoom-out, zoom-in, and close glyph shapes
- verify every icon remains 16x16 and keeps the same gray color
- verify the controls stay at right-24, right-16, and right-6 with the same 32px hit areas
- verify tooltip labels and keyboard activation are unchanged

## Stack

- depends on #40363 because both PRs touch the PDF preview owner
- this visual-only leaf can be reviewed or reverted independently

## Rollback

Revert commit `00aba9a51ff7e123b9adc4802b4056f2dd646b7d`; the parent containment cleanup remains intact.