### PR TITLE
feat: add chunk-level metadata filtering

### DIFF
--- a/api/controllers/console/datasets/datasets_document.py
+++ b/api/controllers/console/datasets/datasets_document.py
@@ -60,6 +60,7 @@ from services.dataset_ref_service import DatasetRefService
 from services.dataset_service import DatasetService, DocumentService
 from services.entities.knowledge_entities.knowledge_entities import KnowledgeConfig, ProcessRule, RetrievalModel
 from services.file_service import FileService
+from services.metadata_service import MetadataService
 from services.vector_space_admission_service import get_vector_space_admission_error_fields
 from tasks.generate_summary_index_task import generate_summary_index_task
 
@@ -1297,18 +1298,24 @@ class DocumentMetadataApi(DocumentResource):
         if not isinstance(doc_metadata, dict):
             raise ValueError("doc_metadata must be a dictionary.")
         metadata_schema: dict[str, Any] = cast(dict[str, Any], DocumentService.DOCUMENT_METADATA_SCHEMA[doc_type])
+        dataset = DatasetService.get_dataset(dataset_id_str, session)
+        if not dataset:
+            raise NotFound("Dataset not found.")
 
-        document.doc_metadata = {}
-        if doc_type == "others":
-            document.doc_metadata = doc_metadata
-        else:
-            for key, value_type in metadata_schema.items():
-                value = doc_metadata.get(key)
-                if value is not None and isinstance(value, value_type):
-                    document.doc_metadata[key] = value
+        with MetadataService.metadata_lock(dataset_id=dataset.id, document_id=document.id):
+            document.doc_metadata = {}
+            if doc_type == "others":
+                document.doc_metadata = doc_metadata
+            else:
+                for key, value_type in metadata_schema.items():
+                    value = doc_metadata.get(key)
+                    if value is not None and isinstance(value, value_type):
+                        document.doc_metadata[key] = value
 
-        document.doc_type = doc_type
-        document.updated_at = naive_utc_now()
+            document.doc_type = doc_type
+            document.updated_at = naive_utc_now()
+            MetadataService.apply_document_metadata_to_segments(session, dataset, document)
+            session.commit()
 
         return SimpleResultMessageResponse(result="success", message="Document metadata updated.").model_dump(
             mode="json"
@@ -1499,7 +1506,10 @@ class DocumentRenameApi(DocumentResource):
         payload = DocumentRenamePayload.model_validate(console_ns.payload or {})
 
         try:
-            document = DocumentService.rename_document(str(dataset_id), str(document_id), payload.name, session)
+            with MetadataService.metadata_lock(dataset_id=dataset.id, document_id=str(document_id)):
+                document = DocumentService.rename_document(str(dataset_id), str(document_id), payload.name, session)
+                MetadataService.apply_document_metadata_to_segments(session, dataset, document)
+                session.commit()
         except services.errors.document.DocumentIndexingError:
             raise DocumentIndexingError("Cannot delete document during indexing.")
 

--- a/api/controllers/console/datasets/datasets_segments.py
+++ b/api/controllers/console/datasets/datasets_segments.py
@@ -65,9 +65,14 @@ from models.dataset import Dataset, Document, DocumentSegment
 from models.model import UploadFile
 from services.dataset_ref_service import DatasetRefService, SegmentRef
 from services.dataset_service import DatasetService, DocumentService, SegmentService
-from services.entities.knowledge_entities.knowledge_entities import ChildChunkUpdateArgs, SegmentUpdateArgs
+from services.entities.knowledge_entities.knowledge_entities import (
+    ChildChunkUpdateArgs,
+    MetadataUpdateArgs,
+    SegmentUpdateArgs,
+)
 from services.errors.chunk import ChildChunkDeleteIndexError as ChildChunkDeleteIndexServiceError
 from services.errors.chunk import ChildChunkIndexingError as ChildChunkIndexingServiceError
+from services.metadata_service import MetadataService
 from services.summary_index_service import SummaryIndexService
 from tasks.batch_create_segment_to_index_task import batch_create_segment_to_index_task
 
@@ -116,6 +121,30 @@ class SegmentBatchImportStatusResponse(ResponseModel):
     job_status: str
 
 
+class SegmentMetadataItemResponse(ResponseModel):
+    id: str
+    name: str
+    type: str
+    value: str | int | float | None = None
+    source: Literal["built_in", "inherited", "override"]
+
+
+class SegmentMetadataResponse(ResponseModel):
+    data: list[SegmentMetadataItemResponse]
+
+
+class SegmentMetadataUpdatePayload(BaseModel):
+    metadata: list[MetadataUpdateArgs] = Field(min_length=1)
+
+
+class SegmentMetadataBatchUpdatePayload(SegmentMetadataUpdatePayload):
+    segment_ids: list[str] = Field(min_length=1)
+
+
+class SegmentMetadataResetPayload(BaseModel):
+    field_names: list[str] = Field(min_length=1)
+
+
 class ConsoleSegmentListResponse(ResponseModel):
     data: list[SegmentResponse]
     limit: int
@@ -152,6 +181,10 @@ register_schema_models(
     ChildChunkUpdatePayload,
     ChildChunkBatchUpdatePayload,
     ChildChunkUpdateArgs,
+    MetadataUpdateArgs,
+    SegmentMetadataUpdatePayload,
+    SegmentMetadataBatchUpdatePayload,
+    SegmentMetadataResetPayload,
 )
 register_response_schema_models(
     console_ns,
@@ -162,6 +195,8 @@ register_response_schema_models(
     ChildChunkListResponse,
     ChildChunkBatchUpdateResponse,
     SegmentBatchImportStatusResponse,
+    SegmentMetadataItemResponse,
+    SegmentMetadataResponse,
     SimpleResultResponse,
 )
 
@@ -471,6 +506,172 @@ class DatasetDocumentSegmentAddApi(Resource):
             "doc_form": document.doc_form,
         }
         return dump_response(SegmentDetailResponse, response), 200
+
+
+@console_ns.route("/datasets/<uuid:dataset_id>/documents/<uuid:document_id>/segments/<uuid:segment_id>/metadata")
+class DatasetDocumentSegmentMetadataApi(Resource):
+    @console_ns.response(200, "Chunk metadata retrieved", console_ns.models[SegmentMetadataResponse.__name__])
+    @setup_required
+    @login_required
+    @account_initialization_required
+    @with_current_user
+    @with_current_tenant_id
+    @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_READONLY)
+    @with_session(write=False)
+    def get(
+        self,
+        session: Session,
+        current_tenant_id: str,
+        current_user: Account,
+        dataset_id: UUID,
+        document_id: UUID,
+        segment_id: UUID,
+    ):
+        dataset = DatasetService.get_dataset(str(dataset_id), session)
+        if not dataset or dataset.tenant_id != current_tenant_id:
+            raise NotFound("Dataset not found.")
+        try:
+            DatasetService.check_dataset_permission(dataset, current_user, session)
+        except services.errors.account.NoPermissionError as e:
+            raise Forbidden(str(e))
+        document = DocumentService.get_document(dataset.id, str(document_id), session=session)
+        if not document:
+            raise NotFound("Document not found.")
+        _, segment = _get_segment_for_document(session, dataset, document, str(segment_id))
+        details = MetadataService.get_segment_metadata_details(session, dataset, document, segment)
+        return dump_response(SegmentMetadataResponse, {"data": details}), 200
+
+    @console_ns.expect(console_ns.models[SegmentMetadataUpdatePayload.__name__])
+    @console_ns.response(200, "Chunk metadata updated", console_ns.models[SegmentMetadataResponse.__name__])
+    @setup_required
+    @login_required
+    @account_initialization_required
+    @with_current_user
+    @with_current_tenant_id
+    @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_EDIT)
+    @with_session
+    @model_validate(SegmentMetadataUpdatePayload)
+    def patch(
+        self,
+        req_data: SegmentMetadataUpdatePayload,
+        session: Session,
+        current_tenant_id: str,
+        current_user: Account,
+        dataset_id: UUID,
+        document_id: UUID,
+        segment_id: UUID,
+    ):
+        dataset = DatasetService.get_dataset(str(dataset_id), session)
+        if not dataset or dataset.tenant_id != current_tenant_id:
+            raise NotFound("Dataset not found.")
+        if not current_user.is_dataset_editor:
+            raise Forbidden()
+        try:
+            DatasetService.check_dataset_permission(dataset, current_user, session)
+        except services.errors.account.NoPermissionError as e:
+            raise Forbidden(str(e))
+        document = DocumentService.get_document(dataset.id, str(document_id), session=session)
+        if not document:
+            raise NotFound("Document not found.")
+        _, segment = _get_segment_for_document(session, dataset, document, str(segment_id))
+        with MetadataService.metadata_lock(dataset_id=dataset.id, document_id=document.id):
+            MetadataService.apply_segment_metadata_override(
+                session, dataset, document, segment, req_data.metadata, current_user, current_tenant_id
+            )
+            session.commit()
+        details = MetadataService.get_segment_metadata_details(session, dataset, document, segment)
+        return dump_response(SegmentMetadataResponse, {"data": details}), 200
+
+
+@console_ns.route("/datasets/<uuid:dataset_id>/documents/<uuid:document_id>/segments/<uuid:segment_id>/metadata/reset")
+class DatasetDocumentSegmentMetadataResetApi(Resource):
+    @console_ns.expect(console_ns.models[SegmentMetadataResetPayload.__name__])
+    @console_ns.response(200, "Chunk metadata reset", console_ns.models[SegmentMetadataResponse.__name__])
+    @setup_required
+    @login_required
+    @account_initialization_required
+    @with_current_user
+    @with_current_tenant_id
+    @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_EDIT)
+    @with_session
+    @model_validate(SegmentMetadataResetPayload)
+    def post(
+        self,
+        req_data: SegmentMetadataResetPayload,
+        session: Session,
+        current_tenant_id: str,
+        current_user: Account,
+        dataset_id: UUID,
+        document_id: UUID,
+        segment_id: UUID,
+    ):
+        dataset = DatasetService.get_dataset(str(dataset_id), session)
+        if not dataset or dataset.tenant_id != current_tenant_id:
+            raise NotFound("Dataset not found.")
+        if not current_user.is_dataset_editor:
+            raise Forbidden()
+        try:
+            DatasetService.check_dataset_permission(dataset, current_user, session)
+        except services.errors.account.NoPermissionError as e:
+            raise Forbidden(str(e))
+        document = DocumentService.get_document(dataset.id, str(document_id), session=session)
+        if not document:
+            raise NotFound("Document not found.")
+        _, segment = _get_segment_for_document(session, dataset, document, str(segment_id))
+        with MetadataService.metadata_lock(dataset_id=dataset.id, document_id=document.id):
+            MetadataService.reset_segment_metadata_fields_to_document(
+                session, dataset, document, segment, req_data.field_names
+            )
+            session.commit()
+        details = MetadataService.get_segment_metadata_details(session, dataset, document, segment)
+        return dump_response(SegmentMetadataResponse, {"data": details}), 200
+
+
+@console_ns.route("/datasets/<uuid:dataset_id>/documents/<uuid:document_id>/segments/metadata/batch")
+class DatasetDocumentSegmentMetadataBatchApi(Resource):
+    @console_ns.expect(console_ns.models[SegmentMetadataBatchUpdatePayload.__name__])
+    @console_ns.response(200, "Chunk metadata updated", console_ns.models[SimpleResultResponse.__name__])
+    @setup_required
+    @login_required
+    @account_initialization_required
+    @with_current_user
+    @with_current_tenant_id
+    @rbac_permission_required(RBACResourceScope.DATASET, RBACPermission.DATASET_EDIT)
+    @with_session
+    @model_validate(SegmentMetadataBatchUpdatePayload)
+    def post(
+        self,
+        req_data: SegmentMetadataBatchUpdatePayload,
+        session: Session,
+        current_tenant_id: str,
+        current_user: Account,
+        dataset_id: UUID,
+        document_id: UUID,
+    ):
+        dataset = DatasetService.get_dataset(str(dataset_id), session)
+        if not dataset or dataset.tenant_id != current_tenant_id:
+            raise NotFound("Dataset not found.")
+        if not current_user.is_dataset_editor:
+            raise Forbidden()
+        try:
+            DatasetService.check_dataset_permission(dataset, current_user, session)
+        except services.errors.account.NoPermissionError as e:
+            raise Forbidden(str(e))
+        document = DocumentService.get_document(dataset.id, str(document_id), session=session)
+        if not document:
+            raise NotFound("Document not found.")
+        with MetadataService.metadata_lock(dataset_id=dataset.id, document_id=document.id):
+            MetadataService.batch_update_segments_metadata(
+                session,
+                dataset,
+                document,
+                req_data.segment_ids,
+                req_data.metadata,
+                current_user,
+                current_tenant_id,
+            )
+            session.commit()
+        return SimpleResultResponse(result="success").model_dump(mode="json"), 200
 
 
 @console_ns.route("/datasets/<uuid:dataset_id>/documents/<uuid:document_id>/segments/<uuid:segment_id>")

--- a/api/controllers/service_api/dataset/segment.py
+++ b/api/controllers/service_api/dataset/segment.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Literal, cast
 from uuid import UUID
 
 from pydantic import BaseModel, Field, ValidationError, field_validator
@@ -8,6 +8,7 @@ from werkzeug.exceptions import NotFound
 
 from configs import dify_config
 from controllers.common.controller_schemas import ChildChunkCreatePayload, ChildChunkUpdatePayload
