### PR TITLE
fix(web): make legacy Home redirect permanent

### DIFF
--- a/web/app/components/main-nav/__tests__/index.spec.tsx
+++ b/web/app/components/main-nav/__tests__/index.spec.tsx
@@ -971,22 +971,6 @@ describe('MainNav', () => {
     expect(homeLink).toHaveClass(activeStackingClassName)
   })
 
-  it('keeps Home active on the legacy explore apps route only', () => {
-    mockPathname = '/explore/apps'
-
-    const { rerender } = renderMainNav()
-
-    const homeLink = screen.getByRole('link', { name: /common.mainNav.home/ })
-    expect(homeLink).toHaveAttribute('aria-current', 'page')
-
-    mockPathname = '/installed/installed-1'
-    rerender(<MainNav />)
-
-    expect(screen.getByRole('link', { name: /common.mainNav.home/ })).not.toHaveAttribute(
-      'aria-current',
-    )
-  })
-
   it('opens goto anything from the search button', async () => {
     renderMainNav(undefined, {
       extra: (

--- a/web/app/components/main-nav/routes.ts
+++ b/web/app/components/main-nav/routes.ts
@@ -42,7 +42,7 @@ export const MAIN_NAV_ROUTES = [
     key: 'home',
     href: '/',
     labelKey: 'mainNav.home',
-    active: (path: string) => path === '/' || path === '/explore/apps',
+    active: (path: string) => path === '/',
     icon: 'i-custom-vender-main-nav-home',
     activeIcon: 'i-custom-vender-main-nav-home-active',
     visibility: VISIBLE_TO_ALL,

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -36,7 +36,7 @@ const nextConfig: NextConfig = {
       {
         source: '/explore/apps',
         destination: '/',
-        permanent: false,
+        permanent: true,
       },
     ]
   },


### PR DESCRIPTION
## Summary

- return a permanent redirect from `/explore/apps` to the canonical Home route
- remove the unreachable main navigation compatibility check for `/explore/apps`
- remove the legacy-path component test

## Why

`/explore/apps` no longer owns a filesystem route, while `/` is the canonical Home entry. This is a URL structure migration, and Next.js evaluates `next.config.ts` redirects before filesystem routing and React rendering.

## Verification

- `vp test run app/components/main-nav/__tests__/index.spec.tsx` (53 tests passed)
- `pnpm check` (0 errors; existing repository warnings only)
- local Next.js request to `/explore/apps?category=assistant` returned `308 Permanent Redirect` with `Location: /?category=assistant`