### PR TITLE
fix(weaviate): delete vectors by doc_id filter instead of object UUIDs

### DIFF
--- a/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/src/dify_vdb_weaviate/weaviate_vector.py
@@ -377,7 +377,14 @@ class WeaviateVector(BaseVector):
     @override
     def delete_by_ids(self, ids: list[str]) -> None:
         """
-        Deletes objects by their UUID identifiers.
+        Deletes objects by their Dify segment IDs.
+
+        Objects are keyed by ``uuid5(URL_NAMESPACE, page_content)`` (see
+        :meth:`_get_uuids`), while callers pass Dify segment IDs
+        (``index_node_id``), which are stored in the ``doc_id`` property. Passing
+        them to ``delete_by_id`` as object UUIDs therefore never matches and
+        silently leaves orphan vectors behind. Delete by a batched ``doc_id``
+        property filter instead.
 
         Silently ignores 404 errors for non-existent IDs.
         """
@@ -386,12 +393,16 @@ class WeaviateVector(BaseVector):
 
         col = self._client.collections.use(self._collection_name)
 
-        for uid in ids:
-            try:
-                col.data.delete_by_id(uid)
-            except UnexpectedStatusCodeError as e:
-                if getattr(e, "status_code", None) != 404:
-                    raise
+        batch_size = 100
+        try:
+            for start in range(0, len(ids), batch_size):
+                chunk = ids[start : start + batch_size]
+                col.data.delete_many(
+                    where=Filter.any_of([Filter.by_property("doc_id").equal(i) for i in chunk])
+                )
+        except UnexpectedStatusCodeError as e:
+            if getattr(e, "status_code", None) != 404:
+                raise
 
     @override
     def search_by_vector(self, query_vector: list[float], **kwargs: Any) -> list[Document]:

--- a/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
+++ b/api/providers/vdb/vdb-weaviate/tests/unit_tests/test_weaviate_vector.py
@@ -803,7 +803,50 @@ class TestWeaviateVector(unittest.TestCase):
         assert wv.text_exists("segment-1") is False
         assert wv.text_exists("segment-1") is True
 
-    def test_delete_by_ids_handles_missing_collections_and_404s(self):
+    def test_delete_by_ids_returns_when_collection_is_missing(self):
+        wv = WeaviateVector.__new__(WeaviateVector)
+        wv._collection_name = self.collection_name
+        wv._client = MagicMock()
+        wv._client.collections.exists.return_value = False
+
+        wv.delete_by_ids(["segment-1"])
+
+        wv._client.collections.use.assert_not_called()
+
+    def test_delete_by_ids_deletes_by_doc_id_property_in_batches(self):
+        """
+        Regression test for #40457.
+
+        ``delete_by_ids`` receives Dify segment IDs (``index_node_id``), which are
+        stored in the object's ``doc_id`` property. Weaviate objects are keyed by
+        ``uuid5(URL_NAMESPACE, page_content)``, so deleting by raw object UUID can
+        never match and silently leaves orphan vectors behind. Deletion must go
+        through a batched ``delete_many`` with a ``doc_id`` property filter.
+        """
+        wv = WeaviateVector.__new__(WeaviateVector)
+        wv._collection_name = self.collection_name
+        wv._client = MagicMock()
+        wv._client.collections.exists.return_value = True
+        mock_col = MagicMock()
+        wv._client.collections.use.return_value = mock_col
+
+        ids = [f"segment-{i:03d}" for i in range(250)]
+        wv.delete_by_ids(ids)
+
+        # The old per-id delete_by_id path passes segment IDs as object UUIDs,
+        # which never coincide, so it must not be used at all.
+        mock_col.data.delete_by_id.assert_not_called()
+
+        # 250 ids are deleted in batches of 100 via a doc_id property filter.
+        assert mock_col.data.delete_many.call_count == 3
+        for call in mock_col.data.delete_many.call_args_list:
+            where = call.kwargs["where"]
+            assert where is not None
+            assert all(getattr(f, "target", None) == "doc_id" for f in where.filters)
+
+    def test_delete_by_ids_swallows_404_errors(self):
+        """A 404 from a concurrently dropped collection is still ignored."""
+
         class FakeUnexpectedStatusCodeError(Exception):
             def __init__(self, status_code):
                 super().__init__(f"status={status_code}")
