### PR TITLE
fix(ci): use KnowledgeFS deployment script

### DIFF
--- a/.github/workflows/deploy-knowledge.yml
+++ b/.github/workflows/deploy-knowledge.yml
@@ -68,4 +68,4 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            ${{ vars.SSH_SCRIPT || secrets.SSH_SCRIPT }}
+            ${{ vars.SSH_KNOWLEDGE_SCRIPT || secrets.SSH_KNOWLEDGE_SCRIPT }}


### PR DESCRIPTION
## Summary

- make `Deploy Knowledge` use the dedicated `SSH_KNOWLEDGE_SCRIPT`
- keep the shared `SSH_SCRIPT` unchanged for other deployment workflows
- let the dedicated script run Dify API and KnowledgeFS migrations before service recreation

## Confirmed production failure

Production had `MIGRATION_ENABLED=false` and Alembic had not applied `7c1e9a4b2d60`. Every `POST /console/api/knowledge-fs/uploads` failed while inserting into the missing `knowledge_fs_staged_uploads` table.

The production database has been migrated and a self-cleaning staged-upload smoke test now succeeds. The Actions variable `SSH_KNOWLEDGE_SCRIPT` has also been updated to run the API migration explicitly; this workflow change is required because the default-branch workflow was still selecting the shared `SSH_SCRIPT`.