### PR TITLE
fix(api): scope trace node execution reads to the owning tenant

### DIFF
--- a/api/core/ops/aliyun_trace/aliyun_trace.py
+++ b/api/core/ops/aliyun_trace/aliyun_trace.py
@@ -294,6 +294,7 @@ class AliyunDataTrace(BaseTraceInstance):
             user=service_account,
             app_id=app_id,
             triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
+            tenant_id=trace_info.tenant_id,
         )
 
         return workflow_node_execution_repository.get_by_workflow_run(workflow_run_id=trace_info.workflow_run_id)

--- a/api/core/ops/arize_phoenix_trace/arize_phoenix_trace.py
+++ b/api/core/ops/arize_phoenix_trace/arize_phoenix_trace.py
@@ -268,6 +268,7 @@ class ArizePhoenixDataTrace(BaseTraceInstance):
             user=service_account,
             app_id=app_id,
             triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
+            tenant_id=trace_info.tenant_id,
         )
 
         # Get all executions for this workflow run

--- a/api/core/ops/langfuse_trace/langfuse_trace.py
+++ b/api/core/ops/langfuse_trace/langfuse_trace.py
@@ -127,6 +127,7 @@ class LangFuseDataTrace(BaseTraceInstance):
             user=service_account,
             app_id=app_id,
             triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
+            tenant_id=trace_info.tenant_id,
         )
 
         # Get all executions for this workflow run

--- a/api/core/ops/langsmith_trace/langsmith_trace.py
+++ b/api/core/ops/langsmith_trace/langsmith_trace.py
@@ -149,6 +149,7 @@ class LangSmithDataTrace(BaseTraceInstance):
             user=service_account,
             app_id=app_id,
             triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
+            tenant_id=trace_info.tenant_id,
         )
 
         # Get all executions for this workflow run

--- a/api/core/ops/opik_trace/opik_trace.py
+++ b/api/core/ops/opik_trace/opik_trace.py
@@ -173,6 +173,7 @@ class OpikDataTrace(BaseTraceInstance):
             user=service_account,
             app_id=app_id,
             triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
+            tenant_id=trace_info.tenant_id,
         )
 
         # Get all executions for this workflow run

--- a/api/core/ops/tencent_trace/tencent_trace.py
+++ b/api/core/ops/tencent_trace/tencent_trace.py
@@ -241,19 +241,12 @@ class TencentDataTrace(BaseTraceInstance):
                 if not service_account:
                     raise ValueError(f"Creator account not found for app {app_id}")
 
-                current_tenant = (
-                    session.query(TenantAccountJoin).filter_by(account_id=service_account.id, current=True).first()
-                )
-                if not current_tenant:
-                    raise ValueError(f"Current tenant not found for account {service_account.id}")
-
-                service_account.set_tenant_id(current_tenant.tenant_id)
-
             repository = SQLAlchemyWorkflowNodeExecutionRepository(
                 session_factory=session_maker,
                 user=service_account,
                 app_id=trace_info.metadata.get("app_id"),
                 triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
+                tenant_id=app.tenant_id,
             )
 
             executions = repository.get_by_workflow_run(workflow_run_id=trace_info.workflow_run_id)

--- a/api/core/ops/weave_trace/weave_trace.py
+++ b/api/core/ops/weave_trace/weave_trace.py
@@ -158,6 +158,7 @@ class WeaveDataTrace(BaseTraceInstance):
             user=service_account,
             app_id=app_id,
             triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
+            tenant_id=trace_info.tenant_id,
         )
 
         # Get all executions for this workflow run

--- a/api/core/repositories/celery_workflow_node_execution_repository.py
+++ b/api/core/repositories/celery_workflow_node_execution_repository.py
@@ -17,7 +17,7 @@ from dify_graph.repositories.workflow_node_execution_repository import (
     OrderConfig,
     WorkflowNodeExecutionRepository,
 )
-from libs.helper import extract_tenant_id
+from libs.helper import resolve_tenant_id
 from models import Account, CreatorUserRole, EndUser
 from models.workflow import WorkflowNodeExecutionTriggeredFrom
 from tasks.workflow_node_execution_tasks import (
@@ -57,6 +57,7 @@ class CeleryWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository):
         user: Union[Account, EndUser],
         app_id: str | None,
         triggered_from: WorkflowNodeExecutionTriggeredFrom | None,
