### PR TITLE
refactor(api): reuse app definition queries in web and service APIs

### DIFF
--- a/api/controllers/service_api/app/app.py
+++ b/api/controllers/service_api/app/app.py
@@ -17,6 +17,7 @@ from extensions.ext_database import db
 from fields.base import ResponseModel
 from libs.helper import dump_response
 from models.model import App, AppMode, load_annotation_reply_config
+from services.app_definition_query_service import AppDefinitionUnavailableError
 
 
 class AppInfoResponse(ResponseModel):
@@ -137,10 +138,12 @@ class AppMetaApi(Resource):
 
         Returns metadata about the application including configuration and settings.
         """
-        return dump_response(
-            AppMetaResponse,
-            {"tool_icons": application_services().app_definitions.get_tool_icons(app_model.id)},
-        )
+        try:
+            tool_icons = application_services().app_definitions.get_tool_icons(app_model.id)
+        except AppDefinitionUnavailableError:
+            raise AppUnavailableError() from None
+
+        return dump_response(AppMetaResponse, {"tool_icons": tool_icons})
 
 
 @service_api_ns.route("/info")

--- a/api/controllers/service_api/app/app.py
+++ b/api/controllers/service_api/app/app.py
@@ -12,10 +12,11 @@ from controllers.service_api.app.error import AgentNotPublishedError, AppUnavail
 from controllers.service_api.wraps import validate_app_token
 from core.app.app_config.common.parameters_mapping import get_parameters_from_feature_dict
 from core.app.apps.agent_app.errors import AgentAppGeneratorError, AgentAppNotPublishedError
+from extensions.ext_application_services import application_services
 from extensions.ext_database import db
 from fields.base import ResponseModel
+from libs.helper import dump_response
 from models.model import App, AppMode, load_annotation_reply_config
-from services.app_service import AppService
 
 
 class AppInfoResponse(ResponseModel):
@@ -136,7 +137,10 @@ class AppMetaApi(Resource):
 
         Returns metadata about the application including configuration and settings.
         """
-        return AppService().get_app_meta(app_model, session=db.session())
+        return dump_response(
+            AppMetaResponse,
+            {"tool_icons": application_services().app_definitions.get_tool_icons(app_model.id)},
+        )
 
 
 @service_api_ns.route("/info")

--- a/api/controllers/web/app.py
+++ b/api/controllers/web/app.py
@@ -18,6 +18,7 @@ from libs.helper import dump_response
 from libs.passport import PassportService
 from libs.token import extract_webapp_passport
 from models.model import App, AppMode, EndUser, load_annotation_reply_config
+from services.app_definition_query_service import AppDefinitionUnavailableError
 from services.app_service import AppService
 from services.enterprise.enterprise_service import EnterpriseService
 from services.feature_service import FeatureService
@@ -133,10 +134,12 @@ class AppMeta(WebApiResource):
     @web_ns.response(200, "Success", web_ns.models[AppMetaResponse.__name__])
     def get(self, app_model: App, end_user: EndUser):
         """Get app meta"""
-        return dump_response(
-            AppMetaResponse,
-            {"tool_icons": application_services().app_definitions.get_tool_icons(app_model.id)},
-        )
+        try:
+            tool_icons = application_services().app_definitions.get_tool_icons(app_model.id)
+        except AppDefinitionUnavailableError:
+            raise AppUnavailableError() from None
+
+        return dump_response(AppMetaResponse, {"tool_icons": tool_icons})
 
 
 @web_ns.route("/webapp/access-mode")

--- a/api/controllers/web/app.py
+++ b/api/controllers/web/app.py
@@ -12,7 +12,9 @@ from controllers.common.agent_app_parameters import get_published_agent_app_feat
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from core.app.app_config.common.parameters_mapping import get_parameters_from_feature_dict
 from core.app.apps.agent_app.errors import AgentAppGeneratorError, AgentAppNotPublishedError
+from extensions.ext_application_services import application_services
 from extensions.ext_database import db
