### PR TITLE
fix(agent-app): deliver tool-generated images to the chat instead of dropping them

### DIFF
--- a/api/core/app/apps/agent_app/app_runner.py
+++ b/api/core/app/apps/agent_app/app_runner.py
@@ -16,6 +16,7 @@ from decimal import Decimal
 from typing import Any, Literal
 
 from dify_agent.layers.ask_human import AskHumanToolArgs
+from dify_agent.layers.dify_plugin import DIFY_PLUGIN_TOOL_FILES_METADATA_KEY
 from dify_agent.protocol import DeferredToolResultsPayload
 from pydantic import JsonValue
 
@@ -50,8 +51,12 @@ from core.app.entities.queue_entities import (
     QueueAgentThoughtEvent,
     QueueLLMChunkEvent,
     QueueMessageEndEvent,
+    QueueMessageFileEvent,
 )
 from core.repositories.human_input_repository import HumanInputFormRepository, HumanInputFormRepositoryImpl
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.tool_engine import ToolEngine
+from core.tools.utils.message_transformer import ToolFileMessageTransformer
 from core.workflow.nodes.agent_v2.ask_human_hitl import AskHumanFormBuildError, create_ask_human_form
 from core.workflow.nodes.agent_v2.ask_human_resume import build_deferred_tool_results, resolve_ask_human_form
 from extensions.ext_database import db
@@ -435,9 +440,21 @@ class _AgentProcessRecorder:
         content = part.get("content")
         if content is None:
             content = part
-        self._record_tool_observation(tool_call_id=tool_call_id, tool_name=tool_name, observation=content)
+        self._record_tool_observation(
+            tool_call_id=tool_call_id,
+            tool_name=tool_name,
+            observation=content,
+            file_references=_tool_file_references(part.get("metadata")),
+        )
 
-    def _record_tool_observation(self, *, tool_call_id: str | None, tool_name: str | None, observation: Any) -> None:
+    def _record_tool_observation(
+        self,
+        *,
+        tool_call_id: str | None,
+        tool_name: str | None,
+        observation: Any,
+        file_references: list[dict[str, Any]] | None = None,
+    ) -> None:
         self._close_thinking_segments()
         thought_id = self._lookup_observation_thought(tool_call_id=tool_call_id, tool_name=tool_name)
         if thought_id is None:
@@ -445,6 +462,67 @@ class _AgentProcessRecorder:
         else:
             self._mark_tool_observed(thought_id)
         self._update_thought(thought_id, observation=_json_or_text(observation))
+        if file_references:
+            self._persist_tool_files(thought_id, file_references)
+
+    def _persist_tool_files(self, thought_id: str, file_references: list[dict[str, Any]]) -> None:
+        """Replay the legacy tool-file chain for backend-reported tool files.
+
+        Mirrors ``ToolEngine.agent_invoke``: download each reported URL into a
+        ``ToolFile``, create ``MessageFile`` rows, and publish
+        ``QueueMessageFileEvent`` so the chat pipeline streams ``message_file``
+        events and ``message_end.files`` is populated. Failures degrade to the
+        text-only observation instead of failing the run.
+        """
+        try:
+            message = db.session.get(Message, self._message_id)
+            if message is None:
+                logger.warning("Agent App tool files skipped: message %s not found", self._message_id)
+                return
+            invoke_messages = [
+                ToolInvokeMessage(
+                    type=ToolInvokeMessage.MessageType.IMAGE,
+                    message=ToolInvokeMessage.TextMessage(text=url),
+                    meta={"mime_type": reference["mime_type"]} if reference.get("mime_type") else {},
+                )
+                for reference in file_references
+                if (url := reference.get("url"))
+            ]
+            if not invoke_messages:
+                return
+            transformed = list(
+                ToolFileMessageTransformer.transform_tool_invoke_messages(
+                    messages=(invoke_message for invoke_message in invoke_messages),
+                    user_id=self._dify_context.user_id,
+                    tenant_id=self._dify_context.tenant_id,
+                    conversation_id=message.conversation_id,
+                )
+            )
+            binary_files = ToolEngine._extract_tool_response_binary_and_text(transformed)
+            message_file_ids = ToolEngine._create_message_files(
+                tool_messages=binary_files,
+                agent_message=message,
+                invoke_from=self._dify_context.invoke_from,
+                user_id=self._dify_context.user_id,
+            )
+            if not message_file_ids:
+                return
+            thought = db.session.get(MessageAgentThought, thought_id)
+            if thought is not None:
+                thought.message_files = json.dumps(message_file_ids)
+                db.session.commit()
+            for message_file_id in message_file_ids:
+                self._queue_manager.publish(
+                    QueueMessageFileEvent(message_file_id=message_file_id), PublishFrom.APPLICATION_MANAGER
+                )
+        except Exception:
+            db.session.rollback()
+            logger.warning(
+                "Failed to persist Agent App tool files: message_id=%s thought_id=%s",
+                self._message_id,
+                thought_id,
+                exc_info=True,
+            )
 
     def _lookup_tool_thought(self, *, index: int, tool_call_id: str | None) -> str | None:
         if tool_call_id and tool_call_id in self._tool_by_call_id:
@@ -597,6 +675,20 @@ def _tool_labels(tool: str | None) -> str:
     if not tool:
         return "{}"
     return json.dumps({tool: {"en_US": tool, "zh_Hans": tool}}, ensure_ascii=False)
+
+
+def _tool_file_references(metadata: Any) -> list[dict[str, Any]]:
+    """Extract SDK-reported tool file references from ToolReturnPart metadata."""
+    if not isinstance(metadata, dict):
+        return []
+    references = metadata.get(DIFY_PLUGIN_TOOL_FILES_METADATA_KEY)
+    if not isinstance(references, list):
+        return []
+    return [
+        reference
+        for reference in references
+        if isinstance(reference, dict) and isinstance(reference.get("url"), str) and reference["url"]
+    ]
 
 
 def _suffix_prefix_overlap_length(text: str, prefix_source: str) -> int:

--- a/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
+++ b/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
@@ -61,7 +61,11 @@ from core.app.entities.queue_entities import (
     QueueAgentThoughtEvent,
     QueueLLMChunkEvent,
     QueueMessageEndEvent,
+    QueueMessageFileEvent,
 )
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.tool_engine import ToolEngine
+from core.tools.utils.message_transformer import ToolFileMessageTransformer
 from core.workflow.nodes.agent_v2.ask_human_resume import AskHumanResumeOutcome
 from core.workflow.nodes.agent_v2.dify_tools_builder import WorkflowAgentToolLayers
 from graphon.model_runtime.entities.llm_entities import LLMResult, LLMUsage