+        tenant_id: str | None = None,
     ):
         """
         Initialize the repository with Celery task configuration and context information.
@@ -66,6 +67,8 @@ class CeleryWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository):
             user: Account or EndUser object containing tenant_id, user ID, and role information
             app_id: App ID for filtering by application (can be None)
             triggered_from: Source of the execution trigger (SINGLE_STEP or WORKFLOW_RUN)
+            tenant_id: Tenant that owns the node executions; defaults to the user's own tenant.
+                Callers acting on another tenant's records must pass this explicitly.
         """
         # Store session factory for fallback operations
         if isinstance(session_factory, Engine):
@@ -77,11 +80,7 @@ class CeleryWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository):
                 f"Invalid session_factory type {type(session_factory).__name__}; expected sessionmaker or Engine"
             )
 
-        # Extract tenant_id from user
-        tenant_id = extract_tenant_id(user)
-        if not tenant_id:
-            raise ValueError("User must have a tenant_id or current_tenant_id")
-        self._tenant_id = tenant_id
+        self._tenant_id = resolve_tenant_id(tenant_id, user)
 
         # Store app context
         self._app_id = app_id

--- a/api/core/repositories/factory.py
+++ b/api/core/repositories/factory.py
@@ -76,6 +76,7 @@ class DifyCoreRepositoryFactory:
         user: Union[Account, EndUser],
         app_id: str,
         triggered_from: WorkflowNodeExecutionTriggeredFrom,
+        tenant_id: str | None = None,
     ) -> WorkflowNodeExecutionRepository:
         """
         Create a WorkflowNodeExecutionRepository instance based on configuration.
@@ -85,6 +86,8 @@ class DifyCoreRepositoryFactory:
             user: Account or EndUser object
             app_id: Application ID
             triggered_from: Source of the execution trigger
+            tenant_id: Tenant that owns the node executions; defaults to the user's own tenant.
+                Callers acting on another tenant's records must pass this explicitly.
 
         Returns:
             Configured WorkflowNodeExecutionRepository instance
@@ -101,6 +104,7 @@ class DifyCoreRepositoryFactory:
                 user=user,
                 app_id=app_id,
                 triggered_from=triggered_from,
+                tenant_id=tenant_id,
             )
         except (ImportError, Exception) as e:
             raise RepositoryImportError(

--- a/api/core/repositories/sqlalchemy_workflow_node_execution_repository.py
+++ b/api/core/repositories/sqlalchemy_workflow_node_execution_repository.py
@@ -23,7 +23,7 @@ from dify_graph.model_runtime.utils.encoders import jsonable_encoder
 from dify_graph.repositories.workflow_node_execution_repository import OrderConfig, WorkflowNodeExecutionRepository
 from dify_graph.workflow_type_encoder import WorkflowRuntimeTypeConverter
 from extensions.ext_storage import storage
-from libs.helper import extract_tenant_id
+from libs.helper import resolve_tenant_id
 from libs.uuid_utils import uuidv7
 from models import (
     Account,
@@ -66,6 +66,7 @@ class SQLAlchemyWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository)
         user: Union[Account, EndUser],
         app_id: str | None,
         triggered_from: WorkflowNodeExecutionTriggeredFrom | None,
+        tenant_id: str | None = None,
     ):
         """
         Initialize the repository with a SQLAlchemy sessionmaker or engine and context information.
@@ -75,6 +76,8 @@ class SQLAlchemyWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository)
             user: Account or EndUser object containing tenant_id, user ID, and role information
             app_id: App ID for filtering by application (can be None)
             triggered_from: Source of the execution trigger (SINGLE_STEP or WORKFLOW_RUN)
