### PR TITLE
fix(web): associate app deletion confirmation label

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -190,9 +190,6 @@
     }
   },
   "web/app/components/app-sidebar/app-info/app-info-modals.tsx": {
-    "jsx_a11y/label-has-associated-control": {
-      "count": 1
-    },
     "no-restricted-imports": {
       "count": 1
     }

--- a/web/app/components/app-sidebar/app-info/__tests__/app-info-modals.spec.tsx
+++ b/web/app/components/app-sidebar/app-info/__tests__/app-info-modals.spec.tsx
@@ -190,6 +190,16 @@ describe('AppInfoModals', () => {
     })
   })
 
+  it('should name the delete confirmation input with its visible label', async () => {
+    await act(async () => {
+      render(<AppInfoModals {...defaultProps} activeModal="delete" />)
+    })
+
+    expect(
+      await screen.findByRole('textbox', { name: /app\.deleteAppConfirmInputLabel/ }),
+    ).toBeInTheDocument()
+  })
+
   it('should render UpdateDSLModal when activeModal is importDSL', async () => {
     await act(async () => {
       render(<AppInfoModals {...defaultProps} activeModal="importDSL" />)

--- a/web/app/components/app-sidebar/app-info/app-info-modals.tsx
+++ b/web/app/components/app-sidebar/app-info/app-info-modals.tsx
@@ -64,6 +64,7 @@ const AppInfoModals = ({
   const { t } = useTranslation()
   const [confirmDeleteInput, setConfirmDeleteInput] = useState('')
   const [isSecretExporting, setIsSecretExporting] = useState(false)
+  const confirmDeleteInputId = React.useId()
   const isDeleteConfirmDisabled = confirmDeleteInput !== appDetail.name
   const exportDialogMode =
     secretEnvList.length > 0 ? 'secret' : activeModal === 'exportWarning' ? 'warning' : null
@@ -147,7 +148,10 @@ const AppInfoModals = ({
                 {t(($) => $.deleteAppConfirmContent, { ns: 'app' })}
               </AlertDialogDescription>
               <div className="mt-2">
-                <label className="mb-1 block system-sm-regular text-text-secondary">
+                <label
+                  htmlFor={confirmDeleteInputId}
+                  className="mb-1 block system-sm-regular text-text-secondary"
+                >
                   <Trans
                     i18nKey={($) => $.deleteAppConfirmInputLabel}
                     ns="app"
@@ -161,6 +165,7 @@ const AppInfoModals = ({
                 </label>
                 <div className="relative">
                   <Input
+                    id={confirmDeleteInputId}
                     type="text"
                     autoComplete="off"
                     spellCheck={false}


### PR DESCRIPTION
## Summary

- Associate the existing visible deletion-confirmation label with its input through `React.useId()`, `htmlFor`, and `id`.
- Preserve the localized instruction as the textbox accessible name.
- Remove the exact `label-has-associated-control` suppression made obsolete by this change.

## Boundary

- No Input or AlertDialog migration.
- No submission, state, copy, class, spacing, or layout changes.
- The separately baselined legacy Input import remains out of scope.
- Dify UI documents `Form` and `Field` migration as a submit-boundary and primitive migration; that larger visual and behavioral change belongs in its own reviewed stack, not this label-only PR.

## Validation

- Added the semantic role/name test first and observed it fail before implementation.
- `pnpm --dir web exec vp test run app/components/app-sidebar/app-info/__tests__/app-info-modals.spec.tsx`: 18/18 passed.
- `pnpm check`: passed with 0 errors; existing warnings remain baselined.
- Targeted lint, format, and `git diff --check`: passed.
- Standalone accessibility lint no longer reports `label-has-associated-control`; it still reports the pre-existing restricted legacy Input import.

## Visual review

- Expected visual delta: none. The rendered boxes, classes, text, and DOM nesting are unchanged; only `id` and `for` attributes are added.
- Intended behavior delta: clicking the visible label now focuses the confirmation input.

## Rollback

- Revert commit `bb321beb25eddb65e8d211be38d7a2fb1b84c867`. This PR is an independent root and has no child dependency.

From Codex.