### PR TITLE
refactor(api): extract web app access queries

### DIFF
--- a/api/.importlinter
+++ b/api/.importlinter
@@ -107,6 +107,23 @@ forbidden_modules =
     sqlalchemy
     werkzeug
 
+[importlinter:contract:webapp-access-query-service-boundary]
+name = Web app access query application service is framework and persistence neutral
+type = forbidden
+source_modules =
+    services.webapp_access_query_service
+forbidden_modules =
+    configs
+    controllers
+    extensions
+    flask
+    models
+    repositories
+    services.enterprise
+    services.feature_service
+    sqlalchemy
+    werkzeug
+
 [importlinter:contract:feature-query-service-boundary]
 name = Feature query application service is framework and persistence neutral
 type = forbidden

--- a/api/controllers/web/app.py
+++ b/api/controllers/web/app.py
@@ -8,6 +8,7 @@ from werkzeug.exceptions import Unauthorized
 
 from constants import HEADER_NAME_APP_CODE
 from controllers.common import fields
+from controllers.common.errors import InvalidArgumentError
 from controllers.common.fields import AccessModeResponse, Parameters
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from extensions.ext_application_services import application_services
@@ -19,10 +20,15 @@ from models.model import App, EndUser
 from services.app_definition_query_service import AppDefinitionNotPublishedError, AppDefinitionUnavailableError
 from services.enterprise.enterprise_service import EnterpriseService
 from services.feature_service import FeatureService
+from services.webapp_access_query_service import (
+    WebAppAccessAppNotFoundError,
+    WebAppAccessReferenceRequiredError,
+    WebAppAccessUnavailableError,
+)
 from services.webapp_auth_service import WebAppAuthService
 
 from . import web_ns
-from .error import AgentNotPublishedError, AppUnavailableError
+from .error import AgentNotPublishedError, AppUnavailableError, WebAppAccessServiceUnavailableError, WebAppNotFoundError
 from .wraps import WebApiResource
 
 logger = logging.getLogger(__name__)
@@ -121,17 +127,26 @@ class AppAccessMode(Resource):
         responses={
             200: "Success",
             400: "Bad Request",
+            404: "App Not Found",
             500: "Internal Server Error",
+            503: "Web App Access Service Unavailable",
         }
     )
     @web_ns.response(200, "Success", web_ns.models[AccessModeResponse.__name__])
     def get(self):
         raw_args = request.args.to_dict()
         args = AppAccessModeQuery.model_validate(raw_args)
-        access_mode = application_services().webapp_access.get_access_mode(
-            app_id=args.app_id,
-            app_code=args.app_code,
-        )
+        try:
+            access_mode = application_services().webapp_access.get_access_mode(
+                app_id=args.app_id,
+                app_code=args.app_code,
+            )
+        except WebAppAccessReferenceRequiredError as e:
+            raise InvalidArgumentError(description=str(e)) from None
+        except WebAppAccessAppNotFoundError:
+            raise WebAppNotFoundError() from None
+        except WebAppAccessUnavailableError:
+            raise WebAppAccessServiceUnavailableError() from None
         return dump_response(AccessModeResponse, {"access_mode": access_mode})
 
 

--- a/api/controllers/web/app.py
+++ b/api/controllers/web/app.py
@@ -8,7 +8,7 @@ from werkzeug.exceptions import Unauthorized
 
 from constants import HEADER_NAME_APP_CODE
 from controllers.common import fields
-from controllers.common.fields import Parameters
+from controllers.common.fields import AccessModeResponse, Parameters
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
 from extensions.ext_application_services import application_services
 from extensions.ext_database import db
@@ -17,7 +17,6 @@ from libs.passport import PassportService
 from libs.token import extract_webapp_passport
 from models.model import App, EndUser
 from services.app_definition_query_service import AppDefinitionNotPublishedError, AppDefinitionUnavailableError
-from services.app_service import AppService
 from services.enterprise.enterprise_service import EnterpriseService
 from services.feature_service import FeatureService
 from services.webapp_auth_service import WebAppAuthService
@@ -54,7 +53,7 @@ register_response_schema_models(
     web_ns,
     Parameters,
     AppMetaResponse,
-    fields.AccessModeResponse,
+    AccessModeResponse,
     fields.BooleanResultResponse,
 )
 
@@ -125,25 +124,15 @@ class AppAccessMode(Resource):
             500: "Internal Server Error",
         }
     )
-    @web_ns.response(200, "Success", web_ns.models[fields.AccessModeResponse.__name__])
+    @web_ns.response(200, "Success", web_ns.models[AccessModeResponse.__name__])
     def get(self):
         raw_args = request.args.to_dict()
         args = AppAccessModeQuery.model_validate(raw_args)
-
-        features = FeatureService.get_system_features()
-        if not features.webapp_auth.enabled:
-            return {"accessMode": "public"}
-
-        app_id = args.app_id
-        if args.app_code:
-            app_id = AppService.get_app_id_by_code(args.app_code, session=db.session())
-
-        if not app_id:
-            raise ValueError("appId or appCode must be provided")
-
-        res = EnterpriseService.WebAppAuth.get_app_access_mode_by_id(app_id)
-
-        return {"accessMode": res.access_mode}
+        access_mode = application_services().webapp_access.get_access_mode(
+            app_id=args.app_id,
+            app_code=args.app_code,
+        )
+        return dump_response(AccessModeResponse, {"access_mode": access_mode})
 
 
 @web_ns.route("/webapp/permission")

--- a/api/controllers/web/app.py
+++ b/api/controllers/web/app.py
@@ -11,6 +11,14 @@ from controllers.common import fields
 from controllers.common.errors import InvalidArgumentError
 from controllers.common.fields import AccessModeResponse, Parameters
 from controllers.common.schema import query_params_from_model, register_response_schema_models, register_schema_models
+from controllers.web import web_ns
+from controllers.web.error import (
+    AgentNotPublishedError,
+    AppUnavailableError,
+    WebAppAccessServiceUnavailableError,
+    WebAppNotFoundError,
+)
+from controllers.web.wraps import WebApiResource
 from extensions.ext_application_services import application_services
 from extensions.ext_database import db
 from libs.helper import dump_response