+from controllers.common.fields import SimpleResultResponse
 from controllers.common.schema import (
     query_params_from_model,
     query_params_from_request,
@@ -41,10 +42,11 @@ from libs.login import current_account_with_tenant
 from models.dataset import Dataset, Document, DocumentSegment
 from services.dataset_ref_service import DatasetRefService, SegmentRef
 from services.dataset_service import DatasetService, DocumentService, SegmentService
-from services.entities.knowledge_entities.knowledge_entities import SegmentUpdateArgs
+from services.entities.knowledge_entities.knowledge_entities import MetadataUpdateArgs, SegmentUpdateArgs
 from services.errors.chunk import ChildChunkDeleteIndexError, ChildChunkIndexingError
 from services.errors.chunk import ChildChunkDeleteIndexError as ChildChunkDeleteIndexServiceError
 from services.errors.chunk import ChildChunkIndexingError as ChildChunkIndexingServiceError
+from services.metadata_service import MetadataService
 from services.summary_index_service import SummaryIndexService
 
 
@@ -78,6 +80,30 @@ class SegmentListQuery(BaseModel):
 
 class SegmentUpdatePayload(BaseModel):
     segment: SegmentUpdateArgs = Field(description="Chunk update payload.")
+
+
+class SegmentMetadataItemResponse(ResponseModel):
+    id: str
+    name: str
+    type: str
+    value: str | int | float | None = None
+    source: Literal["built_in", "inherited", "override"]
+
+
+class SegmentMetadataResponse(ResponseModel):
+    data: list[SegmentMetadataItemResponse]
+
+
+class SegmentMetadataUpdatePayload(BaseModel):
+    metadata: list[MetadataUpdateArgs] = Field(min_length=1)
+
+
+class SegmentMetadataBatchUpdatePayload(SegmentMetadataUpdatePayload):
+    segment_ids: list[str] = Field(min_length=1)
+
+
+class SegmentMetadataResetPayload(BaseModel):
+    field_names: list[str] = Field(min_length=1)
 
 
 class ChildChunkListQuery(BaseModel):
@@ -114,6 +140,10 @@ register_schema_models(
     SegmentListQuery,
     SegmentUpdateArgs,
     SegmentUpdatePayload,
+    MetadataUpdateArgs,
+    SegmentMetadataUpdatePayload,
+    SegmentMetadataBatchUpdatePayload,
+    SegmentMetadataResetPayload,
     ChildChunkCreatePayload,
     ChildChunkListQuery,
     ChildChunkUpdatePayload,
@@ -124,6 +154,9 @@ register_response_schema_models(
     SegmentCreateListResponse,
     SegmentListResponse,
     SegmentDetailResponse,
+    SegmentMetadataItemResponse,
+    SegmentMetadataResponse,
+    SimpleResultResponse,
     ChildChunkDetailResponse,
     ChildChunkListResponse,
 )
@@ -335,6 +368,106 @@ class SegmentApi(DatasetApiResource):
         }
 
         return dump_response(SegmentListResponse, response), 200
+
+
+@service_api_ns.route("/datasets/<uuid:dataset_id>/documents/<uuid:document_id>/segments/<uuid:segment_id>/metadata")
+class DatasetSegmentMetadataApi(DatasetApiResource):
+    @service_api_ns.response(200, "Chunk metadata retrieved", service_api_ns.models[SegmentMetadataResponse.__name__])
+    @with_session(write=False)
+    def get(self, session: Session, tenant_id: str, dataset_id: UUID, document_id: UUID, segment_id: UUID):
+        current_account_with_tenant()
+        dataset = session.scalar(
+            select(Dataset).where(Dataset.tenant_id == tenant_id, Dataset.id == str(dataset_id)).limit(1)
+        )
+        if not dataset:
+            raise NotFound("Dataset not found.")
+        document = DocumentService.get_document(dataset.id, str(document_id), session=session)
+        if not document:
+            raise NotFound("Document not found.")
+        _, segment = _get_segment_for_document(session, dataset, document, str(segment_id))
+        details = MetadataService.get_segment_metadata_details(session, dataset, document, segment)
+        return dump_response(SegmentMetadataResponse, {"data": details}), 200
+
+    @service_api_ns.expect(service_api_ns.models[SegmentMetadataUpdatePayload.__name__])
+    @service_api_ns.response(200, "Chunk metadata updated", service_api_ns.models[SegmentMetadataResponse.__name__])
+    @with_session
+    def patch(self, session: Session, tenant_id: str, dataset_id: UUID, document_id: UUID, segment_id: UUID):
+        current_user, current_tenant_id = current_account_with_tenant()
+        dataset = session.scalar(
+            select(Dataset).where(Dataset.tenant_id == tenant_id, Dataset.id == str(dataset_id)).limit(1)
+        )
+        if not dataset:
+            raise NotFound("Dataset not found.")
+        document = DocumentService.get_document(dataset.id, str(document_id), session=session)
+        if not document:
+            raise NotFound("Document not found.")
+        _, segment = _get_segment_for_document(session, dataset, document, str(segment_id))
+        payload = SegmentMetadataUpdatePayload.model_validate(service_api_ns.payload or {})
+        with MetadataService.metadata_lock(dataset_id=dataset.id, document_id=document.id):
+            MetadataService.apply_segment_metadata_override(
+                session, dataset, document, segment, payload.metadata, current_user, current_tenant_id
+            )
+            session.commit()
+        details = MetadataService.get_segment_metadata_details(session, dataset, document, segment)
+        return dump_response(SegmentMetadataResponse, {"data": details}), 200
+
+
+@service_api_ns.route(
+    "/datasets/<uuid:dataset_id>/documents/<uuid:document_id>/segments/<uuid:segment_id>/metadata/reset"
+)
+class DatasetSegmentMetadataResetApi(DatasetApiResource):
+    @service_api_ns.expect(service_api_ns.models[SegmentMetadataResetPayload.__name__])
+    @service_api_ns.response(200, "Chunk metadata reset", service_api_ns.models[SegmentMetadataResponse.__name__])
+    @with_session
+    def post(self, session: Session, tenant_id: str, dataset_id: UUID, document_id: UUID, segment_id: UUID):
+        current_account_with_tenant()
+        dataset = session.scalar(
+            select(Dataset).where(Dataset.tenant_id == tenant_id, Dataset.id == str(dataset_id)).limit(1)
+        )
+        if not dataset:
+            raise NotFound("Dataset not found.")
+        document = DocumentService.get_document(dataset.id, str(document_id), session=session)
+        if not document:
+            raise NotFound("Document not found.")
+        _, segment = _get_segment_for_document(session, dataset, document, str(segment_id))
+        payload = SegmentMetadataResetPayload.model_validate(service_api_ns.payload or {})
+        with MetadataService.metadata_lock(dataset_id=dataset.id, document_id=document.id):
+            MetadataService.reset_segment_metadata_fields_to_document(
+                session, dataset, document, segment, payload.field_names
+            )
+            session.commit()
+        details = MetadataService.get_segment_metadata_details(session, dataset, document, segment)
+        return dump_response(SegmentMetadataResponse, {"data": details}), 200
+
+
+@service_api_ns.route("/datasets/<uuid:dataset_id>/documents/<uuid:document_id>/segments/metadata/batch")
+class DatasetSegmentMetadataBatchApi(DatasetApiResource):
+    @service_api_ns.expect(service_api_ns.models[SegmentMetadataBatchUpdatePayload.__name__])
+    @service_api_ns.response(200, "Chunk metadata updated", service_api_ns.models[SimpleResultResponse.__name__])
+    @with_session
+    def post(self, session: Session, tenant_id: str, dataset_id: UUID, document_id: UUID):
+        current_user, current_tenant_id = current_account_with_tenant()
+        dataset = session.scalar(
+            select(Dataset).where(Dataset.tenant_id == tenant_id, Dataset.id == str(dataset_id)).limit(1)
+        )
+        if not dataset:
+            raise NotFound("Dataset not found.")
+        document = DocumentService.get_document(dataset.id, str(document_id), session=session)
+        if not document:
+            raise NotFound("Document not found.")
+        payload = SegmentMetadataBatchUpdatePayload.model_validate(service_api_ns.payload or {})
+        with MetadataService.metadata_lock(dataset_id=dataset.id, document_id=document.id):
+            MetadataService.batch_update_segments_metadata(
+                session,
+                dataset,
+                document,
+                payload.segment_ids,
+                payload.metadata,
+                current_user,
+                current_tenant_id,
+            )
+            session.commit()
+        return SimpleResultResponse(result="success").model_dump(mode="json"), 200
 
 
 @service_api_ns.route("/datasets/<uuid:dataset_id>/documents/<uuid:document_id>/segments/<uuid:segment_id>")

--- a/api/core/rag/datasource/keyword/jieba/jieba.py
+++ b/api/core/rag/datasource/keyword/jieba/jieba.py
@@ -3,7 +3,7 @@ from typing import Any, TypedDict, override
 
 import orjson
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
 from configs import dify_config
@@ -109,35 +109,53 @@ class Jieba(BaseKeyword):
             data: Any = keyword_table_dict["__data__"]
             keyword_table = dict(data["table"])
 
-        k = kwargs.get("top_k", 4)
-        document_ids_filter = kwargs.get("document_ids_filter")
-        sorted_chunk_indices = self._retrieve_ids_by_query(keyword_table or {}, query, k)
-
-        documents = []
-
-        segment_query_stmt = select(DocumentSegment).where(
-            DocumentSegment.dataset_id == self.dataset.id, DocumentSegment.index_node_id.in_(sorted_chunk_indices)
+        k = int(kwargs.get("top_k", 4))
+        document_ids_filter = kwargs.get("document_ids_filter") or []
+        index_node_ids_filter = kwargs.get("index_node_ids_filter") or []
+        has_metadata_filter = bool(document_ids_filter or index_node_ids_filter)
+        sorted_chunk_indices = self._retrieve_ids_by_query(
+            keyword_table or {}, query, None if has_metadata_filter else k
         )
-        if document_ids_filter:
-            segment_query_stmt = segment_query_stmt.where(DocumentSegment.document_id.in_(document_ids_filter))
 
-        segments = session.scalars(segment_query_stmt).all()
-        segment_map = {segment.index_node_id: segment for segment in segments}
-        for chunk_index in sorted_chunk_indices:
-            segment = segment_map.get(chunk_index)
+        documents: list[Document] = []
+        candidate_batch_size = max(k * 10, 100)
+        candidate_batches = (
+            sorted_chunk_indices[offset : offset + candidate_batch_size]
+            for offset in range(0, len(sorted_chunk_indices), candidate_batch_size)
+        )
 
-            if segment:
-                documents.append(
-                    Document(
-                        page_content=segment.content,
-                        metadata={
-                            "doc_id": chunk_index,
-                            "doc_hash": segment.index_node_hash,
-                            "document_id": segment.document_id,
-                            "dataset_id": segment.dataset_id,
-                        },
+        for candidate_batch in candidate_batches:
+            segment_query_stmt = select(DocumentSegment).where(
+                DocumentSegment.dataset_id == self.dataset.id,
+                DocumentSegment.index_node_id.in_(candidate_batch),
+            )
+            if has_metadata_filter:
+                allowlist_conditions = []
+                if document_ids_filter:
+                    allowlist_conditions.append(DocumentSegment.document_id.in_(document_ids_filter))
+                if index_node_ids_filter:
+                    allowlist_conditions.append(DocumentSegment.index_node_id.in_(index_node_ids_filter))
+                segment_query_stmt = segment_query_stmt.where(or_(*allowlist_conditions))
+
+            segments = session.scalars(segment_query_stmt).all()
+            segment_map = {segment.index_node_id: segment for segment in segments}
+            for chunk_index in candidate_batch:
+                segment = segment_map.get(chunk_index)
+
+                if segment:
+                    documents.append(
+                        Document(
+                            page_content=segment.content,
+                            metadata={
+                                "doc_id": chunk_index,
+                                "doc_hash": segment.index_node_hash,
+                                "document_id": segment.document_id,
+                                "dataset_id": segment.dataset_id,
+                            },
+                        )
                     )
-                )
+                    if len(documents) >= k:
+                        return documents
 
         return documents
 
@@ -227,7 +245,7 @@ class Jieba(BaseKeyword):
 
         return keyword_table
 
-    def _retrieve_ids_by_query(self, keyword_table: dict[str, set[str]], query: str, k: int = 4) -> list[str]:
+    def _retrieve_ids_by_query(self, keyword_table: dict[str, set[str]], query: str, k: int | None = 4) -> list[str]:
         keyword_table_handler = JiebaKeywordTableHandler()
         keywords = keyword_table_handler.extract_keywords(query)
 
@@ -244,7 +262,7 @@ class Jieba(BaseKeyword):
             reverse=True,
         )
 
-        return sorted_chunk_indices[:k]
+        return sorted_chunk_indices if k is None else sorted_chunk_indices[:k]
 
     def _update_segment_keywords(self, dataset_id: str, node_id: str, keywords: list[str], session: Session):
         stmt = select(DocumentSegment).where(

--- a/api/core/rag/datasource/retrieval_service.py
+++ b/api/core/rag/datasource/retrieval_service.py
@@ -105,6 +105,7 @@ class RetrievalService:
         reranking_mode: str = "reranking_model",
         weights: WeightsDict | None = None,
         document_ids_filter: list[str] | None = None,
+        index_node_ids_filter: list[str] | None = None,
         attachment_ids: list[str] | None = None,
     ):
         if not query and not attachment_ids:
@@ -137,6 +138,11 @@ class RetrievalService:
                         attachment_id=None,
                         all_documents=all_documents,
                         exceptions=exceptions,
+                        **(
+                            {"index_node_ids_filter": index_node_ids_filter}
+                            if index_node_ids_filter is not None
+                            else {}
+                        ),
                     )
                 )
             if attachment_ids:
@@ -157,6 +163,11 @@ class RetrievalService:
                             attachment_id=attachment_id,
                             all_documents=all_documents,
                             exceptions=exceptions,
+                            **(
+                                {"index_node_ids_filter": index_node_ids_filter}
+                                if index_node_ids_filter is not None
+                                else {}
+                            ),
                         )
                     )
 
@@ -277,6 +288,7 @@ class RetrievalService:
         all_documents: list[Document],
         exceptions: list[str],
         document_ids_filter: list[str] | None = None,
+        index_node_ids_filter: list[str] | None = None,
     ):
         with flask_app.app_context():
             try:
@@ -292,6 +304,11 @@ class RetrievalService:
                         session=session,
                         top_k=top_k,
                         document_ids_filter=document_ids_filter,
+                        **(
+                            {"index_node_ids_filter": index_node_ids_filter}
+                            if index_node_ids_filter is not None
+                            else {}
+                        ),
                     )
                 all_documents.extend(documents)
             except Exception as e:
@@ -312,6 +329,7 @@ class RetrievalService:
         retrieval_method: RetrievalMethod,
         exceptions: list[str],
         document_ids_filter: list[str] | None = None,
+        index_node_ids_filter: list[str] | None = None,
         query_type: QueryType = QueryType.TEXT_QUERY,
     ):
         with flask_app.app_context():
@@ -339,6 +357,11 @@ class RetrievalService:
                                 score_threshold=embedding_score_threshold,
                                 filter={"group_id": [dataset.id]},
                                 document_ids_filter=document_ids_filter,
+                                **(
+                                    {"index_node_ids_filter": index_node_ids_filter}
+                                    if index_node_ids_filter is not None
+                                    else {}
+                                ),
                             )
                         )
                     if query_type == QueryType.IMAGE_QUERY:
@@ -351,6 +374,11 @@ class RetrievalService:
                                 score_threshold=embedding_score_threshold,
                                 filter={"group_id": [dataset.id]},
                                 document_ids_filter=document_ids_filter,
+                                **(
+                                    {"index_node_ids_filter": index_node_ids_filter}
+                                    if index_node_ids_filter is not None
+                                    else {}
+                                ),
                             )
                         )
 
@@ -421,6 +449,7 @@ class RetrievalService:
         retrieval_method: str,
         exceptions: list[str],
         document_ids_filter: list[str] | None = None,
+        index_node_ids_filter: list[str] | None = None,
     ):
         with flask_app.app_context():
             try:
@@ -432,7 +461,14 @@ class RetrievalService:
                     vector_processor = Vector(dataset=dataset, session=session)
 
                 documents = vector_processor.search_by_full_text(
-                    cls.escape_query_for_search(query), top_k=top_k, document_ids_filter=document_ids_filter
+                    cls.escape_query_for_search(query),
+                    top_k=top_k,
+                    document_ids_filter=document_ids_filter,
+                    **(
+                        {"index_node_ids_filter": index_node_ids_filter}
+                        if index_node_ids_filter is not None
+                        else {}
+                    ),
                 )
                 if documents:
                     if (
@@ -792,6 +828,7 @@ class RetrievalService:
         reranking_mode: str = "reranking_model",
         weights: WeightsDict | None = None,
         document_ids_filter: list[str] | None = None,
+        index_node_ids_filter: list[str] | None = None,
         attachment_id: str | None = None,
     ):
         if not query and not attachment_id:
@@ -812,6 +849,11 @@ class RetrievalService:
                             all_documents=all_documents_item,
                             exceptions=exceptions,
                             document_ids_filter=document_ids_filter,
+                            **(
+                                {"index_node_ids_filter": index_node_ids_filter}
+                                if index_node_ids_filter is not None
+                                else {}
+                            ),
                         )
                     )
                 if RetrievalMethod.is_support_semantic_search(retrieval_method):
@@ -830,6 +872,11 @@ class RetrievalService:
                                 exceptions=exceptions,
                                 document_ids_filter=document_ids_filter,
                                 query_type=QueryType.TEXT_QUERY,
+                                **(
+                                    {"index_node_ids_filter": index_node_ids_filter}
+                                    if index_node_ids_filter is not None
+                                    else {}
+                                ),
                             )
                         )
                     if attachment_id:
@@ -847,6 +894,11 @@ class RetrievalService:
                                 exceptions=exceptions,
                                 document_ids_filter=document_ids_filter,
                                 query_type=QueryType.IMAGE_QUERY,
+                                **(
+                                    {"index_node_ids_filter": index_node_ids_filter}
+                                    if index_node_ids_filter is not None
+                                    else {}
+                                ),
                             )
                         )
                 if RetrievalMethod.is_support_fulltext_search(retrieval_method) and query:
@@ -863,6 +915,11 @@ class RetrievalService:
                             retrieval_method=retrieval_method,
                             exceptions=exceptions,
                             document_ids_filter=document_ids_filter,
+                            **(
+                                {"index_node_ids_filter": index_node_ids_filter}
+                                if index_node_ids_filter is not None
+                                else {}
+                            ),
                         )
                     )
                 # Use as_completed for early error propagation - cancel remaining futures on first error

--- a/api/core/rag/datasource/retrieval_service.py
+++ b/api/core/rag/datasource/retrieval_service.py
@@ -464,11 +464,7 @@ class RetrievalService:
                     cls.escape_query_for_search(query),
                     top_k=top_k,
                     document_ids_filter=document_ids_filter,
-                    **(
-                        {"index_node_ids_filter": index_node_ids_filter}
-                        if index_node_ids_filter is not None
-                        else {}
-                    ),
+                    **({"index_node_ids_filter": index_node_ids_filter} if index_node_ids_filter is not None else {}),
                 )
                 if documents:
                     if (

--- a/api/core/rag/datasource/vdb/vector_base.py
+++ b/api/core/rag/datasource/vdb/vector_base.py
@@ -16,6 +16,8 @@ class VectorIndexStructDict(TypedDict):
 
 
 class BaseVector(ABC):
+    supports_index_node_ids_filter = False
+
     def __init__(self, collection_name: str):
         self._collection_name = collection_name
 

--- a/api/core/rag/datasource/vdb/vector_factory.py
+++ b/api/core/rag/datasource/vdb/vector_factory.py
@@ -255,7 +255,7 @@ class Vector:
 
     @trace_span()
     def _search_by_vector_traced(self, query_vector: list[float], **kwargs) -> list[Document]:
-        return self._vector_processor.search_by_vector(query_vector, **kwargs)
+        return self._search_with_metadata_filters(self._vector_processor.search_by_vector, query_vector, kwargs)
 
     def search_by_file(self, file_id: str, **kwargs: Any) -> list[Document]:
         upload_file: UploadFile | None = self._session.get(UploadFile, file_id)
@@ -274,7 +274,53 @@ class Vector:
         return self._search_by_vector_traced(multimodal_vector, **kwargs)
 
     def search_by_full_text(self, query: str, **kwargs: Any) -> list[Document]:
-        return self._vector_processor.search_by_full_text(query, **kwargs)
+        return self._search_with_metadata_filters(self._vector_processor.search_by_full_text, query, kwargs)
+
+    def _search_with_metadata_filters(self, search, query: Any, kwargs: dict[str, Any]) -> list[Document]:
+        """Apply chunk allowlists safely, including for vector stores without native support."""
+        index_node_ids = {str(node_id) for node_id in (kwargs.get("index_node_ids_filter") or [])}
+        if not index_node_ids:
+            return search(query, **kwargs)
+
+        document_ids = {str(document_id) for document_id in (kwargs.get("document_ids_filter") or [])}
+        top_k = int(kwargs.get("top_k", 4))
+        candidates: list[Document] = []
+
+        if self._vector_processor.supports_index_node_ids_filter:
+            candidates = search(query, **kwargs)
+        else:
+            # Keep the inherited-document branch server-side filtered. The override
+            # branch is over-recalled and then filtered locally so unsupported
+            # adapters cannot silently ignore the chunk allowlist and leak results.
+            if document_ids:
+                document_kwargs = dict(kwargs)
+                document_kwargs.pop("index_node_ids_filter", None)
+                candidates.extend(search(query, **document_kwargs))
+
+            node_kwargs = dict(kwargs)
+            node_kwargs.pop("document_ids_filter", None)
+            node_kwargs.pop("index_node_ids_filter", None)
+            node_kwargs["top_k"] = max(top_k * 20, min(len(index_node_ids), 1000))
+            candidates.extend(search(query, **node_kwargs))
+
+        filtered: dict[str, Document] = {}
+        for document in candidates:
+            metadata = document.metadata or {}
+            node_id = str(metadata.get("doc_id") or "")
+            document_id = str(metadata.get("document_id") or "")
+            if node_id not in index_node_ids and document_id not in document_ids:
+                continue
+
+            dedupe_key = node_id or f"{document_id}:{document.page_content}"
+            previous = filtered.get(dedupe_key)
+            if previous is None or float(metadata.get("score") or 0) > float(
+                (previous.metadata or {}).get("score") or 0
+            ):
+                filtered[dedupe_key] = document
+
+        return sorted(
+            filtered.values(), key=lambda document: float((document.metadata or {}).get("score") or 0), reverse=True
+        )[:top_k]
 
     def delete(self):
         self._vector_processor.delete()

--- a/api/core/rag/docstore/dataset_docstore.py
+++ b/api/core/rag/docstore/dataset_docstore.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from collections.abc import Sequence
 from typing import Any
 
@@ -8,6 +9,7 @@ from sqlalchemy.orm import Session
 
 from core.rag.models.document import AttachmentDocument, Document
 from models.dataset import ChildChunk, Dataset, DocumentSegment, SegmentAttachmentBinding
+from models.dataset import Document as DatasetDocument
 from models.enums import SegmentType
 
 
@@ -99,6 +101,13 @@ class DatasetDocumentStore:
             if not segment_document:
                 max_position += 1
                 assert self._document_id
+                parent_document = session.get(DatasetDocument, self._document_id)
+                effective_metadata = (
+                    copy.deepcopy(parent_document.doc_metadata)
+                    if parent_document and parent_document.doc_metadata
+                    else {}
+                )
+                security_level = effective_metadata.get("security_level")
                 segment_document = DocumentSegment(
                     tenant_id=self._dataset.tenant_id,
                     dataset_id=self._dataset.id,
@@ -111,6 +120,8 @@ class DatasetDocumentStore:
                     tokens=tokens,
                     enabled=False,
                     created_by=self._user_id,
+                    effective_metadata=effective_metadata,
+                    effective_security_level=security_level if isinstance(security_level, str) else None,
                 )
                 if doc.metadata.get("answer"):
                     segment_document.answer = doc.metadata.pop("answer", "")

--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -10,7 +10,8 @@ from typing import Any, Union, cast
 
 from flask import Flask, current_app
 from opentelemetry.trace import get_current_span
-from sqlalchemy import and_, func, literal, or_, select, update
+from sqlalchemy import Float, and_, func, literal, or_, select, update
+from sqlalchemy import cast as sa_cast
 from sqlalchemy.orm import Session, sessionmaker
 
 from core.app.app_config.entities import (
@@ -81,6 +82,7 @@ from models.dataset import (
     DatasetMetadata,
     DatasetQuery,
     DocumentSegment,
+    DocumentSegmentSummary,
     RateLimitLog,
     SegmentAttachmentBinding,
 )
@@ -129,7 +131,7 @@ class DatasetRetrieval:
         if not request.query and not request.attachment_ids:
             return []
 
-        metadata_filter_document_ids, metadata_condition = None, None
+        metadata_filter_document_ids, metadata_filter_index_node_ids, metadata_condition = None, None, None
 
         if request.metadata_filtering_mode != "disabled":
             app_metadata_model_config = ModelConfig(provider="", name="", mode=LLMMode.CHAT, completion_params={})
@@ -147,16 +149,18 @@ class DatasetRetrieval:
 
             query = request.query if request.query is not None else ""
 
-            metadata_filter_document_ids, metadata_condition = self.get_metadata_filter_condition(
-                session=session,
-                dataset_ids=available_datasets_ids,
-                query=query,
-                tenant_id=request.tenant_id,
-                user_id=request.user_id,
-                metadata_filtering_mode=request.metadata_filtering_mode,
-                metadata_model_config=app_metadata_model_config,
-                metadata_filtering_conditions=app_metadata_filtering_conditions,
-                inputs={},
+            metadata_filter_document_ids, metadata_filter_index_node_ids, metadata_condition = (
+                self.get_metadata_filter_condition(
+                    session=session,
+                    dataset_ids=available_datasets_ids,
+                    query=query,
+                    tenant_id=request.tenant_id,
+                    user_id=request.user_id,
+                    metadata_filtering_mode=request.metadata_filtering_mode,
+                    metadata_model_config=app_metadata_model_config,
+                    metadata_filtering_conditions=app_metadata_filtering_conditions,
+                    inputs={},
+                )
             )
 
         if request.retrieval_mode == DatasetRetrieveConfigEntity.RetrieveStrategy.SINGLE:
@@ -230,6 +234,7 @@ class DatasetRetrieval:
                 planning_strategy,
                 None,  # message_id
                 metadata_filter_document_ids,
+                metadata_filter_index_node_ids,
                 metadata_condition,
             )
         else:
@@ -247,6 +252,7 @@ class DatasetRetrieval:
                 weights=request.weights,
                 reranking_enable=request.reranking_enable,
                 metadata_filter_document_ids=metadata_filter_document_ids,
+                metadata_filter_index_node_ids=metadata_filter_index_node_ids,
                 metadata_condition=metadata_condition,
                 attachment_ids=request.attachment_ids,
             )
@@ -425,16 +431,18 @@ class DatasetRetrieval:
         else:
             inputs = {}
         available_datasets_ids = [dataset.id for dataset in available_datasets]
-        metadata_filter_document_ids, metadata_condition = self.get_metadata_filter_condition(
-            session,
-            available_datasets_ids,
-            query,
-            tenant_id,
-            user_id,
-            retrieve_config.metadata_filtering_mode,  # type: ignore
-            retrieve_config.metadata_model_config,  # type: ignore
-            retrieve_config.metadata_filtering_conditions,
-            inputs,
+        metadata_filter_document_ids, metadata_filter_index_node_ids, metadata_condition = (
+            self.get_metadata_filter_condition(
+                session,
+                available_datasets_ids,
+                query,
+                tenant_id,
+                user_id,
+                retrieve_config.metadata_filtering_mode,  # type: ignore
+                retrieve_config.metadata_model_config,  # type: ignore
+                retrieve_config.metadata_filtering_conditions,
+                inputs,
+            )
         )
 
         all_documents = []
@@ -453,6 +461,7 @@ class DatasetRetrieval:
                 planning_strategy,
                 message_id,
                 metadata_filter_document_ids,
+                metadata_filter_index_node_ids,
                 metadata_condition,
             )
         elif retrieve_config.retrieve_strategy == DatasetRetrieveConfigEntity.RetrieveStrategy.MULTIPLE:
@@ -471,6 +480,7 @@ class DatasetRetrieval:
                 True if retrieve_config.reranking_enabled is None else retrieve_config.reranking_enabled,
                 message_id,
                 metadata_filter_document_ids,
+                metadata_filter_index_node_ids,
                 metadata_condition,
             )
 