@@ -1635,3 +1639,194 @@ def test_submitted_form_resumes_turn_with_deferred_tool_results(monkeypatch: pyt
     # mismatch). A resume therefore re-sends a non-blank query, never blank.
     layer_names = [layer.name for layer in client.request.composition.layers]
     assert "agent_app_user_prompt" in layer_names
+
+
+def test_tool_result_file_metadata_persists_message_files(
+    sqlite_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Issue #40425: tool-result events carrying SDK-reported file references must
+    # replay the legacy tool-file chain so the chat pipeline can render them.
+    message = Message(
+        id="msg-1",
+        app_id="app-1",
+        conversation_id="conv-1",
+        _inputs={},
+        query="draw a cat",
+        message={},
+        message_unit_price=Decimal(0),
+        answer="",
+        answer_unit_price=Decimal(0),
+        currency="USD",
+        from_source=ConversationFromSource.API,
+    )
+    sqlite_session.add(message)
+    sqlite_session.commit()
+
+    transform_calls: list[dict[str, Any]] = []
+
+    def fake_transform(
+        *,
+        messages: Any,
+        user_id: str,
+        tenant_id: str,
+        conversation_id: str | None = None,
+    ) -> Iterator[ToolInvokeMessage]:
+        message_list = list(messages)
+        transform_calls.append(
+            {
+                "messages": message_list,
+                "user_id": user_id,
+                "tenant_id": tenant_id,
+                "conversation_id": conversation_id,
+            }
+        )
+        for _ in message_list:
+            yield ToolInvokeMessage(
+                type=ToolInvokeMessage.MessageType.IMAGE_LINK,
+                message=ToolInvokeMessage.TextMessage(text="/files/tools/tool-file-1.png"),
+                meta={"mime_type": "image/png", "tool_file_id": "tool-file-1"},
+            )
+
+    create_calls: list[dict[str, Any]] = []
+
+    def fake_create_message_files(
+        *, tool_messages: Any, agent_message: Message, invoke_from: InvokeFrom, user_id: str
+    ) -> list[str]:
+        create_calls.append(
+            {
+                "binaries": list(tool_messages),
+                "agent_message_id": agent_message.id,
+                "invoke_from": invoke_from,
+                "user_id": user_id,
+            }
+        )
+        return ["message-file-1"]
+
+    monkeypatch.setattr(
+        ToolFileMessageTransformer,
+        "transform_tool_invoke_messages",
+        staticmethod(fake_transform),
+    )
+    monkeypatch.setattr(ToolEngine, "_create_message_files", staticmethod(fake_create_message_files))
+
+    qm = _FakeQueueManager()
+    recorder = app_runner_module._AgentProcessRecorder(
+        dify_context=_dify_ctx(),
+        message_id="msg-1",
+        queue_manager=qm,  # type: ignore[arg-type]
+    )
+
+    recorder.handle_stream_event(
+        AgentBackendStreamInternalEvent(
+            run_id="run-1",
+            data={
+                "event_kind": "function_tool_call",
+                "part": {
+                    "part_kind": "tool-call",
+                    "tool_name": "generate_image",
+                    "args": {"prompt": "a cat"},
+                    "tool_call_id": "call-1",
+                },
+            },
+        )
+    )
+    recorder.handle_stream_event(
+        AgentBackendStreamInternalEvent(
+            run_id="run-1",
+            data={
+                "event_kind": "function_tool_result",
+                "part": {
+                    "part_kind": "tool-return",
+                    "tool_name": "generate_image",
+                    "tool_call_id": "call-1",
+                    "content": "image has been created and sent to user already",
+                    "metadata": {
+                        "dify_tool_files": [
+                            {"type": "image", "url": "https://tools.example/cat.png", "mime_type": "image/png"}
+                        ]
+                    },
+                },
+            },
+        )
+    )
+
+    assert len(transform_calls) == 1
+    assert transform_calls[0]["user_id"] == "user-1"
+    assert transform_calls[0]["tenant_id"] == "tenant-1"
+    assert transform_calls[0]["conversation_id"] == "conv-1"
+    source_message = transform_calls[0]["messages"][0]
+    assert source_message.type == ToolInvokeMessage.MessageType.IMAGE
+    assert source_message.message.text == "https://tools.example/cat.png"
+    assert source_message.meta == {"mime_type": "image/png"}
+
+    assert len(create_calls) == 1
+    assert create_calls[0]["agent_message_id"] == "msg-1"
+    assert create_calls[0]["invoke_from"] == InvokeFrom.WEB_APP
+    assert [binary.url for binary in create_calls[0]["binaries"]] == ["/files/tools/tool-file-1.png"]
+
+    rows = _thought_rows(sqlite_session)
+    assert len(rows) == 1
+    assert rows[0].observation == "image has been created and sent to user already"
+    assert rows[0].message_files == '["message-file-1"]'
+
+    file_events = [e for e in qm.events if isinstance(e, QueueMessageFileEvent)]
+    assert [e.message_file_id for e in file_events] == ["message-file-1"]
+
+
+def test_tool_result_file_persistence_failure_keeps_observation(
+    sqlite_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A failing download/persist chain must degrade to the text-only observation.
+    message = Message(
+        id="msg-1",
+        app_id="app-1",
+        conversation_id="conv-1",
+        _inputs={},
+        query="draw a cat",
+        message={},
+        message_unit_price=Decimal(0),
+        answer="",
+        answer_unit_price=Decimal(0),
+        currency="USD",
+        from_source=ConversationFromSource.API,
+    )
+    sqlite_session.add(message)
+    sqlite_session.commit()
+
+    def broken_transform(**_kwargs: Any) -> Iterator[ToolInvokeMessage]:
+        raise RuntimeError("download failed")
+
+    monkeypatch.setattr(
+        ToolFileMessageTransformer,
+        "transform_tool_invoke_messages",
+        staticmethod(broken_transform),
+    )
+
+    qm = _FakeQueueManager()
+    recorder = app_runner_module._AgentProcessRecorder(
+        dify_context=_dify_ctx(),
+        message_id="msg-1",
+        queue_manager=qm,  # type: ignore[arg-type]
+    )
+
+    recorder.handle_stream_event(
+        AgentBackendStreamInternalEvent(
+            run_id="run-1",
+            data={
+                "event_kind": "function_tool_result",
+                "part": {
+                    "part_kind": "tool-return",
+                    "tool_name": "generate_image",
+                    "tool_call_id": "call-1",
+                    "content": "image has been created and sent to user already",
+                    "metadata": {"dify_tool_files": [{"type": "image", "url": "https://tools.example/cat.png"}]},
+                },
+            },
+        )
+    )
+
+    rows = _thought_rows(sqlite_session)
+    assert len(rows) == 1
+    assert rows[0].observation == "image has been created and sent to user already"
+    assert rows[0].message_files == ""
+    assert [e for e in qm.events if isinstance(e, QueueMessageFileEvent)] == []

--- a/dify-agent/src/dify_agent/layers/dify_plugin/__init__.py
+++ b/dify-agent/src/dify_agent/layers/dify_plugin/__init__.py
@@ -6,6 +6,7 @@ dependencies. Keep this package root import-safe for client-only installs.
 
 from dify_agent.layers.dify_plugin.configs import (
     DIFY_PLUGIN_LLM_LAYER_TYPE_ID,
+    DIFY_PLUGIN_TOOL_FILES_METADATA_KEY,
     DIFY_PLUGIN_TOOLS_LAYER_TYPE_ID,
     DifyPluginCredentialValue,
     DifyPluginLLMLayerConfig,
@@ -21,6 +22,7 @@ from dify_agent.layers.dify_plugin.configs import (
 
 __all__ = [
     "DIFY_PLUGIN_LLM_LAYER_TYPE_ID",
+    "DIFY_PLUGIN_TOOL_FILES_METADATA_KEY",
     "DIFY_PLUGIN_TOOLS_LAYER_TYPE_ID",
     "DifyPluginCredentialValue",
     "DifyPluginLLMLayerConfig",

--- a/dify-agent/src/dify_agent/layers/dify_plugin/configs.py
+++ b/dify-agent/src/dify_agent/layers/dify_plugin/configs.py
@@ -28,6 +28,12 @@ DifyPluginToolCredentialType: TypeAlias = Literal["api-key", "oauth2", "unauthor
 DifyPluginToolValue: TypeAlias = JsonValue
 DIFY_PLUGIN_LLM_LAYER_TYPE_ID: Final[str] = "dify.plugin.llm"
 DIFY_PLUGIN_TOOLS_LAYER_TYPE_ID: Final[str] = "dify.plugin.tools"
+# Key under ToolReturnPart.metadata carrying file references produced by a plugin
+# tool. The metadata channel is application-facing only and never reaches the
+# LLM; the Dify API reads this key off the tool-result stream event to persist
+# and render tool-generated files (dify issue #40425). Client-safe by design so
+# API-side consumers can import it without server-only dependencies.
+DIFY_PLUGIN_TOOL_FILES_METADATA_KEY: Final[str] = "dify_tool_files"
 
 
 class DifyPluginToolOption(BaseModel):
@@ -172,6 +178,7 @@ class DifyPluginToolsLayerConfig(LayerConfig):
 
 __all__ = [
     "DIFY_PLUGIN_LLM_LAYER_TYPE_ID",
+    "DIFY_PLUGIN_TOOL_FILES_METADATA_KEY",
     "DIFY_PLUGIN_TOOLS_LAYER_TYPE_ID",
     "DifyPluginCredentialValue",
     "DifyPluginLLMLayerConfig",

--- a/dify-agent/src/dify_agent/layers/dify_plugin/tools_layer.py
+++ b/dify-agent/src/dify_agent/layers/dify_plugin/tools_layer.py
@@ -23,12 +23,13 @@ from urllib.parse import urlparse
 
 import httpx
 from pydantic import BaseModel, ConfigDict, JsonValue, ValidationError
-from pydantic_ai import RunContext, Tool
+from pydantic_ai import RunContext, Tool, ToolReturn
 from pydantic_ai.tools import ToolDefinition
 from typing_extensions import Self, override
 
 from agenton.layers import LayerDeps, PlainLayer
 from dify_agent.layers.dify_plugin.configs import (
+    DIFY_PLUGIN_TOOL_FILES_METADATA_KEY,
     DIFY_PLUGIN_TOOLS_LAYER_TYPE_ID,
     DifyPluginToolConfig,
     DifyPluginToolParameter,
@@ -259,7 +260,7 @@ def _build_pydantic_ai_tool(
     tool_description = tool_config.description or tool_name
     tool_schema = deepcopy(tool_config.parameters_json_schema)
 
-    async def invoke_tool(_ctx: RunContext[object], **tool_arguments: object) -> str:
+    async def invoke_tool(_ctx: RunContext[object], **tool_arguments: object) -> str | ToolReturn:
         try:
             merged_arguments = await _prepare_tool_arguments(
                 effective_parameters,
@@ -274,7 +275,14 @@ def _build_pydantic_ai_tool(
                 credentials=dict(tool_config.credentials),
                 tool_parameters=merged_arguments,
             )
-            return _convert_tool_response_to_text(messages)
+            observation = _convert_tool_response_to_text(messages)
+            file_references = _extract_tool_file_references(messages)
+            if file_references:
+                return ToolReturn(
+                    return_value=observation,
+                    metadata={DIFY_PLUGIN_TOOL_FILES_METADATA_KEY: file_references},
+                )
+            return observation
         except DifyPluginToolClientError as exc:
             return _tool_error_text(tool_name=tool_name, error=exc)
         except ValueError as exc:
@@ -676,6 +684,35 @@ def _convert_tool_response_to_text(tool_response: Sequence[DifyPluginToolInvokeM
         existing_parts = set(parts)
         parts.extend(part for part in json_parts if part not in existing_parts)
     return "".join(parts)
+
+
+def _extract_tool_file_references(
+    tool_response: Sequence[DifyPluginToolInvokeMessage],
+) -> list[dict[str, object]]:
+    """Collect URL-bearing file messages the text conversion cannot represent.
+
+    ``IMAGE`` / ``IMAGE_LINK`` daemon messages carry the created file's URL in
+    ``message.text``. The observation text intentionally replaces them with a
+    fixed instruction, so without this side channel the URL is unrecoverable
+    downstream. Blob-type messages are not collected: the daemon stream client
+    delivers them as raw bytes, which do not belong in event metadata.
+    """
+    references: list[dict[str, object]] = []
+    for response in tool_response:
+        if response.type not in {
+            DifyPluginToolInvokeMessage.MessageType.IMAGE,
+            DifyPluginToolInvokeMessage.MessageType.IMAGE_LINK,
+        }:
+            continue
+        message = response.message
+        if not isinstance(message, DifyPluginToolInvokeMessage.TextMessage) or not message.text:
+            continue
+        reference: dict[str, object] = {"type": "image", "url": message.text}
+        mime_type = (response.meta or {}).get("mime_type")
+        if isinstance(mime_type, str) and mime_type:
+            reference["mime_type"] = mime_type
+        references.append(reference)
+    return references
 
 
 __all__ = ["DifyPluginToolsDeps", "DifyPluginToolsLayer"]

--- a/dify-agent/tests/local/dify_agent/layers/dify_plugin/test_configs.py
+++ b/dify-agent/tests/local/dify_agent/layers/dify_plugin/test_configs.py
@@ -19,6 +19,7 @@ from dify_agent.layers.dify_plugin import (
 def test_dify_plugin_package_exports_client_safe_config_symbols_only() -> None:
     assert dify_plugin_exports.__all__ == [
         "DIFY_PLUGIN_LLM_LAYER_TYPE_ID",
+        "DIFY_PLUGIN_TOOL_FILES_METADATA_KEY",
         "DIFY_PLUGIN_TOOLS_LAYER_TYPE_ID",
         "DifyPluginCredentialValue",
         "DifyPluginLLMLayerConfig",

--- a/dify-agent/tests/local/dify_agent/layers/dify_plugin/test_layers.py
+++ b/dify-agent/tests/local/dify_agent/layers/dify_plugin/test_layers.py
@@ -10,6 +10,7 @@ from agenton.compositor import Compositor, LayerNode, LayerProvider
 from dify_agent.adapters.llm import DifyLLMAdapterModel
 from dify_agent.layers.dify_plugin.configs import (
     DIFY_PLUGIN_LLM_LAYER_TYPE_ID,
+    DIFY_PLUGIN_TOOL_FILES_METADATA_KEY,
     DIFY_PLUGIN_TOOLS_LAYER_TYPE_ID,
     DifyPluginLLMLayerConfig,
     DifyPluginToolConfig,
@@ -334,6 +335,62 @@ def test_dify_plugin_tools_layer_uses_prepared_tool_definition_and_invokes_daemo
                 assert tool_def.parameters_json_schema == _prepared_tool_schema()
                 assert tool_def.strict is False
                 assert result == 'found {"count": 1}'
+
+    asyncio.run(scenario())
+
+
+def test_dify_plugin_tools_layer_reports_image_urls_via_tool_return_metadata() -> None:
+    # Issue #40425: the observation text intentionally replaces image messages
+    # with a fixed instruction, so the created file's URL must survive on the
+    # application-only ToolReturn metadata channel for the API to render it.
+    from pydantic_ai import ToolReturn
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/dispatch/tool/invoke"):
+            stream_payload = "\n".join(
+                [
+                    f"data: {json.dumps({'code': 0, 'message': 'ok', 'data': {'type': 'image_link', 'message': {'text': 'https://tools.example/generated/cat.png'}, 'meta': {'mime_type': 'image/png'}}})}",
+                    "",
+                ]
+            )
+            return httpx.Response(200, text=stream_payload)
+
+        raise AssertionError(f"Unexpected request path: {request.url.path}")
+
+    async def scenario() -> None:
+        compositor = Compositor(
+            [
+                LayerNode("execution_context", _execution_context_provider()),
+                LayerNode("tools", _tools_provider(), deps={"execution_context": "execution_context"}),
+            ]
+        )
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            async with compositor.enter(
+                configs={"execution_context": _execution_context_config(), "tools": _tools_config()}
+            ) as run:
+                tools_layer = run.get_layer("tools", DifyPluginToolsLayer)
+                tool = (await tools_layer.get_tools(http_client=client, dify_api_http_client=client))[0]
+
+                result = await tool.function_schema.call(
+                    {"query": "dify", "region": "global"},
+                    None,  # pyright: ignore[reportArgumentType]
+                )
+
+                assert isinstance(result, ToolReturn)
+                # The LLM-facing observation is byte-identical to the pre-fix text.
+                assert result.return_value == (
+                    "image has been created and sent to user already, "
+                    "you do not need to create it, just tell the user to check it now."
+                )
+                assert result.metadata == {
+                    DIFY_PLUGIN_TOOL_FILES_METADATA_KEY: [
+                        {
+                            "type": "image",
+                            "url": "https://tools.example/generated/cat.png",
+                            "mime_type": "image/png",
+                        }
+                    ]
+                }
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
Fixes #40425

## Summary

Credit where it is due: @iMLe0n's source analysis in #40425 identified both loss layers precisely — `_convert_tool_response_to_text` discarding the URL carried in `message.text`, and `AgentAppRunner`/`_AgentProcessRecorder` having no equivalent of the legacy `ToolFileMessageTransformer → ToolEngine._create_message_files → QueueMessageFileEvent` chain. This PR implements their Option A, with one refinement: rather than changing the observation text, the SDK reports URL-bearing `IMAGE`/`IMAGE_LINK` messages on pydantic-ai's application-only `ToolReturn.metadata` channel (`dify_tool_files` key, new client-safe constant in `dify_agent.layers.dify_plugin.configs`). The LLM-facing observation is byte-identical to before — covered by a test — so model behaviour cannot change, and `ToolReturnPart.metadata` already exists in the wire schema, so the protocol gains no new field.

On the API side, `_AgentProcessRecorder` now extracts those references from tool-result events and replays the existing legacy chain: `ToolFileMessageTransformer.transform_tool_invoke_messages` downloads the image into a `ToolFile` (same SSRF-protected path as legacy Agent Chat), `ToolEngine._create_message_files` creates the `MessageFile` rows, the thought row gets `message_files`, and `QueueMessageFileEvent` is published — from which the existing EasyUI pipeline already produces `message_file` SSE events and a populated `message_end.files`. No frontend changes needed. Any failure in the file chain degrades to the text-only observation instead of failing the run.

Two findings from implementation, both about the code rather than the report:

- An API-only fix (issue's Option B) is not possible: the tool closure returns only the converted text, so `ToolReturnPart.content` — the only thing the API receives — carries no file information. The SDK half of this change is what makes the API half possible.
- `agent_v2/agent_node.py` (workflow Agent node) loses the images too, but has no Message/MessageFile surface — exposing tool files there means file-typed node outputs, which is a separate feature. This PR puts the references on the wire for that path as well, so a follow-up can build on it without another SDK change.

Version-skew safe in both directions: an older API ignores the metadata key; an older agent backend sends no metadata and the API behaves exactly as today.

Known limitation: blob-type tool messages (raw bytes on the daemon stream) are not collected — only URL-bearing image messages. In `dify-official-plugins`, 28 tools emit `IMAGE` via `create_image_message` and one (`ddgo_img`) emits `IMAGE_LINK`, so the URL-bearing case covers the tool ecosystem's common path; blob-emitting tools (e.g. the QR-code generator) are a follow-up.

## Verification

**Runtime, end to end (self-hosted Docker, 1.16.1 images):** with the fal `FLUX.1 [dev]` tool configured on an Agent App and the prompt "Use the FLUX.1 [dev] tool to generate an image of a golden retriever":

- **Without this change** (1.16.1): the tool returned a real image URL; the chat showed only "image has been created and sent to user already…" and no image — reproducing the reported behaviour at runtime, since the issue's original analysis was source-only.
- **With this change** (same images, the branch's four source files applied): the image renders in the chat. The exercised path is `IMAGE`-with-URL over a live agent backend; `IMAGE_LINK` follows the identical branch but was not runtime-exercised (the only credential-free `IMAGE_LINK` tool, DuckDuckGo image search, rate-limited during testing).
- The two runs were on two stacks built from the same 1.16.1 images (the unfixed one additionally had `INTERNAL_FILES_URL` set explicitly, unrelated to this path), so this is a before/after demonstration rather than a single-variable toggle on one deployment.

**Unit tests, both failing before and passing after:** SDK-side (daemon `image_link` → `ToolReturn` with unchanged observation text and the file reference in metadata) and API-side (tool-result event with metadata → `MessageFile` ids on the thought, `QueueMessageFileEvent` published; transformer failure → clean degradation to the text-only observation). Full `dify-agent` local suite and the `agent_app` / `clients/agent_backend` / `core/tools` API suites pass.

## Screenshots

**Before**
<img width="1280" height="1203" alt="40425-before" src="https://github.com/user-attachments/assets/9b6c1528-c57f-4e64-950b-7afa47b1f2af" />

**After**
<img width="1280" height="1203" alt="40425-after" src="https://github.com/user-attachments/assets/5a66e3ee-d091-4d1c-ae72-2f56701b8ff9" />

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [x] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods — ruff clean on all changed files; the api-wide `make type-check` reports 194 pre-existing errors on any file including untouched ones, so I have not claimed that gate passes

From Claude Code