### PR TITLE
test: migrate Service API dataset metadata sessions and ORM models to SQLite

### DIFF
--- a/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_apis.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_apis.py
@@ -1,25 +1,21 @@
 """Unit tests for Service API dataset controller behavior.
 
 Service boundaries stay mocked, while ORM collaborators are concrete model instances
-persisted in one in-memory SQLite session. The controller's ``db.session`` and the
-session passed to unwrapped ``@with_session`` endpoints both use that same session,
-so model properties and service call contracts exercise real SQLAlchemy behavior.
+persisted through the shared SQLite session fixture.
 """
 
 import uuid
 from datetime import UTC, datetime
 from inspect import unwrap
-from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
-from sqlalchemy.orm import Session, scoped_session, sessionmaker
+from sqlalchemy.orm import Session
 from werkzeug.exceptions import Forbidden, NotFound
 
 import services
 from controllers.service_api.dataset.error import DatasetInUseError, DatasetNameDuplicateError, InvalidActionError
-from extensions.ext_database import db
 from models.account import Account, Tenant, TenantAccountRole
 from models.dataset import AppDatasetJoin, Dataset, DatasetMetadata, Document
 from models.enums import PermissionEnum
@@ -42,15 +38,9 @@ DATASET_MODEL_TABLES = (
 pytestmark = pytest.mark.parametrize("sqlite_session", [DATASET_MODEL_TABLES], indirect=True)
 
 
-@pytest.fixture(autouse=True)
-def controller_session(sqlite_session: Session, monkeypatch: pytest.MonkeyPatch) -> Session:
-    """Route controller and model database access through the test's SQLite session."""
-
-    # Flask-SQLAlchemy exposes a callable registry that also proxies Session methods.
-    # Seed that registry with this fixture's Session so both access styles share one transaction.
-    existing_session_factory = cast(sessionmaker[Session], lambda: sqlite_session)
-    session_registry = scoped_session(existing_session_factory)
-    monkeypatch.setattr(db, "session", session_registry)
+@pytest.fixture
+def controller_session(sqlite_session: Session) -> Session:
+    """Expose the shared SQLite session under the controller-focused fixture name."""
     return sqlite_session
 
 

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_tag_apis.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_dataset_tag_apis.py
@@ -7,15 +7,13 @@ cover the concrete objects and session passed across the controller boundary.
 
 import uuid
 from inspect import unwrap
-from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
-from sqlalchemy.orm import Session, scoped_session, sessionmaker
+from sqlalchemy.orm import Session
 from werkzeug.exceptions import Forbidden
 
-from extensions.ext_database import db
 from models.account import Account, Tenant, TenantAccountRole
 from models.enums import TagType
 from models.model import Tag
@@ -24,15 +22,9 @@ TAG_MODEL_TABLES = (Account, Tenant, Tag)
 pytestmark = pytest.mark.parametrize("sqlite_session", [TAG_MODEL_TABLES], indirect=True)
 
 
-@pytest.fixture(autouse=True)
-def controller_session(sqlite_session: Session, monkeypatch: pytest.MonkeyPatch) -> Session:
-    """Route controller database access through the test's SQLite session."""
-
-    # Flask-SQLAlchemy exposes a callable registry that also proxies Session methods.
-    # Seed that registry with this fixture's Session so both access styles share one transaction.
-    existing_session_factory = cast(sessionmaker[Session], lambda: sqlite_session)
-    session_registry = scoped_session(existing_session_factory)
-    monkeypatch.setattr(db, "session", session_registry)
+@pytest.fixture
+def controller_session(sqlite_session: Session) -> Session:
+    """Expose the shared SQLite session under the controller-focused fixture name."""
     return sqlite_session
 
 

--- a/api/tests/unit_tests/controllers/service_api/dataset/test_metadata.py
+++ b/api/tests/unit_tests/controllers/service_api/dataset/test_metadata.py
@@ -17,13 +17,14 @@ Decorator strategy:
 
 import uuid
 from inspect import unwrap
-from unittest.mock import ANY, MagicMock, Mock, patch
+from unittest.mock import ANY, patch
 
 import pytest
 from flask import Flask
 from sqlalchemy.orm import Session
 from werkzeug.exceptions import NotFound
 
+from controllers.service_api.dataset import metadata as metadata_module
 from controllers.service_api.dataset.metadata import (
     DatasetMetadataBuiltInFieldActionServiceApi,
     DatasetMetadataBuiltInFieldServiceApi,
@@ -31,21 +32,43 @@ from controllers.service_api.dataset.metadata import (
     DatasetMetadataServiceApi,
     DocumentMetadataEditServiceApi,
 )
+from models.account import Account, Tenant
+from models.dataset import Dataset
+from models.enums import PermissionEnum
 from services.errors.metadata import MetadataResourceNotFoundError
 
 
 @pytest.fixture
-def mock_tenant():
-    tenant = Mock()
+def mock_tenant() -> Tenant:
+    tenant = Tenant(name="Metadata API Tenant")
     tenant.id = str(uuid.uuid4())
     return tenant
 
 
 @pytest.fixture
-def mock_dataset():
-    dataset = Mock()
-    dataset.id = str(uuid.uuid4())
-    return dataset
+def account() -> Account:
+    account = Account(name="Metadata API User", email=f"metadata-api-{uuid.uuid4()}@example.com")
+    account.id = str(uuid.uuid4())
+    return account
+
+
+@pytest.fixture
+def mock_dataset(mock_tenant: Tenant, account: Account) -> Dataset:
+    return Dataset(
+        id=str(uuid.uuid4()),
+        tenant_id=mock_tenant.id,
+        name="Metadata Dataset",
+        description="",
+        provider="vendor",
+        permission=PermissionEnum.ONLY_ME,
+        indexing_technique="economy",
+        created_by=account.id,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _use_current_user(monkeypatch: pytest.MonkeyPatch, account: Account) -> None:
+    monkeypatch.setattr(metadata_module, "current_user", account)
 
 
 # ---------------------------------------------------------------------------
@@ -79,10 +102,8 @@ class TestDatasetMetadataCreatePost(_UsesSQLiteSession):
 
     @patch("controllers.service_api.dataset.metadata.MetadataService")
     @patch("controllers.service_api.dataset.metadata.DatasetService")
-    @patch("controllers.service_api.dataset.metadata.current_user")
     def test_create_metadata_success(
         self,
-        mock_current_user,
         mock_dataset_svc,
         mock_meta_svc,
         app: Flask,
@@ -213,15 +234,14 @@ class TestDatasetMetadataServiceApiPatch(_UsesSQLiteSession):
 
     @patch("controllers.service_api.dataset.metadata.MetadataService")
     @patch("controllers.service_api.dataset.metadata.DatasetService")
-    @patch("controllers.service_api.dataset.metadata.current_user")
     def test_update_metadata_name_success(
         self,
-        mock_current_user,
         mock_dataset_svc,
         mock_meta_svc,
         app: Flask,
         mock_tenant,
         mock_dataset,
+        account: Account,
     ):
         """Test successful metadata name update."""
         metadata_id = str(uuid.uuid4())
@@ -250,7 +270,7 @@ class TestDatasetMetadataServiceApiPatch(_UsesSQLiteSession):
             str(mock_dataset.id), mock_tenant.id, session=session
         )
         mock_meta_svc.update_metadata_name.assert_called_once_with(
-            mock_dataset, metadata_id, "New Name", mock_current_user, session=session
+            mock_dataset, metadata_id, "New Name", account, session=session
         )
 
     @patch("controllers.service_api.dataset.metadata.DatasetService")
@@ -294,10 +314,8 @@ class TestDatasetMetadataServiceApiDelete(_UsesSQLiteSession):
 
     @patch("controllers.service_api.dataset.metadata.MetadataService")
     @patch("controllers.service_api.dataset.metadata.DatasetService")
-    @patch("controllers.service_api.dataset.metadata.current_user")
     def test_delete_metadata_success(
         self,
-        mock_current_user,
         mock_dataset_svc,
         mock_meta_svc,
         app: Flask,
@@ -410,10 +428,8 @@ class TestDatasetMetadataBuiltInFieldAction(_UsesSQLiteSession):
 
     @patch("controllers.service_api.dataset.metadata.MetadataService")
     @patch("controllers.service_api.dataset.metadata.DatasetService")
-    @patch("controllers.service_api.dataset.metadata.current_user")
     def test_enable_built_in_field(
         self,
-        mock_current_user,
         mock_dataset_svc,
         mock_meta_svc,
         app: Flask,
@@ -444,10 +460,8 @@ class TestDatasetMetadataBuiltInFieldAction(_UsesSQLiteSession):
 
     @patch("controllers.service_api.dataset.metadata.MetadataService")
     @patch("controllers.service_api.dataset.metadata.DatasetService")
-    @patch("controllers.service_api.dataset.metadata.current_user")
     def test_disable_built_in_field(
         self,
-        mock_current_user,
         mock_dataset_svc,
         mock_meta_svc,
         app: Flask,
@@ -519,15 +533,14 @@ class TestDocumentMetadataEditPost(_UsesSQLiteSession):
 
     @patch("controllers.service_api.dataset.metadata.MetadataService")
     @patch("controllers.service_api.dataset.metadata.DatasetService")
-    @patch("controllers.service_api.dataset.metadata.current_user")
     def test_update_documents_metadata_success(
         self,
-        mock_current_user,
         mock_dataset_svc,
         mock_meta_svc,
         app: Flask,
         mock_tenant,
         mock_dataset,
+        account: Account,
     ):
         """Test successful documents metadata update."""
         mock_dataset_svc.get_dataset_for_tenant.return_value = mock_dataset
@@ -553,7 +566,7 @@ class TestDocumentMetadataEditPost(_UsesSQLiteSession):
         mock_meta_svc.update_documents_metadata.assert_called_once_with(
             mock_dataset,
             ANY,
-            mock_current_user,
+            account,
             session=session,
         )
 
@@ -585,10 +598,8 @@ class TestDocumentMetadataEditPost(_UsesSQLiteSession):
 
     @patch("controllers.service_api.dataset.metadata.MetadataService")
     @patch("controllers.service_api.dataset.metadata.DatasetService")
-    @patch("controllers.service_api.dataset.metadata.current_user")
     def test_update_documents_metadata_translates_missing_resource(
         self,
-        mock_current_user,
         mock_dataset_svc,
         mock_meta_svc,
         app: Flask,
@@ -607,7 +618,7 @@ class TestDocumentMetadataEditPost(_UsesSQLiteSession):
             with pytest.raises(NotFound) as exc_info:
                 self._call_post(
                     api,
-                    MagicMock(),
+                    self.session,
                     tenant_id=mock_tenant.id,
                     dataset_id=mock_dataset.id,
                 )


### PR DESCRIPTION
## Summary
- replace Service API metadata controller Tenant, Dataset, and current-user mocks with concrete ORM instances
- route metadata error translation through the shared SQLite session
- remove redundant local scoped-session registries from the dataset and dataset-tag controller tests
- retain service/provider/permission mocks while their returned datasets and tags remain real mapped models

## Production changes
- None.

## Size
- 44 additions, 51 deletions (95 changed lines) across 3 focused controller test modules

## Validation
- `make test TARGET_TESTS='./api/tests/unit_tests/controllers/service_api/dataset/test_metadata.py ./api/tests/unit_tests/controllers/service_api/dataset/test_dataset_apis.py ./api/tests/unit_tests/controllers/service_api/dataset/test_dataset_tag_apis.py'` — 45 passed
- `make lint` — passed
- `make type-check` — blocked by the existing mypy 1.20.2 internal error at `typeshed/stdlib/zipimport.pyi:17`
- targeted audit — remaining mocks are service/provider/permission boundaries, not SQLAlchemy sessions or mapped ORM instances
- full test suite intentionally not run per request