### PR TITLE
fix: workflow_run create delay lead hitl pause failed

### DIFF
--- a/api/core/repositories/celery_workflow_execution_repository.py
+++ b/api/core/repositories/celery_workflow_execution_repository.py
@@ -9,13 +9,15 @@ import logging
 from typing import override
 
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
 from core.repositories.factory import WorkflowExecutionRepository
 from graphon.entities import WorkflowExecution
-from models import Account, CreatorUserRole, EndUser
+from models import Account, CreatorUserRole, EndUser, WorkflowRun
 from models.enums import WorkflowRunTriggeredFrom
 from tasks.workflow_execution_tasks import (
+    _create_workflow_run_from_execution,
     save_workflow_execution_task,
 )
 
@@ -96,15 +98,21 @@ class CeleryWorkflowExecutionRepository(WorkflowExecutionRepository):
     @override
     def save(self, execution: WorkflowExecution):
         """
-        Save or update a WorkflowExecution instance asynchronously using Celery.
+        Save or update a WorkflowExecution instance using Celery.
 
-        This method queues the save operation as a Celery task and returns immediately,
-        providing improved performance for high-throughput scenarios.
+        The initial WorkflowRun row is created synchronously so downstream paths
+        that read it directly, such as pause persistence, can rely on its
+        existence. Later updates are queued as Celery tasks to preserve the
+        asynchronous storage behavior.
 
         Args:
             execution: The WorkflowExecution instance to save or update
         """
         try:
+            if self._ensure_workflow_run_exists(execution):
+                logger.debug("Synchronously created workflow execution: %s", execution.id_)
+                return
+
             # Serialize execution for Celery task
             execution_data = execution.model_dump()
 
@@ -125,3 +133,46 @@ class CeleryWorkflowExecutionRepository(WorkflowExecutionRepository):
             # In case of Celery failure, we could implement a fallback to synchronous save
             # For now, we'll re-raise the exception
             raise
+
+    def _ensure_workflow_run_exists(self, execution: WorkflowExecution) -> bool:
+        """
+        Create the WorkflowRun row synchronously if it does not already exist.
+
+        Returns True when this call created the row. Returns False when the row
+        already exists and the caller should enqueue an asynchronous update.
+        """
+        if not self._triggered_from:
+            raise ValueError("triggered_from is required in repository constructor")
+        if not self._creator_user_id:
+            raise ValueError("created_by is required in repository constructor")
+        if not self._creator_user_role:
+            raise ValueError("created_by_role is required in repository constructor")
+
+        with self._session_factory() as session:
+            existing_run = session.get(WorkflowRun, execution.id_)
+            if existing_run:
+                if existing_run.tenant_id != self._tenant_id:
+                    raise ValueError("Unauthorized access to workflow run")
+                return False
+
+            workflow_run = _create_workflow_run_from_execution(
+                execution=execution,
+                tenant_id=self._tenant_id,
+                app_id=self._app_id or "",
+                triggered_from=self._triggered_from,
+                creator_user_id=self._creator_user_id,
+                creator_user_role=self._creator_user_role,
+            )
+            session.add(workflow_run)
+            try:
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                existing_run = session.get(WorkflowRun, execution.id_)
+                if existing_run is None:
+                    raise
+                if existing_run.tenant_id != self._tenant_id:
+                    raise ValueError("Unauthorized access to workflow run")
+                return False
+
+        return True

--- a/api/tests/unit_tests/core/repositories/test_celery_workflow_execution_repository.py
+++ b/api/tests/unit_tests/core/repositories/test_celery_workflow_execution_repository.py
@@ -9,26 +9,16 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.orm import Session, sessionmaker
 
 from core.repositories.celery_workflow_execution_repository import CeleryWorkflowExecutionRepository
 from graphon.entities import WorkflowExecution
-from graphon.enums import WorkflowType
+from graphon.enums import WorkflowExecutionStatus, WorkflowType
 from libs.datetime_utils import naive_utc_now
