### PR TITLE
test: migrate console conversation sessions and ORM models to SQLite

### DIFF
--- a/api/tests/unit_tests/controllers/console/app/test_conversation_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_conversation_api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from decimal import Decimal
 from inspect import unwrap
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,13 +11,41 @@ from werkzeug.exceptions import BadRequest, NotFound
 
 from controllers.console.app import conversation as conversation_module
 from core.app.entities.app_invoke_entities import InvokeFrom
-from models.enums import ConversationFromSource
-from models.model import AppMode, Conversation
+from graphon.enums import WorkflowExecutionStatus
+from models import Account, App, EndUser, Message, MessageAnnotation, MessageFeedback
+from models.enums import (
+    ConversationFromSource,
+    CreatorUserRole,
+    EndUserType,
+    FeedbackFromSource,
+    FeedbackRating,
+    WorkflowRunTriggeredFrom,
+)
+from models.model import AppMode, Conversation, IconType
+from models.workflow import WorkflowRun, WorkflowType
 from services.errors.conversation import ConversationNotExistsError
 
 
-def _make_account():
-    return SimpleNamespace(timezone="UTC", id="u1")
+def _make_account() -> Account:
+    account = Account(name="Account", email="account@example.com", timezone="UTC")
+    account.id = "u1"
+    return account
+
+
+def _app(*, mode: AppMode = AppMode.CHAT) -> App:
+    return App(
+        id="app-1",
+        tenant_id="tenant-1",
+        name="Conversation app",
+        description="",
+        mode=mode,
+        icon_type=IconType.EMOJI,
+        icon="robot",
+        icon_background="#FFFFFF",
+        enable_site=True,
+        enable_api=True,
+        max_active_requests=None,
+    )
 
 
 def _conversation(*, conversation_id: str = "c1", app_id: str = "app-1") -> Conversation:
@@ -63,7 +91,7 @@ def test_completion_conversation_list_returns_paginated_result(
             conversation_module.CompletionConversationQuery(),
             unbound_session,
             account,
-            app_model=SimpleNamespace(id="app-1"),
+            app_model=_app(mode=AppMode.COMPLETION),
         )
     assert response == {"page": 1, "limit": 20, "total": 0, "has_more": False, "data": []}
 
@@ -88,7 +116,7 @@ def test_completion_conversation_list_invalid_time_range(
                 conversation_module.CompletionConversationQuery(),
                 unbound_session,
                 account,
-                app_model=SimpleNamespace(id="app-1"),
+                app_model=_app(mode=AppMode.COMPLETION),
             )
 
 
@@ -112,7 +140,7 @@ def test_chat_conversation_list_advanced_chat_calls_paginate(
             conversation_module.ChatConversationQuery(),
             unbound_session,
             account,
-            app_model=SimpleNamespace(id="app-1", mode=AppMode.ADVANCED_CHAT),
+            app_model=_app(mode=AppMode.ADVANCED_CHAT),
         )
     assert response == {"page": 1, "limit": 20, "total": 0, "has_more": False, "data": []}
 
@@ -122,7 +150,7 @@ def test_get_conversation_updates_read_at(sqlite_session: Session) -> None:
     sqlite_session.add(conversation)
     sqlite_session.flush()
     session = sqlite_session
-    result = conversation_module._get_conversation(session, _make_account(), SimpleNamespace(id="app-1"), "c1")
+    result = conversation_module._get_conversation(session, _make_account(), _app(), "c1")
     assert result is conversation
     assert conversation.read_at is not None
     assert conversation.read_account_id == "u1"
@@ -131,58 +159,120 @@ def test_get_conversation_updates_read_at(sqlite_session: Session) -> None:
 def test_get_conversation_missing_raises_not_found(sqlite_session: Session) -> None:
     session = sqlite_session
     with pytest.raises(NotFound):
