### PR TITLE
fix(web): remove workflow output title tab stop

### DIFF
--- a/oxlint-suppressions.json
+++ b/oxlint-suppressions.json
@@ -5403,9 +5403,6 @@
     }
   },
   "web/app/components/workflow/run/output-panel.tsx": {
-    "jsx_a11y/no-noninteractive-tabindex": {
-      "count": 1
-    },
     "typescript/no-explicit-any": {
       "count": 3
     }

--- a/web/app/components/workflow/run/__tests__/output-panel.spec.tsx
+++ b/web/app/components/workflow/run/__tests__/output-panel.spec.tsx
@@ -1,6 +1,7 @@
 import type { FileEntity } from '@/app/components/base/file-uploader/types'
 import type { FileResponse } from '@/types/workflow'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { TransferMethod } from '@/types/app'
 import OutputPanel from '../output-panel'
 
@@ -37,8 +38,19 @@ vi.mock('@/app/components/workflow/run/status-container', () => ({
 }))
 
 vi.mock('@/app/components/workflow/nodes/_base/components/editor/code-editor', () => ({
-  default: ({ language, value, height }: { language: string; value: string; height?: number }) => (
+  default: ({
+    language,
+    value,
+    height,
+    title,
+  }: {
+    language: string
+    value: string
+    height?: number
+    title?: React.ReactNode
+  }) => (
     <div data-height={height} data-language={language} data-testid="code-editor" data-value={value}>
+      <div>{title}</div>
       {value}
     </div>
   ),
@@ -136,6 +148,17 @@ describe('OutputPanel', () => {
   "score": 1
 }`,
     )
+  })
+
+  it('keeps the non-interactive output title out of the tab order', async () => {
+    const user = userEvent.setup()
+
+    render(<OutputPanel height={200} outputs={{ answer: 'hello', score: 1 }} />)
+
+    const outputTitle = screen.getByText('Output')
+    await user.tab()
+
+    expect(outputTitle).not.toHaveFocus()
   })
 
   it('skips the code editor when structured outputs have no positive height', () => {

--- a/web/app/components/workflow/run/output-panel.tsx
+++ b/web/app/components/workflow/run/output-panel.tsx
@@ -84,7 +84,7 @@ const OutputPanel: FC<OutputPanelProps> = ({ isRunning, outputs, error, height }
           <CodeEditor
             showFileList
             readOnly
-            title={<div tabIndex={0}>Output</div>}
+            title="Output"
             language={CodeLanguage.json}
             value={JSON.stringify(outputs, null, 2)}
             isJSONStringifyBeauty


### PR DESCRIPTION
## Summary

- Pass the read-only workflow output label to CodeEditor as text instead of a focusable non-interactive `div`.
- Remove the useless keyboard stop while preserving the existing visible label.
- Remove the exact `no-noninteractive-tabindex` suppression made obsolete by this change.

## Boundary

- No CodeEditor or Base component contract change.
- No output data, Monaco editor, copy, expand, height, or file-list behavior change.
- The three separately baselined explicit `any` uses remain out of scope.
- No new `data-testid`; the test uses visible text and a real Tab transition.

## Validation

- Added the keyboard-path test first and observed it fail because the first Tab focused the Output label.
- Focused OutputPanel tests: 10/10 passed after implementation.
- Standalone accessibility lint: passed with no diagnostics for OutputPanel.
- Full `vp check`: 0 errors; 2059 existing warnings remain baselined.
- Full ESLint, targeted lint, format, and `git diff --check`: passed.

## Visual review

- Expected visual delta: none. Base already owns the same styled title wrapper; this removes only its unstyled nested `div` and keeps the same `Output` text.
- Review cue: compare header height, left alignment, typography, copy/expand button alignment, and editor height against baseline.

## Rollback

- Revert commit `d9192daf85fd77af71546f5a3ab726a5e5f765b4`. This PR is an independent root and has no child dependency.

From Codex.