+            tenant_id: Tenant that owns the node executions; defaults to the user's own tenant.
+                Callers acting on another tenant's records must pass this explicitly.
         """
         # If an engine is provided, create a sessionmaker from it
         if isinstance(session_factory, Engine):
@@ -86,11 +89,7 @@ class SQLAlchemyWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository)
                 f"Invalid session_factory type {type(session_factory).__name__}; expected sessionmaker or Engine"
             )
 
-        # Extract tenant_id from user
-        tenant_id = extract_tenant_id(user)
-        if not tenant_id:
-            raise ValueError("User must have a tenant_id or current_tenant_id")
-        self._tenant_id = tenant_id
+        self._tenant_id = resolve_tenant_id(tenant_id, user)
 
         # Store app context
         self._app_id = app_id

--- a/api/extensions/logstore/repositories/logstore_workflow_node_execution_repository.py
+++ b/api/extensions/logstore/repositories/logstore_workflow_node_execution_repository.py
@@ -25,7 +25,7 @@ from dify_graph.workflow_type_encoder import WorkflowRuntimeTypeConverter
 from extensions.logstore.aliyun_logstore import AliyunLogStore
 from extensions.logstore.repositories import safe_float, safe_int
 from extensions.logstore.sql_escape import escape_identifier
-from libs.helper import extract_tenant_id
+from libs.helper import resolve_tenant_id
 from models import (
     Account,
     CreatorUserRole,
@@ -111,6 +111,7 @@ class LogstoreWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository):
         user: Union[Account, EndUser],
         app_id: str | None,
         triggered_from: WorkflowNodeExecutionTriggeredFrom | None,
+        tenant_id: str | None = None,
     ):
         """
         Initialize the repository with a SQLAlchemy sessionmaker or engine and context information.
@@ -120,6 +121,8 @@ class LogstoreWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository):
             user: Account or EndUser object containing tenant_id, user ID, and role information
             app_id: App ID for filtering by application (can be None)
             triggered_from: Source of the execution trigger (SINGLE_STEP or WORKFLOW_RUN)