@@ -617,6 +627,7 @@ class DatasetRetrieval:
         planning_strategy: PlanningStrategy,
         message_id: str | None = None,
         metadata_filter_document_ids: dict[str, list[str]] | None = None,
+        metadata_filter_index_node_ids: dict[str, list[str]] | None = None,
         metadata_condition: MetadataFilteringCondition | None = None,
     ):
         tools: list[PromptMessageTool] = []
@@ -678,14 +689,21 @@ class DatasetRetrieval:
                             document.metadata["dataset_name"] = selected_dataset.name
                         results.append(document)
                 else:
-                    if metadata_condition and not metadata_filter_document_ids:
+                    if metadata_condition and not metadata_filter_document_ids and not metadata_filter_index_node_ids:
                         return []
                     document_ids_filter = None
+                    index_node_ids_filter = None
                     if metadata_filter_document_ids:
                         document_ids = metadata_filter_document_ids.get(selected_dataset.id, [])
                         if document_ids:
                             document_ids_filter = document_ids
-                        else:
+                        elif not metadata_filter_index_node_ids:
+                            return []
+                    if metadata_filter_index_node_ids:
+                        index_node_ids = metadata_filter_index_node_ids.get(selected_dataset.id, [])
+                        if index_node_ids:
+                            index_node_ids_filter = index_node_ids
+                        elif not document_ids_filter:
                             return []
                     retrieval_model_config: DefaultRetrievalModelDict = (
                         cast(DefaultRetrievalModelDict, selected_dataset.retrieval_model)
@@ -723,6 +741,11 @@ class DatasetRetrieval:
                             reranking_mode=retrieval_model_config.get("reranking_mode", "reranking_model"),
                             weights=retrieval_model_config.get("weights", None),
                             document_ids_filter=document_ids_filter,
+                            **(
+                                {"index_node_ids_filter": index_node_ids_filter}
+                                if index_node_ids_filter is not None
+                                else {}
+                            ),
                         )
                 self._on_query(query, None, [dataset_id], app_id, user_from, user_id)
 
@@ -758,6 +781,7 @@ class DatasetRetrieval:
         reranking_enable: bool = True,
         message_id: str | None = None,
         metadata_filter_document_ids: dict[str, list[str]] | None = None,
+        metadata_filter_index_node_ids: dict[str, list[str]] | None = None,
         metadata_condition: MetadataFilteringCondition | None = None,
         attachment_ids: list[str] | None = None,
     ):
@@ -809,6 +833,7 @@ class DatasetRetrieval:
                         "available_datasets": available_datasets,
                         "metadata_condition": metadata_condition,
                         "metadata_filter_document_ids": metadata_filter_document_ids,
+                        "metadata_filter_index_node_ids": metadata_filter_index_node_ids,
                         "all_documents": all_documents,
                         "tenant_id": tenant_id,
                         "reranking_enable": reranking_enable,
@@ -835,6 +860,7 @@ class DatasetRetrieval:
                             "available_datasets": available_datasets,
                             "metadata_condition": metadata_condition,
                             "metadata_filter_document_ids": metadata_filter_document_ids,
+                            "metadata_filter_index_node_ids": metadata_filter_index_node_ids,
                             "all_documents": all_documents,
                             "tenant_id": tenant_id,
                             "reranking_enable": reranking_enable,
@@ -1094,6 +1120,7 @@ class DatasetRetrieval:
         top_k: int,
         all_documents: list[Document],
         document_ids_filter: list[str] | None = None,
+        index_node_ids_filter: list[str] | None = None,
         metadata_condition: MetadataFilteringCondition | None = None,
         attachment_ids: list[str] | None = None,
     ):
@@ -1141,6 +1168,7 @@ class DatasetRetrieval:
                         query=query,
                         top_k=top_k,
                         document_ids_filter=document_ids_filter,
+                        index_node_ids_filter=index_node_ids_filter,
                     )
                     if documents:
                         all_documents.extend(documents)
@@ -1161,6 +1189,7 @@ class DatasetRetrieval:
                             reranking_mode=retrieval_model.get("reranking_mode") or "reranking_model",
                             weights=retrieval_model.get("weights", None),
                             document_ids_filter=document_ids_filter,
+                            index_node_ids_filter=index_node_ids_filter,
                             attachment_ids=attachment_ids,
                         )
 
@@ -1178,6 +1207,7 @@ class DatasetRetrieval:
         document_ids_filter: list[str] | None,
         metadata_condition: MetadataFilteringCondition | None,
         attachment_ids: list[str] | None,
+        index_node_ids_filter: list[str] | None = None,
     ) -> None:
         with session_factory.create_session() as session:
             self._retriever(
@@ -1190,6 +1220,11 @@ class DatasetRetrieval:
                 document_ids_filter=document_ids_filter,
                 metadata_condition=metadata_condition,
                 attachment_ids=attachment_ids,
+                **(
+                    {"index_node_ids_filter": index_node_ids_filter}
+                    if index_node_ids_filter is not None
+                    else {}
+                ),
             )
 
     def _run_retriever_thread_safely(
@@ -1206,6 +1241,7 @@ class DatasetRetrieval:
         cancel_event: threading.Event | None,
         thread_exceptions: list[Exception] | None,
         skip_on_error: bool = False,
+        index_node_ids_filter: list[str] | None = None,
     ) -> None:
         """Collect errors after tracing, or skip dataset-level failures when requested."""
         try:
@@ -1218,6 +1254,11 @@ class DatasetRetrieval:
                 document_ids_filter=document_ids_filter,
                 metadata_condition=metadata_condition,
                 attachment_ids=attachment_ids,
+                **(
+                    {"index_node_ids_filter": index_node_ids_filter}
+                    if index_node_ids_filter is not None
+                    else {}
+                ),
             )
         except Exception as exc:
             if skip_on_error:
@@ -1455,17 +1496,35 @@ class DatasetRetrieval:
         metadata_model_config: ModelConfig,
         metadata_filtering_conditions: MetadataFilteringCondition | None,
         inputs: dict[str, Any],
-    ) -> tuple[dict[str, list[str]] | None, MetadataFilteringCondition | None]:
-        document_query = select(DatasetDocument).where(
+    ) -> tuple[
+        dict[str, list[str]] | None,
+        dict[str, list[str]] | None,
+        MetadataFilteringCondition | None,
+    ]:
+        document_query = select(DatasetDocument.id, DatasetDocument.dataset_id).where(
             DatasetDocument.dataset_id.in_(dataset_ids),
             DatasetDocument.indexing_status == "completed",
             DatasetDocument.enabled == True,
             DatasetDocument.archived == False,
         )
-        filters = []  # type: ignore
+        segment_query = (
+            select(DocumentSegment.id, DocumentSegment.dataset_id, DocumentSegment.index_node_id)
+            .join(DatasetDocument, DatasetDocument.id == DocumentSegment.document_id)
+            .where(
+                DocumentSegment.dataset_id.in_(dataset_ids),
+                DatasetDocument.indexing_status == "completed",
+                DatasetDocument.enabled == True,
+                DatasetDocument.archived == False,
+                DatasetDocument.has_segment_metadata_override == True,
+                DocumentSegment.enabled == True,
+                DocumentSegment.status == "completed",
+            )
+        )
+        document_filters: list[Any] = []
+        segment_filters: list[Any] = []
         metadata_condition = None
         if metadata_filtering_mode == "disabled":
-            return None, None
+            return None, None, None
         elif metadata_filtering_mode == "automatic":
             automatic_metadata_filters = self._automatic_metadata_filter_func(
                 session, dataset_ids, query, tenant_id, user_id, metadata_model_config
@@ -1478,7 +1537,21 @@ class DatasetRetrieval:
                         filter.get("condition"),  # type: ignore
                         filter.get("metadata_name"),  # type: ignore
                         filter.get("value"),
-                        filters,  # type: ignore
+                        document_filters,
+                        json_source=DatasetDocument.doc_metadata,
+                    )
+                    self.process_metadata_filter_func(
+                        sequence,
+                        filter.get("condition"),  # type: ignore
+                        filter.get("metadata_name"),  # type: ignore
+                        filter.get("value"),
+                        segment_filters,
+                        json_source=DocumentSegment.effective_metadata,
+                        text_source=(
+                            DocumentSegment.effective_security_level
+                            if filter.get("metadata_name") == "security_level"
+                            else None
+                        ),
                     )
                     conditions.append(
                         Condition(
@@ -1509,12 +1582,24 @@ class DatasetRetrieval:
                             value=expected_value,
                         )
                     )
-                    filters = self.process_metadata_filter_func(
+                    document_filters = self.process_metadata_filter_func(
                         sequence,
                         condition.comparison_operator,
                         metadata_name,
                         expected_value,
-                        filters,
+                        document_filters,
+                        json_source=DatasetDocument.doc_metadata,
+                    )
+                    segment_filters = self.process_metadata_filter_func(
+                        sequence,
+                        condition.comparison_operator,
+                        metadata_name,
+                        expected_value,
+                        segment_filters,
+                        json_source=DocumentSegment.effective_metadata,
+                        text_source=(
+                            DocumentSegment.effective_security_level if metadata_name == "security_level" else None
+                        ),
                     )
                 metadata_condition = MetadataFilteringCondition(
                     logical_operator=metadata_filtering_conditions.logical_operator,
@@ -1522,17 +1607,85 @@ class DatasetRetrieval:
                 )
         else:
             raise ValueError("Invalid metadata filtering mode")
-        if filters:
-            if metadata_filtering_conditions and metadata_filtering_conditions.logical_operator == "and":  # type: ignore
-                document_query = document_query.where(and_(*filters))
+
+        if not document_filters and not segment_filters:
+            return None, None, None
+
+        logical_operator = metadata_condition.logical_operator if metadata_condition else "or"
+        if document_filters:
+            if logical_operator == "and":
+                document_query = document_query.where(
+                    DatasetDocument.has_segment_metadata_override == False, and_(*document_filters)
+                )
             else:
-                document_query = document_query.where(or_(*filters))
-        documents = session.scalars(document_query).all()
-        # group by dataset_id
-        metadata_filter_document_ids = defaultdict(list) if documents else None  # type: ignore
-        for document in documents:
-            metadata_filter_document_ids[document.dataset_id].append(document.id)  # type: ignore
-        return metadata_filter_document_ids, metadata_condition
+                document_query = document_query.where(
+                    DatasetDocument.has_segment_metadata_override == False, or_(*document_filters)
+                )
+        else:
+            document_query = document_query.where(DatasetDocument.has_segment_metadata_override == False)
+
+        if segment_filters:
+            segment_query = segment_query.where(
+                and_(*segment_filters) if logical_operator == "and" else or_(*segment_filters)
+            )
+
+        plain_documents = session.execute(document_query).all()
+        segments = session.execute(segment_query).all()
+        metadata_filter_document_ids: defaultdict[str, list[str]] | None = (
+            defaultdict(list) if plain_documents else None
+        )
+        metadata_filter_index_node_ids: defaultdict[str, list[str]] | None = defaultdict(list) if segments else None
+
+        for document in plain_documents:
+            assert metadata_filter_document_ids is not None
+            metadata_filter_document_ids[document.dataset_id].append(document.id)
+
+        if segments:
+            assert metadata_filter_index_node_ids is not None
+            segment_by_id = {segment.id: segment for segment in segments}
+            seen_ids: dict[str, set[str]] = defaultdict(set)
+
+            def append_index_node(dataset_id: str, index_node_id: str | None) -> None:
+                if not index_node_id or index_node_id in seen_ids[dataset_id]:
+                    return
+                metadata_filter_index_node_ids[dataset_id].append(index_node_id)
+                seen_ids[dataset_id].add(index_node_id)
+
+            for segment in segments:
+                append_index_node(segment.dataset_id, segment.index_node_id)
+
+            segment_ids = list(segment_by_id)
+            child_chunk_rows = session.execute(
+                select(ChildChunk.segment_id, ChildChunk.index_node_id).where(ChildChunk.segment_id.in_(segment_ids))
+            ).all()
+            for child_chunk in child_chunk_rows:
+                parent = segment_by_id.get(child_chunk.segment_id)
+                if parent:
+                    append_index_node(parent.dataset_id, child_chunk.index_node_id)
+
+            summary_rows = session.execute(
+                select(DocumentSegmentSummary.chunk_id, DocumentSegmentSummary.summary_index_node_id).where(
+                    DocumentSegmentSummary.chunk_id.in_(segment_ids),
+                    DocumentSegmentSummary.enabled == True,
+                    DocumentSegmentSummary.status == "completed",
+                )
+            ).all()
+            for summary in summary_rows:
+                parent = segment_by_id.get(summary.chunk_id)
+                if parent:
+                    append_index_node(parent.dataset_id, summary.summary_index_node_id)
+
+            attachment_rows = session.execute(
+                select(SegmentAttachmentBinding.segment_id, SegmentAttachmentBinding.attachment_id).where(
+                    SegmentAttachmentBinding.segment_id.in_(segment_ids)
+                )
+            ).all()
+            for attachment in attachment_rows:
+                parent = segment_by_id.get(attachment.segment_id)
+                if parent:
+                    append_index_node(parent.dataset_id, attachment.attachment_id)
+
+        return metadata_filter_document_ids, metadata_filter_index_node_ids, metadata_condition
 
     def _replace_metadata_filter_value(self, text: str, inputs: dict[str, Any]) -> str:
         if not inputs:
@@ -1612,63 +1765,79 @@ class DatasetRetrieval:
 
     @classmethod
     def process_metadata_filter_func(
-        cls, sequence: int, condition: str, metadata_name: str, value: Any | None, filters: list
+        cls,
+        sequence: int,
+        condition: str,
+        metadata_name: str,
+        value: Any | None,
+        filters: list,
+        *,
+        json_source=DatasetDocument.doc_metadata,
+        text_source=None,
     ):
+        del sequence
         if value is None and condition not in ("empty", "not empty"):
             return filters
 
-        json_field = DatasetDocument.doc_metadata[metadata_name].as_string()
+        if text_source is None:
+            text_field = json_source[metadata_name].as_string()
+            numeric_field = json_source[metadata_name].as_float()
+            nullable_field = json_source[metadata_name]
+        else:
+            text_field = text_source
+            numeric_field = sa_cast(text_source, Float)
+            nullable_field = text_source
 
         from libs.helper import escape_like_pattern
 
         match condition:
             case "contains":
                 escaped_value = escape_like_pattern(str(value))
-                filters.append(json_field.like(f"%{escaped_value}%", escape="\\"))
+                filters.append(text_field.like(f"%{escaped_value}%", escape="\\"))
 
             case "not contains":
                 escaped_value = escape_like_pattern(str(value))
-                filters.append(json_field.notlike(f"%{escaped_value}%", escape="\\"))
+                filters.append(text_field.notlike(f"%{escaped_value}%", escape="\\"))
 
             case "start with":
                 escaped_value = escape_like_pattern(str(value))
-                filters.append(json_field.like(f"{escaped_value}%", escape="\\"))
+                filters.append(text_field.like(f"{escaped_value}%", escape="\\"))
 
             case "end with":
                 escaped_value = escape_like_pattern(str(value))
-                filters.append(json_field.like(f"%{escaped_value}", escape="\\"))
+                filters.append(text_field.like(f"%{escaped_value}", escape="\\"))
 
             case "is" | "=":
                 match value:
                     case str():
-                        filters.append(json_field == value)
+                        filters.append(text_field == value)
                     case int() | float():
-                        filters.append(DatasetDocument.doc_metadata[metadata_name].as_float() == value)
+                        filters.append(numeric_field == value)
 
             case "is not" | "≠":
                 match value:
                     case str():
-                        filters.append(json_field != value)
+                        filters.append(text_field != value)
                     case int() | float():
-                        filters.append(DatasetDocument.doc_metadata[metadata_name].as_float() != value)
+                        filters.append(numeric_field != value)
 
             case "empty":
-                filters.append(DatasetDocument.doc_metadata[metadata_name].is_(None))
+                filters.append(nullable_field.is_(None))
 
             case "not empty":
-                filters.append(DatasetDocument.doc_metadata[metadata_name].isnot(None))
+                filters.append(nullable_field.isnot(None))
 
             case "before" | "<":
-                filters.append(DatasetDocument.doc_metadata[metadata_name].as_float() < value)
+                filters.append(numeric_field < value)
 
             case "after" | ">":
-                filters.append(DatasetDocument.doc_metadata[metadata_name].as_float() > value)
+                filters.append(numeric_field > value)
 
             case "≤" | "<=":
-                filters.append(DatasetDocument.doc_metadata[metadata_name].as_float() <= value)
+                filters.append(numeric_field <= value)
 
             case "≥" | ">=":
-                filters.append(DatasetDocument.doc_metadata[metadata_name].as_float() >= value)
+                filters.append(numeric_field >= value)
             case "in" | "not in":
                 match value:
                     case str():
@@ -1682,7 +1851,7 @@ class DatasetRetrieval:
                     # `field in []` is False, `field not in []` is True
                     filters.append(literal(condition == "not in"))
                 else:
-                    op = json_field.in_ if condition == "in" else json_field.notin_
+                    op = text_field.in_ if condition == "in" else text_field.notin_
                     filters.append(op(value_list))
             case _:
                 pass
@@ -1863,6 +2032,7 @@ class DatasetRetrieval:
         query: str | None,
         attachment_id: str | None,
         dataset_count: int,
+        metadata_filter_index_node_ids: dict[str, list[str]] | None = None,
         cancel_event: threading.Event | None = None,
     ) -> None:
         try:
