### PR TITLE
fix(api): grant access to default file values for WebApp requests

### DIFF
--- a/api/core/app/apps/base_app_generator.py
+++ b/api/core/app/apps/base_app_generator.py
@@ -13,7 +13,12 @@ from core.app.apps.draft_variable_saver import (
     NoopDraftVariableSaver,
 )
 from core.app.entities.app_invoke_entities import InvokeFrom, UserFrom
-from core.app.file_access import DatabaseFileAccessController, FileAccessScope, bind_file_access_scope
+from core.app.file_access import (
+    DatabaseFileAccessController,
+    FileAccessScope,
+    bind_file_access_scope,
+    grant_upload_file_access,
+)
 from extensions.ext_database import db
 from factories import file_factory
 from graphon.enums import NodeType
@@ -216,6 +221,18 @@ class BaseAppGenerator:
             # If default is also None, return None directly
             if value is None:
                 return None
+            # File defaults are configured by the app builder, not the requesting
+            # user, so grant access explicitly or end-user-scoped requests (e.g.
+            # WebApp) would reject them as not owned by the current user.
+            if variable_entity.type in {VariableEntityType.FILE, VariableEntityType.FILE_LIST}:
+                mappings = value if isinstance(value, list) else [value]
+                grant_upload_file_access(
+                    file_id
+                    for mapping in mappings
+                    if isinstance(mapping, dict)
+                    for file_id in [file_factory.resolve_mapping_file_id(mapping, "upload_file_id")]
+                    if file_id
+                )
 
         # Treat empty placeholders for optional file inputs as unset
         if (

--- a/api/factories/file_factory/__init__.py
+++ b/api/factories/file_factory/__init__.py
@@ -6,6 +6,7 @@ exports the workflow-facing file builders for callers.
 """
 
 from .builders import build_from_mapping, build_from_mappings
+from .common import resolve_mapping_file_id
 from .message_files import build_from_message_file, build_from_message_files
 from .storage_keys import StorageKeyLoader
 
@@ -15,4 +16,5 @@ __all__ = [
     "build_from_mappings",
     "build_from_message_file",
     "build_from_message_files",
+    "resolve_mapping_file_id",
 ]

--- a/api/tests/unit_tests/core/app/apps/test_base_app_generator.py
+++ b/api/tests/unit_tests/core/app/apps/test_base_app_generator.py
@@ -6,6 +6,8 @@ import pytest
 from sqlalchemy import inspect
 
 from core.app.apps.base_app_generator import BaseAppGenerator
+from core.app.entities.app_invoke_entities import InvokeFrom, UserFrom
+from core.app.file_access import FileAccessScope, bind_file_access_scope, get_current_file_access_scope
 from graphon.variables.input_entities import VariableEntity, VariableEntityType
 from models import Workflow, WorkflowRun
 
@@ -297,6 +299,33 @@ def test_validate_inputs_with_default_value():
     )
 
     assert result == [{"id": "file1", "name": "doc1.pdf"}, {"id": "file2", "name": "doc2.pdf"}]
+
+
+def test_validate_inputs_file_list_default_grants_upload_file_access():
+    """FILE_LIST default values are configured by the app builder, not the end
+    user making the request, so WebApp requests (which scope file lookups to
+    files owned by the current end user) must have the default's upload files
+    explicitly granted or they are rejected as invalid."""
+    base_app_generator = BaseAppGenerator()
+
+    var_file_list = VariableEntity(
+        variable="test_file_list",
+        label="test_file_list",
+        type=VariableEntityType.FILE_LIST,
+        required=False,
+        default=[{"transfer_method": "local_file", "upload_file_id": "default-file-id"}],
+    )
+
+    scope = FileAccessScope(
+        tenant_id="tenant-1",
+        user_id="end-user-1",
+        user_from=UserFrom.END_USER,
+        invoke_from=InvokeFrom.WEB_APP,
+    )
+
+    with bind_file_access_scope(scope):
+        base_app_generator._validate_inputs(variable_entity=var_file_list, value=None)
+        assert "default-file-id" in get_current_file_access_scope().granted_upload_file_ids
 
 
 def test_validate_inputs_optional_file_with_empty_string():


### PR DESCRIPTION
## Summary

Fixes #40411

When a File / File List input has a configured **Default Value** and the user leaves it unset, the default's `upload_file_id` was uploaded by the account that configured it in the app builder. Console **Preview** runs as that account, so lookups aren't scoped to a specific user and the default resolves fine. Accessing the same app through the **WebApp**, however, runs as an end user, and `DatabaseFileAccessController.apply_upload_file_filters` scopes upload-file lookups to files owned by that end user. Because the default file was never "owned" by the end user (nor previously granted), the lookup returns no row and `factories/file_factory/builders.py::_build_from_local_file` raises `ValueError("Invalid upload file")`, matching the traceback in the issue.

## Root cause

`BaseAppGenerator._validate_inputs` substitutes `variable_entity.default` when no value was supplied, but never made the resulting file mapping's `upload_file_id` visible to the end-user-scoped access controller.

## Fix

When a FILE/FILE_LIST default value is substituted, grant the current file access scope access to the default's `upload_file_id`(s) via the existing `grant_upload_file_access` mechanism (the same mechanism already used elsewhere, e.g. for trusted retriever attachments), so the file resolves correctly regardless of which user (account or end user) is making the request.

## Test plan

Added `test_validate_inputs_file_list_default_grants_upload_file_access` in `api/tests/unit_tests/core/app/apps/test_base_app_generator.py`, which binds an end-user `FileAccessScope` and asserts the default value's `upload_file_id` is granted after `_validate_inputs` substitutes the default.

Confirmed the new test fails without the fix:

```
$ git checkout HEAD~1 -- api/core/app/apps/base_app_generator.py api/factories/file_factory/__init__.py
$ uv run pytest -o addopts="" tests/unit_tests/core/app/apps/test_base_app_generator.py -k grants_upload_file_access -q
...
E           AssertionError: assert 'default-file-id' in frozenset()
1 failed, 20 deselected, 1 warning in 1.36s
$ git checkout HEAD -- api/core/app/apps/base_app_generator.py api/factories/file_factory/__init__.py
```

And passes with the fix:

```
$ uv run pytest -o addopts="" tests/unit_tests/core/app/apps/test_base_app_generator.py -q
21 passed, 1 warning in 1.11s

$ uv run pytest -o addopts="" tests/unit_tests/factories/test_file_factory.py tests/unit_tests/core/app/apps/test_base_app_generator.py tests/unit_tests/core/app/apps/advanced_chat/test_app_generator.py tests/unit_tests/core/app/apps/workflow/test_app_generator_extra.py -q
99 passed, 2 warnings in 2.35s
```

Also ran lint/format on the changed files:

```
$ uv run --directory api --dev ruff check core/app/apps/base_app_generator.py factories/file_factory/__init__.py tests/unit_tests/core/app/apps/test_base_app_generator.py
All checks passed!

$ uv run --directory api --dev ruff format --check core/app/apps/base_app_generator.py factories/file_factory/__init__.py tests/unit_tests/core/app/apps/test_base_app_generator.py
3 files already formatted
```

(A handful of unrelated test modules fail to collect in this sandbox due to a missing `pytest_mock` dependency; confirmed this happens identically on unmodified `main`.)

---

This PR was prepared with AI assistance (Claude).
