### PR TITLE
test: migrate console workflow controller sessions and ORM models to SQLite

### DIFF
--- a/api/tests/unit_tests/controllers/console/app/test_conversation_variables_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_conversation_variables_api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from inspect import unwrap
-from types import SimpleNamespace
+from unittest.mock import PropertyMock, patch
 
 import pytest
 from flask import Flask
@@ -13,12 +13,28 @@ from sqlalchemy.orm import Session
 from controllers.console.app import conversation_variables as conversation_variables_module
 from factories import variable_factory
 from graphon.variables.types import SegmentType
-from models import ConversationVariable
+from models import App, AppMode, ConversationVariable
+from models.model import IconType
+
+
+def _app() -> App:
+    return App(
+        id="app-1",
+        tenant_id="tenant-1",
+        name="Conversation variables app",
+        description="",
+        mode=AppMode.ADVANCED_CHAT,
+        icon_type=IconType.EMOJI,
+        icon="robot",
+        icon_background="#FFFFFF",
+        enable_site=True,
+        enable_api=True,
+        max_active_requests=None,
+    )
 
 
 def test_get_conversation_variables_returns_paginated_response(
     app: Flask,
-    monkeypatch: pytest.MonkeyPatch,
     sqlite_engine: Engine,
     sqlite_session: Session,
 ) -> None:
