### PR TITLE
fix(agent-v2): download File System files on row click (#39961)

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/components/preview/__tests__/working-directory-panel.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/preview/__tests__/working-directory-panel.spec.tsx
@@ -350,30 +350,18 @@ describe('AgentWorkingDirectoryPanel', () => {
     )
   })
 
-  it('should download the selected working directory file from the preview header download action', async () => {
+  it('should download when clicking a file in the file system list', async () => {
     const user = userEvent.setup()
     const download = createDeferred<{ url: string }>()
     mocks.sandboxFileDownloadMutationFn.mockReturnValueOnce(download.promise)
     renderWorkingDirectoryPanel()
 
     await user.click(await screen.findByText('notes.md'))
-    await user.click(
-      await screen.findByRole('button', {
-        name: /common\.operation\.download.*notes\.md/i,
-      }),
-    )
-
-    const downloadingButton = await screen.findByRole('button', {
-      name: /common\.operation\.downloading.*notes\.md/i,
-    })
-    expect(downloadingButton.querySelector('.animate-spin')).toBeInTheDocument()
-    await user.click(downloadingButton)
-    expect(mocks.sandboxFileDownloadMutationFn).toHaveBeenCalledTimes(1)
 
     download.resolve({ url: 'https://example.com/sandbox-file' })
 
     await waitFor(() => {
-      expect(mocks.sandboxFileDownloadMutationFn).toHaveBeenCalled()
+      expect(mocks.sandboxFileDownloadMutationFn).toHaveBeenCalledTimes(1)
       expect(mocks.sandboxFileDownloadMutationFn.mock.calls[0]?.[0]).toEqual({
         params: {
           agent_id: 'agent-1',
@@ -392,13 +380,70 @@ describe('AgentWorkingDirectoryPanel', () => {
     })
   })
 
+  it('should download the selected working directory file from the preview header download action', async () => {
+    const user = userEvent.setup()
+    const selectDownload = createDeferred<{ url: string }>()
+    const headerDownload = createDeferred<{ url: string }>()
+    mocks.sandboxFileDownloadMutationFn
+      .mockReturnValueOnce(selectDownload.promise)
+      .mockReturnValueOnce(headerDownload.promise)
+    renderWorkingDirectoryPanel()
+
+    await user.click(await screen.findByText('notes.md'))
+    selectDownload.resolve({ url: 'https://example.com/sandbox-file-select' })
+
+    await waitFor(() => {
+      expect(mocks.sandboxFileDownloadMutationFn).toHaveBeenCalledTimes(1)
+    })
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: /common\.operation\.download.*notes\.md/i,
+      }),
+    )
+
+    const downloadingButton = await screen.findByRole('button', {
+      name: /common\.operation\.downloading.*notes\.md/i,
+    })
+    expect(downloadingButton.querySelector('.animate-spin')).toBeInTheDocument()
+    expect(mocks.sandboxFileDownloadMutationFn).toHaveBeenCalledTimes(2)
+
+    headerDownload.resolve({ url: 'https://example.com/sandbox-file' })
+
+    await waitFor(() => {
+      expect(mocks.sandboxFileDownloadMutationFn.mock.calls[1]?.[0]).toEqual({
+        params: {
+          agent_id: 'agent-1',
+        },
+        body: {
+          caller_type: 'conversation',
+          caller_id: 'conversation-1',
+          path: '~/workspace/notes.md',
+        },
+      })
+      expect(mocks.downloadUrl).toHaveBeenLastCalledWith({
+        url: 'https://example.com/sandbox-file',
+        fileName: 'notes.md',
+      })
+      expect(toast.success).toHaveBeenCalledWith('common.operation.downloadSuccess')
+    })
+  })
+
   it('should download binary working directory files from the unsupported preview download link', async () => {
     const user = userEvent.setup()
-    const download = createDeferred<{ url: string }>()
-    mocks.sandboxFileDownloadMutationFn.mockReturnValueOnce(download.promise)
+    const selectDownload = createDeferred<{ url: string }>()
+    const previewDownload = createDeferred<{ url: string }>()
+    mocks.sandboxFileDownloadMutationFn
+      .mockReturnValueOnce(selectDownload.promise)
+      .mockReturnValueOnce(previewDownload.promise)
     renderWorkingDirectoryPanel()
 
     await user.click(await screen.findByText('model.bin'))
+    selectDownload.resolve({ url: 'https://example.com/sandbox-file-select' })
+
+    await waitFor(() => {
+      expect(mocks.sandboxFileDownloadMutationFn).toHaveBeenCalledTimes(1)
+    })
 
     expect(
       await screen.findByText('agentV2.agentDetail.configure.files.preview.unsupported'),
@@ -414,11 +459,11 @@ describe('AgentWorkingDirectoryPanel', () => {
     })
     expect(headerDownloadButton.querySelector('.animate-spin')).not.toBeInTheDocument()
 
-    download.resolve({ url: 'https://example.com/sandbox-file' })
+    previewDownload.resolve({ url: 'https://example.com/sandbox-file' })
 
     await waitFor(() => {
-      expect(mocks.sandboxFileDownloadMutationFn).toHaveBeenCalled()
-      expect(mocks.sandboxFileDownloadMutationFn.mock.calls[0]?.[0]).toEqual({
+      expect(mocks.sandboxFileDownloadMutationFn).toHaveBeenCalledTimes(2)
+      expect(mocks.sandboxFileDownloadMutationFn.mock.calls[1]?.[0]).toEqual({
         params: {
           agent_id: 'agent-1',
         },
@@ -428,7 +473,7 @@ describe('AgentWorkingDirectoryPanel', () => {
           path: '~/workspace/model.bin',
         },
       })
-      expect(mocks.downloadUrl).toHaveBeenCalledWith({
+      expect(mocks.downloadUrl).toHaveBeenLastCalledWith({
         url: 'https://example.com/sandbox-file',
         fileName: 'model.bin',
       })

--- a/web/features/agent-v2/agent-detail/configure/components/preview/working-directory-panel.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/preview/working-directory-panel.tsx
@@ -505,8 +505,8 @@ export function AgentWorkingDirectoryPanel({
     enabled: open && !!selectedWorkingDirectoryFile && isImagePreviewFile,
   })
   const handleDownloadFile = useCallback(
-    async (action: AgentSkillDetailDownloadAction) => {
-      if (!selectedWorkingDirectoryFile || isFileDownloadPending) return
+    async (action: AgentSkillDetailDownloadAction, targetFile = selectedWorkingDirectoryFile) => {
+      if (!targetFile || isFileDownloadPending) return
 
       if (source.type === 'agent') {
         setDownloadActionLoadingTarget(action)
@@ -518,10 +518,10 @@ export function AgentWorkingDirectoryPanel({
             body: {
               caller_type: source.callerType,
               caller_id: source.callerId,
-              path: toSandboxApiPath(selectedWorkingDirectoryFile.id),
+              path: toSandboxApiPath(targetFile.id),
             },
           })
-          downloadUrl({ url: result.url, fileName: selectedWorkingDirectoryFile.name })
+          downloadUrl({ url: result.url, fileName: targetFile.name })
           toast.success(tCommon(($) => $['operation.downloadSuccess']))
         } catch {
           // The generated client reports the mutation failure through its shared error handler.
@@ -541,10 +541,10 @@ export function AgentWorkingDirectoryPanel({
           },
           body: {
             node_execution_id: source.nodeExecutionId,
-            path: toSandboxApiPath(selectedWorkingDirectoryFile.id),
+            path: toSandboxApiPath(targetFile.id),
           },
         })
-        downloadUrl({ url: result.url, fileName: selectedWorkingDirectoryFile.name })
+        downloadUrl({ url: result.url, fileName: targetFile.name })
         toast.success(tCommon(($) => $['operation.downloadSuccess']))
       } catch {
         // The generated client reports the mutation failure through its shared error handler.
@@ -560,6 +560,15 @@ export function AgentWorkingDirectoryPanel({
       downloadAgentSandboxFile,
       downloadWorkflowSandboxFile,
     ],
+  )
+  const handleSelectFile = useCallback(
+    (selectedFile: AgentFileNode) => {
+      setSelectedFileId(selectedFile.id)
+      if (selectedFile.icon === 'image') return
+
+      void handleDownloadFile('header', selectedFile)
+    },
+    [handleDownloadFile],
   )
 
   return (
@@ -658,7 +667,7 @@ export function AgentWorkingDirectoryPanel({
             )
           },
           onFolderDoubleClick: ({ file }) => handleDirectoryPathChange(toSandboxHomePath(file.id)),
-          onSelectFile: (selectedFile) => setSelectedFileId(selectedFile.id),
+          onSelectFile: handleSelectFile,
           renderFolderSuffix: ({ file }) =>
             loadingFolderPaths.has(file.id) ? (
               <span


### PR DESCRIPTION
## Summary

Fixes #39961 — agent-generated files in the Agents (BETA) File System panel now start downloading when clicked.

### Root cause

Two issues combined to make files appear "unclickable" on 1.16.1:

1. **Backend (already fixed on main via #40143):** The working directory panel previously called the sandbox **upload** API for downloads, which never returned a valid download URL.
2. **Frontend UX gap:** Clicking a file row only updated preview selection; users had to find and click a separate download button in the preview header.

### Changes

- Trigger sandbox file download when selecting a **non-image** file in the working directory file tree
- Image files continue to use inline preview (no redundant download on click)
- Header/preview download actions still work for manual re-download

## Test plan

- [x] `vitest run working-directory-panel.spec.tsx` — 11 tests passed
- [x] Added test: clicking a file row starts download
- [x] Updated existing download/header/binary tests for new select-on-click behavior

## Notes

Users on **1.16.1** also need the backend fix from #40143 (binding file download API). This PR builds on main where that fix is already merged.