### PR TITLE
fix(web): use a button for citation overflow

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -879,12 +879,6 @@
   "web/app/components/base/chat/chat/citation/index.tsx": {
     "eslint-react/set-state-in-effect": {
       "count": 1
-    },
-    "jsx_a11y/click-events-have-key-events": {
-      "count": 1
-    },
-    "jsx_a11y/no-static-element-interactions": {
-      "count": 1
     }
   },
   "web/app/components/base/chat/chat/hooks.ts": {

--- a/web/app/components/base/chat/chat/citation/__tests__/index.spec.tsx
+++ b/web/app/components/base/chat/chat/citation/__tests__/index.spec.tsx
@@ -226,7 +226,7 @@ describe('Citation', () => {
         />,
       )
       expect(screen.getAllByTestId('popup')).toHaveLength(3)
-      expect(screen.queryByTestId('citation-more-toggle')).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'share.chat.expand' })).not.toBeInTheDocument()
     })
   })
 
@@ -246,7 +246,7 @@ describe('Citation', () => {
           ]}
         />,
       )
-      expect(screen.getByTestId('citation-more-toggle')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'share.chat.expand' })).toBeInTheDocument()
     })
   })
 
@@ -268,7 +268,7 @@ describe('Citation', () => {
           ]}
         />,
       )
-      expect(screen.getByTestId('citation-more-toggle')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'share.chat.expand' })).toBeInTheDocument()
       expect(screen.getAllByTestId('popup')).toHaveLength(2)
     })
   })
@@ -290,38 +290,49 @@ describe('Citation', () => {
           ]}
         />,
       )
-      return screen.getByTestId('citation-more-toggle')
+      return screen.getByRole('button', { name: 'share.chat.expand' })
     }
 
     it('should show the overflow count label matching /+\\s*\\d+/ on the more-toggle in collapsed state', () => {
-      renderOverflowScenario()
-      expect(screen.getByTestId('citation-more-toggle').textContent).toMatch(/^\+\s*\d+$/)
+      const toggle = renderOverflowScenario()
+      expect(toggle).toHaveAttribute('aria-expanded', 'false')
+      expect(toggle.textContent).toMatch(/^\+\s*\d+$/)
     })
 
-    it('should display the collapse icon div after clicking more-toggle to expand', async () => {
+    it('should expose the expanded state after clicking more-toggle', async () => {
       const user = userEvent.setup()
-      renderOverflowScenario()
+      const toggle = renderOverflowScenario()
 
-      await user.click(screen.getByTestId('citation-more-toggle'))
+      await user.click(toggle)
 
+      expect(screen.getByRole('button', { name: 'share.chat.collapse' })).toHaveAttribute(
+        'aria-expanded',
+        'true',
+      )
       expect(document.querySelector('.i-ri-arrow-down-s-line')).toBeInTheDocument()
     })
 
-    it('should return to the count label after clicking the toggle a second time to collapse', async () => {
+    it('should support Enter and Space activation', async () => {
       const user = userEvent.setup()
-      renderOverflowScenario()
+      const toggle = renderOverflowScenario()
+      toggle.focus()
 
-      await user.click(screen.getByTestId('citation-more-toggle'))
-      await user.click(screen.getByTestId('citation-more-toggle'))
+      await user.keyboard('[Enter]')
+      const collapseToggle = screen.getByRole('button', { name: 'share.chat.collapse' })
+      collapseToggle.focus()
+      await user.keyboard('[Space]')
 
-      expect(screen.getByTestId('citation-more-toggle').textContent).toMatch(/^\+\s*\d+$/)
+      expect(screen.getByRole('button', { name: 'share.chat.expand' })).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      )
     })
 
     it('should show all resource popups after expanding via the more-toggle', async () => {
       const user = userEvent.setup()
-      renderOverflowScenario()
+      const toggle = renderOverflowScenario()
 
-      await user.click(screen.getByTestId('citation-more-toggle'))
+      await user.click(toggle)
 
       await waitFor(() => {
         expect(screen.getAllByTestId('popup')).toHaveLength(3)
@@ -335,7 +346,7 @@ describe('Citation', () => {
       setupContainer()
       render(<Citation data={[makeCitationItem()]} />)
       expect(screen.getAllByTestId('citation-measurement-item')).toHaveLength(1)
-      expect(screen.queryByTestId('citation-more-toggle')).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'share.chat.expand' })).not.toBeInTheDocument()
     })
 
     it('should handle all citations sharing one document_id as a single resource', () => {

--- a/web/app/components/base/chat/chat/citation/index.tsx
+++ b/web/app/components/base/chat/chat/citation/index.tsx
@@ -102,17 +102,22 @@ const Citation: FC<CitationProps> = ({
           </div>
         ))}
         {limitNumberInOneLine < resourcesLength && (
-          <div
-            data-testid="citation-more-toggle"
-            className="flex h-7 cursor-pointer items-center rounded-lg bg-components-panel-bg px-2 system-xs-medium text-text-tertiary"
+          <button
+            type="button"
+            aria-expanded={showMore}
+            aria-label={t(($) => $[showMore ? 'chat.collapse' : 'chat.expand'], { ns: 'share' })}
+            className="flex h-7 cursor-pointer items-center rounded-lg bg-components-panel-bg px-2 system-xs-medium text-text-tertiary focus-visible:ring-2 focus-visible:ring-state-accent-solid focus-visible:outline-hidden"
             onClick={() => setShowMore((v) => !v)}
           >
             {!showMore ? (
               `+ ${resourcesLength - limitNumberInOneLine}`
             ) : (
-              <div className="i-ri-arrow-down-s-line size-4 rotate-180 text-text-tertiary" />
+              <span
+                aria-hidden
+                className="i-ri-arrow-down-s-line size-4 rotate-180 text-text-tertiary"
+              />
             )}
-          </div>
+          </button>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

- replace the citation overflow click target with a native button
- expose localized expand/collapse names and `aria-expanded`
- verify click, Enter, Space, and state transitions through role/name queries
- remove the toggle test id and the two exact interaction suppressions

## Boundary

- one citation overflow control only
- reuse the existing `share.chat.expand` and `share.chat.collapse` translations; no locale files changed
- citation grouping, width measurement, popup rendering, and show-more state ownership are unchanged

## Validation

- `pnpm --dir web exec vp test run app/components/base/chat/chat/citation/__tests__/index.spec.tsx` — 21/21 passed
- `./node_modules/.bin/vp lint web/app/components/base/chat/chat/citation/index.tsx web/app/components/base/chat/chat/citation/__tests__/index.spec.tsx`
- `pnpm --dir web lint:a11y app/components/base/chat/chat/citation/index.tsx`
- `pnpm check` — 0 errors, 2059 warnings
- `git diff --check`

## Visual regression review

- verify the collapsed `+ N` control keeps the same 28px height, padding, radius, background, typography, and text color
- verify the expanded arrow keeps the same 16px glyph, rotation, and color
- normal mouse-visible state must remain unchanged
- the only intentional visual addition is the keyboard-only focus-visible ring

## Stack

- depends on #40366
- #40368 is a type-only cleanup leaf
- this interaction layer can be reverted without reverting the measurement-tree fix

## Rollback

Revert commit `9d72648a6c9b501739c452da4d0cfcc3b1ea75f6`.

From Codex