@@ -1877,14 +2047,25 @@ class DatasetRetrieval:
                         break
                     index_type = dataset.indexing_technique
                     document_ids_filter = None
+                    index_node_ids_filter = None
                     if dataset.provider != "external":
-                        if metadata_condition and not metadata_filter_document_ids:
+                        if (
+                            metadata_condition
+                            and not metadata_filter_document_ids
+                            and not metadata_filter_index_node_ids
+                        ):
                             continue
                         if metadata_filter_document_ids:
                             document_ids = metadata_filter_document_ids.get(dataset.id, [])
                             if document_ids:
                                 document_ids_filter = document_ids
-                            else:
+                            elif not metadata_filter_index_node_ids:
+                                continue
+                        if metadata_filter_index_node_ids:
+                            index_node_ids = metadata_filter_index_node_ids.get(dataset.id, [])
+                            if index_node_ids:
+                                index_node_ids_filter = index_node_ids
+                            elif not document_ids_filter:
                                 continue
                     retrieval_thread = threading.Thread(
                         target=propagate_context(self._run_retriever_thread_safely),
@@ -1895,6 +2076,7 @@ class DatasetRetrieval:
                             "top_k": top_k,
                             "all_documents": all_documents_item,
                             "document_ids_filter": document_ids_filter,
+                            "index_node_ids_filter": index_node_ids_filter,
                             "metadata_condition": metadata_condition,
                             "attachment_ids": [attachment_id] if attachment_id else None,
                             "cancel_event": cancel_event,
@@ -1978,6 +2160,7 @@ class DatasetRetrieval:
         query: str | None,
         attachment_id: str | None,
         dataset_count: int,
+        metadata_filter_index_node_ids: dict[str, list[str]] | None = None,
         cancel_event: threading.Event | None = None,
         thread_exceptions: list[Exception] | None = None,
     ) -> None:
@@ -2000,6 +2183,11 @@ class DatasetRetrieval:
                 attachment_id=attachment_id,
                 dataset_count=dataset_count,
                 cancel_event=cancel_event,
+                **(
+                    {"metadata_filter_index_node_ids": metadata_filter_index_node_ids}
+                    if metadata_filter_index_node_ids is not None
+                    else {}
+                ),
             )
         except Exception as exc:
             if cancel_event:

--- a/api/core/rag/retrieval/dataset_retrieval.py
+++ b/api/core/rag/retrieval/dataset_retrieval.py
@@ -1220,11 +1220,7 @@ class DatasetRetrieval:
                 document_ids_filter=document_ids_filter,
                 metadata_condition=metadata_condition,
                 attachment_ids=attachment_ids,
-                **(
-                    {"index_node_ids_filter": index_node_ids_filter}
-                    if index_node_ids_filter is not None
-                    else {}
-                ),
+                **({"index_node_ids_filter": index_node_ids_filter} if index_node_ids_filter is not None else {}),
             )
 
     def _run_retriever_thread_safely(
@@ -1254,11 +1250,7 @@ class DatasetRetrieval:
                 document_ids_filter=document_ids_filter,
                 metadata_condition=metadata_condition,
                 attachment_ids=attachment_ids,
-                **(
-                    {"index_node_ids_filter": index_node_ids_filter}
-                    if index_node_ids_filter is not None
-                    else {}
-                ),
+                **({"index_node_ids_filter": index_node_ids_filter} if index_node_ids_filter is not None else {}),
             )
         except Exception as exc:
             if skip_on_error:

--- a/api/core/tools/utils/dataset_retriever/dataset_retriever_tool.py
+++ b/api/core/tools/utils/dataset_retriever/dataset_retriever_tool.py
@@ -66,21 +66,27 @@ class DatasetRetrieverTool(DatasetRetrieverBaseTool):
         for hit_callback in self.hit_callbacks:
             hit_callback.on_query(query, dataset.id, session)
         dataset_retrieval = DatasetRetrieval()
-        metadata_filter_document_ids, metadata_condition = dataset_retrieval.get_metadata_filter_condition(
-            session,
-            [dataset.id],
-            query,
-            self.tenant_id,
-            self.user_id or "unknown",
-            cast(str, self.retrieve_config.metadata_filtering_mode),
-            cast(ModelConfig, self.retrieve_config.metadata_model_config),
-            self.retrieve_config.metadata_filtering_conditions,
-            self.inputs,
+        metadata_filter_document_ids, metadata_filter_index_node_ids, metadata_condition = (
+            dataset_retrieval.get_metadata_filter_condition(
+                session,
+                [dataset.id],
+                query,
+                self.tenant_id,
+                self.user_id or "unknown",
+                cast(str, self.retrieve_config.metadata_filtering_mode),
+                cast(ModelConfig, self.retrieve_config.metadata_model_config),
+                self.retrieve_config.metadata_filtering_conditions,
+                self.inputs,
+            )
         )
         if metadata_filter_document_ids:
             document_ids_filter = metadata_filter_document_ids.get(dataset.id, [])
         else:
             document_ids_filter = None
+        if metadata_filter_index_node_ids:
+            index_node_ids_filter = metadata_filter_index_node_ids.get(dataset.id, [])
+        else:
+            index_node_ids_filter = None
         if dataset.provider == "external":
             results: list[RetrievalDocument] = []
             external_documents = ExternalDatasetService.fetch_external_knowledge_retrieval(
@@ -125,7 +131,7 @@ class DatasetRetrieverTool(DatasetRetrieverBaseTool):
 
             return "\n".join([item.page_content for item in results])
         else:
-            if metadata_condition and not document_ids_filter:
+            if metadata_condition and not document_ids_filter and not index_node_ids_filter:
                 return ""
             # get retrieval model , if the model is not setting , using default
             retrieval_model = dataset.retrieval_model or default_retrieval_model
@@ -138,6 +144,7 @@ class DatasetRetrieverTool(DatasetRetrieverBaseTool):
                     query=query,
                     top_k=self.top_k,
                     document_ids_filter=document_ids_filter,
+                    index_node_ids_filter=index_node_ids_filter,
                 )
                 return "\n".join([document.page_content for document in documents])
             else:
@@ -157,6 +164,7 @@ class DatasetRetrieverTool(DatasetRetrieverBaseTool):
                         reranking_mode=retrieval_model.get("reranking_mode") or "reranking_model",
                         weights=retrieval_model.get("weights"),
                         document_ids_filter=document_ids_filter,
+                        index_node_ids_filter=index_node_ids_filter,
                     )
                 else:
                     documents = []

--- a/api/migrations/versions/2026_08_11_1200-6f0c2a91b7d3_add_chunk_metadata_overrides.py
+++ b/api/migrations/versions/2026_08_11_1200-6f0c2a91b7d3_add_chunk_metadata_overrides.py
@@ -1,0 +1,136 @@
+"""add chunk metadata overrides
+
+Revision ID: 6f0c2a91b7d3
+Revises: e4708db55c1d
+Create Date: 2026-08-11 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+import models
+
+revision = "6f0c2a91b7d3"
+down_revision = "e4708db55c1d"
+branch_labels = None
+depends_on = None
+
+
+def _is_postgresql() -> bool:
+    return op.get_bind().dialect.name == "postgresql"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "segment_metadata_bindings",
+        sa.Column("id", models.types.StringUUID(), nullable=False),
+        sa.Column("tenant_id", models.types.StringUUID(), nullable=False),
+        sa.Column("dataset_id", models.types.StringUUID(), nullable=False),
+        sa.Column("document_id", models.types.StringUUID(), nullable=False),
+        sa.Column("segment_id", models.types.StringUUID(), nullable=False),
+        sa.Column("metadata_id", models.types.StringUUID(), nullable=False),
+        sa.Column("value_json", models.types.AdjustedJSON(), nullable=False),
+        sa.Column("created_by", models.types.StringUUID(), nullable=False),
+        sa.Column("updated_by", models.types.StringUUID(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.current_timestamp(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.current_timestamp(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["document_id"], ["documents.id"], name="segment_metadata_binding_document_fkey", ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["segment_id"],
+            ["document_segments.id"],
+            name="segment_metadata_binding_segment_fkey",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["metadata_id"],
+            ["dataset_metadatas.id"],
+            name="segment_metadata_binding_metadata_fkey",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name="segment_metadata_binding_pkey"),
+    )
+    op.create_index("segment_metadata_binding_tenant_idx", "segment_metadata_bindings", ["tenant_id"])
+    op.create_index("segment_metadata_binding_dataset_idx", "segment_metadata_bindings", ["dataset_id"])
+    op.create_index("segment_metadata_binding_document_idx", "segment_metadata_bindings", ["document_id"])
+    op.create_index("segment_metadata_binding_metadata_idx", "segment_metadata_bindings", ["metadata_id"])
+    op.create_index(
+        "segment_metadata_binding_segment_metadata_idx",
+        "segment_metadata_bindings",
+        ["segment_id", "metadata_id"],
+        unique=True,
+    )
+
+    op.add_column("document_segments", sa.Column("effective_metadata", models.types.AdjustedJSON(), nullable=True))
+    op.add_column(
+        "document_segments",
+        sa.Column("metadata_override_count", sa.Integer(), server_default=sa.text("0"), nullable=False),
+    )
+    op.add_column("document_segments", sa.Column("effective_security_level", sa.String(length=255), nullable=True))
+    op.add_column(
+        "documents",
+        sa.Column("has_segment_metadata_override", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+    )
+    op.add_column(
+        "documents",
+        sa.Column("segment_metadata_override_count", sa.Integer(), server_default=sa.text("0"), nullable=False),
+    )
+
+    if _is_postgresql():
+        op.execute(
+            """
+            UPDATE document_segments AS ds
+            SET effective_metadata = COALESCE(d.doc_metadata::jsonb, '{}'::jsonb),
+                effective_security_level = d.doc_metadata->>'security_level'
+            FROM documents AS d
+            WHERE ds.document_id = d.id
+            """
+        )
+        metadata_default = sa.text("'{}'::jsonb")
+    else:
+        op.execute(
+            """
+            UPDATE document_segments AS ds
+            JOIN documents AS d ON ds.document_id = d.id
+            SET ds.effective_metadata = COALESCE(d.doc_metadata, JSON_OBJECT()),
+                ds.effective_security_level = JSON_UNQUOTE(JSON_EXTRACT(d.doc_metadata, '$.security_level'))
+            """
+        )
+        metadata_default = sa.text("(JSON_OBJECT())")
+
+    with op.batch_alter_table("document_segments") as batch_op:
+        batch_op.alter_column(
+            "effective_metadata",
+            existing_type=models.types.AdjustedJSON(),
+            nullable=False,
+            server_default=metadata_default,
+        )
+        batch_op.create_index("document_segment_document_position_idx", ["document_id", "position"])
+        batch_op.create_index("document_segment_dataset_security_level_idx", ["dataset_id", "effective_security_level"])
+
+    if _is_postgresql():
+        op.create_index(
+            "document_segment_effective_metadata_idx",
+            "document_segments",
+            ["effective_metadata"],
+            postgresql_using="gin",
+        )
+
+    op.create_index("document_dataset_override_flag_idx", "documents", ["dataset_id", "has_segment_metadata_override"])
+
+
+def downgrade() -> None:
+    op.drop_index("document_dataset_override_flag_idx", table_name="documents")
+    if _is_postgresql():
+        op.drop_index("document_segment_effective_metadata_idx", table_name="document_segments")
+    with op.batch_alter_table("document_segments") as batch_op:
+        batch_op.drop_index("document_segment_dataset_security_level_idx")
+        batch_op.drop_index("document_segment_document_position_idx")
+    op.drop_column("documents", "segment_metadata_override_count")
+    op.drop_column("documents", "has_segment_metadata_override")
+    op.drop_column("document_segments", "effective_security_level")
+    op.drop_column("document_segments", "metadata_override_count")
+    op.drop_column("document_segments", "effective_metadata")
+    op.drop_table("segment_metadata_bindings")

--- a/api/models/dataset.py
+++ b/api/models/dataset.py
@@ -536,6 +536,7 @@ class Document(Base):
     __table_args__ = (
         sa.PrimaryKeyConstraint("id", name="document_pkey"),
         sa.Index("document_dataset_id_idx", "dataset_id"),
+        sa.Index("document_dataset_override_flag_idx", "dataset_id", "has_segment_metadata_override"),
         sa.Index("document_is_paused_idx", "is_paused"),
         sa.Index("document_tenant_idx", "tenant_id"),
         adjusted_json_index("document_metadata_idx", "doc_metadata"),
@@ -600,6 +601,12 @@ class Document(Base):
     )
     doc_type = mapped_column(EnumText(DocumentDocType, length=40), nullable=True)
     doc_metadata = mapped_column(AdjustedJSON, nullable=True)
+    has_segment_metadata_override: Mapped[bool] = mapped_column(
+        sa.Boolean, nullable=False, server_default=sa.text("false"), default=False
+    )
+    segment_metadata_override_count: Mapped[int] = mapped_column(
+        sa.Integer, nullable=False, server_default=sa.text("0"), default=0
+    )
     doc_form: Mapped[IndexStructureType] = mapped_column(
         EnumText(IndexStructureType, length=255), nullable=False, server_default=sa.text("'text_model'")
     )
@@ -906,6 +913,9 @@ class DocumentSegment(TypeBase):
     __tablename__ = "document_segments"
     __table_args__ = (
         sa.PrimaryKeyConstraint("id", name="document_segment_pkey"),
+        sa.Index("document_segment_document_position_idx", "document_id", "position"),
+        sa.Index("document_segment_dataset_security_level_idx", "dataset_id", "effective_security_level"),
+        adjusted_json_index("document_segment_effective_metadata_idx", "effective_metadata"),
         sa.Index("document_segment_dataset_id_idx", "dataset_id"),
         sa.Index("document_segment_document_id_idx", "document_id"),
         sa.Index("document_segment_tenant_dataset_idx", "dataset_id", "tenant_id"),
@@ -949,6 +959,13 @@ class DocumentSegment(TypeBase):
     error: Mapped[str | None] = mapped_column(LongText, nullable=True, default=None)
     stopped_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True, default=None)
     hit_count: Mapped[int] = mapped_column(sa.Integer, nullable=False, default=0)
+    effective_metadata: Mapped[dict[str, Any]] = mapped_column(
+        AdjustedJSON, nullable=False, default_factory=dict, server_default=sa.text("'{}'")
+    )
+    metadata_override_count: Mapped[int] = mapped_column(
+        sa.Integer, nullable=False, default=0, server_default=sa.text("0")
+    )
+    effective_security_level: Mapped[str | None] = mapped_column(String(255), nullable=True, default=None)
 
     @property
     def dataset(self) -> Dataset | None:
@@ -1640,6 +1657,46 @@ class DatasetMetadataBinding(TypeBase):
         DateTime, nullable=False, server_default=func.current_timestamp(), init=False
     )
     created_by: Mapped[str] = mapped_column(StringUUID, nullable=False)
+
+
+class SegmentMetadataBinding(TypeBase):
+    __tablename__ = "segment_metadata_bindings"
+    __table_args__ = (
+        sa.PrimaryKeyConstraint("id", name="segment_metadata_binding_pkey"),
+        sa.Index("segment_metadata_binding_tenant_idx", "tenant_id"),
+        sa.Index("segment_metadata_binding_dataset_idx", "dataset_id"),
+        sa.Index("segment_metadata_binding_document_idx", "document_id"),
+        sa.Index("segment_metadata_binding_metadata_idx", "metadata_id"),
+        sa.Index("segment_metadata_binding_segment_metadata_idx", "segment_id", "metadata_id", unique=True),
+    )
+
+    id: Mapped[str] = mapped_column(
+        StringUUID, insert_default=lambda: str(uuid4()), default_factory=lambda: str(uuid4()), init=False
+    )
+    tenant_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
+    dataset_id: Mapped[str] = mapped_column(StringUUID, nullable=False)
+    document_id: Mapped[str] = mapped_column(
+        StringUUID, sa.ForeignKey("documents.id", ondelete="CASCADE"), nullable=False
+    )
+    segment_id: Mapped[str] = mapped_column(
+        StringUUID, sa.ForeignKey("document_segments.id", ondelete="CASCADE"), nullable=False
+    )
+    metadata_id: Mapped[str] = mapped_column(
+        StringUUID, sa.ForeignKey("dataset_metadatas.id", ondelete="CASCADE"), nullable=False
+    )
+    value_json: Mapped[Any] = mapped_column(AdjustedJSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.current_timestamp(), init=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        nullable=False,
+        server_default=func.current_timestamp(),
+        onupdate=func.current_timestamp(),
+        init=False,
+    )
+    created_by: Mapped[str] = mapped_column(StringUUID, nullable=False)
+    updated_by: Mapped[str | None] = mapped_column(StringUUID, nullable=True, default=None)
 
 
 class PipelineBuiltInTemplate(TypeBase):

--- a/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
@@ -97,6 +97,8 @@ class WeaviateVector(BaseVector):
     in a Weaviate collection.
     """
 