-from models import Account, EndUser, Tenant
+from models import Account, EndUser, Tenant, WorkflowRun
 from models.enums import WorkflowRunTriggeredFrom
 
 RESOURCE_TENANT_ID = "resource-tenant-id"
-
-
-@pytest.fixture
-def mock_session_factory():
-    """Mock SQLAlchemy session factory."""
-    from sqlalchemy import create_engine
-    from sqlalchemy.orm import sessionmaker
-
-    # Create a real sessionmaker with in-memory SQLite for testing
-    engine = create_engine("sqlite:///:memory:")
-    return sessionmaker(bind=engine)
 
 
 @pytest.fixture
@@ -68,13 +58,13 @@ def sample_workflow_execution():
 class TestCeleryWorkflowExecutionRepository:
     """Test cases for CeleryWorkflowExecutionRepository."""
 
-    def test_init_with_sessionmaker(self, mock_session_factory, mock_account):
+    def test_init_with_sessionmaker(self, sqlite_session_factory: sessionmaker[Session], mock_account):
         """Test repository initialization with sessionmaker."""
         app_id = "test-app-id"
         triggered_from = WorkflowRunTriggeredFrom.APP_RUN
 
         repo = CeleryWorkflowExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
             user=mock_account,
             app_id=app_id,
@@ -87,10 +77,10 @@ class TestCeleryWorkflowExecutionRepository:
         assert repo._creator_user_id == mock_account.id
         assert repo._creator_user_role is not None
 
-    def test_init_basic_functionality(self, mock_session_factory, mock_account):
+    def test_init_basic_functionality(self, sqlite_session_factory: sessionmaker[Session], mock_account):
         """Test repository initialization basic functionality."""
         repo = CeleryWorkflowExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
             user=mock_account,
             app_id="test-app",
@@ -102,10 +92,10 @@ class TestCeleryWorkflowExecutionRepository:
         assert repo._app_id == "test-app"
         assert repo._triggered_from == WorkflowRunTriggeredFrom.DEBUGGING
 
-    def test_init_with_end_user(self, mock_session_factory, mock_end_user):
+    def test_init_with_end_user(self, sqlite_session_factory: sessionmaker[Session], mock_end_user):
         """Test repository initialization with EndUser."""
         repo = CeleryWorkflowExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
             user=mock_end_user,
             app_id="test-app",
@@ -114,7 +104,7 @@ class TestCeleryWorkflowExecutionRepository:
 
         assert repo._tenant_id == RESOURCE_TENANT_ID
 
-    def test_init_without_tenant_id_raises_error(self, mock_session_factory):
+    def test_init_without_tenant_id_raises_error(self, sqlite_session_factory: sessionmaker[Session]):
         """Test that initialization fails without tenant_id."""
         # Create an Account with no tenant_id.
         user = Account(name="Test Account", email="test@example.com")
@@ -122,19 +112,21 @@ class TestCeleryWorkflowExecutionRepository:
 
         with pytest.raises(ValueError, match="tenant_id is required"):
             CeleryWorkflowExecutionRepository(
-                session_factory=mock_session_factory,
+                session_factory=sqlite_session_factory,
                 tenant_id="",
                 user=user,
                 app_id="test-app",
                 triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
             )
 
-    def test_init_uses_resource_tenant_when_account_has_no_current_tenant(self, mock_session_factory):
+    def test_init_uses_resource_tenant_when_account_has_no_current_tenant(
+        self, sqlite_session_factory: sessionmaker[Session]
+    ):
         user = Account(name="Test Account", email="test@example.com")
         user.id = str(uuid4())
 
         repo = CeleryWorkflowExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
             user=user,
             app_id="test-app",
@@ -145,10 +137,17 @@ class TestCeleryWorkflowExecutionRepository:
         assert repo._creator_user_id == user.id
 
     @patch("core.repositories.celery_workflow_execution_repository.save_workflow_execution_task")
