### PR TITLE
fix(api): align Human Input timeout handle with frontend/DSL contract

### DIFF
--- a/api/core/workflow/nodes/human_input/callback.py
+++ b/api/core/workflow/nodes/human_input/callback.py
@@ -68,7 +68,7 @@ class DifyHITLCallback:
     _OUTPUT_FIELD_ACTION_ID = "__action_id"
     _OUTPUT_FIELD_ACTION_VALUE = "__action_value"
     _OUTPUT_FIELD_RENDERED_CONTENT = "__rendered_content"
-    _TIMEOUT_HANDLE = "__timeout__"
+    _TIMEOUT_HANDLE = "__timeout"
 
     def __init__(
         self,

--- a/api/tests/unit_tests/core/workflow/nodes/human_input/test_human_input_form_filled_event.py
+++ b/api/tests/unit_tests/core/workflow/nodes/human_input/test_human_input_form_filled_event.py
@@ -264,4 +264,4 @@ def test_human_input_node_emits_timeout_event_before_succeeded():
 
     assert isinstance(events[0], NodeRunStartedEvent)
     assert isinstance(events[1], NodeRunSucceededEvent)
-    assert events[1].node_run_result.edge_source_handle == "__timeout__"
+    assert events[1].node_run_result.edge_source_handle == "__timeout"

--- a/api/tests/unit_tests/core/workflow/test_human_input_callback.py
+++ b/api/tests/unit_tests/core/workflow/test_human_input_callback.py
@@ -132,7 +132,7 @@ def test_dify_hitl_callback_returns_timeout_for_explicit_timeout_form() -> None:
 
     decision = callback(_ctx("run-1", "node-1"))
 
-    assert decision.selected_handle == "__timeout__"
+    assert decision.selected_handle == "__timeout"
     assert decision.outputs == {
         "__action_id": build_segment(""),
         "__action_value": build_segment(""),
@@ -159,7 +159,7 @@ def test_dify_hitl_callback_returns_timeout_for_waiting_form_past_node_deadline(
 
     decision = callback(_ctx("run-1", "node-1"))
 
-    assert decision.selected_handle == "__timeout__"
+    assert decision.selected_handle == "__timeout"
     assert decision.outputs == {
         "__action_id": build_segment(""),
         "__action_value": build_segment(""),


### PR DESCRIPTION
### Summary

Fixes #40459.

The backend `DifyHITLCallback` used `_TIMEOUT_HANDLE = "__timeout__"` (with a
trailing underscore) while the frontend Human Input node and the persisted
workflow DSL use `"__timeout"` as the source handle for the node's Timeout
branch:

- Frontend: `handleId="__timeout"` in
  `web/app/components/workflow/nodes/human-input/node.tsx`
- Backend (before this fix): `_TIMEOUT_HANDLE = "__timeout__"` in
  `api/core/workflow/nodes/human_input/callback.py`

Because of this mismatch, when a Human Input node times out at runtime, the
`Expired` decision's `selected_handle` does not match the `"__timeout"`
source handle configured in the persisted workflow DSL, so the timeout
branch does not fire correctly (and could collide with a user-action branch
that happens to use the id `"__timeout__"`).

This was a regression introduced during the HITL-to-Dify migration (#38247);
an earlier version of that migration (#38225) had the correct
`_TIMEOUT_HANDLE = "__timeout"` value.

### Changes

- `api/core/workflow/nodes/human_input/callback.py`: change
  `_TIMEOUT_HANDLE` back to `"__timeout"` to match the frontend/DSL handle.
- Updated the two existing unit tests that asserted the old (incorrect)
  `"__timeout__"` value to assert `"__timeout"` instead.

### Test plan

Confirmed the tests fail without the fix (reverted only the source line,
kept the updated test assertions):

```
$ uv run --project api pytest api/tests/unit_tests/core/workflow/test_human_input_callback.py api/tests/unit_tests/core/workflow/nodes/human_input/test_human_input_form_filled_event.py -q
...
FAILED api/tests/unit_tests/core/workflow/test_human_input_callback.py::test_dify_hitl_callback_returns_timeout_for_explicit_timeout_form - AssertionError: assert '__timeout__' == '__timeout'
FAILED api/tests/unit_tests/core/workflow/test_human_input_callback.py::test_dify_hitl_callback_returns_timeout_for_waiting_form_past_node_deadline - AssertionError: assert '__timeout__' == '__timeout'
FAILED api/tests/unit_tests/core/workflow/nodes/human_input/test_human_input_form_filled_event.py::test_human_input_node_emits_timeout_event_before_succeeded - AssertionError: assert '__timeout__' == '__timeout'
3 failed, 7 passed, 1 warning in 1.67s
```

With the fix applied, the full suite for the affected module passes:

```
$ uv run --project api pytest api/tests/unit_tests/core/workflow/nodes/human_input/ api/tests/unit_tests/core/workflow/test_human_input_callback.py -q
.....................................................                    [100%]
53 passed, 1 warning in 1.63s
```

Also ran `ruff format --check` and `ruff check` on the changed files — both
pass with no issues.

### AI disclosure

This PR was prepared by an autonomous AI coding agent (Claude, via
Anthropic's Claude Agent SDK), which located the root cause, implemented the
one-line fix, updated the affected tests, and verified the fix against a
failing-test baseline. The change was reviewed before submission.