+    supports_index_node_ids_filter = True
+
     _DOCUMENT_ID_PROPERTY = "document_id"
 
     def __init__(self, collection_name: str, config: WeaviateConfig, attributes: list):
@@ -409,8 +411,13 @@ class WeaviateVector(BaseVector):
 
         where = None
         doc_ids = kwargs.get("document_ids_filter") or []
-        if doc_ids:
-            where = Filter.by_property(self._DOCUMENT_ID_PROPERTY).contains_any(doc_ids)
+        index_node_ids = kwargs.get("index_node_ids_filter") or []
+        node_filter = Filter.by_property("doc_id").contains_any(index_node_ids) if index_node_ids else None
+        document_filter = Filter.by_property(self._DOCUMENT_ID_PROPERTY).contains_any(doc_ids) if doc_ids else None
+        if node_filter is not None and document_filter is not None:
+            where = node_filter | document_filter
+        else:
+            where = node_filter or document_filter
 
         top_k = int(kwargs.get("top_k", 4))
         score_threshold = float(kwargs.get("score_threshold") or 0.0)
@@ -469,8 +476,13 @@ class WeaviateVector(BaseVector):
 
         where = None
         doc_ids = kwargs.get("document_ids_filter") or []
-        if doc_ids:
-            where = Filter.by_property(self._DOCUMENT_ID_PROPERTY).contains_any(doc_ids)
+        index_node_ids = kwargs.get("index_node_ids_filter") or []
+        node_filter = Filter.by_property("doc_id").contains_any(index_node_ids) if index_node_ids else None
+        document_filter = Filter.by_property(self._DOCUMENT_ID_PROPERTY).contains_any(doc_ids) if doc_ids else None
+        if node_filter is not None and document_filter is not None:
+            where = node_filter | document_filter
+        else:
+            where = node_filter or document_filter
 
         top_k = int(kwargs.get("top_k", 4))
 

--- a/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
@@ -478,6 +478,49 @@ class TestWeaviateVector(unittest.TestCase):
         assert mock_col.query.near_vector.call_args.kwargs["filters"] is not None
 
     @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
+    def test_search_by_vector_combines_document_and_node_filters_with_or(self, mock_weaviate_module):
+        mock_client = MagicMock()
+        mock_client.is_ready.return_value = True
+        mock_weaviate_module.connect_to_custom.return_value = mock_client
+        mock_client.collections.exists.return_value = True
+        mock_col = MagicMock()
+        mock_client.collections.use.return_value = mock_col
+        mock_col.query.near_vector.return_value.objects = []
+
+        node_filter = MagicMock()
+        document_filter = MagicMock()
+        combined_filter = MagicMock()
+        node_filter.__or__.return_value = combined_filter
+
+        node_property = MagicMock()
+        node_property.contains_any.return_value = node_filter
+        document_property = MagicMock()
+        document_property.contains_any.return_value = document_filter
+
+        with patch.object(
+            weaviate_vector_module.Filter,
+            "by_property",
+            side_effect=[node_property, document_property],
+        ) as mock_by_property:
+            wv = WeaviateVector(
+                collection_name=self.collection_name,
+                config=self.config,
+                attributes=self.attributes,
+            )
+            wv.search_by_vector(
+                query_vector=[0.2] * 3,
+                document_ids_filter=["doc-1"],
+                index_node_ids_filter=["segment-1"],
+                score_threshold=-1,
+            )
+
+        assert [call.args[0] for call in mock_by_property.call_args_list] == ["doc_id", "document_id"]
+        node_property.contains_any.assert_called_once_with(["segment-1"])
+        document_property.contains_any.assert_called_once_with(["doc-1"])
+        node_filter.__or__.assert_called_once_with(document_filter)
+        assert mock_col.query.near_vector.call_args.kwargs["filters"] is combined_filter
+
+    @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
     def test_search_by_vector_returns_empty_when_collection_is_missing(self, mock_weaviate_module):
         mock_client = MagicMock()
         mock_client.is_ready.return_value = True
@@ -611,6 +654,48 @@ class TestWeaviateVector(unittest.TestCase):
         assert len(docs) == 1
         assert docs[0].vector == [0.3, 0.4]
         assert mock_col.query.bm25.call_args.kwargs["filters"] is not None
+
+    @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
+    def test_search_by_full_text_combines_document_and_node_filters_with_or(self, mock_weaviate_module):
+        mock_client = MagicMock()
+        mock_client.is_ready.return_value = True
+        mock_weaviate_module.connect_to_custom.return_value = mock_client
+        mock_client.collections.exists.return_value = True
+        mock_col = MagicMock()
+        mock_client.collections.use.return_value = mock_col
+        mock_col.query.bm25.return_value.objects = []
+
+        node_filter = MagicMock()
+        document_filter = MagicMock()
+        combined_filter = MagicMock()
+        node_filter.__or__.return_value = combined_filter
+
+        node_property = MagicMock()
+        node_property.contains_any.return_value = node_filter
+        document_property = MagicMock()
+        document_property.contains_any.return_value = document_filter
+
+        with patch.object(
+            weaviate_vector_module.Filter,
+            "by_property",
+            side_effect=[node_property, document_property],
+        ) as mock_by_property:
+            wv = WeaviateVector(
+                collection_name=self.collection_name,
+                config=self.config,
+                attributes=self.attributes,
+            )
+            wv.search_by_full_text(
+                query="bm25",
+                document_ids_filter=["doc-1"],
+                index_node_ids_filter=["segment-1"],
+            )
+
+        assert [call.args[0] for call in mock_by_property.call_args_list] == ["doc_id", "document_id"]
+        node_property.contains_any.assert_called_once_with(["segment-1"])
+        document_property.contains_any.assert_called_once_with(["doc-1"])
+        node_filter.__or__.assert_called_once_with(document_filter)
+        assert mock_col.query.bm25.call_args.kwargs["filters"] is combined_filter
 
     @patch("dify_vdb_weaviate.weaviate_vector.weaviate")
     def test_search_by_full_text_returns_empty_when_collection_is_missing(self, mock_weaviate_module):

--- a/api/services/dataset_service.py
+++ b/api/services/dataset_service.py
@@ -50,6 +50,7 @@ from models.dataset import (
     ExternalKnowledgeBindings,
     Pipeline,
     SegmentAttachmentBinding,
+    SegmentMetadataBinding,
 )
 from models.enums import (
     DatasetRuntimeMode,
@@ -3368,6 +3369,20 @@ class DocumentService:
 
 
 class SegmentService:
+    @staticmethod
+    def _refresh_metadata_override_summary(session: Session, document: Document) -> None:
+        override_segment_count = (
+            session.scalar(
+                select(func.count(func.distinct(SegmentMetadataBinding.segment_id))).where(
+                    SegmentMetadataBinding.document_id == document.id
+                )
+            )
+            or 0
+        )
+        document.segment_metadata_override_count = int(override_segment_count)
+        document.has_segment_metadata_override = override_segment_count > 0
+        session.add(document)
+
     @classmethod
     def segment_create_args_validate(cls, args: dict[str, Any], document: Document):
         if document.doc_form == IndexStructureType.QA_INDEX:
@@ -3424,6 +3439,10 @@ class SegmentService:
                     indexing_at=naive_utc_now(),
                     completed_at=naive_utc_now(),
                     created_by=current_user.id,
+                    effective_metadata=copy.deepcopy(document.doc_metadata) if document.doc_metadata else {},
+                    effective_security_level=(document.doc_metadata or {}).get("security_level")
+                    if isinstance((document.doc_metadata or {}).get("security_level"), str)
+                    else None,
                 )
                 if document.doc_form == IndexStructureType.QA_INDEX:
                     segment_document.word_count += len(args["answer"])
@@ -3521,6 +3540,10 @@ class SegmentService:
                         indexing_at=naive_utc_now(),
                         completed_at=naive_utc_now(),
                         created_by=current_user.id,
+                        effective_metadata=copy.deepcopy(document.doc_metadata) if document.doc_metadata else {},
+                        effective_security_level=(document.doc_metadata or {}).get("security_level")
+                        if isinstance((document.doc_metadata or {}).get("security_level"), str)
+                        else None,
                     )
                     if document.doc_form == IndexStructureType.QA_INDEX:
                         segment_document.answer = segment_item["answer"]
@@ -3871,7 +3894,10 @@ class SegmentService:
                 [segment.index_node_id], dataset.id, document.id, [segment.id], child_node_ids
             )
 
+        session.execute(delete(SegmentMetadataBinding).where(SegmentMetadataBinding.segment_id == segment.id))
         session.delete(segment)
+        session.flush()
+        cls._refresh_metadata_override_summary(session, document)
         # update document word count
         assert document.word_count is not None
         document.word_count -= segment.word_count
@@ -3927,7 +3953,9 @@ class SegmentService:
 
         session.add(document)
 
-        # Delete database records
+        # Delete metadata overrides first so the summary is correct even on databases
+        # where foreign-key cascades are disabled in tests.
+        session.execute(delete(SegmentMetadataBinding).where(SegmentMetadataBinding.segment_id.in_(segment_db_ids)))
         session.execute(
             delete(DocumentSegment).where(
                 DocumentSegment.id.in_(segment_db_ids),
@@ -3936,6 +3964,7 @@ class SegmentService:
                 DocumentSegment.tenant_id == current_user.current_tenant_id,
             )
         )
+        cls._refresh_metadata_override_summary(session, document)
         session.commit()
 
     @classmethod

--- a/api/services/hit_testing_service.py
+++ b/api/services/hit_testing_service.py
@@ -121,6 +121,7 @@ class HitTestingService:
             retrieval_model or dataset.retrieval_model or default_retrieval_model,
         )
         document_ids_filter = None
+        index_node_ids_filter = None
         metadata_filtering_conditions_raw = resolved_retrieval_model.get("metadata_filtering_conditions", {})
         if metadata_filtering_conditions_raw and query:
             dataset_retrieval = DatasetRetrieval()
@@ -129,20 +130,24 @@ class HitTestingService:
 
             metadata_filtering_conditions = MetadataFilteringCondition.model_validate(metadata_filtering_conditions_raw)
 
