### PR TITLE
fix(api): surface last failure detail when SSRF proxy retries are exhausted

### DIFF
--- a/api/core/helper/ssrf_proxy.py
+++ b/api/core/helper/ssrf_proxy.py
@@ -224,6 +224,7 @@ def make_request(
         send_kwargs["follow_redirects"] = kwargs.pop("follow_redirects")
 
     retries = 0
+    last_failure_detail: str | None = None
     while retries <= max_retries:
         try:
             # Preserve the user-provided Host header
@@ -271,17 +272,20 @@ def make_request(
                     response.status_code,
                     url,
                 )
+                last_failure_detail = f"last response status was HTTP {response.status_code}"
                 response.close()
 
         except httpx.RequestError as e:
             logger.warning("Request to URL %s failed on attempt %s: %s", url, retries + 1, e)
             if max_retries == 0:
                 raise
+            last_failure_detail = f"last attempt failed with {e}"
 
         retries += 1
         if retries <= max_retries:
             time.sleep(BACKOFF_FACTOR * (2 ** (retries - 1)))
-    raise MaxRetriesExceededError(f"Reached maximum retries ({max_retries}) for URL {url}")
+    detail_suffix = f" ({last_failure_detail})" if last_failure_detail else ""
+    raise MaxRetriesExceededError(f"Reached maximum retries ({max_retries}) for URL {url}{detail_suffix}")
 
 
 def buffer_response(response: httpx.Response, *, max_response_bytes: int) -> httpx.Response:

--- a/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
+++ b/api/tests/unit_tests/core/helper/test_ssrf_proxy.py
@@ -124,7 +124,10 @@ def test_retry_exceed_max_retries(mock_get_client):
 
     with pytest.raises(Exception) as e:
         make_request("GET", "http://example.com", max_retries=SSRF_DEFAULT_MAX_RETRIES - 1)
-    assert str(e.value) == f"Reached maximum retries ({SSRF_DEFAULT_MAX_RETRIES - 1}) for URL http://example.com"
+    assert str(e.value) == (
+        f"Reached maximum retries ({SSRF_DEFAULT_MAX_RETRIES - 1}) for URL http://example.com "
+        "(last response status was HTTP 500)"
+    )
 
 
 @patch("core.helper.ssrf_proxy._get_ssrf_client", autospec=True)


### PR DESCRIPTION
Fixes #40401

## Summary

- `core.helper.ssrf_proxy.make_request` raised `MaxRetriesExceededError` with only the URL and retry count once all retries were exhausted, discarding the reason the last attempt failed (a forced-retry HTTP status, or a connection/timeout error).
- In #40401 the reporter's external knowledge (RAGFlow) hit-testing request kept getting HTTP 500 from the retrieval endpoint. That failure propagates through `ExternalDatasetService.fetch_external_knowledge_retrieval` and `ExternalKnowledgeHitTestingApi.post`, both of which just re-raise `str(e)`, so the console ends up showing a bare "Reached maximum retries (3) for URL ..." with no indication of *why* — the user has to go dig through container logs to learn it was an upstream 500.
- This PR tracks the last failure (either the forced-retry status code or the request exception) and appends it to the final error message, e.g. `Reached maximum retries (3) for URL http://.../retrieval (last response status was HTTP 500)`. This doesn't change retry behavior or any return value, only the exhausted-retries error message.

## Test plan

- Added/updated `test_retry_exceed_max_retries` in `api/tests/unit_tests/core/helper/test_ssrf_proxy.py` to assert the new message includes the last response status.
- Verified the updated assertion fails against the pre-fix code (`git checkout HEAD~1 -- api/core/helper/ssrf_proxy.py`) and passes after restoring the fix.
- `uv run --project api pytest -o addopts="" api/tests/unit_tests/core/helper/` → 197 passed.
- `uv run --project api pytest -o addopts="" api/tests/unit_tests/core/mcp/auth/test_auth_flow.py api/tests/unit_tests/services/test_external_dataset_service.py` → 158 passed.
- `uv run --project api --group dev ruff check` / `ruff format --check` on the changed files → clean.

## AI disclosure

This change was authored with the assistance of an AI coding agent (Claude Code), with the diff and test results reviewed before submission.