+            tenant_id: Tenant that owns the node executions; defaults to the user's own tenant.
+                Callers acting on another tenant's records must pass this explicitly.
         """
         logger.debug(
             "LogstoreWorkflowNodeExecutionRepository.__init__: app_id=%s, triggered_from=%s", app_id, triggered_from
@@ -127,11 +130,7 @@ class LogstoreWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository):
         # Initialize LogStore client
         self.logstore_client = AliyunLogStore()
 
-        # Extract tenant_id from user
-        tenant_id = extract_tenant_id(user)
-        if not tenant_id:
-            raise ValueError("User must have a tenant_id or current_tenant_id")
-        self._tenant_id = tenant_id
+        self._tenant_id = resolve_tenant_id(tenant_id, user)
 
         # Store app context
         self._app_id = app_id
@@ -144,7 +143,9 @@ class LogstoreWorkflowNodeExecutionRepository(WorkflowNodeExecutionRepository):
         self._creator_user_role = CreatorUserRole.ACCOUNT if isinstance(user, Account) else CreatorUserRole.END_USER
 
         # Initialize SQL repository for dual-write support
-        self.sql_repository = SQLAlchemyWorkflowNodeExecutionRepository(session_factory, user, app_id, triggered_from)
+        self.sql_repository = SQLAlchemyWorkflowNodeExecutionRepository(
+            session_factory, user, app_id, triggered_from, tenant_id=self._tenant_id
+        )
 
         # Control flag for dual-write (write to both LogStore and SQL database)
         # Set to True to enable dual-write for safe migration, False to use LogStore only

--- a/api/libs/helper.py
+++ b/api/libs/helper.py
@@ -93,6 +93,23 @@ def extract_tenant_id(user: Union["Account", "EndUser"]) -> str | None:
         raise ValueError(f"Invalid user type: {type(user)}. Expected Account or EndUser.")
 
 
+def resolve_tenant_id(tenant_id: str | None, user: Union["Account", "EndUser"]) -> str:
+    """
+    Resolve the tenant that owns a record, preferring an explicitly supplied tenant_id.
+
+    Callers acting on records owned by a tenant other than the acting user's own — trace
+    exporters running under a synthesized service account, for instance — must pass
+    tenant_id explicitly; the user is then only used for creator attribution.
+
+    Raises:
+        ValueError: If no tenant_id was supplied and none can be derived from the user
+    """
+    resolved = tenant_id or extract_tenant_id(user)
+    if not resolved:
+        raise ValueError("User must have a tenant_id or current_tenant_id")
+    return resolved
+
+
 def run(script):
     return subprocess.getstatusoutput("source /root/.bashrc && " + script)
 

--- a/api/tests/unit_tests/core/ops/aliyun_trace/test_aliyun_trace.py
+++ b/api/tests/unit_tests/core/ops/aliyun_trace/test_aliyun_trace.py
@@ -405,6 +405,10 @@ def test_get_workflow_node_executions_builds_repo_and_fetches(
     assert result == ["node1"]
     repo.get_by_workflow_run.assert_called_once_with(workflow_run_id=trace_info.workflow_run_id)
 
+    # Node executions must be read from the run's tenant, not the creator's active workspace.
+    kwargs = mock_factory.create_workflow_node_execution_repository.call_args.kwargs
+    assert kwargs["tenant_id"] == "tenant-id"
+
 
 def test_build_workflow_node_span_routes_llm_type(trace_instance: AliyunDataTrace, monkeypatch: pytest.MonkeyPatch):
     node_execution = MagicMock(spec=WorkflowNodeExecution)

--- a/api/tests/unit_tests/core/ops/arize_phoenix_trace/test_arize_phoenix_trace.py
+++ b/api/tests/unit_tests/core/ops/arize_phoenix_trace/test_arize_phoenix_trace.py
@@ -256,10 +256,15 @@ def test_workflow_trace_full(mock_db, mock_repo_factory, mock_sessionmaker, trac
 
     repo.get_by_workflow_run.return_value = [node1]
 
-    with patch.object(trace_instance, "get_service_account_with_tenant"):
+    service_account = MagicMock(current_tenant_id="creator-active-tenant")
+    with patch.object(trace_instance, "get_service_account_with_tenant", return_value=service_account):
         trace_instance.workflow_trace(info)
 
     assert trace_instance.tracer.start_span.call_count >= 2
+
+    # Node executions must be read from the run's tenant, not the creator's active workspace.
+    kwargs = mock_repo_factory.create_workflow_node_execution_repository.call_args.kwargs
+    assert kwargs["tenant_id"] == "t1"
 
 
 @patch("core.ops.arize_phoenix_trace.arize_phoenix_trace.db")

--- a/api/tests/unit_tests/core/ops/langfuse_trace/test_langfuse_trace.py
+++ b/api/tests/unit_tests/core/ops/langfuse_trace/test_langfuse_trace.py
@@ -259,6 +259,49 @@ def test_workflow_trace_no_message_id(trace_instance, monkeypatch):
     assert trace_data.name == TraceTaskName.WORKFLOW_TRACE
 
 
+def test_workflow_trace_scopes_node_query_to_run_tenant(trace_instance, monkeypatch):
+    """Node executions are read from the run's tenant, not the app creator's active workspace."""
+    trace_info = WorkflowTraceInfo(
+        workflow_id="wf-1",
+        tenant_id="run-tenant",
+        workflow_run_id="run-1",
+        workflow_run_elapsed_time=1.0,
+        workflow_run_status="succeeded",
+        workflow_run_inputs={},
+        workflow_run_outputs={},
+        workflow_run_version="1.0",
+        total_tokens=0,
+        file_list=[],
+        query="",
+        message_id=None,
+        conversation_id="conv-1",
+        start_time=_dt(),
+        end_time=_dt(),
+        trace_id=None,
+        metadata={"app_id": "app-1"},
+        workflow_app_log_id="log-1",
+        error="",
+    )
+
+    monkeypatch.setattr("core.ops.langfuse_trace.langfuse_trace.sessionmaker", lambda bind: lambda: MagicMock())
+    monkeypatch.setattr("core.ops.langfuse_trace.langfuse_trace.db", MagicMock(engine="engine"))
+    repo = MagicMock()
+    repo.get_by_workflow_run.return_value = []
+    mock_factory = MagicMock()
+    mock_factory.create_workflow_node_execution_repository.return_value = repo
+    monkeypatch.setattr("core.ops.langfuse_trace.langfuse_trace.DifyCoreRepositoryFactory", mock_factory)
+
+    # The creator has since switched their active workspace away from the app's tenant.
+    service_account = MagicMock(current_tenant_id="creator-active-tenant")
+    monkeypatch.setattr(trace_instance, "get_service_account_with_tenant", lambda app_id: service_account)
+
+    trace_instance.add_trace = MagicMock()
+    trace_instance.workflow_trace(trace_info)
+
+    kwargs = mock_factory.create_workflow_node_execution_repository.call_args.kwargs
+    assert kwargs["tenant_id"] == "run-tenant"
+
+
 def test_workflow_trace_missing_app_id(trace_instance, monkeypatch):
     trace_info = WorkflowTraceInfo(
         workflow_id="wf-1",

--- a/api/tests/unit_tests/core/ops/langsmith_trace/test_langsmith_trace.py
+++ b/api/tests/unit_tests/core/ops/langsmith_trace/test_langsmith_trace.py
@@ -259,11 +259,16 @@ def test_workflow_trace_no_start_time(trace_instance, monkeypatch):
     mock_factory = MagicMock()
     mock_factory.create_workflow_node_execution_repository.return_value = repo
     monkeypatch.setattr("core.ops.langsmith_trace.langsmith_trace.DifyCoreRepositoryFactory", mock_factory)
-    monkeypatch.setattr(trace_instance, "get_service_account_with_tenant", lambda app_id: MagicMock())
+    service_account = MagicMock(current_tenant_id="creator-active-tenant")
+    monkeypatch.setattr(trace_instance, "get_service_account_with_tenant", lambda app_id: service_account)
 
     trace_instance.add_run = MagicMock()
     trace_instance.workflow_trace(trace_info)
     assert trace_instance.add_run.called
+
+    # Node executions must be read from the run's tenant, not the creator's active workspace.
+    kwargs = mock_factory.create_workflow_node_execution_repository.call_args.kwargs
+    assert kwargs["tenant_id"] == "tenant-1"
 
 
 def test_workflow_trace_missing_app_id(trace_instance, monkeypatch):

--- a/api/tests/unit_tests/core/ops/opik_trace/test_opik_trace.py
+++ b/api/tests/unit_tests/core/ops/opik_trace/test_opik_trace.py
@@ -257,12 +257,17 @@ def test_workflow_trace_no_message_id(trace_instance, monkeypatch):
     mock_factory = MagicMock()
     mock_factory.create_workflow_node_execution_repository.return_value = repo
     monkeypatch.setattr("core.ops.opik_trace.opik_trace.DifyCoreRepositoryFactory", mock_factory)
-    monkeypatch.setattr(trace_instance, "get_service_account_with_tenant", lambda app_id: MagicMock())
+    service_account = MagicMock(current_tenant_id="creator-active-tenant")
+    monkeypatch.setattr(trace_instance, "get_service_account_with_tenant", lambda app_id: service_account)
 
     trace_instance.add_trace = MagicMock()
     trace_instance.workflow_trace(trace_info)
 
     trace_instance.add_trace.assert_called_once()
+
+    # Node executions must be read from the run's tenant, not the creator's active workspace.
+    kwargs = mock_factory.create_workflow_node_execution_repository.call_args.kwargs
+    assert kwargs["tenant_id"] == "tenant-1"
 
 
 def test_workflow_trace_missing_app_id(trace_instance, monkeypatch):

--- a/api/tests/unit_tests/core/ops/tencent_trace/test_tencent_trace.py
+++ b/api/tests/unit_tests/core/ops/tencent_trace/test_tencent_trace.py
@@ -16,7 +16,7 @@ from core.ops.entities.trace_entity import (
 from core.ops.tencent_trace.tencent_trace import TencentDataTrace
 from dify_graph.entities import WorkflowNodeExecution
 from dify_graph.enums import BuiltinNodeTypes
-from models import Account, App, TenantAccountJoin
+from models import Account, App
 
 logger = logging.getLogger(__name__)
 
@@ -394,12 +394,10 @@ class TestTencentDataTrace:
         app = MagicMock(spec=App)
         app.id = "app-1"
         app.created_by = "user-1"
+        app.tenant_id = "app-tenant"
 
         account = MagicMock(spec=Account)
         account.id = "user-1"
-
-        tenant_join = MagicMock(spec=TenantAccountJoin)
-        tenant_join.tenant_id = "tenant-1"
 
         mock_executions = [MagicMock()]
 
@@ -408,7 +406,6 @@ class TestTencentDataTrace:
             with patch("core.ops.tencent_trace.tencent_trace.Session") as mock_session_ctx:
                 session = mock_session_ctx.return_value.__enter__.return_value
                 session.scalar.side_effect = [app, account]
-                session.query.return_value.filter_by.return_value.first.return_value = tenant_join
 
                 with patch(
                     "core.ops.tencent_trace.tencent_trace.SQLAlchemyWorkflowNodeExecutionRepository"
@@ -418,7 +415,8 @@ class TestTencentDataTrace:
                     results = tencent_data_trace._get_workflow_node_executions(trace_info)
 
                     assert results == mock_executions
-                    account.set_tenant_id.assert_called_once_with("tenant-1")
+                    # Node executions are scoped to the app's tenant, not the creator's active workspace.
+                    assert mock_repo.call_args.kwargs["tenant_id"] == "app-tenant"
 
     def test_get_workflow_node_executions_no_app_id(self, tencent_data_trace):
         trace_info = MagicMock(spec=WorkflowTraceInfo)

--- a/api/tests/unit_tests/core/ops/weave_trace/test_weave_trace.py
+++ b/api/tests/unit_tests/core/ops/weave_trace/test_weave_trace.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from weave.trace_server.trace_server_interface import TraceStatus
 
+import core.ops.weave_trace.weave_trace as weave_trace_module
 from core.ops.entities.config_entity import WeaveConfig
 from core.ops.entities.trace_entity import (
     DatasetRetrievalTraceInfo,
@@ -602,7 +603,8 @@ class TestWorkflowTrace:
     def test_workflow_trace_no_nodes_no_message_id(self, trace_instance, monkeypatch):
         """Workflow trace with no nodes and no message_id."""
         self._setup_repo(monkeypatch, nodes=[])
-        monkeypatch.setattr(trace_instance, "get_service_account_with_tenant", lambda app_id: MagicMock())
+        service_account = MagicMock(current_tenant_id="creator-active-tenant")
+        monkeypatch.setattr(trace_instance, "get_service_account_with_tenant", lambda app_id: service_account)
 
         trace_instance.start_call = MagicMock()
         trace_instance.finish_call = MagicMock()
@@ -612,6 +614,10 @@ class TestWorkflowTrace:
 
         # Only workflow run: start_call and finish_call each called once
         assert trace_instance.start_call.call_count == 1
+
+        # Node executions must be read from the run's tenant, not the creator's active workspace.
+        factory = weave_trace_module.DifyCoreRepositoryFactory
+        assert factory.create_workflow_node_execution_repository.call_args.kwargs["tenant_id"] == "tenant-1"
         assert trace_instance.finish_call.call_count == 1
 
     def test_workflow_trace_with_message_id(self, trace_instance, monkeypatch):

--- a/api/tests/unit_tests/core/repositories/test_celery_workflow_node_execution_repository.py
+++ b/api/tests/unit_tests/core/repositories/test_celery_workflow_node_execution_repository.py
@@ -129,6 +129,23 @@ class TestCeleryWorkflowNodeExecutionRepository:
             )
 
     @patch("core.repositories.celery_workflow_node_execution_repository.save_workflow_node_execution_task")
+    def test_save_uses_explicit_tenant_over_user_tenant(
+        self, mock_task, mock_session_factory, mock_account, sample_workflow_node_execution
+    ):
+        """An explicit tenant_id wins over the acting user's own tenant."""
+        repo = CeleryWorkflowNodeExecutionRepository(
+            session_factory=mock_session_factory,
+            user=mock_account,
+            app_id="test-app",
+            triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
+            tenant_id="record-owner-tenant",
+        )
+
+        repo.save(sample_workflow_node_execution)
+
+        assert mock_task.delay.call_args[1]["tenant_id"] == "record-owner-tenant"
+
+    @patch("core.repositories.celery_workflow_node_execution_repository.save_workflow_node_execution_task")
     def test_save_caches_and_queues_celery_task(
         self, mock_task, mock_session_factory, mock_account, sample_workflow_node_execution
     ):

