### PR TITLE
docs(web): clarify ref mutation ownership

### DIFF
--- a/.agents/skills/how-to-write-component/references/runtime.md
+++ b/.agents/skills/how-to-write-component/references/runtime.md
@@ -4,6 +4,7 @@ Read this document when a change introduces Effects, navigation side effects, me
 
 ## Effects
 
+- Keep render pure: do not read or write `ref.current` during render except for predictable null-guarded lazy initialization. Update interaction-owned refs in event handlers, synchronize external-system refs after commit, and use state or derivation for rendered values.
 - Use Effects only to synchronize with a named external system such as a browser API, subscription, timer, analytics integration, non-React widget, or imperative DOM API.
 - Do not use Effects to transform render state, handle user actions, copy query data, reset state from props, or fetch data owned by framework APIs or TanStack Query.
 - Initialize query-backed forms with keyed remounts or surface-entry hydration instead of copying data through Effects.


### PR DESCRIPTION
## Summary

Clarify the component runtime guidance for render purity and ref ownership.

## Why

React may replay or discard render work. Mutating externally visible ref state during render can therefore leak values from a tree that never commits.

## Changes

- Require render to remain pure.
- Keep interaction-owned ref writes in event handlers.
- Synchronize external-system refs after commit.
- Allow only predictable null-guarded lazy initialization during render.
- Recommend state or render-time derivation for values that affect rendered output.

The guidance is intentionally concise and tool-independent.

## Verification

- Documentation-only diff.
- Stack-level verification is recorded in #40429.

## Stack

This is PR 1 of 4 and is based on main.

| Order | PR | Scope |
| --- | --- | --- |
| 1 | [#40426](https://github.com/langgenius/dify/pull/40426) | Component guidance |
| 2 | [#40427](https://github.com/langgenius/dify/pull/40427) | Shared refs and persisted debug config |
| 3 | [#40428](https://github.com/langgenius/dify/pull/40428) | Workflow ownership |
| 4 | [#40429](https://github.com/langgenius/dify/pull/40429) | Agent V2, new RAG, and useMitt |

## Screenshots

Not applicable.

From Codex