-            metadata_filter_document_ids, metadata_condition = dataset_retrieval.get_metadata_filter_condition(
-                session=session,
-                dataset_ids=[dataset.id],
-                query=query,
-                metadata_filtering_mode="manual",
-                metadata_filtering_conditions=metadata_filtering_conditions,
-                inputs={},
-                tenant_id="",
-                user_id="",
-                metadata_model_config=ModelConfig(provider="", name="", mode=LLMMode.CHAT, completion_params={}),
+            metadata_filter_document_ids, metadata_filter_index_node_ids, metadata_condition = (
+                dataset_retrieval.get_metadata_filter_condition(
+                    session=session,
+                    dataset_ids=[dataset.id],
+                    query=query,
+                    metadata_filtering_mode="manual",
+                    metadata_filtering_conditions=metadata_filtering_conditions,
+                    inputs={},
+                    tenant_id="",
+                    user_id="",
+                    metadata_model_config=ModelConfig(provider="", name="", mode=LLMMode.CHAT, completion_params={}),
+                )
             )
             if metadata_filter_document_ids:
                 document_ids_filter = metadata_filter_document_ids.get(dataset.id, [])
-            if metadata_condition and not document_ids_filter:
+            if metadata_filter_index_node_ids:
+                index_node_ids_filter = metadata_filter_index_node_ids.get(dataset.id, [])
+            if metadata_condition and not document_ids_filter and not index_node_ids_filter:
                 return cls.compact_retrieve_response(query, [], session=session)
         all_documents = RetrievalService.retrieve(
             retrieval_method=RetrievalMethod(
@@ -161,6 +166,7 @@ class HitTestingService:
             reranking_mode=resolved_retrieval_model.get("reranking_mode") or "reranking_model",
             weights=resolved_retrieval_model.get("weights", None),
             document_ids_filter=document_ids_filter,
+            index_node_ids_filter=index_node_ids_filter,
         )
 
         end = time.perf_counter()

--- a/api/services/metadata_service.py
+++ b/api/services/metadata_service.py
@@ -1,5 +1,10 @@
 import copy
 import logging
+from collections import defaultdict
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Any, cast
+from uuid import uuid4
 
 from sqlalchemy import delete, func, select
 from sqlalchemy.orm import Session
@@ -9,32 +14,338 @@ from extensions.ext_redis import redis_client
 from libs.datetime_utils import naive_utc_now
 from libs.login import resolve_account_fallback
 from models import Account
-from models.dataset import Dataset, DatasetMetadata, DatasetMetadataBinding
+from models.dataset import (
+    Dataset,
+    DatasetMetadata,
+    DatasetMetadataBinding,
+    Document,
+    DocumentSegment,
+    SegmentMetadataBinding,
+)
 from models.enums import DatasetMetadataType
 from services.dataset_service import DocumentService
 from services.entities.knowledge_entities.knowledge_entities import (
     MetadataArgs,
     MetadataOperationData,
+    MetadataUpdateArgs,
 )
 
 logger = logging.getLogger(__name__)
 
 
 class MetadataService:
+    _LOCK_TTL_SECONDS = 3600
+    _LOCK_RELEASE_SCRIPT = """
+        if redis.call('get', KEYS[1]) == ARGV[1] then
+            return redis.call('del', KEYS[1])
+        end
+        return 0
+    """
+
+    @staticmethod
+    def _get_built_in_metadata(document: Document, *, session: Session) -> dict[str, Any]:
+        return {
+            BuiltInField.document_name: document.name,
+            BuiltInField.uploader: document.get_uploader(session=session),
+            BuiltInField.upload_date: document.upload_date.timestamp(),
+            BuiltInField.last_update_date: document.last_update_date.timestamp(),
+            BuiltInField.source: MetadataDataSource[document.data_source_type],
+        }
+
+    @staticmethod
+    def _get_document_default_metadata(dataset: Dataset, document: Document, *, session: Session) -> dict[str, Any]:
+        metadata: dict[str, Any] = (
+            copy.deepcopy(cast(dict[str, Any], document.doc_metadata)) if document.doc_metadata else {}
+        )
+        if dataset.built_in_field_enabled:
+            built_in_names = {field.value for field in BuiltInField}
+            missing_names = built_in_names.difference(metadata)
+            if missing_names:
+                built_in_metadata = MetadataService._get_built_in_metadata(document, session=session)
+                metadata.update({name: built_in_metadata[name] for name in missing_names})
+        return metadata
+
+    @staticmethod
+    def _get_metadata_name_map(session: Session, dataset_id: str) -> dict[str, str]:
+        metadatas = session.scalars(select(DatasetMetadata).where(DatasetMetadata.dataset_id == dataset_id)).all()
+        return {metadata.id: metadata.name for metadata in metadatas}
+
+    @staticmethod
+    def _group_segment_overrides(
+        session: Session, document_id: str, segment_ids: list[str] | None = None
+    ) -> dict[str, list[SegmentMetadataBinding]]:
+        stmt = select(SegmentMetadataBinding).where(SegmentMetadataBinding.document_id == document_id)
+        if segment_ids is not None:
+            if not segment_ids:
+                return {}
+            stmt = stmt.where(SegmentMetadataBinding.segment_id.in_(segment_ids))
+        grouped: dict[str, list[SegmentMetadataBinding]] = defaultdict(list)
+        for binding in session.scalars(stmt).all():
+            grouped[binding.segment_id].append(binding)
+        return grouped
+
+    @staticmethod
+    def _refresh_document_override_summary(session: Session, document: Document) -> None:
+        override_segment_count = (
+            session.scalar(
+                select(func.count(func.distinct(SegmentMetadataBinding.segment_id))).where(
+                    SegmentMetadataBinding.document_id == document.id
+                )
+            )
+            or 0
+        )
+        document.segment_metadata_override_count = int(override_segment_count)
+        document.has_segment_metadata_override = override_segment_count > 0
+        session.add(document)
+
+    @staticmethod
+    def rebuild_segment_effective_metadata(
+        session: Session,
+        dataset: Dataset,
+        document: Document,
+        segment_ids: list[str] | None = None,
+        changed_fields: list[str] | None = None,
+    ) -> None:
+        del changed_fields  # Reserved for a future partial JSON update implementation.
+        stmt = select(DocumentSegment).where(DocumentSegment.document_id == document.id)
+        if segment_ids is not None:
+            if not segment_ids:
+                MetadataService._refresh_document_override_summary(session, document)
+                return
+            stmt = stmt.where(DocumentSegment.id.in_(segment_ids))
+        segments = session.scalars(stmt).all()
+        if not segments:
+            MetadataService._refresh_document_override_summary(session, document)
+            return
+
+        metadata_name_map = MetadataService._get_metadata_name_map(session, dataset.id)
+        override_groups = MetadataService._group_segment_overrides(session, document.id, segment_ids)
+        built_in_names = {field["name"] for field in MetadataService.get_built_in_fields()}
+        default_metadata = MetadataService._get_document_default_metadata(dataset, document, session=session)
+
+        for segment in segments:
+            effective_metadata = copy.deepcopy(default_metadata)
+            valid_override_count = 0
+            for binding in override_groups.get(segment.id, []):
+                metadata_name = metadata_name_map.get(binding.metadata_id)
+                if not metadata_name or metadata_name in built_in_names:
+                    continue
+                effective_metadata[metadata_name] = binding.value_json
+                valid_override_count += 1
+
+            security_level = effective_metadata.get("security_level")
+            segment.effective_metadata = effective_metadata
+            segment.metadata_override_count = valid_override_count
+            segment.effective_security_level = security_level if isinstance(security_level, str) else None
+            session.add(segment)
+
+        MetadataService._refresh_document_override_summary(session, document)
+
+    @staticmethod
+    def apply_document_metadata_to_segments(
+        session: Session,
+        dataset: Dataset,
+        document: Document,
+        changed_fields: list[str] | None = None,
+    ) -> None:
+        MetadataService.rebuild_segment_effective_metadata(
+            session=session,
+            dataset=dataset,
+            document=document,
+            changed_fields=changed_fields,
+        )
+
+    @staticmethod
+    def get_segment_metadata_details(
+        session: Session, dataset: Dataset, document: Document, segment: DocumentSegment
+    ) -> list[dict[str, Any]]:
+        metadata_definitions = session.scalars(
+            select(DatasetMetadata).where(DatasetMetadata.dataset_id == dataset.id)
+        ).all()
+        override_bindings = session.scalars(
+            select(SegmentMetadataBinding).where(SegmentMetadataBinding.segment_id == segment.id)
+        ).all()
+        override_by_metadata_id = {binding.metadata_id: binding for binding in override_bindings}
+        document_metadata = MetadataService._get_document_default_metadata(dataset, document, session=session)
+        effective_metadata = segment.effective_metadata or {}
+
+        details: list[dict[str, Any]] = []
+        for metadata in metadata_definitions:
+            details.append(
+                {
+                    "id": metadata.id,
+                    "name": metadata.name,
+                    "type": metadata.type,
+                    "value": effective_metadata.get(metadata.name, document_metadata.get(metadata.name)),
+                    "source": "override" if metadata.id in override_by_metadata_id else "inherited",
+                }
+            )
+
+        if dataset.built_in_field_enabled:
+            for built_in_field in MetadataService.get_built_in_fields():
+                details.append(
+                    {
+                        "id": "built-in",
+                        "name": built_in_field["name"],
+                        "type": built_in_field["type"],
+                        "value": document_metadata.get(built_in_field["name"]),
+                        "source": "built_in",
+                    }
+                )
+        return details
+
+    @staticmethod
+    def _write_segment_metadata_overrides(
+        session: Session,
+        dataset: Dataset,
+        document: Document,
+        segment: DocumentSegment,
+        metadata_updates: list[MetadataUpdateArgs],
+        current_user: Account,
+        current_tenant_id: str,
+    ) -> None:
+        if segment.dataset_id != dataset.id or segment.document_id != document.id:
+            raise ValueError("Segment does not belong to the specified document.")
+
+        built_in_names = {field["name"] for field in MetadataService.get_built_in_fields()}
+        metadata_by_name = {
+            metadata.name: metadata
+            for metadata in session.scalars(
+                select(DatasetMetadata).where(DatasetMetadata.dataset_id == dataset.id)
+            ).all()
+        }
+        document_metadata = MetadataService._get_document_default_metadata(dataset, document, session=session)
+
+        for metadata_update in metadata_updates:
+            metadata_name = metadata_update.name
+            if metadata_name in built_in_names:
+                raise ValueError(f"Built-in metadata '{metadata_name}' cannot be overridden at segment level.")
+            metadata = metadata_by_name.get(metadata_name)
+            if metadata is None:
+                raise ValueError(f"Metadata '{metadata_name}' is not defined in this dataset.")
+
+            existing_binding = session.scalar(
+                select(SegmentMetadataBinding)
+                .where(
+                    SegmentMetadataBinding.segment_id == segment.id,
+                    SegmentMetadataBinding.metadata_id == metadata.id,
+                )
+                .limit(1)
+            )
+            if (
+                metadata_update.value is not None
+                and metadata_name in document_metadata
+                and metadata_update.value == document_metadata[metadata_name]
+            ):
+                if existing_binding:
+                    session.delete(existing_binding)
+                continue
+
+            if existing_binding:
+                existing_binding.value_json = metadata_update.value
+                existing_binding.updated_by = current_user.id
+                existing_binding.updated_at = naive_utc_now()
+                session.add(existing_binding)
+            else:
+                session.add(
+                    SegmentMetadataBinding(
+                        tenant_id=current_tenant_id,
+                        dataset_id=dataset.id,
+                        document_id=document.id,
+                        segment_id=segment.id,
+                        metadata_id=metadata.id,
+                        value_json=metadata_update.value,
+                        created_by=current_user.id,
+                        updated_by=current_user.id,
+                    )
+                )
+
+    @staticmethod
+    def apply_segment_metadata_override(
+        session: Session,
+        dataset: Dataset,
+        document: Document,
+        segment: DocumentSegment,
+        metadata_updates: list[MetadataUpdateArgs],
+        current_user: Account | None = None,
+        current_tenant_id: str | None = None,
+    ) -> None:
+        current_user, current_tenant_id = resolve_account_fallback(
+            current_user, current_tenant_id, fallback_tenant_id=dataset.tenant_id
+        )
+        MetadataService._write_segment_metadata_overrides(
+            session, dataset, document, segment, metadata_updates, current_user, current_tenant_id
+        )
+        session.flush()
+        MetadataService.rebuild_segment_effective_metadata(session, dataset, document, segment_ids=[segment.id])
+
+    @staticmethod
+    def reset_segment_metadata_fields_to_document(
+        session: Session,
+        dataset: Dataset,
+        document: Document,
+        segment: DocumentSegment,
+        field_names: list[str],
+    ) -> None:
+        metadata_by_name = {
+            metadata.name: metadata.id
+            for metadata in session.scalars(
+                select(DatasetMetadata).where(DatasetMetadata.dataset_id == dataset.id)
+            ).all()
+        }
+        metadata_ids = [metadata_by_name[name] for name in field_names if name in metadata_by_name]
+        if metadata_ids:
+            session.execute(
+                delete(SegmentMetadataBinding).where(
+                    SegmentMetadataBinding.segment_id == segment.id,
+                    SegmentMetadataBinding.metadata_id.in_(metadata_ids),
+                )
+            )
+        session.flush()
+        MetadataService.rebuild_segment_effective_metadata(session, dataset, document, segment_ids=[segment.id])
+
+    @staticmethod
+    def batch_update_segments_metadata(
+        session: Session,
+        dataset: Dataset,
+        document: Document,
+        segment_ids: list[str],
+        metadata_updates: list[MetadataUpdateArgs],
+        current_user: Account | None = None,
+        current_tenant_id: str | None = None,
+    ) -> None:
+        current_user, current_tenant_id = resolve_account_fallback(
+            current_user, current_tenant_id, fallback_tenant_id=dataset.tenant_id
+        )
+        segments = session.scalars(
+            select(DocumentSegment).where(
+                DocumentSegment.document_id == document.id,
+                DocumentSegment.id.in_(segment_ids),
+            )
+        ).all()
+        found_ids = {segment.id for segment in segments}
+        missing_ids = sorted(set(segment_ids) - found_ids)
+        if missing_ids:
+            raise ValueError(f"Segments not found in document: {', '.join(missing_ids)}")
+        for segment in segments:
+            MetadataService._write_segment_metadata_overrides(
+                session, dataset, document, segment, metadata_updates, current_user, current_tenant_id
+            )
+        session.flush()
+        MetadataService.rebuild_segment_effective_metadata(session, dataset, document, segment_ids=segment_ids)
+
     @staticmethod
     def create_metadata(
         dataset_id: str,
         metadata_args: MetadataArgs,
-        current_user: Account | None = None,  # TODO: the service_api is not migrated yet
+        current_user: Account | None = None,
         current_tenant_id: str | None = None,
         *,
         session: Session,
     ) -> DatasetMetadata:
-        # check if metadata name is too long
         if len(metadata_args.name) > 255:
             raise ValueError("Metadata name cannot exceed 255 characters.")
         current_user, current_tenant_id = resolve_account_fallback(current_user, current_tenant_id)
-        # check if metadata name already exists
         if session.scalar(
             select(DatasetMetadata)
             .where(
@@ -45,9 +356,8 @@ class MetadataService:
             .limit(1)
         ):
             raise ValueError("Metadata name already exists.")
-        for field in BuiltInField:
-            if field.value == metadata_args.name:
-                raise ValueError("Metadata name already exists in Built-in fields.")
+        if any(field.value == metadata_args.name for field in BuiltInField):
+            raise ValueError("Metadata name already exists in Built-in fields.")
         metadata = DatasetMetadata(
             tenant_id=current_tenant_id,
             dataset_id=dataset_id,
@@ -65,16 +375,12 @@ class MetadataService:
         metadata_id: str,
         name: str,
         current_user: Account | None = None,
-        current_tenant_id: str | None = None,  # TODO: the service_api is not migrated yet
+        current_tenant_id: str | None = None,
         *,
         session: Session,
     ) -> DatasetMetadata | None:
-        # check if metadata name is too long
         if len(name) > 255:
             raise ValueError("Metadata name cannot exceed 255 characters.")
-
-        lock_key = f"dataset_metadata_lock_{dataset_id}"
-        # check if metadata name already exists
         current_user, current_tenant_id = resolve_account_fallback(current_user, current_tenant_id)
         if session.scalar(
             select(DatasetMetadata)
@@ -82,89 +388,105 @@ class MetadataService:
                 DatasetMetadata.tenant_id == current_tenant_id,
                 DatasetMetadata.dataset_id == dataset_id,
                 DatasetMetadata.name == name,
+                DatasetMetadata.id != metadata_id,
             )
             .limit(1)
         ):
             raise ValueError("Metadata name already exists.")
-        for field in BuiltInField:
-            if field.value == name:
-                raise ValueError("Metadata name already exists in Built-in fields.")
-        try:
-            MetadataService.knowledge_base_metadata_lock_check(dataset_id, None)
-            metadata = session.scalar(
-                select(DatasetMetadata)
-                .where(DatasetMetadata.id == metadata_id, DatasetMetadata.dataset_id == dataset_id)
-                .limit(1)
-            )
-            if metadata is None:
-                raise ValueError("Metadata not found.")
-            old_name = metadata.name
-            metadata.name = name
-            metadata.updated_by = current_user.id
-            metadata.updated_at = naive_utc_now()
+        if any(field.value == name for field in BuiltInField):
+            raise ValueError("Metadata name already exists in Built-in fields.")
 
-            # update related documents
-            dataset_metadata_bindings = session.scalars(
-                select(DatasetMetadataBinding).where(DatasetMetadataBinding.metadata_id == metadata_id)
-            ).all()
-            if dataset_metadata_bindings:
-                document_ids = [binding.document_id for binding in dataset_metadata_bindings]
-                documents = DocumentService.get_document_by_ids(document_ids, session)
-                for document in documents:
-                    if not document.doc_metadata:
-                        doc_metadata = {}
-                    else:
-                        doc_metadata = copy.deepcopy(document.doc_metadata)
-                    value = doc_metadata.pop(old_name, None)
-                    doc_metadata[name] = value
-                    document.doc_metadata = doc_metadata
-                    session.add(document)
-            session.commit()
-            return metadata
+        try:
+            with MetadataService.metadata_lock(dataset_id=dataset_id):
+                metadata = session.scalar(
+                    select(DatasetMetadata)
+                    .where(DatasetMetadata.id == metadata_id, DatasetMetadata.dataset_id == dataset_id)
+                    .limit(1)
+                )
+                if metadata is None:
+                    raise ValueError("Metadata not found.")
+                old_name = metadata.name
+                metadata.name = name
+                metadata.updated_by = current_user.id
+                metadata.updated_at = naive_utc_now()
+
+                document_ids = set(
+                    session.scalars(
+                        select(DatasetMetadataBinding.document_id).where(
+                            DatasetMetadataBinding.metadata_id == metadata_id
+                        )
+                    ).all()
+                )
+                document_ids.update(
+                    session.scalars(
+                        select(SegmentMetadataBinding.document_id).where(
+                            SegmentMetadataBinding.metadata_id == metadata_id
+                        )
+                    ).all()
+                )
+                session.flush()
+                for document in DocumentService.get_document_by_ids(list(document_ids), session):
+                    doc_metadata = copy.deepcopy(document.doc_metadata) if document.doc_metadata else {}
+                    if old_name in doc_metadata:
+                        doc_metadata[name] = doc_metadata.pop(old_name)
+                        document.doc_metadata = doc_metadata
+                        session.add(document)
+                    dataset = session.get(Dataset, document.dataset_id)
+                    if dataset:
+                        MetadataService.rebuild_segment_effective_metadata(session, dataset, document)
+                session.commit()
+                return metadata
         except Exception:
+            session.rollback()
             logger.exception("Update metadata name failed")
             return None
-        finally:
-            redis_client.delete(lock_key)
 
     @staticmethod
     def delete_metadata(dataset_id: str, metadata_id: str, session: Session):
-        lock_key = f"dataset_metadata_lock_{dataset_id}"
         try:
-            MetadataService.knowledge_base_metadata_lock_check(dataset_id, None)
-            metadata = session.scalar(
-                select(DatasetMetadata)
-                .where(DatasetMetadata.id == metadata_id, DatasetMetadata.dataset_id == dataset_id)
-                .limit(1)
-            )
-            if metadata is None:
-                raise ValueError("Metadata not found.")
-            session.delete(metadata)
-
-            # deal related documents
-            dataset_metadata_bindings = session.scalars(
-                select(DatasetMetadataBinding).where(DatasetMetadataBinding.metadata_id == metadata_id)
-            ).all()
-            if dataset_metadata_bindings:
-                document_ids = [binding.document_id for binding in dataset_metadata_bindings]
-                documents = DocumentService.get_document_by_ids(document_ids, session)
-                for document in documents:
-                    if not document.doc_metadata:
-                        doc_metadata = {}
-                    else:
-                        doc_metadata = copy.deepcopy(document.doc_metadata)
+            with MetadataService.metadata_lock(dataset_id=dataset_id):
+                metadata = session.scalar(
+                    select(DatasetMetadata)
+                    .where(DatasetMetadata.id == metadata_id, DatasetMetadata.dataset_id == dataset_id)
+                    .limit(1)
+                )
+                if metadata is None:
+                    raise ValueError("Metadata not found.")
+                document_ids = set(
+                    session.scalars(
+                        select(DatasetMetadataBinding.document_id).where(
+                            DatasetMetadataBinding.metadata_id == metadata_id
+                        )
+                    ).all()
+                )
+                document_ids.update(
+                    session.scalars(
+                        select(SegmentMetadataBinding.document_id).where(
+                            SegmentMetadataBinding.metadata_id == metadata_id
+                        )
+                    ).all()
+                )
+                session.execute(delete(SegmentMetadataBinding).where(SegmentMetadataBinding.metadata_id == metadata_id))
+                session.execute(delete(DatasetMetadataBinding).where(DatasetMetadataBinding.metadata_id == metadata_id))
+                session.flush()
+                for document in DocumentService.get_document_by_ids(list(document_ids), session):
+                    doc_metadata = copy.deepcopy(document.doc_metadata) if document.doc_metadata else {}
                     doc_metadata.pop(metadata.name, None)
                     document.doc_metadata = doc_metadata
                     session.add(document)
-            session.commit()
-            return metadata
+                    dataset = session.get(Dataset, document.dataset_id)
+                    if dataset:
+                        MetadataService.rebuild_segment_effective_metadata(session, dataset, document)
+                session.delete(metadata)
+                session.commit()
+                return metadata
         except Exception:
+            session.rollback()
             logger.exception("Delete metadata failed")
-        finally:
-            redis_client.delete(lock_key)
+            return None
 
     @staticmethod
-    def get_built_in_fields():
+    def get_built_in_fields() -> list[dict[str, str]]:
         return [
             {"name": BuiltInField.document_name, "type": DatasetMetadataType.STRING},
             {"name": BuiltInField.uploader, "type": DatasetMetadataType.STRING},
@@ -174,110 +496,81 @@ class MetadataService:
         ]
 
     @staticmethod
-    def enable_built_in_field(dataset: Dataset, session: Session):
+    def enable_built_in_field(dataset: Dataset, session: Session) -> None:
         if dataset.built_in_field_enabled:
             return
-        lock_key = f"dataset_metadata_lock_{dataset.id}"
         try:
-            MetadataService.knowledge_base_metadata_lock_check(dataset.id, None)
-            session.add(dataset)
-            documents = DocumentService.get_working_documents_by_dataset_id(dataset.id, session)
-            if documents:
-                for document in documents:
-                    if not document.doc_metadata:
-                        doc_metadata = {}
-                    else:
-                        doc_metadata = copy.deepcopy(document.doc_metadata)
-                    doc_metadata[BuiltInField.document_name] = document.name
-                    doc_metadata[BuiltInField.uploader] = document.get_uploader(session=session)
-                    doc_metadata[BuiltInField.upload_date] = document.upload_date.timestamp()
-                    doc_metadata[BuiltInField.last_update_date] = document.last_update_date.timestamp()
-                    doc_metadata[BuiltInField.source] = MetadataDataSource[document.data_source_type]
+            with MetadataService.metadata_lock(dataset_id=dataset.id):
+                dataset.built_in_field_enabled = True
+                session.add(dataset)
+                for document in DocumentService.get_working_documents_by_dataset_id(dataset.id, session):
+                    doc_metadata = copy.deepcopy(document.doc_metadata) if document.doc_metadata else {}
+                    doc_metadata.update(MetadataService._get_built_in_metadata(document, session=session))
                     document.doc_metadata = doc_metadata
                     session.add(document)
-            dataset.built_in_field_enabled = True
-            session.commit()
+                    MetadataService.rebuild_segment_effective_metadata(session, dataset, document)
+                session.commit()
         except Exception:
+            session.rollback()
             logger.exception("Enable built-in field failed")
-        finally:
-            redis_client.delete(lock_key)
 
     @staticmethod
-    def disable_built_in_field(dataset: Dataset, session: Session):
+    def disable_built_in_field(dataset: Dataset, session: Session) -> None:
         if not dataset.built_in_field_enabled:
             return
-        lock_key = f"dataset_metadata_lock_{dataset.id}"
         try:
-            MetadataService.knowledge_base_metadata_lock_check(dataset.id, None)
-            session.add(dataset)
-            documents = DocumentService.get_working_documents_by_dataset_id(dataset.id, session)
-            document_ids = []
-            if documents:
-                for document in documents:
-                    if not document.doc_metadata:
-                        doc_metadata = {}
-                    else:
-                        doc_metadata = copy.deepcopy(document.doc_metadata)
-                    doc_metadata.pop(BuiltInField.document_name, None)
-                    doc_metadata.pop(BuiltInField.uploader, None)
-                    doc_metadata.pop(BuiltInField.upload_date, None)
-                    doc_metadata.pop(BuiltInField.last_update_date, None)
-                    doc_metadata.pop(BuiltInField.source, None)
+            with MetadataService.metadata_lock(dataset_id=dataset.id):
+                dataset.built_in_field_enabled = False
+                session.add(dataset)
+                for document in DocumentService.get_working_documents_by_dataset_id(dataset.id, session):
+                    doc_metadata = copy.deepcopy(document.doc_metadata) if document.doc_metadata else {}
+                    for field in BuiltInField:
+                        doc_metadata.pop(field.value, None)
                     document.doc_metadata = doc_metadata
                     session.add(document)
-                    document_ids.append(document.id)
-            dataset.built_in_field_enabled = False
-            session.commit()
+                    MetadataService.rebuild_segment_effective_metadata(session, dataset, document)
+                session.commit()
         except Exception:
+            session.rollback()
             logger.exception("Disable built-in field failed")
-        finally:
-            redis_client.delete(lock_key)
 
     @staticmethod
     def update_documents_metadata(
         dataset: Dataset,
         metadata_args: MetadataOperationData,
-        current_user: Account | None = None,  # TODO: the service_api is not migrated yet
+        current_user: Account | None = None,
         current_tenant_id: str | None = None,
         *,
         session: Session,
-    ):
+    ) -> None:
         current_user, current_tenant_id = resolve_account_fallback(
             current_user, current_tenant_id, fallback_tenant_id=dataset.tenant_id
         )
         for operation in metadata_args.operation_data:
-            lock_key = f"document_metadata_lock_{operation.document_id}"
             try:
-                MetadataService.knowledge_base_metadata_lock_check(None, operation.document_id)
-                document = DocumentService.get_document(dataset.id, operation.document_id, session=session)
-                if document is None:
-                    raise ValueError("Document not found.")
-                if operation.partial_update:
-                    doc_metadata = copy.deepcopy(document.doc_metadata) if document.doc_metadata else {}
-                else:
-                    doc_metadata = {}
-                for metadata_value in operation.metadata_list:
-                    doc_metadata[metadata_value.name] = metadata_value.value
-                if dataset.built_in_field_enabled:
-                    doc_metadata[BuiltInField.document_name] = document.name
-                    doc_metadata[BuiltInField.uploader] = document.get_uploader(session=session)
-                    doc_metadata[BuiltInField.upload_date] = document.upload_date.timestamp()
-                    doc_metadata[BuiltInField.last_update_date] = document.last_update_date.timestamp()
-                    doc_metadata[BuiltInField.source] = MetadataDataSource[document.data_source_type]
-                document.doc_metadata = doc_metadata
-                session.add(document)
-
-                # deal metadata binding (in the same transaction as the doc_metadata update)
-                if not operation.partial_update:
-                    session.execute(
-                        delete(DatasetMetadataBinding).where(
-                            DatasetMetadataBinding.document_id == operation.document_id
-                        )
+                with MetadataService.metadata_lock(dataset_id=dataset.id, document_id=operation.document_id):
+                    document = DocumentService.get_document(dataset.id, operation.document_id, session=session)
+                    if document is None:
+                        raise ValueError("Document not found.")
+                    doc_metadata = (
+                        copy.deepcopy(document.doc_metadata)
+                        if operation.partial_update and document.doc_metadata
+                        else {}
                     )
+                    for metadata_value in operation.metadata_list:
+                        doc_metadata[metadata_value.name] = metadata_value.value
+                    if dataset.built_in_field_enabled:
+                        doc_metadata.update(MetadataService._get_built_in_metadata(document, session=session))
+                    document.doc_metadata = doc_metadata
+                    session.add(document)
 
-                for metadata_value in operation.metadata_list:
-                    # check if binding already exists
-                    if operation.partial_update:
+                    if not operation.partial_update:
+                        session.execute(
+                            delete(DatasetMetadataBinding).where(
+                                DatasetMetadataBinding.document_id == operation.document_id
+                            )
+                        )
+                    for metadata_value in operation.metadata_list:
                         existing_binding = session.scalar(
                             select(DatasetMetadataBinding)
                             .where(
@@ -288,35 +581,58 @@ class MetadataService:
                         )
                         if existing_binding:
                             continue
-
-                    dataset_metadata_binding = DatasetMetadataBinding(
-                        tenant_id=current_tenant_id,
-                        dataset_id=dataset.id,
-                        document_id=operation.document_id,
-                        metadata_id=metadata_value.id,
-                        created_by=current_user.id,
+                        session.add(
+                            DatasetMetadataBinding(
+                                tenant_id=current_tenant_id,
+                                dataset_id=dataset.id,
+                                document_id=operation.document_id,
+                                metadata_id=metadata_value.id,
+                                created_by=current_user.id,
+                            )
+                        )
+                    MetadataService.apply_document_metadata_to_segments(
+                        session,
+                        dataset,
+                        document,
+                        changed_fields=[item.name for item in operation.metadata_list],
                     )
-                    session.add(dataset_metadata_binding)
-                session.commit()
+                    session.commit()
             except Exception:
                 session.rollback()
                 logger.exception("Update documents metadata failed")
                 raise
-            finally:
-                redis_client.delete(lock_key)
 
     @staticmethod
-    def knowledge_base_metadata_lock_check(dataset_id: str | None, document_id: str | None):
+    def knowledge_base_metadata_lock_check(dataset_id: str | None, document_id: str | None) -> list[tuple[str, str]]:
+        lock_specs: list[tuple[str, str]] = []
         if dataset_id:
-            lock_key = f"dataset_metadata_lock_{dataset_id}"
-            if redis_client.get(lock_key):
-                raise ValueError("Another knowledge base metadata operation is running, please wait a moment.")
-            redis_client.set(lock_key, 1, ex=3600)
+            lock_specs.append((f"dataset_metadata_lock_{dataset_id}", "knowledge base"))
         if document_id:
-            lock_key = f"document_metadata_lock_{document_id}"
-            if redis_client.get(lock_key):
-                raise ValueError("Another document metadata operation is running, please wait a moment.")
-            redis_client.set(lock_key, 1, ex=3600)
+            lock_specs.append((f"document_metadata_lock_{document_id}", "document"))
+
+        acquired: list[tuple[str, str]] = []
+        for lock_key, scope_name in lock_specs:
+            token = str(uuid4())
+            if redis_client.set(lock_key, token, nx=True, ex=MetadataService._LOCK_TTL_SECONDS):
+                acquired.append((lock_key, token))
+                continue
+            MetadataService._release_metadata_locks(acquired)
+            raise ValueError(f"Another {scope_name} metadata operation is running, please wait a moment.")
+        return acquired
+
+    @staticmethod
+    def _release_metadata_locks(acquired: list[tuple[str, str]]) -> None:
+        for lock_key, token in reversed(acquired):
+            redis_client.eval(MetadataService._LOCK_RELEASE_SCRIPT, 1, lock_key, token)
+
+    @staticmethod
+    @contextmanager
+    def metadata_lock(dataset_id: str | None = None, document_id: str | None = None) -> Generator[None, None, None]:
+        acquired = MetadataService.knowledge_base_metadata_lock_check(dataset_id, document_id)
+        try:
+            yield
+        finally:
+            MetadataService._release_metadata_locks(acquired)
 
     @staticmethod
     def get_dataset_metadatas(dataset: Dataset, session: Session):

--- a/api/tasks/batch_create_segment_to_index_task.py
+++ b/api/tasks/batch_create_segment_to_index_task.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import tempfile
 import time
@@ -89,6 +90,7 @@ def batch_create_segment_to_index_task(
                 "id": dataset_document.id,
                 "doc_form": dataset_document.doc_form,
                 "word_count": dataset_document.word_count or 0,
+                "doc_metadata": copy.deepcopy(dataset_document.doc_metadata) if dataset_document.doc_metadata else {},
             }
 
             upload_file_key = upload_file.key
@@ -138,6 +140,8 @@ def batch_create_segment_to_index_task(
         tokens_list = [0] * len(content)
 
     with session_factory.create_session() as session, session.begin():
+        effective_metadata = document_config["doc_metadata"]
+        security_level = effective_metadata.get("security_level")
         for segment, tokens in zip(content, tokens_list):
             content = segment["content"]
             doc_id = str(uuid.uuid4())
@@ -159,6 +163,8 @@ def batch_create_segment_to_index_task(
                 indexing_at=naive_utc_now(),
                 status=SegmentStatus.COMPLETED,
                 completed_at=naive_utc_now(),
+                effective_metadata=copy.deepcopy(effective_metadata),
+                effective_security_level=security_level if isinstance(security_level, str) else None,
             )
             if document_config["doc_form"] == IndexStructureType.QA_INDEX:
                 segment_document.answer = segment["answer"]

--- a/api/tests/test_containers_integration_tests/services/test_metadata_service.py
+++ b/api/tests/test_containers_integration_tests/services/test_metadata_service.py
@@ -941,7 +941,6 @@ class TestMetadataService:
         Test metadata lock check for dataset operations.
         """
         # Arrange: Setup mocks
-        mock_external_service_dependencies["redis_client"].get.return_value = None
         mock_external_service_dependencies["redis_client"].set.return_value = True
 
         dataset_id = "test-dataset-id"
@@ -956,6 +955,7 @@ class TestMetadataService:
         # Verify lock key format
         call_args = mock_external_service_dependencies["redis_client"].set.call_args
         assert call_args[0][0] == f"dataset_metadata_lock_{dataset_id}"
+        assert call_args.kwargs == {"nx": True, "ex": MetadataService._LOCK_TTL_SECONDS}
 
     def test_knowledge_base_metadata_lock_check_document_id(
         self, db_session_with_containers: Session, mock_external_service_dependencies: MetadataServiceDeps
@@ -964,7 +964,6 @@ class TestMetadataService:
         Test metadata lock check for document operations.
         """
         # Arrange: Setup mocks
-        mock_external_service_dependencies["redis_client"].get.return_value = None
         mock_external_service_dependencies["redis_client"].set.return_value = True
 
         document_id = "test-document-id"
@@ -979,6 +978,7 @@ class TestMetadataService:
         # Verify lock key format
         call_args = mock_external_service_dependencies["redis_client"].set.call_args
         assert call_args[0][0] == f"document_metadata_lock_{document_id}"
+        assert call_args.kwargs == {"nx": True, "ex": MetadataService._LOCK_TTL_SECONDS}
 
     def test_knowledge_base_metadata_lock_check_lock_exists(
         self, db_session_with_containers: Session, mock_external_service_dependencies: MetadataServiceDeps
@@ -987,7 +987,7 @@ class TestMetadataService:
         Test metadata lock check when lock already exists.
         """
         # Arrange: Setup mocks to simulate existing lock
-        mock_external_service_dependencies["redis_client"].get.return_value = "1"  # Lock exists
+        mock_external_service_dependencies["redis_client"].set.return_value = False
 
         dataset_id = "test-dataset-id"
 
@@ -1004,7 +1004,7 @@ class TestMetadataService:
         Test metadata lock check when document lock already exists.
         """
         # Arrange: Setup mocks to simulate existing lock
-        mock_external_service_dependencies["redis_client"].get.return_value = "1"  # Lock exists
+        mock_external_service_dependencies["redis_client"].set.return_value = False
 
         document_id = "test-document-id"
 

--- a/api/tests/unit_tests/controllers/console/datasets/test_datasets_document.py
+++ b/api/tests/unit_tests/controllers/console/datasets/test_datasets_document.py
@@ -640,9 +640,16 @@ class TestDocumentMetadataApi:
                 "controllers.console.datasets.datasets_document.DocumentService.DOCUMENT_METADATA_SCHEMA",
                 {"invoice": schema},
             ),
+            patch(
+                "controllers.console.datasets.datasets_document.DatasetService.get_dataset",
+                return_value=make_dataset(),
+            ),
+            patch("controllers.console.datasets.datasets_document.MetadataService.metadata_lock"),
+            patch("controllers.console.datasets.datasets_document.MetadataService.apply_document_metadata_to_segments"),
         ):
             method(api, req_data, session, tenant_id, user, "ds-1", "doc-1")
         assert doc.doc_metadata == {"amount": 10}
+        session.commit.assert_called_once()
 
     def test_put_success(self, app: Flask, patch_tenant):
         api = DocumentMetadataApi()
@@ -659,9 +666,16 @@ class TestDocumentMetadataApi:
                 "controllers.console.datasets.datasets_document.DocumentService.DOCUMENT_METADATA_SCHEMA",
                 {"others": {}},
             ),
+            patch(
+                "controllers.console.datasets.datasets_document.DatasetService.get_dataset",
+                return_value=make_dataset(),
+            ),
+            patch("controllers.console.datasets.datasets_document.MetadataService.metadata_lock"),
+            patch("controllers.console.datasets.datasets_document.MetadataService.apply_document_metadata_to_segments"),
         ):
             response, status = method(api, req_data, session, tenant_id, user, "ds-1", "doc-1")
         assert status == 200
+        session.commit.assert_called_once()
 
     def test_put_invalid_payload(self, app: Flask, patch_tenant):
         api = DocumentMetadataApi()
@@ -1234,6 +1248,8 @@ class TestDocumentRenameApi:
                 "controllers.console.datasets.datasets_document.DocumentService.rename_document",
                 return_value=renamed_document,
             ),
+            patch("controllers.console.datasets.datasets_document.MetadataService.metadata_lock"),
+            patch("controllers.console.datasets.datasets_document.MetadataService.apply_document_metadata_to_segments"),
         ):
             response = method(api, session, user, "ds-1", "doc-1")
         assert response["id"] == "doc-renamed"