@@ -44,17 +60,19 @@ def test_get_conversation_variables_returns_paginated_response(
     sqlite_session.expire(row)
     expected_created_at = int(row.created_at.timestamp())
     expected_updated_at = int(row.updated_at.timestamp())
-    monkeypatch.setattr(conversation_variables_module, "db", SimpleNamespace(engine=sqlite_engine))
-
-    with app.test_request_context(
-        "/console/api/apps/app-1/conversation-variables",
-        method="GET",
-        query_string={"conversation_id": "conv-1"},
+    with (
+        app.test_request_context(
+            "/console/api/apps/app-1/conversation-variables",
+            method="GET",
+            query_string={"conversation_id": "conv-1"},
+        ),
+        patch.object(type(conversation_variables_module.db), "engine", new_callable=PropertyMock) as engine,
     ):
+        engine.return_value = sqlite_engine
         response = method(
             api,
             conversation_variables_module.ConversationVariablesQuery(conversation_id="conv-1"),
-            app_model=SimpleNamespace(id="app-1"),
+            app_model=_app(),
         )
 
     assert response["page"] == 1
@@ -69,7 +87,6 @@ def test_get_conversation_variables_returns_paginated_response(
 @pytest.mark.parametrize("sqlite_session", [(ConversationVariable,)], indirect=True)
 def test_get_conversation_variables_normalizes_value_type_and_value(
     app: Flask,
-    monkeypatch: pytest.MonkeyPatch,
     sqlite_engine: Engine,
     sqlite_session: Session,
 ) -> None:
@@ -87,17 +104,19 @@ def test_get_conversation_variables_normalizes_value_type_and_value(
     )
     sqlite_session.add(ConversationVariable.from_variable(app_id="app-1", conversation_id="conv-1", variable=variable))
     sqlite_session.commit()
-    monkeypatch.setattr(conversation_variables_module, "db", SimpleNamespace(engine=sqlite_engine))
-
-    with app.test_request_context(
-        "/console/api/apps/app-1/conversation-variables",
-        method="GET",
-        query_string={"conversation_id": "conv-1"},
+    with (
+        app.test_request_context(
+            "/console/api/apps/app-1/conversation-variables",
+            method="GET",
+            query_string={"conversation_id": "conv-1"},
+        ),
+        patch.object(type(conversation_variables_module.db), "engine", new_callable=PropertyMock) as engine,
     ):
+        engine.return_value = sqlite_engine
         response = method(
             api,
             conversation_variables_module.ConversationVariablesQuery(conversation_id="conv-1"),
-            app_model=SimpleNamespace(id="app-1"),
+            app_model=_app(),
         )
 
     assert response["data"][0]["value_type"] == "number"

--- a/api/tests/unit_tests/controllers/console/app/test_ops_trace_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_ops_trace_api.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from contextlib import nullcontext
-from types import SimpleNamespace
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -16,6 +15,7 @@ from controllers.console.app import ops_trace as ops_trace_module
 from controllers.console.app import wraps as app_wraps
 from enums import DeploymentEdition
 from libs import login as login_lib
+from models import Tenant
 from models.account import Account, AccountStatus, TenantAccountRole
 from models.model import App, AppMode, IconType
 
@@ -25,19 +25,33 @@ def _make_account(role: TenantAccountRole) -> Account:
     account.id = "account-123"  # type: ignore[assignment]
     account.status = AccountStatus.ACTIVE
     account.role = role
-    account._current_tenant = SimpleNamespace(id="tenant-123")  # type: ignore[assignment]
+    tenant = Tenant(name="Test tenant")
+    tenant.id = "tenant-123"
+    account._current_tenant = tenant
     account._get_current_object = lambda: account  # type: ignore[attr-defined]
     return account
 
 
-def _make_app() -> SimpleNamespace:
-    return SimpleNamespace(id="app-123", tenant_id="tenant-123", status="normal", mode="chat")
+def _make_app() -> App:
+    return App(
+        id="app-123",
+        tenant_id="tenant-123",
+        name="Trace app",
+        description="",
+        mode=AppMode.CHAT,
+        icon_type=IconType.EMOJI,
+        icon="robot",
+        icon_background="#FFFFFF",
+        enable_site=True,
+        enable_api=True,
+        max_active_requests=None,
+    )
 
 
 def _patch_console_guards(
     monkeypatch: pytest.MonkeyPatch,
     account: Account,
-    app_model: SimpleNamespace,
+    app_model: App,
     *,
     rbac_enabled: bool = False,
 ) -> None:

--- a/api/tests/unit_tests/controllers/console/app/test_workflow_comment_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_workflow_comment_api.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from contextlib import nullcontext
 from dataclasses import dataclass
 from datetime import datetime
-from types import SimpleNamespace
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -16,7 +15,9 @@ from controllers.console.app import workflow_comment as workflow_comment_module
 from controllers.console.app import wraps as app_wraps
 from enums import DeploymentEdition
 from libs import login as login_lib
+from models import App, Tenant, WorkflowComment, WorkflowCommentMention, WorkflowCommentReply
 from models.account import Account, AccountStatus, TenantAccountRole
+from models.model import AppMode, IconType
 
 JAN_1_2024_NOON = datetime(2024, 1, 1, 12, 0, 0)
 JAN_1_2024_NOON_TS = int(JAN_1_2024_NOON.timestamp())
@@ -33,16 +34,30 @@ def _make_account(role: TenantAccountRole) -> Account:
     account.status = AccountStatus.ACTIVE
     account.role = role
     account.id = "account-123"  # type: ignore[assignment]
-    account._current_tenant = SimpleNamespace(id="tenant-123")  # type: ignore[attr-defined]
+    tenant = Tenant(name="Test tenant")
+    tenant.id = "tenant-123"
+    account._current_tenant = tenant
     account._get_current_object = lambda: account  # type: ignore[attr-defined]
     return account
 
 
-def _make_app() -> SimpleNamespace:
-    return SimpleNamespace(id="app-123", tenant_id="tenant-123", status="normal", mode="workflow")
+def _make_app() -> App:
+    return App(
+        id="app-123",
+        tenant_id="tenant-123",
+        name="Workflow comments app",
+        description="",
+        mode=AppMode.WORKFLOW,
+        icon_type=IconType.EMOJI,
+        icon="robot",
+        icon_background="#FFFFFF",
+        enable_site=True,
+        enable_api=True,
+        max_active_requests=None,
+    )
 
 
-def _patch_console_guards(monkeypatch: pytest.MonkeyPatch, account: Account, app_model: SimpleNamespace) -> None:
+def _patch_console_guards(monkeypatch: pytest.MonkeyPatch, account: Account, app_model: App) -> None:
     monkeypatch.setattr(login_lib.dify_config, "LOGIN_DISABLED", True)
     monkeypatch.setattr(login_lib, "current_user", account)
     monkeypatch.setattr(login_lib, "current_account_with_tenant", lambda: (account, account.current_tenant_id))
@@ -246,29 +261,29 @@ def test_list_comments_serializes_response_model(app: Flask, monkeypatch: pytest
     app_model = _make_app()
     _patch_console_guards(monkeypatch, account, app_model)
 
-    comment_author = SimpleNamespace(
-        id="account-123",
+    comment_author = Account(
         name="tester",
         email="tester@example.com",
         avatar="https://example.com/avatar.png",
+        status=AccountStatus.ACTIVE,
     )
-    comment = SimpleNamespace(
-        id="comment-1",
+    comment_author.id = "account-123"
+    comment = WorkflowComment(
+        tenant_id="tenant-123",
+        app_id="app-123",
         position_x=1.5,
         position_y=2.5,
         content="hello",
         created_by="account-123",
-        created_by_account=comment_author,
-        created_at=1_700_000_000,
-        updated_at=1_700_000_001,
         resolved=False,
         resolved_at=None,
         resolved_by=None,
-        resolved_by_account=None,
-        reply_count=0,
-        mention_count=0,
-        participants=[comment_author],
     )
+    comment.id = "comment-1"
+    comment.created_at = datetime.fromtimestamp(1_700_000_000)
+    comment.updated_at = datetime.fromtimestamp(1_700_000_001)
+    comment.cache_created_by_account(comment_author)
+    comment.cache_resolved_by_account(None)
     get_comments_mock = MagicMock(return_value=[comment])
     monkeypatch.setattr(workflow_comment_module.WorkflowCommentService, "get_comments", get_comments_mock)
 
@@ -317,48 +332,49 @@ def test_get_comment_serializes_detail_response_model(app: Flask, monkeypatch: p
     app_model = _make_app()
     _patch_console_guards(monkeypatch, account, app_model)
 
-    comment_author = SimpleNamespace(
-        id="account-123",
+    comment_author = Account(
         name="tester",
         email="tester@example.com",
         avatar="https://example.com/avatar.png",
+        status=AccountStatus.ACTIVE,
     )
-    mentioned_user = SimpleNamespace(
-        id="account-456",
+    comment_author.id = "account-123"
+    mentioned_user = Account(
         name="mentioned",
         email="mentioned@example.com",
         avatar=None,
+        status=AccountStatus.ACTIVE,
     )
-    comment = SimpleNamespace(
-        id="comment-1",
+    mentioned_user.id = "account-456"
+    comment = WorkflowComment(
+        tenant_id="tenant-123",
+        app_id="app-123",
         position_x=1.5,
         position_y=2.5,
         content="hello",
         created_by="account-123",
-        created_by_account=comment_author,
-        created_at=JAN_1_2024_NOON,
-        updated_at=JAN_1_2024_1201,
         resolved=True,
         resolved_at=JAN_1_2024_1202,
         resolved_by="account-123",
-        resolved_by_account=comment_author,
-        replies=[
-            SimpleNamespace(
-                id="reply-1",
-                content="reply",
-                created_by="account-456",
-                created_by_account=mentioned_user,
-                created_at=JAN_1_2024_1203,
-            )
-        ],
-        mentions=[
-            SimpleNamespace(
-                mentioned_user_id="account-456",
-                mentioned_user_account=mentioned_user,
-                reply_id="reply-1",
-            )
-        ],
     )
+    comment.id = "comment-1"
+    comment.created_at = JAN_1_2024_NOON
+    comment.updated_at = JAN_1_2024_1201
+    comment.cache_created_by_account(comment_author)
+    comment.cache_resolved_by_account(comment_author)
+    reply = WorkflowCommentReply(comment_id=comment.id, content="reply", created_by="account-456")
+    reply.id = "reply-1"
+    reply.created_at = JAN_1_2024_1203
+    reply.updated_at = JAN_1_2024_1203
+    reply.cache_created_by_account(mentioned_user)
+    mention = WorkflowCommentMention(
+        comment_id=comment.id,
+        mentioned_user_id="account-456",
+        reply_id=reply.id,
+    )
+    mention.cache_mentioned_user_account(mentioned_user)
+    comment.replies.append(reply)
+    comment.mentions.append(mention)
     get_comment_mock = MagicMock(return_value=comment)
     monkeypatch.setattr(workflow_comment_module.WorkflowCommentService, "get_comment", get_comment_mock)
 

--- a/api/tests/unit_tests/controllers/console/app/test_workflow_convert_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_workflow_convert_api.py
@@ -3,13 +3,30 @@
 from __future__ import annotations
 
 from inspect import unwrap
-from types import SimpleNamespace
 
 import pytest
 from flask import Flask
 
 from controllers.console.app import workflow as workflow_module
 from controllers.console.app.workflow import ConvertToWorkflowApi
+from models import Account, App, AppMode
+from models.model import IconType
+
+
+def _app(app_id: str) -> App:
+    return App(
+        id=app_id,
+        tenant_id="tenant-1",
+        name=f"App {app_id}",
+        description="",
+        mode=AppMode.CHAT,
+        icon_type=IconType.EMOJI,
+        icon="robot",
+        icon_background="#FFFFFF",
+        enable_site=True,
+        enable_api=True,
+        max_active_requests=None,
+    )
 
 
 class TestConvertToWorkflowApi:
@@ -21,11 +38,12 @@ class TestConvertToWorkflowApi:
         self, api: ConvertToWorkflowApi, app: Flask, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         method = unwrap(api.post)
+        new_app = _app("new-app-1")
 
         monkeypatch.setattr(
             workflow_module,
             "WorkflowService",
-            lambda: SimpleNamespace(convert_to_workflow=lambda **_kwargs: SimpleNamespace(id="new-app-1")),
+            lambda: type("WorkflowServiceStub", (), {"convert_to_workflow": lambda self, **_kwargs: new_app})(),
         )
         monkeypatch.setattr(
             workflow_module,
@@ -38,11 +56,13 @@ class TestConvertToWorkflowApi:
             method="POST",
             json={},
         ):
+            current_user = Account(name="Current user", email="user@example.com")
+            current_user.id = "u1"
             response = method(
                 api,
                 current_tenant_id="tenant-1",
-                current_user=SimpleNamespace(id="u1"),
-                app_model=SimpleNamespace(id="app-1"),
+                current_user=current_user,
+                app_model=_app("app-1"),
             )
 
         assert response["new_app_id"] == "new-app-1"

--- a/api/tests/unit_tests/controllers/console/app/test_workflow_human_input_debug_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_workflow_human_input_debug_api.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from types import SimpleNamespace
 from unittest.mock import ANY, MagicMock
 
 import pytest
@@ -13,8 +12,9 @@ from controllers.console.app import workflow as workflow_module
 from controllers.console.app import wraps as app_wraps
 from enums import DeploymentEdition
 from libs import login as login_lib
+from models import App, Tenant
 from models.account import Account, AccountStatus, TenantAccountRole
-from models.model import AppMode
+from models.model import AppMode, IconType
 
 
 def _make_account() -> Account:
@@ -22,16 +22,30 @@ def _make_account() -> Account:
     account.status = AccountStatus.ACTIVE
     account.role = TenantAccountRole.OWNER
     account.id = "account-123"  # type: ignore[assignment]
-    account._current_tenant = SimpleNamespace(id="tenant-123")  # type: ignore[attr-defined]
+    tenant = Tenant(name="Test tenant")
+    tenant.id = "tenant-123"
+    account._current_tenant = tenant
     account._get_current_object = lambda: account  # type: ignore[attr-defined]
     return account
 
 
-def _make_app(mode: AppMode) -> SimpleNamespace:
-    return SimpleNamespace(id="app-123", tenant_id="tenant-123", mode=mode.value)
+def _make_app(mode: AppMode) -> App:
+    return App(
+        id="app-123",
+        tenant_id="tenant-123",
+        name="Human input app",
+        description="",
+        mode=mode,
+        icon_type=IconType.EMOJI,
+        icon="robot",
+        icon_background="#FFFFFF",
+        enable_site=True,
+        enable_api=True,
+        max_active_requests=None,
+    )
 
 
-def _patch_console_guards(monkeypatch: pytest.MonkeyPatch, account: Account, app_model: SimpleNamespace) -> None:
+def _patch_console_guards(monkeypatch: pytest.MonkeyPatch, account: Account, app_model: App) -> None:
     # Skip setup and auth guardrails
     monkeypatch.setattr("configs.dify_config.DEPLOYMENT_EDITION", DeploymentEdition.CLOUD)
     monkeypatch.setattr(login_lib.dify_config, "LOGIN_DISABLED", True)

--- a/api/tests/unit_tests/controllers/console/app/test_workflow_node_output_inspector.py
+++ b/api/tests/unit_tests/controllers/console/app/test_workflow_node_output_inspector.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterator
-from typing import Any
 from unittest.mock import ANY, MagicMock
 from uuid import UUID
 
@@ -32,6 +31,8 @@ import pytest
 
 from controllers.console.app import workflow_node_output_inspector as ctrl
 from graphon.enums import WorkflowExecutionStatus
+from models import App, AppMode
+from models.model import IconType
 from services.workflow.inspector_events import InspectorMessage
 from services.workflow.node_output_inspector_service import (
     NodeOutputInspectorError,
@@ -47,13 +48,25 @@ from services.workflow.node_output_inspector_service import (
 
 
 @pytest.fixture
-def app_model() -> Any:
-    """A minimal ``App`` stub the controller passes through to the service.
+def app_model() -> App:
+    """A real transient ``App`` the controller passes through to the service.
 
     The SSE generator never reads its attributes — just forwards it — so a
-    sentinel object is enough.
+    transient mapped instance is sufficient.
     """
-    return MagicMock(name="App", tenant_id="tenant-1", id="app-1")
+    return App(
+        id="app-1",
+        tenant_id="tenant-1",
+        name="Inspector app",
+        description="",
+        mode=AppMode.WORKFLOW,
+        icon_type=IconType.EMOJI,
+        icon="robot",
+        icon_background="#FFFFFF",
+        enable_site=True,
+        enable_api=True,
+        max_active_requests=None,
+    )
 
 
 @pytest.fixture

--- a/api/tests/unit_tests/controllers/console/app/test_workflow_run_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_workflow_run_api.py
@@ -1,16 +1,26 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from inspect import unwrap
-from types import SimpleNamespace
 from typing import Any
 
 import pytest
 from flask import Flask
 from flask_restx import marshal
+from sqlalchemy.orm import Session
 
 from controllers.console.app import workflow_run as workflow_run_module
-from models import Account
+from graphon.enums import WorkflowExecutionStatus, WorkflowNodeExecutionStatus
+from models import Account, App, AppMode
+from models.enums import CreatorUserRole, WorkflowRunTriggeredFrom
+from models.model import IconType
+from models.workflow import (
+    WorkflowNodeExecutionModel,
+    WorkflowNodeExecutionTriggeredFrom,
+    WorkflowRun,
+    WorkflowType,
+)
 
 
 def _serialize_200_response(handler, payload: Any) -> Any:
@@ -24,75 +34,112 @@ def _serialize_200_response(handler, payload: Any) -> Any:
     return payload
 
 
-def _account() -> SimpleNamespace:
-    return SimpleNamespace(id="account-1", name="Alice", email="alice@example.com")
-
-
-def _current_account() -> Account:
+def _account(session: Session) -> Account:
     account = Account(name="Alice", email="alice@example.com")
     account.id = "account-1"
+    session.add(account)
+    session.commit()
     return account
 
 
-def _workflow_run_summary(**overrides) -> SimpleNamespace:
+def _app() -> App:
+    return App(
+        id="app-1",
+        tenant_id="tenant-1",
+        name="Workflow run app",
+        description="",
+        mode=AppMode.WORKFLOW,
+        icon_type=IconType.EMOJI,
+        icon="robot",
+        icon_background="#FFFFFF",
+        enable_site=True,
+        enable_api=True,
+        max_active_requests=None,
+    )
+
+
+def _workflow_run_summary(session: Session, **overrides: object) -> WorkflowRun:
     created_at = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
-    payload = {
-        "id": "run-1",
-        "version": "v1",
-        "status": "succeeded",
-        "elapsed_time": 1.5,
-        "total_tokens": 10,
-        "total_steps": 2,
-        "created_by_account": _account(),
-        "created_at": created_at,
-        "finished_at": created_at,
-        "exceptions_count": 0,
-        "retry_index": 0,
-    }
-    payload.update(overrides)
-    return SimpleNamespace(**payload)
+    workflow_run = WorkflowRun(
+        id="run-1",
+        tenant_id="tenant-1",
+        app_id="app-1",
+        workflow_id="workflow-1",
+        type=WorkflowType.WORKFLOW,
+        triggered_from=WorkflowRunTriggeredFrom.DEBUGGING,
+        version="v1",
+        graph='{"nodes": []}',
+        inputs='{"query": "hello"}',
+        status=WorkflowExecutionStatus.SUCCEEDED,
+        outputs='{"answer": "world"}',
+        error=None,
+        elapsed_time=1.5,
+        total_tokens=10,
+        total_steps=2,
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by="account-1",
+        created_at=created_at,
+        finished_at=created_at,
+        exceptions_count=0,
+    )
+    for name, value in overrides.items():
+        setattr(workflow_run, name, value)
+    workflow_run.retry_index = 0
+    session.add(workflow_run)
+    session.commit()
+    return workflow_run
 
 
-def _workflow_run_node_execution(**overrides) -> SimpleNamespace:
+def _workflow_run_node_execution(session: Session) -> WorkflowNodeExecutionModel:
     created_at = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
-    payload = {
-        "id": "node-exec-1",
-        "index": 1,
-        "predecessor_node_id": None,
-        "node_id": "node-1",
-        "node_type": "start",
-        "title": "Start",
-        "inputs_dict": {"query": "hello"},
-        "process_data_dict": {"step": "prepared"},
-        "outputs_dict": {"answer": "world"},
-        "status": "succeeded",
-        "error": None,
-        "elapsed_time": 1.0,
-        "execution_metadata_dict": {"total_tokens": 3},
-        "extras": {},
-        "created_at": created_at,
-        "created_by_role": "account",
-        "created_by_account": _account(),
-        "created_by_end_user": None,
-        "finished_at": created_at,
-        "inputs_truncated": False,
-        "outputs_truncated": False,
-        "process_data_truncated": False,
-    }
-    payload.update(overrides)
-    return SimpleNamespace(**payload)
+    execution = WorkflowNodeExecutionModel(
+        id="node-exec-1",
+        tenant_id="tenant-1",
+        app_id="app-1",
+        workflow_id="workflow-1",
+        triggered_from=WorkflowNodeExecutionTriggeredFrom.WORKFLOW_RUN,
+        workflow_run_id="run-1",
+        index=1,
+        predecessor_node_id=None,
+        node_execution_id="node-execution-1",
+        node_id="node-1",
+        node_type="start",
+        title="Start",
+        agent_workspace_binding_id=None,
+        inputs=json.dumps({"query": "hello"}),
+        process_data=json.dumps({"step": "prepared"}),
+        outputs=json.dumps({"answer": "world"}),
+        status=WorkflowNodeExecutionStatus.SUCCEEDED,
+        error=None,
+        elapsed_time=1.0,
+        execution_metadata=json.dumps({"total_tokens": 3}),
+        created_at=created_at,
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by="account-1",
+        finished_at=created_at,
+    )
+    execution.offload_data = []
+    session.add(execution)
+    session.commit()
+    return execution
 
 
-def test_workflow_run_list_returns_frontend_history_contract(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_workflow_run_list_returns_frontend_history_contract(
+    app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+) -> None:
+    _account(sqlite_session)
+    workflow_run = _workflow_run_summary(sqlite_session)
+
     class WorkflowRunService:
         def get_paginate_workflow_runs(self, **_kwargs):
             return {
                 "limit": 10,
                 "has_more": False,
-                "data": [_workflow_run_summary()],
+                "data": [workflow_run],
             }
 
     monkeypatch.setattr(workflow_run_module, "WorkflowRunService", WorkflowRunService)
+    monkeypatch.setattr(workflow_run_module.db, "session", sqlite_session)
 
     api = workflow_run_module.WorkflowRunListApi()
     handler = unwrap(api.get)
@@ -101,7 +148,7 @@ def test_workflow_run_list_returns_frontend_history_contract(app: Flask, monkeyp
         payload = handler(
             api,
             workflow_run_module.WorkflowRunListQuery(limit=10),
-            app_model=SimpleNamespace(id="app-1", tenant_id="tenant-1"),
+            app_model=_app(),
         )
 
     response = _serialize_200_response(api.get, payload)
@@ -123,21 +170,26 @@ def test_workflow_run_list_returns_frontend_history_contract(app: Flask, monkeyp
     }
 
 
-def test_advanced_chat_workflow_run_list_keeps_message_fields(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_advanced_chat_workflow_run_list_keeps_message_fields(
+    app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+) -> None:
+    _account(sqlite_session)
+    workflow_run = _workflow_run_summary(
+        sqlite_session,
+        conversation_id="conversation-1",
+        message_id="message-1",
+    )
+
     class WorkflowRunService:
         def get_paginate_advanced_chat_workflow_runs(self, **_kwargs):
             return {
                 "limit": 1,
                 "has_more": True,
-                "data": [
-                    _workflow_run_summary(
-                        conversation_id="conversation-1",
-                        message_id="message-1",
-                    )
-                ],
+                "data": [workflow_run],
             }
 
     monkeypatch.setattr(workflow_run_module, "WorkflowRunService", WorkflowRunService)
+    monkeypatch.setattr(workflow_run_module.db, "session", sqlite_session)
 
     api = workflow_run_module.AdvancedChatAppWorkflowRunListApi()
     handler = unwrap(api.get)
@@ -146,7 +198,7 @@ def test_advanced_chat_workflow_run_list_keeps_message_fields(app: Flask, monkey
         payload = handler(
             api,
             workflow_run_module.WorkflowRunListQuery(limit=1),
-            app_model=SimpleNamespace(id="app-1", tenant_id="tenant-1"),
+            app_model=_app(),
         )
 
     response = _serialize_200_response(api.get, payload)
@@ -155,38 +207,24 @@ def test_advanced_chat_workflow_run_list_keeps_message_fields(app: Flask, monkey
     assert response["data"][0]["message_id"] == "message-1"
 
 
-def test_workflow_run_detail_returns_frontend_detail_contract(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
-    created_at = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
-    workflow_run = SimpleNamespace(
-        id="run-1",
-        version="v1",
-        graph_dict={"nodes": []},
-        inputs_dict={"query": "hello"},
-        status="succeeded",
-        outputs_dict={"answer": "world"},
-        error=None,
-        elapsed_time=1.5,
-        total_tokens=10,
-        total_steps=2,
-        created_by_role="account",
-        created_by_account=_account(),
-        created_by_end_user=None,
-        created_at=created_at,
-        finished_at=created_at,
-        exceptions_count=0,
-    )
+def test_workflow_run_detail_returns_frontend_detail_contract(
+    app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
+) -> None:
+    _account(sqlite_session)
+    workflow_run = _workflow_run_summary(sqlite_session)
 
     class WorkflowRunService:
         def get_workflow_run(self, **_kwargs):
             return workflow_run
 
     monkeypatch.setattr(workflow_run_module, "WorkflowRunService", WorkflowRunService)
+    monkeypatch.setattr(workflow_run_module.db, "session", sqlite_session)
 
     api = workflow_run_module.WorkflowRunDetailApi()
     handler = unwrap(api.get)
 
     with app.test_request_context("/apps/app-1/workflow-runs/run-1", method="GET"):
-        payload = handler(api, app_model=SimpleNamespace(id="app-1", tenant_id="tenant-1"), run_id="run-1")
+        payload = handler(api, app_model=_app(), run_id="run-1")
 
     response = _serialize_200_response(api.get, payload)
 
@@ -211,21 +249,23 @@ def test_workflow_run_detail_returns_frontend_detail_contract(app: Flask, monkey
 
 
 def test_workflow_run_node_executions_return_frontend_trace_contract(
-    app: Flask, monkeypatch: pytest.MonkeyPatch
+    app: Flask, monkeypatch: pytest.MonkeyPatch, sqlite_session: Session
 ) -> None:
+    account = _account(sqlite_session)
+    execution = _workflow_run_node_execution(sqlite_session)
+
     class WorkflowRunService:
         def get_workflow_run_node_executions(self, **_kwargs):
-            return [_workflow_run_node_execution()]
+            return [execution]
 
     monkeypatch.setattr(workflow_run_module, "WorkflowRunService", WorkflowRunService)
+    monkeypatch.setattr(workflow_run_module.db, "session", sqlite_session)
 
     api = workflow_run_module.WorkflowRunNodeExecutionListApi()
     handler = unwrap(api.get)
 
     with app.test_request_context("/apps/app-1/workflow-runs/run-1/node-executions", method="GET"):
-        payload = handler(
-            api, _current_account(), app_model=SimpleNamespace(id="app-1", tenant_id="tenant-1"), run_id="run-1"
-        )
+        payload = handler(api, account, app_model=_app(), run_id="run-1")
 
     response = _serialize_200_response(api.get, payload)
 


### PR DESCRIPTION
## Summary
- replace generic App, Account, Tenant, WorkflowRun, WorkflowNodeExecution, WorkflowComment, reply, and mention stand-ins across seven console workflow-controller test modules
- persist workflow runs, node executions, accounts, and conversation variables in SQLite where model properties or controller queries require database access
- exercise real comment relationships and cached account resolution during response serialization
- keep mocks only for workflow/trace/comment services and other non-ORM collaborators

## Motivation
These controller tests mixed real sessions with mapped-model stand-ins, hiding enum normalization, JSON-backed properties, relationship-derived response fields, and account lookups. The migrated tests now execute those model behaviors against the actual mappings.

## Production changes
None.

## Size
303 additions, 167 deletions (470 changed lines). The batch keeps a cohesive console workflow-controller cluster together.

## Validation
- PASS: combined targeted run for all seven changed modules (58 passed)
- PASS: make lint
- BLOCKED: make type-check reaches mypy 1.20.2 internal error at api/.venv/lib/python3.12/site-packages/mypy/typeshed/stdlib/zipimport.pyi:17
- PASS: focused audit found no mocked SQLAlchemy sessions or mapped-model stand-ins in the migrated modules; remaining MagicMock values are service return dictionaries and external collaborators
- NOT RUN: full make test, per user instruction