### PR TITLE
refactor(api): extract installed app definition queries

### DIFF
--- a/api/.importlinter
+++ b/api/.importlinter
@@ -93,6 +93,20 @@ forbidden_modules =
     sqlalchemy
     werkzeug
 
+[importlinter:contract:app-definition-query-service-boundary]
+name = App definition query application service is framework and persistence neutral
+type = forbidden
+source_modules =
+    services.app_definition_query_service
+forbidden_modules =
+    controllers
+    extensions
+    flask
+    models
+    repositories
+    sqlalchemy
+    werkzeug
+
 [importlinter:contract:feature-query-service-boundary]
 name = Feature query application service is framework and persistence neutral
 type = forbidden

--- a/api/controllers/console/explore/parameter.py
+++ b/api/controllers/console/explore/parameter.py
@@ -1,16 +1,16 @@
-from typing import Any, cast
+from typing import Any
 
 from pydantic import BaseModel, Field
 
-from controllers.common import fields
+from controllers.common.fields import Parameters
 from controllers.common.schema import register_response_schema_models
 from controllers.console import console_ns
 from controllers.console.app.error import AppUnavailableError
 from controllers.console.explore.wraps import InstalledAppResource
-from core.app.app_config.common.parameters_mapping import get_parameters_from_feature_dict
-from extensions.ext_database import db
-from models.model import AppMode, InstalledApp, load_annotation_reply_config
-from services.app_service import AppService
+from extensions.ext_application_services import application_services
+from libs.helper import dump_response
+from models.model import InstalledApp
+from services.app_definition_query_service import AppDefinitionUnavailableError
 
 
 class ExploreAppMetaResponse(BaseModel):
@@ -22,44 +22,22 @@ class ExploreAppMetaResponse(BaseModel):
     tool_icons: dict[str, str | dict[str, Any]] = Field(default_factory=dict)
 
 
-register_response_schema_models(console_ns, fields.Parameters, ExploreAppMetaResponse)
+register_response_schema_models(console_ns, Parameters, ExploreAppMetaResponse)
 
 
 @console_ns.route("/installed-apps/<uuid:installed_app_id>/parameters", endpoint="installed_app_parameters")
 class AppParameterApi(InstalledAppResource):
     """Resource for app variables."""
 
-    @console_ns.response(200, "Success", console_ns.models[fields.Parameters.__name__])
+    @console_ns.response(200, "Success", console_ns.models[Parameters.__name__])
     def get(self, installed_app: InstalledApp):
         """Retrieve app parameters."""
-        session = db.session()
-        app_model = installed_app.app_with_session(session=session)
+        try:
+            parameters = application_services().app_definitions.get_parameters(installed_app.app_id)
+        except AppDefinitionUnavailableError:
+            raise AppUnavailableError() from None
 
-        if app_model is None:
-            raise AppUnavailableError()
-
-        if app_model.mode in {AppMode.ADVANCED_CHAT, AppMode.WORKFLOW}:
-            workflow = app_model.workflow_with_session(session=session)
-            if workflow is None:
-                raise AppUnavailableError()
-
-            features_dict: dict[str, Any] = workflow.features_dict
-            user_input_form = workflow.user_input_form(to_old_structure=True)
-        else:
-            app_model_config = app_model.app_model_config_with_session(session=session)
-            if app_model_config is None:
-                raise AppUnavailableError()
-
-            annotation_reply = load_annotation_reply_config(session, app_model.id)
-            features_dict = cast(
-                dict[str, Any],
-                app_model_config.to_dict(annotation_reply=annotation_reply),
-            )
-
-            user_input_form = features_dict.get("user_input_form", [])
-
-        parameters = get_parameters_from_feature_dict(features_dict=features_dict, user_input_form=user_input_form)
-        return fields.Parameters.model_validate(parameters).model_dump(mode="json")
+        return dump_response(Parameters, parameters)
 
 
 @console_ns.route("/installed-apps/<uuid:installed_app_id>/meta", endpoint="installed_app_meta")
@@ -67,7 +45,7 @@ class ExploreAppMetaApi(InstalledAppResource):
     @console_ns.response(200, "Success", console_ns.models[ExploreAppMetaResponse.__name__])
     def get(self, installed_app: InstalledApp):
         """Get app meta"""
-        app_model = installed_app.app_with_session(session=db.session())
-        if not app_model:
-            raise ValueError("App not found")
-        return AppService().get_app_meta(app_model, session=db.session())
+        return dump_response(
+            ExploreAppMetaResponse,
+            {"tool_icons": application_services().app_definitions.get_tool_icons(installed_app.app_id)},
+        )