@@ -1241,6 +1257,7 @@ class TestDocumentRenameApi:
         assert response["data_source_info"] == {}
         assert response["doc_metadata"] == []
         assert "data_source_info_dict" not in response
+        session.commit.assert_called_once()
 
 
 class TestDocumentApiMetadata:
@@ -1442,10 +1459,17 @@ class TestDocumentListAdvancedCases:
                 "controllers.console.datasets.datasets_document.DocumentService.DOCUMENT_METADATA_SCHEMA",
                 {"contract": schema},
             ),
+            patch(
+                "controllers.console.datasets.datasets_document.DatasetService.get_dataset",
+                return_value=make_dataset(),
+            ),
+            patch("controllers.console.datasets.datasets_document.MetadataService.metadata_lock"),
+            patch("controllers.console.datasets.datasets_document.MetadataService.apply_document_metadata_to_segments"),
         ):
             response, status = method(api, req_data, session, tenant_id, user, "ds-1", "doc-1")
             assert status == 200
             assert doc.doc_metadata == {"amount": 5000, "currency": "USD"}
+            session.commit.assert_called_once()
 
 
 class TestDocumentIndexingEdgeCases:

--- a/api/tests/unit_tests/core/rag/datasource/keyword/jieba/test_jieba.py
+++ b/api/tests/unit_tests/core/rag/datasource/keyword/jieba/test_jieba.py
@@ -204,12 +204,19 @@ def test_search_returns_documents_in_rank_order_and_applies_filter(monkeypatch: 
     patched_runtime.session.flush()
     monkeypatch.setattr(keyword, "_retrieve_ids_by_query", MagicMock(return_value=["node-1", "node-2"]))
 
-    documents = keyword.search("query", session=patched_runtime.session, top_k=2, document_ids_filter=["doc-2"])
+    documents = keyword.search(
+        "query",
+        session=patched_runtime.session,
+        top_k=1,
+        document_ids_filter=["doc-2"],
+        index_node_ids_filter=["node-2"],
+    )
 
     assert len(documents) == 1
     assert documents[0].page_content == "segment-content"
     assert documents[0].metadata["doc_id"] == "node-2"
     assert documents[0].metadata["doc_hash"] == "hash-2"
+    keyword._retrieve_ids_by_query.assert_called_once_with({}, "query", None)
 
 
 def test_delete_removes_keyword_table_and_optional_file(patched_runtime):
@@ -324,6 +331,14 @@ def test_retrieve_ids_by_query_ranks_by_keyword_frequency(monkeypatch: pytest.Mo
     )
 
     assert ranked_ids == ["node-2"]
+
+    all_ranked_ids = keyword._retrieve_ids_by_query(
+        {"kw-a": {"node-1", "node-2"}, "kw-b": {"node-2"}, "kw-c": {"node-3"}},
+        "query",
+        k=None,
+    )
+
+    assert all_ranked_ids == ["node-2", "node-1"]
 
 
 def test_update_segment_keywords_updates_when_segment_exists(patched_runtime):

--- a/api/tests/unit_tests/core/rag/datasource/vdb/test_vector_factory.py
+++ b/api/tests/unit_tests/core/rag/datasource/vdb/test_vector_factory.py
@@ -493,6 +493,72 @@ def test_vector_delegation_methods(vector_factory_module):
     vector._vector_processor.delete_by_metadata_field.assert_called_once_with("doc_id", "doc-1")
 
 
+def test_chunk_filter_fallback_is_fail_closed_for_unsupported_backends(vector_factory_module):
+    vector = vector_factory_module.Vector.__new__(vector_factory_module.Vector)
+    vector._vector_processor = MagicMock(supports_index_node_ids_filter=False)
+    search = MagicMock(
+        side_effect=[
+            [
+                Document(
+                    page_content="inherited",
+                    metadata={"doc_id": "node-public", "document_id": "doc-public", "score": 0.8},
+                )
+            ],
+            [
+                Document(
+                    page_content="override",
+                    metadata={"doc_id": "node-override", "document_id": "doc-mixed", "score": 0.9},
+                ),
+                Document(
+                    page_content="denied",
+                    metadata={"doc_id": "node-denied", "document_id": "doc-mixed", "score": 1.0},
+                ),
+            ],
+        ]
+    )
+
+    result = vector._search_with_metadata_filters(
+        search,
+        [0.1, 0.2],
+        {
+            "top_k": 5,
+            "document_ids_filter": ["doc-public"],
+            "index_node_ids_filter": ["node-override"],
+        },
+    )
+
+    assert [document.metadata["doc_id"] for document in result] == ["node-override", "node-public"]
+    assert search.call_count == 2
+    assert "index_node_ids_filter" not in search.call_args_list[0].kwargs
+    assert "document_ids_filter" not in search.call_args_list[1].kwargs
+
+
+def test_native_chunk_filter_is_still_post_filtered(vector_factory_module):
+    vector = vector_factory_module.Vector.__new__(vector_factory_module.Vector)
+    vector._vector_processor = MagicMock(supports_index_node_ids_filter=True)
+    search = MagicMock(
+        return_value=[
+            Document(
+                page_content="allowed",
+                metadata={"doc_id": "node-allowed", "document_id": "doc-mixed", "score": 0.8},
+            ),
+            Document(
+                page_content="unexpected",
+                metadata={"doc_id": "node-denied", "document_id": "doc-mixed", "score": 0.9},
+            ),
+        ]
+    )
+
+    result = vector._search_with_metadata_filters(
+        search,
+        "query",
+        {"top_k": 4, "index_node_ids_filter": ["node-allowed"]},
+    )
+
+    assert [document.metadata["doc_id"] for document in result] == ["node-allowed"]
+    search.assert_called_once_with("query", top_k=4, index_node_ids_filter=["node-allowed"])
+
+
 def test_search_by_file_handles_missing_and_existing_upload(
     vector_factory_module, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
 ):

--- a/api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py
+++ b/api/tests/unit_tests/core/rag/retrieval/test_dataset_retrieval.py
@@ -2594,7 +2594,7 @@ class TestDatasetRetrievalKnowledgeRetrieval:
                 dataset_retrieval, "_get_available_datasets", return_value=[mock_dataset1, mock_dataset2]
             ):
                 # Mock get_metadata_filter_condition