+from libs.helper import dump_response
 from libs.passport import PassportService
 from libs.token import extract_webapp_passport
 from models.model import App, AppMode, EndUser, load_annotation_reply_config
@@ -131,7 +133,10 @@ class AppMeta(WebApiResource):
     @web_ns.response(200, "Success", web_ns.models[AppMetaResponse.__name__])
     def get(self, app_model: App, end_user: EndUser):
         """Get app meta"""
-        return AppService().get_app_meta(app_model, session=db.session())
+        return dump_response(
+            AppMetaResponse,
+            {"tool_icons": application_services().app_definitions.get_tool_icons(app_model.id)},
+        )
 
 
 @web_ns.route("/webapp/access-mode")

--- a/api/services/app_service.py
+++ b/api/services/app_service.py
@@ -38,7 +38,6 @@ from models.agent import (
     AgentWorkspaceBinding,
 )
 from models.model import App, AppMode, AppModelConfig, IconType, Site, load_annotation_reply_config
-from models.tools import ApiToolProvider
 from models.workflow import Workflow
 from services.agent.errors import AgentAccessNotReadyError, AgentNameConflictError
 from services.agent.home_snapshot_service import AgentHomeSnapshotService
@@ -1062,71 +1061,6 @@ class AppService:
 
         # Trigger asynchronous deletion of app and related data
         remove_app_and_related_data_task.delay(tenant_id=app.tenant_id, app_id=app.id)
-
-    def get_app_meta(self, app_model: App, *, session: Session):
-        """
-        Get app meta info
-        :param app_model: app model
-        :param session: database session
-        :return:
-        """
-        app_mode = AppMode.value_of(app_model.mode)
-
-        meta: dict[str, Any] = {"tool_icons": {}}
-
-        if app_mode in {AppMode.ADVANCED_CHAT, AppMode.WORKFLOW}:
-            workflow = session.get(Workflow, app_model.workflow_id) if app_model.workflow_id else None
-            if workflow is None:
-                return meta
-
-            graph = workflow.graph_dict
-            nodes = graph.get("nodes", [])
-            tools = []
-            for node in nodes:
-                if node.get("data", {}).get("type") == "tool":
-                    node_data = node.get("data", {})
-                    tools.append(
-                        {
-                            "provider_type": node_data.get("provider_type"),
-                            "provider_id": node_data.get("provider_id"),
-                            "tool_name": node_data.get("tool_name"),
-                            "tool_parameters": {},
-                        }
-                    )
-        else:
-            app_model_config = (
-                session.get(AppModelConfig, app_model.app_model_config_id) if app_model.app_model_config_id else None
-            )
-
-            if not app_model_config:
-                return meta
-
-            agent_config = app_model_config.agent_mode_dict
-
-            # get all tools
-            tools = cast(list[dict[str, Any]], agent_config.get("tools", []))
-
-        url_prefix = dify_config.CONSOLE_API_URL + "/console/api/workspaces/current/tool-provider/builtin/"
-
-        for tool in tools:
-            keys = list(tool.keys())
-            if len(keys) >= 4:
-                # current tool standard
-                provider_type = str(tool.get("provider_type", ""))
-                provider_id = str(tool.get("provider_id", ""))
-                tool_name = str(tool.get("tool_name", ""))
-                if provider_type == "builtin":
-                    meta["tool_icons"][tool_name] = url_prefix + provider_id + "/icon"
-                elif provider_type == "api":
-                    try:
-                        provider: ApiToolProvider | None = session.get(ApiToolProvider, provider_id)
-                        if provider is None:
-                            raise ValueError(f"provider not found for tool {tool_name}")
-                        meta["tool_icons"][tool_name] = json.loads(provider.icon)
-                    except:
-                        meta["tool_icons"][tool_name] = {"background": "#252525", "content": "\ud83d\ude01"}
-
-        return meta
 
     @staticmethod
     def get_app_code_by_id(app_id: str, *, session: Session) -> str:

--- a/api/tests/test_containers_integration_tests/services/test_app_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_app_service.py
@@ -1276,45 +1276,6 @@ class TestAppService:
         deleted_app = db_session_with_containers.query(App).filter_by(id=app_id).first()
         assert deleted_app is None
 
