### PR TITLE
refactor(web): type credential icon props directly

### DIFF
--- a/web/app/components/datasets/common/credential-icon.tsx
+++ b/web/app/components/datasets/common/credential-icon.tsx
@@ -1,5 +1,4 @@
 import { cn } from '@langgenius/dify-ui/cn'
-import * as React from 'react'
 import { useCallback, useMemo, useState } from 'react'
 
 type CredentialIconProps = {
@@ -16,12 +15,12 @@ const ICON_BG_COLORS = [
   'bg-components-icon-bg-teal-solid',
 ]
 
-export const CredentialIcon: React.FC<CredentialIconProps> = ({
+export const CredentialIcon = ({
   avatarUrl,
   name,
   size = 20,
   className = '',
-}) => {
+}: CredentialIconProps) => {
   const [showAvatar, setShowAvatar] = useState(!!avatarUrl && avatarUrl !== 'default')
   const firstLetter = useMemo(() => name.charAt(0).toUpperCase(), [name])
   const bgColor = useMemo(


### PR DESCRIPTION
## Summary

- Type `CredentialIcon` props directly on the function parameter instead of through `React.FC`.
- Remove the now-unused React namespace import.

## Boundary

- Type-only component declaration cleanup; no production behavior, DOM, state, image, or fallback change.
- No test, suppression, consumer, or styling changes.
- This is a child of #40376 because it touches the same owner file; keeping it stacked makes this PR a one-file review and avoids an overlapping root PR.

## Validation

- CredentialIcon and real credential-selector consumer tests: 8/8 passed.
- Full `vp check`: 0 errors; 2059 existing warnings remain baselined.
- Full ESLint, targeted lint, format, and `git diff --check`: passed.

## Visual review

- Expected visual delta: strictly none. The generated JSX and all runtime expressions are unchanged; this diff only changes TypeScript annotation and an unused type namespace import.

## Rollback

- Revert commit `8968933ccd1a917670c7f2d5f4143cae41e93852`. Parent dependency: #40376. No child dependency.

From Codex.