### PR TITLE
fix(web): allow unlimited text input in trial apps

### DIFF
--- a/web/app/components/share/text-generation/run-once/__tests__/index.spec.tsx
+++ b/web/app/components/share/text-generation/run-once/__tests__/index.spec.tsx
@@ -493,7 +493,7 @@ describe('RunOnce', () => {
   })
 
   describe('maxLength behavior', () => {
-    it('should not have maxLength attribute when max_length is not set', async () => {
+    it('should not have maxLength attribute when max_length is zero', async () => {
       const promptConfig: PromptConfig = {
         prompt_template: 'template',
         prompt_variables: [
@@ -501,6 +501,7 @@ describe('RunOnce', () => {
             key: 'textInput',
             name: 'Text Input',
             type: 'string',
+            max_length: 0,
           }),
         ],
       }

--- a/web/app/components/share/text-generation/run-once/index.tsx
+++ b/web/app/components/share/text-generation/run-once/index.tsx
@@ -175,7 +175,7 @@ const RunOnce: FC<IRunOnceProps> = ({
                                 [item.key]: e.target.value,
                               })
                             }}
-                            maxLength={item.max_length}
+                            maxLength={item.max_length || undefined}
                           />
                         )}
                         {item.type === 'paragraph' && (


### PR DESCRIPTION
## Summary

Backport of #40403 to `hotfix/1.16.1-fix.4`.

- omit the native `maxlength` attribute when a text input uses `max_length: 0`
- add regression coverage for the unlimited-length case

## Root cause

Dify uses `max_length: 0` to represent an unlimited text input. Passing that value directly to the native HTML input produced `maxlength="0"`, causing the browser to reject every typed character.

## Impact

Users can type into unlimited-length text inputs in trial apps again. Positive max-length limits continue to be enforced.

## Validation

- compared the backport branch against `hotfix/1.16.1-fix.4`: only the two expected files changed (3 additions, 2 deletions)
- verified the final implementation and regression-test contents on the remote branch
- upstream PR #40403 passed its focused test suite (17 tests) and web type-check
- tests were not rerun on the hotfix branch because the full repository checkout timed out in this environment