-    def test_save_queues_celery_task(self, mock_task, mock_session_factory, mock_account, sample_workflow_execution):
-        """Test that save operation queues a Celery task without tracking."""
+    def test_initial_save_creates_workflow_run_synchronously(
+        self,
+        mock_task,
+        sqlite_session_factory: sessionmaker[Session],
+        sqlite_session: Session,
+        mock_account,
+        sample_workflow_execution,
+    ):
+        """Test that initial save creates WorkflowRun before returning."""
         repo = CeleryWorkflowExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
             user=mock_account,
             app_id="test-app",
@@ -157,14 +156,40 @@ class TestCeleryWorkflowExecutionRepository:
 
         repo.save(sample_workflow_execution)
 
-        # Verify Celery task was queued with correct parameters
+        mock_task.delay.assert_not_called()
+        persisted_run = sqlite_session.get(WorkflowRun, sample_workflow_execution.id_)
+        assert persisted_run is not None
+        assert persisted_run.tenant_id == RESOURCE_TENANT_ID
+        assert persisted_run.status == WorkflowExecutionStatus.RUNNING
+
+    @patch("core.repositories.celery_workflow_execution_repository.save_workflow_execution_task")
+    def test_subsequent_save_queues_celery_task(
+        self,
+        mock_task,
+        sqlite_session_factory: sessionmaker[Session],
+        mock_account,
+        sample_workflow_execution,
+    ):
+        """Test that updates for an existing WorkflowRun are saved asynchronously."""
+        repo = CeleryWorkflowExecutionRepository(
+            session_factory=sqlite_session_factory,
+            tenant_id=RESOURCE_TENANT_ID,
+            user=mock_account,
+            app_id="test-app",
+            triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
+        )
+
+        repo.save(sample_workflow_execution)
+        sample_workflow_execution.status = WorkflowExecutionStatus.PAUSED
+        repo.save(sample_workflow_execution)
+
         mock_task.delay.assert_called_once()
         call_args = mock_task.delay.call_args[1]
 
         assert call_args["execution_data"] == sample_workflow_execution.model_dump()
         assert call_args["tenant_id"] == RESOURCE_TENANT_ID
         assert call_args["app_id"] == "test-app"
-        assert call_args["triggered_from"] == WorkflowRunTriggeredFrom.APP_RUN
+        assert call_args["triggered_from"] == WorkflowRunTriggeredFrom.APP_RUN.value
         assert call_args["creator_user_id"] == mock_account.id
 
         # Verify no task tracking occurs (no _pending_saves attribute)
@@ -172,46 +197,57 @@ class TestCeleryWorkflowExecutionRepository:
 
     @patch("core.repositories.celery_workflow_execution_repository.save_workflow_execution_task")
     def test_save_handles_celery_failure(
-        self, mock_task, mock_session_factory, mock_account, sample_workflow_execution
+        self,
+        mock_task,
+        sqlite_session_factory: sessionmaker[Session],
+        mock_account,
+        sample_workflow_execution,
     ):
-        """Test that save operation handles Celery task failures."""
+        """Test that update save operation handles Celery task failures."""
         mock_task.delay.side_effect = Exception("Celery is down")
 
         repo = CeleryWorkflowExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
             user=mock_account,
             app_id="test-app",
             triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
         )
+
+        repo.save(sample_workflow_execution)
 
         with pytest.raises(Exception, match="Celery is down"):
             repo.save(sample_workflow_execution)
 
     @patch("core.repositories.celery_workflow_execution_repository.save_workflow_execution_task")
     def test_save_operation_fire_and_forget(
-        self, mock_task, mock_session_factory, mock_account, sample_workflow_execution
+        self,
+        mock_task,
+        sqlite_session_factory: sessionmaker[Session],
+        mock_account,
+        sample_workflow_execution,
     ):
-        """Test that save operation works in fire-and-forget mode."""
+        """Test that update save operation works in fire-and-forget mode."""
         repo = CeleryWorkflowExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
             user=mock_account,
             app_id="test-app",
             triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
         )
 
