### PR TITLE
test: migrate workspace member sessions and ORM models to SQLite

### DIFF
--- a/api/tests/unit_tests/controllers/console/workspace/test_members.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_members.py
@@ -2,13 +2,13 @@ from contextlib import nullcontext
 from datetime import datetime
 from http import HTTPStatus
 from inspect import unwrap
-from types import SimpleNamespace
 from typing import NamedTuple, override
 from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
 from flask_restx import Resource
+from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
 from controllers.console.auth.error import (
     CannotTransferOwnerToSelfError,
@@ -34,6 +34,8 @@ from controllers.console.workspace.members import (
 from enums import DeploymentEdition
 from libs.external_api import ExternalApi
 from machinery.context import RequestContext
+from models.account import Account, Tenant, TenantAccountJoin
+from models.engine import db
 from services.errors.account import AccountAlreadyInTenantError, SeatsLimitExceededError
 from services.workspace_member_query_service import (
     WorkspaceMemberQueryService,
@@ -55,6 +57,19 @@ class _RecordingWorkspaceMemberQueryService(WorkspaceMemberQueryService):
 
 class _ApplicationServicesStub(NamedTuple):
     workspace_member_queries: WorkspaceMemberQueryService
+
+
+def _tenant(*, name: str = "Workspace") -> Tenant:
+    tenant = Tenant(name=name)
+    tenant.id = "t1"
+    return tenant
+
+
+def _account(*, tenant: Tenant | None = None, account_id: str = "account-1", email: str = "a@test.com") -> Account:
+    account = Account(name="Test User", email=email)
+    account.id = account_id
+    account._current_tenant = tenant
+    return account
 
 
 class TestMemberListApi:
@@ -132,8 +147,8 @@ class TestMemberInviteEmailApi:
         api = MemberInviteEmailApi()
         method = unwrap(api.post)
 
-        tenant = MagicMock(id="t1")
-        user = MagicMock(current_tenant=tenant)
+        tenant = _tenant()
+        user = _account(tenant=tenant)
         features = MagicMock()
         features.workspace_members.enabled = False
         features.workspace_members.is_available.return_value = True
@@ -167,8 +182,8 @@ class TestMemberInviteEmailApi:
         api = MemberInviteEmailApi()
         method = unwrap(api.post)
 
-        tenant = MagicMock(id="t1")
-        user = MagicMock(current_tenant=tenant)
+        tenant = _tenant()
+        user = _account(tenant=tenant)
         features = MagicMock()
         features.workspace_members.enabled = True
         features.workspace_members.is_available.return_value = False
@@ -191,8 +206,8 @@ class TestMemberInviteEmailApi:
         api = MemberInviteEmailApi()
         method = unwrap(api.post)
 
-        tenant = MagicMock(id="t1")
-        user = MagicMock(current_tenant=tenant)
+        tenant = _tenant()
+        user = _account(tenant=tenant)
         features = MagicMock()
         features.members.size = 9
         features.members.limit = 10
@@ -217,8 +232,8 @@ class TestMemberInviteEmailApi:
         api = MemberInviteEmailApi()
         method = unwrap(api.post)
 
-        tenant = MagicMock(id="t1")
-        user = MagicMock(current_tenant=tenant)
+        tenant = _tenant()
+        user = _account(tenant=tenant)
         features = MagicMock()
         features.workspace_members.enabled = False
         features.workspace_members.is_available.return_value = True
@@ -256,7 +271,7 @@ class TestMemberInviteEmailApi:
 
         with app.test_request_context("/", json=payload):
             with pytest.raises(InvalidMemberRoleError) as exc_info:
-                method(api, MagicMock())
+                method(api, _account())
 
         assert exc_info.value.error_code == "invalid_role"
 
@@ -264,11 +279,12 @@ class TestMemberInviteEmailApi:
         app = Flask(__name__)
         api = ExternalApi(app)
         method = unwrap(MemberInviteEmailApi.post)
+        current_user = _account()
 
         @api.route("/workspaces/current/members/invite-email")
         class MemberInviteValidationApi(Resource):
             def post(self):
-                return method(MemberInviteEmailApi(), MagicMock())
+                return method(MemberInviteEmailApi(), current_user)
 
         response = app.test_client().post(
             "/workspaces/current/members/invite-email",
@@ -283,8 +299,8 @@ class TestMemberInviteEmailApi:
         api = MemberInviteEmailApi()
         method = unwrap(api.post)
 
-        tenant = MagicMock(id="t1")
-        user = MagicMock(current_tenant=tenant)
+        tenant = _tenant()
+        user = _account(tenant=tenant)
         features = MagicMock()
         features.workspace_members.enabled = False
         features.workspace_members.is_available.return_value = True
@@ -313,8 +329,8 @@ class TestMemberInviteEmailApi:
         api = MemberInviteEmailApi()
         method = unwrap(api.post)
 
-        tenant = MagicMock(id="t1")
-        user = MagicMock(current_tenant=tenant)
+        tenant = _tenant()
+        user = _account(tenant=tenant)
         features = MagicMock()
         features.workspace_members.enabled = False
         license_info = MagicMock()
@@ -347,8 +363,8 @@ class TestMemberInviteEmailApi:
         api = MemberInviteEmailApi()
         method = unwrap(api.post)
 
-        tenant = MagicMock(id="t1")
-        user = MagicMock(current_tenant=tenant)
+        tenant = _tenant()
+        user = _account(tenant=tenant)
         features = MagicMock()
         features.workspace_members.enabled = False
         license_info = MagicMock()
@@ -385,8 +401,8 @@ class TestMemberInviteEmailApi:
         api = MemberInviteEmailApi()
         method = unwrap(api.post)
 
-        tenant = MagicMock(id="t1")
-        user = MagicMock(current_tenant=tenant)
+        tenant = _tenant()
+        user = _account(tenant=tenant)
         features = MagicMock()
         features.workspace_members.enabled = False
         license_info = MagicMock()
@@ -423,8 +439,8 @@ class TestMemberInviteEmailApi:
         api = MemberInviteEmailApi()
         method = unwrap(api.post)
 
-        tenant = MagicMock(id="t1")
-        user = MagicMock(current_tenant=tenant)
+        tenant = _tenant()
+        user = _account(tenant=tenant)
         features = MagicMock()
         features.workspace_members.enabled = False
         license_info = MagicMock()
@@ -458,8 +474,8 @@ class TestMemberInviteEmailApi:
         api = MemberInviteEmailApi()
         method = unwrap(api.post)
 
-        tenant = MagicMock(id="t1")
-        user = MagicMock(current_tenant=tenant)
+        tenant = _tenant()
+        user = _account(tenant=tenant)
         features = MagicMock()
         features.workspace_members.enabled = False
         license_info = MagicMock()
@@ -493,19 +509,30 @@ class TestMemberInviteEmailApi:
 
 
 class TestCountNewMemberInvites:
-    def test_count_new_member_invites(self):
+    def test_count_new_member_invites(
+        self, monkeypatch: pytest.MonkeyPatch, sqlite_session_factory: sessionmaker[Session]
+    ):
         new_account = None
-        existing_account_not_in_tenant = SimpleNamespace(id="account-2")
-        existing_account_in_tenant = SimpleNamespace(id="account-3")
+        existing_account_not_in_tenant = Account(name="External", email="existing@test.com")
+        existing_account_not_in_tenant.id = "account-2"
+        existing_account_in_tenant = Account(name="Member", email="member@test.com")
+        existing_account_in_tenant.id = "account-3"
+        database_session = scoped_session(sqlite_session_factory)
+        monkeypatch.setattr(db, "session", database_session)
+        database_session.add(
+            TenantAccountJoin(
+                tenant_id="tenant-1",
+                account_id="account-3",
+                current=True,
+                role="normal",
+            )
+        )
+        database_session.commit()
 
-        with (
-            patch(
-                "controllers.console.workspace.members.AccountService.get_account_by_email_with_case_fallback",
-                side_effect=[new_account, existing_account_not_in_tenant, existing_account_in_tenant],
-            ) as mock_get_account,
-            patch("controllers.console.workspace.members.db.session") as mock_session,
-        ):
-            mock_session.scalar.side_effect = [None, "join-id"]
+        with patch(
+            "controllers.console.workspace.members.AccountService.get_account_by_email_with_case_fallback",
+            side_effect=[new_account, existing_account_not_in_tenant, existing_account_in_tenant],
+        ) as mock_get_account:
             result = _count_new_member_invites(
                 "tenant-1",
                 ["new@test.com", "existing@test.com", "member@test.com"],
@@ -513,7 +540,7 @@ class TestCountNewMemberInvites:
 
         assert result == (2, 1)
         assert mock_get_account.call_count == 3
-        assert mock_session.scalar.call_count == 2
+        database_session.remove()
 
 
 class TestMemberUpdateRoleApi:
@@ -524,7 +551,7 @@ class TestMemberUpdateRoleApi:
         payload = {"role": "invalid-role"}
 
         with app.test_request_context("/", json=payload):
-            result, status = method(api, MagicMock(), "id")
+            result, status = method(api, _account(), "id")
 
         assert status == 400
 
@@ -534,8 +561,8 @@ class TestDatasetOperatorMemberListApi:
         api = DatasetOperatorMemberListApi()
         method = unwrap(api.get)
 
-        tenant = MagicMock()
-        user = MagicMock(current_tenant=tenant)
+        tenant = _tenant()
+        user = _account(tenant=tenant)
         member = MagicMock()
         member.id = "op1"
         member.name = "Operator"
@@ -560,7 +587,7 @@ class TestDatasetOperatorMemberListApi:
         api = DatasetOperatorMemberListApi()
         method = unwrap(api.get)
 
-        user = MagicMock(current_tenant=None)
+        user = _account(tenant=None)
 
         with (
             app.test_request_context("/"),
@@ -574,8 +601,8 @@ class TestSendOwnerTransferEmailApi:
         api = SendOwnerTransferEmailApi()
         method = unwrap(api.post)
 
-        tenant = MagicMock(name="ws")
-        user = MagicMock(email="a@test.com", current_tenant=tenant)
+        tenant = _tenant(name="ws")
+        user = _account(tenant=tenant, email="a@test.com")
 
         payload = {}
 
@@ -604,14 +631,14 @@ class TestSendOwnerTransferEmailApi:
             patch("controllers.console.workspace.members.AccountService.is_email_send_ip_limit", return_value=True),
         ):
             with pytest.raises(EmailSendIpLimitError):
-                method(api, MagicMock())
+                method(api, _account())
 
     def test_send_not_owner(self, app: Flask):
         api = SendOwnerTransferEmailApi()
         method = unwrap(api.post)
 
-        tenant = MagicMock()
-        user = MagicMock(current_tenant=tenant)
+        tenant = _tenant()
+        user = _account(tenant=tenant)
 
         with (
             app.test_request_context("/", json={}),
@@ -628,8 +655,8 @@ class TestOwnerTransferCheckApi:
         api = OwnerTransferCheckApi()
         method = unwrap(api.post)
 
-        tenant = MagicMock()
-        user = MagicMock(email="a@test.com", current_tenant=tenant)
+        tenant = _tenant()
+        user = _account(tenant=tenant, email="a@test.com")
 
         payload = {"code": "x", "token": "t"}
 
@@ -652,8 +679,8 @@ class TestOwnerTransferCheckApi:
         api = OwnerTransferCheckApi()
         method = unwrap(api.post)
 
-        tenant = MagicMock()
-        user = MagicMock(email="a@test.com", current_tenant=tenant)
+        tenant = _tenant()
+        user = _account(tenant=tenant, email="a@test.com")
 
         payload = {"code": "x", "token": "t"}
 
@@ -672,8 +699,8 @@ class TestOwnerTransferCheckApi:
         api = OwnerTransferCheckApi()
         method = unwrap(api.post)
 
-        tenant = MagicMock()
-        user = MagicMock(email="a@test.com", current_tenant=tenant)
+        tenant = _tenant()
+        user = _account(tenant=tenant, email="a@test.com")
 
         payload = {"code": "x", "token": "t"}
 
@@ -693,8 +720,8 @@ class TestOwnerTransferCheckApi:
         api = OwnerTransferCheckApi()
         method = unwrap(api.post)
 
-        tenant = MagicMock()
-        user = MagicMock(email="a@test.com", current_tenant=tenant)
+        tenant = _tenant()
+        user = _account(tenant=tenant, email="a@test.com")
 
         payload = {"code": "x", "token": "t"}
 
@@ -719,8 +746,8 @@ class TestOwnerTransferApi:
         api = OwnerTransfer()
         method = unwrap(api.post)
 
-        tenant = MagicMock()
-        user = MagicMock(id="1", email="a@test.com", current_tenant=tenant)
+        tenant = _tenant()
+        user = _account(tenant=tenant, account_id="1", email="a@test.com")
 
         payload = {"token": "t"}
 
@@ -735,8 +762,8 @@ class TestOwnerTransferApi:
         api = OwnerTransfer()
         method = unwrap(api.post)
 
-        tenant = MagicMock()
-        user = MagicMock(id="1", email="a@test.com", current_tenant=tenant)
+        tenant = _tenant()
+        user = _account(tenant=tenant, account_id="1", email="a@test.com")
 
         payload = {"token": "t"}
 

--- a/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
+++ b/api/tests/unit_tests/controllers/console/workspace/test_workspace.py
@@ -39,9 +39,12 @@ from controllers.console.workspace.workspace import (
     WorkspacePermissionResponse,
 )
 from enums import CloudPlan, DeploymentEdition
+from extensions.storage.storage_type import StorageType
 from libs.datetime_utils import naive_utc_now
 from machinery.context import RequestContext
 from models.account import Account, Tenant, TenantAccountJoin, TenantCustomConfigDict, TenantStatus
+from models.enums import CreatorUserRole
+from models.model import UploadFile
 from repositories.workspace_query_repository import WorkspaceQueryRepository
 from services import workspace_plan_gateway
 from services.workspace_query_service import WorkspaceQueryService, WorkspaceRecord
@@ -300,7 +303,7 @@ class TestDeploymentWorkspacePlanGateway:
 
 
 class TestWorkspaceListApi:
-    def test_get_success(self, app: Flask):
+    def test_get_success(self, app: Flask, sqlite_session: Session):
         api = WorkspaceListApi()
         method = unwrap(api.get)
         tenant = make_tenant("t1", name="T")
@@ -309,12 +312,12 @@ class TestWorkspaceListApi:
             app.test_request_context("/all-workspaces", query_string={"page": 1, "limit": 20}),
             patch("controllers.console.workspace.workspace.paginate_query", return_value=paginate_result),
         ):
-            result, status = method(api, MagicMock())
+            result, status = method(api, sqlite_session)
         assert status == HTTPStatus.OK
         assert result["total"] == 1
         assert result["has_more"] is False
 
-    def test_get_has_next_true(self, app: Flask):
+    def test_get_has_next_true(self, app: Flask, sqlite_session: Session):
         api = WorkspaceListApi()
         method = unwrap(api.get)
         tenant = make_tenant("t1", name="T")
@@ -323,7 +326,7 @@ class TestWorkspaceListApi:
             app.test_request_context("/all-workspaces", query_string={"page": 1, "limit": 1}),
             patch("controllers.console.workspace.workspace.paginate_query", return_value=paginate_result),
         ):
-            result, status = method(api, MagicMock())
+            result, status = method(api, sqlite_session)
         assert status == HTTPStatus.OK
         assert result["has_more"] is True
 
@@ -336,12 +339,12 @@ def test_legacy_current_workspace_routes_are_not_registered():
 
 
 class TestCurrentWorkspaceSummaryApi:
-    def test_get_summary(self, app: Flask):
+    def test_get_summary(self, app: Flask, sqlite_session: Session):
         api = CurrentWorkspaceSummaryApi()
         method = unwrap(api.get)
         tenant = make_tenant()
         user = make_account_with_tenant(tenant)
-        session = MagicMock()
+        session = sqlite_session
         summary = {
             "id": tenant.id,
             "name": tenant.name,
@@ -369,7 +372,7 @@ class TestCurrentWorkspaceSummaryApi:
         }
         get_summary.assert_called_once_with(tenant, user.id, session=session)
 
-    def test_get_archived_tenant_returns_conflict(self, app: Flask):
+    def test_get_archived_tenant_returns_conflict(self, app: Flask, sqlite_session: Session):
         api = CurrentWorkspaceSummaryApi()
         method = unwrap(api.get)
         tenant = make_tenant(status=TenantStatus.ARCHIVE)
@@ -377,7 +380,7 @@ class TestCurrentWorkspaceSummaryApi:
 
         with app.test_request_context("/workspaces/current/summary"):
             with pytest.raises(CurrentWorkspaceArchivedError) as exc_info:
-                method(api, MagicMock(), user)
+                method(api, sqlite_session, user)
 
         assert exc_info.value.code == HTTPStatus.CONFLICT
         assert exc_info.value.error_code == "current_workspace_archived"
@@ -428,7 +431,7 @@ class TestSwitchWorkspaceApi:
         assert result["result"] == "success"
         switch_tenant.assert_called_once_with(user, "t2", session=workspace_session)
 
-    def test_switch_not_linked(self, app: Flask):
+    def test_switch_not_linked(self, app: Flask, sqlite_session: Session):
         api = SwitchWorkspaceApi()
         method = unwrap(api.post)
         payload = {"tenant_id": "bad"}
@@ -438,7 +441,7 @@ class TestSwitchWorkspaceApi:
             patch("controllers.console.workspace.workspace.TenantService.switch_tenant", side_effect=Exception),
         ):
             with pytest.raises(AccountNotLinkTenantError):
-                method(api, MagicMock(), user)
+                method(api, sqlite_session, user)
 
     def test_switch_tenant_not_found(self, app: Flask, workspace_session: scoped_session[Session]):
         api = SwitchWorkspaceApi()
@@ -566,8 +569,21 @@ class TestWebappLogoWorkspaceApi:
         api = WebappLogoWorkspaceApi()
         method = unwrap(api.post)
         file = FileStorage(stream=BytesIO(b"data"), filename="logo.png", content_type="image/png")
-        upload = MagicMock(id="file1")
         user = make_account()
+        upload = UploadFile(
+            tenant_id="t1",
+            storage_type=StorageType.LOCAL,
+            key="logo.png",
+            name="logo.png",
+            size=4,
+            extension="png",
+            mime_type="image/png",
+            created_by_role=CreatorUserRole.ACCOUNT,
+            created_by=user.id,
+            created_at=naive_utc_now(),
+            used=False,
+        )
+        upload.id = "file1"
         with (
             app.test_request_context("/upload", data={"file": file}, content_type="multipart/form-data"),
             patch("controllers.console.workspace.workspace.FileService") as fs,
@@ -647,13 +663,13 @@ class TestWorkspaceInfoApi:
         assert result["result"] == "success"
         assert events == ["commit", "get_tenant_info"]
 
-    def test_no_current_tenant(self, app: Flask):
+    def test_no_current_tenant(self, app: Flask, sqlite_session: Session):
         api = WorkspaceInfoApi()
         method = unwrap(api.post)
         payload = {"name": "X"}
         with app.test_request_context("/workspaces/info", json=payload):
             with pytest.raises(ValueError):
-                method(api, MagicMock(), None)
+                method(api, sqlite_session, None)
 
 
 class TestWorkspacePermissionApi:


### PR DESCRIPTION
## Summary
- replace workspace controller session arguments with SQLite-backed sessions
- replace Account, Tenant, TenantAccountJoin, and UploadFile stand-ins with real mapped instances
- persist a real membership row for invite counting so workspace scoping executes through SQLAlchemy
- retain mocks only for application services, billing/features, storage service boundaries, and response DTOs

## Motivation
The prior member-invite test programmed db.session.scalar results and represented tenant/account ownership with mocks. Real persistence now verifies membership existence and workspace filtering.

## Production changes
None.

## Size
- 112 additions, 69 deletions (181 changed lines)

## Validation
- PASS: targeted workspace/member tests (58 tests total; 57 passed in the combined run and the corrected logo-upload case passed on rerun)
- PASS: make lint
- BLOCKED: make type-check — mypy 1.20.2 internal error at typeshed/stdlib/zipimport.pyi:17
- Full test suite intentionally not run per user instruction.