-        conversation_module._get_conversation(session, _make_account(), SimpleNamespace(id="app-1"), "missing")
+        conversation_module._get_conversation(session, _make_account(), _app(), "missing")
 
 
-def test_conversation_response_source_uses_caller_session(unbound_session: Session) -> None:
-    session = unbound_session
-    account = object()
-    annotation = MagicMock()
-    annotation.account_with_session.return_value = account
-    message = MagicMock()
-    conversation = MagicMock()
-    conversation.inputs_with_session.return_value = {"topic": "support"}
-    conversation.model_config_with_session.return_value = {"model_id": "model-1"}
-    conversation.summary_or_query_with_session.return_value = "summary"
-    conversation.annotated_with_session.return_value = True
-    conversation.annotation_with_session.return_value = annotation
-    conversation.message_count_with_session.return_value = 3
-    conversation.user_feedback_stats_with_session.return_value = {"like": 2, "dislike": 1}
-    conversation.admin_feedback_stats_with_session.return_value = {"like": 1, "dislike": 0}
-    conversation.status_count_with_session.return_value = {"success": 1, "failed": 0}
-    conversation.first_message_with_session.return_value = message
-    conversation.from_end_user_session_id_with_session.return_value = "end-user-session"
-    conversation.from_account_name_with_session.return_value = "Account"
+def test_conversation_response_source_uses_caller_session(sqlite_session: Session) -> None:
+    account = _make_account()
+    end_user = EndUser(
+        id="end-user-1",
+        tenant_id="tenant-1",
+        app_id="app-1",
+        type=EndUserType.SERVICE_API,
+        external_user_id="external-user-1",
+        name="End user",
+        session_id="end-user-session",
+    )
+    conversation = _conversation()
+    conversation.mode = AppMode.ADVANCED_CHAT
+    conversation.override_model_configs = "{}"
+    conversation.summary = "summary"
+    conversation.inputs = {"topic": "support"}
+    conversation.from_end_user_id = end_user.id
+    conversation.from_account_id = account.id
+    message = Message(
+        id="message-1",
+        app_id=conversation.app_id,
+        model_provider=None,
+        model_id=None,
+        override_model_configs=None,
+        conversation_id=conversation.id,
+        inputs={},
+        query="first question",
+        message={},
+        message_tokens=1,
+        message_unit_price=Decimal(0),
+        message_price_unit=Decimal("0.001"),
+        answer="answer",
+        answer_tokens=1,
+        answer_unit_price=Decimal(0),
+        answer_price_unit=Decimal("0.001"),
+        parent_message_id=None,
+        provider_response_latency=0,
+        total_price=Decimal(0),
+        currency="USD",
+        error=None,
+        message_metadata=None,
+        invoke_from=InvokeFrom.EXPLORE,
+        from_source=ConversationFromSource.CONSOLE,
+        from_end_user_id=end_user.id,
+        from_account_id=account.id,
+        workflow_run_id="run-1",
+        app_mode=AppMode.ADVANCED_CHAT,
+    )
+    annotation = MessageAnnotation(
+        app_id=conversation.app_id,
+        question="question",
+        content="annotation",
+        account_id=account.id,
+        conversation_id=conversation.id,
+        message_id=message.id,
+    )
+    feedbacks = [
+        MessageFeedback(
+            app_id=conversation.app_id,
+            conversation_id=conversation.id,
+            message_id=message.id,
+            rating=rating,
+            from_source=source,
+            from_account_id=account.id,
+        )
+        for source, rating in (
+            (FeedbackFromSource.USER, FeedbackRating.LIKE),
+            (FeedbackFromSource.USER, FeedbackRating.DISLIKE),
+            (FeedbackFromSource.ADMIN, FeedbackRating.LIKE),
+        )
+    ]
+    workflow_run = WorkflowRun(
+        id="run-1",
+        tenant_id="tenant-1",
+        app_id=conversation.app_id,
+        workflow_id="workflow-1",
+        type=WorkflowType.WORKFLOW,
+        triggered_from=WorkflowRunTriggeredFrom.DEBUGGING,
+        version="1",
+        graph="{}",
+        inputs="{}",
+        status=WorkflowExecutionStatus.SUCCEEDED,
+        outputs="{}",
+        error=None,
+        elapsed_time=1,
+        total_tokens=1,
+        total_steps=1,
+        created_by_role=CreatorUserRole.ACCOUNT,
+        created_by=account.id,
+        finished_at=None,
+        exceptions_count=0,
+    )
+    sqlite_session.add_all([account, end_user, conversation, message, annotation, workflow_run, *feedbacks])
+    sqlite_session.commit()
 
