### PR TITLE
fix: add zh_Hans labels for builtin Audio provider and its tools

### DIFF
--- a/api/core/tools/builtin_tool/providers/audio/audio.yaml
+++ b/api/core/tools/builtin_tool/providers/audio/audio.yaml
@@ -3,6 +3,7 @@ identity:
   name: audio
   label:
     en_US: Audio
+    zh_Hans: 音频
   description:
     en_US: A tool for tts and asr.
     zh_Hans: 一个用于文本转语音和语音转文本的工具。

--- a/api/core/tools/builtin_tool/providers/audio/tools/asr.yaml
+++ b/api/core/tools/builtin_tool/providers/audio/tools/asr.yaml
@@ -3,6 +3,7 @@ identity:
   author: hjlarry
   label:
     en_US: Speech To Text
+    zh_Hans: 语音转文本
 description:
   human:
     en_US: Convert audio file to text.

--- a/api/core/tools/builtin_tool/providers/audio/tools/tts.yaml
+++ b/api/core/tools/builtin_tool/providers/audio/tools/tts.yaml
@@ -3,6 +3,7 @@ identity:
   author: hjlarry
   label:
     en_US: Text To Speech
+    zh_Hans: 文本转语音
 description:
   human:
     en_US: Convert text to audio file.


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #40406`.

## Summary

Add the missing `zh_Hans` labels for the built-in **Audio** provider and its two tools so the Chinese console no longer shows the raw English labels.

Drafted for:

- `api/core/tools/builtin_tool/providers/audio/audio.yaml`
- `api/core/tools/builtin_tool/providers/audio/tools/asr.yaml`
- `api/core/tools/builtin_tool/providers/audio/tools/tts.yaml`

```diff
  identity:
    name: audio
    label:
      en_US: Audio
+     zh_Hans: 音频
```

```diff
  identity:
    name: asr
    label:
      en_US: Speech To Text
+     zh_Hans: 语音转文本
```

```diff
  identity:
    name: tts
    label:
      en_US: Text To Speech
+     zh_Hans: 文本转语音
```

These are the only built-in provider/tool entries that omit `zh_Hans` in `identity.label`; `code`, `time` and `webscraper` all ship a `zh_Hans` label. The added wording mirrors the `zh_Hans` translations already present in the same files' `description` field (`一个用于文本转语音和语音转文本的工具。`, `将音频文件转换为文本。`), so no new translations are introduced.

Fixes #40406

## Screenshots

| Before | After |
| ------ | ----- |
| Audio tool labels show raw English in zh-Hans locale | Audio tool labels show Chinese (`音频` / `语音转文本` / `文本转语音`) |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods