### PR TITLE
fix(web): allow unlimited text input in trial apps

### DIFF
--- a/web/app/components/share/text-generation/run-once/__tests__/index.spec.tsx
+++ b/web/app/components/share/text-generation/run-once/__tests__/index.spec.tsx
@@ -493,7 +493,7 @@ describe('RunOnce', () => {
   })
 
   describe('maxLength behavior', () => {
-    it('should not have maxLength attribute when max_length is not set', async () => {
+    it('should not have maxLength attribute when max_length is zero', async () => {
       const promptConfig: PromptConfig = {
         prompt_template: 'template',
         prompt_variables: [
@@ -501,6 +501,7 @@ describe('RunOnce', () => {
             key: 'textInput',
             name: 'Text Input',
             type: 'string',
+            max_length: 0,
           }),
         ],
       }

--- a/web/app/components/share/text-generation/run-once/index.tsx
+++ b/web/app/components/share/text-generation/run-once/index.tsx
@@ -176,7 +176,7 @@ const RunOnce: FC<IRunOnceProps> = ({
                                 [item.key]: e.target.value,
                               })
                             }}
-                            maxLength={item.max_length}
+                            maxLength={item.max_length || undefined}
                           />
                         )}
                         {item.type === 'paragraph' && (


### PR DESCRIPTION
## Summary
<img width="2726" height="1728" alt="image" src="https://github.com/user-attachments/assets/f17e2d7b-b51c-438d-aa47-a4b32f64cb2b" />

the user can't input in the text-input of the try-app's workflow


- omit the native `maxlength` attribute when a text input uses `max_length: 0`
- add regression coverage for the unlimited-length case

## Root cause

Dify uses `max_length: 0` to represent an unlimited text input. Passing that value directly to the native HTML input produced `maxlength="0"`, causing the browser to reject every typed character.

## Validation

- `pnpm --dir web test app/components/share/text-generation/run-once/__tests__/index.spec.tsx --run` — 17 passed
- `pnpm --dir web type-check`
- staged-file `vp check --fix` pre-commit hook
- manually verified the Daily AI Trend Digest trial input before and after the fix

From Codex
