### PR TITLE
refactor(web): remove React.FC from citation

### DIFF
--- a/web/app/components/base/chat/chat/citation/index.tsx
+++ b/web/app/components/base/chat/chat/citation/index.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import type { CitationItem } from '../type'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -16,11 +15,11 @@ type CitationProps = {
   showHitInfo?: boolean
   containerClassName?: string
 }
-const Citation: FC<CitationProps> = ({
+const Citation = ({
   data,
   showHitInfo,
   containerClassName = 'chat-answer-container',
-}) => {
+}: CitationProps) => {
   const { t } = useTranslation()
   const elesRef = useRef<HTMLDivElement[]>([])
   const [limitNumberInOneLine, setLimitNumberInOneLine] = useState(0)


### PR DESCRIPTION
## Summary

- replace the citation component's `React.FC` annotation with an explicit parameter type
- remove the now-unused `FC` type import

## Boundary

- one component declaration only
- no runtime code, DOM, props, state, styles, translations, tests, or suppressions changed
- this non-accessibility cleanup is a standalone root PR and has no dependency on the citation accessibility stack

## Validation

- `pnpm --dir web exec vp test run app/components/base/chat/chat/citation/__tests__/index.spec.tsx` — 21/21 passed
- `./node_modules/.bin/vp lint web/app/components/base/chat/chat/citation/index.tsx`
- `pnpm check` — 0 errors, 2059 warnings
- `git diff --check origin/main...HEAD`

## Visual regression review

- none: the emitted DOM and runtime logic are unchanged
- reviewers only need to verify the component parameter remains typed as `CitationProps`

## Stack

- standalone root PR
- #40203 and #40204 remain the existing owner stack for citation accessibility behavior
- this type-only cleanup can merge, drop, or revert independently

## Rollback

Revert commit `57049121bf70403dbe5511bf856f8a42c13efa16`.

From Codex