### PR TITLE
test: migrate console app MCP sessions and ORM models to SQLite

### DIFF
--- a/api/tests/unit_tests/controllers/console/app/test_mcp_server_response.py
+++ b/api/tests/unit_tests/controllers/console/app/test_mcp_server_response.py
@@ -1,6 +1,5 @@
 import datetime
 from inspect import unwrap
-from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -18,16 +17,32 @@ from controllers.console.app.mcp_server import (
     MCPServerUpdatePayload,
 )
 from controllers.console.wraps import RBACPermission, RBACResourceScope
+from models import Account
+from models.account import AccountStatus
 from models.enums import AppMCPServerStatus
-from models.model import AppMCPServer
+from models.model import App, AppMCPServer, AppMode, IconType
 
 
-class _ValidatedResponse:
-    def __init__(self, payload: dict[str, str]) -> None:
-        self._payload = payload
-
-    def model_dump(self, mode: str = "json") -> dict[str, str]:
-        return self._payload
+def _app(
+    *,
+    app_id: str = "app-1",
+    tenant_id: str = "tenant-1",
+    name: str = "Demo App",
+    description: str = "App description",
+) -> App:
+    return App(
+        id=app_id,
+        tenant_id=tenant_id,
+        name=name,
+        description=description,
+        mode=AppMode.CHAT,
+        icon_type=IconType.EMOJI,
+        icon="robot",
+        icon_background="#FFFFFF",
+        enable_site=True,
+        enable_api=True,
+        max_active_requests=None,
+    )
 
 
 def _server(
@@ -136,7 +151,7 @@ class TestAppMCPServerController:
         method = unwrap(api.get)
 
         with patch("controllers.console.app.mcp_server.db.session", sqlite_session):
-            response = method(api, app_model=SimpleNamespace(id="app-1"))
+            response = method(api, app_model=_app())
 
         assert response == {}
 
@@ -157,7 +172,7 @@ class TestAppMCPServerController:
                 api,
                 req_data,
                 "tenant-1",
-                app_model=SimpleNamespace(id="app-1", name="Demo App", description="App description"),
+                app_model=_app(),
             )
 
         server = sqlite_session.scalar(select(AppMCPServer))
@@ -185,9 +200,7 @@ class TestAppMCPServerController:
             response = method(
                 api,
                 req_data,
-                app_model=SimpleNamespace(
-                    id="app-1", tenant_id="tenant-1", name="Demo App", description="App description"
-                ),
+                app_model=_app(),
             )
 
         sqlite_session.expire_all()
@@ -233,9 +246,7 @@ class TestAppMCPServerController:
             method(
                 api,
                 req_data,
-                app_model=SimpleNamespace(
-                    id="app-1", tenant_id="tenant-1", name="Demo App", description="App description"
-                ),
+                app_model=_app(),
             )
 
         sqlite_session.expire_all()
@@ -245,32 +256,36 @@ class TestAppMCPServerController:
 
 
 class TestAppMCPServerRefreshController:
-    def test_post_refreshes_server_bound_to_app_and_tenant(self):
+    def test_post_refreshes_server_bound_to_app_and_tenant(self, sqlite_session: Session) -> None:
         api = AppMCPServerRefreshController()
         method = unwrap(api.post)
-        server = SimpleNamespace(server_code="old-code")
+        server = _server(server_code="old-code")
+        server.id = "server-1"
+        tenant_decoy = _server(tenant_id="tenant-2", server_code="tenant-decoy-code")
+        tenant_decoy.id = "server-2"
+        app_decoy = _server(app_id="app-2", server_code="app-decoy-code")
+        app_decoy.id = "server-3"
+        sqlite_session.add_all([server, tenant_decoy, app_decoy])
+        sqlite_session.commit()
 
         with (
-            patch("controllers.console.app.mcp_server.db.session.scalar", return_value=server) as scalar,
-            patch("controllers.console.app.mcp_server.db.session.commit") as commit,
+            patch("controllers.console.app.mcp_server.db.session", sqlite_session),
             patch("controllers.console.app.mcp_server.AppMCPServer.generate_server_code", return_value="new-code"),
-            patch(
-                "controllers.console.app.mcp_server.AppMCPServerResponse.model_validate",
-                return_value=_ValidatedResponse({"id": "server-1", "server_code": "new-code"}),
-            ),
         ):
-            response = method(api, "tenant-1", app_model=SimpleNamespace(id="app-1"))
+            response = method(api, "tenant-1", app_model=_app())
 
-        stmt = scalar.call_args.args[0]
-        compiled = stmt.compile()
-        statement = str(compiled)
-        assert "app_mcp_servers.tenant_id" in statement
-        assert "app_mcp_servers.app_id" in statement
-        assert "tenant-1" in compiled.params.values()
-        assert "app-1" in compiled.params.values()
-        assert server.server_code == "new-code"
-        commit.assert_called_once()
-        assert response == {"id": "server-1", "server_code": "new-code"}
+        sqlite_session.expire_all()
+        refreshed_server = sqlite_session.get(AppMCPServer, "server-1")
+        persisted_tenant_decoy = sqlite_session.get(AppMCPServer, "server-2")
+        persisted_app_decoy = sqlite_session.get(AppMCPServer, "server-3")
+        assert refreshed_server is not None
+        assert persisted_tenant_decoy is not None
+        assert persisted_app_decoy is not None
+        assert refreshed_server.server_code == "new-code"
+        assert persisted_tenant_decoy.server_code == "tenant-decoy-code"
+        assert persisted_app_decoy.server_code == "app-decoy-code"
+        assert response["id"] == "server-1"
+        assert response["server_code"] == "new-code"
 
     def test_route_is_app_scoped_post(self):
         route_map = {
@@ -291,7 +306,8 @@ class TestAppMCPServerRefreshController:
         class PermissionCheckedError(Exception):
             pass
 
-        current_user = SimpleNamespace(id="account-1")
+        current_user = Account(name="Current user", email="user@example.com", status=AccountStatus.ACTIVE)
+        current_user.id = "account-1"
         with (
             patch("controllers.common.wraps.dify_config.RBAC_ENABLED", True),
             patch(


### PR DESCRIPTION
## Summary
- replace mapped App and Account stand-ins with real ORM instances in the console MCP server controller tests
- execute refresh lookup and commit through the real SQLite session
- seed tenant and app decoys to verify complete owner-chain scoping during server-code refresh

## Motivation
The refresh test mocked db.session.scalar/commit and several controller tests passed SimpleNamespace values in place of mapped App and Account entities. Real ORM execution now covers the query, mutation, commit, and response serialization.

## Production changes
None.

## Size
53 additions, 37 deletions (90 changed lines). This is an atomic controller module and is intentionally smaller than the normal batch target.

## Validation
- PASS: make test TARGET_TESTS=./api/tests/unit_tests/controllers/console/app/test_mcp_server_response.py (14 passed)
- PASS: make lint
- BLOCKED: make type-check reaches mypy 1.20.2 internal error at api/.venv/lib/python3.12/site-packages/mypy/typeshed/stdlib/zipimport.pyi:17
- PASS: focused audit found no mocked SQLAlchemy sessions or mapped-model stand-ins in the migrated module
- NOT RUN: full make test, per user instruction