### PR TITLE
docs(web): add Next.js agent rules

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -12,3 +12,13 @@
 - Follow `docs/overlay.md` for overlay selection and migration. Migrate a legacy overlay only when the current behavior change actually involves that overlay boundary.
 - For custom SVG icons, follow `../packages/iconify-collections/README.md`; do not add generated React icons under `app/components/base/icons/src/`.
 - `docs/test.md` is the single source of truth for frontend automated-test policy. Skills may route and execute that policy but must not redefine it.
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->


### PR DESCRIPTION
## Summary

- add the Next.js 16.3 managed agent-rules block to `web/AGENTS.md`
- direct coding agents to the version-matched documentation bundled with the installed Next.js package

## Why

Next.js 16.3 automatically adds this managed block when `next dev` detects an AI coding environment. Committing the generated block prevents repeated uncommitted changes while preserving the existing repository-specific guidance.

## Impact

Documentation and coding-agent guidance only. There is no application runtime, build, lint, or test behavior change.

## Validation

- verified the managed block with `hasCurrentAgentRules('./web')` from the installed Next.js package
- `git diff --check`