--- a/api/tests/unit_tests/core/repositories/test_factory.py
+++ b/api/tests/unit_tests/core/repositories/test_factory.py
@@ -157,8 +157,28 @@ class TestRepositoryFactory:
                 user=mock_user,
                 app_id=app_id,
                 triggered_from=triggered_from,
+                tenant_id=None,
             )
             assert result is mock_repository_instance
+
+    @patch("core.repositories.factory.dify_config", autospec=True)
+    def test_create_workflow_node_execution_repository_forwards_tenant_id(self, mock_config):
+        """An explicit tenant_id reaches the configured repository implementation."""
+        mock_config.CORE_WORKFLOW_NODE_EXECUTION_REPOSITORY = "unittest.mock.MagicMock"
+
+        mock_repository_class = MagicMock()
+        mock_repository_class.return_value = MagicMock(spec=WorkflowNodeExecutionRepository)
+
+        with patch("core.repositories.factory.import_string", return_value=mock_repository_class, autospec=True):
+            DifyCoreRepositoryFactory.create_workflow_node_execution_repository(
+                session_factory=MagicMock(spec=sessionmaker),
+                user=MagicMock(spec=EndUser),
+                app_id="test-app-id",
+                triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
+                tenant_id="record-owner-tenant",
+            )
+
+        assert mock_repository_class.call_args[1]["tenant_id"] == "record-owner-tenant"
 
     @patch("core.repositories.factory.dify_config", autospec=True)
     def test_create_workflow_node_execution_repository_import_error(self, mock_config):

