### PR TITLE
fix: show a persistent toast for agent run timeouts

### DIFF
--- a/web/features/agent-v2/agent-detail/configure/components/preview/__tests__/chat.spec.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/preview/__tests__/chat.spec.tsx
@@ -3,6 +3,7 @@ import type { AgentPreviewChatController } from '../chat-conversation'
 import type { AgentChatRuntimeEmptyStateProps } from '../chat-runtime'
 import type { SpeechToTextTarget } from '@/app/components/base/voice-input/types'
 import type { AgentSoulConfigFormState } from '@/features/agent-v2/agent-composer/form-state'
+import { toast } from '@langgenius/dify-ui/toast'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -34,6 +35,14 @@ const stopPostMock = vi.hoisted(() => vi.fn())
 const mockConsoleState = vi.hoisted(() => ({
   deploymentEdition: 'COMMUNITY' as 'CLOUD' | 'COMMUNITY' | 'ENTERPRISE',
 }))
+
+vi.mock('@langgenius/dify-ui/toast', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}))
+
+const mockToastError = vi.mocked(toast.error)
 
 vi.mock('@/features/system-features/state', async () => {
   const { createSystemFeaturesStateModuleMock } = await import('@/test/console/state-fixture')
@@ -394,6 +403,7 @@ describe('AgentPreviewChat', () => {
     suggestedQuestionsGetMock.mockResolvedValue({ data: [] })
     stopPostMock.mockClear()
     stopPostMock.mockResolvedValue({ result: 'success' })
+    mockToastError.mockClear()
     stopCallbackRef.current = undefined
     sendResultRef.current = undefined
   })
@@ -794,6 +804,51 @@ describe('AgentPreviewChat', () => {
         message: 'Ignored',
       }),
     ).toBeUndefined()
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
+
+  it('should show a dedicated error toast when an agent run reaches the time limit', async () => {
+    renderPreviewChat()
+
+    fireEvent.click(screen.getByRole('button', { name: 'send' }))
+
+    await waitFor(() => expect(handleSendMock).toHaveBeenCalledTimes(1))
+    const callbacks = handleSendMock.mock.calls.at(0)?.[2]
+
+    expect(
+      callbacks.onUnhandledEvent({
+        event: 'error',
+        code: 'agent_run_limit_exceeded',
+        status: 400,
+        message: 'Server-provided message',
+      }),
+    ).toEqual({
+      conversationId: undefined,
+      messageId: undefined,
+      errorCode: 'agent_run_limit_exceeded',
+      errorMessage: 'Server-provided message',
+    })
+
+    expect(mockToastError).toHaveBeenCalledTimes(1)
+    expect(mockToastError).toHaveBeenCalledWith(
+      'agentV2.agentDetail.configure.preview.errors.agentRunLimitExceeded',
+      expect.objectContaining({
+        description: expect.anything(),
+        timeout: 0,
+      }),
+    )
+    const toastDescription = mockToastError.mock.calls.at(0)?.[1]?.description
+    render(<>{toastDescription}</>)
+
+    const learnMoreLink = screen.getByRole('link', {
+      name: 'agentV2.agentDetail.configure.rightPanel.learnMore',
+    })
+    expect(learnMoreLink).toHaveAttribute(
+      'href',
+      'https://docs.dify.ai/en/self-host/use-dify/build/new-agent/build#publish',
+    )
+    expect(learnMoreLink).toHaveAttribute('target', '_blank')
+    expect(learnMoreLink).toHaveAttribute('rel', 'noopener noreferrer')
   })
 
   it('should show the send button loading state while preparing a build run', async () => {

--- a/web/features/agent-v2/agent-detail/configure/components/preview/chat-conversation.tsx
+++ b/web/features/agent-v2/agent-detail/configure/components/preview/chat-conversation.tsx
@@ -12,15 +12,18 @@ import type { AgentComposerModel } from '@/features/agent-v2/agent-composer/form
 import type { Inputs } from '@/models/debug'
 import { Avatar } from '@langgenius/dify-ui/avatar'
 import { cn } from '@langgenius/dify-ui/cn'
+import { toast } from '@langgenius/dify-ui/toast'
 import { useQueryClient } from '@tanstack/react-query'
 import { useAtomValue } from 'jotai'
 import { useCallback, useImperativeHandle, useLayoutEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { AgentRosterResponseContent } from '@/app/components/base/chat/chat/answer/agent-roster-response-content'
 import { useChat } from '@/app/components/base/chat/chat/hooks'
 import { getLastAnswer, isValidGeneratedAnswer } from '@/app/components/base/chat/utils'
 import { ModelFeatureEnum } from '@/app/components/header/account-setting/model-provider-page/declarations'
 import { useTextGenerationCurrentProviderAndModelAndModelList } from '@/app/components/header/account-setting/model-provider-page/hooks'
 import { userProfileAtom } from '@/context/account-state'
+import { useDocLink } from '@/context/i18n'
 import dynamic from '@/next/dynamic'
 import { consoleClient, consoleQuery } from '@/service/client'
 import { buildChatConfig, getAgentSoulInputs, getAgentSoulInputsForm } from './chat-config'
@@ -118,6 +121,8 @@ export function AgentPreviewChatConversation({
   onSaveDraftBeforeRun?: () => Promise<AgentSoulConfig | void>
   onSendInterrupted?: () => void
 }) {
+  const { t } = useTranslation('agentV2')
+  const docLink = useDocLink()
   const queryClient = useQueryClient()
   const userProfile = useAtomValue(userProfileAtom)
   const sendInterruptedRef = useRef(false)
@@ -222,12 +227,32 @@ export function AgentPreviewChatConversation({
             onUnhandledEvent: (event) => {
               if (event.event !== 'error' || typeof event.message !== 'string') return
 
+              const errorCode = typeof event.code === 'string' ? event.code : undefined
+              if (errorCode === 'agent_run_limit_exceeded') {
+                toast.error(
+                  t(($) => $['agentDetail.configure.preview.errors.agentRunLimitExceeded']),
+                  {
+                    description: (
+                      <a
+                        href={docLink('/use-dify/build/new-agent/build#publish')}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-text-accent hover:underline"
+                      >
+                        {t(($) => $['agentDetail.configure.rightPanel.learnMore'])}
+                      </a>
+                    ),
+                    timeout: 0,
+                  },
+                )
+              }
+
               return {
                 conversationId:
                   typeof event.conversation_id === 'string' ? event.conversation_id : undefined,
                 messageId: typeof event.message_id === 'string' ? event.message_id : undefined,
                 errorMessage: event.message,
-                errorCode: typeof event.code === 'string' ? event.code : undefined,
+                errorCode,
               }
             },
             onConversationComplete: (completedConversationId, workflowRunId) => {
@@ -256,6 +281,7 @@ export function AgentPreviewChatConversation({
       config,
       conversationId,
       draftType,
+      docLink,
       handleSend,
       inputs,
       inputsForm,
@@ -266,6 +292,7 @@ export function AgentPreviewChatConversation({
       onSaveDraftBeforeRun,
       queryClient,
       sendMessage,
+      t,
       textGenerationModelList,
     ],
   )

--- a/web/i18n/ar-TN/agent-v-2.json
+++ b/web/i18n/ar-TN/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "شغّل الوكيل كمحادثة مكتملة، تمامًا كما سيختبرها المستخدمون بعد النشر.",
   "agentDetail.configure.preview.empty.title": "معاينة {{name}}",
   "agentDetail.configure.preview.endUserAuth": "مصادقة المستخدم النهائي",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "تم إيقاف تشغيل هذا الوكيل بسبب بلوغ الحد الزمني. حاول مرة أخرى، أو قسّم المهمة إلى خطوات أصغر.",
   "agentDetail.configure.preview.inputPlaceholder": "إرسال رسالة إلى {{name}}",
   "agentDetail.configure.preview.restart": "ابدأ من جديد",
   "agentDetail.configure.preview.sandboxNotice": "يعمل Agent داخل صندوق رمل Linux.",

--- a/web/i18n/de-DE/agent-v-2.json
+++ b/web/i18n/de-DE/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "Führen Sie den Agenten als fertigen Chat aus, genau wie Benutzer ihn nach der Veröffentlichung erleben.",
   "agentDetail.configure.preview.empty.title": "{{name}} in der Vorschau anzeigen",
   "agentDetail.configure.preview.endUserAuth": "Endbenutzer-Authentifizierung",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "Dieser Agent-Lauf wurde beim Erreichen des Zeitlimits gestoppt. Versuche es erneut oder teile die Aufgabe in kleinere Schritte auf.",
   "agentDetail.configure.preview.inputPlaceholder": "Nachricht an {{name}}",
   "agentDetail.configure.preview.restart": "Neu beginnen",
   "agentDetail.configure.preview.sandboxNotice": "Der Agent läuft in einer Linux-Sandbox.",

--- a/web/i18n/en-US/agent-v-2.json
+++ b/web/i18n/en-US/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "Run the agent as a finished chat, exactly how people will experience it once published.",
   "agentDetail.configure.preview.empty.title": "Preview {{name}}",
   "agentDetail.configure.preview.endUserAuth": "End-user authentication",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "This agent run was stopped at the time limit. Try again, or break the task into smaller steps.",
   "agentDetail.configure.preview.inputPlaceholder": "Message {{name}}",
   "agentDetail.configure.preview.restart": "Start fresh",
   "agentDetail.configure.preview.sandboxNotice": "Agent runs in a Linux sandbox.",

--- a/web/i18n/es-ES/agent-v-2.json
+++ b/web/i18n/es-ES/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "Ejecuta el agente como un chat terminado, exactamente como lo verán las personas cuando se publique.",
   "agentDetail.configure.preview.empty.title": "Vista previa de {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Autenticación de usuario final",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "Esta ejecución del agente se detuvo al alcanzar el límite de tiempo. Inténtalo de nuevo o divide la tarea en pasos más pequeños.",
   "agentDetail.configure.preview.inputPlaceholder": "Enviar mensaje a {{name}}",
   "agentDetail.configure.preview.restart": "Empezar de nuevo",
   "agentDetail.configure.preview.sandboxNotice": "El agente se ejecuta en un sandbox de Linux.",

--- a/web/i18n/fa-IR/agent-v-2.json
+++ b/web/i18n/fa-IR/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "عامل را مثل یک چت نهایی اجرا کنید، دقیقاً همان‌طور که کاربران پس از انتشار تجربه می‌کنند.",
   "agentDetail.configure.preview.empty.title": "پیش‌نمایش {{name}}",
   "agentDetail.configure.preview.endUserAuth": "احراز هویت کاربر نهایی",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "این اجرای Agent به‌دلیل رسیدن به محدودیت زمانی متوقف شد. دوباره تلاش کنید یا کار را به گام‌های کوچک‌تر تقسیم کنید.",
   "agentDetail.configure.preview.inputPlaceholder": "ارسال پیام به {{name}}",
   "agentDetail.configure.preview.restart": "شروع تازه",
   "agentDetail.configure.preview.sandboxNotice": "Agent در یک سندباکس لینوکس اجرا می‌شود.",

--- a/web/i18n/fr-FR/agent-v-2.json
+++ b/web/i18n/fr-FR/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "Exécutez l’agent comme un chat finalisé, exactement comme les utilisateurs le verront une fois publié.",
   "agentDetail.configure.preview.empty.title": "Aperçu de {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Authentification de l’utilisateur final",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "Cette exécution de l’agent a été arrêtée, car elle a atteint la limite de temps. Réessayez ou divisez la tâche en étapes plus petites.",
   "agentDetail.configure.preview.inputPlaceholder": "Envoyer un message à {{name}}",
   "agentDetail.configure.preview.restart": "Recommencer",
   "agentDetail.configure.preview.sandboxNotice": "L’agent s’exécute dans un bac à sable Linux.",

--- a/web/i18n/hi-IN/agent-v-2.json
+++ b/web/i18n/hi-IN/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "एजेंट को तैयार चैट की तरह चलाएं, ठीक वैसे जैसे लोग प्रकाशित होने के बाद अनुभव करेंगे।",
   "agentDetail.configure.preview.empty.title": "{{name}} का पूर्वावलोकन",
   "agentDetail.configure.preview.endUserAuth": "अंतिम-उपयोगकर्ता प्रमाणीकरण",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "समय सीमा पूरी होने पर इस Agent रन को रोक दिया गया। फिर से कोशिश करें या टास्क को छोटे चरणों में बाँटें।",
   "agentDetail.configure.preview.inputPlaceholder": "{{name}} को संदेश भेजें",
   "agentDetail.configure.preview.restart": "नए सिरे से शुरू करें",
   "agentDetail.configure.preview.sandboxNotice": "Agent Linux सैंडबॉक्स में चलता है.",

--- a/web/i18n/id-ID/agent-v-2.json
+++ b/web/i18n/id-ID/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "Jalankan agen sebagai chat final, persis seperti yang akan dialami orang setelah diterbitkan.",
   "agentDetail.configure.preview.empty.title": "Pratinjau {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Autentikasi pengguna akhir",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "Proses Agent ini dihentikan karena mencapai batas waktu. Coba lagi, atau bagi tugas menjadi langkah-langkah yang lebih kecil.",
   "agentDetail.configure.preview.inputPlaceholder": "Kirim pesan ke {{name}}",
   "agentDetail.configure.preview.restart": "Mulai dari awal",
   "agentDetail.configure.preview.sandboxNotice": "Agent berjalan di sandbox Linux.",

--- a/web/i18n/it-IT/agent-v-2.json
+++ b/web/i18n/it-IT/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "Esegui l’agente come una chat completa, esattamente come verrà vissuta dopo la pubblicazione.",
   "agentDetail.configure.preview.empty.title": "Anteprima di {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Autenticazione utente finale",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "Questa esecuzione dell'Agent è stata interrotta perché ha raggiunto il limite di tempo. Riprova oppure suddividi l'attività in passaggi più piccoli.",
   "agentDetail.configure.preview.inputPlaceholder": "Invia un messaggio a {{name}}",
   "agentDetail.configure.preview.restart": "Ricomincia",
   "agentDetail.configure.preview.sandboxNotice": "L'agent viene eseguito in una sandbox Linux.",

--- a/web/i18n/ja-JP/agent-v-2.json
+++ b/web/i18n/ja-JP/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "公開後にユーザーが体験する完成版のチャットとしてエージェントを実行します。",
   "agentDetail.configure.preview.empty.title": "{{name}} をプレビュー",
   "agentDetail.configure.preview.endUserAuth": "エンドユーザー認証",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "この Agent 実行は時間の上限に達したため停止されました。もう一度お試しいただくか、タスクを小さく分割してください。",
   "agentDetail.configure.preview.inputPlaceholder": "{{name}} にメッセージを送信",
   "agentDetail.configure.preview.restart": "新しく始める",
   "agentDetail.configure.preview.sandboxNotice": "Agent は Linux サンドボックスで実行されます。",

--- a/web/i18n/ko-KR/agent-v-2.json
+++ b/web/i18n/ko-KR/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "게시 후 사용자가 경험할 완성된 채팅처럼 에이전트를 실행합니다.",
   "agentDetail.configure.preview.empty.title": "{{name}} 미리보기",
   "agentDetail.configure.preview.endUserAuth": "최종 사용자 인증",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "이 Agent 실행은 시간 제한에 도달하여 중지되었습니다. 다시 시도하거나 작업을 더 작은 단계로 나누세요.",
   "agentDetail.configure.preview.inputPlaceholder": "{{name}}에게 메시지 보내기",
   "agentDetail.configure.preview.restart": "새로 시작",
   "agentDetail.configure.preview.sandboxNotice": "Agent는 Linux 샌드박스에서 실행됩니다.",

--- a/web/i18n/lo-LA/agent-v-2.json
+++ b/web/i18n/lo-LA/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "ທົດລອງໃຊ້ຕົວແທນໃນຮູບແບບການສົນທະນາທີ່ສຳເລັດແລ້ວ ຄືກັນກັບທີ່ຜູ້ໃຊ້ຈະໄດ້ຮັບຮູ້ເມື່ອຖືກເຜີຍແຜ່.",
   "agentDetail.configure.preview.empty.title": "ເບິ່ງຕົວຢ່າງ {{name}}",
   "agentDetail.configure.preview.endUserAuth": "ການຢືນຢັນຕົວຕົນຜູ້ໃຊ້ປາຍທາງ",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "ການເຮັດວຽກຂອງ Agent ນີ້ຖືກຢຸດເພາະຮອດຂີດຈຳກັດເວລາ. ລອງໃໝ່ ຫຼື ແບ່ງໜ້າວຽກເປັນຂັ້ນຕອນນ້ອຍລົງ.",
   "agentDetail.configure.preview.inputPlaceholder": "ສົ່ງຂໍ້ຄວາມຫາ {{name}}",
   "agentDetail.configure.preview.restart": "ເລີ່ມຕົວຢ່າງໃໝ່",
   "agentDetail.configure.preview.sandboxNotice": "ຕົວແທນເຮັດວຽກຢູ່ໃນ Linux sandbox.",

--- a/web/i18n/nl-NL/agent-v-2.json
+++ b/web/i18n/nl-NL/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "Voer de agent uit als een afgeronde chat, precies zoals mensen die na publicatie ervaren.",
   "agentDetail.configure.preview.empty.title": "Voorbeeld van {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Authenticatie eindgebruiker",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "Deze Agent-run is gestopt omdat de tijdslimiet is bereikt. Probeer het opnieuw of splits de taak op in kleinere stappen.",
   "agentDetail.configure.preview.inputPlaceholder": "Bericht sturen naar {{name}}",
   "agentDetail.configure.preview.restart": "Opnieuw beginnen",
   "agentDetail.configure.preview.sandboxNotice": "De agent wordt uitgevoerd in een Linux-sandbox.",

--- a/web/i18n/pl-PL/agent-v-2.json
+++ b/web/i18n/pl-PL/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "Uruchom agenta jako gotowy czat, dokładnie tak, jak zobaczą go użytkownicy po publikacji.",
   "agentDetail.configure.preview.empty.title": "Podgląd {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Uwierzytelnianie użytkownika końcowego",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "To uruchomienie Agenta zostało zatrzymane po osiągnięciu limitu czasu. Spróbuj ponownie lub podziel zadanie na mniejsze kroki.",
   "agentDetail.configure.preview.inputPlaceholder": "Wyślij wiadomość do {{name}}",
   "agentDetail.configure.preview.restart": "Zacznij od nowa",
   "agentDetail.configure.preview.sandboxNotice": "Agent działa w piaskownicy Linux.",

--- a/web/i18n/pt-BR/agent-v-2.json
+++ b/web/i18n/pt-BR/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "Execute o agente como um chat finalizado, exatamente como as pessoas verão após a publicação.",
   "agentDetail.configure.preview.empty.title": "Pré-visualizar {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Autenticação do usuário final",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "Esta execução do Agent foi interrompida ao atingir o limite de tempo. Tente novamente ou divida a tarefa em etapas menores.",
   "agentDetail.configure.preview.inputPlaceholder": "Enviar mensagem para {{name}}",
   "agentDetail.configure.preview.restart": "Começar de novo",
   "agentDetail.configure.preview.sandboxNotice": "O agente é executado em uma sandbox Linux.",

--- a/web/i18n/ro-RO/agent-v-2.json
+++ b/web/i18n/ro-RO/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "Rulează agentul ca un chat finalizat, exact cum îl vor experimenta utilizatorii după publicare.",
   "agentDetail.configure.preview.empty.title": "Previzualizează {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Autentificare utilizator final",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "Această rulare a Agentului a fost oprită după atingerea limitei de timp. Încearcă din nou sau împarte sarcina în pași mai mici.",
   "agentDetail.configure.preview.inputPlaceholder": "Trimite mesaj către {{name}}",
   "agentDetail.configure.preview.restart": "Începe din nou",
   "agentDetail.configure.preview.sandboxNotice": "Agentul rulează într-un sandbox Linux.",

--- a/web/i18n/ru-RU/agent-v-2.json
+++ b/web/i18n/ru-RU/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "Запустите агента как готовый чат, именно так, как его увидят пользователи после публикации.",
   "agentDetail.configure.preview.empty.title": "Предпросмотр {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Аутентификация конечного пользователя",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "Этот запуск агента был остановлен из-за достижения лимита времени. Повторите попытку или разбейте задачу на более мелкие шаги.",
   "agentDetail.configure.preview.inputPlaceholder": "Написать {{name}}",
   "agentDetail.configure.preview.restart": "Начать заново",
   "agentDetail.configure.preview.sandboxNotice": "Agent работает в песочнице Linux.",

--- a/web/i18n/sl-SI/agent-v-2.json
+++ b/web/i18n/sl-SI/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "Zaženite agenta kot dokončan klepet, natanko tako, kot ga bodo uporabniki doživeli po objavi.",
   "agentDetail.configure.preview.empty.title": "Predogled {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Preverjanje pristnosti končnega uporabnika",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "Ta zagon agenta je bil ustavljen, ker je dosegel časovno omejitev. Poskusite znova ali razdelite opravilo na manjše korake.",
   "agentDetail.configure.preview.inputPlaceholder": "Pošlji sporočilo za {{name}}",
   "agentDetail.configure.preview.restart": "Začni znova",
   "agentDetail.configure.preview.sandboxNotice": "Agent se izvaja v peskovniku Linux.",

--- a/web/i18n/th-TH/agent-v-2.json
+++ b/web/i18n/th-TH/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "เรียกใช้เอเจนต์เป็นแชทที่เสร็จสมบูรณ์ เหมือนที่ผู้ใช้จะได้รับหลังเผยแพร่",
   "agentDetail.configure.preview.empty.title": "แสดงตัวอย่าง {{name}}",
   "agentDetail.configure.preview.endUserAuth": "การยืนยันตัวตนของผู้ใช้ปลายทาง",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "การเรียกใช้ Agent นี้หยุดลงเนื่องจากถึงขีดจำกัดเวลา โปรดลองอีกครั้ง หรือแบ่งงานออกเป็นขั้นตอนที่เล็กลง",
   "agentDetail.configure.preview.inputPlaceholder": "ส่งข้อความถึง {{name}}",
   "agentDetail.configure.preview.restart": "เริ่มใหม่",
   "agentDetail.configure.preview.sandboxNotice": "Agent ทำงานในแซนด์บ็อกซ์ Linux",

--- a/web/i18n/tr-TR/agent-v-2.json
+++ b/web/i18n/tr-TR/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "Aracıyı yayınlandıktan sonra kullanıcıların deneyimleyeceği tamamlanmış sohbet olarak çalıştırın.",
   "agentDetail.configure.preview.empty.title": "{{name}} önizlemesi",
   "agentDetail.configure.preview.endUserAuth": "Son kullanıcı kimlik doğrulaması",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "Bu Agent çalışması süre sınırına ulaştığı için durduruldu. Tekrar deneyin veya görevi daha küçük adımlara bölün.",
   "agentDetail.configure.preview.inputPlaceholder": "{{name}} ile mesajlaş",
   "agentDetail.configure.preview.restart": "Baştan başla",
   "agentDetail.configure.preview.sandboxNotice": "Agent bir Linux korumalı alanında çalışır.",

--- a/web/i18n/uk-UA/agent-v-2.json
+++ b/web/i18n/uk-UA/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "Запустіть агента як готовий чат, саме так, як його побачать користувачі після публікації.",
   "agentDetail.configure.preview.empty.title": "Перегляд {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Автентифікація кінцевого користувача",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "Цей запуск агента було зупинено через досягнення обмеження часу. Спробуйте ще раз або розділіть завдання на менші кроки.",
   "agentDetail.configure.preview.inputPlaceholder": "Надіслати повідомлення {{name}}",
   "agentDetail.configure.preview.restart": "Почати заново",
   "agentDetail.configure.preview.sandboxNotice": "Agent працює в пісочниці Linux.",

--- a/web/i18n/vi-VN/agent-v-2.json
+++ b/web/i18n/vi-VN/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "Chạy tác nhân như một cuộc trò chuyện hoàn chỉnh, đúng như người dùng sẽ trải nghiệm sau khi xuất bản.",
   "agentDetail.configure.preview.empty.title": "Xem trước {{name}}",
   "agentDetail.configure.preview.endUserAuth": "Xác thực người dùng cuối",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "Lần chạy Agent này đã bị dừng do đạt giới hạn thời gian. Hãy thử lại hoặc chia tác vụ thành các bước nhỏ hơn.",
   "agentDetail.configure.preview.inputPlaceholder": "Nhắn cho {{name}}",
   "agentDetail.configure.preview.restart": "Bắt đầu mới",
   "agentDetail.configure.preview.sandboxNotice": "Agent chạy trong sandbox Linux.",

--- a/web/i18n/zh-Hans/agent-v-2.json
+++ b/web/i18n/zh-Hans/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "像已发布后用户体验到的那样运行 Agent。",
   "agentDetail.configure.preview.empty.title": "预览 {{name}}",
   "agentDetail.configure.preview.endUserAuth": "终端用户认证",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "本次 Agent 运行因达到时长上限而被终止。请重试，或把任务拆分成更小的步骤。",
   "agentDetail.configure.preview.inputPlaceholder": "向 {{name}} 发送消息",
   "agentDetail.configure.preview.restart": "开启新对话",
   "agentDetail.configure.preview.sandboxNotice": "Agent 运行在 Linux 沙盒中。",

--- a/web/i18n/zh-Hant/agent-v-2.json
+++ b/web/i18n/zh-Hant/agent-v-2.json
@@ -156,6 +156,7 @@
   "agentDetail.configure.preview.empty.description": "像發布後使用者體驗到的那樣執行 Agent。",
   "agentDetail.configure.preview.empty.title": "預覽 {{name}}",
   "agentDetail.configure.preview.endUserAuth": "終端使用者驗證",
+  "agentDetail.configure.preview.errors.agentRunLimitExceeded": "本次 Agent 執行因達到時長上限而被終止。請重試，或將任務拆分成更小的步驟。",
   "agentDetail.configure.preview.inputPlaceholder": "傳訊息給 {{name}}",
   "agentDetail.configure.preview.restart": "開啟新對話",
   "agentDetail.configure.preview.sandboxNotice": "Agent 執行於 Linux 沙盒中。",


### PR DESCRIPTION
## Summary

- Show a localized, persistent error toast when Agent V2 receives `agent_run_limit_exceeded`.
- Provide a documentation link while requiring users to dismiss the toast manually.
- Preserve stream error handling and add regression coverage across supported locales.

Fixes DIFY-2859

## Checklist

- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.