### PR TITLE
feat(docker): load ssrf_proxy config from envs/infrastructure with .env override

### DIFF
--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -728,6 +728,11 @@ services:
   # for more information, please refer to
   # https://docs.dify.ai/learn-more/faq/install-faq#18-why-is-ssrf-proxy-needed%3F
   ssrf_proxy:
+    env_file:
+      - path: ./envs/infrastructure/ssrf-proxy.env
+        required: false
+      - path: ./.env
+        required: false
     image: ubuntu/squid:latest
     restart: always
     volumes:
@@ -744,8 +749,6 @@ services:
       # pls clearly modify the squid env vars to fit your network environment.
       HTTP_PORT: ${SSRF_HTTP_PORT:-3128}
       COREDUMP_DIR: ${SSRF_COREDUMP_DIR:-/var/spool/squid}
-      SSRF_PROXY_ALLOW_PRIVATE_IPS: ${SSRF_PROXY_ALLOW_PRIVATE_IPS:-}
-      SSRF_PROXY_ALLOW_PRIVATE_DOMAINS: ${SSRF_PROXY_ALLOW_PRIVATE_DOMAINS:-}
     networks:
       - ssrf_proxy_network
       - default

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -734,6 +734,11 @@ services:
   # for more information, please refer to
   # https://docs.dify.ai/learn-more/faq/install-faq#18-why-is-ssrf-proxy-needed%3F
   ssrf_proxy:
+    env_file:
+      - path: ./envs/infrastructure/ssrf-proxy.env
+        required: false
+      - path: ./.env
+        required: false
     image: ubuntu/squid:latest
     restart: always
     volumes:
@@ -750,8 +755,6 @@ services:
       # pls clearly modify the squid env vars to fit your network environment.
       HTTP_PORT: ${SSRF_HTTP_PORT:-3128}
       COREDUMP_DIR: ${SSRF_COREDUMP_DIR:-/var/spool/squid}
-      SSRF_PROXY_ALLOW_PRIVATE_IPS: ${SSRF_PROXY_ALLOW_PRIVATE_IPS:-}
-      SSRF_PROXY_ALLOW_PRIVATE_DOMAINS: ${SSRF_PROXY_ALLOW_PRIVATE_DOMAINS:-}
     networks:
       - ssrf_proxy_network
       - default


### PR DESCRIPTION
## Summary

`SSRF_PROXY_ALLOW_PRIVATE_IPS` and `SSRF_PROXY_ALLOW_PRIVATE_DOMAINS` are documented to live in `envs/infrastructure/ssrf-proxy.env`, but the current `docker-compose.yaml` only wires them through `environment:` interpolation (`${SSRF_PROXY_ALLOW_PRIVATE_IPS:-}`), which reads from the root `.env` only. As a result, editing those variables in `envs/infrastructure/ssrf-proxy.env` has no effect.

This PR makes the `ssrf_proxy` service load `envs/infrastructure/ssrf-proxy.env` (mirroring how the other infrastructure env files are loaded), while still reading `./.env` last so root `.env` values take precedence — exactly the convention documented in `docker/README.md`:

> Docker Compose reads `envs/*.env` files when present, then reads `.env` last so values in `.env` take precedence.

Note that configuring these variables in `.env` is also fragile today: `dify-env-sync` strips them from the root `.env` on every upgrade (they belong to the `envs/` category, not the root `.env.example`), forcing reconfiguration after each update. `envs/infrastructure/ssrf-proxy.env` is the natural home per the project's env-file design, and this PR makes that path work end to end.

`docker-compose.yaml` is auto-generated from `docker-compose-template.yaml` via `docker/generate_docker_compose`; both files are updated consistently in this PR.

Fixes #40415

## Screenshots

N/A — docker compose configuration change, no UI.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods

From OpenCode
