### PR TITLE
fix(web): hide citation measurement text

### DIFF
--- a/web/app/components/base/chat/chat/citation/__tests__/index.spec.tsx
+++ b/web/app/components/base/chat/chat/citation/__tests__/index.spec.tsx
@@ -99,11 +99,13 @@ describe('Citation', () => {
       expect(screen.getAllByTestId('citation-measurement-item')).toHaveLength(2)
     })
 
-    it('should display the document name inside each measurement item', () => {
+    it('should hide measurement text from the accessibility tree', () => {
       mockClientWidths({ container: 500, item: 50 })
       setupContainer()
       render(<Citation data={[makeCitationItem({ document_name: 'My Report' })]} />)
-      expect(screen.getByTestId('citation-measurement-item')).toHaveTextContent('My Report')
+      const measurementItem = screen.getByTestId('citation-measurement-item')
+      expect(measurementItem).toHaveTextContent('My Report')
+      expect(measurementItem).toHaveAttribute('aria-hidden', 'true')
     })
 
     it('should render a popup for each resource that fits within the container', () => {

--- a/web/app/components/base/chat/chat/citation/index.tsx
+++ b/web/app/components/base/chat/chat/citation/index.tsx
@@ -86,6 +86,7 @@ const Citation: FC<CitationProps> = ({
         {resources.map((res, index) => (
           <div
             key={res.documentId}
+            aria-hidden
             data-testid="citation-measurement-item"
             className="absolute top-0 left-0 -z-10 mr-1 mb-1 h-7 w-auto max-w-60 pr-2 pl-7 text-xs whitespace-nowrap opacity-0"
             ref={(ele: HTMLDivElement | null) => {


### PR DESCRIPTION
## Summary

- hide opacity-zero citation measurement clones from the accessibility tree
- keep their text and refs intact for width measurement
- retain `data-testid="citation-measurement-item"` only as the geometry seam used by the layout test

## Boundary

- citation measurement clones only
- no rendered citation, overflow behavior, CSS class, size, position, or measurement algorithm changed
- no suppression entry changed in this layer

## Validation

- `pnpm --dir web exec vp test run app/components/base/chat/chat/citation/__tests__/index.spec.tsx` — 21/21 passed
- `./node_modules/.bin/vp lint web/app/components/base/chat/chat/citation/index.tsx web/app/components/base/chat/chat/citation/__tests__/index.spec.tsx`
- `pnpm check` — 0 errors, 2059 warnings
- `git diff --check`

## Visual regression review

- verify citation chips and overflow count render exactly as before
- measurement clones retain the same text, ref, dimensions, opacity, and absolute positioning
- `aria-hidden` has no CSS or layout effect

## Stack

- root PR
- #40367 adds the citation overflow button semantics in a separate interaction layer
- this layer can be reviewed and reverted independently

## Rollback

Revert commit `8216b1deb2d9791f58451143e2478b99e8d894e5`.

From Codex