### PR TITLE
refactor(api): snapshot explore banner feature flag

### DIFF
--- a/api/extensions/ext_application_services.py
+++ b/api/extensions/ext_application_services.py
@@ -65,7 +65,7 @@ def build_application_services(
         ),
         explore_banner_queries=ExploreBannerQueryService(
             banners=ExploreBannerQueryRepository(client=database_client),
-            is_enabled=FeatureService.is_explore_banner_enabled,
+            enabled=FeatureService.is_explore_banner_enabled(),
         ),
         schema_definitions=SchemaDefinitionService(source_factory=SchemaManager),
         setup=SetupService(

--- a/api/services/explore_banner_query_service.py
+++ b/api/services/explore_banner_query_service.py
@@ -3,7 +3,7 @@
 ExploreBanner is the legacy contract name shared by the API, feature flag, and database model.
 """
 
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from datetime import datetime
 from typing import Any, NamedTuple, Protocol
 
@@ -28,13 +28,13 @@ class ExploreBannerQueryService:
         self,
         *,
         banners: ExploreBannerQuery,
-        is_enabled: Callable[[], bool],
+        enabled: bool,
     ) -> None:
         self._banners = banners
-        self._is_enabled = is_enabled
+        self._enabled = enabled
 
     def list_for_language(self, language: str) -> tuple[ExploreBannerRecord, ...]:
-        if not self._is_enabled():
+        if not self._enabled:
             return ()
 
         banners = tuple(self._banners.list_enabled(language))

--- a/api/tests/unit_tests/controllers/console/explore/test_banner.py
+++ b/api/tests/unit_tests/controllers/console/explore/test_banner.py
@@ -85,7 +85,7 @@ def _use_sqlite_banner_service(
 ) -> None:
     service = ExploreBannerQueryService(
         banners=ExploreBannerQueryRepository(sqlite_session_factory),
-        is_enabled=lambda: True,
+        enabled=True,
     )
     monkeypatch.setattr(
         banner_module,
@@ -97,7 +97,7 @@ def _use_sqlite_banner_service(
 class TestExploreBannerQueryService:
     def test_returns_empty_without_querying_when_disabled(self) -> None:
         banners = FakeExploreBannerQuery()
-        service = ExploreBannerQueryService(banners=banners, is_enabled=lambda: False)
+        service = ExploreBannerQueryService(banners=banners, enabled=False)
 
         assert service.list_for_language("fr-FR") == ()
         assert banners.requested_languages == []
@@ -105,7 +105,7 @@ class TestExploreBannerQueryService:
     def test_returns_requested_language(self) -> None:
         record = _record()
         banners = FakeExploreBannerQuery({"fr-FR": (record,)})
-        service = ExploreBannerQueryService(banners=banners, is_enabled=lambda: True)
+        service = ExploreBannerQueryService(banners=banners, enabled=True)
 
         assert service.list_for_language("fr-FR") == (record,)
         assert banners.requested_languages == ["fr-FR"]
@@ -113,14 +113,14 @@ class TestExploreBannerQueryService:
     def test_falls_back_to_en_us(self) -> None:
         record = _record(title="fallback")
         banners = FakeExploreBannerQuery({"en-US": (record,)})
-        service = ExploreBannerQueryService(banners=banners, is_enabled=lambda: True)
+        service = ExploreBannerQueryService(banners=banners, enabled=True)
 
         assert service.list_for_language("es-ES") == (record,)
         assert banners.requested_languages == ["es-ES", "en-US"]
 
     def test_does_not_repeat_default_language_query(self) -> None:
         banners = FakeExploreBannerQuery()
-        service = ExploreBannerQueryService(banners=banners, is_enabled=lambda: True)
+        service = ExploreBannerQueryService(banners=banners, enabled=True)
 
         assert service.list_for_language("en-US") == ()
         assert banners.requested_languages == ["en-US"]


### PR DESCRIPTION
## Summary

- replace the Explore banner feature-gate callable with a startup-time boolean snapshot
- evaluate `FeatureService.is_explore_banner_enabled()` when application services are built
- keep language fallback, database querying, controller response, and feature policy unchanged

## Stack

Stacked on #40482.

## Why

Explore banner enablement is deployment configuration and cannot change without restarting the application. Carrying a callable through the query service suggested runtime mutability that does not exist.

## Validation

- 20 focused banner, FeatureService, and composition tests
- Ruff format/check and Pyrefly
- import-linter (9 contracts kept)
- no-new-getattr and no-new-controller-SQLAlchemy guards
- `git diff --check`