### PR TITLE
fix(web): keep agent ref updates out of render

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/__tests__/use-agent-configure-sync.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/__tests__/use-agent-configure-sync.spec.tsx
@@ -4,6 +4,7 @@ import type { AgentSoulConfigFormState } from '@/features/agent-v2/agent-compose
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, renderHook } from '@testing-library/react'
 import { createStore, Provider as JotaiProvider } from 'jotai'
+import { Suspense } from 'react'
 import { CollectionType } from '@/app/components/tools/types'
 import { MetadataFilteringModeEnum } from '@/app/components/workflow/nodes/knowledge-retrieval/types'
 import { defaultAgentSoulConfigFormState } from '@/features/agent-v2/agent-composer/form-state'
@@ -236,11 +237,13 @@ function renderUseAgentConfigureSync({
   baseConfig,
   currentModel,
   enabled = true,
+  suspend = false,
 }: {
   agentName?: Parameters<typeof useAgentConfigureSync>[0]['agentName']
   baseConfig?: Parameters<typeof useAgentConfigureSync>[0]['baseConfig']
   currentModel?: Parameters<typeof useAgentConfigureSync>[0]['currentModel']
   enabled?: boolean
+  suspend?: boolean
 } = {}) {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -249,23 +252,39 @@ function renderUseAgentConfigureSync({
     },
   })
   const store = createStore()
+  const pendingRender = new Promise<void>(() => {})
   const wrapper = ({ children }: PropsWithChildren) => (
     <QueryClientProvider client={queryClient}>
-      <JotaiProvider store={store}>{children}</JotaiProvider>
+      <JotaiProvider store={store}>
+        <Suspense fallback={null}>{children}</Suspense>
+      </JotaiProvider>
     </QueryClientProvider>
   )
 
   return {
     ...renderHook(
-      () =>
-        useAgentConfigureSync({
+      (props) => {
+        const sync = useAgentConfigureSync({
           agentId: 'agent-1',
+          agentName: props.agentName,
+          baseConfig: props.baseConfig,
+          currentModel: props.currentModel,
+          enabled: props.enabled,
+        })
+        if (props.suspend) throw pendingRender
+
+        return sync
+      },
+      {
+        initialProps: {
           agentName,
           baseConfig,
           currentModel,
           enabled,
-        }),
-      { wrapper },
+          suspend,
+        },
+        wrapper,
+      },
     ),
     queryClient,
     store,
@@ -374,6 +393,93 @@ describe('useAgentConfigureSync', () => {
     })
   })
 