@@ -26,10 +34,6 @@ from services.webapp_access_query_service import (
     WebAppAccessUnavailableError,
 )
 from services.webapp_auth_service import WebAppAuthService
-
-from . import web_ns
-from .error import AgentNotPublishedError, AppUnavailableError, WebAppAccessServiceUnavailableError, WebAppNotFoundError
-from .wraps import WebApiResource
 
 logger = logging.getLogger(__name__)
 

--- a/api/controllers/web/error.py
+++ b/api/controllers/web/error.py
@@ -121,6 +121,18 @@ class WebAppAuthAccessDeniedError(BaseHTTPException):
     code = 401
 
 
+class WebAppNotFoundError(BaseHTTPException):
+    error_code = "app_not_found"
+    description = "App not found."
+    code = 404
+
+
+class WebAppAccessServiceUnavailableError(BaseHTTPException):
+    error_code = "web_app_access_unavailable"
+    description = "Web app access service is unavailable."
+    code = 503
+
+
 class InvokeRateLimitError(BaseHTTPException):
     """Raised when the Invoke returns rate limit error."""
 

--- a/api/enums/__init__.py
+++ b/api/enums/__init__.py
@@ -23,6 +23,13 @@ class DeploymentEdition(StrEnum):
     CLOUD = "CLOUD"
 
 
+class WebAppAccessMode(StrEnum):
+    PUBLIC = "public"
+    PRIVATE = "private"
+    PRIVATE_ALL = "private_all"
+    SSO_VERIFIED = "sso_verified"
+
+
 class HostedTrialProvider(StrEnum):
     """Enum representing hosted model provider names for trial access."""
 

--- a/api/extensions/ext_application_services.py
+++ b/api/extensions/ext_application_services.py
@@ -10,13 +10,14 @@ from configs import dify_config
 from constants.dsl_version import CURRENT_APP_DSL_VERSION
 from core.db.session_factory import get_session_maker
 from core.schemas.schema_manager import SchemaManager
-from enums import DeploymentEdition
+from enums import DeploymentEdition, WebAppAccessMode
 from extensions.ext_redis import RedisClientWrapper, redis_client
 from repositories.account_activation_repository import SQLAlchemyAccountActivationRepository
 from repositories.app_definition_query_repository import AppDefinitionQueryRepository
 from repositories.data_source_api_key_auth_repository import SQLAlchemyDataSourceApiKeyAuthBindingRepository
 from repositories.explore_banner_query_repository import ExploreBannerQueryRepository
 from repositories.installation_state_repository import InstallationStateRepository