@@ -812,16 +855,15 @@ class TestWeaviateVector(unittest.TestCase):
         wv = WeaviateVector.__new__(WeaviateVector)
         wv._collection_name = self.collection_name
         wv._client = MagicMock()
-        wv._client.collections.exists.side_effect = [False, True]
+        wv._client.collections.exists.return_value = True
         mock_col = MagicMock()
         wv._client.collections.use.return_value = mock_col
-        mock_col.data.delete_by_id.side_effect = [FakeUnexpectedStatusCodeError(404), None]
+        mock_col.data.delete_many.side_effect = FakeUnexpectedStatusCodeError(404)
 
         with patch.object(weaviate_vector_module, "UnexpectedStatusCodeError", FakeUnexpectedStatusCodeError):
-            wv.delete_by_ids(["ignored"])
-            wv.delete_by_ids(["missing-id", "ok-id"])
+            wv.delete_by_ids(["segment-1"])  # must not raise
 
-        assert mock_col.data.delete_by_id.call_count == 2
+        mock_col.data.delete_many.assert_called_once()
 
     def test_delete_by_ids_reraises_non_404_errors(self):
         class FakeUnexpectedStatusCodeError(Exception):
@@ -835,13 +877,13 @@ class TestWeaviateVector(unittest.TestCase):
         wv._client.collections.exists.return_value = True
         mock_col = MagicMock()
         wv._client.collections.use.return_value = mock_col
-        mock_col.data.delete_by_id.side_effect = FakeUnexpectedStatusCodeError(500)
+        mock_col.data.delete_many.side_effect = FakeUnexpectedStatusCodeError(500)
 
         with (
             patch.object(weaviate_vector_module, "UnexpectedStatusCodeError", FakeUnexpectedStatusCodeError),
             pytest.raises(FakeUnexpectedStatusCodeError, match="status=500"),
         ):
-            wv.delete_by_ids(["bad-id"])
+            wv.delete_by_ids(["segment-1"])
 
     def test_json_serializable_converts_datetime(self):
         wv = WeaviateVector.__new__(WeaviateVector)


### PR DESCRIPTION
## Summary

Fixes #40457 — deleting a Weaviate-backed document never removes its vectors.

`WeaviateVector.delete_by_ids` passes Dify segment IDs (`index_node_id`) straight to `col.data.delete_by_id(uid)`. Those segment IDs are stored in the object's `doc_id` property; the object's actual UUID is `uuid5(URL_NAMESPACE, page_content)` (see `_get_uuids`). The two never coincide, so every delete 404s and the 404 is silently swallowed — the task logs success while orphan vectors accumulate and keep consuming `top_k` slots (9,165 orphans observed on one dataset in the issue).

## Fix

Rewrite `delete_by_ids` to delete by a batched `doc_id` property filter (`Filter.any_of([...])`, 100 ids per batch) instead of raw object UUIDs, following the approach outlined in the issue. `Filter` and `delete_many` are already used elsewhere in this module (`delete_by_metadata_field`), and a filter delete is a no-op for ids that no longer exist, so there is nothing to 404 on. The pre-existing "swallow 404" behaviour is kept, scoped to the new delete path.

## Tests

- `test_delete_by_ids_deletes_by_doc_id_property_in_batches` — regression test asserting `delete_many` is called with a batched `doc_id` filter and `delete_by_id` is never called. Fails before this change (the old path only ever calls `delete_by_id`), passes after.
- Existing `delete_by_ids` unit tests updated to exercise the new delete path (missing collection, 404 swallow, non-404 re-raise).