+  it('should autosave only the latest committed Agent configuration', async () => {
+    const committedProps = {
+      agentName: 'Agent',
+      baseConfig: {
+        app_features: {
+          file_upload: {
+            enabled: true,
+          },
+        },
+      },
+      currentModel: configuredModel,
+      enabled: true,
+      suspend: false,
+    }
+    const nextProps = {
+      agentName: 'Agent',
+      baseConfig: {
+        app_features: {
+          file_upload: {
+            enabled: false,
+          },
+        },
+      },
+      currentModel: {
+        provider: 'langgenius/anthropic/anthropic',
+        model: 'claude-3-5-sonnet',
+      },
+      enabled: true,
+      suspend: true,
+    }
+    const { rerender, store } = renderUseAgentConfigureSync(committedProps)
+
+    rerender(nextProps)
+    act(() => {
+      store.set(agentComposerDraftAtom, {
+        ...defaultAgentSoulConfigFormState,
+        prompt: 'Draft while the next configuration is pending',
+      })
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+
+    expect(composerPutMutationFn).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          agent_soul: expect.objectContaining({
+            app_features: expect.objectContaining({
+              file_upload: expect.objectContaining({ enabled: true }),
+            }),
+            model: expect.objectContaining({
+              model: 'gpt-4o-mini',
+              model_provider: 'langgenius/openai/openai',
+            }),
+          }),
+        }),
+      }),
+    )
+
+    rerender({ ...nextProps, suspend: false })
+    act(() => {
+      store.set(agentComposerDraftAtom, {
+        ...defaultAgentSoulConfigFormState,
+        prompt: 'Draft after the next configuration commits',
+      })
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+
+    expect(composerPutMutationFn).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          agent_soul: expect.objectContaining({
+            app_features: expect.objectContaining({
+              file_upload: expect.objectContaining({ enabled: false }),
+            }),
+            model: expect.objectContaining({
+              model: 'claude-3-5-sonnet',
+              model_provider: 'langgenius/anthropic/anthropic',
+            }),
+          }),
+        }),
+      }),
+    )
+  })
+
   it('should cancel pending autosave when the draft returns to the saved baseline', async () => {
     const { queryClient, store } = renderUseAgentConfigureSync()
     queryClient.setQueryData(['agent-detail', 'agent-1'], {
@@ -446,6 +552,61 @@ describe('useAgentConfigureSync', () => {
       saveDeferred.resolve({ agent_soul: {} })
       await Promise.resolve()
     })
+  })
+
+  it('should keep page-close saving enabled until a disabled configuration commits', async () => {
+    const committedProps = {
+      agentName: 'Agent',
+      baseConfig: undefined,
+      currentModel: configuredModel,
+      enabled: true,
+      suspend: false,
+    }
+    const disabledProps = {
+      ...committedProps,
+      enabled: false,
+      suspend: true,
+    }
+    const { rerender, store } = renderUseAgentConfigureSync(committedProps)
+
+    rerender(disabledProps)
+    act(() => {
+      store.set(agentComposerDraftAtom, {
+        ...defaultAgentSoulConfigFormState,
+        prompt: 'Committed draft before closing',
+      })
+    })
+    await act(async () => {
+      window.dispatchEvent(new Event('beforeunload'))
+      await Promise.resolve()
+    })
+
+    expect(composerPutMutationFn).toHaveBeenCalledTimes(1)
+    expect(composerPutMutationFn).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          agent_soul: expect.objectContaining({
+            prompt: expect.objectContaining({
+              system_prompt: 'Committed draft before closing',
+            }),
+          }),
+        }),
+      }),
+    )
+
+    rerender({ ...disabledProps, suspend: false })
+    act(() => {
+      store.set(agentComposerDraftAtom, {
+        ...defaultAgentSoulConfigFormState,
+        prompt: 'Disabled draft after commit',
+      })
+    })
+    await act(async () => {
+      window.dispatchEvent(new Event('beforeunload'))
+      await Promise.resolve()
+    })
+
+    expect(composerPutMutationFn).toHaveBeenCalledTimes(1)
   })
 
   it('should dispatch the latest keepalive save while an earlier save is pending', async () => {

--- a/web/features/agent-v2/agent-detail/configure/components/composer-session.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/composer-session.tsx
@@ -12,7 +12,7 @@ import { toast } from '@langgenius/dify-ui/toast'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { ScopeProvider } from 'jotai-scope'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { trackEvent } from '@/app/components/base/amplitude'
 import Loading from '@/app/components/base/loading'
@@ -94,11 +94,14 @@ export function AgentConfigureComposerScope({
     onModeChange: onRightPanelModeChange,
   })
 
+  useEffect(() => {
+    if (!buildDraft.isPending) initializedComposerAgentIdRef.current = agentId
+  }, [agentId, buildDraft.isPending])
+
   if (buildDraft.isPending && initializedComposerAgentIdRef.current !== agentId) {
     return <AgentConfigurePageLoading label={t(($) => $['agentDetail.sections.configure'])} />
   }
 
-  initializedComposerAgentIdRef.current = agentId
   const composerHydrationState = composerQuery.data === undefined ? 'unavailable' : 'loaded'
   const composerSessionKey = `${agentId}:${activeVersionId ?? selectedVersionId ?? 'draft'}:${composerHydrationState}:${composerRebaseRevision}`
 

--- a/web/features/agent-v2/agent-detail/configure/components/orchestrate/add-actions-context.ts
+++ b/web/features/agent-v2/agent-detail/configure/components/orchestrate/add-actions-context.ts
@@ -50,7 +50,9 @@ export function useRegisterAgentOrchestrateAddAction(
   const registerAction = context?.registerAction
   const actionRef = useRef(action)
 
-  actionRef.current = action
+  useEffect(() => {
+    actionRef.current = action
+  }, [action])
 
   const stableAction = useCallback<AgentOrchestrateAddAction>((options) => {
     actionRef.current(options)

--- a/web/features/agent-v2/agent-detail/configure/use-agent-configure-sync.ts
+++ b/web/features/agent-v2/agent-detail/configure/use-agent-configure-sync.ts
@@ -64,9 +64,11 @@ export function useAgentConfigureSync({
   const explicitlySavingDraftKeysRef = useRef(new Set<string>())
   const publishInFlightRef = useRef(false)
 
-  baseConfigRef.current = baseConfig
-  currentModelRef.current = currentModel
-  enabledRef.current = enabled
+  useEffect(() => {
+    baseConfigRef.current = baseConfig
+    currentModelRef.current = currentModel
+    enabledRef.current = enabled
+  }, [baseConfig, currentModel, enabled])
 
   const getAgentSoulDraft = useCallback(
     () =>
@@ -246,14 +248,16 @@ export function useAgentConfigureSync({
   )
 
   const latestDraftSaveRef = useRef<() => void>(() => undefined)
-  latestDraftSaveRef.current = () => {
-    const draft = store.get(agentComposerDraftAtom)
+  useEffect(() => {
+    latestDraftSaveRef.current = () => {
+      const draft = store.get(agentComposerDraftAtom)
 
-    void saveComposer({
-      configSnapshot: getAgentSoulDraft(),
-      draftBaseline: draft,
-    })
-  }
+      void saveComposer({
+        configSnapshot: getAgentSoulDraft(),
+        draftBaseline: draft,
+      })
+    }
+  }, [getAgentSoulDraft, saveComposer, store])
 
   const debouncedSaveDraft = useMemo(
     () =>

--- a/web/features/new-rag/document-chunk-tree.tsx
+++ b/web/features/new-rag/document-chunk-tree.tsx
@@ -72,7 +72,9 @@ export function DocumentChunkTreePanel({
     },
   })
   const rowVirtualizerRef = useRef(rowVirtualizer)
-  rowVirtualizerRef.current = rowVirtualizer
+  useEffect(() => {
+    rowVirtualizerRef.current = rowVirtualizer
+  }, [rowVirtualizer])
   const virtualRows = rowVirtualizer.getVirtualItems()
 
   const toggleExpanded = (chunkId: string) => {

--- a/web/features/new-rag/use-document-reindex.ts
+++ b/web/features/new-rag/use-document-reindex.ts
@@ -68,7 +68,9 @@ export function useDocumentReindex({
   })
   const { latestTask, taskIsActive } = taskStatus
   const latestTaskRef = useRef(latestTask)
-  latestTaskRef.current = latestTask
+  useEffect(() => {
+    latestTaskRef.current = latestTask
+  }, [latestTask])
   const submittedTaskObserved = Boolean(
     latestTask &&
     submittedReindex &&

--- a/web/hooks/use-mitt.spec.ts
+++ b/web/hooks/use-mitt.spec.ts
@@ -1,0 +1,74 @@
+import type { Emitter } from 'mitt'
+import { act, renderHook } from '@testing-library/react'
+import create from 'mitt'
+import { useMitt } from './use-mitt'
+
+type Events = {
+  [key: string]: unknown
+  [key: symbol]: unknown
+  message: string
+}
+
+function renderMittHook(initialEmitter?: Emitter<Events>) {
+  const handler = vi.fn()
+  const hook = renderHook(
+    ({ emitter }: { emitter?: Emitter<Events> }) => {
+      const mitt = useMitt<Events>(emitter)
+      mitt.useSubscribe('message', handler)
+      return mitt
+    },
+    { initialProps: { emitter: initialEmitter } },
+  )
+
+  return { ...hook, handler }
+}
+
+describe('useMitt', () => {
+  it('keeps its internal emitter stable across renders', () => {
+    const { handler, rerender, result } = renderMittHook()
+    const initialEmit = result.current.emit
+
+    act(() => result.current.emit('message', 'before rerender'))
+    rerender({ emitter: undefined })
+    act(() => result.current.emit('message', 'after rerender'))
+
+    expect(result.current.emit).toBe(initialEmit)
+    expect(handler).toHaveBeenNthCalledWith(1, 'before rerender')
+    expect(handler).toHaveBeenNthCalledWith(2, 'after rerender')
+  })
+
+  it('moves subscriptions to a new external emitter', () => {
+    const emitterA = create<Events>()
+    const emitterB = create<Events>()
+    const { handler, rerender, result } = renderMittHook(emitterA)
+
+    rerender({ emitter: emitterB })
+    act(() => {
+      emitterA.emit('message', 'old emitter')
+      result.current.emit('message', 'new emitter')
+    })
+
+    expect(handler).toHaveBeenCalledOnce()
+    expect(handler).toHaveBeenCalledWith('new emitter')
+  })
+
+  it('keeps the latest external emitter when the optional emitter is removed', () => {
+    const emitterA = create<Events>()
+    const emitterB = create<Events>()
+    const latestEmitterHandler = vi.fn()
+    const latestWildcardHandler = vi.fn()
+    emitterB.on('message', latestEmitterHandler)
+    emitterB.on('*', latestWildcardHandler)
+    const { handler, rerender, result } = renderMittHook(emitterA)
+
+    rerender({ emitter: emitterB })
+    rerender({ emitter: undefined })
+    act(() => result.current.emit('message', 'latest emitter'))
+
+    expect(latestEmitterHandler).toHaveBeenCalledOnce()
+    expect(latestEmitterHandler).toHaveBeenCalledWith('latest emitter')
+    expect(latestWildcardHandler).toHaveBeenCalledWith('message', 'latest emitter')
+    expect(handler).toHaveBeenCalledOnce()
+    expect(handler).toHaveBeenCalledWith('latest emitter')
+  })
+})

--- a/web/hooks/use-mitt.ts
+++ b/web/hooks/use-mitt.ts
@@ -1,6 +1,6 @@
 import type { Emitter, EventType, Handler, WildcardHandler } from 'mitt'
 import create from 'mitt'
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 const merge = <T extends Record<string, any>>(...args: Array<T | undefined>): T => {
   return Object.assign({}, ...args)
@@ -35,14 +35,20 @@ const defaultSubscribeOption: UseSubscribeOption = {
 }
 
 function useMitt<Events extends _Events>(mitt?: Emitter<Events>): UseMittReturn<Events> {
-  const emitterRef = useRef<Emitter<Events> | undefined>(undefined)
-  if (!emitterRef.current) emitterRef.current = mitt ?? create<Events>()
+  const [internalEmitter] = useState(() => create<Events>())
+  const emitterRef = useRef(mitt ?? internalEmitter)
 
-  if (mitt && emitterRef.current !== mitt) {
+  useEffect(() => {
+    if (!mitt || emitterRef.current === mitt) return
+
     emitterRef.current.off('*')
     emitterRef.current = mitt
-  }
-  const emitter = emitterRef.current
+  }, [mitt])
+
+  const emit = useCallback(<Key extends keyof Events>(type: Key, event?: Events[Key]) => {
+    emitterRef.current.emit(type, event as Events[Key])
+  }, []) as Emitter<Events>['emit']
+
   const useSubscribe: ExtendedOn<Events> = (
     type: string,
     handler: any,
@@ -51,13 +57,14 @@ function useMitt<Events extends _Events>(mitt?: Emitter<Events>): UseMittReturn<
     const { enabled } = merge(defaultSubscribeOption, option)
     useEffect(() => {
       if (enabled) {
+        const emitter = mitt ?? emitterRef.current
         emitter.on(type, handler)
         return () => emitter.off(type, handler)
       }
     })
   }
   return {
-    emit: emitter.emit,
+    emit,
     useSubscribe,
   }
 }


### PR DESCRIPTION
## Summary

Remove the remaining render-phase ref mutations from Agent V2, new RAG, and useMitt without changing their committed runtime contracts.

## Why

These refs feed autosave, registered actions, asynchronous reindexing, virtualized scrolling, loading ownership, and event emitters. They must expose committed values while preserving stable debounce, subscription, and emitter behavior.

## Changes

- Synchronize Agent V2 configuration, action, task, and virtualizer refs after commit.
- Update the latest draft-save callback without rebuilding the debounce instance.
- Record composer initialization only after a non-pending render commits.
- Give useMitt a stable internal emitter and stable emit callback.
- Switch to a new truthy external emitter after commit and clean the previous wildcard subscription.
- Retain the latest external emitter when the optional argument becomes undefined.

## Behavior protected

- Agent autosave and publish use the latest committed model, base configuration, and enabled state.
- Pending debounced saves survive rerenders.
- Composer loading remains scoped to the active agent.
- Reindex completion and virtualized scrolling use the latest committed task and virtualizer.
- useMitt preserves internal identity, migrates A to B subscriptions, and keeps B when the optional external emitter is removed.

## Verification

- useMitt public-contract spec: 3 tests passed for internal stability, A to B migration, and B to undefined retention.
- Agent configure sync spec: 36 tests passed, including abandoned-render autosave and page-close contracts; both cases fail against the former render-write implementation.
- Previous stack-level focused verification: 29 spec files and 553 tests passed.
- The current test-only head passed Main CI, including Web Full-Stack E2E.
- Full-repository verification found no remaining render-phase ref mutations for this scope.
- Other repository diagnostics remain out of scope.

## Stack

This is PR 4 of 4 and depends on #40428.

| Order | PR | Scope |
| --- | --- | --- |
| 1 | [#40426](https://github.com/langgenius/dify/pull/40426) | Component guidance |
| 2 | [#40427](https://github.com/langgenius/dify/pull/40427) | Shared refs and persisted debug config |
| 3 | [#40428](https://github.com/langgenius/dify/pull/40428) | Workflow ownership |
| 4 | [#40429](https://github.com/langgenius/dify/pull/40429) | Agent V2, new RAG, and useMitt |

## Screenshots

Not applicable.

From Codex




