### PR TITLE
test: migrate agent-v2 workflow sessions and ORM models to SQLite

### DIFF
--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_binding_resolver.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_binding_resolver.py
@@ -1,12 +1,11 @@
+from collections.abc import Iterator
 from uuid import uuid4
 
 import pytest
 from sqlalchemy import event, inspect
-from sqlalchemy.engine import Engine
 from sqlalchemy.orm import ORMExecuteState, Session, sessionmaker
 from sqlalchemy.sql import Executable
 
-import core.workflow.nodes.agent_v2.binding_resolver as resolver_module
 from core.workflow.nodes.agent_v2.binding_resolver import WorkflowAgentBindingError, WorkflowAgentBindingResolver
 from models.agent import (
     Agent,
@@ -104,24 +103,24 @@ def _binding(
     )
 
 
-def _bind_factory(monkeypatch: pytest.MonkeyPatch, sqlite_engine: Engine) -> list[Executable]:
+@pytest.fixture
+def orm_statements(sqlite_session_factory: sessionmaker[Session]) -> Iterator[list[Executable]]:
+    """Record statements executed by the service-owned SQLite sessions."""
     scalar_statements: list[Executable] = []
-
-    class RecordingSession(Session):
-        pass
 
     def record_statement(execute_state: ORMExecuteState) -> None:
         scalar_statements.append(execute_state.statement)
 
-    event.listen(RecordingSession, "do_orm_execute", record_statement)
-    factory = sessionmaker(bind=sqlite_engine, class_=RecordingSession, expire_on_commit=False)
-    monkeypatch.setattr(resolver_module.session_factory, "create_session", factory)
-    return scalar_statements
+    event.listen(sqlite_session_factory.class_, "do_orm_execute", record_statement)
+    try:
+        yield scalar_statements
+    finally:
+        event.remove(sqlite_session_factory.class_, "do_orm_execute", record_statement)
 
 
 @pytest.mark.parametrize("sqlite_session", [RESOLVER_MODELS], indirect=True)
 def test_binding_resolver_returns_detached_binding_bundle(
-    monkeypatch: pytest.MonkeyPatch, sqlite_engine: Engine, sqlite_session: Session
+    sqlite_session: Session,
 ) -> None:
     ids = _resolve_ids()
     agent = _agent(tenant_id=ids["tenant_id"])
@@ -138,8 +137,6 @@ def test_binding_resolver_returns_detached_binding_bundle(
     )
     sqlite_session.add(binding)
     sqlite_session.commit()
-    _bind_factory(monkeypatch, sqlite_engine)
-
     bundle = WorkflowAgentBindingResolver().resolve(**ids)
 
     assert bundle.binding.id == binding.id
@@ -152,7 +149,7 @@ def test_binding_resolver_returns_detached_binding_bundle(
 
 @pytest.mark.parametrize("sqlite_session", [RESOLVER_MODELS], indirect=True)
 def test_binding_resolver_uses_active_snapshot_for_roster_agent(
-    monkeypatch: pytest.MonkeyPatch, sqlite_engine: Engine, sqlite_session: Session
+    sqlite_session: Session,
 ) -> None:
     ids = _resolve_ids()
     agent = _agent(
@@ -174,8 +171,6 @@ def test_binding_resolver_uses_active_snapshot_for_roster_agent(
     )
     sqlite_session.add(binding)
     sqlite_session.commit()
-    _bind_factory(monkeypatch, sqlite_engine)
-
     bundle = WorkflowAgentBindingResolver().resolve(**ids)
 
     assert bundle.snapshot.id == active_snapshot.id
@@ -190,9 +185,8 @@ def test_binding_resolver_uses_active_snapshot_for_roster_agent(
 )
 @pytest.mark.parametrize("sqlite_session", [RESOLVER_MODELS], indirect=True)
 def test_binding_resolver_uses_pinned_snapshot_for_existing_node_execution(
-    monkeypatch: pytest.MonkeyPatch,
-    sqlite_engine: Engine,
     sqlite_session: Session,
+    orm_statements: list[Executable],
     binding_type: WorkflowAgentBindingType,
     scope: AgentScope,
     source: AgentSource,
@@ -217,8 +211,6 @@ def test_binding_resolver_uses_pinned_snapshot_for_existing_node_execution(
     )
     sqlite_session.add(binding)
     sqlite_session.commit()
-    scalar_statements = _bind_factory(monkeypatch, sqlite_engine)
-
     bundle = WorkflowAgentBindingResolver().resolve(
         **ids,
         binding_id=binding.id,
@@ -226,13 +218,13 @@ def test_binding_resolver_uses_pinned_snapshot_for_existing_node_execution(
     )
 
     assert bundle.snapshot.id == pinned_snapshot.id
-    assert binding.id in scalar_statements[0].compile().params.values()
-    assert pinned_snapshot.id in scalar_statements[-1].compile().params.values()
+    assert binding.id in orm_statements[0].compile().params.values()
+    assert pinned_snapshot.id in orm_statements[-1].compile().params.values()
 
 
 @pytest.mark.parametrize("sqlite_session", [RESOLVER_MODELS], indirect=True)
 def test_binding_resolver_does_not_fallback_from_an_explicit_empty_snapshot(
-    monkeypatch: pytest.MonkeyPatch, sqlite_engine: Engine, sqlite_session: Session
+    sqlite_session: Session,
 ) -> None:
     ids = _resolve_ids()
     agent = _agent(
@@ -254,8 +246,6 @@ def test_binding_resolver_does_not_fallback_from_an_explicit_empty_snapshot(
     )
     sqlite_session.add(binding)
     sqlite_session.commit()
-    _bind_factory(monkeypatch, sqlite_engine)
-
     with pytest.raises(WorkflowAgentBindingError) as exc_info:
         WorkflowAgentBindingResolver().resolve(**ids, binding_id=binding.id, snapshot_id="")
 
@@ -282,7 +272,7 @@ def test_binding_resolver_rejects_half_pinned_generation(
 
 @pytest.mark.parametrize("sqlite_session", [RESOLVER_MODELS], indirect=True)
 def test_binding_resolver_rejects_unpublished_roster_agent(
-    monkeypatch: pytest.MonkeyPatch, sqlite_engine: Engine, sqlite_session: Session
+    sqlite_session: Session,
 ) -> None:
     ids = _resolve_ids()
     snapshot_id = str(uuid4())
@@ -304,8 +294,6 @@ def test_binding_resolver_rejects_unpublished_roster_agent(
     )
     sqlite_session.add(binding)
     sqlite_session.commit()
-    _bind_factory(monkeypatch, sqlite_engine)
-
     with pytest.raises(WorkflowAgentBindingError) as exc_info:
         WorkflowAgentBindingResolver().resolve(**ids)
 
@@ -315,8 +303,6 @@ def test_binding_resolver_rejects_unpublished_roster_agent(
 
 @pytest.mark.parametrize("sqlite_session", [RESOLVER_MODELS], indirect=True)
 def test_binding_resolver_requires_publish_provenance_for_active_roster_snapshot(
-    monkeypatch: pytest.MonkeyPatch,
-    sqlite_engine: Engine,
     sqlite_session: Session,
 ) -> None:
     ids = _resolve_ids()
@@ -352,8 +338,6 @@ def test_binding_resolver_requires_publish_provenance_for_active_roster_snapshot
         ]
     )
     sqlite_session.commit()
-    _bind_factory(monkeypatch, sqlite_engine)
-
     with pytest.raises(WorkflowAgentBindingError) as exc_info:
         WorkflowAgentBindingResolver().resolve(**ids)
     assert exc_info.value.error_code == "agent_not_available"
@@ -375,9 +359,7 @@ def test_binding_resolver_requires_publish_provenance_for_active_roster_snapshot
     assert bundle.snapshot.id == snapshot.id
 
 
-def test_binding_resolver_raises_when_binding_missing(monkeypatch: pytest.MonkeyPatch, sqlite_engine: Engine) -> None:
-    _bind_factory(monkeypatch, sqlite_engine)
-
+def test_binding_resolver_raises_when_binding_missing() -> None:
     with pytest.raises(WorkflowAgentBindingError) as exc_info:
         WorkflowAgentBindingResolver().resolve(**_resolve_ids())
 
@@ -386,7 +368,7 @@ def test_binding_resolver_raises_when_binding_missing(monkeypatch: pytest.Monkey
 
 @pytest.mark.parametrize("sqlite_session", [RESOLVER_MODELS], indirect=True)
 def test_binding_resolver_raises_when_agent_archived(
-    monkeypatch: pytest.MonkeyPatch, sqlite_engine: Engine, sqlite_session: Session
+    sqlite_session: Session,
 ) -> None:
     ids = _resolve_ids()
     agent = _agent(tenant_id=ids["tenant_id"], status=AgentStatus.ARCHIVED)
@@ -400,8 +382,6 @@ def test_binding_resolver_raises_when_agent_archived(
     )
     sqlite_session.add(binding)
     sqlite_session.commit()
-    _bind_factory(monkeypatch, sqlite_engine)
-
     with pytest.raises(WorkflowAgentBindingError) as exc_info:
         WorkflowAgentBindingResolver().resolve(**ids)
 
@@ -410,7 +390,7 @@ def test_binding_resolver_raises_when_agent_archived(
 
 @pytest.mark.parametrize("sqlite_session", [RESOLVER_MODELS], indirect=True)
 def test_binding_resolver_raises_when_snapshot_missing(
-    monkeypatch: pytest.MonkeyPatch, sqlite_engine: Engine, sqlite_session: Session
+    sqlite_session: Session,
 ) -> None:
     ids = _resolve_ids()
     agent = _agent(tenant_id=ids["tenant_id"])
@@ -424,8 +404,6 @@ def test_binding_resolver_raises_when_snapshot_missing(
     )
     sqlite_session.add(binding)
     sqlite_session.commit()
-    _bind_factory(monkeypatch, sqlite_engine)
-
     with pytest.raises(WorkflowAgentBindingError) as exc_info:
         WorkflowAgentBindingResolver().resolve(**ids)
 

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_file_tenant_validator.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_file_tenant_validator.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime
 import pytest
 from sqlalchemy import Engine, event
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import Session
 
 from core.workflow.nodes.agent_v2.file_tenant_validator import UploadFileTenantValidator
 from extensions.storage.storage_type import StorageType
@@ -25,13 +25,6 @@ TABLES = (ToolFile, UploadFile)
 TENANT_ID = "11111111-1111-1111-1111-111111111111"
 OTHER_TENANT_ID = "22222222-2222-2222-2222-222222222222"
 USER_ID = "33333333-3333-3333-3333-333333333333"
-
-
-@pytest.fixture(autouse=True)
-def _bind_sqlite_session_factory(monkeypatch: pytest.MonkeyPatch, sqlite_engine: Engine) -> None:
-    """Bind the validator's service-owned sessions to the isolated SQLite engine."""
-    sqlite_session_maker = sessionmaker(bind=sqlite_engine, expire_on_commit=False)
-    monkeypatch.setattr("core.db.session_factory._session_maker", sqlite_session_maker)
 
 
 @pytest.fixture

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_session_store.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_session_store.py
@@ -1,21 +1,26 @@
 import json
+from collections.abc import Iterator
 from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 from agenton.compositor import CompositorSessionSnapshot
-from sqlalchemy.orm import Session
+from sqlalchemy import Engine, event, func, select
+from sqlalchemy.orm import Session, sessionmaker
 
 from core.workflow.nodes.agent_v2.session_store import WorkflowAgentSessionScope, WorkflowAgentWorkspaceStore
+from graphon.enums import WorkflowNodeExecutionStatus
 from models.agent import (
     AgentConfigVersionKind,
+    AgentHomeSnapshot,
     AgentWorkingResourceStatus,
     AgentWorkspace,
     AgentWorkspaceBinding,
     AgentWorkspaceOwnerType,
 )
-from models.workflow import WorkflowNodeExecutionModel
+from models.enums import CreatorUserRole
+from models.workflow import WorkflowNodeExecutionModel, WorkflowNodeExecutionTriggeredFrom
 from services.agent.workspace_service import AgentWorkspaceNotFoundError, AgentWorkspaceService
 from services.agent_app_sandbox_service import WorkflowAgentSandboxService
 
@@ -34,18 +39,35 @@ def _scope() -> WorkflowAgentSessionScope:
     )
 
 
-def _binding() -> SimpleNamespace:
-    return SimpleNamespace(
-        id="binding-1",
-        workspace_id="workspace-1",
-        agent_id="agent-1",
-        base_home_snapshot_id="home-1",
-        agent_config_version_id="config-1",
-        agent_config_version_kind=AgentConfigVersionKind.SNAPSHOT,
-        backend_binding_ref="backend-binding-1",
-        session_snapshot=None,
-        pending_form_id=None,
-        pending_tool_call_id=None,
+def _execution_row(
+    *,
+    binding_id: str | None = None,
+    process_data: dict[str, object] | None = None,
+) -> WorkflowNodeExecutionModel:
+    return WorkflowNodeExecutionModel(
+        id="execution-1",
+        tenant_id="tenant-1",
+        app_id="app-1",
+        workflow_id="workflow-1",
+        triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
+        workflow_run_id="run-1",
+        index=1,
+        predecessor_node_id=None,
+        node_execution_id="node-execution-1",
+        node_id="node-1",
+        node_type="agent",
+        title="Agent",
+        agent_workspace_binding_id=binding_id,
+        inputs="{}",
+        process_data=json.dumps(process_data) if process_data is not None else None,
+        outputs=None,
+        status=WorkflowNodeExecutionStatus.RUNNING,
+        error=None,
+        elapsed_time=0,
+        execution_metadata=None,
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by="user-1",
+        finished_at=None,
     )
 
 
@@ -75,6 +97,7 @@ def _binding_row(
     binding_id: str = "binding-1",
     workspace_id: str = "workspace-1",
     status: AgentWorkingResourceStatus = AgentWorkingResourceStatus.ACTIVE,
+    base_home_snapshot_id: str | None = "home-1",
 ) -> AgentWorkspaceBinding:
     return AgentWorkspaceBinding(
         id=binding_id,
@@ -82,12 +105,50 @@ def _binding_row(
         app_id="app-1",
         workspace_id=workspace_id,
         agent_id="agent-1",
-        base_home_snapshot_id="home-1",
+        base_home_snapshot_id=base_home_snapshot_id,
         agent_config_version_id="config-1",
         agent_config_version_kind=AgentConfigVersionKind.SNAPSHOT,
-        backend_binding_ref=f"{binding_id}-ref",
+        backend_binding_ref="backend-binding-1" if binding_id == "binding-1" else f"{binding_id}-ref",
         status=status,
     )
+
+
+def _home_snapshot() -> AgentHomeSnapshot:
+    return AgentHomeSnapshot(
+        id="home-1",
+        tenant_id="tenant-1",
+        agent_id="agent-1",
+        snapshot_ref="home-ref",
+        status=AgentWorkingResourceStatus.ACTIVE,
+    )
+
+
+def _install_backend_client(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    client = MagicMock()
+    client.create_execution_binding_sync.return_value = SimpleNamespace(
+        binding_ref="backend-binding-1",
+        workspace_ref="workspace-1-ref",
+    )
+    monkeypatch.setattr(AgentWorkspaceService, "_client", lambda: nullcontext(client))
+    return client
+
+
+@pytest.fixture
+def executed_statements(sqlite_engine: Engine) -> Iterator[list[str]]:
+    statements: list[str] = []
+
+    def record_statement(_connection, _cursor, statement, _parameters, _context, _executemany) -> None:
+        statements.append(statement)
+
+    event.listen(sqlite_engine, "before_cursor_execute", record_statement)
+    try:
+        yield statements
+    finally:
+        event.remove(sqlite_engine, "before_cursor_execute", record_statement)
+
+
+def _execution_selects(statements: list[str]) -> list[str]:
+    return [statement for statement in statements if "FROM workflow_node_executions" in statement]
 
 
 def test_scope_uses_node_and_workflow_binding_as_workspace_subscope() -> None:
@@ -97,24 +158,20 @@ def test_scope_uses_node_and_workflow_binding_as_workspace_subscope() -> None:
     assert owner.owner_scope_key == "node-1:workflow-binding-1"
 
 
-def test_load_existing_scope_reads_the_generation_from_the_persisted_binding(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    execution = SimpleNamespace(
-        agent_workspace_binding_id="binding-1",
-        process_data_dict={"workflow_agent_binding_id": "workflow-binding-1"},
+def test_load_existing_scope_reads_the_generation_from_the_persisted_binding(sqlite_session: Session) -> None:
+    sqlite_session.add_all(
+        [
+            _execution_row(
+                binding_id="binding-1",
+                process_data={"workflow_agent_binding_id": "workflow-binding-1"},
+            ),
+            _workspace_row(),
+            _binding_row(),
+        ]
     )
-    context = MagicMock()
-    store = WorkflowAgentWorkspaceStore()
-    monkeypatch.setattr(
-        "core.workflow.nodes.agent_v2.session_store.session_factory.create_session",
-        lambda: context,
-    )
-    monkeypatch.setattr(store, "_load_execution_by_identity", MagicMock(return_value=execution))
-    get_active = MagicMock(return_value=_binding())
-    monkeypatch.setattr(AgentWorkspaceService, "get_active_binding", get_active)
+    sqlite_session.commit()
 
-    scope = store.load_existing_node_execution_scope(
+    scope = WorkflowAgentWorkspaceStore().load_existing_node_execution_scope(
         tenant_id="tenant-1",
         app_id="app-1",
         workflow_id="workflow-1",
@@ -127,25 +184,19 @@ def test_load_existing_scope_reads_the_generation_from_the_persisted_binding(
     assert scope.workflow_agent_binding_id == "workflow-binding-1"
     assert scope.agent_id == "agent-1"
     assert scope.agent_config_snapshot_id == "config-1"
-    assert get_active.call_args.kwargs["binding_id"] == "binding-1"
 
 
-def test_load_existing_scope_rejects_unavailable_persisted_binding(monkeypatch: pytest.MonkeyPatch) -> None:
-    execution = SimpleNamespace(
-        agent_workspace_binding_id="binding-missing",
-        process_data_dict={"workflow_agent_binding_id": "workflow-binding-1"},
+def test_load_existing_scope_rejects_unavailable_persisted_binding(sqlite_session: Session) -> None:
+    sqlite_session.add(
+        _execution_row(
+            binding_id="binding-missing",
+            process_data={"workflow_agent_binding_id": "workflow-binding-1"},
+        )
     )
-    context = MagicMock()
-    store = WorkflowAgentWorkspaceStore()
-    monkeypatch.setattr(
-        "core.workflow.nodes.agent_v2.session_store.session_factory.create_session",
-        lambda: context,
-    )
-    monkeypatch.setattr(store, "_load_execution_by_identity", MagicMock(return_value=execution))
-    monkeypatch.setattr(AgentWorkspaceService, "get_active_binding", MagicMock(return_value=None))
+    sqlite_session.commit()
 
     with pytest.raises(AgentWorkspaceNotFoundError, match="participant Binding is unavailable"):
-        store.load_existing_node_execution_scope(
+        WorkflowAgentWorkspaceStore().load_existing_node_execution_scope(
             tenant_id="tenant-1",
             app_id="app-1",
             workflow_id="workflow-1",
@@ -156,182 +207,128 @@ def test_load_existing_scope_rejects_unavailable_persisted_binding(monkeypatch: 
 
 
 @pytest.mark.parametrize("home_snapshot_id", ["home-1", None])
-def test_load_or_create_persists_binding_on_node_execution(monkeypatch, home_snapshot_id: str | None) -> None:
-    execution = WorkflowNodeExecutionModel(
-        agent_workspace_binding_id=None,
-        process_data=json.dumps({"existing": "value"}),
-    )
-    context = MagicMock()
-    session = context.__enter__.return_value
-    create = MagicMock(return_value=_binding())
-    store = WorkflowAgentWorkspaceStore()
-    monkeypatch.setattr(
-        "core.workflow.nodes.agent_v2.session_store.session_factory.create_session",
-        lambda: context,
-    )
-    monkeypatch.setattr(store, "_load_execution", MagicMock(return_value=execution))
-    monkeypatch.setattr(AgentWorkspaceService, "create_binding", create)
+def test_load_or_create_persists_binding_on_node_execution(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_session: Session,
+    home_snapshot_id: str | None,
+) -> None:
+    execution = _execution_row(process_data={"existing": "value"})
+    rows: list[object] = [execution]
+    if home_snapshot_id is not None:
+        rows.append(_home_snapshot())
+    sqlite_session.add_all(rows)
+    sqlite_session.commit()
+    _install_backend_client(monkeypatch)
 
-    stored = store.load_or_create_node_execution_session(_scope(), home_snapshot_id=home_snapshot_id)
+    stored = WorkflowAgentWorkspaceStore().load_or_create_node_execution_session(
+        _scope(), home_snapshot_id=home_snapshot_id
+    )
 
-    assert stored.binding_id == "binding-1"
-    assert stored.workspace_id == "workspace-1"
+    sqlite_session.expire_all()
+    persisted_execution = sqlite_session.get(WorkflowNodeExecutionModel, execution.id)
+    assert persisted_execution is not None
+    assert stored.workspace_id
     assert stored.backend_binding_ref == "backend-binding-1"
-    assert execution.agent_workspace_binding_id == "binding-1"
-    assert execution.process_data_dict == {
+    assert persisted_execution.agent_workspace_binding_id == stored.binding_id
+    assert persisted_execution.process_data_dict == {
         "existing": "value",
         "workflow_agent_binding_id": "workflow-binding-1",
     }
-    assert "agent_workspace_binding_id" not in execution.process_data_dict
-    assert create.call_args.kwargs["session"] is session
-    assert create.call_args.kwargs["base_home_snapshot_id"] == home_snapshot_id
-    session.commit.assert_called_once_with()
+    assert "agent_workspace_binding_id" not in persisted_execution.process_data_dict
+    persisted_binding = sqlite_session.get(AgentWorkspaceBinding, stored.binding_id)
+    assert persisted_binding is not None
+    assert persisted_binding.base_home_snapshot_id == home_snapshot_id
 
-    get_active = MagicMock(return_value=_binding())
-    monkeypatch.setattr(AgentWorkspaceService, "get_active_binding", get_active)
-    session.scalar.return_value = execution
     resolved = WorkflowAgentSandboxService._resolve_binding(
         tenant_id="tenant-1",
         app_id="app-1",
         workflow_run_id="run-1",
         node_id="node-1",
         node_execution_id="execution-1",
-        session=session,
+        session=sqlite_session,
     )
 
     assert resolved.backend_binding_ref == "backend-binding-1"
     assert resolved.agent_id == "agent-1"
     assert resolved.agent_config_version_id == "config-1"
     assert resolved.agent_config_version_kind == "snapshot"
-    owner_scope = get_active.call_args.kwargs["expected_owner_scope"]
-    assert owner_scope.owner_scope_key == "node-1:workflow-binding-1"
-    session.rollback.assert_called_once_with()
 
 
-def test_load_existing_pointer_rejects_missing_workflow_identity(monkeypatch: pytest.MonkeyPatch) -> None:
-    execution = SimpleNamespace(
-        agent_workspace_binding_id="binding-1",
-        process_data=json.dumps({"existing": "value"}),
-        process_data_dict={"existing": "value"},
-    )
-    context = MagicMock()
-    session = context.__enter__.return_value
-    store = WorkflowAgentWorkspaceStore()
-    monkeypatch.setattr(
-        "core.workflow.nodes.agent_v2.session_store.session_factory.create_session",
-        lambda: context,
-    )
-    monkeypatch.setattr(store, "_load_execution", MagicMock(return_value=execution))
-    get_active = MagicMock()
-    monkeypatch.setattr(AgentWorkspaceService, "get_active_binding", get_active)
+def test_load_existing_pointer_rejects_missing_workflow_identity(sqlite_session: Session) -> None:
+    execution = _execution_row(binding_id="binding-1", process_data={"existing": "value"})
+    sqlite_session.add(execution)
+    sqlite_session.commit()
 
     with pytest.raises(AgentWorkspaceNotFoundError, match="caller identity is missing"):
-        store.load_or_create_node_execution_session(_scope(), home_snapshot_id="home-1")
+        WorkflowAgentWorkspaceStore().load_or_create_node_execution_session(_scope(), home_snapshot_id="home-1")
 
-    assert json.loads(execution.process_data) == {"existing": "value"}
-    get_active.assert_not_called()
-    session.commit.assert_not_called()
+    sqlite_session.expire(execution)
+    assert execution.process_data_dict == {"existing": "value"}
+    assert sqlite_session.scalar(select(func.count()).select_from(AgentWorkspaceBinding)) == 0
 
 
-def test_load_existing_pointer_reuses_matching_workflow_identity(monkeypatch: pytest.MonkeyPatch) -> None:
-    original_process_data = json.dumps(
-        {
-            "existing": "value",
-            "workflow_agent_binding_id": "workflow-binding-1",
-        }
-    )
-    execution = SimpleNamespace(
-        agent_workspace_binding_id="binding-1",
-        process_data=original_process_data,
-        process_data_dict=json.loads(original_process_data),
-    )
-    context = MagicMock()
-    session = context.__enter__.return_value
-    store = WorkflowAgentWorkspaceStore()
-    create = MagicMock()
-    binding = _binding()
-    validate_generation = MagicMock()
-    monkeypatch.setattr(
-        "core.workflow.nodes.agent_v2.session_store.session_factory.create_session",
-        lambda: context,
-    )
-    monkeypatch.setattr(store, "_load_execution", MagicMock(return_value=execution))
-    monkeypatch.setattr(AgentWorkspaceService, "create_binding", create)
-    monkeypatch.setattr(AgentWorkspaceService, "get_active_binding", MagicMock(return_value=binding))
-    monkeypatch.setattr(AgentWorkspaceService, "validate_binding_generation", validate_generation)
+def test_load_existing_pointer_reuses_matching_workflow_identity(sqlite_session: Session) -> None:
+    original_process_data = {
+        "existing": "value",
+        "workflow_agent_binding_id": "workflow-binding-1",
+    }
+    execution = _execution_row(binding_id="binding-1", process_data=original_process_data)
+    sqlite_session.add_all([execution, _workspace_row(), _binding_row()])
+    sqlite_session.commit()
 
-    stored = store.load_or_create_node_execution_session(_scope(), home_snapshot_id="home-1")
+    stored = WorkflowAgentWorkspaceStore().load_or_create_node_execution_session(_scope(), home_snapshot_id="home-1")
 
+    sqlite_session.expire(execution)
     assert stored.binding_id == "binding-1"
-    assert execution.process_data == original_process_data
+    assert execution.process_data_dict == original_process_data
     assert "agent_workspace_binding_id" not in execution.process_data_dict
-    create.assert_not_called()
-    session.commit.assert_not_called()
-    validate_generation.assert_called_once_with(
-        binding,
-        base_home_snapshot_id="home-1",
-        agent_config_version_id="config-1",
-        agent_config_version_kind=AgentConfigVersionKind.SNAPSHOT,
-    )
+    assert sqlite_session.scalar(select(func.count()).select_from(AgentWorkspaceBinding)) == 1
 
 
-def test_load_existing_pointer_rejects_conflicting_workflow_identity(monkeypatch: pytest.MonkeyPatch) -> None:
-    execution = SimpleNamespace(
-        agent_workspace_binding_id="binding-1",
-        process_data=json.dumps({"workflow_agent_binding_id": "workflow-binding-other"}),
-        process_data_dict={"workflow_agent_binding_id": "workflow-binding-other"},
+def test_load_existing_pointer_rejects_conflicting_workflow_identity(sqlite_session: Session) -> None:
+    execution = _execution_row(
+        binding_id="binding-1",
+        process_data={"workflow_agent_binding_id": "workflow-binding-other"},
     )
-    context = MagicMock()
-    session = context.__enter__.return_value
-    store = WorkflowAgentWorkspaceStore()
-    get_active = MagicMock()
-    monkeypatch.setattr(
-        "core.workflow.nodes.agent_v2.session_store.session_factory.create_session",
-        lambda: context,
-    )
-    monkeypatch.setattr(store, "_load_execution", MagicMock(return_value=execution))
-    monkeypatch.setattr(AgentWorkspaceService, "get_active_binding", get_active)
+    sqlite_session.add(execution)
+    sqlite_session.commit()
 
     with pytest.raises(AgentWorkspaceNotFoundError, match="caller identity does not match"):
-        store.load_or_create_node_execution_session(_scope(), home_snapshot_id="home-1")
+        WorkflowAgentWorkspaceStore().load_or_create_node_execution_session(_scope(), home_snapshot_id="home-1")
 
-    get_active.assert_not_called()
-    session.commit.assert_not_called()
+    assert sqlite_session.scalar(select(func.count()).select_from(AgentWorkspaceBinding)) == 0
 
 
-def test_load_or_create_fails_before_binding_create_when_caller_row_is_missing(monkeypatch: pytest.MonkeyPatch) -> None:
-    context = MagicMock()
-    session = context.__enter__.return_value
-    create = MagicMock()
+def test_load_or_create_fails_before_binding_create_when_caller_row_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_session: Session,
+    executed_statements: list[str],
+) -> None:
     sleep = MagicMock()
-    store = WorkflowAgentWorkspaceStore()
-    monkeypatch.setattr(
-        "core.workflow.nodes.agent_v2.session_store.session_factory.create_session",
-        lambda: context,
-    )
     monkeypatch.setattr("core.workflow.nodes.agent_v2.session_store.time.sleep", sleep)
-    monkeypatch.setattr(session, "scalar", MagicMock(return_value=None))
-    monkeypatch.setattr(AgentWorkspaceService, "create_binding", create)
 
     with pytest.raises(AgentWorkspaceNotFoundError, match="Workflow node execution caller is unavailable"):
-        store.load_or_create_node_execution_session(_scope(), home_snapshot_id="home-1")
+        WorkflowAgentWorkspaceStore().load_or_create_node_execution_session(_scope(), home_snapshot_id="home-1")
 
-    assert session.scalar.call_count == 60
+    assert len(_execution_selects(executed_statements)) == 60
     assert sleep.call_count == 59
-    create.assert_not_called()
-    session.commit.assert_not_called()
+    assert sqlite_session.scalar(select(func.count()).select_from(AgentWorkspaceBinding)) == 0
 
 
-def test_load_existing_scope_waits_for_caller_row_to_become_visible(monkeypatch: pytest.MonkeyPatch) -> None:
-    execution = SimpleNamespace(agent_workspace_binding_id=None)
-    context = MagicMock()
-    session = context.__enter__.return_value
-    session.scalar.side_effect = [None, None, execution]
+def test_load_existing_scope_waits_for_caller_row_to_become_visible(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_session_factory: sessionmaker[Session],
+    executed_statements: list[str],
+) -> None:
     sleep = MagicMock()
-    monkeypatch.setattr(
-        "core.workflow.nodes.agent_v2.session_store.session_factory.create_session",
-        lambda: context,
-    )
+
+    def make_caller_visible(_seconds: float) -> None:
+        if sleep.call_count == 2:
+            with sqlite_session_factory() as observer:
+                observer.add(_execution_row())
+                observer.commit()
+
+    sleep.side_effect = make_caller_visible
     monkeypatch.setattr("core.workflow.nodes.agent_v2.session_store.time.sleep", sleep)
 
     scope = WorkflowAgentWorkspaceStore().load_existing_node_execution_scope(
@@ -344,24 +341,27 @@ def test_load_existing_scope_waits_for_caller_row_to_become_visible(monkeypatch:
     )
 
     assert scope is None
-    assert session.scalar.call_count == 3
+    assert len(_execution_selects(executed_statements)) == 3
     assert sleep.call_count == 2
 
 
-def test_save_snapshot_targets_binding(monkeypatch: pytest.MonkeyPatch) -> None:
-    save = MagicMock()
-    monkeypatch.setattr(AgentWorkspaceService, "save_binding_session_snapshot", save)
+def test_save_snapshot_targets_binding(sqlite_session: Session) -> None:
+    binding = _binding_row()
+    sqlite_session.add_all([_workspace_row(), binding])
+    sqlite_session.commit()
     snapshot = CompositorSessionSnapshot(layers=[])
 
-    WorkflowAgentWorkspaceStore().save_active_snapshot(scope=_scope(), binding_id="binding-1", snapshot=snapshot)
+    WorkflowAgentWorkspaceStore().save_active_snapshot(
+        scope=_scope(),
+        binding_id=binding.id,
+        snapshot=snapshot,
+    )
 
-    assert save.call_args.kwargs["binding_id"] == "binding-1"
+    sqlite_session.expire(binding)
+    assert binding.session_snapshot == snapshot.model_dump_json()
 
 
-@pytest.mark.parametrize("sqlite_session", [(AgentWorkspace, AgentWorkspaceBinding)], indirect=True)
-def test_retire_workflow_run_only_retires_matching_tenant_and_app(
-    monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
-) -> None:
+def test_retire_workflow_run_only_retires_matching_tenant_and_app(sqlite_session: Session) -> None:
     matching = _workspace_row()
     other_tenant = _workspace_row(workspace_id="workspace-other-tenant", tenant_id="tenant-2")
     other_app = _workspace_row(
@@ -371,10 +371,6 @@ def test_retire_workflow_run_only_retires_matching_tenant_and_app(
     )
     sqlite_session.add_all([matching, other_tenant, other_app])
     sqlite_session.commit()
-    monkeypatch.setattr(
-        "core.workflow.nodes.agent_v2.session_store.session_factory.create_session",
-        lambda: nullcontext(sqlite_session),
-    )
 
     workspace_ids = WorkflowAgentWorkspaceStore().retire_workflow_run(
         tenant_id="tenant-1",
@@ -382,24 +378,18 @@ def test_retire_workflow_run_only_retires_matching_tenant_and_app(
         workflow_run_id="run-1",
     )
 
+    sqlite_session.expire_all()
     assert matching.status is AgentWorkingResourceStatus.RETIRED
     assert other_tenant.status is AgentWorkingResourceStatus.ACTIVE
     assert other_app.status is AgentWorkingResourceStatus.ACTIVE
     assert workspace_ids == [matching.id]
 
 
-@pytest.mark.parametrize("sqlite_session", [(AgentWorkspace, AgentWorkspaceBinding)], indirect=True)
-def test_retire_workflow_run_transitions_active_workspace(
-    monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
-) -> None:
+def test_retire_workflow_run_transitions_active_workspace(sqlite_session: Session) -> None:
     workspace = _workspace_row()
     binding = _binding_row()
     sqlite_session.add_all([workspace, binding])
     sqlite_session.commit()
-    monkeypatch.setattr(
-        "core.workflow.nodes.agent_v2.session_store.session_factory.create_session",
-        lambda: nullcontext(sqlite_session),
-    )
 
     workspace_ids = WorkflowAgentWorkspaceStore().retire_workflow_run(
         tenant_id="tenant-1",
@@ -407,22 +397,16 @@ def test_retire_workflow_run_transitions_active_workspace(
         workflow_run_id="run-1",
     )
 
+    sqlite_session.expire_all()
     assert workspace.status is AgentWorkingResourceStatus.RETIRED
     assert binding.status is AgentWorkingResourceStatus.RETIRED
     assert workspace_ids == [workspace.id]
 
 
-def test_retire_workflow_run_returns_existing_retired_workspace(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_retire_workflow_run_returns_existing_retired_workspace(sqlite_session: Session) -> None:
     workspace = _workspace_row(status=AgentWorkingResourceStatus.RETIRED)
-    context = MagicMock()
-    session = context.__enter__.return_value
-    session.scalars.return_value.all.return_value = [workspace]
-    retire = MagicMock()
-    monkeypatch.setattr(
-        "core.workflow.nodes.agent_v2.session_store.session_factory.create_session",
-        lambda: context,
-    )
-    monkeypatch.setattr(AgentWorkspaceService, "retire_workspace", retire)
+    sqlite_session.add(workspace)
+    sqlite_session.commit()
 
     workspace_ids = WorkflowAgentWorkspaceStore().retire_workflow_run(
         tenant_id="tenant-1",
@@ -430,5 +414,6 @@ def test_retire_workflow_run_returns_existing_retired_workspace(monkeypatch: pyt
         workflow_run_id="run-1",
     )
 
-    retire.assert_not_called()
+    sqlite_session.expire(workspace)
+    assert workspace.status is AgentWorkingResourceStatus.RETIRED
     assert workspace_ids == [workspace.id]

--- a/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_validators.py
+++ b/api/tests/unit_tests/core/workflow/nodes/agent_v2/test_validators.py
@@ -1,15 +1,27 @@
 import json
-from types import SimpleNamespace
+from datetime import UTC, datetime
 from unittest.mock import Mock
 
 import pytest
+from sqlalchemy.orm import Session
 
 from core.workflow.nodes.agent_v2.validators import (
     WorkflowAgentNodeValidationError,
     WorkflowAgentNodeValidator,
 )
-from models.agent import Agent, AgentConfigSnapshot, AgentStatus, WorkflowAgentBindingType, WorkflowAgentNodeBinding
+from extensions.storage.storage_type import StorageType
+from models.agent import (
+    Agent,
+    AgentConfigSnapshot,
+    AgentScope,
+    AgentSource,
+    AgentStatus,
+    WorkflowAgentBindingType,
+    WorkflowAgentNodeBinding,
+)
 from models.agent_config_entities import AgentSoulConfig, AgentSoulModelConfig, WorkflowNodeJobConfig
+from models.enums import CreatorUserRole
+from models.model import UploadFile
 from models.workflow import Workflow
 
 
@@ -28,7 +40,9 @@ def _binding(node_job: WorkflowNodeJobConfig) -> WorkflowAgentNodeBinding:
         tenant_id="tenant-1",
         app_id="app-1",
         workflow_id="workflow-1",
+        workflow_version="draft",
         node_id="agent-node",
+        binding_type=WorkflowAgentBindingType.INLINE_AGENT,
         agent_id="agent-1",
         current_snapshot_id="snapshot-1",
         node_job_config=node_job,
@@ -36,7 +50,14 @@ def _binding(node_job: WorkflowNodeJobConfig) -> WorkflowAgentNodeBinding:
 
 
 def _agent() -> Agent:
-    return Agent(id="agent-1", tenant_id="tenant-1", name="Agent", status=AgentStatus.ACTIVE)
+    return Agent(
+        id="agent-1",
+        tenant_id="tenant-1",
+        name="Agent",
+        status=AgentStatus.ACTIVE,
+        scope=AgentScope.WORKFLOW_ONLY,
+        source=AgentSource.WORKFLOW,
+    )
 
 
 def _snapshot() -> AgentConfigSnapshot:
@@ -133,15 +154,49 @@ def test_historical_agent_version_two_is_not_validated_as_dify_agent() -> None:
     session.scalar.assert_not_called()
 
 
-def test_publish_validation_accepts_upstream_previous_output_ref():
+def _persist_validation_scope(
+    session: Session,
+    *,
+    node_job: WorkflowNodeJobConfig,
+    binding: WorkflowAgentNodeBinding | None = None,
+    agent: Agent | None = None,
+    snapshot: AgentConfigSnapshot | None = None,
+    extras: tuple[object, ...] = (),
+) -> tuple[WorkflowAgentNodeBinding, Agent, AgentConfigSnapshot]:
+    binding = binding or _binding(node_job)
+    agent = agent or _agent()
+    snapshot = snapshot or _snapshot()
+    session.add_all([binding, agent, snapshot, *extras])
+    session.commit()
+    return binding, agent, snapshot
+
+
+def _upload_file(*, file_id: str = "file-1", tenant_id: str = "tenant-1") -> UploadFile:
+    upload_file = UploadFile(
+        tenant_id=tenant_id,
+        storage_type=StorageType.LOCAL,
+        key="files/benchmark.txt",
+        name="benchmark.txt",
+        size=10,
+        extension="txt",
+        mime_type="text/plain",
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by="user-1",
+        created_at=datetime.now(UTC),
+        used=True,
+    )
+    upload_file.id = file_id
+    return upload_file
+
+
+def test_publish_validation_accepts_upstream_previous_output_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate(
         {"previous_node_output_refs": [{"node_id": "previous-node", "output": "text"}]}
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    _persist_validation_scope(sqlite_session, node_job=node_job)
 
     WorkflowAgentNodeValidator.validate_published_workflow(
-        session=session,
+        session=sqlite_session,
         workflow=_workflow(
             _graph(
                 [
@@ -153,47 +208,49 @@ def test_publish_validation_accepts_upstream_previous_output_ref():
     )
 
 
-def test_publish_validation_uses_active_snapshot_for_roster_agent():
+def test_publish_validation_uses_active_snapshot_for_roster_agent(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig()
     binding = _binding(node_job)
     binding.binding_type = WorkflowAgentBindingType.ROSTER_AGENT
     binding.current_snapshot_id = "old-snapshot"
     agent = _agent()
+    agent.scope = AgentScope.ROSTER
+    agent.source = AgentSource.ROSTER
     agent.active_config_snapshot_id = "active-snapshot"
+    agent.active_config_has_model = True
+    agent.active_config_is_published = True
     snapshot = _snapshot()
     snapshot.id = "active-snapshot"
-    session = Mock()
-    session.scalar.side_effect = [binding, agent, snapshot]
+    _persist_validation_scope(sqlite_session, node_job=node_job, binding=binding, agent=agent, snapshot=snapshot)
 
     WorkflowAgentNodeValidator.validate_published_workflow(
-        session=session,
+        session=sqlite_session,
         workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
     )
 
 
-def test_publish_validation_rejects_unpublished_roster_agent():
+def test_publish_validation_rejects_unpublished_roster_agent(sqlite_session: Session):
     binding = _binding(WorkflowNodeJobConfig())
     binding.binding_type = WorkflowAgentBindingType.ROSTER_AGENT
-    session = Mock()
-    session.scalar.side_effect = [binding, None]
+    sqlite_session.add(binding)
+    sqlite_session.commit()
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="unpublished roster agent"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
 
-def test_publish_validation_rejects_non_upstream_previous_output_ref():
+def test_publish_validation_rejects_non_upstream_previous_output_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate(
         {"previous_node_output_refs": [{"node_id": "later-node", "output": "text"}]}
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    _persist_validation_scope(sqlite_session, node_job=node_job)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="non-upstream"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(
                 _graph(
                     [
@@ -205,38 +262,33 @@ def test_publish_validation_rejects_non_upstream_previous_output_ref():
         )
 
 
-def test_draft_validation_allows_unbound_agent_node():
-    session = Mock()
-    session.scalar.return_value = None
-
+def test_draft_validation_allows_unbound_agent_node(sqlite_session: Session):
     WorkflowAgentNodeValidator.validate_draft_workflow(
-        session=session,
+        session=sqlite_session,
         workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
     )
 
 
-def test_draft_validation_allows_missing_previous_node():
+def test_draft_validation_allows_missing_previous_node(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate(
         {"previous_node_output_refs": [{"node_id": "missing-node", "output": "text"}]}
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    _persist_validation_scope(sqlite_session, node_job=node_job)
 
     WorkflowAgentNodeValidator.validate_draft_workflow(
-        session=session,
+        session=sqlite_session,
         workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
     )
 
 
-def test_draft_validation_allows_non_upstream_previous_output_ref():
+def test_draft_validation_allows_non_upstream_previous_output_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate(
         {"previous_node_output_refs": [{"node_id": "later-node", "output": "text"}]}
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    _persist_validation_scope(sqlite_session, node_job=node_job)
 
     WorkflowAgentNodeValidator.validate_draft_workflow(
-        session=session,
+        session=sqlite_session,
         workflow=_workflow(
             _graph(
                 [
@@ -266,30 +318,26 @@ def test_draft_validation_allows_missing_agent_soul_model():
     )
 
 
-def test_draft_validation_rejects_incomplete_previous_output_ref():
+def test_draft_validation_rejects_incomplete_previous_output_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({"previous_node_output_refs": [{"selector": ["previous-node"]}]})
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    _persist_validation_scope(sqlite_session, node_job=node_job)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="incomplete previous node output ref"):
         WorkflowAgentNodeValidator.validate_draft_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
 
-def test_publish_validation_requires_binding():
-    session = Mock()
-    session.scalar.return_value = None
-
+def test_publish_validation_requires_binding(sqlite_session: Session):
     with pytest.raises(WorkflowAgentNodeValidationError, match="requires a binding"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
 
-def test_publish_validation_rejects_duplicate_output_names():
+def test_publish_validation_rejects_duplicate_output_names(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate(
         {
             "declared_outputs": [
@@ -298,17 +346,16 @@ def test_publish_validation_rejects_duplicate_output_names():
             ]
         }
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    _persist_validation_scope(sqlite_session, node_job=node_job)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="duplicate output name"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
 
-def test_publish_validation_rejects_missing_agent_soul_model():
+def test_publish_validation_rejects_missing_agent_soul_model(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({})
     snapshot = AgentConfigSnapshot(
         id="snapshot-1",
@@ -317,17 +364,16 @@ def test_publish_validation_rejects_missing_agent_soul_model():
         version=1,
         config_snapshot=AgentSoulConfig(),
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
+    _persist_validation_scope(sqlite_session, node_job=node_job, snapshot=snapshot)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="requires Agent Soul model"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
 
-def test_publish_validation_dedupes_provider_level_tool_entries():
+def test_publish_validation_dedupes_provider_level_tool_entries(sqlite_session: Session):
     """Provider-level entries (tool_name omitted = all tools of the provider)
     dedupe per provider; one provider-level + one explicit tool entry for the
     same provider is fine (the runtime builder reconciles those)."""
@@ -354,17 +400,16 @@ def test_publish_validation_dedupes_provider_level_tool_entries():
             ]
         },
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
+    _persist_validation_scope(sqlite_session, node_job=node_job, snapshot=snapshot)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="duplicate Dify Plugin Tool"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
 
-def test_publish_validation_accepts_provider_level_plus_explicit_tool_entry():
+def test_publish_validation_accepts_provider_level_plus_explicit_tool_entry(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({})
     snapshot = _snapshot()
     snapshot.config_snapshot = AgentSoulConfig(
@@ -389,16 +434,15 @@ def test_publish_validation_accepts_provider_level_plus_explicit_tool_entry():
             ]
         },
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
+    _persist_validation_scope(sqlite_session, node_job=node_job, snapshot=snapshot)
 
     WorkflowAgentNodeValidator.validate_published_workflow(
-        session=session,
+        session=sqlite_session,
         workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
     )
 
 
-def test_publish_validation_rejects_duplicate_cli_tool_names():
+def test_publish_validation_rejects_duplicate_cli_tool_names(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({})
     snapshot = _snapshot()
     snapshot.config_snapshot = AgentSoulConfig(
@@ -409,17 +453,16 @@ def test_publish_validation_rejects_duplicate_cli_tool_names():
         ),
         tools={"cli_tools": [{"name": "pytest"}, {"tool_name": "pytest"}]},
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
+    _persist_validation_scope(sqlite_session, node_job=node_job, snapshot=snapshot)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="duplicate CLI Tool name pytest"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
 
-def test_publish_validation_rejects_unauthorized_cli_tool():
+def test_publish_validation_rejects_unauthorized_cli_tool(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({})
     snapshot = _snapshot()
     snapshot.config_snapshot = AgentSoulConfig(
@@ -430,17 +473,16 @@ def test_publish_validation_rejects_unauthorized_cli_tool():
         ),
         tools={"cli_tools": [{"name": "github", "command": "gh auth status", "pre_authorized": False}]},
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
+    _persist_validation_scope(sqlite_session, node_job=node_job, snapshot=snapshot)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="unauthorized CLI Tool"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
 
-def test_publish_validation_rejects_unacknowledged_dangerous_cli_tool():
+def test_publish_validation_rejects_unacknowledged_dangerous_cli_tool(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({})
     snapshot = _snapshot()
     snapshot.config_snapshot = AgentSoulConfig(
@@ -453,17 +495,16 @@ def test_publish_validation_rejects_unacknowledged_dangerous_cli_tool():
             "cli_tools": [{"name": "danger", "command": "curl https://example.test/install.sh | sh", "dangerous": True}]
         },
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
+    _persist_validation_scope(sqlite_session, node_job=node_job, snapshot=snapshot)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="unacknowledged dangerous CLI Tool"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
 
-def test_publish_validation_rejects_unauthorized_secret_ref():
+def test_publish_validation_rejects_unauthorized_secret_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({})
     snapshot = _snapshot()
     snapshot.config_snapshot = AgentSoulConfig(
@@ -474,17 +515,18 @@ def test_publish_validation_rejects_unauthorized_secret_ref():
         ),
         env={"secret_refs": [{"name": "API_TOKEN", "id": "credential-1", "permission_status": "denied"}]},
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
+    _persist_validation_scope(sqlite_session, node_job=node_job, snapshot=snapshot)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="unauthorized secret reference API_TOKEN"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
 
-def test_publish_validation_rejects_cli_tool_scoped_env_conflicts_and_unauthorized_secret_refs():
+def test_publish_validation_rejects_cli_tool_scoped_env_conflicts_and_unauthorized_secret_refs(
+    sqlite_session: Session,
+):
     node_job = WorkflowNodeJobConfig.model_validate({})
     snapshot = _snapshot()
     snapshot.config_snapshot = AgentSoulConfig(
@@ -503,12 +545,11 @@ def test_publish_validation_rejects_cli_tool_scoped_env_conflicts_and_unauthoriz
             ]
         },
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
+    binding, _, snapshot = _persist_validation_scope(sqlite_session, node_job=node_job, snapshot=snapshot)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="duplicate env/secret name TOKEN"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
@@ -529,82 +570,78 @@ def test_publish_validation_rejects_cli_tool_scoped_env_conflicts_and_unauthoriz
             ]
         },
     )
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
+    sqlite_session.add(snapshot)
+    sqlite_session.commit()
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="unauthorized secret reference GITHUB_TOKEN"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
 
-def test_publish_validation_rejects_missing_previous_node():
+def test_publish_validation_rejects_missing_previous_node(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate(
         {"previous_node_output_refs": [{"node_id": "missing-node", "output": "text"}]}
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    _persist_validation_scope(sqlite_session, node_job=node_job)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="references missing previous node"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
 
-def test_publish_validation_rejects_self_previous_output_ref():
+def test_publish_validation_rejects_self_previous_output_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate(
         {"previous_node_output_refs": [{"node_id": "agent-node", "output": "text"}]}
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    _persist_validation_scope(sqlite_session, node_job=node_job)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="non-upstream"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
 
-def test_publish_validation_rejects_locked_agent_soul_override_in_metadata():
+def test_publish_validation_rejects_locked_agent_soul_override_in_metadata(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({"metadata": {"agent_soul": {"tools": []}}})
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    _persist_validation_scope(sqlite_session, node_job=node_job)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="cannot override locked Agent Soul fields"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
 
-def test_publish_validation_rejects_invalid_human_contact_ref():
+def test_publish_validation_rejects_invalid_human_contact_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({"human_contacts": [{"channel": "slack"}]})
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    _persist_validation_scope(sqlite_session, node_job=node_job)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="invalid human contact ref"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
 
-def test_publish_validation_rejects_out_of_scope_human_contact_ref():
+def test_publish_validation_rejects_out_of_scope_human_contact_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate(
         {"human_contacts": [{"contact_id": "human-1", "tenant_id": "other-tenant", "channel": "slack"}]}
     )
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot()]
+    _persist_validation_scope(sqlite_session, node_job=node_job)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="out-of-scope human contact"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
 
-def test_publish_validation_accepts_tenant_scoped_file_ref():
+def test_publish_validation_accepts_tenant_scoped_file_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate(
         {
             "declared_outputs": [
@@ -620,40 +657,33 @@ def test_publish_validation_accepts_tenant_scoped_file_ref():
             ]
         }
     )
-    session = Mock()
-    session.scalar.side_effect = [
-        _binding(node_job),
-        _agent(),
-        _snapshot(),
-        SimpleNamespace(id="file-1", tenant_id="tenant-1"),
-    ]
+    _persist_validation_scope(sqlite_session, node_job=node_job, extras=(_upload_file(),))
 
     WorkflowAgentNodeValidator.validate_published_workflow(
-        session=session,
+        session=sqlite_session,
         workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
     )
 
 
-def test_publish_validation_rejects_missing_file_ref():
+def test_publish_validation_rejects_missing_file_ref(sqlite_session: Session):
     node_job = WorkflowNodeJobConfig.model_validate({"metadata": {"file_refs": [{"upload_file_id": "missing-file"}]}})
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), _snapshot(), None]
+    _persist_validation_scope(sqlite_session, node_job=node_job)
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="missing or out-of-scope metadata file ref"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
 
 def test_publish_validation_rejects_missing_or_out_of_scope_knowledge_datasets(
     monkeypatch: pytest.MonkeyPatch,
+    sqlite_session: Session,
 ):
     dataset_id = "550e8400-e29b-41d4-a716-446655440000"
     node_job = WorkflowNodeJobConfig.model_validate({})
     snapshot = _snapshot_with_knowledge_dataset(dataset_id)
-    session = Mock()
-    session.scalar.side_effect = [_binding(node_job), _agent(), snapshot]
+    _persist_validation_scope(sqlite_session, node_job=node_job, snapshot=snapshot)
 
     captured = {}
 
@@ -668,52 +698,44 @@ def test_publish_validation_rejects_missing_or_out_of_scope_knowledge_datasets(
 
     with pytest.raises(WorkflowAgentNodeValidationError, match=dataset_id):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=sqlite_session,
             workflow=_workflow(_graph([{"source": "start", "target": "agent-node"}])),
         )
 
     assert captured == {"ids": [dataset_id], "tenant_id": "tenant-1"}
 
 
-def test_publish_validation_accepts_tool_node_agentic_manual_mode():
-    session = Mock()
-
+def test_publish_validation_accepts_tool_node_agentic_manual_mode(unbound_session: Session):
     WorkflowAgentNodeValidator.validate_published_workflow(
-        session=session,
+        session=unbound_session,
         workflow=_workflow(_tool_graph({"agentic_mode": {"state": "manual"}})),
     )
 
 
-def test_publish_validation_accepts_tool_node_agentic_parameter_draft():
-    session = Mock()
-
+def test_publish_validation_accepts_tool_node_agentic_parameter_draft(unbound_session: Session):
     WorkflowAgentNodeValidator.validate_published_workflow(
-        session=session,
+        session=unbound_session,
         workflow=_workflow(_tool_graph({"agentic_mode": {"state": "agentic", "parameter_draft": {"query": "x"}}})),
     )
 
 
-def test_publish_validation_rejects_incomplete_tool_node_agentic_config():
-    session = Mock()
-
+def test_publish_validation_rejects_incomplete_tool_node_agentic_config(unbound_session: Session):
     with pytest.raises(WorkflowAgentNodeValidationError, match="incomplete agentic mode config"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=unbound_session,
             workflow=_workflow(_tool_graph({"agentic_mode": True})),
         )
 
     with pytest.raises(WorkflowAgentNodeValidationError, match="incomplete agentic mode config"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=unbound_session,
             workflow=_workflow(_tool_graph({"agentic_mode": {"state": "agentic", "complete": False}})),
         )
 
 
-def test_publish_validation_rejects_unauthorized_tool_node_agentic_config():
-    session = Mock()
-
+def test_publish_validation_rejects_unauthorized_tool_node_agentic_config(unbound_session: Session):
     with pytest.raises(WorkflowAgentNodeValidationError, match="unauthorized agentic mode config"):
         WorkflowAgentNodeValidator.validate_published_workflow(
-            session=session,
+            session=unbound_session,
             workflow=_workflow(_tool_graph({"agentic_mode": {"state": "agentic", "permission": {"allowed": False}}})),
         )


### PR DESCRIPTION
## Summary
- migrate agent-v2 workflow validators and session-store tests from mocked SQLAlchemy sessions to the shared SQLite fixtures
- persist real workflow bindings, agents, config snapshots, node executions, workspaces, workspace bindings, home snapshots, and upload files
- exercise service-owned session lifecycle, caller-row visibility polling, generation reuse, sandbox resolution, tenant/app retirement scoping, and committed writes with real ORM queries
- replace local real-session factory shims with the shared SQLite session factory

## Production changes
- None. The real ORM execution exposed fixture validity requirements only.

## Size
- 367 additions, 390 deletions (757 changed lines) across 4 test modules

## Validation
- `make test TARGET_TESTS='./api/tests/unit_tests/core/workflow/nodes/agent_v2/test_binding_resolver.py ./api/tests/unit_tests/core/workflow/nodes/agent_v2/test_file_tenant_validator.py ./api/tests/unit_tests/core/workflow/nodes/agent_v2/test_validators.py ./api/tests/unit_tests/core/workflow/nodes/agent_v2/test_session_store.py'` — 65 passed
- `make lint` — passed
- `make type-check` — blocked by the existing mypy 1.20.2 internal error at `typeshed/stdlib/zipimport.pyi:17`
- targeted structural audit — no mocked SQLAlchemy sessions/factories or mapped ORM stand-ins remain in this persistence cluster
- full test suite intentionally not run per request