### PR TITLE
refactor(web): align education autocomplete async behavior

### DIFF
--- a/packages/dify-ui/src/autocomplete/index.tsx
+++ b/packages/dify-ui/src/autocomplete/index.tsx
@@ -72,11 +72,10 @@ const autocompleteListClassName = [
 ]
 
 const autocompleteItemClassName = [
-  'mx-1 flex min-h-8 cursor-pointer select-none items-center gap-2 rounded-lg px-2 py-1.5 text-text-secondary outline-hidden transition-colors',
+  'mx-1 flex min-h-8 cursor-pointer select-none items-center gap-2 rounded-lg px-2 py-1.5 text-text-secondary outline-hidden',
   'hover:bg-state-base-hover-alt hover:text-text-primary',
   'data-highlighted:bg-state-base-hover data-highlighted:text-text-primary',
   'data-disabled:cursor-not-allowed data-disabled:opacity-30 data-disabled:hover:bg-transparent data-disabled:hover:text-text-secondary',
-  'motion-reduce:transition-none',
 ]
 
 const autocompleteInputGroupVariants = cva(

--- a/packages/dify-ui/src/combobox/index.tsx
+++ b/packages/dify-ui/src/combobox/index.tsx
@@ -79,12 +79,11 @@ const comboboxListClassName = [
 ]
 
 const comboboxItemClassName = [
-  'grid min-h-8 cursor-pointer select-none grid-cols-[1fr_auto] items-center gap-2 rounded-lg px-2 py-1.5 text-text-secondary outline-hidden transition-colors',
+  'grid min-h-8 cursor-pointer select-none grid-cols-[1fr_auto] items-center gap-2 rounded-lg px-2 py-1.5 text-text-secondary outline-hidden',
   'hover:bg-state-base-hover-alt hover:text-text-primary',
   'data-highlighted:bg-state-base-hover data-highlighted:text-text-primary',
   'data-selected:text-text-primary',
   'data-disabled:cursor-not-allowed data-disabled:opacity-30 data-disabled:hover:bg-transparent data-disabled:hover:text-text-secondary',
-  'motion-reduce:transition-none',
 ]
 
 const comboboxTriggerVariants = cva(

--- a/web/app/education/apply/__tests__/institution-field.spec.tsx
+++ b/web/app/education/apply/__tests__/institution-field.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useState } from 'react'
 import InstitutionField from '../institution-field'
@@ -7,7 +7,9 @@ const educationAutocompleteQueryMock = vi.hoisted(() => ({
   options: vi.fn(),
   fetchNextPage: vi.fn(),
   hasNextPage: false,
+  isError: false,
   isFetchingNextPage: false,
+  isFetchNextPageError: false,
   isPending: false,
   isSuccess: true,
   data: {
@@ -51,14 +53,49 @@ const ControlledInstitutionField = () => {
   return <InstitutionField value={value} onValueChange={setValue} />
 }
 
+function stubIntersectionObserver() {
+  let callback: IntersectionObserverCallback | undefined
+
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class MockIntersectionObserver {
+      constructor(nextCallback: IntersectionObserverCallback) {
+        callback = nextCallback
+      }
+
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  )
+
+  return async () => {
+    await waitFor(() => {
+      expect(callback).toBeDefined()
+    })
+    act(() => {
+      callback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      )
+    })
+  }
+}
+
 describe('InstitutionField', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     educationAutocompleteQueryMock.hasNextPage = false
+    educationAutocompleteQueryMock.isError = false
     educationAutocompleteQueryMock.isFetchingNextPage = false
+    educationAutocompleteQueryMock.isFetchNextPageError = false
     educationAutocompleteQueryMock.isPending = false
     educationAutocompleteQueryMock.isSuccess = true
     educationAutocompleteQueryMock.data.pages[0]!.data = ['Alpha University', 'Beta College']
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it('uses a free-form institution name as the suggestions query', async () => {
@@ -115,8 +152,9 @@ describe('InstitutionField', () => {
     expect(input).toHaveValue('Dify Academy')
   })
 
-  it('requests the next page when the suggestions reach the scroll boundary', async () => {
+  it('requests the next page when the suggestions sentinel enters the preload area', async () => {
     const user = userEvent.setup()
+    const triggerIntersection = stubIntersectionObserver()
     educationAutocompleteQueryMock.hasNextPage = true
 
     render(<ControlledInstitutionField />)
@@ -126,15 +164,30 @@ describe('InstitutionField', () => {
       'A',
     )
 
-    const scrollContainer = await screen.findByRole('listbox')
-    Object.defineProperties(scrollContainer, {
-      scrollTop: { value: 60, configurable: true },
-      scrollHeight: { value: 100, configurable: true },
-      clientHeight: { value: 40, configurable: true },
+    await screen.findByRole('listbox')
+    await triggerIntersection()
+
+    expect(educationAutocompleteQueryMock.fetchNextPage).toHaveBeenCalledOnce()
+    expect(educationAutocompleteQueryMock.fetchNextPage).toHaveBeenCalledWith({
+      cancelRefetch: false,
     })
+  })
 
-    fireEvent.scroll(scrollContainer)
+  it('keeps loaded suggestions visible when the next page fails', async () => {
+    const user = userEvent.setup()
+    educationAutocompleteQueryMock.hasNextPage = true
+    educationAutocompleteQueryMock.isError = true
+    educationAutocompleteQueryMock.isFetchNextPageError = true
+    educationAutocompleteQueryMock.isSuccess = false
 
-    expect(educationAutocompleteQueryMock.fetchNextPage).toHaveBeenCalledTimes(1)
+    render(<ControlledInstitutionField />)
+
+    await user.type(
+      screen.getByPlaceholderText(/(?:^|\.)form\.schoolName\.placeholder(?=$|:)/),
+      'A',
+    )
+
+    expect(await screen.findByText('Alpha University')).toBeInTheDocument()
+    expect(screen.getByText('common.dynamicSelect.error').closest('[role="status"]')).not.toBeNull()
   })
 })

--- a/web/app/education/apply/__tests__/institution-field.spec.tsx
+++ b/web/app/education/apply/__tests__/institution-field.spec.tsx
@@ -9,11 +9,6 @@ const educationAutocompleteQueryMock = vi.hoisted(() => ({
   hasNextPage: false,
   isError: false,
   isFetching: false,
-  isFetchingNextPage: false,
-  isFetchNextPageError: false,
-  isPending: false,
-  isPlaceholderData: false,
-  isSuccess: true,
   data: {
     pages: [
       {
@@ -99,11 +94,6 @@ describe('InstitutionField', () => {
     educationAutocompleteQueryMock.hasNextPage = false
     educationAutocompleteQueryMock.isError = false
     educationAutocompleteQueryMock.isFetching = false
-    educationAutocompleteQueryMock.isFetchingNextPage = false
-    educationAutocompleteQueryMock.isFetchNextPageError = false
-    educationAutocompleteQueryMock.isPending = false
-    educationAutocompleteQueryMock.isPlaceholderData = false
-    educationAutocompleteQueryMock.isSuccess = true
     educationAutocompleteQueryMock.data.pages[0]!.data = ['Alpha University', 'Beta College']
     debouncedValueMock.hold = false
     debouncedValueMock.value = ''
@@ -184,7 +174,6 @@ describe('InstitutionField', () => {
 
     debouncedValueMock.hold = false
     educationAutocompleteQueryMock.isFetching = true
-    educationAutocompleteQueryMock.isPlaceholderData = true
     view.rerender(<ControlledInstitutionField />)
 
     expect(input).toHaveAttribute('aria-expanded', 'true')
@@ -195,7 +184,6 @@ describe('InstitutionField', () => {
 
     educationAutocompleteQueryMock.data.pages[0]!.data = ['Alpine University']
     educationAutocompleteQueryMock.isFetching = false
-    educationAutocompleteQueryMock.isPlaceholderData = false
     view.rerender(<ControlledInstitutionField />)
 
     expect(screen.getByText('Alpine University')).toBeInTheDocument()
@@ -245,8 +233,6 @@ describe('InstitutionField', () => {
     const user = userEvent.setup()
     educationAutocompleteQueryMock.hasNextPage = true
     educationAutocompleteQueryMock.isError = true
-    educationAutocompleteQueryMock.isFetchNextPageError = true
-    educationAutocompleteQueryMock.isSuccess = false
 
     render(<ControlledInstitutionField />)
 

--- a/web/app/education/apply/__tests__/institution-field.spec.tsx
+++ b/web/app/education/apply/__tests__/institution-field.spec.tsx
@@ -8,9 +8,11 @@ const educationAutocompleteQueryMock = vi.hoisted(() => ({
   fetchNextPage: vi.fn(),
   hasNextPage: false,
   isError: false,
+  isFetching: false,
   isFetchingNextPage: false,
   isFetchNextPageError: false,
   isPending: false,
+  isPlaceholderData: false,
   isSuccess: true,
   data: {
     pages: [
@@ -23,7 +25,15 @@ const educationAutocompleteQueryMock = vi.hoisted(() => ({
   },
 }))
 
+const debouncedValueMock = vi.hoisted(() => ({
+  hold: false,
+  value: '',
+}))
+
+const keepPreviousDataMock = vi.hoisted(() => vi.fn((previousData: unknown) => previousData))
+
 vi.mock('@tanstack/react-query', () => ({
+  keepPreviousData: keepPreviousDataMock,
   useInfiniteQuery: (options: unknown) => {
     educationAutocompleteQueryMock.options(options)
     return educationAutocompleteQueryMock
@@ -45,7 +55,8 @@ vi.mock('@/service/client', () => ({
 }))
 
 vi.mock('foxact/use-debounced-value', () => ({
-  useDebouncedValue: <T,>(value: T) => value,
+  useDebouncedValue: <T,>(value: T) =>
+    debouncedValueMock.hold ? (debouncedValueMock.value as T) : value,
 }))
 
 const ControlledInstitutionField = () => {
@@ -87,11 +98,15 @@ describe('InstitutionField', () => {
     vi.clearAllMocks()
     educationAutocompleteQueryMock.hasNextPage = false
     educationAutocompleteQueryMock.isError = false
+    educationAutocompleteQueryMock.isFetching = false
     educationAutocompleteQueryMock.isFetchingNextPage = false
     educationAutocompleteQueryMock.isFetchNextPageError = false
     educationAutocompleteQueryMock.isPending = false
+    educationAutocompleteQueryMock.isPlaceholderData = false
     educationAutocompleteQueryMock.isSuccess = true
     educationAutocompleteQueryMock.data.pages[0]!.data = ['Alpha University', 'Beta College']
+    debouncedValueMock.hold = false
+    debouncedValueMock.value = ''
   })
 
   afterEach(() => {
@@ -152,6 +167,41 @@ describe('InstitutionField', () => {
     expect(input).toHaveValue('Dify Academy')
   })
 
+  it('keeps previous suggestions open while a new search settles', async () => {
+    const user = userEvent.setup()
+    const view = render(<ControlledInstitutionField />)
+    const input = screen.getByPlaceholderText(/(?:^|\.)form\.schoolName\.placeholder(?=$|:)/)
+
+    await user.type(input, 'A')
+    expect(await screen.findByText('Alpha University')).toBeInTheDocument()
+
+    debouncedValueMock.hold = true
+    debouncedValueMock.value = 'A'
+    await user.type(input, 'l')
+
+    expect(input).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('Alpha University')).toBeInTheDocument()
+
+    debouncedValueMock.hold = false
+    educationAutocompleteQueryMock.isFetching = true
+    educationAutocompleteQueryMock.isPlaceholderData = true
+    view.rerender(<ControlledInstitutionField />)
+
+    expect(input).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('Alpha University')).toBeInTheDocument()
+    expect(educationAutocompleteQueryMock.options.mock.lastCall?.[0]).toMatchObject({
+      placeholderData: keepPreviousDataMock,
+    })
+
+    educationAutocompleteQueryMock.data.pages[0]!.data = ['Alpine University']
+    educationAutocompleteQueryMock.isFetching = false
+    educationAutocompleteQueryMock.isPlaceholderData = false
+    view.rerender(<ControlledInstitutionField />)
+
+    expect(screen.getByText('Alpine University')).toBeInTheDocument()
+    expect(screen.queryByText('Alpha University')).not.toBeInTheDocument()
+  })
+
   it('requests the next page when the suggestions sentinel enters the preload area', async () => {
     const user = userEvent.setup()
     const triggerIntersection = stubIntersectionObserver()
@@ -188,6 +238,10 @@ describe('InstitutionField', () => {
     )
 
     expect(await screen.findByText('Alpha University')).toBeInTheDocument()
-    expect(screen.getByText('common.dynamicSelect.error').closest('[role="status"]')).not.toBeNull()
+    expect(
+      screen
+        .getAllByText('common.dynamicSelect.error')
+        .some((element) => element.closest('[role="status"]') !== null),
+    ).toBe(true)
   })
 })

--- a/web/app/education/apply/__tests__/institution-field.spec.tsx
+++ b/web/app/education/apply/__tests__/institution-field.spec.tsx
@@ -223,6 +223,24 @@ describe('InstitutionField', () => {
     })
   })
 
+  it('keeps keyboard navigation at the loaded list boundary', async () => {
+    const user = userEvent.setup()
+    educationAutocompleteQueryMock.hasNextPage = true
+
+    render(<ControlledInstitutionField />)
+
+    await user.type(
+      screen.getByPlaceholderText(/(?:^|\.)form\.schoolName\.placeholder(?=$|:)/),
+      'A',
+    )
+    await screen.findByText('Beta College')
+    await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}')
+
+    expect(screen.getByText('Beta College').closest('[role="option"]')).toHaveAttribute(
+      'data-highlighted',
+    )
+  })
+
   it('keeps loaded suggestions visible when the next page fails', async () => {
     const user = userEvent.setup()
     educationAutocompleteQueryMock.hasNextPage = true

--- a/web/app/education/apply/__tests__/page.spec.tsx
+++ b/web/app/education/apply/__tests__/page.spec.tsx
@@ -239,6 +239,7 @@ describe('EducationApplyPage billing boundary', () => {
       screen.getByRole('combobox', { name: 'education.form.schoolName.title' }),
       'DifyUniversity',
     )
+    await user.keyboard('{Escape}')
     expect(
       screen.getByRole('radiogroup', { name: 'education.form.schoolRole.title' }),
     ).toBeInTheDocument()

--- a/web/app/education/apply/institution-field.tsx
+++ b/web/app/education/apply/institution-field.tsx
@@ -36,18 +36,7 @@ const InstitutionField = ({ value, onValueChange }: InstitutionFieldProps) => {
   const debouncedSearchQuery = useDebouncedValue(searchQuery, 300)
   const hasSearchQuery = !!searchQuery
   const isDebouncing = hasSearchQuery && searchQuery !== debouncedSearchQuery
-  const {
-    data,
-    fetchNextPage,
-    hasNextPage,
-    isError,
-    isFetching,
-    isFetchingNextPage,
-    isFetchNextPageError,
-    isPending,
-    isPlaceholderData,
-    isSuccess,
-  } = useInfiniteQuery({
+  const { data, fetchNextPage, hasNextPage, isError, isFetching } = useInfiniteQuery({
     ...consoleQuery.account.education.autocomplete.get.infiniteOptions({
       input: (pageParam) => ({
         query: {
@@ -64,15 +53,16 @@ const InstitutionField = ({ value, onValueChange }: InstitutionFieldProps) => {
     placeholderData: keepPreviousData,
   })
   const suggestions = hasSearchQuery ? (data?.pages.flatMap((page) => page.data ?? []) ?? []) : []
-  const isSearching = isDebouncing || isPending || (isFetching && !isFetchingNextPage)
-  const isLoading = isSearching || isFetchingNextPage
+  const isLoading = isDebouncing || isFetching
   const shouldOpenPopup = isPopupOpen && hasSearchQuery
-  const shouldShowEmpty = shouldOpenPopup && isSuccess && !isLoading && suggestions.length === 0
-  const shouldAnnounceLoading = shouldOpenPopup && isLoading
-  const shouldShowError = shouldOpenPopup && isError && !isLoading
-  const shouldShowFooter = shouldOpenPopup && (isLoading || hasNextPage || shouldShowError)
-  const canLoadMore =
-    shouldOpenPopup && !isDebouncing && !isPlaceholderData && !isFetching && !isFetchNextPageError
+  let footerState: 'error' | 'loading' | null = null
+  if (shouldOpenPopup) {
+    if (isLoading) footerState = 'loading'
+    else if (isError) footerState = 'error'
+    else if (hasNextPage) footerState = 'loading'
+  }
+  const shouldShowEmpty = shouldOpenPopup && footerState === null && suggestions.length === 0
+  const canLoadMore = shouldOpenPopup && hasNextPage && !isLoading && !isError
 
   const handleValueChange = (inputValue: string, eventDetails: AutocompleteChangeEventDetails) => {
     onValueChange(inputValue)
@@ -114,7 +104,7 @@ const InstitutionField = ({ value, onValueChange }: InstitutionFieldProps) => {
         <AutocompleteContent
           popupClassName="w-(--anchor-width) max-w-(--available-width)"
           portalProps={{ keepMounted: true }}
-          popupProps={{ 'aria-busy': isLoading || undefined }}
+          popupProps={{ 'aria-busy': (shouldOpenPopup && isLoading) || undefined }}
         >
           <AutocompleteList ref={listRef}>
             <AutocompleteCollection<string>>
@@ -124,7 +114,7 @@ const InstitutionField = ({ value, onValueChange }: InstitutionFieldProps) => {
                 </AutocompleteItem>
               )}
             </AutocompleteCollection>
-            {shouldShowFooter ? (
+            {footerState !== null ? (
               <div
                 className="relative flex h-10 items-center justify-center px-3"
                 aria-hidden="true"
@@ -140,7 +130,7 @@ const InstitutionField = ({ value, onValueChange }: InstitutionFieldProps) => {
                     scrollContainerRef={listRef}
                   />
                 ) : null}
-                {shouldShowError ? (
+                {footerState === 'error' ? (
                   <span className="system-sm-regular text-text-destructive">
                     {t(($) => $['dynamicSelect.error'], { ns: 'common' })}
                   </span>
@@ -155,9 +145,9 @@ const InstitutionField = ({ value, onValueChange }: InstitutionFieldProps) => {
           </AutocompleteEmpty>
           <AutocompleteStatus className="p-0">
             <span className="sr-only">
-              {shouldAnnounceLoading
+              {shouldOpenPopup && isLoading
                 ? t(($) => $.loading, { ns: 'common' })
-                : shouldShowError
+                : footerState === 'error'
                   ? t(($) => $['dynamicSelect.error'], { ns: 'common' })
                   : null}
             </span>

--- a/web/app/education/apply/institution-field.tsx
+++ b/web/app/education/apply/institution-field.tsx
@@ -100,6 +100,7 @@ const InstitutionField = ({ value, onValueChange }: InstitutionFieldProps) => {
         onValueChange={handleValueChange}
         filter={null}
         mode="list"
+        loopFocus={false}
         open={shouldOpenPopup}
         onOpenChange={setIsPopupOpen}
       >

--- a/web/app/education/apply/institution-field.tsx
+++ b/web/app/education/apply/institution-field.tsx
@@ -1,7 +1,7 @@
 import type { AutocompleteChangeEventDetails } from '@langgenius/dify-ui/autocomplete'
-import type { UIEventHandler } from 'react'
 import {
   Autocomplete,
+  AutocompleteCollection,
   AutocompleteContent,
   AutocompleteEmpty,
   AutocompleteInput,
@@ -14,8 +14,9 @@ import {
 import { Field, FieldLabel } from '@langgenius/dify-ui/field'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { useDebouncedValue } from 'foxact/use-debounced-value'
-import { useId, useState } from 'react'
+import { useId, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { InfiniteScrollSentinel } from '@/app/components/base/infinite-scroll-sentinel'
 import Loading from '@/app/components/base/loading'
 import { consoleQuery } from '@/service/client'
 
@@ -29,31 +30,41 @@ type InstitutionFieldProps = {
 const InstitutionField = ({ value, onValueChange }: InstitutionFieldProps) => {
   const { t } = useTranslation()
   const inputId = useId()
+  const listRef = useRef<HTMLDivElement>(null)
   const [isPopupOpen, setIsPopupOpen] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
   const debouncedSearchQuery = useDebouncedValue(searchQuery, 300)
   const isSearchReady = !!searchQuery && searchQuery === debouncedSearchQuery
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending, isSuccess } =
-    useInfiniteQuery({
-      ...consoleQuery.account.education.autocomplete.get.infiniteOptions({
-        input: (pageParam) => ({
-          query: {
-            keywords: debouncedSearchQuery,
-            limit: EDUCATION_AUTOCOMPLETE_PAGE_SIZE,
-            page: Number(pageParam),
-          },
-        }),
-        initialPageParam: 0,
-        getNextPageParam: (lastPage, pages) =>
-          lastPage.has_next ? (lastPage.curr_page ?? pages.length - 1) + 1 : undefined,
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isError,
+    isFetchingNextPage,
+    isFetchNextPageError,
+    isPending,
+    isSuccess,
+  } = useInfiniteQuery({
+    ...consoleQuery.account.education.autocomplete.get.infiniteOptions({
+      input: (pageParam) => ({
+        query: {
+          keywords: debouncedSearchQuery,
+          limit: EDUCATION_AUTOCOMPLETE_PAGE_SIZE,
+          page: Number(pageParam),
+        },
       }),
-      enabled: isSearchReady,
-    })
+      initialPageParam: 0,
+      getNextPageParam: (lastPage, pages) =>
+        lastPage.has_next ? (lastPage.curr_page ?? pages.length - 1) + 1 : undefined,
+    }),
+    enabled: isSearchReady,
+  })
   const suggestions = isSearchReady ? (data?.pages.flatMap((page) => page.data ?? []) ?? []) : []
   const isLoading = isPending || isFetchingNextPage
-  const shouldOpenPopup = isPopupOpen && isSearchReady && (isLoading || isSuccess)
+  const shouldOpenPopup = isPopupOpen && isSearchReady
   const shouldShowEmpty = shouldOpenPopup && isSuccess && !isLoading && suggestions.length === 0
   const shouldShowLoading = shouldOpenPopup && isLoading
+  const shouldShowError = shouldOpenPopup && isError && !isLoading
 
   const handleValueChange = (inputValue: string, eventDetails: AutocompleteChangeEventDetails) => {
     onValueChange(inputValue)
@@ -65,14 +76,6 @@ const InstitutionField = ({ value, onValueChange }: InstitutionFieldProps) => {
 
     setSearchQuery(inputValue)
     setIsPopupOpen(!!inputValue)
-  }
-
-  const handleScroll: UIEventHandler<HTMLDivElement> = (event) => {
-    const { scrollTop, scrollHeight, clientHeight } = event.currentTarget
-    const isAtBottom = scrollTop + clientHeight >= scrollHeight - 5 && scrollTop > 0
-    if (!isAtBottom || !hasNextPage || isFetchingNextPage) return
-
-    void fetchNextPage()
   }
 
   return (
@@ -104,12 +107,24 @@ const InstitutionField = ({ value, onValueChange }: InstitutionFieldProps) => {
           portalProps={{ keepMounted: true }}
           popupProps={{ 'aria-busy': isLoading || undefined }}
         >
-          <AutocompleteList<string> onScroll={handleScroll}>
-            {(institution) => (
-              <AutocompleteItem key={institution} value={institution} title={institution}>
-                <AutocompleteItemText>{institution}</AutocompleteItemText>
-              </AutocompleteItem>
-            )}
+          <AutocompleteList ref={listRef}>
+            <AutocompleteCollection<string>>
+              {(institution) => (
+                <AutocompleteItem key={institution} value={institution} title={institution}>
+                  <AutocompleteItemText>{institution}</AutocompleteItemText>
+                </AutocompleteItem>
+              )}
+            </AutocompleteCollection>
+            {hasNextPage ? (
+              <InfiniteScrollSentinel
+                canLoadMore={shouldOpenPopup && !isFetchingNextPage && !isFetchNextPageError}
+                onLoadMore={() => {
+                  void fetchNextPage({ cancelRefetch: false })
+                }}
+                preloadDistance={5}
+                scrollContainerRef={listRef}
+              />
+            ) : null}
           </AutocompleteList>
           <AutocompleteEmpty>
             {shouldShowEmpty ? t(($) => $['form.schoolName.noResults'], { ns: 'education' }) : null}
@@ -117,11 +132,15 @@ const InstitutionField = ({ value, onValueChange }: InstitutionFieldProps) => {
           <AutocompleteStatus className="p-0">
             {shouldShowLoading ? (
               <>
-                <span className="sr-only">{t(($) => $.loading, { ns: 'appApi' })}</span>
+                <span className="sr-only">{t(($) => $.loading, { ns: 'common' })}</span>
                 <div aria-hidden="true">
                   <Loading className="h-10" />
                 </div>
               </>
+            ) : shouldShowError ? (
+              <div className="px-3 py-2 text-text-destructive">
+                {t(($) => $['dynamicSelect.error'], { ns: 'common' })}
+              </div>
             ) : null}
           </AutocompleteStatus>
         </AutocompleteContent>

--- a/web/app/education/apply/institution-field.tsx
+++ b/web/app/education/apply/institution-field.tsx
@@ -12,7 +12,7 @@ import {
   AutocompleteStatus,
 } from '@langgenius/dify-ui/autocomplete'
 import { Field, FieldLabel } from '@langgenius/dify-ui/field'
-import { useInfiniteQuery } from '@tanstack/react-query'
+import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query'
 import { useDebouncedValue } from 'foxact/use-debounced-value'
 import { useId, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -34,15 +34,18 @@ const InstitutionField = ({ value, onValueChange }: InstitutionFieldProps) => {
   const [isPopupOpen, setIsPopupOpen] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
   const debouncedSearchQuery = useDebouncedValue(searchQuery, 300)
-  const isSearchReady = !!searchQuery && searchQuery === debouncedSearchQuery
+  const hasSearchQuery = !!searchQuery
+  const isDebouncing = hasSearchQuery && searchQuery !== debouncedSearchQuery
   const {
     data,
     fetchNextPage,
     hasNextPage,
     isError,
+    isFetching,
     isFetchingNextPage,
     isFetchNextPageError,
     isPending,
+    isPlaceholderData,
     isSuccess,
   } = useInfiniteQuery({
     ...consoleQuery.account.education.autocomplete.get.infiniteOptions({
@@ -57,14 +60,19 @@ const InstitutionField = ({ value, onValueChange }: InstitutionFieldProps) => {
       getNextPageParam: (lastPage, pages) =>
         lastPage.has_next ? (lastPage.curr_page ?? pages.length - 1) + 1 : undefined,
     }),
-    enabled: isSearchReady,
+    enabled: hasSearchQuery && !!debouncedSearchQuery,
+    placeholderData: keepPreviousData,
   })
-  const suggestions = isSearchReady ? (data?.pages.flatMap((page) => page.data ?? []) ?? []) : []
-  const isLoading = isPending || isFetchingNextPage
-  const shouldOpenPopup = isPopupOpen && isSearchReady
+  const suggestions = hasSearchQuery ? (data?.pages.flatMap((page) => page.data ?? []) ?? []) : []
+  const isSearching = isDebouncing || isPending || (isFetching && !isFetchingNextPage)
+  const isLoading = isSearching || isFetchingNextPage
+  const shouldOpenPopup = isPopupOpen && hasSearchQuery
   const shouldShowEmpty = shouldOpenPopup && isSuccess && !isLoading && suggestions.length === 0
-  const shouldShowLoading = shouldOpenPopup && isLoading
+  const shouldAnnounceLoading = shouldOpenPopup && isLoading
   const shouldShowError = shouldOpenPopup && isError && !isLoading
+  const shouldShowFooter = shouldOpenPopup && (isLoading || hasNextPage || shouldShowError)
+  const canLoadMore =
+    shouldOpenPopup && !isDebouncing && !isPlaceholderData && !isFetching && !isFetchNextPageError
 
   const handleValueChange = (inputValue: string, eventDetails: AutocompleteChangeEventDetails) => {
     onValueChange(inputValue)
@@ -115,33 +123,43 @@ const InstitutionField = ({ value, onValueChange }: InstitutionFieldProps) => {
                 </AutocompleteItem>
               )}
             </AutocompleteCollection>
-            {hasNextPage ? (
-              <InfiniteScrollSentinel
-                canLoadMore={shouldOpenPopup && !isFetchingNextPage && !isFetchNextPageError}
-                onLoadMore={() => {
-                  void fetchNextPage({ cancelRefetch: false })
-                }}
-                preloadDistance={5}
-                scrollContainerRef={listRef}
-              />
+            {shouldShowFooter ? (
+              <div
+                className="relative flex h-10 items-center justify-center px-3"
+                aria-hidden="true"
+              >
+                {hasNextPage ? (
+                  <InfiniteScrollSentinel
+                    className="absolute inset-x-0 top-0"
+                    canLoadMore={canLoadMore}
+                    onLoadMore={() => {
+                      void fetchNextPage({ cancelRefetch: false })
+                    }}
+                    preloadDistance={5}
+                    scrollContainerRef={listRef}
+                  />
+                ) : null}
+                {shouldShowError ? (
+                  <span className="system-sm-regular text-text-destructive">
+                    {t(($) => $['dynamicSelect.error'], { ns: 'common' })}
+                  </span>
+                ) : (
+                  <Loading className="h-10" />
+                )}
+              </div>
             ) : null}
           </AutocompleteList>
           <AutocompleteEmpty>
             {shouldShowEmpty ? t(($) => $['form.schoolName.noResults'], { ns: 'education' }) : null}
           </AutocompleteEmpty>
           <AutocompleteStatus className="p-0">
-            {shouldShowLoading ? (
-              <>
-                <span className="sr-only">{t(($) => $.loading, { ns: 'common' })}</span>
-                <div aria-hidden="true">
-                  <Loading className="h-10" />
-                </div>
-              </>
-            ) : shouldShowError ? (
-              <div className="px-3 py-2 text-text-destructive">
-                {t(($) => $['dynamicSelect.error'], { ns: 'common' })}
-              </div>
-            ) : null}
+            <span className="sr-only">
+              {shouldAnnounceLoading
+                ? t(($) => $.loading, { ns: 'common' })
+                : shouldShowError
+                  ? t(($) => $['dynamicSelect.error'], { ns: 'common' })
+                  : null}
+            </span>
           </AutocompleteStatus>
         </AutocompleteContent>
       </Autocomplete>


### PR DESCRIPTION
## Summary

- replace manual scroll measurements with the shared `InfiniteScrollSentinel` and explicit Base UI `AutocompleteCollection` anatomy
- keep a stable footer slot for initial and next-page loading states
- preserve the latest successful suggestions while input debounce and the next search request settle
- reduce the education field to the five TanStack Query facts it actually renders instead of deriving UI from overlapping pending, placeholder, and pagination flags
- block pagination while suggestions are loading or the query is in an error state
- disable focus looping so keyboard navigation stays at the loaded boundary until more suggestions arrive
- remove item color transitions from the shared Autocomplete and Combobox primitives so pointer and keyboard highlights update immediately
- keep loaded suggestions visible when a next-page request fails and expose async updates through `AutocompleteStatus`

## Why

The institution autocomplete previously coupled popup visibility and rendered items to a settled query. Continuing to type therefore cleared and closed the popup during the debounce window, then entered a fresh pending state when the query key changed. Manual scroll geometry also duplicated the shared infinite-scroll behavior, and Base UI focus looping moved keyboard users back to the input at the current page boundary.

The field also subscribed to several overlapping TanStack Query result flags even though initial search, refined search, and next-page requests share the same loading presentation. This made the rendering policy harder to follow without adding user-visible distinctions. Separately, the shared Autocomplete and Combobox items used a 150 ms color transition, causing their visual highlight to trail Base UI's synchronous active-item update during keyboard navigation.

This change keeps responsibilities separated: Base UI owns picker semantics and collection navigation, TanStack Query owns the latest successful remote result through `keepPreviousData`, the shared sentinel owns intersection observation, and the education field owns a small loading/error/footer policy. Only picker item feedback becomes immediate; trigger, popup, selected-value, and other overlay transitions are unchanged.

## User impact

Institution suggestions remain visible while a refined search loads and are replaced in place when the new response arrives. The popup no longer flashes closed between keystrokes, the loading row does not pop into the layout only after pagination starts, keyboard navigation waits at the current last suggestion while more results load, and Autocomplete and Combobox highlight feedback is immediate. Free-form institution entry remains supported.

## Validation

- `cd web && ../node_modules/.bin/vp test run app/education/apply/__tests__/institution-field.spec.tsx` (7 passed)
- `pnpm -C packages/dify-ui test -- src/autocomplete/__tests__/index.spec.tsx` (227 passed)
- `pnpm -C packages/dify-ui test -- src/combobox/__tests__/index.spec.tsx` (227 passed)
- `./node_modules/.bin/vp check packages/dify-ui/src/autocomplete/index.tsx packages/dify-ui/src/combobox/index.tsx web/app/education/apply/institution-field.tsx web/app/education/apply/__tests__/institution-field.spec.tsx`
- `pnpm check` (0 errors; existing repository warnings only)
- `git diff --check`
