### PR TITLE
fix(web): render agent image icons from icon_url

### DIFF
--- a/api/fields/agent_fields.py
+++ b/api/fields/agent_fields.py
@@ -81,6 +81,7 @@ class AgentRosterResponse(ResponseModel):
     icon_type: AgentIconType | None = None
     icon: str | None = None
     icon_background: str | None = None
+    icon_url: str | None = None
     agent_kind: AgentKind
     scope: AgentScope
     source: AgentSource

--- a/api/openapi/markdown/console-openapi.md
+++ b/api/openapi/markdown/console-openapi.md
@@ -14239,6 +14239,7 @@ Supported icon storage formats for Agent roster entries.
 | icon | string |  | No |
 | icon_background | string |  | No |
 | icon_type | [AgentIconType](#agenticontype) |  | No |
+| icon_url | string |  | No |
 | id | string |  | Yes |
 | in_current_workflow_count | integer |  | No |
 | is_in_current_workflow | boolean |  | No |
@@ -14703,6 +14704,7 @@ section may be empty, which is how callers express "no knowledge layer".
 | icon | string |  | No |
 | icon_background | string |  | No |
 | icon_type | [AgentIconType](#agenticontype) |  | No |
+| icon_url | string |  | No |
 | id | string |  | Yes |
 | name | string |  | Yes |
 | published_node_reference_count | integer |  | No |

--- a/api/services/agent/roster_service.py
+++ b/api/services/agent/roster_service.py
@@ -103,6 +103,8 @@ class AgentRosterService:
         reference_count: int | None = None,
     ) -> dict[str, Any]:
         published_references = published_references or []
+        from libs.helper import build_icon_url
+
         return {
             "id": agent.id,
             "name": agent.name,
@@ -111,6 +113,7 @@ class AgentRosterService:
             "icon_type": agent.icon_type.value if agent.icon_type else None,
             "icon": agent.icon,
             "icon_background": agent.icon_background,
+            "icon_url": build_icon_url(agent.icon_type, agent.icon),
             "agent_kind": agent.agent_kind.value,
             "scope": agent.scope.value,
             "source": agent.source.value,

--- a/api/tests/unit_tests/services/agent/test_agent_services.py
+++ b/api/tests/unit_tests/services/agent/test_agent_services.py
@@ -10,6 +10,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from core.workflow.nodes.agent_v2.validators import WorkflowAgentNodeValidationError
+from libs.helper import build_icon_url
 from models.account import Account
 from models.agent import (
     Agent,
@@ -239,9 +240,12 @@ def test_serialize_agent_includes_icon_url_for_image_icons(monkeypatch: pytest.M
     agent.icon_type = AgentIconType.IMAGE
     agent.icon = "upload-file-id"
     monkeypatch.setattr(
-        "libs.helper.build_icon_url",
-        lambda icon_type, icon: f"/files/{icon}/file-preview?sign=test",
+        "libs.helper.file_helpers.get_signed_file_url",
+        lambda upload_file_id: f"/files/{upload_file_id}/file-preview?sign=test",
     )
+
+    # Pin AgentIconType → build_icon_url compatibility (StrEnum str() fallback, not IconType).
+    assert build_icon_url(AgentIconType.IMAGE, "upload-file-id") == "/files/upload-file-id/file-preview?sign=test"
 
     payload = AgentRosterService.serialize_agent(agent)
 

--- a/api/tests/unit_tests/services/agent/test_agent_services.py
+++ b/api/tests/unit_tests/services/agent/test_agent_services.py
@@ -23,6 +23,7 @@ from models.agent import (
     AgentDriveFile,
     AgentDriveFileKind,
     AgentHomeSnapshot,
+    AgentIconType,
     AgentKind,
     AgentScope,
     AgentSource,
@@ -231,6 +232,21 @@ def test_peek_authz_app_id_uses_the_roster_agent_app(sqlite_session: Session):
     result = AgentRosterService(session).peek_authz_app_id(tenant_id="tenant-1", agent_id="agent-1")
 
     assert result == "roster-app-1"
+
+
+def test_serialize_agent_includes_icon_url_for_image_icons(monkeypatch: pytest.MonkeyPatch):
+    agent = _agent()
+    agent.icon_type = AgentIconType.IMAGE
+    agent.icon = "upload-file-id"
+    monkeypatch.setattr(
+        "libs.helper.build_icon_url",
+        lambda icon_type, icon: f"/files/{icon}/file-preview?sign=test",
+    )
+
+    payload = AgentRosterService.serialize_agent(agent)
+
+    assert payload["icon"] == "upload-file-id"
+    assert payload["icon_url"] == "/files/upload-file-id/file-preview?sign=test"
 
 
 def test_peek_authz_app_id_returns_none_without_creating_a_backing_app(sqlite_session: Session):

--- a/packages/contracts/generated/api/console/agent/types.gen.ts
+++ b/packages/contracts/generated/api/console/agent/types.gen.ts
@@ -624,6 +624,7 @@ export type AgentInviteOptionResponse = {
   icon?: string | null
   icon_background?: string | null
   icon_type?: AgentIconType | null
+  icon_url?: string | null
   id: string
   in_current_workflow_count?: number
   is_in_current_workflow?: boolean

--- a/packages/contracts/generated/api/console/agent/zod.gen.ts
+++ b/packages/contracts/generated/api/console/agent/zod.gen.ts
@@ -1110,6 +1110,7 @@ export const zAgentInviteOptionResponse = z.object({
   icon: z.string().nullish(),
   icon_background: z.string().nullish(),
   icon_type: zAgentIconType.nullish(),
+  icon_url: z.string().nullish(),
   id: z.string(),
   in_current_workflow_count: z.int().optional().default(0),
   is_in_current_workflow: z.boolean().optional().default(false),

--- a/web/app/components/workflow/block-selector/__tests__/agent-selector.spec.tsx
+++ b/web/app/components/workflow/block-selector/__tests__/agent-selector.spec.tsx
@@ -1,10 +1,11 @@
+import type { AgentInviteOptionResponse } from '@dify/contracts/api/console/agent/types.gen'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import { AgentSelectorContent } from '../agent-selector'
 
 const mocks = vi.hoisted(() => ({
   canManageAgents: true,
-  agents: [] as Array<{ id: string; name: string }>,
+  agents: [] as AgentInviteOptionResponse[],
 }))
 
 vi.mock('@/features/agent-v2/permissions', () => ({
@@ -86,5 +87,39 @@ describe('AgentSelectorContent', () => {
 
     expect(screen.queryByText(startFromScratchLabel)).not.toBeInTheDocument()
     expect(screen.queryByText(manageInConsoleLabel)).not.toBeInTheDocument()
+  })
+
+  it('renders uploaded image icons using icon_url', async () => {
+    mocks.agents = [
+      {
+        id: 'agent-1',
+        name: 'Image Agent',
+        description: 'Uses uploaded icon',
+        active_config_snapshot_id: 'version-1',
+        icon: '29bdb007-4d8c-4888-83a2-7587abcafb26',
+        icon_background: '#F5F3FF',
+        icon_type: 'image',
+        icon_url: '/files/29bdb007-4d8c-4888-83a2-7587abcafb26/file-preview?sign=abc',
+        role: 'Analyst',
+        agent_kind: 'dify_agent',
+        scope: 'roster',
+        source: 'agent_app',
+        status: 'active',
+      },
+    ]
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <AgentSelectorContent open onOpenChange={vi.fn()} onSelect={vi.fn()} />
+      </QueryClientProvider>,
+    )
+
+    await screen.findByText('Image Agent')
+
+    expect(container.querySelector('img[alt="app icon"]')).toHaveAttribute(
+      'src',
+      '/files/29bdb007-4d8c-4888-83a2-7587abcafb26/file-preview?sign=abc',
+    )
   })
 })

--- a/web/app/components/workflow/block-selector/agent-selector.tsx
+++ b/web/app/components/workflow/block-selector/agent-selector.tsx
@@ -22,6 +22,7 @@ import AppIcon from '@/app/components/base/app-icon'
 import Badge from '@/app/components/base/badge'
 import { useHooksStore } from '@/app/components/workflow/hooks-store'
 import { useCanManageAgents } from '@/features/agent-v2/permissions'
+import { getAgentAppIconImageUrl } from '@/features/agent-v2/utils/agent-icon'
 import Link from '@/next/link'
 import { consoleQuery } from '@/service/client'
 import BlockIcon from '../block-icon'
@@ -227,7 +228,7 @@ function AgentSelectorAvatar({ agent }: { agent: AgentInviteOptionResponse }) {
       iconType={agent.icon_type}
       icon={agent.icon ?? undefined}
       background={agent.icon_background}
-      imageUrl={agent.icon ?? undefined}
+      imageUrl={getAgentAppIconImageUrl(agent)}
     />
   )
 }

--- a/web/app/components/workflow/nodes/agent-v2/__tests__/node.spec.tsx
+++ b/web/app/components/workflow/nodes/agent-v2/__tests__/node.spec.tsx
@@ -99,6 +99,28 @@ describe('agent/node', () => {
     expect(container.querySelector('.h-1.px-3')).not.toBeInTheDocument()
   })
 
+  it('renders uploaded image icons using icon_url', () => {
+    mockUseAgentRosterDetail.mockReturnValue({
+      isPending: false,
+      data: {
+        id: 'agent-1',
+        name: 'Nadia',
+        description: 'Clarification Drafter',
+        icon: '29bdb007-4d8c-4888-83a2-7587abcafb26',
+        icon_background: '#E9D7FE',
+        icon_type: 'image',
+        icon_url: '/files/29bdb007-4d8c-4888-83a2-7587abcafb26/file-preview?sign=abc',
+      },
+    })
+
+    const { container } = render(<AgentV2Node id="agent-node" data={createData()} />)
+
+    expect(container.querySelector('img[alt="app icon"]')).toHaveAttribute(
+      'src',
+      '/files/29bdb007-4d8c-4888-83a2-7587abcafb26/file-preview?sign=abc',
+    )
+  })
+
   it('renders a stable roster placeholder while agent detail is loading', () => {
     mockUseAgentRosterDetail.mockReturnValue({ data: undefined })
 

--- a/web/app/components/workflow/nodes/agent-v2/components/agent-roster-field.tsx
+++ b/web/app/components/workflow/nodes/agent-v2/components/agent-roster-field.tsx
@@ -32,6 +32,7 @@ import { useTranslation } from 'react-i18next'
 import AppIcon from '@/app/components/base/app-icon'
 import { AgentSelectorContent } from '@/app/components/workflow/block-selector/agent-selector'
 import { useCanManageAgents } from '@/features/agent-v2/permissions'
+import { getAgentAppIconImageUrl } from '@/features/agent-v2/utils/agent-icon'
 import { EditInConsoleLink } from './edit-in-console-link'
 
 const i18nPrefix = 'nodes.agent'
@@ -42,6 +43,7 @@ type AgentRosterDisplayData = {
   icon?: string | null
   icon_background?: string | null
   icon_type?: string | null
+  icon_url?: string | null
   id: string
   name: string
   role?: string | null
@@ -70,7 +72,7 @@ function AgentRosterAvatar({
       iconType={getAppIconType(agent.icon_type)}
       icon={agent.icon ?? undefined}
       background={agent.icon_background}
-      imageUrl={agent.icon ?? undefined}
+      imageUrl={getAgentAppIconImageUrl(agent)}
       className={className}
     />
   )

--- a/web/app/components/workflow/nodes/agent-v2/node.tsx
+++ b/web/app/components/workflow/nodes/agent-v2/node.tsx
@@ -3,6 +3,7 @@ import type { AgentV2NodeType } from './types'
 import type { AppIconType } from '@/types/app'
 import { useTranslation } from 'react-i18next'
 import AppIcon from '@/app/components/base/app-icon'
+import { getAgentAppIconImageUrl } from '@/features/agent-v2/utils/agent-icon'
 import { SettingItem } from '../_base/components/setting-item'
 import { useAgentRosterDetail, useWorkflowInlineAgentDetail } from './hooks'
 import { hasInlineAgentBinding, hasValidRosterAgentBinding } from './types'
@@ -37,7 +38,7 @@ function AgentNodeAvatar({
       iconType={getAppIconType(agent.icon_type)}
       icon={agent.icon ?? undefined}
       background={agent.icon_background}
-      imageUrl={agent.icon ?? undefined}
+      imageUrl={getAgentAppIconImageUrl(agent)}
     />
   )
 }

--- a/web/features/agent-v2/agent-detail/__tests__/navigation.spec.tsx
+++ b/web/features/agent-v2/agent-detail/__tests__/navigation.spec.tsx
@@ -132,6 +132,24 @@ describe('AgentDetailSection', () => {
     )
   })
 
+  it('renders uploaded image icons using icon_url', () => {
+    mocks.queryData = createAgent({
+      icon: '29bdb007-4d8c-4888-83a2-7587abcafb26',
+      icon_background: '#F5F3FF',
+      icon_type: 'image',
+      icon_url: '/files/29bdb007-4d8c-4888-83a2-7587abcafb26/file-preview?sign=abc',
+    })
+
+    const { container } = renderAgentDetailSection()
+    const image = container.querySelector('img[alt="app icon"]')
+
+    expect(image).toHaveAttribute(
+      'src',
+      '/files/29bdb007-4d8c-4888-83a2-7587abcafb26/file-preview?sign=abc',
+    )
+    expect(container.querySelector('em-emoji')).not.toBeInTheDocument()
+  })
+
   it('renders compact more actions beside the expanded sidebar agent identity', async () => {
     const user = userEvent.setup()
     renderAgentDetailSection()

--- a/web/features/agent-v2/agent-detail/navigation.tsx
+++ b/web/features/agent-v2/agent-detail/navigation.tsx
@@ -18,6 +18,7 @@ import SidebarLeftArrowIcon from '@/app/components/base/icons/src/vender/Sidebar
 import { DetailSidebarToggleButton } from '@/app/components/detail-sidebar/toggle-button'
 import { gotoAnythingDialogHandle } from '@/app/components/goto-anything/dialog-handle'
 import { GOTO_ANYTHING_HOTKEY } from '@/app/components/goto-anything/hotkeys'
+import { getAgentAppIconImageUrl } from '@/features/agent-v2/utils/agent-icon'
 import Link from '@/next/link'
 import { usePathname } from '@/next/navigation'
 import { consoleQuery } from '@/service/client'
@@ -182,8 +183,13 @@ export function AgentDetailSection({ expand = true }: AgentDetailSectionProps) {
 
   const navigation = getAgentDetailNavigation(agentId)
   const agent = agentQuery.data
-  const imageUrl =
-    agent?.icon_type === 'image' || agent?.icon_type === 'link' ? agent.icon : undefined
+  const imageUrl = agent
+    ? getAgentAppIconImageUrl({
+        icon_type: agent.icon_type,
+        icon: agent.icon,
+        icon_url: agent.icon_url,
+      })
+    : undefined
   const iconType = (imageUrl ? 'image' : agent?.icon_type) as AgentIconType | null | undefined
 
   return (

--- a/web/features/agent-v2/roster/components/__tests__/agent-roster-list.spec.tsx
+++ b/web/features/agent-v2/roster/components/__tests__/agent-roster-list.spec.tsx
@@ -129,6 +129,22 @@ describe('AgentRosterList', () => {
     expect(screen.queryByText('agent')).not.toBeInTheDocument()
   })
 
+  it('renders uploaded image icons using icon_url', () => {
+    const { container } = renderList([
+      createAgent({
+        icon: '29bdb007-4d8c-4888-83a2-7587abcafb26',
+        icon_background: '#F5F3FF',
+        icon_type: 'image',
+        icon_url: '/files/29bdb007-4d8c-4888-83a2-7587abcafb26/file-preview?sign=abc',
+      }),
+    ])
+
+    expect(container.querySelector('img[alt="app icon"]')).toHaveAttribute(
+      'src',
+      '/files/29bdb007-4d8c-4888-83a2-7587abcafb26/file-preview?sign=abc',
+    )
+  })
+
   it('exposes each agent card with the agent name', () => {
     renderList([createAgent()])
 

--- a/web/features/agent-v2/roster/components/agent-roster-list.tsx
+++ b/web/features/agent-v2/roster/components/agent-roster-list.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next'
 import { useExportAppDsl } from '@/app/components/app/use-export-app-dsl'
 import AppIcon from '@/app/components/base/app-icon'
 import { SkeletonRectangle } from '@/app/components/base/skeleton'
+import { getAgentAppIconImageUrl } from '@/features/agent-v2/utils/agent-icon'
 import useTimestamp from '@/hooks/use-timestamp'
 import Link from '@/next/link'
 import { AgentWorkflowReferencesDropdown } from './agent-workflow-references-dropdown'
@@ -126,8 +127,11 @@ function AgentRosterItem({ agent }: { agent: AgentAppPartial }) {
   const publishedReferences = agent.published_references ?? []
   const hasPublishedReferences = publishedReferences.length > 0
   const isDraft = agent.active_config_is_published !== true
-  const imageUrl =
-    agent.icon_type === 'image' || agent.icon_type === 'link' ? agent.icon : undefined
+  const imageUrl = getAgentAppIconImageUrl({
+    icon_type: agent.icon_type,
+    icon: agent.icon,
+    icon_url: agent.icon_url,
+  })
   const iconType = (imageUrl ? 'image' : agent.icon_type) as AgentIconType | null | undefined
 
   const handleEditOpen = () => {

--- a/web/features/agent-v2/utils/__tests__/agent-icon.spec.ts
+++ b/web/features/agent-v2/utils/__tests__/agent-icon.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { getAgentAppIconImageUrl } from '../agent-icon'
+
+describe('getAgentAppIconImageUrl', () => {
+  it('returns icon_url for image icons', () => {
+    expect(
+      getAgentAppIconImageUrl({
+        icon_type: 'image',
+        icon: '29bdb007-4d8c-4888-83a2-7587abcafb26',
+        icon_url: '/files/29bdb007-4d8c-4888-83a2-7587abcafb26/file-preview?sign=abc',
+      }),
+    ).toBe('/files/29bdb007-4d8c-4888-83a2-7587abcafb26/file-preview?sign=abc')
+  })
+
+  it('returns icon for link icons', () => {
+    expect(
+      getAgentAppIconImageUrl({
+        icon_type: 'link',
+        icon: 'https://example.com/icon.png',
+        icon_url: null,
+      }),
+    ).toBe('https://example.com/icon.png')
+  })
+
+  it('returns undefined for emoji icons', () => {
+    expect(
+      getAgentAppIconImageUrl({
+        icon_type: 'emoji',
+        icon: '🧪',
+        icon_url: null,
+      }),
+    ).toBeUndefined()
+  })
+})

--- a/web/features/agent-v2/utils/agent-icon.ts
+++ b/web/features/agent-v2/utils/agent-icon.ts
@@ -1,0 +1,12 @@
+export type AgentIconSource = {
+  icon_type?: string | null
+  icon?: string | null
+  icon_url?: string | null
+}
+
+export function getAgentAppIconImageUrl(agent: AgentIconSource): string | undefined {
+  if (agent.icon_type === 'image') return agent.icon_url ?? undefined
+  if (agent.icon_type === 'link') return agent.icon ?? undefined
+
+  return undefined
+}


### PR DESCRIPTION
## Summary

Fixes #40442

Agent image icons were rendered with the raw `upload_files.id` as the `<img src>`, causing 404s on Agents roster, configure sidebar, and workflow agent surfaces. This change uses the signed `icon_url` for image icons (and keeps external link icons unchanged).

## Changes

- Add `getAgentAppIconImageUrl()` helper for consistent icon URL resolution
- Update Agent UI surfaces to pass `icon_url` into `AppIcon.imageUrl`:
  - Agent roster list
  - Agent detail navigation
  - Workflow agent selector, node, and roster field
- Include `icon_url` in roster/invite-option API payloads via `AgentRosterService.serialize_agent`
- Add frontend and backend unit tests

## Test plan

- [x] `pnpm exec vitest run` on affected frontend test files (37 tests passed)
- [x] `pytest tests/unit_tests/services/agent/test_agent_services.py::test_serialize_agent_includes_icon_url_for_image_icons`
- [ ] Manual: create Agent with uploaded image icon, verify icon renders on roster + configure pages after reload