-        # Test that save doesn't block or maintain state
+        repo.save(sample_workflow_execution)
         repo.save(sample_workflow_execution)
 
         # Verify no pending saves are tracked (no _pending_saves attribute)
         assert not hasattr(repo, "_pending_saves")
+        mock_task.delay.assert_called_once()
 
     @patch("core.repositories.celery_workflow_execution_repository.save_workflow_execution_task")
-    def test_multiple_save_operations(self, mock_task, mock_session_factory, mock_account):
+    def test_multiple_save_operations(self, mock_task, sqlite_session_factory: sessionmaker[Session], mock_account):
         """Test multiple save operations work correctly."""
         repo = CeleryWorkflowExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=RESOURCE_TENANT_ID,
             user=mock_account,
             app_id="test-app",
@@ -244,12 +280,19 @@ class TestCeleryWorkflowExecutionRepository:
 
         # Should work without issues and not maintain state (no _pending_saves attribute)
         assert not hasattr(repo, "_pending_saves")
+        mock_task.delay.assert_not_called()
 
     @patch("core.repositories.celery_workflow_execution_repository.save_workflow_execution_task")
-    def test_save_with_different_user_types(self, mock_task, mock_session_factory, mock_end_user):
+    def test_save_with_different_user_types(
+        self,
+        mock_task,
+        sqlite_session_factory: sessionmaker[Session],
+        sqlite_session: Session,
+        mock_end_user,
+    ):
         """Test save operation with different user types."""
         repo = CeleryWorkflowExecutionRepository(
-            session_factory=mock_session_factory,
+            session_factory=sqlite_session_factory,
             tenant_id=mock_end_user.tenant_id,
             user=mock_end_user,
             app_id="test-app",
@@ -268,8 +311,37 @@ class TestCeleryWorkflowExecutionRepository:
 
         repo.save(execution)
 
-        # Verify task was called with EndUser context
-        mock_task.delay.assert_called_once()
-        call_args = mock_task.delay.call_args[1]
-        assert call_args["tenant_id"] == mock_end_user.tenant_id
-        assert call_args["creator_user_id"] == mock_end_user.id
+        mock_task.delay.assert_not_called()
+        persisted_run = sqlite_session.get(WorkflowRun, execution.id_)
+        assert persisted_run is not None
+        assert persisted_run.tenant_id == mock_end_user.tenant_id
+        assert persisted_run.created_by == mock_end_user.id
+
+    def test_save_rejects_execution_owned_by_another_tenant(
+        self,
+        sqlite_session_factory: sessionmaker[Session],
+        mock_account,
+        sample_workflow_execution,
+    ):
+        other_account = Account(name="Other Account", email="other@example.com")
+        other_account.id = str(uuid4())
+        other_tenant_id = str(uuid4())
+        other_repo = CeleryWorkflowExecutionRepository(
+            session_factory=sqlite_session_factory,
+            tenant_id=other_tenant_id,
+            user=other_account,
+            app_id="test-app",
+            triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
+        )
+        other_repo.save(sample_workflow_execution)
+
+        repo = CeleryWorkflowExecutionRepository(
+            session_factory=sqlite_session_factory,
+            tenant_id=RESOURCE_TENANT_ID,
+            user=mock_account,
+            app_id="test-app",
+            triggered_from=WorkflowRunTriggeredFrom.APP_RUN,
+        )
+
+        with pytest.raises(ValueError, match="Unauthorized access to workflow run"):
+            repo.save(sample_workflow_execution)


### PR DESCRIPTION
> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/langgenius/dify/blob/main/CONTRIBUTING.md)
> 1. Ensure there is an associated issue and you have been assigned to it
> 1. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

fix #40445

CeleryWorkflowExecutionRepository.save delay a celery task, so the database operation is async, when hitl execute to pause phase, find workflow run is miss, raise the exception

## Screenshots

| Before | After |
| ------ | ----- |
| ...    | ...   |

## Checklist

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [ ] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
- [ ] I ran `make lint && make type-check` (backend) and `cd web && pnpm exec vp staged` (frontend) to appease the lint gods