-    def test_get_app_meta_success(self, db_session_with_containers: Session, mock_external_service_dependencies):
-        """
-        Test successful app metadata retrieval.
-        """
-        fake = Faker()
-
-        # Create account and tenant first
-        account = AccountService.create_account(
-            email=fake.email(),
-            name=fake.name(),
-            interface_language="en-US",
-            password=generate_valid_password(fake),
-            session=db_session_with_containers,
-        )
-        TenantService.create_owner_tenant_if_not_exist(account, name=fake.company(), session=db_session_with_containers)
-        tenant = account.current_tenant
-
-        # Create app first
-        # Import here to avoid circular dependency
-        from services.app_service import AppService, CreateAppParams
-
-        app_args = CreateAppParams(
-            name=fake.company(),
-            description=fake.text(max_nb_chars=100),
-            mode="chat",
-            icon_type="emoji",
-            icon="📊",
-            icon_background="#6C5CE7",
-        )
-        app_service = AppService()
-        app = app_service.create_app(tenant.id, app_args, account, session=db_session_with_containers)
-
-        # Get app metadata
-        app_meta = app_service.get_app_meta(app, session=db_session_with_containers)
-
-        # Verify metadata contains expected fields
-        assert "tool_icons" in app_meta
-        # Note: get_app_meta currently only returns tool_icons
-
     def test_get_app_code_by_id_success(self, db_session_with_containers: Session, mock_external_service_dependencies):
         """
         Test successful app code retrieval by app ID.
@@ -1590,31 +1551,3 @@ class TestAppService:
 
         with pytest.raises(ValueError, match="not found"):
             AppService.get_app_id_by_code("nonexistent-code", session=db_session_with_containers)
-
-    def test_get_app_meta_returns_empty_when_workflow_missing(
-        self, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
-        """Test get_app_meta returns empty tool_icons when the workflow ID is absent."""
-        from types import SimpleNamespace
-
-        from services.app_service import AppService
-
-        app_service = AppService()
-        workflow_app = SimpleNamespace(mode="workflow", workflow_id=None)
-
-        meta = app_service.get_app_meta(workflow_app, session=db_session_with_containers)
-        assert meta == {"tool_icons": {}}
-
-    def test_get_app_meta_returns_empty_when_model_config_missing(
-        self, db_session_with_containers: Session, mock_external_service_dependencies
-    ):
-        """Test get_app_meta returns empty tool_icons when the model config ID is absent."""
-        from types import SimpleNamespace
-
-        from services.app_service import AppService
-
-        app_service = AppService()
-        chat_app = SimpleNamespace(mode="chat", app_model_config_id=None)
-
-        meta = app_service.get_app_meta(chat_app, session=db_session_with_containers)
-        assert meta == {"tool_icons": {}}

--- a/api/tests/unit_tests/controllers/service_api/app/test_app.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_app.py
@@ -41,6 +41,7 @@ from models.model import (
     TagType,
 )
 from models.workflow import Workflow, WorkflowType
+from services.app_definition_query_service import AppDefinitionUnavailableError
 
 
 @dataclass(frozen=True)
@@ -361,6 +362,29 @@ def test_get_meta_queries_authenticated_app(
 
     app_definitions.get_tool_icons.assert_called_once_with(authenticated_controller.app_id)
     assert response == {"tool_icons": {}}
+
+
+@pytest.mark.usefixtures("authenticated_controller")
+def test_get_meta_maps_unavailable_definition_to_app_unavailable(
+    flask_app: Flask, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app_definitions = Mock()
+    app_definitions.get_tool_icons.side_effect = AppDefinitionUnavailableError
+    monkeypatch.setattr(
+        app_controller,
+        "application_services",
+        Mock(return_value=SimpleNamespace(app_definitions=app_definitions)),
+    )
+
+    with flask_app.test_request_context("/meta", headers={"Authorization": "Bearer token"}):
+        with pytest.raises(AppUnavailableError) as raised:
+            AppMetaApi().get()
+
+    assert raised.value.data == {
+        "code": "app_unavailable",
+        "message": "App unavailable, please check your app configurations.",
+        "status": 400,
+    }
 
 
 @pytest.mark.parametrize("mode", [AppMode.CHAT, AppMode.COMPLETION, AppMode.WORKFLOW, AppMode.ADVANCED_CHAT])

--- a/api/tests/unit_tests/controllers/service_api/app/test_app.py
+++ b/api/tests/unit_tests/controllers/service_api/app/test_app.py
@@ -11,6 +11,7 @@ lookup results.
 import json
 from collections.abc import Iterator
 from dataclasses import dataclass
+from types import SimpleNamespace
 from unittest.mock import Mock
 from uuid import uuid4
 
@@ -344,20 +345,21 @@ def test_parameters_reject_missing_persisted_configuration(
             AppParameterApi().get()
 
 
-def test_get_meta_passes_real_session_and_app(
+def test_get_meta_queries_authenticated_app(
     flask_app: Flask, authenticated_controller: AppDatabase, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    service = Mock()
-    service.get_app_meta.return_value = {"tool_icons": {}}
-    monkeypatch.setattr(app_controller, "AppService", Mock(return_value=service))
+    app_definitions = Mock()
+    app_definitions.get_tool_icons.return_value = {}
+    monkeypatch.setattr(
+        app_controller,
+        "application_services",
+        Mock(return_value=SimpleNamespace(app_definitions=app_definitions)),
+    )
 
     with flask_app.test_request_context("/meta", headers={"Authorization": "Bearer token"}):
         response = AppMetaApi().get()
 
-    service.get_app_meta.assert_called_once()
-    (app_model,) = service.get_app_meta.call_args.args
-    assert app_model.id == authenticated_controller.app_id
-    assert service.get_app_meta.call_args.kwargs["session"] is authenticated_controller.registry()
+    app_definitions.get_tool_icons.assert_called_once_with(authenticated_controller.app_id)
     assert response == {"tool_icons": {}}
 
 

--- a/api/tests/unit_tests/controllers/web/test_app.py
+++ b/api/tests/unit_tests/controllers/web/test_app.py
@@ -11,6 +11,7 @@ from flask import Flask
 from controllers.web.app import AppAccessMode, AppMeta, AppParameterApi, AppWebAuthPermission
 from controllers.web.error import AgentNotPublishedError, AppUnavailableError
 from core.app.apps.agent_app.errors import AgentAppNotPublishedError
+from services.app_definition_query_service import AppDefinitionUnavailableError
 
 
 # ---------------------------------------------------------------------------
@@ -127,6 +128,22 @@ class TestAppMeta:
 
         assert result == {"tool_icons": {}}
         app_definitions.get_tool_icons.assert_called_once_with("app-1")
+
+    @patch("controllers.web.app.application_services")
+    def test_maps_unavailable_definition_to_app_unavailable(self, application_services: MagicMock, app: Flask) -> None:
+        app_definitions = MagicMock()
+        app_definitions.get_tool_icons.side_effect = AppDefinitionUnavailableError
+        application_services.return_value = SimpleNamespace(app_definitions=app_definitions)
+
+        with app.test_request_context("/meta"):
+            with pytest.raises(AppUnavailableError) as raised:
+                AppMeta().get(SimpleNamespace(id="app-1"), SimpleNamespace())
+
+        assert raised.value.data == {
+            "code": "app_unavailable",
+            "message": "App unavailable, please check your app configurations.",
+            "status": 400,
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/unit_tests/controllers/web/test_app.py
+++ b/api/tests/unit_tests/controllers/web/test_app.py
@@ -115,15 +115,18 @@ class TestAppParameterApi:
 # AppMeta
 # ---------------------------------------------------------------------------
 class TestAppMeta:
-    @patch("controllers.web.app.AppService")
-    def test_get_returns_meta(self, mock_service_cls: MagicMock, app: Flask) -> None:
-        mock_service_cls.return_value.get_app_meta.return_value = {"tool_icons": {}}
+    @patch("controllers.web.app.application_services")
+    def test_get_returns_meta(self, application_services: MagicMock, app: Flask) -> None:
+        app_definitions = MagicMock()
+        app_definitions.get_tool_icons.return_value = {}
+        application_services.return_value = SimpleNamespace(app_definitions=app_definitions)
         app_model = SimpleNamespace(id="app-1")
 
         with app.test_request_context("/meta"):
             result = AppMeta().get(app_model, SimpleNamespace())
 
         assert result == {"tool_icons": {}}
+        app_definitions.get_tool_icons.assert_called_once_with("app-1")
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/unit_tests/services/test_app_service.py
+++ b/api/tests/unit_tests/services/test_app_service.py
@@ -16,7 +16,6 @@ from models import Account, Tenant
 from models.account import TenantAccountJoin, TenantAccountRole
 from models.agent import Agent, AgentIconType, AgentScope, AgentSource, AgentStatus
 from models.model import App, AppMode, AppModelConfig, IconType
-from models.workflow import Workflow
 from services.agent.errors import AgentAccessNotReadyError, AgentNameConflictError
 from services.app_service import AppListParams, AppService, CreateAppParams
 
@@ -388,38 +387,6 @@ def test_get_recent_apps_uses_one_tenant_scoped_projection_query(sqlite_session:
     assert len(select_statements) == 1
     assert "count(" not in select_statements[0].lower()
     assert "app_model_configs" not in select_statements[0].lower()
-
-
-class TestAppMeta:
-    def test_loads_workflow_with_caller_session(self, sqlite_session: Session):
-        tenant_id = str(uuid4())
-        app = _persist_app(sqlite_session, tenant_id=tenant_id)
-        app.mode = AppMode.WORKFLOW
-        workflow = Workflow(
-            id=str(uuid4()),
-            tenant_id=tenant_id,
-            app_id=app.id,
-            type="workflow",
-            version="draft",
-            graph='{"nodes": []}',
-            features="{}",
-            created_by=str(uuid4()),
-        )
-        app.workflow_id = workflow.id
-        sqlite_session.add(workflow)
-        sqlite_session.commit()
-
-        assert AppService().get_app_meta(app, session=sqlite_session) == {"tool_icons": {}}
-
-    def test_loads_app_model_config_with_caller_session(self, sqlite_session: Session):
-        app = _persist_app(sqlite_session, tenant_id=str(uuid4()))
-        config = AppModelConfig(app_id=app.id, agent_mode='{"tools": []}')
-        sqlite_session.add(config)
-        sqlite_session.flush()
-        app.app_model_config_id = config.id
-        sqlite_session.commit()
-
-        assert AppService().get_app_meta(app, session=sqlite_session) == {"tool_icons": {}}
 
 
 class TestGetApp:


### PR DESCRIPTION
## Summary

Part of #39993. This PR is stacked on #40462.

- reuse the App Definition query from #40462 for the remaining Web API and Service API `/meta` endpoints
- pass only the admitted app ID from each controller into the shared capability
- remove the legacy `AppService.get_app_meta` implementation and its superseded tests
- map unavailable App Definition reads consistently to the existing `app_unavailable` / 400 contract

## Why

#40462 establishes one App Definition boundary for published parameters and tool-icon metadata. This layer reuses that stable capability instead of introducing another endpoint-oriented meta service.

After this change, all app metadata endpoints share one implementation, the repository owns the read-only SQLAlchemy session, and the same domain failure no longer drifts to `invalid_param` on Web or Service API metadata requests.

## Compatibility

- keep `WebApiResource` and `validate_app_token` admission unchanged
- preserve routes, response schemas, tool-icon mapping, and fallback behavior
- keep the existing `app_unavailable` code, status, and message for frontend error handling
- leave all other `AppService` responsibilities and call sites unchanged

## Validation

- 141 focused App Definition and controller tests passed on the restacked head
- Ruff check and format check
- `git diff --check`