--- a/api/tests/unit_tests/core/repositories/test_sqlalchemy_workflow_node_execution_repository.py
+++ b/api/tests/unit_tests/core/repositories/test_sqlalchemy_workflow_node_execution_repository.py
@@ -153,6 +153,54 @@ def test_init_requires_tenant_id(monkeypatch: pytest.MonkeyPatch) -> None:
         )
 
 
+def test_get_db_models_by_workflow_run_filters_by_explicit_tenant(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit tenant_id wins over the acting user's own tenant when scoping the query."""
+    monkeypatch.setattr(
+        "core.repositories.sqlalchemy_workflow_node_execution_repository.FileService",
+        lambda *_: SimpleNamespace(upload_file=Mock()),
+    )
+
+    session = MagicMock()
+    session.scalars.return_value.all.return_value = []
+
+    repo = SQLAlchemyWorkflowNodeExecutionRepository(
+        session_factory=_session_factory(session),
+        user=_mock_account(tenant_id="acting-user-tenant"),
+        app_id="app",
+        triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
+        tenant_id="record-owner-tenant",
+    )
+
+    repo.get_db_models_by_workflow_run("run")
+
+    stmt = session.scalars.call_args[0][0]
+    sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "record-owner-tenant" in sql
+    assert "acting-user-tenant" not in sql
+
+
+def test_init_falls_back_to_user_tenant_when_not_supplied(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "core.repositories.sqlalchemy_workflow_node_execution_repository.FileService",
+        lambda *_: SimpleNamespace(upload_file=Mock()),
+    )
+
+    session = MagicMock()
+    session.scalars.return_value.all.return_value = []
+
+    repo = SQLAlchemyWorkflowNodeExecutionRepository(
+        session_factory=_session_factory(session),
+        user=_mock_account(tenant_id="acting-user-tenant"),
+        app_id="app",
+        triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
+    )
+
+    repo.get_db_models_by_workflow_run("run")
+
+    stmt = session.scalars.call_args[0][0]
+    assert "acting-user-tenant" in str(stmt.compile(compile_kwargs={"literal_binds": True}))
+
+
 def test_create_truncator_uses_config(monkeypatch: pytest.MonkeyPatch) -> None:
     created: dict[str, Any] = {}
 


### PR DESCRIPTION
## Summary

Backport of #39042 to `lts/1.13.x` (chart `dify-3.9.x`, `appVersion 1.13.3`).

### The bug

Workflow runs export a top-level trace to Langfuse but no child node spans, no tokens and no cost, whenever the app creator's currently-active workspace is not the workspace that owns the app.

`BaseTraceInstance.get_service_account_with_tenant` resolves the service account's tenant from `TenantAccountJoin.current == True` — the creator's *active* workspace, not the app's. That account is handed to `SQLAlchemyWorkflowNodeExecutionRepository`, which derives `self._tenant_id` from it and filters:

```python
WorkflowNodeExecutionModel.tenant_id == self._tenant_id
```

On a tenant mismatch the query returns zero rows and raises nothing, so the exporter loops over an empty list and emits a parent span with no children. The parent survives because it is built from `trace_info.tenant_id`, which is set from `workflow_run.tenant_id` and was always correct — it just was not used for the node query.

Confirmed on a customer instance: app/run tenant and app-creator active tenant differ; the run itself is `succeeded`.


## Verification

- Backend unit suite: **12978 passed, 13 skipped, 0 failures**
- 10 new/extended tests, written first and each watched fail for the right reason (`KeyError: 'tenant_id'` at the exporters, `TypeError: unexpected keyword argument` at the repositories). Every exporter, every repository implementation reachable from the factory, and the factory itself has a covered call site.
- `ruff check` / `ruff format --check` clean on all touched files; `lint-imports` 10/10 contracts kept. The one remaining `UP047` on `_find_first` is pre-existing, verified against a stashed baseline.
- basedpyright: 28 errors before and after, unchanged. mypy and pyrefly report nothing in any touched file.

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `make lint` and `make type-check` (backend) and `cd web && npx lint-staged` (frontend) to appease the lint gods