--- a/api/controllers/console/explore/parameter.py
+++ b/api/controllers/console/explore/parameter.py
@@ -45,7 +45,12 @@ class ExploreAppMetaApi(InstalledAppResource):
     @console_ns.response(200, "Success", console_ns.models[ExploreAppMetaResponse.__name__])
     def get(self, installed_app: InstalledApp):
         """Get app meta"""
+        try:
+            tool_icons = application_services().app_definitions.get_tool_icons(installed_app.app_id)
+        except AppDefinitionUnavailableError:
+            raise AppUnavailableError() from None
+
         return dump_response(
             ExploreAppMetaResponse,
-            {"tool_icons": application_services().app_definitions.get_tool_icons(installed_app.app_id)},
+            {"tool_icons": tool_icons},
         )

--- a/api/extensions/ext_application_services.py
+++ b/api/extensions/ext_application_services.py
@@ -12,10 +12,12 @@ from core.db.session_factory import get_session_maker
 from core.schemas.schema_manager import SchemaManager
 from enums import DeploymentEdition
 from extensions.ext_redis import RedisClientWrapper, redis_client
+from repositories.app_definition_query_repository import AppDefinitionQueryRepository
 from repositories.explore_banner_query_repository import ExploreBannerQueryRepository
 from repositories.installation_state_repository import InstallationStateRepository
 from repositories.workspace_member_query_repository import WorkspaceMemberQueryRepository
 from repositories.workspace_query_repository import WorkspaceQueryRepository
+from services.app_definition_query_service import AppDefinitionQueryService
 from services.explore_banner_query_service import ExploreBannerQueryService
 from services.feature_query_service import FeatureQueryService
 from services.feature_service import FeatureService
@@ -34,6 +36,7 @@ _EXTENSION_KEY = "application_services"
 
 @dataclass(frozen=True, slots=True)
 class ApplicationServices:
+    app_definitions: AppDefinitionQueryService
     explore_banner_queries: ExploreBannerQueryService
     schema_definitions: SchemaDefinitionService
     setup: SetupService
