### PR TITLE
fix(web): hide credential icons from assistive tech

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -2048,11 +2048,6 @@
       "count": 2
     }
   },
-  "web/app/components/datasets/common/credential-icon.tsx": {
-    "jsx_a11y/alt-text": {
-      "count": 1
-    }
-  },
   "web/app/components/datasets/common/document-status-with-action/status-with-action.tsx": {
     "eslint-react/static-components": {
       "count": 2

--- a/web/app/components/datasets/common/__tests__/credential-icon.spec.tsx
+++ b/web/app/components/datasets/common/__tests__/credential-icon.spec.tsx
@@ -5,21 +5,30 @@ describe('CredentialIcon', () => {
   it('shows the credential initial when there is no avatar', () => {
     render(<CredentialIcon name="alice" />)
 
-    expect(screen.getByText('A')).toBeInTheDocument()
+    expect(screen.getByText('A').parentElement).toHaveAttribute('aria-hidden', 'true')
   })
 
-  it('shows the credential avatar when one is configured', () => {
-    render(<CredentialIcon avatarUrl="https://example.com/avatar.png" name="Alice" />)
+  it('hides the credential avatar from the accessibility tree', () => {
+    const { container } = render(
+      <CredentialIcon avatarUrl="https://example.com/avatar.png" name="Alice" />,
+    )
 
-    expect(screen.getByRole('img')).toHaveAttribute('src', 'https://example.com/avatar.png')
+    const image = container.querySelector('img')
+
+    expect(image).toHaveAttribute('src', 'https://example.com/avatar.png')
+    expect(image).toHaveAttribute('alt', '')
+    expect(image?.parentElement).toHaveAttribute('aria-hidden', 'true')
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
   })
 
   it('falls back to the credential initial when the avatar fails to load', () => {
-    render(<CredentialIcon avatarUrl="https://example.com/missing.png" name="Alice" />)
+    const { container } = render(
+      <CredentialIcon avatarUrl="https://example.com/missing.png" name="Alice" />,
+    )
 
-    fireEvent.error(screen.getByRole('img'))
+    fireEvent.error(container.querySelector('img')!)
 
-    expect(screen.queryByRole('img')).not.toBeInTheDocument()
-    expect(screen.getByText('A')).toBeInTheDocument()
+    expect(container.querySelector('img')).not.toBeInTheDocument()
+    expect(screen.getByText('A').parentElement).toHaveAttribute('aria-hidden', 'true')
   })
 })

--- a/web/app/components/datasets/common/credential-icon.tsx
+++ b/web/app/components/datasets/common/credential-icon.tsx
@@ -36,6 +36,7 @@ export const CredentialIcon: React.FC<CredentialIconProps> = ({
   if (avatarUrl && avatarUrl !== 'default' && showAvatar) {
     return (
       <div
+        aria-hidden="true"
         className={cn(
           'flex shrink-0 items-center justify-center overflow-hidden rounded-md border border-divider-regular',
           className,
@@ -43,6 +44,7 @@ export const CredentialIcon: React.FC<CredentialIconProps> = ({
         style={{ width: `${size}px`, height: `${size}px` }}
       >
         <img
+          alt=""
           src={avatarUrl}
           width={size}
           height={size}
@@ -55,6 +57,7 @@ export const CredentialIcon: React.FC<CredentialIconProps> = ({
 
   return (
     <div
+      aria-hidden="true"
       className={cn(
         'flex shrink-0 items-center justify-center rounded-md border border-divider-regular',
         bgColor,

--- a/web/app/components/datasets/documents/create-from-pipeline/data-source/base/credential-selector/__tests__/index.spec.tsx
+++ b/web/app/components/datasets/documents/create-from-pipeline/data-source/base/credential-selector/__tests__/index.spec.tsx
@@ -35,7 +35,7 @@ describe('CredentialSelector', () => {
       'aria-expanded',
       'false',
     )
-    expect(screen.getByRole('img')).toHaveAttribute('src', 'https://example.com/first.png')
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
   })
 
   it('selects the first credential when the current id is invalid', async () => {


### PR DESCRIPTION
## Summary

- treat the credential avatar and initial as decorative because every consumer renders the credential name beside it
- hide both visual branches and give the image empty alt text
- verify the named real consumer trigger and absence of a duplicate image role
- remove the obsolete alt-text suppression

## Review boundary

Image source, fallback, sizing, border, classes, consumer production code, and layout are unchanged.

## Verification

- component and consumer suites: 8/8 passed
- standalone a11y lint: 0 diagnostics
- full static check: 0 errors
- suppression delta: -1
- diff check: passed

## Visual regression and dependency

ARIA and alt attributes are non-visual; avatar, initial, border, alignment, and fallback remain identical. This is an independent root layer; the former React typing child is closed.