### PR TITLE
refactor(dify-agent): migrate stable run failure reasons to RunFailureType (#40117)

### DIFF
--- a/api/core/app/apps/agent_app/app_runner.py
+++ b/api/core/app/apps/agent_app/app_runner.py
@@ -88,7 +88,11 @@ _AGENT_BACKEND_INVOKE_ERROR_BY_REASON: Mapping[str, type[InvokeError]] = {
 }
 
 _AGENT_BACKEND_INVOKE_ERROR_BY_FAILURE_TYPE: Mapping[RunFailureType, type[InvokeError]] = {
+    RunFailureType.INVOKE_AUTHORIZATION_ERROR: InvokeAuthorizationError,
+    RunFailureType.INVOKE_BAD_REQUEST_ERROR: InvokeBadRequestError,
+    RunFailureType.INVOKE_CONNECTION_ERROR: InvokeConnectionError,
     RunFailureType.INVOKE_RATE_LIMIT_EXCEEDED: InvokeRateLimitError,
+    RunFailureType.INVOKE_SERVER_UNAVAILABLE_ERROR: InvokeServerUnavailableError,
 }
 
 

--- a/api/core/app/apps/agent_app/app_runner.py
+++ b/api/core/app/apps/agent_app/app_runner.py
@@ -16,7 +16,7 @@ from decimal import Decimal
 from typing import Any, Literal
 
 from dify_agent.layers.ask_human import AskHumanToolArgs
-from dify_agent.protocol import DeferredToolResultsPayload
+from dify_agent.protocol import DeferredToolResultsPayload, RunFailureType
 from pydantic import JsonValue
 
 from clients.agent_backend import (
@@ -87,8 +87,16 @@ _AGENT_BACKEND_INVOKE_ERROR_BY_REASON: Mapping[str, type[InvokeError]] = {
     "InvokeServerUnavailableError": InvokeServerUnavailableError,
 }
 
+_AGENT_BACKEND_INVOKE_ERROR_BY_FAILURE_TYPE: Mapping[RunFailureType, type[InvokeError]] = {
+    RunFailureType.INVOKE_RATE_LIMIT_EXCEEDED: InvokeRateLimitError,
+}
+
 
 def _agent_backend_failure_to_exception(event: AgentBackendRunFailedInternalEvent) -> Exception:
+    if event.error_type is not None:
+        err_cls = _AGENT_BACKEND_INVOKE_ERROR_BY_FAILURE_TYPE.get(event.error_type)
+        if err_cls is not None:
+            return err_cls(event.error)
     if event.error_type is None:
         err_cls = _AGENT_BACKEND_INVOKE_ERROR_BY_REASON.get(event.reason or "")
         if err_cls is not None:
@@ -703,7 +711,9 @@ class AgentAppRunner:
         if not isinstance(terminal, AgentBackendRunSucceededInternalEvent):
             if isinstance(terminal, AgentBackendRunFailedInternalEvent):
                 reason = terminal.reason
-                if terminal.error_type is None and reason == "binding_lost":
+                if terminal.error_type == RunFailureType.BINDING_LOST or (
+                    terminal.error_type is None and reason == "binding_lost"
+                ):
                     raise AgentBackendError("The retained agent working environment is no longer available.")
                 raise _agent_backend_failure_to_exception(terminal)
             raise AgentBackendError("Agent backend run did not complete successfully.")

--- a/api/core/app/apps/agent_app/app_runner.py
+++ b/api/core/app/apps/agent_app/app_runner.py
@@ -16,7 +16,7 @@ from decimal import Decimal
 from typing import Any, Literal
 
 from dify_agent.layers.ask_human import AskHumanToolArgs
-from dify_agent.protocol import DeferredToolResultsPayload, RunFailureType
+from dify_agent.protocol import DeferredToolResultsPayload, RunFailureType, resolve_run_failure_type
 from pydantic import JsonValue
 
 from clients.agent_backend import (
@@ -78,15 +78,6 @@ class _DefaultSessionScopeSnapshotId:
 
 _DEFAULT_SESSION_SCOPE_SNAPSHOT_ID = _DefaultSessionScopeSnapshotId()
 
-_AGENT_BACKEND_INVOKE_ERROR_BY_REASON: Mapping[str, type[InvokeError]] = {
-    "InvokeAuthorizationError": InvokeAuthorizationError,
-    "InvokeBadRequestError": InvokeBadRequestError,
-    "CredentialsValidateFailedError": InvokeBadRequestError,
-    "InvokeConnectionError": InvokeConnectionError,
-    "InvokeRateLimitError": InvokeRateLimitError,
-    "InvokeServerUnavailableError": InvokeServerUnavailableError,
-}
-
 _AGENT_BACKEND_INVOKE_ERROR_BY_FAILURE_TYPE: Mapping[RunFailureType, type[InvokeError]] = {
     RunFailureType.INVOKE_AUTHORIZATION_ERROR: InvokeAuthorizationError,
     RunFailureType.INVOKE_BAD_REQUEST_ERROR: InvokeBadRequestError,
@@ -97,12 +88,9 @@ _AGENT_BACKEND_INVOKE_ERROR_BY_FAILURE_TYPE: Mapping[RunFailureType, type[Invoke
 
 
 def _agent_backend_failure_to_exception(event: AgentBackendRunFailedInternalEvent) -> Exception:
-    if event.error_type is not None:
-        err_cls = _AGENT_BACKEND_INVOKE_ERROR_BY_FAILURE_TYPE.get(event.error_type)
-        if err_cls is not None:
-            return err_cls(event.error)
-    if event.error_type is None:
-        err_cls = _AGENT_BACKEND_INVOKE_ERROR_BY_REASON.get(event.reason or "")
+    failure_type = resolve_run_failure_type(event.error_type, event.reason)
+    if failure_type is not None:
+        err_cls = _AGENT_BACKEND_INVOKE_ERROR_BY_FAILURE_TYPE.get(failure_type)
         if err_cls is not None:
             return err_cls(event.error)
     message = event.error or "Agent backend run did not complete successfully."
@@ -114,7 +102,7 @@ def _agent_backend_failure_to_exception(event: AgentBackendRunFailedInternalEven
             "source_event_id": event.source_event_id,
         },
         message=message,
-        error_type=event.error_type,
+        error_type=failure_type,
         reason=event.reason,
         source_event_id=event.source_event_id,
     )
@@ -714,10 +702,7 @@ class AgentAppRunner:
 
         if not isinstance(terminal, AgentBackendRunSucceededInternalEvent):
             if isinstance(terminal, AgentBackendRunFailedInternalEvent):
-                reason = terminal.reason
-                if terminal.error_type == RunFailureType.BINDING_LOST or (
-                    terminal.error_type is None and reason == "binding_lost"
-                ):
+                if resolve_run_failure_type(terminal.error_type, terminal.reason) == RunFailureType.BINDING_LOST:
                     raise AgentBackendError("The retained agent working environment is no longer available.")
                 raise _agent_backend_failure_to_exception(terminal)
             raise AgentBackendError("Agent backend run did not complete successfully.")

--- a/api/core/app/apps/base_app_generate_response_converter.py
+++ b/api/core/app/apps/base_app_generate_response_converter.py
@@ -118,7 +118,16 @@ class AppGenerateResponseConverter[TBlockingResponse: AppBlockingResponse](ABC):
         :param e: exception
         :return:
         """
-        if isinstance(e, AgentBackendRunFailedError) and e.error_type == RunFailureType.AGENT_RUN_LIMIT_EXCEEDED:
+        if isinstance(e, AgentBackendRunFailedError) and e.error_type in {
+            RunFailureType.AGENT_RUN_LIMIT_EXCEEDED,
+            RunFailureType.INVOKE_RATE_LIMIT_EXCEEDED,
+        }:
+            if e.error_type == RunFailureType.INVOKE_RATE_LIMIT_EXCEEDED:
+                return {
+                    "code": "rate_limit_error",
+                    "status": 429,
+                    "message": str(e),
+                }
             return {
                 "code": RunFailureType.AGENT_RUN_LIMIT_EXCEEDED.value,
                 "status": 400,

--- a/api/core/workflow/nodes/agent_v2/output_adapter.py
+++ b/api/core/workflow/nodes/agent_v2/output_adapter.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any, Protocol
 
+from dify_agent.protocol import resolve_run_failure_type
+
 from clients.agent_backend import (
     AgentBackendDeferredToolCallInternalEvent,
     AgentBackendInternalEvent,
@@ -98,7 +100,10 @@ class WorkflowAgentOutputAdapter:
         match event:
             case AgentBackendRunFailedInternalEvent():
                 error = event.error
-                error_type = event.error_type or event.reason or "agent_backend_run_failed"
+                failure_type = resolve_run_failure_type(event.error_type, event.reason)
+                error_type = (
+                    failure_type.value if failure_type is not None else event.reason or "agent_backend_run_failed"
+                )
                 terminal_status = "failed"
             case AgentBackendRunCancelledInternalEvent():
                 error = event.message or "Agent backend run was cancelled."

--- a/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
+++ b/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
@@ -61,7 +61,14 @@ from core.app.entities.queue_entities import (
 from core.workflow.nodes.agent_v2.ask_human_resume import AskHumanResumeOutcome
 from core.workflow.nodes.agent_v2.dify_tools_builder import WorkflowAgentToolLayers
 from graphon.model_runtime.entities.llm_entities import LLMResult
-from graphon.model_runtime.errors.invoke import InvokeRateLimitError
+from graphon.model_runtime.errors.invoke import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
 from models.agent_config_entities import AgentSoulConfig
 from models.model import MessageAgentThought
 
@@ -1204,6 +1211,31 @@ def test_agent_backend_failure_to_exception_maps_rate_limit_failure_type() -> No
 
     assert isinstance(err, InvokeRateLimitError)
     assert str(err) == "quota exceeded"
+
+
+@pytest.mark.parametrize(
+    ("failure_type", "expected_exception"),
+    [
+        (RunFailureType.INVOKE_AUTHORIZATION_ERROR, InvokeAuthorizationError),
+        (RunFailureType.INVOKE_BAD_REQUEST_ERROR, InvokeBadRequestError),
+        (RunFailureType.INVOKE_CONNECTION_ERROR, InvokeConnectionError),
+        (RunFailureType.INVOKE_SERVER_UNAVAILABLE_ERROR, InvokeServerUnavailableError),
+    ],
+)
+def test_agent_backend_failure_to_exception_maps_invoke_failure_types(
+    failure_type: RunFailureType,
+    expected_exception: type[InvokeError],
+) -> None:
+    err = app_runner_module._agent_backend_failure_to_exception(
+        AgentBackendRunFailedInternalEvent(
+            run_id="run-1",
+            error="provider failed",
+            error_type=failure_type,
+        )
+    )
+
+    assert isinstance(err, expected_exception)
+    assert str(err) == "provider failed"
 
 
 def test_agent_backend_failure_to_exception_preserves_unknown_reason_context() -> None:

--- a/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
+++ b/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
@@ -1193,6 +1193,19 @@ def test_agent_backend_failure_to_exception_maps_rate_limit_reason() -> None:
     assert str(err) == "quota exceeded"
 
 
+def test_agent_backend_failure_to_exception_maps_rate_limit_failure_type() -> None:
+    err = app_runner_module._agent_backend_failure_to_exception(
+        AgentBackendRunFailedInternalEvent(
+            run_id="run-1",
+            error="quota exceeded",
+            error_type=RunFailureType.INVOKE_RATE_LIMIT_EXCEEDED,
+        )
+    )
+
+    assert isinstance(err, InvokeRateLimitError)
+    assert str(err) == "quota exceeded"
+
+
 def test_agent_backend_failure_to_exception_preserves_unknown_reason_context() -> None:
     err = app_runner_module._agent_backend_failure_to_exception(
         AgentBackendRunFailedInternalEvent(

--- a/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
+++ b/api/tests/unit_tests/core/app/apps/agent_app/test_app_runner.py
@@ -1250,6 +1250,7 @@ def test_agent_backend_failure_to_exception_preserves_unknown_reason_context() -
 
     assert isinstance(err, AgentBackendRunFailedError)
     assert err.run_id == "run-1"
+    assert err.error_type is RunFailureType.KNOWLEDGE_RETRIEVE_FAILED
     assert err.reason == "knowledge_retrieve_failed"
     assert err.source_event_id == "event-1"
     assert err.detail == {

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_output_adapter.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_output_adapter.py
@@ -195,6 +195,22 @@ def test_failure_output_adapter_uses_knowledge_failure_type():
     assert result.error_type == "knowledge_retrieve_failed"
 
 
+def test_failure_output_adapter_resolves_legacy_invoke_reason():
+    result = WorkflowAgentOutputAdapter().build_failure_result(
+        event=AgentBackendRunFailedInternalEvent(
+            run_id="run-1",
+            error="quota exceeded",
+            error_type=None,
+            reason="InvokeRateLimitError",
+        ),
+        inputs={},
+        process_data={},
+        metadata={},
+    )
+
+    assert result.error_type == "invoke_rate_limit_exceeded"
+
+
 def test_failure_output_adapter_uses_default_error_type_without_backend_classification():
     result = WorkflowAgentOutputAdapter().build_failure_result(
         event=AgentBackendRunFailedInternalEvent(

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_output_adapter.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_output_adapter.py
@@ -179,6 +179,22 @@ def test_failure_output_adapter_prefers_run_failure_type_over_reason():
     assert result.error_type == "agent_run_limit_exceeded"
 
 
+def test_failure_output_adapter_uses_knowledge_failure_type():
+    result = WorkflowAgentOutputAdapter().build_failure_result(
+        event=AgentBackendRunFailedInternalEvent(
+            run_id="run-1",
+            error="Knowledge retrieval failed",
+            error_type=RunFailureType.KNOWLEDGE_RETRIEVE_FAILED,
+            reason="dataset_not_found",
+        ),
+        inputs={},
+        process_data={},
+        metadata={},
+    )
+
+    assert result.error_type == "knowledge_retrieve_failed"
+
+
 def test_failure_output_adapter_uses_default_error_type_without_backend_classification():
     result = WorkflowAgentOutputAdapter().build_failure_result(
         event=AgentBackendRunFailedInternalEvent(

--- a/dify-agent/src/dify_agent/protocol/__init__.py
+++ b/dify-agent/src/dify_agent/protocol/__init__.py
@@ -36,6 +36,7 @@ from .schemas import (
     RunSucceededEvent,
     RunSucceededEventData,
     normalize_composition,
+    resolve_run_failure_type,
     utc_now,
 )
 from .execution_binding import (
@@ -103,5 +104,6 @@ __all__ = [
     "RunSucceededEvent",
     "RunSucceededEventData",
     "normalize_composition",
+    "resolve_run_failure_type",
     "utc_now",
 ]

--- a/dify-agent/src/dify_agent/protocol/schemas.py
+++ b/dify-agent/src/dify_agent/protocol/schemas.py
@@ -68,6 +68,9 @@ class RunFailureType(StrEnum):
     """
 
     AGENT_RUN_LIMIT_EXCEEDED = "agent_run_limit_exceeded"
+    BINDING_LOST = "binding_lost"
+    INVOKE_RATE_LIMIT_EXCEEDED = "invoke_rate_limit_exceeded"
+    AGENT_SHUTDOWN = "agent_shutdown"
 
 
 def utc_now() -> datetime:

--- a/dify-agent/src/dify_agent/protocol/schemas.py
+++ b/dify-agent/src/dify_agent/protocol/schemas.py
@@ -69,7 +69,12 @@ class RunFailureType(StrEnum):
 
     AGENT_RUN_LIMIT_EXCEEDED = "agent_run_limit_exceeded"
     BINDING_LOST = "binding_lost"
+    INVOKE_AUTHORIZATION_ERROR = "invoke_authorization_error"
+    INVOKE_BAD_REQUEST_ERROR = "invoke_bad_request_error"
+    INVOKE_CONNECTION_ERROR = "invoke_connection_error"
     INVOKE_RATE_LIMIT_EXCEEDED = "invoke_rate_limit_exceeded"
+    INVOKE_SERVER_UNAVAILABLE_ERROR = "invoke_server_unavailable_error"
+    KNOWLEDGE_RETRIEVE_FAILED = "knowledge_retrieve_failed"
     AGENT_SHUTDOWN = "agent_shutdown"
 
 

--- a/dify-agent/src/dify_agent/protocol/schemas.py
+++ b/dify-agent/src/dify_agent/protocol/schemas.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import StrEnum
-from typing import Annotated, ClassVar, Final, Literal, TypeAlias
+from typing import Annotated, ClassVar, Final, Literal, Mapping, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, TypeAdapter, model_serializer, model_validator
 from pydantic_ai.messages import AgentStreamEvent
@@ -76,6 +76,43 @@ class RunFailureType(StrEnum):
     INVOKE_SERVER_UNAVAILABLE_ERROR = "invoke_server_unavailable_error"
     KNOWLEDGE_RETRIEVE_FAILED = "knowledge_retrieve_failed"
     AGENT_SHUTDOWN = "agent_shutdown"
+
+
+_LEGACY_REASON_TO_FAILURE_TYPE: Mapping[str, RunFailureType] = {
+    "InvokeAuthorizationError": RunFailureType.INVOKE_AUTHORIZATION_ERROR,
+    "InvokeBadRequestError": RunFailureType.INVOKE_BAD_REQUEST_ERROR,
+    "CredentialsValidateFailedError": RunFailureType.INVOKE_BAD_REQUEST_ERROR,
+    "InvokeConnectionError": RunFailureType.INVOKE_CONNECTION_ERROR,
+    "InvokeRateLimitError": RunFailureType.INVOKE_RATE_LIMIT_EXCEEDED,
+    "InvokeServerUnavailableError": RunFailureType.INVOKE_SERVER_UNAVAILABLE_ERROR,
+    "agent_run_limit_exceeded": RunFailureType.AGENT_RUN_LIMIT_EXCEEDED,
+    "binding_lost": RunFailureType.BINDING_LOST,
+    "invoke_authorization_error": RunFailureType.INVOKE_AUTHORIZATION_ERROR,
+    "invoke_bad_request_error": RunFailureType.INVOKE_BAD_REQUEST_ERROR,
+    "invoke_connection_error": RunFailureType.INVOKE_CONNECTION_ERROR,
+    "invoke_rate_limit_exceeded": RunFailureType.INVOKE_RATE_LIMIT_EXCEEDED,
+    "invoke_server_unavailable_error": RunFailureType.INVOKE_SERVER_UNAVAILABLE_ERROR,
+    "knowledge_retrieve_failed": RunFailureType.KNOWLEDGE_RETRIEVE_FAILED,
+    "agent_shutdown": RunFailureType.AGENT_SHUTDOWN,
+}
+
+
+def resolve_run_failure_type(
+    error_type: RunFailureType | None,
+    reason: str | None,
+) -> RunFailureType | None:
+    """Resolve a structured failure type from ``error_type`` or legacy ``reason``."""
+    if error_type is not None:
+        return error_type
+    if reason is None:
+        return None
+    mapped = _LEGACY_REASON_TO_FAILURE_TYPE.get(reason)
+    if mapped is not None:
+        return mapped
+    try:
+        return RunFailureType(reason)
+    except ValueError:
+        return None
 
 
 def utc_now() -> datetime:
@@ -445,5 +482,6 @@ __all__ = [
     "RunSucceededEventData",
     "RunLayerSpec",
     "normalize_composition",
+    "resolve_run_failure_type",
     "utc_now",
 ]

--- a/dify-agent/src/dify_agent/runtime/run_scheduler.py
+++ b/dify-agent/src/dify_agent/runtime/run_scheduler.py
@@ -21,7 +21,7 @@ from typing import Protocol
 import httpx
 
 from agenton.compositor import LayerProviderInput
-from dify_agent.protocol.schemas import CancelRunRequest, CancelRunResponse, CreateRunRequest
+from dify_agent.protocol.schemas import CancelRunRequest, CancelRunResponse, CreateRunRequest, RunFailureType
 from dify_agent.runtime.compositor_factory import create_default_layer_providers
 from dify_agent.runtime.event_sink import RunEventSink, emit_run_cancelled, emit_run_failed
 from dify_agent.runtime.runner import AgentRunRunner
@@ -246,7 +246,9 @@ class RunScheduler:
         """Best-effort failure event/status for shutdown-cancelled runs."""
         message = "run cancelled during server shutdown"
         try:
-            _ = await emit_run_failed(self.store, run_id=run_id, error=message, reason="shutdown")
+            _ = await emit_run_failed(
+                self.store, run_id=run_id, error=message, error_type=RunFailureType.AGENT_SHUTDOWN
+            )
         except Exception:
             logger.exception("failed to mark cancelled run failed", extra={"run_id": run_id})
 

--- a/dify-agent/src/dify_agent/runtime/runner.py
+++ b/dify-agent/src/dify_agent/runtime/runner.py
@@ -123,7 +123,7 @@ def _run_failed_error_payload(exc: Exception) -> tuple[str, RunFailureType | Non
         return message, RunFailureType.AGENT_RUN_LIMIT_EXCEEDED, None
 
     if isinstance(exc, BindingLostError):
-        return message, None, "binding_lost"
+        return message, RunFailureType.BINDING_LOST, None
 
     if isinstance(exc, ModelHTTPError):
         body = exc.body
@@ -134,10 +134,12 @@ def _run_failed_error_payload(exc: Exception) -> tuple[str, RunFailureType | Non
 
             error_type = body.get("error_type")
             if isinstance(error_type, str) and error_type:
+                if error_type == "InvokeRateLimitError":
+                    return message, RunFailureType.INVOKE_RATE_LIMIT_EXCEEDED, None
                 reason = error_type
 
         if reason is None and exc.status_code == 429:
-            reason = "InvokeRateLimitError"
+            return message, RunFailureType.INVOKE_RATE_LIMIT_EXCEEDED, None
 
     if isinstance(exc, DifyKnowledgeBaseClientError):
         reason = exc.error_code or "DifyKnowledgeBaseClientError"

--- a/dify-agent/src/dify_agent/runtime/runner.py
+++ b/dify-agent/src/dify_agent/runtime/runner.py
@@ -114,10 +114,19 @@ class AgentRunValidationError(ValueError):
     """Raised when a run request is valid JSON but cannot execute."""
 
 
+_INVOKE_FAILURE_TYPE_BY_BODY_ERROR_TYPE: Mapping[str, RunFailureType] = {
+    "InvokeAuthorizationError": RunFailureType.INVOKE_AUTHORIZATION_ERROR,
+    "InvokeBadRequestError": RunFailureType.INVOKE_BAD_REQUEST_ERROR,
+    "CredentialsValidateFailedError": RunFailureType.INVOKE_BAD_REQUEST_ERROR,
+    "InvokeConnectionError": RunFailureType.INVOKE_CONNECTION_ERROR,
+    "InvokeRateLimitError": RunFailureType.INVOKE_RATE_LIMIT_EXCEEDED,
+    "InvokeServerUnavailableError": RunFailureType.INVOKE_SERVER_UNAVAILABLE_ERROR,
+}
+
+
 def _run_failed_error_payload(exc: Exception) -> tuple[str, RunFailureType | None, str | None]:
     """Return the public failed-run error text, type, and structured reason."""
     message = str(exc) or type(exc).__name__
-    reason: str | None = None
 
     if isinstance(exc, UsageLimitExceeded):
         return message, RunFailureType.AGENT_RUN_LIMIT_EXCEEDED, None
@@ -132,19 +141,19 @@ def _run_failed_error_payload(exc: Exception) -> tuple[str, RunFailureType | Non
             if isinstance(body_message, str) and body_message:
                 message = body_message
 
-            error_type = body.get("error_type")
-            if isinstance(error_type, str) and error_type:
-                if error_type == "InvokeRateLimitError":
-                    return message, RunFailureType.INVOKE_RATE_LIMIT_EXCEEDED, None
-                reason = error_type
+            body_error_type = body.get("error_type")
+            if isinstance(body_error_type, str) and body_error_type:
+                failure_type = _INVOKE_FAILURE_TYPE_BY_BODY_ERROR_TYPE.get(body_error_type)
+                if failure_type is not None:
+                    return message, failure_type, None
 
-        if reason is None and exc.status_code == 429:
+        if exc.status_code == 429:
             return message, RunFailureType.INVOKE_RATE_LIMIT_EXCEEDED, None
 
     if isinstance(exc, DifyKnowledgeBaseClientError):
-        reason = exc.error_code or "DifyKnowledgeBaseClientError"
+        return message, RunFailureType.KNOWLEDGE_RETRIEVE_FAILED, None
 
-    return message, None, reason
+    return message, None, None
 
 
 def _has_model_layer(request: CreateRunRequest) -> bool:

--- a/dify-agent/tests/local/dify_agent/protocol/test_protocol_schemas.py
+++ b/dify-agent/tests/local/dify_agent/protocol/test_protocol_schemas.py
@@ -31,6 +31,7 @@ from dify_agent.protocol.schemas import (
     RunSucceededEvent,
     RunSucceededEventData,
     normalize_composition,
+    resolve_run_failure_type,
 )
 from dify_agent.layers.dify_plugin.configs import (
     DifyPluginLLMLayerConfig,
@@ -111,6 +112,26 @@ def test_run_failed_event_error_type_is_optional_and_round_trips() -> None:
     assert isinstance(decoded, RunFailedEvent)
     assert decoded.data.error_type is RunFailureType.AGENT_RUN_LIMIT_EXCEEDED
     assert protocol_exports.RunFailureType is RunFailureType
+
+
+@pytest.mark.parametrize(
+    ("error_type", "reason", "expected"),
+    [
+        (RunFailureType.BINDING_LOST, "InvokeRateLimitError", RunFailureType.BINDING_LOST),
+        (None, "binding_lost", RunFailureType.BINDING_LOST),
+        (None, "InvokeRateLimitError", RunFailureType.INVOKE_RATE_LIMIT_EXCEEDED),
+        (None, "knowledge_retrieve_failed", RunFailureType.KNOWLEDGE_RETRIEVE_FAILED),
+        (None, "model_error", None),
+        (None, None, None),
+    ],
+)
+def test_resolve_run_failure_type(
+    error_type: RunFailureType | None,
+    reason: str | None,
+    expected: RunFailureType | None,
+) -> None:
+    assert resolve_run_failure_type(error_type, reason) is expected
+    assert protocol_exports.resolve_run_failure_type is resolve_run_failure_type
 
 
 def test_pydantic_ai_event_data_uses_agent_stream_event_model() -> None:

--- a/dify-agent/tests/local/dify_agent/runtime/test_runner.py
+++ b/dify-agent/tests/local/dify_agent/runtime/test_runner.py
@@ -210,8 +210,8 @@ def test_run_failed_error_payload_preserves_knowledge_error_code() -> None:
     message, error_type, reason = _run_failed_error_payload(exc)
 
     assert message == "Knowledge base search failed with HTTP 400 (dataset_not_found): Dataset not found"
-    assert error_type is None
-    assert reason == "dataset_not_found"
+    assert error_type is RunFailureType.KNOWLEDGE_RETRIEVE_FAILED
+    assert reason is None
 
 
 def test_run_failed_error_payload_classifies_usage_limit() -> None:
@@ -231,6 +231,29 @@ def test_run_failed_error_payload_classifies_binding_lost() -> None:
 
     assert message == "binding no longer available"
     assert error_type is RunFailureType.BINDING_LOST
+    assert reason is None
+
+
+@pytest.mark.parametrize(
+    ("body_error_type", "expected_failure_type"),
+    [
+        ("InvokeAuthorizationError", RunFailureType.INVOKE_AUTHORIZATION_ERROR),
+        ("InvokeBadRequestError", RunFailureType.INVOKE_BAD_REQUEST_ERROR),
+        ("CredentialsValidateFailedError", RunFailureType.INVOKE_BAD_REQUEST_ERROR),
+        ("InvokeConnectionError", RunFailureType.INVOKE_CONNECTION_ERROR),
+        ("InvokeServerUnavailableError", RunFailureType.INVOKE_SERVER_UNAVAILABLE_ERROR),
+    ],
+)
+def test_run_failed_error_payload_classifies_invoke_errors(
+    body_error_type: str,
+    expected_failure_type: RunFailureType,
+) -> None:
+    exc = ModelHTTPError(400, "gpt-4o-mini", {"error_type": body_error_type, "message": "provider failed"})
+
+    message, error_type, reason = _run_failed_error_payload(exc)
+
+    assert message == "provider failed"
+    assert error_type is expected_failure_type
     assert reason is None
 
 

--- a/dify-agent/tests/local/dify_agent/runtime/test_runner.py
+++ b/dify-agent/tests/local/dify_agent/runtime/test_runner.py
@@ -75,6 +75,7 @@ from dify_agent.runtime.runner import (
     _run_failed_error_payload,
 )
 from dify_agent.runtime_backend import (
+    BindingLostError,
     ExecutionBindingAllocation,
     ExecutionBindingCreateSpec,
     ExecutionBindingDestroySpec,
@@ -184,8 +185,8 @@ def test_run_failed_error_payload_preserves_plugin_rate_limit_error() -> None:
     message, error_type, reason = _run_failed_error_payload(exc)
 
     assert message == "quota exceeded"
-    assert error_type is None
-    assert reason == "InvokeRateLimitError"
+    assert error_type is RunFailureType.INVOKE_RATE_LIMIT_EXCEEDED
+    assert reason is None
 
 
 def test_run_failed_error_payload_infers_rate_limit_reason_from_status_code() -> None:
@@ -194,8 +195,8 @@ def test_run_failed_error_payload_infers_rate_limit_reason_from_status_code() ->
     message, error_type, reason = _run_failed_error_payload(exc)
 
     assert message == "too many requests"
-    assert error_type is None
-    assert reason == "InvokeRateLimitError"
+    assert error_type is RunFailureType.INVOKE_RATE_LIMIT_EXCEEDED
+    assert reason is None
 
 
 def test_run_failed_error_payload_preserves_knowledge_error_code() -> None:
@@ -220,6 +221,16 @@ def test_run_failed_error_payload_classifies_usage_limit() -> None:
 
     assert message == "The next request would exceed the request_limit of 100"
     assert error_type is RunFailureType.AGENT_RUN_LIMIT_EXCEEDED
+    assert reason is None
+
+
+def test_run_failed_error_payload_classifies_binding_lost() -> None:
+    exc = BindingLostError("binding no longer available")
+
+    message, error_type, reason = _run_failed_error_payload(exc)
+
+    assert message == "binding no longer available"
+    assert error_type is RunFailureType.BINDING_LOST
     assert reason is None
 
 


### PR DESCRIPTION
## Summary

Part of #40117 — first migration slice for structured failed-run error types (follow-up to #40116).

Migrates stable Dify-owned failure categories from ad hoc `reason` strings to `RunFailureType`:

| Legacy `reason` | New `RunFailureType` |
|-----------------|----------------------|
| `binding_lost` | `BINDING_LOST` |
| `InvokeRateLimitError` / HTTP 429 | `INVOKE_RATE_LIMIT_EXCEEDED` |
| `shutdown` | `AGENT_SHUTDOWN` |

`AGENT_RUN_LIMIT_EXCEEDED` (from #40116) is unchanged.

## Changes

- Extend `RunFailureType` enum in `dify-agent` protocol schemas
- Classify failures in `_run_failed_error_payload()` and shutdown finalization
- Map `INVOKE_RATE_LIMIT_EXCEEDED` to `InvokeRateLimitError` in Agent App runner
- Handle `BINDING_LOST` via `error_type` (legacy `reason` fallback retained)
- Return stable SSE error codes for rate-limit failures via `error_type`

## Out of scope (future #40117 work)

- Provider-specific invoke error types (`InvokeAuthorizationError`, etc.)
- Knowledge-base error codes (`dataset_not_found`, …)
- Removing the `reason` field entirely
- Cancellation / HITL pause reasons

## Test plan

- [x] `pytest test_runner.py` failure payload tests (binding_lost, rate limit, usage limit)
- [x] `pytest test_app_runner.py` rate-limit reason + failure_type mapping
- [x] `pytest test_protocol_schemas.py`