+from repositories.webapp_access_query_repository import WebAppAccessQueryRepository
 from repositories.workspace_member_query_repository import WorkspaceMemberQueryRepository
 from repositories.workspace_query_repository import WorkspaceQueryRepository
 from services.account_activation_adapters import (
@@ -32,6 +33,7 @@ from services.auth.data_source_api_key_auth_gateways import (
     TenantApiKeyAuthCredentialEncryptor,
 )
 from services.auth.data_source_api_key_auth_service import DataSourceApiKeyAuthService
+from services.enterprise.enterprise_service import EnterpriseService
 from services.explore_banner_query_service import ExploreBannerQueryService
 from services.feature_query_service import FeatureQueryService
 from services.feature_service import FeatureService
@@ -40,6 +42,7 @@ from services.init_validation_service import InitValidationService
 from services.schema_definition_service import SchemaDefinitionService
 from services.setup_adapters import RedisSetupLock, RegisterServiceAccountProvisioner
 from services.setup_service import SetupService
+from services.webapp_access_query_service import WebAppAccessQueryService
 from services.workspace_member_query_service import WorkspaceMemberQueryService
 from services.workspace_member_role_resolver import DeploymentWorkspaceMemberRoleResolver
 from services.workspace_plan_gateway import DeploymentWorkspacePlanGateway
@@ -48,11 +51,17 @@ from services.workspace_query_service import WorkspaceQueryService
 _EXTENSION_KEY = "application_services"
 
 
+def _get_enterprise_webapp_access_mode(app_id: str) -> WebAppAccessMode:
+    settings = EnterpriseService.WebAppAuth.get_app_access_mode_by_id(app_id)
+    return WebAppAccessMode(settings.access_mode)
+
+
 @dataclass(frozen=True, slots=True)
 class ApplicationServices:
     account_activation: AccountActivationService
     app_definitions: AppDefinitionQueryService
     data_source_api_key_auth: DataSourceApiKeyAuthService
+    webapp_access: WebAppAccessQueryService
     explore_banner_queries: ExploreBannerQueryService
     schema_definitions: SchemaDefinitionService
     setup: SetupService
@@ -93,6 +102,11 @@ def build_application_services(
             bindings=data_source_api_key_auth_bindings,
             validator=ProviderApiKeyAuthCredentialValidator(),
             encryptor=TenantApiKeyAuthCredentialEncryptor(),
+        ),
+        webapp_access=WebAppAccessQueryService(
+            access=WebAppAccessQueryRepository(session_factory=database_client),
+            webapp_auth_enabled=FeatureService.is_webapp_auth_enabled(),
+            access_mode_for_app=_get_enterprise_webapp_access_mode,
         ),
         explore_banner_queries=ExploreBannerQueryService(
             banners=ExploreBannerQueryRepository(client=database_client),

--- a/api/extensions/ext_application_services.py
+++ b/api/extensions/ext_application_services.py
@@ -1,9 +1,12 @@
 """Composition root for application services used by transport adapters."""
 
+import json
 from dataclasses import dataclass
 from typing import cast
 
+import httpx
 from flask import Flask, current_app
+from pydantic import ValidationError
 from sqlalchemy.orm import Session, sessionmaker
 
 from configs import dify_config
@@ -34,6 +37,7 @@ from services.auth.data_source_api_key_auth_gateways import (
 )
 from services.auth.data_source_api_key_auth_service import DataSourceApiKeyAuthService
 from services.enterprise.enterprise_service import EnterpriseService
+from services.errors.enterprise import EnterpriseServiceError
 from services.explore_banner_query_service import ExploreBannerQueryService
 from services.feature_query_service import FeatureQueryService
 from services.feature_service import FeatureService
@@ -42,7 +46,10 @@ from services.init_validation_service import InitValidationService
 from services.schema_definition_service import SchemaDefinitionService
 from services.setup_adapters import RedisSetupLock, RegisterServiceAccountProvisioner
 from services.setup_service import SetupService
-from services.webapp_access_query_service import WebAppAccessQueryService
+from services.webapp_access_query_service import (
+    WebAppAccessQueryService,
+    WebAppAccessUnavailableError,
+)
 from services.workspace_member_query_service import WorkspaceMemberQueryService
 from services.workspace_member_role_resolver import DeploymentWorkspaceMemberRoleResolver
 from services.workspace_plan_gateway import DeploymentWorkspacePlanGateway
@@ -52,8 +59,14 @@ _EXTENSION_KEY = "application_services"
 
 
 def _get_enterprise_webapp_access_mode(app_id: str) -> WebAppAccessMode:
-    settings = EnterpriseService.WebAppAuth.get_app_access_mode_by_id(app_id)
-    return WebAppAccessMode(settings.access_mode)
+    try:
+        settings = EnterpriseService.WebAppAuth.get_app_access_mode_by_id(app_id)
+    except (EnterpriseServiceError, httpx.RequestError, json.JSONDecodeError, UnicodeDecodeError, ValidationError) as e:
+        raise WebAppAccessUnavailableError from e
+    try:
+        return WebAppAccessMode(settings.access_mode)
+    except ValueError as e:
+        raise WebAppAccessUnavailableError from e
 
 
 @dataclass(frozen=True, slots=True)

--- a/api/openapi/markdown/web-openapi.md
+++ b/api/openapi/markdown/web-openapi.md
@@ -826,7 +826,9 @@ Retrieve the access mode for a web application (public or restricted).
 | ---- | ----------- | ------ |
 | 200 | Success | **application/json**: [AccessModeResponse](#accessmoderesponse)<br> |
 | 400 | Bad Request |  |
+| 404 | App Not Found |  |
 | 500 | Internal Server Error |  |
+| 503 | Web App Access Service Unavailable |  |
 
 ### [GET] /webapp/permission
 Check if user has permission to access a web application.

--- a/api/repositories/webapp_access_query_repository.py
+++ b/api/repositories/webapp_access_query_repository.py
@@ -1,0 +1,20 @@
+"""Database repository for web-app access queries."""
+
+from typing import override
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+from models.model import Site
+from services.webapp_access_query_service import WebAppAccessQuery
+
+
+class WebAppAccessQueryRepository(WebAppAccessQuery):
+    def __init__(self, *, session_factory: sessionmaker[Session]) -> None:
+        self._session_factory = session_factory
+
+    @override
+    def find_app_id_by_code(self, app_code: str) -> str | None:
+        with self._session_factory() as session:
+            app_id = session.scalar(select(Site.app_id).where(Site.code == app_code).limit(1))
+            return str(app_id) if app_id is not None else None

--- a/api/repositories/webapp_access_query_repository.py
+++ b/api/repositories/webapp_access_query_repository.py
@@ -3,10 +3,11 @@
 from typing import override
 
 from sqlalchemy import select
+from sqlalchemy.exc import DBAPIError, TimeoutError
 from sqlalchemy.orm import Session, sessionmaker
 
 from models.model import Site
-from services.webapp_access_query_service import WebAppAccessQuery
+from services.webapp_access_query_service import WebAppAccessQuery, WebAppAccessUnavailableError
 
 
 class WebAppAccessQueryRepository(WebAppAccessQuery):
@@ -15,6 +16,9 @@ class WebAppAccessQueryRepository(WebAppAccessQuery):
 
     @override
     def find_app_id_by_code(self, app_code: str) -> str | None:
-        with self._session_factory() as session:
-            app_id = session.scalar(select(Site.app_id).where(Site.code == app_code).limit(1))
-            return str(app_id) if app_id is not None else None
+        try:
+            with self._session_factory() as session:
+                app_id = session.scalar(select(Site.app_id).where(Site.code == app_code).limit(1))
+                return str(app_id) if app_id is not None else None
+        except (DBAPIError, TimeoutError) as e:
+            raise WebAppAccessUnavailableError from e

--- a/api/services/enterprise/enterprise_service.py
+++ b/api/services/enterprise/enterprise_service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import enum
 import logging
 import uuid
 from datetime import datetime
@@ -9,7 +8,7 @@ from cachetools.func import ttl_cache
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from configs import dify_config
-from enums import DeploymentEdition
+from enums import DeploymentEdition, WebAppAccessMode
 from extensions.ext_redis import redis_client
 from services.enterprise.base import (
     EnterpriseRequest,
@@ -29,13 +28,6 @@ DEFAULT_WORKSPACE_JOIN_TIMEOUT_SECONDS = 1.0
 LICENSE_STATUS_CACHE_KEY = "enterprise:license:status"
 VALID_LICENSE_CACHE_TTL = 600  # 10 minutes — valid licenses are stable
 INVALID_LICENSE_CACHE_TTL = 30  # 30 seconds — short so admin fixes are picked up quickly
-
-
-class WebAppAccessMode(enum.StrEnum):
-    PUBLIC = "public"
-    PRIVATE = "private"
-    PRIVATE_ALL = "private_all"
-    SSO_VERIFIED = "sso_verified"
 
 
 PERMISSION_CHECK_MODES: frozenset[WebAppAccessMode] = frozenset(

--- a/api/services/enterprise/enterprise_service.py
+++ b/api/services/enterprise/enterprise_service.py
@@ -285,7 +285,7 @@ class EnterpriseService:
             params = {"appId": app_id}
             data = EnterpriseRequest.send_request("GET", "/webapp/access-mode/id", params=params)
             if not data:
-                raise ValueError("No data found.")
+                raise EnterpriseServiceError("No data found.")
             return WebAppSettings.model_validate(data)
 
         @classmethod

--- a/api/services/feature_service.py
+++ b/api/services/feature_service.py
@@ -104,10 +104,10 @@ class FeatureService:
         system_features.rbac_enabled = dify_config.RBAC_ENABLED
 
         cls._fulfill_system_params_from_env(system_features)
+        system_features.webapp_auth.enabled = cls.is_webapp_auth_enabled()
 
         if dify_config.DEPLOYMENT_EDITION == DeploymentEdition.ENTERPRISE:
             system_features.branding.enabled = True
-            system_features.webapp_auth.enabled = True
             system_features.enable_change_email = False
             cls._fulfill_params_from_enterprise(system_features)
 
@@ -158,6 +158,10 @@ class FeatureService:
     @staticmethod
     def is_explore_banner_enabled() -> bool:
         return dify_config.DEPLOYMENT_EDITION == DeploymentEdition.CLOUD and dify_config.ENABLE_EXPLORE_BANNER
+
+    @staticmethod
+    def is_webapp_auth_enabled() -> bool:
+        return dify_config.DEPLOYMENT_EDITION == DeploymentEdition.ENTERPRISE
 
     @classmethod
     def _fulfill_system_params_from_env(cls, system_features: feature_entities.SystemFeatureModel):

--- a/api/services/webapp_access_query_service.py
+++ b/api/services/webapp_access_query_service.py
@@ -10,6 +10,18 @@ class WebAppAccessQuery(Protocol):
     def find_app_id_by_code(self, app_code: str) -> str | None: ...
 
 
+class WebAppAccessReferenceRequiredError(ValueError):
+    """Raised when neither an app ID nor an app code was provided."""
+
+
+class WebAppAccessAppNotFoundError(LookupError):
+    """Raised when an app code does not resolve to an app."""
+
+
+class WebAppAccessUnavailableError(RuntimeError):
+    """Raised when an access dependency cannot answer the query."""
+
+
 class WebAppAccessQueryService:
     def __init__(
         self,
@@ -29,9 +41,9 @@ class WebAppAccessQueryService:
         if app_code:
             app_id = self._access.find_app_id_by_code(app_code)
             if app_id is None:
-                raise ValueError(f"App with code {app_code} not found")
+                raise WebAppAccessAppNotFoundError
 
         if not app_id:
-            raise ValueError("appId or appCode must be provided")
+            raise WebAppAccessReferenceRequiredError("appId or appCode must be provided")
 
         return self._access_mode_for_app(app_id)

--- a/api/services/webapp_access_query_service.py
+++ b/api/services/webapp_access_query_service.py
@@ -1,0 +1,37 @@
+"""Application service for resolving web-app access."""
+
+from collections.abc import Callable
+from typing import Protocol
+
+from enums import WebAppAccessMode
+
+
+class WebAppAccessQuery(Protocol):
+    def find_app_id_by_code(self, app_code: str) -> str | None: ...
+
+
+class WebAppAccessQueryService:
+    def __init__(
+        self,
+        *,
+        access: WebAppAccessQuery,
+        webapp_auth_enabled: bool,
+        access_mode_for_app: Callable[[str], WebAppAccessMode],
+    ) -> None:
+        self._access = access
+        self._webapp_auth_enabled = webapp_auth_enabled
+        self._access_mode_for_app = access_mode_for_app
+
+    def get_access_mode(self, *, app_id: str | None, app_code: str | None) -> WebAppAccessMode:
+        if not self._webapp_auth_enabled:
+            return WebAppAccessMode.PUBLIC
+
+        if app_code:
+            app_id = self._access.find_app_id_by_code(app_code)
+            if app_id is None:
+                raise ValueError(f"App with code {app_code} not found")
+
+        if not app_id:
+            raise ValueError("appId or appCode must be provided")
+
+        return self._access_mode_for_app(app_id)

--- a/api/tests/unit_tests/controllers/web/test_app.py
+++ b/api/tests/unit_tests/controllers/web/test_app.py
@@ -8,13 +8,24 @@ from unittest.mock import MagicMock, patch
 import pytest
 from flask import Flask
 
+from controllers.common.errors import InvalidArgumentError
 from controllers.web.app import AppAccessMode, AppMeta, AppParameterApi, AppWebAuthPermission
-from controllers.web.error import AgentNotPublishedError, AppUnavailableError
+from controllers.web.error import (
+    AgentNotPublishedError,
+    AppUnavailableError,
+    WebAppAccessServiceUnavailableError,
+    WebAppNotFoundError,
+)
 from core.app.app_config.common.parameters_mapping import get_parameters_from_feature_dict
 from enums import WebAppAccessMode
 from models.enums import EndUserType
 from models.model import App, AppMode, EndUser
 from services.app_definition_query_service import AppDefinitionNotPublishedError, AppDefinitionUnavailableError
+from services.webapp_access_query_service import (
+    WebAppAccessAppNotFoundError,
+    WebAppAccessReferenceRequiredError,
+    WebAppAccessUnavailableError,
+)
 
 
 def _make_app() -> App:
@@ -131,6 +142,52 @@ class TestAppAccessMode:
 
         assert result == {"accessMode": "sso_verified"}
         webapp_access.get_access_mode.assert_called_once_with(app_id="app-1", app_code="code-1")
+
+    @pytest.mark.parametrize(
+        ("service_error", "http_error", "expected_data"),
+        [
+            pytest.param(
+                WebAppAccessReferenceRequiredError("appId or appCode must be provided"),
+                InvalidArgumentError,
+                {"code": "invalid_param", "message": "appId or appCode must be provided", "status": 400},
+                id="missing-reference",
+            ),
+            pytest.param(
+                WebAppAccessAppNotFoundError(),
+                WebAppNotFoundError,
+                {"code": "app_not_found", "message": "App not found.", "status": 404},
+                id="app-not-found",
+            ),
+            pytest.param(
+                WebAppAccessUnavailableError(),
+                WebAppAccessServiceUnavailableError,
+                {
+                    "code": "web_app_access_unavailable",
+                    "message": "Web app access service is unavailable.",
+                    "status": 503,
+                },
+                id="access-unavailable",
+            ),
+        ],
+    )
+    @patch("controllers.web.app.application_services")
+    def test_maps_query_errors(
+        self,
+        application_services: MagicMock,
+        service_error: Exception,
+        http_error: type[Exception],
+        expected_data: dict[str, object],
+        app: Flask,
+    ) -> None:
+        webapp_access = MagicMock()
+        webapp_access.get_access_mode.side_effect = service_error
+        application_services.return_value = SimpleNamespace(webapp_access=webapp_access)
+
+        with app.test_request_context("/webapp/access-mode?appCode=code-1"):
+            with pytest.raises(http_error) as raised:
+                AppAccessMode().get()
+
+        assert raised.value.data == expected_data
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/unit_tests/controllers/web/test_app.py
+++ b/api/tests/unit_tests/controllers/web/test_app.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
@@ -11,6 +11,7 @@ from flask import Flask
 from controllers.web.app import AppAccessMode, AppMeta, AppParameterApi, AppWebAuthPermission
 from controllers.web.error import AgentNotPublishedError, AppUnavailableError
 from core.app.app_config.common.parameters_mapping import get_parameters_from_feature_dict
+from enums import WebAppAccessMode
 from models.enums import EndUserType
 from models.model import App, AppMode, EndUser
 from services.app_definition_query_service import AppDefinitionNotPublishedError, AppDefinitionUnavailableError
@@ -119,52 +120,17 @@ class TestAppMeta:
 # AppAccessMode
 # ---------------------------------------------------------------------------
 class TestAppAccessMode:
-    @patch("controllers.web.app.FeatureService.get_system_features")
-    def test_returns_public_when_webapp_auth_disabled(self, mock_features: MagicMock, app: Flask) -> None:
-        mock_features.return_value = SimpleNamespace(webapp_auth=SimpleNamespace(enabled=False))
+    @patch("controllers.web.app.application_services")
+    def test_delegates_validated_app_references(self, application_services: MagicMock, app: Flask) -> None:
+        webapp_access = MagicMock()
+        webapp_access.get_access_mode.return_value = WebAppAccessMode.SSO_VERIFIED
+        application_services.return_value = SimpleNamespace(webapp_access=webapp_access)
 
-        with app.test_request_context("/webapp/access-mode?appId=app-1"):
+        with app.test_request_context("/webapp/access-mode?appId=app-1&appCode=code-1"):
             result = AppAccessMode().get()
 
-        assert result == {"accessMode": "public"}
-
-    @patch("controllers.web.app.EnterpriseService.WebAppAuth.get_app_access_mode_by_id")
-    @patch("controllers.web.app.FeatureService.get_system_features")
-    def test_returns_access_mode_with_app_id(
-        self, mock_features: MagicMock, mock_access: MagicMock, app: Flask
-    ) -> None:
-        mock_features.return_value = SimpleNamespace(webapp_auth=SimpleNamespace(enabled=True))
-        mock_access.return_value = SimpleNamespace(access_mode="internal")
-
-        with app.test_request_context("/webapp/access-mode?appId=app-1"):
-            result = AppAccessMode().get()
-
-        assert result == {"accessMode": "internal"}
-        mock_access.assert_called_once_with("app-1")
-
-    @patch("controllers.web.app.AppService.get_app_id_by_code", return_value="resolved-id")
-    @patch("controllers.web.app.EnterpriseService.WebAppAuth.get_app_access_mode_by_id")
-    @patch("controllers.web.app.FeatureService.get_system_features")
-    def test_resolves_app_code_to_id(
-        self, mock_features: MagicMock, mock_access: MagicMock, mock_resolve: MagicMock, app: Flask
-    ) -> None:
-        mock_features.return_value = SimpleNamespace(webapp_auth=SimpleNamespace(enabled=True))
-        mock_access.return_value = SimpleNamespace(access_mode="external")
-
-        with app.test_request_context("/webapp/access-mode?appCode=code1"):
-            result = AppAccessMode().get()
-
-        mock_resolve.assert_called_once_with("code1", session=ANY)
-        mock_access.assert_called_once_with("resolved-id")
-        assert result == {"accessMode": "external"}
-
-    @patch("controllers.web.app.FeatureService.get_system_features")
-    def test_raises_when_no_app_id_or_code(self, mock_features: MagicMock, app: Flask) -> None:
-        mock_features.return_value = SimpleNamespace(webapp_auth=SimpleNamespace(enabled=True))
-
-        with app.test_request_context("/webapp/access-mode"):
-            with pytest.raises(ValueError, match="appId or appCode"):
-                AppAccessMode().get()
+        assert result == {"accessMode": "sso_verified"}
+        webapp_access.get_access_mode.assert_called_once_with(app_id="app-1", app_code="code-1")
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/unit_tests/controllers/web/test_error.py
+++ b/api/tests/unit_tests/controllers/web/test_error.py
@@ -24,8 +24,10 @@ from controllers.web.error import (
     ProviderQuotaExceededError,
     SpeechToTextDisabledError,
     UnsupportedAudioTypeError,
+    WebAppAccessServiceUnavailableError,
     WebAppAuthAccessDeniedError,
     WebAppAuthRequiredError,
+    WebAppNotFoundError,
     WebFormRateLimitExceededError,
 )
 
@@ -49,6 +51,8 @@ _ERROR_SPECS: list[tuple[type, str, int]] = [
     (SpeechToTextDisabledError, "speech_to_text_disabled", 400),
     (WebAppAuthRequiredError, "web_sso_auth_required", 401),
     (WebAppAuthAccessDeniedError, "web_app_access_denied", 401),
+    (WebAppNotFoundError, "app_not_found", 404),
+    (WebAppAccessServiceUnavailableError, "web_app_access_unavailable", 503),
     (InvokeRateLimitError, "rate_limit_error", 429),
     (WebFormRateLimitExceededError, "web_form_rate_limit_exceeded", 429),
     (NotFoundError, "not_found", 404),

--- a/api/tests/unit_tests/extensions/test_ext_application_services.py
+++ b/api/tests/unit_tests/extensions/test_ext_application_services.py
@@ -1,10 +1,13 @@
 """Tests for application-service dependency wiring."""
 
+import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from flask import Flask
+from pydantic import ValidationError
 from sqlalchemy.orm import Session, sessionmaker
 
 from enums import DeploymentEdition, WebAppAccessMode
@@ -19,7 +22,10 @@ from services.account_activation_adapters import (
     RegisterServiceInvitationTokenStore,
 )
 from services.auth.data_source_api_key_auth_service import DataSourceApiKeyAuthService
+from services.enterprise.enterprise_service import WebAppSettings
+from services.errors.enterprise import EnterpriseAPIError, EnterpriseAPINotFoundError
 from services.init_validation_service import InvalidInitializationPasswordError
+from services.webapp_access_query_service import WebAppAccessUnavailableError
 
 
 @pytest.mark.parametrize(
@@ -209,3 +215,88 @@ def test_build_application_services_adapts_enterprise_webapp_access_mode(
 
     assert result is WebAppAccessMode.PRIVATE_ALL
     get_access_mode.assert_called_once_with("app-1")
+
+
+@pytest.mark.parametrize(
+    "enterprise_error",
+    [
+        pytest.param(EnterpriseAPINotFoundError(), id="not-found"),
+        pytest.param(EnterpriseAPIError(), id="api-error"),
+        pytest.param(httpx.ConnectError("connection failed"), id="transport"),
+        pytest.param(json.JSONDecodeError("invalid", "", 0), id="invalid-json"),
+        pytest.param(UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid"), id="invalid-encoding"),
+        pytest.param(
+            ValidationError.from_exception_data(WebAppSettings.__name__, []),
+            id="invalid-response",
+        ),
+    ],
+)
+def test_build_application_services_maps_known_enterprise_errors(
+    sqlite_session_factory: sessionmaker[Session],
+    enterprise_error: Exception,
+) -> None:
+    with (
+        patch("extensions.ext_application_services.FeatureService.is_webapp_auth_enabled", return_value=True),
+        patch(
+            "extensions.ext_application_services.EnterpriseService.WebAppAuth.get_app_access_mode_by_id",
+            side_effect=enterprise_error,
+        ),
+    ):
+        services = ext_application_services.build_application_services(
+            database_client=sqlite_session_factory,
+            deployment_edition=DeploymentEdition.COMMUNITY,
+            initialization_password="",
+            redis=MagicMock(spec=RedisClientWrapper),
+        )
+
+        with pytest.raises(WebAppAccessUnavailableError) as raised:
+            services.webapp_access.get_access_mode(app_id="app-1", app_code=None)
+
+    assert raised.value.__cause__ is enterprise_error
+
+
+def test_build_application_services_maps_invalid_access_mode_to_unavailable(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    with (
+        patch("extensions.ext_application_services.FeatureService.is_webapp_auth_enabled", return_value=True),
+        patch(
+            "extensions.ext_application_services.EnterpriseService.WebAppAuth.get_app_access_mode_by_id",
+            return_value=SimpleNamespace(access_mode="invalid"),
+        ),
+    ):
+        services = ext_application_services.build_application_services(
+            database_client=sqlite_session_factory,
+            deployment_edition=DeploymentEdition.COMMUNITY,
+            initialization_password="",
+            redis=MagicMock(spec=RedisClientWrapper),
+        )
+
+        with pytest.raises(WebAppAccessUnavailableError) as raised:
+            services.webapp_access.get_access_mode(app_id="app-1", app_code=None)
+
+    assert isinstance(raised.value.__cause__, ValueError)
+
+
+def test_build_application_services_does_not_hide_unknown_enterprise_errors(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    failure = TypeError("adapter bug")
+    with (
+        patch("extensions.ext_application_services.FeatureService.is_webapp_auth_enabled", return_value=True),
+        patch(
+            "extensions.ext_application_services.EnterpriseService.WebAppAuth.get_app_access_mode_by_id",
+            side_effect=failure,
+        ),
+    ):
+        services = ext_application_services.build_application_services(
+            database_client=sqlite_session_factory,
+            deployment_edition=DeploymentEdition.COMMUNITY,
+            initialization_password="",
+            redis=MagicMock(spec=RedisClientWrapper),
+        )
+
+        with pytest.raises(TypeError) as raised:
+            services.webapp_access.get_access_mode(app_id="app-1", app_code=None)
+
+    assert raised.value is failure

--- a/api/tests/unit_tests/extensions/test_ext_application_services.py
+++ b/api/tests/unit_tests/extensions/test_ext_application_services.py
@@ -1,12 +1,13 @@
 """Tests for application-service dependency wiring."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
 from sqlalchemy.orm import Session, sessionmaker
 
-from enums import DeploymentEdition
+from enums import DeploymentEdition, WebAppAccessMode
 from extensions import ext_application_services
 from extensions.ext_redis import RedisClientWrapper
 from models.model import DifySetup
@@ -186,3 +187,25 @@ def test_build_application_services_wires_data_source_api_key_auth(
     )
 
     assert isinstance(services.data_source_api_key_auth, DataSourceApiKeyAuthService)
+
+
+def test_build_application_services_adapts_enterprise_webapp_access_mode(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    with (
+        patch("extensions.ext_application_services.FeatureService.is_webapp_auth_enabled", return_value=True),
+        patch(
+            "extensions.ext_application_services.EnterpriseService.WebAppAuth.get_app_access_mode_by_id",
+            return_value=SimpleNamespace(access_mode="private_all"),
+        ) as get_access_mode,
+    ):
+        services = ext_application_services.build_application_services(
+            database_client=sqlite_session_factory,
+            deployment_edition=DeploymentEdition.COMMUNITY,
+            initialization_password="",
+            redis=MagicMock(spec=RedisClientWrapper),
+        )
+        result = services.webapp_access.get_access_mode(app_id="app-1", app_code=None)
+
+    assert result is WebAppAccessMode.PRIVATE_ALL
+    get_access_mode.assert_called_once_with("app-1")

--- a/api/tests/unit_tests/repositories/test_webapp_access_query_repository.py
+++ b/api/tests/unit_tests/repositories/test_webapp_access_query_repository.py
@@ -1,0 +1,31 @@
+from sqlalchemy.orm import Session, sessionmaker
+
+from models.model import Site
+from repositories.webapp_access_query_repository import WebAppAccessQueryRepository
+
+_APP_ID = "11111111-1111-1111-1111-111111111111"
+
+
+def test_find_app_id_by_code_returns_matching_site_app(sqlite_session_factory: sessionmaker[Session]) -> None:
+    with sqlite_session_factory.begin() as session:
+        session.add(
+            Site(
+                app_id=_APP_ID,
+                code="site-code",
+                title="Test Site",
+                default_language="en-US",
+                customize_token_strategy="uuid",
+            )
+        )
+
+    repository = WebAppAccessQueryRepository(session_factory=sqlite_session_factory)
+
+    assert repository.find_app_id_by_code("site-code") == _APP_ID
+
+
+def test_find_app_id_by_code_returns_none_for_missing_code(
+    sqlite_session_factory: sessionmaker[Session],
+) -> None:
+    repository = WebAppAccessQueryRepository(session_factory=sqlite_session_factory)
+
+    assert repository.find_app_id_by_code("missing-code") is None

--- a/api/tests/unit_tests/repositories/test_webapp_access_query_repository.py
+++ b/api/tests/unit_tests/repositories/test_webapp_access_query_repository.py
@@ -1,7 +1,12 @@
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session, sessionmaker
 
 from models.model import Site
 from repositories.webapp_access_query_repository import WebAppAccessQueryRepository
+from services.webapp_access_query_service import WebAppAccessUnavailableError
 
 _APP_ID = "11111111-1111-1111-1111-111111111111"
 
@@ -29,3 +34,27 @@ def test_find_app_id_by_code_returns_none_for_missing_code(
     repository = WebAppAccessQueryRepository(session_factory=sqlite_session_factory)
 
     assert repository.find_app_id_by_code("missing-code") is None
+
+
+def test_find_app_id_by_code_maps_database_failures_to_unavailable() -> None:
+    database_error = OperationalError("select", {}, RuntimeError("connection failed"))
+    session = MagicMock()
+    session.__enter__.return_value.scalar.side_effect = database_error
+    repository = WebAppAccessQueryRepository(session_factory=MagicMock(return_value=session))
+
+    with pytest.raises(WebAppAccessUnavailableError) as raised:
+        repository.find_app_id_by_code("site-code")
+
+    assert raised.value.__cause__ is database_error
+
+
+def test_find_app_id_by_code_does_not_hide_unknown_errors() -> None:
+    failure = TypeError("repository bug")
+    session = MagicMock()
+    session.__enter__.return_value.scalar.side_effect = failure
+    repository = WebAppAccessQueryRepository(session_factory=MagicMock(return_value=session))
+
+    with pytest.raises(TypeError) as raised:
+        repository.find_app_id_by_code("site-code")
+
+    assert raised.value is failure

--- a/api/tests/unit_tests/services/enterprise/test_enterprise_service.py
+++ b/api/tests/unit_tests/services/enterprise/test_enterprise_service.py
@@ -23,7 +23,12 @@ from services.enterprise.enterprise_service import (
     try_join_default_workspace,
 )
 from services.entities.feature_entities import LicenseStatus
-from services.errors.enterprise import EnterpriseAPIError, EnterpriseAPIForbiddenError, EnterpriseAPIUnauthorizedError
+from services.errors.enterprise import (
+    EnterpriseAPIError,
+    EnterpriseAPIForbiddenError,
+    EnterpriseAPIUnauthorizedError,
+    EnterpriseServiceError,
+)
 
 MODULE = "services.enterprise.enterprise_service"
 
@@ -146,6 +151,12 @@ class TestWebAppAuth:
 
         assert isinstance(result, WebAppSettings)
         assert result.access_mode == "public"
+
+    def test_get_app_access_mode_raises_service_error_on_empty_response(self):
+        with patch(f"{MODULE}.EnterpriseRequest") as req:
+            req.send_request.return_value = None
+            with pytest.raises(EnterpriseServiceError, match="No data found"):
+                EnterpriseService.WebAppAuth.get_app_access_mode_by_id("a1")
 
     def test_batch_get_returns_empty_for_no_apps(self):
         assert EnterpriseService.WebAppAuth.batch_get_app_access_mode_by_id([]) == {}

--- a/api/tests/unit_tests/services/test_feature_service_deployment_edition.py
+++ b/api/tests/unit_tests/services/test_feature_service_deployment_edition.py
@@ -36,6 +36,9 @@ def test_get_system_features_uses_configured_deployment_edition(
 
     assert result.deployment_edition is edition
     assert result.model_dump(mode="json")["deployment_edition"] == edition.value
+    webapp_auth_enabled = edition is DeploymentEdition.ENTERPRISE
+    assert FeatureService.is_webapp_auth_enabled() is webapp_auth_enabled
+    assert result.webapp_auth.enabled is webapp_auth_enabled
     if edition is DeploymentEdition.ENTERPRISE:
         fulfill_from_enterprise.assert_called_once_with(result)
     else:

--- a/api/tests/unit_tests/services/test_webapp_access_query_service.py
+++ b/api/tests/unit_tests/services/test_webapp_access_query_service.py
@@ -1,0 +1,72 @@
+from unittest.mock import MagicMock, create_autospec
+
+import pytest
+
+from enums import WebAppAccessMode
+from services.webapp_access_query_service import WebAppAccessQuery, WebAppAccessQueryService
+
+
+def _service(
+    *,
+    access: MagicMock,
+    enabled: bool = True,
+    access_mode: WebAppAccessMode = WebAppAccessMode.PRIVATE,
+) -> tuple[WebAppAccessQueryService, MagicMock]:
+    access_mode_for_app = MagicMock(return_value=access_mode)
+    return (
+        WebAppAccessQueryService(
+            access=access,
+            webapp_auth_enabled=enabled,
+            access_mode_for_app=access_mode_for_app,
+        ),
+        access_mode_for_app,
+    )
+
+
+def test_disabled_auth_returns_public_before_resolving_app() -> None:
+    access: MagicMock = create_autospec(WebAppAccessQuery, instance=True, spec_set=True)
+    service, access_mode_for_app = _service(access=access, enabled=False)
+
+    assert service.get_access_mode(app_id=None, app_code=None) is WebAppAccessMode.PUBLIC
+    access.find_app_id_by_code.assert_not_called()
+    access_mode_for_app.assert_not_called()
+
+
+def test_enabled_auth_reads_access_mode_by_app_id() -> None:
+    access: MagicMock = create_autospec(WebAppAccessQuery, instance=True, spec_set=True)
+    service, access_mode_for_app = _service(access=access)
+
+    assert service.get_access_mode(app_id="app-1", app_code=None) is WebAppAccessMode.PRIVATE
+    access.find_app_id_by_code.assert_not_called()
+    access_mode_for_app.assert_called_once_with("app-1")
+
+
+def test_app_code_takes_precedence_over_app_id() -> None:
+    access: MagicMock = create_autospec(WebAppAccessQuery, instance=True, spec_set=True)
+    access.find_app_id_by_code.return_value = "resolved-id"
+    service, access_mode_for_app = _service(access=access, access_mode=WebAppAccessMode.SSO_VERIFIED)
+
+    assert service.get_access_mode(app_id="ignored-id", app_code="code-1") is WebAppAccessMode.SSO_VERIFIED
+    access.find_app_id_by_code.assert_called_once_with("code-1")
+    access_mode_for_app.assert_called_once_with("resolved-id")
+
+
+def test_missing_app_code_uses_existing_error_contract() -> None:
+    access: MagicMock = create_autospec(WebAppAccessQuery, instance=True, spec_set=True)
+    access.find_app_id_by_code.return_value = None
+    service, access_mode_for_app = _service(access=access)
+
+    with pytest.raises(ValueError, match="^App with code missing-code not found$"):
+        service.get_access_mode(app_id="must-not-fallback", app_code="missing-code")
+
+    access_mode_for_app.assert_not_called()
+
+
+def test_enabled_auth_requires_app_id_or_code() -> None:
+    access: MagicMock = create_autospec(WebAppAccessQuery, instance=True, spec_set=True)
+    service, access_mode_for_app = _service(access=access)
+
+    with pytest.raises(ValueError, match="^appId or appCode must be provided$"):
+        service.get_access_mode(app_id=None, app_code=None)
+
+    access_mode_for_app.assert_not_called()

--- a/api/tests/unit_tests/services/test_webapp_access_query_service.py
+++ b/api/tests/unit_tests/services/test_webapp_access_query_service.py
@@ -3,7 +3,12 @@ from unittest.mock import MagicMock, create_autospec
 import pytest
 
 from enums import WebAppAccessMode
-from services.webapp_access_query_service import WebAppAccessQuery, WebAppAccessQueryService
+from services.webapp_access_query_service import (
+    WebAppAccessAppNotFoundError,
+    WebAppAccessQuery,
+    WebAppAccessQueryService,
+    WebAppAccessReferenceRequiredError,
+)
 
 
 def _service(
@@ -51,12 +56,12 @@ def test_app_code_takes_precedence_over_app_id() -> None:
     access_mode_for_app.assert_called_once_with("resolved-id")
 
 
-def test_missing_app_code_uses_existing_error_contract() -> None:
+def test_missing_app_code_raises_not_found() -> None:
     access: MagicMock = create_autospec(WebAppAccessQuery, instance=True, spec_set=True)
     access.find_app_id_by_code.return_value = None
     service, access_mode_for_app = _service(access=access)
 
-    with pytest.raises(ValueError, match="^App with code missing-code not found$"):
+    with pytest.raises(WebAppAccessAppNotFoundError):
         service.get_access_mode(app_id="must-not-fallback", app_code="missing-code")
 
     access_mode_for_app.assert_not_called()
@@ -66,7 +71,31 @@ def test_enabled_auth_requires_app_id_or_code() -> None:
     access: MagicMock = create_autospec(WebAppAccessQuery, instance=True, spec_set=True)
     service, access_mode_for_app = _service(access=access)
 
-    with pytest.raises(ValueError, match="^appId or appCode must be provided$"):
+    with pytest.raises(WebAppAccessReferenceRequiredError, match="^appId or appCode must be provided$"):
         service.get_access_mode(app_id=None, app_code=None)
 
     access_mode_for_app.assert_not_called()
+
+
+def test_repository_failure_is_not_hidden() -> None:
+    access: MagicMock = create_autospec(WebAppAccessQuery, instance=True, spec_set=True)
+    failure = TypeError("repository bug")
+    access.find_app_id_by_code.side_effect = failure
+    service, _ = _service(access=access)
+
+    with pytest.raises(TypeError) as raised:
+        service.get_access_mode(app_id=None, app_code="code-1")
+
+    assert raised.value is failure
+
+
+def test_access_mode_failure_is_not_hidden() -> None:
+    access: MagicMock = create_autospec(WebAppAccessQuery, instance=True, spec_set=True)
+    service, access_mode_for_app = _service(access=access)
+    failure = TypeError("adapter bug")
+    access_mode_for_app.side_effect = failure
+
+    with pytest.raises(TypeError) as raised:
+        service.get_access_mode(app_id="app-1", app_code=None)
+
+    assert raised.value is failure

--- a/packages/contracts/generated/api/web/types.gen.ts
+++ b/packages/contracts/generated/api/web/types.gen.ts
@@ -1543,7 +1543,9 @@ export type GetWebappAccessModeData = {
 
 export type GetWebappAccessModeErrors = {
   400: unknown
+  404: unknown
   500: unknown
+  503: unknown
 }
 
 export type GetWebappAccessModeResponses = {


### PR DESCRIPTION
## Summary

- define a stable Web App Access query capability for resolving configured access modes
- move app-code lookup into a repository-owned read session
- expose `WebAppAccessMode` from the shared `enums` module and adapt Enterprise settings at the composition root
- snapshot the deployment-wide Web App Auth feature gate when application services are initialized
- keep the controller focused on request validation, error translation, and response serialization
- stabilize access errors as `invalid_param`, `app_not_found`, or `web_app_access_unavailable` based on the failing boundary

This PR is independent of the App Definition stack. It only migrates `/webapp/access-mode`; `/webapp/permission` extends the same capability in a stacked follow-up.

## Compatibility

- Web App Auth disabled still returns `public` before resolving an app
- `appCode` still takes precedence over `appId`
- an unknown `appCode` does not fall back to `appId` and now returns `app_not_found` (404) without echoing the code
- a missing app reference returns `invalid_param` (400)
- known database and Enterprise availability or response failures return `web_app_access_unavailable` (503)
- unknown programming errors remain internal errors instead of being hidden as availability failures
- the successful `accessMode` response is unchanged

## Validation

- 120 focused controller, service, repository, Enterprise, and composition tests
- Ruff check and format check
- Pyrefly
- import-linter: 9 contracts kept
- response-contract linter: 478 valid, 0 mismatch
- no-new-getattr and no-new-controller-SQLAlchemy guards
- `git diff --check`