-    source = conversation_module.ConversationResponseSource(conversation, session=session)
+    source = conversation_module.ConversationResponseSource(conversation, session=sqlite_session)
 
     assert source.inputs == {"topic": "support"}
-    assert source.model_config == {"model_id": "model-1"}
+    assert source.model_config == {"model_id": None, "provider": None}
     assert source.summary_or_query == "summary"
     assert source.annotated is True
     annotation_source = source.annotation
     assert annotation_source is not None
     assert annotation_source.account is account
-    assert source.message_count == 3
-    assert source.user_feedback_stats == {"like": 2, "dislike": 1}
+    assert source.message_count == 1
+    assert source.user_feedback_stats == {"like": 1, "dislike": 1}
     assert source.admin_feedback_stats == {"like": 1, "dislike": 0}
-    assert source.status_count == {"success": 1, "failed": 0}
+    assert source.status_count == {"success": 1, "failed": 0, "partial_success": 0, "paused": 0}
     assert source.first_message is not None
     assert source.from_end_user_session_id == "end-user-session"
     assert source.from_account_name == "Account"
-    conversation.model_config_with_session.assert_called_once_with(session=session)
-    conversation.inputs_with_session.assert_called_once_with(session=session)
-    conversation.summary_or_query_with_session.assert_called_once_with(session=session)
-    conversation.annotated_with_session.assert_called_once_with(session=session)
-    conversation.annotation_with_session.assert_called_once_with(session=session)
-    conversation.message_count_with_session.assert_called_once_with(session=session)
-    conversation.user_feedback_stats_with_session.assert_called_once_with(session=session)
-    conversation.admin_feedback_stats_with_session.assert_called_once_with(session=session)
-    conversation.status_count_with_session.assert_called_once_with(session=session)
-    conversation.first_message_with_session.assert_called_once_with(session=session)
-    conversation.from_end_user_session_id_with_session.assert_called_once_with(session=session)
-    conversation.from_account_name_with_session.assert_called_once_with(session=session)
-    annotation.account_with_session.assert_called_once_with(session=session)
 
 
 def test_completion_conversation_delete_maps_not_found(
@@ -197,4 +287,4 @@ def test_completion_conversation_delete_maps_not_found(
     )
     session = unbound_session
     with pytest.raises(NotFound):
-        method(api, session, _make_account(), app_model=SimpleNamespace(id="app-1"), conversation_id="c1")
+        method(api, session, _make_account(), app_model=_app(), conversation_id="c1")

--- a/api/tests/unit_tests/controllers/console/app/test_message_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_message_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from inspect import unwrap
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,39 +12,8 @@ from sqlalchemy.orm import Session
 
 from controllers.console.app import message as message_module
 from core.app.entities.app_invoke_entities import InvokeFrom
-from models import Account, App
-from models.enums import ConversationFromSource, FeedbackFromSource, FeedbackRating
-from models.model import (
-    AppAnnotationHitHistory,
-    AppMode,
-    Conversation,
-    IconType,
-    Message,
-    MessageAnnotation,
-    MessageFeedback,
-)
-
-
-def _app() -> App:
-    return App(
-        id="app-1",
-        tenant_id="tenant-1",
-        name="Message app",
-        description="",
-        mode=AppMode.CHAT,
-        icon_type=IconType.EMOJI,
-        icon="robot",
-        icon_background="#FFFFFF",
-        enable_site=True,
-        enable_api=True,
-        max_active_requests=None,
-    )
-
-
-def _account() -> Account:
-    account = Account(name="Account", email="account@example.com")
-    account.id = "account-1"
-    return account
+from models.enums import ConversationFromSource
+from models.model import AppMode, Conversation, Message
 
 
 def _persist_message(session: Session, *, message_id: str, app_id: str = "app-1") -> Message:
@@ -89,7 +59,7 @@ def _persist_message(session: Session, *, message_id: str, app_id: str = "app-1"
         app_mode=AppMode.CHAT,
     )
     message.id = message_id
-    session.add_all([_app(), conversation, message])
+    session.add_all([conversation, message])
     session.flush()
     return message
 
@@ -98,8 +68,8 @@ def test_app_message_routes_pass_injected_session(
     app: Flask, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
 ) -> None:
     session = unbound_session
-    current_user = _account()
-    app_model = _app()
+    current_user = SimpleNamespace(id="account-1")
+    app_model = SimpleNamespace(id="app-1", mode="chat")
     message_id = "550e8400-e29b-41d4-a716-446655440000"
     list_messages = MagicMock(return_value={"data": []})
     update_feedback = MagicMock(return_value={"result": "success"})
@@ -131,18 +101,10 @@ def test_app_message_routes_pass_injected_session(
 
 def test_update_message_feedback_commits_injected_session(app: Flask, sqlite_session: Session) -> None:
     message_id = "550e8400-e29b-41d4-a716-446655440000"
+    feedback = SimpleNamespace(rating="dislike", content=None)
+    get_admin_feedback = MagicMock(return_value=feedback)
     message = _persist_message(sqlite_session, message_id=message_id)
-    current_user = _account()
-    feedback = MessageFeedback(
-        app_id=message.app_id,
-        conversation_id=message.conversation_id,
-        message_id=message.id,
-        rating=FeedbackRating.DISLIKE,
-        from_source=FeedbackFromSource.ADMIN,
-        from_account_id=current_user.id,
-    )
-    sqlite_session.add_all([current_user, feedback])
-    sqlite_session.commit()
+    message.admin_feedback_with_session = get_admin_feedback
     session = sqlite_session
     commits: list[str] = []
     event.listen(session, "after_commit", lambda _session: commits.append("commit"))
@@ -150,16 +112,14 @@ def test_update_message_feedback_commits_injected_session(app: Flask, sqlite_ses
     with app.test_request_context(json={"message_id": message_id, "rating": "like", "content": "helpful"}):
         result = message_module._update_message_feedback(
             session=session,
-            current_user=current_user,
-            app_model=_app(),
+            current_user=SimpleNamespace(id="account-1"),
+            app_model=SimpleNamespace(id="app-1"),
         )
 
     assert result == {"result": "success"}
-    session.expire_all()
-    persisted_feedback = session.get(MessageFeedback, feedback.id)
-    assert persisted_feedback is not None
-    assert persisted_feedback.rating == FeedbackRating.LIKE
-    assert persisted_feedback.content == "helpful"
+    assert feedback.rating == "like"
+    assert feedback.content == "helpful"
+    get_admin_feedback.assert_called_once_with(session=session)
     assert commits == ["commit"]
 
 
@@ -175,7 +135,7 @@ def test_get_message_detail_uses_injected_session(monkeypatch: pytest.MonkeyPatc
 
     result = message_module._get_message_detail(
         session=session,
-        app_model=_app(),
+        app_model=SimpleNamespace(id="app-1"),
         message_id=message_id,
     )
 
@@ -183,43 +143,26 @@ def test_get_message_detail_uses_injected_session(monkeypatch: pytest.MonkeyPatc
     response_source_factory.assert_called_once_with(message, session=session)
 
 
-def test_message_response_source_uses_caller_session_for_nested_fields(sqlite_session: Session) -> None:
-    message = _persist_message(sqlite_session, message_id="message-1")
-    message.inputs = {"topic": "support"}
-    account = _account()
-    feedback = MessageFeedback(
-        app_id=message.app_id,
-        conversation_id=message.conversation_id,
-        message_id=message.id,
-        rating=FeedbackRating.LIKE,
-        from_source=FeedbackFromSource.USER,
-        from_account_id=account.id,
-    )
-    annotation = MessageAnnotation(
-        app_id=message.app_id,
-        question="question",
-        content="annotation",
-        account_id=account.id,
-        conversation_id=message.conversation_id,
-        message_id=message.id,
-    )
-    sqlite_session.add_all([account, feedback, annotation])
-    sqlite_session.flush()
-    annotation_history = AppAnnotationHitHistory(
-        app_id=message.app_id,
-        annotation_id=annotation.id,
-        source="console",
-        question="question",
-        account_id=account.id,
-        score=1,
-        message_id=message.id,
-        annotation_question=annotation.question,
-        annotation_content=annotation.content,
-    )
-    sqlite_session.add(annotation_history)
-    sqlite_session.commit()
+def test_message_response_source_uses_caller_session_for_nested_fields(unbound_session: Session) -> None:
+    session = unbound_session
+    account = object()
+    feedback = MagicMock()
+    feedback.from_account_with_session.return_value = account
+    annotation = MagicMock()
+    annotation.account_with_session.return_value = account
+    annotation.annotation_create_account_with_session.return_value = account
+    thought = object()
+    message_file = {"id": "file-1"}
+    message = MagicMock()
+    message.inputs_with_session.return_value = {"topic": "support"}
+    message.user_feedback_with_session.return_value = feedback
+    message.feedbacks_with_session.return_value = [feedback]
+    message.annotation_with_session.return_value = annotation
+    message.annotation_hit_history_with_session.return_value = annotation
+    message.agent_thoughts_with_session.return_value = [thought]
+    message.message_files_with_session.return_value = [message_file]
 
-    source = message_module.MessageResponseSource(message, session=sqlite_session)
+    source = message_module.MessageResponseSource(message, session=session)
 
     assert source.inputs == {"topic": "support"}
     assert source.user_feedback is feedback
@@ -230,8 +173,18 @@ def test_message_response_source_uses_caller_session_for_nested_fields(sqlite_se
     annotation_hit_history_source = source.annotation_hit_history
     assert annotation_hit_history_source is not None
     assert annotation_hit_history_source.annotation_create_account is account
-    assert source.agent_thoughts == []
-    assert source.message_files == []
+    assert source.agent_thoughts == [thought]
+    assert source.message_files == [message_file]
+    message.inputs_with_session.assert_called_once_with(session=session)
+    message.user_feedback_with_session.assert_called_once_with(session=session)
+    message.feedbacks_with_session.assert_called_once_with(session=session)
+    message.annotation_with_session.assert_called_once_with(session=session)
+    message.annotation_hit_history_with_session.assert_called_once_with(session=session)
+    message.agent_thoughts_with_session.assert_called_once_with(session=session)
+    message.message_files_with_session.assert_called_once_with(session=session)
+    feedback.from_account_with_session.assert_called_once_with(session=session)
+    annotation.account_with_session.assert_called_once_with(session=session)
+    annotation.annotation_create_account_with_session.assert_called_once_with(session=session)
 
 
 def test_chat_messages_query_valid(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/api/tests/unit_tests/controllers/console/app/test_message_api.py
+++ b/api/tests/unit_tests/controllers/console/app/test_message_api.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from inspect import unwrap
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,8 +11,39 @@ from sqlalchemy.orm import Session
 
 from controllers.console.app import message as message_module
 from core.app.entities.app_invoke_entities import InvokeFrom
-from models.enums import ConversationFromSource
-from models.model import AppMode, Conversation, Message
+from models import Account, App
+from models.enums import ConversationFromSource, FeedbackFromSource, FeedbackRating
+from models.model import (
+    AppAnnotationHitHistory,
+    AppMode,
+    Conversation,
+    IconType,
+    Message,
+    MessageAnnotation,
+    MessageFeedback,
+)
+
+
+def _app() -> App:
+    return App(
+        id="app-1",
+        tenant_id="tenant-1",
+        name="Message app",
+        description="",
+        mode=AppMode.CHAT,
+        icon_type=IconType.EMOJI,
+        icon="robot",
+        icon_background="#FFFFFF",
+        enable_site=True,
+        enable_api=True,
+        max_active_requests=None,
+    )
+
+
+def _account() -> Account:
+    account = Account(name="Account", email="account@example.com")
+    account.id = "account-1"
+    return account
 
 
 def _persist_message(session: Session, *, message_id: str, app_id: str = "app-1") -> Message:
@@ -59,7 +89,7 @@ def _persist_message(session: Session, *, message_id: str, app_id: str = "app-1"
         app_mode=AppMode.CHAT,
     )
     message.id = message_id
-    session.add_all([conversation, message])
+    session.add_all([_app(), conversation, message])
     session.flush()
     return message
 
@@ -68,8 +98,8 @@ def test_app_message_routes_pass_injected_session(
     app: Flask, monkeypatch: pytest.MonkeyPatch, unbound_session: Session
 ) -> None:
     session = unbound_session
-    current_user = SimpleNamespace(id="account-1")
-    app_model = SimpleNamespace(id="app-1", mode="chat")
+    current_user = _account()
+    app_model = _app()
     message_id = "550e8400-e29b-41d4-a716-446655440000"
     list_messages = MagicMock(return_value={"data": []})
     update_feedback = MagicMock(return_value={"result": "success"})
@@ -101,10 +131,18 @@ def test_app_message_routes_pass_injected_session(
 
 def test_update_message_feedback_commits_injected_session(app: Flask, sqlite_session: Session) -> None:
     message_id = "550e8400-e29b-41d4-a716-446655440000"
-    feedback = SimpleNamespace(rating="dislike", content=None)
-    get_admin_feedback = MagicMock(return_value=feedback)
     message = _persist_message(sqlite_session, message_id=message_id)
-    message.admin_feedback_with_session = get_admin_feedback
+    current_user = _account()
+    feedback = MessageFeedback(
+        app_id=message.app_id,
+        conversation_id=message.conversation_id,
+        message_id=message.id,
+        rating=FeedbackRating.DISLIKE,
+        from_source=FeedbackFromSource.ADMIN,
+        from_account_id=current_user.id,
+    )
+    sqlite_session.add_all([current_user, feedback])
+    sqlite_session.commit()
     session = sqlite_session
     commits: list[str] = []
     event.listen(session, "after_commit", lambda _session: commits.append("commit"))
@@ -112,14 +150,16 @@ def test_update_message_feedback_commits_injected_session(app: Flask, sqlite_ses
     with app.test_request_context(json={"message_id": message_id, "rating": "like", "content": "helpful"}):
         result = message_module._update_message_feedback(
             session=session,
-            current_user=SimpleNamespace(id="account-1"),
-            app_model=SimpleNamespace(id="app-1"),
+            current_user=current_user,
+            app_model=_app(),
         )
 
     assert result == {"result": "success"}
-    assert feedback.rating == "like"
-    assert feedback.content == "helpful"
-    get_admin_feedback.assert_called_once_with(session=session)
+    session.expire_all()
+    persisted_feedback = session.get(MessageFeedback, feedback.id)
+    assert persisted_feedback is not None
+    assert persisted_feedback.rating == FeedbackRating.LIKE
+    assert persisted_feedback.content == "helpful"
     assert commits == ["commit"]
 
 
@@ -135,7 +175,7 @@ def test_get_message_detail_uses_injected_session(monkeypatch: pytest.MonkeyPatc
 
     result = message_module._get_message_detail(
         session=session,
-        app_model=SimpleNamespace(id="app-1"),
+        app_model=_app(),
         message_id=message_id,
     )
 
@@ -143,26 +183,43 @@ def test_get_message_detail_uses_injected_session(monkeypatch: pytest.MonkeyPatc
     response_source_factory.assert_called_once_with(message, session=session)
 
 
-def test_message_response_source_uses_caller_session_for_nested_fields(unbound_session: Session) -> None:
-    session = unbound_session
-    account = object()
-    feedback = MagicMock()
-    feedback.from_account_with_session.return_value = account
-    annotation = MagicMock()
-    annotation.account_with_session.return_value = account
-    annotation.annotation_create_account_with_session.return_value = account
-    thought = object()
-    message_file = {"id": "file-1"}
-    message = MagicMock()
-    message.inputs_with_session.return_value = {"topic": "support"}
-    message.user_feedback_with_session.return_value = feedback
-    message.feedbacks_with_session.return_value = [feedback]
-    message.annotation_with_session.return_value = annotation
-    message.annotation_hit_history_with_session.return_value = annotation
-    message.agent_thoughts_with_session.return_value = [thought]
-    message.message_files_with_session.return_value = [message_file]
+def test_message_response_source_uses_caller_session_for_nested_fields(sqlite_session: Session) -> None:
+    message = _persist_message(sqlite_session, message_id="message-1")
+    message.inputs = {"topic": "support"}
+    account = _account()
+    feedback = MessageFeedback(
+        app_id=message.app_id,
+        conversation_id=message.conversation_id,
+        message_id=message.id,
+        rating=FeedbackRating.LIKE,
+        from_source=FeedbackFromSource.USER,
+        from_account_id=account.id,
+    )
+    annotation = MessageAnnotation(
+        app_id=message.app_id,
+        question="question",
+        content="annotation",
+        account_id=account.id,
+        conversation_id=message.conversation_id,
+        message_id=message.id,
+    )
+    sqlite_session.add_all([account, feedback, annotation])
+    sqlite_session.flush()
+    annotation_history = AppAnnotationHitHistory(
+        app_id=message.app_id,
+        annotation_id=annotation.id,
+        source="console",
+        question="question",
+        account_id=account.id,
+        score=1,
+        message_id=message.id,
+        annotation_question=annotation.question,
+        annotation_content=annotation.content,
+    )
+    sqlite_session.add(annotation_history)
+    sqlite_session.commit()
 
-    source = message_module.MessageResponseSource(message, session=session)
+    source = message_module.MessageResponseSource(message, session=sqlite_session)
 
     assert source.inputs == {"topic": "support"}
     assert source.user_feedback is feedback
@@ -173,18 +230,8 @@ def test_message_response_source_uses_caller_session_for_nested_fields(unbound_s
     annotation_hit_history_source = source.annotation_hit_history
     assert annotation_hit_history_source is not None
     assert annotation_hit_history_source.annotation_create_account is account
-    assert source.agent_thoughts == [thought]
-    assert source.message_files == [message_file]
-    message.inputs_with_session.assert_called_once_with(session=session)
-    message.user_feedback_with_session.assert_called_once_with(session=session)
-    message.feedbacks_with_session.assert_called_once_with(session=session)
-    message.annotation_with_session.assert_called_once_with(session=session)
-    message.annotation_hit_history_with_session.assert_called_once_with(session=session)
-    message.agent_thoughts_with_session.assert_called_once_with(session=session)
-    message.message_files_with_session.assert_called_once_with(session=session)
-    feedback.from_account_with_session.assert_called_once_with(session=session)
-    annotation.account_with_session.assert_called_once_with(session=session)
-    annotation.annotation_create_account_with_session.assert_called_once_with(session=session)
+    assert source.agent_thoughts == []
+    assert source.message_files == []
 
 
 def test_chat_messages_query_valid(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- replace Account, App, Conversation, and related stand-ins in console conversation controller tests with real mapped instances
- persist conversation ownership and nested response data through SQLite-backed sessions
- keep message-response coverage in the dedicated response PR to avoid overlapping files

## Motivation

The previous controller tests asserted behavior against mocked model methods. Real persistence now covers the SQL-backed conversation behavior without splitting a test file across concurrent PRs.

## Production changes

None.

## Size

139 additions, 49 deletions (188 changed lines) in one test module.

## Validation

- PASS: targeted run covering this module (executed with the then-adjacent message module) — 27 passed
- PASS: `make lint`
- BLOCKED: `make type-check` reaches the existing mypy 1.20.2 internal error at `api/.venv/lib/python3.12/site-packages/mypy/typeshed/stdlib/zipimport.pyi:17`
- PASS: focused audit found no mocked SQLAlchemy sessions or mapped-model stand-ins in the migrated module
- NOT RUN: full `make test`, per request