@@ -52,6 +55,12 @@ def build_application_services(
 ) -> ApplicationServices:
     installation_state = InstallationStateRepository(client=database_client)
     return ApplicationServices(
+        app_definitions=AppDefinitionQueryService(
+            definitions=AppDefinitionQueryRepository(session_factory=database_client),
+            builtin_icon_url_prefix=(
+                dify_config.CONSOLE_API_URL + "/console/api/workspaces/current/tool-provider/builtin/"
+            ),
+        ),
         explore_banner_queries=ExploreBannerQueryService(
             banners=ExploreBannerQueryRepository(client=database_client),
             is_enabled=FeatureService.is_explore_banner_enabled,

--- a/api/repositories/app_definition_query_repository.py
+++ b/api/repositories/app_definition_query_repository.py
@@ -1,0 +1,106 @@
+"""Database repository for externally visible app definitions."""
+
+from typing import Any, cast, override
+
+from sqlalchemy.orm import Session, sessionmaker
+
+from models.model import App, AppMode, AppModelConfig, load_annotation_reply_config
+from models.tools import ApiToolProvider
+from models.workflow import Workflow
+from services.app_definition_query_service import AppDefinitionQuery, AppParameterConfig, AppToolIconSource
+
+
+class AppDefinitionQueryRepository(AppDefinitionQuery):
+    def __init__(self, *, session_factory: sessionmaker[Session]) -> None:
+        self._session_factory = session_factory
+
+    @override
+    def get_published_parameter_config(self, app_id: str) -> AppParameterConfig | None:
+        with self._session_factory() as session:
+            app = session.get(App, app_id)
+            if app is None:
+                return None
+
+            if app.mode in {AppMode.ADVANCED_CHAT, AppMode.WORKFLOW}:
+                workflow = app.workflow_with_session(session=session)
+                if workflow is None:
+                    return None
+
+                return AppParameterConfig(
+                    features_dict=workflow.features_dict,
+                    user_input_form=cast(list[dict[str, Any]], workflow.user_input_form(to_old_structure=True)),
+                )
+
+            app_model_config = app.app_model_config_with_session(session=session)
+            if app_model_config is None:
+                return None
+
+            features_dict = app_model_config.to_dict(
+                annotation_reply=load_annotation_reply_config(session, app.id),
+            )
+            return AppParameterConfig(
+                features_dict=features_dict,
+                user_input_form=cast(list[dict[str, Any]], features_dict.get("user_input_form", [])),
+            )
+
+    @override
+    def get_tool_icon_sources(self, app_id: str) -> tuple[AppToolIconSource, ...] | None:
+        with self._session_factory() as session:
+            app = session.get(App, app_id)
+            if app is None:
+                return None
+
+            records: list[AppToolIconSource] = []
+            for tool in self._get_tools(session, app):
+                if len(tool) < 4:
+                    continue
+
+                provider_type = str(tool.get("provider_type", ""))
+                provider_id = str(tool.get("provider_id", ""))
+                tool_name = str(tool.get("tool_name", ""))
+                provider_icon: str | None = None
+                if provider_type == "api":
+                    try:
+                        provider = session.get(ApiToolProvider, provider_id)
+                        provider_icon = provider.icon if provider is not None else None
+                    except Exception:
+                        # Preserve the legacy response fallback when a provider cannot be loaded.
+                        provider_icon = None
+
+                records.append(
+                    AppToolIconSource(
+                        provider_type=provider_type,
+                        provider_id=provider_id,
+                        tool_name=tool_name,
+                        provider_icon=provider_icon,
+                    )
+                )
+
+            return tuple(records)
+
+    @staticmethod
+    def _get_tools(session: Session, app: App) -> list[dict[str, Any]]:
+        if app.mode in {AppMode.ADVANCED_CHAT, AppMode.WORKFLOW}:
+            workflow = session.get(Workflow, app.workflow_id) if app.workflow_id else None
+            if workflow is None:
+                return []
+
+            tools: list[dict[str, Any]] = []
+            nodes = cast(list[dict[str, Any]], workflow.graph_dict.get("nodes", []))
+            for node in nodes:
+                node_data = node.get("data", {})
+                if node_data.get("type") == "tool":
+                    tools.append(
+                        {
+                            "provider_type": node_data.get("provider_type"),
+                            "provider_id": node_data.get("provider_id"),
+                            "tool_name": node_data.get("tool_name"),
+                            "tool_parameters": {},
+                        }
+                    )
+            return tools
+
+        app_model_config = session.get(AppModelConfig, app.app_model_config_id) if app.app_model_config_id else None
+        if app_model_config is None:
+            return []
+        return cast(list[dict[str, Any]], app_model_config.agent_mode_dict.get("tools", []))

--- a/api/services/app_definition_query_service.py
+++ b/api/services/app_definition_query_service.py
@@ -1,0 +1,72 @@
+"""Application service for reading an app's externally visible definition."""
+
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any, NamedTuple, Protocol
+
+from core.app.app_config.common.parameters_mapping import AppParametersDict, get_parameters_from_feature_dict
+
+
+class AppParameterConfig(NamedTuple):
+    features_dict: Mapping[str, Any]
+    user_input_form: list[dict[str, Any]]
+
+
+class AppToolIconSource(NamedTuple):
+    provider_type: str
+    provider_id: str
+    tool_name: str
+    provider_icon: str | None
+
+
+class AppDefinitionQuery(Protocol):
+    def get_published_parameter_config(self, app_id: str) -> AppParameterConfig | None: ...
+
+    def get_tool_icon_sources(self, app_id: str) -> Sequence[AppToolIconSource] | None: ...
+
+
+class AppDefinitionUnavailableError(ValueError):
+    """Raised when an app definition is unavailable."""
+
+
+_API_TOOL_FALLBACK_ICON = {"background": "#252525", "content": "\ud83d\ude01"}
+
+
+class AppDefinitionQueryService:
+    def __init__(
+        self,
+        *,
+        definitions: AppDefinitionQuery,
+        builtin_icon_url_prefix: str,
+    ) -> None:
+        self._definitions = definitions
+        self._builtin_icon_url_prefix = builtin_icon_url_prefix
+
+    def get_parameters(self, app_id: str) -> AppParametersDict:
+        config = self._definitions.get_published_parameter_config(app_id)
+        if config is None:
+            raise AppDefinitionUnavailableError
+
+        return get_parameters_from_feature_dict(
+            features_dict=config.features_dict,
+            user_input_form=config.user_input_form,
+        )
+
+    def get_tool_icons(self, app_id: str) -> dict[str, Any]:
+        tools = self._definitions.get_tool_icon_sources(app_id)
+        if tools is None:
+            raise AppDefinitionUnavailableError("App not found")
+
+        tool_icons: dict[str, Any] = {}
+        for tool in tools:
+            if tool.provider_type == "builtin":
+                tool_icons[tool.tool_name] = self._builtin_icon_url_prefix + tool.provider_id + "/icon"
+            elif tool.provider_type == "api":
+                try:
+                    if tool.provider_icon is None:
+                        raise ValueError("API tool provider not found")
+                    tool_icons[tool.tool_name] = json.loads(tool.provider_icon)
+                except (TypeError, ValueError):
+                    tool_icons[tool.tool_name] = _API_TOOL_FALLBACK_ICON.copy()
+
+        return tool_icons

--- a/api/tests/unit_tests/controllers/console/explore/test_parameter.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_parameter.py
@@ -56,3 +56,19 @@ class TestExploreAppMetaApi:
 
         assert result == {"tool_icons": {"search": "/icon"}}
         app_definitions.get_tool_icons.assert_called_once_with("app-1")
+
+    def test_get_maps_unavailable_definition_to_app_unavailable(self) -> None:
+        services, app_definitions = _application_services()
+        app_definitions.get_tool_icons.side_effect = AppDefinitionUnavailableError
+
+        with (
+            patch.object(module, "application_services", return_value=services),
+            pytest.raises(AppUnavailableError) as raised,
+        ):
+            unwrap(module.ExploreAppMetaApi.get)(module.ExploreAppMetaApi(), _installed_app())
+
+        assert raised.value.data == {
+            "code": "app_unavailable",
+            "message": "App unavailable, please check your app configurations.",
+            "status": 400,
+        }

--- a/api/tests/unit_tests/controllers/console/explore/test_parameter.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_parameter.py
@@ -1,147 +1,58 @@
 from inspect import unwrap
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
 import controllers.console.explore.parameter as module
 from controllers.console.app.error import AppUnavailableError
-from models.model import AppMode
+from services.app_definition_query_service import AppDefinitionQueryService, AppDefinitionUnavailableError
 
 
-def _installed_app(app):
-    installed_app = MagicMock(app=app)
-    installed_app.app_with_session.return_value = app
-    return installed_app
+def _installed_app() -> MagicMock:
+    return MagicMock(app_id="app-1")
+
+
+def _application_services() -> tuple[SimpleNamespace, MagicMock]:
+    app_definitions: MagicMock = create_autospec(AppDefinitionQueryService, instance=True, spec_set=True)
+    return SimpleNamespace(app_definitions=app_definitions), app_definitions
 
 
 class TestAppParameterApi:
-    def test_get_app_none(self):
-        api = module.AppParameterApi()
-        method = unwrap(api.get)
-
-        installed_app = _installed_app(None)
-
-        with pytest.raises(AppUnavailableError):
-            method(installed_app)
-
-    def test_get_advanced_chat_workflow(self):
-        api = module.AppParameterApi()
-        method = unwrap(api.get)
-
-        workflow = MagicMock()
-        workflow.features_dict = {"f": "v"}
-        workflow.user_input_form.return_value = [{"name": "x"}]
-
-        app = MagicMock(
-            mode=AppMode.ADVANCED_CHAT,
-            workflow=workflow,
-        )
-        app.workflow_with_session.return_value = workflow
-
-        installed_app = _installed_app(app)
+    def test_get_parameters(self) -> None:
+        services, app_definitions = _application_services()
+        app_definitions.get_parameters.return_value = {"any": "thing"}
+        installed_app = _installed_app()
 
         with (
-            patch.object(
-                module,
-                "get_parameters_from_feature_dict",
-                return_value={"any": "thing"},
-            ),
-            patch.object(
-                module.fields.Parameters,
-                "model_validate",
-                return_value=MagicMock(model_dump=lambda **_: {"ok": True}),
-            ),
+            patch.object(module, "application_services", return_value=services),
+            patch.object(module, "dump_response", return_value={"ok": True}) as dump_response,
         ):
-            result = method(installed_app)
+            result = unwrap(module.AppParameterApi.get)(module.AppParameterApi(), installed_app)
 
         assert result == {"ok": True}
+        app_definitions.get_parameters.assert_called_once_with("app-1")
+        dump_response.assert_called_once_with(module.Parameters, {"any": "thing"})
 
-    def test_get_advanced_chat_workflow_missing(self):
-        api = module.AppParameterApi()
-        method = unwrap(api.get)
-
-        app = MagicMock(
-            mode=AppMode.ADVANCED_CHAT,
-            workflow=None,
-        )
-        app.workflow_with_session.return_value = None
-
-        installed_app = _installed_app(app)
-
-        with pytest.raises(AppUnavailableError):
-            method(installed_app)
-
-    def test_get_non_workflow_app(self):
-        api = module.AppParameterApi()
-        method = unwrap(api.get)
-
-        app_model_config = MagicMock()
-        app_model_config.to_dict.return_value = {"user_input_form": [{"name": "y"}]}
-
-        app = MagicMock(
-            mode=AppMode.CHAT,
-            app_model_config=app_model_config,
-        )
-        app.id = "app-1"
-        app.app_model_config_with_session.return_value = app_model_config
-
-        installed_app = _installed_app(app)
+    def test_get_maps_unavailable_parameter_config_to_app_unavailable(self) -> None:
+        services, app_definitions = _application_services()
+        app_definitions.get_parameters.side_effect = AppDefinitionUnavailableError
 
         with (
-            patch.object(
-                module,
-                "get_parameters_from_feature_dict",
-                return_value={"whatever": 123},
-            ),
-            patch.object(
-                module.fields.Parameters,
-                "model_validate",
-                return_value=MagicMock(model_dump=lambda **_: {"ok": True}),
-            ),
-            patch.object(module, "load_annotation_reply_config", return_value=None),
+            patch.object(module, "application_services", return_value=services),
+            pytest.raises(AppUnavailableError),
         ):
-            result = method(installed_app)
-
-        assert result == {"ok": True}
-
-    def test_get_non_workflow_missing_config(self):
-        api = module.AppParameterApi()
-        method = unwrap(api.get)
-
-        app = MagicMock(
-            mode=AppMode.CHAT,
-            app_model_config=None,
-        )
-        app.app_model_config_with_session.return_value = None
-
-        installed_app = _installed_app(app)
-
-        with pytest.raises(AppUnavailableError):
-            method(installed_app)
+            unwrap(module.AppParameterApi.get)(module.AppParameterApi(), _installed_app())
 
 
 class TestExploreAppMetaApi:
-    def test_get_meta_success(self):
-        api = module.ExploreAppMetaApi()
-        method = unwrap(api.get)
+    def test_get_meta(self) -> None:
+        services, app_definitions = _application_services()
+        app_definitions.get_tool_icons.return_value = {"search": "/icon"}
+        installed_app = _installed_app()
 
-        app = MagicMock()
-        installed_app = _installed_app(app)
+        with patch.object(module, "application_services", return_value=services):
+            result = unwrap(module.ExploreAppMetaApi.get)(module.ExploreAppMetaApi(), installed_app)
 
-        with patch.object(
-            module.AppService,
-            "get_app_meta",
-            return_value={"meta": "ok"},
-        ):
-            result = method(installed_app)
-
-        assert result == {"meta": "ok"}
-
-    def test_get_meta_app_missing(self):
-        api = module.ExploreAppMetaApi()
-        method = unwrap(api.get)
-
-        installed_app = _installed_app(None)
-
-        with pytest.raises(ValueError):
-            method(installed_app)
+        assert result == {"tool_icons": {"search": "/icon"}}
+        app_definitions.get_tool_icons.assert_called_once_with("app-1")

--- a/api/tests/unit_tests/controllers/console/test_feature.py
+++ b/api/tests/unit_tests/controllers/console/test_feature.py
@@ -1,10 +1,10 @@
 from inspect import unwrap
+from types import SimpleNamespace
 from unittest.mock import create_autospec
 
 from pytest_mock import MockerFixture
 
 from enums import DeploymentEdition
-from extensions.ext_application_services import ApplicationServices
 from machinery.context import RequestContext
 from services.entities.feature_entities import (
     FeatureModel,
@@ -15,13 +15,7 @@ from services.entities.feature_entities import (
     SystemFeatureModel,
     VectorSpaceLimitationModel,
 )
-from services.explore_banner_query_service import ExploreBannerQueryService
 from services.feature_query_service import FeatureQueryService
-from services.init_validation_service import InitValidationService
-from services.schema_definition_service import SchemaDefinitionService
-from services.setup_service import SetupService
-from services.workspace_member_query_service import WorkspaceMemberQueryService
-from services.workspace_query_service import WorkspaceQueryService
 
 
 def _request_context() -> RequestContext:
@@ -35,15 +29,7 @@ def _request_context() -> RequestContext:
 
 def _install_application_services(mocker: MockerFixture):
     feature_queries = create_autospec(FeatureQueryService, instance=True, spec_set=True)
-    services = ApplicationServices(
-        explore_banner_queries=create_autospec(ExploreBannerQueryService, instance=True, spec_set=True),
-        schema_definitions=create_autospec(SchemaDefinitionService, instance=True, spec_set=True),
-        setup=create_autospec(SetupService, instance=True, spec_set=True),
-        feature_queries=feature_queries,
-        init_validation=create_autospec(InitValidationService, instance=True, spec_set=True),
-        workspace_queries=create_autospec(WorkspaceQueryService, instance=True, spec_set=True),
-        workspace_member_queries=create_autospec(WorkspaceMemberQueryService, instance=True, spec_set=True),
-    )
+    services = SimpleNamespace(feature_queries=feature_queries)
     mocker.patch("controllers.console.feature.application_services", return_value=services)
     return feature_queries
 

--- a/api/tests/unit_tests/repositories/test_app_definition_query_repository.py
+++ b/api/tests/unit_tests/repositories/test_app_definition_query_repository.py
@@ -1,0 +1,263 @@
+import json
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
+from core.tools.entities.tool_entities import ApiProviderSchemaType
+from models.model import App, AppMode, AppModelConfig
+from models.tools import ApiToolProvider
+from models.workflow import Workflow, WorkflowKind, WorkflowType
+from repositories.app_definition_query_repository import AppDefinitionQueryRepository
+from services.app_definition_query_service import AppParameterConfig, AppToolIconSource
+
+_APP_ID = "11111111-1111-1111-1111-111111111111"
+_TENANT_ID = "22222222-2222-2222-2222-222222222222"
+_ACCOUNT_ID = "33333333-3333-3333-3333-333333333333"
+_WORKFLOW_ID = "44444444-4444-4444-4444-444444444444"
+_PROVIDER_ID = "55555555-5555-5555-5555-555555555555"
+_MISSING_PROVIDER_ID = "66666666-6666-6666-6666-666666666666"
+
+
+def _persist_app(session: Session, *, mode: AppMode = AppMode.CHAT) -> App:
+    app = App(
+        id=_APP_ID,
+        tenant_id=_TENANT_ID,
+        name="Parameter app",
+        description="",
+        mode=mode,
+        icon_type=None,
+        icon=None,
+        icon_background=None,
+        enable_site=True,
+        enable_api=True,
+        is_public=True,
+        max_active_requests=None,
+    )
+    session.add(app)
+    session.flush()
+    return app
+
+
+def test_get_published_parameter_config_returns_none_for_missing_app(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    repository = AppDefinitionQueryRepository(session_factory=sqlite_session_factory)
+
+    assert repository.get_published_parameter_config(_APP_ID) is None
+
+
+@pytest.mark.parametrize(
+    ("mode", "workflow_type"),
+    [
+        pytest.param(AppMode.WORKFLOW, WorkflowType.WORKFLOW, id="workflow"),
+        pytest.param(AppMode.ADVANCED_CHAT, WorkflowType.CHAT, id="advanced-chat"),
+    ],
+)
+def test_get_published_parameter_config_returns_workflow_features_and_legacy_input_form(
+    sqlite_session_factory: sessionmaker[Session],
+    mode: AppMode,
+    workflow_type: WorkflowType,
+) -> None:
+    variable = {
+        "variable": "query",
+        "label": "Query",
+        "type": "text-input",
+        "required": True,
+        "max_length": 48,
+    }
+    with sqlite_session_factory() as session:
+        app = _persist_app(session, mode=mode)
+        workflow = Workflow(
+            id="44444444-4444-4444-4444-444444444444",
+            tenant_id=_TENANT_ID,
+            app_id=app.id,
+            type=workflow_type,
+            kind=WorkflowKind.STANDARD,
+            version="1",
+            graph=json.dumps({"nodes": [{"id": "start", "data": {"type": "start", "variables": [variable]}}]}),
+            features=json.dumps({"opening_statement": "Hello from workflow"}),
+            created_by=_ACCOUNT_ID,
+            environment_variables=[],
+            conversation_variables=[],
+            rag_pipeline_variables=[],
+        )
+        session.add(workflow)
+        app.workflow_id = workflow.id
+        session.commit()
+
+    result = AppDefinitionQueryRepository(session_factory=sqlite_session_factory).get_published_parameter_config(
+        _APP_ID
+    )
+
+    assert result == AppParameterConfig(
+        features_dict={"opening_statement": "Hello from workflow"},
+        user_input_form=[{"text-input": variable}],
+    )
+
+
+def test_get_published_parameter_config_returns_none_for_workflow_without_published_workflow(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    with sqlite_session_factory() as session:
+        _persist_app(session, mode=AppMode.WORKFLOW)
+        session.commit()
+
+    repository = AppDefinitionQueryRepository(session_factory=sqlite_session_factory)
+
+    assert repository.get_published_parameter_config(_APP_ID) is None
+
+
+def test_get_published_parameter_config_returns_model_config_and_annotation_projection(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    user_input_form = [{"paragraph": {"variable": "details", "label": "Details", "required": False}}]
+    with sqlite_session_factory() as session:
+        app = _persist_app(session)
+        app_model_config = AppModelConfig(
+            app_id=app.id,
+            opening_statement="Hello from model config",
+            user_input_form=json.dumps(user_input_form),
+        )
+        session.add(app_model_config)
+        session.flush()
+        app.app_model_config_id = app_model_config.id
+        session.commit()
+
+    result = AppDefinitionQueryRepository(session_factory=sqlite_session_factory).get_published_parameter_config(
+        _APP_ID
+    )
+
+    assert result is not None
+    assert result.features_dict["opening_statement"] == "Hello from model config"
+    assert result.features_dict["annotation_reply"] == {"enabled": False}
+    assert result.user_input_form == user_input_form
+
+
+def test_get_published_parameter_config_returns_none_for_app_without_published_model_config(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    with sqlite_session_factory() as session:
+        _persist_app(session)
+        session.commit()
+
+    repository = AppDefinitionQueryRepository(session_factory=sqlite_session_factory)
+
+    assert repository.get_published_parameter_config(_APP_ID) is None
+
+
+def _tool(provider_type: str, provider_id: str, tool_name: str) -> dict[str, object]:
+    return {
+        "provider_type": provider_type,
+        "provider_id": provider_id,
+        "tool_name": tool_name,
+        "tool_parameters": {},
+    }
+
+
+def test_get_tool_icon_sources_returns_none_for_missing_app(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    repository = AppDefinitionQueryRepository(session_factory=sqlite_session_factory)
+
+    assert repository.get_tool_icon_sources(_APP_ID) is None
+
+
+@pytest.mark.parametrize(
+    ("mode", "workflow_type"),
+    [
+        pytest.param(AppMode.WORKFLOW, WorkflowType.WORKFLOW, id="workflow"),
+        pytest.param(AppMode.ADVANCED_CHAT, WorkflowType.CHAT, id="advanced-chat"),
+    ],
+)
+def test_get_tool_icon_sources_reads_workflow_tools(
+    sqlite_session_factory: sessionmaker[Session],
+    mode: AppMode,
+    workflow_type: WorkflowType,
+) -> None:
+    with sqlite_session_factory() as session:
+        app = _persist_app(session, mode=mode)
+        workflow = Workflow(
+            id=_WORKFLOW_ID,
+            tenant_id=_TENANT_ID,
+            app_id=app.id,
+            type=workflow_type,
+            kind=WorkflowKind.STANDARD,
+            version="1",
+            graph=json.dumps(
+                {
+                    "nodes": [
+                        {"id": "start", "data": {"type": "start"}},
+                        {"id": "tool", "data": {"type": "tool", **_tool("builtin", "search", "search")}},
+                    ]
+                }
+            ),
+            features="{}",
+            created_by=_ACCOUNT_ID,
+            environment_variables=[],
+            conversation_variables=[],
+            rag_pipeline_variables=[],
+        )
+        session.add(workflow)
+        app.workflow_id = workflow.id
+        session.commit()
+
+    result = AppDefinitionQueryRepository(session_factory=sqlite_session_factory).get_tool_icon_sources(_APP_ID)
+
+    assert result == (AppToolIconSource("builtin", "search", "search", None),)
+
+
+def test_get_tool_icon_sources_reads_model_config_and_api_provider_icons(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    with sqlite_session_factory() as session:
+        app = _persist_app(session)
+        tools = [
+            _tool("builtin", "search", "search"),
+            _tool("api", _PROVIDER_ID, "weather"),
+            _tool("api", _MISSING_PROVIDER_ID, "missing"),
+            _tool("workflow", "workflow-provider", "workflow-tool"),
+            {"provider_type": "builtin", "provider_id": "legacy", "tool_name": "legacy"},
+        ]
+        app_model_config = AppModelConfig(
+            app_id=app.id,
+            agent_mode=json.dumps({"enabled": True, "strategy": "react", "tools": tools, "prompt": None}),
+        )
+        provider = ApiToolProvider(
+            name="Weather",
+            icon='{"background":"#fff","content":"W"}',
+            schema="{}",
+            schema_type_str=ApiProviderSchemaType.OPENAPI,
+            user_id=_ACCOUNT_ID,
+            tenant_id=_TENANT_ID,
+            description="",
+            tools_str="[]",
+            credentials_str="{}",
+        )
+        provider.id = _PROVIDER_ID
+        session.add_all([app_model_config, provider])
+        session.flush()
+        app.app_model_config_id = app_model_config.id
+        session.commit()
+
+    result = AppDefinitionQueryRepository(session_factory=sqlite_session_factory).get_tool_icon_sources(_APP_ID)
+
+    assert result == (
+        AppToolIconSource("builtin", "search", "search", None),
+        AppToolIconSource("api", _PROVIDER_ID, "weather", '{"background":"#fff","content":"W"}'),
+        AppToolIconSource("api", _MISSING_PROVIDER_ID, "missing", None),
+        AppToolIconSource("workflow", "workflow-provider", "workflow-tool", None),
+    )
+
+
+@pytest.mark.parametrize("mode", [AppMode.CHAT, AppMode.WORKFLOW])
+def test_get_tool_icon_sources_returns_empty_for_missing_published_config(
+    sqlite_session_factory: sessionmaker[Session],
+    mode: AppMode,
+) -> None:
+    with sqlite_session_factory() as session:
+        _persist_app(session, mode=mode)
+        session.commit()
+
+    repository = AppDefinitionQueryRepository(session_factory=sqlite_session_factory)
+
+    assert repository.get_tool_icon_sources(_APP_ID) == ()

--- a/api/tests/unit_tests/services/test_app_definition_query_service.py
+++ b/api/tests/unit_tests/services/test_app_definition_query_service.py
@@ -1,0 +1,96 @@
+from unittest.mock import MagicMock, create_autospec, patch
+
+import pytest
+
+import services.app_definition_query_service as module
+from services.app_definition_query_service import (
+    AppDefinitionQuery,
+    AppDefinitionQueryService,
+    AppDefinitionUnavailableError,
+    AppParameterConfig,
+    AppToolIconSource,
+)
+
+_BUILTIN_ICON_URL_PREFIX = "https://console.example/console/api/workspaces/current/tool-provider/builtin/"
+
+
+def _service() -> tuple[AppDefinitionQueryService, MagicMock]:
+    definitions: MagicMock = create_autospec(AppDefinitionQuery, instance=True, spec_set=True)
+    return (
+        AppDefinitionQueryService(
+            definitions=definitions,
+            builtin_icon_url_prefix=_BUILTIN_ICON_URL_PREFIX,
+        ),
+        definitions,
+    )
+
+
+def test_get_parameters_maps_published_config() -> None:
+    service, definitions = _service()
+    config = AppParameterConfig(
+        features_dict={"opening_statement": "Hello"},
+        user_input_form=[{"text-input": {"variable": "query"}}],
+    )
+    definitions.get_published_parameter_config.return_value = config
+    mapped = {"mapped": True}
+
+    with patch.object(module, "get_parameters_from_feature_dict", return_value=mapped) as map_parameters:
+        result = service.get_parameters("app-1")
+
+    assert result is mapped
+    definitions.get_published_parameter_config.assert_called_once_with("app-1")
+    map_parameters.assert_called_once_with(
+        features_dict=config.features_dict,
+        user_input_form=config.user_input_form,
+    )
+
+
+def test_get_parameters_rejects_missing_config() -> None:
+    service, definitions = _service()
+    definitions.get_published_parameter_config.return_value = None
+
+    with pytest.raises(AppDefinitionUnavailableError):
+        service.get_parameters("app-1")
+
+
+def test_get_tool_icons_maps_builtin_and_api_icons() -> None:
+    service, definitions = _service()
+    definitions.get_tool_icon_sources.return_value = (
+        AppToolIconSource("builtin", "search", "search", None),
+        AppToolIconSource("api", "provider-1", "weather", '{"background":"#fff","content":"W"}'),
+        AppToolIconSource("workflow", "ignored", "ignored", None),
+    )
+
+    result = service.get_tool_icons("app-1")
+
+    assert result == {
+        "search": _BUILTIN_ICON_URL_PREFIX + "search/icon",
+        "weather": {"background": "#fff", "content": "W"},
+    }
+    definitions.get_tool_icon_sources.assert_called_once_with("app-1")
+
+
+@pytest.mark.parametrize("provider_icon", [None, "not-json"])
+def test_get_tool_icons_falls_back_for_unavailable_api_icon(provider_icon: str | None) -> None:
+    service, definitions = _service()
+    definitions.get_tool_icon_sources.return_value = (AppToolIconSource("api", "provider-1", "weather", provider_icon),)
+
+    assert service.get_tool_icons("app-1") == {"weather": {"background": "#252525", "content": "\ud83d\ude01"}}
+
+
+def test_get_tool_icons_keeps_last_icon_for_duplicate_tool_name() -> None:
+    service, definitions = _service()
+    definitions.get_tool_icon_sources.return_value = (
+        AppToolIconSource("builtin", "first", "search", None),
+        AppToolIconSource("builtin", "second", "search", None),
+    )
+
+    assert service.get_tool_icons("app-1")["search"].endswith("/second/icon")
+
+
+def test_get_tool_icons_rejects_missing_app() -> None:
+    service, definitions = _service()
+    definitions.get_tool_icon_sources.return_value = None
+
+    with pytest.raises(AppDefinitionUnavailableError, match="App not found"):
+        service.get_tool_icons("missing")


### PR DESCRIPTION
## Summary

Part of #39993.

- define one App Definition query boundary for installed-app parameters and tool-icon metadata
- keep SQLAlchemy session ownership and ORM projection inside a single repository
- expose one composition capability instead of endpoint-shaped parameter and meta services
- preserve the existing response and error contracts while leaving shared admission wrappers unchanged