-                with patch.object(dataset_retrieval, "get_metadata_filter_condition", return_value=(None, None)):
+                with patch.object(dataset_retrieval, "get_metadata_filter_condition", return_value=(None, None, None)):
                     # Mock multiple_retrieve to return documents
                     doc1 = create_mock_document_methods("Python is great", "doc1", score=0.9)
                     doc2 = create_mock_document_methods("Python is awesome", "doc2", score=0.8)
@@ -2691,7 +2691,7 @@ class TestDatasetRetrievalKnowledgeRetrieval:
                 with patch.object(
                     dataset_retrieval,
                     "get_metadata_filter_condition",
-                    return_value=(None, None),
+                    return_value=(None, None, None),
                 ) as mock_get_metadata:
                     with patch.object(dataset_retrieval, "multiple_retrieve", return_value=[]):
                         # Act
@@ -2737,7 +2737,7 @@ class TestDatasetRetrievalKnowledgeRetrieval:
         with patch.object(dataset_retrieval, "_check_knowledge_rate_limit"):
             mock_dataset = create_mock_dataset_methods(dataset_id=dataset_id, tenant_id=tenant_id, provider="external")
             with patch.object(dataset_retrieval, "_get_available_datasets", return_value=[mock_dataset]):
-                with patch.object(dataset_retrieval, "get_metadata_filter_condition", return_value=(None, None)):
+                with patch.object(dataset_retrieval, "get_metadata_filter_condition", return_value=(None, None, None)):
                     # Create external document
                     external_doc = create_mock_document_methods(
                         "External knowledge",
@@ -2792,7 +2792,7 @@ class TestDatasetRetrievalKnowledgeRetrieval:
         with patch.object(dataset_retrieval, "_check_knowledge_rate_limit"):
             mock_dataset = create_mock_dataset_methods(dataset_id=dataset_id, tenant_id=tenant_id)
             with patch.object(dataset_retrieval, "_get_available_datasets", return_value=[mock_dataset]):
-                with patch.object(dataset_retrieval, "get_metadata_filter_condition", return_value=(None, None)):
+                with patch.object(dataset_retrieval, "get_metadata_filter_condition", return_value=(None, None, None)):
                     # Mock multiple_retrieve to return empty list
                     with patch.object(dataset_retrieval, "multiple_retrieve", return_value=[]):
                         # Act
@@ -4366,12 +4366,15 @@ class TestDatasetRetrievalAdditionalHelpers:
                 )
 
     def test_get_metadata_filter_condition(self, retrieval: DatasetRetrieval) -> None:
-        scalars_result = Mock()
-        scalars_result.all.return_value = [SimpleNamespace(dataset_id="d1", id="doc-1")]
         session = MagicMock()
-        session.scalars.return_value = scalars_result
 
-        mapping, condition = retrieval.get_metadata_filter_condition(
+        def configure_plain_document_result() -> None:
+            session.execute.side_effect = [
+                SimpleNamespace(all=lambda: [SimpleNamespace(dataset_id="d1", id="doc-1")]),
+                SimpleNamespace(all=lambda: []),
+            ]
+
+        mapping, node_mapping, condition = retrieval.get_metadata_filter_condition(
             session,
             dataset_ids=["d1"],
             query="python",
@@ -4383,13 +4386,15 @@ class TestDatasetRetrievalAdditionalHelpers:
             inputs={},
         )
         assert mapping is None
+        assert node_mapping is None
         assert condition is None
 
         automatic_filters = [{"condition": "contains", "metadata_name": "author", "value": "Alice"}]
+        configure_plain_document_result()
         with (
             patch.object(retrieval, "_automatic_metadata_filter_func", return_value=automatic_filters),
         ):
-            mapping, condition = retrieval.get_metadata_filter_condition(
+            mapping, node_mapping, condition = retrieval.get_metadata_filter_condition(
                 session,
                 dataset_ids=["d1"],
                 query="python",
@@ -4401,6 +4406,7 @@ class TestDatasetRetrievalAdditionalHelpers:
                 inputs={},
             )
         assert mapping == {"d1": ["doc-1"]}
+        assert node_mapping is None
         assert condition is not None
         assert condition.logical_operator == "or"
 
@@ -4408,7 +4414,8 @@ class TestDatasetRetrievalAdditionalHelpers:
             logical_operator="and",
             conditions=[AppCondition(name="author", comparison_operator="contains", value="{{name}}")],
         )
-        mapping, condition = retrieval.get_metadata_filter_condition(
+        configure_plain_document_result()
+        mapping, node_mapping, condition = retrieval.get_metadata_filter_condition(
             session,
             dataset_ids=["d1"],
             query="python",
@@ -4420,6 +4427,7 @@ class TestDatasetRetrievalAdditionalHelpers:
             inputs={"name": "Alice"},
         )
         assert mapping == {"d1": ["doc-1"]}
+        assert node_mapping is None
         assert condition is not None
         assert condition.conditions
         first_condition = condition.conditions[0]
@@ -4437,6 +4445,79 @@ class TestDatasetRetrievalAdditionalHelpers:
                 metadata_filtering_conditions=None,
                 inputs={},
             )
+
+    def test_get_metadata_filter_condition_returns_mixed_document_and_chunk_allowlists(
+        self, retrieval: DatasetRetrieval
+    ) -> None:
+        session = MagicMock()
+
+        def result(items):
+            return SimpleNamespace(all=lambda: items)
+
+        session.execute.side_effect = [
+            result([SimpleNamespace(dataset_id="d1", id="doc-public")]),
+            result(
+                [
+                    SimpleNamespace(
+                        id="segment-allowed",
+                        dataset_id="d1",
+                        document_id="doc-mixed",
+                        index_node_id="node-allowed",
+                    )
+                ]
+            ),
+            result(
+                [
+                    SimpleNamespace(
+                        segment_id="segment-allowed",
+                        index_node_id="child-node-allowed",
+                    )
+                ]
+            ),
+            result(
+                [
+                    SimpleNamespace(
+                        chunk_id="segment-allowed",
+                        summary_index_node_id="summary-node-allowed",
+                    )
+                ]
+            ),
+            result(
+                [
+                    SimpleNamespace(
+                        segment_id="segment-allowed",
+                        attachment_id="attachment-node-allowed",
+                    )
+                ]
+            ),
+        ]
+        conditions = AppMetadataFilteringCondition(
+            logical_operator="and",
+            conditions=[AppCondition(name="security_level", comparison_operator="=", value="public")],
+        )
+
+        document_mapping, node_mapping, condition = retrieval.get_metadata_filter_condition(
+            session,
+            dataset_ids=["d1"],
+            query="public question",
+            tenant_id="tenant-1",
+            user_id="u1",
+            metadata_filtering_mode="manual",
+            metadata_model_config=AppModelConfig(provider="openai", name="gpt", mode="chat"),
+            metadata_filtering_conditions=conditions,
+            inputs={},
+        )
+
+        assert document_mapping == {"d1": ["doc-public"]}
+        assert node_mapping == {
+            "d1": [
+                "node-allowed",
+                "child-node-allowed",
+                "summary-node-allowed",
+                "attachment-node-allowed",
+            ]
+        }
+        assert condition == conditions
 
     def test_get_available_datasets(self, retrieval: DatasetRetrieval) -> None:
         session = Mock()
@@ -4732,7 +4813,7 @@ class TestRetrieveCoverage:
         with (
             patch("core.rag.retrieval.dataset_retrieval.ModelManager.for_tenant") as mock_model_manager,
             patch.object(retrieval, "_get_available_datasets", return_value=[SimpleNamespace(id="d1")]),
-            patch.object(retrieval, "get_metadata_filter_condition", return_value=(None, None)),
+            patch.object(retrieval, "get_metadata_filter_condition", return_value=(None, None, None)),
             patch.object(retrieval, "single_retrieve", return_value=[]) as mock_single_retrieve,
         ):
             mock_model_manager.return_value.get_model_instance.return_value = bound_model_instance
@@ -4777,7 +4858,7 @@ class TestRetrieveCoverage:
         with (
             patch("core.rag.retrieval.dataset_retrieval.ModelManager.for_tenant") as mock_model_manager,
             patch.object(retrieval, "_get_available_datasets", return_value=[SimpleNamespace(id="d1")]),
-            patch.object(retrieval, "get_metadata_filter_condition", return_value=(None, None)),
+            patch.object(retrieval, "get_metadata_filter_condition", return_value=(None, None, None)),
             patch.object(retrieval, "single_retrieve", return_value=[external_doc]),
         ):
             bound_model_instance = Mock()
@@ -4875,7 +4956,7 @@ class TestRetrieveCoverage:
         with (
             patch("core.rag.retrieval.dataset_retrieval.ModelManager.for_tenant") as mock_model_manager,
             patch.object(retrieval, "_get_available_datasets", return_value=[SimpleNamespace(id="d1")]),
-            patch.object(retrieval, "get_metadata_filter_condition", return_value=(None, None)),
+            patch.object(retrieval, "get_metadata_filter_condition", return_value=(None, None, None)),
             patch.object(retrieval, "multiple_retrieve", return_value=[external_doc, dify_doc]),
             patch(
                 "core.rag.retrieval.dataset_retrieval.RetrievalService.format_retrieval_documents",

--- a/api/tests/unit_tests/core/tools/utils/test_misc_utils_extra.py
+++ b/api/tests/unit_tests/core/tools/utils/test_misc_utils_extra.py
@@ -206,6 +206,7 @@ def test_single_dataset_retriever_external_run_returns_content_and_resources(sql
     callback = _TestHitCallback()
     metadata_filter_result = (
         {dataset.id: ["doc-a"]},
+        None,
         {"logical_operator": "and"},
     )
     external_documents = [
@@ -262,7 +263,7 @@ def test_single_dataset_retriever_returns_empty_when_metadata_filter_finds_no_do
     with patch.object(
         single_retriever_module.DatasetRetrieval,
         "get_metadata_filter_condition",
-        return_value=({dataset.id: []}, {"logical_operator": "and"}),
+        return_value=({dataset.id: []}, {dataset.id: []}, {"logical_operator": "and"}),
     ):
         with patch.object(single_retriever_module.RetrievalService, "retrieve") as retrieve_mock:
             result = tool.run(session=sqlite_session, query="hello")
@@ -354,7 +355,7 @@ def test_single_dataset_retriever_non_economy_run_sorts_context_and_resources(sq
         patch.object(
             single_retriever_module.DatasetRetrieval,
             "get_metadata_filter_condition",
-            return_value=(None, None),
+            return_value=(None, None, None),
         ),
         patch.object(single_retriever_module.RetrievalService, "retrieve", return_value=documents),
         patch.object(

--- a/api/tests/unit_tests/services/hit_service.py
+++ b/api/tests/unit_tests/services/hit_service.py
@@ -266,6 +266,7 @@ class TestHitTestingServiceRetrieve:
         mock_dataset_retrieval.get_metadata_filter_condition.return_value = (
             {dataset.id: ["doc-1", "doc-2"]},
             None,
+            None,
         )
 
         documents = [HitTestingTestDataFactory.create_document_mock()]
@@ -318,7 +319,7 @@ class TestHitTestingServiceRetrieve:
         external_retrieval_model = {}
 
         mock_dataset_retrieval = MagicMock()
-        mock_dataset_retrieval.get_metadata_filter_condition.return_value = ({}, True)
+        mock_dataset_retrieval.get_metadata_filter_condition.return_value = ({}, {}, True)
 
         with (
             patch("services.hit_testing_service.DatasetRetrieval", autospec=True) as mock_dataset_retrieval_class,

--- a/api/tests/unit_tests/services/test_metadata_service_session_boundary.py
+++ b/api/tests/unit_tests/services/test_metadata_service_session_boundary.py
@@ -1,6 +1,8 @@
 from datetime import datetime
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
+import pytest
 from sqlalchemy import event, select
 from sqlalchemy.orm import Session
 
@@ -13,6 +15,7 @@ from services.entities.knowledge_entities.knowledge_entities import (
     DocumentMetadataOperation,
     MetadataArgs,
     MetadataOperationData,
+    MetadataUpdateArgs,
 )
 from services.metadata_service import MetadataService
 
@@ -142,3 +145,123 @@ def test_get_dataset_metadatas_uses_caller_session(monkeypatch, sqlite_session: 
         "built_in_field_enabled": False,
     }
     assert sqlite_session.scalar(select(DatasetMetadataBinding).limit(1)) is not None
+
+
+def test_rebuild_effective_metadata_merges_document_defaults_and_segment_overrides() -> None:
+    session = MagicMock()
+    dataset = SimpleNamespace(id="dataset-1", built_in_field_enabled=False)
+    document = SimpleNamespace(
+        id="document-1",
+        doc_metadata={"security_level": "public", "region": "cn"},
+        segment_metadata_override_count=0,
+        has_segment_metadata_override=False,
+    )
+    inherited_segment = SimpleNamespace(id="segment-1")
+    overridden_segment = SimpleNamespace(id="segment-2")
+    metadata_definitions = [SimpleNamespace(id="metadata-security", name="security_level")]
+    override = SimpleNamespace(segment_id="segment-2", metadata_id="metadata-security", value_json="confidential")
+
+    def result(items):
+        scalar_result = MagicMock()
+        scalar_result.all.return_value = items
+        return scalar_result
+
+    session.scalars.side_effect = [
+        result([inherited_segment, overridden_segment]),
+        result(metadata_definitions),
+        result([override]),
+    ]
+    session.scalar.return_value = 1
+
+    MetadataService.rebuild_segment_effective_metadata(session, dataset, document)
+
+    assert inherited_segment.effective_metadata == {"security_level": "public", "region": "cn"}
+    assert inherited_segment.effective_security_level == "public"
+    assert inherited_segment.metadata_override_count == 0
+    assert overridden_segment.effective_metadata == {"security_level": "confidential", "region": "cn"}
+    assert overridden_segment.effective_security_level == "confidential"
+    assert overridden_segment.metadata_override_count == 1
+    assert document.has_segment_metadata_override is True
+    assert document.segment_metadata_override_count == 1
+
+
+def test_segment_value_equal_to_document_default_removes_override() -> None:
+    session = MagicMock()
+    dataset = SimpleNamespace(id="dataset-1", tenant_id="tenant-1", built_in_field_enabled=False)
+    document = SimpleNamespace(id="document-1", doc_metadata={"security_level": "public"})
+    segment = SimpleNamespace(id="segment-1", dataset_id="dataset-1", document_id="document-1")
+    metadata = SimpleNamespace(id="metadata-security", name="security_level")
+    existing_binding = SimpleNamespace(id="binding-1")
+    metadata_result = MagicMock()
+    metadata_result.all.return_value = [metadata]
+    session.scalars.return_value = metadata_result
+    session.scalar.return_value = existing_binding
+
+    with patch.object(MetadataService, "rebuild_segment_effective_metadata") as rebuild:
+        MetadataService.apply_segment_metadata_override(
+            session,
+            dataset,
+            document,
+            segment,
+            [MetadataUpdateArgs(name="security_level", value="public")],
+            _account(),
+            "tenant-1",
+        )
+
+    session.delete.assert_called_once_with(existing_binding)
+    rebuild.assert_called_once_with(session, dataset, document, segment_ids=[segment.id])
+
+
+def test_segment_explicit_null_is_preserved_as_override() -> None:
+    session = MagicMock()
+    dataset = SimpleNamespace(id="dataset-1", tenant_id="tenant-1", built_in_field_enabled=False)
+    document = SimpleNamespace(id="document-1", doc_metadata={"security_level": None})
+    segment = SimpleNamespace(id="segment-1", dataset_id="dataset-1", document_id="document-1")
+    metadata = SimpleNamespace(id="metadata-security", name="security_level")
+    metadata_result = MagicMock()
+    metadata_result.all.return_value = [metadata]
+    session.scalars.return_value = metadata_result
+    session.scalar.return_value = None
+
+    with patch.object(MetadataService, "rebuild_segment_effective_metadata"):
+        MetadataService.apply_segment_metadata_override(
+            session,
+            dataset,
+            document,
+            segment,
+            [MetadataUpdateArgs(name="security_level", value=None)],
+            _account(),
+            "tenant-1",
+        )
+
+    binding = session.add.call_args.args[0]
+    assert binding.value_json is None
+    assert binding.metadata_id == metadata.id
+    session.delete.assert_not_called()
+
+
+def test_metadata_lock_uses_owner_token_for_atomic_release() -> None:
+    with patch("services.metadata_service.redis_client") as redis:
+        redis.set.return_value = True
+        with MetadataService.metadata_lock(document_id="document-1"):
+            pass
+
+    lock_key, token = redis.set.call_args.args[:2]
+    assert lock_key == "document_metadata_lock_document-1"
+    redis.set.assert_called_once_with(
+        lock_key,
+        token,
+        nx=True,
+        ex=MetadataService._LOCK_TTL_SECONDS,
+    )
+    redis.eval.assert_called_once_with(MetadataService._LOCK_RELEASE_SCRIPT, 1, lock_key, token)
+
+
+def test_metadata_lock_does_not_release_another_owner() -> None:
+    with patch("services.metadata_service.redis_client") as redis:
+        redis.set.return_value = False
+        with pytest.raises(ValueError, match="Another document metadata operation"):
+            with MetadataService.metadata_lock(document_id="document-1"):
+                pass
+
+    redis.eval.assert_not_called()


### PR DESCRIPTION
## Summary

- add segment-level metadata overrides while preserving document metadata as the default layer
- materialize effective chunk metadata and indexed security levels, with migration/backfill and hybrid routing flags
- expose Console and Service APIs to read, update, batch update, and reset chunk metadata
- prefilter eligible chunks in PostgreSQL and propagate index-node allowlists through keyword, vector, and Weaviate retrieval
- keep existing workflow `metadata_filtering_conditions` compatible and make child chunks, summaries, and attachments inherit parent chunk permissions

## Why

Dify currently filters metadata at document granularity. A mixed document can therefore expose confidential chunks when the document itself is marked public. This change lets most documents keep the existing fast document-level path while only documents with chunk overrides use segment-level filtering.

Closes #38606.

## Validation

- 308 targeted API/controller/service/retrieval unit tests passed; 32 plugin-registration cases were deselected because the sparse local environment does not install every vector backend
- 35 `MetadataService` container integration tests passed against PostgreSQL 14 and Redis
- 41 Weaviate adapter tests passed, including document/chunk filter OR semantics for vector and BM25 search
- the Alembic migration passed a live PostgreSQL 14 upgrade, metadata backfill, index verification, and downgrade test
- Ruff passed for all changed Python files
- Pyrefly reported 0 diagnostics for the changed core production modules
- Alembic resolves a single head: `6f0c2a91b7d3`

## Notes

- Weaviate applies the index-node allowlist natively. Other vector backends fail closed by over-recalling and post-filtering until native support is added; this prevents leakage but can reduce recall for very selective filters.
